### PR TITLE
fix: filter watched-session presence by recipient visibility

### DIFF
--- a/docs/concepts/presence.md
+++ b/docs/concepts/presence.md
@@ -34,6 +34,32 @@ Presence entries are structured objects with fields like:
 - `reason`: free-form client-supplied string; the Gateway itself only emits `self`, `connect`, and `disconnect`
 - `deviceId`, `roles`, `scopes`: device identity and role/scope hints from the connect handshake
 - `ts`: last update timestamp (ms since epoch)
+- `watchedSessions`: session keys the client explicitly declares it is viewing, filtered for the recipient
+
+### Watched session references
+
+Hello snapshots, `system-presence`, and `presence` events include only watched
+session references that the recipient can see under the current session-list
+visibility rules. Drafts, incognito sessions, and operator role restrictions
+follow those same rules. Missing or deleted sessions are omitted, including for
+admins. Keys retain their agent scope, including agent-qualified `global` and
+`unknown` references.
+
+Session references require an operator connection with read access
+(`operator.read`, `operator.write`, or `operator.admin`). Nodes, pairing-only
+clients, and non-admin clients awaiting authenticated profile verification still
+receive the non-session presence roster in hello snapshots and events, without
+watched references. An established admin grant does not depend on profile
+verification. `system-presence` itself requires operator read access.
+
+Filtering preserves the connection and person metadata and the presence timestamp.
+When no references are visible, `watchedSessions` is omitted, just as when the
+client declares no watches; there are no hidden-session counts or markers.
+Message subscriptions alone do not declare viewer presence.
+
+These are coordination features within a shared agent, not isolation between
+mutually untrusted users. Everyone operating an agent shares that agent's
+capabilities. See [Multi-user trust boundary](/concepts/multi-user#trust-boundary).
 
 ## Producers (where presence comes from)
 
@@ -73,16 +99,17 @@ is sampled for this compatibility value.
 When a node connects over the Gateway WebSocket with `role: node`, the Gateway
 upserts a presence entry for that node (same flow as other WS clients).
 
-## Merge + dedupe rules (why `instanceId` matters)
+## Connection rows and beacon deduplication
 
-Presence entries are stored in a single in-memory map, keyed case-insensitively
-by the first available of, in order: a paired device id, `connect.client.instanceId`,
-or the per-connection id as a last resort.
+Presence entries are stored in a single in-memory map with case-insensitive keys.
+User WebSocket clients have one row per connection, so two tabs watching different
+sessions cannot overwrite each other. Node connections use their device id,
+then `connect.client.instanceId`, then the connection id.
 
-Ephemeral control-plane clients are excluded from tracking entirely (see
-above), so their connection ids never become keys. For every other client, the
-connection id fallback means a client that reconnects without a stable
-`instanceId` shows up as a **duplicate** row.
+`system-event` beacons merge by device id or instance id when supplied, otherwise
+by parsed host or other beacon metadata. A stable `instanceId` helps consumers
+associate rows with the same client; it does not merge separate user WebSocket
+connections. Ephemeral control-plane clients are excluded from tracking entirely.
 
 ## TTL and bounded size
 
@@ -116,11 +143,11 @@ indicator (Active/Idle/Stale) based on the age of the last update.
 
 ## Debugging tips
 
-- To see the raw list, call `system-presence` against the Gateway.
+- To see the list projected for your connection, call `system-presence` against the Gateway.
 - If you see duplicates:
   - confirm clients send a stable `client.instanceId` in the handshake
   - confirm periodic beacons use the same `instanceId`
-  - check whether the connection-derived entry is missing `instanceId` (duplicates are expected)
+  - check for multiple tabs or reconnects; separate user connections have separate rows, and old rows expire after the TTL
 
 ## Related
 

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -367,10 +367,11 @@ function makeScopedBroadcastClients() {
 
 function makeScopedBroadcastContext() {
   const scoped = makeScopedBroadcastClients();
-  return {
-    ...scoped,
-    ...createGatewayBroadcaster({ clients: scoped.clients }),
-  };
+  const broadcaster = createGatewayBroadcaster({
+    clients: scoped.clients,
+    preparePresenceProjection: (presence) => () => presence,
+  });
+  return { ...scoped, ...broadcaster };
 }
 
 function sentEvents(socket: RecordingSocket) {

--- a/src/gateway/presence-projection.ts
+++ b/src/gateway/presence-projection.ts
@@ -1,0 +1,70 @@
+import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SystemPresence } from "../infra/system-presence.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
+import { authorizeOperatorScopesForRequiredScope, READ_SCOPE } from "./method-scopes.js";
+import { isGatewayClientProfilePending } from "./server-methods/gateway-client-identity.js";
+import type { GatewayClient } from "./server-methods/types.js";
+import { createSessionListEntryFilter, isGatewayAdmin } from "./session-sharing.js";
+import {
+  resolveGatewaySessionStoreTargetWithStore,
+  type GatewaySessionStoreDiscoveryCache,
+} from "./session-utils-store-lookup.js";
+import { resolveCanonicalSessionStoreMatchFromStoreKeys } from "./session-utils-store.js";
+
+/** One synchronous snapshot/fanout owns these reads; never reuse them across broadcasts. */
+export function createPresenceRecipientProjection(params: {
+  cfg: OpenClawConfig;
+  presence: SystemPresence[];
+}): (client: GatewayClient | null) => SystemPresence[] {
+  const targets = new Map<string, { canonicalKey: string; entry: SessionEntry } | undefined>();
+  const targetDiscoveryCache: GatewaySessionStoreDiscoveryCache = new Map();
+  const resolveTarget = (sessionKey: string) => {
+    if (!targets.has(sessionKey)) {
+      const parsed = parseAgentSessionKey(sessionKey);
+      // Viewer declarations wrap sentinel keys with their agent. The stored key
+      // remains global/unknown in that agent's store, not a literal prefixed row.
+      const key =
+        parsed?.rest === "global" || parsed?.rest === "unknown" ? parsed.rest : sessionKey;
+      const target = resolveGatewaySessionStoreTargetWithStore({
+        cfg: params.cfg,
+        key,
+        agentId: parsed?.agentId,
+        readOnly: true,
+        exactRead: true,
+        clone: false,
+        targetDiscoveryCache,
+      });
+      const match = resolveCanonicalSessionStoreMatchFromStoreKeys(target.store, target.storeKeys);
+      targets.set(
+        sessionKey,
+        match ? { canonicalKey: target.canonicalKey, entry: match.entry } : undefined,
+      );
+    }
+    return targets.get(sessionKey);
+  };
+  return (client) => {
+    const canRead =
+      client?.connect != null &&
+      (client.connect.role ?? "operator") === "operator" &&
+      authorizeOperatorScopesForRequiredScope(READ_SCOPE, client.connect.scopes ?? []).allowed &&
+      // Match session reads: an established admin grant does not depend on profile verification.
+      (isGatewayAdmin(client) || !isGatewayClientProfilePending(client));
+    const entryFilter = canRead
+      ? createSessionListEntryFilter({ cfg: params.cfg, client })
+      : undefined;
+    return params.presence.map((row) => {
+      if (!row.watchedSessions) {
+        return row;
+      }
+      const watchedSessions = canRead
+        ? row.watchedSessions.filter((key) => {
+            const target = resolveTarget(key);
+            return target && (entryFilter?.(target.canonicalKey, target.entry) ?? true);
+          })
+        : [];
+      const { watchedSessions: _watchedSessions, ...person } = row;
+      return watchedSessions.length ? { ...person, watchedSessions } : person;
+    });
+  };
+}

--- a/src/gateway/server-broadcast.serialization.test.ts
+++ b/src/gateway/server-broadcast.serialization.test.ts
@@ -2,13 +2,26 @@
 // not consume per-client seqs (which would fire every client's gap detector and
 // cause a synchronized reconnect storm) and must leave a server-side record.
 import { once } from "node:events";
+import { existsSync } from "node:fs";
 import type { AddressInfo } from "node:net";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
+import { resolveSessionStorePathCore } from "../config/sessions.js";
+import {
+  deleteSessionEntryLifecycle,
+  patchSessionEntryCore,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { setVerbose } from "../global-state.js";
+import type { SystemPresence } from "../infra/system-presence.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
+import { ensureProfileForEmail } from "../state/user-profiles.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createPresenceRecipientProjection } from "./presence-projection.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
+import { createGatewayConnectionState } from "./server-connection-state.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
 const warnSpy = vi.hoisted(() => vi.fn());
@@ -65,6 +78,20 @@ afterEach(() => {
 });
 
 describe("broadcast serialization failures", () => {
+  it("never sends raw presence when its owner projection is missing", () => {
+    const peer = makeClient("unprepared");
+    const { broadcast } = createGatewayBroadcaster({ clients: new Set([peer.client]) });
+    warnSpy.mockClear();
+    broadcast("presence", {
+      presence: [{ text: "watcher", ts: 1, watchedSessions: ["agent:main:hidden"] }],
+    });
+    expect(peer.socket.send).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("presence recipient projection unavailable"),
+    );
+    broadcast("skills.changed", {});
+    expect(peer.socket.frames).toEqual([{ event: "skills.changed", seq: 1 }]);
+  });
   it.each([
     { state: "closing", readyState: WebSocket.CLOSING },
     { state: "closed", readyState: WebSocket.CLOSED },
@@ -209,5 +236,196 @@ describe("broadcast serialization failures", () => {
 
     expect(filtered.socket.send).not.toHaveBeenCalled();
     expect(dataReads).toBe(0);
+  });
+});
+
+describe("presence recipient projection", () => {
+  it("preserves scoped sentinels, recipient ordering, and current visibility without changing the source", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      let cfg: OpenClawConfig = { agents: { entries: { main: {}, work: {} } } };
+      const sharedKey = "agent:main:shared";
+      const incognitoKey = "agent:main:dashboard:incognito-presence";
+      const keys = [
+        sharedKey,
+        incognitoKey,
+        "agent:main:global",
+        "agent:work:global",
+        "agent:work:unknown",
+      ];
+      for (const [agentId, sessionKey, visibility] of [
+        ["main", sharedKey, "shared"],
+        ["main", incognitoKey, "shared"],
+        ["main", "global", "draft"],
+        ["work", "global", "read-only"],
+        ["work", "unknown", "suggest"],
+      ] as const) {
+        await upsertSessionEntryCore(
+          { agentId, sessionKey },
+          {
+            sessionId: `${agentId}-${sessionKey}`,
+            updatedAt: 1,
+            visibility,
+            createdActor: { type: "human", id: "creator" },
+          },
+        );
+      }
+      const reader = makeClient("reader");
+      reader.client.authenticatedUserProfile = {
+        profileId: ensureProfileForEmail("presence-reader@example.test").id,
+        displayName: "Reader",
+        avatarRevision: "1",
+        hasAvatar: false,
+        updatedAt: 1,
+      };
+      const admin = makeClient("admin");
+      admin.client.connect.scopes = ["operator.admin"];
+      const connection = createGatewayConnectionState({ cfg, getRuntimeConfig: () => cfg });
+      const person = {
+        text: "watcher",
+        ts: 42,
+        instanceId: "watcher",
+        user: { id: "creator", name: "Creator" },
+      };
+      const watcher = { ...person, watchedSessions: [...keys, "agent:main:deleted"] };
+      const presence = [watcher, { text: "idle", ts: 41 }];
+      Object.freeze(watcher.watchedSessions);
+      presence.forEach(Object.freeze);
+      Object.freeze(presence);
+      const payload = { presence };
+      const stateVersion = { presence: 7, health: 3 };
+      const lastFrame = (peer: ReturnType<typeof makeClient>) =>
+        // SAFETY: These sockets record JSON frames emitted by the real presence broadcaster below.
+        JSON.parse(peer.socket.send.mock.lastCall![0]) as {
+          payload: { presence: SystemPresence[] };
+          seq: number;
+          stateVersion: typeof stateVersion;
+        };
+      for (const order of [
+        [reader, admin],
+        [admin, reader],
+      ]) {
+        connection.clients.clear();
+        order.forEach((peer) => connection.clients.add(peer.client));
+        connection.broadcast("presence", payload, { stateVersion });
+        expect(lastFrame(reader).payload.presence).toEqual([
+          { ...person, watchedSessions: [sharedKey, "agent:work:global", "agent:work:unknown"] },
+          presence[1],
+        ]);
+        expect(lastFrame(admin).payload.presence).toEqual([
+          { ...person, watchedSessions: keys },
+          presence[1],
+        ]);
+        expect(lastFrame(reader).stateVersion).toEqual(stateVersion);
+      }
+      await patchSessionEntryCore({ agentId: "main", sessionKey: sharedKey }, () => ({
+        visibility: "draft",
+      }));
+      await deleteSessionEntryLifecycle({
+        agentId: "work",
+        storePath: resolveSessionStorePathCore(undefined, { agentId: "work" }),
+        target: { canonicalKey: "global", storeKeys: ["global"] },
+        archiveTranscript: false,
+      });
+      connection.broadcast("presence", payload);
+      expect(lastFrame(reader).payload.presence).toEqual([
+        { ...person, watchedSessions: ["agent:work:unknown"] },
+        presence[1],
+      ]);
+      expect(lastFrame(admin).payload.presence[0]?.watchedSessions).toEqual(
+        keys.filter((key) => key !== "agent:work:global"),
+      );
+
+      cfg = {
+        ...cfg,
+        gateway: {
+          roles: {
+            default: "restricted",
+            definitions: {
+              restricted: { sessions: { others: "none" }, agents: "*", scopes: ["operator.read"] },
+            },
+          },
+        },
+      };
+      connection.broadcastToConnIds("presence", payload, new Set([reader.client.connId]), {
+        stateVersion,
+      });
+      expect(lastFrame(reader)).toEqual({
+        type: "event",
+        event: "presence",
+        payload: { presence: [person, presence[1]] },
+        seq: 4,
+        stateVersion,
+      });
+      expect(lastFrame(admin).seq).toBe(3);
+      expect(watcher.watchedSessions).toEqual([...keys, "agent:main:deleted"]);
+    });
+  });
+
+  it("keeps solo and system authority without treating pending identity or missing read scope as solo", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const key = "agent:main:private";
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey: key },
+        {
+          sessionId: "private",
+          updatedAt: 1,
+          visibility: "draft",
+          createdActor: { type: "human", id: "creator" },
+        },
+      );
+      const person = { text: "watcher", ts: 1 };
+      const presence = [{ ...person, watchedSessions: [key] }];
+      const solo = makeClient("solo").client;
+      solo.connect.scopes = ["operator.write"];
+      const pending = makeClient("pending").client;
+      pending.authenticatedGitHubIdentitySync = async () => ({
+        profileId: "creator",
+        updatedAt: 1,
+      });
+      const node = makeClient("node").client;
+      node.connect.role = "node";
+      node.connect.scopes = ["operator.admin"];
+      const noRead = makeClient("no-read").client;
+      noRead.connect.scopes = [];
+      const project = createPresenceRecipientProjection({ cfg: {}, presence });
+      expect(project(solo)).toEqual(presence);
+      for (const client of [pending, node, noRead, null]) {
+        expect(project(client)).toEqual([person]);
+      }
+      pending.connect.scopes = ["operator.admin"];
+      expect(project(pending)).toEqual(presence);
+      const cfg: OpenClawConfig = { gateway: { roles: { definitions: {} } } };
+      const restrictedProject = createPresenceRecipientProjection({ cfg, presence });
+      expect(restrictedProject(solo)).toEqual([person]);
+      solo.internal = { operatorRoleActor: { kind: "system" } };
+      expect(restrictedProject(solo)).toEqual(presence);
+      pending.authenticatedUserProfile = {
+        profileId: "creator",
+        displayName: null,
+        avatarRevision: "1",
+        hasAvatar: false,
+        updatedAt: 1,
+      };
+      pending.connect.scopes = ["operator.read"];
+      expect(project(pending)).toEqual(presence);
+    });
+  });
+
+  it("omits obsolete watches without creating missing agent stores or omission metadata", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const person = { text: "watcher", ts: 1 };
+      const project = createPresenceRecipientProjection({
+        cfg: { agents: { entries: { uncreated: {} } } },
+        presence: [
+          { ...person, watchedSessions: ["agent:uncreated:missing"] },
+          { ...person, watchedSessions: [] },
+          person,
+        ],
+      });
+      const admin = makeClient("admin").client;
+      admin.connect.scopes = ["operator.admin"];
+      expect(project(admin)).toEqual([person, person, person]);
+      expect(existsSync(state.agentDir("uncreated"))).toBe(false);
+    });
   });
 });

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -3,6 +3,7 @@ import {
   hasGatewayClientCap,
 } from "../../packages/gateway-protocol/src/client-info.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import type { SystemPresence } from "../infra/system-presence.js";
 // Gateway WebSocket broadcaster.
 // Applies event scope guards and slow-consumer handling before sending frames.
 import { logRejectedLargePayload } from "../logging/diagnostic-payload.js";
@@ -210,6 +211,9 @@ function hasEventScope(
 
 export function createGatewayBroadcaster(params: {
   clients: Set<GatewayWsClient>;
+  preparePresenceProjection?: (
+    presence: SystemPresence[],
+  ) => (client: GatewayWsClient) => SystemPresence[];
   sessionMessageSubscribers?: SessionMessageSubscriberRegistry;
   canReceiveSessionEvent?: (
     client: GatewayWsClient,
@@ -244,6 +248,10 @@ export function createGatewayBroadcaster(params: {
       opts?.agentId,
     );
     const isTargeted = Boolean(targetConnIds);
+    const presencePayload =
+      // SAFETY: Internal presence producers emit { presence: SystemPresence[] }; wire input cannot publish events.
+      event === "presence" ? (payload as { presence: SystemPresence[] }) : undefined;
+    let projectPresence: ((client: GatewayWsClient) => SystemPresence[]) | undefined;
     let outboundEventLogged = false;
     let frameBase:
       | {
@@ -258,7 +266,7 @@ export function createGatewayBroadcaster(params: {
       if (!frameBase) {
         frameBase = {
           eventJSON: JSON.stringify(event),
-          payloadFragment: serializeFrameField("payload", payload),
+          payloadFragment: presencePayload ? "" : serializeFrameField("payload", payload),
           stateVersionFragment:
             opts?.stateVersion === undefined
               ? ""
@@ -377,7 +385,20 @@ export function createGatewayBroadcaster(params: {
       let frame: string;
       try {
         const base = getFrameBase();
-        frame = `{"type":"event","event":${base.eventJSON}${base.payloadFragment},"seq":${nextSeq}${base.stateVersionFragment}}`;
+        let payloadFragment = base.payloadFragment;
+        if (presencePayload) {
+          // Presence contains session references. Only the connection owner's
+          // recipient projection may cross this boundary; never send the raw roster.
+          if (!params.preparePresenceProjection) {
+            throw new Error("presence recipient projection unavailable");
+          }
+          projectPresence ??= params.preparePresenceProjection(presencePayload.presence);
+          payloadFragment = serializeFrameField("payload", {
+            ...presencePayload,
+            presence: projectPresence(c),
+          });
+        }
+        frame = `{"type":"event","event":${base.eventJSON}${payloadFragment},"seq":${nextSeq}${base.stateVersionFragment}}`;
       } catch (err) {
         log.error(`broadcast serialization failed for event ${event}: ${formatErrorMessage(err)}`);
         return;

--- a/src/gateway/server-connection-state.ts
+++ b/src/gateway/server-connection-state.ts
@@ -1,6 +1,7 @@
 // Gateway connection and run registries.
 // This state is transport-fed but can be constructed without HTTP or WebSocket servers.
 import type { ChatAbortControllerEntry } from "./chat-abort.js";
+import { createPresenceRecipientProjection } from "./presence-projection.js";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
 import {
   createChatRunState,
@@ -27,6 +28,8 @@ export function createGatewayConnectionState(params: {
   const sessionMessageSubscribers = createSessionMessageSubscriberRegistry(isConnectionActive);
   const gatewayBroadcaster = createGatewayBroadcaster({
     clients,
+    preparePresenceProjection: (presence) =>
+      createPresenceRecipientProjection({ cfg: loadRuntimeConfig(), presence }),
     sessionMessageSubscribers,
     canReceiveSessionEvent: (client, sessionKeys, agentId, event, payload) =>
       canReceiveSessionEvent({

--- a/src/gateway/server-methods/system.ts
+++ b/src/gateway/server-methods/system.ts
@@ -38,6 +38,7 @@ import { withSystemEventOwner } from "../../infra/system-event-ownership.js";
 import { enqueueSystemEvent, isSystemEventContextChanged } from "../../infra/system-events.js";
 import { listSystemPresence, updateSystemPresence } from "../../infra/system-presence.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { createPresenceRecipientProjection } from "../presence-projection.js";
 import { getGatewayProcessInstanceId } from "../process-instance.js";
 import { broadcastPresenceSnapshot } from "../server/presence-events.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
@@ -140,8 +141,11 @@ export const systemHandlers: GatewayRequestHandlers = {
     setHeartbeatsEnabled(enabled);
     respond(true, { ok: true, enabled }, undefined);
   },
-  "system-presence": ({ respond }) => {
-    const presence = listSystemPresence();
+  "system-presence": ({ respond, client, context }) => {
+    const presence = createPresenceRecipientProjection({
+      cfg: context.getRuntimeConfig(),
+      presence: listSystemPresence(),
+    })(client);
     respond(true, presence, undefined);
   },
   "system.info": async ({ params, respond, context }) => {

--- a/src/gateway/server.auth.identity-scopes.test.ts
+++ b/src/gateway/server.auth.identity-scopes.test.ts
@@ -1,18 +1,24 @@
 import { randomUUID } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
+import { Type } from "typebox";
+import { Value } from "typebox/value";
 import { afterEach, describe, expect, test } from "vitest";
+import { PresenceEntrySchema } from "../../packages/gateway-protocol/src/schema/snapshot.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { writeConfigFile } from "../config/config.js";
+import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import type { GatewayAuthConfig, GatewayOperatorRolesConfig } from "../config/types.gateway.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { getPairedDevice, listDevicePairing } from "../infra/device-pairing.js";
+import { listSystemPresence, type SystemPresence } from "../infra/system-presence.js";
 import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profiles.js";
 import {
   connectReq,
   CONTROL_UI_CLIENT,
   installGatewayTestHooks,
   NODE_CLIENT,
+  onceMessage,
   openTailscaleWs,
   openWs,
   rpcReq,
@@ -59,6 +65,190 @@ function responseScopes(response: Awaited<ReturnType<typeof connectReq>>): strin
 }
 
 describe("gateway identity scope grants", () => {
+  test("projects watched sessions for each authenticated presence recipient across hello, RPC, and events", async () => {
+    await configureGatewayAuth(
+      {
+        mode: "trusted-proxy",
+        identityScopes: { "admin@example.com": ["operator.admin"] },
+        trustedProxy: {
+          userHeader: "x-forwarded-user",
+          requiredHeaders: ["x-forwarded-proto"],
+          allowLoopback: true,
+        },
+      },
+      {
+        roles: {
+          default: "reader",
+          definitions: {
+            reader: { sessions: { others: "view" }, agents: "*", scopes: ["operator.read"] },
+            restricted: { sessions: { others: "none" }, agents: "*", scopes: ["operator.read"] },
+            maintainer: { sessions: { others: "write" }, agents: "*", scopes: ["operator.admin"] },
+            pairing: { sessions: { others: "none" }, agents: [], scopes: ["operator.pairing"] },
+          },
+        },
+      },
+    );
+    const creator = ensureProfileForEmail("creator@example.com");
+    const restricted = ensureProfileForEmail("restricted@example.com");
+    setUserProfileRole(restricted.id, "restricted");
+    setUserProfileRole(ensureProfileForEmail("admin@example.com").id, "maintainer");
+    setUserProfileRole(ensureProfileForEmail("pairing@example.com").id, "pairing");
+    const sharedKey = "agent:main:presence-shared";
+    const draftKey = "agent:main:presence-draft";
+    const incognitoKey = "agent:main:dashboard:incognito-presence";
+    const restrictedKey = "agent:main:presence-restricted-draft";
+    const missingKey = "agent:main:presence-missing";
+    const watchedKeys = [sharedKey, draftKey, incognitoKey, restrictedKey, missingKey].toSorted();
+    const watcherInstanceId = `presence-watcher-${randomUUID()}`;
+    const identityDir = tempDirs.make("openclaw-presence-identities-");
+
+    await withGatewayServer(async ({ port }) => {
+      for (const [sessionKey, profileId, visibility, incognito] of [
+        [sharedKey, creator.id, "shared", false],
+        [draftKey, creator.id, "draft", false],
+        [incognitoKey, creator.id, "shared", true],
+        [restrictedKey, restricted.id, "draft", false],
+      ] as const) {
+        await upsertSessionEntryCore(
+          { agentId: "main", sessionKey },
+          {
+            sessionId: randomUUID(),
+            updatedAt: Date.now(),
+            createdActor: { type: "human", id: profileId },
+            visibility,
+            ...(incognito ? { incognito: true } : {}),
+          },
+        );
+      }
+      const sockets: Awaited<ReturnType<typeof openWs>>[] = [];
+      const openRecipient = async (
+        name: string,
+        scopes: string[],
+        role: "operator" | "node" = "operator",
+      ) => {
+        const ws = await openWs(port, {
+          ...TRUSTED_PROXY_HEADERS,
+          "x-forwarded-user": `${name}@example.com`,
+        });
+        sockets.push(ws);
+        const connected = await connectReq(ws, {
+          skipDefaultAuth: true,
+          prePairDevice: true,
+          scopes,
+          role,
+          client: {
+            ...(role === "node" ? NODE_CLIENT : CONTROL_UI_CLIENT),
+            instanceId: sockets.length === 1 ? watcherInstanceId : `presence-${name}`,
+          },
+          deviceIdentityPath: path.join(identityDir, `${name}-${sockets.length}.sqlite`),
+          browserOrigin: BROWSER_ORIGIN,
+        });
+        expect(connected.ok, `${name} connect: ${JSON.stringify(connected.error)}`).toBe(true);
+        expect(responseScopes(connected), `${name} effective scopes`).toEqual(scopes);
+        return {
+          ws,
+          hello: connected.payload as { snapshot: { presence: SystemPresence[] } },
+        };
+      };
+      try {
+        const watcher = await openRecipient("admin", ["operator.admin"]);
+        const declared = await rpcReq(watcher.ws, "sessions.viewers.set", {
+          sessionKeys: watchedKeys,
+        });
+        expect(declared).toMatchObject({ ok: true, payload: { sessionKeys: watchedKeys } });
+        const rawWatcher = listSystemPresence().find(
+          (entry) => entry.instanceId === watcherInstanceId,
+        );
+        expect(rawWatcher?.watchedSessions).toEqual(watchedKeys);
+        const { watchedSessions: _watchedSessions, ...person } = rawWatcher!;
+        expect(person.user?.id).toBe(ensureProfileForEmail("admin@example.com").id);
+        expect(person.ts).toBeGreaterThan(0);
+
+        const recipients = [];
+        for (const scenario of [
+          { name: "creator", scopes: ["operator.read"], allowed: [sharedKey, draftKey] },
+          { name: "reader", scopes: ["operator.read"], allowed: [sharedKey] },
+          { name: "restricted", scopes: ["operator.read"], allowed: [restrictedKey] },
+          {
+            name: "admin",
+            scopes: ["operator.admin"],
+            allowed: [sharedKey, draftKey, incognitoKey, restrictedKey],
+          },
+          { name: "pairing", scopes: ["operator.pairing"], allowed: [] },
+          { name: "node", scopes: [], allowed: [] },
+        ]) {
+          const recipient = await openRecipient(
+            scenario.name,
+            scenario.scopes,
+            scenario.name === "node" ? "node" : "operator",
+          );
+          const canRead = scenario.name !== "pairing" && scenario.name !== "node";
+          const listed = await rpcReq<{ sessions: Array<{ key: string }> }>(
+            recipient.ws,
+            "sessions.list",
+            { agentId: "main" },
+          );
+          expect(listed.ok, `${scenario.name} sessions.list scope`).toBe(canRead);
+          if (canRead) {
+            expect(
+              listed.payload?.sessions
+                .map((entry) => entry.key)
+                .filter((key) => watchedKeys.includes(key))
+                .toSorted(),
+              `${scenario.name} canonical sessions.list visibility`,
+            ).toEqual(scenario.allowed.toSorted());
+          }
+          const presence = await rpcReq(recipient.ws, "system-presence");
+          expect(presence.ok, `${scenario.name} system-presence scope`).toBe(canRead);
+          recipients.push({ ...recipient, ...scenario, canRead, rpcPresence: presence.payload });
+        }
+
+        const eventPromises = recipients.map(({ ws }) =>
+          onceMessage<{ type: string; event: string; payload: { presence: SystemPresence[] } }>(
+            ws,
+            (frame) => frame.type === "event" && frame.event === "presence",
+          ),
+        );
+        expect(
+          await rpcReq(watcher.ws, "system-event", { text: "presence recipient repro" }),
+        ).toMatchObject({ ok: true });
+        const events = await Promise.all(eventPromises);
+        for (const [index, recipient] of recipients.entries()) {
+          for (const [surface, rows] of [
+            ["hello", recipient.hello.snapshot.presence],
+            ["system-presence", recipient.rpcPresence],
+            ["presence event", events[index]!.payload.presence],
+          ] as const) {
+            if (surface === "system-presence" && !recipient.canRead) {
+              continue; // The RPC is rejected for pairing-only operators and nodes.
+            }
+            if (!Value.Check(Type.Array(PresenceEntrySchema), rows)) {
+              throw new Error(`${recipient.name} ${surface} returned invalid presence rows`);
+            }
+            const received = rows.find((entry) => entry.instanceId === watcherInstanceId);
+            const { watchedSessions, ...receivedPerson } = received ?? {};
+            expect
+              .soft(
+                receivedPerson,
+                `${recipient.name} ${surface} preserves the person and timestamp without hidden counts`,
+              )
+              .toEqual(person);
+            expect
+              .soft(
+                watchedSessions ?? [],
+                `${recipient.name} ${surface} watched session disclosure`,
+              )
+              .toEqual(recipient.allowed.toSorted());
+          }
+        }
+      } finally {
+        for (const ws of sockets) {
+          ws.close();
+        }
+      }
+    });
+  });
+
   test.each([
     {
       label: "unassigned default guest",

--- a/src/gateway/server/health-state.test.ts
+++ b/src/gateway/server/health-state.test.ts
@@ -95,7 +95,7 @@ describe("buildGatewaySnapshot update metadata", () => {
       agents: { entries: { main: agent } },
     });
 
-    const snapshot = healthState.buildGatewaySnapshot({ revisionProjector });
+    const snapshot = healthState.buildGatewaySnapshot({ client: null, revisionProjector });
 
     expect(snapshot.sessionDefaults?.modelConfigured).toBe(expected);
   });
@@ -131,6 +131,7 @@ describe("buildGatewaySnapshot update metadata", () => {
     });
 
     const snapshot = healthState.buildGatewaySnapshot({
+      client: null,
       includeUpdateDetails: false,
       revisionProjector,
     });
@@ -167,6 +168,7 @@ describe("buildGatewaySnapshot update metadata", () => {
     getUpdateScheduleMock.mockReturnValue(updateSchedule);
 
     const snapshot = healthState.buildGatewaySnapshot({
+      client: null,
       includeUpdateDetails: true,
       revisionProjector,
     });

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -15,7 +15,9 @@ import type { GatewayConfigRevisionProjector } from "../config-revision-token.js
 import { projectUpdateAvailable } from "../events.js";
 import { collectGatewayHealthSnapshot } from "../health/collector.js";
 import type { HealthSummary } from "../health/types.js";
+import { createPresenceRecipientProjection } from "../presence-projection.js";
 import type { ChannelRuntimeSnapshot } from "../server-channel-runtime.types.js";
+import type { GatewayClient } from "../server-methods/types.js";
 import type { GatewayEventLoopHealth } from "./event-loop-health.js";
 
 let presenceVersion = 1;
@@ -49,6 +51,7 @@ const healthRefreshStates: Record<HealthAudience, HealthRefreshState> = {
 };
 
 export function buildGatewaySnapshot(opts: {
+  client: GatewayClient | null;
   includeSensitive?: boolean;
   includeUpdateDetails?: boolean;
   revisionProjector: GatewayConfigRevisionProjector;
@@ -60,7 +63,9 @@ export function buildGatewaySnapshot(opts: {
   const scope = cfg.session?.scope ?? "per-sender";
   const mainSessionKey =
     scope === "global" ? "global" : resolveAgentMainSessionKey({ cfg, agentId: defaultAgentId });
-  const presence = listSystemPresence();
+  const presence = createPresenceRecipientProjection({ cfg, presence: listSystemPresence() })(
+    opts.client,
+  );
   const uptimeMs = Math.round(process.uptime() * 1000);
   const includeUpdateDetails = opts?.includeUpdateDetails === true;
   const updateAvailable =

--- a/src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts
+++ b/src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts
@@ -83,6 +83,7 @@ describe("sendGatewayHello setup completion ordering", () => {
         const broadcast = vi.fn();
         const context = {
           handler: {
+            getClient: () => null,
             connId: "conn-setup-order",
             gatewayMethods: [],
             events: [],
@@ -193,6 +194,7 @@ describe("sendGatewayHello setup completion ordering", () => {
         const close = vi.fn();
         const context = {
           handler: {
+            getClient: () => null,
             connId: "conn-setup-send-failure",
             gatewayMethods: [],
             events: [],
@@ -300,6 +302,7 @@ describe("sendGatewayHello setup completion ordering", () => {
         const close = vi.fn();
         const context = {
           handler: {
+            getClient: () => null,
             connId: "conn-setup-replaced",
             gatewayMethods: [],
             events: [],
@@ -389,6 +392,7 @@ describe("sendGatewayHello setup completion ordering", () => {
         const close = vi.fn();
         const context = {
           handler: {
+            getClient: () => null,
             connId: "conn-generic-send-failure",
             gatewayMethods: [],
             events: [],

--- a/src/gateway/server/ws-connection/connect-hello.ts
+++ b/src/gateway/server/ws-connection/connect-hello.ts
@@ -101,6 +101,7 @@ export async function sendGatewayHello(
       : undefined;
   const canMigrateRecovery = role === "operator" && !authenticatedPrincipal && Boolean(deviceToken);
   const snapshot = buildGatewaySnapshot({
+    client: context.handler.getClient(),
     includeSensitive: scopes.includes(ADMIN_SCOPE),
     includeUpdateDetails: canReadDetailedUpdateMetadata(role, scopes),
     revisionProjector: buildRequestContext().configRevisionProjector,

--- a/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
+++ b/src/gateway/server/ws-connection/connect-hello.update-scope.test.ts
@@ -84,6 +84,7 @@ import { sendGatewayHello } from "./connect-hello.js";
 function makeContext(role: "operator" | "node", scopes: string[]) {
   return {
     handler: {
+      getClient: () => null,
       connId: `conn-${role}`,
       bootId: "gateway-boot-a",
       gatewayMethods: [],
@@ -161,6 +162,7 @@ describe("sendGatewayHello update detail scope", () => {
     await sendGatewayHello(context as never, makeState(role, scopes) as never, {});
 
     expect(buildGatewaySnapshotMock).toHaveBeenCalledWith({
+      client: null,
       includeSensitive: false,
       includeUpdateDetails: false,
     });
@@ -172,6 +174,7 @@ describe("sendGatewayHello update detail scope", () => {
     await sendGatewayHello(context as never, makeState("operator", ["operator.read"]) as never, {});
 
     expect(buildGatewaySnapshotMock).toHaveBeenCalledWith({
+      client: null,
       includeSensitive: false,
       includeUpdateDetails: true,
     });
@@ -223,6 +226,7 @@ describe("sendGatewayHello update detail scope", () => {
     await sendGatewayHello(context as never, state as never, {});
 
     expect(buildGatewaySnapshotMock).toHaveBeenCalledWith({
+      client: null,
       includeSensitive: false,
       includeUpdateDetails: false,
     });

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -272,6 +272,17 @@ describe("session.message websocket events", () => {
         );
       };
       const declaredKeys = ["agent:main:watch-00", "agent:main:watch-01"];
+      const replacementKey = "agent:main:replacement";
+      const storePath = await createSessionStoreFile();
+      await writeSessionStore({
+        storePath,
+        entries: Object.fromEntries(
+          [...declaredKeys, replacementKey].map((key) => [
+            key,
+            { sessionId: key, updatedAt: Date.now() },
+          ]),
+        ),
+      });
       const declaredPresence = onceMessage(observerWs, (message) => {
         const entry = findWatchedEntry(message);
         return (
@@ -318,7 +329,6 @@ describe("session.message websocket events", () => {
         )?.watchedSessions,
       ).toEqual(declaredKeys);
 
-      const replacementKey = "agent:main:replacement";
       const replacementPresence = onceMessage(observerWs, (message) => {
         const entry = findWatchedEntry(message);
         return Array.isArray(entry?.watchedSessions) && entry.watchedSessions[0] === replacementKey;


### PR DESCRIPTION
Closes #130732 — watched-session presence references ignore recipient visibility.

Related: #130664 (People activity cards) and #130649 (feature context); those remain separate work.

<details>
<summary>Additional instructions</summary>

This branch is in the main repository and remains editable by maintainers.

</details>

## What Problem This Solves

Resolves a problem where Gateway clients receive watched-session references that their own session list omits. Hello snapshots, `system-presence`, and presence events previously returned the raw watched-key array, including creator-only drafts, incognito sessions, role-hidden sessions, and stale references. Pairing-only and node connections could also receive those nested references.

## Why This Change Was Made

One recipient projection now applies the existing `createSessionListEntryFilter` policy at all three presence transport boundaries. It resolves sessions read-only, caches exact lookups only within a synchronous fanout, preserves agent-qualified sentinel keys, and omits missing sessions even for admins. The broadcaster never falls back to a raw roster when its projector is absent.

Filtering declarations cannot account for other recipients, and UI-only masking leaves the references on the wire. This leaves the raw producer and existing authorization policy intact, including established admin grants, while removing the three unprojected egress paths. It does not change UI/person cards, timing/time-zone policy, health summaries, configuration, protocol schemas, storage schemas, or dependencies.

## User Impact

Presence carries only watched-session references visible to the receiving operator under the existing session-list policy. Clients without session read access, and pending non-admin identities, retain the non-session roster without watched references. Person/device metadata, timestamps, event sequence numbers, and state versions remain unchanged. Hidden and missing references have no counts or omission markers.

This is a consistency repair within the existing shared-agent trust model, not a new multi-tenant isolation guarantee. Documentation: https://docs.openclaw.ai/concepts/presence.

## Evidence

The pre-fix isolated Gateway/WebSocket reproduction at `99539badfd6fac6a4daa7d903ada250bfa5a2da3` recorded 16 failing recipient/surface assertions while 13 existing identity-scope tests passed. The regression uses disposable state, synthetic trusted-proxy identities, real authentication/profile/session paths, and real WebSocket clients; TypeBox validates the returned presence shape. It compares hello, RPC, and event output with each recipient's canonical `sessions.list` result.

Synchronized candidate: `00410f54ed1eaca596a26485cabc805e6e75db7d`. The rebase was conflict-free and `git range-diff` confirmed the reviewed patch was unchanged.

Local validation on the candidate (all exit 0):

- Focused Gateway and infra suite: **12 files, 225 tests passed**.
- Changed formatting, typecheck, lint, dead-code, import-cycle and owner guards passed.
- Full build passed, including CLI bootstrap imports, SDK exports and UI build checks. The four existing `web-tree-sitter` eval warnings match the prior build; no ineffective-dynamic-import warning was emitted.

Exact commands:

```sh
node scripts/run-vitest.mjs src/gateway/server-broadcast.serialization.test.ts src/gateway/server.auth.identity-scopes.test.ts src/gateway/session-message-events.test.ts src/gateway/server/health-state.test.ts src/gateway/server/ws-connection/connect-hello.update-scope.test.ts src/gateway/server/ws-connection/connect-hello.setup-completion.test.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/gateway/gateway-misc.test.ts src/gateway/session-sharing.test.ts src/gateway/session-viewer-presence.test.ts src/gateway/server-methods/sessions-viewers.test.ts src/infra/system-presence.test.ts
node scripts/check-changed.mjs
git diff --check HEAD^ HEAD
pnpm build
```

Hosted [CI run 33047015467](https://github.com/openclaw/openclaw/actions/runs/33047015467) completed successfully on this exact head. The exact-head watcher and native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 130764` both exited 0; preparation reused the hosted proof without changing the head.

Coverage includes creator, ordinary reader, restricted reader, admin, pairing-only and node clients; pending identity and solo/system authority; both fanout orders; targeted delivery; frozen raw input; current visibility, deletion and role-policy changes; agent-qualified `global`/`unknown`; and absence of missing-store creation. Subscription and hello/update siblings remain covered.

This is authenticated Gateway/WebSocket fixture proof, not a separately built live UI or external provider/channel test. The absence of raw references is a wire assertion; there is no visual change to screenshot. No operator Gateway or live state was modified.

Production LOC: +109/-5 (net +104). Tests: +435/-6 (net +429). Docs: +37/-10 (net +27). The production growth adds the missing recipient ownership boundary and read-only exact resolution shared by three egress paths; no existing net-neutral equivalent could preserve these contracts without duplicating or changing the session policy.

Fresh Codex autoreview reported no actionable P0 findings; its requested threshold was P0, not an exhaustive lower-priority review. Independent source review also found no verified blocker. The watched-session field was introduced by #111225 (authored and merged by @steipete, commit `5c9916950e63ca0fbfb52abf7e9ecb2e43a4d43d`, 2026-07-19); this report proves current source behavior and makes no stable-release impact claim.

AI-assisted. The repair, owning visibility policy, transport call paths, and regression evidence were inspected before publication.
