### PR TITLE
fix(models): app-server harnesses with no provider binding get no runtime chooser at all

### DIFF
--- a/scripts/proof-app-server-runtime-chooser-bindings.ts
+++ b/scripts/proof-app-server-runtime-chooser-bindings.ts
@@ -1,0 +1,172 @@
+/**
+ * Real-behavior proof for the app-server runtime-chooser bindings fix.
+ *
+ * What is REAL here (no vitest, no mocks of the seam under test):
+ *   - `buildModelsProviderData()` from src/auto-reply/reply/commands-models.ts —
+ *     the exact production function that builds `/models` provider data.
+ *   - The real plugin registry (`setActivePluginRegistry` with a real empty
+ *     registry), so no CLI runtime backends are registered. Every runtime choice
+ *     observed below therefore comes from the app-server binding list under test,
+ *     not from a CLI backend that happened to be registered.
+ *   - `listAppServerRuntimeModelBackendBindings()` and the real bundled plugin
+ *     manifests read off disk via `listBundledPluginMetadata()`.
+ *   - The downstream selection lookup is reproduced exactly as the Discord model
+ *     picker does it (extensions/discord/src/monitor/
+ *     native-command-model-picker-interaction.ts): index into
+ *     `runtimeChoicesByProvider.get(provider)` and read `.id`.
+ *
+ * What is stubbed: nothing between the entrypoint and the assertions. Providers
+ * are declared inline in the config (a first-class production path) so the proof
+ * needs no network and no ambient credentials.
+ *
+ * Scenarios:
+ *   1. github-copilot — the bug. Before the fix the provider had NO chooser
+ *      entry at all; after it, the Copilot runtime is offered and selectable.
+ *   2. openai — regression guard. The pre-existing Codex chooser still works.
+ *   3. A provider served by no app-server harness — stays absent from the
+ *      chooser map, proving the fix did not blanket-add choosers everywhere.
+ *   4. Binding coverage — every agent harness declared by a real bundled
+ *      manifest on disk has a binding row.
+ *
+ * Run: pnpm tsx scripts/proof-app-server-runtime-chooser-bindings.ts
+ */
+import assert from "node:assert/strict";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type CommandsModelsModule = typeof import("../src/auto-reply/reply/commands-models.js");
+type BindingsModule = typeof import("../src/agents/app-server-runtime-bindings.js");
+type BundledMetadataModule = typeof import("../src/plugins/bundled-plugin-metadata.js");
+type PluginRuntimeModule = typeof import("../src/plugins/runtime.js");
+type RegistryEmptyModule = typeof import("../src/plugins/registry-empty.js");
+type OpenClawConfig = import("../src/config/types.openclaw.js").OpenClawConfig;
+
+const repoRoot = process.env.PROOF_REPO_ROOT ?? process.cwd();
+const importSource = async (relativePath: string) =>
+  import(pathToFileURL(path.join(repoRoot, relativePath)).href);
+
+const { buildModelsProviderData } = (await importSource(
+  "src/auto-reply/reply/commands-models.ts",
+)) as CommandsModelsModule;
+const { listAppServerRuntimeModelBackendBindings } = (await importSource(
+  "src/agents/app-server-runtime-bindings.ts",
+)) as BindingsModule;
+const { listBundledPluginMetadata } = (await importSource(
+  "src/plugins/bundled-plugin-metadata.ts",
+)) as BundledMetadataModule;
+const { setActivePluginRegistry } = (await importSource(
+  "src/plugins/runtime.ts",
+)) as PluginRuntimeModule;
+const { createEmptyPluginRegistry } = (await importSource(
+  "src/plugins/registry-empty.ts",
+)) as RegistryEmptyModule;
+
+// A real, empty registry: no CLI backends registered, so nothing below can be
+// attributed to listCliRuntimeModelBackendBindings().
+setActivePluginRegistry(createEmptyPluginRegistry());
+
+/** Mirrors the Discord picker's runtime selection: 1-based index -> runtime id. */
+function selectRuntimeChoiceId(params: {
+  data: Awaited<ReturnType<typeof buildModelsProviderData>>;
+  provider: string;
+  runtimeIndex: number;
+}): string | undefined {
+  const choices = params.data.runtimeChoicesByProvider?.get(params.provider);
+  return choices?.[params.runtimeIndex - 1]?.id;
+}
+
+const config = {
+  models: {
+    providers: {
+      "github-copilot": {
+        baseUrl: "https://api.individual.githubcopilot.com",
+        apiKey: "proof-github-copilot-key",
+        models: [{ id: "claude-opus-4-6", name: "Claude Opus 4.6" }],
+      },
+      openai: {
+        baseUrl: "https://api.openai.com/v1",
+        apiKey: "proof-openai-key",
+        models: [{ id: "gpt-5.5", name: "GPT-5.5" }],
+      },
+      "proof-standalone": {
+        baseUrl: "https://proof-standalone.example.test/v1",
+        apiKey: "proof-standalone-key",
+        models: [{ id: "proof-model", name: "Proof Model" }],
+      },
+    },
+  },
+  agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+} as unknown as OpenClawConfig;
+
+const data = await buildModelsProviderData(config);
+
+function runtimeIdsFor(provider: string): string[] {
+  return (data.runtimeChoicesByProvider?.get(provider) ?? []).map((choice) => choice.id);
+}
+
+// --- Scenario 1: github-copilot gets a Copilot runtime choice (the bug). -----
+const copilotChoices = data.runtimeChoicesByProvider?.get("github-copilot");
+assert.ok(
+  copilotChoices,
+  "github-copilot has NO runtime chooser entry at all — this is the reported bug",
+);
+assert.ok(
+  runtimeIdsFor("github-copilot").includes("copilot"),
+  `github-copilot chooser is missing the copilot runtime; got ${JSON.stringify(runtimeIdsFor("github-copilot"))}`,
+);
+const copilotIndex = runtimeIdsFor("github-copilot").indexOf("copilot") + 1;
+assert.equal(
+  selectRuntimeChoiceId({ data, provider: "github-copilot", runtimeIndex: copilotIndex }),
+  "copilot",
+  "selecting the Copilot entry through the picker lookup did not resolve to the copilot runtime",
+);
+const copilotChoice = copilotChoices.find((choice) => choice.id === "copilot");
+assert.equal(
+  copilotChoice?.label,
+  "GitHub Copilot",
+  `Copilot chooser entry renders a raw id instead of a label: ${JSON.stringify(copilotChoice)}`,
+);
+console.log(
+  `[1] github-copilot runtime choices: ${JSON.stringify(runtimeIdsFor("github-copilot"))}`,
+);
+
+// --- Scenario 2: openai still offers Codex (no regression). -----------------
+assert.ok(
+  runtimeIdsFor("openai").includes("codex"),
+  `openai lost its Codex runtime choice; got ${JSON.stringify(runtimeIdsFor("openai"))}`,
+);
+console.log(`[2] openai runtime choices: ${JSON.stringify(runtimeIdsFor("openai"))}`);
+
+// --- Scenario 3: a provider with no app-server harness stays absent. --------
+assert.equal(
+  data.runtimeChoicesByProvider?.get("proof-standalone"),
+  undefined,
+  "a provider served by no app-server harness must not gain a runtime chooser",
+);
+console.log("[3] proof-standalone runtime choices: absent (as expected)");
+
+// --- Scenario 4: every bundled app-server harness has a binding. ------------
+const boundRuntimes = new Set(
+  listAppServerRuntimeModelBackendBindings().map((binding) => binding.runtime),
+);
+const bundledHarnessIds = new Set<string>();
+for (const entry of listBundledPluginMetadata({ includeChannelConfigs: false })) {
+  const cliBackends = new Set(entry.manifest.cliBackends ?? []);
+  for (const harnessId of entry.manifest.activation?.onAgentHarnesses ?? []) {
+    if (!cliBackends.has(harnessId)) {
+      bundledHarnessIds.add(harnessId);
+    }
+  }
+}
+assert.ok(bundledHarnessIds.size > 0, "read zero bundled agent harnesses — the scan is broken");
+const unbound = [...bundledHarnessIds].filter((harnessId) => !boundRuntimes.has(harnessId));
+assert.deepEqual(
+  unbound,
+  [],
+  `bundled agent harness(es) ${unbound.join(", ")} ship with no model-provider binding`,
+);
+console.log(
+  `[4] bundled app-server harnesses ${JSON.stringify([...bundledHarnessIds].toSorted())} all bound`,
+);
+
+console.log("All runtime assertions passed.");

--- a/src/agents/app-server-runtime-bindings.test.ts
+++ b/src/agents/app-server-runtime-bindings.test.ts
@@ -1,0 +1,56 @@
+// Guards that every bundled app-server agent harness has a runtime-chooser binding.
+import { describe, expect, it } from "vitest";
+import { listBundledPluginMetadata } from "../plugins/bundled-plugin-metadata.js";
+import { listAppServerRuntimeModelBackendBindings } from "./app-server-runtime-bindings.js";
+
+/**
+ * Harness ids declared by bundled extensions that are NOT CLI backends. CLI
+ * backends declare `modelProvider` on their registration and are covered by
+ * `listCliRuntimeModelBackendBindings()`; everything else is an app-server
+ * harness whose provider pairing only exists in
+ * `listAppServerRuntimeModelBackendBindings()`.
+ */
+function listBundledAppServerHarnessIds(): readonly string[] {
+  const harnessIds = new Set<string>();
+  for (const entry of listBundledPluginMetadata({ includeChannelConfigs: false })) {
+    const cliBackends = new Set(entry.manifest.cliBackends ?? []);
+    for (const harnessId of entry.manifest.activation?.onAgentHarnesses ?? []) {
+      if (!cliBackends.has(harnessId)) {
+        harnessIds.add(harnessId);
+      }
+    }
+  }
+  return [...harnessIds].toSorted((left, right) => left.localeCompare(right));
+}
+
+describe("listAppServerRuntimeModelBackendBindings", () => {
+  it("binds every bundled app-server harness to a model provider", () => {
+    const harnessIds = listBundledAppServerHarnessIds();
+    // A vacuous pass would hide the very regression this test exists to catch.
+    expect(harnessIds.length).toBeGreaterThan(0);
+
+    const boundRuntimes = new Set(
+      listAppServerRuntimeModelBackendBindings().map((binding) => binding.runtime),
+    );
+    const unbound = harnessIds.filter((harnessId) => !boundRuntimes.has(harnessId));
+    expect(
+      unbound,
+      `bundled agent harness(es) ${unbound.join(", ")} have no model-provider binding, so /models offers no runtime chooser for the provider(s) they serve. Add a row to APP_SERVER_RUNTIME_MODEL_BACKEND_BINDINGS in src/agents/app-server-runtime-bindings.ts.`,
+    ).toEqual([]);
+  });
+
+  it("covers the codex and copilot harnesses shipped today", () => {
+    expect(listBundledAppServerHarnessIds()).toEqual(expect.arrayContaining(["codex", "copilot"]));
+    expect(listAppServerRuntimeModelBackendBindings()).toEqual(
+      expect.arrayContaining([
+        { provider: "openai", runtime: "codex" },
+        { provider: "github-copilot", runtime: "copilot" },
+      ]),
+    );
+  });
+
+  it("declares each runtime once so the chooser cannot list duplicates", () => {
+    const runtimes = listAppServerRuntimeModelBackendBindings().map((binding) => binding.runtime);
+    expect(runtimes).toEqual([...new Set(runtimes)]);
+  });
+});

--- a/src/agents/app-server-runtime-bindings.ts
+++ b/src/agents/app-server-runtime-bindings.ts
@@ -1,0 +1,46 @@
+/**
+ * Bindings between a model provider and the app-server agent-harness runtime
+ * that serves it. These are the non-CLI parallel of the CLI runtime bindings in
+ * `cli-backends.ts`, and they drive the runtime chooser `/models` offers for a
+ * provider.
+ *
+ * Why this list is explicit rather than derived:
+ *
+ * - A CLI backend declares `modelProvider` on its own registration, so
+ *   `listCliRuntimeModelBackendBindings()` can read the pairing straight off the
+ *   registry. An `AgentHarness` registration carries no such declaration, so
+ *   there is nothing equivalent to read.
+ * - Harness plugins ship `activation.onStartup: false` with
+ *   `activation.onAgentHarnesses`, which means they are only imported once an
+ *   agent is already configured to use them. Deriving these bindings from the
+ *   live harness registry would therefore hide each runtime from the chooser
+ *   until the user had already selected it — removing the discovery path the
+ *   chooser exists to provide.
+ * - Manifest metadata carries the harness id but not the provider it serves.
+ *   `sessionRouteStateOwners.providerIds` is close but is not the same fact:
+ *   the Codex harness owns `codex`/`codex-cli`/`openai-codex` session route
+ *   state while serving the `openai` model provider.
+ *
+ * `app-server-runtime-bindings.test.ts` fails when a bundled extension declares
+ * an agent harness that has no row here, so a new bridge-backed provider cannot
+ * silently ship without a chooser.
+ */
+
+/** Binding between a model provider and the app-server runtime that serves it. */
+export type AppServerRuntimeModelBackendBinding = {
+  provider: string;
+  runtime: string;
+};
+
+const APP_SERVER_RUNTIME_MODEL_BACKEND_BINDINGS: readonly AppServerRuntimeModelBackendBinding[] = [
+  // Codex app-server harness (extensions/codex) running OpenAI models.
+  { provider: "openai", runtime: "codex" },
+  // GitHub Copilot agent runtime (extensions/copilot). `github-copilot/*` models
+  // opt into it with `agentRuntime.id: "copilot"` — see copilot-routing.ts.
+  { provider: "github-copilot", runtime: "copilot" },
+];
+
+/** Lists model-provider to app-server-runtime bindings for runtime choosers. */
+export function listAppServerRuntimeModelBackendBindings(): readonly AppServerRuntimeModelBackendBinding[] {
+  return APP_SERVER_RUNTIME_MODEL_BACKEND_BINDINGS;
+}

--- a/src/auto-reply/reply/commands-models.app-server-runtime-choices.test.ts
+++ b/src/auto-reply/reply/commands-models.app-server-runtime-choices.test.ts
@@ -1,0 +1,92 @@
+// Covers the runtime chooser /models offers for providers served by an
+// app-server agent harness rather than by a CLI backend.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { buildModelsProviderData } from "./commands-models.js";
+
+const modelCatalogMocks = vi.hoisted(() => ({ loadModelCatalog: vi.fn() }));
+
+vi.mock("../../agents/prepared-model-catalog.js", () => ({
+  loadProviderScopedThinkingCatalog: vi.fn(async () => []),
+  loadPreparedModelCatalog: modelCatalogMocks.loadModelCatalog,
+  loadPreparedModelCatalogSnapshot: async (...args: unknown[]) => {
+    const entries = await modelCatalogMocks.loadModelCatalog(...args);
+    return { entries, routeVariants: entries };
+  },
+}));
+
+vi.mock("../../agents/model-provider-auth.js", () => ({
+  createProviderAuthChecker: () =>
+    Object.assign(
+      vi.fn(() => true),
+      {
+        evaluateModelAuth: vi.fn(async () => ({ availability: true, routeResolution: null })),
+      },
+    ),
+  hasAuthForModelProvider: () => true,
+  getCurrentProviderAuthState: () => null,
+  clearCurrentProviderAuthState: () => undefined,
+}));
+
+const CONFIG = {
+  agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+} as OpenClawConfig;
+
+beforeEach(() => {
+  // No CLI backends registered anywhere, so every runtime choice observed here
+  // comes from the app-server bindings rather than a CLI runtime binding.
+  cliBackendsTesting.setDepsForTest({
+    resolvePluginSetupRegistry: () => ({
+      providers: [],
+      cliBackends: [],
+      configMigrations: [],
+      autoEnableProbes: [],
+      diagnostics: [],
+    }),
+    resolveRuntimeCliBackends: () => [],
+  });
+  setActivePluginRegistry(createEmptyPluginRegistry());
+  modelCatalogMocks.loadModelCatalog.mockReset();
+  modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+    { provider: "openai", id: "gpt-5.5", name: "GPT-5.5" },
+    { provider: "github-copilot", id: "claude-opus-4-6", name: "Claude Opus 4.6" },
+    { provider: "unbound-provider", id: "unbound-model", name: "Unbound Model" },
+  ]);
+});
+
+describe("buildModelsProviderData app-server runtime choices", () => {
+  it("offers the Copilot runtime for github-copilot models", async () => {
+    const data = await buildModelsProviderData(CONFIG);
+
+    expect(data.runtimeChoicesByProvider?.get("github-copilot")).toEqual([
+      {
+        id: "openclaw",
+        label: "OpenClaw Default",
+        description: "Use the built-in OpenClaw runtime.",
+      },
+      {
+        id: "copilot",
+        label: "GitHub Copilot",
+        description: "Use the GitHub Copilot runtime selected by the effective harness policy.",
+      },
+    ]);
+  });
+
+  it("keeps offering the Codex runtime for openai models", async () => {
+    const data = await buildModelsProviderData(CONFIG);
+
+    expect(data.runtimeChoicesByProvider?.get("openai")?.map((choice) => choice.id)).toEqual([
+      "codex",
+      "openclaw",
+    ]);
+  });
+
+  it("leaves providers with no app-server harness out of the chooser", async () => {
+    const data = await buildModelsProviderData(CONFIG);
+
+    expect(data.runtimeChoicesByProvider?.get("unbound-provider")).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -9,6 +9,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
+import { listAppServerRuntimeModelBackendBindings } from "../../agents/app-server-runtime-bindings.js";
 import { listCliRuntimeModelBackendBindings } from "../../agents/cli-backends.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import { resolveModelAuthLabel } from "../../agents/model-auth-label.js";
@@ -364,7 +365,11 @@ export async function buildModelsProviderData(
 
   const runtimeChoicesByProvider = new Map<string, ModelsRuntimeChoice[]>();
   const runtimeBindings = [
-    { provider: "openai", runtime: "codex", cli: false },
+    ...listAppServerRuntimeModelBackendBindings().map((binding) => ({
+      provider: binding.provider,
+      runtime: binding.runtime,
+      cli: false,
+    })),
     ...listCliRuntimeModelBackendBindings().map((binding) => ({
       provider: binding.provider,
       runtime: binding.runtime,

--- a/src/status/agent-runtime-label.ts
+++ b/src/status/agent-runtime-label.ts
@@ -15,6 +15,7 @@ const AGENT_RUNTIME_LABELS: Readonly<Record<string, string>> = {
   openclaw: "OpenClaw Default",
   codex: "OpenAI Codex",
   "codex-cli": "OpenAI Codex",
+  copilot: "GitHub Copilot",
   "claude-cli": "Claude CLI",
   "google-gemini-cli": "Gemini CLI",
 };


### PR DESCRIPTION
## What Problem This Solves

`/models` builds its per-provider **runtime chooser** from a hardcoded array inside `buildModelsProviderData` (`src/auto-reply/reply/commands-models.ts`). Its only non-CLI entry was:

```ts
const runtimeBindings = [
  { provider: "openai", runtime: "codex", cli: false },
  ...listCliRuntimeModelBackendBindings().map(/* CLI runtimes only */),
];
```

`runtimeChoicesByProvider` is keyed off that array, so a provider missing from it does not get a *shorter* chooser — it gets **no entry at all** (`undefined`), and every channel picker that reads `runtimeChoicesByProvider.get(provider)` silently renders nothing.

`extensions/copilot` is exactly such a provider today. It is an app-server agent harness — `activation.onAgentHarnesses: ["copilot"]`, no CLI backend — and it serves the `github-copilot` model provider. That pairing is first-class in core: `src/agents/copilot-routing.ts` documents it and supports opting in with `agentRuntime.id: "copilot"` at provider, model, or agent scope. But because there is no binding row, `/models` never offers the Copilot runtime for `github-copilot/*` models, so a supported configuration is unreachable from the picker.

The shape of the defect matters more than the single missing row: **any app-server harness extension that ships without someone remembering to edit this array gets no chooser, silently, until a user reports it.** That is how this surfaced.

### Why the list stays explicit instead of becoming registry-derived

I tried to derive the bindings and concluded it is not the right change here:

- A CLI backend declares `modelProvider` on its own registration, which is precisely what lets `listCliRuntimeModelBackendBindings()` read the pairing off the registry. An `AgentHarness` registration carries **no** provider declaration, so there is no equivalent fact to read.
- Harness plugins ship `activation.onStartup: false` with `activation.onAgentHarnesses`, so they are only imported once an agent is *already* configured to use them. Deriving from the live harness registry would therefore hide each runtime from the chooser until the user had already selected it — removing the discovery path the chooser exists to provide. That is a user-visible regression for Codex today.
- Static manifest metadata carries the harness id but not the provider it serves. `sessionRouteStateOwners.providerIds` looks like a candidate but is a different fact: the Codex harness owns `codex`/`codex-cli`/`openai-codex` **session route state** while serving the `openai` **model provider**, so it cannot reproduce the existing `openai/codex` row.

Declaring the provider on the harness registration contract would be the clean long-term fix, but that is a plugin-SDK surface change and belongs in its own PR.

So this PR keeps the bindings explicit, moves them somewhere they are documented and testable, and adds the guard that makes the omission loud instead of silent.

## Change

- **New** `src/agents/app-server-runtime-bindings.ts` — `listAppServerRuntimeModelBackendBindings()`, the non-CLI parallel of the CLI runtime bindings, with the reasoning above recorded at the definition site. Carries the pre-existing `openai`/`codex` row and the missing `github-copilot`/`copilot` row.
- `commands-models.ts` now spreads that list instead of inlining a literal.
- **New guard test** `src/agents/app-server-runtime-bindings.test.ts` reads the **real bundled manifests off disk** (`listBundledPluginMetadata()`), collects every declared agent harness that is not a CLI backend, and fails when one has no binding row — naming the offender. It also asserts the harness scan is non-empty, so it cannot pass vacuously.
- **New behavior test** `src/auto-reply/reply/commands-models.app-server-runtime-choices.test.ts` covers the chooser for `github-copilot`, the unchanged `openai`/Codex path, and a provider served by no app-server harness (which must stay absent).
- `copilot` gains an `AGENT_RUNTIME_LABELS` entry so the new chooser row renders "GitHub Copilot" rather than the raw runtime id, matching every other runtime the chooser offers. Without it the fix ships a visibly half-done picker entry.

The behavior test lives in a new file rather than in `commands-models.test.ts` because that file is already at the 1000-line `max-lines` lint cap.

## Evidence

### Real behavior proof

`scripts/proof-app-server-runtime-chooser-bindings.ts` — no vitest, no mocks of the seam under test. It drives the real `buildModelsProviderData()`, against a real (empty) plugin registry so that **no CLI backend is registered and every runtime choice observed is attributable to the bindings under test**, reads the real bundled manifests off disk, and reproduces the downstream selection exactly as the Discord picker does it (`extensions/discord/src/monitor/native-command-model-picker-interaction.ts`: index into `runtimeChoicesByProvider.get(provider)`, read `.id`).

```
$ pnpm tsx scripts/proof-app-server-runtime-chooser-bindings.ts
[1] github-copilot runtime choices: ["openclaw","copilot"]
[2] openai runtime choices: ["codex","openclaw"]
[3] proof-standalone runtime choices: absent (as expected)
[4] bundled app-server harnesses ["codex","copilot"] all bound
All runtime assertions passed.
```

**The proof and both tests were confirmed to fail with the fix reverted** — a green-only proof would have the same silent-failure problem as the bug. With the `github-copilot` row removed:

```
$ pnpm tsx scripts/proof-app-server-runtime-chooser-bindings.ts
AssertionError [ERR_ASSERTION]: github-copilot has NO runtime chooser entry at all — this is the reported bug
  actual: undefined
  expected: true
exit 1
```

```
$ pnpm vitest run src/agents/app-server-runtime-bindings.test.ts
 × binds every bundled app-server harness to a model provider
AssertionError: bundled agent harness(es) copilot have no model-provider binding, so /models
offers no runtime chooser for the provider(s) they serve. Add a row to
APP_SERVER_RUNTIME_MODEL_BACKEND_BINDINGS in src/agents/app-server-runtime-bindings.ts.:
expected [ 'copilot' ] to deeply equal []
```

```
$ pnpm vitest run src/auto-reply/reply/commands-models.app-server-runtime-choices.test.ts
 × offers the Copilot runtime for github-copilot models
AssertionError: expected undefined to deeply equal [ { id: 'openclaw', …(2) }, …(1) ]
```

That `expected undefined` is the defect stated precisely: not a missing option, a missing chooser.

### Validation gates

All run from the topic worktree:

| Gate | Result |
|---|---|
| `pnpm tsgo:core` | exit 0 |
| `pnpm tsgo:core:test` | exit 0 |
| `pnpm vitest run` (3 suites, see below) | 4 files, 45 tests passed |
| `pnpm config:schema:check` | `[base-config-schema] ok` |
| `pnpm plugin-sdk:surface:check` | exit 0 |
| `pnpm oxlint <touched files>` | exit 0 |
| `git diff --check` | exit 0 |
| `pnpm tsx scripts/proof-...ts` | `All runtime assertions passed.` |

Test count reconciles exactly: the 3 new binding tests run in two vitest projects (`agents-core`, `agents-support`) = 6, plus 3 new chooser tests, plus 36 pre-existing in `commands-models.test.ts` = **45 across 4 files**.

### Scope note

The Control UI was checked and is **not** affected: it has no runtime chooser at all. `ui/src/lib/agents/display.ts` and `ui/src/pages/chat/chat-pane-session-controls.ts` only *display* the session's current `agentRuntime.id`, and the UI's own `resolveAgentRuntimeLabel` returns the raw id for every runtime, so there is no parallel binding list there to drift. The consumers of `runtimeChoicesByProvider` are the chat-channel model pickers (Discord's native `/model` picker; Telegram and Mattermost via `buildModelsProviderData` on the plugin SDK), and this fix covers all of them.

---

*Written by Tank (Claude), an AI agent operated by Eddie Abrams (zeroaltitude).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
