### PR TITLE
refactor(diagnostics): remove retired pressure-bundle writer

### DIFF
--- a/src/logging/diagnostic-memory.test.ts
+++ b/src/logging/diagnostic-memory.test.ts
@@ -1,7 +1,4 @@
 // Diagnostic memory tests cover memory snapshot capture and diagnostic log output.
-import fs from "node:fs";
-import os from "node:os";
-import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   onInternalDiagnosticEvent,
@@ -9,6 +6,7 @@ import {
   resetDiagnosticEventsForTest,
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { emitDiagnosticMemorySample, resetDiagnosticMemoryForTest } from "./diagnostic-memory.js";
 import {
   readLatestDiagnosticStabilityBundleSync,
@@ -397,62 +395,12 @@ describe("diagnostic memory", () => {
     ).toBe(1);
   });
 
-  it("resolves session store paths only for enabled critical bundle writes", () => {
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-memory-pressure-lazy-"));
-    const resolveSessionStorePaths = vi.fn(() => []);
-    try {
-      emitDiagnosticMemorySample({
-        now: 1000,
-        stateDir,
-        resolveSessionStorePaths,
-        memoryUsage: memoryUsage({ rss: 500 }),
-        thresholds: {
-          rssWarningBytes: 1000,
-          rssCriticalBytes: 3000,
-        },
-      });
-      emitDiagnosticMemorySample({
-        now: 2000,
-        stateDir,
-        resolveSessionStorePaths,
-        memoryUsage: memoryUsage({ rss: 2000 }),
-        thresholds: {
-          rssWarningBytes: 1000,
-          rssCriticalBytes: 3000,
-        },
-      });
-
-      expect(resolveSessionStorePaths).not.toHaveBeenCalled();
-
-      emitDiagnosticMemorySample({
-        now: 3000,
-        stateDir,
-        writeCriticalBundle: true,
-        resolveSessionStorePaths,
-        memoryUsage: memoryUsage({ rss: 4000 }),
-        thresholds: {
-          rssWarningBytes: 1000,
-          rssCriticalBytes: 3000,
-        },
-      });
-
-      expect(resolveSessionStorePaths).toHaveBeenCalledTimes(1);
-    } finally {
-      fs.rmSync(stateDir, { recursive: true, force: true });
-    }
-  });
-
-  it("can disable critical pressure bundle writes", () => {
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-memory-pressure-disabled-"));
-    const resolveSessionStorePaths = vi.fn(() => []);
+  it("does not write bundles when critical pressure is emitted", async () => {
+    const state = await createOpenClawTestState({ label: "memory-pressure" });
     try {
       startDiagnosticStabilityRecorder();
-
       emitDiagnosticMemorySample({
         now: Date.parse("2026-04-22T12:00:00.000Z"),
-        stateDir,
-        writeCriticalBundle: false,
-        resolveSessionStorePaths,
         memoryUsage: memoryUsage({ rss: 4000, heapUsed: 3000 }),
         thresholds: {
           rssWarningBytes: 1000,
@@ -460,38 +408,11 @@ describe("diagnostic memory", () => {
           pressureRepeatMs: 60_000,
         },
       });
-
-      expect(resolveSessionStorePaths).not.toHaveBeenCalled();
-      expect(readLatestDiagnosticStabilityBundleSync({ stateDir }).status).toBe("missing");
+      expect(readLatestDiagnosticStabilityBundleSync({ stateDir: state.stateDir }).status).toBe(
+        "missing",
+      );
     } finally {
-      fs.rmSync(stateDir, { recursive: true, force: true });
-    }
-  });
-
-  it("leaves critical pressure bundle writes off by default", () => {
-    const stateDir = fs.mkdtempSync(
-      path.join(os.tmpdir(), "openclaw-memory-pressure-default-off-"),
-    );
-    const resolveSessionStorePaths = vi.fn(() => []);
-    try {
-      startDiagnosticStabilityRecorder();
-
-      emitDiagnosticMemorySample({
-        now: Date.parse("2026-04-22T12:00:00.000Z"),
-        stateDir,
-        resolveSessionStorePaths,
-        memoryUsage: memoryUsage({ rss: 4000, heapUsed: 3000 }),
-        thresholds: {
-          rssWarningBytes: 1000,
-          rssCriticalBytes: 3000,
-          pressureRepeatMs: 60_000,
-        },
-      });
-
-      expect(resolveSessionStorePaths).not.toHaveBeenCalled();
-      expect(readLatestDiagnosticStabilityBundleSync({ stateDir }).status).toBe("missing");
-    } finally {
-      fs.rmSync(stateDir, { recursive: true, force: true });
+      await state.cleanup();
     }
   });
 
@@ -579,70 +500,5 @@ describe("diagnostic memory", () => {
     expect(records.at(-1)?.message).toContain(
       "nextStep=run openclaw gateway status --deep and openclaw gateway diagnostics export; restart gateway if pressure persists",
     );
-  });
-
-  it("writes a stability bundle when critical pressure is emitted", () => {
-    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-memory-pressure-"));
-    const customRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-memory-custom-sessions-"));
-    try {
-      const sessionsDir = path.join(stateDir, "agents", "main", "sessions");
-      const customSessionsDir = path.join(customRoot, "custom-sessions");
-      fs.mkdirSync(sessionsDir, { recursive: true });
-      fs.mkdirSync(customSessionsDir, { recursive: true });
-      fs.writeFileSync(path.join(sessionsDir, "small.jsonl"), "small\n", "utf8");
-      fs.writeFileSync(path.join(sessionsDir, "large.jsonl"), "x".repeat(4096), "utf8");
-      fs.writeFileSync(path.join(customSessionsDir, "sessions.json"), "{}\n", "utf8");
-      fs.writeFileSync(
-        path.join(customSessionsDir, "custom-secret-session.jsonl"),
-        "x".repeat(8192),
-        "utf8",
-      );
-      startDiagnosticStabilityRecorder();
-
-      emitDiagnosticMemorySample({
-        now: Date.parse("2026-04-22T12:00:00.000Z"),
-        uptimeMs: 0,
-        stateDir,
-        writeCriticalBundle: true,
-        sessionStorePaths: [path.join(customSessionsDir, "sessions.json")],
-        memoryUsage: memoryUsage({ rss: 4000, heapUsed: 3000 }),
-        thresholds: {
-          rssWarningBytes: 1000,
-          rssCriticalBytes: 3000,
-          pressureRepeatMs: 60_000,
-        },
-      });
-
-      const latest = readLatestDiagnosticStabilityBundleSync({ stateDir });
-      expect(latest.status).toBe("found");
-      if (latest.status !== "found") {
-        return;
-      }
-      expect(latest.bundle.reason).toBe("diagnostic.memory.pressure.critical");
-      expect(latest.bundle.snapshot.summary.byType["diagnostic.memory.pressure"]).toBe(1);
-      expect(latest.bundle.evidence?.memoryPressure).toMatchObject({
-        level: "critical",
-        reason: "rss_threshold",
-        thresholdBytes: 3000,
-        memory: expect.objectContaining({
-          rssBytes: 4000,
-          heapUsedBytes: 3000,
-        }),
-      });
-      expect(latest.bundle.evidence?.memoryPressure?.heapStatistics?.heapSizeLimitBytes).toEqual(
-        expect.any(Number),
-      );
-      expect(latest.bundle.evidence?.memoryPressure?.activeResources?.total).toEqual(
-        expect.any(Number),
-      );
-      expect(latest.bundle.evidence?.memoryPressure?.topSessionFiles?.[0]).toMatchObject({
-        relativePath: "sessions/<session>.jsonl",
-        sizeBytes: 8192,
-      });
-      expect(JSON.stringify(latest.bundle)).not.toContain("custom-secret-session");
-    } finally {
-      fs.rmSync(stateDir, { recursive: true, force: true });
-      fs.rmSync(customRoot, { recursive: true, force: true });
-    }
   });
 });

--- a/src/logging/diagnostic-memory.ts
+++ b/src/logging/diagnostic-memory.ts
@@ -6,7 +6,6 @@ import {
   type DiagnosticMemoryPressureEvent,
   type DiagnosticMemoryUsage,
 } from "../infra/diagnostic-events.js";
-import { writeDiagnosticMemoryPressureBundleSync } from "./diagnostic-stability-bundle.js";
 import { createSubsystemLogger } from "./subsystem.js";
 
 // Diagnostic memory sampler with threshold/growth pressure detection and repeat suppression.
@@ -312,11 +311,9 @@ function formatPressureNextStep(
     : "nextStep=run openclaw gateway status --deep and openclaw gateway diagnostics export; restart gateway if pressure persists";
 }
 
-function logMemoryPressure(params: {
-  pressure: Omit<DiagnosticMemoryPressureEvent, "seq" | "ts" | "type">;
-  writeCriticalBundle: boolean;
-}): void {
-  const { pressure } = params;
+function logMemoryPressure(
+  pressure: Omit<DiagnosticMemoryPressureEvent, "seq" | "ts" | "type">,
+): void {
   const message =
     `memory pressure: level=${pressure.level} reason=${pressure.reason}` +
     ` ${formatPressureSummary(pressure)}` +
@@ -325,9 +322,7 @@ function logMemoryPressure(params: {
     formatOptionalPressureMetric("thresholdBytes", pressure.thresholdBytes) +
     formatOptionalPressureMetric("rssGrowthBytes", pressure.rssGrowthBytes) +
     formatOptionalPressureMetric("windowMs", pressure.windowMs) +
-    (pressure.level === "critical"
-      ? ` memoryPressureSnapshot=${params.writeCriticalBundle ? "enabled" : "disabled"}`
-      : "") +
+    (pressure.level === "critical" ? " memoryPressureSnapshot=disabled" : "") +
     ` ${formatPressureNextStep(pressure)}`;
   log.warn(message);
 }
@@ -342,10 +337,6 @@ export function emitDiagnosticMemorySample(options?: {
   uptimeMs?: number;
   thresholds?: DiagnosticMemoryThresholds;
   emitSample?: boolean;
-  writeCriticalBundle?: boolean;
-  stateDir?: string;
-  sessionStorePaths?: string[];
-  resolveSessionStorePaths?: () => string[] | undefined;
 }): DiagnosticMemoryUsage {
   const now = options?.now ?? Date.now();
   const memory = normalizeMemoryUsage(options?.memoryUsage ?? process.memoryUsage());
@@ -376,25 +367,8 @@ export function emitDiagnosticMemorySample(options?: {
       type: "diagnostic.memory.pressure",
       ...pressure,
     });
-    const writeCriticalBundle = options?.writeCriticalBundle === true;
-    logMemoryPressure({ pressure, writeCriticalBundle });
-    if (pressure.level === "critical" && writeCriticalBundle) {
-      // Critical snapshots are opt-in because bundle writes can add IO during memory pressure.
-      const sessionStorePaths = options?.sessionStorePaths ?? options?.resolveSessionStorePaths?.();
-      const result = writeDiagnosticMemoryPressureBundleSync({
-        pressure,
-        stateDir: options?.stateDir,
-        sessionStorePaths,
-        now: new Date(now),
-      });
-      if (result.status === "written") {
-        log.warn(
-          `critical memory pressure bundle written: path=${result.path} reason=${pressure.reason} level=${pressure.level}`,
-        );
-      } else if (result.status === "failed") {
-        log.warn(`critical memory pressure bundle failed: ${String(result.error)}`);
-      }
-    } else if (pressure.level === "critical") {
+    logMemoryPressure(pressure);
+    if (pressure.level === "critical") {
       log.warn("critical memory pressure snapshot disabled");
     }
   }

--- a/src/logging/diagnostic-stability-bundle.test.ts
+++ b/src/logging/diagnostic-stability-bundle.test.ts
@@ -247,11 +247,30 @@ describe("diagnostic stability bundles", () => {
   it("sanitizes imported bundles before returning them", () => {
     const file = path.join(tempDir, "imported.json");
     const bundle = createImportedBundle();
+    const retainedRuntimeEvidence = {
+      heapStatistics: { heapSizeLimitBytes: 8192, usedHeapSizeBytes: 1536 },
+      heapSpaces: [
+        {
+          spaceName: "old_space",
+          spaceSizeBytes: 2048,
+          spaceUsedBytes: 1536,
+          spaceAvailableBytes: 512,
+          physicalSpaceSizeBytes: 2048,
+        },
+      ],
+      cgroup: {
+        version: "v2",
+        values: { current: 4096, max: "max" },
+        events: { high: 2, "events.local.oom": 1 },
+      },
+      activeResources: { total: 3, byType: { Timeout: 2, PipeWrap: 1 } },
+    };
     Object.assign(bundle, {
       reason: "private reason token=secret",
       privateTopLevel: "top-level-secret",
       evidence: {
         memoryPressure: {
+          ...retainedRuntimeEvidence,
           level: "critical",
           reason: "rss_threshold",
           memory: {
@@ -331,6 +350,7 @@ describe("diagnostic stability bundles", () => {
     expect(result.bundle.evidence?.memoryPressure?.topSessionFiles?.[0]?.relativePath).toBe(
       "agents/<agent>/sessions/<session>.jsonl",
     );
+    expect(result.bundle.evidence?.memoryPressure).toMatchObject(retainedRuntimeEvidence);
     expect(result.bundle.snapshot.events[0]).toEqual({
       seq: 1,
       ts: 1,

--- a/src/logging/diagnostic-stability-bundle.ts
+++ b/src/logging/diagnostic-stability-bundle.ts
@@ -2,9 +2,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import v8 from "node:v8";
 import { expectDefined } from "@openclaw/normalization-core";
-import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveStateDir } from "../config/paths.js";
 import type {
@@ -31,12 +29,6 @@ const BUNDLE_PREFIX = "openclaw-stability-";
 const BUNDLE_SUFFIX = ".json";
 const REDACTED_HOSTNAME = "<redacted-hostname>";
 const MAX_SAFE_ERROR_MESSAGE_LENGTH = 500;
-const MAX_ACTIVE_RESOURCE_TYPES = 25;
-const MAX_SESSION_FILE_RESULTS = 20;
-const MAX_SESSION_SCAN_AGENTS = 100;
-const MAX_SESSION_SCAN_FILES = 5000;
-const CGROUP_V2_MEMORY_FILES = ["current", "max", "high", "peak", "swap.current", "swap.max"];
-const CGROUP_V2_MEMORY_EVENTS = ["events", "events.local"];
 
 type DiagnosticHeapSpaceSummary = {
   spaceName: string;
@@ -156,14 +148,6 @@ type WriteDiagnosticStabilityBundleForFailureOptions = Omit<
   WriteDiagnosticStabilityBundleOptions,
   "error" | "includeEmpty" | "reason"
 >;
-
-type WriteDiagnosticMemoryPressureBundleOptions = Omit<
-  WriteDiagnosticStabilityBundleOptions,
-  "reason" | "error" | "evidence" | "includeEmpty"
-> & {
-  pressure: Omit<DiagnosticMemoryPressureEvent, "seq" | "ts" | "type" | "trace">;
-  sessionStorePaths?: string[];
-};
 
 let fatalHookUnsubscribe: (() => void) | null = null;
 
@@ -898,136 +882,6 @@ function parseDiagnosticStabilityBundle(value: unknown): DiagnosticStabilityBund
   };
 }
 
-function readPositiveMemoryFile(file: string): number | "max" | undefined {
-  try {
-    const raw = fs.readFileSync(file, "utf8").trim();
-    if (raw === "max") {
-      return "max";
-    }
-    return parseStrictNonNegativeInteger(raw);
-  } catch {
-    return undefined;
-  }
-}
-
-function readCgroupEventFile(file: string): Record<string, number> {
-  try {
-    const events: Record<string, number> = {};
-    for (const line of fs.readFileSync(file, "utf8").split(/\r?\n/u)) {
-      const [key, raw] = line.trim().split(/\s+/u);
-      if (!key || !SAFE_REASON_CODE.test(key)) {
-        continue;
-      }
-      const value = parseStrictNonNegativeInteger(raw ?? "");
-      if (value !== undefined) {
-        events[key] = value;
-      }
-    }
-    return events;
-  } catch {
-    return {};
-  }
-}
-
-function resolveCgroupV2MemoryDir(): string | undefined {
-  if (process.platform !== "linux") {
-    return undefined;
-  }
-  try {
-    const line = fs
-      .readFileSync("/proc/self/cgroup", "utf8")
-      .split(/\r?\n/u)
-      .find((entry) => entry.startsWith("0::"));
-    if (!line) {
-      return undefined;
-    }
-    const rawPath = line.slice("0::".length).trim();
-    const relative = rawPath.replace(/^\/+/u, "");
-    return path.join("/sys/fs/cgroup", relative);
-  } catch {
-    return undefined;
-  }
-}
-
-function collectCgroupMemorySummary(): DiagnosticCgroupMemorySummary | undefined {
-  const dir = resolveCgroupV2MemoryDir();
-  if (!dir) {
-    return undefined;
-  }
-  const values: Record<string, number | "max"> = {};
-  for (const name of CGROUP_V2_MEMORY_FILES) {
-    const value = readPositiveMemoryFile(path.join(dir, `memory.${name}`));
-    if (value !== undefined) {
-      values[name] = value;
-    }
-  }
-  const events: Record<string, number> = {};
-  for (const name of CGROUP_V2_MEMORY_EVENTS) {
-    const parsed = readCgroupEventFile(path.join(dir, `memory.${name}`));
-    for (const [key, value] of Object.entries(parsed)) {
-      events[name === "events" ? key : `${name}.${key}`] = value;
-    }
-  }
-  return Object.keys(values).length > 0 || Object.keys(events).length > 0
-    ? { version: "v2", values, events }
-    : undefined;
-}
-
-function collectHeapStatistics(): DiagnosticHeapStatisticsSummary | undefined {
-  try {
-    const stats = v8.getHeapStatistics();
-    return {
-      totalHeapSizeBytes: stats.total_heap_size,
-      totalHeapSizeExecutableBytes: stats.total_heap_size_executable,
-      totalPhysicalSizeBytes: stats.total_physical_size,
-      totalAvailableSizeBytes: stats.total_available_size,
-      usedHeapSizeBytes: stats.used_heap_size,
-      heapSizeLimitBytes: stats.heap_size_limit,
-      mallocedMemoryBytes: stats.malloced_memory,
-      externalMemoryBytes: stats.external_memory,
-    };
-  } catch {
-    return undefined;
-  }
-}
-
-function collectHeapSpaces(): DiagnosticHeapSpaceSummary[] | undefined {
-  try {
-    const spaces = v8.getHeapSpaceStatistics().map((space) => ({
-      spaceName: space.space_name,
-      spaceSizeBytes: space.space_size,
-      spaceUsedBytes: space.space_used_size,
-      spaceAvailableBytes: space.space_available_size,
-      physicalSpaceSizeBytes: space.physical_space_size,
-    }));
-    return spaces.length > 0 ? spaces : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function collectActiveResources(): DiagnosticActiveResourceSummary | undefined {
-  try {
-    if (typeof process.getActiveResourcesInfo !== "function") {
-      return undefined;
-    }
-    const names = process.getActiveResourcesInfo();
-    const byType: Record<string, number> = {};
-    for (const name of names) {
-      if (!SAFE_REASON_CODE.test(name)) {
-        continue;
-      }
-      byType[name] = (byType[name] ?? 0) + 1;
-    }
-    const sorted = Object.entries(byType)
-      .toSorted((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-      .slice(0, MAX_ACTIVE_RESOURCE_TYPES);
-    return { total: names.length, byType: Object.fromEntries(sorted) };
-  } catch {
-    return undefined;
-  }
-}
-
 function sanitizeSessionEvidencePath(relativePath: string): string {
   const parts = relativePath.split("/");
   if (parts.length === 4 && parts[0] === "agents" && parts[2] === "sessions") {
@@ -1050,170 +904,6 @@ function sanitizeSessionEvidenceFileName(fileName: string): string {
     return "<session>.json";
   }
   return "<session>";
-}
-
-function visitDirentsBounded(
-  dir: string,
-  maxEntries: number,
-  visitor: (entry: fs.Dirent) => boolean | void,
-): void {
-  if (maxEntries <= 0) {
-    return;
-  }
-  let handle: fs.Dir | undefined;
-  try {
-    handle = fs.opendirSync(dir);
-    for (let count = 0; count < maxEntries; count += 1) {
-      const entry = handle.readSync();
-      if (!entry || visitor(entry) === false) {
-        return;
-      }
-    }
-  } catch {
-    // Best-effort diagnostic evidence only.
-  } finally {
-    try {
-      handle?.closeSync();
-    } catch {
-      // Best-effort diagnostic evidence only.
-    }
-  }
-}
-
-function pushSessionFileSummary(
-  results: DiagnosticSessionFileSummary[],
-  stateDir: string,
-  file: string,
-  relativePathOverride?: string,
-): void {
-  try {
-    const stat = fs.statSync(file);
-    if (!stat.isFile()) {
-      return;
-    }
-    const relativePath = (relativePathOverride ?? path.relative(stateDir, file)).replace(
-      /\\/gu,
-      "/",
-    );
-    if (relativePath.startsWith("../") || path.isAbsolute(relativePath)) {
-      return;
-    }
-    results.push({
-      relativePath: sanitizeSessionEvidencePath(relativePath),
-      sizeBytes: stat.size,
-      mtimeMs: stat.mtimeMs,
-    });
-  } catch {
-    // Best-effort diagnostic evidence only.
-  }
-}
-
-function scanSessionDirectory(params: {
-  results: DiagnosticSessionFileSummary[];
-  stateDir: string;
-  sessionsDir: string;
-  relativePrefix: string;
-  seenDirs: Set<string>;
-  scannedSessionEntries: { count: number };
-}): void {
-  const sessionsDir = path.resolve(params.sessionsDir);
-  if (params.seenDirs.has(sessionsDir)) {
-    return;
-  }
-  params.seenDirs.add(sessionsDir);
-  visitDirentsBounded(
-    sessionsDir,
-    MAX_SESSION_SCAN_FILES - params.scannedSessionEntries.count,
-    (sessionEntry) => {
-      params.scannedSessionEntries.count += 1;
-      if (!sessionEntry.isFile() || !/\.(?:jsonl|json)$/u.test(sessionEntry.name)) {
-        return params.scannedSessionEntries.count < MAX_SESSION_SCAN_FILES;
-      }
-      pushSessionFileSummary(
-        params.results,
-        params.stateDir,
-        path.join(sessionsDir, sessionEntry.name),
-        path.posix.join(params.relativePrefix, sessionEntry.name),
-      );
-      return params.scannedSessionEntries.count < MAX_SESSION_SCAN_FILES;
-    },
-  );
-}
-
-function collectTopSessionFiles(
-  stateDir: string,
-  sessionStorePaths: string[] = [],
-): DiagnosticSessionFileSummary[] | undefined {
-  const results: DiagnosticSessionFileSummary[] = [];
-  const seenDirs = new Set<string>();
-  const scannedSessionEntries = { count: 0 };
-  try {
-    pushSessionFileSummary(results, stateDir, path.join(stateDir, "sessions.json"));
-    const agentsDir = path.join(stateDir, "agents");
-    visitDirentsBounded(agentsDir, MAX_SESSION_SCAN_AGENTS, (agentEntry) => {
-      if (!agentEntry.isDirectory() || scannedSessionEntries.count >= MAX_SESSION_SCAN_FILES) {
-        return;
-      }
-      scanSessionDirectory({
-        results,
-        stateDir,
-        sessionsDir: path.join(agentsDir, agentEntry.name, "sessions"),
-        relativePrefix: path.posix.join("agents", agentEntry.name, "sessions"),
-        seenDirs,
-        scannedSessionEntries,
-      });
-    });
-    for (const storePath of sessionStorePaths) {
-      if (scannedSessionEntries.count >= MAX_SESSION_SCAN_FILES) {
-        break;
-      }
-      const sessionsDir = path.dirname(path.resolve(storePath));
-      scanSessionDirectory({
-        results,
-        stateDir,
-        sessionsDir,
-        relativePrefix: "sessions",
-        seenDirs,
-        scannedSessionEntries,
-      });
-    }
-  } catch {
-    // Best-effort diagnostic evidence only.
-  }
-  const top = results
-    .toSorted((a, b) => b.sizeBytes - a.sizeBytes || a.relativePath.localeCompare(b.relativePath))
-    .slice(0, MAX_SESSION_FILE_RESULTS);
-  return top.length > 0 ? top : undefined;
-}
-
-function buildMemoryPressureEvidence(
-  options: WriteDiagnosticMemoryPressureBundleOptions,
-): DiagnosticStabilityBundleEvidence {
-  const stateDir = options.stateDir ?? resolveStateDir(options.env ?? process.env);
-  const heapStatistics = collectHeapStatistics();
-  const heapSpaces = collectHeapSpaces();
-  const cgroup = collectCgroupMemorySummary();
-  const activeResources = collectActiveResources();
-  const topSessionFiles = collectTopSessionFiles(stateDir, options.sessionStorePaths);
-  return {
-    memoryPressure: {
-      level: options.pressure.level,
-      reason: options.pressure.reason,
-      memory: options.pressure.memory,
-      ...(options.pressure.thresholdBytes !== undefined
-        ? { thresholdBytes: options.pressure.thresholdBytes }
-        : {}),
-      ...(options.pressure.rssGrowthBytes !== undefined
-        ? { rssGrowthBytes: options.pressure.rssGrowthBytes }
-        : {}),
-      ...(options.pressure.windowMs !== undefined ? { windowMs: options.pressure.windowMs } : {}),
-      ...(heapStatistics ? { heapStatistics } : {}),
-      ...(heapSpaces ? { heapSpaces } : {}),
-      ...(cgroup ? { cgroup } : {}),
-      ...(activeResources ? { activeResources } : {}),
-      ...(topSessionFiles ? { topSessionFiles } : {}),
-    },
-  };
 }
 
 function isMemoryPressureReason(reason: string): reason is DiagnosticMemoryPressureEvent["reason"] {
@@ -1363,17 +1053,6 @@ export function writeDiagnosticStabilityBundleSync(
   } catch (error) {
     return { status: "failed", error };
   }
-}
-
-export function writeDiagnosticMemoryPressureBundleSync(
-  options: WriteDiagnosticMemoryPressureBundleOptions,
-): WriteDiagnosticStabilityBundleResult {
-  return writeDiagnosticStabilityBundleSync({
-    ...options,
-    reason: "diagnostic.memory.pressure.critical",
-    includeEmpty: true,
-    evidence: buildMemoryPressureEvidence(options),
-  });
 }
 
 export function writeDiagnosticStabilityBundleForFailureSync(

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -2,7 +2,6 @@
 import { monitorEventLoopDelay, performance } from "node:perf_hooks";
 import { resolveCompactionTimeoutMs } from "../agents/embedded-agent-runner/compaction-safety-timeout.js";
 import { getRuntimeConfig } from "../config/config.js";
-import { resolveAllAgentSessionStoreTargetsSync } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   areDiagnosticsEnabledForProcess,
@@ -92,7 +91,19 @@ const loadStuckSessionRecoveryRuntime = createLazyRuntimeModule(
   () => import("./diagnostic-stuck-session-recovery.runtime.js"),
 );
 
-type EmitDiagnosticMemorySample = typeof emitDiagnosticMemorySample;
+// The logging-core SDK shipped this callback input before automatic bundles retired.
+// Preserve its optional fields; the heartbeat only supplies emitSample.
+type DiagnosticMemorySampleCallbackOptions = NonNullable<
+  Parameters<typeof emitDiagnosticMemorySample>[0]
+> & {
+  writeCriticalBundle?: boolean;
+  stateDir?: string;
+  sessionStorePaths?: string[];
+  resolveSessionStorePaths?: () => string[] | undefined;
+};
+type EmitDiagnosticMemorySample = (
+  options?: DiagnosticMemorySampleCallbackOptions,
+) => ReturnType<typeof emitDiagnosticMemorySample>;
 type EventLoopDelayMonitor = ReturnType<typeof monitorEventLoopDelay>;
 type EventLoopUtilization = ReturnType<typeof performance.eventLoopUtilization>;
 type CpuUsage = ReturnType<typeof process.cpuUsage>;
@@ -136,18 +147,6 @@ type StartDiagnosticHeartbeatOptions = {
     stuckSessionAbortMs: number;
   };
 };
-
-function resolveDiagnosticSessionStorePaths(config?: OpenClawConfig): string[] | undefined {
-  if (!config) {
-    return undefined;
-  }
-  try {
-    const paths = resolveAllAgentSessionStoreTargetsSync(config).map((target) => target.storePath);
-    return paths.length > 0 ? paths : undefined;
-  } catch {
-    return undefined;
-  }
-}
 
 let diagnosticLivenessMonitor: EventLoopDelayMonitor | null = null;
 let lastDiagnosticLivenessWallAt = 0;
@@ -1217,8 +1216,6 @@ export function startDiagnosticHeartbeat(
     } else {
       emitDiagnosticMemorySample({
         emitSample: shouldRecordMemorySample,
-        writeCriticalBundle: false,
-        resolveSessionStorePaths: () => resolveDiagnosticSessionStorePaths(heartbeatConfig),
       });
     }
 


### PR DESCRIPTION
Related: #111382 (retirement of numeric configuration knobs).

<details>
<summary>Additional instructions</summary>

This same-repository branch is available for maintainer edits.

</details>

## What Problem This Solves

The diagnostics runtime still carried an automatic memory-pressure bundle writer after its configuration was retired and its only production caller was changed to pass `writeCriticalBundle: false`. Its V8, cgroup, active-resource, and session-file collectors were unreachable in production but kept a second bundle-producing path and obsolete enabling tests alive.

## Why This Change Was Made

Remove that private writer and its exclusive collectors at the diagnostics owner. Memory sampling, threshold/growth detection, pressure events, warning text, and repeat suppression remain unchanged. The generic/manual and fatal-error bundle writers remain, as do existing bundle readers, sanitizers, retention, CLI rendering, and support ZIP export.

The public `logging-core` heartbeat callback retains all optional input fields from the stable SDK. This is a type-only preservation of a shipped callback contract, not a runtime compatibility shim. No public configuration, migration, persistence schema, or protocol changes.

## User Impact

No intended behavior change. Operators can still inspect and safely export older memory-pressure bundles. Plugin authors keep the existing heartbeat callback input contract. AI-assisted maintainer-requested cleanup; no UI surface changed.

## Evidence

Production: **+19/-369, net -350 lines**. Tests: **+27/-151, net -124 lines**. Three obsolete writer cases were removed; the retained import/redaction test now explicitly covers old heap, cgroup, and active-resource evidence.

- Before editing: six whole-file focused suites passed with 161 tests. Candidate: the same suites passed with 158 tests. Supplemental local runs used Node 24.19.0 and installed Vitest 4.1.10; the repository pins 4.1.11.
- A read-only baseline/prototype differential, followed by the actual candidate differential, compared return values, events, and log bytes across 1,280 controlled Node/Bun pressure samples. Neither the writer nor its session-path resolver was called. This is deterministic source-level equivalence proof, not a live OOM test.
- Pinned Linux proof: Blacksmith Testbox `tbx_01m10v203mdkg4z3d0x94grzsr`, Node 24.19.0 / Vitest 4.1.11; all six focused files and 158 tests passed. The complete source patch, dependency fingerprint, package/build/manifests, and 774 workspace aliases were checked before execution.
- Independent Codex pre-commit review: no actionable findings, one complete pass over the five-file diff and 18 complete context files.
- The same pinned Linux candidate passed the complete `node scripts/check-changed.mjs --base a678ed6565c209023ceb962d849972fc962497f6 --staged`, `pnpm plugin-sdk:surface:check`, and `pnpm build` gates. All 147 public SDK subpaths were verified; runtime import cycles and unused-export scans stayed at zero.
- A strict TypeScript consumer of the fresh built `dist/plugin-sdk/logging-core.js` declarations checks all nine optional callback fields from the actual `openclaw@2026.7.1` published declarations, all thirteen fields from current baseline, unchanged return type, optional arguments, and callback assignability in both directions.
- Four real built CLI processes, with source fallback disabled and isolated state, read an older bundle by explicit path and `latest`, render text and JSON, and export a support ZIP. Heap, cgroup, active-resource, and session-file evidence survives; host, session-name, payload, and fixture-token fields are redacted. Offline status/health results are recorded, and the imported file is not modified.

The local typed-lint attempt stopped in prerequisite SDK declaration generation on stale unrelated Google, markdown-it, and TUI dependency types; the complete pinned checks above passed. The first CLI probe used the wrong fixture field name (`spaceAvailableSizeBytes` instead of the existing `spaceAvailableBytes` contract). After correcting only that untracked fixture, the full probe passed; production source and assertions were not weakened.
