### PR TITLE
fix(mcp): honor effective bundle allowlist

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts
@@ -184,6 +184,16 @@ describe("prepareEmbeddedAttemptBundleTools", () => {
     expect(mocks.createBundleLspToolRuntime).not.toHaveBeenCalled();
   });
 
+  it("creates the MCP runtime when the effective policy adds bundle-mcp", async () => {
+    const input = createInput([], []);
+    input.attempt.toolsAllow = ["read"];
+    input.preparedToolBase.effectiveToolsAllow = ["read", "bundle-mcp"];
+
+    await prepareEmbeddedAttemptBundleTools(input);
+
+    expect(mocks.getOrCreateSessionMcpRuntime).toHaveBeenCalledOnce();
+  });
+
   it("refreshes spawned-child inheritance after authorized MCP tools materialize", async () => {
     const inheritedToolAllowlist = ["sessions_spawn"];
     mocks.getOrCreateSessionMcpRuntime.mockResolvedValue({});

--- a/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-bundle-tools.ts
@@ -88,7 +88,7 @@ export async function prepareEmbeddedAttemptBundleTools(params: {
     shouldCreateBundleMcpRuntimeForAttempt({
       toolsEnabled,
       disableTools: params.attempt.disableTools || params.isRawModelRun,
-      toolsAllow: params.attempt.toolsAllow,
+      toolsAllow: effectiveToolsAllow,
     });
   const bundleMetadataSnapshot = params.getCurrentAttemptPluginMetadataSnapshot();
   // Scoped registries are partial views; only complete snapshots can bypass bundle discovery.


### PR DESCRIPTION
## Summary
- create the bundled MCP runtime from the effective tool policy, including global `tools.alsoAllow` grants
- add regression coverage where the profile allowlist omits `bundle-mcp` but the effective policy adds it

## Why
With `tools.profile: coding`, `tools.alsoAllow: [bundle-mcp]`, and tool-search directory mode, the raw profile allowlist was consulted before MCP materialization. Bundled MCP tools therefore never entered a cold agent session even though the final effective policy allowed them.

## Test
`pnpm exec vitest run src/agents/embedded-agent-runner/run/attempt-bundle-tools.test.ts` (42 passed)