### PR TITLE
fix(tasks): settle legacy reconciling cron rows as lost during sidecar migration

### DIFF
--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -711,6 +711,42 @@ function appendLegacyTaskWithObsoleteDeliveryStatus(taskRunsPath: string): void 
   }
 }
 
+function appendLegacyReconcilingCronTaskWithDelivery(taskRunsPath: string): void {
+  const sqlite = requireNodeSqlite();
+  const db = new sqlite.DatabaseSync(taskRunsPath);
+  try {
+    db.prepare(
+      `
+        INSERT INTO task_runs (
+          task_id, runtime, requester_session_key, agent_id, run_id, task,
+          status, delivery_status, notify_policy, created_at, last_event_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+    ).run(
+      "legacy-reconciling",
+      "cron",
+      "",
+      "ops",
+      "legacy-reconciling-run",
+      "Legacy reconciling cron run",
+      "reconciling",
+      "pending",
+      "done_only",
+      170,
+      180,
+    );
+    db.prepare(
+      `
+        INSERT INTO task_delivery_state (
+          task_id, requester_origin_json, last_notified_event_at
+        ) VALUES (?, ?, ?)
+      `,
+    ).run("legacy-reconciling", '{"channel":"test","to":"target"}', 190);
+  } finally {
+    db.close();
+  }
+}
+
 async function detectAndRunMigrations(params: {
   root: string;
   cfg: OpenClawConfig;
@@ -3920,6 +3956,39 @@ describe("doctor legacy state migrations", () => {
       const tasks = loadTaskRegistryStateFromSqlite().tasks;
       expect(tasks.get("legacy-not-requested")?.deliveryStatus).toBe("not_applicable");
       expect(tasks.get("legacy-task")?.deliveryStatus).toBe("not_applicable");
+    });
+  });
+
+  it("settles legacy reconciling cron rows as lost and drops their delivery state", async () => {
+    const root = makeDoctorStateDir();
+    const { taskRunsPath } = writeLegacyTaskStateSidecars(root);
+    appendLegacyReconcilingCronTaskWithDelivery(taskRunsPath);
+
+    const result = await autoMigrateLegacyTaskStateSidecars({
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+
+    expect(result.warnings).toContain(
+      "Skipped 1 task delivery sidecar row settled as lost during migration",
+    );
+
+    const shared = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    expect(
+      shared.db
+        .prepare("SELECT status, delivery_status, notify_policy FROM task_runs WHERE task_id = ?")
+        .get("legacy-reconciling"),
+    ).toEqual({ status: "lost", delivery_status: "not_applicable", notify_policy: "silent" });
+    expect(
+      shared.db
+        .prepare("SELECT 1 FROM task_delivery_state WHERE task_id = ?")
+        .get("legacy-reconciling"),
+    ).toBeUndefined();
+
+    await withStateDir(root, async () => {
+      const tasks = loadTaskRegistryStateFromSqlite().tasks;
+      expect(tasks.get("legacy-reconciling")?.status).toBe("lost");
     });
   });
 

--- a/src/commands/doctor-state-migrations.test.ts
+++ b/src/commands/doctor-state-migrations.test.ts
@@ -3992,6 +3992,61 @@ describe("doctor legacy state migrations", () => {
     });
   });
 
+  it("keeps recorded delivery state for rows that were already lost before migration", async () => {
+    const root = makeDoctorStateDir();
+    const { taskRunsPath } = writeLegacyTaskStateSidecars(root);
+    const sqlite = requireNodeSqlite();
+    const db = new sqlite.DatabaseSync(taskRunsPath);
+    try {
+      db.prepare(
+        `
+          INSERT INTO task_runs (
+            task_id, runtime, requester_session_key, agent_id, run_id, task,
+            status, delivery_status, notify_policy, created_at, last_event_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `,
+      ).run(
+        "legacy-prelost",
+        "cron",
+        "",
+        "ops",
+        "legacy-prelost-run",
+        "Legacy already-lost cron task",
+        "lost",
+        "pending",
+        "done_only",
+        200,
+        210,
+      );
+      db.prepare(
+        `
+          INSERT INTO task_delivery_state (
+            task_id, requester_origin_json, last_notified_event_at
+          ) VALUES (?, ?, ?)
+        `,
+      ).run("legacy-prelost", '{"channel":"test","to":"target"}', 220);
+    } finally {
+      db.close();
+    }
+
+    const result = await autoMigrateLegacyTaskStateSidecars({
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+
+    expect(result.warnings).not.toContain(
+      "Skipped 1 task delivery sidecar row settled as lost during migration",
+    );
+
+    const shared = openOpenClawStateDatabase({
+      env: { OPENCLAW_STATE_DIR: root } as NodeJS.ProcessEnv,
+    });
+    expect(
+      shared.db
+        .prepare("SELECT 1 FROM task_delivery_state WHERE task_id = ?")
+        .get("legacy-prelost"),
+    ).toBeDefined();
+  });
+
   it("canonicalizes cross-agent attribution while importing task sidecars", async () => {
     const root = makeDoctorStateDir();
     const { taskRunsPath } = writeLegacyTaskStateSidecars(root);

--- a/src/infra/state-migrations.storage.ts
+++ b/src/infra/state-migrations.storage.ts
@@ -35,7 +35,7 @@ import {
   normalizeLegacySqliteInteger,
   pickLegacyColumn,
   readLegacyTaskDeliveryRows,
-  readLegacyTaskRows,
+  readLegacyTaskRowsWithSettlements,
   type SqliteBindRow,
 } from "./state-migrations.task-sidecar-rows.js";
 
@@ -650,8 +650,12 @@ async function migrateLegacyTaskRunsSidecar(params: {
   const warnings: string[] = [];
   let taskRows: SqliteBindRow[];
   let deliveryRows: SqliteBindRow[];
+  let settledLostTaskIds = new Set<string>();
   try {
-    taskRows = readLegacyTaskRows(sourcePath);
+    const { rows, settledLostTaskIds: settled } =
+      readLegacyTaskRowsWithSettlements(sourcePath);
+    taskRows = rows;
+    settledLostTaskIds = settled;
     deliveryRows = readLegacyTaskDeliveryRows(sourcePath);
   } catch (err) {
     return {
@@ -712,15 +716,10 @@ async function migrateLegacyTaskRunsSidecar(params: {
           importedTasks++;
         }
         const deliveryColumns = ["requester_origin_json", "last_notified_event_at"];
-        // Reconciling cron rows settled during normalization must not carry
-        // their pending delivery state into shared state as actionable.
-        const settledLostTaskIds = new Set(
-          taskRows
-            .filter((row) => row.status === "lost")
-            .map((row) => legacyKeyValue(expectDefined(row.task_id, "task migration row key"))),
-        );
         for (const row of deliveryRows) {
           const taskId = legacyKeyValue(expectDefined(row.task_id, "delivery migration row key"));
+          // Only deliveries of tasks this migration just settled are skipped;
+          // pre-existing lost rows keep their recorded delivery state.
           if (settledLostTaskIds.has(taskId)) {
             skippedSettledDeliveryStates++;
             continue;

--- a/src/infra/state-migrations.storage.ts
+++ b/src/infra/state-migrations.storage.ts
@@ -652,8 +652,7 @@ async function migrateLegacyTaskRunsSidecar(params: {
   let deliveryRows: SqliteBindRow[];
   let settledLostTaskIds = new Set<string>();
   try {
-    const { rows, settledLostTaskIds: settled } =
-      readLegacyTaskRowsWithSettlements(sourcePath);
+    const { rows, settledLostTaskIds: settled } = readLegacyTaskRowsWithSettlements(sourcePath);
     taskRows = rows;
     settledLostTaskIds = settled;
     deliveryRows = readLegacyTaskDeliveryRows(sourcePath);

--- a/src/infra/state-migrations.storage.ts
+++ b/src/infra/state-migrations.storage.ts
@@ -665,6 +665,7 @@ async function migrateLegacyTaskRunsSidecar(params: {
     let importedTasks = 0;
     let importedDeliveryStates = 0;
     let skippedOrphanDeliveryStates = 0;
+    let skippedSettledDeliveryStates = 0;
     runOpenClawStateWriteTransaction(
       ({ db }) => {
         const taskColumns = [
@@ -711,8 +712,19 @@ async function migrateLegacyTaskRunsSidecar(params: {
           importedTasks++;
         }
         const deliveryColumns = ["requester_origin_json", "last_notified_event_at"];
+        // Reconciling cron rows settled during normalization must not carry
+        // their pending delivery state into shared state as actionable.
+        const settledLostTaskIds = new Set(
+          taskRows
+            .filter((row) => row.status === "lost")
+            .map((row) => legacyKeyValue(expectDefined(row.task_id, "task migration row key"))),
+        );
         for (const row of deliveryRows) {
           const taskId = legacyKeyValue(expectDefined(row.task_id, "delivery migration row key"));
+          if (settledLostTaskIds.has(taskId)) {
+            skippedSettledDeliveryStates++;
+            continue;
+          }
           const existing = db
             .prepare(
               `SELECT requester_origin_json, last_notified_event_at FROM task_delivery_state WHERE task_id = ?`,
@@ -751,6 +763,11 @@ async function migrateLegacyTaskRunsSidecar(params: {
     if (skippedOrphanDeliveryStates > 0) {
       warnings.push(
         `Skipped ${skippedOrphanDeliveryStates} orphan task delivery sidecar ${skippedOrphanDeliveryStates === 1 ? "row" : "rows"} with no task run`,
+      );
+    }
+    if (skippedSettledDeliveryStates > 0) {
+      warnings.push(
+        `Skipped ${skippedSettledDeliveryStates} task delivery sidecar ${skippedSettledDeliveryStates === 1 ? "row" : "rows"} settled as lost during migration`,
       );
     }
   } catch (err) {

--- a/src/infra/state-migrations.task-sidecar-rows.ts
+++ b/src/infra/state-migrations.task-sidecar-rows.ts
@@ -41,7 +41,7 @@ function legacyStringValue(value: unknown): string {
 // A legacy cron reconciliation has no surviving runtime to finish it, so the
 // importer settles it as explicit historical evidence instead of carrying a
 // nonterminal row (and its actionable pending delivery) forward.
-export function isUnresumableCronReconcilingRow(row: Record<string, unknown>): boolean {
+function isUnresumableCronReconcilingRow(row: Record<string, unknown>): boolean {
   return row.runtime === "cron" && row.status === "reconciling";
 }
 
@@ -109,7 +109,7 @@ function normalizeLegacyTaskRow(row: Record<string, unknown>): SqliteBindRow {
   };
 }
 
-export function readLegacyTaskRows(sourcePath: string): SqliteBindRow[] {
+function readLegacyTaskRows(sourcePath: string): SqliteBindRow[] {
   const db = openNodeSqliteDatabase(sourcePath, { readOnly: true });
   try {
     const columns = listSqliteColumns(db, "task_runs");
@@ -174,6 +174,7 @@ export function readLegacyTaskRowsWithSettlements(sourcePath: string): {
       return { rows: [], settledLostTaskIds };
     }
     for (const raw of db
+      // SAFETY: the SELECT projects only the two TEXT columns referenced below.
       .prepare(`SELECT task_id FROM task_runs WHERE runtime = 'cron' AND status = 'reconciling'`)
       .all() as Array<Record<string, unknown>>) {
       const taskId = legacyStringValue(raw.task_id);

--- a/src/infra/state-migrations.task-sidecar-rows.ts
+++ b/src/infra/state-migrations.task-sidecar-rows.ts
@@ -171,19 +171,6 @@ function readNormalizedLegacyTaskRows(
     });
 }
 
-function readLegacyTaskRows(sourcePath: string): SqliteBindRow[] {
-  const db = openNodeSqliteDatabase(sourcePath, { readOnly: true });
-  try {
-    const columns = listSqliteColumns(db, "task_runs");
-    if (columns.size === 0) {
-      return [];
-    }
-    return readNormalizedLegacyTaskRows(db, columns);
-  } finally {
-    db.close();
-  }
-}
-
 /**
  * Reads normalized task rows plus the ids this migration settles as lost.
  * Both results come from the same single-pass snapshot so delivery-state

--- a/src/infra/state-migrations.task-sidecar-rows.ts
+++ b/src/infra/state-migrations.task-sidecar-rows.ts
@@ -38,6 +38,13 @@ function legacyStringValue(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
+// A legacy cron reconciliation has no surviving runtime to finish it, so the
+// importer settles it as explicit historical evidence instead of carrying a
+// nonterminal row (and its actionable pending delivery) forward.
+export function isUnresumableCronReconcilingRow(row: Record<string, unknown>): boolean {
+  return row.runtime === "cron" && row.status === "reconciling";
+}
+
 function normalizeLegacyTaskRow(row: Record<string, unknown>): SqliteBindRow {
   const runtime = legacyStringValue(row.runtime);
   const sourceId = typeof row.source_id === "string" ? row.source_id : "";
@@ -66,7 +73,7 @@ function normalizeLegacyTaskRow(row: Record<string, unknown>): SqliteBindRow {
   // A legacy cron reconciliation has no surviving runtime to finish it, so the
   // importer settles it as explicit historical evidence instead of carrying a
   // nonterminal row (and its actionable pending delivery) forward.
-  const isUnresumableCronReconciling = runtime === "cron" && row.status === "reconciling";
+  const isUnresumableCronReconciling = isUnresumableCronReconcilingRow(row);
   const status = isUnresumableCronReconciling ? "lost" : (row.status ?? "");
   const settledDeliveryStatus = isUnresumableCronReconciling ? "not_applicable" : deliveryStatus;
   const settledNotifyPolicy = isUnresumableCronReconciling ? "silent" : (row.notify_policy ?? "");
@@ -145,6 +152,36 @@ export function readLegacyTaskRows(sourcePath: string): SqliteBindRow[] {
       )
       .all()
       .map((row) => normalizeLegacyTaskRow(row as Record<string, unknown>));
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Reads normalized task rows plus the ids this migration settles as lost.
+ * The settled set is captured from the raw rows so delivery-state skipping
+ * can stay scoped to rows reconciled here instead of every lost row.
+ */
+export function readLegacyTaskRowsWithSettlements(sourcePath: string): {
+  rows: SqliteBindRow[];
+  settledLostTaskIds: Set<string>;
+} {
+  const db = openNodeSqliteDatabase(sourcePath, { readOnly: true });
+  const settledLostTaskIds = new Set<string>();
+  try {
+    const columns = listSqliteColumns(db, "task_runs");
+    if (columns.size === 0) {
+      return { rows: [], settledLostTaskIds };
+    }
+    for (const raw of db
+      .prepare(`SELECT task_id FROM task_runs WHERE runtime = 'cron' AND status = 'reconciling'`)
+      .all() as Array<Record<string, unknown>>) {
+      const taskId = legacyStringValue(raw.task_id);
+      if (taskId) {
+        settledLostTaskIds.add(taskId);
+      }
+    }
+    return { rows: readLegacyTaskRows(sourcePath), settledLostTaskIds };
   } finally {
     db.close();
   }

--- a/src/infra/state-migrations.task-sidecar-rows.ts
+++ b/src/infra/state-migrations.task-sidecar-rows.ts
@@ -173,10 +173,11 @@ export function readLegacyTaskRowsWithSettlements(sourcePath: string): {
     if (columns.size === 0) {
       return { rows: [], settledLostTaskIds };
     }
-    for (const raw of db
-      // SAFETY: the SELECT projects only the two TEXT columns referenced below.
+    const rawReconciling = db
       .prepare(`SELECT task_id FROM task_runs WHERE runtime = 'cron' AND status = 'reconciling'`)
-      .all() as Array<Record<string, unknown>>) {
+      // SAFETY: the SELECT projects only the TEXT task_id column read below.
+      .all() as Array<Record<string, unknown>>;
+    for (const raw of rawReconciling) {
       const taskId = legacyStringValue(raw.task_id);
       if (taskId) {
         settledLostTaskIds.add(taskId);

--- a/src/infra/state-migrations.task-sidecar-rows.ts
+++ b/src/infra/state-migrations.task-sidecar-rows.ts
@@ -109,6 +109,68 @@ function normalizeLegacyTaskRow(row: Record<string, unknown>): SqliteBindRow {
   };
 }
 
+function legacyTaskSelectColumns(columns: Set<string>): string[] {
+  return [
+    "task_id",
+    "runtime",
+    pickLegacyColumn(columns, "task_kind"),
+    pickLegacyColumn(columns, "source_id"),
+    pickLegacyColumn(columns, "requester_session_key"),
+    pickLegacyColumn(columns, "owner_key"),
+    pickLegacyColumn(columns, "scope_kind"),
+    pickLegacyColumn(columns, "child_session_key"),
+    pickLegacyColumn(columns, "parent_flow_id"),
+    pickLegacyColumn(columns, "parent_task_id"),
+    pickLegacyColumn(columns, "agent_id"),
+    pickLegacyColumn(columns, "requester_agent_id"),
+    pickLegacyColumn(columns, "run_id"),
+    pickLegacyColumn(columns, "label"),
+    "task",
+    "status",
+    "delivery_status",
+    "notify_policy",
+    "created_at",
+    pickLegacyColumn(columns, "started_at"),
+    pickLegacyColumn(columns, "ended_at"),
+    pickLegacyColumn(columns, "last_event_at"),
+    pickLegacyColumn(columns, "cleanup_after"),
+    pickLegacyColumn(columns, "error"),
+    pickLegacyColumn(columns, "progress_summary"),
+    pickLegacyColumn(columns, "terminal_summary"),
+    pickLegacyColumn(columns, "terminal_outcome"),
+    pickLegacyColumn(columns, "detail_json"),
+  ];
+}
+
+/**
+ * Reads and normalizes every legacy task row in one pass. When provided,
+ * onSettledReconciling observes each reconciling cron row at the exact moment
+ * it is settled, so callers see a consistent snapshot instead of issuing a
+ * second query over a database that may have changed in between.
+ */
+function readNormalizedLegacyTaskRows(
+  db: DatabaseSync,
+  columns: Set<string>,
+  onSettledReconciling?: (taskId: string) => void,
+): SqliteBindRow[] {
+  const selectColumns = legacyTaskSelectColumns(columns);
+  return db
+    .prepare(
+      `SELECT ${selectColumns.join(", ")} FROM task_runs ORDER BY created_at ASC, task_id ASC`,
+    )
+    .all()
+    .map((row) => {
+      const raw = row as Record<string, unknown>;
+      if (onSettledReconciling && isUnresumableCronReconcilingRow(raw)) {
+        const taskId = legacyStringValue(raw.task_id);
+        if (taskId) {
+          onSettledReconciling(taskId);
+        }
+      }
+      return normalizeLegacyTaskRow(raw);
+    });
+}
+
 function readLegacyTaskRows(sourcePath: string): SqliteBindRow[] {
   const db = openNodeSqliteDatabase(sourcePath, { readOnly: true });
   try {
@@ -116,42 +178,7 @@ function readLegacyTaskRows(sourcePath: string): SqliteBindRow[] {
     if (columns.size === 0) {
       return [];
     }
-    const selectColumns = [
-      "task_id",
-      "runtime",
-      pickLegacyColumn(columns, "task_kind"),
-      pickLegacyColumn(columns, "source_id"),
-      pickLegacyColumn(columns, "requester_session_key"),
-      pickLegacyColumn(columns, "owner_key"),
-      pickLegacyColumn(columns, "scope_kind"),
-      pickLegacyColumn(columns, "child_session_key"),
-      pickLegacyColumn(columns, "parent_flow_id"),
-      pickLegacyColumn(columns, "parent_task_id"),
-      pickLegacyColumn(columns, "agent_id"),
-      pickLegacyColumn(columns, "requester_agent_id"),
-      pickLegacyColumn(columns, "run_id"),
-      pickLegacyColumn(columns, "label"),
-      "task",
-      "status",
-      "delivery_status",
-      "notify_policy",
-      "created_at",
-      pickLegacyColumn(columns, "started_at"),
-      pickLegacyColumn(columns, "ended_at"),
-      pickLegacyColumn(columns, "last_event_at"),
-      pickLegacyColumn(columns, "cleanup_after"),
-      pickLegacyColumn(columns, "error"),
-      pickLegacyColumn(columns, "progress_summary"),
-      pickLegacyColumn(columns, "terminal_summary"),
-      pickLegacyColumn(columns, "terminal_outcome"),
-      pickLegacyColumn(columns, "detail_json"),
-    ];
-    return db
-      .prepare(
-        `SELECT ${selectColumns.join(", ")} FROM task_runs ORDER BY created_at ASC, task_id ASC`,
-      )
-      .all()
-      .map((row) => normalizeLegacyTaskRow(row as Record<string, unknown>));
+    return readNormalizedLegacyTaskRows(db, columns);
   } finally {
     db.close();
   }
@@ -159,8 +186,8 @@ function readLegacyTaskRows(sourcePath: string): SqliteBindRow[] {
 
 /**
  * Reads normalized task rows plus the ids this migration settles as lost.
- * The settled set is captured from the raw rows so delivery-state skipping
- * can stay scoped to rows reconciled here instead of every lost row.
+ * Both results come from the same single-pass snapshot so delivery-state
+ * skipping stays scoped to rows reconciled here without re-reading the db.
  */
 export function readLegacyTaskRowsWithSettlements(sourcePath: string): {
   rows: SqliteBindRow[];
@@ -173,17 +200,10 @@ export function readLegacyTaskRowsWithSettlements(sourcePath: string): {
     if (columns.size === 0) {
       return { rows: [], settledLostTaskIds };
     }
-    const rawReconciling = db
-      .prepare(`SELECT task_id FROM task_runs WHERE runtime = 'cron' AND status = 'reconciling'`)
-      // SAFETY: the SELECT projects only the TEXT task_id column read below.
-      .all() as Array<Record<string, unknown>>;
-    for (const raw of rawReconciling) {
-      const taskId = legacyStringValue(raw.task_id);
-      if (taskId) {
-        settledLostTaskIds.add(taskId);
-      }
-    }
-    return { rows: readLegacyTaskRows(sourcePath), settledLostTaskIds };
+    const rows = readNormalizedLegacyTaskRows(db, columns, (taskId) =>
+      settledLostTaskIds.add(taskId),
+    );
+    return { rows, settledLostTaskIds };
   } finally {
     db.close();
   }

--- a/src/infra/state-migrations.task-sidecar-rows.ts
+++ b/src/infra/state-migrations.task-sidecar-rows.ts
@@ -63,6 +63,13 @@ function normalizeLegacyTaskRow(row: Record<string, unknown>): SqliteBindRow {
   const executorAgentId = requesterAgentId ? childAgentId || persistedAgentId : persistedAgentId;
   const deliveryStatus =
     row.delivery_status === "not-requested" ? "not_applicable" : row.delivery_status;
+  // A legacy cron reconciliation has no surviving runtime to finish it, so the
+  // importer settles it as explicit historical evidence instead of carrying a
+  // nonterminal row (and its actionable pending delivery) forward.
+  const isUnresumableCronReconciling = runtime === "cron" && row.status === "reconciling";
+  const status = isUnresumableCronReconciling ? "lost" : (row.status ?? "");
+  const settledDeliveryStatus = isUnresumableCronReconciling ? "not_applicable" : deliveryStatus;
+  const settledNotifyPolicy = isUnresumableCronReconciling ? "silent" : (row.notify_policy ?? "");
   return {
     task_id: taskId,
     runtime,
@@ -79,9 +86,9 @@ function normalizeLegacyTaskRow(row: Record<string, unknown>): SqliteBindRow {
     run_id: legacyBindValue(row.run_id),
     label: legacyBindValue(row.label),
     task: legacyBindValue(row.task ?? ""),
-    status: legacyBindValue(row.status ?? ""),
-    delivery_status: legacyBindValue(deliveryStatus ?? ""),
-    notify_policy: legacyBindValue(row.notify_policy ?? ""),
+    status: legacyBindValue(status),
+    delivery_status: legacyBindValue(settledDeliveryStatus ?? ""),
+    notify_policy: legacyBindValue(settledNotifyPolicy),
     created_at: normalizeLegacySqliteInteger(row.created_at as number | bigint | null) ?? 0,
     started_at: normalizeLegacySqliteInteger(row.started_at as number | bigint | null),
     ended_at: normalizeLegacySqliteInteger(row.ended_at as number | bigint | null),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users migrating a legacy task-runs sidecar that contains a cron row with `status = "reconciling"` would keep a nonterminal task in shared SQLite state: after restart no backing cron runtime exists to finish that reconciliation, so the row stays active forever and its pending delivery state keeps looking actionable.

Closes #130017.

## Why This Change Was Made

The sidecar importer is the boundary where this row must become explicit historical evidence, per the issue's expected behavior. `normalizeLegacyTaskRow` now settles unresumable cron reconciliations to `status = "lost"`, `delivery_status = "not_applicable"`, `notify_policy = "silent"`, and the storage migration skips copying delivery rows for tasks settled as lost (reported as a migration warning instead of silently carrying stale custody evidence). Non-cron rows and every other status pass through exactly as before.

## User Impact

Migrated registries no longer report phantom nonterminal cron runs; task-pressure/readiness checks return to zero and stale pending deliveries disappear instead of surviving the upgrade.

## Evidence

- New end-to-end test in `doctor-state-migrations.test.ts` builds a real legacy SQLite sidecar with a `reconciling` cron row plus a pending delivery row; it asserts the migrated row reads `{status: "lost", delivery_status: "not_applicable", notify_policy: "silent"}`, the delivery row is absent from shared state, and the warning `Skipped 1 task delivery sidecar row settled as lost during migration` is reported.
- `pnpm exec vitest run src/commands/doctor-state-migrations.test.ts src/tasks/task-registry.store.test.ts` → 144/144 passing (including the pre-existing strict-parse throw-contract tests for `task-registry.types`).

### Update: review finding addressed + live migration trace

**Finding fixed.** The delivery-skip set is no longer derived from normalized lost rows (which also matched pre-existing `lost` rows and would have suppressed their recorded pending terminal notifications). `readLegacyTaskRowsWithSettlements` now captures the settled ids from the raw `runtime = 'cron' AND status = 'reconciling'` rows at read time, so **only** rows this migration actually settles drop their delivery state; rows that were already lost keep their delivery state exactly as before. A regression test asserts a pre-existing lost cron row's pending delivery row survives migration, alongside the existing reconciling-row tests.

**Live after-fix run against a representative operator sidecar.** Built a real legacy `tasks/runs.sqlite` sidecar with one healthy running cron task (delivery pending), one `reconciling` cron task (delivery pending), and one already-`lost` cron task (delivery pending), then ran the stock migration entry point on it:

```text
result.changes:
  "Migrated 3 task registry sidecar rows → shared SQLite state"
  "Archived task registry sidecar legacy source → …/tasks/runs.sqlite.migrated"
result.warnings:
  "Skipped 1 task delivery sidecar row settled as lost during migration"
```

Post-migration shared-state reads:

```text
legacy-reconciling → {status: "lost", delivery_status: "not_applicable", notify_policy: "silent"}
  its delivery row: absent
legacy-prelost     → status stays "lost"; its pending delivery row: present (untouched)
healthy running task: untouched
```

Regression suites: `doctor-state-migrations.test.ts` + `task-registry.store.test.ts` — 145/145 passing.

@clawsweeper re-review
