### PR TITLE
fix(packaging): serialize packs when the docs map is already generated

### DIFF
--- a/scripts/package-docs-map.mjs
+++ b/scripts/package-docs-map.mjs
@@ -77,10 +77,8 @@ export async function preparePackageDocsMap(cwd = process.cwd()) {
   const mapPath = path.join(cwd, DOCS_MAP_PATH);
   const content = renderDocsHeadingMap(path.join(cwd, "docs"));
   const original = existsSync(mapPath) ? await readFile(mapPath, "utf8") : null;
-  if (original === content) {
-    return false;
-  }
-
+  // The receipt owns every source-mutating pack step, even when the map is
+  // already generated; skipping it lets another pack restore our prepared files.
   await mkdir(path.dirname(receiptPath), { recursive: true });
   try {
     await writeFile(

--- a/test/scripts/package-docs-map.test.ts
+++ b/test/scripts/package-docs-map.test.ts
@@ -41,17 +41,6 @@ describe("package docs map", () => {
     expect(existsSync(mapPath)).toBe(false);
   });
 
-  it("preserves an identical map that existed before packaging", async () => {
-    const root = makePackageRoot();
-    const mapPath = path.join(root, "docs", "docs_map.md");
-    const content = renderDocsHeadingMap(path.join(root, "docs"));
-    writeFileSync(mapPath, content, "utf8");
-
-    await expect(preparePackageDocsMap(root)).resolves.toBe(false);
-    await expect(restorePackageDocsMap(root)).resolves.toBe(false);
-    expect(readFileSync(mapPath, "utf8")).toBe(content);
-  });
-
   it("restores a tracked source stub after packaging", async () => {
     const root = makePackageRoot();
     const mapPath = path.join(root, "docs", "docs_map.md");
@@ -64,29 +53,35 @@ describe("package docs map", () => {
     expect(readFileSync(mapPath, "utf8")).toBe(stub);
   });
 
-  it("serializes concurrent package preparations with the receipt", async () => {
-    const root = makePackageRoot();
-    const mapPath = path.join(root, "docs", "docs_map.md");
-    const stub = "# Docs map source\n";
-    writeFileSync(mapPath, stub, "utf8");
+  it.each(["source stub", "generated map"])(
+    "serializes preparations starting from a %s",
+    async (initialMap) => {
+      const root = makePackageRoot();
+      const mapPath = path.join(root, "docs", "docs_map.md");
+      const original =
+        initialMap === "generated map"
+          ? renderDocsHeadingMap(path.join(root, "docs"))
+          : "# Docs map source\n";
+      writeFileSync(mapPath, original, "utf8");
 
-    const results = await Promise.allSettled([
-      preparePackageDocsMap(root),
-      preparePackageDocsMap(root),
-    ]);
+      const results = await Promise.allSettled([
+        preparePackageDocsMap(root),
+        preparePackageDocsMap(root),
+      ]);
 
-    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
-    const rejected = results.find((result) => result.status === "rejected");
-    expect(rejected).toMatchObject({
-      reason: expect.objectContaining({
-        code: "PACKAGE_DOCS_MAP_ACTIVE",
-        message: expect.stringContaining("node scripts/openclaw-postpack.mjs"),
-      }),
-    });
-    expect(readFileSync(mapPath, "utf8")).toBe(renderDocsHeadingMap(path.join(root, "docs")));
-    await expect(restorePackageDocsMap(root)).resolves.toBe(true);
-    expect(readFileSync(mapPath, "utf8")).toBe(stub);
-  });
+      expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+      const rejected = results.find((result) => result.status === "rejected");
+      expect(rejected).toMatchObject({
+        reason: expect.objectContaining({
+          code: "PACKAGE_DOCS_MAP_ACTIVE",
+          message: expect.stringContaining("node scripts/openclaw-postpack.mjs"),
+        }),
+      });
+      expect(readFileSync(mapPath, "utf8")).toBe(renderDocsHeadingMap(path.join(root, "docs")));
+      await expect(restorePackageDocsMap(root)).resolves.toBe(true);
+      expect(readFileSync(mapPath, "utf8")).toBe(original);
+    },
+  );
 
   it("refuses to remove a transient map changed after prepack", async () => {
     const root = makePackageRoot();


### PR DESCRIPTION
Closes #130533

## What Problem This Solves

Fixes an issue where concurrent source-package operations can produce unsanitized package metadata when `docs/docs_map.md` already contains the generated map. A competing pack can restore files still owned by the first operation, allowing its real npm archive to retain unpublished `workspace:*` metadata.

## Why This Change Was Made

The existing docs-map receipt owns the entire source-mutating pack lifecycle. Remove the early return that skipped its exclusive acquisition when map bytes were already correct. Ordinary npm prepack, Docker packing, and OCM's prepared runtime pack share that owner; no new lock, downstream guard, fallback, or persistence surface is added.

Existing restoration already preserves an identical pre-existing map while releasing the receipt last. The test now covers both initial map states in one concurrency table, retaining byte-restoration assertions and removing the obsolete standalone no-op expectation.

## User Impact

A competing pack is rejected before it can touch another pack's prepared manifest or changelog, regardless of the initial docs-map contents. Successful packs restore the original source files and release ownership for later packing. No public option, plugin API, database/schema, provider, or release-publication behavior changes.

Production **+2/-4 (net -2)**; tests **+29/-34 (net -5)**. This repairs the demonstrated no-op lock bypass, not a claim that every possible packaging concurrency pattern has been proven.

## Evidence

- Frozen baseline: `565fd935449e6b75b211ca13ff43747d66b3fac2`. Fresh main at `93d879dcd1209730c78c31e0c4a36ca8673a2dd4` has unchanged affected owners and tests.
- Regression first: the generated-map case failed on unchanged production because **two preparations fulfilled instead of one**, with **five passing controls**. The corrected six-case owner suite passes.
- **57 focused tests pass** across docs-map ownership, changelog, prepack, sealed install-smoke payload, and OCM workspace packing. The complete package-builder suite also passes **37 tests, with three Windows-only skips**: **94 executed packaging tests** in total.
- Real npm 11.17.0 / Node 24.19.0 fixture proof uses a controlled scheduling gate in the existing runner callback and delegates to the actual npm runner. Before: a generated-map contender succeeds, restores the held owner's manifest, and the first archive contains `workspace:*`. The source-stub control correctly rejects the contender. After: both contenders receive `PACKAGE_DOCS_MAP_ACTIVE`, create no archive, and leave every held source artifact unchanged. Both first archives contain sanitized metadata and only current release notes; original manifest/changelog/map bytes are restored, receipts/backups removed, and subsequent packs succeed.
- Separate actual producer → seal → verify proof passes with the generated receipt. Verification rejects tampering with each of the tarball, receipt, both installers, and payload manifest; it succeeds again after restoring the original bytes. This is an isolated fixture with a synthetic run identity, not a release or installed-application claim. All fixture homes, npm caches, and work directories are removed.
- The final expanded proof binds six owner source hashes and the complete diff SHA-256 `169958319bd6789f5de50f234375a1b7a47e03eba749c647c02ef686a9545844`. Changed owner SHA-256: `bbf0cfeecfccade8a333d4181a350cd8c141d3c0e2c7080bc3f77f0a2422673e`.
- Repeated the real npm and producer/seal/verify proof on committed head `962d371d9a0bf6282508d6572fad5c800503a0ba`; it checks the immutable head, clean diff and six source hashes before and after execution. All checks pass.
- Separate real Node CLI subprocesses exercised docs-map/manifest/changelog preparation and composite postpack recovery for both initial map states. A contender exits 1 with `PACKAGE_DOCS_MAP_ACTIVE` and the postpack recovery command. An operator-edited changelog makes cleanup refuse safely, preserving the edit and lifecycle receipt; contenders stay blocked. Restoring the prepared bytes permits cleanup to restore every original source file, and repeated cleanup plus subsequent preparation/cleanup succeed. This models interrupted preparation using completed processes, not killing an in-flight npm process. Temporary homes and work are removed.
- Local tests use canonical tooling/package configs through the existing private dependency resolver. This linked checkout has no local `tsx`; the normal test/build wrappers fail before execution. The adapted changed-file gate passes its first eight checks, then stops because `oxfmt` is absent from its command path. Direct formatting, AST lint, and `git diff --check` pass separately. No clean-install, full changed-gate, or full local build claim; required exact-head hosted CI remains mandatory.
- Local runtime is Node 24.19.0 with reused Vitest 4.1.10; hosted CI uses the lockfile-pinned Vitest 4.1.11. The dependency resolver adapts resolution only; it does not make this a fresh pinned local install.
- Additional exact-head process proof runs eight separate Node preparation commands for each absent/stub/generated initial map: exactly one owner and seven `PACKAGE_DOCS_MAP_ACTIVE` rejections per case, followed by correct restoration and receipt removal. This supplements—not inflates—the 94 executed tests and does not claim exhaustive concurrency coverage.
- Fresh Codex autoreview completed cleanly at its P0 reporting threshold; separate independent source/dependency review found no actionable P0–P3 issues and verified the exact diff/source hashes and canonical owner repair.
- Root directly read docs-map, manifest, changelog, prepack/postpack, Docker packer, sealed-payload consumer, and relevant tests; independent review also traced OCM and npm's prepack/archive/postpack ordering. Existing tools already provide the required lock and restoration—no new dependency is needed.
- Provenance: #117398 (`385f1dee165f0a9557e3dd67e83b7b1bc48b06e2`), authored and merged by @steipete, introduced both the lifecycle-serialization invariant and the early return. No stable-release regression is claimed.
- Exact-head [CI run33027802855](https://github.com/openclaw/openclaw/actions/runs/33027802855) completed **success**, attempt1, on `962d371d9a0bf6282508d6572fad5c800503a0ba`, verified by fresh REST at update time 2026-08-27T00:58:26Z. This is the substantive ready-event run; skipped draft CI is excluded. No retry or source change needed. Native review/prepare/merge gates remain mandatory.

AI-assisted maintainer repair.
