### PR TITLE
refactor(test): avoid setup discovery in native command checks

### DIFF
--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.test.ts
@@ -79,6 +79,12 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    cliBackendsTesting.setDepsForTest({
+      resolveRuntimeCliBackends: () => [{ id: "claude-cli", modelProvider: "anthropic" }] as never,
+      resolvePluginSetupCliBackend: () => {
+        throw new Error("native command attempted synchronous CLI setup discovery");
+      },
+    });
     vi.spyOn(preparedModelCatalog, "loadPreparedModelCatalogSnapshot").mockResolvedValue({
       entries: [
         {
@@ -429,15 +435,6 @@ describe("maybeResolveNativeSlashCommandFastReply", () => {
         ("targetAgentId" in testCase ? testCase.targetAgentId : undefined) ?? "main";
       const resolvedModel = "resolvedModel" in testCase ? testCase.resolvedModel : undefined;
       const targetSessionKey = `agent:${targetAgentId}:main`;
-      if ("hasBoundCli" in testCase) {
-        cliBackendsTesting.setDepsForTest({
-          resolveRuntimeCliBackends: () =>
-            [{ id: "claude-cli", modelProvider: "anthropic" }] as never,
-          resolvePluginSetupCliBackend: () => {
-            throw new Error("approved bound CLI attempted synchronous setup discovery");
-          },
-        });
-      }
       const storePath = path.join(tempDirs.make("openclaw-native-source-"), "sessions.json");
       await replaceSessionEntry(
         { agentId: targetAgentId, sessionKey: targetSessionKey, storePath },


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in the base repository; maintainers with repository write access can edit it.

</details>

## What Problem This Solves

Resolves a problem where the native `/compact` context-selection test can spend minutes in plugin setup discovery before checking the selected model's context budget.

## Why This Change Was Made

Share the existing registered CLI metadata fixture across the native slash-command suite instead of installing it only for one later bound-CLI case. The context-selection regression intentionally selects a CLI runtime; its metadata belongs in the fixture, while plugin activation and setup fallback belong to their dedicated owner tests. The existing guard rejects unexpected setup discovery, and per-test cleanup is unchanged.

## User Impact

No user-visible or production behavior changes. Developers retain all 52 cases and their assertions, including full model selection, the explicit CLI runtime override, persisted session overrides, authorization checks, and the selected model's context budget. Dedicated CLI-backend and session-runtime compatibility tests retain setup fallback and missing-runtime coverage. Production delta is 0; test diff is +6/-9, net -3 lines.

## Evidence

- Before the change, a temporary diagnostic kept the real runtime-registry getter and measured the real setup resolver before deliberately rejecting that call. In the full original file order, the context-selection case was the only failure; the other 51 cases passed. The setup lookup itself took 175,407.25 ms. The diagnostic is not part of this patch.
- After sharing the existing fixture, all 52 cases passed in their original order without entering setup discovery. The context-selection case took 1,588 ms; its assertions and timeout were unchanged.
- Both owner test files passed: `src/agents/cli-backends.test.ts` and `src/agents/session-runtime-compat.test.ts`, 26 tests total.
- Focused formatting, lint, and `git diff --check` passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33033641665) passed on its first attempt, including all 52 jobs and the required validation gate.

These timings attribute the observed local stall to setup discovery; they do not prove that every earlier hosted timeout had the same cause or attribute whole-suite startup time to this fixture.

P2 autoreview and independent final review completed with no actionable findings.

Candidate head: `bea2aae4a999a51e7c7597643e458c3f12c3bbc4`. Exact-head hosted CI and context/evidence validation passed. Native preparation remains required before merge.
