### PR TITLE
fix(agents): continue settled tool batches after a transport drop

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { AssistantMessage } from "../../../llm/types.js";
 import {
   buildEmbeddedRunnerAssistant,
   createMockUsage,
@@ -10,7 +11,143 @@ import { recoverEmbeddedRunAttempt } from "./attempt-recovery.js";
 import { createEmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
 import { resolveEmbeddedRunAttemptTerminalState } from "./terminal-outcome.js";
 
+type TransportDropScenario = {
+  errorMessage?: string;
+  content?: AssistantMessage["content"];
+  activeCount?: number;
+  transportDropContinuations?: number;
+};
+
+// Live shape: a code-mode exec batch settled, then the ChatGPT Responses stream
+// died while the model was still reasoning, so the errored turn is thinking-only.
+async function recoverAfterTransportDrop(scenario: TransportDropScenario = {}) {
+  const toolCalls = ["call_1", "call_2"];
+  const toolAssistant = buildEmbeddedRunnerAssistant({
+    stopReason: "toolUse",
+    content: toolCalls.map((id) => ({ type: "toolCall", id, name: "exec", arguments: {} })),
+  });
+  const erroredAssistant = buildEmbeddedRunnerAssistant({
+    stopReason: "error",
+    errorMessage: scenario.errorMessage ?? "WebSocket error",
+    content: scenario.content ?? [{ type: "thinking", thinking: "checking the results" }],
+    usage: createMockUsage(0, 0),
+  });
+  const messagesSnapshot = [
+    { role: "user", content: "why is it unauthorized?" },
+    toolAssistant,
+    ...toolCalls.map((id) => ({ role: "toolResult", toolCallId: id, toolName: "exec" })),
+    erroredAssistant,
+  ] as never;
+  const attempt = makeEmbeddedRunnerAttempt({
+    messagesSnapshot,
+    toolMetas: toolCalls.map(() => ({ toolName: "exec", replaySafe: false })) as never,
+    lastAssistant: erroredAssistant,
+    currentAttemptAssistant: erroredAssistant,
+    itemLifecycle: {
+      startedCount: toolCalls.length,
+      completedCount: toolCalls.length,
+      activeCount: scenario.activeCount ?? 0,
+    },
+  });
+  const terminalState = resolveEmbeddedRunAttemptTerminalState({
+    attempt,
+    assistant: erroredAssistant,
+  });
+  const continueFromCurrentTranscript = vi.fn();
+  const contextRecoveryState = createEmbeddedRunContextRecoveryState();
+  contextRecoveryState.transportDropContinuations = scenario.transportDropContinuations ?? 0;
+  const failoverRetryController = {
+    resolveAuthProfileFailureReason: vi.fn(),
+    advanceAuthProfile: vi.fn(),
+    advanceRateLimitAuthProfile: vi.fn(),
+    maybeMarkAuthProfileFailure: vi.fn(),
+    maybeBackoffBeforeOverloadFailover: vi.fn(),
+  };
+  const recovery = await recoverEmbeddedRunAttempt({
+    runInput: {
+      runParams: {
+        config: {},
+        agentId: "main",
+        sessionId: "session:transport-drop",
+        runId: "run:transport-drop",
+      },
+      resolvedSessionKey: "agent:main:transport-drop",
+      startedAtMs: Date.now(),
+      laneController: { throwIfAborted: vi.fn() },
+    },
+    preparedRuntime: {
+      provider: "openai",
+      modelId: "gpt-5.6-luna",
+      model: { id: "gpt-5.6-luna" },
+      genericCompactionRecoveryAllowed: false,
+      snapshot: () => ({
+        thinkLevel: "off",
+        agentHarness: { id: "openclaw" },
+        outerContextTokenMeta: {},
+        pluginHarnessOwnsTransport: false,
+      }),
+    },
+    normalizedAttempt: {
+      attempt,
+      sessionIdUsed: attempt.sessionIdUsed,
+      attemptAssistant: erroredAssistant,
+      currentAttemptAssistant: erroredAssistant,
+      currentAttemptCompletedAssistant: undefined,
+      terminalState,
+      setTerminalLifecycleMeta: vi.fn(),
+      attemptCompactionCount: 0,
+      activeErrorContext: { provider: "openai", model: "gpt-5.6-luna" },
+      resolveReplayInvalidForAttempt: () => true,
+      canRestartForLiveSwitch: false,
+    },
+    runtimePlan: { auth: {} },
+    sessionPromptState: { sessionFile: "/tmp/session.jsonl", continueFromCurrentTranscript },
+    failoverRetryController,
+    compactionRuntime: {},
+    contextRecoveryState,
+    usageAccumulator: createUsageAccumulator(),
+    lastRunPromptUsage: undefined,
+    runtimeAuthRetry: false,
+    codexAppServerRecoveryRetryAvailable: false,
+    codexAppServerRecoveryRetries: 0,
+    lastRetryFailoverReason: null,
+    traceAttempts: [],
+    sessionAgentId: "main",
+  } as never);
+  return { recovery, continueFromCurrentTranscript, contextRecoveryState, failoverRetryController };
+}
+
 describe("recoverEmbeddedRunAttempt", () => {
+  it("continues from the transcript after a transient transport drop on a settled exec batch", async () => {
+    const {
+      recovery,
+      continueFromCurrentTranscript,
+      contextRecoveryState,
+      failoverRetryController,
+    } = await recoverAfterTransportDrop();
+
+    expect(recovery).toMatchObject({ action: "retry" });
+    expect(contextRecoveryState.transportDropContinuations).toBe(1);
+    expect(continueFromCurrentTranscript).toHaveBeenCalledTimes(1);
+    expect(failoverRetryController.advanceAuthProfile).not.toHaveBeenCalled();
+    expect(failoverRetryController.maybeMarkAuthProfileFailure).not.toHaveBeenCalled();
+  });
+
+  it.each<[string, TransportDropScenario]>([
+    ["the exec batch is still running", { activeCount: 1 }],
+    ["the assistant error is not transient", { errorMessage: "invalid request: bad schema" }],
+    [
+      "the errored turn already carried visible text",
+      { content: [{ type: "text", text: "Partial" }] },
+    ],
+    ["the continuation budget is spent", { transportDropContinuations: 2 }],
+  ])("keeps the replay gate closed when %s", async (_label, scenario) => {
+    const { recovery, continueFromCurrentTranscript } = await recoverAfterTransportDrop(scenario);
+
+    expect(recovery).toEqual({ action: "proceed", shouldSurfaceCodexCompletionTimeout: false });
+    expect(continueFromCurrentTranscript).not.toHaveBeenCalled();
+  });
+
   it("surfaces before_agent_run blocks with current carried usage", async () => {
     const historicalAssistant = buildEmbeddedRunnerAssistant({
       usage: createMockUsage(128_814, 3_000),

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
@@ -16,6 +16,7 @@ type TransportDropScenario = {
   content?: AssistantMessage["content"];
   diagnostics?: AssistantMessage["diagnostics"];
   activeCount?: number;
+  codeModeSuspended?: boolean;
   transportDropContinuations?: number;
 };
 
@@ -50,7 +51,12 @@ async function recoverAfterTransportDrop(scenario: TransportDropScenario = {}) {
   ] as never;
   const attempt = makeEmbeddedRunnerAttempt({
     messagesSnapshot,
-    toolMetas: toolCalls.map(() => ({ toolName: "exec", replaySafe: false })) as never,
+    toolMetas: toolCalls.map((toolCallId) => ({
+      toolCallId,
+      toolName: "exec",
+      replaySafe: false,
+      ...(scenario.codeModeSuspended ? { codeModeSuspended: true } : {}),
+    })) as never,
     lastAssistant: erroredAssistant,
     currentAttemptAssistant: erroredAssistant,
     itemLifecycle: {
@@ -145,6 +151,7 @@ describe("recoverEmbeddedRunAttempt", () => {
 
   it.each<[string, TransportDropScenario]>([
     ["the exec batch is still running", { activeCount: 1 }],
+    ["a Code Mode run is parked", { activeCount: 1, codeModeSuspended: true }],
     ["the assistant error is not transient", { errorMessage: "invalid request: bad schema" }],
     [
       "the failure is retryable but not a transport drop",

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
@@ -18,6 +18,8 @@ type TransportDropScenario = {
   activeCount?: number;
   codeModeSuspended?: boolean;
   transportDropContinuations?: number;
+  terminal?: Parameters<typeof makeEmbeddedRunnerAttempt>[0]["terminal"];
+  yieldDetected?: boolean;
 };
 
 // Live shape: a code-mode exec batch settled, then the ChatGPT Responses stream
@@ -64,6 +66,8 @@ async function recoverAfterTransportDrop(scenario: TransportDropScenario = {}) {
       completedCount: toolCalls.length,
       activeCount: scenario.activeCount ?? 0,
     },
+    ...(scenario.terminal ? { terminal: scenario.terminal } : {}),
+    ...(scenario.yieldDetected ? { yieldDetected: true } : {}),
   });
   const terminalState = resolveEmbeddedRunAttemptTerminalState({
     attempt,
@@ -149,9 +153,24 @@ describe("recoverEmbeddedRunAttempt", () => {
     expect(failoverRetryController.maybeMarkAuthProfileFailure).not.toHaveBeenCalled();
   });
 
+  it.each([0, 1])(
+    "continues a parked Code Mode run from its persisted waiting result with activeCount=%i",
+    async (activeCount) => {
+      const { recovery, continueFromCurrentTranscript } = await recoverAfterTransportDrop({
+        codeModeSuspended: true,
+        activeCount,
+      });
+
+      expect(recovery).toMatchObject({ action: "retry" });
+      expect(continueFromCurrentTranscript).toHaveBeenCalledTimes(1);
+    },
+  );
+
   it.each<[string, TransportDropScenario]>([
     ["the exec batch is still running", { activeCount: 1 }],
-    ["a Code Mode run is parked", { codeModeSuspended: true }],
+    ["the run was externally aborted", { terminal: { kind: "aborted", source: "external" } }],
+    ["the run timed out", { terminal: { kind: "timeout", phase: "prompt", source: "runtime" } }],
+    ["the attempt already has terminal state", { yieldDetected: true }],
     ["the assistant error is not transient", { errorMessage: "invalid request: bad schema" }],
     [
       "the failure is retryable but not a transport drop",

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
@@ -151,7 +151,7 @@ describe("recoverEmbeddedRunAttempt", () => {
 
   it.each<[string, TransportDropScenario]>([
     ["the exec batch is still running", { activeCount: 1 }],
-    ["a Code Mode run is parked", { activeCount: 1, codeModeSuspended: true }],
+    ["a Code Mode run is parked", { codeModeSuspended: true }],
     ["the assistant error is not transient", { errorMessage: "invalid request: bad schema" }],
     [
       "the failure is retryable but not a transport drop",

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
@@ -14,6 +14,7 @@ import { resolveEmbeddedRunAttemptTerminalState } from "./terminal-outcome.js";
 type TransportDropScenario = {
   errorMessage?: string;
   content?: AssistantMessage["content"];
+  diagnostics?: AssistantMessage["diagnostics"];
   activeCount?: number;
   transportDropContinuations?: number;
 };
@@ -29,6 +30,15 @@ async function recoverAfterTransportDrop(scenario: TransportDropScenario = {}) {
   const erroredAssistant = buildEmbeddedRunnerAssistant({
     stopReason: "error",
     errorMessage: scenario.errorMessage ?? "WebSocket error",
+    diagnostics:
+      scenario.diagnostics ??
+      ([
+        {
+          type: "provider_transport_failure",
+          error: { message: "WebSocket error" },
+          details: { phase: "after_message_stream_start" },
+        },
+      ] as never),
     content: scenario.content ?? [{ type: "thinking", thinking: "checking the results" }],
     usage: createMockUsage(0, 0),
   });
@@ -136,6 +146,10 @@ describe("recoverEmbeddedRunAttempt", () => {
   it.each<[string, TransportDropScenario]>([
     ["the exec batch is still running", { activeCount: 1 }],
     ["the assistant error is not transient", { errorMessage: "invalid request: bad schema" }],
+    [
+      "the failure is retryable but not a transport drop",
+      { errorMessage: "429 rate limit exceeded; retry after 2 seconds", diagnostics: [] },
+    ],
     [
       "the errored turn already carried visible text",
       { content: [{ type: "text", text: "Partial" }] },

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -1,9 +1,12 @@
 import { formatErrorMessage, toErrorObject } from "../../../infra/errors.js";
+import type { AssistantMessage } from "../../../llm/types.js";
+import { isRetryableAssistantError } from "../../../llm/utils/retry.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../defaults.js";
 import type { FailoverReason } from "../../embedded-agent-helpers.js";
 import { LiveSessionModelSwitchError } from "../../live-model-switch-error.js";
 import { shouldSwitchToLiveModel, clearLiveModelSwitchPending } from "../../live-model-switch.js";
+import { hasOnlyAssistantReasoningContent } from "../../replay-turn-classification.js";
 import type { normalizeUsage } from "../../usage.js";
 import { log } from "../logger.js";
 import { getEmbeddedSessionPromptState } from "../session-prompt-state.js";
@@ -11,7 +14,11 @@ import type { EmbeddedAgentRunResult, TraceAttempt } from "../types.js";
 import type { createUsageAccumulator } from "../usage-accumulator.js";
 import type { prepareAndDispatchEmbeddedRunAttempt } from "./attempt-dispatch-preparation.js";
 import type { normalizeEmbeddedRunAttempt } from "./attempt-normalization.js";
-import { hasAsyncActivity, isCurrentAttemptReplaySafe } from "./attempt-terminal-evidence.js";
+import {
+  hasAsyncActivity,
+  hasAttemptTerminalState,
+  isCurrentAttemptReplaySafe,
+} from "./attempt-terminal-evidence.js";
 import { buildEmbeddedRunBlockedResult } from "./blocked-run-result.js";
 import { resolveCodexAppServerRecoveryRetry } from "./codex-app-server-recovery.js";
 import { resolveCompactionLiveModelSelection } from "./compaction-live-model-selection.js";
@@ -27,6 +34,17 @@ import type { prepareEmbeddedRunRuntime } from "./runtime-preparation.js";
 import type { createEmbeddedRunSessionPromptState } from "./session-prompt-state.js";
 import { isEmbeddedRunTerminalInterrupted } from "./terminal-outcome.js";
 import { recoverEmbeddedRunTimeout } from "./timeout-context-recovery.js";
+
+const MAX_TRANSPORT_DROP_CONTINUATIONS = 2;
+
+/** Errored assistant turn with transient transport evidence and no visible output. */
+function isSilentTransportDropAssistant(assistant: AssistantMessage | undefined): boolean {
+  if (!assistant || assistant.stopReason !== "error" || !isRetryableAssistantError(assistant)) {
+    return false;
+  }
+  const content = Array.isArray(assistant.content) ? assistant.content : [];
+  return content.length === 0 || hasOnlyAssistantReasoningContent(assistant);
+}
 
 type PreparedRuntime = Awaited<ReturnType<typeof prepareEmbeddedRunRuntime>>;
 type NormalizedAttempt = Extract<
@@ -126,6 +144,24 @@ export async function recoverEmbeddedRunAttempt(input: {
     attempt.preflightRecovery?.source === "mid-turn" &&
     midTurnBatchSettled &&
     !hasAsyncActivity(attempt.toolMetas);
+  // A transient transport failure that lands after the whole tool batch settled
+  // is a resume, not a replay: the continuation prompt re-enters after the
+  // persisted tool results and nothing from the failed attempt is resubmitted.
+  // Only a silent errored assistant qualifies; partial visible text would be
+  // duplicated or replaced. Everything #122516 closed for side-effecting
+  // attempts (prompt resubmission, profile rotation, model fallback) stays
+  // closed below this branch.
+  const settledTransportDropAssistant =
+    !currentAttemptReplaySafe &&
+    !promptError &&
+    !aborted &&
+    !timedOut &&
+    !terminalInterrupted &&
+    !hasAttemptTerminalState(attempt) &&
+    midTurnBatchSettled &&
+    isSilentTransportDropAssistant(currentAttemptAssistant)
+      ? currentAttemptAssistant
+      : undefined;
   const { signalOwnedInterruption } = terminalState;
   const assistantOverflowCandidate =
     currentAttemptCompletedAssistant !== undefined
@@ -184,7 +220,11 @@ export async function recoverEmbeddedRunAttempt(input: {
       }),
     };
   }
-  if (!currentAttemptReplaySafe && !canContinueSettledMidTurnOverflow) {
+  if (
+    !currentAttemptReplaySafe &&
+    !canContinueSettledMidTurnOverflow &&
+    !settledTransportDropAssistant
+  ) {
     return replayUnsafeOutcome;
   }
 
@@ -312,8 +352,26 @@ export async function recoverEmbeddedRunAttempt(input: {
       }),
     };
   }
-  // Settled-tool continuation authorizes only current-transcript overflow recovery.
-  // Every path below can replay or replace the original attempt and remains fail-closed.
+  const recoveryState = input.contextRecoveryState;
+  if (
+    settledTransportDropAssistant &&
+    recoveryState.transportDropContinuations < MAX_TRANSPORT_DROP_CONTINUATIONS
+  ) {
+    runInput.laneController.throwIfAborted();
+    recoveryState.transportDropContinuations += 1;
+    sessionPromptState.continueFromCurrentTranscript();
+    log.warn(
+      `provider transport dropped after a settled tool batch; continuing from the transcript ` +
+        `attempt=${recoveryState.transportDropContinuations}/${MAX_TRANSPORT_DROP_CONTINUATIONS} ` +
+        `provider=${preparedRuntime.provider} model=${preparedRuntime.modelId} ` +
+        `error=${settledTransportDropAssistant.errorMessage?.trim() ?? "unknown"} ` +
+        `runId=${params.runId} sessionId=${params.sessionId}`,
+    );
+    return retry();
+  }
+  // Settled-tool continuation authorizes only current-transcript overflow and
+  // transport-drop recovery. Every path below can replay or replace the original
+  // attempt and remains fail-closed.
   if (!currentAttemptReplaySafe) {
     return replayUnsafeOutcome;
   }

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -39,7 +39,12 @@ const MAX_TRANSPORT_DROP_CONTINUATIONS = 2;
 
 /** Errored assistant turn with transient transport evidence and no visible output. */
 function isSilentTransportDropAssistant(assistant: AssistantMessage | undefined): boolean {
-  if (!assistant || assistant.stopReason !== "error" || !isRetryableAssistantError(assistant)) {
+  if (
+    !assistant ||
+    assistant.stopReason !== "error" ||
+    !isRetryableAssistantError(assistant) ||
+    !assistant.diagnostics?.some((diagnostic) => diagnostic.type === "provider_transport_failure")
+  ) {
     return false;
   }
   const content = Array.isArray(assistant.content) ? assistant.content : [];

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -163,7 +163,7 @@ export async function recoverEmbeddedRunAttempt(input: {
     !timedOut &&
     !terminalInterrupted &&
     !hasAttemptTerminalState(attempt) &&
-    midTurnBatchSettled &&
+    settledEvidence.allToolsProvenSettled &&
     isSilentTransportDropAssistant(currentAttemptAssistant)
       ? currentAttemptAssistant
       : undefined;

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -164,6 +164,7 @@ export async function recoverEmbeddedRunAttempt(input: {
     !terminalInterrupted &&
     !hasAttemptTerminalState(attempt) &&
     settledEvidence.allToolsProvenSettled &&
+    !settledEvidence.parkedCodeModeRun &&
     isSilentTransportDropAssistant(currentAttemptAssistant)
       ? currentAttemptAssistant
       : undefined;

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -163,8 +163,9 @@ export async function recoverEmbeddedRunAttempt(input: {
     !timedOut &&
     !terminalInterrupted &&
     !hasAttemptTerminalState(attempt) &&
-    settledEvidence.allToolsProvenSettled &&
-    !settledEvidence.parkedCodeModeRun &&
+    midTurnBatchSettled &&
+    // A parked Code Mode result is persisted same-session state. Continuing is
+    // how the model reaches wait; it does not resubmit the prompt or exec call.
     isSilentTransportDropAssistant(currentAttemptAssistant)
       ? currentAttemptAssistant
       : undefined;

--- a/src/agents/embedded-agent-runner/run/context-recovery-state.ts
+++ b/src/agents/embedded-agent-runner/run/context-recovery-state.ts
@@ -8,6 +8,7 @@ export function createEmbeddedRunContextRecoveryState() {
     overflowCompactionAttempts: 0,
     timeoutCompactionAttempts: 0,
     toolResultTruncationAttempted: false,
+    transportDropContinuations: 0,
   };
 }
 

--- a/src/agents/embedded-agent-subscribe.handlers.types.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.types.ts
@@ -178,6 +178,7 @@ export type EmbeddedAgentSubscribeState = {
   lastReasoningSent?: string;
   pendingAssistantUsage?: NormalizedUsage;
   assistantUsageCommitted: boolean;
+  retryUsage?: NormalizedUsage;
 
   compactionInFlight: boolean;
   lastCompactionTokensAfter?: number;

--- a/src/agents/embedded-agent-subscribe.run-state.ts
+++ b/src/agents/embedded-agent-subscribe.run-state.ts
@@ -63,6 +63,7 @@ export function createEmbeddedAgentSubscribeState(
     lastReasoningSent: undefined,
     pendingAssistantUsage: undefined,
     assistantUsageCommitted: false,
+    retryUsage: undefined,
     compactionInFlight: false,
     lastCompactionTokensAfter: undefined,
     pendingCompactionRetry: 0,

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -425,6 +425,72 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
   });
 
+  it("keeps a successful retry call when later post-call processing fails", () => {
+    const { emit, subscription } = createSubscribedSessionHarness({ runId: "run" });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        usage: { input: 100, output: 20, totalTokens: 120 },
+      },
+    });
+    emit(retryingCompactionEnd());
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        usage: { input: 240, output: 30, totalTokens: 270 },
+      },
+    });
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        stopReason: "error",
+        usage: makeZeroUsageSnapshot(),
+      },
+    });
+
+    expect(subscription.getLastAssistantUsage()).toEqual({
+      input: 240,
+      output: 30,
+      total: 270,
+    });
+  });
+
+  it("restores the previous call when a retry fails before recording usage", () => {
+    const { emit, subscription } = createSubscribedSessionHarness({ runId: "run" });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        usage: { input: 100, output: 20, totalTokens: 120 },
+      },
+    });
+    emit(retryingCompactionEnd());
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        stopReason: "error",
+        usage: makeZeroUsageSnapshot(),
+      },
+    });
+
+    expect(subscription.getLastAssistantUsage()).toEqual({
+      input: 100,
+      output: 20,
+      total: 120,
+    });
+  });
+
   it.each(THINKING_TAG_CASES)(
     "streams <%s> reasoning via onReasoningStream without leaking into final text",
     async ({ open, close }) => {

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -70,7 +70,6 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   let lastAssistantUsage: ReturnType<typeof normalizeUsage>;
   let compactionCount = 0;
   let currentAttemptAssistant: AssistantMessage | undefined;
-
   const assistantTexts = state.assistantTexts;
   const toolMetas = state.toolMetas;
   const toolMetaById = state.toolMetaById;
@@ -283,7 +282,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       total: usageTotals.total || derivedTotal || undefined,
     };
   };
-  const getLastAssistantUsage = () => (lastAssistantUsage ? { ...lastAssistantUsage } : undefined);
+  const getLastAssistantUsage = () => normalizeUsage(lastAssistantUsage ?? state.retryUsage);
   const incrementCompactionCount = () => {
     compactionCount += 1;
   };
@@ -451,9 +450,10 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.deterministicApprovalPromptSent = false;
     state.lastDeliveredBlockReplyText = undefined;
     state.toolExecutionSinceLastBlockReply = false;
-    // A retry is a new model attempt. A silent retry must not inherit the
-    // completed assistant or pre-compaction context snapshot.
+    // Keep prior usage only until the retry records its own call; later
+    // post-call failures must retain that newer call.
     currentAttemptAssistant = undefined;
+    state.retryUsage = lastAssistantUsage ?? state.retryUsage;
     lastAssistantUsage = undefined;
     state.replayState = mergeEmbeddedRunReplayState(state.replayState, params.initialReplayState);
     state.livenessState = "working";

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -282,7 +282,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       total: usageTotals.total || derivedTotal || undefined,
     };
   };
-  const getLastAssistantUsage = () => normalizeUsage(lastAssistantUsage ?? state.retryUsage);
+  const getLastAssistantUsage = () => normalizeUsage(lastAssistantUsage);
   const incrementCompactionCount = () => {
     compactionCount += 1;
   };
@@ -450,8 +450,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
     state.deterministicApprovalPromptSent = false;
     state.lastDeliveredBlockReplyText = undefined;
     state.toolExecutionSinceLastBlockReply = false;
-    // Keep prior usage only until the retry records its own call; later
-    // post-call failures must retain that newer call.
+    // Keep prior usage until the retry records its own call or terminal error.
     currentAttemptAssistant = undefined;
     state.retryUsage = lastAssistantUsage ?? state.retryUsage;
     lastAssistantUsage = undefined;
@@ -470,6 +469,8 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       // Context-engine projection may later replace or mutate transcript
       // objects. Final delivery needs the model event owned by this run.
       currentAttemptAssistant = structuredClone(msg) as AssistantMessage;
+      lastAssistantUsage ??= msg.stopReason === "error" ? state.retryUsage : undefined;
+      state.retryUsage = undefined;
     }
   };
 


### PR DESCRIPTION
Closes #130720

## What Problem This Solves

### High Level TLDR
When the provider stream dies mid-turn *after* the tool calls have run and their results are persisted, the embedded runner gave up and showed "⚠️ Agent couldn't generate a response. Note: some tool actions may have already been executed — please verify before retrying." The work was already in the transcript; nothing needed re-running. Under code mode every tool call is `exec`, so any turn with a tool call died on a socket hiccup. This change continues such turns from the persisted transcript, bounded, without reopening the paths the replay gate exists to close.

### Root Cause
`recoverEmbeddedRunAttempt` (`src/agents/embedded-agent-runner/run/attempt-recovery.ts`) returns `replayUnsafeOutcome` as soon as `isCurrentAttemptReplaySafe(attempt)` is false, and `handleEmbeddedAssistantFailure` (`run/assistant-failure.ts:130-138`, the early `proceed` from #122516) does the same before the empty-error retry, profile rotation, or model fallback are consulted. Code-mode `exec` is unconditionally replay-unsafe (`src/agents/tool-mutation.ts`, `isReplaySafeToolCall("exec") === false`, regardless of `restartSafe`), so the whole attempt is marked side-effecting the moment one tool runs.

That gate protects against **resubmitting the original prompt** (or rotating profile / falling back to another model) after committed side effects — #122516's stated concern. It never distinguished "continue from the persisted tool results", which the runner already does safely for settled mid-turn overflow (#128970, `canContinueSettledMidTurnOverflow` → `continueFromCurrentTranscript`). The inner session auto-retry that classifies `WebSocket error` as transient (`src/llm/utils/retry.ts`, `retry-evidence.ts`) is deliberately disabled for embedded runs (#84798 / #73781), so no layer resumed the turn.

RCA evidence (live gateway, redacted):
```
[openai-transport] ChatGPT Responses stream terminated
[telegram] embedded run agent end: ... isError=true model=gpt-5.6-sol provider=openai error=LLM request failed. rawError=WebSocket error
[agent/embedded] incomplete turn detected: ... stopReason=error hasLastAssistant=yes hasCurrentAttemptAssistant=yes payloads=1 tools=13 replaySafe=no compactions=0 reasoningRetries=0/2 emptyRetries=0/1 missingAssistantRetries=0/1 — surfacing error to user
```
Persisted errored assistant: content `[thinking]` only, `errorMessage: "WebSocket error"`, `diagnostics: provider_transport_failure` (`phase: after_message_stream_start`), no `errorCode`; all 13 `exec` results persisted before it.

### Exact change
`attempt-recovery.ts`: a `settledTransportDropAssistant` fact — current-attempt assistant with `stopReason: "error"`, generic transient evidence per `isRetryableAssistantError`, producer-recorded `provider_transport_failure` diagnostics, no visible output (empty or reasoning-only content), attempt not aborted/timed out/interrupted, no terminal state, and canonical `midTurnBatchSettled` evidence (`allToolsProvenSettled || parkedCodeModeRun`). A producer-recorded `codeModeSuspended`/waiting result is persisted same-session state: continuing from the current transcript lets the model call `wait` for that existing cell and does not replay the original prompt or `exec`. Without parked evidence, `activeCount=1` remains rejected. Requiring the transport diagnostic keeps short-window 429/rate-limit failures with the existing backoff and profile-rotation owner. When eligible and below the two-continuation budget, the runner resumes through `continueFromCurrentTranscript()`; prompt resubmission, profile rotation, and model fallback stay closed for side-effecting attempts.

The subscription usage owner now keeps the previous `lastCallUsage` only as a retry fallback. The previous call stays hidden while the retry is active. A newly committed retry call remains authoritative if later post-call processing fails, while a retry that terminates with an error before recording usage restores the previous exact call.

### Scope boundary
- Replay-safe attempts are untouched (existing empty-error retry path).
- Parked Code Mode batches may continue only from producer-recorded waiting evidence, with either outer `activeCount=0` or `activeCount=1`.
- Active work without parked evidence, asynchronous work, visible text, tool errors, delivery, aborts, timeouts, terminal states, and non-transient errors still surface as before.
- Prompt resubmission, profile rotation, and model fallback remain closed for side-effecting attempts.

## Why This Change Was Made
The invariant is "never re-execute committed side effects", not "never continue after them". Continuing from persisted results is the same contract the runner already honors for settled mid-turn overflow; extending it to transient transport failures removes a default-path dead end that code mode turned from an edge case into the common case.

## User Impact
Tool-heavy turns survive a provider socket drop instead of ending in the generic warning; the model picks up after the last tool result. Operators see a `provider transport dropped after a settled tool batch; continuing from the transcript attempt=n/2 …` warn line.

## Evidence

### Real behavior proof
The focused fixtures reproduce the settled replay-unsafe transport failure, the short-window rate-limit exclusion, and retry usage ordering.

```text
# pre-fix against the original production files
attempt-recovery: 1 failed | 7 passed (8)
subscription usage: 1 failed | 93 passed (94)

# current head
attempt-recovery: 13 passed (13)
subscription usage: 94 passed (94)
retry classifier: 630 passed (630)
```

Positive cases cover a normally settled batch plus parked Code Mode waiting results with both `activeCount=0` and `activeCount=1`. Fail-closed cases cover `activeCount=1` without parked evidence, abort, timeout, existing terminal state, non-transient errors, retryable non-transport/rate-limit errors, visible partial text, and an exhausted continuation budget. Retry-usage coverage proves both sides of the ordering invariant: restore the previous call only before a replacement call is captured, and retain a newer successful call across a later post-call error.

Validation: `node scripts/check-changed.mjs -- <six touched files>` passed formatting, core and core-test tsgo, oxlint, import-cycle, database-first, and repository guard lanes.

Autoreview: Codex `gpt-5.6-sol` / high, including a fresh P0/P1 correctness and security pass that explicitly distinguished transcript continuation from replay — clean (patch correct, confidence 0.97).

### What was not tested
- The final parked-run predicate delta was not redeployed. Earlier live managed-Gateway proof at `5e01721177b2a208d995c55c705473202afc66be` is preserved in the PR discussion: it injected a transport reset after one persisted `exec` result, observed one bounded transcript continuation, and proved the original call/result were not duplicated. The final delta is covered by deterministic owner-boundary regressions for parked `activeCount=0/1` and active-without-parked rejection.
- The operator's primary gateway and state were not modified.
- The Codex app-server harness is unchanged; it has its own once-per-run stdio replay and never resumed dropped turns after tools either — separate surface, not touched here.

Production LOC for the full PR: +77 / -8 (net +69); tests +243 / -0.

Worked on by:
- @VACInc

---
[View the OpenClaw team session](https://team.openclaw.ai/chat/roboclaw/dashboard/da50a1b3-33d2-4ad4-af41-d441c295e3f5)




