### PR TITLE
fix(cron): capture Codex shell aliases under canonical tool identity with a restrict-only exec pin

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -233,7 +233,6 @@ extensions/codex/src/app-server/session-binding.ts	4
 extensions/codex/src/app-server/session-history.ts	6
 extensions/codex/src/app-server/settled-turn-context.ts	3
 extensions/codex/src/app-server/shared-client.ts	4
-extensions/codex/src/app-server/shell-dynamic-tools.ts	2
 extensions/codex/src/app-server/side-question.ts	8
 extensions/codex/src/app-server/startup-binding.ts	2
 extensions/codex/src/app-server/thread-fingerprints.ts	2

--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -65,6 +65,7 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
 });
 
 let tempDir: string;
+const hostCapabilityClosers: Array<() => void> = [];
 
 function setOpenClawCodingToolsFactoryForTests(
   factory: NonNullable<typeof dynamicToolBuildState.openClawCodingToolsFactory>,
@@ -74,6 +75,15 @@ function setOpenClawCodingToolsFactoryForTests(
 
 function resetOpenClawCodingToolsFactoryForTests(): void {
   dynamicToolBuildState.openClawCodingToolsFactory = undefined;
+}
+
+async function bindProductionCodexHostCapabilities(
+  params: EmbeddedRunAttemptParams,
+): Promise<void> {
+  const { hostCapabilities: _hostCapabilities, ...attempt } = params;
+  const host = await createAgentHarnessHostCapabilitiesForTest({ attempt, pluginId: "codex" });
+  params.hostCapabilities = host.capabilities;
+  hostCapabilityClosers.push(host.close);
 }
 
 type RuntimeDynamicToolForTest = Parameters<
@@ -141,6 +151,12 @@ function createRuntimeDynamicTool(name: string): RuntimeDynamicToolForTest {
       details: {},
     })),
   };
+}
+
+function shellTestToolNames(tools: readonly { name: string }[]): string[] {
+  return tools
+    .map((tool) => tool.name)
+    .filter((name) => ["message", "gateway_exec", "gateway_process", "node_exec"].includes(name));
 }
 
 async function buildDynamicToolsForTest(
@@ -449,6 +465,9 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   afterEach(async () => {
+    for (const close of hostCapabilityClosers.splice(0)) {
+      close();
+    }
     resetOpenClawCodingToolsFactoryForTests();
     vi.restoreAllMocks();
     vi.unstubAllEnvs();
@@ -604,8 +623,7 @@ describe("Codex app-server dynamic tool build", () => {
     params.sessionRoot = workspaceDir;
     params.execOverrides = { host: "gateway", mode: "ask" };
     params.runtimePlan = createCodexRuntimePlanFixture();
-    const execTool = createRuntimeDynamicTool("exec");
-    setOpenClawCodingToolsFactoryForTests(() => [execTool]);
+    await bindProductionCodexHostCapabilities(params);
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
       sessionPermissionPolicy: { mode: "guarded", root: workspaceDir, execMode: "ask" },
@@ -614,19 +632,9 @@ describe("Codex app-server dynamic tool build", () => {
       tools.find((tool) => tool.name === "gateway_exec"),
       "guarded Gateway shell alias",
     );
-    await gatewayExec.execute("guarded-call", {
-      command: "echo approved",
-      host: "node",
-      security: "full",
-      ask: "off",
-    });
-
-    expect(execTool.execute).toHaveBeenCalledWith(
-      "guarded-call",
-      { command: "echo approved", host: "gateway", ask: "always" },
-      undefined,
-      undefined,
-    );
+    expect(gatewayExec.parameters).not.toHaveProperty("properties.host");
+    expect(gatewayExec.parameters).not.toHaveProperty("properties.security");
+    expect(gatewayExec.parameters).not.toHaveProperty("properties.ask");
   });
 
   it.each([
@@ -1494,86 +1502,35 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   it("keeps a pinned Gateway shell path beside Codex native shell", async () => {
-    const execTool = {
-      ...createRuntimeDynamicTool("exec"),
-      parameters: {
-        type: "object",
-        properties: {
-          command: { type: "string" },
-          workdir: { type: "string" },
-          host: { type: "string" },
-          security: { type: "string" },
-          ask: { type: "string" },
-          node: { type: "string" },
-        },
-        required: ["command", "host"],
-        additionalProperties: false,
-      },
-    };
-    vi.mocked(execTool.execute).mockResolvedValueOnce({
-      content: [
-        {
-          type: "text",
-          text: "Command still running (session exec-1, pid 123). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
-        },
-      ],
-      details: { status: "running" },
-    });
-    const processTool = createRuntimeDynamicTool("process");
-    let capturedOperationalRunInstance: unknown;
-    setOpenClawCodingToolsFactoryForTests((options) => {
-      capturedOperationalRunInstance = options?.operationalRunInstance;
-      return [execTool, processTool, createRuntimeDynamicTool("message")];
-    });
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "gateway-session.jsonl"), workspaceDir);
     params.disableTools = false;
     params.runtimePlan = createCodexRuntimePlanFixture();
     params.execOverrides = { host: "gateway" };
+    await bindProductionCodexHostCapabilities(params);
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
       nativeToolSurfaceEnabled: true,
     });
 
-    expect(tools.map((tool) => tool.name)).toEqual(["message", "gateway_exec", "gateway_process"]);
-    expect(capturedOperationalRunInstance).toBeUndefined();
+    expect(shellTestToolNames(tools)).toEqual(["message", "gateway_exec", "gateway_process"]);
     const gatewayExec = tools.find((tool) => tool.name === "gateway_exec");
     expect(gatewayExec?.description).toContain("OpenClaw-managed Gateway environment access");
     expect(tools.find((tool) => tool.name === "gateway_process")?.description).toContain(
       "gateway_exec",
     );
-    expect(gatewayExec?.parameters).toEqual({
+    expect(gatewayExec?.parameters).toMatchObject({
       type: "object",
       properties: {
         command: { type: "string" },
         workdir: { type: "string" },
       },
       required: ["command"],
-      additionalProperties: false,
     });
-    const result = await gatewayExec?.execute(
-      "gateway-call",
-      {
-        command: "env",
-        host: "node",
-        node: "remote-node",
-        security: "full",
-        ask: "off",
-      },
-      undefined,
-    );
-    expect(execTool.execute).toHaveBeenCalledWith(
-      "gateway-call",
-      { command: "env", host: "gateway" },
-      undefined,
-      undefined,
-    );
-    expect(result?.content).toEqual([
-      {
-        type: "text",
-        text: "Command still running (session exec-1, pid 123). Use gateway_process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
-      },
-    ]);
+    expect(gatewayExec?.parameters).not.toHaveProperty("properties.host");
+    expect(gatewayExec?.parameters).not.toHaveProperty("properties.security");
+    expect(gatewayExec?.parameters).not.toHaveProperty("properties.ask");
+    expect(gatewayExec?.parameters).not.toHaveProperty("properties.node");
   });
 
   it.each([
@@ -1617,43 +1574,19 @@ describe("Codex app-server dynamic tool build", () => {
     { excluded: "exec", expected: ["message"] },
     { excluded: "gateway_exec", expected: ["message"] },
   ])("applies the partial Gateway shell exclusion for $excluded", async (testCase) => {
-    const execTool = createRuntimeDynamicTool("exec");
-    vi.mocked(execTool.execute).mockResolvedValueOnce({
-      content: [
-        {
-          type: "text",
-          text: "Command still running (session exec-1, pid 123). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
-        },
-      ],
-      details: { status: "running" },
-    });
-    setOpenClawCodingToolsFactoryForTests(() => [
-      execTool,
-      createRuntimeDynamicTool("process"),
-      createRuntimeDynamicTool("message"),
-    ]);
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "gateway-exclusion.jsonl"), workspaceDir);
     params.disableTools = false;
     params.runtimePlan = createCodexRuntimePlanFixture();
     params.execOverrides = { host: "gateway" };
+    await bindProductionCodexHostCapabilities(params);
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
       nativeToolSurfaceEnabled: true,
       pluginConfig: { codexDynamicToolsExclude: [testCase.excluded] },
     });
 
-    expect(tools.map((tool) => tool.name)).toEqual(testCase.expected);
-    const gatewayExec = tools.find((tool) => tool.name === "gateway_exec");
-    if (gatewayExec) {
-      const result = await gatewayExec.execute("gateway-call", { command: "sleep 60" });
-      expect(result.content).toEqual([
-        {
-          type: "text",
-          text: "Command still running (session exec-1, pid 123). Background session follow-up is unavailable because gateway_process is not exposed. Rerun without background=true and set yieldMs high enough to wait for completion.",
-        },
-      ]);
-    }
+    expect(shellTestToolNames(tools)).toEqual(testCase.expected);
   });
 
   it("exposes pinned node shell tools for node-targeted Codex app-server runs", async () => {
@@ -1780,42 +1713,18 @@ describe("Codex app-server dynamic tool build", () => {
   });
 
   it("does not expose Gateway process sessions as remote-node control in auto host runs", async () => {
-    const execTool = {
-      ...createRuntimeDynamicTool("exec"),
-      parameters: {
-        type: "object",
-        properties: {
-          command: { type: "string" },
-          host: { type: "string" },
-          security: { type: "string" },
-          ask: { type: "string" },
-          node: { type: "string" },
-        },
-        required: ["command"],
-        additionalProperties: false,
-      },
-    };
-    vi.mocked(execTool.execute).mockResolvedValueOnce({
-      content: [{ type: "text", text: "arm64" }],
-      details: { status: "completed" },
-    });
-    const processTool = createRuntimeDynamicTool("process");
-    setOpenClawCodingToolsFactoryForTests(() => [
-      execTool,
-      processTool,
-      createRuntimeDynamicTool("message"),
-    ]);
     const sessionFile = path.join(tempDir, "auto-node-session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
     params.runtimePlan = createCodexRuntimePlanFixture();
+    await bindProductionCodexHostCapabilities(params);
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
       nativeToolSurfaceEnabled: true,
     });
 
-    expect(tools.map((tool) => tool.name)).toEqual([
+    expect(shellTestToolNames(tools)).toEqual([
       "message",
       "gateway_exec",
       "gateway_process",
@@ -1826,21 +1735,6 @@ describe("Codex app-server dynamic tool build", () => {
       signal: new AbortController().signal,
       loading: "direct",
     });
-    const gatewayList = await bridge.handleToolCall({
-      threadId: "auto-thread",
-      turnId: "auto-turn",
-      tool: "gateway_process",
-      callId: "gateway-process-list",
-      arguments: { action: "list" },
-    });
-    expect(gatewayList.success).toBe(true);
-    expect(processTool.execute).toHaveBeenCalledWith(
-      "gateway-process-list",
-      { action: "list" },
-      expect.any(AbortSignal),
-      undefined,
-    );
-    vi.mocked(processTool.execute).mockClear();
     const nodeList = await bridge.handleToolCall({
       threadId: "auto-thread",
       turnId: "auto-turn",
@@ -1852,44 +1746,19 @@ describe("Codex app-server dynamic tool build", () => {
     expect(nodeList.contentItems).toEqual([
       { type: "inputText", text: "Unknown OpenClaw tool: node_process" },
     ]);
-    expect(processTool.execute).not.toHaveBeenCalled();
     const nodeExec = tools.find((tool) => tool.name === "node_exec");
     expect(nodeExec?.description).toContain("Select the node by name or id");
-    expect(nodeExec?.parameters).toEqual({
+    expect(nodeExec?.parameters).toMatchObject({
       type: "object",
       properties: {
         command: { type: "string" },
         node: { type: "string" },
       },
       required: ["command"],
-      additionalProperties: false,
     });
-    await nodeExec?.execute(
-      "call-auto-node",
-      {
-        command: "/usr/bin/uname -m",
-        node: "mac-mini",
-        host: "gateway",
-        security: "full",
-        ask: "off",
-      },
-      undefined,
-    );
-    expect(execTool.execute).toHaveBeenCalledWith(
-      "call-auto-node",
-      {
-        command: "/usr/bin/uname -m",
-        node: "mac-mini",
-        host: "node",
-      },
-      undefined,
-      undefined,
-    );
-
-    vi.mocked(execTool.execute).mockResolvedValueOnce({
-      content: [{ type: "text", text: "arm64" }],
-      details: { status: "completed" },
-    });
+    expect(nodeExec?.parameters).not.toHaveProperty("properties.host");
+    expect(nodeExec?.parameters).not.toHaveProperty("properties.security");
+    expect(nodeExec?.parameters).not.toHaveProperty("properties.ask");
     const boundAutoParams = createParams(
       path.join(tempDir, "bound-auto-node-session.jsonl"),
       workspaceDir,
@@ -1899,32 +1768,17 @@ describe("Codex app-server dynamic tool build", () => {
     boundAutoParams.config = {
       tools: { exec: { host: "auto", node: "bound-mac-mini" } },
     } as never;
+    await bindProductionCodexHostCapabilities(boundAutoParams);
     const boundAutoTools = await buildDynamicToolsForTest(boundAutoParams, workspaceDir, {
       nativeToolSurfaceEnabled: true,
     });
     const boundNodeExec = boundAutoTools.find((tool) => tool.name === "node_exec");
-    expect(boundNodeExec?.parameters).toEqual({
+    expect(boundNodeExec?.parameters).toMatchObject({
       type: "object",
       properties: { command: { type: "string" } },
       required: ["command"],
-      additionalProperties: false,
     });
-    await boundNodeExec?.execute(
-      "call-bound-auto-node",
-      { command: "/usr/bin/uname -m", node: "other-node" },
-      undefined,
-    );
-    expect(execTool.execute).toHaveBeenLastCalledWith(
-      "call-bound-auto-node",
-      {
-        command: "/usr/bin/uname -m",
-        node: "bound-mac-mini",
-        host: "node",
-      },
-      undefined,
-      undefined,
-    );
-
+    expect(boundNodeExec?.parameters).not.toHaveProperty("properties.node");
     const gatewayParams = createParams(
       path.join(tempDir, "gateway-node-session.jsonl"),
       workspaceDir,
@@ -1932,10 +1786,11 @@ describe("Codex app-server dynamic tool build", () => {
     gatewayParams.disableTools = false;
     gatewayParams.runtimePlan = createCodexRuntimePlanFixture();
     gatewayParams.execOverrides = { host: "gateway" };
+    await bindProductionCodexHostCapabilities(gatewayParams);
     const gatewayTools = await buildDynamicToolsForTest(gatewayParams, workspaceDir, {
       nativeToolSurfaceEnabled: true,
     });
-    expect(gatewayTools.map((tool) => tool.name)).toEqual([
+    expect(shellTestToolNames(gatewayTools)).toEqual([
       "message",
       "gateway_exec",
       "gateway_process",
@@ -1948,7 +1803,7 @@ describe("Codex app-server dynamic tool build", () => {
     const allowlistedTools = await buildDynamicToolsForTest(allowlistedParams, workspaceDir, {
       nativeToolSurfaceEnabled: true,
     });
-    expect(allowlistedTools.map((tool) => tool.name)).toEqual(["message"]);
+    expect(shellTestToolNames(allowlistedTools)).toEqual(["message"]);
   });
 
   it("restores the policy-filtered OpenClaw shell when a finite allowlist disables native Code Mode", async () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -19,7 +19,10 @@ import {
   type RuntimeToolSchemaDiagnostic,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
-import { runWithCronCreatorAuthorityCapabilityResolver } from "openclaw/plugin-sdk/codex-mcp-projection";
+import {
+  resolveCodexScheduledToolProjectionFactory,
+  runWithCronCreatorAuthorityCapabilityResolver,
+} from "openclaw/plugin-sdk/codex-mcp-projection";
 import { isToolAllowed } from "openclaw/plugin-sdk/sandbox";
 import {
   isCodexRemoteExecPlacementSandbox,
@@ -47,8 +50,9 @@ import {
   CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME,
   CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
   CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
-  createExecAliasDynamicTool,
-  createGatewayProcessAliasDynamicTool,
+  createGatewayExecProjection,
+  createGatewayProcessProjection,
+  createNodeExecAliasDynamicTool,
   isCodexDynamicToolExcluded,
 } from "./shell-dynamic-tools.js";
 import { filterCodexVisionTools } from "./vision-tools.js";
@@ -620,15 +624,20 @@ function addGatewayShellDynamicToolsIfAvailable(
   const processAliasAvailable = Boolean(
     processTool && !processExcluded && !existingNames.has(CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME),
   );
+  const createProjection = resolveCodexScheduledToolProjectionFactory(
+    input.params.hostCapabilities,
+  );
+  if (!createProjection) {
+    return filteredTools;
+  }
   const toolsToAppend = [
-    createExecAliasDynamicTool(execTool, {
-      host: "gateway",
+    createGatewayExecProjection(createProjection, execTool, {
       processAliasAvailable,
       ...(input.sessionPermissionPolicy?.mode === "guarded" ? { ask: "always" } : {}),
     }),
   ];
   if (processAliasAvailable && processTool) {
-    toolsToAppend.push(createGatewayProcessAliasDynamicTool(processTool));
+    toolsToAppend.push(createGatewayProcessProjection(createProjection, processTool));
   }
   return [...filteredTools, ...toolsToAppend];
 }
@@ -905,10 +914,7 @@ function addNodeShellDynamicToolsIfNeeded(
       (tool) => normalizeCodexDynamicToolName(tool.name) === CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
     )
   ) {
-    return [
-      ...filteredTools,
-      createExecAliasDynamicTool(execTool, { host: "node", node: nodePolicy.node }),
-    ];
+    return [...filteredTools, createNodeExecAliasDynamicTool(execTool, nodePolicy.node)];
   }
   return filteredTools;
 }

--- a/extensions/codex/src/app-server/shell-dynamic-tools.ts
+++ b/extensions/codex/src/app-server/shell-dynamic-tools.ts
@@ -1,24 +1,17 @@
+import {
+  pinExecToolTarget,
+  type CodexScheduledToolProjectionFactory,
+} from "openclaw/plugin-sdk/codex-mcp-projection";
 import type { CodexPluginConfig } from "./config.js";
 import { normalizeCodexDynamicToolName } from "./dynamic-tool-profile.js";
 
 type OpenClawCodingToolsFactory =
   (typeof import("openclaw/plugin-sdk/agent-harness"))["createOpenClawCodingTools"];
 type OpenClawDynamicTool = ReturnType<OpenClawCodingToolsFactory>[number];
-type ExecAliasParams =
-  | { host: "gateway"; processAliasAvailable: boolean; ask?: "always" }
-  | { host: "node"; node?: string };
 
 export const CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME = "node_exec";
 export const CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME = "gateway_exec";
 export const CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME = "gateway_process";
-const CODEX_EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
-const CODEX_NODE_EXEC_PARAMETER_NAMES = new Set([
-  "command",
-  "workdir",
-  "env",
-  "timeoutSeconds",
-  "node",
-]);
 const PROCESS_FOLLOWUP_TEXT =
   "Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.";
 
@@ -33,120 +26,66 @@ export function isCodexDynamicToolExcluded(
   );
 }
 
-export function createExecAliasDynamicTool(
+export function createNodeExecAliasDynamicTool(
   execTool: OpenClawDynamicTool,
-  params: ExecAliasParams,
+  node?: string,
 ): OpenClawDynamicTool {
-  const pinnedNode = params.host === "node" ? params.node?.trim() : undefined;
-  const nodeAlias = params.host === "node";
-  const gatewayProcessAliasAvailable = params.host === "gateway" && params.processAliasAvailable;
-  const name = nodeAlias ? CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME : CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME;
-  const description = nodeAlias
-    ? pinnedNode
-      ? "Run a shell command to completion on the OpenClaw configured remote node for this session. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work."
-      : "Run a shell command to completion on an OpenClaw remote node. Select the node by name or id when multiple nodes are available. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work."
-    : "Run a shell command through OpenClaw on the Gateway host for OpenClaw-managed Gateway environment access, including Secret Store agent-readable environment values and protected egress sentinels. Native Codex shell remains preferred for ordinary local work. This tool always uses OpenClaw host=gateway internally and follows Gateway exec approval and allowlist policy.";
-  const followupText = nodeAlias
-    ? "Remote-node background follow-up is unavailable. Wait for the command to complete."
-    : gatewayProcessAliasAvailable
-      ? "Use gateway_process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up."
-      : "Background session follow-up is unavailable because gateway_process is not exposed. Rerun without background=true and set yieldMs high enough to wait for completion.";
+  const pinnedNode = node?.trim();
+  const pinnedTool = pinExecToolTarget(execTool, {
+    host: "node",
+    ...(pinnedNode ? { node: pinnedNode } : {}),
+  });
+  const execute: OpenClawDynamicTool["execute"] = async (toolCallId, args, signal, onUpdate) => {
+    const result = await pinnedTool.execute(toolCallId, args, signal, onUpdate);
+    return {
+      ...result,
+      content: result.content.map((item) =>
+        item.type === "text"
+          ? Object.assign({}, item, {
+              text: item.text.replace(
+                PROCESS_FOLLOWUP_TEXT,
+                "Remote-node background follow-up is unavailable. Wait for the command to complete.",
+              ),
+            })
+          : item,
+      ),
+    };
+  };
   return {
-    ...execTool,
-    name,
-    description,
-    parameters: hideExecDynamicToolParameters(
-      execTool.parameters,
-      !nodeAlias || Boolean(pinnedNode),
-      nodeAlias,
-    ),
-    execute: async (toolCallId, args, signal, onUpdate) => {
-      const result = await execTool.execute(
-        toolCallId,
-        pinExecDynamicToolArgs(args, params, pinnedNode),
-        signal,
-        onUpdate,
-      );
-      return {
-        ...result,
-        content: result.content.map((item) =>
-          item.type === "text"
-            ? Object.assign({}, item, {
-                text: item.text.replace(PROCESS_FOLLOWUP_TEXT, followupText),
-              })
-            : item,
-        ),
-      };
-    },
+    ...pinnedTool,
+    name: CODEX_NODE_EXEC_DYNAMIC_TOOL_NAME,
+    description: pinnedNode
+      ? "Run a shell command to completion on the OpenClaw configured remote node for this session. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work."
+      : "Run a shell command to completion on an OpenClaw remote node. Select the node by name or id when multiple nodes are available. This tool always uses OpenClaw host=node internally and follows the existing node exec approval and allowlist policy. Remote-node background follow-up is unavailable. Use Codex's native shell for local app-server work.",
+    execute,
   };
 }
 
-export function createGatewayProcessAliasDynamicTool(
+export function createGatewayExecProjection(
+  createProjection: CodexScheduledToolProjectionFactory,
+  execTool: OpenClawDynamicTool,
+  params: { processAliasAvailable: boolean; ask?: "always" },
+): OpenClawDynamicTool {
+  return createProjection(execTool, {
+    kind: "exec",
+    name: CODEX_GATEWAY_EXEC_DYNAMIC_TOOL_NAME,
+    description:
+      "Run a shell command through OpenClaw on the Gateway host for OpenClaw-managed Gateway environment access, including Secret Store agent-readable environment values and protected egress sentinels. Native Codex shell remains preferred for ordinary local work. This tool always uses OpenClaw host=gateway internally and follows Gateway exec approval and allowlist policy.",
+    followupText: params.processAliasAvailable
+      ? "Use gateway_process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up."
+      : "Background session follow-up is unavailable because gateway_process is not exposed. Rerun without background=true and set yieldMs high enough to wait for completion.",
+    ...(params.ask ? { ask: params.ask } : {}),
+  });
+}
+
+export function createGatewayProcessProjection(
+  createProjection: CodexScheduledToolProjectionFactory,
   processTool: OpenClawDynamicTool,
 ): OpenClawDynamicTool {
-  return {
-    ...processTool,
+  return createProjection(processTool, {
+    kind: "process",
     name: CODEX_GATEWAY_PROCESS_DYNAMIC_TOOL_NAME,
     description:
       "Manage background shell sessions in the existing per-session OpenClaw process scope: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use for gateway_exec follow-up; use native Codex shell session handling for ordinary local work.",
-  };
-}
-
-function pinExecDynamicToolArgs(
-  args: unknown,
-  params: ExecAliasParams,
-  configuredNode?: string,
-): unknown {
-  const source = normalizeExecDynamicToolArgs(args);
-  const { host: _host, security: _security, ask: _ask, node: requestedNode, ...rest } = source;
-  if (params.host === "gateway") {
-    return { ...rest, host: params.host, ...(params.ask ? { ask: params.ask } : {}) };
-  }
-  const nodeArgs = Object.fromEntries(
-    Object.entries(rest).filter(([name]) => CODEX_NODE_EXEC_PARAMETER_NAMES.has(name)),
-  );
-  const node = configuredNode ?? (typeof requestedNode === "string" ? requestedNode.trim() : "");
-  return {
-    ...nodeArgs,
-    host: params.host,
-    ...(node ? { node } : {}),
-  };
-}
-
-function normalizeExecDynamicToolArgs(args: unknown): Record<string, unknown> {
-  return args && typeof args === "object" && !Array.isArray(args)
-    ? (args as Record<string, unknown>)
-    : {};
-}
-
-function hideExecDynamicToolParameters(
-  parameters: OpenClawDynamicTool["parameters"],
-  hideNode: boolean,
-  nodeOnly: boolean,
-) {
-  if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
-    return parameters;
-  }
-  const schema = parameters as Record<string, unknown>;
-  const rawProperties = schema.properties;
-  if (!rawProperties || typeof rawProperties !== "object" || Array.isArray(rawProperties)) {
-    return parameters;
-  }
-  const includeParameter = (name: string) =>
-    nodeOnly
-      ? CODEX_NODE_EXEC_PARAMETER_NAMES.has(name) && !(hideNode && name === "node")
-      : !CODEX_EXEC_POLICY_PARAMETER_NAMES.has(normalizeCodexDynamicToolName(name)) &&
-        !(hideNode && normalizeCodexDynamicToolName(name) === "node");
-  const nextProperties = Object.fromEntries(
-    Object.entries(rawProperties).filter(([name]) => includeParameter(name)),
-  );
-  const rawRequired = schema.required;
-  const nextRequired = Array.isArray(rawRequired)
-    ? rawRequired.filter((name) => typeof name !== "string" || includeParameter(name))
-    : rawRequired;
-  return {
-    ...schema,
-    properties: nextProperties,
-    ...(Array.isArray(rawRequired) ? { required: nextRequired } : {}),
-  };
+  });
 }

--- a/src/agents/agent-tool-metadata.ts
+++ b/src/agents/agent-tool-metadata.ts
@@ -3,6 +3,7 @@ import type { AnyAgentTool } from "./agent-tools.types.js";
 import { copyBeforeToolCallHookMarker } from "./before-tool-call-metadata.js";
 import { copyChannelAgentToolMeta } from "./channel-tool-metadata.js";
 import { copyCodeModeControlToolIdentity } from "./code-mode-control-tools.js";
+import { copyCronScheduledToolProjection } from "./exec-tool-target-pinning.js";
 import { copyInternalToolExecutionPreparer } from "./runtime/internal-hooks.js";
 import { copyToolTerminalPresentation } from "./tool-terminal-presentation.js";
 
@@ -71,6 +72,7 @@ export function copyAgentToolMetadata<T extends AnyAgentTool>(source: AnyAgentTo
   copyBeforeToolCallHookMarker(source, target);
   copyToolTerminalPresentation(source, target);
   copyCodeModeControlToolIdentity(source, target);
+  copyCronScheduledToolProjection(source, target);
   copyInternalToolExecutionPreparer(source, target);
   copyAgentToolActionDescriptor(source, target);
   return target;

--- a/src/agents/agent-tools.scheduled-exec-target.test.ts
+++ b/src/agents/agent-tools.scheduled-exec-target.test.ts
@@ -48,11 +48,13 @@ describe("createOpenClawCodingTools scheduled exec target", () => {
       },
     });
     const execTool = tools.find((tool) => tool.name === "exec");
-    expect(execTool).toBeDefined();
+    if (!execTool) {
+      throw new Error("expected an exec tool on the scheduled surface");
+    }
 
     // The pinned schema stops advertising host/security/ask/node entirely.
     const properties = Object.keys(
-      (execTool?.parameters as { properties?: Record<string, unknown> }).properties ?? {},
+      (execTool.parameters as { properties?: Record<string, unknown> }).properties ?? {},
     );
     expect(properties).toContain("command");
     expect(properties).not.toContain("host");
@@ -60,7 +62,7 @@ describe("createOpenClawCodingTools scheduled exec target", () => {
     expect(properties).not.toContain("ask");
     expect(properties).not.toContain("node");
 
-    await execTool?.execute?.("call-1", {
+    await execTool.execute("call-1", {
       command: "echo hi",
       host: "node",
       node: "remote",

--- a/src/agents/agent-tools.scheduled-exec-target.test.ts
+++ b/src/agents/agent-tools.scheduled-exec-target.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Scheduled restrict-only exec pin enforcement in createOpenClawCodingTools.
+ * A cap captured from a host-pinned creator surface must rebuild exec pinned to
+ * that target; absence of the pin keeps baseline exec behavior.
+ */
+import { describe, expect, it, vi } from "vitest";
+import "./test-helpers/fast-coding-tools.js";
+import "./test-helpers/fast-openclaw-tools.js";
+import { createOpenClawCodingTools } from "./agent-tools.js";
+
+const shellSpies = vi.hoisted(() => ({
+  exec: vi.fn(async () => ({ content: [], details: {} })),
+  process: vi.fn(async () => ({ content: [], details: {} })),
+}));
+
+vi.mock("./bash-tools.js", () => ({
+  createExecTool: () => ({
+    name: "exec",
+    description: "exec test double",
+    parameters: {
+      type: "object",
+      properties: {
+        command: { type: "string" },
+        host: { type: "string" },
+        security: { type: "string" },
+        ask: { type: "string" },
+        node: { type: "string" },
+      },
+      required: ["command", "host"],
+    },
+    execute: shellSpies.exec,
+  }),
+  createProcessTool: () => ({
+    name: "process",
+    description: "process test double",
+    parameters: { type: "object", properties: {} },
+    execute: shellSpies.process,
+  }),
+}));
+
+describe("createOpenClawCodingTools scheduled exec target", () => {
+  it("pins exec to the scheduled cap's restrict-only target", async () => {
+    const tools = createOpenClawCodingTools({
+      scheduledToolPolicy: {
+        version: 1,
+        mode: "trusted",
+        execTarget: { host: "gateway" },
+      },
+    });
+    const execTool = tools.find((tool) => tool.name === "exec");
+    expect(execTool).toBeDefined();
+
+    // The pinned schema stops advertising host/security/ask/node entirely.
+    const properties = Object.keys(
+      (execTool?.parameters as { properties?: Record<string, unknown> }).properties ?? {},
+    );
+    expect(properties).toContain("command");
+    expect(properties).not.toContain("host");
+    expect(properties).not.toContain("security");
+    expect(properties).not.toContain("ask");
+    expect(properties).not.toContain("node");
+
+    await execTool?.execute?.("call-1", {
+      command: "echo hi",
+      host: "node",
+      node: "remote",
+      security: "full",
+      ask: "off",
+    });
+    expect(shellSpies.exec).toHaveBeenCalledWith(
+      "call-1",
+      { command: "echo hi", host: "gateway" },
+      undefined,
+      undefined,
+    );
+  });
+
+  it("keeps baseline exec behavior without a scheduled exec target", async () => {
+    const tools = createOpenClawCodingTools({
+      scheduledToolPolicy: { version: 1, mode: "trusted" },
+    });
+    const execTool = tools.find((tool) => tool.name === "exec");
+    expect(execTool).toBeDefined();
+
+    await execTool?.execute?.("call-2", { command: "echo hi", host: "node" });
+    expect(shellSpies.exec).toHaveBeenCalledWith(
+      "call-2",
+      { command: "echo hi", host: "node" },
+      undefined,
+      undefined,
+    );
+  });
+});

--- a/src/agents/agent-tools.scheduled-exec-target.test.ts
+++ b/src/agents/agent-tools.scheduled-exec-target.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it, vi } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
 import { createOpenClawCodingTools } from "./agent-tools.js";
+import { pinExecToolTarget } from "./exec-tool-target-pinning.js";
+import type { AnyAgentTool } from "./tools/common.js";
 
 const shellSpies = vi.hoisted(() => ({
   exec: vi.fn(async () => ({ content: [], details: {} })),
@@ -75,6 +77,34 @@ describe("createOpenClawCodingTools scheduled exec target", () => {
       undefined,
       undefined,
     );
+  });
+
+  it("pins the whole tool lifecycle, including execution preparation", async () => {
+    const prepare = vi.fn(async (args: unknown) => args);
+    const finalize = vi.fn((params: unknown) => params);
+    const execute = vi.fn(async () => ({ content: [], details: {} }));
+    const source: AnyAgentTool = {
+      name: "exec",
+      label: "Exec",
+      description: "exec",
+      parameters: { type: "object", properties: {} },
+      prepareBeforeToolCallParams: prepare,
+      finalizeBeforeToolCallParams: finalize,
+      execute,
+    };
+
+    const pinned = pinExecToolTarget(source, { host: "gateway" });
+    await pinned.prepareBeforeToolCallParams?.(
+      { command: "echo hi", host: "node", node: "remote", security: "full" },
+      { hookContext: undefined },
+    );
+    pinned.finalizeBeforeToolCallParams?.({ command: "echo hi", host: "node" }, {});
+
+    expect(prepare).toHaveBeenCalledWith(
+      { command: "echo hi", host: "gateway" },
+      { hookContext: undefined },
+    );
+    expect(finalize).toHaveBeenCalledWith({ command: "echo hi", host: "gateway" }, {});
   });
 
   it("keeps baseline exec behavior without a scheduled exec target", async () => {

--- a/src/agents/agent-tools.scheduled-exec-target.test.ts
+++ b/src/agents/agent-tools.scheduled-exec-target.test.ts
@@ -11,27 +11,31 @@ import { pinExecToolTarget } from "./exec-tool-target-pinning.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 const shellSpies = vi.hoisted(() => ({
+  defaults: vi.fn(),
   exec: vi.fn(async () => ({ content: [], details: {} })),
   process: vi.fn(async () => ({ content: [], details: {} })),
 }));
 
 vi.mock("./bash-tools.js", () => ({
-  createExecTool: () => ({
-    name: "exec",
-    description: "exec test double",
-    parameters: {
-      type: "object",
-      properties: {
-        command: { type: "string" },
-        host: { type: "string" },
-        security: { type: "string" },
-        ask: { type: "string" },
-        node: { type: "string" },
+  createExecTool: (defaults: unknown) => {
+    shellSpies.defaults(defaults);
+    return {
+      name: "exec",
+      description: "exec test double",
+      parameters: {
+        type: "object",
+        properties: {
+          command: { type: "string" },
+          host: { type: "string" },
+          security: { type: "string" },
+          ask: { type: "string" },
+          node: { type: "string" },
+        },
+        required: ["command", "host"],
       },
-      required: ["command", "host"],
-    },
-    execute: shellSpies.exec,
-  }),
+      execute: shellSpies.exec,
+    };
+  },
   createProcessTool: () => ({
     name: "process",
     description: "process test double",
@@ -46,14 +50,13 @@ describe("createOpenClawCodingTools scheduled exec target", () => {
       scheduledToolPolicy: {
         version: 1,
         mode: "trusted",
-        execTarget: { host: "gateway" },
+        execTarget: { host: "gateway", ask: "always" },
       },
     });
     const execTool = tools.find((tool) => tool.name === "exec");
     if (!execTool) {
       throw new Error("expected an exec tool on the scheduled surface");
     }
-
     // The pinned schema stops advertising host/security/ask/node entirely.
     const properties = Object.keys(
       (execTool.parameters as { properties?: Record<string, unknown> }).properties ?? {},
@@ -71,9 +74,12 @@ describe("createOpenClawCodingTools scheduled exec target", () => {
       security: "full",
       ask: "off",
     });
+    expect(shellSpies.defaults).toHaveBeenCalledWith(
+      expect.objectContaining({ host: "gateway", ask: "always" }),
+    );
     expect(shellSpies.exec).toHaveBeenCalledWith(
       "call-1",
-      { command: "echo hi", host: "gateway" },
+      { command: "echo hi", host: "gateway", ask: "always" },
       undefined,
       undefined,
     );
@@ -93,18 +99,21 @@ describe("createOpenClawCodingTools scheduled exec target", () => {
       execute,
     };
 
-    const pinned = pinExecToolTarget(source, { host: "gateway" });
+    const pinned = pinExecToolTarget(source, { host: "gateway", ask: "always" });
     await pinned.prepareBeforeToolCallParams?.(
-      { command: "echo hi", host: "node", node: "remote", security: "full" },
+      { command: "echo hi", host: "node", node: "remote", security: "full", ask: "off" },
       { hookContext: undefined },
     );
-    pinned.finalizeBeforeToolCallParams?.({ command: "echo hi", host: "node" }, {});
+    pinned.finalizeBeforeToolCallParams?.({ command: "echo hi", host: "node", ask: "off" }, {});
 
     expect(prepare).toHaveBeenCalledWith(
-      { command: "echo hi", host: "gateway" },
+      { command: "echo hi", host: "gateway", ask: "always" },
       { hookContext: undefined },
     );
-    expect(finalize).toHaveBeenCalledWith({ command: "echo hi", host: "gateway" }, {});
+    expect(finalize).toHaveBeenCalledWith(
+      { command: "echo hi", host: "gateway", ask: "always" },
+      {},
+    );
   });
 
   it("keeps baseline exec behavior without a scheduled exec target", async () => {

--- a/src/agents/agent-tools.scheduled-exec-target.test.ts
+++ b/src/agents/agent-tools.scheduled-exec-target.test.ts
@@ -116,6 +116,25 @@ describe("createOpenClawCodingTools scheduled exec target", () => {
     );
   });
 
+  it("keeps the scheduled approval floor in a reused full-permission session", () => {
+    createOpenClawCodingTools({
+      sessionPermissionPolicy: { root: process.cwd(), mode: "full" },
+      scheduledToolPolicy: {
+        version: 1,
+        mode: "trusted",
+        execTarget: { host: "gateway", ask: "always" },
+      },
+    });
+
+    expect(shellSpies.defaults).toHaveBeenCalledWith(
+      expect.objectContaining({
+        host: "gateway",
+        ask: "always",
+        bypassHostApprovalFloors: false,
+      }),
+    );
+  });
+
   it("keeps baseline exec behavior without a scheduled exec target", async () => {
     const tools = createOpenClawCodingTools({
       scheduledToolPolicy: { version: 1, mode: "trusted" },

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -577,6 +577,11 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   options?.recordToolPrepStage?.("workspace-policy");
   const { cleanupMs: cleanupMsOverride, ...execDefaults } = options?.exec ?? {};
   const effectiveExecPolicy = applyExecPolicyLayer(execConfig, options?.exec);
+  // A scheduled cap captured from a host-pinned creator surface narrows the
+  // rebuilt exec tool to that execution target: the host default follows the
+  // pin so the forced target passes exec's configured-host policy, and the
+  // tool itself is wrapped below so caller arguments cannot retarget it.
+  const scheduledExecTarget = options?.scheduledToolPolicy?.execTarget;
   const processToolAvailabilityRef: NonNullable<ExecToolDefaults["processToolAvailabilityRef"]> =
     {};
   const coreTools = createCoreCodingTools({
@@ -607,7 +612,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     execDefaults: {
       ...execDefaults,
       bypassHostApprovalFloors: sessionCoreToolPolicy?.bypassHostApprovalFloors,
-      host: options?.exec?.host ?? execConfig.host,
+      host: scheduledExecTarget?.host ?? options?.exec?.host ?? execConfig.host,
       mode: effectiveExecPolicy.mode,
       security: effectiveExecPolicy.security,
       ask: effectiveExecPolicy.ask,
@@ -774,9 +779,6 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
           executeTool: options?.toolSearchCatalogExecutor,
         })
       : [];
-  // A scheduled cap captured from a host-pinned creator surface narrows the
-  // rebuilt exec tool to the same execution target; absence keeps baseline exec.
-  const scheduledExecTarget = options?.scheduledToolPolicy?.execTarget;
   const scheduledCoreTools = scheduledExecTarget
     ? coreTools.map((tool) =>
         tool.name === "exec"

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -32,7 +32,10 @@ import type { SkillSnapshot, SkillUsagePath } from "../skills/types.js";
 import type { SkillWorkshopRunOptions } from "../skills/workshop/types.js";
 import { resolveGatewayMessageChannel } from "../utils/message-channel.js";
 import type { OperationalRunInstanceRef } from "./admitted-run-context.js";
-import { bindAssembledAgentToolActionDescriptor } from "./agent-tool-metadata.js";
+import {
+  bindAssembledAgentToolActionDescriptor,
+  copyAgentToolMetadata,
+} from "./agent-tool-metadata.js";
 import type { ToolOutcomeObserver } from "./agent-tools.before-tool-call.js";
 import { finalizeAgentTools } from "./agent-tools.finalize.js";
 import { filterToolsByMessageProvider } from "./agent-tools.message-provider-policy.js";
@@ -65,6 +68,7 @@ import { createCoreCodingTools } from "./core-coding-tools.js";
 import type { OpenClawCodingToolConstructionPlan } from "./core-tool-factory-descriptors.js";
 import { bindActiveCronCreatorAuthorityResolver } from "./cron-creator-authority-context.js";
 import { applyDelegationCapability, type DelegationCapability } from "./delegation-capability.js";
+import { pinExecToolTarget } from "./exec-tool-target-pinning.js";
 import { prepareGitHubToolEnvironment } from "./github-tool-identity.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
 import { resolveExecToolConfig } from "./lazy-exec-tool.js";
@@ -770,8 +774,18 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
           executeTool: options?.toolSearchCatalogExecutor,
         })
       : [];
+  // A scheduled cap captured from a host-pinned creator surface narrows the
+  // rebuilt exec tool to the same execution target; absence keeps baseline exec.
+  const scheduledExecTarget = options?.scheduledToolPolicy?.execTarget;
+  const scheduledCoreTools = scheduledExecTarget
+    ? coreTools.map((tool) =>
+        tool.name === "exec"
+          ? copyAgentToolMetadata(tool, pinExecToolTarget(tool, { host: scheduledExecTarget.host }))
+          : tool,
+      )
+    : coreTools;
   const tools: AnyAgentTool[] = [
-    ...coreTools,
+    ...scheduledCoreTools,
     // Channel docking: include channel-defined agent tools (login, etc.).
     ...(includeChannelTools ? listChannelAgentTools({ cfg: options?.config }) : []),
     ...(includeOpenClawTools

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -577,10 +577,9 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   options?.recordToolPrepStage?.("workspace-policy");
   const { cleanupMs: cleanupMsOverride, ...execDefaults } = options?.exec ?? {};
   const effectiveExecPolicy = applyExecPolicyLayer(execConfig, options?.exec);
-  // A scheduled cap captured from a host-pinned creator surface narrows the
-  // rebuilt exec tool to that execution target: the host default follows the
-  // pin so the forced target passes exec's configured-host policy, and the
-  // tool itself is wrapped below so caller arguments cannot retarget it.
+  // A scheduled cap narrows the rebuilt exec tool to its captured policy.
+  // Defaults carry host/approval floors into resolution; the wrapper below
+  // prevents caller arguments from weakening either restriction.
   const scheduledExecTarget = options?.scheduledToolPolicy?.execTarget;
   const processToolAvailabilityRef: NonNullable<ExecToolDefaults["processToolAvailabilityRef"]> =
     {};
@@ -615,7 +614,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
       host: scheduledExecTarget?.host ?? options?.exec?.host ?? execConfig.host,
       mode: effectiveExecPolicy.mode,
       security: effectiveExecPolicy.security,
-      ask: effectiveExecPolicy.ask,
+      ask: scheduledExecTarget?.ask ?? effectiveExecPolicy.ask,
       config: execRuntimeConfig,
       preparedRunEnvironment,
       reviewer: options?.exec?.reviewer ?? execConfig.reviewer,
@@ -782,7 +781,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const scheduledCoreTools = scheduledExecTarget
     ? coreTools.map((tool) =>
         tool.name === "exec"
-          ? copyAgentToolMetadata(tool, pinExecToolTarget(tool, { host: scheduledExecTarget.host }))
+          ? copyAgentToolMetadata(tool, pinExecToolTarget(tool, scheduledExecTarget))
           : tool,
       )
     : coreTools;

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -578,7 +578,7 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
   const { cleanupMs: cleanupMsOverride, ...execDefaults } = options?.exec ?? {};
   const effectiveExecPolicy = applyExecPolicyLayer(execConfig, options?.exec);
   // A scheduled cap narrows the rebuilt exec tool to its captured policy.
-  // Defaults carry host/approval floors into resolution; the wrapper below
+  // Its approval floor outranks a reused full session; the wrapper below
   // prevents caller arguments from weakening either restriction.
   const scheduledExecTarget = options?.scheduledToolPolicy?.execTarget;
   const processToolAvailabilityRef: NonNullable<ExecToolDefaults["processToolAvailabilityRef"]> =
@@ -610,7 +610,8 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     applyPatchWorkspaceOnly,
     execDefaults: {
       ...execDefaults,
-      bypassHostApprovalFloors: sessionCoreToolPolicy?.bypassHostApprovalFloors,
+      bypassHostApprovalFloors:
+        scheduledExecTarget?.ask !== "always" && sessionCoreToolPolicy?.bypassHostApprovalFloors,
       host: scheduledExecTarget?.host ?? options?.exec?.host ?? execConfig.host,
       mode: effectiveExecPolicy.mode,
       security: effectiveExecPolicy.security,

--- a/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
+++ b/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
@@ -6,10 +6,12 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it } from "vitest";
 import { GATEWAY_CLIENT_CAPS } from "../../packages/gateway-protocol/src/client-info.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
 import { clearSessionStoreCacheForTest } from "../config/sessions/store-writer-state.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
 import { startGatewayServer } from "../gateway/server.js";
 import {
@@ -21,7 +23,7 @@ import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "../gateway/test-helpers.env.js
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { withTimeout } from "../utils/with-timeout.js";
-import { createExecTool } from "./bash-tools.exec-run.js";
+import { createOpenClawCodingTools } from "./agent-tools.js";
 import type { ExecApprovalFollowupOutcome } from "./bash-tools.exec-types.js";
 
 const TEST_ENV_KEYS = [
@@ -42,6 +44,14 @@ const GATEWAY_CONNECT_TIMEOUT_MS = 120_000;
 const EXEC_APPROVAL_E2E_TIMEOUT_MS = 180_000;
 
 type Cleanup = () => Promise<void> | void;
+
+function requireApprovalId(details: unknown): string {
+  const record = asNonArrayRecord(details);
+  if (record?.status !== "approval-pending" || typeof record.approvalId !== "string") {
+    throw new Error("expected approval-pending exec result");
+  }
+  return record.approvalId;
+}
 
 describe("gateway-hosted exec approvals", () => {
   const cleanup: Cleanup[] = [];
@@ -72,27 +82,21 @@ describe("gateway-hosted exec approvals", () => {
       const token = "exec-approval-e2e-token";
       const configPath = path.join(stateDir, "openclaw.json");
       await fs.mkdir(stateDir, { recursive: true });
-      await fs.writeFile(
-        configPath,
-        `${JSON.stringify(
-          {
-            gateway: {
-              port,
-              auth: { mode: "token", token },
-            },
-            tools: {
-              exec: {
-                host: "gateway",
-                security: "allowlist",
-                ask: "always",
-              },
-            },
+      const config = {
+        agents: { defaults: { workspace: workspaceDir } },
+        gateway: {
+          port,
+          auth: { mode: "token", token },
+        },
+        tools: {
+          exec: {
+            host: "gateway",
+            security: "full",
+            ask: "off",
           },
-          null,
-          2,
-        )}\n`,
-        "utf8",
-      );
+        },
+      } satisfies OpenClawConfig;
+      await fs.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
 
       setTestEnvValue("HOME", tempHome);
       setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
@@ -132,21 +136,47 @@ describe("gateway-hosted exec approvals", () => {
       cleanup.push(() => disconnectGatewayClient(operator));
 
       let resolveOutcome: (outcome: ExecApprovalFollowupOutcome) => void = () => {};
-      const outcomePromise = new Promise<ExecApprovalFollowupOutcome>((resolve) => {
-        resolveOutcome = resolve;
-      });
 
-      const tool = createExecTool({
-        host: "gateway",
-        security: "allowlist",
-        ask: "always",
+      const tools = createOpenClawCodingTools({
+        agentId: "main",
+        workspaceDir,
         cwd: workspaceDir,
-        approvalRunningNoticeMs: 0,
-        approvalFollowupMode: "direct",
-        approvalFollowup: ({ outcome }) => {
-          resolveOutcome(outcome);
-          return undefined;
+        config,
+        scheduledToolPolicy: {
+          version: 1,
+          mode: "trusted",
+          execTarget: { host: "gateway", ask: "always" },
         },
+        exec: {
+          approvalRunningNoticeMs: 0,
+          approvalFollowupMode: "direct",
+          approvalFollowup: ({ outcome }) => {
+            resolveOutcome(outcome);
+            return undefined;
+          },
+        },
+      });
+      const tool = tools.find((candidate) => candidate.name === "exec");
+      if (!tool) {
+        throw new Error("expected scheduled exec tool");
+      }
+
+      const markerPath = path.join(workspaceDir, "denied-marker");
+      const deniedPending = await tool.execute("exec-approval-e2e-denied", {
+        command: `touch ${JSON.stringify(markerPath)}`,
+        workdir: workspaceDir,
+        timeoutSeconds: 5,
+      });
+      const deniedApprovalId = requireApprovalId(deniedPending.details);
+      await operator.request(
+        "exec.approval.resolve",
+        { id: deniedApprovalId, decision: "deny" },
+        { timeoutMs: 10_000 },
+      );
+      await expect(fs.stat(markerPath)).rejects.toMatchObject({ code: "ENOENT" });
+
+      const allowedOutcomePromise = new Promise<ExecApprovalFollowupOutcome>((resolve) => {
+        resolveOutcome = resolve;
       });
 
       const pending = await tool.execute("exec-approval-e2e", {
@@ -154,19 +184,15 @@ describe("gateway-hosted exec approvals", () => {
         workdir: workspaceDir,
         timeoutSeconds: 5,
       });
-
-      expect(pending.details.status).toBe("approval-pending");
-      if (pending.details.status !== "approval-pending") {
-        throw new Error("expected approval-pending exec result");
-      }
+      const approvalId = requireApprovalId(pending.details);
 
       await operator.request(
         "exec.approval.resolve",
-        { id: pending.details.approvalId, decision: "allow-once" },
+        { id: approvalId, decision: "allow-once" },
         { timeoutMs: 10_000 },
       );
 
-      const outcome = await withTimeout(outcomePromise, 15_000, {
+      const outcome = await withTimeout(allowedOutcomePromise, 15_000, {
         message: "timed out waiting for approved exec outcome",
       });
       expect(outcome.status).toBe("completed");

--- a/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
+++ b/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
@@ -66,7 +66,7 @@ describe("gateway-hosted exec approvals", () => {
   });
 
   it(
-    "lets OpenClaw-style gateway tool calls request and wait for approval over separate connections",
+    "keeps a scheduled approval floor in a reused full-permission session",
     async () => {
       const envSnapshot = captureEnv(TEST_ENV_KEYS);
       cleanup.push(() => envSnapshot.restore());
@@ -142,6 +142,7 @@ describe("gateway-hosted exec approvals", () => {
         workspaceDir,
         cwd: workspaceDir,
         config,
+        sessionPermissionPolicy: { root: workspaceDir, mode: "full" },
         scheduledToolPolicy: {
           version: 1,
           mode: "trusted",

--- a/src/agents/exec-tool-target-pinning.ts
+++ b/src/agents/exec-tool-target-pinning.ts
@@ -1,0 +1,206 @@
+// Host-owned projection identity for scheduled shell aliases. A harness (for
+// example Codex) presents core `exec`/`process` under runtime-specific alias
+// names; this module lets the exact host capability that constructed the
+// concrete core tool mint an alias projection and lets cron creator capture
+// translate that alias back to its canonical tool name. The registry is
+// in-memory object identity only — nothing here is persisted.
+import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
+import type { AnyAgentTool } from "./tools/common.js";
+
+/** Canonical identity of a host-created scheduled tool alias. */
+export type CronScheduledToolProjectionInfo = Readonly<{
+  /** Canonical core tool the alias projects. */
+  targetTool: "exec" | "process";
+  /** Restrict-only execution target the alias enforces. */
+  execTarget?: Readonly<{ host: "gateway" }>;
+}>;
+
+type CronScheduledToolProjection = Readonly<{
+  assertActive: () => void;
+  /** Alias name the projection was sealed under; identity checks reject renames. */
+  sourceToolName: string;
+  info: CronScheduledToolProjectionInfo;
+  execute: AnyAgentTool["execute"];
+}>;
+
+const scheduledToolProjections = new WeakMap<AnyAgentTool, CronScheduledToolProjection>();
+
+const EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
+const NODE_EXEC_PARAMETER_NAMES = new Set(["command", "workdir", "env", "timeoutSeconds", "node"]);
+const PROCESS_FOLLOWUP_TEXT =
+  "Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.";
+
+type PinnedExecToolTarget = { host: "gateway"; ask?: "always" } | { host: "node"; node?: string };
+
+export type CronScheduledToolProjectionRequest =
+  | Readonly<{
+      kind: "exec";
+      name: string;
+      description: string;
+      followupText: string;
+      ask?: "always";
+    }>
+  | Readonly<{ kind: "process"; name: string; description: string }>;
+
+/** Constructs and registers an alias from an exact host-owned shell source. */
+export function createCronScheduledToolProjection(
+  sourceTool: AnyAgentTool,
+  assertActive: () => void,
+  targetTool: "exec" | "process",
+  projection: CronScheduledToolProjectionRequest,
+): AnyAgentTool {
+  assertActive();
+  if (projection.kind !== targetTool) {
+    throw new Error("scheduled tool projection does not match its host-created source");
+  }
+  const projectedTool =
+    projection.kind === "exec"
+      ? createScheduledExecProjection(sourceTool, projection)
+      : { ...sourceTool, name: projection.name, description: projection.description };
+  const info: CronScheduledToolProjectionInfo =
+    targetTool === "exec"
+      ? Object.freeze({ targetTool, execTarget: Object.freeze({ host: "gateway" as const }) })
+      : Object.freeze({ targetTool });
+  scheduledToolProjections.set(
+    projectedTool,
+    Object.freeze({
+      assertActive,
+      sourceToolName: projectedTool.name,
+      info,
+      execute: projectedTool.execute,
+    }),
+  );
+  return projectedTool;
+}
+
+function createScheduledExecProjection(
+  sourceTool: AnyAgentTool,
+  projection: Readonly<{
+    name: string;
+    description: string;
+    followupText: string;
+    ask?: "always";
+  }>,
+): AnyAgentTool {
+  const pinnedTool = pinExecToolTarget(sourceTool, {
+    host: "gateway",
+    ...(projection.ask ? { ask: projection.ask } : {}),
+  });
+  return {
+    ...pinnedTool,
+    name: projection.name,
+    description: projection.description,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const result = await pinnedTool.execute(toolCallId, args, signal, onUpdate);
+      return {
+        ...result,
+        content: result.content.map((item) =>
+          item.type === "text"
+            ? Object.assign({}, item, {
+                text: item.text.replace(PROCESS_FOLLOWUP_TEXT, projection.followupText),
+              })
+            : item,
+        ),
+      };
+    },
+  };
+}
+
+/**
+ * Resolves the canonical identity of a host-created alias on the final
+ * executable surface. Returns undefined for tools without a registered
+ * projection; throws when a registered projection's executable or name was
+ * changed after host creation, so tampered aliases never canonicalize.
+ */
+export function readCronScheduledToolProjection(
+  tool: AnyAgentTool,
+): CronScheduledToolProjectionInfo | undefined {
+  const projection = scheduledToolProjections.get(tool);
+  if (!projection) {
+    return undefined;
+  }
+  projection.assertActive();
+  if (tool.name !== projection.sourceToolName || tool.execute !== projection.execute) {
+    throw new Error("scheduled tool projection executable changed after host creation");
+  }
+  return projection.info;
+}
+
+/** Preserves projection identity across shallow tool-object copies made by tool plumbing. */
+export function copyCronScheduledToolProjection(source: AnyAgentTool, target: AnyAgentTool): void {
+  const projection = scheduledToolProjections.get(source);
+  if (
+    projection &&
+    source.name === projection.sourceToolName &&
+    target.name === projection.sourceToolName &&
+    source.execute === projection.execute &&
+    target.execute === projection.execute
+  ) {
+    scheduledToolProjections.set(target, projection);
+  }
+}
+
+/** Restricts an exec tool to one host target even when callers submit broader arguments. */
+export function pinExecToolTarget(tool: AnyAgentTool, target: PinnedExecToolTarget): AnyAgentTool {
+  const pinnedNode = target.host === "node" ? target.node?.trim() : undefined;
+  return {
+    ...tool,
+    parameters: restrictExecToolParameters(tool.parameters, target.host, Boolean(pinnedNode)),
+    execute: (toolCallId, args, signal, onUpdate) =>
+      tool.execute(toolCallId, pinExecToolArgs(args, target, pinnedNode), signal, onUpdate),
+  };
+}
+
+function pinExecToolArgs(
+  args: unknown,
+  target: PinnedExecToolTarget,
+  pinnedNode: string | undefined,
+): Record<string, unknown> {
+  const source = asNonArrayRecord(args);
+  const { host: _host, security: _security, ask: _ask, node: requestedNode, ...rest } = source;
+  if (target.host === "gateway") {
+    return { ...rest, host: "gateway", ...(target.ask ? { ask: target.ask } : {}) };
+  }
+  const nodeArgs = Object.fromEntries(
+    Object.entries(rest).filter(([name]) => NODE_EXEC_PARAMETER_NAMES.has(name)),
+  );
+  const node = pinnedNode ?? (typeof requestedNode === "string" ? requestedNode.trim() : "");
+  return {
+    ...nodeArgs,
+    host: "node",
+    ...(node ? { node } : {}),
+  };
+}
+
+function restrictExecToolParameters(
+  parameters: AnyAgentTool["parameters"],
+  host: PinnedExecToolTarget["host"],
+  hasPinnedNode: boolean,
+): AnyAgentTool["parameters"] {
+  if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
+    return parameters;
+  }
+  // SAFETY: the guards above establish a non-array object schema before field inspection.
+  const schema = parameters as Record<string, unknown>;
+  const rawProperties = schema.properties;
+  if (!rawProperties || typeof rawProperties !== "object" || Array.isArray(rawProperties)) {
+    return parameters;
+  }
+  const includeParameter = (name: string) =>
+    host === "node"
+      ? NODE_EXEC_PARAMETER_NAMES.has(name) && !(hasPinnedNode && name === "node")
+      : !EXEC_POLICY_PARAMETER_NAMES.has(name) && name !== "node";
+  const properties = Object.fromEntries(
+    Object.entries(rawProperties).filter(([name]) => includeParameter(name)),
+  );
+  const rawRequired = schema.required;
+  const required = Array.isArray(rawRequired)
+    ? rawRequired.filter((name) => typeof name !== "string" || includeParameter(name))
+    : rawRequired;
+  return {
+    ...schema,
+    properties,
+    ...(Array.isArray(rawRequired) ? { required } : {}),
+    // SAFETY: this preserves the original schema shape and only removes properties and required names.
+  } as AnyAgentTool["parameters"];
+}

--- a/src/agents/exec-tool-target-pinning.ts
+++ b/src/agents/exec-tool-target-pinning.ts
@@ -86,6 +86,9 @@ function createScheduledExecProjection(
     host: "gateway",
     ...(projection.ask ? { ask: projection.ask } : {}),
   });
+  // The spread below carries the source's symbol-keyed markers (including the
+  // before-tool-call wrap marker), so downstream trusted bridges recognize the
+  // alias as already wrapped and never replace its registered executable.
   return {
     ...pinnedTool,
     name: projection.name,
@@ -143,11 +146,29 @@ export function copyCronScheduledToolProjection(source: AnyAgentTool, target: An
 /** Restricts an exec tool to one host target even when callers submit broader arguments. */
 export function pinExecToolTarget(tool: AnyAgentTool, target: PinnedExecToolTarget): AnyAgentTool {
   const pinnedNode = target.host === "node" ? target.node?.trim() : undefined;
+  const pinArgs = (args: unknown) => pinExecToolArgs(args, target, pinnedNode);
+  const prepare = tool.prepareBeforeToolCallParams;
+  const finalize = tool.finalizeBeforeToolCallParams;
   return {
     ...tool,
     parameters: restrictExecToolParameters(tool.parameters, target.host, Boolean(pinnedNode)),
+    // The whole tool lifecycle sees only pinned arguments: preparation resolves
+    // workdir/env against the pinned host, finalize's host-consistency checks
+    // compare against the pinned host, and execution runs the pinned host —
+    // caller-supplied host/node can never leak target-specific prepared state.
+    ...(prepare
+      ? {
+          prepareBeforeToolCallParams: (args, context) => prepare(pinArgs(args), context),
+        }
+      : {}),
+    ...(finalize
+      ? {
+          finalizeBeforeToolCallParams: (params, preparedParams) =>
+            finalize(pinArgs(params), preparedParams),
+        }
+      : {}),
     execute: (toolCallId, args, signal, onUpdate) =>
-      tool.execute(toolCallId, pinExecToolArgs(args, target, pinnedNode), signal, onUpdate),
+      tool.execute(toolCallId, pinArgs(args), signal, onUpdate),
   };
 }
 

--- a/src/agents/exec-tool-target-pinning.ts
+++ b/src/agents/exec-tool-target-pinning.ts
@@ -23,7 +23,9 @@ type CronScheduledToolProjection = Readonly<{
   execute: AnyAgentTool["execute"];
 }>;
 
-const scheduledToolProjections = new WeakMap<AnyAgentTool, CronScheduledToolProjection>();
+// Keyed by tool object identity; readers may hold a narrower structural view
+// of the tool than the registering host, so the key type is plain `object`.
+const scheduledToolProjections = new WeakMap<object, CronScheduledToolProjection>();
 
 const EXEC_POLICY_PARAMETER_NAMES = new Set(["host", "security", "ask"]);
 const NODE_EXEC_PARAMETER_NAMES = new Set(["command", "workdir", "env", "timeoutSeconds", "node"]);
@@ -115,9 +117,10 @@ function createScheduledExecProjection(
  * projection; throws when a registered projection's executable or name was
  * changed after host creation, so tampered aliases never canonicalize.
  */
-export function readCronScheduledToolProjection(
-  tool: AnyAgentTool,
-): CronScheduledToolProjectionInfo | undefined {
+export function readCronScheduledToolProjection(tool: {
+  name: string;
+  execute?: unknown;
+}): CronScheduledToolProjectionInfo | undefined {
   const projection = scheduledToolProjections.get(tool);
   if (!projection) {
     return undefined;

--- a/src/agents/exec-tool-target-pinning.ts
+++ b/src/agents/exec-tool-target-pinning.ts
@@ -11,8 +11,8 @@ import type { AnyAgentTool } from "./tools/common.js";
 export type CronScheduledToolProjectionInfo = Readonly<{
   /** Canonical core tool the alias projects. */
   targetTool: "exec" | "process";
-  /** Restrict-only execution target the alias enforces. */
-  execTarget?: Readonly<{ host: "gateway" }>;
+  /** Restrict-only execution policy the alias enforces. */
+  execTarget?: Readonly<{ host: "gateway"; ask?: "always" }>;
 }>;
 
 type CronScheduledToolProjection = Readonly<{
@@ -61,7 +61,13 @@ export function createCronScheduledToolProjection(
       : { ...sourceTool, name: projection.name, description: projection.description };
   const info: CronScheduledToolProjectionInfo =
     targetTool === "exec"
-      ? Object.freeze({ targetTool, execTarget: Object.freeze({ host: "gateway" as const }) })
+      ? Object.freeze({
+          targetTool,
+          execTarget: Object.freeze({
+            host: "gateway" as const,
+            ...(projection.kind === "exec" && projection.ask ? { ask: projection.ask } : {}),
+          }),
+        })
       : Object.freeze({ targetTool });
   scheduledToolProjections.set(
     projectedTool,

--- a/src/agents/harness/host-capability.scheduled-projection.test.ts
+++ b/src/agents/harness/host-capability.scheduled-projection.test.ts
@@ -1,0 +1,192 @@
+import { Type } from "typebox";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetAgentRunRegistryForTest } from "../../infra/agent-run-registry.js";
+import {
+  createOperationalRunInstanceRef,
+  prepareAgentRunAdmission,
+  type PreparedAgentRunAdmission,
+} from "../admitted-run-context.js";
+import {
+  createCronScheduledToolProjection,
+  readCronScheduledToolProjection,
+} from "../exec-tool-target-pinning.js";
+import type { AnyAgentTool } from "../tools/common.js";
+import { createAgentHarnessHostCapabilities } from "./host-capability.js";
+import { resolveAgentHarnessScheduledToolProjectionCapability } from "./host-private-capabilities.js";
+
+type HostAttempt = Parameters<typeof createAgentHarnessHostCapabilities>[0]["attempt"];
+
+const admissions: PreparedAgentRunAdmission[] = [];
+
+async function admittedAttempt(runId: string): Promise<HostAttempt> {
+  const admission = prepareAgentRunAdmission({
+    cfg: {},
+    facts: {
+      runId,
+      agentId: "main",
+      ingress: { kind: "system", boundary: "host-capability-test", state: "present" },
+    },
+    operationalRunInstance: createOperationalRunInstanceRef(runId),
+  });
+  admissions.push(admission);
+  return {
+    agentId: "main",
+    sessionId: "session-1",
+    sessionKey: "agent:main:session-1",
+    runId,
+    cwd: "/attempt/worktree",
+    workspaceDir: "/workspace",
+    currentChannelId: "chat-1",
+    messageChannel: "telegram",
+    admittedRunContext: await admission.admit("plugin-harness", `harness-${runId}`),
+  };
+}
+
+afterEach(() => {
+  for (const admission of admissions.splice(0)) {
+    admission.close();
+  }
+  resetAgentRunRegistryForTest();
+});
+
+describe("agent harness scheduled tool projection", () => {
+  it("issues scheduled shell projections only from this host-created tool surface", async () => {
+    const attempt = await admittedAttempt("run-scheduled-tool-projection");
+    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
+    const sourceTools = host.capabilities.createToolSurface?.({}) ?? [];
+    const execTool = sourceTools.find((tool) => tool.name === "exec");
+    const createProjection = resolveAgentHarnessScheduledToolProjectionCapability({
+      hostCapabilities: host.capabilities,
+      ownerPluginId: "codex",
+    });
+    if (!execTool || !createProjection) {
+      throw new Error("expected host-created exec projection test surface");
+    }
+    const alias = createProjection(execTool, {
+      kind: "exec",
+      name: "gateway_exec",
+      description: "Gateway exec",
+      followupText: "Use gateway_process for follow-up.",
+    });
+    expect(readCronScheduledToolProjection(alias)).toEqual({
+      targetTool: "exec",
+      execTarget: { host: "gateway" },
+    });
+
+    // A shallow same-name copy is a different object: no projection identity.
+    expect(readCronScheduledToolProjection({ ...alias })).toBeUndefined();
+
+    // Swapping the alias executable after host creation is a tamper signal.
+    const renamedAlias = { ...alias };
+    Object.assign(alias, { execute: async () => ({ content: [], details: {} }) });
+    expect(() => readCronScheduledToolProjection(alias)).toThrow("changed after host creation");
+    Object.assign(alias, { execute: renamedAlias.execute });
+
+    // A source whose executable was swapped is not the host-created shell tool.
+    const forgedExecute = async () => ({ content: [], details: {} });
+    const sourceExecute = execTool.execute;
+    execTool.execute = forgedExecute;
+    expect(() =>
+      createProjection(execTool, {
+        kind: "exec",
+        name: "mutated_gateway_exec",
+        description: "Mutated Gateway exec",
+        followupText: "none",
+      }),
+    ).toThrow("was not created by this host capability");
+    execTool.execute = sourceExecute;
+
+    // A plugin-bound copy of exec is not the host-created source object.
+    const pluginExec = { ...execTool, name: "exec" };
+    const [boundPluginExec] = host.capabilities.bindToolSurface([pluginExec]);
+    expect(() =>
+      createProjection(boundPluginExec!, {
+        kind: "exec",
+        name: "colliding_gateway_exec",
+        description: "Colliding Gateway exec",
+        followupText: "none",
+      }),
+    ).toThrow("was not created by this host capability");
+
+    // A non-shell host tool renamed to exec never gains shell projection rights.
+    const nonShellTool = sourceTools.find(
+      (tool) => tool.name !== "exec" && tool.name !== "process",
+    );
+    if (!nonShellTool) {
+      throw new Error("expected a non-shell host-created tool");
+    }
+    nonShellTool.name = "exec";
+    expect(() =>
+      createProjection(nonShellTool, {
+        kind: "exec",
+        name: "forged_gateway_exec",
+        description: "Forged Gateway exec",
+        followupText: "none",
+      }),
+    ).toThrow("was not created by this host capability");
+
+    host.close();
+    expect(() => readCronScheduledToolProjection(alias)).toThrow();
+  });
+
+  it("keeps scheduled shell issuance private to the registered owner plugin", async () => {
+    const attempt = await admittedAttempt("run-non-codex-projection");
+    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "other-harness" });
+
+    expect(
+      resolveAgentHarnessScheduledToolProjectionCapability({
+        hostCapabilities: host.capabilities,
+        ownerPluginId: "codex",
+      }),
+    ).toBeUndefined();
+    host.close();
+  });
+
+  it("constructs scheduled exec projections with host-owned policy", async () => {
+    const execute = vi.fn(async () => ({
+      content: [
+        {
+          type: "text" as const,
+          text: "Command still running. Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
+        },
+      ],
+      details: {},
+    }));
+    const source = {
+      name: "exec",
+      label: "Exec",
+      description: "exec",
+      parameters: Type.Object({}),
+      execute,
+    } satisfies AnyAgentTool;
+    const alias = createCronScheduledToolProjection(source, () => {}, "exec", {
+      kind: "exec",
+      name: "gateway_exec",
+      description: "Gateway exec",
+      followupText: "Use gateway_process for follow-up.",
+      ask: "always",
+    });
+
+    const result = await alias.execute("call-1", {
+      command: "echo safe",
+      host: "node",
+      node: "remote",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-1",
+      { command: "echo safe", host: "gateway", ask: "always" },
+      undefined,
+      undefined,
+    );
+    expect(readCronScheduledToolProjection(alias)).toEqual({
+      targetTool: "exec",
+      execTarget: { host: "gateway", ask: "always" },
+    });
+    expect(result.content).toEqual([
+      { type: "text", text: "Command still running. Use gateway_process for follow-up." },
+    ]);
+  });
+});

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -427,6 +427,10 @@ describe("agent harness host capability", () => {
       undefined,
       undefined,
     );
+    expect(readCronScheduledToolProjection(alias)).toEqual({
+      targetTool: "exec",
+      execTarget: { host: "gateway", ask: "always" },
+    });
     expect(result.content).toEqual([
       { type: "text", text: "Command still running. Use gateway_process for follow-up." },
     ]);

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -36,6 +36,10 @@ import {
   runBeforeToolCallHook,
 } from "../agent-tools.before-tool-call.js";
 import {
+  createCronScheduledToolProjection,
+  readCronScheduledToolProjection,
+} from "../exec-tool-target-pinning.js";
+import {
   attachInternalToolExecutionPreparer,
   getInternalToolExecutionPreparer,
   type InternalToolExecutionPreparer,
@@ -48,6 +52,7 @@ import {
   createAgentHarnessHostCapabilities,
   retainBeforeToolCallForNativeHookRelay,
 } from "./host-capability.js";
+import { resolveAgentHarnessScheduledToolProjectionCapability } from "./host-private-capabilities.js";
 
 vi.mock("../agent-tools.before-tool-call.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../agent-tools.before-tool-call.js")>()),
@@ -289,6 +294,142 @@ describe("agent harness host capability", () => {
       }
       fs.rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("issues scheduled shell projections only from this host-created tool surface", async () => {
+    const { attempt } = await admittedAttempt("run-scheduled-tool-projection");
+    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
+    const sourceTools = host.capabilities.createToolSurface?.({}) ?? [];
+    const execTool = sourceTools.find((tool) => tool.name === "exec");
+    const createProjection = resolveAgentHarnessScheduledToolProjectionCapability({
+      hostCapabilities: host.capabilities,
+      ownerPluginId: "codex",
+    });
+    if (!execTool || !createProjection) {
+      throw new Error("expected host-created exec projection test surface");
+    }
+    const alias = createProjection(execTool, {
+      kind: "exec",
+      name: "gateway_exec",
+      description: "Gateway exec",
+      followupText: "Use gateway_process for follow-up.",
+    });
+    expect(readCronScheduledToolProjection(alias)).toEqual({
+      targetTool: "exec",
+      execTarget: { host: "gateway" },
+    });
+
+    // A shallow same-name copy is a different object: no projection identity.
+    expect(readCronScheduledToolProjection({ ...alias })).toBeUndefined();
+
+    // Swapping the alias executable after host creation is a tamper signal.
+    const renamedAlias = { ...alias };
+    Object.assign(alias, { execute: async () => ({ content: [], details: {} }) });
+    expect(() => readCronScheduledToolProjection(alias)).toThrow("changed after host creation");
+    Object.assign(alias, { execute: renamedAlias.execute });
+
+    // A source whose executable was swapped is not the host-created shell tool.
+    const forgedExecute = async () => ({ content: [], details: {} });
+    const sourceExecute = execTool.execute;
+    execTool.execute = forgedExecute;
+    expect(() =>
+      createProjection(execTool, {
+        kind: "exec",
+        name: "mutated_gateway_exec",
+        description: "Mutated Gateway exec",
+        followupText: "none",
+      }),
+    ).toThrow("was not created by this host capability");
+    execTool.execute = sourceExecute;
+
+    // A plugin-bound copy of exec is not the host-created source object.
+    const pluginExec = { ...execTool, name: "exec" };
+    const [boundPluginExec] = host.capabilities.bindToolSurface([pluginExec]);
+    expect(() =>
+      createProjection(boundPluginExec!, {
+        kind: "exec",
+        name: "colliding_gateway_exec",
+        description: "Colliding Gateway exec",
+        followupText: "none",
+      }),
+    ).toThrow("was not created by this host capability");
+
+    // A non-shell host tool renamed to exec never gains shell projection rights.
+    const nonShellTool = sourceTools.find(
+      (tool) => tool.name !== "exec" && tool.name !== "process",
+    );
+    if (!nonShellTool) {
+      throw new Error("expected a non-shell host-created tool");
+    }
+    nonShellTool.name = "exec";
+    expect(() =>
+      createProjection(nonShellTool, {
+        kind: "exec",
+        name: "forged_gateway_exec",
+        description: "Forged Gateway exec",
+        followupText: "none",
+      }),
+    ).toThrow("was not created by this host capability");
+
+    host.close();
+    expect(() => readCronScheduledToolProjection(alias)).toThrow();
+  });
+
+  it("keeps scheduled shell issuance private to the registered owner plugin", async () => {
+    const { attempt } = await admittedAttempt("run-non-codex-projection");
+    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "other-harness" });
+
+    expect(
+      resolveAgentHarnessScheduledToolProjectionCapability({
+        hostCapabilities: host.capabilities,
+        ownerPluginId: "codex",
+      }),
+    ).toBeUndefined();
+    host.close();
+  });
+
+  it("constructs scheduled exec projections with host-owned policy", async () => {
+    const execute = vi.fn(async () => ({
+      content: [
+        {
+          type: "text" as const,
+          text: "Command still running. Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
+        },
+      ],
+      details: {},
+    }));
+    const source = {
+      name: "exec",
+      label: "Exec",
+      description: "exec",
+      parameters: Type.Object({}),
+      execute,
+    } satisfies AnyAgentTool;
+    const alias = createCronScheduledToolProjection(source, () => {}, "exec", {
+      kind: "exec",
+      name: "gateway_exec",
+      description: "Gateway exec",
+      followupText: "Use gateway_process for follow-up.",
+      ask: "always",
+    });
+
+    const result = await alias.execute("call-1", {
+      command: "echo safe",
+      host: "node",
+      node: "remote",
+      security: "full",
+      ask: "off",
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-1",
+      { command: "echo safe", host: "gateway", ask: "always" },
+      undefined,
+      undefined,
+    );
+    expect(result.content).toEqual([
+      { type: "text", text: "Command still running. Use gateway_process for follow-up." },
+    ]);
   });
 
   it("overwrites plugin policy fields with the host snapshot and revokes lexically", async () => {

--- a/src/agents/harness/host-capability.test.ts
+++ b/src/agents/harness/host-capability.test.ts
@@ -36,10 +36,6 @@ import {
   runBeforeToolCallHook,
 } from "../agent-tools.before-tool-call.js";
 import {
-  createCronScheduledToolProjection,
-  readCronScheduledToolProjection,
-} from "../exec-tool-target-pinning.js";
-import {
   attachInternalToolExecutionPreparer,
   getInternalToolExecutionPreparer,
   type InternalToolExecutionPreparer,
@@ -52,7 +48,6 @@ import {
   createAgentHarnessHostCapabilities,
   retainBeforeToolCallForNativeHookRelay,
 } from "./host-capability.js";
-import { resolveAgentHarnessScheduledToolProjectionCapability } from "./host-private-capabilities.js";
 
 vi.mock("../agent-tools.before-tool-call.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../agent-tools.before-tool-call.js")>()),
@@ -294,146 +289,6 @@ describe("agent harness host capability", () => {
       }
       fs.rmSync(root, { recursive: true, force: true });
     }
-  });
-
-  it("issues scheduled shell projections only from this host-created tool surface", async () => {
-    const { attempt } = await admittedAttempt("run-scheduled-tool-projection");
-    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "codex" });
-    const sourceTools = host.capabilities.createToolSurface?.({}) ?? [];
-    const execTool = sourceTools.find((tool) => tool.name === "exec");
-    const createProjection = resolveAgentHarnessScheduledToolProjectionCapability({
-      hostCapabilities: host.capabilities,
-      ownerPluginId: "codex",
-    });
-    if (!execTool || !createProjection) {
-      throw new Error("expected host-created exec projection test surface");
-    }
-    const alias = createProjection(execTool, {
-      kind: "exec",
-      name: "gateway_exec",
-      description: "Gateway exec",
-      followupText: "Use gateway_process for follow-up.",
-    });
-    expect(readCronScheduledToolProjection(alias)).toEqual({
-      targetTool: "exec",
-      execTarget: { host: "gateway" },
-    });
-
-    // A shallow same-name copy is a different object: no projection identity.
-    expect(readCronScheduledToolProjection({ ...alias })).toBeUndefined();
-
-    // Swapping the alias executable after host creation is a tamper signal.
-    const renamedAlias = { ...alias };
-    Object.assign(alias, { execute: async () => ({ content: [], details: {} }) });
-    expect(() => readCronScheduledToolProjection(alias)).toThrow("changed after host creation");
-    Object.assign(alias, { execute: renamedAlias.execute });
-
-    // A source whose executable was swapped is not the host-created shell tool.
-    const forgedExecute = async () => ({ content: [], details: {} });
-    const sourceExecute = execTool.execute;
-    execTool.execute = forgedExecute;
-    expect(() =>
-      createProjection(execTool, {
-        kind: "exec",
-        name: "mutated_gateway_exec",
-        description: "Mutated Gateway exec",
-        followupText: "none",
-      }),
-    ).toThrow("was not created by this host capability");
-    execTool.execute = sourceExecute;
-
-    // A plugin-bound copy of exec is not the host-created source object.
-    const pluginExec = { ...execTool, name: "exec" };
-    const [boundPluginExec] = host.capabilities.bindToolSurface([pluginExec]);
-    expect(() =>
-      createProjection(boundPluginExec!, {
-        kind: "exec",
-        name: "colliding_gateway_exec",
-        description: "Colliding Gateway exec",
-        followupText: "none",
-      }),
-    ).toThrow("was not created by this host capability");
-
-    // A non-shell host tool renamed to exec never gains shell projection rights.
-    const nonShellTool = sourceTools.find(
-      (tool) => tool.name !== "exec" && tool.name !== "process",
-    );
-    if (!nonShellTool) {
-      throw new Error("expected a non-shell host-created tool");
-    }
-    nonShellTool.name = "exec";
-    expect(() =>
-      createProjection(nonShellTool, {
-        kind: "exec",
-        name: "forged_gateway_exec",
-        description: "Forged Gateway exec",
-        followupText: "none",
-      }),
-    ).toThrow("was not created by this host capability");
-
-    host.close();
-    expect(() => readCronScheduledToolProjection(alias)).toThrow();
-  });
-
-  it("keeps scheduled shell issuance private to the registered owner plugin", async () => {
-    const { attempt } = await admittedAttempt("run-non-codex-projection");
-    const host = createAgentHarnessHostCapabilities({ attempt, pluginId: "other-harness" });
-
-    expect(
-      resolveAgentHarnessScheduledToolProjectionCapability({
-        hostCapabilities: host.capabilities,
-        ownerPluginId: "codex",
-      }),
-    ).toBeUndefined();
-    host.close();
-  });
-
-  it("constructs scheduled exec projections with host-owned policy", async () => {
-    const execute = vi.fn(async () => ({
-      content: [
-        {
-          type: "text" as const,
-          text: "Command still running. Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.",
-        },
-      ],
-      details: {},
-    }));
-    const source = {
-      name: "exec",
-      label: "Exec",
-      description: "exec",
-      parameters: Type.Object({}),
-      execute,
-    } satisfies AnyAgentTool;
-    const alias = createCronScheduledToolProjection(source, () => {}, "exec", {
-      kind: "exec",
-      name: "gateway_exec",
-      description: "Gateway exec",
-      followupText: "Use gateway_process for follow-up.",
-      ask: "always",
-    });
-
-    const result = await alias.execute("call-1", {
-      command: "echo safe",
-      host: "node",
-      node: "remote",
-      security: "full",
-      ask: "off",
-    });
-
-    expect(execute).toHaveBeenCalledWith(
-      "call-1",
-      { command: "echo safe", host: "gateway", ask: "always" },
-      undefined,
-      undefined,
-    );
-    expect(readCronScheduledToolProjection(alias)).toEqual({
-      targetTool: "exec",
-      execTarget: { host: "gateway", ask: "always" },
-    });
-    expect(result.content).toEqual([
-      { type: "text", text: "Command still running. Use gateway_process for follow-up." },
-    ]);
   });
 
   it("overwrites plugin policy fields with the host snapshot and revokes lexically", async () => {

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -36,8 +36,8 @@ import {
 } from "../tools/gateway-caller-context.js";
 import { callGatewayTool } from "../tools/gateway.js";
 import type { AgentHarnessHostCapabilities } from "./host-capability-types.js";
-import { createSessionNodeInvocation } from "./node-execution-authority.js";
 import { registerAgentHarnessScheduledToolProjectionCapability } from "./host-private-capabilities.js";
+import { createSessionNodeInvocation } from "./node-execution-authority.js";
 
 type AgentHarnessHostAttempt = Partial<EmbeddedRunAttemptParams> &
   Pick<EmbeddedRunAttemptParams, "admittedRunContext" | "runId">;

--- a/src/agents/harness/host-capability.ts
+++ b/src/agents/harness/host-capability.ts
@@ -20,6 +20,7 @@ import {
 } from "../agent-tools.before-tool-call.js";
 import { createOpenClawCodingTools } from "../agent-tools.js";
 import type { EmbeddedRunAttemptParams } from "../embedded-agent-runner/run/types.js";
+import { createCronScheduledToolProjection } from "../exec-tool-target-pinning.js";
 import { prepareGitHubToolEnvironment } from "../github-tool-identity.js";
 import {
   attachInternalToolExecutionPreparer,
@@ -36,6 +37,7 @@ import {
 import { callGatewayTool } from "../tools/gateway.js";
 import type { AgentHarnessHostCapabilities } from "./host-capability-types.js";
 import { createSessionNodeInvocation } from "./node-execution-authority.js";
+import { registerAgentHarnessScheduledToolProjectionCapability } from "./host-private-capabilities.js";
 
 type AgentHarnessHostAttempt = Partial<EmbeddedRunAttemptParams> &
   Pick<EmbeddedRunAttemptParams, "admittedRunContext" | "runId">;
@@ -308,6 +310,10 @@ export function createAgentHarnessHostCapabilities(params: {
   });
 
   const trajectoryRecorder = attempt.trajectoryRecorder;
+  const scheduledToolSources = new WeakMap<
+    AnyAgentTool,
+    Readonly<{ targetTool: "exec" | "process"; execute: AnyAgentTool["execute"] }>
+  >();
   const bindToolSurface: AgentHarnessHostCapabilities["bindToolSurface"] = (tools, options) => {
     assertActive();
     const boundAbortSignal = attempt.abortSignal
@@ -359,10 +365,19 @@ export function createAgentHarnessHostCapabilities(params: {
     bindToolSurface,
     createToolSurface: (options, bindingOptions) => {
       assertActive();
-      return bindToolSurface(
+      const tools = bindToolSurface(
         createOpenClawCodingTools({ ...options, operationalRunInstance }),
         bindingOptions,
       );
+      for (const tool of tools) {
+        if (tool.name === "exec" || tool.name === "process") {
+          scheduledToolSources.set(
+            tool,
+            Object.freeze({ targetTool: tool.name, execute: tool.execute }),
+          );
+        }
+      }
+      return tools;
     },
     prepareMutableFileApproval: async (request) => {
       assertActive();
@@ -435,6 +450,27 @@ export function createAgentHarnessHostCapabilities(params: {
         decision: result.decision,
         terminalReason: result.terminalReason,
       };
+    },
+  });
+  registerAgentHarnessScheduledToolProjectionCapability({
+    hostCapabilities: capabilities,
+    ownerPluginId: params.pluginId,
+    create: (sourceTool, projection) => {
+      assertActive();
+      const source = scheduledToolSources.get(sourceTool);
+      if (
+        !source ||
+        sourceTool.name !== source.targetTool ||
+        sourceTool.execute !== source.execute
+      ) {
+        throw new Error("scheduled tool projection source was not created by this host capability");
+      }
+      return createCronScheduledToolProjection(
+        sourceTool,
+        assertActive,
+        source.targetTool,
+        projection,
+      );
     },
   });
   return {

--- a/src/agents/harness/host-private-capabilities.ts
+++ b/src/agents/harness/host-private-capabilities.ts
@@ -1,0 +1,36 @@
+import type { CronScheduledToolProjectionRequest } from "../exec-tool-target-pinning.js";
+import type { AnyAgentTool } from "../tools/common.js";
+import type { AgentHarnessHostCapabilities } from "./host-capability-types.js";
+
+export type AgentHarnessScheduledToolProjectionFactory = (
+  sourceTool: AnyAgentTool,
+  projection: CronScheduledToolProjectionRequest,
+) => AnyAgentTool;
+
+const scheduledToolProjectionCapabilities = new WeakMap<
+  AgentHarnessHostCapabilities,
+  Readonly<{
+    ownerPluginId: string;
+    create: AgentHarnessScheduledToolProjectionFactory;
+  }>
+>();
+
+export function registerAgentHarnessScheduledToolProjectionCapability(params: {
+  hostCapabilities: AgentHarnessHostCapabilities;
+  ownerPluginId: string;
+  create: AgentHarnessScheduledToolProjectionFactory;
+}): void {
+  scheduledToolProjectionCapabilities.set(
+    params.hostCapabilities,
+    Object.freeze({ ownerPluginId: params.ownerPluginId, create: params.create }),
+  );
+}
+
+/** Resolves a private issuer only for the exact authoritative plugin owner. */
+export function resolveAgentHarnessScheduledToolProjectionCapability(params: {
+  hostCapabilities: AgentHarnessHostCapabilities;
+  ownerPluginId: string;
+}): AgentHarnessScheduledToolProjectionFactory | undefined {
+  const capability = scheduledToolProjectionCapabilities.get(params.hostCapabilities);
+  return capability?.ownerPluginId === params.ownerPluginId ? capability.create : undefined;
+}

--- a/src/agents/scheduled-tool-policy.test.ts
+++ b/src/agents/scheduled-tool-policy.test.ts
@@ -138,4 +138,51 @@ describe("resolveScheduledToolCallerContext", () => {
       }),
     ).toEqual({ accountId: "creator", channel: undefined, local: true, scheduled: true });
   });
+
+  it("attaches the restrict-only exec pin from the persisted job field", () => {
+    expect(
+      resolveScheduledToolPolicyContext({
+        toolsAllow: ["exec"],
+        scheduledToolPolicy: { version: 1, mode: "trusted" },
+        execTarget: { version: 1, host: "gateway" },
+      }),
+    ).toEqual({ version: 1, mode: "trusted", execTarget: { host: "gateway" } });
+  });
+
+  it("preserves the pin when re-resolving an already-resolved context", () => {
+    const first = resolveScheduledToolPolicyContext({
+      toolsAllow: ["exec"],
+      scheduledToolPolicy: {
+        version: 1,
+        mode: "account",
+        ownerSessionKey: "agent:main:main",
+        ownerAccountId: "creator",
+      },
+      execTarget: { version: 1, host: "gateway" },
+    });
+    expect(first?.execTarget).toEqual({ host: "gateway" });
+    const again = resolveScheduledToolPolicyContext({
+      toolsAllow: ["exec"],
+      scheduledToolPolicy: first,
+      execTarget: first?.execTarget,
+    });
+    expect(again?.execTarget).toEqual({ host: "gateway" });
+  });
+
+  it("ignores invalid exec pin shapes instead of widening or failing", () => {
+    for (const execTarget of [
+      { version: 2, host: "gateway" },
+      { version: 1, host: "node" },
+      "gateway",
+      null,
+    ]) {
+      expect(
+        resolveScheduledToolPolicyContext({
+          toolsAllow: ["exec"],
+          scheduledToolPolicy: { version: 1, mode: "trusted" },
+          execTarget,
+        })?.execTarget,
+      ).toBeUndefined();
+    }
+  });
 });

--- a/src/agents/scheduled-tool-policy.test.ts
+++ b/src/agents/scheduled-tool-policy.test.ts
@@ -149,6 +149,19 @@ describe("resolveScheduledToolCallerContext", () => {
     ).toEqual({ version: 1, mode: "trusted", execTarget: { host: "gateway" } });
   });
 
+  it("preserves a trusted context's pin when re-resolved through the same API", () => {
+    const first = resolveScheduledToolPolicyContext({
+      toolsAllow: ["exec"],
+      scheduledToolPolicy: { version: 1, mode: "trusted" },
+      execTarget: { version: 1, host: "gateway" },
+    });
+    const again = resolveScheduledToolPolicyContext({
+      toolsAllow: ["exec"],
+      scheduledToolPolicy: first,
+    });
+    expect(again).toEqual({ version: 1, mode: "trusted", execTarget: { host: "gateway" } });
+  });
+
   it("preserves the pin when re-resolving an already-resolved context", () => {
     const first = resolveScheduledToolPolicyContext({
       toolsAllow: ["exec"],

--- a/src/agents/scheduled-tool-policy.test.ts
+++ b/src/agents/scheduled-tool-policy.test.ts
@@ -144,22 +144,30 @@ describe("resolveScheduledToolCallerContext", () => {
       resolveScheduledToolPolicyContext({
         toolsAllow: ["exec"],
         scheduledToolPolicy: { version: 1, mode: "trusted" },
-        execTarget: { version: 1, host: "gateway" },
+        execTarget: { version: 1, host: "gateway", ask: "always" },
       }),
-    ).toEqual({ version: 1, mode: "trusted", execTarget: { host: "gateway" } });
+    ).toEqual({
+      version: 1,
+      mode: "trusted",
+      execTarget: { host: "gateway", ask: "always" },
+    });
   });
 
   it("preserves a trusted context's pin when re-resolved through the same API", () => {
     const first = resolveScheduledToolPolicyContext({
       toolsAllow: ["exec"],
       scheduledToolPolicy: { version: 1, mode: "trusted" },
-      execTarget: { version: 1, host: "gateway" },
+      execTarget: { version: 1, host: "gateway", ask: "always" },
     });
     const again = resolveScheduledToolPolicyContext({
       toolsAllow: ["exec"],
       scheduledToolPolicy: first,
     });
-    expect(again).toEqual({ version: 1, mode: "trusted", execTarget: { host: "gateway" } });
+    expect(again).toEqual({
+      version: 1,
+      mode: "trusted",
+      execTarget: { host: "gateway", ask: "always" },
+    });
   });
 
   it("preserves the pin when re-resolving an already-resolved context", () => {
@@ -171,15 +179,15 @@ describe("resolveScheduledToolCallerContext", () => {
         ownerSessionKey: "agent:main:main",
         ownerAccountId: "creator",
       },
-      execTarget: { version: 1, host: "gateway" },
+      execTarget: { version: 1, host: "gateway", ask: "always" },
     });
-    expect(first?.execTarget).toEqual({ host: "gateway" });
+    expect(first?.execTarget).toEqual({ host: "gateway", ask: "always" });
     const again = resolveScheduledToolPolicyContext({
       toolsAllow: ["exec"],
       scheduledToolPolicy: first,
       execTarget: first?.execTarget,
     });
-    expect(again?.execTarget).toEqual({ host: "gateway" });
+    expect(again?.execTarget).toEqual({ host: "gateway", ask: "always" });
   });
 
   it("ignores invalid exec pin shapes instead of widening or failing", () => {

--- a/src/agents/scheduled-tool-policy.ts
+++ b/src/agents/scheduled-tool-policy.ts
@@ -52,6 +52,9 @@ export function resolveScheduledToolPolicyContext(params: {
     return undefined;
   }
   const rawPolicy = params.scheduledToolPolicy;
+  // Already-resolved contexts carry context-only fields (ownerOrigin,
+  // execTarget) that the strict persisted-policy normalizer rejects; rebuild
+  // the closed policy shape for both modes before normalizing.
   const policy = normalizeCronScheduledToolPolicy(
     isRecord(rawPolicy) && rawPolicy.mode === "account"
       ? {
@@ -60,7 +63,9 @@ export function resolveScheduledToolPolicyContext(params: {
           ownerSessionKey: rawPolicy.ownerSessionKey,
           ownerAccountId: rawPolicy.ownerAccountId,
         }
-      : rawPolicy,
+      : isRecord(rawPolicy) && rawPolicy.mode === "trusted"
+        ? { version: rawPolicy.version, mode: rawPolicy.mode }
+        : rawPolicy,
   );
   if (!policy) {
     return undefined;

--- a/src/agents/scheduled-tool-policy.ts
+++ b/src/agents/scheduled-tool-policy.ts
@@ -7,12 +7,16 @@ import {
 } from "../cron/scheduled-tool-policy.js";
 
 /** Trusted runtime context for a scheduled run with a server-stamped tool cap. */
-export type ScheduledToolPolicyContext =
+export type ScheduledToolPolicyContext = (
   | Extract<CronScheduledToolPolicy, { mode: "trusted" }>
   | (Extract<CronScheduledToolPolicy, { mode: "account" }> & {
       /** Missing legacy runtime contexts are treated as unknown and fail closed. */
       ownerOrigin?: CronScheduledToolCallerOrigin;
-    });
+    })
+) & {
+  /** Restrict-only pin for the rebuilt exec tool; absence keeps baseline exec. */
+  execTarget?: { host: "gateway" };
+};
 
 /** Separates a scheduled creator's authorization identity from its delivery route. */
 export function resolveScheduledToolCallerContext(params: {
@@ -42,6 +46,7 @@ export function resolveScheduledToolPolicyContext(params: {
   toolsAllow?: readonly string[];
   scheduledToolPolicy?: unknown;
   callerOrigin?: unknown;
+  execTarget?: unknown;
 }): ScheduledToolPolicyContext | undefined {
   if (params.toolsAllow === undefined) {
     return undefined;
@@ -57,13 +62,27 @@ export function resolveScheduledToolPolicyContext(params: {
         }
       : rawPolicy,
   );
-  if (!policy || policy.mode === "trusted") {
-    return policy;
+  if (!policy) {
+    return undefined;
+  }
+  // Accept the persisted `{version: 1, host}` shape and an already-resolved
+  // context's bare `{host}` shape; anything else keeps the baseline (no pin).
+  const rawExecTarget =
+    params.execTarget ?? (isRecord(rawPolicy) ? rawPolicy.execTarget : undefined);
+  const pinned =
+    isRecord(rawExecTarget) &&
+    rawExecTarget.host === "gateway" &&
+    (rawExecTarget.version === undefined || rawExecTarget.version === 1)
+      ? { execTarget: { host: "gateway" as const } }
+      : {};
+  if (policy.mode === "trusted") {
+    return { ...policy, ...pinned };
   }
   return {
     ...policy,
     ownerOrigin: normalizeCronScheduledToolCallerOrigin(
       params.callerOrigin ?? (isRecord(rawPolicy) ? rawPolicy.ownerOrigin : undefined),
     ),
+    ...pinned,
   };
 }

--- a/src/agents/scheduled-tool-policy.ts
+++ b/src/agents/scheduled-tool-policy.ts
@@ -14,8 +14,8 @@ export type ScheduledToolPolicyContext = (
       ownerOrigin?: CronScheduledToolCallerOrigin;
     })
 ) & {
-  /** Restrict-only pin for the rebuilt exec tool; absence keeps baseline exec. */
-  execTarget?: { host: "gateway" };
+  /** Restrict-only policy for the rebuilt exec tool; absence keeps baseline exec. */
+  execTarget?: { host: "gateway"; ask?: "always" };
 };
 
 /** Separates a scheduled creator's authorization identity from its delivery route. */
@@ -78,7 +78,12 @@ export function resolveScheduledToolPolicyContext(params: {
     isRecord(rawExecTarget) &&
     rawExecTarget.host === "gateway" &&
     (rawExecTarget.version === undefined || rawExecTarget.version === 1)
-      ? { execTarget: { host: "gateway" as const } }
+      ? {
+          execTarget: {
+            host: "gateway" as const,
+            ...(rawExecTarget.ask === "always" ? { ask: "always" as const } : {}),
+          },
+        }
       : {};
   if (policy.mode === "trusted") {
     return { ...policy, ...pinned };

--- a/src/agents/tools/cron-tool-creator-cap.test.ts
+++ b/src/agents/tools/cron-tool-creator-cap.test.ts
@@ -1,7 +1,36 @@
+import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { mergeCronPayload } from "../../cron/service/payload-merge.js";
 import type { CronPayloadPatch } from "../../cron/types.js";
-import { capCronJobToolsAllowOnCreate, planCronJobUpdatePatch } from "./cron-tool-creator-cap.js";
+import { createCronScheduledToolProjection } from "../exec-tool-target-pinning.js";
+import type { AnyAgentTool } from "./common.js";
+import {
+  capCronJobToolsAllowOnCreate,
+  cronCreateRequiresCreatorAuthority,
+  planCronJobUpdatePatch,
+  replaceWithEffectiveCronCreatorToolAllowlist,
+  resolveCronCreatorExecToolTarget,
+} from "./cron-tool-creator-cap.js";
+import type { CronCreatorToolAllowlistEntry } from "./cron-tool.types.js";
+
+function testTool(name: string): AnyAgentTool {
+  return {
+    name,
+    label: name,
+    description: `${name} tool`,
+    parameters: Type.Object({}),
+    execute: async () => ({ content: [], details: {} }),
+  };
+}
+
+function gatewayExecAlias(execTool: AnyAgentTool): AnyAgentTool {
+  return createCronScheduledToolProjection(execTool, () => {}, "exec", {
+    kind: "exec",
+    name: "gateway_exec",
+    description: "Gateway exec alias",
+    followupText: "Use gateway_process for follow-up.",
+  });
+}
 
 type CronJobUpdatePatchPlan = ReturnType<typeof planCronJobUpdatePatch>;
 
@@ -145,5 +174,87 @@ describe("cron tool creator cap", () => {
         }),
       ),
     ).toEqual({ payload: { kind: "agentTurn", model: null } });
+  });
+
+  it("captures a host-created gateway alias under its canonical exec identity", () => {
+    const alias = gatewayExecAlias(testTool("exec"));
+    const target: CronCreatorToolAllowlistEntry[] = [];
+
+    replaceWithEffectiveCronCreatorToolAllowlist(target, [alias, testTool("read")]);
+
+    expect(target).toEqual([
+      { name: "exec", aliasName: "gateway_exec", execTarget: { host: "gateway" } },
+      { name: "read" },
+    ]);
+    expect(resolveCronCreatorExecToolTarget(target)).toEqual({ host: "gateway" });
+  });
+
+  it("captures an unregistered same-name tool literally, never as shell authority", () => {
+    const colliding = testTool("gateway_exec");
+    const target: CronCreatorToolAllowlistEntry[] = [];
+
+    replaceWithEffectiveCronCreatorToolAllowlist(target, [colliding]);
+
+    expect(target).toEqual([{ name: "gateway_exec" }]);
+    expect(resolveCronCreatorExecToolTarget(target)).toBeUndefined();
+  });
+
+  it("drops the restrict-only pin when a direct unpinned exec grant also exists", () => {
+    const execTool = testTool("exec");
+    const alias = gatewayExecAlias(testTool("exec"));
+    const aliasFirst: CronCreatorToolAllowlistEntry[] = [];
+    const directFirst: CronCreatorToolAllowlistEntry[] = [];
+
+    replaceWithEffectiveCronCreatorToolAllowlist(aliasFirst, [alias, execTool]);
+    replaceWithEffectiveCronCreatorToolAllowlist(directFirst, [execTool, alias]);
+
+    expect(aliasFirst).toEqual([{ name: "exec", aliasName: "gateway_exec" }]);
+    expect(directFirst).toEqual([{ name: "exec", aliasName: "gateway_exec" }]);
+    expect(resolveCronCreatorExecToolTarget(aliasFirst)).toBeUndefined();
+    expect(resolveCronCreatorExecToolTarget(directFirst)).toBeUndefined();
+  });
+
+  it("caps explicit alias-name requests to the canonical persisted tool id", () => {
+    const alias = gatewayExecAlias(testTool("exec"));
+    const creator: CronCreatorToolAllowlistEntry[] = [];
+    replaceWithEffectiveCronCreatorToolAllowlist(creator, [alias, testTool("read")]);
+
+    for (const requested of [["gateway_exec"], ["exec"], ["gateway_exec", "read"]]) {
+      const job = {
+        trigger: { script: "return { fire: false }" },
+        payload: { kind: "systemEvent", text: "wake", toolsAllow: [...requested] },
+      };
+      capCronJobToolsAllowOnCreate(job, creator);
+      const expected = requested.includes("read") ? ["exec", "read"] : ["exec"];
+      expect(job.payload.toolsAllow).toEqual(expected);
+    }
+
+    const unrelated = {
+      trigger: { script: "return { fire: false }" },
+      payload: { kind: "systemEvent", text: "wake", toolsAllow: ["write"] },
+    };
+    capCronJobToolsAllowOnCreate(unrelated, creator);
+    expect(unrelated.payload.toolsAllow).toEqual([]);
+  });
+
+  it("treats an alias-name finite request as already covered by creator authority", () => {
+    const alias = gatewayExecAlias(testTool("exec"));
+    const creator: CronCreatorToolAllowlistEntry[] = [];
+    replaceWithEffectiveCronCreatorToolAllowlist(creator, [alias]);
+
+    const job = {
+      trigger: { script: "return { fire: false }" },
+      payload: { kind: "systemEvent", text: "wake", toolsAllow: ["gateway_exec"] },
+    };
+    expect(cronCreateRequiresCreatorAuthority(job, creator)).toBe(false);
+    expect(
+      cronCreateRequiresCreatorAuthority(
+        {
+          trigger: { script: "return { fire: false }" },
+          payload: { kind: "systemEvent", text: "wake", toolsAllow: ["exec", "browser"] },
+        },
+        creator,
+      ),
+    ).toBe(true);
   });
 });

--- a/src/agents/tools/cron-tool-creator-cap.test.ts
+++ b/src/agents/tools/cron-tool-creator-cap.test.ts
@@ -23,12 +23,13 @@ function testTool(name: string): AnyAgentTool {
   };
 }
 
-function gatewayExecAlias(execTool: AnyAgentTool): AnyAgentTool {
+function gatewayExecAlias(execTool: AnyAgentTool, ask?: "always"): AnyAgentTool {
   return createCronScheduledToolProjection(execTool, () => {}, "exec", {
     kind: "exec",
     name: "gateway_exec",
     description: "Gateway exec alias",
     followupText: "Use gateway_process for follow-up.",
+    ...(ask ? { ask } : {}),
   });
 }
 
@@ -177,16 +178,23 @@ describe("cron tool creator cap", () => {
   });
 
   it("captures a host-created gateway alias under its canonical exec identity", () => {
-    const alias = gatewayExecAlias(testTool("exec"));
+    const alias = gatewayExecAlias(testTool("exec"), "always");
     const target: CronCreatorToolAllowlistEntry[] = [];
 
     replaceWithEffectiveCronCreatorToolAllowlist(target, [alias, testTool("read")]);
 
     expect(target).toEqual([
-      { name: "exec", aliasName: "gateway_exec", execTarget: { host: "gateway" } },
+      {
+        name: "exec",
+        aliasName: "gateway_exec",
+        execTarget: { host: "gateway", ask: "always" },
+      },
       { name: "read" },
     ]);
-    expect(resolveCronCreatorExecToolTarget(target)).toEqual({ host: "gateway" });
+    expect(resolveCronCreatorExecToolTarget(target)).toEqual({
+      host: "gateway",
+      ask: "always",
+    });
   });
 
   it("captures an unregistered same-name tool literally, never as shell authority", () => {
@@ -212,6 +220,19 @@ describe("cron tool creator cap", () => {
     expect(directFirst).toEqual([{ name: "exec", aliasName: "gateway_exec" }]);
     expect(resolveCronCreatorExecToolTarget(aliasFirst)).toBeUndefined();
     expect(resolveCronCreatorExecToolTarget(directFirst)).toBeUndefined();
+  });
+
+  it("keeps only restrictions shared by duplicate gateway aliases", () => {
+    const guarded = gatewayExecAlias(testTool("exec"), "always");
+    const unguarded = gatewayExecAlias(testTool("exec"));
+    const guardedFirst: CronCreatorToolAllowlistEntry[] = [];
+    const unguardedFirst: CronCreatorToolAllowlistEntry[] = [];
+
+    replaceWithEffectiveCronCreatorToolAllowlist(guardedFirst, [guarded, unguarded]);
+    replaceWithEffectiveCronCreatorToolAllowlist(unguardedFirst, [unguarded, guarded]);
+
+    expect(resolveCronCreatorExecToolTarget(guardedFirst)).toEqual({ host: "gateway" });
+    expect(resolveCronCreatorExecToolTarget(unguardedFirst)).toEqual({ host: "gateway" });
   });
 
   it("caps explicit alias-name requests to the canonical persisted tool id", () => {

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -55,6 +55,7 @@ export function replaceWithEffectiveCronCreatorToolAllowlist<T extends { name: s
   // the same capability. The alias name is kept for explicit-cap matching only.
   const indexByName = new Map<string, number>();
   for (const tool of tools) {
+    // SAFETY: the projection registry is keyed by object identity only; a non-tool object misses.
     const projection = readCronScheduledToolProjection(tool as unknown as AnyAgentTool);
     const name = normalizeToolPolicyName(projection ? projection.targetTool : tool.name);
     if (!name) {

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -1,4 +1,5 @@
 import { isRecord } from "../../utils.js";
+import { readCronScheduledToolProjection } from "../exec-tool-target-pinning.js";
 import { isToolAllowedByPolicyName } from "../tool-policy-match.js";
 import {
   buildPluginToolGroups,
@@ -6,11 +7,14 @@ import {
   expandToolGroups,
   normalizeToolPolicyName,
 } from "../tool-policy.js";
+import type { AnyAgentTool } from "./common.js";
 import type { CronCreatorToolAllowlistEntry, CronToolsAllowCaptureRef } from "./cron-tool.types.js";
 
 type NormalizedCronCreatorTool = {
   name: string;
   pluginId?: string;
+  aliasName?: string;
+  execTarget?: { host: "gateway" };
 };
 
 type CronJobUpdatePatchPlan =
@@ -46,17 +50,43 @@ export function replaceWithEffectiveCronCreatorToolAllowlist<T extends { name: s
   toolMeta?: (tool: T) => { pluginId?: string } | undefined,
 ): void {
   target.length = 0;
-  const seen = new Set<string>();
+  // Host-created alias projections (for example a Codex gateway shell alias) are
+  // recorded under their canonical core tool name so scheduled runtimes rebuild
+  // the same capability. The alias name is kept for explicit-cap matching only.
+  const indexByName = new Map<string, number>();
   for (const tool of tools) {
-    const name = normalizeToolPolicyName(tool.name);
-    if (!name || seen.has(name)) {
+    const projection = readCronScheduledToolProjection(tool as unknown as AnyAgentTool);
+    const name = normalizeToolPolicyName(projection ? projection.targetTool : tool.name);
+    if (!name) {
       continue;
     }
-    seen.add(name);
+    const aliasName = projection ? normalizeToolPolicyName(tool.name) : undefined;
+    const existingIndex = indexByName.get(name);
+    const existing = existingIndex === undefined ? undefined : target[existingIndex];
+    if (existing !== undefined) {
+      // Merge duplicate grants of one canonical tool: alias names stay matchable,
+      // and the restrict-only target survives only when every grantor pins it.
+      if (typeof existing === "string") {
+        continue;
+      }
+      if (aliasName && !existing.aliasName) {
+        existing.aliasName = aliasName;
+      }
+      if (existing.execTarget && !projection?.execTarget) {
+        delete existing.execTarget;
+      }
+      continue;
+    }
     const meta = toolMeta?.(tool);
     const pluginId =
       typeof meta?.pluginId === "string" ? normalizeToolPolicyName(meta.pluginId) : undefined;
-    target.push(pluginId ? { name, pluginId } : { name });
+    indexByName.set(name, target.length);
+    target.push({
+      name,
+      ...(pluginId ? { pluginId } : {}),
+      ...(aliasName && aliasName !== name ? { aliasName } : {}),
+      ...(projection?.execTarget ? { execTarget: { host: projection.execTarget.host } } : {}),
+    });
   }
 }
 
@@ -100,9 +130,32 @@ function normalizeCronCreatorToolsAllow(
       typeof entry === "string" || typeof entry.pluginId !== "string"
         ? undefined
         : normalizeToolPolicyName(entry.pluginId);
-    normalized.push(pluginId ? { name, pluginId } : { name });
+    const aliasName =
+      typeof entry === "string" || typeof entry.aliasName !== "string"
+        ? undefined
+        : normalizeToolPolicyName(entry.aliasName);
+    const execTarget =
+      typeof entry !== "string" && entry.execTarget?.host === "gateway"
+        ? ({ host: "gateway" } as const)
+        : undefined;
+    normalized.push({
+      name,
+      ...(pluginId ? { pluginId } : {}),
+      ...(aliasName && aliasName !== name ? { aliasName } : {}),
+      ...(execTarget ? { execTarget } : {}),
+    });
   }
   return normalized;
+}
+
+/** Restrict-only exec target present only when the creator's exec grant is host-pinned. */
+export function resolveCronCreatorExecToolTarget(
+  entries: readonly CronCreatorToolAllowlistEntry[] | undefined,
+): { host: "gateway" } | undefined {
+  const execEntry = normalizeCronCreatorToolsAllow(entries ?? []).find(
+    (tool) => tool.name === "exec",
+  );
+  return execEntry?.execTarget ? { host: execEntry.execTarget.host } : undefined;
 }
 
 function hasCronTriggerScript(value: unknown): boolean {
@@ -142,7 +195,9 @@ function explicitFiniteToolsNeedResolution(
     return false;
   }
   const creatorNames = new Set(
-    normalizeCronCreatorToolsAllow(creatorToolAllowlist ?? []).map((tool) => tool.name),
+    normalizeCronCreatorToolsAllow(creatorToolAllowlist ?? []).flatMap((tool) =>
+      tool.aliasName ? [tool.name, tool.aliasName] : [tool.name],
+    ),
   );
   return normalizeCronToolsAllow(
     toolsAllow.filter((entry): entry is string => typeof entry === "string"),
@@ -222,9 +277,16 @@ function capCronJobToolsAllow(params: {
     { allow: requestedToolsAllow },
     pluginGroups,
   );
-  params.payload.toolsAllow = creatorToolNames.filter((toolName) =>
-    isToolAllowedByPolicyName(toolName, requestedPolicy),
-  );
+  // A creator tool matches under its canonical name or the runtime alias the
+  // creating surface presented; the persisted cap always holds canonical names.
+  params.payload.toolsAllow = creatorToolsAllow
+    .filter(
+      (tool) =>
+        isToolAllowedByPolicyName(tool.name, requestedPolicy) ||
+        (tool.aliasName !== undefined &&
+          isToolAllowedByPolicyName(tool.aliasName, requestedPolicy)),
+    )
+    .map((tool) => tool.name);
   delete params.payload.toolsAllowIsDefault;
 }
 

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -7,7 +7,6 @@ import {
   expandToolGroups,
   normalizeToolPolicyName,
 } from "../tool-policy.js";
-import type { AnyAgentTool } from "./common.js";
 import type { CronCreatorToolAllowlistEntry, CronToolsAllowCaptureRef } from "./cron-tool.types.js";
 
 type NormalizedCronCreatorTool = {
@@ -55,8 +54,7 @@ export function replaceWithEffectiveCronCreatorToolAllowlist<T extends { name: s
   // the same capability. The alias name is kept for explicit-cap matching only.
   const indexByName = new Map<string, number>();
   for (const tool of tools) {
-    // SAFETY: the projection registry is keyed by object identity only; a non-tool object misses.
-    const projection = readCronScheduledToolProjection(tool as unknown as AnyAgentTool);
+    const projection = readCronScheduledToolProjection(tool);
     const name = normalizeToolPolicyName(projection ? projection.targetTool : tool.name);
     if (!name) {
       continue;

--- a/src/agents/tools/cron-tool-creator-cap.ts
+++ b/src/agents/tools/cron-tool-creator-cap.ts
@@ -13,7 +13,7 @@ type NormalizedCronCreatorTool = {
   name: string;
   pluginId?: string;
   aliasName?: string;
-  execTarget?: { host: "gateway" };
+  execTarget?: { host: "gateway"; ask?: "always" };
 };
 
 type CronJobUpdatePatchPlan =
@@ -73,6 +73,11 @@ export function replaceWithEffectiveCronCreatorToolAllowlist<T extends { name: s
       }
       if (existing.execTarget && !projection?.execTarget) {
         delete existing.execTarget;
+      } else if (
+        existing.execTarget?.ask === "always" &&
+        projection?.execTarget?.ask !== "always"
+      ) {
+        delete existing.execTarget.ask;
       }
       continue;
     }
@@ -84,7 +89,7 @@ export function replaceWithEffectiveCronCreatorToolAllowlist<T extends { name: s
       name,
       ...(pluginId ? { pluginId } : {}),
       ...(aliasName && aliasName !== name ? { aliasName } : {}),
-      ...(projection?.execTarget ? { execTarget: { host: projection.execTarget.host } } : {}),
+      ...(projection?.execTarget ? { execTarget: { ...projection.execTarget } } : {}),
     });
   }
 }
@@ -135,7 +140,10 @@ function normalizeCronCreatorToolsAllow(
         : normalizeToolPolicyName(entry.aliasName);
     const execTarget =
       typeof entry !== "string" && entry.execTarget?.host === "gateway"
-        ? ({ host: "gateway" } as const)
+        ? ({
+            host: "gateway" as const,
+            ...(entry.execTarget.ask === "always" ? { ask: "always" as const } : {}),
+          } as const)
         : undefined;
     normalized.push({
       name,
@@ -150,11 +158,11 @@ function normalizeCronCreatorToolsAllow(
 /** Restrict-only exec target present only when the creator's exec grant is host-pinned. */
 export function resolveCronCreatorExecToolTarget(
   entries: readonly CronCreatorToolAllowlistEntry[] | undefined,
-): { host: "gateway" } | undefined {
+): { host: "gateway"; ask?: "always" } | undefined {
   const execEntry = normalizeCronCreatorToolsAllow(entries ?? []).find(
     (tool) => tool.name === "exec",
   );
-  return execEntry?.execTarget ? { host: execEntry.execTarget.host } : undefined;
+  return execEntry?.execTarget ? { ...execEntry.execTarget } : undefined;
 }
 
 function hasCronTriggerScript(value: unknown): boolean {

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -48,6 +48,7 @@ import {
   assertInheritedCronToolCaptureReady,
   capCronJobToolsAllowOnCreate,
   cronCreateRequiresCreatorAuthority,
+  resolveCronCreatorExecToolTarget,
 } from "./cron-tool-creator-cap.js";
 import {
   assertCronPacingInput,
@@ -235,6 +236,7 @@ export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): Any
       };
       const runtimeConfig = getRuntimeConfig();
       const callerScope = resolveCronToolCallerScope(opts, runtimeConfig);
+      const creatorExecToolTarget = resolveCronCreatorExecToolTarget(opts?.creatorToolAllowlist);
       const callerIdentity =
         callerScope && opts?.agentSessionKey?.trim()
           ? {
@@ -246,7 +248,10 @@ export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): Any
                 : {}),
               ...(opts?.creatorToolAllowlistCaptureRef?.value?.version === 1 &&
               opts.creatorToolAllowlistCaptureRef.value.source === "final-executable-surface"
-                ? { cronToolsAllowCapture: "final-executable-surface" as const }
+                ? {
+                    cronToolsAllowCapture: "final-executable-surface" as const,
+                    ...(creatorExecToolTarget ? { cronExecToolTarget: creatorExecToolTarget } : {}),
+                  }
                 : {}),
             }
           : undefined;
@@ -485,11 +490,17 @@ export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): Any
                 }
               }
             }
+            const resolvedExecToolTarget = resolveCronCreatorExecToolTarget(
+              resolvedAuthority?.tools,
+            );
             const writeCallerIdentity =
               resolvedAuthority && callerIdentity
                 ? {
                     ...callerIdentity,
                     cronToolsAllowCapture: "final-executable-surface" as const,
+                    ...(resolvedExecToolTarget
+                      ? { cronExecToolTarget: resolvedExecToolTarget }
+                      : {}),
                     cronCreatorAuthorityGrant: resolvedAuthority.grant,
                   }
                 : callerIdentity;
@@ -560,15 +571,22 @@ export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): Any
                 creatorToolAllowlistCaptureRef: opts?.creatorToolAllowlistCaptureRef,
                 resolveCreatorToolAuthority: opts?.resolveCreatorToolAuthority,
                 withCreatorAuthorityProvenance: callerIdentity
-                  ? async (authority, run) =>
-                      await withGatewayToolCallerIdentity(
+                  ? async (authority, run) => {
+                      const authorityExecToolTarget = resolveCronCreatorExecToolTarget(
+                        authority.tools,
+                      );
+                      return await withGatewayToolCallerIdentity(
                         {
                           ...callerIdentity,
                           cronToolsAllowCapture: "final-executable-surface",
+                          ...(authorityExecToolTarget
+                            ? { cronExecToolTarget: authorityExecToolTarget }
+                            : {}),
                           cronCreatorAuthorityGrant: authority.grant,
                         },
                         run,
-                      )
+                      );
+                    }
                   : undefined,
                 gatewayOpts,
                 callGateway,

--- a/src/agents/tools/cron-tool.types.ts
+++ b/src/agents/tools/cron-tool.types.ts
@@ -8,8 +8,13 @@ import type { callGatewayTool } from "./gateway.js";
 export type CronCreatorToolAllowlistEntry =
   | string
   | {
+      /** Canonical policy name persisted into toolsAllow caps. */
       name: string;
       pluginId?: string;
+      /** Runtime-specific alias the creator surface presented for this tool. */
+      aliasName?: string;
+      /** Restrict-only execution target carried by a host-created alias projection. */
+      execTarget?: { host: "gateway" };
     };
 
 type CronToolsAllowCaptureProvenance = {

--- a/src/agents/tools/cron-tool.types.ts
+++ b/src/agents/tools/cron-tool.types.ts
@@ -13,8 +13,8 @@ export type CronCreatorToolAllowlistEntry =
       pluginId?: string;
       /** Runtime-specific alias the creator surface presented for this tool. */
       aliasName?: string;
-      /** Restrict-only execution target carried by a host-created alias projection. */
-      execTarget?: { host: "gateway" };
+      /** Restrict-only execution policy carried by a host-created alias projection. */
+      execTarget?: { host: "gateway"; ask?: "always" };
     };
 
 type CronToolsAllowCaptureProvenance = {

--- a/src/agents/tools/gateway-caller-context.ts
+++ b/src/agents/tools/gateway-caller-context.ts
@@ -41,6 +41,8 @@ type GatewayToolCallerIdentity = {
   /** Host-signed capability for the scheduled run's existing self-management surface. */
   cronSelfManagementJobId?: string;
   cronToolsAllowCapture?: "final-executable-surface";
+  /** Restrict-only fact: exec on the captured creator surface is host-pinned. */
+  cronExecToolTarget?: { host: "gateway" };
   /** One-shot Gateway-owned proof for a freshly resolved configured-MCP cap. */
   cronCreatorAuthorityGrant?: CronCreatorAuthorityGrant;
   // Trusted run context, carried separately from model-authored tool arguments.
@@ -205,6 +207,7 @@ export async function withGatewayToolCallerIdentity<T>(
     identity.cronSelfManagementJobId?.trim() ?? inheritedOwner?.cronSelfManagementJobId;
   const cronToolsAllowCapture =
     identity.cronToolsAllowCapture ?? inheritedOwner?.cronToolsAllowCapture;
+  const cronExecToolTarget = identity.cronExecToolTarget ?? inheritedOwner?.cronExecToolTarget;
   const cronCreatorAuthorityGrant =
     identity.cronCreatorAuthorityGrant ?? inheritedOwner?.cronCreatorAuthorityGrant;
   const turnSourceChannel = inheritedOwner?.turnSourceChannel ?? identity.turnSourceChannel?.trim();
@@ -226,6 +229,7 @@ export async function withGatewayToolCallerIdentity<T>(
       ...(signedAgentRuntimeIdentityToken ? { signedAgentRuntimeIdentityToken } : {}),
       ...(cronSelfManagementJobId ? { cronSelfManagementJobId } : {}),
       ...(cronToolsAllowCapture ? { cronToolsAllowCapture } : {}),
+      ...(cronExecToolTarget ? { cronExecToolTarget } : {}),
       ...(cronCreatorAuthorityGrant ? { cronCreatorAuthorityGrant } : {}),
       ...(executionIdentityToken ? { executionIdentityToken } : {}),
       ...(receiptAuthority ? { receiptAuthority } : {}),

--- a/src/agents/tools/gateway-caller-context.ts
+++ b/src/agents/tools/gateway-caller-context.ts
@@ -41,8 +41,8 @@ type GatewayToolCallerIdentity = {
   /** Host-signed capability for the scheduled run's existing self-management surface. */
   cronSelfManagementJobId?: string;
   cronToolsAllowCapture?: "final-executable-surface";
-  /** Restrict-only fact: exec on the captured creator surface is host-pinned. */
-  cronExecToolTarget?: { host: "gateway" };
+  /** Restrict-only policy enforced by exec on the captured creator surface. */
+  cronExecToolTarget?: { host: "gateway"; ask?: "always" };
   /** One-shot Gateway-owned proof for a freshly resolved configured-MCP cap. */
   cronCreatorAuthorityGrant?: CronCreatorAuthorityGrant;
   // Trusted run context, carried separately from model-authored tool arguments.

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -180,6 +180,39 @@ function mockExdevRename(filePath: string) {
 }
 
 describe("collectLegacyCronStoreHealthFindings", () => {
+  it("reports alias-only Gateway exec jobs with recreation guidance", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCurrentCronStore(storePath, [
+      createCurrentCronJob({
+        id: "legacy-gateway-exec",
+        name: "Legacy gateway shell",
+        scheduledToolPolicy: { version: 1, mode: "trusted" },
+        payload: {
+          kind: "agentTurn",
+          message: "run",
+          toolsAllow: ["gateway_exec"],
+        },
+      }),
+    ]);
+
+    const findings = await collectLegacyCronStoreHealthFindings({
+      cfg: createCronConfig(storePath),
+    });
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          requirement: "legacy-gateway-exec-recreation",
+          message: expect.stringContaining("retired `gateway_exec` alias"),
+          fixHint: expect.stringContaining("fresh authenticated creator turn"),
+        }),
+      ]),
+    );
+    expect((await readPersistedJobs(storePath))[0]?.payload).toMatchObject({
+      toolsAllow: ["gateway_exec"],
+    });
+  });
+
   it("reports legacy cron store, run-log, and payload findings without mutating files", async () => {
     const storePath = await makeTempStorePath();
     await writeLegacyCronArrayStore(storePath, [

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -25,6 +25,7 @@ import {
 import {
   formatLegacyIssuePreview,
   formatIncompleteInheritedAuthorityAdvisory,
+  formatLegacyGatewayExecAdvisory,
   formatScheduledToolPolicyAdvisory,
   formatUnresolvedCommandPromptAdvisory,
   formatUnresolvedShellPromptAdvisory,
@@ -304,6 +305,18 @@ export async function collectLegacyCronStoreHealthFindings(params: {
     }
   }
 
+  if (normalized.legacyGatewayExecJobs.length > 0) {
+    findings.push(
+      legacyCronStoreFinding({
+        message: `${pluralize(normalized.legacyGatewayExecJobs.length, "automation")} require recreation because they grant the retired \`gateway_exec\` alias.`,
+        path: sqliteStorePath,
+        requirement: "legacy-gateway-exec-recreation",
+        fixHint:
+          "Review the affected jobs with `openclaw automations list --all`, then recreate each one from a fresh authenticated creator turn or explicitly reauthorize its complete tool cap from a trusted operator shell.",
+      }),
+    );
+  }
+
   const notifyCount = rawJobs.filter((job) => job.notify === true).length;
   if (notifyCount > 0) {
     findings.push(
@@ -514,6 +527,12 @@ export async function maybeRepairLegacyCronStore(params: {
   });
   if (scheduledToolPolicyAdvisory) {
     note(scheduledToolPolicyAdvisory, "Cron");
+  }
+  const legacyGatewayExecAdvisory = formatLegacyGatewayExecAdvisory(
+    normalized.legacyGatewayExecJobs,
+  );
+  if (legacyGatewayExecAdvisory) {
+    note(legacyGatewayExecAdvisory, "Cron");
   }
   const staticMcpByAgentWorkspace = new Map<string, boolean>();
   const incompleteInheritedAuthorityAdvisory = formatIncompleteInheritedAuthorityAdvisory(

--- a/src/commands/doctor/cron/repair-plan.ts
+++ b/src/commands/doctor/cron/repair-plan.ts
@@ -80,6 +80,18 @@ export function formatScheduledToolPolicyAdvisory(params: {
   return lines.join("\n");
 }
 
+/** Advisory for alias-only jobs whose original exec authority cannot be proven from storage. */
+export function formatLegacyGatewayExecAdvisory(names: string[]): string | null {
+  if (names.length === 0) {
+    return null;
+  }
+  return [
+    `${pluralize(names.length, "automation")} ${names.length === 1 ? "grants" : "grant"} the retired \`gateway_exec\` alias${formatJobNameList(names)}.`,
+    "- Doctor will not convert this alias to `exec` because the stored name does not prove its original producer or approval restrictions.",
+    "- Recreate the automation from a fresh authenticated creator turn, or explicitly reauthorize its complete tool cap from a trusted operator shell.",
+  ].join("\n");
+}
+
 /** Advisory for legacy default caps that were captured before configured MCP was final. */
 export function formatIncompleteInheritedAuthorityAdvisory(names: string[]): string | null {
   if (names.length === 0) {

--- a/src/commands/doctor/cron/scheduled-tool-policy-migration.test.ts
+++ b/src/commands/doctor/cron/scheduled-tool-policy-migration.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { formatScheduledToolPolicyAdvisory } from "./repair-plan.js";
+import {
+  formatLegacyGatewayExecAdvisory,
+  formatScheduledToolPolicyAdvisory,
+} from "./repair-plan.js";
 import { normalizeStoredCronJobs } from "./store-migration.js";
 
 function job(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -123,5 +126,20 @@ describe("migrateScheduledToolPolicy", () => {
         invalidJobs: result.invalidScheduledToolPolicyJobs,
       }),
     ).toContain("openclaw cron edit <id> --tools");
+  });
+
+  it("reports alias-only Gateway exec jobs without converting their authority", () => {
+    const raw = job({
+      payload: { kind: "agentTurn", message: "run", toolsAllow: ["read", "gateway_exec"] },
+      scheduledToolPolicy: { version: 1, mode: "trusted" },
+    });
+
+    const result = normalizeStoredCronJobs([raw]);
+
+    expect(result.legacyGatewayExecJobs).toEqual(["Legacy"]);
+    expect((raw.payload as { toolsAllow: string[] }).toolsAllow).toEqual(["read", "gateway_exec"]);
+    expect(formatLegacyGatewayExecAdvisory(result.legacyGatewayExecJobs)).toContain(
+      "will not convert this alias",
+    );
   });
 });

--- a/src/commands/doctor/cron/store-migration.ts
+++ b/src/commands/doctor/cron/store-migration.ts
@@ -114,6 +114,7 @@ type NormalizeCronStoreJobsResult = {
   unsupportedLegacyTriggerScriptJobs: string[];
   legacyScheduledToolPolicyJobs: string[];
   invalidScheduledToolPolicyJobs: string[];
+  legacyGatewayExecJobs: string[];
   jobs: Array<Record<string, unknown>>;
   mutated: boolean;
   removedJobs: Array<{ job: Record<string, unknown>; reason: string; sourceIndex: number }>;
@@ -169,6 +170,7 @@ export function normalizeStoredCronJobs(
   const unresolvedAgentTurnShellToolPromptJobs: string[] = [];
   const legacyTriggerScriptJobs: string[] = [];
   const unsupportedLegacyTriggerScriptJobs: string[] = [];
+  const legacyGatewayExecJobs: string[] = [];
   const scheduledToolPolicyMigrations = createScheduledToolPolicyMigrationCollector();
   const unresolvedAgentTurnPromptJobsByKind = {
     commandPromptWithoutShellAccess: unresolvedAgentTurnCommandPromptJobs,
@@ -354,6 +356,18 @@ export function normalizeStoredCronJobs(
     }
 
     if (payloadRecord) {
+      const hasLegacyGatewayExec =
+        Array.isArray(payloadRecord.toolsAllow) &&
+        payloadRecord.toolsAllow.some(
+          (tool) =>
+            typeof tool === "string" && normalizeOptionalLowercaseString(tool) === "gateway_exec",
+        );
+      if (hasLegacyGatewayExec) {
+        const name = normalizeOptionalString(raw.name) ?? normalizeOptionalString(raw.id);
+        if (name) {
+          legacyGatewayExecJobs.push(name);
+        }
+      }
       const hadLegacyPayloadProvider = Boolean(normalizeOptionalString(payloadRecord.provider));
       const hadLegacyPayloadCodexModel = hasLegacyOpenAICodexCronModelRef(payloadRecord);
       const hadLegacyTaskSuggestionToolName = hasLegacyToolNameList(
@@ -635,6 +649,7 @@ export function normalizeStoredCronJobs(
     unsupportedLegacyTriggerScriptJobs,
     legacyScheduledToolPolicyJobs: scheduledToolPolicyMigrations.legacyJobs,
     invalidScheduledToolPolicyJobs: scheduledToolPolicyMigrations.invalidJobs,
+    legacyGatewayExecJobs,
     jobs,
     mutated,
     removedJobs,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -17,6 +17,7 @@ import type {
   CronScheduledToolCallerOrigin,
   CronScheduledToolPolicy,
   CronToolsAllowExecTarget,
+  CronToolsAllowExecTargetRequirement,
 } from "../../cron/scheduled-tool-policy.js";
 import type { ChannelRouteRef } from "../../plugin-sdk/channel-route.js";
 import type { SessionBoardFace } from "../../shared/session-types.js";
@@ -460,6 +461,8 @@ type SessionEntryCore = SessionRestartRecoveryState &
       scheduledToolPolicy?: CronScheduledToolPolicy;
       /** Restrict-only exec pin copied from the owning cron job's cap. */
       toolsAllowExecTarget?: CronToolsAllowExecTarget;
+      /** Expected pin copied with the cap so detached continuation loss fails closed. */
+      toolsAllowExecTargetRequirement?: CronToolsAllowExecTargetRequirement;
       /** Store-private origin paired with an account scheduled-tool policy. */
       scheduledToolCallerOrigin?: CronScheduledToolCallerOrigin;
       cliSessionBindingFacts?: {

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -16,6 +16,7 @@ import type { ChatType } from "../../channels/chat-type.js";
 import type {
   CronScheduledToolCallerOrigin,
   CronScheduledToolPolicy,
+  CronToolsAllowExecTarget,
 } from "../../cron/scheduled-tool-policy.js";
 import type { ChannelRouteRef } from "../../plugin-sdk/channel-route.js";
 import type { SessionBoardFace } from "../../shared/session-types.js";
@@ -457,6 +458,8 @@ type SessionEntryCore = SessionRestartRecoveryState &
       toolsAllowIsDefault?: boolean;
       /** Exact server-stamped authority provenance copied from the owning cron job. */
       scheduledToolPolicy?: CronScheduledToolPolicy;
+      /** Restrict-only exec pin copied from the owning cron job's cap. */
+      toolsAllowExecTarget?: CronToolsAllowExecTarget;
       /** Store-private origin paired with an account scheduled-tool policy. */
       scheduledToolCallerOrigin?: CronScheduledToolCallerOrigin;
       cliSessionBindingFacts?: {

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -327,6 +327,7 @@ function createCronPromptExecutor(params: {
     toolsAllow: params.agentPayload?.toolsAllow,
     scheduledToolPolicy: validatedScheduledToolPolicy,
     callerOrigin: params.job.toolsAllowProvenance?.callerOrigin,
+    execTarget: params.job.toolsAllowExecTarget,
   });
   const { sourceDelivery } = params;
   const sourceReplyDeliveryMode = sourceDelivery.sourceReplyDeliveryMode;

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -624,6 +624,7 @@ export async function prepareCronRunContext(params: {
             owner: input.job.owner,
           }),
           scheduledToolCallerOrigin: input.job.toolsAllowProvenance?.callerOrigin,
+          toolsAllowExecTarget: input.job.toolsAllowExecTarget,
           cliSessionBindingFacts: {
             sourceReplyDeliveryMode: sourceDelivery.sourceReplyDeliveryMode,
             requireExplicitMessageTarget: sourceDelivery.messageTool.requireExplicitTarget,

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -625,6 +625,7 @@ export async function prepareCronRunContext(params: {
           }),
           scheduledToolCallerOrigin: input.job.toolsAllowProvenance?.callerOrigin,
           toolsAllowExecTarget: input.job.toolsAllowExecTarget,
+          toolsAllowExecTargetRequirement: input.job.toolsAllowExecTargetRequirement,
           cliSessionBindingFacts: {
             sourceReplyDeliveryMode: sourceDelivery.sourceReplyDeliveryMode,
             requireExplicitMessageTarget: sourceDelivery.messageTool.requireExplicitTarget,

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -279,6 +279,7 @@ describe("createPersistCronSessionEntry", () => {
         ownerAccountId: "work",
       },
       scheduledToolCallerOrigin: { kind: "local" },
+      toolsAllowExecTarget: { version: 1, host: "gateway" },
       persistSessionEntry,
     });
 
@@ -291,6 +292,10 @@ describe("createPersistCronSessionEntry", () => {
     });
     expect(store[runSessionKey]?.previousSessionId).toBeUndefined();
     expect(store[runSessionKey]?.forkSource).toBeUndefined();
+    expect(store[runSessionKey]?.cronRunContinuation?.toolsAllowExecTarget).toEqual({
+      version: 1,
+      host: "gateway",
+    });
     expect(store[runSessionKey]?.cronRunContinuation?.scheduledToolPolicy).toEqual({
       version: 1,
       mode: "account",

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -279,7 +279,7 @@ describe("createPersistCronSessionEntry", () => {
         ownerAccountId: "work",
       },
       scheduledToolCallerOrigin: { kind: "local" },
-      toolsAllowExecTarget: { version: 1, host: "gateway" },
+      toolsAllowExecTarget: { version: 1, host: "gateway", ask: "always" },
       persistSessionEntry,
     });
 
@@ -295,6 +295,7 @@ describe("createPersistCronSessionEntry", () => {
     expect(store[runSessionKey]?.cronRunContinuation?.toolsAllowExecTarget).toEqual({
       version: 1,
       host: "gateway",
+      ask: "always",
     });
     expect(store[runSessionKey]?.cronRunContinuation?.scheduledToolPolicy).toEqual({
       version: 1,

--- a/src/cron/isolated-agent/run-session-state.test.ts
+++ b/src/cron/isolated-agent/run-session-state.test.ts
@@ -270,7 +270,7 @@ describe("createPersistCronSessionEntry", () => {
       runSessionKey,
       createdActor: { type: "human", id: "profile-ada" },
       thinkingLevel: "high",
-      toolsAllow: ["image_generate", "write"],
+      toolsAllow: ["image_generate", "exec", "write"],
       toolsAllowIsDefault: true,
       scheduledToolPolicy: {
         version: 1,
@@ -280,6 +280,11 @@ describe("createPersistCronSessionEntry", () => {
       },
       scheduledToolCallerOrigin: { kind: "local" },
       toolsAllowExecTarget: { version: 1, host: "gateway", ask: "always" },
+      toolsAllowExecTargetRequirement: {
+        version: 1,
+        target: { version: 1, host: "gateway", ask: "always" },
+        grantIndex: 1,
+      },
       persistSessionEntry,
     });
 
@@ -296,6 +301,11 @@ describe("createPersistCronSessionEntry", () => {
       version: 1,
       host: "gateway",
       ask: "always",
+    });
+    expect(store[runSessionKey]?.cronRunContinuation?.toolsAllowExecTargetRequirement).toEqual({
+      version: 1,
+      target: { version: 1, host: "gateway", ask: "always" },
+      grantIndex: 1,
     });
     expect(store[runSessionKey]?.cronRunContinuation?.scheduledToolPolicy).toEqual({
       version: 1,

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -19,11 +19,14 @@ import {
   normalizeCronScheduledToolCallerOrigin,
   normalizeCronScheduledToolPolicy,
   normalizeCronToolsAllowExecTarget,
+  normalizeCronToolsAllowExecTargetRequirement,
+  stripCronPinnedExecGrant,
 } from "../scheduled-tool-policy.js";
 import type {
   CronScheduledToolCallerOrigin,
   CronScheduledToolPolicy,
   CronToolsAllowExecTarget,
+  CronToolsAllowExecTargetRequirement,
 } from "../scheduled-tool-policy.js";
 import { setSessionRuntimeModel } from "./run.runtime.js";
 import type { resolveCronSession } from "./session.js";
@@ -255,6 +258,7 @@ export function createCronRunContinuationSession(params: {
   scheduledToolPolicy?: CronScheduledToolPolicy;
   scheduledToolCallerOrigin?: CronScheduledToolCallerOrigin;
   toolsAllowExecTarget?: CronToolsAllowExecTarget;
+  toolsAllowExecTargetRequirement?: CronToolsAllowExecTargetRequirement;
   cliSessionBindingFacts?: {
     extraSystemPromptStatic?: string;
     sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
@@ -273,14 +277,23 @@ export function createCronRunContinuationSession(params: {
     params.toolsAllow === undefined
       ? undefined
       : normalizeCronToolsAllowExecTarget(params.toolsAllowExecTarget);
+  const toolsAllowExecTargetRequirement =
+    params.toolsAllow === undefined
+      ? undefined
+      : normalizeCronToolsAllowExecTargetRequirement(params.toolsAllowExecTargetRequirement);
+  const storedToolsAllow = stripCronPinnedExecGrant({
+    toolsAllow: params.toolsAllow,
+    requirement: toolsAllowExecTargetRequirement,
+  });
   const continuation: NonNullable<SessionEntry["cronRunContinuation"]> = {
     lifecycleRevision: params.cronSession.lifecycleRevision,
     phase: "running" as const,
-    ...(params.toolsAllow !== undefined ? { toolsAllow: [...params.toolsAllow] } : {}),
+    ...(storedToolsAllow !== undefined ? { toolsAllow: storedToolsAllow } : {}),
     ...(params.toolsAllowIsDefault === true ? { toolsAllowIsDefault: true } : {}),
     ...(scheduledToolPolicy ? { scheduledToolPolicy } : {}),
     ...(scheduledToolPolicy?.mode === "account" ? { scheduledToolCallerOrigin } : {}),
     ...(toolsAllowExecTarget ? { toolsAllowExecTarget } : {}),
+    ...(toolsAllowExecTargetRequirement ? { toolsAllowExecTargetRequirement } : {}),
     ...(params.cliSessionBindingFacts
       ? { cliSessionBindingFacts: { ...params.cliSessionBindingFacts } }
       : {}),

--- a/src/cron/isolated-agent/run-session-state.ts
+++ b/src/cron/isolated-agent/run-session-state.ts
@@ -18,10 +18,12 @@ import type { SkillSnapshot } from "../../skills/types.js";
 import {
   normalizeCronScheduledToolCallerOrigin,
   normalizeCronScheduledToolPolicy,
+  normalizeCronToolsAllowExecTarget,
 } from "../scheduled-tool-policy.js";
 import type {
   CronScheduledToolCallerOrigin,
   CronScheduledToolPolicy,
+  CronToolsAllowExecTarget,
 } from "../scheduled-tool-policy.js";
 import { setSessionRuntimeModel } from "./run.runtime.js";
 import type { resolveCronSession } from "./session.js";
@@ -252,6 +254,7 @@ export function createCronRunContinuationSession(params: {
   toolsAllowIsDefault?: boolean;
   scheduledToolPolicy?: CronScheduledToolPolicy;
   scheduledToolCallerOrigin?: CronScheduledToolCallerOrigin;
+  toolsAllowExecTarget?: CronToolsAllowExecTarget;
   cliSessionBindingFacts?: {
     extraSystemPromptStatic?: string;
     sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
@@ -266,6 +269,10 @@ export function createCronRunContinuationSession(params: {
   const scheduledToolCallerOrigin = normalizeCronScheduledToolCallerOrigin(
     params.scheduledToolCallerOrigin,
   );
+  const toolsAllowExecTarget =
+    params.toolsAllow === undefined
+      ? undefined
+      : normalizeCronToolsAllowExecTarget(params.toolsAllowExecTarget);
   const continuation: NonNullable<SessionEntry["cronRunContinuation"]> = {
     lifecycleRevision: params.cronSession.lifecycleRevision,
     phase: "running" as const,
@@ -273,6 +280,7 @@ export function createCronRunContinuationSession(params: {
     ...(params.toolsAllowIsDefault === true ? { toolsAllowIsDefault: true } : {}),
     ...(scheduledToolPolicy ? { scheduledToolPolicy } : {}),
     ...(scheduledToolPolicy?.mode === "account" ? { scheduledToolCallerOrigin } : {}),
+    ...(toolsAllowExecTarget ? { toolsAllowExecTarget } : {}),
     ...(params.cliSessionBindingFacts
       ? { cliSessionBindingFacts: { ...params.cliSessionBindingFacts } }
       : {}),

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -18,6 +18,7 @@ import { coerceFiniteScheduleNumber } from "./schedule-number.js";
 import {
   normalizeCronScheduledToolCallerOrigin,
   normalizeCronScheduledToolPolicy,
+  normalizeCronToolsAllowExecTarget,
 } from "./scheduled-tool-policy.js";
 import { inferCronJobName } from "./service/normalize.js";
 import {
@@ -413,6 +414,15 @@ export function normalizeCronJobInput(
       };
     } else {
       delete next.toolsAllowProvenance;
+    }
+  }
+
+  if ("toolsAllowExecTarget" in base) {
+    const execTarget = normalizeCronToolsAllowExecTarget(base.toolsAllowExecTarget);
+    if (execTarget) {
+      next.toolsAllowExecTarget = execTarget;
+    } else {
+      delete next.toolsAllowExecTarget;
     }
   }
 

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -19,6 +19,7 @@ import {
   normalizeCronScheduledToolCallerOrigin,
   normalizeCronScheduledToolPolicy,
   normalizeCronToolsAllowExecTarget,
+  normalizeCronToolsAllowExecTargetRequirement,
 } from "./scheduled-tool-policy.js";
 import { inferCronJobName } from "./service/normalize.js";
 import {
@@ -423,6 +424,17 @@ export function normalizeCronJobInput(
       next.toolsAllowExecTarget = execTarget;
     } else {
       delete next.toolsAllowExecTarget;
+    }
+  }
+
+  if ("toolsAllowExecTargetRequirement" in base) {
+    const requirement = normalizeCronToolsAllowExecTargetRequirement(
+      base.toolsAllowExecTargetRequirement,
+    );
+    if (requirement) {
+      next.toolsAllowExecTargetRequirement = requirement;
+    } else {
+      delete next.toolsAllowExecTargetRequirement;
     }
   }
 

--- a/src/cron/public-job.test.ts
+++ b/src/cron/public-job.test.ts
@@ -54,13 +54,22 @@ describe("toPublicCronJob", () => {
     const job: CronStoredJob = {
       ...makeCronJob({}),
       toolsAllowProvenance: { version: 1, source: "final-executable-surface" },
+      toolsAllowExecTarget: { version: 1, host: "gateway", ask: "always" },
+      toolsAllowExecTargetRequirement: {
+        version: 1,
+        target: { version: 1, host: "gateway", ask: "always" },
+        grantIndex: 0,
+      },
     };
 
     expect(toPublicCronJob(job)).not.toHaveProperty("toolsAllowProvenance");
+    expect(toPublicCronJob(job)).not.toHaveProperty("toolsAllowExecTarget");
+    expect(toPublicCronJob(job)).not.toHaveProperty("toolsAllowExecTargetRequirement");
     expect(job.toolsAllowProvenance).toEqual({
       version: 1,
       source: "final-executable-surface",
     });
+    expect(job.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway", ask: "always" });
   });
 
   it("strips private creator provenance without mutating the stored job", () => {

--- a/src/cron/public-job.ts
+++ b/src/cron/public-job.ts
@@ -5,6 +5,8 @@ export function toPublicCronJob(job: CronStoredJob): CronJob {
   const {
     createdActor: _createdActor,
     toolsAllowProvenance: _toolsAllowProvenance,
+    toolsAllowExecTarget: _toolsAllowExecTarget,
+    toolsAllowExecTargetRequirement: _toolsAllowExecTargetRequirement,
     runtimeAuthority: _runtimeAuthority,
     runtimeAuthorityRecoveryRequired: _runtimeAuthorityRecoveryRequired,
     ...publicJob

--- a/src/cron/scheduled-tool-policy.ts
+++ b/src/cron/scheduled-tool-policy.ts
@@ -30,6 +30,27 @@ export function normalizeCronScheduledToolCallerOrigin(
     : { kind: "unknown" };
 }
 
+/**
+ * Restrict-only execution target for a job's exec grant, captured from a
+ * creator surface whose only exec capability was host-pinned. Absence — on
+ * older readers, after tampering, or for non-pinned creators — yields the
+ * baseline unpinned exec under normal scheduled exec policy; presence can
+ * only narrow, so this field needs no integrity seal.
+ */
+export type CronToolsAllowExecTarget = {
+  version: 1;
+  host: "gateway";
+};
+
+/** Accepts only the exact restrict-only shape; anything else stays absent. */
+export function normalizeCronToolsAllowExecTarget(
+  value: unknown,
+): CronToolsAllowExecTarget | undefined {
+  return isRecord(value) && value.version === 1 && value.host === "gateway"
+    ? { version: 1, host: "gateway" }
+    : undefined;
+}
+
 /** Server-authored provenance for a persisted scheduled tool-cap authority envelope. */
 export type CronScheduledToolPolicy =
   | {

--- a/src/cron/scheduled-tool-policy.ts
+++ b/src/cron/scheduled-tool-policy.ts
@@ -40,14 +40,20 @@ export function normalizeCronScheduledToolCallerOrigin(
 export type CronToolsAllowExecTarget = {
   version: 1;
   host: "gateway";
+  /** Mandatory approval floor inherited from the captured creator surface. */
+  ask?: "always";
 };
 
-/** Accepts only the exact restrict-only shape; anything else stays absent. */
+/** Retains only recognized restrictions; future fields remain reader-safe. */
 export function normalizeCronToolsAllowExecTarget(
   value: unknown,
 ): CronToolsAllowExecTarget | undefined {
   return isRecord(value) && value.version === 1 && value.host === "gateway"
-    ? { version: 1, host: "gateway" }
+    ? {
+        version: 1,
+        host: "gateway",
+        ...(value.ask === "always" ? { ask: "always" } : {}),
+      }
     : undefined;
 }
 

--- a/src/cron/scheduled-tool-policy.ts
+++ b/src/cron/scheduled-tool-policy.ts
@@ -32,10 +32,9 @@ export function normalizeCronScheduledToolCallerOrigin(
 
 /**
  * Restrict-only execution target for a job's exec grant, captured from a
- * creator surface whose only exec capability was host-pinned. Absence — on
- * older readers, after tampering, or for non-pinned creators — yields the
- * baseline unpinned exec under normal scheduled exec policy; presence can
- * only narrow, so this field needs no integrity seal.
+ * creator surface whose only exec capability was host-pinned. New pinned jobs
+ * persist this as part of a grant-coupled envelope; unmarked legacy jobs keep
+ * baseline exec behavior.
  */
 export type CronToolsAllowExecTarget = {
   version: 1;
@@ -43,6 +42,20 @@ export type CronToolsAllowExecTarget = {
   /** Mandatory approval floor inherited from the captured creator surface. */
   ask?: "always";
 };
+
+/** Persisted proof that this job was created with an exact exec restriction. */
+export type CronToolsAllowExecTargetRequirement =
+  | {
+      version: 1;
+      target: CronToolsAllowExecTarget;
+      grantIndex: number;
+      recoveryRequired?: never;
+    }
+  | {
+      version: 1;
+      target?: never;
+      recoveryRequired: true;
+    };
 
 /** Retains only recognized restrictions; future fields remain reader-safe. */
 export function normalizeCronToolsAllowExecTarget(
@@ -55,6 +68,108 @@ export function normalizeCronToolsAllowExecTarget(
         ...(value.ask === "always" ? { ask: "always" } : {}),
       }
     : undefined;
+}
+
+/** Invalid requirement markers remain durable fail-closed recovery state. */
+export function normalizeCronToolsAllowExecTargetRequirement(
+  value: unknown,
+): CronToolsAllowExecTargetRequirement | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value) || value.version !== 1) {
+    return { version: 1, recoveryRequired: true };
+  }
+  if (value.recoveryRequired === true) {
+    return { version: 1, recoveryRequired: true };
+  }
+  const rawTarget = value.target;
+  const target =
+    isRecord(rawTarget) &&
+    rawTarget.version === 1 &&
+    rawTarget.host === "gateway" &&
+    (rawTarget.ask === undefined || rawTarget.ask === "always")
+      ? {
+          version: 1 as const,
+          host: "gateway" as const,
+          ...(rawTarget.ask === "always" ? { ask: "always" as const } : {}),
+        }
+      : undefined;
+  const grantIndex = value.grantIndex;
+  return target && typeof grantIndex === "number" && Number.isInteger(grantIndex) && grantIndex >= 0
+    ? { version: 1, target, grantIndex }
+    : { version: 1, recoveryRequired: true };
+}
+
+function resolveMatchingCronExecTarget(params: {
+  requirement?: unknown;
+  execTarget?: unknown;
+}): Extract<CronToolsAllowExecTargetRequirement, { target: CronToolsAllowExecTarget }> | undefined {
+  const requirement = normalizeCronToolsAllowExecTargetRequirement(params.requirement);
+  const execTarget = normalizeCronToolsAllowExecTarget(params.execTarget);
+  return requirement &&
+    "target" in requirement &&
+    requirement.target !== undefined &&
+    execTarget?.host === requirement.target.host &&
+    execTarget.ask === requirement.target.ask
+    ? requirement
+    : undefined;
+}
+
+/** Removes a pinned exec grant from the generic persisted cap; the private envelope owns it. */
+export function stripCronPinnedExecGrant(params: {
+  toolsAllow?: readonly string[];
+  requirement?: unknown;
+}): string[] | undefined {
+  if (!params.toolsAllow) {
+    return undefined;
+  }
+  return normalizeCronToolsAllowExecTargetRequirement(params.requirement)
+    ? params.toolsAllow.filter((tool) => tool !== "exec")
+    : [...params.toolsAllow];
+}
+
+/** Rehydrates canonical exec only after the persisted grant and restriction agree. */
+export function restoreCronPinnedExecGrant(params: {
+  toolsAllow?: readonly string[];
+  requirement?: unknown;
+  execTarget?: unknown;
+}): string[] | undefined {
+  if (!params.toolsAllow) {
+    return undefined;
+  }
+  const requirement = resolveMatchingCronExecTarget(params);
+  if (!requirement || params.toolsAllow.includes("exec")) {
+    return [...params.toolsAllow];
+  }
+  const restored = [...params.toolsAllow];
+  restored.splice(Math.min(requirement.grantIndex, restored.length), 0, "exec");
+  return restored;
+}
+
+/** Returns operator-visible recovery guidance when a required pin cannot be proven intact. */
+export function resolveCronToolsAllowExecTargetRecoveryError(params: {
+  jobId?: string;
+  requirement?: unknown;
+  execTarget?: unknown;
+}): string | undefined {
+  const requirement = normalizeCronToolsAllowExecTargetRequirement(params.requirement);
+  if (!requirement) {
+    return undefined;
+  }
+  if (resolveMatchingCronExecTarget(params)) {
+    return undefined;
+  }
+  const subject = params.jobId ? `Automation ${params.jobId}` : "This automation";
+  const recoveryCommand = params.jobId
+    ? `openclaw automations edit ${params.jobId} --tools <tool,...>`
+    : "openclaw automations list --all";
+  return (
+    `${subject} cannot run because its captured exec restriction is missing or invalid. ` +
+    "No trigger, script, or agent action was executed. Recreate it from a fresh authenticated creator turn, " +
+    `or explicitly reauthorize its complete tool cap from a trusted operator shell with ` +
+    `\`${recoveryCommand}\`.`
+  );
 }
 
 /** Server-authored provenance for a persisted scheduled tool-cap authority envelope. */

--- a/src/cron/service/jobs-tool-policy.test.ts
+++ b/src/cron/service/jobs-tool-policy.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { CronStoredJob } from "../types.js";
+import { reconcileToolsAllowExecTarget } from "./jobs-tool-policy.js";
+
+function toolJob(toolsAllow: string[] | undefined): CronStoredJob {
+  return {
+    id: "job-1",
+    name: "job",
+    enabled: true,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    schedule: { kind: "every", everyMs: 60_000 },
+    payload: {
+      kind: "script",
+      script: "return {}",
+      ...(toolsAllow ? { toolsAllow } : {}),
+    },
+    state: {},
+  } as unknown as CronStoredJob;
+}
+
+describe("reconcileToolsAllowExecTarget", () => {
+  it("stamps the restrict-only pin only for exec-granting caps with the server fact", () => {
+    const job = toolJob(["exec", "read"]);
+    reconcileToolsAllowExecTarget({
+      job,
+      explicitlyMutatesToolsAllow: true,
+      toolsAllowExecTarget: { version: 1, host: "gateway" },
+    });
+    expect(job.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway" });
+  });
+
+  it("never stamps a pin onto a cap that does not grant exec", () => {
+    const job = toolJob(["read"]);
+    reconcileToolsAllowExecTarget({
+      job,
+      explicitlyMutatesToolsAllow: true,
+      toolsAllowExecTarget: { version: 1, host: "gateway" },
+    });
+    expect(job.toolsAllowExecTarget).toBeUndefined();
+  });
+
+  it("clears the pin when the cap is explicitly rewritten without the server fact", () => {
+    const job = toolJob(["exec"]);
+    job.toolsAllowExecTarget = { version: 1, host: "gateway" };
+    reconcileToolsAllowExecTarget({ job, explicitlyMutatesToolsAllow: true });
+    expect(job.toolsAllowExecTarget).toBeUndefined();
+  });
+
+  it("keeps the pin across edits that do not touch the cap", () => {
+    const job = toolJob(["exec"]);
+    job.toolsAllowExecTarget = { version: 1, host: "gateway" };
+    reconcileToolsAllowExecTarget({ job, explicitlyMutatesToolsAllow: false });
+    expect(job.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway" });
+  });
+
+  it("drops the pin when the job stops using a tool runtime cap", () => {
+    const job = toolJob(undefined);
+    job.toolsAllowExecTarget = { version: 1, host: "gateway" };
+    reconcileToolsAllowExecTarget({
+      job,
+      explicitlyMutatesToolsAllow: false,
+      toolsAllowExecTarget: { version: 1, host: "gateway" },
+    });
+    expect(job.toolsAllowExecTarget).toBeUndefined();
+  });
+});

--- a/src/cron/service/jobs-tool-policy.test.ts
+++ b/src/cron/service/jobs-tool-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CronStoredJob } from "../types.js";
-import { reconcileToolsAllowExecTarget } from "./jobs-tool-policy.js";
+import { reconcileToolsAllowAuthority } from "./jobs-tool-policy.js";
 
 function toolJob(toolsAllow: string[] | undefined): CronStoredJob {
   return {
@@ -19,11 +19,12 @@ function toolJob(toolsAllow: string[] | undefined): CronStoredJob {
   } as unknown as CronStoredJob;
 }
 
-describe("reconcileToolsAllowExecTarget", () => {
+describe("reconcileToolsAllowAuthority exec pin", () => {
   it("stamps the restrict-only pin only for exec-granting caps with the server fact", () => {
     const job = toolJob(["exec", "read"]);
-    reconcileToolsAllowExecTarget({
+    reconcileToolsAllowAuthority({
       job,
+      previouslyUsedToolRuntime: true,
       explicitlyMutatesToolsAllow: true,
       toolsAllowExecTarget: { version: 1, host: "gateway" },
     });
@@ -32,8 +33,9 @@ describe("reconcileToolsAllowExecTarget", () => {
 
   it("never stamps a pin onto a cap that does not grant exec", () => {
     const job = toolJob(["read"]);
-    reconcileToolsAllowExecTarget({
+    reconcileToolsAllowAuthority({
       job,
+      previouslyUsedToolRuntime: true,
       explicitlyMutatesToolsAllow: true,
       toolsAllowExecTarget: { version: 1, host: "gateway" },
     });
@@ -43,22 +45,31 @@ describe("reconcileToolsAllowExecTarget", () => {
   it("clears the pin when the cap is explicitly rewritten without the server fact", () => {
     const job = toolJob(["exec"]);
     job.toolsAllowExecTarget = { version: 1, host: "gateway" };
-    reconcileToolsAllowExecTarget({ job, explicitlyMutatesToolsAllow: true });
+    reconcileToolsAllowAuthority({
+      job,
+      previouslyUsedToolRuntime: true,
+      explicitlyMutatesToolsAllow: true,
+    });
     expect(job.toolsAllowExecTarget).toBeUndefined();
   });
 
   it("keeps the pin across edits that do not touch the cap", () => {
     const job = toolJob(["exec"]);
     job.toolsAllowExecTarget = { version: 1, host: "gateway" };
-    reconcileToolsAllowExecTarget({ job, explicitlyMutatesToolsAllow: false });
+    reconcileToolsAllowAuthority({
+      job,
+      previouslyUsedToolRuntime: true,
+      explicitlyMutatesToolsAllow: false,
+    });
     expect(job.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway" });
   });
 
   it("drops the pin when the job stops using a tool runtime cap", () => {
     const job = toolJob(undefined);
     job.toolsAllowExecTarget = { version: 1, host: "gateway" };
-    reconcileToolsAllowExecTarget({
+    reconcileToolsAllowAuthority({
       job,
+      previouslyUsedToolRuntime: true,
       explicitlyMutatesToolsAllow: false,
       toolsAllowExecTarget: { version: 1, host: "gateway" },
     });

--- a/src/cron/service/jobs-tool-policy.test.ts
+++ b/src/cron/service/jobs-tool-policy.test.ts
@@ -26,9 +26,9 @@ describe("reconcileToolsAllowAuthority exec pin", () => {
       job,
       previouslyUsedToolRuntime: true,
       explicitlyMutatesToolsAllow: true,
-      toolsAllowExecTarget: { version: 1, host: "gateway" },
+      toolsAllowExecTarget: { version: 1, host: "gateway", ask: "always" },
     });
-    expect(job.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway" });
+    expect(job.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway", ask: "always" });
   });
 
   it("never stamps a pin onto a cap that does not grant exec", () => {
@@ -44,7 +44,7 @@ describe("reconcileToolsAllowAuthority exec pin", () => {
 
   it("clears the pin when the cap is explicitly rewritten without the server fact", () => {
     const job = toolJob(["exec"]);
-    job.toolsAllowExecTarget = { version: 1, host: "gateway" };
+    job.toolsAllowExecTarget = { version: 1, host: "gateway", ask: "always" };
     reconcileToolsAllowAuthority({
       job,
       previouslyUsedToolRuntime: true,
@@ -55,13 +55,13 @@ describe("reconcileToolsAllowAuthority exec pin", () => {
 
   it("keeps the pin across edits that do not touch the cap", () => {
     const job = toolJob(["exec"]);
-    job.toolsAllowExecTarget = { version: 1, host: "gateway" };
+    job.toolsAllowExecTarget = { version: 1, host: "gateway", ask: "always" };
     reconcileToolsAllowAuthority({
       job,
       previouslyUsedToolRuntime: true,
       explicitlyMutatesToolsAllow: false,
     });
-    expect(job.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway" });
+    expect(job.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway", ask: "always" });
   });
 
   it("drops the pin when the job stops using a tool runtime cap", () => {

--- a/src/cron/service/jobs-tool-policy.test.ts
+++ b/src/cron/service/jobs-tool-policy.test.ts
@@ -29,6 +29,11 @@ describe("reconcileToolsAllowAuthority exec pin", () => {
       toolsAllowExecTarget: { version: 1, host: "gateway", ask: "always" },
     });
     expect(job.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway", ask: "always" });
+    expect(job.toolsAllowExecTargetRequirement).toEqual({
+      version: 1,
+      target: { version: 1, host: "gateway", ask: "always" },
+      grantIndex: 0,
+    });
   });
 
   it("never stamps a pin onto a cap that does not grant exec", () => {
@@ -40,33 +45,55 @@ describe("reconcileToolsAllowAuthority exec pin", () => {
       toolsAllowExecTarget: { version: 1, host: "gateway" },
     });
     expect(job.toolsAllowExecTarget).toBeUndefined();
+    expect(job.toolsAllowExecTargetRequirement).toBeUndefined();
   });
 
   it("clears the pin when the cap is explicitly rewritten without the server fact", () => {
     const job = toolJob(["exec"]);
     job.toolsAllowExecTarget = { version: 1, host: "gateway", ask: "always" };
+    job.toolsAllowExecTargetRequirement = {
+      version: 1,
+      target: { version: 1, host: "gateway", ask: "always" },
+      grantIndex: 0,
+    };
     reconcileToolsAllowAuthority({
       job,
       previouslyUsedToolRuntime: true,
       explicitlyMutatesToolsAllow: true,
     });
     expect(job.toolsAllowExecTarget).toBeUndefined();
+    expect(job.toolsAllowExecTargetRequirement).toBeUndefined();
   });
 
   it("keeps the pin across edits that do not touch the cap", () => {
     const job = toolJob(["exec"]);
     job.toolsAllowExecTarget = { version: 1, host: "gateway", ask: "always" };
+    job.toolsAllowExecTargetRequirement = {
+      version: 1,
+      target: { version: 1, host: "gateway", ask: "always" },
+      grantIndex: 0,
+    };
     reconcileToolsAllowAuthority({
       job,
       previouslyUsedToolRuntime: true,
       explicitlyMutatesToolsAllow: false,
     });
     expect(job.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway", ask: "always" });
+    expect(job.toolsAllowExecTargetRequirement).toEqual({
+      version: 1,
+      target: { version: 1, host: "gateway", ask: "always" },
+      grantIndex: 0,
+    });
   });
 
   it("drops the pin when the job stops using a tool runtime cap", () => {
     const job = toolJob(undefined);
     job.toolsAllowExecTarget = { version: 1, host: "gateway" };
+    job.toolsAllowExecTargetRequirement = {
+      version: 1,
+      target: { version: 1, host: "gateway" },
+      grantIndex: 0,
+    };
     reconcileToolsAllowAuthority({
       job,
       previouslyUsedToolRuntime: true,
@@ -74,5 +101,6 @@ describe("reconcileToolsAllowAuthority exec pin", () => {
       toolsAllowExecTarget: { version: 1, host: "gateway" },
     });
     expect(job.toolsAllowExecTarget).toBeUndefined();
+    expect(job.toolsAllowExecTargetRequirement).toBeUndefined();
   });
 });

--- a/src/cron/service/jobs-tool-policy.ts
+++ b/src/cron/service/jobs-tool-policy.ts
@@ -4,7 +4,11 @@ import {
   type CronScheduledToolPolicy,
 } from "../scheduled-tool-policy.js";
 import { cronJobUsesToolRuntime } from "../tools-allow.js";
-import type { CronStoredJob, CronToolsAllowProvenance } from "../types.js";
+import type {
+  CronStoredJob,
+  CronToolsAllowExecTarget,
+  CronToolsAllowProvenance,
+} from "../types.js";
 
 export function stampScheduledToolPolicy(
   job: CronStoredJob,
@@ -48,6 +52,35 @@ export function reconcileScheduledToolPolicy(params: {
   delete job.scheduledToolPolicy;
   if (params.explicitlyMutatesToolsAllow || !params.previouslyUsedToolRuntime) {
     stampScheduledToolPolicy(job, params.scheduledToolPolicy);
+  }
+}
+
+/**
+ * Stamps or clears the restrict-only exec pin alongside the cap it was
+ * captured with. The pin exists only while the job grants canonical `exec`
+ * from a creator surface whose exec capability was host-pinned; explicit cap
+ * rewrites without that server-verified fact clear it, falling back to the
+ * baseline unpinned exec policy.
+ */
+export function reconcileToolsAllowExecTarget(params: {
+  job: CronStoredJob;
+  explicitlyMutatesToolsAllow: boolean;
+  toolsAllowExecTarget?: CronToolsAllowExecTarget;
+}): void {
+  const { job } = params;
+  if (!cronJobUsesToolRuntime(job) || job.payload.toolsAllow === undefined) {
+    delete job.toolsAllowExecTarget;
+    return;
+  }
+  if (!params.explicitlyMutatesToolsAllow) {
+    return;
+  }
+  const grantsExec =
+    Array.isArray(job.payload.toolsAllow) && job.payload.toolsAllow.includes("exec");
+  if (params.toolsAllowExecTarget && grantsExec) {
+    job.toolsAllowExecTarget = structuredClone(params.toolsAllowExecTarget);
+  } else {
+    delete job.toolsAllowExecTarget;
   }
 }
 

--- a/src/cron/service/jobs-tool-policy.ts
+++ b/src/cron/service/jobs-tool-policy.ts
@@ -1,3 +1,4 @@
+import { cloneCronRuntimeAuthority, type CronRuntimeAuthority } from "../runtime-authority.js";
 import {
   createTrustedCronScheduledToolPolicy,
   resolveCronScheduledToolPolicy,
@@ -10,7 +11,7 @@ import type {
   CronToolsAllowProvenance,
 } from "../types.js";
 
-export function stampScheduledToolPolicy(
+function stampScheduledToolPolicy(
   job: CronStoredJob,
   scheduledToolPolicy: CronScheduledToolPolicy | undefined,
 ): void {
@@ -29,7 +30,7 @@ export function stampScheduledToolPolicy(
   job.scheduledToolPolicy = structuredClone(policy);
 }
 
-export function reconcileScheduledToolPolicy(params: {
+function reconcileScheduledToolPolicy(params: {
   job: CronStoredJob;
   previouslyUsedToolRuntime: boolean;
   explicitlyMutatesToolsAllow: boolean;
@@ -62,7 +63,7 @@ export function reconcileScheduledToolPolicy(params: {
  * rewrites without that server-verified fact clear it, falling back to the
  * baseline unpinned exec policy.
  */
-export function reconcileToolsAllowExecTarget(params: {
+function reconcileToolsAllowExecTarget(params: {
   job: CronStoredJob;
   explicitlyMutatesToolsAllow: boolean;
   toolsAllowExecTarget?: CronToolsAllowExecTarget;
@@ -84,7 +85,7 @@ export function reconcileToolsAllowExecTarget(params: {
   }
 }
 
-export function reconcileToolsAllowProvenance(params: {
+function reconcileToolsAllowProvenance(params: {
   job: CronStoredJob;
   explicitlyMutatesToolsAllow: boolean;
   toolsAllowProvenance?: CronToolsAllowProvenance;
@@ -101,4 +102,59 @@ export function reconcileToolsAllowProvenance(params: {
     return;
   }
   delete params.job.toolsAllowProvenance;
+}
+
+/** Reconciles runtime-owned opaque authority with the mutation that owns this write. */
+export function reconcileRuntimeAuthority(params: {
+  job: CronStoredJob;
+  captured: boolean;
+  runtimeAuthority?: CronRuntimeAuthority;
+  explicitlyMutatesToolsAllow: boolean;
+}): void {
+  if (!cronJobUsesToolRuntime(params.job)) {
+    // Runtime authority cannot survive a payload transition into a path that
+    // does not execute the captured tool surface and later reappear on reuse.
+    delete params.job.runtimeAuthority;
+    delete params.job.runtimeAuthorityRecoveryRequired;
+    return;
+  }
+  if (params.captured) {
+    delete params.job.runtimeAuthorityRecoveryRequired;
+    const runtimeAuthority = params.runtimeAuthority
+      ? cloneCronRuntimeAuthority(params.runtimeAuthority)
+      : undefined;
+    if (params.runtimeAuthority && !runtimeAuthority) {
+      throw new TypeError("captured cron runtime authority is invalid");
+    }
+    if (runtimeAuthority) {
+      params.job.runtimeAuthority = runtimeAuthority;
+    } else {
+      // A fresh exact-surface capture with no runtime authority intentionally
+      // replaces any older runtime-specific grant instead of retaining it.
+      delete params.job.runtimeAuthority;
+    }
+    return;
+  }
+  if (params.explicitlyMutatesToolsAllow) {
+    // Explicit tool caps are a complete replacement. Runtime-owned authority
+    // may be restored only by another authenticated exact-surface capture.
+    if (params.job.runtimeAuthority) {
+      params.job.runtimeAuthorityRecoveryRequired = true;
+      delete params.job.runtimeAuthority;
+    }
+  }
+}
+
+/** Reconciles the scheduled policy, capture provenance, and exec pin as one cap-authority unit. */
+export function reconcileToolsAllowAuthority(params: {
+  job: CronStoredJob;
+  previouslyUsedToolRuntime: boolean;
+  explicitlyMutatesToolsAllow: boolean;
+  scheduledToolPolicy?: CronScheduledToolPolicy;
+  toolsAllowProvenance?: CronToolsAllowProvenance;
+  toolsAllowExecTarget?: CronToolsAllowExecTarget;
+}): void {
+  reconcileScheduledToolPolicy(params);
+  reconcileToolsAllowProvenance(params);
+  reconcileToolsAllowExecTarget(params);
 }

--- a/src/cron/service/jobs-tool-policy.ts
+++ b/src/cron/service/jobs-tool-policy.ts
@@ -8,6 +8,7 @@ import { cronJobUsesToolRuntime } from "../tools-allow.js";
 import type {
   CronStoredJob,
   CronToolsAllowExecTarget,
+  CronToolsAllowExecTargetRequirement,
   CronToolsAllowProvenance,
 } from "../types.js";
 
@@ -71,6 +72,7 @@ function reconcileToolsAllowExecTarget(params: {
   const { job } = params;
   if (!cronJobUsesToolRuntime(job) || job.payload.toolsAllow === undefined) {
     delete job.toolsAllowExecTarget;
+    delete job.toolsAllowExecTargetRequirement;
     return;
   }
   if (!params.explicitlyMutatesToolsAllow) {
@@ -80,8 +82,14 @@ function reconcileToolsAllowExecTarget(params: {
     Array.isArray(job.payload.toolsAllow) && job.payload.toolsAllow.includes("exec");
   if (params.toolsAllowExecTarget && grantsExec) {
     job.toolsAllowExecTarget = structuredClone(params.toolsAllowExecTarget);
+    job.toolsAllowExecTargetRequirement = {
+      version: 1,
+      target: structuredClone(params.toolsAllowExecTarget),
+      grantIndex: job.payload.toolsAllow.indexOf("exec"),
+    } satisfies CronToolsAllowExecTargetRequirement;
   } else {
     delete job.toolsAllowExecTarget;
+    delete job.toolsAllowExecTargetRequirement;
   }
 }
 

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -23,6 +23,7 @@ import type {
   CronJobState,
   CronSchedule,
   CronStoredJob,
+  CronToolsAllowExecTarget,
   CronToolsAllowProvenance,
 } from "../types.js";
 import { resolveInitialCronDelivery } from "./initial-delivery.js";
@@ -33,6 +34,7 @@ import {
 } from "./jobs-scheduling.js";
 import {
   reconcileScheduledToolPolicy,
+  reconcileToolsAllowExecTarget,
   reconcileToolsAllowProvenance,
   stampScheduledToolPolicy,
 } from "./jobs-tool-policy.js";
@@ -210,6 +212,7 @@ export function createJob(
   opts?: DeliveryValidationOptions & {
     scheduledToolPolicy?: CronScheduledToolPolicy;
     toolsAllowProvenance?: CronToolsAllowProvenance;
+    toolsAllowExecTarget?: CronToolsAllowExecTarget;
   },
 ): CronStoredJob {
   const now = state.deps.nowMs();
@@ -281,6 +284,11 @@ export function createJob(
     explicitlyMutatesToolsAllow: true,
     toolsAllowProvenance: opts?.toolsAllowProvenance,
   });
+  reconcileToolsAllowExecTarget({
+    job,
+    explicitlyMutatesToolsAllow: true,
+    toolsAllowExecTarget: opts?.toolsAllowExecTarget,
+  });
   validateFullJob(
     job,
     {
@@ -305,6 +313,7 @@ export function applyJobPatch(
     cronConfig?: CronConfig;
     scheduledToolPolicy?: CronScheduledToolPolicy;
     toolsAllowProvenance?: CronToolsAllowProvenance;
+    toolsAllowExecTarget?: CronToolsAllowExecTarget;
   } & DeliveryValidationOptions,
 ) {
   const previouslyUsedToolRuntime = cronJobUsesToolRuntime(job);
@@ -389,6 +398,12 @@ export function applyJobPatch(
     explicitlyMutatesToolsAllow:
       patch.payload !== undefined && Object.hasOwn(patch.payload, "toolsAllow"),
     toolsAllowProvenance: opts?.toolsAllowProvenance,
+  });
+  reconcileToolsAllowExecTarget({
+    job,
+    explicitlyMutatesToolsAllow:
+      patch.payload !== undefined && Object.hasOwn(patch.payload, "toolsAllow"),
+    toolsAllowExecTarget: opts?.toolsAllowExecTarget,
   });
   if (patch.delivery) {
     const implicitMode = resolveCronDeliveryPlan(job).mode;
@@ -478,6 +493,7 @@ export function applyDeclarativeJobSpec(
     cronConfig?: CronConfig;
     scheduledToolPolicy?: CronScheduledToolPolicy;
     toolsAllowProvenance?: CronToolsAllowProvenance;
+    toolsAllowExecTarget?: CronToolsAllowExecTarget;
   } & DeliveryValidationOptions,
 ) {
   const previouslyUsedToolRuntime = cronJobUsesToolRuntime(job);
@@ -536,6 +552,11 @@ export function applyDeclarativeJobSpec(
     job,
     explicitlyMutatesToolsAllow: explicitlyDeclaresToolsAllow,
     toolsAllowProvenance: opts.toolsAllowProvenance,
+  });
+  reconcileToolsAllowExecTarget({
+    job,
+    explicitlyMutatesToolsAllow: explicitlyDeclaresToolsAllow,
+    toolsAllowExecTarget: opts.toolsAllowExecTarget,
   });
   const delivery = resolveInitialCronDelivery(input);
   if (delivery) {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -32,12 +32,7 @@ import {
   normalizeStreamScheduleBounds,
   resolveEveryAnchorMs,
 } from "./jobs-scheduling.js";
-import {
-  reconcileScheduledToolPolicy,
-  reconcileToolsAllowExecTarget,
-  reconcileToolsAllowProvenance,
-  stampScheduledToolPolicy,
-} from "./jobs-tool-policy.js";
+import { reconcileToolsAllowAuthority } from "./jobs-tool-policy.js";
 import {
   assertAnnounceDeliveryChannelSupport,
   assertTimeScheduleSatisfiable,
@@ -278,15 +273,12 @@ export function createJob(
   // New trusted jobs are explicit by construction. Agent-runtime callers are
   // required to arrive with a creator cap before the service can apply this default.
   applyDefaultCronToolsAllow(job);
-  stampScheduledToolPolicy(job, opts?.scheduledToolPolicy);
-  reconcileToolsAllowProvenance({
+  reconcileToolsAllowAuthority({
     job,
+    previouslyUsedToolRuntime: false,
     explicitlyMutatesToolsAllow: true,
+    scheduledToolPolicy: opts?.scheduledToolPolicy,
     toolsAllowProvenance: opts?.toolsAllowProvenance,
-  });
-  reconcileToolsAllowExecTarget({
-    job,
-    explicitlyMutatesToolsAllow: true,
     toolsAllowExecTarget: opts?.toolsAllowExecTarget,
   });
   validateFullJob(
@@ -386,23 +378,13 @@ export function applyJobPatch(
     // Ordinary edits to an existing capless job intentionally remain legacy.
     applyDefaultCronToolsAllow(job);
   }
-  reconcileScheduledToolPolicy({
+  reconcileToolsAllowAuthority({
     job,
     previouslyUsedToolRuntime,
     explicitlyMutatesToolsAllow:
       patch.payload !== undefined && Object.hasOwn(patch.payload, "toolsAllow"),
     scheduledToolPolicy: opts?.scheduledToolPolicy,
-  });
-  reconcileToolsAllowProvenance({
-    job,
-    explicitlyMutatesToolsAllow:
-      patch.payload !== undefined && Object.hasOwn(patch.payload, "toolsAllow"),
     toolsAllowProvenance: opts?.toolsAllowProvenance,
-  });
-  reconcileToolsAllowExecTarget({
-    job,
-    explicitlyMutatesToolsAllow:
-      patch.payload !== undefined && Object.hasOwn(patch.payload, "toolsAllow"),
     toolsAllowExecTarget: opts?.toolsAllowExecTarget,
   });
   if (patch.delivery) {
@@ -542,20 +524,12 @@ export function applyDeclarativeJobSpec(
       applyDefaultCronToolsAllow(job);
     }
   }
-  reconcileScheduledToolPolicy({
+  reconcileToolsAllowAuthority({
     job,
     previouslyUsedToolRuntime,
     explicitlyMutatesToolsAllow: explicitlyDeclaresToolsAllow,
     scheduledToolPolicy: opts.scheduledToolPolicy,
-  });
-  reconcileToolsAllowProvenance({
-    job,
-    explicitlyMutatesToolsAllow: explicitlyDeclaresToolsAllow,
     toolsAllowProvenance: opts.toolsAllowProvenance,
-  });
-  reconcileToolsAllowExecTarget({
-    job,
-    explicitlyMutatesToolsAllow: explicitlyDeclaresToolsAllow,
     toolsAllowExecTarget: opts.toolsAllowExecTarget,
   });
   const delivery = resolveInitialCronDelivery(input);

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -269,6 +269,7 @@ function declarativeFields(job: CronStoredJob, includeEnabled: boolean) {
     payload: job.payload,
     scheduledToolPolicy: job.scheduledToolPolicy,
     toolsAllowProvenance: job.toolsAllowProvenance,
+    toolsAllowExecTarget: job.toolsAllowExecTarget,
     runtimeAuthority: job.runtimeAuthority,
     runtimeAuthorityRecoveryRequired: job.runtimeAuthorityRecoveryRequired,
     delivery: job.delivery,
@@ -395,6 +396,7 @@ export async function add(
         cronConfig: state.deps.cronConfig,
         scheduledToolPolicy: opts?.scheduledToolPolicy,
         toolsAllowProvenance: opts?.toolsAllowProvenance,
+        toolsAllowExecTarget: opts?.toolsAllowExecTarget,
         configuredChannels,
       });
       const runtimeAuthorityMutation = consumeRuntimeAuthorityMutationOptions(opts);
@@ -440,6 +442,7 @@ export async function add(
     const job = createJob(state, creationInput, {
       scheduledToolPolicy: opts?.scheduledToolPolicy,
       toolsAllowProvenance: opts?.toolsAllowProvenance,
+      toolsAllowExecTarget: opts?.toolsAllowExecTarget,
       configuredChannels,
     });
     if (opts?.createdActor) {
@@ -539,6 +542,7 @@ async function updateLoadedJob(params: {
     cronConfig: state.deps.cronConfig,
     scheduledToolPolicy: opts?.scheduledToolPolicy,
     toolsAllowProvenance: opts?.toolsAllowProvenance,
+    toolsAllowExecTarget: opts?.toolsAllowExecTarget,
     configuredChannels,
   });
   if (patch.agentId !== undefined) {

--- a/src/cron/service/ops-mutations.ts
+++ b/src/cron/service/ops-mutations.ts
@@ -15,14 +15,12 @@ import {
   requestActiveCronJobCancellation,
 } from "../active-jobs.js";
 import { resolveCronJobConfigRevision } from "../config-revision.js";
-import { cloneCronRuntimeAuthority, type CronRuntimeAuthority } from "../runtime-authority.js";
 import { cronSchedulingInputsEqual } from "../schedule-identity.js";
 import { removeCronJobBaseSession } from "../session-reaper.js";
 import { removeStaleCronJobFamilyRows } from "../store.js";
 import { createCronStreamSourceIdentity, cronStreamScheduleKey } from "../stream-schedule.js";
 import { systemOwnedDeclarationKeyNamespace } from "../system-owned-declaration.js";
 import { normalizeCronTaskRunJobId } from "../task-run-history.js";
-import { cronJobUsesToolRuntime } from "../tools-allow.js";
 import {
   isSystemOwnedCronPayloadKind,
   type CronJob,
@@ -38,6 +36,7 @@ import {
   nextWakeAtMs,
   recomputeNextRunsForMaintenance,
 } from "./jobs-scheduling.js";
+import { reconcileRuntimeAuthority } from "./jobs-tool-policy.js";
 import { cronPatchTouchesDeliveryResolution } from "./jobs-validation.js";
 import { applyJobPatch, applyDeclarativeJobSpec, createJob } from "./jobs.js";
 import {
@@ -276,46 +275,6 @@ function declarativeFields(job: CronStoredJob, includeEnabled: boolean) {
     displayName: job.displayName,
     ...(includeEnabled ? { enabled: job.enabled } : {}),
   };
-}
-
-function reconcileRuntimeAuthority(params: {
-  job: CronStoredJob;
-  captured: boolean;
-  runtimeAuthority?: CronRuntimeAuthority;
-  explicitlyMutatesToolsAllow: boolean;
-}): void {
-  if (!cronJobUsesToolRuntime(params.job)) {
-    // Runtime authority cannot survive a payload transition into a path that
-    // does not execute the captured tool surface and later reappear on reuse.
-    delete params.job.runtimeAuthority;
-    delete params.job.runtimeAuthorityRecoveryRequired;
-    return;
-  }
-  if (params.captured) {
-    delete params.job.runtimeAuthorityRecoveryRequired;
-    const runtimeAuthority = params.runtimeAuthority
-      ? cloneCronRuntimeAuthority(params.runtimeAuthority)
-      : undefined;
-    if (params.runtimeAuthority && !runtimeAuthority) {
-      throw new TypeError("captured cron runtime authority is invalid");
-    }
-    if (runtimeAuthority) {
-      params.job.runtimeAuthority = runtimeAuthority;
-    } else {
-      // A fresh exact-surface capture with no runtime authority intentionally
-      // replaces any older runtime-specific grant instead of retaining it.
-      delete params.job.runtimeAuthority;
-    }
-    return;
-  }
-  if (params.explicitlyMutatesToolsAllow) {
-    // Explicit tool caps are a complete replacement. Runtime-owned authority
-    // may be restored only by another authenticated exact-surface capture.
-    if (params.job.runtimeAuthority) {
-      params.job.runtimeAuthorityRecoveryRequired = true;
-      delete params.job.runtimeAuthority;
-    }
-  }
 }
 
 function consumeRuntimeAuthorityMutationOptions(

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -37,6 +37,7 @@ import type {
   CronRunTelemetry,
   CronStoredJob,
   CronStoreFile,
+  CronToolsAllowExecTarget,
   CronToolsAllowProvenance,
 } from "../types.js";
 
@@ -108,7 +109,7 @@ export type CronServiceDeps = {
   /** List enabled, configured channel ids without exposing channel machinery to cron core. */
   listConfiguredChannels?: () => readonly string[] | Promise<readonly string[]>;
   evaluateCronTrigger?: (params: {
-    job: CronJob;
+    job: CronStoredJob;
     script: string;
     state: unknown;
     streamBatch?: string;
@@ -241,7 +242,7 @@ export type CronServiceDeps = {
     } & CronRunOutcome
   >;
   runScriptJob?: (params: {
-    job: CronJob;
+    job: CronStoredJob;
     streamBatch?: string;
     abortSignal?: AbortSignal;
   }) => Promise<
@@ -468,6 +469,8 @@ export type CronAddOptions = {
   scheduledToolPolicy?: CronScheduledToolPolicy;
   /** Private proof from an authenticated agent-runtime caller. */
   toolsAllowProvenance?: CronToolsAllowProvenance;
+  /** Restrict-only exec pin from the signed creator-turn identity. */
+  toolsAllowExecTarget?: CronToolsAllowExecTarget;
   /** Synchronous Gateway-owned liveness guard consumed immediately before mutation. */
   commitGuard?: () => void;
   /** One-use fresh capture; callback presence means fresh even when it returns undefined. */
@@ -479,6 +482,8 @@ export type CronUpdateInput = CronJobPatch;
 export type CronUpdateOptions = {
   scheduledToolPolicy?: CronScheduledToolPolicy;
   toolsAllowProvenance?: CronToolsAllowProvenance;
+  /** Restrict-only exec pin from the signed creator-turn identity. */
+  toolsAllowExecTarget?: CronToolsAllowExecTarget;
   /** Synchronous Gateway-owned liveness guard consumed immediately before mutation. */
   commitGuard?: () => void;
   /** One-use fresh capture; callback presence means fresh even when it returns undefined. */

--- a/src/cron/service/timer-execution.tool-policy.test.ts
+++ b/src/cron/service/timer-execution.tool-policy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import { makeCronJob } from "../delivery.test-helpers.js";
+import { createNoopLogger } from "../service.test-harness.js";
+import type { CronStoredJob } from "../types.js";
+import { createCronServiceState } from "./state.js";
+import { executeJobCore } from "./timer-execution.js";
+
+function damagedPinnedJob(kind: "trigger" | "script" | "agentTurn"): CronStoredJob {
+  const payload: CronStoredJob["payload"] =
+    kind === "script"
+      ? { kind: "script", script: "return {}", toolsAllow: ["exec"] }
+      : { kind: "agentTurn", message: "run", toolsAllow: ["exec"] };
+  return {
+    ...makeCronJob({
+      payload,
+      ...(kind === "trigger" ? { trigger: { script: "return { fire: true }" } } : {}),
+    }),
+    toolsAllowExecTargetRequirement: {
+      version: 1,
+      target: { version: 1, host: "gateway", ask: "always" },
+      grantIndex: 0,
+    },
+  };
+}
+
+describe("scheduled exec target recovery", () => {
+  it.each(["trigger", "script", "agentTurn"] as const)(
+    "stops a damaged pinned %s job before executable work",
+    async (kind) => {
+      const evaluateCronTrigger = vi.fn(async () => ({ kind: "evaluated" as const, fire: true }));
+      const runScriptJob = vi.fn(async () => ({ status: "ok" as const }));
+      const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+      const state = createCronServiceState({
+        storePath: `/tmp/cron-exec-target-recovery-${kind}.json`,
+        cronEnabled: true,
+        log: createNoopLogger(),
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeat: vi.fn(),
+        evaluateCronTrigger,
+        runScriptJob,
+        runIsolatedAgentJob,
+      });
+
+      const result = await executeJobCore(state, damagedPinnedJob(kind));
+
+      expect(result).toMatchObject({
+        status: "error",
+        error: expect.stringContaining("captured exec restriction is missing or invalid"),
+      });
+      expect(evaluateCronTrigger).not.toHaveBeenCalled();
+      expect(runScriptJob).not.toHaveBeenCalled();
+      expect(runIsolatedAgentJob).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps legacy unmarked exec grants on baseline policy", async () => {
+    const runIsolatedAgentJob = vi.fn(async () => ({ status: "ok" as const }));
+    const state = createCronServiceState({
+      storePath: "/tmp/cron-exec-target-legacy.json",
+      cronEnabled: true,
+      log: createNoopLogger(),
+      enqueueSystemEvent: vi.fn(),
+      requestHeartbeat: vi.fn(),
+      runIsolatedAgentJob,
+    });
+    const job = makeCronJob({
+      payload: { kind: "agentTurn", message: "run", toolsAllow: ["exec"] },
+    });
+
+    await expect(executeJobCore(state, job)).resolves.toMatchObject({ status: "ok" });
+    expect(runIsolatedAgentJob).toHaveBeenCalledOnce();
+  });
+});

--- a/src/cron/service/timer-execution.ts
+++ b/src/cron/service/timer-execution.ts
@@ -11,12 +11,14 @@ import { type CronActiveJobMarker, isCronActiveJobMarkerCurrent } from "../activ
 import { resolveCronJobEffectiveAgentId } from "../agent-id.js";
 import { isHeartbeatTaskCronJob } from "../heartbeat-task.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
+import { resolveCronToolsAllowExecTargetRecoveryError } from "../scheduled-tool-policy.js";
 import { cronScriptFailureMetadata } from "../script-failure.js";
 import { appendCronPayloadText, cronStreamScheduleKey } from "../stream-schedule.js";
 import type {
   CronDeliveryTrace,
   CronResolvedDeliveryState,
   CronJob,
+  CronStoredJob,
   CronNextCheckProposal,
   CronRunOutcome,
   CronRunTelemetry,
@@ -38,7 +40,7 @@ import { enqueueCronSystemEvent, requestCronHeartbeat } from "./wake.js";
 /** Executes a cron job without mutating persisted job state. */
 export async function executeJobCore(
   state: CronServiceState,
-  job: CronJob,
+  job: CronStoredJob,
   abortSignal?: AbortSignal,
   options?: ExecuteJobCoreOptions,
 ): Promise<
@@ -86,6 +88,20 @@ export async function executeJobCore(
 
   if (abortSignal?.aborted) {
     return resolveAbortError();
+  }
+  const execTargetRecoveryError = resolveCronToolsAllowExecTargetRecoveryError({
+    jobId: job.id,
+    requirement: job.toolsAllowExecTargetRequirement,
+    execTarget: job.toolsAllowExecTarget,
+  });
+  if (execTargetRecoveryError) {
+    return {
+      status: "error",
+      error: execTargetRecoveryError,
+      diagnostics: createCronRunDiagnosticsFromError("cron-preflight", execTargetRecoveryError, {
+        nowMs: state.deps.nowMs,
+      }),
+    };
   }
   if (options?.streamScheduleKey !== undefined || options?.streamSourceIdentity !== undefined) {
     // Defense in depth over the locked admission checks: stream-origin work must

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -888,6 +888,43 @@ describe("cron store", () => {
     expect(readOnly?.runtimeAuthority).toEqual(job.runtimeAuthority);
   });
 
+  it("round-trips the restrict-only exec target and drops foreign shapes", async () => {
+    const { storePath } = await makeStorePath();
+    const authorityStore = makeAuthorityStore("exec-target-round-trip");
+    const job = expectDefined(authorityStore.jobs[0], "exec target job test invariant");
+    job.payload = {
+      kind: "agentTurn",
+      message: "scheduled continuation",
+      toolsAllow: ["exec", "read"],
+    };
+    job.toolsAllowExecTarget = { version: 1, host: "gateway" };
+
+    await saveCronStore(storePath, authorityStore);
+    const reloaded = (await loadCronStore(storePath)).jobs[0];
+    expect(reloaded?.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway" });
+
+    // A tampered or future shape is not a pin; the job falls back to baseline exec.
+    const database = openOpenClawStateDatabase().db;
+    const row = database.prepare("SELECT job_json FROM cron_jobs WHERE job_id = ?").get(job.id) as {
+      job_json: string;
+    };
+    const edited = JSON.parse(row.job_json) as Record<string, unknown>;
+    edited.toolsAllowExecTarget = { version: 1, host: "node" };
+    database
+      .prepare("UPDATE cron_jobs SET job_json = ? WHERE job_id = ?")
+      .run(JSON.stringify(edited), job.id);
+    const rejected = (await loadCronStore(storePath)).jobs[0];
+    expect(rejected?.toolsAllowExecTarget).toBeUndefined();
+
+    // Extra keys from a newer writer are tolerated: known fields rebuild cleanly.
+    edited.toolsAllowExecTarget = { version: 1, host: "gateway", note: "future-field" };
+    database
+      .prepare("UPDATE cron_jobs SET job_json = ? WHERE job_id = ?")
+      .run(JSON.stringify(edited), job.id);
+    const tolerated = (await loadCronStore(storePath)).jobs[0];
+    expect(tolerated?.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway" });
+  });
+
   it("retires authority when an older writer changes its tool cap", async () => {
     const { storePath } = await makeStorePath();
     const authorityStore = makeAuthorityStore("downgrade-cap-change");

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -897,11 +897,15 @@ describe("cron store", () => {
       message: "scheduled continuation",
       toolsAllow: ["exec", "read"],
     };
-    job.toolsAllowExecTarget = { version: 1, host: "gateway" };
+    job.toolsAllowExecTarget = { version: 1, host: "gateway", ask: "always" };
 
     await saveCronStore(storePath, authorityStore);
     const reloaded = (await loadCronStore(storePath)).jobs[0];
-    expect(reloaded?.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway" });
+    expect(reloaded?.toolsAllowExecTarget).toEqual({
+      version: 1,
+      host: "gateway",
+      ask: "always",
+    });
 
     // A tampered or future shape is not a pin; the job falls back to baseline exec.
     const database = openOpenClawStateDatabase().db;
@@ -917,12 +921,28 @@ describe("cron store", () => {
     expect(rejected?.toolsAllowExecTarget).toBeUndefined();
 
     // Extra keys from a newer writer are tolerated: known fields rebuild cleanly.
-    edited.toolsAllowExecTarget = { version: 1, host: "gateway", note: "future-field" };
+    edited.toolsAllowExecTarget = {
+      version: 1,
+      host: "gateway",
+      ask: "always",
+      note: "future-field",
+    };
     database
       .prepare("UPDATE cron_jobs SET job_json = ? WHERE job_id = ?")
       .run(JSON.stringify(edited), job.id);
     const tolerated = (await loadCronStore(storePath)).jobs[0];
-    expect(tolerated?.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway" });
+    expect(tolerated?.toolsAllowExecTarget).toEqual({
+      version: 1,
+      host: "gateway",
+      ask: "always",
+    });
+
+    edited.toolsAllowExecTarget = { version: 1, host: "gateway", ask: "off" };
+    database
+      .prepare("UPDATE cron_jobs SET job_json = ? WHERE job_id = ?")
+      .run(JSON.stringify(edited), job.id);
+    const nonRestrictiveAsk = (await loadCronStore(storePath)).jobs[0];
+    expect(nonRestrictiveAsk?.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway" });
   });
 
   it("retires authority when an older writer changes its tool cap", async () => {

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -898,29 +898,53 @@ describe("cron store", () => {
       toolsAllow: ["exec", "read"],
     };
     job.toolsAllowExecTarget = { version: 1, host: "gateway", ask: "always" };
+    job.toolsAllowExecTargetRequirement = {
+      version: 1,
+      target: { version: 1, host: "gateway", ask: "always" },
+      grantIndex: 0,
+    };
 
     await saveCronStore(storePath, authorityStore);
     const reloaded = (await loadCronStore(storePath)).jobs[0];
+    expect(reloaded?.payload.toolsAllow).toEqual(["exec", "read"]);
     expect(reloaded?.toolsAllowExecTarget).toEqual({
       version: 1,
       host: "gateway",
       ask: "always",
     });
+    expect(reloaded?.toolsAllowExecTargetRequirement).toEqual({
+      version: 1,
+      target: { version: 1, host: "gateway", ask: "always" },
+      grantIndex: 0,
+    });
 
-    // A tampered or future shape is not a pin; the job falls back to baseline exec.
+    // A damaged target cannot rehydrate the private exec grant.
     const database = openOpenClawStateDatabase().db;
     const row = database.prepare("SELECT job_json FROM cron_jobs WHERE job_id = ?").get(job.id) as {
       job_json: string;
     };
     const edited = JSON.parse(row.job_json) as Record<string, unknown>;
+    expect((edited.payload as { toolsAllow?: string[] }).toolsAllow).toEqual(["read"]);
     edited.toolsAllowExecTarget = { version: 1, host: "node" };
     database
       .prepare("UPDATE cron_jobs SET job_json = ? WHERE job_id = ?")
       .run(JSON.stringify(edited), job.id);
     const rejected = (await loadCronStore(storePath)).jobs[0];
     expect(rejected?.toolsAllowExecTarget).toBeUndefined();
+    expect(rejected?.payload.toolsAllow).toEqual(["read"]);
+
+    // Older writers may drop both private fields, but cannot restore broad exec.
+    const requirement = edited.toolsAllowExecTargetRequirement;
+    delete edited.toolsAllowExecTarget;
+    delete edited.toolsAllowExecTargetRequirement;
+    database
+      .prepare("UPDATE cron_jobs SET job_json = ? WHERE job_id = ?")
+      .run(JSON.stringify(edited), job.id);
+    const downgraded = (await loadCronStore(storePath)).jobs[0];
+    expect(downgraded?.payload.toolsAllow).toEqual(["read"]);
 
     // Extra keys from a newer writer are tolerated: known fields rebuild cleanly.
+    edited.toolsAllowExecTargetRequirement = requirement;
     edited.toolsAllowExecTarget = {
       version: 1,
       host: "gateway",
@@ -936,6 +960,7 @@ describe("cron store", () => {
       host: "gateway",
       ask: "always",
     });
+    expect(tolerated?.payload.toolsAllow).toEqual(["exec", "read"]);
 
     edited.toolsAllowExecTarget = { version: 1, host: "gateway", ask: "off" };
     database
@@ -943,6 +968,35 @@ describe("cron store", () => {
       .run(JSON.stringify(edited), job.id);
     const nonRestrictiveAsk = (await loadCronStore(storePath)).jobs[0];
     expect(nonRestrictiveAsk?.toolsAllowExecTarget).toEqual({ version: 1, host: "gateway" });
+    expect(nonRestrictiveAsk?.payload.toolsAllow).toEqual(["read"]);
+  });
+
+  it("never stores broad exec when a required target is already damaged", async () => {
+    const { storePath } = await makeStorePath();
+    const authorityStore = makeAuthorityStore("damaged-exec-target-save");
+    const job = expectDefined(authorityStore.jobs[0], "exec target job test invariant");
+    job.payload = {
+      kind: "agentTurn",
+      message: "scheduled continuation",
+      toolsAllow: ["read", "exec"],
+    };
+    job.toolsAllowExecTarget = { version: 1, host: "gateway", ask: "always" };
+    job.toolsAllowExecTargetRequirement = { version: 1, recoveryRequired: true };
+
+    await saveCronStore(storePath, authorityStore);
+
+    const database = openOpenClawStateDatabase().db;
+    const row = database.prepare("SELECT job_json FROM cron_jobs WHERE job_id = ?").get(job.id) as {
+      job_json: string;
+    };
+    const stored = JSON.parse(row.job_json) as { payload: { toolsAllow?: string[] } };
+    expect(stored.payload.toolsAllow).toEqual(["read"]);
+    const reloaded = (await loadCronStore(storePath)).jobs[0];
+    expect(reloaded?.payload.toolsAllow).toEqual(["read"]);
+    expect(reloaded?.toolsAllowExecTargetRequirement).toEqual({
+      version: 1,
+      recoveryRequired: true,
+    });
   });
 
   it("retires authority when an older writer changes its tool cap", async () => {

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -8,6 +8,7 @@ import { normalizeCronJobIdentityFields } from "../normalize-job-identity.js";
 import { normalizeCronJobInput } from "../normalize.js";
 import { getInvalidPersistedCronJobReason } from "../persisted-shape.js";
 import { tryCronScheduleIdentity } from "../schedule-identity.js";
+import { normalizeCronToolsAllowExecTarget } from "../scheduled-tool-policy.js";
 import type { CronJobState, CronStoredJob, CronStoreFile } from "../types.js";
 import { deliveryFromJson, deliveryToJson } from "./delivery-codec.js";
 import { normalizeNumber, tryParseJsonObject } from "./scalar-codec.js";
@@ -111,12 +112,17 @@ function rowToCronJob(row: CronJobRow, jobJson: Record<string, unknown>): CronSt
   if (!state || getInvalidPersistedCronJobReason(jobJson)) {
     return null;
   }
+  const toolsAllowExecTarget = normalizeCronToolsAllowExecTarget(jobJson.toolsAllowExecTarget);
   const createdAtMs =
     typeof jobJson.createdAtMs === "number" && Number.isFinite(jobJson.createdAtMs)
       ? jobJson.createdAtMs
       : Date.now();
   // Doctor retains unresolved legacy markers in config JSON; runtime never consumes them.
-  const { notify: _legacyNotify, ...runtimeConfig } = decodeCronJobConfig(jobJson);
+  const {
+    notify: _legacyNotify,
+    toolsAllowExecTarget: _rawToolsAllowExecTarget,
+    ...runtimeConfig
+  } = decodeCronJobConfig(jobJson);
   if (isRecord(runtimeConfig.delivery) && runtimeConfig.delivery.mode === undefined) {
     // Legacy destination-only config remains untouched for doctor; runtime defaults to announce.
     runtimeConfig.delivery = deliveryFromJson({ ...runtimeConfig.delivery, mode: "announce" });
@@ -124,6 +130,7 @@ function rowToCronJob(row: CronJobRow, jobJson: Record<string, unknown>): CronSt
   return {
     ...runtimeConfig,
     id: row.job_id,
+    ...(toolsAllowExecTarget ? { toolsAllowExecTarget } : {}),
     createdAtMs,
     updatedAtMs:
       normalizeNumber(row.runtime_updated_at_ms) ?? normalizeNumber(row.updated_at) ?? createdAtMs,

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -8,7 +8,12 @@ import { normalizeCronJobIdentityFields } from "../normalize-job-identity.js";
 import { normalizeCronJobInput } from "../normalize.js";
 import { getInvalidPersistedCronJobReason } from "../persisted-shape.js";
 import { tryCronScheduleIdentity } from "../schedule-identity.js";
-import { normalizeCronToolsAllowExecTarget } from "../scheduled-tool-policy.js";
+import {
+  normalizeCronToolsAllowExecTarget,
+  normalizeCronToolsAllowExecTargetRequirement,
+  restoreCronPinnedExecGrant,
+  stripCronPinnedExecGrant,
+} from "../scheduled-tool-policy.js";
 import type { CronJobState, CronStoredJob, CronStoreFile } from "../types.js";
 import { deliveryFromJson, deliveryToJson } from "./delivery-codec.js";
 import { normalizeNumber, tryParseJsonObject } from "./scalar-codec.js";
@@ -24,9 +29,20 @@ function stripJobRuntimeFields(job: CronStoreFile["jobs"][number]): Record<strin
     updatedAtMs: _updatedAtMs,
     ...rest
   } = job;
+  const payload = isRecord(rest.payload) ? rest.payload : undefined;
+  const toolsAllow = Array.isArray(payload?.toolsAllow)
+    ? payload.toolsAllow.filter((tool): tool is string => typeof tool === "string")
+    : undefined;
+  const storedToolsAllow = stripCronPinnedExecGrant({
+    toolsAllow,
+    requirement: rest.toolsAllowExecTargetRequirement,
+  });
   // Runtime state and authority have separate owners; JSON is canonical for config.
   return {
     ...rest,
+    ...(payload && storedToolsAllow
+      ? { payload: { ...payload, toolsAllow: storedToolsAllow } }
+      : {}),
     ...(rest.delivery ? { delivery: deliveryToJson(rest.delivery) } : {}),
     state: {},
   };
@@ -113,6 +129,9 @@ function rowToCronJob(row: CronJobRow, jobJson: Record<string, unknown>): CronSt
     return null;
   }
   const toolsAllowExecTarget = normalizeCronToolsAllowExecTarget(jobJson.toolsAllowExecTarget);
+  const toolsAllowExecTargetRequirement = normalizeCronToolsAllowExecTargetRequirement(
+    jobJson.toolsAllowExecTargetRequirement,
+  );
   const createdAtMs =
     typeof jobJson.createdAtMs === "number" && Number.isFinite(jobJson.createdAtMs)
       ? jobJson.createdAtMs
@@ -121,8 +140,21 @@ function rowToCronJob(row: CronJobRow, jobJson: Record<string, unknown>): CronSt
   const {
     notify: _legacyNotify,
     toolsAllowExecTarget: _rawToolsAllowExecTarget,
+    toolsAllowExecTargetRequirement: _rawToolsAllowExecTargetRequirement,
     ...runtimeConfig
   } = decodeCronJobConfig(jobJson);
+  const payload = isRecord(runtimeConfig.payload) ? runtimeConfig.payload : undefined;
+  const toolsAllow = Array.isArray(payload?.toolsAllow)
+    ? payload.toolsAllow.filter((tool): tool is string => typeof tool === "string")
+    : undefined;
+  const runtimeToolsAllow = restoreCronPinnedExecGrant({
+    toolsAllow,
+    requirement: toolsAllowExecTargetRequirement,
+    execTarget: toolsAllowExecTarget,
+  });
+  if (payload && runtimeToolsAllow) {
+    runtimeConfig.payload = { ...payload, toolsAllow: runtimeToolsAllow };
+  }
   if (isRecord(runtimeConfig.delivery) && runtimeConfig.delivery.mode === undefined) {
     // Legacy destination-only config remains untouched for doctor; runtime defaults to announce.
     runtimeConfig.delivery = deliveryFromJson({ ...runtimeConfig.delivery, mode: "announce" });
@@ -131,6 +163,7 @@ function rowToCronJob(row: CronJobRow, jobJson: Record<string, unknown>): CronSt
     ...runtimeConfig,
     id: row.job_id,
     ...(toolsAllowExecTarget ? { toolsAllowExecTarget } : {}),
+    ...(toolsAllowExecTargetRequirement ? { toolsAllowExecTargetRequirement } : {}),
     createdAtMs,
     updatedAtMs:
       normalizeNumber(row.runtime_updated_at_ms) ?? normalizeNumber(row.updated_at) ?? createdAtMs,

--- a/src/cron/trigger-script.test.ts
+++ b/src/cron/trigger-script.test.ts
@@ -120,6 +120,57 @@ describe("cron trigger script evaluator", () => {
     },
   );
 
+  it("runs the documented exec contract from a canonically captured pinned cap", async () => {
+    const workspaceDir = tempDirs.make("openclaw-cron-canonical-cap-");
+    // The configured default exec host is a nonexistent node: only the
+    // restrict-only gateway pin can make this command run.
+    const config = {
+      agents: { defaults: { workspace: workspaceDir } },
+      tools: {
+        exec: {
+          host: "node",
+          node: "configured-node-must-not-run",
+          security: "full",
+          ask: "off",
+        },
+      },
+    } as OpenClawConfig;
+    const evaluate = createCronScriptRuntime({ config }).evaluateTrigger;
+
+    await expect(
+      evaluate({
+        jobId: "job-canonical-pinned-exec",
+        script:
+          'await exec({ command: "printf openclaw-canonical-ok", host: "node", node: "remote" }); return { fire: false };',
+        state: null,
+        toolsAllow: ["exec", "process"],
+        scheduledToolPolicy: { version: 1, mode: "trusted" },
+        execTarget: { version: 1, host: "gateway" },
+      }),
+    ).resolves.toEqual({ kind: "evaluated", fire: false });
+  });
+
+  it("keeps an uncanonicalized alias-name cap fail-closed for exec", async () => {
+    const workspaceDir = tempDirs.make("openclaw-cron-alias-collision-");
+    const evaluate = createCronScriptRuntime({
+      config: {
+        agents: { defaults: { workspace: workspaceDir } },
+        tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+      } as OpenClawConfig,
+    }).evaluateTrigger;
+
+    const result = await evaluate({
+      jobId: "job-colliding-gateway-exec",
+      script: 'await exec({ command: "printf must-not-run" }); return { fire: false };',
+      state: null,
+      toolsAllow: ["gateway_exec"],
+      scheduledToolPolicy: { version: 1, mode: "trusted" },
+    });
+
+    expect(result).toMatchObject({ kind: "error", code: "internal_error" });
+    expect(result.kind === "error" ? result.error : "").toContain("exec is not defined");
+  });
+
   it("prefers a valid returned value and injects trigger state", async () => {
     const runHeadless = vi.fn(async (_params: HeadlessParams) =>
       completed({

--- a/src/cron/trigger-script.ts
+++ b/src/cron/trigger-script.ts
@@ -59,7 +59,11 @@ import {
   MAX_CRON_SCRIPT_TIMEOUT_SECONDS,
   MAX_CRON_SCRIPT_TOOL_BUDGET,
 } from "./script-payload.js";
-import type { CronTriggerEvaluationResult, CronTriggerFailureCode } from "./types.js";
+import type {
+  CronToolsAllowExecTarget,
+  CronTriggerEvaluationResult,
+  CronTriggerFailureCode,
+} from "./types.js";
 
 const MAX_CONCURRENT_TRIGGER_EVALS = 3;
 const MAX_TRIGGER_STATE_BYTES = 16 * 1024;
@@ -92,6 +96,7 @@ type PrepareTriggerRuntime = (params: {
   agentId?: string;
   toolsAllow?: string[];
   scheduledToolPolicy?: ScheduledToolPolicyContext;
+  execTarget?: CronToolsAllowExecTarget;
   signal?: AbortSignal;
 }) => Promise<PreparedTriggerRuntime>;
 
@@ -190,6 +195,7 @@ async function prepareTriggerRuntime(
           scheduledToolPolicy: resolveScheduledToolPolicyContext({
             toolsAllow: params.toolsAllow,
             scheduledToolPolicy: params.scheduledToolPolicy,
+            execTarget: params.execTarget,
           }),
           toolConstructionPlan: toolPlan.codingToolConstructionPlan,
         })
@@ -355,6 +361,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
     agentId: string;
     toolsAllow?: string[];
     scheduledToolPolicy?: ScheduledToolPolicyContext;
+    execTarget?: CronToolsAllowExecTarget;
     toolsAllowKey: string;
     signal: AbortSignal;
   }): Promise<PreparedTriggerRuntime> => {
@@ -390,6 +397,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
       agentId: request.requestedAgentId,
       toolsAllow: request.toolsAllow,
       scheduledToolPolicy: request.scheduledToolPolicy,
+      execTarget: request.execTarget,
       signal: request.signal,
     });
     const entry: TriggerRuntimeCacheEntry = {
@@ -416,6 +424,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
     script: string;
     toolsAllow?: string[];
     scheduledToolPolicy?: ScheduledToolPolicyContext;
+    execTarget?: CronToolsAllowExecTarget;
     abortSignal?: AbortSignal;
     wallClockMs: number;
     maxToolCalls: number;
@@ -436,6 +445,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
       const toolsAllowKey = JSON.stringify([
         params.toolsAllow ?? null,
         params.scheduledToolPolicy ?? null,
+        params.execTarget ?? null,
       ]);
       const runtime = await resolveCachedRuntime({
         runtimeConfig,
@@ -444,6 +454,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
         agentId,
         toolsAllow: params.toolsAllow,
         scheduledToolPolicy: params.scheduledToolPolicy,
+        execTarget: params.execTarget,
         toolsAllowKey,
         signal: evaluationScope.signal,
       });
@@ -617,6 +628,7 @@ export function createCronScriptRuntime(deps: CronTriggerEvaluatorDeps) {
       streamBatch?: string;
       toolsAllow?: string[];
       scheduledToolPolicy?: ScheduledToolPolicyContext;
+      execTarget?: CronToolsAllowExecTarget;
       abortSignal?: AbortSignal;
     }): Promise<CronTriggerEvaluationResult> => {
       if (activeTriggerEvaluations >= MAX_CONCURRENT_TRIGGER_EVALS) {
@@ -644,6 +656,7 @@ export function createCronScriptRuntime(deps: CronTriggerEvaluatorDeps) {
       streamBatch?: string;
       toolsAllow?: string[];
       scheduledToolPolicy?: ScheduledToolPolicyContext;
+      execTarget?: CronToolsAllowExecTarget;
       timeoutSeconds?: number;
       toolBudget?: number;
       abortSignal?: AbortSignal;

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -9,10 +9,12 @@ import type { CronRuntimeAuthority } from "./runtime-authority.js";
 import type {
   CronScheduledToolCallerOrigin,
   CronScheduledToolPolicy,
+  CronToolsAllowExecTarget,
 } from "./scheduled-tool-policy.js";
 import type { CronJobBase, CronPacing } from "./types-shared.js";
 
 export type { CronPacing } from "./types-shared.js";
+export type { CronToolsAllowExecTarget } from "./scheduled-tool-policy.js";
 export type { CronCompletionStatus } from "./completion-status.js";
 
 /** Supported schedule forms persisted in cron job specs. */
@@ -541,6 +543,7 @@ export type CronStoredJob = CronJob & {
   /** Immutable creator provenance stamped by the trusted cron creation seam. */
   createdActor?: SessionCreatedActor;
   toolsAllowProvenance?: CronToolsAllowProvenance;
+  toolsAllowExecTarget?: CronToolsAllowExecTarget;
   /** Runtime-private authority omitted from public Gateway and wire contracts. */
   runtimeAuthority?: CronRuntimeAuthority;
   /** Authority was explicitly cleared and must be reauthorized before app reuse. */

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -10,11 +10,15 @@ import type {
   CronScheduledToolCallerOrigin,
   CronScheduledToolPolicy,
   CronToolsAllowExecTarget,
+  CronToolsAllowExecTargetRequirement,
 } from "./scheduled-tool-policy.js";
 import type { CronJobBase, CronPacing } from "./types-shared.js";
 
 export type { CronPacing } from "./types-shared.js";
-export type { CronToolsAllowExecTarget } from "./scheduled-tool-policy.js";
+export type {
+  CronToolsAllowExecTarget,
+  CronToolsAllowExecTargetRequirement,
+} from "./scheduled-tool-policy.js";
 export type { CronCompletionStatus } from "./completion-status.js";
 
 /** Supported schedule forms persisted in cron job specs. */
@@ -544,6 +548,8 @@ export type CronStoredJob = CronJob & {
   createdActor?: SessionCreatedActor;
   toolsAllowProvenance?: CronToolsAllowProvenance;
   toolsAllowExecTarget?: CronToolsAllowExecTarget;
+  /** Exact expected pin for jobs created from a verified host-owned exec projection. */
+  toolsAllowExecTargetRequirement?: CronToolsAllowExecTargetRequirement;
   /** Runtime-private authority omitted from public Gateway and wire contracts. */
   runtimeAuthority?: CronRuntimeAuthority;
   /** Authority was explicitly cleared and must be reauthorized before app reuse. */

--- a/src/gateway/agent-runtime-identity-token.test.ts
+++ b/src/gateway/agent-runtime-identity-token.test.ts
@@ -364,6 +364,7 @@ describe("agent runtime identity token", () => {
       sessionKey: "agent:main:main",
       operationalRunInstance: run.operationalRunInstance,
       cronToolsAllowCapture: "final-executable-surface",
+      cronExecToolTarget: { host: "gateway", ask: "always" },
     });
 
     await expect(runtimeToken.verifyAgentRuntimeIdentityToken(token)).resolves.toMatchObject({
@@ -372,6 +373,7 @@ describe("agent runtime identity token", () => {
       sessionKey: "agent:main:main",
       operationalRunInstance: run.operationalRunInstance,
       cronToolsAllowCapture: "final-executable-surface",
+      cronExecToolTarget: { host: "gateway", ask: "always" },
     });
   });
 

--- a/src/gateway/agent-runtime-identity-token.ts
+++ b/src/gateway/agent-runtime-identity-token.ts
@@ -58,6 +58,7 @@ export type AgentRuntimeIdentity = {
   messageActionContext?: AgentRuntimeMessageActionContext;
   cronSelfManagementContext?: AgentRuntimeCronSelfManagementContext;
   cronToolsAllowCapture?: "final-executable-surface";
+  cronExecToolTarget?: { host: "gateway" };
   cronCreatorAuthorityGrant?: CronCreatorAuthorityGrant;
   sessionSpawnContext?: AgentRuntimeSessionSpawnContext;
 };
@@ -89,6 +90,7 @@ type AgentRuntimeIdentityTokenPayload = {
   messageActionContext?: AgentRuntimeMessageActionContext;
   cronSelfManagementContext?: AgentRuntimeCronSelfManagementContext;
   cronToolsAllowCapture?: "final-executable-surface";
+  cronExecToolTarget?: { host: "gateway" };
   cronCreatorAuthorityGrant?: CronCreatorAuthorityGrant;
   sessionSpawnContext?: AgentRuntimeSessionSpawnContext;
   executionLineageHandoffId?: string;
@@ -227,6 +229,7 @@ const agentRuntimeIdentityTokenPayloadSchema = z.object({
   messageActionContext: messageActionContextSchema.optional(),
   cronSelfManagementContext: cronSelfManagementContextSchema.optional(),
   cronToolsAllowCapture: z.literal("final-executable-surface").optional(),
+  cronExecToolTarget: z.object({ host: z.literal("gateway") }).optional(),
   cronCreatorAuthorityGrant: cronCreatorAuthorityGrantSchema.optional(),
   sessionSpawnContext: sessionSpawnContextSchema.optional(),
   executionLineageHandoffId: normalizedRequiredStringSchema.optional(),
@@ -372,6 +375,7 @@ function decodePayload(value: string, nowMs: number): AgentRuntimeIdentityTokenP
     const sessionSpawnContext = raw.sessionSpawnContext;
     const executionLineageHandoffId = raw.executionLineageHandoffId;
     const cronToolsAllowCapture = raw.cronToolsAllowCapture;
+    const cronExecToolTarget = cronToolsAllowCapture ? raw.cronExecToolTarget : undefined;
     const cronCreatorAuthorityGrant = raw.cronCreatorAuthorityGrant;
     if (cronCreatorAuthorityGrant && !cronToolsAllowCapture) {
       return undefined;
@@ -404,6 +408,7 @@ function decodePayload(value: string, nowMs: number): AgentRuntimeIdentityTokenP
       ...(sessionSpawnContext ? { sessionSpawnContext } : {}),
       ...(executionLineageHandoffId ? { executionLineageHandoffId } : {}),
       ...(cronToolsAllowCapture ? { cronToolsAllowCapture } : {}),
+      ...(cronExecToolTarget ? { cronExecToolTarget } : {}),
       ...(cronCreatorAuthorityGrant ? { cronCreatorAuthorityGrant } : {}),
       ...(executionIdentity ? { executionIdentity } : {}),
     };
@@ -426,6 +431,7 @@ export type AgentRuntimeIdentityTokenParams = {
   messageActionContext?: AgentRuntimeMessageActionContext;
   cronSelfManagementJobId?: string;
   cronToolsAllowCapture?: "final-executable-surface";
+  cronExecToolTarget?: { host: "gateway" };
   cronCreatorAuthorityGrant?: CronCreatorAuthorityGrant;
   sessionSpawnContext?: AgentRuntimeSessionSpawnContext;
   executionLineageHandoffId?: string;
@@ -528,6 +534,10 @@ function prepareAgentRuntimeIdentityTokenPayload(params: AgentRuntimeIdentityTok
     ...(params.cronToolsAllowCapture === "final-executable-surface"
       ? { cronToolsAllowCapture: params.cronToolsAllowCapture }
       : {}),
+    ...(params.cronToolsAllowCapture === "final-executable-surface" &&
+    params.cronExecToolTarget?.host === "gateway"
+      ? { cronExecToolTarget: { host: "gateway" as const } }
+      : {}),
     ...(params.cronCreatorAuthorityGrant
       ? { cronCreatorAuthorityGrant: params.cronCreatorAuthorityGrant }
       : {}),
@@ -617,6 +627,7 @@ export async function verifyAgentRuntimeIdentityToken(
     ...(payload.cronToolsAllowCapture
       ? { cronToolsAllowCapture: payload.cronToolsAllowCapture }
       : {}),
+    ...(payload.cronExecToolTarget ? { cronExecToolTarget: payload.cronExecToolTarget } : {}),
     ...(payload.cronCreatorAuthorityGrant
       ? { cronCreatorAuthorityGrant: payload.cronCreatorAuthorityGrant }
       : {}),

--- a/src/gateway/agent-runtime-identity-token.ts
+++ b/src/gateway/agent-runtime-identity-token.ts
@@ -58,7 +58,7 @@ export type AgentRuntimeIdentity = {
   messageActionContext?: AgentRuntimeMessageActionContext;
   cronSelfManagementContext?: AgentRuntimeCronSelfManagementContext;
   cronToolsAllowCapture?: "final-executable-surface";
-  cronExecToolTarget?: { host: "gateway" };
+  cronExecToolTarget?: { host: "gateway"; ask?: "always" };
   cronCreatorAuthorityGrant?: CronCreatorAuthorityGrant;
   sessionSpawnContext?: AgentRuntimeSessionSpawnContext;
 };
@@ -90,7 +90,7 @@ type AgentRuntimeIdentityTokenPayload = {
   messageActionContext?: AgentRuntimeMessageActionContext;
   cronSelfManagementContext?: AgentRuntimeCronSelfManagementContext;
   cronToolsAllowCapture?: "final-executable-surface";
-  cronExecToolTarget?: { host: "gateway" };
+  cronExecToolTarget?: { host: "gateway"; ask?: "always" };
   cronCreatorAuthorityGrant?: CronCreatorAuthorityGrant;
   sessionSpawnContext?: AgentRuntimeSessionSpawnContext;
   executionLineageHandoffId?: string;
@@ -229,7 +229,9 @@ const agentRuntimeIdentityTokenPayloadSchema = z.object({
   messageActionContext: messageActionContextSchema.optional(),
   cronSelfManagementContext: cronSelfManagementContextSchema.optional(),
   cronToolsAllowCapture: z.literal("final-executable-surface").optional(),
-  cronExecToolTarget: z.object({ host: z.literal("gateway") }).optional(),
+  cronExecToolTarget: z
+    .object({ host: z.literal("gateway"), ask: z.literal("always").optional() })
+    .optional(),
   cronCreatorAuthorityGrant: cronCreatorAuthorityGrantSchema.optional(),
   sessionSpawnContext: sessionSpawnContextSchema.optional(),
   executionLineageHandoffId: normalizedRequiredStringSchema.optional(),
@@ -431,7 +433,7 @@ export type AgentRuntimeIdentityTokenParams = {
   messageActionContext?: AgentRuntimeMessageActionContext;
   cronSelfManagementJobId?: string;
   cronToolsAllowCapture?: "final-executable-surface";
-  cronExecToolTarget?: { host: "gateway" };
+  cronExecToolTarget?: { host: "gateway"; ask?: "always" };
   cronCreatorAuthorityGrant?: CronCreatorAuthorityGrant;
   sessionSpawnContext?: AgentRuntimeSessionSpawnContext;
   executionLineageHandoffId?: string;
@@ -536,7 +538,7 @@ function prepareAgentRuntimeIdentityTokenPayload(params: AgentRuntimeIdentityTok
       : {}),
     ...(params.cronToolsAllowCapture === "final-executable-surface" &&
     params.cronExecToolTarget?.host === "gateway"
-      ? { cronExecToolTarget: { host: "gateway" as const } }
+      ? { cronExecToolTarget: { ...params.cronExecToolTarget } }
       : {}),
     ...(params.cronCreatorAuthorityGrant
       ? { cronCreatorAuthorityGrant: params.cronCreatorAuthorityGrant }

--- a/src/gateway/agent-turn/agent-handler-helpers.ts
+++ b/src/gateway/agent-turn/agent-handler-helpers.ts
@@ -14,6 +14,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
   CronScheduledToolCallerOrigin,
   CronScheduledToolPolicy,
+  CronToolsAllowExecTarget,
 } from "../../cron/scheduled-tool-policy.js";
 import type { PluginHookSessionEndReason } from "../../plugins/hook-types.js";
 import {
@@ -43,6 +44,7 @@ export type RestoredCronContinuation = {
   toolsAllowIsDefault?: boolean;
   scheduledToolPolicy?: CronScheduledToolPolicy;
   scheduledToolCallerOrigin?: CronScheduledToolCallerOrigin;
+  toolsAllowExecTarget?: CronToolsAllowExecTarget;
   cliSessionBindingFacts?: {
     extraSystemPromptStatic?: string;
     sourceReplyDeliveryMode?: "automatic" | "message_tool_only";

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -349,6 +349,7 @@ export function startAgentRunExecution(params: {
                     toolsAllow: params.restoredCronContinuation.toolsAllow,
                     scheduledToolPolicy: params.restoredCronContinuation.scheduledToolPolicy,
                     callerOrigin: params.restoredCronContinuation.scheduledToolCallerOrigin,
+                    execTarget: params.restoredCronContinuation.toolsAllowExecTarget,
                   })
                 : undefined,
               requireExplicitMessageTarget:

--- a/src/gateway/agent-turn/agent-session-persist.ts
+++ b/src/gateway/agent-turn/agent-session-persist.ts
@@ -25,6 +25,8 @@ import {
   normalizeCronScheduledToolCallerOrigin,
   normalizeCronScheduledToolPolicy,
   normalizeCronToolsAllowExecTarget,
+  resolveCronToolsAllowExecTargetRecoveryError,
+  restoreCronPinnedExecGrant,
 } from "../../cron/scheduled-tool-policy.js";
 import { assertAgentRunLifecycleGenerationCurrent } from "../../infra/agent-events.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -249,12 +251,24 @@ export async function persistAgentSessionPhase(params: {
                   "cron run continuation has no reusable native CLI session";
                 throw new Error(restoredCronContinuationError);
               }
+              restoredCronContinuationError = resolveCronToolsAllowExecTargetRecoveryError({
+                requirement: marker.toolsAllowExecTargetRequirement,
+                execTarget: marker.toolsAllowExecTarget,
+              });
+              if (restoredCronContinuationError) {
+                throw new Error(restoredCronContinuationError);
+              }
+              const restoredToolsAllow = restoreCronPinnedExecGrant({
+                toolsAllow: marker.toolsAllow,
+                requirement: marker.toolsAllowExecTargetRequirement,
+                execTarget: marker.toolsAllowExecTarget,
+              });
               restoredCronContinuation = {
                 ...params.restoredCronContinuationIdentity,
                 provider,
                 model,
                 ...(freshEntry.thinkingLevel ? { thinking: freshEntry.thinkingLevel } : {}),
-                ...(marker.toolsAllow !== undefined ? { toolsAllow: [...marker.toolsAllow] } : {}),
+                ...(restoredToolsAllow !== undefined ? { toolsAllow: restoredToolsAllow } : {}),
                 ...(marker.toolsAllowIsDefault === true ? { toolsAllowIsDefault: true } : {}),
                 ...(normalizeCronScheduledToolPolicy(marker.scheduledToolPolicy)
                   ? {

--- a/src/gateway/agent-turn/agent-session-persist.ts
+++ b/src/gateway/agent-turn/agent-session-persist.ts
@@ -24,6 +24,7 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   normalizeCronScheduledToolCallerOrigin,
   normalizeCronScheduledToolPolicy,
+  normalizeCronToolsAllowExecTarget,
 } from "../../cron/scheduled-tool-policy.js";
 import { assertAgentRunLifecycleGenerationCurrent } from "../../infra/agent-events.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
@@ -266,6 +267,13 @@ export async function persistAgentSessionPhase(params: {
                   ? {
                       scheduledToolCallerOrigin: normalizeCronScheduledToolCallerOrigin(
                         marker.scheduledToolCallerOrigin,
+                      ),
+                    }
+                  : {}),
+                ...(normalizeCronToolsAllowExecTarget(marker.toolsAllowExecTarget)
+                  ? {
+                      toolsAllowExecTarget: normalizeCronToolsAllowExecTarget(
+                        marker.toolsAllowExecTarget,
                       ),
                     }
                   : {}),

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -816,6 +816,7 @@ export function buildGatewayCronService(params: {
                 scheduledToolPolicy: job.scheduledToolPolicy,
                 owner: job.owner,
               }),
+              execTarget: job.toolsAllowExecTarget,
               abortSignal,
             }),
         }
@@ -1005,6 +1006,7 @@ export function buildGatewayCronService(params: {
           scheduledToolPolicy: job.scheduledToolPolicy,
           owner: job.owner,
         }),
+        execTarget: job.toolsAllowExecTarget,
         timeoutSeconds: job.payload.timeoutSeconds,
         toolBudget: job.payload.toolBudget,
         abortSignal,

--- a/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
+++ b/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
@@ -1440,6 +1440,8 @@ describe("gateway agent handler", () => {
         basePersisted: true,
         toolsAllow: ["image_generate", "write"],
         toolsAllowIsDefault: true,
+        scheduledToolPolicy: { version: 1, mode: "trusted" },
+        toolsAllowExecTarget: { version: 1, host: "gateway", ask: "always" },
         cliSessionBindingFacts: {
           sourceReplyDeliveryMode: "automatic" as const,
           requireExplicitMessageTarget: true,
@@ -1484,6 +1486,11 @@ describe("gateway agent handler", () => {
       sessionId?: string;
       toolsAllow?: string[];
       toolsAllowIsDefault?: boolean;
+      scheduledToolPolicy?: {
+        version: 1;
+        mode: "trusted";
+        execTarget?: { host: "gateway"; ask?: "always" };
+      };
       requireExplicitMessageTarget?: boolean;
       sourceReplyDeliveryMode?: string;
       cliSessionBindingFacts?: {
@@ -1500,6 +1507,11 @@ describe("gateway agent handler", () => {
     expect(callArgs.bootstrapContextRunKind).toBe("cron");
     expect(callArgs.toolsAllow).toEqual(["image_generate", "write"]);
     expect(callArgs.toolsAllowIsDefault).toBe(true);
+    expect(callArgs.scheduledToolPolicy).toEqual({
+      version: 1,
+      mode: "trusted",
+      execTarget: { host: "gateway", ask: "always" },
+    });
     expect(callArgs.requireExplicitMessageTarget).toBe(true);
     expect(callArgs.sourceReplyDeliveryMode).toBe("automatic");
     expect(callArgs.cliSessionBindingFacts).toEqual({

--- a/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
+++ b/src/gateway/server-methods/agent.media-and-routing.test-utils.ts
@@ -1442,6 +1442,11 @@ describe("gateway agent handler", () => {
         toolsAllowIsDefault: true,
         scheduledToolPolicy: { version: 1, mode: "trusted" },
         toolsAllowExecTarget: { version: 1, host: "gateway", ask: "always" },
+        toolsAllowExecTargetRequirement: {
+          version: 1,
+          target: { version: 1, host: "gateway", ask: "always" },
+          grantIndex: 1,
+        },
         cliSessionBindingFacts: {
           sourceReplyDeliveryMode: "automatic" as const,
           requireExplicitMessageTarget: true,
@@ -1505,7 +1510,7 @@ describe("gateway agent handler", () => {
     expect(callArgs.model).toBe("claude-opus-4-8");
     expect(callArgs.thinking).toBe("high");
     expect(callArgs.bootstrapContextRunKind).toBe("cron");
-    expect(callArgs.toolsAllow).toEqual(["image_generate", "write"]);
+    expect(callArgs.toolsAllow).toEqual(["image_generate", "exec", "write"]);
     expect(callArgs.toolsAllowIsDefault).toBe(true);
     expect(callArgs.scheduledToolPolicy).toEqual({
       version: 1,
@@ -1567,6 +1572,15 @@ describe("gateway agent handler", () => {
       basePersisted: false,
       code: ErrorCodes.INVALID_REQUEST,
     },
+    {
+      name: "when its required exec pin is missing",
+      client: "continuation" as const,
+      phase: "ready" as const,
+      freshRevision: "revision-1",
+      basePersisted: true,
+      damagedExecPin: true,
+      code: ErrorCodes.UNAVAILABLE,
+    },
   ])("rejects a cron media continuation $name", async (testCase) => {
     mocks.agentCommand.mockClear();
     const sessionKey = "agent:main:cron:job-1:run:run-1";
@@ -1582,6 +1596,16 @@ describe("gateway agent handler", () => {
           "basePersisted" in testCase ? testCase.basePersisted : testCase.phase === "ready",
         ...("ownerLifecycleGeneration" in testCase
           ? { ownerLifecycleGeneration: testCase.ownerLifecycleGeneration }
+          : {}),
+        ...("damagedExecPin" in testCase
+          ? {
+              toolsAllow: ["image_generate", "write"],
+              toolsAllowExecTargetRequirement: {
+                version: 1,
+                target: { version: 1, host: "gateway", ask: "always" },
+                grantIndex: 1,
+              },
+            }
           : {}),
       },
     };

--- a/src/gateway/server-methods/cron-caller-scope.test.ts
+++ b/src/gateway/server-methods/cron-caller-scope.test.ts
@@ -43,12 +43,18 @@ describe("cron caller scope ownership", () => {
             sessionKey: "agent:main:main",
             turnSourceAccountId: "work",
             cronToolsAllowCapture: "final-executable-surface",
+            cronExecToolTarget: { host: "gateway", ask: "always" },
             ...source,
           },
         },
       } as never);
 
       expect(scope?.toolsAllowProvenance?.callerOrigin).toEqual(origin);
+      expect(scope?.toolsAllowExecTarget).toEqual({
+        version: 1,
+        host: "gateway",
+        ask: "always",
+      });
     },
   );
 

--- a/src/gateway/server-methods/cron-caller-scope.ts
+++ b/src/gateway/server-methods/cron-caller-scope.ts
@@ -8,6 +8,7 @@ import type {
   CronJob,
   CronJobCreate,
   CronJobPatch,
+  CronToolsAllowExecTarget,
   CronToolsAllowProvenance,
 } from "../../cron/types.js";
 import { normalizeAccountId } from "../../routing/account-id.js";
@@ -23,6 +24,8 @@ export type CronCallerScope = {
   accountId: string;
   currentJobId?: string;
   toolsAllowProvenance?: CronToolsAllowProvenance;
+  /** Restrict-only exec pin carried by the signed creator-turn identity. */
+  toolsAllowExecTarget?: CronToolsAllowExecTarget;
   cronCreatorAuthorityGrant?: CronCreatorAuthorityGrant;
 };
 
@@ -57,6 +60,11 @@ export function readCronCallerScope(
             source: "final-executable-surface" as const,
             callerOrigin,
           },
+          ...(identity.cronExecToolTarget?.host === "gateway"
+            ? {
+                toolsAllowExecTarget: { version: 1 as const, host: "gateway" as const },
+              }
+            : {}),
         }
       : {}),
     ...(identity.cronCreatorAuthorityGrant

--- a/src/gateway/server-methods/cron-caller-scope.ts
+++ b/src/gateway/server-methods/cron-caller-scope.ts
@@ -24,7 +24,7 @@ export type CronCallerScope = {
   accountId: string;
   currentJobId?: string;
   toolsAllowProvenance?: CronToolsAllowProvenance;
-  /** Restrict-only exec pin carried by the signed creator-turn identity. */
+  /** Restrict-only exec policy carried by the signed creator-turn identity. */
   toolsAllowExecTarget?: CronToolsAllowExecTarget;
   cronCreatorAuthorityGrant?: CronCreatorAuthorityGrant;
 };
@@ -62,7 +62,10 @@ export function readCronCallerScope(
           },
           ...(identity.cronExecToolTarget?.host === "gateway"
             ? {
-                toolsAllowExecTarget: { version: 1 as const, host: "gateway" as const },
+                toolsAllowExecTarget: {
+                  version: 1 as const,
+                  ...identity.cronExecToolTarget,
+                },
               }
             : {}),
         }

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -943,6 +943,9 @@ export const cronHandlers: GatewayRequestHandlers = {
               ...(callerScope?.toolsAllowProvenance
                 ? { toolsAllowProvenance: callerScope.toolsAllowProvenance }
                 : {}),
+              ...(callerScope?.toolsAllowExecTarget
+                ? { toolsAllowExecTarget: callerScope.toolsAllowExecTarget }
+                : {}),
             }
           : {}),
       });
@@ -1146,6 +1149,9 @@ export const cronHandlers: GatewayRequestHandlers = {
               scheduledToolPolicy: resolveCronScheduledToolPolicyForCaller(callerScope),
               ...(callerScope?.toolsAllowProvenance
                 ? { toolsAllowProvenance: callerScope.toolsAllowProvenance }
+                : {}),
+              ...(callerScope?.toolsAllowExecTarget
+                ? { toolsAllowExecTarget: callerScope.toolsAllowExecTarget }
                 : {}),
               ...(commitGuard ? { commitGuard } : {}),
               ...(captureRuntimeAuthority ? { captureRuntimeAuthority } : {}),

--- a/src/plugin-sdk/codex-mcp-projection.test.ts
+++ b/src/plugin-sdk/codex-mcp-projection.test.ts
@@ -1,0 +1,34 @@
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import type { AnyAgentTool } from "../agents/tools/common.js";
+
+describe("codex MCP projection", () => {
+  it("does not expose scheduled authority minting", async () => {
+    const projection = await import("./codex-mcp-projection.js");
+
+    expect(projection).not.toHaveProperty("bindCronScheduledTool");
+  });
+
+  it("does not capture a colliding plugin-created gateway exec tool", async () => {
+    const projection = await import("./codex-mcp-projection.js");
+    const tools: Array<string | { name: string; pluginId?: string }> = [];
+    const captureRef: { value?: { version: 1; source: "final-executable-surface" } } = {};
+    const collidingTool = {
+      name: "gateway_exec",
+      label: "Plugin gateway exec",
+      description: "A plugin-created tool with the same name as the Codex alias.",
+      parameters: Type.Object({}),
+      execute: async () => ({ content: [], details: {} }),
+    } satisfies AnyAgentTool;
+
+    const authority = await projection.captureFinalCodexCronCreatorToolAllowlist(
+      tools,
+      captureRef,
+      [collidingTool],
+    );
+
+    expect(tools).toEqual([{ name: "gateway_exec" }]);
+    expect(captureRef.value).toEqual({ version: 1, source: "final-executable-surface" });
+    expect(authority).toBeUndefined();
+  });
+});

--- a/src/plugin-sdk/codex-mcp-projection.ts
+++ b/src/plugin-sdk/codex-mcp-projection.ts
@@ -2,11 +2,30 @@
 // runtime's user-mcp-server projection so the bundled Codex app-server harness
 // can attach the same user `mcp.servers` entries to its thread config without
 // deep-importing core helpers.
+import { pinExecToolTarget } from "../agents/exec-tool-target-pinning.js";
+import type { AgentHarnessHostCapabilities } from "../agents/harness/host-capability-types.js";
+import {
+  resolveAgentHarnessScheduledToolProjectionCapability,
+  type AgentHarnessScheduledToolProjectionFactory,
+} from "../agents/harness/host-private-capabilities.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import type {
   CronCreatorToolAllowlistEntry,
   CronToolsAllowCaptureRef,
 } from "../agents/tools/cron-tool.types.js";
+
+export { pinExecToolTarget };
+export type CodexScheduledToolProjectionFactory = AgentHarnessScheduledToolProjectionFactory;
+
+/** Resolve the private scheduled-tool projection issuer for the Codex harness owner. */
+export function resolveCodexScheduledToolProjectionFactory(
+  hostCapabilities: AgentHarnessHostCapabilities,
+): CodexScheduledToolProjectionFactory | undefined {
+  return resolveAgentHarnessScheduledToolProjectionCapability({
+    hostCapabilities,
+    ownerPluginId: "codex",
+  });
+}
 
 export {
   buildCodexUserMcpServersThreadConfigPatch,

--- a/ui/src/test-helpers/mock-gateway-page.test-support.ts
+++ b/ui/src/test-helpers/mock-gateway-page.test-support.ts
@@ -1,9 +1,9 @@
 import { Script } from "node:vm";
-import { JSDOM, type DOMWindow } from "jsdom";
+import { JSDOM } from "jsdom";
 import { it } from "vitest";
 
 type MockGatewayPage = {
-  window: DOMWindow;
+  window: Window & typeof globalThis;
   execute: (script: string) => void;
   close: () => void;
 };
@@ -13,7 +13,7 @@ export const mockGatewayTest = it.extend<{ gatewayPage: MockGatewayPage }>({
     const dom = new JSDOM("", { url: "http://mock-control-ui/", runScripts: "outside-only" });
     try {
       await use({
-        window: dom.window,
+        window: dom.window as unknown as Window & typeof globalThis,
         execute: (script) => {
           new Script(script, { filename: `mock-gateway:${task.name}` }).runInContext(
             dom.getInternalVMContext(),


### PR DESCRIPTION
Supersedes #126496. Related: #92238.

## What Problem This Solves

Cron trigger scripts created from a Codex-backed turn fail with `Unknown tool id: exec` when they use the documented `exec(...)` contract. Codex sessions present OpenClaw's `exec` as a runtime-specific dynamic tool named `gateway_exec`; creator capture recorded that presentation name into the persisted `toolsAllow` cap, and the headless trigger runtime — which rebuilds canonical core tools — could not resolve it.

## Why This Change Was Made

The violated invariant: the core-owned `toolsAllow` cap must be recorded in core's canonical tool vocabulary, not a runtime's presentation names. #126496 compensated downstream — persisting the alias name plus a sealed sidecar binding that authorized a trigger-time `gateway_exec`→`exec` projection — and the *granting* nature of that persisted artifact forced SHA-256 seals, downgrade recovery, and a schema change.

This PR fixes the capture instead:

- **Object-identity projection registry (in-memory only).** The host capability marks the concrete `exec`/`process` tool objects it constructs; a host-private, `ownerPluginId`-gated factory is the only way to mint a Codex gateway alias from those exact objects. Capture consults the registry and records the alias under its canonical name. A foreign tool merely *named* `gateway_exec` has no registry entry, captures literally, and stays fail-closed. Nothing about the registry is persisted.
- **Durable fail-closed pin.** A private requirement records the exact Gateway target and original `exec` grant position. Storage removes `exec` from the generic persisted cap and restores it only when the requirement and target validate; missing, malformed, or mismatched state stays without broad `exec` and fails before trigger, script, or agent execution. Detached-media continuation copies and revalidates the same requirement. Legacy unmarked jobs retain their existing baseline policy. **No SQLite schema change.**
- **One enforcement choke point.** `createOpenClawCodingTools` pins the rebuilt exec tool (host default, argument rewrite, schema stripping, and the before-tool-call preparation/finalization lifecycle) when the scheduled context carries the pin — covering trigger scripts, script payloads, non-Codex isolated agent turns, and the cron run continuation path. Codex-runtime payload runs already rebuild pinned aliases via the landed scheduled-app-authority round trip.
- Node (`node_exec`) and sandbox aliases stay unmapped (fail closed), matching #126496's scoping. Existing jobs with persisted `gateway_exec` caps are not migrated (explicit maintainer decision): recreate them from a creator turn.

## User Impact

Automations created from a Codex-backed session can call `exec(...)` in trigger and script payloads without widening `toolsAllow`. The persisted cap is the ordinary canonical shape (`toolsAllow: ["exec", ...]`), inspectable with standard tooling. The command stays pinned to the Gateway even when cron's configured default exec host differs, and the pin survives detached-media run continuations. Same-name non-Codex tools, literal alias-name caps, and node/sandbox aliases fail closed.

## Evidence

**Current exact-head follow-up:** rebased onto `869cf47b8dafe7c372a788c615ee7e7acc5bd85d`; exact head `ddef1ff060da565f589291cdb623dc90bb6887e8`. Full build, 6 focused Vitest shards / 195 tests, every `check-changed` lane, and fresh whole-branch autoreview passed. ClawSweeper dispositions, exact-head real-Gateway deny/no-side-effect plus allow-once proof, direct Codex contract links, managed scheduler evidence, and cleanup are recorded in [the durable proof comment](https://github.com/openclaw/openclaw/pull/130579#issuecomment-5454255068). Exact-head CI is attached as [run 33183670282](https://github.com/openclaw/openclaw/actions/runs/33183670282).

Original validation on head `713294f66ab` (approval-floor repair plus the existing canonical-capture change):

- `pnpm check:changed` over the full changed set passes every lane (format, ratchets, dead-export scan, core/extension typechecks, core/extension lint, import cycles, plugin boundaries, SDK surface budget).
- Focused suites pass: cron store/normalize/ops/trigger-script/jobs-tool-policy, creator-cap, scheduled-tool-policy, host-capability, agent-tool metadata, run-session-state, agent-session-persist, plugin-sdk projection, and the Codex extension `dynamic-tool-build` suite (90 tests exercising the production host-capability + projection-factory path).
- New regression coverage: capture canonicalization and alias-name cap matching; collision fail-closed (unregistered `gateway_exec` captured literally; trigger errors `exec is not defined` with no filesystem effect); pin persistence round-trip with tolerant normalization (foreign shapes dropped, future extra keys tolerated); pin enforcement across schema/arguments/preparation lifecycle; continuation-slot round-trip; trusted-context re-resolution.
- Guarded approval-floor coverage: capture, signed caller identity, cron persistence, hidden continuation, generated-media continuation, runtime reconstruction, and the full preparation/finalization lifecycle retain `ask: "always"`. A real Gateway E2E starts from `tools.exec.ask: "off"`; denial prevents the marker side effect, while a separate allow-once request completes.
- Trigger-level final-effect regression: a canonically captured pinned cap executes `exec(...)` gateway-pinned **while the configured default exec host is a nonexistent node**, proving the pin (not config luck) carries execution; the same script with a literal `gateway_exec` cap fails closed.

Managed-Gateway proof was later completed on packaged substantive head `713294f66ab` (patch-equivalent to the previous PR head except a lint-only refactor): guarded canonical capture persisted `ask: "always"`, its natural trigger was denied with no marker effect, an unguarded comparison succeeded, trigger updates retained the floor, and a separate five-minute one-shot visibly delivered into WebChat. It is explicitly not exact-current-head proof. The ClawSweeper persistent-full-session repair is covered on exact current head by a real-Gateway deny/no-side-effect plus allow-once E2E; full evidence and cleanup are in [the follow-up comment](https://github.com/openclaw/openclaw/pull/130579#issuecomment-5454255068). The earlier canonical-capture run was:

1. A real Codex-backed creator turn (`openai/gpt-5.6-luna`, `agentRuntime: { id: "codex" }`) called the automations tool once to add a trigger job **without** `toolsAllow`.
2. Persisted row (SQLite `cron_jobs.job_json`): `toolsAllow` contains canonical `exec` and `process` (plus `node_exec` captured literally, unmapped by design), `toolsAllowIsDefault: true`, `toolsAllowExecTarget: { version: 1, host: "gateway" }`, `toolsAllowProvenance: { source: "final-executable-surface", ... }`, account-mode `scheduledToolPolicy` — no `gateway_exec` anywhere.
3. The trigger fired on schedule and Gateway-pinned `exec` wrote the allowed marker file.
4. Forbidden colliding-issuer case: an operator-created job with literal `toolsAllow: ["gateway_exec"]` and the same trigger script recorded `cron trigger evaluation failed (internal_error): ReferenceError: exec is not defined` in run history, and the forbidden marker check returned ENOENT — stopped before any filesystem I/O.

Direct Codex contract inspection used the exact pinned `@openai/codex` **0.150.1** source (sibling `../codex` checkout, tag `rust-v0.150.1`, commit `90854393966b21e9ebfd21b122334eb09a20c93d`), personally inspected by the acting agent:

- `codex-rs/protocol/src/dynamic_tools.rs` — `DynamicToolFunctionSpec` carries name/description/input_schema/defer_loading; `DynamicToolCallRequest` carries call_id/turn_id/started_at_ms/namespace/tool/arguments. No producer identity crosses the protocol, which is why producer identity lives in OpenClaw's object-identity registry rather than anything round-tripped through Codex.
- `codex-rs/app-server/src/request_processors/thread_processor.rs:326-411` — `validate_dynamic_tools` rejects empty/whitespace/reserved names, duplicate names per namespace, and duplicate namespaces, so a colliding registration cannot shadow the harness alias within a namespace.
- `codex-rs/core/src/tools/handlers/dynamic.rs` — dispatch reconstructs `ToolName` from namespace+name and round-trips arguments only.

Follow-up uncommitted-diff autoreview on the approval-floor repair (Codex `gpt-5.6-sol`) was clean at 0.98 confidence with no accepted/actionable findings. Earlier branch autoreview (Codex `gpt-5.5`, `--mode branch --base origin/main`): final run clean — "no actionable defects; the patch consistently carries the captured Gateway exec target from the Codex host projection through cron creation, persistence, and scheduled runtime reconstruction" (0.83). Three earlier accepted findings were fixed with regression tests (continuation-path pin propagation, whole-lifecycle pinning including exec preparation, trusted-context re-resolution); one finding (alias identity loss via bridge re-wrap) was rejected with direct evidence — the spread-carried symbol wrap marker makes the bridge skip re-wrapping (`extensions/codex/src/app-server/dynamic-tools.ts:1075`), confirmed by the live managed run.

Current production LOC: net +595 (+814/−219); tests/tooling net +648 (+896/−248). The growth funds the host-identity alias issuance, canonical capture, restrict-only pin across persistence/continuation, and lifecycle-complete enforcement; the follow-up approval-floor repair itself is one non-bypassable owner-boundary expression.

This PR is AI-assisted. I reviewed the implementation and validation results and understand the change.



