### PR TITLE
fix(daemon): preserve structured command termination outcomes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2511,7 +2511,7 @@ src/commands/doctor-config-analysis.ts	3
 src/commands/doctor-config-flow.ts	3
 src/commands/doctor-config-preflight.cron.ts	4
 src/commands/doctor-db-bloat.ts	1
-src/commands/doctor-gateway-services.ts	2
+src/commands/doctor-gateway-services.ts	1
 src/commands/doctor-heartbeat-main-session-repair.ts	1
 src/commands/doctor-heartbeat-scratch-migration.ts	6
 src/commands/doctor-main-session-recovery.ts	1

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -5,7 +5,9 @@ import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import type { LaunchctlResult } from "../daemon/launchd-exec.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { withTempDir } from "../test-utils/temp-dir.js";
 import { createDoctorPrompter } from "./doctor-prompter.js";
 import {
   readEmbeddedGatewayTokenForTest,
@@ -51,7 +53,7 @@ const mocks = vi.hoisted(() => ({
   uninstallLegacySystemdUnits: vi.fn().mockResolvedValue([]),
   readWindowsProcessArgsSync: vi.fn(),
   readWindowsStartupFallbackRuntimeForUpdate: vi.fn(),
-  runExec: vi.fn(),
+  execLaunchctl: vi.fn(),
   findSystemdGatewayInstallation: vi.fn().mockResolvedValue({ kind: "none" }),
   isSystemUnitActiveAndEnabled: vi.fn().mockResolvedValue(false),
   uninstallUserSystemdGatewayUnit: vi.fn().mockResolvedValue({
@@ -136,8 +138,9 @@ vi.mock("../infra/container-environment.js", () => ({
   isContainerEnvironment: mocks.isContainerEnvironment,
 }));
 
-vi.mock("../process/exec.js", () => ({
-  runExec: mocks.runExec,
+vi.mock("../daemon/launchd-exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../daemon/launchd-exec.js")>()),
+  execLaunchctl: mocks.execLaunchctl,
 }));
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
@@ -221,52 +224,33 @@ function setupLegacyMacService() {
   ]);
 }
 
-function launchctlFailure(
-  params: {
-    message?: string;
-    stderr?: string;
-    stdout?: string;
-    timedOut?: boolean;
-  } = {},
-) {
-  return Object.assign(new Error(params.message ?? "launchctl failed"), {
-    stderr: params.stderr ?? "",
-    stdout: params.stdout ?? "",
-    ...(params.timedOut ? { timedOut: true } : {}),
-  });
+function launchctlResult(params: Partial<LaunchctlResult> = {}): LaunchctlResult {
+  return { stdout: "", stderr: "", code: 0, termination: "exit", ...params };
 }
 
 function expectBoundedLaunchctlCleanup() {
   const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-  expect(mocks.runExec).toHaveBeenNthCalledWith(
+  expect(mocks.execLaunchctl).toHaveBeenNthCalledWith(
     1,
-    "launchctl",
     ["bootout", domain, LEGACY_MAC_PLIST],
-    { logOutput: false, timeoutMs: 5_000 },
+    5_000,
   );
-  expect(mocks.runExec).toHaveBeenNthCalledWith(2, "launchctl", ["unload", LEGACY_MAC_PLIST], {
-    logOutput: false,
-    timeoutMs: 5_000,
-  });
-  expect(mocks.runExec).toHaveBeenNthCalledWith(
+  expect(mocks.execLaunchctl).toHaveBeenNthCalledWith(2, ["unload", LEGACY_MAC_PLIST], 5_000);
+  expect(mocks.execLaunchctl).toHaveBeenNthCalledWith(
     3,
-    "launchctl",
     ["print", `${domain}/${LEGACY_MAC_LABEL}`],
-    {
-      logOutput: false,
-      timeoutMs: expect.any(Number),
-    },
+    expect.any(Number),
   );
-  const probeTimeout = mocks.runExec.mock.calls[2]?.[2]?.timeoutMs;
+  const probeTimeout = mocks.execLaunchctl.mock.calls[2]?.[1];
   expect(probeTimeout).toBeGreaterThan(0);
   expect(probeTimeout).toBeLessThanOrEqual(5_000);
 }
 
 function mockConfirmedUnloaded(stderr = "Could not find service") {
-  mocks.runExec
-    .mockResolvedValueOnce({ stdout: "", stderr: "" })
-    .mockResolvedValueOnce({ stdout: "", stderr: "" })
-    .mockRejectedValueOnce(launchctlFailure({ stderr }));
+  mocks.execLaunchctl
+    .mockResolvedValueOnce(launchctlResult())
+    .mockResolvedValueOnce(launchctlResult())
+    .mockResolvedValueOnce(launchctlResult({ code: 113, stderr }));
 }
 
 async function runRepair(cfg: OpenClawConfig, options: { allowExecSecretRefs?: boolean } = {}) {
@@ -1962,7 +1946,7 @@ describe("maybeScanExtraGatewayServices", () => {
     mocks.renderGatewayServiceCleanupHints.mockReturnValue([]);
     mocks.isSystemdUnitActive.mockResolvedValue(false);
     mocks.uninstallLegacySystemdUnits.mockResolvedValue([]);
-    mocks.runExec.mockResolvedValue({ stdout: "", stderr: "" });
+    mocks.execLaunchctl.mockReset().mockResolvedValue(launchctlResult());
   });
 
   afterEach(() => {
@@ -2211,11 +2195,11 @@ describe("maybeScanExtraGatewayServices", () => {
   );
 
   it.each([
-    ["timeouts", launchctlFailure({ timedOut: true })],
-    ["unknown failures", launchctlFailure({ stderr: "Permission denied" })],
+    ["timeouts", launchctlResult({ code: 124, termination: "timeout" })],
+    ["unknown failures", launchctlResult({ code: 1, stderr: "Permission denied" })],
   ])("keeps the plist when both launchctl calls end in %s", async (_, failure) => {
     setupLegacyMacService();
-    mocks.runExec.mockRejectedValue(failure);
+    mocks.execLaunchctl.mockResolvedValue(failure);
     const mkdir = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
     const access = vi.spyOn(fs, "access").mockResolvedValue(undefined);
     const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
@@ -2239,11 +2223,11 @@ describe("maybeScanExtraGatewayServices", () => {
 
   it("keeps the plist when a successful cleanup command is followed by a loaded probe", async () => {
     setupLegacyMacService();
-    mocks.runExec
-      .mockRejectedValueOnce(launchctlFailure({ timedOut: true }))
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })
-      .mockResolvedValueOnce({ stdout: "state = waiting\npid = 0\n", stderr: "" })
-      .mockRejectedValueOnce(launchctlFailure({ stderr: "Permission denied" }));
+    mocks.execLaunchctl
+      .mockResolvedValueOnce(launchctlResult({ code: 124, termination: "timeout" }))
+      .mockResolvedValueOnce(launchctlResult())
+      .mockResolvedValueOnce(launchctlResult({ stdout: "state = waiting\npid = 0\n" }))
+      .mockResolvedValueOnce(launchctlResult({ code: 1, stderr: "Permission denied" }));
     const mkdir = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
     const access = vi.spyOn(fs, "access").mockResolvedValue(undefined);
     const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
@@ -2251,7 +2235,7 @@ describe("maybeScanExtraGatewayServices", () => {
 
     await maybeScanExtraGatewayServices({ deep: false }, runtime, makeDoctorPrompts());
 
-    expect(mocks.runExec).toHaveBeenCalledTimes(4);
+    expect(mocks.execLaunchctl).toHaveBeenCalledTimes(4);
     expect(mkdir).not.toHaveBeenCalled();
     expect(access).not.toHaveBeenCalled();
     expect(rename).not.toHaveBeenCalled();
@@ -2262,49 +2246,78 @@ describe("maybeScanExtraGatewayServices", () => {
     expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
   });
 
-  it("keeps the plist when the postcondition probe times out", async () => {
-    setupLegacyMacService();
-    mocks.runExec
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })
-      .mockRejectedValueOnce(
-        launchctlFailure({
-          message: "Command timed out after 5000 milliseconds",
-          stderr: "Could not find service",
-        }),
+  it.each(["timeout", "signal"] as const)(
+    "keeps the plist when the postcondition probe ends with %s",
+    async (termination) => {
+      setupLegacyMacService();
+      mocks.execLaunchctl
+        .mockResolvedValueOnce(launchctlResult())
+        .mockResolvedValueOnce(launchctlResult())
+        .mockResolvedValueOnce(
+          launchctlResult({ code: 124, termination, stderr: "Could not find service" }),
+        );
+      const mkdir = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+      const access = vi.spyOn(fs, "access").mockResolvedValue(undefined);
+      const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
+      const runtime = makeDoctorIo();
+
+      await maybeScanExtraGatewayServices({ deep: false }, runtime, makeDoctorPrompts());
+
+      expectBoundedLaunchctlCleanup();
+      expect(mkdir).not.toHaveBeenCalled();
+      expect(access).not.toHaveBeenCalled();
+      expect(rename).not.toHaveBeenCalled();
+      expectNoteContaining(
+        `${LEGACY_MAC_LABEL} (launchctl could not confirm unload)`,
+        "Legacy gateway cleanup skipped",
       );
-    const mkdir = vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
-    const access = vi.spyOn(fs, "access").mockResolvedValue(undefined);
-    const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
-    const runtime = makeDoctorIo();
+      expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
+    },
+  );
 
-    await maybeScanExtraGatewayServices({ deep: false }, runtime, makeDoctorPrompts());
-
-    expectBoundedLaunchctlCleanup();
-    expect(mkdir).not.toHaveBeenCalled();
-    expect(access).not.toHaveBeenCalled();
-    expect(rename).not.toHaveBeenCalled();
-    expectNoteContaining(
-      `${LEGACY_MAC_LABEL} (launchctl could not confirm unload)`,
-      "Legacy gateway cleanup skipped",
-    );
-    expectNoNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
-  });
+  it.skipIf(process.platform === "win32").each([false, true])(
+    "uses real command outcomes for legacy cleanup (signal=%s)",
+    async (signal) => {
+      setupLegacyMacService();
+      const actual = await vi.importActual<typeof import("../daemon/launchd-exec.js")>(
+        "../daemon/launchd-exec.js",
+      );
+      mocks.execLaunchctl.mockImplementation(actual.execLaunchctl);
+      await withTempDir("openclaw-doctor-launchctl-", async (dir) => {
+        await fs.writeFile(
+          path.join(dir, "launchctl"),
+          `#!/bin/sh\nif [ "$1" = print ]; then\n  printf 'Could not find service\\n' >&2\n  ${signal ? "kill -TERM $$" : "exit 113"}\nfi\nexit 0\n`,
+          { mode: 0o700 },
+        );
+        vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
+        vi.spyOn(fs, "access").mockResolvedValue(undefined);
+        const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
+        await withEnvAsync({ PATH: dir }, async () => {
+          await maybeScanExtraGatewayServices({ deep: false }, makeDoctorIo(), makeDoctorPrompts());
+        });
+        expect(rename).toHaveBeenCalledTimes(signal ? 0 : 1);
+        expectNoteContaining(
+          LEGACY_MAC_LABEL,
+          signal ? "Legacy gateway cleanup skipped" : "Legacy gateway removed",
+        );
+      });
+    },
+  );
 
   it("polls a still-registered stopped label until launchd reports it gone", async () => {
     setupLegacyMacService();
-    mocks.runExec
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })
-      .mockResolvedValueOnce({ stdout: "state = waiting\npid = 0\n", stderr: "" })
-      .mockRejectedValueOnce(launchctlFailure({ stderr: "Could not find service" }));
+    mocks.execLaunchctl
+      .mockResolvedValueOnce(launchctlResult())
+      .mockResolvedValueOnce(launchctlResult())
+      .mockResolvedValueOnce(launchctlResult({ stdout: "state = waiting\npid = 0\n" }))
+      .mockResolvedValueOnce(launchctlResult({ code: 113, stderr: "Could not find service" }));
     vi.spyOn(fs, "mkdir").mockResolvedValue(undefined);
     vi.spyOn(fs, "access").mockResolvedValue(undefined);
     const rename = vi.spyOn(fs, "rename").mockResolvedValue(undefined);
 
     await maybeScanExtraGatewayServices({ deep: false }, makeDoctorIo(), makeDoctorPrompts());
 
-    expect(mocks.runExec).toHaveBeenCalledTimes(4);
+    expect(mocks.execLaunchctl).toHaveBeenCalledTimes(4);
     expect(rename).toHaveBeenCalledTimes(1);
     expectNoteContaining(LEGACY_MAC_LABEL, "Legacy gateway removed");
   });

--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 // Doctor gateway service tests cover service audit diagnostics and duplicate gateway service reporting.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -49,7 +50,9 @@ const mocks = vi.hoisted(() => ({
   needsNodeRuntimeMigration: vi.fn(() => false),
   renderSystemNodeWarning: vi.fn().mockReturnValue(undefined),
   resolveSystemNodeInfo: vi.fn().mockResolvedValue(null),
-  isSystemdUnitActive: vi.fn().mockResolvedValue(false),
+  isSystemdUnitActive: vi
+    .fn<typeof import("../daemon/systemd-exec.js").isSystemdUnitActive>()
+    .mockResolvedValue({ ok: true, value: false }),
   uninstallLegacySystemdUnits: vi.fn().mockResolvedValue([]),
   readWindowsProcessArgsSync: vi.fn(),
   readWindowsStartupFallbackRuntimeForUpdate: vi.fn(),
@@ -433,7 +436,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
     mocks.needsNodeRuntimeMigration.mockReturnValue(false);
     mocks.renderSystemNodeWarning.mockReturnValue(undefined);
     mocks.resolveSystemNodeInfo.mockResolvedValue(null);
-    mocks.isSystemdUnitActive.mockResolvedValue(false);
+    mocks.isSystemdUnitActive.mockResolvedValue(ok(false));
     mocks.readWindowsProcessArgsSync.mockReturnValue(["node", "openclaw.mjs", "update"]);
     mocks.resolveGatewayAuthTokenForService.mockImplementation(async (cfg: OpenClawConfig, env) => {
       const configToken =
@@ -1053,7 +1056,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
       ...createGatewayCommand("/opt/new-openclaw/dist/index.js"),
       workingDirectory: "/tmp",
     });
-    mocks.isSystemdUnitActive.mockResolvedValue(true);
+    mocks.isSystemdUnitActive.mockResolvedValue(ok(true));
 
     await runRepair({ gateway: {} });
 
@@ -1144,7 +1147,7 @@ describe("maybeRepairGatewayServiceConfig", () => {
       ...createGatewayCommand("/opt/new-openclaw/dist/index.js"),
       workingDirectory: "/tmp",
     });
-    mocks.isSystemdUnitActive.mockResolvedValue(false);
+    mocks.isSystemdUnitActive.mockResolvedValue(ok(false));
 
     await runRepair({ gateway: {} });
 
@@ -1157,46 +1160,69 @@ describe("maybeRepairGatewayServiceConfig", () => {
     expect(mocks.stage).not.toHaveBeenCalled();
   });
 
-  it("leaves all service metadata unchanged when an active unit has command drift plus other issues", async () => {
-    mockProcessPlatform("linux");
-    mocks.readCommand.mockResolvedValue({
-      programArguments: ["/usr/bin/openclaw", "run"],
-      environment: {},
-      sourcePath: "/home/test/.config/systemd/user/openclaw-gateway.service",
-    });
-    mocks.auditGatewayServiceConfig.mockResolvedValue({
-      ok: false,
-      issues: [
-        {
-          code: "gateway-command-missing",
-          message: "Service command does not include the gateway subcommand",
-          level: "aggressive",
-        },
-        {
-          code: "gateway-port-mismatch",
-          message: "Gateway service port does not match current gateway config.",
-          detail: "18789 -> 18888",
-          level: "recommended",
-        },
-      ],
-    });
-    mocks.buildGatewayInstallPlan.mockResolvedValue({
-      programArguments: gatewayProgramArguments,
-      workingDirectory: "/tmp",
-      environment: {},
-    });
-    mocks.isSystemdUnitActive.mockResolvedValue(true);
+  it.each([
+    ["active", ok(true)],
+    ["bus query failed", err("Failed to connect to bus: Permission denied")],
+    ["timed out", err("Command timed out")],
+  ] satisfies [string, Result<boolean, string>][])(
+    "leaves service metadata unchanged when unit activity is %s and command drift accompanies other issues",
+    async (_, active) => {
+      mockProcessPlatform("linux");
+      mocks.readCommand.mockResolvedValue({
+        programArguments: ["/usr/bin/openclaw", "run"],
+        environment: {},
+        sourcePath: "/home/test/.config/systemd/user/openclaw-gateway.service",
+      });
+      mocks.auditGatewayServiceConfig.mockResolvedValue({
+        ok: false,
+        issues: [
+          {
+            code: "gateway-command-missing",
+            message: "Service command does not include the gateway subcommand",
+            level: "aggressive",
+          },
+          {
+            code: "gateway-port-mismatch",
+            message: "Gateway service port does not match current gateway config.",
+            detail: "18789 -> 18888",
+            level: "recommended",
+          },
+        ],
+      });
+      mocks.buildGatewayInstallPlan.mockResolvedValue({
+        programArguments: gatewayProgramArguments,
+        workingDirectory: "/tmp",
+        environment: {},
+      });
+      mocks.isSystemdUnitActive.mockResolvedValue(active);
 
-    await runRepair({ gateway: { port: 18888 } });
+      await runRepair({ gateway: { port: 18888 } });
 
-    expectNoteContaining(
-      "Gateway service port does not match current gateway config.",
-      "Gateway service config",
-    );
-    expectNoteContaining("leaving supervisor metadata unchanged", "Gateway service config");
-    expect(mocks.install).not.toHaveBeenCalled();
-    expect(mocks.stage).not.toHaveBeenCalled();
-  });
+      expectNoteContaining(
+        "Gateway service port does not match current gateway config.",
+        "Gateway service config",
+      );
+      expectNoteContaining("supervisor metadata unchanged", "Gateway service config");
+      if (active.ok) {
+        expectNoteContaining(
+          "is running; skipped command/entrypoint rewrites",
+          "Gateway service config",
+        );
+        expectNoNoteContaining("Service command does not include", "Gateway service config");
+      } else {
+        expectNoteContaining("Service command does not include", "Gateway service config");
+        expectNoteContaining(active.error, "Gateway service config");
+        expectNoteContaining(
+          "systemctl --user status openclaw-gateway.service",
+          "Gateway service config",
+        );
+        expectNoNoteContaining("is running;", "Gateway service config");
+      }
+      expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+      expect(mocks.install).not.toHaveBeenCalled();
+      expect(mocks.stage).not.toHaveBeenCalled();
+    },
+  );
 
   it("skips entrypoint rewrite in non-interactive fix mode", async () => {
     setupGatewayEntrypointRepairScenario({
@@ -1944,7 +1970,7 @@ describe("maybeScanExtraGatewayServices", () => {
     mocks.isContainerEnvironment.mockReturnValue(false);
     mocks.findExtraGatewayServices.mockResolvedValue([]);
     mocks.renderGatewayServiceCleanupHints.mockReturnValue([]);
-    mocks.isSystemdUnitActive.mockResolvedValue(false);
+    mocks.isSystemdUnitActive.mockResolvedValue(ok(false));
     mocks.uninstallLegacySystemdUnits.mockResolvedValue([]);
     mocks.execLaunchctl.mockReset().mockResolvedValue(launchctlResult());
   });
@@ -1954,51 +1980,45 @@ describe("maybeScanExtraGatewayServices", () => {
     mockProcessPlatform(originalPlatform);
   });
 
-  it("ignores inactive non-legacy Linux gateway-like services", async () => {
-    mockProcessPlatform("linux");
-    mocks.findExtraGatewayServices.mockResolvedValue([
-      {
-        platform: "linux",
+  it.each([
+    ["inactive", ok(false), "user", false],
+    ["active", ok(true), "system", true],
+    ["unknown", err("Failed to connect to bus: Permission denied"), "system", true],
+  ] satisfies [string, Result<boolean, string>, "user" | "system", boolean][])(
+    "reports non-legacy Linux gateway-like services with %s activity only when appropriate",
+    async (_, active, scope, reported) => {
+      mockProcessPlatform("linux");
+      const { renderGatewayServiceCleanupHints } =
+        await vi.importActual<typeof import("../daemon/inspect.js")>("../daemon/inspect.js");
+      mocks.renderGatewayServiceCleanupHints.mockImplementation(renderGatewayServiceCleanupHints);
+      const unitPath = `${scope === "user" ? "/home/test/.config/systemd/user" : "/etc/systemd/system"}/custom-gateway.service`;
+      const service = {
+        platform: "linux" as const,
         label: "custom-gateway.service",
-        detail: "unit: /home/test/.config/systemd/user/custom-gateway.service",
-        scope: "user",
+        detail: `unit: ${unitPath}`,
+        scope,
         legacy: false,
-      },
-    ]);
-    mocks.isSystemdUnitActive.mockResolvedValue(false);
+      };
+      mocks.findExtraGatewayServices.mockResolvedValue([service]);
+      mocks.isSystemdUnitActive.mockResolvedValue(active);
 
-    await maybeScanExtraGatewayServices({ deep: false }, makeDoctorIo(), makeDoctorPrompts());
+      await maybeScanExtraGatewayServices({ deep: false }, makeDoctorIo(), makeDoctorPrompts());
 
-    expect(mocks.isSystemdUnitActive).toHaveBeenCalledWith(
-      process.env,
-      "custom-gateway.service",
-      "user",
-    );
-    expectNoNoteContaining("custom-gateway.service", "Other gateway-like services detected");
-  });
-
-  it("reports active non-legacy Linux gateway-like services", async () => {
-    mockProcessPlatform("linux");
-    mocks.findExtraGatewayServices.mockResolvedValue([
-      {
-        platform: "linux",
-        label: "custom-gateway.service",
-        detail: "unit: /etc/systemd/system/custom-gateway.service",
-        scope: "system",
-        legacy: false,
-      },
-    ]);
-    mocks.isSystemdUnitActive.mockResolvedValue(true);
-
-    await maybeScanExtraGatewayServices({ deep: true }, makeDoctorIo(), makeDoctorPrompts());
-
-    expect(mocks.isSystemdUnitActive).toHaveBeenCalledWith(
-      process.env,
-      "custom-gateway.service",
-      "system",
-    );
-    expectNoteContaining("custom-gateway.service", "Other gateway-like services detected");
-  });
+      expect(mocks.isSystemdUnitActive).toHaveBeenCalledWith(
+        process.env,
+        "custom-gateway.service",
+        scope,
+      );
+      if (reported) {
+        expectNoteContaining("custom-gateway.service", "Other gateway-like services detected");
+        expect(mocks.renderGatewayServiceCleanupHints).toHaveBeenCalledWith([service]);
+        expectNoteContaining(`${scope === "system" ? "sudo " : ""}rm ${unitPath}`, "Cleanup hints");
+      } else {
+        expectNoNoteContaining("custom-gateway.service", "Other gateway-like services detected");
+      }
+      expect(mocks.uninstallLegacySystemdUnits).not.toHaveBeenCalled();
+    },
+  );
 
   it("renders cleanup hints only for the detected extra macOS gateway", async () => {
     mockProcessPlatform("darwin");
@@ -2504,7 +2524,9 @@ describe("maybeResolveDuelingSystemdGatewayScopes", () => {
     expect(prompter.confirmRuntimeRepair).not.toHaveBeenCalled();
     expect(mocks.uninstallUserSystemdGatewayUnit).not.toHaveBeenCalled();
     expect(mocks.note).toHaveBeenCalledWith(
-      expect.stringContaining("not both running and enabled at boot"),
+      expect.stringContaining(
+        "Could not verify the system-scope unit is both running and enabled at boot",
+      ),
       "Gateway cleanup needs an owner decision",
     );
   });

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -16,7 +16,7 @@ import {
   renderGatewayServiceCleanupHints,
   type ExtraGatewayService,
 } from "../daemon/inspect.js";
-import { isLaunchctlNotLoaded } from "../daemon/launchd.js";
+import { execLaunchctl, isLaunchctlNotLoaded } from "../daemon/launchd-exec.js";
 import { OPENCLAW_WRAPPER_ENV_KEY } from "../daemon/program-args.js";
 import { renderSystemNodeWarning, resolveSystemNodeInfo } from "../daemon/runtime-paths.js";
 import { readWindowsStartupFallbackRuntimeForUpdate } from "../daemon/schtasks.js";
@@ -52,7 +52,6 @@ import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.j
 import { isTruthyEnvValue } from "../infra/env.js";
 import { NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON } from "../infra/gateway-supervision.js";
 import { readWindowsProcessArgsSync } from "../infra/windows-port-pids.js";
-import { runExec } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { buildGatewayInstallPlan } from "./daemon-install-helpers.js";
 import { resolveGatewayDaemonRuntime, type GatewayDaemonRuntime } from "./daemon-runtime.js";
@@ -126,47 +125,18 @@ const EXECSTART_REPAIR_CODES = new Set<string>([
 ]);
 const DOCTOR_LAUNCHCTL_TIMEOUT_MS = 5_000;
 const DOCTOR_LAUNCHCTL_CONFIRM_POLL_MS = 100;
-type LaunchctlCleanupAttempt =
-  | { status: "succeeded"; stdout: string; stderr: string }
-  | { status: "failed"; stdout: string; stderr: string; timedOut: boolean };
-
-const runLaunchctlQuietly = async (
-  args: string[],
-  timeoutMs = DOCTOR_LAUNCHCTL_TIMEOUT_MS,
-): Promise<LaunchctlCleanupAttempt> => {
-  try {
-    const output = await runExec("launchctl", args, {
-      logOutput: false,
-      timeoutMs,
-    });
-    return { status: "succeeded", ...output };
-  } catch (error) {
-    const record = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
-    const message = typeof record.message === "string" ? record.message : "";
-    return {
-      status: "failed",
-      stdout: typeof record.stdout === "string" ? record.stdout : "",
-      stderr: typeof record.stderr === "string" ? record.stderr : "",
-      timedOut:
-        record.timedOut === true ||
-        record.noOutputTimedOut === true ||
-        /\bcommand timed out\b/i.test(message),
-    };
-  }
-};
-
 async function confirmLegacyLaunchdServiceUnloaded(serviceTarget: string): Promise<boolean> {
   const deadline = Date.now() + DOCTOR_LAUNCHCTL_TIMEOUT_MS;
   while (Date.now() < deadline) {
     const remainingMs = Math.max(1, deadline - Date.now());
-    const probe = await runLaunchctlQuietly(
+    const probe = await execLaunchctl(
       ["print", serviceTarget],
       Math.min(DOCTOR_LAUNCHCTL_TIMEOUT_MS, remainingMs),
     );
-    if (probe.status === "failed") {
+    if (probe.code !== 0) {
       // A successful print (including a stopped job) means launchd still owns
       // the label. Unknown errors and probe timeouts stay fail-closed.
-      return !probe.timedOut && isLaunchctlNotLoaded(probe);
+      return isLaunchctlNotLoaded(probe);
     }
     const delayMs = Math.min(DOCTOR_LAUNCHCTL_CONFIRM_POLL_MS, deadline - Date.now());
     if (delayMs <= 0) {
@@ -397,8 +367,8 @@ async function cleanupLegacyLaunchdService(params: {
   plistPath: string;
 }): Promise<{ status: "removed"; destination?: string } | { status: "failed"; reason: string }> {
   const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-  await runLaunchctlQuietly(["bootout", domain, params.plistPath]);
-  await runLaunchctlQuietly(["unload", params.plistPath]);
+  await execLaunchctl(["bootout", domain, params.plistPath], DOCTOR_LAUNCHCTL_TIMEOUT_MS);
+  await execLaunchctl(["unload", params.plistPath], DOCTOR_LAUNCHCTL_TIMEOUT_MS);
 
   // bootout/unload can return before launchd finishes stopping the job. A plist
   // must stay in place unless a bounded print probe observes the label gone.

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -271,34 +271,24 @@ async function readWindowsGatewayRuntimeForUpdateRepair(params: {
   return await params.service.readRuntime(params.env).catch(() => null);
 }
 
-async function suppressRunningSystemdExecStartRepairs(params: {
-  command: GatewayServiceCommandConfig;
-  issues: { code: string }[];
-}): Promise<boolean> {
-  if (process.platform !== "linux") {
-    return false;
+async function resolveSystemdServiceRewriteBlock(
+  command: GatewayServiceCommandConfig,
+  issues: { code: string }[],
+): Promise<string | undefined> {
+  if (process.platform !== "linux" || !issues.some(isExecStartRepairIssue)) {
+    return undefined;
   }
-  if (!params.issues.some(isExecStartRepairIssue)) {
-    return false;
+  const unitName = resolveSystemdUnitNameFromServicePath(command.sourcePath);
+  const scope = resolveSystemdScopeFromServicePath(command.sourcePath);
+  const active = await isSystemdUnitActive(process.env, unitName, scope);
+  if (!active.ok) {
+    return `Could not determine whether gateway service ${unitName} is active: ${active.error}. Leaving supervisor metadata unchanged. Check \`systemctl${scope === "user" ? " --user" : ""} status ${unitName}\` and rerun doctor.`;
   }
-  const unitName = resolveSystemdUnitNameFromServicePath(params.command.sourcePath);
-  const scope = resolveSystemdScopeFromServicePath(params.command.sourcePath);
-  if (!(await isSystemdUnitActive(process.env, unitName, scope))) {
-    return false;
+  if (!active.value) {
+    return undefined;
   }
-  const before = params.issues.length;
-  params.issues.splice(
-    0,
-    params.issues.length,
-    ...params.issues.filter((issue) => !isExecStartRepairIssue(issue)),
-  );
-  if (params.issues.length !== before) {
-    note(
-      `Gateway service ${unitName} is running; skipped command/entrypoint rewrites for this doctor pass.`,
-      "Gateway service config",
-    );
-  }
-  return true;
+  issues.splice(0, issues.length, ...issues.filter((issue) => !isExecStartRepairIssue(issue)));
+  return `Gateway service ${unitName} is running; skipped command/entrypoint rewrites and leaving supervisor metadata unchanged. Stop the service first or use \`openclaw gateway install --force\` when you want to replace the active launcher.`;
 }
 
 async function filterInactiveExtraGatewayServices(
@@ -313,7 +303,8 @@ async function filterInactiveExtraGatewayServices(
       activeOrLegacy.push(svc);
       continue;
     }
-    if (await isSystemdUnitActive(process.env, svc.label, svc.scope)) {
+    const active = await isSystemdUnitActive(process.env, svc.label, svc.scope);
+    if (!active.ok || active.value) {
       activeOrLegacy.push(svc);
     }
   }
@@ -655,10 +646,10 @@ export async function maybeRepairGatewayServiceConfig(
     });
   }
 
-  const serviceRewriteBlocked = await suppressRunningSystemdExecStartRepairs({
-    command,
-    issues: audit.issues,
-  });
+  const serviceRewriteBlock = await resolveSystemdServiceRewriteBlock(command, audit.issues);
+  if (serviceRewriteBlock) {
+    note(serviceRewriteBlock, "Gateway service config");
+  }
 
   const hasEntrypointMismatch = audit.issues.some(
     (issue) => issue.code === SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,
@@ -704,11 +695,7 @@ export async function maybeRepairGatewayServiceConfig(
     return cfg;
   }
 
-  if (serviceRewriteBlocked) {
-    note(
-      "Gateway service is running; leaving supervisor metadata unchanged. Stop the service first or use `openclaw gateway install --force` when you want to replace the active launcher.",
-      "Gateway service config",
-    );
+  if (serviceRewriteBlock) {
     return cfg;
   }
 
@@ -1067,7 +1054,7 @@ export async function maybeResolveDuelingSystemdGatewayScopes(
   if (!systemOwnsGateway) {
     note(
       [
-        "The system-scope unit is not both running and enabled at boot, so the",
+        "Could not verify the system-scope unit is both running and enabled at boot, so the",
         "user-scope unit may be your working gateway. Not removing anything",
         "automatically.",
         "If the system-scope unit is the one you want, activate it and re-run doctor:",
@@ -1081,7 +1068,7 @@ export async function maybeResolveDuelingSystemdGatewayScopes(
   }
   note(
     [
-      "The system-scope unit is the active or boot-enabled supervisor and is",
+      "The system-scope unit is the active and boot-enabled supervisor and is",
       "treated as authoritative; the user-scope unit is the redundant leftover.",
     ].join("\n"),
     "System-scope unit owns the gateway",

--- a/src/daemon/exec-file.ts
+++ b/src/daemon/exec-file.ts
@@ -1,7 +1,13 @@
 /** Child-process wrapper used by daemon installers to preserve stdout/stderr on failure. */
-import { runCommandWithTimeout } from "../process/exec.js";
+import { extractErrorCode } from "../infra/errors.js";
+import { createSanitizedCommandError } from "../process/exec-result.js";
+import { runCommandWithTimeout, type SpawnResult } from "../process/exec.js";
 
-type ExecResult = { stdout: string; stderr: string; code: number };
+export type ExecResult = Pick<SpawnResult, "stdout" | "stderr"> & {
+  code: number;
+  termination: SpawnResult["termination"] | "error";
+  errorCode?: string;
+};
 
 /** Runs a child process as UTF-8 and returns exit data instead of throwing on nonzero exit. */
 export async function execFileUtf8(
@@ -16,20 +22,36 @@ export async function execFileUtf8(
   } = {},
 ): Promise<ExecResult> {
   try {
-    const result = await runCommandWithTimeout([command, ...args], {
-      baseEnv: options.env,
-      cwd: options.cwd,
-      killSignal: options.killSignal,
-      maxOutputBytes: 1024 * 1024,
-      timeoutMs: options.timeout,
-    });
+    const { stdout, stderr, code, termination, signal } = await runCommandWithTimeout(
+      [command, ...args],
+      {
+        baseEnv: options.env,
+        cwd: options.cwd,
+        killSignal: options.killSignal,
+        maxOutputBytes: 1024 * 1024,
+        timeoutMs: options.timeout,
+      },
+    );
+    const diagnostic =
+      termination === "exit"
+        ? ""
+        : createSanitizedCommandError({
+            timedOut: termination === "timeout" || termination === "no-output-timeout",
+            isTerminated: true,
+            signal,
+          }).message;
+    // A child can exit zero while handling termination; daemon actions must still fail.
     return {
-      stdout: result.stdout,
-      stderr: result.stderr,
-      code: result.code ?? 1,
+      stdout,
+      stderr: [stderr, diagnostic].filter(Boolean).join("\n"),
+      code: termination === "exit" ? (code ?? 1) : code || 1,
+      termination,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    return { stdout: "", stderr: message, code: 1 };
+    const errorCode = extractErrorCode(error);
+    // Launch diagnostics omit argv; preserve errno separately so daemon owners
+    // never have to recover execution failures from sanitized prose.
+    return { stdout: "", stderr: message, code: 1, termination: "error", errorCode };
   }
 }

--- a/src/daemon/launchd-exec.ts
+++ b/src/daemon/launchd-exec.ts
@@ -3,9 +3,9 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import { getWindowsCmdExePath } from "../infra/windows-install-roots.js";
-import { execFileUtf8 } from "./exec-file.js";
+import { execFileUtf8, type ExecResult } from "./exec-file.js";
 
-export type LaunchctlResult = { stdout: string; stderr: string; code: number };
+export type LaunchctlResult = ExecResult;
 
 export async function execLaunchctl(args: string[], timeoutMs?: number): Promise<LaunchctlResult> {
   const isWindows = process.platform === "win32";
@@ -17,16 +17,19 @@ export async function execLaunchctl(args: string[], timeoutMs?: number): Promise
   });
 }
 
-export function isLaunchctlNotLoaded(result: Pick<LaunchctlResult, "stdout" | "stderr">): boolean {
+export function isLaunchctlNotLoaded(result: LaunchctlResult): boolean {
   const detail = normalizeLowercaseStringOrEmpty(result.stderr || result.stdout);
   return (
-    detail.includes("no such process") ||
-    detail.includes("could not find service") ||
-    detail.includes("not found")
+    result.termination === "exit" &&
+    (detail.includes("no such process") ||
+      detail.includes("could not find service") ||
+      detail.includes("not found"))
   );
 }
 
-export function formatLaunchctlResultDetail(result: LaunchctlResult): string {
+export function formatLaunchctlResultDetail(
+  result: Pick<LaunchctlResult, "stdout" | "stderr">,
+): string {
   const sanitized = sanitizeForLog((result.stderr || result.stdout).replace(/[\r\n\t]+/g, " "))
     .replace(/\s+/g, " ")
     .trim();

--- a/src/daemon/launchd-restart-handoff.test.ts
+++ b/src/daemon/launchd-restart-handoff.test.ts
@@ -56,8 +56,12 @@ async function executeHandoff(
   const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "launchd-stub-"));
   try {
     const home = path.join(stubDir, "home");
+    const stateDir = path.join(home, ".openclaw");
+    const systemDaemonsDir = path.join(stubDir, "LaunchDaemons");
+    const handoffEnv = { HOME: home, OPENCLAW_PROFILE: "default", OPENCLAW_STATE_DIR: stateDir };
     const callsPath = path.join(stubDir, "launchctl.calls");
-    fs.mkdirSync(path.join(home, ".openclaw", "logs"), { recursive: true });
+    fs.mkdirSync(path.join(stateDir, "logs"), { recursive: true });
+    fs.mkdirSync(systemDaemonsDir);
     fs.writeFileSync(
       path.join(stubDir, "launchctl"),
       `#!/bin/sh
@@ -75,18 +79,21 @@ ${launchctlStub}
     spawnMock.mockReturnValue({ pid: 4242, unref: unrefMock, once: vi.fn() });
     if (mode === "park") {
       scheduleDetachedLaunchdMaintenancePark({
-        env: { HOME: home, OPENCLAW_PROFILE: "default" },
+        env: handoffEnv,
         waitForPid: noWaitPid,
       });
     } else {
       scheduleDetachedLaunchdRestartHandoff({
-        env: { HOME: home, OPENCLAW_PROFILE: "default" },
+        env: handoffEnv,
         mode,
         waitForPid: noWaitPid,
       });
     }
     const [, args] = requireSpawnCall();
-    const script = args[1];
+    const script = args[1]?.replaceAll(
+      "/Library/LaunchDaemons",
+      `'${systemDaemonsDir.replaceAll("'", "'\\''")}'`,
+    );
     if (!script) {
       throw new Error("expected generated restart script");
     }
@@ -101,15 +108,16 @@ ${launchctlStub}
           "handoff-test",
           "gui/501/test.label",
           "gui/501",
-          "/tmp/test.plist",
+          path.join(stubDir, "test.plist"),
           String(noWaitPid),
         ],
         {
           env: {
-            ...process.env,
+            ...handoffEnv,
+            TMPDIR: stubDir,
             LAUNCHCTL_CALLS_PATH: callsPath,
             LAUNCHCTL_STUB_DIR: stubDir,
-            PATH: `${stubDir}:${process.env.PATH}`,
+            PATH: `${stubDir}:/usr/bin:/bin`,
           },
         },
       );
@@ -126,10 +134,7 @@ ${launchctlStub}
       .trim()
       .split("\n")
       .filter((call) => call !== "print system/ai.openclaw.gateway");
-    const log = fs.readFileSync(
-      path.join(home, ".openclaw", "logs", "gateway-restart.log"),
-      "utf8",
-    );
+    const log = fs.readFileSync(path.join(stateDir, "logs", "gateway-restart.log"), "utf8");
     return { calls, exitCode, log };
   } finally {
     fs.rmSync(stubDir, { recursive: true, force: true });

--- a/src/daemon/launchd-runtime.ts
+++ b/src/daemon/launchd-runtime.ts
@@ -13,6 +13,7 @@ import {
   execLaunchctl,
   formatLaunchctlResultDetail,
   isLaunchctlNotLoaded,
+  type LaunchctlResult,
 } from "./launchd-exec.js";
 import { resolveLaunchAgentLabel } from "./launchd-label.js";
 import { LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS } from "./launchd-plist.js";
@@ -127,7 +128,7 @@ export async function bootstrapLaunchAgentOrThrow(params: {
         actionHint: params.actionHint,
       });
     }
-    if (isLaunchctlOperationAlreadyInProgress(detail)) {
+    if (boot.termination === "exit" && isLaunchctlOperationAlreadyInProgress(detail)) {
       const state = await probeLaunchAgentState(params.serviceTarget);
       if (state.state === "running" || state.state === "stopped") {
         params.onMutation?.("bootstrap");
@@ -283,13 +284,11 @@ export async function readLaunchAgentRuntime(
   };
 }
 
-export function isLaunchctlAlreadyLoaded(res: {
-  stdout: string;
-  stderr: string;
-  code: number;
-}): boolean {
+export function isLaunchctlAlreadyLoaded(res: LaunchctlResult): boolean {
   const detail = normalizeLowercaseStringOrEmpty(res.stderr || res.stdout);
-  return res.code === 130 || detail.includes("already exists in domain");
+  return (
+    res.termination === "exit" && (res.code === 130 || detail.includes("already exists in domain"))
+  );
 }
 
 export function isUnsupportedGuiDomain(detail: string): boolean {
@@ -309,11 +308,7 @@ function isLaunchctlOperationAlreadyInProgress(detail: string): boolean {
   );
 }
 
-function isLaunchctlBootstrapPendingTeardown(res: {
-  stdout: string;
-  stderr: string;
-  code: number;
-}): boolean {
+function isLaunchctlBootstrapPendingTeardown(res: LaunchctlResult): boolean {
   // `bootout` returns once launchd accepts the request, not once the job is gone,
   // so bootstrapping the same label mid-teardown answers EIO. The plist is valid
   // here, so this is a timing conflict to retry rather than a real I/O fault.
@@ -321,7 +316,7 @@ function isLaunchctlBootstrapPendingTeardown(res: {
   // launchd answers the same EIO for a label that is simply still registered
   // ("already exists in domain"). That job is not tearing down, so waiting for a
   // teardown that never comes only delays the failure.
-  if (isLaunchctlAlreadyLoaded(res)) {
+  if (res.termination !== "exit" || isLaunchctlAlreadyLoaded(res)) {
     return false;
   }
   const normalized = normalizeLowercaseStringOrEmpty(res.stderr || res.stdout);

--- a/src/daemon/launchd-system.test.ts
+++ b/src/daemon/launchd-system.test.ts
@@ -1,6 +1,6 @@
 // System launchd ownership tests cover loaded, installed, and unverifiable states.
 import { execFileSync } from "node:child_process";
-import { chmodSync, constants, mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, constants, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -80,21 +80,27 @@ import {
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const hostPlatform = process.platform;
+const absentQuery = 'printf "%s\\n" "Could not find service" >&2\nexit 113';
 
 function runRenderedProbe(
   plistName: string,
   plistMode: "unlabeled" | "same-label" | "malformed" | "unreadable",
+  launchctlBody = absentQuery,
 ) {
   const root = tempDirs.make("openclaw-launchd-probe-");
   const daemonsDir = path.join(root, "daemons");
   const binDir = path.join(root, "bin");
+  const probeLog = path.join(root, "probe.log");
   mkdirSync(daemonsDir);
   mkdirSync(binDir);
+  writeFileSync(probeLog, "");
+  writeFileSync(path.join(root, "non-executable"), "#!/bin/sh\nexit 0\n", { mode: 0o600 });
   writeFileSync(path.join(daemonsDir, plistName), `${plistMode}\n`);
   const plutilShim = path.join(binDir, "plutil");
   writeFileSync(
     plutilShim,
     `#!/bin/sh
+printf 'scan\\n' >> "$OPENCLAW_TEST_PROBE_LOG"
 mode=$1
 for last; do :; done
 case "$last" in
@@ -103,7 +109,7 @@ case "$last" in
     exit 1
     ;;
 esac
-fixture=$(cat "$last")
+fixture=$(/bin/cat "$last")
 if [ "$mode" = "-extract" ]; then
   if [ "$fixture" = "same-label" ]; then
     printf '%s\\n' "ai.openclaw.gateway"
@@ -122,7 +128,11 @@ exit 1
   const launchctlShim = path.join(binDir, "launchctl");
   writeFileSync(
     launchctlShim,
-    '#!/bin/sh\nprintf "%s\\n" "Could not find service" >&2\nexit 113\n',
+    `#!/bin/sh
+printf 'query\\n' >> "$OPENCLAW_TEST_PROBE_LOG"
+query_count=$(/usr/bin/grep -c '^query$' "$OPENCLAW_TEST_PROBE_LOG")
+${launchctlBody}
+`,
     { mode: 0o700 },
   );
   chmodSync(plutilShim, 0o700);
@@ -133,12 +143,25 @@ exit 1
   const script = renderSystemLaunchDaemonOwnershipShellProbe("ai.openclaw.gateway")
     .replaceAll("/Library/LaunchDaemons", daemonsDir)
     .replaceAll("/usr/bin/plutil", plutilShim)
-    .concat('printf "conflict=%s\\n" "$openclaw_system_launchd_conflict"\n');
+    .concat(
+      'printf "conflict=%s\\ndetail=%s\\n" "$openclaw_system_launchd_conflict" "$openclaw_system_launchd_detail"\n',
+    );
   const shell = hostPlatform === "darwin" ? "/bin/sh" : "/bin/bash";
-  return execFileSync(shell, ["-c", script], {
+  const output = execFileSync(shell, ["-c", script], {
     encoding: "utf8",
-    env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ""}` },
-  }).match(/^conflict=(.*)$/m)?.[1];
+    env: {
+      HOME: root,
+      TMPDIR: root,
+      PATH: binDir,
+      OPENCLAW_TEST_PROBE_LOG: probeLog,
+      OPENCLAW_TEST_PROBE_DIR: root,
+    },
+  });
+  return {
+    conflict: output.match(/^conflict=(.*)$/m)?.[1],
+    detail: output.match(/^detail=(.*)$/m)?.[1],
+    events: readFileSync(probeLog, "utf8").trim().split("\n").filter(Boolean),
+  };
 }
 
 describe("system LaunchDaemon ownership", () => {
@@ -351,7 +374,6 @@ describe("system LaunchDaemon ownership", () => {
     const script = renderSystemLaunchDaemonOwnershipShellProbe("ai.openclaw.gateway");
 
     expect(script).toContain('launchctl print "$openclaw_system_launchd_target"');
-    expect(script.match(/launchctl print "\$openclaw_system_launchd_target"/g)).toHaveLength(2);
     expect(script).toContain(
       '/usr/bin/plutil -extract Label raw -o - -- "$openclaw_system_launchd_plist"',
     );
@@ -372,13 +394,56 @@ describe("system LaunchDaemon ownership", () => {
   });
 
   it("executes the rendered probe across readable and unreadable plists", () => {
-    expect(runRenderedProbe("com.google.keystone.daemon.plist", "unlabeled")).toBe("");
-    expect(runRenderedProbe("com.vendor.unreadable.plist", "unreadable")).toBe("");
-    expect(runRenderedProbe("vendor-openclaw.plist", "same-label")).toContain(
+    expect(runRenderedProbe("com.google.keystone.daemon.plist", "unlabeled").conflict).toBe("");
+    expect(runRenderedProbe("com.vendor.unreadable.plist", "unreadable").conflict).toBe("");
+    expect(runRenderedProbe("vendor-openclaw.plist", "same-label").conflict).toContain(
       "vendor-openclaw.plist",
     );
-    expect(runRenderedProbe("com.vendor.broken.plist", "malformed")).toContain(
+    expect(runRenderedProbe("com.vendor.broken.plist", "malformed").conflict).toContain(
       "com.vendor.broken.plist",
     );
   });
+
+  it.each([
+    ["loaded", "exit 0", 1, "loaded system LaunchDaemon"],
+    ["absent", absentQuery, 2, ""],
+    ["query error", 'printf "Operation not permitted\\n" >&2\nexit 1', 1, "could not verify"],
+    ["signal", 'printf "Could not find service\\n" >&2\nkill -TERM $$', 1, "could not verify"],
+    [
+      "execution failure",
+      'printf "Could not find service\\n" >&2\nexec "$OPENCLAW_TEST_PROBE_DIR/non-executable"',
+      1,
+      "could not verify",
+    ],
+    [
+      "missing command",
+      'printf "Could not find service\\n" >&2\nexec "$OPENCLAW_TEST_PROBE_DIR/missing"',
+      1,
+      "could not verify",
+    ],
+    [
+      "signal after scan",
+      `if [ "$query_count" -eq 1 ]; then\n${absentQuery}\nfi\nprintf "Could not find service\\n" >&2\nkill -TERM $$`,
+      2,
+      "could not verify",
+    ],
+    [
+      "loaded after scan",
+      `if [ "$query_count" -eq 2 ]; then exit 0; fi\n${absentQuery}`,
+      2,
+      "loaded system LaunchDaemon",
+    ],
+  ] as const)(
+    "executes the rendered ownership query with %s outcome",
+    (_, body, queries, detail) => {
+      const result = runRenderedProbe("foreign.plist", "unlabeled", body);
+      expect(result.conflict).toBe(detail ? "system/ai.openclaw.gateway" : "");
+      if (detail) {
+        expect(result.detail).toContain(detail);
+      } else {
+        expect(result.detail).toBe("");
+      }
+      expect(result.events).toEqual(queries === 1 ? ["query"] : ["query", "scan", "scan", "query"]);
+    },
+  );
 });

--- a/src/daemon/launchd-system.ts
+++ b/src/daemon/launchd-system.ts
@@ -48,15 +48,21 @@ openclaw_system_launchd_detail=""
 openclaw_system_launchd_target=${quotePosixArgument(serviceTarget)}
 openclaw_system_launchd_dir=${quotePosixArgument(SYSTEM_LAUNCH_DAEMON_DIR)}
 openclaw_system_launchd_label=${quotePosixArgument(label)}
-openclaw_system_launchd_probe=$(launchctl print "$openclaw_system_launchd_target" 2>&1)
-openclaw_system_launchd_probe_status=$?
-if [ "$openclaw_system_launchd_probe_status" -eq 0 ]; then
-  openclaw_system_launchd_conflict="$openclaw_system_launchd_target"
-  openclaw_system_launchd_detail="loaded system LaunchDaemon $openclaw_system_launchd_target"
-elif ! printf '%s' "$openclaw_system_launchd_probe" | /usr/bin/grep -Eiq 'could not find service|no such process|not found'; then
-  openclaw_system_launchd_conflict="$openclaw_system_launchd_target"
-  openclaw_system_launchd_detail="could not verify $openclaw_system_launchd_target: $openclaw_system_launchd_probe"
-fi
+openclaw_query_system_launchd() {
+  openclaw_system_launchd_probe=$(launchctl print "$openclaw_system_launchd_target" 2>&1)
+  openclaw_system_launchd_probe_status=$?
+  # POSIX shell status 126/127 means execution failed; >128 can represent a signal.
+  # Partial absence output cannot establish that the ownership query completed.
+  if [ "$openclaw_system_launchd_probe_status" -eq 0 ]; then
+    openclaw_system_launchd_conflict="$openclaw_system_launchd_target"
+    openclaw_system_launchd_detail="loaded system LaunchDaemon $openclaw_system_launchd_target"
+  elif [ "$openclaw_system_launchd_probe_status" -eq 126 ] || [ "$openclaw_system_launchd_probe_status" -eq 127 ] || [ "$openclaw_system_launchd_probe_status" -gt 128 ] ||
+       ! printf '%s' "$openclaw_system_launchd_probe" | /usr/bin/grep -Eiq 'could not find service|no such process|not found'; then
+    openclaw_system_launchd_conflict="$openclaw_system_launchd_target"
+    openclaw_system_launchd_detail="could not verify $openclaw_system_launchd_target (exit $openclaw_system_launchd_probe_status): $openclaw_system_launchd_probe"
+  fi
+}
+openclaw_query_system_launchd
 if [ -z "$openclaw_system_launchd_conflict" ]; then
   if [ ! -e "$openclaw_system_launchd_dir" ]; then
     :
@@ -100,15 +106,7 @@ if [ -z "$openclaw_system_launchd_conflict" ]; then
   fi
 fi
 if [ -z "$openclaw_system_launchd_conflict" ]; then
-  openclaw_system_launchd_probe=$(launchctl print "$openclaw_system_launchd_target" 2>&1)
-  openclaw_system_launchd_probe_status=$?
-  if [ "$openclaw_system_launchd_probe_status" -eq 0 ]; then
-    openclaw_system_launchd_conflict="$openclaw_system_launchd_target"
-    openclaw_system_launchd_detail="loaded system LaunchDaemon $openclaw_system_launchd_target"
-  elif ! printf '%s' "$openclaw_system_launchd_probe" | /usr/bin/grep -Eiq 'could not find service|no such process|not found'; then
-    openclaw_system_launchd_conflict="$openclaw_system_launchd_target"
-    openclaw_system_launchd_detail="could not verify $openclaw_system_launchd_target: $openclaw_system_launchd_probe"
-  fi
+  openclaw_query_system_launchd
 fi
 `;
 }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -516,7 +516,7 @@ vi.mock("./exec-file.js", async (importOriginal) => {
     execFileUtf8: vi.fn(async (...args: Parameters<typeof actual.execFileUtf8>) =>
       state.realExecFile
         ? await actual.execFileUtf8(...args)
-        : executeLaunchctlMock(args[0], args[1]),
+        : { ...executeLaunchctlMock(args[0], args[1]), termination: "exit" as const },
     ),
   };
 });

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PortListener } from "../infra/ports-types.js";
 import { deleteTestEnvValue, setTestEnvValue, withEnvAsync } from "../test-utils/env.js";
 import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "./constants.js";
+import type { ExecResult } from "./exec-file.js";
 import {
   LAUNCH_AGENT_ENV_WRAPPER_SHELL,
   LAUNCH_AGENT_EXIT_TIMEOUT_SECONDS,
@@ -45,6 +46,7 @@ const state = vi.hoisted(() => ({
   printFailuresRemaining: 0,
   bootstrapError: "",
   bootstrapCode: 1,
+  bootstrapTermination: "exit" as ExecResult["termination"],
   bootstrapLoadsServiceOnFailure: false,
   bootstrapTransient: false,
   kickstartError: "",
@@ -484,7 +486,12 @@ function executeLaunchctlMock(file: string, args: string[]) {
         state.serviceLoaded = true;
         state.serviceRunning = true;
       }
-      return { stdout: "", stderr: detail, code: state.bootstrapCode };
+      return {
+        stdout: "",
+        stderr: detail,
+        code: state.bootstrapCode,
+        termination: state.bootstrapTermination,
+      };
     }
     state.serviceLoaded = true;
     state.serviceRunning = true;
@@ -516,7 +523,7 @@ vi.mock("./exec-file.js", async (importOriginal) => {
     execFileUtf8: vi.fn(async (...args: Parameters<typeof actual.execFileUtf8>) =>
       state.realExecFile
         ? await actual.execFileUtf8(...args)
-        : { ...executeLaunchctlMock(args[0], args[1]), termination: "exit" as const },
+        : { termination: "exit" as const, ...executeLaunchctlMock(args[0], args[1]) },
     ),
   };
 });
@@ -678,6 +685,7 @@ beforeEach(() => {
   state.printFailuresRemaining = 0;
   state.bootstrapError = "";
   state.bootstrapCode = 1;
+  state.bootstrapTermination = "exit";
   state.bootstrapLoadsServiceOnFailure = false;
   state.bootstrapTransient = false;
   state.kickstartError = "";
@@ -1509,22 +1517,33 @@ describe("launchd bootstrap repair", () => {
     expect(launchctlCommandNames()).not.toContain("kickstart");
   });
 
-  it("treats 'already exists in domain' bootstrap failures as success and nudges the service when stopped", async () => {
-    state.bootstrapError =
-      "Could not bootstrap service: 5: Input/output error: already exists in domain for gui/501";
-    state.serviceRunning = false;
-    const env = createDefaultLaunchdEnv();
+  it.each(["exit", "timeout", "signal"] as const)(
+    "accepts already-loaded bootstrap output only after a completed command (%s)",
+    async (termination) => {
+      state.bootstrapError =
+        "Could not bootstrap service: 5: Input/output error: already exists in domain for gui/501";
+      state.bootstrapTermination = termination;
+      state.serviceRunning = false;
+      const env = createDefaultLaunchdEnv();
 
-    const repair = await repairLaunchAgentBootstrap({ env });
+      const repair = await repairLaunchAgentBootstrap({ env });
 
-    const { serviceId } = expectLaunchctlEnableBootstrapOrder(env);
-    expect(repair).toEqual({ ok: true, status: "already-loaded" });
-    expect(state.launchctlCalls.find((call) => call[0] === "kickstart")).toEqual([
-      "kickstart",
-      serviceId,
-    ]);
-    expect(countMatching(state.launchctlCalls, (call) => call[0] === "kickstart")).toBe(1);
-  });
+      const { serviceId } = expectLaunchctlEnableBootstrapOrder(env);
+      if (termination === "exit") {
+        expect(repair).toEqual({ ok: true, status: "already-loaded" });
+        expect(state.launchctlCalls.filter((call) => call[0] === "kickstart")).toEqual([
+          ["kickstart", serviceId],
+        ]);
+      } else {
+        expect(repair).toEqual({
+          ok: false,
+          status: "bootstrap-failed",
+          detail: state.bootstrapError,
+        });
+        expect(launchctlCommandNames()).not.toContain("kickstart");
+      }
+    },
+  );
 
   it("keeps genuine bootstrap failures as failures", async () => {
     state.bootstrapError = "Could not find specified service";
@@ -3187,27 +3206,34 @@ describe("launchd install", () => {
     expect(onMutation).not.toHaveBeenCalledWith({ mode: "bootstrap" });
   });
 
-  it("reloads the LaunchAgent through a transient reload bootstrap failure", async () => {
-    const env = createLaunchdEnvWithGatewayPort("18789");
-    setLaunchAgentPlist(env, "ai.openclaw.gateway", ["node", "gateway.js"]);
-    // launchd answers EIO while the just-booted-out job is still tearing down.
-    state.bootstrapError = "Bootstrap failed: 5: Input/output error";
-    state.bootstrapCode = 5;
-    state.bootstrapTransient = true;
-    const onMutation = vi.fn();
+  it.each(["exit", "timeout", "signal"] as const)(
+    "retries teardown bootstrap output only after a completed command (%s)",
+    async (termination) => {
+      const env = createLaunchdEnvWithGatewayPort("18789");
+      setLaunchAgentPlist(env, "ai.openclaw.gateway", ["node", "gateway.js"]);
+      state.bootstrapError = "Bootstrap failed: 5: Input/output error";
+      state.bootstrapCode = termination === "exit" ? 5 : 1;
+      state.bootstrapTermination = termination;
+      state.bootstrapTransient = true;
+      const onMutation = vi.fn();
 
-    const result = await runRestartLaunchAgentWithFakeTimers(
-      launchAgentControlFixture(env, {
-        onMutation,
-      }),
-    );
+      const result = runRestartLaunchAgentWithFakeTimers(
+        launchAgentControlFixture(env, { onMutation }),
+      );
 
-    // Teardown is transient, so the retry must land a real bootstrap rather than
-    // surfacing an error the operator has to recover from by hand.
-    expect(result).toEqual({ outcome: "completed" });
-    expect(state.serviceLoaded).toBe(true);
-    expect(onMutation).toHaveBeenCalledWith({ mode: "bootstrap" });
-  });
+      if (termination === "exit") {
+        await expect(result).resolves.toEqual({ outcome: "completed" });
+      } else {
+        await expect(result).rejects.toThrow(
+          "launchctl bootstrap failed: Bootstrap failed: 5: Input/output error",
+        );
+      }
+      // Recovery can restore the job after interruption, but must not turn the
+      // failed restart into success by treating partial EIO output as a retry.
+      expect(state.serviceLoaded).toBe(true);
+      expect(onMutation).toHaveBeenCalledWith({ mode: "bootstrap" });
+    },
+  );
 
   it("reports the LaunchAgent as unloaded when bootstrap teardown never clears", async () => {
     const env = createLaunchdEnvWithGatewayPort("18789");
@@ -3279,29 +3305,43 @@ describe("launchd install", () => {
     expect(onMutation).toHaveBeenCalledWith({ mode: "bootstrap" });
   });
 
-  it("treats a concurrent launchd bootstrap as success when the service is loaded", async () => {
-    const env = createLaunchdEnvWithGatewayPort("18789");
-    const plistPath = resolveLaunchAgentPlistPath(env);
-    setLegacyGatewayLaunchAgentPlist(plistPath, [
-      "    <key>StandardOutPath</key>",
-      "    <string>/Users/test/.openclaw-default/logs/gateway.log</string>",
-    ]);
-    state.bootstrapError = "Bootstrap failed: 37: Operation already in progress";
-    state.bootstrapCode = 5;
-    state.bootstrapLoadsServiceOnFailure = true;
+  it.each(["exit", "timeout", "signal"] as const)(
+    "accepts in-progress bootstrap output only after a completed command (%s)",
+    async (termination) => {
+      const env = createLaunchdEnvWithGatewayPort("18789");
+      const plistPath = resolveLaunchAgentPlistPath(env);
+      setLegacyGatewayLaunchAgentPlist(plistPath, [
+        "    <key>StandardOutPath</key>",
+        "    <string>/Users/test/.openclaw-default/logs/gateway.log</string>",
+      ]);
+      state.bootstrapError = "Bootstrap failed: 37: Operation already in progress";
+      state.bootstrapCode = termination === "exit" ? 5 : 1;
+      state.bootstrapTermination = termination;
+      state.bootstrapLoadsServiceOnFailure = true;
+      const onMutation = vi.fn();
 
-    await restartLaunchAgent(launchAgentControlFixture(env));
+      const result = restartLaunchAgent(launchAgentControlFixture(env, { onMutation }));
+      if (termination === "exit") {
+        await expect(result).resolves.toEqual({ outcome: "completed" });
+        expect(onMutation).toHaveBeenCalledWith({ mode: "bootstrap" });
+      } else {
+        await expect(result).rejects.toThrow(
+          "launchctl bootstrap failed: Bootstrap failed: 37: Operation already in progress",
+        );
+        expect(onMutation).not.toHaveBeenCalledWith({ mode: "bootstrap" });
+      }
 
-    expect(launchctlCommandNames()).toEqual([
-      "print",
-      "enable",
-      "bootout",
-      "enable",
-      "bootstrap",
-      "print",
-    ]);
-    expect(launchctlCommandNames()).not.toContain("kickstart");
-  });
+      expect(launchctlCommandNames()).toEqual([
+        "print",
+        "enable",
+        "bootout",
+        "enable",
+        "bootstrap",
+        "print",
+      ]);
+      expect(launchctlCommandNames()).not.toContain("kickstart");
+    },
+  );
 
   it("uses the configured gateway port for stale cleanup", async () => {
     const env = createLaunchdEnvWithGatewayPort("19001");

--- a/src/daemon/systemd-exec.ts
+++ b/src/daemon/systemd-exec.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { escapeRegExp } from "../shared/regexp.js";
-import { execFileUtf8 } from "./exec-file.js";
+import { execFileUtf8, type ExecResult } from "./exec-file.js";
 import type { GatewayServiceEnv } from "./service-types.js";
 import {
   classifySystemdUnavailableDetail,
@@ -19,7 +19,7 @@ async function execSystemdCommand(
   args: string[],
   env?: GatewayServiceEnv,
   timeoutMs?: number,
-): Promise<{ stdout: string; stderr: string; code: number }> {
+): Promise<ExecResult> {
   return await execFileUtf8(command, args, {
     env: env ? resolveSystemctlProcessEnv(env) : process.env,
     // A wedged systemd socket can leave manager commands blocked forever; the timeout
@@ -32,18 +32,22 @@ export async function execSystemctl(
   args: string[],
   env?: GatewayServiceEnv,
   timeoutMs?: number,
-): Promise<{ stdout: string; stderr: string; code: number }> {
+): Promise<ExecResult> {
   return await execSystemdCommand("systemctl", args, env, timeoutMs);
 }
 
 export function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
-  // Concatenate both streams so pattern matchers (isSystemdUnitNotEnabled,
-  // isSystemctlMissing) can see the unit status from stdout even when
-  // execFileUtf8 populates stderr with the Node error message fallback.
+  // Unit status can be in stdout while stderr contains a launcher diagnostic.
   return `${result.stderr} ${result.stdout}`.trim();
 }
 
-export const isSystemctlMissing = isSystemctlMissingDetail;
+export function isSystemctlMissing(result: ExecResult): boolean {
+  return (
+    result.errorCode === "ENOENT" ||
+    result.errorCode === "EACCES" ||
+    (result.termination === "exit" && isSystemctlMissingDetail(readSystemctlDetail(result)))
+  );
+}
 
 export function isSystemdUnitNotEnabled(detail: string): boolean {
   if (!detail) {
@@ -114,10 +118,6 @@ export function isNonFatalSystemdInstallProbeError(error: unknown): boolean {
   }
   const normalized = normalizeLowercaseStringOrEmpty(detail);
   return isSystemctlBusUnavailable(normalized) || isGenericSystemctlIsEnabledFailure(normalized);
-}
-
-function resolveSystemctlDirectUserScopeArgs(): string[] {
-  return ["--user"];
 }
 
 function readSystemctlEnvUser(env: GatewayServiceEnv): string | null {
@@ -243,7 +243,7 @@ async function execSystemdUserCommand(
   env: GatewayServiceEnv,
   args: string[],
   timeoutMs?: number,
-): Promise<{ stdout: string; stderr: string; code: number }> {
+): Promise<ExecResult> {
   const { machineUser, preferMachineScope } = resolveSystemctlUserScope(env);
   const run = (scopeArgs: string[]) =>
     execSystemdCommand(command, [...scopeArgs, ...args], env, timeoutMs);
@@ -257,13 +257,17 @@ async function execSystemdUserCommand(
     }
   }
 
-  const directResult = await run(resolveSystemctlDirectUserScopeArgs());
+  const directResult = await run(["--user"]);
   if (directResult.code === 0) {
     return directResult;
   }
 
-  const detail = `${directResult.stderr} ${directResult.stdout}`.trim();
-  if (!machineUser || !shouldFallbackToMachineUserScope(detail)) {
+  const detail = readSystemctlDetail(directResult);
+  if (
+    directResult.termination !== "exit" ||
+    !machineUser ||
+    !shouldFallbackToMachineUserScope(detail)
+  ) {
     return directResult;
   }
 
@@ -278,7 +282,7 @@ export async function execSystemctlUser(
   env: GatewayServiceEnv,
   args: string[],
   timeoutMs?: number,
-): Promise<{ stdout: string; stderr: string; code: number }> {
+): Promise<ExecResult> {
   return await execSystemdUserCommand("systemctl", env, args, timeoutMs);
 }
 
@@ -286,7 +290,7 @@ export async function execBusctlUser(
   env: GatewayServiceEnv,
   args: string[],
   timeoutMs?: number,
-): Promise<{ stdout: string; stderr: string; code: number }> {
+): Promise<ExecResult> {
   return await execSystemdUserCommand("busctl", env, args, timeoutMs);
 }
 
@@ -299,7 +303,7 @@ export async function disableSystemdUserUnitForRemoval(
     return;
   }
   const detail = readSystemctlDetail(result);
-  if (isSystemdUnitAlreadyMissingOrInactive(detail, unitName)) {
+  if (result.termination === "exit" && isSystemdUnitAlreadyMissingOrInactive(detail, unitName)) {
     return;
   }
   throw new Error(`systemctl disable failed: ${detail || "unknown error"}`);
@@ -318,14 +322,11 @@ export async function isSystemdUserServiceAvailable(
   env: GatewayServiceEnv = process.env as GatewayServiceEnv,
 ): Promise<boolean> {
   const res = await execSystemctlUser(env, ["status"]);
-  if (res.code === 0) {
-    return true;
-  }
-  const detail = `${res.stderr} ${res.stdout}`.trim();
-  if (!detail) {
-    return false;
-  }
-  return !isSystemdUserScopeUnavailable(detail);
+  const detail = readSystemctlDetail(res);
+  return (
+    res.termination === "exit" &&
+    (res.code === 0 || (Boolean(detail) && !isSystemdUserScopeUnavailable(detail)))
+  );
 }
 
 export async function isSystemdUnitActive(
@@ -351,13 +352,10 @@ export async function assertSystemdAvailable(
     return;
   }
   const detail = readSystemctlDetail(res);
-  if (isSystemctlMissing(detail)) {
+  if (isSystemctlMissing(res)) {
     throw new Error("systemctl not available; systemd user services are required on Linux.");
   }
-  if (!detail) {
-    throw new Error("systemctl --user unavailable: unknown error");
-  }
-  if (!isSystemdUserScopeUnavailable(detail)) {
+  if (res.termination === "exit" && detail && !isSystemdUserScopeUnavailable(detail)) {
     return;
   }
   throw new Error(`systemctl --user unavailable: ${detail || "unknown error"}`.trim());
@@ -365,8 +363,5 @@ export async function assertSystemdAvailable(
 
 export async function isSystemctlAvailable(env: GatewayServiceEnv): Promise<boolean> {
   const res = await execSystemctlUser(env, ["status"]);
-  if (res.code === 0) {
-    return true;
-  }
-  return !isSystemctlMissing(readSystemctlDetail(res));
+  return res.termination === "exit" && (res.code === 0 || !isSystemctlMissing(res));
 }

--- a/src/daemon/systemd-exec.ts
+++ b/src/daemon/systemd-exec.ts
@@ -2,6 +2,7 @@
 import * as fsSync from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { escapeRegExp } from "../shared/regexp.js";
 import { execFileUtf8, type ExecResult } from "./exec-file.js";
@@ -333,14 +334,18 @@ export async function isSystemdUnitActive(
   env: GatewayServiceEnv,
   unitName: string,
   scope: SystemdUnitScope = "user",
-): Promise<boolean> {
+): Promise<Result<boolean, string>> {
   const normalizedUnit = unitName.trim();
   if (!normalizedUnit) {
-    return false;
+    return ok(false);
   }
   const args = ["is-active", "--quiet", normalizedUnit];
   const res = scope === "system" ? await execSystemctl(args) : await execSystemctlUser(env, args);
-  return res.code === 0;
+  // is-active uses 3 for not-active and 4 for missing; query failures exit 1.
+  if (res.termination === "exit" && [0, 3, 4].includes(res.code)) {
+    return ok(res.code === 0);
+  }
+  return err(readSystemctlDetail(res) || `systemctl is-active exited with code ${res.code}`);
 }
 
 export async function assertSystemdAvailable(

--- a/src/daemon/systemd-install.ts
+++ b/src/daemon/systemd-install.ts
@@ -549,7 +549,11 @@ async function activateSystemdService(params: { env: GatewayServiceEnv }) {
 
   const runAfterReloadRetry = async (action: "enable" | "restart") => {
     const result = await execSystemctlUser(params.env, [action, unitName]);
-    if (result.code === 0 || !isSystemdUnitMissingDetail(readSystemctlDetail(result))) {
+    if (
+      result.code === 0 ||
+      result.termination !== "exit" ||
+      !isSystemdUnitMissingDetail(readSystemctlDetail(result))
+    ) {
       return result;
     }
     const retryReload = await reloadSystemd();

--- a/src/daemon/systemd-runtime.ts
+++ b/src/daemon/systemd-runtime.ts
@@ -126,7 +126,7 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
     return true;
   }
   const detail = readSystemctlDetail(res);
-  if (!isSystemctlMissing(detail) && isSystemdUnitNotEnabled(detail)) {
+  if (res.termination === "exit" && !isSystemctlMissing(res) && isSystemdUnitNotEnabled(detail)) {
     return false;
   }
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
@@ -162,7 +162,7 @@ export async function readSystemdServiceRuntime(
       : await execSystemctlUser(env, showArgs, timeoutMs);
   if (res.code !== 0) {
     const detail = (res.stderr || res.stdout).trim();
-    const missing = !installed && isSystemdUnitMissingDetail(detail);
+    const missing = res.termination === "exit" && !installed && isSystemdUnitMissingDetail(detail);
     return {
       status: missing ? "stopped" : "unknown",
       ...(!missing && detail ? { detail } : {}),

--- a/src/daemon/systemd-scope.ts
+++ b/src/daemon/systemd-scope.ts
@@ -192,7 +192,8 @@ export async function isSystemUnitActiveAndEnabled(
   env: GatewayServiceEnv,
   unitName: string,
 ): Promise<boolean> {
-  if (!(await isSystemdUnitActive(env, unitName, "system"))) {
+  const active = await isSystemdUnitActive(env, unitName, "system");
+  if (!active.ok || !active.value) {
     return false;
   }
   const res = await execSystemctl(["is-enabled", unitName], env);

--- a/src/daemon/systemd-system.test.ts
+++ b/src/daemon/systemd-system.test.ts
@@ -1,13 +1,20 @@
 // System systemd ownership tests cover loaded, installed, and unverifiable states.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExecResult } from "./exec-file.js";
 
 const state = vi.hoisted(() => ({
-  systemctl: { stdout: "not-found\n", stderr: "", code: 0 },
+  systemctl: {
+    stdout: "not-found\n",
+    stderr: "",
+    code: 0,
+    termination: "exit" as ExecResult["termination"],
+  },
   managerUnitPath: {
     stdout:
       "/etc/systemd/system /run/systemd/system /usr/local/lib/systemd/system /usr/lib/systemd/system\n",
     stderr: "",
     code: 0,
+    termination: "exit" as ExecResult["termination"],
   },
   paths: new Set<string>(),
   pathErrors: new Map<string, string>(),
@@ -47,12 +54,13 @@ describe("system systemd ownership", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    state.systemctl = { stdout: "not-found\n", stderr: "", code: 0 };
+    state.systemctl = { stdout: "not-found\n", stderr: "", code: 0, termination: "exit" };
     state.managerUnitPath = {
       stdout:
         "/etc/systemd/system /run/systemd/system /usr/local/lib/systemd/system /usr/lib/systemd/system\n",
       stderr: "",
       code: 0,
+      termination: "exit",
     };
     state.paths.clear();
     state.pathErrors.clear();
@@ -75,7 +83,7 @@ describe("system systemd ownership", () => {
   });
 
   it("reports a unit loaded by the system manager", async () => {
-    state.systemctl = { stdout: "loaded\n", stderr: "", code: 0 };
+    state.systemctl = { stdout: "loaded\n", stderr: "", code: 0, termination: "exit" };
 
     await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
       ownership: { status: "loaded", unitName: "openclaw-gateway.service" },
@@ -113,6 +121,7 @@ describe("system systemd ownership", () => {
       stdout: "",
       stderr: "Failed to connect to bus: Permission denied",
       code: 1,
+      termination: "exit",
     };
 
     await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
@@ -130,6 +139,7 @@ describe("system systemd ownership", () => {
       stdout: "",
       stderr: "Failed to connect to bus: No such file or directory",
       code: 1,
+      termination: "exit",
     };
 
     await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
@@ -140,6 +150,23 @@ describe("system systemd ownership", () => {
       },
     });
   });
+
+  it.each(["exit", "timeout", "signal"] as const)(
+    "accepts system-manager absence only after a completed query (%s)",
+    async (termination) => {
+      const detail = "Unit openclaw-gateway.service could not be found.";
+      state.systemctl = { stdout: "", stderr: detail, code: 1, termination };
+
+      const result = assertNoSystemSystemdOwnership("openclaw-gateway.service");
+      if (termination === "exit") {
+        await expect(result).resolves.toBeUndefined();
+      } else {
+        await expect(result).rejects.toMatchObject({
+          ownership: { status: "unverifiable", operation: "systemctl", detail },
+        });
+      }
+    },
+  );
 
   it("fails closed when an exact system path cannot be inspected", async () => {
     const unitPath = "/etc/systemd/system/openclaw-gateway.service";
@@ -160,6 +187,7 @@ describe("system systemd ownership", () => {
       stdout: "",
       stderr: "manager UnitPath unavailable",
       code: 1,
+      termination: "exit",
     };
 
     await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({
@@ -179,8 +207,8 @@ describe("system systemd ownership", () => {
       }
       systemctlCalls += 1;
       return systemctlCalls === 1
-        ? { stdout: "not-found\n", stderr: "", code: 0 }
-        : { stdout: "loaded\n", stderr: "", code: 0 };
+        ? { stdout: "not-found\n", stderr: "", code: 0, termination: "exit" }
+        : { stdout: "loaded\n", stderr: "", code: 0, termination: "exit" };
     });
 
     await expect(assertNoSystemSystemdOwnership("openclaw-gateway.service")).rejects.toMatchObject({

--- a/src/daemon/systemd-system.ts
+++ b/src/daemon/systemd-system.ts
@@ -53,6 +53,7 @@ async function querySystemManager(unitName: string): Promise<SystemSystemdOwners
   const detail = `${result.stderr} ${result.stdout}`.trim();
   const normalizedDetail = detail.toLowerCase();
   if (
+    result.termination === "exit" &&
     normalizedDetail.includes(unitName.toLowerCase()) &&
     /not[- ]found|could not be found/i.test(normalizedDetail)
   ) {

--- a/src/daemon/systemd-unavailable.test.ts
+++ b/src/daemon/systemd-unavailable.test.ts
@@ -1,5 +1,15 @@
 // Systemd unavailable tests cover fallback behavior when systemd is not present.
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { withTempDir } from "../test-utils/temp-dir.js";
+import { execFileUtf8 } from "./exec-file.js";
+import { isLaunchctlNotLoaded } from "./launchd-exec.js";
+import {
+  assertSystemdAvailable,
+  isSystemctlAvailable,
+  isSystemdUserServiceAvailable,
+} from "./systemd-exec.js";
 import {
   classifySystemdUnavailableDetail,
   isSystemctlMissingDetail,
@@ -41,5 +51,89 @@ describe("classifySystemdUnavailableDetail", () => {
 
   it("returns null for unrelated details", () => {
     expect(classifySystemdUnavailableDetail("permission denied")).toBeNull();
+  });
+});
+
+describe.skipIf(process.platform === "win32")("systemd process availability", () => {
+  function systemctlEnv(dir: string) {
+    return {
+      PATH: dir,
+      XDG_RUNTIME_DIR: dir,
+      DBUS_SESSION_BUS_ADDRESS: `unix:path=${path.join(dir, "bus")}`,
+    };
+  }
+
+  it.each(["ENOENT", "EACCES"])("rejects unavailable systemctl with %s", async (errorCode) => {
+    await withTempDir("openclaw-systemctl-", async (dir) => {
+      if (errorCode === "EACCES") {
+        await fs.writeFile(path.join(dir, "systemctl"), "#!/bin/sh\nexit 0\n", { mode: 0o600 });
+      }
+      const env = systemctlEnv(dir);
+      await expect(isSystemctlAvailable(env)).resolves.toBe(false);
+      await expect(isSystemdUserServiceAvailable(env)).resolves.toBe(false);
+      await expect(assertSystemdAvailable(env)).rejects.toThrow("systemctl not available");
+
+      const result = await execFileUtf8("systemctl", ["private-argument"], { env });
+      expect(result).toMatchObject({ stdout: "", code: 1, errorCode });
+      expect(result.stderr).not.toContain("private-argument");
+      expect(isLaunchctlNotLoaded(result)).toBe(false);
+    });
+  });
+
+  it.each([
+    { output: "running", code: 0, available: true },
+    { output: "degraded", code: 1, available: true },
+    { output: "Failed to connect to bus: No medium found", code: 1, available: false },
+  ])("preserves manager status $output", async ({ output, code, available }) => {
+    await withTempDir("openclaw-systemctl-", async (dir) => {
+      await fs.writeFile(
+        path.join(dir, "systemctl"),
+        `#!/bin/sh\nprintf '%s\\n' '${output}'\nexit ${code}\n`,
+        { mode: 0o700 },
+      );
+      const env = systemctlEnv(dir);
+      await expect(execFileUtf8("systemctl", ["--user", "status"], { env })).resolves.toEqual({
+        stdout: `${output}\n`,
+        stderr: "",
+        code,
+        termination: "exit",
+      });
+      await expect(isSystemctlAvailable(env)).resolves.toBe(true);
+      await expect(isSystemdUserServiceAvailable(env)).resolves.toBe(available);
+      if (available) {
+        await expect(assertSystemdAvailable(env)).resolves.toBeUndefined();
+      } else {
+        await expect(assertSystemdAvailable(env)).rejects.toThrow("systemctl --user unavailable");
+      }
+    });
+  });
+
+  it.each(["timeout", "signal"])("rejects partial status after %s", async (termination) => {
+    await withTempDir("openclaw-systemctl-", async (dir) => {
+      await fs.writeFile(
+        path.join(dir, "systemctl"),
+        `#!/bin/sh\nprintf 'Could not find service\\n'\n${termination === "timeout" ? "exec /bin/sleep 10" : "kill -TERM $$"}\n`,
+        { mode: 0o700 },
+      );
+      const env = systemctlEnv(dir);
+      await expect(assertSystemdAvailable(env, 500)).rejects.toThrow(
+        "systemctl --user unavailable",
+      );
+      const result = await execFileUtf8("systemctl", ["--user", "status"], {
+        env,
+        timeout: 500,
+        killSignal: "SIGKILL",
+      });
+      expect(result).toMatchObject({ stdout: "Could not find service\n", termination });
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain(
+        termination === "timeout" ? "Command timed out" : "Command was terminated by SIGTERM",
+      );
+      expect(isLaunchctlNotLoaded(result)).toBe(false);
+      if (termination === "signal") {
+        await expect(isSystemctlAvailable(env)).resolves.toBe(false);
+        await expect(isSystemdUserServiceAvailable(env)).resolves.toBe(false);
+      }
+    });
   });
 });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -11,6 +11,7 @@ import type { ExecResult } from "./exec-file.js";
 type ExecFileError = Error & {
   stderr?: string;
   code?: string | number;
+  termination?: ExecResult["termination"];
 };
 type ExecFileCallback = (error: ExecFileError | null, stdout: string, stderr: string) => void;
 type ExecFileMock = (
@@ -68,7 +69,7 @@ vi.mock("./exec-file.js", () => {
           stdout: stdout ?? "",
           stderr: stderr || error?.message || "",
           code: error && typeof error.code === "number" ? error.code : error ? 1 : 0,
-          termination: typeof error?.code === "string" ? "error" : "exit",
+          termination: error?.termination ?? (typeof error?.code === "string" ? "error" : "exit"),
           errorCode: typeof error?.code === "string" ? error.code : undefined,
         };
       });
@@ -113,10 +114,11 @@ const NODE_SERVICE = "openclaw-node.service";
 
 const createExecFileError = (
   message: string,
-  options: { stderr?: string; code?: string | number } = {},
+  options: Pick<ExecFileError, "stderr" | "code" | "termination"> = {},
 ): ExecFileError => {
   const err = new Error(message) as ExecFileError;
   err.code = options.code ?? 1;
+  err.termination = options.termination;
   if (options.stderr) {
     err.stderr = options.stderr;
   }
@@ -634,15 +636,25 @@ describe("isSystemdServiceEnabled", () => {
     expect(result).toBe(true);
   });
 
-  it("returns false when systemctl reports disabled", async () => {
-    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
-      const err = new Error("disabled") as Error & { code?: number };
-      err.code = 1;
-      cb(err, "disabled", "");
-    });
-    const result = await readManagedServiceEnabled();
-    expect(result).toBe(false);
-  });
+  it.each(["exit", "timeout", "signal"] as const)(
+    "accepts disabled output only after a completed is-enabled command (%s)",
+    async (termination) => {
+      execFileMock.mockImplementationOnce(
+        systemctlUserResult(
+          [createExecFileError("disabled", { termination }), "disabled", ""],
+          "is-enabled",
+          GATEWAY_SERVICE,
+        ),
+      );
+
+      const result = readManagedServiceEnabled();
+      if (termination === "exit") {
+        await expect(result).resolves.toBe(false);
+      } else {
+        await expect(result).rejects.toThrow("systemctl is-enabled unavailable:");
+      }
+    },
+  );
 
   it("returns false for the WSL2 Ubuntu 24.04 wrapper-only is-enabled failure", async () => {
     execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
@@ -1182,19 +1194,30 @@ describe("readSystemdServiceRuntime", () => {
     });
   });
 
-  it("reports a missing unit without surfacing routine systemctl stderr", async () => {
-    execFileMock
-      .mockImplementationOnce(systemctlUserSuccess("status"))
-      .mockImplementationOnce((_cmd, _args, _opts, cb) => {
-        const detail = "Unit openclaw-gateway.service could not be found.";
-        cb(createExecFileError(detail, { stderr: detail }), "", detail);
-      });
+  it.each(["exit", "timeout", "signal"] as const)(
+    "reports a missing unit only after a completed show command (%s)",
+    async (termination) => {
+      const detail = "Unit openclaw-gateway.service could not be found.";
+      const accessSpy = vi
+        .spyOn(fs, "access")
+        .mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+      execFileMock
+        .mockImplementationOnce(systemctlUserSuccess("status"))
+        .mockImplementationOnce((_cmd, _args, _opts, cb) => {
+          cb(createExecFileError(detail, { termination }), "", detail);
+        });
 
-    await expect(readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME })).resolves.toEqual({
-      status: "stopped",
-      missingUnit: true,
-    });
-  });
+      try {
+        await expect(readSystemdServiceRuntime({ HOME: TEST_MANAGED_HOME })).resolves.toEqual(
+          termination === "exit"
+            ? { status: "stopped", missingUnit: true }
+            : { status: "unknown", missingUnit: false, detail },
+        );
+      } finally {
+        accessSpy.mockRestore();
+      }
+    },
+  );
 
   it("keeps unexpected systemctl failures visible", async () => {
     execFileMock
@@ -3003,6 +3026,49 @@ describe("systemd service install and uninstall", () => {
       expect(execFileMock).toHaveBeenCalledTimes(6);
     });
   });
+
+  it.each([
+    { action: "enable", termination: "timeout" },
+    { action: "restart", termination: "signal" },
+  ] as const)(
+    "does not retry an interrupted $action reporting a missing unit ($termination)",
+    async ({ action, termination }) => {
+      await withNodeSystemdFixture(async ({ env }) => {
+        execFileMock
+          .mockImplementation(execFileSuccess())
+          .mockImplementationOnce(systemctlUserSuccess("status"))
+          .mockImplementationOnce(systemctlUserSuccess("daemon-reload"));
+        if (action === "restart") {
+          execFileMock.mockImplementationOnce(systemctlUserSuccess("enable", NODE_SERVICE));
+        }
+        execFileMock.mockImplementationOnce(
+          systemctlUserResult(
+            [
+              createExecFileError(`${action} interrupted`, { termination }),
+              "",
+              "Unit file openclaw-node.service does not exist.",
+            ],
+            action,
+            NODE_SERVICE,
+          ),
+        );
+
+        await expect(
+          installSystemdService(
+            nodeSystemdServiceFixture(env, {
+              environment: { OPENCLAW_SYSTEMD_UNIT: "openclaw-node" },
+            }),
+          ),
+        ).rejects.toThrow(`systemctl ${action} failed:`);
+        expect(execFileMock.mock.calls.map(([, args]) => args[1])).toEqual([
+          "status",
+          "daemon-reload",
+          ...(action === "restart" ? ["enable"] : []),
+          action,
+        ]);
+      });
+    },
+  );
 
   it("falls back to machine user scope when install activation hits a no-medium user bus failure", async () => {
     await withNodeSystemdFixture(async ({ env }) => {

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildGatewayInstallPlan } from "../commands/daemon-install-helpers.js";
+import type { ExecResult } from "./exec-file.js";
 
 type ExecFileError = Error & {
   stderr?: string;
@@ -60,19 +61,15 @@ vi.mock("./exec-file.js", () => {
       args: string[],
       options: Omit<ExecFileOptionsWithStringEncoding, "encoding"> = {},
     ) => {
-      let settled:
-        | {
-            stdout: string;
-            stderr: string;
-            code: number;
-          }
-        | undefined;
+      let settled: ExecResult | undefined;
 
       execFileMock(command, args, { ...options, encoding: "utf8" }, (error, stdout, stderr) => {
         settled = {
           stdout: stdout ?? "",
           stderr: stderr || error?.message || "",
           code: error && typeof error.code === "number" ? error.code : error ? 1 : 0,
+          termination: typeof error?.code === "string" ? "error" : "exit",
+          errorCode: typeof error?.code === "string" ? error.code : undefined,
         };
       });
 

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 // Systemd tests cover Linux service install, start, stop, and status behavior.
 import { expectDefined } from "@openclaw/normalization-core";
+import { err as resultErr, ok } from "@openclaw/normalization-core/result";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildGatewayInstallPlan } from "../commands/daemon-install-helpers.js";
 import type { ExecResult } from "./exec-file.js";
@@ -787,25 +788,46 @@ describe("isSystemdUnitActive", () => {
     assertNoSystemSystemdOwnershipMock.mockResolvedValue();
   });
 
+  describe.each(["user", "system"] as const)("%s activity queries", (scope) => {
+    it.each([
+      ["bus failure", { code: 1 }, "Failed to connect to bus: Permission denied"],
+      ["unexpected exit", { code: 2 }, "Unexpected query failure"],
+      ["launch error", { code: "ENOENT" }, "Command failed during launch (ENOENT)"],
+      ["signal", { code: 1, termination: "signal" }, "Command was terminated by SIGTERM"],
+      ["timeout", { code: 3, termination: "timeout" }, "Command timed out"],
+    ] satisfies [string, Pick<ExecFileError, "code" | "termination">, string][])(
+      "keeps failed activity probes distinguishable from inactive units: %s",
+      async (_, options, detail) => {
+        execFileMock.mockImplementation(
+          execFileResult(createExecFileError(detail, options), "", detail),
+        );
+
+        await expect(
+          isSystemdUnitActive({ HOME: TEST_MANAGED_HOME }, GATEWAY_SERVICE, scope),
+        ).resolves.toEqual(resultErr(detail));
+      },
+    );
+  });
+
   it("checks user-scoped units through the user systemd manager", async () => {
     execFileMock.mockImplementationOnce(
       systemctlUserSuccess("is-active", "--quiet", GATEWAY_SERVICE),
     );
 
-    await expect(isSystemdUnitActive({ HOME: TEST_MANAGED_HOME }, GATEWAY_SERVICE)).resolves.toBe(
-      true,
-    );
+    await expect(
+      isSystemdUnitActive({ HOME: TEST_MANAGED_HOME }, GATEWAY_SERVICE),
+    ).resolves.toEqual(ok(true));
   });
 
-  it("checks system-scoped units without the user manager", async () => {
+  it.each([3, 4])("recognizes non-active system-scoped units (exit %i)", async (code) => {
     execFileMock.mockImplementationOnce((_cmd, args, _opts, cb) => {
       expect(args).toEqual(["is-active", "--quiet", GATEWAY_SERVICE]);
-      cb(createExecFileError("inactive", { code: 3 }), "", "");
+      cb(createExecFileError("not active", { code }), "", "");
     });
 
     await expect(
       isSystemdUnitActive({ HOME: TEST_MANAGED_HOME }, GATEWAY_SERVICE, "system"),
-    ).resolves.toBe(false);
+    ).resolves.toEqual(ok(false));
   });
 });
 
@@ -3320,12 +3342,21 @@ describe("isSystemUnitActiveAndEnabled", () => {
     await expect(isSystemUnitActiveAndEnabled({}, GATEWAY_SERVICE)).resolves.toBe(false);
   });
 
-  it("returns false when systemctl is unavailable", async () => {
-    execFileMock.mockImplementation(
-      execFileResult(createExecFileError("spawn systemctl ENOENT", { code: "ENOENT" }), "", ""),
-    );
-    await expect(isSystemUnitActiveAndEnabled({}, GATEWAY_SERVICE)).resolves.toBe(false);
-  });
+  it.each([
+    ["unavailable", { code: "ENOENT" }],
+    ["bus query failed", { code: 1 }],
+    ["terminated", { code: 1, termination: "signal" }],
+    ["timed out", { code: 3, termination: "timeout" }],
+  ] satisfies [string, Pick<ExecFileError, "code" | "termination">][])(
+    "does not adopt the system unit when its activity is unknown: %s",
+    async (detail, options) => {
+      execFileMock.mockImplementation(
+        execFileResult(createExecFileError(detail, options), "", detail),
+      );
+      await expect(isSystemUnitActiveAndEnabled({}, GATEWAY_SERVICE)).resolves.toBe(false);
+      expect(execFileMock).toHaveBeenCalledTimes(1);
+    },
+  );
 
   // systemctl(1) Table 3: these all exit 0 but none survive a reboot as an
   // enabled unit, so none may authorize deleting the user-scope unit.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators checking or repairing Gateway services could have an interrupted or unavailable service-manager command treated as proof that a service was absent or stopped. Doctor could then hide a detected service or proceed with a repair without knowing the service state.

## Why This Change Was Made

The daemon command boundary now preserves normal exit, spawn failure, timeout and signal outcomes instead of discarding that information. Service classifiers consume those facts directly. The Systemd activity helper returns the existing Result type; both Doctor paths and the competing-service check preserve unknown outcomes rather than translating them into inactivity.

The detached launchd guard uses one query classifier before and after its existing filesystem scan. Execution failures and signal-range shell statuses cannot become absence merely because partial output contains familiar text. The generated shell remains independent of the installed JavaScript package. The shared handoff test fixture now confines its service scan, state, plist and temporary paths to an owned fixture directory.

## User Impact

Doctor retains uncertain service findings and explains why it cannot safely repair them. Normal active, inactive and missing-service results retain their intended behavior. A failed ownership probe no longer permits cleanup or restart decisions based on partial output.

No new configuration, dependency, schema, service policy, timeout, public API or compatibility path is introduced. Production changes are +147/-166 (net -19); tests are +647/-286; the pre-existing assertion-baseline relocation remains net zero.

## Evidence

- Captured failing regressions before each repair. The complete owner and sibling selection passes 614 tests across 13 files, with six unchanged platform skips. After mechanical lint corrections, both affected owner suites were rerun: 279 tests passed. It covers Systemd, launchd, scheduled-task command execution, process execution, Doctor, noninteractive installation, detached handoff, process respawn and updater restart helpers.
- Real inert child-process proof passes 14 cases across user/system scopes: normal activity exits, an ordinary manager error, missing/non-executable commands, and SIGTERM after partial output. This exercises the actual process adapter and activity classifier; it does not claim a native Linux service deployment.
- The actual rendered shell failed four regression cases before the classifier repair and passes all 23 cases afterward, including initial/final interrupted queries and executable failures. No operator service was installed, stopped or changed. A separate read-only native launchctl query confirmed normal missing-service exit 113 on this host.
- The shell classification matches the [POSIX exit-status contract](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_08_02). Numeric diagnostics preserve uncertainty rather than claiming a particular signal from an overlapping numeric status.
- All 29 full changed checks passed on the final 18-file patch, including production/test types, lint, dead-code scans and architecture guards. Fresh cumulative Codex autoreview reports no P0 findings. Independent source review of the process/result consumers and both generated-shell consumers reports no actionable findings. Exact published-head CI remains required before landing.

The latest completed ClawSweeper finding and both rank-up moves are addressed: unknown is-active outcomes remain structured, and timeout/signal coverage reaches the activity boundary and both Doctor consumers. The detached shell classifier is an additional repair of the same invariant. Native Linux deployment, a real detached launchd activation, and packaged installation are not claimed by these isolated proofs.
