### PR TITLE
refactor(agents): retain one process record through completion

### DIFF
--- a/src/agents/bash-process-registry.test.ts
+++ b/src/agents/bash-process-registry.test.ts
@@ -10,11 +10,9 @@ import {
   addSession,
   appendOutput,
   deleteSession,
-  drainFinishedSession,
   drainSession,
   getActiveBackgroundExecSessionCount,
   getFinishedSession,
-  getFinishedSessionForProcess,
   isProcessSessionIdTaken,
   listFinishedSessions,
   listRunningSessions,
@@ -208,34 +206,21 @@ describe("bash process registry", () => {
     addSession(session);
     markExited(session, 0, null, "completed");
     expect(listFinishedSessions()).toHaveLength(0);
+    expect(session.endedAt).toBeUndefined();
 
     markBackgrounded(session);
     markExited(session, 0, null, "completed");
     const finishedSessions = listFinishedSessions();
     const endedAt = finishedSessions[0]?.endedAt;
     expect(endedAt).toEqual(expect.any(Number));
-    expect(finishedSessions).toStrictEqual([
-      {
-        id: "sess",
-        command: "echo test",
-        scopeKey: undefined,
-        startedAt: session.startedAt,
-        endedAt,
-        cwd: "/tmp",
-        status: "completed",
-        exitCode: 0,
-        exitSignal: null,
-        exitReason: undefined,
-        aggregated: "",
-        tail: "",
-        truncated: false,
-        totalOutputChars: 0,
-        unreadOutput: { output: "", outputDropped: false },
-      },
-    ]);
+    expect(finishedSessions).toEqual([session]);
+    expect(session.terminalStatus).toBe("completed");
+    deleteSession(session.id);
+    expect(session.endedAt).toBe(endedAt);
+    expect(listFinishedSessions()).toHaveLength(0);
   });
 
-  it("moves unread output into the exact finished snapshot and consumes it once", () => {
+  it("retains unread output on its exact process and consumes it once", () => {
     const session = createRegistrySession({
       id: "exact-finished-output",
       maxOutputChars: 100,
@@ -246,10 +231,9 @@ describe("bash process registry", () => {
     appendOutput(session, "stdout", "terminal output\n");
     markExited(session, 0, null, "completed");
 
-    const finished = getFinishedSessionForProcess(session);
-    expect(finished).toBe(getFinishedSession(session.id));
-    expect(finished && drainFinishedSession(finished).output).toBe("terminal output\n");
-    expect(finished && drainFinishedSession(finished).output).toBe("");
+    const finished = getFinishedSession(session.id);
+    expect(finished).toBe(session);
+    expect(finished && drainSession(finished).output).toBe("terminal output\n");
     expect(drainSession(session).output).toBe("");
   });
 

--- a/src/agents/bash-process-registry.ts
+++ b/src/agents/bash-process-registry.ts
@@ -49,7 +49,7 @@ type PendingOutputChunk = {
   text: string;
 };
 
-/** Mutable session state for a running bash exec process. */
+/** One process record from execution through completed retention. */
 export interface ProcessSession {
   id: string;
   command: string;
@@ -84,11 +84,14 @@ export interface ProcessSession {
   stdin?: SessionStdin;
   pid?: number;
   startedAt: number;
+  /** Set only on admission to completed retention; survives index removal. */
+  endedAt?: number;
   cwd?: string;
   maxOutputChars: number;
   pendingMaxOutputChars?: number;
   totalOutputChars: number;
-  pendingOutput: PendingOutputChunk[];
+  /** Live chunks become frozen text at completion, releasing the chunk graph. */
+  pendingOutput: PendingOutputChunk[] | string;
   pendingStdoutChars: number;
   pendingStderrChars: number;
   /** Output was dropped from the pending poll buffers since their last drain. */
@@ -110,32 +113,9 @@ export interface ProcessSession {
   cursorKeyMode: "unknown" | "normal" | "application";
 }
 
-/** Retained summary for a completed background session. */
-interface FinishedSession {
-  id: string;
-  command: string;
-  scopeKey?: string;
-  startedAt: number;
-  endedAt: number;
-  cwd?: string;
-  status: ProcessStatus;
-  exitCode?: number | null;
-  exitSignal?: NodeJS.Signals | number | null;
-  exitReason?: TerminationReason;
-  noOutputTimedOut?: boolean;
-  aggregated: string;
-  tail: string;
-  truncated: boolean;
-  totalOutputChars: number;
-  unreadOutput?: ReturnType<typeof drainSession>;
-  terminalPollObserved?: boolean;
-  notifyOnExitRemoval?: NotifyOnExitRemoval;
-}
-
 const runningSessions = new Map<string, ProcessSession>();
-const finishedSessions = new Map<string, FinishedSession>();
-let finishedSessionsByProcess = new WeakMap<ProcessSession, FinishedSession>();
-// Keep start chronology private while snapshots retain their completion-order eviction contract.
+const finishedSessions = new Map<string, ProcessSession & { endedAt: number }>();
+// Display uses start chronology; retained records are evicted in completion order.
 let processSessionStartOrders = new WeakMap<object, number>();
 let nextProcessSessionStartOrder = 0;
 const activeBackgroundExecSessionIds = new Set<string>();
@@ -178,11 +158,6 @@ export function getFinishedSession(id: string) {
   return finishedSessions.get(id);
 }
 
-/** Returns the terminal snapshot owned by this exact process incarnation. */
-export function getFinishedSessionForProcess(session: ProcessSession) {
-  return finishedSessionsByProcess.get(session);
-}
-
 function deleteFinishedSession(id: string): boolean {
   const session = finishedSessions.get(id);
   if (!session) {
@@ -220,6 +195,9 @@ export function clearFinishedSessionsForScopes(scopeKeys: Iterable<string>): voi
 
 /** Appends process output while enforcing aggregate and pending-output caps. */
 export function appendOutput(session: ProcessSession, stream: "stdout" | "stderr", chunk: string) {
+  if (typeof session.pendingOutput === "string") {
+    return;
+  }
   const streamChars = stream === "stdout" ? session.pendingStdoutChars : session.pendingStderrChars;
   const pendingCap = Math.min(
     session.pendingMaxOutputChars ?? DEFAULT_PENDING_OUTPUT_CHARS,
@@ -247,20 +225,16 @@ export function appendOutput(session: ProcessSession, stream: "stdout" | "stderr
 
 /** Drains pending chunks in producer callback order for a process poll. */
 export function drainSession(session: ProcessSession) {
-  const output = session.pendingOutput.map((chunk) => chunk.text).join("");
+  const pending = session.pendingOutput;
+  const output =
+    typeof pending === "string" ? pending : pending.map((chunk) => chunk.text).join("");
   const outputDropped = session.pendingOutputDropped;
-  session.pendingOutput = [];
+  // Draining a terminal record must not reopen it to late producer callbacks.
+  session.pendingOutput = typeof pending === "string" ? "" : [];
   session.pendingStdoutChars = 0;
   session.pendingStderrChars = 0;
   session.pendingOutputDropped = false;
   return { output, outputDropped };
-}
-
-/** Consumes the output transferred to one exact terminal snapshot. */
-export function drainFinishedSession(session: FinishedSession) {
-  const output = session.unreadOutput;
-  session.unreadOutput = undefined;
-  return output ?? { output: "", outputDropped: false };
 }
 
 /** Moves a session to finished state and records exit metadata. */
@@ -282,7 +256,12 @@ export function markExited(
   session.exitReason = exitReason;
   session.noOutputTimedOut = noOutputTimedOut;
   session.tail = tail(session.aggregated, 2000);
-  moveToFinished(session, status);
+  // Finalizer diagnostics are already appended. Freeze output before retention
+  // accounts for its size, and release the live per-callback chunk objects.
+  const pending = drainSession(session);
+  session.pendingOutput = pending.output;
+  session.pendingOutputDropped = pending.outputDropped;
+  moveToFinished(session);
 }
 
 /** Marks a running session as reconnectable after the exec call returns. */
@@ -296,13 +275,9 @@ export function markBackgrounded(session: ProcessSession) {
 /** Records that a terminal process poll consumed the process result. */
 export function markTerminalPollObserved(session: ProcessSession): void {
   session.terminalPollObserved = true;
-  const finished = finishedSessionsByProcess.get(session);
-  if (finished) {
-    finished.terminalPollObserved = true;
-  }
 }
 
-/** Retains the precise event removal handle across the finished-session move. */
+/** Retains the precise completion-event removal handle on its process owner. */
 export function recordNotifyOnExitRemoval(
   session: ProcessSession,
   remove: NotifyOnExitRemoval,
@@ -312,10 +287,6 @@ export function recordNotifyOnExitRemoval(
     return;
   }
   session.notifyOnExitRemoval = remove;
-  const finished = finishedSessionsByProcess.get(session);
-  if (finished) {
-    finished.notifyOnExitRemoval = remove;
-  }
 }
 
 /** Acknowledges one completion event without touching unrelated queue entries. */
@@ -340,7 +311,7 @@ export function getActiveBackgroundExecSessionCount(): number {
   return activeBackgroundExecSessionIds.size;
 }
 
-function moveToFinished(session: ProcessSession, status: ProcessStatus) {
+function moveToFinished(session: ProcessSession) {
   runningSessions.delete(session.id);
 
   // The supervisor owns the raw process. The registry releases only the
@@ -361,31 +332,7 @@ function moveToFinished(session: ProcessSession, status: ProcessStatus) {
   // Keep full completed logs; evict older records rather than silently
   // truncating the process poll/log contract or dropping the newest result.
   deleteFinishedSession(session.id);
-  const finished: FinishedSession = {
-    id: session.id,
-    command: session.command,
-    scopeKey: session.scopeKey,
-    startedAt: session.startedAt,
-    endedAt: Date.now(),
-    cwd: session.cwd,
-    status,
-    exitCode: session.exitCode,
-    exitSignal: session.exitSignal,
-    exitReason: session.exitReason,
-    ...(session.noOutputTimedOut !== undefined
-      ? { noOutputTimedOut: session.noOutputTimedOut }
-      : {}),
-    aggregated: session.aggregated,
-    tail: session.tail,
-    truncated: session.truncated,
-    totalOutputChars: session.totalOutputChars,
-    unreadOutput: drainSession(session),
-    ...(session.terminalPollObserved ? { terminalPollObserved: true } : {}),
-    ...(session.notifyOnExitRemoval ? { notifyOnExitRemoval: session.notifyOnExitRemoval } : {}),
-  };
-  processSessionStartOrders.set(finished, processSessionStartOrders.get(session)!);
-  finishedSessionsByProcess.set(session, finished);
-  finishedSessions.set(session.id, finished);
+  finishedSessions.set(session.id, Object.assign(session, { endedAt: Date.now() }));
   finishedSessionOutputChars += session.aggregated.length;
   while (
     finishedSessions.size > MAX_FINISHED_SESSION_COUNT ||
@@ -455,7 +402,6 @@ export function listFinishedSessions() {
 function resetProcessRegistryForTests() {
   runningSessions.clear();
   finishedSessions.clear();
-  finishedSessionsByProcess = new WeakMap();
   processSessionStartOrders = new WeakMap();
   nextProcessSessionStartOrder = 0;
   finishedSessionOutputChars = 0;

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -16,6 +16,7 @@ import {
 import type { GatewayActiveWorkInspectors } from "../infra/gateway-active-work.js";
 import type { ManagedRun } from "../process/supervisor/index.js";
 import type { RunExit, SpawnInput } from "../process/supervisor/types.js";
+import { getFinishedSession, markTerminalPollObserved } from "./bash-process-registry.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
 
 const requestHeartbeatMock = vi.hoisted(() => vi.fn());
@@ -62,7 +63,7 @@ beforeAll(async () => {
 beforeEach(() => {
   resetGatewaySuspendCoordinatorForLifecycleRestart();
   resetProcessRegistryForTests();
-  requestHeartbeatMock.mockClear();
+  requestHeartbeatMock.mockReset();
   enqueueSystemEventWithReceiptMock.mockReset();
   enqueueSystemEventWithReceiptMock.mockReturnValue(vi.fn(() => true));
   supervisorMock.spawn.mockReset();
@@ -360,18 +361,18 @@ describe("sandbox exec finalization suspension", () => {
       const finalizeExec = vi.fn<NonNullable<BashSandboxConfig["finalizeExec"]>>(
         async () => await finalization.promise,
       );
-      supervisorMock.spawn.mockImplementationOnce(
-        async (input: { onStdout?: (chunk: string) => void }) => {
-          input.onStdout?.("sandbox output\n");
-          return {
-            runId: "sandbox-run",
-            startedAtMs: Date.now(),
-            pid: 123,
-            wait: async () => await exit.promise,
-            cancel: vi.fn(),
-          };
-        },
-      );
+      let producer: SpawnInput | undefined;
+      supervisorMock.spawn.mockImplementationOnce(async (input: SpawnInput) => {
+        producer = input;
+        input.onStdout?.("sandbox output\n");
+        return {
+          runId: "sandbox-run",
+          startedAtMs: Date.now(),
+          pid: 123,
+          wait: async () => await exit.promise,
+          cancel: vi.fn(),
+        };
+      });
 
       const run = await runExecProcess({
         command: "sandbox-command",
@@ -412,6 +413,8 @@ describe("sandbox exec finalization suspension", () => {
       });
       await vi.waitFor(() => expect(finalizeExec).toHaveBeenCalledOnce());
       expect(run.session.finalizing).toBe(true);
+      producer?.onStderr?.("during cleanup\n");
+      expect(getFinishedSession(run.session.id)).toBeUndefined();
 
       const busy = prepareSuspension(`before-finalize-${expectedFailureKind ?? "success"}`);
       expect(busy.status).toBe("busy");
@@ -443,12 +446,124 @@ describe("sandbox exec finalization suspension", () => {
       expect(requireSystemEventCall()[0]).toContain(
         expectedStatus === "failed" ? "Exec failed" : "Exec completed",
       );
+      expect(requireSystemEventCall()[0]).toContain("during cleanup");
+      const retained = getFinishedSession(run.session.id);
+      const outputBeforeLateCallback = {
+        aggregated: retained?.aggregated,
+        tail: retained?.tail,
+        totalOutputChars: retained?.totalOutputChars,
+        truncated: retained?.truncated,
+      };
+      expect(outputBeforeLateCallback.aggregated).toContain("sandbox output\nduring cleanup\n");
+      if (finalizeRejects && !processTimesOut) {
+        expect(outputBeforeLateCallback.aggregated).toContain("sandbox finalize failed");
+      }
+      producer?.onStdout?.("late output".repeat(1_000));
+      expect(getFinishedSession(run.session.id)).toMatchObject(outputBeforeLateCallback);
 
       const ready = prepareSuspension(`after-finalize-${expectedFailureKind ?? "success"}`);
       expect(ready.status).toBe("ready");
       if (ready.status === "ready") {
         expect(resumeGatewaySuspend(ready.suspensionId)).toMatchObject({ ok: true });
       }
+    },
+  );
+});
+
+describe("terminal execution-context release", () => {
+  it.each([
+    { path: "notify", trace: ["task", "enqueue", "wake"] },
+    { path: "quiet", trace: ["task"] },
+    { path: "unrouted", trace: ["task"] },
+    { path: "observed", trace: ["task"] },
+    { path: "task failure", trace: ["task", "task"] },
+    { path: "enqueue failure", trace: ["task", "enqueue", "task"] },
+    { path: "wake failure", trace: ["task", "enqueue", "wake", "task"] },
+  ])(
+    "releases routing after $path without changing notification order",
+    async ({ path, trace }) => {
+      const exit = createDeferred<RunExit>();
+      const observed: string[] = [];
+      const removal = vi.fn(() => true);
+      const deliveryContext = { channel: "telegram", to: "synthetic-chat" };
+      const failure = new Error("notification boundary failed");
+      enqueueSystemEventWithReceiptMock.mockImplementation((_text, options) => {
+        observed.push("enqueue");
+        expect(options.deliveryContext).toEqual(deliveryContext);
+        if (path === "enqueue failure") {
+          throw failure;
+        }
+        return removal;
+      });
+      requestHeartbeatMock.mockImplementation(() => {
+        observed.push("wake");
+        if (path === "wake failure") {
+          throw failure;
+        }
+      });
+      supervisorMock.spawn.mockImplementationOnce(async (input: SpawnInput) => ({
+        ...runtimeManagedRun(input, path === "quiet" ? "" : "retained output\n"),
+        wait: () => exit.promise,
+      }));
+      const run = await runExecProcess({
+        command: "context-release",
+        workdir: "/tmp",
+        env: {},
+        usePty: false,
+        warnings: [],
+        maxOutput: 1_000,
+        pendingMaxOutput: 1_000,
+        scopeKey: "process-scope",
+        sessionKey: path === "unrouted" ? undefined : "agent:main:main",
+        agentId: "main",
+        mainKey: "main",
+        sessionScope: "per-sender",
+        eventRouting: { mainKey: "main", sessionScope: "per-sender" },
+        notifyDeliveryContext: deliveryContext,
+        notifyOnExit: true,
+        notifyOnExitEmptySuccess: false,
+        timeoutSec: null,
+        onSettledBeforeNotify: () => {
+          observed.push("task");
+          if (path === "task failure" && observed.length === 1) {
+            throw failure;
+          }
+        },
+      });
+      markBackgrounded(run.session);
+      if (path === "observed") {
+        markTerminalPollObserved(run.session);
+      }
+      exit.resolve({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 1,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      });
+      const outcome = await run.promise;
+      expect(observed).toEqual(trace);
+      expect(outcome.status).toBe(path.endsWith("failure") ? "failed" : "completed");
+      const retained = getFinishedSession(run.session.id);
+      expect(retained).toMatchObject({ scopeKey: "process-scope", terminalStatus: "completed" });
+      for (const field of [
+        "sessionKey",
+        "agentId",
+        "mainKey",
+        "sessionScope",
+        "eventRouting",
+        "notifyDeliveryContext",
+        "notifyOnExit",
+        "notifyOnExitEmptySuccess",
+        "stdin",
+      ] as const) {
+        expect(retained?.[field], field).toBeUndefined();
+      }
+      expect(retained?.notifyOnExitRemoval).toBe(trace.includes("wake") ? removal : undefined);
+      expect(removal).not.toHaveBeenCalled();
     },
   );
 });

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -839,20 +839,33 @@ export async function runExecProcess(opts: {
       // Finalization can release remote process/session resources. Keep the
       // background-work blocker until that owner transition has settled.
       session.finalizing = false;
-      const shouldNotify = !session.exited;
-      if (shouldNotify) {
-        markExited(
-          session,
-          finalOutcome.exitCode,
-          finalOutcome.exitSignal,
-          finalOutcome.status,
-          finalOutcome.exitReason,
-          finalOutcome.noOutputTimedOut,
-        );
-      }
-      opts.onSettledBeforeNotify?.(finalOutcome);
-      if (shouldNotify) {
-        maybeNotifyOnExit(session, finalOutcome.status);
+      try {
+        const shouldNotify = !session.exited;
+        if (shouldNotify) {
+          markExited(
+            session,
+            finalOutcome.exitCode,
+            finalOutcome.exitSignal,
+            finalOutcome.status,
+            finalOutcome.exitReason,
+            finalOutcome.noOutputTimedOut,
+          );
+        }
+        opts.onSettledBeforeNotify?.(finalOutcome);
+        if (shouldNotify) {
+          maybeNotifyOnExit(session, finalOutcome.status);
+        }
+      } finally {
+        // Notifications need start-time routing, but completed logs must not
+        // retain it, including when a task callback or notification throws.
+        delete session.sessionKey;
+        delete session.agentId;
+        delete session.mainKey;
+        delete session.sessionScope;
+        delete session.eventRouting;
+        delete session.notifyDeliveryContext;
+        delete session.notifyOnExit;
+        delete session.notifyOnExitEmptySuccess;
       }
     }
     return finalOutcome;

--- a/src/agents/bash-tools.exec-task-wiring.test.ts
+++ b/src/agents/bash-tools.exec-task-wiring.test.ts
@@ -163,7 +163,7 @@ describe("exec background task wiring", () => {
     abortController.abort();
 
     await expect
-      .poll(() => getFinishedSession(sessionId)?.status, {
+      .poll(() => getFinishedSession(sessionId)?.terminalStatus, {
         timeout: 5_000,
         interval: 10,
       })

--- a/src/agents/bash-tools.exec.background-abort.test.ts
+++ b/src/agents/bash-tools.exec.background-abort.test.ts
@@ -203,7 +203,7 @@ async function expectBackgroundSessionTimesOut(params: {
 
   const finished = await waitForFinishedSession(sessionId);
   try {
-    expect(finished?.status).toBe("failed");
+    expect(finished?.terminalStatus).toBe("failed");
   } finally {
     cleanupRunningSession(sessionId);
   }

--- a/src/agents/bash-tools.process.e2e.test.ts
+++ b/src/agents/bash-tools.process.e2e.test.ts
@@ -129,7 +129,7 @@ test.skipIf(process.platform === "win32").each([
     expect(outcome.status).toBe(expectedStatus);
     expect(details.status).toBe(expectedStatus);
     expect(details.exitCode).toBe(expectedExitCode);
-    expect(getFinishedSession(run.session.id)?.status).toBe(expectedStatus);
+    expect(getFinishedSession(run.session.id)?.terminalStatus).toBe(expectedStatus);
     expect(textContent(poll)).toContain(`Process exited with ${expectedExitLabel}.`);
     expect(notification).toContain(expectedExitLabel);
     if (finalizerError) {

--- a/src/agents/bash-tools.process.poll-timeout.test.ts
+++ b/src/agents/bash-tools.process.poll-timeout.test.ts
@@ -438,6 +438,45 @@ test("process poll accepts string timeout values", async () => {
   });
 });
 
+test("terminal polls compact tiny stream chunks and never reopen frozen output", async () => {
+  const sessionId = "sess-compact-terminal";
+  const { processTool, session } = createProcessSessionHarness(sessionId);
+  session.maxOutputChars = 3_000;
+  session.pendingMaxOutputChars = 1_000;
+  for (let index = 0; index < 2_000; index += 1) {
+    appendOutput(session, "stdout", "o");
+    appendOutput(session, "stderr", "e");
+  }
+  markExited(session, 0, null, "completed");
+
+  // Retention must release thousands of chunk objects, not just cap their text.
+  expect(session.pendingOutput).toBe("oe".repeat(1_000));
+  expect(session.pendingStdoutChars).toBe(0);
+  expect(session.pendingStderrChars).toBe(0);
+  const terminal = await pollSession(processTool, "compact-first", sessionId);
+  expect(terminal.content[0]).toMatchObject({
+    text:
+      "oe".repeat(1_000) +
+      "\n\n[earlier output was discarded at the retention cap and cannot be recovered]" +
+      "\n\n[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]" +
+      "\n\nProcess exited with code 0.",
+  });
+  appendOutput(session, "stderr", "late".repeat(1_000));
+  const repeated = await pollSession(processTool, "compact-second", sessionId);
+  expect(repeated.content[0]).toMatchObject({
+    text: "(no new output)\n\n[earlier output was discarded at the retention cap and cannot be recovered]\n\nProcess exited with code 0.",
+  });
+  expect(session.totalOutputChars).toBe(4_000);
+  expect(session.pendingOutput).toBe("");
+  expect(session.pendingOutputDropped).toBe(false);
+  const log = await processTool.execute("compact-log", { action: "log", sessionId });
+  expect(log.content[0]).toMatchObject({
+    text:
+      "oe".repeat(1_500) +
+      "\n\n[earlier output was discarded at the retention cap and cannot be recovered]",
+  });
+});
+
 test("process poll warns when the session times out while poll is waiting", async () => {
   vi.useFakeTimers();
   try {
@@ -526,7 +565,7 @@ test.each([
         type: "text",
         text: expect.stringContaining(`Process exited with ${expectedExit}.`),
       });
-      expect(getFinishedSession(sessionId)?.status).toBe(ownerStatus);
+      expect(getFinishedSession(sessionId)?.terminalStatus).toBe(ownerStatus);
 
       const retainedPoll = await pollSession(processTool, "toolcall-terminal-retained", sessionId);
       expect(retainedPoll.details).toMatchObject({ status: ownerStatus });

--- a/src/agents/bash-tools.process.ts
+++ b/src/agents/bash-tools.process.ts
@@ -13,10 +13,8 @@ import {
   type ProcessSession,
   compareProcessSessionStartOrder,
   deleteSession,
-  drainFinishedSession,
   drainSession,
   getFinishedSession,
-  getFinishedSessionForProcess,
   getSession,
   listFinishedSessions,
   listRunningSessions,
@@ -163,11 +161,9 @@ function resetPollRetrySuggestion(sessionId: string): void {
   }
 }
 
-type FinishedSession = NonNullable<ReturnType<typeof getFinishedSession>>;
-
-function finishedSessionDetails(sessionId: string, finished: FinishedSession) {
+function finishedSessionDetails(sessionId: string, finished: ProcessSession) {
   return {
-    status: finished.status === "completed" ? "completed" : "failed",
+    status: finished.terminalStatus === "completed" ? "completed" : "failed",
     sessionId,
     exitCode: finished.exitCode ?? undefined,
     ...(finished.exitSignal != null ? { exitSignal: finished.exitSignal } : {}),
@@ -186,16 +182,13 @@ function finishedSessionDetails(sessionId: string, finished: FinishedSession) {
   };
 }
 
-function finishedPollResult(
-  sessionId: string,
-  finished: FinishedSession,
-): AgentToolResult<unknown> {
+function finishedPollResult(sessionId: string, finished: ProcessSession): AgentToolResult<unknown> {
   resetPollRetrySuggestion(sessionId);
   acknowledgeNotifyOnExit(finished);
-  const { output: unreadOutput, outputDropped } = drainFinishedSession(finished);
+  const { output: unreadOutput, outputDropped } = drainSession(finished);
   const output = unreadOutput.trim();
   // Omitted retained output is pageable only while this public id still owns
-  // the exact snapshot; a reused slug must never point the model at successor logs.
+  // the exact process; a reused slug must never point the model at successor logs.
   const retainedOutputNote = outputDropped
     ? getFinishedSession(sessionId) === finished
       ? "\n\n[earlier output is omitted from this poll; use action=log with offset and limit to inspect retained output]"
@@ -326,41 +319,31 @@ export function createProcessTool(
         const sessions = [...listRunningSessions(), ...listFinishedSessions()]
           .filter((s) => isInScope(s))
           .toSorted(compareProcessSessionStartOrder)
-          .map((s) => {
-            if ("endedAt" in s) {
-              return {
+          .map((s) =>
+            Object.assign(
+              {
                 sessionId: s.id,
-                status: s.status,
+                status: s.terminalStatus ?? "running",
                 startedAt: s.startedAt,
-                endedAt: s.endedAt,
-                runtimeMs: s.endedAt - s.startedAt,
+                runtimeMs: (s.endedAt ?? Date.now()) - s.startedAt,
                 cwd: s.cwd,
                 command: s.command,
                 name: deriveSessionName(s.command),
                 tail: s.tail,
                 truncated: s.truncated,
-                exitCode: s.exitCode ?? undefined,
-                exitSignal: s.exitSignal ?? undefined,
-              };
-            }
-            const runtime = describeRunningSession(s);
-            return {
-              sessionId: s.id,
-              status: "running",
-              pid: s.pid ?? undefined,
-              startedAt: s.startedAt,
-              runtimeMs: Date.now() - s.startedAt,
-              cwd: s.cwd,
-              command: s.command,
-              name: deriveSessionName(s.command),
-              tail: s.tail,
-              truncated: s.truncated,
-              stdinWritable: runtime.stdinWritable,
-              waitingForInput: runtime.waitingForInput,
-              idleMs: runtime.idleMs,
-              lastOutputAt: runtime.lastOutputAt,
-            };
-          });
+              },
+              s.endedAt !== undefined
+                ? {
+                    endedAt: s.endedAt,
+                    exitCode: s.exitCode ?? undefined,
+                    exitSignal: s.exitSignal ?? undefined,
+                  }
+                : Object.assign(
+                    { pid: s.pid ?? undefined },
+                    runningSessionInputDetails(describeRunningSession(s)),
+                  ),
+            ),
+          );
         const lines = sessions.map((s) => {
           const label = s.name ? truncateMiddle(s.name, 80) : truncateMiddle(s.command, 120);
           const marker = "waitingForInput" in s && s.waitingForInput ? " [input-wait]" : "";
@@ -459,11 +442,10 @@ export function createProcessTool(
           }
           if (scopedSession.exited) {
             markTerminalPollObserved(scopedSession);
-            // Exit finalization owns the terminal transition. Re-read by process
-            // object because the public id may already index a successor.
-            const finishedAfterWait = getFinishedSessionForProcess(scopedSession);
-            if (finishedAfterWait && isInScope(finishedAfterWait)) {
-              return finishedPollResult(params.sessionId, finishedAfterWait);
+            // Retention admission survives clear/eviction on this exact object.
+            // A process removed before exit was never retained; never read a successor.
+            if (scopedSession.endedAt !== undefined && isInScope(scopedSession)) {
+              return finishedPollResult(params.sessionId, scopedSession);
             }
             resetPollRetrySuggestion(params.sessionId);
             return failText(`No session found for ${params.sessionId}`);
@@ -500,70 +482,48 @@ export function createProcessTool(
         }
 
         case "log": {
-          if (scopedSession) {
-            if (!scopedSession.backgrounded) {
-              return failText(`Session ${params.sessionId} is not backgrounded.`);
-            }
-            const window = resolveLogSliceWindow(params.offset, params.limit);
-            const { slice, totalLines, totalChars } = sliceLogLines(
-              scopedSession.aggregated,
-              window.effectiveOffset,
-              window.effectiveLimit,
-            );
-            const runtime = describeRunningSession(scopedSession);
-            const logDefaultTailNote = defaultTailNote(totalLines, window.usingDefaultTail);
-            return {
-              content: [
-                {
-                  type: "text",
-                  text:
-                    (slice || "(no output yet)") +
-                    logDefaultTailNote +
-                    retentionCapNote(scopedSession) +
-                    buildInputWaitHint(runtime),
-                },
-              ],
-              details: {
-                status: scopedSession.exited ? "completed" : "running",
-                sessionId: params.sessionId,
-                total: totalLines,
-                totalLines,
-                totalChars,
-                truncated: scopedSession.truncated,
-                name: deriveSessionName(scopedSession.command),
-                ...runningSessionInputDetails(runtime),
-              },
-            };
+          const record = scopedSession ?? scopedFinished;
+          if (!record) {
+            return failText(`No session found for ${params.sessionId}`);
           }
-          if (scopedFinished) {
-            const window = resolveLogSliceWindow(params.offset, params.limit);
-            const { slice, totalLines, totalChars } = sliceLogLines(
-              scopedFinished.aggregated,
-              window.effectiveOffset,
-              window.effectiveLimit,
-            );
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: appendExecTimeoutRetryGuidance(
-                    (slice || "(no output recorded)") +
-                      defaultTailNote(totalLines, window.usingDefaultTail) +
-                      retentionCapNote(scopedFinished),
-                    scopedFinished.exitReason,
-                  ),
-                },
-              ],
-              details: {
-                ...finishedSessionDetails(params.sessionId, scopedFinished),
-                total: totalLines,
-                totalLines,
-                totalChars,
-                truncated: scopedFinished.truncated,
-              },
-            };
+          if (scopedSession && !scopedSession.backgrounded) {
+            return failText(`Session ${params.sessionId} is not backgrounded.`);
           }
-          return failText(`No session found for ${params.sessionId}`);
+          const window = resolveLogSliceWindow(params.offset, params.limit);
+          const { slice, totalLines, totalChars } = sliceLogLines(
+            record.aggregated,
+            window.effectiveOffset,
+            window.effectiveLimit,
+          );
+          const runtime = scopedSession ? describeRunningSession(scopedSession) : undefined;
+          const text =
+            (slice || (scopedSession ? "(no output yet)" : "(no output recorded)")) +
+            defaultTailNote(totalLines, window.usingDefaultTail) +
+            retentionCapNote(record);
+          return {
+            content: [
+              {
+                type: "text",
+                text: runtime
+                  ? text + buildInputWaitHint(runtime)
+                  : appendExecTimeoutRetryGuidance(text, record.exitReason),
+              },
+            ],
+            details: {
+              ...(runtime
+                ? {
+                    status: record.exited ? "completed" : "running",
+                    sessionId: params.sessionId,
+                    name: deriveSessionName(record.command),
+                    ...runningSessionInputDetails(runtime),
+                  }
+                : finishedSessionDetails(params.sessionId, record)),
+              total: totalLines,
+              totalLines,
+              totalChars,
+              truncated: record.truncated,
+            },
+          };
         }
 
         case "write": {

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -681,7 +681,7 @@ const runNotifyNoopCase = async ({ label, defaults, expectNotification }: Notify
 
   const sessionId = await startBackgroundCommand(tool, COMMAND_NOOP);
   await expect
-    .poll(() => getFinishedSession(sessionId)?.status, BACKGROUND_POLL_OPTIONS)
+    .poll(() => getFinishedSession(sessionId)?.terminalStatus, BACKGROUND_POLL_OPTIONS)
     .toBe(PROCESS_STATUS_COMPLETED);
   const events = peekSystemEvents(DEFAULT_NOTIFY_SESSION_KEY);
   expectNotifyNoopEvents(events, expectNotification, sessionId, label);
@@ -836,7 +836,7 @@ describe("exec notifyOnExit", () => {
     const formatted = await drainNotifyEvents();
 
     expect(finished?.id).toBe(sessionId);
-    expect(finished?.status).toBe(PROCESS_STATUS_COMPLETED);
+    expect(finished?.terminalStatus).toBe(PROCESS_STATUS_COMPLETED);
     expect(finished?.exitCode).toBe(0);
     expect(hasEvent).toBe(true);
     expect(queuedEvent).toBeDefined();

--- a/src/auto-reply/reply/bash-command.stop.test.ts
+++ b/src/auto-reply/reply/bash-command.stop.test.ts
@@ -176,7 +176,7 @@ describe("handleBashChatCommand stop", () => {
     getFinishedSessionMock.mockReturnValue({
       id: "session-first",
       scopeKey: "chat:bash",
-      status: "failed",
+      terminalStatus: "failed",
     });
     const restarted = await handleBashChatCommand(buildParams("/bash second"));
     expect(restarted.text).toContain("session-second");

--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -250,7 +250,7 @@ export async function handleBashChatCommand(params: {
       const exitLabel = finished.exitSignal
         ? `signal ${String(finished.exitSignal)}`
         : `code ${String(finished.exitCode ?? 0)}`;
-      const prefix = finished.status === "completed" ? "⚙️" : "⚠️";
+      const prefix = finished.terminalStatus === "completed" ? "⚙️" : "⚠️";
       return {
         text: [
           `${prefix} bash finished (session ${formatSessionSnippet(sessionId)}).`,


### PR DESCRIPTION
## What Problem This Solves

Background command retention currently maintains a second completed-process object and several bridges to keep that copy synchronized with the original process. This is an internal architectural cleanup, not a claim of a newly discovered user-facing bug.

## Why This Change Was Made

Keep one exact process record from execution through completed retention. Delete the copied finished-session shape, completion WeakMap bridge, unread-output transfer/second drain, mirrored notification receipts, and duplicate log/list projections. Live output chunks become immutable terminal text after finalization; completion admission stays on that exact record even after its public index is cleared or reused.

Running/completed indexes, active-process ownership, completion-order eviction, start-order display, finalizer sequencing, and public tool results remain distinct and unchanged. Release the eight start-time routing fields after existing settlement/notification callbacks, including their exceptional paths. No supervisor, Docker lifecycle, configuration, persistence, protocol, dependency, or public SDK change.

## User Impact

No intended user-visible change. Poll, log, remove, cancellation, retained output, and completion notifications keep their existing behavior with fewer internal state copies. Production: **+119/−200 (net −81)**. Tests: **+184/−46 (net +138)**.

## Evidence

- Untouched baseline: 182 tests across 17 files, including nine real process/PTY tests. Final candidate: 190 tests covering the same scenarios plus eight resource-release/output-compaction cases; 181 focused local tests also passed.
- The same real-process proof ran against baseline and candidate: remove one of two live child processes while a poll waits, retain its active/reserved identity until confirmed termination, keep the independent sibling alive, and finish with no active children.
- Real Docker backend proof on both versions: normal workspace-user preparation, two execs in one container, removal of one exec without killing the container or sibling, retained sibling output without second-poll replay, and cleanup of both temporary environment files and the task-owned container.
- Full changed gate passed. Clean-machine full build and public SDK surface check passed; all 147 public entrypoints and their 363-file declaration closure were inspected. Full source inventory/content/symlink/mode fingerprint matched before and after remote tests/build (34,093 files).
- Fresh independent source/behavior review and fresh P1 review passed. The task-owned remote lease is stopped. Exact-head hosted CI and repository-native landing gates remain required.

One initial proof fixture omitted normal Docker workspace-user selection; it was corrected to call the actual preparation helper and rerun on both baseline and candidate. An initial local E2E run started an unintended full build and was stopped; the later complete remote runs above are the proof. Neither incomplete run is counted as successful.

Named separate follow-up: investigate the existing foreground `/bash` failure/exit-zero display; it is not reproduced or changed by this refactor. This work makes no performance benchmark or new bug-fix claim.

AI-assisted implementation and review.
