### PR TITLE
fix(nodes): show paired-device launch approvals in the requesting browser

### DIFF
--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -263,15 +263,11 @@ describe("applyPluginNodeInvokePolicy", () => {
 
     const result = await invokeDemoPolicy(context);
 
-    if (result === null) {
-      throw new Error("expected plugin policy failure");
-    }
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      throw new Error("expected plugin policy failure");
-    }
-    expect(result.code).toBe("PLUGIN_POLICY_MISSING");
-    expect(result.details).toStrictEqual({ nodeCommandDispatched: false });
+    expect(result).toMatchObject({
+      ok: false,
+      code: "PLUGIN_POLICY_MISSING",
+      details: { nodeCommandDispatched: false },
+    });
     expect(invoke).not.toHaveBeenCalled();
   });
 
@@ -735,10 +731,13 @@ describe("applyPluginNodeInvokePolicy", () => {
     expect(invoke).toHaveBeenCalledOnce();
   });
 
-  it("binds plugin policy approval requests to the invoking client", async () => {
+  it.each([false, true])("routes approvals for synthetic=%s", async (synthetic) => {
     const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
-    const visibleConnIds = new Set(["conn-owner-approval"]);
+    const visibleConnIds = new Set(
+      synthetic ? ["conn-owner-approval", "conn-requester"] : ["conn-owner-approval"],
+    );
     const getApprovalClientConnIds = createApprovalClientLookup([
+      createOperatorClient(),
       createOperatorClient("conn-owner-approval"),
       createApprovalClient({
         connId: "conn-other-approval",
@@ -751,7 +750,9 @@ describe("applyPluginNodeInvokePolicy", () => {
       pluginApprovalManager: manager,
       getApprovalClientConnIds,
     });
-    const resultPromise = invokeDemoPolicy(context, createOperatorClient());
+    const requester = createOperatorClient();
+    requester.internal = synthetic ? { syntheticClient: true } : undefined;
+    const resultPromise = invokeDemoPolicy(context, requester);
 
     const record = await expectSinglePendingApproval(manager);
     expect(record.requestedByConnId).toBe("conn-requester");

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -192,7 +192,9 @@ function createApprovalRuntime(params: {
         decisionPromise,
         respond,
         context: params.context,
-        clientConnId: params.client?.connId,
+        // Internal calls retain the operator's connection as provenance; it is
+        // still a reviewer, not the transport requester to exclude from delivery.
+        clientConnId: params.client?.internal?.syntheticClient ? undefined : params.client?.connId,
         requestEventName: "plugin.approval.requested",
         requestEvent,
         twoPhase: false,


### PR DESCRIPTION
Closes #130556

## What Problem This Solves

Fixes an issue where users starting Codex work on a paired device from Control UI would wait for a node-launch approval that was never delivered to their browser. A separate authorized reviewer could see it, but the initiating browser showed neither the approval event nor its attention badge.

## Why This Change Was Made

The internal duplex invocation retains the browser connection ID as requester provenance. The node-policy adapter incorrectly also used that ID to exclude the transport requester from approval delivery. Internal calls now retain their identity binding without excluding the operator's connection; ordinary transport requesters remain excluded.

Pairing, command allowlisting, approval visibility/scopes, live authority checks, and one-time decision consumption are unchanged. This does not waive Codex's separate node-wide per-attempt launch approval in Full Access.

The fix stays at the node-policy approval owner. Clearing the inherited connection ID globally would discard valid requester ownership; changing shared approval visibility would unnecessarily broaden the repair. No config, protocol, schema, or dependency changes.

Production LOC: +3/-1 (net +2, entirely the explanatory comment; executable LOC neutral). Tests: +13/-12 (net +1). The existing ownership regression is table-driven for ordinary versus internal callers, with unrelated-device exclusion and requester metadata retained.

## User Impact

The requesting Control UI receives the required launch approval in its inbox, can approve it without reloading, and continues remote native execution. Full Access still suppresses native-command approvals; the documented separate node-launch approval remains required.

Provenance: the interaction was made visible by duplex support in #126961, authored and merged by @steipete on August 21, 2026 (`d17bbfc31a8f`). The requester-exclusion path predates that change.

## Evidence

- The new internal-caller regression failed on the pre-fix source because the requesting connection was absent from recipients. The ordinary-caller case passed.
- 77 tests across node-policy, node decision receipts, and shared approval routing pass after the fix.
- The full changed-file gate passes for both files, including production/test typing, lint, and boundary guards. Final Codex autoreview reports no accepted/actionable findings.
- Rebuilt candidate, real development Gateway, paired node CLI, pinned native Codex CLI 0.149.1, and Chromium: three complete browser/stress cycles passed. Each includes browser model/node/Full Access selection, inbox approval, native file/HTTP execution, ten fresh-process burst turns, cancellation, immediate replacement, and process cleanup. Total: 39 Full Access native executions, 30 burst turns, three cancel/replacements, 39 node-launch approvals, zero native-command approval events. Baseline deny, credential-canary scrubbing, disconnect termination, and fresh recovery also pass in each cycle.
- The separate OpenClaw harness baseline at `64f30c70d797e29beb4f081a4b873643aa457924` passed three Docker-network rounds and three browser rounds: 300 container creates/starts/exits/removals, zero approval events or leftover containers, plus the paired-node lifecycle suite.
- Blacksmith Testbox: https://github.com/openclaw/openclaw/actions/runs/33026136183 — owned environment stopped after artifact collection. The candidate build used a Testbox synthetic sync commit over the pinned baseline; production file hashes matched the local patch. No claim that this environment is a live model-provider reliability test.
- Personally checked pinned upstream Codex stdio lifecycle semantics in [transport.rs](https://github.com/openai/codex/blob/rust-v0.149.1/codex-rs/exec-server/src/server/transport.rs#L132-L157). This defect is OpenClaw approval delivery before native launch, not Codex's process protocol.

The provider is a deterministic HTTP Responses fixture. Its unsupported WebSocket upgrade produces the visible HTTP-fallback diagnostic in the recording; that is not an approval or a live-provider failure.

Before: initiating browser waits, without an approval badge.

![Before: missing approval](https://github.com/user-attachments/assets/17d3b1de-8d04-4051-8ab4-2f51b66b54d9)

After: the same requesting browser receives and displays the required approval.

![After: visible launch approval](https://github.com/user-attachments/assets/19f9ec7d-a22c-4159-bae4-0c253cf9d684)

After approving: native execution finishes in the remote session.

![After: completed native execution](https://github.com/user-attachments/assets/c25ee7f4-d958-4a20-96ad-855839bb0517)

Real browser flow, including the inbox approval around eight seconds:

https://github.com/user-attachments/assets/bdc77673-4810-4bb0-8229-4c4b2004af60

AI-assisted; focused source, dependency-contract inspection, runtime proof, and Codex autoreview performed. Temporary stress drivers and recordings are not committed.

## Final review and landing evidence

ClawSweeper found no actionable correctness or security findings and agreed with the owner-bound fix. Its pending-CI item is now satisfied: [CI run 33030537821](https://github.com/openclaw/openclaw/actions/runs/33030537821) and CodeQL passed on `c9d208a1f84cc0ba53efe57717572e04c2ece205`. No additional Rank-up moves were listed. This is a maintainer-directed native landing, not an automatic ClawSweeper merge; approval authority and the separate launch policy remain unchanged.

Maintainer-tooling follow-up: after successfully merging and removing its worktree, the native landing wrapper's exit cleanup encountered a deleted-current-directory error and retained its operation lock. The exact stale lock was safely recovered after verifying no PR tools remained. This did not affect the landed code or checks.
