### PR TITLE
fix(cli): reject empty agent scopes for global model commands

### DIFF
--- a/src/cli/models-cli.runtime.ts
+++ b/src/cli/models-cli.runtime.ts
@@ -38,7 +38,7 @@ export function rejectAgentScopedModelCommand(
   // does not exist. Kept scope-neutral: `scan --no-probe` returns after printing
   // the catalog without writing config at all.
   const agent = resolveOptionFromCommand<string>(command, "agent");
-  if (!agent) {
+  if (agent === undefined) {
     return;
   }
   throw new Error(

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -551,69 +551,62 @@ describe("models cli", () => {
     expectCommandOptions(modelsAuthListCommand, { agent: "poe", json: true });
   });
 
-  it.each([
+  const globalModelCommands = [
     {
       label: "set",
-      args: ["models", "--agent", "poe", "set", "anthropic/claude-sonnet-4-6"],
+      args: ["set", "anthropic/claude-sonnet-4-6"],
       command: modelsSetCommand,
     },
     {
       label: "set-image",
-      args: ["models", "--agent", "poe", "set-image", "openai/gpt-image-1"],
+      args: ["set-image", "openai/gpt-image-1"],
       command: modelsSetImageCommand,
     },
     {
       label: "aliases list",
-      args: ["models", "--agent", "poe", "aliases", "list"],
+      args: ["aliases", "list"],
       command: modelsAliasesListCommand,
     },
     {
       label: "aliases add",
-      args: ["models", "--agent", "poe", "aliases", "add", "zzz", "soraka/grok-4.6"],
+      args: ["aliases", "add", "zzz", "soraka/grok-4.6"],
       command: modelsAliasesAddCommand,
     },
     {
       label: "aliases remove",
-      args: ["models", "--agent", "poe", "aliases", "remove", "zzz"],
+      args: ["aliases", "remove", "zzz"],
       command: modelsAliasesRemoveCommand,
     },
     {
       label: "scan",
-      args: ["models", "--agent", "poe", "scan", "--no-probe", "--no-input"],
+      args: ["scan", "--no-probe", "--no-input"],
       command: modelsScanCommand,
     },
     {
       label: "refresh",
-      args: ["models", "--agent", "poe", "refresh"],
+      args: ["refresh"],
       command: modelsRefreshCommand,
     },
-  ])("rejects parent --agent for models $label", async ({ args, command }) => {
-    await expect(runModelsCommand(args)).rejects.toThrow("does not support --agent");
+  ];
 
+  it.each(
+    globalModelCommands.flatMap(({ label, args, command }) =>
+      ["poe", ""].map((agent) => ({ label, args, command, agent })),
+    ),
+  )("rejects parent --agent '$agent' for models $label", async ({ args, command, agent }) => {
+    await expect(runModelsCommand(["models", "--agent", agent, ...args])).rejects.toThrow(
+      "does not support --agent",
+    );
     expect(command).not.toHaveBeenCalled();
   });
 
-  it.each([
-    {
-      label: "aliases list",
-      args: ["models", "aliases", "list"],
-      command: modelsAliasesListCommand,
+  it.each(globalModelCommands)(
+    "still runs models $label without --agent",
+    async ({ args, command }) => {
+      await runModelsCommand(["models", ...args]);
+      expect(command).toHaveBeenCalledOnce();
     },
-    {
-      label: "scan",
-      args: ["models", "scan", "--no-probe", "--no-input"],
-      command: modelsScanCommand,
-    },
-    {
-      label: "refresh",
-      args: ["models", "refresh"],
-      command: modelsRefreshCommand,
-    },
-  ])("still runs models $label without --agent", async ({ args, command }) => {
-    await runModelsCommand(args);
-
-    expect(command).toHaveBeenCalled();
-  });
+  );
 
   it("shows help for models auth without error exit", async () => {
     const program = new Command();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users passing an explicitly empty `--agent` value to a global model command could silently change global configuration. For example, `openclaw models --agent "" aliases remove <alias>` previously removed the global alias instead of rejecting the unsupported scope.

## Why This Change Was Made

The existing shared scope guard treated an empty value as if the option were absent. Commander preserves an explicitly supplied empty string, so the guard must distinguish absence from a supplied value. All seven existing global command paths already use this guard; no separate command-specific validation is needed.

The regression coverage now uses one command table for nonempty, empty, and omitted scopes, removing the duplicated omission table. Production LOC: +1/-1, net0. Tests: +23/-30, net-7. No new option, default, dependency, fallback, or configuration shape; no changelog change.

## User Impact

Explicit empty scopes now fail visibly before the global command runs. Omitting `--agent` still runs global commands normally. This does not add agent-scoped model mutations or change model fallback policy.

## Evidence

- At the refreshed base, all seven empty-scope regression cases failed for the intended reason: the global handlers were invoked. The seven nonempty controls passed. This includes the new `models refresh` path from main.
- 145 focused and sibling tests passed before refresh. After resolving the real test-table conflict with main, all 75 tests in the changed CLI suite passed, and all 28 checks in the complete local changed-file gate passed at `a2fc0f55947131d6bb3d5cbe034630e42552a67a`, including type checks, lint, unused exports, import cycles, and state/auth boundary guards.
- Actual source CLI execution with the real entrypoint, Commander tree, bootstrap/migrations, alias command and config writer reproduced the bug and fix. Baseline explicit empty scope exited0 and removed a temporary alias. Candidate explicit empty scope exited1 with `does not support --agent` and byte-identical configuration. Candidate omitted scope exited0 and removed the alias normally.
- Fresh structured Codex autoreview of the rebased seven-command patch completed with no P0 findings. [Exact-head hosted CI33075872735](https://github.com/openclaw/openclaw/actions/runs/33075872735) completed successfully at `a2fc0f55947131d6bb3d5cbe034630e42552a67a`; all 82 jobs finished successfully or were skipped. The previous green run on `10619c6` is historical.

The CLI proof used fresh temporary HOME/config/state and the same existing built-plugin runtime for both source checkouts. It is source CLI proof, not a fully built candidate package or deployment. An initial unmatched source/built-plugin layout timed out during migration preflight before reaching the guard; a separate isolated-cwd tsx-resolution failure was also corrected in the fixture. No production bypass, increased deadline, provider call, credentials, or operator-state mutation was used. All three final cases completed within the unchanged120-second limit; fixtures and owned processes were cleaned up.

The guard is present in the inspected stable source; the available history does not establish its original introduction. No linked issue is closed by this PR.
