### PR TITLE
fix(ci): preserve macOS Swift first-attempt failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3831,23 +3831,18 @@ jobs:
       - name: Swift build (release)
         run: |
           set -euo pipefail
-          for attempt in 1 2 3; do
-            # The macOS lane validates the desktop app build; the CLI product is
-            # intentionally left to its own narrower surfaces instead of making
-            # this lane rebuild the whole package graph.
-            if swift build --package-path apps/macos --product OpenClaw --configuration release; then
-              exit 0
-            fi
-            if [[ "$attempt" -eq 3 ]]; then
-              break
-            fi
-            echo "swift build failed (attempt $attempt/3). Retrying…"
-            # SwiftPM can invalidate a restored binary artifact while planning.
-            # Reset so the next attempt downloads a complete dependency graph.
-            swift package --package-path apps/macos reset
-            sleep $((attempt * 20))
-          done
-          exit 1
+          # The macOS lane validates the desktop app build; the CLI product is
+          # intentionally left to its own narrower surfaces instead of making
+          # this lane rebuild the whole package graph.
+          if swift build --package-path apps/macos --product OpenClaw --configuration release; then
+            exit 0
+          fi
+
+          sparkle_framework="apps/macos/.build/artifacts/sparkle/Sparkle/Sparkle.xcframework"
+          [[ -d "$sparkle_framework" && ! -f "$sparkle_framework/Info.plist" ]] || exit 1
+          echo "::warning::SwiftPM did not produce complete Sparkle metadata; resetting once before retry."
+          swift package --package-path apps/macos reset
+          swift build --package-path apps/macos --product OpenClaw --configuration release
 
       - name: OpenClawKit Talk-trait opt-out (no ElevenLabsKit when default traits disabled)
         run: |
@@ -3880,22 +3875,12 @@ jobs:
         run: |
           set -euo pipefail
           swift_test_args=(--package-path apps/macos --enable-code-coverage)
-          for attempt in 1 2 3; do
-            attempt_args=("${swift_test_args[@]}")
-            # Keep the fast first-attempt Blacksmith path parallel, but make
-            # in-job retries serial after any contention-driven failure.
-            if [[ "$SWIFT_TEST_EXECUTION" == "parallel" && "$attempt" -eq 1 ]]; then
-              attempt_args+=(--parallel)
-            else
-              attempt_args+=(--no-parallel)
-            fi
-            if swift test "${attempt_args[@]}"; then
-              exit 0
-            fi
-            echo "swift test failed (attempt $attempt/3). Retrying…"
-            sleep $((attempt * 20))
-          done
-          exit 1
+          if [[ "$SWIFT_TEST_EXECUTION" == "parallel" ]]; then
+            swift_test_args+=(--parallel)
+          else
+            swift_test_args+=(--no-parallel)
+          fi
+          swift test "${swift_test_args[@]}"
 
       - name: Save SwiftPM cache
         if: needs.preflight.outputs.cache_write_allowed == 'true' && steps.swiftpm-cache.outputs.cache-hit != 'true'

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -6241,7 +6241,7 @@ server.listen(0, "127.0.0.1", () => {
     expect(schemaVersionStep.run).toContain('elif [[ "$HISTORICAL_TARGET" == "true" ]]');
   });
 
-  it("resets SwiftPM state between macOS release build retries", () => {
+  it("retries macOS release builds only when Sparkle metadata is incomplete", () => {
     const workflow = readCiWorkflow();
     const macosInstallStep = workflow.jobs["macos-swift"].steps.find(
       (step: WorkflowStep) => step.name === "Install XcodeGen / SwiftLint / SwiftFormat",
@@ -6257,6 +6257,9 @@ server.listen(0, "127.0.0.1", () => {
     );
     const buildStep = workflow.jobs["macos-swift"].steps.find(
       (step: WorkflowStep) => step.name === "Swift build (release)",
+    );
+    const validateCacheStep = workflow.jobs["macos-swift"].steps.find(
+      (step: WorkflowStep) => step.name === "Validate Swift build cache",
     );
 
     for (const installStep of [macosInstallStep, iosInstallStep]) {
@@ -6304,15 +6307,148 @@ server.listen(0, "127.0.0.1", () => {
     expect(macosLintStep.run).toContain("swiftlint lint --config config/swiftlint.yml");
     expect(macosLintStep.run).toContain("swiftformat --lint apps/macos/Sources");
     expect(iosLintStep.run).toContain("skipping iOS lint for this frozen target");
-    expect(buildStep.run).toContain("for attempt in 1 2 3");
-    expect(buildStep.run).toContain('if [[ "$attempt" -eq 3 ]]; then');
+    expect(buildStep.run).not.toContain("for attempt in");
+    expect(buildStep.run.match(/swift build /gu)).toHaveLength(2);
+    expect(buildStep.run).toContain(
+      '[[ -d "$sparkle_framework" && ! -f "$sparkle_framework/Info.plist" ]]',
+    );
     expect(buildStep.run).toContain("swift package --package-path apps/macos reset");
     expect(buildStep.run.indexOf("swift package --package-path apps/macos reset")).toBeGreaterThan(
-      buildStep.run.indexOf("swift build failed"),
+      buildStep.run.indexOf("sparkle_framework="),
     );
+
+    const runCacheFixture = (artifactState: "no-build" | "absent" | "incomplete" | "complete") => {
+      const root = tempDirs.make(`openclaw-swift-cache-${artifactState}-`);
+      const binDir = path.join(root, "bin");
+      const buildDir = path.join(root, "apps/macos/.build");
+      const frameworkDir = path.join(
+        root,
+        "apps/macos/.build/artifacts/sparkle/Sparkle/Sparkle.xcframework",
+      );
+      const callsPath = path.join(root, "swift-calls");
+      const outputPath = path.join(root, "github-output");
+      mkdirSync(binDir, { recursive: true });
+      if (artifactState === "absent") {
+        mkdirSync(buildDir, { recursive: true });
+      } else if (artifactState === "incomplete" || artifactState === "complete") {
+        mkdirSync(frameworkDir, { recursive: true });
+      }
+      if (artifactState === "complete") {
+        writeFileSync(path.join(frameworkDir, "Info.plist"), "complete\n", "utf8");
+      }
+      writeFileSync(
+        path.join(binDir, "swift"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$SWIFT_CALLS"
+`,
+        "utf8",
+      );
+      chmodSync(path.join(binDir, "swift"), 0o755);
+      const result = runWorkflowShellScript(validateCacheStep.run, {
+        cwd: root,
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: outputPath,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          SWIFT_CALLS: callsPath,
+        },
+      });
+      const calls = existsSync(callsPath) ? readFileSync(callsPath, "utf8").trim().split("\n") : [];
+      return {
+        calls,
+        output: readFileSync(outputPath, "utf8").trim(),
+        status: result.status,
+      };
+    };
+
+    for (const artifactState of ["no-build", "complete"] as const) {
+      const result = runCacheFixture(artifactState);
+      expect(result.status).toBe(0);
+      expect(result.calls).toEqual([]);
+      expect(result.output).toBe("cache-valid=true");
+    }
+    for (const artifactState of ["absent", "incomplete"] as const) {
+      const result = runCacheFixture(artifactState);
+      expect(result.status).toBe(0);
+      expect(result.calls).toEqual(["package --package-path apps/macos reset"]);
+      expect(result.output).toBe("cache-valid=false");
+    }
+
+    const runBuildFixture = (
+      artifactState: "absent" | "incomplete" | "complete",
+      buildOutcome: "recover" | "fail",
+    ) => {
+      const root = tempDirs.make(`openclaw-swift-build-${artifactState}-${buildOutcome}-`);
+      const binDir = path.join(root, "bin");
+      const frameworkDir = path.join(
+        root,
+        "apps/macos/.build/artifacts/sparkle/Sparkle/Sparkle.xcframework",
+      );
+      const callsPath = path.join(root, "swift-calls");
+      mkdirSync(binDir, { recursive: true });
+      if (artifactState === "incomplete" || artifactState === "complete") {
+        mkdirSync(frameworkDir, { recursive: true });
+      }
+      if (artifactState === "complete") {
+        writeFileSync(path.join(frameworkDir, "Info.plist"), "complete\n", "utf8");
+      }
+      writeFileSync(
+        path.join(binDir, "swift"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$SWIFT_CALLS"
+if [[ "\${1:-}" == "package" ]]; then
+  exit 0
+fi
+build_count="$(grep -c '^build ' "$SWIFT_CALLS")"
+if [[ "$BUILD_OUTCOME" == "recover" && "$build_count" -eq 2 ]]; then
+  exit 0
+fi
+exit 1
+`,
+        "utf8",
+      );
+      chmodSync(path.join(binDir, "swift"), 0o755);
+      const result = runWorkflowShellScript(buildStep.run, {
+        cwd: root,
+        env: {
+          ...process.env,
+          BUILD_OUTCOME: buildOutcome,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          SWIFT_CALLS: callsPath,
+        },
+      });
+      return {
+        calls: readFileSync(callsPath, "utf8").trim().split("\n"),
+        output: `${result.stdout}${result.stderr}`,
+        status: result.status,
+      };
+    };
+
+    const absentFramework = runBuildFixture("absent", "fail");
+    expect(absentFramework.status).toBe(1);
+    expect(absentFramework.calls.filter((call) => call.startsWith("build "))).toHaveLength(1);
+    expect(absentFramework.calls.filter((call) => call.startsWith("package "))).toHaveLength(0);
+
+    const recovered = runBuildFixture("incomplete", "recover");
+    expect(recovered.status).toBe(0);
+    expect(recovered.calls.filter((call) => call.startsWith("build "))).toHaveLength(2);
+    expect(recovered.calls.filter((call) => call.startsWith("package "))).toHaveLength(1);
+    expect(recovered.output).toContain("did not produce complete Sparkle metadata");
+
+    const completeFramework = runBuildFixture("complete", "fail");
+    expect(completeFramework.status).toBe(1);
+    expect(completeFramework.calls.filter((call) => call.startsWith("build "))).toHaveLength(1);
+    expect(completeFramework.calls.filter((call) => call.startsWith("package "))).toHaveLength(0);
+
+    const secondFailure = runBuildFixture("incomplete", "fail");
+    expect(secondFailure.status).toBe(1);
+    expect(secondFailure.calls.filter((call) => call.startsWith("build "))).toHaveLength(2);
+    expect(secondFailure.calls.filter((call) => call.startsWith("package "))).toHaveLength(1);
   });
 
-  it("serializes macOS Swift tests only on hosted dispatches and retries", () => {
+  it("preserves the first macOS Swift test failure", () => {
     const workflow = readCiWorkflow();
     const macosSwift = workflow.jobs["macos-swift"];
     const testStep = macosSwift.steps.find((step: WorkflowStep) => step.name === "Swift test");
@@ -6323,17 +6459,48 @@ server.listen(0, "127.0.0.1", () => {
     expect(testStep.run).toContain(
       "swift_test_args=(--package-path apps/macos --enable-code-coverage)",
     );
-    expect(testStep.run).toContain('attempt_args=("${swift_test_args[@]}")');
-    expect(testStep.run).toContain(
-      'if [[ "$SWIFT_TEST_EXECUTION" == "parallel" && "$attempt" -eq 1 ]]',
-    );
-    expect(testStep.run).toContain("attempt_args+=(--parallel)");
-    expect(testStep.run).toContain("else\n    attempt_args+=(--no-parallel)");
-    expect(testStep.run).toContain('swift test "${attempt_args[@]}"');
+    expect(testStep.run).toContain('if [[ "$SWIFT_TEST_EXECUTION" == "parallel" ]]');
+    expect(testStep.run).toContain("swift_test_args+=(--parallel)");
+    expect(testStep.run).toContain("swift_test_args+=(--no-parallel)");
+    expect(testStep.run).toContain('swift test "${swift_test_args[@]}"');
     expect(testStep.run).not.toContain(
       "swift test --package-path apps/macos --parallel --enable-code-coverage",
     );
-    expect(testStep.run).toContain("for attempt in 1 2 3");
+    expect(testStep.run).not.toContain("for attempt in");
+
+    for (const execution of ["parallel", "serial"] as const) {
+      const root = tempDirs.make(`openclaw-swift-test-first-attempt-${execution}-`);
+      const binDir = path.join(root, "bin");
+      const callsPath = path.join(root, "swift-calls");
+      mkdirSync(binDir, { recursive: true });
+      writeFileSync(
+        path.join(binDir, "swift"),
+        `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$SWIFT_CALLS"
+test_count="$(grep -c '^test ' "$SWIFT_CALLS")"
+[[ "$test_count" -gt 1 ]]
+`,
+        "utf8",
+      );
+      chmodSync(path.join(binDir, "swift"), 0o755);
+      const result = runWorkflowShellScript(testStep.run, {
+        cwd: root,
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH ?? ""}`,
+          SWIFT_CALLS: callsPath,
+          SWIFT_TEST_EXECUTION: execution,
+        },
+      });
+      const calls = readFileSync(callsPath, "utf8").trim().split("\n");
+      expect(result.status).toBe(1);
+      expect(calls).toEqual([
+        `test --package-path apps/macos --enable-code-coverage --${
+          execution === "parallel" ? "parallel" : "no-parallel"
+        }`,
+      ]);
+    }
   });
 
   it("bounds the Windows Crabbox hydrate main fetch", () => {


### PR DESCRIPTION
AI-assisted: yes. The maintainer reviewed the implementation and evidence.

Related: https://github.com/openclaw/openclaw/pull/130095

## What Problem This Solves

The macOS Swift CI lane broadly retried failed release builds and tests, allowing a later attempt to hide the first actionable failure.

## Why This Change Was Made

Swift tests now execute exactly once and preserve their first result.

The workflow deliberately separates two phases:

1. `Validate Swift build cache` runs before any build. It invalidates a restored `.build` when Sparkle is absent or incomplete, so stale cache state cannot affect the first build and no build failure can be hidden.
2. After `Swift build (release)` fails, reset and retry are permitted exactly once only when `Sparkle.xcframework` exists and its root `Info.plist` is missing. An absent or complete framework preserves the first failed build, and a failed second build remains terminal.

The guard fixtures execute both phases independently and cover absent, incomplete, complete, and second-failure states.

## User Impact

There is no runtime user-facing change. Maintainers get trustworthy macOS CI failures while retaining a bounded recovery path for the known incomplete-Sparkle artifact condition.

## Evidence

- Exact head: `bfba9e9ea32b10d58da2ca00b51fc3335b02b727`.
- Exact scope: `.github/workflows/ci.yml` and `test/scripts/ci-workflow-guards.test.ts`.
- Workflow production/config delta: net `-15` LOC; test delta: net `+167` LOC.
- Workflow guard suite: 136 passed, 2 skipped.
- Pinned actionlint and zizmor checks, workflow static checks, scoped formatting, exact-base `git diff --check`, TruffleHog, and privacy scans passed.
- Claude fable-5/high autoreview through P2: clean, with no accepted or actionable findings.
- Exact PR CI run `33074932320` succeeded, including all UI shards, `openclaw/ci-gate`, and `check-lint`: https://github.com/openclaw/openclaw/actions/runs/33074932320
- Exact non-skipped `macos-swift` job succeeded: https://github.com/openclaw/openclaw/actions/runs/33076680048/job/98532905550
- The release build succeeded on its first attempt with zero reset/retry execution.
- OpenClawKit passed 1470 tests once; macOS Swift passed 1837 tests once.
- The manual-run `check-lint` exit 143 was a GitHub runner shutdown (`The runner has received a shutdown signal`), not a deterministic lint failure. The identical exact-head `check-lint` passed in PR CI.
- Remaining manual-run screenshot jobs are non-authoritative for this CI-only Swift change.
- Hosted partial-cache recovery is covered deterministically by executable workflow fixtures. Deliberately poisoning a hosted cache is not a reliable or reproducible validation method.

## ClawSweeper Disposition

The latest P2 and rank-up move are addressed. The pre-build absent-cache reset cannot mask a first build failure because it occurs before any build attempt. The post-failure retry now requires an existing incomplete XCFramework, exactly matching the intended recovery boundary.
