### PR TITLE
fix: doctor skips per-agent legacy model refs

### DIFF
--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -1488,6 +1488,65 @@ describe("normalizeCompatibilityConfigValues", () => {
     });
   });
 
+  it("migrates legacy Claude CLI refs in agent entries", () => {
+    const res = normalizeCompatibilityConfigValues(
+      legacyConfig({
+        agents: {
+          entries: {
+            main: {
+              description: "Primary agent",
+              model: {
+                primary: "claude-cli/claude-opus-4-7",
+                fallbacks: ["claude-cli/claude-sonnet-4-6", "openai/gpt-5.5"],
+              },
+              models: {
+                "claude-cli/claude-opus-4-7": { alias: "Legacy Opus" },
+                "anthropic/claude-opus-4-7": {
+                  alias: "Canonical Opus",
+                  agentRuntime: { id: "openclaw" },
+                },
+                "claude-cli/claude-sonnet-4-6": { alias: "Sonnet" },
+              },
+              modelPolicy: {
+                allow: ["claude-cli/claude-opus-4-7", "claude-cli/claude-sonnet-4-6"],
+              },
+            },
+            worker: { model: "openai/gpt-5.5" },
+          },
+        },
+      }),
+    );
+
+    expect(res.config.agents?.entries).toStrictEqual({
+      main: {
+        description: "Primary agent",
+        model: {
+          primary: "anthropic/claude-opus-4-7",
+          fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-5.5"],
+        },
+        models: {
+          "anthropic/claude-opus-4-7": {
+            alias: "Canonical Opus",
+            agentRuntime: { id: "openclaw" },
+          },
+          "anthropic/claude-sonnet-4-6": {
+            alias: "Sonnet",
+            agentRuntime: { id: "claude-cli" },
+          },
+        },
+        modelPolicy: {
+          allow: ["anthropic/claude-opus-4-7", "anthropic/claude-sonnet-4-6"],
+        },
+      },
+      worker: { model: "openai/gpt-5.5" },
+    });
+    expect(res.changes).toEqual([
+      "Moved agents.entries.main.model legacy runtime primary refs to canonical provider refs and selected claude-cli runtime.",
+      "Moved agents.entries.main.models legacy runtime keys to canonical provider keys.",
+      "Moved agents.entries.main.modelPolicy.allow legacy runtime refs to canonical provider refs.",
+    ]);
+  });
+
   it("migrates legacy Claude CLI model maps and allowlists when the primary is canonical", () => {
     const res = normalizeCompatibilityConfigValues(
       legacyConfig({

--- a/src/commands/doctor/shared/legacy-config-core-normalizers.ts
+++ b/src/commands/doctor/shared/legacy-config-core-normalizers.ts
@@ -765,6 +765,28 @@ export function normalizeLegacyRuntimeModelRefs(
     }
   }
 
+  if (isRecord(rawAgents.entries)) {
+    let nextEntries: Record<string, unknown> | undefined;
+    for (const [agentId, entry] of Object.entries(rawAgents.entries)) {
+      if (!isRecord(entry)) {
+        continue;
+      }
+      const agent = normalizeLegacyRuntimeAgentContainer(
+        entry,
+        `agents.entries.${sanitizeForLog(agentId)}`,
+        changes,
+        blockedModelIdentities,
+      );
+      if (agent.changed) {
+        (nextEntries ??= { ...rawAgents.entries })[agentId] = agent.value;
+      }
+    }
+    if (nextEntries) {
+      nextAgents.entries = nextEntries;
+      changed = true;
+    }
+  }
+
   const nextCfg = changed
     ? {
         ...cfgWithProviders,


### PR DESCRIPTION
Related: #130671

AI-assisted with OpenAI Codex. I understand the change and reviewed the final diff. Two direct adversarial Codex review passes were run; the one test-proof finding was fixed, and the confirmation review returned clean. [Review session log](https://gist.github.com/Marvinthebored/e024a74aa5acf25364aee43c88117ec6).

## What Problem This Solves

Fixes an issue where users who run `openclaw doctor --fix` with legacy runtime-encoded model references under `agents.entries.*` would keep those per-agent references unchanged, even though the same references under global defaults and legacy agent lists were repaired.

This could leave one multi-agent config with mixed legacy `claude-cli/*` and canonical `anthropic/*` references.

## Why This Change Was Made

The existing Doctor normalizer already owns whole-config legacy model-reference cleanup. This change routes canonical `agents.entries` through that same agent-container normalizer, without adding new migration semantics or changing Anthropic auth login.

ClawSweeper applied `clawsweeper:no-new-fix-pr` because widening auth login's model-config write into explicit per-agent overrides required a product decision. This PR follows ClawSweeper's recommended boundary instead: credential storage remains agent-scoped, the optional model-config write remains limited to global defaults, and Doctor completes the cleanup across the canonical agent roster.

## User Impact

`openclaw doctor --fix` now canonicalizes matching per-agent model selections, model-map keys, and allowlist references. It preserves unrelated agents and fields, canonical-key collision metadata, and explicit runtime choices.

## Evidence

- Actual Doctor behavior was verified with a secret-free, schema-valid two-agent config (`agents.ownership: "explicit"`). The command was run with both `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR` pointed at a disposable directory:

  ```shell
  node scripts/run-node.mjs config validate
  # Config valid: <temp>/openclaw.json

  node scripts/run-node.mjs doctor --fix --yes --force --non-interactive --no-workspace-suggestions
  # Doctor complete. (exit 0)
  ```

  Redacted relevant state before:

  ```json
  {
    "main": {
      "model": { "primary": "claude-cli/claude-opus-5", "fallbacks": ["openai/gpt-5.5"] },
      "models": { "claude-cli/claude-opus-5": { "alias": "Opus" } },
      "modelPolicy": { "allow": ["claude-cli/claude-opus-5", "openai/gpt-5.5"] }
    },
    "fastbot": { "model": { "primary": "openai/gpt-5.5", "fallbacks": [] } }
  }
  ```

  Redacted relevant state after:

  ```json
  {
    "main": {
      "model": { "primary": "anthropic/claude-opus-5", "fallbacks": ["openai/gpt-5.5"] },
      "models": {
        "anthropic/claude-opus-5": {
          "alias": "Opus",
          "agentRuntime": { "id": "claude-cli" }
        }
      },
      "modelPolicy": { "allow": ["anthropic/claude-opus-5", "openai/gpt-5.5"] }
    },
    "fastbot": { "model": { "primary": "openai/gpt-5.5", "fallbacks": [] } }
  }
  ```

  Doctor reported all three repairs:

  ```text
  Moved agents.entries.main.model legacy runtime primary refs to canonical provider refs and selected claude-cli runtime.
  Moved agents.entries.main.models legacy runtime keys to canonical provider keys.
  Moved agents.entries.main.modelPolicy.allow legacy runtime refs to canonical provider refs.
  ```

- Stock regression proof on current `origin/main`: checking out the stock normalizer and running the focused test failed with the per-agent `claude-cli/*` selections, keys, and allowlist entries still present (`1 failed`, `81 skipped`).
- Patched focused test: `1 passed`, `81 skipped`.
- Full migration test file: `82 passed`.
- Exact-head local ClawSweeper review at `f4d139f66671`: patch correct; 0 findings; security cleared; no maintainer decision; 0 Rank-up moves.
- Telegram collateral at the exact CI merge for `f4d139f66671`: a recorded default direct message returned `OPENCLAW_E2E_BASIC` with one provider request. This Doctor change is not Telegram-visible, so the Doctor CLI proof above is authoritative.
- `node scripts/check-changed.mjs -- src/commands/doctor-legacy-config.migrations.test.ts src/commands/doctor/shared/legacy-config-core-normalizers.ts` passed all selected gates, including formatting, dead-code scans, type checks, lint, import cycles, and Doctor registry checks.
- Two direct adversarial Codex passes covered migration ownership, roster coexistence, malformed entries, canonical collisions, explicit runtimes, unrelated-field preservation, and strict absence assertions. One finding changed the regression assertion from `toEqual` to `toStrictEqual`; the confirmation review returned clean.
- Diff size: 22 production lines and 59 test lines across two files. No dependency or changelog changes.
- The operator's live config and state were not used. The proof ran the actual Doctor CLI against an isolated fixture and disposable state directory, so no production config, credentials, paths, or services were touched.


