### PR TITLE
fix(ui): prevent encoded-path readiness timeouts

### DIFF
--- a/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
+++ b/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
@@ -3,7 +3,12 @@ import path from "node:path";
 import { expect, it } from "vitest";
 import { decodeResumeHandoff } from "../../../src/shared/resume-handoff.js";
 import type { ChatPaneElement } from "../pages/chat/route-draft-focus-handoff.ts";
-import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import {
+  controlUiSessionPath,
+  controlUiSessionUrl,
+  installMockGateway,
+  waitForControlUiRoute,
+} from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -100,6 +105,13 @@ suite.define(() => {
         await expect
           .poll(() => activePane.evaluate((pane) => (pane as ChatPaneElement).sessionKey))
           .toBe(sessionKey);
+        await waitForControlUiRoute(page, {
+          routeId: "chat",
+          pathname: controlUiSessionPath(sessionKey, basePath),
+          pathnamePrefix: `${basePath}/chat/`,
+          search: "",
+          hash: "",
+        });
         await activePane.getByText("Ready for terminal continuation.").waitFor({ timeout: 10_000 });
 
         const menuTrigger = activePane.getByRole("button", {
@@ -182,6 +194,7 @@ suite.define(() => {
         await expect
           .poll(() => activePane.evaluate((pane) => (pane as ChatPaneElement).sessionKey))
           .toBe(sessionKey);
+        await waitForControlUiRoute(page, { routeId: "chat" });
         await activePane
           .getByRole("paragraph")
           .filter({ hasText: /^Mobile session menu proof\.$/ })

--- a/ui/src/e2e/control-ui-route-readiness.e2e.test.ts
+++ b/ui/src/e2e/control-ui-route-readiness.e2e.test.ts
@@ -1,0 +1,44 @@
+import { expect, it } from "vitest";
+import type { ChatPaneElement } from "../pages/chat/route-draft-focus-handoff.ts";
+import {
+  controlUiSessionUrl,
+  installMockGateway,
+  navigateToControlUiSession,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Control UI route readiness" });
+
+suite.define(() => {
+  it.each([
+    { name: "root", basePath: "" },
+    { name: "encoded mount", basePath: "/nested/$&;=()+,![]{}'`/%25PATH%25" },
+  ])("navigates exact session keys at the $name", async ({ basePath }) => {
+    await suite.withPage({ viewport: { width: 1200, height: 800 } }, async ({ page }) => {
+      const initialSessionKey = "agent:runner:route:initial";
+      await installMockGateway(page, { basePath, sessionKey: initialSessionKey });
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, initialSessionKey));
+      const visiblePane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--visible");
+      await expect
+        .poll(() => visiblePane.evaluate((pane) => (pane as ChatPaneElement).sessionKey))
+        .toBe(initialSessionKey);
+
+      const mountUrl = new URL(suite.server.baseUrl);
+      mountUrl.pathname = basePath || "/";
+      const encodedBase = basePath ? mountUrl.pathname : "";
+      for (const [rest, suffix] of [
+        ["a/b", "a%2Fb"],
+        ["a:b", "a/b"],
+        ["%2F%25%3F%23", "%252F%2525%253F%2523"],
+        ["a?b#c", "a%3Fb%23c"],
+      ]) {
+        const sessionKey = `agent:runner:route:${rest}`;
+        await navigateToControlUiSession(page, sessionKey);
+        expect(new URL(page.url()).pathname).toBe(`${encodedBase}/chat/runner/route/${suffix}`);
+        expect(await visiblePane.evaluate((pane) => (pane as ChatPaneElement).sessionKey)).toBe(
+          sessionKey,
+        );
+      }
+    });
+  });
+});

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -34,10 +34,11 @@ export function controlUiSessionUrl(baseUrl: string, sessionKey: string): string
 }
 
 export async function navigateToControlUiSession(page: Page, sessionKey: string): Promise<void> {
-  await page.evaluate((pathname) => {
+  const expectedPathname = await page.evaluate((sessionPath) => {
     const app = document.querySelector("openclaw-app") as HTMLElement & {
       runtime?: {
         context: {
+          basePath: string;
           navigate: (routeId: string, options: { pathname: string }) => void;
         };
       };
@@ -45,9 +46,13 @@ export async function navigateToControlUiSession(page: Page, sessionKey: string)
     if (!app.runtime) {
       throw new Error("OpenClaw application runtime is unavailable");
     }
+    const pathname = `${app.runtime.context.basePath}${sessionPath}`;
+    const url = new URL(window.location.href);
+    url.pathname = pathname;
     app.runtime.context.navigate("chat", { pathname });
+    return url.pathname;
   }, controlUiSessionPath(sessionKey));
-  await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey));
+  await page.waitForURL((url) => url.pathname === expectedPathname);
   await page.waitForFunction(
     (targetSessionKey) =>
       [...document.querySelectorAll<HTMLElement>("openclaw-chat-pane")].some(
@@ -109,13 +114,22 @@ export async function waitForControlUiRoute(page: Page, target: ControlUiRouteTa
         };
         const state = app.runtime?.router.getState();
         const pathname = window.location.pathname;
+        // Router paths retain literal characters that browser history percent-encodes.
+        // Serialize as a pathname; decoding would alias encoded delimiters and percent data.
+        const browserPathname = (value: string) => {
+          const url = new URL(window.location.href);
+          url.pathname = value;
+          return url.pathname;
+        };
         return (
           state?.status === "success" &&
           state.matches[0]?.routeId === expected.routeId &&
-          state.resolvedLocation?.pathname === pathname &&
+          state.resolvedLocation !== null &&
+          browserPathname(state.resolvedLocation.pathname) === pathname &&
           state.pendingMatches.length === 0 &&
-          (expected.pathname === undefined || pathname === expected.pathname) &&
-          (expected.pathnamePrefix === undefined || pathname.startsWith(expected.pathnamePrefix)) &&
+          (expected.pathname === undefined || pathname === browserPathname(expected.pathname)) &&
+          (expected.pathnamePrefix === undefined ||
+            pathname.startsWith(browserPathname(expected.pathnamePrefix))) &&
           (expected.search === undefined || window.location.search === expected.search) &&
           (expected.hash === undefined || window.location.hash === expected.hash)
         );


### PR DESCRIPTION
Related: #129933 (sidebar dashboard badge sizing; its CI repair exposed this separate shared-helper defect).

<details>
<summary>Additional instructions</summary>

This is a same-repository, maintainer-editable branch.

</details>

## What Problem This Solves

Resolves a problem where Control UI end-to-end tests time out waiting for an already-settled route when the configured mount path contains punctuation that browser history percent-encodes. The original desktop and mobile terminal-continuation fixtures both reproduced the failure even though the router reported `success`, matched `chat`, and had no pending matches.

The sibling session-navigation helper also omitted the configured mount path, so switching sessions under a nested mount could wait on a pane the requested navigation never reached.

## Why This Change Was Made

Serialize router and expected pathnames through the native `URL.pathname` setter before comparing them with the browser pathname. This uses the browser's encoding contract without decoding percent escapes or conflating encoded delimiters with path separators. Session navigation now includes the runtime-owned base path and compares the same serialized pathname.

All route/status/resolved-location/pending/search/hash checks and the existing visible/active-pane ownership waits remain intact. This does not alter production routing, add test-only production seams, increase timeouts, or bypass browser actionability.

## User Impact

No production or visual UI change. Developers can use the shared readiness helpers with punctuation-rich mount paths and navigate exact session keys without false readiness timeouts.

AI-assisted, maintainer-requested test-support repair. Production LOC: +0/-0. Test support: +19/-5. Tests: +58/-1, including a two-case root/encoded-mount regression that distinguishes slash data, session separators, literal percent escapes, and query/hash characters.

## Evidence

Before helper edits, the new regression callers failed against current-main baseline `a872abc9782982b3425e7e2eb42ca120896d842a`:

- Original terminal-continuation module, desktop then mobile: both hit the unchanged 60-second route deadline. The router retained literal braces/backtick; Chromium exposed `%7B`, `%7D`, and `%60`. Both had `status: success`, the correct session, and `pendingMatches: []`.
- New session-navigation regression: the root case passed; the encoded-mount case hit the existing 10-second pane deadline because the helper navigated without the configured base path.

After repair, real isolated Chromium with the existing mocked Gateway passed four E2E files / seven tests:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/control-ui-route-readiness.e2e.test.ts ui/src/e2e/chat-continue-in-terminal.e2e.test.ts ui/src/e2e/plugins-hub-navigation.e2e.test.ts ui/src/e2e/dynamic-route-loader-count.e2e.test.ts
```

The existing helper unit tests also passed (two tests). The original desktop and mobile active-pane ownership assertions, header actions, clipboard/continuation dialog, and reconnect assertions remain covered.

`check:changed` passed repository guards, formatting, dead-export scans, core-test typechecks, and UI typechecks, then caught a local `no-shadow` naming error. That variable was renamed; focused formatting, lint, stylelint, E2E typechecking, and the full focused browser command above were rerun successfully:

```sh
node_modules/.bin/oxfmt --check ui/src/test-helpers/control-ui-e2e.ts ui/src/e2e/chat-continue-in-terminal.e2e.test.ts ui/src/e2e/control-ui-route-readiness.e2e.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/test-helpers/control-ui-e2e.ts ui/src/e2e/chat-continue-in-terminal.e2e.test.ts ui/src/e2e/control-ui-route-readiness.e2e.test.ts
node --import tsx scripts/run-stylelint.mts ui/src/test-helpers/control-ui-e2e.ts ui/src/e2e/chat-continue-in-terminal.e2e.test.ts ui/src/e2e/control-ui-route-readiness.e2e.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.ui-pages-e2e.json --incremental
git diff --check
```

Independent Codex autoreview reported no actionable findings. No live provider or operator Gateway was used; this test-support defect is exercised through the real browser/router with deterministic Gateway fixtures. Screenshot uploads are not applicable because no production or visual surface changes.

Post-rebase verification: the patch rebased without conflicts onto `3255882803c78de5103d2d37f7698add84f34c5d`; `git range-diff` confirmed an identical patch. On head `32cc73363b20bd688774113089be3a427c5b1252`, the same four-file browser command passed all seven tests in 40.56s, the helper unit command (`node scripts/run-vitest.mjs ui/src/test-helpers/control-ui-e2e.test.ts`) passed both tests, and all focused checks listed above exited 0.

[Exact-head CI run 33037747630](https://github.com/openclaw/openclaw/actions/runs/33037747630) completed successfully: 67 successful jobs and 18 scope-disabled skips. All four UI E2E shards, the real-Gateway UI lane, the UI checks, and [the required openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33037747630/job/98406691626) passed. The separate [Labeler run 33037722037](https://github.com/openclaw/openclaw/actions/runs/33037722037) initially failed on a GitHub API response timeout and passed on one failed-job retry (attempt 2); no code or check changes were needed.

ClawSweeper follow-up: the [completed review](https://github.com/openclaw/openclaw/pull/130666#issuecomment-5434280094) found no actionable functional or security defect. Its sole rank-up move—wait for exact-head UI E2E and required repository checks—is satisfied by the successful CI run linked above. Its separate browser probe reported that the command was still running after 30 seconds and did not provide a terminal test result; that probe is not counted as passing evidence. The completed seven-test local browser run and all hosted UI E2E shards provide the finished proof. A newer review-started placeholder has no additional findings. No timeout, assertion, or code changes were made, and no re-review was requested.
