### PR TITLE
fix(sandbox): read tool rejects declared binds with workspace-only enabled

### DIFF
--- a/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/agent-tools.create-openclaw-coding-tools.test.ts
@@ -49,7 +49,10 @@ import { createOpenClawTools } from "./openclaw-tools.js";
 import { expectReadWriteEditTools } from "./test-helpers/agent-tools-fs-helpers.js";
 import { createAgentToolsSandboxContext } from "./test-helpers/agent-tools-sandbox-context.js";
 import { stubTool } from "./test-helpers/fast-tool-stubs.js";
-import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
+import {
+  createHostSandboxFsBridge,
+  createSandboxFsBridgeFromResolver,
+} from "./test-helpers/host-sandbox-fs-bridge.js";
 import { buildEmptyExplicitToolAllowlistError } from "./tool-allowlist-guard.js";
 import { DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY, normalizeToolPolicyName } from "./tool-policy.js";
 import { replaceWithEffectiveCronCreatorToolAllowlist } from "./tools/cron-tool.js";
@@ -1080,6 +1083,54 @@ describe("createOpenClawCodingTools", () => {
     });
 
     expect(latestCreateOpenClawToolsOptions().fsPolicy).toEqual({ workspaceOnly: true });
+  });
+
+  it("allows workspace-only reads from declared sandbox bind mounts", async () => {
+    const workspaceDir = tempDirs.make("openclaw-sandbox-workspace-");
+    const bindRoot = tempDirs.make("openclaw-sandbox-bind-");
+    const boundFile = path.join(bindRoot, "example", "tree-index.json");
+    await fs.mkdir(path.dirname(boundFile), { recursive: true });
+    await fs.writeFile(boundFile, '{"ready":true}\n', "utf8");
+
+    const sandbox = createAgentToolsSandboxContext({
+      workspaceDir,
+      workspaceAccess: "none",
+      dockerOverrides: { binds: [`${bindRoot}:/cache/repos:ro`] },
+    });
+    sandbox.fsBridge = createSandboxFsBridgeFromResolver((filePath) => {
+      const relativePath = path.posix.relative("/cache/repos", filePath);
+      return {
+        hostPath: path.join(bindRoot, relativePath),
+        relativePath,
+        containerPath: filePath,
+      };
+    });
+
+    const tools = createOpenClawCodingTools({
+      workspaceDir,
+      config: { tools: { fs: { workspaceOnly: true } } },
+      sandbox,
+    });
+
+    const { readTool, writeTool, editTool } = expectReadWriteEditTools(tools);
+    const result = await readTool.execute("read-declared-bind", {
+      path: "/cache/repos/example/tree-index.json",
+    });
+    expect(extractToolText(result)).toContain('{"ready":true}');
+    await expect(
+      writeTool.execute("write-declared-bind", {
+        path: "/cache/repos/example/tree-index.json",
+        content: "overwritten",
+      }),
+    ).rejects.toThrow(/Path escapes sandbox root/i);
+    await expect(
+      editTool.execute("edit-declared-bind", {
+        path: "/cache/repos/example/tree-index.json",
+        oldText: "true",
+        newText: "false",
+      }),
+    ).rejects.toThrow(/Path escapes sandbox root/i);
+    await expect(fs.readFile(boundFile, "utf8")).resolves.toBe('{"ready":true}\n');
   });
 
   it("uses the canonical spawn workspace for follow-up task suggestions", () => {

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -21,11 +21,8 @@ import { createLazyExecTool } from "./lazy-exec-tool.js";
 import { createLazyProcessTool } from "./lazy-process-tool.js";
 import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js";
 import type { SandboxContext } from "./sandbox.js";
-import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./sandbox/constants.js";
-import {
-  resolveReadOnlyWorkspaceSkillMounts,
-  type ReadOnlyWorkspaceSkillMount,
-} from "./sandbox/workspace-mounts.js";
+import { buildSandboxFsMounts } from "./sandbox/fs-paths.js";
+import { resolveReadOnlyWorkspaceSkillMounts } from "./sandbox/workspace-mounts.js";
 import type {
   createEditTool,
   createReadTool as CreateReadTool,
@@ -33,25 +30,12 @@ import type {
 } from "./sessions/tools/index.js";
 import { createReadTool } from "./sessions/tools/read.js";
 
-function readOnlySandboxReadMounts(
+function sandboxReadMounts(
   sandbox: SandboxContext,
-  readOnlyWorkspaceSkillMounts: readonly ReadOnlyWorkspaceSkillMount[],
 ): Array<{ containerRoot: string; hostRoot: string }> | undefined {
-  const mounts: Array<{ containerRoot: string; hostRoot: string }> = [];
-  if (sandbox.workspaceAccess === "ro" && sandbox.agentWorkspaceDir !== sandbox.workspaceDir) {
-    mounts.push({
-      containerRoot: SANDBOX_AGENT_WORKSPACE_MOUNT,
-      hostRoot: sandbox.agentWorkspaceDir,
-    });
-  }
-  if (sandbox.workspaceAccess === "rw") {
-    mounts.push(
-      ...readOnlyWorkspaceSkillMounts.map((mount) => ({
-        containerRoot: mount.containerPath,
-        hostRoot: mount.hostPath,
-      })),
-    );
-  }
+  const mounts = buildSandboxFsMounts(sandbox)
+    .filter((mount) => mount.source !== "workspace")
+    .map((mount) => ({ containerRoot: mount.containerRoot, hostRoot: mount.hostRoot }));
   return mounts.length > 0 ? mounts : undefined;
 }
 
@@ -165,10 +149,7 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
             sandboxRoot ?? options.containmentRoot,
             sandboxRoot
               ? {
-                  additionalContainerMounts: readOnlySandboxReadMounts(
-                    sandbox,
-                    readOnlyWorkspaceSkillMounts,
-                  ),
+                  additionalContainerMounts: sandboxReadMounts(sandbox),
                   containerWorkdir: sandbox.containerWorkdir,
                   bridge: sandboxFsBridge,
                 }


### PR DESCRIPTION
Fixes #130193

## What Problem This Solves

Fixes an issue where sandboxed agents using `tools.fs.workspaceOnly: true` could not read files from their own declared `sandbox.docker.binds`. The workspace guard rejected those container paths before the sandbox filesystem bridge could resolve the configured mount, so operators saw `Path escapes sandbox root` for files that were present and readable inside the sandbox.

## Why This Change Was Made

The read guard now consumes the canonical sandbox filesystem mount table instead of maintaining a second, incomplete list of workspace and skill mounts. This keeps the guard and bridge aligned for agent workspace, protected skill, and declared bind mounts while excluding the primary workspace mount already represented by the guard root.

The change only expands read access to mounts already declared in the sandbox configuration. Write, edit, and apply-patch confinement is unchanged; no config, schema, default, container mount, or persistence format changes.

## User Impact

Sandboxed agents can read operator-declared bind-mounted files while workspace-only confinement remains enabled. Read-only bind mounts remain protected from write and edit operations, and paths outside the workspace plus declared mounts remain rejected.

## Evidence

Before the repair, the new production-assembly regression failed with:

```text
Path escapes sandbox root (...): /cache/repos/example/tree-index.json
```

After the repair, the focused agent tool suite passes:

```text
Test Files  1 passed (1)
     Tests  131 passed (131)
```

A real Docker sandbox was provisioned with `workspaceOnly: true`, `workspaceAccess: none`, and a read-only bind mounted at `/cache/repos`. The production sandbox resolver, filesystem bridge, and assembled read/write/edit tools observed:

```json
{"reporterPath":"/cache/repos/example/tree-index.json","readDelivered":true,"writeRejected":true,"editRejected":true,"hostContentPreserved":true}
```

Impact-surface verification also passed the canonical mount resolver and workspace-root guard suites (31 tests, with one unrelated platform skip), the runtime import-cycle guard, and the full `pnpm check` preflight/typecheck/lint pipeline. The consumer sweep covered `createCoreCodingTools`, `buildSandboxFsMounts`, the filesystem bridge, workspace/agent/skill mount handling, and the write/edit guard siblings; only the read wrapper receives the additional canonical mounts.
