### PR TITLE
refactor(models): simplify prepared owner access

### DIFF
--- a/src/agents/embedded-agent-runner/model.generation-scope.test.ts
+++ b/src/agents/embedded-agent-runner/model.generation-scope.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { AuthStorage, ModelRegistry } from "../sessions/index.js";
 import {
   createModelGenerationFixture,
   publishCurrentModelGeneration,
@@ -32,7 +34,48 @@ describe("model runtime generation scope", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     resetModelGenerationFixtureState();
+  });
+
+  it.each([
+    { auth: true, registry: true },
+    { auth: true, registry: false },
+    { auth: false, registry: true },
+    { auth: false, registry: false },
+  ])("fills only missing discovery stores (auth=$auth, registry=$registry)", async (supplied) => {
+    const generation = createModelGenerationFixture({ config: {}, label: "stores" });
+    const { preparedModelRuntime } = generation;
+    const stores = preparedModelRuntime.createStores();
+    stores.authStorage.setRuntimeApiKey(generation.provider, "fixture-runtime-key");
+    const preparedStores = vi.spyOn(preparedModelRuntime, "createStores");
+    const emptyAuth = vi.spyOn(AuthStorage, "inMemory");
+    const emptyRegistry = vi.spyOn(ModelRegistry, "inMemory");
+
+    const result = await resolveModelAsync(
+      generation.provider,
+      generation.modelId,
+      preparedModelRuntime.agentDir,
+      preparedModelRuntime.config,
+      {
+        ...(supplied.auth ? { authStorage: stores.authStorage } : {}),
+        ...(supplied.registry ? { modelRegistry: stores.modelRegistry } : {}),
+        preparedModelRuntime,
+        skipAgentDiscovery: true,
+        workspaceDir: preparedModelRuntime.workspaceDir,
+      },
+    );
+
+    expect(preparedStores).not.toHaveBeenCalled();
+    const allocations = supplied.auth && supplied.registry ? 0 : 1;
+    expect(emptyAuth).toHaveBeenCalledTimes(allocations);
+    expect(emptyRegistry).toHaveBeenCalledTimes(allocations);
+    expect(result.authStorage === stores.authStorage).toBe(supplied.auth);
+    expect(result.modelRegistry === stores.modelRegistry).toBe(supplied.registry);
+    const model = expectDefined(result.model, "resolved fixture model");
+    expect(await result.modelRegistry.getApiKeyAndHeaders(model)).toMatchObject({
+      apiKey: supplied.auth || supplied.registry ? "fixture-runtime-key" : undefined,
+    });
   });
 
   it("keeps alias, suppression, static metadata, and runtime hooks on the prepared generation", async () => {

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -14,12 +14,7 @@ import {
   loadPreparedModelRuntimeSnapshot,
   type PreparedModelRuntimeSnapshot,
 } from "../prepared-model-runtime.js";
-import {
-  AuthStorage as AgentAuthStorageClass,
-  ModelRegistry as AgentModelRegistryClass,
-  type AuthStorage,
-  type ModelRegistry,
-} from "../sessions/index.js";
+import { AuthStorage, ModelRegistry } from "../sessions/index.js";
 import { mergeModelMediaInput } from "./model.compat.js";
 import { buildConfiguredFallbackModel } from "./model.configured-fallback.js";
 import {
@@ -74,15 +69,8 @@ export function createEmptyAgentDiscoveryStores(): {
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
 } {
-  const authStorage =
-    typeof AgentAuthStorageClass.inMemory === "function"
-      ? AgentAuthStorageClass.inMemory({})
-      : AgentAuthStorageClass.create();
-  const modelRegistry =
-    typeof AgentModelRegistryClass.inMemory === "function"
-      ? AgentModelRegistryClass.inMemory(authStorage)
-      : AgentModelRegistryClass.create(authStorage);
-  return { authStorage, modelRegistry };
+  const authStorage = AuthStorage.inMemory({});
+  return { authStorage, modelRegistry: ModelRegistry.inMemory(authStorage) };
 }
 
 function resolvePreparedAgentSnapshot(
@@ -163,18 +151,17 @@ export async function resolveModelAsync(
     const workspaceDir =
       options?.workspaceDir ?? preparedModelRuntime?.workspaceDir ?? derivedWorkspaceDir;
     const normalizedRef = normalizeProviderModelRef({ provider, modelId, cfg, workspaceDir });
-    const preparedStores =
-      !options?.authStorage || !options?.modelRegistry
-        ? preparedModelRuntime?.createStores()
-        : undefined;
-    const fallbackStores =
-      emptyDiscoveryStores ?? preparedStores ?? createEmptyAgentDiscoveryStores();
-    const authStorage = options?.authStorage ?? fallbackStores.authStorage;
-    const modelRegistry =
-      options?.modelRegistry ??
-      (options?.authStorage
-        ? fallbackStores.modelRegistry.fork(authStorage)
-        : fallbackStores.modelRegistry);
+    let { authStorage, modelRegistry } = options ?? {};
+    if (!authStorage || !modelRegistry) {
+      const stores =
+        emptyDiscoveryStores ??
+        preparedModelRuntime?.createStores() ??
+        createEmptyAgentDiscoveryStores();
+      authStorage ??= stores.authStorage;
+      modelRegistry ??= options?.authStorage
+        ? stores.modelRegistry.fork(authStorage)
+        : stores.modelRegistry;
+    }
     const runtimeHooks = resolveRuntimeHooks(options);
     let staticCatalogResolved = false;
     let staticCatalogModel: StaticCatalogFallbackModel | undefined;

--- a/src/agents/prepared-model-catalog.scoped-thinking.test.ts
+++ b/src/agents/prepared-model-catalog.scoped-thinking.test.ts
@@ -1,5 +1,4 @@
-// Boundary proof for the turn-path thinking fallback: manifest first, then a provider-scoped
-// static catalog, then scoped live discovery only for runtime-only models (e.g. Ollama).
+// Turn-path thinking reuses published facts before manifest/scoped discovery fallback.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const manifestCatalogMock = vi.fn((..._args: unknown[]): Array<Record<string, unknown>> => []);
@@ -90,6 +89,7 @@ describe("loadProviderScopedThinkingCatalog", () => {
     });
 
     expect(catalog[0]?.compat?.supportedReasoningEfforts).toContain("ultra");
+    expect(manifestCatalogMock).not.toHaveBeenCalled();
     expect(scopedStaticMock).not.toHaveBeenCalled();
     expect(scopedLiveMock).not.toHaveBeenCalled();
   });

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -163,7 +163,7 @@ export function getPreparedModelCatalogOwnerSnapshot(
   if (publishedFull && preparedModelRuntimeConfigsMatch(publishedFull.config, full.config)) {
     return publishedFull;
   }
-  if (activationFull && activationFull.workspaceDir !== full.workspaceDir) {
+  if (activationFull.workspaceDir !== full.workspaceDir) {
     const activatedFull = getPreparedModelRuntimeSnapshot(activationFull);
     if (activatedFull && preparedModelRuntimeConfigsMatch(activatedFull.config, full.config)) {
       return activatedFull;
@@ -176,7 +176,7 @@ export function getPreparedModelCatalogOwnerSnapshot(
   if (publishedExact && preparedModelRuntimeConfigsMatch(publishedExact.config, exact.config)) {
     return publishedExact;
   }
-  if (!activationExact || activationExact.workspaceDir === exact.workspaceDir) {
+  if (activationExact.workspaceDir === exact.workspaceDir) {
     return undefined;
   }
   const activatedExact = getPreparedModelRuntimeSnapshot(activationExact);
@@ -248,22 +248,6 @@ async function resolvePreparedModelCatalogOwnerSnapshotWithPolicy(
       return lease.snapshot;
     } finally {
       lease.release();
-    }
-  }
-  if (exact !== full) {
-    const fullCandidates =
-      activationFull.workspaceDir === full.workspaceDir ? [full] : [full, activationFull];
-    for (const candidate of fullCandidates) {
-      try {
-        const preparedFull = await prepareModelRuntimeSnapshot(candidate);
-        if (acceptsPreparedSnapshotConfig(preparedFull, full, configPolicy)) {
-          return preparedFull;
-        }
-      } catch (error) {
-        if (!(error instanceof PreparedModelRuntimeOwnerNotPublishedError)) {
-          throw error;
-        }
-      }
     }
   }
   try {
@@ -363,13 +347,6 @@ export async function loadProviderScopedThinkingCatalog(params: {
   agentDir?: string;
   workspaceDir?: string;
 }): Promise<ModelCatalogEntry[]> {
-  const { loadManifestModelCatalog } = await import("./model-catalog.js");
-  const manifestCatalog = normalizeThinkingCatalogProviders(
-    loadManifestModelCatalog({
-      config: params.config,
-      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-    }),
-  );
   const scopedParams = {
     config: params.config,
     ...(params.agentId ? { agentId: params.agentId } : {}),
@@ -401,6 +378,13 @@ export async function loadProviderScopedThinkingCatalog(params: {
   if (publishedCatalog && entryResolved(publishedCatalog.entries)) {
     return await augmentHarnessCatalog(publishedCatalog);
   }
+  const { loadManifestModelCatalog } = await import("./model-catalog.js");
+  const manifestCatalog = normalizeThinkingCatalogProviders(
+    loadManifestModelCatalog({
+      config: params.config,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    }),
+  );
   if (entryResolved(manifestCatalog)) {
     return await augmentHarnessCatalog({
       entries: manifestCatalog,

--- a/src/agents/prepared-model-runtime-materializations.ts
+++ b/src/agents/prepared-model-runtime-materializations.ts
@@ -1,7 +1,6 @@
 import {
   getPreparedRuntimeAuthMaterializations,
   registerRuntimeAuthMaterializationMutationListener,
-  type RuntimeAuthMaterialization,
 } from "./auth-profiles/runtime-materializations.js";
 import { setPreparedModelRuntimeAuthMaterializations } from "./prepared-model-runtime-auth.js";
 import {
@@ -47,7 +46,6 @@ function publishPreparedRuntimeAuthMaterializations(params: {
   owners: ReadonlyMap<string, PreparedModelRuntimeOwner>;
   onInvalidated: () => void;
   onPublished: () => void;
-  read?: (agentDir?: string) => readonly RuntimeAuthMaterialization[];
 }): void {
   const event = {
     ...params.event,
@@ -65,13 +63,12 @@ function publishPreparedRuntimeAuthMaterializations(params: {
   if (affectedOwners.length === 0) {
     return;
   }
-  const read = params.read ?? getPreparedRuntimeAuthMaterializations;
   for (const { owner, snapshot } of affectedOwners) {
     // A successful route only changes this bounded secret-free fact set. Rebuilding the model
     // catalog here would pull plugin lifecycle work into the turn-completion boundary.
     setPreparedModelRuntimeAuthMaterializations(
       snapshot,
-      Object.freeze([...read(owner.input.agentDir)]),
+      Object.freeze([...getPreparedRuntimeAuthMaterializations(owner.input.agentDir)]),
     );
   }
   // Chat metadata treats published as "every configured owner is capturable".

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -117,23 +117,11 @@ export async function loadPreparedModelRuntimeSnapshot(
         throw error;
       }
     }
-    const activationGate = pendingModelRuntimeReplacement;
-    if (activationGate) {
-      await activationGate.promise;
-      if (pendingModelRuntimeReplacement) {
-        continue;
-      }
-      input = rebindInputToCommittedConfiguredOwner(owners, input);
+    if (pendingModelRuntimeReplacement) {
       continue;
     }
     const activated = await activateStandalonePreparedModelRuntime(input);
-    const replacementAfterActivation = pendingModelRuntimeReplacement;
-    if (replacementAfterActivation) {
-      await replacementAfterActivation.promise;
-      if (pendingModelRuntimeReplacement) {
-        continue;
-      }
-      input = rebindInputToCommittedConfiguredOwner(owners, input);
+    if (pendingModelRuntimeReplacement) {
       continue;
     }
     if (!activated) {
@@ -185,29 +173,21 @@ export async function publishPreparedModelRuntimeSnapshot(
     if (!options.force && hasSameLifecycleInput(existing.input, input)) {
       return await existing.pending;
     }
-    return await publishModelRuntimeSnapshot(
-      input,
-      owners,
-      agentBuildCompletions,
-      modelRuntimeBuildTimeoutMs,
-      existing,
-      options.provenance,
-      options.catalogMode,
-    );
-  }
-  if (existing?.buildCompletion) {
-    throw (
-      existing.refreshError ??
-      new Error(`prepared model runtime build is still settling for ${input.agentDir}`)
-    );
-  }
-  if (
-    existing?.snapshot &&
-    !existing.needsRefresh &&
-    !options.force &&
-    hasSameLifecycleInput(existing.input, input)
-  ) {
-    return existing.snapshot;
+  } else {
+    if (existing?.buildCompletion) {
+      throw (
+        existing.refreshError ??
+        new Error(`prepared model runtime build is still settling for ${input.agentDir}`)
+      );
+    }
+    if (
+      existing?.snapshot &&
+      !existing.needsRefresh &&
+      !options.force &&
+      hasSameLifecycleInput(existing.input, input)
+    ) {
+      return existing.snapshot;
+    }
   }
   return await publishModelRuntimeSnapshot(
     input,


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested model architecture cleanup: model resolution and thinking metadata reads do unnecessary discovery work even when the caller already supplies stores or a published generation already answers the lookup. The prepared owner lifecycle also repeats replacement-wait and publication plumbing.

## Why This Change Was Made

Reuse prepared facts before loading the manifest. Fill only missing discovery stores, retaining the injected auth/registry pair and generation boundary. The internal empty-store constructor now uses the in-memory APIs directly; both exist in the current implementation and stable v2026.7.1-2, so its runtime feature-detection fallback has no supported target.

Replacement races return to the existing loop-top wait/rebind owner. Pending publication coalescing, forced supersession, and timed-out-but-still-settling builds retain their distinct decisions. Remove the unreachable exact-versus-full branch and the unused private auth-materialization reader injection. Single-owner and batch publication remain separate because their atomicity and recovery contracts differ.

## User Impact

No public API, config, defaults, provider metadata, storage, or auth behavior change. The same model and thinking results require less duplicate work. Production LOC: +41/-93 (net -52); tests: +46/-3 (net +43).

## Evidence

- Baseline: 152 owner/catalog/lifecycle tests and 12 embedded model-resolution tests passed before edits.
- Failed-before proof: the published-thinking case still called manifest discovery; all four injected-store combinations constructed stores whose results were discarded. The same cases pass after the refactor and verify returned store identity and auth binding.
- After: 168 focused tests in 12 files pass, covering owner selection, replacement/activation, leases, auth materialization, config stamps, thinking, harness catalog, generation scope, skip-discovery, and resolution consistency.
- Independent Codex autoreview of the complete patch is clean.
- Full 15-phase build passed, including all plugin artifacts, SDK declaration/export checks and the Control UI bundle. Four actual CLI catalog views (default, all, local, provider-filtered) match the pre-refactor baseline exactly under isolated HOME/state/config, without credentials.
- Full changed-file gate passed, including formatting, core and core-test typechecks, lint, dead exports, import cycles and ownership/storage guards. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33038746706) is green on d88876881b43ea99df1619abd5d309c8cea05c85.

The lifecycle suite covers replacement during lookup/activation, owner rebinding, workspace retention and timed-out builds. There is no new promise-depth-dependent test for the instant after standalone publication and before its awaiting caller resumes: the changed branch synchronously returns to the already-tested loop-top gate without intervening work. No authenticated inference claim is made for these local owner tests.
