### PR TITLE
refactor(github-copilot): reuse prepared embedding credentials

### DIFF
--- a/extensions/github-copilot/embeddings.transport.test.ts
+++ b/extensions/github-copilot/embeddings.transport.test.ts
@@ -34,16 +34,19 @@ const DISCOVERY_MODELS_BODY = JSON.stringify({
 
 async function startCopilotServer(handle: {
   models: { status: number; body: string } | ((response: ServerResponse) => void);
-  embeddings?: { status: number; body: string };
+  embeddings?: { status: number; body: string } | ((response: ServerResponse) => void);
+  observeRequest?: (request: IncomingMessage, body: string) => void;
 }): Promise<CopilotServer> {
   const requests: CopilotServer["requests"] = [];
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     void (async () => {
       // Drain the request body so keep-alive sockets close cleanly.
-      await new Promise<void>((resolve) => {
-        req.resume();
-        req.on("end", resolve);
+      const body = await new Promise<string>((resolve) => {
+        const chunks: Buffer[] = [];
+        req.on("data", (chunk: Buffer) => chunks.push(chunk));
+        req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
       });
+      handle.observeRequest?.(req, body);
       requests.push({ method: req.method, url: req.url });
       const isEmbeddings = req.method === "POST" && req.url === "/embeddings";
       const route = isEmbeddings && handle.embeddings ? handle.embeddings : handle.models;
@@ -241,25 +244,75 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter real transport", () => {
     }
   });
 
-  it("returns embedding vectors on a successful response over real transport", async () => {
-    const server = await startCopilotServer({
-      models: { status: 200, body: DISCOVERY_MODELS_BODY },
-      embeddings: {
-        status: 200,
-        body: JSON.stringify({ data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }] }),
-      },
-    });
-    pointTokenAt(server.baseUrl);
+  it.each(["profile", "custom"])(
+    "preserves %s authentication and embedding wire requests",
+    async (auth) => {
+      const observed: Array<{
+        authorization: string | undefined;
+        integration: unknown;
+        custom: unknown;
+        body: string;
+      }> = [];
+      const server = await startCopilotServer({
+        models: { status: 200, body: DISCOVERY_MODELS_BODY },
+        observeRequest: (request, body) => {
+          observed.push({
+            authorization: request.headers.authorization,
+            integration: request.headers["copilot-integration-id"],
+            custom: request.headers["x-proof"],
+            body,
+          });
+        },
+        embeddings: (response) => {
+          response.writeHead(200, { "content-type": "application/json" });
+          response.end(
+            JSON.stringify({
+              data:
+                server.requests.length === 2
+                  ? [{ index: 0, embedding: [3, 4] }]
+                  : [
+                      { index: 1, embedding: [0, 2] },
+                      { index: 0, embedding: [3, 0] },
+                    ],
+            }),
+          );
+        },
+      });
+      pointTokenAt(server.baseUrl);
 
-    const result = await githubCopilotMemoryEmbeddingProviderAdapter.create(defaultCreateOptions());
-    const vector = await result.provider?.embed("hello", { inputType: "query" });
+      const result = await githubCopilotMemoryEmbeddingProviderAdapter.create({
+        ...defaultCreateOptions(),
+        remote: {
+          ...(auth === "custom" ? { baseUrl: server.baseUrl, apiKey: "explicit-test-token" } : {}),
+          headers: { Authorization: "replaced-test-token", "X-Proof": "forwarded" },
+        },
+      });
+      expect(await result.provider?.embed("hello", { inputType: "query" })).toEqual([0.6, 0.8]);
+      expect(await result.provider?.embedBatch(["first", { text: "second" }])).toEqual([
+        [1, 0],
+        [0, 1],
+      ]);
 
-    expect(server.requests).toEqual([
-      { method: "GET", url: "/models" },
-      { method: "POST", url: "/embeddings" },
-    ]);
-    expect(Array.isArray(vector)).toBe(true);
-    expect(vector).toHaveLength(3);
-    expect(vector?.every((value) => typeof value === "number")).toBe(true);
-  });
+      expect(server.requests).toEqual([
+        { method: "GET", url: "/models" },
+        { method: "POST", url: "/embeddings" },
+        { method: "POST", url: "/embeddings" },
+      ]);
+      const authorization = `Bearer ${auth === "custom" ? "explicit-test-token" : "copilot_test_token_abc"}`;
+      expect(observed).toEqual(
+        [
+          "",
+          JSON.stringify({ model: "text-embedding-3-small", input: ["hello"] }),
+          JSON.stringify({ model: "text-embedding-3-small", input: ["first", "second"] }),
+        ].map((body) => ({
+          authorization,
+          integration: "copilot-developer-cli",
+          custom: "forwarded",
+          body,
+        })),
+      );
+      expect(resolveFirstGithubTokenMock).toHaveBeenCalledTimes(auth === "custom" ? 0 : 1);
+      expect(resolveCopilotRuntimeAuthMock).toHaveBeenCalledTimes(auth === "custom" ? 0 : 1);
+    },
+  );
 });

--- a/extensions/github-copilot/embeddings.ts
+++ b/extensions/github-copilot/embeddings.ts
@@ -58,14 +58,10 @@ type CopilotModelEntry = {
 };
 
 type GitHubCopilotEmbeddingClient = {
-  githubToken: string;
   model: string;
-  runtimeAuth?: { apiKey: string; baseUrl: string };
-  baseUrl?: string;
-  headers?: Record<string, string>;
-  env?: NodeJS.ProcessEnv;
-  fetchImpl?: typeof fetch;
-  githubDomain?: string;
+  baseUrl: string;
+  headers: Record<string, string>;
+  fetchImpl: typeof fetch;
 };
 
 function isCopilotSetupError(err: unknown): boolean {
@@ -221,48 +217,23 @@ function parseGitHubCopilotEmbeddingPayload(payload: unknown, expectedCount: num
   return vectors as number[][];
 }
 
-async function resolveGitHubCopilotEmbeddingSession(client: GitHubCopilotEmbeddingClient): Promise<{
-  baseUrl: string;
-  headers: Record<string, string>;
-}> {
-  const auth =
-    client.runtimeAuth ??
-    (await resolveCopilotRuntimeAuth({
-      githubToken: client.githubToken,
-      env: client.env,
-      fetchImpl: client.fetchImpl,
-      githubDomain: client.githubDomain,
-    }));
-  const baseUrl = client.baseUrl?.trim() || auth.baseUrl || DEFAULT_COPILOT_API_BASE_URL;
-  return {
-    baseUrl,
-    headers: {
-      ...COPILOT_HEADERS_STATIC,
-      ...client.headers,
-      Authorization: `Bearer ${auth.apiKey}`,
-    },
-  };
-}
-
-async function createGitHubCopilotEmbeddingProvider(
+function createGitHubCopilotEmbeddingProvider(
   client: GitHubCopilotEmbeddingClient,
-): Promise<{ provider: MemoryEmbeddingProvider; client: GitHubCopilotEmbeddingClient }> {
-  const initialSession = await resolveGitHubCopilotEmbeddingSession(client);
-
+): MemoryEmbeddingProvider {
   const embedMany = async (input: string[], signal?: AbortSignal): Promise<number[][]> => {
     if (input.length === 0) {
       return [];
     }
 
-    const url = `${initialSession.baseUrl.replace(/\/$/, "")}/embeddings`;
+    const url = `${client.baseUrl.replace(/\/$/, "")}/embeddings`;
     return await withRemoteHttpResponse({
       url,
       fetchImpl: client.fetchImpl,
-      ssrfPolicy: buildRemoteBaseUrlPolicy(initialSession.baseUrl),
+      ssrfPolicy: buildRemoteBaseUrlPolicy(client.baseUrl),
       signal,
       init: {
         method: "POST",
-        headers: initialSession.headers,
+        headers: client.headers,
         body: JSON.stringify({ model: client.model, input }),
       },
       onResponse: async (response) => {
@@ -282,29 +253,23 @@ async function createGitHubCopilotEmbeddingProvider(
   };
 
   return {
-    provider: {
-      id: COPILOT_EMBEDDING_PROVIDER_ID,
-      model: client.model,
-      embed: async (input, options) => {
-        const [vector] = await embedMany(
-          [typeof input === "string" ? input : input.text],
-          options?.signal,
-        );
-        return vector ?? [];
-      },
-      embedBatch: async (inputs, options) => {
-        const texts = inputs.map((input) => (typeof input === "string" ? input : input.text));
-        if (options?.inputType === "query") {
-          return await Promise.all(
-            texts.map(async (text) => (await embedMany([text], options.signal))[0] ?? []),
-          );
-        }
-        return await embedMany(texts, options?.signal);
-      },
+    id: COPILOT_EMBEDDING_PROVIDER_ID,
+    model: client.model,
+    embed: async (input, options) => {
+      const [vector] = await embedMany(
+        [typeof input === "string" ? input : input.text],
+        options?.signal,
+      );
+      return vector ?? [];
     },
-    client: {
-      ...client,
-      baseUrl: initialSession.baseUrl,
+    embedBatch: async (inputs, options) => {
+      const texts = inputs.map((input) => (typeof input === "string" ? input : input.text));
+      if (options?.inputType === "query") {
+        return await Promise.all(
+          texts.map(async (text) => (await embedMany([text], options.signal))[0] ?? []),
+        );
+      }
+      return await embedMany(texts, options?.signal);
     },
   };
 }
@@ -375,14 +340,14 @@ export const githubCopilotMemoryEmbeddingProviderAdapter: MemoryEmbeddingProvide
     const userModel = options.model?.trim() || undefined;
     const model = pickBestModel(availableModels, userModel);
 
-    const { provider } = await createGitHubCopilotEmbeddingProvider({
+    const provider = createGitHubCopilotEmbeddingProvider({
       baseUrl,
-      env: process.env,
       fetchImpl: fetch,
-      githubToken: value,
-      runtimeAuth,
-      githubDomain,
-      headers: options.remote?.headers,
+      headers: {
+        ...COPILOT_HEADERS_STATIC,
+        ...options.remote?.headers,
+        Authorization: `Bearer ${runtimeAuth.apiKey}`,
+      },
       model,
     });
 


### PR DESCRIPTION
## What Problem This Solves

Copilot embedding setup already resolves authentication before discovering models, but its private provider factory still carries an unreachable authentication fallback and returns an unused client. That duplicate path obscures which layer owns credential preparation.

## Why This Change Was Made

Make the private factory consume the prepared base URL, headers, model, and fetch implementation, and return the embedding provider directly. Headers and fetch are still captured after discovery, with the same static → remote → bearer-header precedence.

The existing 10-second discovery deadline, authentication selection, per-query request fanout, document batching, vector validation, error handling, redaction, cancellation, and guarded-transport cleanup are unchanged. No configuration, public SDK, or persistence changes.

## User Impact

No intended user-visible behavior change. This removes an obsolete internal path while preserving Copilot memory-search behavior.

Production: +30/−65 lines, net **−35**. Tests: +76/−23 lines, net **+53**.

## Evidence

Reviewed commit and CI head: `1656cf67a30df7ba146e83341145a82bf159d7ac`.

- Before and after the cleanup: **29 tests passed** across `extensions/github-copilot/embeddings.test.ts` and `extensions/github-copilot/embeddings.transport.test.ts`, using `node scripts/run-vitest.mjs` with one worker. These include real-socket discovery deadlines, credential redaction, and stored-profile/custom-endpoint request characterization. The characterization verifies bearer-header precedence, exact query/document request bodies, vector reordering, and normalization.
- Before and after: the real provider adapter authenticated with an existing credential, performed one account lookup and one model discovery, then embedded a query and a two-text document batch. All four HTTP requests returned **200**; all three vectors had **1,536 finite dimensions** and unit norm. The existing read-only auth-store mode was used; no new credentials or auth migrations were created.
- Formatting and `git diff --check` passed. Independent source/proof review and Codex autoreview through **P2** found no actionable issues.
- Local type-aware lint is **not green**: the identical command fails on untouched baseline `3255882803c78de5103d2d37f7698add84f34c5d` and this patch at the unchanged `SsrFPolicy` annotation. These isolated worktrees lack the generated SDK declaration selected by the plugin package-boundary configuration. No rule or annotation was weakened. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33040818916) passed lint, production types, test types, and all tests with the generated declarations available.
- The first hosted build failed its unrelated UI startup gzip budget: 343,445 bytes against a 343,442-byte limit. One rerun of the failed jobs, with the same source and budget, passed at 343,404 bytes. The 41-byte output variation is observed; its precise cause is not established. **CI attempt 2 and its aggregate gate passed** on the exact reviewed head. No further retry or budget change was made.
