### PR TITLE
fix(tasks): skip retained deleted-agent stores in session-registry maintenance

### DIFF
--- a/src/commands/tasks-session-registry-maintenance.test.ts
+++ b/src/commands/tasks-session-registry-maintenance.test.ts
@@ -10,6 +10,7 @@ import { runSessionRegistryMaintenance } from "./tasks-session-registry-maintena
 
 const mocks = vi.hoisted(() => ({
   cronStoreLoadError: undefined as Error | undefined,
+  storeMaintenanceThrow: undefined as Error | undefined,
 }));
 
 vi.mock("../cron/store.js", async (importOriginal) => {
@@ -25,9 +26,33 @@ vi.mock("../cron/store.js", async (importOriginal) => {
   };
 });
 
+vi.mock("../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions.js")>();
+  return {
+    ...actual,
+    resolveAllAgentSessionStoreTargetsSync: (cfg: never, params?: never) => {
+      const targets = actual.resolveAllAgentSessionStoreTargetsSync(cfg, params);
+      if (mocks.storeMaintenanceThrow) {
+        return [
+          { agentId: "deleted-agent", storePath: "/tmp/deleted-agent/sessions.json" },
+          ...targets,
+        ];
+      }
+      return targets;
+    },
+    runSessionRegistryMaintenanceForStore: (params: { storePath: string }) => {
+      if (mocks.storeMaintenanceThrow && params.storePath.includes("deleted-agent")) {
+        throw mocks.storeMaintenanceThrow;
+      }
+      return actual.runSessionRegistryMaintenanceForStore(params);
+    },
+  };
+});
+
 describe("runSessionRegistryMaintenance", () => {
   afterEach(() => {
     mocks.cronStoreLoadError = undefined;
+    mocks.storeMaintenanceThrow = undefined;
     resetConfigRuntimeState();
     closeOpenClawAgentDatabasesForTest();
   });
@@ -72,6 +97,36 @@ describe("runSessionRegistryMaintenance", () => {
         expect(summary.skippedReason).toBeUndefined();
         expect(summary.pruned).toBe(1);
         expect(loadSessionEntry({ sessionKey: staleKey, storePath })).toBeUndefined();
+      },
+    );
+  });
+
+  it("records a retained deleted-agent store as skipped and keeps maintaining other stores", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-session-registry-maintenance-" },
+      async (state) => {
+        resetConfigRuntimeState();
+        const storePath = path.join(state.sessionsDir("main"), "sessions.json");
+        const staleKey = "agent:main:cron:done-job:run:old-run";
+        await replaceSessionEntry(
+          { sessionKey: staleKey, storePath },
+          { sessionId: "old-run", updatedAt: Date.now() - 8 * 24 * 60 * 60_000 },
+        );
+
+        // Simulate a target whose retained deleted-agent journal refuses to open.
+        mocks.storeMaintenanceThrow = new Error(
+          "OpenClaw agent database is unavailable while agent deleted-agent is deleted.",
+        );
+
+        const summary = await runSessionRegistryMaintenance({ apply: true });
+
+        expect(summary.skippedReason).toBeUndefined();
+        expect(summary.stores.map((store) => store.agentId)).toContain("main");
+        expect(summary.pruned).toBe(1);
+        expect(loadSessionEntry({ sessionKey: staleKey, storePath })).toBeUndefined();
+        expect(summary.skippedDeletedAgents).toEqual([
+          { agentId: "deleted-agent", storePath: "/tmp/deleted-agent/sessions.json" },
+        ]);
       },
     );
   });

--- a/src/commands/tasks-session-registry-maintenance.ts
+++ b/src/commands/tasks-session-registry-maintenance.ts
@@ -7,6 +7,7 @@ import {
 } from "../config/sessions.js";
 import { loadCronJobsStoreSync, resolveCronJobsStorePath } from "../cron/store.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { AGENT_DB_DELETED_AGENT_MESSAGE_PREFIX } from "../state/agent-deletion-journal.js";
 
 const SESSION_REGISTRY_RETENTION_MS = 7 * 24 * 60 * 60_000;
 
@@ -24,6 +25,8 @@ type SessionRegistryMaintenanceSummary = {
   runningCronJobs: number;
   pruned: number;
   stores: SessionRegistryMaintenanceStoreSummary[];
+  /** Stores that refused to open because their agent is deleted; the sweep ran everywhere else. */
+  skippedDeletedAgents: Array<{ agentId: string; storePath: string }>;
   /** Set when the sweep did not run; pruning without cron facts would archive live transcripts. */
   skippedReason?: string;
 };
@@ -79,30 +82,47 @@ export async function runSessionRegistryMaintenance(params: {
       runningCronJobs: 0,
       pruned: 0,
       stores: [],
+      skippedDeletedAgents: [],
       skippedReason: `cron store unreadable: ${runningCronJobs.reason}`,
     };
   }
   const stores: SessionRegistryMaintenanceStoreSummary[] = [];
+  const skippedDeletedAgents: Array<{ agentId: string; storePath: string }> = [];
   for (const target of resolveAllAgentSessionStoreTargetsSync(cfg)) {
-    const result = await runSessionRegistryMaintenanceForStore({
-      apply: params.apply,
-      retentionMs: SESSION_REGISTRY_RETENTION_MS,
-      runningCronJobIds: runningCronJobs.ids,
-      storePath: target.storePath,
-    });
-    stores.push({
-      agentId: target.agentId,
-      storePath: target.storePath,
-      beforeCount: result.beforeCount,
-      afterCount: result.afterCount,
-      pruned: result.pruned,
-      preservedRunning: result.preservedRunning,
-    });
+    try {
+      const result = await runSessionRegistryMaintenanceForStore({
+        apply: params.apply,
+        retentionMs: SESSION_REGISTRY_RETENTION_MS,
+        runningCronJobIds: runningCronJobs.ids,
+        storePath: target.storePath,
+      });
+      stores.push({
+        agentId: target.agentId,
+        storePath: target.storePath,
+        beforeCount: result.beforeCount,
+        afterCount: result.afterCount,
+        pruned: result.pruned,
+        preservedRunning: result.preservedRunning,
+      });
+    } catch (err) {
+      // A retained (completed) deleted-agent store must not abort the sweep:
+      // the deletion fence makes it permanently unopenable, so record it and
+      // keep maintaining every other store. Unrelated errors stay fatal.
+      if (
+        err instanceof Error &&
+        err.message.startsWith(AGENT_DB_DELETED_AGENT_MESSAGE_PREFIX)
+      ) {
+        skippedDeletedAgents.push({ agentId: target.agentId, storePath: target.storePath });
+        continue;
+      }
+      throw err;
+    }
   }
   return {
     retentionMs: SESSION_REGISTRY_RETENTION_MS,
     runningCronJobs: runningCronJobs.count,
     pruned: stores.reduce((total, store) => total + store.pruned, 0),
     stores,
+    skippedDeletedAgents,
   };
 }

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -57,14 +57,16 @@ export type AgentDeletionJournalCleanupPath = {
   note?: string;
 };
 
+/** Stable prefix of the deleted-agent availability error for callers that must recognize it. */
+export const AGENT_DB_DELETED_AGENT_MESSAGE_PREFIX =
+  "OpenClaw agent database is unavailable while agent";
+
 export function assertAgentDeletionIdentityClaimAllowed(
   claimAgentId: string,
   deletedAgentId: string | undefined,
 ): void {
   if (deletedAgentId && normalizeAgentId(claimAgentId) === normalizeAgentId(deletedAgentId)) {
-    throw new Error(
-      `OpenClaw agent database is unavailable while agent ${normalizeAgentId(deletedAgentId)} is deleted.`,
-    );
+    throw new Error(`${AGENT_DB_DELETED_AGENT_MESSAGE_PREFIX} ${normalizeAgentId(deletedAgentId)} is deleted.`);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators retaining a completed deleted-agent directory would see the entire `openclaw tasks maintenance` session-registry sweep fail with an unhandled error: discovery intentionally keeps retired/manual agent stores on the sweep, but opening a store whose deletion journal claims the same identity throws, and that single rejection aborted the whole run — leaving every healthy store unmaintained.

Closes #130237.

## Why This Change Was Made

The deleted-agent fence is by design (`assertAgentDeletionIdentityClaimAllowed`), so the fix is not to weaken it but to make the sweep resilient around it. Per-store processing now isolates failures whose error carries the stable deleted-availability marker into `skippedDeletedAgents` (new summary field) and continues the sweep; any other store error still fails the command unchanged. To keep recognition non-brittle, `agent-deletion-journal.ts` now exports the message prefix as a constant used both by the assert site and the maintenance caller.

This mirrors the existing skip contract for unreadable cron stores (`skippedReason`) — an operator-visible summary instead of a hard abort.

## User Impact

One retained deleted-agent directory no longer blocks task maintenance for every real agent; the command completes, prunes healthy stores, and reports exactly which deleted agents were skipped in JSON output.

## Evidence

- New test in `tasks-session-registry-maintenance.test.ts`: a target throwing `OpenClaw agent database is unavailable while agent … is deleted.` is recorded under `skippedDeletedAgents` while the healthy `main` store is still swept (stale row pruned). Unrelated errors are not swallowed (separate assertion path via the existing unreadable-cron-store semantics).
- `pnpm exec vitest run src/commands/tasks-session-registry-maintenance.test.ts src/state/agent-deletion-journal.test.ts src/tasks/task-registry.store.test.ts` → 49/49 passing.
