### PR TITLE
refactor(video): deduplicate generation contracts

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3493,7 +3493,6 @@ src/plugin-sdk/ssrf-policy.ts	1
 src/plugin-sdk/status-helpers.ts	7
 src/plugin-sdk/tool-payload.ts	2
 src/plugin-sdk/tool-plugin.ts	10
-src/plugin-sdk/video-generation.ts	1
 src/plugin-sdk/windows-spawn.ts	1
 src/plugin-state/plugin-blob-store.ts	1
 src/plugin-state/plugin-state-store.sqlite.ts	2

--- a/src/plugin-sdk/video-generation.ts
+++ b/src/plugin-sdk/video-generation.ts
@@ -1,10 +1,5 @@
 // Public video-generation helpers and types for provider plugins.
-//
-// Keep these public type declarations local to the plugin-sdk entrypoint so the
-// emitted declaration surface stays stable for package-boundary consumers.
 
-import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   DASHSCOPE_WAN_VIDEO_CATALOG_BY_MODEL,
   DASHSCOPE_WAN_VIDEO_CAPABILITIES,
@@ -13,6 +8,7 @@ import {
   DEFAULT_VIDEO_GENERATION_TIMEOUT_MS,
   runDashscopeVideoGenerationTask,
 } from "../video-generation/dashscope-compatible.js";
+import type { VideoGenerationProvider, VideoGenerationResult } from "../video-generation/types.js";
 import { resolveApiKeyForProvider } from "./provider-auth-runtime.js";
 import { isProviderApiKeyConfigured } from "./provider-auth.js";
 import {
@@ -20,180 +16,23 @@ import {
   sanitizeConfiguredModelProviderRequest,
 } from "./provider-http.js";
 
-/** Video asset returned by a provider after generation or transformation. */
-export type GeneratedVideoAsset = {
-  /** Non-empty raw video bytes; may accompany url as a delivery fallback. */
-  buffer?: Buffer;
-  /** Provider-hosted URL returned instead of bytes or alongside them as a delivery fallback.
-   * When buffer is absent, callers can forward or download without materializing the video. */
-  url?: string;
-  mimeType: string;
-  fileName?: string;
-  metadata?: Record<string, unknown>;
-};
-
-/** Resolution label accepted by video generation providers. */
-export type VideoGenerationResolution =
-  | "360P"
-  | "480P"
-  | "540P"
-  | "720P"
-  | "768P"
-  | "1080P"
-  | (string & {});
-
-/**
- * Canonical semantic role hints for reference assets (first/last frame,
- * reference image/video/audio). Providers may accept additional role strings;
- * the asset.role type accepts both canonical values and arbitrary strings.
- */
-export type VideoGenerationAssetRole =
-  | "first_frame"
-  | "last_frame"
-  | "reference_image"
-  | "reference_video"
-  | "reference_audio";
-
-/** Source media asset supplied to image/video/audio-to-video providers. */
-export type VideoGenerationSourceAsset = {
-  url?: string;
-  buffer?: Buffer;
-  mimeType?: string;
-  fileName?: string;
-  /**
-   * Optional semantic role hint forwarded to the provider. Canonical values
-   * come from `VideoGenerationAssetRole`; plain strings are accepted for
-   * provider-specific extensions.
-   */
-  role?: VideoGenerationAssetRole | (string & {});
-  metadata?: Record<string, unknown>;
-};
-
-/** Context passed when checking whether a video provider is configured. */
-export type VideoGenerationProviderConfiguredContext = {
-  cfg?: OpenClawConfig;
-  agentDir?: string;
-};
-
-/** Context passed when resolving model-specific video generation capabilities. */
-export type VideoGenerationModelCapabilitiesContext = {
-  provider: string;
-  model: string;
-  cfg: OpenClawConfig;
-  agentDir?: string;
-  authStore?: AuthProfileStore;
-  timeoutMs?: number;
-};
-
-/** Normalized request object passed to a selected video generation provider. */
-export type VideoGenerationRequest = {
-  provider: string;
-  model: string;
-  prompt: string;
-  cfg: OpenClawConfig;
-  agentDir?: string;
-  authStore?: AuthProfileStore;
-  timeoutMs?: number;
-  size?: string;
-  aspectRatio?: string;
-  resolution?: VideoGenerationResolution;
-  durationSeconds?: number;
-  audio?: boolean;
-  watermark?: boolean;
-  inputImages?: VideoGenerationSourceAsset[];
-  inputVideos?: VideoGenerationSourceAsset[];
-  /** Reference audio assets (e.g. background music) forwarded to the provider. */
-  inputAudios?: VideoGenerationSourceAsset[];
-  /** Arbitrary provider-specific parameters forwarded as-is (e.g. seed, draft, camerafixed). */
-  providerOptions?: Record<string, unknown>;
-};
-
-/** Provider video generation response returned to the runtime. */
-export type VideoGenerationResult = {
-  videos: GeneratedVideoAsset[];
-  model?: string;
-  metadata?: Record<string, unknown>;
-};
-
-/** Supported high-level video generation operation modes. */
-export type VideoGenerationMode = "generate" | "imageToVideo" | "videoToVideo";
-
-/**
- * Primitive type tag for a declared `providerOptions` key. Keep narrow —
- * plugins that need richer shapes should leave them out of the typed contract
- * and interpret the forwarded opaque value inside their own provider code.
- */
-export type VideoGenerationProviderOptionType = "number" | "boolean" | "string";
-
-/** Capability limits and supported options for one video generation mode. */
-export type VideoGenerationModeCapabilities = {
-  maxVideos?: number;
-  maxInputImages?: number;
-  maxInputImagesByModel?: Readonly<Record<string, number>>;
-  maxInputVideos?: number;
-  maxInputVideosByModel?: Readonly<Record<string, number>>;
-  /** Max number of reference audio assets the provider accepts (e.g. background music, voice reference). */
-  maxInputAudios?: number;
-  maxInputAudiosByModel?: Readonly<Record<string, number>>;
-  maxDurationSeconds?: number;
-  supportedDurationSeconds?: readonly number[];
-  supportedDurationSecondsByModel?: Readonly<Record<string, readonly number[]>>;
-  sizes?: readonly string[];
-  aspectRatios?: readonly string[];
-  resolutions?: readonly VideoGenerationResolution[];
-  supportsSize?: boolean;
-  supportsAspectRatio?: boolean;
-  supportsResolution?: boolean;
-  supportsAudio?: boolean;
-  supportsWatermark?: boolean;
-  /**
-   * Declared typed schema for `VideoGenerationRequest.providerOptions`. Keys
-   * listed here are accepted and validated against the declared primitive
-   * type before forwarding; unknown keys or type mismatches skip the
-   * candidate provider at runtime so mis-typed or provider-specific options
-   * never silently reach the wrong provider.
-   */
-  providerOptions?: Readonly<Record<string, VideoGenerationProviderOptionType>>;
-};
-
-/** Capability block for transform modes that may be independently enabled. */
-export type VideoGenerationTransformCapabilities = VideoGenerationModeCapabilities & {
-  enabled: boolean;
-};
-
-/** Full provider capability map including base and transform mode overrides. */
-export type VideoGenerationProviderCapabilities = VideoGenerationModeCapabilities & {
-  generate?: VideoGenerationModeCapabilities;
-  imageToVideo?: VideoGenerationTransformCapabilities;
-  videoToVideo?: VideoGenerationTransformCapabilities;
-};
-
-/** Static catalog metadata that overrides provider defaults for one video model. */
-export type VideoGenerationCatalogModelEntry = {
-  capabilities?: VideoGenerationProviderCapabilities;
-  modes?: readonly VideoGenerationMode[];
-};
-
-/** Video generation provider contract implemented by provider plugins. */
-export type VideoGenerationProvider = {
-  id: string;
-  aliases?: string[];
-  label?: string;
-  defaultModel?: string;
-  /** Default provider operation timeout in milliseconds when caller/config omit timeoutMs. */
-  defaultTimeoutMs?: number;
-  models?: string[];
-  capabilities: VideoGenerationProviderCapabilities;
-  catalogByModel?: Readonly<Record<string, VideoGenerationCatalogModelEntry>>;
-  isConfigured?: (ctx: VideoGenerationProviderConfiguredContext) => boolean;
-  resolveModelCapabilities?: (
-    ctx: VideoGenerationModelCapabilitiesContext,
-  ) =>
-    | VideoGenerationProviderCapabilities
-    | undefined
-    | Promise<VideoGenerationProviderCapabilities | undefined>;
-  generateVideo: (req: VideoGenerationRequest) => Promise<VideoGenerationResult>;
-};
+export type {
+  GeneratedVideoAsset,
+  VideoGenerationResolution,
+  VideoGenerationAssetRole,
+  VideoGenerationSourceAsset,
+  VideoGenerationProviderConfiguredContext,
+  VideoGenerationModelCapabilitiesContext,
+  VideoGenerationRequest,
+  VideoGenerationResult,
+  VideoGenerationMode,
+  VideoGenerationProviderOptionType,
+  VideoGenerationModeCapabilities,
+  VideoGenerationTransformCapabilities,
+  VideoGenerationProviderCapabilities,
+  VideoGenerationCatalogModelEntry,
+  VideoGenerationProvider,
+} from "../video-generation/types.js";
 
 export type DashscopeVideoGenerationProviderOptions = {
   providerId: string;

--- a/src/plugin-sdk/video-generation.ts
+++ b/src/plugin-sdk/video-generation.ts
@@ -13,23 +13,6 @@ import {
   DEFAULT_VIDEO_GENERATION_TIMEOUT_MS,
   runDashscopeVideoGenerationTask,
 } from "../video-generation/dashscope-compatible.js";
-import type {
-  GeneratedVideoAsset as CoreGeneratedVideoAsset,
-  VideoGenerationAssetRole as CoreVideoGenerationAssetRole,
-  VideoGenerationCatalogModelEntry as CoreVideoGenerationCatalogModelEntry,
-  VideoGenerationMode as CoreVideoGenerationMode,
-  VideoGenerationModeCapabilities as CoreVideoGenerationModeCapabilities,
-  VideoGenerationModelCapabilitiesContext as CoreVideoGenerationModelCapabilitiesContext,
-  VideoGenerationProvider as CoreVideoGenerationProvider,
-  VideoGenerationProviderCapabilities as CoreVideoGenerationProviderCapabilities,
-  VideoGenerationProviderConfiguredContext as CoreVideoGenerationProviderConfiguredContext,
-  VideoGenerationProviderOptionType as CoreVideoGenerationProviderOptionType,
-  VideoGenerationRequest as CoreVideoGenerationRequest,
-  VideoGenerationResolution as CoreVideoGenerationResolution,
-  VideoGenerationResult as CoreVideoGenerationResult,
-  VideoGenerationSourceAsset as CoreVideoGenerationSourceAsset,
-  VideoGenerationTransformCapabilities as CoreVideoGenerationTransformCapabilities,
-} from "../video-generation/types.js";
 import { resolveApiKeyForProvider } from "./provider-auth-runtime.js";
 import { isProviderApiKeyConfigured } from "./provider-auth.js";
 import {
@@ -211,53 +194,6 @@ export type VideoGenerationProvider = {
     | Promise<VideoGenerationProviderCapabilities | undefined>;
   generateVideo: (req: VideoGenerationRequest) => Promise<VideoGenerationResult>;
 };
-
-type AssertAssignable<_Left extends _Right, _Right> = true;
-const videoGenerationSdkCompat: [
-  AssertAssignable<GeneratedVideoAsset, CoreGeneratedVideoAsset>,
-  AssertAssignable<CoreGeneratedVideoAsset, GeneratedVideoAsset>,
-  AssertAssignable<VideoGenerationAssetRole, CoreVideoGenerationAssetRole>,
-  AssertAssignable<CoreVideoGenerationAssetRole, VideoGenerationAssetRole>,
-  AssertAssignable<VideoGenerationProviderOptionType, CoreVideoGenerationProviderOptionType>,
-  AssertAssignable<CoreVideoGenerationProviderOptionType, VideoGenerationProviderOptionType>,
-  AssertAssignable<VideoGenerationMode, CoreVideoGenerationMode>,
-  AssertAssignable<CoreVideoGenerationMode, VideoGenerationMode>,
-  AssertAssignable<VideoGenerationCatalogModelEntry, CoreVideoGenerationCatalogModelEntry>,
-  AssertAssignable<CoreVideoGenerationCatalogModelEntry, VideoGenerationCatalogModelEntry>,
-  AssertAssignable<VideoGenerationModeCapabilities, CoreVideoGenerationModeCapabilities>,
-  AssertAssignable<CoreVideoGenerationModeCapabilities, VideoGenerationModeCapabilities>,
-  AssertAssignable<VideoGenerationProvider, CoreVideoGenerationProvider>,
-  AssertAssignable<CoreVideoGenerationProvider, VideoGenerationProvider>,
-  AssertAssignable<VideoGenerationProviderCapabilities, CoreVideoGenerationProviderCapabilities>,
-  AssertAssignable<CoreVideoGenerationProviderCapabilities, VideoGenerationProviderCapabilities>,
-  AssertAssignable<
-    VideoGenerationProviderConfiguredContext,
-    CoreVideoGenerationProviderConfiguredContext
-  >,
-  AssertAssignable<
-    CoreVideoGenerationProviderConfiguredContext,
-    VideoGenerationProviderConfiguredContext
-  >,
-  AssertAssignable<
-    VideoGenerationModelCapabilitiesContext,
-    CoreVideoGenerationModelCapabilitiesContext
-  >,
-  AssertAssignable<
-    CoreVideoGenerationModelCapabilitiesContext,
-    VideoGenerationModelCapabilitiesContext
-  >,
-  AssertAssignable<VideoGenerationRequest, CoreVideoGenerationRequest>,
-  AssertAssignable<CoreVideoGenerationRequest, VideoGenerationRequest>,
-  AssertAssignable<VideoGenerationResolution, CoreVideoGenerationResolution>,
-  AssertAssignable<CoreVideoGenerationResolution, VideoGenerationResolution>,
-  AssertAssignable<VideoGenerationResult, CoreVideoGenerationResult>,
-  AssertAssignable<CoreVideoGenerationResult, VideoGenerationResult>,
-  AssertAssignable<VideoGenerationSourceAsset, CoreVideoGenerationSourceAsset>,
-  AssertAssignable<CoreVideoGenerationSourceAsset, VideoGenerationSourceAsset>,
-  AssertAssignable<VideoGenerationTransformCapabilities, CoreVideoGenerationTransformCapabilities>,
-  AssertAssignable<CoreVideoGenerationTransformCapabilities, VideoGenerationTransformCapabilities>,
-] = [] as never;
-void videoGenerationSdkCompat;
 
 export type DashscopeVideoGenerationProviderOptions = {
   providerId: string;

--- a/src/video-generation/types.ts
+++ b/src/video-generation/types.ts
@@ -1,21 +1,182 @@
-// Video generation types reuse the SDK contracts and add runtime normalization metadata.
+// Shared video-generation request, provider, capability, and normalization contracts.
 import type { MediaNormalizationEntry } from "../../packages/media-generation-core/src/normalization.js";
-import type { VideoGenerationResolution } from "../plugin-sdk/video-generation.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 
-export type {
-  GeneratedVideoAsset,
-  VideoGenerationResolution,
-  VideoGenerationSourceAsset,
-  VideoGenerationRequest,
-  VideoGenerationResult,
-  VideoGenerationMode,
-  VideoGenerationProviderOptionType,
-  VideoGenerationModeCapabilities,
-  VideoGenerationTransformCapabilities,
-  VideoGenerationProviderCapabilities,
-  VideoGenerationCatalogModelEntry,
-  VideoGenerationProvider,
-} from "../plugin-sdk/video-generation.js";
+/** Video asset returned by a provider after generation or transformation. */
+export type GeneratedVideoAsset = {
+  /** Non-empty raw video bytes; may accompany url as a delivery fallback. */
+  buffer?: Buffer;
+  /** Provider-hosted URL returned instead of bytes or alongside them as a delivery fallback.
+   * When buffer is absent, callers can forward or download without materializing the video. */
+  url?: string;
+  mimeType: string;
+  fileName?: string;
+  metadata?: Record<string, unknown>;
+};
+
+/** Resolution label accepted by video generation providers. */
+export type VideoGenerationResolution =
+  | "360P"
+  | "480P"
+  | "540P"
+  | "720P"
+  | "768P"
+  | "1080P"
+  | (string & {});
+
+/**
+ * Canonical semantic role hints for reference assets (first/last frame,
+ * reference image/video/audio). Providers may accept additional role strings;
+ * the asset.role type accepts both canonical values and arbitrary strings.
+ */
+export type VideoGenerationAssetRole =
+  | "first_frame"
+  | "last_frame"
+  | "reference_image"
+  | "reference_video"
+  | "reference_audio";
+
+/** Source media asset supplied to image/video/audio-to-video providers. */
+export type VideoGenerationSourceAsset = {
+  url?: string;
+  buffer?: Buffer;
+  mimeType?: string;
+  fileName?: string;
+  /**
+   * Optional semantic role hint forwarded to the provider. Canonical values
+   * come from `VideoGenerationAssetRole`; plain strings are accepted for
+   * provider-specific extensions.
+   */
+  role?: VideoGenerationAssetRole | (string & {});
+  metadata?: Record<string, unknown>;
+};
+
+/** Context passed when checking whether a video provider is configured. */
+export type VideoGenerationProviderConfiguredContext = {
+  cfg?: OpenClawConfig;
+  agentDir?: string;
+};
+
+/** Context passed when resolving model-specific video generation capabilities. */
+export type VideoGenerationModelCapabilitiesContext = {
+  provider: string;
+  model: string;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  authStore?: AuthProfileStore;
+  timeoutMs?: number;
+};
+
+/** Normalized request object passed to a selected video generation provider. */
+export type VideoGenerationRequest = {
+  provider: string;
+  model: string;
+  prompt: string;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  authStore?: AuthProfileStore;
+  timeoutMs?: number;
+  size?: string;
+  aspectRatio?: string;
+  resolution?: VideoGenerationResolution;
+  durationSeconds?: number;
+  audio?: boolean;
+  watermark?: boolean;
+  inputImages?: VideoGenerationSourceAsset[];
+  inputVideos?: VideoGenerationSourceAsset[];
+  /** Reference audio assets (e.g. background music) forwarded to the provider. */
+  inputAudios?: VideoGenerationSourceAsset[];
+  /** Arbitrary provider-specific parameters forwarded as-is (e.g. seed, draft, camerafixed). */
+  providerOptions?: Record<string, unknown>;
+};
+
+/** Provider video generation response returned to the runtime. */
+export type VideoGenerationResult = {
+  videos: GeneratedVideoAsset[];
+  model?: string;
+  metadata?: Record<string, unknown>;
+};
+
+/** Supported high-level video generation operation modes. */
+export type VideoGenerationMode = "generate" | "imageToVideo" | "videoToVideo";
+
+/**
+ * Primitive type tag for a declared `providerOptions` key. Keep narrow —
+ * plugins that need richer shapes should leave them out of the typed contract
+ * and interpret the forwarded opaque value inside their own provider code.
+ */
+export type VideoGenerationProviderOptionType = "number" | "boolean" | "string";
+
+/** Capability limits and supported options for one video generation mode. */
+export type VideoGenerationModeCapabilities = {
+  maxVideos?: number;
+  maxInputImages?: number;
+  maxInputImagesByModel?: Readonly<Record<string, number>>;
+  maxInputVideos?: number;
+  maxInputVideosByModel?: Readonly<Record<string, number>>;
+  /** Max number of reference audio assets the provider accepts (e.g. background music, voice reference). */
+  maxInputAudios?: number;
+  maxInputAudiosByModel?: Readonly<Record<string, number>>;
+  maxDurationSeconds?: number;
+  supportedDurationSeconds?: readonly number[];
+  supportedDurationSecondsByModel?: Readonly<Record<string, readonly number[]>>;
+  sizes?: readonly string[];
+  aspectRatios?: readonly string[];
+  resolutions?: readonly VideoGenerationResolution[];
+  supportsSize?: boolean;
+  supportsAspectRatio?: boolean;
+  supportsResolution?: boolean;
+  supportsAudio?: boolean;
+  supportsWatermark?: boolean;
+  /**
+   * Declared typed schema for `VideoGenerationRequest.providerOptions`. Keys
+   * listed here are accepted and validated against the declared primitive
+   * type before forwarding; unknown keys or type mismatches skip the
+   * candidate provider at runtime so mis-typed or provider-specific options
+   * never silently reach the wrong provider.
+   */
+  providerOptions?: Readonly<Record<string, VideoGenerationProviderOptionType>>;
+};
+
+/** Capability block for transform modes that may be independently enabled. */
+export type VideoGenerationTransformCapabilities = VideoGenerationModeCapabilities & {
+  enabled: boolean;
+};
+
+/** Full provider capability map including base and transform mode overrides. */
+export type VideoGenerationProviderCapabilities = VideoGenerationModeCapabilities & {
+  generate?: VideoGenerationModeCapabilities;
+  imageToVideo?: VideoGenerationTransformCapabilities;
+  videoToVideo?: VideoGenerationTransformCapabilities;
+};
+
+/** Static catalog metadata that overrides provider defaults for one video model. */
+export type VideoGenerationCatalogModelEntry = {
+  capabilities?: VideoGenerationProviderCapabilities;
+  modes?: readonly VideoGenerationMode[];
+};
+
+/** Video generation provider contract implemented by provider plugins. */
+export type VideoGenerationProvider = {
+  id: string;
+  aliases?: string[];
+  label?: string;
+  defaultModel?: string;
+  /** Default provider operation timeout in milliseconds when caller/config omit timeoutMs. */
+  defaultTimeoutMs?: number;
+  models?: string[];
+  capabilities: VideoGenerationProviderCapabilities;
+  catalogByModel?: Readonly<Record<string, VideoGenerationCatalogModelEntry>>;
+  isConfigured?: (ctx: VideoGenerationProviderConfiguredContext) => boolean;
+  resolveModelCapabilities?: (
+    ctx: VideoGenerationModelCapabilitiesContext,
+  ) =>
+    | VideoGenerationProviderCapabilities
+    | undefined
+    | Promise<VideoGenerationProviderCapabilities | undefined>;
+  generateVideo: (req: VideoGenerationRequest) => Promise<VideoGenerationResult>;
+};
 
 export type VideoGenerationIgnoredOverride = {
   key: "size" | "aspectRatio" | "resolution" | "audio" | "watermark";

--- a/src/video-generation/types.ts
+++ b/src/video-generation/types.ts
@@ -1,164 +1,25 @@
-// Video generation types describe requests, providers, and normalized media output.
+// Video generation types reuse the SDK contracts and add runtime normalization metadata.
 import type { MediaNormalizationEntry } from "../../packages/media-generation-core/src/normalization.js";
-import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { VideoGenerationResolution } from "../plugin-sdk/video-generation.js";
 
-export type GeneratedVideoAsset = {
-  /** Non-empty raw video bytes for local delivery; may accompany url as a fallback. */
-  buffer?: Buffer;
-  /** Provider-hosted URL returned instead of bytes or alongside them as a delivery fallback.
-   * When buffer is absent, surfaces can forward the URL without materializing the video. */
-  url?: string;
-  mimeType: string;
-  fileName?: string;
-  metadata?: Record<string, unknown>;
-};
-
-export type VideoGenerationResolution =
-  | "360P"
-  | "480P"
-  | "540P"
-  | "720P"
-  | "768P"
-  | "1080P"
-  | (string & {});
-
-/**
- * Canonical semantic role hints for reference assets. The list covers the
- * near-universal I2V vocabulary plus per-kind reference roles. Providers may
- * accept additional role strings (extend the asset.role type with a plain
- * string at call sites) — core forwards whatever value is set.
- */
-export type VideoGenerationAssetRole =
-  | "first_frame"
-  | "last_frame"
-  | "reference_image"
-  | "reference_video"
-  | "reference_audio";
-
-export type VideoGenerationSourceAsset = {
-  url?: string;
-  buffer?: Buffer;
-  mimeType?: string;
-  fileName?: string;
-  /**
-   * Optional semantic role hint forwarded to the provider. Canonical values
-   * come from `VideoGenerationAssetRole`; plain strings are accepted for
-   * provider-specific extensions. Core does not validate the value beyond
-   * shape.
-   */
-  // Union with `(string & {})` keeps autocomplete on the canonical values while
-  // still accepting arbitrary provider-specific role strings.
-  role?: VideoGenerationAssetRole | (string & {});
-  metadata?: Record<string, unknown>;
-};
-
-export type VideoGenerationProviderConfiguredContext = {
-  cfg?: OpenClawConfig;
-  agentDir?: string;
-};
-
-export type VideoGenerationRequest = {
-  provider: string;
-  model: string;
-  prompt: string;
-  cfg: OpenClawConfig;
-  agentDir?: string;
-  authStore?: AuthProfileStore;
-  timeoutMs?: number;
-  size?: string;
-  aspectRatio?: string;
-  resolution?: VideoGenerationResolution;
-  durationSeconds?: number;
-  /** Enable generated audio in the output when the provider supports it. Distinct from inputAudios (reference audio input). */
-  audio?: boolean;
-  watermark?: boolean;
-  inputImages?: VideoGenerationSourceAsset[];
-  inputVideos?: VideoGenerationSourceAsset[];
-  /** Reference audio assets (e.g. background music). Role field on each asset is forwarded to the provider as-is. */
-  inputAudios?: VideoGenerationSourceAsset[];
-  /** Arbitrary provider-specific options forwarded as-is to provider.generateVideo. Core does not validate or log the contents. */
-  providerOptions?: Record<string, unknown>;
-};
-
-export type VideoGenerationModelCapabilitiesContext = {
-  provider: string;
-  model: string;
-  cfg: OpenClawConfig;
-  agentDir?: string;
-  authStore?: AuthProfileStore;
-  timeoutMs?: number;
-};
-
-export type VideoGenerationResult = {
-  videos: GeneratedVideoAsset[];
-  model?: string;
-  metadata?: Record<string, unknown>;
-};
+export type {
+  GeneratedVideoAsset,
+  VideoGenerationResolution,
+  VideoGenerationSourceAsset,
+  VideoGenerationRequest,
+  VideoGenerationResult,
+  VideoGenerationMode,
+  VideoGenerationProviderOptionType,
+  VideoGenerationModeCapabilities,
+  VideoGenerationTransformCapabilities,
+  VideoGenerationProviderCapabilities,
+  VideoGenerationCatalogModelEntry,
+  VideoGenerationProvider,
+} from "../plugin-sdk/video-generation.js";
 
 export type VideoGenerationIgnoredOverride = {
   key: "size" | "aspectRatio" | "resolution" | "audio" | "watermark";
   value: string | boolean;
-};
-
-export type VideoGenerationMode = "generate" | "imageToVideo" | "videoToVideo";
-
-/**
- * Primitive type tag for a declared `providerOptions` key. Core validates
- * the agent-supplied value against this tag before forwarding it to the
- * provider. Kept deliberately narrow — plugins that need richer shapes
- * should keep those fields out of the typed contract and reinterpret the
- * forwarded opaque value inside their own provider code.
- */
-export type VideoGenerationProviderOptionType = "number" | "boolean" | "string";
-
-/* jscpd:ignore-start -- Core mirrors public SDK capability shape; assignability checks guard drift. */
-export type VideoGenerationModeCapabilities = {
-  maxVideos?: number;
-  maxInputImages?: number;
-  maxInputImagesByModel?: Readonly<Record<string, number>>;
-  maxInputVideos?: number;
-  maxInputVideosByModel?: Readonly<Record<string, number>>;
-  /** Max number of reference audio assets the provider accepts (e.g. background music, voice reference). */
-  maxInputAudios?: number;
-  maxInputAudiosByModel?: Readonly<Record<string, number>>;
-  maxDurationSeconds?: number;
-  supportedDurationSeconds?: readonly number[];
-  supportedDurationSecondsByModel?: Readonly<Record<string, readonly number[]>>;
-  sizes?: readonly string[];
-  aspectRatios?: readonly string[];
-  resolutions?: readonly VideoGenerationResolution[];
-  supportsSize?: boolean;
-  supportsAspectRatio?: boolean;
-  supportsResolution?: boolean;
-  /** Provider can generate audio in the output video. */
-  supportsAudio?: boolean;
-  supportsWatermark?: boolean;
-  /**
-   * Declared typed schema for the opaque `VideoGenerationRequest.providerOptions`
-   * bag. Keys listed here are accepted; any other keys the agent passes are
-   * rejected at the runtime fallback boundary so mis-typed or provider-specific
-   * options never silently reach the wrong provider. Plugins that currently
-   * accept no providerOptions should leave this undefined or set to `{}`.
-   */
-  providerOptions?: Readonly<Record<string, VideoGenerationProviderOptionType>>;
-};
-/* jscpd:ignore-end */
-
-export type VideoGenerationTransformCapabilities = VideoGenerationModeCapabilities & {
-  enabled: boolean;
-};
-
-export type VideoGenerationProviderCapabilities = VideoGenerationModeCapabilities & {
-  generate?: VideoGenerationModeCapabilities;
-  imageToVideo?: VideoGenerationTransformCapabilities;
-  videoToVideo?: VideoGenerationTransformCapabilities;
-};
-
-/** Static catalog metadata that overrides provider defaults for one video model. */
-export type VideoGenerationCatalogModelEntry = {
-  capabilities?: VideoGenerationProviderCapabilities;
-  modes?: readonly VideoGenerationMode[];
 };
 
 export type VideoGenerationNormalization = {
@@ -166,24 +27,4 @@ export type VideoGenerationNormalization = {
   aspectRatio?: MediaNormalizationEntry<string>;
   resolution?: MediaNormalizationEntry<VideoGenerationResolution>;
   durationSeconds?: MediaNormalizationEntry<number>;
-};
-
-export type VideoGenerationProvider = {
-  id: string;
-  aliases?: string[];
-  label?: string;
-  defaultModel?: string;
-  /** Default provider operation timeout in milliseconds when caller/config omit timeoutMs. */
-  defaultTimeoutMs?: number;
-  models?: string[];
-  capabilities: VideoGenerationProviderCapabilities;
-  catalogByModel?: Readonly<Record<string, VideoGenerationCatalogModelEntry>>;
-  isConfigured?: (ctx: VideoGenerationProviderConfiguredContext) => boolean;
-  resolveModelCapabilities?: (
-    ctx: VideoGenerationModelCapabilitiesContext,
-  ) =>
-    | VideoGenerationProviderCapabilities
-    | undefined
-    | Promise<VideoGenerationProviderCapabilities | undefined>;
-  generateVideo: (req: VideoGenerationRequest) => Promise<VideoGenerationResult>;
 };


### PR DESCRIPTION
## What Problem This Solves

Video-generation contracts were duplicated between core and the plugin SDK, with a private assignability tuple and unused runtime binding keeping the copies in sync. This cleanup removes 223 net production lines while retaining the existing SDK contract.

## Why This Change Was Made

The existing `src/video-generation/types.ts` contract module is the canonical owner. The SDK reexports its 15 shared types, matching image/music ownership. The declaration bodies and JSDoc are preserved exactly; both internal normalization types, the SDK builder-options type, and all runtime helper bodies are unchanged. No new module or SDK export is introduced.

The first published version incorrectly made the SDK runtime facade canonical. Ordinary CI caught a static type-import cycle despite zero runtime value cycles. That failure was reproduced locally and retained as evidence; this revision removes the reverse dependency instead of weakening the architecture guard. It addresses the ClawSweeper finding and rank-up move using the existing contract-only owner, so an additional neutral module is unnecessary.

The original local SDK copies came from a package-boundary repair. This revision therefore checks the generated declaration graph and real plugin package projects, not just source-level assignability. The ClawSweeper vector/embedding storage heuristic does not apply: this change has no persistent-store, schema, migration, or runtime-state surface.

## User Impact

No intended behavior or API change. Provider contracts, export names and type/value namespaces, request fields, runtime helpers, private workspace declaration bridge, and package exclusions remain unchanged. Tests are retained. There is no external provider API change or live video-generation claim.

Production: +68/-291, net **−223**. Tests: 0. One required, canonically pruned assertion-baseline line is bookkeeping and excluded from the production count.

## Evidence

Revised implementation proof, fresh independent published-head review and exact-head CI are complete as described below. Native preparation and merge remain separate steps; this is not a merge assertion.

- Local canonical static and runtime import-cycle guards both pass with zero cycles. Pinned Linux repeats both checks successfully.
- Targeted typed lint and 134 focused tests across seven files pass locally. The same 134 tests pass on Linux with Node 24.19.0, pinned Vitest 4.1.11, TypeScript 6.0.3 and tsdown 0.22.14.
- Source AST/erasure checks prove all 15 declaration/JSDoc blocks, two internal types and the SDK builder contract/body are preserved; runtime output changes only by deletion of the unused compatibility binding.
- Fresh clean-machine proof: [Blacksmith Testbox run 33036055043](https://github.com/openclaw/openclaw/actions/runs/33036055043), exact frozen base plus three-file patch, dependency/source equality and candidate-root aliases verified. The owned environment was cleaned and stopped after collecting the proof.
- Full canonical changed gate passes all 33 selected checks, including types, lint, three Knip scans, SDK surface, ratchets and boundary guards. Fresh complete precommit Codex review reports no findings. Independent inspection of the actual generated source/declaration/package artifacts also passed.
- Fresh canonical before/after builds pass. Built video SDK JavaScript is byte-identical. The same two pre-existing UI dynamic-import warnings occur on both sides, with unchanged UI sources.
- Generated declarations pass strict compiler checks for all 31 exports, matching names, aliases, type/value namespaces, bidirectional assignability and no top-level any. The declaration files are not byte-identical: 15 existing type-only aliases gain explicit type qualifiers and move into the core-owned generated chunk. Both complete 27-file declaration closures resolve inside the package; actual package inventories preserve the private video declaration exclusion, workspace bridge and runtime export. Built SDK cold import and provider construction pass with source fallback disabled.
- Four real plugin package projects pass: xai, alibaba, qwen and google. DeepInfra and OpenRouter hit the same existing generated private PinnedDispatcherPool identity error on both the untouched baseline and candidate; both implicated declaration chunks are byte-identical before/after. This is a named declaration-builder follow-up, not a six-project pass. No checker suppression or consumer workaround was added.
- Fresh independent full published-head Codex review passed without findings. [Exact-head CI run 33039188417](https://github.com/openclaw/openclaw/actions/runs/33039188417) completed successfully on attempt 2. Attempt 1's compact job stopped before tests because Control UI startup gzip was 343,457 B against a 343,442 B budget; another job built the same merge at 343,416 B and passed. One standard failed-jobs retry passed with no source change, budget increase or suppression. The 41 B variability is observed; build-metadata attribution is an inference. UI-budget fragility is a separate follow-up.
- Historical failures retained: the first published version's architecture-cycle failure; an initially over-strict declaration export-line byte assertion, corrected to exact parsed export/type semantics; and the reproduced baseline consumer declaration failures. Prior reviews/builds of the SDK-owner direction do not cover this revision.

AI-assisted implementation and review using Codex.
