### PR TITLE
fix(doctor): migrate deprecated bindings match.peer.kind dm to direct

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -78,6 +78,75 @@ describe("legacy session typing config migrate", () => {
 });
 
 describe("compatibility binding repair migrate", () => {
+  it("migrates legacy match.peer.kind dm values to direct", () => {
+    const res = migrateLegacyConfigForTest({
+      bindings: [
+        {
+          type: "route",
+          agentId: "alpha",
+          match: { channel: "telegram", peer: { kind: "dm", id: "123" } },
+        },
+        {
+          type: "route",
+          agentId: "alpha",
+          match: { channel: "telegram", peer: { kind: "group", id: "456" } },
+        },
+        { type: "route", agentId: "alpha", match: { channel: "discord" } },
+      ],
+    });
+
+    const bindings = res.config?.bindings as Array<{
+      match?: { peer?: { kind?: string } };
+    }>;
+    expect(bindings[0]?.match?.peer).toEqual({ kind: "direct", id: "123" });
+    expect(bindings[1]?.match?.peer).toEqual({ kind: "group", id: "456" });
+    expect(
+      res.changes.some((change) =>
+        change.includes(
+          'Moved deprecated bindings[].match.peer.kind "dm" → "direct" for 1 binding.',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("reports pluralized dm peer kind migrations and leaves canonical kinds untouched", () => {
+    const res = migrateLegacyConfigForTest({
+      bindings: [
+        {
+          type: "route",
+          agentId: "main",
+          match: { channel: "whatsapp", peer: { kind: "dm", id: "a" } },
+        },
+        {
+          type: "route",
+          agentId: "main",
+          match: { channel: "telegram", peer: { kind: "dm", id: "b" } },
+        },
+      ],
+    });
+
+    const bindings = res.config?.bindings as Array<{ match?: { peer?: { kind?: string } } }>;
+    expect(bindings.every((binding) => binding.match?.peer?.kind === "direct")).toBe(true);
+    expect(res.changes.some((change) => change.includes('"dm" → "direct" for 2 bindings.'))).toBe(
+      true,
+    );
+  });
+
+  it("leaves configs without dm peer kinds unchanged", () => {
+    const res = migrateLegacyConfigForTest({
+      bindings: [
+        {
+          type: "route",
+          agentId: "alpha",
+          match: { channel: "telegram", peer: { kind: "group", id: "456" } },
+        },
+      ],
+    });
+
+    expect(res.config).toBeNull();
+    expect(res.changes).toStrictEqual([]);
+  });
+
   it("prunes bindings for missing agents when agents.list is valid", () => {
     const res = repairBindingsForTest({
       agents: {

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -5,8 +5,10 @@ import { describe, expect, it } from "vitest";
 import { findLegacyConfigIssues } from "../../../config/legacy.js";
 import type { LegacyConfigMigrationContext } from "../../../config/legacy.shared.js";
 import type { OpenClawConfig } from "../../../config/types.js";
+import { validateConfigObjectRaw } from "../../../config/validation.js";
 import { legacyCodexProviderIdentityKey } from "./codex-route-model-ref.js";
 import { pruneBindingsForMissingAgents } from "./legacy-config-binding-repair.js";
+import { migrateLegacyConfig } from "./legacy-config-migrate.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./legacy-config-migrations.js";
 import { collectBlockedLegacyOpenAICodexProviderPlan } from "./legacy-config-migrations.runtime.models.js";
 
@@ -78,73 +80,99 @@ describe("legacy session typing config migrate", () => {
 });
 
 describe("compatibility binding repair migrate", () => {
-  it("migrates legacy match.peer.kind dm values to direct", () => {
-    const res = migrateLegacyConfigForTest({
+  it("migrates route and ACP dm peer kinds through validation and is idempotent", () => {
+    const raw = {
+      agents: { entries: { main: {} } },
       bindings: [
         {
           type: "route",
-          agentId: "alpha",
+          agentId: "main",
           match: { channel: "telegram", peer: { kind: "dm", id: "123" } },
         },
         {
-          type: "route",
-          agentId: "alpha",
-          match: { channel: "telegram", peer: { kind: "group", id: "456" } },
-        },
-        { type: "route", agentId: "alpha", match: { channel: "discord" } },
-      ],
-    });
-
-    const bindings = res.config?.bindings as Array<{
-      match?: { peer?: { kind?: string } };
-    }>;
-    expect(bindings[0]?.match?.peer).toEqual({ kind: "direct", id: "123" });
-    expect(bindings[1]?.match?.peer).toEqual({ kind: "group", id: "456" });
-    expect(
-      res.changes.some((change) =>
-        change.includes(
-          'Moved deprecated bindings[].match.peer.kind "dm" → "direct" for 1 binding.',
-        ),
-      ),
-    ).toBe(true);
-  });
-
-  it("reports pluralized dm peer kind migrations and leaves canonical kinds untouched", () => {
-    const res = migrateLegacyConfigForTest({
-      bindings: [
-        {
-          type: "route",
+          type: "acp",
           agentId: "main",
-          match: { channel: "whatsapp", peer: { kind: "dm", id: "a" } },
+          match: { channel: "discord", peer: { kind: "dm", id: "456" } },
+          acp: { mode: "persistent" },
         },
         {
           type: "route",
           agentId: "main",
-          match: { channel: "telegram", peer: { kind: "dm", id: "b" } },
+          match: { channel: "telegram", peer: { kind: "direct", id: "789" } },
+        },
+        {
+          type: "route",
+          agentId: "main",
+          match: { channel: "discord", peer: { kind: "group", id: "abc" } },
         },
       ],
-    });
+    };
 
-    const bindings = res.config?.bindings as Array<{ match?: { peer?: { kind?: string } } }>;
-    expect(bindings.every((binding) => binding.match?.peer?.kind === "direct")).toBe(true);
-    expect(res.changes.some((change) => change.includes('"dm" → "direct" for 2 bindings.'))).toBe(
-      true,
+    expect(findLegacyConfigIssues(raw)).toEqual([expect.objectContaining({ path: "bindings" })]);
+
+    const res = migrateLegacyConfig(raw);
+    const bindings = res.config?.bindings as Array<{ match?: { peer?: { kind?: unknown } } }>;
+    expect(bindings.map((binding) => binding.match?.peer?.kind)).toEqual([
+      "direct",
+      "direct",
+      "direct",
+      "group",
+    ]);
+    expect(res.changes).toContain(
+      'Moved deprecated bindings[].match.peer.kind "dm" → "direct" for 2 bindings.',
     );
+    expect(res.partiallyValid).toBeUndefined();
+    const validation = validateConfigObjectRaw(res.config);
+    expect(validation.ok, validation.ok ? undefined : JSON.stringify(validation.issues)).toBe(true);
+    expect(migrateLegacyConfig(res.config)).toEqual({ config: null, changes: [] });
   });
 
-  it("leaves configs without dm peer kinds unchanged", () => {
-    const res = migrateLegacyConfigForTest({
+  it("rewrites only exact dm values and leaves malformed peer kinds visible to validation", () => {
+    const raw = {
       bindings: [
         {
           type: "route",
-          agentId: "alpha",
-          match: { channel: "telegram", peer: { kind: "group", id: "456" } },
+          agentId: "main",
+          match: { channel: "telegram", peer: { kind: "dm", id: "exact" } },
+        },
+        {
+          type: "route",
+          agentId: "main",
+          match: { channel: "telegram", peer: { kind: "DM", id: "uppercase" } },
+        },
+        {
+          type: "route",
+          agentId: "main",
+          match: { channel: "telegram", peer: { kind: " dm ", id: "spaced" } },
+        },
+        {
+          type: "route",
+          agentId: "main",
+          match: { channel: "telegram", peer: { kind: 42, id: "number" } },
         },
       ],
-    });
+    };
 
-    expect(res.config).toBeNull();
-    expect(res.changes).toStrictEqual([]);
+    expect(findLegacyConfigIssues(raw)).toEqual([expect.objectContaining({ path: "bindings" })]);
+
+    const res = migrateLegacyConfig(raw);
+    const bindings =
+      (
+        res.config as {
+          bindings?: Array<{ match?: { peer?: { kind?: unknown } } }>;
+        }
+      )?.bindings ?? [];
+    expect(bindings.map((binding) => binding.match?.peer?.kind)).toEqual([
+      "direct",
+      "DM",
+      " dm ",
+      42,
+    ]);
+    expect(res.changes).toContain(
+      'Moved deprecated bindings[].match.peer.kind "dm" → "direct" for 1 binding.',
+    );
+    expect(res.partiallyValid).toBe(true);
+    expect(validateConfigObjectRaw(res.config).ok).toBe(false);
   });
 
   it("prunes bindings for missing agents when agents.list is valid", () => {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
@@ -1263,8 +1263,46 @@ function listInheritedProviderPoliciesWithProfiles(
   return entries;
 }
 
+function bindingMatchHasLegacyDmPeerKind(binding: unknown): boolean {
+  const match = getRecord(getRecord(binding)?.match);
+  const peer = getRecord(match?.peer);
+  return peer !== null && peer.kind === "dm";
+}
+
+const BINDING_DM_PEER_KIND_RULE: LegacyConfigRule = {
+  path: ["bindings"],
+  message:
+    'bindings[].match.peer.kind uses the retired "dm" alias; use "direct". Run "openclaw doctor --fix".',
+  match: (value) =>
+    Array.isArray(value) && value.some((binding) => bindingMatchHasLegacyDmPeerKind(binding)),
+};
+
 /** Legacy config migration specs for agent/runtime-owned config keys. */
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "bindings.match.peer.kind.dm-to-direct",
+    describe: "Move deprecated bindings match.peer.kind dm values to direct",
+    legacyRules: [BINDING_DM_PEER_KIND_RULE],
+    apply: (raw, changes) => {
+      if (!Array.isArray(raw.bindings)) {
+        return;
+      }
+      let migrated = 0;
+      for (const binding of raw.bindings) {
+        const match = getRecord(getRecord(binding)?.match);
+        const peer = getRecord(match?.peer);
+        if (peer !== null && peer.kind === "dm") {
+          peer.kind = "direct";
+          migrated += 1;
+        }
+      }
+      if (migrated > 0) {
+        changes.push(
+          `Moved deprecated bindings[].match.peer.kind "dm" → "direct" for ${migrated} binding${migrated === 1 ? "" : "s"}.`,
+        );
+      }
+    },
+  }),
   defineLegacyConfigMigration({
     id: "tools.profile-configured-sections-alsoAllow",
     describe: "Repair explicit configured-section tool grants filtered by profiles",


### PR DESCRIPTION
## What Problem This Solves

Stable `2026.7.1-2` configurations can contain `bindings[].match.peer.kind: "dm"`. Current strict validation accepts only the canonical `"direct"` value, but Doctor previously had no migration for this retired alias. The remaining validation error prevented Doctor's atomic write, so an otherwise fully migrated config still could not start the Gateway.

Closes #130523.

## Why This Change Was Made

The compatibility owner is the existing Doctor registry in `src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts`. This change adds one registered rule there: detect exact `"dm"` peer kinds and rewrite them to `"direct"` before strict validation. Runtime validation stays canonical; no alias or fallback is reintroduced.

The migration covers both route and ACP bindings, preserves canonical values, ignores non-exact/malformed values, reports the number changed, and is idempotent.

## User Impact

Upgrading users can run `openclaw doctor --fix` and persist the complete stable-config repair instead of manually editing binding kinds before the Gateway can reach ready.

**Release-note context:** Doctor now migrates legacy binding peer kind `dm` to `direct` so stable configurations upgrade cleanly.

## Provenance

- Stable `v2026.7.1-2` accepted this stored value.
- The strict-schema retirement was carried by #111142 / `58452de711884d4dbfd4c7899c2bc597e5bb524e`, authored and merged by @steipete on July 19, 2026, without a matching binding migration.
- This repair remains on contributor KevinZhou/@pengzh1's branch and preserves their production commit as the parent change.

## Scope

- Production: `+38/-0` in the existing runtime-agent Doctor migration owner.
- Tests: `+97/-0` at the real migration + strict-validation boundary.
- No `CHANGELOG.md` edit; OpenClaw contributor PR policy keeps release-note context in this body.

## Full Issue-Config CLI Proof

The isolated fixture contains every legacy key family listed in #130523:

```text
meta.lastTouchedAt
agents.defaults.compaction.memoryFlush.prompt
agents.defaults.compaction.memoryFlush.systemPrompt
agents.defaults.compaction.reserveTokensFloor
agents.defaults.cliBackends
agents.defaults.memorySearch
tools.media.image.models
tools.media.audio.models
bindings[route].match.peer.kind = "dm"
bindings[acp].match.peer.kind = "dm"
commands.ownerDisplay
memory.backend
memory.qmd
plugins.bundledDiscovery
```

### Current main before this repair

```text
config validate --json: rc=1
doctor --fix --non-interactive --yes: rc=1
config SHA before: 20f577299eb0731895543338764d652558c588b2d63bcc0bbb273045823846c5
config SHA after:  20f577299eb0731895543338764d652558c588b2d63bcc0bbb273045823846c5
remaining validation paths:
  bindings.0 (route peer kind "dm")
  bindings.1 (ACP peer kind "dm")
result: repaired candidate rejected; no config changes written
```

This proves the existing migration set repairs every other reported key but cannot persist the candidate while the two binding aliases remain.

### This branch

```text
doctor --fix --non-interactive --yes: rc=0
change: Moved deprecated bindings[].match.peer.kind "dm" → "direct" for 2 bindings.
config SHA before: 20f577299eb0731895543338764d652558c588b2d63bcc0bbb273045823846c5
config SHA after:  08a89d44beacad8ce47ef7f349f021116278a4cfd9c97d715e516e0707455a4b

persisted assertions:
  route peer kind = "direct"
  ACP peer kind = "direct"
  every other legacy key listed above removed or migrated

config validate --json:
  {"valid":true,"warnings":[]}

second doctor --fix: rc=0
second-pass SHA before: 08a89d44beacad8ce47ef7f349f021116278a4cfd9c97d715e516e0707455a4b
second-pass SHA after:  08a89d44beacad8ce47ef7f349f021116278a4cfd9c97d715e516e0707455a4b
result: byte-idempotent
```

### Isolated Gateway

The repaired config was started with an isolated state directory, token, and dynamically selected free loopback port:

```text
[gateway] http server listening
[gateway] ready
GET /health -> {"ok":true,"status":"live"}
openclaw gateway health --json -> {"ok":true,...}
shutdown -> clean; task-owned listener removed
```

## Verification

- Focused migration suite: `182 passed`.
- Migration-validation, migration E2E, and agent-schema suites: `3 + 7 + 17 passed`.
- Final focused migration/validation/schema rerun: green.
- Native `scripts/pr review-tests` on exact head: passed.
- `pnpm check:test-types`: passed.
- Changed-path dry-run and required `scripts/check-changed.mjs` gates: passed.
- Focused formatter/linter and `git diff --check`: passed.
- Fresh full-branch autoreview: clean, patch correct (`0.99`), no actionable findings.
- Exact-head CI: run `33036927116`, attempt 2, head `3ee67bd323ec519226a3660bf4a1b0bb52442096`, passed.
- The sole attempt-1 failure was the unrelated Gateway timing test in `checks-node-compact-small-11`; its exact test passed locally, the one authorized failed-job retry passed, and `openclaw/ci-gate` passed.

## Maintainer Notes

- ClawSweeper's optional rank-up move requested a rebase plus green exact-head CI. The branch was not rebased solely for behind-main drift: native guard is conflict-free and intervening `main` changes do not touch this migration surface. Exact-head validation and CI are supplied for the remote head.
- #130590 is the overlapping duplicate and will be closed only after this canonical PR lands.

## Evidence

Redacted terminal output from the real registered doctor migration pipeline (applyLegacyDoctorMigrations -> strict validation), driven against a config containing legacy bindings[].match.peer.kind: "dm":

- On current main the migration set has nothing for dm and the candidate keeps failing strict validation:
  path=bindings.0 :: Invalid input (allowed: "direct", "group", "channel", "acp")
  path=bindings.2 :: Invalid input (allowed: "direct", "group", "channel", "acp")
- With this branch the same run reports:
  Moved deprecated bindings[].match.peer.kind "dm" -> "direct" for 2 bindings.
  ...and the migrated candidate passes strict validation with zero remaining issues (doctor converges; atomic write proceeds).
- Regression suites in this PR cover the single-binding rewrite, pluralized rewrites, and pass-through for canonical kinds; doctor-state-migrations and zod-schema suites stay green.
