### PR TITLE
fix: preserve Gateway error reasons in text logs

### DIFF
--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -64,6 +64,8 @@ profile uses `openclaw-YYYY-MM-DD.log`, while named profiles use
 
 In `--json` mode, invalid `--port`, `--limit`, `--interval`, or `--max-bytes` values and conflicting `--url`/`--port` options produce the standard CLI failure envelope on stdout: `{"ok":false,"error":{"type":"cli_error","message":"..."}}`. Terminal log-fetch failures instead emit `{"type":"error",...}` on stderr. Both exit with status `1`.
 
+In text mode, terminal log-fetch failures print the redacted error reason, selected Gateway connection details, and a doctor hint on stderr. A received RPC rejection is shown as the error, rather than reported as a Gateway reachability failure.
+
 ## Related
 
 - [Logging overview](/logging)

--- a/src/cli/logs-cli.port.test.ts
+++ b/src/cli/logs-cli.port.test.ts
@@ -117,7 +117,7 @@ describe("logs local port selection", () => {
   );
 
   it.each(["text", "json"])(
-    "reports the selected port when the RPC fails in %s mode",
+    "reports the rejection reason and selected port when the RPC fails in %s mode",
     async (mode) => {
       await withLogsGateway({ denied: true }, async ({ port, requests, stderr }) => {
         const args = [
@@ -130,12 +130,16 @@ describe("logs local port selection", () => {
         await expect(runLogs(args)).rejects.toBeInstanceOf(ExitError);
         expect(requests).toEqual(["connect", "logs.tail"]);
         const output = stderr.join("");
+        expect(output).toContain("logs unavailable for this client");
         if (mode === "json") {
           expect(JSON.parse(output)).toMatchObject({
             type: "error",
+            message: "Gateway not reachable. Is it running and accessible?",
+            error: "logs unavailable for this client",
             details: { url: `ws://127.0.0.1:${port}` },
           });
         } else {
+          expect(output).not.toContain("Gateway not reachable");
           expect(output).toContain(`Gateway target: ws://127.0.0.1:${port}`);
         }
       });

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -890,7 +890,9 @@ describe("logs cli", () => {
 
       expect(readConfiguredLogTail).not.toHaveBeenCalled();
       expect((stderrWrites.join("").match(/gateway disconnected/g) ?? []).length).toBe(8);
-      expect(stderrWrites.join("")).toContain("Gateway not reachable");
+      expect(stderrWrites.join("")).toContain(
+        "gateway closed (1006 abnormal closure): abnormal closure",
+      );
       expect(stdoutWrites.join("")).not.toContain("local fallback line");
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
@@ -914,7 +916,9 @@ describe("logs cli", () => {
       await runLogsCli(["logs", "--follow", "--url", "ws://127.0.0.1:18789"]);
 
       expect((stderrWrites.join("").match(/gateway disconnected/g) ?? []).length).toBe(8);
-      expect(stderrWrites.join("")).toContain("Gateway not reachable");
+      expect(stderrWrites.join("")).toContain(
+        "gateway closed (1006 abnormal closure): abnormal closure",
+      );
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
@@ -1018,7 +1022,9 @@ describe("logs cli", () => {
       await runLogsCli(["logs", "--follow", "--url", "ws://127.0.0.1:18789"]);
 
       expect(stderrWrites.join("")).not.toContain("gateway disconnected");
-      expect(stderrWrites.join("")).toContain("Gateway not reachable");
+      expect(stderrWrites.join("")).toContain(
+        "gateway closed (1008 policy violation): pairing required",
+      );
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
@@ -1038,11 +1044,11 @@ describe("logs cli", () => {
       await runLogsCli(["logs", "--follow", "--url", "ws://127.0.0.1:18789"]);
 
       expect(stderrWrites.join("")).not.toContain("gateway disconnected");
-      expect(stderrWrites.join("")).toContain("Gateway not reachable");
+      expect(stderrWrites.join("")).toContain("gateway closed (4001 unauthorized): unauthorized");
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
-    it("redacts credential-bearing Gateway URLs from JSON errors", async () => {
+    it.each(["text", "json"])("redacts Gateway URLs in %s errors", async (mode) => {
       const rawUrl =
         "wss://user:password@gateway.example/ws?token=secret&key=api-key&X-Amz-Signature=signed";
       buildGatewayConnectionDetails.mockReturnValueOnce({
@@ -1054,9 +1060,10 @@ describe("logs cli", () => {
       const stderrWrites = captureStderrWrites();
       const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 
-      await runLogsCli(["logs", "--json", "--url", rawUrl]);
+      await runLogsCli(["logs", mode === "json" ? "--json" : "--plain", "--url", rawUrl]);
 
       const stderr = stderrWrites.join("");
+      expect(stderr).toContain("failed to connect to");
       expect(stderr).toContain("gateway.example/ws");
       expect(stderr).not.toContain("password");
       expect(stderr).not.toContain("secret");
@@ -1126,7 +1133,9 @@ describe("logs cli", () => {
 
     expect(readConfiguredLogTail).not.toHaveBeenCalled();
     expect(stdoutWrites.join("")).not.toContain("local fallback line");
-    expect(stderrWrites.join("")).toContain("Gateway not reachable");
+    expect(stderrWrites.join("")).toContain(
+      "gateway closed (1000 normal closure): no close reason",
+    );
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -507,7 +507,7 @@ async function emitGatewayError(
     return;
   }
 
-  if (!errorLine(colorize(rich, theme.error, message))) {
+  if (!errorLine(colorize(rich, theme.error, errorText))) {
     return;
   }
   if (!errorLine(details.message)) {


### PR DESCRIPTION
Closes #130616

## What Problem This Solves

Fixes an issue where operators using text-mode `openclaw logs` saw only “Gateway not reachable” when a reachable Gateway rejected `logs.tail`. The actual server reason was discarded, making an RPC rejection look like a connection failure. JSON already retained the reason.

## Why This Change Was Made

The terminal-error owner already formats and redacts the authoritative error. Text output now sends that prepared string through its existing safe stderr writer instead of the generic reachability message. No new formatter, fallback, or control-flow branch is introduced. JSON shape and wording, selected-target diagnostics, auth, retries/recovery, broken-pipe handling, and exit behavior remain unchanged.

## User Impact

Human-readable logs failures now show the actionable error alongside the selected Gateway details and doctor hint. The same terminal projection covers exhausted follow retries and non-recoverable failures. URL credentials stay redacted; stdout stays empty on the tested terminal rejection. The CLI reference documents the text behavior without changing the JSON contract.

## Evidence

Before the repair, a real built CLI connected to a credential-free loopback WebSocket fixture and received `INVALID_REQUEST: logs unavailable for this client`. Both text and JSON reached `connect` and `logs.tail`, exited 1, and emitted no stdout. Only JSON retained the reason; the text assertion failed. The new focused redaction/reason assertion also failed on unchanged production.

After the fix, the same rebuilt-CLI process probe passed: text stderr begins `logs unavailable for this client`, followed by selected connection details and the doctor hint. JSON output remains unchanged. Temporary HOME/config/state and an ephemeral loopback port were used; no operator Gateway or external service was accessed.

175 focused tests passed across logs, recovery, JSON, auth forwarding, error formatting, URL redaction, and safe-stream writing:

```bash
node scripts/run-vitest.mjs src/cli/logs-cli.test.ts src/cli/logs-cli.runtime.test.ts src/cli/gateway-port-option.test.ts src/cli/gateway-rpc.runtime.test.ts src/cli/json-output-mode.test.ts src/infra/errors.test.ts src/logging/log-tail-redaction.test.ts packages/net-policy/src/redact-sensitive-url.test.ts packages/terminal-core/src/stream-writer.test.ts
```

The worker sandbox denied loopback socket creation before assertions. The coordinator reran the original owner/port order through the normal local test path: **49 tests passed**, including all nine socket-boundary cases. This overlaps the 175-test run; it is not an extra 49 unique tests.

```bash
node scripts/run-vitest.mjs src/cli/logs-cli.test.ts src/cli/logs-cli.port.test.ts
```

```bash
node scripts/check-changed.mjs -- src/cli/logs-cli.ts src/cli/logs-cli.test.ts src/cli/logs-cli.port.test.ts docs/cli/logs.md
```

```bash
node --import tsx scripts/build-all.mts
```

```bash
git diff --check
```

All passed, along with targeted formatting and docs review. Full build completed in 5m 7.3s; existing dependency direct-eval warnings were nonfatal. Fresh independent P1 autoreview found no actionable findings (correct, confidence 0.96).

[Exact-head CI 33040754720](https://github.com/openclaw/openclaw/actions/runs/33040754720) is green on `4d129de6de72aa266da955775ed555ed30e4ad4f`. Native review artifacts validate at `READY FOR /prepare-pr`; current-main comparison found no changes in the affected owner/tests/docs. The earlier draft-only CI was skipped and is not counted as proof. The latest ClawSweeper comment remains a review-started placeholder, with no published verdict/rank-up list; it is not counted as completed review.

Production **+1/-1, net zero**; tests **+21/-8**; docs **+2/-0**. Tests extend existing error/follow and WebSocket fixtures without a new production seam. No schema, protocol, configuration, dependency, or persistence change. AI-assisted repair; release-note context is the restored diagnostic behavior above.

Documentation: https://docs.openclaw.ai/cli/logs.
