### PR TITLE
fix: preserve data URL attachment filename extensions

### DIFF
--- a/src/infra/outbound/message-action-params.attachments.test.ts
+++ b/src/infra/outbound/message-action-params.attachments.test.ts
@@ -29,6 +29,7 @@ const onePixelPng = Buffer.from(
 const onePixelPngBase64 = onePixelPng.toString("base64");
 const wrappedOnePixelPngBase64 = onePixelPngBase64.match(/.{1,24}/g)?.join("\r\n") ?? "";
 const parameterizedPngDataUrl = `data:image/png;charset=utf-8;name=../../ignored.svg;base64,${wrappedOnePixelPngBase64}`;
+const csvBase64 = Buffer.from("name,value\nexample,1\n").toString("base64");
 
 function firstMockArg(
   mock: { mock: { calls: readonly unknown[][] } },
@@ -106,10 +107,29 @@ describe("runMessageAction media behavior", () => {
     await resetMessageActionMediaMocks();
   });
 
-  it.each(["send", "sendAttachment", "reply", "upload-file", "setGroupIcon"] as const)(
-    "normalizes parameterized, line-wrapped image data URLs for %s",
-    async (action) => {
-      const args: Record<string, unknown> = { buffer: parameterizedPngDataUrl };
+  it.each(
+    (["send", "sendAttachment", "reply", "upload-file", "setGroupIcon"] as const).flatMap(
+      (action) => [
+        {
+          action,
+          buffer: parameterizedPngDataUrl,
+          base64: onePixelPngBase64,
+          contentType: "image/png",
+          filename: "attachment.png",
+        },
+        {
+          action,
+          buffer: `data:text/csv;base64,${csvBase64}`,
+          base64: csvBase64,
+          contentType: "text/csv",
+          filename: "attachment.csv",
+        },
+      ],
+    ),
+  )(
+    "normalizes $contentType data URLs and infers filenames for $action",
+    async ({ action, buffer, base64, contentType, filename }) => {
+      const args: Record<string, unknown> = { buffer };
 
       await hydrateAttachmentParamsForAction({
         cfg: {},
@@ -120,14 +140,13 @@ describe("runMessageAction media behavior", () => {
         mediaPolicy: { mode: "host" },
       });
 
-      expect(args.contentType).toBe("image/png");
+      expect(args.contentType).toBe(contentType);
+      expect(args.filename).toBe(filename);
       if (action === "send") {
         expect(args.media).toBe("buffer://message-send/attachment");
-        expect(args.filename).toBe("attachment.png");
       } else {
-        expect(canonicalizeBase64(String(args.buffer))).toBe(onePixelPngBase64);
+        expect(canonicalizeBase64(String(args.buffer))).toBe(base64);
       }
-      expect(args.filename).not.toBe("../../ignored.svg");
     },
   );
 
@@ -329,6 +348,7 @@ describe("runMessageAction media behavior", () => {
 
         const payload = requireActionPayload(result);
         expect(payload.contentType).toBe("image/png");
+        expect(payload.filename).toBe("attachment.png");
         expect(canonicalizeBase64(String(payload.buffer))).toBe(onePixelPngBase64);
       },
     );
@@ -617,6 +637,7 @@ describe("runMessageAction media behavior", () => {
 
       const handlerParams = firstMockArg(handleActionMock, "handleAction");
       expect(handlerParams.contentType).toBe("image/png");
+      expect(handlerParams.filename).toBe("attachment.png");
       expect(canonicalizeBase64(String(handlerParams.buffer))).toBe(onePixelPngBase64);
     });
 

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -538,7 +538,7 @@ async function hydrateAttachmentPayload(params: {
   } else if (!filename) {
     params.args.filename = inferAttachmentFilename({
       mediaHint: mediaSource,
-      contentType: contentTypeParam ?? undefined,
+      contentType: normalized.contentType,
     });
   }
 }


### PR DESCRIPTION
Closes #130618

## What Problem This Solves

Fixes an issue where attachment actions using valid data URL buffers produced filenames such as `attachment` instead of `attachment.png` or `attachment.csv`, even though the content type had already been recognized. Ordinary `send` did not have this filename defect.

## Why This Change Was Made

The shared attachment hydrator extracted MIME from the data URL, then inferred the filename from the earlier, missing input MIME. Filename inference now consumes the normalized MIME already owned by that hydrator. This reuses the existing normalizer and filename helper; it adds no new branch, channel-specific handling, dependency, or fallback.

## User Impact

`sendAttachment`, `reply`, `upload-file`, and shared group-icon attachment normalization retain the expected MIME-derived filename extension. Explicit filenames and content types still take precedence, and raw base64 naming behavior is unchanged. Buffer decoding, media access policy, sandboxing, delivery, and persistent state are untouched.

## Evidence

Before the production edit, 11 regression assertions failed: PNG/CSV filename inference across four attachment actions, plus existing action-runner dispatch fixtures for sendAttachment, upload-file, and reply. All failures received `attachment` instead of the expected MIME-derived filename. Ordinary-send controls and explicit content-type controls passed.

After the one-line producer repair, **267 tests passed** across the two hydration/runner suites and the shared MIME suite:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/infra/outbound/message-action-params.attachments.test.ts src/infra/outbound/message-action-params.test.ts packages/media-core/src/mime.test.ts
```

```bash
pnpm check:changed
```

```bash
git diff --check
```

All passed. Changed checks include formatting, type checks, lint, import-cycle and architecture guards. A separate Node process with temporary HOME/config/state and no module mocks passed **25 real hydration cases**: data URL, explicit filename, explicit MIME, raw base64 with MIME, and raw base64 without MIME across all five actions.

Fresh independent P1 autoreview found no actionable findings (correct, confidence 0.94). [Exact-head CI 33034708529](https://github.com/openclaw/openclaw/actions/runs/33034708529) is green on `6bd02709b140456ccd666a6a30477801c22e8999`; native review artifacts validate at `READY FOR /prepare-pr`. Production **+1/-1, net zero**; tests **+29/-8**. Coverage extends existing tables and dispatch fixtures, with no test-only production seam.

The latest ClawSweeper comment is still a review-started placeholder; no verdict or rank-up list has been published. It is not counted as completed review. The independent review and exact-head proof above are complete.

Proof limit: this is real core hydration and existing plugin-handler boundary proof, not a claim of live recipient delivery. No isolated iMessage recipient/account was provisioned; native recipient rendering, group-icon acceptance, and chat screenshots are therefore unverified. No external API or channel transport behavior changed. The group-icon CSV case checks the shared normalizer only, not that a recipient accepts CSV icons.

No docs contract or public options change. Existing documentation already accepts buffer/filename attachment inputs; release-note context is the restored inferred extensions described above. No changelog file edit. AI-assisted repair.
