### PR TITLE
fix(memory): stop false Copilot index mismatch warnings

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -44,6 +44,9 @@ default agent's heartbeat firing to trigger reconciliation. See
 [Dreaming](/concepts/dreaming) for scheduling details.
 
 Status also lists any extra search paths from `memory.search.extraPaths`.
+For providers that discover their default model at initialization, plain status
+defers model identity checks until that model is known. Use `--deep` to initialize
+the provider and verify the model and provider settings against the existing index.
 
 ## `memory index`
 

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -959,6 +959,17 @@ catalog, API-key auth, and dynamic model resolution.
         general embedding contract for reusable vector generation, including
         memory search. The retired memory-specific registrar and manifest
         contract are no longer accepted.
+
+        Providers that accept model aliases can expose
+        `normalizeModel(options): string`. Memory uses this synchronous hook for
+        both creation options and cold index identity checks. Keep it configuration-only:
+        do not authenticate or access the network. Make normalization idempotent and
+        reuse it in `create`, which may receive an already-normalized model or be
+        called outside memory. Return an empty string only when the
+        model remains unknown until discovery; do not turn an invalid explicit
+        model into an omitted selection. For an exact pre-initialization identity,
+        `resolveIndexIdentity(options)` additionally supplies the required
+        `cacheKeyData` and any equivalent persisted aliases.
       </Tab>
       <Tab title="Image and video generation">
         Image and video capabilities use a **mode-aware** shape. Image

--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -227,6 +227,16 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
   });
 
   it("strips the provider prefix from a user-selected model", async () => {
+    const options = {
+      ...defaultCreateOptions(),
+      model: "github-copilot/text-embedding-3-small",
+    };
+    expect(githubCopilotMemoryEmbeddingProviderAdapter.normalizeModel?.(options)).toBe(
+      "text-embedding-3-small",
+    );
+    expect(resolveFirstGithubTokenMock).not.toHaveBeenCalled();
+    expect(resolveCopilotRuntimeAuthMock).not.toHaveBeenCalled();
+    expect(fetchWithSsrFGuardMock).not.toHaveBeenCalled();
     mockDiscoveryResponse({
       ok: true,
       json: buildModelsResponse([
@@ -234,15 +244,19 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
       ]),
     });
 
-    const result = await githubCopilotMemoryEmbeddingProviderAdapter.create({
-      ...defaultCreateOptions(),
-      model: "github-copilot/text-embedding-3-small",
-    } as never);
+    const result = await githubCopilotMemoryEmbeddingProviderAdapter.create(options);
 
     expect(result.provider?.model).toBe("text-embedding-3-small");
   });
 
-  it("throws when the user-selected model is unavailable", async () => {
+  it.each([
+    "gpt-4o",
+    "github-copilot/",
+    "github-copilot/github-copilot/text-embedding-3-small",
+    "github-copilot/ text-embedding-3-small",
+    "github-copilot/\tgithub-copilot/text-embedding-3-small",
+    "other/text-embedding-3-small",
+  ])("rejects the unavailable explicit model %s", async (model) => {
     mockDiscoveryResponse({
       ok: true,
       json: buildModelsResponse([
@@ -253,9 +267,13 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
     await expect(
       githubCopilotMemoryEmbeddingProviderAdapter.create({
         ...defaultCreateOptions(),
-        model: "gpt-4o",
+        model:
+          githubCopilotMemoryEmbeddingProviderAdapter.normalizeModel?.({
+            ...defaultCreateOptions(),
+            model,
+          }) ?? model,
       } as never),
-    ).rejects.toThrow('GitHub Copilot embedding model "gpt-4o" is not available');
+    ).rejects.toThrow(`GitHub Copilot embedding model "${model}" is not available`);
   });
 
   it("throws when discovery finds no embedding models", async () => {

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -145,22 +145,29 @@ async function discoverEmbeddingModels(params: {
   }
 }
 
+function normalizeCopilotEmbeddingModel(model: string): string {
+  const normalized = model.trim();
+  const prefix = `${COPILOT_EMBEDDING_PROVIDER_ID}/`;
+  const stripped = normalized.startsWith(prefix) ? normalized.slice(prefix.length) : normalized;
+  // Keep invalid selections explicit and normalization idempotent across
+  // cold memory options and direct provider creation.
+  return stripped && stripped === stripped.trim() && !stripped.startsWith(prefix)
+    ? stripped
+    : normalized;
+}
+
 function pickBestModel(available: string[], userModel?: string): string {
   if (userModel) {
-    const normalized = userModel.trim();
-    // Strip the provider prefix if users set "github-copilot/model-name".
-    const stripped = normalized.startsWith(`${COPILOT_EMBEDDING_PROVIDER_ID}/`)
-      ? normalized.slice(`${COPILOT_EMBEDDING_PROVIDER_ID}/`.length)
-      : normalized;
+    const normalized = normalizeCopilotEmbeddingModel(userModel);
     if (available.length === 0) {
       throw new Error("No embedding models available from GitHub Copilot");
     }
-    if (!available.includes(stripped)) {
+    if (!available.includes(normalized)) {
       throw new Error(
-        `GitHub Copilot embedding model "${stripped}" is not available. Available: ${available.join(", ")}`,
+        `GitHub Copilot embedding model "${normalized}" is not available. Available: ${available.join(", ")}`,
       );
     }
-    return stripped;
+    return normalized;
   }
   for (const preferred of PREFERRED_MODELS) {
     if (available.includes(preferred)) {
@@ -306,6 +313,7 @@ export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProvide
   id: COPILOT_EMBEDDING_PROVIDER_ID,
   transport: "remote",
   authProviderId: COPILOT_EMBEDDING_PROVIDER_ID,
+  normalizeModel: ({ model }) => normalizeCopilotEmbeddingModel(model),
   autoSelectPriority: 15,
   allowExplicitWhenConfiguredAuto: true,
   shouldContinueAutoSelection: (err: unknown) => isCopilotSetupError(err),

--- a/extensions/memory-core/src/memory/embedding.test-mocks.ts
+++ b/extensions/memory-core/src/memory/embedding.test-mocks.ts
@@ -15,7 +15,6 @@ export function resetEmbeddingMocks(): void {
 }
 
 vi.mock("./embeddings.js", () => ({
-  resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
   resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
     providerId === "local" ? "local" : "remote",
   resolveEmbeddingProviderIndexIdentity: () => undefined,

--- a/extensions/memory-core/src/memory/embeddings.test.ts
+++ b/extensions/memory-core/src/memory/embeddings.test.ts
@@ -8,6 +8,7 @@ import {
   createEmbeddingProvider,
   resolveEmbeddingProviderFallbackModel,
   resolveEmbeddingProviderFallbackRemote,
+  resolveEmbeddingProviderIndexIdentity,
 } from "./embeddings.js";
 
 const mockEmbeddingRegistry = vi.hoisted(() => ({
@@ -117,6 +118,32 @@ describe("createEmbeddingProvider", () => {
 
   afterEach(() => {
     clearTestMemoryAdapters();
+  });
+
+  it("uses the provider's canonical model for cold identity and creation without inventing a cache key", async () => {
+    registerTestMemoryAdapter({
+      id: "dynamic",
+      normalizeModel: ({ model }) => model.replace(/^dynamic\//, ""),
+      create: async ({ model }) => ({
+        provider: {
+          id: "dynamic",
+          model,
+          embed: async () => [1],
+          embedBatch: async (texts) => texts.map(() => [1]),
+        },
+      }),
+    });
+    const options = { ...createOptions("dynamic"), model: " dynamic/embed-v1 " };
+    expect(resolveEmbeddingProviderIndexIdentity(options)).toEqual({
+      provider: { id: "dynamic", model: "embed-v1" },
+      cacheKeyData: undefined,
+      aliases: undefined,
+    });
+    expect((await createEmbeddingProvider(options)).provider?.model).toBe("embed-v1");
+    expect(resolveEmbeddingProviderIndexIdentity({ ...options, model: "" })?.provider).toEqual({
+      id: "dynamic",
+      model: "",
+    });
   });
 
   it("normalizes legacy auto mode to OpenAI", async () => {
@@ -427,7 +454,7 @@ describe("createEmbeddingProvider", () => {
     );
   });
 
-  it("uses config-scoped lookup for generic fallback model resolution", () => {
+  it("uses config-scoped defaults for cold identity and fallback model resolution", () => {
     registerGenericEmbeddingProvider({
       id: "openai-compatible",
       defaultModel: "generic-default",
@@ -444,6 +471,10 @@ describe("createEmbeddingProvider", () => {
     );
 
     expect(model).toBe("generic-default");
-    expect(mockEmbeddingRegistry.genericLookupConfigs).toEqual([options.config]);
+    expect(resolveEmbeddingProviderIndexIdentity(options)?.provider).toEqual({
+      id: "openai-compatible",
+      model: "generic-default",
+    });
+    expect(mockEmbeddingRegistry.genericLookupConfigs).toEqual([options.config, options.config]);
   });
 });

--- a/extensions/memory-core/src/memory/embeddings.ts
+++ b/extensions/memory-core/src/memory/embeddings.ts
@@ -55,27 +55,20 @@ function getAdapter(
   throw new Error(`Unknown memory embedding provider: ${id}`);
 }
 
-function resolveProviderModel(
-  adapter: MemoryEmbeddingProviderAdapter,
-  requestedModel: string,
-): string {
-  const trimmed = requestedModel.trim();
-  if (trimmed) {
-    return trimmed;
-  }
-  return adapter.defaultModel ?? "";
-}
-
 function resolveAdapterCreateOptions(
+  adapter: MemoryEmbeddingProviderAdapter,
   options: CreateEmbeddingProviderOptions,
-  model: string,
 ): MemoryEmbeddingProviderCreateOptions {
   const { outputDimensionality, ...base } = options;
-  return {
+  const createOptions = {
     ...base,
     fallback: "none",
-    model,
+    model: options.model.trim() || adapter.defaultModel || "",
     ...(typeof outputDimensionality === "number" ? { dimensions: outputDimensionality } : {}),
+  };
+  return {
+    ...createOptions,
+    model: adapter.normalizeModel?.(createOptions) ?? createOptions.model,
   };
 }
 
@@ -99,17 +92,6 @@ export function resolveEmbeddingProviderFallbackRemote(
   return Object.keys(sharedRemote).length > 0 ? sharedRemote : undefined;
 }
 
-export function resolveEmbeddingProviderAdapterId(
-  providerId: string,
-  config?: MemoryEmbeddingProviderCreateOptions["config"],
-): string | undefined {
-  try {
-    return getAdapter(providerId, config).id;
-  } catch {
-    return undefined;
-  }
-}
-
 export function resolveEmbeddingProviderAdapterTransport(
   providerId: string,
   config?: MemoryEmbeddingProviderCreateOptions["config"],
@@ -126,17 +108,13 @@ export function resolveEmbeddingProviderIndexIdentity(options: CreateEmbeddingPr
     options.provider === "auto" ? DEFAULT_MEMORY_EMBEDDING_PROVIDER : options.provider;
   try {
     const adapter = getAdapter(provider, options.config);
-    const model = resolveProviderModel(adapter, options.model);
-    const identity = adapter.resolveIndexIdentity?.(
-      resolveAdapterCreateOptions({ ...options, provider }, model),
-    );
-    return identity
-      ? {
-          provider: { id: adapter.id, model: identity.model },
-          cacheKeyData: identity.cacheKeyData,
-          aliases: identity.aliases,
-        }
-      : undefined;
+    const createOptions = resolveAdapterCreateOptions(adapter, { ...options, provider });
+    const identity = adapter.resolveIndexIdentity?.(createOptions);
+    return {
+      provider: { id: adapter.id, model: identity?.model ?? createOptions.model },
+      cacheKeyData: identity?.cacheKeyData,
+      aliases: identity?.aliases,
+    };
   } catch {
     return undefined;
   }
@@ -146,10 +124,7 @@ async function createWithAdapter(
   adapter: MemoryEmbeddingProviderAdapter,
   options: CreateEmbeddingProviderOptions,
 ): Promise<EmbeddingProviderResult> {
-  const createOptions = resolveAdapterCreateOptions(
-    options,
-    resolveProviderModel(adapter, options.model),
-  );
+  const createOptions = resolveAdapterCreateOptions(adapter, options);
   const result = await adapter.create(createOptions);
   return {
     provider: result.provider,

--- a/extensions/memory-core/src/memory/manager-index.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-index.test-support.ts
@@ -174,23 +174,18 @@ vi.mock("./embeddings.js", async (importOriginal) => {
     const audio = lower.split("audio").length - 1;
     return [alpha, beta, image, audio];
   };
+  const resolveFallbackModel = (providerId: string, fallbackSourceModel: string) =>
+    providerId === "gemini" || providerId === "fallback-provider"
+      ? `${providerId}-embed`
+      : fallbackSourceModel;
   return {
     ...actual,
-    resolveEmbeddingProviderFallbackModel: (providerId: string, fallbackSourceModel: string) =>
-      providerId === "gemini" || providerId === "fallback-provider"
-        ? `${providerId}-embed`
-        : fallbackSourceModel,
-    resolveEmbeddingProviderAdapterId: (
-      providerId: string,
-      config?: {
-        models?: {
-          providers?: Record<string, { api?: string; baseUrl?: string; models?: unknown[] }>;
-        };
-      },
-    ) => config?.models?.providers?.[providerId]?.api ?? providerId,
+    resolveEmbeddingProviderFallbackModel: resolveFallbackModel,
     resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
       providerId === "local" ? "local" : "remote",
-    resolveEmbeddingProviderIndexIdentity: (options: { provider?: string; model?: string }) =>
+    resolveEmbeddingProviderIndexIdentity: (
+      options: Parameters<typeof actual.resolveEmbeddingProviderIndexIdentity>[0],
+    ) =>
       options.provider === providerState.identityAlias.provider
         ? {
             provider: {
@@ -211,7 +206,12 @@ vi.mock("./embeddings.js", async (importOriginal) => {
               },
             ],
           }
-        : undefined,
+        : {
+            provider: {
+              id: options.config.models?.providers?.[options.provider]?.api ?? options.provider,
+              model: options.model.trim() || resolveFallbackModel(options.provider, ""),
+            },
+          },
     createEmbeddingProvider: async (options: ProviderCall) => {
       providerState.providerCalls.push({
         provider: options.provider,

--- a/extensions/memory-core/src/memory/manager-reindex-state.test.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.test.ts
@@ -32,7 +32,7 @@ function createMeta(overrides: Partial<MemoryIndexMeta> = {}): MemoryIndexMeta {
 function createIdentityParams(
   overrides: {
     meta?: MemoryIndexMeta | null;
-    provider?: { id: string; model: string } | null;
+    provider?: { id: string; model?: string } | null;
     providerKey?: string;
     providerAliases?: Array<{ model: string; providerKey: string }>;
     providerKeyKnown?: boolean;
@@ -144,6 +144,23 @@ describe("memory reindex state", () => {
         }),
       ),
     ).toEqual({ status: "valid" });
+  });
+
+  it("defers only model and key checks when the configured model is unknown", () => {
+    const params = createIdentityParams({ provider: { id: "openai" }, providerKey: undefined });
+    expect(resolveMemoryIndexIdentityState(params)).toEqual({ status: "valid" });
+    expect(resolveMemoryIndexIdentityState({ ...params, provider: { id: "other" } })).toEqual({
+      status: "mismatched",
+      reason: "index was built for provider openai, expected other",
+    });
+    expect(resolveMemoryIndexIdentityState({ ...params, configuredScopeHash: "other" })).toEqual({
+      status: "mismatched",
+      reason: "index scope changed",
+    });
+    expect(resolveMemoryIndexIdentityState({ ...params, vectorReady: true })).toEqual({
+      status: "mismatched",
+      reason: "index vector dimensions are missing",
+    });
   });
 
   it("keeps model identity strict when paths share a basename", () => {

--- a/extensions/memory-core/src/memory/manager-reindex-state.ts
+++ b/extensions/memory-core/src/memory/manager-reindex-state.ts
@@ -135,7 +135,7 @@ export function resolveConfiguredScopeHash(params: {
 
 export function resolveMemoryIndexIdentityState(params: {
   meta: MemoryIndexMeta | null;
-  provider: { id: string; model: string } | null;
+  provider: { id: string; model?: string } | null;
   providerKey?: string;
   providerAliases?: Array<Pick<MemoryIndexProviderIdentity, "model" | "providerKey">>;
   providerKeyKnown?: boolean;
@@ -163,12 +163,15 @@ export function resolveMemoryIndexIdentityState(params: {
       reason: "index chunking implementation changed",
     };
   }
-  const expectedModel = params.provider?.model?.trim() || "fts-only";
+  const expectedModel =
+    params.provider && params.provider.model === undefined
+      ? undefined
+      : params.provider?.model?.trim() || "fts-only";
   const matchingModelIdentities = [
     { model: expectedModel, providerKey: params.providerKey },
     ...(params.providerAliases ?? []),
   ].filter((identity) => identity.model === meta.model);
-  if (matchingModelIdentities.length === 0) {
+  if (expectedModel !== undefined && matchingModelIdentities.length === 0) {
     return {
       status: "mismatched",
       reason: `index was built for model ${meta.model}, expected ${expectedModel}`,
@@ -182,6 +185,7 @@ export function resolveMemoryIndexIdentityState(params: {
     };
   }
   if (
+    expectedModel !== undefined &&
     params.providerKeyKnown !== false &&
     !matchingModelIdentities.some((identity) => identity.providerKey === meta.providerKey)
   ) {

--- a/extensions/memory-core/src/memory/manager-sync-base.ts
+++ b/extensions/memory-core/src/memory/manager-sync-base.ts
@@ -23,8 +23,6 @@ import {
 import { runSqliteImmediateTransactionSync } from "openclaw/plugin-sdk/sqlite-runtime";
 import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
 import {
-  resolveEmbeddingProviderAdapterId,
-  resolveEmbeddingProviderFallbackModel,
   resolveEmbeddingProviderIndexIdentity,
   type EmbeddingProvider,
   type EmbeddingProviderId,
@@ -46,6 +44,7 @@ import {
 } from "./manager-reindex-state.js";
 import {
   markMemoryVectorRebuildRequired,
+  memoryTableExists,
   requiresMemoryVectorRebuild,
 } from "./manager-vector-rebuild-state.js";
 import type { MemoryWatchSettleQueue } from "./watch-settle.js";
@@ -100,11 +99,6 @@ const EMBEDDING_CACHE_SEED_BATCH_SIZE = 1_000;
 const VECTOR_LOAD_TIMEOUT_MS = 30_000;
 const log = createSubsystemLogger("memory");
 
-function memoryTableExists(db: DatabaseSync, tableName: string): boolean {
-  return Boolean(
-    db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(tableName),
-  );
-}
 export abstract class MemoryManagerSyncBase {
   protected readonly acquireLocalService?: MemoryCoreAcquireLocalService;
   protected abstract readonly cfg: OpenClawConfig;
@@ -379,19 +373,16 @@ export abstract class MemoryManagerSyncBase {
             ...resolveMemoryPrimaryProviderRequest({ settings: this.settings }),
           })
         : undefined;
-    // Plain status can compare identity before provider init. Mirror provider
-    // init's empty-model fallback so adapter defaults do not look mismatched.
+    // Dynamic defaults stay unknown until provider initialization. Plain status
+    // must not reinterpret an undiscovered semantic model as keyword-only.
     const configuredProvider =
       this.settings.provider === "none"
         ? null
-        : (configuredIndexIdentity?.provider ?? {
-            id:
-              resolveEmbeddingProviderAdapterId(this.settings.provider, this.cfg) ??
-              this.settings.provider,
+        : {
+            id: configuredIndexIdentity?.provider.id ?? this.settings.provider,
             model:
-              this.settings.model.trim() ||
-              resolveEmbeddingProviderFallbackModel(this.settings.provider, "fts-only", this.cfg),
-          });
+              (configuredIndexIdentity?.provider.model ?? this.settings.model.trim()) || undefined,
+          };
     const provider = hasProviderOverride
       ? params.provider!
       : this.provider
@@ -408,7 +399,7 @@ export abstract class MemoryManagerSyncBase {
       provider.model === this.provider.model
         ? this.resolveProviderIndexIdentities()
         : [];
-    const configuredProviderIdentities = configuredIndexIdentity
+    const configuredProviderIdentities = configuredIndexIdentity?.cacheKeyData
       ? resolveMemoryIndexProviderIdentities({
           provider: configuredIndexIdentity.provider,
           cacheKeyData: configuredIndexIdentity.cacheKeyData,

--- a/extensions/memory-core/src/memory/manager-sync-yield.test.ts
+++ b/extensions/memory-core/src/memory/manager-sync-yield.test.ts
@@ -76,7 +76,6 @@ vi.mock("openclaw/plugin-sdk/memory-core-host-engine-sessions", async (importOri
 });
 
 vi.mock("./embeddings.js", () => ({
-  resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
   resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
     providerId === "local" ? "local" : "remote",
   resolveEmbeddingProviderIndexIdentity: () => undefined,

--- a/extensions/memory-core/src/memory/manager-vector-rebuild-state.ts
+++ b/extensions/memory-core/src/memory/manager-vector-rebuild-state.ts
@@ -7,7 +7,7 @@ import {
 
 const VECTOR_REBUILD_META_KEY = "memory_vector_rebuild_v1";
 
-function vectorTableExists(db: DatabaseSync, tableName: string): boolean {
+export function memoryTableExists(db: DatabaseSync, tableName: string): boolean {
   return Boolean(
     db.prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?").get(tableName),
   );
@@ -49,7 +49,7 @@ export function resolvePersistedMemoryVectorIndexState(params: {
   if (row?.value === "1") {
     return { state: "incomplete" };
   }
-  if (!vectorTableExists(params.db, params.vectorTable)) {
+  if (!memoryTableExists(params.db, params.vectorTable)) {
     return params.metaVectorDims && params.hasSemanticChunks
       ? { state: "incomplete" }
       : { state: "empty" };

--- a/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
+++ b/extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts
@@ -66,7 +66,6 @@ function restoreFtsOnlyStateDir(): void {
 
 vi.mock("./embeddings.js", () => ({
   createEmbeddingProvider: createEmbeddingProviderMock,
-  resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
   resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
     providerId === "local" ? "local" : "remote",
   resolveEmbeddingProviderIndexIdentity: () => undefined,
@@ -119,7 +118,7 @@ describe("memory manager FTS-only reindex", () => {
   });
 
   async function createManager(
-    params: { provider?: string; vectorEnabled?: boolean } = {},
+    params: { provider?: string; purpose?: "status"; vectorEnabled?: boolean } = {},
   ): Promise<MemoryIndexManager> {
     const store =
       params.vectorEnabled === undefined
@@ -146,7 +145,7 @@ describe("memory manager FTS-only reindex", () => {
         list: [{ id: "main", default: true }],
       },
     } as OpenClawConfig;
-    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    const result = await getMemorySearchManager({ cfg, agentId: "main", purpose: params.purpose });
     if (!result.manager) {
       throw new Error(result.error ?? "manager missing");
     }
@@ -191,6 +190,25 @@ describe("memory manager FTS-only reindex", () => {
     const secondStatus = memoryManager.status();
     expect(secondStatus.chunks).toBeGreaterThan(0);
     expect(countChunksContaining("Alpha topic")).toBeGreaterThan(0);
+  });
+
+  it("keeps a reopened semantic index valid before discovering the provider model", async () => {
+    providerAvailable = true;
+    const indexed = await createManager({ provider: "openai" });
+    await indexed.sync({ force: true });
+    expect(indexed.status().chunks).toBeGreaterThan(0);
+    await indexed.close();
+    await closeAllMemorySearchManagers();
+    await closeAllMemoryIndexManagers();
+    createEmbeddingProviderMock.mockClear();
+
+    const reopened = await createManager({ provider: "openai", purpose: "status" });
+    expect(reopened.status().custom?.indexIdentity).toEqual({ status: "valid" });
+    expect(reopened.status().custom?.providerState).toEqual({
+      mode: "pending",
+      requestedProvider: "openai",
+    });
+    expect(createEmbeddingProviderMock).not.toHaveBeenCalled();
   });
 
   it("returns keyword matches when optional provider construction fails during search bootstrap", async () => {

--- a/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
+++ b/extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts
@@ -35,7 +35,6 @@ function restoreSelfHealStateDir(): void {
 
 vi.mock("./embeddings.js", () => ({
   createEmbeddingProvider: createEmbeddingProviderMock,
-  resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
   resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
     providerId === "local" ? "local" : "remote",
   resolveEmbeddingProviderIndexIdentity: () => undefined,

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -156,7 +156,6 @@ vi.mock("./sqlite-vec.js", () => ({
 }));
 
 vi.mock("./embeddings.js", () => ({
-  resolveEmbeddingProviderAdapterId: (providerId: string) => providerId,
   resolveEmbeddingProviderAdapterTransport: (providerId: string) =>
     providerId === "local" ? "local" : "remote",
   resolveEmbeddingProviderIndexIdentity: () => undefined,

--- a/src/plugins/embedding-provider-types.ts
+++ b/src/plugins/embedding-provider-types.ts
@@ -89,6 +89,8 @@ export type EmbeddingProviderAdapter = {
   defaultModel?: string;
   transport?: "local" | "remote";
   authProviderId?: string;
+  /** Canonical model from config only: synchronous, without auth or network access. */
+  normalizeModel?: (options: EmbeddingProviderCreateOptions) => string;
   resolveIndexIdentity?: (
     options: EmbeddingProviderCreateOptions,
   ) => EmbeddingProviderIndexIdentity;


### PR DESCRIPTION
Closes #113553. Supersedes #113816 with contributor credit preserved.

## What Problem This Solves

Fixes an issue where users running plain `openclaw memory status` would see a valid Copilot semantic index reported as incompatible before the embedding provider initialized. This affected both an omitted, dynamically discovered model and the supported `github-copilot/<model>` configuration form, and could produce unnecessary rebuild guidance.

## Why This Change Was Made

Cold status now carries an unknown model as unknown instead of inventing `fts-only`. Provider-owned model normalization is shared by memory creation and cold identity resolution, while Copilot also reuses its normalizer for direct adapter creation. Known runtime models, exact provider keys, equivalent identity aliases, and the other index consistency checks remain strict.

The Plugin SDK gains an additive, synchronous, configuration-only `normalizeModel(options)` hook. The shipped full `resolveIndexIdentity` return contract remains unchanged: its model and cache-key data are still required. No endpoint, auth, cache key, database schema, or migration is invented for a cold provider. Duplicate configured-model lookup and SQLite table-existence code are consolidated.

The stale fallback is present in stable `v2026.7.1-2` and was carried forward by the manager split in #108583 (`c077e801ddd4`, authored and merged by @steipete). The original introducing commit is beyond the available shallow-history boundary; the split is not being claimed as the introduction.

This is a credited continuation of @1052326311's #113816. Maintainer edits are disabled on that fork, so this replacement is based on current main. Thanks to @leiouhe for the report. AI-assisted with Codex.

## User Impact

An existing valid Copilot index remains valid before initialization, without authentication or provider calls. `memory status --deep` still initializes the provider and checks the actual discovered identity. Explicit model/provider changes remain mismatches, and invalid explicit model selections do not silently become automatic discovery. No reindex is needed merely to benefit from this diagnostic fix.

Release-note context: fix false Copilot memory-index mismatch warnings before provider initialization and for supported provider-prefixed model IDs; thanks @1052326311 and @leiouhe.

## Evidence

- Exact trusted base: `67d22a58acadd23e09ec923a6c90cf5c2586efb5`, including the unified embedding-provider contract from #130506.
- Red: three new owner regressions failed for the intended reasons, with 49 existing tests passing. One regression builds a real disposable SQLite semantic index, closes the manager, and reopens it for cold status; the transport is mocked only in this unit regression.
- Green final patch: eight affected files, 117 tests passed; the existing configured-provider-alias and adapter-default manager cases also passed (2 tests). Earlier generic provider/alias, vector-state, and registry-contract checks passed as part of the seven-file/80-test run. An initial run was externally terminated before test execution; the exact unchanged retry passed.
- Authenticated live before proof: the actual Copilot adapter received successful user, model-discovery, and embedding responses and built a disposable index containing one file, one chunk, and a complete 1536-dimensional vector index. Fresh no-credential processes then reproduced both false mismatch warnings with zero HTTP requests.
- Independent live after proof against that same pre-fix index: omitted and prefixed cold models are valid with the provider pending and zero HTTP; genuine cold model/provider changes remain mismatches. Both authenticated initialization cases return active/valid after successful provider requests. Switching to the actually available `text-embedding-ada-002` activates that model and correctly reports a mismatch; restoring the discovered `text-embedding-3-small` reports active/valid. Index revision and chunk/metadata digest remain unchanged throughout those active probes. The dirty flag retained by intentional mismatch probes is not claimed to be reset.
- Final-byte rebinding: after the invalid-input-only normalization correction and dead-code removal, independent fresh cold omitted/prefixed runs again passed on the final source bytes: no credentials, zero HTTP/blocked attempts, pending provider, valid identity, and the original complete 1536-dimensional index retained. The earlier authenticated valid-input paths were independently source-checked as unchanged; their artifacts are not mislabeled as the later source bytes.
- Model-normalization hardening: nested-prefix and whitespace-suffix selections demonstrably failed the new rejection regressions before the canonical-form repair. The full Copilot suite now passes all 22 tests. Normalization is a fixed point, so cold projection and repeated creation cannot disagree.
- Independent source review and fresh structured Codex review through P2: no accepted/actionable findings remain. Targeted type-aware lint, formatting, and `git diff --check` pass. Full hosted checks must pass on the exact published head before native landing.

Focused regression command:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/github-copilot/embeddings.test.ts \
  extensions/memory-core/src/memory/embeddings.test.ts \
  extensions/memory-core/src/memory/manager-reindex-state.test.ts \
  extensions/memory-core/src/memory/manager.fts-only-reindex.test.ts \
  extensions/memory-core/src/memory/manager.self-heal-missing-identity.test.ts \
  extensions/memory-core/src/memory/manager.watcher-config.test.ts \
  extensions/memory-core/src/memory/manager-sync-yield.test.ts \
  extensions/memory-core/src/memory/manager.reindex-recovery.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/memory-core/src/memory/index.test.ts \
  -t 'keeps status clean when configured'
```

The live proof uses actual source adapters and the real memory manager/store against a disposable index created before the repair, not hand-written index metadata. It is source-runtime evidence, not a packaged CLI or release validation claim. Operator memory/configuration is untouched.

ClawSweeper's source-PR rank-up request to keep unknown-model handling exclusively before initialization is retained; initialized identities remain strict. The replacement also covers the previously unaddressed prefix mismatch. Production LOC: +50/-70 (net -20); tests/support: +111/-31 (net +80); docs: +14. The only new public surface is one optional pure SDK hook; no config keys or operator steps are added.

### Bounded follow-up

Audit cold model identity for other provider-specific aliases against their exact endpoint/custom-provider contracts. OpenAI preserves `openai/` on non-native router endpoints, while Ollama and LM Studio normalization can depend on the configured provider ID. Those policies are deliberately not replaced with a generic prefix-stripping rule; the new options-based hook provides their appropriate owner seam.
