### PR TITLE
fix(compaction): show the summarizer the audited latest ask

### DIFF
--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -365,11 +365,36 @@ describe("session-entry compaction budgeting", () => {
     expect(preparation.value).toMatchObject({
       firstKeptEntryId: "entry-3",
       isSplitTurn: true,
+      splitTurnCompleted: true,
       tokensBefore: 10,
       turnPrefixMessages: [{ role: "user" }, { role: "assistant" }],
     });
     expect(JSON.stringify(preparation.value)).not.toContain("private output");
     expect(JSON.stringify(entries)).toContain("private output");
+  });
+
+  it("binds split-turn completion to the cut turn instead of a newer retained turn", () => {
+    const entries: SessionTreeEntry[] = [
+      createMessageEntry({ role: "user", content: "boundary request", timestamp: 1 }, 0),
+      createMessageEntry(createAssistant("boundary complete", createUsage(10), 2), 1),
+      createMessageEntry({ role: "user", content: "newer unresolved request", timestamp: 3 }, 2),
+    ];
+
+    const preparation = prepareCompaction(entries, {
+      enabled: true,
+      reserveTokens: 0,
+      keepRecentTokens: 8,
+    });
+
+    expect(preparation.ok).toBe(true);
+    if (!preparation.ok || !preparation.value) {
+      throw new Error("expected the boundary turn to be split");
+    }
+    expect(preparation.value).toMatchObject({
+      firstKeptEntryId: "entry-1",
+      isSplitTurn: true,
+      splitTurnCompleted: true,
+    });
   });
 
   it("applies the shared common-CJK budget heuristic", () => {

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -712,6 +712,8 @@ export interface CompactionPreparation {
   turnPrefixMessages: AgentMessage[];
   /** Whether compaction splits a turn. */
   isSplitTurn: boolean;
+  /** Explicit terminal state of the turn whose prefix was split from its retained suffix. */
+  splitTurnCompleted?: boolean;
   /** Estimated context tokens before compaction. */
   tokensBefore: number;
   /** Previous compaction summary used for iterative updates. */
@@ -722,6 +724,24 @@ export interface CompactionPreparation {
   fileOps: FileOperations;
   /** Settings used to prepare compaction. */
   settings: CompactionSettings;
+}
+
+function latestUserTurnCompleted(messages: AgentMessage[]): boolean {
+  let sawTurnTail = false;
+  let completed = false;
+  for (const message of messages.toReversed()) {
+    if (message.role === "user") {
+      return completed;
+    }
+    if (!sawTurnTail && (message.role === "assistant" || message.role === "toolResult")) {
+      sawTurnTail = true;
+      completed =
+        message.role === "assistant" &&
+        message.stopReason === "stop" &&
+        message.content.some((block) => block.type === "text" && block.text.trim().length > 0);
+    }
+  }
+  return false;
 }
 
 /** Prepare session entries for compaction, or return undefined when compaction is not applicable. */
@@ -833,12 +853,23 @@ export function prepareCompaction(
     }
   }
   const turnPrefixMessages: AgentMessage[] = [];
+  const retainedTurnSuffixMessages: AgentMessage[] = [];
   if (cutPoint.isSplitTurn) {
     for (let i = cutPoint.turnStartIndex; i < cutPoint.firstKeptEntryIndex; i++) {
       const entry = effectiveEntries.at(i);
       const msg = entry ? getMessageFromEntryForCompaction(entry) : undefined;
       if (msg) {
         turnPrefixMessages.push(msg);
+      }
+    }
+    for (let i = cutPoint.firstKeptEntryIndex; i < boundaryEnd; i++) {
+      const entry = effectiveEntries.at(i);
+      if (!entry || (i > cutPoint.firstKeptEntryIndex && isTurnStartEntry(entry))) {
+        break;
+      }
+      const msg = getMessageFromEntryForCompaction(entry);
+      if (msg) {
+        retainedTurnSuffixMessages.push(msg);
       }
     }
   }
@@ -857,6 +888,14 @@ export function prepareCompaction(
     messagesToSummarize,
     turnPrefixMessages,
     isSplitTurn: cutPoint.isSplitTurn,
+    ...(cutPoint.isSplitTurn
+      ? {
+          splitTurnCompleted: latestUserTurnCompleted([
+            ...turnPrefixMessages,
+            ...retainedTurnSuffixMessages,
+          ]),
+        }
+      : {}),
     tokensBefore,
     previousSummary,
     previousSummaryDetails,

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -130,6 +130,13 @@ function parseRequiredSummarySectionContents(summary: string): string[] | null {
   return contents.map((lines) => lines.join("\n").trim());
 }
 
+function parsePendingUserAskSections(summary: string): string[] {
+  return summary
+    .split(/^## Pending user asks[ \t]*$/gmu)
+    .slice(1)
+    .map((section) => section.split(/^##[ \t]+\S.*$/mu, 1)[0]?.trim() ?? "");
+}
+
 /**
  * Plan truncation that keeps the audit facts and lets everything else shrink.
  * Only the headings, the bounded latest-ask context, and the audited source
@@ -400,6 +407,7 @@ function hasAskOverlap(summary: string, latestAsk: string | null): boolean {
 export function auditSummaryQuality(params: {
   summary: string;
   structuralSummary: string;
+  completionSummary?: string;
   identifiers: string[];
   latestAsk: string | null;
   latestAskCompleted?: boolean;
@@ -425,9 +433,10 @@ export function auditSummaryQuality(params: {
     reasons.push("latest_user_ask_not_reflected");
   }
   if (params.latestAskCompleted) {
-    const sectionContents = parseRequiredSummarySectionContents(params.structuralSummary);
-    const pendingAsks = sectionContents?.[PENDING_ASK_SECTION_INDEX] ?? "";
-    if (hasAskOverlap(pendingAsks, params.latestAsk)) {
+    const pendingAskSections = parsePendingUserAskSections(
+      params.completionSummary ?? params.structuralSummary,
+    );
+    if (pendingAskSections.some((pendingAsks) => hasAskOverlap(pendingAsks, params.latestAsk))) {
       reasons.push("completed_latest_user_ask_marked_pending");
     }
   }

--- a/src/agents/agent-hooks/compaction-safeguard-quality.ts
+++ b/src/agents/agent-hooks/compaction-safeguard-quality.ts
@@ -70,6 +70,7 @@ export function buildCompactionStructureInstructions(
     ...REQUIRED_SUMMARY_SECTIONS,
     identifierSectionInstruction,
     "Do not omit unresolved asks from the user.",
+    "Record completed requests outside ## Pending user asks; list only unresolved user requests there.",
     "When prior compaction summaries are present, re-distill them with new messages and remove stale duplicate detail.",
   ].join("\n");
   const custom = customInstructions?.trim();
@@ -144,6 +145,7 @@ export function createSummaryQualityRetentionPlan(
     auditSummary?: string;
     identifiers: string[];
     latestAsk: string | null;
+    latestAskCompleted?: boolean;
     requiredAskContext?: string;
     identifierPolicy?: CompactionSummarizationInstructions["identifierPolicy"];
   },
@@ -162,9 +164,13 @@ export function createSummaryQualityRetentionPlan(
   const marker = truncatedMarker.trim();
   // Protected tails render after each section's optional content so the audit
   // facts survive regardless of how much model text the budget keeps.
+  const protectedAskSectionIndex = params.latestAskCompleted ? 0 : PENDING_ASK_SECTION_INDEX;
+  const protectedAskContext = params.latestAskCompleted
+    ? `Latest turn completed:\n${requiredAskContext}`
+    : requiredAskContext;
   const protectedTails = REQUIRED_SUMMARY_SECTIONS.map((_, index) =>
-    index === PENDING_ASK_SECTION_INDEX
-      ? requiredAskContext
+    index === protectedAskSectionIndex
+      ? protectedAskContext
       : index === EXACT_IDENTIFIERS_SECTION_INDEX
         ? auditedIdentifiers.join("\n")
         : "",
@@ -396,6 +402,7 @@ export function auditSummaryQuality(params: {
   structuralSummary: string;
   identifiers: string[];
   latestAsk: string | null;
+  latestAskCompleted?: boolean;
   identifierPolicy?: CompactionSummarizationInstructions["identifierPolicy"];
 }): { ok: boolean; reasons: string[] } {
   const reasons: string[] = [];
@@ -416,6 +423,13 @@ export function auditSummaryQuality(params: {
   }
   if (!hasAskOverlap(params.summary, params.latestAsk)) {
     reasons.push("latest_user_ask_not_reflected");
+  }
+  if (params.latestAskCompleted) {
+    const sectionContents = parseRequiredSummarySectionContents(params.structuralSummary);
+    const pendingAsks = sectionContents?.[PENDING_ASK_SECTION_INDEX] ?? "";
+    if (hasAskOverlap(pendingAsks, params.latestAsk)) {
+      reasons.push("completed_latest_user_ask_marked_pending");
+    }
   }
   return { ok: reasons.length === 0, reasons };
 }

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2751,6 +2751,60 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
   });
 
+  it("retries a split-turn summary that revives a completed request", async () => {
+    mockSummarizeInStages.mockReset();
+    const latestAsk = "combine the provider boxes into one completed artifact";
+    const identifier = "/tmp/pr130620/live/marker";
+    const structuredSummary = (pendingAsk: string) =>
+      [
+        "## Decisions",
+        `${latestAsk} was completed.`,
+        "## Open TODOs",
+        "None.",
+        "## Constraints/Rules",
+        "Preserve exact identifiers.",
+        "## Pending user asks",
+        pendingAsk,
+        "## Exact identifiers",
+        identifier,
+      ].join("\n");
+    mockSummarizeInStages
+      .mockResolvedValueOnce(summaryResult(structuredSummary(latestAsk)))
+      .mockResolvedValueOnce(summaryResult(structuredSummary("None.")));
+
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model: createAnthropicModelFixture(),
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+    });
+    const event = {
+      preparation: {
+        messagesToSummarize: [] as AgentMessage[],
+        turnPrefixMessages: [
+          { role: "user", content: `${latestAsk} and preserve ${identifier}`, timestamp: 1 },
+        ] as AgentMessage[],
+        splitTurnCompleted: true,
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 90_000,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 4_000 },
+        isSplitTurn: true,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
+
+    const finalSummary = expectCompactionResult(result).summary;
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
+    expect(finalSummary).not.toContain(`## Pending user asks\n${latestAsk}`);
+    expect(finalSummary).toContain("## Pending user asks\nNone.");
+    const retry = requireRecord(mockCallArg(mockSummarizeInStages, 1));
+    expect(retry.customInstructions).toContain("completed_latest_user_ask_marked_pending");
+  });
+
   it("audits all-preserved fallback output against pre-partition source facts", async () => {
     mockSummarizeInStages.mockReset();
     const latestAsk = "report deployment status";

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -2551,6 +2551,78 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(retry.customInstructions).toContain("complete summary body within 16000 UTF-16");
   });
 
+  it("hands the summarizer the latest ask hidden inside preserved turns", async () => {
+    mockSummarizeInStages.mockReset();
+    const latestAsk = "combine the bars into one box per provider";
+    const structuredSummary = (pendingAsk: string) =>
+      [
+        "## Decisions",
+        "Keep the dashboard flow.",
+        "## Open TODOs",
+        "None.",
+        "## Constraints/Rules",
+        "Validate in the browser.",
+        "## Pending user asks",
+        pendingAsk,
+        "## Exact identifiers",
+        "None captured.",
+      ].join("\n");
+    // The producer can only echo an ask it was shown.
+    mockSummarizeInStages.mockImplementation(async (params) =>
+      summaryResult(
+        structuredSummary(params.customInstructions?.includes(latestAsk) ? latestAsk : "None."),
+      ),
+    );
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      model: createAnthropicModelFixture(),
+      recentTurnsPreserve: 12,
+      qualityGuardEnabled: true,
+      qualityGuardMaxRetries: 1,
+    });
+    // One user turn followed by a long tool chain: preservation keeps the ask
+    // plus the trailing conversation messages, whose bulky results push the ask
+    // past the preserved-turns cap, so neither the summarizer input nor the
+    // finalized suffix carries it.
+    const toolChain = Array.from({ length: 40 }, (_, index) => {
+      const id = `call_${index}`;
+      return [
+        castAgentMessage({
+          role: "assistant",
+          content: [{ type: "toolCall", id, name: "exec", arguments: {} }],
+          timestamp: 2 + index * 2,
+        }),
+        castAgentMessage({
+          role: "toolResult",
+          toolCallId: id,
+          toolName: "exec",
+          content: [{ type: "text", text: "output ".repeat(200) }],
+          timestamp: 3 + index * 2,
+        }),
+      ];
+    }).flat();
+    const event = createCompactionEvent({ messageText: latestAsk, tokensBefore: 90_000 });
+    event.preparation.messagesToSummarize = [
+      { role: "user", content: latestAsk, timestamp: 1 },
+      ...toolChain,
+    ];
+    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4_000,
+    };
+    (event.preparation as { isSplitTurn?: boolean }).isSplitTurn = false;
+
+    const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
+
+    expect(expectCompactionResult(result).summary).toContain(latestAsk);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    const call = requireRecord(mockCallArg(mockSummarizeInStages, 0));
+    expect(call.customInstructions).toContain(latestAsk);
+    const summarizedRoles = requireArray(call.messages).map(
+      (message) => requireRecord(message).role,
+    );
+    expect(summarizedRoles).not.toContain("user");
+  });
+
   it("propagates caller abort during corrective generation", async () => {
     mockSummarizeInStages.mockReset();
     const controller = new AbortController();

--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -656,6 +656,7 @@ describe("compaction-safeguard summary budgets", () => {
         auditSummary,
         identifiers: [identifier],
         latestAsk,
+        latestAskCompleted: false,
         requiredAskContext: latestAsk,
         identifierPolicy: "strict",
       }),
@@ -694,6 +695,7 @@ describe("compaction-safeguard summary budgets", () => {
         auditSummary: body,
         identifiers: [identifier],
         latestAsk,
+        latestAskCompleted: false,
         requiredAskContext: latestAsk,
         identifierPolicy: "strict",
       }),
@@ -709,6 +711,47 @@ describe("compaction-safeguard summary budgets", () => {
     expect(
       auditSummaryQuality({ summary: finalized.summary, identifiers: [identifier], latestAsk }).ok,
     ).toBe(true);
+  });
+
+  it("retains a completed latest ask outside the pending section", () => {
+    const latestAsk = "combine the bars into one box per provider";
+    const body = [
+      "## Decisions",
+      `${latestAsk} is completed.`,
+      "x".repeat(MAX_COMPACTION_SUMMARY_CHARS),
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Validate in the browser.",
+      "## Pending user asks",
+      "None.",
+      "## Exact identifiers",
+      "None captured.",
+    ].join("\n");
+    const finalized = requireRecord(
+      budgetCompactionSummary(body, "", MAX_COMPACTION_SUMMARY_CHARS, {
+        auditSummary: body,
+        identifiers: [],
+        latestAsk,
+        latestAskCompleted: true,
+        requiredAskContext: latestAsk,
+        identifierPolicy: "strict",
+      }),
+    );
+    if (typeof finalized.summary !== "string" || typeof finalized.structuralSummary !== "string") {
+      throw new Error("expected finalized summary strings");
+    }
+
+    expect(finalized.structuralSummary).toContain(`Latest turn completed:\n${latestAsk}`);
+    expect(finalized.structuralSummary).toContain("## Pending user asks\nNone.");
+    expect(
+      auditSummaryQuality({
+        summary: finalized.summary,
+        identifiers: [],
+        latestAsk,
+        latestAskCompleted: true,
+      }),
+    ).toEqual({ ok: true, reasons: [] });
   });
 });
 
@@ -1233,6 +1276,31 @@ describe("compaction-safeguard recent-turn preservation", () => {
       latestAsk: "Explain post-compaction behavior for memory indexing",
     });
     expect(quality.ok).toBe(true);
+  });
+
+  it("rejects a completed latest ask when the summary marks it pending", () => {
+    const latestAsk = "combine the bars into one box per provider";
+    const summary = [
+      "## Decisions",
+      `${latestAsk} is completed.`,
+      "## Open TODOs",
+      "None.",
+      "## Constraints/Rules",
+      "Validate in the browser.",
+      "## Pending user asks",
+      latestAsk,
+      "## Exact identifiers",
+      "None captured.",
+    ].join("\n");
+
+    expect(
+      auditSummaryQuality({
+        summary,
+        identifiers: [],
+        latestAsk,
+        latestAskCompleted: true,
+      }),
+    ).toEqual({ ok: false, reasons: ["completed_latest_user_ask_marked_pending"] });
   });
 
   it("dedupes pure-hex identifiers across case variants", () => {
@@ -2551,13 +2619,14 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(retry.customInstructions).toContain("complete summary body within 16000 UTF-16");
   });
 
-  it("hands the summarizer the latest ask hidden inside preserved turns", async () => {
+  it("hands the summarizer the full latest turn hidden inside preserved turns", async () => {
     mockSummarizeInStages.mockReset();
     const latestAsk = "combine the bars into one box per provider";
-    const structuredSummary = (pendingAsk: string) =>
+    const completion = "The provider boxes are combined.";
+    const structuredSummary = (decision: string, pendingAsk = "None.") =>
       [
         "## Decisions",
-        "Keep the dashboard flow.",
+        decision,
         "## Open TODOs",
         "None.",
         "## Constraints/Rules",
@@ -2567,12 +2636,20 @@ describe("compaction-safeguard recent-turn preservation", () => {
         "## Exact identifiers",
         "None captured.",
       ].join("\n");
-    // The producer can only echo an ask it was shown.
-    mockSummarizeInStages.mockImplementation(async (params) =>
-      summaryResult(
-        structuredSummary(params.customInstructions?.includes(latestAsk) ? latestAsk : "None."),
-      ),
-    );
+    // The producer can only classify the ask as completed when it sees both sides of the turn.
+    mockSummarizeInStages.mockImplementation(async (params) => {
+      const serialized = JSON.stringify(params.messages);
+      const decision =
+        serialized.includes(latestAsk) && serialized.includes(completion)
+          ? `${latestAsk} is completed.`
+          : "No current-turn decision captured.";
+      return summaryResult(
+        structuredSummary(
+          decision,
+          mockSummarizeInStages.mock.calls.length === 1 ? latestAsk : "None.",
+        ),
+      );
+    });
     const sessionManager = stubSessionManager();
     setCompactionSafeguardRuntime(sessionManager, {
       model: createAnthropicModelFixture(),
@@ -2580,11 +2657,10 @@ describe("compaction-safeguard recent-turn preservation", () => {
       qualityGuardEnabled: true,
       qualityGuardMaxRetries: 1,
     });
-    // One user turn followed by a long tool chain: preservation keeps the ask
-    // plus the trailing conversation messages, whose bulky results push the ask
-    // past the preserved-turns cap, so neither the summarizer input nor the
-    // finalized suffix carries it.
-    const toolChain = Array.from({ length: 40 }, (_, index) => {
+    // Every message is recent enough to be preserved, while bulky results push
+    // the ask past the preserved-turns cap. The summary producer still needs
+    // the whole latest turn so it can distinguish completed from pending work.
+    const toolChain = Array.from({ length: 12 }, (_, index) => {
       const id = `call_${index}`;
       return [
         castAgentMessage({
@@ -2605,6 +2681,12 @@ describe("compaction-safeguard recent-turn preservation", () => {
     event.preparation.messagesToSummarize = [
       { role: "user", content: latestAsk, timestamp: 1 },
       ...toolChain,
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: completion }],
+        stopReason: "stop",
+        timestamp: 100,
+      }),
     ];
     (event.preparation as { settings?: { reserveTokens: number } }).settings = {
       reserveTokens: 4_000,
@@ -2613,14 +2695,20 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
     const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
 
-    expect(expectCompactionResult(result).summary).toContain(latestAsk);
-    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
+    const finalSummary = expectCompactionResult(result).summary;
+    expect(finalSummary).toContain(latestAsk);
+    expect(finalSummary).toContain("## Pending user asks\nNone.");
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(2);
     const call = requireRecord(mockCallArg(mockSummarizeInStages, 0));
-    expect(call.customInstructions).toContain(latestAsk);
-    const summarizedRoles = requireArray(call.messages).map(
-      (message) => requireRecord(message).role,
-    );
-    expect(summarizedRoles).not.toContain("user");
+    const summarizedMessages = requireArray(call.messages);
+    const summarizedRoles = summarizedMessages.map((message) => requireRecord(message).role);
+    expect(summarizedRoles).toContain("user");
+    expect(JSON.stringify(summarizedMessages)).toContain(completion);
+    expect(call.customInstructions).not.toContain(latestAsk);
+    const auditInput = requireRecord(mockCallArg(mockAuditSummaryQuality));
+    expect(auditInput.latestAskCompleted).toBe(true);
+    const retry = requireRecord(mockCallArg(mockSummarizeInStages, 1));
+    expect(retry.customInstructions).toContain("completed_latest_user_ask_marked_pending");
   });
 
   it("propagates caller abort during corrective generation", async () => {
@@ -2758,7 +2846,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(auditInput.identifiers).toEqual([]);
   });
 
-  it("rejects all-preserved fallback output that truncates source facts", async () => {
+  it("summarizes an all-preserved turn when verbatim capping truncates source facts", async () => {
     mockSummarizeInStages.mockReset();
     const latestAsk = "report deployment status";
     const identifier = "/tmp/all-preserved-truncated.log";
@@ -2770,6 +2858,23 @@ describe("compaction-safeguard recent-turn preservation", () => {
       qualityGuardMaxRetries: 1,
     });
     const sourceText = `${"x".repeat(610)} ${latestAsk} ${identifier}`;
+    mockSummarizeInStages.mockImplementation(async (params) => {
+      const serialized = JSON.stringify(params.messages);
+      return summaryResult(
+        [
+          "## Decisions",
+          serialized.includes(sourceText) ? `${latestAsk} is active.` : "No request captured.",
+          "## Open TODOs",
+          "None.",
+          "## Constraints/Rules",
+          "Preserve exact source facts.",
+          "## Pending user asks",
+          latestAsk,
+          "## Exact identifiers",
+          serialized.includes(identifier) ? identifier : "None captured.",
+        ].join("\n"),
+      );
+    });
     const event = createCompactionEvent({ messageText: sourceText, tokensBefore: 1_500 });
     (
       event.preparation as { settings?: { reserveTokens: number }; isSplitTurn?: boolean }
@@ -2778,29 +2883,19 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
     const { result } = await runCompactionScenario({ sessionManager, event, apiKey: "test-key" });
 
-    expect(result).toEqual({ cancel: true });
-    expect(mockSummarizeInStages).not.toHaveBeenCalled();
+    const summary = expectCompactionResult(result).summary;
+    expect(summary).toContain(latestAsk);
+    expect(summary).toContain(identifier);
+    expect(mockSummarizeInStages).toHaveBeenCalledTimes(1);
     expect(mockAuditSummaryQuality).toHaveBeenCalledTimes(1);
     const auditInput = requireRecord(mockCallArg(mockAuditSummaryQuality));
     expect(auditInput.latestAsk).toBe(sourceText);
     expect(auditInput.identifiers).toEqual([identifier]);
     expect(auditInput.summary).toContain("## Recent turns preserved verbatim");
-    expect(auditInput.summary).not.toContain(identifier);
-    expect(auditInput.summary).not.toContain(latestAsk);
-    expect(mockAuditSummaryQuality.mock.results[0]?.value).toEqual({
-      ok: false,
-      reasons: [`missing_identifiers:${identifier}`, "latest_user_ask_not_reflected"],
-    });
-    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBe(
-      "Compaction safeguard finalized summary failed quality checks.",
-    );
-    const terminalWarnings = compactionLogger.warn.mock.calls.flat().join("\n");
-    expect(terminalWarnings).toContain(
-      "reasonCodes=missing_identifiers,latest_user_ask_not_reflected",
-    );
-    expect(terminalWarnings).toContain("reasonCount=2");
-    expect(terminalWarnings).not.toContain(identifier);
-    expect(terminalWarnings).not.toContain(sourceText);
+    expect(auditInput.summary).toContain(identifier);
+    expect(auditInput.summary).toContain(latestAsk);
+    expect(mockAuditSummaryQuality.mock.results[0]?.value).toEqual({ ok: true, reasons: [] });
+    expect(consumeCompactionSafeguardCancelReason(sessionManager)).toBeNull();
   });
 
   it("retries when generated summary misses headings even if preserved turns contain them", async () => {

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -1239,7 +1239,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       const oracleMessages = [...messagesToSummarize, ...turnPrefixMessages];
       const latestUserTurn = extractLatestUserTurn(oracleMessages);
       const latestUserAsk = latestUserTurn?.ask ?? null;
-      const latestUserAskCompleted = latestUserTurn?.completed ?? false;
+      const latestUserAskCompleted =
+        preparation.splitTurnCompleted ?? latestUserTurn?.completed ?? false;
       const identifiers = extractOpaqueIdentifiers(
         oracleMessages.slice(-10).map(extractMessageText).filter(Boolean).join("\n"),
       );
@@ -1379,6 +1380,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         const quality = auditSummaryQuality({
           summary: finalized.summary,
           structuralSummary: finalized.structuralSummary,
+          completionSummary: unbudgetedSummary,
           identifiers,
           latestAsk: latestUserAsk,
           latestAskCompleted: latestUserAskCompleted,

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -1256,7 +1256,22 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       // incorporates context from pruned messages instead of losing it entirely.
       const effectivePreviousSummary = droppedSummary ?? preparation.previousSummary;
 
-      let currentInstructions = structuredInstructions;
+      // The audited latest ask is read from the pre-partition window, but the
+      // summarizer only receives the partitioned messages; when the ask sits in
+      // the preserved recent turns the producer never sees it, so every attempt
+      // fails `latest_user_ask_not_reflected` and compaction cancels. Hand the
+      // bounded ask over as untrusted data so the guard only demands what the
+      // producer was shown.
+      const askInstructionBlock = latestUserAsk
+        ? wrapUntrustedInstructionBlock(
+            "Latest user request; reflect it under ## Pending user asks unless it is already completed",
+            formatRequiredAskContext(latestUserAsk),
+          )
+        : "";
+      const attemptInstructions = askInstructionBlock
+        ? `${structuredInstructions}\n\n${askInstructionBlock}`
+        : structuredInstructions;
+      let currentInstructions = attemptInstructions;
       const totalAttempts = qualityGuardEnabled ? qualityGuardMaxRetries + 1 : 1;
 
       for (let attempt = 0; attempt < totalAttempts; attempt += 1) {
@@ -1385,8 +1400,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           `Previous summary failed quality checks (${reasons}).`,
         );
         currentInstructions = qualityFeedbackReasons
-          ? `${structuredInstructions}\n\n${qualityFeedbackInstruction}\n${budgetInstruction}\n\n${qualityFeedbackReasons}`
-          : `${structuredInstructions}\n\n${qualityFeedbackInstruction}\n${budgetInstruction}`;
+          ? `${attemptInstructions}\n\n${qualityFeedbackInstruction}\n${budgetInstruction}\n\n${qualityFeedbackReasons}`
+          : `${attemptInstructions}\n\n${qualityFeedbackInstruction}\n${budgetInstruction}`;
       }
 
       throw new Error("Compaction safeguard exhausted summary attempts without a decision.");

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -219,6 +219,7 @@ type SummaryQualityRetention = {
   auditSummary: string;
   identifiers: string[];
   latestAsk: string | null;
+  latestAskCompleted: boolean;
   requiredAskContext: string;
   identifierPolicy: "strict" | "off" | "custom";
 };
@@ -836,14 +837,25 @@ function formatRequiredAskContext(summary: string): string {
   return `${truncateUtf16Safe(source, headBudget)}${REQUIRED_ASK_CONTEXT_TRUNCATED_MARKER}${sliceUtf16Safe(source, -tailBudget)}`;
 }
 
-function extractLatestUserAsk(messages: AgentMessage[]): string | null {
+function extractLatestUserTurn(
+  messages: AgentMessage[],
+): { ask: string; completed: boolean } | null {
+  let sawTurnTail = false;
+  let completed = false;
   for (const message of messages.toReversed()) {
-    if (message.role !== "user") {
+    if (message.role === "user") {
+      const ask = extractMessageText(message);
+      if (ask) {
+        return { ask, completed };
+      }
       continue;
     }
-    const text = extractMessageText(message);
-    if (text) {
-      return text;
+    if (!sawTurnTail && (message.role === "assistant" || message.role === "toolResult")) {
+      sawTurnTail = true;
+      completed =
+        message.role === "assistant" &&
+        message.stopReason === "stop" &&
+        Boolean(extractMessageText(message));
     }
   }
   return null;
@@ -1225,7 +1237,9 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       }
 
       const oracleMessages = [...messagesToSummarize, ...turnPrefixMessages];
-      const latestUserAsk = extractLatestUserAsk(oracleMessages);
+      const latestUserTurn = extractLatestUserTurn(oracleMessages);
+      const latestUserAsk = latestUserTurn?.ask ?? null;
+      const latestUserAskCompleted = latestUserTurn?.completed ?? false;
       const identifiers = extractOpaqueIdentifiers(
         oracleMessages.slice(-10).map(extractMessageText).filter(Boolean).join("\n"),
       );
@@ -1236,8 +1250,19 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         messages: messagesToSummarize,
         recentTurnsPreserve,
       });
-      messagesToSummarize = summaryTargetMessages;
       const preservedTurnsSectionLocal = buildPreservedTurnsSection(preservedRecentMessages);
+      const latestPreparedAsk = extractLatestUserTurn(messagesToSummarize)?.ask ?? null;
+      const requiredAskContext = formatRequiredAskContext(latestUserAsk ?? "");
+      // The producer needs the preserved completion context whenever it runs; handing over the
+      // ask alone can resurrect completed work. All-preserved windows stay model-free unless
+      // verbatim capping would hide the audited ask.
+      const includePreservedContext =
+        qualityGuardEnabled &&
+        latestPreparedAsk === latestUserAsk &&
+        Boolean(latestPreparedAsk) &&
+        (summaryTargetMessages.length > 0 ||
+          !preservedTurnsSectionLocal.text.includes(requiredAskContext));
+      messagesToSummarize = includePreservedContext ? messagesToSummarize : summaryTargetMessages;
       const allMessages = [...messagesToSummarize, ...turnPrefixMessages];
 
       // Use adaptive chunk ratio based on message sizes, reserving headroom for
@@ -1256,22 +1281,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       // incorporates context from pruned messages instead of losing it entirely.
       const effectivePreviousSummary = droppedSummary ?? preparation.previousSummary;
 
-      // The audited latest ask is read from the pre-partition window, but the
-      // summarizer only receives the partitioned messages; when the ask sits in
-      // the preserved recent turns the producer never sees it, so every attempt
-      // fails `latest_user_ask_not_reflected` and compaction cancels. Hand the
-      // bounded ask over as untrusted data so the guard only demands what the
-      // producer was shown.
-      const askInstructionBlock = latestUserAsk
-        ? wrapUntrustedInstructionBlock(
-            "Latest user request; reflect it under ## Pending user asks unless it is already completed",
-            formatRequiredAskContext(latestUserAsk),
-          )
-        : "";
-      const attemptInstructions = askInstructionBlock
-        ? `${structuredInstructions}\n\n${askInstructionBlock}`
-        : structuredInstructions;
-      let currentInstructions = attemptInstructions;
+      let currentInstructions = structuredInstructions;
       const totalAttempts = qualityGuardEnabled ? qualityGuardMaxRetries + 1 : 1;
 
       for (let attempt = 0; attempt < totalAttempts; attempt += 1) {
@@ -1341,6 +1351,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                 auditSummary: unbudgetedSummary,
                 identifiers,
                 latestAsk: latestUserAsk,
+                latestAskCompleted: latestUserAskCompleted,
                 requiredAskContext:
                   splitTurnAskContextLocal || formatRequiredAskContext(latestUserAsk ?? ""),
                 identifierPolicy,
@@ -1370,6 +1381,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           structuralSummary: finalized.structuralSummary,
           identifiers,
           latestAsk: latestUserAsk,
+          latestAskCompleted: latestUserAskCompleted,
           identifierPolicy,
         });
         if (quality.ok) {
@@ -1400,8 +1412,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           `Previous summary failed quality checks (${reasons}).`,
         );
         currentInstructions = qualityFeedbackReasons
-          ? `${attemptInstructions}\n\n${qualityFeedbackInstruction}\n${budgetInstruction}\n\n${qualityFeedbackReasons}`
-          : `${attemptInstructions}\n\n${qualityFeedbackInstruction}\n${budgetInstruction}`;
+          ? `${structuredInstructions}\n\n${qualityFeedbackInstruction}\n${budgetInstruction}\n\n${qualityFeedbackReasons}`
+          : `${structuredInstructions}\n\n${qualityFeedbackInstruction}\n${budgetInstruction}`;
       }
 
       throw new Error("Compaction safeguard exhausted summary attempts without a decision.");

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -263,11 +263,11 @@ describe("sidebar attention refresh ownership", () => {
     );
     element.querySelector<HTMLButtonElement>(".sidebar-issues-button")!.click();
 
-    await waitForFast(() => {
-      const panel = element.querySelector(".sidebar-issues-panel");
-      expect(panel).not.toBeNull();
-      expect(panel?.closest("openclaw-menu-surface")).not.toBeNull();
-    });
+    await import("./sidebar-attention-panel.runtime.ts");
+    await element.updateComplete;
+    const panel = element.querySelector(".sidebar-issues-panel");
+    expect(panel).not.toBeNull();
+    expect(panel?.closest("openclaw-menu-surface")).not.toBeNull();
   });
 
   it("keeps the latest refresh when an older load on the same client finishes last", async () => {


### PR DESCRIPTION
## What Problem This Solves

A long tool-heavy turn could hit the context limit and then fail both automatic and manual compaction with `latest_user_ask_not_reflected`. The quality guard audited the latest user request from the pre-partition window, while recent-turn preservation removed that request—and sometimes its completing assistant response—from the messages given to the summarizer. If the bounded verbatim suffix then dropped the request, the guard demanded a fact the producer never saw and cancelled compaction.

The original patch handed only the bounded request to the summarizer. Autoreview found that an all-preserved window could still skip the summarizer and that request-only context could resurrect completed work. ClawSweeper then found the remaining inverse: even with the full turn visible, an accepted summary could still list a completed request under `## Pending user asks`.

Final live Gateway proof exposed one more boundary: when the retention cut split a long completed turn, the summarizer saw only its prefix while the terminal assistant response stayed in the retained suffix. The audit therefore treated the boundary request as unresolved and accepted a split-turn summary that revived it under pending work.

## Why This Change Was Made

The quality producer receives the full prepared context whenever it is already generating a summary. An all-preserved window remains model-free when its audited request survives verbatim; if bounded preservation would hide the request, the same prepared context is summarized instead of returning a doomed fallback.

For genuine split turns, Agent Core now records whether that exact cut turn completes in its retained suffix. The safeguard carries that cut-scoped fact into retention and audits every generated `## Pending user asks` section, including the separately generated split-turn summary. A bad first summary is rejected with a concrete reason and corrected within the existing bounded retry. Non-split turns keep their existing local completion inference.

This keeps the quality guard fail-closed, preserves the bounded verbatim suffix, and avoids treating user text as prompt authority. No config, schema, protocol, or default changes are introduced.

The first exact-head CI run also exposed an unrelated flaky UI test. Product code was unaffected: the test hit Vitest's 1-second wait timeout while the attention panel awaited a lazy import. The test now joins that import and then awaits Lit's update before asserting the same top-layer menu ancestry. No timeout was increased and no assertion was weakened.

## User Impact

Sessions whose latest user turn is preserved behind a long tool chain—or split across the retention cut—can compact instead of cancelling or reviving completed work. Accepted checkpoints cannot mark a successfully completed latest turn as pending.

## Evidence

### Live Gateway proof

- Exact committed head: `8e62635fd626e69da80179777a0b1de4e9cf0356`
- Direct AWS Crabbox run: https://crabbox.openclaw.ai/portal/runs/run_24a23cff22e0
- Environment: built OpenClaw Gateway and CLI from the exact head, isolated state, deterministic local OpenAI-compatible provider.
- The first compaction response deliberately placed the completed split-turn request under `## Pending user asks`.
- Observed three provider requests: completed user turn, rejected bad compaction, corrective compaction.
- Persisted result: all three generated pending sections were `None.`; the completed request and `/tmp/pr130620/live/marker` remained under non-pending context.
- The one-shot lease `cbx_3381f0b0b953` was destroyed after artifact collection.

### Regression proof

- The split-turn regression reproduces the live failure: empty history body, long request prefix, terminal completion in the retained suffix, bad first summary, corrective retry.
- Agent Core coverage proves completion is bound to the turn intersecting the cut, not a newer retained turn with different terminal state.
- The completed-turn regression first returns a summary that places the completed request under `## Pending user asks`; the repaired owner rejects it and accepts only the corrected checkpoint.
- The all-preserved regression proves the producer sees both the latest request and its terminal assistant completion.
- The retention regression proves a completed request survives final artifact budgeting outside the pending section.

### Local verification

- `node scripts/run-vitest.mjs packages/agent-core/src/harness/compaction/compaction.test.ts src/agents/agent-hooks/compaction-safeguard.test.ts` — 45/45 core and 142/142 safeguard passed
- `node scripts/run-vitest.mjs ui/src/components/sidebar-attention.test.ts` — 33/33 passed on the prior exact head; the UI file is unchanged by the split-turn repair
- Focused attention-panel test — 10/10 repeated runs passed
- `node scripts/check-changed.mjs` — formatting, core/core-test typecheck, lint, dead-code, architecture, import-cycle, guard, and UI i18n lanes passed
- Final project-local structured autoreview — clean; no P0/P1 actionable findings (0.93 confidence)

### CI diagnosis

Initial run `33034247213` failed only `checks-node-compact-large-11` in `ui/src/components/sidebar-attention.test.ts`; the assertion timed out at 1009 ms while awaiting the lazy panel module. All compaction checks and the focused ClawSweeper proof passed on that head. Run `33038123439` completed green on the prior repaired head. Exact-head CI for `8e62635fd626e69da80179777a0b1de4e9cf0356` is tracked separately before merge.

### Scope

- Production: +100 / -9 (net +91)
- Tests: +270 / -24 (net +246)
- Total: 6 files, +370 / -33

The production growth carries one cut-scoped completion fact through the existing Agent Core preparation contract and adds the missing generated-section audit. There is no parallel compaction path or compatibility surface.

### What was not tested

No replay of the reporter's private ~255k-token gateway transcript was performed. The live proof uses the real Gateway/session/CLI/persistence path with deterministic provider responses so the bad-first-summary/corrective-retry boundary is reproducible; it is not external-provider proof.

## Worked on by
- @VACInc
