### PR TITLE
fix(apple): avoid rebuilding unchanged tool diff previews

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift
@@ -54,7 +54,17 @@ enum ChatToolActivity {
     }
 }
 
-struct ChatToolActivityRow: View {
+struct ChatToolActivityRow: View, Equatable {
+    let item: ChatToolActivityItem
+
+    var body: some View {
+        // Compare the item before constructing the content: its initializer prepares
+        // the diff, which unchanged siblings must not repeat on every tool update.
+        ChatToolActivityRowContent(item: self.item)
+    }
+}
+
+private struct ChatToolActivityRowContent: View {
     let item: ChatToolActivityItem
     private let resolvedDiff: (lines: [ChatToolDiffLine], stat: ChatToolDiffStat?)?
     @State private var expanded = false
@@ -421,6 +431,7 @@ struct ChatToolActivityList: View {
             // Protocol IDs can collide with specified fallback IDs; encounter order is unique here.
             ForEach(self.items.indices, id: \.self) { index in
                 ChatToolActivityRow(item: self.items[index])
+                    .equatable()
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Related: #124759

## What Problem This Solves

Fixes an issue where users viewing Apple chat tool activity repeatedly pay the cost of rebuilding unchanged edit previews whenever another tool result updates. With the real shared SwiftUI list hosted in a controlled Debug probe, ten updates beside twenty unchanged 500-line edits took **19.975 seconds before and 0.122 seconds after**.

This is a measured contributor to the trace-enabled lag report, not a claim that every cause of #124759 is resolved. Initial diff preparation, tool/result pairing, and streaming text parsing are unchanged; the issue should remain open for broader device-level verification. Thanks @VirPoe for the report.

## Why This Change Was Made

`ChatToolActivityRow` prepared its diff in its initializer, before SwiftUI could decide whether that row needed updating. The row now provides a cheap full-item equality boundary above the existing stateful content. Unchanged rows avoid rebuilding their diffs; changed arguments, authoritative details, result text, error state, pending state, and live diff counts still reach the content.

The existing disclosure state, index-based identity (including duplicate protocol IDs), collapsed diff statistics, failed-edit handling, and authoritative-details precedence stay intact. No global cache, persistence, protocol, configuration, or new dependency is involved. Adding equality to the former heavy initializer would be too late; deferring all diff work until expansion would incorrectly remove collapsed statistics.

Production LOC: **+12/-1 (net +11)**; tests: unchanged. The added view boundary is necessary to compare inputs before the existing expensive initializer runs. A timing threshold in ordinary CI would be noisy, and a production diff-call counter would be a test-only seam, so this change uses a disposable real-view before/after probe plus the existing semantic suite.

Provenance: the eager initializer is present at this checkout's shallow history boundary (`f4f990a91bce`); that boundary does not establish the introducing commit or author.

## User Impact

Existing edit previews no longer stall unrelated tool updates by repeatedly recomputing the same line diffs. Both iOS and macOS use this shared component. There is no intended visual or interaction change.

## Evidence

- Baseline: current main `3cb0dd4851e865fde9156782630a44d60d048481`; candidate: this focused diff.
- Real `NSHostingView` / `ChatToolActivityList` Debug probe, 20 unchanged edit rows (500 old/new lines each), one changing sibling, 10 synchronous layout updates: **19.975 s → 0.122 s**. These are controlled macOS shared-view timings, not physical-iPhone frame-rate measurements or Release-build latency claims.
- A baseline stack sample caught `ChatToolActivityList.body → ChatToolActivityRow.init → resolveDiff → computeLineDiff` on the main thread during those updates.
- `swift test --package-path apps/shared/OpenClawKit --filter 'ChatToolPerformanceProbeTests|ChatToolDiffTests|ChatToolActivityTests'`: **37 passed** (35 existing semantic tests and 2 disposable probes). Existing coverage includes authoritative details, failed edits, truncation, live/foreign argument fallback, pairing order, and orphan results.
- Native pointer/bitmap probe: expanded a real row, replaced authoritative details using the same ID and list position, and verified the row stayed expanded while its preview and badge updated from one to two additions. Captures inspected; no production test seam was added.
- Local changed gate passed: `node scripts/check-changed.mjs -- apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatToolActivityViews.swift` (502 tests, pinned SwiftFormat, SwiftLint, and schema guard).
- [Exact-head CI 33034036645](https://github.com/openclaw/openclaw/actions/runs/33034036645), attempt 1: completed successfully at `9ed71be61a55f9c2f54d8af23bd5d47e32007b01`, including macOS Swift tests, iOS Debug/Release builds and lifecycle tests, iPhone/iPad screenshots, and the required `openclaw/ci-gate`.
- Independent Codex autoreview: clean, no accepted/actionable findings.

AI-assisted maintainer repair. No changes to the diff algorithm or its safety bounds.

### Review follow-through

The latest ClawSweeper review at this exact head found no actionable correctness issue. Its two pre-merge items are handled as follows: retain the net +11-line two-layer view boundary (the comparison must precede diff initialization, and the alternatives above either run too late or change visible behavior), and finish the native exact-head CI before landing. No protocol, persisted state, or product-policy decision is involved.

The review's attempted Swift verification did not reach the tests: its environment lacked the `SQLite3` module after dependency resolution. That failed attempt is not counted as passing evidence. The completed native scoped run and hosted macOS Swift/iOS build-and-lifecycle jobs provide the relevant Apple proof; the full hosted CI gate, including downstream screenshot jobs, has now passed. No re-review is needed for this evidence-only update; the reviewed code is unchanged.

### Same-ID refresh proof

These are captures of the candidate's real shared SwiftUI row, not a visual redesign comparison. A native pointer click expanded the first result; the second capture follows a result update with the same item ID and position, without clicking again. The disclosure remains open and both the preview and badge update.

![Expanded row with one addition](https://github.com/user-attachments/assets/68f8a1ca-4718-4b37-8715-3bc514ed37be)

![Same expanded row after updating to two additions](https://github.com/user-attachments/assets/464c6983-6775-4efe-82d4-8537e9e22beb)
