### PR TITLE
fix(channels): keep configured accounts in JSON inventory

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -31,6 +31,8 @@ openclaw channels dead-letters list --channel telegram --account default
 
 `channels list` shows chat channels only: configured accounts by default, with `installed`, `configured`, and `enabled` status tags per account (`--json` for machine output). Pass `--all` to also surface bundled channels that have no configured account yet and installable catalog channels that are not yet on disk. Provider auth and model usage live elsewhere: `openclaw models auth list` for provider auth profiles, `openclaw status` or `openclaw models list` for usage/quota.
 
+`--json` returns a local account inventory from plugin metadata without contacting the Gateway or executing channel setup/runtime code. Configured accounts remain visible even when their plugin has a setup entry. Use `channels status --probe` for live checks.
+
 In an explicit multi-agent setup, workspace-scoped channel plugins come from
 `agents.defaults.systemAgent.agentId`. Without that owner, `channels list`
 returns the shared bundled, managed, and global inventory with a diagnostic;

--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -763,46 +763,80 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     expect(fs.existsSync(fullMarker)).toBe(false);
   });
 
-  it("uses manifest channel configs before setup-only plugin loading", () => {
-    const { pluginDir, fullMarker, setupMarker } = writeExternalSetupChannelPlugin({
-      pluginId: "external-chat-plugin",
-      channelId: "external-chat",
-      manifestChannelConfig: true,
-      setupRequiresRuntime: false,
-    });
-    const plugins = listReadOnlyChannelPluginsForConfig(
-      createExternalChannelTestConfig({ pluginDir, pluginId: "external-chat-plugin" }),
-      {
-        env: { ...process.env },
-        includePersistedAuthState: false,
-      },
-    );
+  it.each(
+    ["external", "bundled"].flatMap((origin) =>
+      [undefined, false, true].map((setupRequiresRuntime) => ({ origin, setupRequiresRuntime })),
+    ),
+  )(
+    "uses $origin manifest inventory with setup.requiresRuntime=$setupRequiresRuntime",
+    ({ origin, setupRequiresRuntime }) => {
+      const fixtureRoot = makePluginLoaderTempDir();
+      const fixtureDir = path.join(fixtureRoot, "external-chat-plugin");
+      fs.mkdirSync(fixtureDir);
+      const { pluginDir, fullMarker, setupMarker } = writeExternalSetupChannelPlugin({
+        pluginDir: fixtureDir,
+        pluginId: "external-chat-plugin",
+        channelId: "external-chat",
+        manifestChannelConfig: true,
+        setupRequiresRuntime,
+      });
+      const cfg = createExternalChannelTestConfig({ pluginDir, pluginId: "external-chat-plugin" });
+      if (origin === "bundled") {
+        vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", undefined);
+        vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", fixtureRoot);
+        delete cfg.plugins?.load;
+      }
+      for (const includeSetupFallbackPlugins of [undefined, false]) {
+        const result = resolveReadOnlyChannelPluginsForConfig(cfg, {
+          includePersistedAuthState: false,
+          ...(includeSetupFallbackPlugins === undefined ? {} : { includeSetupFallbackPlugins }),
+        });
+        expect(result.missingConfiguredChannelIds).toEqual([]);
+        expect(result.loadFailures).toEqual([]);
+        expect(
+          result.manifestRecords.find((record) => record.id === "external-chat-plugin")?.origin,
+        ).toBe(origin === "bundled" ? "bundled" : "config");
 
-    const plugin = plugins.find((entry) => entry.id === "external-chat");
-    expect(plugin?.meta.label).toBe("External Chat Manifest");
-    expect(plugin?.meta.blurb).toBe("manifest config");
-    expect(plugin?.meta.preferOver).toEqual(["legacy-external-chat"]);
-    const schema = plugin?.configSchema?.schema as
-      | { properties?: Record<string, { type?: string }> }
-      | undefined;
-    expect(schema?.properties?.token?.type).toBe("string");
-    expectRecordFields(plugin?.configSchema?.uiHints?.token, {
-      label: "Token",
-      sensitive: true,
-    });
-    expect(
-      plugin?.config.listAccountIds({ channels: { "external-chat": { token: "t" } } } as never),
-    ).toEqual(["default"]);
-    const account = plugin?.config.resolveAccount({
-      channels: { "external-chat": { token: "configured" } },
-    } as never);
-    const accountFields = expectRecordFields(account, {
-      accountId: "default",
-    });
-    expectRecordFields(accountFields.config, { token: "configured" });
-    expect(fs.existsSync(setupMarker)).toBe(false);
-    expect(fs.existsSync(fullMarker)).toBe(false);
-  });
+        const plugin = result.plugins.find((entry) => entry.id === "external-chat");
+        expect(plugin?.meta.label).toBe("External Chat Manifest");
+        expect(plugin?.meta.blurb).toBe("manifest config");
+        expect(plugin?.meta.preferOver).toEqual(["legacy-external-chat"]);
+        const schema = plugin?.configSchema?.schema as
+          | { properties?: Record<string, { type?: string }> }
+          | undefined;
+        expect(schema?.properties?.token?.type).toBe("string");
+        expectRecordFields(plugin?.configSchema?.uiHints?.token, {
+          label: "Token",
+          sensitive: true,
+        });
+        expect(
+          plugin?.config.listAccountIds({ channels: { "external-chat": { token: "t" } } } as never),
+        ).toEqual(["default"]);
+        const account = plugin?.config.resolveAccount({
+          channels: { "external-chat": { token: "configured" } },
+        } as never);
+        const accountFields = expectRecordFields(account, {
+          accountId: "default",
+        });
+        expectRecordFields(accountFields.config, { token: "configured" });
+        const namedCfg = createExternalChannelTestConfig({
+          pluginDir,
+          channels: {
+            "external-chat": { defaultAccount: "ops", accounts: { ops: {}, alerts: {} } },
+          },
+        });
+        expect(plugin?.config.listAccountIds(namedCfg)).toEqual(["alerts", "ops"]);
+        expect(plugin?.config.defaultAccountId?.(namedCfg)).toBe("ops");
+        expect(fs.existsSync(setupMarker)).toBe(false);
+        expect(fs.existsSync(fullMarker)).toBe(false);
+      }
+      const plugins = listReadOnlyChannelPluginsForConfig(cfg, {
+        includePersistedAuthState: false,
+        includeSetupFallbackPlugins: true,
+      });
+      expectExternalChatSetupOnlyPluginLoaded({ plugins, setupMarker, fullMarker });
+    },
+  );
 
   it("sanitizes terminal control sequences from manifest channel metadata", () => {
     const { pluginDir } = writeExternalSetupChannelPlugin({
@@ -1199,36 +1233,46 @@ describe("listReadOnlyChannelPluginsForConfig", () => {
     expect(fs.existsSync(fullMarker)).toBe(false);
   });
 
-  it("falls back to manifest metadata and reports setup-entry load failures", () => {
-    const { pluginDir, fullMarker, setupMarker } = writeExternalSetupChannelPlugin({
-      pluginId: "external-chat-plugin",
-      channelId: "external-chat",
-    });
-    fs.writeFileSync(
-      path.join(pluginDir, "setup-entry.cjs"),
-      `throw new Error("Cannot find module 'ansi-escapes'");`,
-      "utf-8",
-    );
-
-    const result = resolveReadOnlyChannelPluginsForConfig(
-      createExternalChannelTestConfig({ pluginDir, pluginId: "external-chat-plugin" }),
-      {
-        env: { ...process.env },
-        includeSetupFallbackPlugins: true,
-      },
-    );
-
-    expect(pluginIds(result.plugins)).toContain("external-chat");
-    expect(result.missingConfiguredChannelIds).not.toContain("external-chat");
-    expect(result.loadFailures).toEqual([
-      expect.objectContaining({
-        channelId: "external-chat",
+  it.each([
+    { manifestChannelConfig: false, setupRequiresRuntime: undefined, missing: false },
+    { manifestChannelConfig: true, setupRequiresRuntime: undefined, missing: true },
+    { manifestChannelConfig: true, setupRequiresRuntime: true, missing: true },
+    { manifestChannelConfig: true, setupRequiresRuntime: false, missing: false },
+  ])(
+    "preserves setup failure visibility with channelConfigs=$manifestChannelConfig and requiresRuntime=$setupRequiresRuntime",
+    ({ manifestChannelConfig, setupRequiresRuntime, missing }) => {
+      const { pluginDir, fullMarker, setupMarker } = writeExternalSetupChannelPlugin({
         pluginId: "external-chat-plugin",
-        message: expect.stringContaining("Cannot find module"),
-      }),
-    ]);
-    expect(fs.existsSync(setupMarker)).toBe(false);
-    expect(fs.existsSync(fullMarker)).toBe(false);
-  });
+        channelId: "external-chat",
+        manifestChannelConfig,
+        setupRequiresRuntime,
+      });
+      fs.writeFileSync(
+        path.join(pluginDir, "setup-entry.cjs"),
+        `throw new Error("Cannot find module 'ansi-escapes'");`,
+        "utf-8",
+      );
+
+      const result = resolveReadOnlyChannelPluginsForConfig(
+        createExternalChannelTestConfig({ pluginDir, pluginId: "external-chat-plugin" }),
+        {
+          env: { ...process.env },
+          includeSetupFallbackPlugins: true,
+        },
+      );
+
+      expect(pluginIds(result.plugins).includes("external-chat")).toBe(!missing);
+      expect(result.missingConfiguredChannelIds).toEqual(missing ? ["external-chat"] : []);
+      expect(result.loadFailures).toEqual([
+        expect.objectContaining({
+          channelId: "external-chat",
+          pluginId: "external-chat-plugin",
+          message: expect.stringContaining("Cannot find module"),
+        }),
+      ]);
+      expect(fs.existsSync(setupMarker)).toBe(false);
+      expect(fs.existsSync(fullMarker)).toBe(false);
+    },
+  );
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -618,6 +618,7 @@ function addManifestChannelPlugins(
   options: {
     pluginIds: ReadonlySet<string>;
     channelIds: readonly string[];
+    includeSetupFallbackPlugins: boolean;
   },
 ): void {
   const channelIds = new Set(options.channelIds);
@@ -632,7 +633,9 @@ function addManifestChannelPlugins(
       if (!channelIds.has(channelId)) {
         continue;
       }
-      if (!canUseManifestChannelPlugin(record, channelId)) {
+      // Inventory can describe accounts without executing setup. Setup-backed callers
+      // must still see missing capabilities when a runtime-dependent setup fails.
+      if (options.includeSetupFallbackPlugins && !canUseManifestChannelPlugin(record, channelId)) {
         continue;
       }
       addChannelPlugins(byId, [buildManifestChannelPlugin({ record, channelId })], {
@@ -710,6 +713,7 @@ export function resolveReadOnlyChannelPluginsForConfig(
 ): ReadOnlyChannelPluginResolution {
   const env = options.env ?? process.env;
   const workspaceDir = resolveReadOnlyWorkspaceDir(cfg, options);
+  const includeSetupFallbackPlugins = options.includeSetupFallbackPlugins === true;
   const loadedChannelPlugins = listChannelPlugins();
   const cacheKey = resolveReadOnlyChannelPluginResolutionCacheKey({
     cfg,
@@ -765,7 +769,7 @@ export function resolveReadOnlyChannelPluginsForConfig(
 
   addChannelPlugins(byId, loadedChannelPlugins);
 
-  if (options.includeSetupFallbackPlugins === true) {
+  if (includeSetupFallbackPlugins) {
     for (const channelId of configuredChannelIds) {
       if (byId.has(channelId)) {
         continue;
@@ -805,6 +809,7 @@ export function resolveReadOnlyChannelPluginsForConfig(
       ),
     ),
     channelIds: bundledManifestMissingChannelIds,
+    includeSetupFallbackPlugins,
   });
 
   const missingConfiguredChannelIds = configuredChannelIds.filter(
@@ -820,7 +825,7 @@ export function resolveReadOnlyChannelPluginsForConfig(
   });
   if (externalPluginIds.length > 0) {
     const externalPluginIdSet = new Set(externalPluginIds);
-    if (options.includeSetupFallbackPlugins === true) {
+    if (includeSetupFallbackPlugins) {
       const missingChannelIdSet = new Set(missingConfiguredChannelIds);
       for (const record of externalManifestRecords) {
         if (!externalPluginIdSet.has(record.id) || !record.setupSource) {
@@ -862,6 +867,7 @@ export function resolveReadOnlyChannelPluginsForConfig(
     addManifestChannelPlugins(byId, externalManifestRecords, {
       pluginIds: externalPluginIdSet,
       channelIds: externalManifestMissingChannelIds,
+      includeSetupFallbackPlugins,
     });
   }
 

--- a/src/cli/channels-list-route-cold-imports.test.ts
+++ b/src/cli/channels-list-route-cold-imports.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterAll, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
 import {
   createColdPluginFixture,
   isColdPluginRuntimeLoaded,
@@ -60,50 +61,69 @@ afterAll(() => {
   vi.unstubAllEnvs();
 });
 
-it("renders configured channel metadata without loading the plugin runtime", async () => {
-  const pluginRoot = path.join(tempRoot, "cold-channel-plugin");
-  fs.mkdirSync(pluginRoot, { recursive: true });
-  const fixture = createColdPluginFixture({
-    rootDir: pluginRoot,
-    pluginId: "cold-channel-plugin",
-    channelId: "cold-channel",
-    manifest: {
-      channelConfigs: {
-        "cold-channel": {
-          schema: {
-            type: "object",
-            additionalProperties: false,
-            properties: { token: { type: "string" } },
+it.each([
+  { name: "top-level", channel: { token: "configured" }, accounts: ["default"] },
+  {
+    name: "named",
+    channel: { accounts: { alerts: { token: "configured" }, default: { token: "configured" } } },
+    accounts: ["alerts", "default"],
+  },
+])(
+  "renders $name channel accounts without loading setup or runtime",
+  async ({ name, channel, accounts }) => {
+    resetPluginRuntimeStateForTest();
+    testState.json.length = 0;
+    const pluginRoot = path.join(tempRoot, name);
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    const setupMarker = path.join(pluginRoot, "setup-loaded.txt");
+    const fixture = createColdPluginFixture({
+      rootDir: pluginRoot,
+      pluginId: "cold-channel-plugin",
+      channelId: "cold-channel",
+      setupEntrySource: `require("node:fs").writeFileSync(${JSON.stringify(setupMarker)}, "loaded");
+throw new Error("JSON inventory must not execute setup");`,
+      manifest: {
+        channelConfigs: {
+          "cold-channel": {
+            schema: {
+              type: "object",
+              additionalProperties: false,
+              properties: { token: { type: "string" } },
+            },
+            label: "Cold Channel",
+            description: "Prepared cold channel metadata",
           },
-          label: "Cold Channel",
-          description: "Prepared cold channel metadata",
         },
       },
-    },
-  });
-  vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
-  vi.stubEnv("OPENCLAW_HOME", path.join(tempRoot, "home"));
-  vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tempRoot, "state"));
-  testState.config = {
-    channels: { "cold-channel": { token: "configured" } },
-    plugins: {
-      load: { paths: [pluginRoot] },
-      entries: { "cold-channel-plugin": { enabled: true } },
-    },
-  };
+    });
+    vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+    vi.stubEnv("OPENCLAW_HOME", path.join(tempRoot, "home"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.join(tempRoot, "state"));
+    testState.config = {
+      channels: { "cold-channel": channel },
+      plugins: {
+        load: { paths: [pluginRoot] },
+        entries: { "cold-channel-plugin": { enabled: true } },
+      },
+    };
 
-  await expect(tryRouteCli(["node", "openclaw", "channels", "list", "--json"])).resolves.toBe(true);
+    for (const flags of [["--json"], ["--all", "--json"]]) {
+      await expect(tryRouteCli(["node", "openclaw", "channels", "list", ...flags])).resolves.toBe(
+        true,
+      );
+    }
 
-  expect(testState.json).toEqual([
-    {
+    const expected = {
       chat: {
         "cold-channel": {
-          accounts: ["default"],
+          accounts,
           installed: true,
           origin: "configured",
         },
       },
-    },
-  ]);
-  expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
-});
+    };
+    expect(testState.json).toEqual([expected, expected]);
+    expect(fs.existsSync(setupMarker)).toBe(false);
+    expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+  },
+);

--- a/src/commands/plugin-control-plane-cold-imports.test.ts
+++ b/src/commands/plugin-control-plane-cold-imports.test.ts
@@ -1,5 +1,7 @@
 // Plugin control-plane cold-import tests guard setup and plugin metadata paths against runtime-heavy imports.
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
 import {
   createColdPluginConfig,
   createColdPluginFixture,
@@ -7,20 +9,78 @@ import {
   isColdPluginRuntimeLoaded,
 } from "../plugins/test-helpers/cold-plugin-fixtures.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { buildAuthChoiceGroups, formatAuthChoiceChoicesForCli } from "./auth-choice-options.js";
 import { listManifestInstalledChannelIds } from "./channel-setup/discovery.js";
 
 const tempDirs: string[] = [];
+
+// Status also checks sandbox containers; keep that unrelated host probe hermetic.
+vi.mock("../agents/sandbox/docker.js", () => ({
+  execDockerRaw: vi.fn(async () => ({ code: 0, stdout: "", stderr: "" })),
+}));
 
 function makeTempDir() {
   return makeTrackedTempDir("openclaw-command-cold-imports", tempDirs);
 }
 
 afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  resetPluginRuntimeStateForTest();
   cleanupTrackedTempDirs(tempDirs);
 });
 
 describe("command control-plane plugin discovery", () => {
+  it.each([true, false])(
+    "audits setup-backed channel warnings in status with enabled=%s",
+    async (enabled) => {
+      await withOpenClawTestState(
+        {
+          env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1", OPENCLAW_BUNDLED_PLUGINS_DIR: undefined },
+        },
+        async (state) => {
+          const finding = {
+            checkId: "channels.cold-channel.setup_warning",
+            severity: "warn",
+            title: "Cold channel setup warning",
+            detail: "The configured fixture channel requests a security warning.",
+          };
+          const plugin = createColdPluginFixture({
+            rootDir: makeTempDir(),
+            manifest: { setup: { requiresRuntime: false } },
+            setupEntrySource: `module.exports = {
+  plugin: {
+    id: "cold-channel",
+    meta: { id: "cold-channel", label: "Cold Channel" },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: (cfg) => cfg.channels["cold-channel"],
+      inspectAccount: (cfg) => ({ ...cfg.channels["cold-channel"], configured: true }),
+    },
+    security: {
+      collectWarnings: ({ account }) => account.auditWarning ? [${JSON.stringify(finding)}] : [],
+    },
+  },
+};`,
+          });
+          const config = {
+            ...createColdPluginConfig(plugin.rootDir, plugin.pluginId),
+            agents: { defaults: { workspace: state.workspaceDir } },
+            channels: { [plugin.channelId]: { enabled, auditWarning: true } },
+          };
+          const { resolveStatusSecurityAudit } = await import("./status-runtime-shared.js");
+          const report = await resolveStatusSecurityAudit({ config, sourceConfig: config });
+
+          expect(report.findings.filter((entry) => entry.checkId === finding.checkId)).toEqual(
+            enabled ? [finding] : [],
+          );
+          expect(isColdPluginRuntimeLoaded(plugin)).toBe(false);
+        },
+      );
+    },
+  );
+
   it("resolves channel setup metadata without importing plugin runtime", () => {
     const plugin = createColdPluginFixture({ rootDir: makeTempDir() });
     const workspaceDir = makeTempDir();

--- a/src/commands/status-json.test.ts
+++ b/src/commands/status-json.test.ts
@@ -33,20 +33,6 @@ vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,
 }));
 
-vi.mock("../channels/plugins/read-only.js", () => ({
-  resolveReadOnlyChannelPluginsForConfig: vi.fn(() => ({
-    plugins: [
-      { id: "discord" },
-      { id: "imessage" },
-      { id: "signal" },
-      { id: "slack" },
-      { id: "telegram" },
-      { id: "whatsapp" },
-    ],
-    missingConfiguredChannelIds: [],
-  })),
-}));
-
 vi.mock("./status.daemon.js", () => ({
   getDaemonStatusSummary: mocks.getDaemonStatusSummary,
   getNodeDaemonStatusSummary: mocks.getNodeDaemonStatusSummary,
@@ -159,32 +145,14 @@ describe("statusJsonCommand", () => {
 
     await statusJsonCommand({ all: true }, runtime);
 
-    expect(mocks.runSecurityAudit).toHaveBeenCalledOnce();
-    const auditInput = mocks.runSecurityAudit.mock.calls[0]?.[0] as
-      | {
-          config?: unknown;
-          sourceConfig?: unknown;
-          deep?: unknown;
-          includeFilesystem?: unknown;
-          includeChannelSecurity?: unknown;
-          loadPluginSecurityCollectors?: unknown;
-          plugins?: Array<{ id: string }>;
-        }
-      | undefined;
-    expect(auditInput?.config).toStrictEqual({ update: { channel: "stable" } });
-    expect(auditInput?.sourceConfig).toStrictEqual({});
-    expect(auditInput?.deep).toBe(false);
-    expect(auditInput?.includeFilesystem).toBe(true);
-    expect(auditInput?.includeChannelSecurity).toBe(true);
-    expect(auditInput?.loadPluginSecurityCollectors).toBe(false);
-    expect(auditInput?.plugins?.map((plugin) => plugin.id)).toStrictEqual([
-      "discord",
-      "imessage",
-      "signal",
-      "slack",
-      "telegram",
-      "whatsapp",
-    ]);
+    expect(mocks.runSecurityAudit).toHaveBeenCalledExactlyOnceWith({
+      config: { update: { channel: "stable" } },
+      sourceConfig: {},
+      deep: false,
+      includeFilesystem: true,
+      includeChannelSecurity: true,
+      loadPluginSecurityCollectors: false,
+    });
     expect(logs).toStrictEqual([expect.any(String)]);
     const payload = JSON.parse(logs[0] ?? "{}") as Record<string, unknown>;
     expect(payload).toEqual({

--- a/src/commands/status-runtime-shared.test.ts
+++ b/src/commands/status-runtime-shared.test.ts
@@ -16,12 +16,7 @@ const mocks = vi.hoisted(() => ({
   callGateway: vi.fn(),
   getDaemonStatusSummary: vi.fn(),
   getNodeDaemonStatusSummary: vi.fn(),
-  resolveReadOnlyChannelPluginsForConfig: vi.fn(),
   resolveModelAuthLabel: vi.fn(),
-}));
-
-vi.mock("../channels/plugins/read-only.js", () => ({
-  resolveReadOnlyChannelPluginsForConfig: mocks.resolveReadOnlyChannelPluginsForConfig,
 }));
 
 vi.mock("../infra/provider-usage.js", () => ({
@@ -78,44 +73,9 @@ describe("status-runtime-shared", () => {
     mocks.getDaemonStatusSummary.mockResolvedValue({ label: "LaunchAgent" });
     mocks.getNodeDaemonStatusSummary.mockResolvedValue({ label: "node" });
     mocks.resolveModelAuthLabel.mockReturnValue(undefined);
-    mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({
-      plugins: [{ id: "telegram" }],
-      configuredChannelIds: ["telegram"],
-      missingConfiguredChannelIds: [],
-    });
   });
 
   it("resolves the shared security audit payload", async () => {
-    await resolveStatusSecurityAudit({
-      config: { gateway: {} },
-      sourceConfig: { gateway: {} },
-    });
-
-    expect(mocks.runSecurityAudit).toHaveBeenCalledWith({
-      config: { gateway: {} },
-      sourceConfig: { gateway: {} },
-      deep: false,
-      includeFilesystem: true,
-      includeChannelSecurity: true,
-      loadPluginSecurityCollectors: false,
-      plugins: [{ id: "telegram" }],
-    });
-    expect(mocks.resolveReadOnlyChannelPluginsForConfig).toHaveBeenCalledWith(
-      { gateway: {} },
-      {
-        activationSourceConfig: { gateway: {} },
-        includeSetupFallbackPlugins: false,
-      },
-    );
-  });
-
-  it("lets the security audit load configured channel plugins when read-only discovery is incomplete", async () => {
-    mocks.resolveReadOnlyChannelPluginsForConfig.mockReturnValue({
-      plugins: [],
-      configuredChannelIds: ["external"],
-      missingConfiguredChannelIds: ["external"],
-    });
-
     await resolveStatusSecurityAudit({
       config: { gateway: {} },
       sourceConfig: { gateway: {} },
@@ -514,7 +474,6 @@ describe("status-runtime-shared", () => {
       includeFilesystem: true,
       includeChannelSecurity: true,
       loadPluginSecurityCollectors: false,
-      plugins: [{ id: "telegram" }],
     });
   });
 

--- a/src/commands/status-runtime-shared.ts
+++ b/src/commands/status-runtime-shared.ts
@@ -28,9 +28,6 @@ const providerUsageLoader = createLazyImportLoader(() => import("../infra/provid
 const securityAuditModuleLoader = createLazyImportLoader(
   () => import("../security/audit.runtime.js"),
 );
-const readOnlyChannelPluginsModuleLoader = createLazyImportLoader(
-  () => import("../channels/plugins/read-only.js"),
-);
 const gatewayCallModuleLoader = createLazyImportLoader(() => import("../gateway/call.js"));
 
 function loadProviderUsage() {
@@ -39,10 +36,6 @@ function loadProviderUsage() {
 
 function loadSecurityAuditModule() {
   return securityAuditModuleLoader.load();
-}
-
-function loadReadOnlyChannelPluginsModule() {
-  return readOnlyChannelPluginsModuleLoader.load();
 }
 
 function loadGatewayCallModule() {
@@ -94,11 +87,8 @@ export async function resolveStatusSecurityAudit(params: {
   timeoutMs?: number;
 }) {
   const { runSecurityAudit } = await loadSecurityAuditModule();
-  const { resolveReadOnlyChannelPluginsForConfig } = await loadReadOnlyChannelPluginsModule();
-  const readOnlyPlugins = resolveReadOnlyChannelPluginsForConfig(params.config, {
-    activationSourceConfig: params.sourceConfig,
-    includeSetupFallbackPlugins: false,
-  });
+  // The audit owns setup-backed capabilities; inventory projections can name
+  // accounts without carrying their channel security adapters.
   return await runSecurityAudit({
     config: params.config,
     sourceConfig: params.sourceConfig,
@@ -107,10 +97,6 @@ export async function resolveStatusSecurityAudit(params: {
     includeFilesystem: true,
     includeChannelSecurity: true,
     loadPluginSecurityCollectors: false,
-    // Missing configured channel plugins make plugin-specific collectors unreliable; omit plugin list then.
-    ...(readOnlyPlugins.missingConfiguredChannelIds.length === 0
-      ? { plugins: readOnlyPlugins.plugins }
-      : {}),
   });
 }
 

--- a/src/plugins/test-helpers/cold-plugin-fixtures.ts
+++ b/src/plugins/test-helpers/cold-plugin-fixtures.ts
@@ -23,6 +23,7 @@ type ColdPluginFixtureOptions = {
   channelId?: string;
   authChoiceId?: string;
   runtimeMessage?: string;
+  setupEntrySource?: string;
   manifest?: Record<string, unknown>;
 };
 
@@ -40,7 +41,10 @@ export function createColdPluginFixture(options: ColdPluginFixtureOptions): Cold
         name: options.packageName ?? "@example/openclaw-cold-control-plane",
         version: options.packageVersion ?? "1.0.0",
         ...options.packageJson,
-        openclaw: { extensions: ["./index.cjs"] },
+        openclaw: {
+          extensions: ["./index.cjs"],
+          ...(options.setupEntrySource !== undefined ? { setupEntry: "./setup-entry.cjs" } : {}),
+        },
       },
       null,
       2,
@@ -87,6 +91,13 @@ export function createColdPluginFixture(options: ColdPluginFixtureOptions): Cold
     `require("node:fs").writeFileSync(${JSON.stringify(runtimeMarker)}, "loaded", "utf8");\nthrow new Error(${JSON.stringify(options.runtimeMessage ?? "runtime entry should not load for cold plugin metadata discovery")});\n`,
     "utf8",
   );
+  if (options.setupEntrySource !== undefined) {
+    fs.writeFileSync(
+      path.join(options.rootDir, "setup-entry.cjs"),
+      options.setupEntrySource,
+      "utf8",
+    );
+  }
   return {
     authChoiceId,
     channelId,


### PR DESCRIPTION
Closes #130700

## What Problem This Solves

Fixes an issue where `channels list --json` successfully returned an incomplete account inventory when a configured plugin also had a setup entry. `--all --json` could also present installed configured channels as merely available, with no accounts.

## Why This Change Was Made

Read-only discovery uses its existing mode to keep inventory metadata-only while preserving setup precedence, runtime eligibility, and failure diagnostics for capability consumers. Status auditing delegates setup-aware discovery to the existing audit owner instead of treating inventory completeness as capability completeness. This deletes the duplicate lookup and lazy-loader wrapper while keeping registry-wide plugin collectors disabled.

## User Impact

Top-level and named accounts remain visible in default and `--all` JSON inventory. Setup-owned channel audit warnings are no longer lost behind metadata-only projections. No configuration/default, public API, schema, protocol, dependency, or persistent-storage change is introduced.

Runtime production: **+11/−19 (net −8)**. Tests and test support: **+250/−188 (net +62)**. Documentation: **+2/−0**. `src/plugins/test-helpers/cold-plugin-fixtures.ts` is test support, not shipped runtime logic. The final patch contains no UI changes.

## Evidence

Final head: **`067f1df77b5235febaa630b70e6bc0323dbf5a86`**, based on `d8b8b9240a3443fa5ade57f811ef6eabf3e43a55`. `git range-diff` confirms both retained inventory/status commits are unchanged across the conflict-only refresh. The six inspected inventory/audit/eligibility owners are unchanged between the preceding and final bases.

- **Reproduction:** the original built-main observation showed text/live status reporting accounts that JSON omitted. Before editing, resolver, cold CLI route, and real audit-owner regressions failed for the intended reasons. Later paired built-CLI runs on Node 24.19.0 and 26.7.0 reproduced all four inventory omissions and the missing setup-owned warning on immutable unpatched `9f581a7beec97f09220be60b3f7b6db804c3425f`.
- **Final-head tests:** 91 focused tests pass across eight files/five Vitest shards. Coverage includes default/named accounts, both JSON modes, bundled/external manifests, omitted/false/true runtime declarations, setup precedence/failures, disabled-channel auditing, registry lifecycle, exact status JSON output, and cold execution boundaries.
- **Final-head build:** `pnpm build` passes in 4m 15.2s, including 48 native-require modules, 147 public SDK subpaths, the UI gate, and matching build-info metadata. Startup JS gzip is 342,598 B. This patch changes no UI source, budget, or baseline.
- **Final-head CLI acceptance:** all four inventory cases and the setup-owned audit-warning case pass on Node 24.19.0 and Node 26.7.0 in fresh real CLI processes with isolated HOME/state/config/workspace and a synthetic external plugin. No operator profile, credentials, or live Gateway is used. Native retention removed the earlier immutable baseline before the last refresh, so this final run is explicitly candidate-only and reuses the captured before-results above; it is not presented as another paired baseline replay.
- **Review and checks:** the retained production patch and status-JSON correction passed isolated Codex autoreview at its default P0 scope. Broad changed-file gates passed before the mechanical conflict refresh: core/core-test and plugin/plugin-test typechecks, core/plugin lint, formatting, i18n, three dead-export scans, zero runtime import cycles, and selected architecture/storage guards. Final refresh sanity reran the affected tests, full build, exact UI E2E type graph, six Chromium cases, and whitespace check rather than repeating unrelated broad gates.
- **Current-main interaction:** newer plugin consent code governs managed activation and status diagnostics, not the unchanged inventory eligibility decisions. The repair preserves trust, allowlist, disablement, and setup-runtime policy.

Exact-head [CI run 33075267351, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33075267351/attempts/2) is complete and green for `067f1df77b5235febaa630b70e6bc0323dbf5a86`, including [build-artifacts](https://github.com/openclaw/openclaw/actions/runs/33075267351/job/98548975517) and [the aggregate CI gate](https://github.com/openclaw/openclaw/actions/runs/33075267351/job/98550606190). Native review artifact validation and preparation passed without changing the head; the hosted CI/Testbox verifier accepted the exact-head evidence and the push guard verified the remote tree already matched. The remaining operation is the native pinned merge.

```bash
scripts/pr review-validate-artifacts 130738
```

```bash
OPENCLAW_TESTBOX=1 scripts/pr prepare-run 130738
```

### Built-CLI results

The fixture declares both `channelConfigs` and a setup entry. Setup and full-runtime entries contain execution sentinels; inventory must not execute either. These are actual synthetic-channel JSON rows, not mocked return values.

| Case | Captured unpatched result | Final candidate JSON row |
|---|---|---|
| Top-level, default JSON | Row absent | `{"accounts":["default"],"installed":true,"origin":"configured"}` |
| Top-level, `--all` JSON | Row absent | `{"accounts":["default"],"installed":true,"origin":"configured"}` |
| Named accounts, default JSON | Row absent | `{"accounts":["alerts","ops"],"installed":true,"origin":"configured"}` |
| Named accounts, `--all` JSON | Row absent | `{"accounts":["alerts","ops"],"installed":true,"origin":"configured"}` |

All inventory cases leave setup and full-runtime sentinels absent. For `status --all --json`, the baseline omitted a distinctive warning without loading setup; the candidate returns that warning after loading its lightweight setup adapter, while the full runtime remains cold. Both Node versions pass the final candidate matrix.

```bash
node dist/index.js channels list --json
```

```bash
node dist/index.js channels list --all --json
```

```bash
node dist/index.js status --all --json --timeout 3000
```

Focused tests:

```bash
OPENCLAW_VITEST_MAX_WORKERS=4 pnpm test src/channels/plugins/read-only.test.ts src/cli/channels-list-route-cold-imports.test.ts src/commands/plugin-control-plane-cold-imports.test.ts src/commands/channels.list.test.ts src/commands/status-runtime-shared.test.ts src/commands/status-json.test.ts src/security/audit-channel-readonly-setup-fallback.test.ts src/security/audit-plugin-readonly-scope.test.ts --reporter=verbose
```

Canonical main-side CI-repair sanity:

```bash
node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.ui-pages-e2e.json --builders 1
```

```bash
pnpm test:ui:e2e ui/src/e2e/sidebar-interactions.e2e.test.ts --reporter=verbose
```

The browser harness builds an isolated Control UI and mocks the Gateway. Its six cases cover composer focus/cue timing, reduced motion, keyboard menus, agent selection, and avatar rendering; this is not an authenticated live-Gateway claim.

The broad changed gate executed before the final mechanical refresh was:

```bash
pnpm check:changed -- docs/cli/channels.md src/channels/plugins/read-only.test.ts src/channels/plugins/read-only.ts src/cli/channels-list-route-cold-imports.test.ts src/commands/plugin-control-plane-cold-imports.test.ts src/commands/status-json.test.ts src/commands/status-runtime-shared.test.ts src/commands/status-runtime-shared.ts src/plugins/test-helpers/cold-plugin-fixtures.ts ui/src/e2e/sidebar-interactions.e2e.test.ts
```

### CI corrections and review follow-through

[The first CI failure](https://github.com/openclaw/openclaw/actions/runs/33063799282/job/98489039364) exposed one missed sibling expectation in `status-json.test.ts`: it still required the metadata-only plugin override this repair removes. The same failure was reproduced locally. Its unused discovery mock and cast-heavy assertions are replaced with one exact audit call assertion retaining configuration forwarding and every audit flag. Exact JSON output and real setup-owned warning coverage remain intact.

[The next merge-result typecheck](https://github.com/openclaw/openclaw/actions/runs/33066326932/job/98497523018) included a newer main-side UI test regression from [the composer cue timing change](https://github.com/openclaw/openclaw/pull/128677). The same TS2339 was reproduced locally. A separate [prepared-provider usage repair](https://github.com/openclaw/openclaw/pull/129220) then landed the canonical textarea guard in `8862a1746a5baa7ee61f92c692add8d34568869c`. This branch retains that main-side fix and drops its independently verified alternative, resolving the overlap without retaining any UI diff. No check, assertion, baseline, or enforcement limit was weakened.

The [latest completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/130738#issuecomment-5435129920), reviewed August 27 at 13:18 UTC, covers the exact final head and finds no patch or security defect. Its remaining steps were exact-head CI completion and maintainer merge handling. CI is now green; maintainer decision is to land the owner-boundary repair through native guards. Earlier built-CLI proof requests are addressed above. The [Control UI variance repair](https://github.com/openclaw/openclaw/pull/130688) is merged. The review's stored-data/vector hint on the documentation is inapplicable: this patch changes no database, schema, embedding metadata, or persistence owner.

### Startup-memory failure and bounded diagnostic retry

[Attempt 1's artifact check](https://github.com/openclaw/openclaw/actions/runs/33075267351/job/98527960904) measured `status --json` at a 453.0 MiB median, above the unchanged 451 MiB effective ceiling (samples 454.7, 448.9, 453.0). The matched [main CI run](https://github.com/openclaw/openclaw/actions/runs/33074529883/job/98525462915) passed at 420.4 MiB. Both used Node 24.19.0 and the 32-vCPU Blacksmith runner class.

The unchanged candidate was then built on a [Linux Testbox](https://github.com/openclaw/openclaw/actions/runs/33076891899). It passed at 421.1 MiB alone, 419.4 MiB while replaying the original CI verifier wave, and 423.7 MiB alone afterward; the full verifier wave also passed. That Testbox used 16 vCPUs, so it is not presented as an identical CI environment. The owned lease has been stopped.

One narrow diagnostic rerun of the failed artifact job on the **same 32-vCPU Blacksmith runner class** passed at **421.0 MiB** (samples 421.0, 415.1, 434.6). [Attempt 2](https://github.com/openclaw/openclaw/actions/runs/33075267351/attempts/2) is complete and green, including the aggregate gate. No source, workflow, threshold, tolerance, sample count, timeout, or runtime setting was changed for this investigation. The failure did not reproduce; neither a code regression nor a concurrency cause was established. This is not a claimed performance fix. Follow-up: characterize startup-memory RSS variance without weakening the limits.

Regression provenance: [the read-only CLI optimization](https://github.com/openclaw/openclaw/pull/117932) made the bad setup-eligibility filter visible on the cold JSON branch on August 2, 2026 (code author and merger: @steipete); the predicate predates that branch. The separate [broader read-only discovery refactor](https://github.com/openclaw/openclaw/pull/117370) retains the predicate and does not address this trigger.

Named follow-up: align Telegram's setup-only audit adapter with its fuller plugin. This repair restores generic discovery ownership and available adapters; it does not add adapters omitted by individual plugins. Documentation: https://docs.openclaw.ai/cli/channels.

AI-assisted.
