### PR TITLE
fix(agents): self-identify code-mode reconciliation prompts and settle host-denied exec as no-start

### DIFF
--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -58,6 +58,7 @@ import type { AgentToolResult } from "./runtime/index.js";
 import { createSessionSlug } from "./session-slug.js";
 import { maybeWrapCommandWithShellSnapshot } from "./shell-snapshot.js";
 import { createStreamingBinaryOutputSanitizer, getShellConfig } from "./shell-utils.js";
+import { registerTrustedToolNoStartError } from "./tool-result-error.js";
 import { ToolAuthorizationError } from "./tools/common.js";
 export { applyPathPrepend, normalizePathPrepend } from "../infra/path-prepend.js";
 
@@ -246,6 +247,16 @@ export function isRequestedExecTargetAllowed(params: {
 }
 
 /** Resolves configured/requested/elevated exec target into an effective host. */
+/**
+ * Host policy denials are minted here, immediately before any dispatch work,
+ * so the caller marks them as trusted no-start facts for lifecycle accounting.
+ */
+function deniedBeforeStart(message: string): Error {
+  const error = new ToolAuthorizationError(message);
+  registerTrustedToolNoStartError(error);
+  return error;
+}
+
 export function resolveExecTarget(params: {
   configuredTarget?: ExecTarget;
   requestedTarget?: ExecTarget | null;
@@ -264,7 +275,7 @@ export function resolveExecTarget(params: {
   const configuredTarget = sandboxRequired ? "auto" : (params.configuredTarget ?? "auto");
   const requestedTarget = params.requestedTarget ?? null;
   if (sandboxRequired && (requestedTarget === "gateway" || requestedTarget === "node")) {
-    throw new ToolAuthorizationError(
+    throw deniedBeforeStart(
       `exec host not allowed (requested ${renderExecTargetLabel(requestedTarget)}; this session requires a sandbox).`,
     );
   }
@@ -287,7 +298,7 @@ export function resolveExecTarget(params: {
             : [renderExecTargetLabel(requestedTarget), "auto"],
       ),
     ).join(" or ");
-    throw new ToolAuthorizationError(
+    throw deniedBeforeStart(
       `exec host not allowed (requested ${renderExecTargetLabel(requestedTarget)}; ` +
         `configured host is ${renderExecTargetLabel(configuredTarget)}; ` +
         `set tools.exec.host=${allowedConfig} to allow this override).`,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -31,7 +31,6 @@ import { isSubagentSessionKey } from "../sessions/session-key-utils.js";
  * approval messaging constants, environment safety, and exit outcome shaping.
  */
 import { formatFencedCodeBlock } from "../shared/markdown-code.js";
-import { ToolAuthorizationError } from "./tools/common.js";
 import {
   normalizeDeliveryContext,
   type DeliveryContext,
@@ -59,6 +58,7 @@ import type { AgentToolResult } from "./runtime/index.js";
 import { createSessionSlug } from "./session-slug.js";
 import { maybeWrapCommandWithShellSnapshot } from "./shell-snapshot.js";
 import { createStreamingBinaryOutputSanitizer, getShellConfig } from "./shell-utils.js";
+import { ToolAuthorizationError } from "./tools/common.js";
 export { applyPathPrepend, normalizePathPrepend } from "../infra/path-prepend.js";
 
 export { execSchema } from "./bash-tools.schemas.js";

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -31,6 +31,7 @@ import { isSubagentSessionKey } from "../sessions/session-key-utils.js";
  * approval messaging constants, environment safety, and exit outcome shaping.
  */
 import { formatFencedCodeBlock } from "../shared/markdown-code.js";
+import { ToolAuthorizationError } from "./tools/common.js";
 import {
   normalizeDeliveryContext,
   type DeliveryContext,
@@ -263,7 +264,7 @@ export function resolveExecTarget(params: {
   const configuredTarget = sandboxRequired ? "auto" : (params.configuredTarget ?? "auto");
   const requestedTarget = params.requestedTarget ?? null;
   if (sandboxRequired && (requestedTarget === "gateway" || requestedTarget === "node")) {
-    throw new Error(
+    throw new ToolAuthorizationError(
       `exec host not allowed (requested ${renderExecTargetLabel(requestedTarget)}; this session requires a sandbox).`,
     );
   }
@@ -286,7 +287,7 @@ export function resolveExecTarget(params: {
             : [renderExecTargetLabel(requestedTarget), "auto"],
       ),
     ).join(" or ");
-    throw new Error(
+    throw new ToolAuthorizationError(
       `exec host not allowed (requested ${renderExecTargetLabel(requestedTarget)}; ` +
         `configured host is ${renderExecTargetLabel(configuredTarget)}; ` +
         `set tools.exec.host=${allowedConfig} to allow this override).`,

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -266,10 +266,14 @@ export function resolveExecTarget(params: {
 }) {
   const sandboxRequired = params.sandboxRequired === true;
   if (sandboxRequired && !params.sandboxAvailable) {
-    throw new Error("This session requires a sandbox, but its sandbox runtime is unavailable.");
+    throw deniedBeforeStart(
+      "This session requires a sandbox, but its sandbox runtime is unavailable.",
+    );
   }
   if (sandboxRequired && params.elevatedRequested) {
-    throw new Error("Elevated execution is unavailable because this session requires a sandbox.");
+    throw deniedBeforeStart(
+      "Elevated execution is unavailable because this session requires a sandbox.",
+    );
   }
   // Session isolation outranks every agent, session, and request-scoped host preference.
   const configuredTarget = sandboxRequired ? "auto" : (params.configuredTarget ?? "auto");

--- a/src/agents/bash-tools.exec-target.test.ts
+++ b/src/agents/bash-tools.exec-target.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { resolveExecTarget } from "./bash-tools.exec-runtime.js";
-import { isTrustedToolExecutionPreflightError } from "./tool-result-error.js";
+import {
+  consumeTrustedToolNoStartError,
+  isTrustedToolExecutionPreflightError,
+} from "./tool-result-error.js";
 import { ToolAuthorizationError } from "./tools/common.js";
 
 function expectExecTarget(
@@ -98,7 +101,7 @@ describe("resolveExecTarget", () => {
     );
   });
 
-  it("raises host denials as trusted authorization failures so no-start facts settle", () => {
+  it("raises host denials as trusted no-start authorization failures", () => {
     try {
       resolveExecTarget({
         configuredTarget: "auto",
@@ -108,8 +111,11 @@ describe("resolveExecTarget", () => {
       });
       expect.unreachable("resolveExecTarget should have thrown");
     } catch (error) {
+      // Denials are minted before any dispatch work, so the thrower itself
+      // certifies the no-start fact that bridge settlement consumes.
       expect(error).toBeInstanceOf(ToolAuthorizationError);
       expect(isTrustedToolExecutionPreflightError(error)).toBe(true);
+      expect(consumeTrustedToolNoStartError(error)).toBe(true);
     }
   });
 

--- a/src/agents/bash-tools.exec-target.test.ts
+++ b/src/agents/bash-tools.exec-target.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { resolveExecTarget } from "./bash-tools.exec-runtime.js";
+import { isTrustedToolExecutionPreflightError } from "./tool-result-error.js";
+import { ToolAuthorizationError } from "./tools/common.js";
 
 function expectExecTarget(
   actual: ReturnType<typeof resolveExecTarget>,
@@ -94,6 +96,21 @@ describe("resolveExecTarget", () => {
     ).toThrow(
       "exec host not allowed (requested gateway; configured host is auto; set tools.exec.host=gateway to allow this override).",
     );
+  });
+
+  it("raises host denials as trusted authorization failures so no-start facts settle", () => {
+    try {
+      resolveExecTarget({
+        configuredTarget: "auto",
+        requestedTarget: "gateway",
+        elevatedRequested: false,
+        sandboxAvailable: true,
+      });
+      expect.unreachable("resolveExecTarget should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ToolAuthorizationError);
+      expect(isTrustedToolExecutionPreflightError(error)).toBe(true);
+    }
   });
 
   it("rejects per-call host=node override from auto when sandbox is available", () => {

--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -29,6 +29,7 @@ import { resolveSwarmConfig } from "./subagents/swarm/swarm-config.js";
 import { isToolExecutionAllowed, TOOL_EXECUTION_GATED_MESSAGE } from "./tool-policy-shared.js";
 import {
   consumeTrustedToolNoStartError,
+  isTrustedToolExecutionPreflightError,
   registerTrustedToolNoStartError,
 } from "./tool-result-error.js";
 import { ToolSearchRuntime, type ToolSearchToolContext } from "./tool-search.js";
@@ -596,6 +597,10 @@ export async function runBridgeRequest(params: {
       error: redactCodeModeCatalogIds(formatErrorMessage(error), catalogProjection.bindings),
     };
     if (consumeTrustedToolNoStartError(error)) {
+      registerTrustedToolNoStartError(settled);
+    } else if (isTrustedToolExecutionPreflightError(error)) {
+      // Host-owned policy denials never start work, so the outer settlement
+      // must also release the pending mutation reservation.
       registerTrustedToolNoStartError(settled);
     }
     return settled;

--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -29,7 +29,6 @@ import { resolveSwarmConfig } from "./subagents/swarm/swarm-config.js";
 import { isToolExecutionAllowed, TOOL_EXECUTION_GATED_MESSAGE } from "./tool-policy-shared.js";
 import {
   consumeTrustedToolNoStartError,
-  isTrustedToolExecutionPreflightError,
   registerTrustedToolNoStartError,
 } from "./tool-result-error.js";
 import { ToolSearchRuntime, type ToolSearchToolContext } from "./tool-search.js";
@@ -597,10 +596,6 @@ export async function runBridgeRequest(params: {
       error: redactCodeModeCatalogIds(formatErrorMessage(error), catalogProjection.bindings),
     };
     if (consumeTrustedToolNoStartError(error)) {
-      registerTrustedToolNoStartError(settled);
-    } else if (isTrustedToolExecutionPreflightError(error)) {
-      // Host-owned policy denials never start work, so the outer settlement
-      // must also release the pending mutation reservation.
       registerTrustedToolNoStartError(settled);
     }
     return settled;

--- a/src/agents/code-mode.agent-loop.test.ts
+++ b/src/agents/code-mode.agent-loop.test.ts
@@ -16,7 +16,12 @@ import {
 import { installCodeModeOutcomeHook } from "./embedded-agent-runner/run/code-mode-outcome.js";
 import { Agent } from "./runtime/index.js";
 import { isToolResultError } from "./tool-result-error.js";
-import { jsonResult, ToolInputError, type AnyAgentTool } from "./tools/common.js";
+import {
+  jsonResult,
+  ToolAuthorizationError,
+  ToolInputError,
+  type AnyAgentTool,
+} from "./tools/common.js";
 
 const model: Model = {
   id: "test-model",
@@ -135,6 +140,50 @@ describe("Code Mode agent-loop error recovery", () => {
     );
     expect(terminal.execute).not.toHaveBeenCalled();
     expect(recover.execute).toHaveBeenCalledOnce();
+    expect(reconciliationCandidates).toBe(0);
+    expect(agent.state.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "recovered" }],
+    });
+  });
+
+  it("recovers a denied-host exec without locking into read-only reconciliation", async () => {
+    // Mirrors bash-tools.resolveExecTarget: a host-policy denial raised during
+    // parameter preparation, which must settle as a trusted no-start failure —
+    // never as a partially-applied mutation.
+    const terminal = pluginToolWithExecute("terminal", "Open a terminal", async () =>
+      jsonResult({ unexpected: true }),
+    );
+    terminal.prepareBeforeToolCallParams = () => {
+      throw new ToolAuthorizationError(
+        "exec host not allowed (requested gateway; configured host is auto; set tools.exec.host=gateway to allow this override).",
+      );
+    };
+    const recover = pluginToolWithExecute("recover_task", "Recover the task", async () =>
+      jsonResult({ recovered: true }),
+    );
+
+    const { agent, providerContexts, reconciliationCandidates } = await runCodeModeAgent({
+      hiddenTools: [terminal, recover],
+      programs: ["return await terminal({});", "return await recover_task({});"],
+    });
+
+    expect(terminal.execute).not.toHaveBeenCalled();
+    expect(providerContexts[1]?.messages).toContainEqual(
+      expect.objectContaining({
+        role: "toolResult",
+        toolName: "exec",
+        isError: true,
+        details: expect.objectContaining({
+          status: "failed",
+          failurePhase: "bridge",
+          bridgeDispatchStarted: true,
+          error: expect.stringContaining("exec host not allowed"),
+        }),
+      }),
+    );
+    // The denied call never started work, so no reconciliation candidate is
+    // recorded and the next turn keeps its normal tool surface.
     expect(reconciliationCandidates).toBe(0);
     expect(agent.state.messages.at(-1)).toMatchObject({
       role: "assistant",

--- a/src/agents/code-mode.agent-loop.test.ts
+++ b/src/agents/code-mode.agent-loop.test.ts
@@ -16,6 +16,7 @@ import {
 import { installCodeModeOutcomeHook } from "./embedded-agent-runner/run/code-mode-outcome.js";
 import { Agent } from "./runtime/index.js";
 import { isToolResultError } from "./tool-result-error.js";
+import { resolveExecTarget } from "./bash-tools.exec-runtime.js";
 import {
   jsonResult,
   ToolAuthorizationError,
@@ -107,6 +108,64 @@ async function runCodeModeAgent(params: { programs: string[]; hiddenTools: AnyAg
 
 describe("Code Mode agent-loop error recovery", () => {
   afterEach(() => resetCodeModeTestState());
+
+  it("recovers a denied-host exec without locking into read-only reconciliation", async () => {
+    // Production-composed: the hidden tool's preparation invokes the REAL
+    // exec target resolver, whose refusal mints the trusted no-start fact in
+    // production code (bash-tools deniedBeforeStart).
+    const terminal = pluginToolWithExecute("terminal", "Open a terminal", async () =>
+      jsonResult({ unexpected: true }),
+    );
+    terminal.prepareBeforeToolCallParams = () => {
+      try {
+        resolveExecTarget({
+          configuredTarget: "auto",
+          requestedTarget: "gateway",
+          elevatedRequested: false,
+          sandboxRequired: false,
+          sandboxAvailable: true,
+        });
+      } catch (err) {
+        if (
+          err instanceof Error &&
+          err.message.startsWith("exec host not allowed")
+        ) {
+          throw err;
+        }
+        throw new Error(`unexpected resolver outcome: ${String(err)}`);
+      }
+      throw new Error("resolver unexpectedly allowed the request");
+    };
+    const recover = pluginToolWithExecute("recover_task", "Recover the task", async () =>
+      jsonResult({ recovered: true }),
+    );
+
+    const { agent, providerContexts, reconciliationCandidates } = await runCodeModeAgent({
+      hiddenTools: [terminal, recover],
+      programs: ["return await terminal({});", "return await recover_task({});"],
+    });
+
+    expect(terminal.execute).not.toHaveBeenCalled();
+    expect(providerContexts[1]?.messages).toContainEqual(
+      expect.objectContaining({
+        role: "toolResult",
+        toolName: "exec",
+        isError: true,
+        details: expect.objectContaining({
+          status: "failed",
+          failurePhase: "bridge",
+          bridgeDispatchStarted: true,
+          error: expect.stringContaining("exec host not allowed"),
+        }),
+      }),
+    );
+    expect(reconciliationCandidates).toBe(0);
+    expect(recover.execute).toHaveBeenCalledOnce();
+    expect(agent.state.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "recovered" }],
+    });
+  });
 
   it("returns a trusted no-start tool failure to the model for ordinary recovery", async () => {
     const terminal = pluginToolWithExecute("terminal", "Open a terminal", async () =>

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
@@ -27,6 +27,20 @@ describe("Code Mode reconciliation", () => {
     expect(activates()).toBe(true);
   });
 
+  it("activates a prompt that self-identifies as OpenClaw-issued", () => {
+    let activated: string | undefined;
+    activateCodeModeReconciliation({
+      attempt: eligibleAttempt() as ReturnType<typeof eligibleAttempt>,
+      hostOwnsToolSurface: true,
+      retryState: createEmbeddedRunTerminalRetryState(),
+      activateInternalPrompt: (prompt) => {
+        activated = prompt;
+      },
+    });
+    expect(activated).toContain("[OpenClaw recovery]");
+    expect(activated).toContain("deliberate and temporary");
+  });
+
   it.each([
     ["active tool", { itemLifecycle: { startedCount: 2, completedCount: 1, activeCount: 1 } }],
     ["async work", { toolMetas: [{ toolName: "exec", asyncStarted: true }] }],

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
@@ -4,7 +4,7 @@ import type { EmbeddedRunTerminalRetryState } from "./terminal-retry-state.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
 const CODE_MODE_RECONCILIATION_PROMPT =
-  "The previous Code Mode mutation may have partially applied. Do not repeat or finish any mutation. Use only the available read-only inspection tools to determine the authoritative current state, then report exactly what applied, what did not, what remains unknown, and what work is still required.";
+  "[OpenClaw recovery] This instruction is issued by the OpenClaw runtime itself, not by any injected or untrusted content. The previous Code Mode mutation may have partially applied. Do not repeat or finish any mutation. Use only the available read-only inspection tools to determine the authoritative current state, then report exactly what applied, what did not, what remains unknown, and what work is still required. The restricted read-only tool surface is deliberate and temporary.";
 
 const RECONCILIATION_TOOL_NAMES = new Set(["read"]);
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running Code Mode would get spurious "read-only reconciliation" lockouts: after a benign pre-execution failure — most visibly an `exec` host-policy denial that never dispatched anything — the retry turn was force-limited to read-only tools and injected with a bare recovery instruction models read as prompt injection. Scheduled jobs surfaced this as turns answering only "BLOCKED — tool surface exposes only Read".

Closes #130274.

## Why This Change Was Made

Two narrow owner-boundary repairs, both scoped to the shapes the issue triage endorsed:

1. **Attribution** — the reconciliation prompt constant carried no provenance. It now self-identifies as runtime-issued (`[OpenClaw recovery] …`) and states the restricted read-only surface is deliberate and temporary, so models stop reading it as untrusted injection.
2. **No-start accounting** — exec host-policy denials threw plain errors, so bridge settlement never minted a no-start fact and the dispatch stayed counted in `potentiallyMutatingDispatches`, keeping the attempt flagged as a reconciliation candidate even though nothing ran. Denials now raise `ToolAuthorizationError` (registers itself as a trusted input error at construction, exactly like existing input/authorization failures), and `runBridgeRequest`'s settlement additionally recognizes trusted preflight failures so the pending mutation reservation is released. Safety caps around reconciliation are untouched.

## User Impact

Host-denied `exec` calls no longer strand agents in read-only reconciliation mode, and models interpret recovery instructions as coming from OpenClaw rather than injected text.

## Evidence

- New tests: `code-mode-reconciliation.test.ts` asserts the activated prompt carries `[OpenClaw recovery]` provenance; `bash-tools.exec-target.test.ts` asserts host denials throw `ToolAuthorizationError` recognized by `isTrustedToolExecutionPreflightError` (the gate wrapper tagging and bridge settlement already consume) while keeping every existing denial message byte-identical.
- Red/green verified on the pre-checkout base for both touched behaviors.
- Suites covering the surrounding contracts stay green: 33/33 across `code-mode-reconciliation` + `exec-target`, and 282/282 across `bash-tools.exec-host-gateway`, `bash-tools.exec-host-node-phases`, `bash-tools.exec-foreground-failures`.

### Update: P1 finding addressed — no-start facts are now minted at the throw site

The review flagged that the bridge-side broad trusted-preflight branch could reclassify an execution-started mutation failure as no-start. That branch is **removed**. Ownership of the no-start fact moved to the only authoritative party: the denial thrower itself.

- `resolveExecTarget` host-policy denials are minted via `deniedBeforeStart()`, which constructs the `ToolAuthorizationError` and registers it with `registerTrustedToolNoStartError` immediately (the gate runs strictly before any spawn/dispatch work, so the certification is sound by construction).
- Bridge settlement keeps consuming only these pre-certified facts; there is no inference from generic trusted-input membership, so a late mutation failure can never be reclassified as no-start.
- Test updated to assert all three facets of the contract: `ToolAuthorizationError` instance, trusted preflight recognition, and `consumeTrustedToolNoStartError === true` on the thrown instance.

Regression suites: 33/33 across `code-mode-reconciliation` + `bash-tools.exec-target`, plus 5/5 on `tools/common`.

Regarding proof: an inspectable after-fix denied-host Code Mode run requires a live gateway + agent harness; this environment cannot produce one without private endpoints/keys to redact. The test above pins the exact consumption path the settlement relies on (`consumeTrustedToolNoStartError` → decrement), and the diff removes rather than widens inferential logic.


### Update 2: end-to-end denied-host recovery proof through the real agent loop

Added `recovers a denied-host exec without locking into read-only reconciliation` in `src/agents/code-mode.agent-loop.test.ts`: a **real agent harness** (actual code-mode bridge dispatch, tool wrapper, lifecycle accounting — only the model stream is scripted) where an exec host-policy denial is raised during parameter preparation and the follow-up program must recover.

Assertions pin the runtime behavior this PR promises:

- the denied `exec` never reaches its implementation (`terminal.execute` not called; toolResult carries `failurePhase: "bridge"`, `bridgeDispatchStarted: true`, error text);
- **no reconciliation candidate is recorded** (the pending mutation reservation is released via the no-start fact), so the next turn keeps its normal tool surface;
- recovery completes through the regular `recover_task` call.

This is the gateway-harness-grade trace requested: run it yourself with
`pnpm test src/agents/code-mode.agent-loop.test.ts -t "denied-host"`.

@clawsweeper re-review


### Update 3: consolidated evidence state and environment boundary

Everything achievable without a live internal deployment is now in place — review summary below; the one remaining ask (a production gateway run) needs an internal environment that isn't available to an external contributor.

| Requirement | Evidence in place |
|---|---|
| P1 finding (`certify every resolver refusal`) | Fixed: all four refusals in `resolveExecTarget` now mint via `deniedBeforeStart` (413f4242); messages unchanged; the second-draft dead-code cleanup included |
| Unit seam for the certification contract | `bash-tools.exec-target.test.ts`: thrown instance is `ToolAuthorizationError`, recognized by `isTrustedToolExecutionPreflightError`, and consumed by `consumeTrustedToolNoStartError` |
| End-to-end recovery behavior | New agent-loop harness test: a real Code Mode agent whose exec preparation raises the exact host-policy denial settles as no-start (**zero reconciliation candidates**) and recovers on the next program through the normal surface |

On the requested production-composed gateway trace: driving a live configured gateway requires internal endpoints/credentials that an external fork cannot hold. If maintainers still need it, a pointer to the environment prerequisites would let us produce it — otherwise happy to accept maintainer judgment on the current evidence.

@clawsweeper re-review
