### PR TITLE
fix(macos): allow cold ChatGPT Codex probes

### DIFF
--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -486,13 +486,13 @@ describe("detectInferenceBackends", () => {
 
   it("checks login status with the Codex executable discovered in a macOS app", async () => {
     const command = "/Applications/ChatGPT.app/Contents/Resources/codex";
-    const probed: Array<{ command: string; args: string[] }> = [];
+    const probed: Array<{ command: string; args: string[]; timeoutMs?: number }> = [];
     const candidates = await detectInferenceBackends({
       env: { HOME: "/Users/tester" },
       platform: "darwin",
       deps: {
-        probeLocalCommand: async (probedCommand, args = ["--version"]) => {
-          probed.push({ command: probedCommand, args });
+        probeLocalCommand: async (probedCommand, args = ["--version"], opts = {}) => {
+          probed.push({ command: probedCommand, args, timeoutMs: opts.timeoutMs });
           return {
             command: probedCommand,
             found: probedCommand === command,
@@ -504,7 +504,42 @@ describe("detectInferenceBackends", () => {
 
     expect(candidates).toMatchObject([{ kind: "codex-cli", detail: "installed" }]);
     expect(candidates[0]?.credentials).toBeUndefined();
-    expect(probed).toContainEqual({ command, args: ["login", "status"] });
+    expect(probed).toContainEqual({ command, args: ["--version"], timeoutMs: 3_000 });
+    expect(probed).toContainEqual({ command, args: ["login", "status"], timeoutMs: 3_000 });
+  });
+
+  it("allows a cold ChatGPT app probe more time than generic CLI discovery", async () => {
+    const command = "/Applications/ChatGPT.app/Contents/Resources/codex";
+    const candidates = await detectInferenceBackends({
+      env: { HOME: "/Users/tester" },
+      platform: "darwin",
+      deps: {
+        probeLocalCommand: async (probedCommand, args = ["--version"], opts = {}) => {
+          if (probedCommand !== command) {
+            return { command: probedCommand, found: false };
+          }
+          if (args[0] === "login") {
+            return { command: probedCommand, found: true, version: "Logged in using ChatGPT" };
+          }
+          return opts.timeoutMs === 3_000
+            ? { command: probedCommand, found: true, version: "codex-cli 0.149.0" }
+            : {
+                command: probedCommand,
+                found: true,
+                timedOut: true,
+                error: "timed out after 1500ms",
+              };
+        },
+      },
+    });
+
+    expect(candidates).toMatchObject([
+      {
+        kind: "codex-cli",
+        credentials: true,
+        detail: "logged in · ChatGPT subscription",
+      },
+    ]);
   });
 
   it.each([

--- a/src/commands/onboard-inference.ts
+++ b/src/commands/onboard-inference.ts
@@ -181,6 +181,7 @@ function randomizeClaudeCodexTie(
 
 // ChatGPT.app is the current desktop owner; keep Codex stable/beta as fallbacks.
 const CODEX_MACOS_APP_NAMES = ["ChatGPT.app", "Codex.app", "Codex Beta.app"] as const;
+const CODEX_MACOS_APP_PROBE_TIMEOUT_MS = 3_000;
 
 async function probeCodexCommand(params: {
   probe: typeof probeLocalCommand;
@@ -199,7 +200,12 @@ async function probeCodexCommand(params: {
     ]),
   );
   for (const executable of appExecutables) {
-    const appProbe = await params.probe(executable);
+    // ChatGPT.app's signed Codex binary can spend most of the generic 1.5s
+    // probe budget in macOS cold-start validation. Keep the broader probe
+    // contract tight while giving known desktop-app binaries enough headroom.
+    const appProbe = await params.probe(executable, ["--version"], {
+      timeoutMs: CODEX_MACOS_APP_PROBE_TIMEOUT_MS,
+    });
     if (appProbe.found) {
       return appProbe;
     }


### PR DESCRIPTION
## Summary

Give known macOS ChatGPT/Codex app-bundle binaries a 3-second `--version` probe budget so a cold signed binary is detected during the first onboarding pass. Generic PATH discovery, other tools, and non-macOS probes keep the existing 1.5-second budget.

This is the bottom layer of the macOS onboarding/prewarm stack and replaces #128819. The commit preserves Hannes Rudolph's authorship.

## Stack

1. **#130541 — Codex cold-start probe** (this PR)
2. #130542 — noninteractive Gateway-profile Keychain access
3. #130543 — exact prewarmed core runtime
4. #130544 — exact prewarmed official-plugin cache

## Evidence

- Mac Studio focused Vitest validation passed as part of the exact stacked head.
- Prior clean Parallels proof measured the first bundled Codex launch at 1.53s and the warm launch at 0.01s, directly crossing the generic 1.5-second budget.
- The original PR's exact-head first-pass detection proof remains linked in #128819.

## Draft status

Draft while the complete stack finishes packaged-app acceptance in the dedicated Mac Studio Parallels guest.
