### PR TITLE
fix(talk): preserve replacement speech when an old utterance is canceled

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift
@@ -74,6 +74,9 @@ public final class TalkSystemSpeechSynthesizer: NSObject {
             }
         }, onCancel: {
             Task { @MainActor in
+                // A replacement may start before this actor hop runs. Cancellation
+                // must stop only the utterance owned by the canceled call.
+                guard self.currentToken == token else { return }
                 self.stop()
             }
         })

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkSystemSpeechSynthesizerTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkSystemSpeechSynthesizerTests.swift
@@ -3,6 +3,44 @@ import XCTest
 
 @MainActor
 final class TalkSystemSpeechSynthesizerTests: XCTestCase {
+    func testLiveOldCancellationDoesNotStopReplacement() async throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["OPENCLAW_LIVE_TEST"] == "1",
+            "Requires working native speech/audio services; run with OPENCLAW_LIVE_TEST=1.")
+        let speaker = TalkSystemSpeechSynthesizer.shared
+        defer { speaker.stop() }
+        let first = await self.startSpeech()
+        defer { first.cancel() }
+
+        first.cancel()
+        var replacementStarts = 0
+        try await speaker.speak(
+            text: "Replacement speech.", language: "en-US",
+            onStart: { replacementStarts += 1 })
+
+        XCTAssertEqual(replacementStarts, 1)
+        try await self.assertCanceled(first)
+    }
+
+    private func startSpeech() async -> Task<Void, Error> {
+        let started = self.expectation(description: "utterance started")
+        let speech = Task { @MainActor in
+            try await TalkSystemSpeechSynthesizer.shared.speak(
+                text: String(repeating: "This utterance will be interrupted. ", count: 20),
+                language: "en-US",
+                onStart: { started.fulfill() })
+        }
+        await self.fulfillment(of: [started], timeout: 10)
+        return speech
+    }
+
+    private func assertCanceled(_ speech: Task<Void, Error>) async throws {
+        do {
+            try await speech.value
+            XCTFail("Interrupted speech completed successfully")
+        } catch TalkSystemSpeechSynthesizer.SpeakError.canceled {}
+    }
+
     func testWatchdogTimeoutDefaultsToLatinProfile() {
         let timeout = TalkSystemSpeechSynthesizer.watchdogTimeoutSeconds(
             text: String(repeating: "a", count: 100),
@@ -37,7 +75,7 @@ final class TalkSystemSpeechSynthesizerTests: XCTestCase {
 
     func testWatchdogTimeoutClampsVeryLongUtterances() {
         let timeout = TalkSystemSpeechSynthesizer.watchdogTimeoutSeconds(
-            text: String(repeating: "a", count: 10_000),
+            text: String(repeating: "a", count: 10000),
             language: "en-US")
 
         XCTAssertEqual(timeout, 900.0, accuracy: 0.001)


### PR DESCRIPTION
Closes #130674

## What Problem This Solves

Fixes an issue where users could lose replacement system speech in iOS or macOS Talk when the previous speech task was cancelled just before the replacement started. The same shared owner is used by iOS spoken chat pushes.

## Why This Change Was Made

Cancellation schedules cleanup on the main actor. A newer utterance can take ownership before that cleanup runs, so an unconditional stop cancels the wrong operation. Revalidate the existing captured token immediately before stopping, matching the watchdog's ownership check. Explicit public stop remains unconditional; delegate callbacks retain their existing utterance-identity checks.

This is the shared-owner repair, not a caller-specific workaround. No extra state, API, dependency, config, persistence, or fallback is introduced. Production delta is +3/-0: the necessary ownership check and its two-line invariant comment. Tests are separate (+39/-1, including formatter normalization). Moving the check to individual callers would leave other users of the shared synthesizer exposed; introducing another cancellation abstraction would add unnecessary surface.

## User Impact

A cancelled utterance can no longer stop speech that replaced it. Active speech cancellation and explicit stop retain their behavior. This fixes the separately reproduced race in #130674, not every silent-audio, provider, or CarPlay report.

## Evidence

- Real Apple AVSpeechSynthesizer, not a fake: against unchanged main source at `73b98c4b50160a1f57f6a0f9197ae6c6b53c22b4`, ordinary control speech completed, but cancelling A and immediately awaiting B on the main actor cancelled B before its start callback, despite its caller not being cancelled. Reproduced twice. The retained regression also failed on the original source.
- With the token check, replacement speech started and completed; the final opt-in retained regression passed (1 test, 0 failures, 3.269 seconds). Earlier focused coverage also passed active cancellation, explicit stop, and the existing watchdog tests (8 tests, 0 failures).
- Run the retained real-engine regression alone on an audio-capable Mac: `OPENCLAW_LIVE_TEST=1 swift test --package-path apps/shared/OpenClawKit --filter testLiveOldCancellationDoesNotStopReplacement`. It still requires successful replacement completion, exactly one start callback, and cancellation of A. After opt-in, speech errors are failures, not skips.
- Live-audio test is explicitly opt-in: later parallel/rapid lifecycle runs timed out, and the isolated iOS simulator host reported `AudioQueue -66680` / unavailable default audio I/O. Do not make headless CI depend on working speech output, extend timeouts, or replace the assertions with a mock. Default CI compiles the regression but intentionally skips its live execution.
- Physical iPhone was detected, but SwiftPM tool-hosted tests cannot run directly on device. A separate isolated application-host attempt was blocked by missing Foundation development provisioning; no physical-device test is claimed. The simulator host used the exact owner and test source, but failed on the audio-service error above. No visual UI changes; screenshots would not prove this audio ownership race.
- Independent owner/history review and isolated Codex autoreview: no accepted/actionable finding. Read iOS Talk and spoken-chat-push callers, macOS Talk, sibling buffered-audio lifecycle, watchdog/delegate ownership, and Apple's cancellation-handler and AVSpeech stop contracts.
- Provenance: the unconditional cancellation stop exists in [f86772f26ce625314324abba0c7c715913593fc9](https://github.com/openclaw/openclaw/commit/f86772f26ce625314324abba0c7c715913593fc9), authored and committed by Peter Steinberger on December 30, 2025, and in stable `v2026.7.1-2`. The later delegate repair #33304 did not introduce it.

Changed-surface gate passed: `env -u OPENCLAW_TESTBOX PATH="$PWD/.build/swift-tools:$PATH" node scripts/check-changed.mjs -- apps/shared/OpenClawKit/Sources/OpenClawKit/TalkSystemSpeechSynthesizer.swift apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkSystemSpeechSynthesizerTests.swift`. This included Swift lint, repository guards, and 502 passing tests across seven macOS CI shards. Default focused Swift tests also passed with exactly one intentional live-only skip.

Exact-head hosted [CI run 33039448772](https://github.com/openclaw/openclaw/actions/runs/33039448772) passed on attempt 1 for `d97573868434e98da265e5414c142220450067ca`, including macOS Swift, iOS build/lifecycle tests, and the iPhone/Watch and iPad screenshot pipeline. Broader native silent-audio reports remain open; this change does not prove their cause.
