### PR TITLE
refactor(config): share TTS migration traversal

### DIFF
--- a/src/commands/doctor/shared/legacy-config-migrate.provider-shapes.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.provider-shapes.test.ts
@@ -23,6 +23,103 @@ function migrateLegacyConfig(raw: unknown): {
 }
 
 describe("legacy migrate provider-shaped config", () => {
+  const legacyTts = {
+    provider: "edge",
+    enabled: true,
+    providers: { custom: { voice: "legacy" } },
+  };
+  const voiceAndEnabledMigrations = ["tts.speaker-selection-keys", "tts.enabled-auto-mode"];
+
+  it.each<{ name: string; path: string; value: unknown; expected: string[] }>([
+    {
+      name: "root TTS",
+      path: "tts",
+      value: legacyTts,
+      expected: ["tts.providers-generic-shape", ...voiceAndEnabledMigrations],
+    },
+    {
+      name: "legacy agent list",
+      path: "agents",
+      value: { list: [{ tts: legacyTts }] },
+      expected: voiceAndEnabledMigrations,
+    },
+    {
+      name: "agent defaults and keyed entries",
+      path: "agents",
+      value: { defaults: { tts: legacyTts }, entries: { main: { tts: legacyTts } } },
+      expected: [],
+    },
+    {
+      name: "channel root",
+      path: "channels",
+      value: { slack: { tts: legacyTts } },
+      expected: voiceAndEnabledMigrations,
+    },
+    {
+      name: "channel accounts",
+      path: "channels",
+      value: { slack: { accounts: { work: { tts: legacyTts } } } },
+      expected: voiceAndEnabledMigrations,
+    },
+    {
+      name: "Discord root and account roots",
+      path: "channels",
+      value: { " Discord ": { tts: legacyTts, accounts: { work: { tts: legacyTts } } } },
+      expected: [],
+    },
+    {
+      name: "Discord voice",
+      path: "channels",
+      value: { discord: { voice: { tts: legacyTts } } },
+      expected: voiceAndEnabledMigrations,
+    },
+    {
+      name: "Discord account voice",
+      path: "channels",
+      value: {
+        discord: {
+          accounts: { work: { voice: { tts: legacyTts } } },
+        },
+      },
+      expected: voiceAndEnabledMigrations,
+    },
+    {
+      name: "blocked channel and account keys",
+      path: "channels",
+      value: {
+        constructor: { tts: legacyTts },
+        slack: { accounts: { prototype: { tts: legacyTts } } },
+      },
+      expected: [],
+    },
+    {
+      name: "voice-call plugin",
+      path: "plugins.entries",
+      value: { "voice-call": { config: { tts: legacyTts } } },
+      expected: ["tts.providers-generic-shape", ...voiceAndEnabledMigrations],
+    },
+    {
+      name: "other plugins",
+      path: "plugins.entries",
+      value: { custom: { config: { tts: legacyTts } } },
+      expected: [],
+    },
+    {
+      name: "malformed scopes",
+      path: "channels",
+      value: { slack: { tts: [], voice: false, accounts: { work: null } }, discord: 1 },
+      expected: [],
+    },
+  ])("previews only supported migrations for $name", ({ path, value, expected }) => {
+    const detected = LEGACY_CONFIG_MIGRATIONS_RUNTIME_TTS.filter((migration) =>
+      migration.legacyRules?.some(
+        (rule) => rule.path.join(".") === path && rule.match?.(value, {}),
+      ),
+    ).map((migration) => migration.id);
+
+    expect(detected).toEqual(expected);
+  });
+
   it("moves legacy realtime Talk selectors into talk.realtime without treating speech config as runtime fallback", () => {
     const changes: string[] = [];
     const migrated = normalizeLegacyTalkConfig(
@@ -189,6 +286,7 @@ describe("legacy migrate provider-shaped config", () => {
         },
       },
     });
+    expect(migrateLegacyConfig(res.config)).toEqual({ config: null, changes: [] });
   });
 
   it("routes legacy messages.tts.realtime voice to talk.realtime.speakerVoice", () => {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.tts.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.tts.ts
@@ -48,110 +48,27 @@ function hasLegacySpeakerSelectionKeys(value: unknown): boolean {
 }
 
 function hasLegacyTtsSpeakerSelection(value: unknown): boolean {
-  const tts = getRecord(value);
-  if (!tts) {
-    return false;
-  }
-  if (hasLegacyTtsSpeakerSelectionInProviderMap(tts.providers)) {
-    return true;
-  }
-  if (
-    LEGACY_TTS_PROVIDER_KEYS.some((providerId) => hasLegacySpeakerSelectionKeys(tts[providerId]))
-  ) {
-    return true;
-  }
-  return hasLegacyTtsSpeakerSelectionInPersonas(tts.personas);
-}
-
-function hasLegacyTtsSpeakerSelectionInProviderMap(value: unknown): boolean {
-  const providers = getRecord(value);
-  return Boolean(
-    providers &&
-    Object.entries(providers).some(
-      ([providerId, providerConfig]) =>
-        !isBlockedObjectKey(providerId) && hasLegacySpeakerSelectionKeys(providerConfig),
-    ),
-  );
-}
-
-function hasLegacyTtsSpeakerSelectionInPersonas(value: unknown): boolean {
-  const personas = getRecord(value);
-  if (!personas) {
-    return false;
-  }
-  return Object.entries(personas).some(([personaId, personaValue]) => {
-    if (isBlockedObjectKey(personaId)) {
-      return false;
-    }
-    const persona = getRecord(personaValue);
-    if (!persona) {
-      return false;
-    }
-    if (hasLegacyTtsSpeakerSelectionInProviderMap(persona.providers)) {
+  for (const [config] of visitLegacyTtsSpeakerConfigs(value, "")) {
+    if (hasLegacySpeakerSelectionKeys(config)) {
       return true;
-    }
-    return LEGACY_TTS_PROVIDER_KEYS.some((providerId) =>
-      hasLegacySpeakerSelectionKeys(persona[providerId]),
-    );
-  });
-}
-
-type LegacyTtsMatcher = (value: unknown) => boolean;
-
-function hasLegacyTtsInAgentLocations(value: unknown, matcher: LegacyTtsMatcher): boolean {
-  const agents = getRecord(value);
-  const agentList = Array.isArray(agents?.list) ? agents.list : [];
-  return agentList.some((entry) => matcher(getRecord(getRecord(entry)?.tts)));
-}
-
-function supportsChannelRootTtsMigration(channelId: string): boolean {
-  return !CHANNEL_ROOT_TTS_UNSUPPORTED_IDS.has(channelId.trim().toLowerCase());
-}
-
-function hasLegacyTtsInChannelLocations(value: unknown, matcher: LegacyTtsMatcher): boolean {
-  const channels = getRecord(value);
-  for (const [channelId, channelValue] of Object.entries(channels ?? {})) {
-    if (isBlockedObjectKey(channelId)) {
-      continue;
-    }
-    const channel = getRecord(channelValue);
-    const migrateRootTts = supportsChannelRootTtsMigration(channelId);
-    if (migrateRootTts && matcher(getRecord(channel?.tts))) {
-      return true;
-    }
-    if (matcher(getRecord(getRecord(channel?.voice)?.tts))) {
-      return true;
-    }
-    const accounts = getRecord(channel?.accounts);
-    for (const [accountId, accountValue] of Object.entries(accounts ?? {})) {
-      if (isBlockedObjectKey(accountId)) {
-        continue;
-      }
-      const account = getRecord(accountValue);
-      if (
-        (migrateRootTts && matcher(getRecord(account?.tts))) ||
-        matcher(getRecord(getRecord(account?.voice)?.tts))
-      ) {
-        return true;
-      }
     }
   }
   return false;
 }
 
-function hasLegacyTtsInPluginLocations(value: unknown, matcher: LegacyTtsMatcher): boolean {
-  const entries = getRecord(value);
-  if (!entries) {
-    return false;
-  }
-  return Object.entries(entries).some(([pluginId, entryValue]) => {
-    if (isBlockedObjectKey(pluginId) || !LEGACY_TTS_PLUGIN_IDS.has(pluginId)) {
-      return false;
+type LegacyTtsMatcher = (value: unknown) => boolean;
+
+function hasLegacyTtsInLocations(raw: Record<string, unknown>, matcher: LegacyTtsMatcher): boolean {
+  for (const [tts] of visitKnownTtsConfigLocations(raw)) {
+    if (matcher(tts)) {
+      return true;
     }
-    const entry = getRecord(entryValue);
-    const config = getRecord(entry?.config);
-    return matcher(getRecord(config?.tts));
-  });
+  }
+  return false;
+}
+
+function supportsChannelRootTtsMigration(channelId: string): boolean {
+  return !CHANNEL_ROOT_TTS_UNSUPPORTED_IDS.has(channelId.trim().toLowerCase());
 }
 
 function getOrCreateTtsProviders(tts: Record<string, unknown>): Record<string, unknown> {
@@ -256,78 +173,57 @@ function migrateLegacyTtsSpeakerSelection(
   pathLabel: string,
   changes: string[],
 ): void {
-  if (!tts) {
-    return;
-  }
-  migrateLegacySpeakerSelectionProviderMap(tts.providers, `${pathLabel}.providers`, changes);
-  for (const providerId of LEGACY_TTS_PROVIDER_KEYS) {
-    const providerConfig = getRecord(tts[providerId]);
-    if (!providerConfig) {
-      continue;
-    }
-    migrateLegacySpeakerSelectionConfig(providerConfig, `${pathLabel}.${providerId}`, changes);
-  }
-  const personas = getRecord(tts.personas);
-  for (const [personaId, personaValue] of Object.entries(personas ?? {})) {
-    if (isBlockedObjectKey(personaId)) {
-      continue;
-    }
-    const persona = getRecord(personaValue);
-    if (!persona) {
-      continue;
-    }
-    migrateLegacySpeakerSelectionProviderMap(
-      persona.providers,
-      `${pathLabel}.personas.${personaId}.providers`,
-      changes,
-    );
-    for (const providerId of LEGACY_TTS_PROVIDER_KEYS) {
-      const providerConfig = getRecord(persona[providerId]);
-      if (!providerConfig) {
-        continue;
-      }
-      migrateLegacySpeakerSelectionConfig(
-        providerConfig,
-        `${pathLabel}.personas.${personaId}.${providerId}`,
-        changes,
-      );
-    }
+  for (const [config, path] of visitLegacyTtsSpeakerConfigs(tts, pathLabel)) {
+    migrateLegacySpeakerSelectionConfig(config, path, changes);
   }
 }
 
-function migrateLegacySpeakerSelectionProviderMap(
+function* visitLegacySpeakerSelectionScope(
   value: unknown,
   pathLabel: string,
-  changes: string[],
-): void {
-  const providers = getRecord(value);
-  if (!providers) {
+): Generator<[Record<string, unknown>, string]> {
+  const scope = getRecord(value);
+  if (!scope) {
     return;
   }
-  for (const [providerId, providerValue] of Object.entries(providers)) {
-    if (isBlockedObjectKey(providerId)) {
-      continue;
+  for (const [providerId, providerValue] of Object.entries(getRecord(scope.providers) ?? {})) {
+    const config = getRecord(providerValue);
+    if (!isBlockedObjectKey(providerId) && config) {
+      yield [config, `${pathLabel}.providers.${providerId}`];
     }
-    const providerConfig = getRecord(providerValue);
-    if (!providerConfig) {
-      continue;
+  }
+  for (const providerId of LEGACY_TTS_PROVIDER_KEYS) {
+    const config = getRecord(scope[providerId]);
+    if (config) {
+      yield [config, `${pathLabel}.${providerId}`];
     }
-    migrateLegacySpeakerSelectionConfig(providerConfig, `${pathLabel}.${providerId}`, changes);
   }
 }
 
-function visitKnownTtsConfigLocations(
+function* visitLegacyTtsSpeakerConfigs(
+  value: unknown,
+  pathLabel: string,
+): Generator<[Record<string, unknown>, string]> {
+  const tts = getRecord(value);
+  yield* visitLegacySpeakerSelectionScope(tts, pathLabel);
+  for (const [personaId, persona] of Object.entries(getRecord(tts?.personas) ?? {})) {
+    if (!isBlockedObjectKey(personaId)) {
+      yield* visitLegacySpeakerSelectionScope(persona, `${pathLabel}.personas.${personaId}`);
+    }
+  }
+}
+
+// Keep previews lazy while sharing the repair walk and its supported-path exclusions.
+function* visitKnownTtsConfigLocations(
   raw: Record<string, unknown>,
-  visit: (tts: Record<string, unknown> | null | undefined, pathLabel: string) => void,
-): void {
-  visit(getRecord(raw.tts), "tts");
+): Generator<[Record<string, unknown> | null, string]> {
+  yield [getRecord(raw.tts), "tts"];
 
   const agents = getRecord(raw.agents);
   const agentList = Array.isArray(agents?.list) ? agents.list : [];
-  agentList.forEach((entry, index) => {
-    const agent = getRecord(entry);
-    visit(getRecord(agent?.tts), `agents.list[${index}].tts`);
-  });
+  for (const [index, entry] of agentList.entries()) {
+    yield [getRecord(getRecord(entry)?.tts), `agents.list[${index}].tts`];
+  }
 
   const channels = getRecord(raw.channels);
   for (const [channelId, channelValue] of Object.entries(channels ?? {})) {
@@ -337,34 +233,32 @@ function visitKnownTtsConfigLocations(
     const channel = getRecord(channelValue);
     const migrateRootTts = supportsChannelRootTtsMigration(channelId);
     if (migrateRootTts) {
-      visit(getRecord(channel?.tts), `channels.${channelId}.tts`);
+      yield [getRecord(channel?.tts), `channels.${channelId}.tts`];
     }
-    visit(getRecord(getRecord(channel?.voice)?.tts), `channels.${channelId}.voice.tts`);
-    const accounts = getRecord(channel?.accounts);
-    for (const [accountId, accountValue] of Object.entries(accounts ?? {})) {
+    yield [getRecord(getRecord(channel?.voice)?.tts), `channels.${channelId}.voice.tts`];
+    for (const [accountId, accountValue] of Object.entries(getRecord(channel?.accounts) ?? {})) {
       if (isBlockedObjectKey(accountId)) {
         continue;
       }
       const account = getRecord(accountValue);
       if (migrateRootTts) {
-        visit(getRecord(account?.tts), `channels.${channelId}.accounts.${accountId}.tts`);
+        yield [getRecord(account?.tts), `channels.${channelId}.accounts.${accountId}.tts`];
       }
-      visit(
+      yield [
         getRecord(getRecord(account?.voice)?.tts),
         `channels.${channelId}.accounts.${accountId}.voice.tts`,
-      );
+      ];
     }
   }
 
-  const plugins = getRecord(raw.plugins);
-  const pluginEntries = getRecord(plugins?.entries);
+  const pluginEntries = getRecord(getRecord(raw.plugins)?.entries);
   for (const [pluginId, entryValue] of Object.entries(pluginEntries ?? {})) {
-    if (isBlockedObjectKey(pluginId) || !LEGACY_TTS_PLUGIN_IDS.has(pluginId)) {
-      continue;
+    if (!isBlockedObjectKey(pluginId) && LEGACY_TTS_PLUGIN_IDS.has(pluginId)) {
+      yield [
+        getRecord(getRecord(getRecord(entryValue)?.config)?.tts),
+        `plugins.entries.${pluginId}.config.tts`,
+      ];
     }
-    const entry = getRecord(entryValue);
-    const config = getRecord(entry?.config);
-    visit(getRecord(config?.tts), `plugins.entries.${pluginId}.config.tts`);
   }
 }
 
@@ -379,7 +273,8 @@ const LEGACY_TTS_PROVIDER_RULES: LegacyConfigRule[] = [
     path: ["plugins", "entries"],
     message:
       'plugins.entries.voice-call.config.tts legacy provider aliases/keys are legacy; use provider: "microsoft" and plugins.entries.voice-call.config.tts.providers.<provider>. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyTtsInPluginLocations(value, hasLegacyTtsProviderKeys),
+    match: (value) =>
+      hasLegacyTtsInLocations({ plugins: { entries: value } }, hasLegacyTtsProviderKeys),
   },
 ];
 
@@ -393,19 +288,19 @@ const LEGACY_TTS_ENABLED_RULES: LegacyConfigRule[] = [
     path: ["agents"],
     message:
       'agents.list[].tts.enabled is legacy; use agents.list[].tts.auto. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyTtsInAgentLocations(value, hasLegacyTtsEnabled),
+    match: (value) => hasLegacyTtsInLocations({ agents: value }, hasLegacyTtsEnabled),
   },
   {
     path: ["channels"],
     message:
       'supported channel TTS enabled fields are legacy; use the same TTS block auto field. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyTtsInChannelLocations(value, hasLegacyTtsEnabled),
+    match: (value) => hasLegacyTtsInLocations({ channels: value }, hasLegacyTtsEnabled),
   },
   {
     path: ["plugins", "entries"],
     message:
       'plugins.entries.voice-call.config.tts.enabled is legacy; use plugins.entries.voice-call.config.tts.auto. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyTtsInPluginLocations(value, hasLegacyTtsEnabled),
+    match: (value) => hasLegacyTtsInLocations({ plugins: { entries: value } }, hasLegacyTtsEnabled),
   },
 ];
 
@@ -420,19 +315,20 @@ const LEGACY_TTS_SPEAKER_SELECTION_RULES: LegacyConfigRule[] = [
     path: ["agents"],
     message:
       'agents.list[].tts speaker selection fields voice/voiceName/voiceId are legacy; use speakerVoice or speakerVoiceId. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyTtsInAgentLocations(value, hasLegacyTtsSpeakerSelection),
+    match: (value) => hasLegacyTtsInLocations({ agents: value }, hasLegacyTtsSpeakerSelection),
   },
   {
     path: ["channels"],
     message:
       'supported channel TTS speaker selection fields voice/voiceName/voiceId are legacy; use speakerVoice or speakerVoiceId. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyTtsInChannelLocations(value, hasLegacyTtsSpeakerSelection),
+    match: (value) => hasLegacyTtsInLocations({ channels: value }, hasLegacyTtsSpeakerSelection),
   },
   {
     path: ["plugins", "entries"],
     message:
       'plugins.entries.voice-call.config.tts speaker selection fields voice/voiceName/voiceId are legacy; use speakerVoice or speakerVoiceId. Run "openclaw doctor --fix".',
-    match: (value) => hasLegacyTtsInPluginLocations(value, hasLegacyTtsSpeakerSelection),
+    match: (value) =>
+      hasLegacyTtsInLocations({ plugins: { entries: value } }, hasLegacyTtsSpeakerSelection),
   },
 ];
 
@@ -487,24 +383,12 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_TTS: LegacyConfigMigrationSpec[] =
     describe: "Move legacy bundled TTS config keys into tts.providers",
     legacyRules: LEGACY_TTS_PROVIDER_RULES,
     apply: (raw, changes) => {
-      migrateLegacyTtsConfig(getRecord(raw.tts), "tts", changes);
-
-      const plugins = getRecord(raw.plugins);
-      const pluginEntries = getRecord(plugins?.entries);
-      if (!pluginEntries) {
-        return;
-      }
-      for (const [pluginId, entryValue] of Object.entries(pluginEntries)) {
-        if (isBlockedObjectKey(pluginId) || !LEGACY_TTS_PLUGIN_IDS.has(pluginId)) {
-          continue;
-        }
-        const entry = getRecord(entryValue);
-        const config = getRecord(entry?.config);
-        migrateLegacyTtsConfig(
-          getRecord(config?.tts),
-          `plugins.entries.${pluginId}.config.tts`,
-          changes,
-        );
+      // Provider aliases have a narrower migration scope than speaker keys and enabled.
+      for (const [tts, pathLabel] of visitKnownTtsConfigLocations({
+        tts: raw.tts,
+        plugins: raw.plugins,
+      })) {
+        migrateLegacyTtsConfig(tts, pathLabel, changes);
       }
     },
   }),
@@ -513,9 +397,9 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_TTS: LegacyConfigMigrationSpec[] =
     describe: "Move TTS speaker selection keys to speakerVoice/speakerVoiceId",
     legacyRules: LEGACY_TTS_SPEAKER_SELECTION_RULES,
     apply: (raw, changes) => {
-      visitKnownTtsConfigLocations(raw, (tts, pathLabel) =>
-        migrateLegacyTtsSpeakerSelection(tts, pathLabel, changes),
-      );
+      for (const [tts, pathLabel] of visitKnownTtsConfigLocations(raw)) {
+        migrateLegacyTtsSpeakerSelection(tts, pathLabel, changes);
+      }
     },
   }),
   defineLegacyConfigMigration({
@@ -523,9 +407,9 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_TTS: LegacyConfigMigrationSpec[] =
     describe: "Move legacy TTS enabled toggles to auto mode",
     legacyRules: LEGACY_TTS_ENABLED_RULES,
     apply: (raw, changes) => {
-      visitKnownTtsConfigLocations(raw, (tts, pathLabel) =>
-        migrateLegacyTtsEnabled(tts, pathLabel, changes),
-      );
+      for (const [tts, pathLabel] of visitKnownTtsConfigLocations(raw)) {
+        migrateLegacyTtsEnabled(tts, pathLabel, changes);
+      }
     },
   }),
 ];


### PR DESCRIPTION
Related: #130637 (separate migration-persistence follow-up; not fixed by this cleanup).

## What Problem This Solves

Doctor's TTS migration previews and repairs maintained separate copies of the same location and speaker/persona walks. Keeping those copies aligned made future maintenance unnecessarily error-prone.

## Why This Change Was Made

Share the existing private traversal between detection and repair, retaining lazy preview termination and the supported-location exclusions. All four migration IDs, their order, messages, collision precedence, blocked-key handling, and public config behavior remain unchanged. Production is net **−116 lines**; tests add 98 lines. No files moved, generated output, dependencies, SDK, schema, defaults, or persistence changes.

## User Impact

No intended user-visible change. Root and voice-call provider aliases retain their existing scope; speaker/enabled migrations retain their existing legacy-agent and supported channel locations. Unsupported agent defaults/keyed entries, Discord root/account-root TTS, and unknown plugins are not newly migrated.

During end-to-end verification, a preexisting Doctor persistence problem was independently reproduced on the unchanged base: legacy per-agent TTS repairs can be announced but not saved. Investigation of that repair also exposed authored environment-reference preservation requirements. The larger authored-migration-owner repair remains tracked in #130637; this PR does not claim to resolve it or alter its behavior.

## Evidence

- Exact-source differential: 57 fixtures compare detection metadata/matches, complete mutation output, ordered messages, and repeated application against the frozen base; all pass.
- 30 focused tests and changed-file type-aware lint pass locally; the same 30 tests pass on pinned Linux Node 24/Vitest 4.1.11.
- Complete pinned Linux changed gate passes, including production/core-test type-checking, lint, and all guards. Full build and all seven existing migration E2E tests pass.
- Built CLI preview/fix/validate/repeat passes across eight processes for root migration with a current roster and for already-current config. Preview leaves config bytes untouched; repair preserves canonical agent TTS and the original owner-only backup; repeated repair makes no TTS changes. No provider credentials or running Gateway were used; isolated Gateway-unavailable diagnostics were expected.
- The unchanged public per-agent defect probe reproduces the same result on both the frozen base and cleanup tree; this is regression-boundary evidence, not a claim that #130637 is fixed.
- Complete precommit and distinct published-head Codex reviews pass with no actionable findings. Ordinary CI [33041664114](https://github.com/openclaw/openclaw/actions/runs/33041664114), attempt 1, completed successfully at `0f51ba4269b9ac8706eb39ff24c053b5370eda23`; no retries.
- Actual hosted merge-candidate execution completed full builds and verified 48 built control-plane modules/Doctor closures. The final changed-config shard passed 2,967 tests across 212 files. These hosted results supplement, not replace, the focused TTS and eight-process CLI proof above.

This cleanup was AI-assisted and independently reviewed with Codex. The latest ClawSweeper comment was inspected before native preparation; it is still a review-start placeholder, with no published findings or Rank-up moves. No passing ClawSweeper verdict is claimed.
