### PR TITLE
fix(sandbox): retire plugin backends with registry lifecycle

### DIFF
--- a/extensions/mxc/src/plugin.ts
+++ b/extensions/mxc/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { OpenClawPluginApi, OpenClawPluginService } from "openclaw/plugin-sdk/plugin-entry";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { registerSandboxBackend } from "openclaw/plugin-sdk/sandbox";
 import { resolveMxcBinaryPath } from "./binary-resolver.js";
 import { resolveConfig } from "./config.js";
@@ -43,15 +43,16 @@ export function registerMxcPlugin(api: OpenClawPluginApi): void {
     manager: mxcSandboxBackendManager,
   });
 
-  // Cleanup service unregisters backend on shutdown.
-  const cleanupService: OpenClawPluginService = {
+  // Eager CLI registrations must retire even if Gateway services never start.
+  api.lifecycle.registerRuntimeLifecycle({
     id: "mxc-sandbox-cleanup",
-    start() {
-      /* no-op */
+    cleanup: ({ reason, sessionKey, runId }) => {
+      if (sessionKey !== undefined || runId !== undefined) {
+        return;
+      }
+      if (reason === "disable" || reason === "restart") {
+        unregister();
+      }
     },
-    stop() {
-      unregister();
-    },
-  };
-  api.registerService(cleanupService);
+  });
 }

--- a/extensions/mxc/test/plugin.test.ts
+++ b/extensions/mxc/test/plugin.test.ts
@@ -1,37 +1,40 @@
 import type {
   OpenClawPluginApi,
-  OpenClawPluginService,
-  OpenClawPluginServiceContext,
+  PluginRuntimeLifecycleRegistration,
 } from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { createPluginRegistryFixture } from "openclaw/plugin-sdk/plugin-test-contracts";
+import {
+  createEmptyPluginRegistry,
+  createPluginRecord,
+  getActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  getSandboxBackendFactory,
+  getSandboxBackendManager,
+  getSandboxBackendWorkdirResolver,
+} from "openclaw/plugin-sdk/sandbox";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const {
   assertMxcReadinessMock,
   warnMxcHostPrepIfNeededMock,
   createMxcSandboxBackendFactoryMock,
-  factoryMock,
   mxcSandboxBackendManagerMock,
-  registerSandboxBackendMock,
   resolveMxcBinaryPathMock,
-  unregisterMock,
 } = vi.hoisted(() => {
-  const factory = { id: "factory" };
-  const unregister = vi.fn();
   return {
     assertMxcReadinessMock: vi.fn(),
     warnMxcHostPrepIfNeededMock: vi.fn(),
-    createMxcSandboxBackendFactoryMock: vi.fn(() => factory),
-    factoryMock: factory,
-    mxcSandboxBackendManagerMock: { id: "manager" },
-    registerSandboxBackendMock: vi.fn(() => unregister),
+    createMxcSandboxBackendFactoryMock: vi.fn(() => async () => {
+      throw new Error("MXC provider must not run in registration tests");
+    }),
+    mxcSandboxBackendManagerMock: { describeRuntime: vi.fn(), removeRuntime: vi.fn() },
     resolveMxcBinaryPathMock: vi.fn(() => "mxc-test-binary"),
-    unregisterMock: unregister,
   };
 });
-
-vi.mock("openclaw/plugin-sdk/sandbox", () => ({
-  registerSandboxBackend: registerSandboxBackendMock,
-}));
 
 vi.mock("../src/binary-resolver.js", () => ({
   resolveMxcBinaryPath: resolveMxcBinaryPathMock,
@@ -54,10 +57,15 @@ import { registerMxcPlugin } from "../src/plugin.js";
 
 const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 
-type MxcPluginApiForTest = Pick<
-  OpenClawPluginApi,
-  "pluginConfig" | "registerService" | "registrationMode"
->;
+function readBackend() {
+  return {
+    factory: getSandboxBackendFactory("mxc"),
+    manager: getSandboxBackendManager("mxc"),
+    resolveWorkdir: getSandboxBackendWorkdirResolver("mxc"),
+  };
+}
+
+const stops: Array<() => Promise<void>> = [];
 
 const nonFullRegistrationModes = [
   "discovery",
@@ -84,26 +92,27 @@ function restoreProcessPlatformForTest(): void {
 function createApi(
   pluginConfig: Record<string, unknown> | undefined = {},
   registrationMode: OpenClawPluginApi["registrationMode"] = "full",
-): {
-  api: OpenClawPluginApi;
-  registerService: ReturnType<typeof vi.fn>;
-  services: OpenClawPluginService[];
-} {
-  const services: OpenClawPluginService[] = [];
-  const registerService = vi.fn((service: OpenClawPluginService): void => {
-    services.push(service);
-  });
-  const api = {
+) {
+  const lifecycles: PluginRuntimeLifecycleRegistration[] = [];
+  const registerService = vi.fn();
+  const api = createTestPluginApi({
+    id: "mxc",
     pluginConfig,
     registrationMode,
     registerService,
-  } satisfies MxcPluginApiForTest;
-
-  return {
-    api: api as unknown as OpenClawPluginApi,
-    registerService,
-    services,
+    registerRuntimeLifecycle: (lifecycle) => lifecycles.push(lifecycle),
+  });
+  const cleanup = async (
+    context: Parameters<NonNullable<PluginRuntimeLifecycleRegistration["cleanup"]>>[0],
+  ) => {
+    for (const lifecycle of lifecycles.toReversed()) {
+      await lifecycle.cleanup?.(context);
+    }
   };
+  const stop = () => cleanup({ reason: "disable" });
+  stops.push(stop);
+
+  return { api, registerService, lifecycles, cleanup, stop };
 }
 
 describe("registerMxcPlugin", () => {
@@ -113,22 +122,24 @@ describe("registerMxcPlugin", () => {
     assertMxcReadinessMock.mockClear();
     warnMxcHostPrepIfNeededMock.mockClear();
     createMxcSandboxBackendFactoryMock.mockClear();
-    registerSandboxBackendMock.mockClear();
     resolveMxcBinaryPathMock.mockReset();
     resolveMxcBinaryPathMock.mockReturnValue("mxc-test-binary");
-    unregisterMock.mockClear();
     setProcessPlatformForTest("win32");
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    for (const stop of stops.splice(0).toReversed()) {
+      await stop();
+    }
     warnSpy.mockRestore();
     restoreProcessPlatformForTest();
   });
 
   test("warns and stays dormant on non-Windows platforms", () => {
     setProcessPlatformForTest("darwin");
-    const { api, registerService } = createApi();
+    const original = readBackend();
+    const { api, registerService, lifecycles } = createApi();
 
     registerMxcPlugin(api);
 
@@ -137,14 +148,19 @@ describe("registerMxcPlugin", () => {
     );
     expect(resolveMxcBinaryPathMock).not.toHaveBeenCalled();
     expect(assertMxcReadinessMock).not.toHaveBeenCalled();
-    expect(registerSandboxBackendMock).not.toHaveBeenCalled();
+    expect(readBackend()).toEqual(original);
+    expect(lifecycles).toEqual([]);
     expect(registerService).not.toHaveBeenCalled();
   });
 
   test.each(nonFullRegistrationModes)(
     "does not register runtime hooks during %s registration",
     (registrationMode) => {
-      const { api, registerService } = createApi({ timeoutSeconds: 60 }, registrationMode);
+      const original = readBackend();
+      const { api, registerService, lifecycles } = createApi(
+        { timeoutSeconds: 60 },
+        registrationMode,
+      );
 
       registerMxcPlugin(api);
 
@@ -153,39 +169,114 @@ describe("registerMxcPlugin", () => {
       expect(assertMxcReadinessMock).not.toHaveBeenCalled();
       expect(warnMxcHostPrepIfNeededMock).not.toHaveBeenCalled();
       expect(createMxcSandboxBackendFactoryMock).not.toHaveBeenCalled();
-      expect(registerSandboxBackendMock).not.toHaveBeenCalled();
+      expect(readBackend()).toEqual(original);
+      expect(lifecycles).toEqual([]);
       expect(registerService).not.toHaveBeenCalled();
     },
   );
 
-  test("registers the sandbox backend on Windows when feature probes pass", () => {
-    const { api, services } = createApi({ timeoutSeconds: 60 });
+  test.each(["disable", "restart"] as const)(
+    "registers eagerly on Windows and restores hooks on global %s",
+    async (reason) => {
+      const original = readBackend();
+      const { api, cleanup, stop } = createApi({ timeoutSeconds: 60 });
 
-    registerMxcPlugin(api);
+      registerMxcPlugin(api);
 
-    expect(resolveMxcBinaryPathMock).toHaveBeenCalledWith(undefined);
-    expect(assertMxcReadinessMock).toHaveBeenCalledWith();
-    expect(warnMxcHostPrepIfNeededMock).toHaveBeenCalledWith();
-    expect(createMxcSandboxBackendFactoryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        timeoutSeconds: 60,
-      }),
-    );
-    expect(registerSandboxBackendMock).toHaveBeenCalledWith("mxc", {
-      factory: factoryMock,
-      manager: mxcSandboxBackendManagerMock,
-    });
-    expect(services).toHaveLength(1);
+      expect(resolveMxcBinaryPathMock).toHaveBeenCalledWith(undefined);
+      expect(assertMxcReadinessMock).toHaveBeenCalledWith();
+      expect(warnMxcHostPrepIfNeededMock).toHaveBeenCalledWith();
+      expect(createMxcSandboxBackendFactoryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          timeoutSeconds: 60,
+        }),
+      );
+      expect(readBackend()).toEqual({
+        factory: expect.any(Function),
+        manager: mxcSandboxBackendManagerMock,
+        resolveWorkdir: null,
+      });
+      await cleanup({ reason });
+      expect(readBackend()).toEqual(original);
+      await stop();
+      expect(readBackend()).toEqual(original);
+    },
+  );
 
-    void services[0]?.stop?.({} as OpenClawPluginServiceContext);
-    expect(unregisterMock).toHaveBeenCalledTimes(1);
+  test.each(["disable", "restart", "reset", "delete"] as const)(
+    "preserves backend hooks during scoped %s cleanup",
+    async (reason) => {
+      const generation = createApi();
+      registerMxcPlugin(generation.api);
+      const backend = readBackend();
+      for (const scope of [
+        { sessionKey: "agent:other:main" },
+        { runId: "other-run" },
+        { sessionKey: "" },
+        { runId: "" },
+      ]) {
+        await generation.cleanup({ reason, ...scope });
+        expect(readBackend()).toEqual(backend);
+      }
+      if (reason === "reset" || reason === "delete") {
+        await generation.cleanup({ reason });
+        expect(readBackend()).toEqual(backend);
+      }
+    },
+  );
+
+  test.each(["older-first", "newer-first"] as const)(
+    "preserves live registrations when generations retire %s",
+    async (order) => {
+      const original = readBackend();
+      const older = createApi();
+      registerMxcPlugin(older.api);
+      const olderBackend = readBackend();
+      const newer = createApi();
+      registerMxcPlugin(newer.api);
+      const newerBackend = readBackend();
+      expect(newerBackend.factory).not.toBe(olderBackend.factory);
+      const first = order === "older-first" ? older : newer;
+      const last = order === "older-first" ? newer : older;
+      await first.stop();
+      expect(readBackend()).toEqual(order === "older-first" ? newerBackend : olderBackend);
+      await last.stop();
+      expect(readBackend()).toEqual(original);
+      await first.stop();
+      expect(readBackend()).toEqual(original);
+    },
+  );
+
+  test("retires a registered backend even when no plugin services ever start", async () => {
+    const original = readBackend();
+    const originalRegistry = getActivePluginRegistry();
+    const { registry } = createPluginRegistryFixture();
+    const record = createPluginRecord({ id: "mxc" });
+    registry.registry.plugins.push(record);
+    registerMxcPlugin(registry.createApi(record, { config: {}, pluginConfig: {} }));
+    try {
+      expect(readBackend().factory).toEqual(expect.any(Function));
+      setActivePluginRegistry(registry.registry);
+      setActivePluginRegistry(createEmptyPluginRegistry());
+      await expect.poll(readBackend).toEqual(original);
+    } finally {
+      for (const { lifecycle } of registry.registry.runtimeLifecycles.toReversed()) {
+        await lifecycle.cleanup?.({ reason: "disable" });
+      }
+      if (originalRegistry) {
+        setActivePluginRegistry(originalRegistry);
+      } else {
+        resetPluginRuntimeStateForTest();
+      }
+    }
   });
 
   test("keeps the existing binary-resolution failure path after host support passes", () => {
     resolveMxcBinaryPathMock.mockImplementation(() => {
       throw new Error("missing binary");
     });
-    const { api, registerService } = createApi();
+    const original = readBackend();
+    const { api, registerService, lifecycles } = createApi();
 
     expect(() => registerMxcPlugin(api)).toThrow(
       "[mxc] MXC sandbox backend cannot load: missing binary. Install @microsoft/mxc-sdk or set mxcBinaryPath.",
@@ -193,7 +284,8 @@ describe("registerMxcPlugin", () => {
 
     expect(warnSpy).not.toHaveBeenCalled();
     expect(assertMxcReadinessMock).not.toHaveBeenCalled();
-    expect(registerSandboxBackendMock).not.toHaveBeenCalled();
+    expect(readBackend()).toEqual(original);
+    expect(lifecycles).toEqual([]);
     expect(registerService).not.toHaveBeenCalled();
   });
 });

--- a/extensions/openshell/index.test.ts
+++ b/extensions/openshell/index.test.ts
@@ -1,0 +1,126 @@
+import type {
+  OpenClawPluginApi,
+  OpenClawPluginService,
+  OpenClawPluginServiceContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import {
+  getSandboxBackendFactory,
+  getSandboxBackendManager,
+  getSandboxBackendWorkdirResolver,
+  type CreateSandboxBackendParams,
+} from "openclaw/plugin-sdk/sandbox";
+import { afterEach, describe, expect, it } from "vitest";
+import plugin from "./index.js";
+import { createOpenShellBackendSandboxConfig } from "./src/openshell.test-support.js";
+
+function readBackend() {
+  return {
+    factory: getSandboxBackendFactory("openshell"),
+    manager: getSandboxBackendManager("openshell"),
+    resolveWorkdir: getSandboxBackendWorkdirResolver("openshell"),
+  };
+}
+
+const workdirParams: CreateSandboxBackendParams = {
+  sessionKey: "agent:openshell-lifecycle:main",
+  scopeKey: "agent:openshell-lifecycle:main",
+  workspaceDir: "/tmp/openclaw-openshell-lifecycle/workspace",
+  agentWorkspaceDir: "/tmp/openclaw-openshell-lifecycle/workspace",
+  cfg: createOpenShellBackendSandboxConfig(),
+};
+
+describe("OpenShell plugin registration lifecycle", () => {
+  const stops: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    for (const stop of stops.splice(0).toReversed()) {
+      await stop();
+    }
+  });
+
+  async function registerGeneration(remoteWorkspaceDir: string) {
+    const services: OpenClawPluginService[] = [];
+    const api = createTestPluginApi({
+      id: "openshell",
+      pluginConfig: { remoteWorkspaceDir },
+      registerService: (service) => services.push(service),
+    });
+    const context: OpenClawPluginServiceContext = {
+      config: {},
+      stateDir: "/tmp/openclaw-openshell-lifecycle",
+      logger: api.logger,
+    };
+    plugin.register(api);
+    const stop = async () => {
+      for (const service of services.toReversed()) {
+        await service.stop?.(context);
+      }
+    };
+    stops.push(stop);
+    for (const service of services) {
+      await service.start(context);
+    }
+    return { backend: readBackend(), stop };
+  }
+
+  it("restores all backend hooks after each plugin generation stops", async () => {
+    const original = readBackend();
+    for (const remoteWorkspaceDir of ["/sandbox/first", "/sandbox/second", "/agent/third"]) {
+      const generation = await registerGeneration(remoteWorkspaceDir);
+      expect(generation.backend.factory).toEqual(expect.any(Function));
+      expect(generation.backend.manager).toEqual({
+        describeRuntime: expect.any(Function),
+        removeRuntime: expect.any(Function),
+      });
+      expect(generation.backend.resolveWorkdir?.(workdirParams)).toBe(remoteWorkspaceDir);
+
+      await generation.stop();
+      expect(readBackend()).toEqual(original);
+      await generation.stop();
+      expect(readBackend()).toEqual(original);
+    }
+  });
+
+  it.each(["older-first", "newer-first"] as const)(
+    "preserves the live backend when plugin generations stop %s",
+    async (order) => {
+      const original = readBackend();
+      const older = await registerGeneration("/sandbox/older");
+      const newer = await registerGeneration("/sandbox/newer");
+      expect(readBackend()).toEqual(newer.backend);
+
+      const first = order === "older-first" ? older : newer;
+      const last = order === "older-first" ? newer : older;
+      await first.stop();
+      expect(readBackend()).toEqual(last.backend);
+      await last.stop();
+      expect(readBackend()).toEqual(original);
+      await first.stop();
+      expect(readBackend()).toEqual(original);
+    },
+  );
+
+  it.each([
+    "discovery",
+    "tool-discovery",
+    "setup-only",
+    "setup-runtime",
+    "cli-metadata",
+  ] satisfies OpenClawPluginApi["registrationMode"][])(
+    "does not register runtime hooks or services in %s mode",
+    (registrationMode) => {
+      const original = readBackend();
+      const services: OpenClawPluginService[] = [];
+      plugin.register(
+        createTestPluginApi({
+          registrationMode,
+          pluginConfig: { remoteWorkspaceDir: "/outside-managed-roots" },
+          registerService: (service) => services.push(service),
+        }),
+      );
+      expect(services).toEqual([]);
+      expect(readBackend()).toEqual(original);
+    },
+  );
+});

--- a/extensions/openshell/index.test.ts
+++ b/extensions/openshell/index.test.ts
@@ -1,9 +1,17 @@
 import type {
   OpenClawPluginApi,
   OpenClawPluginService,
-  OpenClawPluginServiceContext,
+  PluginRuntimeLifecycleRegistration,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { createPluginRegistryFixture } from "openclaw/plugin-sdk/plugin-test-contracts";
+import {
+  createEmptyPluginRegistry,
+  createPluginRecord,
+  getActivePluginRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
 import {
   getSandboxBackendFactory,
   getSandboxBackendManager,
@@ -39,55 +47,73 @@ describe("OpenShell plugin registration lifecycle", () => {
     }
   });
 
-  async function registerGeneration(remoteWorkspaceDir: string) {
-    const services: OpenClawPluginService[] = [];
+  function registerGeneration(remoteWorkspaceDir: string) {
+    const lifecycles: PluginRuntimeLifecycleRegistration[] = [];
     const api = createTestPluginApi({
       id: "openshell",
       pluginConfig: { remoteWorkspaceDir },
-      registerService: (service) => services.push(service),
+      registerRuntimeLifecycle: (lifecycle) => lifecycles.push(lifecycle),
     });
-    const context: OpenClawPluginServiceContext = {
-      config: {},
-      stateDir: "/tmp/openclaw-openshell-lifecycle",
-      logger: api.logger,
-    };
     plugin.register(api);
-    const stop = async () => {
-      for (const service of services.toReversed()) {
-        await service.stop?.(context);
+    const cleanup = async (
+      context: Parameters<NonNullable<PluginRuntimeLifecycleRegistration["cleanup"]>>[0],
+    ) => {
+      for (const lifecycle of lifecycles.toReversed()) {
+        await lifecycle.cleanup?.(context);
       }
     };
+    const stop = () => cleanup({ reason: "disable" });
     stops.push(stop);
-    for (const service of services) {
-      await service.start(context);
-    }
-    return { backend: readBackend(), stop };
+    return { backend: readBackend(), cleanup, stop };
   }
 
-  it("restores all backend hooks after each plugin generation stops", async () => {
-    const original = readBackend();
-    for (const remoteWorkspaceDir of ["/sandbox/first", "/sandbox/second", "/agent/third"]) {
-      const generation = await registerGeneration(remoteWorkspaceDir);
-      expect(generation.backend.factory).toEqual(expect.any(Function));
-      expect(generation.backend.manager).toEqual({
-        describeRuntime: expect.any(Function),
-        removeRuntime: expect.any(Function),
-      });
-      expect(generation.backend.resolveWorkdir?.(workdirParams)).toBe(remoteWorkspaceDir);
+  it.each(["disable", "restart"] as const)(
+    "restores eager backend hooks on global %s",
+    async (reason) => {
+      const original = readBackend();
+      for (const remoteWorkspaceDir of ["/sandbox/first", "/sandbox/second", "/agent/third"]) {
+        const generation = registerGeneration(remoteWorkspaceDir);
+        expect(generation.backend.factory).toEqual(expect.any(Function));
+        expect(generation.backend.manager).toEqual({
+          describeRuntime: expect.any(Function),
+          removeRuntime: expect.any(Function),
+        });
+        expect(generation.backend.resolveWorkdir?.(workdirParams)).toBe(remoteWorkspaceDir);
 
-      await generation.stop();
-      expect(readBackend()).toEqual(original);
-      await generation.stop();
-      expect(readBackend()).toEqual(original);
-    }
-  });
+        await generation.cleanup({ reason });
+        expect(readBackend()).toEqual(original);
+        await generation.stop();
+        expect(readBackend()).toEqual(original);
+      }
+    },
+  );
+
+  it.each(["disable", "restart", "reset", "delete"] as const)(
+    "preserves global backend hooks during scoped %s cleanup",
+    async (reason) => {
+      const generation = registerGeneration("/sandbox/scoped");
+      for (const scope of [
+        { sessionKey: "agent:other:main" },
+        { runId: "other-run" },
+        { sessionKey: "" },
+        { runId: "" },
+      ]) {
+        await generation.cleanup({ reason, ...scope });
+        expect(readBackend()).toEqual(generation.backend);
+      }
+      if (reason === "reset" || reason === "delete") {
+        await generation.cleanup({ reason });
+        expect(readBackend()).toEqual(generation.backend);
+      }
+    },
+  );
 
   it.each(["older-first", "newer-first"] as const)(
     "preserves the live backend when plugin generations stop %s",
     async (order) => {
       const original = readBackend();
-      const older = await registerGeneration("/sandbox/older");
-      const newer = await registerGeneration("/sandbox/newer");
+      const older = registerGeneration("/sandbox/older");
+      const newer = registerGeneration("/sandbox/newer");
       expect(readBackend()).toEqual(newer.backend);
 
       const first = order === "older-first" ? older : newer;
@@ -112,15 +138,48 @@ describe("OpenShell plugin registration lifecycle", () => {
     (registrationMode) => {
       const original = readBackend();
       const services: OpenClawPluginService[] = [];
+      const lifecycles: PluginRuntimeLifecycleRegistration[] = [];
       plugin.register(
         createTestPluginApi({
           registrationMode,
           pluginConfig: { remoteWorkspaceDir: "/outside-managed-roots" },
           registerService: (service) => services.push(service),
+          registerRuntimeLifecycle: (lifecycle) => lifecycles.push(lifecycle),
         }),
       );
       expect(services).toEqual([]);
+      expect(lifecycles).toEqual([]);
       expect(readBackend()).toEqual(original);
     },
   );
+
+  it("retires a registered backend even when no plugin services ever start", async () => {
+    const originalBackend = readBackend();
+    const originalRegistry = getActivePluginRegistry();
+    const { registry } = createPluginRegistryFixture();
+    const record = createPluginRecord({ id: "openshell" });
+    registry.registry.plugins.push(record);
+    plugin.register(
+      registry.createApi(record, {
+        config: {},
+        pluginConfig: { remoteWorkspaceDir: "/sandbox/unstarted" },
+      }),
+    );
+    try {
+      expect(readBackend().factory).toEqual(expect.any(Function));
+      expect(readBackend().resolveWorkdir?.(workdirParams)).toBe("/sandbox/unstarted");
+      setActivePluginRegistry(registry.registry);
+      setActivePluginRegistry(createEmptyPluginRegistry());
+      await expect.poll(readBackend).toEqual(originalBackend);
+    } finally {
+      for (const { lifecycle } of registry.registry.runtimeLifecycles.toReversed()) {
+        await lifecycle.cleanup?.({ reason: "disable" });
+      }
+      if (originalRegistry) {
+        setActivePluginRegistry(originalRegistry);
+      } else {
+        resetPluginRuntimeStateForTest();
+      }
+    }
+  });
 });

--- a/extensions/openshell/index.ts
+++ b/extensions/openshell/index.ts
@@ -17,7 +17,7 @@ export default definePluginEntry({
       return;
     }
     const pluginConfig = resolveOpenShellPluginConfig(api.pluginConfig);
-    registerSandboxBackend("openshell", {
+    const unregister = registerSandboxBackend("openshell", {
       factory: createOpenShellSandboxBackendFactory({
         pluginConfig,
       }),
@@ -25,6 +25,11 @@ export default definePluginEntry({
         pluginConfig,
       }),
       resolveWorkdir: () => pluginConfig.remoteWorkspaceDir,
+    });
+    api.registerService({
+      id: "openshell-sandbox-cleanup",
+      start: () => {},
+      stop: unregister,
     });
   },
 });

--- a/extensions/openshell/index.ts
+++ b/extensions/openshell/index.ts
@@ -26,10 +26,17 @@ export default definePluginEntry({
       }),
       resolveWorkdir: () => pluginConfig.remoteWorkspaceDir,
     });
-    api.registerService({
+    // Eager CLI registrations must retire even if Gateway services never start.
+    api.lifecycle.registerRuntimeLifecycle({
       id: "openshell-sandbox-cleanup",
-      start: () => {},
-      stop: unregister,
+      cleanup: ({ reason, sessionKey, runId }) => {
+        if (sessionKey !== undefined || runId !== undefined) {
+          return;
+        }
+        if (reason === "disable" || reason === "restart") {
+          unregister();
+        }
+      },
     });
   },
 });


### PR DESCRIPTION
Follow-up to #130518, which separated built-in sandbox defaults from explicit backend registrations.

## What Problem This Solves

Fixes stale OpenShell and MXC sandbox backend registrations after their owning plugin registry retires. Gateway startup can be cancelled after eager plugin registration but before plugin services start; a service-only cleanup hook never runs in that case. The initial draft fixed normal OpenShell hot reload but missed this cancellation boundary.

## Why This Change Was Made

Both plugins now retain the existing backend disposer in the existing plugin-runtime lifecycle. Registry replacement and shutdown own cleanup independently of whether services ever started. The no-op cleanup services are removed, leaving one cleanup owner.

Registration stays eager because sandbox CLI commands load full plugins without starting Gateway services. Only unscoped plugin disable/restart retires the global backend; session/run cleanup and reset/delete leave it available. The core registry's generation-aware, idempotent disposer remains unchanged, so a late old cleanup cannot erase a newer backend.

No core SDK/API, configuration, storage, backend default, platform readiness, or provider transport change is introduced. Production LOC is +24/-11 (net +13); the growth retains OpenShell's previously discarded disposer and expresses the necessary global-versus-scoped cleanup boundary in both plugins. Tests add a net 277 lines.

## User Impact

OpenShell and MXC backend availability follows the active plugin generation, including interrupted startup. Retired registrations cannot remain available after disable or reappear when later generations retire. CLI backend discovery remains available before service startup.

Release-note intent: fix stale OpenShell/MXC sandbox backend availability after plugin disable, reload, or cancelled startup. This does not revoke already-created backend handles or change sandbox execution.

## Evidence

Both new native public-SDK registry-retirement regressions failed before the runtime-owner correction and passed afterward. They register the real plugin API and retire the actual registry without ever starting services. OpenShell covers factory, manager, and workdir hooks; MXC covers factory/manager and its absent workdir hook. Entry tests also cover eager availability, global disable/restart, scoped cleanup for all four reasons including defined empty IDs, repeated disposal, both stale-generation orders, non-full modes, and MXC platform/binary-failure controls.

Final local tests pass: 110 OpenShell tests across seven files, 66 MXC tests across nine passing files, and 13 core sandbox-registry ownership tests. MXC's 56 Windows-only tests are skipped on this macOS host and are not counted as Windows proof. Tests use the repository wrapper, one worker, and this checkout's own frozen-lockfile dependencies. The full changed-file typecheck/lint/guard gate passes, including zero runtime import cycles. The fresh isolated Codex P0–P2 review reports no actionable findings.

The corrected candidate `aa0f5049aebd7e718369235866098e0c3123e8f8` passes the canonical full build (8m23s), including all 63 external plugin local-dist builds and the existing UI performance budget. Actual compiled Gateway testing passes the complete same-boot enabled/disabled/re-enabled/workdir-change/disabled cycle. A fresh disabled Gateway exposes no hooks. Both owned processes exit normally and their ports close; all 11,784 compiled files and dependency identities remain unchanged. This run uses Node 24.20.0.

The separately reproduced cancellation gap also passes against this exact compiled candidate: the real loader eagerly registers all hooks, the real startup owner is cancelled before services start, and normal registry clear removes all hooks. Require-factory then reports not registered, and repeated clear remains safe. No provider command is invoked. The old failing pre-service cancellation receipt is preserved; a normal reload-only result is not substituted for this boundary.

Native Windows registration validation passes all 16 MXC entry tests on Node 24.20.0 / pnpm 11.22.0, from an exact-head fresh checkout and frozen lockfile on Azure Crabbox (`run_819c6e85bd20`). Readiness, binary resolution, and backend factories are declared test fixtures. The machine has no IsoEnvBroker service, so compiled MXC/container execution was not run. The run exited 0 and its lease was released. Earlier launcher failures occurred before product tests and are not counted as proof.

Exact-head hosted [CI run 33105489824](https://github.com/openclaw/openclaw/actions/runs/33105489824) is green, including `openclaw/ci-gate`: 33 successful jobs, 20 path-selected skips, no failures. The earlier automated cancellation finding is addressed by the runtime-owner correction and the actual compiled cancellation regression. No earlier draft-skipped CI is counted as validation.

Proof scope is plugin registration lifecycle, not authenticated OpenShell/MXC provider execution, Windows container execution, existing-handle revocation, or managed plugin installation. Both plugins remain external packages; compiled local proof must use the canonical external-plugin local-dist build output and its declared dependencies, not a copied source plugin.
