### PR TITLE
fix(browser): reject non-decimal --wait-ms during extension install

### DIFF
--- a/extensions/browser/src/browser/extension-install.test.ts
+++ b/extensions/browser/src/browser/extension-install.test.ts
@@ -1050,4 +1050,12 @@ describe("installer option bounds", () => {
     expect(() => normalizeExtensionInstallWaitMs(999)).toThrow("--wait-ms");
     expect(() => normalizeExtensionInstallWaitMs(120_001)).toThrow("--wait-ms");
   });
+
+  it("rejects non-decimal --wait-ms string coercions instead of silently accepting them", () => {
+    // Number("0x1000")===4096 and Number("1e4")===10000 would pass the old
+    // range check silently; the strict parser requires plain decimal integers.
+    expect(() => normalizeExtensionInstallWaitMs("0x1000")).toThrow("--wait-ms");
+    expect(() => normalizeExtensionInstallWaitMs("1e4")).toThrow("--wait-ms");
+    expect(normalizeExtensionInstallWaitMs("10000")).toBe(10_000);
+  });
 });

--- a/extensions/browser/src/browser/extension-install.test.ts
+++ b/extensions/browser/src/browser/extension-install.test.ts
@@ -1047,15 +1047,20 @@ describe("installer option bounds", () => {
   it("accepts bounded waits and rejects unbounded waits", () => {
     expect(normalizeExtensionInstallWaitMs(undefined)).toBe(30_000);
     expect(normalizeExtensionInstallWaitMs("1000")).toBe(1_000);
+    expect(normalizeExtensionInstallWaitMs(10_000)).toBe(10_000);
+    expect(normalizeExtensionInstallWaitMs("120000")).toBe(120_000);
     expect(() => normalizeExtensionInstallWaitMs(999)).toThrow("--wait-ms");
     expect(() => normalizeExtensionInstallWaitMs(120_001)).toThrow("--wait-ms");
   });
 
-  it("rejects non-decimal --wait-ms string coercions instead of silently accepting them", () => {
-    // Number("0x1000")===4096 and Number("1e4")===10000 would pass the old
-    // range check silently; the strict parser requires plain decimal integers.
-    expect(() => normalizeExtensionInstallWaitMs("0x1000")).toThrow("--wait-ms");
-    expect(() => normalizeExtensionInstallWaitMs("1e4")).toThrow("--wait-ms");
+  it.each(["0x1000", "1e4", "+50000", " 50000", "50000 ", "50000\t"])(
+    "rejects non-decimal --wait-ms string %j",
+    (value) => {
+      expect(() => normalizeExtensionInstallWaitMs(value)).toThrow("--wait-ms");
+    },
+  );
+
+  it("accepts ordinary decimal strings", () => {
     expect(normalizeExtensionInstallWaitMs("10000")).toBe(10_000);
   });
 });

--- a/extensions/browser/src/browser/extension-install.ts
+++ b/extensions/browser/src/browser/extension-install.ts
@@ -1,7 +1,6 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import {
   assertOwnedPath,
@@ -382,9 +381,11 @@ export function normalizeExtensionInstallWaitMs(value: unknown): number {
   if (value === undefined) {
     return BROWSER_EXTENSION_INSTALL_WAIT_DEFAULT_MS;
   }
-  const parsed = typeof value === "number" ? value : parseStrictPositiveInteger(value);
+  const parsed =
+    typeof value === "number" || (typeof value === "string" && /^\d+$/u.test(value))
+      ? Number(value)
+      : Number.NaN;
   if (
-    parsed === undefined ||
     !Number.isInteger(parsed) ||
     parsed < BROWSER_EXTENSION_INSTALL_WAIT_MIN_MS ||
     parsed > BROWSER_EXTENSION_INSTALL_WAIT_MAX_MS

--- a/extensions/browser/src/browser/extension-install.ts
+++ b/extensions/browser/src/browser/extension-install.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import {
   assertOwnedPath,
@@ -381,8 +382,9 @@ export function normalizeExtensionInstallWaitMs(value: unknown): number {
   if (value === undefined) {
     return BROWSER_EXTENSION_INSTALL_WAIT_DEFAULT_MS;
   }
-  const parsed = typeof value === "number" ? value : Number(value);
+  const parsed = typeof value === "number" ? value : parseStrictPositiveInteger(value);
   if (
+    parsed === undefined ||
     !Number.isInteger(parsed) ||
     parsed < BROWSER_EXTENSION_INSTALL_WAIT_MIN_MS ||
     parsed > BROWSER_EXTENSION_INSTALL_WAIT_MAX_MS

--- a/extensions/browser/src/cli/browser-cli-extension.test.ts
+++ b/extensions/browser/src/cli/browser-cli-extension.test.ts
@@ -114,6 +114,28 @@ describe("browser extension pairing Gateway URL", () => {
     expect(output.at(-1)).toContain("extension identity verified");
   });
 
+  it.each(["0x1000", "1e4", "+50000", " 50000", "50000 ", "50000\t"])(
+    "rejects invalid install --wait-ms value %j before installation",
+    async (value) => {
+      const errorSpy = vi
+        .spyOn(cliCoreApiModule.defaultRuntime, "error")
+        .mockImplementation(runtime.error);
+      vi.spyOn(cliCoreApiModule.defaultRuntime, "exit").mockImplementation(runtime.exit);
+      const { registerBrowserExtensionCommands } = await import("./browser-cli-extension.js");
+      const program = new Command();
+      registerBrowserExtensionCommands(program.command("browser"), () => ({}));
+
+      await expect(
+        program.parseAsync(["browser", "extension", "install", "--wait-ms", value], {
+          from: "user",
+        }),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("--wait-ms"));
+      expect(installMocks.installChromeExtensionBootstrap).not.toHaveBeenCalled();
+    },
+  );
+
   it("rejects path-rewriting proxy prefixes for strict v2 resource binding", async () => {
     vi.spyOn(cliCoreApiModule, "getRuntimeConfig").mockReturnValue({});
     const errorSpy = vi


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `browser extension install --wait-ms` would silently accept
non-decimal strings as valid wait times. Because `normalizeExtensionInstallWaitMs`
coerced the user-supplied value with `Number()`, inputs such as `0x1000` (4096ms),
`1e4` (10000ms), or `+50000` (50000ms) passed the integer/range checks and were
used as the install wait instead of being rejected. A typo like `--wait-ms 1e4`
could produce a far shorter registration wait than intended, with no error.

## Why This Change Was Made

The browser plugin now validates `--wait-ms` at its owning normalization
boundary. Numeric callers remain accepted. String callers must contain ASCII
decimal digits only and then satisfy the existing integer range of
1000-120000.

This validation remains owner-local because the shared strict integer parser
trims whitespace and accepts signed strings, which is not the CLI contract
here.

## User Impact

Operators who pass a non-decimal `browser extension install --wait-ms` value get
an explicit `--wait-ms must be an integer from 1000 to 120000` error instead of a
silently coerced wait. Canonical decimal values such as `10000` are unchanged.

## Evidence

### Maintainer risk acknowledgements

- Compatibility accepted: this intentionally rejects undocumented hexadecimal,
  scientific, signed, and whitespace-padded `--wait-ms` strings. Documented
  decimal input remains supported, and the permissive forms appeared only in
  beta releases.
- Production growth accepted: the +3 net production lines are the smallest
  owner-local lexical guard. The shared parser intentionally accepts signed and
  trimmed strings; this change adds no helper, fallback, dependency, or broader
  surface.

### Root cause and canonical fix

Current `main` used `Number(value)`, which accepted hexadecimal, scientific
notation, leading `+`, and whitespace-padded strings.
`normalizeExtensionInstallWaitMs` owns this contract and is called by the CLI
before any preparation log or installation work.

The canonical fix enforces decimal lexical form at that owner boundary while
retaining the existing numeric, integer, and range validation.

### Current-main failure

Current `main` at `21b41efc7bb83dbdba9ce57c2d7140f6c20014e2`
retains the same affected owner and CLI source as
`dff2d268206c4ebfad2852cbeab7d8d2163a5fcd`. At the latter SHA, the focused
pre-fix regression matrix failed 12 assertions: non-decimal strings were
accepted and the CLI reached the installer.

### Exact-head CLI proof

Head: `626fad01adff8001f9e1b6b1ed248f29bf314bb1`

```text
$ openclaw browser extension install --wait-ms 1e4
Error: --wait-ms must be an integer from 1000 to 120000
exit: 1
installation started: no

$ openclaw browser extension install --wait-ms +50000
Error: --wait-ms must be an integer from 1000 to 120000
exit: 1
installation started: no
```

### Focused checks

- `node scripts/run-vitest.mjs extensions/browser/src/browser/extension-install.test.ts extensions/browser/src/cli/browser-cli-extension.test.ts` - passed
- Hosted CI - 57 successful, 43 skipped, 0 failed; `openclaw/ci-gate` passed
- Exact-head autoreview - 0 findings, 0.98 confidence
- Local ClawSweeper - A/A/A, proof sufficient, 0 findings or risks
- Hosted ClawSweeper - no code findings; its remaining request was the exact-head CLI proof attached above

### Scope and compatibility

- Production: +4/-1, net +3
- Tests: +35/-0
- Numeric callers, canonical decimal strings, bounds, exported normalization,
  and the real Commander boundary are covered.
- The affected behavior was introduced only in `v2026.8.1-beta.2` and
  `v2026.8.1-beta.3`; no stable shipped contract accepted these noncanonical
  forms.
- No config, default, protocol, SDK, auth, provider, security, session, storage,
  lifecycle, dependency, or feature surface changes.

## Follow-up

None. The narrower grammar intentionally differs from the shared
signed/whitespace-tolerant integer parser.
