### PR TITLE
fix(plugins): report failed plugin slash commands instead of silently ignoring them

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -516,6 +516,8 @@ The manifest row is the canonical help text. Register the same command at runtim
 
 Use `commandAliases` when a plugin owns a runtime command name that users may mistakenly put in `plugins.allow` or try to run as a root CLI command. OpenClaw uses this metadata for diagnostics without importing plugin runtime code.
 
+If a plugin fails to load, invoking its declared `runtime-slash` command in chat returns the plugin name, a short failure reason, and recovery guidance (`openclaw doctor` and gateway logs). Unknown commands and commands belonging to intentionally disabled plugins keep their normal handling; manifest ownership alone does not make a command executable.
+
 ```json
 {
   "commandAliases": [

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -95,13 +95,14 @@ function buildPluginParams(
 }
 
 async function withDeclaredCommandPlugin(
-  options: { enabled?: boolean; fails?: boolean },
+  options: { enabled?: boolean; fails?: boolean; alias?: string },
   run: (cfg: OpenClawConfig) => Promise<void>,
 ) {
   const tempDir = await fs.realpath(
     await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-command-availability-")),
   );
   const pluginId = "recovery-controls";
+  const alias = options.alias ?? "recover";
   const pluginFile = path.join(tempDir, "index.cjs");
   const cfg: OpenClawConfig = {
     agents: { defaults: { workspace: tempDir } },
@@ -119,7 +120,7 @@ async function withDeclaredCommandPlugin(
         id: pluginId,
         configSchema: { type: "object", additionalProperties: false, properties: {} },
         commandAliases: [
-          { name: "recover", kind: "runtime-slash", cliCommand: "plugins" },
+          { name: alias, kind: "runtime-slash", cliCommand: "plugins" },
           { name: "legacy-recover" },
         ],
       }),
@@ -130,7 +131,7 @@ async function withDeclaredCommandPlugin(
         ${
           options.fails === false
             ? ""
-            : `api.registerCommand({ name: "recover", description: "Recovery controls", acceptsArgs: true, handler: () => ({ text: "must be rolled back" }) });
+            : `api.registerCommand({ name: ${JSON.stringify(alias)}, description: "Recovery controls", acceptsArgs: true, handler: () => ({ text: "must be rolled back" }) });
         throw new Error("fixture registration failed\\n    at private loader frame");`
         }
       } };`,
@@ -166,8 +167,12 @@ describe("handlePluginCommand", () => {
   });
   afterEach(() => resetPluginRuntimeStateForTest());
 
-  it("replies when a declared slash command was rolled back after register failed", async () => {
-    await withDeclaredCommandPlugin({}, async (cfg) => {
+  it.each([
+    { alias: "recover", command: "/recover stop" },
+    { alias: "recover-controls", command: "/recover_controls stop" },
+    { alias: "recover_controls", command: "/recover-controls stop" },
+  ])("replies for $command after registering $alias failed", async ({ alias, command }) => {
+    await withDeclaredCommandPlugin({ alias }, async (cfg) => {
       expect(registry.plugins.find((plugin) => plugin.id === "recovery-controls")).toMatchObject({
         status: "error",
         failurePhase: "register",
@@ -175,7 +180,7 @@ describe("handlePluginCommand", () => {
       });
       expect(registry.commands).toHaveLength(0);
 
-      const result = await handlePluginCommand(buildPluginParams("/recover stop", cfg), true);
+      const result = await handlePluginCommand(buildPluginParams(command, cfg), true);
 
       expect(result?.shouldContinue).toBe(false);
       expect(result?.reply?.text).toContain('Plugin "recovery-controls" failed to load');

--- a/src/auto-reply/reply/commands-plugin.test.ts
+++ b/src/auto-reply/reply/commands-plugin.test.ts
@@ -12,6 +12,7 @@ import {
   replaceSessionEntry,
 } from "../../config/sessions/session-accessor.js";
 import { registerPluginCommandInRegistry } from "../../plugins/command-registration.js";
+import { loadOpenClawPlugins } from "../../plugins/loader.js";
 import {
   PLUGIN_COMMAND_DISPATCH,
   type PluginCommandExecutionReplyOptions,
@@ -21,9 +22,11 @@ import type { PluginRegistry } from "../../plugins/registry-types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import type { PluginCommandContext, PluginCommandResult } from "../../plugins/types.js";
 import { resolveIncognitoOpenClawAgentSqlitePath } from "../../state/openclaw-agent-db.js";
+import { withEnvAsync } from "../../test-utils/env.js";
 import { handlePluginCommand } from "./commands-plugin.js";
 import type { HandleCommandsParams } from "./commands-types.js";
 import { shouldBypassPluginOwnedBindingForCommand } from "./dispatch-from-config.plugin-binding.js";
+import { finalizeInboundContext } from "./inbound-context.js";
 
 const compactEmbeddedAgentSessionMock = vi.hoisted(() => vi.fn());
 
@@ -91,6 +94,69 @@ function buildPluginParams(
   } as unknown as HandleCommandsParams;
 }
 
+async function withDeclaredCommandPlugin(
+  options: { enabled?: boolean; fails?: boolean },
+  run: (cfg: OpenClawConfig) => Promise<void>,
+) {
+  const tempDir = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-command-availability-")),
+  );
+  const pluginId = "recovery-controls";
+  const pluginFile = path.join(tempDir, "index.cjs");
+  const cfg: OpenClawConfig = {
+    agents: { defaults: { workspace: tempDir } },
+    commands: { text: true },
+    plugins: {
+      allow: [pluginId],
+      load: { paths: [pluginFile] },
+      entries: { [pluginId]: { enabled: options.enabled ?? true } },
+    },
+  };
+  try {
+    await fs.writeFile(
+      path.join(tempDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: pluginId,
+        configSchema: { type: "object", additionalProperties: false, properties: {} },
+        commandAliases: [
+          { name: "recover", kind: "runtime-slash", cliCommand: "plugins" },
+          { name: "legacy-recover" },
+        ],
+      }),
+    );
+    await fs.writeFile(
+      pluginFile,
+      `module.exports = { id: "${pluginId}", register(api) {
+        ${
+          options.fails === false
+            ? ""
+            : `api.registerCommand({ name: "recover", description: "Recovery controls", acceptsArgs: true, handler: () => ({ text: "must be rolled back" }) });
+        throw new Error("fixture registration failed\\n    at private loader frame");`
+        }
+      } };`,
+    );
+    await withEnvAsync(
+      {
+        OPENCLAW_STATE_DIR: path.join(tempDir, "state"),
+        OPENCLAW_CONFIG_PATH: path.join(tempDir, "openclaw.json"),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      },
+      async () => {
+        registry = loadOpenClawPlugins({
+          config: cfg,
+          workspaceDir: tempDir,
+          cache: false,
+          logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+        });
+        await run(cfg);
+      },
+    );
+  } finally {
+    resetPluginRuntimeStateForTest();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
 describe("handlePluginCommand", () => {
   beforeEach(() => {
     compactEmbeddedAgentSessionMock.mockReset();
@@ -99,6 +165,83 @@ describe("handlePluginCommand", () => {
     setActivePluginRegistry(registry);
   });
   afterEach(() => resetPluginRuntimeStateForTest());
+
+  it("replies when a declared slash command was rolled back after register failed", async () => {
+    await withDeclaredCommandPlugin({}, async (cfg) => {
+      expect(registry.plugins.find((plugin) => plugin.id === "recovery-controls")).toMatchObject({
+        status: "error",
+        failurePhase: "register",
+        error: expect.stringContaining("fixture registration failed"),
+      });
+      expect(registry.commands).toHaveLength(0);
+
+      const result = await handlePluginCommand(buildPluginParams("/recover stop", cfg), true);
+
+      expect(result?.shouldContinue).toBe(false);
+      expect(result?.reply?.text).toContain('Plugin "recovery-controls" failed to load');
+      expect(result?.reply?.text).toContain("fixture registration failed");
+      expect(result?.reply?.text).toContain("openclaw doctor");
+      expect(result?.reply?.text).not.toContain("private loader frame");
+    });
+  });
+
+  it.each([
+    { name: "unknown command", command: "/randomtext", options: {}, pluginStatus: "error" },
+    {
+      name: "alias without slash kind",
+      command: "/legacy-recover",
+      options: {},
+      pluginStatus: "error",
+    },
+    {
+      name: "disabled plugin",
+      command: "/recover stop",
+      options: { enabled: false },
+      pluginStatus: "disabled",
+    },
+    {
+      name: "healthy unregistered command",
+      command: "/recover stop",
+      options: { fails: false },
+      pluginStatus: "loaded",
+    },
+  ])("preserves fall-through for $name", async ({ command, options, pluginStatus }) => {
+    await withDeclaredCommandPlugin(options, async (cfg) => {
+      expect(registry.plugins.find((plugin) => plugin.id === "recovery-controls")?.status).toBe(
+        pluginStatus,
+      );
+      await expect(handlePluginCommand(buildPluginParams(command, cfg), true)).resolves.toBeNull();
+    });
+  });
+
+  it("carries failed command availability through binding selection and fences registry replacement", async () => {
+    await withDeclaredCommandPlugin({}, async (cfg) => {
+      const replyOptions: NonNullable<HandleCommandsParams["opts"]> &
+        PluginCommandExecutionReplyOptions = {};
+      expect(
+        shouldBypassPluginOwnedBindingForCommand(
+          finalizeInboundContext({
+            Body: "/recover stop",
+            CommandAuthorized: true,
+            CommandSource: "text",
+            Provider: "whatsapp",
+            Surface: "whatsapp",
+          }),
+          cfg,
+          replyOptions,
+        ),
+      ).toBe(true);
+      expect(replyOptions[PLUGIN_COMMAND_DISPATCH]?.kind).toBe("plugin");
+      const params = buildPluginParams("/recover stop", cfg);
+      params.opts = replyOptions;
+
+      expect((await handlePluginCommand(params, true))?.reply?.text).toContain(
+        "fixture registration failed",
+      );
+      setActivePluginRegistry(createEmptyPluginRegistry());
+      expect((await handlePluginCommand(params, true))?.reply?.text).toContain("registry changed");
+    });
+  });
 
   it("dispatches registered plugin commands with gateway scopes and session metadata", async () => {
     const handler = registerTestCommand();

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -334,6 +334,8 @@ export function applyPluginManifestRecordDetails(
   record.kind = manifestRecord.kind;
   record.configUiHints = manifestRecord.configUiHints;
   record.configJsonSchema = manifestRecord.configSchema;
+  // Manifest ownership survives rollback of executable registrations.
+  record.commandAliases = manifestRecord.commandAliases;
 }
 
 export function applyManifestSnapshotMetadata(

--- a/src/plugins/plugin-command-matcher.ts
+++ b/src/plugins/plugin-command-matcher.ts
@@ -33,29 +33,30 @@ function listInvocationKeys(
   return [...keys];
 }
 
+export function parsePluginInvocation(commandBody: string) {
+  const commandMatch = commandBody.trim().match(/^\/\s*([^\s]+)(?:\s+([\s\S]*))?$/);
+  if (!commandMatch) {
+    return null;
+  }
+  const key = normalizeLowercaseStringOrEmpty(`/${commandMatch[1]}`);
+  return {
+    keys: [...new Set([key, key.replace(/_/g, "-"), key.replace(/-/g, "_")])],
+    args: commandMatch[2]?.trim() || undefined,
+  };
+}
+
 export function matchRegisteredPluginCommand(params: {
   commands: readonly RegisteredPluginCommand[];
   commandBody: string;
   channel?: string;
   aliasScope: PluginCommandAliasScope;
 }): { command: RegisteredPluginCommand; args?: string } | null {
-  const trimmed = params.commandBody.trim();
-  if (!trimmed.startsWith("/")) {
+  const invocation = parsePluginInvocation(params.commandBody);
+  if (!invocation) {
     return null;
   }
-  const commandMatch = trimmed.match(/^\/\s*([^\s]+)(?:\s+([\s\S]*))?$/);
-  if (!commandMatch) {
-    return null;
-  }
-  const key = normalizeLowercaseStringOrEmpty(`/${commandMatch[1]}`);
-  const alternateKeys = [key];
-  if (key.includes("_")) {
-    alternateKeys.push(key.replace(/_/g, "-"));
-  }
-  if (key.includes("-")) {
-    alternateKeys.push(key.replace(/-/g, "_"));
-  }
-  const command = alternateKeys
+  const { keys, args } = invocation;
+  const command = keys
     .map((candidateKey) =>
       params.commands.find(
         (candidate) =>
@@ -64,12 +65,8 @@ export function matchRegisteredPluginCommand(params: {
       ),
     )
     .find((candidate): candidate is RegisteredPluginCommand => candidate !== undefined);
-  if (!command) {
+  if (!command || (args && !command.acceptsArgs)) {
     return null;
   }
-  const args = commandMatch[2]?.trim();
-  if (args && !command.acceptsArgs) {
-    return null;
-  }
-  return { command, args: args || undefined };
+  return { command, args };
 }

--- a/src/plugins/plugin-command-runtime.test.ts
+++ b/src/plugins/plugin-command-runtime.test.ts
@@ -7,6 +7,7 @@ vi.mock("./host-hook-cleanup.js", () => ({ cleanupReplacedPluginHostRegistry }))
 
 import { getPluginCommandExecutionCount } from "./command-execution-lock.js";
 import { registerPluginCommandInRegistry } from "./command-registration.js";
+import { createPluginRecord } from "./loader-records.js";
 import { withPluginCommandAccountStartScope } from "./plugin-command-account-start-scope.js";
 import {
   createPluginCommandRuntime,
@@ -74,6 +75,58 @@ afterEach(() => {
 });
 
 describe("plugin command runtime", () => {
+  it("keeps failed command diagnostics scoped, authorized, redacted, and bounded", async () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push({
+      ...createPluginRecord({
+        id: "recovery",
+        source: "/plugins/recovery/index.js",
+        origin: "config",
+        enabled: true,
+        configSchema: true,
+      }),
+      status: "error",
+      failurePhase: "validation",
+      error: `missing payload token=fixture-secret-value private-detail ${"x".repeat(400)}\n    at loader`,
+      commandAliases: [{ name: "recover", kind: "runtime-slash" }],
+    });
+    setActivePluginRegistry(registry);
+    withPluginRuntimeRegistryScope(createEmptyPluginRegistry(), () => {
+      expect(
+        matchPluginCommandInvocation(createPluginCommandRuntime(), "/recover stop", {
+          channel: "telegram",
+        }),
+      ).toBeNull();
+    });
+    const disabled = createEmptyPluginRegistry();
+    disabled.plugins.push({ ...registry.plugins[0]!, enabled: false });
+    withPluginRuntimeRegistryScope(disabled, () => {
+      expect(
+        matchPluginCommandInvocation(createPluginCommandRuntime(), "/recover stop", {
+          channel: "telegram",
+        }),
+      ).toBeNull();
+    });
+    const match = matchPluginCommandInvocation(createPluginCommandRuntime(), "/recover stop", {
+      channel: "telegram",
+    });
+    expect(match).not.toBeNull();
+    if (!match) {
+      throw new Error("expected failed command diagnostic");
+    }
+    await expect(
+      match.dispatch.execute({ ...executionContext, isAuthorizedSender: false }),
+    ).resolves.toEqual({ text: "⚠️ This command requires authorization." });
+    const reply = await match.dispatch.execute({
+      ...executionContext,
+      config: { logging: { redactPatterns: ["private-detail"] } },
+    });
+    expect(reply.text).toContain("missing payload");
+    expect(reply.text).toContain("openclaw doctor");
+    expect(reply.text).not.toMatch(/fixture-secret-value|private-detail|at loader/);
+    expect(reply.text!.length).toBeLessThan(400);
+  });
+
   it("prepares plugin host cleanup before gateway shutdown", async () => {
     await prepareActivePluginRegistryShutdown();
     const registry = createEmptyPluginRegistry();

--- a/src/plugins/plugin-command-runtime.ts
+++ b/src/plugins/plugin-command-runtime.ts
@@ -10,7 +10,7 @@ import {
   PLUGIN_COMMAND_DISPATCH,
   type PluginCommandReplyOptions,
 } from "./plugin-command-dispatch-contract.js";
-import { matchRegisteredPluginCommand } from "./plugin-command-matcher.js";
+import { matchRegisteredPluginCommand, parsePluginInvocation } from "./plugin-command-matcher.js";
 import {
   pluginCommandSupportsChannel,
   projectPluginCommandNativeMetadata,
@@ -277,10 +277,14 @@ export function matchPluginCommandInvocation(
     aliasScope: { kind: "provider", provider },
   });
   if (!match) {
-    const owner = resolveManifestCommandAliasOwnerInRegistry({
-      command: commandBody.trim().match(/^\/\s*([^\s]+)/)?.[1],
-      registry: state.registry,
-    });
+    const owner = parsePluginInvocation(commandBody)
+      ?.keys.map((key) =>
+        resolveManifestCommandAliasOwnerInRegistry({
+          command: key.slice(1),
+          registry: state.registry,
+        }),
+      )
+      .find((candidate) => candidate !== undefined);
     const plugin =
       owner?.kind === "runtime-slash"
         ? state.registry.plugins.find((entry) => entry.id === owner.pluginId)

--- a/src/plugins/plugin-command-runtime.ts
+++ b/src/plugins/plugin-command-runtime.ts
@@ -1,7 +1,10 @@
 /** Registry-bound plugin command selection and execution for native/channel surfaces. */
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { redactToolPayloadTextWithConfig } from "../logging/redact.js";
 import type { RegisteredPluginCommand } from "./command-registry-state.js";
+import { resolveManifestCommandAliasOwnerInRegistry } from "./manifest-command-aliases.js";
 import { retainPluginCommandCatalogForCurrentAccount } from "./plugin-command-account-start-scope.js";
 import {
   PLUGIN_COMMAND_DISPATCH,
@@ -17,7 +20,7 @@ import {
   resolveSelectedPluginCommandRegistry,
 } from "./plugin-command-registry.js";
 import { isPluginRegistryRetired } from "./registry-lifecycle.js";
-import type { PluginRegistry } from "./registry-types.js";
+import type { PluginRecord, PluginRegistry } from "./registry-types.js";
 import type { PluginCommandContext, PluginCommandResult } from "./types.js";
 
 export { PLUGIN_COMMAND_DISPATCH };
@@ -104,8 +107,9 @@ type SelectedCommand = {
   runtime: PluginCommandRuntime;
   registry: PluginRegistry;
   channel: string;
-  command: RegisteredPluginCommand;
-  args?: string;
+  selection:
+    | { availability: "loaded"; command: RegisteredPluginCommand; args?: string }
+    | { availability: "manifest-only"; plugin: PluginRecord };
 };
 
 const dispatchSelections = new WeakMap<object, SelectedCommand>();
@@ -121,9 +125,8 @@ const RETIRED_SELECTION_REPLY = {
 function createSelectedPluginCommandDispatch(
   runtime: PluginCommandRuntime,
   state: PluginCommandRuntimeState,
-  command: RegisteredPluginCommand,
+  selection: SelectedCommand["selection"],
   channel: string,
-  args?: string,
 ): PluginCommandDispatch {
   const dispatch = Object.freeze({
     kind: "plugin" as const,
@@ -137,9 +140,8 @@ function createSelectedPluginCommandDispatch(
   dispatchSelections.set(dispatch as object, {
     runtime,
     registry: state.registry,
-    command,
+    selection,
     channel: normalizeOptionalLowercaseString(channel) ?? "",
-    ...(args?.trim() ? { args: args.trim() } : {}),
   });
   return dispatch;
 }
@@ -160,14 +162,31 @@ async function executeSelectedPluginCommand(
   if (selected.channel !== channel) {
     return { ...INVALID_SELECTION_REPLY };
   }
+  const { selection } = selected;
+  if (selection.availability === "manifest-only") {
+    if (!context.isAuthorizedSender) {
+      return { text: "⚠️ This command requires authorization." };
+    }
+    // Registration diagnostics may include stacks or secrets; chat gets a bounded summary.
+    const reason = truncateUtf16Safe(
+      redactToolPayloadTextWithConfig(
+        selection.plugin.error?.split(/[\r\n]/, 1)[0]?.trim() || "reason not recorded",
+        context.config.logging,
+      ),
+      240,
+    );
+    return {
+      text: `⚠️ Plugin "${selection.plugin.id}" failed to load: ${reason}. Run \`openclaw doctor\` and check the gateway logs.`,
+    };
+  }
   const { executeRegisteredPluginCommand } = await import("./plugin-command-execution.js");
   if (isPluginRegistryRetired(selected.registry)) {
     return { ...RETIRED_SELECTION_REPLY };
   }
   return await executeRegisteredPluginCommand(selected.registry, {
     ...context,
-    args: selected.args,
-    command: selected.command,
+    args: selection.args,
+    command: selection.command,
   });
 }
 
@@ -212,7 +231,12 @@ export function createPluginCommandRuntime(): PluginCommandRuntime {
                 if (args && !command.acceptsArgs) {
                   return Object.freeze({ kind: "non-plugin" as const });
                 }
-                return createSelectedPluginCommandDispatch(runtime, state, command, channel, args);
+                return createSelectedPluginCommandDispatch(
+                  runtime,
+                  state,
+                  { availability: "loaded", command, args },
+                  channel,
+                );
               },
             });
           }),
@@ -253,16 +277,35 @@ export function matchPluginCommandInvocation(
     aliasScope: { kind: "provider", provider },
   });
   if (!match) {
-    return null;
+    const owner = resolveManifestCommandAliasOwnerInRegistry({
+      command: commandBody.trim().match(/^\/\s*([^\s]+)/)?.[1],
+      registry: state.registry,
+    });
+    const plugin =
+      owner?.kind === "runtime-slash"
+        ? state.registry.plugins.find((entry) => entry.id === owner.pluginId)
+        : undefined;
+    if (plugin?.status !== "error" || !plugin.enabled) {
+      return null;
+    }
+    return Object.freeze({
+      dispatch: createSelectedPluginCommandDispatch(
+        runtime,
+        state,
+        { availability: "manifest-only", plugin },
+        channel,
+      ),
+      acceptsArgs: true,
+      requireAuth: true,
+    });
   }
   const metadata = projectPluginCommandNativeMetadata(match.command, provider);
   return Object.freeze({
     dispatch: createSelectedPluginCommandDispatch(
       runtime,
       state,
-      match.command,
+      { availability: "loaded", command: match.command, args: match.args },
       channel,
-      match.args,
     ),
     acceptsArgs: metadata.acceptsArgs,
     requireAuth: metadata.requireAuth,

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -512,6 +512,7 @@ export type PluginRecord = {
   services: string[];
   gatewayDiscoveryServiceIds: string[];
   commands: string[];
+  commandAliases?: PluginManifestRecord["commandAliases"];
   httpRoutes: number;
   hookCount: number;
   configSchema: boolean;


### PR DESCRIPTION
Closes #112248

## What Problem This Solves

Fixes an issue where operators whose plugin failed to load would send that plugin's slash command in chat and get **nothing back** — no effect, no error, no acknowledgement. The command was accepted and silently discarded.

Concretely, with the Codex plugin failing to register, `/codex stop` during a wedged turn did nothing and said nothing. As the reporter put it, a recovery command that silently no-ops "trains operators to trust a control that is not actually connected." Worse, the text fell through to the model as an ordinary message, so it also burned an inference request.

This is the failure class this repo weights worst: every user action must end in a visible outcome or a recorded, intentional non-outcome.

## Why This Change Was Made

A plugin's commands are advertised from manifest metadata, which is deliberate — the surface must survive cold start without executing plugin code. But when `register()` throws, the loader rolls back the plugin's executable registrations while keeping its record and diagnostics as operator-visible load outcomes. The command matcher only ever consulted surviving executable registrations, so it could no longer tell an unknown command apart from a declared command whose owner had failed, and returned "not a plugin command" for both.

The shared command runtime now reuses the existing manifest alias resolver and the existing `loaded` / `manifest-only` availability vocabulary that the tool-ownership path already established. When a `/name` invocation matches nothing executable, and the manifest declares `name` as a `runtime-slash` command owned by a plugin the registry records as **enabled and in error**, dispatch returns a bounded diagnostic naming the plugin, the first redacted line of its recorded failure, and the recovery step. It reads the failure fact the producer already recorded rather than inferring it from absent contributions, and it runs through the existing dispatch lifecycle, so authorization, channel identity, opaque selection, and registry-retirement checks all still apply.

Deliberate non-goals: intentionally disabled plugins keep ordinary fall-through, because disabling is an operator's explicit choice and reporting it as a load failure would be wrong. Unknown commands, aliases without the `runtime-slash` kind, and healthy plugins are all untouched.

## User Impact

Operators get an actionable reply instead of silence:

> ⚠️ Plugin "codex" failed to load: TypeError: … . Run `openclaw doctor` and check the gateway logs.

They also stop paying for a model round-trip on a command that was never going to work. Plugin authors get the same signal in the surface where users actually hit it, not just in gateway logs.

## Evidence

**Live before/after on an isolated mock gateway.** Real ephemeral Gateway child process, isolated `OPENCLAW_STATE_DIR`, reserved free ports (58729 before, 58231 after) — never the operator's gateway or `~/.openclaw`. A fixture plugin declares and registers `/recoveryprobe`, then deliberately throws during register; `fixtureRegisterFailureObserved: true` in both runs.

| | before | after |
|---|---|---|
| `commandForwardedToProvider` | `true` | `false` |
| `inferenceRequests` | 2 | 1 |
| `visibleReplies` | none | the warning above |

Before, `/recoveryprobe stop` reached the mock provider and produced no channel reply — the silent no-op, reproduced end to end. After, it never reaches the provider and returns the visible outcome. Both captures, verdicts, gateway logs and provider records were opened and read.

**Regression tests fail pre-fix for the intended reason.** The new expected-outcome assertions in `commands-plugin.test.ts` (null result, binding bypass) and `plugin-command-runtime.test.ts` (diagnostic match) all fail against pre-fix production; 235 focused tests pass after. Fall-through for unknown commands, non-`runtime-slash` aliases, disabled plugins and healthy plugins is covered so ordinary chat cannot regress.

**Gates:** `node scripts/check-changed.mjs` passed. `pnpm build` passed including the Control UI startup budget. `oxfmt` clean on touched paths. Codex autoreview: no accepted findings.

**Pre-existing failures, attributed.** A full `src/plugins` run has 5 failing files that are **not** caused by this change: running the identical selection on clean `origin/main` produces exactly the same failing set (`bundled-plugin-metadata`, `hooks.correlation`, `install-record-commit.sqlite`, `npm-install-security-scan.release`, `tools.optional`). Two further files that failed only inside the full-suite run (`plugin-lifecycle-lease`, `update`) pass on both branch and main in that selection, so they are load-ordering flakes rather than regressions.

## Follow-up

The CLI-metadata registration pass still runs twice per invocation; independent bootstrap stages build fresh metadata registries with different config/allowlist scopes, so correct reuse needs its own ownership change rather than being bolted on here. Notes are in the branch artifacts and it is not addressed in this PR.
