### PR TITLE
fix(ui): render model provider controls progressively

### DIFF
--- a/ui/src/e2e/model-providers-progressive.e2e.test.ts
+++ b/ui/src/e2e/model-providers-progressive.e2e.test.ts
@@ -1,0 +1,121 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium, type Browser } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  canRunPlaywrightChromium,
+  installMockGateway,
+  resolvePlaywrightChromiumExecutablePath,
+  startControlUiE2eServer,
+  type ControlUiE2eServer,
+} from "../test-helpers/control-ui-e2e.ts";
+
+const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
+const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
+const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
+const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
+const recordVisuals = process.env.OPENCLAW_UI_E2E_RECORD === "1";
+const artifactDir = path.resolve(
+  process.env.OPENCLAW_UI_E2E_PROOF_DIR ?? ".artifacts/control-ui-e2e/model-providers-progressive",
+);
+
+describeControlUiE2e("Control UI progressive Model Providers loading", () => {
+  let browser: Browser;
+  let server: ControlUiE2eServer;
+
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
+    }
+    server = await startControlUiE2eServer();
+    browser = await chromium.launch({ executablePath: chromiumExecutablePath });
+    if (recordVisuals) {
+      await mkdir(artifactDir, { recursive: true });
+    }
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+    await server?.close();
+  });
+
+  it("renders provider controls before usage and cost settle", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1_000, width: 1_280 },
+      ...(recordVisuals
+        ? { recordVideo: { dir: artifactDir, size: { height: 1_000, width: 1_280 } } }
+        : {}),
+    });
+    const page = await context.newPage();
+    const now = Date.now();
+    const gateway = await installMockGateway(page, {
+      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai", available: true }],
+      heldMethods: ["usage.status", "sessions.usage"],
+      methodResponses: {
+        "config.get": {
+          config: { agents: { defaults: { model: "openai/gpt-5.5" } } },
+          sourceConfig: {},
+          hash: "progressive-model-providers",
+          issues: [],
+          raw: "{}",
+          valid: true,
+        },
+        "models.authStatus": {
+          ts: now,
+          providers: [
+            {
+              provider: "openai",
+              displayName: "OpenAI",
+              status: "static",
+              profiles: [],
+              apiKey: { source: "env", envVar: "OPENAI_API_KEY" },
+            },
+          ],
+        },
+        "usage.status": {
+          updatedAt: now,
+          providers: [{ provider: "openai", displayName: "OpenAI", plan: "Pro", windows: [] }],
+        },
+        "sessions.usage": {
+          aggregates: {
+            byProvider: [
+              {
+                provider: "openai",
+                count: 1,
+                totals: { totalTokens: 100, totalCost: 1.25 },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    try {
+      expect((await page.goto(`${server.baseUrl}settings/model-providers`))?.status()).toBe(200);
+      await gateway.waitForRequest("usage.status");
+      await gateway.waitForRequest("sessions.usage");
+      const provider = page.locator('[data-provider-id="openai"]');
+      await provider.waitFor();
+      await expect.poll(async () => provider.textContent()).toContain("Credentials configured");
+      await expect.poll(async () => provider.textContent()).toContain("Loading");
+      expect(await gateway.getRequests("usage.status")).toHaveLength(1);
+      expect(await gateway.getRequests("sessions.usage")).toHaveLength(1);
+      if (recordVisuals) {
+        await page.screenshot({ path: path.join(artifactDir, "before.png"), fullPage: true });
+      }
+
+      await gateway.resolveDeferred("usage.status");
+      await gateway.resolveDeferred("sessions.usage");
+      await expect.poll(async () => provider.textContent()).toContain("Pro");
+      await expect.poll(async () => provider.textContent()).toContain("$1.25");
+      expect(await page.locator('[data-provider-id="unknown-provider"]').count()).toBe(0);
+      if (recordVisuals) {
+        await page.screenshot({ path: path.join(artifactDir, "after.png"), fullPage: true });
+      }
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/e2e/model-providers-progressive.e2e.test.ts
+++ b/ui/src/e2e/model-providers-progressive.e2e.test.ts
@@ -107,8 +107,13 @@ describeControlUiE2e("Control UI progressive Model Providers loading", () => {
       }
 
       await gateway.resolveDeferred("usage.status");
-      await gateway.resolveDeferred("sessions.usage");
       await expect.poll(async () => provider.textContent()).toContain("Pro");
+      expect(await provider.textContent()).not.toContain("$1.25");
+      if (recordVisuals) {
+        await page.screenshot({ path: path.join(artifactDir, "usage-ready.png"), fullPage: true });
+      }
+
+      await gateway.resolveDeferred("sessions.usage");
       await expect.poll(async () => provider.textContent()).toContain("$1.25");
       expect(await page.locator('[data-provider-id="unknown-provider"]').count()).toBe(0);
       if (recordVisuals) {

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { loadModelProvidersData } from "./load.ts";
+import { loadModelProvidersData, loadModelProvidersSupplementalData } from "./load.ts";
 
 describe("loadModelProvidersData", () => {
   it("keeps full catalog discovery out of the initial page load", async () => {
@@ -22,7 +22,7 @@ describe("loadModelProvidersData", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
 
-    await loadModelProvidersData(client, { agentId: "writer" });
+    const result = await loadModelProvidersData(client, { agentId: "writer" });
 
     expect(request).toHaveBeenCalledWith("models.list", {
       view: "configured",
@@ -35,6 +35,10 @@ describe("loadModelProvidersData", () => {
           method === "models.list" && (params as { view?: string } | undefined)?.view === "all",
       ),
     ).toHaveLength(0);
+    expect(request.mock.calls.some(([method]) => method === "usage.status")).toBe(false);
+    expect(request.mock.calls.some(([method]) => method === "sessions.usage")).toBe(false);
+    expect(result.providerUsage).toBeNull();
+    expect(result.costByProvider).toBeNull();
   });
 
   it("scopes only credential status to the selected agent", async () => {
@@ -66,10 +70,8 @@ describe("loadModelProvidersData", () => {
       ["models.list", { view: "configured", agentId: "writer", refresh: true }],
     ]);
     expect(result.providerOutcomes).toEqual([]);
-    expect(request).toHaveBeenCalledWith("usage.status");
-    const sessionUsageCall = request.mock.calls.find(([method]) => method === "sessions.usage");
-    expect(sessionUsageCall?.[1]).not.toHaveProperty("agentId");
-    expect(sessionUsageCall?.[1]).toHaveProperty("agentScope", "all");
+    expect(request.mock.calls.some(([method]) => method === "usage.status")).toBe(false);
+    expect(request.mock.calls.some(([method]) => method === "sessions.usage")).toBe(false);
   });
 
   it("does not send a configured refresh for an already-retired page task", async () => {
@@ -165,8 +167,8 @@ describe("loadModelProvidersData", () => {
     expect(result.providerOutcomes).toEqual([]);
     expect(result.catalogError).toBeNull();
     expect(result.config).toEqual({});
-    expect(result.providerUsage).toEqual({ ok: true, value: { updatedAt: 1, providers: [] } });
-    expect(result.costByProvider).toEqual([]);
+    expect(result.providerUsage).toBeNull();
+    expect(result.costByProvider).toBeNull();
     expect(result.error).toBeNull();
   });
 
@@ -189,13 +191,13 @@ describe("loadModelProvidersData", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
 
-    const result = await loadModelProvidersData(client, { agentId: "main" });
+    const result = await loadModelProvidersSupplementalData(client, new AbortController().signal);
 
     expect(result.providerUsage).toEqual({
       ok: false,
       error: { kind: "request-failed" },
     });
-    expect(result.error).toBeNull();
+    expect(result.costByProvider).toEqual([]);
   });
 
   it("keeps provider-scoped usage errors as data instead of a global request failure", async () => {
@@ -227,12 +229,31 @@ describe("loadModelProvidersData", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
 
-    const result = await loadModelProvidersData(client, { agentId: "main" });
+    const result = await loadModelProvidersSupplementalData(client, new AbortController().signal);
 
     expect(result.providerUsage).toMatchObject({
       ok: true,
       value: { providers: [{ error: "provider API unavailable" }] },
     });
+  });
+
+  it("cancels both supplemental requests through the shared task signal", async () => {
+    const request = vi.fn(async (method: string) =>
+      method === "usage.status"
+        ? { updatedAt: 1, providers: [] }
+        : { aggregates: { byProvider: [] } },
+    );
+    const client = { request } as unknown as GatewayBrowserClient;
+    const signal = new AbortController().signal;
+
+    await loadModelProvidersSupplementalData(client, signal);
+
+    expect(request).toHaveBeenCalledWith("usage.status", undefined, { signal });
+    expect(request).toHaveBeenCalledWith(
+      "sessions.usage",
+      expect.objectContaining({ agentScope: "all", groupBy: "family" }),
+      { signal },
+    );
   });
 
   it("surfaces an explicit catalog refresh failure while retaining cached configured models", async () => {

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import { loadModelProvidersData, loadModelProvidersSupplementalData } from "./load.ts";
+import { loadModelProviderCost, loadModelProvidersData, loadModelProviderUsage } from "./load.ts";
 
 describe("loadModelProvidersData", () => {
   it("keeps full catalog discovery out of the initial page load", async () => {
@@ -191,13 +191,12 @@ describe("loadModelProvidersData", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
 
-    const result = await loadModelProvidersSupplementalData(client, new AbortController().signal);
+    const result = await loadModelProviderUsage(client, new AbortController().signal);
 
-    expect(result.providerUsage).toEqual({
+    expect(result).toEqual({
       ok: false,
       error: { kind: "request-failed" },
     });
-    expect(result.costByProvider).toEqual([]);
   });
 
   it("keeps provider-scoped usage errors as data instead of a global request failure", async () => {
@@ -229,9 +228,9 @@ describe("loadModelProvidersData", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
 
-    const result = await loadModelProvidersSupplementalData(client, new AbortController().signal);
+    const result = await loadModelProviderUsage(client, new AbortController().signal);
 
-    expect(result.providerUsage).toMatchObject({
+    expect(result).toMatchObject({
       ok: true,
       value: { providers: [{ error: "provider API unavailable" }] },
     });
@@ -246,7 +245,10 @@ describe("loadModelProvidersData", () => {
     const client = { request } as unknown as GatewayBrowserClient;
     const signal = new AbortController().signal;
 
-    await loadModelProvidersSupplementalData(client, signal);
+    await Promise.all([
+      loadModelProviderUsage(client, signal),
+      loadModelProviderCost(client, signal),
+    ]);
 
     expect(request).toHaveBeenCalledWith("usage.status", undefined, { signal });
     expect(request).toHaveBeenCalledWith(

--- a/ui/src/pages/model-providers/load.ts
+++ b/ui/src/pages/model-providers/load.ts
@@ -38,8 +38,6 @@ export type ModelProvidersData = {
   error: string | null;
 };
 
-type ModelProvidersSupplementalData = Pick<ModelProvidersData, "providerUsage" | "costByProvider">;
-
 type RequestResult<T> = { ok: true; result: T } | { ok: false; error: unknown };
 
 export const EMPTY_MODEL_PROVIDERS_DATA: ModelProvidersData = {
@@ -128,29 +126,32 @@ export async function loadModelProvidersData(
   };
 }
 
-export async function loadModelProvidersSupplementalData(
+export function loadModelProviderUsage(
   client: GatewayBrowserClient,
   signal: AbortSignal,
-): Promise<ModelProvidersSupplementalData> {
-  const [providerUsage, costByProvider] = await Promise.all([
-    requestProviderUsage(client, { signal }),
-    requestSessionUsage(
-      client,
-      {
-        startDate: localDate(MODEL_PROVIDERS_COST_DAYS - 1),
-        endDate: localDate(0),
-        scope: "family",
-        timeZone: "local",
-      },
-      { signal },
-    )
-      .then((result) => result?.aggregates?.byProvider ?? null)
-      .catch((error: unknown) => {
-        if (signal.aborted) {
-          throw error;
-        }
-        return null;
-      }),
-  ]);
-  return { providerUsage, costByProvider };
+): Promise<ProviderUsageRequestResult> {
+  return requestProviderUsage(client, { signal });
+}
+
+export function loadModelProviderCost(
+  client: GatewayBrowserClient,
+  signal: AbortSignal,
+): Promise<SessionModelUsage[] | null> {
+  return requestSessionUsage(
+    client,
+    {
+      startDate: localDate(MODEL_PROVIDERS_COST_DAYS - 1),
+      endDate: localDate(0),
+      scope: "family",
+      timeZone: "local",
+    },
+    { signal },
+  )
+    .then((result) => result?.aggregates?.byProvider ?? null)
+    .catch((error: unknown) => {
+      if (signal.aborted) {
+        throw error;
+      }
+      return null;
+    });
 }

--- a/ui/src/pages/model-providers/load.ts
+++ b/ui/src/pages/model-providers/load.ts
@@ -38,6 +38,8 @@ export type ModelProvidersData = {
   error: string | null;
 };
 
+type ModelProvidersSupplementalData = Pick<ModelProvidersData, "providerUsage" | "costByProvider">;
+
 type RequestResult<T> = { ok: true; result: T } | { ok: false; error: unknown };
 
 export const EMPTY_MODEL_PROVIDERS_DATA: ModelProvidersData = {
@@ -97,24 +99,14 @@ export async function loadModelProvidersData(
         refreshResult.ok ? refreshResult : loadConfiguredCatalog({ preparedOnly: true }),
       )
     : loadConfiguredCatalog({ preparedOnly: true });
-  const [authStatus, catalog, refreshResult, config, providerUsageFetch, costByProvider] =
-    await Promise.all([
-      settleRequest(loadModelAuthStatus(client, opts)),
-      catalogLoad,
-      catalogRefresh ?? Promise.resolve(undefined),
-      request<ConfigSnapshot>("config.get", {})
-        .then((snapshot) => resolveEditableSnapshotConfig(snapshot))
-        .catch(() => null),
-      requestProviderUsage(client, opts.signal ? { signal: opts.signal } : undefined),
-      requestSessionUsage(client, {
-        startDate: localDate(MODEL_PROVIDERS_COST_DAYS - 1),
-        endDate: localDate(0),
-        scope: "family",
-        timeZone: "local",
-      })
-        .then((result) => result?.aggregates?.byProvider ?? null)
-        .catch(() => null),
-    ]);
+  const [authStatus, catalog, refreshResult, config] = await Promise.all([
+    settleRequest(loadModelAuthStatus(client, opts)),
+    catalogLoad,
+    catalogRefresh ?? Promise.resolve(undefined),
+    request<ConfigSnapshot>("config.get", {})
+      .then((snapshot) => resolveEditableSnapshotConfig(snapshot))
+      .catch(() => null),
+  ]);
   return {
     authStatus:
       authStatus.ok && Array.isArray(authStatus.result?.providers) ? authStatus.result : null,
@@ -127,11 +119,38 @@ export async function loadModelProvidersData(
           ? null
           : errorMessage(catalog.error),
     config,
-    providerUsage: providerUsageFetch,
-    costByProvider,
+    providerUsage: null,
+    costByProvider: null,
     updatedAt: Date.now(),
     // Auth status is the primary provider list; its failure is the only one
     // worth surfacing as a page-level error.
     error: authStatus.ok ? null : errorMessage(authStatus.error),
   };
+}
+
+export async function loadModelProvidersSupplementalData(
+  client: GatewayBrowserClient,
+  signal: AbortSignal,
+): Promise<ModelProvidersSupplementalData> {
+  const [providerUsage, costByProvider] = await Promise.all([
+    requestProviderUsage(client, { signal }),
+    requestSessionUsage(
+      client,
+      {
+        startDate: localDate(MODEL_PROVIDERS_COST_DAYS - 1),
+        endDate: localDate(0),
+        scope: "family",
+        timeZone: "local",
+      },
+      { signal },
+    )
+      .then((result) => result?.aggregates?.byProvider ?? null)
+      .catch((error: unknown) => {
+        if (signal.aborted) {
+          throw error;
+        }
+        return null;
+      }),
+  ]);
+  return { providerUsage, costByProvider };
 }

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -104,7 +104,8 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
   });
   private readonly refreshPolicy = new UsageRefreshPolicy({
     isLoading: () => this.loadClient !== null || this.supplemental.usageLoading,
-    reload: () => this.supplemental.load(),
+    // Usage convergence must not restart the independent local-cost request.
+    reload: () => this.supplemental.loadUsage(),
     onIncompleteUsageExhausted: () => this.requestUpdate(),
   });
   private readonly supplemental = new ModelProviderSupplementalLoader(this, {

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -47,6 +47,7 @@ import {
 } from "./mutations.ts";
 import { isMissingMethodError, mergeProbeResults } from "./probe-results.ts";
 import type { ModelProvidersRouteData } from "./route.ts";
+import { ModelProviderSupplementalLoader } from "./supplemental-load.ts";
 import { renderModelProviders, type ModelProviderRowMessage } from "./view.ts";
 
 const MODEL_PROVIDERS_DOCS_URL = "https://docs.openclaw.ai/concepts/model-providers";
@@ -87,7 +88,6 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       if (!client || !agentId) {
         return initialState;
       }
-      this.refreshPolicy.beginLoad();
       return loadModelProvidersData(client, {
         agentId,
         ...(force ? { refresh: true } : {}),
@@ -97,17 +97,23 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     onComplete: ({ client, data }) => {
       this.loadClient = null;
       this.adoptLoadedData(client, data);
-      this.refreshPolicy.flushPending();
     },
     onError: () => {
       this.loadClient = null;
-      this.refreshPolicy.flushPending();
     },
   });
   private readonly refreshPolicy = new UsageRefreshPolicy({
-    isLoading: () => this.loadClient !== null,
-    reload: () => void this.refresh({ force: false }),
+    isLoading: () => this.loadClient !== null || this.supplemental.loading,
+    reload: () => this.supplemental.load(),
     onIncompleteUsageExhausted: () => this.requestUpdate(),
+  });
+  private readonly supplemental = new ModelProviderSupplementalLoader(this, {
+    getGateway: () => this.gateway,
+    getData: () => this.data,
+    getDataClient: () => this.dataClient,
+    setData: (data) => (this.data = data),
+    setDataClient: (client) => (this.dataClient = client),
+    refreshPolicy: this.refreshPolicy,
   });
   private readonly gateway = new GatewayPageController(this, {
     getGateway: () => this.context?.gateway,
@@ -122,7 +128,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
         this.resetConnectionState({ preserveVisibleData: true });
       }
       if (change.becameConnected && !change.initial) {
-        this.refreshPolicy.request("reconnect");
+        void this.refresh({ force: false });
       }
     },
     onPageActivation: () => this.refreshPolicy.request("focus"),
@@ -201,15 +207,13 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
   }
 
   private adoptLoadedData(client: GatewayBrowserClient | null, data: ModelProvidersData) {
-    this.data = data;
-    this.dataClient = client;
-    this.refreshPolicy.markProviderUsage(data.providerUsage, data.updatedAt, this.gateway.epoch);
+    this.supplemental.adoptCoreData(client, data);
   }
 
   private invalidateRequests() {
-    this.refreshPolicy.interrupt();
     this.loadClient = null;
     void this.refreshTask.run([null, this.selectedAgentId, false]);
+    this.supplemental.invalidate();
   }
 
   private resetConnectionState(options: { preserveVisibleData?: boolean } = {}) {
@@ -627,6 +631,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       refreshing: this.loadClient !== null,
       error: rosterError ?? data.error ?? data.catalogError,
       providerUsageFailed: data.providerUsage?.ok === false,
+      supplementalLoading: this.supplemental.loading,
       updatedAt: data.updatedAt,
       costDays: MODEL_PROVIDERS_COST_DAYS,
       credentialAgentLabel: selectedAgentLabel,

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -103,7 +103,7 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
     },
   });
   private readonly refreshPolicy = new UsageRefreshPolicy({
-    isLoading: () => this.loadClient !== null || this.supplemental.loading,
+    isLoading: () => this.loadClient !== null || this.supplemental.usageLoading,
     reload: () => this.supplemental.load(),
     onIncompleteUsageExhausted: () => this.requestUpdate(),
   });
@@ -283,9 +283,8 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       this.refreshPolicy.markLoadDeferred();
       return Promise.resolve();
     }
-    if (opts.force) {
-      this.refreshPolicy.resetPayload();
-    }
+    // Cancel the old supplemental generation before it can publish during core loading.
+    this.supplemental.beginCoreRefresh(opts.force);
     this.loadClient = client;
     return this.refreshTask.run([client, this.selectedAgentId, opts.force]);
   }

--- a/ui/src/pages/model-providers/model-providers-page.usage.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.usage.test.ts
@@ -150,42 +150,65 @@ describe("ModelProvidersPage usage convergence", () => {
     );
   });
 
-  it("cancels and replaces supplemental work on reconnect", async () => {
+  it("cancels and replaces supplemental work on forced refresh", async () => {
     const harness = createHarness("main");
     const oldUsage = deferred<unknown>();
+    const oldCost = deferred<unknown>();
     const originalRequest = harness.request.getMockImplementation()!;
-    let firstSignal: AbortSignal | undefined;
+    let firstUsageSignal: AbortSignal | undefined;
+    let firstCostSignal: AbortSignal | undefined;
     let usageCall = 0;
+    let costCall = 0;
     harness.request.mockImplementation(
       async (method: string, _params?: unknown, options?: { signal?: AbortSignal }) => {
-        if (method !== "usage.status") {
+        if (method === "sessions.usage") {
+          costCall += 1;
+          if (costCall === 1) {
+            firstCostSignal = options?.signal;
+            return oldCost.promise;
+          }
           return originalRequest(method);
         }
-        usageCall += 1;
-        if (usageCall === 1) {
-          firstSignal = options?.signal;
-          return oldUsage.promise;
+        if (method === "usage.status") {
+          usageCall += 1;
+          if (usageCall === 1) {
+            firstUsageSignal = options?.signal;
+            return oldUsage.promise;
+          }
+          return { updatedAt: 2, providers: [] };
         }
-        return { updatedAt: 2, providers: [] };
+        return originalRequest(method);
       },
     );
     const page = appendPage(harness.context);
     await vi.waitFor(() => expect(requestCount(harness.request, "usage.status")).toBe(1));
+    await vi.waitFor(() => expect(requestCount(harness.request, "sessions.usage")).toBe(1));
 
-    harness.publishPhase("offline");
-    await page.updateComplete;
-    expect(firstSignal?.aborted).toBe(true);
-    harness.publishPhase("connected");
+    const releaseCoreRefresh = harness.deferNextAuthStatus();
+    const refresh = page.refresh({ force: true });
+    expect(firstUsageSignal?.aborted).toBe(true);
+    expect(firstCostSignal?.aborted).toBe(true);
+
+    oldUsage.resolve({ updatedAt: 1, providers: [] });
+    oldCost.resolve({
+      aggregates: { byProvider: [{ provider: "stale", totals: { totalCost: 1 } }] },
+    });
+    await Promise.resolve();
+    expect(page.data?.providerUsage).toBeNull();
+    expect(page.data?.costByProvider).toBeNull();
+
+    releaseCoreRefresh();
+    await refresh;
 
     await vi.waitFor(() => expect(requestCount(harness.request, "usage.status")).toBe(2));
+    await vi.waitFor(() => expect(requestCount(harness.request, "sessions.usage")).toBe(2));
     await vi.waitFor(() =>
       expect(page.data?.providerUsage).toMatchObject({ ok: true, value: { updatedAt: 2 } }),
     );
-    oldUsage.resolve({ updatedAt: 1, providers: [] });
-    await Promise.resolve();
-    await page.updateComplete;
+    await vi.waitFor(() => expect(page.data?.costByProvider).toEqual([]));
 
     expect(requestCount(harness.request, "usage.status")).toBe(2);
+    expect(requestCount(harness.request, "sessions.usage")).toBe(2);
     expect(page.data?.providerUsage).toMatchObject({ ok: true, value: { updatedAt: 2 } });
   });
 });

--- a/ui/src/pages/model-providers/model-providers-page.usage.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.usage.test.ts
@@ -99,6 +99,36 @@ describe("ModelProvidersPage usage convergence", () => {
     expect(page.textContent ?? "").toContain("did not finish loading");
   });
 
+  it("retries incomplete usage without restarting pending cost", async () => {
+    vi.useFakeTimers();
+    focusDocument();
+    const harness = createHarness("main");
+    harness.setUsageStatus({ updatedAt: 1, providers: [], refreshing: true });
+    const pendingCost = deferred<unknown>();
+    const originalRequest = harness.request.getMockImplementation()!;
+    let costSignal: AbortSignal | undefined;
+    harness.request.mockImplementation(
+      async (method: string, _params?: unknown, options?: { signal?: AbortSignal }) => {
+        if (method === "sessions.usage") {
+          costSignal = options?.signal;
+          return pendingCost.promise;
+        }
+        return originalRequest(method);
+      },
+    );
+
+    const page = appendPage(harness.context);
+    await page.updateComplete;
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(requestCount(harness.request, "usage.status")).toBeGreaterThan(1);
+    expect(requestCount(harness.request, "sessions.usage")).toBe(1);
+    expect(costSignal?.aborted).toBe(false);
+
+    pendingCost.resolve({ aggregates: { byProvider: [] } });
+    await vi.waitFor(() => expect(page.data?.costByProvider).toEqual([]));
+  });
+
   it("does not warn about a stall while disconnected", async () => {
     vi.useFakeTimers();
     const harness = createHarness("main");

--- a/ui/src/pages/model-providers/model-providers-page.usage.test.ts
+++ b/ui/src/pages/model-providers/model-providers-page.usage.test.ts
@@ -6,7 +6,9 @@ import {
   advanceUsageRetries,
   appendPage,
   createHarness,
+  deferred,
   focusDocument,
+  requestCount,
 } from "./model-providers-page.test-support.ts";
 
 afterEach(() => {
@@ -85,9 +87,9 @@ describe("ModelProvidersPage usage convergence", () => {
     await page.updateComplete;
     expect(page.textContent ?? "").toContain("did not finish loading");
 
-    // loadModelProvidersData turns a rejected usage.status into providerUsage:
-    // null. Read as a completed load that would reset the budget and erase the
-    // notice, leaving broken usage looking exactly like absent usage.
+    // The supplemental load turns a rejected usage.status into a failed result.
+    // Treating it as complete would reset the budget and erase the notice,
+    // leaving broken usage looking exactly like absent usage.
     harness.failUsageStatus();
     page.querySelector<HTMLButtonElement>(".settings-section__actions button")?.click();
     await page.updateComplete;
@@ -137,7 +139,7 @@ describe("ModelProvidersPage usage convergence", () => {
     await vi.waitFor(() =>
       expect(
         harness.request.mock.calls.filter(([method]) => method === "usage.status").length,
-      ).toBe(2),
+      ).toBe(1),
     );
     releaseOldLoad();
     await vi.waitFor(() =>
@@ -146,5 +148,44 @@ describe("ModelProvidersPage usage convergence", () => {
         value: { updatedAt: 2 },
       }),
     );
+  });
+
+  it("cancels and replaces supplemental work on reconnect", async () => {
+    const harness = createHarness("main");
+    const oldUsage = deferred<unknown>();
+    const originalRequest = harness.request.getMockImplementation()!;
+    let firstSignal: AbortSignal | undefined;
+    let usageCall = 0;
+    harness.request.mockImplementation(
+      async (method: string, _params?: unknown, options?: { signal?: AbortSignal }) => {
+        if (method !== "usage.status") {
+          return originalRequest(method);
+        }
+        usageCall += 1;
+        if (usageCall === 1) {
+          firstSignal = options?.signal;
+          return oldUsage.promise;
+        }
+        return { updatedAt: 2, providers: [] };
+      },
+    );
+    const page = appendPage(harness.context);
+    await vi.waitFor(() => expect(requestCount(harness.request, "usage.status")).toBe(1));
+
+    harness.publishPhase("offline");
+    await page.updateComplete;
+    expect(firstSignal?.aborted).toBe(true);
+    harness.publishPhase("connected");
+
+    await vi.waitFor(() => expect(requestCount(harness.request, "usage.status")).toBe(2));
+    await vi.waitFor(() =>
+      expect(page.data?.providerUsage).toMatchObject({ ok: true, value: { updatedAt: 2 } }),
+    );
+    oldUsage.resolve({ updatedAt: 1, providers: [] });
+    await Promise.resolve();
+    await page.updateComplete;
+
+    expect(requestCount(harness.request, "usage.status")).toBe(2);
+    expect(page.data?.providerUsage).toMatchObject({ ok: true, value: { updatedAt: 2 } });
   });
 });

--- a/ui/src/pages/model-providers/supplemental-load.ts
+++ b/ui/src/pages/model-providers/supplemental-load.ts
@@ -2,7 +2,7 @@ import { initialState, Task } from "@lit/task";
 import type { ReactiveControllerHost } from "lit";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { UsageRefreshPolicy } from "../usage/refresh-policy.ts";
-import { loadModelProvidersSupplementalData, type ModelProvidersData } from "./load.ts";
+import { loadModelProviderCost, loadModelProviderUsage, type ModelProvidersData } from "./load.ts";
 
 type SupplementalGateway = {
   connected: boolean;
@@ -20,58 +20,49 @@ type SupplementalOptions = {
   refreshPolicy: UsageRefreshPolicy;
 };
 
-type SupplementalTaskValue = {
-  client: GatewayBrowserClient;
-  data: Awaited<ReturnType<typeof loadModelProvidersSupplementalData>>;
-  epoch: number;
-};
+type SupplementalKind = "usage" | "cost";
+type SupplementalTaskValue<T> = { client: GatewayBrowserClient; data: T; epoch: number };
 
 /** Loads usage and cost after the provider controls have their required data. */
 export class ModelProviderSupplementalLoader {
-  private activeClient: GatewayBrowserClient | null = null;
-  private readonly task: Task<[GatewayBrowserClient | null, number], SupplementalTaskValue>;
+  private readonly pending = new Set<SupplementalKind>();
+  private readonly usageTask: Task<
+    [GatewayBrowserClient | null, number],
+    SupplementalTaskValue<Awaited<ReturnType<typeof loadModelProviderUsage>>>
+  >;
+  private readonly costTask: Task<
+    [GatewayBrowserClient | null, number],
+    SupplementalTaskValue<Awaited<ReturnType<typeof loadModelProviderCost>>>
+  >;
 
   constructor(
     host: ReactiveControllerHost,
     private readonly options: SupplementalOptions,
   ) {
-    this.task = new Task(host, {
-      autoRun: false,
-      task: ([client, epoch], { signal }) =>
-        client
-          ? loadModelProvidersSupplementalData(client, signal).then((data) => ({
-              client,
-              data,
-              epoch,
-            }))
-          : initialState,
-      onComplete: ({ client, data, epoch }) => {
-        this.activeClient = null;
-        const current = this.options.getData();
-        if (
-          current &&
-          client === this.options.getDataClient() &&
-          this.options.getGateway().isCurrent({ client, epoch })
-        ) {
-          this.options.setData({ ...current, ...data });
-          this.options.refreshPolicy.markProviderUsage(data.providerUsage, Date.now(), epoch);
-        }
-        this.options.refreshPolicy.flushPending();
-      },
-      onError: () => {
-        this.activeClient = null;
-        this.options.refreshPolicy.flushPending();
-      },
-    });
+    this.usageTask = this.createTask(
+      host,
+      "usage",
+      loadModelProviderUsage,
+      (providerUsage) => ({ providerUsage }),
+      (providerUsage, epoch) =>
+        this.options.refreshPolicy.markProviderUsage(providerUsage, Date.now(), epoch),
+    );
+    this.costTask = this.createTask(host, "cost", loadModelProviderCost, (costByProvider) => ({
+      costByProvider,
+    }));
   }
 
   get loading(): boolean {
-    return this.activeClient !== null;
+    return this.pending.size > 0;
+  }
+
+  get usageLoading(): boolean {
+    return this.pending.has("usage");
   }
 
   adoptCoreData(client: GatewayBrowserClient | null, data: ModelProvidersData): void {
     const previous = client === this.options.getDataClient() ? this.options.getData() : null;
-    // Keep the last usage snapshot visible until its replacement finishes.
+    // Keep the last supplemental snapshot visible until its replacement finishes.
     this.options.setData({
       ...data,
       providerUsage: previous?.providerUsage ?? data.providerUsage,
@@ -85,7 +76,8 @@ export class ModelProviderSupplementalLoader {
         this.options.getGateway().epoch,
       );
     }
-    // Core route data leaves both fields empty; populated route data already has its snapshot.
+    // The same route data can be adopted more than once. Core refresh cancels
+    // the prior generation before its replacement reaches this boundary.
     if (client && !this.loading && data.providerUsage === null && data.costByProvider === null) {
       void this.load(client);
     }
@@ -93,19 +85,67 @@ export class ModelProviderSupplementalLoader {
 
   invalidate(): void {
     this.options.refreshPolicy.interrupt();
-    this.activeClient = null;
-    void this.task.run([null, this.options.getGateway().epoch]);
+    this.cancelGeneration();
   }
 
-  load(explicitClient?: GatewayBrowserClient): Promise<void> {
+  beginCoreRefresh(force: boolean): void {
+    this.cancelGeneration();
+    if (force) {
+      this.options.refreshPolicy.resetPayload();
+    }
+  }
+
+  private cancelGeneration(): void {
+    this.pending.clear();
+    const epoch = this.options.getGateway().epoch;
+    void this.usageTask.run([null, epoch]);
+    void this.costTask.run([null, epoch]);
+  }
+
+  async load(explicitClient?: GatewayBrowserClient): Promise<void> {
     const gateway = this.options.getGateway();
     const client = explicitClient ?? gateway.client;
     if (!gateway.connected || !client) {
       this.options.refreshPolicy.markLoadDeferred();
-      return Promise.resolve();
+      return;
     }
     this.options.refreshPolicy.beginLoad();
-    this.activeClient = client;
-    return this.task.run([client, gateway.epoch]);
+    this.pending.add("usage");
+    this.pending.add("cost");
+    await Promise.all([
+      this.usageTask.run([client, gateway.epoch]),
+      this.costTask.run([client, gateway.epoch]),
+    ]);
+  }
+
+  private createTask<T>(
+    host: ReactiveControllerHost,
+    kind: SupplementalKind,
+    load: (client: GatewayBrowserClient, signal: AbortSignal) => Promise<T>,
+    patch: (data: T) => Partial<Pick<ModelProvidersData, "providerUsage" | "costByProvider">>,
+    onComplete?: (data: T, epoch: number) => void,
+  ): Task<[GatewayBrowserClient | null, number], SupplementalTaskValue<T>> {
+    return new Task(host, {
+      autoRun: false,
+      task: ([client, epoch], { signal }) =>
+        client ? load(client, signal).then((data) => ({ client, data, epoch })) : initialState,
+      onComplete: ({ client, data, epoch }) => {
+        this.pending.delete(kind);
+        const current = this.options.getData();
+        if (
+          current &&
+          client === this.options.getDataClient() &&
+          this.options.getGateway().isCurrent({ client, epoch })
+        ) {
+          this.options.setData({ ...current, ...patch(data) });
+          onComplete?.(data, epoch);
+        }
+        this.options.refreshPolicy.flushPending();
+      },
+      onError: () => {
+        this.pending.delete(kind);
+        this.options.refreshPolicy.flushPending();
+      },
+    });
   }
 }

--- a/ui/src/pages/model-providers/supplemental-load.ts
+++ b/ui/src/pages/model-providers/supplemental-load.ts
@@ -1,0 +1,111 @@
+import { initialState, Task } from "@lit/task";
+import type { ReactiveControllerHost } from "lit";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { UsageRefreshPolicy } from "../usage/refresh-policy.ts";
+import { loadModelProvidersSupplementalData, type ModelProvidersData } from "./load.ts";
+
+type SupplementalGateway = {
+  connected: boolean;
+  client: GatewayBrowserClient | null;
+  epoch: number;
+  isCurrent: (params: { client: GatewayBrowserClient; epoch: number }) => boolean;
+};
+
+type SupplementalOptions = {
+  getGateway: () => SupplementalGateway;
+  getData: () => ModelProvidersData | null;
+  getDataClient: () => GatewayBrowserClient | null;
+  setData: (data: ModelProvidersData) => void;
+  setDataClient: (client: GatewayBrowserClient | null) => void;
+  refreshPolicy: UsageRefreshPolicy;
+};
+
+type SupplementalTaskValue = {
+  client: GatewayBrowserClient;
+  data: Awaited<ReturnType<typeof loadModelProvidersSupplementalData>>;
+  epoch: number;
+};
+
+/** Loads usage and cost after the provider controls have their required data. */
+export class ModelProviderSupplementalLoader {
+  private activeClient: GatewayBrowserClient | null = null;
+  private readonly task: Task<[GatewayBrowserClient | null, number], SupplementalTaskValue>;
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly options: SupplementalOptions,
+  ) {
+    this.task = new Task(host, {
+      autoRun: false,
+      task: ([client, epoch], { signal }) =>
+        client
+          ? loadModelProvidersSupplementalData(client, signal).then((data) => ({
+              client,
+              data,
+              epoch,
+            }))
+          : initialState,
+      onComplete: ({ client, data, epoch }) => {
+        this.activeClient = null;
+        const current = this.options.getData();
+        if (
+          current &&
+          client === this.options.getDataClient() &&
+          this.options.getGateway().isCurrent({ client, epoch })
+        ) {
+          this.options.setData({ ...current, ...data });
+          this.options.refreshPolicy.markProviderUsage(data.providerUsage, Date.now(), epoch);
+        }
+        this.options.refreshPolicy.flushPending();
+      },
+      onError: () => {
+        this.activeClient = null;
+        this.options.refreshPolicy.flushPending();
+      },
+    });
+  }
+
+  get loading(): boolean {
+    return this.activeClient !== null;
+  }
+
+  adoptCoreData(client: GatewayBrowserClient | null, data: ModelProvidersData): void {
+    const previous = client === this.options.getDataClient() ? this.options.getData() : null;
+    // Keep the last usage snapshot visible until its replacement finishes.
+    this.options.setData({
+      ...data,
+      providerUsage: previous?.providerUsage ?? data.providerUsage,
+      costByProvider: previous?.costByProvider ?? data.costByProvider,
+    });
+    this.options.setDataClient(client);
+    if (data.providerUsage !== null) {
+      this.options.refreshPolicy.markProviderUsage(
+        data.providerUsage,
+        data.updatedAt,
+        this.options.getGateway().epoch,
+      );
+    }
+    // Core route data leaves both fields empty; populated route data already has its snapshot.
+    if (client && !this.loading && data.providerUsage === null && data.costByProvider === null) {
+      void this.load(client);
+    }
+  }
+
+  invalidate(): void {
+    this.options.refreshPolicy.interrupt();
+    this.activeClient = null;
+    void this.task.run([null, this.options.getGateway().epoch]);
+  }
+
+  load(explicitClient?: GatewayBrowserClient): Promise<void> {
+    const gateway = this.options.getGateway();
+    const client = explicitClient ?? gateway.client;
+    if (!gateway.connected || !client) {
+      this.options.refreshPolicy.markLoadDeferred();
+      return Promise.resolve();
+    }
+    this.options.refreshPolicy.beginLoad();
+    this.activeClient = client;
+    return this.task.run([client, gateway.epoch]);
+  }
+}

--- a/ui/src/pages/model-providers/supplemental-load.ts
+++ b/ui/src/pages/model-providers/supplemental-load.ts
@@ -102,7 +102,18 @@ export class ModelProviderSupplementalLoader {
     void this.costTask.run([null, epoch]);
   }
 
-  async load(explicitClient?: GatewayBrowserClient): Promise<void> {
+  load(explicitClient?: GatewayBrowserClient): Promise<void> {
+    return this.loadRequests(explicitClient, true);
+  }
+
+  loadUsage(): Promise<void> {
+    return this.loadRequests(undefined, false);
+  }
+
+  private async loadRequests(
+    explicitClient: GatewayBrowserClient | undefined,
+    includeCost: boolean,
+  ): Promise<void> {
     const gateway = this.options.getGateway();
     const client = explicitClient ?? gateway.client;
     if (!gateway.connected || !client) {
@@ -111,11 +122,13 @@ export class ModelProviderSupplementalLoader {
     }
     this.options.refreshPolicy.beginLoad();
     this.pending.add("usage");
+    const usage = this.usageTask.run([client, gateway.epoch]);
+    if (!includeCost) {
+      await usage;
+      return;
+    }
     this.pending.add("cost");
-    await Promise.all([
-      this.usageTask.run([client, gateway.epoch]),
-      this.costTask.run([client, gateway.epoch]),
-    ]);
+    await Promise.all([usage, this.costTask.run([client, gateway.epoch])]);
   }
 
   private createTask<T>(

--- a/ui/src/pages/model-providers/view.test.ts
+++ b/ui/src/pages/model-providers/view.test.ts
@@ -31,6 +31,7 @@ function props(overrides: Partial<ModelProvidersViewProps> = {}): ModelProviders
     refreshing: false,
     error: null,
     providerUsageFailed: false,
+    supplementalLoading: false,
     updatedAt: 1,
     costDays: 30,
     credentialAgentLabel: "Writer",

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -45,6 +45,7 @@ type ModelProvidersViewProps = {
   refreshing: boolean;
   error: string | null;
   providerUsageFailed: boolean;
+  supplementalLoading: boolean;
   updatedAt: number | null;
   costDays: number;
   credentialAgentLabel: string;
@@ -451,11 +452,16 @@ function renderProviderRow(card: ModelProviderCard, props: ModelProvidersViewPro
         </div>
       </div>
       ${renderCredentialSummary(card, props.credentialAgentLabel)}
-      <div class="model-providers__global-metrics">
+      <div
+        class="model-providers__global-metrics"
+        aria-busy=${props.supplementalLoading ? "true" : "false"}
+      >
         <div class="model-providers__global-metrics-title">${t("modelProviders.globalUsage")}</div>
         ${card.usage
           ? renderProviderUsageDetails(card.usage)
-          : html`<div class="model-providers__no-stats">${t("modelProviders.noStats")}</div>`}
+          : html`<div class="model-providers__no-stats">
+              ${t(props.supplementalLoading ? "common.loading" : "modelProviders.noStats")}
+            </div>`}
         ${renderLocalCost(card, props.costDays)}
       </div>
       ${renderProviderActions(card, props)} ${renderKeyEditor(card, props)}


### PR DESCRIPTION
Fixes #130111.

## What Problem This Solves

The Model Providers page waited for provider quota and local session-cost requests before it showed auth, catalog, and config controls. A slow supplemental request left the whole provider section on `Loading…`.

## Root cause

The route loader put auth, catalog, config, provider usage, and session cost in one `Promise.all`. The page could not adopt the required provider data until every supplemental request settled.

## Fix

- Load auth, catalog, and config first so provider controls render as soon as their required data is ready.
- Load provider usage and local cost independently through one supplemental lifecycle owner so each result appears as soon as it is ready.
- Pass abort signals through both supplemental Gateway requests and reject stale client or Gateway-epoch completions.
- Cancel the active supplemental generation when a core refresh starts, then replace it after core data returns.
- Retry incomplete provider usage without restarting an independent local-cost request.
- Keep existing usage failures visible and show `Loading…` while supplemental data is pending.

## Evidence

- Current main `de969147e7f3ba404e20d8f9966b97f1981e5f17`: Chromium held `usage.status` and `sessions.usage`; provider controls did not appear within 1 second.
- Head `ee7154a5f6feaa45aafb1dab620b63f0f53091c2`: the same browser flow showed provider controls while both calls remained pending, showed the `Pro` plan while cost remained pending, then showed `$1.25` after cost release.
- The browser observed exactly one `usage.status` request and one `sessions.usage` request.
- Pre-correction head `3c917fb890551dd2f827c4833103a9bc946ee50e` left an old supplemental request active while a held core refresh ran.
- Head `ee7154a5f6feaa45aafb1dab620b63f0f53091c2` aborts both old supplemental requests before the held core refresh can finish or stale data can publish.
- Pre-correction head `f9f8b32ffd19d8dbd08eea30861bb91287488037` restarted a held local-cost request during automatic usage recovery; the new head retries only usage and lets that cost request publish.
- 81 focused load, page, refresh, reconnect, and view tests pass.
- Focused Control UI end-to-end test passes.

### Before / After browser evidence

| Scenario | Current main | Repair head |
| --- | --- | --- |
| Both supplemental requests held | Provider controls stayed absent after 1 second | `Credentials configured` and `Loading…` appeared while both requests stayed pending |
| Only provider usage released | Not observable because the provider card was still blocked | `Pro` appeared while `$1.25` stayed absent |
| Local cost released | Provider card appeared only after both requests finished | `$1.25` appeared on the already-visible provider card |

The isolated Chromium run observed one `usage.status` request and one `sessions.usage` request. It used a mocked Gateway WebSocket with held responses and no private account or provider data.

## Change size

- Production: +194 lines net. The growth is the supplemental task owner, including independent publication, cancellation, stale-result fencing, refresh coalescing, and pending state.
- Tests: +244 lines net. Coverage proves current-main red behavior, exact browser traffic, independent publication, usage-only recovery, cancellation, reconnect replacement, and stale-write rejection.
