### PR TITLE
refactor(lmstudio): remove unreachable catalog merge

### DIFF
--- a/extensions/lmstudio/src/setup.ts
+++ b/extensions/lmstudio/src/setup.ts
@@ -292,33 +292,6 @@ function resolvePersistedLmstudioApiKey(params: {
     : undefined;
 }
 
-/** Keeps explicit model entries first and appends unique discovered entries. */
-function mergeDiscoveredModels(params: {
-  explicitModels?: ModelDefinitionConfig[];
-  discoveredModels?: ModelDefinitionConfig[];
-}): ModelDefinitionConfig[] {
-  const explicitModels = Array.isArray(params.explicitModels) ? params.explicitModels : [];
-  const discoveredModels = Array.isArray(params.discoveredModels) ? params.discoveredModels : [];
-  if (explicitModels.length === 0) {
-    return discoveredModels;
-  }
-  if (discoveredModels.length === 0) {
-    return explicitModels;
-  }
-
-  const merged = [...explicitModels];
-  const seen = new Set(normalizeStringEntries(explicitModels.map((model) => model.id)));
-  for (const model of discoveredModels) {
-    const id = model.id.trim();
-    if (!id || seen.has(id)) {
-      continue;
-    }
-    seen.add(id);
-    merged.push(model);
-  }
-  return merged;
-}
-
 async function discoverLmstudioProviderCatalog(params: {
   baseUrl?: string;
   apiKey?: string;
@@ -1025,12 +998,7 @@ export async function discoverLmstudioProvider(ctx: ProviderCatalogContext): Pro
       headers: resolvedHeaders,
       quiet: !apiKey && !explicit && !resolvedDiscoveryApiKey,
     }));
-  const models = explicitProvider
-    ? explicitProvider.models
-    : mergeDiscoveredModels({
-        explicitModels: explicit?.models,
-        discoveredModels: provider.models,
-      });
+  const models = provider.models;
   if (models.length === 0 && !apiKey && !explicit?.apiKey) {
     return null;
   }


### PR DESCRIPTION
Related: #130204

## What Problem This Solves

LM Studio catalog discovery still carried a second model-selection path whose merge and deduplication branches could never run. This maintainer-requested cleanup removes misleading policy from a provider boundary that already selects either explicitly configured models or the discovered catalog.

## Why This Change Was Made

Use the selected provider's model array directly and delete the private merge helper. Nonempty explicit models already bypass live discovery; otherwise the helper always returned the discovered array unchanged. The same explicit-model short circuit exists in stable `v2026.7.1`, and #130204 preserved it while consolidating provider assembly.

This is an AI-assisted, behavior-neutral change entirely inside the LM Studio plugin: **production +1/-33, net -32; tests unchanged**. It adds no abstraction and changes no public API, configuration, authentication policy, reasoning metadata, or storage behavior.

## User Impact

No user-visible behavior changes. Explicit model order, duplicate rows, array identity, API selection, authentication/header precedence, empty-catalog handling, and live discovery remain unchanged.

## Evidence

Validated source head: `45cd46f230afc0eb8ea7db4d44fcac4134ffb96b` (baseline `3255882803c78de5103d2d37f7698add84f34c5d`). The LM Studio owner modules are unchanged on the newer inspected `origin/main` at `71d4a8c3e305c623aa3ffe92696eec18f116cfc6`.

- The unchanged setup, registration, and model-discovery suites passed **133 tests across 3 files before and after** the change: `node scripts/run-vitest.mjs extensions/lmstudio/src/setup.test.ts extensions/lmstudio/index.test.ts extensions/lmstudio/src/models.test.ts`, with one worker and distinct test caches.
- Read-only live proof called the actual public `discoverLmstudioProvider` entry point against LM Studio 0.4.21+2. Before and after returned identical full provider JSON for **13 LLMs**. Each run made one model-list GET; explicit configuration retained the original array, including duplicate rows and its Responses API selection, without another network request. LM Studio and Ollama both remained at **zero loaded models**. No inference, model load, service restart, or user configuration write occurred.
- Scoped formatter and the canonical lint wrapper with `--type-aware --type-check`, one thread, and the extensions tsconfig passed with zero diagnostics. The documented artifact-preparation skip avoided only unrelated global SDK preparation; type-aware checking remained enabled. Changed-lane dry run selected extension production and test checks; no full local changed-gate or whole-program typecheck result is claimed.
- The required isolated Codex review through P2 reported no findings. Independent source and proof review covered the same final diff.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33039699152) passed on its first attempt, including all 51 jobs and the required CI gate. All 162 checks on the published head were terminal with no failures or pending checks.
