### PR TITLE
fix(android): report disabled notification categories instead of success

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/node/SystemHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/SystemHandler.kt
@@ -29,29 +29,14 @@ internal data class SystemNotifyRequest(
 
 /** Notification posting seam used by production Android and unit tests. */
 internal interface SystemNotificationPoster {
-  fun isAuthorized(): Boolean
-
   fun post(request: SystemNotifyRequest)
 }
 
 private class AndroidSystemNotificationPoster(
   private val appContext: Context,
 ) : SystemNotificationPoster {
-  /** Checks both Android 13 runtime permission and app-level notification enablement. */
-  override fun isAuthorized(): Boolean {
-    if (Build.VERSION.SDK_INT >= 33) {
-      val granted =
-        ContextCompat.checkSelfPermission(appContext, Manifest.permission.POST_NOTIFICATIONS) ==
-          PackageManager.PERMISSION_GRANTED
-      if (!granted) return false
-    }
-    return NotificationManagerCompat.from(appContext).areNotificationsEnabled()
-  }
-
   /** Posts through a priority-specific channel so Android's immutable channel importance is respected. */
   override fun post(request: SystemNotifyRequest) {
-    val channelId = ensureChannel(request.priority)
-    val notification = buildSystemNotification(appContext, channelId, request)
     if (
       Build.VERSION.SDK_INT >= 33 &&
       ContextCompat.checkSelfPermission(appContext, Manifest.permission.POST_NOTIFICATIONS) !=
@@ -59,6 +44,11 @@ private class AndroidSystemNotificationPoster(
     ) {
       throw SecurityException("notifications permission missing")
     }
+    if (!NotificationManagerCompat.from(appContext).areNotificationsEnabled()) {
+      throw SecurityException("notifications disabled")
+    }
+    val channelId = ensureChannel(request.priority)
+    val notification = buildSystemNotification(appContext, channelId, request)
     NotificationManagerCompat.from(appContext).notify((System.currentTimeMillis() and 0x7FFFFFFF).toInt(), notification)
   }
 
@@ -82,6 +72,10 @@ private class AndroidSystemNotificationPoster(
     val channelId = "$NOTIFICATION_CHANNEL_BASE_ID.$suffix"
     val manager = appContext.getSystemService(NotificationManager::class.java)
     val existing = manager.getNotificationChannel(channelId)
+    // notify() silently drops blocked channels; report the user's existing choice before posting.
+    if (existing?.importance == NotificationManager.IMPORTANCE_NONE) {
+      throw SecurityException("notification channel disabled")
+    }
     if (existing == null) {
       manager.createNotificationChannel(NotificationChannel(channelId, name, importance))
     }
@@ -138,19 +132,13 @@ class SystemHandler private constructor(
         message = "INVALID_REQUEST: empty notification",
       )
     }
-    if (!poster.isAuthorized()) {
-      return GatewaySession.InvokeResult.error(
-        code = "NOT_AUTHORIZED",
-        message = "NOT_AUTHORIZED: notifications",
-      )
-    }
     return try {
       poster.post(params)
       GatewaySession.InvokeResult.ok(null)
     } catch (_: SecurityException) {
       GatewaySession.InvokeResult.error(
         code = "NOT_AUTHORIZED",
-        message = "NOT_AUTHORIZED: notifications",
+        message = "NOT_AUTHORIZED: enable OpenClaw notifications and the selected priority in Android Settings",
       )
     } catch (err: Throwable) {
       GatewaySession.InvokeResult.error(

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/InvokeDispatcherTest.kt
@@ -386,8 +386,6 @@ private class InvokeDispatcherFakeNotificationsStateProvider : NotificationsStat
 }
 
 private class InvokeDispatcherFakeSystemNotificationPoster : SystemNotificationPoster {
-  override fun isAuthorized(): Boolean = true
-
   override fun post(request: SystemNotifyRequest) = Unit
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/SystemHandlerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/SystemHandlerTest.kt
@@ -1,6 +1,10 @@
 package ai.openclaw.app.node
 
 import ai.openclaw.app.MainActivity
+import android.Manifest
+import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import org.junit.Assert.assertEquals
@@ -19,17 +23,30 @@ import org.robolectric.annotation.Config
 class SystemHandlerTest {
   @Test
   fun handleSystemNotify_rejectsUnauthorized() {
-    val handler = SystemHandler.forTesting(poster = FakePoster(authorized = false))
+    val context: Application = RuntimeEnvironment.getApplication()
+    val manager = context.getSystemService(NotificationManager::class.java)
+    val handler = SystemHandler(context)
 
-    val result = handler.handleSystemNotify("""{"title":"OpenClaw","body":"hi"}""")
+    for (permissionGranted in listOf(false, true)) {
+      if (permissionGranted) {
+        Shadows.shadowOf(context).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+      } else {
+        Shadows.shadowOf(context).denyPermissions(Manifest.permission.POST_NOTIFICATIONS)
+      }
+      Shadows.shadowOf(manager).setNotificationsEnabled(!permissionGranted)
 
-    assertFalse(result.ok)
-    assertEquals("NOT_AUTHORIZED", result.error?.code)
+      val result = handler.handleSystemNotify("""{"title":"OpenClaw","body":"hi"}""")
+
+      assertFalse(result.ok)
+      assertEquals("NOT_AUTHORIZED", result.error?.code)
+      assertTrue(manager.notificationChannels.isEmpty())
+      assertTrue(manager.activeNotifications.isEmpty())
+    }
   }
 
   @Test
   fun handleSystemNotify_rejectsEmptyNotification() {
-    val handler = SystemHandler.forTesting(poster = FakePoster(authorized = true))
+    val handler = SystemHandler.forTesting(poster = FakePoster())
 
     val result = handler.handleSystemNotify("""{"title":"   ","body":"  "}""")
 
@@ -39,7 +56,7 @@ class SystemHandlerTest {
 
   @Test
   fun handleSystemNotify_rejectsInvalidRequestObject() {
-    val handler = SystemHandler.forTesting(poster = FakePoster(authorized = true))
+    val handler = SystemHandler.forTesting(poster = FakePoster())
 
     val result = handler.handleSystemNotify("""{"title":"OpenClaw"}""")
 
@@ -49,7 +66,7 @@ class SystemHandlerTest {
 
   @Test
   fun handleSystemNotify_postsNotification() {
-    val poster = FakePoster(authorized = true)
+    val poster = FakePoster()
     val handler = SystemHandler.forTesting(poster = poster)
 
     val result = handler.handleSystemNotify("""{"title":"OpenClaw","body":"done","priority":"active"}""")
@@ -59,8 +76,49 @@ class SystemHandlerTest {
   }
 
   @Test
+  fun handleSystemNotify_rejectsBlockedSelectedChannels() {
+    val context: Application = RuntimeEnvironment.getApplication()
+    Shadows.shadowOf(context).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+    val manager = context.getSystemService(NotificationManager::class.java)
+    val handler = SystemHandler(context)
+    assertTrue(manager.areNotificationsEnabled())
+
+    val priorities = listOf(null to "active", "active" to "active", "passive" to "passive", "timeSensitive" to "timesensitive")
+    for ((priority, suffix) in priorities) {
+      val channelId = "openclaw.system.notify.$suffix"
+      manager.createNotificationChannel(NotificationChannel(channelId, "Blocked", NotificationManager.IMPORTANCE_NONE))
+      val priorityField = priority?.let { ",\"priority\":\"$it\"" }.orEmpty()
+
+      val result = handler.handleSystemNotify("""{"title":"OpenClaw","body":"blocked"$priorityField}""")
+
+      assertFalse("priority=$priority must not report a blocked post as successful", result.ok)
+      assertEquals("NOT_AUTHORIZED", result.error?.code)
+      assertEquals(NotificationManager.IMPORTANCE_NONE, manager.getNotificationChannel(channelId).importance)
+    }
+  }
+
+  @Test
+  fun handleSystemNotify_postsAllowedChannelWhenAnotherPriorityIsBlocked() {
+    val context: Application = RuntimeEnvironment.getApplication()
+    Shadows.shadowOf(context).grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+    val manager = context.getSystemService(NotificationManager::class.java)
+    manager.createNotificationChannel(
+      NotificationChannel("openclaw.system.notify.active", "Blocked", NotificationManager.IMPORTANCE_NONE),
+    )
+    val handler = SystemHandler(context)
+
+    val result = handler.handleSystemNotify("""{"title":"OpenClaw","body":"allowed","priority":"passive"}""")
+
+    assertTrue(result.ok)
+    assertEquals(NotificationManager.IMPORTANCE_LOW, manager.getNotificationChannel("openclaw.system.notify.passive").importance)
+    val notification = manager.activeNotifications.single().notification
+    assertEquals("openclaw.system.notify.passive", notification.channelId)
+    assertEquals("allowed", notification.extras.getCharSequence("android.text"))
+  }
+
+  @Test
   fun handleSystemNotify_trimsAndPassesOptionalFields() {
-    val poster = FakePoster(authorized = true)
+    val poster = FakePoster()
     val handler = SystemHandler.forTesting(poster = poster)
 
     val result =
@@ -97,7 +155,7 @@ class SystemHandlerTest {
 
   @Test
   fun handleSystemNotify_returnsUnauthorizedWhenPostFailsPermission() {
-    val handler = SystemHandler.forTesting(poster = ThrowingPoster(authorized = true, error = SecurityException("denied")))
+    val handler = SystemHandler.forTesting(poster = ThrowingPoster(error = SecurityException("denied")))
 
     val result = handler.handleSystemNotify("""{"title":"OpenClaw","body":"done"}""")
 
@@ -107,7 +165,7 @@ class SystemHandlerTest {
 
   @Test
   fun handleSystemNotify_returnsUnavailableWhenPostFailsUnexpectedly() {
-    val handler = SystemHandler.forTesting(poster = ThrowingPoster(authorized = true, error = IllegalStateException("boom")))
+    val handler = SystemHandler.forTesting(poster = ThrowingPoster(error = IllegalStateException("boom")))
 
     val result = handler.handleSystemNotify("""{"title":"OpenClaw","body":"done"}""")
 
@@ -117,15 +175,11 @@ class SystemHandlerTest {
   }
 }
 
-private class FakePoster(
-  private val authorized: Boolean,
-) : SystemNotificationPoster {
+private class FakePoster : SystemNotificationPoster {
   var posts: Int = 0
     private set
   var lastRequest: SystemNotifyRequest? = null
     private set
-
-  override fun isAuthorized(): Boolean = authorized
 
   override fun post(request: SystemNotifyRequest) {
     posts += 1
@@ -134,10 +188,7 @@ private class FakePoster(
 }
 
 private class ThrowingPoster(
-  private val authorized: Boolean,
   private val error: Throwable,
 ) : SystemNotificationPoster {
-  override fun isAuthorized(): Boolean = authorized
-
   override fun post(request: SystemNotifyRequest): Unit = throw error
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users invoking `system.notify` would receive a successful result even though Android discarded the notification because its selected notification category was disabled. App-wide notification permission can remain enabled while the user blocks only OpenClaw Active, Passive, or Time Sensitive notifications.

## Why This Change Was Made

The Android posting owner now checks both app permission and the selected channel before posting. A blocked channel returns the existing `NOT_AUTHORIZED` error with a direction to Android Settings; it does not change the user's settings or select a different priority. Consolidating authorization into the posting operation removes the separate preflight and its duplicated permission check.

Production: +10/-22 (net -12). Tests: +69/-20 (net +49). No new permissions, dependencies, configuration, or persistence changes.

## User Impact

Agents can now distinguish a known blocked notification from a successful post and tell the user which Android setting needs attention. Other permitted notification priorities still work. This change concerns posting OpenClaw notifications, not reading or forwarding other apps' notifications. It does not claim that a successful post was seen or read.

## Evidence

Reviewed head: `be428b74888e20cb61d4136057add44ebf7a722a`, against base `c3ea9775ca7ced58bd3d253e277aa11590595680`. A new regression failed on unchanged production code because a blocked default channel incorrectly returned success. The final owner and neighboring notification/dispatcher suites passed 142 tests across Play and third-party builds. Android Lint for both flavors, all four Kotlin lint tasks, the Play debug build, and the normal changed-file checks passed. Autoreview examined the complete change at its P0 threshold and found no findings; independent broader source review found no actionable issues.

The same instrumentation APK exercised the production handler on Android 36, disabling the selected channel through the real Android Settings screen while leaving app notifications enabled:

| Observation | Before | After |
| --- | --- | --- |
| Selected channel importance | 0 (blocked) | 0 (blocked) |
| Blocked post result | Success | `NOT_AUTHORIZED` |
| Blocked notification present | No | No |
| Allowed passive sibling | Posted | Posted |
| Regression result | Intended assertion failure | Pass |

Notification shade captures show the permitted sibling in both runs. The separate stable Settings capture is supplemental proof of the blocked category, not a before/after frame. The test device's original channel setting was restored afterward. The SDK contract confirms that `IMPORTANCE_NONE` is hidden from the notification shade and that app-wide authorization is separate from channel importance.

<details>
<summary>Android notification shade before and after</summary>

Before: the permitted passive notification appears, but the absent blocked notification was incorrectly reported as successful.

![Before: permitted passive notification](https://github.com/user-attachments/assets/f12a2ac5-8e80-4917-9524-72b4eb4a7346)

After: the permitted passive notification still appears; the blocked call now returns `NOT_AUTHORIZED`.

![After: permitted passive notification](https://github.com/user-attachments/assets/de93278d-ceca-4ea4-8ccd-67d1c6dbd09a)

</details>

<details>
<summary>Supplemental Android Settings evidence</summary>

Separate stable post-test capture of the selected channel disabled in Android Settings.

![Android Settings showing the selected category disabled](https://github.com/user-attachments/assets/91631d50-1373-4140-ae8b-b535e066caa8)

</details>

AI-assisted maintenance.
