### PR TITLE
fix(android): inline widgets fail behind gateway proxy paths

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -30,6 +30,7 @@ import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -1967,39 +1968,44 @@ class GatewaySession(
     val trimmed = raw?.trim().orEmpty()
     val parsed = trimmed.takeIf { it.isNotBlank() }?.let { runCatching { java.net.URI(it) }.getOrNull() }
     val host = parsed?.host?.trim().orEmpty()
-    val port = parsed?.port ?: -1
-    val scheme =
-      parsed
-        ?.scheme
-        ?.trim()
-        .orEmpty()
-        .ifBlank { "http" }
-    val suffix = buildUrlSuffix(parsed)
-
-    // If raw URL is a non-loopback address and this connection uses TLS,
-    // normalize scheme/port to the endpoint we actually connected to.
-    if (trimmed.isNotBlank() && host.isNotBlank() && !isLoopbackGatewayHost(host)) {
-      val needsTlsRewrite =
-        isTlsConnection &&
-          (
-            !scheme.equals("https", ignoreCase = true) ||
-              (port > 0 && port != endpoint.port) ||
-              (port <= 0 && endpoint.port != 443)
-          )
-      if (needsTlsRewrite) {
-        return buildCanvasUrl(host = host, scheme = "https", port = endpoint.port, suffix = suffix)
+    val scheme = parsed?.scheme ?: "http"
+    val port = parsed?.port?.takeIf { it > 0 } ?: if (scheme.equals("https", ignoreCase = true)) 443 else 80
+    val usesFallbackHost = host.isBlank() || isLoopbackGatewayHost(host)
+    val gatewayOrigin = "http://${formatGatewayAuthority(endpoint.host.trim().trimEnd('.'), endpoint.port)}".toHttpUrlOrNull()
+    val surfaceOrigin = "http://${formatGatewayAuthority(host.trimEnd('.'), port)}".toHttpUrlOrNull()
+    val isGatewayAuthority = usesFallbackHost || (gatewayOrigin != null && surfaceOrigin == gatewayOrigin)
+    val path = parsed?.rawPath.orEmpty()
+    val capability = path.removePrefix("/__openclaw__/cap/")
+    val isRootCapability = path != capability && capability.isNotEmpty() && !capability.contains('/')
+    val hasUriExtras = parsed?.rawUserInfo != null || parsed?.rawQuery != null || parsed?.rawFragment != null
+    val isHttpSurface = scheme.equals("http", ignoreCase = true) || scheme.equals("https", ignoreCase = true)
+    // Only gateway-hosted root capabilities inherit its proxy prefix. Judge the original
+    // authority before TLS rewriting, and leave explicit surface paths and token bytes intact.
+    val contextPath =
+      if (isGatewayAuthority && isRootCapability && !hasUriExtras && isHttpSurface) {
+        endpoint.contextPath
+      } else {
+        ""
       }
-      return trimmed
-    }
+    val suffix = contextPath + buildUrlSuffix(parsed)
 
-    val fallbackHost =
-      endpoint.tailnetDns?.trim().takeIf { !it.isNullOrEmpty() }
-        ?: endpoint.lanHost?.trim().takeIf { !it.isNullOrEmpty() }
-        ?: endpoint.host.trim()
-    if (fallbackHost.isEmpty()) return trimmed.ifBlank { null }
-
-    val fallbackScheme = if (isTlsConnection) "https" else scheme
-    return buildCanvasUrl(host = fallbackHost, scheme = fallbackScheme, port = endpoint.port, suffix = suffix)
+    val needsTlsRewrite = isTlsConnection && (!scheme.equals("https", ignoreCase = true) || port != endpoint.port)
+    if (!usesFallbackHost && !needsTlsRewrite && contextPath.isEmpty()) return trimmed
+    val resolvedHost =
+      if (usesFallbackHost) {
+        endpoint.tailnetDns?.trim().takeIf { !it.isNullOrEmpty() }
+          ?: endpoint.lanHost?.trim().takeIf { !it.isNullOrEmpty() }
+          ?: endpoint.host.trim()
+      } else {
+        host
+      }
+    if (resolvedHost.isEmpty()) return trimmed.ifBlank { null }
+    return buildCanvasUrl(
+      host = resolvedHost,
+      scheme = if (isTlsConnection) "https" else scheme,
+      port = if (usesFallbackHost || isTlsConnection) endpoint.port else port,
+      suffix = suffix,
+    )
   }
 
   private fun buildCanvasUrl(

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.gateway
 
+import ai.openclaw.app.chat.ChatWidgetUrlResolver
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
@@ -18,6 +19,8 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
@@ -198,25 +201,57 @@ class GatewaySessionInvokeTest {
   @Test
   fun refreshCanvasHostUrl_usesNodeRefreshMethod() =
     runBlocking {
-      assertCanvasHostRefreshMethod(role = "node", expectedMethod = "node.pluginSurface.refresh")
+      for (contextPath in listOf("", "/tenant%20gateway/gw", "/tenant%2Fgateway", "//tenant/gw", "/__openclaw__")) {
+        assertCanvasHostRefreshMethod(role = "node", expectedMethod = "node.pluginSurface.refresh", contextPath = contextPath)
+      }
     }
 
   @Test
   fun refreshCanvasHostUrl_usesOperatorRefreshMethod() =
     runBlocking {
-      assertCanvasHostRefreshMethod(role = "operator", expectedMethod = "plugin.surface.refresh")
+      for (contextPath in listOf("", "/tenant%20gateway/gw", "/tenant%2Fgateway", "//tenant/gw", "/__openclaw__")) {
+        assertCanvasHostRefreshMethod(role = "operator", expectedMethod = "plugin.surface.refresh", contextPath = contextPath)
+      }
     }
 
   private suspend fun assertCanvasHostRefreshMethod(
     role: String,
     expectedMethod: String,
+    contextPath: String,
   ) {
     val json = testJson()
     val connected = CompletableDeferred<Unit>()
     val lastDisconnect = AtomicReference("")
     val refreshRequests = AtomicInteger()
+    val documentPath = "/__openclaw__/canvas/documents/widget-1/index.html"
+    val documentBody = "<html><body>Gateway widget</body></html>"
+    val documentPaths =
+      listOf("old-token", "new-token").map { "$contextPath/__openclaw__/cap/$it$documentPath" }
+    val activeDocumentPath = AtomicReference(documentPaths.first())
+    val requestedPaths = CopyOnWriteArrayList<String>()
+    val httpClient = OkHttpClient()
+
+    fun loadDocument(surfaceUrl: String): Pair<Int, String> {
+      val url = requireNotNull(ChatWidgetUrlResolver.resolve(surfaceUrl, documentPath))
+      return httpClient.newCall(Request.Builder().url(url).build()).execute().use { response ->
+        response.code to response.body.string()
+      }
+    }
     val server =
-      startGatewayServer(json) { webSocket, id, method, frame ->
+      startGatewayServer(
+        json,
+        onHandshake = { assertEquals(contextPath.ifEmpty { "/" }, it.path) },
+        onHttpRequest = { request ->
+          val path = requireNotNull(request.path)
+          requestedPaths.add(path)
+          assertNull(request.getHeader("Authorization"))
+          if (path == activeDocumentPath.get()) {
+            MockResponse().setHeader("Content-Type", "text/html").setBody(documentBody)
+          } else {
+            MockResponse().setResponseCode(404)
+          }
+        },
+      ) { webSocket, id, method, frame ->
         when (method) {
           "connect" ->
             webSocket.send(
@@ -228,6 +263,7 @@ class GatewaySessionInvokeTest {
             )
           expectedMethod -> {
             refreshRequests.incrementAndGet()
+            activeDocumentPath.set(documentPaths.last())
             assertEquals(
               "canvas",
               frame["params"]
@@ -261,22 +297,74 @@ class GatewaySessionInvokeTest {
         port = server.port,
         role = role,
         scopes = if (role == "operator") listOf("operator.read") else listOf("node:invoke"),
+        contextPath = contextPath,
       )
       awaitConnectedOrThrow(connected, lastDisconnect, server)
       val oldUrl = requireNotNull(harness.session.currentCanvasHostUrl())
-      assertTrue(oldUrl.endsWith("/old-token"))
-
+      val beforeRefresh = loadDocument(oldUrl)
       val refreshed = harness.session.refreshCanvasHostUrlIfCurrent(oldUrl)
       val lagging = harness.session.refreshCanvasHostUrlIfCurrent(oldUrl)
+      val afterRefresh = loadDocument(requireNotNull(refreshed))
+      val expiredDocument = loadDocument(oldUrl)
+      val responses = listOf(beforeRefresh, afterRefresh)
 
-      assertTrue(refreshed?.endsWith("/new-token") == true)
+      assertEquals("hello and refresh document responses for $role at $contextPath; paths=$requestedPaths", listOf(200 to documentBody, 200 to documentBody), responses)
+      assertEquals(documentPaths + documentPaths.first(), requestedPaths)
+      assertEquals(404, expiredDocument.first)
+      assertTrue(oldUrl.endsWith("/old-token"))
+      assertTrue(refreshed.endsWith("/new-token"))
       assertEquals(refreshed, harness.session.currentCanvasHostUrl())
       assertEquals(refreshed, lagging)
       assertEquals(1, refreshRequests.get())
     } finally {
+      httpClient.connectionPool.evictAll()
+      httpClient.dispatcher.executorService.shutdown()
       shutdownHarness(harness, server)
     }
   }
+
+  @Test
+  fun refreshCanvasHostUrl_preservesExplicitSurfaceRoutes() =
+    runBlocking {
+      val json = testJson()
+      val connected = CompletableDeferred<Unit>()
+      val lastDisconnect = AtomicReference("")
+      val contextPath = "/tenant%20gateway/gw"
+      val capabilityPath = "/__openclaw__/cap/token"
+      val advertised = AtomicReference("https://canvas.example:9443$capabilityPath")
+      val server =
+        startGatewayServer(json) { webSocket, id, method, _ ->
+          if (method == "connect") {
+            webSocket.send(connectResponseFrame(id, pluginSurfaceUrls = mapOf("canvas" to advertised.get())))
+          } else if (method == "plugin.surface.refresh") {
+            webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":{"pluginSurfaceUrls":{"canvas":"${advertised.get()}"}}}""")
+          }
+        }
+      val harness = createNodeHarness(connected, lastDisconnect) { GatewaySession.InvokeResult.ok(null) }
+      try {
+        connectNodeSession(harness.session, server.port, role = "operator", scopes = listOf("operator.read"), contextPath = contextPath)
+        awaitConnectedOrThrow(connected, lastDisconnect, server)
+        assertEquals(advertised.get(), harness.session.currentCanvasHostUrl())
+        val origin = "http://127.0.0.1:${server.port}"
+        val explicitRoutes =
+          listOf(
+            "https://canvas.example:9443$capabilityPath",
+            "http://canvas.example:${server.port}$capabilityPath",
+            "$origin$contextPath$capabilityPath",
+            "$origin/custom$capabilityPath",
+            "$origin$capabilityPath?variant=raw%2Fvalue",
+            "$origin$capabilityPath#fragment",
+            "$origin/__openclaw__/cap/",
+            "$origin/__openclaw__/canvas/documents/widget/index.html",
+          )
+        for (route in explicitRoutes) {
+          advertised.set(route)
+          assertEquals(route, harness.session.refreshCanvasHostUrl())
+        }
+      } finally {
+        shutdownHarness(harness, server)
+      }
+    }
 
   @Test
   fun connect_advertisesCompatibleProtocolRange() =
@@ -1443,6 +1531,7 @@ class GatewaySessionInvokeTest {
     bootstrapToken: String? = null,
     role: String = "node",
     scopes: List<String> = listOf("node:invoke"),
+    contextPath: String = "",
   ) {
     session.connect(
       endpoint =
@@ -1452,6 +1541,7 @@ class GatewaySessionInvokeTest {
           host = "127.0.0.1",
           port = port,
           tlsEnabled = false,
+          contextPath = contextPath,
         ),
       token = token,
       bootstrapToken = bootstrapToken,
@@ -1577,12 +1667,16 @@ class GatewaySessionInvokeTest {
     json: Json,
     challengeFrame: String = CONNECT_CHALLENGE_FRAME,
     onHandshake: ((RecordedRequest) -> Unit)? = null,
+    onHttpRequest: ((RecordedRequest) -> MockResponse)? = null,
     onRequestFrame: (webSocket: WebSocket, id: String, method: String, frame: JsonObject) -> Unit,
   ): MockWebServer =
     MockWebServer().apply {
       dispatcher =
         object : Dispatcher() {
           override fun dispatch(request: RecordedRequest): MockResponse {
+            if (!request.getHeader("Upgrade").equals("websocket", ignoreCase = true)) {
+              return onHttpRequest?.invoke(request) ?: MockResponse().setResponseCode(404)
+            }
             onHandshake?.invoke(request)
             return MockResponse().withWebSocketUpgrade(
               object : WebSocketListener() {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users would see **Widget unavailable** in chat when their gateway was reached through a reverse-proxy path. The gateway connection succeeded, but both the initial widget and its refreshed capability URL lost that path and fetched a nonexistent root route.

## Why This Change Was Made

Restore the raw proxy prefix in `GatewaySession`, the shared owner of hello and refreshed canvas URLs. Only the gateway's own canonical root capability URL inherits the prefix; explicit external hosts/ports, custom paths, already-prefixed paths, and URI extras remain outside that rewrite. Existing OkHttp host canonicalization handles equivalent address spellings without resolving DNS or changing capability-token bytes.

The normalizer now uses one URL-building path instead of separate TLS/fallback returns. Production LOC: +37/-31 (net +6); regression tests: +100/-6. The small production increase enforces the original-authority and canonical-capability boundaries before existing transport rewriting.

## User Impact

Inline widgets render through the configured gateway path, including after capability refresh. Existing external canvas routes and stale-capability rejection remain intact. No configuration, protocol, permissions, storage, or dependency changes.

## Evidence

- Existing node/operator refresh tests now exercise real WebSocket hello and refresh responses followed by actual HTTP document requests. Unchanged production failed both prefix cases with 404/404; repaired code passes. Controls cover no prefix, raw encoded prefixes, repeated slashes, explicit routes, and expired capabilities in the original execution order.
- Real Android 36 emulator, production `GatewaySession` → widget resolver → production `ChatInlineWidget` WebView, identical instrumentation APK before and after: initial/refreshed requests changed from 404/404 and visible errors to 200/200 and rendered documents. An IPv4-mapped alias also changed from 404/404 to 200/200 against the same IPv4 server; this is not an IPv6 transport claim. The expired capability still returned 404, and document requests carried no authorization/custom credential headers.
- 338 focused gateway/media/widget tests passed across Play and ThirdParty; both Android lint variants, app/benchmark/wear/wear-shared ktlint, Play debug assembly, and the normal changed-file repository guard passed. Independent owner-boundary review and managed autoreview found no actionable defects in their respective review scopes.

### Before and after

Screenshots show only synthetic task-owned documents in the production widget.

| State | Before | After |
| --- | --- | --- |
| Initial widget | ![Initial widget unavailable](https://github.com/user-attachments/assets/ab9859ec-4e83-42fa-b658-833c1c3dccb8) | ![Initial widget rendered](https://github.com/user-attachments/assets/1eb79bd3-d4c5-475f-96b8-d582d4e44ba3) |
| Refreshed capability | ![Refreshed widget unavailable](https://github.com/user-attachments/assets/3d34f25a-dfef-4aa2-bd6f-c848eaef4c5b) | ![Refreshed widget rendered](https://github.com/user-attachments/assets/1db53e9a-84ab-4253-88f5-3d36258eeda2) |

### Boundaries and follow-ups

This is an Android session-owner repair. It does not alter iOS/Web canvas resolution or the existing Android TLS rewriting of an explicitly different canvas port. Proxy prefixes that themselves contain the full `/__openclaw__/cap/` marker expose a separate gateway capability-parser ambiguity and are not claimed as fixed here. The platform run used cleartext on an isolated private interface; TLS behavior is covered by existing owner tests, not by that device run.

Manual gateway-path support made this omission observable; the preexisting canvas normalizer did not inherit that path. Current-main behavior is verified; stable-release ancestry is not claimed.
