### PR TITLE
docs: document model-not-found fallback

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -257,7 +257,7 @@ Overloaded and rate-limit errors are handled more aggressively than billing cool
 
 ## Model fallback
 
-If all profiles for a provider fail, OpenClaw moves to the next model in `agents.defaults.model.fallbacks`. This applies to auth failures, rate limits, and timeouts that exhausted profile rotation (other errors do not advance fallback). Provider errors that do not expose enough detail are still labeled precisely in fallback state: `empty_response` means the provider returned no usable message or status, `no_error_details` means the provider explicitly returned `Unknown error (no error details in response)`, and `unclassified` means OpenClaw preserved the raw preview but no classifier matched it yet.
+If all profiles for a provider fail, OpenClaw moves to the next model in `agents.defaults.model.fallbacks` when the failure matches one of the failover reasons listed below. This includes `model_not_found` for HTTP 404 responses unless the response body identifies a more specific condition such as context overflow, session expiry, billing, authentication, or request format. Provider errors that do not expose enough detail are still labeled precisely in fallback state: `empty_response` means the provider returned no usable message or status, `no_error_details` means the provider explicitly returned `Unknown error (no error details in response)`, and `unclassified` means OpenClaw preserved the raw preview but no classifier matched it yet.
 
 Provider-busy signals such as `ModelNotReadyException` land in the overloaded bucket and follow the same one-rotation-then-fallback policy as rate limits (see the defaults table above).
 
@@ -290,6 +290,7 @@ OpenClaw builds the candidate list from the currently requested `provider/model`
     - overloaded/provider-busy errors
     - timeout-shaped failover errors
     - billing disables
+    - `model_not_found`, including eligible HTTP 404 responses
     - `LiveSessionModelSwitchError` for a stale current or earlier candidate; later configured targets redirect directly, while targets outside the chain return to the bounded session-model retry owner
     - other unrecognized errors when there are still remaining candidates
 
@@ -347,6 +348,8 @@ The active run carries its chosen candidate directly. Live reconciliation change
 - human-readable error summary
 
 Structured `model_fallback_decision` logs also include flat `fallbackStep*` fields when a candidate fails, is skipped, or a later fallback succeeds. These fields make the attempted transition explicit (`fallbackStepFromModel`, `fallbackStepToModel`, `fallbackStepFromFailureReason`, `fallbackStepFromFailureDetail`, `fallbackStepFinalOutcome`) so log and diagnostic exporters can reconstruct the primary failure even when the terminal fallback also fails.
+
+For a missing-model fallback, look for a `model_fallback_decision` event whose `reason` or `fallbackStepFromFailureReason` is `model_not_found`.
 
 When every candidate fails, OpenClaw throws `FailoverError` with structured attempt records. The outer reply runner can use those records to build a more specific message such as "all models are temporarily rate-limited" and include the soonest cooldown expiry when one is known.
 


### PR DESCRIPTION
## What Problem This Solves

The model-failover guide says that errors outside authentication, rate limits, and timeouts do not advance fallback. Eligible `model_not_found` failures already do, so that sentence can send operators toward unnecessary external probing or model-swapping workarounds.

Fixes #130256.

## Why This Change Was Made

Document the existing classifier and fallback policy in the canonical guide: eligible HTTP 404 responses become `model_not_found` after preserving more-specific error classifications. Add that reason to the trigger list and point operators to the existing `model_fallback_decision` fields used to diagnose the transition.

## User Impact

Operators can recognize an existing missing-model fallback and find its recorded reason. Runtime behavior and configuration are unchanged. Docs +4/-1; production and tests +0/-0.

## Evidence

The complete classifier, error normalization, fallback runner, policy, and observation owners were reviewed against main, along with the configured-fallback/no-fallback policy cases and missing-model warning coverage. Stable `v2026.8.1` contains the same HTTP 404 exception branch.

At head `07539fe0197902f75abc3aba81f1fd9238707ddb`, trusted main tooling parsed the actual changed page as MDX and passed its formatter check; the complete PR diff passed `git diff --check`. Independent Codex review of the complete candidate found no P0 defects. No links, headings, or executable examples changed. No fork scripts or configuration were executed. The author previously reported 47 passing focused policy tests; that runtime test run is attributed evidence, not a new maintainer run.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33040272664) passed, including the documentation check. The observed retired-model transition in the linked issue is reporter evidence; this documentation-only change does not require another provider call.

Thanks @MonkeyLeeT.
