### PR TITLE
refactor: simplify channel config adapters

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3929,7 +3929,6 @@ ui/src/app/browser.ts	1
 ui/src/app/canvas-surface-lease.runtime.ts	3
 ui/src/app/config.ts	1
 ui/src/app/custom-theme.ts	2
-ui/src/app/gateway-store.ts	1
 ui/src/app/native-bridge.ts	3
 ui/src/app/native-gateways.runtime.ts	4
 ui/src/app/native-link-routing.ts	3
@@ -4059,7 +4058,6 @@ ui/src/lib/session-pull-requests.ts	2
 ui/src/lib/sessions/custom-groups.ts	5
 ui/src/lib/sessions/grouping.ts	4
 ui/src/lib/sessions/index.ts	1
-ui/src/lib/sessions/navigation.ts	1
 ui/src/lib/sessions/reconcile.ts	10
 ui/src/lib/sessions/session-key.ts	4
 ui/src/lib/sessions/swarm-activity.ts	1

--- a/extensions/tlon/src/core.test.ts
+++ b/extensions/tlon/src/core.test.ts
@@ -8,36 +8,17 @@ import {
 import type { WizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../api.js";
+import { tlonPlugin } from "./channel.js";
 import { tlonChannelConfigSchema } from "./config-schema.js";
 import { tlonSetupWizard } from "./setup-surface.js";
-import { normalizeShip, resolveTlonOutboundTarget } from "./targets.js";
+import { resolveTlonOutboundTarget } from "./targets.js";
 import { listTlonAccountIds, resolveTlonAccount } from "./types.js";
 
 const tlonTestPlugin = {
   id: "tlon",
   meta: { label: "Tlon" },
   setupWizard: tlonSetupWizard,
-  config: {
-    listAccountIds: listTlonAccountIds,
-    defaultAccountId: () => "default",
-    resolveAllowFrom: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId?: string | null }) =>
-      resolveTlonAccount(cfg, accountId).dmAllowlist,
-    formatAllowFrom: ({
-      allowFrom,
-    }: {
-      cfg: OpenClawConfig;
-      allowFrom: Array<string | number> | undefined | null;
-    }) => {
-      const entries: string[] = [];
-      for (const entry of allowFrom ?? []) {
-        const normalized = normalizeShip(String(entry));
-        if (normalized) {
-          entries.push(normalized);
-        }
-      }
-      return entries;
-    },
-  },
+  config: tlonPlugin.config,
   setup: {
     resolveAccountId: ({ accountId }: { cfg: OpenClawConfig; accountId?: string | null }) =>
       accountId ?? "default",

--- a/src/plugin-sdk/allowlist-config-edit.test.ts
+++ b/src/plugin-sdk/allowlist-config-edit.test.ts
@@ -210,26 +210,37 @@ describe("buildDmGroupAccountAllowlistAdapter", () => {
     });
   });
 
-  it("materializes inherited entries before adding a named-account override", async () => {
-    const parsedConfig: Record<string, unknown> = {
-      channels: { demo: { allowFrom: ["dm-owner"], accounts: { alt: {} } } },
-    };
+  it.each([
+    { name: "inherited", account: {}, expected: ["dm-owner", "dm-admin"] },
+    { name: "explicit empty", account: { allowFrom: [] }, expected: ["dm-admin"] },
+    {
+      name: "stored mixed entries",
+      account: { allowFrom: [" Owner ", 42, "", "Owner", "owner", "  ", 42] },
+      expected: ["Owner", "42", "owner", "dm-admin"],
+    },
+  ])(
+    "preserves $name entries when adding a named-account override",
+    async ({ account, expected }) => {
+      const parsedConfig: Record<string, unknown> = {
+        channels: { demo: { allowFrom: ["dm-owner"], accounts: { alt: account } } },
+      };
 
-    await adapter.applyConfigEdit?.({
-      cfg: parsedConfig as OpenClawConfig,
-      parsedConfig,
-      accountId: "alt",
-      scope: "dm",
-      action: "add",
-      entry: "dm-admin",
-    });
+      await adapter.applyConfigEdit?.({
+        cfg: parsedConfig as OpenClawConfig,
+        parsedConfig,
+        accountId: "alt",
+        scope: "dm",
+        action: "add",
+        entry: "dm-admin",
+      });
 
-    expect(parsedConfig).toMatchObject({
-      channels: {
-        demo: { accounts: { alt: { allowFrom: ["dm-owner", "dm-admin"] } } },
-      },
-    });
-  });
+      expect(parsedConfig).toMatchObject({
+        channels: {
+          demo: { accounts: { alt: { allowFrom: expected } } },
+        },
+      });
+    },
+  );
 
   it("writes an empty named-account override when removing the last inherited entry", async () => {
     const parsedConfig: Record<string, unknown> = {
@@ -322,21 +333,26 @@ describe("buildLegacyDmAccountAllowlistAdapter", () => {
     });
   });
 
-  it("writes dm allowlist entries and keeps legacy cleanup behavior", () => {
-    expect(
-      adapter.applyConfigEdit?.({
-        cfg: {},
-        parsedConfig: {
-          channels: {
-            demo: {
-              accounts: {
-                alt: {
-                  dm: { allowFrom: ["owner"] },
-                },
-              },
+  it.each([
+    { stored: undefined, expected: ["Owner", "owner", "42", "member", "admin"] },
+    { stored: [" Owner ", 42], expected: ["Owner", "42", "owner", "member", "admin"] },
+  ])("merges legacy entries with $stored and cleans up the old path", ({ stored, expected }) => {
+    const parsedConfig = {
+      channels: {
+        demo: {
+          accounts: {
+            alt: {
+              allowFrom: stored,
+              dm: { allowFrom: ["Owner", "owner", "", 42, " member "] },
             },
           },
         },
+      },
+    };
+    expect(
+      adapter.applyConfigEdit?.({
+        cfg: {},
+        parsedConfig,
         accountId: "alt",
         scope: "dm",
         action: "add",
@@ -350,6 +366,10 @@ describe("buildLegacyDmAccountAllowlistAdapter", () => {
         kind: "account",
         scope: { channelId: "demo", accountId: "alt" },
       },
+    });
+    expect(parsedConfig.channels.demo.accounts.alt).toEqual({
+      allowFrom: expected,
+      dm: {},
     });
   });
 });

--- a/src/plugin-sdk/allowlist-config-edit.ts
+++ b/src/plugin-sdk/allowlist-config-edit.ts
@@ -1,4 +1,5 @@
 // Allowlist config edit helpers build safe config mutations for channel allowlists.
+import { normalizeUniqueStringEntries } from "@openclaw/normalization-core/string-normalization";
 import type { ConfigWriteTarget } from "../channels/plugins/config-writes.js";
 import type { ChannelAllowlistAdapter } from "../channels/plugins/types.adapters.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
@@ -278,7 +279,7 @@ function applyAccountScopedAllowlistConfigEdit(params: {
     params.channelId,
     params.accountId,
   );
-  const existing: string[] = [];
+  const storedEntries: unknown[] = [];
   let hasStoredList = false;
   for (const path of params.paths.readPaths) {
     const existingRaw = getNestedValue(resolvedTarget.target, path);
@@ -287,24 +288,14 @@ function applyAccountScopedAllowlistConfigEdit(params: {
     }
     hasStoredList = true;
     for (const entry of existingRaw) {
-      const value = String(entry).trim();
-      if (!value || existing.includes(value)) {
-        continue;
-      }
-      existing.push(value);
+      storedEntries.push(entry);
     }
   }
   // A new account override starts from its effective inherited list; otherwise the
   // first scoped edit would silently discard every channel-level entry.
-  if (!hasStoredList) {
-    for (const entry of params.resolveEffectiveEntries?.() ?? []) {
-      const value = String(entry).trim();
-      if (!value || existing.includes(value)) {
-        continue;
-      }
-      existing.push(value);
-    }
-  }
+  const existing = normalizeUniqueStringEntries(
+    hasStoredList ? storedEntries : (params.resolveEffectiveEntries?.() ?? []),
+  );
 
   const normalizedEntry = params.normalize([params.entry]);
   if (normalizedEntry.length === 0) {

--- a/src/plugin-sdk/channel-config-helpers.ts
+++ b/src/plugin-sdk/channel-config-helpers.ts
@@ -231,46 +231,6 @@ function createNamedAccountConfigBase<
   };
 }
 
-function resolveAccessorAccountWithFallback<
-  AccessorAccount,
-  Config extends OpenClawConfig = OpenClawConfig,
->(
-  resolveAccessorAccount:
-    | ((params: ChannelConfigAccessorParams<Config>) => AccessorAccount)
-    | undefined,
-  fallbackResolveAccessorAccount: (params: ChannelConfigAccessorParams<Config>) => AccessorAccount,
-): (params: ChannelConfigAccessorParams<Config>) => AccessorAccount {
-  // Read-only accessors can use a lighter account projection than runtime setup;
-  // fall back to the runtime resolver only when the channel has no projection hook.
-  return resolveAccessorAccount ?? fallbackResolveAccessorAccount;
-}
-
-function createChannelConfigAdapterWithAccessors<
-  ResolvedAccount,
-  AccessorAccount,
-  Config extends OpenClawConfig = OpenClawConfig,
->(params: {
-  base: ChannelCrudConfigAdapter<ResolvedAccount>;
-  resolveAccessorAccount?: (params: ChannelConfigAccessorParams<Config>) => AccessorAccount;
-  fallbackResolveAccessorAccount: (params: ChannelConfigAccessorParams<Config>) => AccessorAccount;
-  resolveAllowFrom: (account: AccessorAccount) => Array<string | number> | null | undefined;
-  formatAllowFrom: (allowFrom: Array<string | number>) => string[];
-  resolveDefaultTo?: (account: AccessorAccount) => string | number | null | undefined;
-}): ChannelConfigAdapterWithAccessors<ResolvedAccount> {
-  return {
-    ...params.base,
-    ...createScopedAccountConfigAccessors<AccessorAccount, Config>({
-      resolveAccount: resolveAccessorAccountWithFallback(
-        params.resolveAccessorAccount,
-        params.fallbackResolveAccessorAccount,
-      ),
-      resolveAllowFrom: params.resolveAllowFrom,
-      formatAllowFrom: params.formatAllowFrom,
-      resolveDefaultTo: params.resolveDefaultTo,
-    }),
-  };
-}
-
 function createChannelConfigAdapterFromBase<
   ResolvedAccount,
   AccessorAccount,
@@ -283,14 +243,16 @@ function createChannelConfigAdapterFromBase<
   formatAllowFrom: (allowFrom: Array<string | number>) => string[];
   resolveDefaultTo?: (account: AccessorAccount) => string | number | null | undefined;
 }): ChannelConfigAdapterWithAccessors<ResolvedAccount> {
-  return createChannelConfigAdapterWithAccessors<ResolvedAccount, AccessorAccount, Config>({
-    base: params.base,
-    resolveAccessorAccount: params.resolveAccessorAccount,
-    fallbackResolveAccessorAccount: params.resolveAccountForAccessors,
-    resolveAllowFrom: params.resolveAllowFrom,
-    formatAllowFrom: params.formatAllowFrom,
-    resolveDefaultTo: params.resolveDefaultTo,
-  });
+  return {
+    ...params.base,
+    ...createScopedAccountConfigAccessors<AccessorAccount, Config>({
+      // Read-only accessors prefer a lighter projection over runtime account setup.
+      resolveAccount: params.resolveAccessorAccount ?? params.resolveAccountForAccessors,
+      resolveAllowFrom: params.resolveAllowFrom,
+      formatAllowFrom: params.formatAllowFrom,
+      resolveDefaultTo: params.resolveDefaultTo,
+    }),
+  };
 }
 
 /** Build the common CRUD/config helpers for channels that store multiple named accounts. */
@@ -536,20 +498,15 @@ export function createHybridChannelConfigBase<
       });
     },
     deleteAccount({ cfg, accountId }) {
-      if (normalizeAccountId(accountId) === DEFAULT_ACCOUNT_ID) {
-        if (params.preserveSectionOnDefaultDelete) {
-          // Some hybrid channels keep non-account config at the root, so deleting
-          // default account credentials must clear only account-owned fields.
-          return clearTopLevelChannelConfigFields({
-            cfg,
-            sectionKey: params.sectionKey,
-            clearBaseFields: params.clearBaseFields,
-          });
-        }
-        return deleteAccountFromConfigSectionInSection({
+      if (
+        normalizeAccountId(accountId) === DEFAULT_ACCOUNT_ID &&
+        params.preserveSectionOnDefaultDelete
+      ) {
+        // Some hybrid channels keep non-account config at the root, so deleting
+        // default account credentials must clear only account-owned fields.
+        return clearTopLevelChannelConfigFields({
           cfg,
           sectionKey: params.sectionKey,
-          accountId,
           clearBaseFields: params.clearBaseFields,
         });
       }

--- a/ui/src/app/gateway-store.ts
+++ b/ui/src/app/gateway-store.ts
@@ -21,6 +21,7 @@ import { bumpCanvasWidgetFrameConnectionGeneration } from "../lib/chat/canvas-wi
 import { formatUiError, formatUiExternalText } from "../lib/format-error.ts";
 import { setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
 import { resolveSessionKey } from "../lib/sessions/index.ts";
+import { readSessionDefaults } from "../lib/sessions/session-key.ts";
 import { generateUUID } from "../lib/uuid.ts";
 import { clearStoredChatSnapshots } from "../pages/chat/session-snapshot-invalidation.runtime.ts";
 import type {
@@ -440,7 +441,7 @@ export function createApplicationGateway(
         if (persistConnectionSettings) {
           settings = loadSettings();
         }
-        const sessionDefaults = readSessionDefaults(hello);
+        const sessionDefaults = readSessionDefaults({ hello });
         const sessionKey = resolveSessionKey(snapshot.sessionKey, hello);
         const lastActiveSessionKey = resolveSessionKey(settings.lastActiveSessionKey, hello);
         if (
@@ -669,17 +670,4 @@ function isSameOriginGateway(gatewayUrl: string): boolean {
 function normalizeCanvasPluginSurfaceUrl(value: string | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
-}
-
-export function readSessionDefaults(
-  hello: GatewayHelloOk,
-): { defaultAgentId?: string | null; modelConfigured?: boolean } | undefined {
-  const snapshot = hello.snapshot;
-  if (!snapshot || typeof snapshot !== "object" || !("sessionDefaults" in snapshot)) {
-    return undefined;
-  }
-  const defaults = snapshot.sessionDefaults;
-  return defaults && typeof defaults === "object"
-    ? (defaults as { defaultAgentId?: string | null; modelConfigured?: boolean })
-    : undefined;
 }

--- a/ui/src/lib/sessions/navigation.ts
+++ b/ui/src/lib/sessions/navigation.ts
@@ -15,6 +15,7 @@ import {
   normalizeAgentId,
   normalizeSessionKeyForUiComparison,
   parseAgentSessionKey,
+  readSessionDefaults,
   resolveUiConfiguredMainKey,
   resolveUiDefaultAgentId,
   resolveUiGlobalAliasAgentId,
@@ -62,23 +63,6 @@ export type SessionScopeHostWithKey = SessionScopeHost & {
 };
 
 export type SessionRefreshTarget = { sessionKey: string; agentId?: string };
-
-type SessionDefaults = {
-  defaultAgentId?: string | null;
-  mainKey?: string | null;
-  mainSessionKey?: string | null;
-};
-
-function readSessionDefaults(
-  host: Pick<SessionNavigationInput, "hello">,
-): SessionDefaults | undefined {
-  const snapshot = host.hello?.snapshot;
-  if (!snapshot || typeof snapshot !== "object" || !("sessionDefaults" in snapshot)) {
-    return undefined;
-  }
-  const defaults = snapshot.sessionDefaults;
-  return defaults && typeof defaults === "object" ? (defaults as SessionDefaults) : undefined;
-}
 
 export function resolveSessionKey(
   sessionKey: string | undefined | null,

--- a/ui/src/lib/sessions/session-key.ts
+++ b/ui/src/lib/sessions/session-key.ts
@@ -24,6 +24,7 @@ type UiSessionDefaults = {
   defaultAgentId?: string | null;
   mainKey?: string | null;
   mainSessionKey?: string | null;
+  modelConfigured?: boolean;
 };
 
 export { normalizeAgentId };
@@ -107,7 +108,7 @@ export function normalizeSessionKeyForUiComparison(sessionKey: string | undefine
   return parts.join(":");
 }
 
-function readSessionDefaults(
+export function readSessionDefaults(
   host: Pick<UiSessionDefaultsHost, "hello">,
 ): UiSessionDefaults | undefined {
   const snapshot = host.hello?.snapshot;

--- a/ui/src/pages/model-setup/first-run.ts
+++ b/ui/src/pages/model-setup/first-run.ts
@@ -1,8 +1,8 @@
 import type { RouteLocation, RouterHistory } from "@openclaw/uirouter";
 import { sameRouteLocation, type RouteId } from "../../app-routes.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import { readSessionDefaults } from "../../app/gateway-store.ts";
 import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
+import { readSessionDefaults } from "../../lib/sessions/session-key.ts";
 
 export function isDefaultChatLanding(
   location: RouteLocation,
@@ -67,7 +67,7 @@ export async function startModelSetupFirstRunRedirectAfterLocation(params: {
       }
       return;
     }
-    const defaults = snapshot.hello ? readSessionDefaults(snapshot.hello) : undefined;
+    const defaults = readSessionDefaults(snapshot);
     const selectedAgentId = context.agentSelection.state.selectedId?.trim() || null;
     if (
       canCallGatewayMethod(snapshot, "openclaw.setup.detect", "operator.admin") &&

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -10,13 +10,13 @@ import type {
 } from "../../api/types.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
-import { readSessionDefaults } from "../../app/gateway-store.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { renderDocsLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { resolveScrollBehavior } from "../../lib/scroll-behavior.ts";
+import { readSessionDefaults } from "../../lib/sessions/session-key.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import type { ModelSetupDetectionConnection } from "./detect-cache.ts";
@@ -669,9 +669,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         canAdmin &&
         !gatewayTooOld &&
         isGatewayMethodAdvertised(snapshot, "openclaw.setup.prepare.start") === true,
-      modelConfigured: snapshot.hello
-        ? readSessionDefaults(snapshot.hello)?.modelConfigured === true
-        : false,
+      modelConfigured: readSessionDefaults(snapshot)?.modelConfigured === true,
       gatewayTooOld,
       refreshWarning: this.setupRefreshWarning,
       actionsDisabled: this.actionsDisabled(),


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested duplication/LOC cleanup of the channel configuration SDK. Private adapter layers repeat the same callback wiring, and allowlist editing maintains two copies of string normalization already owned by normalization-core. Tlon's config tests also exercise a handwritten copy instead of its real adapter.

The first hosted build exposed a separate startup-budget failure: UI JavaScript measured 343,443 bytes against the unchanged 343,442-byte limit. A bounded nearby cleanup removes two duplicate session-default readers and routes the existing UI consumers through the session-key owner; the size budget and tolerance are not increased.

## Why This Change Was Made

Compose CRUD and read-only accessors in one existing private owner, preserving the lightweight accessor resolver's precedence and lazy invocation. Fold the identical hybrid-account deletion branches together and reuse `normalizeUniqueStringEntries` for stored/inherited entries. Keep stored-list presence separate from length so an explicit empty override never reactivates inherited entries.

The Tlon fixture now uses `tlonPlugin.config`; its declarative setup wizard and setup hooks remain unchanged. The historical test copy was an [import-speed optimization](https://github.com/openclaw/openclaw/commit/a96790fde7dced7d7f3b04c9344f19c101d7e8f2), but the current plugin keeps its runtime lazy. The adapter layering came from [an earlier deduplication pass](https://github.com/openclaw/openclaw/commit/bcd61f0a382d1693d14e9856c57fdcca4c2859f0); inherited/empty-list semantics were established in #106638 and remain intact.

The UI consolidation preserves the original object guards and returned object, default-agent resolution, navigation, and first-run model setup policy. It removes the app-layer reader rather than adding a compatibility export. Two obsolete assertion-safety baseline entries are removed as required by the shrink-only ratchet.

Production: **+26/-107 (net -81)**. Tests: **+53/-52 (net +1)**. Ratchet metadata: **-2**. Overall: **82 lines removed**, with additional meaningful cases and no new production test seams.

## User Impact

No intended behavior change. Public SDK exports/signatures, config keys/defaults, account normalization, credential-clearing behavior, and allowlist edit results remain unchanged. Numeric coercion, first-seen order, case preservation, legacy-path cleanup, and explicit-empty overrides are retained. No dependency, schema, migration, authorization, or transport changes.

## Evidence

- Baseline: 107 tests across the SDK, LINE, Microsoft Teams, and Tlon passed before production edits. Expanded allowlist characterization passed against the original production owner (56 focused tests).
- Final focused proof: **127 tests in 8 files across 4 shards passed**. Tlon's 17 core tests now include the real shared hybrid adapter instead of copied config logic.
- Command: `node scripts/run-vitest.mjs src/plugin-sdk/channel-config-helpers.test.ts src/plugin-sdk/allowlist-config-edit.test.ts src/channels/plugins/config-helpers.test.ts extensions/line/src/config-adapter.test.ts extensions/line/src/channel.allowlist.test.ts extensions/msteams/src/channel.test.ts extensions/tlon/src/channel.outbound.test.ts extensions/tlon/src/core.test.ts`.
- Formatting, targeted core type-aware lint, `git diff --check`, SDK export/surface checks, plugin boundaries, and all three dead-export scans pass. Configured Codex autoreview reported no actionable P0 findings; an independent full-source review found no blockers across owner/caller/sibling boundaries.
- UI baseline: 148 relevant tests passed before production edits. Final UI proof: **156 tests in six files passed**, covering navigation, session keys, Gateway lifecycle, first-run model setup, and the setup page.
- Combined final rerun with the matching dependency installation: **283 tests in 14 files across five routed shards passed**. The UI/ratchet changed-surface gate completed successfully, including core-test/UI typechecks, core/scripts lint, formatting, i18n verification, and all three dead-export scans.
- Full rebased-branch `check-changed --base 036e635c71c` also **passed**, including production/test types for core and plugins, UI types, core/plugin/scripts lint, declaration generation, import-cycle and owner-boundary guards. Hosted build independently passes startup size at **343,295 bytes** against the unchanged **343,442-byte** ceiling.
- Chromium mocked-Gateway proof: the existing sidebar/session navigation flow passed (`ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts`, `keeps every sidebar session stable`). This is browser behavior proof with a mocked Gateway, not authenticated channel traffic.
- UI build reproduces the startup-budget failure before the cleanup (343,461 bytes locally), then passes after it (**343,318 bytes**, limit **343,442**; eight startup requests; 770 precompressed sidecars verified). These are observed build totals, not exact code-only savings: build identity also affects compression. Hosted failure was [run 33040938230, build-artifacts](https://github.com/openclaw/openclaw/actions/runs/33040938230/job/98414345531), which built merge ref `268ac56e`.
- Rebased head `d997cf7dc09b2dd8bd3bbef169c5c340a64fcfd7` retains main's reduced-motion behavior; the only conflict was adjacent imports. Range-diff verified, all 156 UI tests pass again, and the rebuilt UI passes at **343,283 bytes** with the same ceiling. Exact-head CI: [33042127037](https://github.com/openclaw/openclaw/actions/runs/33042127037).
- Initial local type/build errors were reproduced unchanged on the clean baseline and traced to stale task-local dependency symlinks. Those links use an existing installation with the candidate's identical lockfile, including the correct UI dependency tree; no dependency files or manifests were modified. Exact-head CI completed successfully before native prepare/merge.
- Merged as [7930940c237a](https://github.com/openclaw/openclaw/commit/7930940c237a3ae8d51b9b5747e0ab679d676089). After pulling `main`, all **283 focused tests passed again**, the Chromium mocked-Gateway navigation test passed again, and the UI rebuild passed at **343,222 bytes**. Checkout is clean. This validates the affected owners, not the independently landed Codex package upgrade on main.

This is deterministic config-owner/consumer and mocked-Gateway browser proof, not a live authenticated channel test. No message delivery, external API, rendered layout, or visual behavior changes; no before/after visual change is claimed.

AI-assisted with Codex; manually inspected and verified.
