### PR TITLE
fix(gateway): close the history stream startup event gap

### DIFF
--- a/src/gateway/sessions-history-http.revocation.test.ts
+++ b/src/gateway/sessions-history-http.revocation.test.ts
@@ -30,10 +30,14 @@ vi.mock("../config/config.js", () => ({
 }));
 
 vi.mock("../sessions/transcript-events.js", async (importOriginal) => {
-  const { attachSessionTranscriptRunId, resolveTerminalAssistantTranscriptRunId } =
-    await importOriginal<typeof import("../sessions/transcript-events.js")>();
+  const {
+    attachSessionTranscriptRunId,
+    readSessionTranscriptUpdateVersion,
+    resolveTerminalAssistantTranscriptRunId,
+  } = await importOriginal<typeof import("../sessions/transcript-events.js")>();
   return {
     attachSessionTranscriptRunId,
+    readSessionTranscriptUpdateVersion,
     resolveTerminalAssistantTranscriptRunId,
     onInternalSessionTranscriptUpdate: (cb: typeof transcriptUpdateHandler) => {
       transcriptUpdateHandler = cb;
@@ -182,7 +186,7 @@ class MockRes extends EventEmitter {
   writes: string[] = [];
   writableEnded = false;
   socket = new EventEmitter();
-  closeOnNextWrite = false;
+  closeOnFrame?: "retry" | "history";
 
   setHeader(name: string, value: string) {
     this.headers.set(name.toLowerCase(), value);
@@ -190,8 +194,10 @@ class MockRes extends EventEmitter {
 
   write(chunk: string) {
     this.writes.push(chunk);
-    if (this.closeOnNextWrite) {
-      this.closeOnNextWrite = false;
+    const written = this.writes.join("");
+    const closeMarker = this.closeOnFrame === "retry" ? "retry:" : "event: history";
+    if (this.closeOnFrame && written.includes(closeMarker) && written.endsWith("\n\n")) {
+      this.closeOnFrame = undefined;
       this.emit("close");
     }
     return true;
@@ -218,11 +224,11 @@ async function openSessionHistoryStream(
 
 async function openSessionHistoryStreamPair(
   options: Parameters<typeof handleSessionHistoryHttpRequest>[2],
-  params?: { closeOnFirstWrite?: boolean; expectSubscribed?: boolean },
+  params?: { closeOnFrame?: "retry" | "history"; expectSubscribed?: boolean },
 ) {
   const req = new MockReq(SESSION_HISTORY_URL);
   const res = new MockRes();
-  res.closeOnNextWrite = params?.closeOnFirstWrite === true;
+  res.closeOnFrame = params?.closeOnFrame;
 
   const handled = await handleSessionHistoryHttpRequest(
     req as unknown as IncomingMessage,
@@ -520,15 +526,18 @@ describe("session history SSE auth revocation", () => {
     });
   });
 
-  it("does not create SSE resources after an initial write closes the stream", async () => {
-    const { req, res } = await openSessionHistoryStreamPair(TRUSTED_PROXY_STARTUP_OPTIONS, {
-      closeOnFirstWrite: true,
-      expectSubscribed: false,
-    });
+  it.each(["retry", "history"] as const)(
+    "cleans up SSE resources when the initial %s frame closes the stream",
+    async (closeOnFrame) => {
+      const { req, res } = await openSessionHistoryStreamPair(TRUSTED_PROXY_STARTUP_OPTIONS, {
+        closeOnFrame,
+        expectSubscribed: false,
+      });
 
-    expect(res.writes.join("")).toBe("retry: 1000\n\n");
-    expect(transcriptUpdateHandler).toBeUndefined();
-    expect(req.listenerCount("error")).toBe(0);
-    expect(res.listenerCount("error")).toBe(0);
-  });
+      expect(res.writes.join("")).toContain("retry: 1000\n\n");
+      expect(transcriptUpdateHandler).toBeUndefined();
+      expect(req.listenerCount("error")).toBe(0);
+      expect(res.listenerCount("error")).toBe(0);
+    },
+  );
 });

--- a/src/gateway/sessions-history-http.test.ts
+++ b/src/gateway/sessions-history-http.test.ts
@@ -23,6 +23,7 @@ import { ensureProfileForEmail, setAvatar, setDisplayName } from "../state/user-
 import { resolveCurrentUserProfileDisplay } from "./current-user-profile-display.js";
 import { SSE_CONTENT_TYPE } from "./http-common.js";
 import { hasExplicitAcceptableMediaRange } from "./http-media-range.js";
+import * as sessionHistoryState from "./session-history-state.js";
 import { SessionHistorySseState } from "./session-history-state.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
@@ -1605,6 +1606,56 @@ describe("session history HTTP endpoints", () => {
         seq: 2,
         id: appendedId,
       });
+    });
+  });
+
+  test.each([
+    { name: "complete", query: undefined },
+    { name: "bounded", query: "?limit=2" },
+  ])("includes updates committed while opening $name SSE history", async ({ query }) => {
+    const sessionKey = "agent:main:main";
+    const { storePath } = await seedSession({ text: "first message" });
+
+    await withGatewayHarness(async (harness) => {
+      const readSnapshot = sessionHistoryState.readSessionHistoryRawSnapshotAsync;
+      const snapshotSpy = vi
+        .spyOn(sessionHistoryState, "readSessionHistoryRawSnapshotAsync")
+        .mockImplementationOnce(async (params) => {
+          const snapshot = await readSnapshot(params);
+          await appendVisibleAssistantMessage({
+            sessionKey,
+            text: "committed during startup",
+            storePath,
+          });
+          return snapshot;
+        });
+      try {
+        const stream = await openSessionHistorySse(harness.port, sessionKey, { query });
+        try {
+          await expectHistoryEventTexts(stream, ["first message", "committed during startup"]);
+          const thirdId = await appendVisibleAssistantMessage({
+            sessionKey,
+            text: "live after startup",
+            storePath,
+          });
+          if (query) {
+            await expectHistoryEventTexts(stream, [
+              "committed during startup",
+              "live after startup",
+            ]);
+          } else {
+            await expectMessageEventMatch(stream, {
+              text: "live after startup",
+              seq: 3,
+              id: thirdId,
+            });
+          }
+        } finally {
+          await stream.reader.cancel();
+        }
+      } finally {
+        snapshotSpy.mockRestore();
+      }
     });
   });
 

--- a/src/gateway/sessions-history-http.ts
+++ b/src/gateway/sessions-history-http.ts
@@ -13,7 +13,10 @@ import { getRuntimeConfig } from "../config/io.js";
 import { isSessionTranscriptProjectionUnavailableError } from "../config/sessions/session-accessor.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import { onInternalSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import {
+  onInternalSessionTranscriptUpdate,
+  readSessionTranscriptUpdateVersion,
+} from "../sessions/transcript-events.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import { DEFAULT_CHAT_HISTORY_TEXT_MAX_CHARS } from "./chat-display-projection.js";
@@ -224,6 +227,7 @@ export async function handleSessionHistoryHttpRequest(
     sessionKey: target.canonicalKey,
     storePath: target.storePath,
   };
+  const snapshotVersion = readSessionTranscriptUpdateVersion();
   let rawSnapshot: Awaited<ReturnType<typeof readSessionHistoryRawSnapshotAsync>>;
   try {
     rawSnapshot = await readSessionHistoryRawSnapshotAsync({
@@ -272,7 +276,6 @@ export async function handleSessionHistoryHttpRequest(
     ...historySnapshot,
     target: historyTarget,
   });
-  let sentHistory = sseState.snapshot();
   let streamStopped = false;
   let streamQueue = Promise.resolve();
   const streamResources: {
@@ -287,7 +290,7 @@ export async function handleSessionHistoryHttpRequest(
     });
     // Send the entire requested page before bounding private live state.
     // Cursor refreshes reread SQLite, so their next page remains complete.
-    sentHistory = sseState.retainRecentMessages(MAX_SESSION_HISTORY_LIMIT);
+    sseState.retainRecentMessages(MAX_SESSION_HISTORY_LIMIT);
   }
 
   function releaseStreamResources() {
@@ -362,15 +365,10 @@ export async function handleSessionHistoryHttpRequest(
   if (isStreamClosed()) {
     return true;
   }
-  writeStreamHistory(sentHistory);
-  if (isStreamClosed()) {
-    return true;
-  }
-
   const queueStreamWork = (work: () => Promise<void>) => {
     streamQueue = streamQueue
       .then(async () => {
-        if (streamStopped || res.writableEnded) {
+        if (isStreamClosed()) {
           return;
         }
         await work();
@@ -383,6 +381,17 @@ export async function handleSessionHistoryHttpRequest(
         closeStream();
       });
   };
+
+  // The listener is installed before this queued delivery runs. Refresh once if a
+  // commit crossed the initial read; subsequent updates queue behind this snapshot.
+  queueStreamWork(async () => {
+    if (snapshotVersion !== readSessionTranscriptUpdateVersion()) {
+      await sseState.refreshAsync();
+    }
+    if (!isStreamClosed()) {
+      writeStreamHistory(sseState.snapshot());
+    }
+  });
 
   const isStreamStillAuthorized = async (): Promise<boolean> => {
     const cfgLocal = getRuntimeConfig();
@@ -457,48 +466,40 @@ export async function handleSessionHistoryHttpRequest(
       return;
     }
     queueStreamWork(async () => {
-      if (res.writableEnded) {
-        return;
-      }
       if (!(await isStreamStillAuthorized())) {
         closeStream();
         return;
       }
-      if (update.message !== undefined) {
-        if (limit === undefined && cursor === undefined) {
-          if (sseState.shouldRefreshForTranscriptPath(updatePath)) {
-            sentHistory = await sseState.refreshAsync();
-            writeStreamHistory(sentHistory);
-            return;
-          }
-          const nextEvent = sseState.appendInlineMessage({
-            message: update.message,
-            messageId: update.messageId,
-            messageSeq: update.messageSeq,
-          });
-          if (!nextEvent) {
-            return;
-          }
-          if (nextEvent.shouldRefresh) {
-            sentHistory = await sseState.refreshAsync();
-            writeStreamHistory(sentHistory);
-            return;
-          }
-          if (nextEvent.message === undefined) {
-            return;
-          }
-          sentHistory = sseState.retainRecentMessages(MAX_SESSION_HISTORY_LIMIT);
-          sseWrite(res, "message", {
-            sessionKey: target.canonicalKey,
-            message: nextEvent.message,
-            ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),
-            messageSeq: nextEvent.messageSeq,
-          });
+      if (update.message !== undefined && limit === undefined && cursor === undefined) {
+        if (sseState.shouldRefreshForTranscriptPath(updatePath)) {
+          writeStreamHistory(await sseState.refreshAsync());
           return;
         }
+        const nextEvent = sseState.appendInlineMessage({
+          message: update.message,
+          messageId: update.messageId,
+          messageSeq: update.messageSeq,
+        });
+        if (!nextEvent) {
+          return;
+        }
+        if (nextEvent.shouldRefresh) {
+          writeStreamHistory(await sseState.refreshAsync());
+          return;
+        }
+        if (nextEvent.message === undefined) {
+          return;
+        }
+        sseState.retainRecentMessages(MAX_SESSION_HISTORY_LIMIT);
+        sseWrite(res, "message", {
+          sessionKey: target.canonicalKey,
+          message: nextEvent.message,
+          ...(typeof update.messageId === "string" ? { messageId: update.messageId } : {}),
+          messageSeq: nextEvent.messageSeq,
+        });
+        return;
       }
-      sentHistory = await sseState.refreshAsync();
-      writeStreamHistory(sentHistory);
+      writeStreamHistory(await sseState.refreshAsync());
     });
   });
   return true;


### PR DESCRIPTION
## Summary

Close the history SSE startup gap between reading the initial transcript and subscribing to transcript updates. A message committed during that interval could disappear from both the initial history and subsequent stream, leaving the client permanently incomplete.

The stream owner now captures the existing transcript mutation version before reading, installs its listener synchronously, and queues the initial history before subsequent updates. If a mutation crossed the initial read, it refreshes that snapshot once. This removes duplicate sent-history state without adding an event buffer, protocol field, database schema, or authorization path. Production LOC: +45/-44; tests: +77/-17. The one net production line expresses the missing startup ordering invariant.

## Verification

- Actual Gateway HTTP and SQLite reproductions failed before the fix for both complete and bounded initial history: a second message committed during the first read was absent. Both cases pass after the fix.
- A separate loopback probe with injected auth/storage dependencies observed the pre-fix gap while a later third message still arrived. The candidate instead produced initial history containing messages 1 and 2, followed by message 3.
- The final 131-test run passed: 40 state/revocation tests and 91 Gateway HTTP tests. Cleanup closes after a complete SSE frame; its 12-test rerun also passed.
- The complete local `check:changed` gate and `git diff --check` passed. Independent current-main review found the affected files unchanged. Structured Codex autoreview completed with no findings at its default P0 threshold.

An unrelated concurrent transcript mutation can cause one extra startup snapshot read. Existing authorization/revocation, history limits, and queue behavior are retained. This does not address the separate stream-backpressure report in #127368. Hosted checks on the published head remain the landing gate.
