### PR TITLE
fix(tooling): resume PR checkouts after completed deletions

### DIFF
--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -163,8 +163,10 @@ recover_review_transition() {
   fi
 
   validate_review_transition_state "$pr" "$source" "$target" || return 1
-  if ! git diff --quiet "$source" "$target"; then
-    git diff --name-only --no-renames -z "$source" "$target" |
+  # Completed deletions are absent from both index and target, so replay only
+  # remaining entries rather than passing already-removed paths to restore.
+  if ! git diff --cached --quiet "$target"; then
+    git diff --cached --name-only --no-renames -z "$target" |
       git --literal-pathspecs restore --source="$target" --staged --worktree \
         --pathspec-from-file=- --pathspec-file-nul || return 1
   fi

--- a/test/scripts/pr-worktree-containment.test.ts
+++ b/test/scripts/pr-worktree-containment.test.ts
@@ -76,6 +76,7 @@ function createReviewFixture(): ReviewFixture {
   writeFileSync(join(root, "transition-a.txt"), "pr-a\n");
   writeFileSync(join(root, "transition-b.txt"), "pr-b\n");
   writeFileSync(join(root, "overlap.txt"), "pr-a-overlap\n");
+  writeFileSync(join(root, "pr-only.txt"), "removed on main\n");
   git(root, "add", ".");
   git(root, "commit", "-m", "PR head A");
   const prASha = git(root, "rev-parse", "HEAD");
@@ -255,6 +256,53 @@ describePosix("scripts/pr worktree containment", () => {
     ).toBe(false);
     expectCanonicalCheckoutUnchanged(fixture);
   });
+
+  for (const mode of ["branch", "detached"] as const) {
+    it.each([
+      {
+        name: "partially restored index",
+        setup: ['git restore --source="$target_sha" --staged --worktree -- pr-only.txt'],
+      },
+      {
+        name: "fully restored index",
+        setup: ['git restore --source="$target_sha" --staged --worktree -- .'],
+      },
+      {
+        name: "interrupted recovery checkout",
+        setup: [
+          'git() { if [ "${1:-}" = checkout ]; then return 73; fi; command git "$@"; }',
+          "if recover_review_transition 42; then exit 1; fi",
+          "unset -f git",
+          'git diff --cached --quiet "$target_sha"',
+        ],
+      },
+    ])(`recovers completed deletions after $name (${mode})`, ({ setup }) => {
+      const fixture = createReviewFixture();
+      const worktree = join(fixture.root, ".worktrees", "pr-42");
+      const result = runShell(fixture, [
+        "review_init 42",
+        "review_checkout_pr 42",
+        'printf "preserve me\\n" > .local/review-note',
+        "source_sha=$(git rev-parse HEAD)",
+        "target_sha=$(git rev-parse origin/main)",
+        `write_review_transition_journal 42 "$source_sha" "$target_sha" ${mode} temp/pr-42`,
+        ...setup,
+        "test ! -e pr-only.txt",
+        'test "$(git rev-parse HEAD)" = "$source_sha"',
+        "test -f .local/review-transition.json",
+        "recover_review_transition 42",
+      ]);
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(git(worktree, "rev-parse", "HEAD")).toBe(fixture.mainSha);
+      expect(git(worktree, "branch", "--show-current")).toBe(mode === "branch" ? "temp/pr-42" : "");
+      expect(git(worktree, "status", "--porcelain=v1", "--untracked-files=no")).toBe("");
+      expect(existsSync(join(worktree, "pr-only.txt"))).toBe(false);
+      expect(readFileSync(join(worktree, ".local", "review-note"), "utf8")).toBe("preserve me\n");
+      expect(existsSync(join(worktree, ".local", "review-transition.json"))).toBe(false);
+      expectCanonicalCheckoutUnchanged(fixture);
+    });
+  }
 
   for (const testCase of [
     {


### PR DESCRIPTION
Closes #130628. Observed while preparing #130595.

## What Problem This Solves

Fixes an issue where maintainers retrying an interrupted PR checkout would remain stuck on a Git pathspec error when the transition had already deleted a file. The failure also occurs when all files reached the target but checkout was interrupted before moving HEAD.

## Why This Change Was Made

Recovery already proves that every index entry belongs to the journaled source or target. It now restores only entries still different from the target, instead of replaying completed deletions that Git can no longer resolve. The journal, source/target validation, literal NUL-delimited filenames, foreign-state refusal, and final tree/branch checks are unchanged.

The owner is `recover_review_transition` in `scripts/pr-lib/worktree.sh`; both native initialization and main/PR checkout use it. No reset, force-clean, fallback checkout, or relaxation of the worktree-containment boundary is added. The earlier recovery implementation was introduced in #125467 and carried forward by #129169's bounded pathspec streaming.

## User Impact

Interrupted maintainer PR transitions can be resumed after completed deletions. Product runtime, plugin APIs, configuration, and persisted user data do not change. Tooling is +4/-2 lines (the two extra lines explain the retry invariant); tests are +48. This repair is not counted toward the production cleanup target.

## Evidence

Six real-Git regressions fail on the original implementation with `pathspec 'pr-only.txt' did not match any file(s) known to git`. They cover partially restored and fully restored indexes plus a real recovery interrupted at checkout, in both branch and detached modes.

On the fix, all **64 tests across three suites passed**:

```sh
node scripts/run-vitest.mjs test/scripts/pr-worktree-containment.test.ts test/scripts/pr-wrappers.test.ts test/scripts/pr-review-artifact-validation.test.ts
bash -n scripts/pr-lib/worktree.sh
git diff --check
```

This exercises actual registered temporary Git worktrees and preserves sibling checkouts and review artifacts. Existing foreign staged/unstaged/untracked/ignored-state refusals and literal filename/bounded-argument regressions remain passing. Tested on macOS 27.0, Git 2.55.0, Node 24.19.0.

Complete independent pre-commit Codex review passed with no P0–P3 findings. It reviewed the full patch, complete owner/callers/tests and both baseline files with authenticated read-only isolation. A separate published-head review and ordinary exact-head hosted CI are still required before native preparation and merge.

Local formatting and initial changed-check guards passed. The complete local changed gate and targeted typed-lint wrapper could not finish because the shared installed dependencies are stale: for example Vitest 4.1.10 versus pinned 4.1.11, markdown-it 14.3.0 versus 15.0.0, and pi-tui 0.82.1 versus 0.84.2. The reported type errors were outside the changed files; no dependencies, assertions, or guards were weakened. Pinned hosted checks must close that gap before landing. No build is needed for this shell-only tooling/runtime boundary.

AI-assisted implementation and review.
