### PR TITLE
fix(ui): straighten the Online sidebar divider

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2157,6 +2157,7 @@ openclaw-settings-save-indicator:empty {
   padding-top: 12px;
   margin: 12px 0 10px;
   border-top: 1px solid color-mix(in srgb, var(--border) 64%, transparent);
+  border-radius: 0;
 }
 
 .sidebar-online__list {


### PR DESCRIPTION
## What Problem This Solves

The Control UI's Online sidebar divider curved downward at both ends, making a section separator look like the top of an unfinished rounded card. This is a maintainer-requested visual refinement.

## Why This Change Was Made

Set the Online section's border radius to zero at the rule that owns its top border. The section shares rounded container styling with Sessions; the local override preserves Sessions' rounded drop target and the rounded interactive people rows without changing shared styling.

## User Impact

Online now has a straight, subtle inset divider. Its color, 1px thickness, position, spacing, roster, and expand/collapse behavior are unchanged in light and dark mode. No configuration, protocol, persistence, or native app code changes.

## Evidence

Before/after screenshots below were captured from the running Control UI dev server with deterministic synthetic Gateway data, visually inspected, and sanitized before upload. No personal sessions or live credentials were used.

- Chromium: light/dark × expanded/collapsed. Computed section radius changes from 10px to 0px; border color/thickness, bounding rectangle, padding, and margin remain identical.
- People rows retain 10px rounding on hover and keyboard focus; Sessions retains its 10px rounding.
- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts -t 'AppSidebar viewer presence'` — 5 passed (295 unrelated cases filtered out).
- `node_modules/.bin/oxfmt --check ui/src/styles/layout.css` — passed.
- `node --import tsx scripts/run-stylelint.mts ui/src/styles/layout.css` — passed.
- `git diff --check` — passed.
- Independent Codex autoreview — clean; no accepted/actionable findings.
- `pnpm ui:build` — passed, including the Control UI performance budget checks.

Production LOC: +1/-0; tests: +0/-0. One owner-scoped CSS declaration is the complete visual change. Existing roster interaction tests plus rendered before/after checks cover this cosmetic refinement; no source-string test or new production seam was added.

AI-assisted. Release-note context: Control UI Online sidebar separators are straight while interactive rows retain their rounded corners.

![Before — curved Online divider (dark)](https://github.com/user-attachments/assets/6dcb4745-c361-4862-8243-48413395c4e5)

![After — straight Online divider (dark)](https://github.com/user-attachments/assets/7f86655e-4a92-4f85-8be1-3e61c5af3f19)

![Before — curved Online divider (light)](https://github.com/user-attachments/assets/a4367e79-d4d5-43af-b066-0678fe859fb8)

![After — straight Online divider (light)](https://github.com/user-attachments/assets/a3564af4-2c6a-425a-a200-d4eabaa93b52)