### PR TITLE
fix(cli): reject missing repeatable inference inputs

### DIFF
--- a/docs/cli/infer.md
+++ b/docs/cli/infer.md
@@ -101,6 +101,7 @@ A good infer-based skill maps common user intents to the right subcommand, inclu
 
 - Use `--json` when the output feeds another command or script; text output otherwise.
 - Use `--provider` or `--model provider/model` to pin a specific backend.
+- `image edit` and `image describe-many` require at least one `--file`; `embedding create` requires at least one `--text`. Repeat the flag for multiple inputs. Omitting it is a usage error, not an empty successful result, and no inference request is sent.
 - Use `model run --thinking <level>` for a one-shot thinking/reasoning override: `off`, `minimal`, `low`, `medium`, `high`, `adaptive`, `xhigh`, or `max`.
 - For `image describe`, `audio transcribe`, and `video describe`, `--model` must use the form `<provider/model>`.
 - For `image describe`, `--file` accepts local paths and HTTP(S) URLs; remote URLs go through the normal media-fetch SSRF policy.

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -568,6 +568,32 @@ vi.mock("../plugins/web-search-providers.runtime.js", () => ({
 }));
 
 describe("capability cli", () => {
+  it.each(
+    [
+      { args: ["image", "edit", "--prompt", "crop the image"], option: "--file <path>" },
+      { args: ["image", "describe-many"], option: "--file <path>" },
+      { args: ["embedding", "create"], option: "--text <text>" },
+    ].flatMap(({ args, option }) =>
+      ["infer", "capability"].map((root) => ({ args, option, root })),
+    ),
+  )("rejects missing required repeatable input for $root $args", async ({ root, args, option }) => {
+    const argv = [root, ...args, "--json"];
+    const program = new Command().exitOverride().configureOutput({ writeErr: () => {} });
+    await registerCapabilityCli(program, ["node", "openclaw", ...argv]);
+
+    await expect(
+      program.parseAsync(argv, { from: "user" }).then(() => undefined),
+    ).rejects.toMatchObject({
+      code: "commander.missingMandatoryOptionValue",
+      message: `error: required option '${option}' not specified`,
+    });
+    expect(mocks.resolveCommandConfigWithSecrets).not.toHaveBeenCalled();
+    expect(mocks.generateImage).not.toHaveBeenCalled();
+    expect(mocks.describeImageFile).not.toHaveBeenCalled();
+    expect(mocks.createEmbeddingProvider).not.toHaveBeenCalled();
+    expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.unstubAllEnvs();
@@ -2417,6 +2443,8 @@ describe("capability cli", () => {
       "edit",
       "--file",
       inputPath,
+      "--file",
+      inputPath,
       "--prompt",
       "make three variants",
       "--count",
@@ -2425,6 +2453,7 @@ describe("capability cli", () => {
     );
 
     expect(firstImageGenerationCall()?.count).toBe(3);
+    expect(firstImageGenerationCall()?.inputImages).toHaveLength(2);
   });
 
   it("rejects unsupported image output format and background hints", async () => {
@@ -3678,15 +3707,20 @@ describe("capability cli", () => {
   );
 
   it("uses only embedding providers for embedding creation", async () => {
-    await runCapability("embedding", "create", "--text", "hello", "--json");
+    await runCapability("embedding", "create", "--text", "hello", "--text", "world", "--json");
 
     expect(firstEmbeddingProviderCall()?.provider).toBe("auto");
     expect(firstEmbeddingProviderCall()?.fallback).toBe("none");
     expect(firstJsonOutput()?.capability).toBe("embedding.create");
     expect(firstJsonOutput()?.provider).toBe("openai");
     expect(firstJsonOutput()?.model).toBe("text-embedding-3-small");
-    expect(firstJsonOutput()).toMatchObject({ outputs: [{ embedding: [0.1, 0.2] }] });
-    expect(mocks.embedBatch).toHaveBeenCalledWith(["hello"], { inputType: "document" });
+    expect(firstJsonOutput()).toMatchObject({
+      outputs: [
+        { text: "hello", embedding: [0.1, 0.2] },
+        { text: "world", embedding: [0.1, 0.2] },
+      ],
+    });
+    expect(mocks.embedBatch).toHaveBeenCalledWith(["hello", "world"], { inputType: "document" });
     expect(closeEmbeddingProviderMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/cli/capability-cli/embedding.ts
+++ b/src/cli/capability-cli/embedding.ts
@@ -111,7 +111,7 @@ export function registerEmbeddingCapabilityCommands(capability: Command): void {
   embedding
     .command("create")
     .description("Create embeddings")
-    .requiredOption("--text <text>", "Input text", collectOption, [])
+    .requiredOption("--text <text>", "Input text", collectOption)
     .option("--provider <id>", "Provider id")
     .option("--model <provider/model>", "Model override")
     .option(

--- a/src/cli/capability-cli/image.ts
+++ b/src/cli/capability-cli/image.ts
@@ -366,7 +366,7 @@ export function registerImageCapabilityCommands(capability: Command): void {
     image
       .command("edit")
       .description("Edit images with one or more input files")
-      .requiredOption("--file <path>", "Input file", collectOption, [])
+      .requiredOption("--file <path>", "Input file", collectOption)
       .requiredOption("--prompt <text>", "Prompt text"),
   ).action(async (opts, command) => {
     await runCommandWithRuntime(defaultRuntime, async () => {
@@ -410,7 +410,7 @@ export function registerImageCapabilityCommands(capability: Command): void {
   image
     .command("describe-many")
     .description("Describe multiple image files")
-    .requiredOption("--file <path>", "Image file", collectOption, [])
+    .requiredOption("--file <path>", "Image file", collectOption)
     .option("--prompt <text>", "Prompt hint")
     .option("--model <provider/model>", "Model override")
     .option("--timeout-ms <ms>", "Provider request timeout in milliseconds")


### PR DESCRIPTION
Closes #130607

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where operators omitting required repeatable inference inputs could receive successful empty output or reach a provider operation instead of a usage error. It affects `image edit`, `image describe-many`, and `embedding create`, through both `infer` and `capability`.

## Why This Change Was Made

Remove three redundant empty-array option defaults so Commander can enforce the existing required-input contract. The canonical collector already initializes and preserves repeated values; no extra handler guard or parallel validation path is needed. Optional inputs, provider routing, authentication, and persistence are unchanged.

Production LOC: +3/-3 (net zero). Tests: +37/-3. Docs: +1/-0. AI-assisted.

## User Impact

Omitted `--file`/`--text` now exits 1 with the exact missing flag and command-specific help. JSON callers receive the canonical `ok:false` / `cli_error` envelope. Valid one-input and repeated-input behavior is preserved. The inference CLI reference now states this requirement explicitly.

## Evidence

- Pre-edit real Commander regressions failed for all three commands under both aliases; the three repeated-input controls passed.
- Four actual built CLI baseline cases reproduced exit-0 empty success for `image describe-many` under both aliases in text/JSON modes.
- The same repaired boundary passed all six missing-input regressions and all repeated-input controls. Full focused suite: 198 tests across command behavior, lazy registration, and shared parser helpers.
- Twelve actual built CLI cases (three commands, both aliases, text/JSON) all exited 1 with the correct missing option, recovery hint, and JSON envelope. Isolated fixture state was cleaned; no provider credentials or live-provider claim.
- An independent verifier reran all 198 focused tests and 38 actual built-CLI checks on the unchanged patch: all passed, including missing inputs, help, missing values, and single/repeated input acceptance.
- A source-blind validator passed all seven prewritten behavior clauses using 54 actual CLI invocations: 16 missing-input cases, 16 flags without values, eight help cases, and 14 safe positive parser controls. Both aliases and text/JSON renderers were exercised with fresh varied values; no timeouts or behavioral findings. Positive controls prove parser acceptance only, not live inference.
- Baseline and repaired `cliStartup` builds passed. The complete changed-file gate, Oxfmt, and `git diff --check` passed.
- Fresh authenticated Codex whole-patch review, including complete affected owners/callers/siblings/tests/docs and reproduction evidence: zero actionable P0-P2 findings.

The first local changed gate found a missing UI importer dependency link, resolving root transitive pako 1.0.11 instead of UI's pinned 3.0.1. The link was repaired using the already-installed exact dependency donor, without package changes or validation waivers. The next pass caught a lint issue in the new test table; its direct projection was corrected, the targeted regressions passed again, and the final complete gate and refreshed whole-patch review passed. Independent and source-blind verification used the same final source bytes.
