### PR TITLE
refactor(ollama): remove orphan embedding hook

### DIFF
--- a/extensions/ollama/index.ts
+++ b/extensions/ollama/index.ts
@@ -83,9 +83,6 @@ import { createLazyConfiguredOllamaStreamFn } from "./src/stream-registration.js
 import { createLazyOllamaWebSearchProvider } from "./src/web-search-provider-registration.js";
 
 const loadOllamaSetup = createLazyRuntimeModule(() => import("./src/setup.runtime.js"));
-const loadOllamaEmbeddingProvider = createLazyRuntimeModule(
-  () => import("./src/embedding-provider.runtime.js"),
-);
 const loadOllamaMemoryEmbeddingProviderAdapter = createLazyRuntimeModule(
   async () =>
     (await import("./src/memory-embedding-adapter.js")).ollamaMemoryEmbeddingProviderAdapter,
@@ -1020,25 +1017,6 @@ export default definePluginEntry({
           resolveProviderApiKey: ctx.resolveProviderApiKey,
           capContextTokens: true,
         }),
-      createEmbeddingProvider: async ({ config, model, provider: embeddingProvider, remote }) => {
-        const { createOllamaEmbeddingProvider } = await loadOllamaEmbeddingProvider();
-        const { provider, client } = await createOllamaEmbeddingProvider({
-          config,
-          remote,
-          model: model || DEFAULT_OLLAMA_EMBEDDING_MODEL,
-          provider: embeddingProvider || OLLAMA_PROVIDER_ID,
-        });
-        return {
-          id: provider.id,
-          model: provider.model,
-          maxInputTokens: provider.maxInputTokens,
-          embedQuery: async (text, options) =>
-            await provider.embed(text, { ...options, inputType: "query" }),
-          embedBatch: async (texts, options) =>
-            await provider.embedBatch(texts, { ...options, inputType: "document" }),
-          client,
-        };
-      },
       resolveSyntheticAuth: ({ provider, providerConfig }) => {
         if (!shouldUseSyntheticOllamaAuth(providerConfig)) {
           return undefined;

--- a/extensions/ollama/lazy-import.test.ts
+++ b/extensions/ollama/lazy-import.test.ts
@@ -13,7 +13,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 describe("ollama lazy imports", () => {
   afterEach(() => {
     for (const moduleId of [
-      "./src/embedding-provider.runtime.js",
       "./src/media-understanding-provider.js",
       "./src/memory-embedding-adapter.js",
       "./src/node-inference.js",
@@ -29,9 +28,6 @@ describe("ollama lazy imports", () => {
   });
 
   it("loads optional runtime owners only on first use", async () => {
-    let embeddingImports = 0;
-    const embeddingQueryCalls: unknown[] = [];
-    const embeddingBatchCalls: unknown[] = [];
     let mediaImports = 0;
     let memoryImports = 0;
     let nodeInferenceImports = 0;
@@ -49,28 +45,6 @@ describe("ollama lazy imports", () => {
         return false;
       },
     }));
-    vi.doMock("./src/embedding-provider.runtime.js", () => {
-      embeddingImports += 1;
-      return {
-        createOllamaEmbeddingProvider: async () => {
-          return {
-            provider: {
-              id: "ollama",
-              model: "nomic-embed-text",
-              embed: async (...args: unknown[]) => {
-                embeddingQueryCalls.push(args);
-                return [1];
-              },
-              embedBatch: async (...args: unknown[]) => {
-                embeddingBatchCalls.push(args);
-                return [[2]];
-              },
-            },
-            client: { baseUrl: "http://127.0.0.1:11434" },
-          };
-        },
-      };
-    });
     vi.doMock("./src/memory-embedding-adapter.js", () => {
       memoryImports += 1;
       return {
@@ -192,7 +166,6 @@ describe("ollama lazy imports", () => {
     await vi.waitFor(() => expect(wslChecks).toBe(1));
 
     expect({
-      embeddingImports,
       mediaImports,
       memoryImports,
       nodeInferenceImports,
@@ -201,7 +174,6 @@ describe("ollama lazy imports", () => {
       webSearchImports,
       wslImports,
     }).toEqual({
-      embeddingImports: 0,
       mediaImports: 0,
       memoryImports: 0,
       nodeInferenceImports: 0,
@@ -227,19 +199,6 @@ describe("ollama lazy imports", () => {
     });
 
     const localProvider = providers.find((provider) => provider.id === "ollama");
-    const localEmbedding = await localProvider?.createEmbeddingProvider?.({
-      config: {},
-      model: "",
-      provider: "ollama",
-    } as never);
-    expect(localEmbedding).toMatchObject({
-      id: "ollama",
-      client: { baseUrl: "http://127.0.0.1:11434" },
-    });
-    await expect(localEmbedding?.embedQuery("query")).resolves.toEqual([1]);
-    await expect(localEmbedding?.embedBatch(["document"])).resolves.toEqual([[2]]);
-    expect(embeddingQueryCalls).toEqual([["query", { inputType: "query" }]]);
-    expect(embeddingBatchCalls).toEqual([[["document"], { inputType: "document" }]]);
     await expect(
       localProvider?.auth[0]?.run({
         config: {},
@@ -279,7 +238,6 @@ describe("ollama lazy imports", () => {
     });
 
     expect({
-      embeddingImports,
       mediaImports,
       memoryImports,
       nodeInferenceImports,
@@ -288,7 +246,6 @@ describe("ollama lazy imports", () => {
       webSearchImports,
       wslImports,
     }).toEqual({
-      embeddingImports: 1,
       mediaImports: 1,
       memoryImports: 1,
       nodeInferenceImports: 1,


### PR DESCRIPTION
## What Problem This Solves

Ollama still implemented the optional `ProviderPlugin.createEmbeddingProvider` hook after the production provider runtime stopped consuming that hook. Its lazy runtime loader and a large lazy-import test branch therefore described a path that current OpenClaw could not call.

The dormant wrapper duplicated the active memory embedding adapter's query/document projection and made the plugin entrypoint appear to own two embedding creation paths.

## Why This Change Was Made

This removes only Ollama's orphan hook implementation, its now-dead lazy loader, and the obsolete mock/assertion branch that exercised it.

The public optional `ProviderPlugin` type remains available. Ollama's actual memory embedding adapter, embedding runtime, query/document behavior, output dimensionality handling, Gateway embedding transport, and plugin SDK helpers are unchanged.

The hook and wrapper existed in the `v2026.7.1` lineage; the wrapper was removed from the current architecture. This cleanup does not claim the historical hook was never functional.

## User Impact

No user-visible behavior change is intended. Ollama embeddings continue through the canonical registered memory embedding adapter and existing transport path. The change removes a misleading internal layer rather than a working public capability.

## Evidence

- Current-main source search finds no production `.createEmbeddingProvider` consumer; only the optional public type, Ollama implementation, and its test branch remained.
- Grouped owner/sibling coverage passes 97/97 tests across Ollama lazy imports and transport, Memory Core provider creation/state, and shared embedding runtime resolution.
- The isolated real-transport file passes 4/4 on rerun; its initial cold run timed out under a concurrent full build, while the unchanged isolated rerun passed 4/4.
- Ollama package-local type checking passes with zero diagnostics.
- The complete changed-path gate passes all phases after restoring the exact pinned Daytona SDK importer in a task-owned dependency overlay: production and test type graphs, scoped lint, plugin boundaries, database/media/runtime-sidecar guards, dead-code scans, formatting, and zero import cycles.
- Fresh review reports no actionable findings.
- Production: 0/-22, net -22 lines. Tests: 0/-43, net -43 lines. Total: 65 lines removed.
- No public SDK/type, configuration, protocol, dependency, package manifest, or persisted-state change.

`CHANGELOG.md` is release-owned; this behavior-preserving internal cleanup needs no release entry.
