### PR TITLE
fix(imessage): preserve dunder reference links

### DIFF
--- a/extensions/imessage/src/markdown-format.test.ts
+++ b/extensions/imessage/src/markdown-format.test.ts
@@ -144,17 +144,47 @@ describe("extractMarkdownFormatRuns", () => {
     });
   });
 
-  it("does not confuse an earlier matching bold span with a protected dunder", () => {
+  it("does not confuse an earlier matching bold span with a dunder call", () => {
     expect(extractMarkdownFormatRuns("**init**() then __init__()")).toEqual({
       text: "init() then __init__()",
       ranges: [{ start: 0, length: 4, styles: ["bold"] }],
     });
   });
 
-  it("searches past unrelated declarations for the matching dunder range", () => {
+  it("keeps dunder declarations literal after ordinary declarations", () => {
     expect(extractMarkdownFormatRuns("def init():\ndef __init__(self):")).toEqual({
       text: "def init():\ndef __init__(self):",
       ranges: [],
+    });
+  });
+
+  it("resolves reference labels that contain different dunder identifiers", () => {
+    expect(
+      extractMarkdownFormatRuns(
+        "[Class][obj.__class__]\n\n[obj.__class__]: https://example.org/python",
+      ),
+    ).toEqual({
+      text: "Class (https://example.org/python)",
+      ranges: [],
+    });
+  });
+
+  it("preserves every repeated destination containing a dunder identifier", () => {
+    expect(
+      extractMarkdownFormatRuns(
+        [
+          "[Class][docs] and [Type][docs] **done**",
+          "",
+          "[docs]: https://docs.python.org/3/library/stdtypes.html#instance.__class__",
+        ].join("\n"),
+      ),
+    ).toEqual({
+      text: [
+        "Class (https://docs.python.org/3/library/stdtypes.html#instance.__class__)",
+        "and Type (https://docs.python.org/3/library/stdtypes.html#instance.__class__)",
+        "done",
+      ].join(" "),
+      ranges: [{ start: 153, length: 4, styles: ["bold"] }],
     });
   });
 });

--- a/extensions/imessage/src/markdown-format.ts
+++ b/extensions/imessage/src/markdown-format.ts
@@ -50,39 +50,6 @@ function codeDelimiter(content: string): string {
 }
 
 type TextEdit = { start: number; end: number; text: string };
-type DunderProtection = { token: string; identifier: string };
-
-function protectDunderIdentifiers(input: string): {
-  markdown: string;
-  protections: DunderProtection[];
-} {
-  const protections: DunderProtection[] = [];
-  let markdown = "";
-  let cursor = 0;
-  for (const match of input.matchAll(/__[\p{L}_][\p{L}\p{N}_]*__/gu)) {
-    const identifier = match[0];
-    const start = match.index ?? 0;
-    const end = start + identifier.length;
-    const before = input[start - 1];
-    const beforeBefore = input[start - 2];
-    const after = input[end];
-    const member = before === ".";
-    const call = after === "(";
-    const functionArgument = before === "(" && /[\p{L}\p{N}_]/u.test(beforeBefore ?? "");
-    const index = after === "[";
-    if (!member && !call && !functionArgument && !index) {
-      continue;
-    }
-    let token = `OCdunder${protections.length}token`;
-    while (input.includes(token)) {
-      token += "x";
-    }
-    markdown += input.slice(cursor, start) + token;
-    protections.push({ token, identifier });
-    cursor = end;
-  }
-  return { markdown: markdown + input.slice(cursor), protections };
-}
 
 function applyTextEdits(text: string, edits: TextEdit[]) {
   const ordered = edits.toSorted((left, right) => left.start - right.start);
@@ -102,31 +69,6 @@ function applyTextEdits(text: string, edits: TextEdit[]) {
           delta + (edit.end <= offset ? edit.text.length - edit.end + edit.start : 0),
         0,
       ),
-  };
-}
-
-function restoreDunderIdentifiers(
-  text: string,
-  ranges: IMessageFormatRange[],
-  codeRanges: Array<{ start: number; length: number }>,
-  protections: DunderProtection[],
-) {
-  const edits = protections.flatMap((protection) => {
-    const start = text.indexOf(protection.token);
-    return start === -1
-      ? []
-      : [{ start, end: start + protection.token.length, text: protection.identifier }];
-  });
-  const edited = applyTextEdits(text, edits);
-  const mapRange = <T extends { start: number; length: number }>(range: T): T => ({
-    ...range,
-    start: edited.mapOffset(range.start),
-    length: edited.mapOffset(range.start + range.length) - edited.mapOffset(range.start),
-  });
-  return {
-    text: edited.text,
-    ranges: ranges.map(mapRange),
-    codeRanges: codeRanges.map(mapRange),
   };
 }
 
@@ -157,12 +99,12 @@ export function extractMarkdownFormatRuns(input: string): {
   text: string;
   ranges: IMessageFormatRange[];
 } {
-  const protectedDunders = protectDunderIdentifiers(input);
-  const ir = markdownToIR(protectedDunders.markdown, {
+  const ir = markdownToIR(input, {
     autolink: false,
     enableHtmlUnderline: true,
     headingStyle: "rich",
     linkify: false,
+    preserveDunderIdentifiers: true,
     preserveSourceBlockSpacing: true,
   });
   const rendered = renderMarkdownWithAttributedRanges(
@@ -175,7 +117,7 @@ export function extractMarkdownFormatRuns(input: string): {
     { styleMap: { code: "code" } },
     IMESSAGE_CODE_PROFILE,
   );
-  const dunders = restoreDunderIdentifiers(
+  return restoreCodeMarkers(
     rendered.text,
     rendered.ranges.map(({ start, length, style }) => ({
       start,
@@ -183,7 +125,5 @@ export function extractMarkdownFormatRuns(input: string): {
       styles: [style],
     })),
     code.ranges,
-    protectedDunders.protections,
   );
-  return restoreCodeMarkers(dunders.text, dunders.ranges, dunders.codeRanges);
 }

--- a/extensions/imessage/src/send.test.ts
+++ b/extensions/imessage/src/send.test.ts
@@ -639,6 +639,17 @@ describe("sendMessageIMessage receipts", () => {
         }
       }
 
+      const dunderReferenceRequestIndex = countNativeRequests();
+      await sendMessageIMessage(
+        "chat_id:10",
+        [
+          "[Class][docs] and [Type][docs] **done**",
+          "",
+          "[docs]: https://docs.python.org/3/library/stdtypes.html#instance.__class__",
+        ].join("\n"),
+        { config: cfg },
+      );
+
       const oversizedYaml = [
         "```yaml",
         ...Array.from({ length: 6 }, (_, index) =>
@@ -678,7 +689,7 @@ describe("sendMessageIMessage receipts", () => {
           );
       const requests = readRequests();
       const expectedFixedRequestCount =
-        1 + disguisedCases.length + 1 + channelContractRequestCount + embeddedRequestCount;
+        1 + disguisedCases.length + 1 + channelContractRequestCount + embeddedRequestCount + 1;
       expect(fixedRequestCount).toBe(expectedFixedRequestCount);
       const monitorRequests = requests.slice(
         expectedFixedRequestCount,
@@ -735,10 +746,27 @@ describe("sendMessageIMessage receipts", () => {
           (boldRange?.start ?? 0) + (boldRange?.length ?? 0),
         ),
       ).toBe("😀 styled");
+      expect(requests[dunderReferenceRequestIndex]?.params).toMatchObject({
+        text: [
+          "Class (https://docs.python.org/3/library/stdtypes.html#instance.__class__)",
+          "and Type (https://docs.python.org/3/library/stdtypes.html#instance.__class__)",
+          "done",
+        ].join(" "),
+        formatting: [{ start: 153, length: 4, styles: ["bold"] }],
+      });
 
       const { imessageActionsRuntime } = await import("./actions.runtime.js");
       const actionOptions = { cliPath, chatGuid: "iMessage;+;chat0000" };
       const fencedYaml = ["```yaml", ...roles.map((role) => `${role}:`), "```"].join("\n");
+      await imessageActionsRuntime.sendRichMessage({
+        chatGuid: actionOptions.chatGuid,
+        text: [
+          "[Class][obj.__class__] **done**",
+          "",
+          "[obj.__class__]: https://example.org/python",
+        ].join("\n"),
+        options: actionOptions,
+      });
       await imessageActionsRuntime.sendRichMessage({
         chatGuid: actionOptions.chatGuid,
         text: [
@@ -862,8 +890,9 @@ describe("sendMessageIMessage receipts", () => {
           .map((line) => JSON.parse(line) as string[]);
       const actionValue = (args: string[], flag: string) => args[args.indexOf(flag) + 1] ?? "";
       const actions = readActions();
-      expect(actions).toHaveLength(6);
+      expect(actions).toHaveLength(7);
       const [
+        dunderReferenceAction,
         replyAction,
         effectAction,
         attachmentAction,
@@ -872,6 +901,7 @@ describe("sendMessageIMessage receipts", () => {
         pollAction,
       ] = actions;
       if (
+        !dunderReferenceAction ||
         !replyAction ||
         !effectAction ||
         !attachmentAction ||
@@ -879,8 +909,14 @@ describe("sendMessageIMessage receipts", () => {
         !editAction ||
         !pollAction
       ) {
-        throw new Error("Expected all six native iMessage action subprocesses");
+        throw new Error("Expected all seven native iMessage action subprocesses");
       }
+      expect(actionValue(dunderReferenceAction, "--text")).toBe(
+        "Class (https://example.org/python) done",
+      );
+      expect(JSON.parse(actionValue(dunderReferenceAction, "--format"))).toEqual([
+        { start: 35, length: 4, styles: ["bold"] },
+      ]);
       expect(replyAction).toContain("--reply-to");
       expect(actionValue(replyAction, "--reply-to")).toBe("reply-message-guid");
       expect(actionValue(effectAction, "--effect")).toBe("com.apple.MobileSMS.expressivesend.loud");

--- a/packages/markdown-core/src/ir.dunder-identifiers.test.ts
+++ b/packages/markdown-core/src/ir.dunder-identifiers.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import { markdownToIR } from "./ir.js";
+
+const DUNDER_OPTIONS = {
+  autolink: false,
+  linkify: false,
+  preserveDunderIdentifiers: true,
+} as const;
+
+describe("markdownToIR preserveDunderIdentifiers", () => {
+  it("leaves CommonMark emphasis unchanged by default", () => {
+    expect(markdownToIR("obj.__class__", { autolink: false, linkify: false })).toEqual({
+      text: "obj.class",
+      styles: [{ start: 4, end: 9, style: "bold" }],
+      links: [],
+    });
+  });
+
+  it("keeps ordinary parenthesized bold unchanged when enabled", () => {
+    expect(markdownToIR("(__warning__)", DUNDER_OPTIONS)).toEqual({
+      text: "(warning)",
+      styles: [{ start: 1, end: 8, style: "bold" }],
+      links: [],
+    });
+  });
+
+  it.each([
+    ["member access", "obj.__class__"],
+    ["call", "__init__()"],
+    ["function argument", "print(__name__)"],
+    ["index", '__dict__["key"]'],
+  ])("preserves %s identifiers", (_name, source) => {
+    expect(markdownToIR(source, DUNDER_OPTIONS)).toEqual({
+      text: source,
+      styles: [],
+      links: [],
+    });
+  });
+
+  it.each([
+    {
+      name: "full",
+      source: "[Class][obj.__class__]\n\n[obj.__class__]: https://example.org/python",
+      text: "Class",
+      end: 5,
+    },
+    {
+      name: "collapsed",
+      source: "[obj.__class__][]\n\n[obj.__class__]: https://example.org/python",
+      text: "obj.__class__",
+      end: 13,
+    },
+    {
+      name: "shortcut",
+      source: "[obj.__class__]\n\n[obj.__class__]: https://example.org/python",
+      text: "obj.__class__",
+      end: 13,
+    },
+    {
+      name: "case-normalized",
+      source: "[Class][OBJ.__CLASS__]\n\n[obj.__class__]: https://example.org/python",
+      text: "Class",
+      end: 5,
+    },
+    {
+      name: "whitespace-normalized",
+      source: "[Class][obj. __class__]\n\n[obj.\t__class__]: https://example.org/python",
+      text: "Class",
+      end: 5,
+    },
+  ])("preserves $name reference links", ({ source, text, end }) => {
+    expect(markdownToIR(source, DUNDER_OPTIONS)).toEqual({
+      text,
+      styles: [],
+      links: [{ start: 0, end, href: "https://example.org/python" }],
+    });
+  });
+
+  it("preserves repeated reference destinations", () => {
+    const href = "https://docs.python.org/3/library/stdtypes.html#instance.__class__";
+    expect(
+      markdownToIR(`[Class][docs] and [Type][docs]\n\n[docs]: ${href}`, DUNDER_OPTIONS),
+    ).toEqual({
+      text: "Class and Type",
+      styles: [],
+      links: [
+        { start: 0, end: 5, href },
+        { start: 10, end: 14, href },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      name: "inline",
+      source: "`obj.__class__`",
+      text: "obj.__class__",
+      styles: [{ start: 0, end: 13, style: "code" }],
+    },
+    {
+      name: "fenced",
+      source: "```python\nobj.__class__\n```",
+      text: "obj.__class__\n",
+      styles: [{ start: 0, end: 14, style: "code_block", language: "python" }],
+    },
+    {
+      name: "indented",
+      source: "    obj.__class__",
+      text: "obj.__class__\n",
+      styles: [{ start: 0, end: 14, style: "code_block" }],
+    },
+  ])("leaves $name code handling unchanged", ({ source, text, styles }) => {
+    expect(markdownToIR(source, DUNDER_OPTIONS)).toEqual({
+      text,
+      styles,
+      links: [],
+    });
+  });
+});

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -270,6 +270,8 @@ export type MarkdownParseOptions = {
   horizontalRuleText?: string;
   /** Preserve source line spacing after headings and code blocks. */
   preserveSourceBlockSpacing?: boolean;
+  /** Preserve Python-style dunder identifiers in code-like contexts. */
+  preserveDunderIdentifiers?: boolean;
 };
 
 function appendHeadingSeparator(state: RenderState, nextBlockStart: number | undefined) {
@@ -298,6 +300,13 @@ function createMarkdownIt(options: MarkdownParseOptions): MarkdownItParser {
   md.linkify.set({ fuzzyLink: true });
   md.use(markdownItCjkFriendly);
   md.use(markdownItAssistantTranscriptRoles);
+  if (options.preserveDunderIdentifiers) {
+    md.inline.ruler.before(
+      "emphasis",
+      "markdown_core_dunder_identifiers",
+      preserveDunderIdentifier,
+    );
+  }
   if (options.enableTaskLists) {
     md.core.ruler.before("inline", "markdown_core_task_lists", protectTaskListMarkers);
   }
@@ -322,6 +331,32 @@ function createMarkdownIt(options: MarkdownParseOptions): MarkdownItParser {
     md.disable("autolink");
   }
   return md;
+}
+
+function preserveDunderIdentifier(state: StateInline, silent: boolean): boolean {
+  const match = /^__[\p{L}_][\p{L}\p{N}_]*__/u.exec(state.src.slice(state.pos, state.posMax));
+  if (!match) {
+    return false;
+  }
+  const identifier = match[0];
+  const end = state.pos + identifier.length;
+  const before = state.src[state.pos - 1];
+  const beforeBefore = state.src[state.pos - 2];
+  const after = end < state.posMax ? state.src[end] : undefined;
+  const member = before === ".";
+  const call = after === "(";
+  const functionArgument = before === "(" && /[\p{L}\p{N}_]/u.test(beforeBefore ?? "");
+  const index = after === "[";
+  if (!member && !call && !functionArgument && !index) {
+    return false;
+  }
+  // markdown-it also invokes matching rules silently while scanning labels;
+  // both modes must consume the same source span.
+  if (!silent) {
+    state.push("text", "", 0).content = identifier;
+  }
+  state.pos = end;
+  return true;
 }
 
 function protectTaskListMarkers(state: StateCore): void {

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -270,7 +270,10 @@ export type MarkdownParseOptions = {
   horizontalRuleText?: string;
   /** Preserve source line spacing after headings and code blocks. */
   preserveSourceBlockSpacing?: boolean;
-  /** Preserve Python-style dunder identifiers in code-like contexts. */
+  /**
+   * Treat Python-style `__name__` member, call, argument, and index identifiers as literal text
+   * instead of emphasis delimiters. Disabled by default.
+   */
   preserveDunderIdentifiers?: boolean;
 };
 


### PR DESCRIPTION
## Summary

- preserve Markdown reference labels containing `__dunder__` identifiers before emphasis parsing
- opt iMessage into that parser behavior and remove its placeholder-based protect/restore path
- define the exported parser option's durable default-off semantics
- cover repeated destinations, code spans, formatted labels, and the outbound send path

## Root cause

iMessage protected dunder identifiers by replacing them with temporary text before Markdown parsing. Reference-link parsing could duplicate or relocate those placeholders, so restoration leaked strings such as `OCdunder0token` and shifted entity offsets.

The Markdown parser owns tokenization. An opt-in inline rule now emits dunder identifiers as text in normal inline contexts before emphasis parsing, while code spans and other existing parser contexts retain their established behavior.

## Validation

- markdown-core focused tests: 15 passed
- iMessage formatter and send tests: 113 passed
- Testbox: `tbx_01m109tjst5846hs5x8wm6m7n8`
- Testbox workflow: `33026896298`
- fresh branch autoreview: clean, correctness 0.97
- `scripts/check-changed.mjs`: all applicable changed-file checks passed; dead-export scan could not resolve three existing Control UI config modules from the shared worktree dependency tree, so it discarded export findings

## Scope

- production: +42 / -64, net -22
- tests: +190 / -5
- one additive default-off Plugin SDK parser option, with explicit member/call/argument/index semantics
- no sanitizer, delivery, persistence, or config behavior changes

This is user-visible and release-note worthy; the landing release workflow owns the changelog entry.

Fixes #130497

Reported by @steipete.
