### PR TITLE
fix(ui): discarded config edits return after reverting Raw

### DIFF
--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -139,6 +139,67 @@ async function capture(page: Page, name: string): Promise<void> {
 }
 
 suite.define(() => {
+  it("restores form values when a failed edit is reverted in Raw mode", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        recordVideo: captureUiProofEnabled
+          ? { dir: uiProofArtifactDir, size: { height: 1000, width: 1440 } }
+          : undefined,
+        serviceWorkers: "block",
+        viewport: { height: 1000, width: 1440 },
+      },
+      async ({ page }) => {
+        const initialConfig = {
+          laboratory: { endpoint: "saved-api", retryBudget: 2 },
+          tools: {},
+        };
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "config.get": configResponse(initialConfig, "revert-snapshot"),
+            "config.schema": configSchemaResponse(),
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}settings/advanced?section=laboratory`);
+        const endpoint = page.getByRole("textbox", { name: "Endpoint", exact: true });
+        await expect.poll(() => endpoint.inputValue()).toBe("saved-api");
+
+        await gateway.deferNext("config.set");
+        await endpoint.fill("discarded-api");
+        await gateway.waitForRequest("config.set");
+        await gateway.rejectDeferred("config.set", {
+          code: "UNAVAILABLE",
+          message: "QA configuration save failed",
+        });
+        const saveIndicator = page.locator("openclaw-settings-save-indicator");
+        await expect.poll(() => saveIndicator.textContent()).toContain("Save failed");
+        await page.getByRole("button", { name: "Raw", exact: true }).click();
+        await page
+          .locator(".config-raw-field textarea")
+          .fill(JSON.stringify(initialConfig, null, 2));
+        await page.getByRole("button", { name: "Form", exact: true }).click();
+        await endpoint.waitFor();
+        await capture(page, "11-form-after-raw-revert.png");
+        expect.soft(await endpoint.inputValue()).toBe("saved-api");
+
+        const previousSaves = (await gateway.getRequests("config.set")).length;
+        await gateway.deferNext("config.set");
+        await page.getByRole("spinbutton", { name: "Retry budget", exact: true }).fill("3");
+        const save = mutationParams(
+          await gateway.waitForRequest("config.set", { after: previousSaves }),
+        );
+        expect(save.baseHash).toBe("revert-snapshot");
+        expect(JSON.parse(String(save.raw))).toEqual({
+          ...initialConfig,
+          laboratory: { endpoint: "saved-api", retryBudget: 3 },
+        });
+        await gateway.resolveDeferred("config.set");
+        await expect.poll(() => saveIndicator.textContent()).toContain("Saved");
+      },
+    );
+  });
+
   it("edits schema and raw config with guarded set, patch, reload, and apply requests", async () => {
     await suite.withPage(
       {

--- a/ui/src/lib/config/config-draft-model.test.ts
+++ b/ui/src/lib/config/config-draft-model.test.ts
@@ -727,79 +727,95 @@ describe("config draft model", () => {
     runtimeConfig.dispose();
   });
 
-  it("clears a failure status and error when a mutation reverts the draft clean", async () => {
-    vi.useFakeTimers();
-    let setCalls = 0;
-    const request = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        return {
-          config: { count: 1 },
-          raw: '{\n  "count": 1\n}\n',
-          hash: "hash-1",
-          valid: true,
-          issues: [],
-        };
+  it.each(["form", "raw"] as const)(
+    "clears a failure when %s editing reverts the draft clean",
+    async (mode) => {
+      vi.useFakeTimers();
+      let setCalls = 0;
+      const request = vi.fn(async (method: string) => {
+        if (method === "config.get") {
+          return {
+            config: { count: 1 },
+            raw: '{\n  "count": 1\n}\n',
+            hash: "hash-1",
+            valid: true,
+            issues: [],
+          };
+        }
+        if (method === "config.set") {
+          setCalls += 1;
+          throw new Error("disk full");
+        }
+        return {};
+      });
+      const { runtimeConfig } = createConfigCapabilityHarness(
+        request as GatewayBrowserClient["request"],
+      );
+      await runtimeConfig.ensureLoaded();
+
+      runtimeConfig.patchForm(["count"], 2);
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+      expect(runtimeConfig.state.configAutoSaveStatus).toBe("error");
+
+      // Reverting to the original makes the failure moot.
+      if (mode === "raw") {
+        runtimeConfig.setRaw(runtimeConfig.state.configRawOriginal);
+      } else {
+        runtimeConfig.patchForm(["count"], 1);
       }
-      if (method === "config.set") {
-        setCalls += 1;
-        throw new Error("disk full");
+      expect(runtimeConfig.state.configForm).toEqual({ count: 1 });
+      expect(runtimeConfig.state.configFormDirty).toBe(false);
+      expect(runtimeConfig.state.configAutoSaveStatus).toBe("idle");
+      expect(runtimeConfig.state.lastError).toBeNull();
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS * 2);
+      expect(setCalls).toBe(1);
+      runtimeConfig.dispose();
+    },
+  );
+
+  it.each(["form", "raw"] as const)(
+    "keeps conflict status when %s editing reverts the draft clean",
+    async (mode) => {
+      vi.useFakeTimers();
+      const request = vi.fn(async (method: string) => {
+        if (method === "config.get") {
+          return {
+            config: { count: 1 },
+            raw: '{\n  "count": 1\n}\n',
+            hash: "hash-1",
+            valid: true,
+            issues: [],
+          };
+        }
+        if (method === "config.set") {
+          throw new Error("config changed since last load; re-run config.get and retry");
+        }
+        return {};
+      });
+      const { runtimeConfig } = createConfigCapabilityHarness(
+        request as GatewayBrowserClient["request"],
+      );
+      await runtimeConfig.ensureLoaded();
+
+      runtimeConfig.patchForm(["count"], 2);
+      await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
+      expect(runtimeConfig.state.configAutoSaveStatus).toBe("conflict");
+
+      // The snapshot is known stale; local cleanliness cannot clear that.
+      if (mode === "raw") {
+        runtimeConfig.setRaw(runtimeConfig.state.configRawOriginal);
+      } else {
+        runtimeConfig.patchForm(["count"], 1);
       }
-      return {};
-    });
-    const { runtimeConfig } = createConfigCapabilityHarness(
-      request as GatewayBrowserClient["request"],
-    );
-    await runtimeConfig.ensureLoaded();
+      expect(runtimeConfig.state.configForm).toEqual({ count: 1 });
+      expect(runtimeConfig.state.configFormDirty).toBe(false);
+      expect(runtimeConfig.state.configAutoSaveStatus).toBe("conflict");
 
-    runtimeConfig.patchForm(["count"], 2);
-    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
-    expect(runtimeConfig.state.configAutoSaveStatus).toBe("error");
-
-    // Reverting to the original makes the failure moot.
-    runtimeConfig.patchForm(["count"], 1);
-    expect(runtimeConfig.state.configFormDirty).toBe(false);
-    expect(runtimeConfig.state.configAutoSaveStatus).toBe("idle");
-    expect(runtimeConfig.state.lastError).toBeNull();
-    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS * 2);
-    expect(setCalls).toBe(1);
-    runtimeConfig.dispose();
-  });
-
-  it("keeps the conflict status until reload even when the draft reverts clean", async () => {
-    vi.useFakeTimers();
-    const request = vi.fn(async (method: string) => {
-      if (method === "config.get") {
-        return {
-          config: { count: 1 },
-          raw: '{\n  "count": 1\n}\n',
-          hash: "hash-1",
-          valid: true,
-          issues: [],
-        };
-      }
-      if (method === "config.set") {
-        throw new Error("config changed since last load; re-run config.get and retry");
-      }
-      return {};
-    });
-    const { runtimeConfig } = createConfigCapabilityHarness(
-      request as GatewayBrowserClient["request"],
-    );
-    await runtimeConfig.ensureLoaded();
-
-    runtimeConfig.patchForm(["count"], 2);
-    await vi.advanceTimersByTimeAsync(CONFIG_FORM_AUTO_SAVE_DEBOUNCE_MS);
-    expect(runtimeConfig.state.configAutoSaveStatus).toBe("conflict");
-
-    // The snapshot is known stale; local cleanliness cannot clear that.
-    runtimeConfig.patchForm(["count"], 1);
-    expect(runtimeConfig.state.configFormDirty).toBe(false);
-    expect(runtimeConfig.state.configAutoSaveStatus).toBe("conflict");
-
-    await runtimeConfig.refresh({ discardPendingChanges: true });
-    expect(runtimeConfig.state.configAutoSaveStatus).toBe("idle");
-    runtimeConfig.dispose();
-  });
+      await runtimeConfig.refresh({ discardPendingChanges: true });
+      expect(runtimeConfig.state.configAutoSaveStatus).toBe("idle");
+      runtimeConfig.dispose();
+    },
+  );
 
   it("discards offline drafts locally instead of no-op refreshing", async () => {
     vi.useFakeTimers();

--- a/ui/src/lib/config/config-draft-model.ts
+++ b/ui/src/lib/config/config-draft-model.ts
@@ -587,16 +587,16 @@ export function updateConfigRawValue(state: RuntimeConfigState, value: string) {
   // mutateConfigForm/diff path needs it synchronously.
   void warmJson5().catch(() => undefined);
   state.configRaw = value;
-  // A raw-text edit becomes the authoritative draft; without this,
-  // serializeFormForSubmit would submit the stale form and drop raw edits.
-  state.configFormMode = "raw";
   state.configFormDirty = value !== state.configRawOriginal;
-  resetStaleAutoSaveStatus(state);
   if (state.configFormDirty) {
     state.configDraftBaseHash = state.configDraftBaseHash ?? state.configSnapshot?.hash ?? null;
   } else {
-    state.configDraftBaseHash = state.configSnapshot?.hash ?? null;
+    resetConfigPendingChanges(state);
   }
+  // Raw edits own submission; a clean revert also restores the saved form
+  // above so a later form edit cannot resurrect discarded values.
+  state.configFormMode = "raw";
+  resetStaleAutoSaveStatus(state);
 }
 
 export function resetConfigPendingChanges(state: RuntimeConfigState) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reverting Raw configuration to the saved text would still see discarded values after returning to Form. After a failed save, changing an unrelated field could submit the discarded values again.

## Why This Change Was Made

The shared configuration draft owner marked an exact Raw revert clean without restoring its form object. Reuse the existing pending-change reset so saved Raw text, form values, and draft tracking return to the same snapshot together. Raw remains the submission authority, and existing saving/conflict/paused status rules are preserved.

Production LOC: +5/-5 (net 0) | Tests: +144/-67 (net +77, including table-driven test reindent).

Best-fix verdict: repair the draft owner, not the Form renderer or save serializer. Those downstream alternatives would leave contradictory draft state available to other consumers. The old partial-reset path is removed; no Gateway, schema, persistence, authentication, dependency, or public configuration contract changes.

Provenance: the omission is present in the Raw updater introduced by #86726 (2026-05-26; code and PR author `clawsweeper[bot]`, merger `clawsweeper[bot]`, automerge approved by @Takhoffman). Autosave #107458 made the resubmission path more immediate; owner extraction #122117 carried the omission forward. Stable `v2026.7.1` contains the stale-form/manual-resubmission path, but predates the autosave symptom. Current PR author: @steipete.

## User Impact

Returning Raw to the exact saved contents now actually discards pending form edits. Returning to Form shows saved values, and the next unrelated edit cannot resurrect the discarded values. Conflict recovery remains explicitly latched rather than being silently cleared.

## Evidence

- Chromium regression failed before the fix on both the displayed value and the next `config.set` payload; the complete configuration safe-write file passes after the fix (5 tests).
- Shared configuration owner suite passes: 126 tests in 6 files. The new Raw clean-revert cases independently fail against the original production function, while the Form siblings pass. Coverage includes failed-save reset, conflict retention, dirty/invalid Raw, write/reconnect/discard, and apply behavior.
- `node scripts/check-changed.mjs` passes, including formatting, guards, Knip, core-test/UI typechecks, and scoped lint. `node scripts/ui.js build` passes with performance budgets.
- Fresh independent Codex branch review reports no accepted/actionable findings at its default P0 threshold.
- Source inspection covered Raw input and Form switching in the config page/view, the runtime capability/write coordinator, full draft owner, save-failure handling, sibling reset/mutation paths, tests, current main, and stable-tag history.

Live-proof limitation: the isolated loopback dev Gateway serves the rebuilt UI and its health endpoint is live, but the existing Chrome profile is unavailable to the browser integration and its extension relay returns a network error. The screenshots and interaction proof below come from the repository's real Chromium UI harness with a mocked Gateway, not an authenticated live-profile session. Maintainer directed landing after this gap was disclosed; no provider/channel or live-profile proof is claimed.

Before: restoring saved Raw text still shows the discarded endpoint in Form.

![Before: discarded endpoint remains after Raw revert](https://github.com/user-attachments/assets/7a98080a-835a-4e7f-86d7-4611907171a5)

After: the same flow shows the saved endpoint; the test also verifies the next write retains it.

![After: saved endpoint restored after Raw revert](https://github.com/user-attachments/assets/4c928722-2dba-480d-a591-f61d83378267)

All screenshot data is synthetic. Separate known performance issue #127341 (whole-document cloning/serialization per edit) remains outside this correctness repair.
