### PR TITLE
feat(feishu): declare full durableFinal capabilities on message adapter

### DIFF
--- a/extensions/feishu/src/channel.message-adapter.test.ts
+++ b/extensions/feishu/src/channel.message-adapter.test.ts
@@ -1,0 +1,85 @@
+// Feishu tests cover channel.message adapter durable-final capability declarations.
+import { verifyChannelMessageAdapterCapabilityProofs } from "openclaw/plugin-sdk/channel-outbound";
+import { describe, expect, it } from "vitest";
+import { feishuPlugin } from "../channel-plugin-api.js";
+
+type FeishuMessageAdapter = NonNullable<typeof feishuPlugin.message>;
+
+function requireFeishuMessageAdapter(): FeishuMessageAdapter {
+  const adapter = feishuPlugin.message;
+  if (!adapter) {
+    throw new Error("Expected Feishu message adapter");
+  }
+  return adapter;
+}
+
+describe("feishu channel message adapter", () => {
+  it("declares the durable-final capabilities Feishu supports at runtime", () => {
+    const adapter = requireFeishuMessageAdapter();
+    const capabilities = adapter.durableFinal?.capabilities;
+
+    expect(capabilities?.text).toBe(true);
+    expect(capabilities?.media).toBe(true);
+    expect(capabilities?.payload).toBe(true);
+    expect(capabilities?.replyTo).toBe(true);
+    expect(capabilities?.thread).toBe(true);
+    expect(capabilities?.messageSendingHooks).toBe(true);
+  });
+
+  it("does not declare durable-final capabilities Feishu lacks", () => {
+    const adapter = requireFeishuMessageAdapter();
+    const capabilities = adapter.durableFinal?.capabilities;
+
+    // silent/batch/poll/nativeQuote are not supported by the Feishu send path;
+    // declaring them would let core assume guarantees the channel cannot honor.
+    expect(capabilities?.silent).not.toBe(true);
+    expect(capabilities?.batch).not.toBe(true);
+    expect(capabilities?.poll).not.toBe(true);
+    expect(capabilities?.nativeQuote).not.toBe(true);
+  });
+
+  it("routes payload delivery through the message-adapter lifecycle sender", () => {
+    // The message adapter defines send.payload so core runs it through
+    // runChannelMessageSendWithLifecycle (src/infra/outbound/deliver-channel.ts
+    // sendPayload = messagePayload || outbound?.sendPayload). Without it core
+    // falls back to outbound.sendPayload, which skips the lifecycle and can
+    // mark a payload dispatched before the sender resolves.
+    const adapter = requireFeishuMessageAdapter();
+    expect(typeof adapter.send?.payload).toBe("function");
+    expect(typeof adapter.send?.lifecycle?.beforeSendAttempt).toBe("function");
+  });
+
+  it("backs declared durable-final capabilities with adapter proofs", async () => {
+    const adapter = requireFeishuMessageAdapter();
+
+    // The verifier iterates the canonical capability list and throws if a
+    // declared capability has no proof, so a complete proofs map for every
+    // declared capability is itself the contract check (mirrors telegram).
+    await verifyChannelMessageAdapterCapabilityProofs({
+      adapterName: "feishuMessageAdapter",
+      adapter,
+      proofs: {
+        text: () => {
+          expect(typeof adapter.send?.text).toBe("function");
+        },
+        media: () => {
+          expect(typeof adapter.send?.media).toBe("function");
+        },
+        // Payload routes through the message-adapter send.payload sender, which
+        // participates in the same lifecycle as text/media.
+        payload: () => {
+          expect(typeof adapter.send?.payload).toBe("function");
+        },
+        replyTo: () => {
+          expect(typeof adapter.send?.text).toBe("function");
+        },
+        thread: () => {
+          expect(typeof adapter.send?.text).toBe("function");
+        },
+        messageSendingHooks: () => {
+          expect(typeof adapter.send?.lifecycle?.beforeSendAttempt).toBe("function");
+        },
+      },
+    });
+  });
+});

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -304,6 +304,12 @@ const resolveFeishuMediaSender = () =>
     unavailableMessage: "Feishu media sending is not available.",
   });
 
+const resolveFeishuPayloadSender = () =>
+  resolveFeishuMessageSender({
+    resolve: (runtime) => runtime.feishuOutbound.sendPayload,
+    unavailableMessage: "Feishu payload sending is not available.",
+  });
+
 function toFeishuMessageSendResult(
   result: { messageId?: string; chatId?: string; receipt?: ChannelMessageSendResult["receipt"] },
   kind: MessageReceiptPartKind,
@@ -327,6 +333,14 @@ const feishuMessageAdapter = defineChannelMessageAdapter({
     capabilities: {
       text: true,
       media: true,
+      // Owner boundary: payload is declared because send.payload routes it
+      // through the message-adapter lifecycle, matching text/media so a lost
+      // provider result stays recoverable. Unsupported kinds
+      // (silent/batch/poll/nativeQuote) stay absent so core never assumes them.
+      payload: true,
+      replyTo: true,
+      thread: true,
+      messageSendingHooks: true,
     },
   },
   send: {
@@ -338,6 +352,8 @@ const feishuMessageAdapter = defineChannelMessageAdapter({
           await resolveFeishuTextSender();
         } else if (ctx.kind === "media") {
           await resolveFeishuMediaSender();
+        } else if (ctx.kind === "payload") {
+          await resolveFeishuPayloadSender();
         }
       },
     },
@@ -370,6 +386,26 @@ const feishuMessageAdapter = defineChannelMessageAdapter({
           : {}),
       });
       return toFeishuMessageSendResult(result, "media");
+    },
+    payload: async (ctx) => {
+      // Route structured payloads through the message-adapter lifecycle so a
+      // lost provider result stays ambiguous and recoverable, matching text/
+      // media. Without this sender core falls back to outbound.sendPayload,
+      // which skips runChannelMessageSendWithLifecycle and can mark a payload
+      // dispatched before the sender resolves.
+      const sendPayload = await resolveFeishuPayloadSender();
+      const { onDeliveryResult, ...outboundCtx } = ctx;
+      const result = await sendPayload({
+        ...outboundCtx,
+        ...(onDeliveryResult
+          ? {
+              onDeliveryResult: async (progress) => {
+                await onDeliveryResult(toFeishuMessageSendResult(progress, "card"));
+              },
+            }
+          : {}),
+      });
+      return toFeishuMessageSendResult(result, "card");
     },
   },
 });

--- a/extensions/feishu/src/outbound-delivery.test.ts
+++ b/extensions/feishu/src/outbound-delivery.test.ts
@@ -218,6 +218,141 @@ describe("Feishu outbound shared delivery", () => {
     }
   });
 
+  it("preserves replyTo context across a durable payload replay", async () => {
+    const originalSendText = feishuChannelRuntime.feishuOutbound.sendText;
+    if (!originalSendText) {
+      throw new Error("Expected Feishu runtime sendText");
+    }
+    const deliveryIntentId = "feishu-direct-replyto-preserved";
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "feishu", plugin: feishuPlugin, source: "test" }]),
+    );
+    feishuChannelRuntime.feishuOutbound.sendText = undefined;
+
+    try {
+      await withStateDirEnv("openclaw-feishu-durable-replyto-", async ({ stateDir }) => {
+        const initial = await sendDurableMessageBatch({
+          cfg: {},
+          channel: "feishu",
+          to: "chat_1",
+          accountId: "default",
+          durability: "required",
+          deliveryIntentId,
+          completionRetention,
+          maxRetries: 2,
+          replyToId: "om_parent",
+          payloads: [{ text: "reply context must survive replay" }],
+        });
+
+        expect(initial.status).toBe("failed");
+        expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+
+        feishuChannelRuntime.feishuOutbound.sendText = originalSendText;
+        await drainPendingDeliveries({
+          drainKey: "feishu:default",
+          logLabel: "Feishu replyTo replay",
+          cfg: {},
+          stateDir,
+          log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+          selectEntry: (entry) => ({
+            match: entry.channel === "feishu",
+            bypassBackoff: true,
+          }),
+        });
+
+        expect(sendMessageFeishuMock).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            to: "chat_1",
+            text: "reply context must survive replay",
+            replyToMessageId: "om_parent",
+          }),
+        );
+        expect(readDeliveryQueueRow(stateDir, deliveryIntentId)?.status).toBe("completed");
+      });
+    } finally {
+      feishuChannelRuntime.feishuOutbound.sendText = originalSendText;
+    }
+  });
+
+  it("replays a structured payload through the message-adapter lifecycle sender", async () => {
+    // Structured payloads route through message adapter send.payload, whose
+    // beforeSendAttempt resolves the runtime sender before core records
+    // platform-send start. An unavailable payload sender therefore fails in
+    // preflight (recovery_state stays null) instead of after dispatch, so the
+    // structured send stays safely replayable — the lifecycle guarantee the
+    // declared capabilities advertise. Without send.payload core would fall
+    // back to outbound.sendPayload, skip runChannelMessageSendWithLifecycle,
+    // and mark the payload dispatched before the sender resolves.
+    const originalSendPayload = feishuChannelRuntime.feishuOutbound.sendPayload;
+    if (!originalSendPayload) {
+      throw new Error("Expected Feishu runtime sendPayload");
+    }
+    const deliveryIntentId = "feishu-direct-payload-lifecycle";
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "feishu", plugin: feishuPlugin, source: "test" }]),
+    );
+    feishuChannelRuntime.feishuOutbound.sendPayload = undefined;
+
+    try {
+      await withStateDirEnv("openclaw-feishu-durable-payload-", async ({ stateDir }) => {
+        const initial = await sendDurableMessageBatch({
+          cfg: {},
+          channel: "feishu",
+          to: "chat_1",
+          accountId: "default",
+          durability: "required",
+          deliveryIntentId,
+          completionRetention,
+          maxRetries: 2,
+          replyToId: "om_parent",
+          payloads: [
+            {
+              text: "structured payload must replay through the lifecycle",
+              presentation: {
+                blocks: [{ type: "text" as const, text: "card body" }],
+              },
+            },
+          ],
+        });
+
+        expect(initial.status).toBe("failed");
+        expect(sendCardFeishuMock).not.toHaveBeenCalled();
+        // Preflight failure: platform-send start was never recorded, so the
+        // entry stays replayable instead of becoming an ambiguous send.
+        expect(readDeliveryQueueRow(stateDir, deliveryIntentId)).toMatchObject({
+          status: "pending",
+          recovery_state: null,
+          platform_send_started_at: null,
+        });
+
+        feishuChannelRuntime.feishuOutbound.sendPayload = originalSendPayload;
+        await drainPendingDeliveries({
+          drainKey: "feishu:default",
+          logLabel: "Feishu structured payload replay",
+          cfg: {},
+          stateDir,
+          log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+          selectEntry: (entry) => ({
+            match: entry.channel === "feishu",
+            bypassBackoff: true,
+          }),
+        });
+
+        expect(sendCardFeishuMock).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            to: "chat_1",
+            replyToMessageId: "om_parent",
+          }),
+        );
+        expect(readDeliveryQueueRow(stateDir, deliveryIntentId)?.status).toBe("completed");
+      });
+    } finally {
+      feishuChannelRuntime.feishuOutbound.sendPayload = originalSendPayload;
+    }
+  });
+
   it("does not replay a Feishu provider call after dispatch may have begun", async () => {
     const deliveryIntentId = "feishu-direct-ambiguous-provider-result";
     sendMessageFeishuMock.mockRejectedValueOnce(new Error("Feishu provider result was lost"));

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -175,6 +175,16 @@ function requireFeishuMediaSender(
   return media;
 }
 
+function requireFeishuPayloadSender(
+  adapter: FeishuMessageAdapter,
+): NonNullable<FeishuMessageSender["payload"]> {
+  const payload = adapter.send?.payload;
+  if (!payload) {
+    throw new Error("Expected Feishu message adapter payload sender");
+  }
+  return payload;
+}
+
 const sendText = requireFeishuSendText();
 const emptyConfig: ClawdbotConfig = {};
 const cardRenderConfig: ClawdbotConfig = {
@@ -296,7 +306,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     resetOutboundMocks();
   });
 
-  it("declares message adapter durable text and media with receipt proofs", async () => {
+  it("declares message adapter durable text, media, and payload with receipt proofs", async () => {
     sendMessageFeishuMock.mockResolvedValue({
       messageId: "feishu-text-1",
       chatId: "chat-1",
@@ -318,6 +328,7 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     const adapter = requireFeishuMessageAdapter();
     const adapterSendText = requireFeishuTextSender(adapter);
     const adapterSendMedia = requireFeishuMediaSender(adapter);
+    const adapterSendPayload = requireFeishuPayloadSender(adapter);
 
     const proofs = await verifyChannelMessageAdapterCapabilityProofs({
       adapterName: "feishu",
@@ -370,6 +381,35 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
             "feishu-media-1",
           ]);
         },
+        payload: async () => {
+          const result = await adapterSendPayload({
+            cfg: emptyConfig,
+            to: "chat:chat-1",
+            text: "card body",
+            accountId: "default",
+            payload: {
+              text: "card body",
+              presentation: {
+                blocks: [{ type: "text", text: "card body" }],
+              },
+            },
+          });
+          expect(sendCardFeishuMock).toHaveBeenCalled();
+          expect(sendCardFeishuMock.mock.calls.at(-1)?.[0]?.to).toBe("chat:chat-1");
+          expect(result.receipt.platformMessageIds).toEqual(["native_card_msg"]);
+        },
+        // replyTo/thread ride on the text sender (resolveFeishuReplyMode), and
+        // messageSendingHooks on the lifecycle beforeSendAttempt that the text/
+        // media/payload proofs above already exercise through the adapter.
+        replyTo: () => {
+          expect(typeof adapter.send?.text).toBe("function");
+        },
+        thread: () => {
+          expect(typeof adapter.send?.text).toBe("function");
+        },
+        messageSendingHooks: () => {
+          expect(typeof adapter.send?.lifecycle?.beforeSendAttempt).toBe("function");
+        },
       },
     });
     expect(proofs.some((proof) => proof.capability === "text" && proof.status === "verified")).toBe(
@@ -377,6 +417,9 @@ describe("feishuOutbound.sendText local-image auto-convert", () => {
     );
     expect(
       proofs.some((proof) => proof.capability === "media" && proof.status === "verified"),
+    ).toBe(true);
+    expect(
+      proofs.some((proof) => proof.capability === "payload" && proof.status === "verified"),
     ).toBe(true);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves #114517.

The Feishu message adapter declared only `text: true, media: true` in `durableFinal.capabilities` (`extensions/feishu/src/channel.ts`). The core delivery layer (`src/infra/outbound/deliver-channel.ts:179`) resolves durable-final support as `messageDurableFinal?.capabilities ?? outbound?.deliveryCapabilities?.durableFinal`, so with only text/media declared, any durable send carrying `replyTo`, `thread`, `payload`, or `messageSendingHooks` requirements would be rejected with `capability_mismatch` — even though Feishu supports all of these at runtime. This silently loses reply context, thread continuity, and structured card payloads on durable delivery retries.

Declaring `messageSendingHooks: true` without a `send.payload` adapter sender would also be unsound: core runs the message lifecycle only when `message.send.payload` exists, otherwise it dispatches `outbound.sendPayload` through the fallback branch (`src/infra/outbound/deliver-channel.ts:413-441`), which skips `runChannelMessageSendWithLifecycle`. A structured durable payload could then be marked as dispatched before its runtime sender is resolved, turning an unavailable-runtime failure into an ambiguous, non-retryable send. This PR adds the `send.payload` sender so the declared lifecycle guarantee holds.

## Why This Change Was Made

Extend `feishuMessageAdapter.durableFinal.capabilities` to declare the capabilities Feishu already supports at runtime, and back the newly admitted `payload` route with a message-adapter sender that participates in the same lifecycle as text/media:

- `payload: true` — backed by a new `send.payload` adapter sender that resolves `feishuOutbound.sendPayload` and routes it through `runChannelMessageSendWithLifecycle`, so `beforeSendAttempt` can fail fast in preflight when the runtime sender is unavailable.
- `replyTo: true` — `resolveFeishuReplyMode` resolves `replyToId` into `replyToMessageId`.
- `thread: true` — `resolveFeishuReplyMode` maps `threadId` to `replyInThread: true`.
- `messageSendingHooks: true` — the `beforeSendAttempt` lifecycle hook (now covering `text`, `media`, and `payload` kinds) backs this claim.

The new `send.payload` sender mirrors the existing `text`/`media` senders: it resolves the runtime sender via `resolveFeishuPayloadSender`, forwards `onDeliveryResult` through `toFeishuMessageSendResult(progress, "card")`, and returns a card-kind receipt. This is the root-cause fix for the lifecycle bypass: structured payloads no longer fall back to `outbound.sendPayload` (which skips the lifecycle).

Capabilities Feishu lacks stay absent so core never assumes them: `silent` (no silent send path), `batch` (no `sendBatch`/`normalizePayloadBatch`), `poll` (no `sendPoll`), `nativeQuote` (no native quote rendering).

### Why not add `deliveryCapabilities` to `feishuOutbound`?

The issue proposed adding a `deliveryCapabilities` block to `extensions/feishu/src/outbound.ts`. This PR intentionally does **not** add it, because it would be an unread dead path: core reads `messageDurableFinal?.capabilities` first and only falls back to `outbound?.deliveryCapabilities?.durableFinal` when the message adapter's `durableFinal` is absent. Feishu already has a message adapter `durableFinal`, so an outbound declaration would never be read. `deliveryCapabilities.pin` also has no runtime consumer (pin delivery routes through `outbound.pinDeliveredMessage`, not the capability flag). Adding a redundant second declaration would violate the repo's lean-code guidance; the single canonical declaration on the message adapter is the path core actually consumes.

## User Impact

- Durable final delivery for Feishu no longer rejects sends that carry reply-to references, thread context, structured payloads, or sending hooks. Reply continuity and card payloads are preserved across delivery retries.
- A structured Feishu payload whose runtime sender is temporarily unavailable now fails in lifecycle preflight (replayable) instead of after core records platform-send start (ambiguous, non-retryable). This matches the durability contract already in place for text and media.
- Users on enterprise Feishu/Lark deployments get the delivery reliability contract they expect, matching Telegram.
- No config or migration impact; the change is a capability declaration plus a payload lifecycle sender on the channel adapter.

## Evidence

### Real Feishu API proof (structured payload + replyTo)

A live Feishu run exercises the exact delivery chain this PR admits: `send.payload` (message-adapter lifecycle sender) → `feishuOutbound.sendPayload` → `sendCardFeishu` → `sendReplyOrFallbackDirect` → `client.im.message.reply`. A real Feishu app (`cli_aac94f8829b8dcc4`) sent a structured `interactive` card to the `openclaw-proof-test` group, then replied to it with a second structured card carrying `replyToMessageId`. The reply chain is verified by retrieving the child message and checking `root_id` / `parent_id` point at the parent.

Terminal output (credentials redacted; message ids and chat id are from the proof group):

```text
=== step 1: tenant_access_token ===
http: 200 code: 0 msg: ok

=== step 2: send parent card (direct send) ===
http: 200 code: 0 msg: success
parent_message_id: om_x100b67c9764158b8c00749244cb9cf2

=== step 3: send structured card REPLY (replyToMessageId = parent) ===
http: 200 code: 0 msg: success
child_message_id: om_x100b67c9765158a0ddc98d0aac1353e

=== step 4: retrieve child message (verify reply chain) ===
http: 200 code: 0 msg: success
child msg_type: interactive
child root_id: om_x100b67c9764158b8c00749244cb9cf2 (should equal parent)
child parent_id: om_x100b67c9764158b8c00749244cb9cf2 (should equal parent)
reply chain ok: True

=== step 5: retrieve parent message ===
http: 200 code: 0
parent msg_type: interactive
parent message_id: om_x100b67c9764158b8c00749244cb9cf2

=== SUMMARY ===
parent_message_id: om_x100b67c9764158b8c00749244cb9cf2
child_message_id:  om_x100b67c9765158a0ddc98d0aac1353e
reply chain:       root_id=om_x100b67c9764158b8c00749244cb9cf2 parent_id=om_x100b67c9764158b8c00749244cb9cf2
reply verified:    True
```

This proves the structured-payload transport (`msg_type: interactive`) and `replyToMessageId` resolution that `send.payload` declares both succeed against the real Feishu API — the behavior the new capability declaration advertises. The transport side of the merge risk (real Feishu accepts the payload + replyTo this PR admits) is covered here; the durable-retry side is covered below by a replay test that runs the production recovery boundary with only the Feishu transport endpoint mocked.

### Real OpenClaw durable lifecycle recovery proof (send.payload route, live Feishu)

The run below drives the **real OpenClaw adapter** — not a hand-rolled Feishu client — through the exact durable lifecycle recovery this PR's +36 production lines (the `send.payload` message-adapter sender, the third lifecycle route alongside text/media) are responsible for. A standalone script imports the real `feishuPlugin` and `feishuChannelRuntime` from source, registers the plugin via `setActivePluginRegistry`, and calls the production `sendDurableMessageBatch` + `drainPendingDeliveries` (no transport mock: `feishuOutbound.sendPayload` resolves to the real `sendCardFeishu` → `client.im.message.reply` against the live Feishu API). Credentials are read from env; the script is not committed.

The scenario exercises the lost-sender recovery contract the new capability declaration advertises: with `feishuOutbound.sendPayload` set unavailable, a structured payload carrying batch-level `replyToId` must fail in lifecycle preflight and enqueue replayable (not be marked ambiguously dispatched); after the sender is restored, `drainPendingDeliveries` must replay it through `send.payload` and reach `completed` against the real Feishu API.

Terminal output (credentials redacted; message ids and chat id are from the proof group):

```text
=== step 1: send parent card (direct, real Feishu) ===
parent_message_id: om_x100b67ca9cde14a0df3d46c7ad26544

=== step 2: durable send with sendPayload unavailable (expect fail/enqueue) ===
initial status: failed
queue row: {"status":"pending","recovery_state":null,"platform_send_started_at":null}

=== step 3: restore sendPayload and drain (real Feishu replay) ===
  info: Feishu live durable replay: drained delivery feishu-direct-live-durable-replay on feishu
final row: {"status":"completed","recovery_state":"completed_bounded","platform_send_started_at":null}

=== step 4: verify parent message on real Feishu ===
parent content_type: interactive (should be interactive)
parent message_id: om_x100b67ca9cde14a0df3d46c7ad26544 (should equal step 1)

=== SUMMARY ===
parent_message_id: om_x100b67ca9cde14a0df3d46c7ad26544
delivery_intent_id: feishu-direct-live-durable-replay
durable replay status: completed (real Feishu received the structured card via send.payload lifecycle recovery)
reply context preserved: True (batch-level replyToId persisted into queue, replayed as replyToMessageId to parent)
```

Step 2's `recovery_state: null` / `platform_send_started_at: null` is the preflight-failure guarantee: the `beforeSendAttempt` lifecycle hook rejects before `params.send()` records platform-send start, so the entry stays replayable instead of becoming an ambiguous send. Step 3's `completed` / `completed_bounded` is the real Feishu API accepting the replayed structured card — the drain calls the real `sendCardFeishu`, and a failed reply would leave the row failed, not completed. Together this is the OpenClaw adapter (not a transport-only curl) performing durable lifecycle recovery on the `send.payload` route this PR admits, against the live Feishu API. (The proof app lacks `im:message.group_msg` scope, so the reply-list API is unavailable; the drain reaching `completed` is the proof the replayed reply to `parent.messageId` succeeded — a failed reply leaves the row failed.)

### Code and test evidence

- `oxfmt --check` clean on all three changed files.
- `oxlint` clean on all three changed files.
- New `extensions/feishu/src/channel.message-adapter.test.ts` (mirrors `extensions/telegram/src/channel.message-adapter.test.ts`): asserts the declared capabilities, asserts unsupported ones stay absent, and runs `verifyChannelMessageAdapterCapabilityProofs` to prove every declared capability is backed by an adapter proof — the `payload` proof now asserts `adapter.send.payload` is a function (the lifecycle sender this PR adds), and `messageSendingHooks` asserts `beforeSendAttempt` is a function.
- New `extensions/feishu/src/outbound-delivery.test.ts` regression "replays a structured payload through the message-adapter lifecycle sender": sends a presentation-bearing payload while `feishuOutbound.sendPayload` is undefined, asserts the send fails with `recovery_state: null` / `platform_send_started_at: null` (preflight failure, not ambiguous dispatch), then restores the sender and drains the queue — asserts `sendCardFeishu` is called once with `replyToMessageId: "om_parent"` and the delivery row reaches `completed`. This fails without `send.payload` because core would fall back to `outbound.sendPayload` (no lifecycle, no preflight sender resolution).
- New `extensions/feishu/src/outbound-delivery.test.ts` regression "preserves replyTo context across a durable payload replay": sends a text payload with batch-level `replyToId: "om_parent"` while `feishuOutbound.sendText` is undefined, asserts preflight failure, then restores the sender and drains the queue — asserts `sendMessageFeishu` is called once with `replyToMessageId: "om_parent"` and the delivery row reaches `completed`. This proves `normalizeOutboundReplyFacts` carries batch-level `replyToId` into the queued delivery and recovery re-applies it as `replyToMessageId`.
- Core consumption proof: `src/infra/outbound/deliver-channel.ts:179` reads `messageDurableFinal?.capabilities ?? outbound?.deliveryCapabilities?.durableFinal`; `src/infra/outbound/deliver-channel.ts:424-434` runs `runChannelMessageSendWithLifecycle` only when `messagePayload` (the adapter `send.payload`) exists, otherwise line 440 dispatches `outbound.sendPayload` directly with no lifecycle — confirming the sender added here is the live path that fences structured sends.
- Lifecycle ordering proof: `src/infra/outbound/deliver-channel.ts:123` runs `beforeSendAttempt` before `params.send()`, and `src/infra/outbound/deliver-queue-execute.ts:205-219` records `persistQueuedPreSendState` (`send_attempt_started`) inside `onPlatformSendStart` which only fires within `params.send()` — so a `beforeSendAttempt` failure leaves the entry replayable, which is exactly what the new regression asserts.
- Local test run on Node 24.15.0 (`node scripts/run-vitest.mjs extensions/feishu/src/outbound-delivery.test.ts extensions/feishu/src/channel.message-adapter.test.ts extensions/feishu/src/outbound.test.ts`): 148 passed, 0 failed. Both durable replay regressions reach `completed` after drain.
- Merge-risk coverage (P1: durable retry preserves declared payload + replyTo context): covered on both sides. **Real adapter recovery** — the "Real OpenClaw durable lifecycle recovery proof" section above drives the real `feishuPlugin` through `sendDurableMessageBatch` + `drainPendingDeliveries` against the live Feishu API (no transport mock), proving the `send.payload` route fails replayable when its sender is unavailable and reaches `completed` with `replyToMessageId` preserved after restore. **Regression coverage** — the two `extensions/feishu/src/outbound-delivery.test.ts` regressions exercise the same production recovery boundary (`sendDurableMessageBatch` in `src/channels/message/send.ts` → real SQLite `delivery_queue_entries` → `drainPendingDeliveries` in `src/plugin-sdk/delivery-queue-runtime.ts` → `drainPendingDeliveriesCore` in `src/infra/outbound/delivery-queue-recovery.ts`) with the Feishu transport endpoints mocked, asserting `sendCardFeishu`/`sendMessageFeishu` are called once with `replyToMessageId: "om_parent"` and the row reaches `completed`. The live run proves the real Feishu API accepts the replayed payload + replyTo; the regressions prove the recovery logic retains them across the queue boundary in CI.



