### PR TITLE
fix(memory): keep indexing after memory folder replacement

### DIFF
--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -1,7 +1,7 @@
 // Memory Core plugin module owns memory filesystem watch synchronization.
 import fsSync from "node:fs";
 import path from "node:path";
-import chokidar, { type FSWatcher } from "chokidar";
+import chokidar from "chokidar";
 import { isPathInside } from "openclaw/plugin-sdk/file-access-runtime";
 import { classifyMemoryMultimodalPath } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import {
@@ -9,6 +9,7 @@ import {
   type ResolvedMemorySearchConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import {
+  isFileMissingError,
   matchesExtraMemoryPathEntry,
   normalizeExtraMemoryPathEntries,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
@@ -43,10 +44,12 @@ const TEST_MEMORY_NATIVE_WATCH_FACTORY_KEY = Symbol.for("openclaw.test.memoryNat
 
 type NativeMemoryWatchPair = {
   dir: string;
-  main: fsSync.FSWatcher;
+  main: fsSync.FSWatcher | null;
   parent: fsSync.FSWatcher | null;
   treeWatchers?: Map<string, LinuxMemoryDirectoryWatcher>;
 };
+
+type NativeMemoryWatchResult = "attached" | "missing" | "failed";
 
 type LinuxMemoryDirectoryWatcher = {
   watcher: fsSync.FSWatcher;
@@ -190,38 +193,15 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
         ? this.attachNativeMemoryWatchForDir(dir, markDirty)
         : process.platform === "linux"
           ? this.attachLinuxMemoryDirectoryTreeWatchForDir(dir, markDirty)
-          : false;
-      if (!attached) {
+          : "failed";
+      if (attached !== "attached") {
         // Native creation failed (dir missing, unsupported FS, throw) —
         // fall back to chokidar so directory coverage isn't dropped.
         fileWatchPaths.add(dir);
       }
     }
     if (fileWatchPaths.size > 0) {
-      const existingWatcher = this.currentMemoryChokidarWatcher();
-      if (existingWatcher) {
-        existingWatcher.add(Array.from(fileWatchPaths));
-      } else {
-        const watcher = resolveMemoryWatchFactory()(Array.from(fileWatchPaths), {
-          ignoreInitial: true,
-          ignored: (watchPath, stats) =>
-            shouldIgnoreMemoryWatchPath(watchPath, stats, this.settings.multimodal),
-        });
-        this.watcher = watcher;
-        watcher.on("add", markDirty);
-        watcher.on("change", markDirty);
-        watcher.on("unlink", markDirty);
-        watcher.on("unlinkDir", markDirty);
-        watcher.on("error", (err) => {
-          // File watcher errors (e.g., ENOSPC) should not crash the gateway.
-          // Log the error and continue - memory search still works without auto-sync.
-          const message = err instanceof Error ? err.message : String(err);
-          log.warn(`memory watcher error: ${message}`);
-        });
-        watcher.once("ready", () => {
-          this.warnIfMemoryWatchPressure(countChokidarWatchedEntries(watcher), "paths");
-        });
-      }
+      this.attachMemoryChokidarPaths(Array.from(fileWatchPaths), markDirty);
     }
     this.scheduleMemoryWatchPressureStartupCheck();
   }
@@ -265,35 +245,31 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     );
   }
 
-  private currentMemoryChokidarWatcher(): FSWatcher | null {
-    return this.watcher;
-  }
-
-  // Attach a native recursive `fs.watch` to `dir` plus a non-recursive
-  // parent-directory watch that detects root-replacement
-  // (`rm -rf memory && mkdir memory`) by inode comparison. Returns true if
-  // the main native watcher attached. Called from ensureWatcher(); also
-  // re-entered from the parent-watch handler on detected replacement.
+  // Pair recursive coverage with a parent watch that survives root replacement.
   protected attachNativeMemoryWatchForDir(
     dir: string,
     markDirty: (watchPath?: string, stats?: MemoryWatchEventStats) => void,
-  ): boolean {
+  ): NativeMemoryWatchResult {
     if (this.closed) {
-      return false;
+      return "failed";
     }
     let recordedInode: number | null;
     try {
       recordedInode = fsSync.statSync(dir).ino;
-    } catch {
-      // Dir doesn't exist; caller will fall back to chokidar.
-      return false;
+    } catch (err) {
+      // Startup falls back; an existing parent can wait for a missing root.
+      return isFileMissingError(err) ? "missing" : "failed";
     }
-    let mainWatcher: fsSync.FSWatcher;
+    const pair: NativeMemoryWatchPair = { dir, main: null, parent: null };
+    let mainWatcher: fsSync.FSWatcher | undefined;
     try {
       mainWatcher = resolveMemoryNativeWatchFactory()(
         dir,
         { recursive: true },
         (_eventType, filename) => {
+          if (this.closed || (mainWatcher && pair.main !== mainWatcher)) {
+            return;
+          }
           if (filename == null) {
             // Node docs: filename may be null on some platforms even when
             // recursive watching is otherwise supported. Be conservative
@@ -318,13 +294,19 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
         },
       );
     } catch (err) {
+      if (isFileMissingError(err)) {
+        return "missing";
+      }
       log.warn(
         `failed to start native recursive watcher on ${dir}: ${String(err)}; falling back to chokidar`,
       );
-      return false;
+      return "failed";
     }
-    const pair: NativeMemoryWatchPair = { dir, main: mainWatcher, parent: null };
+    pair.main = mainWatcher;
     mainWatcher.on("error", (err) => {
+      if (pair.main !== mainWatcher) {
+        return;
+      }
       const message = err instanceof Error ? err.message : String(err);
       log.warn(`memory native watcher error on ${dir}: ${message}`);
       // Per Node docs the FSWatcher is no longer usable after an error.
@@ -340,6 +322,21 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       this.attachMemoryChokidarFallback(dir, markDirty);
     });
     this.nativeMemoryWatchPairs.push(pair);
+    this.attachNativeMemoryParentWatch(pair, recordedInode, markDirty, "native", () =>
+      this.attachNativeMemoryWatchForDir(dir, markDirty),
+    );
+    return "attached";
+  }
+
+  private attachNativeMemoryParentWatch(
+    pair: NativeMemoryWatchPair,
+    recordedInode: number,
+    markDirty: (watchPath?: string, stats?: MemoryWatchEventStats) => void,
+    label: "native" | "Linux",
+    reattach: () => NativeMemoryWatchResult,
+  ): void {
+    const { dir } = pair;
+    let watchedInode: number | null = recordedInode;
     // Non-recursive parent watcher: catches root-directory replacement so
     // we can reattach the main watcher on the new inode. Without this,
     // `rm -rf memory && mkdir memory` would leave the main watcher bound
@@ -347,73 +344,97 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     try {
       const parentDir = path.dirname(dir);
       const baseName = path.basename(dir);
-      const parentWatcher = resolveMemoryNativeWatchFactory()(
+      const parentInode = fsSync.statSync(parentDir).ino;
+      let parentWatcher: fsSync.FSWatcher | null = null;
+      parentWatcher = resolveMemoryNativeWatchFactory()(
         parentDir,
         { recursive: false },
         (_eventType, filename) => {
+          if (this.closed || (parentWatcher && pair.parent !== parentWatcher)) {
+            return;
+          }
           // Per Node docs `filename` can be null on some platforms even
           // when the parent watcher is otherwise supported. Treat null
           // as an unknown event and re-check the watched directory's inode;
           // otherwise filter by basename so sibling events don't trigger reattach.
-          if (filename !== null && filename !== baseName) {
+          // A retained parent can itself be replaced while the root is absent.
+          // Its self-rename must reach the inode check before we trust it again.
+          if (
+            filename !== null &&
+            filename !== baseName &&
+            (pair.main || filename !== path.basename(parentDir))
+          ) {
             return;
           }
-          let currentInode: number | null;
+          let currentInode: number | null = null;
+          let result: NativeMemoryWatchResult = "missing";
           try {
             currentInode = fsSync.statSync(dir).ino;
-          } catch {
-            currentInode = null;
+          } catch (err) {
+            result = isFileMissingError(err) ? "missing" : "failed";
+            if (result === "missing") {
+              try {
+                if (fsSync.statSync(parentDir).ino !== parentInode) {
+                  result = "failed";
+                }
+              } catch {
+                result = "failed";
+              }
+            }
           }
-          if (currentInode === recordedInode) {
+          if (currentInode === watchedInode && result !== "failed") {
             return;
           }
-          // Root was replaced (or removed). Tear down the existing pair
-          // and either reattach (if dir still exists) or fall back to
-          // chokidar (if dir is gone).
-          this.closeNativeMemoryWatchPair(pair);
-          if (this.closed) {
-            return;
-          }
+          // Keep the parent authoritative while the root is absent. Chokidar's
+          // asynchronous missing-path setup can miss an immediate recreation.
+          this.closeNativeMemoryWatchChildren(pair);
+          watchedInode = null;
           markDirty();
           if (currentInode !== null) {
-            // Re-attach on the new inode (this also installs a fresh
-            // parent watcher closed over the new recordedInode). If the
-            // helper's own statSync races with the dir disappearing
-            // between our inode check and its own check, it returns
-            // false — fall back to chokidar so coverage isn't lost.
-            if (!this.attachNativeMemoryWatchForDir(dir, markDirty)) {
-              this.attachMemoryChokidarFallback(dir, markDirty);
-            }
-          } else {
+            result = reattach();
+          }
+          if (result === "missing") {
+            return;
+          }
+          // New coverage must attach before the old parent closes: the root
+          // can disappear again between the inode check and native attachment.
+          this.closeNativeMemoryWatchPair(pair);
+          if (result === "failed") {
             this.attachMemoryChokidarFallback(dir, markDirty);
           }
         },
       );
-      parentWatcher.on("error", (err) => {
+      const attachedParent = parentWatcher;
+      attachedParent.on("error", (err) => {
+        if (pair.parent !== attachedParent) {
+          return;
+        }
         const message = err instanceof Error ? err.message : String(err);
-        log.warn(`memory native parent watcher error on ${path.dirname(dir)}: ${message}`);
+        log.warn(`memory ${label} parent watcher error on ${path.dirname(dir)}: ${message}`);
         try {
-          parentWatcher.close();
+          attachedParent.close();
         } catch {
           // ignore
         }
-        this.removeNativeMemoryParentWatch(parentWatcher);
-        if (pair.parent === parentWatcher) {
-          pair.parent = null;
+        pair.parent = null;
+        if (!pair.main) {
+          this.closeNativeMemoryWatchPair(pair);
+          if (!this.closed) {
+            markDirty();
+            this.attachMemoryChokidarFallback(dir, markDirty);
+          }
         }
-        // Main watcher still alive — root-replacement detection is lost
-        // but normal events still flow. No fallback needed.
+        // A live main watcher still covers normal events without its parent.
       });
-      pair.parent = parentWatcher;
+      pair.parent = attachedParent;
     } catch (err) {
       // Parent watcher couldn't start (e.g. parentDir not accessible).
       // The main watcher still works for non-replacement events; just
       // log and continue.
       log.warn(
-        `memory native parent watcher could not start on ${path.dirname(dir)}: ${String(err)}`,
+        `memory ${label} parent watcher could not start on ${path.dirname(dir)}: ${String(err)}`,
       );
     }
-    return true;
   }
 
   // Linux inotify reports direct child changes from a watched directory, but
@@ -422,19 +443,20 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
   protected attachLinuxMemoryDirectoryTreeWatchForDir(
     dir: string,
     markDirty: (watchPath?: string, stats?: MemoryWatchEventStats) => void,
-  ): boolean {
+  ): NativeMemoryWatchResult {
     if (this.closed) {
-      return false;
+      return "failed";
     }
     let recordedInode: number | null;
     try {
       recordedInode = fsSync.statSync(dir).ino;
-    } catch {
-      return false;
+    } catch (err) {
+      return isFileMissingError(err) ? "missing" : "failed";
     }
 
     let pair: NativeMemoryWatchPair | null = null;
     const treeWatchers = new Map<string, LinuxMemoryDirectoryWatcher>();
+    let rootMissing = false;
 
     const closeAndFallback = (message: string) => {
       log.warn(message);
@@ -474,7 +496,8 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
           return null;
         }
         currentInode = currentStat.ino;
-      } catch {
+      } catch (err) {
+        rootMissing ||= watchDir === dir && isFileMissingError(err);
         return null;
       }
       const existing = treeWatchers.get(watchDir);
@@ -484,12 +507,15 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
         }
         closeDirectorySubtree(watchDir);
       }
-      let watcher: fsSync.FSWatcher;
+      let watcher: fsSync.FSWatcher | undefined;
       try {
         watcher = resolveMemoryNativeWatchFactory()(
           watchDir,
           { recursive: false },
           (eventType, filename) => {
+            if (this.closed || (watcher && treeWatchers.get(watchDir)?.watcher !== watcher)) {
+              return;
+            }
             if (filename == null) {
               markDirty();
               if (!this.attachLinuxMemoryDirectoryTreeSubtree(watchDir, attachDirectory)) {
@@ -528,7 +554,8 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
           },
         );
       } catch (err) {
-        if (watchDir === dir) {
+        rootMissing ||= watchDir === dir && isFileMissingError(err);
+        if (watchDir === dir && !rootMissing) {
           log.warn(
             `failed to start Linux memory directory watcher on ${watchDir}: ${String(err)}; falling back to chokidar`,
           );
@@ -537,6 +564,9 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       }
       treeWatchers.set(watchDir, { watcher, ino: currentInode });
       watcher.on("error", (err) => {
+        if (treeWatchers.get(watchDir)?.watcher !== watcher) {
+          return;
+        }
         const detail = err instanceof Error ? err.message : String(err);
         closeAndFallback(`memory Linux directory watcher error on ${watchDir}: ${detail}`);
       });
@@ -545,70 +575,30 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
 
     const mainWatcher = attachDirectory(dir);
     if (!mainWatcher) {
-      return false;
+      return rootMissing ? "missing" : "failed";
     }
     pair = { dir, main: mainWatcher, parent: null, treeWatchers };
     this.nativeMemoryWatchPairs.push(pair);
-    if (!this.attachLinuxMemoryDirectoryTreeSubtree(dir, attachDirectory)) {
+    let subtreeAttached = this.attachLinuxMemoryDirectoryTreeSubtree(dir, attachDirectory);
+    // Scan errors can refer to a missing child, not the root. Only the root's
+    // identity can decide whether an existing parent should retain coverage.
+    try {
+      subtreeAttached = fsSync.statSync(dir).ino === recordedInode && subtreeAttached;
+    } catch (err) {
+      this.closeNativeMemoryWatchPair(pair);
+      return isFileMissingError(err) ? "missing" : "failed";
+    }
+    if (!subtreeAttached) {
       closeAndFallback(
         `failed to attach Linux memory directory watcher subtree under ${dir}; falling back to chokidar`,
       );
-      return true;
+      return "attached";
     }
 
-    try {
-      const parentDir = path.dirname(dir);
-      const baseName = path.basename(dir);
-      const parentWatcher = resolveMemoryNativeWatchFactory()(
-        parentDir,
-        { recursive: false },
-        (_eventType, filename) => {
-          if (filename !== null && filename !== baseName) {
-            return;
-          }
-          let currentInode: number | null;
-          try {
-            currentInode = fsSync.statSync(dir).ino;
-          } catch {
-            currentInode = null;
-          }
-          if (currentInode === recordedInode) {
-            return;
-          }
-          this.closeNativeMemoryWatchPair(pair);
-          if (this.closed) {
-            return;
-          }
-          markDirty();
-          if (currentInode !== null) {
-            if (!this.attachLinuxMemoryDirectoryTreeWatchForDir(dir, markDirty)) {
-              this.attachMemoryChokidarFallback(dir, markDirty);
-            }
-          } else {
-            this.attachMemoryChokidarFallback(dir, markDirty);
-          }
-        },
-      );
-      parentWatcher.on("error", (err) => {
-        const message = err instanceof Error ? err.message : String(err);
-        log.warn(`memory Linux parent watcher error on ${path.dirname(dir)}: ${message}`);
-        try {
-          parentWatcher.close();
-        } catch {
-          // ignore
-        }
-        this.removeNativeMemoryParentWatch(parentWatcher);
-        if (pair?.parent === parentWatcher) {
-          pair.parent = null;
-        }
-      });
-      pair.parent = parentWatcher;
-    } catch (err) {
-      log.warn(
-        `memory Linux parent watcher could not start on ${path.dirname(dir)}: ${String(err)}`,
-      );
-    }
-    return true;
+    this.attachNativeMemoryParentWatch(pair, recordedInode, markDirty, "Linux", () =>
+      this.attachLinuxMemoryDirectoryTreeWatchForDir(dir, markDirty),
+    );
+    return "attached";
   }
 
   private attachLinuxMemoryDirectoryTreeSubtree(
@@ -649,7 +639,7 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     return true;
   }
 
-  private closeNativeMemoryWatchPair(pair: NativeMemoryWatchPair): void {
+  private closeNativeMemoryWatchChildren(pair: NativeMemoryWatchPair): void {
     if (pair.treeWatchers) {
       for (const entry of pair.treeWatchers.values()) {
         try {
@@ -661,11 +651,16 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       pair.treeWatchers.clear();
     } else {
       try {
-        pair.main.close();
+        pair.main?.close();
       } catch {
         // ignore close failures
       }
     }
+    pair.main = null;
+  }
+
+  private closeNativeMemoryWatchPair(pair: NativeMemoryWatchPair): void {
+    this.closeNativeMemoryWatchChildren(pair);
     if (pair.parent) {
       try {
         pair.parent.close();
@@ -687,15 +682,6 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     }
   }
 
-  private removeNativeMemoryParentWatch(w: fsSync.FSWatcher): void {
-    for (const pair of this.nativeMemoryWatchPairs) {
-      if (pair.parent === w) {
-        pair.parent = null;
-        return;
-      }
-    }
-  }
-
   private removeNativeMemoryWatchPair(pair: NativeMemoryWatchPair): void {
     const idx = this.nativeMemoryWatchPairs.indexOf(pair);
     if (idx >= 0) {
@@ -703,10 +689,8 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
     }
   }
 
-  // Reattach `dir` to chokidar after a native recursive watcher dies, so
+  // Reattach `dir` to chokidar after a native watcher dies, so
   // subsequent memory changes under `dir` continue to drive watch sync.
-  // Called from the native watcher `error` handler in ensureWatcher();
-  // factored out so the fallback shape can be unit-tested in isolation.
   protected attachMemoryChokidarFallback(
     dir: string,
     markDirty: (watchPath?: string, stats?: MemoryWatchEventStats) => void,
@@ -716,34 +700,40 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       return;
     }
     try {
-      if (this.watcher) {
-        // Existing chokidar watcher (handling MEMORY.md and/or other file
-        // paths) — extend it to cover this directory too.
-        this.watcher.add(dir);
-        return;
-      }
-      // No chokidar watcher exists yet. Spin one up just for this directory
-      // so the periodic-sync gap is closed.
-      const watcher = resolveMemoryWatchFactory()([dir], {
-        ignoreInitial: true,
-        ignored: (watchPath, stats) =>
-          shouldIgnoreMemoryWatchPath(watchPath, stats, this.settings.multimodal),
-      });
-      this.watcher = watcher;
-      watcher.on("add", markDirty);
-      watcher.on("change", markDirty);
-      watcher.on("unlink", markDirty);
-      watcher.on("unlinkDir", markDirty);
-      watcher.on("error", (err) => {
-        const message = err instanceof Error ? err.message : String(err);
-        log.warn(`memory watcher error: ${message}`);
-      });
-      watcher.once("ready", () => {
-        this.warnIfMemoryWatchPressure(countChokidarWatchedEntries(watcher), "paths");
-      });
+      this.attachMemoryChokidarPaths(dir, markDirty);
     } catch (err) {
       log.warn(`failed to attach chokidar fallback for ${dir}: ${String(err)}`);
     }
+  }
+
+  private attachMemoryChokidarPaths(
+    paths: string | string[],
+    markDirty: (watchPath?: string, stats?: MemoryWatchEventStats) => void,
+  ): void {
+    // Linux subtree startup can create the fallback before ensureWatcher
+    // attaches file paths. Reuse that watcher rather than replacing it.
+    if (this.watcher) {
+      this.watcher.add(paths);
+      return;
+    }
+    const watcher = resolveMemoryWatchFactory()(typeof paths === "string" ? [paths] : paths, {
+      ignoreInitial: true,
+      ignored: (watchPath, stats) =>
+        shouldIgnoreMemoryWatchPath(watchPath, stats, this.settings.multimodal),
+    });
+    this.watcher = watcher;
+    watcher.on("add", markDirty);
+    watcher.on("change", markDirty);
+    watcher.on("unlink", markDirty);
+    watcher.on("unlinkDir", markDirty);
+    watcher.on("error", (err) => {
+      // File watcher errors must not crash the gateway; manual search still works.
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`memory watcher error: ${message}`);
+    });
+    watcher.once("ready", () => {
+      this.warnIfMemoryWatchPressure(countChokidarWatchedEntries(watcher), "paths");
+    });
   }
 
   protected ensureIntervalSync() {

--- a/extensions/memory-core/src/memory/manager-watch-ops.ts
+++ b/extensions/memory-core/src/memory/manager-watch-ops.ts
@@ -586,6 +586,9 @@ export abstract class MemoryManagerWatchOps extends MemoryManagerSyncBase {
       subtreeAttached = fsSync.statSync(dir).ino === recordedInode && subtreeAttached;
     } catch (err) {
       this.closeNativeMemoryWatchPair(pair);
+      if (!this.closed) {
+        markDirty();
+      }
       return isFileMissingError(err) ? "missing" : "failed";
     }
     if (!subtreeAttached) {

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -261,65 +261,88 @@ describe("memory watcher config", () => {
     expect(result.manager.status().backend).toBe("builtin");
     expect(result.manager.status().sources).toContain("memory");
     manager = result.manager as unknown as MemoryIndexManager;
+    return manager;
   }
 
-  it("routes directories to native recursive fs.watch and files to chokidar", async () => {
+  async function setupParentWatchLifecycle(platform: NodeJS.Platform, extraRoot = false) {
+    Object.defineProperty(process, "platform", { value: platform, configurable: true });
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-    const cfg = createWatcherConfig();
-
-    await expectWatcherManager(cfg);
-
-    // Chokidar should only see file paths (MEMORY.md); directories use native watch.
-    expect(watchMock).toHaveBeenCalledTimes(1);
-    const [chokidarPaths, chokidarOptions] = watchMock.mock.calls[0] as unknown as [
-      string[],
-      Record<string, unknown>,
-    ];
-    expect(chokidarPaths).toStrictEqual([
-      path.join(workspaceDir, "MEMORY.md"),
-      path.join(workspaceDir, "USER.md"),
-    ]);
-    expect(chokidarPaths.filter((watchedPath) => watchedPath.includes("*"))).toEqual([]);
-    expect(chokidarOptions.ignoreInitial).toBe(true);
-    expect(chokidarOptions).not.toHaveProperty("awaitWriteFinish");
-
-    // Native fs.watch should receive memory/ and extraDir as recursive watches.
-    // Each watched directory installs a main recursive watcher PLUS a
-    // non-recursive parent-directory watcher used to detect root
-    // replacement (see attachNativeMemoryWatchForDir). 2 dirs × 2 watchers
-    // each = 4 native fs.watch calls.
-    expect(nativeWatchMock).toHaveBeenCalledTimes(4);
-    const mainNativeCalls = (
-      nativeWatchMock.mock.calls as unknown as [string, { recursive?: boolean }, unknown][]
-    ).filter((call) => call[1].recursive === true);
-    const parentNativeCalls = (
-      nativeWatchMock.mock.calls as unknown as [string, { recursive?: boolean }, unknown][]
-    ).filter((call) => call[1].recursive !== true);
-    expect(mainNativeCalls.map((call) => call[0])).toStrictEqual(
-      expect.arrayContaining([path.join(workspaceDir, "memory"), extraDir]),
+    const parentDir = extraRoot ? path.join(extraDir, "parent") : workspaceDir;
+    const dir = path.join(parentDir, "memory");
+    await fs.mkdir(dir, { recursive: true });
+    const activeManager = await expectWatcherManager(
+      createWatcherConfig({ extraPaths: extraRoot ? [dir] : [] }),
     );
-    expect(parentNativeCalls.map((call) => call[0])).toStrictEqual(
-      expect.arrayContaining([workspaceDir, workspaceDir]),
-    );
+    const main = createdNativeWatchers.find((watcher) => watcher.dir === dir);
+    const parent = createdNativeWatchers.find((watcher) => watcher.dir === parentDir);
+    if (!main || !parent) {
+      throw new Error("expected a main and parent memory watcher");
+    }
+    vi.useFakeTimers();
+    const sync = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
+    return { activeManager, dir, parentDir, main, parent, sync };
+  }
 
-    // Shared ignore predicate still controls non-md/non-multimodal churn.
-    const ignored = chokidarOptions.ignored as WatchIgnoredFn | undefined;
-    expect(ignored).toBeTypeOf("function");
-    expect(ignored?.(path.join(workspaceDir, "memory", "node_modules", "pkg", "index.md"))).toBe(
-      true,
-    );
-    expect(ignored?.(path.join(workspaceDir, "memory", ".venv", "lib", "python.md"))).toBe(true);
-    expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.tmp"), {})).toBe(true);
-    expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.json"), {})).toBe(true);
-    expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.json"), undefined)).toBe(
-      false,
-    );
-    expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.md"))).toBe(false);
-    expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.md"), {})).toBe(false);
-    expect(
-      ignored?.(path.join(workspaceDir, "memory", "project"), { isDirectory: () => true }),
-    ).toBe(false);
-  });
+  it.each(["darwin", "win32"])(
+    "routes directories to native recursive watch on %s",
+    async (platform) => {
+      Object.defineProperty(process, "platform", { value: platform, configurable: true });
+      await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+      const cfg = createWatcherConfig();
+
+      await expectWatcherManager(cfg);
+
+      // Chokidar should only see file paths (MEMORY.md); directories use native watch.
+      expect(watchMock).toHaveBeenCalledTimes(1);
+      const [chokidarPaths, chokidarOptions] = watchMock.mock.calls[0] as unknown as [
+        string[],
+        Record<string, unknown>,
+      ];
+      expect(chokidarPaths).toStrictEqual([
+        path.join(workspaceDir, "MEMORY.md"),
+        path.join(workspaceDir, "USER.md"),
+      ]);
+      expect(chokidarPaths.filter((watchedPath) => watchedPath.includes("*"))).toEqual([]);
+      expect(chokidarOptions.ignoreInitial).toBe(true);
+      expect(chokidarOptions).not.toHaveProperty("awaitWriteFinish");
+
+      // Native fs.watch should receive memory/ and extraDir as recursive watches.
+      // Each watched directory installs a main recursive watcher PLUS a
+      // non-recursive parent-directory watcher used to detect root
+      // replacement (see attachNativeMemoryWatchForDir). 2 dirs × 2 watchers
+      // each = 4 native fs.watch calls.
+      expect(nativeWatchMock).toHaveBeenCalledTimes(4);
+      const mainNativeCalls = (
+        nativeWatchMock.mock.calls as unknown as [string, { recursive?: boolean }, unknown][]
+      ).filter((call) => call[1].recursive === true);
+      const parentNativeCalls = (
+        nativeWatchMock.mock.calls as unknown as [string, { recursive?: boolean }, unknown][]
+      ).filter((call) => call[1].recursive !== true);
+      expect(mainNativeCalls.map((call) => call[0])).toStrictEqual(
+        expect.arrayContaining([path.join(workspaceDir, "memory"), extraDir]),
+      );
+      expect(parentNativeCalls.map((call) => call[0])).toStrictEqual([workspaceDir, workspaceDir]);
+      expect(parentNativeCalls.every((call) => call[1].recursive === false)).toBe(true);
+
+      // Shared ignore predicate still controls non-md/non-multimodal churn.
+      const ignored = chokidarOptions.ignored as WatchIgnoredFn | undefined;
+      expect(ignored).toBeTypeOf("function");
+      expect(ignored?.(path.join(workspaceDir, "memory", "node_modules", "pkg", "index.md"))).toBe(
+        true,
+      );
+      expect(ignored?.(path.join(workspaceDir, "memory", ".venv", "lib", "python.md"))).toBe(true);
+      expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.tmp"), {})).toBe(true);
+      expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.json"), {})).toBe(true);
+      expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.json"), undefined)).toBe(
+        false,
+      );
+      expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.md"))).toBe(false);
+      expect(ignored?.(path.join(workspaceDir, "memory", "project", "notes.md"), {})).toBe(false);
+      expect(
+        ignored?.(path.join(workspaceDir, "memory", "project"), { isDirectory: () => true }),
+      ).toBe(false);
+    },
+  );
 
   it("filters patterned extra path file events while watching the directory root", async () => {
     await setupWatcherWorkspace({ name: "seed.md", contents: "seed" });
@@ -640,79 +663,21 @@ describe("memory watcher config", () => {
   });
 
   it("attaches Linux native watchers for new subdirectories", async () => {
-    const originalPlatformValue = process.platform;
-    try {
-      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
-      await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-      const cfg = createWatcherConfig();
+    const { dir, main, sync } = await setupParentWatchLifecycle("linux");
+    const newDir = path.join(dir, "new-topic");
+    await fs.mkdir(newDir);
+    main.emit("rename", "new-topic");
+    await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
 
-      await expectWatcherManager(cfg);
-      vi.useFakeTimers();
-      const syncSpy = vi
-        .spyOn(
-          manager as unknown as {
-            sync: (params?: { reason?: string }) => Promise<void>;
-          },
-          "sync",
-        )
-        .mockResolvedValue(undefined);
-
-      const memoryDir = path.join(workspaceDir, "memory");
-      const newDir = path.join(memoryDir, "new-topic");
-      await fs.mkdir(newDir);
-      const memoryWatcher = createdNativeWatchers.find((w) => w.dir === memoryDir);
-      memoryWatcher?.emit("rename", "new-topic");
-      await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
-
-      expect(syncSpy).toHaveBeenCalledWith({ reason: "watch" });
-      expect(
-        createdNativeWatchers.some((watcher) => watcher.dir === newDir && !watcher.recursive),
-      ).toBe(true);
-    } finally {
-      Object.defineProperty(process, "platform", {
-        value: originalPlatformValue,
-        configurable: true,
-      });
-    }
+    expect(sync).toHaveBeenCalledWith({ reason: "watch" });
+    expect(
+      createdNativeWatchers.some((watcher) => watcher.dir === newDir && !watcher.recursive),
+    ).toBe(true);
   });
 
-  it("reattaches Linux native watchers for recreated subdirectories", async () => {
-    const originalPlatformValue = process.platform;
-    try {
-      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
-      await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-      const memoryDir = path.join(workspaceDir, "memory");
-      const nestedDir = path.join(memoryDir, "topic");
-      const childDir = path.join(nestedDir, "child");
-      await fs.mkdir(childDir, { recursive: true });
-      const cfg = createWatcherConfig();
-
-      await expectWatcherManager(cfg);
-
-      const originalNestedWatcher = createdNativeWatchers.find((w) => w.dir === nestedDir);
-      const originalChildWatcher = createdNativeWatchers.find((w) => w.dir === childDir);
-      expect(originalNestedWatcher).toBeDefined();
-      expect(originalChildWatcher).toBeDefined();
-      await fs.rm(nestedDir, { recursive: true, force: true });
-      await fs.mkdir(nestedDir);
-
-      const memoryWatcher = createdNativeWatchers.find((w) => w.dir === memoryDir);
-      memoryWatcher?.emit("rename", "topic");
-
-      expect(originalNestedWatcher!.close).toHaveBeenCalled();
-      expect(originalChildWatcher!.close).toHaveBeenCalled();
-      expect(createdNativeWatchers.filter((w) => w.dir === nestedDir)).toHaveLength(2);
-    } finally {
-      Object.defineProperty(process, "platform", {
-        value: originalPlatformValue,
-        configurable: true,
-      });
-    }
-  });
-
-  it("closes Linux native watchers for deleted subdirectories", async () => {
-    const originalPlatformValue = process.platform;
-    try {
+  it.each([false, true])(
+    "releases Linux subtrees and reattaches recreated=%s",
+    async (recreated) => {
       Object.defineProperty(process, "platform", { value: "linux", configurable: true });
       await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
       const memoryDir = path.join(workspaceDir, "memory");
@@ -728,151 +693,99 @@ describe("memory watcher config", () => {
       expect(nestedWatcher).toBeDefined();
       expect(childWatcher).toBeDefined();
       await fs.rm(nestedDir, { recursive: true, force: true });
+      if (recreated) {
+        await fs.mkdir(nestedDir);
+      }
 
       const memoryWatcher = createdNativeWatchers.find((w) => w.dir === memoryDir);
       memoryWatcher?.emit("rename", "topic");
 
       expect(nestedWatcher!.close).toHaveBeenCalled();
       expect(childWatcher!.close).toHaveBeenCalled();
-    } finally {
-      Object.defineProperty(process, "platform", {
-        value: originalPlatformValue,
-        configurable: true,
-      });
-    }
-  });
+      expect(createdNativeWatchers.filter((w) => w.dir === nestedDir)).toHaveLength(
+        recreated ? 2 : 1,
+      );
+    },
+  );
 
   it("keeps startup chokidar fallback when Linux nested watcher setup fails", async () => {
-    const originalPlatformValue = process.platform;
-    try {
-      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
-      await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-      const nestedDir = path.join(workspaceDir, "memory", "topic");
-      await fs.mkdir(nestedDir);
-      nativeWatchMockFailingDir.current = nestedDir;
-      const cfg = createWatcherConfig();
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const nestedDir = path.join(workspaceDir, "memory", "topic");
+    await fs.mkdir(nestedDir);
+    nativeWatchMockFailingDir.current = nestedDir;
+    const cfg = createWatcherConfig();
 
-      await expectWatcherManager(cfg);
+    await expectWatcherManager(cfg);
 
-      expect(watchMock).toHaveBeenCalledTimes(1);
-      const [fallbackPaths] = watchMock.mock.calls[0] as unknown as [
-        string[],
-        Record<string, unknown>,
-      ];
-      expect(fallbackPaths).toStrictEqual([path.join(workspaceDir, "memory")]);
-      expect(createdChokidarWatchers[0]?.add).toHaveBeenCalledWith([
-        path.join(workspaceDir, "MEMORY.md"),
-        path.join(workspaceDir, "USER.md"),
-      ]);
-    } finally {
-      Object.defineProperty(process, "platform", {
-        value: originalPlatformValue,
-        configurable: true,
-      });
-    }
+    expect(watchMock).toHaveBeenCalledTimes(1);
+    const [fallbackPaths] = watchMock.mock.calls[0] as unknown as [
+      string[],
+      Record<string, unknown>,
+    ];
+    expect(fallbackPaths).toStrictEqual([path.join(workspaceDir, "memory")]);
+    expect(createdChokidarWatchers[0]?.add).toHaveBeenCalledWith([
+      path.join(workspaceDir, "MEMORY.md"),
+      path.join(workspaceDir, "USER.md"),
+    ]);
   });
 
-  it("falls back to chokidar when Linux subtree lstat races with deletion", async () => {
-    const originalPlatformValue = process.platform;
-    let lstatSpy: { mockRestore: () => void } | undefined;
-    try {
+  it.each(["ENOENT", "EACCES", "ROOT_REPLACED", "CHILD_STAT_MISSING"])(
+    "handles Linux subtree scan %s",
+    async (code) => {
       Object.defineProperty(process, "platform", { value: "linux", configurable: true });
       await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-      const nestedDir = path.join(workspaceDir, "memory", "racy-topic");
-      await fs.mkdir(nestedDir);
-      const originalLstatSync = fsSync.lstatSync.bind(fsSync);
-      const lstatMock = vi.spyOn(fsSync, "lstatSync");
-      lstatSpy = lstatMock;
-      lstatMock.mockImplementation(
-        (
-          target: Parameters<typeof fsSync.lstatSync>[0],
-          options?: Parameters<typeof fsSync.lstatSync>[1],
-        ): ReturnType<typeof fsSync.lstatSync> => {
-          if (path.resolve(String(target)) === nestedDir) {
-            throw Object.assign(new Error("ENOENT: no such file or directory, lstat"), {
-              code: "ENOENT",
-            });
-          }
-          return originalLstatSync(target, options);
-        },
-      );
-      const cfg = createWatcherConfig();
-
-      await expectWatcherManager(cfg);
-
-      expect(watchMock).toHaveBeenCalledTimes(1);
-      const [fallbackPaths] = watchMock.mock.calls[0] as unknown as [
-        string[],
-        Record<string, unknown>,
-      ];
-      expect(fallbackPaths).toStrictEqual([path.join(workspaceDir, "memory")]);
-      expect(createdChokidarWatchers[0]?.add).toHaveBeenCalledWith([
-        path.join(workspaceDir, "MEMORY.md"),
-        path.join(workspaceDir, "USER.md"),
-      ]);
-      expect(memoryLoggerWarn).toHaveBeenCalledWith(
-        expect.stringContaining("failed to attach Linux memory directory watcher subtree"),
-      );
-    } finally {
-      Object.defineProperty(process, "platform", {
-        value: originalPlatformValue,
-        configurable: true,
+      const dir = path.join(workspaceDir, "memory");
+      const nestedDir = path.join(dir, "racy-topic");
+      await fs.mkdir(path.join(nestedDir, "survivor"), { recursive: true });
+      const originalLstat = fsSync.lstatSync.bind(fsSync);
+      const lstatSpy = vi.spyOn(fsSync, "lstatSync");
+      lstatSpy.mockImplementation((...args: Parameters<typeof fsSync.lstatSync>) => {
+        if (String(args[0]) === nestedDir && (code === "ENOENT" || code === "EACCES")) {
+          throw Object.assign(new Error(`subtree lstat ${code}`), { code });
+        }
+        return originalLstat(...args);
       });
-      lstatSpy?.mockRestore();
-    }
-  });
-
-  it("routes directories through native recursive watch on Windows", async () => {
-    // Windows uses ReadDirectoryChangesW for `fs.watch(dir, { recursive: true })`,
-    // which is a single-watcher native recursive backend (constant FD profile).
-    const originalPlatformLocal = process.platform;
-    try {
-      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
-      await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-      const cfg = createWatcherConfig();
-
-      await expectWatcherManager(cfg);
-
-      // Chokidar should only see the file path (MEMORY.md); both directory
-      // paths (memory/ and extraDir) go to native recursive watch.
-      expect(watchMock).toHaveBeenCalledTimes(1);
-      const [chokidarPathsWin] = watchMock.mock.calls[0] as unknown as [
-        string[],
-        Record<string, unknown>,
-      ];
-      expect(chokidarPathsWin).toStrictEqual([
-        path.join(workspaceDir, "MEMORY.md"),
-        path.join(workspaceDir, "USER.md"),
-      ]);
-
-      // 2 directories × (main + parent) = 4 native watch calls.
-      expect(nativeWatchMock).toHaveBeenCalledTimes(4);
-      const nativeDirsWin = (
-        nativeWatchMock.mock.calls as unknown as [string, { recursive?: boolean }, unknown][]
-      )
-        .filter((call) => call[1].recursive === true)
-        .map((call) => call[0]);
-      expect(nativeDirsWin).toStrictEqual(
-        expect.arrayContaining([path.join(workspaceDir, "memory"), extraDir]),
-      );
-      // Parent watchers must use recursive:false to avoid double-recursion
-      // over the same tree.
-      const parentDirsWin = (
-        nativeWatchMock.mock.calls as unknown as [string, { recursive?: boolean }, unknown][]
-      )
-        .filter((call) => call[1].recursive !== true)
-        .map((call) => call[0]);
-      expect(parentDirsWin).toHaveLength(2);
-      for (const parentDir of parentDirsWin) {
-        expect(parentDir).toBe(workspaceDir);
+      const originalReaddir = fsSync.readdirSync.bind(fsSync);
+      const readdirSpy = vi.spyOn(fsSync, "readdirSync");
+      readdirSpy.mockImplementation((...args: Parameters<typeof fsSync.readdirSync>) => {
+        if (String(args[0]) === nestedDir && code === "CHILD_STAT_MISSING") {
+          throw Object.assign(new Error("DT_UNKNOWN child disappeared"), { code: "ENOENT" });
+        }
+        if (String(args[0]) === nestedDir && code === "ROOT_REPLACED") {
+          fsSync.renameSync(dir, path.join(workspaceDir, "previous-memory"));
+          fsSync.mkdirSync(dir);
+        }
+        return originalReaddir(...args);
+      });
+      try {
+        const activeManager = await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
+        const main = createdNativeWatchers.find((watcher) => watcher.dir === dir);
+        expect(main).toBeDefined();
+        expect(watchMock).toHaveBeenCalledTimes(1);
+        expect(main!.close).toHaveBeenCalledTimes(1);
+        expect(watchMock).toHaveBeenCalledWith(
+          [dir],
+          expect.objectContaining({ ignoreInitial: true }),
+        );
+        expect(createdChokidarWatchers[0]?.add).toHaveBeenCalledWith([
+          path.join(workspaceDir, "MEMORY.md"),
+          path.join(workspaceDir, "USER.md"),
+        ]);
+        expect(memoryLoggerWarn).toHaveBeenCalledWith(
+          expect.stringContaining("failed to attach Linux memory directory watcher subtree"),
+        );
+        vi.useFakeTimers();
+        const sync = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
+        createdChokidarWatchers[0]?.emit("change");
+        await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+        expect(sync).toHaveBeenCalledWith({ reason: "watch" });
+      } finally {
+        lstatSpy.mockRestore();
+        readdirSpy.mockRestore();
       }
-    } finally {
-      Object.defineProperty(process, "platform", {
-        value: originalPlatformLocal,
-        configurable: true,
-      });
-    }
-  });
+    },
+  );
 
   it("creates a chokidar watcher on the fly when no file-path chokidar exists yet", async () => {
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
@@ -904,63 +817,17 @@ describe("memory watcher config", () => {
     expect(newChokidarCall?.[0]).toStrictEqual([memoryDir]);
   });
 
-  it("attaches a non-recursive parent-directory watcher for root-replacement detection", async () => {
-    // Each native memory directory watch is paired with a non-recursive
-    // watcher on the parent directory; the parent watcher catches
-    // root-replacement events (`rm -rf memory && mkdir memory`) so the
-    // main watcher can be reattached on the new inode.
-    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-    const cfg = createWatcherConfig({ extraPaths: [] });
-    await expectWatcherManager(cfg);
-
-    const memoryDir = path.join(workspaceDir, "memory");
-    const mainWatcher = createdNativeWatchers.find((w) => w.dir === memoryDir && w.recursive);
-    const parentWatcher = createdNativeWatchers.find((w) => w.dir === workspaceDir && !w.recursive);
-    expect(mainWatcher).toBeDefined();
-    expect(parentWatcher).toBeDefined();
-    // Parent watcher's mock options must reflect recursive: false.
-    expect(parentWatcher!.options.recursive).not.toBe(true);
-  });
-
   it("treats null parent-watcher filename as an unknown event and re-checks the inode", async () => {
-    // Node fs.watch can emit `filename: null` on some platforms even on
-    // otherwise-supported recursive backends; the parent watcher must
-    // not silently drop it. With statSync returning the recorded inode
-    // (no real replacement), the no-action path is taken and no
-    // teardown/reattach happens.
-    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-    const cfg = createWatcherConfig({ extraPaths: [] });
-    await expectWatcherManager(cfg);
-    vi.useFakeTimers();
-    const syncSpy = vi
-      .spyOn(
-        manager as unknown as {
-          sync: (params?: { reason?: string }) => Promise<void>;
-        },
-        "sync",
-      )
-      .mockResolvedValue(undefined);
-
-    const memoryDir = path.join(workspaceDir, "memory");
-    const mainWatcher = createdNativeWatchers.find((w) => w.dir === memoryDir && w.recursive);
-    const parentWatcher = createdNativeWatchers.find((w) => w.dir === workspaceDir && !w.recursive);
-    expect(parentWatcher).toBeDefined();
-    expect(mainWatcher).toBeDefined();
+    const { main, parent, sync } = await setupParentWatchLifecycle("darwin");
     const nativeCallsBefore = nativeWatchMock.mock.calls.length;
-    const mainCloseSpy = mainWatcher!.close;
-    const parentCloseSpy = parentWatcher!.close;
+    parent.emit("rename", null);
+    await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
 
-    // Null filename — must not return silently.
-    parentWatcher!.emit("rename", null);
-    await vi.advanceTimersByTimeAsync(50);
-
-    // The handler ran. Because the real inode matches the recorded
-    // inode (no actual replacement), no teardown/reattach happened
-    // and no broad dirty was scheduled.
-    expect(mainCloseSpy).not.toHaveBeenCalled();
-    expect(parentCloseSpy).not.toHaveBeenCalled();
+    // The unchanged inode must not trigger teardown or a broad sync.
+    expect(main.close).not.toHaveBeenCalled();
+    expect(parent.close).not.toHaveBeenCalled();
     expect(nativeWatchMock.mock.calls.length).toBe(nativeCallsBefore);
-    expect(syncSpy).not.toHaveBeenCalledWith({ reason: "watch" });
+    expect(sync).not.toHaveBeenCalled();
   });
 
   it("closes the paired parent watcher when the native main watcher errors", async () => {
@@ -969,54 +836,23 @@ describe("memory watcher config", () => {
     // root-replacement event would reattach native coverage on top of an
     // already-installed chokidar fallback, creating duplicate handles
     // and event paths.
-    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-    const cfg = createWatcherConfig({ extraPaths: [] });
-    await expectWatcherManager(cfg);
-
-    const memoryDir = path.join(workspaceDir, "memory");
-    const mainWatcher = createdNativeWatchers.find((w) => w.dir === memoryDir && w.recursive);
-    const parentWatcher = createdNativeWatchers.find((w) => w.dir === workspaceDir && !w.recursive);
-    expect(mainWatcher).toBeDefined();
-    expect(parentWatcher).toBeDefined();
-    const parentCloseSpy = parentWatcher!.close;
-
-    mainWatcher!.emitError(new Error("watcher error: ENOSPC"));
+    const { main, parent } = await setupParentWatchLifecycle("darwin");
+    main.emitError(new Error("watcher error: ENOSPC"));
 
     // The error handler should have closed and removed the paired
     // parent watcher before installing the chokidar fallback.
-    expect(parentCloseSpy).toHaveBeenCalled();
+    expect(parent.close).toHaveBeenCalled();
   });
 
   it("ignores parent-directory events for unrelated basenames", async () => {
-    // When the parent-directory watcher fires for a sibling (not the
-    // watched root's basename), no teardown or reattach should occur.
-    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
-    const cfg = createWatcherConfig({ extraPaths: [] });
-    await expectWatcherManager(cfg);
-    vi.useFakeTimers();
-    const syncSpy = vi
-      .spyOn(
-        manager as unknown as {
-          sync: (params?: { reason?: string }) => Promise<void>;
-        },
-        "sync",
-      )
-      .mockResolvedValue(undefined);
-
-    const parentWatcher = createdNativeWatchers.find((w) => w.dir === workspaceDir && !w.recursive);
-    expect(parentWatcher).toBeDefined();
+    const { main, parent, sync } = await setupParentWatchLifecycle("darwin");
     const nativeCallsBefore = nativeWatchMock.mock.calls.length;
-    const mainCloseSpy = createdNativeWatchers.find(
-      (w) => w.dir === path.join(workspaceDir, "memory") && w.recursive,
-    )!.close;
+    parent.emit("rename", "unrelated-sibling-dir");
+    await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
 
-    // Sibling event — should be ignored.
-    parentWatcher!.emit("rename", "unrelated-sibling-dir");
-    await vi.advanceTimersByTimeAsync(50);
-
-    expect(mainCloseSpy).not.toHaveBeenCalled();
+    expect(main.close).not.toHaveBeenCalled();
     expect(nativeWatchMock.mock.calls.length).toBe(nativeCallsBefore);
-    expect(syncSpy).not.toHaveBeenCalled();
+    expect(sync).not.toHaveBeenCalled();
   });
 
   it("ignores re-entrant ensureWatcher calls", async () => {
@@ -1033,6 +869,224 @@ describe("memory watcher config", () => {
 
     expect(watchMock.mock.calls.length).toBe(chokidarCallsAfterFirst);
     expect(nativeWatchMock.mock.calls.length).toBe(nativeCallsAfterFirst);
+  });
+
+  describe.each(["darwin", "win32", "linux"] as const)("%s parent watch lifecycle", (platform) => {
+    it.each(["memory", null])("reattaches a replaced root for filename %s", async (filename) => {
+      const { dir, main, parent, sync } = await setupParentWatchLifecycle(platform);
+      await fs.rename(dir, path.join(workspaceDir, "previous-memory"));
+      await fs.mkdir(dir);
+
+      parent.emit("rename", filename);
+
+      expect(main.close).toHaveBeenCalledTimes(1);
+      expect(parent.close).toHaveBeenCalledTimes(1);
+      const replacements = createdNativeWatchers.filter((watcher) => watcher.dir === dir);
+      expect(replacements).toHaveLength(2);
+      expect(replacements[1]?.recursive).toBe(platform !== "linux");
+      expect(createdChokidarWatchers[0]?.add).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+      expect(sync).toHaveBeenCalledWith({ reason: "watch" });
+
+      sync.mockClear();
+      await fs.writeFile(path.join(dir, "fresh.md"), "fresh memory");
+      replacements[1]?.emit("change", "fresh.md");
+      await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+      expect(sync).toHaveBeenCalledWith({ reason: "watch" });
+    });
+
+    const failures = [
+      "missing",
+      "stat-race",
+      "stat-failure",
+      "creation-failure",
+      "parent-replaced",
+      "retained-parent-replaced",
+    ];
+    if (platform === "linux") {
+      failures.push("subtree-race");
+    }
+    it.each(failures)(
+      "preserves watch coverage when reattachment encounters %s",
+      async (failure) => {
+        const parentReplaced =
+          failure === "parent-replaced" || failure === "retained-parent-replaced";
+        const { dir, parentDir, main, parent, sync } = await setupParentWatchLifecycle(
+          platform,
+          parentReplaced,
+        );
+        await fs.rename(dir, path.join(workspaceDir, "previous-memory"));
+        if (failure === "retained-parent-replaced") {
+          parent.emit("rename", "memory");
+          expect(parent.close).not.toHaveBeenCalled();
+        }
+        if (parentReplaced) {
+          await fs.rename(parentDir, path.join(extraDir, "previous-parent"));
+          await fs.mkdir(parentDir);
+        } else if (failure !== "missing") {
+          await fs.mkdir(dir);
+        }
+        const originalStat = fsSync.statSync.bind(fsSync);
+        let rootStats = 0;
+        const statSpy = vi.spyOn(fsSync, "statSync");
+        statSpy.mockImplementation((...args: Parameters<typeof fsSync.statSync>) => {
+          if (String(args[0]) === dir && failure === "stat-failure") {
+            throw Object.assign(new Error("root stat failed"), { code: "EACCES" });
+          }
+          if (String(args[0]) === dir && failure === "stat-race" && ++rootStats > 1) {
+            throw Object.assign(new Error("root disappeared before reattachment"), {
+              code: "ENOENT",
+            });
+          }
+          return originalStat(...args);
+        });
+        if (failure === "creation-failure") {
+          nativeWatchMockFailingDir.current = dir;
+        }
+        const originalLstat = fsSync.lstatSync.bind(fsSync);
+        const lstatSpy = vi.spyOn(fsSync, "lstatSync");
+        lstatSpy.mockImplementation((...args: Parameters<typeof fsSync.lstatSync>) => {
+          if (String(args[0]) === dir && failure === "subtree-race") {
+            fsSync.renameSync(dir, path.join(workspaceDir, "raced-memory"));
+          }
+          return originalLstat(...args);
+        });
+
+        try {
+          parent.emit(
+            "rename",
+            failure === "retained-parent-replaced" ? path.basename(parentDir) : "memory",
+          );
+        } finally {
+          statSpy.mockRestore();
+          lstatSpy.mockRestore();
+        }
+
+        expect(main.close).toHaveBeenCalledTimes(1);
+        const roots = createdNativeWatchers.filter((watcher) => watcher.dir === dir);
+        expect(roots).toHaveLength(failure === "subtree-race" ? 2 : 1);
+        for (const root of roots) {
+          expect(root.close).toHaveBeenCalledTimes(1);
+        }
+        await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+        expect(sync).toHaveBeenCalledWith({ reason: "watch" });
+        sync.mockClear();
+        if (failure === "creation-failure" || failure === "stat-failure" || parentReplaced) {
+          expect(parent.close).toHaveBeenCalledTimes(1);
+          expect(createdChokidarWatchers[0]?.add).toHaveBeenCalledExactlyOnceWith(dir);
+          createdChokidarWatchers[0]?.emit("change");
+        } else {
+          expect(parent.close).not.toHaveBeenCalled();
+          expect(createdChokidarWatchers[0]?.add).not.toHaveBeenCalled();
+          main.emitError(new Error("stale closed main"));
+          main.emit("rename", null);
+          await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+          expect(sync).not.toHaveBeenCalled();
+          if (failure === "missing" || failure === "subtree-race") {
+            parent.emit("rename", null);
+            expect(main.close).toHaveBeenCalledTimes(1);
+            await fs.mkdir(dir);
+          }
+          parent.emit("rename", "memory");
+          expect(parent.close).toHaveBeenCalledTimes(1);
+          expect(main.close).toHaveBeenCalledTimes(1);
+          expect(createdChokidarWatchers[0]?.add).not.toHaveBeenCalled();
+          expect(createdNativeWatchers.filter((watcher) => watcher.dir === dir)).toHaveLength(
+            roots.length + 1,
+          );
+        }
+        await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+        expect(sync).toHaveBeenCalledExactlyOnceWith({ reason: "watch" });
+      },
+    );
+
+    it.each([false, true])(
+      "keeps coverage after a parent error with root missing=%s",
+      async (missing) => {
+        const { activeManager, dir, main, parent, sync } =
+          await setupParentWatchLifecycle(platform);
+        if (missing) {
+          await fs.rename(dir, path.join(workspaceDir, "previous-memory"));
+          parent.emit("rename", "memory");
+        }
+        parent.emitError(new Error("parent unavailable"));
+        expect(parent.close).toHaveBeenCalledTimes(1);
+        expect(main.close).toHaveBeenCalledTimes(missing ? 1 : 0);
+        if (missing) {
+          expect(createdChokidarWatchers[0]?.add).toHaveBeenCalledExactlyOnceWith(dir);
+          createdChokidarWatchers[0]?.emit("change");
+        } else {
+          expect(createdChokidarWatchers[0]?.add).not.toHaveBeenCalled();
+          main.emit("change", "notes.md");
+        }
+        expect(memoryLoggerWarn).toHaveBeenCalledWith(
+          `memory ${platform === "linux" ? "Linux" : "native"} parent watcher error on ${workspaceDir}: parent unavailable`,
+        );
+        await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+        expect(sync).toHaveBeenCalledWith({ reason: "watch" });
+        await activeManager.close();
+        expect(main.close).toHaveBeenCalledTimes(1);
+        expect(parent.close).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it.each([false, true])(
+      "retains main coverage without a parent with root symlink=%s",
+      async (symlink) => {
+        Object.defineProperty(process, "platform", { value: platform, configurable: true });
+        await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+        if (symlink) {
+          const memoryDir = path.join(workspaceDir, "memory");
+          const target = path.join(workspaceDir, "memory-target");
+          await fs.rename(memoryDir, target);
+          await fs.symlink(target, memoryDir, originalPlatform === "win32" ? "junction" : "dir");
+        }
+        nativeWatchMockFailingDir.current = workspaceDir;
+        const activeManager = await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
+        const main = createdNativeWatchers.find(
+          (watcher) => watcher.dir === path.join(workspaceDir, "memory"),
+        );
+        vi.useFakeTimers();
+        const sync = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
+
+        expect(main?.close).not.toHaveBeenCalled();
+        main?.emit("change", "notes.md");
+        await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+
+        expect(sync).toHaveBeenCalledWith({ reason: "watch" });
+        expect(createdChokidarWatchers[0]?.add).not.toHaveBeenCalled();
+        expect(memoryLoggerWarn).toHaveBeenCalledWith(
+          `memory ${platform === "linux" ? "Linux" : "native"} parent watcher could not start on ${workspaceDir}: Error: simulated native fs.watch creation failure`,
+        );
+      },
+    );
+
+    it.each([false, true])(
+      "does not restore watches after closure with root missing=%s",
+      async (missing) => {
+        const { activeManager, dir, main, parent, sync } =
+          await setupParentWatchLifecycle(platform);
+        await fs.rename(dir, path.join(workspaceDir, "previous-memory"));
+        if (missing) {
+          parent.emit("rename", "memory");
+        }
+        await activeManager.close();
+        const nativeCalls = nativeWatchMock.mock.calls.length;
+        const chokidarCalls = watchMock.mock.calls.length;
+        await fs.mkdir(dir);
+
+        parent.emit("rename", "memory");
+        main.emitError(new Error("late native error"));
+        await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+
+        expect(nativeWatchMock).toHaveBeenCalledTimes(nativeCalls);
+        expect(watchMock).toHaveBeenCalledTimes(chokidarCalls);
+        expect(createdChokidarWatchers[0]?.add).not.toHaveBeenCalled();
+        expect(sync).not.toHaveBeenCalled();
+        expect(main.close).toHaveBeenCalledTimes(1);
+        expect(parent.close).toHaveBeenCalledTimes(1);
+      },
+    );
   });
 
   it("settles changed file stats before running watch sync", async () => {

--- a/extensions/memory-core/src/memory/manager.watcher-config.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-config.test.ts
@@ -354,20 +354,13 @@ describe("memory watcher config", () => {
       extraPaths: [{ path: extraDir, pattern: "notes/**/*.md" }],
     });
 
-    await expectWatcherManager(cfg);
+    const activeManager = await expectWatcherManager(cfg);
     const extraWatcher = createdNativeWatchers.find(
       (watcher) => watcher.dir === extraDir && watcher.recursive,
     );
     expect(extraWatcher).toBeDefined();
     vi.useFakeTimers();
-    const syncSpy = vi
-      .spyOn(
-        manager as unknown as {
-          sync: (params?: { reason?: string }) => Promise<void>;
-        },
-        "sync",
-      )
-      .mockResolvedValue(undefined);
+    const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
 
     extraWatcher?.emit("change", path.join("drafts", "skip.md"));
     await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
@@ -438,16 +431,9 @@ describe("memory watcher config", () => {
       await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
       const cfg = createWatcherConfig();
 
-      await expectWatcherManager(cfg);
+      const activeManager = await expectWatcherManager(cfg);
       vi.useFakeTimers();
-      const syncSpy = vi
-        .spyOn(
-          manager as unknown as {
-            sync: (params?: { reason?: string }) => Promise<void>;
-          },
-          "sync",
-        )
-        .mockResolvedValue(undefined);
+      const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
 
       createdChokidarWatchers[0]?.emit(event);
       await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
@@ -462,16 +448,9 @@ describe("memory watcher config", () => {
       await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
       const cfg = createWatcherConfig();
 
-      await expectWatcherManager(cfg);
+      const activeManager = await expectWatcherManager(cfg);
       vi.useFakeTimers();
-      const syncSpy = vi
-        .spyOn(
-          manager as unknown as {
-            sync: (params?: { reason?: string }) => Promise<void>;
-          },
-          "sync",
-        )
-        .mockResolvedValue(undefined);
+      const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
 
       const memoryWatcher = createdNativeWatchers.find(
         (w) => w.dir === path.join(workspaceDir, "memory"),
@@ -487,16 +466,9 @@ describe("memory watcher config", () => {
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
     const cfg = createWatcherConfig();
 
-    await expectWatcherManager(cfg);
+    const activeManager = await expectWatcherManager(cfg);
     vi.useFakeTimers();
-    const syncSpy = vi
-      .spyOn(
-        manager as unknown as {
-          sync: (params?: { reason?: string }) => Promise<void>;
-        },
-        "sync",
-      )
-      .mockResolvedValue(undefined);
+    const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
 
     const memoryWatcher = createdNativeWatchers.find(
       (w) => w.dir === path.join(workspaceDir, "memory"),
@@ -541,16 +513,9 @@ describe("memory watcher config", () => {
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
     const cfg = createWatcherConfig();
 
-    await expectWatcherManager(cfg);
+    const activeManager = await expectWatcherManager(cfg);
     vi.useFakeTimers();
-    const syncSpy = vi
-      .spyOn(
-        manager as unknown as {
-          sync: (params?: { reason?: string }) => Promise<void>;
-        },
-        "sync",
-      )
-      .mockResolvedValue(undefined);
+    const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
 
     const memoryDir = path.join(workspaceDir, "memory");
     const memoryWatcher = createdNativeWatchers.find((w) => w.dir === memoryDir);
@@ -728,6 +693,35 @@ describe("memory watcher config", () => {
       path.join(workspaceDir, "MEMORY.md"),
       path.join(workspaceDir, "USER.md"),
     ]);
+  });
+
+  it("schedules startup sync when the Linux root disappears during its initial scan", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
+    const dir = path.join(workspaceDir, "memory");
+    const originalReaddir = fsSync.readdirSync.bind(fsSync);
+    const readdirSpy = vi.spyOn(fsSync, "readdirSync");
+    readdirSpy.mockImplementation((...args: Parameters<typeof fsSync.readdirSync>) => {
+      if (String(args[0]) === dir) {
+        fsSync.renameSync(dir, path.join(workspaceDir, "previous-memory"));
+      }
+      return originalReaddir(...args);
+    });
+    try {
+      vi.useFakeTimers();
+      const activeManager = await expectWatcherManager(createWatcherConfig({ extraPaths: [] }));
+      const main = createdNativeWatchers.find((watcher) => watcher.dir === dir);
+      expect(main).toBeDefined();
+      expect(main!.close).toHaveBeenCalledTimes(1);
+      expect(createdNativeWatchers.some((watcher) => watcher.dir === workspaceDir)).toBe(false);
+      expect(watchMock).toHaveBeenCalledTimes(1);
+      const sync = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
+      // ignoreInitial fallback cannot replace the broad sync lost with native coverage.
+      await vi.advanceTimersByTimeAsync(BUILT_IN_WATCH_DEBOUNCE_MS);
+      expect(sync).toHaveBeenCalledExactlyOnceWith({ reason: "watch" });
+    } finally {
+      readdirSpy.mockRestore();
+    }
   });
 
   it.each(["ENOENT", "EACCES", "ROOT_REPLACED", "CHILD_STAT_MISSING"])(
@@ -1093,18 +1087,11 @@ describe("memory watcher config", () => {
     await setupWatcherWorkspace({ name: "notes.md", contents: "hello" });
     const cfg = createWatcherConfig();
 
-    await expectWatcherManager(cfg);
+    const activeManager = await expectWatcherManager(cfg);
     vi.useFakeTimers();
     const notesPath = path.join(extraDir, "notes.md");
     const initialStats = await fs.stat(notesPath);
-    const syncSpy = vi
-      .spyOn(
-        manager as unknown as {
-          sync: (params?: { reason?: string }) => Promise<void>;
-        },
-        "sync",
-      )
-      .mockResolvedValue(undefined);
+    const syncSpy = vi.spyOn(activeManager, "sync").mockResolvedValue(undefined);
 
     // extraDir is now watched via native fs.watch; emit a change event that
     // resolves to notes.md and confirm settle behavior still applies before

--- a/extensions/memory-core/src/memory/manager.watcher-filesystem.test.ts
+++ b/extensions/memory-core/src/memory/manager.watcher-filesystem.test.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import { MEMORY_INDEX_CHUNKS_TABLE } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { createOpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { describe, expect, it } from "vitest";
+import {
+  configureMemoryCoreDreamingStateForTests,
+  resetMemoryCoreDreamingStateForTests,
+} from "../test-helpers.js";
+import { MemoryIndexManager } from "./manager.js";
+
+function activeFilesystemWatchers() {
+  return process.getActiveResourcesInfo().filter((resource) => resource === "FSEventWrap").length;
+}
+
+describe("memory watchers on the real filesystem", () => {
+  it.each(["replacement", "removal"] as const)(
+    "keeps search fresh after root %s and releases watchers on close",
+    async (operation) => {
+      const state = await createOpenClawTestState({ label: "memory-watch-filesystem" });
+      const initialWatchers = activeFilesystemWatchers();
+      let manager: MemoryIndexManager | null = null;
+      let index: DatabaseSync | undefined;
+      try {
+        await configureMemoryCoreDreamingStateForTests(state.env);
+        const memoryDir = path.join(state.workspaceDir, "memory");
+        await fs.mkdir(memoryDir);
+        // Preserve an indexed file while the watched root is absent.
+        await fs.writeFile(path.join(state.workspaceDir, "MEMORY.md"), "Evergreen sentinel.");
+        await fs.writeFile(path.join(memoryDir, "old.md"), "Amethyst sentinel.");
+        const cfg: OpenClawConfig = {
+          plugins: { enabled: false },
+          agents: { defaults: { workspace: state.workspaceDir }, list: [{ id: "main" }] },
+          memory: {
+            search: {
+              provider: "none",
+              sources: ["memory"],
+              store: { vector: { enabled: false } },
+              query: { minScore: 0 },
+            },
+          },
+        };
+        manager = await MemoryIndexManager.get({ cfg, agentId: "main" });
+        if (!manager) {
+          throw new Error("memory manager unavailable");
+        }
+        const activeManager = manager;
+        await activeManager.sync({ reason: "test-initial-index" });
+        expect(activeManager.status().fts?.available).toBe(true);
+        expect(activeFilesystemWatchers()).toBeGreaterThan(initialWatchers);
+        const indexPath = activeManager.status().dbPath;
+        if (!indexPath) {
+          throw new Error("memory index path unavailable");
+        }
+        index = new DatabaseSync(indexPath, { readOnly: true });
+        const indexedRows = index.prepare(
+          `SELECT path, text FROM ${MEMORY_INDEX_CHUNKS_TABLE} ORDER BY path, start_line`,
+        );
+        // Observe committed data without searching: search can synchronize dirty
+        // or empty indexes itself and would conceal broken filesystem watchers.
+        const expectIndexed = async (files: Array<{ path: string; text: string }>) => {
+          await expect
+            .poll(() => indexedRows.all(), { timeout: 15_000 })
+            .toEqual([{ path: "MEMORY.md", text: "Evergreen sentinel." }, ...files]);
+        };
+        await expectIndexed([{ path: "memory/old.md", text: "Amethyst sentinel." }]);
+
+        await fs.rename(memoryDir, state.path("previous-memory"));
+        if (operation === "removal") {
+          // Observe deletion before recreation; the parent must retain coverage
+          // even after the dead root's native watchers have been closed.
+          await expectIndexed([]);
+        }
+        await fs.mkdir(memoryDir);
+        const fresh = { path: "memory/fresh.md", text: "Heliotrope sentinel." };
+        await fs.writeFile(path.join(memoryDir, "fresh.md"), fresh.text);
+        await expectIndexed([fresh]);
+
+        const nestedDir = path.join(memoryDir, "nested");
+        await fs.mkdir(nestedDir);
+        const nested = { path: "memory/nested/note.md", text: "Juniper sentinel." };
+        await fs.writeFile(path.join(nestedDir, "note.md"), nested.text);
+        await expectIndexed([fresh, nested]);
+        nested.text = "Cobalt sentinel.";
+        await fs.writeFile(path.join(nestedDir, "note.md"), nested.text);
+        await expectIndexed([fresh, nested]);
+        await fs.rm(nestedDir, { recursive: true });
+        await expectIndexed([fresh]);
+        expect((await activeManager.search("Heliotrope")).map((result) => result.path)).toEqual([
+          fresh.path,
+        ]);
+        expect(await activeManager.search("Amethyst")).toEqual([]);
+        expect(await activeManager.search("Cobalt")).toEqual([]);
+
+        index.close();
+        index = undefined;
+        await activeManager.close();
+        await expect.poll(activeFilesystemWatchers).toBe(initialWatchers);
+      } finally {
+        index?.close();
+        await manager?.close();
+        resetMemoryCoreDreamingStateForTests();
+        await state.cleanup();
+      }
+    },
+    60_000,
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users replacing or temporarily removing their memory folder could stop receiving automatic memory-index updates, especially for later nested-file changes on Linux.

## Why This Change Was Made

The native watcher now retains its parent-directory coverage while the memory root is absent, instead of closing it before asynchronously establishing fallback coverage. One shared parent lifecycle handles recursive macOS/Windows watches and Linux directory-only watches, and one shared chokidar setup handles initial and fallback creation.

Attachment distinguishes a missing root from genuine failures, ignores stale events from closed watchers, and validates the Linux root after scanning descendants. A retained parent also handles its own rename and validates its inode before being trusted again. Existing symlink handling, genuine-error fallback, platform-specific main-watch algorithms, and teardown behavior remain intact. No config, schema, storage, or public API changes.

If a Linux root disappears during the initial scan after its watcher has attached, closing that partial coverage also schedules a broad sync. This preserves the old failure-path scheduling contract; setting the manager's dirty flag or starting an `ignoreInitial` fallback alone does not schedule that sync.

## User Impact

Memory-folder removal and recreation retain automatic indexing without a restart or manual search. This change addresses roots that already have native parent coverage; the separate initial-startup missing-root fallback limitation is unchanged.

## Evidence

AI-assisted maintainer cleanup with a connected watcher-lifecycle repair.

- Captured failures before the repairs: root missing/stat-to-attach races across macOS/Windows/Linux fixtures, Linux root disappearance after main attachment, root replacement during descendant scanning, symlink roots, and non-missing stat errors. The repaired focused cases pass.
- The published-head review caught a missing startup-sync trigger during the Linux initial scan. A new regression reproduces it with a real directory rename at the scan boundary and no synthetic watcher event: it fails against the earlier PR head and passes unchanged against the pre-cleanup owner. The repaired owner passes it too.
- Final local proof: 80 tests across watcher config, interval behavior, and real filesystem convergence pass on Node 24.19.0/macOS. Six redundant structural type casts in sync spies were removed without changing their assertions. Platform fixtures are not native Windows kernel proof.
- [Linux filesystem proof](https://github.com/openclaw/openclaw/actions/runs/33041900973): both root replacement/removal cases pass on Node 24.19.0/Linux 6.6.141/Vitest 4.1.11. The complete 34,146-file source digest matched the local candidate before execution. This ran the final production and real-filesystem test bytes; only the separate deterministic test's six spy-cast cleanups followed. Tests observe committed index rows before any search, cover nested creation/edit/deletion, and verify watcher handles are released. The owned Testbox completed and stopped.
- Independent source-blind proof exercised the actual memory runtime through a temporary loopback service/API on macOS, with fresh credential-free homes/state, provider `none`, vectors disabled, and real SQLite/filesystem watchers. Nine root/nested index transitions converged in 1.59–2.01 seconds. All 158 pre-search status/index responses retained zero searches and one initial manual sync; six final searches confirmed the recovered content and absence of stale content. This is runtime service/API proof, not packaged CLI or full Gateway proof.
- The first source-blind close observation was explicitly rejected as too short after its last edit, despite no observed index change. A separate complementary readiness/close/shutdown check on unchanged source completed both file writes before starting its clock: all 17 committed rowsets remained byte-identical for 3.438 seconds after the final edit, with zero remaining watcher handles and no searches. Both service runs exited cleanly with unchanged source fences. The combined proof retains the first run's passing indexing/search clauses and the separate corrected close check; the first run is not represented as an all-pass result.
- [Ordered Linux parent-event probe](https://github.com/openclaw/openclaw/actions/runs/33038423291) confirms that replacing the parent after root removal produces the parent's own basename, and only a fresh watcher observes subsequent root recreation. Node's actual `readdirSync` producer was also exercised with a `DT_UNKNOWN` entry: its child stat can fail while the scanned directory remains present, so only the root owner classifies root absence.
- Targeted typed lint and formatting pass. The final local changed gate passed its 17 preceding checks, including five doctor-contract tests and all three dead-export scans, then stopped on existing shared-install dependency type mismatches outside the changed files (including ACPX, CUA, markdown-it, and pi-tui). No changed-owner type diagnostics. This local result remains a failure, not a claimed passing gate.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33043504320) passed on `3854618cab8e5ee8565dcacb083cd56b0a3ef3db`: Node 24.19.0/Vitest 4.1.11, 76 watcher-lifecycle tests and both real-filesystem tests; the selected suite passed 1,956 tests. Production and test types, typed lint, and formatting all completed successfully, closing the local dependency mismatch gap.
- Production: 173 added / 180 removed, net **-7**. Tests: net **+151**, including the 110-line real-filesystem test; duplicated routing/setup/assertion coverage was consolidated.

Fresh complete P0–P3 precommit review of the complete branch and startup-sync repair found no actionable issue. A separate two-part published-head review now has zero accepted findings after adjudication. One raw P2 claimed that Linux symlink-root recovery could lose nested notifications; its raw finding and nonzero harness result are retained. The canonical `listMemoryFiles` producer intentionally excludes symlink roots and subtrees in the baseline, final head, current main, and stable release contract. Direct source/docs inspection and a six-case real-filesystem probe through the public SDK confirmed that those paths are not eligible for indexing. No product change was made to expand that contract, and this is not described as two clean raw review reports.

## Maintainer Decision and ClawSweeper Follow-through

The latest exact-head review's CI request is satisfied by the successful run above. Its optional native Windows rank-up proof was attempted but could not run: the available remote route was unreachable and isolated local environment creation failed before Windows started. Native Windows runtime behavior remains unverified; platform fixtures are not kernel proof. The bounded platform uncertainty is accepted for this repair based on actual macOS/Linux index-convergence and cleanup proof, Windows fixtures covering the same shared recursive/parent lifecycle, and preservation of the existing genuine-error fallback and platform-specific main-watch algorithms. No source change or review rerun was used to conceal that limitation.

ClawSweeper's 30-second expected-output timeout is preserved as an incomplete observation, not a passing replay. The completed exact-head filesystem tests and separately scoped runtime API proof above provide the actual terminal evidence. The stored-data heuristic does not correspond to a schema, migration, persisted-format, or embedding-policy change in this diff. Native preparation and merge remain separate final gates.
