### PR TITLE
fix(channels): respect room boundaries for join introductions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Group join introductions:** preserve Slack workspace routing and group-DM boundaries, honor Telegram General-topic policy and agent routing, keep failed Telegram introductions retryable, and truncate room context without splitting Unicode characters.
+
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
 
 - **Control UI agent files:** keep confirmed saves and file metadata intact when older reads or list refreshes finish later, preserve newer drafts, and rebuild invalidated file lists without losing the open editor.

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -666,7 +666,7 @@ See [Slash commands](/tools/slash-commands) for the command catalog and behavior
 
 <AccordionGroup>
   <Accordion title="Introductions when joining a server">
-    When the bot joins an allowed Discord server, OpenClaw posts one room-specific introduction. It prefers the server's system channel when the bot can view and send messages there; otherwise, it uses the first text channel with both **View Channel** and **Send Messages** permissions. If no eligible channel exists, no introduction is sent.
+    When the bot joins an allowed Discord server, OpenClaw posts one room-specific introduction. It prefers the server's system channel when channel policy allows it and the bot can view and send messages there; otherwise, it uses the first policy-allowed text channel with both **View Channel** and **Send Messages** permissions. If no eligible channel exists, no introduction is sent.
 
     Introductions use the channel name and topic, plus recent messages when available. Reading earlier messages also requires **Read Message History**; when that permission is missing, OpenClaw still introduces itself using channel metadata instead of failing.
 

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -70,8 +70,7 @@ there, grounded in what that platform can actually show it.
 `channels.<channel>.joinIntro: false`, or override a single account with
 `channels.<channel>.accounts.<accountId>.joinIntro`. Resolution order is the
 account value, then the channel value, then the default of `true`. There is no
-per-room switch, because a room is only configurable after the bot has already
-joined it. Only Discord, Slack, and Telegram accept this option; other channels
+per-room introduction switch. Only Discord, Slack, and Telegram accept this option; other channels
 reject it rather than accepting a setting they never read.
 
 **What it reads.** Core requests up to 100 recent messages plus room metadata,
@@ -88,15 +87,17 @@ When history is unavailable or unreadable, the introduction is still posted from
 room metadata alone and says what it can see rather than inventing activity.
 
 **Where it posts.** Slack and Telegram introduce in the room that was joined.
+Slack excludes direct messages and group DMs. Telegram forum introductions use
+the General topic's access policy and configured agent.
 Discord joins a server rather than a channel, so it uses the system channel when
-it can both view and send there, otherwise the first text channel that qualifies;
+it can both view and send there and channel policy allows it, otherwise the first text channel that qualifies;
 if no channel qualifies, it records a skip instead of posting.
 
 **How often.** Once per room. A durable claim is recorded per channel, account,
 and room with a 90-day lifetime, so reconnects and gateway restarts do not repeat
-an introduction. Discord additionally ignores server-available events older than
-five minutes, so restarting never mass-introduces into servers the bot already
-belonged to. A re-invite after the claim expires introduces again.
+an introduction. Discord additionally ignores server-available events when the
+bot's native join timestamp is older than five minutes, avoiding introductions
+for longstanding memberships. A re-invite after the claim expires introduces again.
 
 **Safety.** Room titles, topics, pinned text, and message history are third-party
 content, so they are wrapped as untrusted external content and the introduction

--- a/extensions/slack/src/monitor/events/members.test.ts
+++ b/extensions/slack/src/monitor/events/members.test.ts
@@ -184,7 +184,7 @@ describe("registerSlackMemberEvents", () => {
     const request = memberMocks.reportJoin.mock.calls[0]?.[0] as Parameters<
       typeof import("openclaw/plugin-sdk/channel-join-intro-runtime").reportChannelRoomJoin
     >[0];
-    await expect(request.resolveRoomContext({ messageLimit: 30 })).resolves.toEqual({
+    await expect(request.resolveRoomContext({ messageLimit: 100 })).resolves.toEqual({
       title: "#deploys",
       purpose: "Coordinate production deployments\nCurrent release: 42",
       recentMessages: [
@@ -194,7 +194,7 @@ describe("registerSlackMemberEvents", () => {
     });
     expect(readHistory).toHaveBeenCalledWith({
       channel: "C1",
-      limit: 30,
+      limit: 100,
       latest: undefined,
       oldest: undefined,
     });
@@ -251,7 +251,7 @@ describe("registerSlackMemberEvents", () => {
     const request = memberMocks.reportJoin.mock.calls[0]?.[0] as Parameters<
       typeof import("openclaw/plugin-sdk/channel-join-intro-runtime").reportChannelRoomJoin
     >[0];
-    await expect(request.resolveRoomContext({ messageLimit: 30 })).resolves.toEqual({
+    await expect(request.resolveRoomContext({ messageLimit: 100 })).resolves.toEqual({
       title: "#general",
       purpose: undefined,
     });
@@ -270,13 +270,48 @@ describe("registerSlackMemberEvents", () => {
     );
   });
 
-  it("never introduces the bot into a direct-message conversation", async () => {
-    await runMemberCase({
-      overrides: { dmPolicy: "open" },
-      event: makeMemberEvent({ channel: "D1", user: "U_BOT" }),
+  it.each([
+    { name: "direct message", channelId: "D1", channelType: "im" as const },
+    { name: "group direct message", channelId: "G1", channelType: "mpim" as const },
+  ])(
+    "never introduces the bot into a $name with native member-event channel types",
+    async ({ channelId, channelType }) => {
+      await runMemberCase({
+        overrides: { dmPolicy: "open", channelType },
+        event: {
+          ...makeMemberEvent({ channel: channelId, user: "U_BOT" }),
+          channel_type: channelId[0],
+        },
+      });
+
+      expect(memberMocks.reportJoin).not.toHaveBeenCalled();
+    },
+  );
+
+  it("skips a self-join when lookup failure leaves the conversation type unknown", async () => {
+    const harness = initSlackHarness({ channelType: "mpim" });
+    harness.ctx.cfg = { channels: { slack: { groupPolicy: "open" } } };
+    harness.ctx.accountId = "default";
+    harness.ctx.resolveChannelName = vi.fn(async () => ({}));
+    harness.ctx.runtime.log = vi.fn();
+    registerSlackMemberEvents({ ctx: harness.ctx });
+    const handler = harness.getHandler("member_joined_channel");
+    if (!handler) {
+      throw new Error("expected Slack member joined handler");
+    }
+
+    await handler({
+      event: {
+        ...makeMemberEvent({ channel: "G1", user: "U_BOT" }),
+        channel_type: "G",
+      },
+      body: { event_id: "Ev-self-unknown-type" },
     });
 
     expect(memberMocks.reportJoin).not.toHaveBeenCalled();
+    expect(harness.ctx.runtime.log).toHaveBeenCalledWith(
+      expect.stringContaining("reason=channel-type-unavailable"),
+    );
   });
 
   it("does not track mismatched events", async () => {
@@ -385,6 +420,53 @@ describe("registerSlackMemberEvents", () => {
       expect.objectContaining({ teamId: "T111" }),
     );
     expect(resolveUserName).toHaveBeenCalledWith("U1", expect.objectContaining({ teamId: "T222" }));
+  });
+
+  it("qualifies enterprise self-join room and delivery targets by listener workspace", async () => {
+    const harness = initSlackHarness({ channelType: "channel" });
+    harness.ctx.cfg = { channels: { slack: { groupPolicy: "open" } } };
+    harness.ctx.accountId = "default";
+    harness.ctx.installationIdentity = {
+      kind: "enterprise",
+      apiAppId: "A_GRID",
+      enterpriseId: "E_GRID",
+    };
+    harness.ctx.resolveSlackSystemEventRoute = (input) => ({
+      agentId: "main",
+      sessionKey: `session:${input.eventScope?.teamId}`,
+    });
+    registerSlackMemberEvents({ ctx: harness.ctx });
+    const handler = harness.getHandler("member_joined_channel");
+    if (!handler) {
+      throw new Error("expected Slack member joined handler");
+    }
+
+    for (const teamId of ["T111", "T222"]) {
+      await handler({
+        event: makeMemberEvent({ channel: "C1", user: "U_BOT" }),
+        body: { api_app_id: "A_GRID", event_id: `Ev-self-join-${teamId}` },
+        context: {
+          isEnterpriseInstall: true,
+          enterpriseId: "E_GRID",
+          teamId,
+        } as AllMiddlewareArgs["context"],
+        client: { token: `listener-${teamId}` } as AllMiddlewareArgs["client"],
+      });
+    }
+
+    expect(memberMocks.reportJoin.mock.calls.map(([request]) => request)).toEqual([
+      expect.objectContaining({
+        conversationId: "team:T111:C1",
+        deliverTo: "team:T111:channel:C1",
+        route: { agentId: "main", sessionKey: "session:T111" },
+      }),
+      expect.objectContaining({
+        conversationId: "team:T222:C1",
+        deliverTo: "team:T222:channel:C1",
+        route: { agentId: "main", sessionKey: "session:T222" },
+      }),
+    ]);
+    expect(memberMocks.enqueue).not.toHaveBeenCalled();
   });
 
   it("rejects enterprise member events without validated listener scope", async () => {

--- a/extensions/slack/src/monitor/events/members.ts
+++ b/extensions/slack/src/monitor/events/members.ts
@@ -6,9 +6,9 @@ import { danger } from "openclaw/plugin-sdk/runtime-env";
 import { enqueueRoutedSystemEvent } from "openclaw/plugin-sdk/system-event-runtime";
 import { readSlackMessages } from "../../actions.js";
 import { SlackSystemEventAuthRetryError } from "../auth.js";
-import { normalizeSlackChannelType } from "../channel-type.js";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackMemberChannelEvent } from "../types.js";
+import { qualifySlackConversationId } from "../workspace-routing.js";
 import {
   authorizeAndResolveSlackSystemEventContext,
   resolveSlackListenerEventScope,
@@ -45,9 +45,16 @@ export function registerSlackMemberEvents(params: {
       const payload = paramsLocal.event;
       const channelId = payload.channel;
       const channelInfo = channelId ? await ctx.resolveChannelName(channelId, eventScope) : {};
-      const channelType = payload.channel_type ?? channelInfo?.type;
+      const channelType = channelInfo.type ?? payload.channel_type;
       if (paramsLocal.verb === "joined" && payload.user === ctx.botUserId && channelId) {
-        const roomType = normalizeSlackChannelType(channelType, channelId);
+        // Native C/G markers cannot distinguish private channels from multi-person DMs.
+        const roomType = channelInfo.type;
+        if (!roomType) {
+          ctx.runtime.log?.(
+            `slack join introduction skipped: channel=${channelId} reason=channel-type-unavailable`,
+          );
+          return;
+        }
         if (roomType === "channel" || roomType === "group") {
           // Joining is conversation admission, not a human message: sender allowlists
           // and requireMention cannot apply to the bot's own membership event.
@@ -65,8 +72,8 @@ export function registerSlackMemberEvents(params: {
             cfg: ctx.cfg,
             channel: "slack",
             accountId: ctx.accountId,
-            conversationId: channelId,
-            deliverTo: `channel:${channelId}`,
+            conversationId: qualifySlackConversationId(channelId, eventScope),
+            deliverTo: qualifySlackConversationId(`channel:${channelId}`, eventScope),
             route: ctx.resolveSlackSystemEventRoute({
               channelId,
               channelType: roomType,

--- a/extensions/telegram/src/bot-handlers.event-bindings.ts
+++ b/extensions/telegram/src/bot-handlers.event-bindings.ts
@@ -84,15 +84,24 @@ export function createTelegramEventBindings({
       }
 
       const chatId = membership.chat.id;
+      const threadSpec = resolveTelegramThreadSpec({
+        isGroup: true,
+        isForum: membership.chat.is_forum === true,
+      });
       const currentCfg = telegramDeps.getRuntimeConfig();
       const telegramCfg = resolveTelegramAccount({ cfg: currentCfg, accountId }).config;
-      const { groupConfig } = params.resolveTelegramGroupConfig(chatId, undefined, currentCfg);
+      const { groupConfig, topicConfig } = params.resolveTelegramGroupConfig(
+        chatId,
+        threadSpec.id,
+        currentCfg,
+      );
       const groupPolicyAccess = evaluateTelegramGroupPolicyAccess({
         isGroup: true,
         chatId,
         cfg: currentCfg,
         telegramCfg,
         groupConfig,
+        topicConfig,
         effectiveGroupAllow: normalizeAllowFrom(),
         resolveGroupPolicy: params.resolveGroupPolicy,
         enforcePolicy: true,
@@ -101,12 +110,15 @@ export function createTelegramEventBindings({
         requireSenderForAllowlistAuthorization: false,
         checkChatAllowlist: true,
       });
-      const roomAllowed = groupConfig?.enabled !== false && groupPolicyAccess.allowed;
+      const roomAllowed =
+        groupConfig?.enabled !== false &&
+        topicConfig?.enabled !== false &&
+        groupPolicyAccess.allowed;
       const inviter = membership.from;
       const inviterLabel =
         [inviter.first_name, inviter.last_name].filter(Boolean).join(" ") || inviter.username;
 
-      await reportChannelRoomJoin({
+      const outcome = await reportChannelRoomJoin({
         cfg: currentCfg,
         channel: "telegram",
         accountId,
@@ -117,7 +129,8 @@ export function createTelegramEventBindings({
           accountId,
           chatId,
           isGroup: true,
-          threadSpec: resolveTelegramThreadSpec({ isGroup: true }),
+          threadSpec,
+          topicAgentId: topicConfig?.agentId,
         }).route,
         inviterLabel,
         roomAllowed,
@@ -132,6 +145,12 @@ export function createTelegramEventBindings({
           };
         },
       });
+      if (outcome.kind === "failed") {
+        recordTelegramMessageProcessingResult({
+          kind: "failed-retryable",
+          error: new Error(outcome.reason),
+        });
+      }
     });
   };
 

--- a/extensions/telegram/src/bot.create-telegram-bot.join-intro.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.join-intro.test.ts
@@ -1,5 +1,10 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ensureTelegramMessageProcessingResult,
+  runWithTelegramSpooledReplayUpdate,
+  runWithTelegramUpdateProcessingFrame,
+} from "./bot-processing-outcome.js";
 import { telegramBotInfoForTest } from "./bot.create-telegram-bot.test-support.js";
 
 type ReportChannelRoomJoin =
@@ -25,6 +30,7 @@ function createMembershipContext(params?: {
   newStatus?: "left" | "member";
   memberId?: number;
   contextBotId?: number;
+  isForum?: boolean;
 }) {
   const member = {
     id: params?.memberId ?? telegramBotInfoForTest.id,
@@ -36,6 +42,7 @@ function createMembershipContext(params?: {
       id: TELEGRAM_GROUP_CHAT_ID,
       type: params?.chatType ?? "supergroup",
       title: "Incident Response",
+      is_forum: params?.isForum,
     },
     from: { id: 12345, is_bot: false, first_name: "Sam", last_name: "Rivera" },
     date: 1736380800,
@@ -61,7 +68,7 @@ function registerJoinHandler(config: OpenClawConfig) {
 
 describe("Telegram group join introductions", () => {
   beforeEach(() => {
-    reportChannelRoomJoinMock.mockClear();
+    reportChannelRoomJoinMock.mockReset().mockResolvedValue({ kind: "posted" });
   });
 
   it("reports the bot's native group join with metadata-only room context", async () => {
@@ -99,13 +106,66 @@ describe("Telegram group join introductions", () => {
       roomAllowed: true,
       route: { agentId: "main" },
     });
-    await expect(params.resolveRoomContext({ messageLimit: 30 })).resolves.toEqual({
+    await expect(params.resolveRoomContext({ messageLimit: 100 })).resolves.toEqual({
       title: "Incident Response",
       purpose: "Coordinate production incidents",
       pinned: "Start with the incident checklist",
       historyUnavailable: true,
     });
     expect(getChatSpy).toHaveBeenCalledWith(TELEGRAM_GROUP_CHAT_ID);
+  });
+
+  it("keeps a failed introduction retryable for durable ingress", async () => {
+    const handler = registerJoinHandler({
+      channels: { telegram: { groupPolicy: "open" } },
+    });
+    reportChannelRoomJoinMock.mockResolvedValueOnce({
+      kind: "failed",
+      reason: "provider unavailable",
+    });
+    const context = createMembershipContext();
+
+    const { result } = await runWithTelegramUpdateProcessingFrame(() =>
+      runWithTelegramSpooledReplayUpdate(context.update, async () => {
+        await handler(context);
+        ensureTelegramMessageProcessingResult({ kind: "completed" });
+      }),
+    );
+
+    expect(result).toMatchObject({
+      kind: "failed-retryable",
+      error: expect.objectContaining({ message: "provider unavailable" }),
+    });
+  });
+
+  it("routes a forum introduction through the General topic's configured agent", async () => {
+    const handler = registerJoinHandler({
+      agents: { ownership: "explicit", list: [{ id: "main" }, { id: "triage" }] },
+      bindings: [{ agentId: "main", match: { channel: "telegram", accountId: "default" } }],
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: {
+            [String(TELEGRAM_GROUP_CHAT_ID)]: {
+              topics: { "1": { agentId: "triage" } },
+            },
+          },
+        },
+      },
+    });
+
+    await handler(createMembershipContext({ isForum: true }));
+
+    expect(reportChannelRoomJoinMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deliverTo: String(TELEGRAM_GROUP_CHAT_ID),
+        roomAllowed: true,
+        route: expect.objectContaining({
+          agentId: "triage",
+          sessionKey: expect.stringContaining(":topic:1"),
+        }),
+      }),
+    );
   });
 
   it.each([
@@ -144,17 +204,42 @@ describe("Telegram group join introductions", () => {
         groups: { "-1009999999999": { enabled: true } },
       },
     },
-  ])("passes a rejected conversation to the shared owner for $name", async ({ config }) => {
-    const handler = registerJoinHandler({ channels: { telegram: config } });
+    {
+      name: "a disabled General forum topic",
+      isForum: true,
+      config: {
+        groupPolicy: "open" as const,
+        groups: {
+          [String(TELEGRAM_GROUP_CHAT_ID)]: { topics: { "1": { enabled: false } } },
+        },
+      },
+    },
+    {
+      name: "disabled General forum topic policy",
+      isForum: true,
+      config: {
+        groupPolicy: "open" as const,
+        groups: {
+          [String(TELEGRAM_GROUP_CHAT_ID)]: {
+            topics: { "1": { groupPolicy: "disabled" as const } },
+          },
+        },
+      },
+    },
+  ])(
+    "passes a rejected conversation to the shared owner for $name",
+    async ({ config, isForum }) => {
+      const handler = registerJoinHandler({ channels: { telegram: config } });
 
-    await handler(createMembershipContext());
+      await handler(createMembershipContext({ isForum }));
 
-    expect(reportChannelRoomJoinMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationId: String(TELEGRAM_GROUP_CHAT_ID),
-        roomAllowed: false,
-      }),
-    );
-    expect(getChatSpy).not.toHaveBeenCalled();
-  });
+      expect(reportChannelRoomJoinMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationId: String(TELEGRAM_GROUP_CHAT_ID),
+          roomAllowed: false,
+        }),
+      );
+      expect(getChatSpy).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/channels/join-intro/join-intro-prompt.test.ts
+++ b/src/channels/join-intro/join-intro-prompt.test.ts
@@ -23,6 +23,22 @@ describe("buildChannelJoinIntroPrompt", () => {
     expect(snapshot?.indexOf("message-98")).toBeLessThan(snapshot?.indexOf("message-99") ?? -1);
   });
 
+  it.each([
+    { name: "room metadata", context: { title: `#a${"🙂".repeat(6_000)}` } },
+    {
+      name: "the newest message",
+      context: { title: "#a", recentMessages: [{ text: "🙂".repeat(6_000) }] },
+    },
+  ])("preserves Unicode when truncating $name", ({ context }) => {
+    const prompt = buildChannelJoinIntroPrompt({ context });
+    const snapshot = prompt.split("\n\nRoom context:\n")[1];
+
+    expect(snapshot?.length).toBeLessThanOrEqual(12_000);
+    expect(snapshot).toContain("🙂");
+    // In Unicode mode, this range matches only unpaired surrogate code units.
+    expect(/[\uD800-\uDFFF]/u.test(prompt)).toBe(false);
+  });
+
   it("grounds unreadable room history in visible room facts and asks what the room needs", () => {
     const prompt = buildChannelJoinIntroPrompt({
       context: { title: "Design Team", purpose: "Brand review", historyUnavailable: true },

--- a/src/channels/join-intro/join-intro-prompt.ts
+++ b/src/channels/join-intro/join-intro-prompt.ts
@@ -1,3 +1,5 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+
 export type ChannelJoinedRoomContext = {
   /** Human room name, e.g. "#deploys" or "Design Team". */
   title?: string;
@@ -11,9 +13,8 @@ export type ChannelJoinedRoomContext = {
   historyUnavailable?: boolean;
 };
 
-// Roughly 3K snapshot tokens. Characterizing a room needs enough traffic to see recurring
-// topics, and this turn runs once per room lifetime rather than on every message, so the
-// budget buys grounding quality instead of recurring context cost.
+// Keep enough history to show recurring room topics without unbounded context.
+// This is a UTF-16 code-unit cap; token usage varies by language.
 const CHANNEL_JOIN_INTRO_MAX_SNAPSHOT_CHARS = 12_000;
 
 function formatChannelJoinRoomSnapshot(params: {
@@ -38,7 +39,9 @@ function formatChannelJoinRoomSnapshot(params: {
     roomFacts.push("Earlier room messages cannot be read on this platform.");
   }
 
-  let snapshot = roomFacts.join("\n").slice(0, CHANNEL_JOIN_INTRO_MAX_SNAPSHOT_CHARS);
+  const metadata = truncateUtf16Safe(roomFacts.join("\n"), CHANNEL_JOIN_INTRO_MAX_SNAPSHOT_CHARS);
+  const messageHeader = "\nRecent room messages:\n";
+  let remaining = CHANNEL_JOIN_INTRO_MAX_SNAPSHOT_CHARS - metadata.length - messageHeader.length;
   const recentMessages: string[] = [];
   for (const message of (context.recentMessages ?? []).toReversed()) {
     const text = message.text.trim();
@@ -46,30 +49,22 @@ function formatChannelJoinRoomSnapshot(params: {
       continue;
     }
     const line = `${message.sender?.trim() || "Participant"}: ${text}`;
-    const messageHeader = recentMessages.length === 0 ? "\nRecent room messages:\n" : "\n";
-    const remaining =
-      CHANNEL_JOIN_INTRO_MAX_SNAPSHOT_CHARS - snapshot.length - messageHeader.length;
     if (remaining <= 0) {
       break;
     }
     if (line.length > remaining) {
       if (recentMessages.length === 0) {
-        recentMessages.unshift(line.slice(0, remaining));
+        recentMessages.unshift(truncateUtf16Safe(line, remaining));
       }
       break;
     }
     recentMessages.unshift(line);
-    snapshot += messageHeader + line;
+    remaining -= line.length + 1;
   }
 
-  if (recentMessages.length > 0) {
-    const metadata = roomFacts.join("\n").slice(0, CHANNEL_JOIN_INTRO_MAX_SNAPSHOT_CHARS);
-    return `${metadata}\nRecent room messages:\n${recentMessages.join("\n")}`.slice(
-      0,
-      CHANNEL_JOIN_INTRO_MAX_SNAPSHOT_CHARS,
-    );
-  }
-  return snapshot || "No room details or readable message history were provided.";
+  return recentMessages.length > 0
+    ? `${metadata}${messageHeader}${recentMessages.join("\n")}`
+    : metadata || "No room details or readable message history were provided.";
 }
 
 export function buildChannelJoinIntroPrompt(params: {


### PR DESCRIPTION
Related: #130103

## What Problem This Solves

Fixes an issue where automatic introductions could enter Slack group DMs or disabled Telegram General topics, fail for Enterprise Slack installations, or disappear permanently after a transient Telegram failure. Oversized Unicode room context could also be split into invalid text.

## Why This Change Was Made

The join adapters must retain the conversation identity and policy already owned by their channels. Slack now uses resolved conversation types and the existing workspace qualifier. Telegram uses the canonical General-topic resolver, admission policy, configured agent, and durable-ingress failure outcome. The shared prompt builder uses the existing Unicode-safe truncation helper and removes duplicate snapshot construction.

This preserves the intended 100-message fetch, 12,000-character snapshot budget, and once-per-room suppression. It does not change the storage schema, claim lifetime, or successful re-invite behavior.

## User Impact

Introductions respect the same room boundaries as normal operation. Enterprise Slack targets retain their workspace; Telegram transient failures remain eligible for retry; long multilingual context stays valid. Documentation clarifies Discord target policy and native join timestamps.

## Evidence

Nine added regression cases failed on the merged implementation: two Unicode boundaries, three Slack admission/routing cases, and four Telegram policy/routing/retry cases. After repair, 97 focused and sibling tests pass across nine files, including Enterprise Slack delivery, Telegram processing-result/drain behavior, shared claim handling, and Discord target selection. The independent Codex P0 review found no blockers.

A fresh isolated Linux container ran the actual Gateway with `openai/gpt-5.6-luna` and a synthetic Telegram API. It produced exactly one 33-word, room-specific introduction. Replaying the join, leaving, and re-inviting produced no additional message; the shared owner recorded `already-introduced`. The run checked SHA-256 fingerprints of the seven relevant runtime/harness files, and those bytes match this commit. Gateway, fixture, and container cleanup completed. This is real-model/Gateway evidence, **not native Telegram proof**.

```json
{
  "status": "pass",
  "executionBase": "35630bf1dfba1482f44b503ec016d3a5502255ef",
  "verifiedCommit": "b63cc1a538bf95fdc70b3e00bf65996f96d811b7",
  "gateway": "real",
  "model": "openai/gpt-5.6-luna",
  "telegramTransport": "synthetic",
  "firstJoinDeliveries": 1,
  "totalDeliveriesAfterReplayAndReinvite": 1,
  "reinviteOutcome": "already-introduced",
  "cleanupComplete": true
}
```

The local changed-file gate passed its contract, formatting, export, core typecheck, and core-test typecheck stages, then stopped because the shared linked-worktree install lacks `@daytona/sdk`, required by the untouched Daytona plugin. No shared dependency install was modified. Exact-head CI is pending.

Native Telegram proof remains blocked on unavailable test-account access. No native channel settings were changed in this follow-up. Keep this PR unmerged until that proof is completed. The successful isolated-container fallback had no host mounts or Docker socket.

Production delta: +47/-26 (net +21); tests: +205/-22 (net +183). The growth carries the existing workspace identity, topic policy/agent, and retry outcome into their canonical owners; the prompt simplification removes five production lines. No new helper, configuration key, storage schema, or delivery path was added.

Dependency/source checks included the [Slack membership-event contract](https://docs.slack.dev/reference/events/member_joined_channel/), installed grammY types, canonical channel routing/ingress helpers, and Codex text contracts at `codex-rs/protocol/src/user_input.rs:15` and `codex-rs/protocol/src/models.rs:853`.
