### PR TITLE
fix(gateway): finish node disconnect cleanup before yielding

### DIFF
--- a/src/gateway/server.node-chat-subscriptions.test.ts
+++ b/src/gateway/server.node-chat-subscriptions.test.ts
@@ -1,7 +1,9 @@
 // Real gateway WebSocket coverage for canonical node chat subscriptions and reconnects.
 import { describe, expect, test, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { registerAgentRunContext } from "../infra/agent-run-registry.js";
+import * as devicePairingNode from "../infra/device-pairing-node.js";
 import { approveNodePairing, requestNodePairing } from "../infra/device-pairing-node.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
 import { pairDeviceIdentity } from "./device-authz.test-helpers.js";
@@ -61,6 +63,9 @@ describe("gateway node chat subscriptions", () => {
       const reconnectEvents: ReceivedNodeEvent[] = [];
       let first: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
       let reconnected: Awaited<ReturnType<typeof connectGatewayClient>> | undefined;
+      const disconnectHistoryPending = createDeferred();
+      const recordDisconnection = devicePairingNode.recordPairedNodeDisconnection;
+      const disconnectHistory = vi.spyOn(devicePairingNode, "recordPairedNodeDisconnection");
       const connectNode = (events: ReceivedNodeEvent[]) =>
         connectGatewayClient({
           url: `ws://127.0.0.1:${getStarted().port}`,
@@ -87,8 +92,13 @@ describe("gateway node chat subscriptions", () => {
         emitCompletedSessionRun("canonical-node-first", "agent:main:main");
         await expectNodeChatEvent(firstEvents, "canonical-node-first", "agent:main:main");
 
+        disconnectHistory.mockImplementationOnce(async (params) => {
+          await disconnectHistoryPending.promise;
+          return recordDisconnection(params);
+        });
         await first.stopAndWait();
         first = undefined;
+        await vi.waitFor(() => expect(disconnectHistory).toHaveBeenCalledOnce());
 
         reconnected = await connectNode(reconnectEvents);
         await reconnected.request("node.event", {
@@ -97,6 +107,16 @@ describe("gateway node chat subscriptions", () => {
         });
         emitCompletedSessionRun("canonical-node-reconnect", "agent:main:main");
         await expectNodeChatEvent(reconnectEvents, "canonical-node-reconnect", "agent:main:main");
+
+        // Completing the old connection's history must not retire its replacement's observer.
+        disconnectHistoryPending.resolve();
+        await disconnectHistory.mock.results[0]?.value;
+        emitCompletedSessionRun("canonical-node-after-disconnect-history", "agent:main:main");
+        await expectNodeChatEvent(
+          reconnectEvents,
+          "canonical-node-after-disconnect-history",
+          "agent:main:main",
+        );
 
         await reconnected.request("node.event", {
           event: "chat.subscribe",
@@ -125,6 +145,9 @@ describe("gateway node chat subscriptions", () => {
           }),
         );
       } finally {
+        disconnectHistoryPending.resolve();
+        await disconnectHistory.mock.results[0]?.value;
+        disconnectHistory.mockRestore();
         await first?.stopAndWait();
         await reconnected?.stopAndWait();
       }

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -543,30 +543,12 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
               }
             }
             currentDisconnectedNodeId = context.nodeRegistry.unregister(connId);
-            if (
-              disconnectedNodeHistory &&
-              currentDisconnectedNodeId === disconnectedNodeHistory.nodeId
-            ) {
-              try {
-                await recordPairedNodeDisconnection({
-                  nodeId: disconnectedNodeHistory.nodeId,
-                  connectedAtMs: disconnectedNodeHistory.connectedAtMs,
-                  disconnectedAtMs: disconnectedNodeHistory.disconnectedAtMs,
-                  expectedPairingGeneration: {
-                    nodeId: disconnectedNodeHistory.nodeId,
-                    key: disconnectedNodeHistory.pairingGeneration,
-                  },
-                });
-              } catch (error) {
-                logGateway.warn(
-                  `failed to record node disconnect for ${disconnectedNodeHistory.nodeId}: ${formatForLog(error)}`,
-                );
-              }
-            }
           } finally {
             retainClientUntilNodeDrain = false;
           }
         }
+        // Retire node-owned projections before history persistence yields; a reconnect
+        // may own this node id by the time the write finishes.
         if (
           client?.presenceKey &&
           (client.connect.role !== "node" || currentDisconnectedNodeId !== null)
@@ -581,6 +563,26 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
           removeRemoteNodeInfo(currentDisconnectedNodeId);
           context.nodeUnsubscribeAll(currentDisconnectedNodeId);
           clearNodeWakeState(currentDisconnectedNodeId);
+        }
+        if (
+          disconnectedNodeHistory &&
+          currentDisconnectedNodeId === disconnectedNodeHistory.nodeId
+        ) {
+          try {
+            await recordPairedNodeDisconnection({
+              nodeId: disconnectedNodeHistory.nodeId,
+              connectedAtMs: disconnectedNodeHistory.connectedAtMs,
+              disconnectedAtMs: disconnectedNodeHistory.disconnectedAtMs,
+              expectedPairingGeneration: {
+                nodeId: disconnectedNodeHistory.nodeId,
+                key: disconnectedNodeHistory.pairingGeneration,
+              },
+            });
+          } catch (error) {
+            logGateway.warn(
+              `failed to record node disconnect for ${disconnectedNodeHistory.nodeId}: ${formatForLog(error)}`,
+            );
+          }
         }
       }
       logWs("out", "close", {

--- a/src/gateway/watch-node-http.test.ts
+++ b/src/gateway/watch-node-http.test.ts
@@ -12,6 +12,7 @@ import {
   GATEWAY_CLIENT_MODES,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { PROTOCOL_VERSION, type ConnectParams } from "../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   issueDeviceBootstrapToken,
@@ -25,6 +26,7 @@ import {
 } from "../infra/device-identity.js";
 import { approveDevicePairing } from "../infra/device-pairing-approval.js";
 import { listNodePairing } from "../infra/device-pairing-node.js";
+import { withDevicePairingLock } from "../infra/device-pairing-state.js";
 import { loadDevicePairSetupCompletionRecord } from "../infra/device-pairing-store.js";
 import { revokeDeviceToken } from "../infra/device-pairing-tokens.js";
 import {
@@ -438,18 +440,30 @@ describe("watch node HTTP transport", () => {
     expect(wrongMethod.status).toBe(405);
     expect(nodeRegistry.get(identity.deviceId)).toBeDefined();
 
-    const disconnectResponse = await fetch(`${baseUrl}/disconnect`, {
-      method: "POST",
-      headers: { authorization: `Bearer ${sessionToken}` },
+    await waitForLastConnectedMetadata(baseDir, identity.deviceId);
+    const pairingLockReady = createDeferred();
+    const pairingLockPending = createDeferred();
+    const pairingLock = withDevicePairingLock(async () => {
+      pairingLockReady.resolve();
+      await pairingLockPending.promise;
     });
-    expect(disconnectResponse.status).toBe(200);
-    await expect(readJson(disconnectResponse)).resolves.toEqual({ ok: true });
-    expect(nodeRegistry.get(identity.deviceId)).toBeUndefined();
-    await vi.waitFor(() =>
+    await pairingLockReady.promise;
+    try {
+      const disconnectResponse = await fetch(`${baseUrl}/disconnect`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${sessionToken}` },
+      });
+      expect(disconnectResponse.status).toBe(200);
+      await expect(readJson(disconnectResponse)).resolves.toEqual({ ok: true });
+      expect(nodeRegistry.get(identity.deviceId)).toBeUndefined();
+      // Presence/subscription retirement must not wait for the unrelated history write.
       expect(disconnectedNodes).toEqual([
         { nodeId: identity.deviceId, reason: "watch disconnected" },
-      ]),
-    );
+      ]);
+    } finally {
+      pairingLockPending.resolve();
+      await pairingLock;
+    }
     await vi.waitFor(async () => {
       const paired = (await listNodePairing(baseDir)).paired.find(
         (entry) => entry.nodeId === identity.deviceId,

--- a/src/gateway/watch-node-http.ts
+++ b/src/gateway/watch-node-http.ts
@@ -346,29 +346,27 @@ export function createWatchNodeHttpRuntime(options: WatchNodeHttpRuntimeOptions)
         : undefined;
     const disconnectedNodeId = options.nodeRegistry.unregister(session.connId);
     if (disconnectedNodeId) {
-      void (async () => {
-        try {
-          if (disconnectHistory && disconnectHistory.nodeId === disconnectedNodeId) {
-            await recordPairedNodeDisconnection({
-              nodeId: disconnectHistory.nodeId,
-              connectedAtMs: disconnectHistory.connectedAtMs,
-              disconnectedAtMs: now(),
-              expectedPairingGeneration: {
-                nodeId: disconnectHistory.nodeId,
-                key: disconnectHistory.pairingGeneration,
-              },
-              baseDir: options.pairingBaseDir,
-            });
-          }
-        } catch (error) {
-          options.onError?.("watch node disconnect persistence failed", error);
-        }
-        try {
-          options.onNodeDisconnected?.(disconnectedNodeId, reason);
-        } catch (error) {
-          options.onError?.("watch node disconnect cleanup failed", error);
-        }
-      })();
+      const disconnectedAtMs = now();
+      // Finish node-owned cleanup before persistence yields to a replacement connection.
+      try {
+        options.onNodeDisconnected?.(disconnectedNodeId, reason);
+      } catch (error) {
+        options.onError?.("watch node disconnect cleanup failed", error);
+      }
+      if (disconnectHistory && disconnectHistory.nodeId === disconnectedNodeId) {
+        void recordPairedNodeDisconnection({
+          nodeId: disconnectHistory.nodeId,
+          connectedAtMs: disconnectHistory.connectedAtMs,
+          disconnectedAtMs,
+          expectedPairingGeneration: {
+            nodeId: disconnectHistory.nodeId,
+            key: disconnectHistory.pairingGeneration,
+          },
+          baseDir: options.pairingBaseDir,
+        }).catch((error: unknown) =>
+          options.onError?.("watch node disconnect persistence failed", error),
+        );
+      }
     }
   };
 


### PR DESCRIPTION
## Summary

Finish node-wide disconnect cleanup synchronously after unregistering the exact connection, before awaiting connection-history persistence. Both Gateway WebSocket nodes and Watch HTTP nodes had the same race: a replacement could connect during the await, then the old disconnect would erase the replacement's subscriptions, presence, and projection state.

The connection lifecycle owns this cleanup. The change preserves dispatch draining and existing pairing/history generation fences, moves the cleanup before the first yield, and removes the redundant Watch async wrapper. No protocol, authorization, schema, or configuration changes. Production LOC: +43/-43; tests: +46/-9.

## Verification

- Captured the failure before editing using authenticated Gateway WebSocket and Watch HTTP connections, real pairing state, and a held history-write boundary. Replacement delivery was lost after the old disconnect resumed.
- The same scenarios pass with the fix. Independent before/after probes also retain replacement fanout, reject stale credentials with HTTP 401, and refuse a stale history write.
- 47 focused owner/sibling tests passed; the final durable regression run passed all 17 tests. The complete local `check:changed` gate and `git diff --check` passed.
- Independent source review found the affected owner/caller files unchanged on refreshed main. Structured Codex autoreview completed with no findings at its default P0 threshold.

Proof exercised actual local Gateway transports and persistence with isolated temporary state. It did not deploy to a physical Watch or an operator Gateway. Hosted checks on the published head remain the landing gate.
