### PR TITLE
test(gateway): await runtime ownership before lifecycle events

### DIFF
--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -2664,6 +2664,7 @@ describe("gateway server chat", () => {
     await withMainSessionStore(async () => {
       const runId = "idem-wait-chat-active-with-agent-lifecycle";
       const blockedReply = createDeferred();
+      const runtimeStarted = createDeferred();
       mockGetReplyFromConfigOnce(async (_ctx, opts) => {
         opts?.onAgentRunStart?.(runId);
         const runtimeOwner = claimAgentRunContext(
@@ -2677,6 +2678,7 @@ describe("gateway server chat", () => {
           { ownsContext: true, trackOwner: true },
         );
         expect(runtimeOwner).toBeDefined();
+        runtimeStarted.resolve();
         try {
           await blockedReply.promise;
         } finally {
@@ -2688,6 +2690,8 @@ describe("gateway server chat", () => {
         const subscribeRes = await rpcReq(ws, "sessions.subscribe", {});
         expect(subscribeRes.ok).toBe(true);
         await sendChatAndExpectStarted(runId, "hold chat run open");
+        // The ACK precedes dispatch; emit lifecycle only after the runtime owns this run.
+        await runtimeStarted.promise;
 
         const terminalSessionChange = onceMessage(
           ws,


### PR DESCRIPTION
Related: #126497, #129033, #107834

## What Problem This Solves

Resolves a scheduling race in the Gateway chat lifecycle test: a successful
`chat.send` acknowledgment does not guarantee the mocked runtime has acquired
its run ownership yet. The test could emit lifecycle completion before its
"runtime still active" precondition existed.

## Why This Change Was Made

Wait for the existing mocked runtime to finish its successful ownership claim
before emitting lifecycle events. Reuse the shared deferred helper; retain every
ownership assertion, the 40ms active-run wait, the eight-second settlement wait,
and the existing cleanup. No production code changes.

## User Impact

Test-only reliability improvement. Gateway behavior and operator configuration
are unchanged. This is maintainer-requested cleanup discovered during Copilot
validation, not a change to the Copilot model policy.

## Evidence

On trusted main baseline `96ea1e33ea63f76f0b0397aa4dda103ff6bbe635`, inserting
a 300ms asynchronous delay at the beginning of the existing mocked reply callback
reproduced the race: the terminal event reported `activeRunIds: []` before the
runtime acquired ownership, and the unchanged assertion failed with
`expected [] to be null`. With this readiness barrier and the identical delay,
the test passed. The injected delay and diagnostic logging are not in this PR.

Final patch validation:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/gateway/server.chat.gateway-server-chat.test.ts
```

Result: all 64 tests passed in their original file order. The real Gateway
WebSocket path observes active runtime ownership at terminal lifecycle, then an
empty active-run set with the correct last-run identity after cleanup. All 17
changed-surface guards, the complete core-test typecheck shards, type-aware core
lint, formatting, and diff checks passed. Independent review and fresh automated
P2 review found no actionable issues. Test delta: +4/-0; production delta: zero.

Scope clarification: this proves the startup-order race, not the separate
eight-second final-settlement timeout seen in CI runs 33031871343 and 33033789170
while validating #107834. That later timeout did not reproduce in baseline
full-file runs or the untouched baseline's exact 25-file CI group (297 tests
passed) and is not claimed fixed here. #129033's ownership-fact matcher remains
intact.

AI-assisted maintainer follow-up. The runtime-ownership fixture was introduced
in #126497 (author @zhangguiping-xydt, merged by @steipete); this PR adds only the
missing test precondition barrier.
