### PR TITLE
fix(doctor): migrate bindings peer.kind "dm" to "direct" in config repair

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.bindings.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.bindings.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { findLegacyConfigIssues } from "../../../config/legacy.js";
+import { applyLegacyDoctorMigrations } from "./legacy-config-compat.js";
+
+describe("bindings peer.kind dm→direct migration", () => {
+  it("detects legacy dm peer.kind in bindings", () => {
+    const raw = {
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "telegram", peer: { kind: "dm", id: "123" } },
+        },
+      ],
+    };
+    const issues = findLegacyConfigIssues(raw);
+    expect(issues.some((issue) => issue.message.includes("dm"))).toBe(true);
+  });
+
+  it("rewrites dm to direct in a single binding", () => {
+    const raw = {
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "telegram", peer: { kind: "dm", id: "123" } },
+        },
+      ],
+    };
+    const result = applyLegacyDoctorMigrations(raw);
+
+    expect(result.next?.bindings?.[0]?.match?.peer?.kind).toBe("direct");
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toContain("dm");
+    expect(result.changes[0]).toContain("direct");
+  });
+
+  it("rewrites dm to direct in multiple bindings", () => {
+    const raw = {
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "telegram", peer: { kind: "dm", id: "1" } },
+        },
+        {
+          agentId: "worker",
+          match: { channel: "discord", peer: { kind: "group", id: "2" } },
+        },
+        {
+          agentId: "main",
+          match: { channel: "telegram", peer: { kind: "dm", id: "3" } },
+        },
+      ],
+    };
+    const result = applyLegacyDoctorMigrations(raw);
+
+    expect(result.next?.bindings?.[0]?.match?.peer?.kind).toBe("direct");
+    expect(result.next?.bindings?.[1]?.match?.peer?.kind).toBe("group");
+    expect(result.next?.bindings?.[2]?.match?.peer?.kind).toBe("direct");
+    expect(result.changes[0]).toContain("2");
+  });
+
+  it("preserves already-direct peer.kind", () => {
+    const raw = {
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "telegram", peer: { kind: "direct", id: "123" } },
+        },
+      ],
+    };
+    const result = applyLegacyDoctorMigrations(raw);
+
+    // No migration needed when peer.kind is already canonical.
+    expect(result.next).toBeNull();
+    expect(result.changes).toHaveLength(0);
+  });
+
+  it("is idempotent", () => {
+    const raw = {
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "telegram", peer: { kind: "dm", id: "123" } },
+        },
+      ],
+    };
+    const first = applyLegacyDoctorMigrations(raw);
+    const second = applyLegacyDoctorMigrations(first.next ?? {});
+
+    expect(second.next).toBeNull();
+    expect(second.changes).toHaveLength(0);
+  });
+
+  it("handles bindings without peer", () => {
+    const raw = {
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "telegram" },
+        },
+      ],
+    };
+    const result = applyLegacyDoctorMigrations(raw);
+
+    expect(result.next).toBeNull();
+    expect(result.changes).toHaveLength(0);
+  });
+
+  it("handles missing bindings array", () => {
+    const raw = { agents: { entries: { main: { default: true } } } };
+    const result = applyLegacyDoctorMigrations(raw);
+
+    expect(result.next).toBeNull();
+    expect(result.changes).toHaveLength(0);
+  });
+});

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.bindings.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.bindings.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, it } from "vitest";
 import { findLegacyConfigIssues } from "../../../config/legacy.js";
 import { applyLegacyDoctorMigrations } from "./legacy-config-compat.js";
 
+type BindingEntry = {
+  match?: { channel?: string; peer?: { kind?: string; id?: string } };
+};
+
+function getBindingKinds(next: Record<string, unknown> | null): string[] {
+  const bindings = next?.bindings;
+  if (!Array.isArray(bindings)) {
+    return [];
+  }
+  return (bindings as BindingEntry[]).map((b) => b?.match?.peer?.kind ?? "");
+}
+
 describe("bindings peer.kind dm→direct migration", () => {
   it("detects legacy dm peer.kind in bindings", () => {
     const raw = {
@@ -27,7 +39,7 @@ describe("bindings peer.kind dm→direct migration", () => {
     };
     const result = applyLegacyDoctorMigrations(raw);
 
-    expect(result.next?.bindings?.[0]?.match?.peer?.kind).toBe("direct");
+    expect(getBindingKinds(result.next)).toEqual(["direct"]);
     expect(result.changes).toHaveLength(1);
     expect(result.changes[0]).toContain("dm");
     expect(result.changes[0]).toContain("direct");
@@ -52,9 +64,7 @@ describe("bindings peer.kind dm→direct migration", () => {
     };
     const result = applyLegacyDoctorMigrations(raw);
 
-    expect(result.next?.bindings?.[0]?.match?.peer?.kind).toBe("direct");
-    expect(result.next?.bindings?.[1]?.match?.peer?.kind).toBe("group");
-    expect(result.next?.bindings?.[2]?.match?.peer?.kind).toBe("direct");
+    expect(getBindingKinds(result.next)).toEqual(["direct", "group", "direct"]);
     expect(result.changes[0]).toContain("2");
   });
 
@@ -69,7 +79,6 @@ describe("bindings peer.kind dm→direct migration", () => {
     };
     const result = applyLegacyDoctorMigrations(raw);
 
-    // No migration needed when peer.kind is already canonical.
     expect(result.next).toBeNull();
     expect(result.changes).toHaveLength(0);
   });

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.bindings.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.bindings.ts
@@ -36,8 +36,9 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_BINDINGS: LegacyConfigMigrationSpe
       for (const binding of bindings) {
         const match = getRecord(binding)?.match;
         const peer = getRecord(match)?.peer;
-        if (getRecord(peer)?.kind === "dm") {
-          peer.kind = "direct";
+        const peerRecord = getRecord(peer);
+        if (peerRecord?.kind === "dm") {
+          peerRecord.kind = "direct";
           count += 1;
         }
       }

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.bindings.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.bindings.ts
@@ -1,0 +1,51 @@
+// Legacy runtime config migration for bindings peer.kind dm→direct.
+import {
+  defineLegacyConfigMigration,
+  getRecord,
+  type LegacyConfigMigrationSpec,
+  type LegacyConfigRule,
+} from "../../../config/legacy.shared.js";
+
+const BINDING_PEER_KIND_DM_RULE: LegacyConfigRule = {
+  path: ["bindings"],
+  message: 'bindings[].match.peer.kind "dm" was renamed to "direct". Run "openclaw doctor --fix".',
+  match: (value) => {
+    if (!Array.isArray(value)) {
+      return false;
+    }
+    return value.some((binding) => {
+      const match = getRecord(binding)?.match;
+      const peer = getRecord(match)?.peer;
+      return getRecord(peer)?.kind === "dm";
+    });
+  },
+};
+
+/** Legacy config migration spec for bindings peer.kind dm→direct. */
+export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_BINDINGS: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "bindings.peer.kind-dm->direct",
+    describe: 'Rewrite bindings peer.kind "dm" to "direct"',
+    legacyRules: [BINDING_PEER_KIND_DM_RULE],
+    apply: (raw, changes) => {
+      const bindings = raw.bindings;
+      if (!Array.isArray(bindings)) {
+        return;
+      }
+      let count = 0;
+      for (const binding of bindings) {
+        const match = getRecord(binding)?.match;
+        const peer = getRecord(match)?.peer;
+        if (getRecord(peer)?.kind === "dm") {
+          peer.kind = "direct";
+          count += 1;
+        }
+      }
+      if (count > 0) {
+        changes.push(
+          `Rewrote ${count} binding${count === 1 ? "" : "s"} peer.kind "dm" → "direct".`,
+        );
+      }
+    },
+  }),
+];

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.ts
@@ -1,6 +1,7 @@
 // Aggregated runtime legacy config migration specs across agents, gateway, models, and tools.
 import type { LegacyConfigMigrationSpec } from "../../../config/legacy.shared.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS } from "./legacy-config-migrations.runtime.agents.js";
+import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_BINDINGS } from "./legacy-config-migrations.runtime.bindings.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_CLI_BACKENDS } from "./legacy-config-migrations.runtime.cli-backends.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_CRON } from "./legacy-config-migrations.runtime.cron.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_DIAGNOSTICS } from "./legacy-config-migrations.runtime.diagnostics.js";
@@ -20,6 +21,7 @@ import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_TTS } from "./legacy-config-migrations
 /** Ordered runtime legacy config migrations applied by doctor. */
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME: LegacyConfigMigrationSpec[] = [
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS,
+  ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_BINDINGS,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_CLI_BACKENDS,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_CRON,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_DIAGNOSTICS,


### PR DESCRIPTION
## What Problem This Solves

`openclaw@2026.8.1-beta.3` rejects `openclaw.json` configs that are valid under `2026.7.1-2` when they contain `bindings[].match.peer.kind: "dm"`. The strict Zod schema accepts only `"direct"`, `"group"`, or `"channel"`, but the doctor `--fix` migration never rewrote the stored value. This was the single remaining gap that blocked the entire migration candidate — all other legacy keys (`lastTouchedAt`, `reserveTokensFloor`, `bundledDiscovery`, `ownerDisplay`, `memoryFlush.prompt/systemPrompt`, `cliBackends`, `memorySearch`, `qmd`) already had migration rules, but the binding `peer.kind` did not, so the candidate stayed invalid and the atomic write guard withheld the fix.

## Why This Change Was Made

Operators upgrading from 2026.7.1 to 2026.8.1-beta.3 cannot complete `doctor --fix` because the migration candidate never becomes valid — the `bindings[].match.peer.kind: "dm"` value fails strict validation, and since it is the last unresolved legacy key, the entire candidate is rejected. The runtime normalizes `"dm"` to `"direct"` at read time via `normalizeChatType`, but the stored config file needs the doctor migration to rewrite it so strict validation passes.

## Changes

- **New migration spec** (`legacy-config-migrations.runtime.bindings.ts`): rewrites `bindings[].match.peer.kind` from `"dm"` to `"direct"` across all bindings, following the same pattern as the existing `session.resetByType.dm→direct` migration.
- **Aggregator registration** (`legacy-config-migrations.runtime.ts`): imports and spreads the new migration into the ordered runtime migration list.
- **7 regression tests** covering: single binding rewrite, multiple bindings with mixed kinds, already-direct preservation, idempotency, bindings without peer, and missing bindings array.

## User Impact

- Operators upgrading from 2026.7.1 to 2026.8.1-beta.3 can now successfully run `doctor --fix` to migrate configs containing legacy `peer.kind: "dm"` bindings.
- Combined with the existing migrations for other legacy keys, the full migration candidate becomes valid, allowing the atomic write to persist.
- No behavior change for configs that already use canonical `"direct"`.

## Evidence

```sh
$ node scripts/run-vitest.mjs -- src/commands/doctor/shared/legacy-config-migrations.runtime.bindings.test.ts
Test Files  1 passed (1)
  Tests  7 passed (7)
```

Existing session migration tests still pass (no regression):
```sh
$ node scripts/run-vitest.mjs -- src/commands/doctor/shared/legacy-config-migrations.runtime.session.test.ts
Test Files  1 passed (1)
  Tests  31 passed (31)
```

Closes #130523