### PR TITLE
fix: remove unavailable OpenGrep install alternatives

### DIFF
--- a/scripts/run-opengrep.sh
+++ b/scripts/run-opengrep.sh
@@ -45,10 +45,8 @@ if ! command -v opengrep >/dev/null 2>&1; then
   cat >&2 <<'EOF'
 error: 'opengrep' not found on PATH.
 
-Install with one of:
+Install with:
   curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/v1.27.1/install.sh | bash -s -- -v v1.27.1
-  brew install opengrep/tap/opengrep
-  pipx install opengrep
 
 (See https://opengrep.dev for other options.)
 EOF

--- a/test/scripts/run-opengrep.test.ts
+++ b/test/scripts/run-opengrep.test.ts
@@ -42,6 +42,37 @@ function installOpengrepStub(repo: string): { argsPath: string; binDir: string }
 }
 
 describe("run-opengrep.sh", () => {
+  it("fails before scanning with official installation advice when opengrep is missing", () => {
+    const repo = createTempDir("openclaw-run-opengrep-missing-");
+    copyRunOpengrepFiles(repo);
+    writeFile(path.join(repo, "security/opengrep/precise.yml"), "rules: []\n");
+
+    const binDir = path.join(repo, "bin");
+    fs.mkdirSync(binDir);
+    for (const command of ["bash", "dirname", "cat"]) {
+      const executable = execFileSync("bash", ["-c", 'command -v "$1"', "_", command], {
+        encoding: "utf8",
+      }).trim();
+      fs.symlinkSync(executable, path.join(binDir, command));
+    }
+
+    const result = spawnSync(
+      "bash",
+      ["scripts/run-opengrep.sh", "--changed", "--sarif", "--error"],
+      { cwd: repo, env: { ...process.env, PATH: binDir }, encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(127);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("'opengrep' not found on PATH");
+    expect(result.stderr).toMatch(
+      /curl -fsSL https:\/\/raw\.githubusercontent\.com\/opengrep\/opengrep\/\S+\/install\.sh \| bash -s -- -v \S+/,
+    );
+    expect(fs.existsSync(path.join(repo, ".opengrep-out"))).toBe(false);
+    expect(result.stderr).not.toContain("pipx");
+    expect(result.stderr).not.toContain("opengrep/tap/opengrep");
+  });
+
   it("validates the rulepack when only OpenGrep rulepack files changed", () => {
     const repo = createTempDir("openclaw-run-opengrep-");
     git(repo, "init", "-q");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can edit this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where developers running the local OpenGrep scan without OpenGrep installed would receive installation commands for an unavailable PyPI package and an unavailable Homebrew tap.

The diagnostic still recommended `pipx install opengrep` and `brew install opengrep/tap/opengrep`. Live checks returned HTTP 404 for both the [PyPI package endpoint](https://pypi.org/pypi/opengrep/json) and the [Homebrew tap repository endpoint](https://api.github.com/repos/opengrep/homebrew-tap).

## Why This Change Was Made

Keep the existing pinned official GitHub installer and remove the unsupported alternatives from the missing-tool diagnostic. The [publisher's current installation instructions](https://github.com/opengrep/opengrep#installation) document the GitHub installer and release binaries; the retained [v1.27.1 installer](https://github.com/opengrep/opengrep/blob/v1.27.1/install.sh) supports the existing version-selection argument.

This is a diagnostic-only repair at the script's missing-dependency boundary. Scan flags, rulepack selection, path selection, output handling, exit status, and all dependency pins remain unchanged. No new installer or fallback path is introduced.

## User Impact

Developers who are missing OpenGrep receive the official installation command rather than dead-end package-manager alternatives. Existing installations and CI scans behave exactly as before.

AI-assisted with Codex; the change and validation were reviewed by the maintainer's agent.

## Evidence

- Added one subprocess-boundary regression to `test/scripts/run-opengrep.test.ts`, using an isolated PATH containing Bash and the required system utilities but no OpenGrep. It checks exit 127, empty stdout, actionable official-installer guidance, absence of the unavailable alternatives, and no scan-output directory.
- Red proof against the original script: the new test failed specifically because stderr contained `pipx`; five existing tests were skipped for that focused run.
- Green proof: `node scripts/run-vitest.mjs test/scripts/run-opengrep.test.ts` — all 6 tests passed, including existing rulepack, empty-SARIF, Git-discovery-failure, and merge-base cases.
- `bash -n scripts/run-opengrep.sh` and `node_modules/.bin/oxfmt --check test/scripts/run-opengrep.test.ts` passed.
- `node scripts/check-changed.mjs -- scripts/run-opengrep.sh test/scripts/run-opengrep.test.ts` passed, including the selected guards, formatting, root-test typecheck, and script lint. An initial worker attempt could not fetch pnpm signature metadata; the unchanged gate subsequently passed locally without disabling verification or changing dependencies.
- Executed the actual worktree script with OpenGrep absent from an isolated PATH: exit 127 with the corrected stderr diagnostic. Verified all script bytes outside the missing-tool heredoc are unchanged from the pre-fix script.
- Independent autoreview reported no accepted/actionable findings; refreshed before commit.
- Scope: tooling +1/-3 (net -2); tests +31/-0. No lockfile, version, workflow, or dependency-pin edits.
