### PR TITLE
fix(codex): prevent stale resumes from disrupting shared sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Codex resume ownership:** revalidate ownership immediately before native resume and unsubscribe writes, including overload retries, while preserving healthy shared clients when a rejected request loses its owner.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
 
 - **Control UI agent files:** keep confirmed saves and file metadata intact when older reads or list refreshes finish later, preserve newer drafts, and rebuild invalidated file lists without losing the open editor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Codex resume ownership:** revalidate ownership immediately before native resume and unsubscribe writes, including overload retries, while preserving healthy shared clients when a rejected request loses its owner.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
 
 - **Control UI agent files:** keep confirmed saves and file metadata intact when older reads or list refreshes finish later, preserve newer drafts, and rebuild invalidated file lists without losing the open editor.

--- a/extensions/codex/src/app-server/client-runtime.ts
+++ b/extensions/codex/src/app-server/client-runtime.ts
@@ -512,7 +512,7 @@ export async function unsubscribeCodexAppServerLiveThread(
       return;
     }
     assertCurrent?.();
-    await client.request("thread/unsubscribe", { threadId }, { timeoutMs });
+    await client.request("thread/unsubscribe", { threadId }, { timeoutMs, assertCurrent });
   });
   const ownsTransition = runtime !== undefined && transition === undefined;
   if (transition) {

--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -279,6 +279,43 @@ describe("CodexAppServerClient", () => {
     expect(harness.writes).toHaveLength(1);
   });
 
+  it("keeps the shared client when ownership expires after an overload rejection", async () => {
+    vi.useFakeTimers();
+    const harness = createClientHarness();
+    clients.push(harness.client);
+    const releaseGuard = vi.fn();
+    harness.client.setThreadSessionRequestGuard(async () => releaseGuard);
+    let current = true;
+    const ownershipError = new Error("request owner expired");
+    const request = harness.client.request(
+      "thread/resume",
+      { threadId: "thread-1" },
+      {
+        timeoutMs: 5_000,
+        assertCurrent: () => {
+          if (!current) {
+            throw ownershipError;
+          }
+        },
+      },
+    );
+    const rejection = expect(request).rejects.toBe(ownershipError);
+    await vi.advanceTimersByTimeAsync(0);
+    const first = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
+    harness.send({
+      id: first.id,
+      error: { code: -32_001, message: "Server overloaded; retry later." },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    current = false;
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    await rejection;
+    expect(harness.writes).toHaveLength(1);
+    expect(releaseGuard).toHaveBeenCalledOnce();
+    expect(harness.client.getCloseError()).toBeUndefined();
+  });
+
   it("surfaces relogin details from Codex app-server RPC errors", async () => {
     const harness = createClientHarness();
     clients.push(harness.client);

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -56,6 +56,12 @@ type PendingRequest = {
   cleanup: () => void;
 };
 
+type RequestOptions = {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  assertCurrent?: () => void;
+};
+
 /** Process-local generation fence for bindings tied to one app-server client instance. */
 export function getCodexAppServerClientInstanceId(client: object): string {
   const current = CODEX_APP_SERVER_CLIENT_INSTANCE_IDS.get(client);
@@ -357,20 +363,19 @@ export class CodexAppServerClient {
   request<M extends CodexAppServerRequestMethod>(
     method: M,
     params: CodexAppServerRequestParams<M>,
-    options?: { timeoutMs?: number; signal?: AbortSignal },
+    options?: RequestOptions,
   ): Promise<CodexAppServerRequestResult<M>>;
   request<T = JsonValue | undefined>(
     method: string,
     params?: unknown,
-    options?: { timeoutMs?: number; signal?: AbortSignal },
+    options?: RequestOptions,
   ): Promise<T>;
   request<T = JsonValue | undefined>(
     method: string,
     params?: unknown,
-    optionsInput?: { timeoutMs?: number; signal?: AbortSignal },
+    optionsInput?: RequestOptions,
   ): Promise<T> {
-    let options = optionsInput;
-    options ??= {};
+    const options = optionsInput ?? {};
     if (this.closed) {
       return Promise.reject(this.closeError ?? new Error("codex app-server client is closed"));
     }
@@ -434,15 +439,15 @@ export class CodexAppServerClient {
           if (remainingTimeoutMs !== undefined && remainingTimeoutMs <= 0) {
             throw new CodexAppServerLocalRequestCancellationError(method, "timed out", false);
           }
-          return await this.requestWithoutThreadSessionGuard<T>(
+          return await this.requestWithOverloadRetry<T>(
             method,
             params,
             {
               ...options,
               ...(remainingTimeoutMs !== undefined ? { timeoutMs: remainingTimeoutMs } : {}),
             },
-            () => {
-              requestMayHaveWritten = true;
+            (mayHaveWritten) => {
+              requestMayHaveWritten = mayHaveWritten;
             },
           );
         } catch (error) {
@@ -461,23 +466,14 @@ export class CodexAppServerClient {
         }
       })();
     }
-    return this.requestWithoutThreadSessionGuard<T>(method, params, options);
-  }
-
-  private requestWithoutThreadSessionGuard<T>(
-    method: string,
-    params: unknown,
-    options: { timeoutMs?: number; signal?: AbortSignal },
-    onWriteAttempt?: () => void,
-  ): Promise<T> {
-    return this.requestWithOverloadRetry(method, params, options, onWriteAttempt);
+    return this.requestWithOverloadRetry<T>(method, params, options);
   }
 
   private async requestWithOverloadRetry<T>(
     method: string,
     params: unknown,
-    options: { timeoutMs?: number; signal?: AbortSignal },
-    onWriteAttempt?: () => void,
+    options: RequestOptions,
+    onWriteStateChange?: (mayHaveWritten: boolean) => void,
   ): Promise<T> {
     const deadline =
       options.timeoutMs !== undefined && Number.isFinite(options.timeoutMs)
@@ -499,7 +495,7 @@ export class CodexAppServerClient {
             ...options,
             ...(remainingTimeoutMs !== undefined ? { timeoutMs: remainingTimeoutMs } : {}),
           },
-          onWriteAttempt,
+          onWriteStateChange,
         );
       } catch (error) {
         // Codex emits -32001 only when ingress rejects a request before enqueue,
@@ -511,6 +507,9 @@ export class CodexAppServerClient {
         ) {
           throw error;
         }
+        // Ingress rejected this attempt, so cancellation before the retry
+        // must not retire a shared client with no outstanding native request.
+        onWriteStateChange?.(false);
         const backoffMs = Math.round(
           CODEX_APP_SERVER_OVERLOAD_RETRY_BASE_MS * 2 ** retry * (0.75 + Math.random() * 0.5),
         );
@@ -557,8 +556,8 @@ export class CodexAppServerClient {
   private requestOnce<T>(
     method: string,
     params: unknown,
-    options: { timeoutMs?: number; signal?: AbortSignal },
-    onWriteAttempt?: () => void,
+    options: RequestOptions,
+    onWriteStateChange?: (mayHaveWritten: boolean) => void,
   ): Promise<T> {
     if (this.closed) {
       return Promise.reject(this.closeError ?? new Error("codex app-server client is closed"));
@@ -639,8 +638,11 @@ export class CodexAppServerClient {
         return;
       }
       try {
+        // Config-fence waits and overload retries can outlive the caller's
+        // ownership. Revalidate before each physical write, without an await.
+        options.assertCurrent?.();
         mayHaveWritten = true;
-        onWriteAttempt?.();
+        onWriteStateChange?.(true);
         this.writeMessage(message, (error) => rejectPending(error));
       } catch (error) {
         rejectPending(toStringifiedError(error));

--- a/extensions/codex/src/app-server/session-retirement.test.ts
+++ b/extensions/codex/src/app-server/session-retirement.test.ts
@@ -250,7 +250,7 @@ describe("Codex session deletion subscriptions", () => {
     expect(fixture.request).toHaveBeenCalledExactlyOnceWith(
       "thread/unsubscribe",
       { threadId: fixture.binding.threadId },
-      { timeoutMs: 5_000 },
+      { timeoutMs: 5_000, assertCurrent: expect.any(Function) },
     );
   });
 });

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -217,6 +217,7 @@ export async function resumeExistingCodexThread(
         },
         request: resumeParams,
         signal: params.signal,
+        assertCurrent: context.assertResumeOwnership,
       }),
     );
     context.assertResumeConfiguration?.();

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -12,7 +12,8 @@ import {
 } from "./client-runtime.js";
 import { CodexAppServerClient, CodexAppServerRpcError } from "./client.js";
 import { createFakeCodexAppServerClient } from "./codex-app-server.test-fixtures.js";
-import type { CodexDynamicToolFunctionSpec, JsonValue } from "./protocol.js";
+import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
+import type { CodexDynamicToolFunctionSpec, JsonValue, RpcRequest } from "./protocol.js";
 import {
   createParams as createRunAttemptParams,
   setupRunAttemptTestHooks,
@@ -28,8 +29,10 @@ import {
 import {
   getLeasedSharedCodexAppServerClient,
   releaseLeasedSharedCodexAppServerClient,
+  resolveCodexNativeConfigFenceKey,
   retainSharedCodexAppServerClientIfCurrent,
 } from "./shared-client.js";
+import { createClientHarness } from "./test-support.js";
 import { fingerprintEnvironmentSelection } from "./thread-fingerprints.js";
 import {
   buildThreadResumeParams,
@@ -309,6 +312,7 @@ async function createManualResumeFixture(
     missingMetadata?: boolean;
     omitCatalog?: boolean;
     competingLease?: "read" | "release" | "resume";
+    wireClient?: boolean;
   } = {},
 ) {
   const dynamicTools = options.dynamicTools ?? [];
@@ -333,7 +337,7 @@ async function createManualResumeFixture(
   const compete = () => {
     // A sibling can start and finish between reads; sole ownership at the
     // final snapshot must not erase that intervening native runtime activity.
-    const release = retainSharedCodexAppServerClientIfCurrent(harness.client);
+    const release = retainSharedCodexAppServerClientIfCurrent(client);
     expect(release).toBeTypeOf("function");
     release?.();
   };
@@ -383,13 +387,39 @@ async function createManualResumeFixture(
     }
     throw new Error(`unexpected method: ${method}`);
   });
-  const { client } = harness;
-  Object.assign(client, {
-    initialize: async () => undefined,
-    addTransportExitHandler: () => () => undefined,
-    setThreadSessionRequestGuard: () => undefined,
-    close: () => harness.close(),
-  });
+  const wire = options.wireClient ? createClientHarness() : undefined;
+  const client = wire?.client ?? harness.client;
+  if (wire) {
+    // Keep the existing native response fixture behind the real wire client so
+    // its async request guard and synchronous write edge remain under test.
+    const appendWrites = wire.writes.push.bind(wire.writes);
+    vi.spyOn(wire.writes, "push").mockImplementation((...messages) => {
+      const count = appendWrites(...messages);
+      for (const message of messages) {
+        const request = JSON.parse(message) as RpcRequest;
+        void Promise.resolve(harness.request(request.method, request.params)).then(
+          (result) => wire.send({ id: request.id, result }),
+          (error: unknown) =>
+            wire.send({
+              id: request.id,
+              error: { code: -32603, message: String(error) },
+            }),
+        );
+      }
+      return count;
+    });
+    vi.spyOn(harness, "notify").mockImplementation(async (notification) => {
+      wire.send(notification);
+    });
+    vi.spyOn(client, "initialize").mockResolvedValue(undefined);
+  } else {
+    Object.assign(client, {
+      initialize: async () => undefined,
+      addTransportExitHandler: () => () => undefined,
+      setThreadSessionRequestGuard: () => undefined,
+      close: () => harness.close(),
+    });
+  }
   const start = vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(client);
   try {
     await getLeasedSharedCodexAppServerClient({
@@ -407,7 +437,9 @@ async function createManualResumeFixture(
     resolveCodexCommandDeps({
       bindingStore: testCodexAppServerBindingStore,
       codexControlRequest: async (_pluginConfig, method, requestParams, requestOptions) => {
-        const result = await client.request<JsonValue>(method, requestParams);
+        const result = await client.request<JsonValue>(method, requestParams, {
+          timeoutMs: 60_000,
+        });
         await requestOptions?.onResponse?.(result, client, { authProfileId: undefined });
         return result;
       },
@@ -438,9 +470,15 @@ async function createManualResumeFixture(
   };
   return {
     ...harness,
+    client,
+    wire,
     close: () => {
       releaseLeasedSharedCodexAppServerClient(client);
-      harness.close();
+      if (wire) {
+        wire.client.close();
+      } else {
+        harness.close();
+      }
     },
     common,
     sessionFile,
@@ -993,6 +1031,51 @@ describe("Codex app-server thread lifecycle bindings", () => {
       }
     },
   );
+
+  it("does not write a pending resume after its sole client lease changes behind the native config fence", async () => {
+    const fixture = await createManualResumeFixture({ wireClient: true });
+    const before = await readCodexAppServerBinding(fixture.sessionFile);
+    const fenceKey = resolveCodexNativeConfigFenceKey({ client: fixture.client });
+    expect(fenceKey).toBeTypeOf("string");
+    const releaseFence = await acquireCodexNativeConfigFence(fenceKey!);
+    const guardEntered = createDeferred<void>();
+    const abort = new AbortController();
+    fixture.client.setThreadSessionRequestGuard(async (options) => {
+      guardEntered.resolve();
+      return await acquireCodexNativeConfigFence(fenceKey!, options);
+    });
+    const starting = fixture.start({ signal: abort.signal });
+    const settled = starting.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    try {
+      await Promise.race([
+        guardEntered.promise,
+        settled.then(() => {
+          throw new Error("manual resume settled before reaching its native config fence");
+        }),
+      ]);
+      const releaseSibling = retainSharedCodexAppServerClientIfCurrent(fixture.client);
+      expect(releaseSibling).toBeTypeOf("function");
+      releaseSibling?.();
+      releaseFence();
+
+      await expect(starting).rejects.toThrow("another runner");
+      expect(await readCodexAppServerBinding(fixture.sessionFile)).toEqual(before);
+      expect(fixture.client.getCloseError()).toBeUndefined();
+      expect(
+        fixture
+          .wire!.writes.map((message) => (JSON.parse(message) as RpcRequest).method)
+          .filter((method) => method === "thread/resume"),
+      ).toEqual(["thread/resume"]);
+    } finally {
+      abort.abort();
+      releaseFence();
+      await settled;
+      fixture.close();
+    }
+  });
 
   it("rejects a pending binding deleted while waiting for the native owner queue", async () => {
     const fixture = await createManualResumeFixture();

--- a/extensions/codex/src/app-server/thread-resume.ts
+++ b/extensions/codex/src/app-server/thread-resume.ts
@@ -19,6 +19,7 @@ export async function resumeCodexAppServerThread(params: {
   request: CodexThreadResumeParams;
   timeoutMs?: number;
   signal?: AbortSignal;
+  assertCurrent?: () => void;
 }): Promise<CodexThreadResumeResponse> {
   const threadId = params.request.threadId;
   let response: CodexThreadResumeResponse;
@@ -27,10 +28,12 @@ export async function resumeCodexAppServerThread(params: {
       await params.client.request("thread/resume", params.request, {
         ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
         ...(params.signal ? { signal: params.signal } : {}),
+        assertCurrent: params.assertCurrent,
       }),
     );
     assertCodexThreadResumeSubscription(threadId, response.thread.id);
   } catch (error) {
+    params.assertCurrent?.();
     if (
       isCodexAppServerStartSelectionChangedError(error) ||
       isCodexAppServerPrewriteRequestCancellationError(error)


### PR DESCRIPTION
Related: #128366

## What Problem This Solves

Fixes an issue where users continuing a manually attached Codex thread could receive an ownership conflict after OpenClaw had already sent the native resume request. A sibling runner acquiring and releasing the shared client while the request waited for native configuration made the earlier ownership check stale.

## Why This Change Was Made

The physical JSON-RPC writer now revalidates the caller's exact ownership immediately before each write, including overload retries. Resume and unsubscribe carry the existing lease assertion to that boundary. Cleanup also revalidates ownership before retiring a client.

A confirmed overload rejection clears the previous attempt's write uncertainty, so a subsequently revoked request does not close a healthy shared app-server. Indeterminate requests that actually reached Codex still retain the configuration fence until process exit. The redundant request forwarding method was removed; no public config, persistence schema, dependency version, or native protocol changes.

## User Impact

Conflicting resumptions stop before a stale native write. Existing bindings and native history remain intact, and unrelated sessions retain their healthy shared client.

## Evidence

- On main `8dac217ce94e`, the transport-backed manual-adoption regression failed with two `thread/resume` frames instead of one after a sibling lease acquire/release behind the configuration fence.
- A second regression exposed incorrect shared-client closure after an overload rejection followed by ownership loss. Both cases are covered at the real JSON-RPC transport boundary, using the existing test fixtures.
- All 318 lifecycle/transport tests pass across seven existing suites; focused lint reports zero warnings/errors and formatting passes. The initial broader run caught one stale mock argument assertion, which now includes the ownership callback. Full rebuild passes. Authenticated Gateway validation with pinned Codex 0.149.1 passes (1 test passed, 1 optional test skipped; 424.13s). The run covers reset, a competing attachment, session deletion, sibling continuation, and reattachment of the preserved native history. The same scenario against published Codex 0.150.1 also passes (1 passed, 1 optional skipped; 310.38s), with `competingResumeRejected`, `removedBinding`, `siblingContinued`, and `nativeHistoryResumed` all true.
- Live environment: disposable Linux `local-container` lease `cbx_6c25200b3b1f`, no host Docker socket or operator state. `pnpm test:live:codex-harness`, API-key auth, `openai/gpt-5.6-luna`, low reasoning. Pinned run `run_56982980d514` and latest run `run_e2c8f31271df` passed; this local backend has no public run URL.
- Direct dependency inspection: upstream Codex was pulled to `5af6979986a23fcd6bbeb1ef7b206cbc96e9a0a2`, with pinned `rust-v0.149.1` checked separately. `codex-rs/app-server-transport/src/transport/mod.rs:229-255` proves overload rejection occurs before enqueue; `request_processors/thread_processor.rs:1011-1037` proves unsubscribe removes only the current connection; `:4140-4183` confirms loaded resumes can ignore overrides. No dependency upgrade is included.
- Production delta: +6 net lines after removing the forwarding wrapper; tests/support: +120 net lines. The added production surface carries the existing ownership invariant to the only boundary that can prevent a stale native write.

- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33040604255) passed for `162d9ad297f39c88c424ed47da956fff5f201d0d`: 78 jobs passed, 20 skipped, no failures. Fresh Codex autoreview reported no actionable P0 findings, and independent source review found no additional defect.

Final [CI run](https://github.com/openclaw/openclaw/actions/runs/33042085025) passed on `ac0ac13326a336c8c4a4b8270843e862a577bd94`. The runtime and test patch is byte-for-byte identical to live-tested `162d9ad297f39c88c424ed47da956fff5f201d0d`.

Release-note context is retained above. The native landing gate requires normal PRs to leave the release-owned `CHANGELOG.md` unchanged; the final mechanical cleanup removes only that note, without changing runtime or tests.

### Follow-ups from the wider audit

These pre-existing paths are outside this focused transport repair:

- **Offline session cleanup owner loading:** the actual built `sessions cleanup --store ... --enforce --json` command exited successfully and removed an aged canonical session, but retained its valid Codex binding and occupied capacity slot. The local CLI composition root does not load harness deletion owners. Repair should select trusted owners from persisted sessions, not only the current configured model.
- **Cross-process parent-fork skip update:** a separate process committed new session label/name values after the fork owner read its snapshot; the activity-only skip patch then restored the old values. The parent-fork SQLite owner needs transaction-time snapshot validation. This path predates #128366.
- **Ordinary binding reconfiguration:** unlike pending adoption, a known binding can fingerprint changed developer instructions as applied after a successful native rejoin ignores overrides. Source-audit finding from the older #115089 flow; no injected native shutdown-failure proof yet.
- **Parent-owned Codex V2 children:** pinned and latest Codex reject direct turns when `canAcceptDirectInput` is explicitly false. Newer Codex also resumes these children through their parent, ignoring caller configuration. Interactive attachment should honor that explicit capability while retaining unknown/null values and cleanup ownership. Source-audit finding; no native-child live reproduction in this follow-up.
