### PR TITLE
fix(cloud-workers): build complete source runtime artifacts

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -184,11 +184,32 @@ openclaw config set cloudWorkers.profiles.aws.settings.setup \
   "${existing_setup}; sudo npm install -g openclaw@${gateway_version}; openclaw plugins install npm:@openclaw/codex@${gateway_version} --pin --force"
 ```
 
-`--force` allows setup replay to converge when the plugin is already installed. After upgrading the Gateway, update both appended package versions to match it while preserving the rest of the setup. Unreleased source builds require exact locally packed packages instead of registry versions.
+`--force` allows setup replay to converge when the plugin is already installed. After upgrading the Gateway, update both appended package versions to match it while preserving the rest of the setup. This recipe requires both exact versions to exist in the registry. For unreleased source builds, use a complete custom node package as described below; a standalone local plugin tarball does not carry official npm provenance.
+
+### Build a complete custom node package
+
+For a trusted source build, produce the node distribution from the same source revision as the Gateway. The canonical package builder can explicitly include source-owned plugins that the ordinary core package excludes:
+
+```bash
+source_sha="$(git rev-parse HEAD)"
+node scripts/package-openclaw-for-docker.mjs \
+  --bundle-plugin codex \
+  --pnpm-pack \
+  --allow-unreleased-changelog \
+  --output-dir .artifacts/cloud-node \
+  --output-name "openclaw-cloud-${source_sha}.tgz"
+shasum -a 256 ".artifacts/cloud-node/openclaw-cloud-${source_sha}.tgz"
+```
+
+Run this in a clean, trusted checkout with dependencies installed. The builder compiles the runtime, includes the selected plugin's built entrypoints and import closure, and regenerates the installation inventory. It temporarily adds the plugin's exact runtime dependency pins to the distribution manifest, rejecting conflicting or unpinned dependencies, then restores the source manifest and inventory. Repeat `--bundle-plugin <id>` for additional source plugins. Without that option, the ordinary core package and external plugin publication contracts are unchanged.
+
+Publish the resulting archive through your existing immutable artifact delivery path and make `settings.setup` verify its SHA-256 before installing it globally with normal npm lifecycle scripts enabled. Record both source SHA and archive digest: different unreleased builds can share a version. Do not copy a plugin into an installed release or substitute a standalone `npm-pack:` plugin archive for this distribution.
+
+Native dependencies are declared at the distribution root and installed for the target operating system and CPU; the archive does not copy the build host's plugin `node_modules`. Target installation still needs registry access and is not an offline dependency bundle. Verify each target architecture you deploy. Use `--skip-build` only when reusing a complete build from that same source revision with all selected plugin outputs present.
 
 ### Bundle installation
 
-The setup bootstrap first reuses an installed `openclaw` binary when its version exactly matches the Gateway, then tries the exact `openclaw@<version>` registry package. For an unreleased source build, install a locally packed candidate with the same version in `settings.setup`; the provider will select it before touching the registry. After the node connects and publishes its session-host inventory, the Gateway pushes one content-addressed worker bundle through the paired channel. The node verifies and publishes those exact bytes without installing the normal OpenClaw package dependency tree. A stale Gateway build retires the environment and reprovisions against the current bundle rather than downgrading the execution-context protocol.
+The setup bootstrap first reuses an installed `openclaw` binary when its version exactly matches the Gateway, then tries the exact `openclaw@<version>` registry package. For an unreleased source build, install the matching [complete custom node package](/gateway/cloud-workers#build-a-complete-custom-node-package) in `settings.setup`; the provider will select it before touching the registry. After the node connects and publishes its session-host inventory, the Gateway pushes one content-addressed worker bundle through the paired channel. The node verifies and publishes those exact bytes without installing the normal OpenClaw package dependency tree. A stale Gateway build retires the environment and reprovisions against the current bundle rather than downgrading the execution-context protocol.
 
 Codex remote execution additionally requires `settings.setup` or the cloud image to install the exact official npm `@openclaw/codex` plugin matching the Gateway version, including its pinned platform-native `@openai/codex` dependency. An exact-version bundled plugin is also accepted. Enrollment preserves the plugin's official npm or bundled provenance in the node's isolated per-lease state; it does not install plugins from npm or accept an untrusted local plugin path. A missing, mismatched, or untrusted plugin fails before the node starts.
 

--- a/extensions/crabbox/src/crabbox-worker-node-enrollment.ts
+++ b/extensions/crabbox/src/crabbox-worker-node-enrollment.ts
@@ -42,7 +42,10 @@ export function createCrabboxNodeEnrollmentSetup(params: {
     if (executionMode !== "remote-exec") {
       return [];
     }
+    // Uncaught node -e errors dump source and append a stack to the diagnosis,
+    // pushing the actionable message out of the bounded provider error tail.
     const inspectPlugin = [
+      "try{",
       'const fs=require("node:fs"),path=require("node:path"),module=require("node:module");',
       'const inspection=JSON.parse(fs.readFileSync(0,"utf8")),plugin=inspection.plugin;',
       `const version=${JSON.stringify(enrollment.openclawVersion)};`,
@@ -69,6 +72,7 @@ export function createCrabboxNodeEnrollmentSetup(params: {
       'if(!existing.isSymbolicLink()||fs.realpathSync(projected)!==root){throw new Error("Codex node plugin path is occupied")}',
       '}catch(error){if(error.code!=="ENOENT"){throw error}fs.symlinkSync(root,projected)}',
       "}",
+      "}catch(error){console.error(String(error));process.exitCode=1}",
     ].join("");
     return [
       `"$@" plugins inspect codex --json | node -e ${shellQuote(inspectPlugin)} "$state_dir"`,

--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1063,39 +1064,68 @@ describe("Crabbox worker provider", () => {
     });
   });
 
-  it("preserves the node enrollment diagnosis after the Crabbox banner and setup noise", async () => {
-    const diagnosis =
-      "Error: Codex remote-exec requires the exact official @openclaw/codex@2026.8.1 plugin to be installed by cloudWorkers profile setup";
-    const stderr = [
-      `workspace owner acquired wait=218ms recovered=false run context: run=${"a".repeat(32)} lease=${LEASE_ID} slug=openclaw-${"b".repeat(32)} provider=machine0 ssh=openclaw@worker.example.test:2222 workspace=/workspace/openclaw`,
-      "x".repeat(2_000),
-      diagnosis,
-      "    at prepareCodex ([eval]:20:11)",
-      "    at runScriptInThisContext (node:internal/vm:209:10)",
-      "    at node:internal/process/execution:446:12",
-      "    at [eval]-wrapper:6:24",
-      "    at runScriptInContext (node:internal/process/execution:444:60)",
-      "    at evalFunction (node:internal/process/execution:279:30)",
-      "Node.js v24.15.0",
-    ].join("\n");
-    const provider = providerWithRunner(async (argv) => {
-      if (argv[1] === "status") {
-        return commandResult({ stdout: inspectJson() });
-      }
-      return argv[1] === "run"
-        ? commandResult({ code: 1, stderr, stdout: "setup progress ".repeat(200) })
-        : commandResult();
-    });
+  it.skipIf(process.platform === "win32")(
+    "preserves the actual node enrollment diagnosis after setup noise",
+    async () => {
+      const diagnosis =
+        "Error: Codex remote-exec requires the exact official @openclaw/codex@2026.8.1 plugin to be installed by cloudWorkers profile setup";
+      const home = tempDirs.make("crabbox-enrollment-");
+      const bin = path.join(home, "bin");
+      fs.mkdirSync(bin);
+      fs.symlinkSync(process.execPath, path.join(bin, "node"));
+      fs.writeFileSync(
+        path.join(bin, "openclaw"),
+        [
+          "#!/bin/sh",
+          'case "$*" in',
+          '  --version) echo "OpenClaw 2026.8.1" ;;',
+          '  "plugins inspect codex --json") echo \'{"ok":false}\'; exit 1 ;;',
+          '  *) echo "unexpected command: $*" >&2; exit 99 ;;',
+          "esac",
+        ].join("\n"),
+        { mode: 0o700 },
+      );
+      const calls: string[][] = [];
+      const provider = providerWithRunner(async (argv, options) => {
+        calls.push(argv);
+        if (argv[1] === "status") {
+          return commandResult({ stdout: inspectJson() });
+        }
+        if (argv[1] !== "run") {
+          return commandResult();
+        }
+        const result = spawnSync("/bin/bash", [], {
+          input: options.input,
+          encoding: "utf8",
+          timeout: 10_000,
+          env: {
+            HOME: home,
+            PATH: `${bin}:/usr/bin:/bin`,
+            CRABBOX_WORKER_SETUP_CODE: "fixture-setup",
+          },
+        });
+        expect(result.status).toBe(1);
+        return commandResult({
+          code: result.status,
+          stdout: "setup progress ".repeat(200),
+          stderr: `workspace owner acquired\n${result.stderr}\nworkspace owner released\nremote command exited 1`,
+        });
+      });
 
-    await expect(
-      provider.provision({ ...PROFILE, provider: "machine0" }, OPERATION_ID, {
-        executionMode: "remote-exec",
-      }),
-    ).rejects.toMatchObject({
-      code: "invalid_profile",
-      message: expect.stringContaining(diagnosis),
-    });
-  });
+      await expect(
+        provider.provision({ ...PROFILE, provider: "machine0" }, OPERATION_ID, {
+          executionMode: "remote-exec",
+        }),
+      ).rejects.toMatchObject({
+        code: "invalid_profile",
+        message: expect.stringContaining(diagnosis),
+      });
+      expect(calls.at(-1)?.[1]).toBe("stop");
+      expect(
+        fs.existsSync(path.join(home, ".openclaw", "cloud-workers", LEASE_ID, "node.pid")),
+      ).toBe(false);
+    },
+  );
 
   it("preserves the allocated lease and both failures when setup cleanup times out", async () => {
     let releaseCommitted = false;

--- a/scripts/lib/package-bundled-plugins.mts
+++ b/scripts/lib/package-bundled-plugins.mts
@@ -1,0 +1,166 @@
+// Composes explicitly selected source plugins into a custom core distribution.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import { satisfies, valid } from "semver";
+import { validateBundledPackageDependencyAlignment } from "../package-source-dependencies.mjs";
+import {
+  collectBundledPluginBuildEntries,
+  collectRootPackageExcludedExtensionDirs,
+  DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV,
+  NON_PACKAGED_BUNDLED_PLUGIN_DIRS,
+} from "./bundled-plugin-build-entries.mjs";
+import { assertRealOutputRoot } from "./output-root-guard.mjs";
+import {
+  PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
+  PACKAGE_INSTALL_GUARD_RELATIVE_PATH,
+} from "./package-dist-inventory-contract.mts";
+
+type PackageJson = {
+  name: string;
+  version: string;
+  files: string[];
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+};
+
+export function resolvePackageBundledPlugins(sourceDir: string, pluginIds: string[]) {
+  const ids = [...new Set(pluginIds)].toSorted();
+  if (ids.length === 0) {
+    return [];
+  }
+  const entries = collectBundledPluginBuildEntries({
+    cwd: sourceDir,
+    env: { [DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV]: ids.join(",") },
+  });
+  const excluded = collectRootPackageExcludedExtensionDirs({ cwd: sourceDir });
+  return ids.map((id) => {
+    const entry = entries.find((candidate) => candidate.id === id);
+    if (!entry?.hasPackageJson || !excluded.has(id) || NON_PACKAGED_BUNDLED_PLUGIN_DIRS.has(id)) {
+      throw new Error(
+        `--bundle-plugin requires a source plugin excluded from the core package: ${id}`,
+      );
+    }
+    return entry;
+  });
+}
+
+/** Called under the canonical packer's source lifecycle lock, before bundling workspace deps. */
+export async function preparePackageBundledPlugins(sourceDir: string, pluginIds: string[]) {
+  const selected = resolvePackageBundledPlugins(sourceDir, pluginIds);
+  if (selected.length === 0) {
+    return async () => {};
+  }
+  assertRealOutputRoot(path.join(sourceDir, "dist"));
+  const packagePath = path.join(sourceDir, "package.json");
+  const original = await fs.readFile(packagePath, "utf8");
+  const packageJson = JSON.parse(original) as PackageJson;
+  for (const { id, sourceEntries } of selected) {
+    const sourcePackage = JSON.parse(
+      await fs.readFile(path.join(sourceDir, "extensions", id, "package.json"), "utf8"),
+    ) as PackageJson;
+    const pluginRoot = path.join(sourceDir, "dist", "extensions", id);
+    const builtPackage = JSON.parse(
+      await fs.readFile(path.join(pluginRoot, "package.json"), "utf8"),
+    ) as PackageJson;
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(pluginRoot, "openclaw.plugin.json"), "utf8"),
+    ) as { id: string };
+    if (
+      manifest.id !== id ||
+      (["name", "version", "dependencies", "optionalDependencies"] as const).some(
+        (key) => !isDeepStrictEqual(builtPackage[key], sourcePackage[key]),
+      )
+    ) {
+      throw new Error(
+        `Built plugin ${id} does not match source metadata; rebuild before packaging`,
+      );
+    }
+    for (const entry of sourceEntries) {
+      await fs.access(path.join(pluginRoot, entry.replace(/\.[^.]+$/u, ".js")));
+    }
+    for (const section of ["dependencies", "optionalDependencies"] as const) {
+      const dependencies = sourcePackage[section] ?? {};
+      for (const [name, spec] of Object.entries(dependencies)) {
+        if (valid(spec) !== spec) {
+          throw new Error(
+            `Selected plugin ${id} requires an exact dependency pin: ${name}@${spec}`,
+          );
+        }
+      }
+      for (const existing of [packageJson.dependencies, packageJson.optionalDependencies]) {
+        validateBundledPackageDependencyAlignment({
+          bundledDependencies: dependencies,
+          bundledPackageLabel: `selected plugin ${id}`,
+          rootDependencies: { ...dependencies, ...existing },
+        });
+      }
+      packageJson[section] = { ...packageJson[section], ...dependencies };
+    }
+  }
+  // A required dependency must not remain optional when another selected owner needs it.
+  for (const name of Object.keys(packageJson.dependencies ?? {})) {
+    delete packageJson.optionalDependencies?.[name];
+  }
+  for (const { id, packageJson: metadata } of selected) {
+    const plugin = metadata as PackageJson;
+    for (const [name, range] of Object.entries(plugin.peerDependencies ?? {})) {
+      const version =
+        name === packageJson.name
+          ? packageJson.version
+          : (packageJson.dependencies?.[name] ?? packageJson.optionalDependencies?.[name]);
+      if (
+        (!version && !plugin.peerDependenciesMeta?.[name]?.optional) ||
+        (version && !satisfies(version, range))
+      ) {
+        throw new Error(`Selected plugin ${id} requires peer ${name}@${range} in the distribution`);
+      }
+    }
+  }
+  const exclusions = new Set(selected.map(({ id }) => `!dist/extensions/${id}/**`));
+  packageJson.files = packageJson.files.filter((entry) => !exclusions.has(entry));
+  const snapshots = await Promise.all(
+    ["package.json", PACKAGE_DIST_INVENTORY_RELATIVE_PATH, PACKAGE_INSTALL_GUARD_RELATIVE_PATH].map(
+      async (relativePath) => {
+        const target = path.join(sourceDir, relativePath);
+        const bytes = await fs.readFile(target).catch((error: unknown) => {
+          if (!(error instanceof Error && "code" in error && error.code === "ENOENT")) {
+            throw error;
+          }
+          return null;
+        });
+        return { target, bytes };
+      },
+    ),
+  );
+  const cleanup = async (preparationFailure?: { cause: unknown }) => {
+    const results = await Promise.allSettled(
+      snapshots.map(({ target, bytes }) =>
+        bytes === null ? fs.rm(target, { force: true }) : fs.writeFile(target, bytes),
+      ),
+    );
+    const failures = results.filter((result) => result.status === "rejected");
+    if (failures.length) {
+      throw new AggregateError(
+        [
+          ...(preparationFailure ? [preparationFailure.cause] : []),
+          ...failures.map((result) => result.reason),
+        ],
+        "Selected plugin package cleanup failed",
+        preparationFailure,
+      );
+    }
+  };
+  try {
+    await fs.writeFile(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+    // Inventory must see the custom manifest before pack, or postinstall would prune the plugin.
+    const { writePackageDistInventoryForPublish } = await import("./package-dist-inventory.ts");
+    await writePackageDistInventoryForPublish(sourceDir);
+    return cleanup;
+  } catch (error) {
+    await cleanup({ cause: error });
+    throw error;
+  }
+}

--- a/scripts/lib/package-bundled-plugins.mts
+++ b/scripts/lib/package-bundled-plugins.mts
@@ -70,9 +70,16 @@ export async function preparePackageBundledPlugins(sourceDir: string, pluginIds:
     ) as { id: string };
     if (
       manifest.id !== id ||
-      (["name", "version", "dependencies", "optionalDependencies"] as const).some(
-        (key) => !isDeepStrictEqual(builtPackage[key], sourcePackage[key]),
-      )
+      (
+        [
+          "name",
+          "version",
+          "dependencies",
+          "optionalDependencies",
+          "peerDependencies",
+          "peerDependenciesMeta",
+        ] as const
+      ).some((key) => !isDeepStrictEqual(builtPackage[key], sourcePackage[key]))
     ) {
       throw new Error(
         `Built plugin ${id} does not match source metadata; rebuild before packaging`,

--- a/scripts/package-openclaw-for-docker.mts
+++ b/scripts/package-openclaw-for-docker.mts
@@ -65,6 +65,7 @@ type PackageManifestLifecycle = {
   restorePackageManifest: (cwd: string) => Promise<unknown>;
 };
 type PackageOptions = RunOptions & {
+  bundlePlugins?: string[];
   allowUnreleasedChangelog?: unknown;
   extractAiRuntime?: (tarballPath: string, destination: string) => Promise<unknown>;
   normalizeTarballModes?: (tarballPath: string) => Promise<unknown>;
@@ -226,6 +227,7 @@ function resolvePackedOpenClawFileName(value: string) {
 export function parseArgs(argv: string[]) {
   const args = argv;
   const options = {
+    bundlePlugins: [] as string[],
     allowUnreleasedChangelog: false,
     outputDir: "",
     outputName: "",
@@ -250,6 +252,13 @@ export function parseArgs(argv: string[]) {
     const arg = args[index];
     if (arg === "--allow-unreleased-changelog") {
       setOnce(arg, "allowUnreleasedChangelog", true);
+    } else if (arg === "--bundle-plugin") {
+      options.bundlePlugins.push(readOptionValue(args, index, arg));
+      index += 1;
+    } else if (arg?.startsWith("--bundle-plugin=")) {
+      options.bundlePlugins.push(
+        readEqualsOptionValue(arg.slice("--bundle-plugin=".length), "--bundle-plugin"),
+      );
     } else if (arg === "--output-dir") {
       setOnce("--output-dir", "outputDir", readOptionValue(args, index, arg));
       index += 1;
@@ -488,6 +497,12 @@ export async function buildPackageArtifacts(
   };
   for (const envName of PACKAGE_BUILD_PLUGIN_SELECTION_ENV_NAMES) {
     delete buildEnv[envName];
+  }
+  if (packageOptions.bundlePlugins?.length) {
+    // Default frozen-ref harnesses must load without source-only composition dependencies.
+    const { resolvePackageBundledPlugins } = await import("./lib/package-bundled-plugins.mts");
+    const selectedPlugins = resolvePackageBundledPlugins(sourceDir, packageOptions.bundlePlugins);
+    buildEnv[DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV] = selectedPlugins.map(({ id }) => id).join(",");
   }
   const timeoutMs = resolveTimeoutMs(
     "OPENCLAW_DOCKER_PACKAGE_BUILD_TIMEOUT_MS",
@@ -988,8 +1003,16 @@ export async function packOpenClawPackageForDocker(
   let packReceiptDir: string | undefined;
   try {
     let cleanupBundledAiRuntime = async () => {};
+    let cleanupBundledPlugins = async () => {};
     try {
       await cleanPackedOpenClawTarballs(outputPath);
+      if (packageOptions.bundlePlugins?.length) {
+        const { preparePackageBundledPlugins } = await import("./lib/package-bundled-plugins.mts");
+        cleanupBundledPlugins = await preparePackageBundledPlugins(
+          sourcePath,
+          packageOptions.bundlePlugins,
+        );
+      }
       cleanupBundledAiRuntime = await prepareBundledAiRuntime(
         sourcePath,
         outputPath,
@@ -1020,12 +1043,16 @@ export async function packOpenClawPackageForDocker(
       try {
         await cleanupBundledAiRuntime();
       } finally {
-        await restorePackageSourceArtifacts(
-          sourcePath,
-          restoreDocsMap,
-          restoreManifest,
-          restoreChangelog,
-        );
+        try {
+          await cleanupBundledPlugins();
+        } finally {
+          await restorePackageSourceArtifacts(
+            sourcePath,
+            restoreDocsMap,
+            restoreManifest,
+            restoreChangelog,
+          );
+        }
       }
     }
     // Scan the emptied pnpm destination instead of trusting its absolute-path output.
@@ -1119,13 +1146,14 @@ async function main() {
   await fs.mkdir(outputDir, { recursive: true });
 
   if (!options.skipBuild) {
-    await buildPackageArtifacts(sourceDir);
+    await buildPackageArtifacts(sourceDir, { bundlePlugins: options.bundlePlugins });
   }
 
   console.error("==> Writing OpenClaw package inventory");
   await writePackageInventoryForDocker(sourceDir);
 
   const tarball = await packOpenClawPackageForDocker(sourceDir, outputDir, {
+    bundlePlugins: options.bundlePlugins,
     allowUnreleasedChangelog: options.allowUnreleasedChangelog,
     outputName: options.outputName,
     packJsonPath: options.packJson,

--- a/scripts/package-source-dependencies.mjs
+++ b/scripts/package-source-dependencies.mjs
@@ -32,7 +32,7 @@ export function validateBundledPackageDependencyAlignment({
     }
     if (rootVersion !== version && rootVersion !== `workspace:${version}`) {
       throw new Error(
-        `${rootPackageLabel} must declare ${name}@${version} to bundle @openclaw/ai without duplicate dependencies`,
+        `${rootPackageLabel} must declare ${name}@${version} to bundle ${bundledPackageLabel} without duplicate dependencies`,
       );
     }
     aligned.push([name, version]);

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -56,6 +56,8 @@ function createSelectedPluginPackageFixture() {
     version: packageJson.version,
     dependencies: { shared: "1.0.0", native: "2.0.0" },
     optionalDependencies: { optional: "3.0.0" },
+    peerDependencies: { peer: "1.0.0" },
+    peerDependenciesMeta: { peer: { optional: true } },
     openclaw: { extensions: ["./index.ts"], release: { publishToNpm: true } },
   };
   const files = {
@@ -333,31 +335,39 @@ describe("package-openclaw-for-docker", () => {
     expect(runImpl).toHaveBeenCalledOnce();
   });
 
-  it.each(["missing-entry", "stale-metadata"])(
-    "rejects %s in a selected built plugin",
-    async (failure) => {
-      const { sourceDir, outputDir, files, pluginPackage } = createSelectedPluginPackageFixture();
-      if (failure === "missing-entry") {
-        fs.rmSync(path.join(sourceDir, "dist/extensions/demo/index.js"));
-      } else {
-        fs.writeFileSync(
-          path.join(sourceDir, "dist/extensions/demo/package.json"),
-          JSON.stringify({ ...pluginPackage, version: "2026.7.1" }),
-        );
-      }
-      await expect(
-        packOpenClawPackageForDocker(sourceDir, outputDir, {
-          ...skipDocsMapLifecycle,
-          prepareChangelog: async () => {},
-          restoreChangelog: async () => {},
-          bundlePlugins: ["demo"],
-        }),
-      ).rejects.toThrow(failure === "missing-entry" ? /ENOENT/ : /does not match source metadata/);
-      expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(
-        files["package.json"],
+  it.each([
+    { failure: "missing-entry", metadata: {} },
+    { failure: "stale-metadata", metadata: { version: "2026.7.1" } },
+    { failure: "stale-peer-dependencies", metadata: { peerDependencies: { missing: "1.0.0" } } },
+    { failure: "stale-peer-meta", metadata: { peerDependenciesMeta: {} } },
+  ])("rejects $failure in a selected built plugin", async ({ failure, metadata }) => {
+    const { sourceDir, outputDir, files, pluginPackage } = createSelectedPluginPackageFixture();
+    if (failure === "missing-entry") {
+      fs.rmSync(path.join(sourceDir, "dist/extensions/demo/index.js"));
+    } else {
+      fs.writeFileSync(
+        path.join(sourceDir, "dist/extensions/demo/package.json"),
+        JSON.stringify({ ...pluginPackage, ...metadata }),
       );
-    },
-  );
+    }
+    const runCaptureImpl = vi.fn(async () => {
+      throw new Error("unexpected pack");
+    });
+    await expect(
+      packOpenClawPackageForDocker(sourceDir, outputDir, {
+        ...skipDocsMapLifecycle,
+        prepareChangelog: async () => {},
+        restoreChangelog: async () => {},
+        prepareBundledAiRuntime: skipBundledAiRuntime,
+        bundlePlugins: ["demo"],
+        runCaptureImpl,
+      }),
+    ).rejects.toThrow(failure === "missing-entry" ? /ENOENT/ : /does not match source metadata/);
+    expect(runCaptureImpl).not.toHaveBeenCalled();
+    expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(
+      files["package.json"],
+    );
+  });
 
   it.each([
     { id: "../outside", error: /invalid plugin id/ },

--- a/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
@@ -9,6 +9,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
 import * as tar from "tar";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV } from "../../../../scripts/lib/bundled-plugin-build-entries.mjs";
+import { writePackageDistInventoryForPublish } from "../../../../scripts/lib/package-dist-inventory.ts";
 import {
   preparePackageManifest,
   restorePackageManifest,
@@ -35,6 +36,50 @@ const skipDocsMapLifecycle = {
 };
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const tsxImport = import.meta.resolve("tsx");
+
+function createSelectedPluginPackageFixture() {
+  const sourceDir = tempDirs.make("openclaw-selected-plugin-source-");
+  const outputDir = tempDirs.make("openclaw-selected-plugin-output-");
+  const packageJson = {
+    name: "openclaw",
+    version: "2026.8.1",
+    files: [
+      "dist",
+      "!dist/extensions/demo/**",
+      "!dist/extensions/other/**",
+      "!dist/extensions/*/node_modules/**",
+    ],
+    dependencies: { shared: "1.0.0" },
+  };
+  const pluginPackage = {
+    name: "@openclaw/demo",
+    version: packageJson.version,
+    dependencies: { shared: "1.0.0", native: "2.0.0" },
+    optionalDependencies: { optional: "3.0.0" },
+    openclaw: { extensions: ["./index.ts"], release: { publishToNpm: true } },
+  };
+  const files = {
+    "package.json": JSON.stringify(packageJson),
+    "extensions/demo/package.json": JSON.stringify(pluginPackage),
+    "extensions/demo/openclaw.plugin.json": '{"id":"demo"}',
+    "extensions/demo/index.ts": "export {};",
+    "dist/extensions/demo/package.json": JSON.stringify({
+      ...pluginPackage,
+      openclaw: { ...pluginPackage.openclaw, extensions: ["./index.js"] },
+    }),
+    "dist/extensions/demo/openclaw.plugin.json": '{"id":"demo"}',
+    "dist/extensions/demo/index.js": 'export { value } from "../../shared-runtime.js";',
+    "dist/extensions/demo/node_modules/host-native/index.js": "not portable",
+    "dist/extensions/other/index.js": "not selected",
+    "dist/shared-runtime.js": "export const value = 42;",
+  };
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const target = path.join(sourceDir, relativePath);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, contents);
+  }
+  return { sourceDir, outputDir, files, pluginPackage };
+}
 
 function isProcessAlive(pid: number): boolean {
   if (!Number.isSafeInteger(pid) || pid <= 0) {
@@ -100,6 +145,48 @@ async function waitForExit(
 }
 
 describe("package-openclaw-for-docker", () => {
+  it("packs explicitly selected plugin runtime and dependencies without changing the ordinary package", async () => {
+    const { sourceDir, outputDir, files } = createSelectedPluginPackageFixture();
+    await writePackageDistInventoryForPublish(sourceDir);
+    const inventoryPath = path.join(sourceDir, "dist/postinstall-inventory.json");
+    const originalInventory = fs.readFileSync(inventoryPath, "utf8");
+    const options = {
+      ...skipDocsMapLifecycle,
+      prepareChangelog: async () => {},
+      restoreChangelog: async () => {},
+    };
+    const selected = await packOpenClawPackageForDocker(sourceDir, outputDir, {
+      ...options,
+      bundlePlugins: ["demo"],
+    });
+    const extractDir = tempDirs.make("openclaw-selected-plugin-extract-");
+    await tar.x({ file: selected, cwd: extractDir });
+    const packedRoot = path.join(extractDir, "package");
+    expect(fs.existsSync(path.join(packedRoot, "dist/extensions/demo/index.js"))).toBe(true);
+    expect(fs.existsSync(path.join(packedRoot, "dist/shared-runtime.js"))).toBe(true);
+    expect(fs.existsSync(path.join(packedRoot, "dist/extensions/other/index.js"))).toBe(false);
+    expect(fs.existsSync(path.join(packedRoot, "dist/extensions/demo/node_modules"))).toBe(false);
+    expect(
+      JSON.parse(fs.readFileSync(path.join(packedRoot, "package.json"), "utf8")),
+    ).toMatchObject({
+      dependencies: { shared: "1.0.0", native: "2.0.0" },
+      optionalDependencies: { optional: "3.0.0" },
+    });
+    expect(
+      JSON.parse(fs.readFileSync(path.join(packedRoot, "dist/postinstall-inventory.json"), "utf8")),
+    ).toContain("dist/extensions/demo/index.js");
+    expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(
+      files["package.json"],
+    );
+    expect(fs.readFileSync(inventoryPath, "utf8")).toBe(originalInventory);
+
+    const ordinary = await packOpenClawPackageForDocker(sourceDir, outputDir, options);
+    const ordinaryEntries: string[] = [];
+    await tar.t({ file: ordinary, onentry: (entry) => ordinaryEntries.push(entry.path) });
+    expect(ordinaryEntries.some((entry) => entry.startsWith("package/dist/extensions/demo/"))).toBe(
+      false,
+    );
+  });
   it.runIf(process.platform === "win32")(
     "runs npm through the toolchain-local runner on Windows",
     async () => {
@@ -202,6 +289,7 @@ describe("package-openclaw-for-docker", () => {
       ]),
     ).toEqual({
       allowUnreleasedChangelog: true,
+      bundlePlugins: [],
       outputDir: ".artifacts/docker",
       outputName: "openclaw-current.tgz",
       packJson: ".artifacts/docker/pack.json",
@@ -212,13 +300,136 @@ describe("package-openclaw-for-docker", () => {
   });
 
   it("rejects missing package artifact option values", () => {
-    for (const flag of ["--output-dir", "--output-name", "--source-dir"]) {
+    for (const flag of ["--output-dir", "--output-name", "--source-dir", "--bundle-plugin"]) {
       expect(() => parseArgs([flag])).toThrow(`${flag} requires a value`);
       expect(() => parseArgs([flag, "--skip-build"])).toThrow(`${flag} requires a value`);
       expect(() => parseArgs([flag, "-h"])).toThrow(`${flag} requires a value`);
       expect(() => parseArgs([`${flag}=`])).toThrow(`${flag} requires a value`);
       expect(() => parseArgs([`${flag}=-h`])).toThrow(`${flag} requires a value`);
     }
+  });
+
+  it("accepts repeatable explicit plugin selections", () => {
+    expect(parseArgs(["--bundle-plugin", "demo", "--bundle-plugin=other"]).bundlePlugins).toEqual([
+      "demo",
+      "other",
+    ]);
+  });
+
+  it("builds explicit plugin selections through the canonical build environment", async () => {
+    const { sourceDir } = createSelectedPluginPackageFixture();
+    const runImpl = vi.fn(
+      async (
+        _command: string,
+        _args: string[],
+        _cwd: string,
+        options: { env?: NodeJS.ProcessEnv },
+      ) => {
+        expect(options.env?.[DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV]).toBe("demo");
+        expect(fs.existsSync(path.join(sourceDir, "dist"))).toBe(false);
+      },
+    );
+    await buildPackageArtifacts(sourceDir, { bundlePlugins: ["demo", "demo"], runImpl });
+    expect(runImpl).toHaveBeenCalledOnce();
+  });
+
+  it.each(["missing-entry", "stale-metadata"])(
+    "rejects %s in a selected built plugin",
+    async (failure) => {
+      const { sourceDir, outputDir, files, pluginPackage } = createSelectedPluginPackageFixture();
+      if (failure === "missing-entry") {
+        fs.rmSync(path.join(sourceDir, "dist/extensions/demo/index.js"));
+      } else {
+        fs.writeFileSync(
+          path.join(sourceDir, "dist/extensions/demo/package.json"),
+          JSON.stringify({ ...pluginPackage, version: "2026.7.1" }),
+        );
+      }
+      await expect(
+        packOpenClawPackageForDocker(sourceDir, outputDir, {
+          ...skipDocsMapLifecycle,
+          prepareChangelog: async () => {},
+          restoreChangelog: async () => {},
+          bundlePlugins: ["demo"],
+        }),
+      ).rejects.toThrow(failure === "missing-entry" ? /ENOENT/ : /does not match source metadata/);
+      expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(
+        files["package.json"],
+      );
+    },
+  );
+
+  it.each([
+    { id: "../outside", error: /invalid plugin id/ },
+    { id: "missing", error: /unknown plugin id/ },
+    { id: "demo,other", error: /unknown plugin id/ },
+  ])("rejects invalid selected plugin $id before packing", async ({ id, error }) => {
+    const { sourceDir, outputDir, files } = createSelectedPluginPackageFixture();
+    const runCaptureImpl = vi.fn();
+    await expect(
+      packOpenClawPackageForDocker(sourceDir, outputDir, {
+        ...skipDocsMapLifecycle,
+        prepareChangelog: async () => {},
+        restoreChangelog: async () => {},
+        bundlePlugins: [id],
+        runCaptureImpl,
+      }),
+    ).rejects.toThrow(error);
+    expect(runCaptureImpl).not.toHaveBeenCalled();
+    expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(
+      files["package.json"],
+    );
+  });
+
+  it.each([
+    { spec: "2.0.0", error: /must declare shared@2.0.0/ },
+    { spec: "^1.0.0", error: /requires an exact dependency pin/ },
+  ])(
+    "rejects selected plugin dependency $spec without resolving a replacement",
+    async ({ spec, error }) => {
+      const { sourceDir, outputDir, files, pluginPackage } = createSelectedPluginPackageFixture();
+      pluginPackage.dependencies.shared = spec;
+      for (const prefix of ["extensions", "dist/extensions"]) {
+        fs.writeFileSync(
+          path.join(sourceDir, prefix, "demo/package.json"),
+          JSON.stringify(pluginPackage),
+        );
+      }
+      await expect(
+        packOpenClawPackageForDocker(sourceDir, outputDir, {
+          ...skipDocsMapLifecycle,
+          prepareChangelog: async () => {},
+          restoreChangelog: async () => {},
+          bundlePlugins: ["demo"],
+        }),
+      ).rejects.toThrow(error);
+      expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(
+        files["package.json"],
+      );
+      expect(fs.existsSync(path.join(sourceDir, "dist/postinstall-inventory.json"))).toBe(false);
+    },
+  );
+
+  it("restores selected package metadata and inventory after npm pack fails", async () => {
+    const { sourceDir, outputDir, files } = createSelectedPluginPackageFixture();
+    const runCaptureImpl = vi.fn(async () => {
+      throw new Error("pack rejected");
+    });
+    await expect(
+      packOpenClawPackageForDocker(sourceDir, outputDir, {
+        ...skipDocsMapLifecycle,
+        prepareChangelog: async () => {},
+        restoreChangelog: async () => {},
+        bundlePlugins: ["demo"],
+        runCaptureImpl,
+      }),
+    ).rejects.toThrow("pack rejected");
+    expect(runCaptureImpl).toHaveBeenCalledOnce();
+    expect(fs.readFileSync(path.join(sourceDir, "package.json"), "utf8")).toBe(
+      files["package.json"],
+    );
+    expect(fs.existsSync(path.join(sourceDir, "dist/postinstall-inventory.json"))).toBe(false);
+    expect(fs.existsSync(path.join(sourceDir, "dist/openclaw-install-guard"))).toBe(false);
   });
 
   it("rejects duplicate package artifact CLI options", () => {

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -369,7 +369,7 @@ describe("package source preflight", () => {
         rootManifestContent: rootManifest(),
       }),
     ).toThrow(
-      "package.json must declare openai@6.50.0 to bundle @openclaw/ai without duplicate dependencies",
+      "package.json must declare openai@6.50.0 to bundle packages/ai/package.json without duplicate dependencies",
     );
   });
 
@@ -421,7 +421,7 @@ describe("package source preflight", () => {
         rootManifestContent: JSON.stringify(root),
       }),
     ).toThrow(
-      "package.json must declare partial-json@0.1.7 to bundle @openclaw/ai without duplicate dependencies",
+      "package.json must declare partial-json@0.1.7 to bundle packages/ai/package.json without duplicate dependencies",
     );
   });
 


### PR DESCRIPTION
Closes #130702

## What Problem This Solves

Fixes an issue where source-built cloud workers cannot start Codex remote execution when the installed core-only artifact omits the required external runtime plugin and the exact source-version plugin is not available in the registry.

The worker correctly refuses the missing or untrusted runtime. A standalone local plugin archive does not carry official npm provenance, so changing a server's setup command to install such an archive is not a valid substitute. The missing piece is a complete source-built cloud distribution.

## Why This Change Was Made

The canonical package builder now accepts repeatable `--bundle-plugin <id>` selections. It builds through the existing source-plugin selection contract, includes only the selected excluded plugins, incorporates their exact declared dependencies into the temporary distribution manifest, and regenerates the installation inventory before packing. Dependency conflicts, nonexact pins, missing or mismatched build output, and private/nonpackaged selections fail visibly. Source metadata and inventory are restored afterward.

This is a package-composition capability, not a new runtime installer. Normal core packaging remains lean and unchanged. External plugin publication, trust classification, node enrollment, execution approvals, configuration, protocol, and persistence contracts are unchanged. Native dependencies install for the target platform; the archive does not copy the build machine's plugin `node_modules` or native executable.

The same failure also exposed a diagnostic bug in the generated prelaunch Node program: an uncaught exception printed its source and stack after the useful message, displacing that message from the bounded provider error. Catching at that producer preserves the concise reason and exit code 1 without increasing limits, parsing stacks downstream, or weakening prerequisites or cleanup.

## User Impact

Operators using unpublished source builds have a documented, reproducible way to produce an exact matching cloud-node artifact, including the required runtime plugin. Existing digest-pinned artifact delivery can install that complete distribution normally. Setup failures retain their actionable reason.

The documented source recipe uses the repository's supported `--pnpm-pack` option. A complete artifact must still be generated from the same source revision as its Gateway and delivered through the operator's trusted setup path. No registry release or server-specific workaround is included in this PR.

Release note: allow complete source-built cloud worker packages with selected runtime plugins, and preserve concise enrollment failure diagnostics.

## Evidence

### Actual package and native runtime proof

A real core-only archive installed in clean Linux arm64 with Node 26.7.0, npm 11.19.0, a fresh HOME, and normal package lifecycle scripts reproduced `Plugin not found: codex` and the generated prelaunch prerequisite failure (exit 1). The actual archive regression also failed before the source repair because the selected plugin was absent.

The final verified candidate installed normally in a second fresh Linux arm64 environment. It reported `@openclaw/codex@2026.8.1`, `origin: bundled`, exact `@openai/codex@0.149.1`, and prelaunch exit 0. The installed plugin imported successfully. The real platform-native binary then completed `initialize` → `initialized` → `environment/info` → stdin EOF, exiting 0 without a signal in a credential-free HOME/CODEX_HOME.

| Artifact | SHA-256 | Result |
| --- | --- | --- |
| Core-only baseline | `d8b85576900558783c65f8fe707a17c0030f73b9836097293fa4d46e13f3dae5` | No Codex plugin; prelaunch exit 1 |
| Verified selected-plugin candidate | `244e8531513db999bf71bff0a5cd98cc7a766f1b57f5e5a9fdeee76fa5c5a00c` | Bundled plugin, prelaunch/native protocol pass |

These are proof artifacts from base `b05938bac10130b2f086a541b04a43a43bd6faa9` plus the implementation, not artifacts mislabeled with an eventual merge SHA. The last documentation-only change makes the recipe explicitly match the tested pnpm packing mode. Final deployment artifacts must be rebuilt from the landed source.

The ordinary and selected archives passed the canonical tarball checker, including relative import closure and installation inventory parity. Independent archive inspection found no credentials, auth files, lockfiles, nested plugin dependency trees, or copied host-native Codex payload. Task-owned containers were removed.

### Regression and static checks

- 286 owner/sibling tests passed across package building, dependency preflight/postinstall, Gateway enrollment/provisioning, Crabbox provisioning, Codex binary resolution, and native node relay. Three Windows-only cases were skipped on the local host.
- Parent independently reran the actual selected-package/default-package regression: passed.
- The package tests cover selected content and shared imports, unchanged ordinary exclusions, dependency/optional ownership, invalid selection, conflicts, nonexact pins, stale/missing output, repeatable selection, build forwarding, and restoration on success and failure.
- The existing dependency-free frozen-source harness test caught an initially eager helper import; lazy loading fixed it without weakening the test.
- The original changed-check run passed guards, four typecheck lanes, extension lint, dead exports, and five embedded doctor tests, then found two script lint issues. Those were corrected at their owner. Full script lint/typecheck, all owner/sibling tests, and the remaining database-first/media/sidecar/import-cycle guards passed afterward. The original log retains its exit 1; this is complete scoped follow-up coverage, not a claim that the same aggregate invocation was rerun successfully.
- Final formatting, docs MDX, and `git diff --check` passed. Parent checked formatting after the final documentation-only flag correction.
- Fresh isolated Codex autoreview: clean at the configured P0 threshold. Parent inspected the package, installation, trust, enrollment, and native dependency contracts independently.

### Boundaries and limitations

The normal source build was completed before the packaging changes; real artifacts reused that complete build with `--skip-build`. New selection forwarding has regression coverage. Normal package installation and real native transport are proved on Linux arm64, not a mocked executable. Local Linux x64 emulation failed before installation with `Exec format error`; no x64 success is claimed. This proof does not claim a real cloud allocation, node pairing, full agent turn, offline completeness, or production deployment.

The default npm packing path hit its existing five-minute limit on the loaded local checkout. Cleanup succeeded, and the existing supported pnpm packing mode produced the verified artifact. No timeout, retry policy, budget, baseline, or package lifecycle check was weakened.

Direct dependency contract inspection used Codex tag `rust-v0.149.1`, peeled commit `ff29a44391deccde0aba0f8390337d7f3c319ea4`: `codex-cli/bin/codex.js` platform-native resolution and `codex-rs/exec-server/src/server/transport.rs` / `tests/initialize.rs` stdio initialization and shutdown. OpenClaw's official/bundled provenance and native dependency checks remain untouched.

Production: runtime +4/−0; packaging/tooling +202/−8 (net +194); total net +198. Tests +276/−35 (net +241). Documentation adds the complete-package recipe. The production growth supplies explicit distribution composition and reversible inventory/dependency ownership; removing the normal public core exclusion instead would violate the external-plugin publication contract.

AI-assisted, maintainer-requested root-cause repair. Server artifact adoption and cloud launch verification follow source landing through the existing deployment owner; no live server configuration was edited to make this proof pass.

### Publication head and refreshed base

The repair was committed and rebased once onto main at `c47974ccf4cb780a59dabcf47cbdb35f60a5c516`. `git range-diff` confirms the repair patch is unchanged. This base includes the readable/copyable cloud diagnostics UI repair in #130672 and preserves main's larger machine-catalog handling.

Main also advanced the Codex dependency to `0.150.1`. Dependencies were refreshed with one successful `pnpm install`; this PR does not change that pin. The historical clean-install artifact evidence above remains specifically for `0.149.1`, not a rebuilt `0.150.1` artifact. Direct comparison of the upstream [native launcher](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-cli/bin/codex.js#L16) and [stdio transport](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/exec-server/src/server/transport.rs#L131) found them unchanged from the inspected `rust-v0.149.1` source; the [initialize regression](https://github.com/openai/codex/blob/90854393966b21e9ebfd21b122334eb09a20c93d/codex-rs/exec-server/tests/initialize.rs#L16) additionally checks returned environment information. Final deployment still requires a new artifact and target-platform verification from the landed SHA.

Post-rebase verification at `c93390e8bf8876f310de8026c02dd2fdffce4081`:

```sh
node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts test/scripts/package-source-preflight.test.ts test/scripts/postinstall-bundled-plugins.test.ts extensions/crabbox/src/crabbox-worker-provider.test.ts extensions/codex/src/node-exec-server.test.ts extensions/codex/src/app-server/managed-binary.test.ts src/gateway/worker-environments/node-enrollment.test.ts src/gateway/worker-environments/provider-provisioning-node.test.ts
node scripts/run-tsgo.mjs --project tsconfig.scripts.json
node scripts/check-docs-mdx.mjs docs/gateway/cloud-workers.md
git diff --check origin/main...HEAD
```

All commands passed: 286 tests across eight files, three Windows-only skips, in 229 seconds; script types, docs MDX, and changed-file formatting passed. The package test exercises real selected/default tarball contents. The preserved main machine-catalog regression also passed. `pull_request` [CI run 33043636976](https://github.com/openclaw/openclaw/actions/runs/33043636976) completed successfully on this exact head. The single CI watcher exited 0 with `GREEN` and zero pending checks; the final check query found no failed or pending checks. No CI repair or rerun was needed. Source metadata remains restored and the checkout is clean.


### Landing review follow-up

ClawSweeper identified stale built peer metadata in the new generic selection path. The follow-up at `a8117c6ead9f4a60e94b25a885b47ed9735abf02` compares both `peerDependencies` and `peerDependenciesMeta` in the existing built/source parity check. The existing fixture now covers a different built peer declaration and a source-optional peer becoming required only in the built manifest. Both cases failed before the fix by reaching packing unexpectedly; both pass after the repair and assert packing never starts.

The focused package, source dependency, and postinstall suite passed 98 tests with three Windows-only skips, including actual selected/default fixture archives and cleanup. Fresh isolated Codex autoreview passed at the configured P0 threshold; the reviewer did not run tests. Production is now +213/-8 (net +205), tests +286/-35 (net +251), docs +23/-2, still eight files. The seven additional production lines are the formatted extension of the existing comparison to both peer contracts; no new runtime path or manifest/lock/version change.

This addresses the peer comparison and stale-peer regression Rank-up moves. The optional full selected-runtime artifact rebuild is deferred to the separately authorized landed-SHA artifact and deployment-owner follow-up. The current proof rebuilds fixture archives, not a fresh Codex 0.150.1 native distribution. Historical arm64 evidence and all platform/cloud/deployment limitations above remain unchanged. The landing agent personally inspected the exact Codex 0.150.1 launcher, stdio transport, and initialization test linked above.


Current follow-up local verification (all passed):

```sh
node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts test/scripts/package-source-preflight.test.ts test/scripts/postinstall-bundled-plugins.test.ts
node scripts/check-changed.mjs -- scripts/lib/package-bundled-plugins.mts test/e2e/qa-lab/runtime/package-openclaw-for-docker.e2e.test.ts
git diff --check c47974ccf4cb780a59dabcf47cbdb35f60a5c516...a8117c6ead9f4a60e94b25a885b47ed9735abf02
```

The changed gate includes script and test-root typechecks, full script lint, formatting, and relevant guards. An earlier gate invocation was stopped when the native checkout refresh invalidated its fixed-tree context; the command above was rerun completely at the new head and exited 0. No failed check was waived.


Final exact-head [CI33046530552](https://github.com/openclaw/openclaw/actions/runs/33046530552) completed successfully at `a8117c6ead9f4a60e94b25a885b47ed9735abf02`, with no failed or pending checks. `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 130735` completed successfully using native **exact-head** evidence (also Workflow Sanity33046530646); the prepared and remote head stayed unchanged and no push or rebase was needed. Current active branch rules require the CI gate and linear history, with no enforced independent approval. No bypass used. The latest new-head ClawSweeper comment remains a started placeholder; the completed review's findings and Rank-up moves are addressed above.
