### PR TITLE
fix(agents): honor preflight compaction budget

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
@@ -500,11 +500,15 @@ describe("recoverEmbeddedRunOverflow", () => {
   });
 
   it("forwards preflight prompt estimates into synthetic overflow compaction", async () => {
+    const promptError = overflowError();
     const result = await recoverEmbeddedRunOverflow(
       makeInput({
+        promptError,
         attempt: {
+          terminal: { kind: "failed", source: "precheck", error: promptError },
           preflightRecovery: {
             route: "compact_then_truncate",
+            source: "mid-turn",
             estimatedPromptTokens: 268_138,
             promptBudgetBeforeReserve: 241_616,
             overflowTokens: 26_522,
@@ -516,9 +520,63 @@ describe("recoverEmbeddedRunOverflow", () => {
     expect(result).toEqual({ action: "retry" });
     expect(mocks.compact).toHaveBeenCalledWith(
       expect.anything(),
-      expect.objectContaining({ currentTokenCount: 268_138, trigger: "overflow" }),
+      expect.objectContaining({
+        tokenBudget: 241_616,
+        currentTokenCount: 268_138,
+        trigger: "overflow",
+      }),
     );
   });
+
+  it("keeps the raw budget for provider overflow with preflight metadata", async () => {
+    const result = await recoverEmbeddedRunOverflow(
+      makeInput({
+        attempt: {
+          preflightRecovery: {
+            route: "compact_then_truncate",
+            source: "mid-turn",
+            estimatedPromptTokens: 268_138,
+            promptBudgetBeforeReserve: 241_616,
+            overflowTokens: 26_522,
+          },
+        },
+      }),
+    );
+
+    expect(result).toEqual({ action: "retry" });
+    expect(mocks.compact).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ tokenBudget: 200_000 }),
+    );
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "keeps the raw budget for an invalid preflight budget of %s",
+    async (promptBudgetBeforeReserve) => {
+      const promptError = overflowError();
+      const result = await recoverEmbeddedRunOverflow(
+        makeInput({
+          promptError,
+          attempt: {
+            terminal: { kind: "failed", source: "precheck", error: promptError },
+            preflightRecovery: {
+              route: "compact_only",
+              source: "mid-turn",
+              estimatedPromptTokens: 268_138,
+              promptBudgetBeforeReserve,
+              overflowTokens: 26_522,
+            },
+          },
+        }),
+      );
+
+      expect(result).toEqual({ action: "retry" });
+      expect(mocks.compact).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ tokenBudget: 200_000 }),
+      );
+    },
+  );
 
   it("uses the minimally over-budget count for unparseable overflow text", async () => {
     const result = await recoverEmbeddedRunOverflow(

--- a/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/overflow-context-recovery.ts
@@ -93,9 +93,9 @@ export async function recoverEmbeddedRunOverflow(
     return { action: "none" };
   }
 
+  const terminal = projectAgentRunAttemptTerminal(input.attempt.terminal);
   const providerPromptRejection =
-    contextOverflowError.source === "assistantError" ||
-    projectAgentRunAttemptTerminal(input.attempt.terminal).promptErrorSource === "prompt"
+    contextOverflowError.source === "assistantError" || terminal.promptErrorSource === "prompt"
       ? markLastProviderPromptContextRejected(getProviderPromptState(input.runParams.runId))
       : undefined;
 
@@ -104,6 +104,14 @@ export async function recoverEmbeddedRunOverflow(
   const errorText = contextOverflowError.text;
   const observedOverflowTokens = extractObservedOverflowTokenCount(errorText);
   const preflightRecovery = input.attempt.preflightRecovery;
+  const preflightPromptBudget =
+    terminal.promptErrorSource === "precheck" &&
+    preflightRecovery?.source === "mid-turn" &&
+    typeof preflightRecovery.promptBudgetBeforeReserve === "number" &&
+    Number.isFinite(preflightRecovery.promptBudgetBeforeReserve) &&
+    preflightRecovery.promptBudgetBeforeReserve > 0
+      ? Math.floor(preflightRecovery.promptBudgetBeforeReserve)
+      : undefined;
   const preflightEstimatedPromptTokens =
     typeof preflightRecovery?.estimatedPromptTokens === "number" &&
     Number.isFinite(preflightRecovery.estimatedPromptTokens) &&
@@ -169,7 +177,7 @@ export async function recoverEmbeddedRunOverflow(
     await input.runOwnsCompactionBeforeHook("overflow recovery");
     try {
       const compaction = await compactEmbeddedRunForRecovery(input, {
-        tokenBudget: input.contextTokenBudget,
+        tokenBudget: preflightPromptBudget ?? input.contextTokenBudget,
         trigger: "overflow",
         diagId: overflowDiagId,
         attempt: input.state.overflowCompactionAttempts,


### PR DESCRIPTION
## Summary

- compact synthetic mid-turn precheck failures against the reserve-adjusted prompt budget that triggered recovery
- retain the raw context-window budget for provider overflow, timeout recovery, and invalid preflight metadata
- cover the narrower target, provider-originated overflow, and invalid budget values

## Root cause

The mid-turn precheck preserved `promptBudgetBeforeReserve`, but overflow recovery always passed `contextTokenBudget` to forced context-engine compaction. A prompt above the reserve-adjusted budget but below the hard window could therefore be judged already under target, making recovery a deterministic no-op.

The overflow owner has both the failure provenance and the measured preflight budget. It now selects the narrower target only for a genuine synthetic mid-turn precheck failure with a finite positive budget.

## Contract evidence

Sibling Codex source independently separates proactive compaction pressure from the hard provider window:

- `codex-rs/protocol/src/openai_models.rs:481`
- `codex-rs/core/src/session/context_window.rs:53`
- `codex-rs/core/src/session/turn.rs:1024`
- `codex-rs/codex-api/src/sse/responses.rs:680`

## Validation

- pre-fix regression: compaction received `200000` instead of the triggering `241616`
- focused overflow, timeout, and preflight tests: 50 passed
- `pnpm tsgo:core`: passed
- targeted lint, format, and `git diff --check`: passed
- fresh post-rebase branch autoreview: clean, correctness 0.98
- Testbox `tbx_01m10c0h3eyw9jt5x0dj7q5d0w`, workflow `33028988171`: infrastructure blocked after more than five hours without a terminal summary; the exact task-owned lease and processes were stopped, and no replacement heavy run was started

## Scope

- production: +11 / -3, net +8
- tests: +59 / -1, net +58
- no context-engine contract, timeout, config, protocol, persistence, or compatibility changes

The positive production delta is the explicit provenance and validity gate needed to prevent the narrower budget from leaking into provider overflow.

This deterministic session-block fix is release-note worthy; the landing release workflow owns the changelog entry.

Fixes #130226

Reported by @HelloBias.
