### PR TITLE
fix(slack): retain all multipart action send receipts

### DIFF
--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -9,6 +9,7 @@ import { handleSlackAction, slackActionRuntime } from "./action-runtime.js";
 import { sendSlackMessage as sendSlackMessageThroughPublicOwner } from "./actions.js";
 import { parseSlackBlocksInput } from "./blocks-input.js";
 import { registerSlackInstallationState } from "./installation-identity-state.js";
+import type { SlackSendResult } from "./send.js";
 import { buildSlackThreadingToolContext } from "./threading-tool-context.js";
 
 const originalSlackActionRuntime = { ...slackActionRuntime };
@@ -53,7 +54,11 @@ const resolveSlackConversationInfo = vi.fn(
     return { type: "channel", ...(channelName ? { name: channelName } : {}) };
   },
 );
-const sendSlackMessage = vi.fn(async (..._args: unknown[]) => ({ channelId: "C123" }));
+const sendSlackMessage = vi.fn(
+  async (..._args: unknown[]): Promise<Partial<SlackSendResult> & { channelId: string }> => ({
+    channelId: "C123",
+  }),
+);
 const unpinSlackMessage = vi.fn(async (..._args: unknown[]) => ({}));
 
 describe("handleSlackAction", () => {
@@ -859,7 +864,9 @@ describe("handleSlackAction", () => {
     },
   ])("accepts $name and allows empty content", async ({ blocks, expectedBlocks }) => {
     const cfg = slackConfig();
-    await handleSlackAction(
+    const nativeResult = { channelId: "C123", messageId: "123.456", threadTs: "123.400" };
+    sendSlackMessage.mockResolvedValueOnce(nativeResult);
+    const result = await handleSlackAction(
       {
         action: "sendMessage",
         to: "channel:C123",
@@ -874,6 +881,7 @@ describe("handleSlackAction", () => {
       threadTs: undefined,
       blocks: expectedBlocks,
     });
+    expect(result.details).toEqual({ ok: true, result: nativeResult });
   });
 
   it.each([
@@ -1067,9 +1075,9 @@ describe("handleSlackAction", () => {
     ).rejects.toThrow(/replyBroadcast is only supported for text or block thread replies/i);
   });
 
-  it("sends media before a separate blocks message", async () => {
-    sendSlackMessage.mockResolvedValueOnce({ channelId: "C123" });
-    sendSlackMessage.mockResolvedValueOnce({ channelId: "C123" });
+  it.each([false, true])("sends media before separate blocks (prepared=%s)", async (prepared) => {
+    sendSlackMessage.mockResolvedValueOnce({ channelId: "C123", messageId: "F123" });
+    sendSlackMessage.mockResolvedValueOnce({ channelId: "C123", messageId: "123.456" });
 
     const cfg = slackConfig();
     const result = await handleSlackAction(
@@ -1081,6 +1089,9 @@ describe("handleSlackAction", () => {
         blocks: JSON.stringify([{ type: "divider" }]),
       },
       cfg,
+      prepared
+        ? { preparedMessages: [{ text: "hello", blocks: [{ type: "divider" }] }] }
+        : undefined,
     );
 
     expect(sendSlackMessage).toHaveBeenCalledTimes(2);
@@ -1100,9 +1111,13 @@ describe("handleSlackAction", () => {
     expect(requireRecordArg(sendSlackMessage, "sendSlackMessage", 1, 2)).not.toHaveProperty(
       "mediaUrl",
     );
-    expect(result.details).toEqual({
+    expect(result.details).toMatchObject({
       ok: true,
-      result: { channelId: "C123" },
+      result: {
+        channelId: "C123",
+        messageId: "123.456",
+        receipt: { platformMessageIds: ["F123", "123.456"] },
+      },
     });
   });
 
@@ -1112,8 +1127,8 @@ describe("handleSlackAction", () => {
     const context = createReplyToFirstContext(hasRepliedRef);
     const content = "x".repeat(8001);
     const blocks = [{ type: "divider" }];
-    sendSlackMessage.mockResolvedValueOnce({ channelId: "controls" });
-    sendSlackMessage.mockResolvedValueOnce({ channelId: "content" });
+    sendSlackMessage.mockResolvedValueOnce({ channelId: "C123", messageId: "123.456" });
+    sendSlackMessage.mockResolvedValueOnce({ channelId: "C123", messageId: "123.457" });
 
     const result = await handleSlackAction(
       {
@@ -1143,9 +1158,13 @@ describe("handleSlackAction", () => {
     });
     expect(textOptions).not.toHaveProperty("blocks");
     expect(hasRepliedRef.value).toBe(true);
-    expect(result.details).toEqual({
+    expect(result.details).toMatchObject({
       ok: true,
-      result: { channelId: "content" },
+      result: {
+        channelId: "C123",
+        messageId: "123.457",
+        receipt: { platformMessageIds: ["123.456", "123.457"] },
+      },
     });
   });
 
@@ -1182,11 +1201,33 @@ describe("handleSlackAction", () => {
 
   it("delivers a prepared presentation plan in order on one resolved thread", async () => {
     const cfg = slackConfig();
-    const chartBlocks = [{ type: "data_visualization", title: "Revenue", chart: {} }];
+    const chartBlocks = [
+      { type: "data_visualization", title: "Revenue", chart: {} },
+      { type: "actions", elements: [{ type: "button", action_id: "question-choice" }] },
+    ];
     const controlBlocks = [{ type: "actions", elements: [] }];
     const hasRepliedRef = { value: false };
+    for (const [index, ids] of [["123.456"], ["123.457", "123.458"], ["123.459"]].entries()) {
+      sendSlackMessage.mockResolvedValueOnce({
+        channelId: "C123",
+        messageId: ids.at(-1),
+        ...(index === 0 ? { meta: { slackQuestionActionIds: ["question-choice"] } } : {}),
+        receipt: {
+          platformMessageIds: ids,
+          primaryPlatformMessageId: ids[0],
+          parts: ids.map((platformMessageId, partIndex) => ({
+            platformMessageId,
+            kind: index === 1 ? "text" : "card",
+            index: partIndex,
+            threadId: "1111111111.111111",
+          })),
+          threadId: "1111111111.111111",
+          sentAt: 123,
+        },
+      });
+    }
 
-    await handleSlackAction(
+    const result = await handleSlackAction(
       {
         action: "sendMessage",
         to: "channel:C123",
@@ -1227,6 +1268,29 @@ describe("handleSlackAction", () => {
       threadTs: "1111111111.111111",
     });
     expect(hasRepliedRef.value).toBe(true);
+    expect(result.details).toMatchObject({
+      ok: true,
+      result: {
+        channelId: "C123",
+        messageId: "123.459",
+        meta: {
+          slackQuestionActionIds: ["question-choice"],
+          slackQuestionMessageId: "123.456",
+        },
+        receipt: {
+          primaryPlatformMessageId: "123.456",
+          platformMessageIds: ["123.456", "123.457", "123.458", "123.459"],
+          parts: [
+            { platformMessageId: "123.456", kind: "card", index: 0 },
+            { platformMessageId: "123.457", kind: "text", index: 1 },
+            { platformMessageId: "123.458", kind: "text", index: 2 },
+            { platformMessageId: "123.459", kind: "card", index: 3 },
+          ],
+          threadId: "1111111111.111111",
+          sentAt: 123,
+        },
+      },
+    });
   });
 
   it.each([

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -32,6 +32,8 @@ import { resolveSlackChannelConfig } from "./monitor/channel-config.js";
 import { isSlackChannelAllowedByPolicy } from "./monitor/policy.js";
 import { hasSlackNativeDataBlock } from "./native-data-blocks.js";
 import type { SlackReplyDeliveryMessage } from "./reply-blocks.js";
+import { mergeSlackSendResults } from "./send-results.js";
+import type { SlackSendResult } from "./send.js";
 import { formatSlackTarget } from "./target-parsing.js";
 import { parseSlackTarget, resolveSlackChannelId, slackContextTargetsMatch } from "./targets.js";
 
@@ -633,6 +635,7 @@ export async function handleSlackAction(
     if (!isActionEnabled("messages")) {
       throw new Error("Slack messages are disabled.");
     }
+    const sentResults: SlackSendResult[] = [];
     const sendSlackMessage = async (
       target: string,
       content: string,
@@ -656,6 +659,7 @@ export async function handleSlackAction(
       if (replyReference) {
         replyReference.value = true;
       }
+      sentResults.push(result);
       return result;
     };
     switch (action) {
@@ -739,53 +743,38 @@ export async function handleSlackAction(
             blocks,
           });
         };
-        const result = preparedMessages?.length
-          ? await (async () => {
-              let lastResult:
-                | Awaited<ReturnType<typeof slackActionRuntime.sendSlackMessage>>
-                | undefined;
-              if (mediaUrl) {
-                lastResult = await sendSlackMessage(destination, "", {
-                  ...baseSendOpts,
-                  mediaUrl,
-                });
-              }
-              for (const [index, message] of preparedMessages.entries()) {
-                lastResult = await sendSlackMessage(destination, message.text, {
-                  ...baseSendOpts,
-                  ...(index === 0 && replyBroadcast ? { replyBroadcast: true } : {}),
-                  ...(message.blocks ? { blocks: message.blocks } : {}),
-                  ...(message.authoredTextPlacement
-                    ? { authoredTextPlacement: message.authoredTextPlacement }
-                    : {}),
-                  ...(Object.hasOwn(message, "nativeDataFallbackBaseText")
-                    ? { nativeDataFallbackBaseText: message.nativeDataFallbackBaseText }
-                    : {}),
-                  ...(message.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
-                });
-              }
-              if (!lastResult) {
-                throw new Error("Slack prepared message plan produced no delivery.");
-              }
-              return lastResult;
-            })()
-          : blocks
-            ? await (async () => {
-                if (mediaUrl) {
-                  await sendSlackMessage(destination, "", {
-                    ...sendOpts,
-                    mediaUrl,
-                  });
-                }
-                return await sendContentAndBlocks();
-              })()
-            : await sendSlackMessage(destination, content ?? "", {
-                ...sendOpts,
-                mediaUrl: mediaUrl ?? undefined,
-                blocks,
-              });
+        if (mediaUrl && (preparedMessages?.length || blocks)) {
+          await sendSlackMessage(destination, "", {
+            ...(preparedMessages?.length ? baseSendOpts : sendOpts),
+            mediaUrl,
+          });
+        }
+        if (preparedMessages?.length) {
+          for (const [index, message] of preparedMessages.entries()) {
+            await sendSlackMessage(destination, message.text, {
+              ...baseSendOpts,
+              ...(index === 0 && replyBroadcast ? { replyBroadcast: true } : {}),
+              ...(message.blocks ? { blocks: message.blocks } : {}),
+              ...(message.authoredTextPlacement
+                ? { authoredTextPlacement: message.authoredTextPlacement }
+                : {}),
+              ...(Object.hasOwn(message, "nativeDataFallbackBaseText")
+                ? { nativeDataFallbackBaseText: message.nativeDataFallbackBaseText }
+                : {}),
+              ...(message.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+            });
+          }
+        } else if (blocks) {
+          await sendContentAndBlocks();
+        } else {
+          await sendSlackMessage(destination, content ?? "", {
+            ...sendOpts,
+            mediaUrl: mediaUrl ?? undefined,
+            blocks,
+          });
+        }
 
-        return jsonResult({ ok: true, result });
+        return jsonResult({ ok: true, result: mergeSlackSendResults(sentResults) });
       }
       case "uploadFile": {
         const to = readStringParam(params, "to", { required: true });

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -1,7 +1,6 @@
 // Slack plugin module implements outbound adapter behavior.
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
 import {
-  createMessageReceiptFromOutboundResults,
   resolveOutboundSendDep,
   type OutboundIdentity,
 } from "openclaw/plugin-sdk/channel-outbound";
@@ -41,6 +40,7 @@ import {
   type SlackReplyBlockResolution,
   type SlackReplyBlockSegment,
 } from "./reply-blocks.js";
+import { mergeSlackSendResults } from "./send-results.js";
 import type { SlackSendIdentity, SlackSendResult } from "./send.js";
 import { parseSlackTarget } from "./target-parsing.js";
 import { resolveSlackThreadTsValue } from "./thread-ts.js";
@@ -337,47 +337,24 @@ export const slackOutbound: ChannelOutboundAdapter = {
             sentResults.push(result);
           },
           finalize: async () => {
-            let lastResult: Awaited<ReturnType<SlackSendFn>> | undefined;
             for (const message of deliveryMessages) {
-              lastResult = await sendSlackOutboundMessage({
-                ...ctx,
-                text: message.text,
-                ...(message.blocks ? { blocks: message.blocks } : {}),
-                ...(message.authoredTextPlacement
-                  ? { authoredTextPlacement: message.authoredTextPlacement }
-                  : {}),
-                ...(message.nativeDataFallbackBaseText
-                  ? { nativeDataFallbackBaseText: message.nativeDataFallbackBaseText }
-                  : {}),
-                ...(message.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
-                deliveryQueueId: useSingleDeliveryMarker ? ctx.deliveryQueueId : undefined,
-              });
-              sentResults.push(lastResult);
+              sentResults.push(
+                await sendSlackOutboundMessage({
+                  ...ctx,
+                  text: message.text,
+                  ...(message.blocks ? { blocks: message.blocks } : {}),
+                  ...(message.authoredTextPlacement
+                    ? { authoredTextPlacement: message.authoredTextPlacement }
+                    : {}),
+                  ...(message.nativeDataFallbackBaseText
+                    ? { nativeDataFallbackBaseText: message.nativeDataFallbackBaseText }
+                    : {}),
+                  ...(message.textIsSlackPlainText ? { textIsSlackPlainText: true } : {}),
+                  deliveryQueueId: useSingleDeliveryMarker ? ctx.deliveryQueueId : undefined,
+                }),
+              );
             }
-            if (!lastResult) {
-              throw new Error("Slack rendered presentation produced no deliverable segment");
-            }
-            if (sentResults.length === 1) {
-              return lastResult;
-            }
-            const receipt = createMessageReceiptFromOutboundResults({ results: sentResults });
-            receipt.parts = receipt.parts.map((part, index) => ({ ...part, index }));
-            const questionResult = sentResults.find(
-              (result) => result.meta?.slackQuestionActionIds.length,
-            );
-            return {
-              ...lastResult,
-              receipt,
-              ...(questionResult?.meta
-                ? {
-                    meta: {
-                      ...questionResult.meta,
-                      slackQuestionMessageId:
-                        questionResult.meta.slackQuestionMessageId ?? questionResult.messageId,
-                    },
-                  }
-                : {}),
-            };
+            return mergeSlackSendResults(sentResults);
           },
         }),
       ),

--- a/extensions/slack/src/send-results.ts
+++ b/extensions/slack/src/send-results.ts
@@ -1,0 +1,30 @@
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
+import type { SlackSendResult } from "./send.js";
+
+export function mergeSlackSendResults(results: readonly SlackSendResult[]): SlackSendResult {
+  const lastResult = results.at(-1);
+  if (!lastResult) {
+    throw new Error("Slack send plan produced no delivery.");
+  }
+  if (results.length === 1) {
+    return lastResult;
+  }
+  // A logical send can span media, rendered segments, and nested text chunks.
+  // Keep every accepted ID while retaining the legacy final-message scalar fields.
+  const receipt = createMessageReceiptFromOutboundResults({ results });
+  receipt.parts = receipt.parts.map((part, index) => ({ ...part, index }));
+  const questionResult = results.find((result) => result.meta?.slackQuestionActionIds.length);
+  return {
+    ...lastResult,
+    receipt,
+    ...(questionResult?.meta
+      ? {
+          meta: {
+            ...questionResult.meta,
+            slackQuestionMessageId:
+              questionResult.meta.slackQuestionMessageId ?? questionResult.messageId,
+          },
+        }
+      : {}),
+  };
+}


### PR DESCRIPTION
Closes #130604

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch; edits are available to repository maintainers.

</details>

## What Problem This Solves

Fixes an issue where users sending multipart reports with the Slack message tool received only the last message ID when the tool targeted the bare current channel in an Enterprise Grid conversation. All parts were delivered, but the model's receipt omitted earlier parts.

## Why This Change Was Made

Reuse one Slack-private receipt aggregator for the action path and core outbound adapter. It collects media, prepared presentation segments, and split text while preserving nested receipt metadata, thread placement, question-card identity, the legacy final-message fields, and unchanged single-message results. Existing send order, failure propagation, and first-accepted-delivery callbacks remain intact.

No auth, target-admission, SDK, configuration, or persistence contracts change. Production LOC: +82/-86 (net -4); tests: +77/-13 (net +64).

Provenance: the prepared-message fanout's last-result-only reduction dates to #104539 (code/PR author @steipete; merged by @steipete-oai on July 11, 2026). This change consolidates that action path with the existing outbound receipt owner rather than altering target selection.

## User Impact

Multipart Slack action sends now return every accepted message ID in order, so agents can refer back to the complete report. Threaded and single-message sends retain their existing behavior.

## Evidence

- Final regression tests against the original action owner: four missing-receipt failures, 107 controls passed. Final focused suite: 218 tests passed across action runtime, outbound adapter, channel routing, and reply-block preparation.
- Full changed gate passed, including extension/test types, typed lint, all three dead-export scans, and relevant repository guards. The runtime build passed.
- Real isolated Gateway + Slack SDK + mocked Slack HTTP/model services: the pre-fix native assertion saw two accepted IDs but only the last receipt ID. The final build passed bare multipart, workspace-qualified multipart, threaded multipart, and single-message cases; accepted IDs exactly matched receipt IDs and thread/workspace placement. This is mock-Gateway proof, not live Slack SaaS proof.
- Independent source review and authenticated Codex review found no actionable findings. The patch remained byte-identical through proof and review.
- An independent run passed 240 tests across the four Slack suites and the canonical receipt suite. A fresh source-blind validator passed all four native-flow cases: seven accepted messages, all seven IDs retained in receipts, and all nine chart blocks preserved. Native signed events carried the expected workspace and enterprise installation metadata; the fixture's pre-proxy acknowledgment is not the Gateway ingress evidence.

Focused command:

```sh
node scripts/run-vitest.mjs extensions/slack/src/action-runtime.test.ts extensions/slack/src/outbound-adapter.test.ts extensions/slack/src/channel.test.ts extensions/slack/src/reply-blocks.test.ts
```

```json
{"kind":"mock-gateway","passed":4,"acceptedMessages":7,"receiptIds":7,"chartBlocks":9,"cases":["bare multipart receipt","qualified target control","threaded multipart receipt","single-message control"]}
```

AI-assisted with Codex. Release-note context: retain complete receipts for multipart Slack message-tool sends.
