### PR TITLE
fix(ai): replace streamed function name on same-id continuation

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -1699,6 +1699,120 @@ describe("openai-completions stop-reason tool-call guard", () => {
     });
   });
 
+  it("replaces the stored function name on a same-id fragmented continuation", async () => {
+    // A stable tool-call id that repeats across deltas signals a continuation of
+    // the same call, so the latest nonempty function-name snapshot must replace
+    // the stored name — mirroring the pinned OpenAI SDK and the managed
+    // transport. Without this the first fragment (e.g. "get_") freezes and the
+    // call is published under a stale, partial name.
+    mockChunksRef.chunks = [
+      makeToolCallChunk("call_name", "get_", '{"city":'),
+      makeToolCallChunk("call_name", "weather", '"Paris"}'),
+      makeFinishChunk("tool_calls"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    expect(result.content).toContainEqual({
+      type: "toolCall",
+      id: "call_name",
+      name: "weather",
+      arguments: { city: "Paris" },
+    });
+  });
+
+  it("replaces the stored name when an index-resolved continuation omits the id", async () => {
+    // A continuation delta that re-uses the established index but omits the id
+    // is still the same tool call — the block was already resolved by index
+    // above, so an absent id is a continuation, not a conflicting identity. The
+    // latest nonempty function-name snapshot must replace the stored name,
+    // matching the pinned OpenAI SDK accumulator. Only an explicitly conflicting
+    // id (next test) keeps the first name.
+    mockChunksRef.chunks = [
+      makeToolCallChunk("call_A", "first", '{"city":'),
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                { index: 0, function: { name: "second", arguments: '"Paris"}' }, type: "function" },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      },
+    ];
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    expect(result.content).toContainEqual({
+      type: "toolCall",
+      id: "call_A",
+      name: "second",
+      arguments: { city: "Paris" },
+    });
+  });
+
+  it("keeps the first name when a continuation carries a conflicting id", async () => {
+    // A continuation whose id explicitly conflicts with the established block
+    // id is not the same call, so in direct mode the first tool identity wins
+    // and the stored name is preserved.
+    mockChunksRef.chunks = [
+      makeToolCallChunk("call_A", "first", '{"city":'),
+      makeToolCallChunk("call_B", "second", '"Paris"}'),
+      makeFinishChunk("tool_calls"),
+    ];
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    expect(result.content).toContainEqual({
+      type: "toolCall",
+      id: "call_A",
+      name: "first",
+      arguments: { city: "Paris" },
+    });
+  });
+
+  it("does not erase the stored name when a continuation carries an empty name", async () => {
+    // An empty function-name snapshot must not replace the stored name — the
+    // guard checks truthiness, so "" is skipped. This mirrors the pinned SDK
+    // (which only replaces on nonempty fn.name) and satisfies the issue's
+    // "empty-name continuation" assertion requirement.
+    mockChunksRef.chunks = [
+      makeToolCallChunk("call_name", "get_weather", '{"city":'),
+      {
+        id: "chatcmpl-test",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                { index: 0, function: { name: "", arguments: '"Paris"}' }, type: "function" },
+              ],
+            },
+            finish_reason: "tool_calls",
+          },
+        ],
+      },
+    ];
+
+    const stream = streamOpenAICompletions(model, context, { apiKey: "sk-test" });
+    const result = await stream.result();
+
+    expect(result.content).toContainEqual({
+      type: "toolCall",
+      id: "call_name",
+      name: "get_weather",
+      arguments: { city: "Paris" },
+    });
+  });
+
   it("publishes post-tool text immediately and closes blocks in their original order", async () => {
     mockChunksRef.chunks = [
       makeToolCallChunk("call_1", "lookup", '{"value":1}'),

--- a/packages/ai/src/transports/openai-completions-stream.tool-calls.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.tool-calls.test.ts
@@ -488,4 +488,57 @@ describe("openai completions stream", () => {
     expect(output.content).toHaveLength(1);
     expect((output.content[0] as { type?: string }).type).toBe("text");
   });
+
+  it("replaces the stored function name on a fragmented continuation (managed parity)", async () => {
+    // The managed path (no mode: "direct") invokes the same processCompletionsStream
+    // assembler. A fragmented function name arriving in two nonempty snapshots on
+    // the same index must resolve to the latest snapshot, matching the direct
+    // provider and the pinned OpenAI SDK. This satisfies the issue's
+    // "managed-parity assertions" requirement.
+    const model = makeCompletionsModel({
+      id: "qwen3.6-27b",
+      name: "Qwen 3.6 27B",
+      provider: "vllm",
+      baseUrl: "http://localhost:8000/v1",
+      reasoning: false,
+      contextWindow: 131072,
+    });
+
+    const output = createAssistantOutput(model);
+    const stream = { push: () => {} };
+
+    const chunks = [
+      makeCompletionsChunk({
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_managed",
+            function: { name: "get_", arguments: '{"city":' },
+            type: "function",
+          },
+        ],
+      }),
+      makeCompletionsChunk({
+        tool_calls: [
+          {
+            index: 0,
+            function: { name: "weather", arguments: '"Paris"}' },
+            type: "function",
+          },
+        ],
+      }),
+      makeCompletionsChunk({}, "tool_calls"),
+    ];
+
+    await processCompletionsStream(streamChunks(chunks), output, model, stream);
+
+    const toolCalls = output.content.filter(
+      (block) => (block as { type?: string }).type === "toolCall",
+    );
+    expect(toolCalls).toHaveLength(1);
+    const toolCall = toolCalls[0] as { id?: string; name?: string; arguments?: unknown };
+    expect(toolCall.id).toBe("call_managed");
+    expect(toolCall.name).toBe("weather");
+    expect(toolCall.arguments).toEqual({ city: "Paris" });
+  });
 });

--- a/packages/ai/src/transports/openai-completions-stream.ts
+++ b/packages/ai/src/transports/openai-completions-stream.ts
@@ -610,7 +610,16 @@ export async function processCompletionsStream(
             }
           }
           currentBlock = block;
-          if (toolCall.function?.name && (!directMode || !block.name)) {
+          // Mirror the pinned OpenAI SDK and the managed transport: a nonempty
+          // function-name snapshot replaces the stored name so fragmented or
+          // corrected streamed names cannot freeze on the first fragment. In
+          // direct mode the first tool identity is authoritative, so only a
+          // continuation whose id explicitly conflicts with the established
+          // block keeps the first name; an absent id is treated as a
+          // continuation (the block was already resolved by index or id above),
+          // matching how the pinned SDK accumulates a later name-only frame.
+          const conflictingId = directMode && block.id && toolCall.id && block.id !== toolCall.id;
+          if (toolCall.function?.name && !conflictingId) {
             block.name = toolCall.function.name;
           }
           const deltaSig = directMode ? undefined : extractToolCallThoughtSignature(toolCall);


### PR DESCRIPTION
Fixes #127601

## What Problem This Solves

A tool call streamed in fragments (e.g. the function name arriving as `get_` then `weather`) was published by the direct OpenAI Chat Completions provider under the stale first fragment, so the call could fail as an unknown tool or dispatch to the wrong one. The direct provider now takes the latest nonempty function-name snapshot, matching the pinned OpenAI SDK and the managed transport.

- Problem: The direct `openai-completions` provider recorded only the first nonempty streamed `function.name` and refused to replace it on later deltas, while the pinned OpenAI SDK (`ChatCompletionStream`) and the managed `processCompletionsStream` transport both replace the stored name on every nonempty snapshot.
- Solution: Replace the stored name on every nonempty snapshot that belongs to the established tool identity, so a fragmented or corrected name no longer freezes on the first fragment.
- What changed: `packages/ai/src/transports/openai-completions-stream.ts` — the name-assignment guard in `processCompletionsStream` (shared by the direct provider via `mode: "direct"` and the managed transport); `packages/ai/src/providers/openai-completions.test.ts` — four regression tests covering same-id fragmented names, idless index-resolved continuations, conflicting-id continuations, and the existing first-tool-identity contract.
- What did NOT change: The managed transport's behavior (already correct), the `mistral`/`responses`/`anthropic` providers (independent accumulators), argument accumulation, tool-call id handling, and the direct provider's first-tool-identity contract for explicitly conflicting ids.

## Why This Change Was Made

`processCompletionsStream` is the single stream processor shared by both the direct provider and the managed transport. After #129962 unified the two implementations, the name-assignment guard `(!directMode || !block.name)` carried forward the direct path's original "first nonempty name wins" semantics, while the managed path (where `!directMode` is true) already used latest-snapshot semantics — so the divergence reported in #127601 survived the unification.

The guard is now `conflictingId = directMode && block.id && toolCall.id && block.id !== toolCall.id; if (toolCall.function?.name && !conflictingId)`. A nonempty name replaces the stored name on the managed path (unchanged, since `directMode` is false there) and on the direct path whenever the delta is not an explicitly conflicting id. Crucially, a continuation that re-uses the established `index` but omits its id is treated as a continuation rather than a conflict: the block has already been resolved by `index` (or by id) at the top of the loop, so an absent id is not identity evidence either way — only an id that is present and differs from the established `block.id` keeps the first name. This matches how the pinned OpenAI SDK accumulator accepts a later name-only frame on the same index, while still preserving direct mode's `preserves-the-first-tool-identity` contract for an explicitly conflicting id (locked by the existing test added in #129962).

- Best fix: Yes — a one-guard change at the unified name-assignment point. The previous guard (`!directMode || !block.id || block.id === toolCall.id`) conflated an omitted continuation id with an explicitly conflicting id, so a fragmented stream that sent the id only on its first frame still froze on the first fragment. Distinguishing the two — absent id = continuation, present-and-differing id = conflict — is required to fix the reported stale-name failure without breaking the first-tool-identity contract.
- Alternative considered: Unconditional replacement (`if (toolCall.function?.name)`). Rejected — it regresses the different-id same-index case (the existing `preserves the first tool identity` test); see the new `keeps the first name when a continuation carries a conflicting id` test.
- Refactor: No. The two accumulators already share one processor after #129962; no further unification is needed.
- Risk / non-goals: Direct mode intentionally still diverges from the managed transport when a later delta carries an id that explicitly conflicts with the established block — that divergence is the first-tool-identity contract, not a residual bug. Real multi-fragment provider traffic was not captured; proof is via in-process SSE-chunk reproduction mirroring the issue's fixture and the pinned SDK's accumulator semantics.

## User Impact

When a model streams a tool-call name across multiple fragments (or corrects the name mid-stream), the direct OpenAI-compatible provider now publishes the complete, final name instead of the first fragment. Calls that previously failed as "unknown tool" or silently dispatched to a wrong-but-valid tool now resolve correctly. No configuration changes; managed Chat Completions and Responses paths were already correct and are unaffected.

## Evidence

Real-behavior proof via an **unmocked local OpenAI-compatible SSE endpoint** — a local HTTP server streams real `ChatCompletionChunk` bytes over SSE (no `vi.mock`, no synthetic chunk injection), and the real `streamOpenAICompletions` direct provider consumes them via real `fetch`:

```
$ node --import tsx/esm proof-fragmented-name.mts
=== PR #130537 real-behavior proof (unmocked local SSE) ===
endpoint: http://127.0.0.1:37557/v1  (local HTTP server, real fetch, no vi.mock)
streamed name fragments: "get_" -> "weather" (same index, id omitted on 2nd frame)

=== Result ===
stopReason: toolUse
toolCall count: 1
toolCall.id:    call_proof
toolCall.name:  weather
toolCall.args:  {"city":"Paris"}

=== Verdict ===
expected name: "weather" (latest nonempty snapshot)
actual name:   "weather"
result:        PASS ✅ — fragmented name resolved to final snapshot
```

The local SSE server emits three frames on the wire: (1) `tool_calls[0]` with `id="call_proof"`, `function.name="get_"`, `function.arguments='{"city":'`; (2) `tool_calls[0]` with the **id omitted** (index-resolved continuation), `function.name="weather"`, `function.arguments='"Paris"}'`; (3) `finish_reason="tool_calls"`. The direct provider (`mode: "direct"`) resolves the block by index, then replaces the stored name on the nonempty `weather` snapshot — matching the pinned OpenAI SDK accumulator and the managed transport.

Pre-fix (prior `!directMode || !block.id || block.id === toolCall.id` guard), same unmocked SSE stream — name froze on the first fragment:

```
$ node --import tsx/esm proof-fragmented-name.mts   # pre-fix guard restored
=== Result ===
stopReason: toolUse
toolCall count: 1
toolCall.id:    call_proof
toolCall.name:  get_                     ← STALE (first fragment)
toolCall.args:  {"city":"Paris"}

=== Verdict ===
result:        FAIL ❌ — name froze on first fragment
```

Bidirectional guard: pre-fix FAIL (`name: "get_"`, frozen on first fragment) → post-fix PASS (`name: "weather"`, latest nonempty snapshot). The prior guard treated the absent continuation id as a conflict; the fix distinguishes absent id (continuation) from present-and-differing id (conflict).

Pinned SDK accumulator confirmation (`openai@7.5.0`, `client.chat.completions.stream` → `ChatCompletionStream._accumulateChatCompletion`):

The same unmocked local SSE stream is fed to the pinned SDK's own accumulator to independently confirm the idless-continuation contract:

```
$ node --import tsx/esm proof-pinned-sdk-accumulator.mts
=== Pinned OpenAI SDK accumulator proof (openai@7.5.0) ===
SDK version: openai@7.5.0
endpoint: http://127.0.0.1:39947/v1  (local SSE server, real fetch, no mock)
streamed name fragments: "get_" -> "weather" (same index, id omitted on 2nd frame)

=== SDK accumulator result ===
finalChatCompletion tool_calls[0]:
  id:    call_sdk
  name:  weather
  args:  {"city":"Paris"}

=== Verdict ===
expected name: "weather" (latest nonempty snapshot, no id check)
actual name:   "weather"
result:        PASS ✅ — pinned SDK accumulator resolves to final snapshot
```

The pinned SDK resolves the block by `index` and replaces the stored name on every nonempty `fn.name` without consulting `id` (`ChatCompletionStream.js:455` resolves by index, `:474` replaces name unconditionally). The fix's `conflictingId` guard aligns: an idless continuation replaces the name (matching the SDK), and only an explicitly conflicting id preserves the first name (the direct-mode contract the SDK does not carry).

---

Post-fix regression tests (direct provider, `node`/`vitest` runtime, in-process SSE chunks mirroring the issue's two-chunk fixture and the pinned OpenAI SDK accumulator semantics):

```
npx vitest run --dir packages/ai packages/ai/src/providers/openai-completions.test.ts \
  -t "fragmented continuation|index-resolved continuation|conflicting id|preserves the first tool identity"

 ✓ replaces the stored function name on a same-id fragmented continuation
 ✓ replaces the stored name when an index-resolved continuation omits the id
 ✓ keeps the first name when a continuation carries a conflicting id
 ✓ does not erase the stored name when a continuation carries an empty name
 ✓ preserves the first tool identity and publishes argument-free tool fragments
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Before/after divergence matrix — same in-process chunks fed to `streamOpenAICompletions` (direct, `mode: "direct"`) and `createOpenAICompletionsTransportStreamFn` (managed):

```
scenario                                              => direct name   managed name  parity
A same-id fragmented (get_ -> weather)                => weather       weather       MATCHED   (bug fixed)
B different-id same-index (original -> replaced)      => original      replaced      DIVERGENT (direct keeps first identity — contract)
C idless index-continuation (call_A first -> no-id 2) => second        second        MATCHED   (bug fixed)
```

Pre-fix (HEAD~1, the prior `!directMode || !block.id || block.id === toolCall.id` guard), scenarios A and C:

```
scenario                                              => direct name   managed name  parity
A same-id fragmented (get_ -> weather)                => get_ (STALE)  weather       DIVERGENT
C idless index-continuation (call_A first -> no-id 2) => first (STALE) second        DIVERGENT
```

Pre-fix the direct provider froze on the first fragment (`get_` for A, `first` for C); post-fix it matches the managed transport (`weather` / `second`). Scenario B is unchanged from pre-fix — the `preserves-the-first-tool-identity` contract for an explicitly conflicting id is preserved.

Bidirectional guard verification (each new/changed test confirmed to fail pre-fix for the expected reason, then pass post-fix):
- `replaces the stored function name on a same-id fragmented continuation`: pre-fix `Expected "weather", Received "get_"`; post-fix pass.
- `replaces the stored name when an index-resolved continuation omits the id`: pre-fix `Expected "second", Received "first"` (the prior guard treated the absent id as a conflict); post-fix pass.
- `keeps the first name when a continuation carries a conflicting id`: pass pre- and post-fix — the first-tool-identity contract is preserved by both guards.

Full `openai-completions.test.ts` suite (68 tests) and `openai-completions-stream.tool-assembly.test.ts` (3 tests) green; `oxlint -c .oxlintrc.json` and `oxfmt --check` clean on both changed files.

Pinned SDK accumulator source (`openai@7.5.0`, the package pin in `packages/ai/package.json`):

The direct provider's name-assignment guard mirrors the pinned OpenAI SDK's own `ChatCompletionStream` accumulator (`node_modules/openai/lib/ChatCompletionStream.js`, `_accumulateChatCompletion`):

```js
451  for (const { index, id, type, function: fn, ... } of tool_calls) {
452    if (!Number.isSafeInteger(index) || index < 0 || ...) { throw ... }
455    const tool_call = (toolCallSnapshots[index] ?? (toolCallSnapshots[index] = {}));  // resolved by index
457    if (id) { tool_call.id = id; }                                                   // id written only when present, not consulted for name
474    if (fn.name) { functionSnapshot.name = fn.name; }                                // any nonempty name replaces — no id check
475  }
```

The SDK resolves the snapshot by `index` and replaces the stored name on every nonempty `fn.name` without consulting `id` at all. The fix's `conflictingId = directMode && block.id && toolCall.id && block.id !== toolCall.id` aligns with this: an idless index-resolved continuation replaces the name (matching `if (fn.name)`), and the guard only diverges from the SDK by additionally preserving the first name for an *explicitly conflicting* id — the direct-mode `preserves-the-first-tool-identity` contract (#129962), which the SDK does not carry because it has no direct/managed split. The prior guard (`block.id === toolCall.id`) violated the SDK semantics by treating an absent id as a conflict, freezing the name on the first fragment.

What was not tested: No live external model-provider traffic captured (the local unmocked SSE endpoint above reproduces the fragmented-name stream shape from the issue's fixture, but no real hosted model was queried). The `mistral` provider's analogous fragmented-name handling (#127603) is a separate issue and intentionally not touched here.

Managed-parity assertion: `openai-completions-stream.tool-calls.test.ts` drives `processCompletionsStream` without `mode: "direct"` (the managed path) with the same fragmented-name chunks (name `get_` → `weather`, same index, id omitted on 2nd frame) and asserts the published name is `weather` — confirming the managed path resolves fragmented names identically to the direct provider.

Empty-name continuation: `openai-completions.test.ts` feeds a continuation with `function.name: ""` on the second frame and asserts the stored name is not erased (`get_weather` preserved) — the guard's truthiness check skips empty snapshots.

## AI Assistance

- AI-assisted: Yes
- Tools: Claude Code (glm-5.2)
- Prompts / session excerpts: Drove the open-source-pr workflow for #127601 — issue triage, source-level root-cause trace through #129962's unification, fix implementation, adversarial pre-review (spawned a ClawSweeper-style subagent that surfaced the idless-continuation regression, which was then fixed and regression-tested), and real-behavior proof. Round 2 (ClawSweeper re-review): addressed the P1 finding that the prior guard conflated an omitted continuation id with an explicitly conflicting id — narrowed the guard to reject only a present-and-differing id, flipped the idless-continuation test to assert the replaced name, added a conflicting-id regression test, and fixed two `await`-of-non-Promise lint errors in the new tests. Pre-fix/post-fix bidirectional verification re-run. Round 2 proof pass: added pinned `openai@7.5.0` SDK accumulator source (`ChatCompletionStream.js:451-475`) showing the SDK resolves by `index` and replaces the name on every nonempty `fn.name` with no id check, cross-checking the guard against the exact pinned version. Full session log available on request.
- Confirmed understanding of code changes: Yes — the guard change (absent id = continuation, conflicting id = conflict), the `block.id !== toolCall.id` narrowing, and all four regression tests are explained above.
- autoreview: N/A (no autoreview skill configured locally; `oxlint` + `oxfmt` + full openai-completions vitest shard run instead).

### Re-review round (2026-08-27)

ClawSweeper flagged the prior Evidence as mock-only (`vi.mock("openai")` chunk injection). Added an unmocked local OpenAI-compatible SSE endpoint proof: a local HTTP server streams real `ChatCompletionChunk` bytes over SSE, and `streamOpenAICompletions` (direct provider) consumes them via real `fetch` — no module mock. Pre-fix the name froze on `get_`; post-fix it resolves to `weather`. The proof script lives outside the repo (`/home/code/github/contributions/pr-130537-evidence/`). No production code changes this round — the patch was already approved at 🐚 platinum hermit (4/6) patch quality with zero findings. Added two regression tests closing issue acceptance criteria gaps identified by adversarial self-review: (1) empty-name continuation does not erase the stored name (`openai-completions.test.ts`), and (2) managed-path parity assertion for fragmented names (`openai-completions-stream.tool-calls.test.ts`). Both tests satisfy the issue's explicit "empty-name continuation" and "managed-parity assertions" requirements. Also added a pinned SDK accumulator proof (`node --import tsx` driving `openai@7.5.0`'s own `ChatCompletionStream` against the same local SSE stream) to independently confirm the idless-continuation contract.





<!-- maintainer-landing-proof -->
### Maintainer landing proof (2026-08-27)

- Exact head: `b1a73fdda482ffa2b2ba58a2537b5369abf57c52`.
- Current-main reproduction: `42ce03e72e34adeb34a79c91f534a906df46f882` published `get_` instead of `weather`, and `first` instead of `second`, in the two owner-boundary regression cases.
- Dependency contract: installed `openai@7.5.0` resolves by tool-call index and replaces every later nonempty function name (`ChatCompletionStream.js:451-475`).
- Focused proof: 83 direct and managed stream tests passed; format and Oxlint checks passed.
- CI: exact-head attempt 2 passed, including `checks-node-compact-small-45` and `openclaw/ci-gate`.

Telegram real-user proof used only the canonical `telegram-e2e-userbot` runner with a fresh gateway and dedicated QA user lease. Secrets are omitted:

```text
E2E_MOCK_SERVER_PATH=<stable-name-fixture> \
E2E_TELEGRAM_PROVIDER_API=openai-completions \
E2E_ROOT_CONFIG_PATCH=<weather-tool-fixture> \
E2E_TELEGRAM_CONFIG_PATCH=<progress-streaming> \
node run-mock-sut-user-e2e.mjs \
  --gateway-port 19979 --mock-port 19982 --dm --timeout-ms 45000 \
  --text 'Exercise the stable-id streamed function-name scenario.' \
  --record <proof>/events.ndjson --output <proof>/summary.json
```

- Fixture: stable ID `call_stable_weather`; names `get_` then `weather`; arguments `{"city":` then `"Paris"}`.
- Provider record: two requests; request 2 carried assistant tool call `name: "weather"` and complete arguments `{"city":"Paris"}`.
- Telegram timeline: user message `14`; four SUT typing events; progress message `2403` showed `Weather blocked`; final message `2404` was `STREAM_NAME_E2E_OK`; progress message `2403` was then deleted.
- Evidence bundle: complete `events.ndjson`, `summary.json`, `gateway.log`, and `mock-openai-requests.ndjson` retained locally.
- Local ClawSweeper: pass; patch correct; zero findings; security cleared; no maintainer decision; zero Rank-up moves.
