### PR TITLE
fix(macos): recognize Screen Recording access after granting permission

### DIFF
--- a/apps/macos/Sources/OpenClaw/ComputerActionService.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerActionService.swift
@@ -367,11 +367,13 @@ struct ComputerControlPermissionSnapshot: Equatable, Sendable {
     let postEvent: Access
     let screenCapture: Access
 
+    @MainActor
     static func probe() -> Self {
         Self(
             accessibility: AXIsProcessTrusted() ? .granted : .missing,
             postEvent: CGPreflightPostEventAccess() ? .granted : .missing,
-            screenCapture: CGPreflightScreenCaptureAccess() ? .granted : .missing)
+            screenCapture: PermissionManager.screenRecordingPermissions.checkScreenRecordingPermission()
+                ? .granted : .missing)
     }
 
     var diagnostic: Diagnostic {

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -1,11 +1,11 @@
 import AppKit
 import ApplicationServices
 import AVFoundation
-import CoreGraphics
 import CoreLocation
 import Foundation
 import Observation
 import OpenClawIPC
+import PeekabooAutomationKit
 import Speech
 import UserNotifications
 
@@ -24,6 +24,8 @@ enum CapabilityAuthorizationStatus: Equatable, Sendable {
 }
 
 enum PermissionManager {
+    @MainActor static let screenRecordingPermissions = PermissionsService()
+
     /// UNUserNotificationCenter.current() aborts with NSInternalInconsistencyException
     /// ("bundleProxyForCurrentProcess is nil") in unbundled processes such as
     /// `swift build` dev binaries. Every notification-center call must check this
@@ -129,12 +131,12 @@ enum PermissionManager {
         return await MainActor.run { AXIsProcessTrusted() }
     }
 
+    @MainActor
     private static func ensureScreenRecording(interactive: Bool) async -> Bool {
-        let granted = ScreenRecordingProbe.isAuthorized()
-        if interactive, !granted {
-            await ScreenRecordingProbe.requestAuthorization()
+        if interactive, !self.screenRecordingPermissions.checkScreenRecordingPermission() {
+            self.screenRecordingPermissions.requestScreenRecordingPermission()
         }
-        return ScreenRecordingProbe.isAuthorized()
+        return await self.screenRecordingPermissions.checkScreenRecordingPermissionLive(forceProbe: interactive)
     }
 
     private static func ensureMicrophone(interactive: Bool) async -> Bool {
@@ -251,11 +253,10 @@ enum PermissionManager {
                 results[cap] = await MainActor.run { AXIsProcessTrusted() } ? .granted : .notGranted
 
             case .screenRecording:
-                if #available(macOS 10.15, *) {
-                    results[cap] = CGPreflightScreenCaptureAccess() ? .granted : .notGranted
-                } else {
-                    results[cap] = .granted
-                }
+                // CoreGraphics can retain a denial after a grant. Peekaboo retains confirmed grants
+                // and only unlocks live probes after an explicit permission request.
+                results[cap] = await self.screenRecordingPermissions.checkScreenRecordingPermissionLive()
+                    ? .granted : .notGranted
 
             case .microphone:
                 results[cap] = AVCaptureDevice.authorizationStatus(for: .audio) == .authorized
@@ -483,21 +484,5 @@ final class PermissionMonitor {
         self.lastCheck = Date()
 
         self.isChecking = false
-    }
-}
-
-enum ScreenRecordingProbe {
-    static func isAuthorized() -> Bool {
-        if #available(macOS 10.15, *) {
-            return CGPreflightScreenCaptureAccess()
-        }
-        return true
-    }
-
-    @MainActor
-    static func requestAuthorization() async {
-        if #available(macOS 10.15, *) {
-            _ = CGRequestScreenCaptureAccess()
-        }
     }
 }

--- a/docs/platforms/mac/permissions.md
+++ b/docs/platforms/mac/permissions.md
@@ -2,6 +2,7 @@
 summary: "macOS permission persistence (TCC) and signing requirements"
 read_when:
   - Debugging missing or stuck macOS permission prompts
+  - Screen Recording still appears missing after granting access
   - Deciding whether to grant Accessibility to node or a CLI runtime
   - Packaging or signing the macOS app
   - Changing bundle IDs or app install paths
@@ -13,11 +14,23 @@ macOS permission grants are fragile. TCC associates a permission grant with the 
 ## Requirements for stable permissions
 
 - Same path: run a release app from `/Applications/OpenClaw.app`; keep development builds at one fixed path such as `dist/OpenClaw.app`.
-- Same bundle identifier: OpenClaw's bundle ID is `ai.openclaw.mac`; changing it creates a new permission identity.
+- Same bundle identifier: release builds use `ai.openclaw.mac`; development builds default to `ai.openclaw.mac.debug`. Each has a separate permission identity.
 - Signed app: unsigned or ad-hoc signed builds do not persist permissions.
 - Consistent signature: use a real Apple Development or Developer ID certificate so the signature stays stable across rebuilds.
 
 Ad-hoc signatures generate a new identity every build. macOS forgets previous grants, and prompts can disappear entirely until the stale entries are cleared.
+
+## Screen Recording still appears missing after granting access
+
+If Quick Chat still shows **Needs additional permissions: Screen Recording**:
+
+1. Click **Grant** in OpenClaw.
+2. If macOS opens System Settings, enable the running OpenClaw app under **Privacy & Security -> Screen & System Audio Recording** (called **Screen Recording** on older macOS versions).
+3. Return to OpenClaw and retry the screenshot. You can also recheck access with **Settings -> Permissions -> Refresh**.
+
+After an explicit **Grant** request, OpenClaw checks ScreenCaptureKit as well as the macOS permission preflight. This lets it recognize access when the preflight still reports an old denial. Passive status checks do not initiate this probe before you request access.
+
+If access still appears missing, quit and reopen OpenClaw from the same app path. Some macOS permission changes require an app restart before capture works. If both release and development builds are installed, grant access to the build you are actually running: approving `/Applications/OpenClaw.app` does not grant access to a development build with a different bundle identifier.
 
 ## Accessibility grants for Node and CLI runtimes
 


### PR DESCRIPTION
Closes #130528

## What Problem This Solves

Fixes an issue where users who grant Screen Recording to the macOS app can still see Quick Chat's “Needs additional permissions” strip and be refused by the screenshot picker when macOS retains an old preflight denial.

## Why This Change Was Made

Use the already-pinned Peekaboo permission service as the shared owner for screen-recording status and requests. It retains confirmed request/live-probe grants and performs a rate-limited ScreenCaptureKit check after explicit consent. Remove the duplicate CoreGraphics-only probe; computer-control diagnostics consume the same confirmed state without adding an await to input execution.

Passive checks remain non-prompting before an explicit request. Actual capture remains enforced by macOS. No dependency, config, persistence, or public API changes. Production LOC: +14/-27 (net -13); tests unchanged; docs +14/-1.

## User Impact

Quick Chat, Permissions settings, and screenshot readiness recognize usable access after a grant instead of repeatedly reporting a cached denial. Recovery docs explain when a genuine app restart is still needed and that development/release builds have separate permission identities.

## Evidence

- `swift test --package-path apps/macos --build-system native --filter 'PermissionManagerTests|QuickChatModelTests|ComputerActionServiceTests|QuickChatWindowPickerTests'`: 74 tests pass before and after the patch.
- Eight existing `PermissionsServiceStateTests` from pinned Peekaboo revision `028cd9eb2d7b413c26f02f169c5f6224b2fcb3e0` pass in a disposable Swift package using that exact dependency. Only its logging mock was replaced with the concrete logger. They cover stale false preflights, retained request grants, consent gating, rate limiting, and concurrent forced refreshes.
- SwiftFormat, Markdown formatting, and `git diff --check` pass.
- Fresh Codex autoreview: no actionable P0 finding; independent source/dependency review found no actionable runtime issue. AI-assisted implementation.
- Source/dependency inspection covers QuickChatModel, QuickChatWindowPicker, PermissionMonitor, ComputerControlPermissionSnapshot, and pinned Peekaboo PermissionsService/ScreenRecordingPermissionChecker.
- The initial Xcode-backed test run built successfully but could not load Sparkle in its test runner. The native SwiftPM backend passed; no product workaround was added.

Signed exact-head app verification is complete: native Permissions Settings reports Screen Recording **Granted**, the selected OpenClaw GUI Bridge reports usable screen access, and an exact-window capture through that host succeeds. [Sanitized before/after captures and live proof](https://github.com/openclaw/openclaw/pull/130530#issuecomment-5433093637) are attached. The development bundle kept its identifier and matching Developer ID requirement and passed deep/strict signature verification. It now runs outside generated build output, which concurrent builds were repeatedly clearing. No TCC state was modified/reset and no Gateway was restarted.

This proves restart recovery and actual capture, not the exact same-process denied-to-granted Quick Chat transition. That stronger transition was not replayed because it would require changing the operator's existing permission grant. The unbundled test host already has permission, and a proposed test passed before the patch, so it was not kept as regression proof. The pinned dependency's eight existing deterministic tests cover stale false preflights, retained request grants, consent gating, and concurrent forced rechecks. [Direct dependency inspection and contract citations](https://github.com/openclaw/openclaw/pull/130530#issuecomment-5432957156) address the corresponding review gap. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33027375705) is green.

Follow-up: keep development app installations outside `dist`; the full JavaScript build intentionally clears that directory. Build/deployment ownership changes are separate from this permission-state repair.

Historical provenance: the CoreGraphics-only status path predates the available shallow history and was carried forward by #112321 (authored and merged by @steipete, July 21, 2026). That change preserved passive consent boundaries; this patch preserves those boundaries while adopting the dependency's existing live-grant handling. The original introduction is not established.
