### PR TITLE
fix(subagents): reconcile transport-ambiguous dispatch instead of misreporting an accepted run

### DIFF
--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -949,6 +949,53 @@ describe("spawnAcpDirect", () => {
     expect(transcriptCalls[1]?.threadId).toBe("child-thread");
   });
 
+  it("reconciles a transport-ambiguous ACP dispatch so an accepted run is surfaced instead of misreported as dispatch_failed", async () => {
+    let agentDispatchAttempts = 0;
+    // A plain Error whose message matches isGatewayRpcUnavailableError (the gateway
+    // timeout transport shape) models "the gateway may have accepted the ACP run
+    // before the ack was lost" - distinct from a genuine dispatch rejection. The
+    // reconcile lives on the shared subagent gateway seam, so the ACP launch (which
+    // replays with the same childIdem idempotency key) surfaces the accepted run.
+    hoisted.callGatewayMock.mockImplementation(async (argsUnknown: unknown) => {
+      const args = argsUnknown as { method?: string };
+      if (args.method === "agent") {
+        agentDispatchAttempts += 1;
+        if (agentDispatchAttempts === 1) {
+          throw new Error("gateway timeout after 60000ms");
+        }
+        return { runId: "accepted-acp-run" };
+      }
+      if (args.method === "sessions.patch") {
+        return { ok: true };
+      }
+      return args.method === "sessions.delete" ? { ok: true } : {};
+    });
+
+    const result = await spawnAcpDirect(
+      {
+        task: "ambiguous ACP child",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey: "agent:main:main",
+        agentChannel: "discord",
+        agentAccountId: "default",
+        agentTo: "channel:parent-channel",
+        agentThreadId: "requester-thread",
+      },
+    );
+
+    // The reconcile replay reuses the same childIdem idempotency key; the gateway
+    // surfaces the already-accepted run, so the caller must not conclude the ACP
+    // child never started.
+    expect(agentDispatchAttempts).toBe(2);
+    const accepted = expectAcceptedSpawn(result);
+    expect(accepted.runId).toBe("accepted-acp-run");
+    expect(accepted.childSessionKey).toMatch(/^agent:codex:acp:/);
+  });
+
   it("forwards ACP lineage with unsupported external native actions and the exact parent token", async () => {
     const parentToken = createExecutionIdentityAdmissionToken("parent-run", {
       contextId: "parent-context",

--- a/src/agents/subagents/spawn/acp-spawn.test.ts
+++ b/src/agents/subagents/spawn/acp-spawn.test.ts
@@ -963,7 +963,7 @@ describe("spawnAcpDirect", () => {
         if (agentDispatchAttempts === 1) {
           throw new Error("gateway timeout after 60000ms");
         }
-        return { runId: "accepted-acp-run" };
+        return { runId: "accepted-acp-run", status: "in_flight" };
       }
       if (args.method === "sessions.patch") {
         return { ok: true };
@@ -994,6 +994,28 @@ describe("spawnAcpDirect", () => {
     const accepted = expectAcceptedSpawn(result);
     expect(accepted.runId).toBe("accepted-acp-run");
     expect(accepted.childSessionKey).toMatch(/^agent:codex:acp:/);
+  });
+
+  it("does not register an ACP child when reconciliation finds a terminal run", async () => {
+    let agentDispatchAttempts = 0;
+    hoisted.callGatewayMock.mockImplementation(async (argsUnknown: unknown) => {
+      const args = argsUnknown as { method?: string };
+      if (args.method === "agent" && ++agentDispatchAttempts === 1) {
+        throw new Error("gateway timeout after 60000ms");
+      }
+      return args.method === "agent"
+        ? { runId: "stopped-acp-run", status: "timeout" }
+        : { ok: true };
+    });
+
+    const result = await spawnAcpDirect(
+      { task: "ambiguous ACP child", agentId: "codex", mode: "run" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(agentDispatchAttempts).toBe(2);
+    expect(expectFailedSpawn(result).error).toContain("no active subagent run (status: timeout)");
+    expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();
   });
 
   it("forwards ACP lineage with unsupported external native actions and the exact parent token", async () => {

--- a/src/agents/subagents/spawn/subagent-spawn-gateway.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-gateway.ts
@@ -1,3 +1,5 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { AgentRuntimeIdentity } from "../../../gateway/agent-runtime-identity-token.js";
 import { withInProcessAgentRuntimeIdentity } from "../../../gateway/in-process-agent-runtime-identity.js";
 import { isGatewayRpcUnavailableError } from "../../../gateway/transport-error.js";
@@ -20,6 +22,8 @@ import {
 
 const DEFAULT_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS = 60_000;
 const MAX_SUBAGENT_AGENT_GATEWAY_TIMEOUT_MS = 300_000;
+const SUBAGENT_AGENT_RECONCILE_INTERVAL_MS = 800;
+const SUBAGENT_AGENT_RECONCILE_TIMEOUT_MS = 6_400;
 
 type SubagentGatewayResponse = Awaited<ReturnType<typeof callGateway>>;
 type SubagentGatewayDispatchMode = "in_process" | "out_of_process";
@@ -155,29 +159,53 @@ async function callSubagentGatewayWithDispatchMode(
           ),
         )
       : deps.callGateway(typeof timeoutMs === "number" ? { ...request, timeoutMs } : request);
-  // A transport-ambiguous agent dispatch (gateway timeout/closed) does NOT prove the
-  // run never landed: the gateway can accept (and start) an agent run before the ack
-  // is received, and a same-idempotency-key replay returns that already-accepted run
-  // instead of starting a duplicate. Reconcile only agent dispatch calls (native and
-  // ACP share this seam); cleanup and other non-agent methods retry nothing.
+  // Only agent launches have an idempotency key backed by authoritative Gateway state.
+  // Other methods must not repeat after a transport-ambiguous failure.
   const response =
     request.method === "agent"
-      ? await reconcileSubagentAgentDispatch(() => dispatchAgentRequest(request.timeoutMs))
+      ? await reconcileSubagentAgentDispatch(dispatchAgentRequest, request.timeoutMs)
       : await dispatchAgentRequest(request.timeoutMs);
   return { response, dispatchMode: "out_of_process" };
 }
 
-async function reconcileSubagentAgentDispatch<T>(dispatch: () => Promise<T>): Promise<T> {
+async function reconcileSubagentAgentDispatch(
+  dispatch: (timeoutMs?: number | null) => Promise<SubagentGatewayResponse>,
+  timeoutMs?: number | null,
+): Promise<SubagentGatewayResponse> {
   try {
-    return await dispatch();
+    return await dispatch(timeoutMs);
   } catch (error) {
     if (!isGatewayRpcUnavailableError(error)) {
       throw error;
     }
-    // The first dispatch may have accepted the run gateway-side before the ack was
-    // lost. A same-key replay returns that already-accepted run instead of starting a
-    // duplicate, so surface the recovered run rather than misreporting "no target".
-    return await dispatch();
+    const deadline = Date.now() + SUBAGENT_AGENT_RECONCILE_TIMEOUT_MS;
+    while (true) {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        throw error;
+      }
+      // Only an explicit provisional replay gets another attempt. Transport failures
+      // and Gateway rejections remain terminal, so an unreachable Gateway pays at
+      // most one short reconciliation call instead of a second launch timeout.
+      const response = await dispatch(Math.min(SUBAGENT_AGENT_RECONCILE_INTERVAL_MS, remainingMs));
+      const replay = asOptionalRecord(response);
+      if (
+        replay?.admissionPending !== true &&
+        (replay?.status === "accepted" || replay?.status === "in_flight") &&
+        readGatewayRunId(response)
+      ) {
+        return response;
+      }
+      if (replay?.admissionPending !== true) {
+        throw new Error(
+          `Gateway found no active subagent run (status: ${String(replay?.status)}). Retry the spawn.`,
+          { cause: error },
+        );
+      }
+      await delay(
+        Math.min(SUBAGENT_AGENT_RECONCILE_INTERVAL_MS, Math.max(0, deadline - Date.now())),
+      );
+    }
   }
 }
 

--- a/src/agents/subagents/spawn/subagent-spawn-gateway.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-gateway.ts
@@ -1,5 +1,6 @@
 import type { AgentRuntimeIdentity } from "../../../gateway/agent-runtime-identity-token.js";
 import { withInProcessAgentRuntimeIdentity } from "../../../gateway/in-process-agent-runtime-identity.js";
+import { isGatewayRpcUnavailableError } from "../../../gateway/transport-error.js";
 import type { WorkerTurnExecutionIdentity } from "../../../gateway/worker-environments/placement-turn-claim-events.js";
 import { getActiveAgentRunDelegatedAuthority } from "../../../infra/agent-run-registry.js";
 import { getGatewayToolCallerIdentity } from "../../tools/gateway-caller-context.js";
@@ -137,13 +138,13 @@ async function callSubagentGatewayWithDispatchMode(
       : await dispatch();
     return { response, dispatchMode: "in_process" };
   }
-  const response =
+  const dispatchAgentRequest = (timeoutMs?: number | null) =>
     sessionSpawnContext && gatewayCaller?.operationalRunInstance
-      ? await runWithGatewaySessionSpawnContext(sessionSpawnContext, () =>
+      ? runWithGatewaySessionSpawnContext(sessionSpawnContext, () =>
           runWithGatewaySessionSpawnParentExecutionIdentity(parentExecutionIdentityToken, () =>
             callGatewayTool(
               request.method,
-              typeof request.timeoutMs === "number" ? { timeoutMs: request.timeoutMs } : {},
+              typeof timeoutMs === "number" ? { timeoutMs } : {},
               request.params,
               {
                 expectFinal: request.expectFinal,
@@ -153,8 +154,31 @@ async function callSubagentGatewayWithDispatchMode(
             ),
           ),
         )
-      : await deps.callGateway(request);
+      : deps.callGateway(typeof timeoutMs === "number" ? { ...request, timeoutMs } : request);
+  // A transport-ambiguous agent dispatch (gateway timeout/closed) does NOT prove the
+  // run never landed: the gateway can accept (and start) an agent run before the ack
+  // is received, and a same-idempotency-key replay returns that already-accepted run
+  // instead of starting a duplicate. Reconcile only agent dispatch calls (native and
+  // ACP share this seam); cleanup and other non-agent methods retry nothing.
+  const response =
+    request.method === "agent"
+      ? await reconcileSubagentAgentDispatch(() => dispatchAgentRequest(request.timeoutMs))
+      : await dispatchAgentRequest(request.timeoutMs);
   return { response, dispatchMode: "out_of_process" };
+}
+
+async function reconcileSubagentAgentDispatch<T>(dispatch: () => Promise<T>): Promise<T> {
+  try {
+    return await dispatch();
+  } catch (error) {
+    if (!isGatewayRpcUnavailableError(error)) {
+      throw error;
+    }
+    // The first dispatch may have accepted the run gateway-side before the ack was
+    // lost. A same-key replay returns that already-accepted run instead of starting a
+    // duplicate, so surface the recovered run rather than misreporting "no target".
+    return await dispatch();
+  }
 }
 
 export async function callSubagentGateway(

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -1122,32 +1122,67 @@ describe("spawnSubagentDirect seam flow", () => {
 
   it("reconciles a transport-ambiguous dispatch so an accepted run is surfaced instead of misreported as an error", async () => {
     let dispatchAttempts = 0;
-    // A plain Error whose message matches isGatewayRpcUnavailableError (the gateway
-    // timeout transport shape) models "the gateway may have accepted before the ack
-    // was lost" - distinct from a genuine dispatch rejection.
-    hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
-      if (request.method === "agent") {
-        dispatchAttempts += 1;
-        if (dispatchAttempts === 1) {
-          throw new Error("gateway timeout after 60000ms");
+    hoisted.callGatewayMock.mockImplementation(
+      async (request: { method?: string; timeoutMs?: number }) => {
+        if (request.method === "agent") {
+          dispatchAttempts += 1;
+          if (dispatchAttempts === 1) {
+            throw new Error("gateway timeout after 60000ms");
+          }
+          if (dispatchAttempts === 2) {
+            return {
+              runId: "accepted-ambig-run",
+              status: "in_flight",
+              admissionPending: true,
+            };
+          }
+          return { runId: "accepted-ambig-run", status: "in_flight" };
         }
-        return { runId: "accepted-ambig-run" };
-      }
-      return request.method?.startsWith("sessions.") ? { ok: true } : {};
-    });
+        return request.method?.startsWith("sessions.") ? { ok: true } : {};
+      },
+    );
     const context = { agentSessionKey: "agent:main:main" };
 
     const result = await spawnSubagentDirect({ task: "ambiguous child" }, context);
 
-    // The reconcile replay reuses the same idempotency key; the gateway surfaces it
-    // back as accepted, so the caller must not conclude nothing is running.
-    expect(dispatchAttempts).toBe(2);
+    expect(dispatchAttempts).toBe(3);
+    const agentRequests = gatewayRequestRecords().filter((request) => request.method === "agent");
+    expect(agentRequests.map((request) => request.params)).toEqual([
+      agentRequests[0]?.params,
+      agentRequests[0]?.params,
+      agentRequests[0]?.params,
+    ]);
+    expect(agentRequests.slice(1).map((request) => request.timeoutMs)).toEqual([800, 800]);
     expect(result).toMatchObject({
       status: "accepted",
       runId: "accepted-ambig-run",
       childSessionKey: expect.any(String),
     });
     expect(hoisted.registerSubagentRunMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not register a child when reconciliation finds a terminal run", async () => {
+    let dispatchAttempts = 0;
+    hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent" && ++dispatchAttempts === 1) {
+        throw new Error("gateway timeout after 60000ms");
+      }
+      return request.method === "agent"
+        ? { runId: "stopped-run", status: "timeout" }
+        : { ok: true };
+    });
+
+    const result = await spawnSubagentDirect(
+      { task: "ambiguous terminal child" },
+      { agentSessionKey: "agent:main:main" },
+    );
+
+    expect(dispatchAttempts).toBe(2);
+    expect(result).toMatchObject({
+      status: "error",
+      error: expect.stringContaining("no active subagent run (status: timeout)"),
+    });
+    expect(hoisted.registerSubagentRunMock).not.toHaveBeenCalled();
   });
 
   it("shares pending child capacity between native and visible spawn paths", async () => {

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -1120,6 +1120,36 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(hoisted.registerSubagentRunMock).toHaveBeenCalledTimes(1);
   });
 
+  it("reconciles a transport-ambiguous dispatch so an accepted run is surfaced instead of misreported as an error", async () => {
+    let dispatchAttempts = 0;
+    // A plain Error whose message matches isGatewayRpcUnavailableError (the gateway
+    // timeout transport shape) models "the gateway may have accepted before the ack
+    // was lost" - distinct from a genuine dispatch rejection.
+    hoisted.callGatewayMock.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent") {
+        dispatchAttempts += 1;
+        if (dispatchAttempts === 1) {
+          throw new Error("gateway timeout after 60000ms");
+        }
+        return { runId: "accepted-ambig-run" };
+      }
+      return request.method?.startsWith("sessions.") ? { ok: true } : {};
+    });
+    const context = { agentSessionKey: "agent:main:main" };
+
+    const result = await spawnSubagentDirect({ task: "ambiguous child" }, context);
+
+    // The reconcile replay reuses the same idempotency key; the gateway surfaces it
+    // back as accepted, so the caller must not conclude nothing is running.
+    expect(dispatchAttempts).toBe(2);
+    expect(result).toMatchObject({
+      status: "accepted",
+      runId: "accepted-ambig-run",
+      childSessionKey: expect.any(String),
+    });
+    expect(hoisted.registerSubagentRunMock).toHaveBeenCalledTimes(1);
+  });
+
   it("shares pending child capacity between native and visible spawn paths", async () => {
     const { maybeSpawnVisibleSession } = await import("../../tools/sessions-spawn-visible.js");
     hoisted.configOverride = createConfigOverride({

--- a/src/gateway/agent-turn/agent-request-preflight.test.ts
+++ b/src/gateway/agent-turn/agent-request-preflight.test.ts
@@ -19,6 +19,7 @@ function runPreflight(
     includeCollectorFields?: boolean;
     launchPending?: boolean;
     cached?: boolean;
+    admissionPending?: boolean;
     completed?: boolean;
     ended?: boolean;
   },
@@ -68,7 +69,12 @@ function runPreflight(
             {
               ts: 1,
               ok: true,
-              payload: { status: "accepted", runId: "gateway-run", sessionKey },
+              payload: {
+                status: "accepted",
+                runId: "gateway-run",
+                sessionKey,
+                ...(options.admissionPending ? { reservationId: "pending" } : {}),
+              },
             },
           ],
         ])
@@ -298,6 +304,29 @@ describe("agent request Swarm preflight", () => {
       undefined,
       expect.objectContaining({ cached: true, runId: "gateway-run" }),
     );
+  });
+
+  it("marks a provisional cached replay as admission pending without exposing its reservation", async () => {
+    const replayed = runPreflight(undefined, true, {
+      backend: true,
+      register: true,
+      launchPending: false,
+      cached: true,
+      admissionPending: true,
+    });
+    expect(replayed.result).toBeDefined();
+    await replayed.replay();
+    expect(replayed.respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        runId: "gateway-run",
+        status: "in_flight",
+        admissionPending: true,
+      }),
+      undefined,
+      expect.objectContaining({ cached: true, runId: "gateway-run" }),
+    );
+    expect(replayed.respond.mock.calls[0]?.[1]).not.toHaveProperty("reservationId");
   });
 
   it("rejects a terminal collector even when its pending launch flag remains set", () => {

--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -60,19 +60,11 @@ function replayAgentTurnIfCached(params: {
     return false;
   }
   if (cached.ok && isAcceptedAgentDedupePayload(cached.payload)) {
-    const cachedRunId =
-      typeof cached.payload.runId === "string" && cached.payload.runId.trim()
-        ? cached.payload.runId.trim()
-        : runId;
-    const cachedSessionKey =
-      typeof cached.payload.sessionKey === "string" && cached.payload.sessionKey.trim()
-        ? cached.payload.sessionKey.trim()
-        : undefined;
-    const cachedAgentId =
-      typeof cached.payload.agentId === "string" && cached.payload.agentId.trim()
-        ? cached.payload.agentId.trim()
-        : undefined;
+    const cachedRunId = normalizeOptionalString(cached.payload.runId) ?? runId;
+    const cachedSessionKey = normalizeOptionalString(cached.payload.sessionKey);
+    const cachedAgentId = normalizeOptionalString(cached.payload.agentId);
     const cachedRuntime = asOptionalRecord(cached.payload.runtime);
+    const admissionPending = typeof cached.payload.reservationId === "string";
     params.io.emitAcceptance(
       [
         true,
@@ -82,6 +74,7 @@ function replayAgentTurnIfCached(params: {
           ...(cachedSessionKey ? { sessionKey: cachedSessionKey } : {}),
           ...(cachedAgentId ? { agentId: cachedAgentId } : {}),
           ...(cachedRuntime ? { runtime: cachedRuntime } : {}),
+          ...(admissionPending ? { admissionPending: true } : {}),
         },
         undefined,
       ],

--- a/src/gateway/server-methods/agent.base.test-utils.ts
+++ b/src/gateway/server-methods/agent.base.test-utils.ts
@@ -267,7 +267,7 @@ describe("gateway agent handler", () => {
     });
     expect(duplicateRespond).toHaveBeenCalledWith(
       true,
-      { runId, status: "in_flight", agentId: "ops" },
+      { runId, status: "in_flight", agentId: "ops", admissionPending: true },
       undefined,
       {
         cached: true,


### PR DESCRIPTION
Closes #130164

## What Problem This Solves

A `sessions_spawn` call can lose its Gateway acknowledgement after the Gateway has already accepted the child run. The parent then reports `status: "error"` even though the child exists and is running.

The same-key replay also has a provisional state. Before admission settles, the Gateway reserves the run ID. That reservation must not be registered as an active child until it becomes a settled acceptance.

## Why This Change Was Made

The child launch already carries one stable idempotency key. The Gateway dedupe record is the authoritative owner for that key.

The shared out-of-process spawn seam now reconciles only transport-ambiguous `agent` dispatches. Native and ACP spawns use this same path.

- A settled `accepted` or `in_flight` replay returns the existing run.
- An explicit provisional replay waits with an absolute 6.4-second deadline and 800 ms per-call pacing.
- A genuine Gateway rejection, another transport failure, or a terminal replay does not retry or register a child.
- Cleanup and non-agent Gateway calls never retry.

The Gateway now exposes only `admissionPending: true` for provisional replay. It does not expose the internal reservation ID.

## User Impact

- A lost acknowledgement no longer makes a running child invisible to its parent.
- The same idempotency key cannot start a duplicate child.
- A child that settles to `timeout` or another terminal result is not registered as active.
- No configuration, storage, timeout option, compatibility path, or new public API was added.

## Evidence

**Red — exact current main `8e4075371039`:** An isolated real Gateway accepted and recorded one WebSocket `agent` dispatch. A frame proxy dropped only the accepted acknowledgement. The parent returned `status: "error"`, while a same-key replay returned the same authoritative run ID. The parent registry was empty.

**Green — production-identical head `64be0ae2137f`:** The same isolated Gateway scenario sent two `agent` frames with one idempotency key. The parent returned `status: "accepted"`. Gateway replay returned the same run ID as `in_flight`. The parent registry contained exactly one running child, and the controlled provider completed exactly one child turn. Final head `1e9ed747a902` changes only the matching Gateway test assertion.

**Terminal control — production-identical head `64be0ae2137f`:** A real Gateway replay first returned `admissionPending: true`. A real abort then settled that same run to `timeout`. The parent returned a visible retry error and registered no child. Final head `1e9ed747a902` changes only the matching Gateway test assertion.

### Sanitized current-head Gateway trace

```json
{
  "accepted_replay": {
    "request_1": { "method": "agent", "idempotencyKey": "same-key" },
    "response_1": { "status": "accepted", "runId": "run-a", "action": "dropped" },
    "request_2": { "method": "agent", "idempotencyKey": "same-key" },
    "response_2": { "status": "in_flight", "runId": "run-a" },
    "parent": { "status": "accepted", "runId": "run-a" },
    "registry": [{ "runId": "run-a", "status": "running" }],
    "providerRequests": 1
  },
  "provisional_to_terminal": {
    "request_1": { "method": "agent", "idempotencyKey": "same-key" },
    "transport": "response dropped",
    "request_2": { "method": "agent", "idempotencyKey": "same-key" },
    "response_2": { "status": "in_flight", "runId": "run-b", "admissionPending": true },
    "control": { "method": "chat.abort", "aborted": true, "runId": "run-b" },
    "request_3": { "method": "agent", "idempotencyKey": "same-key" },
    "response_3": { "status": "timeout", "runId": "run-b" },
    "parent": { "status": "error", "retryVisible": true },
    "registry": []
  }
}
```

Telegram was not used as the proof surface. Telegram tool calls have an in-process Gateway context, while this defect exists only on the out-of-process WebSocket dispatch path.

Regression support:

```text
node scripts/run-vitest.mjs src/agents/subagents/spawn/subagent-spawn.test.ts src/agents/subagents/spawn/acp-spawn.test.ts src/gateway/agent-turn/agent-request-preflight.test.ts
# 173 passed

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/subagents/spawn/acp-spawn.test.ts src/agents/subagents/spawn/subagent-spawn-gateway.ts src/agents/subagents/spawn/subagent-spawn.test.ts src/gateway/agent-turn/agent-request-preflight.test.ts src/gateway/agent-turn/agent-turn-service.ts
# passed

git diff --check
# passed
```
