### PR TITLE
fix(telegram): strip malformed reply directives before channel delivery

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -315,3 +315,12 @@ describe("sanitizeReplyDirectiveId", () => {
     expect(hasUnpairedSurrogate("a😊b")).toBe(false);
   });
 });
+
+describe("malformed reply directive stripping", () => {
+  it("strips incomplete reply_to_current tags", () => {
+    expect(stripInlineDirectiveTagsForDelivery("Hello [[reply_to_current")).toBe("Hello");
+  });
+  it("strips incomplete reply_to tags", () => {
+    expect(stripInlineDirectiveTagsForDelivery("Hello [[reply_to:someone")).toBe("Hello");
+  });
+});

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -25,6 +25,7 @@ type InlineDirectiveParseOptions = {
 // delivery intent; persisted transcripts already carry openclawDelivery facts).
 const AUDIO_TAG_RE = /\[\[\s*audio_as_voice\s*\]\]/gi;
 const REPLY_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*([^\]\n]+))\s*\]\]/gi;
+const MALFORMED_REPLY_DIRECTIVE_RE = /\[\[\s*(?:reply_to_current\]?(?!\])|reply_to\s*:\s*[^\]\n]*)\s*\]?(?!\])/gi;
 const INLINE_DIRECTIVE_TAG_WITH_PADDING_RE =
   /\s*(?:\[\[\s*audio_as_voice\s*\]\]|\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\])\s*/gi;
 const MAX_REPLY_DIRECTIVE_ID_LENGTH = 256;

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -158,9 +158,10 @@ export function stripInlineDirectiveTagsForDelivery(text: string): StripInlineDi
     return { text, changed: false };
   }
   const stripped = replaceOutsideCodeRegions(text, INLINE_DIRECTIVE_TAG_WITH_PADDING_RE, () => " ");
-  const changed = stripped !== text;
+  const malformedStripped = replaceOutsideCodeRegions(stripped, MALFORMED_REPLY_DIRECTIVE_RE, () => " ");
+  const changed = malformedStripped !== text;
   return {
-    text: changed ? stripped.trim() : text,
+    text: changed ? malformedStripped.trim() : text,
     changed,
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Telegram group replies can expose an internal reply directive in the visible message when the model emits a malformed tag like `[[reply_to_current]` instead of `[[reply_to_current]]`.

## Why This Change Was Made

In `src/utils/directive-tags.ts:22`, the `REPLY_TAG_RE` regex requires a complete `]]` terminator. Malformed tags pass through all stripping functions unchanged. A new `MALFORMED_REPLY_DIRECTIVE_RE` catches incomplete patterns.

## User Impact

- Previously: malformed reply directives leaked into visible Telegram messages
- After fix: incomplete directive prefixes are stripped before delivery

## Evidence

- Issue: [#129154](https://github.com/openclaw/openclaw/issues/129154) (P2)
- Fix applies to all channels via shared module