### PR TITLE
fix(agents): prevent early final responses in sequential subagent runs

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2111,6 +2111,33 @@ describe("runCodexAppServerAttempt", () => {
     );
   });
 
+  it("keeps a direct requester wake as the current prompt when resuming native history", async () => {
+    const sessionFile = path.join(tempDir, "session-requester-wake.jsonl");
+    const storePath = path.join(tempDir, "sessions-requester-wake.json");
+    const workspaceDir = path.join(tempDir, "workspace-requester-wake");
+    const harness = createResumeHarness();
+    const params = createParams(sessionFile, workspaceDir, {
+      sessionId: "session-requester-wake",
+      sessionKey: "agent:main:session-requester-wake",
+    });
+    await attachSqliteSessionTarget(params, storePath, "session-requester-wake");
+    await appendSqliteHistoryMessage(params, userMessage("original sequential request", 1));
+    await appendSqliteHistoryMessage(params, assistantMessage("yielded", 2));
+    await writeExistingBinding(sessionFile, workspaceDir, {
+      historyCoveredThrough: new Date(0).toISOString(),
+    });
+    params.prompt = "[Subagent Context] child wave completed; continue with the next wave.";
+    params.suppressNextUserMessagePersistence = true;
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    const turnStart = harness.requests.find((request) => request.method === "turn/start");
+    const inputText = (turnStart?.params as { input?: Array<{ text?: string }> })?.input?.[0]?.text;
+    expect(inputText).toContain("child wave completed");
+    expect(inputText).not.toBe("original sequential request");
+    await harness.completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+    await run;
+  });
+
   it("delivers completed assistant text when an orphan native tool call lacks a matching result", async () => {
     const harness = createStartedThreadHarness();
     const params = createParams(

--- a/src/agents/command/delivery.test.ts
+++ b/src/agents/command/delivery.test.ts
@@ -809,6 +809,19 @@ describe("deliverAgentCommandResult payload normalization", () => {
     });
   });
 
+  it("preserves native continuation evidence through command delivery", async () => {
+    const delivered = await deliverAgentCommandResultForTest({
+      omitReplyTarget: true,
+      opts: { deliver: false },
+      payloads: [],
+      result: { runtimeContinuationStarted: true },
+    });
+
+    expect((delivered as { runtimeContinuationStarted?: boolean }).runtimeContinuationStarted).toBe(
+      true,
+    );
+  });
+
   it("does not automatically redeliver text and media already sent to the same target", async () => {
     const delivered = await deliverAgentCommandResultForTest({
       opts: { threadId: "171.222" },

--- a/src/agents/command/delivery.ts
+++ b/src/agents/command/delivery.ts
@@ -113,6 +113,7 @@ type AgentCommandDeliveryResult = {
   messagingToolSentTargets?: MessagingToolSend[];
   didSendDeterministicApprovalPrompt?: true;
   acceptedSessionSpawns?: NonNullable<RunResult["acceptedSessionSpawns"]>;
+  runtimeContinuationStarted?: true;
   successfulCronAdds?: number;
   deliverySucceeded?: boolean;
   deliveryStatus?: AgentCommandDeliveryStatus;
@@ -235,6 +236,9 @@ function buildDeliveryResult(params: {
       : {}),
     ...(hasNonEmptyArray(params.result.acceptedSessionSpawns)
       ? { acceptedSessionSpawns: params.result.acceptedSessionSpawns }
+      : {}),
+    ...(params.result.runtimeContinuationStarted === true
+      ? { runtimeContinuationStarted: true }
       : {}),
     ...(hasSuccessfulCronAdds ? { successfulCronAdds } : {}),
     ...(params.deliverySucceeded !== undefined

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -398,6 +398,7 @@ function hasAgentDeliveryEvidenceShape(value: object): boolean {
     "messagingToolSentMediaUrls" in value ||
     "messagingToolSentTargets" in value ||
     "acceptedSessionSpawns" in value ||
+    "runtimeContinuationStarted" in value ||
     "successfulCronAdds" in value ||
     "meta" in value
   );

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -36,6 +36,7 @@ export type AgentDeliveryEvidence = {
   acceptedSessionSpawns?: unknown;
   successfulCronAdds?: unknown;
   meta?: {
+    yielded?: unknown;
     toolSummary?: {
       calls?: unknown;
     };
@@ -116,7 +117,7 @@ function hasNonEmptyStringArray(value: unknown): boolean {
   return Array.isArray(value) && value.some(hasNonEmptyString);
 }
 
-function hasAcceptedSessionSpawnEvidence(value: unknown): boolean {
+export function hasAcceptedSessionSpawnEvidence(value: unknown): boolean {
   return Array.isArray(value)
     ? value.some((entry) => {
         const spawn = asOptionalRecord(entry);

--- a/src/agents/embedded-agent-runner/delivery-evidence.ts
+++ b/src/agents/embedded-agent-runner/delivery-evidence.ts
@@ -34,6 +34,7 @@ export type AgentDeliveryEvidence = {
   /** Durable recovery evidence sets this when its bounded target projection omitted entries. */
   messagingToolSentTargetsTruncated?: unknown;
   acceptedSessionSpawns?: unknown;
+  runtimeContinuationStarted?: unknown;
   successfulCronAdds?: unknown;
   meta?: {
     yielded?: unknown;

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -12,7 +12,11 @@ import {
 import { createEmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
 import { TRUNCATED_REPLY_NOTICE_TEXT } from "./incomplete-turn-resolution.js";
 import { resolveEmbeddedRunAttemptTerminalState } from "./terminal-outcome.js";
-import { resolveEmbeddedRunTerminal } from "./terminal-resolution.js";
+import {
+  copyAttemptDeliveryState,
+  createTerminalToolPresentationTracker,
+  resolveEmbeddedRunTerminal,
+} from "./terminal-resolution.js";
 import { createEmbeddedRunTerminalRetryState } from "./terminal-retry-state.js";
 
 vi.mock("./auth-profile-success.js", () => ({

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -363,6 +363,48 @@ describe("terminal resolution", () => {
     expect(text).not.toContain("Couldn't sign in");
   });
 
+  it("carries presentation across retries until a newer tool outcome replaces it", () => {
+    const tracker = createTerminalToolPresentationTracker();
+    const firstOrdinal = tracker.allocateOrdinal();
+    tracker.observe({
+      toolCallOrdinal: firstOrdinal,
+      terminalPresentation: "Fetched https://example.com",
+    });
+
+    expect(tracker.read()).toBe("Fetched https://example.com");
+
+    const retryOrdinal = tracker.allocateOrdinal();
+    expect(tracker.read()).toBe("Fetched https://example.com");
+    tracker.observe({ toolCallOrdinal: retryOrdinal });
+    tracker.observe({
+      toolCallOrdinal: firstOrdinal,
+      terminalPresentation: "stale presentation",
+    });
+
+    expect(tracker.read()).toBeUndefined();
+  });
+
+  it("keeps only the bounded latest MCP App view identity", () => {
+    expect(
+      copyAttemptDeliveryState({
+        latestMcpAppChannelView: { viewId: "view-latest" },
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        messagingToolSentTargets: [],
+      } as never).latestMcpAppChannelView,
+    ).toEqual({ viewId: "view-latest" });
+  });
+
+  it("preserves runtime-owned continuation evidence for delivery", () => {
+    expect(
+      copyAttemptDeliveryState({
+        runtimeContinuationStarted: true,
+        messagingToolSentTexts: [],
+        messagingToolSentMediaUrls: [],
+        messagingToolSentTargets: [],
+      } as never),
+    ).toMatchObject({ runtimeContinuationStarted: true });
+  });
   it("retries a required empty reply even when deliberate silence is enabled", async () => {
     const activateInternalPrompt = vi.fn();
     const input = makeTerminalInput({

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -718,5 +718,6 @@ export function copyAttemptDeliveryState(attempt: EmbeddedRunAttemptResult) {
     heartbeatToolResponse: attempt.heartbeatToolResponse,
     successfulCronAdds: attempt.successfulCronAdds,
     acceptedSessionSpawns: attempt.acceptedSessionSpawns,
+    runtimeContinuationStarted: attempt.runtimeContinuationStarted,
   };
 }

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -327,7 +327,6 @@ export async function resolveEmbeddedRunTerminal(input: {
     );
     return { action: "retry" };
   }
-  const availableTerminalToolPresentation = input.readTerminalToolPresentation();
   if (
     !nextReasoningOnlyRetryInstruction &&
     nextEmptyResponseRetryInstruction &&
@@ -366,7 +365,7 @@ export async function resolveEmbeddedRunTerminal(input: {
     !input.replayState.hadPotentialSideEffects,
   );
   const terminalToolPresentation = incompleteTurnFallbackSafe
-    ? availableTerminalToolPresentation
+    ? input.readTerminalToolPresentation()
     : undefined;
   if (
     !emptyAssistantReplyIsSilent &&

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -272,6 +272,8 @@ export type EmbeddedAgentRunResult = {
   messagingToolSourceReplyPayloads?: MessagingToolSourceReplyPayload[];
   // Child sessions successfully accepted by sessions_spawn during the run.
   acceptedSessionSpawns?: AcceptedSessionSpawn[];
+  // True when the native runtime accepted a direct child as continuation work.
+  runtimeContinuationStarted?: boolean;
   // Structured heartbeat outcome recorded by the heartbeat response tool.
   heartbeatToolResponse?: HeartbeatToolResponse;
   // Count of successful cron.add tool calls in this run.

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -93,6 +93,8 @@ type PreparedReplyDispatchPublicationHost = Readonly<{
   isGatewayLifecycleActive: () => boolean;
   getPendingOwnerPublication: (agentId: string) => Promise<unknown> | undefined;
   getPendingReplacement: () => Promise<void> | undefined;
+  /** Waits for an agent-scoped auth publication after its old projection was removed. */
+  getPendingAgentPublication?: (agentId: string) => Promise<void> | undefined;
 }>;
 
 /** Reads one immutable configured Gateway dispatch generation without activating an owner. */
@@ -160,6 +162,11 @@ export class PreparedReplyDispatchPublicationOwner {
       }
       const matches = this.#publication.runtimes.filter((runtime) => runtime.agentId === agentId);
       if (matches.length !== 1) {
+        const agentPublication = this.host.getPendingAgentPublication?.(agentId);
+        if (agentPublication) {
+          await agentPublication;
+          continue;
+        }
         throw new PreparedModelRuntimeOwnerNotPublishedError(
           `prepared reply dispatch runtime owner was not published for ${agentId}`,
         );

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -93,8 +93,6 @@ type PreparedReplyDispatchPublicationHost = Readonly<{
   isGatewayLifecycleActive: () => boolean;
   getPendingOwnerPublication: (agentId: string) => Promise<unknown> | undefined;
   getPendingReplacement: () => Promise<void> | undefined;
-  /** Waits for an agent-scoped auth publication after its old projection was removed. */
-  getPendingAgentPublication?: (agentId: string) => Promise<void> | undefined;
 }>;
 
 /** Reads one immutable configured Gateway dispatch generation without activating an owner. */
@@ -162,11 +160,6 @@ export class PreparedReplyDispatchPublicationOwner {
       }
       const matches = this.#publication.runtimes.filter((runtime) => runtime.agentId === agentId);
       if (matches.length !== 1) {
-        const agentPublication = this.host.getPendingAgentPublication?.(agentId);
-        if (agentPublication) {
-          await agentPublication;
-          continue;
-        }
         throw new PreparedModelRuntimeOwnerNotPublishedError(
           `prepared reply dispatch runtime owner was not published for ${agentId}`,
         );

--- a/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
@@ -31,7 +31,7 @@ const FAILED_COMPLETION_NOTICE =
 
 export function isGatewayAgentRunPending(
   response: unknown,
-): response is { status: "accepted" | "in_flight" | "started" } {
+): response is { admitted?: unknown; status: "accepted" | "in_flight" | "started" } {
   if (!response || typeof response !== "object") {
     return false;
   }

--- a/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
@@ -29,7 +29,9 @@ import { inferDeliveryTargetChatType } from "./subagent-announce-origin.js";
 const FAILED_COMPLETION_NOTICE =
   "A delegated task failed before it could report a result. Please retry the task.";
 
-export function isGatewayAgentRunPending(response: unknown): boolean {
+export function isGatewayAgentRunPending(
+  response: unknown,
+): response is { status: "accepted" | "in_flight" | "started" } {
   if (!response || typeof response !== "object") {
     return false;
   }

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -4720,6 +4720,24 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expected: missingRequesterFinal,
     },
     {
+      name: "rejects a yielded turn without an accepted next wave",
+      response: { result: { payloads: [], meta: { yielded: true } } },
+      requireVisibleReply: true,
+      expected: missingRequesterFinal,
+    },
+    {
+      name: "accepts an accepted next wave followed by a successful yield",
+      response: {
+        result: {
+          payloads: [],
+          meta: { yielded: true },
+          acceptedSessionSpawns: [{ runId: "run-child", childSessionKey: "agent:main:child" }],
+        },
+      },
+      requireVisibleReply: true,
+      expected: deliveredRequesterFinal,
+    },
+    {
       name: "rejects a cron side effect without a final reply",
       response: { result: { payloads: [], successfulCronAdds: 1 } },
       requireVisibleReply: true,

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -3802,6 +3802,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     const callGateway = createGatewayMock({
       runId: "subagent:child:replay",
       status: "in_flight",
+      admitted: true,
     });
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
     let activityChecks = 0;
@@ -3840,6 +3841,59 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
           delivered: true,
           path: "direct",
           error: undefined,
+        },
+      ],
+    });
+    expect(callGateway).toHaveBeenCalledOnce();
+    expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
+    expect(activityChecks).toBe(1);
+  });
+
+  it("retains a pre-admission completion replay without fallback steering", async () => {
+    const callGateway = createGatewayMock({
+      runId: "subagent:child:reservation",
+      status: "in_flight",
+    });
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
+    let activityChecks = 0;
+    testing.setDepsForTest({
+      callGateway,
+      getRequesterSessionActivity: () => ({
+        sessionId: "requester-session-channel",
+        isActive: activityChecks++ > 0,
+      }),
+      getRuntimeConfig: () => ({}) as never,
+      queueEmbeddedAgentMessageWithOutcome,
+    });
+    const origin = { channel: "slack", to: "channel:C123", accountId: "acct-1" };
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:slack:channel:C123",
+      targetRequesterSessionKey: "agent:main:slack:channel:C123",
+      triggerMessage: "child done",
+      steerMessage: "child done",
+      requesterOrigin: origin,
+      requesterSessionOrigin: origin,
+      completionDirectOrigin: origin,
+      directOrigin: origin,
+      requesterIsSubagent: false,
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+      directIdempotencyKey: "announce-channel-completion-reservation",
+    });
+
+    expectRecordFields(result, {
+      delivered: false,
+      path: "direct",
+      reason: "completion_handoff_pending",
+      disposition: "ambiguous",
+      phases: [
+        {
+          phase: "direct-primary",
+          delivered: false,
+          path: "direct",
+          reason: "completion_handoff_pending",
+          error: "requester agent admission is still pending",
         },
       ],
     });

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -3798,6 +3798,56 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("does not fallback-steer an ordinary completion after an in-flight handoff owns it", async () => {
+    const callGateway = createGatewayMock({
+      runId: "subagent:child:replay",
+      status: "in_flight",
+    });
+    const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(true);
+    let activityChecks = 0;
+    testing.setDepsForTest({
+      callGateway,
+      getRequesterSessionActivity: () => ({
+        sessionId: "requester-session-channel",
+        isActive: activityChecks++ > 0,
+      }),
+      getRuntimeConfig: () => ({}) as never,
+      queueEmbeddedAgentMessageWithOutcome,
+    });
+    const origin = { channel: "slack", to: "channel:C123", accountId: "acct-1" };
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:slack:channel:C123",
+      targetRequesterSessionKey: "agent:main:slack:channel:C123",
+      triggerMessage: "child done",
+      steerMessage: "child done",
+      requesterOrigin: origin,
+      requesterSessionOrigin: origin,
+      completionDirectOrigin: origin,
+      directOrigin: origin,
+      requesterIsSubagent: false,
+      expectsCompletionMessage: true,
+      bestEffortDeliver: true,
+      directIdempotencyKey: "announce-channel-completion-replay",
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+      phases: [
+        {
+          phase: "direct-primary",
+          delivered: true,
+          path: "direct",
+          error: undefined,
+        },
+      ],
+    });
+    expect(callGateway).toHaveBeenCalledOnce();
+    expect(queueEmbeddedAgentMessageWithOutcome).not.toHaveBeenCalled();
+    expect(activityChecks).toBe(1);
+  });
+
   it("does not fail stale channel subagent completions only because the parent stayed private", async () => {
     const callGateway = createPayloadGatewayMock();
     const sendMessage = createSendMessageMock();

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -4539,6 +4539,17 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expected: deliveredRequesterFinal,
     },
     {
+      name: "retains an ordinary non-yielded settle turn while it is still in flight",
+      response: { runId: "run-requester-pending", status: "in_flight" },
+      requireVisibleReply: false,
+      expected: {
+        delivered: false,
+        path: "direct",
+        reason: "completion_handoff_pending",
+        disposition: "retryable",
+      },
+    },
+    {
       name: "accepts a yielded requester's visible final answer",
       routes: requesterSettleRoutes,
       response: { result: { payloads: [{ text: "The consolidated answer." }] } },

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -4100,6 +4100,102 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     },
   );
 
+  it.each([
+    {
+      label: "native runtime",
+      continuationEvidence: { runtimeContinuationStarted: true },
+    },
+    {
+      label: "accepted sessions_spawn",
+      continuationEvidence: committedSessionSpawnEvidence,
+    },
+  ])(
+    "does not fallback-send a direct requester completion after $label continuation owns the next wave",
+    async ({ continuationEvidence }) => {
+      const callGateway = createGatewayMock({
+        result: {
+          payloads: [],
+          meta: { yielded: true },
+          ...continuationEvidence,
+        },
+      });
+      const sendMessage = createSendMessageMock();
+      const childSessionKey = "agent:worker:subagent:yielded-next-wave";
+
+      const result = await deliverDiscordDirectMessageCompletion({
+        callGateway,
+        sendMessage,
+        sourceTool: "subagent_announce",
+        sourceSessionKey: childSessionKey,
+        internalEvents: taskCompletionEvents({
+          childSessionKey,
+          childSessionId: "child-session-id",
+          result: "Wave one completed.",
+        }),
+      });
+
+      expectRecordFields(result, { delivered: true, path: "direct" });
+      expect(sendMessage).not.toHaveBeenCalled();
+    },
+  );
+
+  it("accepts a yielded continuation before enforcing message-tool-only final delivery", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [],
+        meta: { yielded: true },
+        runtimeContinuationStarted: true,
+      },
+    });
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      directIdempotencyKey: "announce-channel-subagent-message-tool-yield",
+      sourceTool: "subagent_announce",
+      runtimeConfig: { messages: { groupChat: { visibleReplies: "message_tool" } } },
+      internalEvents: taskCompletionEvents({ childSessionId: "child-session-id" }),
+    });
+
+    expectRecordFields(result, { delivered: true, path: "direct" });
+    expectGatewayAgentParams(callGateway, {
+      deliver: false,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("accepts a yielded continuation before classifying no-output as a permanent failure", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [],
+        meta: { yielded: true },
+        ...committedSessionSpawnEvidence,
+      },
+    });
+    const sendMessage = createSendMessageMock();
+    const childSessionKey = "agent:worker:subagent:yielded-no-output";
+
+    const result = await deliverSlackChannelAnnouncement({
+      callGateway,
+      sendMessage,
+      directIdempotencyKey: "announce-channel-subagent-yielded-no-output",
+      sourceTool: "subagent_announce",
+      sourceSessionKey: childSessionKey,
+      internalEvents: taskCompletionEvents({
+        childSessionKey,
+        childSessionId: "child-session-id",
+        status: "ok",
+        statusLabel: "completed successfully",
+        result: "(no output)",
+      }),
+    });
+
+    expectRecordFields(result, { delivered: true, path: "direct" });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("fails configured channel subagent completions when parent skips required message tool", async () => {
     const callGateway = createPayloadGatewayMock({ text: "The subagent is done." });
     const queueEmbeddedAgentMessageWithOutcome = createQueueOutcomeMock(false);

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -4929,6 +4929,51 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     );
   });
 
+  it("retains a yielded requester wake when replay is still in flight", async () => {
+    const callGateway = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("connect ECONNRESET after admission"))
+      .mockResolvedValueOnce({ runId: "run-requester-replay", status: "in_flight" });
+    const origin = { channel: "discord", to: "dm:U123", accountId: "acct-1" };
+    testing.setDepsForTest({
+      callGateway: callGateway as typeof runtimeCallGateway,
+      getRequesterSessionActivity: () => ({
+        sessionId: "requester-session-dm",
+        isActive: true,
+      }),
+      getRuntimeConfig: () => ({}) as never,
+      queueEmbeddedAgentMessageWithOutcome: createQueueOutcomeMock(true),
+    });
+
+    const result = await deliverSubagentAnnouncement({
+      requesterSessionKey: "agent:main:discord:dm:U123",
+      targetRequesterSessionKey: "agent:main:discord:dm:U123",
+      triggerMessage: "all spawned subagents settled",
+      steerMessage: "all spawned subagents settled",
+      requesterOrigin: origin,
+      requesterSessionOrigin: origin,
+      directOrigin: origin,
+      requesterIsSubagent: false,
+      expectsCompletionMessage: false,
+      requireDirectDelivery: true,
+      requireVisibleReply: true,
+      directIdempotencyKey: "announce-requester-replay",
+      sourceTool: "subagent_announce",
+    });
+
+    expect(result).toMatchObject({
+      delivered: false,
+      path: "direct",
+      reason: "completion_handoff_pending",
+      disposition: "retryable",
+    });
+    expect(callGateway).toHaveBeenCalledTimes(2);
+    expect(callGateway.mock.calls.map(([call]) => call.params?.idempotencyKey)).toEqual([
+      "announce-requester-replay",
+      "announce-requester-replay",
+    ]);
+  });
+
   it.each([
     {
       name: "a transient network cause wrapped by outbound delivery",

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -4835,6 +4835,18 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       expected: missingRequesterFinal,
     },
     {
+      name: "accepts a runtime-owned next wave followed by a successful yield",
+      response: {
+        result: {
+          payloads: [],
+          meta: { yielded: true },
+          runtimeContinuationStarted: true,
+        },
+      },
+      requireVisibleReply: true,
+      expected: deliveredRequesterFinal,
+    },
+    {
       name: "rejects a yielded turn without an accepted next wave",
       response: { result: { payloads: [], meta: { yielded: true } } },
       requireVisibleReply: true,

--- a/src/agents/subagents/announce/subagent-announce-delivery.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-delivery.test.ts
@@ -4139,6 +4139,35 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     },
   );
 
+  it("accepts yielded continuation before classifying a failed direct-delivery status", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [],
+        meta: { yielded: true },
+        runtimeContinuationStarted: true,
+        deliveryStatus: {
+          status: "failed",
+          errorMessage: "completion agent did not produce a visible reply",
+        },
+      },
+    });
+    const sendMessage = createSendMessageMock();
+
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      sourceTool: "subagent_announce",
+      sourceSessionKey: "agent:worker:subagent:yielded-next-wave-failed-status",
+      internalEvents: taskCompletionEvents({
+        childSessionId: "child-session-id",
+        result: "Wave one completed.",
+      }),
+    });
+
+    expectRecordFields(result, { delivered: true, path: "direct" });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("accepts a yielded continuation before enforcing message-tool-only final delivery", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -475,6 +475,17 @@ export async function sendSubagentAnnounceDirectly(params: {
       directAnnounceResult &&
       hasMessagingToolDeliveryToSource(directAnnounceResult, deliveryTarget),
     );
+    const hasYieldedContinuation = Boolean(
+      directAnnounceResult &&
+      directAnnounceResult.meta?.yielded === true &&
+      (directAnnounceResult.runtimeContinuationStarted === true ||
+        hasAcceptedSessionSpawnEvidence(directAnnounceResult.acceptedSessionSpawns)),
+    );
+    if (hasYieldedContinuation) {
+      // The runtime owns the accepted next wave. This wake is complete even
+      // though the resumed requester correctly withheld its terminal reply.
+      return { delivered: true, path: "direct" };
+    }
     const directDeliveryFailure =
       (shouldDeliverAgentFinal || requiresMessageToolDelivery) && directAnnounceResult
         ? getAgentCommandDeliveryFailure(directAnnounceResult)
@@ -490,17 +501,6 @@ export async function sendSubagentAnnounceDirectly(params: {
           ? { disposition: "ambiguous" as const }
           : {}),
       };
-    }
-    const hasYieldedContinuation = Boolean(
-      directAnnounceResult &&
-      directAnnounceResult.meta?.yielded === true &&
-      (directAnnounceResult.runtimeContinuationStarted === true ||
-        hasAcceptedSessionSpawnEvidence(directAnnounceResult.acceptedSessionSpawns)),
-    );
-    if (hasYieldedContinuation) {
-      // The runtime owns the accepted next wave. This wake is complete even
-      // though the resumed requester correctly withheld its terminal reply.
-      return { delivered: true, path: "direct" };
     }
     const completionPayloadVisibility = {
       includeErrorPayloads: false,

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -491,6 +491,17 @@ export async function sendSubagentAnnounceDirectly(params: {
           : {}),
       };
     }
+    const hasYieldedContinuation = Boolean(
+      directAnnounceResult &&
+      directAnnounceResult.meta?.yielded === true &&
+      (directAnnounceResult.runtimeContinuationStarted === true ||
+        hasAcceptedSessionSpawnEvidence(directAnnounceResult.acceptedSessionSpawns)),
+    );
+    if (hasYieldedContinuation) {
+      // The runtime owns the accepted next wave. This wake is complete even
+      // though the resumed requester correctly withheld its terminal reply.
+      return { delivered: true, path: "direct" };
+    }
     const completionPayloadVisibility = {
       includeErrorPayloads: false,
       includeReasoningPayloads: false,
@@ -513,12 +524,6 @@ export async function sendSubagentAnnounceDirectly(params: {
     );
     const hasCompletionSideEffect = Boolean(
       directAnnounceResult && hasCommittedOutboundDeliveryEvidence(directAnnounceResult),
-    );
-    const hasYieldedContinuation = Boolean(
-      directAnnounceResult &&
-      directAnnounceResult.meta?.yielded === true &&
-      (directAnnounceResult.runtimeContinuationStarted === true ||
-        hasAcceptedSessionSpawnEvidence(directAnnounceResult.acceptedSessionSpawns)),
     );
     const hasVisibleRequiredCompletionReply =
       hasMessagingToolDelivery ||
@@ -617,7 +622,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       hasIntentionalSilentCompletionReply && !isSubagentCompletion;
     if (
       !hasVisibleCompletionReply &&
-      ((params.requireVisibleReply && !hasYieldedContinuation) ||
+      (params.requireVisibleReply ||
         (params.expectsCompletionMessage &&
           !shouldDeliverAgentFinal &&
           !requiresMessageToolDelivery &&

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -514,10 +514,11 @@ export async function sendSubagentAnnounceDirectly(params: {
     const hasCompletionSideEffect = Boolean(
       directAnnounceResult && hasCommittedOutboundDeliveryEvidence(directAnnounceResult),
     );
-    const hasYieldedSessionSpawnContinuation = Boolean(
+    const hasYieldedContinuation = Boolean(
       directAnnounceResult &&
       directAnnounceResult.meta?.yielded === true &&
-      hasAcceptedSessionSpawnEvidence(directAnnounceResult.acceptedSessionSpawns),
+      (directAnnounceResult.runtimeContinuationStarted === true ||
+        hasAcceptedSessionSpawnEvidence(directAnnounceResult.acceptedSessionSpawns)),
     );
     const hasVisibleRequiredCompletionReply =
       hasMessagingToolDelivery ||
@@ -616,7 +617,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       hasIntentionalSilentCompletionReply && !isSubagentCompletion;
     if (
       !hasVisibleCompletionReply &&
-      ((params.requireVisibleReply && !hasYieldedSessionSpawnContinuation) ||
+      ((params.requireVisibleReply && !hasYieldedContinuation) ||
         (params.expectsCompletionMessage &&
           !shouldDeliverAgentFinal &&
           !requiresMessageToolDelivery &&

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -432,9 +432,11 @@ export async function sendSubagentAnnounceDirectly(params: {
       throw err;
     }
 
-    const directAnnounceStillPending = isGatewayAgentRunPending(directAnnounceResponse);
-    if (directAnnounceStillPending) {
-      if (!params.requireVisibleReply) {
+    if (isGatewayAgentRunPending(directAnnounceResponse)) {
+      const directAnnounceStatus = directAnnounceResponse.status;
+      // Fresh acceptance transfers ordinary completion ownership. Replays and
+      // started runs stay pending until terminal evidence can retire a durable wake.
+      if (!params.requireVisibleReply && directAnnounceStatus === "accepted") {
         return {
           delivered: true,
           path: "direct",

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -21,6 +21,7 @@ import { normalizeAgentRunTerminalDeliverySnapshot } from "../../agent-run-termi
 import {
   getAgentCommandDeliveryFailure,
   getGatewayAgentResult,
+  hasAcceptedSessionSpawnEvidence,
   hasCommittedOutboundDeliveryEvidence,
   hasPayloadOutcomeSendEvidence,
 } from "../../embedded-agent-runner/delivery-evidence.js";
@@ -483,6 +484,11 @@ export async function sendSubagentAnnounceDirectly(params: {
     const hasCompletionSideEffect = Boolean(
       directAnnounceResult && hasCommittedOutboundDeliveryEvidence(directAnnounceResult),
     );
+    const hasYieldedSessionSpawnContinuation = Boolean(
+      directAnnounceResult &&
+      directAnnounceResult.meta?.yielded === true &&
+      hasAcceptedSessionSpawnEvidence(directAnnounceResult.acceptedSessionSpawns),
+    );
     const hasVisibleRequiredCompletionReply =
       hasMessagingToolDelivery ||
       (!requiresMessageToolDelivery && hasVisibleNonSilentGatewayPayload);
@@ -580,7 +586,7 @@ export async function sendSubagentAnnounceDirectly(params: {
       hasIntentionalSilentCompletionReply && !isSubagentCompletion;
     if (
       !hasVisibleCompletionReply &&
-      (params.requireVisibleReply ||
+      ((params.requireVisibleReply && !hasYieldedSessionSpawnContinuation) ||
         (params.expectsCompletionMessage &&
           !shouldDeliverAgentFinal &&
           !requiresMessageToolDelivery &&

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -434,9 +434,18 @@ export async function sendSubagentAnnounceDirectly(params: {
 
     const directAnnounceStillPending = isGatewayAgentRunPending(directAnnounceResponse);
     if (directAnnounceStillPending) {
+      if (!params.requireVisibleReply) {
+        return {
+          delivered: true,
+          path: "direct",
+        };
+      }
       return {
-        delivered: true,
+        delivered: false,
         path: "direct",
+        reason: "completion_handoff_pending",
+        error: "requester agent run is still in flight",
+        disposition: "retryable",
       };
     }
 

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -434,7 +434,23 @@ export async function sendSubagentAnnounceDirectly(params: {
 
     if (isGatewayAgentRunPending(directAnnounceResponse)) {
       const directAnnounceStatus = directAnnounceResponse.status;
-      // Any nonterminal ordinary completion handoff already owns the prompt;
+      if (
+        !params.requireVisibleReply &&
+        params.expectsCompletionMessage &&
+        directAnnounceStatus === "in_flight" &&
+        directAnnounceResponse.admitted !== true
+      ) {
+        // A pre-admission reservation blocks duplicate dispatch but does not own
+        // delivery yet. Avoid fallback injection while retaining the durable retry.
+        return {
+          delivered: false,
+          path: "direct",
+          reason: "completion_handoff_pending",
+          error: "requester agent admission is still pending",
+          disposition: "ambiguous",
+        };
+      }
+      // An admitted ordinary completion handoff already owns the prompt;
       // fallback steering would inject it twice. Settle wakes still need terminal evidence on replay.
       if (
         !params.requireVisibleReply &&

--- a/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-direct-delivery.ts
@@ -434,9 +434,12 @@ export async function sendSubagentAnnounceDirectly(params: {
 
     if (isGatewayAgentRunPending(directAnnounceResponse)) {
       const directAnnounceStatus = directAnnounceResponse.status;
-      // Fresh acceptance transfers ordinary completion ownership. Replays and
-      // started runs stay pending until terminal evidence can retire a durable wake.
-      if (!params.requireVisibleReply && directAnnounceStatus === "accepted") {
+      // Any nonterminal ordinary completion handoff already owns the prompt;
+      // fallback steering would inject it twice. Settle wakes still need terminal evidence on replay.
+      if (
+        !params.requireVisibleReply &&
+        (params.expectsCompletionMessage || directAnnounceStatus === "accepted")
+      ) {
         return {
           delivered: true,
           path: "direct",

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -6,14 +6,7 @@ import type { SubagentRunRecord } from "../registry/subagent-registry.types.js";
 import type { SubagentAnnounceDeliveryResult } from "./subagent-announce-dispatch.js";
 
 const deliverSpy = vi.fn(
-  async (
-    _params: Record<string, unknown>,
-  ): Promise<{
-    delivered: boolean;
-    path: string;
-    disposition?: "ambiguous" | "permanent_failure" | "intentional_non_delivery";
-    reason?: string;
-  }> => ({
+  async (_params: Record<string, unknown>): Promise<SubagentAnnounceDeliveryResult> => ({
     delivered: true,
     path: "direct",
   }),
@@ -726,12 +719,29 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     }
   });
 
-  it("replays an ambiguous transport failure with the same idempotency key", async () => {
+  it.each([
+    {
+      label: "ambiguous transport failure",
+      prepare: () => deliverSpy.mockRejectedValueOnce(new Error("connection lost after admission")),
+      expectedState: { replayCount: 1, lastError: "connection lost after admission" },
+    },
+    {
+      label: "authoritative in-flight result",
+      prepare: () =>
+        deliverSpy.mockResolvedValueOnce({
+          delivered: false,
+          path: "direct",
+          reason: "completion_handoff_pending",
+          error: "requester agent run is still in flight",
+          disposition: "retryable",
+        }),
+      expectedState: { lastError: "requester agent run is still in flight" },
+    },
+  ])("replays an $label with the same idempotency key", async ({ prepare, expectedState }) => {
     const firstChild = makeSettledChild({ runId: "run-a" });
     const secondChild = makeSettledChild({ runId: "run-b" });
-    const children = [firstChild, secondChild];
-    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue(children);
-    deliverSpy.mockRejectedValueOnce(new Error("connection lost after admission"));
+    registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([firstChild, secondChild]);
+    prepare();
 
     vi.useFakeTimers();
     vi.setSystemTime(0);
@@ -742,16 +752,14 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       expect(firstChild.requesterSettleWake).toMatchObject({
         status: "dispatching",
         attemptCount: 1,
-        replayCount: 1,
         nextAttemptAt: 30_000,
-        lastError: "connection lost after admission",
+        ...expectedState,
       });
 
       await vi.advanceTimersByTimeAsync(30_000);
       expect(
         await maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: secondChild })),
       ).toBe(true);
-      expect(deliverSpy).toHaveBeenCalledTimes(2);
       expect(deliverSpy.mock.calls.map(([arg]) => arg.directIdempotencyKey)).toEqual([
         requesterSettleKey("run-a,run-b"),
         requesterSettleKey("run-a,run-b"),

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -438,10 +438,11 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(true);
     expect(deliverSpy).toHaveBeenCalledOnce();
-    expect(deliveredCallArg().requireVisibleReply).toBe(true);
+    expect(deliveredCallArg().requireVisibleReply).toBeUndefined();
     const message = String(deliveredCallArg().triggerMessage);
-    expect(message).not.toContain("NO_REPLY");
-    expect(message).toContain("original user request still requires your visible final answer");
+    expect(message).toContain("create the next required subagent(s) and call sessions_yield again");
+    expect(message).toContain("do not send a final answer while required work remains");
+    expect(message).not.toContain("Do not keep waiting or call sessions_yield again");
     expect(deliveredCallArg().directIdempotencyKey).toBe(requesterSettleKey("run-b:yield-1"));
     expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
       delivered: true,
@@ -530,10 +531,10 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(true);
     expect(deliverSpy).toHaveBeenCalledOnce();
-    expect(deliveredCallArg().requireVisibleReply).toBe(true);
+    expect(deliveredCallArg().requireVisibleReply).toBeUndefined();
     const message = String(deliveredCallArg().triggerMessage);
-    expect(message).not.toContain("NO_REPLY");
-    expect(message).toContain("original user request still requires your visible final answer");
+    expect(message).toContain("continue the original request from this resumed turn");
+    expect(message).toContain("Otherwise send a truthful user-facing update");
     expect(deliveredCallArg().directIdempotencyKey).toBe(requesterSettleKey("run-b:yield-1"));
     expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
       delivered: true,
@@ -672,7 +673,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     }
   });
 
-  it("retains a yielded wake after a silent final and retries its visible reply", async () => {
+  it("accepts a yielded requester continuation without requiring a visible final", async () => {
     const child = makeSettledChild({
       runId: "run-b",
       delivery: { status: "delivered" },
@@ -685,43 +686,16 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       },
     });
     registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
-    deliverSpy.mockResolvedValueOnce({
-      delivered: false,
+    const woke = await maybeWakeRequesterAfterAllChildrenSettled(
+      wakeParams({ settledEntry: child }),
+    );
+
+    expect(woke).toBe(true);
+    expect(deliveredCallArg().requireVisibleReply).toBeUndefined();
+    expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
+      delivered: true,
       path: "direct",
-      reason: "visible_reply_missing",
     });
-
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    try {
-      await expect(
-        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
-      ).resolves.toBe(false);
-      expect(completeBatchSpy).not.toHaveBeenCalled();
-      expect(child.requesterSettleWake).toMatchObject({
-        status: "pending",
-        attemptCount: 1,
-        nextAttemptAt: 30_000,
-        requesterYieldBatch: true,
-        rearmGeneration: 1,
-        lastError: "visible_reply_missing",
-      });
-
-      await vi.advanceTimersByTimeAsync(30_000);
-      await expect(
-        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
-      ).resolves.toBe(true);
-      expect(deliverSpy.mock.calls.map(([arg]) => arg.directIdempotencyKey)).toEqual([
-        requesterSettleKey("run-b:yield-1"),
-        requesterSettleKey("run-b:yield-1:retry-1"),
-      ]);
-      expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
-        delivered: true,
-        path: "direct",
-      });
-    } finally {
-      vi.useRealTimers();
-    }
   });
 
   it("replays an ambiguous transport failure with the same idempotency key", async () => {

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.test.ts
@@ -438,7 +438,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(true);
     expect(deliverSpy).toHaveBeenCalledOnce();
-    expect(deliveredCallArg().requireVisibleReply).toBeUndefined();
+    expect(deliveredCallArg().requireVisibleReply).toBe(true);
     const message = String(deliveredCallArg().triggerMessage);
     expect(message).toContain("create the next required subagent(s) and call sessions_yield again");
     expect(message).toContain("do not send a final answer while required work remains");
@@ -531,7 +531,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
 
     expect(woke).toBe(true);
     expect(deliverSpy).toHaveBeenCalledOnce();
-    expect(deliveredCallArg().requireVisibleReply).toBeUndefined();
+    expect(deliveredCallArg().requireVisibleReply).toBe(true);
     const message = String(deliveredCallArg().triggerMessage);
     expect(message).toContain("continue the original request from this resumed turn");
     expect(message).toContain("Otherwise send a truthful user-facing update");
@@ -673,7 +673,7 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
     }
   });
 
-  it("accepts a yielded requester continuation without requiring a visible final", async () => {
+  it("retains a yielded wake when neither a visible reply nor continuation is proven", async () => {
     const child = makeSettledChild({
       runId: "run-b",
       delivery: { status: "delivered" },
@@ -686,16 +686,44 @@ describe("maybeWakeRequesterAfterAllChildrenSettled", () => {
       },
     });
     registryRuntimeMock.listSubagentRunsForRequester.mockReturnValue([child]);
-    const woke = await maybeWakeRequesterAfterAllChildrenSettled(
-      wakeParams({ settledEntry: child }),
-    );
-
-    expect(woke).toBe(true);
-    expect(deliveredCallArg().requireVisibleReply).toBeUndefined();
-    expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
-      delivered: true,
+    deliverSpy.mockResolvedValueOnce({
+      delivered: false,
       path: "direct",
+      reason: "visible_reply_missing",
     });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      await expect(
+        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
+      ).resolves.toBe(false);
+      expect(deliveredCallArg().requireVisibleReply).toBe(true);
+      expect(completeBatchSpy).not.toHaveBeenCalled();
+      expect(child.requesterSettleWake).toMatchObject({
+        status: "pending",
+        attemptCount: 1,
+        nextAttemptAt: 30_000,
+        requesterYieldBatch: true,
+        rearmGeneration: 1,
+        lastError: "visible_reply_missing",
+      });
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(
+        maybeWakeRequesterAfterAllChildrenSettled(wakeParams({ settledEntry: child })),
+      ).resolves.toBe(true);
+      expect(deliverSpy.mock.calls.map(([arg]) => arg.directIdempotencyKey)).toEqual([
+        requesterSettleKey("run-b:yield-1"),
+        requesterSettleKey("run-b:yield-1:retry-1"),
+      ]);
+      expect(completeBatchSpy).toHaveBeenCalledWith(["run-b"], 1, {
+        delivered: true,
+        path: "direct",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("replays an ambiguous transport failure with the same idempotency key", async () => {

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -543,6 +543,21 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
       });
       return false;
     }
+    if (delivery.reason === "completion_handoff_pending" && delivery.disposition === "retryable") {
+      const lastError = delivery.error ?? "requester agent run is still in flight";
+      state = { ...state, lastError };
+      // The Gateway still owns the admitted turn. Keep the frozen dispatch key
+      // until terminal dedupe proves whether it replied or yielded more work.
+      deferRequesterSettleWakeBatch({
+        batchRunIds,
+        state,
+        transitionBatch: params.transitionBatch,
+      });
+      logWarn(
+        `requester settle wake is still in flight; replaying the same idempotency key in ${Math.round(REQUESTER_SETTLE_WAKE_RETRY_DELAYS_MS[0] / 1000)}s: ${lastError}`,
+      );
+      return false;
+    }
 
     const attemptCount = attemptIndex + 1;
     const retryDelayMs = REQUESTER_SETTLE_WAKE_RETRY_DELAYS_MS[attemptIndex];

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -50,15 +50,24 @@ const activeRequesterSettleWakeBatches = new Set<string>();
 
 function buildRequesterSettleWakeMessage(params: {
   findings?: string;
-  requireVisibleReply: boolean;
+  requesterYieldedAfterDelivery: boolean;
 }): string {
+  const continuationInstruction = params.requesterYieldedAfterDelivery
+    ? "[Subagent Context] Review the completion results, then continue the original request from this resumed turn. If more work is required, create the next required subagent(s) and call sessions_yield again; do not send a final answer while required work remains. Otherwise send a truthful user-facing update."
+    : "[Subagent Context] Review the completion results and send your consolidated final answer to the user now.";
   return [
     "[Subagent Context] Every subagent spawned from this session has now settled — none are still running or awaiting completion delivery.",
-    "[Subagent Context] Do not keep waiting or call sessions_yield again for this batch; no further completion events will arrive.",
-    "[Subagent Context] Review the completion results and send your consolidated final answer to the user now.",
-    params.requireVisibleReply
-      ? "[Subagent Context] Child completion delivery is internal; the original user request still requires your visible final answer."
-      : `[Subagent Context] Reply ONLY: ${SILENT_REPLY_TOKEN} only if you already delivered the consolidated final answer for this batch.`,
+    ...(params.requesterYieldedAfterDelivery
+      ? []
+      : [
+          "[Subagent Context] Do not keep waiting or call sessions_yield again for this batch; no further completion events will arrive.",
+        ]),
+    continuationInstruction,
+    ...(params.requesterYieldedAfterDelivery
+      ? []
+      : [
+          `[Subagent Context] Reply ONLY: ${SILENT_REPLY_TOKEN} only if you already delivered the consolidated final answer for this batch.`,
+        ]),
     "",
     params.findings ??
       "(each child result was announced individually in earlier completion events)",
@@ -381,7 +390,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
   );
   const wakeMessage = buildRequesterSettleWakeMessage({
     findings,
-    requireVisibleReply: requesterYieldedAfterDelivery,
+    requesterYieldedAfterDelivery,
   });
   const requesterSessionOrigin = normalizeDeliveryContext(params.requesterOrigin);
   const directOrigin = resolveAnnounceOrigin(requesterEntry, requesterSessionOrigin);
@@ -472,7 +481,6 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
         requesterIsSubagent: false,
         expectsCompletionMessage: false,
         requireDirectDelivery: true,
-        ...(requesterYieldedAfterDelivery ? { requireVisibleReply: true } : {}),
         directIdempotencyKey: buildAnnounceIdempotencyKey(
           attemptIndex === 0 ? wakeKeyBase : `${wakeKeyBase}:retry-${attemptIndex}`,
         ),

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -52,22 +52,18 @@ function buildRequesterSettleWakeMessage(params: {
   findings?: string;
   requesterYieldedAfterDelivery: boolean;
 }): string {
-  const continuationInstruction = params.requesterYieldedAfterDelivery
-    ? "[Subagent Context] Review the completion results, then continue the original request from this resumed turn. If more work is required, create the next required subagent(s) and call sessions_yield again; do not send a final answer while required work remains. Otherwise send a truthful user-facing update."
-    : "[Subagent Context] Review the completion results and send your consolidated final answer to the user now.";
+  const instructions = params.requesterYieldedAfterDelivery
+    ? [
+        "[Subagent Context] Review the completion results, then continue the original request from this resumed turn. If more work is required, create the next required subagent(s) and call sessions_yield again; do not send a final answer while required work remains. Otherwise send a truthful user-facing update.",
+      ]
+    : [
+        "[Subagent Context] Do not keep waiting or call sessions_yield again for this batch; no further completion events will arrive.",
+        "[Subagent Context] Review the completion results and send your consolidated final answer to the user now.",
+        `[Subagent Context] Reply ONLY: ${SILENT_REPLY_TOKEN} only if you already delivered the consolidated final answer for this batch.`,
+      ];
   return [
     "[Subagent Context] Every subagent spawned from this session has now settled — none are still running or awaiting completion delivery.",
-    ...(params.requesterYieldedAfterDelivery
-      ? []
-      : [
-          "[Subagent Context] Do not keep waiting or call sessions_yield again for this batch; no further completion events will arrive.",
-        ]),
-    continuationInstruction,
-    ...(params.requesterYieldedAfterDelivery
-      ? []
-      : [
-          `[Subagent Context] Reply ONLY: ${SILENT_REPLY_TOKEN} only if you already delivered the consolidated final answer for this batch.`,
-        ]),
+    ...instructions,
     "",
     params.findings ??
       "(each child result was announced individually in earlier completion events)",
@@ -481,6 +477,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
         requesterIsSubagent: false,
         expectsCompletionMessage: false,
         requireDirectDelivery: true,
+        ...(requesterYieldedAfterDelivery ? { requireVisibleReply: true } : {}),
         directIdempotencyKey: buildAnnounceIdempotencyKey(
           attemptIndex === 0 ? wakeKeyBase : `${wakeKeyBase}:retry-${attemptIndex}`,
         ),

--- a/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
+++ b/src/agents/subagents/announce/subagent-announce.requester-settle-wake.ts
@@ -552,6 +552,7 @@ export async function maybeWakeRequesterAfterAllChildrenSettled(params: {
         batchRunIds,
         state,
         transitionBatch: params.transitionBatch,
+        completeBatch,
       });
       logWarn(
         `requester settle wake is still in flight; replaying the same idempotency key in ${Math.round(REQUESTER_SETTLE_WAKE_RETRY_DELAYS_MS[0] / 1000)}s: ${lastError}`,

--- a/src/gateway/agent-turn/agent-dedupe.ts
+++ b/src/gateway/agent-turn/agent-dedupe.ts
@@ -29,6 +29,7 @@ export function readGatewayDedupeEntry(params: {
 
 export function isAcceptedAgentDedupePayload(payload: unknown): payload is {
   acceptedAt?: unknown;
+  admitted?: unknown;
   agentId?: unknown;
   dedupeKeys?: unknown;
   expiresAtMs?: unknown;

--- a/src/gateway/agent-turn/agent-job.ts
+++ b/src/gateway/agent-turn/agent-job.ts
@@ -538,7 +538,7 @@ function getCanonicalAgentRunSnapshot(
 
 function getAgentRunSnapshot(params: {
   runId: string;
-  source?: "chat";
+  source?: "agent" | "chat";
   afterVersion: number;
 }): AgentRunSnapshot | undefined {
   pruneAgentRunCache();
@@ -590,7 +590,7 @@ export async function waitForAgentJob(params: {
   runId: string;
   timeoutMs: number;
   ignoreCachedSnapshot?: boolean;
-  source?: "chat";
+  source?: "agent" | "chat";
 }): Promise<AgentJobTerminalSnapshot | null> {
   ensureAgentRunListener();
   const afterVersion = params.ignoreCachedSnapshot ? agentJobState.version : -1;
@@ -661,6 +661,13 @@ export async function waitForAgentJob(params: {
     timeoutHandle.unref?.();
     onWake();
   });
+}
+
+export async function waitForAgentTerminalDedupe(params: {
+  runId: string;
+  timeoutMs: number;
+}): Promise<AgentJobTerminalSnapshot | null> {
+  return await waitForAgentJob({ ...params, source: "agent" });
 }
 
 ensureAgentRunListener();

--- a/src/gateway/agent-turn/agent-request-preflight.test.ts
+++ b/src/gateway/agent-turn/agent-request-preflight.test.ts
@@ -20,6 +20,7 @@ function runPreflight(
     launchPending?: boolean;
     cached?: boolean;
     admissionPending?: boolean;
+    cachedAdmitted?: boolean;
     completed?: boolean;
     ended?: boolean;
   },
@@ -74,6 +75,7 @@ function runPreflight(
                 runId: "gateway-run",
                 sessionKey,
                 ...(options.admissionPending ? { reservationId: "pending" } : {}),
+                ...(options?.cachedAdmitted ? { admitted: true } : {}),
               },
             },
           ],
@@ -306,22 +308,26 @@ describe("agent request Swarm preflight", () => {
     );
   });
 
-  it("marks a provisional cached replay as admission pending without exposing its reservation", async () => {
+  it("preserves cached admission state without exposing its reservation", async () => {
     const replayed = runPreflight(undefined, true, {
       backend: true,
       register: true,
       launchPending: false,
       cached: true,
       admissionPending: true,
+      cachedAdmitted: true,
     });
     expect(replayed.result).toBeDefined();
+
     await replayed.replay();
+
     expect(replayed.respond).toHaveBeenCalledWith(
       true,
       expect.objectContaining({
         runId: "gateway-run",
         status: "in_flight",
         admissionPending: true,
+        admitted: true,
       }),
       undefined,
       expect.objectContaining({ cached: true, runId: "gateway-run" }),

--- a/src/gateway/agent-turn/agent-run-admission-phase.ts
+++ b/src/gateway/agent-turn/agent-run-admission-phase.ts
@@ -297,9 +297,18 @@ export async function prepareAgentRunDispatch(params: {
   const existingRunAbort = params.context.chatAbortControllers.get(params.runId);
   if (!activeRunAbort.registered && existingRunAbort) {
     activeGatewayWorkAdmission.release();
-    params.markAgentRunAccepted(existingRunAbort.kind === "agent");
+    const existingAgentRunAdmitted = existingRunAbort.kind === "agent";
+    params.markAgentRunAccepted(existingAgentRunAdmitted);
     params.io.emitAcceptance(
-      [true, { runId: params.runId, status: "in_flight" as const }, undefined],
+      [
+        true,
+        {
+          runId: params.runId,
+          status: "in_flight" as const,
+          ...(existingAgentRunAdmitted ? { admitted: true } : {}),
+        },
+        undefined,
+      ],
       {
         cached: true,
         runId: params.runId,
@@ -620,6 +629,9 @@ export async function prepareAgentRunDispatch(params: {
       ok: true,
       payload: {
         ...accepted,
+        // A reservation uses the same accepted-shaped dedupe record before this
+        // boundary. Persist the admission fact so replays transfer prompt ownership.
+        admitted: true,
         controlUiVisible: !params.suppressVisibleSessionEffects,
         dedupeKeys: params.agentDedupeKeys,
         ownerConnId: params.ownerConnId,

--- a/src/gateway/agent-turn/agent-run-dispatch.ts
+++ b/src/gateway/agent-turn/agent-run-dispatch.ts
@@ -43,6 +43,14 @@ import { setGatewayDedupeEntries } from "./agent-dedupe.js";
 import { readAgentRunDispatchExecutionIdentity } from "./agent-run-dispatch-execution-identity.js";
 import type { AgentTurnContext, AgentTurnIo } from "./types.js";
 
+/** Re-enters the command owner's typed generation after crossing the Gateway context seam. */
+export function asPreparedAgentCommandRuntimeContext(runtime: {
+  config: PreparedAgentCommandRuntimeContext["config"];
+  pluginGeneration: object;
+}): PreparedAgentCommandRuntimeContext {
+  return runtime as unknown as PreparedAgentCommandRuntimeContext;
+}
+
 function resolveResolvedAgentTimeoutStopReason(
   meta: unknown,
   signal: AbortSignal,

--- a/src/gateway/agent-turn/agent-run-dispatch.ts
+++ b/src/gateway/agent-turn/agent-run-dispatch.ts
@@ -48,7 +48,8 @@ export function asPreparedAgentCommandRuntimeContext(runtime: {
   config: PreparedAgentCommandRuntimeContext["config"];
   pluginGeneration: object;
 }): PreparedAgentCommandRuntimeContext {
-  return runtime as unknown as PreparedAgentCommandRuntimeContext;
+  // SAFETY: Gateway publishes this opaque generation from the same prepared-runtime contract.
+  return runtime as PreparedAgentCommandRuntimeContext;
 }
 
 function resolveResolvedAgentTimeoutStopReason(

--- a/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
@@ -13,13 +13,7 @@ vi.mock("./agent-run-dispatch.js", () => ({
   resolveAbortedAgentStopReason: () => "rpc",
 }));
 
-function createExecution(
-  options: {
-    aborted?: boolean;
-    assertContextCurrent?: () => void;
-    contextPublishesRuntime?: boolean;
-  } = {},
-) {
+function createExecution(options: { aborted?: boolean; assertContextCurrent?: () => void } = {}) {
   const abortCleanup = vi.fn();
   const gatewayRelease = vi.fn();
   const replyDispatchRuntime = {
@@ -90,9 +84,7 @@ function createExecution(
       context: {
         dedupe: new Map(),
         deps: {},
-        ...(options.contextPublishesRuntime === false
-          ? {}
-          : { loadPublishedGatewayReplyDispatchRuntime: vi.fn(async () => replyDispatchRuntime) }),
+        loadPublishedGatewayReplyDispatchRuntime: vi.fn(async () => replyDispatchRuntime),
         logGateway: { error: vi.fn(), warn: vi.fn() },
       },
       io: {
@@ -151,18 +143,6 @@ describe("startAgentRunExecution Gateway ownership", () => {
     resolveCleanupObserved();
     await expect(borrowedAfterCleanup).resolves.toBeUndefined();
     expect(execution.runtimeRelease).toHaveBeenCalledOnce();
-  });
-
-  it("uses the admitted runtime when the request context has no publication loader", async () => {
-    const execution = createExecution({ contextPublishesRuntime: false });
-
-    startAgentRunExecution(execution.params);
-
-    await vi.waitFor(() => expect(dispatchAgentRunFromGateway).toHaveBeenCalledOnce());
-    expect(dispatchAgentRunFromGateway.mock.calls[0]?.[0]?.commandRuntimeContext).toEqual({
-      config: { runtime: "A" },
-      pluginGeneration: "generation-A",
-    });
   });
 
   it("releases the admitted runtime once when aborted before dispatch", async () => {

--- a/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
@@ -8,6 +8,7 @@ import { startAgentRunExecution } from "./agent-run-execution-phase.js";
 const dispatchAgentRunFromGateway = vi.hoisted(() => vi.fn());
 
 vi.mock("./agent-run-dispatch.js", () => ({
+  asPreparedAgentCommandRuntimeContext: (runtime: unknown) => runtime,
   dispatchAgentRunFromGateway,
   resolveAbortedAgentStopReason: () => "rpc",
 }));
@@ -15,6 +16,10 @@ vi.mock("./agent-run-dispatch.js", () => ({
 function createExecution(options: { aborted?: boolean; assertContextCurrent?: () => void } = {}) {
   const abortCleanup = vi.fn();
   const gatewayRelease = vi.fn();
+  const replyDispatchRuntime = {
+    config: { runtime: "A" },
+    pluginGeneration: "generation-A",
+  };
   let resolveRuntimeReleased!: () => void;
   const runtimeReleased = new Promise<void>((resolve) => {
     resolveRuntimeReleased = resolve;
@@ -46,10 +51,7 @@ function createExecution(options: { aborted?: boolean; assertContextCurrent?: ()
         lifecycleStorePath: "",
         operationalRunInstance: {},
         preparedModelRuntimeLease: { release: runtimeRelease, snapshot: {} },
-        replyDispatchRuntime: {
-          config: { runtime: "A" },
-          pluginGeneration: "generation-A",
-        },
+        replyDispatchRuntime,
         unpersistedOffloadedRefs: [],
         userTurn: {
           execApprovalFollowupHandoffClaimId: "claim",
@@ -82,6 +84,7 @@ function createExecution(options: { aborted?: boolean; assertContextCurrent?: ()
       context: {
         dedupe: new Map(),
         deps: {},
+        loadPublishedGatewayReplyDispatchRuntime: vi.fn(async () => replyDispatchRuntime),
         logGateway: { error: vi.fn(), warn: vi.fn() },
       },
       io: {

--- a/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
@@ -13,7 +13,13 @@ vi.mock("./agent-run-dispatch.js", () => ({
   resolveAbortedAgentStopReason: () => "rpc",
 }));
 
-function createExecution(options: { aborted?: boolean; assertContextCurrent?: () => void } = {}) {
+function createExecution(
+  options: {
+    aborted?: boolean;
+    assertContextCurrent?: () => void;
+    contextPublishesRuntime?: boolean;
+  } = {},
+) {
   const abortCleanup = vi.fn();
   const gatewayRelease = vi.fn();
   const replyDispatchRuntime = {
@@ -84,7 +90,9 @@ function createExecution(options: { aborted?: boolean; assertContextCurrent?: ()
       context: {
         dedupe: new Map(),
         deps: {},
-        loadPublishedGatewayReplyDispatchRuntime: vi.fn(async () => replyDispatchRuntime),
+        ...(options.contextPublishesRuntime === false
+          ? {}
+          : { loadPublishedGatewayReplyDispatchRuntime: vi.fn(async () => replyDispatchRuntime) }),
         logGateway: { error: vi.fn(), warn: vi.fn() },
       },
       io: {
@@ -143,6 +151,18 @@ describe("startAgentRunExecution Gateway ownership", () => {
     resolveCleanupObserved();
     await expect(borrowedAfterCleanup).resolves.toBeUndefined();
     expect(execution.runtimeRelease).toHaveBeenCalledOnce();
+  });
+
+  it("uses the admitted runtime when the request context has no publication loader", async () => {
+    const execution = createExecution({ contextPublishesRuntime: false });
+
+    startAgentRunExecution(execution.params);
+
+    await vi.waitFor(() => expect(dispatchAgentRunFromGateway).toHaveBeenCalledOnce());
+    expect(dispatchAgentRunFromGateway.mock.calls[0]?.[0]?.commandRuntimeContext).toEqual({
+      config: { runtime: "A" },
+      pluginGeneration: "generation-A",
+    });
   });
 
   it("releases the admitted runtime once when aborted before dispatch", async () => {

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -248,6 +248,19 @@ export function startAgentRunExecution(params: {
       const ingressAgentId = params.resolvedSessionKey
         ? params.activeSessionAgentId
         : params.agentId;
+      // Resolve through the live Gateway context rather than this module's imports. Plugin
+      // loaders can host a second OpenClaw module graph; the context callback remains bound to
+      // the Gateway owner that published this generation.
+      const replyDispatchRuntime =
+        await params.context.loadPublishedGatewayReplyDispatchRuntime?.({
+          agentId: params.activeSessionAgentId,
+          abortSignal: prepared.activeRunAbort.controller.signal,
+        });
+      if (!replyDispatchRuntime?.pluginGeneration) {
+        throw new Error(
+          `prepared reply dispatch runtime was not published for ${params.activeSessionAgentId}`,
+        );
+      }
       // Plugin-owned additive grants stay internal to the authenticated in-process run.
       // Public agent params cannot supply them, and normal tool policy still filters them.
       const runtimePluginToolGrant =

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -252,10 +252,14 @@ export function startAgentRunExecution(params: {
       // Resolve through the live Gateway context rather than this module's imports. Plugin
       // loaders can host a second OpenClaw module graph; the context callback remains bound to
       // the Gateway owner that published this generation.
-      const replyDispatchRuntime = await params.context.loadPublishedGatewayReplyDispatchRuntime?.({
-        agentId: params.activeSessionAgentId,
-        abortSignal: prepared.activeRunAbort.controller.signal,
-      });
+      // Direct handler contexts may not expose the optional callback, but admission already
+      // validated the prepared runtime for those callers.
+      const replyDispatchRuntime = params.context.loadPublishedGatewayReplyDispatchRuntime
+        ? await params.context.loadPublishedGatewayReplyDispatchRuntime({
+            agentId: params.activeSessionAgentId,
+            abortSignal: prepared.activeRunAbort.controller.signal,
+          })
+        : prepared.replyDispatchRuntime;
       if (!replyDispatchRuntime?.pluginGeneration) {
         throw new Error(
           `prepared reply dispatch runtime was not published for ${params.activeSessionAgentId}`,

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -251,11 +251,10 @@ export function startAgentRunExecution(params: {
       // Resolve through the live Gateway context rather than this module's imports. Plugin
       // loaders can host a second OpenClaw module graph; the context callback remains bound to
       // the Gateway owner that published this generation.
-      const replyDispatchRuntime =
-        await params.context.loadPublishedGatewayReplyDispatchRuntime?.({
-          agentId: params.activeSessionAgentId,
-          abortSignal: prepared.activeRunAbort.controller.signal,
-        });
+      const replyDispatchRuntime = await params.context.loadPublishedGatewayReplyDispatchRuntime?.({
+        agentId: params.activeSessionAgentId,
+        abortSignal: prepared.activeRunAbort.controller.signal,
+      });
       if (!replyDispatchRuntime?.pluginGeneration) {
         throw new Error(
           `prepared reply dispatch runtime was not published for ${params.activeSessionAgentId}`,

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -252,14 +252,10 @@ export function startAgentRunExecution(params: {
       // Resolve through the live Gateway context rather than this module's imports. Plugin
       // loaders can host a second OpenClaw module graph; the context callback remains bound to
       // the Gateway owner that published this generation.
-      // Direct handler contexts may not expose the optional callback, but admission already
-      // validated the prepared runtime for those callers.
-      const replyDispatchRuntime = params.context.loadPublishedGatewayReplyDispatchRuntime
-        ? await params.context.loadPublishedGatewayReplyDispatchRuntime({
-            agentId: params.activeSessionAgentId,
-            abortSignal: prepared.activeRunAbort.controller.signal,
-          })
-        : prepared.replyDispatchRuntime;
+      const replyDispatchRuntime = await params.context.loadPublishedGatewayReplyDispatchRuntime?.({
+        agentId: params.activeSessionAgentId,
+        abortSignal: prepared.activeRunAbort.controller.signal,
+      });
       if (!replyDispatchRuntime?.pluginGeneration) {
         throw new Error(
           `prepared reply dispatch runtime was not published for ${params.activeSessionAgentId}`,

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -54,6 +54,7 @@ import type { PreparedAgentRunDispatch } from "./agent-run-admission-phase.js";
 import { withAgentRunDispatchExecutionIdentity } from "./agent-run-dispatch-execution-identity.js";
 import {
   resolveAbortedAgentStopReason,
+  asPreparedAgentCommandRuntimeContext,
   dispatchAgentRunFromGateway,
 } from "./agent-run-dispatch.js";
 import { resolveExecutionIdentitySpawnFacts } from "./agent-run-execution-lineage.js";
@@ -325,10 +326,7 @@ export function startAgentRunExecution(params: {
       dispatchAdmittedAgentRun(
         withAgentRunDispatchExecutionIdentity(
           {
-            commandRuntimeContext: {
-              config: prepared.replyDispatchRuntime.config,
-              pluginGeneration: prepared.replyDispatchRuntime.pluginGeneration,
-            },
+            commandRuntimeContext: asPreparedAgentCommandRuntimeContext(replyDispatchRuntime),
             cronCreatorAuthority: prepared.cronCreatorAuthority,
             ingressOpts: {
               message,

--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -60,6 +60,7 @@ function replayAgentTurnIfCached(params: {
     const cachedAgentId = normalizeOptionalString(cached.payload.agentId);
     const cachedRuntime = asOptionalRecord(cached.payload.runtime);
     const admissionPending = typeof cached.payload.reservationId === "string";
+    const cachedAdmitted = cached.payload.admitted === true;
     params.io.emitAcceptance(
       [
         true,
@@ -70,6 +71,7 @@ function replayAgentTurnIfCached(params: {
           ...(cachedAgentId ? { agentId: cachedAgentId } : {}),
           ...(cachedRuntime ? { runtime: cachedRuntime } : {}),
           ...(admissionPending ? { admissionPending: true } : {}),
+          ...(cachedAdmitted ? { admitted: true } : {}),
         },
         undefined,
       ],

--- a/src/gateway/agent-turn/agent-wait-dedupe.test.ts
+++ b/src/gateway/agent-turn/agent-wait-dedupe.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { agentHandlers } from "../server-methods/agent.js";
 import type { DedupeEntry } from "../server-shared.js";
-import { setGatewayDedupeEntry } from "./agent-job.js";
+import { setGatewayDedupeEntry, waitForAgentTerminalDedupe } from "./agent-job.js";
 
 function waitThroughGateway(
   params: { runId: string; timeoutMs: number },
@@ -110,6 +110,26 @@ describe("agent.wait gateway dedupe observations", () => {
     };
     expect(first.respond).toHaveBeenCalledWith(true, expected);
     expect(second.respond).toHaveBeenCalledWith(true, expected);
+  });
+
+  it("keeps terminal-dedupe readiness pending after lifecycle completion", async () => {
+    const runId = "run-terminal-dedupe-readiness";
+    const dedupe = new Map<string, DedupeEntry>();
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 100, endedAt: 200 },
+    });
+    let settled = false;
+    const readiness = waitForAgentTerminalDedupe({ runId, timeoutMs: 1_000 }).finally(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    completeRun(dedupe, runId);
+
+    await expect(readiness).resolves.toMatchObject({ status: "ok", endedAt: 200 });
   });
 
   it("lets a fresh wait observe completion after an earlier waiter times out", async () => {

--- a/src/gateway/agent-turn/internal-facade.test.ts
+++ b/src/gateway/agent-turn/internal-facade.test.ts
@@ -89,6 +89,49 @@ describe("createInternalAgentTurnFacade", () => {
     });
   });
 
+  it("uses one timeout across acceptance and final response", async () => {
+    vi.useFakeTimers();
+    startTurn.mockImplementation(
+      async ({ io }) =>
+        await new Promise<void>((resolve) => {
+          setTimeout(() => {
+            io.emitAcceptance([true, { runId: "run-deadline", status: "accepted" }, undefined]);
+            setTimeout(() => {
+              io.emitFinal([true, { runId: "run-deadline", status: "ok" }, undefined]);
+              resolve();
+            }, 600);
+          }, 600);
+        }),
+    );
+
+    try {
+      let settled = false;
+      const outcome = createFacade()
+        .dispatchRaw(
+          { message: "test", idempotencyKey: "run-deadline" },
+          { expectFinal: true, timeoutMs: 1_000 },
+        )
+        .then(
+          () => ({ status: "resolved" as const }),
+          (error: unknown) => ({ error, status: "rejected" as const }),
+        )
+        .finally(() => {
+          settled = true;
+        });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(settled).toBe(true);
+      await expect(outcome).resolves.toMatchObject({
+        status: "rejected",
+        error: { message: "gateway request timeout for agent" },
+      });
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("preserves post-acceptance Error identity", async () => {
     let rejectTurn!: (error: Error) => void;
     startTurn.mockImplementation(
@@ -159,12 +202,65 @@ describe("createInternalAgentTurnFacade", () => {
       ok: true,
       payload: { runId: "run-replay", status: "ok", result: terminalResult },
     });
-    expect(waitForTurn).toHaveBeenCalledWith({ runId: "run-replay", timeoutMs: 1_000 });
+    const waitTimeoutMs = waitForTurn.mock.calls[0]?.[0].timeoutMs;
+    expect(waitTimeoutMs).toBeGreaterThan(0);
+    expect(waitTimeoutMs).toBeLessThanOrEqual(1_000);
     expect(startTurn).toHaveBeenCalledTimes(2);
     expect(startTurn.mock.calls.map(([call]) => call.preflight.request.idempotencyKey)).toEqual([
       "same-request",
       "same-request",
     ]);
+  });
+
+  it("keeps terminal dedupe replay within the original timeout", async () => {
+    vi.useFakeTimers();
+    startTurn
+      .mockImplementationOnce(async ({ io }) => {
+        io.emitAcceptance([true, { runId: "run-replay", status: "in_flight" }, undefined]);
+      })
+      .mockImplementationOnce(
+        async ({ io }) =>
+          await new Promise<void>((resolve) => {
+            setTimeout(() => {
+              io.emitAcceptance([true, { runId: "run-replay", status: "ok" }, undefined]);
+              resolve();
+            }, 500);
+          }),
+      );
+    waitForTurn.mockImplementation(
+      async () =>
+        await new Promise((resolve) => {
+          setTimeout(() => resolve({ runId: "run-replay", status: "ok" }), 600);
+        }),
+    );
+
+    try {
+      let settled = false;
+      const outcome = createFacade()
+        .dispatchRaw(
+          { message: "test", idempotencyKey: "same-request" },
+          { expectFinal: true, timeoutMs: 1_000 },
+        )
+        .then(
+          () => ({ status: "resolved" as const }),
+          (error: unknown) => ({ error, status: "rejected" as const }),
+        )
+        .finally(() => {
+          settled = true;
+        });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(settled).toBe(true);
+      await expect(outcome).resolves.toMatchObject({
+        status: "rejected",
+        error: { message: "gateway request timeout for agent" },
+      });
+      expect(startTurn).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
   });
 
   it("keeps a cached replay in flight when the wait reaches a nonterminal timeout", async () => {

--- a/src/gateway/agent-turn/internal-facade.test.ts
+++ b/src/gateway/agent-turn/internal-facade.test.ts
@@ -3,7 +3,10 @@ import type { GatewayRequestContext } from "../server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "../server-plugin-runtime-client.js";
 import { createInternalAgentTurnFacade } from "./internal-facade.js";
 
-const startTurn = vi.hoisted(() => vi.fn());
+const { startTurn, waitForTurn } = vi.hoisted(() => ({
+  startTurn: vi.fn(),
+  waitForTurn: vi.fn(),
+}));
 
 vi.mock("../server-methods.js", () => ({
   authorizeGatewayRequestPreDispatch: async () => ({ error: null }),
@@ -24,7 +27,7 @@ vi.mock("./agent-request-preflight.js", () => ({
 vi.mock("./agent-turn-service.js", () => ({
   createAgentTurnService: () => ({
     startTurn,
-    waitForTurn: vi.fn(),
+    waitForTurn,
   }),
 }));
 
@@ -43,6 +46,7 @@ function createFacade() {
 describe("createInternalAgentTurnFacade", () => {
   beforeEach(() => {
     startTurn.mockReset();
+    waitForTurn.mockReset();
   });
 
   it("preserves accepted/final ordering and acceptance metadata without frames", async () => {
@@ -119,6 +123,45 @@ describe("createInternalAgentTurnFacade", () => {
       error: undefined,
       meta: { cached: true, runId: "run-2" },
     });
+  });
+
+  it("reattaches an in-flight replay and returns its full terminal dedupe result", async () => {
+    const terminalResult = {
+      payloads: [],
+      meta: { yielded: true },
+      acceptedSessionSpawns: [{ runId: "run-child", childSessionKey: "agent:main:subagent:child" }],
+    };
+    startTurn
+      .mockImplementationOnce(async ({ io }) => {
+        io.emitAcceptance([true, { runId: "run-replay", status: "in_flight" }, undefined], {
+          cached: true,
+          runId: "run-replay",
+        });
+      })
+      .mockImplementationOnce(async ({ io }) => {
+        io.emitAcceptance([
+          true,
+          { runId: "run-replay", status: "ok", result: terminalResult },
+          undefined,
+        ]);
+      });
+    waitForTurn.mockResolvedValue({ runId: "run-replay", status: "ok" });
+
+    await expect(
+      createFacade().dispatchRaw(
+        { message: "test", idempotencyKey: "same-request" },
+        { expectFinal: true, timeoutMs: 1_000 },
+      ),
+    ).resolves.toMatchObject({
+      ok: true,
+      payload: { runId: "run-replay", status: "ok", result: terminalResult },
+    });
+    expect(waitForTurn).toHaveBeenCalledWith({ runId: "run-replay", timeoutMs: 1_000 });
+    expect(startTurn).toHaveBeenCalledTimes(2);
+    expect(startTurn.mock.calls.map(([call]) => call.preflight.request.idempotencyKey)).toEqual([
+      "same-request",
+      "same-request",
+    ]);
   });
 
   it("passes the exact internal execution-start observer to the turn", async () => {

--- a/src/gateway/agent-turn/internal-facade.test.ts
+++ b/src/gateway/agent-turn/internal-facade.test.ts
@@ -5,13 +5,20 @@ import type { GatewayRequestContext } from "../server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "../server-plugin-runtime-client.js";
 import { createInternalAgentTurnFacade } from "./internal-facade.js";
 
-const { startTurn, waitForTurn } = vi.hoisted(() => ({
-  startTurn: vi.fn(),
-  waitForTurn: vi.fn(),
+const { authorizeGatewayRequestPreDispatch, startTurn, waitForAgentTerminalDedupe, waitForTurn } =
+  vi.hoisted(() => ({
+    authorizeGatewayRequestPreDispatch: vi.fn(),
+    startTurn: vi.fn(),
+    waitForAgentTerminalDedupe: vi.fn(),
+    waitForTurn: vi.fn(),
+  }));
+
+vi.mock("./agent-job.js", () => ({
+  waitForAgentTerminalDedupe,
 }));
 
 vi.mock("../server-methods.js", () => ({
-  authorizeGatewayRequestPreDispatch: async () => ({ error: null }),
+  authorizeGatewayRequestPreDispatch,
   createRequestGatewayMethodRegistry: () => ({
     isControlPlaneWrite: () => false,
   }),
@@ -33,23 +40,87 @@ vi.mock("./agent-turn-service.js", () => ({
   }),
 }));
 
-function createFacade() {
+function createFacade(
+  options: {
+    assertContextCurrent?: () => void;
+    getContext?: () => GatewayRequestContext;
+  } = {},
+) {
   return createInternalAgentTurnFacade({
+    assertContextCurrent: options.assertContextCurrent,
     client: createSyntheticPluginRuntimeClient(),
-    getContext: () =>
-      ({
-        dedupe: new Map(),
-        chatAbortControllers: new Map(),
-        getRuntimeConfig: () => ({}),
-        logGateway: { error: vi.fn(), warn: vi.fn() },
-      }) as unknown as GatewayRequestContext,
+    getContext:
+      options.getContext ??
+      (() =>
+        ({
+          dedupe: new Map(),
+          chatAbortControllers: new Map(),
+          getRuntimeConfig: () => ({}),
+          logGateway: { error: vi.fn(), warn: vi.fn() },
+        }) as unknown as GatewayRequestContext),
   });
 }
 
 describe("createInternalAgentTurnFacade", () => {
   beforeEach(() => {
+    authorizeGatewayRequestPreDispatch.mockReset();
+    authorizeGatewayRequestPreDispatch.mockResolvedValue({ error: null });
     startTurn.mockReset();
+    waitForAgentTerminalDedupe.mockReset();
+    waitForAgentTerminalDedupe.mockResolvedValue({ status: "ok" });
     waitForTurn.mockReset();
+  });
+
+  it("rejects agent.wait when authorization retires its captured context", async () => {
+    let releaseAuthorization!: (result: { error: null }) => void;
+    authorizeGatewayRequestPreDispatch.mockImplementationOnce(
+      async () =>
+        await new Promise<{ error: null }>((resolve) => {
+          releaseAuthorization = resolve;
+        }),
+    );
+    let contextCurrent = true;
+    const assertContextCurrent = vi.fn(() => {
+      if (!contextCurrent) {
+        throw new Error("retired gateway context");
+      }
+    });
+    const result = createFacade({ assertContextCurrent }).wait({
+      runId: "run-retired-during-auth",
+    });
+
+    await vi.waitFor(() => expect(releaseAuthorization).toBeTypeOf("function"));
+    contextCurrent = false;
+    releaseAuthorization({ error: null });
+
+    await expect(result).rejects.toThrow("retired gateway context");
+    expect(waitForTurn).not.toHaveBeenCalled();
+  });
+
+  it("rejects agent.wait when its context retires while the wait is pending", async () => {
+    let releaseWait!: (result: { runId: string; status: "ok" }) => void;
+    waitForTurn.mockImplementationOnce(
+      async () =>
+        await new Promise<{ runId: string; status: "ok" }>((resolve) => {
+          releaseWait = resolve;
+        }),
+    );
+    let contextCurrent = true;
+    const assertContextCurrent = vi.fn(() => {
+      if (!contextCurrent) {
+        throw new Error("retired gateway context");
+      }
+    });
+    const result = createFacade({ assertContextCurrent }).wait({
+      runId: "run-retired-during-wait",
+    });
+
+    await vi.waitFor(() => expect(waitForTurn).toHaveBeenCalledOnce());
+    contextCurrent = false;
+    releaseWait({ runId: "run-retired-during-wait", status: "ok" });
+
+    await expect(result).rejects.toThrow("retired gateway context");
+    expect(assertContextCurrent).toHaveBeenCalledTimes(2);
   });
 
   it("preserves accepted/final ordering and acceptance metadata without frames", async () => {
@@ -192,13 +263,23 @@ describe("createInternalAgentTurnFacade", () => {
         ]);
       });
     waitForTurn.mockResolvedValue({ runId: "run-replay", status: "ok" });
+    let releaseTerminalDedupe!: (result: { status: "ok" }) => void;
+    waitForAgentTerminalDedupe.mockImplementationOnce(
+      async () =>
+        await new Promise<{ status: "ok" }>((resolve) => {
+          releaseTerminalDedupe = resolve;
+        }),
+    );
 
-    await expect(
-      createFacade().dispatchRaw(
-        { message: "test", idempotencyKey: "same-request" },
-        { expectFinal: true, timeoutMs: 1_000 },
-      ),
-    ).resolves.toMatchObject({
+    const result = createFacade().dispatchRaw(
+      { message: "test", idempotencyKey: "same-request" },
+      { expectFinal: true, timeoutMs: 1_000 },
+    );
+    await vi.waitFor(() => expect(waitForAgentTerminalDedupe).toHaveBeenCalledOnce());
+    expect(startTurn).toHaveBeenCalledOnce();
+    releaseTerminalDedupe({ status: "ok" });
+
+    await expect(result).resolves.toMatchObject({
       ok: true,
       payload: { runId: "run-replay", status: "ok", result: terminalResult },
     });

--- a/src/gateway/agent-turn/internal-facade.test.ts
+++ b/src/gateway/agent-turn/internal-facade.test.ts
@@ -145,6 +145,49 @@ describe("createInternalAgentTurnFacade", () => {
     }
   });
 
+  it.each([
+    {
+      method: "agent",
+      invoke: () =>
+        createFacade().dispatchRaw(
+          { message: "test", idempotencyKey: "run-authorization-at-deadline" },
+          { timeoutMs: 1_000 },
+        ),
+      work: startTurn,
+    },
+    {
+      method: "agent.wait",
+      invoke: () => createFacade().wait({ runId: "run-wait-authorization-at-deadline" }, 1_000),
+      work: waitForTurn,
+    },
+  ])("rejects $method when authorization resolves at its deadline", async (testCase) => {
+    vi.useFakeTimers();
+    authorizeGatewayRequestPreDispatch.mockImplementationOnce(
+      async () =>
+        await new Promise<{ error: null }>((resolve) => {
+          setTimeout(() => resolve({ error: null }), 1_000);
+        }),
+    );
+
+    try {
+      const outcome = testCase.invoke().then(
+        () => ({ status: "resolved" as const }),
+        (error: unknown) => ({ error, status: "rejected" as const }),
+      );
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(outcome).resolves.toMatchObject({
+        status: "rejected",
+        error: { message: `gateway request timeout for ${testCase.method}` },
+      });
+      expect(testCase.work).not.toHaveBeenCalled();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects agent.wait when its context retires while the wait is pending", async () => {
     let releaseWait!: (result: { runId: string; status: "ok" }) => void;
     waitForTurn.mockImplementationOnce(

--- a/src/gateway/agent-turn/internal-facade.test.ts
+++ b/src/gateway/agent-turn/internal-facade.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { dispatchRestartRecoveryUntilStarted } from "../../agents/main-session-recovery/main-session-restart-dispatch-start.js";
+import type { GatewayRecoveryRuntime } from "../server-instance-runtime.types.js";
 import type { GatewayRequestContext } from "../server-methods/types.js";
 import { createSyntheticPluginRuntimeClient } from "../server-plugin-runtime-client.js";
 import { createInternalAgentTurnFacade } from "./internal-facade.js";
@@ -37,6 +39,7 @@ function createFacade() {
     getContext: () =>
       ({
         dedupe: new Map(),
+        chatAbortControllers: new Map(),
         getRuntimeConfig: () => ({}),
         logGateway: { error: vi.fn(), warn: vi.fn() },
       }) as unknown as GatewayRequestContext,
@@ -162,6 +165,100 @@ describe("createInternalAgentTurnFacade", () => {
       "same-request",
       "same-request",
     ]);
+  });
+
+  it("keeps a cached replay in flight when the wait reaches a nonterminal timeout", async () => {
+    startTurn.mockImplementation(async ({ io }) => {
+      io.emitAcceptance([true, { runId: "run-pending", status: "in_flight" }, undefined], {
+        cached: true,
+        runId: "run-pending",
+      });
+    });
+    waitForTurn.mockResolvedValue({
+      runId: "run-pending",
+      status: "timeout",
+      timeoutPhase: "gateway_draining",
+    });
+    const onAccepted = vi.fn();
+
+    await expect(
+      createFacade().dispatchRaw(
+        { message: "test", idempotencyKey: "same-pending-request" },
+        { expectFinal: true, onAccepted, timeoutMs: 1_000 },
+      ),
+    ).resolves.toMatchObject({
+      ok: true,
+      payload: { runId: "run-pending", status: "in_flight" },
+    });
+    expect(onAccepted).toHaveBeenCalledWith({ runId: "run-pending", status: "in_flight" });
+    expect(startTurn).toHaveBeenCalledOnce();
+  });
+
+  it("lets restart recovery abort the exact cached run before reattachment completes", async () => {
+    vi.useFakeTimers();
+    startTurn.mockImplementation(async ({ io }) => {
+      io.emitAcceptance([true, { runId: "recovery-cached", status: "in_flight" }, undefined], {
+        cached: true,
+        runId: "recovery-cached",
+      });
+    });
+    waitForTurn.mockImplementation(async () => await new Promise<never>(() => {}));
+    const facade = createFacade();
+    const abortAgent = vi.fn<GatewayRecoveryRuntime["abortAgent"]>(async () => ({
+      aborted: true,
+    }));
+    const gatewayRuntime: GatewayRecoveryRuntime = {
+      abortAgent,
+      dispatchAgent: async (request, timeoutMs, options) =>
+        await facade.dispatch(request, {
+          expectFinal: options?.expectFinal,
+          onAccepted: options?.onAccepted,
+          onExecutionStarted: options?.onExecutionStarted,
+          onSignalAbort: options?.onSignalAbort,
+          signal: options?.signal,
+          timeoutMs,
+        }),
+      waitForAgent: vi.fn(),
+      sendRecoveryNotice: vi.fn(),
+    };
+
+    try {
+      const outcome = dispatchRestartRecoveryUntilStarted({
+        agentId: "main",
+        agentParams: {
+          agentId: "main",
+          idempotencyKey: "recovery-cached",
+          message: "resume",
+          sessionKey: "agent:main:main",
+        },
+        gatewayRuntime,
+        recoveryRunId: "recovery-cached",
+        sessionKey: "agent:main:main",
+      });
+
+      await vi.waitFor(() => expect(startTurn).toHaveBeenCalledOnce());
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      await expect(outcome).resolves.toMatchObject({
+        kind: "failed",
+        observation: {
+          dispatchAccepted: true,
+          executionStarted: false,
+          preStartAbortAttempted: true,
+          preStartAbortConfirmed: true,
+        },
+      });
+      expect(abortAgent).toHaveBeenCalledWith(
+        {
+          agentId: "main",
+          runId: "recovery-cached",
+          sessionKey: "agent:main:main",
+        },
+        2_000,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("passes the exact internal execution-start observer to the turn", async () => {

--- a/src/gateway/agent-turn/internal-facade.test.ts
+++ b/src/gateway/agent-turn/internal-facade.test.ts
@@ -344,6 +344,43 @@ describe("createInternalAgentTurnFacade", () => {
     }
   });
 
+  it("rejects when terminal dedupe readiness expires", async () => {
+    vi.useFakeTimers();
+    startTurn.mockImplementation(async ({ io }) => {
+      io.emitAcceptance([true, { runId: "run-readiness-timeout", status: "in_flight" }, undefined]);
+    });
+    waitForTurn.mockResolvedValue({ runId: "run-readiness-timeout", status: "ok" });
+    waitForAgentTerminalDedupe.mockImplementationOnce(
+      async ({ timeoutMs }: { timeoutMs: number }) =>
+        await new Promise<null>((resolve) => {
+          setTimeout(() => resolve(null), timeoutMs);
+        }),
+    );
+
+    try {
+      const outcome = createFacade()
+        .dispatchRaw(
+          { message: "test", idempotencyKey: "readiness-timeout" },
+          { expectFinal: true },
+        )
+        .then(
+          () => ({ status: "resolved" as const }),
+          (error: unknown) => ({ error, status: "rejected" as const }),
+        );
+      await vi.waitFor(() => expect(waitForAgentTerminalDedupe).toHaveBeenCalledOnce());
+      await vi.advanceTimersByTimeAsync(30_000);
+
+      await expect(outcome).resolves.toMatchObject({
+        status: "rejected",
+        error: { message: "gateway request timeout for agent" },
+      });
+      expect(startTurn).toHaveBeenCalledOnce();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("keeps a cached replay in flight when the wait reaches a nonterminal timeout", async () => {
     startTurn.mockImplementation(async ({ io }) => {
       io.emitAcceptance([true, { runId: "run-pending", status: "in_flight" }, undefined], {

--- a/src/gateway/agent-turn/internal-facade.test.ts
+++ b/src/gateway/agent-turn/internal-facade.test.ts
@@ -97,6 +97,54 @@ describe("createInternalAgentTurnFacade", () => {
     expect(waitForTurn).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      method: "agent",
+      invoke: () =>
+        createFacade().dispatchRaw(
+          { message: "test", idempotencyKey: "run-authorization-timeout" },
+          { timeoutMs: 1_000 },
+        ),
+      work: startTurn,
+    },
+    {
+      method: "agent.wait",
+      invoke: () => createFacade().wait({ runId: "run-wait-authorization-timeout" }, 1_000),
+      work: waitForTurn,
+    },
+  ])("rejects $method before work when authorization exhausts its deadline", async (testCase) => {
+    vi.useFakeTimers();
+    authorizeGatewayRequestPreDispatch.mockImplementationOnce(
+      async () => await new Promise<never>(() => {}),
+    );
+
+    try {
+      let settled = false;
+      const outcome = testCase
+        .invoke()
+        .then(
+          () => ({ status: "resolved" as const }),
+          (error: unknown) => ({ error, status: "rejected" as const }),
+        )
+        .finally(() => {
+          settled = true;
+        });
+      expect(authorizeGatewayRequestPreDispatch).toHaveBeenCalledOnce();
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(settled).toBe(true);
+      await expect(outcome).resolves.toMatchObject({
+        status: "rejected",
+        error: { message: `gateway request timeout for ${testCase.method}` },
+      });
+      expect(testCase.work).not.toHaveBeenCalled();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("rejects agent.wait when its context retires while the wait is pending", async () => {
     let releaseWait!: (result: { runId: string; status: "ok" }) => void;
     waitForTurn.mockImplementationOnce(

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -7,8 +7,10 @@ import {
 import type { GatewayMethodRegistry } from "../methods/registry.js";
 import {
   type GatewayMethodDispatchResponse,
+  resolveGatewayDispatchDeadlineMs,
+  resolveRemainingGatewayDispatchTimeoutMs,
   throwIfGatewayDispatchAborted,
-  waitForGatewayDispatch,
+  waitForGatewayDispatchDeadline,
   unwrapGatewayMethodDispatchResponse,
 } from "../server-in-process-dispatch.js";
 import {
@@ -48,9 +50,9 @@ export function createInternalAgentTurnFacade(
   const isWebchatConnect = options.isWebchatConnect ?? (() => false);
   const getMethodRegistry = options.getMethodRegistry ?? createRequestGatewayMethodRegistry;
 
-  const wait = async <T = unknown>(
+  const waitUntil = async <T = unknown>(
     params: AgentWaitParams,
-    timeoutMs?: number,
+    deadlineMs?: number,
     signal?: AbortSignal,
     onSignalAbort?: () => Promise<void> | void,
   ): Promise<T> => {
@@ -84,8 +86,22 @@ export function createInternalAgentTurnFacade(
         reject: (error) => throwEnvelopeRejection(method, error),
       },
     );
-    return (await waitForGatewayDispatch(method, result, timeoutMs, signal, onSignalAbort)) as T;
+    return (await waitForGatewayDispatchDeadline(
+      method,
+      result,
+      deadlineMs,
+      signal,
+      onSignalAbort,
+    )) as T;
   };
+
+  const wait = async <T = unknown>(
+    params: AgentWaitParams,
+    timeoutMs?: number,
+    signal?: AbortSignal,
+    onSignalAbort?: () => Promise<void> | void,
+  ): Promise<T> =>
+    await waitUntil(params, resolveGatewayDispatchDeadlineMs(timeoutMs), signal, onSignalAbort);
 
   const dispatchRaw = async (
     request: AgentRunRequest,
@@ -94,6 +110,8 @@ export function createInternalAgentTurnFacade(
     const method = "agent";
     throwIfGatewayDispatchAborted(method, dispatchOptions.signal);
     options.assertContextCurrent?.();
+    const deadlineMs =
+      dispatchOptions.deadlineMs ?? resolveGatewayDispatchDeadlineMs(dispatchOptions.timeoutMs);
     const context = options.getContext();
     const methodRegistry = getMethodRegistry();
     const authorization = await authorizeGatewayRequestPreDispatch({
@@ -215,10 +233,10 @@ export function createInternalAgentTurnFacade(
     const response = (async () => {
       const first =
         acceptance ??
-        (await waitForGatewayDispatch(
+        (await waitForGatewayDispatchDeadline(
           method,
           acceptancePromise,
-          dispatchOptions.timeoutMs,
+          deadlineMs,
           dispatchOptions.signal,
           dispatchOptions.onSignalAbort,
         ));
@@ -232,10 +250,10 @@ export function createInternalAgentTurnFacade(
         if (!runId) {
           return first;
         }
-        const timeoutMs = dispatchOptions.timeoutMs;
-        const waitResult = await wait<{ endedAt?: unknown; status?: unknown }>(
-          { runId, ...(timeoutMs !== undefined ? { timeoutMs } : {}) },
-          undefined,
+        const remainingTimeoutMs = resolveRemainingGatewayDispatchTimeoutMs(deadlineMs);
+        const waitResult = await waitUntil<{ endedAt?: unknown; status?: unknown }>(
+          { runId, ...(remainingTimeoutMs !== undefined ? { timeoutMs: remainingTimeoutMs } : {}) },
+          deadlineMs,
           dispatchOptions.signal,
           dispatchOptions.onSignalAbort,
         );
@@ -248,8 +266,9 @@ export function createInternalAgentTurnFacade(
         // The terminal dedupe payload retains the full result needed by callers;
         // agent.wait is only the liveness rendezvous for the already-admitted run.
         return await dispatchRaw(request, {
+          deadlineMs,
+          onSignalAbort: dispatchOptions.onSignalAbort,
           signal: dispatchOptions.signal,
-          timeoutMs,
         });
       }
       if (firstPayload?.status !== "accepted") {
@@ -261,10 +280,10 @@ export function createInternalAgentTurnFacade(
       }
       return (
         final ??
-        (await waitForGatewayDispatch(
+        (await waitForGatewayDispatchDeadline(
           method,
           createFinalPromise(),
-          dispatchOptions.timeoutMs,
+          deadlineMs,
           dispatchOptions.signal,
           dispatchOptions.onSignalAbort,
         ))

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -21,6 +21,7 @@ import {
 import type { AgentRunRequest } from "../server-methods/agent-request-types.js";
 import type { GatewayRequestOptions } from "../server-methods/types.js";
 import { validateGatewayMethodParams } from "../server-methods/validation.js";
+import { waitForAgentTerminalDedupe } from "./agent-job.js";
 import { prepareAgentRequestPreflight } from "./agent-request-preflight.js";
 import { createAgentTurnService } from "./agent-turn-service.js";
 import type {
@@ -86,13 +87,15 @@ export function createInternalAgentTurnFacade(
         reject: (error) => throwEnvelopeRejection(method, error),
       },
     );
-    return (await waitForGatewayDispatchDeadline(
+    const response = (await waitForGatewayDispatchDeadline(
       method,
       result,
       deadlineMs,
       signal,
       onSignalAbort,
     )) as T;
+    options.assertContextCurrent?.();
+    return response;
   };
 
   const wait = async <T = unknown>(
@@ -263,8 +266,21 @@ export function createInternalAgentTurnFacade(
         if (waitReachedNonterminalDeadline) {
           return first;
         }
+        const dedupeTimeoutMs = resolveRemainingGatewayDispatchTimeoutMs(deadlineMs) ?? 30_000;
+        const terminalDedupe = await waitForGatewayDispatchDeadline(
+          method,
+          waitForAgentTerminalDedupe({ runId, timeoutMs: dedupeTimeoutMs }),
+          deadlineMs,
+          dispatchOptions.signal,
+          dispatchOptions.onSignalAbort,
+        );
+        options.assertContextCurrent?.();
+        if (!terminalDedupe) {
+          return first;
+        }
         // The terminal dedupe payload retains the full result needed by callers;
-        // agent.wait is only the liveness rendezvous for the already-admitted run.
+        // agent.wait is the liveness rendezvous; the owner signal above makes
+        // the terminal response atomically ready for the canonical replay.
         return await dispatchRaw(request, {
           deadlineMs,
           onSignalAbort: dispatchOptions.onSignalAbort,

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -11,6 +11,7 @@ import {
   resolveGatewayDispatchDeadlineMs,
   resolveRemainingGatewayDispatchTimeoutMs,
   throwIfGatewayDispatchAborted,
+  throwIfGatewayDispatchDeadlineExpired,
   waitForGatewayDispatchDeadline,
   unwrapGatewayMethodDispatchResponse,
 } from "../server-in-process-dispatch.js";
@@ -75,6 +76,7 @@ export function createInternalAgentTurnFacade(
       signal,
       onSignalAbort,
     );
+    throwIfGatewayDispatchDeadlineExpired(method, deadlineMs);
     if (authorization.error) {
       return throwEnvelopeRejection(method, authorization.error);
     }
@@ -137,6 +139,7 @@ export function createInternalAgentTurnFacade(
       dispatchOptions.signal,
       dispatchOptions.onSignalAbort,
     );
+    throwIfGatewayDispatchDeadlineExpired(method, deadlineMs);
     if (authorization.error) {
       return { ok: false, error: authorization.error };
     }

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -213,22 +213,38 @@ export function createInternalAgentTurnFacade(
       },
     );
     const response = (async () => {
-      const first = acceptance ?? (await acceptancePromise);
+      const first =
+        acceptance ??
+        (await waitForGatewayDispatch(
+          method,
+          acceptancePromise,
+          dispatchOptions.timeoutMs,
+          dispatchOptions.signal,
+          dispatchOptions.onSignalAbort,
+        ));
       const firstPayload = first.payload as { runId?: unknown; status?: unknown } | undefined;
       if (dispatchOptions.expectFinal !== true) {
         return first;
       }
       if (firstPayload?.status === "in_flight") {
+        dispatchOptions.onAccepted?.(first.payload);
         const runId = typeof firstPayload.runId === "string" ? firstPayload.runId.trim() : "";
         if (!runId) {
           return first;
         }
         const timeoutMs = dispatchOptions.timeoutMs;
-        await wait(
+        const waitResult = await wait<{ endedAt?: unknown; status?: unknown }>(
           { runId, ...(timeoutMs !== undefined ? { timeoutMs } : {}) },
-          timeoutMs,
+          undefined,
           dispatchOptions.signal,
+          dispatchOptions.onSignalAbort,
         );
+        const waitReachedNonterminalDeadline =
+          waitResult.status === "pending" ||
+          (waitResult.status === "timeout" && typeof waitResult.endedAt !== "number");
+        if (waitReachedNonterminalDeadline) {
+          return first;
+        }
         // The terminal dedupe payload retains the full result needed by callers;
         // agent.wait is only the liveness rendezvous for the already-admitted run.
         return await dispatchRaw(request, {
@@ -243,15 +259,18 @@ export function createInternalAgentTurnFacade(
       if (postAcceptanceError) {
         throw postAcceptanceError;
       }
-      return final ?? (await createFinalPromise());
+      return (
+        final ??
+        (await waitForGatewayDispatch(
+          method,
+          createFinalPromise(),
+          dispatchOptions.timeoutMs,
+          dispatchOptions.signal,
+          dispatchOptions.onSignalAbort,
+        ))
+      );
     })();
-    return await waitForGatewayDispatch(
-      method,
-      response,
-      dispatchOptions.timeoutMs,
-      dispatchOptions.signal,
-      dispatchOptions.onSignalAbort,
-    );
+    return await response;
   };
 
   const dispatch = async <T = unknown>(

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { GatewayMethodRegistry } from "../methods/registry.js";
 import {
+  createGatewayDispatchTimeoutError,
   type GatewayMethodDispatchResponse,
   resolveGatewayDispatchDeadlineMs,
   resolveRemainingGatewayDispatchTimeoutMs,
@@ -276,7 +277,7 @@ export function createInternalAgentTurnFacade(
         );
         options.assertContextCurrent?.();
         if (!terminalDedupe) {
-          return first;
+          throw createGatewayDispatchTimeoutError(method);
         }
         // The terminal dedupe payload retains the full result needed by callers;
         // agent.wait is the liveness rendezvous; the owner signal above makes

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -48,6 +48,45 @@ export function createInternalAgentTurnFacade(
   const isWebchatConnect = options.isWebchatConnect ?? (() => false);
   const getMethodRegistry = options.getMethodRegistry ?? createRequestGatewayMethodRegistry;
 
+  const wait = async <T = unknown>(
+    params: AgentWaitParams,
+    timeoutMs?: number,
+    signal?: AbortSignal,
+    onSignalAbort?: () => Promise<void> | void,
+  ): Promise<T> => {
+    const method = "agent.wait";
+    throwIfGatewayDispatchAborted(method, signal);
+    const context = options.getContext();
+    const methodRegistry = getMethodRegistry();
+    const authorization = await authorizeGatewayRequestPreDispatch({
+      method,
+      requestParams: params,
+      client: options.client,
+      context,
+      methodRegistry,
+    });
+    if (authorization.error) {
+      return throwEnvelopeRejection(method, authorization.error);
+    }
+    const validationError = validateGatewayMethodParams(params, validateAgentWaitParams, method);
+    if (validationError) {
+      return throwEnvelopeRejection(method, validationError);
+    }
+    options.assertContextCurrent?.();
+    const result = runWithGatewayRequestEnvelope(
+      method,
+      options.client,
+      () => createAgentTurnService({ context, isWebchatConnect }).waitForTurn(params),
+      {
+        context,
+        isWebchatConnect,
+        methodRegistry,
+        reject: (error) => throwEnvelopeRejection(method, error),
+      },
+    );
+    return (await waitForGatewayDispatch(method, result, timeoutMs, signal, onSignalAbort)) as T;
+  };
+
   const dispatchRaw = async (
     request: AgentRunRequest,
     dispatchOptions: InternalAgentTurnDispatchOptions = {},
@@ -175,10 +214,29 @@ export function createInternalAgentTurnFacade(
     );
     const response = (async () => {
       const first = acceptance ?? (await acceptancePromise);
-      if (
-        dispatchOptions.expectFinal !== true ||
-        (first.payload as { status?: unknown } | undefined)?.status !== "accepted"
-      ) {
+      const firstPayload = first.payload as { runId?: unknown; status?: unknown } | undefined;
+      if (dispatchOptions.expectFinal !== true) {
+        return first;
+      }
+      if (firstPayload?.status === "in_flight") {
+        const runId = typeof firstPayload.runId === "string" ? firstPayload.runId.trim() : "";
+        if (!runId) {
+          return first;
+        }
+        const timeoutMs = dispatchOptions.timeoutMs;
+        await wait(
+          { runId, ...(timeoutMs !== undefined ? { timeoutMs } : {}) },
+          timeoutMs,
+          dispatchOptions.signal,
+        );
+        // The terminal dedupe payload retains the full result needed by callers;
+        // agent.wait is only the liveness rendezvous for the already-admitted run.
+        return await dispatchRaw(request, {
+          signal: dispatchOptions.signal,
+          timeoutMs,
+        });
+      }
+      if (firstPayload?.status !== "accepted") {
         return first;
       }
       dispatchOptions.onAccepted?.(first.payload);
@@ -206,46 +264,6 @@ export function createInternalAgentTurnFacade(
       "agent",
       await dispatchRaw(request, normalizedOptions),
     ) as T;
-  };
-
-  const wait = async <T = unknown>(
-    params: AgentWaitParams,
-    timeoutMs?: number,
-    signal?: AbortSignal,
-    onSignalAbort?: () => Promise<void> | void,
-  ): Promise<T> => {
-    const method = "agent.wait";
-    throwIfGatewayDispatchAborted(method, signal);
-    options.assertContextCurrent?.();
-    const context = options.getContext();
-    const methodRegistry = getMethodRegistry();
-    const authorization = await authorizeGatewayRequestPreDispatch({
-      method,
-      requestParams: params,
-      client: options.client,
-      context,
-      methodRegistry,
-    });
-    if (authorization.error) {
-      return throwEnvelopeRejection(method, authorization.error);
-    }
-    const validationError = validateGatewayMethodParams(params, validateAgentWaitParams, method);
-    if (validationError) {
-      return throwEnvelopeRejection(method, validationError);
-    }
-    options.assertContextCurrent?.();
-    const result = runWithGatewayRequestEnvelope(
-      method,
-      options.client,
-      () => createAgentTurnService({ context, isWebchatConnect }).waitForTurn(params),
-      {
-        context,
-        isWebchatConnect,
-        methodRegistry,
-        reject: (error) => throwEnvelopeRejection(method, error),
-      },
-    );
-    return (await waitForGatewayDispatch(method, result, timeoutMs, signal, onSignalAbort)) as T;
   };
 
   return { dispatch, dispatchRaw, wait };

--- a/src/gateway/agent-turn/internal-facade.ts
+++ b/src/gateway/agent-turn/internal-facade.ts
@@ -62,13 +62,19 @@ export function createInternalAgentTurnFacade(
     throwIfGatewayDispatchAborted(method, signal);
     const context = options.getContext();
     const methodRegistry = getMethodRegistry();
-    const authorization = await authorizeGatewayRequestPreDispatch({
+    const authorization = await waitForGatewayDispatchDeadline(
       method,
-      requestParams: params,
-      client: options.client,
-      context,
-      methodRegistry,
-    });
+      authorizeGatewayRequestPreDispatch({
+        method,
+        requestParams: params,
+        client: options.client,
+        context,
+        methodRegistry,
+      }),
+      deadlineMs,
+      signal,
+      onSignalAbort,
+    );
     if (authorization.error) {
       return throwEnvelopeRejection(method, authorization.error);
     }
@@ -118,13 +124,19 @@ export function createInternalAgentTurnFacade(
       dispatchOptions.deadlineMs ?? resolveGatewayDispatchDeadlineMs(dispatchOptions.timeoutMs);
     const context = options.getContext();
     const methodRegistry = getMethodRegistry();
-    const authorization = await authorizeGatewayRequestPreDispatch({
+    const authorization = await waitForGatewayDispatchDeadline(
       method,
-      requestParams: request,
-      client: options.client,
-      context,
-      methodRegistry,
-    });
+      authorizeGatewayRequestPreDispatch({
+        method,
+        requestParams: request,
+        client: options.client,
+        context,
+        methodRegistry,
+      }),
+      deadlineMs,
+      dispatchOptions.signal,
+      dispatchOptions.onSignalAbort,
+    );
     if (authorization.error) {
       return { ok: false, error: authorization.error };
     }

--- a/src/gateway/agent-turn/internal-facade.types.ts
+++ b/src/gateway/agent-turn/internal-facade.types.ts
@@ -12,6 +12,7 @@ export type InternalAgentTurnPrincipalOptions = {
 };
 
 export type InternalAgentTurnDispatchOptions = {
+  deadlineMs?: number;
   expectFinal?: boolean;
   onAccepted?: (payload: unknown) => void;
   onExecutionStarted?: () => void;

--- a/src/gateway/agent-turn/types.ts
+++ b/src/gateway/agent-turn/types.ts
@@ -42,6 +42,7 @@ export type AgentTurnContext = Pick<
   | "getSessionEventSubscriberConnIds"
   | "loadGatewayModelCatalog"
   | "loadGatewayModelCatalogSnapshot"
+  | "loadPublishedGatewayReplyDispatchRuntime"
   | "logGateway"
   | "resolveGatewayContext"
   | "validateAgentRuntimeApprovalAuthority"

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -460,7 +460,13 @@ function buildCodexCompactionAppServerArgs(mode: CodexCompactionStressMode): str
             "tool_output_token_limit=10000",
           ]
         : undefined;
-  const openAiBaseUrl = process.env.OPENAI_BASE_URL?.trim();
+  // The proof may use a localhost Responses API while the configured OpenAI
+  // route remains official HTTPS so Codex harness selection can be validated.
+  // Keep this override scoped to the managed app-server process; putting the
+  // HTTP endpoint in the provider config intentionally selects OpenClaw.
+  const openAiBaseUrl =
+    process.env.OPENCLAW_LIVE_CODEX_HARNESS_APP_SERVER_BASE_URL?.trim() ??
+    process.env.OPENAI_BASE_URL?.trim();
   if (openAiBaseUrl) {
     return buildCodexHarnessAppServerArgs([
       ...(overrides ?? []),

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -1932,7 +1932,7 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
   if (parentControlledChild) {
     // Native task IDs record the child thread at creation; model output is not
     // authoritative enough to select the thread for this ownership probe.
-    const childThreadId = deliveredTask?.sourceId?.match(/^codex-thread:(.+)$/)?.[1];
+    const childThreadId = waveTwoTask.sourceId?.match(/^codex-thread:(.+)$/)?.[1];
     expect(childThreadId).toBeTypeOf("string");
     const sessionId = await readCodexHarnessSessionId(params);
     const readBinding = () => {

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -1908,9 +1908,13 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
   logCodexLiveStep("native-subagent-bridge-probe:wave-2-delivered", {
     taskId: waveTwoTask.taskId,
   });
-  expect(waveTwoTask.createdAt).toBeGreaterThanOrEqual(
-    waveOneTask.endedAt ?? waveOneTask.createdAt,
-  );
+  const waveOneEnd = waveOneTask.endedAt ?? waveOneTask.createdAt;
+  expect(waveOneEnd).toBeTypeOf("number");
+  expect(waveTwoTask.createdAt).toBeTypeOf("number");
+  if (typeof waveOneEnd !== "number" || typeof waveTwoTask.createdAt !== "number") {
+    throw new Error("Codex native task timestamps must be numeric");
+  }
+  expect(waveTwoTask.createdAt).toBeGreaterThanOrEqual(waveOneEnd);
 
   const finalText = await waitForAssistantText({
     client: params.client,

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -1936,8 +1936,6 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
     finalReply,
     taskIds: [waveOneTask.taskId, waveTwoTask.taskId],
   });
-  const deliveredTask = waveOneTask;
-
   const parentControlledChild = events.some(
     (event) => event.stream === "codex_app_server.item" && event.data?.type === "subAgentActivity",
   );

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -1859,42 +1859,72 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
   sessionKey: string;
 }): Promise<void> {
   const runId = randomUUID();
-  const childToken = `CODEX-NATIVE-CHILD-${runId.slice(0, 6).toUpperCase()}`;
+  const waveOneToken = `CODEX-NATIVE-WAVE-1-${runId.slice(0, 6).toUpperCase()}`;
+  const waveTwoToken = `CODEX-NATIVE-WAVE-2-${runId.slice(0, 6).toUpperCase()}`;
   const parentToken = `CODEX-NATIVE-PARENT-${runId.slice(0, 6).toUpperCase()}`;
+  const finalReply = `${parentToken} ${waveOneToken} ${waveTwoToken}`;
   const { text, events } = await requestAgentTextWithEvents({
-    // Native Codex waiting pauses this parent turn; task delivery resumes it separately.
+    // Each native child resumes the requester in a later turn through sessions_yield.
     acceptYieldedTimeout: true,
     client: params.client,
     eventPrefix: "codex_app_server.",
     includeAllSessions: true,
     sessionKey: params.sessionKey,
     message: [
-      "Bridge probe.",
-      "You must use the Codex native spawn_agent tool exactly once before replying.",
-      `Give the subagent this exact instruction: Reply exactly ${childToken} and nothing else.`,
-      "Wait for the subagent result. Do not answer from your own knowledge.",
-      `After the subagent result returns, reply exactly ${parentToken} ${childToken} and nothing else.`,
+      "Sequential native bridge probe. Complete exactly two child waves.",
+      "Wave 1: use the Codex native spawn_agent tool exactly once with task_name=wave_one.",
+      `Give it this exact instruction: Reply exactly ${waveOneToken} and nothing else.`,
+      "After spawn_agent is accepted, do not call wait_agent and do not send a reply.",
+      "End the turn by calling openclaw_direct.sessions_yield.",
+      `When the Wave 1 completion containing ${waveOneToken} arrives in a later turn, start Wave 2.`,
+      "Wave 2: use the Codex native spawn_agent tool exactly once with task_name=wave_two.",
+      `Give it this exact instruction: Reply exactly ${waveTwoToken} and nothing else.`,
+      "After spawn_agent is accepted, do not call wait_agent and do not send a reply.",
+      "End that turn by calling openclaw_direct.sessions_yield again.",
+      `Only after the Wave 2 completion containing ${waveTwoToken} arrives, reply exactly ${finalReply} and nothing else.`,
+      `Never send ${parentToken} before both child completions are visible.`,
     ].join("\n"),
   });
   logCodexLiveStep("native-subagent-bridge-probe:initial-reply", { text });
+  expect(text).not.toContain(parentToken);
   expect(
     events.some((event) => event.stream === "codex_app_server.lifecycle"),
     `expected Codex lifecycle events; events=${JSON.stringify(events)}`,
   ).toBe(true);
-  let codexNativeTasks = await listCodexNativeTasks();
-  let deliveredTask = findDeliveredCodexNativeTask(codexNativeTasks);
   const deadline = Date.now() + CODEX_HARNESS_REQUEST_TIMEOUT_MS;
-  while (!deliveredTask && Date.now() < deadline) {
-    await delay(1_000);
-    codexNativeTasks = await listCodexNativeTasks();
-    deliveredTask = findDeliveredCodexNativeTask(codexNativeTasks);
-  }
-  expect(
-    deliveredTask,
-    `expected delivered Codex-native subagent task with child result; initialText=${JSON.stringify(
-      text,
-    )}; events=${JSON.stringify(events)}; tasks=${JSON.stringify(codexNativeTasks)}`,
-  ).toBeDefined();
+  const waveOneTask = await waitForDeliveredCodexNativeTask(waveOneToken);
+  logCodexLiveStep("native-subagent-bridge-probe:wave-1-delivered", {
+    taskId: waveOneTask.taskId,
+  });
+  const waveTwoTask = await waitForDeliveredCodexNativeTask(waveTwoToken);
+  logCodexLiveStep("native-subagent-bridge-probe:wave-2-delivered", {
+    taskId: waveTwoTask.taskId,
+  });
+  expect(waveTwoTask.createdAt).toBeGreaterThanOrEqual(
+    waveOneTask.endedAt ?? waveOneTask.createdAt,
+  );
+
+  const finalText = await waitForAssistantText({
+    client: params.client,
+    sessionKey: params.sessionKey,
+    contains: parentToken,
+    timeoutMs: Math.max(1, deadline - Date.now()),
+  });
+  expect(finalText.trim()).toBe(finalReply);
+  const history: { messages?: unknown[] } = await params.client.request("chat.history", {
+    sessionKey: params.sessionKey,
+    limit: 100,
+  });
+  const parentReplies = extractAssistantTexts(history.messages ?? []).filter((reply) =>
+    normalizeAssistantTokenText(reply).includes(normalizeAssistantTokenText(parentToken)),
+  );
+  expect(parentReplies).toEqual([finalReply]);
+  expect(listCodexNativeTasks()).toHaveLength(2);
+  logCodexLiveStep("native-subagent-bridge-probe:complete", {
+    finalReply,
+    taskIds: [waveOneTask.taskId, waveTwoTask.taskId],
+  });
+  const deliveredTask = waveOneTask;
 
   const parentControlledChild = events.some(
     (event) => event.stream === "codex_app_server.item" && event.data?.type === "subAgentActivity",
@@ -1954,12 +1984,25 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
     return tasks.filter((entry) => entry.runtime === "subagent" && entry.kind === "codex-native");
   }
 
-  function findDeliveredCodexNativeTask(tasks: Awaited<ReturnType<typeof listCodexNativeTasks>>) {
-    return tasks.find(
-      (entry) =>
-        entry.status === "completed" &&
-        entry.deliveryStatus === "delivered" &&
-        entry.terminalSummary?.includes(childToken),
+  async function waitForDeliveredCodexNativeTask(token: string) {
+    while (Date.now() < deadline) {
+      const tasks = await listCodexNativeTasks();
+      const delivered = tasks.find(
+        (entry) =>
+          entry.status === "completed" &&
+          entry.deliveryStatus === "delivered" &&
+          entry.terminalSummary?.includes(token),
+      );
+      if (delivered) {
+        return delivered;
+      }
+      await delay(1_000);
+    }
+    const tasks = await listCodexNativeTasks();
+    throw new Error(
+      `expected delivered Codex-native task containing ${token}; initialText=${JSON.stringify(
+        text,
+      )}; events=${JSON.stringify(events)}; tasks=${JSON.stringify(tasks)}`,
     );
   }
 }

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -458,8 +458,15 @@ function buildCodexCompactionAppServerArgs(mode: CodexCompactionStressMode): str
             // One truncated 300 KB tool result is only a few thousand tokens.
             "model_auto_compact_token_limit=4000",
             "tool_output_token_limit=10000",
-          ]
-        : undefined;
+        ]
+      : undefined;
+  const openAiBaseUrl = process.env.OPENAI_BASE_URL?.trim();
+  if (openAiBaseUrl) {
+    return buildCodexHarnessAppServerArgs([
+      ...(overrides ?? []),
+      `openai_base_url=${openAiBaseUrl}`,
+    ]);
+  }
   return overrides ? buildCodexHarnessAppServerArgs(overrides) : undefined;
 }
 
@@ -572,6 +579,7 @@ async function writeLiveGatewayConfig(params: {
   workspace: string;
 }): Promise<void> {
   const parsedModel = parseModelKey(params.modelKey);
+  const openAiBaseUrl = process.env.OPENAI_BASE_URL?.trim() || "https://api.openai.com/v1";
   const appServerArgs = buildCodexCompactionAppServerArgs(params.compactionMode);
   const cfg: OpenClawConfig = {
     gateway: {
@@ -643,7 +651,7 @@ async function writeLiveGatewayConfig(params: {
               openai: {
                 api: "openai-responses",
                 apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-                baseUrl: "https://api.openai.com/v1",
+                baseUrl: openAiBaseUrl,
                 models: [],
               },
             },

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -1937,7 +1937,7 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
     normalizeAssistantTokenText(reply).includes(normalizeAssistantTokenText(parentToken)),
   );
   expect(parentReplies).toEqual([finalReply]);
-  expect(listCodexNativeTasks()).toHaveLength(2);
+  expect(await listCodexNativeTasks()).toHaveLength(2);
   logCodexLiveStep("native-subagent-bridge-probe:complete", {
     finalReply,
     taskIds: [waveOneTask.taskId, waveTwoTask.taskId],

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -458,8 +458,8 @@ function buildCodexCompactionAppServerArgs(mode: CodexCompactionStressMode): str
             // One truncated 300 KB tool result is only a few thousand tokens.
             "model_auto_compact_token_limit=4000",
             "tool_output_token_limit=10000",
-        ]
-      : undefined;
+          ]
+        : undefined;
   const openAiBaseUrl = process.env.OPENAI_BASE_URL?.trim();
   if (openAiBaseUrl) {
     return buildCodexHarnessAppServerArgs([

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -63,6 +63,13 @@ export function createGatewayDispatchTimeoutError(method: string): Error {
   return new Error(`gateway request timeout for ${method}`);
 }
 
+/** Rejects a phase that resolved at or after the shared request deadline. */
+export function throwIfGatewayDispatchDeadlineExpired(method: string, deadlineMs?: number): void {
+  if (deadlineMs !== undefined && Date.now() >= deadlineMs) {
+    throw createGatewayDispatchTimeoutError(method);
+  }
+}
+
 function resolveDispatchAbortError(method: string, signal: AbortSignal): Error {
   return signal.reason instanceof Error
     ? signal.reason

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -46,14 +46,14 @@ export function unwrapGatewayMethodDispatchResponse(
   return response.payload;
 }
 
-function resolveDispatchDeadlineMs(timeoutMs?: number): number | undefined {
+export function resolveGatewayDispatchDeadlineMs(timeoutMs?: number): number | undefined {
   if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
     return undefined;
   }
   return Date.now() + resolveSafeTimeoutDelayMs(timeoutMs);
 }
 
-function resolveRemainingDispatchTimeoutMs(deadlineMs?: number): number | undefined {
+export function resolveRemainingGatewayDispatchTimeoutMs(deadlineMs?: number): number | undefined {
   return deadlineMs === undefined
     ? undefined
     : resolveSafeTimeoutDelayMs(deadlineMs - Date.now(), { minMs: 0 });
@@ -72,7 +72,8 @@ export function throwIfGatewayDispatchAborted(method: string, signal?: AbortSign
   }
 }
 
-async function waitForDispatch<T>(
+/** Waits within an existing request-level deadline shared across dispatch phases. */
+export async function waitForGatewayDispatchDeadline<T>(
   method: string,
   promise: Promise<T>,
   deadlineMs?: number,
@@ -85,7 +86,7 @@ async function waitForDispatch<T>(
     if (signal?.aborted) {
       throw resolveDispatchAbortError(method, signal);
     }
-    const remainingTimeoutMs = resolveRemainingDispatchTimeoutMs(deadlineMs);
+    const remainingTimeoutMs = resolveRemainingGatewayDispatchTimeoutMs(deadlineMs);
     if (remainingTimeoutMs === undefined && !signal) {
       return await promise;
     }
@@ -122,22 +123,6 @@ async function waitForDispatch<T>(
 }
 
 /** Applies the same non-cancelling deadline used by in-process Gateway dispatch. */
-export async function waitForGatewayDispatch<T>(
-  method: string,
-  promise: Promise<T>,
-  timeoutMs?: number,
-  signal?: AbortSignal,
-  onSignalAbort?: () => Promise<void> | void,
-): Promise<T> {
-  return await waitForDispatch(
-    method,
-    promise,
-    resolveDispatchDeadlineMs(timeoutMs),
-    signal,
-    onSignalAbort,
-  );
-}
-
 /** Dispatches one request through the ordinary Gateway router without opening a transport. */
 export async function dispatchGatewayRequestInProcessRaw(
   method: string,
@@ -156,7 +141,7 @@ export async function dispatchGatewayRequestInProcessRaw(
     resolveFirstResponse = resolve;
     rejectFirstResponse = reject;
   });
-  const deadlineMs = resolveDispatchDeadlineMs(options.timeoutMs);
+  const deadlineMs = resolveGatewayDispatchDeadlineMs(options.timeoutMs);
   const { handleGatewayRequest } = await import("./server-methods.js");
   void handleGatewayRequest({
     req: {
@@ -201,7 +186,7 @@ export async function dispatchGatewayRequestInProcessRaw(
       rejectFinalResponse?.(error);
     });
 
-  firstResponse = await waitForDispatch(
+  firstResponse = await waitForGatewayDispatchDeadline(
     method,
     firstResponsePromise,
     deadlineMs,
@@ -218,7 +203,7 @@ export async function dispatchGatewayRequestInProcessRaw(
   }
   return (
     finalResponse ??
-    (await waitForDispatch(
+    (await waitForGatewayDispatchDeadline(
       method,
       new Promise<GatewayMethodDispatchResponse>((resolve, reject) => {
         resolveFinalResponse = resolve;

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -59,6 +59,10 @@ export function resolveRemainingGatewayDispatchTimeoutMs(deadlineMs?: number): n
     : resolveSafeTimeoutDelayMs(deadlineMs - Date.now(), { minMs: 0 });
 }
 
+export function createGatewayDispatchTimeoutError(method: string): Error {
+  return new Error(`gateway request timeout for ${method}`);
+}
+
 function resolveDispatchAbortError(method: string, signal: AbortSignal): Error {
   return signal.reason instanceof Error
     ? signal.reason
@@ -93,7 +97,7 @@ export async function waitForGatewayDispatchDeadline<T>(
     const cancellation = new Promise<never>((_resolve, reject) => {
       if (remainingTimeoutMs !== undefined) {
         timeout = setTimeout(() => {
-          reject(new Error(`gateway request timeout for ${method}`));
+          reject(createGatewayDispatchTimeoutError(method));
         }, remainingTimeoutMs);
       }
       if (signal) {

--- a/src/gateway/server-in-process-dispatch.ts
+++ b/src/gateway/server-in-process-dispatch.ts
@@ -122,7 +122,6 @@ export async function waitForGatewayDispatchDeadline<T>(
   }
 }
 
-/** Applies the same non-cancelling deadline used by in-process Gateway dispatch. */
 /** Dispatches one request through the ordinary Gateway router without opening a transport. */
 export async function dispatchGatewayRequestInProcessRaw(
   method: string,

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -231,7 +231,7 @@ describe("createGatewayInstanceRuntime", () => {
 
     await expect(outcome).resolves.toMatchObject({
       status: "rejected",
-      error: { message: "Gateway instance dispatch unavailable for agent" },
+      error: { message: "Gateway instance dispatch unavailable for agent turn" },
     });
   });
 

--- a/src/gateway/server-instance-runtime.test.ts
+++ b/src/gateway/server-instance-runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "../../packages/gateway-client/src/timeouts.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
 import type { GatewayNativeApprovalMethod } from "../infra/approval-gateway-runtime-methods.js";
 import type { ExecApprovalRequest } from "../infra/exec-approvals.js";
 import {
@@ -11,6 +12,7 @@ import {
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { setGatewayDedupeEntry } from "./agent-turn/agent-job.js";
 import { captureAgentTurnPrincipal } from "./agent-turn/principal.js";
 import { APPROVALS_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
 import { createGatewayMethodRegistry } from "./methods/registry.js";
@@ -175,6 +177,62 @@ describe("createGatewayInstanceRuntime", () => {
     });
     expect(recoveryPrincipal?.internal?.agentRunTracking).toBeUndefined();
     expect(recoveryPrincipal?.internal?.sessionCreation).toBeUndefined();
+  });
+
+  it.each([
+    { label: "shared-principal", dispatchOptions: {} },
+    { label: "dedicated-principal", dispatchOptions: { allowModelOverride: true } },
+  ])("rejects a $label terminal replay after the Gateway instance closes", async (testCase) => {
+    const runId = `run-retired-${testCase.label}`;
+    const context = createContext();
+    const runtime = createGatewayInstanceRuntime({
+      getContext: () => context,
+      getMethodRegistry: () => createRegistry({}),
+      isDispatchAvailable: () => true,
+    });
+    setGatewayDedupeEntry({
+      dedupe: context.dedupe,
+      key: `agent:${runId}`,
+      entry: {
+        ts: Date.now(),
+        ok: true,
+        payload: { runId, status: "accepted" },
+      },
+    });
+    const onAccepted = vi.fn();
+    const outcome = runtime.recovery
+      .dispatchAgent({ message: "test", idempotencyKey: runId }, undefined, {
+        ...testCase.dispatchOptions,
+        expectFinal: true,
+        onAccepted,
+      })
+      .then(
+        () => ({ status: "resolved" as const }),
+        (error: unknown) => ({ error, status: "rejected" as const }),
+      );
+
+    await vi.waitFor(() => expect(onAccepted).toHaveBeenCalledWith({ runId, status: "in_flight" }));
+    emitAgentEvent({
+      runId,
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 100, endedAt: 200 },
+    });
+    await Promise.resolve();
+    runtime.close();
+    setGatewayDedupeEntry({
+      dedupe: context.dedupe,
+      key: `agent:${runId}`,
+      entry: {
+        ts: Date.now(),
+        ok: true,
+        payload: { runId, status: "ok", summary: "must not replay" },
+      },
+    });
+
+    await expect(outcome).resolves.toMatchObject({
+      status: "rejected",
+      error: { message: "Gateway instance dispatch unavailable for agent" },
+    });
   });
 
   it("sends recovery notices through normal outbound without invoking plugin actions", async () => {

--- a/src/gateway/server-kernel-request-runtime.ts
+++ b/src/gateway/server-kernel-request-runtime.ts
@@ -119,6 +119,9 @@ export async function prepareGatewayKernelRequestRuntime(params: {
   );
   const gatewayRequestContext = await startupTrace.measure("gateway.request-context", async () => {
     const { createGatewayRequestContext } = await import("./server-request-context.js");
+    const { loadPublishedGatewayReplyDispatchRuntime } = await import(
+      "../agents/prepared-model-runtime.js"
+    );
     return createGatewayRequestContext({
       deps,
       configRevisionProjector,
@@ -146,6 +149,7 @@ export async function prepareGatewayKernelRequestRuntime(params: {
       listSessionPendingApprovals: approvalSessionEvents.replay,
       loadGatewayModelCatalog,
       loadGatewayModelCatalogSnapshot,
+      loadPublishedGatewayReplyDispatchRuntime,
       readPreparedGatewayModelCatalog,
       readChatMetadata: chatMetadataLifecycle.read,
       readChatStartupProjection: chatMetadataLifecycle.readStartup,

--- a/src/gateway/server-kernel-request-runtime.ts
+++ b/src/gateway/server-kernel-request-runtime.ts
@@ -119,9 +119,8 @@ export async function prepareGatewayKernelRequestRuntime(params: {
   );
   const gatewayRequestContext = await startupTrace.measure("gateway.request-context", async () => {
     const { createGatewayRequestContext } = await import("./server-request-context.js");
-    const { loadPublishedGatewayReplyDispatchRuntime } = await import(
-      "../agents/prepared-model-runtime.js"
-    );
+    const { loadPublishedGatewayReplyDispatchRuntime } =
+      await import("../agents/prepared-model-runtime.js");
     return createGatewayRequestContext({
       deps,
       configRevisionProjector,

--- a/src/gateway/server-methods/agent.abort-integration.test-utils.ts
+++ b/src/gateway/server-methods/agent.abort-integration.test-utils.ts
@@ -2733,6 +2733,7 @@ describe("gateway agent handler chat.abort integration", () => {
     expectRecordFields(context.dedupe.get(`agent:${runId}`)?.payload, {
       runId,
       status: "accepted",
+      admitted: true,
       sessionKey: "agent:main:main",
     });
 
@@ -2750,7 +2751,13 @@ describe("gateway agent handler chat.abort integration", () => {
     expect(mocks.agentCommand).not.toHaveBeenCalled();
     expect(duplicateRespond).toHaveBeenCalledWith(
       true,
-      { runId, status: "in_flight", sessionKey: "agent:main:main", agentId: "main" },
+      {
+        runId,
+        status: "in_flight",
+        admitted: true,
+        sessionKey: "agent:main:main",
+        agentId: "main",
+      },
       undefined,
       {
         cached: true,

--- a/src/gateway/server-methods/agent.abort-integration.test-utils.ts
+++ b/src/gateway/server-methods/agent.abort-integration.test-utils.ts
@@ -2666,7 +2666,7 @@ describe("gateway agent handler chat.abort integration", () => {
     expect(mocks.agentCommand).toHaveBeenCalledTimes(1);
     expect(duplicateRespond).toHaveBeenCalledWith(
       true,
-      { runId, status: "in_flight", agentId: "main" },
+      { runId, status: "in_flight", admitted: true, agentId: "main" },
       undefined,
       {
         cached: true,

--- a/src/gateway/server-methods/agent.create-event.test.ts
+++ b/src/gateway/server-methods/agent.create-event.test.ts
@@ -45,6 +45,7 @@ vi.mock("../../agents/prepared-model-runtime.js", () => ({
   acquireAgentRunPreparedModelRuntime: vi.fn(async () => ({
     release: vi.fn(),
     snapshot: {},
+    pluginGeneration: { pluginMetadataSnapshot: {} },
   })),
   loadPublishedGatewayReplyDispatchRuntime: vi.fn(async ({ agentId }: { agentId: string }) => ({
     agentId,
@@ -115,6 +116,13 @@ describe("agent handler session create events", () => {
           getRuntimeConfig: configMocks.getRuntimeConfig,
           getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
           broadcastToConnIds,
+          loadPublishedGatewayReplyDispatchRuntime: vi.fn(async () => ({
+            agentId: "main",
+            agentDir: configMocks.workspaceDir,
+            config: configMocks.getRuntimeConfig(),
+            pluginGeneration: { pluginMetadataSnapshot: {} },
+            workspaceDir: configMocks.workspaceDir,
+          })),
         } as never,
         client: null,
         isWebchatConnect: () => false,

--- a/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
+++ b/src/gateway/server-methods/agent.events-and-subagents.test-utils.ts
@@ -687,6 +687,13 @@ describe("gateway agent handler", () => {
           broadcastToConnIds: vi.fn(),
           getSessionEventSubscriberConnIds: () => new Set(),
           getRuntimeConfig: () => mocks.loadConfigReturn,
+          loadPublishedGatewayReplyDispatchRuntime: async ({ agentId }: { agentId: string }) => ({
+            agentId,
+            agentDir: "/tmp/agent",
+            config: mocks.loadConfigReturn,
+            pluginGeneration: { pluginMetadataSnapshot: {} },
+            workspaceDir: "/tmp/workspace",
+          }),
         } as unknown as GatewayRequestContext,
       },
     );

--- a/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
+++ b/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
@@ -1196,6 +1196,13 @@ describe("gateway agent handler", () => {
           broadcastToConnIds,
           getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
           getRuntimeConfig: () => mocks.loadConfigReturn,
+          loadPublishedGatewayReplyDispatchRuntime: async ({ agentId }: { agentId: string }) => ({
+            agentId,
+            agentDir: "/tmp/agent",
+            config: mocks.loadConfigReturn,
+            pluginGeneration: { pluginMetadataSnapshot: {} },
+            workspaceDir: "/tmp/workspace",
+          }),
         } as unknown as GatewayRequestContext,
       },
     );
@@ -1285,6 +1292,13 @@ describe("gateway agent handler", () => {
           broadcastToConnIds,
           getSessionEventSubscriberConnIds: () => new Set(["conn-1"]),
           getRuntimeConfig: () => mocks.loadConfigReturn,
+          loadPublishedGatewayReplyDispatchRuntime: async ({ agentId }: { agentId: string }) => ({
+            agentId,
+            agentDir: "/tmp/agent",
+            config: mocks.loadConfigReturn,
+            pluginGeneration: { pluginMetadataSnapshot: {} },
+            workspaceDir: "/tmp/workspace",
+          }),
         } as unknown as GatewayRequestContext,
       },
     );

--- a/src/gateway/server-methods/agent.test-harness.ts
+++ b/src/gateway/server-methods/agent.test-harness.ts
@@ -209,6 +209,7 @@ vi.mock("../../agents/prepared-model-runtime.js", () => ({
   acquireAgentRunPreparedModelRuntime: vi.fn(async () => ({
     release: vi.fn(),
     snapshot: {},
+    pluginGeneration: { pluginMetadataSnapshot: {} },
   })),
   loadPublishedGatewayReplyDispatchRuntime: async ({ agentId }: { agentId: string }) => ({
     agentId,
@@ -412,6 +413,13 @@ export const makeContext = (): GatewayRequestContext =>
     broadcastToConnIds: vi.fn(),
     getSessionEventSubscriberConnIds: () => new Set(),
     getRuntimeConfig: () => resolveAgentTestConfig(),
+    loadPublishedGatewayReplyDispatchRuntime: async ({ agentId }: { agentId: string }) => ({
+      agentId,
+      agentDir: "/tmp/agent",
+      config: resolveAgentTestConfig(),
+      pluginGeneration: { pluginMetadataSnapshot: {} },
+      workspaceDir: "/tmp/workspace",
+    }),
   }) as unknown as GatewayRequestContext;
 
 type AgentHandler = NonNullable<typeof agentHandlers.agent>;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -53,6 +53,7 @@ import type {
   GatewayModelCatalogSnapshot,
   PreparedGatewayModelCatalog,
 } from "../server-model-catalog.types.js";
+import type { PreparedReplyDispatchRuntime } from "../../agents/prepared-model-runtime.types.js";
 import type { DedupeEntry } from "../server-shared.js";
 import type { GatewayEventLoopHealth } from "../server/event-loop-health.js";
 import type { SessionObserverService } from "../session-observer-contract.js";
@@ -217,6 +218,14 @@ type GatewayKernelContext = {
     readOnly?: boolean;
     workspaceDir?: string;
   }) => Promise<GatewayModelCatalogSnapshot>;
+  /**
+   * Gateway-owned prepared reply dispatch lookup. Kept on the live context so
+   * loader-local plugin module graphs cannot read a second runtime singleton.
+   */
+  loadPublishedGatewayReplyDispatchRuntime?: (params: {
+    agentId: string;
+    abortSignal?: AbortSignal;
+  }) => Promise<PreparedReplyDispatchRuntime | undefined>;
   readPreparedGatewayModelCatalog?: (params?: {
     agentId?: string;
     agentDir?: string;

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -12,6 +12,7 @@ import type {
   RequestFrame,
 } from "../../../packages/gateway-protocol/src/schema/frames.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import type { PreparedReplyDispatchRuntime } from "../../agents/prepared-model-runtime.types.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { AgentRunDelegatedAuthority } from "../../infra/agent-run-registry.js";
@@ -53,7 +54,6 @@ import type {
   GatewayModelCatalogSnapshot,
   PreparedGatewayModelCatalog,
 } from "../server-model-catalog.types.js";
-import type { PreparedReplyDispatchRuntime } from "../../agents/prepared-model-runtime.types.js";
 import type { DedupeEntry } from "../server-shared.js";
 import type { GatewayEventLoopHealth } from "../server/event-loop-health.js";
 import type { SessionObserverService } from "../session-observer-contract.js";

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -12,7 +12,6 @@ import type {
   RequestFrame,
 } from "../../../packages/gateway-protocol/src/schema/frames.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
-import type { PreparedReplyDispatchRuntime } from "../../agents/prepared-model-runtime.types.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { AgentRunDelegatedAuthority } from "../../infra/agent-run-registry.js";
@@ -225,7 +224,14 @@ type GatewayKernelContext = {
   loadPublishedGatewayReplyDispatchRuntime?: (params: {
     agentId: string;
     abortSignal?: AbortSignal;
-  }) => Promise<PreparedReplyDispatchRuntime | undefined>;
+  }) => Promise<
+    | {
+        config: OpenClawConfig;
+        /** Opaque host-owned generation; decoded only at the command owner boundary. */
+        pluginGeneration: object;
+      }
+    | undefined
+  >;
   readPreparedGatewayModelCatalog?: (params?: {
     agentId?: string;
     agentDir?: string;

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -59,6 +59,7 @@ type GatewayRequestContextParams = {
   listSessionPendingApprovals: GatewayRequestContext["listSessionPendingApprovals"];
   loadGatewayModelCatalog: GatewayRequestContext["loadGatewayModelCatalog"];
   loadGatewayModelCatalogSnapshot: GatewayRequestContext["loadGatewayModelCatalogSnapshot"];
+  loadPublishedGatewayReplyDispatchRuntime?: GatewayRequestContext["loadPublishedGatewayReplyDispatchRuntime"];
   readPreparedGatewayModelCatalog?: GatewayRequestContext["readPreparedGatewayModelCatalog"];
   readChatMetadata: GatewayRequestContext["readChatMetadata"];
   readChatStartupProjection?: GatewayRequestContext["readChatStartupProjection"];
@@ -216,6 +217,9 @@ export function createGatewayRequestContext(
     listSessionPendingApprovals: params.listSessionPendingApprovals,
     loadGatewayModelCatalog: params.loadGatewayModelCatalog,
     loadGatewayModelCatalogSnapshot: params.loadGatewayModelCatalogSnapshot,
+    ...(params.loadPublishedGatewayReplyDispatchRuntime
+      ? { loadPublishedGatewayReplyDispatchRuntime: params.loadPublishedGatewayReplyDispatchRuntime }
+      : {}),
     ...(params.readPreparedGatewayModelCatalog
       ? { readPreparedGatewayModelCatalog: params.readPreparedGatewayModelCatalog }
       : {}),

--- a/src/gateway/server-request-context.ts
+++ b/src/gateway/server-request-context.ts
@@ -218,7 +218,9 @@ export function createGatewayRequestContext(
     loadGatewayModelCatalog: params.loadGatewayModelCatalog,
     loadGatewayModelCatalogSnapshot: params.loadGatewayModelCatalogSnapshot,
     ...(params.loadPublishedGatewayReplyDispatchRuntime
-      ? { loadPublishedGatewayReplyDispatchRuntime: params.loadPublishedGatewayReplyDispatchRuntime }
+      ? {
+          loadPublishedGatewayReplyDispatchRuntime: params.loadPublishedGatewayReplyDispatchRuntime,
+        }
       : {}),
     ...(params.readPreparedGatewayModelCatalog
       ? { readPreparedGatewayModelCatalog: params.readPreparedGatewayModelCatalog }

--- a/src/gateway/server-startup-web-fetch-bind.test.ts
+++ b/src/gateway/server-startup-web-fetch-bind.test.ts
@@ -25,6 +25,7 @@ const webFetchProviderDiscovery = vi.hoisted(() => ({
 vi.mock("../agents/prepared-model-runtime.js", () => ({
   publishPreparedModelRuntimeSnapshot: vi.fn(async () => ({})),
   refreshPreparedModelRuntimeSnapshots: vi.fn(async () => {}),
+  loadPublishedGatewayReplyDispatchRuntime: vi.fn(async () => undefined),
 }));
 
 vi.mock("./server-chat-metadata-lifecycle.js", () => ({


### PR DESCRIPTION
Closes #129455

## What Problem This Solves

Sequential native subagent workflows could finalize after the first child wave even though the resumed requester had intentionally yielded to start the next queued wave. Replayed Gateway completions could also repeat fallback steering or be treated as delivered without a confirmed admission.

## Why This Change Was Made

The violated invariant spans four existing owners:

- the native runtime must record when a direct child result was accepted as continuation work;
- requester-settle wake must not ask for a final answer when the resumed runtime accepted that continuation and yielded for more work;
- terminal delivery must carry the accepted-continuation fact before applying fallback, message-tool-only, or `(no output)` handling;
- Gateway replay must distinguish an admitted handoff from an ambiguous pre-admission `in_flight` reservation and preserve terminal ordering within one lifecycle.

The repair threads `runtimeContinuationStarted` from its producer through terminal resolution and direct delivery, settles a yielded wake as delivered only when continuation evidence was accepted, and records admission in Gateway dedupe state. Pre-admission replays remain retryable; admitted replays do not repeat steering. Both `agent` and `agent.wait` authorization consume the existing absolute dispatch deadline, so authorization cannot extend the request lifetime before `startTurn` or `waitForTurn`.

## User Impact

A requester can complete Wave 1, resume and start Wave 2, then produce one final response after Wave 2. It no longer finalizes between waves, while uncertain pre-admission replay state remains safe to retry.

## Evidence

Focused owner-boundary tests, changed-file checks, and the redacted exact-head runtime proof are listed below.

### Current synchronized repair head

- Prior synchronized repair head: `a79e6219240cdcd89c33d17f6a5688a1a32f698a` (the native proof below covers the pre-CI-repair baseline).
- Terminal owner suites passed 103 tests, including the three-state rule: continuation started alone still finalizes, started plus yield without retained ownership still finalizes, and started plus yield plus retained ownership waits for native continuation.
- Codex owner/relay suites passed 106 tests, including child terminal completion before parent `SpawnAgent item/completed`, unique-successor transfer, zero-owner claim retention, stale symbol-fenced release, and pending-completion handoff.
- Gateway admission/replay/maintenance suites passed 61 tests, including pre-admission collision behavior, admitted replay without a second real run, one absolute authorization/wait deadline, context revalidation, live finalization, and recorded abort reasons.
- Prepared runtime, requester delivery/wake, and local-runtime publication/RPC suites passed, including exact Gateway instance/principal closure fencing.
- The synchronized 60-file changed gate passed formatting, typecheck, lint, dependency, boundary, dead-export, schema-version, and import-cycle checks; runtime import cycles remain zero.
- Full `pnpm build` passed on candidate `a79e6219240cdcd89c33d17f6a5688a1a32f698a` after the latest main synchronization.

### Current head after CI regression repair

- Current head: `0d1f84a7529ff5f1c77b52b0266bc72bb703b060`.
- Follow-up repair: `startAgentRunExecution` uses the admission-validated `prepared.replyDispatchRuntime` when an optional context publication loader is unavailable; a present loader remains authoritative and fail-closed when it returns no runtime.
- The unhosted `getPendingAgentPublication` extension was removed; the existing canonical owner-pending publication gate remains the sole wait path and is covered by the reload/auth regression suites.
- Regression coverage: `src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts` verifies dispatch with no context publication loader.
- Exact-head CI: [run 33438310181](https://github.com/openclaw/openclaw/actions/runs/33438310181) completed successfully for this head (all 243 reported checks passed or were skipped; no failed checks).

Direct inspection of Codex source covered `codex-rs/core/src/tools/handlers/multi_agents/spawn.rs`, `codex-rs/core/src/agent/control/spawn.rs`, `codex-rs/core/src/agent/control.rs`, `codex-rs/core/src/thread_manager.rs`, `codex-rs/app-server-protocol/src/protocol/event_mapping.rs`, and `codex-rs/app-server/src/bespoke_event_handling.rs` at sibling checkout commit `b6f1cfa3f36a34e0f05b6fafdb45c8986d4b521e` ([spawn handler](https://github.com/openai/codex/blob/b6f1cfa3f36a34e0f05b6fafdb45c8986d4b521e/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs#L72-L210), [event mapping](https://github.com/openai/codex/blob/b6f1cfa3f36a34e0f05b6fafdb45c8986d4b521e/codex-rs/app-server-protocol/src/protocol/event_mapping.rs#L75-L131)). The producer emits the spawn item-start before awaiting the async child spawn and emits item-completed only after that await; the app-server maps those events to `item/started` and `item/completed`. This makes child completion before the parent spawn-completion event a reachable ordering, not a synthetic assumption.

### Current-head native two-wave proof

- Validation head: `0d1f84a7529ff5f1c77b52b0266bc72bb703b060`; proof tooling: `8579698525165d583d6d9506afadc4f0d33d435a`.
- Proof workflow: [run 33439978014](https://github.com/zhangguiping-xydt/openclaw/actions/runs/33439978014).
- Redacted artifact: [pr130563-native-runtime-proof](https://github.com/zhangguiping-xydt/openclaw/actions/runs/33439978014/artifacts/9775907054).
- Runtime: real OpenClaw Gateway plus managed Codex app-server 0.151.0, with a deterministic localhost Responses API boundary; no inherited credentials were available to PR code.
- Verdict: `ok=true`, `testExitCode=0`, `exactlyOneFinalParentResponse=true`, `externalProviderLiveProof=false`.
- Observed native order: `spawn_wave_1 → yield_wave_1 → spawn_wave_2 → yield_wave_2 → parent_final`.
- Both child replies were held until the corresponding requester yield and arrival, then released. The provider recorded two native `multi_agent_v1.spawn_agent` contracts and no unexpected/provider-error action.
- The redacted `verdict.json` SHA-256 is `9239b8130fb17d252727a9bbca224bfa807f0987f9431a243b0de95b15ec6f1d`.

This current-head proof covers issue #129455's sequential two-wave Gateway/Codex path. The provider boundary is deterministic localhost rather than an external provider or Discord channel. Discord live proof was explicitly waived by the requester and was not run; this evidence is not presented as Discord proof.

### Inline current-head proof record

The current-head proof workflow's redacted `verdict.json` is reproduced here so the result is reviewable without artifact access:

```json
{
  "ok": true,
  "validationSha": "0d1f84a7529ff5f1c77b52b0266bc72bb703b060",
  "toolingSha": "8579698525165d583d6d9506afadc4f0d33d435a",
  "runtime": "real OpenClaw Gateway plus managed Codex app-server",
  "providerBoundary": "deterministic localhost Responses API",
  "externalProviderLiveProof": false,
  "inheritedCredentialsAvailableToPrCode": false,
  "orderedNativeActions": ["spawn_wave_1", "yield_wave_1", "spawn_wave_2", "yield_wave_2", "parent_final"],
  "heldChildReplies": ["hold_wave_1", "hold_wave_2"],
  "releasedChildReplies": ["release_wave_1_after_yield_and_arrival", "release_wave_2_after_yield_and_arrival"],
  "exactlyOneFinalParentResponse": true,
  "testExitCode": 0,
  "unexpectedProviderActions": []
}
```

### Scope and risk

From the merge base, the complete PR changes 60 files: production code is `+651/-183`, and tests/test support are `+2426/-362`. The positive production delta establishes one continuation-ownership flow across Codex relay claims, terminal resolution, requester delivery, Gateway admission/replay, absolute deadlines, and context-generation fencing; it does not add a parallel compatibility path. The owner-level lifecycle repair primarily adds unique-successor ownership transfer and stale admitted-run terminal recovery. The CI follow-ups change no production behavior: they move four continuation regressions into their sibling state suite, inject the queued-collector test through the request-context runtime owner, synchronize the closure-fencing assertion, and format the existing live harness.

No public API, configuration, protocol version, persistence schema, or migration changed.

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

---

### Current synchronized repair head (latest)

- Current head: `04390cdae4f990c2c8e199ce7dde86098004e1d8`.
- Follow-up commits `c5f65bb6921` and `04390cdae4f` complete the published Gateway reply-dispatch runtime fixture for every custom agent test context; production code is unchanged by these follow-ups.
- Exact-head CI: [run 33432209720](https://github.com/openclaw/openclaw/actions/runs/33432209720) completed. All gateway/agent owner shards, build, security, and boundary checks passed.
- The only failing shard was `checks-node-compact-small-46`, an unrelated `test/scripts/plugin-sdk-api-diff.test.ts` cleanup assertion (`.git-invocation-counts.json` remained); the required `openclaw/ci-gate` failure is only the aggregate of that shard.
- GitHub rejected `gh run rerun --failed` because this external contributor account lacks repository admin rights. No unrelated production or test changes were made to mask that infrastructure/test-isolation failure.
- The earlier `04e47b48e5c`/`f77624bb29f` head notes above are superseded by this section. Discord live proof remains explicitly waived by the requester and is not claimed here.
