### PR TITLE
fix(tests): Parallels snapshot checks unexpectedly contact npm

### DIFF
--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -1056,14 +1056,6 @@ kill -TERM "$$"`,
       const tempDir = makeTempDir(tempDirs, "openclaw-parallels-macos-restore-");
       const callsPath = join(tempDir, "prlctl-calls.jsonl");
       const statePath = join(tempDir, "vm-state");
-      const npmBootstrapPath = join(tempDir, "npm-bootstrap.mjs");
-      writeFileSync(
-        npmBootstrapPath,
-        `if (process.argv[1]?.endsWith("npm-cli.js") && process.argv.includes("view")) {
-  process.stdout.write("2026.1.1\\n");
-  process.exit(0);
-}`,
-      );
       writeNodeFakePrlctl(
         tempDir,
         `const fs = process.getBuiltinModule("node:fs");
@@ -1092,7 +1084,6 @@ if (commandArgs[0] === "list") {
 }`,
       );
 
-      const fakeEnv = fakePrlctlEnv(tempDir);
       const result = spawnSync(
         process.execPath,
         [
@@ -1103,8 +1094,6 @@ if (commandArgs[0] === "list") {
           "upgrade",
           "--latest-version",
           "2026.1.1",
-          "--target-package-spec",
-          "openclaw@2026.1.1",
           "--api-key-env",
           "OPENCLAW_PARALLELS_TEST_KEY",
           "--json",
@@ -1114,9 +1103,7 @@ if (commandArgs[0] === "list") {
           encoding: "utf8",
           env: {
             ...process.env,
-            ...fakeEnv,
-            "BASH_FUNC_ifconfig%%": "() { return 1; }",
-            NODE_OPTIONS: `${fakeEnv.NODE_OPTIONS} --import=${pathToFileURL(npmBootstrapPath).href}`,
+            ...fakePrlctlEnv(tempDir),
             OPENCLAW_PARALLELS_ARTIFACT_ROOT: tempDir,
             OPENCLAW_PARALLELS_TEST_KEY: "fixture",
           },
@@ -1125,6 +1112,7 @@ if (commandArgs[0] === "list") {
       );
 
       expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain("macOS guest command failed with exit code 41");
       const calls = readFileSync(callsPath, "utf8")
         .trim()
         .split("\n")


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Parallels macOS snapshot restoration checks fail before reaching the VM when npm is installed through Homebrew. Both powered-on and powered-off snapshot cases attempted a real lookup of the fixture package `openclaw@2026.1.1`, which returns E404.

Related: #129788 (snapshot session preservation) and #129861 (network-free macOS upgrade preparation).

## Why This Change Was Made

The fixture selected a registry target and intercepted npm only when its entrypoint ended in `npm-cli.js`. The supported bare-npm runner can instead launch a Homebrew entrypoint named `npm`, so that interception was incomplete. The default upgrade path already needs no host package lookup; use that canonical path and delete the obsolete npm preload/package override. An explicit assertion now confirms that the test reaches the intended guest-command failure after restoration.

## User Impact

No product runtime changes. Developers can run the snapshot checks without an external npm dependency, while retaining coverage that powered-on snapshots resume their saved session and powered-off snapshots start normally.

## Evidence

On main commit `4b287caac326dd3a8b081754b61421cdb7120b98`, both snapshot cases reproduced npm E404 before restoration. After this change, both pass and the original five-suite execution order passes all 155 tests:

```sh
node scripts/run-vitest.mjs test/scripts/parallels-phase-runner.test.ts test/scripts/parallels-smoke-model.test.ts test/scripts/parallels-update-job-timeout.test.ts test/scripts/parallels-npm-update-smoke.test.ts test/scripts/parallels-windows-git.test.ts
node scripts/check-changed.mjs -- test/scripts/parallels-smoke-model.test.ts
git diff --check
```

The changed gate passed test-root typechecking and script linting. Independent Codex autoreview reported no actionable findings. A live npm invocation probe confirmed the Homebrew entrypoint naming that caused the original fixture to miss interception. Separate real Parallels product smoke runs are in progress and are not claimed as completed evidence for this test-only change.

Production LOC: +0/-0. Tests: +2/-14 (net -12). No configuration, dependency, persistence, or protocol changes. AI-assisted.
