### PR TITLE
refactor(models): build provider catalogs as complete batches

### DIFF
--- a/extensions/baseten/models.ts
+++ b/extensions/baseten/models.ts
@@ -2,7 +2,7 @@
  * Baseten model catalog, compat metadata, and live row projection.
  */
 import {
-  buildManifestModelDefinition,
+  buildManifestModelProviderConfig,
   readManifestProviderDefaultModelRef,
 } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type {
@@ -108,16 +108,13 @@ export function buildBasetenModelCompat(modelId: string): ModelCompatConfig {
 
 /** Builds the network-free fallback catalog. */
 export function buildStaticBasetenModels(): ModelDefinitionConfig[] {
-  return BASETEN_MODEL_CATALOG.map(
-    buildManifestModelDefinition({
-      providerId: "baseten",
-      catalog: BASETEN_MANIFEST_CATALOG,
-      decorate: (normalized) => ({
-        ...normalized,
-        compat: buildBasetenModelCompat(normalized.id),
-      }),
-    }),
-  );
+  return buildManifestModelProviderConfig({
+    providerId: "baseten",
+    catalog: BASETEN_MANIFEST_CATALOG,
+  }).models.map((normalized) => ({
+    ...normalized,
+    compat: buildBasetenModelCompat(normalized.id),
+  }));
 }
 
 type BasetenLiveModelRow = {

--- a/extensions/baseten/models.ts
+++ b/extensions/baseten/models.ts
@@ -111,10 +111,7 @@ export function buildStaticBasetenModels(): ModelDefinitionConfig[] {
   return buildManifestModelProviderConfig({
     providerId: "baseten",
     catalog: BASETEN_MANIFEST_CATALOG,
-  }).models.map((normalized) => ({
-    ...normalized,
-    compat: buildBasetenModelCompat(normalized.id),
-  }));
+  }).models.map((model) => Object.assign(model, { compat: buildBasetenModelCompat(model.id) }));
 }
 
 type BasetenLiveModelRow = {

--- a/extensions/cerebras/models.ts
+++ b/extensions/cerebras/models.ts
@@ -1,9 +1,9 @@
 /**
  * Cerebras model catalog helpers derived from the plugin manifest.
  */
-import { buildManifestModelDefinition } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { buildCerebrasProvider } from "./provider-catalog.js";
 
 const CEREBRAS_MANIFEST_CATALOG = manifest.modelCatalog.providers.cerebras;
 
@@ -14,7 +14,5 @@ export const CEREBRAS_MODEL_CATALOG = CEREBRAS_MANIFEST_CATALOG.models;
 
 /** Builds normalized Cerebras catalog model definitions. */
 export function buildCerebrasCatalogModels(): ModelDefinitionConfig[] {
-  return CEREBRAS_MODEL_CATALOG.map(
-    buildManifestModelDefinition({ providerId: "cerebras", catalog: CEREBRAS_MANIFEST_CATALOG }),
-  );
+  return buildCerebrasProvider().models;
 }

--- a/extensions/chutes/models.ts
+++ b/extensions/chutes/models.ts
@@ -3,7 +3,7 @@
  */
 import { withTrustedEnvProxyGuardedFetchMode } from "openclaw/plugin-sdk/fetch-runtime";
 import { buildLiveModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
-import { buildManifestModelDefinition } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   fetchWithSsrFGuard,
@@ -35,13 +35,10 @@ function decorateChutesModelDefinition(model: ModelDefinitionConfig): ModelDefin
 }
 
 /** Bundled fallback Chutes model catalog, normalized from the plugin manifest. */
-export const CHUTES_MODEL_CATALOG: ModelDefinitionConfig[] = CHUTES_MANIFEST_CATALOG.models.map(
-  buildManifestModelDefinition({
-    providerId: "chutes",
-    catalog: CHUTES_MANIFEST_CATALOG,
-    decorate: decorateChutesModelDefinition,
-  }),
-);
+export const CHUTES_MODEL_CATALOG: ModelDefinitionConfig[] = buildManifestModelProviderConfig({
+  providerId: "chutes",
+  catalog: CHUTES_MANIFEST_CATALOG,
+}).models.map(decorateChutesModelDefinition);
 
 interface ChutesModelEntry {
   id: string;

--- a/extensions/cohere/models.ts
+++ b/extensions/cohere/models.ts
@@ -1,14 +1,13 @@
 /**
  * Cohere model catalog helpers derived from the plugin manifest.
  */
-import { buildManifestModelDefinition } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const COHERE_MANIFEST_CATALOG = manifest.modelCatalog.providers.cohere;
 
 export const COHERE_BASE_URL = COHERE_MANIFEST_CATALOG.baseUrl;
-const COHERE_MODEL_CATALOG = COHERE_MANIFEST_CATALOG.models;
 const COHERE_COMMAND_A_PLUS_MODEL_ID = "command-a-plus-05-2026";
 const COHERE_COMMAND_A_REASONING_MODEL_ID = "command-a-reasoning-08-2025";
 const COHERE_NORTH_MINI_CODE_MODEL_ID = "north-mini-code-1-0";
@@ -25,7 +24,8 @@ export function isModernCohereModelId(modelId: string): boolean {
 }
 
 export function buildCohereCatalogModels(): ModelDefinitionConfig[] {
-  return COHERE_MODEL_CATALOG.map(
-    buildManifestModelDefinition({ providerId: "cohere", catalog: COHERE_MANIFEST_CATALOG }),
-  );
+  return buildManifestModelProviderConfig({
+    providerId: "cohere",
+    catalog: COHERE_MANIFEST_CATALOG,
+  }).models;
 }

--- a/extensions/deepseek/models.ts
+++ b/extensions/deepseek/models.ts
@@ -9,7 +9,7 @@ export const DEEPSEEK_BASE_URL = DEEPSEEK_MANIFEST_CATALOG.baseUrl;
 export const DEEPSEEK_MODEL_CATALOG: ModelDefinitionConfig[] = buildManifestModelProviderConfig({
   providerId: "deepseek",
   catalog: DEEPSEEK_MANIFEST_CATALOG,
-}).models.map((model) => ({ ...model, api: "openai-completions" }));
+}).models.map((model) => Object.assign(model, { api: "openai-completions" }));
 
 const DEEPSEEK_V4_MODEL_IDS = new Set(["deepseek-v4-flash", "deepseek-v4-pro"]);
 

--- a/extensions/deepseek/models.ts
+++ b/extensions/deepseek/models.ts
@@ -1,18 +1,15 @@
 // Deepseek plugin module implements models behavior.
-import { buildManifestModelDefinition } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const DEEPSEEK_MANIFEST_CATALOG = manifest.modelCatalog.providers.deepseek;
 export const DEEPSEEK_BASE_URL = DEEPSEEK_MANIFEST_CATALOG.baseUrl;
 
-export const DEEPSEEK_MODEL_CATALOG: ModelDefinitionConfig[] = DEEPSEEK_MANIFEST_CATALOG.models.map(
-  buildManifestModelDefinition({
-    providerId: "deepseek",
-    catalog: DEEPSEEK_MANIFEST_CATALOG,
-    decorate: (model) => ({ ...model, api: "openai-completions" }),
-  }),
-);
+export const DEEPSEEK_MODEL_CATALOG: ModelDefinitionConfig[] = buildManifestModelProviderConfig({
+  providerId: "deepseek",
+  catalog: DEEPSEEK_MANIFEST_CATALOG,
+}).models.map((model) => ({ ...model, api: "openai-completions" }));
 
 const DEEPSEEK_V4_MODEL_IDS = new Set(["deepseek-v4-flash", "deepseek-v4-pro"]);
 

--- a/extensions/meta/models.ts
+++ b/extensions/meta/models.ts
@@ -1,9 +1,9 @@
 /**
  * Meta model catalog helpers derived from the plugin manifest.
  */
-import { buildManifestModelDefinition } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { buildMetaProvider } from "./provider-catalog.js";
 
 const META_MANIFEST_CATALOG = manifest.modelCatalog.providers["meta"];
 
@@ -14,7 +14,5 @@ export const META_MODEL_CATALOG = META_MANIFEST_CATALOG.models;
 
 /** Builds normalized Meta catalog model definitions. */
 export function buildMetaCatalogModels(): ModelDefinitionConfig[] {
-  return META_MODEL_CATALOG.map(
-    buildManifestModelDefinition({ providerId: "meta", catalog: META_MANIFEST_CATALOG }),
-  );
+  return buildMetaProvider().models;
 }

--- a/extensions/mistral/model-definitions.ts
+++ b/extensions/mistral/model-definitions.ts
@@ -1,9 +1,7 @@
-import {
-  buildManifestModelProviderConfig,
-  readManifestProviderDefaultModelRef,
-} from "openclaw/plugin-sdk/provider-catalog-shared";
+import { readManifestProviderDefaultModelRef } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { buildMistralProvider } from "./provider-catalog.js";
 
 const MISTRAL_MANIFEST_CATALOG = manifest.modelCatalog.providers.mistral;
 
@@ -12,16 +10,11 @@ export const MISTRAL_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(man
 export const MISTRAL_DEFAULT_MODEL_ID = MISTRAL_DEFAULT_MODEL_REF.slice("mistral/".length);
 
 export function buildMistralModelDefinition(): ModelDefinitionConfig {
-  const model = buildMistralCatalogModels().find((entry) => entry.id === MISTRAL_DEFAULT_MODEL_ID);
+  const model = buildMistralProvider().models.find(
+    (entry) => entry.id === MISTRAL_DEFAULT_MODEL_ID,
+  );
   if (!model) {
     throw new Error(`Missing Mistral provider model ${MISTRAL_DEFAULT_MODEL_ID}`);
   }
   return model;
-}
-
-function buildMistralCatalogModels(): ModelDefinitionConfig[] {
-  return buildManifestModelProviderConfig({
-    providerId: "mistral",
-    catalog: MISTRAL_MANIFEST_CATALOG,
-  }).models;
 }

--- a/extensions/tencent/models.ts
+++ b/extensions/tencent/models.ts
@@ -13,7 +13,7 @@ const TOKENHUB_MANIFEST_CATALOG = manifest.modelCatalog.providers[TOKENHUB_PROVI
 export const TOKENHUB_MODEL_CATALOG: ModelDefinitionConfig[] = buildManifestModelProviderConfig({
   providerId: TOKENHUB_PROVIDER_ID,
   catalog: TOKENHUB_MANIFEST_CATALOG,
-}).models.map((model) => ({ ...model, api: "openai-completions" }));
+}).models.map((model) => Object.assign(model, { api: "openai-completions" }));
 
 // ---------- TokenPlan provider ----------
 
@@ -25,4 +25,4 @@ const TOKENPLAN_MANIFEST_CATALOG = manifest.modelCatalog.providers[TOKENPLAN_PRO
 export const TOKENPLAN_MODEL_CATALOG: ModelDefinitionConfig[] = buildManifestModelProviderConfig({
   providerId: TOKENPLAN_PROVIDER_ID,
   catalog: TOKENPLAN_MANIFEST_CATALOG,
-}).models.map((model) => ({ ...model, api: "openai-completions" }));
+}).models.map((model) => Object.assign(model, { api: "openai-completions" }));

--- a/extensions/tencent/models.ts
+++ b/extensions/tencent/models.ts
@@ -1,5 +1,5 @@
 // Tencent plugin module implements models behavior.
-import { buildManifestModelDefinition } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
@@ -10,13 +10,10 @@ export const TOKENHUB_PROVIDER_ID = "tencent-tokenhub";
 export const TOKENHUB_BASE_URL = manifest.modelCatalog.providers[TOKENHUB_PROVIDER_ID].baseUrl;
 
 const TOKENHUB_MANIFEST_CATALOG = manifest.modelCatalog.providers[TOKENHUB_PROVIDER_ID];
-export const TOKENHUB_MODEL_CATALOG: ModelDefinitionConfig[] = TOKENHUB_MANIFEST_CATALOG.models.map(
-  buildManifestModelDefinition({
-    providerId: TOKENHUB_PROVIDER_ID,
-    catalog: TOKENHUB_MANIFEST_CATALOG,
-    decorate: (model) => ({ ...model, api: "openai-completions" }),
-  }),
-);
+export const TOKENHUB_MODEL_CATALOG: ModelDefinitionConfig[] = buildManifestModelProviderConfig({
+  providerId: TOKENHUB_PROVIDER_ID,
+  catalog: TOKENHUB_MANIFEST_CATALOG,
+}).models.map((model) => ({ ...model, api: "openai-completions" }));
 
 // ---------- TokenPlan provider ----------
 
@@ -25,11 +22,7 @@ export const TOKENPLAN_PROVIDER_ID = "tencent-tokenplan";
 export const TOKENPLAN_BASE_URL = manifest.modelCatalog.providers[TOKENPLAN_PROVIDER_ID].baseUrl;
 
 const TOKENPLAN_MANIFEST_CATALOG = manifest.modelCatalog.providers[TOKENPLAN_PROVIDER_ID];
-export const TOKENPLAN_MODEL_CATALOG: ModelDefinitionConfig[] =
-  TOKENPLAN_MANIFEST_CATALOG.models.map(
-    buildManifestModelDefinition({
-      providerId: TOKENPLAN_PROVIDER_ID,
-      catalog: TOKENPLAN_MANIFEST_CATALOG,
-      decorate: (model) => ({ ...model, api: "openai-completions" }),
-    }),
-  );
+export const TOKENPLAN_MODEL_CATALOG: ModelDefinitionConfig[] = buildManifestModelProviderConfig({
+  providerId: TOKENPLAN_PROVIDER_ID,
+  catalog: TOKENPLAN_MANIFEST_CATALOG,
+}).models.map((model) => ({ ...model, api: "openai-completions" }));

--- a/extensions/together/models.ts
+++ b/extensions/together/models.ts
@@ -1,15 +1,12 @@
 // Together plugin module implements models behavior.
-import { buildManifestModelDefinition } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const TOGETHER_MANIFEST_CATALOG = manifest.modelCatalog.providers.together;
 export const TOGETHER_BASE_URL = TOGETHER_MANIFEST_CATALOG.baseUrl;
 
-export const TOGETHER_MODEL_CATALOG: ModelDefinitionConfig[] = TOGETHER_MANIFEST_CATALOG.models.map(
-  buildManifestModelDefinition({
-    providerId: "together",
-    catalog: TOGETHER_MANIFEST_CATALOG,
-    decorate: (model) => ({ ...model, api: "openai-completions" }),
-  }),
-);
+export const TOGETHER_MODEL_CATALOG: ModelDefinitionConfig[] = buildManifestModelProviderConfig({
+  providerId: "together",
+  catalog: TOGETHER_MANIFEST_CATALOG,
+}).models.map((model) => ({ ...model, api: "openai-completions" }));

--- a/extensions/together/models.ts
+++ b/extensions/together/models.ts
@@ -9,4 +9,4 @@ export const TOGETHER_BASE_URL = TOGETHER_MANIFEST_CATALOG.baseUrl;
 export const TOGETHER_MODEL_CATALOG: ModelDefinitionConfig[] = buildManifestModelProviderConfig({
   providerId: "together",
   catalog: TOGETHER_MANIFEST_CATALOG,
-}).models.map((model) => ({ ...model, api: "openai-completions" }));
+}).models.map((model) => Object.assign(model, { api: "openai-completions" }));

--- a/extensions/venice/models.ts
+++ b/extensions/venice/models.ts
@@ -1,5 +1,5 @@
 import {
-  buildManifestModelDefinition,
+  buildManifestModelProviderConfig,
   readManifestProviderDefaultModelRef,
 } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type {
@@ -44,13 +44,10 @@ function decorateVeniceModelDefinition(entry: ModelDefinitionConfig): ModelDefin
 }
 
 /** Venice's decorated network-free fallback catalog. */
-export const VENICE_MODEL_CATALOG: ModelDefinitionConfig[] = VENICE_MANIFEST_CATALOG.models.map(
-  buildManifestModelDefinition({
-    providerId: "venice",
-    catalog: VENICE_MANIFEST_CATALOG,
-    decorate: decorateVeniceModelDefinition,
-  }),
-);
+export const VENICE_MODEL_CATALOG: ModelDefinitionConfig[] = buildManifestModelProviderConfig({
+  providerId: "venice",
+  catalog: VENICE_MANIFEST_CATALOG,
+}).models.map(decorateVeniceModelDefinition);
 
 interface VeniceModelSpec {
   name: string;

--- a/src/plugin-sdk/provider-catalog-shared.test.ts
+++ b/src/plugin-sdk/provider-catalog-shared.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import {
   applyProviderNativeStreamingUsageCompat,
-  buildManifestModelDefinition,
   buildManifestModelProviderConfig,
   clearLiveCatalogCacheForTests,
   getCachedLiveCatalogValue,
@@ -449,20 +448,6 @@ describe("provider-catalog-shared manifest provider configs", () => {
         "example",
       ),
     ).toBe("example/example-model");
-
-    expect(
-      buildManifestModelDefinition({
-        providerId: "example",
-        catalog,
-        decorate: (model) => ({
-          ...model,
-          compat: { ...model.compat, supportsUsageInStreaming: false },
-        }),
-      })(catalog.models[0]),
-    ).toEqual({
-      ...buildManifestModelProviderConfig({ providerId: "example", catalog }).models[0],
-      compat: { supportsUsageInStreaming: false },
-    });
   });
 
   it("normalizes retired nested Gemini ids before emitting manifest provider config", () => {

--- a/src/plugin-sdk/provider-catalog-shared.ts
+++ b/src/plugin-sdk/provider-catalog-shared.ts
@@ -311,32 +311,6 @@ export function buildManifestProviderCatalogFamily(params: {
   };
 }
 
-/** Builds one normalized runtime model row from a provider manifest catalog entry. */
-export function buildManifestModelDefinition(params: {
-  /** Provider id that owns the manifest catalog row. */
-  providerId: string;
-  /** Raw manifest modelCatalog provider block that contains the row. */
-  catalog: unknown;
-  /** Optional provider policy applied after manifest normalization. */
-  decorate?: (model: ModelDefinitionConfig) => ModelDefinitionConfig;
-}): (model: unknown) => ModelDefinitionConfig {
-  if (!params.catalog || typeof params.catalog !== "object" || Array.isArray(params.catalog)) {
-    throw new Error(`Missing modelCatalog.providers.${params.providerId}`);
-  }
-  const catalog = params.catalog;
-  return (rawModel) => {
-    const provider = buildManifestModelProviderConfig({
-      providerId: params.providerId,
-      catalog: { ...catalog, models: [rawModel] },
-    });
-    const model = provider.models[0];
-    if (!model) {
-      throw new Error(`Missing modelCatalog.providers.${params.providerId}.models[0]`);
-    }
-    return params.decorate?.(model) ?? model;
-  };
-}
-
 function normalizeConfiguredCatalogModelInput(
   input: unknown,
 ): ConfiguredProviderCatalogEntry["input"] | undefined {


### PR DESCRIPTION
## What Problem This Solves

Several provider plugins build their offline catalogs by repeatedly normalizing a one-model provider block. That duplicates the existing whole-provider construction path and adds an SDK adapter whose only job is to wrap that path again.

## Why This Change Was Made

Use the canonical whole-provider builder for Baseten, Cerebras, Chutes, Cohere, DeepSeek, Meta, Tencent, Together and Venice. Reuse Mistral's existing provider builder for its default model. Delete the row-by-row adapter and its self-comparison assertion; keep provider-specific decorators in their owning plugins.

Production: +48/-110 (net -62). Tests: +0/-15. No dependency, manifest metadata, config/default, transport, auth, discovery-cache or persistence change.

The removed SDK symbol was introduced in #113879 and is absent from the latest stable tag, v2026.7.1-2. Tags containing it are beta-only. The SDK subpath and all other provider exports remain unchanged; no compatibility shim is needed for this unreleased helper.

## User Impact

No intended behavior change. Existing catalog order, pricing, input capabilities, default-model selection, explicit per-model APIs and vendor compatibility overrides remain intact. Live discovery continues using the same provider-owned projection and credential/cache boundaries. The manifest itself is unchanged, so there is no hosted catalog update to publish.

## Evidence

- Before-edit baseline: 128 tests across 19 SDK/provider files passed.
- After-edit: the same 128 tests across all 19 files passed. After the lint cleanup, all 61 affected SDK/provider tests across eight files passed again, and targeted type-aware lint passed.
- Full build passed all 15 phases, including CLI bootstrap imports, 147 public SDK subpaths and built plugin control-plane loads. An earlier local build collided with an E2E setup rebuild; the clean serialized rerun above passed. Local changed-check startup also hit the shared Vitest cache; focused reruns use an isolated cache and hosted CI supplies the complete gate.
- Actual built CLI with isolated empty config returned all five expected Cohere models with correct input/context metadata. A separate isolated fixture probe captured default/all/local/provider-filtered output; the all-model view also retains `zai/glm-5.3-flash` with text+image, 1,048,576 context and `missing: false`. These are real CLI probes, not authenticated inference calls; no external API behavior changed.
- Initial CI rejected spreading newly allocated rows inside `.map()`. The follow-up decorates those owned rows in place; [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33031004005) passed on `8b0fb83e06fe2e96a5b08fa4e6c9068cead062d8`, including all 65 selected plugin test shards and the final CI gate.
- Independent Codex autoreview: no actionable findings. An initial attempt selected an older installed CLI and failed before review; the retry used the installed compatible CLI and completed successfully.
- Direct source audit covered the shared catalog normalizer/builder, all affected provider builders, onboarding and registration callers, public barrels, sibling catalog-family implementation, and stable-tag history.
- Existing tests retain independent coverage of pricing tiers, thinking/context/media metadata, invalid manifest rejection, provider decorations, onboarding defaults, live fallback and credential isolation. Only the obsolete adapter self-comparison is deleted.

Follow-up from the broader audit: OpenCode Zen/Go have duplicated snapshot/lifecycle plumbing, but their dynamic-resolution policy differs intentionally (Go remains seed-only outside its authenticated catalog). A later snapshot refactor must preserve that account boundary. Their live-test model selection also needs updating: upstream metadata now marks Zen x-preview-f-free/deepseek-v4-flash-free and Go ox-alpha-free deprecated; production lifecycle filtering must not be weakened to satisfy stale tests.
