### PR TITLE
refactor(feishu): unify private tool registration setup

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -6,54 +6,6 @@ import {
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
 import { registerFeishuSubagentHooks } from "./subagent-hooks-api.js";
 
-function registerFeishuDocTools(api: OpenClawPluginApi) {
-  const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
-    specifier: "./api.js",
-    exportName: "registerFeishuDocTools",
-  });
-  register(api);
-}
-
-function registerFeishuChatTools(api: OpenClawPluginApi) {
-  const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
-    specifier: "./api.js",
-    exportName: "registerFeishuChatTools",
-  });
-  register(api);
-}
-
-function registerFeishuWikiTools(api: OpenClawPluginApi) {
-  const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
-    specifier: "./api.js",
-    exportName: "registerFeishuWikiTools",
-  });
-  register(api);
-}
-
-function registerFeishuDriveTools(api: OpenClawPluginApi) {
-  const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
-    specifier: "./api.js",
-    exportName: "registerFeishuDriveTools",
-  });
-  register(api);
-}
-
-function registerFeishuPermTools(api: OpenClawPluginApi) {
-  const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
-    specifier: "./api.js",
-    exportName: "registerFeishuPermTools",
-  });
-  register(api);
-}
-
-function registerFeishuBitableTools(api: OpenClawPluginApi) {
-  const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
-    specifier: "./api.js",
-    exportName: "registerFeishuBitableTools",
-  });
-  register(api);
-}
-
 export default defineBundledChannelEntry({
   id: "feishu",
   name: "Feishu",
@@ -73,11 +25,19 @@ export default defineBundledChannelEntry({
   },
   registerFull(api) {
     registerFeishuSubagentHooks(api);
-    registerFeishuDocTools(api);
-    registerFeishuChatTools(api);
-    registerFeishuWikiTools(api);
-    registerFeishuDriveTools(api);
-    registerFeishuPermTools(api);
-    registerFeishuBitableTools(api);
+    for (const exportName of [
+      "registerFeishuDocTools",
+      "registerFeishuChatTools",
+      "registerFeishuWikiTools",
+      "registerFeishuDriveTools",
+      "registerFeishuPermTools",
+      "registerFeishuBitableTools",
+    ]) {
+      const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(
+        import.meta.url,
+        { specifier: "./api.js", exportName },
+      );
+      register(api);
+    }
   },
 });

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -5,7 +5,6 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import { Type, type TSchema } from "typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import { feishuExternalToolResult as json } from "./tool-result.js";
 
@@ -586,12 +585,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
-  if (accounts.length === 0) {
-    return;
-  }
-
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(api.config);
   if (!toolsCfg.bitable) {
     return;
   }

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -3,7 +3,6 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuChatSchema, type FeishuChatParams } from "./chat-schema.js";
 import { resolveFeishuChatType } from "./chat-type.js";
 import { createFeishuClient } from "./client.js";
@@ -244,12 +243,7 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
   }
   const cfg = api.config;
 
-  const accounts = listEnabledFeishuAccounts(cfg);
-  if (accounts.length === 0) {
-    return;
-  }
-
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(cfg);
   if (!toolsCfg.chat) {
     return;
   }

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -5,7 +5,6 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeOptionalString, uniqueStrings } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { Type } from "typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
 import { resolveConfiguredHttpTimeoutMs } from "./client-timeout.js";
 import { FeishuDocSchema, type FeishuDocParams } from "./doc-schema.js";
 import { BATCH_SIZE, insertBlocksInBatches } from "./docx-batch-insert.js";
@@ -76,28 +75,20 @@ const BLOCK_TYPE_NAMES: Record<number, string> = {
 // Block types that cannot be created via documentBlockChildren.create API
 const UNSUPPORTED_CREATE_TYPES = new Set([31, 32]);
 
-/** Clean blocks for insertion (remove unsupported types and read-only fields) */
+/** Remove block types unsupported by the children insertion API. */
 function cleanBlocksForInsert(blocks: FeishuDocxBlock[]): {
   cleaned: FeishuDocxBlock[];
   skipped: string[];
 } {
   const skipped: string[] = [];
-  const cleaned = blocks
-    .filter((block) => {
-      if (UNSUPPORTED_CREATE_TYPES.has(block.block_type)) {
-        const typeName = BLOCK_TYPE_NAMES[block.block_type] || `type_${block.block_type}`;
-        skipped.push(typeName);
-        return false;
-      }
-      return true;
-    })
-    .map((block) => {
-      if (block.block_type === 31 && block.table?.merge_info) {
-        const { merge_info: _merge_info, ...tableRest } = block.table;
-        return Object.assign({}, block, { table: tableRest });
-      }
-      return block;
-    });
+  const cleaned = blocks.filter((block) => {
+    if (UNSUPPORTED_CREATE_TYPES.has(block.block_type)) {
+      const typeName = BLOCK_TYPE_NAMES[block.block_type] || `type_${block.block_type}`;
+      skipped.push(typeName);
+      return false;
+    }
+    return true;
+  });
   return { cleaned, skipped };
 }
 
@@ -1200,16 +1191,9 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
     return;
   }
 
-  // Check if any account is configured
-  const accounts = listEnabledFeishuAccounts(api.config);
-  if (accounts.length === 0) {
-    return;
-  }
-
   // Register if enabled on any account; account routing is resolved per execution.
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(api.config);
 
-  const registered: string[] = [];
   type FeishuDocExecuteParams = FeishuDocParams & { accountId?: string };
 
   const getClient = (params: { accountId?: string } | undefined, defaultAccountId?: string) =>
@@ -1434,7 +1418,6 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
       },
       { name: "feishu_doc" },
     );
-    registered.push("feishu_doc");
   }
 
   // Keep feishu_app_scopes as independent tool
@@ -1464,7 +1447,6 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
       }),
       { name: "feishu_app_scopes" },
     );
-    registered.push("feishu_app_scopes");
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -4,7 +4,6 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import { isRecord, readStringValue as readString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
 import { cleanupAmbientCommentTypingReaction } from "./comment-reaction.js";
 import { encodeQuery, extractReplyText, formatFeishuApiError } from "./comment-shared.js";
 import { parseFeishuCommentTarget, type CommentFileType } from "./comment-target.js";
@@ -798,12 +797,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
-  if (accounts.length === 0) {
-    return;
-  }
-
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(api.config);
   if (!toolsCfg.drive) {
     return;
   }

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -1,7 +1,6 @@
 // Feishu plugin module implements perm behavior.
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuPermSchema, type FeishuPermParams } from "./perm-schema.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import {
@@ -118,12 +117,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
-  if (accounts.length === 0) {
-    return;
-  }
-
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(api.config);
   if (!toolsCfg.perm) {
     return;
   }

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -20,6 +20,8 @@ vi.mock("./client.js", () => ({
 }));
 
 let registerFeishuBitableTools: typeof import("./bitable.js").registerFeishuBitableTools;
+let registerFeishuChatTools: typeof import("./chat.js").registerFeishuChatTools;
+let registerFeishuDocTools: typeof import("./docx.js").registerFeishuDocTools;
 let registerFeishuDriveTools: typeof import("./drive.js").registerFeishuDriveTools;
 let registerFeishuPermTools: typeof import("./perm.js").registerFeishuPermTools;
 let registerFeishuWikiTools: typeof import("./wiki.js").registerFeishuWikiTools;
@@ -92,6 +94,8 @@ describe("feishu tool account routing", () => {
         }),
       ));
     ({ registerFeishuWikiTools } = await import("./wiki.js"));
+    ({ registerFeishuChatTools } = await import("./chat.js"));
+    ({ registerFeishuDocTools } = await import("./docx.js"));
   });
 
   afterAll(() => {
@@ -101,6 +105,41 @@ describe("feishu tool account routing", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  test.each([
+    ["missing channel", {}],
+    ["unconfigured account", { channels: { feishu: { accounts: { a: { enabled: true } } } } }],
+    [
+      "disabled channel",
+      { channels: { feishu: { ...createConfig({}).channels?.feishu, enabled: false } } },
+    ],
+    [
+      "disabled accounts",
+      {
+        channels: {
+          feishu: {
+            accounts: {
+              a: { enabled: false, appId: "app-a", appSecret: "sec-a" }, // pragma: allowlist secret
+            },
+          },
+        },
+      },
+    ],
+  ])("does not register workplace tools for %s", (_label, config) => {
+    const { api, registered } = createToolFactoryHarness(config);
+    for (const register of [
+      registerFeishuDocTools,
+      registerFeishuChatTools,
+      registerFeishuWikiTools,
+      registerFeishuDriveTools,
+      registerFeishuPermTools,
+      registerFeishuBitableTools,
+    ]) {
+      register(api);
+    }
+    expect(registered).toEqual([]);
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
   });
 
   test("wiki tool registers when first account disables it and routes to agentAccountId", async () => {

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -4,6 +4,7 @@ import { normalizeOptionalAccountId } from "openclaw/plugin-sdk/account-resoluti
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import {
+  listEnabledFeishuAccounts,
   listFeishuAccountIds,
   resolveDefaultFeishuAccountId,
   resolveFeishuAccount,
@@ -128,8 +129,9 @@ export function createFeishuToolClient(params: {
 }
 
 export function resolveAnyEnabledFeishuToolsConfig(
-  accounts: ResolvedFeishuAccount[],
+  config: OpenClawPluginApi["config"],
 ): Required<FeishuToolsConfig> {
+  const accounts = listEnabledFeishuAccounts(config);
   const merged: Required<FeishuToolsConfig> = {
     doc: false,
     chat: false,

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -2,7 +2,6 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { readPositiveIntegerParam } from "openclaw/plugin-sdk/param-readers";
 import type { OpenClawPluginApi } from "../runtime-api.js";
-import { listEnabledFeishuAccounts } from "./accounts.js";
 import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
 import {
   feishuExternalToolResult as jsonResult,
@@ -209,12 +208,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
     return;
   }
 
-  const accounts = listEnabledFeishuAccounts(api.config);
-  if (accounts.length === 0) {
-    return;
-  }
-
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(api.config);
   if (!toolsCfg.wiki) {
     return;
   }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of repeated private Feishu tool-registration setup. Six tool families repeated the same enabled-account scan, and the plugin entry repeated six identical lazy-loader wrappers. The document insertion path also retained a transformation that its preceding filter made unreachable, plus unread registration bookkeeping.

## Why This Change Was Made

The existing private account/tool configuration helper now owns the enabled-account scan. Each caller retains its missing-config guard and existing execution-time account selection. The entry invokes the same synchronous loader in the same order, immediately registering each family after loading it; subagent hooks still run first, and failures still stop subsequent registrations.

The unreachable document transformation and unused array are deleted. This adds no abstraction, public API, configuration, dependency, or fallback.

Production LOC: +32/-118 (net -86). Tests: +39/-0 in one existing registration-boundary suite. AI-assisted with Codex.

## User Impact

No user-visible behavior change. Tool names, schemas, defaults, ordering, authorization, error handling, and external-content fences remain unchanged. Public barrels and package/SDK exports are untouched.

## Evidence

- Nine focused Feishu test files: 123 tests passed with pinned Lark SDK 1.73.0, Vitest 4.1.11, and Node 24.19.0. Repeated successfully after completing the temporary checkout's nested workspace dependency links.
- Full changed-code gate passed, including production/test extension typechecks, type-aware lint, export scans, plugin boundaries, sidecar inventory, and import-cycle checks.
- Full canonical build passed. A fresh Node process loaded `dist/extensions/feishu/index.js` with `OPENCLAW_DISABLE_BUNDLED_ENTRY_SOURCE_FALLBACK=1` and registered both hooks followed by all 14 expected tools. The schema/definition digest was `2b3745da52f83c85dc4d354347fc865334d6b58f0ddfbe36e0ecdb6f4080b03b`.
- Base/candidate entry execution parity covered the descriptor, exact loader arguments, API identity, order, and all 13 hook/load/register failure boundaries. This additional owner-level proof used dependency stubs; the cold built-entry proof used the real loader.
- Fresh independent Codex precommit review found no actionable findings. Formatting and `git diff --check` passed.

Clean Linux proof used [Blacksmith Testbox run 33024449947](https://github.com/openclaw/openclaw/actions/runs/33024449947), frozen base `02a60e0d871480b7c9db87cb59eec5583e2ec3ce`, and candidate tree `5221cdbc0ff565eaf6b01e1c7a0c4f91715ab61b`. Complete dependency fingerprints and consumed workspace sources were checked. Initial builds exposed missing artifact/dependency links in the temporary proof checkout; only that environment was repaired, then the full build and focused tests passed. The runtime consumed byte-identical candidate-produced AI artifacts. The owned temporary checkout was removed and the Testbox was stopped.

Commands run on the frozen candidate:

```sh
node scripts/run-vitest.mjs extensions/feishu/src/tool-account.test.ts extensions/feishu/src/tool-account-routing.test.ts extensions/feishu/src/docx.account-selection.test.ts extensions/feishu/src/docx.test.ts extensions/feishu/src/chat.test.ts extensions/feishu/src/wiki.test.ts extensions/feishu/src/drive.test.ts extensions/feishu/src/bitable.test.ts extensions/feishu/setup-entry.test.ts
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --base 02a60e0d871480b7c9db87cb59eec5583e2ec3ce --staged
node --import tsx scripts/build-all.mts
```

The cold registration proof did not execute external API calls or use real credentials. Existing ineffective-dynamic-import warnings were confined to unchanged Control UI modules; none came from Feishu.

Latest landing verification: ordinary exact-head CI [33026774878](https://github.com/openclaw/openclaw/actions/runs/33026774878) passed at `bcc0e4374802ec856c204775402a91ce4c077f66`. A distinct published-head Codex review completed with no actionable findings after scanning all nine changed files and 38 complete source/test contexts; source and remote head remained unchanged. The latest completed ClawSweeper review found no defects and requested only normal CI and maintainer handling, now complete.
