### PR TITLE
fix(audit): report denied exec approvals only once

### DIFF
--- a/src/agents/agent-tools.before-tool-call.decision.test.ts
+++ b/src/agents/agent-tools.before-tool-call.decision.test.ts
@@ -18,6 +18,7 @@ import {
   bindAssembledAgentToolActionDescriptor,
   copyAgentToolMetadata,
 } from "./agent-tool-metadata.js";
+import { markToolDecisionRecorded } from "./agent-tools.before-tool-call.decision.js";
 import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
 import { createCoreCodingTools } from "./core-coding-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
@@ -220,7 +221,7 @@ describe("generic tool action decision receipts", () => {
     expect(JSON.stringify(works)).not.toMatch(/sessions_list|SECRET_GATEWAY|private\/gateway/u);
   });
 
-  it("keeps an execution failure separate from its prior generic decision", async () => {
+  it("keeps an execution failure separate from its generic decision", async () => {
     const works: ExecutionDecisionWork[] = [];
     const tool = wrapToolWithBeforeToolCallHook(
       assembledTool(
@@ -435,6 +436,22 @@ describe("generic tool action decision receipts", () => {
       decision: { reasonCode: "plugin_hook_approval_required" },
       source: { owner: "plugin-hook" },
     });
+  });
+
+  it("does not duplicate an owner-native decision created during tool execution", async () => {
+    const works: ExecutionDecisionWork[] = [];
+    const execute = vi.fn(async () => {
+      markToolDecisionRecorded();
+      return { content: [], details: { ok: true } };
+    });
+    const tool = wrapToolWithBeforeToolCallHook(
+      assembledTool("tool", "late_owner_subject", execute),
+    );
+
+    await admittedRun({ works, run: () => tool.execute("late-owner-call", {}) });
+
+    expect(execute).toHaveBeenCalledOnce();
+    expect(works).toEqual([]);
   });
 
   it("records prepareControl disposal as suppression without launching the tool", async () => {

--- a/src/agents/agent-tools.before-tool-call.decision.ts
+++ b/src/agents/agent-tools.before-tool-call.decision.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { createHash } from "node:crypto";
 import { recordExecutionDecisionWork } from "../audit/execution-decision-work.js";
 import { getAgentToolActionDescriptor } from "./agent-tool-metadata.js";
@@ -9,6 +10,31 @@ const genericDecisions = {
   denied: ["denied", "enforced", "generic_action_policy_denied"],
   suppressed: ["not-applicable", "attribution-only", "generic_action_suppressed"],
 } as const;
+const toolDecisionOwner = new AsyncLocalStorage<{ recorded: boolean }>();
+
+/** Marks the current tool call after its owner-native decision record is registered. */
+export function markToolDecisionRecorded(): void {
+  const state = toolDecisionOwner.getStore();
+  if (state) {
+    state.recorded = true;
+  }
+}
+
+/** Records generic attribution only when execution creates no owner-native record. */
+export async function runWithGenericToolActionDecision<T>(
+  tool: AnyAgentTool,
+  toolCallId: string | undefined,
+  run: () => Promise<T> | T,
+): Promise<T> {
+  const state = { recorded: false };
+  try {
+    return await toolDecisionOwner.run(state, run);
+  } finally {
+    if (!state.recorded) {
+      recordGenericToolActionDecision(tool, toolCallId, "allowed");
+    }
+  }
+}
 
 export function recordGenericToolActionDecision(
   tool: AnyAgentTool,

--- a/src/agents/agent-tools.before-tool-call.wrapper.ts
+++ b/src/agents/agent-tools.before-tool-call.wrapper.ts
@@ -20,7 +20,10 @@ import {
   copyAgentToolSourceExecutionGuard,
   runAgentToolSourceExecutionGuard,
 } from "./agent-tool-source-execution-guard.js";
-import { recordGenericToolActionDecision } from "./agent-tools.before-tool-call.decision.js";
+import {
+  recordGenericToolActionDecision,
+  runWithGenericToolActionDecision,
+} from "./agent-tools.before-tool-call.decision.js";
 import {
   buildToolContentPrivateData,
   emitSkillUsedDiagnostic,
@@ -527,9 +530,6 @@ export function wrapToolWithBeforeToolCallHook(
       // Host capabilities can close while hooks, approval, validation, or
       // steering awaits. Recheck at the final synchronous source boundary.
       runAgentToolSourceExecutionGuard(tool);
-      if (!outcome.ownerDecision) {
-        recordGenericToolActionDecision(tool, toolCallId, "allowed");
-      }
       onImplementationStart?.();
       recordAdjustedParamsForToolCall(toolCallId, executeParams, ctx?.runId);
       const eventBase = buildEventBase(executeParams);
@@ -544,13 +544,11 @@ export function wrapToolWithBeforeToolCallHook(
       try {
         let result: Awaited<ReturnType<ForwardedToolExecution>>;
         try {
-          result = await (execute as ForwardedToolExecution)(
-            toolCallId,
-            executeParams,
-            signal,
-            forwardedOnUpdate,
-            ...executionArgs,
-          );
+          const args = [toolCallId, executeParams, signal, forwardedOnUpdate, ...executionArgs];
+          const invoke = () => (execute as ForwardedToolExecution)(...args);
+          result = outcome.ownerDecision
+            ? await invoke()
+            : await runWithGenericToolActionDecision(tool, toolCallId, invoke);
         } catch (error) {
           throw tool.resultContentSource === "network" &&
             getBeforeToolCallFailureDisposition(error) === undefined

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -23,6 +23,7 @@ import {
   resolveShellWrapperTransportArgv,
 } from "../infra/shell-wrapper-resolution.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
+import { markToolDecisionRecorded } from "./agent-tools.before-tool-call.decision.js";
 import {
   DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS,
   DEFAULT_APPROVAL_TIMEOUT_MS,
@@ -163,6 +164,7 @@ async function registerExecApprovalRequest(
     buildExecApprovalRequestToolParams(params),
     { expectFinal: false },
   );
+  markToolDecisionRecorded();
   const decision = parseDecision(registrationResult);
   const id = parseString(registrationResult?.id) ?? params.id;
   const expiresAtMs =

--- a/test/e2e/qa-lab/runtime/agent-run-decision-receipt.ts
+++ b/test/e2e/qa-lab/runtime/agent-run-decision-receipt.ts
@@ -109,11 +109,18 @@ function assertNoGenericApprovalDuplicate(
       .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
       .get("execution_decision_facts");
     if (table) {
-      const count = database
-        .prepare("SELECT COUNT(*) AS count FROM execution_decision_facts")
-        .get() as { count: number };
-      if (count.count !== 0) {
-        throw new Error("operator approval was duplicated into execution_decision_facts");
+      const rows = database
+        .prepare(
+          `SELECT action_family, reason_code, owner
+           FROM execution_decision_facts
+           WHERE owner = 'tool-action' AND reason_code = 'generic_action_attributed'
+           ORDER BY occurred_at, receipt_id`,
+        )
+        .all();
+      if (rows.length !== 0) {
+        throw new Error(
+          `operator approval was duplicated into execution_decision_facts: ${JSON.stringify(rows)}`,
+        );
       }
     }
   } finally {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an exec command requiring operator approval produced both the authoritative operator-approval receipt and a generic tool-action receipt for the same action. Audit inspection could therefore report duplicate decision attribution after the command was denied.

## Why This Change Was Made

Generic tool attribution now waits until tool execution establishes whether an owner-native decision record was registered. Successful exec approval registration marks that closure-bound execution scope, so the generic producer remains active for ordinary tools and exec calls without approval but yields to the authoritative approval owner when one exists.

The QA assertion now targets only generic `tool-action` attribution; valid generic facts from other owners, including model routing, remain allowed.

## User Impact

Operators inspecting a denied exec approval see one authoritative decision source. Ordinary generic tool and model-routing audit facts are preserved.

## Evidence

Pinned base: `565fd935449e6b75b211ca13ff43747d66b3fac2`.

Pre-fix real-flow regression:

- `qa suite --provider-mode mock-openai --scenario agent-run-decision-receipt`
- actual Gateway agent run, actual exec approval registration, actual denial
- failed with both `model-routing/model_route_selected` and duplicate `tool/generic_action_attributed` rows

Post-fix real-flow proof:

- same QA scenario passes through denial, conflicting-retry rejection, CLI audit inspection, redaction checks, generic tool-duplicate check, Gateway replacement, and byte-equivalent durable readback
- channel message flow scenario passed on `qa-channel` with `mock-openai`
- Control UI Playwright: `activity-run-inspector.e2e.test.ts`, 10/10 passed
- Codex native approval E2E: 1/1 passed across Gateway restart
- focused cross-owner matrix: 31 files, 655 passed, 4 skipped
- focused owner matrix: 3 files, 40 passed
- focused oxlint and oxfmt checks passed
- ordinary Codex autoreview: no actionable finding
- TruffleHog `565fd935...3cd8705f`: 0 verified, 0 unknown

Blacksmith Testbox `pearl-barnacle-e78d` built successfully, then stopped at QA CLI preflight because the submitted `--output-dir` was absolute. This was an invocation error, not infrastructure, so the packet's one-retry rule did not permit a replacement box. Run: https://github.com/openclaw/openclaw/actions/runs/33027065807

The supplementary actual subagent lineage scenario timed out waiting for its worker child session. No common cause with this receipt defect was proven; it was not retried or attributed to this change.

## Root Cause and Ownership

C02 recorded generic attribution at `agent-tool.before-execute`, before the exec implementation could register its owner-native approval row. The generic producer therefore had no observation of the later owner boundary.

The fix stays in the generic decision owner: a per-execution async scope defers the generic decision until execution returns or throws, while exec marks the scope only after approval registration succeeds. It does not filter persisted data, special-case command text, or disable generic attribution for all exec calls.

Production LOC: +37/-11 (net +26) | Tests: +30/-6 (net +24). The production growth is the closure-bound ownership seam needed to carry a downstream owner fact across awaited execution; the already-limit-bound wrapper shrinks by two lines.

Test audit:

- Observable invariant: one decision owner per approved tool action.
- Prior coverage only exercised owners decided by the pre-execution hook.
- The new focused regression covers an owner-native record created during implementation, and the QA scenario covers the real Gateway/approval path.
- The async scope is used by production generic and exec approval owners; no test-only production seam was added.

Best-fix verdict: best owner-boundary fix.

Alternatives considered:

- Excluding every exec action from generic attribution would lose valid no-approval facts.
- Filtering or deleting the generic row during audit reads would retain duplicate persisted state and move repair to a consumer.
- Inferring approval from tool names or arguments would violate the owner boundary.

## Provenance

Clear regression from C02 PR #130358, merge commit `29625bc310f58dc6d6a7d66bf84b9e06e89709b3`, August 26, 2026. Blamed code author, PR author, merger, and current PR author: Josh Avant (@joshavant). The triggering line was the unconditional pre-execution generic `allowed` record when the before-tool hook did not own the decision.

## Codex Contract Check

Direct sibling inspection used Codex SHA `f1087ff151b06e781ecb086068d45fcc62d02da3`:

- `codex-rs/app-server-protocol/src/protocol/common.rs:1649-1681`
- `codex-rs/app-server-protocol/src/protocol/v2/item.rs:58-103,1451-1525`
- `codex-rs/protocol/src/protocol.rs:3868-3905`

Codex distinguishes `Decline` (deny command, continue agent) from `Cancel`/`Abort` (interrupt). OpenClaw preserves that contract in `extensions/codex/src/app-server/approval-bridge.ts:828-843`, with regression coverage at `extensions/codex/src/app-server/approval-bridge.test.ts:1415-1439`.
