### PR TITLE
fix(release): validate blocked FRV state transitions

### DIFF
--- a/scripts/full-release-validation-policy.mjs
+++ b/scripts/full-release-validation-policy.mjs
@@ -506,6 +506,16 @@ function dispatchResultBlockers(children) {
     }));
 }
 
+function releaseState(cancelled, activeRunIds, blockers, errors) {
+  const active = activeRunIds.length > 0;
+  return (
+    (cancelled && active && "cancelled_with_children") ||
+    (errors.length > 0 && "orchestration_error") ||
+    (blockers.length > 0 && (active ? "blocked_diagnostics_running" : "blocked_complete")) ||
+    (active ? "qualifying" : "passed")
+  );
+}
+
 export function classifyReleaseSnapshot({
   cancelled = false,
   children,
@@ -567,24 +577,12 @@ export function classifyReleaseSnapshot({
   );
   const errors = normalizeIssues([...extraErrors, ...childErrors], "orchestration_error");
 
-  let state;
-  if (cancelled && active.length > 0) {
-    state = "cancelled_with_children";
-  } else if (errors.length > 0) {
-    state = "orchestration_error";
-  } else if (blockers.length > 0) {
-    state = active.length > 0 ? "blocked_diagnostics_running" : "blocked_complete";
-  } else if (active.length > 0) {
-    state = "qualifying";
-  } else {
-    state = "passed";
-  }
-
+  const activeRunIds = active.map((child) => String(child.runId));
   return {
-    activeRunIds: active.map((child) => String(child.runId)),
+    activeRunIds,
     blockers,
     errors,
-    state,
+    state: releaseState(cancelled, activeRunIds, blockers, errors),
   };
 }
 
@@ -726,6 +724,8 @@ export function validateReleaseStateArtifact(payload, expected, expectedMode) {
     payload.mode !== mode ||
     payload.kind !== expectedKind ||
     !RELEASE_DECISION_STATE_SET.has(stringValue(payload.state)) ||
+    typeof payload.cancellation?.requested !== "boolean" ||
+    !Array.isArray(payload.cancellation?.cancelledRunIds) ||
     !/^[a-f0-9]{64}$/u.test(String(payload.executionPlanSha256 ?? "")) ||
     positiveInteger(payload.parentRunAttempt) === undefined ||
     positiveInteger(payload.sourceParentRunAttempt) === undefined ||
@@ -817,19 +817,11 @@ export function releasePlanGateFailures(gates) {
     }));
 }
 
-function verifyStateChildren(state, executionPlan, label) {
+function verifyStateStructure(state, executionPlan, label) {
   const selected = executionPlan.children.filter((entry) => entry.selected);
   const expectedKeys = selected.map((child) => child.key).toSorted();
-  const actualKeys = Object.keys(state.children).toSorted();
-  if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
+  if (JSON.stringify(Object.keys(state.children).toSorted()) !== JSON.stringify(expectedKeys)) {
     throw new Error(`${label} child set differs from the immutable execution plan`);
-  }
-  if (
-    state.activeRunIds.length > 0 ||
-    state.cancellation?.requested === true ||
-    (state.cancellation?.cancelledRunIds?.length ?? 0) > 0
-  ) {
-    throw new Error(`${label} claims passed with active or cancelled children`);
   }
   const snapshots = selected.map((child) => {
     if (!child.runId || !child.runAttempt) {
@@ -847,9 +839,6 @@ function verifyStateChildren(state, executionPlan, label) {
     ) {
       throw new Error(`${label} child provenance differs from the immutable plan: ${child.key}`);
     }
-    if (snapshot.errors.length > 0) {
-      throw new Error(`${label} child contains collector errors: ${child.key}`);
-    }
     return Object.assign({}, child, snapshot, {
       jobs: snapshot.timing.jobs.map((job) => ({
         conclusion: job.conclusion,
@@ -860,7 +849,19 @@ function verifyStateChildren(state, executionPlan, label) {
       })),
     });
   });
-  const recomputed = classifyReleaseSnapshot({
+  const { cancelledRunIds, requested } = state.cancellation;
+  const affectedRunIds = new Set(affectedActiveRunIds(snapshots, state.blockers));
+  if (
+    (requested &&
+      !state.errors.some(
+        ({ child, kind }) => child === "<collector>" && kind === "collector_cancelled",
+      )) ||
+    new Set(cancelledRunIds).size !== cancelledRunIds.length ||
+    cancelledRunIds.some((runId) => !/^[1-9][0-9]*$/u.test(runId) || !affectedRunIds.has(runId))
+  ) {
+    throw new Error(`${label} cancellation differs from exact child state`);
+  }
+  const baseline = classifyReleaseSnapshot({
     children: snapshots,
     extraBlockers: executionPlan.blockers,
     extraErrors: executionPlan.errors,
@@ -868,25 +869,57 @@ function verifyStateChildren(state, executionPlan, label) {
     releaseProfile: executionPlan.releaseProfile,
     workflowRef: executionPlan.workflowRef,
   });
-  if (
-    state.state !== "passed" ||
-    state.blockers.length > 0 ||
-    state.errors.length > 0 ||
-    recomputed.state !== "passed" ||
-    recomputed.blockers.length > 0 ||
-    recomputed.errors.length > 0
-  ) {
-    throw new Error(`${label} does not satisfy canonical terminal release policy`);
+  if (JSON.stringify(state.activeRunIds) !== JSON.stringify(baseline.activeRunIds)) {
+    throw new Error(`${label} activeRunIds differs from canonical release policy`);
+  }
+  for (const key of ["blockers", "errors"]) {
+    const claimed = new Set(state[key].map((issue) => JSON.stringify(issue)));
+    if (baseline[key].some((issue) => !claimed.has(JSON.stringify(issue)))) {
+      throw new Error(`${label} omits baseline ${key}`);
+    }
+  }
+  if (releaseState(requested, state.activeRunIds, state.blockers, state.errors) !== state.state) {
+    throw new Error(`${label} state differs from canonical release policy`);
   }
 }
 
-export function verifyReleaseStateArtifacts(
-  executionPlanPayload,
-  decisionPayload,
-  drainPayload,
-  expected = {},
-) {
-  const executionPlan = validateReleaseExecutionPlanArtifact(executionPlanPayload, expected);
+function verifyStateTransition(decision, drain) {
+  const reuseRecovery =
+    ["blocked_complete", "blocked_diagnostics_running"].includes(decision.state) &&
+    drain.state === "passed" &&
+    decision.errors.length === 0 &&
+    decision.blockers.length > 0 &&
+    decision.blockers.every(
+      ({ child, kind }) =>
+        child === "<evidence>" && ["reused_evidence_invalid", "provenance_mismatch"].includes(kind),
+    );
+  if (
+    ["qualifying", "blocked_diagnostics_running"].includes(drain.state) ||
+    decision.state === "qualifying" ||
+    (decision.state === "passed" && drain.state === "blocked_complete") ||
+    (decision.state.startsWith("blocked_") && drain.state === "passed" && !reuseRecovery)
+  ) {
+    throw new Error("release decision and diagnostic drain transition is invalid");
+  }
+  if (
+    decision.state.startsWith("blocked_") &&
+    drain.state === "blocked_complete" &&
+    !decision.blockers.every((blocker) =>
+      drain.blockers.some(
+        (candidate) =>
+          JSON.stringify(candidate) === JSON.stringify(blocker) ||
+          (blocker.kind === "workflow_failure" &&
+            candidate.kind === "job_failure" &&
+            ["child", "runId"].every((key) => candidate[key] === blocker[key])),
+      ),
+    )
+  ) {
+    throw new Error("diagnostic drain changed or removed a release decision blocker");
+  }
+}
+
+function verifyReleaseStatePair(planPayload, decisionPayload, drainPayload, expected = {}) {
+  const executionPlan = validateReleaseExecutionPlanArtifact(planPayload, expected);
   const decision = validateReleaseStateArtifact(decisionPayload, expected, "decision");
   const drain = validateReleaseStateArtifact(drainPayload, expected, "drain");
   if (
@@ -897,8 +930,9 @@ export function verifyReleaseStateArtifacts(
   ) {
     throw new Error("release decision and diagnostic drain execution plans differ");
   }
-  verifyStateChildren(decision, executionPlan, "release decision");
-  verifyStateChildren(drain, executionPlan, "diagnostic drain");
+  verifyStateStructure(decision, executionPlan, "release decision");
+  verifyStateStructure(drain, executionPlan, "diagnostic drain");
+  verifyStateTransition(decision, drain);
   return {
     decision,
     drain,
@@ -911,13 +945,19 @@ export function verifyReleaseStateArtifacts(
   };
 }
 
+export function verifyReleaseStateArtifacts(plan, decision, drain, expected = {}) {
+  const verified = verifyReleaseStatePair(plan, decision, drain, expected);
+  if (verified.decision.state !== "passed" || verified.drain.state !== "passed") {
+    const outcome = verified.drain.state === "passed" ? verified.decision : verified.drain;
+    throw new Error(formatReleaseStateOutcome(outcome));
+  }
+  return verified;
+}
+
 function newestStateCandidate(candidates, mode, runId, expected) {
   const prefix = mode === "decision" ? "full-release-decision" : "full-release-diagnostics";
   const pattern = new RegExp(`^${prefix}-${runId}-([1-9][0-9]*)$`, "u");
-  const maxParentRunAttempt =
-    expected.maxParentRunAttempt === undefined
-      ? Number.POSITIVE_INFINITY
-      : Number(expected.maxParentRunAttempt);
+  const maxParentRunAttempt = Number(expected.maxParentRunAttempt ?? Number.POSITIVE_INFINITY);
   const sorted = candidates
     .map((candidate) => {
       const match = pattern.exec(String(candidate.name ?? ""));
@@ -960,7 +1000,7 @@ export function selectReleaseStateArtifacts(
     executionPlan.parentRunId,
     selectionExpected,
   );
-  return verifyReleaseStateArtifacts(executionPlan, decision, drain, selectionExpected);
+  return verifyReleaseStatePair(executionPlan, decision, drain, selectionExpected);
 }
 
 function issueSummary(prefix, issue) {

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -361,10 +361,19 @@ describe("release decision policy", () => {
 });
 
 describe("release state artifacts", () => {
+  const FAILED_JOB = {
+    conclusion: "failure",
+    name: "test",
+    status: "completed",
+    url: "https://example.invalid/jobs/test",
+  };
+
   function artifact(
     mode: "decision" | "drain",
     parentRunAttempt = 2,
     sealedPlan = executionPlan({ rerunGroup: "ci" }),
+    childOverrides: Record<string, unknown> = {},
+    options: Record<string, any> = {},
   ) {
     const plannedChild = sealedPlan.children.find(
       (entry: Record<string, any>) => entry.key === "normalCi",
@@ -376,11 +385,22 @@ describe("release state artifacts", () => {
         createdAt: "2026-08-21T00:00:00Z",
         status: "completed",
         updatedAt: "2026-08-21T00:01:00Z",
+        ...childOverrides,
       }),
     ];
-    return buildReleaseStateArtifact({
+    const cancellation = options.cancellation ?? {};
+    const decision = classifyReleaseSnapshot({
+      cancelled: cancellation.requested === true,
       children,
-      decision: { activeRunIds: [], blockers: [], errors: [], state: "passed" },
+      extraBlockers: options.extraBlockers,
+      extraErrors: options.extraErrors,
+      releaseProfile: "stable",
+      workflowRef: "release-ci/tooling",
+    });
+    return buildReleaseStateArtifact({
+      cancellation,
+      children,
+      decision,
       executionPlan: sealedPlan,
       expected: {
         parentRunAttempt,
@@ -395,20 +415,94 @@ describe("release state artifacts", () => {
     });
   }
 
+  function stateArtifact(
+    mode: "decision" | "drain",
+    state: string,
+    sealedPlan = executionPlan({ rerunGroup: "ci" }),
+  ) {
+    const active = { conclusion: "", status: "in_progress" };
+    if (state === "qualifying") {
+      return artifact(mode, 2, sealedPlan, active);
+    }
+    if (state === "blocked_diagnostics_running") {
+      return artifact(mode, 2, sealedPlan, { ...active, jobs: [FAILED_JOB] });
+    }
+    if (state === "blocked_complete") {
+      return artifact(mode, 2, sealedPlan, { conclusion: "failure", jobs: [FAILED_JOB] });
+    }
+    if (state === "orchestration_error") {
+      return artifact(
+        mode,
+        2,
+        sealedPlan,
+        {},
+        {
+          extraErrors: [{ child: "<collector>", kind: "api_error", message: `${mode} error` }],
+        },
+      );
+    }
+    if (state === "cancelled_with_children") {
+      return artifact(mode, 2, sealedPlan, active, {
+        cancellation: { cancelledRunIds: [], requested: true },
+        extraErrors: [
+          {
+            child: "<collector>",
+            kind: "collector_cancelled",
+            message: `${mode} collector received a termination signal`,
+          },
+        ],
+      });
+    }
+    return artifact(mode, 2, sealedPlan);
+  }
+
+  function blockedArtifacts(sealedPlan = executionPlan({ rerunGroup: "ci" })) {
+    return {
+      decision: artifact("decision", 2, sealedPlan, {
+        conclusion: "",
+        jobs: [FAILED_JOB],
+        status: "in_progress",
+      }),
+      drain: artifact("drain", 2, sealedPlan, {
+        conclusion: "failure",
+        jobs: [FAILED_JOB],
+      }),
+      sealedPlan,
+    };
+  }
+
+  function stateExpected(maxParentRunAttempt = 2) {
+    return {
+      maxParentRunAttempt,
+      parentRunId: "77",
+      releaseProfile: "stable",
+      rerunGroup: "ci",
+      targetSha: TARGET_SHA,
+      workflowRef: "release-ci/tooling",
+      workflowSha: SHA,
+    };
+  }
+
+  function selectPair(
+    sealedPlan: Record<string, any>,
+    decision: Record<string, any>,
+    drain: Record<string, any>,
+  ) {
+    return selectReleaseStateArtifacts(
+      sealedPlan,
+      [{ name: "full-release-decision-77-2", payload: decision }],
+      [{ name: "full-release-diagnostics-77-2", payload: drain }],
+      stateExpected(),
+    );
+  }
+
   it("uses one policy for decision, drain, and final verification", () => {
     expect(
       verifyReleaseStateArtifacts(
         executionPlan({ rerunGroup: "ci" }),
         artifact("decision"),
         artifact("drain"),
-        {
-          parentRunAttempt: 2,
-          parentRunId: "77",
-          releaseProfile: "stable",
-          rerunGroup: "ci",
-          targetSha: TARGET_SHA,
-          workflowSha: SHA,
-        },
+        { ...stateExpected(), parentRunAttempt: 2 },
       ),
     ).toMatchObject({ decision: { state: "passed" }, drain: { state: "passed" } });
   });
@@ -422,17 +516,362 @@ describe("release state artifacts", () => {
         { name: "full-release-decision-77-2", payload: artifact("decision", 2, sealedPlan) },
       ],
       [{ name: "full-release-diagnostics-77-1", payload: artifact("drain", 1, sealedPlan) }],
-      {
-        maxParentRunAttempt: 3,
-        parentRunId: "77",
-        releaseProfile: "stable",
-        rerunGroup: "ci",
-        targetSha: TARGET_SHA,
-        workflowRef: "release-ci/tooling",
-        workflowSha: SHA,
-      },
+      stateExpected(3),
     );
     expect(selected.sourceAttempts).toEqual({ decision: 2, drain: 1, executionPlan: 1 });
+  });
+
+  it("selects a blocked decision with its completed diagnostic drain", () => {
+    const { decision, sealedPlan } = blockedArtifacts();
+    const drain = artifact("drain", 2, sealedPlan, {
+      conclusion: "failure",
+      jobs: [
+        FAILED_JOB,
+        { ...FAILED_JOB, name: "terminal diagnostic", url: "https://example.invalid/jobs/drain" },
+      ],
+    });
+    const selected = selectPair(sealedPlan, decision, drain);
+    expect(selected).toMatchObject({
+      decision: { activeRunIds: ["101"], state: "blocked_diagnostics_running" },
+      drain: { activeRunIds: [], blockers: [{ job: "test" }, { job: "terminal diagnostic" }] },
+    });
+  });
+
+  it("selects a terminal blocked pair when workflow evidence refines to failed jobs", () => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    const decision = artifact("decision", 2, sealedPlan, {
+      conclusion: "failure",
+      jobs: [],
+    });
+    const drain = stateArtifact("drain", "blocked_complete", sealedPlan);
+    expect(selectPair(sealedPlan, decision, drain).drain.blockers).toContainEqual(
+      expect.objectContaining({ job: "test", kind: "job_failure" }),
+    );
+  });
+
+  it.each([
+    ["blocked_diagnostics_running", "orchestration_error"],
+    ["blocked_complete", "orchestration_error"],
+    ["passed", "orchestration_error"],
+    ["orchestration_error", "passed"],
+    ["orchestration_error", "blocked_complete"],
+    ["orchestration_error", "orchestration_error"],
+  ])("selects recovery evidence from %s to %s", (from, to) => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    expect(
+      selectPair(
+        sealedPlan,
+        stateArtifact("decision", from, sealedPlan),
+        stateArtifact("drain", to, sealedPlan),
+      ),
+    ).toMatchObject({ decision: { state: from }, drain: { state: to } });
+  });
+
+  it("selects a fail-fast cancellation bound to its active blocked child", () => {
+    const { decision, drain, sealedPlan } = blockedArtifacts();
+    decision.cancellation.cancelledRunIds = ["101"];
+    expect(selectPair(sealedPlan, decision, drain).decision.cancellation).toEqual({
+      cancelledRunIds: ["101"],
+      requested: false,
+    });
+  });
+
+  it.each([
+    ["cancelled_with_children", "passed"],
+    ["passed", "cancelled_with_children"],
+  ])("selects signal cancellation recovery evidence from %s to %s", (from, to) => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    expect(
+      selectPair(
+        sealedPlan,
+        stateArtifact("decision", from, sealedPlan),
+        stateArtifact("drain", to, sealedPlan),
+      ),
+    ).toMatchObject({ decision: { state: from }, drain: { state: to } });
+  });
+
+  it("selects a cancellation request that races with child completion", () => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    const decision = artifact(
+      "decision",
+      2,
+      sealedPlan,
+      {},
+      {
+        cancellation: { requested: true },
+        extraErrors: [
+          {
+            child: "<collector>",
+            kind: "collector_cancelled",
+            message: "decision collector received a termination signal",
+          },
+        ],
+      },
+    );
+    const drain = stateArtifact("drain", "passed", sealedPlan);
+    expect(selectPair(sealedPlan, decision, drain).decision.state).toBe("orchestration_error");
+    expect(() => verifyReleaseStateArtifacts(sealedPlan, decision, drain, stateExpected())).toThrow(
+      "Full Release Validation state: orchestration_error",
+    );
+  });
+
+  it("rejects a forged passed state with an unproven cancellation request", () => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    const decision = artifact("decision", 2, sealedPlan);
+    const drain = artifact("drain", 2, sealedPlan);
+    decision.cancellation.requested = true;
+    expect(() => selectPair(sealedPlan, decision, drain)).toThrow("cancellation differs");
+    expect(() => verifyReleaseStateArtifacts(sealedPlan, decision, drain, stateExpected())).toThrow(
+      "cancellation differs",
+    );
+  });
+
+  it("selects reuse-validation blocker recovery without authorizing publication", () => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    const decision = artifact(
+      "decision",
+      2,
+      sealedPlan,
+      {},
+      {
+        extraBlockers: [
+          {
+            child: "<evidence>",
+            kind: "reused_evidence_invalid",
+            message: "reuse validation failed",
+          },
+        ],
+      },
+    );
+    const drain = stateArtifact("drain", "passed", sealedPlan);
+    expect(selectPair(sealedPlan, decision, drain).decision.state).toBe("blocked_complete");
+    expect(() => verifyReleaseStateArtifacts(sealedPlan, decision, drain, stateExpected())).toThrow(
+      "Full Release Validation state: blocked_complete\n- Blocker: reuse validation failed",
+    );
+  });
+
+  it.each(["reused_evidence_invalid", "provenance_mismatch"])(
+    "selects active %s recovery without authorizing publication",
+    (kind) => {
+      const sealedPlan = executionPlan({ rerunGroup: "ci" });
+      const decision = artifact(
+        "decision",
+        2,
+        sealedPlan,
+        { conclusion: "", status: "in_progress" },
+        { extraBlockers: [{ child: "<evidence>", kind, message: "evidence failed" }] },
+      );
+      const drain = stateArtifact("drain", "passed", sealedPlan);
+      expect(selectPair(sealedPlan, decision, drain).decision.state).toBe(
+        "blocked_diagnostics_running",
+      );
+      expect(() =>
+        verifyReleaseStateArtifacts(sealedPlan, decision, drain, stateExpected()),
+      ).toThrow(
+        "Full Release Validation state: blocked_diagnostics_running\n- Blocker: evidence failed",
+      );
+    },
+  );
+
+  it("rejects evidence recovery mixed with a child-run blocker", () => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    const decision = artifact(
+      "decision",
+      2,
+      sealedPlan,
+      { conclusion: "", jobs: [FAILED_JOB], status: "in_progress" },
+      {
+        extraBlockers: [
+          { child: "<evidence>", kind: "reused_evidence_invalid", message: "evidence failed" },
+        ],
+      },
+    );
+    expect(() =>
+      selectPair(sealedPlan, decision, stateArtifact("drain", "passed", sealedPlan)),
+    ).toThrow("transition is invalid");
+  });
+
+  it("rejects blocked artifacts for publication with the terminal drain blocker", () => {
+    const { decision, drain, sealedPlan } = blockedArtifacts();
+    expect(() => verifyReleaseStateArtifacts(sealedPlan, decision, drain, stateExpected())).toThrow(
+      "Full Release Validation state: blocked_complete\n- Blocker: test (failure)",
+    );
+  });
+
+  it("reports the decision error when a recovered drain passed", () => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    expect(() =>
+      verifyReleaseStateArtifacts(
+        sealedPlan,
+        stateArtifact("decision", "orchestration_error", sealedPlan),
+        stateArtifact("drain", "passed", sealedPlan),
+        stateExpected(),
+      ),
+    ).toThrow("Full Release Validation state: orchestration_error\n- Collector error:");
+  });
+
+  it("does not authorize selected signal cancellation evidence", () => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    expect(() =>
+      verifyReleaseStateArtifacts(
+        sealedPlan,
+        stateArtifact("decision", "cancelled_with_children", sealedPlan),
+        stateArtifact("drain", "passed", sealedPlan),
+        stateExpected(),
+      ),
+    ).toThrow("Full Release Validation state: cancelled_with_children");
+  });
+
+  it.each([
+    {
+      name: "removed decision blocker",
+      mutate: (pair: ReturnType<typeof blockedArtifacts>) => {
+        pair.drain = artifact("drain", 2, pair.sealedPlan, {
+          conclusion: "failure",
+          jobs: [],
+        });
+      },
+      reason: "changed or removed",
+    },
+    {
+      name: "changed decision blocker",
+      mutate: (pair: ReturnType<typeof blockedArtifacts>) => {
+        pair.drain = artifact("drain", 2, pair.sealedPlan, {
+          conclusion: "failure",
+          jobs: [{ ...FAILED_JOB, name: "different test" }],
+        });
+      },
+      reason: "changed or removed",
+    },
+    {
+      name: "child provenance drift",
+      mutate: (pair: ReturnType<typeof blockedArtifacts>) => {
+        pair.drain.children.normalCi!.displayTitle = "nearby title";
+      },
+      reason: "provenance differs",
+    },
+    {
+      name: "active drain",
+      mutate: (pair: ReturnType<typeof blockedArtifacts>) => {
+        pair.drain = artifact("drain", 2, pair.sealedPlan, {
+          conclusion: "",
+          jobs: [FAILED_JOB],
+          status: "in_progress",
+        });
+      },
+      reason: "transition is invalid",
+    },
+    {
+      name: "signal cancellation without active children",
+      mutate: (pair: ReturnType<typeof blockedArtifacts>) => {
+        pair.drain.cancellation = { cancelledRunIds: ["101"], requested: true };
+      },
+      reason: "cancellation differs",
+    },
+    {
+      name: "falsely classified drain",
+      mutate: (pair: ReturnType<typeof blockedArtifacts>) => {
+        pair.drain.state = "passed";
+      },
+      reason: "differs from canonical release policy",
+    },
+  ])("rejects a blocked transition with $name", ({ mutate, reason }) => {
+    const pair = blockedArtifacts();
+    mutate(pair);
+    const { decision, drain, sealedPlan } = pair;
+    expect(() => selectPair(sealedPlan, decision, drain)).toThrow(reason);
+  });
+
+  it.each([
+    ["qualifying", "passed"],
+    ["passed", "blocked_complete"],
+    ["blocked_complete", "passed"],
+    ["blocked_diagnostics_running", "passed"],
+    ["blocked_diagnostics_running", "blocked_diagnostics_running"],
+    ["orchestration_error", "blocked_diagnostics_running"],
+    ["cancelled_with_children", "blocked_diagnostics_running"],
+  ])("rejects contradictory evidence from %s to %s", (from, to) => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    expect(() =>
+      selectPair(
+        sealedPlan,
+        stateArtifact("decision", from, sealedPlan),
+        stateArtifact("drain", to, sealedPlan),
+      ),
+    ).toThrow("transition is invalid");
+  });
+
+  it.each([
+    {
+      name: "unplanned signal cancellation ID",
+      cancelledRunIds: ["999"],
+      state: "cancelled_with_children",
+    },
+    {
+      name: "fail-fast cancellation without a blocker",
+      cancelledRunIds: ["101"],
+      state: "qualifying",
+    },
+    {
+      name: "duplicate fail-fast cancellation ID",
+      cancelledRunIds: ["101", "101"],
+      state: "blocked_diagnostics_running",
+    },
+    {
+      name: "nonnumeric fail-fast cancellation ID",
+      cancelledRunIds: ["01"],
+      state: "blocked_diagnostics_running",
+    },
+  ])("rejects $name", ({ cancelledRunIds, state }) => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    const decision = stateArtifact("decision", state, sealedPlan);
+    decision.cancellation.cancelledRunIds = cancelledRunIds;
+    expect(() =>
+      selectPair(sealedPlan, decision, stateArtifact("drain", "passed", sealedPlan)),
+    ).toThrow("cancellation differs");
+  });
+
+  it("accepts runtime-only blockers and errors as conservative evidence", () => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    const decision = artifact(
+      "decision",
+      2,
+      sealedPlan,
+      {},
+      {
+        extraBlockers: [
+          { child: "<evidence>", kind: "provenance_mismatch", message: "reuse drift" },
+        ],
+        extraErrors: [{ child: "<collector>", kind: "api_error", message: "collector failed" }],
+      },
+    );
+    expect(
+      selectPair(sealedPlan, decision, stateArtifact("drain", "passed", sealedPlan)),
+    ).toMatchObject({
+      decision: {
+        blockers: [expect.objectContaining({ kind: "provenance_mismatch" })],
+        errors: [expect.objectContaining({ kind: "api_error" })],
+        state: "orchestration_error",
+      },
+    });
+  });
+
+  it("fails closed when bounded runtime errors displace baseline child errors", () => {
+    const sealedPlan = executionPlan({ rerunGroup: "ci" });
+    const childErrors = Array.from({ length: 25 }, (_, index) => ({
+      child: "normalCi",
+      kind: "api_error",
+      message: `child error ${index}`,
+    }));
+    const extraErrors = Array.from({ length: 5 }, (_, index) => ({
+      child: "<collector>",
+      kind: "api_error",
+      message: `collector error ${index}`,
+    }));
+    const decision = artifact("decision", 2, sealedPlan, { errors: childErrors }, { extraErrors });
+    expect(() =>
+      selectPair(sealedPlan, decision, stateArtifact("drain", "passed", sealedPlan)),
+    ).toThrow("omits baseline errors");
   });
 
   function selectFromFilesystem(layout: "asymmetric" | "multi" | "single") {
@@ -574,31 +1013,23 @@ describe("release state artifacts", () => {
         drain.children.normalCi.conclusion = "failure";
       },
       name: "failed child hidden behind passed state",
-      reason: "canonical terminal release policy",
+      reason: "omits baseline blockers",
     },
     {
       mutate: (drain: Record<string, any>) => {
         drain.children.normalCi.errors = [{ kind: "api_error", message: "hidden" }];
       },
       name: "hidden child collector error",
-      reason: "contains collector errors",
+      reason: "omits baseline errors",
     },
   ])("rejects a malformed passed drain with $name", ({ mutate, reason }) => {
     const sealedPlan = executionPlan({ rerunGroup: "ci" });
     const decision = artifact("decision", 2, sealedPlan);
     const drain = structuredClone(artifact("drain", 2, sealedPlan));
     mutate(drain);
-    expect(() =>
-      verifyReleaseStateArtifacts(sealedPlan, decision, drain, {
-        maxParentRunAttempt: 2,
-        parentRunId: "77",
-        releaseProfile: "stable",
-        rerunGroup: "ci",
-        targetSha: TARGET_SHA,
-        workflowRef: "release-ci/tooling",
-        workflowSha: SHA,
-      }),
-    ).toThrow(reason);
+    expect(() => verifyReleaseStateArtifacts(sealedPlan, decision, drain, stateExpected())).toThrow(
+      reason,
+    );
   });
 
   it("uses state-specific operator guidance", () => {

--- a/test/scripts/full-release-validation-state.test.ts
+++ b/test/scripts/full-release-validation-state.test.ts
@@ -569,7 +569,7 @@ describe("release state artifacts", () => {
 
   it("selects a fail-fast cancellation bound to its active blocked child", () => {
     const { decision, drain, sealedPlan } = blockedArtifacts();
-    decision.cancellation.cancelledRunIds = ["101"];
+    decision.cancellation = { cancelledRunIds: ["101"], requested: false };
     expect(selectPair(sealedPlan, decision, drain).decision.cancellation).toEqual({
       cancelledRunIds: ["101"],
       requested: false,
@@ -619,7 +619,7 @@ describe("release state artifacts", () => {
     const sealedPlan = executionPlan({ rerunGroup: "ci" });
     const decision = artifact("decision", 2, sealedPlan);
     const drain = artifact("drain", 2, sealedPlan);
-    decision.cancellation.requested = true;
+    decision.cancellation = { cancelledRunIds: [], requested: true };
     expect(() => selectPair(sealedPlan, decision, drain)).toThrow("cancellation differs");
     expect(() => verifyReleaseStateArtifacts(sealedPlan, decision, drain, stateExpected())).toThrow(
       "cancellation differs",
@@ -825,7 +825,10 @@ describe("release state artifacts", () => {
   ])("rejects $name", ({ cancelledRunIds, state }) => {
     const sealedPlan = executionPlan({ rerunGroup: "ci" });
     const decision = stateArtifact("decision", state, sealedPlan);
-    decision.cancellation.cancelledRunIds = cancelledRunIds;
+    decision.cancellation = {
+      cancelledRunIds,
+      requested: state === "cancelled_with_children",
+    };
     expect(() =>
       selectPair(sealedPlan, decision, stateArtifact("drain", "passed", sealedPlan)),
     ).toThrow("cancellation differs");


### PR DESCRIPTION
## What Problem This Solves
FRV run https://github.com/openclaw/openclaw/actions/runs/33038820221 reached a valid non-green Decision artifact while diagnostics were active, then a terminal Drain artifact. Final artifact selection reused the strict publication verifier, so it could not select valid blocked evidence and ended with the misleading `release decision claims passed with active or cancelled children` failure instead of reporting the actual blocker.

## Why This Change Was Made
Separate artifact structural/provenance validation from terminal-green authorization. Selection now validates immutable plan binding, child provenance, canonical state classification, cancellation evidence, and allowed Decision-to-Drain transitions while preserving non-green states. The public final verifier remains fail-closed and reports the authoritative Decision or Drain outcome. Decision-only evidence-reuse failures can recover in Drain selection without authorizing publication.

## User Impact
Full Release Validation can preserve and report valid blocked/orchestration evidence instead of failing in the verifier. Publication still requires both Decision and Drain to be `passed`.

## Evidence
- Before: run 33038820221 failed final verification after diagnostics drained.
- After: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/full-release-validation-state.test.ts` -> 85/85.
- Formatter, oxlint, diff check: clean.
- Independent P0/P1 review: clean.
- Production LOC: +90/-50, net +40. Tests: +461/-30.
- Non-goal: no runner-owned snapshot or FRV architecture redesign.

## Hosted Validation Constraint
Pre-merge hosted FRV using this PR as tooling is infeasible because `verifyTrustedWorkflowRef` accepts only tooling SHAs reachable from protected `origin/main` or a `release-publish` tag; the PR SHA is intentionally neither.

This explicitly skips ClawSweeper's real-run request. The focused 85/85 state tests and fail-closed final authorization remain the pre-merge proof. The exact post-merge action is a fresh beta/all/no-soak/no-reuse FRV on landed `main`, with serialized observation checks every 15 minutes.
