### PR TITLE
fix(agents): reconcile subagents through scoped session owner

### DIFF
--- a/docs/tools/swarm.md
+++ b/docs/tools/swarm.md
@@ -359,6 +359,13 @@ Collector results remain waitable until their group is archived. After every
 member reaches its retention deadline, OpenClaw archives the group's children
 as a batch so completed swarms do not remain in the live session tree.
 
+Resetting a child session durably revokes completed runs' cleanup before changing
+that session, so a delayed cleanup retry cannot delete its replacement. Reset fails
+if completion is still settling or revocation cannot be saved. If reset fails or
+the Gateway stops after revocation is saved, the original session may remain with
+that cleanup disabled. Collector results and task outcomes keep their normal
+retention, and active reset continuations keep running.
+
 ## Stop a Swarm
 
 Use **Stop** in the parent chat to cancel a running swarm. A Stop targeting a

--- a/src/agents/subagents/registry/subagent-recovery-state.ts
+++ b/src/agents/subagents/registry/subagent-recovery-state.ts
@@ -3,6 +3,9 @@ import { isAgentEventLifecycleGenerationCurrent } from "../../../infra/agent-eve
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 
 export function shouldSuppressSubagentRecoverySessionEffects(entry: SubagentRunRecord): boolean {
+  if (entry.execution.suppressSessionEffects === true) {
+    return true;
+  }
   if (entry.killIntent) {
     const killLifecycleGeneration = entry.killIntent.lifecycleGeneration;
     return (
@@ -10,9 +13,6 @@ export function shouldSuppressSubagentRecoverySessionEffects(entry: SubagentRunR
       killLifecycleGeneration.length === 0 ||
       !isAgentEventLifecycleGenerationCurrent(killLifecycleGeneration)
     );
-  }
-  if (entry.execution.suppressSessionEffects === true) {
-    return true;
   }
   const lifecycleGeneration = entry.execution.restartRecovery?.lifecycleGeneration;
   return (

--- a/src/agents/subagents/registry/subagent-registry-lifecycle-completion.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-completion.ts
@@ -315,7 +315,7 @@ export async function completeSubagentRunAttempt(
         completionReason = SUBAGENT_ENDED_REASON_KILLED;
         completionOutcome = { status: "error", error: killIntent.reason };
         entry.killIntent = undefined;
-        if (killOwnsCurrentLifecycle) {
+        if (killOwnsCurrentLifecycle && entry.execution.suppressSessionEffects !== true) {
           suppressSessionEffects = false;
           entry.execution = {
             ...entry.execution,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.ts
@@ -82,6 +82,39 @@ export class SubagentLifecycleController {
     };
   }
 
+  /** The reset owner calls this synchronously before publishing another session generation. */
+  revokeTerminalSessionEffects(entries: Iterable<SubagentRunRecord>): void {
+    const previous = new Map<SubagentRunRecord, SubagentRunRecord["execution"]>();
+    for (const entry of entries) {
+      if (this.options.runs.get(entry.runId) !== entry) {
+        continue;
+      }
+      // A capture may have staged terminal state and still own rollback. Reset
+      // must not persist that tentative result or let its rollback erase revocation.
+      if (this.terminalCompletionLocks.has(entry.runId)) {
+        throw new Error("Subagent completion is still settling; retry the session reset.");
+      }
+      // Even an already-set flag may come from a failed best-effort sweep write.
+      if (entry.execution.status === "terminal" && entry.pauseReason !== "sessions_yield") {
+        previous.set(entry, entry.execution);
+      }
+    }
+    if (previous.size === 0) {
+      return;
+    }
+    for (const [entry, execution] of previous) {
+      entry.execution = { ...execution, suppressSessionEffects: true };
+    }
+    try {
+      this.options.persistOrThrow(...[...previous.keys()].map((entry) => entry.runId));
+    } catch (error) {
+      for (const [entry, execution] of previous) {
+        entry.execution = execution;
+      }
+      throw error;
+    }
+  }
+
   clearScheduledResumeTimers = () => {
     for (const timer of this.scheduledResumeTimers) {
       clearTimeout(timer);

--- a/src/agents/subagents/registry/subagent-registry-restore.ts
+++ b/src/agents/subagents/registry/subagent-registry-restore.ts
@@ -331,7 +331,7 @@ export function createSubagentRegistryRestorer(config: {
     activated = true;
   }
 
-  function restoreSubagentRunsOnce(retryDelayMs = RESTORE_RETRY_DELAY_MS) {
+  function restoreSubagentRunsOnce(retryDelayMs = RESTORE_RETRY_DELAY_MS, throwOnError = false) {
     if (restoreState !== "idle") {
       return;
     }
@@ -371,6 +371,9 @@ export function createSubagentRegistryRestorer(config: {
         `failed to restore subagent runs from disk: ${err instanceof Error ? err.message : String(err)}`,
       );
       scheduleRestoreRetry(retryDelayMs);
+      if (throwOnError) {
+        throw err;
+      }
     }
   }
 

--- a/src/agents/subagents/registry/subagent-registry-restore.ts
+++ b/src/agents/subagents/registry/subagent-registry-restore.ts
@@ -27,10 +27,7 @@ import type { SubagentLifecycleController } from "./subagent-registry-lifecycle.
 import { isRetiredRunningSubagent } from "./subagent-registry-restart-recovery-helpers.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import { deleteSubagentSessionForCleanup } from "./subagent-session-cleanup.js";
-import {
-  loadSubagentSessionEntry,
-  type SubagentSessionStoreCache,
-} from "./subagent-session-reconciliation.js";
+import { loadSubagentSessionEntry } from "./subagent-session-reconciliation.js";
 
 type RestoredQueuedFailureSettlementClaim = {
   entry: SubagentRunRecord;
@@ -211,7 +208,6 @@ export function createSubagentRegistryRestorer(config: {
     ensureListener();
     // Session-mode runs have no archive deadline but still need TTL cleanup.
     startSweeper();
-    const restoredSessionCache: SubagentSessionStoreCache = new Map();
     for (const [runId, entry] of runs) {
       // Restart recovery exclusively owns receipt-bearing source rows until it
       // remaps or terminalizes them. Generic resume would wait on an obsolete run.
@@ -221,7 +217,6 @@ export function createSubagentRegistryRestorer(config: {
       if (entry.collect && entry.execution.status === "queued") {
         const cleanupSessionEntry = loadSubagentSessionEntry({
           childSessionKey: entry.childSessionKey,
-          storeCache: restoredSessionCache,
         });
         const launch = entry.queuedLaunch;
         if (!launch) {
@@ -320,7 +315,6 @@ export function createSubagentRegistryRestorer(config: {
       }
       const sessionEntry = loadSubagentSessionEntry({
         childSessionKey: entry.childSessionKey,
-        storeCache: restoredSessionCache,
       });
       // Orphan recovery owns aborted sessions and exact still-running retired
       // executions. Completed sessions must resume normal settlement and delivery.

--- a/src/agents/subagents/registry/subagent-registry-sweep-kill.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweep-kill.ts
@@ -29,7 +29,6 @@ import {
 import {
   loadSubagentSessionEntry,
   resolveCompletionFromSessionEntry,
-  type SubagentSessionStoreCache,
 } from "./subagent-session-reconciliation.js";
 
 function findNextSubagentRunCreatedAt(
@@ -297,7 +296,6 @@ export async function reconcileProvisionalSubagentKill(params: {
   entry: SubagentRunRecord;
   now: number;
   runs: Map<string, SubagentRunRecord>;
-  storeCache: SubagentSessionStoreCache;
   completeSubagentRunWithRecovery: (
     completion: SubagentCompletionRequest,
     source: string,
@@ -356,7 +354,6 @@ export async function reconcileProvisionalSubagentKill(params: {
   }
   const sessionEntry = loadSubagentSessionEntry({
     childSessionKey: entry.childSessionKey,
-    storeCache: params.storeCache,
   });
   const completion = resolveCompletionFromSessionEntry(sessionEntry, now, {
     notBeforeMs: entry.execution.startedAt ?? entry.createdAt,

--- a/src/agents/subagents/registry/subagent-registry-sweeper-recovery.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweeper-recovery.test.ts
@@ -1,12 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
+import { resolveSessionStorePathCore } from "../../../config/sessions.js";
+import {
+  deleteSessionEntryLifecycle,
+  loadSessionEntryReadOnly,
+  replaceSessionEntrySync,
+  resetSessionEntryLifecycle,
+} from "../../../config/sessions/session-accessor.js";
 import type { GatewayRecoveryRuntime } from "../../../gateway/server-instance-runtime.types.js";
 import { resetGatewayWorkAdmission } from "../../../process/gateway-work-admission.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
 import { createSubagentRunRecord } from "../../subagent-test-fixtures.test-helpers.js";
 import { reconcileDurableSubagentKillIntent } from "./subagent-registry-sweep-kill.js";
 import { retireSupersededSubagentRun } from "./subagent-registry-sweeper-retire.js";
 import { createSubagentRegistrySweeper } from "./subagent-registry-sweeper.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import { loadSubagentSessionEntry } from "./subagent-session-reconciliation.js";
 
 const recoverRow = vi.hoisted(() => vi.fn());
 const getAgentRunContext = vi.hoisted(() => vi.fn<(_runId: string) => unknown>(() => undefined));
@@ -69,8 +78,17 @@ function run(): SubagentRunRecord {
 const childRuns = (runs: Map<string, SubagentRunRecord>) => (childSessionKey: string) =>
   [...runs.values()].filter((entry) => entry.childSessionKey === childSessionKey);
 
-function createHarness(runtime: { current?: GatewayRecoveryRuntime }) {
-  const entry = run();
+function archivedRun(overrides: Partial<SubagentRunRecord> = {}): SubagentRunRecord {
+  return {
+    ...run(),
+    cleanup: "delete",
+    archiveAtMs: Date.now() - 1,
+    execution: { status: "terminal", endedAt: Date.now() - 10_000, outcome: { status: "ok" } },
+    ...overrides,
+  };
+}
+
+function createHarness(runtime: { current?: GatewayRecoveryRuntime }, entry = run()) {
   const runs = new Map([[entry.runId, entry]]);
   const finalizeInterruptedSubagentRun = vi.fn(
     async (_params: {
@@ -136,7 +154,14 @@ function createHarness(runtime: { current?: GatewayRecoveryRuntime }) {
     notifyContextEngineSubagentEnded,
     retireSupersededRun: vi.fn(),
     getRunsForChildSession: childRuns(runs),
-    getRunsForCollectorGroup: () => [],
+    getRunsForCollectorGroup: (requesterSessionKey, groupId) =>
+      [...runs].filter(
+        ([, candidate]) =>
+          candidate.collect &&
+          candidate.groupId === groupId &&
+          (candidate.swarmRequesterSessionKey ?? candidate.requesterSessionKey) ===
+            requesterSessionKey,
+      ),
     warn,
   });
   return {
@@ -158,6 +183,9 @@ describe("subagent registry recovery scheduling", () => {
     vi.useFakeTimers();
     resetGatewayWorkAdmission();
     recoverRow.mockReset();
+    vi.mocked(loadSubagentSessionEntry)
+      .mockReset()
+      .mockImplementation(() => killSessionEntry.current);
     getAgentRunContext.mockReset().mockReturnValue(undefined);
     killRuntime.abortEmbeddedAgentRun.mockReset().mockReturnValue(false);
     killRuntime.isEmbeddedAgentRunActive.mockReset().mockReturnValue(false);
@@ -179,6 +207,66 @@ describe("subagent registry recovery scheduling", () => {
   afterEach(() => {
     resetGatewayWorkAdmission();
     vi.useRealTimers();
+  });
+
+  it("observes a sibling completion committed while another completion is awaiting", async () => {
+    const actual = await vi.importActual<typeof import("./subagent-session-reconciliation.js")>(
+      "./subagent-session-reconciliation.js",
+    );
+    await vi
+      .mocked(loadSubagentSessionEntry)
+      .withImplementation(actual.loadSubagentSessionEntry, async () => {
+        await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+          recoverRow.mockResolvedValue({ status: "ignored" });
+          const { entry, runs, completeSubagentRunWithRecovery, sweeper } = createHarness({
+            current: {} as GatewayRecoveryRuntime,
+          });
+          const sibling = {
+            ...run(),
+            runId: "sibling-run",
+            childSessionKey: "agent:main:subagent:sibling",
+          };
+          runs.set(sibling.runId, sibling);
+          const sessionEntry = {
+            sessionId: "child-session",
+            startedAt: entry.execution.startedAt,
+            updatedAt: Date.now(),
+          };
+          replaceSessionEntrySync(
+            { sessionKey: entry.childSessionKey, env: state.env },
+            { ...sessionEntry, status: "done", endedAt: Date.now() },
+          );
+          replaceSessionEntrySync(
+            { sessionKey: sibling.childSessionKey, env: state.env },
+            { ...sessionEntry, sessionId: "sibling-session", status: "running" },
+          );
+          const completion = createDeferred();
+          completeSubagentRunWithRecovery.mockReturnValueOnce(completion.promise);
+          const pending = sweeper.sweepOnce();
+          try {
+            await vi.waitFor(() => expect(completeSubagentRunWithRecovery).toHaveBeenCalledOnce());
+            replaceSessionEntrySync(
+              { sessionKey: sibling.childSessionKey, env: state.env },
+              {
+                ...sessionEntry,
+                sessionId: "sibling-session",
+                status: "done",
+                endedAt: Date.now(),
+              },
+            );
+            completion.resolve();
+            await pending;
+            expect(completeSubagentRunWithRecovery).toHaveBeenLastCalledWith(
+              expect.objectContaining({ runId: sibling.runId, outcome: { status: "ok" } }),
+              "sweeper-session-completion",
+            );
+          } finally {
+            completion.resolve();
+            await pending;
+            sweeper.reset();
+          }
+        });
+      });
   });
 
   it("makes four dispatch attempts and three separate terminal attempts", async () => {
@@ -203,6 +291,125 @@ describe("subagent registry recovery scheduling", () => {
     expect(recoverRow).toHaveBeenCalledTimes(5);
     sweeper.reset();
   });
+
+  it.each(["ordinary", "collector group", "collector launch"])(
+    "preserves a reset sibling during an earlier await in %s cleanup",
+    async (kind) => {
+      const actual = await vi.importActual<typeof import("./subagent-session-reconciliation.js")>(
+        "./subagent-session-reconciliation.js",
+      );
+      await vi
+        .mocked(loadSubagentSessionEntry)
+        .withImplementation(actual.loadSubagentSessionEntry, async () => {
+          await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+            const { entry, runs, callGateway, sweeper } = createHarness({}, archivedRun());
+            const sibling = archivedRun({
+              runId: "sibling-run",
+              childSessionKey: "agent:main:subagent:sibling",
+              ...(kind !== "ordinary"
+                ? { collect: true, groupId: "group", collectorCompletion: { status: "done" } }
+                : {}),
+              collectorLaunchCleanupPending: kind === "collector launch",
+            });
+            runs.set(sibling.runId, sibling);
+            const storePath = resolveSessionStorePathCore(undefined, { agentId: "main" });
+            for (const child of [entry, sibling]) {
+              replaceSessionEntrySync(
+                { sessionKey: child.childSessionKey, env: state.env },
+                {
+                  sessionId: child.runId,
+                  lifecycleRevision: "original-revision",
+                  updatedAt: Date.now(),
+                },
+              );
+            }
+            callGateway.mockImplementation(async ({ params: request }) => {
+              if (request.key === entry.childSessionKey) {
+                await resetSessionEntryLifecycle({
+                  agentId: "main",
+                  storePath,
+                  target: {
+                    canonicalKey: sibling.childSessionKey,
+                    storeKeys: [sibling.childSessionKey],
+                  },
+                  buildNextEntry: ({ currentEntry }) => ({
+                    ...currentEntry,
+                    sessionId: sibling.runId,
+                    lifecycleRevision: "reset-revision",
+                    updatedAt: Date.now(),
+                  }),
+                });
+              }
+              const deleted = await deleteSessionEntryLifecycle({
+                agentId: "main",
+                storePath,
+                target: { canonicalKey: request.key, storeKeys: [request.key] },
+                expectedSessionId: request.expectedSessionId,
+                expectedLifecycleRevision: request.expectedLifecycleRevision,
+                archiveTranscript: false,
+                deleteTranscriptWithoutArchive: true,
+              });
+              if (deleted.expectedEntryMismatch) {
+                throw Object.assign(new Error("session changed"), {
+                  name: "GatewayClientRequestError",
+                  gatewayCode: "INVALID_REQUEST",
+                  details: { reason: "session-changed" },
+                });
+              }
+              return deleted;
+            });
+            try {
+              await sweeper.sweepOnce();
+              expect(
+                loadSessionEntryReadOnly({ sessionKey: entry.childSessionKey }),
+              ).toBeUndefined();
+              expect(
+                loadSessionEntryReadOnly({ sessionKey: sibling.childSessionKey }),
+              ).toMatchObject({
+                sessionId: sibling.runId,
+                lifecycleRevision: "reset-revision",
+              });
+            } finally {
+              sweeper.reset();
+            }
+          });
+        });
+    },
+  );
+
+  it.each(["replacement", "new member"])(
+    "defers a collector group with a %s observed after an earlier cleanup await",
+    async (change) => {
+      const { entry, runs, callGateway, sweeper } = createHarness({}, archivedRun());
+      const collector = (runId: string) =>
+        archivedRun({
+          runId,
+          childSessionKey: `agent:main:subagent:${runId}`,
+          collect: true,
+          groupId: "group",
+          collectorCompletion: { status: "done" },
+        });
+      const sibling = collector("sibling");
+      const groupmate = collector("groupmate");
+      runs.set(sibling.runId, sibling);
+      runs.set(groupmate.runId, groupmate);
+      const changed = collector(change === "replacement" ? sibling.runId : "new-member");
+      callGateway.mockImplementationOnce(async () => {
+        await Promise.resolve();
+        runs.set(changed.runId, changed);
+        return {};
+      });
+
+      await sweeper.sweepOnce();
+
+      expect(callGateway).toHaveBeenCalledOnce();
+      expect(runs.has(entry.runId)).toBe(false);
+      expect(runs.get(changed.runId)).toBe(changed);
+      expect(changed.execution.suppressSessionEffects).toBeUndefined();
+      expect(runs.get(groupmate.runId)).toBe(groupmate);
+      sweeper.reset();
+    },
+  );
 
   it("drops a stale terminal retry when a newer generation wins during finalization", async () => {
     const runtime = { current: {} as GatewayRecoveryRuntime };

--- a/src/agents/subagents/registry/subagent-registry-sweeper.ts
+++ b/src/agents/subagents/registry/subagent-registry-sweeper.ts
@@ -29,7 +29,6 @@ import {
 } from "./subagent-registry-sweep-kill.js";
 import type {
   ContextEngineSubagentEndedParams,
-  SubagentCompletionRequest,
   SubagentRunRecord,
 } from "./subagent-registry.types.js";
 import { isStaleUnendedSubagentRun } from "./subagent-run-liveness.js";
@@ -38,7 +37,6 @@ import {
   loadSubagentSessionEntry,
   resolveCompletionFromSessionEntry,
   resolveSubagentRunOrphanReason,
-  type SubagentSessionStoreCache,
 } from "./subagent-session-reconciliation.js";
 export { retireSupersededSubagentRun } from "./subagent-registry-sweeper-retire.js";
 
@@ -48,7 +46,8 @@ const restartRecoveryLoader = createLazyImportLoader(
   () => import("./subagent-registry-restart-recovery.js"),
 );
 const killRuntimeLoader = createLazyImportLoader(() => import("./subagent-control.runtime.js"));
-type SubagentRunManager = ReturnType<typeof createSubagentRunManager>;
+type RunManager = ReturnType<typeof createSubagentRunManager>;
+type CompletionRuntime = ReturnType<typeof createSubagentRegistryCompletionRuntime>;
 
 export function createSubagentRegistrySweeper(params: {
   runs: Map<string, SubagentRunRecord>;
@@ -57,24 +56,19 @@ export function createSubagentRegistrySweeper(params: {
   clearPendingLifecycleError: (runId: string) => void;
   clearPendingLifecycleTimeout: (runId: string) => void;
   sweepPendingLifecycle: (now: number) => void;
-  completeSubagentRunWithRecovery: (
-    completion: SubagentCompletionRequest,
-    source: string,
-  ) => Promise<void>;
+  completeSubagentRunWithRecovery: CompletionRuntime["completeSubagentRunWithRecovery"];
   getGatewayRecoveryRuntime: () => GatewayRecoveryRuntime | undefined;
-  abandonSubagentRestartRecoveryLaunch: SubagentRunManager["abandonSubagentRestartRecoveryLaunch"];
-  clearAcceptedSubagentRestartRecovery: SubagentRunManager["clearAcceptedSubagentRestartRecovery"];
-  clearPendingSubagentRecoveryNotice: SubagentRunManager["clearPendingSubagentRecoveryNotice"];
-  resumeSettledSubagentRestartRecovery: SubagentRunManager["resumeSettledSubagentRestartRecovery"];
-  replaceSubagentRunAfterSteer: SubagentRunManager["replaceSubagentRunAfterSteer"];
-  markSubagentRestartRecoveryLaunchAttempted: SubagentRunManager["markSubagentRestartRecoveryLaunchAttempted"];
-  markSubagentRestartRecoveryLaunchAccepted: SubagentRunManager["markSubagentRestartRecoveryLaunchAccepted"];
-  markSubagentRestartRecoveryLaunchConsumed: SubagentRunManager["markSubagentRestartRecoveryLaunchConsumed"];
-  reserveSubagentRestartRecoveryLaunch: SubagentRunManager["reserveSubagentRestartRecoveryLaunch"];
-  resetSubagentRestartRecoveryLaunchAttempt: SubagentRunManager["resetSubagentRestartRecoveryLaunchAttempt"];
-  finalizeInterruptedSubagentRun: ReturnType<
-    typeof createSubagentRegistryCompletionRuntime
-  >["finalizeInterruptedSubagentRun"];
+  abandonSubagentRestartRecoveryLaunch: RunManager["abandonSubagentRestartRecoveryLaunch"];
+  clearAcceptedSubagentRestartRecovery: RunManager["clearAcceptedSubagentRestartRecovery"];
+  clearPendingSubagentRecoveryNotice: RunManager["clearPendingSubagentRecoveryNotice"];
+  resumeSettledSubagentRestartRecovery: RunManager["resumeSettledSubagentRestartRecovery"];
+  replaceSubagentRunAfterSteer: RunManager["replaceSubagentRunAfterSteer"];
+  markSubagentRestartRecoveryLaunchAttempted: RunManager["markSubagentRestartRecoveryLaunchAttempted"];
+  markSubagentRestartRecoveryLaunchAccepted: RunManager["markSubagentRestartRecoveryLaunchAccepted"];
+  markSubagentRestartRecoveryLaunchConsumed: RunManager["markSubagentRestartRecoveryLaunchConsumed"];
+  reserveSubagentRestartRecoveryLaunch: RunManager["reserveSubagentRestartRecoveryLaunch"];
+  resetSubagentRestartRecoveryLaunchAttempt: RunManager["resetSubagentRestartRecoveryLaunchAttempt"];
+  finalizeInterruptedSubagentRun: CompletionRuntime["finalizeInterruptedSubagentRun"];
   resumeRequesterSettleWake: SubagentLifecycleController["resumeRequesterSettleWake"];
   startSubagentAnnounceCleanupFlow: SubagentLifecycleController["startSubagentAnnounceCleanupFlow"];
   completeCleanupBookkeeping: SubagentLifecycleController["completeCleanupBookkeeping"];
@@ -179,16 +173,10 @@ export function createSubagentRegistrySweeper(params: {
     );
   }
 
-  type FrozenSessionIdentity = {
-    sessionId: string;
-    lifecycleRevision: string;
-  };
+  type FrozenSessionIdentity = { sessionId: string; lifecycleRevision: string };
 
-  function freezeSessionIdentity(
-    childSessionKey: string,
-    storeCache: SubagentSessionStoreCache,
-  ): FrozenSessionIdentity | undefined {
-    const sessionEntry = loadSubagentSessionEntry({ childSessionKey, storeCache });
+  function freezeSessionIdentity(childSessionKey: string): FrozenSessionIdentity | undefined {
+    const sessionEntry = loadSubagentSessionEntry({ childSessionKey });
     const sessionId = sessionEntry?.sessionId?.trim();
     const lifecycleRevision = sessionEntry?.lifecycleRevision?.trim();
     return sessionId && lifecycleRevision ? { sessionId, lifecycleRevision } : undefined;
@@ -221,6 +209,20 @@ export function createSubagentRegistrySweeper(params: {
     workspaceDir: entry.workspaceDir,
   });
 
+  const isSessionCleanupDeferred = (entry: SubagentRunRecord) =>
+    entry.pauseReason === "sessions_yield" ||
+    entry.delivery?.status === "in_progress" ||
+    (entry.delivery?.status === "pending" &&
+      (entry.expectsCompletionMessage === true ||
+        entry.delivery.payload !== undefined ||
+        entry.delivery.disposition === "session_queued"));
+
+  const isCollectorArchiveReady = (entry: SubagentRunRecord, now: number) =>
+    entry.collectorCompletion &&
+    entry.collectorLaunchCleanupPending !== true &&
+    entry.archiveAtMs !== undefined &&
+    entry.archiveAtMs <= now;
+
   async function sweepOnce() {
     if (sweepInProgress) {
       return;
@@ -228,7 +230,6 @@ export function createSubagentRegistrySweeper(params: {
     sweepInProgress = true;
     try {
       const now = Date.now();
-      const storeCache: SubagentSessionStoreCache = new Map();
       const mutatedRunIds = new Set<string>();
       const collectorArchiveCandidates = new Map<
         string,
@@ -256,6 +257,26 @@ export function createSubagentRegistrySweeper(params: {
             : 0)
         );
       });
+      // Completion stays fresh across awaits, but deletion must retain the earlier
+      // CAS identity. Bind it to the exact run so replacements wait for another pass.
+      const cleanupIdentities = new Map<SubagentRunRecord, FrozenSessionIdentity | undefined>();
+      for (const [, entry] of runEntries) {
+        if (
+          typeof entry.execution.endedAt !== "number" ||
+          isRestoredQueuedFailureSettlementClaimed(entry) ||
+          entry.requesterSettleWake ||
+          isSuspendedPendingFinalDelivery(entry) ||
+          entry.killIntent ||
+          entry.killReconciliation ||
+          shouldSuppressSubagentRecoverySessionEffects(entry) ||
+          !(entry.collect && entry.collectorCompletion
+            ? entry.collectorLaunchCleanupPending || isCollectorArchiveReady(entry, now)
+            : entry.archiveAtMs && entry.archiveAtMs <= now && !isSessionCleanupDeferred(entry))
+        ) {
+          continue;
+        }
+        cleanupIdentities.set(entry, freezeSessionIdentity(entry.childSessionKey));
+      }
       recovery.prune();
       const suspendedEntries = runEntries.filter(([, entry]) =>
         isSuspendedPendingFinalDelivery(entry),
@@ -325,7 +346,6 @@ export function createSubagentRegistrySweeper(params: {
             entry,
             now,
             runs,
-            storeCache,
             completeSubagentRunWithRecovery: params.completeSubagentRunWithRecovery,
             retireSupersededRun: params.retireSupersededRun,
             startSubagentAnnounceCleanupFlow: params.startSubagentAnnounceCleanupFlow,
@@ -370,7 +390,6 @@ export function createSubagentRegistrySweeper(params: {
 
             const sessionEntry = loadSubagentSessionEntry({
               childSessionKey: entry.childSessionKey,
-              storeCache,
             });
             const completion = resolveCompletionFromSessionEntry(sessionEntry, now, {
               notBeforeMs: entry.execution.startedAt ?? entry.createdAt,
@@ -418,7 +437,10 @@ export function createSubagentRegistrySweeper(params: {
           if (entry.collectorLaunchCleanupPending) {
             const suppressSessionEffects = shouldSuppressSubagentRecoverySessionEffects(entry);
             if (!suppressSessionEffects) {
-              const sessionIdentity = freezeSessionIdentity(entry.childSessionKey, storeCache);
+              if (!cleanupIdentities.has(entry)) {
+                continue;
+              }
+              const sessionIdentity = cleanupIdentities.get(entry);
               if (!sessionIdentity) {
                 entry.execution = {
                   ...entry.execution,
@@ -478,14 +500,7 @@ export function createSubagentRegistrySweeper(params: {
           }
           continue;
         }
-        if (
-          entry.pauseReason === "sessions_yield" ||
-          entry.delivery?.status === "in_progress" ||
-          (entry.delivery?.status === "pending" &&
-            (entry.expectsCompletionMessage === true ||
-              entry.delivery.payload !== undefined ||
-              entry.delivery.disposition === "session_queued"))
-        ) {
+        if (isSessionCleanupDeferred(entry)) {
           // Queued or leased completion delivery owns this row until it settles.
           continue;
         }
@@ -518,7 +533,10 @@ export function createSubagentRegistrySweeper(params: {
         const suppressSessionEffects = shouldSuppressSubagentRecoverySessionEffects(entry);
         let sessionOwnershipChanged = false;
         if (!suppressSessionEffects) {
-          const sessionIdentity = freezeSessionIdentity(entry.childSessionKey, storeCache);
+          if (!cleanupIdentities.has(entry)) {
+            continue;
+          }
+          const sessionIdentity = cleanupIdentities.get(entry);
           if (!sessionIdentity) {
             sessionOwnershipChanged = true;
           } else {
@@ -559,10 +577,9 @@ export function createSubagentRegistrySweeper(params: {
         if (
           groupEntries.some(
             ([, candidate]) =>
-              !candidate.collectorCompletion ||
-              candidate.collectorLaunchCleanupPending === true ||
-              candidate.archiveAtMs === undefined ||
-              candidate.archiveAtMs > now,
+              !isCollectorArchiveReady(candidate, now) ||
+              (!shouldSuppressSubagentRecoverySessionEffects(candidate) &&
+                !cleanupIdentities.has(candidate)),
           )
         ) {
           continue;
@@ -570,10 +587,14 @@ export function createSubagentRegistrySweeper(params: {
         let deleteFailed = false;
         let groupMembershipChanged = false;
         for (const [candidateRunId, candidate] of groupEntries) {
+          if (runs.get(candidateRunId) !== candidate) {
+            groupMembershipChanged = true;
+            break;
+          }
           if (shouldSuppressSubagentRecoverySessionEffects(candidate)) {
             continue;
           }
-          const sessionIdentity = freezeSessionIdentity(candidate.childSessionKey, storeCache);
+          const sessionIdentity = cleanupIdentities.get(candidate);
           if (!sessionIdentity) {
             candidate.execution = {
               ...candidate.execution,
@@ -660,10 +681,7 @@ export function createSubagentRegistrySweeper(params: {
           liveGroupEntries.some(
             ([candidateRunId, candidate]) =>
               expectedGroupEntries.get(candidateRunId) !== candidate ||
-              !candidate.collectorCompletion ||
-              candidate.collectorLaunchCleanupPending === true ||
-              candidate.archiveAtMs === undefined ||
-              candidate.archiveAtMs > now,
+              !isCollectorArchiveReady(candidate, now),
           )
         ) {
           continue;

--- a/src/agents/subagents/registry/subagent-registry.archive.e2e.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.archive.e2e.test.ts
@@ -22,7 +22,9 @@ const taskStatusMocks = vi.hoisted(() => ({
   listTasksForSessionKeyForStatus: vi.fn(() => [] as never[]),
 }));
 const sessionAccessorMocks = vi.hoisted(() => ({
-  listSessionEntriesReadOnly: vi.fn(() => [] as Array<{ sessionKey: string; entry: unknown }>),
+  loadSessionEntryReadOnly: vi.fn<
+    typeof import("../../../config/sessions/session-accessor.js").loadSessionEntryReadOnly
+  >(() => undefined),
 }));
 
 const noop = () => {};
@@ -66,7 +68,7 @@ vi.mock("../../../config/sessions/session-accessor.js", async (importOriginal) =
     await importOriginal<typeof import("../../../config/sessions/session-accessor.js")>();
   return {
     ...actual,
-    listSessionEntriesReadOnly: sessionAccessorMocks.listSessionEntriesReadOnly,
+    loadSessionEntryReadOnly: sessionAccessorMocks.loadSessionEntryReadOnly,
   };
 });
 
@@ -161,8 +163,7 @@ describe("subagent registry archive behavior", () => {
     taskStatusMocks.findTaskByRunIdForStatus.mockReset();
     taskStatusMocks.listTasksForSessionKeyForStatus.mockReset();
     taskStatusMocks.listTasksForSessionKeyForStatus.mockReturnValue([]);
-    sessionAccessorMocks.listSessionEntriesReadOnly.mockReset();
-    sessionAccessorMocks.listSessionEntriesReadOnly.mockReturnValue([]);
+    sessionAccessorMocks.loadSessionEntryReadOnly.mockReset();
     taskStatusMocks.findTaskByRunIdForStatus.mockImplementation((runId: string) => {
       const entry = mod
         .listSubagentRunsForRequester("agent:main:main")
@@ -381,15 +382,11 @@ describe("subagent registry archive behavior", () => {
     const attachmentsDir = path.join(attachmentsRootDir, "child");
     await fs.mkdir(attachmentsDir, { recursive: true });
     await fs.writeFile(path.join(attachmentsDir, "artifact.txt"), "artifact", "utf8");
-    sessionAccessorMocks.listSessionEntriesReadOnly.mockReturnValue([
-      {
-        sessionKey: "agent:main:subagent:delete-retry",
-        entry: {
-          sessionId: "session-delete-retry",
-          lifecycleRevision: "lifecycle-delete-retry",
-        },
-      },
-    ]);
+    sessionAccessorMocks.loadSessionEntryReadOnly.mockReturnValue({
+      sessionId: "session-delete-retry",
+      lifecycleRevision: "lifecycle-delete-retry",
+      updatedAt: Date.now(),
+    });
     let deleteAttempts = 0;
     vi.mocked(callGateway).mockImplementation(async (request: unknown) => {
       const method = (request as { method?: string }).method;
@@ -889,15 +886,11 @@ describe("subagent registry archive behavior", () => {
     const deletePromise = new Promise<void>((resolve) => {
       resolveDelete = resolve;
     });
-    sessionAccessorMocks.listSessionEntriesReadOnly.mockReturnValue([
-      {
-        sessionKey: "agent:main:subagent:delete-inflight",
-        entry: {
-          sessionId: "session-delete-inflight",
-          lifecycleRevision: "lifecycle-delete-inflight",
-        },
-      },
-    ]);
+    sessionAccessorMocks.loadSessionEntryReadOnly.mockReturnValue({
+      sessionId: "session-delete-inflight",
+      lifecycleRevision: "lifecycle-delete-inflight",
+      updatedAt: Date.now(),
+    });
     vi.mocked(callGateway).mockImplementation(async (request: unknown) => {
       const method = (request as { method?: string }).method;
       if (method === "agent.wait") {

--- a/src/agents/subagents/registry/subagent-registry.ts
+++ b/src/agents/subagents/registry/subagent-registry.ts
@@ -1,5 +1,6 @@
 /** Coordinates subagent registration, lifecycle, delivery, steering, recovery, and persistence. */
 import type { AgentWaitParams } from "../../../../packages/gateway-protocol/src/index.js";
+import { resolveAgentIdFromSessionKey } from "../../../config/sessions.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { callGateway } from "../../../gateway/call.js";
 import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
@@ -98,6 +99,22 @@ function persistSubagentRunsOrThrow(...runIds: string[]) {
     subagentRuns,
     runIds.length > 0 ? runIds : undefined,
   );
+}
+
+/** Prepare registry hydration before the session owner's synchronous reset commit. */
+export function prepareSubagentSessionCleanupRevocation(params: {
+  sessionKey: string;
+  agentId: string;
+}): () => void {
+  subagentRestorer.restoreOnce(undefined, true);
+  return () => {
+    if (resolveAgentIdFromSessionKey(params.sessionKey) !== params.agentId) {
+      return;
+    }
+    subagentLifecycleController.revokeTerminalSessionEffects(
+      getSubagentRunsForChildSession(params.sessionKey),
+    );
+  };
 }
 
 function findSubagentTaskForRun(entry: SubagentRunRecord) {

--- a/src/agents/subagents/registry/subagent-registry.ts
+++ b/src/agents/subagents/registry/subagent-registry.ts
@@ -1,6 +1,5 @@
 /** Coordinates subagent registration, lifecycle, delivery, steering, recovery, and persistence. */
 import type { AgentWaitParams } from "../../../../packages/gateway-protocol/src/index.js";
-import { resolveAgentIdFromSessionKey } from "../../../config/sessions.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { callGateway } from "../../../gateway/call.js";
 import type { GatewayContextResolver } from "../../../gateway/server-methods/types.js";
@@ -102,17 +101,13 @@ function persistSubagentRunsOrThrow(...runIds: string[]) {
 }
 
 /** Prepare registry hydration before the session owner's synchronous reset commit. */
-export function prepareSubagentSessionCleanupRevocation(params: {
-  sessionKey: string;
-  agentId: string;
-}): () => void {
+export function prepareSubagentSessionCleanupRevocation(sessionKey: string): () => void {
   subagentRestorer.restoreOnce(undefined, true);
   return () => {
-    if (resolveAgentIdFromSessionKey(params.sessionKey) !== params.agentId) {
-      return;
-    }
+    // The reset owner already resolved the target. Child keys are agent-scoped;
+    // an unscoped global key must not be reinterpreted as another child session.
     subagentLifecycleController.revokeTerminalSessionEffects(
-      getSubagentRunsForChildSession(params.sessionKey),
+      getSubagentRunsForChildSession(sessionKey),
     );
   };
 }

--- a/src/agents/subagents/registry/subagent-session-reconciliation.test.ts
+++ b/src/agents/subagents/registry/subagent-session-reconciliation.test.ts
@@ -1,16 +1,18 @@
+import fs from "node:fs";
 import { describe, expect, it } from "vitest";
-import { resolveSessionStorePathCore, type SessionEntry } from "../../../config/sessions.js";
-import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import type { SessionEntry } from "../../../config/sessions.js";
 import {
+  listSessionEntriesReadOnly,
+  replaceSessionEntrySync,
+} from "../../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { resolveIncognitoOpenClawAgentSqlitePath } from "../../../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
+import {
+  loadSubagentSessionEntry,
   resolveSubagentSessionCompletion,
-  type SubagentSessionStoreCache,
+  resolveSubagentSessionStartedAt,
 } from "./subagent-session-reconciliation.js";
-
-const configuredStorePath = "/virtual/openclaw-subagent-reconciliation-sessions.json";
-const cfg = {
-  session: { store: configuredStorePath },
-} satisfies OpenClawConfig;
-const storePath = resolveSessionStorePathCore(configuredStorePath, { agentId: "main" });
 
 const terminalSession: SessionEntry = {
   sessionId: "sibling-session",
@@ -20,23 +22,22 @@ const terminalSession: SessionEntry = {
   endedAt: 2_000,
 };
 
-function resolveCompletion(childSessionKey: string, storedSessionKey: string) {
-  const storeCache: SubagentSessionStoreCache = new Map([
-    [storePath, { [storedSessionKey]: terminalSession }],
-  ]);
-  return resolveSubagentSessionCompletion({
-    childSessionKey,
-    fallbackEndedAt: 3_000,
-    notBeforeMs: 0,
-    storeCache,
-    cfg,
+async function resolveCompletion(childSessionKey: string, storedSessionKey: string) {
+  return withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+    replaceSessionEntrySync({ sessionKey: storedSessionKey, env: state.env }, terminalSession);
+    return resolveSubagentSessionCompletion({
+      childSessionKey,
+      fallbackEndedAt: 3_000,
+      notBeforeMs: 0,
+      cfg: {},
+    });
   });
 }
 
 describe("subagent session reconciliation keys", () => {
-  it("matches case-insensitive structural session-key segments", () => {
+  it("matches case-insensitive structural session-key segments", async () => {
     expect(
-      resolveCompletion("Agent:MAIN:telegram:group:ROOM", "agent:main:telegram:group:room"),
+      await resolveCompletion("Agent:MAIN:telegram:group:ROOM", "agent:main:telegram:group:room"),
     ).toMatchObject({ endedAt: 2_000, outcome: { status: "ok" } });
   });
 
@@ -53,8 +54,74 @@ describe("subagent session reconciliation keys", () => {
     },
   ])(
     "does not match a case-distinct $channel opaque peer",
-    ({ childSessionKey, storedSessionKey }) => {
-      expect(resolveCompletion(childSessionKey, storedSessionKey)).toBeNull();
+    async ({ childSessionKey, storedSessionKey }) => {
+      expect(await resolveCompletion(childSessionKey, storedSessionKey)).toBeNull();
+    },
+  );
+});
+
+describe("subagent session reconciliation ownership", () => {
+  it.each([
+    { name: "default per-agent", file: undefined },
+    { name: "configured fixed", file: "sessions.json" },
+    { name: "configured custom", file: "custom-sessions.json" },
+    { name: "explicit shared SQLite", file: "shared.sqlite" },
+  ])("reconciles each agent in a $name store", async ({ file }) => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const storePath = file ? state.path(file) : undefined;
+      const cfg: OpenClawConfig = storePath ? { session: { store: storePath } } : {};
+      for (const agentId of ["main", "worker"]) {
+        replaceSessionEntrySync(
+          { agentId, sessionKey: `agent:${agentId}:subagent:child`, storePath, env: state.env },
+          { ...terminalSession, sessionId: `${agentId}-child` },
+        );
+      }
+
+      for (const agentId of ["main", "worker"]) {
+        const childSessionKey = `agent:${agentId}:subagent:child`;
+        expect(loadSubagentSessionEntry({ childSessionKey, cfg })?.sessionId).toBe(
+          `${agentId}-child`,
+        );
+        expect(
+          resolveSubagentSessionCompletion({ childSessionKey, cfg, fallbackEndedAt: 3_000 }),
+        ).toMatchObject({ endedAt: 2_000, outcome: { status: "ok" } });
+        expect(resolveSubagentSessionStartedAt({ childSessionKey, cfg })).toBe(1_000);
+      }
+    });
+  });
+
+  it.each(["main", "worker"])(
+    "keeps %s incognito completion separate from its configured durable store",
+    async (agentId) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+        const storePath = state.path("custom-sessions.json");
+        const cfg = { session: { store: storePath } } satisfies OpenClawConfig;
+        const durableKey = `agent:${agentId}:subagent:durable`;
+        const childSessionKey = `agent:${agentId}:subagent:incognito-child`;
+        replaceSessionEntrySync(
+          { agentId, sessionKey: durableKey, storePath, env: state.env },
+          { ...terminalSession, sessionId: "durable-child" },
+        );
+        replaceSessionEntrySync(
+          { agentId, sessionKey: childSessionKey, storePath, env: state.env },
+          { ...terminalSession, sessionId: "incognito-child", incognito: true },
+        );
+
+        expect(
+          resolveSubagentSessionCompletion({ childSessionKey, cfg, fallbackEndedAt: 3_000 }),
+        ).toMatchObject({ endedAt: 2_000, outcome: { status: "ok" } });
+        expect(loadSubagentSessionEntry({ childSessionKey, cfg })?.sessionId).toBe(
+          "incognito-child",
+        );
+        expect(
+          listSessionEntriesReadOnly({ agentId, storePath, env: state.env }).map(
+            ({ sessionKey }) => sessionKey,
+          ),
+        ).toEqual([durableKey]);
+        expect(
+          fs.existsSync(resolveIncognitoOpenClawAgentSqlitePath({ agentId, env: state.env })),
+        ).toBe(false);
+      });
     },
   );
 });

--- a/src/agents/subagents/registry/subagent-session-reconciliation.ts
+++ b/src/agents/subagents/registry/subagent-session-reconciliation.ts
@@ -10,11 +10,7 @@ import {
   resolveSessionStorePathCore,
   type InternalSessionEntry as SessionEntry,
 } from "../../../config/sessions.js";
-import {
-  listSessionEntriesReadOnly,
-  loadSessionEntryReadOnly,
-} from "../../../config/sessions/session-accessor.js";
-import { normalizeStoreSessionKey } from "../../../config/sessions/store-entry.js";
+import { loadSessionEntryReadOnly } from "../../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { SubagentRunOutcome } from "../announce/subagent-announce-output.js";
 import {
@@ -26,7 +22,6 @@ import {
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
 import { isStaleUnendedSubagentRun } from "./subagent-run-liveness.js";
 
-export type SubagentSessionStoreCache = Map<string, Record<string, SessionEntry>>;
 export type SubagentRunOrphanReason =
   | "missing-session-entry"
   | "missing-session-id"
@@ -70,34 +65,8 @@ function freshSessionStartedAt(
   return notBeforeMs === undefined || startedAt >= notBeforeMs ? startedAt : undefined;
 }
 
-/** Load a child session entry using the agent-specific session store path. */
+/** Read the current child entry; session-key scope also selects incognito storage. */
 export function loadSubagentSessionEntry(params: {
-  childSessionKey: string;
-  storeCache?: SubagentSessionStoreCache;
-  cfg?: OpenClawConfig;
-}): SessionEntry | undefined {
-  const key = params.childSessionKey.trim();
-  if (!key) {
-    return undefined;
-  }
-  const agentId = resolveAgentIdFromSessionKey(key);
-  const cfg = params.cfg ?? getRuntimeConfig();
-  const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
-  let store = params.storeCache?.get(storePath);
-  if (!store) {
-    store = Object.fromEntries(
-      listSessionEntriesReadOnly({ storePath, clone: false }).map(({ sessionKey, entry }) => [
-        sessionKey,
-        entry,
-      ]),
-    );
-    params.storeCache?.set(storePath, store);
-  }
-  return store[key] ?? store[normalizeStoreSessionKey(key)];
-}
-
-/** Resolve a child session entry without depending on the file-backed store shape. */
-function loadSubagentSessionEntryForAccessor(params: {
   childSessionKey: string;
   cfg?: OpenClawConfig;
 }): SessionEntry | undefined {
@@ -109,6 +78,7 @@ function loadSubagentSessionEntryForAccessor(params: {
   const cfg = params.cfg ?? getRuntimeConfig();
   const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
   return loadSessionEntryReadOnly({
+    agentId,
     storePath,
     sessionKey: key,
     clone: false,
@@ -127,7 +97,7 @@ export function resolveSubagentRunOrphanReason(params: {
     return "missing-session-entry";
   }
   try {
-    const sessionEntry = loadSubagentSessionEntryForAccessor({
+    const sessionEntry = loadSubagentSessionEntry({
       childSessionKey,
       cfg: params.cfg,
     });
@@ -227,13 +197,11 @@ export function resolveSubagentSessionCompletion(params: {
   childSessionKey: string;
   fallbackEndedAt: number;
   notBeforeMs?: number;
-  storeCache?: SubagentSessionStoreCache;
   cfg?: OpenClawConfig;
 }): SubagentSessionCompletion | null {
   return resolveCompletionFromSessionEntry(
     loadSubagentSessionEntry({
       childSessionKey: params.childSessionKey,
-      storeCache: params.storeCache,
       cfg: params.cfg,
     }),
     params.fallbackEndedAt,
@@ -245,12 +213,10 @@ export function resolveSubagentSessionCompletion(params: {
 export function resolveSubagentSessionStartedAt(params: {
   childSessionKey: string;
   notBeforeMs?: number;
-  storeCache?: SubagentSessionStoreCache;
   cfg?: OpenClawConfig;
 }): number | undefined {
   const sessionEntry = loadSubagentSessionEntry({
     childSessionKey: params.childSessionKey,
-    storeCache: params.storeCache,
     cfg: params.cfg,
   });
   return isFreshForRun(sessionEntry, params.notBeforeMs)

--- a/src/gateway/server-methods/tasks.access.test.ts
+++ b/src/gateway/server-methods/tasks.access.test.ts
@@ -8,7 +8,11 @@ import {
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { ensureProfileForEmail } from "../../state/user-profiles.js";
-import { deleteTaskRecordById } from "../../tasks/runtime-internal.js";
+import {
+  deleteTaskRecordById,
+  getTaskById,
+  markTaskTerminalById,
+} from "../../tasks/runtime-internal.js";
 import { reloadTaskRegistryFromStore } from "../../tasks/task-registry.js";
 import { saveTaskRegistryStateToSqlite } from "../../tasks/task-registry.store.sqlite.js";
 import { resetTaskRegistryForTests } from "../../tasks/task-runtime.test-helpers.js";
@@ -34,6 +38,55 @@ afterEach(async () => {
 });
 
 describe("task page access snapshots", () => {
+  it("returns a stable session page before unrelated task churn runs", async () => {
+    const targetKey = "agent:main:target";
+    const tasks = Array.from({ length: 33 }, (_, index) =>
+      createSnapshotTask({
+        taskId: `scoped-task-${index}`,
+        requesterSessionKey: index < 20 ? targetKey : "agent:main:foreign",
+        ownerKey: index < 20 ? targetKey : "agent:main:foreign",
+        deliveryStatus: "not_applicable",
+      }),
+    );
+    saveTaskRegistryStateToSqlite({
+      tasks: new Map(tasks.map((task) => [task.taskId, task])),
+      deliveryStates: new Map(),
+    });
+    reloadTaskRegistryFromStore();
+    const before = tasks.slice(0, 20).map((task) => getTaskById(task.taskId));
+    let mutations = 0;
+    const mutate = () => {
+      if (mutations === 9) {
+        return;
+      }
+      expect(
+        markTaskTerminalById({
+          taskId: `scoped-task-${20 + mutations++}`,
+          status: "succeeded",
+          endedAt: 2_000 + mutations,
+        }),
+      ).not.toBeNull();
+      pending = setImmediate(mutate);
+    };
+    let pending = setImmediate(mutate);
+    try {
+      const { calls, payload } = await runTaskHandler(
+        "tasks.list",
+        { sessionKey: targetKey, limit: 100 },
+        {},
+        identifiedClient(["operator.admin"]),
+      );
+      expect({ calls, mutations }).toMatchObject({
+        calls: [[true, expect.any(Object)]],
+        mutations: 0,
+      });
+      expect(payload?.tasks).toHaveLength(20);
+      expect(payload?.nextCursor).toBeUndefined();
+      expect(tasks.slice(0, 20).map((task) => getTaskById(task.taskId))).toEqual(before);
+    } finally {
+      clearImmediate(pending);
+    }
+  });
   it.each(["canonical", "main alias", "distinct requesters", "warm"] as const)(
     "bounds session lookup work across a yielded task page using %s keys",
     async (mode) => {

--- a/src/gateway/server.sessions.reset-subagent-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-subagent-cleanup.test.ts
@@ -1,0 +1,540 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { listRegisteredAgentHarnesses, registerAgentHarness } from "../agents/harness/registry.js";
+import { restoreRegisteredAgentHarnesses } from "../agents/harness/registry.test-support.js";
+import { subagentRegistryDeps } from "../agents/subagents/registry/subagent-registry-deps.js";
+import * as completionOwner from "../agents/subagents/registry/subagent-registry-lifecycle-completion.js";
+import { subagentRuns } from "../agents/subagents/registry/subagent-registry-memory.js";
+import { onSubagentRegistryPersisted } from "../agents/subagents/registry/subagent-registry-state.js";
+import {
+  cleanupSubagentRegistryPersistenceTest,
+  settleSubagentRegistryPersistenceWork,
+} from "../agents/subagents/registry/subagent-registry.persistence.test-support.js";
+import { loadSubagentRegistryFromSqlite } from "../agents/subagents/registry/subagent-registry.store.sqlite.js";
+import {
+  registerSubagentRun,
+  claimSubagentRunKill,
+  initSubagentRegistry,
+  settleFailedQueuedSubagentLaunch,
+  resetSubagentRegistryForTests,
+  testing,
+} from "../agents/subagents/registry/subagent-registry.test-helpers.js";
+import { waitForCollectorCompletion } from "../agents/tools/agents-wait-tool.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import { resolveSessionStorePathCore } from "../config/sessions.js";
+import { loadSessionEntry, replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import { beginSessionWorkAdmission } from "../sessions/session-lifecycle-admission.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { resetTaskRegistryForTests } from "../tasks/task-registry.test-support.js";
+import { findTaskByRunIdForStatus } from "../tasks/task-status-access.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { createDirectChatContext } from "./server-chat.agent-events.test-helpers.js";
+import { sessionDeleteHandlers } from "./server-methods/sessions-delete.js";
+import { sessionMutationHandlers } from "./server-methods/sessions-mutations.js";
+import { performGatewaySessionReset } from "./session-reset-service.js";
+
+let stateDir: string;
+let cfg: OpenClawConfig;
+const env = captureEnv(["OPENCLAW_STATE_DIR"]);
+const key = "agent:main:subagent:reset-cleanup";
+const runId = "reset-cleanup-run";
+let attempts = 0;
+let harnesses: ReturnType<typeof listRegisteredAgentHarnesses>;
+
+async function request(
+  method: "sessions.reset" | "sessions.delete",
+  params: Record<string, unknown>,
+) {
+  const handler = expectDefined(
+    (method === "sessions.reset" ? sessionMutationHandlers : sessionDeleteHandlers)[method],
+    "session handler",
+  );
+  let result: unknown;
+  await handler({
+    req: { type: "req", id: method, method, params },
+    params,
+    client: null,
+    isWebchatConnect: () => false,
+    context: createDirectChatContext({ getRuntimeConfig: () => cfg }),
+    respond: (ok, payload, error) => {
+      if (!ok) {
+        throw new Error(error?.message ?? "request failed");
+      }
+      result = payload;
+    },
+  });
+  return result;
+}
+
+beforeEach(async () => {
+  stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-reset-cleanup-"));
+  setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+  cfg = { agents: { list: [{ id: "main", default: true, workspace: stateDir }] } };
+  setRuntimeConfigSnapshot(cfg);
+  resetSubagentRegistryForTests({ persist: false });
+  resetTaskRegistryForTests({ persist: false });
+  attempts = 0;
+  harnesses = listRegisteredAgentHarnesses();
+  testing.setDepsForTest({
+    callGateway: async <T>(options: { method: string; params?: unknown }) => {
+      expect(options.method).toBe("sessions.delete");
+      if (++attempts === 1) {
+        throw new Error("first delete transport unavailable");
+      }
+      return (await request("sessions.delete", options.params as Record<string, unknown>)) as T;
+    },
+  });
+  replaceSessionEntrySync(
+    { sessionKey: key, agentId: "main" },
+    {
+      sessionId: "reset-cleanup-session",
+      lifecycleRevision: "original",
+      updatedAt: Date.now(),
+    },
+  );
+  registerCollector(runId);
+  expect(findTaskByRunIdForStatus(runId)?.status).toBe("queued");
+  expect(settleFailedQueuedSubagentLaunch(runId, "launch failed")).toBe(true);
+  expect(findTaskByRunIdForStatus(runId)?.status).toBe("failed");
+  await testing.sweepOnceForTests();
+  expect(attempts).toBe(1);
+  expect(loadSubagentRegistryFromSqlite().get(runId)?.collectorLaunchCleanupPending).toBe(true);
+  expect(loadSessionEntry({ sessionKey: key })?.lifecycleRevision).toBe("original");
+});
+
+function registerCollector(id: string, childSessionKey = key, agentId = "main") {
+  registerSubagentRun({
+    runId: id,
+    childSessionKey,
+    requesterSessionKey: "agent:main:main",
+    requesterAgentId: "main",
+    agentId,
+    requesterDisplayKey: "main",
+    task: "failed collector launch",
+    cleanup: "delete",
+    collect: true,
+    groupId: "reset-cleanup-group",
+    swarmRequesterSessionKey: "agent:main:main",
+    queued: true,
+    expectsCompletionMessage: false,
+    taskRowOwnership: "required",
+  });
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  restoreRegisteredAgentHarnesses(harnesses);
+  await cleanupSubagentRegistryPersistenceTest({
+    stateDir,
+    resetRegistry: () => resetSubagentRegistryForTests({ persist: false }),
+    resetDeps: () => testing.setDepsForTest(),
+    closeDatabases: () => {
+      resetTaskRegistryForTests({ persist: false });
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+    },
+  });
+  clearRuntimeConfigSnapshot();
+  env.restore();
+});
+
+test.each(["unchanged", "reset", "reset-reopen", "reopen-reset-reopen"])(
+  "collector cleanup retry: %s",
+  async (mode) => {
+    const reset = mode !== "unchanged";
+    if (mode === "reopen-reset-reopen") {
+      reopen();
+    }
+    if (reset) {
+      await request("sessions.reset", { key });
+      expect(loadSessionEntry({ sessionKey: key })?.lifecycleRevision).not.toBe("original");
+    }
+    const beforeRetry = loadSessionEntry({ sessionKey: key });
+    if (mode.endsWith("reopen")) {
+      reopen();
+    }
+    await testing.sweepOnceForTests();
+    expect(loadSessionEntry({ sessionKey: key })).toEqual(reset ? beforeRetry : undefined);
+    expect(attempts).toBe(reset ? 1 : 2);
+    await expectResultRetained();
+  },
+);
+
+function reopen() {
+  resetSubagentRegistryForTests({ persist: false });
+  resetTaskRegistryForTests({ persist: false });
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  initSubagentRegistry();
+}
+
+async function expectResultRetained() {
+  expect(loadSubagentRegistryFromSqlite().get(runId)?.collectorLaunchCleanupPending).toBe(false);
+  await expect(
+    waitForCollectorCompletion({
+      runId,
+      currentSessionKeys: new Set(["agent:main:main"]),
+      currentAgentId: "main",
+      config: cfg,
+    }),
+  ).resolves.toMatchObject({ runId, status: "failed", result: "launch failed" });
+  expect(findTaskByRunIdForStatus(runId)).toMatchObject({
+    status: "failed",
+    error: "launch failed",
+  });
+}
+
+function agentDatabase() {
+  const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId: "main" });
+  return openOpenClawAgentDatabase({
+    agentId: "main",
+    path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+  });
+}
+
+test("a real registry write failure blocks reset publication and leaves cleanup retryable", async () => {
+  const database = openOpenClawStateDatabase();
+  database.db.exec(`CREATE TEMP TRIGGER reject_revocation BEFORE UPDATE ON subagent_runs
+    WHEN json_extract(NEW.payload_json, '$.execution.suppressSessionEffects') = 1
+    BEGIN SELECT RAISE(ABORT, 'revocation write rejected'); END`);
+  const before = loadSessionEntry({ sessionKey: key });
+  await expect(request("sessions.reset", { key })).rejects.toThrow("revocation write rejected");
+  expect(loadSessionEntry({ sessionKey: key })).toEqual(before);
+  expect(subagentRuns.get(runId)?.execution.suppressSessionEffects).not.toBe(true);
+  expect(loadSubagentRegistryFromSqlite().get(runId)?.execution.suppressSessionEffects).not.toBe(
+    true,
+  );
+  database.db.exec("DROP TRIGGER reject_revocation");
+  reopen();
+  await testing.sweepOnceForTests();
+  expect(loadSessionEntry({ sessionKey: key })).toBeUndefined();
+  expect(attempts).toBe(2);
+  await expectResultRetained();
+});
+
+test("durable revocation survives reset-store failure and reopen without reviving deletion", async () => {
+  agentDatabase().db.exec(`CREATE TEMP TRIGGER reject_reset BEFORE UPDATE ON session_nodes
+    WHEN json_extract(NEW.entry_json, '$.lifecycleRevision') != json_extract(OLD.entry_json, '$.lifecycleRevision')
+    BEGIN SELECT RAISE(ABORT, 'reset store rejected'); END`);
+  const before = loadSessionEntry({ sessionKey: key });
+  await expect(request("sessions.reset", { key })).rejects.toThrow("reset store rejected");
+  expect(loadSubagentRegistryFromSqlite().get(runId)?.execution.suppressSessionEffects).toBe(true);
+  reopen();
+  await testing.sweepOnceForTests();
+  expect(loadSessionEntry({ sessionKey: key })).toEqual(before);
+  expect(attempts).toBe(1);
+  await expectResultRetained();
+});
+
+test("postcommit failure cannot restore cleanup authority after a successful reset", async () => {
+  await expect(
+    performGatewaySessionReset({
+      key,
+      reason: "reset",
+      commandSource: "test",
+      workerPlacementContext: {},
+      onCommitted: () => {
+        throw new Error("reset response lost");
+      },
+    }),
+  ).rejects.toThrow("reset response lost");
+  const successor = loadSessionEntry({ sessionKey: key });
+  expect(successor?.lifecycleRevision).not.toBe("original");
+  reopen();
+  await testing.sweepOnceForTests();
+  expect(loadSessionEntry({ sessionKey: key })).toEqual(successor);
+  expect(attempts).toBe(1);
+  await expectResultRetained();
+});
+
+function startCollector(id: string) {
+  registerCollector(id);
+  emitAgentEvent({
+    runId: id,
+    stream: "lifecycle",
+    data: { phase: "start", startedAt: Date.now() },
+  });
+  expect(subagentRuns.get(id)?.execution.status).toBe("running");
+}
+
+test("same-turn reset keeps its active continuation and task unsuppressed", async () => {
+  const activeId = "active-continuation";
+  startCollector(activeId);
+  const interrupt = vi.fn();
+  const admission = await beginSessionWorkAdmission({
+    scope: resolveSessionStorePathCore(undefined, { agentId: "main" }),
+    identities: [key, "reset-cleanup-session"],
+    assertAllowed: () => {},
+    onInterrupt: interrupt,
+  });
+  try {
+    await admission.run(() => request("sessions.reset", { key }));
+    expect(admission.isActive()).toBe(true);
+    expect(interrupt).not.toHaveBeenCalled();
+    expect(subagentRuns.get(activeId)?.execution).toMatchObject({ status: "running" });
+    expect(
+      loadSubagentRegistryFromSqlite().get(activeId)?.execution.suppressSessionEffects,
+    ).not.toBe(true);
+    expect(findTaskByRunIdForStatus(activeId)?.status).toBe("running");
+    expect(loadSubagentRegistryFromSqlite().get(runId)?.execution.suppressSessionEffects).toBe(
+      true,
+    );
+  } finally {
+    admission.release();
+  }
+});
+
+test.each(["new", "replacement"])(
+  "reset preparation does not revoke a %s active owner",
+  async (mode) => {
+    const original = expectDefined(subagentRuns.get(runId), "registered collector");
+    const activeId = mode === "replacement" ? runId : "new-active-owner";
+    registerAgentHarness({
+      id: "reset-cleanup-race",
+      label: "Reset cleanup race",
+      supports: () => ({ supported: false }),
+      runAttempt: async () => {
+        throw new Error("not used");
+      },
+      reset: async () => {
+        startCollector(activeId);
+      },
+    });
+    await request("sessions.reset", { key });
+    expect(subagentRuns.get(activeId)?.execution.status).toBe("running");
+    expect(
+      loadSubagentRegistryFromSqlite().get(activeId)?.execution.suppressSessionEffects,
+    ).not.toBe(true);
+    if (mode === "replacement") {
+      expect(subagentRuns.get(runId)).not.toBe(original);
+      expect(original.execution.suppressSessionEffects).not.toBe(true);
+    }
+  },
+);
+
+test("a changed session generation skips revocation together with reset", async () => {
+  registerAgentHarness({
+    id: "reset-cleanup-replacement",
+    label: "Reset cleanup replacement",
+    supports: () => ({ supported: false }),
+    runAttempt: async () => {
+      throw new Error("not used");
+    },
+    reset: async () => {
+      replaceSessionEntrySync(
+        { sessionKey: key },
+        {
+          sessionId: "reset-cleanup-session",
+          lifecycleRevision: "replacement",
+          updatedAt: Date.now(),
+        },
+      );
+    },
+  });
+  await request("sessions.reset", { key });
+  expect(loadSessionEntry({ sessionKey: key })?.lifecycleRevision).toBe("replacement");
+  expect(loadSubagentRegistryFromSqlite().get(runId)?.execution.suppressSessionEffects).not.toBe(
+    true,
+  );
+});
+
+test("revocation rechecks terminal owners after awaited entry planning", async () => {
+  const id = "late-terminal-owner";
+  registerCollector(id);
+  let settled = false;
+  const unsubscribe = onSubagentRegistryPersisted(() => {
+    if (!settled && subagentRuns.get(runId)?.execution.suppressSessionEffects) {
+      settled = true;
+      queueMicrotask(() => {
+        settleFailedQueuedSubagentLaunch(id, "late launch failed");
+      });
+    }
+  });
+  try {
+    await request("sessions.reset", { key });
+    expect(settled).toBe(true);
+    expect(loadSubagentRegistryFromSqlite().get(id)?.execution.suppressSessionEffects).toBe(true);
+  } finally {
+    unsubscribe();
+  }
+});
+
+test.each([
+  { agentId: "main", incognito: false },
+  { agentId: "worker", incognito: false },
+  { agentId: "main", incognito: true },
+  { agentId: "worker", incognito: true },
+])(
+  "custom-store reset revokes only its $agentId child (incognito: $incognito)",
+  async ({ agentId, incognito }) => {
+    cfg = {
+      agents: {
+        list: [
+          { id: "main", default: true, workspace: stateDir },
+          { id: "worker", workspace: stateDir },
+        ],
+      },
+      session: { store: path.join(stateDir, "custom-sessions.json") },
+    };
+    setRuntimeConfigSnapshot(cfg);
+    const childSessionKey = `agent:${agentId}:${incognito ? "incognito" : "subagent"}:scoped-cleanup`;
+    const scope = {
+      agentId,
+      sessionKey: childSessionKey,
+      storePath: expectDefined(cfg.session?.store, "custom store"),
+    };
+    const id = "scoped-collector";
+    const siblingKey = `agent:${agentId === "main" ? "worker" : "main"}:subagent:scoped-cleanup`;
+    replaceSessionEntrySync(scope, {
+      sessionId: "scoped-original",
+      lifecycleRevision: "scoped-original",
+      updatedAt: Date.now(),
+      ...(incognito ? { incognito: true } : {}),
+    });
+    replaceSessionEntrySync(
+      { ...scope, agentId: agentId === "main" ? "worker" : "main", sessionKey: siblingKey },
+      { sessionId: "sibling", lifecycleRevision: "sibling", updatedAt: Date.now() },
+    );
+    registerCollector(id, childSessionKey, agentId);
+    expect(settleFailedQueuedSubagentLaunch(id, "scoped launch failed")).toBe(true);
+    attempts = 0;
+    await testing.sweepOnceForTests();
+    expect(attempts).toBe(1);
+    await request("sessions.reset", { key: childSessionKey, agentId });
+    expect(loadSubagentRegistryFromSqlite().get(id)?.execution.suppressSessionEffects).toBe(true);
+    if (incognito) {
+      expect(loadSessionEntry(scope)).toBeUndefined();
+      replaceSessionEntrySync(scope, {
+        sessionId: "private-successor",
+        lifecycleRevision: "private-successor",
+        updatedAt: Date.now(),
+        incognito: true,
+      });
+    }
+    const successor = loadSessionEntry(scope);
+    expect(successor?.lifecycleRevision).not.toBe("scoped-original");
+    await testing.sweepOnceForTests();
+    expect(loadSessionEntry(scope)).toEqual(successor);
+    expect(attempts).toBe(1);
+    expect(
+      loadSessionEntry({
+        ...scope,
+        agentId: agentId === "main" ? "worker" : "main",
+        sessionKey: siblingKey,
+      })?.sessionId,
+    ).toBe("sibling");
+  },
+);
+
+test("reset cannot publish while a terminal completion owns an awaited capture", async () => {
+  const completion = vi.spyOn(completionOwner, "completeSubagentRunAttempt");
+  const entered = createDeferredCore();
+  const release = createDeferredCore();
+  const capture = subagentRegistryDeps.captureSubagentCompletionReply;
+  testing.setDepsForTest({
+    ...subagentRegistryDeps,
+    captureSubagentCompletionReply: async (...args) => {
+      entered.resolve();
+      await release.promise;
+      return await capture(...args);
+    },
+  });
+  const id = "completing-owner";
+  startCollector(id);
+  emitAgentEvent({ runId: id, stream: "lifecycle", data: { phase: "end", endedAt: Date.now() } });
+  await entered.promise;
+  const original = loadSessionEntry({ sessionKey: key });
+  try {
+    await expect(request("sessions.reset", { key })).rejects.toThrow(/completion.*settling/i);
+    expect(loadSessionEntry({ sessionKey: key })).toEqual(original);
+    expect(loadSubagentRegistryFromSqlite().get(id)?.execution.suppressSessionEffects).not.toBe(
+      true,
+    );
+  } finally {
+    release.resolve();
+    await expectDefined(completion.mock.results[0]?.value, "completion attempt");
+    await settleSubagentRegistryPersistenceWork();
+  }
+});
+
+test("a retained kill claim cannot revive durably revoked session cleanup", async () => {
+  const id = "kill-claim-owner";
+  registerCollector(id);
+  expect(
+    claimSubagentRunKill({
+      runId: id,
+      expected: expectDefined(subagentRuns.get(id), "registered collector"),
+      sessionId: "reset-cleanup-session",
+      sessionLifecycleRevision: "original",
+    }),
+  ).toBeDefined();
+  expect(settleFailedQueuedSubagentLaunch(id, "launch failed during cancellation")).toBe(true);
+  await request("sessions.reset", { key });
+  const successor = loadSessionEntry({ sessionKey: key });
+  emitAgentEvent({
+    runId: id,
+    stream: "lifecycle",
+    data: { phase: "end", aborted: true, stopReason: "aborted", endedAt: Date.now() },
+  });
+  await settleSubagentRegistryPersistenceWork();
+  expect(loadSubagentRegistryFromSqlite().get(id)?.execution.suppressSessionEffects).toBe(true);
+  await testing.sweepOnceForTests();
+  expect(loadSessionEntry({ sessionKey: key })).toEqual(successor);
+});
+
+test.each([false, true])(
+  "reset persists earlier best-effort suppression (existing row: %s)",
+  async (resetAgain) => {
+    await request("sessions.delete", { key });
+    const database = openOpenClawStateDatabase();
+    database.db.exec(`CREATE TEMP TRIGGER reject_best_effort BEFORE UPDATE ON subagent_runs
+    WHEN json_extract(NEW.payload_json, '$.execution.suppressSessionEffects') = 1
+    BEGIN SELECT RAISE(ABORT, 'best effort write rejected'); END`);
+    await testing.sweepOnceForTests();
+    expect(subagentRuns.get(runId)?.execution.suppressSessionEffects).toBe(true);
+    expect(loadSubagentRegistryFromSqlite().get(runId)?.execution.suppressSessionEffects).not.toBe(
+      true,
+    );
+    database.db.exec("DROP TRIGGER reject_best_effort");
+    await request("sessions.reset", { key });
+    if (resetAgain) {
+      await request("sessions.reset", { key });
+    }
+    const successor = loadSessionEntry({ sessionKey: key });
+    expect(successor).toBeDefined();
+    reopen();
+    await testing.sweepOnceForTests();
+    expect(loadSessionEntry({ sessionKey: key })).toEqual(successor);
+  },
+);
+
+test("reset preserves a yielded continuation instead of revoking it as completed cleanup", async () => {
+  const id = "yielded-continuation";
+  startCollector(id);
+  emitAgentEvent({
+    runId: id,
+    stream: "lifecycle",
+    data: { phase: "end", yielded: true, endedAt: Date.now() },
+  });
+  expect(subagentRuns.get(id)?.pauseReason).toBe("sessions_yield");
+  await request("sessions.reset", { key });
+  expect(loadSubagentRegistryFromSqlite().get(id)).toMatchObject({ pauseReason: "sessions_yield" });
+  expect(loadSubagentRegistryFromSqlite().get(id)?.execution.suppressSessionEffects).not.toBe(true);
+});

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -1497,10 +1497,7 @@ export async function performGatewaySessionReset(params: {
 
       const { prepareSubagentSessionCleanupRevocation } =
         await import("../agents/subagents/registry/subagent-registry.js");
-      const revokeSessionCleanup = prepareSubagentSessionCleanupRevocation({
-        sessionKey: target.canonicalKey,
-        agentId,
-      });
+      const revokeSessionCleanup = prepareSubagentSessionCleanupRevocation(target.canonicalKey);
       const commitGuard = () => {
         assertCompletionAuthorized?.();
         const current = loadSessionEntryReadOnly({

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -55,6 +55,7 @@ import {
 import { rebindCliSessionReseedReceiptsForReset } from "../config/sessions/cli-session-binding.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import { resolveResetPreservedSelection } from "../config/sessions/reset-preserved-selection.js";
+import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import { createSessionDiffBaselineCaptureClaim } from "../config/sessions/session-diff-baseline-capture.js";
 import { sessionEntryForkedFromParent } from "../config/sessions/session-entry-lineage.js";
 import { projectPublicSessionEntry } from "../config/sessions/session-entry-projection.js";
@@ -1494,6 +1495,30 @@ export async function performGatewaySessionReset(params: {
           })
         : undefined;
 
+      const { prepareSubagentSessionCleanupRevocation } =
+        await import("../agents/subagents/registry/subagent-registry.js");
+      const revokeSessionCleanup = prepareSubagentSessionCleanupRevocation({
+        sessionKey: target.canonicalKey,
+        agentId,
+      });
+      const commitGuard = () => {
+        assertCompletionAuthorized?.();
+        const current = loadSessionEntryReadOnly({
+          agentId,
+          storePath,
+          sessionKey: target.canonicalKey,
+          clone: false,
+        });
+        if (
+          current?.sessionId === entry?.sessionId &&
+          current?.lifecycleRevision === resetLifecycleRevision
+        ) {
+          // Revoke durably before publishing the successor. A later reset failure may
+          // retain the old session, but must never restore its stale deletion authority.
+          revokeSessionCleanup();
+        }
+      };
+
       if (incognito) {
         if (!entry) {
           return {
@@ -1511,6 +1536,7 @@ export async function performGatewaySessionReset(params: {
           reason: params.reason,
         });
         const deleted = await deleteSessionEntryLifecycle({
+          commitGuard,
           agentId: target.agentId,
           archiveTranscript: false,
           deleteDeliveryArtifacts: true,
@@ -1574,7 +1600,7 @@ export async function performGatewaySessionReset(params: {
       let creationAuthorizationError: ReturnType<typeof errorShape> | undefined;
       let fastModeSelectionError: ReturnType<typeof missingScopeErrorShape> | undefined;
       const lifecyclePromise = resetSessionEntryLifecycle({
-        commitGuard: assertCompletionAuthorized,
+        commitGuard,
         archivePreviousTranscript: false,
         agentId: target.agentId,
         resetBoundary: boundaryEntry

--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -1,3 +1,4 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -6,6 +7,7 @@ import {
   resetTaskRegistryForTests,
 } from "./task-registry-query.js";
 import { markTaskTerminalById } from "./task-registry-record-api.js";
+import { reloadTaskRegistryFromStore, tasks as authoritativeTasks } from "./task-registry-state.js";
 import { configureTaskRegistryRuntime } from "./task-registry.store.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
@@ -33,6 +35,66 @@ async function readTaskPage(params: Parameters<typeof listTaskRecordPage>[0]) {
 }
 
 describe("listTaskRecordPage", () => {
+  it("keeps missing indexed IDs bounded across a yielded registry replacement", async () => {
+    const sessionKey = "agent:main:reset";
+    const records = Array.from({ length: 97 }, (_, index): TaskRecord => ({
+      taskId: `task-${index}`,
+      runtime: "cli",
+      requesterSessionKey: sessionKey,
+      ownerKey: sessionKey,
+      scopeKind: "session",
+      task: "Before replacement",
+      status: "running",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+      createdAt: 1,
+    }));
+    configureTaskSnapshot(records);
+    getTaskById("task-0");
+    let reads = 0;
+    const readsPerTurn: number[] = [];
+    const get = authoritativeTasks.get.bind(authoritativeTasks);
+    const spy = vi.spyOn(authoritativeTasks, "get").mockImplementation((id) => {
+      reads += 1;
+      return get(id);
+    });
+    let replaced = false;
+    const preparedAfterReplacement: string[] = [];
+    const tick = () => {
+      readsPerTurn.push(reads);
+      reads = 0;
+      if (!replaced) {
+        configureTaskSnapshot([
+          { ...expectDefined(records[0], "replacement fixture"), taskId: "replacement" },
+        ]);
+        reloadTaskRegistryFromStore();
+        replaced = true;
+      }
+      pending = setImmediate(tick);
+    };
+    let pending = setImmediate(tick);
+    try {
+      const page = await readTaskPage({
+        offset: 0,
+        limit: 10,
+        sessionKey,
+        prepareFilter: (batch) => {
+          if (replaced) {
+            preparedAfterReplacement.push(...batch.map((task) => task.taskId));
+          }
+          return () => true;
+        },
+      });
+      readsPerTurn.push(reads);
+      expect(page.tasks.map((task) => task.taskId)).toEqual(["replacement"]);
+      expect(preparedAfterReplacement).toEqual(["replacement"]);
+      expect(Math.max(...readsPerTurn)).toBeLessThanOrEqual(32);
+    } finally {
+      clearImmediate(pending);
+      spy.mockRestore();
+    }
+  });
+
   it.each([
     { scope: "sparse", matching: 1 },
     { scope: "dense", matching: 65 },

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -198,7 +198,9 @@ export async function listTaskRecordPage(params: {
         await yieldToEventLoop();
       }
       const batch: TaskRecord[] = [];
-      while (!current.done && batch.length < 32 && scannedCount < scanLimit) {
+      // A registry reload can leave this iterator with IDs whose records no longer exist.
+      const batchEnd = Math.min(scannedCount + 32, scanLimit);
+      while (!current.done && scannedCount < batchEnd) {
         const task = tasks.get(current.value);
         if (task) {
           batch.push(task);


### PR DESCRIPTION
<!-- swarm-split-progress -->
## Split landing progress

Twenty-nine focused fixes have merged while the remaining Swarm repair continues.

- Merged: #146462 (repair authorization guidance), #146486 (plugin import scanning), #146488 (prepared provider metadata), #146494 (memory provenance queries), #146492 (database permission checks), #146490 (queued caller context and cleanup fencing), #146542 (scoped reconciliation), #146565 (durable reset cleanup), #146639 (trajectory retention query), #146571 (asynchronous snapshot cleanup), #146661 (bounded task-index scan batches), #146491 (writer fairness), #146668 (exact session-read batching), #146563 (agent write admission and worker-event settlement), #146711 (terminal Stop reasons), #146732 (Session write admission), #146712 (task-observer ownership), #146749 (lifecycle retention), #146666 (UI metadata ownership), #146797 (session-row bookkeeping optimization), #146795 (consumed-input cleanup), #146861 (native worker identity in startup profiles), #146842 (embedded transcript admission), #146801 (native session model provenance), #146866 (conversation reply capture), #146927 (directory write admission), #146917 (queue and recovery state ownership), #146760 (memory write admission), and #146984 (conversation admission and storage binding).
- All selected splits are merged. Clean main `dec9fe0a197327a5b1a67807e609bd9df4c3075a` contains all 29 merge commits. The final conversation slice passed 366 distinct runtime cases, normal Worker/SDK/UI build, public/private SDK consumers, canonical changed checks, isolated P0/P1 review, native maintainer review, and required CI on its exact published head. Native prepare and merge completed without changing that head. Final combined-source normal build and real-provider acceptance remain pending; the original branch is unchanged and is not being merged as a stale aggregate.
- Queue/recovery retains its 236-case component proof, normal build, and both SDK declaration profiles. Its subsequent test-only CI correction passed 261 owning/state-context cases, 20 targeted check stages, and fresh independent review; production is unchanged. Memory retains its prior full canonical and component proof, with 70 focused current-main cases and fresh review for the timing-fixture integration. The PRs keep reused build bindings and declaration-regeneration limits explicit. Additional synchronous consumer work remains separately accounted for; current source review found no further default Swarm correctness blocker beyond the selected slices, but their latency still needs measurement.
- Main fixed the shared sidebar and test-root failures through #146862 and #146803; redundant CI repair #146875 is closed as superseded. TLS, startup and test-inventory prerequisites landed through #146412, #146410 and #146538, replacing closed duplicates #146473, #146539 and #146553. Main #146667 owns the MCP cache-expectation correction; the metadata PR landed with only its three metadata files.

Each split receives independent review and exact-head required CI. Optional scanner acquisition or SARIF-upload failures are recorded separately and are not described as an all-checks-green result. The unchanged 500 ms responsiveness target has not yet passed; final composed-source, real-provider UI and active-deletion acceptance remain outstanding. Historical test and media evidence below predates these split heads and does not establish current acceptance.

<!-- /swarm-split-progress -->

## What Problem This Solves

Subagent reconciliation could miss completed Incognito or secondary-agent children, and copied store snapshots could miss completion committed while a sweep awaited another child. Real OpenAI Swarm stress testing also exposed avoidable `tasks.list` instability: a session-scoped page scanned unrelated task history and could exhaust its revision attempts during churn.

The existing [reset/cleanup hold](https://github.com/openclaw/openclaw/pull/130741#issuecomment-5442027116) identified a separate reachable ownership failure. If a failed collector launch's first cleanup attempt failed, a reset between sweeps could publish a successor that the old collector subsequently deleted. This refresh retains the scoped-reader repair and resolves that hold at the reset owner; it does not attribute the pre-existing between-sweep defect to this PR.

## Why This Change Was Made

Reconciliation now uses one canonical `loadSessionEntryReadOnly` call with the child's agent, configured store, and session key. The whole-store reconstruction/cache plumbing and duplicate reader are removed. Completion metadata stays fresh across awaits, while cleanup retains the session ID and lifecycle revision captured before the sweep's first await, bound to the exact run object. New or replaced group members wait for the next pass.

Session reset now durably sets the existing terminal-run `execution.suppressSessionEffects` flag before publishing its next lifecycle generation. The existing lifecycle controller, completion lock, strict targeted persistence, and synchronous reset commit guard own this transition. A failed revocation blocks reset; a later reset-store or postcommit failure cannot revive deletion authority. Pending completion capture, retained kill claims, earlier memory-only suppression, missing-row recreation, and yielded continuations are covered explicitly.

Session-scoped task pages now enumerate the existing related-session index rather than global history. That index includes requester, owner, and child relationships and is maintained when they change. Global/cursor revision checks, 32-entry fairness, ordering before pagination, detached output, and final authorization remain intact. ACP generation lookup explicitly retains its former owner/child scope.

## User Impact

Completed Swarm work is reconciled through its correct session owner, unrelated history no longer expands small scoped task scans, and delayed terminal cleanup cannot delete a reset successor. Swarm remains enabled by default; the existing 8 concurrent / 50 live / 200 lifetime / 600-second wait limits are unchanged. Code Mode remains a separate opt-in.

The maintainer explicitly accepted the fail-closed reset tradeoff: if revocation cannot persist, reset fails; if reset fails after revocation persists, the original session may remain with old cleanup suppressed. Reset asks the caller to retry when completion is still settling. Collector results, task outcomes, normal retention, unchanged-session retries, and active/yielded continuations remain available. Ordinary reset retains the session ID and transcript history while advancing the lifecycle revision/context boundary.

No schema, persistent field, config key, protocol, dependency, or public Plugin SDK surface is added. The assertion baseline changes only to record a removed assertion (4 → 3). No changelog is edited.

## Evidence

### Source and regression proof

The original cleanup hold was reproduced before editing with real collector registration, required task persistence, real SQLite stores, and real reset/delete handlers. The unchanged-session retry passed while reset-between-retries lost its successor. Additional failing regressions caught completion rollback, kill-claim resurrection, memory-only suppression, and yielded-continuation mistakes before the final repair.

The integrated candidate passed 703 tests across the standalone reset boundary suite and grouped registry, task, Gateway, and archive siblings, plus the full changed gate and a full build. Independent Codex autoreview found no actionable P0–P2 findings. The clean rebase retains every changed source/test/doc file byte-for-byte; current-main dependency/owner drift is separately checked.

The exact rebased head `d13b7876e7b2702b73935acfa5eed5cafaaf21c2`, above frozen main `903980a972d4ea2652290bcd7bc9a8f71ef7624a`, passed a full build, **798 tests across 27 files**, and all **30 changed-check stages**. This includes 95 focused tests for relevant upstream owner/dependency drift. A fresh two-part Codex review was scoped-clean through P2. No source changes followed those checks.

Write-failure proof uses real temporary SQLite abort triggers. Reopen proof closes both database owners, clears in-memory registry/task state, and reloads durable rows. It is not described as an OS-kill crash experiment.

### Real OpenAI stress

A session-owned local Gateway used isolated home/state/workspace/auth, loopback port 19489, no channels, and `openai/gpt-5.6-luna` with a real API key. The operator's Gateway and state were untouched. Source, complete build tree, exact Gateway boot, observer version, and parent/child/group identities were frozen and checked.

The original baseline matrix failed `tasks.list: UNAVAILABLE` during its second warm twenty-child burst; a separate baseline UI20 run reproduced the same error. Later independent observations found all children and parents settled, but neither failed trial was relabeled as passing.

The candidate passed native-tool collection and the complete nine-case Code Mode matrix: 2/8/9/20-child bursts, three additional twenty-child bursts, Stop with eight running tasks plus one queued task, and recovery afterward. Real UI20, Stop9, and recovery2 also passed. The queued child was never admitted; started children and the parent settled. Gateway task state is not claimed to prove eight simultaneous physical guest starts or OS-worker exit.

On the exact rebased build, unmodified managed **Codex 0.153.0** completed two direct collector spawns, collected both structured results, emitted both exact child terminal events, and left parent/children idle in 13.741 seconds after Send. Its first observer attempt rejected Codex's `toolResult` content envelope because the decoder handled only plain `text` parts. The original history reproduces that decoder defect; a separate source-backed observer correction and one fresh live run passed without changing runtime, model, limits, or error/identity assertions. The original attempt remains failed.

A new synthetic-avatar UI recording pass also completed UI20, Stop9, and recovery2 with all 79 task-page requests successful. One normal child `/clear` action was acknowledged; separate read-only verification showed cleared context, persisted cleanup suppression, the still-completed task, and byte-identical cached collector completion. That extra reset script initially expected a new physical session ID, which is not the reset contract; its failed assertion is retained, and the separate readback—not a retried reset—established the resulting state. This is ordinary live reset proof, not a substitute for the SQLite write-failure/order regressions.

### Performance and LOC

On canonical SQLite fixtures containing 1,000 completed sessions with 16 KiB prompts, the warm median selected-session read was 24.613 ms through the old whole-store path versus 0.109 ms through the canonical singleton. Parsed session JSON fell from roughly 16.8 MB to 16.8 KB per warm read. Real baseline main-thread profiles independently show full-listing/parsing work beneath collector completion and cleanup.

For a stable in-memory page selecting 20 related tasks from 10,000 total records, the bounded benchmark median was 5.001 ms versus 0.016 ms, and event-loop yields fell from 312 to zero. These are helper/selection measurements, not a claimed universal live Swarm speedup. Live model timings varied, and some validation shared the host; all original measurements and failures were retained.

| Classification | Added | Removed | Net |
|---|---:|---:|---:|
| Production | 192 | 137 | +55 |
| Tests/support | 1,216 | 76 | +1,140 |
| Documentation | 7 | 0 | +7 |
| Shrink-only assertion metadata | 1 | 1 | 0 |

The production reduction goal was not achieved overall: the original reader simplification removes 39 lines, the approved durable ownership guarantee adds 79, and complete scoped task selection adds 15. The repair uses existing owners and persistence instead of adding another authority store, cache, or fallback. Removing the new ownership checks would weaken the accepted guarantee.

Historical sidebar-readiness and persistence-resume timing observations from the earlier PR proof remain separate follow-ups; this refresh does not claim to fix them.

### Browser proof

These recordings use the real running Gateway, real OpenAI responses, the OpenClaw runtime, and synthetic task data. They were captured on the integrated build before the clean rebase; every changed source/test/doc file matches the rebased PR byte-for-byte. They are not presented as Codex UI recordings or as a live reproduction of the storage-fault race.

**Twenty children complete and return the exact aggregate:**

https://github.com/user-attachments/assets/ddacc40a-f7ed-4cb6-810e-80a3ff605a0b

**Stop cancels the active swarm, including its queued child:**

https://github.com/user-attachments/assets/c5fc2a8f-f386-498c-920c-ed9a6940b5cb

**Completed child before reset:**

![Completed synthetic collector child before reset](https://github.com/user-attachments/assets/952fcb8e-f7bd-4846-a01b-2cb04dad7f82)

**Same child after context reset; its old collector result remains retained in the registry:**

![Synthetic child after context reset](https://github.com/user-attachments/assets/59edf556-df76-45e9-93ce-0afb11209d94)

Earlier initials-containing recordings remain local and are not uploaded. The final fixture uses a neutral synthetic avatar through the normal profile API; it does not hide UI elements or alter rendered behavior. Agent transcripts and credentials are not attached.


