### PR TITLE
fix(parallels): main install and update smoke cannot complete

### DIFF
--- a/scripts/e2e/parallels-windows-prepare.sh
+++ b/scripts/e2e/parallels-windows-prepare.sh
@@ -88,7 +88,7 @@ fi
 
 require_host_tools() {
   local tool
-  for tool in prlctl curl python3 ruby; do
+  for tool in prlctl curl python3 ruby node; do
     command -v "$tool" >/dev/null 2>&1 || die "missing host tool: $tool"
   done
 }
@@ -114,12 +114,18 @@ vm_exists() {
 }
 
 vm_state() {
-  prlctl status "$VM_NAME" 2>/dev/null | awk '{print $NF}'
+  run_bounded 30 prlctl status "$VM_NAME" 2>/dev/null | awk '{print $NF}'
 }
 
 ensure_vm_running() {
-  local state
+  local state deadline=$((SECONDS + 120))
   state="$(vm_state)"
+  # snapshot-switch can return before Parallels finishes restoring the disk state.
+  while [[ "$state" == "restoring" ]]; do
+    [[ "$SECONDS" -lt "$deadline" ]] || die "snapshot restore did not finish within 120 seconds"
+    sleep 1
+    state="$(vm_state)"
+  done
   case "$state" in
     running)
       ;;
@@ -617,8 +623,18 @@ ensure_git() {
   wait_for_check Git 'where git.exe'
 }
 
+guest_node_supported() {
+  local version
+  version="$(guest_user_cmd 'node.exe --version' | tr -d '\r' | tail -n 1)" || return 1
+  node --input-type=module - "$SCRIPT_DIR/../preinstall-package-manager-warning.mjs" "$version" <<'JS'
+import { pathToFileURL } from "node:url";
+const { enforceSupportedNodeRuntime } = await import(pathToFileURL(process.argv[2]).href);
+process.exitCode = enforceSupportedNodeRuntime({ version: process.argv[3], execPath: "Windows guest PATH" }) ? 0 : 1;
+JS
+}
+
 ensure_node() {
-  if guest_user_cmd 'where node.exe' >/dev/null 2>&1; then
+  if guest_node_supported >/dev/null 2>&1; then
     return
   fi
   winget_download OpenJS.NodeJS.LTS
@@ -630,6 +646,7 @@ ensure_node() {
   run_windows_installer msiexec.exe /i "$installer" /qn /norestart
   finish_installer_reboot
   wait_for_check Node.js 'where node.exe'
+  guest_node_supported || die "installed Node.js does not satisfy the OpenClaw runtime requirement"
 }
 
 cleanup_installers() {
@@ -640,6 +657,7 @@ cleanup_installers() {
 verify_baseline() {
   set_guest_paths
   guest_user_cmd 'git --version && node --version && npm --version'
+  guest_node_supported || die "baseline Node.js is unsupported; rerun prepare with --baseline-snapshot <new-name> to upgrade it"
   guest_user_cmd 'wsl.exe --version' || die "MSI-backed WSL is unavailable"
   guest_user_cmd 'wsl.exe --status' || die "WSL status failed"
   guest_system_ps "if (-not (Get-CimInstance Win32_ComputerSystem).HypervisorPresent) { throw 'Windows hypervisor is not active; WSL 2 workloads cannot start' }"

--- a/scripts/e2e/parallels/common.ts
+++ b/scripts/e2e/parallels/common.ts
@@ -2,12 +2,7 @@
 export * from "./filesystem.ts";
 export * from "./env-limits.ts";
 export * from "./host-command.ts";
-export {
-  resolveHostIp,
-  resolveHostPort,
-  startHostServer,
-  startNpmRegistryServer,
-} from "./host-server.ts";
+export { resolveHostIp, resolveHostPort } from "./host-server.ts";
 export * from "./lane-runner.ts";
 export * from "./macos-users.ts";
 export {

--- a/scripts/e2e/parallels/guest-transports.ts
+++ b/scripts/e2e/parallels/guest-transports.ts
@@ -12,10 +12,15 @@ interface GuestExecOptions {
   timeoutMs?: number;
 }
 
+interface PosixGuestOptions extends GuestExecOptions {
+  env?: Record<string, string>;
+}
+
 interface WindowsBackgroundPowerShellOptions {
   append?: (chunk: string | Uint8Array) => void;
   beforeLaunchAttempt?: () => void;
   completedLogDrainGraceMs?: number;
+  env?: Record<string, string>;
   label: string;
   onLaunchRetry?: (message: string) => void;
   pollIntervalMs?: number;
@@ -41,6 +46,15 @@ function guestScriptName(extension: string): string {
 
 function posixSingleQuote(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function windowsProcessEnvScript(env: Record<string, string> = {}): string {
+  return Object.entries(env)
+    .map(
+      ([key, value]) =>
+        `Set-Item -LiteralPath ${psSingleQuote(`Env:${key}`)} -Value ${psSingleQuote(value)}`,
+    )
+    .join("\n");
 }
 
 function appendOutput(
@@ -387,6 +401,7 @@ function Add-OpenClawBackgroundLog {
 }
 try {
   & {
+${windowsProcessEnvScript(options.env)}
 ${options.script}
   } *>&1 | Add-OpenClawBackgroundLog
   Write-OpenClawUtf8File $exitPath '0'
@@ -709,14 +724,20 @@ Remove-Item -Path $runDir -Recurse -Force -ErrorAction SilentlyContinue`),
 export class LinuxGuest {
   private vmName: string;
   private phases: PhaseRunner;
+  private getEnv: () => Record<string, string>;
 
-  constructor(vmName: string, phases: PhaseRunner) {
+  constructor(vmName: string, phases: PhaseRunner, getEnv = () => ({})) {
     this.vmName = vmName;
     this.phases = phases;
+    this.getEnv = getEnv;
   }
 
-  exec(args: string[], options: GuestExecOptions = {}): string {
-    const result = run("prlctl", this.transportArgs(args), {
+  exec(args: string[], options: PosixGuestOptions = {}): string {
+    return this.run(args, options).stdout.trim();
+  }
+
+  run(args: string[], options: PosixGuestOptions = {}): CommandResult {
+    const result = run("prlctl", this.transportArgs(args, options.env), {
       check: false,
       input: options.input,
       quiet: true,
@@ -725,11 +746,17 @@ export class LinuxGuest {
     this.phases.append(result.stdout);
     this.phases.append(result.stderr);
     throwIfFailed("Linux guest command", result, options.check);
-    return result.stdout.trim();
+    return result;
   }
 
-  private transportArgs(args: string[]): string[] {
-    return ["exec", this.vmName, "/usr/bin/env", "HOME=/root", "OPENCLAW_ALLOW_ROOT=1", ...args];
+  private transportArgs(args: string[], env: Record<string, string> = {}): string[] {
+    const envArgs = Object.entries({
+      HOME: "/root",
+      OPENCLAW_ALLOW_ROOT: "1",
+      ...this.getEnv(),
+      ...env,
+    }).map(([key, value]) => `${key}=${value}`);
+    return ["exec", this.vmName, "/usr/bin/env", ...envArgs, ...args];
   }
 
   bash(script: string): string {
@@ -750,16 +777,13 @@ export class LinuxGuest {
   }
 }
 
-interface MacosGuestOptions extends GuestExecOptions {
-  env?: Record<string, string>;
-}
-
 type MacosGuestInput = {
   vmName: string;
   getUser: () => string;
   getTransport: () => "current-user" | "sudo";
   resolveDesktopHome: (user: string) => string;
   path: string;
+  getEnv?: () => Record<string, string>;
 };
 
 export class MacosGuest {
@@ -771,12 +795,12 @@ export class MacosGuest {
     this.phases = phases;
   }
 
-  exec(args: string[], options: MacosGuestOptions = {}): string {
+  exec(args: string[], options: PosixGuestOptions = {}): string {
     return this.run(args, options).stdout.trim();
   }
 
   private transportArgs(args: string[], env: Record<string, string> = {}): string[] {
-    const envArgs = Object.entries({ PATH: this.input.path, ...env }).map(
+    const envArgs = Object.entries({ PATH: this.input.path, ...this.input.getEnv?.(), ...env }).map(
       ([key, value]) => `${key}=${value}`,
     );
     const user = this.input.getUser();
@@ -798,7 +822,7 @@ export class MacosGuest {
       : ["exec", this.input.vmName, "--current-user", "/usr/bin/env", ...envArgs, ...args];
   }
 
-  run(args: string[], options: MacosGuestOptions = {}): CommandResult {
+  run(args: string[], options: PosixGuestOptions = {}): CommandResult {
     const result = run("prlctl", this.transportArgs(args, options.env), {
       check: false,
       input: options.input,
@@ -845,10 +869,12 @@ export class MacosGuest {
 export class WindowsGuest {
   private vmName: string;
   private phases: PhaseRunner;
+  private getEnv: () => Record<string, string>;
 
-  constructor(vmName: string, phases: PhaseRunner) {
+  constructor(vmName: string, phases: PhaseRunner, getEnv = () => ({})) {
     this.vmName = vmName;
     this.phases = phases;
+    this.getEnv = getEnv;
   }
 
   exec(args: string[], options: GuestExecOptions = {}): string {
@@ -886,7 +912,7 @@ export class WindowsGuest {
         encodePowerShell(writeScript),
       ],
       {
-        input: script,
+        input: `${windowsProcessEnvScript(this.getEnv())}\n${script}`,
         quiet: true,
         timeoutMs: this.phases.remainingTimeoutMs(120_000),
       },

--- a/scripts/e2e/parallels/linux-smoke.ts
+++ b/scripts/e2e/parallels/linux-smoke.ts
@@ -41,8 +41,10 @@ import {
   expectedPackageBuildCommit,
   expectedPackageTargetVersion,
   extractLastOpenClawVersion,
+  npmRegistryEnv,
   packAndServeSmokeArtifact,
   printSmokeTargetSummary,
+  posixStopGatewayScript,
   parseSmokeCliArgs,
   SmokeRunController,
   type SmokeCliOptions,
@@ -184,6 +186,7 @@ class LinuxSmoke extends SmokeRunController<LinuxOptions> {
   private snapshot!: SnapshotInfo;
   private phases!: PhaseRunner;
   private guest!: LinuxGuest;
+  private guestEnv: Record<string, string> = {};
 
   protected status = {
     daemon: "systemd-user-unavailable",
@@ -217,7 +220,7 @@ class LinuxSmoke extends SmokeRunController<LinuxOptions> {
       this.snapshot = shouldSkipSnapshotRestore()
         ? currentRunningSnapshotInfo(this.options.vmName)
         : resolveSnapshot(this.options.vmName, this.options.snapshotHint);
-      this.guest = new LinuxGuest(this.options.vmName, this.phases);
+      this.guest = new LinuxGuest(this.options.vmName, this.phases, () => this.guestEnv);
       this.latestVersion = resolveLatestVersion(this.options.latestVersion);
       await this.prepareHost(
         defaultOptions().hostPort,
@@ -232,6 +235,8 @@ class LinuxSmoke extends SmokeRunController<LinuxOptions> {
         this.hostIp,
         this.hostPort,
         this.artifactLabel(),
+        false,
+        this.options.provider,
       );
 
       await this.runLanesAndFinish();
@@ -354,6 +359,8 @@ printf 'preflight.npmRoot=%s\n' "$(npm root -g 2>/dev/null || true)"`);
   }
 
   private restoreSnapshot(): void {
+    // A restored baseline must resolve public packages, not the previous candidate registry.
+    this.guestEnv = {};
     if (shouldSkipSnapshotRestore()) {
       say(`Skip snapshot restore; using current running VM ${this.options.vmName}`);
       this.waitForGuestReady();
@@ -463,19 +470,10 @@ fi`);
     if (!this.artifact || !this.server) {
       die("package artifact/server missing");
     }
+    this.guestEnv = npmRegistryEnv(this.options.npmRegistry ?? this.server.registry?.url);
     const tgzUrl = this.server.urlFor(this.artifact.path);
     this.downloadGuestFile(tgzUrl, `/tmp/${tempName}`);
-    const npmArgs = ["npm", "install", "-g", `/tmp/${tempName}`, "--no-fund", "--no-audit"];
-    this.guestExec(
-      this.options.npmRegistry
-        ? [
-            "/usr/bin/env",
-            `NPM_CONFIG_REGISTRY=${this.options.npmRegistry}`,
-            `npm_config_registry=${this.options.npmRegistry}`,
-            ...npmArgs,
-          ]
-        : npmArgs,
-    );
+    this.guestExec(["npm", "install", "-g", `/tmp/${tempName}`, "--no-fund", "--no-audit"]);
     this.guestExec(["openclaw", "--version"]);
   }
 
@@ -614,17 +612,7 @@ setsid sh -lc ` +
     const args = help.includes("--require-rpc")
       ? ["openclaw", "gateway", "status", "--deep", "--require-rpc"]
       : ["openclaw", "gateway", "status", "--deep"];
-    const result = run(
-      "prlctl",
-      ["exec", this.options.vmName, "/usr/bin/env", "HOME=/root", "OPENCLAW_ALLOW_ROOT=1", ...args],
-      {
-        check: false,
-        quiet: true,
-        timeoutMs: this.remainingPhaseTimeoutMs(),
-      },
-    );
-    this.log(result.stdout);
-    this.log(result.stderr);
+    const result = this.guest.run(args, { check: false });
     if (check && result.status !== 0) {
       throw new Error("gateway status failed");
     }
@@ -633,26 +621,10 @@ setsid sh -lc ` +
 
   private verifyGatewayStatus(): void {
     for (let attempt = 1; attempt <= 8; attempt++) {
-      const result = run(
-        "prlctl",
-        [
-          "exec",
-          this.options.vmName,
-          "/usr/bin/env",
-          "HOME=/root",
-          "OPENCLAW_ALLOW_ROOT=1",
-          "openclaw",
-          "gateway",
-          "status",
-          "--deep",
-          "--require-rpc",
-          "--timeout",
-          "15000",
-        ],
-        { check: false, quiet: true, timeoutMs: this.remainingPhaseTimeoutMs() },
+      const result = this.guest.run(
+        ["openclaw", "gateway", "status", "--deep", "--require-rpc", "--timeout", "15000"],
+        { check: false },
       );
-      this.log(result.stdout);
-      this.log(result.stderr);
       if (result.status === 0) {
         return;
       }
@@ -710,6 +682,7 @@ rm -rf /root/.openclaw/test-bad-plugin`);
   }
 
   private verifyLocalTurn(): void {
+    this.guestBash(`set -euo pipefail\n${posixStopGatewayScript()}`);
     this.guestExec(["openclaw", "models", "set", this.auth.modelId]);
     const modelProviderConfigBatch = modelProviderConfigBatchJson(this.auth.modelId, "linux");
     if (modelProviderConfigBatch) {

--- a/scripts/e2e/parallels/macos-smoke.ts
+++ b/scripts/e2e/parallels/macos-smoke.ts
@@ -13,7 +13,6 @@ import {
   packageBuildCommitFromTgz,
   packageVersionFromTgz,
   parseMacosDsclUserHomeLine,
-  packOpenClaw,
   modelProviderConfigBatchJson,
   posixCodexPlatformPackageRepairFunction,
   posixProviderOnlyPluginIsolationScript,
@@ -30,7 +29,6 @@ import {
   shouldSkipSnapshotRestore,
   shellQuote,
   validateSnapshotRestoreMode,
-  startHostServer,
   warn,
   withProgressOnStderr,
   writeJson,
@@ -47,7 +45,13 @@ import { runSmokeLane, type SmokeLane, type SmokeLaneStatus } from "./lane-runne
 import { MacosDiscordSmoke } from "./macos-discord.ts";
 import { resolveMacosVmName, waitForVmStatus } from "./parallels-vm.ts";
 import { PhaseRunner } from "./phase-runner.ts";
-import { parseSmokeCliArgs, type SmokeCliOptions } from "./smoke-common.ts";
+import {
+  npmRegistryEnv,
+  packAndServeSmokeArtifact,
+  parseSmokeCliArgs,
+  posixStopGatewayScript,
+  type SmokeCliOptions,
+} from "./smoke-common.ts";
 
 interface MacosOptions extends SmokeCliOptions {
   vmNameExplicit: boolean;
@@ -189,6 +193,7 @@ class MacosSmoke {
   private snapshot!: SnapshotInfo;
   private phases!: PhaseRunner;
   private guest!: MacosGuest;
+  private guestEnv: Record<string, string> = {};
   private discord: MacosDiscordSmoke | null = null;
   private guestUser = "";
   private guestTransport: "current-user" | "sudo" = "current-user";
@@ -238,6 +243,7 @@ class MacosSmoke {
     this.guest = new MacosGuest(
       {
         getTransport: () => this.guestTransport,
+        getEnv: () => this.guestEnv,
         getUser: () => this.guestUser,
         path: guestPath,
         resolveDesktopHome: (user) => this.resolveDesktopHome(user),
@@ -274,23 +280,19 @@ class MacosSmoke {
           this.options.hostPortExplicit,
           defaultOptions().hostPort,
         );
-        this.artifact = await packOpenClaw({
-          destination: this.tgzDir,
-          packageSpec: this.options.targetPackageSpec,
-          requireControlUi: true,
-        });
+        [this.artifact, this.server, this.hostPort] = await packAndServeSmokeArtifact(
+          this.tgzDir,
+          this.options.targetPackageSpec,
+          this.hostIp,
+          this.hostPort,
+          this.artifactLabel(),
+          true,
+          this.options.provider,
+        );
         if (this.options.targetPackageSpec) {
           this.targetExpectVersion =
             this.artifact.version || (await packageVersionFromTgz(this.artifact.path));
         }
-        this.server = await startHostServer({
-          artifactPath: this.artifact.path,
-          dir: this.tgzDir,
-          hostIp: this.hostIp,
-          label: this.artifactLabel(),
-          port: this.hostPort,
-        });
-        this.hostPort = this.server.port;
       } else if (this.targetInstallsDirectly()) {
         this.targetExpectVersion = run(
           "npm",
@@ -642,6 +644,8 @@ exec node "$entry" ${argv}`,
   }
 
   private restoreSnapshot(): void {
+    // A restored baseline must resolve public packages, not the previous candidate registry.
+    this.guestEnv = {};
     if (shouldSkipSnapshotRestore()) {
       say(`Skip snapshot restore; using current running VM ${this.options.vmName}`);
       this.waitForCurrentUser();
@@ -734,14 +738,12 @@ ${guestOpenClaw} --version`,
   }
 
   private installMain(tempName: string): void {
-    const npmRegistryEnv = this.options.npmRegistry
-      ? `NPM_CONFIG_REGISTRY=${shellQuote(this.options.npmRegistry)} npm_config_registry=${shellQuote(this.options.npmRegistry)} `
-      : "";
+    this.guestEnv = npmRegistryEnv(this.options.npmRegistry ?? this.server?.registry?.url);
     if (this.targetInstallsDirectly()) {
       this
         .guestSh(`printf 'install-source: registry-spec %s\\n' ${shellQuote(this.options.targetPackageSpec || "")}
 for attempt in 1 2; do
-  if ${npmRegistryEnv}${guestNpm} install -g ${shellQuote(this.options.targetPackageSpec || "")}; then
+  if ${guestNpm} install -g ${shellQuote(this.options.targetPackageSpec || "")}; then
     break
   fi
   if [ "$attempt" -eq 2 ]; then
@@ -761,7 +763,7 @@ ${guestOpenClaw} --version`);
 curl -fsSL --connect-timeout 10 --max-time 120 --retry 2 --retry-delay 2 ${shellQuote(
       tgzUrl,
     )} -o /tmp/${tempName}
-${npmRegistryEnv}${guestNpm} install -g /tmp/${tempName}
+${guestNpm} install -g /tmp/${tempName}
 ${guestOpenClaw} --version`);
   }
 
@@ -958,29 +960,7 @@ sleep 1`,
   }
 
   private guestOpenClaw(args: string[], check: boolean): boolean {
-    const result = run(
-      "prlctl",
-      [
-        "exec",
-        this.options.vmName,
-        ...(this.guestTransport === "sudo"
-          ? [
-              "/usr/bin/sudo",
-              "-H",
-              "-u",
-              this.guestUser,
-              "/usr/bin/env",
-              `HOME=${this.guestHome()}`,
-              `PATH=${guestPath}`,
-            ]
-          : ["--current-user", "/usr/bin/env", `PATH=${guestPath}`]),
-        guestOpenClaw,
-        ...args,
-      ],
-      { check: false, quiet: true, timeoutMs: this.remainingPhaseTimeoutMs() },
-    );
-    this.log(result.stdout);
-    this.log(result.stderr);
+    const result = this.guest.run([guestOpenClaw, ...args], { check: false });
     if (check && result.status !== 0) {
       throw new Error(`openclaw ${args.join(" ")} failed`);
     }
@@ -1036,6 +1016,9 @@ exit 1`);
   }
 
   private verifyTurn(): void {
+    this.guestSh(
+      `set -euo pipefail\n${posixStopGatewayScript(this.guestTransport === "sudo" ? undefined : guestOpenClawEntryRunner)}`,
+    );
     this.guestOpenClawEntryExec(["models", "set", this.auth.modelId]);
     const modelProviderConfigBatch = modelProviderConfigBatchJson(
       this.auth.modelId,

--- a/scripts/e2e/parallels/npm-update-scripts.ts
+++ b/scripts/e2e/parallels/npm-update-scripts.ts
@@ -16,6 +16,7 @@ import {
   modelProviderConfigBatchJson,
   resolveParallelsModelTimeoutSeconds,
 } from "./provider-auth.ts";
+import { posixStopGatewayScript } from "./smoke-common.ts";
 import type { Platform, ProviderAuth } from "./types.ts";
 
 interface NpmUpdateScriptInput {
@@ -51,7 +52,8 @@ function posixNpmRegistryEnv(registry: string | undefined): string {
     return "";
   }
   const quoted = shellQuote(registry);
-  return `NPM_CONFIG_REGISTRY=${quoted} npm_config_registry=${quoted} `;
+  // The candidate registry must also serve plugins provisioned after the core swap.
+  return `export NPM_CONFIG_REGISTRY=${quoted} npm_config_registry=${quoted}\n`;
 }
 
 function posixModelProviderConfigCommands(
@@ -145,11 +147,11 @@ fi`;
 }
 
 function windowsUpdateWithScopedEnv(input: NpmUpdateScriptInput): string {
-  const registryEntry = input.npmRegistry
-    ? `; NPM_CONFIG_REGISTRY = ${psSingleQuote(input.npmRegistry)}`
+  const registryScript = input.npmRegistry
+    ? `$env:NPM_CONFIG_REGISTRY = ${psSingleQuote(input.npmRegistry)}\n`
     : "";
-  return `$script:OpenClawUpdateExit = 0
-$updateOutput = Invoke-WithScopedEnv @{ OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS = '1'${registryEntry} } {
+  return `${registryScript}$script:OpenClawUpdateExit = 0
+$updateOutput = Invoke-WithScopedEnv @{ OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS = '1' } {
   Invoke-OpenClaw update --tag ${psSingleQuote(input.updateTarget)} --yes --json --no-restart 2>&1
   $script:OpenClawUpdateExit = $LASTEXITCODE
 }
@@ -348,6 +350,7 @@ ${posixNpmRegistryEnv(input.npmRegistry)}OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE
 ${posixVersionCheck(macosOpenClawCommand, input.expectedNeedle)}
 start_openclaw_gateway
 wait_for_gateway
+${posixStopGatewayScript()}
 "$OPENCLAW_BIN" models set ${shellQuote(input.auth.modelId)}
 ${posixModelProviderConfigCommands(macosOpenClawCommand, input.auth.modelId, "macos")}
 "$OPENCLAW_BIN" config set agents.defaults.skipBootstrap true --strict-json
@@ -428,6 +431,7 @@ if ($updateExit -ne 0) {
 }
 ${windowsVersionCheck(input.expectedNeedle)}
 ${windowsGatewayReadyScript(input)}
+Stop-OpenClawGatewayProcesses
 ${windowsAssertAgentOkScript(input)}`;
 }
 
@@ -509,6 +513,7 @@ ${posixNpmRegistryEnv(input.npmRegistry)}OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE
 ${posixVersionCheck("openclaw", input.expectedNeedle)}
 start_openclaw_gateway
 wait_for_gateway
+${posixStopGatewayScript()}
 openclaw models set ${shellQuote(input.auth.modelId)}
 ${posixModelProviderConfigCommands("openclaw", input.auth.modelId, "linux")}
 openclaw config set agents.defaults.skipBootstrap true --strict-json

--- a/scripts/e2e/parallels/npm-update-smoke.ts
+++ b/scripts/e2e/parallels/npm-update-smoke.ts
@@ -15,6 +15,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
 import prettyMilliseconds from "pretty-ms";
 import { stripLeadingPackageManagerSeparator } from "../../lib/arg-utils.mts";
+import { resolveProviderConfig } from "../../lib/cross-os-release-checks/config.ts";
 import {
   die,
   ensureValue,
@@ -37,14 +38,11 @@ import {
   run,
   say,
   shellQuote,
-  startHostServer,
-  startNpmRegistryServer,
   withProgressOnStderr,
   writeSummaryMarkdown,
   writeJson,
   type HostServer,
   type NpmRegistryPackage,
-  type NpmRegistryServer,
   type PackageArtifact,
   type Platform,
   type Provider,
@@ -53,6 +51,7 @@ import {
 import { runWindowsBackgroundPowerShell } from "./guest-transports.ts";
 import { linuxUpdateScript, macosUpdateScript, windowsUpdateScript } from "./npm-update-scripts.ts";
 import { ensureVmRunning, resolveMacosVmName, resolveUbuntuVmName } from "./parallels-vm.ts";
+import { expectedPackageTargetVersion, startSmokeArtifactServer } from "./smoke-common.ts";
 import { runTimedUpdateJob } from "./update-job-timeout.ts";
 
 const LOGGED_PROCESS_TREE_EXIT_POLL_MS = 25;
@@ -66,6 +65,7 @@ interface NpmUpdateOptions {
   hostIp?: string;
   macosSnapshotHint?: string;
   macosVm?: string;
+  windowsVm?: string;
   packageSpec: string;
   targetTarball?: string;
   updateTarget: string;
@@ -140,7 +140,7 @@ interface NpmUpdateSummary {
 }
 
 const macosVmDefault = "macOS Tahoe";
-const windowsVm = "Windows 11";
+const windowsVmDefault = "Windows 11";
 const linuxVmDefault = "Ubuntu 26.04";
 
 function resolveRequiredTimerMs(timeoutMs: number): number {
@@ -399,6 +399,7 @@ Options:
   --platform <list>           Comma-separated platforms to run: all, macos, windows, linux.
                              Default: all
   --macos-vm <name>           Explicit Parallels macOS VM name.
+  --windows-vm <name>         Explicit Parallels Windows VM name.
   --macos-snapshot-hint <hint>
                              Snapshot name substring/fuzzy match passed to macOS fresh lanes.
   --provider <openai|anthropic|minimax>
@@ -422,6 +423,7 @@ export function parseArgs(argv: string[]): NpmUpdateOptions {
     json: false,
     macosSnapshotHint: undefined,
     macosVm: undefined,
+    windowsVm: undefined,
     modelId: undefined,
     packageSpec: "",
     targetTarball: undefined,
@@ -475,6 +477,10 @@ export function parseArgs(argv: string[]): NpmUpdateOptions {
         break;
       case "--macos-vm":
         options.macosVm = ensureValue(args, i, arg);
+        i++;
+        break;
+      case "--windows-vm":
+        options.windowsVm = ensureValue(args, i, arg);
         i++;
         break;
       case "--macos-snapshot-hint":
@@ -601,7 +607,6 @@ export class NpmUpdateSmoke {
   private harnessTargetFamily = "";
   private hostIp = "";
   protected server: HostServer | null = null;
-  private registryServer: NpmRegistryServer | null = null;
   private artifact: PackageArtifact | null = null;
   private freshTargetSpec = "";
   private startedAt = Date.now();
@@ -618,6 +623,7 @@ export class NpmUpdateSmoke {
   private targetRegistryHostUrl = "";
   private targetRegistryUrl = "";
   private macosVm = macosVmDefault;
+  private windowsVm: string;
   private linuxVm = linuxVmDefault;
   private options: NpmUpdateOptions;
 
@@ -629,6 +635,7 @@ export class NpmUpdateSmoke {
 
   constructor(options: NpmUpdateOptions) {
     this.options = options;
+    this.windowsVm = options.windowsVm ?? windowsVmDefault;
     this.auth = resolveProviderAuth({
       apiKeyEnv: options.apiKeyEnv,
       modelId: options.modelId,
@@ -649,7 +656,6 @@ export class NpmUpdateSmoke {
       await this.runSteps();
     } finally {
       await this.server?.stop().catch(() => undefined);
-      await this.registryServer?.stop().catch(() => undefined);
       await rm(this.tgzDir, { force: true, recursive: true }).catch(() => undefined);
     }
   }
@@ -710,7 +716,7 @@ export class NpmUpdateSmoke {
       jobs.push(this.spawnFresh("macOS", "macos", this.macosFreshArgs()));
     }
     if (this.options.platforms.has("windows")) {
-      jobs.push(this.spawnFresh("Windows", "windows", []));
+      jobs.push(this.spawnFresh("Windows", "windows", ["--vm", this.windowsVm]));
     }
     if (this.options.platforms.has("linux")) {
       jobs.push(
@@ -738,7 +744,14 @@ export class NpmUpdateSmoke {
     }
     if (this.options.platforms.has("windows")) {
       jobs.push(
-        this.spawnFresh("Windows", "windows", [], {}, this.freshTargetSpec, "fresh-target"),
+        this.spawnFresh(
+          "Windows",
+          "windows",
+          ["--vm", this.windowsVm],
+          {},
+          this.freshTargetSpec,
+          "fresh-target",
+        ),
       );
     }
     if (this.options.platforms.has("linux")) {
@@ -894,79 +907,54 @@ export class NpmUpdateSmoke {
         buildCommitShort: this.targetTarballBuildCommit.slice(0, 7),
         path: hostedTarballPath,
         version: this.targetTarballVersion,
+        registryPackages: [...this.targetDependencyPackages, ...this.targetRegistryPackages],
       };
-      if (this.targetDependencyPackages.length > 0 || this.targetRegistryPackages.length > 0) {
-        // Prepared sibling packages publish before core, so pre-publish VM installs need
-        // a local registry that serves the exact package set without touching public npm.
-        this.registryServer = await startNpmRegistryServer({
-          hostIp: this.hostIp,
-          packages: [
-            {
-              name: "openclaw",
-              version: this.targetTarballVersion,
-              tarballPath: hostedTarballPath,
-            },
-            ...this.targetDependencyPackages,
-            ...this.targetRegistryPackages,
-          ],
-        });
-        this.targetRegistryHostUrl = this.registryServer.hostUrl;
-        this.targetRegistryUrl = this.registryServer.url;
-        this.updateTargetTarball = `${this.registryServer.url}/openclaw/-/${path.basename(
-          hostedTarballPath,
-        )}`;
-        this.updateTargetEffective = this.targetTarballVersion;
-        this.freshTargetSpec = `openclaw@${this.targetTarballVersion}`;
-        this.updateExpectedNeedle = this.targetTarballVersion;
-        this.updateTargetPackageVersion = this.targetTarballVersion;
-        this.updateTargetBuildCommit = this.artifact.buildCommitShort ?? "";
-        return;
+    } else if (!this.options.updateTarget || this.options.updateTarget === "local-main") {
+      const providerConfig = resolveProviderConfig(this.options.provider);
+      if (!providerConfig) {
+        die(`missing release smoke configuration for provider: ${this.options.provider}`);
       }
-      this.server = await startHostServer({
-        artifactPath: this.artifact.path,
-        dir: this.tgzDir,
-        hostIp: this.hostIp,
-        label: "prepared candidate tgz",
-        port: 0,
-      });
-      const targetUrl = this.server.urlFor(this.artifact.path);
-      this.updateTargetEffective = targetUrl;
-      this.freshTargetSpec = targetUrl;
-      this.updateExpectedNeedle = this.targetTarballVersion;
-      this.updateTargetPackageVersion = this.targetTarballVersion;
-      this.updateTargetBuildCommit = this.artifact.buildCommitShort ?? "";
-      this.updateTargetTarball = targetUrl;
-      return;
-    }
-    if (!this.options.updateTarget || this.options.updateTarget === "local-main") {
       this.artifact = await packOpenClaw({
         destination: this.tgzDir,
         requireControlUi: true,
+        requiredCompanionPackages: providerConfig.requiredCompanionPackages,
       });
-      this.server = await startHostServer({
-        artifactPath: this.artifact.path,
-        dir: this.tgzDir,
-        hostIp: this.hostIp,
-        label: "current main tgz",
-        port: 0,
-      });
-      this.updateTargetEffective = this.server.urlFor(this.artifact.path);
-      this.updateExpectedNeedle = this.currentHeadShort;
-      this.updateTargetPackageVersion = this.artifact.version ?? "";
+    } else {
+      this.updateTargetEffective = this.options.updateTarget;
+      this.updateExpectedNeedle = this.isExplicitPackageTarget(this.updateTargetEffective)
+        ? ""
+        : resolveOpenClawRegistryVersion(this.updateTargetEffective) || this.updateTargetEffective;
+      const metadata = this.resolveRegistryPackageMetadata(this.updateTargetEffective);
+      this.updateTargetPackageVersion = metadata.version;
       this.updateTargetBuildCommit =
-        this.artifact.buildCommitShort ?? this.artifact.buildCommit ?? "";
-      this.updateTargetTarball = this.updateTargetEffective;
+        metadata.gitHead || this.resolvePackageBuildCommit(metadata.tarball);
+      this.updateTargetTarball = metadata.tarball;
       return;
     }
-    this.updateTargetEffective = this.options.updateTarget;
-    this.updateExpectedNeedle = this.isExplicitPackageTarget(this.updateTargetEffective)
-      ? ""
-      : resolveOpenClawRegistryVersion(this.updateTargetEffective) || this.updateTargetEffective;
-    const metadata = this.resolveRegistryPackageMetadata(this.updateTargetEffective);
-    this.updateTargetPackageVersion = metadata.version;
+    this.server = await startSmokeArtifactServer({
+      artifact: this.artifact,
+      dir: this.tgzDir,
+      hostIp: this.hostIp,
+      label: this.targetTarballPath ? "prepared candidate tgz" : "current main tgz",
+      port: 0,
+    });
+    this.targetRegistryHostUrl = this.server.registry?.hostUrl ?? "";
+    this.targetRegistryUrl = this.server.registry?.url ?? "";
+    this.updateTargetPackageVersion = await expectedPackageTargetVersion(this.artifact);
+    this.updateTargetTarball = this.server.urlFor(this.artifact.path);
+    this.updateTargetEffective = this.targetRegistryUrl
+      ? this.updateTargetPackageVersion
+      : this.updateTargetTarball;
+    if (this.targetTarballPath) {
+      this.freshTargetSpec = this.targetRegistryUrl
+        ? `openclaw@${this.updateTargetPackageVersion}`
+        : this.updateTargetTarball;
+    }
+    this.updateExpectedNeedle = this.targetTarballPath
+      ? this.targetTarballVersion
+      : this.currentHeadShort;
     this.updateTargetBuildCommit =
-      metadata.gitHead || this.resolvePackageBuildCommit(metadata.tarball);
-    this.updateTargetTarball = metadata.tarball;
+      this.artifact.buildCommitShort ?? this.artifact.buildCommit ?? "";
   }
 
   private resolvePackageBuildCommit(tarball: string): string {
@@ -1024,7 +1012,7 @@ export class NpmUpdateSmoke {
       jobs.push(this.spawnUpdate("macOS", "macos", (ctx) => this.runMacosUpdate(ctx)));
     }
     if (this.options.platforms.has("windows")) {
-      ensureVmRunning(windowsVm);
+      ensureVmRunning(this.windowsVm);
       jobs.push(this.spawnUpdate("Windows", "windows", (ctx) => this.runWindowsUpdate(ctx)));
     }
     if (this.options.platforms.has("linux")) {
@@ -1291,11 +1279,11 @@ export class NpmUpdateSmoke {
   ): Promise<void> {
     await runWindowsBackgroundPowerShell({
       append: (chunk) => ctx.append(chunk),
-      beforeLaunchAttempt: () => ensureVmRunning(windowsVm),
+      beforeLaunchAttempt: () => ensureVmRunning(this.windowsVm),
       label: "Windows update",
       script,
       timeoutMs,
-      vmName: windowsVm,
+      vmName: this.windowsVm,
     });
   }
 

--- a/scripts/e2e/parallels/package-artifact.ts
+++ b/scripts/e2e/parallels/package-artifact.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { resolveNpmJsonEntries } from "../../lib/npm-json-output.mts";
 import { sleep as delay } from "../../lib/sleep.mjs";
+import { createPrepublishPluginRegistryArtifact } from "../../prepublish-plugin-registry-artifact.mjs";
 import { readPositiveIntEnv } from "./env-limits.ts";
 import { exists, readJson } from "./filesystem.ts";
 import { die, repoRoot, run, say, sh } from "./host-command.ts";
@@ -137,6 +138,7 @@ export async function packOpenClaw(input: {
   destination: string;
   packageSpec?: string;
   requireControlUi?: boolean;
+  requiredCompanionPackages?: readonly string[];
 }): Promise<PackageArtifact> {
   await mkdir(input.destination, { recursive: true });
   if (input.packageSpec) {
@@ -193,8 +195,32 @@ export async function packOpenClaw(input: {
     if (!buildCommit) {
       die(`failed to read packed build commit from ${tgzPath}`);
     }
+    const version = await packageVersionFromTgz(tgzPath);
+    const registryDir = path.join(input.destination, "plugins");
+    // Source-built core and required official plugins must describe one exact
+    // checkout; the canonical artifact creator rejects dirty or mismatched sources.
+    const registry = input.requiredCompanionPackages?.length
+      ? createPrepublishPluginRegistryArtifact({
+          repoRoot,
+          outputDir: registryDir,
+          sourceSha: buildCommit,
+          candidateVersion: version,
+          requiredPackages: [...input.requiredCompanionPackages],
+        })
+      : undefined;
+    const registryPackages = registry?.manifest.packages.map((entry) => ({
+      name: entry.name,
+      version: entry.version,
+      tarballPath: path.join(registryDir, entry.tarball),
+    }));
     say(`Packed ${tgzPath}`);
-    return { buildCommit, buildCommitShort: buildCommit.slice(0, 7), path: tgzPath };
+    return {
+      buildCommit,
+      buildCommitShort: buildCommit.slice(0, 7),
+      path: tgzPath,
+      version,
+      registryPackages,
+    };
   });
 }
 

--- a/scripts/e2e/parallels/smoke-common.ts
+++ b/scripts/e2e/parallels/smoke-common.ts
@@ -2,10 +2,16 @@
 import { readFile, rm } from "node:fs/promises";
 import path from "node:path";
 import { stripLeadingPackageManagerSeparator } from "../../lib/arg-utils.mts";
+import { resolveProviderConfig } from "../../lib/cross-os-release-checks/config.ts";
 import { parseTcpPort } from "./env-limits.ts";
 import { extractLastOpenClawVersionFromLog } from "./filesystem.ts";
 import { run, say, die } from "./host-command.ts";
-import { resolveHostIp, resolveHostPort, startHostServer } from "./host-server.ts";
+import {
+  resolveHostIp,
+  resolveHostPort,
+  startHostServer,
+  startNpmRegistryServer,
+} from "./host-server.ts";
 import { runSmokeLane, type SmokeLane, type SmokeLaneStatus } from "./lane-runner.ts";
 import {
   packageBuildCommitFromTgz,
@@ -249,13 +255,38 @@ function logSmokeRunStart(input: {
   say(`Run logs: ${input.runDir}`);
 }
 
-async function startSmokeArtifactServer(input: {
+export function npmRegistryEnv(registry?: string): Record<string, string> {
+  return registry ? { NPM_CONFIG_REGISTRY: registry, npm_config_registry: registry } : {};
+}
+
+export function posixStopGatewayScript(managedCommand?: string): string {
+  // Embedded turns require exclusive state ownership. Unmanaged stop sends
+  // SIGTERM without waiting; Darwin pads the run loop's process title with spaces.
+  const stop = managedCommand
+    ? `gateway_stop_args=(gateway stop)
+if ${managedCommand} gateway stop --help | grep -Eq '^[[:space:]]+--force([[:space:]]|$)'; then
+  gateway_stop_args+=(--force)
+fi
+${managedCommand} "\${gateway_stop_args[@]}"`
+    : "pkill -f '^openclaw-gateway([[:space:]]|$)' || [ \"$?\" -eq 1 ]";
+  return `${stop}
+gateway_stop_deadline=$((SECONDS + 30))
+while pgrep -f '^openclaw-gateway([[:space:]]|$)' >/dev/null; do
+  if [ "$SECONDS" -ge "$gateway_stop_deadline" ]; then
+    echo "gateway did not release state ownership before the local agent turn" >&2
+    exit 1
+  fi
+  sleep 1
+done`;
+}
+
+export async function startSmokeArtifactServer(input: {
   artifact: PackageArtifact;
   dir: string;
   hostIp: string;
   label: string;
   port: number;
-}): Promise<{ hostPort: number; server: HostServer }> {
+}): Promise<HostServer> {
   const server = await startHostServer({
     artifactPath: input.artifact.path,
     dir: input.dir,
@@ -263,7 +294,36 @@ async function startSmokeArtifactServer(input: {
     label: input.label,
     port: input.port,
   });
-  return { hostPort: server.port, server };
+  if (!input.artifact.registryPackages?.length) {
+    return server;
+  }
+  try {
+    const registry = await startNpmRegistryServer({
+      hostIp: input.hostIp,
+      packages: [
+        {
+          name: "openclaw",
+          version: await expectedPackageTargetVersion(input.artifact),
+          tarballPath: input.artifact.path,
+        },
+        ...input.artifact.registryPackages,
+      ],
+    });
+    return {
+      ...server,
+      registry: { url: registry.url, hostUrl: registry.hostUrl },
+      stop: async () => {
+        try {
+          await server.stop();
+        } finally {
+          await registry.stop();
+        }
+      },
+    };
+  } catch (error) {
+    await server.stop().catch(() => undefined);
+    throw error;
+  }
 }
 
 export async function packAndServeSmokeArtifact(
@@ -272,12 +332,18 @@ export async function packAndServeSmokeArtifact(
   hostIp: string,
   hostPort: number,
   label: string,
-  requireControlUi = false,
+  requireControlUi: boolean,
+  provider: Provider,
 ): Promise<readonly [artifact: PackageArtifact, server: HostServer, hostPort: number]> {
+  const providerConfig = resolveProviderConfig(provider);
+  if (!providerConfig) {
+    die(`missing release smoke configuration for provider: ${provider}`);
+  }
   const artifact = await packOpenClaw({
     destination: tgzDir,
     packageSpec,
     requireControlUi,
+    requiredCompanionPackages: providerConfig.requiredCompanionPackages,
   });
   const server = await startSmokeArtifactServer({
     artifact,
@@ -286,7 +352,7 @@ export async function packAndServeSmokeArtifact(
     label,
     port: hostPort,
   });
-  return [artifact, server.server, server.hostPort];
+  return [artifact, server, server.port];
 }
 
 async function runRequestedSmokeLanes(input: {

--- a/scripts/e2e/parallels/types.ts
+++ b/scripts/e2e/parallels/types.ts
@@ -38,11 +38,13 @@ export interface PackageArtifact {
   version?: string;
   buildCommit?: string;
   buildCommitShort?: string;
+  registryPackages?: NpmRegistryPackage[];
 }
 
 export interface HostServer {
   hostIp: string;
   port: number;
+  registry?: Pick<NpmRegistryServer, "url" | "hostUrl">;
   urlFor(filePath: string): string;
   stop(): Promise<void>;
 }

--- a/scripts/e2e/parallels/windows-smoke.ts
+++ b/scripts/e2e/parallels/windows-smoke.ts
@@ -46,6 +46,7 @@ import {
   expectedPackageBuildCommit,
   expectedPackageTargetVersion,
   extractLastOpenClawVersion,
+  npmRegistryEnv,
   packAndServeSmokeArtifact,
   parseSmokeCliArgs,
   printSmokeTargetSummary,
@@ -178,6 +179,7 @@ class WindowsSmoke extends SmokeRunController<WindowsOptions> {
   private snapshot!: SnapshotInfo;
   private phases!: PhaseRunner;
   private guest!: WindowsGuest;
+  private guestEnv: Record<string, string> = {};
 
   protected status = {
     freshAgent: "skip",
@@ -204,7 +206,7 @@ class WindowsSmoke extends SmokeRunController<WindowsOptions> {
   async run(): Promise<void> {
     this.runDir = await makeTempDir("openclaw-parallels-windows.");
     this.phases = new PhaseRunner(this.runDir);
-    this.guest = new WindowsGuest(this.options.vmName, this.phases);
+    this.guest = new WindowsGuest(this.options.vmName, this.phases, () => this.guestEnv);
     this.tgzDir = await makeTempDir("openclaw-parallels-windows-tgz.");
     try {
       validateSnapshotRestoreMode(this.options.mode, "Windows smoke");
@@ -228,6 +230,8 @@ class WindowsSmoke extends SmokeRunController<WindowsOptions> {
           this.hostIp,
           this.hostPort,
           this.artifactLabel(),
+          false,
+          this.options.provider,
         );
       }
       if (!this.server) {
@@ -296,6 +300,9 @@ class WindowsSmoke extends SmokeRunController<WindowsOptions> {
     await this.phase("fresh.gateway-restart", 420, () => this.gatewayAction("restart"));
     await this.phase("fresh.gateway-status", 420, () => this.verifyGatewayReachable());
     this.status.freshGateway = "pass";
+    await this.phase("fresh.gateway-stop-before-local-agent", 420, () =>
+      this.gatewayAction("stop"),
+    );
     await this.phase("fresh.first-agent-turn", this.agentTimeoutSeconds, () => this.verifyTurn());
     this.status.freshAgent = "pass";
   }
@@ -352,6 +359,9 @@ class WindowsSmoke extends SmokeRunController<WindowsOptions> {
     await this.phase("upgrade.gateway-restart", 420, () => this.gatewayAction("restart"));
     await this.phase("upgrade.gateway-status", 420, () => this.verifyGatewayReachable());
     this.status.upgradeGateway = "pass";
+    await this.phase("upgrade.gateway-stop-before-local-agent", 420, () =>
+      this.gatewayAction("stop"),
+    );
     await this.phase("upgrade.first-agent-turn", this.agentTimeoutSeconds, () => this.verifyTurn());
     this.status.upgradeAgent = "pass";
   }
@@ -378,6 +388,8 @@ class WindowsSmoke extends SmokeRunController<WindowsOptions> {
   }
 
   private restoreSnapshot(): void {
+    // A restored baseline must resolve public packages, not the previous candidate registry.
+    this.guestEnv = {};
     if (shouldSkipSnapshotRestore()) {
       say(`Skip snapshot restore; using current running VM ${this.options.vmName}`);
       return;
@@ -488,16 +500,13 @@ Invoke-OpenClaw --version
     if (!this.artifact || !this.server) {
       die("package artifact/server missing");
     }
+    this.guestEnv = npmRegistryEnv(this.options.npmRegistry ?? this.server.registry?.url);
     const tgzUrl = this.server.urlFor(this.artifact.path);
-    const registryScript = this.options.npmRegistry
-      ? `$env:NPM_CONFIG_REGISTRY = ${psSingleQuote(this.options.npmRegistry)}`
-      : "";
     return this.guestPowerShellBackground(
       `install-main-${tempName.replaceAll(/[^A-Za-z0-9_-]/g, "-")}`,
       `$ErrorActionPreference = 'Stop'
 $tgz = Join-Path $env:TEMP ${psSingleQuote(tempName)}
 curl.exe -fsSL --connect-timeout 10 --max-time 120 --retry 2 --retry-delay 2 ${psSingleQuote(tgzUrl)} -o $tgz
-${registryScript}
 npm.cmd install -g $tgz --no-fund --no-audit --loglevel=error
 if ($LASTEXITCODE -ne 0) { throw "npm install failed with exit code $LASTEXITCODE" }
 Invoke-OpenClaw --version
@@ -569,6 +578,7 @@ ${this.windowsPluginIsolationScript()}`,
         this.waitForGuestReady(120);
       },
       label,
+      env: this.guestEnv,
       onLaunchRetry: warn,
       script: `${windowsOpenClawResolver}\n${script}`,
       timeoutMs: this.remainingPhaseTimeoutMs(timeoutMs) ?? timeoutMs,

--- a/scripts/e2e/parallels/windows-smoke.ts
+++ b/scripts/e2e/parallels/windows-smoke.ts
@@ -678,10 +678,11 @@ if ($LASTEXITCODE -ne 0) { throw "gateway ${action} failed with exit code $LASTE
     const start = Date.now();
     while (Date.now() < deadline) {
       const probe = this.guestPowerShell(
-        "Invoke-OpenClaw gateway probe --url ws://127.0.0.1:18789 --timeout 30000 --json",
+        "Invoke-OpenClaw gateway status --deep --require-rpc --timeout 30000 --json",
         { check: false, timeoutMs: 60_000 },
       );
-      if (/"ok"\s*:\s*true/.test(probe)) {
+      const status = JSON.parse(probe || "{}") as { rpc?: { ok?: boolean } };
+      if (status.rpc?.ok === true) {
         return;
       }
       if (!recoveryTried && Date.now() - start >= this.gatewayRecoveryAfterMs) {

--- a/scripts/prepublish-plugin-registry-artifact.mjs
+++ b/scripts/prepublish-plugin-registry-artifact.mjs
@@ -378,6 +378,7 @@ function main() {
 
 const isMain =
   process.argv[1] &&
+  fs.existsSync(process.argv[1]) &&
   fs.realpathSync(process.argv[1]) === fs.realpathSync(fileURLToPath(import.meta.url));
 if (isMain) {
   try {

--- a/test/scripts/parallels-npm-update-smoke.test.ts
+++ b/test/scripts/parallels-npm-update-smoke.test.ts
@@ -138,6 +138,45 @@ describe("parallels npm update smoke", () => {
     });
   });
 
+  it("accepts an explicit Windows VM at the aggregate CLI", () => {
+    const result = hostCommandRun(
+      process.execPath,
+      ["--import", "tsx", SCRIPT_PATH, "--windows-vm", "Windows Test Guest", "--help"],
+      { check: false, quiet: true },
+    );
+    expect(result.status, result.stderr).toBe(0);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "uses the selected Windows VM for same-guest update transport",
+    async () => {
+      const root = tempDirs.make("openclaw-parallels-windows-selection-");
+      const logPath = path.join(root, "prlctl.log");
+      const prlctlPath = path.join(root, "prlctl");
+      writeFileSync(
+        prlctlPath,
+        `#!/usr/bin/env bash\nprintf '%s|%s|%s\\n' "$1" "$2" "$3" >'${logPath}'\ncat >/dev/null\nexit 7\n`,
+      );
+      chmodSync(prlctlPath, 0o755);
+
+      await withEnvAsync(
+        { OPENAI_API_KEY: "test-key", PATH: `${root}${path.delimiter}${process.env.PATH ?? ""}` },
+        async () => {
+          const smoke = new NpmUpdateSmoke({ ...parseArgs([]), windowsVm: "Windows Test Guest" });
+          const guestWindows = Reflect.get(smoke, "guestWindows") as (
+            script: string,
+            timeoutMs: number,
+            ctx: { append: (chunk: string) => void },
+          ) => Promise<void>;
+          await expect(
+            guestWindows.call(smoke, "Write-Output update", 180_000, { append: () => undefined }),
+          ).rejects.toThrow("background script write failed");
+        },
+      );
+      expect(readFileSync(logPath, "utf8")).toBe("exec|Windows Test Guest|--current-user\n");
+    },
+  );
+
   it("stops the host artifact server when the wrapper fails mid-run", async () => {
     let stopCalls = 0;
     const server: HostServer = {
@@ -339,37 +378,93 @@ exit 1
     expect(script).toContain("freshTargetStatus");
   });
 
-  it("serves a prepared package set for both proof phases", () => {
-    const script = readFileSync(SCRIPT_PATH, "utf8");
+  it.runIf(process.platform !== "win32").each([
+    ["macos", macosUpdateScript],
+    ["linux", linuxUpdateScript],
+  ] as const)(
+    "keeps the %s candidate registry available through gateway shutdown and the local turn",
+    (platform, buildScript) => {
+      const root = tempDirs.make("openclaw-parallels-update-registry-");
+      const logPath = path.join(root, "registry.log");
+      const lifecycleLog = path.join(root, "lifecycle.log");
+      const gatewayOwner = path.join(root, "gateway-owner");
+      const gatewayTitle = platform === "macos" ? "openclaw-gateway        " : "openclaw-gateway";
+      const registry = "http://192.0.2.2:48123";
+      const script = buildScript({
+        auth: TEST_AUTH,
+        expectedNeedle: "2026.7.1-beta.3",
+        npmRegistry: registry,
+        updateTarget: "2026.7.1-beta.3",
+      }).replaceAll(
+        `/tmp/openclaw-parallels-${platform}-gateway.log`,
+        path.join(root, "gateway.log"),
+      );
+      const result = hostCommandRun(
+        "bash",
+        [
+          "-c",
+          `
+export HOME='${root}'
+unset OPENCLAW_WORKSPACE_DIR
+node() { cat >/dev/null; }
+python3() { cat >/dev/null; }
+function /usr/bin/env() { cat >/dev/null; }
+release_gateway_owner() {
+  if [ -f '${gatewayOwner}' ]; then
+    printf 'stop\\n' >>'${lifecycleLog}'
+    rm '${gatewayOwner}'
+  fi
+}
+pkill() {
+  if [ "$1" = '-f' ] && printf '%s\\n' '${gatewayTitle}' | grep -Eq "$2"; then
+    release_gateway_owner
+  else
+    return 1
+  fi
+}
+pgrep() { return 1; }
+lsof() { :; }
+sleep() { :; }
+setsid() { :; }
+openclaw() {
+  case "$1 \${2-}" in
+    "gateway stop")
+      if [[ " $* " == *" --help "* ]]; then echo '--force'; return 0; fi
+      release_gateway_owner
+      return 0 ;;
+    "gateway status")
+      touch '${gatewayOwner}'
+      printf 'ready\\n' >>'${lifecycleLog}' ;;
+    "agent --local")
+      if [ -f '${gatewayOwner}' ]; then echo 'gateway owns state' >&2; return 73; fi
+      printf 'local-turn\\n' >>'${lifecycleLog}'
+      echo '{"finalAssistantVisibleText":"OK"}' ;;
+    "gateway run"|"models set"|"config set") return 0 ;;
+  esac
+  printf '%s|%s|%s\\n' "$1" "\${NPM_CONFIG_REGISTRY-}" "\${npm_config_registry-}" >>'${logPath}'
+  case "$1" in
+    --version) echo 'OpenClaw 2026.7.1-beta.3' ;;
+  esac
+}
+${script}`,
+        ],
+        { check: false, quiet: true, timeoutMs: 5000 },
+      );
 
-    expect(script).toContain("--target-tarball <path>");
-    expect(script).toContain("--dependency-tarball <path>");
-    expect(script).toContain("--registry-package-tarball <path>");
-    expect(script).toContain('label: "prepared candidate tgz"');
-    expect(script).toContain("await copyFile(this.targetTarballPath, hostedTarballPath)");
-    expect(script).toContain("startNpmRegistryServer");
-    expect(script).toContain("...this.targetRegistryPackages");
-    expect(script).toContain("this.updateTargetEffective = this.targetTarballVersion");
-    expect(script).toContain("this.freshTargetSpec = `openclaw@${this.targetTarballVersion}`");
-    expect(script).toContain("NPM_CONFIG_REGISTRY: this.targetRegistryHostUrl");
-    expect(script).toContain("npm_config_registry: this.targetRegistryHostUrl");
-    expect(script).toContain("this.updateExpectedNeedle = this.targetTarballVersion");
-    expect(script).toContain('readPositiveIntEnv("OPENCLAW_PARALLELS_NPM_UPDATE_TIMEOUT_S", 2700)');
-  });
-
-  it("routes update installs through the prepared package registry", () => {
-    const registry = "http://192.0.2.2:48123";
-    const input = {
-      auth: TEST_AUTH,
-      expectedNeedle: "2026.7.1-beta.3",
-      npmRegistry: registry,
-      updateTarget: "2026.7.1-beta.3",
-    };
-
-    expect(macosUpdateScript(input)).toContain(`NPM_CONFIG_REGISTRY='${registry}'`);
-    expect(linuxUpdateScript(input)).toContain(`NPM_CONFIG_REGISTRY='${registry}'`);
-    expect(windowsUpdateScript(input)).toContain(`NPM_CONFIG_REGISTRY = '${registry}'`);
-  });
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(readFileSync(logPath, "utf8").trim().split("\n")).toEqual([
+        `update|${registry}|${registry}`,
+        `--version|${registry}|${registry}`,
+        `gateway|${registry}|${registry}`,
+        `agent|${registry}|${registry}`,
+      ]);
+      expect(readFileSync(lifecycleLog, "utf8").trim().split("\n")).toEqual([
+        "ready",
+        "stop",
+        "local-turn",
+      ]);
+    },
+  );
 
   it("restarts POSIX gateways only after an exact current-launch migration refusal", () => {
     const input = {

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -48,6 +48,7 @@ import {
 import {
   LinuxGuest,
   MacosGuest,
+  WindowsGuest,
   runPosixBackgroundShell,
   runWindowsBackgroundPowerShell,
 } from "../../scripts/e2e/parallels/guest-transports.ts";
@@ -499,6 +500,92 @@ describe("Parallels smoke model selection", () => {
     expect(controller).toContain("winget.exe download --source winget");
     expect(controller).toContain("OPENCLAW_PARALLELS_WINDOWS_LIBRARY_ONLY");
     expect(controller).not.toContain("openclaw-windows-node");
+  });
+
+  it.each([
+    ["ensure_node", "v24.14.0", "v24.15.0", true, 0],
+    ["ensure_node", "missing", "v24.15.0", true, 0],
+    ["ensure_node", "v24.15.0", "v24.15.0", false, 0],
+    ["ensure_node", "v24.14.0", "v24.14.0", true, 1],
+    ["verify_baseline", "v24.14.0", "v24.15.0", false, 1],
+    ["verify_baseline", "v24.15.0", "v24.15.0", false, 0],
+  ])(
+    "%s enforces the Windows Node contract from %s after installation of %s",
+    (command, initialVersion, installedVersion, installs, exitCode) => {
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `set -euo pipefail
+OPENCLAW_PARALLELS_WINDOWS_LIBRARY_ONLY=1 source "$1"
+guest_version="$3"
+guest_user_cmd() {
+  case "$1" in
+    'where node.exe') [[ "$guest_version" != missing ]] ;;
+    'node.exe --version') [[ "$guest_version" != missing ]] && printf '%s\\r\\n' "$guest_version" ;;
+    'git --version && node --version && npm --version'|'wsl.exe --version'|'wsl.exe --status') : ;;
+    *) printf 'unexpected guest command: %s\\n' "$1" >&2; return 1 ;;
+  esac
+}
+winget_download() { printf 'download=%s\\n' "$1"; WINGET_EXPECTED_HASH=fixture; }
+downloaded_installer() { printf 'node.msi'; }
+stage_installer() { printf 'staged-node.msi'; }
+finish_installer_reboot() { :; }
+wait_for_check() { guest_user_cmd "$2"; }
+set_guest_paths() { :; }
+guest_system_ps() { :; }
+get_wsl_default_version() { printf '2'; }
+assert_clean_product_state() { :; }
+assert_no_pending_reboot() { :; }
+installed_version="$4"
+run_windows_installer() { printf 'installed-node\\n'; guest_version="$installed_version"; }
+"$2"
+printf 'verified-node=%s\\n' "$guest_version"`,
+          "bash",
+          WINDOWS_PREPARE_WRAPPER,
+          command,
+          initialVersion,
+          installedVersion,
+        ],
+        { encoding: "utf8", timeout: 10_000 },
+      );
+
+      expect(result.status, result.stderr).toBe(exitCode);
+      expect(result.stdout.includes("installed-node")).toBe(installs);
+      if (installs) {
+        expect(result.stdout).toContain("download=OpenJS.NodeJS.LTS");
+      }
+      if (exitCode === 0) {
+        expect(result.stdout).toContain("verified-node=v24.15.0");
+      } else {
+        expect(result.stderr).toContain("upgrade Node");
+      }
+    },
+  );
+
+  it("waits for Windows snapshot restoration before starting the guest", () => {
+    const tempDir = makeTempDir(tempDirs, "openclaw-windows-restore-");
+    const statePath = join(tempDir, "state");
+    writeFileSync(statePath, "restoring");
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `set -euo pipefail
+OPENCLAW_PARALLELS_WINDOWS_LIBRARY_ONLY=1 source "$1"
+vm_state() { cat "$VM_STATE_FILE"; }
+sleep() { printf stopped >"$VM_STATE_FILE"; }
+run_bounded() { printf 'invoked=%s\\n' "$*"; }
+ensure_vm_running`,
+        "bash",
+        WINDOWS_PREPARE_WRAPPER,
+      ],
+      { encoding: "utf8", env: { ...process.env, VM_STATE_FILE: statePath }, timeout: 10_000 },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("Starting VM: Windows 11");
+    expect(readFileSync(statePath, "utf8")).toBe("stopped");
   });
 
   it("resets Linux product state before both install lanes", () => {
@@ -1721,6 +1808,54 @@ if (commandArgs[0] === "list") {
     expect(state.cleanupPayload).toContain('for child in $(/usr/bin/pgrep -P "$1"');
     expect(state.cleanupPayload).toContain('/bin/kill -TERM "$1"');
     expect(state.cleanupPayload).toContain('/bin/kill -KILL "$1"');
+  });
+
+  it("carries refreshed Windows guest environment into every PowerShell script", () => {
+    const tempDir = makeTempDir(tempDirs, "openclaw-parallels-windows-env-");
+    const scriptsPath = join(tempDir, "scripts.jsonl");
+    writeNodeFakePrlctl(
+      tempDir,
+      `if (args.includes("-EncodedCommand")) { const fs = process.getBuiltinModule("node:fs"); fs.appendFileSync(${JSON.stringify(scriptsPath)}, JSON.stringify(fs.readFileSync(0, "utf8")) + "\\n"); } process.exit(0);`,
+    );
+    let registry = "http://192.0.2.2:48123/first";
+    withEnv(fakePrlctlEnv(tempDir), () => {
+      const guest = new WindowsGuest("Windows VM", new PhaseRunner(tempDir), () => ({
+        NPM_CONFIG_REGISTRY: registry,
+      }));
+      guest.powershell("Write-Output $env:NPM_CONFIG_REGISTRY");
+      registry = "http://192.0.2.2:48123/second's";
+      guest.powershell("Write-Output $env:NPM_CONFIG_REGISTRY");
+    });
+
+    const scripts = readFileSync(scriptsPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as string);
+    expect(scripts).toEqual([
+      "Set-Item -LiteralPath 'Env:NPM_CONFIG_REGISTRY' -Value 'http://192.0.2.2:48123/first'\nWrite-Output $env:NPM_CONFIG_REGISTRY",
+      "Set-Item -LiteralPath 'Env:NPM_CONFIG_REGISTRY' -Value 'http://192.0.2.2:48123/second''s'\nWrite-Output $env:NPM_CONFIG_REGISTRY",
+    ]);
+  });
+
+  it("carries Windows background environment before the detached command", async () => {
+    let uploadedScript = "";
+    const runCommand = (_command: string, _args: string[], options?: { input?: string }) => {
+      uploadedScript = options?.input ?? "";
+      return { status: 1, stderr: "fixture upload failure", stdout: "" };
+    };
+    await expect(
+      runWindowsBackgroundPowerShell({
+        env: { NPM_CONFIG_REGISTRY: "http://192.0.2.2:48123/candidate's" },
+        label: "environment proof",
+        runCommand,
+        script: "Write-Output $env:NPM_CONFIG_REGISTRY",
+        timeoutMs: 720_000,
+        vmName: "Windows VM",
+      }),
+    ).rejects.toThrow("background script write failed");
+    expect(uploadedScript).toContain(
+      "Set-Item -LiteralPath 'Env:NPM_CONFIG_REGISTRY' -Value 'http://192.0.2.2:48123/candidate''s'\nWrite-Output $env:NPM_CONFIG_REGISTRY",
+    );
   });
 
   it("paces ambiguous Windows background launch materialization probes", async () => {

--- a/test/scripts/prepublish-plugin-registry-artifact.test.ts
+++ b/test/scripts/prepublish-plugin-registry-artifact.test.ts
@@ -3,7 +3,9 @@ import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as packageArtifact from "../../scripts/e2e/parallels/package-artifact.ts";
+import { packAndServeSmokeArtifact } from "../../scripts/e2e/parallels/smoke-common.ts";
 import { resolveCrossOsCompanionPackages } from "../../scripts/lib/cross-os-release-checks/companions.ts";
 import {
   PREPUBLISH_PLUGIN_REGISTRY_MANIFEST,
@@ -19,6 +21,7 @@ const SCRIPT = path.resolve("scripts/prepublish-plugin-registry-artifact.mjs");
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  vi.restoreAllMocks();
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { force: true, recursive: true });
   }
@@ -28,7 +31,7 @@ function sha256(file: string): string {
   return createHash("sha256").update(readFileSync(file)).digest("hex");
 }
 
-function fixture() {
+function fixture(packageName = PACKAGE_NAME) {
   const root = mkdtempSync(path.join(tmpdir(), "openclaw-prepublish-plugin-registry-"));
   tempDirs.push(root);
   const packageRoot = path.join(root, "package");
@@ -37,7 +40,7 @@ function fixture() {
   mkdirSync(artifactDir);
   writeFileSync(
     path.join(packageRoot, "package.json"),
-    `${JSON.stringify({ name: PACKAGE_NAME, version: VERSION })}\n`,
+    `${JSON.stringify({ name: packageName, version: VERSION })}\n`,
   );
   const tarballPath = path.join(artifactDir, TARBALL);
   execFileSync("tar", ["-czf", tarballPath, "-C", root, "package"]);
@@ -49,7 +52,7 @@ function fixture() {
     candidateVersion: VERSION,
     packages: [
       {
-        name: PACKAGE_NAME,
+        name: packageName,
         version: VERSION,
         tarball: TARBALL,
         sha256: sha256(tarballPath),
@@ -157,6 +160,54 @@ console.log("package manifest stdout");
 }
 
 describe("prepublish plugin registry artifact", () => {
+  it.runIf(process.platform !== "win32")(
+    "serves a Parallels candidate with its companion packages and closes both endpoints",
+    async () => {
+      const core = fixture("openclaw");
+      const companion = fixture();
+      vi.spyOn(packageArtifact, "packOpenClaw").mockResolvedValue({
+        path: core.tarballPath,
+        version: VERSION,
+        registryPackages: [
+          { name: PACKAGE_NAME, version: VERSION, tarballPath: companion.tarballPath },
+        ],
+      });
+      const [, server] = await packAndServeSmokeArtifact(
+        core.artifactDir,
+        undefined,
+        "127.0.0.1",
+        0,
+        "candidate fixture",
+        false,
+        "openai",
+      );
+      const staticUrl = server.urlFor(core.tarballPath);
+      let registryUrl = "";
+      try {
+        expect(server.registry).toBeDefined();
+        registryUrl = server.registry!.url;
+        for (const [name, tarball] of [
+          ["openclaw", core.tarballPath],
+          [PACKAGE_NAME, companion.tarballPath],
+        ] as const) {
+          const response = await fetch(`${registryUrl}/${encodeURIComponent(name)}`);
+          const metadata = await response.json();
+          expect(metadata.versions[VERSION]).toMatchObject({ name, version: VERSION });
+          const packed = await fetch(metadata.versions[VERSION].dist.tarball);
+          expect(Buffer.from(await packed.arrayBuffer())).toEqual(readFileSync(tarball));
+        }
+        expect(Buffer.from(await (await fetch(staticUrl)).arrayBuffer())).toEqual(
+          readFileSync(core.tarballPath),
+        );
+      } finally {
+        await server.stop();
+      }
+      for (const url of [staticUrl, registryUrl]) {
+        await expect(fetch(url, { signal: AbortSignal.timeout(1_000) })).rejects.toThrow();
+      }
+    },
+  );
+
   it("validates the immutable manifest, package set, hashes, and packed identity", () => {
     const paths = fixture();
     const result = validate(paths);

--- a/test/scripts/prepublish-plugin-registry-artifact.test.ts
+++ b/test/scripts/prepublish-plugin-registry-artifact.test.ts
@@ -1,8 +1,17 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as packageArtifact from "../../scripts/e2e/parallels/package-artifact.ts";
 import { packAndServeSmokeArtifact } from "../../scripts/e2e/parallels/smoke-common.ts";
@@ -160,6 +169,16 @@ console.log("package manifest stdout");
 }
 
 describe("prepublish plugin registry artifact", () => {
+  it("can be imported from stdin without running the CLI", () => {
+    const result = spawnSync(process.execPath, ["--input-type=module", "-"], {
+      input: `import { PREPUBLISH_PLUGIN_REGISTRY_MANIFEST } from ${JSON.stringify(pathToFileURL(SCRIPT).href)};\nconsole.log(PREPUBLISH_PLUGIN_REGISTRY_MANIFEST);\n`,
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(`${PREPUBLISH_PLUGIN_REGISTRY_MANIFEST}\n`);
+  });
+
   it.runIf(process.platform !== "win32")(
     "serves a Parallels candidate with its companion packages and closes both endpoints",
     async () => {
@@ -323,36 +342,43 @@ describe("prepublish plugin registry artifact", () => {
     ).toThrow("tracked changes");
   });
 
-  it("keeps noisy package commands off the CLI JSON stdout contract", () => {
-    const { repoRoot, sourceSha } = cliFixture();
-    const artifactDir = path.join(repoRoot, "artifact");
-    const result = spawnSync(
-      process.execPath,
-      [
-        SCRIPT,
-        "create",
-        "--repo-root",
-        repoRoot,
-        "--artifact-dir",
-        artifactDir,
-        "--source-sha",
-        sourceSha,
-        "--candidate-version",
-        VERSION,
-        "--required-packages-json",
-        JSON.stringify([PACKAGE_NAME]),
-      ],
-      { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-    );
+  it.each(process.platform === "win32" ? ["direct"] : ["direct", "symlink"])(
+    "keeps noisy package commands off the CLI JSON stdout contract (%s entrypoint)",
+    (entrypoint) => {
+      const { repoRoot, sourceSha } = cliFixture();
+      const artifactDir = path.join(repoRoot, "artifact");
+      const script = entrypoint === "symlink" ? path.join(repoRoot, "artifact-cli.mjs") : SCRIPT;
+      if (entrypoint === "symlink") {
+        symlinkSync(SCRIPT, script);
+      }
+      const result = spawnSync(
+        process.execPath,
+        [
+          script,
+          "create",
+          "--repo-root",
+          repoRoot,
+          "--artifact-dir",
+          artifactDir,
+          "--source-sha",
+          sourceSha,
+          "--candidate-version",
+          VERSION,
+          "--required-packages-json",
+          JSON.stringify([PACKAGE_NAME]),
+        ],
+        { cwd: repoRoot, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      );
 
-    expect(result.status).toBe(0);
-    expect(JSON.parse(result.stdout)).toMatchObject({
-      manifestSha256: expect.stringMatching(/^[0-9a-f]{64}$/u),
-      packages: [PACKAGE_NAME],
-    });
-    expect(result.stderr).toContain("runtime build stdout");
-    expect(result.stderr).toContain("package manifest stdout");
-  });
+      expect(result.status).toBe(0);
+      expect(JSON.parse(result.stdout)).toMatchObject({
+        manifestSha256: expect.stringMatching(/^[0-9a-f]{64}$/u),
+        packages: [PACKAGE_NAME],
+      });
+      expect(result.stderr).toContain("runtime build stdout");
+      expect(result.stderr).toContain("package manifest stdout");
+    },
+  );
 
   it("rejects traversal and duplicate package entries", () => {
     const traversal = fixture();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where maintainers running Parallels smoke tests against unpublished main could not complete fresh installation or the installed CLI's update flow. Required official plugins were missing from the candidate package set, the candidate registry disappeared before plugin provisioning finished, and local agent checks ran while a Gateway still owned the same state directory. Windows preparation also accepted an unsupported Node installation and the aggregate could not select a renamed Windows VM.

## Why This Change Was Made

Use the existing canonical prepublish artifact creator and provider companion-package requirements, then serve core and matching plugins through one shared artifact-server lifecycle. Carry registry settings through guest command environments until candidate verification finishes, clearing them when restoring a baseline; do not persist npmrc settings or relax clean-source/hash checks.

The harness now releases the Gateway it started before testing the explicitly local agent. Managed services use their existing stop command; manually started POSIX gateways are signaled and awaited, including Darwin's padded process title. The product's state ownership and unknown-service guards are unchanged. Windows readiness now uses the configured Gateway target and requires the authoritative RPC result, rather than overriding the URL without credentials or accepting socket connectivity alone. Windows preparation reuses the package's Node engine validator, waits for an in-progress snapshot restore, and the aggregate accepts `--windows-vm` throughout baseline, update, and fresh-target execution.

## User Impact

Maintainer test tooling only. No product runtime, public configuration, persistence, provider routing, or release publication changes. Removes duplicate package-server ownership and direct guest command paths. Tooling LOC: +298/-204 (net +94); tests: +371/-64 (net +307). Growth implements the missing package-set and process-lifecycle boundaries plus explicit Windows VM selection.

## Evidence

- Product under test: main `4b287caac326dd3a8b081754b61421cdb7120b98`, resolved at the start of the matrix; core and `@openclaw/codex` both version `2026.8.1`. Baseline: published `2026.7.1-2`.
- Captured pre-fix failures: real npm 404 for the missing matching Codex plugin; post-update registry loss; Node 24.14 rejected by package preinstall; snapshot state still `restoring`; unknown `--windows-vm`; local-agent state-lock refusal after successful Gateway RPC; Darwin process-title padding.
- All 185 tests across eight Parallels/prepublish suites pass. `node scripts/check-changed.mjs` for all changed files passes, including scripts/root-test type checks and scoped lint. Independent Codex autoreview reported no actionable blockers at its default P0 threshold. A subsequently discovered stdin-import failure is fixed at the canonical artifact creator entrypoint; its 13-test suite (including stdin and symlink CLI checks), changed-file gate, and independent review also pass.
- Real same-state macOS and Linux reproductions: Gateway RPC passed, the original local turn failed on state ownership, the repaired shutdown completed, and the same-state live model turn returned `OK`.
- macOS stable-to-dev internal update reached the pinned main commit, with onboarding, Gateway RPC, and dashboard HTML/assets passing; its initial final-agent failure was the lifecycle reproduction above. Update phase: 1,033.992 seconds.
- Corrected macOS and Linux fresh-baseline → internal updater → fresh-target flows all pass with live `OK` turns: macOS 693.343 seconds, Linux 588.4 seconds. Windows has passed its baseline and real internal update, including authenticated RPC and a live local turn. Cold fresh candidate passed in 510.5 seconds, and a same-state configured RPC canary verified authenticated operator.read access. The final official harness rerun on that guest also passed RPC, managed shutdown, and live local OK in 417.9 seconds; it deliberately skipped snapshot restore to exercise the revised check without repeating already-proven cold setup.

- The complete default package-and-serve path passed in a clean isolated checkout at `88da14d72b4d7f307bb8c0f790978707bc783252`: runtime and Control UI builds, automatic provider companion selection, canonical companion build, real HTTP metadata and exact tarball hashes, both endpoint shutdown, and clean Git status before/after. This proof is pinned to that source commit; later changes only remove unused exports and repair Windows readiness.
- CI caught two unused server re-exports; they were removed and the dependency gate passed on the next run. The Windows RPC follow-up passed an independent review and changed-file gates; the complete eight-suite run was repeated on the final source and passed all 185 tests in 27.38 seconds.

Related test fixture repair: #130638. Headless macOS service control intentionally cannot establish launchd ownership without a GUI session; this change preserves that fail-closed policy and manages only the harness-owned manual gateway.

Follow-up: separate immutable tooling SHA from artifact SHA in prepared-tarball summaries. `buildCommonSmokeSummary` currently falls back to checkout HEAD when the prepared artifact lacks cached build metadata, so a concurrent commit can change the summary identity after code was loaded. This run records the loaded tooling SHA, packaged build-info SHA, hashes, and rerun boundaries separately; no success claim relies on that fallback.

Final PR head `d97098ec4b8507bb98900a4512f2fdabea7fc949`: [exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33038524421). All 15 changed files match the locally tested source; the final complete-branch independent review is clean at the configured P0 threshold.

Diagnostics follow-up: retain a sanitized guest npm error-log tail before combined-mode snapshot reset. PowerShell can stop on npm's first native stderr line, and the next leg can discard the fuller guest log. The actual old-Node failure was preserved by a fresh-only reproduction; general error-log retention is separate from the repaired package/runtime prerequisites.
