### PR TITLE
fix(ci): stabilize Control UI startup gzip ratchet

### DIFF
--- a/scripts/check-control-ui-performance.mts
+++ b/scripts/check-control-ui-performance.mts
@@ -20,6 +20,7 @@ const DEFAULT_STARTUP_BUDGET_BASELINE_PATH = path.resolve(
 // Each landed change can consume this much ratchet tolerance, so small increases
 // may accumulate. The fixed startup JS ceiling bounds that cumulative creep.
 const CONTROL_UI_STARTUP_JS_GZIP_TOLERANCE_BYTES = 512;
+const CONTROL_UI_STARTUP_JS_GZIP_BUILD_VARIANCE_BYTES = 64;
 
 // Small, explicit headroom over the optimized baseline. Budget changes should
 // accompany an intentional loading or chunking decision.
@@ -151,14 +152,15 @@ export function evaluateControlUiPerformanceBudgets(
   startupJsTolerance = CONTROL_UI_STARTUP_JS_GZIP_TOLERANCE_BYTES,
 ) {
   const baselineBytes = startupBudgetBaseline?.startupJsGzipBytes;
-  const startupJsGzipLimit =
-    baselineBytes === undefined
-      ? budgets.startupJsGzipBytes
-      : Math.min(baselineBytes, budgets.startupJsGzipBytes) + startupJsTolerance;
+  const startupJsLimits = resolveControlUiStartupJsGzipLimits(
+    budgets,
+    startupBudgetBaseline,
+    startupJsTolerance,
+  );
   const checks: Array<[string, number, number, "count" | "bytes"]> = [
     ["startup JS requests", metrics.startup.js.requests, budgets.startupJsRequests, "count"],
     ["startup CSS requests", metrics.startup.css.requests, budgets.startupCssRequests, "count"],
-    ["startup JS gzip", metrics.startup.js.gzipBytes, startupJsGzipLimit, "bytes"],
+    ["startup JS gzip", metrics.startup.js.gzipBytes, startupJsLimits.enforcementLimit, "bytes"],
     ["startup CSS gzip", metrics.startup.css.gzipBytes, budgets.startupCssGzipBytes, "bytes"],
     ["largest JS gzip", metrics.largest.js.gzipBytes, budgets.largestJsGzipBytes, "bytes"],
     ["largest CSS gzip", metrics.largest.css.gzipBytes, budgets.largestCssGzipBytes, "bytes"],
@@ -175,6 +177,30 @@ export function evaluateControlUiPerformanceBudgets(
     });
   }
   return violations;
+}
+
+function resolveControlUiStartupJsGzipLimits(
+  budgets: Readonly<typeof CONTROL_UI_PERFORMANCE_BUDGETS>,
+  startupBudgetBaseline: Readonly<ControlUiStartupBudgetBaseline> | null,
+  startupJsTolerance: number,
+) {
+  const baselineCap = budgets.startupJsGzipBytes;
+  if (!startupBudgetBaseline) {
+    return {
+      baselineCap,
+      growthLimit: baselineCap,
+      buildVariance: 0,
+      enforcementLimit: baselineCap,
+    };
+  }
+  const growthLimit =
+    Math.min(startupBudgetBaseline.startupJsGzipBytes, baselineCap) + startupJsTolerance;
+  return {
+    baselineCap,
+    growthLimit,
+    buildVariance: CONTROL_UI_STARTUP_JS_GZIP_BUILD_VARIANCE_BYTES,
+    enforcementLimit: growthLimit + CONTROL_UI_STARTUP_JS_GZIP_BUILD_VARIANCE_BYTES,
+  };
 }
 
 type ControlUiPerformanceBudgetViolation = ReturnType<
@@ -215,6 +241,11 @@ export function formatControlUiPerformanceReport(
   startupBudgetBaseline: Readonly<ControlUiStartupBudgetBaseline> | null = null,
   startupJsTolerance: number = CONTROL_UI_STARTUP_JS_GZIP_TOLERANCE_BYTES,
 ): string {
+  const startupJsLimits = resolveControlUiStartupJsGzipLimits(
+    budgets,
+    startupBudgetBaseline,
+    startupJsTolerance,
+  );
   const violations = evaluateControlUiPerformanceBudgets(
     metrics,
     budgets,
@@ -223,11 +254,11 @@ export function formatControlUiPerformanceReport(
   );
   const lines = [
     "Control UI performance:",
-    `  startup JS: ${formatAssetSummary(metrics.startup.js)} (limits: ${formatRequestCount(budgets.startupJsRequests)}, ${formatControlUiPerformanceBytes(startupBudgetBaseline ? Math.min(startupBudgetBaseline.startupJsGzipBytes, budgets.startupJsGzipBytes) + startupJsTolerance : budgets.startupJsGzipBytes)} gzip)`,
+    `  startup JS: ${formatAssetSummary(metrics.startup.js)} (limits: ${formatRequestCount(budgets.startupJsRequests)}, ${formatControlUiPerformanceBytes(startupJsLimits.enforcementLimit)} gzip / ${startupJsLimits.enforcementLimit} B)`,
   ];
   if (startupBudgetBaseline) {
     lines.push(
-      `  startup JS gzip vs baseline: ${metrics.startup.js.gzipBytes} B (baseline ${startupBudgetBaseline.startupJsGzipBytes} B + tolerance ${startupJsTolerance} B, max committed baseline ${budgets.startupJsGzipBytes} B)`,
+      `  startup JS gzip vs baseline: ${metrics.startup.js.gzipBytes} B (baseline ${startupBudgetBaseline.startupJsGzipBytes} B + growth allowance ${startupJsTolerance} B = growth limit ${startupJsLimits.growthLimit} B; build-variance allowance ${startupJsLimits.buildVariance} B; enforcement limit ${startupJsLimits.enforcementLimit} B; max committed baseline ${startupJsLimits.baselineCap} B)`,
     );
   }
   lines.push(
@@ -341,6 +372,7 @@ export function runControlUiPerformanceCheck(
     budgets,
     startupBudgetBaseline,
     startupJsTolerance: CONTROL_UI_STARTUP_JS_GZIP_TOLERANCE_BYTES,
+    startupJsBuildVariance: CONTROL_UI_STARTUP_JS_GZIP_BUILD_VARIANCE_BYTES,
     violations,
     report,
   };

--- a/test/scripts/control-ui-performance.test.ts
+++ b/test/scripts/control-ui-performance.test.ts
@@ -206,17 +206,38 @@ describe("Control UI performance budgets", () => {
   });
 
   it("allows startup JS growth exactly at the ratchet tolerance", () => {
-    const violations = evaluateControlUiPerformanceBudgets(
-      createMetrics(326_187),
-      { ...looseBudgets, startupJsGzipBytes: 319 * 1024, largestJsGzipBytes: 400_000 },
-      startupBaseline(325_675),
-    );
+    const metrics = createMetrics(326_187);
+    const baseline = startupBaseline(325_675);
+    const budgets = {
+      ...looseBudgets,
+      startupJsGzipBytes: 319 * 1024,
+      largestJsGzipBytes: 400_000,
+    };
+    const violations = evaluateControlUiPerformanceBudgets(metrics, budgets, baseline);
 
     expect(violations).toEqual([]);
+    expect(formatControlUiPerformanceReport(metrics, budgets, baseline)).toContain(
+      "growth allowance 512 B = growth limit 326187 B",
+    );
   });
 
-  it("fails startup JS growth one byte beyond the ratchet tolerance", () => {
-    const metrics = createMetrics(326_188);
+  it("allows startup JS at the growth plus build-variance boundary", () => {
+    const metrics = createMetrics(326_251);
+    const baseline = startupBaseline(325_675);
+    const budgets = {
+      ...looseBudgets,
+      startupJsGzipBytes: 319 * 1024,
+      largestJsGzipBytes: 400_000,
+    };
+
+    expect(evaluateControlUiPerformanceBudgets(metrics, budgets, baseline)).toEqual([]);
+    expect(formatControlUiPerformanceReport(metrics, budgets, baseline)).toContain(
+      "build-variance allowance 64 B; enforcement limit 326251 B",
+    );
+  });
+
+  it("fails startup JS one byte beyond the growth plus build-variance boundary", () => {
+    const metrics = createMetrics(326_252);
     const baseline = startupBaseline(325_675);
     const budgets = {
       ...looseBudgets,
@@ -228,12 +249,25 @@ describe("Control UI performance budgets", () => {
       evaluateControlUiPerformanceBudgets(metrics, budgets, baseline).map((entry) => entry.metric),
     ).toContain("startup JS gzip");
     expect(formatControlUiPerformanceReport(metrics, budgets, baseline)).toContain(
-      "startup JS gzip: 318.5 KiB exceeds 318.5 KiB (326188 B vs 326187 B)",
+      "startup JS gzip: 318.6 KiB exceeds 318.6 KiB (326252 B vs 326251 B)",
     );
     expect(formatControlUiPerformanceReport(metrics, budgets, baseline)).toContain(
-      "limits: 10 requests, 318.5 KiB gzip",
+      "limits: 10 requests, 318.6 KiB gzip / 326251 B",
     );
   });
+
+  it.each([343_426, 343_464])(
+    "allows same-source startup JS observations within a 38 B spread (%i B)",
+    (startupJsGzipBytes) => {
+      const violations = evaluateControlUiPerformanceBudgets(
+        createMetrics(startupJsGzipBytes),
+        { ...looseBudgets, startupJsGzipBytes: 350 * 1024, largestJsGzipBytes: 400_000 },
+        startupBaseline(342_930),
+      );
+
+      expect(violations).toEqual([]);
+    },
+  );
 
   it("rejects committed startup JS baselines above the fixed cap", () => {
     const budgets = {
@@ -251,7 +285,7 @@ describe("Control UI performance budgets", () => {
     ).toEqual(["startup JS gzip baseline"]);
   });
 
-  it("rejects startup JS measurements above the cap plus tolerance", () => {
+  it("rejects startup JS measurements above the cap plus growth and build variance", () => {
     const budgets = {
       ...looseBudgets,
       startupJsGzipBytes: 319 * 1024,
@@ -260,7 +294,7 @@ describe("Control UI performance budgets", () => {
 
     expect(
       evaluateControlUiPerformanceBudgets(
-        createMetrics(319 * 1024 + 513),
+        createMetrics(319 * 1024 + 577),
         budgets,
         startupBaseline(319 * 1024),
       ).map((entry) => entry.metric),
@@ -292,6 +326,31 @@ describe("Control UI performance budgets", () => {
     expect(() => runControlUiPerformanceCheck(distDir, looseBudgets, baselinePath)).toThrow(
       /Cannot read Control UI startup budget baseline .*--update-baseline/u,
     );
+  });
+
+  it("reports product growth and build variance as separate result fields", () => {
+    const { distDir, writeAsset } = createDistFixture();
+    fs.writeFileSync(
+      path.join(distDir, "index.html"),
+      '<script type="module" src="./assets/index-a.js"></script>\n' +
+        '<link rel="stylesheet" href="./assets/index-c.css">\n',
+    );
+    writeAsset("index-a.js", { rawBytes: 100, gzipBytes: 40, brotliBytes: 30 });
+    writeAsset("index-c.css", { rawBytes: 50, gzipBytes: 15, brotliBytes: 12 });
+    const baselinePath = path.join(distDir, "baseline.json");
+    fs.writeFileSync(
+      baselinePath,
+      JSON.stringify({
+        startupJsGzipBytes: 40,
+        reason: "test baseline",
+        updatedAt: "2026-08-27",
+      }),
+    );
+
+    expect(runControlUiPerformanceCheck(distDir, looseBudgets, baselinePath)).toMatchObject({
+      startupJsTolerance: 512,
+      startupJsBuildVariance: 64,
+    });
   });
 
   it("fails closed when the startup baseline exceeds the configured cap", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where unrelated pull requests could fail the Control UI startup gzip ratchet when identical source builds varied by a few dozen compressed bytes.

The observed hosted failure measured 343,463 B against a 343,442 B limit, while equivalent builds from the same source measured as low as 343,426 B. Same-head measurements varied by up to 38 B.

## Why This Change Was Made

This keeps the existing 512 B product-growth allowance unchanged and adds a separately named 64 B build-variance allowance. The check now calculates and reports the committed baseline cap, growth limit, variance allowance, and final enforcement limit independently.

The baseline JSON, Control UI source, Vite configuration, workflows, and compression behavior are unchanged.

## User Impact

Maintainers get a stable startup-size gate that still blocks meaningful product growth while tolerating the measured compression variance. There is no user-visible UI change.

AI-assisted: yes.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/control-ui-performance.test.ts`: 17/17 passed
  - 512 B growth boundary passes
  - 512 B + 64 B enforcement boundary passes
  - one byte above the enforcement boundary fails
  - two same-source observations spanning 38 B both pass
  - report and result fields distinguish growth from build variance
- `pnpm ui:build`: passed; startup JS measured 343,408 B, with growth limit 343,442 B and enforcement limit 343,506 B
- Exact-head release gate: https://github.com/openclaw/openclaw/actions/runs/33041643291
  - attempt 1 exercised the adjusted gate successfully: startup JS measured 343,443 B against the new 343,506 B final enforcement limit
  - attempt 1 failed only the unrelated `checks-ui-e2e (5/12)` sidebar shard, with 91/92 tests passing; `openclaw/ci-gate` failed derivatively
  - one failed-job-only attempt 2 passed the sidebar shard and `openclaw/ci-gate`, with no new failures
  - the retry establishes accepted exact-head green for this PR; it does not prove the unrelated sidebar test is stable
  - the separate sidebar test remediation is tracked in https://github.com/openclaw/openclaw/pull/130747
- `node_modules/.bin/oxfmt --check scripts/check-control-ui-performance.mts test/scripts/control-ui-performance.test.ts`: passed
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/check-control-ui-performance.mts`: passed
- `pnpm tsgo:scripts`: passed
- `pnpm tsgo:test:root`: passed
- `git diff --check`: passed
- privacy scan: passed
- fresh structured autoreview: Claude fable-5/high, clean with no accepted or actionable findings; Sol/high was unavailable because the standalone Codex CLI is not installed in this lane
