### PR TITLE
fix: avoid stalled maintainer author activity lookups

### DIFF
--- a/.agents/skills/openclaw-pr-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-pr-maintainer/SKILL.md
@@ -93,8 +93,8 @@ gh api -X POST "repos/openclaw/openclaw/issues/<number>/assignees" -f 'assignees
 - For every reviewed, triaged, closed, or landed issue/PR, show the opener's human name when available, GitHub login, and account age.
 - Get the login from `gh issue view` / `gh pr view` (`author.login`), then fetch profile metadata once with `gh api users/<login> --jq '{login,name,created_at,type}'`.
 - Report opener identity as one compact line:
-  `By: Jane Doe (@jane, acct 2021-04-03) | OpenClaw: 4 PRs, 2 issues, 11 commits/12mo | GitHub: 9 repos, 86 commits, 9 PRs, 3 issues, 12 reviews`
-- Always show recent activity in two lanes: OpenClaw-local PRs, issues, and commits in the last 12 months; and general public GitHub activity over the same window. For linked issue-fixing PRs, include both the PR author and issue opener when they differ.
+  `By: Jane Doe (@jane, acct 2021-04-03) | OpenClaw: 4 PRs, 2 issues, 11 commits/12mo | GitHub contributions: 86 commits, 9 PRs, 3 issues, 12 reviews/12mo`
+- Show activity in two separate lanes: repo search totals for authored PRs/issues and commits, and GitHub contribution-graph totals. State each interval; neither lane is an exhaustive activity history. For linked issue-fixing PRs, include both the PR author and issue opener when they differ.
 - Prefer the bundled helper for activity lookups:
 
 ```bash
@@ -102,11 +102,11 @@ gh api -X POST "repos/openclaw/openclaw/issues/<number>/assignees" -f 'assignees
 .agents/skills/openclaw-pr-maintainer/scripts/github-activity.sh --global <login>
 ```
 
-- The helper reports repo-local activity first and can fetch public GitHub contribution totals for the same window with `--global`; run the global form by default for review/triage identity summaries.
-- If the global contribution graph reports zero or looks inconsistent with visible public activity, sanity-check with `gh api users/<login>`, `gh api 'users/<login>/events/public?per_page=100'`, and recent public repo commits before calling the account inactive.
-- The helper is intentionally cache-friendly for gitcrawl-backed `gh`: it rounds repo-local windows to the UTC day, rounds global contribution windows to the UTC hour, and counts PRs/issues from one paginated issues response before fetching commits separately. Prefer reusing the helper instead of hand-rolling several `gh api` loops.
-- If the contribution graph is misleading or zero but public events/repos show activity, keep it one line, for example:
-  `By: pickaxe (@ProspectOre, acct 2019-08-24) | OpenClaw: 5 PRs, 0 issues, 5 commits/12mo | GitHub: 5 repos, 29 recent events, 100 public own-repo commits; graph=0`
+- Run `--global` by default for review/triage identity summaries. The helper prints canonical profile identity before requesting activity, then makes three single-page REST searches (`per_page=1`) for repo totals and one optional GraphQL contribution aggregate: at most five `gh` calls per resolved login, independent of activity volume. It uses `total_count`, never fetched row counts or pagination.
+- Keep bare PATH `gh` with native `--cache 1h` for profile, search, and GraphQL reads. Octopool delegates author/date-filtered searches and GraphQL, so bare `gh` alone does not guarantee fleet-cache coverage. Native caching keeps repeated lookups bounded without a custom store; do not source `plain-gh.sh`, force fresh reads, or query private cache databases.
+- Windows use completed UTC days with calendar-month subtraction clamped at month ends. Repo search uses PR/issue creation time and default-branch commit committer date. `--months` controls the repo interval; global contributions cap at 12 months because GitHub accepts at most one year. The helper prints both intervals and explicitly labels a global cap for longer requests.
+- Search totals reflect GitHub's index and may be cached or lag recent changes. Printed intervals are query bounds, not proof of live freshness. Incomplete search results, malformed/missing data, request failures, and unresolved identity are not zero. The helper labels those outcomes, continues later logins, and exits nonzero if identity or requested activity is unavailable or incomplete.
+- Contribution totals follow GitHub's contribution rules and token visibility; they may include private repositories. Do not call them public-only or infer inactivity from a zero graph. Do not automatically scan events or repositories as a fallback; report the limitation and inspect specific evidence separately only when needed.
 - If `name` is empty, use the login only. If profile lookup is rate-limited or unavailable, say `account age unknown` rather than omitting the opener.
 - Use identity and activity as triage signal, not proof by itself: new, low-activity, or bot-like accounts can raise review caution, but code, repro, and CI evidence still decide.
 

--- a/.agents/skills/openclaw-pr-maintainer/scripts/github-activity.sh
+++ b/.agents/skills/openclaw-pr-maintainer/scripts/github-activity.sh
@@ -4,14 +4,6 @@ set -euo pipefail
 repo="openclaw/openclaw"
 months="12"
 include_global="0"
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(git -C "$script_dir/../../../.." rev-parse --show-toplevel 2>/dev/null || true)"
-if [ -z "$repo_root" ]; then
-  repo_root="$(cd "$script_dir/../../../.." && pwd)"
-fi
-
-# shellcheck disable=SC1091
-source "$repo_root/scripts/lib/plain-gh.sh"
 
 usage() {
   printf 'Usage: %s [--repo owner/repo] [--months N] [--global] <github-login> [login...]\n' "$0"
@@ -22,86 +14,54 @@ die() {
   exit 1
 }
 
-need() {
-  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
-}
-
-gh() {
-  gh_plain "$@"
-}
-
-date_utc_relative_months() {
-  local count="$1"
-  if date -u -v-"${count}"m +%Y-%m-%dT00:00:00Z >/dev/null 2>&1; then
-    date -u -v-"${count}"m +%Y-%m-%dT00:00:00Z
-    return
+search_count() {
+  local endpoint="$1" query="$2" response count
+  query=$(jq -rn --arg q "$query" '$q | @uri')
+  # Native gh caching also covers author/date searches the fleet shim delegates.
+  if ! response=$(gh api "search/${endpoint}?q=${query}&per_page=1" --cache 1h 2>/dev/null); then
+    printf 'unavailable (request failed)'
+    return 1
   fi
-  date -u -d "${count} months ago" +%Y-%m-%dT00:00:00Z
-}
-
-date_to_epoch() {
-  local value="$1"
-  if date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$value" +%s >/dev/null 2>&1; then
-    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$value" +%s
-    return
+  if ! count=$(jq -er '
+    if type == "object" and
+       (.total_count | type == "number" and . >= 0 and . == floor) and
+       (.incomplete_results | type == "boolean") then
+      if .incomplete_results then "incomplete (reported \(.total_count))"
+      else .total_count | tostring end
+    else error("invalid search aggregate") end' <<<"$response" 2>/dev/null); then
+    printf 'unavailable (invalid response)'
+    return 1
   fi
-  date -u -d "$value" +%s
-}
-
-rough_age() {
-  local created_at="$1"
-  local now_s created_s days
-  now_s=$(date -u +%s)
-  created_s=$(date_to_epoch "$created_at")
-  days=$(( (now_s - created_s) / 86400 ))
-  if (( days < 120 )); then
-    printf '~%dd old' "$days"
-    return
-  fi
-  awk -v days="$days" 'BEGIN { printf "~%.1fy old", days / 365.2425 }'
-}
-
-thread_kinds() {
-  local login="$1"
-  local since_ts="$2"
-  gh api --paginate "repos/${repo}/issues?state=all&creator=${login}&since=${since_ts}&per_page=100" \
-    --jq ".[] | select(.created_at >= \"${since_ts}\") | if has(\"pull_request\") then \"pr\" else \"issue\" end"
-}
-
-count_kind_lines() {
-  local kind="$1"
-  local lines="$2"
-  grep -cx "$kind" <<<"$lines" 2>/dev/null || true
-}
-
-count_commits() {
-  local login="$1"
-  local since_ts="$2"
-  gh api --paginate "repos/${repo}/commits?author=${login}&since=${since_ts}&per_page=100" \
-    --jq '.[].sha' | wc -l | tr -d '[:space:]'
+  printf '%s' "$count"
+  [[ "$count" != incomplete* ]]
 }
 
 global_activity() {
-  local login="$1"
-  local since_ts="$2"
-  local now_ts="$3"
+  local login="$1" response
+  # GraphQL may use the real CLI via the shim, but remains one aggregate request.
   # shellcheck disable=SC2016
-  gh api graphql \
-    -f login="$login" \
-    -f from="$since_ts" \
-    -f to="$now_ts" \
-    -f query='
-query($login: String!, $from: DateTime!, $to: DateTime!) {
-  user(login: $login) {
-    contributionsCollection(from: $from, to: $to) {
-      totalCommitContributions
-      totalIssueContributions
-      totalPullRequestContributions
-      totalPullRequestReviewContributions
+  if ! response=$(gh api graphql --cache 1h -f login="$login" -f from="$global_from" -f to="$global_to" \
+    -f query='query($login: String!, $from: DateTime!, $to: DateTime!) {
+      user(login: $login) { contributionsCollection(from: $from, to: $to) {
+        totalCommitContributions totalIssueContributions
+        totalPullRequestContributions totalPullRequestReviewContributions
+      } }
+    }' 2>/dev/null); then
+    printf 'unavailable (request failed)\n'
+    return 1
+  fi
+  jq -er '
+    if (.errors // [] | length) > 0 then error("GraphQL errors") else
+      .data.user.contributionsCollection |
+      [.totalCommitContributions, .totalPullRequestContributions,
+       .totalIssueContributions, .totalPullRequestReviewContributions] |
+      if all(.[]; type == "number" and . >= 0 and . == floor) then
+        "\(.[0]) commits, \(.[1]) PRs, \(.[2]) issues, \(.[3]) reviews"
+      else error("invalid contribution aggregate") end
+    end' <<<"$response" 2>/dev/null || {
+      printf 'unavailable (invalid response)\n'
+      return 1
     }
-  }
-}' \
-    --jq '.data.user.contributionsCollection // empty'
 }
 
 while [[ $# -gt 0 ]]; do
@@ -114,7 +74,7 @@ while [[ $# -gt 0 ]]; do
     --months)
       [[ $# -ge 2 ]] || die "--months requires a positive integer"
       months="$2"
-      [[ "$months" =~ ^[0-9]+$ && "$months" != "0" ]] || die "--months must be a positive integer"
+      [[ "$months" =~ ^[1-9][0-9]*$ ]] || die "--months must be a positive integer"
       shift 2
       ;;
     --global)
@@ -129,63 +89,68 @@ while [[ $# -gt 0 ]]; do
       shift
       break
       ;;
-    -*)
-      die "unknown option: $1"
-      ;;
-    *)
-      break
-      ;;
+    -*) die "unknown option: $1" ;;
+    *) break ;;
   esac
 done
 
-[[ $# -gt 0 ]] || {
-  usage >&2
-  exit 2
-}
+[[ $# -gt 0 ]] || { usage >&2; exit 2; }
+[[ "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || die "--repo requires owner/repo"
+for command in gh jq; do
+  command -v "$command" >/dev/null 2>&1 || die "missing required command: $command"
+done
 
-OPENCLAW_GH_BIN="$(resolve_plain_gh_bin)" || die "missing required command: gh"
-export OPENCLAW_GH_BIN
-need jq
-
-since_ts=$(date_utc_relative_months "$months")
-now_ts=$(date -u +%Y-%m-%dT%H:00:00Z)
-
+# Use completed UTC days and clamp calendar subtraction at month ends on both OSes.
+# The contribution API accepts at most one year; never relabel that as the repo range.
+clock=$(date -u +%s)
+windows=$(jq -nr --argjson clock "$clock" --argjson months "$months" '
+  def iso: strftime("%Y-%m-%dT%H:%M:%SZ");
+  ($clock | gmtime | .[3:6] = [0,0,0]) as $end |
+  def ago($n):
+    ($end[0] * 12 + $end[1] - $n) as $month |
+    [($month / 12 | floor), ($month % 12), 1, 0, 0, 0, 0, 0] as $first |
+    if $first[0] < 1 then error("unsupported date range") else
+      ($first | .[1] += 1 | mktime - 86400 | gmtime | .[2]) as $last |
+      $first | .[2] = ([$end[2], $last] | min) | mktime | iso
+    end;
+  [$months, 12] | min as $global |
+  [ago($months), ($end | mktime - 1 | iso), ago($global),
+   ($end | mktime | iso), $global] | @tsv') || die "unsupported --months range"
+IFS=$'\t' read -r repo_from repo_to global_from global_to global_months <<<"$windows"
+failed=0
 for login in "$@"; do
-  profile=$(gh api "users/${login}" --jq '{login,name,created_at,type}')
-  display_login=$(jq -r '.login' <<<"$profile")
-  name=$(jq -r '.name // empty' <<<"$profile")
-  created_at=$(jq -r '.created_at' <<<"$profile")
-  type=$(jq -r '.type' <<<"$profile")
-  created_day=${created_at%%T*}
-
-  kinds=$(thread_kinds "$display_login" "$since_ts")
-  prs=$(count_kind_lines pr "$kinds")
-  issues=$(count_kind_lines issue "$kinds")
-  commits=$(count_commits "$display_login" "$since_ts")
-
-  if [[ -n "$name" ]]; then
-    printf '%s (@%s, %s, account created %s, %s)\n' \
-      "$name" "$display_login" "$type" "$created_day" "$(rough_age "$created_at")"
-  else
-    printf '@%s (%s, account created %s, %s)\n' \
-      "$display_login" "$type" "$created_day" "$(rough_age "$created_at")"
+  [[ "$login" =~ ^[A-Za-z0-9_-]+(\[bot\])?$ ]] || {
+    printf '@%s (invalid login; account age unknown)\n' "$login"
+    failed=1
+    continue
+  }
+  if ! profile=$(gh api "users/${login}" --cache 1h --jq '{login,name,created_at,type}' 2>/dev/null) ||
+     ! display_login=$(jq -er '.login | select(type == "string" and test("^[A-Za-z0-9_-]+(\\[bot\\])?$"))' <<<"$profile" 2>/dev/null); then
+    printf '@%s (profile unavailable; account age unknown)\n' "$login"
+    printf 'Activity unavailable (identity not resolved)\n'
+    failed=1
+    continue
   fi
-  printf '%s last %smo: %s PRs, %s issues, %s commits\n' "$repo" "$months" "$prs" "$issues" "$commits"
-
+  # Identity is useful even if the very next activity request stalls or fails.
+  jq -r --argjson clock "$clock" '
+    (if (.name | type) == "string" and .name != "" then "\(.name) (@\(.login), " else "@\(.login) (" end) as $who |
+    (try (.created_at | fromdateiso8601) catch null) as $created |
+    (if $created == null then "account age unknown" else
+      "account created \(.created_at | split("T")[0]), ~\((($clock - $created) / 86400) | floor)d old" end) as $age |
+    "\($who)\(.type | select(type == "string" and length > 0) // "type unknown"), \($age))"' <<<"$profile"
+  query="repo:${repo} author:${display_login}"
+  prs=$(search_count issues "$query is:pr created:${repo_from}..${repo_to}") || failed=1
+  issues=$(search_count issues "$query is:issue created:${repo_from}..${repo_to}") || failed=1
+  commits=$(search_count commits "$query committer-date:${repo_from}..${repo_to}") || failed=1
+  printf '%s last %smo [%s..%s]: %s PRs, %s issues, %s commits\n' \
+    "$repo" "$months" "$repo_from" "$repo_to" "$prs" "$issues" "$commits"
+  printf 'Repo counts: search index totals, default-branch commits; 1h cache; index/cache may lag. Query bounds are not live as-of timestamps.\n'
   if [[ "$include_global" == "1" ]]; then
-    if global_json=$(global_activity "$display_login" "$since_ts" "$now_ts" 2>/dev/null); then
-      if [[ -n "$global_json" ]]; then
-        global_commits=$(jq -r '.totalCommitContributions' <<<"$global_json")
-        global_issues=$(jq -r '.totalIssueContributions' <<<"$global_json")
-        global_prs=$(jq -r '.totalPullRequestContributions' <<<"$global_json")
-        global_reviews=$(jq -r '.totalPullRequestReviewContributions' <<<"$global_json")
-        printf 'GitHub public last %smo: %s commits, %s PRs, %s issues, %s reviews\n' \
-          "$months" "$global_commits" "$global_prs" "$global_issues" "$global_reviews"
-      else
-        printf 'GitHub public last %smo: unavailable\n' "$months"
-      fi
-    else
-      printf 'GitHub public last %smo: unavailable\n' "$months"
-    fi
+    printf 'GitHub contributions last %smo [%s..%s]' "$global_months" "$global_from" "$global_to"
+    [[ "$global_months" == "$months" ]] || printf ' (capped at one year; requested %smo)' "$months"
+    printf ': '
+    global_activity "$display_login" || failed=1
+    printf 'Contribution graph only; token-visible activity may include private repositories. Zero does not prove inactivity.\n'
   fi
 done
+exit "$failed"

--- a/test/scripts/github-activity-helper.test.ts
+++ b/test/scripts/github-activity-helper.test.ts
@@ -1,96 +1,304 @@
-// Github Activity Helper tests cover github activity helper script behavior.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { closeSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { writeNodeBackedJq } from "./test-helpers.ts";
+import { describe, expect, it } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.ts";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
 const helperPath = path.join(
   repoRoot,
   ".agents/skills/openclaw-pr-maintainer/scripts/github-activity.sh",
 );
-const tempDirs: string[] = [];
+const { createTempDir } = createScriptTestHarness();
 
-afterEach(() => {
-  for (const dir of tempDirs.splice(0)) {
-    rmSync(dir, { recursive: true, force: true });
-  }
-});
+type Fixture = {
+  blockActivity?: boolean;
+  now?: string;
+  profile?: unknown;
+  search?: unknown[];
+  global?: unknown;
+  fail?: string[];
+};
+type Request = { route: string; args: string[]; output: string };
 
-function runHelper(args: string[]) {
-  const dir = mkdtempSync(path.join(tmpdir(), "github-activity-helper-"));
-  tempDirs.push(dir);
+function runHelper(args: string[], fixture: Fixture = {}) {
+  const dir = createTempDir("github-activity-helper-");
   const binDir = path.join(dir, "bin");
   const logPath = path.join(dir, "gh.log");
-  const ghPath = path.join(binDir, "gh");
+  const outputPath = path.join(dir, "stdout");
+  const fixturePath = path.join(dir, "fixture.json");
   mkdirSync(binDir);
-  writeNodeBackedJq(binDir);
+  writeFileSync(logPath, "");
+  writeFileSync(fixturePath, JSON.stringify(fixture));
+  const ghPath = path.join(binDir, "gh");
+  const bypassPath = path.join(binDir, "gh-plain");
+  const epoch = Date.parse(fixture.now ?? "2026-08-26T12:34:56Z") / 1000;
+  writeFileSync(
+    path.join(binDir, "date"),
+    `#!/bin/sh
+if [ "$*" = "-u +%s" ]; then printf '%s\\n' '${epoch}'; else exec /bin/date "$@"; fi
+`,
+    { mode: 0o755 },
+  );
   writeFileSync(
     ghPath,
-    `#!/usr/bin/env bash
+    `#!/bin/bash
 set -euo pipefail
-printf '%s\\t' "$@" >> "$FAKE_GH_LOG"
-printf '\\n' >> "$FAKE_GH_LOG"
-if [[ "$1" == "api" && "$2" == users/* ]]; then
-  printf '{"login":"kevinslin","name":"Kevin Lin","created_at":"2010-09-21T00:00:00Z","type":"User"}\\n'
-  exit 0
+jq -cn --arg route "\${0##*/}" --rawfile output "$OUTPUT" --args \
+  '{route: $route, args: $ARGS.positional, output: $output}' -- "$@" >> "$REQUEST_LOG"
+if body=$(jq -cn --slurpfile fixtures "$FIXTURE" --slurpfile requests "$REQUEST_LOG" --args '
+  $fixtures[0] as $fixture | $ARGS.positional as $args |
+  if any($fixture.fail[]?; . as $needle | any($args[]; contains($needle))) then
+    null | halt_error(1)
+  elif $fixture.blockActivity and $args[0] == "api" and ($args[1] | startswith("users/") | not) then
+    null | halt_error(124)
+  elif $args[0] == "api" and ($args[1] | startswith("users/")) then
+    if $fixture | has("profile") then $fixture.profile else
+      {login: "Canonical", name: "Example Author", created_at: "2010-09-21T00:00:00Z", type: "User"}
+    end
+  elif $args[0] == "api" and ($args[1] | startswith("search/")) then
+    ((([$requests[] | select(.args[1] | startswith("search/"))] | length) - 1) % 3) as $index |
+    if $fixture.search and $index < ($fixture.search | length) then $fixture.search[$index] else
+      {total_count: ([2345, 0, 9876][$index]), incomplete_results: false, items: []}
+    end
+  elif $args[0] == "api" and $args[1] == "graphql" then
+    if $fixture | has("global") then $fixture.global else
+      {data: {user: {contributionsCollection: {
+        totalCommitContributions: 8, totalIssueContributions: 1,
+        totalPullRequestContributions: 3, totalPullRequestReviewContributions: 2
+      }}}}
+    end
+  else null | halt_error(64) end
+' -- "$@" 2>/dev/null); then
+  jq_filter=""
+  previous=""
+  for arg in "$@"; do
+    if [[ "$previous" == "--jq" ]]; then jq_filter="$arg"; fi
+    previous="$arg"
+  done
+  if [[ -n "$jq_filter" ]]; then
+    printf '%s\\n' "$body" | jq -cr "$jq_filter"
+  else
+    printf '%s\\n' "$body"
+  fi
+else
+  response_code=$?
+  # Bound the blocked-scan reproduction without network or a surviving child process.
+  if [[ "$response_code" == 124 ]]; then sleep 0.5; fi
+  exit "$response_code"
 fi
-if [[ "$1" == "api" && "$2" == "--paginate" && "$3" == repos/*/issues* ]]; then
-  printf 'pr\\nissue\\npr\\n'
-  exit 0
-fi
-if [[ "$1" == "api" && "$2" == "--paginate" && "$3" == repos/*/commits* ]]; then
-  printf 'sha-one\\nsha-two\\n'
-  exit 0
-fi
-if [[ "$1" == "api" && "$2" == "graphql" ]]; then
-  printf '{"totalCommitContributions":8,"totalIssueContributions":1,"totalPullRequestContributions":3,"totalPullRequestReviewContributions":2}\\n'
-  exit 0
-fi
-printf 'unexpected gh args: %s\\n' "$*" >&2
-exit 64
 `,
+    { mode: 0o755 },
   );
-  chmodSync(ghPath, 0o755);
-  const result = spawnSync("bash", [helperPath, ...args], {
-    cwd: repoRoot,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      FAKE_GH_LOG: logPath,
-      OPENCLAW_GH_BIN: ghPath,
-      PATH: `${binDir}:${process.env.PATH ?? ""}`,
-    },
-  });
+  writeFileSync(bypassPath, readFileSync(ghPath), { mode: 0o755 });
+  const output = openSync(outputPath, "w");
+  let result;
+  try {
+    result = spawnSync("bash", [helperPath, ...args], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", output, "pipe"],
+      // Only CLI fixtures and command lookup cross this boundary; no live auth/config.
+      env: {
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        HOME: dir,
+        GH_TOKEN: "offline-fixture",
+        OPENCLAW_GH_BIN: bypassPath,
+        FIXTURE: fixturePath,
+        REQUEST_LOG: logPath,
+        OUTPUT: outputPath,
+      },
+    });
+  } finally {
+    closeSync(output);
+  }
   return {
-    log: readFileSync(logPath, "utf8"),
     result,
+    stdout: readFileSync(outputPath, "utf8"),
+    requests: readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as Request),
   };
 }
 
 describe("openclaw-pr-maintainer github activity helper", () => {
-  it("counts PRs and issues from one paginated issues response", () => {
-    const { log, result } = runHelper(["--months", "1", "kevinslin"]);
-
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout).toContain("Kevin Lin (@kevinslin, User, account created 2010-09-21");
-    expect(result.stdout).toContain("openclaw/openclaw last 1mo: 2 PRs, 1 issues, 2 commits");
-    expect(log.match(/repos\/openclaw\/openclaw\/issues/g)).toHaveLength(1);
-    expect(log.match(/repos\/openclaw\/openclaw\/commits/g)).toHaveLength(1);
-    expect(log).toMatch(/since=\d{4}-\d{2}-\d{2}T00:00:00Z/);
+  it("prints canonical identity before the first activity request, even when a scan blocks", () => {
+    const { requests } = runHelper(["alias"], { blockActivity: true });
+    expect(requests[0].args[1]).toBe("users/alias");
+    expect(requests[1].output).toContain(
+      "Example Author (@Canonical, User, account created 2010-09-21",
+    );
   });
 
-  it("uses the hourly global activity window for cacheable GraphQL reads", () => {
-    const { log, result } = runHelper(["--months", "1", "--global", "kevinslin"]);
-
+  it("uses three single-page search aggregates regardless of row count", () => {
+    const { result, stdout, requests } = runHelper(["alias"]);
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain(
-      "GitHub public last 1mo: 8 commits, 3 PRs, 1 issues, 2 reviews",
+    expect(stdout).toContain("2345 PRs, 0 issues, 9876 commits");
+    expect(requests).toHaveLength(4);
+    expect(requests.every((request) => request.route === "gh")).toBe(true);
+    const searches = requests.slice(1).map(({ args }) => {
+      expect(args[0]).toBe("api");
+      expect(args).not.toContain("--paginate");
+      expect(args).not.toContain("-f");
+      expect(args).not.toContain("-F");
+      const url = new URL(args[1], "https://api.github.test/");
+      expect(url.searchParams.get("per_page")).toBe("1");
+      expect(url.searchParams.get("q")).toContain("repo:openclaw/openclaw author:Canonical");
+      return url;
+    });
+    expect(searches.map((url) => url.pathname)).toEqual([
+      "/search/issues",
+      "/search/issues",
+      "/search/commits",
+    ]);
+    expect(searches[0].searchParams.get("q")).toContain("is:pr");
+    expect(searches[1].searchParams.get("q")).toContain("is:issue");
+    expect(searches[2].searchParams.get("q")).toContain("committer-date:");
+    expect(stdout).toContain("index/cache may lag");
+  });
+
+  it("distinguishes incomplete, missing, and failed searches from a valid zero", () => {
+    const { result, stdout, requests } = runHelper(["alias"], {
+      search: [{ total_count: 7, incomplete_results: true }, {}, {}],
+      fail: ["search/commits"],
+    });
+    expect(result.status).toBe(1);
+    expect(requests).toHaveLength(4);
+    expect(stdout).toContain("incomplete (reported 7) PRs");
+    expect(stdout).toContain("unavailable (invalid response) issues");
+    expect(stdout).toContain("unavailable (request failed) commits");
+    expect(stdout).not.toContain("0 commits");
+  });
+
+  it.each([
+    null,
+    { total_count: -1, incomplete_results: false },
+    { total_count: 0 },
+    { total_count: "0", incomplete_results: false },
+  ])("rejects malformed aggregate %j", (bad) => {
+    const { result, stdout } = runHelper(["alias"], { search: [bad, bad, bad] });
+    expect(result.status).toBe(1);
+    expect(stdout).toContain("unavailable (invalid response)");
+  });
+
+  it("keeps a longer repo window separate from the capped global window", () => {
+    const { result, stdout, requests } = runHelper(["--months", "24", "--global", "alias"]);
+    expect(result.status).toBe(0);
+    expect(requests).toHaveLength(5);
+    expect(requests.map(({ args }) => args[args.indexOf("--cache") + 1])).toEqual(
+      Array(5).fill("1h"),
     );
-    expect(log.match(/api\tgraphql/g)).toHaveLength(1);
-    expect(log).toMatch(/to=\d{4}-\d{2}-\d{2}T\d{2}:00:00Z/);
+    const repoQuery =
+      new URL(requests[1].args[1], "https://api.github.test").searchParams.get("q") ?? "";
+    const repoRange = /created:([^ ]+)\.\.([^ ]+)/.exec(repoQuery);
+    expect(repoRange).not.toBeNull();
+    const graphql = requests[4].args;
+    const from = graphql.find((arg) => arg.startsWith("from="))?.slice(5) ?? "";
+    const to = graphql.find((arg) => arg.startsWith("to="))?.slice(3) ?? "";
+    expect(repoRange?.slice(1)).toEqual(["2024-08-26T00:00:00Z", "2026-08-25T23:59:59Z"]);
+    expect(from).toBe("2025-08-26T00:00:00Z");
+    expect(to).toBe("2026-08-26T00:00:00Z");
+    expect(Date.parse(to) - Date.parse(from)).toBeLessThanOrEqual(366 * 86400000);
+    expect(stdout).toContain("GitHub contributions last 12mo");
+    expect(stdout).toContain("requested 24mo");
+    expect(stdout).toContain("8 commits, 3 PRs, 1 issues, 2 reviews");
+    expect(stdout).not.toContain("GitHub public");
+  });
+
+  it.each([
+    { data: { user: null } },
+    {
+      data: {
+        user: {
+          contributionsCollection: {
+            totalCommitContributions: "0",
+            totalIssueContributions: 0,
+            totalPullRequestContributions: 0,
+            totalPullRequestReviewContributions: 0,
+          },
+        },
+      },
+    },
+    { data: { user: { contributionsCollection: {} } } },
+    { errors: [{ message: "unavailable" }], data: { user: null } },
+  ])("does not turn unavailable contributions into zero: %j", (global) => {
+    const { result, stdout, requests } = runHelper(["--global", "alias"], { global });
+    expect(result.status).toBe(1);
+    expect(requests).toHaveLength(5);
+    expect(stdout).toMatch(/GitHub contributions.*unavailable/);
+    expect(stdout).not.toContain("0 reviews");
+  });
+
+  it("continues other logins after profile failure without activity for the unknown identity", () => {
+    const { result, stdout, requests } = runHelper(["missing", "alias"], {
+      fail: ["users/missing"],
+    });
+    expect(result.status).toBe(1);
+    expect(stdout).toContain("@missing (profile unavailable; account age unknown)");
+    expect(stdout).toContain("Example Author (@Canonical");
+    expect(requests).toHaveLength(5);
+    expect(requests[1].args[1]).toBe("users/alias");
+  });
+  it("continues later logins after a failed global request without falling back to scans", () => {
+    const { result, stdout, requests } = runHelper(["--global", "first", "second"], {
+      fail: ["graphql"],
+    });
+    expect(result.status).toBe(1);
+    expect(requests).toHaveLength(10);
+    expect(stdout.match(/unavailable \(request failed\)/g)).toHaveLength(2);
+    expect(requests[5].args[1]).toBe("users/second");
+  });
+
+  it("keeps valid contribution zeroes without inferring inactivity or scanning other endpoints", () => {
+    const { result, stdout, requests } = runHelper(["--global", "alias"], {
+      global: {
+        data: {
+          user: {
+            contributionsCollection: {
+              totalCommitContributions: 0,
+              totalIssueContributions: 0,
+              totalPullRequestContributions: 0,
+              totalPullRequestReviewContributions: 0,
+            },
+          },
+        },
+      },
+    });
+    expect(result.status).toBe(0);
+    expect(requests).toHaveLength(5);
+    expect(stdout).toContain("0 commits, 0 PRs, 0 issues, 0 reviews");
+    expect(stdout).toContain("Zero does not prove inactivity");
+  });
+
+  it.each([null, {}, { login: null }])("skips activity for malformed identity %j", (profile) => {
+    const { result, stdout, requests } = runHelper(["alias"], { profile });
+    expect(result.status).toBe(1);
+    expect(requests).toHaveLength(1);
+    expect(stdout).toContain("account age unknown");
+  });
+
+  it("preserves a nameless bot profile with an unknown creation date", () => {
+    const { result, stdout } = runHelper(["alias"], {
+      profile: { login: "helper[bot]", name: null, created_at: "invalid", type: "Bot" },
+    });
+    expect(result.status).toBe(0);
+    expect(stdout).toContain("@helper[bot] (Bot, account age unknown)");
+  });
+
+  it.each([
+    ["2024-03-31T15:00:00Z", "1", "2024-02-29T00:00:00Z"],
+    ["2024-02-29T15:00:00Z", "12", "2023-02-28T00:00:00Z"],
+    ["2025-03-31T15:00:00Z", "1", "2025-02-28T00:00:00Z"],
+  ])("bounds calendar subtraction at month ends: %s", (now, months, from) => {
+    const { result, requests } = runHelper(["--months", months, "--global", "alias"], { now });
+    expect(result.status).toBe(0);
+    const query = new URL(requests[1].args[1], "https://api.github.test").searchParams.get("q");
+    expect(query).toContain(`created:${from}..`);
+    expect(requests[4].args).toContain(`from=${from}`);
+    const to = requests[4].args.find((arg) => arg.startsWith("to="))?.slice(3) ?? "";
+    expect(Date.parse(to) - Date.parse(from)).toBeLessThanOrEqual(366 * 86400000);
   });
 });

--- a/test/scripts/github-activity-helper.test.ts
+++ b/test/scripts/github-activity-helper.test.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { closeSync, mkdirSync, openSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
@@ -20,6 +21,12 @@ type Fixture = {
   fail?: string[];
 };
 type Request = { route: string; args: string[]; output: string };
+
+function requiredAt<T>(items: T[], index: number): T {
+  const item = items[index];
+  assert(item !== undefined, `Missing fixture item at index ${index}`);
+  return item;
+}
 
 function runHelper(args: string[], fixture: Fixture = {}) {
   const dir = createTempDir("github-activity-helper-");
@@ -127,8 +134,8 @@ fi
 describe("openclaw-pr-maintainer github activity helper", () => {
   it("prints canonical identity before the first activity request, even when a scan blocks", () => {
     const { requests } = runHelper(["alias"], { blockActivity: true });
-    expect(requests[0].args[1]).toBe("users/alias");
-    expect(requests[1].output).toContain(
+    expect(requiredAt(requests, 0).args[1]).toBe("users/alias");
+    expect(requiredAt(requests, 1).output).toContain(
       "Example Author (@Canonical, User, account created 2010-09-21",
     );
   });
@@ -144,7 +151,7 @@ describe("openclaw-pr-maintainer github activity helper", () => {
       expect(args).not.toContain("--paginate");
       expect(args).not.toContain("-f");
       expect(args).not.toContain("-F");
-      const url = new URL(args[1], "https://api.github.test/");
+      const url = new URL(requiredAt(args, 1), "https://api.github.test/");
       expect(url.searchParams.get("per_page")).toBe("1");
       expect(url.searchParams.get("q")).toContain("repo:openclaw/openclaw author:Canonical");
       return url;
@@ -154,9 +161,9 @@ describe("openclaw-pr-maintainer github activity helper", () => {
       "/search/issues",
       "/search/commits",
     ]);
-    expect(searches[0].searchParams.get("q")).toContain("is:pr");
-    expect(searches[1].searchParams.get("q")).toContain("is:issue");
-    expect(searches[2].searchParams.get("q")).toContain("committer-date:");
+    expect(requiredAt(searches, 0).searchParams.get("q")).toContain("is:pr");
+    expect(requiredAt(searches, 1).searchParams.get("q")).toContain("is:issue");
+    expect(requiredAt(searches, 2).searchParams.get("q")).toContain("committer-date:");
     expect(stdout).toContain("index/cache may lag");
   });
 
@@ -191,11 +198,12 @@ describe("openclaw-pr-maintainer github activity helper", () => {
     expect(requests.map(({ args }) => args[args.indexOf("--cache") + 1])).toEqual(
       Array(5).fill("1h"),
     );
+    const repoArgs = requiredAt(requests, 1).args;
     const repoQuery =
-      new URL(requests[1].args[1], "https://api.github.test").searchParams.get("q") ?? "";
+      new URL(requiredAt(repoArgs, 1), "https://api.github.test").searchParams.get("q") ?? "";
     const repoRange = /created:([^ ]+)\.\.([^ ]+)/.exec(repoQuery);
     expect(repoRange).not.toBeNull();
-    const graphql = requests[4].args;
+    const graphql = requiredAt(requests, 4).args;
     const from = graphql.find((arg) => arg.startsWith("from="))?.slice(5) ?? "";
     const to = graphql.find((arg) => arg.startsWith("to="))?.slice(3) ?? "";
     expect(repoRange?.slice(1)).toEqual(["2024-08-26T00:00:00Z", "2026-08-25T23:59:59Z"]);
@@ -240,7 +248,7 @@ describe("openclaw-pr-maintainer github activity helper", () => {
     expect(stdout).toContain("@missing (profile unavailable; account age unknown)");
     expect(stdout).toContain("Example Author (@Canonical");
     expect(requests).toHaveLength(5);
-    expect(requests[1].args[1]).toBe("users/alias");
+    expect(requiredAt(requests, 1).args[1]).toBe("users/alias");
   });
   it("continues later logins after a failed global request without falling back to scans", () => {
     const { result, stdout, requests } = runHelper(["--global", "first", "second"], {
@@ -249,7 +257,7 @@ describe("openclaw-pr-maintainer github activity helper", () => {
     expect(result.status).toBe(1);
     expect(requests).toHaveLength(10);
     expect(stdout.match(/unavailable \(request failed\)/g)).toHaveLength(2);
-    expect(requests[5].args[1]).toBe("users/second");
+    expect(requiredAt(requests, 5).args[1]).toBe("users/second");
   });
 
   it("keeps valid contribution zeroes without inferring inactivity or scanning other endpoints", () => {
@@ -295,10 +303,12 @@ describe("openclaw-pr-maintainer github activity helper", () => {
   ])("bounds calendar subtraction at month ends: %s", (now, months, from) => {
     const { result, requests } = runHelper(["--months", months, "--global", "alias"], { now });
     expect(result.status).toBe(0);
-    const query = new URL(requests[1].args[1], "https://api.github.test").searchParams.get("q");
+    const repoArgs = requiredAt(requests, 1).args;
+    const query = new URL(requiredAt(repoArgs, 1), "https://api.github.test").searchParams.get("q");
     expect(query).toContain(`created:${from}..`);
-    expect(requests[4].args).toContain(`from=${from}`);
-    const to = requests[4].args.find((arg) => arg.startsWith("to="))?.slice(3) ?? "";
+    const graphql = requiredAt(requests, 4).args;
+    expect(graphql).toContain(`from=${from}`);
+    const to = graphql.find((arg) => arg.startsWith("to="))?.slice(3) ?? "";
     expect(Date.parse(to) - Date.parse(from)).toBeLessThanOrEqual(366 * 86400000);
   });
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where maintainer author-activity lookups could remain silent for several minutes for prolific GitHub accounts. The helper downloaded every matching issue/PR and commit for the requested window before showing even the person's profile, consuming quota merely to count records.

This is a maintainer-tooling fix, separate from any people-card or frontend work. Ownership was checked: OpenClaw owns this skill; it is not a generated copy from `openclaw/agent-skills`.

## Why This Change Was Made

Print canonical profile identity before activity requests, and replace the two paginated scans with three single-page search aggregates using `total_count` and `incomplete_results`. The optional global lane remains one contribution-graph aggregate, giving a fixed maximum of five helper-level `gh` calls per resolved login regardless of activity volume.

Keep ordinary PATH `gh` dispatch and use its existing `--cache 1h` support. A bounded live probe confirmed that the fleet cache delegates author/date-filtered searches; native GitHub CLI caching covers both those REST reads and GraphQL without adding a custom cache. Local archive freshness did not establish complete annual coverage, so archive rows are not presented as complete totals. The shared plain-gh helper is unchanged because its mutation-oriented callers have a different responsibility.

## User Impact

Maintainers see identity promptly and get fast, repeatable activity summaries. Missing profiles, failed or malformed responses, and incomplete searches are labeled rather than becoming misleading zero counts. Later logins still run, and unavailable/incomplete requested data produces a nonzero exit.

The helper prints separate repo/global intervals covering completed UTC days. Repo commits are default-branch search results filtered by committer date; longer requested repo windows retain an explicitly labeled 12-month cap for the global contribution API. Search indexing and the one-hour cache may lag, and contribution totals follow token visibility rather than claiming to be public-only or proving inactivity.

No frontend, runtime product, configuration, dependency, or storage-schema changes. AI-assisted implementation and review.

## Evidence

- Safe before/after reproduction used fake CLI responses, no live pagination: the original helper's stdout was empty when its first activity scan blocked. The regression fails before the fix and passes afterward.
- Live `--global steipete` flow: profile at **0.841s**, full result at **8.494s**; cached repeat completed in **1.450s** with profile at **0.396s**. A proof wrapper enforced a five-call budget and refused pagination; both runs exited 0.
- A bounded live REST search returned a total above 11,000 while fetching one item. Cached repeat probes preserved GitHub response request IDs, dates, and quota headers. No unbounded GitHub scans were run.
- Live contribution API checks rejected a two-year interval and accepted the tested 366-day leap-year intervals.
- `node scripts/run-vitest.mjs test/scripts/github-activity-helper.test.ts test/scripts/plain-gh.test.ts test/scripts/gh-read.test.ts` — **47/47 passed**. The new CLI fixture was simplified to Bash/jq after a loaded-host Node-startup timeout; the existing 5000ms deadline and assertions were not relaxed.
- `bash -n .agents/skills/openclaw-pr-maintainer/scripts/github-activity.sh` — passed.
- `shellcheck .agents/skills/openclaw-pr-maintainer/scripts/github-activity.sh` — passed.
- `node_modules/.bin/oxfmt --check .agents/skills/openclaw-pr-maintainer/SKILL.md test/scripts/github-activity-helper.test.ts` — passed.
- Initial [CI run 33042972095](https://github.com/openclaw/openclaw/actions/runs/33042972095) found unchecked test-fixture array access in `check-test-types`. The fixture now asserts required entries before use; no production behavior, timeout, or behavioral assertion was changed. The root test typecheck (`node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.root.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-root.tsbuildinfo`) and the same 47-test group pass after repair.
- `git diff --check` — passed. The `.claude/skills` symlink resolves to the same canonical `.agents/skills` files; no mirror sync is required.
- Validation limit: the broad local changed-file checker classified this hidden skill script as all lanes and was deliberately stopped during an unrelated whole-repository database-first guard (exit 143). That run is not claimed as passing; focused proof above covers the changed helper and sibling dispatcher boundaries.

Production tooling: **+98/-133 (net -35)**. Tests/test support: **+280/-62 (net +218)**. Skill guidance: **+7/-7**.
