### PR TITLE
docs(gateway): clarify independent HTTP endpoint switches

### DIFF
--- a/docs/gateway/openai-http-api.md
+++ b/docs/gateway/openai-http-api.md
@@ -15,7 +15,8 @@ Once enabled, it serves all of these on the same port as the Gateway (WS + HTTP 
 | GET    | `/v1/models`           |
 | GET    | `/v1/models/{id}`      |
 | POST   | `/v1/embeddings`       |
-| POST   | `/v1/responses`        |
+
+`POST /v1/responses` is enabled separately with `gateway.http.endpoints.responses.enabled`. See [OpenResponses API](/gateway/openresponses-http-api).
 
 Requests run as a normal Gateway agent run (same codepath as `openclaw agent`), so routing, permissions, and config match your Gateway.
 

--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -10,7 +10,9 @@ The Gateway can serve an OpenResponses-compatible `POST /v1/responses` endpoint.
 
 Requests run as a normal Gateway agent run (same codepath as `openclaw agent`), so routing, permissions, and config match your Gateway.
 
-Enable or disable with `gateway.http.endpoints.responses.enabled`. When enabled, the same compatibility surface also serves `GET /v1/models`, `GET /v1/models/{id}`, `POST /v1/embeddings`, and `POST /v1/chat/completions`.
+Enable or disable with `gateway.http.endpoints.responses.enabled`. When enabled, the same compatibility surface also serves `GET /v1/models`, `GET /v1/models/{id}`, and `POST /v1/embeddings`.
+
+`POST /v1/chat/completions` is enabled separately with `gateway.http.endpoints.chatCompletions.enabled`. See [OpenAI Chat Completions](/gateway/openai-http-api).
 
 ## Authentication, security, and routing
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators following either HTTP API setup page would expect both generation endpoints to work after enabling only one. The other endpoint correctly returns 404, contrary to the old documentation.

## Why This Change Was Made

The Gateway intentionally resolves `chatCompletions.enabled` and `responses.enabled` independently. Both can enable the shared model-discovery and embeddings routes, but neither enables the other generation endpoint. Each page now names the existing independent switch and links to the other setup page.

This corrects the documented contract without changing runtime behavior, authentication, defaults, configuration schema, or protocol. Production LOC: +0/-0. Tests: +0/-0. Documentation: +5/-2 across two files. No changelog change.

## User Impact

Operators can enable the generation endpoint their client actually uses without being misled about the other endpoint. Model discovery and embeddings remain shared as documented.

## Evidence

- Read the configuration resolver, runtime preparation, HTTP router, both generation handlers, and the existing configuration reference. The independent flags originate in `src/gateway/server-runtime-config.ts`; `src/gateway/server-http.ts` gates generation separately and shares only models/embeddings.
- Ran 40 real loopback HTTP assertions against the source config resolver, router, and handlers: all four flag combinations, five routes, and correct/wrong HTTP methods. Enabled generation/embedding handlers returned visible JSON 400 responses for deliberately malformed bodies; enabled model routes returned 200; disabled routes returned 404; wrong methods returned 405 only when enabled. An independent replay also passed all 40 assertions and verified listener/fixture cleanup.
- Passed the changed-file gate and all six docs-check components: formatting, Markdown lint, MDX validation, i18n glossary, internal links, and configuration examples. The link audit checked 6,664 internal links with no broken links; config validation checked 1,206 fences.
- Structured Codex autoreview completed with no P0 findings.

The HTTP proof used isolated temporary configuration, loopback listeners, authentication mode none, and hooks disabled. It did not start the full Gateway kernel, invoke a provider, or validate generated model output. No operator state or external messages were used. The documentation-only change does not alter any of those boundaries.

Provenance: the incorrect cross-enablement statements predate the available shallow history; no introduction is attributed to the history boundary.
