### PR TITLE
fix(ui): make cloud failure diagnostics readable and copyable

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -521,6 +521,8 @@ Capability toggles stay disabled until the Gateway, session, and runtime config 
 
 ## Chat behavior
 
+Chat error banners, including cloud runner failures, keep a compact preview. Open **Error details** to read and select the complete diagnostic received by the UI, then use **Copy error** to copy it. The disclosure works with Enter or Space; the expanded text wraps long lines and can be scrolled with the keyboard. Expanding or copying an error does not retry the failed operation.
+
 <AccordionGroup>
   <Accordion title="Send and history semantics">
     - `chat.send` is **non-blocking**: it acks immediately with `{ runId, status: "started" }` and the response streams via `chat` events. Trusted Control UI clients may also receive optional ACK timing metadata for local diagnostics.

--- a/ui/src/app/app-host-lifecycle.test.ts
+++ b/ui/src/app/app-host-lifecycle.test.ts
@@ -1,0 +1,54 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { COMMAND_PALETTE_TARGET_EVENT } from "../components/command-palette-contract.ts";
+import { resetAppHostTestGlobals } from "./app-host.test-support.ts";
+import "./app-host.ts";
+import type { ShellChromeHost } from "./app-shell-chrome.ts";
+import { NATIVE_HISTORY_STATE_EVENT } from "./native-web-chrome.ts";
+
+type ShellLifecycle = {
+  connectedCallback(): void;
+  disconnectedCallback(): void;
+};
+
+afterEach(resetAppHostTestGlobals);
+
+describe("OpenClaw shell event lifecycle", () => {
+  it("retires host, window, and document actions on disconnect and reconnects once", () => {
+    const shell = document.createElement("openclaw-app-shell") as ShellChromeHost & ShellLifecycle;
+    const navigate = vi.spyOn(shell, "navigate").mockImplementation(() => {});
+    const onSlashCommand = vi.fn();
+    const target = { owner: shell, onSlashCommand };
+    const history = { canGoBack: true, canGoForward: false };
+    const dispatchActions = () => {
+      shell.dispatchEvent(new CustomEvent(COMMAND_PALETTE_TARGET_EVENT, { detail: target }));
+      window.dispatchEvent(new CustomEvent(NATIVE_HISTORY_STATE_EVENT, { detail: history }));
+      document.dispatchEvent(
+        new KeyboardEvent("keydown", { code: "Comma", key: ",", ctrlKey: true, shiftKey: true }),
+      );
+    };
+
+    try {
+      for (let connection = 1; connection <= 2; connection += 1) {
+        shell.connectedCallback();
+        dispatchActions();
+        expect(shell.commandPaletteTarget).toBe(target);
+        expect(shell.nativeHistoryState).toBe(history);
+        expect(navigate).toHaveBeenCalledTimes(connection);
+        expect(navigate).toHaveBeenLastCalledWith("appearance");
+
+        shell.disconnectedCallback();
+        shell.commandPaletteTarget = undefined;
+        shell.nativeHistoryState = { canGoBack: false, canGoForward: false };
+        dispatchActions();
+        expect(shell.commandPaletteTarget).toBeUndefined();
+        expect(shell.nativeHistoryState.canGoBack).toBe(false);
+        expect(navigate).toHaveBeenCalledTimes(connection);
+      }
+    } finally {
+      shell.disconnectedCallback();
+      navigate.mockRestore();
+    }
+  });
+});

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -30,8 +30,8 @@ import type {
   ApplicationGateway,
   ApplicationGatewaySnapshot,
 } from "./context.ts";
-import "./app-host.ts";
 import type { LazyCustomElementRequestController } from "./lazy-custom-element.ts";
+import "./app-host.ts";
 import {
   persistLazyShellAction,
   readLazyShellAction,
@@ -740,21 +740,6 @@ describe("OpenClaw shell keyboard shortcuts", () => {
     expect(
       shouldMergeChatChrome({ mobileNavLayout: true, routeId: "chat", onboarding: false }),
     ).toBe(false);
-  });
-
-  it("wires merged header window events for the shell lifecycle", () => {
-    const addEventListener = vi.spyOn(window, "addEventListener");
-    const shell = document.createElement("openclaw-app-shell") as unknown as ShellChromeEventState;
-
-    shell.connectedCallback();
-
-    expect(addEventListener).toHaveBeenCalledWith(COMMAND_PALETTE_OPEN_EVENT, expect.any(Function));
-    expect(addEventListener).toHaveBeenCalledWith(
-      SHELL_NAV_DRAWER_TOGGLE_EVENT,
-      expect.any(Function),
-    );
-    shell.disconnectedCallback();
-    addEventListener.mockRestore();
   });
 
   it("prevents unhandled window file drops without overriding accepted targets", () => {

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -121,6 +121,7 @@ export interface ShellChromeHost extends HTMLElement {
 
 export class ShellChromeOwner {
   private pendingLazyAction = readLazyShellAction();
+  private listeners: AbortController | undefined;
 
   constructor(private readonly host: ShellChromeHost) {}
 
@@ -133,56 +134,62 @@ export class ShellChromeOwner {
   }
 
   connect(): void {
+    this.disconnect();
+    this.listeners = new AbortController();
+    // One connection owns all three targets; abort removes exactly its listeners.
+    const options = { signal: this.listeners.signal };
     const host = this.host;
     host.nativeHistoryState = readNativeHistoryState();
-    host.addEventListener(COMMAND_PALETTE_TARGET_EVENT, this.handleCommandPaletteTarget);
-    window.addEventListener(COMMAND_PALETTE_OPEN_EVENT, this.handleCommandPaletteOpen);
-    window.addEventListener(SHELL_NAV_DRAWER_TOGGLE_EVENT, this.handleShellNavDrawerToggle);
-    window.addEventListener(DEBUG_OVERLAY_REQUEST_EVENT, this.handleDebugOverlayRequest);
-    window.addEventListener(KEYBOARD_SHORTCUTS_REQUEST_EVENT, this.handleKeyboardShortcutsRequest);
-    document.addEventListener("keydown", this.handleDocumentKeydown);
-    window.addEventListener("resize", this.handleWindowResize);
-    window.addEventListener("dragover", this.handleUnhandledFileDrag);
-    window.addEventListener("drop", this.handleUnhandledFileDrag);
-    window.addEventListener(NATIVE_HISTORY_STATE_EVENT, this.handleNativeHistoryState);
+    host.addEventListener(COMMAND_PALETTE_TARGET_EVENT, this.handleCommandPaletteTarget, options);
+    window.addEventListener(COMMAND_PALETTE_OPEN_EVENT, this.handleCommandPaletteOpen, options);
+    window.addEventListener(
+      SHELL_NAV_DRAWER_TOGGLE_EVENT,
+      this.handleShellNavDrawerToggle,
+      options,
+    );
+    window.addEventListener(DEBUG_OVERLAY_REQUEST_EVENT, this.handleDebugOverlayRequest, options);
+    window.addEventListener(
+      KEYBOARD_SHORTCUTS_REQUEST_EVENT,
+      this.handleKeyboardShortcutsRequest,
+      options,
+    );
+    document.addEventListener("keydown", this.handleDocumentKeydown, options);
+    window.addEventListener("resize", this.handleWindowResize, options);
+    window.addEventListener("dragover", this.handleUnhandledFileDrag, options);
+    window.addEventListener("drop", this.handleUnhandledFileDrag, options);
+    window.addEventListener(NATIVE_HISTORY_STATE_EVENT, this.handleNativeHistoryState, options);
     // Shipped Mac hosts use these same events even when native web chrome is absent.
-    window.addEventListener("openclaw:native-toggle-sidebar", this.handleNativeToggleSidebar);
-    window.addEventListener("openclaw:native-open-search", this.handleNativeOpenSearch);
-    window.addEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
-    window.addEventListener("openclaw:native-new-session", this.handleNativeNewSession);
-    window.addEventListener("openclaw:native-navigate", this.handleNativeNavigate);
-    window.addEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
-    window.addEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
-    window.addEventListener(DESKTOP_PANEL_TOGGLE_EVENT, this.handleDeferredDesktopToggle);
-    window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
-    window.addEventListener(SHELL_APPROVALS_OPEN_EVENT, this.handleApprovalsOpen);
+    window.addEventListener(
+      "openclaw:native-toggle-sidebar",
+      this.handleNativeToggleSidebar,
+      options,
+    );
+    window.addEventListener("openclaw:native-open-search", this.handleNativeOpenSearch, options);
+    window.addEventListener(
+      "openclaw:native-toggle-search",
+      this.handleNativeToggleSearch,
+      options,
+    );
+    window.addEventListener("openclaw:native-new-session", this.handleNativeNewSession, options);
+    window.addEventListener("openclaw:native-navigate", this.handleNativeNavigate, options);
+    window.addEventListener(
+      TERMINAL_PANEL_TOGGLE_EVENT,
+      this.handleDeferredTerminalToggle,
+      options,
+    );
+    window.addEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle, options);
+    window.addEventListener(DESKTOP_PANEL_TOGGLE_EVENT, this.handleDeferredDesktopToggle, options);
+    window.addEventListener(
+      CUSTODIAN_PANEL_TOGGLE_EVENT,
+      this.handleDeferredCustodianToggle,
+      options,
+    );
+    window.addEventListener(SHELL_APPROVALS_OPEN_EVENT, this.handleApprovalsOpen, options);
   }
 
   disconnect(): void {
-    const host = this.host;
-    host.removeEventListener(COMMAND_PALETTE_TARGET_EVENT, this.handleCommandPaletteTarget);
-    window.removeEventListener(COMMAND_PALETTE_OPEN_EVENT, this.handleCommandPaletteOpen);
-    window.removeEventListener(SHELL_NAV_DRAWER_TOGGLE_EVENT, this.handleShellNavDrawerToggle);
-    window.removeEventListener(DEBUG_OVERLAY_REQUEST_EVENT, this.handleDebugOverlayRequest);
-    window.removeEventListener(
-      KEYBOARD_SHORTCUTS_REQUEST_EVENT,
-      this.handleKeyboardShortcutsRequest,
-    );
-    document.removeEventListener("keydown", this.handleDocumentKeydown);
-    window.removeEventListener("resize", this.handleWindowResize);
-    window.removeEventListener("dragover", this.handleUnhandledFileDrag);
-    window.removeEventListener("drop", this.handleUnhandledFileDrag);
-    window.removeEventListener(NATIVE_HISTORY_STATE_EVENT, this.handleNativeHistoryState);
-    window.removeEventListener("openclaw:native-toggle-sidebar", this.handleNativeToggleSidebar);
-    window.removeEventListener("openclaw:native-open-search", this.handleNativeOpenSearch);
-    window.removeEventListener("openclaw:native-toggle-search", this.handleNativeToggleSearch);
-    window.removeEventListener("openclaw:native-new-session", this.handleNativeNewSession);
-    window.removeEventListener("openclaw:native-navigate", this.handleNativeNavigate);
-    window.removeEventListener(TERMINAL_PANEL_TOGGLE_EVENT, this.handleDeferredTerminalToggle);
-    window.removeEventListener(BROWSER_PANEL_TOGGLE_EVENT, this.handleDeferredBrowserToggle);
-    window.removeEventListener(DESKTOP_PANEL_TOGGLE_EVENT, this.handleDeferredDesktopToggle);
-    window.removeEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.handleDeferredCustodianToggle);
-    window.removeEventListener(SHELL_APPROVALS_OPEN_EVENT, this.handleApprovalsOpen);
+    this.listeners?.abort();
+    this.listeners = undefined;
   }
 
   toggleNavigationSurface(trigger?: HTMLElement): void {

--- a/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
@@ -262,6 +262,7 @@ suite.define(() => {
 
       await page
         .getByRole("alert")
+        .locator("summary")
         .getByText("Could not store this message for reconnect.", { exact: false })
         .waitFor({ timeout: 10_000 });
       await row.waitFor();

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -374,8 +374,9 @@ suite.define(() => {
           await page.screenshot({ path: path.join(artifactDir, `terminal-partial-${label}.png`) });
         }
         const alert = page.locator(".chat-error");
-        await alert.getByText(errorText).waitFor({ timeout: 10_000 });
-        expect(await alert.locator("button").count()).toBe(0);
+        await alert.locator("summary").getByText(errorText).waitFor({ timeout: 10_000 });
+        expect(await alert.getByRole("button", { name: "Dismiss error" }).count()).toBe(0);
+        expect(await alert.getByRole("button", { name: "Retry", exact: true }).count()).toBe(0);
         expect(await page.locator(".chat-thread-inner").getByText(errorText).count()).toBe(0);
         const [alertBox, composerBox] = await Promise.all([
           alert.boundingBox(),

--- a/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
+++ b/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
@@ -213,7 +213,11 @@ suite.define(() => {
           ),
         )
         .toBe(sessionA);
-      await visiblePane.getByText(message, { exact: true }).waitFor();
+      await visiblePane
+        .getByRole("alert")
+        .locator("summary")
+        .getByText(message, { exact: true })
+        .waitFor();
 
       await page.getByRole("button", { name: "Runs on Cloud" }).click();
       await page.getByText("Stop cloud worker…", { exact: true }).waitFor();

--- a/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
+++ b/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
@@ -18,6 +18,13 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
 const sessionKey = "agent:main:conflict-proof";
+const workerFailureDiagnostic = [
+  "Worker provider rejected profile: node enrollment setup failed with exit code 1: provider reported lease destroyed",
+  "<img src=x onerror=alert(1)>",
+  `Trace: ${"diagnostic-segment/".repeat(100)}`,
+  ...Array.from({ length: 30 }, (_, index) => `    at enroll (worker.ts:${index + 1}:1)`),
+  "Final diagnostic line: enrollment did not complete.",
+].join("\n");
 
 const conflict = {
   paths: ["src/local.ts", "ui/src/app.ts"],
@@ -63,7 +70,7 @@ function sessionsList(includeConflict: boolean) {
   };
 }
 
-function workerRecoverySessionsList(includeError: boolean) {
+function workerRecoverySessionsList(includeError: boolean, failedState = "failed") {
   const now = Date.now();
   return {
     count: 1,
@@ -80,7 +87,7 @@ function workerRecoverySessionsList(includeError: boolean) {
         model: "gpt-5.5",
         modelProvider: "openai",
         placement: {
-          state: includeError ? "failed" : "active",
+          state: includeError ? failedState : "active",
           generation: 2,
           createdAtMs: now - 10_000,
           updatedAtMs: now,
@@ -92,8 +99,11 @@ function workerRecoverySessionsList(includeError: boolean) {
           workerBundleHash: "a".repeat(64),
           ...(includeError
             ? {
-                recoveryError: "cloud worker disappeared: provider reported lease destroyed",
-                terminalReason: "stale terminal worker failure",
+                recoveryError: workerFailureDiagnostic,
+                terminalReason:
+                  failedState === "failed"
+                    ? "stale terminal worker failure"
+                    : workerFailureDiagnostic,
                 terminalAtMs: now,
               }
             : {}),
@@ -269,42 +279,132 @@ describeControlUiE2e("Control UI cloud workspace conflict recovery", () => {
     }
   });
 
-  it("shows a durable selected-chat alert while workspace recovery is pending", async () => {
-    const context = await browser.newContext({
-      colorScheme: "dark",
-      locale: "en-US",
-      serviceWorkers: "block",
-      viewport: { height: 900, width: 1440 },
-    });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      historyMessages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "Remote work completed successfully." }],
-          timestamp: Date.now() - 2_000,
-        },
-      ],
-      methodResponses: { "sessions.list": workerRecoverySessionsList(false) },
-      sessionKey,
-    });
+  it.each(["failed", "reclaimed", "request"])(
+    "exposes the full %s diagnostic with keyboard and clipboard access",
+    async (failedState) => {
+      const context = await browser.newContext({
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+        permissions: ["clipboard-read", "clipboard-write"],
+      });
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, {
+        historyMessages: [
+          {
+            role: "assistant",
+            content: [{ type: "text", text: "Remote work completed successfully." }],
+            timestamp: Date.now() - 2_000,
+          },
+        ],
+        methodResponses: { "sessions.list": workerRecoverySessionsList(false) },
+        sessionKey,
+      });
 
-    try {
-      const response = await page.goto(controlUiSessionUrl(server.baseUrl, sessionKey));
-      expect(response?.status()).toBe(200);
-      await page.getByText("Remote work completed successfully.").waitFor({ timeout: 10_000 });
-      expect(await page.getByRole("alert").count()).toBe(0);
-      await capture(page, "05-before-workspace-recovery-error.png");
+      try {
+        const response = await page.goto(controlUiSessionUrl(server.baseUrl, sessionKey));
+        expect(response?.status()).toBe(200);
+        await page.getByText("Remote work completed successfully.").waitFor({ timeout: 10_000 });
+        expect(await page.getByRole("alert").count()).toBe(0);
+        await capture(page, "05-before-workspace-recovery-error.png");
 
-      await gateway.setMethodResponse("sessions.list", workerRecoverySessionsList(true));
-      await page.reload();
-      const alert = page.getByRole("alert").filter({ hasText: "Runner failed" });
-      await alert.waitFor({ timeout: 10_000 });
-      expect(await alert.textContent()).toContain("provider reported lease destroyed");
-      expect(await alert.textContent()).not.toContain("stale terminal worker failure");
-      await capture(page, "05-after-workspace-recovery-error.png");
-    } finally {
-      await context.close();
-    }
-  });
+        if (failedState === "request") {
+          await gateway.setMethodResponse("sessions.patch", {
+            __mockError: { code: "UNAVAILABLE", message: workerFailureDiagnostic },
+          });
+          await page.locator(".chat-pane__session-title-button").click();
+          const rename = page.locator(".chat-pane__session-title-input");
+          await rename.fill("Rejected rename");
+          await rename.press("Enter");
+          await gateway.waitForRequest("sessions.patch");
+        } else {
+          await gateway.setMethodResponse(
+            "sessions.list",
+            workerRecoverySessionsList(true, failedState),
+          );
+          await page.reload();
+        }
+        const alert = page
+          .getByRole("alert")
+          .filter({ hasText: "provider reported lease destroyed" });
+        await alert.waitFor({ timeout: 10_000 });
+        expect(await alert.textContent()).toContain("provider reported lease destroyed");
+        expect(await alert.textContent()).not.toContain("stale terminal worker failure");
+        await capture(page, `05-${failedState}-collapsed-error.png`);
+        const summary = alert.locator("summary");
+        const diagnostic = alert.locator("pre");
+        const expected = `${failedState === "request" ? "" : "Runner failed: "}${workerFailureDiagnostic}`;
+        expect(await summary.count()).toBe(1);
+        expect(await diagnostic.isVisible()).toBe(false);
+        for (const width of [1440, 320]) {
+          await page.setViewportSize({ width, height: width === 320 ? 568 : 900 });
+          await summary.focus();
+          await page.keyboard.press("Enter");
+          await diagnostic.waitFor({ state: "visible" });
+          expect(await diagnostic.textContent()).toBe(expected);
+          expect(await alert.locator("img").count()).toBe(0);
+          const bounds = await diagnostic.evaluate((node) => {
+            const box = node.getBoundingClientRect();
+            return {
+              left: box.left,
+              right: box.right,
+              top: box.top,
+              bottom: box.bottom,
+              viewport: innerWidth,
+              height: innerHeight,
+              scrollWidth: node.scrollWidth,
+              clientWidth: node.clientWidth,
+              scrollHeight: node.scrollHeight,
+              clientHeight: node.clientHeight,
+            };
+          });
+          expect(bounds.left).toBeGreaterThanOrEqual(0);
+          expect(bounds.right).toBeLessThanOrEqual(bounds.viewport);
+          expect(bounds.top).toBeGreaterThanOrEqual(0);
+          expect(bounds.bottom).toBeLessThanOrEqual(bounds.height);
+          expect(bounds.scrollWidth).toBeLessThanOrEqual(bounds.clientWidth + 1);
+          expect(bounds.scrollHeight).toBeGreaterThan(bounds.clientHeight);
+          await page.keyboard.press("Tab");
+          expect(await diagnostic.evaluate((node) => node === document.activeElement)).toBe(true);
+          await page.keyboard.press("PageDown");
+          await expect.poll(() => diagnostic.evaluate((node) => node.scrollTop)).toBeGreaterThan(0);
+          expect(
+            await diagnostic.evaluate((node) => {
+              const range = document.createRange();
+              range.selectNodeContents(node);
+              const selection = window.getSelection();
+              selection?.removeAllRanges();
+              selection?.addRange(range);
+              return selection?.toString();
+            }),
+          ).toBe(expected);
+          const copy = alert.getByRole("button", { name: "Copy error", exact: true });
+          await copy.focus();
+          await page.keyboard.press("Enter");
+          await expect
+            .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+            .toBe(expected);
+          await diagnostic.evaluate((node) => {
+            window.getSelection()?.removeAllRanges();
+            node.scrollTop = node.scrollHeight;
+          });
+          await capture(page, `06-${failedState}-${width}-expanded-error.png`);
+          await summary.focus();
+          await page.keyboard.press("Space");
+          await expect.poll(() => diagnostic.isVisible()).toBe(false);
+          await alert
+            .getByRole("button", { name: "Copy error", exact: true, includeHidden: true })
+            .waitFor({ state: "attached" });
+        }
+        expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+        if (failedState === "request") {
+          await alert.getByRole("button", { name: "Dismiss error" }).click();
+          await alert.waitFor({ state: "detached" });
+        }
+      } finally {
+        await context.close();
+      }
+    },
+  );
 });

--- a/ui/src/e2e/new-session-page.cloud-startup-failure.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup-failure.e2e.test.ts
@@ -15,9 +15,14 @@ suite.define(() => {
   it.each([false, true])(
     "keeps cloud startup visible through failure (history fails: %s)",
     async (historyFails) => {
-      const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+      const context = await suite.browser.newContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        permissions: ["clipboard-read", "clipboard-write"],
+      });
       const page = await context.newPage();
       const sessionKey = "agent:cloud:failed-startup-e2e";
+      const diagnostic = `cloud profile was removed\n${"Enrollment detail. ".repeat(80)}\nFinal startup diagnostic.`;
       const gateway = await installMockGateway(page, {
         defaultAgentId: "cloud",
         deferredMethods: ["sessions.dispatch", ...(historyFails ? ["chat.startup"] : [])],
@@ -86,12 +91,21 @@ suite.define(() => {
         expect(await page.locator(".chat-send-btn--stop").count()).toBe(0);
         await gateway.rejectDeferred("sessions.dispatch", {
           code: "INVALID_REQUEST",
-          message: "cloud profile was removed",
+          message: diagnostic,
         });
 
-        const alert = page.locator('.chat-cloud-startup-error[role="alert"]');
+        const alert = page.getByRole("alert").filter({ hasText: "cloud profile was removed" });
         await pollLocatorText(alert).toContain("cloud profile was removed");
         await expect.poll(() => working.count()).toBe(0);
+        expect(await alert.locator("summary").count()).toBe(1);
+        await alert.locator("summary").click();
+        const text = alert.locator("pre");
+        await text.waitFor({ state: "visible" });
+        expect(await text.textContent()).toContain(diagnostic);
+        await alert.getByRole("button", { name: "Copy error", exact: true }).click();
+        await expect
+          .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+          .toBe(await text.textContent());
         expect(page.url()).toContain(controlUiSessionPath(sessionKey));
         expect(await gateway.getRequests("sessions.send")).toHaveLength(0);
         expect(await gateway.getRequests("sessions.delete")).toHaveLength(0);

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -493,7 +493,7 @@ suite.define(() => {
         message: "send outcome unknown",
       });
 
-      const alert = page.locator('.chat-cloud-startup-error[role="alert"]');
+      const alert = page.getByRole("alert").filter({ hasText: "send outcome unknown" });
       await pollLocatorText(alert).toContain("send outcome unknown");
       expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionKey));
       await replaceGatewayClient(page);

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5196,6 +5196,8 @@ export const en: TranslationMap = {
   },
   chat: {
     cloudWorkerFailed: "Runner failed: {error}",
+    errorDetails: "Error details",
+    copyError: "Copy error",
     diskSpace: {
       warningTitle: "Cloud session disk space is low",
       criticalTitle: "Cloud session disk space is critically low",

--- a/ui/src/pages/chat/chat-view-notices.ts
+++ b/ui/src/pages/chat/chat-view-notices.ts
@@ -1,6 +1,7 @@
-import { html, nothing } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import type { SessionPlacementDiskSpace } from "../../../../packages/gateway-protocol/src/schema/session-placement.ts";
 import type { ApplicationPlacementStartupStatus } from "../../app/session-placement-startup.ts";
+import { renderCopyButton } from "../../components/copy-button.ts";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { formatBytes } from "../../lib/agents/display.ts";
@@ -62,7 +63,7 @@ function renderDiskSpaceNotice(diskSpace: SessionPlacementDiskSpace | undefined)
   `;
 }
 
-function renderErrorNotice(error: string, onDismiss?: () => void) {
+function renderErrorNotice(error: string, action: TemplateResult | typeof nothing = nothing) {
   return html`
     <div
       class="chat-composer-neighbor-card chat-composer-neighbor-card--danger chat-error"
@@ -71,32 +72,40 @@ function renderErrorNotice(error: string, onDismiss?: () => void) {
       <span class="chat-composer-neighbor-card__icon" aria-hidden="true"
         >${icons.alertTriangle}</span
       >
-      <span class="chat-composer-neighbor-card__copy chat-error__content"
-        ><strong>${error}</strong></span
-      >
-      ${onDismiss
-        ? html`
-            <openclaw-tooltip .content=${t("chat.actions.dismissError")}>
-              <button
-                class="chat-error__dismiss"
-                type="button"
-                @click=${onDismiss}
-                aria-label=${t("chat.actions.dismissError")}
-              >
-                ${icons.x}
-              </button>
-            </openclaw-tooltip>
-          `
-        : nothing}
+      <details class="chat-error__content">
+        <summary class="chat-error__summary">
+          <strong>${error}</strong>
+          <span>${t("chat.errorDetails")}</span>
+          <span class="chat-error__chevron" aria-hidden="true">${icons.chevronDown}</span>
+        </summary>
+        <pre class="chat-error__diagnostic" tabindex="0" aria-label=${t("chat.errorDetails")}>
+${error}</pre>
+        ${renderCopyButton(error, t("chat.copyError"))}
+      </details>
+      ${action}
     </div>
   `;
 }
 
 export function renderChatTopbarNotices(props: ChatViewNoticesProps) {
+  const dismiss = props.onDismissError
+    ? html`
+        <openclaw-tooltip .content=${t("chat.actions.dismissError")}>
+          <button
+            class="chat-error__dismiss"
+            type="button"
+            @click=${props.onDismissError}
+            aria-label=${t("chat.actions.dismissError")}
+          >
+            ${icons.x}
+          </button>
+        </openclaw-tooltip>
+      `
+    : nothing;
   return html`
     <div class="chat-topbar-notices">
       ${renderDiskSpaceNotice(props.diskSpace)}
-      ${props.error ? renderErrorNotice(props.error, props.onDismissError) : nothing}
+      ${props.error ? renderErrorNotice(props.error, dismiss) : nothing}
       ${props.focusMode && props.onToggleFocusMode
         ? html`
             <openclaw-tooltip .content=${t("chat.actions.exitFocusMode")}>
@@ -133,26 +142,14 @@ function renderPlacementStartupError(
   if (status?.phase !== "failed") {
     return nothing;
   }
-  return html`
-    <div
-      class="chat-composer-neighbor-card chat-composer-neighbor-card--danger chat-cloud-startup-error"
-      role="alert"
-    >
-      <span class="chat-composer-neighbor-card__icon" aria-hidden="true"
-        >${icons.alertTriangle}</span
-      >
-      <span class="chat-composer-neighbor-card__copy"
-        ><strong
-          >${t("newSession.placementStartFailed", {
-            error: status.error ?? t("newSession.createFailed"),
-          })}</strong
-        ></span
-      >
-      ${status.retryable && onRetry
-        ? html`<button class="btn btn--sm" type="button" @click=${onRetry}>
-            ${t("common.retry")}
-          </button>`
-        : nothing}
-    </div>
-  `;
+  const error = t("newSession.placementStartFailed", {
+    error: status.error ?? t("newSession.createFailed"),
+  });
+  const retry =
+    status.retryable && onRetry
+      ? html`<button class="btn btn--sm" type="button" @click=${onRetry}>
+          ${t("common.retry")}
+        </button>`
+      : nothing;
+  return renderErrorNotice(error, retry);
 }

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -933,19 +933,30 @@ describe("inline approval card", () => {
 });
 
 describe("chat run error", () => {
-  it("renders a non-interactive alert in the composer overlay", () => {
-    const container = renderChatView({
-      runError: { summary: "Error: gateway disconnected" },
-    });
+  it.each(["run", "request"])(
+    "exposes the complete %s error as selectable text and a copy action",
+    (source) => {
+      const diagnostic =
+        "Error: gateway disconnected\n<img src=x onerror=alert(1)>\nFinal diagnostic line";
+      const container = renderChatView(
+        source === "run" ? { runError: { summary: diagnostic } } : { error: diagnostic },
+      );
 
-    const alert = requireElement(container, ".chat-error", "chat run error");
-    const summary = requireElement(alert, ".chat-error__content", "chat run error summary");
-    expect(alert.getAttribute("role")).toBe("alert");
-    expect(summary.textContent?.trim()).toBe("Error: gateway disconnected");
-    expect(alert.querySelector<HTMLButtonElement>('[aria-label="Dismiss error"]')).toBeNull();
-    expect(alert.closest(".agent-chat__composer-overlay")).not.toBeNull();
-    expect(alert.closest(".agent-chat__composer-shell")).not.toBeNull();
-  });
+      const alert = requireElement(container, ".chat-error", "chat run error");
+      expect(alert.getAttribute("role")).toBe("alert");
+      const details = requireElement(alert, "details", "error disclosure");
+      expect(details.hasAttribute("open")).toBe(false);
+      expect(requireElement(details, "pre", "full diagnostic").textContent).toBe(diagnostic);
+      expect(alert.querySelector("img")).toBeNull();
+      expect(alert.querySelector<HTMLButtonElement>('[aria-label="Copy error"]')).not.toBeNull();
+      expect(alert.querySelector<HTMLButtonElement>('[aria-label="Dismiss error"]') !== null).toBe(
+        source === "request",
+      );
+      expect(
+        alert.closest(source === "run" ? ".agent-chat__composer-overlay" : ".chat-topbar-notices"),
+      ).not.toBeNull();
+    },
+  );
 
   it("keeps dismiss on the error state owned by its callback", () => {
     const onDismissError = vi.fn();
@@ -955,6 +966,32 @@ describe("chat run error", () => {
 
     expect(onDismissError).toHaveBeenCalledOnce();
     expect(container.querySelector(".chat-error")?.closest(".chat-topbar-notices")).not.toBeNull();
+  });
+
+  it.each([false, true])("keeps startup Retry owned by retryable=%s", (retryable) => {
+    const onRetrySessionPlacementStartup = vi.fn();
+    const container = renderChatView({
+      placementStartup: {
+        sessionKey: "agent:main:startup",
+        phase: "failed",
+        startedAt: 1,
+        error: "Provisioning failed\nFinal diagnostic line",
+        retryable,
+      },
+      onRetrySessionPlacementStartup,
+    });
+    const alert = requireElement(container, ".chat-error", "startup error");
+    expect(requireElement(alert, "pre", "startup diagnostic").textContent).toContain(
+      "Provisioning failed\nFinal diagnostic line",
+    );
+    alert.querySelector<HTMLElement>("summary")?.click();
+    expect(onRetrySessionPlacementStartup).not.toHaveBeenCalled();
+    const retry = Array.from(alert.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Retry",
+    );
+    expect(Boolean(retry)).toBe(retryable);
+    retry?.click();
+    expect(onRetrySessionPlacementStartup).toHaveBeenCalledTimes(retryable ? 1 : 0);
   });
 });
 

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -79,8 +79,70 @@ openclaw-chat-page {
 }
 
 .chat-error__content {
+  flex: 1;
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.chat-error:has(details[open]) {
+  align-items: start;
+}
+
+.chat-error__summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  list-style: none;
+  cursor: var(--cursor-action);
+}
+
+.chat-error__summary::-webkit-details-marker {
+  display: none;
+}
+
+.chat-error__summary strong {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-error__summary > span {
+  flex: 0 0 auto;
+  color: var(--muted);
+}
+
+.chat-error__chevron {
+  display: inline-flex;
+}
+
+.chat-error__chevron svg {
+  width: 14px;
+  height: 14px;
+}
+
+.chat-error__content[open] .chat-error__chevron {
+  transform: rotate(180deg);
+}
+
+/* Preserve the received diagnostic as text; only its collapsed preview clips. */
+.chat-error__diagnostic {
+  max-height: min(16rem, 35dvh);
+  margin: 10px 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font: inherit;
+  user-select: text;
+}
+
+.chat-error__summary:focus-visible,
+.chat-error__diagnostic:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: var(--radius-sm);
 }
 
 .chat-error__dismiss {
@@ -416,6 +478,10 @@ openclaw-chat-page {
   width: 24px;
   height: 24px;
   margin: -1px -3px -1px 0;
+}
+
+.chat-topbar-notices .chat-error:has(details[open]) {
+  border-radius: var(--radius-lg);
 }
 
 .chat-workspace-conflict-notice {


### PR DESCRIPTION
Closes #130652

## What Problem This Solves

Fixes an issue where users opening a failed cloud session could only see a single truncated error line above the composer, with no way to read or copy the diagnostic. Initial provisioning failures and ordinary chat request errors had the same limitation.

## Why This Change Was Made

Use one shared error notice with a compact preview, native **Error details** disclosure, a selectable wrapping/scrolling diagnostic, and the existing **Copy error** control. Route startup failures through that same renderer, so initial cloud failures and durable runner failures cannot drift apart. Startup progress retains the canonical chat working indicator introduced by #130669.

The error remains plain escaped text. Existing Retry and dismissal callbacks retain ownership; opening or copying a diagnostic does not retry, send, or delete anything. No new modal, custom disclosure state, configuration, persistence, protocol, dependency, or backend output limit.

## User Impact

Operators can expand, select, keyboard-scroll, and copy the complete diagnostic received by the Control UI on desktop and small phones. Short failures remain compact. Backend redaction and bounded diagnostic retention are unchanged; this does not claim to recover raw output already omitted by a provider.

Release note: make cloud runner and chat failure diagnostics readable and copyable, including initial provisioning failures.

## Evidence

CI repair addresses both failures from [the original run 33037946381](https://github.com/openclaw/openclaw/actions/runs/33037946381):

- Error text deliberately appears in the compact summary and expanded diagnostic. Queue-edit, streaming on desktop/mobile, and placement-reclaim tests now target the visible summary while retaining their message, visibility, lifecycle, and action assertions.
- Startup JS already exceeded the 343442 B gzip gate on the original branch base (343459 B). After resolving genuine conflicts with #130669, the shell now binds its host/window/document listeners to one connection-owned abort signal instead of maintaining a duplicate teardown list. All handlers remain, and a real event lifecycle test proves that disconnected shells are inert and reconnect once. Published-head local build: **343361 B, 81 B below the unchanged limit** (the pre-commit candidate measured 343345 B). No budget, baseline, gate, capability, or assertion was weakened.

Repaired head: [`bc6647826bbde95c172e44d157f466ff6fc03198`](https://github.com/openclaw/openclaw/commit/bc6647826bbde95c172e44d157f466ff6fc03198). Exact-head [pull-request CI run 33040515478](https://github.com/openclaw/openclaw/actions/runs/33040515478) completed **success**, including `openclaw/ci-gate`, build-artifacts, real-Gateway UI E2E, all four UI browser shards, and compact-small-18. GitHub reports the PR **MERGEABLE / CLEAN**. Ready for final maintainer landing review; not merged.

Regression tests failed before the production fix: the error disclosure did not exist in both ordinary runner failures and newly created cloud sessions. Sanitized before/after screenshots show the clipped baseline and the expanded desktop/320×568 states, including the final diagnostic line and successful Copy feedback. These are real Chromium renders with a deterministic mocked Gateway, not live cloud-provider proof. The parent also opened and interacted with the local rendered preview.

- 440 focused UI tests passed across chat rendering, working indicators, history, abort diagnostics, clipboard/redaction, shell events, and native controls. After moving lifecycle coverage into its own file to respect the existing test-file limit, all 64 shell/native tests passed again.
- 46 built-UI Chromium E2E tests passed across the original diagnostic flows, all four failed sibling assertions, and native sidebar controls:
  `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/cloud-workspace-conflict.e2e.test.ts ui/src/e2e/new-session-page.cloud-startup-failure.e2e.test.ts ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts ui/src/e2e/chat-flow.queue-edit.e2e.test.ts ui/src/e2e/chat-flow.streaming.e2e.test.ts ui/src/e2e/chat-header-session-outcomes.e2e.test.ts ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts`
- Browser assertions cover failed/reclaimed placements, startup rejection with successful and failed history loads, ordinary request errors, exact clipboard text, HTML escaping, text selection, keyboard disclosure/scrolling, desktop/phone bounds, and retained Retry/dismissal ownership.
- `pnpm ui:build` passed, including all 770 compressed sidecars and the startup performance gate.
- Final full changed checks passed: guards, formatting, dead exports, i18n, core-test/UI typechecks, lint, and styles. Command: `git diff --cached --name-only -z | xargs -0 node scripts/check-changed.mjs --base HEAD --` before completing the rebase.
- Fresh independent Codex autoreview is clean at the configured P0 threshold, with no accepted/actionable findings.
- ClawSweeper found no actionable code/security finding; its Rank-up request for green build-artifacts and real-Gateway UI checks is satisfied by run 33040515478. A new review-start placeholder is pending and is not treated as a blocking finding.

Production LOC: +158/−86 (net +72). Tests: +271/−75 (net +196). Docs: +2. Production growth is 66 CSS lines for accessible disclosure/wrapping/scrolling and six net TypeScript/catalog lines, including explicit ownership of shell listener cleanup. No duplicate state or modal path was added.

AI-assisted, maintainer-requested repair. Underlying cloud runtime packaging is a separate root-cause repair; this PR fixes access to the diagnostic, not cloud allocation itself.

![Before: clipped runner error](https://github.com/user-attachments/assets/47653e33-471c-429d-80eb-7fefec994727)

![After: desktop expanded diagnostic and copy feedback](https://github.com/user-attachments/assets/22a4db0d-2abe-450c-abe5-850bb82f9c34)

![After: phone diagnostic final line and copy feedback](https://github.com/user-attachments/assets/85c54237-2ab6-4e6a-bb3f-478e1000403f)
