### PR TITLE
fix(portals): event streams stall before the first event

### DIFF
--- a/docs/gateway/portals.md
+++ b/docs/gateway/portals.md
@@ -59,6 +59,8 @@ The server can listen on IPv4 or IPv6 loopback (`127.0.0.1` or `::1`), both on t
 
 The proxy rewrites `Host` to the local target, so typical development servers such as Vite and Next.js need no additional configuration. WebSockets and hot module replacement are proxied through the same portal.
 
+Streaming HTTP responses, including server-sent events, forward response headers without waiting for the first body chunk.
+
 ## Availability and configuration
 
 Portals add no dedicated configuration key. The `portal` tool follows ordinary tool policy, described in [Tools configuration](/gateway/config-tools).

--- a/src/gateway/portals/portal-http-proxy.test.ts
+++ b/src/gateway/portals/portal-http-proxy.test.ts
@@ -648,6 +648,88 @@ describe("portal HTTP proxy", () => {
     }
   });
 
+  it.each([
+    ["direct", "complete"],
+    ["local", "complete"],
+    ["worker", "complete"],
+    ["direct", "abort"],
+    ["local", "abort"],
+    ["worker", "abort"],
+  ] as const)(
+    "delivers %s response headers before the first body chunk and handles %s",
+    async (kind, completion) => {
+      let appResponse: ServerResponse | undefined;
+      targetHandler = (req, res) => {
+        if (req.url === "/events") {
+          appResponse = res;
+          res.setHeader("Content-Type", "text/event-stream");
+          res.setHeader("X-App", "header-first");
+          res.flushHeaders();
+          return;
+        }
+        if (req.url === "/start" && req.method === "POST" && appResponse) {
+          res.writeHead(204).end();
+          if (completion === "complete") {
+            appResponse.end("data: started\n\n");
+          } else {
+            appResponse.destroy();
+          }
+          return;
+        }
+        res.writeHead(404).end();
+      };
+      const portal =
+        kind === "direct"
+          ? undefined
+          : await portalService().open({
+              targetPort,
+              ...(kind === "worker"
+                ? { target: workerTarget(async () => createWorkerStream(targetPort), targetPort) }
+                : {}),
+            });
+      const connection = {
+        host: "127.0.0.1",
+        port: portal?.listenPort ?? targetPort,
+        ...(portal ? { headers: { Cookie: portalAuthCookie(portal) } } : {}),
+      };
+      const browserRequest = request({
+        ...connection,
+        path: "/events",
+        signal: AbortSignal.timeout(3_000),
+      });
+      const responseHeaders = new Promise<IncomingMessage>((resolve, reject) => {
+        browserRequest.once("response", resolve);
+        browserRequest.once("error", reject);
+      });
+      browserRequest.end();
+      try {
+        // An idle event stream opens before the client asks the app to produce data.
+        const browserResponse = await responseHeaders;
+        expect(browserResponse.statusCode).toBe(200);
+        expect(browserResponse.headers["content-type"]).toBe("text/event-stream");
+        expect(browserResponse.headers["x-app"]).toBe("header-first");
+        const chunks: Buffer[] = [];
+        const responseClosed = new Promise<void>((resolve) => {
+          browserResponse.on("data", (chunk: Buffer) => chunks.push(chunk));
+          browserResponse.on("error", () => undefined);
+          browserResponse.once("close", resolve);
+        });
+        expect(await httpCall({ ...connection, path: "/start", method: "POST" })).toMatchObject({
+          status: 204,
+        });
+        await responseClosed;
+        expect(browserResponse.statusCode).toBe(200);
+        expect(browserResponse.complete).toBe(completion === "complete");
+        expect(Buffer.concat(chunks).toString("utf8")).toBe(
+          completion === "complete" ? "data: started\n\n" : "",
+        );
+      } finally {
+        browserRequest.destroy();
+        appResponse?.destroy();
+      }
+    },
+  );
+
   it.each(["rejected", "closed", "reset"] as const)(
     "shows the worker retry page for HTTP and upgrades when its node stream is %s",
     async (streamState) => {

--- a/src/gateway/portals/portal-http-proxy.ts
+++ b/src/gateway/portals/portal-http-proxy.ts
@@ -319,6 +319,9 @@ export function handlePortalProxyRequest(params: {
         res.setHeader("Referrer-Policy", PORTAL_REFERRER_POLICY);
         res.statusCode = proxyRes.statusCode ?? 502;
         proxyRes.once("error", () => res.destroy());
+        // Streaming apps may wait for the client's open event before producing data.
+        // Preserve the upstream header boundary instead of waiting for the first chunk.
+        res.flushHeaders();
         proxyRes.pipe(res);
       });
       proxyReq.once("error", () => {


### PR DESCRIPTION
Closes #130726

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users opening event-stream applications through a portal would wait for the connection to open until the application published its first event. A client that waits for response headers before requesting work could not complete that handshake, even though direct access to the same application worked.

## Why This Change Was Made

The shared portal HTTP proxy now forwards the upstream response-header boundary immediately after copying and rewriting headers, before piping body data. This applies to both local and worker targets without an SSE-specific branch; existing cookie, referrer, hop-by-hop header, and disconnect handling stays unchanged.

Production LOC: **+3/-0**, consisting of one necessary `flushHeaders()` call and a two-line invariant comment; tests **+82/-0**; docs **+2/-0**. Node otherwise buffers headers until the first body write or end, so piping alone cannot preserve an idle stream's header boundary. Moving this into the application, injecting heartbeat data, or special-casing SSE would leave the proxy's generic transport contract incomplete; no new helper, fallback, config option, protocol shape, or persistence path is needed.

Provenance: the original path was introduced in #122536, authored and merged by @steipete on August 13, 2026, and carried forward by the worker-portal change #130105, also authored and merged by @steipete on August 26. Source history identifies `cc2fc55f9b480b16ca2ba5d06dacf0c97cf2d587` as the original implementation; a first affected stable release has not been established.

## User Impact

Portal clients can establish an event stream before the application publishes its first event. A stream that subsequently fails still closes as an incomplete response instead of being replaced with a waiting page. The documented application contract now explicitly includes header-first streaming.

## Evidence

- **Native RED before production edits:** the complete portal HTTP suite had 23 passing tests and four failures, exactly the local/worker header-first completion and abort cases. Both direct-server controls and all existing tests passed.
- **Native GREEN:** `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/portals/portal-http-proxy.test.ts src/gateway/portals/portal-service.test.ts src/gateway/server-methods/portals.test.ts` passed all **48 tests**, including the original-order stream-disconnect cases, local/worker targets, service lifecycle, and RPC siblings. Independent verification also passed all 48.
- **Real Gateway RED:** a built Gateway opened the portal through its public `portal.open` API. The direct application completed headers → start request → exact event; the portal request timed out before headers. That baseline build was `8dac217ce94e14a67ad2fc65837e518a2fbe0669`, with verified source identity for the four affected Gateway owners against audited main `fb0e5bd6bb79f88153938ac573f7bd810303ffd1`, not an exact-head full-runtime claim.
- **Candidate-built Gateway GREEN:** the canonical CLI-startup build passed all seven phases. The runtime built from audited main plus this patch passed nine behavioral checks through actual Gateway `portal.open`/`portal.close` calls: a direct control, two fresh portal streams with distinct text and headers observed before publication, upstream abort retaining status 200 with an incomplete/reset transport, client cancellation observed by the application, finite GET/HEAD/POST/204 responses including multibyte content length, WebSocket echo, the unavailable-application 502 waiting page, and listener closure.
- **Local changed gate:** all 28 selected phases passed. The first attempt exposed a missing ignored UI dependency link that resolved `pako` from the root install instead of the UI's pinned package. Linking the matching UI donor corrected the validation environment; no source, dependency pin, type waiver, or gate was changed.
- **Review:** complete-patch Codex review and independent source challenge found no actionable findings. Formatting and `git diff --check` passed.
- **Source-blind validation:** a fresh validator exercised only the documented disposable Gateway/API fixture and reported **six checks passed, zero failed, and one blocked** (real worker node unavailable), with no accepted behavioral findings. Eight probes independently covered fresh header/start/event sequences, upstream abort, client cancellation, varied finite GET/HEAD/POST/204 traffic, WebSocket echoes, waiting response, and owned portal-listener closure. The complete runtime was subsequently shut down; all owned PIDs, ports, and temporary state were verified removed.
- **Pending before landing:** exact PR-head hosted CI.

The native worker cases use the repository's paired-duplex transport fixture, not a real enrolled cloud worker. The disposable full-Gateway runtime supports local portals only, so live worker-node validation remains unavailable and must not be reported as passing. No provider, live-channel, auth-policy, or storage behavior is claimed by this proof.
