### PR TITLE
docs: route cloud sandbox providers to Crabbox

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -130,6 +130,7 @@ It is widely known, fast to iterate in, and easy to read, modify, and extend.
 - New core skills when they can live on [ClawHub](https://clawhub.ai/)
 - Full-doc translation sets for all docs (deferred; we plan AI-generated translations later)
 - Commercial service integrations that do not clearly fit the model-provider category
+- Cloud-based sandbox providers as OpenClaw plugins; implement provider support in [Crabbox](https://github.com/openclaw/crabbox) instead
 - Wrapper channels around already supported channels without a clear capability or security gap
 - MCP work that duplicates existing MCP, ACPX, plugin, or ClawHub paths without a clear product or security gap
 - Heavy orchestration layers that duplicate existing agent and tool infrastructure


### PR DESCRIPTION
## What Problem This Solves

The vision document recommends plugins for optional capabilities but does not state the ownership boundary for cloud-based sandbox providers. Contributors need to know that those implementations belong in Crabbox rather than new OpenClaw plugins.

## Why This Change Was Made

Adds one explicit entry to **What We Will Not Merge (For Now)** directing cloud-based sandbox provider support to [Crabbox](https://github.com/openclaw/crabbox). This records the maintainer-requested direction without changing runtime behavior or removing existing integrations.

## User Impact

Contributors have a clear implementation destination for cloud-based sandbox providers. No runtime, configuration, or compatibility changes.

## Evidence

- `pnpm docs:list` — passed.
- `git diff --check` — passed.
- `node_modules/.bin/oxfmt --check VISION.md` — passed.
- Manually reviewed the full vision document and verified that the linked Crabbox repository is public and active.
- Documentation only: `VISION.md` +1/-0; production and test LOC unchanged. Runtime tests and autoreview are not applicable to this one-line policy note.

AI-assisted; requested and reviewed by the maintainer.
