### PR TITLE
fix: session creation targets the wrong Gateway after admission

### DIFF
--- a/src/agents/tools/in-process-gateway.test.ts
+++ b/src/agents/tools/in-process-gateway.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { readInProcessAgentRuntimeIdentity } from "../../gateway/in-process-agent-runtime-identity.js";
 import type { GatewayRequestContext } from "../../gateway/server-methods/types.js";
 
@@ -27,6 +28,7 @@ import { withGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 import { getGatewaySessionSpawnContext } from "./gateway-session-spawn-context.js";
 import {
   callAgentToolGatewayRequest,
+  callInProcessGatewayTool,
   callInProcessGatewayToolWithCreation,
   withAgentToolGatewayRuntimeIdentity,
 } from "./in-process-gateway.js";
@@ -107,6 +109,157 @@ describe("trusted in-process Gateway session creation", () => {
       },
     );
     expect(getGatewaySessionSpawnContext()).toBeUndefined();
+  });
+
+  it("keeps session creation on the admitted Gateway through async settlement", async () => {
+    const admitted = { gateway: "admitted" } as unknown as GatewayRequestContext;
+    const replacement = { gateway: "replacement" } as unknown as GatewayRequestContext;
+    const params = { agentId: "main", label: "worker" };
+    const creation = {
+      via: "spawn" as const,
+      actor: { type: "agent" as const, id: "main" },
+      requesterSessionKey: "agent:main:main",
+    };
+    const controller = new AbortController();
+    let current = admitted;
+    let admittedDispatches = 0;
+    let replacementDispatches = 0;
+    const dispatchThroughSelectedGateway = (
+      options:
+        | {
+            resolveGatewayContext?: () => GatewayRequestContext | undefined;
+            sessionCreation?: unknown;
+            signal?: AbortSignal;
+            syntheticScopes?: string[];
+            timeoutMs?: number;
+          }
+        | undefined,
+    ) => {
+      const selected = options?.resolveGatewayContext?.() ?? replacement;
+      if (selected === admitted) {
+        admittedDispatches += 1;
+      } else if (selected === replacement) {
+        replacementDispatches += 1;
+      }
+      return selected;
+    };
+    const runAsAdmittedCaller = async <T>(run: () => Promise<T>) =>
+      await withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          gatewayContextResolver: () => current,
+        },
+        run,
+      );
+
+    mocks.dispatch.mockImplementationOnce(async (_method, _params, options) => {
+      expect(dispatchThroughSelectedGateway(options)).toBe(admitted);
+      expect(options).toEqual({
+        forceSyntheticClient: true,
+        resolveGatewayContext: expect.any(Function),
+        sessionCreation: creation,
+        signal: controller.signal,
+        syntheticScopes: ["operator.write"],
+        timeoutMs: 2_000,
+      });
+      return { key: "agent:main:worker" };
+    });
+
+    await expect(
+      runAsAdmittedCaller(() =>
+        callInProcessGatewayToolWithCreation("sessions.create", params, creation, {
+          signal: controller.signal,
+          timeoutMs: 2_000,
+        }),
+      ),
+    ).resolves.toEqual({ key: "agent:main:worker" });
+    expect(mocks.dispatch).toHaveBeenLastCalledWith("sessions.create", params, expect.any(Object));
+    expect({ admittedDispatches, replacementDispatches }).toEqual({
+      admittedDispatches: 1,
+      replacementDispatches: 0,
+    });
+
+    current = admitted;
+    const dispatchesBeforeReplacement = mocks.dispatch.mock.calls.length;
+    await expect(
+      runAsAdmittedCaller(async () => {
+        current = replacement;
+        return await callInProcessGatewayToolWithCreation("sessions.create", params, creation);
+      }),
+    ).rejects.toThrow("Gateway instance unavailable for sessions.create");
+    expect(mocks.dispatch).toHaveBeenCalledTimes(dispatchesBeforeReplacement);
+    expect(mocks.callGatewayTool).not.toHaveBeenCalled();
+    expect(replacementDispatches).toBe(0);
+
+    for (const settlement of ["resolve", "reject"] as const) {
+      current = admitted;
+      const pendingDispatch = createDeferred<{ key: string }>();
+      mocks.dispatch.mockImplementationOnce(async (_method, _params, options) => {
+        expect(dispatchThroughSelectedGateway(options)).toBe(admitted);
+        return await pendingDispatch.promise;
+      });
+
+      const expectedDispatchCount = mocks.dispatch.mock.calls.length + 1;
+      const creationCall = runAsAdmittedCaller(() =>
+        callInProcessGatewayToolWithCreation("sessions.create", params, creation),
+      );
+      await vi.waitFor(() => expect(mocks.dispatch).toHaveBeenCalledTimes(expectedDispatchCount));
+      current = replacement;
+      if (settlement === "resolve") {
+        pendingDispatch.resolve({ key: "agent:main:worker" });
+      } else {
+        pendingDispatch.reject(new Error("inner dispatch failed"));
+      }
+      await expect(creationCall).rejects.toThrow(
+        "Gateway instance unavailable for sessions.create",
+      );
+      expect(replacementDispatches).toBe(0);
+    }
+  });
+
+  it("retains the generic helper's admitted binding and transport fallback", async () => {
+    const admitted = { gateway: "admitted" } as unknown as GatewayRequestContext;
+    const replacement = { gateway: "replacement" } as unknown as GatewayRequestContext;
+    let current = admitted;
+    mocks.dispatch.mockImplementationOnce(async (_method, _params, options) => ({
+      selected: options?.resolveGatewayContext?.() ?? replacement,
+    }));
+
+    await expect(
+      withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          gatewayContextResolver: () => current,
+        },
+        () => callInProcessGatewayTool("sessions.list", {}),
+      ),
+    ).resolves.toEqual({ selected: admitted });
+
+    current = admitted;
+    await expect(
+      withGatewayToolCallerIdentity(
+        {
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          gatewayContextResolver: () => current,
+        },
+        async () => {
+          current = replacement;
+          return await callInProcessGatewayTool("sessions.list", {});
+        },
+      ),
+    ).rejects.toThrow("Gateway instance unavailable for sessions.list");
+
+    mocks.hasContext = false;
+    await callInProcessGatewayTool("sessions.list", { limit: 5 });
+    expect(mocks.callGatewayTool).toHaveBeenCalledWith(
+      "sessions.list",
+      {},
+      { limit: 5 },
+      { scopes: ["operator.write"] },
+    );
   });
 });
 

--- a/src/agents/tools/in-process-gateway.ts
+++ b/src/agents/tools/in-process-gateway.ts
@@ -232,16 +232,28 @@ export async function callInProcessGatewayToolWithCreation<T = Record<string, un
   options: { signal?: AbortSignal; timeoutMs?: number | null } = {},
 ): Promise<T> {
   const scopes = resolveLeastPrivilegeOperatorScopesForMethod(method, params);
-  if (hasInProcessGatewayContext()) {
-    return await dispatchGatewayMethodInProcess<T>(method, params, {
-      forceSyntheticClient: true,
-      sessionCreation: creation,
-      syntheticScopes: scopes,
-      ...(options.signal ? { signal: options.signal } : {}),
-      ...(options.timeoutMs !== undefined && options.timeoutMs !== null
-        ? { timeoutMs: options.timeoutMs }
-        : {}),
-    });
+  const resolveGatewayContext = callerGatewayContextResolver();
+  const boundGateway = resolveGatewayContext
+    ? bindInProcessGatewayContext(method, resolveGatewayContext)
+    : undefined;
+  if (hasInProcessGatewayContext(boundGateway?.resolve)) {
+    return await runBoundInProcessGatewayCall(
+      boundGateway,
+      async (boundResolver) =>
+        await dispatchGatewayMethodInProcess<T>(method, params, {
+          forceSyntheticClient: true,
+          sessionCreation: creation,
+          syntheticScopes: scopes,
+          ...(options.signal ? { signal: options.signal } : {}),
+          ...(options.timeoutMs !== undefined && options.timeoutMs !== null
+            ? { timeoutMs: options.timeoutMs }
+            : {}),
+          ...(boundResolver ? { resolveGatewayContext: boundResolver } : {}),
+        }),
+    );
+  }
+  if (boundGateway) {
+    throw new Error(`Gateway instance unavailable for ${method}`);
   }
   // The fallback is a real local Gateway request. Carry spawn policy only in
   // the signed agent-runtime identity token, never in model-authored params.


### PR DESCRIPTION
Follow-up to #130112

## What Problem This Solves

Fixes an issue where an agent creating a session could dispatch `sessions.create`
through a different in-process Gateway when the ambient Gateway changed after
the agent run was admitted.

## Why This Change Was Made

Session creation now uses the same admitted-instance binding and settlement
revalidation as the other in-process Gateway tool paths. The request stays on
the Gateway that admitted the caller or fails closed if that Gateway is replaced
before dispatch or before the asynchronous result settles.

The transport fallback, signed visible-spawn policy, timeout and abort handling,
least-privilege scopes, trusted creation provenance, and model-authored request
parameters retain their existing boundaries.

## User Impact

Agent-created sessions remain attached to the Gateway that owns the admitted
run. A retained tool cannot silently create the session through another active
Gateway after replacement.

## Evidence

- Current-main baseline: the focused two-Gateway regression failed on
  `a87fb08e70e3e562c1056da6cf25372b6c64a383` because session creation omitted
  the admitted resolver and selected the ambient replacement Gateway.
- Exact candidate: `153cc87b6f23a887e4e34c7edaed87900cb543e8`.
- Blacksmith Testbox through Crabbox:
  `tbx_01m10qc1d1je4yk56m8vtyvdm5`,
  https://github.com/openclaw/openclaw/actions/runs/33039301825.
- The remote proof fetched the published branch, required `FETCH_HEAD` to equal
  the exact candidate, and verified that the published and synced trees both
  equal `fff54b4d61c1d752df84d054bfe74ff361405bbb` before testing.
- Focused result: `src/agents/tools/in-process-gateway.test.ts` passes 13/13.
- Changed gate: full `core, coreTests` `check:changed` plan passes, including
  production and test types, formatting, oxlint, import cycles, and repository
  guards.
- The regression proves admitted resolver forwarding, zero ambient dispatches,
  replacement rejection before dispatch, and revalidation after both fulfilled
  and rejected asynchronous completion.
- Repository autoreview: clean, no actionable findings.
- Workloop independent review inspected the staged source and proof, marked the
  test-audit obligations satisfied, and found the resolver-forwarding repair and
  corrected regression sound.
- Current `origin/main` at `e87fcb0850697e747e1c73f414aabe4bd6155531`
  has no intervening changes in either scoped file.
- Production LOC: `+22/-10` (net `+12`). Tests: `+153/-0`.
- Provenance: the original creation helper was introduced by Peter Steinberger
  in #111861 on July 23, 2026; #130112 made the admitted resolver available to
  this path but did not forward it through creation dispatch.

Visual proof is not applicable because this changes backend Gateway ownership
without changing rendered UI. The two-Gateway dispatch regression is the direct
behavioral proof.
