### PR TITLE
fix(ui): wait for presented sidebar session before clearing draft

### DIFF
--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -1,9 +1,11 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import type { ChatPaneElement } from "../pages/chat/route-draft-focus-handoff.ts";
 import {
   waitForControlUiGatewayReady,
   waitForControlUiGatewayReconnecting,
 } from "../test-helpers/control-ui-e2e-readiness.ts";
+import { waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
 import { expectRequestCountStable } from "./chat-flow.test-support.ts";
 import {
   actionOpacity,
@@ -79,8 +81,19 @@ suite.define(() => {
       await draft.waitFor();
 
       await homeRow.click();
-      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(mainKey));
+      await waitForControlUiRoute(page, {
+        pathname: controlUiSessionPath(mainKey),
+        routeId: "chat",
+      });
       await draft.waitFor();
+      const presentedPanes = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+      await expect
+        .poll(() =>
+          presentedPanes.evaluateAll((panes) =>
+            panes.map((pane) => (pane as ChatPaneElement).sessionKey),
+          ),
+        )
+        .toEqual([mainKey]);
 
       await composer.fill("");
       await secondRow.getByRole("link").click();


### PR DESCRIPTION
Related: #130688

## What Problem This Solves

Resolves a flaky Control UI sidebar E2E failure where returning Home could clear the composer from the previously presented retained pane. The browser URL could commit to the Home session before that session's chat pane became the single presented pane, leaving the draft indicator behind and failing the assertion.

## Why This Change Was Made

The test now waits for the existing router readiness contract, then requires exactly one presented chat pane with the Home session key before clearing the composer. Production code, shared helpers, retry counts, and timeout budgets are unchanged.

## User Impact

No product behavior changes. CI now verifies draft clearing against the pane users can actually interact with instead of racing the retained-pane transition.

## Evidence

- Failure source: exact-head CI for #130688, run https://github.com/openclaw/openclaw/actions/runs/33041643291, where the draft icon remained present after the route changed.
- Refreshed onto exact shared base `802af31b14e5f50d85988e584a6001cede3b2820`; exact head `3b309cc4aca137f3f18610593c087f062fd10ccc`.
- Focused test: 1/1 passed.
- Full `session-management.sidebar.e2e.test.ts`: 11/11 passed.
- Focused test stress: 25/25 sequential one-worker runs passed.
- Existing route-readiness E2E: 2/2 passed.
- `oxfmt`, `git diff --check`, and privacy scan passed.
- Fresh Claude fable-5/high autoreview reported no P0/P1 findings.
- No screenshot is included because the change only synchronizes an automated test and does not alter rendered UI.

AI-assisted: yes. The maintainer reviewed the implementation and evidence.
