### PR TITLE
fix(ui): preserve first startup errors across session navigation

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -120,6 +120,8 @@ For connections with a durable user profile, the Gateway stores each agent's lat
 
 On the first identified connection, the Control UI uploads existing browser-local new-session preferences only when the Gateway has no such preferences yet. Later changes write to the Gateway first and then update the browser mirror. Connections without a durable identity continue using browser-local preferences and the loaded session roster for recents.
 
+When a remote project session starts before its repository finishes cloning, chat shows workspace preparation progress. If preparation fails, opening or reloading chat restores the session's failure summary. Correct the reported problem, then send a new message in the same session to retry preparation.
+
 ## Personal identity
 
 Authenticated people have a durable Gateway profile with a display name, avatar, linked emails, and optional verified GitHub identity. Open **Settings → Profile → Identity** to update the editable fields. The profile follows the authenticated person across browsers; clearing browser site data does not delete it.

--- a/src/config/sessions/session-transcript-turn-lifecycle.types.ts
+++ b/src/config/sessions/session-transcript-turn-lifecycle.types.ts
@@ -31,6 +31,7 @@ export type SessionTranscriptTurnLifecyclePatch = {
   endedAt?: number;
   lifecycleRunId?: SessionEntry["lifecycleRunId"];
   lastRunId?: SessionEntry["lastRunId"];
+  lastRunError?: SessionEntry["lastRunError"];
   pendingFinalDelivery?: SessionEntry["pendingFinalDelivery"];
   mainRestartRecovery?: SessionEntry["mainRestartRecovery"];
   restartRecoveryBeforeAgentReplyState?: SessionRestartRecoveryState["restartRecoveryBeforeAgentReplyState"];

--- a/src/gateway/server-methods/chat-restart-recovery.ts
+++ b/src/gateway/server-methods/chat-restart-recovery.ts
@@ -29,6 +29,7 @@ import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 import { resolveChatRunOwnerAgentId } from "../chat-run-owner.js";
 import type { GatewayRecoveryRuntime } from "../server-instance-runtime.types.js";
+import { deriveGatewaySessionLifecycleSnapshot } from "../session-lifecycle-state.js";
 import { resolveChatSendActiveScopeKey } from "./chat-origin-routing.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -44,6 +45,12 @@ type RestartSafeChatAdmission = {
   priorTerminalSourceRunId?: string;
   requestFingerprint: string;
   retryExpectedState?: SessionTranscriptTurnExpectedState;
+};
+
+export type RestartSafeChatTerminalState = {
+  error?: string;
+  retryable: boolean;
+  status: "failed" | "killed";
 };
 
 type RetryableUnadoptedChatClaim = SessionEntry & {
@@ -377,11 +384,11 @@ export function buildRestartSafeChatTranscriptState(params: {
       restartRecoveryBeforeAgentReplyState: undefined,
       restartRecoveryDeliveryReceiptState: undefined,
       restartRecoveryDeliveryToolCallId: undefined,
-      status: "running",
+      ...deriveGatewaySessionLifecycleSnapshot({
+        event: { runId: params.clientRunId, ts: params.startedAt, data: { phase: "start" } },
+      }),
       lifecycleRunId: params.clientRunId,
       lastRunId: undefined,
-      startedAt: params.startedAt,
-      endedAt: undefined,
       restartRecoveryDeliveryContext: undefined,
       restartRecoveryDeliveryRequestFingerprint: params.admission.requestFingerprint,
       restartRecoveryDeliveryRunId: params.clientRunId,
@@ -394,22 +401,19 @@ export function buildRestartSafeChatTranscriptState(params: {
       ...(params.admission.priorTerminalSourceRunId
         ? { restartRecoveryTerminalRunIds: [params.admission.priorTerminalSourceRunId] }
         : {}),
-      runtimeMs: undefined,
-      abortedLastRun: false,
-      updatedAt: params.startedAt,
     },
   };
 }
 
-export async function terminalizeRestartSafeChatAdmission(params: {
-  admittedSessionId: string;
-  clientRunId: string;
-  retryable: boolean;
-  sessionKey: string;
-  startedAt: number;
-  status: "failed" | "killed";
-  storePath: string;
-}): Promise<boolean> {
+export async function terminalizeRestartSafeChatAdmission(
+  params: RestartSafeChatTerminalState & {
+    admittedSessionId: string;
+    clientRunId: string;
+    sessionKey: string;
+    startedAt: number;
+    storePath: string;
+  },
+): Promise<boolean> {
   const endedAt = Date.now();
   let terminalized = false;
   await patchSessionEntryCore(
@@ -422,11 +426,25 @@ export async function terminalizeRestartSafeChatAdmission(params: {
         return null;
       }
       terminalized = true;
+      // Commit the diagnostic with claim release; a later lifecycle write could
+      // race the next admission before a newly mounted chat reads the failure.
       return {
+        ...deriveGatewaySessionLifecycleSnapshot({
+          event: {
+            runId: params.clientRunId,
+            ts: endedAt,
+            data: {
+              phase: params.status === "failed" ? "error" : "end",
+              startedAt: params.startedAt,
+              endedAt,
+              aborted: params.status === "killed",
+              error: params.error,
+            },
+          },
+        }),
         abortedLastRun: params.retryable ? false : params.status === "killed",
         lifecycleRunId: undefined,
         lastRunId: params.clientRunId,
-        endedAt,
         ...(params.retryable
           ? {}
           : buildRestartRecoveryClaimCleanupPatch({
@@ -434,9 +452,6 @@ export async function terminalizeRestartSafeChatAdmission(params: {
               recordTerminalSource: true,
               terminalSourceRunId: current.restartRecoveryDeliverySourceRunId,
             })),
-        runtimeMs: Math.max(0, endedAt - params.startedAt),
-        status: params.status,
-        updatedAt: endedAt,
       };
     },
     { requireWriteSuccess: true, skipMaintenance: true },

--- a/src/gateway/server-methods/chat-send-agent-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-agent-dispatch.ts
@@ -18,6 +18,7 @@ import { chatRunBelongsToSelectedAgent } from "../chat-run-owner.js";
 import type { ChatRunTiming } from "../server-chat-state.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
 import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
+import type { RestartSafeChatTerminalState } from "./chat-restart-recovery.js";
 import type { AdmittedChatSend } from "./chat-send-admission.js";
 import type { prepareChatSendAttachments } from "./chat-send-attachments.js";
 import {
@@ -71,10 +72,9 @@ type StartChatDispatchParams = {
   };
   request: NormalizedChatSendRequest;
   session: PreparedChatSendSession;
-  terminalizeRestartSafeAdmission: (terminalState: {
-    retryable: boolean;
-    status: "failed" | "killed";
-  }) => Promise<boolean>;
+  terminalizeRestartSafeAdmission: (
+    terminalState: RestartSafeChatTerminalState,
+  ) => Promise<boolean>;
   timing: {
     chatSendAckedAtMs: number;
     chatSendTiming: ChatRunTiming | undefined;

--- a/src/gateway/server-methods/chat-send-dispatch-errors.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.ts
@@ -8,6 +8,7 @@ import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-a
 import { formatForLog } from "../ws-log.js";
 import { buildAbortedChatSendPayload } from "./chat-abort-authorization.js";
 import { broadcastChatError, broadcastChatFinal } from "./chat-broadcast.js";
+import type { RestartSafeChatTerminalState } from "./chat-restart-recovery.js";
 import type { AdmittedChatSend } from "./chat-send-admission.js";
 import type { PreparedChatSendSession } from "./chat-send-session.js";
 import { hasTrackedActiveSessionRun } from "./session-active-runs.js";
@@ -31,16 +32,14 @@ export async function handleChatSendSetupError(params: {
   error: unknown;
   respond: RespondFn;
   session: Pick<PreparedChatSendSession, "agentId" | "clientRunId" | "sessionKey">;
-  terminalizeRestartSafeAdmission: (state: {
-    retryable: boolean;
-    status: "failed" | "killed";
-  }) => Promise<boolean>;
+  terminalizeRestartSafeAdmission: (state: RestartSafeChatTerminalState) => Promise<boolean>;
 }): Promise<void> {
   const { cleanupAdmittedRun, lifecycleGeneration, restartSafeAdmission } = params.admission;
   const { agentId, clientRunId, sessionKey } = params.session;
+  const errorMessage = String(params.error);
   if (restartSafeAdmission) {
     const terminalized = await params
-      .terminalizeRestartSafeAdmission({ retryable: true, status: "failed" })
+      .terminalizeRestartSafeAdmission({ error: errorMessage, retryable: true, status: "failed" })
       .catch((terminalizeError: unknown) => {
         params.context.logGateway.warn(
           `failed to release restart-safe chat admission after setup error: ${formatForLog(
@@ -60,7 +59,6 @@ export async function handleChatSendSetupError(params: {
   cleanupAdmittedRun({ force: true });
   clearAgentRunContext(clientRunId, lifecycleGeneration);
   params.context.removeChatRun(clientRunId, clientRunId, sessionKey);
-  const errorMessage = String(params.error);
   const error = errorShape(ErrorCodes.UNAVAILABLE, errorMessage);
   const payload = { runId: clientRunId, status: "error" as const, summary: errorMessage };
   setGatewayDedupeEntry({
@@ -91,10 +89,7 @@ export function createChatSendDispatchErrorLifecycle(params: {
     PreparedChatSendSession,
     "agentId" | "backingSessionId" | "cfg" | "clientRunId" | "now" | "rawSessionKey" | "sessionKey"
   >;
-  terminalizeRestartSafeAdmission: (state: {
-    retryable: boolean;
-    status: "failed" | "killed";
-  }) => Promise<boolean>;
+  terminalizeRestartSafeAdmission: (state: RestartSafeChatTerminalState) => Promise<boolean>;
   userTurnRecorder: Pick<UserTurnTranscriptRecorder, "hasPersisted" | "isBlocked">;
 }) {
   const {
@@ -198,6 +193,7 @@ export function createChatSendDispatchErrorLifecycle(params: {
     let restartSafeDispatchFailureTerminalized = false;
     if (restartSafeAdmission && !agentTerminalPersistenceOwnedAtDispatchReject) {
       restartSafeDispatchFailureTerminalized = await terminalizeRestartSafeAdmission({
+        error: errorMessage,
         retryable: true,
         status: "failed",
       }).catch((terminalizeError: unknown) => {

--- a/src/gateway/server-methods/chat-send-handler.ts
+++ b/src/gateway/server-methods/chat-send-handler.ts
@@ -6,7 +6,10 @@ import { emitDiagnosticsTimelineEvent } from "../../infra/diagnostics-timeline.j
 import type { SkillWorkshopProposalRevisionConstraint } from "../../skills/workshop/types.js";
 import { discardPreparedInboundMedia } from "../chat-attachments.js";
 import type { ChatRunTiming } from "../server-chat-state.js";
-import { terminalizeRestartSafeChatAdmission } from "./chat-restart-recovery.js";
+import {
+  terminalizeRestartSafeChatAdmission,
+  type RestartSafeChatTerminalState,
+} from "./chat-restart-recovery.js";
 import { startChatDispatch } from "./chat-send-agent-dispatch.js";
 import { prepareChatSendAttachments } from "./chat-send-attachments.js";
 import { handleChatSendSetupError } from "./chat-send-dispatch-errors.js";
@@ -118,10 +121,9 @@ async function handleChatSendWithOptions(
   });
 
   const admissionStartedAt = Date.now();
-  const terminalizeRestartSafeAdmission = async (terminalState: {
-    retryable: boolean;
-    status: "failed" | "killed";
-  }): Promise<boolean> =>
+  const terminalizeRestartSafeAdmission = async (
+    terminalState: RestartSafeChatTerminalState,
+  ): Promise<boolean> =>
     await terminalizeRestartSafeChatAdmission({
       admittedSessionId,
       clientRunId,

--- a/src/gateway/server.sessions.create.projects.test.ts
+++ b/src/gateway/server.sessions.create.projects.test.ts
@@ -299,6 +299,23 @@ test("sessions.create survives Gateway restart after remote project failure and 
   );
   const entryAfterFailure = loadSessionEntry({ agentId: "main", sessionKey: key, storePath });
 
+  // The first chat pane subscribes only after create-and-navigate. Its history
+  // must recover the failure without receiving the already-emitted chat event.
+  for (const method of ["chat.startup", "chat.history"] as const) {
+    const history = await directSessionReq(method, { sessionKey: key }, controlUiClient);
+    expect(history.ok, JSON.stringify(history.error)).toBe(true);
+    expect(history.payload).toMatchObject({
+      sessionInfo: {
+        sessionId,
+        status: "failed",
+        hasActiveRun: false,
+        lastRunId: runId,
+        lastRunError: expect.stringContaining(failureMessage),
+      },
+      messages: [expect.objectContaining({ role: "user" })],
+    });
+  }
+
   const retriedMaterialization = createDeferredCore<typeof project>();
   projectCloneMocks.materialize.mockReturnValueOnce(retriedMaterialization.promise);
   const restartedContext = { broadcast, chatAbortControllers: new Map(), dedupe: new Map() };
@@ -321,6 +338,9 @@ test("sessions.create survives Gateway restart after remote project failure and 
       status: "started",
     });
     await vi.waitFor(() => expect(projectCloneMocks.materialize).toHaveBeenCalledTimes(2));
+    expect(loadSessionEntry({ agentId: "main", sessionKey: key, storePath })?.lastRunError).toBe(
+      undefined,
+    );
     expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
     expect(entryAfterCreation).toMatchObject({
       sessionId,

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -73,7 +73,7 @@ type PersistedLifecycleSessionShape = Pick<
   | "lifecycleRunId"
 >;
 
-type GatewaySessionLifecycleSnapshot = Partial<LifecycleSessionShape>;
+type GatewaySessionLifecycleSnapshot = Partial<Pick<SessionEntry, keyof LifecycleSessionShape>>;
 
 const SESSION_RUN_ERROR_MAX_CHARS = 160;
 
@@ -176,8 +176,8 @@ function resolveRuntimeMs(params: {
   return undefined;
 }
 
-function deriveGatewaySessionLifecycleSnapshot(params: {
-  session?: Partial<LifecycleSessionShape> | null;
+export function deriveGatewaySessionLifecycleSnapshot(params: {
+  session?: GatewaySessionLifecycleSnapshot | null;
   event: LifecycleEventLike;
 }): GatewaySessionLifecycleSnapshot {
   const phase = resolveLifecyclePhase(params.event);

--- a/ui/src/pages/chat/chat-gateway.ts
+++ b/ui/src/pages/chat/chat-gateway.ts
@@ -5,7 +5,6 @@ import {
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { isAssistantHeartbeatAckForDisplay } from "../../lib/chat/heartbeat-display.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
-import { formatUiExternalText } from "../../lib/format-error.ts";
 // Control UI page module reconciles Chat Gateway events into Chat state.
 import { isUiGlobalSessionKey, resolveUiDefaultAgentId } from "../../lib/sessions/session-key.ts";
 import {
@@ -24,7 +23,7 @@ import {
   readChatSessionProjectionScope,
   setChatSessionProjection,
 } from "./history-merge.ts";
-import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
+import { reconcileChatRunLifecycle, setChatRunError } from "./run-lifecycle.ts";
 import { appendChatMessageToCache } from "./session-message-cache.ts";
 import {
   latestStreamBoundaryRunId,
@@ -50,10 +49,6 @@ type AssistantMessageNormalizationOptions = {
   requireContentArray?: boolean;
   allowTextField?: boolean;
 };
-
-function setChatRunError(state: ChatState, summary: string) {
-  state.chatRunError = { summary: formatUiExternalText(summary) };
-}
 
 function chatEventSessionMatches(state: ChatState, payload: ChatEventPayload): boolean {
   return chatScopedEventSessionMatches(state, payload.sessionKey, payload.agentId);

--- a/ui/src/pages/chat/chat-history-cursor.test.ts
+++ b/ui/src/pages/chat/chat-history-cursor.test.ts
@@ -118,13 +118,23 @@ describe("chat history cursor revalidation", () => {
     });
   });
 
-  it("advances the cursor when catch-up is already current", async () => {
+  it("recovers a missed terminal failure even when cursor catch-up has no new messages", async () => {
     const cached = message("user", "cached", "cached-user", 1);
     const handler = vi.fn(async (_params?: unknown) => ({
       kind: "delta",
       messages: [],
       deltaCursor: "cursor-2",
-      sessionInfo: { key: "main", kind: "direct", sessionId: "session-cursor", updatedAt: 2 },
+      sessionInfo: {
+        key: "main",
+        kind: "direct",
+        sessionId: "session-cursor",
+        updatedAt: 2,
+        status: "failed",
+        hasActiveRun: false,
+        lastRunId: "run-first",
+        lastRunError:
+          "Git clone could not reach GitHub. Check the Gateway network connection and retry.",
+      },
     }));
     const state = createState(handler);
     const cache = seedCachedHistory(state, [cached], "cursor-1");
@@ -132,6 +142,9 @@ describe("chat history cursor revalidation", () => {
     await loadChatHistory(state);
 
     expect(state.chatMessages).toEqual([cached]);
+    expect(state.chatRunError?.summary).toContain(
+      "Check the Gateway network connection and retry.",
+    );
     expect(
       readChatSessionSnapshot(cache, state, { sessionKey: state.sessionKey })?.deltaCursor,
     ).toBe("cursor-2");

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -1,17 +1,20 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createInitialUserMessageHandoff } from "../../app/initial-user-message-handoff.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
 import { handleChatGatewayEvent } from "./chat-gateway.ts";
 import { loadChatHistory, type ChatHistoryResult, type ChatState } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
 import { buildChatItems } from "./chat-thread-build.ts";
 import {
+  admitInitialUserMessageHandoff,
   getChatSessionProjection,
   readChatSessionProjectionScope,
   reduceChatSessionProjection,
   setChatSessionProjection,
 } from "./history-merge.ts";
+import { prepareInitialUserMessageHandoff } from "./initial-turn-handoff.ts";
 import { handleAgentEvent, type ToolStreamEntry } from "./tool-stream.ts";
 
 type TestState = ChatState & Parameters<typeof handleAgentEvent>[0];
@@ -76,7 +79,127 @@ function activeHistory(runId: string): ChatHistoryResult {
   };
 }
 
+function failedHistory(): ChatHistoryResult {
+  return {
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "text", text: "Inspect the unavailable project" }],
+        timestamp: 1,
+        __openclaw: { id: "first-user", idempotencyKey: "run-first:user", seq: 1 },
+      },
+    ],
+    sessionInfo: {
+      key: "main",
+      kind: "direct",
+      updatedAt: 2,
+      status: "failed",
+      hasActiveRun: false,
+      lastRunId: "run-first",
+      lastRunError:
+        "ProjectCloneError: Git clone could not reach GitHub. Check the Gateway network connection and retry.",
+    },
+  };
+}
+
 describe("chat history in-flight assistant recovery", () => {
+  it.each(["chat.startup", "chat.history"] as const)(
+    "recovers a failure missed before route subscription through %s",
+    async (method) => {
+      const history = failedHistory();
+      const state = createState(history);
+      state.client = {
+        request: vi.fn().mockResolvedValue(history),
+      } as unknown as GatewayBrowserClient;
+      if (method === "chat.startup") {
+        state.initialUserMessage = createInitialUserMessageHandoff();
+        prepareInitialUserMessageHandoff(
+          state.initialUserMessage,
+          state.sessionKey,
+          { text: "Inspect the unavailable project", createdAt: 1 },
+          state.client,
+          { runId: "run-first" },
+        );
+        admitInitialUserMessageHandoff(state, state.sessionKey);
+      }
+
+      await loadChatHistory(state, { startup: method === "chat.startup" });
+
+      expect(state.chatRunError?.summary).toContain(history.sessionInfo!.lastRunError);
+      expect(state.chatRunId).toBeNull();
+      expect(state.chatMessages).toEqual(history.messages);
+    },
+  );
+
+  it("clears a recovered failure when a retry is active and retains the live retry error", async () => {
+    const history = failedHistory();
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(history)
+      .mockResolvedValueOnce(activeHistory("run-retry"));
+    const state = createState(history);
+    state.client = { request } as unknown as GatewayBrowserClient;
+    await loadChatHistory(state);
+    expect(state.chatRunError?.summary).toContain(history.sessionInfo!.lastRunError);
+
+    await loadChatHistory(state);
+    expect(state.chatRunId).toBe("run-retry");
+    expect(state.chatRunError).toBeNull();
+
+    const fullError = "A more detailed live retry error. Check repository access and retry.";
+    handleChatGatewayEvent(state, {
+      runId: "run-retry",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: fullError,
+    });
+    request.mockResolvedValue({
+      ...history,
+      sessionInfo: {
+        ...history.sessionInfo,
+        lastRunId: "run-retry",
+        lastRunError: "A more detailed live retry error.",
+      },
+    });
+    await loadChatHistory(state);
+    expect(state.chatRunError?.summary).toContain(fullError);
+    expect(state.chatRunId).toBeNull();
+  });
+
+  it.each(["running", "completed"])(
+    "does not replace a newer %s run with a delayed failed snapshot",
+    async (phase) => {
+      let resolveHistory!: (result: ChatHistoryResult) => void;
+      const request = vi.fn().mockReturnValue(
+        new Promise<ChatHistoryResult>((resolve) => {
+          resolveHistory = resolve;
+        }),
+      );
+      const state = createState(failedHistory());
+      state.client = { request } as unknown as GatewayBrowserClient;
+      const loading = loadChatHistory(state);
+      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+      handleChatGatewayEvent(state, {
+        runId: "run-newer",
+        sessionKey: "main",
+        state: "delta",
+        deltaText: "Working",
+      });
+      if (phase === "completed") {
+        handleChatGatewayEvent(state, {
+          runId: "run-newer",
+          sessionKey: "main",
+          state: "final",
+          message: { role: "assistant", content: "Done" },
+        });
+      }
+      resolveHistory(failedHistory());
+      await loading;
+      expect(state.chatRunError).toBeNull();
+      expect(state.chatRunId).toBe(phase === "running" ? "run-newer" : null);
+    },
+  );
+
   it.each([
     {
       name: "restores workspace preparation before visible activity",

--- a/ui/src/pages/chat/chat-history.ts
+++ b/ui/src/pages/chat/chat-history.ts
@@ -58,7 +58,11 @@ import {
   recordControlUiPerformanceEvent,
   roundedControlUiDurationMs,
 } from "./performance.ts";
-import { reconcileChatRunLifecycle } from "./run-lifecycle.ts";
+import {
+  reconcileChatRunFromSessionRow,
+  reconcileChatRunLifecycle,
+  setChatRunError,
+} from "./run-lifecycle.ts";
 import { scheduleChatScroll } from "./scroll.ts";
 import { applySessionMessagePayload } from "./session-message-apply.ts";
 import {
@@ -468,7 +472,7 @@ function mergeInFlightAssistantTails(
   return cumulativeLiveTail;
 }
 
-function applyInFlightRunSnapshot(params: {
+function applyHistoryRunSnapshot(params: {
   state: ChatState;
   run: ChatHistoryResult["inFlightRun"];
   sessionInfo: GatewaySessionRow | undefined;
@@ -490,6 +494,30 @@ function applyInFlightRunSnapshot(params: {
   } = params;
   const inFlightRunId = run?.runId?.trim();
   if (!inFlightRunId || !run) {
+    const terminalRunId = sessionInfo?.lastRunId;
+    if (
+      terminalRunId &&
+      sessionInfo.lastRunError &&
+      (sessionInfo.status === "failed" || sessionInfo.status === "timeout") &&
+      !isSessionRunActive(sessionInfo) &&
+      (!state.chatRunId || state.chatRunId === terminalRunId) &&
+      runProjectionsUnchanged(previousRunProjections, runProjectionsBeforeApply)
+    ) {
+      // A create-time failure can precede the pane subscription. Recover its
+      // durable terminal through the same reducer; newer live runs win the race
+      // and an existing full diagnostic wins over the bounded session summary.
+      const projection = reduceChatSessionProjection(state, {
+        type: "runTerminal",
+        runId: terminalRunId,
+        status: sessionInfo.status === "timeout" ? "timeout" : "error",
+        errorMessage: sessionInfo.lastRunError,
+      });
+      setChatRunError(
+        state,
+        projection.runs[terminalRunId]?.errorMessage ?? sessionInfo.lastRunError,
+      );
+      reconcileChatRunFromSessionRow(state, sessionInfo, { publishRunStatus: false });
+    }
     return;
   }
   const projectedInFlightRun = currentRunProjections[inFlightRunId];
@@ -513,6 +541,7 @@ function applyInFlightRunSnapshot(params: {
     // Their identity fences ABA races where a run starts and finishes while
     // history is pending; deltas from this same live run must still merge.
     state.chatRunId = inFlightRunId;
+    state.chatRunError = null;
   }
   if (!inFlightRunIsActive || state.chatRunId !== inFlightRunId) {
     return;
@@ -1832,7 +1861,7 @@ async function loadChatHistoryUncached(
       state.chatQueueModeOverride = response.sessionInfo.queueMode;
       state.chatEffectiveQueueMode = response.sessionInfo.effectiveQueueMode;
       const currentRunProjections = readChatRunProjections(state, sessionKey, requestAgentId);
-      applyInFlightRunSnapshot({
+      applyHistoryRunSnapshot({
         state,
         run: response.inFlightRun,
         sessionInfo: response.sessionInfo,
@@ -2018,7 +2047,7 @@ async function loadChatHistoryUncached(
       }
     }
 
-    applyInFlightRunSnapshot({
+    applyHistoryRunSnapshot({
       state,
       run: res.inFlightRun,
       sessionInfo: res.sessionInfo,

--- a/ui/src/pages/chat/run-lifecycle.ts
+++ b/ui/src/pages/chat/run-lifecycle.ts
@@ -2,6 +2,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { GatewaySessionRow, SessionRunStatus, SessionsListResult } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
+import { formatUiExternalText } from "../../lib/format-error.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import {
   reconcileSessionRunTerminal,
@@ -140,6 +141,13 @@ function setChatError(state: ChatAbortRunState, error: string | null) {
 
 export function isChatBusy(host: { chatSending?: boolean; chatRunId?: string | null }) {
   return Boolean(host.chatSending || host.chatRunId);
+}
+
+export function setChatRunError(
+  state: { chatRunError?: { summary: string } | null },
+  summary: string,
+) {
+  state.chatRunError = { summary: formatUiExternalText(summary) };
 }
 
 type SessionRunHost = {


### PR DESCRIPTION
Closes #130589. Follow-up to #130192 (session-first remote project startup).

## What Problem This Solves

Fixes an issue where users starting a remote-project session could lose the first clone error while navigating into the new chat. Reloading a failed chat also removed its diagnostic, leaving only the submitted message; users had to retry to see why setup failed.

## Why This Change Was Made

Early setup/dispatch failures now pass their diagnostic through the existing canonical session lifecycle snapshot, saving the bounded `lastRunError` atomically with terminalization. Chat startup, full history, and cursor catch-up restore missed terminal failures through the existing run reducer and shared error display.

This removes duplicate lifecycle assignments rather than introducing another error store or UI cache. Retry admission clears the old diagnostic, newer live runs win over stale history, and a complete live diagnostic is preserved instead of being replaced by the 160-character stored summary. Clone policy, authentication, cancellation ownership, retry policy, schemas, and protocol contracts are unchanged.

## User Impact

The first startup error stays visible after opening the session, reloading the browser, or restarting the Gateway—without sending another message. Normal retries remain usable and do not display stale errors from the previous run.

## Evidence

Real Chrome and a real loopback-only Gateway, built from main `42112dd86ec3010cb14011d7514c82063b12974a` and then the repaired source, with isolated state and a real failing GitHub clone. No mocked Gateway, forged events, or operator service changes were used.

- Before: the durable row had `status=failed` and `lastRunId`, but no `lastRunError`; browser reload left no diagnostic.
- After: an error that arrived before the chat pane mounted was recovered on its first open. The original prompt and actionable error remained visible after reload and a complete isolated Gateway stop/start, without retry.
- Screenshots below were inspected and contain only synthetic test-session content. Test services/state were cleaned up.

Red-green regressions:

- Gateway startup/history assertion failed on main because `lastRunError` was absent.
- UI recovery assertions failed on main because `chatRunError` was absent.
- Final focused proof: 65 Gateway tests and 222 UI tests passed, including cancellation, retry clearing, cursor catch-up, initial-turn handoff, complete live diagnostics, and stale newer-run fences.

Exact local commands:

```bash
node scripts/run-vitest.mjs src/gateway/server.sessions.create.projects.test.ts src/gateway/server-methods/chat-send-dispatch-errors.test.ts src/gateway/session-lifecycle-state.test.ts src/gateway/server.chat-abort-dispatch-rejection.test.ts
```

```bash
node scripts/run-vitest.mjs src/gateway/server.chat.gateway-server-chat-b.test.ts -t 'durably admits a restart-safe|releases an unadopted durable claim|releases a durable claim|leaves a post-admission routing rejection'
```

```bash
node scripts/run-vitest.mjs ui/src/pages/chat/chat-history.inflight.test.ts ui/src/pages/chat/chat-history-cursor.test.ts ui/src/pages/chat/chat-history.test.ts ui/src/pages/chat/chat-state.test.ts ui/src/pages/chat/run-lifecycle.test.ts ui/src/pages/chat/initial-turn-handoff.test.ts ui/src/pages/new-session/draft-submission-flow.test.ts
```

`pnpm build`, the full changed-file check plan, `git diff --check`, and independent autoreview passed. Relevant error/lifecycle owners remained unchanged on later main `8e1c34e21dd08f813cefc982079384fdd83fc084`.

Production LOC: +97/-51 (net +46) | Tests: +158/-2 (net +156) | Docs: +2/-0. The necessary growth restores a missing durable diagnostic and its history presentation using existing ownership and run-identity fences; there is no new persistence surface or fallback path.

AI-assisted; source, red-green tests, and real browser behavior were independently inspected.

![Before: reloading the failed session loses the clone diagnostic](https://github.com/user-attachments/assets/12c16225-0d22-477f-b4ce-d944231c3954)

![After: the first clone failure is recovered when chat opens](https://github.com/user-attachments/assets/263d5b57-56d9-4c51-8a57-61a11676ee13)