### PR TITLE
perf(cron): carry the published plugin generation into hook/cron isolated runs

### DIFF
--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -642,6 +642,9 @@ export async function prepareCronRunContext(params: {
       config: cfgWithAgentDefaults,
       workspaceDir,
       allowGatewaySubagentBinding: true,
+      // The published owner already selected this run's metadata generation.
+      // Reloading it here re-hashes every installed plugin on each hook/cron run.
+      ...(modelOwner.metadataSnapshot ? { metadataSnapshot: modelOwner.metadataSnapshot } : {}),
       selections: runtimePluginCandidates.map((candidate) => {
         const runtime = resolveSessionRuntimeOverrideForProvider({
           provider: candidate.provider,

--- a/src/cron/isolated-agent/run.plugin-generation.test.ts
+++ b/src/cron/isolated-agent/run.plugin-generation.test.ts
@@ -1,0 +1,105 @@
+// Proves isolated cron/hook runs carry the published Gateway plugin generation
+// into embedded execution instead of rebuilding metadata per run (#125596 family).
+import { describe, expect, it, vi } from "vitest";
+import { getPreparedModelRuntimePluginGeneration } from "../../agents/prepared-model-runtime-generation-scope.js";
+import { makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
+import { setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  mockRunCronFallbackPassthrough,
+  runEmbeddedAgentMock,
+} from "./run.test-harness.js";
+
+const preparedRuntimeMocks = vi.hoisted(() => ({
+  acquireRuntime: vi.fn(),
+  loadDispatchRuntime: vi.fn(),
+}));
+
+vi.mock("../../agents/prepared-model-runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/prepared-model-runtime.js")>()),
+  acquireAgentRunPreparedModelRuntime: preparedRuntimeMocks.acquireRuntime,
+  loadPublishedGatewayReplyDispatchRuntime: preparedRuntimeMocks.loadDispatchRuntime,
+}));
+
+const { PreparedModelRuntimeOwnerNotPublishedError } = await vi.importActual<
+  typeof import("../../agents/prepared-model-runtime.errors.js")
+>("../../agents/prepared-model-runtime.errors.js");
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+describe("runCronIsolatedAgentTurn plugin generation carry", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  it("admits the published generation and keeps it active through embedded execution", async () => {
+    const metadataSnapshot = { plugins: [], index: { plugins: [] } };
+    const pluginGeneration = {
+      configuredCatalogEntries: [],
+      inlineProviderModels: [],
+      pluginMetadataSnapshot: metadataSnapshot,
+    } as never;
+    const config = {};
+    preparedRuntimeMocks.loadDispatchRuntime.mockResolvedValue({
+      agentId: "default",
+      agentDir: "/tmp/dispatch-agent-dir",
+      workspaceDir: "/tmp/dispatch-workspace",
+      config,
+      pluginGeneration,
+    });
+    const release = vi.fn();
+    preparedRuntimeMocks.acquireRuntime.mockResolvedValue({
+      snapshot: { config, metadataSnapshot },
+      release,
+    });
+    mockRunCronFallbackPassthrough();
+    let embeddedRunGeneration: unknown = "not-captured";
+    runEmbeddedAgentMock.mockImplementation(async () => {
+      embeddedRunGeneration = getPreparedModelRuntimePluginGeneration();
+      return { payloads: [{ text: "test output" }], meta: { agentMeta: {} } };
+    });
+
+    await expect(runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture())).resolves.toMatchObject(
+      { status: "ok" },
+    );
+    expect(preparedRuntimeMocks.loadDispatchRuntime).toHaveBeenCalledWith({ agentId: "default" });
+    expect(preparedRuntimeMocks.acquireRuntime).toHaveBeenCalledWith(
+      {
+        config,
+        agentId: "default",
+        agentDir: "/tmp/dispatch-agent-dir",
+        allowGatewaySubagentBinding: true,
+        workspaceDir: "/tmp/workspace",
+      },
+      { catalogMode: "static", pluginGeneration },
+    );
+    expect(embeddedRunGeneration).toBe(pluginGeneration);
+    expect(release).toHaveBeenCalledOnce();
+    expect(getPreparedModelRuntimePluginGeneration()).toBeUndefined();
+  });
+
+  it("runs without a generation when no Gateway publication exists", async () => {
+    preparedRuntimeMocks.loadDispatchRuntime.mockResolvedValue(undefined);
+    mockRunCronFallbackPassthrough();
+    let embeddedRunGeneration: unknown = "not-captured";
+    runEmbeddedAgentMock.mockImplementation(async () => {
+      embeddedRunGeneration = getPreparedModelRuntimePluginGeneration();
+      return { payloads: [{ text: "test output" }], meta: { agentMeta: {} } };
+    });
+
+    await expect(runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture())).resolves.toMatchObject(
+      { status: "ok" },
+    );
+    expect(preparedRuntimeMocks.acquireRuntime).not.toHaveBeenCalled();
+    expect(embeddedRunGeneration).toBeUndefined();
+  });
+
+  it("falls back to generation-free execution when the owner is not published", async () => {
+    preparedRuntimeMocks.loadDispatchRuntime.mockRejectedValue(
+      new PreparedModelRuntimeOwnerNotPublishedError("owner not published"),
+    );
+
+    await expect(runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture())).resolves.toMatchObject(
+      { status: "ok" },
+    );
+    expect(preparedRuntimeMocks.acquireRuntime).not.toHaveBeenCalled();
+  });
+});

--- a/src/cron/isolated-agent/run.runtime-plugins.test.ts
+++ b/src/cron/isolated-agent/run.runtime-plugins.test.ts
@@ -48,4 +48,27 @@ describe("runCronIsolatedAgentTurn runtime plugin owner", () => {
       ],
     });
   });
+
+  it("reuses the published owner metadata snapshot for the run registry load", async () => {
+    const metadataSnapshot = { plugins: [], index: { plugins: [] } };
+    loadModelCatalogOwnerMock.mockImplementation(
+      async (params: { agentId?: string; config: object }) => ({
+        agentId: params.agentId ?? "default",
+        agentDir: "/tmp/agent-dir",
+        workspaceDir: "/tmp/workspace",
+        config: params.config,
+        metadataSnapshot,
+        modelCatalog: { entries: [], routeVariants: [] },
+      }),
+    );
+
+    await expect(runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture())).resolves.toMatchObject(
+      { status: "ok" },
+    );
+    expect(loadAgentRuntimePluginRegistryHandleMock).toHaveBeenCalledOnce();
+    // Exact snapshot identity: a rebuilt copy would still re-hash every installed plugin.
+    expect(loadAgentRuntimePluginRegistryHandleMock.mock.calls[0]?.[0].metadataSnapshot).toBe(
+      metadataSnapshot,
+    );
+  });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,4 +1,14 @@
 import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
+import { withPreparedModelRuntimePluginGenerationScope } from "../../agents/prepared-model-runtime-generation-scope.js";
+import {
+  PreparedModelRuntimeOwnerNotPublishedError,
+  acquireAgentRunPreparedModelRuntime,
+  loadPublishedGatewayReplyDispatchRuntime,
+} from "../../agents/prepared-model-runtime.js";
+import type {
+  PreparedModelRuntimePluginGeneration,
+  PreparedModelRuntimeSnapshot,
+} from "../../agents/prepared-model-runtime.types.js";
 import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
 import { cleanupBrowserSessionsForLifecycleEnd } from "../../browser-lifecycle-cleanup.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
@@ -40,6 +50,60 @@ import type { RunCronAgentTurnResult } from "./run.types.js";
 import { cleanupCronRunSessionAfterRun } from "./session-cleanup.js";
 
 const cronExecutorRuntimeLoader = createLazyImportLoader(() => import("./run-executor.runtime.js"));
+
+type CronRunPluginGenerationLease = {
+  pluginGeneration: PreparedModelRuntimePluginGeneration;
+  borrowSnapshot: () => PreparedModelRuntimeSnapshot | undefined;
+  release: () => void;
+};
+
+/**
+ * Gateway-hosted isolated runs reuse the published plugin generation instead of
+ * rebuilding metadata snapshots per run (#125596 carried this for the channel
+ * path; hook/cron turns share the invariant). Standalone hosts (no Gateway
+ * lifecycle) and startup/replacement races return undefined so the embedded
+ * orchestrator admits on whatever generation is current at execution time.
+ */
+async function acquireCronRunPluginGeneration(context: {
+  agentId: string;
+  workspaceDir: string;
+}): Promise<CronRunPluginGenerationLease | undefined> {
+  try {
+    const dispatchRuntime = await loadPublishedGatewayReplyDispatchRuntime({
+      agentId: context.agentId,
+    });
+    if (!dispatchRuntime) {
+      return undefined;
+    }
+    // Holding this static lease across the run anchors the admitted generation:
+    // a config/plugin reload mid-run lets nested embedded admissions borrow the
+    // leased snapshot instead of failing on the superseded configured owner.
+    const lease = await acquireAgentRunPreparedModelRuntime(
+      {
+        config: dispatchRuntime.config,
+        agentId: dispatchRuntime.agentId,
+        agentDir: dispatchRuntime.agentDir,
+        allowGatewaySubagentBinding: true,
+        workspaceDir: context.workspaceDir,
+      },
+      { catalogMode: "static", pluginGeneration: dispatchRuntime.pluginGeneration },
+    );
+    let leaseActive = true;
+    return {
+      pluginGeneration: dispatchRuntime.pluginGeneration,
+      borrowSnapshot: () => (leaseActive ? lease.snapshot : undefined),
+      release: () => {
+        leaseActive = false;
+        lease.release();
+      },
+    };
+  } catch (error) {
+    if (error instanceof PreparedModelRuntimeOwnerNotPublishedError) {
+      return undefined;
+    }
+    throw error;
+  }
+}
 
 function isCronNestedLaneTaskTimeoutError(err: unknown): boolean {
   return isCommandLaneTaskTimeoutError(err, CommandLane.CronNested);
@@ -259,13 +323,27 @@ export async function runCronIsolatedAgentTurn(params: {
       pluginRegistry: prepared.context.pluginRegistry,
       executionIdentity: params.executionIdentity,
     };
-    const execution = await prepared.context.sessionWorkAdmission.run(() =>
-      withAgentRunLifecycleGeneration(runLifecycleGeneration, () =>
-        withPluginRuntimeRegistryScope(prepared.context.pluginRegistry, () =>
-          executeCronRun(executionParams),
+    const runExecutionWithAdmission = () =>
+      prepared.context.sessionWorkAdmission.run(() =>
+        withAgentRunLifecycleGeneration(runLifecycleGeneration, () =>
+          withPluginRuntimeRegistryScope(prepared.context.pluginRegistry, () =>
+            executeCronRun(executionParams),
+          ),
         ),
-      ),
-    );
+      );
+    const pluginGenerationLease = await acquireCronRunPluginGeneration(prepared.context);
+    let execution: Awaited<ReturnType<typeof runExecutionWithAdmission>>;
+    try {
+      execution = pluginGenerationLease
+        ? await withPreparedModelRuntimePluginGenerationScope(
+            pluginGenerationLease.pluginGeneration,
+            runExecutionWithAdmission,
+            pluginGenerationLease.borrowSnapshot,
+          )
+        : await runExecutionWithAdmission();
+    } finally {
+      pluginGenerationLease?.release();
+    }
     const finalized = await finalizeCronRun({
       prepared: prepared.context,
       execution,


### PR DESCRIPTION
## What Problem This Solves

#130167 fixed the catastrophic cold full-registry load on hook/cron isolated runs (42.6s event-loop block), but a CPU profile of a 13-run gmail hook burst still showed ~5-6s aggregate of per-run synchronous work: `prepareCronRunContext` rebuilt a plugin metadata snapshot per run through `loadAgentRuntimePluginRegistryHandle` (installed-plugin-index `safeHashFile` ~2.2s, `resolvePluginDoctorContractArtifactPath` ~1.8s, `realpathSync` walks), and the embedded orchestrator rebuilt-and-froze another snapshot plus a fresh prepared-runtime owner per run.

The channel path already avoids this: #125596 carries `dispatchRuntime.pluginGeneration` from the published Gateway generation into every reply turn, and the gateway `agent` RPC path carries `commandRuntimeContext.pluginGeneration` the same way. Hook dispatch and the cron scheduler passed no generation, so isolated runs violated "Gateway/plugin metadata is process-stable; runtime hot paths never freshness-poll."

## Why This Change Was Made

Root cause: the isolated-run owner (`runCronIsolatedAgentTurn`) never consumed the published prepared-runtime generation, even though `prepareCronRunContext` already resolves the published model-catalog owner for model selection. Two carries complete the invariant at the owner:

- `prepareCronRunContext` now passes the published owner's `metadataSnapshot` into `loadAgentRuntimePluginRegistryHandle`, so the per-run registry handle (still built per run because cron runtime selections differ per job) reuses the prepared metadata instead of re-hashing every installed plugin.
- `runCronIsolatedAgentTurn` loads the published Gateway dispatch runtime for the resolved agent, acquires a static prepared-runtime lease pinned to its `pluginGeneration` (mirroring `runPreparedReply`), and wraps execution in `withPreparedModelRuntimePluginGenerationScope` with a borrow accessor. The embedded orchestrator picks the generation up from the ambient scope, skips its own `loadPluginMetadataSnapshot`, and its prepared-runtime acquisition reuses the published generation; a config/plugin reload mid-run lets nested admissions borrow the leased snapshot instead of failing on the superseded configured owner.

Standalone hosts (no Gateway lifecycle) and startup/replacement races return `undefined` from the loader and keep today's behavior: the orchestrator admits on whatever generation is current at execution time. No hook/cron call-site signatures changed.

## User Impact

Hook bursts (e.g. gmail fan-out) and cron isolated runs no longer spend seconds of synchronous event-loop time per run rebuilding process-stable plugin metadata; gateway responsiveness under bursts improves accordingly. No behavior or config surface changes.

## Evidence

- New regression tests (both fail on pre-fix code, verified): `src/cron/isolated-agent/run.plugin-generation.test.ts` proves the published generation is admitted (`acquireAgentRunPreparedModelRuntime` called with `{catalogMode: "static", pluginGeneration}`), stays ambient through embedded execution, releases its lease, and that missing/unpublished publications fall back to generation-free execution; `run.runtime-plugins.test.ts` proves the exact owner `metadataSnapshot` object reaches the registry load.
- Full cron isolated-agent suite: 42 files, 628 tests green. Sibling generation-semantics suites (`prepared-model-runtime.test.ts`, `get-reply-run.prepared-metadata.test.ts`, embedded-runner prepared-harness integration) green.
- Live proof on an isolated dev gateway (own `OPENCLAW_STATE_DIR`, port 19850, `OPENCLAW_DIAGNOSTICS` timeline): two `cron run` executions of an isolated agentTurn job traversed prepare → embedded runner → live Anthropic API (expected 401 with a dummy key — both hotspots run before the provider call). `plugins.metadata.scan` timeline spans: 22 at startup, still 22 after both runs — zero per-run metadata rebuilds; no generation-supersession errors. Pre-fix, `loadAgentRuntimePluginRegistryHandle` unconditionally called `loadPluginMetadataSnapshot`, which always emits this span.
- `pnpm build` clean (no `[INEFFECTIVE_DYNAMIC_IMPORT]`); `check:changed` gates green.

Production LOC: +81 (run.ts +78, run-prepare.ts +3), all in the new generation-admission helper and scope wiring that mirrors `runPreparedReply`; no net-neutral absorbing refactor exists because the cron path previously had no generation consumption to reshape.

Follow-ups from the same investigation (out of scope here, evidence in #130167): (1) `prepareCronRunContext` runs before the HookDispatch lane bounds anything, so N concurrent preps still run on burst admission — much cheaper now, but still unbounded; (2) first dispatch cold-evaluates the embedded-runner dist chunk graph (~4-6s once per process) — a post-ready background warmup would hide it.
