### PR TITLE
fix(telegram): prevent truncation when editing rich messages

### DIFF
--- a/extensions/telegram/src/send-edit.ts
+++ b/extensions/telegram/src/send-edit.ts
@@ -9,7 +9,7 @@ import {
   recordOutboundMessageForPromptContext,
   type TelegramOutboundPromptContextMessage,
 } from "./outbound-message-context.js";
-import { getTelegramRichRawApi } from "./rich-message.js";
+import { buildTelegramRichMarkdownPlan, getTelegramRichRawApi } from "./rich-message.js";
 import { withTelegramPlainFallback } from "./rich-plain-fallback.js";
 import {
   isTelegramMessageHasNoTextError,
@@ -167,14 +167,21 @@ async function editMessageTelegramWithContext(
   }
 
   const performTextEdit = async () => {
-    const page = planTelegramTextDeliveryPages({
-      text: textMode === "html" ? htmlText : text,
-      maxChars: Number.MAX_SAFE_INTEGER,
-      tableMode,
-      richMessages: useRichMessages,
-      skipEntityDetection: !linkPreviewEnabled,
-      ...(textMode === "html" ? { textMode: "html" as const } : {}),
-    })[0];
+    const richPlan = useRichMessages
+      ? buildTelegramRichMarkdownPlan(text, { tableMode, skipEntityDetection: !linkPreviewEnabled })
+      : undefined;
+    // An edit replaces one message. Keep the complete rich document so a
+    // structural-limit rejection recovers all its text, not just the first send page.
+    const page = richPlan?.richMessage.blocks.length
+      ? { ...richPlan, sourceText: richPlan.plainText, sourceTextMode: "markdown" as const }
+      : planTelegramTextDeliveryPages({
+          text: textMode === "html" ? htmlText : text,
+          maxChars: Number.MAX_SAFE_INTEGER,
+          tableMode,
+          richMessages: useRichMessages,
+          skipEntityDetection: !linkPreviewEnabled,
+          ...(textMode === "html" ? { textMode: "html" as const } : {}),
+        })[0];
     if (!page) {
       throw new Error("telegram editMessage failed: empty text");
     }

--- a/extensions/telegram/src/send-rich-editing.test.ts
+++ b/extensions/telegram/src/send-rich-editing.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  getTelegramSendTestMocks,
+  importTelegramSendModule,
+  installTelegramSendTestHooks,
+} from "./send.test-harness.js";
+
+installTelegramSendTestHooks();
+
+const { botApi, botRawApi } = getTelegramSendTestMocks();
+const { editMessageTelegram } = await importTelegramSendModule();
+const richConfig = { channels: { telegram: { richMessages: true } } };
+const editedMessage = { message_id: 321, chat: { id: 123, type: "private" } };
+const paragraphs = (count: number) =>
+  Array.from({ length: count }, (_, index) => `P${String(index + 1).padStart(3, "0")}`);
+const listItems = (count: number) =>
+  Array.from({ length: count }, (_, index) => `L${String(index + 1).padStart(3, "0")}`);
+
+describe("Telegram rich message edits", () => {
+  it.each([
+    { name: "501 paragraphs", tokens: paragraphs(501), separator: "\n\n", prefix: "" },
+    { name: "251 list items", tokens: listItems(251), separator: "\n", prefix: "- " },
+  ])("preserves every item when $name requires plain recovery", async (testCase) => {
+    const text = testCase.tokens
+      .map((token) => `${testCase.prefix}${token}`)
+      .join(testCase.separator);
+    botRawApi.editMessageText.mockRejectedValueOnce(
+      new Error("400: Bad Request: RICH_MESSAGE_BLOCKS_TOO_MANY"),
+    );
+    botApi.editMessageText.mockResolvedValueOnce(editedMessage);
+
+    await expect(
+      editMessageTelegram("123", 321, text, {
+        cfg: richConfig,
+        token: "tok",
+        buttons: [],
+        linkPreview: false,
+      }),
+    ).resolves.toEqual({ ok: true, messageId: "321", chatId: "123" });
+
+    expect(botRawApi.editMessageText).toHaveBeenCalledOnce();
+    expect(botApi.editMessageText).toHaveBeenCalledOnce();
+    const [chatId, messageId, deliveredText, options] = botApi.editMessageText.mock.calls[0]!;
+    expect([chatId, messageId]).toEqual(["123", 321]);
+    expect(String(deliveredText).match(/[PL]\d{3}/g)).toEqual(testCase.tokens);
+    expect(options).toEqual({
+      link_preview_options: { is_disabled: true },
+      reply_markup: { inline_keyboard: [] },
+    });
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+    expect(botRawApi.sendRichMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps a complete 500-paragraph replacement on the rich edit endpoint", async () => {
+    const tokens = paragraphs(500);
+    botRawApi.editMessageText.mockResolvedValueOnce(editedMessage);
+
+    await editMessageTelegram("123", 321, tokens.join("\n\n"), {
+      cfg: richConfig,
+      token: "tok",
+    });
+
+    expect(botRawApi.editMessageText).toHaveBeenCalledOnce();
+    expect(JSON.stringify(botRawApi.editMessageText.mock.calls[0]?.[0]).match(/P\d{3}/g)).toEqual(
+      tokens,
+    );
+    expect(botApi.editMessageText).not.toHaveBeenCalled();
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps source text visible when rich rendering produces no blocks", async () => {
+    const text = "[reference]: https://example.com";
+    botApi.editMessageText.mockResolvedValueOnce(editedMessage);
+
+    await editMessageTelegram("123", 321, text, { cfg: richConfig, token: "tok" });
+
+    expect(botApi.editMessageText).toHaveBeenCalledWith("123", 321, text);
+    expect(botRawApi.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized plain replacement without editing separate chunks", async () => {
+    const text = `START${"x".repeat(4100)}END`;
+    botRawApi.editMessageText.mockRejectedValueOnce(
+      new Error("400: Bad Request: RICH_MESSAGE_URL_INVALID"),
+    );
+    const rejection = new Error("400: Bad Request: message is too long");
+    botApi.editMessageText.mockRejectedValueOnce(rejection);
+
+    await expect(
+      editMessageTelegram("123", 321, text, { cfg: richConfig, token: "tok" }),
+    ).rejects.toBe(rejection);
+
+    expect(botApi.editMessageText).toHaveBeenCalledExactlyOnceWith("123", 321, text);
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #130525

<details>
<summary>Additional instructions</summary>

This PR uses a branch in `openclaw/openclaw`, so repository maintainers can push fixes directly.

</details>

## What Problem This Solves

Fixes an issue where users editing a Telegram message would silently lose the end of their replacement when rich messages were enabled and the content exceeded the rich block-count limit. Short replacements can hit that limit: 501 short paragraphs fit in 3004 characters, and 251 short list items fit in 1756 characters.

Both cases previously returned a successful edit receipt despite dropping the final paragraph or final two list items. Rich-to-plain recovery also preserved only the truncated first page.

## Why This Change Was Made

An edit replaces one existing message; send pagination is not the correct owner for that operation. The edit producer now supplies the complete existing rich plan to the established single-message delivery/fallback flow. If Telegram rejects its structure, the same plain-text recovery receives the full replacement. An oversized plain replacement still fails visibly rather than creating extra messages.

Ordinary send pagination, intentional draft-preview clamping, default HTML edits, caption edits, zero-block source text, reply markup, and link-preview behavior remain unchanged. No config, public API, protocol, storage, dependency, or retry-policy change.

The first-page edit behavior came from #117327 (`2cf725191cb9e69b212c0e987362fd2799fb4aa3`, merged 2026-08-11; code/PR author @steipete, merger @obviyus). This repair restores whole-document ownership without reinstating a separate fallback implementation.

Production LOC: +16/-9 (net +7). Tests: +96. The production growth makes the one-message boundary explicit while reusing the existing rich-plan producer and fallback orchestrator. Looping send pages would overwrite the same message repeatedly; changing shared pagination would break valid send and preview behavior.

## User Impact

Telegram rich-message edits preserve the complete replacement or report a failure, instead of silently accepting only its first page. Release note: Telegram: preserve complete rich-message edits when structural limits require plain-text recovery.

## Evidence

The native proof used the actual built CLI, an isolated real Gateway/action registry, the Telegram plugin, and real grammY HTTP serialization. Only the external Telegram Bot API boundary was simulated. It enforced Telegram's documented recursive 500-block limit and 4096-character plain-text edit limit. This is not a Telegram SaaS/Desktop or live-provider claim.

| Scenario | Baseline | Candidate |
| --- | --- | --- |
| 501 paragraphs, 3004 characters | Successful receipt, P501 missing | All 501 paragraphs retained |
| 251 list items, 1756 characters | Successful receipt, L250/L251 missing | All 251 items retained |
| Rich rejection of 501 paragraphs | Plain recovery missing P501 | Complete plain recovery |
| 500 paragraphs / 249 list items | Complete rich edits | Unchanged |
| Short rich rejection | Complete plain recovery | Unchanged |
| Rich rejection and oversized plain rejection | Visible failure, seed unchanged | Unchanged, no extra messages |
| Default HTML: 501 paragraphs / 251 items | Complete edits | Unchanged |

```json
{"kind":"real-gateway-cli-mock-telegram-http","baseline":{"regressions":3,"passingControls":6},"candidate":{"passed":9,"failed":0,"editAttempts":14,"fullOrderedTokensVerified":true,"cleanupComplete":true}}
```

Before production edits, the new regression file had two expected missing-tail failures and three passing controls. After the repair, all 375 tests passed across `send-rich-editing.test.ts`, `send.test.ts`, `send-caption-editing.test.ts`, `draft-stream.test.ts`, and `rich-plain-fallback.test.ts`. The private QA build and all selected changed gates passed, including extension production/test typechecks, targeted type-aware lint, formatting, five doctor-contract tests, dependency/boundary guards, dead-export scans, and runtime import-cycle checks. Authenticated Codex review of the whole patch and owner/caller/sibling context reported no actionable findings.

An independent verifier repeated all 375 tests and nine native scenarios against the same frozen source. A separate source-blind validator then passed all six behavior-contract clauses using nine fresh cases through a restricted real CLI/Gateway interface. It checked the full marker and visible-word order, message identity, accepted state after every operation, complete short/long recovery, explicit oversized failure, default HTML parity, and zero continuation sends.

```json
{"sourceBlind":{"verdict":"satisfies_contract","clausesPassed":6,"casesPassed":9,"transportAttempts":23,"seedSends":9,"editAttempts":14,"extraMessages":0,"findings":0},"ownedRuntimeCleanup":"complete"}
```

The first private validation interface rejected fixture IDs before reaching the product; only that ignored test interface was corrected, then validation restarted with fresh inputs. No product changes were made during independent verification.

Focused commands:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/telegram/src/send-rich-editing.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/send-caption-editing.test.ts extensions/telegram/src/draft-stream.test.ts extensions/telegram/src/rich-plain-fallback.test.ts
node scripts/check-changed.mjs -- extensions/telegram/src/send-edit.ts extensions/telegram/src/send-rich-editing.test.ts
OPENCLAW_BUILD_PRIVATE_QA=1 node --import tsx scripts/build-all.mts qaRuntime
```

Exact-head CI passed for `40b51a8c8b0a3d690072b5a106f13d4173444df1`: [CI run 33026956563](https://github.com/openclaw/openclaw/actions/runs/33026956563). The repository-native workflow merged this repair as [98017ad71e83604f4b525220f49094f41b792861](https://github.com/openclaw/openclaw/commit/98017ad71e83604f4b525220f49094f41b792861); a post-merge fetch confirmed it on `main` with the exact reviewed source and regression-test blobs.

AI-assisted repair, with independent source review and source-blind behavior validation.
