### PR TITLE
refactor(models): simplify picker and thinking projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Doctor checks:** use the host health registry for both lookup and registration in the Crabbox and Codex plugins, preventing duplicate-check errors on repeated lint runs and avoiding a heavyweight health-SDK import during cold discovery.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
 
 - **Control UI agent files:** keep confirmed saves and file metadata intact when older reads or list refreshes finish later, preserve newer drafts, and rebuild invalidated file lists without losing the open editor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Doctor checks:** use the host health registry for both lookup and registration in the Crabbox and Codex plugins, preventing duplicate-check errors on repeated lint runs and avoiding a heavyweight health-SDK import during cold discovery.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
 
 - **Control UI agent files:** keep confirmed saves and file metadata intact when older reads or list refreshes finish later, preserve newer drafts, and rebuild invalidated file lists without losing the open editor.

--- a/extensions/codex/api.ts
+++ b/extensions/codex/api.ts
@@ -11,6 +11,7 @@ const CODEX_PLUGIN_ROOT = path.dirname(fileURLToPath(import.meta.url));
 export { CODEX_MANAGED_APP_SERVER_CHECK_ID };
 
 export function registerCodexManagedAppServerDoctorChecks(host: {
+  getHealthCheck(id: string): HealthCheck | undefined;
   registerHealthCheck(check: HealthCheck): void;
 }): void {
   registerChecks({ ...host, pluginRoot: CODEX_PLUGIN_ROOT });

--- a/extensions/codex/src/doctor.test.ts
+++ b/extensions/codex/src/doctor.test.ts
@@ -78,6 +78,7 @@ function createCheck(deps: ReturnType<typeof managedDeps>) {
   registerCodexManagedAppServerDoctorChecks(
     {
       pluginRoot: "/candidate/plugin",
+      getHealthCheck: () => check,
       registerHealthCheck(value) {
         check = value;
       },
@@ -91,6 +92,25 @@ function createCheck(deps: ReturnType<typeof managedDeps>) {
 }
 
 describe("managed Codex doctor check", () => {
+  it("registers once in each host registry", () => {
+    for (let index = 0; index < 2; index++) {
+      let check: HealthCheck | undefined;
+      const host = {
+        pluginRoot: "/candidate/plugin",
+        getHealthCheck: () => check,
+        registerHealthCheck: vi.fn((value: HealthCheck) => {
+          check = value;
+        }),
+      };
+
+      registerCodexManagedAppServerDoctorChecks(host);
+      registerCodexManagedAppServerDoctorChecks(host);
+
+      expect(host.registerHealthCheck).toHaveBeenCalledOnce();
+      expect(check?.id).toBe(CODEX_MANAGED_APP_SERVER_CHECK_ID);
+    }
+  });
+
   it("accepts the exact pinned native binary without changing explicit long-context config", async () => {
     const cfg = config();
     const before = structuredClone(cfg);

--- a/extensions/codex/src/doctor.ts
+++ b/extensions/codex/src/doctor.ts
@@ -2,7 +2,7 @@ import { execFile } from "node:child_process";
 import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
 import { listAgentIds, resolveAgentDir } from "openclaw/plugin-sdk/agent-scope-runtime";
 import { resolveEffectiveAgentRuntime } from "openclaw/plugin-sdk/command-auth-native";
-import { getHealthCheck, type HealthCheck, type HealthFinding } from "openclaw/plugin-sdk/health";
+import type { HealthCheck, HealthFinding } from "openclaw/plugin-sdk/health";
 import {
   resolveCodexAppServerRuntimeOptions,
   resolveCodexAppServerStartOptionsForAgent,
@@ -32,6 +32,7 @@ type CodexManagedDoctorDependencies = {
 };
 
 type CodexManagedDoctorRegistrationHost = {
+  readonly getHealthCheck: (id: string) => HealthCheck | undefined;
   readonly registerHealthCheck: (check: HealthCheck) => void;
   readonly pluginRoot: string;
 };
@@ -207,7 +208,8 @@ export function registerCodexManagedAppServerDoctorChecks(
   host: CodexManagedDoctorRegistrationHost,
   deps?: CodexManagedDoctorDependencies,
 ): void {
-  if (getHealthCheck(CODEX_MANAGED_APP_SERVER_CHECK_ID)) {
+  // Lookup and registration must use the same host registry across artifact loaders.
+  if (host.getHealthCheck(CODEX_MANAGED_APP_SERVER_CHECK_ID)) {
     return;
   }
   host.registerHealthCheck(

--- a/extensions/crabbox/doctor-health-api.ts
+++ b/extensions/crabbox/doctor-health-api.ts
@@ -12,6 +12,7 @@ const CRABBOX_PLUGIN_ROOT = path.dirname(fileURLToPath(import.meta.url));
 export { CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID };
 
 export function registerWorkerProviderDoctorChecks(host: {
+  getHealthCheck(id: string): HealthCheck | undefined;
   registerHealthCheck(check: HealthCheck): void;
 }): void {
   registerChecks({

--- a/extensions/crabbox/src/doctor.test.ts
+++ b/extensions/crabbox/src/doctor.test.ts
@@ -13,6 +13,7 @@ function captureCrabboxDoctorCheck(): HealthCheck {
   let check: HealthCheck | undefined;
   registerCrabboxWorkerProviderDoctorChecks({
     openclawRoot: OPENCLAW_ROOT,
+    getHealthCheck: () => check,
     registerHealthCheck(value) {
       check = value;
     },

--- a/extensions/crabbox/src/doctor.ts
+++ b/extensions/crabbox/src/doctor.ts
@@ -1,4 +1,4 @@
-import { getHealthCheck, type HealthCheck, type HealthFinding } from "openclaw/plugin-sdk/health";
+import type { HealthCheck, HealthFinding } from "openclaw/plugin-sdk/health";
 import {
   asOptionalRecord as readRecord,
   normalizeOptionalString as nonEmptyString,
@@ -10,6 +10,7 @@ export const CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID = "crabbox/cloud-worker-profi
 
 type CrabboxDoctorRegistrationHost = {
   readonly openclawRoot: string;
+  readonly getHealthCheck: (id: string) => HealthCheck | undefined;
   readonly registerHealthCheck: (check: HealthCheck) => void;
 };
 
@@ -111,7 +112,8 @@ function createCrabboxCloudWorkerProfileCheck(openclawRoot: string): HealthCheck
 export function registerCrabboxWorkerProviderDoctorChecks(
   host: CrabboxDoctorRegistrationHost,
 ): void {
-  if (getHealthCheck(CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID)) {
+  // Lookup and registration must use the same host registry across artifact loaders.
+  if (host.getHealthCheck(CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID)) {
     return;
   }
   host.registerHealthCheck(createCrabboxCloudWorkerProfileCheck(host.openclawRoot));

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -451,18 +451,13 @@ describe("runDoctorLintCli", () => {
     });
     const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     try {
-      const exitCode = await runDoctorLintCli(runtime, {
-        json: true,
-        onlyIds: [CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID],
-      });
-
-      expect(exitCode).toBe(1);
-      expect(
-        await runDoctorLintCli(runtime, {
+      for (let run = 0; run < 2; run++) {
+        const exitCode = await runDoctorLintCli(runtime, {
           json: true,
           onlyIds: [CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID],
-        }),
-      ).toBe(1);
+        });
+        expect(exitCode).toBe(1);
+      }
       const payload = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
       expect(payload).toMatchObject({
         ok: false,

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -457,6 +457,12 @@ describe("runDoctorLintCli", () => {
       });
 
       expect(exitCode).toBe(1);
+      expect(
+        await runDoctorLintCli(runtime, {
+          json: true,
+          onlyIds: [CRABBOX_CLOUD_WORKER_PROFILE_CHECK_ID],
+        }),
+      ).toBe(1);
       const payload = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
       expect(payload).toMatchObject({
         ok: false,

--- a/src/flows/bundled-health-checks.test.ts
+++ b/src/flows/bundled-health-checks.test.ts
@@ -339,6 +339,7 @@ describe("registerBundledHealthChecks", () => {
       artifactCandidates: ["doctor-health-api.js"],
     });
     expect(mocks.registerWorkerProviderDoctorChecks).toHaveBeenCalledWith({
+      getHealthCheck: expect.any(Function),
       registerHealthCheck: expect.any(Function),
     });
   });
@@ -373,6 +374,7 @@ describe("registerBundledHealthChecks", () => {
       artifactBasename: "api.js",
     });
     expect(mocks.registerCodexManagedAppServerDoctorChecks).toHaveBeenCalledWith({
+      getHealthCheck: expect.any(Function),
       registerHealthCheck: expect.any(Function),
     });
   });

--- a/src/flows/bundled-health-checks.ts
+++ b/src/flows/bundled-health-checks.ts
@@ -26,6 +26,7 @@ type EmbeddingProviderSetupInspectionResult =
 // Bridges bundled plugin doctor checks into the core health registry.
 type BundledHealthApi = {
   registerCodexManagedAppServerDoctorChecks?: (host: {
+    getHealthCheck: typeof getHealthCheck;
     registerHealthCheck: typeof registerHealthCheck;
   }) => void;
   pluginStateIsolatedDoctorCheckIds?: readonly string[];
@@ -45,6 +46,7 @@ type BundledHealthApi = {
 
 type WorkerProviderHealthApi = {
   registerWorkerProviderDoctorChecks?: (host: {
+    getHealthCheck: typeof getHealthCheck;
     registerHealthCheck: typeof registerHealthCheck;
   }) => void;
 };
@@ -127,7 +129,7 @@ export function registerBundledHealthChecks(params: {
     loadBundledPluginPublicArtifactModuleSync<BundledHealthApi>({
       dirName: "codex",
       artifactBasename: "api.js",
-    }).registerCodexManagedAppServerDoctorChecks?.({ registerHealthCheck });
+    }).registerCodexManagedAppServerDoctorChecks?.({ getHealthCheck, registerHealthCheck });
   }
   if (shouldRegisterPolicyHealth(params)) {
     loadBundledPluginPublicArtifactModuleSync<BundledHealthApi>({
@@ -160,7 +162,7 @@ function registerBundledWorkerProviderHealthChecks(
     loadBundledPluginPublicArtifactModuleFromCandidatesSync<WorkerProviderHealthApi>({
       dirName: pluginId,
       artifactCandidates: ["doctor-health-api.js"],
-    })?.registerWorkerProviderDoctorChecks?.({ registerHealthCheck });
+    })?.registerWorkerProviderDoctorChecks?.({ getHealthCheck, registerHealthCheck });
   }
 }
 

--- a/src/gateway/session-utils-model.ts
+++ b/src/gateway/session-utils-model.ts
@@ -179,34 +179,11 @@ export function resolveGatewayModelThinkingProfile(params: {
       sessionKey: params.sessionKey,
     });
   const thinkingPolicyProvider = params.thinkingPolicyProvider ?? params.provider;
-  if (!params.rowContext) {
-    return {
-      thinkingLevels: listGatewayThinkingLevelOptions({
-        provider: thinkingPolicyProvider,
-        model: params.model,
-        modelCatalog: params.modelCatalog,
-        agentRuntime,
-        configuredReasoning: params.configuredReasoning,
-        providerPolicySource: params.providerPolicySource,
-      }),
-      thinkingDefault: resolveGatewaySessionThinkingDefault({
-        cfg: params.cfg,
-        provider: params.provider,
-        thinkingPolicyProvider,
-        model: params.model,
-        agentId: params.agentId,
-        modelCatalog: params.modelCatalog,
-        agentRuntime,
-        configuredReasoning: params.configuredReasoning,
-        providerPolicySource: params.providerPolicySource,
-      }),
-    };
-  }
   const key = `${normalizeAgentId(params.agentId)}\0${agentRuntime}\0${normalizeLowercaseStringOrEmpty(thinkingPolicyProvider)}\0${String(params.configuredReasoning)}\0${params.providerPolicySource ?? "active-or-bundled"}\0${createSessionRowModelCacheKey(
     params.provider,
     params.model,
   )}`;
-  const cached = params.rowContext.thinkingMetadataByModelRef.get(key);
+  const cached = params.rowContext?.thinkingMetadataByModelRef.get(key);
   if (cached) {
     return cached;
   }
@@ -231,7 +208,7 @@ export function resolveGatewayModelThinkingProfile(params: {
       providerPolicySource: params.providerPolicySource,
     }),
   };
-  params.rowContext.thinkingMetadataByModelRef.set(key, metadata);
+  params.rowContext?.thinkingMetadataByModelRef.set(key, metadata);
   return metadata;
 }
 

--- a/ui/src/lib/agents/tools-effective.ts
+++ b/ui/src/lib/agents/tools-effective.ts
@@ -4,7 +4,6 @@ import type {
   ToolsEffectiveResult,
 } from "../../api/types.ts";
 import {
-  createChatModelOverride,
   normalizeChatModelOverrideValue,
   resolvePreferredServerChatModelValue,
 } from "../chat/model-ref.ts";
@@ -154,7 +153,7 @@ function resolveEffectiveToolsModelKey(
     return defaultModel;
   }
   if (cachedOverride) {
-    return normalizeChatModelOverrideValue(createChatModelOverride(cachedOverride), catalog);
+    return normalizeChatModelOverrideValue(cachedOverride, catalog);
   }
   const activeRow = state.sessionsResult?.sessions?.find((row) => row.key === resolvedSessionKey);
   if (activeRow?.model) {

--- a/ui/src/lib/chat/model-ref.test.ts
+++ b/ui/src/lib/chat/model-ref.test.ts
@@ -12,7 +12,6 @@ import {
   buildCatalogDisplayLookup,
   buildChatModelOptionFromLookup,
   buildQualifiedChatModelValue,
-  createChatModelOverride,
   formatCatalogChatModelDisplayFromLookup,
   normalizeChatModelOverrideValue,
   resolvePreferredServerChatModelValue,
@@ -111,15 +110,13 @@ describe("chat-model-ref helpers", () => {
   });
 
   it("normalizes raw overrides when the catalog match is unique", () => {
-    expect(normalizeChatModelOverrideValue(createChatModelOverride("gpt-5-mini"), catalog)).toBe(
-      "openai/gpt-5-mini",
-    );
+    expect(normalizeChatModelOverrideValue("gpt-5-mini", catalog)).toBe("openai/gpt-5-mini");
   });
 
   it("keeps ambiguous raw overrides unchanged", () => {
     expect(
       normalizeChatModelOverrideValue(
-        createChatModelOverride("gpt-5-mini"),
+        "gpt-5-mini",
         createAmbiguousModelCatalog("gpt-5-mini", "openai", "openrouter"),
       ),
     ).toBe("gpt-5-mini");

--- a/ui/src/lib/chat/model-ref.ts
+++ b/ui/src/lib/chat/model-ref.ts
@@ -3,16 +3,6 @@ import type { ModelCatalogEntry } from "../../api/types.ts";
 
 const LEGACY_OPENAI_PROVIDER_IDS = new Set(["codex", "openai-codex"]);
 
-export type ChatModelOverride =
-  | {
-      kind: "qualified";
-      value: string;
-    }
-  | {
-      kind: "raw";
-      value: string;
-    };
-
 export function normalizeChatModelProviderId(provider: string): string {
   const normalized = provider.trim().toLowerCase();
   return LEGACY_OPENAI_PROVIDER_IDS.has(normalized) ? "openai" : normalized;
@@ -33,55 +23,17 @@ export function buildQualifiedChatModelValue(model: string, provider?: string | 
     : `${trimmedProvider}/${trimmedModel}`;
 }
 
-export function createChatModelOverride(value: string): ChatModelOverride | null {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-  if (trimmed.includes("/")) {
-    return { kind: "qualified", value: trimmed };
-  }
-  return { kind: "raw", value: trimmed };
-}
-
 export function normalizeChatModelOverrideValue(
-  override: ChatModelOverride | null | undefined,
+  value: string | null | undefined,
   catalog: ModelCatalogEntry[],
 ): string {
-  if (!override) {
-    return "";
-  }
-  const trimmed = override?.value.trim();
+  const trimmed = value?.trim();
   if (!trimmed) {
     return "";
   }
-  if (override.kind === "qualified") {
-    return trimmed;
-  }
-
-  return resolveUniqueCatalogValueById(trimmed, catalog) || trimmed;
-}
-
-function resolveServerChatModelValue(model?: string | null, provider?: string | null): string {
-  if (typeof model !== "string") {
-    return "";
-  }
-  const trimmedModel = model.trim();
-  if (!trimmedModel) {
-    return "";
-  }
-  const trimmedProvider = provider?.trim();
-  if (!trimmedProvider) {
-    return trimmedModel;
-  }
-  const providerPrefix = `${trimmedProvider.toLowerCase()}/`;
-  if (trimmedModel.toLowerCase().startsWith(providerPrefix)) {
-    return trimmedModel;
-  }
-  if (trimmedModel.includes("/")) {
-    return trimmedModel;
-  }
-  return buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
+  return trimmed.includes("/")
+    ? trimmed
+    : resolveUniqueCatalogValueById(trimmed, catalog) || trimmed;
 }
 
 function hasCatalogQualifiedValue(catalog: ModelCatalogEntry[], value: string): boolean {
@@ -132,17 +84,14 @@ export function resolvePreferredServerChatModelValue(
   const trimmedProvider = provider?.trim();
 
   if (!trimmedProvider) {
-    return normalizeChatModelOverrideValue(createChatModelOverride(trimmedModel), catalog);
+    return normalizeChatModelOverrideValue(trimmedModel, catalog);
   }
 
   if (!trimmedModel.includes("/")) {
-    const normalized = normalizeChatModelOverrideValue(
-      createChatModelOverride(trimmedModel),
-      catalog,
-    );
+    const normalized = normalizeChatModelOverrideValue(trimmedModel, catalog);
     return normalized !== trimmedModel
       ? normalized
-      : resolveServerChatModelValue(trimmedModel, trimmedProvider);
+      : buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
   }
 
   const qualifiedServerValue = buildQualifiedChatModelValue(trimmedModel, trimmedProvider);
@@ -176,7 +125,7 @@ export function resolvePreferredServerChatModelValue(
   // Without catalog confirmation, preserve slash-containing server values as-is.
   // Re-qualifying them here can turn an already-qualified ref under a stale
   // provider into a nonsense double-prefix like "zai/openai/gpt-5-mini".
-  return resolveServerChatModelValue(trimmedModel, trimmedProvider);
+  return trimmedModel;
 }
 
 function formatChatModelDisplay(value: string): string {
@@ -270,13 +219,6 @@ export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<str
   return displayLookup;
 }
 
-function formatCatalogEntryDisplay(
-  entry: ModelCatalogEntry,
-  displayLookup: ChatModelDisplayLookup,
-): string {
-  return displayLookup.get(createQualifiedCatalogKey(entry)) ?? formatRawCatalogLabel(entry);
-}
-
 export function formatCatalogChatModelDisplayFromLookup(
   value: string,
   displayLookup: ChatModelDisplayLookup,
@@ -293,9 +235,9 @@ export function buildChatModelOptionFromLookup(
   entry: ModelCatalogEntry,
   displayLookup: ChatModelDisplayLookup,
 ): { value: string; label: string } {
-  const provider = entry.provider?.trim();
+  const value = buildQualifiedChatModelValue(entry.id, entry.provider);
   return {
-    value: buildQualifiedChatModelValue(entry.id, provider),
-    label: formatCatalogEntryDisplay(entry, displayLookup),
+    value,
+    label: displayLookup.get(value.toLowerCase()) ?? formatRawCatalogLabel(entry),
   };
 }

--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -268,35 +268,57 @@ describe("chat-model-select-state", () => {
     ]);
   });
 
-  it("keeps an available OpenAI route when an unavailable legacy route has the same model id", () => {
-    const state = createChatModelState({
-      chatModelCatalog: createModelCatalog(
-        {
-          id: "gpt-5.5",
-          name: "GPT-5.5",
-          provider: "openai",
-          available: true,
-        },
-        {
-          id: "gpt-5.5",
-          name: "GPT-5.5",
-          provider: "codex",
-          available: false,
-        },
-      ),
-      sessionsResult: createSessionsListResult({
-        model: "gpt-5.5",
-        modelProvider: "codex",
-        defaultsModel: "gpt-5.5",
-        defaultsProvider: "codex",
-      }),
-    });
+  it.each([
+    {
+      name: "available",
+      available: true,
+      options: [{ value: "openai/gpt-5.5", label: "GPT-5.5" }],
+    },
+    {
+      name: "indeterminate",
+      available: undefined,
+      options: [{ value: "openai/gpt-5.5", label: "GPT-5.5" }],
+    },
+    {
+      name: "all-cold",
+      available: false,
+      options: [
+        { value: "openai/gpt-5.5", label: "GPT-5.5 · openai", disabled: true },
+        { value: "codex/gpt-5.5", label: "GPT-5.5 · codex", disabled: true },
+      ],
+    },
+  ])(
+    "preserves $name route labels and options beside a cold legacy alias",
+    ({ available, options }) => {
+      const state = createChatModelState({
+        chatModelCatalog: createModelCatalog(
+          {
+            id: "gpt-5.5",
+            name: "GPT-5.5",
+            provider: "openai",
+            available,
+          },
+          {
+            id: "gpt-5.5",
+            name: "GPT-5.5",
+            provider: "codex",
+            available: false,
+          },
+        ),
+        sessionsResult: createSessionsListResult({
+          model: "gpt-5.5",
+          modelProvider: "codex",
+          defaultsModel: "gpt-5.5",
+          defaultsProvider: "codex",
+        }),
+      });
 
-    const resolved = resolveChatModelSelectState(state);
-    expect(resolved.currentOverride).toBe("openai/gpt-5.5");
-    expect(resolved.defaultModel).toBe("openai/gpt-5.5");
-    expect(resolved.options).toEqual([{ value: "openai/gpt-5.5", label: "GPT-5.5" }]);
-  });
+      const resolved = resolveChatModelSelectState(state);
+      expect(resolved.currentOverride).toBe("openai/gpt-5.5");
+      expect(resolved.defaultModel).toBe("openai/gpt-5.5");
+      expect(resolved.options).toEqual(options);
+    },
+  );
 
   it("preserves an exact available OpenAI route when a legacy route is also available", () => {
     const state = createChatModelState({
@@ -384,20 +406,24 @@ describe("chat-model-select-state", () => {
     ).toBe(true);
   });
 
-  it("uses the session provider for fast mode with a slash-containing raw model id", () => {
+  it.each([
+    { name: "missing", providers: [] },
+    { name: "ambiguous", providers: ["xai", "proxy"] },
+  ])("uses the session provider with a $name raw-id catalog", ({ providers }) => {
+    const model = "google/gemma-4-26b-a4b-it";
     const sessionsResult = createSessionsListResult({
-      model: "google/gemma-4-26b-a4b-it",
+      model,
       modelProvider: "xai",
-      defaultsModel: "google/gemma-4-26b-a4b-it",
+      defaultsModel: model,
       defaultsProvider: "xai",
     });
 
     expect(
       resolveChatFastModeSelectState({
         activeRunId: null,
-        catalog: [],
+        catalog: providers.map((provider) => ({ id: model, name: "Gemma", provider })),
         connected: true,
-        currentModelOverride: "google/gemma-4-26b-a4b-it",
+        currentModelOverride: model,
         gatewayAvailable: true,
         loading: false,
         sending: false,

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -11,7 +11,6 @@ import {
   buildCatalogDisplayLookup,
   buildChatModelOptionFromLookup,
   buildQualifiedChatModelValue,
-  createChatModelOverride,
   formatCatalogChatModelDisplayFromLookup,
   normalizeChatModelProviderId,
   normalizeChatModelOverrideValue,
@@ -67,9 +66,8 @@ type ChatFastModeSelectStateInput = {
   stream: string | null;
 };
 
-// Providers with a real runtime fast-mode mapping: anthropic sets
-// service_tier auto/standard_only (extensions/anthropic/stream-wrappers.ts),
-// openai sets service_tier priority, minimax/xai swap to fast model variants.
+// Providers with a runtime fast-mode mapping: Anthropic sets speed (or legacy
+// service_tier), OpenAI sets service_tier priority, MiniMax/xAI select fast variants.
 // Providers without a wire mapping must not offer the toggle.
 const FAST_MODE_PROVIDER_IDS = new Set(["anthropic", "minimax", "minimax-portal", "openai", "xai"]);
 
@@ -93,10 +91,7 @@ export function resolveChatModelOverrideValue(state: ChatModelSelectStateInput):
 
   const sharedOverrides = state.modelOverrides;
   if (Object.hasOwn(sharedOverrides, state.sessionKey)) {
-    const shared = sharedOverrides[state.sessionKey];
-    return shared == null
-      ? ""
-      : normalizeChatModelOverrideValue(createChatModelOverride(shared), catalog);
+    return normalizeChatModelOverrideValue(sharedOverrides[state.sessionKey], catalog);
   }
 
   const activeRow = resolveActiveSessionRow(state);
@@ -156,13 +151,6 @@ function buildChatModelOptions(
 ): ChatModelSelectOption[] {
   const seen = new Set<string>();
   const options: ChatModelSelectOption[] = [];
-  const availableKeys = new Set(
-    catalog
-      .filter((entry) => entry.available !== false)
-      .map((entry) =>
-        normalizeChatModelAvailabilityKey(buildQualifiedChatModelValue(entry.id, entry.provider)),
-      ),
-  );
 
   for (const entry of catalog.toSorted(
     (left, right) =>
@@ -175,12 +163,7 @@ function buildChatModelOptions(
     const option = buildChatModelOptionFromLookup(entry, displayLookup);
     const value = option.value.trim();
     const key = value.toLowerCase();
-    if (
-      !value ||
-      seen.has(key) ||
-      (entry.available === false &&
-        availableKeys.has(normalizeChatModelAvailabilityKey(option.value)))
-    ) {
+    if (!value || seen.has(key)) {
       continue;
     }
     seen.add(key);
@@ -208,13 +191,24 @@ export function resolveChatModelSelectState(
   state: ChatModelSelectStateInput,
 ): ChatModelSelectState {
   const catalog = state.chatModelCatalog ?? [];
-  const displayLookup = buildCatalogDisplayLookup(
-    catalog.filter(
-      (entry) =>
-        entry.available !== false || isChatModelUnavailable(entry.id, entry.provider, catalog),
-    ),
+  const availableKeys = new Set(
+    catalog
+      .filter((entry) => entry.available !== false)
+      .map((entry) =>
+        normalizeChatModelAvailabilityKey(buildQualifiedChatModelValue(entry.id, entry.provider)),
+      ),
   );
-  const options = buildChatModelOptions(catalog, displayLookup);
+  // Catalog members already have a qualified identity. Prepare one retained inventory
+  // so unavailable aliases cannot disambiguate labels for their selectable sibling.
+  const pickerCatalog = catalog.filter(
+    (entry) =>
+      entry.available !== false ||
+      !availableKeys.has(
+        normalizeChatModelAvailabilityKey(buildQualifiedChatModelValue(entry.id, entry.provider)),
+      ),
+  );
+  const displayLookup = buildCatalogDisplayLookup(pickerCatalog);
+  const options = buildChatModelOptions(pickerCatalog, displayLookup);
   const currentOverride = resolveCatalogChatModelValue(
     resolveChatModelOverrideValue(state),
     options,
@@ -266,53 +260,53 @@ export function resolveChatFastModeStatus(session: GatewaySessionRow | undefined
   return `${t("chat.commandResults.fast.current", { value })}${sourceSuffix}.`;
 }
 
-function resolveProviderFromModelValue(
+function resolveFastModeProvider(
   value: string,
   catalog: ModelCatalogEntry[],
-  providerHint: string | null,
+  sessionProvider: string | null,
+  defaultProvider: string | null,
 ): string | null {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
+  const normalizedValue = value.trim().toLowerCase();
+  if (!normalizedValue) {
+    return sessionProvider ?? defaultProvider;
   }
-  const normalizedValue = trimmed.toLowerCase();
-  const idProviders = new Set(
-    catalog
-      .filter((entry) => entry.id.trim().toLowerCase() === normalizedValue)
-      .map((entry) => normalizeChatModelProviderId(entry.provider))
-      .filter(Boolean),
-  );
-  const qualifiedProviders = new Set(
-    catalog
-      .filter(
-        (entry) =>
-          buildQualifiedChatModelValue(entry.id, entry.provider).trim().toLowerCase() ===
-          normalizedValue,
-      )
-      .map((entry) => normalizeChatModelProviderId(entry.provider))
-      .filter(Boolean),
-  );
+  const idProviders = new Set<string>();
+  const qualifiedProviders = new Set<string>();
+  let hasCatalogMatch = false;
+  for (const entry of catalog) {
+    const matchesId = entry.id.trim().toLowerCase() === normalizedValue;
+    const matchesQualified =
+      buildQualifiedChatModelValue(entry.id, entry.provider).trim().toLowerCase() ===
+      normalizedValue;
+    if (!matchesId && !matchesQualified) {
+      continue;
+    }
+    hasCatalogMatch = true;
+    const provider = normalizeChatModelProviderId(entry.provider);
+    if (provider) {
+      if (matchesId) {
+        idProviders.add(provider);
+      }
+      if (matchesQualified) {
+        qualifiedProviders.add(provider);
+      }
+    }
+  }
   if (qualifiedProviders.size === 1) {
     return [...qualifiedProviders][0] ?? null;
   }
-  if (providerHint && idProviders.has(providerHint) && !qualifiedProviders.has(providerHint)) {
-    return providerHint;
+  if (
+    sessionProvider &&
+    idProviders.has(sessionProvider) &&
+    !qualifiedProviders.has(sessionProvider)
+  ) {
+    return sessionProvider;
   }
-  return idProviders.size === 1 ? ([...idProviders][0] ?? null) : null;
-}
-
-function hasCatalogProviderMetadata(value: string, catalog: ModelCatalogEntry[]): boolean {
-  const normalizedValue = value.trim().toLowerCase();
-  if (!normalizedValue) {
-    return false;
+  if (idProviders.size === 1) {
+    return [...idProviders][0] ?? null;
   }
-  return catalog.some((entry) => {
-    const normalizedId = entry.id.trim().toLowerCase();
-    const qualifiedValue = buildQualifiedChatModelValue(entry.id, entry.provider)
-      .trim()
-      .toLowerCase();
-    return normalizedId === normalizedValue || qualifiedValue === normalizedValue;
-  });
+  // An ambiguous catalog match must not be replaced by a stale session/default provider.
+  return hasCatalogMatch ? null : (sessionProvider ?? defaultProvider);
 }
 
 export function resolveChatFastModeSelectState(
@@ -324,18 +318,12 @@ export function resolveChatFastModeSelectState(
   const activeProvider = normalizeChatModelProviderId(activeRow?.modelProvider ?? "") || null;
   const defaultProvider =
     normalizeChatModelProviderId(input.sessionsResult?.defaults?.modelProvider ?? "") || null;
-  const catalogHasProviderMetadata = hasCatalogProviderMetadata(
+  const effectiveProvider = resolveFastModeProvider(
     input.currentModelOverride,
     input.catalog,
+    activeProvider,
+    defaultProvider,
   );
-  const fallbackProvider =
-    !input.currentModelOverride || !catalogHasProviderMetadata
-      ? (activeProvider ?? defaultProvider)
-      : null;
-  const effectiveProvider =
-    resolveProviderFromModelValue(input.currentModelOverride, input.catalog, activeProvider) ??
-    fallbackProvider ??
-    null;
   const configuredOverride =
     activeRow?.fastMode === "auto"
       ? "auto"


### PR DESCRIPTION
## What Problem This Solves

The chat model picker, tool-model selection, and Gateway thinking metadata repeat the same normalization/projection work in several branches. This maintainer-requested cleanup removes those parallel paths while preserving the models, labels, defaults, and controls operators see.

While diagnosing this PR's Doctor CI timeout, repeated lint execution exposed an existing registry-ownership bug in Crabbox, also reproduced in Codex: the plugin looked up a check through its own SDK module graph but registered it into the host's registry. With separate artifact-loader graphs, the second invocation registered the same ID again and threw instead of returning diagnostics.

## Why This Change Was Made

Keep each decision with its existing owner: the UI prepares one retained catalog for picker options and label disambiguation; model references normalize directly from their stored strings; Gateway thinking metadata has one projection with optional request-local caching. Fast-mode provider matching scans the catalog once, retaining qualified-route precedence and refusing stale-provider fallback for ambiguous catalog matches.

Removed the transient override union/constructor, a caller-dominated server-ref fallback, repeated picker availability scans, and duplicate cached/uncached thinking projection. No new abstraction or dependency, public/config/default surface, persistence change, or provider catalog metadata change.

The Doctor repair passes lookup alongside registration through both bundled plugin artifacts, following the existing memory-core contract. It removes the runtime health-barrel back-edge. CUA and Policy already deduplicate explicit hosts and also support a separate implicit-global registration contract; those paths are unchanged. Codex's remaining broad model/runtime SDK imports are a separate cold-loading follow-up, not needed to repair registry ownership.

Production LOC: +91/-177 (net -86). Tests: +92/-45 (net +47). The Doctor portion adds eight net production lines to carry the actual host registry across the plugin boundary; the consumer cleanup removes 94. No pure moves or generated files. Release-note context is in this body; the final documentation-only commit removes the root changelog entry to follow current main's release-owned policy.

## User Impact

No intended change to model selection. Nested IDs, legacy saved route aliases, unavailable models, ambiguous providers, session pins versus inherited defaults, and request-owned tool selection keep their existing contracts. Repeated Doctor lint now uses the same host registry for lookup and registration. Probe behavior, check selection, config, and stored data are unchanged. The provider fast-mode allowlist remains unchanged: replacing it requires authoritative route/auth-bound capability metadata, which is a separate follow-up, not something to infer from effective session configuration.

## Evidence

- Baseline: 291 tests across eight Gateway/UI files passed. Candidate: all 294 tests passed, including the expanded available/indeterminate/all-cold alias table and ambiguous nested-ID provider case. These are refactor-retention cases, not claimed bug regressions.
- Gateway tests cover session/default projection, cached and uncached thinking, runtime policy, ACP ownership, serialization, and row-context reuse. UI tests cover reference resolution, picker availability, agent tool-model ownership, and session overrides.
- Independent Codex autoreview of the complete patch: no actionable findings.
- Freshly bundled Chromium proof: three E2E tests passed across chat model switching/reasoning synchronization and chat/Agents alias display. Before/after screenshots were visually inspected and contain only fixture data. The browser uses a mocked Gateway WebSocket; this is not authenticated provider inference.
- Original consumer full changed gate passed. Expanded host tests: 26 core registration tests, all 19 Crabbox/Codex plugin tests, and all 25 whole-file Doctor lint tests passed. One earlier whole-file run timed out in deferred SQLite inspection; the retry passed with unchanged assertions and timeout. The repeat-call test was compressed into a loop after CI caught the file-length limit; its independent review and targeted lint passed.
- Real built CLI proof: isolated `doctor --lint --json --only crabbox/cloud-worker-profiles` returns exactly one actionable missing-binary finding and exit 1; the Codex managed-app-server check accepts the installed pinned artifact and exits 0. Both built plugin APIs register once per independent host across repeated calls. No operator Gateway or private profile was used.
- The expanded local changed gate passed through core/core-test/UI typechecks, Doctor contract closure, plugin boundaries, dead exports, and earlier guards. Both extension typecheck lanes are blocked locally by the absent unchanged `@daytona/sdk` dependency in the shared worktree install; no dependency reconciliation was performed. Exact-head hosted CI owns complete installed-dependency coverage.
- All CI-artifact build phases completed, including 147 SDK export checks, 48 native-loaded control-plane closures and the rebuilt Control UI performance gate. The declaration step initially exhausted Node's default 4 GiB heap; resuming it and the remaining official phases with CI's existing `--max-old-space-size=8192` budget passed. Runtime source is unchanged by the subsequent test-only loop commit.
- Doctor regression proof: before the fix, the repeated real Crabbox lint case threw `health check already registered: crabbox/cloud-worker-profiles`; the Codex independent-host test registered twice instead of once. An additional built Codex artifact probe reproduced the duplicate registration. The unchanged whole Doctor lint file passed locally before adding the repeat-call regression; the CI timeout is not being described as a measured performance attribution.

Provenance: Crabbox's mismatch came from #124995 (code author, PR author, and merger @steipete; August 18, 2026). Codex's matching pattern came from #124137 (code author Jason / PR author and merger @fuller-stack-dev; August 16, 2026). This PR repairs the host boundary without changing the existing version probe. Direct upstream source inspection checked `codex-rs/cli/src/main.rs:98-113` at `d47e5cc0e2bbd35774dff15c83570519735d2ac4`, where the CLI enables Clap's version option.

ClawSweeper follow-through: the latest review at 06:25 UTC on the final head found no actionable patch defects. Its remaining rank-up requests are complete: [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33045361758) passed on `995fc460b6797e0fb84d267025a586752a54cef0`, and the lead personally inspected the unchanged upstream Codex version contract in [codex-rs/cli/src/main.rs](https://github.com/openai/codex/blob/d47e5cc0e2bbd35774dff15c83570519735d2ac4/codex-rs/cli/src/main.rs#L98). The review worker lacked that sibling checkout; the maintainer verification did not. The CI guard initially hit a 120-second Git fetch timeout; its targeted unchanged retry passed. The built command owner also passes twice in the same process for each affected check: Crabbox returns exit 1 / one finding / one check on both calls; Codex returns exit 0 / zero findings / one check on both calls. Separate real CLI parser runs pass. The stored-data detector is not applicable: there is no schema, serialized field, or persistence behavior change. Independent Codex autoreviews of the consumer cleanup, complete Doctor repair, final test-loop cleanup, and documentation-only changelog removal are clean.

Focused command:

```sh
node scripts/run-vitest.mjs src/gateway/session-utils.test.ts src/gateway/session-utils.perf.test.ts src/gateway/session-utils-model.acp-owner.test.ts src/gateway/server.sessions.thinking-e2e.test.ts ui/src/lib/chat/model-ref.test.ts ui/src/lib/chat/model-select-state.test.ts ui/src/lib/agents/index.test.ts ui/src/lib/sessions/session-model-override.test.ts
```

Best-fix judgment: consolidate the existing owners, rather than introduce a cross-layer model registry or duplicate provider policy in the UI. Core runtime selection, plugin metadata, auth boundaries, and persisted values are unchanged. Code inspection covered the complete production owners and their chat/session/Agents callers, Gateway row construction and thinking handlers, adjacent tests, and model metadata stores. No authenticated provider inference is claimed for this behavior-neutral consumer refactor.

![Before: fixture catalog aliases in the chat picker](https://github.com/user-attachments/assets/801abcd3-bc4b-4136-91f0-f849f07a867d)

![After: the same catalog labels and routes](https://github.com/user-attachments/assets/6c008478-9517-4ebd-a5fc-2dcd41f46ede)

![After: saved model switch updates supported reasoning](https://github.com/user-attachments/assets/d8174bae-cb59-46d2-8126-14044ef30f8f)
