### PR TITLE
refactor(memory): remove unused private REM facade

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3458,7 +3458,7 @@ src/plugin-sdk/facade-runtime.ts	6
 src/plugin-sdk/file-lock.ts	10
 src/plugin-sdk/inbound-reply-dispatch.ts	1
 src/plugin-sdk/lazy-value.ts	1
-src/plugin-sdk/memory-core-bundled-runtime.ts	13
+src/plugin-sdk/memory-core-bundled-runtime.ts	11
 src/plugin-sdk/memory-host-core.ts	26
 src/plugin-sdk/migration-runtime.ts	4
 src/plugin-sdk/migration.ts	8

--- a/src/plugin-sdk/memory-core-bundled-runtime.test.ts
+++ b/src/plugin-sdk/memory-core-bundled-runtime.test.ts
@@ -15,8 +15,6 @@ const repairShortTermPromotionArtifactsImpl = vi.hoisted(() => vi.fn());
 const previewGroundedRemMarkdownImpl = vi.hoisted(() => vi.fn());
 const writeBackfillDiaryEntriesImpl = vi.hoisted(() => vi.fn());
 const removeBackfillDiaryEntriesImpl = vi.hoisted(() => vi.fn());
-const filterRecallEntriesWithinLookbackImpl = vi.hoisted(() => vi.fn());
-const previewRemHarnessImpl = vi.hoisted(() => vi.fn());
 
 vi.mock("./facade-loader.js", async () => {
   const actual = await vi.importActual<typeof import("./facade-loader.js")>("./facade-loader.js");
@@ -39,8 +37,6 @@ describe("plugin-sdk memory-core bundled runtime", () => {
     previewGroundedRemMarkdownImpl.mockReset().mockResolvedValue({ files: [] });
     writeBackfillDiaryEntriesImpl.mockReset().mockResolvedValue({ writtenCount: 1 });
     removeBackfillDiaryEntriesImpl.mockReset().mockResolvedValue({ removedCount: 1 });
-    filterRecallEntriesWithinLookbackImpl.mockReset().mockReturnValue([]);
-    previewRemHarnessImpl.mockReset().mockResolvedValue({ ok: true });
     loadBundledPluginPublicSurfaceModuleSyncCore
       .mockReset()
       .mockImplementation(({ artifactBasename }) => {
@@ -62,8 +58,6 @@ describe("plugin-sdk memory-core bundled runtime", () => {
             previewGroundedRemMarkdown: previewGroundedRemMarkdownImpl,
             writeBackfillDiaryEntries: writeBackfillDiaryEntriesImpl,
             removeBackfillDiaryEntries: removeBackfillDiaryEntriesImpl,
-            filterRecallEntriesWithinLookback: filterRecallEntriesWithinLookbackImpl,
-            previewRemHarness: previewRemHarnessImpl,
           };
         }
         throw new Error(`unexpected artifact ${String(artifactBasename)}`);
@@ -110,39 +104,6 @@ describe("plugin-sdk memory-core bundled runtime", () => {
     expect(loadBundledPluginPublicSurfaceModuleSyncCore).toHaveBeenCalledWith({
       dirName: "memory-core",
       artifactBasename: "runtime-api.js",
-    });
-  });
-
-  it("delegates filterRecallEntriesWithinLookback through the bundled api surface", async () => {
-    const module = await import("./memory-core-bundled-runtime.js");
-    const kept = [{ key: "keep" }] as never;
-    filterRecallEntriesWithinLookbackImpl.mockReturnValueOnce(kept);
-
-    const params = { entries: [] as never, nowMs: 0, lookbackDays: 1 };
-    const result = module.filterRecallEntriesWithinLookback(params);
-
-    expect(result).toBe(kept);
-    expect(filterRecallEntriesWithinLookbackImpl).toHaveBeenCalledWith(params);
-    expect(loadBundledPluginPublicSurfaceModuleSyncCore).toHaveBeenCalledWith({
-      dirName: "memory-core",
-      artifactBasename: "api.js",
-    });
-  });
-
-  it("delegates previewRemHarness through the bundled api surface", async () => {
-    const module = await import("./memory-core-bundled-runtime.js");
-    const preview = { workspaceDir: "/tmp/openclaw" };
-    previewRemHarnessImpl.mockResolvedValueOnce(preview);
-
-    const params = { workspaceDir: "/tmp/openclaw", candidateLimit: 3 };
-    const result = await module.previewRemHarness(params);
-
-    expect(result).toBe(preview);
-    expect(previewRemHarnessImpl).toHaveBeenCalledWith(params);
-    expect(configureMemoryCoreDreamingStateImpl).toHaveBeenCalledWith(expect.any(Function));
-    expect(loadBundledPluginPublicSurfaceModuleSyncCore).toHaveBeenCalledWith({
-      dirName: "memory-core",
-      artifactBasename: "api.js",
     });
   });
 });

--- a/src/plugin-sdk/memory-core-bundled-runtime.ts
+++ b/src/plugin-sdk/memory-core-bundled-runtime.ts
@@ -138,34 +138,6 @@ type GroundedRemPreviewResult = {
   files: GroundedRemFilePreview[];
 };
 
-type RemDreamingPreview = {
-  sourceEntryCount: number;
-  reflections: string[];
-  candidateTruths: Array<{
-    snippet: string;
-    confidence: number;
-    evidence: string;
-  }>;
-  candidateKeys: string[];
-  bodyLines: string[];
-};
-
-type PromotionCandidate = {
-  key: string;
-  path: string;
-  startLine: number;
-  endLine: number;
-  snippet: string;
-  recallCount: number;
-  uniqueQueries: number;
-  avgScore: number;
-  maxScore: number;
-  ageDays: number;
-  firstRecalledAt: string;
-  lastRecalledAt: string;
-  promotedAt?: string;
-};
-
 export type ShortTermDreamingStatsEntry = {
   key: string;
   path: string;
@@ -203,35 +175,6 @@ export type ShortTermDreamingStats = {
   promotedEntries: ShortTermDreamingStatsEntry[];
 };
 
-type RemHarnessPreviewResult = {
-  workspaceDir: string;
-  nowMs: number;
-  remConfig: {
-    enabled: boolean;
-    lookbackDays: number;
-    limit: number;
-    minPatternStrength: number;
-  };
-  deepConfig: {
-    minScore: number;
-    minRecallCount: number;
-    minUniqueQueries: number;
-    recencyHalfLifeDays: number;
-    maxAgeDays?: number;
-  };
-  recallEntryCount: number;
-  remSkipped: boolean;
-  rem: RemDreamingPreview;
-  groundedInputPaths: string[];
-  grounded: GroundedRemPreviewResult | null;
-  deep: {
-    candidateLimit?: number;
-    candidateCount: number;
-    truncated: boolean;
-    candidates: PromotionCandidate[];
-  };
-};
-
 type ApiFacadeModule = {
   configureMemoryCoreDreamingState: (
     openKeyedStore: <T>(options: OpenKeyedStoreOptions) => PluginStateKeyedStore<T>,
@@ -255,23 +198,6 @@ type ApiFacadeModule = {
   removeBackfillDiaryEntries: (params: {
     workspaceDir: string;
   }) => Promise<{ dreamsPath: string; removed: number }>;
-  filterRecallEntriesWithinLookback: (params: {
-    entries: readonly unknown[];
-    nowMs: number;
-    lookbackDays: number;
-  }) => unknown[];
-  previewRemHarness: (params: {
-    workspaceDir: string;
-    cfg?: unknown;
-    pluginConfig?: Record<string, unknown>;
-    grounded?: boolean;
-    groundedInputPaths?: string[];
-    groundedFileLimit?: number;
-    includePromoted?: boolean;
-    candidateLimit?: number;
-    remPreviewLimit?: number;
-    nowMs?: number;
-  }) => Promise<RemHarnessPreviewResult>;
 };
 
 export type RepairDreamingArtifactsResult = {
@@ -381,14 +307,3 @@ export const removeBackfillDiaryEntries: ApiFacadeModule["removeBackfillDiaryEnt
   loadApiFacadeModule().removeBackfillDiaryEntries(
     ...args,
   )) as ApiFacadeModule["removeBackfillDiaryEntries"];
-
-/** Filter recall entries to the configured REM lookback window. */
-export const filterRecallEntriesWithinLookback: ApiFacadeModule["filterRecallEntriesWithinLookback"] =
-  ((...args) =>
-    loadApiFacadeModule().filterRecallEntriesWithinLookback(
-      ...args,
-    )) as ApiFacadeModule["filterRecallEntriesWithinLookback"];
-
-/** Preview REM harness output across dreaming, grounded, and deep promotion candidates. */
-export const previewRemHarness: ApiFacadeModule["previewRemHarness"] = ((...args) =>
-  loadApiFacadeModule().previewRemHarness(...args)) as ApiFacadeModule["previewRemHarness"];


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the main repository; maintainers with repository write access can update it. GitHub's fork-only maintainer-edit setting does not apply.

</details>

## What Problem This Solves

Internal memory maintenance still carried an unused REM harness forwarding path after the Gateway doctor REM RPC was removed. Its duplicate result types and proxy-only tests kept that obsolete private path alive in the core facade.

## Why This Change Was Made

Remove the two unconsumed private forwarders and their exclusive mirrored types. The real memory plugin API and CLI remain the canonical owners of REM preview and lookback filtering. All eleven live facade forwarders, lazy loading, dreaming-state injection, and grounded-preview types remain unchanged.

This file is absent from the public SDK package exports, entrypoint inventory, declaration/build registration, and dynamic SDK alias inventory. Existing stable-tag public surfaces remain intact; this does not retire a public API.

## User Impact

No user-visible behavior change. Memory CLI commands, doctor diagnostics, plugin APIs, persisted memory state, and configuration are unchanged. Production is +0/-85 lines; tests are +0/-39 lines. The assertion baseline shrinks exactly from 13 to 11 for the affected file; baseline bookkeeping is not counted as production cleanup.

## Evidence

- Complete owner/caller/export/history inspection: the retired doctor RPC was removed by #121387; its orphan private tail has no remaining runtime consumer. The real plugin API, public REM CLI, and dreaming phases still call the canonical plugin implementations.
- Focused Linux proof: 464 tests passed across the retained facade, Gateway doctor, doctor memory search, capability CLI, memory CLI, and dreaming phases.
- Exact candidate: base `fc51e97e60d5285beaa458ad25924388b3cef38d`, tree `3764757bab8c8f7c218ae6e6f401c3ce27633ff2`; full binary patch SHA-256 `06e7f9fb4308ad7dec155025ffbe8860b33d36894c827f7e866d5514f81d09d4`.
- [Blacksmith Testbox environment](https://github.com/openclaw/openclaw/actions/runs/33029943830): detached exact candidate; Linux Node 24.19.0, Vitest 4.1.11, TypeScript 6.0.3, tsx 4.23.12. Dependency fingerprint and complete consumed workspace/build-source closure matched before dependency links; all 772 workspace/SDK aliases resolve inside the candidate.
- Pre-commit Codex review completed with no actionable findings; formatting and diff checks passed.
- Full canonical changed checks passed, including core/plugin/test types, lint, architecture guards, and all three unused-export scans. SDK export/surface checks passed, with all 147 public SDK subpaths unchanged.
- Full build passed with canonical declarations, all 63 external plugin local builds, built doctor-module loading, and UI output checks.
- Real built `doctor --non-interactive --deep` and `memory rem-harness --agent proof --json` passed in fresh temporary HOME/state/workspace with no forwarded credentials and bundled source fallback disabled. Doctor reported valid-config memory/dreaming diagnostics; the public REM command returned the expected empty-workspace preview.

The isolated profile intentionally has no running Gateway or provider credentials; its corresponding doctor diagnostics were visible. This is real command/memory-path proof, not authenticated semantic-search or Gateway connectivity proof.

Proof setup corrections were confined to temporary scripts: dependency ownership and one test path were corrected before tests ran; an initial CLI fixture accidentally mixed explicit-agent ownership with a retired default marker, so it was corrected and the full real CLI proof rerun with additional invalid-config rejection assertions. The reviewed source patch never changed.

Only the two obsolete forwarding tests and their mocks are removed. Existing cold-load and live-forwarding coverage remains. No replacement implementation-shaped tests or product seams are added.

Follow-up outside this frozen cleanup: remove unused legacy provider-metadata mocks in the doctor memory-search test when that test owner is next edited.
