### PR TITLE
refactor(msteams): simplify attachment size and redirect handling

### DIFF
--- a/extensions/msteams/src/attachments.test.ts
+++ b/extensions/msteams/src/attachments.test.ts
@@ -468,7 +468,7 @@ describe("msteams attachments", () => {
       runAttachmentAuthRetryCase,
     );
 
-    it("preserves auth fallback when dispatcher-mode fetch returns a redirect", async () => {
+    it("follows an authenticated redirect through guarded fetch", async () => {
       const redirectedUrl = createTestUrl("redirected.png");
       const tokenProvider = createTokenProvider();
       const fetchMock = vi.fn(async (url: string, opts?: RequestInit) => {
@@ -484,12 +484,6 @@ describe("msteams attachments", () => {
         return createNotFoundResponse();
       });
 
-      readRemoteMediaBufferMock.mockImplementationOnce(async (params) => {
-        return await readRemoteMediaBufferWithRedirects(params, {
-          dispatcher: {},
-        } as RequestInit);
-      });
-
       const media = await downloadAttachmentsWithFetch(
         createImageAttachments(TEST_URL_IMAGE),
         fetchMock,
@@ -498,7 +492,18 @@ describe("msteams attachments", () => {
 
       expectAttachmentMediaLength(media, 1);
       expect(tokenProvider.getAccessToken).toHaveBeenCalledOnce();
-      expect(fetchMock.mock.calls.map(([calledUrl]) => calledUrl)).toContain(redirectedUrl);
+      expect(fetchMock.mock.calls.map(([calledUrl]) => calledUrl)).toEqual([
+        TEST_URL_IMAGE,
+        TEST_URL_IMAGE,
+        redirectedUrl,
+      ]);
+      expect(
+        fetchMock.mock.calls.map(([, init]) => new Headers(init?.headers).get("Authorization")),
+      ).toEqual([null, "Bearer token", "Bearer token"]);
+      for (const [, init] of fetchMock.mock.calls) {
+        expect(init).toHaveProperty("dispatcher");
+        expect(init?.redirect).toBe("manual");
+      }
     });
 
     it("continues scope fallback after non-auth failure and succeeds on later scope", async () => {

--- a/extensions/msteams/src/attachments/shared.test.ts
+++ b/extensions/msteams/src/attachments/shared.test.ts
@@ -196,26 +196,74 @@ describe("safeFetch", () => {
     expect(called).toBe(false);
   });
 
-  it("returns the redirect response when dispatcher is provided by an outer guard", async () => {
-    const redirectedTo = "https://cdn.sharepoint.com/storage/file.pdf";
-    const fetchMock = mockFetchWithRedirect({
-      "https://teams.sharepoint.com/file.pdf": redirectedTo,
-    });
-    const res = await safeFetch({
-      url: "https://teams.sharepoint.com/file.pdf",
-      allowHosts: ["sharepoint.com"],
-      fetchFn: fetchMock as unknown as typeof fetch,
-      requestInit: { dispatcher: {} } as RequestInit,
-      resolveFn: publicResolve,
-    });
-    expect(res.status).toBe(302);
-    expect(res.headers.get("location")).toBe(redirectedTo);
-    expect(fetchMock).toHaveBeenCalledOnce();
+  it.each([301, 302, 303, 307, 308])(
+    "returns dispatcher-mode %i responses to the outer guard",
+    async (status) => {
+      const redirectedTo = "https://cdn.sharepoint.com/storage/file.pdf";
+      const response = new Response(null, {
+        status,
+        headers: { location: redirectedTo },
+      });
+      const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => response);
+      const resolveFn = vi.fn(publicResolve);
+      const headers = new Headers({ Authorization: "Bearer fixture-token" });
+      const res = await safeFetch({
+        url: "https://teams.sharepoint.com/file.pdf",
+        allowHosts: ["sharepoint.com"],
+        authorizationAllowHosts: ["teams.sharepoint.com"],
+        fetchFn: fetchMock as unknown as typeof fetch,
+        requestInit: { dispatcher: {}, headers } as RequestInit,
+        resolveFn,
+      });
+      expect(res).toBe(response);
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(resolveFn).toHaveBeenCalledExactlyOnceWith("teams.sharepoint.com");
+      const sentHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+      expect(sentHeaders.get("authorization")).toBeNull();
+      expect(headers.get("authorization")).toBe("Bearer fixture-token");
+    },
+  );
+
+  it.each([200, 302])(
+    "returns dispatcher-mode %i responses without a location unchanged",
+    async (status) => {
+      const response = new Response(null, { status });
+      const fetchMock = vi.fn(async () => response);
+      const res = await safeFetch({
+        url: "https://teams.sharepoint.com/file.pdf",
+        allowHosts: ["sharepoint.com"],
+        fetchFn: fetchMock as typeof fetch,
+        requestInit: { dispatcher: {} } as RequestInit,
+      });
+      expect(res).toBe(response);
+      expect(fetchMock).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([
+    ["private DNS", privateResolve("127.0.0.1")],
+    ["failed DNS", failingResolve],
+  ])("blocks dispatcher-mode fetch before dispatch on %s", async (_label, resolveFn) => {
+    const fetchMock = vi.fn();
+    await expect(
+      safeFetch({
+        url: "https://teams.sharepoint.com/file.pdf",
+        allowHosts: ["sharepoint.com"],
+        fetchFn: fetchMock as typeof fetch,
+        requestInit: { dispatcher: {} } as RequestInit,
+        resolveFn,
+      }),
+    ).rejects.toThrow("Initial download URL blocked");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("still enforces allowlist checks before returning dispatcher-mode redirects", async () => {
+  it.each([
+    ["https://evil.example.com/steal", "blocked by allowlist"],
+    ["http://teams.sharepoint.com/file.pdf", "blocked by allowlist"],
+    ["https://[invalid", "Invalid redirect URL"],
+  ])("rejects dispatcher-mode redirect %s", async (location, error) => {
     const fetchMock = mockFetchWithRedirect({
-      "https://teams.sharepoint.com/file.pdf": "https://evil.example.com/steal",
+      "https://teams.sharepoint.com/file.pdf": location,
     });
     await expect(
       safeFetch({
@@ -225,7 +273,7 @@ describe("safeFetch", () => {
         requestInit: { dispatcher: {} } as RequestInit,
         resolveFn: publicResolve,
       }),
-    ).rejects.toThrow("blocked by allowlist");
+    ).rejects.toThrow(error);
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
@@ -597,63 +645,69 @@ describe("Graph shared-link helpers", () => {
 describe("msteams inline image limits", () => {
   const smallPngDataUrl = "data:image/png;base64,aGVsbG8="; // "hello" (5 bytes)
 
-  it("rejects inline data images above per-image limit", () => {
+  it.each([
+    ["AA==", "00"],
+    ["AAA=", "0000"],
+    ["AAAA", "000000"],
+    ["Z E = =", "64"],
+    ["A\tA==", "00"],
+  ])("enforces exact decoded-size limits for %s", (payload, hex) => {
+    const data = Buffer.from(hex, "hex");
     const attachments = [
       {
         contentType: "text/html",
-        content: `<img src="${smallPngDataUrl}" />`,
+        content: `<img src="data:image/png;base64,${payload}" />`,
       },
     ];
-    const out = extractInlineImageCandidates(attachments, { maxInlineBytes: 4 });
-    expect(out).toStrictEqual([{ kind: "unavailable" }]);
+    expect(
+      extractInlineImageCandidates(attachments, { maxInlineBytes: data.length - 1 }),
+    ).toStrictEqual([{ kind: "unavailable" }]);
+    expect(
+      extractInlineImageCandidates(attachments, { maxInlineBytes: data.length }),
+    ).toStrictEqual([{ kind: "data", data, contentType: "image/png" }]);
   });
 
-  it("accepts inline data images within limit", () => {
-    const attachments = [
-      {
-        contentType: "text/html",
-        content: `<img src="${smallPngDataUrl}" />`,
-      },
-    ];
-    const out = extractInlineImageCandidates(attachments, { maxInlineBytes: 10 });
-    expect(out.length).toBe(1);
-    expect(out[0]?.kind).toBe("data");
-    if (out[0]?.kind === "data") {
-      expect(out[0].data.byteLength).toBeGreaterThan(0);
-      expect(out[0].contentType).toBe("image/png");
-    }
-  });
+  it.each(["aGV=sbG8=", "A===", "AA", "-AAA", "A!AA"])(
+    "rejects malformed inline base64 %s",
+    (payload) => {
+      const attachments = [
+        {
+          contentType: "text/html",
+          content: `<img src="data:image/png;base64,${payload}" />`,
+        },
+      ];
+      const out = extractInlineImageCandidates(attachments, { maxInlineBytes: 10 });
+      expect(out).toStrictEqual([{ kind: "unavailable" }]);
+    },
+  );
 
-  it("rejects inline data images with malformed base64 padding", () => {
-    const attachments = [
-      {
-        contentType: "text/html",
-        content: `<img src="data:image/png;base64,aGV=sbG8=" />`,
-      },
-    ];
-    const out = extractInlineImageCandidates(attachments, { maxInlineBytes: 10 });
-    expect(out).toStrictEqual([{ kind: "unavailable" }]);
-  });
-
-  it("enforces cumulative inline size limit across attachments", () => {
-    const attachments = [
-      {
-        contentType: "text/html",
-        content: `<img src="${smallPngDataUrl}" />`,
-      },
-      {
-        contentType: "text/html",
-        content: `<img src="${smallPngDataUrl}" />`,
-      },
-    ];
-    const out = extractInlineImageCandidates(attachments, {
-      maxInlineBytes: 10,
-      maxInlineTotalBytes: 6,
-    });
-    expect(out.length).toBe(2);
-    expect(out[0]?.kind).toBe("data");
-    expect(out[1]).toStrictEqual({ kind: "unavailable" });
-  });
+  it.each([
+    [9, ["data", "unavailable", "unavailable"]],
+    [10, ["data", "data", "unavailable"]],
+  ])(
+    "enforces cumulative inline size limit %i across attachments",
+    (maxInlineTotalBytes, kinds) => {
+      const attachments = [
+        {
+          contentType: "text/html",
+          content: `<img src="${smallPngDataUrl}" />`,
+        },
+        {
+          contentType: "text/html",
+          content: `<img src="${smallPngDataUrl}" />`,
+        },
+        {
+          contentType: "text/html",
+          content: `<img src="${smallPngDataUrl}" />`,
+        },
+      ];
+      const out = extractInlineImageCandidates(attachments, {
+        maxInlineBytes: 10,
+        maxInlineTotalBytes,
+      });
+      expect(out.map((candidate) => candidate.kind)).toEqual(kinds);
+    },
+  );
 });
 
 describe("normalizeContentType case-insensitivity", () => {

--- a/extensions/msteams/src/attachments/shared.ts
+++ b/extensions/msteams/src/attachments/shared.ts
@@ -104,42 +104,6 @@ const DEFAULT_MEDIA_AUTH_HOST_ALLOWLIST = [
 export const GRAPH_ROOT = "https://graph.microsoft.com/v1.0";
 export { isRecord };
 
-// Keep this local; importing the broad media-runtime SDK barrel pulls image/audio runtimes into
-// hot MSTeams attachment tests for one tiny estimator.
-function estimateBase64DecodedBytes(base64: string): number {
-  let effectiveLen = 0;
-  for (let i = 0; i < base64.length; i += 1) {
-    const code = base64.charCodeAt(i);
-    if (code <= 0x20) {
-      continue;
-    }
-    effectiveLen += 1;
-  }
-
-  if (effectiveLen === 0) {
-    return 0;
-  }
-
-  let padding = 0;
-  let end = base64.length - 1;
-  while (end >= 0 && base64.charCodeAt(end) <= 0x20) {
-    end -= 1;
-  }
-  if (end >= 0 && base64[end] === "=") {
-    padding = 1;
-    end -= 1;
-    while (end >= 0 && base64.charCodeAt(end) <= 0x20) {
-      end -= 1;
-    }
-    if (end >= 0 && base64[end] === "=") {
-      padding = 2;
-    }
-  }
-
-  const estimated = Math.floor((effectiveLen * 3) / 4) - padding;
-  return Math.max(0, estimated);
-}
-
 /**
  * Host suffixes for SharePoint/OneDrive shared links that must be fetched via
  * the Graph `/shares/{shareId}/driveItem/content` endpoint instead of directly.
@@ -396,7 +360,8 @@ function decodeDataImageWithLimits(
     return { candidate: null, estimatedBytes: 0 };
   }
 
-  const estimatedBytes = estimateBase64DecodedBytes(canonicalPayload);
+  // Validation above guarantees whitespace-free base64 for this allocation-free size check.
+  const estimatedBytes = Buffer.byteLength(canonicalPayload, "base64");
   if (estimatedBytes <= 0) {
     return { candidate: null, estimatedBytes: 0 };
   }
@@ -664,7 +629,7 @@ async function safeFetch(params: {
     "dispatcher" in (params.requestInit as Record<string, unknown>),
   );
   const currentHeaders = new Headers(params.requestInit?.headers);
-  let currentUrl = params.url;
+  const currentUrl = params.url;
 
   if (!isUrlAllowed(currentUrl, params.allowHosts)) {
     throw new Error(`Initial download URL blocked: ${currentUrl}`);
@@ -707,70 +672,53 @@ async function safeFetch(params: {
     return responseWithRelease(guarded.response, guarded.release);
   }
 
-  if (resolveFn) {
-    try {
-      const initialHost = new URL(currentUrl).hostname;
-      await resolveAndValidateIP(initialHost, resolveFn);
-    } catch {
-      throw new Error(`Initial download URL blocked: ${currentUrl}`);
-    }
+  try {
+    const initialHost = new URL(currentUrl).hostname;
+    await resolveAndValidateIP(initialHost, resolveFn);
+  } catch {
+    throw new Error(`Initial download URL blocked: ${currentUrl}`);
   }
 
-  for (let i = 0; i <= MAX_SAFE_REDIRECTS; i++) {
-    const res = await (params.fetchFn ?? fetch)(currentUrl, {
-      ...params.requestInit,
-      headers: currentHeaders,
-      redirect: "manual",
-    });
+  const res = await (params.fetchFn ?? fetch)(currentUrl, {
+    ...params.requestInit,
+    headers: currentHeaders,
+    redirect: "manual",
+  });
 
-    if (!isRedirectStatus(res.status)) {
-      return res;
-    }
-
-    const location = res.headers.get("location");
-    if (!location) {
-      return res;
-    }
-
-    let redirectUrl: string;
-    try {
-      redirectUrl = new URL(location, currentUrl).toString();
-    } catch {
-      throw new Error(`Invalid redirect URL: ${location}`);
-    }
-
-    // Validate redirect target against hostname allowlist
-    if (!isUrlAllowed(redirectUrl, params.allowHosts)) {
-      throw new Error(`Media redirect target blocked by allowlist: ${redirectUrl}`);
-    }
-
-    // Prevent credential bleed: only keep Authorization on redirect hops that
-    // are explicitly auth-allowlisted.
-    if (
-      currentHeaders.has("authorization") &&
-      params.authorizationAllowHosts &&
-      !isUrlAllowed(redirectUrl, params.authorizationAllowHosts)
-    ) {
-      currentHeaders.delete("authorization");
-    }
-
-    // When a pinned dispatcher is already injected by an upstream guard
-    // (for example fetchWithSsrFGuard), let that guard own redirect handling
-    // after this allowlist validation step.
-    if (hasDispatcher) {
-      return res;
-    }
-
-    // Validate redirect target's resolved IP
-    if (resolveFn) {
-      const redirectHost = new URL(redirectUrl).hostname;
-      await resolveAndValidateIP(redirectHost, resolveFn);
-    }
-
-    currentUrl = redirectUrl;
+  if (!isRedirectStatus(res.status)) {
+    return res;
   }
 
-  throw new Error(`Too many redirects (>${MAX_SAFE_REDIRECTS})`);
+  const location = res.headers.get("location");
+  if (!location) {
+    return res;
+  }
+
+  let redirectUrl: string;
+  try {
+    redirectUrl = new URL(location, currentUrl).toString();
+  } catch {
+    throw new Error(`Invalid redirect URL: ${location}`);
+  }
+
+  // Validate redirect target against hostname allowlist
+  if (!isUrlAllowed(redirectUrl, params.allowHosts)) {
+    throw new Error(`Media redirect target blocked by allowlist: ${redirectUrl}`);
+  }
+
+  // Prevent credential bleed: only keep Authorization on redirect hops that
+  // are explicitly auth-allowlisted.
+  if (
+    currentHeaders.has("authorization") &&
+    params.authorizationAllowHosts &&
+    !isUrlAllowed(redirectUrl, params.authorizationAllowHosts)
+  ) {
+    currentHeaders.delete("authorization");
+  }
+
+  // A pinned dispatcher is already injected by an upstream guard; let it own
+  // redirect handling after this allowlist validation step.
+  return res;
 }
 
 export async function safeFetchWithPolicy(params: {


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup of redundant Microsoft Teams attachment handling. The attachment owner repeats base64 size accounting after validation and retains a redirect loop whose later iterations cannot run, making the actual guard ownership harder to follow.

## Why This Change Was Made

Use the already-imported `Buffer.byteLength` only after the unchanged inline-base64 validator, and express the injected-dispatcher path as its existing single request. Keep initial DNS and hostname checks, redirect validation, authorization handling, response identity, and the normal SDK-owned five-redirect limit unchanged. No new dependency, SDK surface, configuration, or network policy.

The existing auth-redirect test also injected a dispatcher through a downloader mock that is no longer called. Remove that ineffective setup and assert the actual guarded-fetch request sequence instead; strengthen the real dispatcher and inline-size boundary tests.

## User Impact

No intended user-visible change. Existing attachment acceptance, limits, authorization, errors, and redirect behavior remain the same. Production LOC: +41/-93 (net -52); tests: +136/-77 (net +59), using standard Git diff.

## Evidence

- Baseline: `43be187b6727a47030dbbba4256eaad89937bded`. The three affected files were unchanged on freshly checked main `18c801daa1165f0bb7f30576b52f6642ff023233`; related open Teams PRs did not supersede this cleanup.
- Node 24.19.0 differential proof: 401,442 raw base64 inputs, 159,424 accepted canonical payloads with identical estimated and decoded lengths, plus 96 per-image threshold comparisons. Direct inspection of Node's Buffer implementation and string-size limit confirms the arithmetic is equivalent without overflow. The [Node Buffer contract](https://nodejs.org/docs/latest-v24.x/api/buffer.html#static-method-bufferbytelengthstring-encoding) requires valid input; the unchanged Teams validator supplies that precondition.
- Additional differential owner proof: 2,307 fetch control-flow traces and 816 inline-image boundary cases matched before/after. These use controlled fetch/DNS doubles, not live Teams or external-network proof.
- Focused existing suite: baseline 110 tests passed; final reviewed candidate 128 tests passed across four files. Local runtime Node 24.19.0, Vitest 4.1.10 and Undici 8.9.0; these local dependency versions are older than the pinned Vitest 4.1.11/Undici 8.10.0, so local results are supplemental to exact-head CI.
- The misleading test's injected mock was independently confirmed unused: an explicit invocation assertion failed with zero calls before the test correction. The corrected test verifies the real three-request auth/redirect order and guarded dispatch.
- Fresh independent pre-commit Codex review passed with no findings, covering the complete diff and 28 complete source inputs, including the Node 24 Buffer implementation. This is static review, not test or live execution.
- Formatting, `git diff --check`, and the changed-code gate's initial/static/dead-export guards passed. The full local changed-code gate failed at extension type checking on stale or missing installed dependencies, with no Teams diagnostic: for example, installed CUA 0.19.3 versus pinned 0.20.0, pi-tui 0.82.1 versus 0.84.2, markdown-it 14.3.0 versus 15.0.0, and missing IMAP/geolocation packages. The shared dependency installation was left untouched. This is a recorded local gate failure, not a passing full gate; ordinary exact-head CI must supply the pinned type/lint proof before landing.
- [Ordinary exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33032741177) passed on `aed33f24fb9636994e3b56daa1657bb08db26141`, including production/test types, lint, guards, build artifacts and the full Teams test configuration: 96 files and 1,530 tests passed under Node 24 with Vitest 4.1.11. The hosted job used the frozen-lockfile setup and exercised all four focused attachment test files. This closes the pinned hosted validation gap without altering the local shared install.
- A separate published-head Codex review passed with no findings across the complete patch and 30 complete source/proof inputs. The exact head, tree, raw patch and source bytes were verified unchanged after the reviewer exited.
- Latest ClawSweeper check before native preparation was its active review-started placeholder on this head; no completed findings or rank-up moves had been posted. There is no skipped actionable move to apply at this checkpoint.

Focused command:

```sh
node scripts/run-vitest.mjs extensions/msteams/src/attachments/shared.test.ts extensions/msteams/src/attachments.test.ts extensions/msteams/src/attachments.helpers.test.ts extensions/msteams/src/attachments/remote-media.test.ts
```

No separate full build was needed for this internal refactor: imports, lazy loading, package boundaries, and published surfaces are unchanged; ordinary CI's build-artifacts job passed. No live Teams tenant was exercised; no external API behavior is changed or claimed proven by these tests. Native preparation and merge verification remain required before landing.

AI-assisted; implementation and source contracts inspected.
