### PR TITLE
fix(crabbox): keep bootstrap runtimes accessible under private umasks

### DIFF
--- a/scripts/crabbox-untrusted-bootstrap.sh
+++ b/scripts/crabbox-untrusted-bootstrap.sh
@@ -67,19 +67,28 @@ trap cleanup EXIT
   /usr/bin/grep "  ${archive}\$" SHASUMS256.txt | /usr/bin/sha256sum -c -
 )
 
-sudo /bin/rm -rf -- "$install_root" "$corepack_home"
-sudo /usr/bin/mkdir -p "$install_root" "$corepack_home"
-sudo /usr/bin/tar -xJf "$tmp_dir/$archive" -C "$install_root" --strip-components=1
-sudo /usr/bin/env \
+# Only public toolchain artifacts need shared access; keep caller state private.
+sudo /bin/bash -s -- "$install_root" "$corepack_home" "$tmp_dir/$archive" "$pnpm_spec" <<'INSTALL'
+set -euo pipefail
+umask 022
+install_root="$1"
+corepack_home="$2"
+archive_path="$3"
+pnpm_spec="$4"
+/bin/rm -rf -- "$install_root" "$corepack_home"
+/usr/bin/mkdir -p "$install_root" "$corepack_home"
+/usr/bin/tar -xJf "$archive_path" -C "$install_root" --strip-components=1
+/usr/bin/env \
   COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   COREPACK_HOME="$corepack_home" \
   PATH="$install_root/bin:/usr/bin:/bin" \
   "$install_root/bin/corepack" enable --install-directory "$install_root/bin"
-sudo /usr/bin/env \
+/usr/bin/env \
   COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   COREPACK_HOME="$corepack_home" \
   PATH="$install_root/bin:/usr/bin:/bin" \
   "$install_root/bin/corepack" prepare "$pnpm_spec" --activate
+INSTALL
 
 for tool in node npm npx corepack pnpm pnpx; do
   if [[ -e "$install_root/bin/$tool" ]]; then


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This branch is in `openclaw/openclaw`; repository maintainers can update it directly.

</details>

## What Problem This Solves

Fixes an issue where maintainers running the sanitized AWS Crabbox bootstrap could fail with `/usr/local/bin/node: No such file or directory` before dependency installation or tests when the caller used a private `0077` umask.

This is a bootstrap repair discovered during cron QA, not a change to cron behavior.

## Why This Change Was Made

The bootstrap installed Node and Corepack as root while inheriting the caller's umask. Both public installation roots became `0700`; Node existed underneath, but the non-root caller could not traverse the directories, so the existing symlink loop skipped it.

Group the existing public installation commands in one strict root child shell with umask `022`. This gives public toolchain directories and newly created Corepack cache descendants the access they need without changing the caller's private umask. Quoted positional arguments and a literal heredoc preserve the command/data boundary. IMDS, exact-head, archive-checksum, package-manager-pin, temporary-HOME, and error-propagation checks remain unchanged.

A global umask change would relax private caller state. Changing only the two root directory modes would leave cache descendants susceptible to the same problem. No fallback runtime or recursive permission repair is added.

Production/tooling: **+14/-5, net +9**. Those lines establish one process-local permission boundary for the public runtime installation. Tests: unchanged.

## User Impact

Maintainers can use the documented secretless bootstrap with a private caller umask and still execute the pinned Node/pnpm runtime. Private temporary state remains private. There is no bot-facing behavior or configuration change.

## Evidence

Reviewed head: `985e3770729b9264f5bde372aeae8be29d13ddae`, based on `6ae89b5a8ed6a1bdbd0d9b7639fc8162afbb7578`.

Real same-host sanitized AWS proof, with no instance role, Tailscale, or credential hydration:

- Before: the original bootstrap exited **127** after archive verification and Corepack preparation. Both installation roots were root-owned `0700`; the caller received permission denied when inspecting the installed Node binary, and the global Node symlink was missing.
- After: the exact corrected script completed the real Node **24.19.0** / pnpm **11.22.0** bootstrap and frozen-lockfile dependency installation. The non-root command verified both public roots were `0755`, every Corepack cache directory was readable/traversable, and cache files were readable.
- Privacy assertions verified caller umask **0077**, temporary HOME **0700**, and a newly created private file **0600**. The enclosing command completed with exit **0**.
- Corrected script SHA-256: `5cd52c255f6df752e74a6f913354107516de3fc002a5bcf19586e04ac13d5985`. This is byte-identical to the committed script. The executable witness and complete captured logs were independently inspected, not only their success marker.

Local trusted checks:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/crabbox-untrusted-bootstrap.test.ts
2 tests passed (Node 24.19.0, Vitest 4.1.11)
bash -n scripts/crabbox-untrusted-bootstrap.sh
shellcheck scripts/crabbox-untrusted-bootstrap.sh
shfmt -d -i 2 -ci scripts/crabbox-untrusted-bootstrap.sh
git diff --check
```

The existing pin and bounded-IMDS tests remain intact. No extracted-source or mocked-install mini-harness was added: this regression depends on privileged installation followed by non-root traversal, and the real before/after run directly exercises that boundary without introducing brittle test-only structure.

Structured autoreview and a separate enforced read-only, ephemeral Codex review both completed without actionable findings. Exact-head hosted CI is still required before landing.
