### PR TITLE
refactor(agents): use fixed tool-loop defaults directly

### DIFF
--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -50,33 +50,6 @@ const TOOL_CALL_HISTORY_SIZE = 30;
 export const UNKNOWN_TOOL_THRESHOLD = 10;
 const CRITICAL_THRESHOLD = 20;
 const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
-const DEFAULT_LOOP_DETECTION_CONFIG = {
-  enabled: false,
-  historySize: TOOL_CALL_HISTORY_SIZE,
-  warningThreshold: TOOL_LOOP_WARNING_THRESHOLD,
-  unknownToolThreshold: UNKNOWN_TOOL_THRESHOLD,
-  criticalThreshold: CRITICAL_THRESHOLD,
-  globalCircuitBreakerThreshold: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
-  detectors: {
-    genericRepeat: true,
-    knownPollNoProgress: true,
-    pingPong: true,
-  },
-};
-
-type ResolvedLoopDetectionConfig = {
-  enabled: boolean;
-  historySize: number;
-  warningThreshold: number;
-  unknownToolThreshold: number;
-  criticalThreshold: number;
-  globalCircuitBreakerThreshold: number;
-  detectors: {
-    genericRepeat: boolean;
-    knownPollNoProgress: boolean;
-    pingPong: boolean;
-  };
-};
 
 type ToolLoopDetectionScope = {
   runId?: string;
@@ -88,18 +61,6 @@ function selectHistoryForScope(
 ): ToolCallRecord[] {
   const runId = normalizeRunId(scope?.runId);
   return history.filter((record) => normalizeRunId(record.runId) === runId);
-}
-
-function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedLoopDetectionConfig {
-  return {
-    enabled: config?.enabled ?? DEFAULT_LOOP_DETECTION_CONFIG.enabled,
-    historySize: DEFAULT_LOOP_DETECTION_CONFIG.historySize,
-    warningThreshold: DEFAULT_LOOP_DETECTION_CONFIG.warningThreshold,
-    unknownToolThreshold: DEFAULT_LOOP_DETECTION_CONFIG.unknownToolThreshold,
-    criticalThreshold: DEFAULT_LOOP_DETECTION_CONFIG.criticalThreshold,
-    globalCircuitBreakerThreshold: DEFAULT_LOOP_DETECTION_CONFIG.globalCircuitBreakerThreshold,
-    detectors: DEFAULT_LOOP_DETECTION_CONFIG.detectors,
-  };
 }
 
 /**
@@ -514,8 +475,7 @@ export function detectToolCallLoop(
   config?: ToolLoopDetectionConfig,
   scope?: ToolLoopDetectionScope,
 ): LoopDetectionResult {
-  const resolvedConfig = resolveLoopDetectionConfig(config);
-  if (!resolvedConfig.enabled) {
+  if (!config?.enabled) {
     return { stuck: false };
   }
   const history = selectHistoryForScope(state.toolCallHistory ?? [], scope);
@@ -527,11 +487,9 @@ export function detectToolCallLoop(
   const knownPollTool = isKnownPollToolCall(toolName, params);
   const pingPong = getPingPongStreak(history, currentHash);
   const argumentChurnLivenessSignal =
-    argumentChurn.count >= resolvedConfig.warningThreshold
-      ? ("argument_churn" as const)
-      : undefined;
+    argumentChurn.count >= TOOL_LOOP_WARNING_THRESHOLD ? ("argument_churn" as const) : undefined;
 
-  if (unknownToolStreak.count >= resolvedConfig.unknownToolThreshold) {
+  if (unknownToolStreak.count >= UNKNOWN_TOOL_THRESHOLD) {
     return {
       stuck: true,
       level: "critical",
@@ -542,7 +500,7 @@ export function detectToolCallLoop(
     };
   }
 
-  if (noProgressStreak >= resolvedConfig.globalCircuitBreakerThreshold) {
+  if (noProgressStreak >= GLOBAL_CIRCUIT_BREAKER_THRESHOLD) {
     log.error(
       `Global circuit breaker triggered: ${toolName} repeated ${noProgressStreak} times with no progress`,
     );
@@ -556,11 +514,7 @@ export function detectToolCallLoop(
     };
   }
 
-  if (
-    knownPollTool &&
-    resolvedConfig.detectors.knownPollNoProgress &&
-    noProgressStreak >= resolvedConfig.criticalThreshold
-  ) {
+  if (knownPollTool && noProgressStreak >= CRITICAL_THRESHOLD) {
     log.error(`Critical polling loop detected: ${toolName} repeated ${noProgressStreak} times`);
     return {
       stuck: true,
@@ -572,11 +526,7 @@ export function detectToolCallLoop(
     };
   }
 
-  if (
-    knownPollTool &&
-    resolvedConfig.detectors.knownPollNoProgress &&
-    noProgressStreak >= resolvedConfig.warningThreshold
-  ) {
+  if (knownPollTool && noProgressStreak >= TOOL_LOOP_WARNING_THRESHOLD) {
     log.warn(`Polling loop warning: ${toolName} repeated ${noProgressStreak} times`);
     return {
       stuck: true,
@@ -593,11 +543,7 @@ export function detectToolCallLoop(
     ? `pingpong:${canonicalPairKey(currentHash, pingPong.pairedSignature)}`
     : `pingpong:${toolName}:${currentHash}`;
 
-  if (
-    resolvedConfig.detectors.pingPong &&
-    pingPong.count >= resolvedConfig.criticalThreshold &&
-    pingPong.noProgressEvidence
-  ) {
+  if (pingPong.count >= CRITICAL_THRESHOLD && pingPong.noProgressEvidence) {
     log.error(
       `Critical ping-pong loop detected: alternating calls count=${pingPong.count} currentTool=${toolName}`,
     );
@@ -612,7 +558,7 @@ export function detectToolCallLoop(
     };
   }
 
-  if (resolvedConfig.detectors.pingPong && pingPong.count >= resolvedConfig.warningThreshold) {
+  if (pingPong.count >= TOOL_LOOP_WARNING_THRESHOLD) {
     log.warn(
       `Ping-pong loop warning: alternating calls count=${pingPong.count} currentTool=${toolName}`,
     );
@@ -633,11 +579,7 @@ export function detectToolCallLoop(
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
   ).length;
-  if (
-    !knownPollTool &&
-    resolvedConfig.detectors.genericRepeat &&
-    noProgressStreak >= resolvedConfig.criticalThreshold
-  ) {
+  if (!knownPollTool && noProgressStreak >= CRITICAL_THRESHOLD) {
     log.error(`Critical generic loop detected: ${toolName} repeated ${noProgressStreak} times`);
     return {
       stuck: true,
@@ -649,16 +591,12 @@ export function detectToolCallLoop(
     };
   }
 
-  if (argumentChurn.count >= resolvedConfig.warningThreshold) {
+  if (argumentChurn.count >= TOOL_LOOP_WARNING_THRESHOLD) {
     log.warn(`Argument churn warning: ${toolName} cycled through stable argument patterns`);
     return buildArgumentChurnWarning(toolName, argumentChurn);
   }
 
-  if (
-    !knownPollTool &&
-    resolvedConfig.detectors.genericRepeat &&
-    recentCount >= resolvedConfig.warningThreshold
-  ) {
+  if (!knownPollTool && recentCount >= TOOL_LOOP_WARNING_THRESHOLD) {
     log.warn(`Loop warning: ${toolName} called ${recentCount} times with identical arguments`);
     return {
       stuck: true,
@@ -682,10 +620,9 @@ export function recordToolCall(
   toolName: string,
   params: unknown,
   toolCallId?: string,
-  config?: ToolLoopDetectionConfig,
+  _config?: ToolLoopDetectionConfig,
   scope?: ToolLoopDetectionScope,
 ): void {
-  const resolvedConfig = resolveLoopDetectionConfig(config);
   const runId = normalizeRunId(scope?.runId);
   if (!state.toolCallHistory) {
     state.toolCallHistory = [];
@@ -699,8 +636,8 @@ export function recordToolCall(
     timestamp: Date.now(),
   });
 
-  if (state.toolCallHistory.length > resolvedConfig.historySize) {
-    state.toolCallHistory.splice(0, state.toolCallHistory.length - resolvedConfig.historySize);
+  if (state.toolCallHistory.length > TOOL_CALL_HISTORY_SIZE) {
+    state.toolCallHistory.splice(0, state.toolCallHistory.length - TOOL_CALL_HISTORY_SIZE);
   }
 }
 
@@ -719,7 +656,6 @@ export function recordToolCallOutcome(
     runId?: string;
   },
 ): ToolCallRecord | undefined {
-  const resolvedConfig = resolveLoopDetectionConfig(params.config);
   const runId = normalizeRunId(params.runId);
   const outcome = hashToolOutcome(params.toolName, params.toolParams, params.result, params.error);
   if (!outcome.resultHash && !outcome.outcomeKind) {
@@ -779,8 +715,8 @@ export function recordToolCallOutcome(
     recordedOutcome = record;
   }
 
-  if (state.toolCallHistory.length > resolvedConfig.historySize) {
-    state.toolCallHistory.splice(0, state.toolCallHistory.length - resolvedConfig.historySize);
+  if (state.toolCallHistory.length > TOOL_CALL_HISTORY_SIZE) {
+    state.toolCallHistory.splice(0, state.toolCallHistory.length - TOOL_CALL_HISTORY_SIZE);
   }
   return recordedOutcome;
 }


### PR DESCRIPTION
Related: #111382

<details>
<summary>Additional instructions</summary>

Maintainer-owned branch; maintainer edits remain allowed.

</details>

## What Problem This Solves

The tool-loop detector still rebuilt a private configuration object for thresholds and detector switches that are now fixed built-in defaults. That obsolete indirection duplicates the real policy constants and makes the current behavior harder to audit. This is a maintainer-requested cleanup, not a change to loop-detection policy.

## Why This Change Was Made

Use the existing constants directly and remove the duplicate private config object, resolved type, resolver, and always-true detector conditions. Keep the exported argument positions/types, opt-in setting, thresholds, detector precedence, outcome matching, run scoping, warning text, and history trimming unchanged.

The public numeric/detector options retired in #111382 stay retired. Their doctor migration remains intact for upgrades; this PR only removes the runtime's constant projection. No dependency, schema, storage, API, import, or lazy-loading changes.

## User Impact

No user-visible behavior change. Loop detection remains opt-in and uses exactly the same warning, critical, circuit-breaker, and history limits.

## Evidence

- Production **+16/-80 (net -64)**; tests unchanged.
- Original owner baseline: **83 tests passed**. Final Node 24.19.0 owner/admission/runner-bridge proof: **90 tests across 3 files passed**, including run isolation, outcome reconciliation, vetoes, detector escalation, and batch admission.
- Formatting, typed lint, dead-export scans, runtime and static import-cycle checks, plugin boundaries, doctor/dependency/line/assertion guards, and native-state/database/media/sidecar/webhook/pairing guards passed.
- Independent Codex precommit review of the complete patch and 20 whole owner/caller/test/config contexts: no actionable findings.
- Local full changed gate and core-test typecheck stopped on unrelated stale installed dependency declarations (Google SDK, Pi TUI, and Markdown-it); no diagnostics in the changed owner. The local install also has Vitest 4.1.10 instead of pinned 4.1.11. No dependency overrides or shared-install changes were made. **This proof gap is closed by successful exact-head hosted CI below.**
- A broader E2E attempt stopped before test collection during its implicit build because `@lit/context` was unavailable in the local worktree. No E2E, standalone build, or live-provider result is claimed; this internal constant cleanup changes no build, package, import, or external API surface.

Focused command:

```sh
node scripts/run-vitest.mjs src/agents/tool-loop-detection.test.ts src/agents/tool-loop-admission.test.ts src/agents/embedded-agent-runner/run/tool-loop-recovery.test.ts
```

AI-assisted with Codex; the owner, callers, retained upgrade contract, and proof limitations were manually inspected.

### Exact-head hosted completion

[Ordinary PR CI](https://github.com/openclaw/openclaw/actions/runs/33038389870) completed successfully on `d822f7a2f52c2aa368bbc4963de261730518fa84`. Completed logs confirm Linux Node 24.19.0, the frozen lockfile, and Vitest 4.1.11: the owner passed 83 tests, admission passed 6, and runner recovery passed 1. Full production types, test types (all core shards, plugins, root tests and scripts), typed lint, build artifacts, and the required CI gate passed.

A distinct independent published-head Codex review of the full patch and 24 complete context files also completed with no P0–P3 findings. The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/130681#issuecomment-5434407808) found no actionable defect; its remaining next step was exact-head CI and normal landing checks. CI is now successful and native preparation passed without changing the commit. Its focused replay also passed all 90 tests; the harness did not find a single `Test Files 3 passed` line because the runner reports separate 2-file and 1-file shards, not because tests failed.

The pre-existing volatile-delivery-ID documentation wording identified during review was independently corrected by #130261 while this PR was in flight. Post-merge inspection confirms that correction and the complete upstream nonce-hashing fix are preserved; no follow-up remains for that wording, and this cleanup takes no credit for the upstream repair.

### Landing

Merged as [b5ed58c2bc67504a0009e3b7e46826ff59949ca5](https://github.com/openclaw/openclaw/commit/b5ed58c2bc67504a0009e3b7e46826ff59949ca5) after native hosted-proof preparation and merge both completed successfully. The actual squash removes 64 net production lines and matches the reviewed cleanup after accounting only for shifted hunk coordinates and blob IDs. The temporary native review workspace was removed. Native cleanup reported a remote-branch deletion warning, so the source branch was retained; no force cleanup was attempted.
