### PR TITLE
fix: retain best-effort cron context for follow-up replies

### DIFF
--- a/.agents/skills/telegram-e2e-userbot/scripts/run-mock-sut-user-e2e.mjs
+++ b/.agents/skills/telegram-e2e-userbot/scripts/run-mock-sut-user-e2e.mjs
@@ -691,6 +691,7 @@ async function runCronScenarioAction({
   gatewayEnv,
   cronDeliveryTarget,
   message,
+  bestEffort,
   isStopped,
 }) {
   let jobId;
@@ -717,6 +718,7 @@ async function runCronScenarioAction({
         "telegram",
         "--to",
         cronDeliveryTarget,
+        ...(bestEffort ? ["--best-effort-deliver"] : []),
         "--json",
         "--keep-after-run",
       ],
@@ -1324,6 +1326,7 @@ async function driveWithTelegramProxy(args, repoRoot, creds) {
               gatewayEnv: controlEnv,
               cronDeliveryTarget: selectedChatTarget.cronDeliveryTarget,
               message: action.message,
+              bestEffort: action.bestEffort,
               isStopped: () => controlsStopped,
             }).then(
               (result) => {

--- a/.agents/skills/telegram-e2e-userbot/scripts/scenario.mjs
+++ b/.agents/skills/telegram-e2e-userbot/scripts/scenario.mjs
@@ -9,7 +9,7 @@ const ACTION_KEYS = {
   restartGateway: new Set(["type", "atMs", "graceMs"]),
   patchConfig: new Set(["type", "atMs", "patch"]),
   systemEvent: new Set(["type", "atMs", "text"]),
-  cron: new Set(["type", "atMs", "message"]),
+  cron: new Set(["type", "atMs", "message", "bestEffort"]),
   command: new Set(["type", "atMs", "argv", "cwd", "timeoutMs"]),
   telegramApiHold: new Set(["type", "atMs", "method", "skip"]),
   telegramApiWaitHeld: new Set(["type", "atMs", "method", "timeoutMs"]),
@@ -77,10 +77,14 @@ export function parseScenario(value) {
       return { type: action.type, atMs, text: nonEmptyString(action.text, `${label}.text`) };
     }
     if (action.type === "cron") {
+      if (action.bestEffort !== undefined && typeof action.bestEffort !== "boolean") {
+        throw new Error(`${label}.bestEffort must be a boolean.`);
+      }
       return {
         type: action.type,
         atMs,
         message: nonEmptyString(action.message, `${label}.message`),
+        ...(action.bestEffort === true ? { bestEffort: true } : {}),
       };
     }
     if (action.type === "command") {

--- a/.agents/skills/telegram-e2e-userbot/scripts/scenario.test.mjs
+++ b/.agents/skills/telegram-e2e-userbot/scripts/scenario.test.mjs
@@ -20,7 +20,7 @@ test("normalizes Telegram and gateway actions", () => {
         },
         { type: "patchConfig", atMs: 750, patch: { channels: { telegram: { historyLimit: 9 } } } },
         { type: "systemEvent", atMs: 900, text: "heartbeat proof" },
-        { type: "cron", atMs: 950, message: "deliver the schedule" },
+        { type: "cron", atMs: 950, message: "deliver the schedule", bestEffort: true },
         { type: "command", atMs: 975, argv: ["node", "--version"], cwd: "repo" },
         { type: "telegramApiHold", atMs: 980, method: "sendMessage", skip: 1 },
         { type: "telegramApiWaitHeld", atMs: 990, method: "sendMessage" },
@@ -48,7 +48,7 @@ test("normalizes Telegram and gateway actions", () => {
           patch: { channels: { telegram: { historyLimit: 9 } } },
         },
         { type: "systemEvent", atMs: 900, text: "heartbeat proof" },
-        { type: "cron", atMs: 950, message: "deliver the schedule" },
+        { type: "cron", atMs: 950, message: "deliver the schedule", bestEffort: true },
         {
           type: "command",
           atMs: 975,
@@ -112,6 +112,10 @@ test("rejects fields and action types outside the closed schema", () => {
   assert.throws(
     () => parseScenario({ actions: [{ type: "restartGateway", atMs: -1 }] }),
     /atMs must be a non-negative integer/u,
+  );
+  assert.throws(
+    () => parseScenario({ actions: [{ type: "cron", message: "deliver", bestEffort: "yes" }] }),
+    /bestEffort must be a boolean/u,
   );
 });
 

--- a/src/channels/inbound-event/session-transcript-context.runtime.test.ts
+++ b/src/channels/inbound-event/session-transcript-context.runtime.test.ts
@@ -59,6 +59,34 @@ describe("session transcript inbound context", () => {
     ]);
   });
 
+  it("restores marked Cron delivery context when no live chat window survives", async () => {
+    readRecent.mockImplementation(async (params) =>
+      params.includeCronDirectDeliveryContext
+        ? [{ id: "cron-1", role: "assistant", text: "scheduled payload", timestamp: 2_000 }]
+        : [],
+    );
+    const ctx = context({
+      SessionTranscriptContext: { chatWindow: true, historyLimit: 3 },
+    });
+
+    await mergeSessionTranscriptContext({
+      agentId: "main",
+      ctx,
+      sessionKey: ctx.SessionKey!,
+      storePath: "/tmp/sessions.json",
+    });
+
+    expect(ctx.ChannelStructuredContext).toEqual([
+      expect.objectContaining({
+        source: "session",
+        type: "chat_window",
+        payload: expect.objectContaining({
+          messages: [expect.objectContaining({ body: "scheduled payload" })],
+        }),
+      }),
+    ]);
+  });
+
   it("dedupes the canonical turn against the live window and merges chronologically", async () => {
     readRecent.mockResolvedValue([
       { id: "u1", role: "user", text: "cached user turn", timestamp: 1_000 },
@@ -132,6 +160,7 @@ describe("session transcript inbound context", () => {
       storePath: "/tmp/sessions.json",
     });
 
+    expect(readRecent.mock.calls[0]?.[0]).not.toHaveProperty("includeCronDirectDeliveryContext");
     expect(ctx.ChannelStructuredContext?.[0]).toMatchObject({
       source: "session",
       payload: {

--- a/src/channels/inbound-event/session-transcript-context.runtime.ts
+++ b/src/channels/inbound-event/session-transcript-context.runtime.ts
@@ -119,11 +119,15 @@ export async function mergeSessionTranscriptContext(params: {
   if (!agentId) {
     throw new Error("Session transcript context requires an agent owner.");
   }
+  const windows = chatWindowEntries(params.ctx);
   const turns = await readRecentUserAssistantTextForSession({
     agentId,
     sessionKey: params.sessionKey,
     storePath: params.storePath,
     limit,
+    ...(windows.length === 0 && options?.chatWindow === true
+      ? { includeCronDirectDeliveryContext: true }
+      : {}),
     ...((options?.beforeTimestampMs ?? params.ctx.Timestamp) !== undefined
       ? { beforeTimestampMs: options?.beforeTimestampMs ?? params.ctx.Timestamp }
       : {}),
@@ -154,7 +158,6 @@ export async function mergeSessionTranscriptContext(params: {
   if (transcript.length === 0) {
     return;
   }
-  const windows = chatWindowEntries(params.ctx);
   if (windows.length === 0 && options?.chatWindow) {
     params.ctx.ChannelStructuredContext = [
       ...(params.ctx.ChannelStructuredContext ?? []),

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -9,6 +9,7 @@ import { normalizeLegacySessionEntryDelivery } from "../../infra/state-migration
 import * as transcriptEvents from "../../sessions/transcript-events.js";
 import type { InternalSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
 import {
+  CRON_DIRECT_DELIVERY_CONTEXT_KIND,
   OPENCLAW_DELIVERY_MIRROR_MODEL,
   OPENCLAW_TRANSCRIPT_ARTIFACT_API,
   OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER,
@@ -1012,6 +1013,52 @@ describe("appendAssistantMessageToSessionTranscript", () => {
         text: "from shared session",
         timestamp: 4_000,
       },
+    ]);
+  });
+
+  it("admits only marked Cron delivery context when explicitly requested", async () => {
+    await writeTranscriptStore();
+    await persistSessionTranscriptTurn(createFixtureTranscriptScope(), {
+      updateMode: "none",
+      messages: [
+        { eventId: "user", message: { role: "user", content: "ordinary user" } },
+        { eventId: "assistant", message: { role: "assistant", content: "ordinary assistant" } },
+      ],
+    });
+    await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      text: "scheduled result",
+      idempotencyKey: "cron-delivery",
+      deliveryMirror: { kind: CRON_DIRECT_DELIVERY_CONTEXT_KIND },
+    });
+    await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      text: "ordinary delivery mirror",
+      idempotencyKey: "channel-delivery",
+      deliveryMirror: { kind: "channel-final" },
+    });
+    const params = {
+      agentId: "main",
+      sessionKey,
+      storePath: fixture.storePath(),
+      limit: 10,
+    };
+
+    await expect(readRecentUserAssistantTextForSession(params)).resolves.toEqual([
+      expect.objectContaining({ role: "user", text: "ordinary user" }),
+      expect.objectContaining({ role: "assistant", text: "ordinary assistant" }),
+    ]);
+    await expect(
+      readRecentUserAssistantTextForSession({
+        ...params,
+        includeCronDirectDeliveryContext: true,
+      }),
+    ).resolves.toEqual([
+      expect.objectContaining({ role: "user", text: "ordinary user" }),
+      expect.objectContaining({ role: "assistant", text: "ordinary assistant" }),
+      expect.objectContaining({ role: "assistant", text: "scheduled result" }),
     ]);
   });
 

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -15,10 +15,11 @@ import {
   extractFirstTextBlock,
 } from "../../shared/chat-message-content.js";
 import {
+  CRON_DIRECT_DELIVERY_CONTEXT_KIND,
   OPENCLAW_DELIVERY_MIRROR_MODEL,
   OPENCLAW_TRANSCRIPT_ARTIFACT_API,
   OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER,
-  isTranscriptOnlyOpenClawAssistantModel,
+  isTranscriptOnlyOpenClawAssistantMessage,
 } from "../../shared/transcript-only-openclaw-assistant.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import {
@@ -101,6 +102,9 @@ type InternalSessionTranscriptDeliveryMirror =
       final: boolean;
       sourceTurnId?: string;
       toolCallId?: string;
+    }
+  | {
+      kind: typeof CRON_DIRECT_DELIVERY_CONTEXT_KIND;
     };
 
 export type SessionTranscriptAssistantMessage = Parameters<SessionManager["appendMessage"]>[0] & {
@@ -123,6 +127,7 @@ export type SessionRecentConversationText = {
 
 type ReadRecentSessionConversationTextOptions = {
   beforeTimestampMs?: number;
+  includeCronDirectDeliveryContext?: boolean;
   limit?: number;
   minTimestampMs?: number;
   role?: "user" | "assistant";
@@ -186,13 +191,6 @@ function parseAssistantTranscriptText(
   };
 }
 
-function isTranscriptOnlyOpenClawAssistantMessage(message: {
-  provider?: unknown;
-  model?: unknown;
-}): boolean {
-  return isTranscriptOnlyOpenClawAssistantModel(message.provider, message.model);
-}
-
 type SessionConversationTranscriptTarget = {
   sqliteScope?: SqliteSessionFileMarker;
 };
@@ -212,6 +210,7 @@ function parseRecentConversationText(
         provenance?: unknown;
         provider?: unknown;
         model?: unknown;
+        openclawDeliveryMirror?: unknown;
         __openclaw?: unknown;
       }
     | undefined;
@@ -222,7 +221,19 @@ function parseRecentConversationText(
   ) {
     return undefined;
   }
-  if (message.role === "assistant" && isTranscriptOnlyOpenClawAssistantMessage(message)) {
+  const deliveryMirror = message.openclawDeliveryMirror;
+  const includeCronDirectDeliveryContext =
+    options.includeCronDirectDeliveryContext === true &&
+    deliveryMirror !== null &&
+    typeof deliveryMirror === "object" &&
+    !Array.isArray(deliveryMirror) &&
+    "kind" in deliveryMirror &&
+    deliveryMirror.kind === CRON_DIRECT_DELIVERY_CONTEXT_KIND;
+  if (
+    message.role === "assistant" &&
+    isTranscriptOnlyOpenClawAssistantMessage(message) &&
+    !includeCronDirectDeliveryContext
+  ) {
     return undefined;
   }
   const upstreamUserText =
@@ -752,7 +763,8 @@ function isIdentifiedDeliveryMirror(message: SessionTranscriptAssistantMessage):
     isRedundantDeliveryMirror(message) &&
     (marker?.kind === "channel-final" ||
       marker?.kind === "channel-final-suppressed" ||
-      marker?.kind === "message-tool-source-reply")
+      marker?.kind === "message-tool-source-reply" ||
+      marker?.kind === CRON_DIRECT_DELIVERY_CONTEXT_KIND)
   );
 }
 

--- a/src/cron/isolated-agent/delivery-dispatch-awareness.ts
+++ b/src/cron/isolated-agent/delivery-dispatch-awareness.ts
@@ -21,6 +21,7 @@ import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { parseThreadSessionSuffix } from "../../routing/session-key.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { CRON_DIRECT_DELIVERY_CONTEXT_KIND } from "../../shared/transcript-only-openclaw-assistant.js";
 import type { CronJob } from "../types.js";
 import {
   buildDirectCronDeliveryIdempotencyKey,
@@ -44,6 +45,7 @@ export type DirectCronTranscriptMirror = {
   mediaUrls?: string[];
   storePath?: string;
   idempotencyKey: string;
+  deliveryMirror?: { kind: typeof CRON_DIRECT_DELIVERY_CONTEXT_KIND };
   config: OpenClawConfig;
 };
 

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1751,6 +1751,9 @@ describe("dispatchCronDelivery — double-announce guard", () => {
         mediaUrls: undefined,
       }),
     );
+    expect(
+      vi.mocked(appendAssistantMessageToSessionTranscript).mock.calls[0]?.[0],
+    ).not.toHaveProperty("deliveryMirror");
     expect(enqueueSystemEvent).toHaveBeenCalledWith("Redacted cron update.", {
       sessionKey: "agent:main:main",
       contextKey: "cron-direct-delivery:v1:cron:test-job:1000:telegram::123456:",
@@ -2113,6 +2116,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
   });
 
   it("skips main-session awareness for best-effort deliveries", async () => {
+    mockResolvedOutboundRoute();
     const params = makeBaseParams({
       synthesizedText: "Best-effort cron update.",
       deliveryBestEffort: true,
@@ -2124,6 +2128,12 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(state.deliveryAttempted).toBe(true);
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
     expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    expect(appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:telegram:direct:123456",
+        deliveryMirror: { kind: "cron-direct-delivery-context" },
+      }),
+    );
   });
 
   it("skips stale cron deliveries while still suppressing fallback main summary", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -16,6 +16,7 @@ import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
 import { isCronSessionKey } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { CRON_DIRECT_DELIVERY_CONTEXT_KIND } from "../../shared/transcript-only-openclaw-assistant.js";
 import { resolveAdmittedCronCompletionStatus } from "../completion-status.js";
 import { normalizeCronRunErrorText } from "../service/execution-errors.js";
 import type { CronResolvedDeliveryState } from "../types.js";
@@ -505,14 +506,17 @@ export async function dispatchCronDelivery(
         delivery,
         deliveryBestEffort: params.deliveryBestEffort,
       });
+      const targetSessionAwarenessText =
+        !params.deliveryBestEffort &&
+        (shouldQueueAwarenessForDelivery ||
+          !isSameSessionKey(deliverySessionKey, awarenessMainSessionKey))
+          ? deliveryAwarenessText
+          : undefined;
       // For explicit isolated deliveries that resolve to the main session, the
       // awareness queue is the intentional main-session record on the next turn;
       // adding an immediate assistant mirror would make the cron text appear twice.
-      const awarenessText = shouldQueueAwarenessForDelivery ? deliveryAwarenessText : undefined;
       const deliveryWillReachAwarenessMainSession =
-        mirrorTargetsAwarenessMainSession &&
-        shouldQueueAwarenessForDelivery &&
-        Boolean(awarenessText);
+        mirrorTargetsAwarenessMainSession && Boolean(targetSessionAwarenessText);
       // Implicit/default isolated delivery must not create main-session awareness.
       const mirrorWouldBypassIsolatedAwarenessPolicy =
         mirrorTargetsAwarenessMainSession &&
@@ -557,6 +561,10 @@ export async function dispatchCronDelivery(
             agentId: params.agentId,
           }),
           idempotencyKey: deliveryIdempotencyKey,
+          // The durable marker is a fallback only when target awareness is absent.
+          ...(targetSessionAwarenessText === undefined
+            ? { deliveryMirror: { kind: CRON_DIRECT_DELIVERY_CONTEXT_KIND } }
+            : {}),
           config: params.cfgWithAgentDefaults,
         };
         if (mirrorTargetsDeletingRunSession) {
@@ -569,20 +577,14 @@ export async function dispatchCronDelivery(
           });
         }
       }
-      if (
-        deliveryState.delivered &&
-        !params.deliveryBestEffort &&
-        deliveryAwarenessText &&
-        (shouldQueueAwarenessForDelivery ||
-          !isSameSessionKey(deliverySessionKey, awarenessMainSessionKey))
-      ) {
+      if (deliveryState.delivered && targetSessionAwarenessText) {
         await queueCronAwarenessSystemEvent({
           cfg: params.cfgWithAgentDefaults,
           jobId: params.job.id,
           agentId: params.agentId,
           deliveryIdempotencyKey,
           queueMainSession: shouldQueueAwarenessForDelivery,
-          text: deliveryAwarenessText,
+          text: targetSessionAwarenessText,
           targetSessionKey: deliverySessionKey,
         });
       }

--- a/src/shared/transcript-only-openclaw-assistant.ts
+++ b/src/shared/transcript-only-openclaw-assistant.ts
@@ -4,6 +4,7 @@
 export const OPENCLAW_TRANSCRIPT_ARTIFACT_API = "openclaw-transcript" as const;
 export const OPENCLAW_TRANSCRIPT_ARTIFACT_PROVIDER = "openclaw" as const;
 export const OPENCLAW_DELIVERY_MIRROR_MODEL = "delivery-mirror" as const;
+export const CRON_DIRECT_DELIVERY_CONTEXT_KIND = "cron-direct-delivery-context" as const;
 const OPENCLAW_GATEWAY_INJECTED_MODEL = "gateway-injected" as const;
 
 const TRANSCRIPT_ONLY_OPENCLAW_ASSISTANT_MODELS = new Set<string>([
@@ -14,6 +15,7 @@ const OPENCLAW_DELIVERY_MIRROR_KINDS = new Set([
   "channel-final",
   "channel-final-suppressed",
   "message-tool-source-reply",
+  CRON_DIRECT_DELIVERY_CONTEXT_KIND,
 ]);
 
 function isOpenClawDeliveryMirrorMarker(value: unknown): boolean {


### PR DESCRIPTION
Related: #88757

## What Problem This Solves

Fixes an issue where an operator's terse reply to a successful best-effort isolated Cron announcement could reach the model without the announcement after a Gateway restart.

For example, a scheduled check-in can ask for the operator's current weight. If the operator replies only “200 pounds,” the model needs the delivered check-in to understand what the number means.

This is the best-effort persistence slice of the broader proactive-message context problem. It does not change command Cron or every cross-session message path.

## Root Cause

Successful direct Cron delivery already writes an idempotent mirror to the destination session transcript. Normal provider context correctly filters those OpenClaw-authored mirrors.

Required delivery also queues short-lived target awareness. Best-effort delivery does not. After a restart removes the live Telegram chat window, neither source carries the scheduled message into the next ordinary reply.

## Why This Change Was Made

The repair marks a successful direct Cron mirror only when no required target-awareness event owns that context. The transcript reader keeps the marker filtered by default and admits it only when an inbound channel asks for a chat window but has no live window.

Strict delivery, explicit reply context, message-tool delivery, current-session completion, failed delivery, partial delivery, reset fencing, and cleanup keep their existing paths.

The Telegram proof runner now accepts `bestEffort: true` on its Cron scenario action. This keeps the live regression replayable without selecting a credential or bypassing the Convex lease pool.

## User Impact

After a successful best-effort isolated Cron announcement, the next ordinary reply can see the delivered content exactly once after a Gateway restart.

No config, environment variable, SQLite schema, migration, database version, public plugin API, or user-facing command changes.

## Evidence

- **Live Telegram red:** exact current main `b30cef73edae8daec41c0ba36bfbe24f02701325` delivered the scheduled result, restarted the Gateway, and processed the terse follow-up with `0` scheduled-result copies in the provider request.
- **Live Telegram green:** exact pushed head `e6cfe7587123ab9338f1671de4fc36290b5c3d49` ran the same flow with exactly `1` scheduled-result copy in the follow-up provider request.
- **Anti-cheat evidence:** each run recorded two provider requests, two distinct Telegram message IDs, a completed Cron run, completed Gateway restart, removed Cron job, complete event recording, and released runner resources.
- **Focused owner tests:** transcript `65/65`, Cron delivery `164/164`, focused channel context `2/2`, and Telegram scenario parser `5/5` passed.
- **Repository gates:** targeted format and lint, conflict markers, max-lines, assertion safety, coercion, deprecation, database-first, and import-cycle checks passed. Exact main and head builds passed their fingerprints and CLI smoke checks.
- **Production versus proof delta:** production `+44/-23` (net `+21`), unit tests `+86`, and Telegram harness `+14/-3`. The production growth carries the producer marker, default-closed selective reader, and no-live-window consumer together.

Proof limitations:

- The provider is deterministic and local. Telegram transport, Telegram user actions, Cron execution, Gateway restart, transcript persistence, and the follow-up request are real.
- PR #128845 overlaps transcript files but owns idle-session freshness, not restart context. Integration must preserve both facts if it lands first.

## Review Follow-up

- A rebase is not needed: GitHub reports this head as mergeable, and the changed owner and Telegram harness files are byte-identical between merge base `11bf3cb3d099f8a1b5db3d209b339375aef9f34d` and current main `1ab7b7533318a264be37d29dae33d7bb3aff92b0`.
- Local merge-tree checks complete without a conflict for current main plus this head and for this head plus PR #128845.
- PR #128845 remains an adjacent, distinct idle-freshness change. This PR owns restart-time context recovery, and the exact-head Telegram proof above covers that boundary.

### Sanitized Exact-Head Trace

```json
{
  "head": "e6cfe7587123ab9338f1671de4fc36290b5c3d49",
  "cron": {
    "status": "completed",
    "runStatus": "ok",
    "cleanup": "removed"
  },
  "gatewayRestart": "completed",
  "recordingComplete": true,
  "distinctTelegramMessageCount": 2,
  "scheduledResultCopiesInFollowupProviderRequest": 1,
  "verdictSha256": "42138ef9c5f787cacd3800f1f06a120a7eef02f13456655b00515acb2469c9ee"
}
```

The equivalent current-main trace recorded `scheduledResultCopiesInFollowupProviderRequest: 0`.

AI-assisted development disclosure: the implementation and tests were produced with Codex assistance under human direction and validated through the evidence above.
