### PR TITLE
fix(agents): compact forced overflow recovery against the reserve-adjusted prompt budget

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
@@ -383,6 +383,56 @@ describe("recoverEmbeddedRunOverflow", () => {
     expect(mocks.truncateOversizedToolResults).not.toHaveBeenCalled();
   });
 
+  it("compacts against the reserve-adjusted budget from the preflight snapshot", async () => {
+    const input = makeInput({
+      attempt: {
+        terminal: { kind: "failed", source: "precheck", error: overflowError() },
+        sessionIdUsed: "session-1",
+        messagesSnapshot: [],
+        preflightRecovery: {
+          route: "compact_only",
+          source: "mid-turn",
+          estimatedPromptTokens: 190_000,
+          promptBudgetBeforeReserve: 185_000,
+          overflowTokens: 5_000,
+        },
+      },
+    });
+
+    expect(await recoverEmbeddedRunOverflow(input)).toEqual({ action: "retry" });
+    expect(mocks.compact).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ tokenBudget: 185_000, trigger: "overflow" }),
+    );
+  });
+
+  it("falls back to the raw context budget without a preflight reserve snapshot", async () => {
+    const result = await recoverEmbeddedRunOverflow(makeInput());
+
+    expect(result).toEqual({ action: "retry" });
+    expect(mocks.compact).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ tokenBudget: 200_000 }),
+    );
+  });
+
+  it("keeps the raw context budget when the preflight reserve snapshot is not usable", async () => {
+    const input = makeInput({
+      attempt: {
+        terminal: { kind: "failed", source: "precheck", error: overflowError() },
+        sessionIdUsed: "session-1",
+        messagesSnapshot: [],
+        preflightRecovery: { route: "compact_only" },
+      },
+    });
+
+    expect(await recoverEmbeddedRunOverflow(input)).toEqual({ action: "retry" });
+    expect(mocks.compact).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ tokenBudget: 200_000 }),
+    );
+  });
+
   it("continues from the current transcript after mid-turn compaction", async () => {
     const input = makeInput({
       attempt: {

--- a/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
@@ -115,6 +115,16 @@ export async function recoverEmbeddedRunOverflow(
     preflightEstimatedPromptTokens ??
     (input.contextTokenBudget > 0 ? input.contextTokenBudget + 1 : undefined);
   const activeSession = input.getActiveSession();
+  // The synthetic precheck route carries the admission budget OpenClaw actually
+  // rendered against (context budget minus provider reserve). Compacting to the
+  // raw context budget can leave the transcript above what providers admit, so
+  // prefer the measured value when a finite positive snapshot is present.
+  const recoveryTokenBudget =
+    typeof preflightRecovery?.promptBudgetBeforeReserve === "number" &&
+    Number.isFinite(preflightRecovery.promptBudgetBeforeReserve) &&
+    preflightRecovery.promptBudgetBeforeReserve > 0
+      ? Math.ceil(preflightRecovery.promptBudgetBeforeReserve)
+      : input.contextTokenBudget;
   log.warn(
     `[context-overflow-diag] sessionKey=${runParams.sessionKey ?? runParams.sessionId} ` +
       `provider=${input.provider}/${input.modelId} source=${contextOverflowError.source} ` +
@@ -169,7 +179,7 @@ export async function recoverEmbeddedRunOverflow(
     await input.runOwnsCompactionBeforeHook("overflow recovery");
     try {
       const compaction = await compactEmbeddedRunForRecovery(input, {
-        tokenBudget: input.contextTokenBudget,
+        tokenBudget: recoveryTokenBudget,
         trigger: "overflow",
         diagId: overflowDiagId,
         attempt: input.state.overflowCompactionAttempts,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users hitting a context overflow after the mid-turn precheck would have forced compaction trim the transcript to the wrong target, so the retried turn kept failing with context-overflow until `MAX_OVERFLOW_COMPACTION_ATTEMPTS` exhausted and the run died.

Closes #130226.

## Why This Change Was Made

The precheck deliberately snapshots `promptBudgetBeforeReserve` into the attempt's recovery payload — its own comment says compaction engines should compact "against the prompt OpenClaw actually rendered" (`attempt-prompt-preflight.ts`). The outer overflow recovery path ignores that snapshot and passes the raw `contextTokenBudget` to forced compaction; since reserve tokens are subtracted from what providers admit, trimming to the raw budget can still leave the transcript above the admission threshold. This change resolves the recovery token budget from a finite positive `preflightRecovery.promptBudgetBeforeReserve` when present and falls back to the raw budget otherwise (no snapshot ⇒ unchanged behavior).

## User Impact

Sessions that overflow past the prompt-admission threshold now compact to a target providers actually accept on the first recovery attempt instead of burning all attempts and surfacing a hard failure.

## Evidence

- New focused tests in `run.overflow-context-recovery.test.ts`: with a mid-turn preflight snapshot compaction receives `tokenBudget: 185_000` (reserve-adjusted) rather than the 200_000 raw budget; without a snapshot — and with an empty snapshot object — the raw budget is used exactly as before.
- Red/green verified locally: reverting only `overflow-context-recovery.ts` to `upstream/main` makes the new test fail in both project contexts; with the fix `pnpm exec vitest run src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts` passes 56/56.
