### PR TITLE
fix(sessions): keep archived actions inert

### DIFF
--- a/src/gateway/server-methods/sessions-rewind.test.ts
+++ b/src/gateway/server-methods/sessions-rewind.test.ts
@@ -31,6 +31,7 @@ vi.mock("../../media/store.js", async (importOriginal) => {
   return { ...actual, readMediaBuffer: mocks.readMediaBuffer };
 });
 
+import { resolveSessionStorePathCore } from "../../config/sessions.js";
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
@@ -40,8 +41,10 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { runExclusiveSessionLifecycleMutation } from "../../sessions/session-lifecycle-admission.js";
 import { listSessionStateEventsSince } from "../../sessions/session-state-events.js";
 import { upsertSessionUpstreamLink } from "../../sessions/session-upstream-links.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { sessionRewindHandlers } from "./sessions-rewind.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -279,6 +282,17 @@ function installUpstreamForkHarness(): void {
     },
   });
   setActivePluginRegistry(registry);
+}
+
+async function archiveSourceSession(storePath?: string): Promise<void> {
+  const entry = expectDefined(
+    loadSessionEntry({ agentId: "main", sessionKey, storePath }),
+    "source session",
+  );
+  await upsertSessionEntryCore(
+    { agentId: "main", sessionKey, storePath },
+    { ...entry, archivedAt: Date.now() },
+  );
 }
 
 describe("session message-cut methods", () => {
@@ -526,6 +540,66 @@ describe("session message-cut methods", () => {
       undefined,
     );
     expect(mocks.readMediaBuffer).toHaveBeenCalledTimes(4);
+  });
+
+  it.each([
+    ["sessions.rewind", "user-entry", "Rewind"],
+    ["sessions.branches.switch", "off-path-entry", "Branch switch"],
+  ] as const)("rejects archived %s", async (method, entryId, label) => {
+    await archiveSourceSession();
+
+    const respond = await invoke(method, entryId);
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.INVALID_REQUEST,
+        message: `${label} is unavailable for archived sessions.`,
+      }),
+    );
+  });
+
+  it("allows archived sessions to fork", async () => {
+    await archiveSourceSession();
+
+    const respond = await invoke("sessions.fork", "user-entry");
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ sessionKey: expect.any(String) }),
+      undefined,
+    );
+  });
+
+  it("rechecks archived state after waiting for the session lifecycle lock", async () => {
+    const storePath = resolveSessionStorePathCore(undefined, { agentId: "main" });
+    const mutationEntered = createDeferredCore();
+    const releaseMutation = createDeferredCore();
+    const archiving = runExclusiveSessionLifecycleMutation({
+      scope: storePath,
+      identities: [sourceSessionId],
+      run: async () => {
+        mutationEntered.resolve();
+        await releaseMutation.promise;
+        await archiveSourceSession(storePath);
+      },
+    });
+    await mutationEntered.promise;
+
+    const rewinding = invoke("sessions.rewind", "user-entry");
+    releaseMutation.resolve();
+    await archiving;
+
+    const respond = await rewinding;
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: ErrorCodes.INVALID_REQUEST,
+        message: "Rewind is unavailable for archived sessions.",
+      }),
+    );
   });
 
   it.each([

--- a/src/gateway/server-methods/sessions-rewind.ts
+++ b/src/gateway/server-methods/sessions-rewind.ts
@@ -344,12 +344,12 @@ async function mutateSessionAtMessage(
         return;
       }
       const upstreamLink = readSessionUpstreamLink(current.canonicalKey, current.target.agentId);
-      if (upstreamLink && action !== "fork") {
-        respond(
-          false,
-          undefined,
-          errorShape(ErrorCodes.INVALID_REQUEST, EXTERNAL_CONVERSATION_ERROR),
-        );
+      const archived = current.entry.archivedAt !== undefined;
+      if ((archived || upstreamLink) && action !== "fork") {
+        const message = archived
+          ? `${action === "switch" ? "Branch switch" : "Rewind"} is unavailable for archived sessions.`
+          : EXTERNAL_CONVERSATION_ERROR;
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, message));
         return;
       }
       const placementError = resolveSessionWorkerPlacementMutationError({

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -440,7 +440,34 @@ suite.define(() => {
     const archivedBy = { type: "human" as const, id: "profile-mira", label: "Mira" };
     const batchRows = [sessionRows[0]!, sessionRows[1]!, sessionRows[3]!];
     const gateway = await installMockGateway(page, {
+      featureMethods: [
+        "chat.metadata",
+        "chat.startup",
+        "progressCard.get",
+        "sessions.patch",
+        "sessions.patchMany",
+      ],
+      historyMessages: [
+        {
+          id: "archived-reply",
+          role: "assistant",
+          timestamp: baseTime - 2_000,
+          content: "Reply retained in the transcript.",
+          openclawDelivery: { replyToCurrent: true },
+        },
+      ],
       methodResponses: {
+        "progressCard.get": {
+          card: {
+            revision: 1,
+            sessionKey: selected.key,
+            steps: [
+              { step: "Inspect archive", status: "completed" },
+              { step: "Finish archive", status: "in_progress" },
+            ],
+            updatedAt: baseTime,
+          },
+        },
         "sessions.list": sessionsListResponse([
           sessionRow("agent:main:main", "Main", baseTime),
           ...sessionRows,
@@ -478,6 +505,12 @@ suite.define(() => {
       await rowFor(selected.key).locator("a").first().click();
       await assertSelectedRoute();
       await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
+      const replyPreview = activePane.locator(".chat-reply-preview", {
+        hasText: "Replying to current message",
+      });
+      const progressCard = activePane.locator('[data-progress-card-placement="composer"]');
+      await replyPreview.waitFor({ state: "visible" });
+      await progressCard.waitFor({ state: "visible" });
       await page.evaluate((sessionKey) => {
         const titleHistory: string[] = [];
         const paneTitleHistory: string[] = [];
@@ -653,6 +686,8 @@ suite.define(() => {
       await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
       await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
       await expect.poll(() => activePane.locator(".agent-chat__input").count()).toBe(0);
+      await expect.poll(() => replyPreview.locator(".session-run-spinner").count()).toBe(0);
+      await expect.poll(() => progressCard.count()).toBe(0);
       const archiveEvent = activePane.locator(".chat-notice", { hasText: "Archived by Mira" });
       await archiveEvent.waitFor({ state: "visible", timeout: 10_000 });
       await captureUiProof(page, "archive-attribution-notice-after.png");
@@ -681,6 +716,7 @@ suite.define(() => {
       await archiveEvent.waitFor({ state: "detached", timeout: 10_000 });
       await selectedRow.waitFor({ state: "visible", timeout: 10_000 });
       await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
+      await progressCard.waitFor({ state: "visible" });
       await expect
         .poll(() =>
           activePane.evaluate(
@@ -793,79 +829,6 @@ suite.define(() => {
       await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
       await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
       await archivedRow.waitFor({ state: "detached", timeout: 10_000 });
-    } finally {
-      await context.close();
-    }
-  });
-
-  it("shows the archived notice when an archived session is cold-loaded outside the active list", async () => {
-    const context = await suite.browser.newContext({
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1280 },
-    });
-    const page = await context.newPage();
-    const archived = sessionRow(
-      "agent:main:dashboard:cold-archive",
-      "Archived planning",
-      Date.parse("2026-07-01T16:00:00.000Z"),
-      { archived: true },
-    );
-    const gateway = await installMockGateway(page, {
-      methodResponses: {
-        "sessions.describe": { session: archived },
-        "sessions.list": sessionsListResponse([
-          sessionRow("agent:main:main", "Main", archived.updatedAt + 1),
-        ]),
-        "sessions.patch": {},
-      },
-      sessionArchiveFiltering: true,
-      sessionKey: archived.key,
-    });
-
-    try {
-      await page.goto(`${suite.server.baseUrl}chat?session=${encodeURIComponent(archived.key)}`);
-      const activePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--active");
-
-      const selectedRow = page.locator(
-        `.sidebar-recent-session[data-session-key="${archived.key}"]`,
-      );
-      await selectedRow.waitFor({ state: "visible", timeout: 10_000 });
-      await expect
-        .poll(() => selectedRow.getAttribute("class"))
-        .toContain("sidebar-recent-session--active");
-      await selectedRow.locator(".sidebar-session__archive-glyph").waitFor({ state: "visible" });
-      await expect.poll(() => page.getByText("Archived planning", { exact: true }).count()).toBe(2);
-
-      const archivedNotice = activePane.locator(".agent-chat__disabled-banner");
-      await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
-      await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
-      await expect.poll(() => activePane.locator(".agent-chat__input").count()).toBe(0);
-
-      await gateway.setMethodResponse("sessions.describe", {
-        session: { ...archived, archived: false },
-      });
-      await activateSelfRemovingControl(archivedNotice.getByRole("button", { name: "Unarchive" }));
-      await waitForPatch(
-        gateway,
-        (params) => params.key === archived.key && params.archived === false,
-      );
-      await gateway.emitGatewayEvent("sessions.changed", {
-        ...archived,
-        archived: false,
-        reason: "update",
-        sessionKey: archived.key,
-      });
-
-      await archivedNotice.waitFor({ state: "detached", timeout: 10_000 });
-      await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
-      await expect
-        .poll(() =>
-          activePane.evaluate(
-            (element) => (element as HTMLElement & { sessionKey?: string }).sessionKey,
-          ),
-        )
-        .toBe(archived.key);
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-management.archived-actions.e2e.test.ts
+++ b/ui/src/e2e/session-management.archived-actions.e2e.test.ts
@@ -1,0 +1,304 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
+import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
+import {
+  activateSelfRemovingControl,
+  captureUiProof,
+  captureUiProofEnabled,
+  controlUiSessionUrl,
+  createSessionManagementE2eSuite,
+  installMockGateway,
+  requireRecord,
+  sessionRow,
+  sessionsListResponse,
+  uiProofArtifactDir,
+  waitForPatch,
+} from "./session-management.test-support.ts";
+
+const suite = createSessionManagementE2eSuite();
+
+suite.define(() => {
+  for (const viewport of [
+    { height: 900, label: "desktop", width: 1280 },
+    { height: 844, label: "mobile", width: 390 },
+  ] as const) {
+    it(`keeps archived transcript actions inert on ${viewport.label}`, async () => {
+      const context = await suite.browser.newContext({
+        locale: "en-US",
+        recordVideo: captureUiProofEnabled
+          ? { dir: uiProofArtifactDir, size: viewport }
+          : undefined,
+        serviceWorkers: "block",
+        viewport,
+      });
+      await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+        origin: new URL(suite.server.baseUrl).origin,
+      });
+      const page = await context.newPage();
+      const proofVideo = page.video();
+      const baseTime = Date.parse("2026-07-01T16:00:00.000Z");
+      const sessionKey = "agent:main:archive-actions";
+      const messageText = "Archive action proof.";
+      const session = sessionRow(sessionKey, "Archive actions", baseTime);
+      const gateway = await installMockGateway(page, {
+        featureMethods: [
+          "chat.metadata",
+          "chat.startup",
+          "sessions.branches.list",
+          "sessions.branches.switch",
+          "sessions.fork",
+          "sessions.github.publish",
+          "sessions.patch",
+          "sessions.rewind",
+          SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
+        ],
+        historyMessages: [
+          {
+            role: "user",
+            timestamp: baseTime,
+            content: messageText,
+            __openclaw: { id: "archive-action-user", seq: 1 },
+          },
+          {
+            role: "assistant",
+            timestamp: baseTime + 1,
+            content: "Action proof response.",
+            __openclaw: { id: "archive-action-assistant", seq: 2 },
+          },
+        ],
+        methodResponses: {
+          [SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD]: { subscribed: true },
+          "sessions.branches.list": {
+            branches: [
+              {
+                active: true,
+                headline: "Current branch",
+                leafEntryId: "archive-action-assistant",
+                messageCount: 2,
+              },
+              {
+                active: false,
+                headline: "Other branch",
+                leafEntryId: "archive-action-other",
+                messageCount: 1,
+              },
+            ],
+          },
+          "sessions.fork": {
+            editorText: messageText,
+            sessionKey: "agent:main:dashboard:archive-action-fork",
+          },
+          "sessions.list": sessionsListResponse([
+            sessionRow("agent:main:main", "Main", baseTime + 1_000),
+            session,
+          ]),
+        },
+        sessionArchiveFiltering: true,
+        sessionKey,
+      });
+
+      try {
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
+        const activePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--active");
+        const transcript = activePane.locator(".chat-thread");
+        const userBubble = activePane.locator(".chat-group.user .chat-bubble", {
+          hasText: messageText,
+        });
+        await userBubble.waitFor({ state: "visible", timeout: 10_000 });
+        expect(await userBubble.getAttribute("data-entry-id")).toBe("archive-action-user");
+        const branchTrigger = activePane.locator(".chat-pane__branches-trigger");
+        await branchTrigger.waitFor({ state: "visible", timeout: 10_000 });
+        expect(await branchTrigger.isDisabled()).toBe(false);
+
+        await gateway.waitForRequest(SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD);
+        await gateway.emitGatewayEvent(CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT, {
+          sessions: {
+            [sessionKey]: {
+              branch: {
+                additions: 4,
+                branch: "fix/archive-actions",
+                deletions: 1,
+                owner: "openclaw",
+                repo: "openclaw",
+              },
+              pullRequests: [],
+              rateLimited: false,
+              status: "ok",
+            },
+          },
+        });
+        await page.getByRole("button", { name: "Publish PR" }).waitFor();
+
+        await userBubble.click({ button: "right" });
+        const initialMenu = page.locator(".chat-reply-context-menu");
+        await initialMenu.waitFor({ state: "visible" });
+        const initialLabels = await initialMenu
+          .locator("button")
+          .evaluateAll((buttons) => buttons.map((button) => button.getAttribute("aria-label")));
+        expect(initialLabels).toContain("Rewind to here");
+        await initialMenu.locator('[aria-label="Rewind to here"]').click();
+        await page.locator(".chat-confirm-popover").waitFor({ state: "visible" });
+
+        await gateway.emitGatewayEvent("sessions.changed", {
+          ...session,
+          archived: true,
+          archivedAt: baseTime + 2_000,
+          reason: "update",
+          sessionKey,
+        });
+
+        const archivedNotice = activePane.locator(".agent-chat__disabled-banner");
+        await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
+        await expect.poll(() => page.locator(".chat-reply-context-menu").count()).toBe(0);
+        await expect.poll(() => page.locator(".chat-confirm-popover").count()).toBe(0);
+        await expect
+          .poll(() => transcript.evaluate((element) => element === document.activeElement))
+          .toBe(true);
+        await expect.poll(() => branchTrigger.isDisabled()).toBe(true);
+        await expect.poll(() => page.getByRole("button", { name: "Publish PR" }).count()).toBe(0);
+
+        await userBubble.evaluate((element) => {
+          const selection = window.getSelection();
+          const range = document.createRange();
+          range.selectNodeContents(element);
+          selection?.removeAllRanges();
+          selection?.addRange(range);
+        });
+        await userBubble.click({ button: "right" });
+        const menu = page.locator(".chat-reply-context-menu");
+        await menu.waitFor({ state: "visible" });
+        expect(
+          await menu
+            .locator("button")
+            .evaluateAll((buttons) => buttons.map((button) => button.getAttribute("aria-label"))),
+        ).toEqual(["Copy", "Fork from here"]);
+        await captureUiProof(page, `archived-actions-${viewport.label}.png`);
+        expect(
+          await page.evaluate(() => {
+            const portal = document.querySelector<HTMLElement>(".chat-reply-context-menu");
+            const rect = portal?.getBoundingClientRect();
+            return {
+              documentOverflows: document.documentElement.scrollWidth > window.innerWidth,
+              menuFits:
+                Boolean(rect) &&
+                rect!.left >= 0 &&
+                rect!.top >= 0 &&
+                rect!.right <= window.innerWidth &&
+                rect!.bottom <= window.innerHeight,
+            };
+          }),
+        ).toEqual({ documentOverflows: false, menuFits: true });
+
+        await menu.locator('[aria-label="Copy"]').click();
+        await expect
+          .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+          .toBe(messageText);
+
+        await userBubble.click({ button: "right" });
+        await page
+          .locator(".chat-reply-context-menu")
+          .locator('[aria-label="Fork from here"]')
+          .click();
+        const fork = await gateway.waitForRequest("sessions.fork");
+        expect(requireRecord(fork.params)).toMatchObject({
+          entryId: "archive-action-user",
+          sessionKey,
+        });
+        expect(await gateway.getRequests("sessions.rewind")).toHaveLength(0);
+        expect(await gateway.getRequests("sessions.branches.switch")).toHaveLength(0);
+        expect(await gateway.getRequests("sessions.github.publish")).toHaveLength(0);
+      } finally {
+        await context.close();
+        if (proofVideo) {
+          await proofVideo.saveAs(
+            path.join(uiProofArtifactDir, `archived-actions-${viewport.label}.webm`),
+          );
+        }
+      }
+    });
+  }
+
+  it("shows the archived notice when an archived session is cold-loaded outside the active list", async () => {
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const archived = sessionRow(
+      "agent:main:dashboard:cold-archive",
+      "Archived planning",
+      Date.parse("2026-07-01T16:00:00.000Z"),
+      { archived: true },
+    );
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.branches.list": {
+          branches: [
+            { active: true, headline: "Current branch", leafEntryId: "current", messageCount: 2 },
+            { active: false, headline: "Other branch", leafEntryId: "other", messageCount: 1 },
+          ],
+        },
+        "sessions.describe": { session: archived },
+        "sessions.list": sessionsListResponse([
+          sessionRow("agent:main:main", "Main", archived.updatedAt + 1),
+        ]),
+        "sessions.patch": {},
+      },
+      sessionArchiveFiltering: true,
+      sessionKey: archived.key,
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}chat?session=${encodeURIComponent(archived.key)}`);
+      const activePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--active");
+
+      const selectedRow = page.locator(
+        `.sidebar-recent-session[data-session-key="${archived.key}"]`,
+      );
+      await selectedRow.waitFor({ state: "visible", timeout: 10_000 });
+      await expect
+        .poll(() => selectedRow.getAttribute("class"))
+        .toContain("sidebar-recent-session--active");
+      await selectedRow.locator(".sidebar-session__archive-glyph").waitFor({ state: "visible" });
+      await expect.poll(() => page.getByText("Archived planning", { exact: true }).count()).toBe(2);
+
+      const archivedNotice = activePane.locator(".agent-chat__disabled-banner");
+      await archivedNotice.waitFor({ state: "visible", timeout: 10_000 });
+      await expect.poll(() => archivedNotice.textContent()).toContain("This session is archived.");
+      await expect.poll(() => activePane.locator(".agent-chat__input").count()).toBe(0);
+      await expect
+        .poll(() => activePane.locator(".chat-pane__branches-trigger").isDisabled())
+        .toBe(true);
+      expect(await gateway.getRequests("sessions.branches.switch")).toHaveLength(0);
+
+      await gateway.setMethodResponse("sessions.describe", {
+        session: { ...archived, archived: false },
+      });
+      await activateSelfRemovingControl(archivedNotice.getByRole("button", { name: "Unarchive" }));
+      await waitForPatch(
+        gateway,
+        (params) => params.key === archived.key && params.archived === false,
+      );
+      await gateway.emitGatewayEvent("sessions.changed", {
+        ...archived,
+        archived: false,
+        reason: "update",
+        sessionKey: archived.key,
+      });
+
+      await archivedNotice.waitFor({ state: "detached", timeout: 10_000 });
+      await activePane.locator(".agent-chat__input textarea").waitFor({ state: "visible" });
+      await expect
+        .poll(() =>
+          activePane.evaluate(
+            (element) => (element as HTMLElement & { sessionKey?: string }).sessionKey,
+          ),
+        )
+        .toBe(archived.key);
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/pages/chat/chat-pane-base.ts
+++ b/ui/src/pages/chat/chat-pane-base.ts
@@ -37,6 +37,7 @@ import type { BoardFace, BoardVisibleChatDock } from "../../lib/board/settings.t
 import type { BoardTab } from "../../lib/board/types.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { parseCatalogSessionKey } from "../../lib/sessions/catalog-key.ts";
+import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import type { SwarmRosterHydrator } from "../../lib/sessions/swarm-roster.ts";
 import { SessionUnreadPatchGuard } from "../../lib/sessions/unread.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -198,7 +199,8 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   protected readonly taskSidebarTranscript = new ChatTranscriptController(this);
   protected readonly progressCard = new SessionProgressCardController(this, {
     gateway: () => this.context?.gateway,
-    sessionKey: () => this.state?.sessionKey,
+    sessionKey: () =>
+      this.state && !this.isCurrentSessionArchived(this.state) ? this.state.sessionKey : undefined,
   });
   private boardFullscreenController: FullscreenController | null = null;
   protected get boardFullscreen(): FullscreenController {
@@ -222,6 +224,15 @@ export abstract class ChatPaneBase extends OpenClawLightDomElement {
   });
   protected questionPrompts: QuestionPrompt[] = [];
   protected state: ChatPageHost | undefined;
+
+  protected isCurrentSessionArchived(state: ChatPageHost): boolean {
+    return (
+      state.selectedChatSessionArchived ||
+      state.sessionsResult?.sessions.some(
+        (row) => row.archived === true && areUiSessionKeysEquivalent(row.key, state.sessionKey),
+      ) === true
+    );
+  }
   /* Infinity until the first ResizeObserver tick so an unmeasured pane keeps
    * the wide side-by-side layout instead of flashing the stacked one. */
   @litState() protected paneWidth = Number.POSITIVE_INFINITY;

--- a/ui/src/pages/chat/chat-pane-header.ts
+++ b/ui/src/pages/chat/chat-pane-header.ts
@@ -145,11 +145,14 @@ export abstract class ChatPaneHeader extends ChatPaneDiscussion {
       this.context.gateway.snapshot,
       Boolean(this.state?.chatRunId),
     ).branchSwitch;
-    const branchSwitchDisabledReason = !branchSwitchAccess.allowed
-      ? branchSwitchAccess.reason
-      : branchSwitchWorking
-        ? t("chat.sessionHeader.branchSwitchUnavailable")
-        : null;
+    const branchSwitchDisabledReason =
+      this.state && this.isCurrentSessionArchived(this.state)
+        ? t("chat.archivedSessionDisabled")
+        : !branchSwitchAccess.allowed
+          ? branchSwitchAccess.reason
+          : branchSwitchWorking
+            ? t("chat.sessionHeader.branchSwitchUnavailable")
+            : null;
     const sharingSnapshot = this.context.gateway.snapshot;
     // Sharing was introduced behind this advertised method. Keep the control
     // hidden for older Gateways that omit method metadata.

--- a/ui/src/pages/chat/chat-pane-lifecycle.ts
+++ b/ui/src/pages/chat/chat-pane-lifecycle.ts
@@ -62,6 +62,7 @@ import { refreshPageChat, retireChatMetadataRequests } from "./chat-state-refres
 import { resetChatViewState } from "./chat-view-state.ts";
 import { dismissConfirmedActionPopovers } from "./components/chat-message.ts";
 import { clearChatModelSearchOnEscape } from "./components/chat-model-picker.ts";
+import { dismissThreadPortals } from "./components/chat-thread-interactions.ts";
 import { WIDGET_PROMPT_EVENT, type WidgetPromptEventDetail } from "./components/chat-tool-cards.ts";
 import { CHAT_COMPOSER_DRAFT_STORAGE_ERROR } from "./composer-persistence.ts";
 import { exportChatMarkdown } from "./export.ts";
@@ -96,6 +97,7 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
   });
 
   private chatRouteReadyReported = false;
+  private currentSessionArchived: boolean | undefined;
   private stagedAttachmentGatewayOwner: ChatAttachmentGatewayOwner = null;
   private suppressStagedAttachmentHandoffOnDisconnect = false;
 
@@ -664,6 +666,12 @@ export abstract class ChatPaneLifecycle extends ChatPaneSessionCreation {
         this.showComposerPrefillAttention(input);
       }
     }
+    const archived = this.state ? this.isCurrentSessionArchived(this.state) : false;
+    if (archived && this.currentSessionArchived === false) {
+      dismissThreadPortals(this.presentationId, this);
+      this.querySelector<HTMLElement>(".chat-thread")?.focus({ preventScroll: true });
+    }
+    this.currentSessionArchived = archived;
     this.cancelResetConfirmationForSessionChange();
     this.syncHistoryObserver();
     const board = this.resolveBoardView();

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -72,6 +72,7 @@ export class ChatPane extends ChatPaneLayoutRender {
     }
     void this.ensureTaskSuggestionCloudProfiles();
     const selectedSession = selectedChatSessionRow(state);
+    const selectedSessionArchived = this.isCurrentSessionArchived(state);
     const mutationAccess = readChatPaneMutationAccess(
       this.context.gateway.snapshot,
       state.sessionKey,
@@ -96,7 +97,7 @@ export class ChatPane extends ChatPaneLayoutRender {
       Boolean(placement) && placement?.state !== "local" && !hasAbortableSessionRun(state);
     const canPublishPullRequest =
       Boolean(publishClient) &&
-      Boolean(selectedSession?.key) &&
+      Boolean(selectedSession?.key && !selectedSessionArchived) &&
       !hasAbortableSessionRun(state) &&
       publicationHasDirectPlacement &&
       hasOperatorWriteAccess(this.context.gateway.snapshot.hello?.auth ?? null) &&
@@ -165,7 +166,6 @@ export class ChatPane extends ChatPaneLayoutRender {
       selectedAgentFound: selectedAgent !== undefined,
       agentModel: agentDefaultModel,
     });
-    const selectedSessionArchived = this.isCurrentSessionArchived(state);
     const placementStartup = this.context.placementStartup.get(state.sessionKey);
     const placementStartupPending =
       placementStartup !== null && placementStartup.phase !== "failed";
@@ -274,6 +274,11 @@ export class ChatPane extends ChatPaneLayoutRender {
       onFork: (entryId) => this.forkFromMessage(entryId),
       onReset: () => void clearChatHistory(state),
     });
+    const setReply: NonNullable<ChatProps["onSetReply"]> = (target) => {
+      state.chatReplyTarget = target;
+      state.requestUpdate?.();
+    };
+    const replyMessageAccess = this.currentReplyMessageAccess(state.sessionKey);
     const composerControls = catalogKey
       ? undefined
       : renderChatPaneComposerControls({
@@ -606,12 +611,9 @@ export class ChatPane extends ChatPaneLayoutRender {
         state.chatReplyTarget = null;
         state.requestUpdate?.();
       },
-      onSetReply: (target) => {
-        state.chatReplyTarget = target;
-        state.requestUpdate?.();
-      },
-      replyMessageAccess: catalogKey ? undefined : this.currentReplyMessageAccess(state.sessionKey),
-      onRewindMessage: sessionActionCallbacks.onRewindMessage,
+      onSetReply: selectedSessionArchived ? undefined : setReply,
+      replyMessageAccess: catalogKey || selectedSessionArchived ? undefined : replyMessageAccess,
+      onRewindMessage: selectedSessionArchived ? undefined : sessionActionCallbacks.onRewindMessage,
       onForkMessage: sessionActionCallbacks.onForkMessage,
       onClearHistory: sessionActionCallbacks.onClearHistory,
       agentsList: state.agentsList,

--- a/ui/src/pages/chat/chat-pane-sharing.ts
+++ b/ui/src/pages/chat/chat-pane-sharing.ts
@@ -29,7 +29,6 @@ import {
   type ChatPaneConnectionScope,
 } from "./chat-pane-shared.ts";
 import { resetSessionCompanion } from "./chat-session-companion.ts";
-import type { ChatPageHost } from "./chat-state-host.ts";
 import { resolveChatAgentId } from "./chat-state-route.ts";
 import { clearTypingActorForSessionMessage } from "./chat-typing-presence.ts";
 import {
@@ -333,15 +332,6 @@ export abstract class ChatPaneSharing extends ChatPaneBase {
 
   protected hasMultipleIdentities(): boolean {
     return hasMultiplePresenceIdentities(this.presencePayload);
-  }
-
-  protected isCurrentSessionArchived(state: ChatPageHost): boolean {
-    return (
-      state.selectedChatSessionArchived ||
-      state.sessionsResult?.sessions.some(
-        (row) => row.archived === true && areUiSessionKeysEquivalent(row.key, state.sessionKey),
-      ) === true
-    );
   }
 
   protected resetSessionSuggestions(): void {

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -451,10 +451,8 @@ export function renderGroupedMessage(
             : undefined,
           opts.onOpenReply,
           opts.onResolveReply,
-          opts.replyNavigationId ===
-            (normalizedMessage.replyTarget?.kind === "id"
-              ? normalizedMessage.replyTarget.id
-              : null),
+          normalizedMessage.replyTarget?.kind === "id" &&
+            opts.replyNavigationId === normalizedMessage.replyTarget.id,
         )}
         ${renderInlineToolCards(toolCards, {
           messageKey,
@@ -498,8 +496,8 @@ export function renderGroupedMessage(
           : undefined,
         opts.onOpenReply,
         opts.onResolveReply,
-        opts.replyNavigationId ===
-          (normalizedMessage.replyTarget?.kind === "id" ? normalizedMessage.replyTarget.id : null),
+        normalizedMessage.replyTarget?.kind === "id" &&
+          opts.replyNavigationId === normalizedMessage.replyTarget.id,
       )}
       ${isStandaloneToolMessage
         ? html`

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -174,7 +174,7 @@ export function getTranscriptState(paneId: string): ChatThreadState {
   return state;
 }
 
-function dismissThreadPortals(paneId?: string, owner?: ParentNode): void {
+export function dismissThreadPortals(paneId?: string, owner?: ParentNode): void {
   removeReplyContextMenu(paneId);
   if (owner) {
     dismissConfirmedActionPopovers(owner);


### PR DESCRIPTION
Fixes #130442
Related: #130455

## What Problem This Solves

Fixes an issue where archived chat sessions still exposed history-changing actions, could retain stale message menus or rewind confirmations after archival, and accepted rewind or branch-switch requests at the Gateway.

This is a credited replacement for #130455 because its source branch has `maintainerCanModify=false` and the landed diff needed additional lifecycle, Gateway, and regression-proof work. The implementation commit preserves @vyctorbrzezowski as co-author.

## Why This Change Was Made

Archived state is now consumed through the canonical pane fact across transcript actions, publication, progress indicators, and branch switching. Archive transitions dismiss portaled interactions and restore transcript focus, while the Gateway rechecks archived state inside the session lifecycle lock before rewind or branch switching; forking remains available.

No protocol, schema, persistence, documentation, or localization surface changes are included.

## User Impact

Archived sessions now offer Copy and Fork from transcript menus without exposing Reply, Rewind, branch switching, or pull-request publication. Archiving an open session closes stale menus and confirmations cleanly, and users can still fork archived history into a new session.

Release-note context: archived sessions no longer permit history mutation through the Control UI or Gateway.

## Evidence

- Exact tested head: `7e0f9cd4431e021a638a2ac8e98243f6a7e87271`
- Production LOC: `+49/-37` (net `+12`); tests: raw `+414/-73`, net-new `+341` after discounting the mechanical E2E move
- Pre-fix proof:
  - archived rewind and branch switching succeeded instead of rejecting
  - a rewind queued behind the lifecycle lock succeeded after the session was archived
  - the archived transcript retained a stale rewind confirmation/menu
  - archived reply/progress indicators remained active
- `pnpm exec vitest run src/gateway/server-methods/sessions-rewind.test.ts` — 29 passed
- `pnpm --dir ui exec vitest run src/pages/chat/components/chat-pane-header.test.ts` — 49 passed
- Control UI archive E2E — 13 passed across `ui/src/e2e/session-management.archive.e2e.test.ts` and `ui/src/e2e/session-management.archived-actions.e2e.test.ts`
  - archived menus expose only Copy and Fork
  - cold-loaded archived sessions disable branch switching and send no switch request
  - archive transitions close stale menu/dialog state and restore transcript focus
  - Copy and Fork work; no rewind, branch-switch, or publication request is sent
  - desktop `1280x900` and mobile `390x844` have no menu/document overflow
- Reviewer-visible desktop/mobile screenshots and recordings: https://github.com/openclaw/openclaw/pull/130642#issuecomment-5433952904
- `oxfmt`, `oxlint`, `git diff --check`, and the max-lines ratchet passed.
- Fresh Codex autoreview reported no actionable findings (`patch is correct`, confidence `0.97`); the later E2E file split was mechanical and changed no behavior.
- `pnpm check:changed` passed every gate through core production typecheck. The core-test type shard remains blocked by the existing shared dependency error `ui/vite.config.ts(9,22): TS7016` for missing `pako` declarations; this PR does not touch that dependency surface.
