### PR TITLE
fix(acp): closed sessions start fresh after restart (#107487)

### DIFF
--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -1953,9 +1953,9 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     });
 
     expect(await wrappedStore.load("agent:codex:acp:binding:test")).toBeUndefined();
-    expect(baseStore["load"]).toHaveBeenCalledTimes(1);
+    expect(baseStore["load"]).toHaveBeenCalledTimes(2);
     expect(await wrappedStore.load("agent:codex:acp:binding:test")).toBeUndefined();
-    expect(baseStore["load"]).toHaveBeenCalledTimes(1);
+    expect(baseStore["load"]).toHaveBeenCalledTimes(2);
 
     await wrappedStore.save({
       acpxRecordId: "fresh-record",
@@ -1965,7 +1965,39 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(await wrappedStore.load("agent:codex:acp:binding:test")).toEqual({
       acpxRecordId: "stale",
     });
-    expect(baseStore["load"]).toHaveBeenCalledTimes(2);
+    expect(baseStore["load"]).toHaveBeenCalledTimes(3);
+  });
+
+  it("persists fresh-session preparation across runtime instances", async () => {
+    const sessionKey = "agent:codex:acp:binding:test";
+    let persisted: Record<string, unknown> = {
+      acpxRecordId: sessionKey,
+      closed: false,
+      acpx: {},
+    };
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => structuredClone(persisted)),
+      save: vi.fn(async (record) => {
+        persisted = structuredClone(record);
+      }),
+    };
+
+    const { runtime } = makeRuntime(baseStore);
+    await runtime.prepareFreshSession({ sessionKey });
+
+    expect(baseStore["save"]).toHaveBeenCalledOnce();
+    expect(persisted).toMatchObject({
+      acpxRecordId: sessionKey,
+      closed: true,
+      acpx: { reset_on_next_ensure: true },
+    });
+
+    const { wrappedStore: restartedStore } = makeRuntime(baseStore);
+    await expect(restartedStore.load(sessionKey)).resolves.toMatchObject({
+      acpxRecordId: sessionKey,
+      closed: true,
+      acpx: { reset_on_next_ensure: true },
+    });
   });
 
   it("marks the session fresh after discardPersistentState close", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -73,6 +73,7 @@ const ACPX_OPENCLAW_TOOLS_MCP_SERVER_NAME = "openclaw-tools";
 const OPENCLAW_TOOLS_MCP_AGENT_SESSION_KEY_ENV = "OPENCLAW_TOOLS_MCP_AGENT_SESSION_KEY";
 type ResetAwareSessionStore = AcpSessionStore & {
   markFresh: (sessionKey: string) => void;
+  discardPersistedRecord: (sessionKey: string) => Promise<void>;
 };
 
 type OpenClawLeaseSessionMetadata = {
@@ -372,6 +373,23 @@ function createResetAwareSessionStore(
       if (normalized) {
         freshSessionKeys.add(normalized);
       }
+    },
+    async discardPersistedRecord(sessionKey: string): Promise<void> {
+      const normalized = sessionKey.trim();
+      if (!normalized) {
+        return;
+      }
+      freshSessionKeys.add(normalized);
+      const record = await baseStore.load(normalized);
+      if (!record || readRecordResetOnNextEnsure(record)) {
+        return;
+      }
+      await baseStore.save({
+        ...record,
+        closed: true,
+        closedAt: new Date().toISOString(),
+        acpx: { ...record.acpx, reset_on_next_ensure: true },
+      });
     },
   };
 }
@@ -1838,7 +1856,7 @@ export class AcpxRuntime implements CompleteAcpRuntime {
     // Fresh reset has no ACP handle to close the delegate's upstream client.
     // Keep the scoped delegate reachable so the next ensure can replace it;
     // close() owns cache release when the session lifecycle ends.
-    this.sessionStore.markFresh(input.sessionKey);
+    await this.sessionStore.discardPersistedRecord(input.sessionKey);
   }
 
   async close(input: Parameters<AcpRuntime["close"]>[0]): Promise<void> {

--- a/src/acp/control-plane/manager.runtime-resume-state.test.ts
+++ b/src/acp/control-plane/manager.runtime-resume-state.test.ts
@@ -80,7 +80,7 @@ describe("tryPrepareFreshManagerRuntimeSession", () => {
     expect(logVerboseMock).not.toHaveBeenCalled();
   });
 
-  it("records preparation failures without throwing", async () => {
+  it("propagates preparation failures after recording them", async () => {
     logVerboseMock.mockClear();
     const backend = {
       id: "acpx",
@@ -94,9 +94,9 @@ describe("tryPrepareFreshManagerRuntimeSession", () => {
         close: vi.fn(async () => {}),
       },
     } as AcpRuntimeBackend;
-    await expect(
-      tryPrepareFreshManagerRuntimeSession(callParams(backend)),
-    ).resolves.toBeUndefined();
+    await expect(tryPrepareFreshManagerRuntimeSession(callParams(backend))).rejects.toThrow(
+      "backend exploded",
+    );
     expect(logVerboseMock).toHaveBeenCalledWith(
       expect.stringContaining(
         "unable to prepare fresh session for agent:main:acp:test: backend exploded",

--- a/src/acp/control-plane/manager.runtime-resume-state.ts
+++ b/src/acp/control-plane/manager.runtime-resume-state.ts
@@ -193,10 +193,9 @@ export async function discardPersistedManagerRuntimeState(params: {
 }
 
 /**
- * Best-effort fresh-session preparation against a maybe-missing backend.
- * Every non-applied path records why it was skipped: a reset that silently
- * skips this step looks successful while the backend keeps resuming the old
- * conversation, which is the worst failure mode for session resets.
+ * Backend discovery stays best-effort so missing plugins do not block cleanup.
+ * Once preparation starts, failures propagate: acknowledging a close without
+ * its durable reset lets the backend resume the old conversation after restart.
  */
 export async function tryPrepareFreshManagerRuntimeSession(params: {
   deps: Pick<AcpSessionManagerDeps, "getRuntimeBackend">;
@@ -207,23 +206,35 @@ export async function tryPrepareFreshManagerRuntimeSession(params: {
   missingBackendError?: unknown;
 }): Promise<void> {
   const configuredBackend = (params.meta.backend || params.cfg.acp?.backend || "").trim();
+  let backend: ReturnType<AcpSessionManagerDeps["getRuntimeBackend"]>;
   try {
-    const backend = params.deps.getRuntimeBackend(configuredBackend || undefined);
-    if (!backend) {
-      if (params.missingBackendError) {
-        throw toErrorObject(params.missingBackendError, "Non-Error thrown");
-      }
+    backend = params.deps.getRuntimeBackend(configuredBackend || undefined);
+  } catch (error) {
+    logVerbose(
+      `${params.logPrefix}: unable to prepare fresh session for ${params.sessionKey}: ${formatErrorMessage(error)}`,
+    );
+    return;
+  }
+  if (!backend) {
+    if (params.missingBackendError) {
+      const error = toErrorObject(params.missingBackendError, "Non-Error thrown");
       logVerbose(
-        `${params.logPrefix}: fresh-session preparation skipped for ${params.sessionKey}: ACP backend "${configuredBackend || "(default)"}" is not registered`,
+        `${params.logPrefix}: unable to prepare fresh session for ${params.sessionKey}: ${formatErrorMessage(error)}`,
       );
       return;
     }
-    if (!backend.runtime.prepareFreshSession) {
-      logVerbose(
-        `${params.logPrefix}: fresh-session preparation skipped for ${params.sessionKey}: ACP backend "${backend.id}" does not support prepareFreshSession`,
-      );
-      return;
-    }
+    logVerbose(
+      `${params.logPrefix}: fresh-session preparation skipped for ${params.sessionKey}: ACP backend "${configuredBackend || "(default)"}" is not registered`,
+    );
+    return;
+  }
+  if (!backend.runtime.prepareFreshSession) {
+    logVerbose(
+      `${params.logPrefix}: fresh-session preparation skipped for ${params.sessionKey}: ACP backend "${backend.id}" does not support prepareFreshSession`,
+    );
+    return;
+  }
+  try {
     await backend.runtime.prepareFreshSession({
       sessionKey: params.sessionKey,
     });
@@ -231,5 +242,6 @@ export async function tryPrepareFreshManagerRuntimeSession(params: {
     logVerbose(
       `${params.logPrefix}: unable to prepare fresh session for ${params.sessionKey}: ${formatErrorMessage(error)}`,
     );
+    throw error;
   }
 }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1112,6 +1112,44 @@ describe("AcpSessionManager", () => {
     });
   });
 
+  it("does not clear metadata when fresh-session preparation fails", async () => {
+    const runtimeState = createRuntime();
+    runtimeState.close.mockRejectedValueOnce(
+      new AcpRuntimeError(
+        "ACP_BACKEND_UNSUPPORTED_CONTROL",
+        'ACP backend "acpx" does not support session/close.',
+      ),
+    );
+    runtimeState.prepareFreshSession.mockRejectedValueOnce(new Error("session store is read-only"));
+    hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+      id: "acpx",
+      runtime: runtimeState.runtime,
+    });
+    hoisted.readAcpSessionEntryMock.mockReturnValue({
+      sessionKey: "agent:openclaw:acp:session-1",
+      storeSessionKey: "agent:openclaw:acp:session-1",
+      acp: readySessionMeta({
+        agent: "openclaw",
+      }),
+    });
+
+    const manager = new AcpSessionManager();
+    await expect(
+      manager.closeSession({
+        cfg: baseCfg,
+        sessionKey: "agent:openclaw:acp:session-1",
+        reason: "manual-close",
+        allowBackendUnavailable: true,
+        discardPersistentState: true,
+        clearMeta: true,
+      }),
+    ).rejects.toThrow("session store is read-only");
+
+    expect(hoisted.upsertAcpSessionMetaMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ failOnError: true }),
+    );
+  });
+
   it("clears persisted resume identity when close discards persistent state", async () => {
     const runtimeState = createRuntime();
     const sessionKey = "agent:claude:acp:binding:discord:default:9373ab192b2317f4";

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1929,6 +1929,14 @@ describe("/acp command", () => {
     const result = await runThreadAcpCommand("/acp close", baseCfg);
 
     expect(hoisted.closeMock).toHaveBeenCalledTimes(1);
+    expectMockCallFields(hoisted.closeMock, {
+      cfg: baseCfg,
+      sessionKey: defaultAcpSessionKey,
+      reason: "manual-close",
+      allowBackendUnavailable: true,
+      discardPersistentState: true,
+      clearMeta: true,
+    });
     expectMockCallFields(hoisted.sessionBindingUnbindMock, {
       targetSessionKey: defaultAcpSessionKey,
       reason: "manual",
@@ -1964,6 +1972,7 @@ describe("/acp command", () => {
       sessionKey: defaultAcpSessionKey,
       reason: "manual-close",
       allowBackendUnavailable: true,
+      discardPersistentState: true,
       clearMeta: true,
     });
     expectMockCallFields(hoisted.sessionBindingUnbindMock, {

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -518,6 +518,7 @@ export async function handleAcpCloseAction(
           sessionKey,
           reason: "manual-close",
           allowBackendUnavailable: true,
+          discardPersistentState: true,
           clearMeta: true,
         });
         runtimeNotice = closed.runtimeNotice ? ` (${closed.runtimeNotice})` : "";


### PR DESCRIPTION
Closes #107487

## What Problem This Solves

### Summary

Fixes an issue where users who ran `/acp close` on a persistent ACPX session could have that same backend session resume after OpenClaw restarted. The command reported the session closed, but the persistent ACPX record remained reusable.

## Why This Change Was Made

### Root Cause

- `src/auto-reply/reply/commands-acp/lifecycle.ts` closed manual sessions without requesting `discardPersistentState`.
- The manager already has the canonical unsupported-close recovery: it calls `prepareFreshSession` when an ACP agent cannot implement `session/close`.
- `extensions/acpx/src/runtime.ts` implemented `prepareFreshSession` only with a process-local hidden-key set. That prevented reuse in the current process but did not survive restart.
- Pinned `acpx@0.13.1` already defines the durable contract: successful discard writes `closed: true` plus `acpx.reset_on_next_ensure: true`, and the next ensure refuses to reuse that record.

Execution path:

`/acp close` -> `AcpSessionManager.closeSession` -> unsupported backend close -> `AcpxRuntime.prepareFreshSession` -> persisted reset marker

### Changes

- Manual `/acp close` now requests persistent-state discard.
- The ACPX reset-aware store persists the same `reset_on_next_ensure` marker used by successful upstream discard close, while retaining the existing process-local hide for the current process.
- Manager recovery preserves best-effort missing-plugin cleanup but propagates an invoked preparation failure before clearing metadata.
- Added exact command-intent coverage and a restart-boundary regression that creates a second runtime instance over the same store.
- No public API, config, protocol, dependency, SQLite schema, or schema-version change.

Production delta is +48/-17 (+31 net). The growth is limited to two owner boundaries that cannot be expressed by existing state: the private durable ACPX reset marker path and precise propagation of an invoked preparation failure while preserving existing missing-plugin cleanup. Test delta is +86/-7.

## User Impact

After `/acp close`, the next persistent ACP turn starts a fresh backend session even when the agent does not support `session/close` and OpenClaw restarts between the close and the next turn.

## Evidence

### Real Behavior Proof

I ran the production `AcpSessionManager`, `/acp close` handler, `AcpxRuntime`, and real file session store against an external ACP stdio agent in three separate Node 24 OS processes (`seed` -> `close` -> `resume`). The agent advertised `session/resume` but intentionally did not advertise `session/close`. No runtime or manager mocks were used.

| State boundary | Current `main` before | This PR after |
|---|---|---|
| Stored session after `/acp close` | `fake-session-001`, `acpx: {}` | `fake-session-001`, `acpx.reset_on_next_ensure: true` |
| First ACP method in a new OpenClaw process | `session/resume(fake-session-001)` | `session/new -> fake-session-002` |
| User-visible close result | Reported closed with no durable reset | Reported closed and surfaced the unsupported `session/close` notice |

Before:

```text
close record: {"acp_session_id":"fake-session-001","closed":true,"acpx":{}}
restart:       {"method":"session/resume","sessionId":"fake-session-001"}
```

After:

```text
close record: {"acp_session_id":"fake-session-001","closed":true,"acpx":{"reset_on_next_ensure":true}}
restart:       {"method":"session/new","sessionId":"fake-session-002"}
```

This covers the `merge-risk: session-state` boundary in the original execution order and across a real process restart.

Review failure-path proof used the same production setup with the actual ACPX sessions directory and record made read-only before close:

```text
close reply: ACP error (ACP_TURN_FAILED): EACCES: permission denied
next: Retry, or use `/acp cancel` and send the message again.
record:      {"acp_session_id":"fake-session-001","closed":true,"acpx":{}}
restart:     {"method":"session/resume","sessionId":"fake-session-001"}
```

The failed durable write is visible and actionable, metadata is not cleared, and no reset marker is claimed. The old identity remains resumable because the close was not acknowledged.

### Test

- Failing first:
  - command regression received `discardPersistentState: undefined`
  - restart regression observed zero durable store writes
- Review failing first:
  - a rejected `prepareFreshSession` still resolved close with `metaCleared: true`
  - after the fix, manager close rejects before its metadata-clear write
- `pnpm test src/auto-reply/reply/commands-acp.test.ts src/acp/control-plane/manager.test.ts src/gateway/server.sessions.reset-cleanup.test.ts extensions/acpx/src/runtime.test.ts -- --reporter=dot` — 224 passed
- `pnpm test src/acp/control-plane/manager.runtime-resume-state.test.ts src/acp/control-plane/manager.test.ts src/auto-reply/reply/commands-acp.test.ts extensions/acpx/src/runtime.test.ts -- --reporter=dot` — 207 passed
- `pnpm test:extension acpx` — 253 passed
- `pnpm build` — passed
- `node scripts/check-changed.mjs -- extensions/acpx/src/runtime.ts extensions/acpx/src/runtime.test.ts src/acp/control-plane/manager.runtime-resume-state.ts src/acp/control-plane/manager.runtime-resume-state.test.ts src/acp/control-plane/manager.test.ts src/auto-reply/reply/commands-acp/lifecycle.ts src/auto-reply/reply/commands-acp.test.ts` — passed
- Fresh Codex autoreview of the original repair and the review remediation — clean, no accepted/actionable findings

Codex contract check:

- [`thread.rs`](https://github.com/openai/codex/blob/f5420174dafba153913a3e697f89002c338dfd7e/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L321-L350) defines resume by thread ID.
- [`message_processor.rs`](https://github.com/openai/codex/blob/f5420174dafba153913a3e697f89002c338dfd7e/codex-rs/app-server/src/message_processor.rs#L1139-L1148) dispatches `ThreadResume`.

### Risk

- Session state: bounded to explicit manual close. Real multi-process proof shows the closed identity cannot resume after restart.
- Compatibility: no format migration or new field was introduced; this persists the existing marker already owned and consumed by pinned ACPX.

### Changelog

Not added: repository policy keeps `CHANGELOG.md` release-generated for normal PRs.

### Notes

- AI-assisted: yes. The bug was independently reproduced on current main, fixed test-first, and fully validated by MoerAI.
- Prior PR #111628 identified the same durable marker seam and was self-closed by its author. This PR independently revalidated the current-main defect and the pinned dependency contract, then reproduced the fix through the real multi-process path.
- Codex P1 review addressed: a real durable-store write failure now stops metadata clearing and returns an actionable ACP error instead of acknowledging close.
