### PR TITLE
fix(apple): load chat media behind reverse-proxy paths

### DIFF
--- a/apps/ios/Sources/Chat/IOSMediaArtifactLoader.swift
+++ b/apps/ios/Sources/Chat/IOSMediaArtifactLoader.swift
@@ -25,7 +25,6 @@ struct IOSMediaArtifactLoader: Sendable {
     static let maximumImageBytes = 12 * 1024 * 1024
     static let maximumAudioBytes = 16 * 1024 * 1024
     static let maximumVideoBytes = 16 * 1024 * 1024
-    private static let managedMediaPathPrefix = "/api/chat/media/outgoing/"
     private let connectionProvider: ConnectionProvider
     private let requestFactory: RequestFactory
 
@@ -71,8 +70,10 @@ struct IOSMediaArtifactLoader: Sendable {
         let path = response.url?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard let connection = await self.connectionProvider(),
               connection.gatewayID == expectedGatewayID,
-              let sourceURL = Self.managedMediaURL(config: connection.config, path: path),
-              let url = Self.playbackURL(sourceURL, mode: playback)
+              let url = OpenClawChatMediaURL.resolve(
+                  gatewayURL: connection.config.url,
+                  ticketedPath: path,
+                  playback: playback)
         else { throw LoadError.invalidSource }
 
         let headers = url.scheme?.lowercased() == "https"
@@ -139,39 +140,5 @@ struct IOSMediaArtifactLoader: Sendable {
         case .audio: self.maximumAudioBytes
         case .video: self.maximumVideoBytes
         }
-    }
-
-    private static func managedMediaURL(config: GatewayConnectConfig, path: String) -> URL? {
-        guard path.hasPrefix(self.managedMediaPathPrefix),
-              let relative = URLComponents(string: path),
-              relative.scheme == nil,
-              relative.host == nil,
-              relative.fragment == nil,
-              relative.percentEncodedPath.hasPrefix(Self.managedMediaPathPrefix),
-              relative.queryItems?.contains(where: {
-                  $0.name == "mediaTicket" && $0.value?.isEmpty == false
-              }) == true,
-              var base = URLComponents(url: config.url, resolvingAgainstBaseURL: false),
-              base.host != nil
-        else { return nil }
-        switch base.scheme?.lowercased() {
-        case "wss", "https": base.scheme = "https"
-        case "ws", "http": base.scheme = "http"
-        default: return nil
-        }
-        base.percentEncodedPath = relative.percentEncodedPath
-        base.percentEncodedQuery = relative.percentEncodedQuery
-        base.fragment = nil
-        return base.url
-    }
-
-    private static func playbackURL(_ url: URL, mode: OpenClawChatPlaybackMode?) -> URL? {
-        guard mode == .transcode else { return url }
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
-        var queryItems = components.queryItems ?? []
-        queryItems.removeAll { $0.name == "playback" }
-        queryItems.append(URLQueryItem(name: "playback", value: "1"))
-        components.queryItems = queryItems
-        return components.url
     }
 }

--- a/apps/ios/Tests/IOSMediaArtifactLoaderTests.swift
+++ b/apps/ios/Tests/IOSMediaArtifactLoaderTests.swift
@@ -7,8 +7,11 @@ import Testing
 
 @Suite("iOS managed media artifact loader")
 struct IOSMediaArtifactLoaderTests {
-    @Test @MainActor func `loads ticketed image with proxy headers and without a gateway bearer`() async throws {
-        let gatewayURL = try #require(URL(string: "wss://gateway.example"))
+    @Test(arguments: Self.gatewayRoutes)
+    @MainActor func `loads ticketed image with proxy headers and without a gateway bearer`(
+        route: (gateway: String, media: String)) async throws
+    {
+        let gatewayURL = try #require(URL(string: route.gateway))
         let config = Self.config(url: gatewayURL)
         let loader = IOSMediaArtifactLoader(
             connectionProvider: {
@@ -20,7 +23,7 @@ struct IOSMediaArtifactLoaderTests {
             requestFactory: { _, maximumBytes in
                 #expect(maximumBytes == 12 * 1024 * 1024)
                 return { request in
-                    #expect(request.url?.absoluteString == Self.ticketedAbsoluteURL)
+                    #expect(request.url?.absoluteString == route.media + Self.ticketedPath)
                     #expect(request.value(forHTTPHeaderField: "Accept") == "image/*")
                     #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
                     #expect(request.value(forHTTPHeaderField: "X-Proxy-Token") == "proxy")
@@ -41,8 +44,11 @@ struct IOSMediaArtifactLoaderTests {
         #expect(media.mimeType == "image/png")
     }
 
-    @Test @MainActor func `returns direct video stream when route needs no pinned session`() async throws {
-        let config = try Self.config(url: #require(URL(string: "wss://gateway.example")))
+    @Test(arguments: Self.gatewayRoutes)
+    @MainActor func `returns direct video stream when route needs no pinned session`(
+        route: (gateway: String, media: String)) async throws
+    {
+        let config = try Self.config(url: #require(URL(string: route.gateway)))
         let loader = IOSMediaArtifactLoader(
             connectionProvider: {
                 IOSMediaArtifactLoader.Connection(
@@ -64,7 +70,7 @@ struct IOSMediaArtifactLoaderTests {
             Issue.record("video should use the ticketed stream URL")
             return
         }
-        #expect(stream.url.absoluteString == Self.ticketedAbsoluteURL)
+        #expect(stream.url.absoluteString == route.media + Self.ticketedPath)
         #expect(stream.mimeType == "video/mp4")
         #expect(stream.sizeBytes == 4096)
     }
@@ -135,8 +141,11 @@ struct IOSMediaArtifactLoaderTests {
         #expect(media.mimeType == "video/mp4")
     }
 
-    @Test @MainActor func `requests playback rendition for buffered audio`() async throws {
-        let config = try Self.config(url: #require(URL(string: "wss://gateway.example")))
+    @Test(arguments: Self.gatewayRoutes)
+    @MainActor func `requests playback rendition for buffered audio`(
+        route: (gateway: String, media: String)) async throws
+    {
+        let config = try Self.config(url: #require(URL(string: route.gateway)))
         let loader = IOSMediaArtifactLoader(
             connectionProvider: {
                 IOSMediaArtifactLoader.Connection(
@@ -146,7 +155,7 @@ struct IOSMediaArtifactLoaderTests {
             },
             requestFactory: { _, _ in
                 { request in
-                    #expect(request.url?.absoluteString == Self.ticketedPlaybackAbsoluteURL)
+                    #expect(request.url?.absoluteString == route.media + Self.ticketedPath + "&playback=1")
                     #expect(request.value(forHTTPHeaderField: "Range") == nil)
                     return try Self.response(
                         for: request,
@@ -299,6 +308,17 @@ struct IOSMediaArtifactLoaderTests {
         }
     }
 
+    private static let gatewayRoutes = [
+        (gateway: "wss://gateway.example", media: "https://gateway.example"),
+        (gateway: "wss://gateway.example/", media: "https://gateway.example"),
+        (
+            gateway: "wss://gateway.example:8443/tenant%20gateway/gw",
+            media: "https://gateway.example:8443/tenant%20gateway/gw"),
+        (
+            gateway: "wss://gateway.example/tenant%2Fgateway//gw/",
+            media: "https://gateway.example/tenant%2Fgateway//gw/"),
+        (gateway: "wss://gateway.example/tenant%FFgateway/gw", media: "https://gateway.example/tenant%FFgateway/gw"),
+    ]
     private static let ticketedPath =
         "/api/chat/media/outgoing/main/11111111-1111-4111-8111-111111111111/full?mediaTicket=ticket"
     private static let ticketedAbsoluteURL = "https://gateway.example\(ticketedPath)"

--- a/apps/macos/Sources/OpenClaw/GatewayConnection+ManagedImages.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection+ManagedImages.swift
@@ -3,8 +3,6 @@ import OpenClawChatUI
 import OpenClawKit
 import OpenClawProtocol
 
-private let gatewayManagedMediaPathPrefix = "/api/chat/media/outgoing/"
-
 extension GatewayConnection {
     func loadMediaArtifact(
         sessionKey: String,
@@ -43,10 +41,10 @@ extension GatewayConnection {
             return .data(OpenClawChatMediaData(data: data, mimeType: declaredMIME))
         }
         guard let ticketedPath = response.url?.trimmingCharacters(in: .whitespacesAndNewlines),
-              let sourceURL = Self.managedMediaURL(
+              let url = OpenClawChatMediaURL.resolve(
                   gatewayURL: lease.route.url,
-                  ticketedPath: ticketedPath),
-              let url = Self.playbackURL(sourceURL, mode: playback)
+                  ticketedPath: ticketedPath,
+                  playback: playback)
         else { return nil }
 
         let canStreamDirectly = kind == .video &&
@@ -106,38 +104,5 @@ extension GatewayConnection {
         case .image: 12 * 1024 * 1024
         case .audio, .video: 16 * 1024 * 1024
         }
-    }
-
-    private static func managedMediaURL(gatewayURL: URL, ticketedPath: String) -> URL? {
-        guard ticketedPath.hasPrefix(gatewayManagedMediaPathPrefix),
-              let relative = URLComponents(string: ticketedPath),
-              relative.scheme == nil,
-              relative.host == nil,
-              relative.fragment == nil,
-              relative.queryItems?.contains(where: {
-                  $0.name == "mediaTicket" && $0.value?.isEmpty == false
-              }) == true,
-              var base = URLComponents(url: gatewayURL, resolvingAgainstBaseURL: false),
-              base.host != nil
-        else { return nil }
-        switch base.scheme?.lowercased() {
-        case "wss", "https": base.scheme = "https"
-        case "ws", "http": base.scheme = "http"
-        default: return nil
-        }
-        base.percentEncodedPath = relative.percentEncodedPath
-        base.percentEncodedQuery = relative.percentEncodedQuery
-        base.fragment = nil
-        return base.url
-    }
-
-    private static func playbackURL(_ url: URL, mode: OpenClawChatPlaybackMode?) -> URL? {
-        guard mode == .transcode else { return url }
-        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
-        var queryItems = components.queryItems ?? []
-        queryItems.removeAll { $0.name == "playback" }
-        queryItems.append(URLQueryItem(name: "playback", value: "1"))
-        components.queryItems = queryItems
-        return components.url
     }
 }

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMediaURL.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatMediaURL.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public enum OpenClawChatMediaURL {
+    public static func resolve(
+        gatewayURL: URL,
+        ticketedPath: String,
+        playback: OpenClawChatPlaybackMode?) -> URL?
+    {
+        let prefix = "/api/chat/media/outgoing/"
+        guard ticketedPath.hasPrefix(prefix),
+              let relative = URLComponents(string: ticketedPath),
+              relative.scheme == nil,
+              relative.host == nil,
+              relative.fragment == nil,
+              relative.percentEncodedPath.hasPrefix(prefix),
+              relative.queryItems?.contains(where: {
+                  $0.name == "mediaTicket" && $0.value?.isEmpty == false
+              }) == true,
+              var base = URLComponents(url: gatewayURL, resolvingAgainstBaseURL: false),
+              base.host != nil
+        else { return nil }
+        switch base.scheme?.lowercased() {
+        case "wss", "https": base.scheme = "https"
+        case "ws", "http": base.scheme = "http"
+        default: return nil
+        }
+        // The Gateway returns a root-relative route, but the proxy owns its prefix.
+        // Preserve encoded octets and repeated slashes just as the WebSocket does.
+        let contextPath = base.percentEncodedPath == "/" ? "" : base.percentEncodedPath
+        base.percentEncodedPath = contextPath + relative.percentEncodedPath
+        base.percentEncodedQuery = relative.percentEncodedQuery
+        base.fragment = nil
+        if playback == .transcode {
+            var queryItems = base.queryItems ?? []
+            queryItems.removeAll { $0.name == "playback" }
+            queryItems.append(URLQueryItem(name: "playback", value: "1"))
+            base.queryItems = queryItems
+        }
+        return base.url
+    }
+}

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMediaURLTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatMediaURLTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+@testable import OpenClawChatUI
+
+struct ChatMediaURLTests {
+    @Test(arguments: [
+        ("ws://gateway.example:18789", "http://gateway.example:18789"),
+        ("http://gateway.example/", "http://gateway.example"),
+        ("wss://gateway.example/tenant%20gateway/gw", "https://gateway.example/tenant%20gateway/gw"),
+        ("https://gateway.example/tenant%2Fgateway//gw/", "https://gateway.example/tenant%2Fgateway//gw/"),
+        ("wss://gateway.example/tenant%FFgateway/gw", "https://gateway.example/tenant%FFgateway/gw"),
+    ])
+    func `preserves gateway route and ticket`(route: (gateway: String, media: String)) throws {
+        let gateway = try #require(URL(string: route.gateway))
+        let ticketedPath = Self.mediaPath + "?mediaTicket=synthetic%2Fticket%3D&download=1"
+        let url = OpenClawChatMediaURL.resolve(gatewayURL: gateway, ticketedPath: ticketedPath, playback: nil)
+        #expect(url?.absoluteString == route.media + ticketedPath)
+    }
+
+    @Test func `rendition replaces playback without gateway query`() throws {
+        let gateway = try #require(URL(string: "wss://gateway.example/proxy?ignored=1#ignored"))
+        let ticketedPath = Self.mediaPath + "?mediaTicket=synthetic%2Fticket%3D&playback=0&playback=2"
+        let url = try #require(OpenClawChatMediaURL.resolve(
+            gatewayURL: gateway,
+            ticketedPath: ticketedPath,
+            playback: .transcode))
+        #expect(url.scheme == "https")
+        #expect(url.path == "/proxy" + Self.mediaPath)
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        #expect(components.queryItems == [
+            URLQueryItem(name: "mediaTicket", value: "synthetic/ticket="),
+            URLQueryItem(name: "playback", value: "1"),
+        ])
+        #expect(components.fragment == nil)
+    }
+
+    @Test(arguments: [
+        "https://other.example/api/chat/media/outgoing/main/id/full?mediaTicket=ticket",
+        "//other.example/api/chat/media/outgoing/main/id/full?mediaTicket=ticket",
+        "/api/chat/media/outgoing/main/id/full?mediaTicket=ticket#fragment",
+        "/api/chat/media/outgoing/main/id/full",
+        "/api/chat/media/outgoing/main/id/full?mediaTicket=",
+        "/unrelated?mediaTicket=ticket",
+    ])
+    func `rejects non ticket routes`(ticketedPath: String) throws {
+        let gateway = try #require(URL(string: "wss://gateway.example/proxy"))
+        #expect(OpenClawChatMediaURL.resolve(
+            gatewayURL: gateway,
+            ticketedPath: ticketedPath,
+            playback: nil) == nil)
+    }
+
+    @Test(arguments: ["ftp://gateway.example/proxy", "file:///proxy", "/proxy"])
+    func `rejects non gateway UR ls`(gateway: String) throws {
+        let gatewayURL = try #require(URL(string: gateway))
+        #expect(OpenClawChatMediaURL.resolve(
+            gatewayURL: gatewayURL,
+            ticketedPath: Self.mediaPath + "?mediaTicket=ticket",
+            playback: .transcode) == nil)
+    }
+
+    private static let mediaPath = "/api/chat/media/outgoing/main/11111111-1111-4111-8111-111111111111/full"
+}

--- a/docs/nodes/media-playback.md
+++ b/docs/nodes/media-playback.md
@@ -71,6 +71,11 @@ artifact through `artifacts.download`, which returns inline base64 bytes when
 the artifact is byte-backed or a short-lived, ticketed URL when it is
 Gateway-managed.
 
+Native clients resolve ticketed media against the connected Gateway URL,
+preserving its reverse-proxy path prefix. A Gateway reached at
+`wss://gateway.example/openclaw` loads managed media beneath
+`https://gateway.example/openclaw/api/chat/media/outgoing/`, not the server root.
+
 The ticketed byte routes support:
 
 - `Range` requests with HTTP `206 Partial Content` for seeking


### PR DESCRIPTION
Closes #130746. Related: #129957 (Android sibling repair).

## What Problem This Solves

Fixes an issue where iOS and macOS users could connect to a Gateway behind a reverse-proxy path but could not load its managed chat images, audio, or video. Media requests discarded the working WebSocket route's context prefix and targeted the server root.

## Why This Change Was Made

Move the two duplicated ticketed-media URL builders and playback-query helpers into one shared Apple chat resolver. Preserve the exact encoded Gateway prefix, including escaped path octets and repeated/trailing slashes; treat only the lone root slash as an empty context. Generic relative-URL resolution would still discard the prefix, while decoding and rebuilding the path could change its meaning.

Connection and authority ownership stay in the transports: iOS retains gateway identity checks, HTTPS-only sanitized proxy headers, TLS pinning, bounded downloads, and its direct-video streaming decision; macOS retains its immutable server lease and post-await liveness checks. Ticket, canonical-route, scheme, fragment, MIME, and size restrictions remain in effect. No configuration, persistence, protocol, dependency, or credential changes.

Production LOC: **+48/-75 (net -27)**. Tests: **+92/-9**. Documentation: **+5/-0**. The new shared resolver has two production callers and replaces both old paths; no test-only production seam was added.

## User Impact

Managed images, audio playback/renditions, and video URLs now use the same proxy context as the connected Gateway. Root-mounted Gateways and inline byte-backed artifacts retain their behavior. The media-playback documentation includes the expected reverse-proxy route.

## Evidence

- On unchanged production code, the expanded existing iOS loader tests produced **9 intended failures and 12 passing controls**: buffered images, transcoded audio, and direct video streams all dropped each non-root prefix. The repaired app passed **all 21 invocations** on the same iOS 27 simulator.
- Shared URL, media attachment, playback retry/coordinator, and deep-link security coverage: **51 tests in 5 suites passed**. URL cases cover root and prefixed routes, host/port, escaped spaces/slashes/non-UTF-8 octets, repeated/trailing slashes, unchanged native ticket query bytes, playback replacement, rejected absolute/foreign/fragment/unticketed paths, and unsupported Gateway URLs.
- Independent Codex autoreview completed with no actionable findings. Direct caller/owner/sibling inspection covered both Apple transports, the Gateway ticket producer, Android's landed repair, and the Control UI proxy-prefix test.
- Full-app iOS proof used a separate disposable iPhone simulator and a loopback-only mock Gateway/reverse proxy with synthetic messages, tickets, and assets. XCTest completed normal onboarding by pasting a setup code; no demo mode, injected app transport, or loader reimplementation was used. Both node/operator WebSockets connected through `/tenant%20gateway/gw`, and the real app requested `chat.history` and `artifacts.download`.
- Before the fix, all three actual media requests dropped the prefix and returned HTTP 404; the app displayed Image/Audio/Video unavailable. After the fix, all three requests retained the exact encoded prefix and returned HTTP 200. The native image, audio controls, and decoded video appeared. The request verifier checked exact asset SHA-256/byte counts (PNG 1,058; WAV 88,278; MP4 2,379), MIME, host, and absence of Authorization/custom proxy headers. The final frontdoor UI test passed after correcting a test selector that initially expected a nonexistent video accessibility label.
- This is real iOS app + URLSession HTTP behavior against a mock Gateway, not physical-device or live-provider proof. HTTPS direct streaming, TLS pinning, proxy-header handling, and rendition behavior have focused loader coverage; no new physical-device or authenticated reverse-proxy proof is claimed.
- Separate native playback checks passed: audio entered Pause and advanced to completion, video entered playback, and the image opened full preview. The iOS 27 XCTest accessibility hit-testing needed observed-coordinate taps for the visible SwiftUI media controls. Preview dismissal remains an explicitly unclassified accessibility/product follow-up; it is not attributed to this URL repair. All fixture processes were stopped and the disposable simulator deleted after collecting the evidence.

### CI and remaining follow-ups

Exact-head [CI run 33045779839](https://github.com/openclaw/openclaw/actions/runs/33045779839) is **green on attempt 2** for `b36ccfb8c2e58b81c45769f9c23be3996f48afb4`, including the required `openclaw/ci-gate`. iOS build, macOS Swift/Node, iPhone/Watch and iPad screenshots, documentation, and the other Android lanes passed on the initial attempt. This satisfies ClawSweeper's native-CI rank-up request. The first attempt failed only `android-test-third-party` (plus its dependent gate): `GatewaySessionReconnectTest.connectToNewGatewayClosesActiveConnectionAndStartsReplacement` observed two HTTP upgrade requests instead of one. Android source and tests are unchanged by this PR. The failure did not reproduce in 40 initial and then 1,000 additional local iterations with the original assertion and added lifecycle diagnostics. Those temporary diagnostics were removed; no assertion, timeout, or Android production change is included. The single targeted hosted rerun passed without a source change. The full unchanged local third-party suite also passed **2,398 tests across 196 files, with zero failures, errors, or skips**. Do not interpret the passing rerun as a root-cause repair; the intermittent Android request-count failure remains a named follow-up until reproduced with causal evidence.

The local changed gate passed static guards, formatting and Swift lint, then its macOS script-test batch hit the no-output watchdog while installer fixtures were still advancing. The identical test slice **passed all 502 tests across 14 files / 7 shards** when rerun with verbose reporting so progress was observable; no timeout or assertion was weakened. The native-state schema guard passed separately. A redundant Testbox attempt timed out during source synchronization before executing tests and its lease was stopped.

Before:

![Before: image, audio, and video unavailable behind the proxy path](https://github.com/user-attachments/assets/b1d26dcb-05b1-4328-9e2d-a8f22f6c2438)

After:

![After: image, audio controls, and decoded video load through the proxy path](https://github.com/user-attachments/assets/89c520b7-d483-43d8-a84e-ccfc3835f7f5)

Focused commands:

```sh
xcodebuild -quiet -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max' \
  -only-testing:OpenClawTests/IOSMediaArtifactLoaderTests \
  -parallel-testing-enabled NO test

swift test --package-path apps/shared/OpenClawKit \
  --filter 'ChatMediaURLTests|ChatMediaPlaybackLoaderTests|ChatMediaPlaybackCoordinatorTests|ChatMessageMediaAttachmentTests|DeepLinksSecurityTests'
```

Provenance: both overwrite implementations first appeared in #115042, merged July 28, 2026 as `4b05d83035cc7b466f155645603ce87d5b9fdf1a`. Code/PR author and merger: @steipete; the initial implementation also credits Francesco Giannicola (@metaforismo). Later audio/video and rendition work carried the omission forward. Local shallow blame was checked against that original PR patch rather than misattributing the bug to the shallow boundary. This is not claimed as a stable-tag regression.

AI-assisted maintainer repair.
