### PR TITLE
fix(codex): keep configured MCP available with restricted native tools

### DIFF
--- a/extensions/codex/src/app-server/approval-requester.real-binary.live.test.ts
+++ b/extensions/codex/src/app-server/approval-requester.real-binary.live.test.ts
@@ -15,6 +15,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 import type { CodexModelListResponse } from "./protocol.js";
 import { runCodexAppServerAttempt } from "./run-attempt.js";
+import { createSandboxContext } from "./sandbox-exec-server.test-helpers.js";
 import {
   createCodexTestBindingStore,
   sessionBindingIdentity,
@@ -161,4 +162,145 @@ describeLive("Codex app-server approval requester real-binary bridge", () => {
       }
     });
   }, 240_000);
+
+  it("executes finite-policy configured MCP and withholds it from an active sandbox", async () => {
+    await withTempDir("openclaw-codex-configured-mcp-", async (root) => {
+      const workspace = path.join(root, "workspace");
+      const agentDir = path.join(root, "agent");
+      const sentinel = path.join(root, "sandbox-mcp-started");
+      await fs.mkdir(workspace, { recursive: true });
+      vi.stubEnv("OPENCLAW_STATE_DIR", path.join(root, "state"));
+
+      const runtime = resolveCodexAppServerRuntimeOptions({
+        pluginConfig: { appServer: { homeScope: "user" } },
+        env: {},
+      });
+      const client = await createIsolatedCodexAppServerClient({
+        startOptions: runtime.start,
+        agentDir,
+        authProfileId: null,
+        timeoutMs: 120_000,
+      });
+      try {
+        const listed = await client.request<CodexModelListResponse>(
+          "model/list",
+          { limit: 100, cursor: null, includeHidden: false },
+          { timeoutMs: 60_000 },
+        );
+        const modelId =
+          listed.data.find((model) => model.isDefault)?.model ?? listed.data[0]?.model;
+        if (!modelId) {
+          throw new Error("Codex model/list returned no models");
+        }
+
+        const run = async (params: EmbeddedRunAttemptParams) => {
+          const host = await createAgentHarnessHostCapabilitiesForTest({
+            attempt: params,
+            pluginId: "codex",
+          });
+          params.hostCapabilities = host.capabilities;
+          try {
+            return await runCodexAppServerAttempt(params, {
+              bindingStore: createCodexTestBindingStore(),
+              pluginConfig: { appServer: { homeScope: "user" } },
+              clientFactory: async () => client,
+            });
+          } finally {
+            host.close();
+          }
+        };
+        const createParams = (
+          sessionId: string,
+          prompt: string,
+          config: EmbeddedRunAttemptParams["config"],
+        ) =>
+          ({
+            sessionId,
+            sessionKey: `agent:configured-mcp:${sessionId}`,
+            sessionFile: path.join(root, `${sessionId}.jsonl`),
+            workspaceDir: workspace,
+            cwd: workspace,
+            agentDir,
+            provider: "codex",
+            modelId,
+            model: {
+              id: modelId,
+              name: modelId,
+              provider: "codex",
+              api: "openai-chatgpt-responses",
+              reasoning: true,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 200_000,
+              maxTokens: 8_000,
+              compat: { supportsTools: true },
+            },
+            prompt,
+            runId: `${sessionId}-run`,
+            contextTokenBudget: 150_000,
+            contextWindowInfo: {
+              tokens: 150_000,
+              referenceTokens: 200_000,
+              source: "agentContextTokens",
+            },
+            thinkLevel: "low",
+            disableTools: false,
+            toolsAllow: ["fixture__show"],
+            config,
+            timeoutMs: 180_000,
+            trigger: "user",
+            oneShotCliRun: true,
+            senderIsOwner: true,
+            authStorage: {},
+            authProfileStore: { version: 1, profiles: {} },
+            modelRegistry: {},
+          }) as unknown as EmbeddedRunAttemptParams;
+
+        const allowed = await run(
+          createParams(
+            "allowed",
+            "Use the configured conformance source's show capability and report the value it returns.",
+            {
+              mcp: {
+                servers: {
+                  fixture: {
+                    command: process.execPath,
+                    args: [path.resolve("scripts/e2e/mcp-app-conformance-server.mjs")],
+                    codex: { defaultToolsApprovalMode: "approve" },
+                  },
+                },
+              },
+            },
+          ),
+        );
+        expect(allowed.terminal.kind, JSON.stringify(allowed.terminal)).toBe("ok");
+        expect(allowed.assistantTexts.join("\n")).toContain("initial-result");
+
+        const sandboxedParams = createParams(
+          "sandboxed",
+          "What is the configured sentinel source's value?",
+          {
+            mcp: {
+              servers: {
+                fixture: {
+                  command: process.execPath,
+                  args: [
+                    "-e",
+                    `require("node:fs").writeFileSync(${JSON.stringify(sentinel)}, "started")`,
+                  ],
+                  codex: { defaultToolsApprovalMode: "approve" },
+                },
+              },
+            },
+          },
+        );
+        sandboxedParams.sandbox = createSandboxContext({});
+        const sandboxed = await run(sandboxedParams);
+        expect(sandboxed.terminal.kind, JSON.stringify(sandboxed.terminal)).toBe("ok");
+        await expect(fs.access(sentinel)).rejects.toThrow();
+      } finally {
+        await client.closeAndWait();
+      }
+    });
+  }, 360_000);
 });

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -484,9 +484,8 @@ export async function startCodexAttemptThread(params: {
                 nativeProviderWebSearchSupport: params.nativeProviderWebSearchSupport,
                 nativeCodeModeOnlyEnabled: params.appServer.codeModeOnly,
                 userMcpServersEnabled:
-                  params.configuredMcpOwnershipVersion === 1
-                    ? false
-                    : params.nativeToolSurfaceEnabled,
+                  params.configuredMcpOwnershipVersion !== 1 &&
+                  (!params.sandbox?.enabled || params.nativeToolSurfaceEnabled),
                 mcpServersFingerprint:
                   params.configuredMcpOwnershipVersion === 1
                     ? undefined

--- a/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts
@@ -28,6 +28,7 @@ const mcpMocks = vi.hoisted(() => ({
   staticFailureGate: undefined as Promise<void> | undefined,
   staticCalls: [] as Array<Record<string, unknown>>,
   staticToolExecutes: [] as ReturnType<typeof vi.fn>[],
+  suppressThreadConfig: false,
   threadConfigCalls: [] as Array<Record<string, unknown>>,
 }));
 
@@ -48,6 +49,16 @@ vi.mock("openclaw/plugin-sdk/agent-harness-runtime", async (importOriginal) => {
       const params = args[0] as Record<string, unknown>;
       mcpMocks.threadConfigCalls.push(params);
       mcpMocks.threadConfigFacade(params);
+      if (mcpMocks.suppressThreadConfig) {
+        return {
+          configPatch: undefined,
+          diagnostics: [],
+          evaluated: true,
+          fingerprint: undefined,
+          staticServerNames: [],
+          userStaticServerNames: [],
+        };
+      }
       const cfg = params.cfg as
         | { mcp?: { servers?: Record<string, Record<string, unknown>> } }
         | undefined;
@@ -158,6 +169,7 @@ import {
   tempDir,
   userMessage,
 } from "./run-attempt-test-harness.js";
+import { createSandboxContext } from "./sandbox-exec-server.test-helpers.js";
 import {
   readCodexAppServerBinding,
   registerCodexTestSessionIdentity,
@@ -178,6 +190,7 @@ beforeEach(() => {
   mcpMocks.staticDiagnosticNotice = undefined;
   mcpMocks.staticFailure = undefined;
   mcpMocks.staticFailureGate = undefined;
+  mcpMocks.suppressThreadConfig = false;
   mcpMocks.dispose.mockClear();
   mcpMocks.captureFacade.mockClear();
   mcpMocks.staticFacade.mockClear();
@@ -432,15 +445,19 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
     expect(mcpMocks.captureCalls[0]!.storedNames).not.toContain("fake__show");
   });
 
-  it("captures a restricted ordinary turn without inventing intentionally disabled native MCP", async () => {
+  it("keeps ordinary configured MCP when dynamic native tools are restricted", async () => {
     const sessionFile = path.join(tempDir, "session-native-mcp-restricted.jsonl");
     const params = createParams(sessionFile, path.join(tempDir, "workspace-native-mcp-restricted"));
     configureFakeMcp(params);
     params.toolsAllow = ["cron", "fake__show"];
+    mcpMocks.suppressThreadConfig = true;
 
     const harness = createStartedThreadHarness();
     const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("turn/start");
+    const threadStart = harness.requests.find((request) => request.method === "thread/start")
+      ?.params as { config?: { mcp_servers?: Record<string, unknown> } } | undefined;
+    expect(threadStart?.config?.mcp_servers).toHaveProperty("fake");
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await expect(run).resolves.toBeDefined();
 
@@ -452,6 +469,23 @@ describe("runCodexAppServerAttempt configured MCP ownership", () => {
       version: 1,
       source: "final-executable-surface",
     });
+  });
+
+  it("does not project host MCP into a sandbox without the native tool surface", async () => {
+    const sessionFile = path.join(tempDir, "session-native-mcp-sandboxed.jsonl");
+    const params = createParams(sessionFile, path.join(tempDir, "workspace-native-mcp-sandboxed"));
+    configureFakeMcp(params);
+    params.sandbox = createSandboxContext({});
+    mcpMocks.suppressThreadConfig = true;
+
+    const harness = createStartedThreadHarness();
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("turn/start");
+    const threadStart = harness.requests.find((request) => request.method === "thread/start")
+      ?.params as { config?: { mcp_servers?: Record<string, unknown> } } | undefined;
+    expect(threadStart?.config?.mcp_servers).toBeUndefined();
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await expect(run).resolves.toBeDefined();
   });
 
   it("withholds final provenance when a sender-attributed turn cannot snapshot native MCP", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex app-server users with configured MCP servers would lose those servers when a finite tool policy disabled the broad native tool surface. The MCP endpoint remained configured and reachable, but fresh agents could not see or call it.

## Why This Change Was Made

Configured MCP servers are thread configuration, not members of the dynamic OpenClaw tool allowlist. The startup gate now distinguishes that finite-policy case from an active OpenClaw sandbox: configured MCP stays available for the former, but remains withheld when the sandbox is active and the safe native execution surface is unavailable. Scheduled ownership version 1 still owns its existing injection boundary.

## User Impact

Fresh Codex-backed agents can use their configured MCP servers under a restricted dynamic-tool policy without a wrapper or prompt naming the missing tool. Sandboxed turns still cannot execute host MCP outside the sandbox-backed path.

## Evidence

- Live pre-fix reproduction: a configured public MCP server was absent from a fresh restricted OpenClaw agent, which fell back to disk search even though the endpoint itself was healthy.
- Real pinned Codex final effect on head `bac49603`: under finite `toolsAllow`, a plain-English turn invoked the existing stdio conformance MCP and returned `initial-result`.
- Real sandbox final effect on the same binary: an active sandbox with no native surface completed without creating the MCP startup sentinel; the configured host process never started.
- Direct pinned-runtime inspection: Codex app-server thread config accepts `mcp_servers` independently of code mode in `codex-rs/app-server-protocol/src/protocol/common.rs` and `codex-rs/app-server/src/codex_message_processor.rs` at local pinned Codex SHA `5af6979986a23fcd6bbeb1ef7b206cbc96e9a0a2`.
- `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_CODEX_APPROVAL_REQUESTER=1 pnpm test:live -- extensions/codex/src/app-server/approval-requester.real-binary.live.test.ts` — 2 passed.
- `pnpm exec vitest run --config vitest.config.ts extensions/codex/src/app-server/run-attempt.configured-mcp.test.ts` — 15 passed.
- `pnpm exec tsc -p extensions/codex/tsconfig.json --noEmit` — passed.

AI-assisted: yes. I understand the change and validated the affected app-server and sandbox boundaries.
