### PR TITLE
fix(android): keep the composer visible with slash suggestions

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt
@@ -462,13 +462,22 @@ internal object AndroidScreenshotFixture {
       put(
         "commands",
         buildJsonArray {
-          add(
-            buildJsonObject {
-              put("name", JsonPrimitive("status"))
-              put("description", JsonPrimitive("Show current OpenClaw status"))
-              put("acceptsArgs", JsonPrimitive(false))
-            },
-          )
+          listOf(
+            Triple("help", "Show available commands.", false),
+            Triple("commands", "List all slash commands.", false),
+            Triple("tools", "List available runtime tools.", true),
+            Triple("skill", "Run a skill by name.", true),
+            Triple("learn", "Draft a reusable skill from recent work or named sources.", true),
+            Triple("loop", "Loop a prompt: /loop [interval] <prompt> | /loop status | /loop stop [name]", true),
+          ).forEach { (name, description, acceptsArgs) ->
+            add(
+              buildJsonObject {
+                put("name", JsonPrimitive(name))
+                put("description", JsonPrimitive(description))
+                put("acceptsArgs", JsonPrimitive(acceptsArgs))
+              },
+            )
+          }
         },
       )
       put(

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -101,6 +101,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
@@ -2345,6 +2346,8 @@ private fun ChatComposer(
       SlashCommandPanel(
         commands = slashCommands,
         onSelect = { command -> onValueChange(slashCommandCompletion(command)) },
+        // Reserve the editor and run controls before measuring suggestions.
+        modifier = Modifier.weight(1f, fill = false),
       )
     }
 
@@ -2615,9 +2618,10 @@ private fun ChatModelPickerRow(
 private fun SlashCommandPanel(
   commands: List<ChatCommandEntry>,
   onSelect: (ChatCommandEntry) -> Unit,
+  modifier: Modifier,
 ) {
-  ClawPanel(contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp)) {
-    Column {
+  ClawPanel(modifier = modifier, contentPadding = PaddingValues(horizontal = 0.dp, vertical = 0.dp)) {
+    Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
       if (commands.isEmpty()) {
         Text(
           text = nativeString("No commands found"),

--- a/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotFixtureTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotFixtureTest.kt
@@ -50,7 +50,7 @@ class AndroidScreenshotFixtureTest {
         ?.content,
     )
     assertEquals(1, metadata["models"]?.jsonArray?.size)
-    assertEquals(1, metadata["commands"]?.jsonArray?.size)
+    assertEquals(6, metadata["commands"]?.jsonArray?.size)
     assertEquals(
       AndroidScreenshotFixture.cronJobName,
       cronJobs

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
@@ -1,0 +1,150 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.AndroidScreenshotFixture
+import ai.openclaw.app.AndroidScreenshotScene
+import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.NodeApp
+import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.NodeRuntimeMode
+import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.ui.design.ClawDesignTheme
+import android.content.Context
+import android.provider.Settings
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h800dp-420dpi")
+class ChatComposerLayoutTest {
+  @get:Rule
+  val composeRule = createComposeRule()
+
+  private lateinit var app: NodeApp
+  private lateinit var prefs: SecurePrefs
+  private lateinit var runtime: NodeRuntime
+  private var originalRuntime: NodeRuntime? = null
+  private val viewModelStore = ViewModelStore()
+  private var originalAnimatorScale: String? = null
+
+  @Before
+  fun setUp() {
+    app = RuntimeEnvironment.getApplication() as NodeApp
+    prefs = SecurePrefs(app, app.getSharedPreferences("chat-composer-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    AndroidScreenshotFixture.configure(AndroidScreenshotScene.Chat)
+    runtime = NodeRuntime(app, prefs, NodeRuntimeMode.ScreenshotFixture)
+    originalRuntime = app.peekRuntime()
+    setApplicationRuntime(runtime)
+    originalAnimatorScale = Settings.Global.getString(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE)
+    Settings.Global.putFloat(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 0f)
+  }
+
+  @After
+  fun tearDown() {
+    viewModelStore.clear()
+    setApplicationRuntime(originalRuntime)
+    runtime.disconnect()
+    AndroidScreenshotFixture.configure(AndroidScreenshotScene.Home)
+    Settings.Global.putString(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, originalAnimatorScale)
+  }
+
+  @Test
+  fun slashSuggestionsKeepEditorAndStopVisibleAndLastSuggestionReachable() {
+    showChat()
+    val editor = composeRule.onNode(hasSetTextAction())
+    editor.performTextReplacement("/")
+    editor.assertTextEquals("/")
+
+    assertEditorAndStopVisible()
+    val lastSuggestion = composeRule.onNodeWithText("/loop").performScrollTo().assertIsDisplayed()
+    assertEditorAndStopVisible()
+    lastSuggestion.performClick()
+    editor.assertTextEquals("/loop ")
+    assertEditorAndStopVisible()
+  }
+
+  @Test
+  fun normalTextAndShortSuggestionListsKeepComposerVisible() {
+    showChat()
+    val editor = composeRule.onNode(hasSetTextAction())
+    listOf("hello", "/help", "/unknown").forEach { input ->
+      editor.performTextReplacement(input)
+      editor.assertTextEquals(input)
+      assertEditorAndStopVisible()
+    }
+  }
+
+  private fun showChat() {
+    val viewModel = MainViewModel(app, prefs, SavedStateHandle())
+    viewModelStore.put("chat", viewModel)
+    viewModel.enterScreenshotFixtureMode(AndroidScreenshotScene.Chat)
+    composeRule.setContent {
+      ClawDesignTheme {
+        // A portrait phone's remaining content viewport after its IME opens.
+        Box(Modifier.size(width = 360.dp, height = 400.dp).clipToBounds().testTag("chat-viewport")) {
+          ChatScreen(
+            viewModel = viewModel,
+            talkActive = false,
+            showSidebarButton = true,
+            onOpenSidebar = {},
+            onToggleTalk = {},
+            onOpenSessions = {},
+            onOpenDashboard = {},
+            onOpenGatewaySettings = {},
+          )
+        }
+      }
+    }
+    composeRule.waitUntil { viewModel.chatCommands.value.size == 6 }
+  }
+
+  private fun assertEditorAndStopVisible() {
+    val viewport = composeRule.onNodeWithTag("chat-viewport").getUnclippedBoundsInRoot()
+    val editorNode = composeRule.onNode(hasSetTextAction())
+    val stopNode = composeRule.onNodeWithContentDescription("Stop")
+    val editor = editorNode.getUnclippedBoundsInRoot()
+    val stop = stopNode.getUnclippedBoundsInRoot()
+    assertTrue("Editor must retain a visible line: $editor inside $viewport", editor.bottom > editor.top)
+    assertTrue("Stop must retain its touch target: $stop inside $viewport", stop.bottom - stop.top >= 48.dp)
+    for (bounds in listOf(editor, stop)) {
+      assertTrue("Composer control must stay below the viewport top", bounds.top >= viewport.top)
+      assertTrue("Composer control must stay above the viewport bottom", bounds.bottom <= viewport.bottom)
+    }
+    editorNode.assertIsDisplayed()
+    stopNode.assertIsDisplayed().assertHasClickAction()
+  }
+
+  private fun setApplicationRuntime(value: NodeRuntime?) {
+    NodeApp::class.java
+      .getDeclaredField("runtimeInstance")
+      .apply { isAccessible = true }
+      .set(app, value)
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users typing `/` could lose access to the message editor and Send or Stop control when the software keyboard reduced the available height. Six ordinary command suggestions could consume the entire composer viewport.

## Why This Change Was Made

The composer now measures its editor and actions before allocating the remaining height to a scrollable suggestion panel. The panel uses `weight(fill = false)` so short lists stay compact, without a fixed height cap or changes to keyboard inset handling, manifests, permissions, or persistence.

The existing screenshot fixture now supplies six real default command entries, allowing a full `ChatScreen` regression test without exposing a new production test hook. Runtime LOC is +6/-2 (net +4); fixture support is +16/-7, and tests are +151/-1. The runtime growth adds only the missing remaining-height ownership and scrolling behavior.

## User Impact

Users can keep typing and reach Send or Stop while browsing slash-command suggestions with the keyboard open. The last suggestion remains reachable by scrolling and selecting it still completes the command in the editor.

Follow-up: improve slash-suggestion usability with very short wide-screen keyboard viewports. A supplementary 800 × 700 dp check left only 26.7 dp for suggestions after the fixed headers and composer, less than one 48 dp row. The editor and Send remained visible, but full suggestion-row visibility in that constrained layout needs separate work. The before/after proof below is for the phone viewport, not complete foldable-device coverage.

## Evidence

- The full `ChatScreen` layout regression failed on unchanged production with a zero-height editor. The repaired test passes, including scrolling to `/loop`, selecting it, and preserving the editor and 48 dp action target. Ordinary text, one-match, and no-match controls also pass.
- 216 focused tests passed across Play and third-party variants. Both Android lint tasks, all four Kotlin style suites, the Play debug build, the normal changed-file checks, and independent P0–P2 review passed.
- Actual `MainActivity` before/after checks used Android 16, Gboard, and the same 360 × 800 dp phone viewport. The baseline hid the editor and action behind the keyboard; the fixed build retained the full editor and 48 dp action target while the six-command menu scrolled independently.
- Both active-run Stop and idle Send states were checked. The idle comparison used separate disposable fixture APKs that omitted only the history's active-run field; that omission is not part of this PR. Selecting the sixth command completed `/loop `. Tapping Send reached the existing controller and displayed the fixture's expected unsupported-gateway error. This proves action reachability, not successful remote message delivery.

The following task-fixture screenshots show the idle Send comparison with the real keyboard open:

| Before | After |
| --- | --- |
| ![Before: slash suggestions hide the editor and Send control](https://github.com/user-attachments/assets/03dffd5b-f0b6-4647-97f5-c8396a73f518) | ![After: suggestions scroll above the visible editor and Send control](https://github.com/user-attachments/assets/14e931bf-86c2-432e-82f0-25f2caf91ea8) |
