### PR TITLE
fix(memory): include provider API-key SecretRefs in memory command scope

### DIFF
--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -22,14 +22,13 @@ import {
 } from "./cli.host.runtime.js";
 import type { MemoryCoreAcquireLocalService } from "./memory/embedding-local-service.js";
 import type { ShortTermAuditSummary } from "./short-term-promotion.js";
+import { getMemoryEmbeddingCommandSecretTargetIds } from "../../src/cli/command-secret-targets.js";
 const { warn } = theme;
 export type MemoryManager = NonNullable<
   Awaited<ReturnType<typeof getMemorySearchManager>>["manager"]
 >;
 type MemoryManagerPurpose = Parameters<typeof getMemorySearchManager>[0]["purpose"];
-function getMemoryCommandSecretTargetIds(): Set<string> {
-  return new Set(["memory.search.remote.apiKey", "agents.entries.*.memory.search.remote.apiKey"]);
-}
+
 function isMemorySecretOwnerFailure(error: unknown, message: string): boolean {
   const candidate = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
   if (
@@ -60,7 +59,7 @@ async function loadMemoryCommandConfig(
     const { resolvedConfig, diagnostics } = await resolveCommandSecretRefsViaGateway({
       config,
       commandName,
-      targetIds: getMemoryCommandSecretTargetIds(),
+      targetIds: getMemoryEmbeddingCommandSecretTargetIds(),
       ...(mode ? { mode } : {}),
     });
     return { config: resolvedConfig, diagnostics };


### PR DESCRIPTION
## What Problem This Solves

The memory CLI excludes `models.providers.*` from its SecretRef target scope, so a valid provider-level API-key SecretRef remains unresolved and indexing fails with a misleading `memory.search.remote.apiKey` path.

## Why This Change Was Made

Replace the private `getMemoryCommandSecretTargetIds()` (2 entries) with the shared `getMemoryEmbeddingCommandSecretTargetIds()` from `src/cli/command-secret-targets.ts` which includes all 15+ provider credential paths.

## User Impact

- Previously: memory indexing failed when API key was configured at provider level
- After fix: all provider credential paths are resolved

## Evidence

- Issue: [#129749](https://github.com/openclaw/openclaw/issues/129749) (P2)
- Shared function already exists and is used by the CLI runner