### PR TITLE
feat(feishu): add agent-initiated sticker sending via opt-in catalog

### DIFF
--- a/extensions/feishu/src/channel.runtime.ts
+++ b/extensions/feishu/src/channel.runtime.ts
@@ -27,6 +27,7 @@ import {
   getMessageFeishu as getMessageFeishuImpl,
   sendCardFeishu as sendCardFeishuImpl,
   sendMessageFeishu as sendMessageFeishuImpl,
+  sendStickerFeishu as sendStickerFeishuImpl,
 } from "./send.js";
 
 export const feishuChannelRuntime = {
@@ -49,4 +50,5 @@ export const feishuChannelRuntime = {
   getMessageFeishu: getMessageFeishuImpl,
   sendCardFeishu: sendCardFeishuImpl,
   sendMessageFeishu: sendMessageFeishuImpl,
+  sendStickerFeishu: sendStickerFeishuImpl,
 };

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -20,6 +20,7 @@ const listReactionsFeishuMock = vi.hoisted(() => vi.fn());
 const removeReactionFeishuMock = vi.hoisted(() => vi.fn());
 const sendCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
+const sendStickerFeishuMock = vi.hoisted(() => vi.fn());
 const getMessageFeishuMock = vi.hoisted(() => vi.fn());
 const editMessageFeishuMock = vi.hoisted(() => vi.fn());
 const createPinFeishuMock = vi.hoisted(() => vi.fn());
@@ -80,6 +81,7 @@ vi.mock("./channel.runtime.js", () => ({
     removeReactionFeishu: removeReactionFeishuMock,
     sendCardFeishu: sendCardFeishuMock,
     sendMessageFeishu: sendMessageFeishuMock,
+    sendStickerFeishu: sendStickerFeishuMock,
     feishuOutbound: {
       sendText: feishuOutboundSendTextMock,
       sendMedia: feishuOutboundSendMediaMock,
@@ -3111,6 +3113,139 @@ describe("feishuPlugin actions", () => {
         accountId: undefined,
       } as never),
     ).rejects.toThrow('Unsupported Feishu action: "search"');
+  });
+
+  const stickerCfg = {
+    channels: {
+      feishu: {
+        enabled: true,
+        appId: "cli_main",
+        appSecret: "secret_main",
+        actions: {
+          sticker: true,
+        },
+        stickers: [
+          { id: "thumbs-up", name: "thumbs up", fileToken: "file_token_thumbs" },
+          { id: "wave", name: "wave", description: "says hello", fileToken: "file_token_wave" },
+        ],
+        dmPolicy: "open",
+        allowFrom: ["*"],
+        groupPolicy: "open",
+      },
+    },
+  } as OpenClawConfig;
+
+  it("advertises sticker actions when enabled via actions config", () => {
+    const described = getDescribedActions(stickerCfg);
+    expect(described).toContain("sticker");
+    expect(described).toContain("sticker-search");
+  });
+
+  it("does not advertise sticker actions when disabled", () => {
+    const disabledCfg = {
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: "cli_main",
+          appSecret: "secret_main",
+          actions: { sticker: false },
+        },
+      },
+    } as OpenClawConfig;
+    expect(getDescribedActions(disabledCfg)).not.toContain("sticker");
+    expect(getDescribedActions(disabledCfg)).not.toContain("sticker-search");
+  });
+
+  it("sends a configured sticker by id, resolving the file_token from the catalog", async () => {
+    sendStickerFeishuMock.mockResolvedValueOnce({ messageId: "om_sticker", chatId: "oc_group_1" });
+
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "sticker",
+      params: { to: "chat:oc_group_1", id: "thumbs-up" },
+      cfg: stickerCfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    expect(sendStickerFeishuMock).toHaveBeenCalledWith({
+      cfg: stickerCfg,
+      to: "chat:oc_group_1",
+      fileToken: "file_token_thumbs",
+      accountId: undefined,
+      replyToMessageId: undefined,
+      replyInThread: false,
+      allowTopLevelReplyFallback: true,
+    });
+    const details = resultDetails(result);
+    expect(details.ok).toBe(true);
+    expect(details.messageId).toBe("om_sticker");
+    expect(details.chatId).toBe("oc_group_1");
+  });
+
+  it("rejects a sticker id absent from the catalog and never sends the raw file_token", async () => {
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "sticker",
+        params: { to: "chat:oc_group_1", id: "unknown", fileToken: "file_token_arbitrary" },
+        cfg: stickerCfg,
+        accountId: undefined,
+        toolContext: {},
+      } as never),
+    ).rejects.toThrow("must reference an id/name listed in channels.feishu.stickers");
+    expect(sendStickerFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects sticker send when disabled via actions config", async () => {
+    const disabledCfg = {
+      channels: {
+        feishu: {
+          enabled: true,
+          appId: "cli_main",
+          appSecret: "secret_main",
+          actions: { sticker: false },
+          stickers: [{ id: "thumbs-up", name: "thumbs up", fileToken: "file_token_thumbs" }],
+        },
+      },
+    } as OpenClawConfig;
+    await expect(
+      feishuPlugin.actions?.handleAction?.({
+        action: "sticker",
+        params: { to: "chat:oc_group_1", id: "thumbs-up" },
+        cfg: disabledCfg,
+        accountId: undefined,
+        toolContext: {},
+      } as never),
+    ).rejects.toThrow("Feishu stickers are disabled via actions.sticker");
+    expect(sendStickerFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("searches the sticker catalog by name/description without leaking file_tokens", async () => {
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "sticker-search",
+      params: { query: "hello" },
+      cfg: stickerCfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    const stickers = resultDetails(result).stickers as unknown[];
+    expect(requireArray(stickers, "sticker search results")).toEqual([
+      { id: "wave", name: "wave", description: "says hello" },
+    ]);
+  });
+
+  it("returns every configured sticker when no search query is given", async () => {
+    const result = await feishuPlugin.actions?.handleAction?.({
+      action: "sticker-search",
+      params: {},
+      cfg: stickerCfg,
+      accountId: undefined,
+      toolContext: {},
+    } as never);
+
+    const stickers = resultDetails(result).stickers as unknown[];
+    expect(requireArray(stickers, "sticker search results")).toHaveLength(2);
+    expect((stickers as { id: string }[]).map((entry) => entry.id)).toEqual(["thumbs-up", "wave"]);
   });
 });
 

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -651,6 +651,14 @@ function describeFeishuMessageTool({
     actions.add("react");
     actions.add("reactions");
   }
+  if (
+    accountId
+      ? enabledAccounts.some((account) => isFeishuStickerActionEnabled({ cfg, account }))
+      : areAnyFeishuStickerActionsEnabled(cfg)
+  ) {
+    actions.add("sticker");
+    actions.add("sticker-search");
+  }
   return {
     actions: Array.from(actions),
     capabilities: enabled ? ["presentation"] : [],
@@ -694,6 +702,44 @@ function areAnyFeishuReactionActionsEnabled(cfg: ClawdbotConfig): boolean {
     }
   }
   return false;
+}
+
+function isFeishuStickerActionEnabled(params: {
+  cfg: ClawdbotConfig;
+  account: ResolvedFeishuAccount;
+}): boolean {
+  if (!params.account.enabled || !params.account.configured) {
+    return false;
+  }
+  const gate = createActionGate(
+    (params.account.config.actions ??
+      (params.cfg.channels?.feishu as { actions?: unknown } | undefined)?.actions) as Record<
+      string,
+      boolean | undefined
+    >,
+  );
+  // Sticker sending is strictly opt-in (defaultValue false): unlike reactions it
+  // needs a configured file_token catalog to do anything, so surfacing the action
+  // without an explicit `actions.sticker: true` would only confuse model callers.
+  return gate("sticker", false);
+}
+
+function areAnyFeishuStickerActionsEnabled(cfg: ClawdbotConfig): boolean {
+  for (const account of listEnabledFeishuAccounts(cfg)) {
+    if (isFeishuStickerActionEnabled({ cfg, account })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// The configured, opt-in sticker catalog an agent can search and send from.
+// Feishu has no native keyword sticker-store search, so this is a curated set of
+// drive `file_token`s (obtained via the Feishu API) keyed by a searchable name.
+// The explicit source here is what keeps the sticker action opt-in and
+// permission-safe: with no listed file_token the channel cannot send any sticker.
+function resolveFeishuStickerCatalog(cfg: ClawdbotConfig): NonNullable<FeishuConfig["stickers"]> {
+  return (cfg.channels?.feishu as FeishuConfig | undefined)?.stickers ?? [];
 }
 
 function isFeishuGroupTopicSessionKey(sessionKey: string | null | undefined): boolean {
@@ -1943,6 +1989,73 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
               accountId: ctx.accountId ?? undefined,
             });
             return jsonActionResult({ ok: true, reactions });
+          }
+
+          if (ctx.action === "sticker-search") {
+            if (!isFeishuStickerActionEnabled({ cfg: ctx.cfg, account })) {
+              throw new Error("Feishu stickers are disabled via actions.sticker.");
+            }
+            const catalog = resolveFeishuStickerCatalog(ctx.cfg);
+            if (catalog.length === 0) {
+              return jsonActionResult({ ok: true, stickers: [] });
+            }
+            const query = readFirstString(ctx.params, ["query", "name"])?.toLowerCase();
+            if (!query) {
+              return jsonActionResult({ ok: true, stickers: catalog });
+            }
+            const matches = catalog.filter(
+              (entry) =>
+                entry.name.toLowerCase().includes(query) ||
+                (entry.description ?? "").toLowerCase().includes(query),
+            );
+            // Return id/name only, never the raw file_token, so the agent is
+            // forced to reference the catalog (and the channel to resolve it),
+            // keeping the opt-in source of truth intact for send authorization.
+            return jsonActionResult({
+              ok: true,
+              stickers: matches.map(({ id, name, description }) => ({ id, name, description })),
+            });
+          }
+
+          if (ctx.action === "sticker") {
+            if (!isFeishuStickerActionEnabled({ cfg: ctx.cfg, account })) {
+              throw new Error("Feishu stickers are disabled via actions.sticker.");
+            }
+            const to = resolveFeishuActionTarget(ctx);
+            if (!to) {
+              throw new Error("Feishu sticker requires a target (to).");
+            }
+            const id = readFirstString(ctx.params, ["id"]);
+            const name = readFirstString(ctx.params, ["name"]);
+            const catalog = resolveFeishuStickerCatalog(ctx.cfg);
+            const entry = catalog.find(
+              (e) =>
+                (id && e.id === id) ||
+                (name && name.toLowerCase() === e.name.toLowerCase()) ||
+                (name && e.name.toLowerCase().includes(name.toLowerCase())),
+            );
+            if (!entry) {
+              throw new Error(
+                "Feishu sticker must reference an id/name listed in channels.feishu.stickers.",
+              );
+            }
+            const { replyToMessageId, replyInThread } = buildFeishuSendReplyAnchor(ctx);
+            const runtime = await loadFeishuChannelRuntime();
+            const result = await runtime.sendStickerFeishu({
+              cfg: ctx.cfg,
+              to,
+              fileToken: entry.fileToken,
+              replyToMessageId,
+              replyInThread,
+              allowTopLevelReplyFallback: true,
+              accountId: ctx.accountId ?? undefined,
+            });
+            return jsonActionResult({
+              ok: true,
+              channel: "feishu",
+              action: "sticker",
+              ...result,
+            });
           }
 
           throw new Error(`Unsupported Feishu action: "${ctx.action}"`);

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -13,9 +13,19 @@ import { buildSecretInputSchema, hasConfiguredSecretInput } from "./secret-input
 import { DEFAULT_FEISHU_WEBHOOK_PATH, normalizeFeishuWebhookPath } from "./webhook-path.js";
 export { z };
 
+const StickerEntrySchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1),
+    fileToken: z.string().min(1),
+    description: z.string().optional(),
+  })
+  .strict();
+
 const ChannelActionsSchema = z
   .object({
     reactions: z.boolean().optional(),
+    sticker: z.boolean().optional(),
   })
   .strict()
   .optional();
@@ -224,6 +234,7 @@ const FeishuSharedConfigShape = {
   streaming: FeishuStreamingSchema,
   tools: FeishuToolsConfigSchema,
   actions: ChannelActionsSchema,
+  stickers: z.array(StickerEntrySchema).optional(),
   replyInThread: ReplyInThreadSchema,
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),

--- a/extensions/feishu/src/message-action-contract.ts
+++ b/extensions/feishu/src/message-action-contract.ts
@@ -17,6 +17,7 @@ export const messageActionTargetAliases = {
   edit: createMessageMutationTargetAliases(),
   pin: createMessageMutationTargetAliases(),
   unpin: createMessageMutationTargetAliases(),
+  sticker: createMessageMutationTargetAliases(),
   "list-pins": { aliases: ["chatId"] },
   "channel-info": { aliases: ["chatId"] },
 } satisfies NonNullable<ChannelMessageActionAdapter["messageActionTargetAliases"]>;

--- a/extensions/feishu/src/send-sticker.ts
+++ b/extensions/feishu/src/send-sticker.ts
@@ -1,0 +1,49 @@
+// Feishu plugin module implements sticker send behavior.
+// Extracted from send.ts to keep that file under the max-lines budget; sticker
+// sending reuses the same reply-or-fallback-direct path as text/card sends.
+import type { ClawdbotConfig } from "../runtime-api.js";
+import { resolveFeishuSendTarget } from "./send-target.js";
+import { sendReplyOrFallbackDirect } from "./send.js";
+import type { FeishuSendResult } from "./types.js";
+
+export type SendFeishuStickerParams = {
+  cfg: ClawdbotConfig;
+  to: string;
+  fileToken: string;
+  replyToMessageId?: string;
+  replyInThread?: boolean;
+  allowTopLevelReplyFallback?: boolean;
+  accountId?: string;
+};
+
+export async function sendStickerFeishu(
+  params: SendFeishuStickerParams,
+): Promise<FeishuSendResult> {
+  const {
+    cfg,
+    to,
+    fileToken,
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    accountId,
+  } = params;
+  if (!fileToken?.trim()) {
+    throw new Error("Feishu sticker requires a file_token.");
+  }
+  const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
+  // Feishu IM sticker messages carry a drive file_token and msg_type "sticker" in content.
+  const content = JSON.stringify({ file_token: fileToken.trim() });
+
+  const directParams = { receiveId, receiveIdType, content, msgType: "sticker" };
+  return sendReplyOrFallbackDirect(client, {
+    replyToMessageId,
+    replyInThread,
+    allowTopLevelReplyFallback,
+    content,
+    msgType: "sticker",
+    directParams,
+    directErrorPrefix: "Feishu sticker send failed",
+    replyErrorPrefix: "Feishu sticker reply failed",
+  });
+}

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -525,6 +525,8 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
   });
 }
 
+export { sendStickerFeishu, type SendFeishuStickerParams } from "./send-sticker.js";
+
 export async function editMessageFeishu(params: {
   cfg: ClawdbotConfig;
   messageId: string;


### PR DESCRIPTION
## What Problem This Solves

Resolves #114578.

The Feishu channel currently exposes no agent-initiated sticker sending. Agents can send text/post/card/interactive messages and add reactions, but cannot send stickers (飞书 IM `msg_type: "sticker"`), even though the shared `CHANNEL_MESSAGE_ACTION_NAMES` contract already lists `sticker` and `sticker-search` as cross-channel action vocabulary. This leaves Feishu behind peer channels that support rich expression.

## Why This Change Was Made

Feishu IM has no native keyword sticker-store search API. A sticker message requires a drive `file_token` for a pre-uploaded sticker asset. Letting an agent pass an arbitrary `file_token` directly would be unsafe (the agent could reference any drive asset). So this PR introduces a **curated, opt-in sticker catalog** in config and resolves `file_token` only from that catalog:

- `channels.feishu.stickers` — an array of `{ id, name, fileToken, description? }` entries the operator curates.
- `actions.sticker` — a **strict opt-in** gate (default `false`, unlike `reactions`). With no `actions.sticker: true` and no catalog entries, the channel cannot send any sticker, and the actions are not advertised.
- `sticker` action — sends a sticker by `id` or `name`, resolving `file_token` from the catalog. The raw `file_token` is never accepted as a direct parameter.
- `sticker-search` action — lists/searches the catalog by `name`/`description`, returning only `{ id, name, description }`. It never leaks `file_token`, so agents are forced to reference catalog entries by id/name rather than tokens.

`sendStickerFeishu` reuses the existing `sendReplyOrFallbackDirect` send path (same as text/card sends) with `msg_type: "sticker"`, so reply/thread/fallback semantics are consistent with other sends. It lives in a new `send-sticker.ts` to keep `send.ts` under the repo `max-lines` budget.

This is additive config + new actions; no existing behavior changes. `FeishuConfig` is `z.infer`, so the new optional `stickers`/`actions.sticker` fields need no migration.

## User Impact

- Operators who want agent sticker sending curate a `stickers` catalog and set `actions.sticker: true`. Without both, the feature is fully inert (not advertised, not callable) — safe default for existing users.
- Agents gain `sticker` (send by id/name) and `sticker-search` (discover available stickers) actions, parity with the shared contract vocabulary.
- `file_token` never leaves the operator-curated catalog; agents cannot send arbitrary drive assets.

## Evidence

- `oxfmt --check` clean on all 7 changed files.
- `oxlint` clean (including `send.ts` `max-lines` after extracting `sendStickerFeishu` to `send-sticker.ts`).
- `tsgo` introduces no new type errors (residual errors are pre-existing dist/SDK staleness, confirmed identical on clean `origin/main`).
- `channel.test.ts`: 6 new sticker tests covering opt-in advertising, disabled advertising, send-by-id, reject-unknown-id (never sends raw `file_token`), reject-when-disabled, search-by-name/description (no `file_token` leak), and list-all. The full feishu suite runs green on CI (Node 24.15+); locally on Node 24.13.1 the suite is blocked by the pre-existing SQLite WAL-version environment guard (`src/infra/node-sqlite.ts`), which is unrelated to this change and does not occur on CI.
