### PR TITLE
fix: cloud machine picker loses CPU and RAM with larger catalogs

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-machine-options.ts
+++ b/extensions/crabbox/src/crabbox-worker-machine-options.ts
@@ -1,7 +1,6 @@
 import type { WorkerProvider } from "openclaw/plugin-sdk/plugin-entry";
 import { asPositiveSafeInteger, isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { CrabboxCommandRunner } from "./crabbox-worker-command.js";
-import { runCrabboxCommand } from "./crabbox-worker-command.js";
 import {
   type CrabboxMachineShape,
   listCrabboxMachineOptions,
@@ -55,11 +54,11 @@ export function createCrabboxMachineOptionsResolver(
   const machineShapesByBinary = new Map<string, Promise<CrabboxMachineShapes>>();
   const loadMachineShapes = async (binary: string): Promise<CrabboxMachineShapes> => {
     try {
-      const result = await runCrabboxCommand({
-        action: "providers",
-        args: ["providers", "--json"],
-        binary,
-        runCommand: dependencies.runCommand,
+      // The full provider matrix exceeds the lifecycle command's 64 KiB log cap.
+      // Keep catalog JSON intact or every provider loses its machine shapes.
+      const result = await dependencies.runCommand([binary, "providers", "--json"], {
+        maxOutputBytes: 1024 * 1024,
+        killProcessTree: true,
         timeoutMs: CRABBOX_MACHINE_CATALOG_TIMEOUT_MS,
       });
       if (result.termination !== "exit" || result.code !== 0) {

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -166,25 +166,34 @@ function hasLoneSurrogate(value: string): boolean {
 }
 
 describe("Crabbox worker provider", () => {
-  it("derives ordered machine classes and shapes while preserving configured defaults", async () => {
+  it("reads large machine catalogs while preserving shapes, order, and configured defaults", async () => {
     const calls: string[][] = [];
-    const provider = providerWithRunner(async (argv) => {
+    const provider = providerWithRunner(async (argv, options) => {
       calls.push(argv);
-      return commandResult({
-        stdout: JSON.stringify([
-          {
-            provider: "aws",
-            classes: [
-              { class: "tiny", type: "c7a.2xlarge", vcpu: 8, memoryGb: 16 },
-              { class: "small", type: "c7a.4xlarge", vcpu: 16, memoryGb: 32 },
-              { class: "standard", type: "c7a.8xlarge", vcpu: 32, memoryGb: 64 },
-              { class: "fast", type: "c7a.16xlarge", vcpu: 64, memoryGb: 128 },
-              { class: "large", type: "c7a.24xlarge", vcpu: 96, memoryGb: 192 },
-              { class: "beast", type: "c7a.48xlarge", vcpu: 192, memoryGb: 384 },
-            ],
-          },
-        ]),
-      });
+      return processRuntime.runCommandWithTimeout(
+        [process.execPath, "-e", "process.stdin.pipe(process.stdout)"],
+        {
+          ...options,
+          input: JSON.stringify([
+            {
+              provider: "unrelated",
+              classCatalog: { metadata: "x".repeat(65_536) },
+            },
+            {
+              provider: "aws",
+              classes: [
+                { class: "tiny", type: "c7a.2xlarge", vcpu: 8, memoryGb: 16 },
+                { class: "small", type: "c7a.4xlarge", vcpu: 16, memoryGb: 32 },
+                { class: "standard", type: "c7a.8xlarge", vcpu: 32, memoryGb: 64 },
+                { class: "fast", type: "c7a.16xlarge", vcpu: 64, memoryGb: 128 },
+                { class: "large", type: "c7a.24xlarge", vcpu: 96, memoryGb: 192 },
+                { class: "beast", type: "c7a.48xlarge", vcpu: 192, memoryGb: 384 },
+              ],
+            },
+            { provider: "machine0", classCatalog: { disposition: "unmapped", profiles: [] } },
+          ]),
+        },
+      );
     });
     expect(provider.supportedExecutionModes).toEqual(["worker-turn", "remote-exec"]);
     expect(await provider.listMachineOptions?.(PROFILE)).toEqual([
@@ -215,6 +224,12 @@ describe("Crabbox worker provider", () => {
       },
     ]);
     await provider.listMachineOptions?.(PROFILE);
+    expect(await provider.listMachineOptions?.({ ...PROFILE, provider: "machine0" })).toEqual([
+      { id: "standard", label: "Standard", default: true },
+      { id: "fast", label: "Fast" },
+      { id: "large", label: "Large" },
+      { id: "beast", label: "Beast" },
+    ]);
     expect(calls.filter((argv) => argv[1] === "providers")).toHaveLength(1);
   });
 


### PR DESCRIPTION
Closes #130660

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled; this branch is in the upstream repository.

</details>

## What Problem This Solves

Fixes an issue where operators choosing a cloud machine would lose CPU/RAM details and additional machine classes when Crabbox's provider catalog grew beyond 64 KiB. The New session picker showed only Standard, Fast, Large, and Beast, even though the provider reported specifications plus Tiny and Small.

## Why This Change Was Made

The bundled Crabbox plugin was reading structured catalog JSON through the lifecycle-command wrapper's truncating 64 KiB log capture. The observed catalog is 81,716 bytes: the command exited successfully, but its captured JSON was invalid and the loader cached an empty catalog.

The catalog owner now uses the existing injected runner with a bounded 1 MiB capture, retaining its timeout and process-tree cleanup. Lifecycle commands keep their existing 64 KiB limit. The UI, provisioning, configuration, machine selection, and cache policy are unchanged; no specifications are hardcoded.

**Best-fix judgment:** repair the structured-data capture at its owner. Hardcoding UI specifications would drift from Crabbox; raising the shared lifecycle-log limit would widen unrelated operations. A provider-specific command/parser rewrite is unnecessary for this already-supported catalog contract.

**Provenance:** the latent capture-limit mismatch was introduced by the CPU/RAM feature in https://github.com/openclaw/openclaw/pull/125696 on August 18, 2026 (code author and merger: @steipete). The renderer remains intact. Crabbox's richer catalog in https://github.com/openclaw/crabbox/pull/1404 made this mismatch observable with the current payload; the exact first historical binary to cross the cap was not rebuilt.

## User Impact

Provider-reported CPU/RAM and the full available class list return. In the verified AWS catalog, Standard shows **32 vCPU · 64 GB**, and Beast shows **192 vCPU · 384 GB**; Tiny and Small are visible again. Default and explicit machine selection still work.

Unknown specifications stay unknown. Machine0 currently advertises an unmapped static class catalog, so this change does not invent CPU/RAM for it or alter its provisioning contract. An existing Gateway must run the updated code and restart to replace its process-lifetime catalog snapshot.

## Evidence

**Real before/after flow:** two isolated, normally authenticated Gateways built from the original and fixed source, each with its own state, OS home, port, and synthetic Git project. Both call the same actual Crabbox development binary (`0.46.0-18-g19bd2f51-dirty`), not a mocked command. Browser access used the normal one-time `openclaw dashboard --json` owner handoff and a real Chromium browser. No mocked Gateway, injected catalog, DOM edits, disabled pairing, or fabricated scopes.

The recorder observed real `environments.list` WebSocket responses and checked the rendered menu. Before: four label-only rows. After: six rows with the actual AWS CPU/RAM values. In both variants, selecting Beast and returning to Standard preserved selection and the Default marker. No cloud worker was provisioned and no model was invoked. Attached screenshots were inspected and cropped to exclude the machine name and private paths.

**Regression and sibling proof:** the extended existing provider test emits a catalog larger than 64 KiB through a real child process and OpenClaw's actual output-capture implementation. It failed before the production change with the exact four label-only fallback symptom; afterward all 165 provider tests and 38 picker/selection tests passed.

Commands run:

```bash
node scripts/run-vitest.mjs extensions/crabbox/src/crabbox-worker-provider.test.ts
```

```bash
node scripts/run-vitest.mjs ui/src/pages/new-session/cloud-target.test.ts ui/src/pages/new-session/where-chip.test.ts ui/src/pages/new-session/discovery.test.ts ui/src/pages/new-session/draft-place-state.test.ts
```

```bash
node scripts/check-changed.mjs -- extensions/crabbox/src/crabbox-worker-machine-options.ts extensions/crabbox/src/crabbox-worker-provider.test.ts
```

The complete changed-file gate passed, including types, formatting, lint, boundary checks, and runtime import cycles. Fresh Codex autoreview reported no accepted/actionable findings. AI-assisted implementation and verification.

**Build note:** the original full `pnpm build` passed. The fixed runtime build passed compilation/postbuild but its first UI performance check exceeded the unchanged startup gzip budget by 5 bytes due to build-timestamp compression variation. Rebuilding the unchanged UI with the original build's recorded timestamp through normal build tooling passed at 343,435 B against the unchanged 343,442 B cap, and the UI outputs are byte-identical between variants. Separate runtime manifests and source hashes identify the before/after runtime code; no generated UI or budget baseline was edited. Exact-head CI remains the landing gate.

**Scope:** production +5/−6 (net −1); tests +32/−17 (net +15). Two changed files, no dependencies or configuration changes.

![Before: cloud machine picker shows four names without CPU or RAM](https://github.com/user-attachments/assets/5b1053a4-7426-4624-911c-f709ecaa49ba)

![After: cloud machine picker shows six classes with provider-reported CPU and RAM](https://github.com/user-attachments/assets/283bd3aa-df20-4733-8122-7d74469e74a3)