### PR TITLE
fix(agents): preserve silent reply after settled tools

### DIFF
--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -337,6 +337,7 @@ export function resolveSettledToolTerminalContinuationInstruction(params: {
   );
   if (
     params.payloadCount !== 0 ||
+    (!params.allowEmptyStopContinuation && hasOnlySilentAssistantReply(attempt.assistantTexts)) ||
     params.hasTerminalToolPresentation ||
     params.aborted ||
     ((params.timedOut || terminal.kind === "timeout") && !idlePromptTimeout) ||

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -662,6 +662,60 @@ describe("terminal resolution", () => {
     ).toBeNull();
   });
 
+  it("keeps explicit silence terminal only for reply-optional settled turns", () => {
+    const toolUseAssistant = buildEmbeddedRunnerAssistant({
+      stopReason: "toolUse",
+      content: [{ type: "toolCall", id: "tool-1", name: "write", arguments: {} }],
+    });
+    const silentAssistant = buildEmbeddedRunnerAssistant({
+      stopReason: "stop",
+      content: [{ type: "text", text: SILENT_REPLY_TOKEN }],
+    });
+    const attempt = makeEmbeddedRunnerAttempt({
+      assistantTexts: [SILENT_REPLY_TOKEN],
+      toolMetas: [{ toolName: "write", toolCallId: "tool-1", replaySafe: false }],
+      itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+      messagesSnapshot: [
+        { role: "user", content: [{ type: "text", text: "[OpenClaw heartbeat poll]" }] },
+        toolUseAssistant,
+        { role: "toolResult", toolCallId: "tool-1", toolName: "write", isError: false },
+        silentAssistant,
+      ] as never,
+      lastAssistant: silentAssistant,
+      currentAttemptAssistant: silentAssistant,
+      replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+      currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+    });
+
+    const request = (runParams: {
+      trigger: "heartbeat" | "user";
+      terminalReplyExpectation?: "required";
+    }) =>
+      resolveSettledTurnFinalizationRequest({
+        runParams: {
+          sessionId: "session:settled-silent",
+          runId: "run:settled-silent",
+          ...runParams,
+        } as never,
+        attempt,
+        activeErrorContext: { provider: "openai", model: "gpt-5.6-luna" },
+        modelApi: "openai-responses",
+        executionContract: undefined,
+        payloadsWithToolMedia: [],
+        hasTerminalToolPresentation: false,
+        terminalState: resolveEmbeddedRunAttemptTerminalState({
+          attempt,
+          assistant: silentAssistant,
+        }),
+        settledTurnFinalizationAvailable: true,
+      });
+
+    expect(request({ trigger: "heartbeat" })).toBeNull();
+    expect(request({ trigger: "user", terminalReplyExpectation: "required" })).toBe(
+      SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION,
+    );
+  });
+
   it("requires an available finalizer and no visible structured error", () => {
     const assistant = buildEmbeddedRunnerAssistant({
       stopReason: "toolUse",


### PR DESCRIPTION
## Problem

An embedded heartbeat can use tools, finish with the exact silent token `NO_REPLY`, and still trigger settled-turn finalization. The extra model call can produce unrelated prose that OpenClaw then sends to the user.

## Root cause

Reply payload preparation correctly removes `NO_REPLY` from outbound payloads. Settled-tool recovery then sees zero visible payloads, selects the earlier tool-use assistant as the completed batch, and treats the turn as missing a final answer. It ignored the preserved assistant text that already proved deliberate silence.

Codex treats a completed assistant message as terminal when no tool follow-up remains (`codex-rs/core/src/session/turn.rs:395-501`). OpenClaw owns the additional `NO_REPLY` delivery contract.

## Fix

- Reuse the canonical silent-reply classifier before settled-tool finalization when the caller does not require a visible reply.
- Preserve finalization for required direct turns, blank stops, mixed prose, and failed tools.
- Add owner-boundary regressions for heartbeat silence and the required direct-turn counter-case.

## Proof

- Before the production edit, the heartbeat regression returned the extra-answer prompt instead of `null`.
- Before the scope repair, the direct-required counter-test returned `null` instead of the finalization prompt.
- After the repair: `terminal-resolution.test.ts` and `settled-tool-evidence.test.ts` pass, 73 tests total.
- Formatting, Oxlint, conflict-marker, assertion-safety, max-lines, and diff checks pass.
- Exact-head CI is green: https://github.com/openclaw/openclaw/actions/runs/33039152078
- Exact-head local ClawSweeper: patch correct, zero findings, security cleared before final proof.
- Local content-free OTEL traces on two operator-owned Telegram bots reproduced: heartbeat model call → `read` tool → model call returning `NO_REPLY` → separate isolated model trace → Telegram delivery.
- Final-head Telegram real-user proof: https://github.com/openclaw/openclaw/pull/130675#issuecomment-5434563570

## Final-head Telegram result

The canonical local `telegram-e2e-userbot` recorder drove heartbeat → tool → `NO_REPLY` on `f8d8058a6a0410d5c29fba900c5af91c27a7535e`. The provider received exactly two requests, the second carried the matching tool output, no finalization request occurred, and Telegram observed no SUT message, edit, or deletion.

## Scope

- Production: +1 line.
- Tests: +54 lines.
- No config, storage, protocol, provider, or channel contract changes.
