### PR TITLE
fix: interrupt mode cannot stop active low-level channel replies

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.base.test-utils.ts
@@ -1301,6 +1301,47 @@ describe("dispatchReplyFromConfig", () => {
     }
   });
 
+  it("lets low-level channel turns reach queue resolution while a reply operation is active", async () => {
+    setNoAbort();
+    const { createRuntimeChannel } = await import("../../plugins/runtime/runtime-channel.js");
+    const lowLevelDispatch = createRuntimeChannel().reply.dispatchReplyFromConfig;
+    const sessionKey = "agent:main:dingtalk-connector:direct:1";
+    const activeOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "active-session",
+      resetTriggered: false,
+    });
+    activeOperation.setPhase("running");
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async () => {
+      activeOperation.abortByUser();
+      activeOperation.complete();
+      return { text: "newest reply" } satisfies ReplyPayload;
+    });
+    const resultPromise = lowLevelDispatch({
+      ctx: buildTestCtx({
+        Provider: "dingtalk-connector",
+        Surface: "dingtalk-connector",
+        SessionKey: sessionKey,
+        BodyForAgent: "interrupt this active turn",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    try {
+      await vi.waitFor(() => expect(replyResolver).toHaveBeenCalledOnce());
+      await expect(resultPromise).resolves.toMatchObject({ queuedFinal: true });
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "newest reply" });
+    } finally {
+      if (!activeOperation.result) {
+        activeOperation.complete();
+      }
+      await Promise.allSettled([resultPromise]);
+    }
+  });
+
   it("lets Gateway-owned turns reach queue resolution while a reply operation is active", async () => {
     setNoAbort();
     const sessionKey = "agent:main:main";

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -66,6 +66,7 @@ import { stageRemoteInboundMediaIfNeeded } from "./stage-remote-inbound-media.js
 export async function gatherDispatchRequest(
   params: DispatchFromConfigParams,
   messageAuditTerminal: InboundMessageAuditTerminalRecorder | undefined,
+  allowActiveQueueResolution = false,
 ) {
   const ctx = isFinalizedInboundContext(params.ctx)
     ? params.ctx
@@ -388,6 +389,7 @@ export async function gatherDispatchRequest(
   const workspaceDir =
     preparedReplyDispatchRuntime?.workspaceDir ?? resolveAgentWorkspaceDir(cfg, sessionAgentId);
   const replyOperationCoordinator = createDispatchReplyOperationCoordinator({
+    allowActiveQueueResolution,
     agentId: sessionAgentId,
     cfg,
     ctx,

--- a/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
@@ -208,6 +208,7 @@ function resolveDispatchResetAdmission(params: {
 }
 
 export function createDispatchReplyOperationCoordinator(params: {
+  allowActiveQueueResolution?: boolean;
   agentId: string;
   cfg: OpenClawConfig;
   ctx: FinalizedMsgContext;
@@ -351,7 +352,10 @@ export function createDispatchReplyOperationCoordinator(params: {
       phase !== "pre_dispatch" &&
       preDispatchAbortOperation?.result &&
       preDispatchAbortOperation.result.kind !== "completed" &&
-      !dispatchReplyOperation
+      !dispatchReplyOperation &&
+      // Low-level queue resolution can abort the old owner before final delivery acquires its
+      // successor operation. The old result belongs to that owner, not to this inbound turn.
+      params.allowActiveQueueResolution !== true
     ) {
       dispatchAbortOperation = preDispatchAbortOperation;
       return { status: "busy" };
@@ -370,7 +374,8 @@ export function createDispatchReplyOperationCoordinator(params: {
     );
     const allowGatewayEmbeddedQueueResolution =
       replyTurnKind === "visible" &&
-      params.replyOptions?.turnAdoptionLifecycle !== undefined &&
+      (params.replyOptions?.turnAdoptionLifecycle !== undefined ||
+        params.allowActiveQueueResolution === true) &&
       activeReplyOperation === undefined &&
       activeEmbeddedSessionId === operationSessionId;
     if (allowGatewayEmbeddedQueueResolution) {
@@ -384,12 +389,13 @@ export function createDispatchReplyOperationCoordinator(params: {
     const allowGatewayQueueResolution =
       phase !== "pre_dispatch" &&
       replyTurnKind === "visible" &&
-      params.replyOptions?.turnAdoptionLifecycle !== undefined &&
+      (params.replyOptions?.turnAdoptionLifecycle !== undefined ||
+        params.allowActiveQueueResolution === true) &&
       activeReplyOperation !== undefined &&
       activeReplyOperation.turnKind !== "heartbeat";
     if (allowGatewayQueueResolution) {
-      // Gateway turns need to reach getReplyFromConfig while the owner is active;
-      // that layer applies the session's steer/followup/collect/drop policy.
+      // Gateway and low-level plugin turns must reach getReplyFromConfig while the owner is active;
+      // that layer applies the session's steer/followup/collect/drop policy without concurrent runs.
       return { status: "ready" };
     }
     const allowSlackRoutedThreadBypass =

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -24,6 +24,20 @@ export type { DispatchFromConfigResult } from "./dispatch-from-config.types.js";
 export async function dispatchReplyFromConfig(
   params: DispatchFromConfigParams,
 ): Promise<DispatchFromConfigResult> {
+  return await dispatchReplyFromConfigWithQueuePolicy(params, false);
+}
+
+/** Low-level plugin dispatch must reach queue policy before waiting on the active reply owner. */
+export async function dispatchLowLevelChannelReplyFromConfig(
+  params: DispatchFromConfigParams,
+): Promise<DispatchFromConfigResult> {
+  return await dispatchReplyFromConfigWithQueuePolicy(params, true);
+}
+
+async function dispatchReplyFromConfigWithQueuePolicy(
+  params: DispatchFromConfigParams,
+  allowActiveQueueResolution: boolean,
+): Promise<DispatchFromConfigResult> {
   const ticket = reserveReplyAdmissionTicket([
     params.ctx.SessionKey,
     params.ctx.CommandTargetSessionKey,
@@ -36,7 +50,11 @@ export async function dispatchReplyFromConfig(
     : params;
   const messageAuditTerminal = createInboundMessageAuditTerminal(params);
   try {
-    const result = await dispatchReplyFromConfigInner(ticketedParams, messageAuditTerminal);
+    const result = await dispatchReplyFromConfigInner(
+      ticketedParams,
+      messageAuditTerminal,
+      allowActiveQueueResolution,
+    );
     messageAuditTerminal?.finishSuccess(result);
     return result;
   } catch (error) {
@@ -50,8 +68,13 @@ export async function dispatchReplyFromConfig(
 async function dispatchReplyFromConfigInner(
   params: DispatchFromConfigParams,
   messageAuditTerminal: ReturnType<typeof createInboundMessageAuditTerminal>,
+  allowActiveQueueResolution: boolean,
 ): Promise<DispatchFromConfigResult> {
-  const gathered = await gatherDispatchRequest(params, messageAuditTerminal);
+  const gathered = await gatherDispatchRequest(
+    params,
+    messageAuditTerminal,
+    allowActiveQueueResolution,
+  );
   if (gathered.status === "complete") {
     return gathered.result;
   }

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -98,6 +98,7 @@ vi.mock("./server-methods.js", () => ({
 
 vi.mock("../auto-reply/reply/dispatch-from-config.js", () => ({
   dispatchReplyFromConfig,
+  dispatchLowLevelChannelReplyFromConfig: dispatchReplyFromConfig,
 }));
 
 vi.mock("./agent-turn/internal-facade.js", () => ({

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -513,13 +513,13 @@ function createGatewayPluginRuntimeBindings(
     },
     runtime: {
       dispatchReplyFromConfig: async (params) => {
-        const { dispatchReplyFromConfig } =
+        const { dispatchLowLevelChannelReplyFromConfig } =
           await import("../auto-reply/reply/dispatch-from-config.js");
         const sessionWorkerPlacementContext = getInProcessGatewayRequestContext(
           resolveBoundGatewayContext,
         );
         const run = async () =>
-          await dispatchReplyFromConfig({
+          await dispatchLowLevelChannelReplyFromConfig({
             ...params,
             ...(sessionWorkerPlacementContext ? { sessionWorkerPlacementContext } : {}),
           });

--- a/src/plugins/runtime/runtime-channel.ts
+++ b/src/plugins/runtime/runtime-channel.ts
@@ -22,7 +22,7 @@ import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
-import { dispatchReplyFromConfig } from "../../auto-reply/reply/dispatch-from-config.js";
+import { dispatchLowLevelChannelReplyFromConfig } from "../../auto-reply/reply/dispatch-from-config.js";
 import { finalizeInboundContext } from "../../auto-reply/reply/inbound-context.js";
 import {
   buildMentionRegexes,
@@ -118,7 +118,8 @@ export function createRuntimeChannel(options?: {
       createReplyDispatcherWithTyping,
       resolveEffectiveMessagesConfig,
       resolveHumanDelayConfig,
-      dispatchReplyFromConfig: options?.dispatchReplyFromConfig ?? dispatchReplyFromConfig,
+      dispatchReplyFromConfig:
+        options?.dispatchReplyFromConfig ?? dispatchLowLevelChannelReplyFromConfig,
       withReplyDispatcher,
       settleReplyDispatcher,
       finalizeInboundContext,


### PR DESCRIPTION
## What Problem This Solves

Low-level channel plugins could not interrupt an active reply even when the session queue mode was `interrupt`. The newer inbound waited for the active reply operation to become idle before queue policy could run.

## Root cause

Active queue resolution was gated on the durable Gateway turn-adoption lifecycle. The deprecated low-level plugin dispatcher does not carry that lifecycle. Its Gateway-bound dispatcher also replaced the initial local wrapper, so the first repair attempt did not reach the real plugin runtime path.

After interruption, final delivery also treated the old aborted operation as the new turn's abort owner. This dropped the newest reply after the second model request completed.

## Fix

- Bind low-level plugin dispatch to a host-private internal entry point. The public `PluginRuntime.channel.reply.dispatchReplyFromConfig` call shape does not change.
- Let that entry point reach the existing queue resolver while a visible non-heartbeat reply is active.
- After interrupt mode clears the old owner, acquire the successor reply operation for the newest final delivery.
- Keep ordinary core dispatch admission and all existing steer, follow-up, collect, drop, and heartbeat behavior unchanged.

## Evidence

An ephemeral mock Gateway loaded a disposable low-level channel plugin and a controlled streaming provider.

- Current main `651c1ec27488b8e6f8d5b6aef94c80810c20d237`: after 5 seconds, the first provider request remained open, only one request existed, and the second channel dispatch remained unsettled.
- Proven repair `25656bf253b75a5ba69b78b3b2b5c62f77cdd0b0`: the first request closed in about 100 ms, the second distinct request started, and only the second final reply reached the channel recorder.
- Current head `f2a2e7cacb7b8b452571823b59b0e3349bdacbb1` is a patch-content-identical rebase of the proven repair onto main with CI repair #132609. Both commits have canonical zero-context patch hash `d8fcafc1611de0d0232c7dacd63d6d058845e895945b16de7b630fb001e95317`.
- Anti-cheat: the provider recorded distinct request bodies and close time. The channel recorder linked the final to the second message ID. Both proof runtimes passed exact-SHA build fingerprints and CLI smoke checks.

Sanitized harness verdict:

```json
{
  "currentMain": {
    "sha": "651c1ec27488b8e6f8d5b6aef94c80810c20d237",
    "observedAfterMs": 5004,
    "firstRequestClosed": false,
    "requestCount": 1,
    "secondDispatchSettled": false
  },
  "repair": {
    "provenSha": "25656bf253b75a5ba69b78b3b2b5c62f77cdd0b0",
    "rebasedSha": "f2a2e7cacb7b8b452571823b59b0e3349bdacbb1",
    "firstRequestClosedAfterMs": 107,
    "requestCount": 2,
    "secondDispatchSettled": true,
    "firstFinalCount": 0,
    "secondFinalCount": 1,
    "secondFinalReplyTo": "second-message"
  }
}
```

## Validation

- 312 focused Gateway, reply lifecycle, queue, abort, and plugin-runtime tests passed.
- Full exact-head build and Plugin SDK export validation passed before the patch-identical rebase.
- Current main CI healed the three inherited failures: run `33252915861` passed, including the large state-test shard and all lint and compact-test lanes.
- Formatting, lint, changed-scope ratchets, import-cycle checks, plugin boundary checks, and `git diff --check` passed.
- Production: +43/-11. Tests: +42. The production growth keeps the compatibility bridge host-private and carries the existing queue decision through the real Gateway binding without adding a second queue or interrupt implementation.

AI-assisted. I reviewed the complete reply admission, queue, abort, Gateway binding, and final-delivery paths and verified the result through the running product flow.
