### PR TITLE
fix(agents): key tool report digest cache on content hash instead of object identity

### DIFF
--- a/src/agents/system-prompt-report.ts
+++ b/src/agents/system-prompt-report.ts
@@ -13,7 +13,7 @@ import type { WorkspaceBootstrapFile } from "./workspace.js";
 
 type ToolReportEntry = SessionSystemPromptReport["tools"]["entries"][number];
 
-const toolReportEntryCache = new WeakMap<AgentTool, ToolReportEntry>();
+const toolReportEntryCache = new Map<string, ToolReportEntry>();
 const toolSchemaStatsCache = new WeakMap<
   object,
   Pick<ToolReportEntry, "propertiesCount" | "schemaChars" | "schemaHash">
@@ -84,7 +84,10 @@ function buildToolSchemaStats(
 
 function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools"]["entries"] {
   return tools.map((tool) => {
-    const cached = toolReportEntryCache.get(tool);
+    const name = tool.name ?? tool.label ?? "";
+  const summary = (typeof tool.description === "string" ? tool.description : "").trim();
+  const cacheKey = name + "\0" + summary;
+  const cached = toolReportEntryCache.get(cacheKey);
     if (cached) {
       return cached;
     }
@@ -93,7 +96,7 @@ function buildToolsEntries(tools: AgentTool[]): SessionSystemPromptReport["tools
     const summaryChars = summary.length;
     const schemaStats = buildToolSchemaStats(tool.parameters);
     const entry = { name, summaryChars, summaryHash: sha256(summary), ...schemaStats };
-    toolReportEntryCache.set(tool, entry);
+    toolReportEntryCache.set(cacheKey, entry);
     return entry;
   });
 }


### PR DESCRIPTION
## What Problem This Solves

The per-tool report digest cache uses `WeakMap<AgentTool, ...>` keyed on tool object identity. The producer rebuilds tool objects every call, so the cache misses 100% of the time.

## Why This Change Was Made

Replace `WeakMap<AgentTool, ...>` with `Map<string, ...>` keyed on `name + "\0" + description`. This is a pure function of those fields.

## User Impact

- Previously: tool report generation rebuilt entries from scratch every time
- After fix: stable content-keyed cache eliminates redundant work

## Evidence

- Issue: [#129116](https://github.com/openclaw/openclaw/issues/129116) (P3)