### PR TITLE
fix(google): preserve gateway queries in embedding batches

### DIFF
--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -414,7 +414,9 @@ describe("Google embedding-batch bounded JSON reads", () => {
             url.searchParams.get("uploadType") === "multipart"
           ) {
             request.setEncoding("utf8");
-            for await (const chunk of request) uploadBody += chunk;
+            for await (const chunk of request) {
+              uploadBody += chunk;
+            }
             respondJson({ file: { name: "files/input-0" } });
             return;
           }
@@ -475,6 +477,9 @@ describe("Google embedding-batch bounded JSON reads", () => {
             headers: { "X-Proof-Tenant": "remote" },
           },
         });
+        if (!adapter.provider) {
+          throw new Error("Expected a Gemini embedding provider");
+        }
         await expect(adapter.provider.embed("hello", { inputType: "query" })).resolves.toEqual([
           1, 0, 0,
         ]);

--- a/extensions/google/embedding-batch.test.ts
+++ b/extensions/google/embedding-batch.test.ts
@@ -1,8 +1,10 @@
 // Google tests cover embedding batch bounded JSON response reads.
 import { createServer } from "node:http";
+import * as embeddingSdk from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runGeminiEmbeddingBatches } from "./embedding-batch.js";
 import type { GeminiEmbeddingClient } from "./embedding-provider.js";
+import { geminiMemoryEmbeddingProviderAdapter } from "./memory-embedding-adapter.js";
 
 // Pass-through so onResponse receives real Response objects (required by
 // readProviderJsonResponse which needs a real .body ReadableStream).
@@ -321,15 +323,25 @@ describe("Google embedding-batch bounded JSON reads", () => {
     expect(response.bodyUsed).toBe(true);
   });
 
-  it("normalizes raw Google Operations and uses the canonical download route", async () => {
+  it.each([
+    { baseUrl: "https://generativelanguage.googleapis.com/v1beta", version: "v1beta", query: "" },
+    {
+      baseUrl: "https://generativelanguage.googleapis.com/v1alpha/?tenant=remote",
+      version: "v1alpha",
+      query: "tenant=remote&",
+    },
+  ])("uses canonical Google file routes for $baseUrl", async ({ baseUrl, version, query }) => {
     const fetchMock = stubBatchFetch();
 
-    const result = await runBatch();
+    const result = await runBatch(singleRequest(), makeGeminiClient(baseUrl));
 
     expect(result.get("r0")).toEqual([1, 0, 0]);
-    expect(fetchMock.mock.calls.map(([input]) => fetchInputUrl(input))).toContain(
-      "https://generativelanguage.googleapis.com/download/v1beta/files/out-0:download?alt=media",
-    );
+    expect(fetchMock.mock.calls.map(([input]) => fetchInputUrl(input))).toEqual([
+      `https://generativelanguage.googleapis.com/upload/${version}/files?${query}uploadType=multipart`,
+      `https://generativelanguage.googleapis.com/${version}/models/gemini-embedding-001:asyncBatchEmbedContent${query ? `?${query.slice(0, -1)}` : ""}`,
+      `https://generativelanguage.googleapis.com/${version}/batches/b-0${query ? `?${query.slice(0, -1)}` : ""}`,
+      `https://generativelanguage.googleapis.com/download/${version}/files/out-0:download?${query}alt=media`,
+    ]);
     for (const [, init] of fetchMock.mock.calls) {
       expect(new Headers(init?.headers).get("x-goog-api-key")).toBe("test-key");
     }
@@ -351,79 +363,159 @@ describe("Google embedding-batch bounded JSON reads", () => {
     );
   });
 
-  it("runs the complete batch lifecycle over loopback HTTP", async () => {
-    let createBody: unknown;
-    const authHeaders: Array<string | undefined> = [];
-    const server = createServer((request, response) => {
-      void (async () => {
-        const url = new URL(request.url ?? "/", "http://127.0.0.1");
-        const apiKey = request.headers["x-goog-api-key"];
-        authHeaders.push(Array.isArray(apiKey) ? apiKey.join(", ") : apiKey);
-        const respondJson = (body: unknown) => {
-          response.writeHead(200, { "content-type": "application/json" });
-          response.end(JSON.stringify(body));
-        };
-        if (url.pathname === "/upload/v1beta/files") {
-          request.resume();
-          await new Promise<void>((resolve) => {
-            request.once("end", () => resolve());
-          });
-          respondJson({ file: { name: "files/input-0" } });
-          return;
-        }
-        if (url.pathname.endsWith(":asyncBatchEmbedContent")) {
-          let body = "";
-          request.setEncoding("utf8");
-          for await (const chunk of request) {
-            body += chunk;
-          }
-          createBody = JSON.parse(body) as unknown;
-          respondJson({
-            name: "batches/b-0",
-            done: false,
-            metadata: { state: "BATCH_STATE_PENDING" },
-          });
-          return;
-        }
-        if (url.pathname === "/v1beta/batches/b-0") {
-          respondJson({
-            name: "batches/b-0",
-            done: true,
-            metadata: { state: "BATCH_STATE_SUCCEEDED" },
-            response: { responsesFile: "files/output-0" },
-          });
-          return;
-        }
-        if (url.pathname === "/v1beta/files/output-0:download") {
-          response.writeHead(200, { "content-type": "application/jsonl" });
-          const line = JSON.stringify({
-            key: "r0",
-            response: { embedding: { values: [1, 0, 0] } },
-          });
-          response.write(line.slice(0, 17));
-          response.end(line.slice(17));
-          return;
-        }
-        response.writeHead(404).end();
-      })().catch((error: unknown) => {
-        response.writeHead(500).end(error instanceof Error ? error.message : String(error));
-      });
-    });
-    const port = await listenLoopbackServer(server);
-
-    try {
-      const result = await runBatch(
-        singleRequest(),
-        makeGeminiClient(`http://127.0.0.1:${port}/v1beta`),
+  it.each([
+    { basePath: "/v1beta", prefix: "", query: "" },
+    { basePath: "/gateway/v1beta/", prefix: "/gateway", query: "?tenant=remote" },
+    { basePath: "/gateway/v1beta/", prefix: "/gateway", query: "?tenant=remote&route=a/" },
+    { basePath: "/gateway/v1beta", prefix: "/gateway", query: "?tenant=/openai/team/" },
+    { basePath: "/gateway/v1beta/openai", prefix: "/gateway", query: "?tenant=remote" },
+  ])(
+    "runs the public adapter over HTTP for $basePath with query $query",
+    async ({ basePath, prefix, query }) => {
+      let createBody: unknown;
+      let uploadBody = "";
+      const observedUrls: string[] = [];
+      const authHeaders: Array<string | undefined> = [];
+      const tenantHeaders: Array<string | undefined> = [];
+      const realSdk = await vi.importActual<typeof embeddingSdk>(
+        "openclaw/plugin-sdk/memory-core-host-engine-embeddings",
       );
+      const remoteHttp = vi
+        .spyOn(embeddingSdk, "withRemoteHttpResponse")
+        .mockImplementation(realSdk.withRemoteHttpResponse);
+      const server = createServer((request, response) => {
+        void (async () => {
+          const url = new URL(request.url ?? "/", "http://127.0.0.1");
+          observedUrls.push(`${request.method} ${url.pathname}${url.search}`);
+          const apiKey = request.headers["x-goog-api-key"];
+          authHeaders.push(Array.isArray(apiKey) ? apiKey.join(", ") : apiKey);
+          const tenant = request.headers["x-proof-tenant"];
+          tenantHeaders.push(Array.isArray(tenant) ? tenant.join(", ") : tenant);
+          const expectedQuery = new URLSearchParams(query);
+          const configuredQuerySurvives = [...expectedQuery].every(
+            ([name, value]) => url.searchParams.get(name) === value,
+          );
+          if (!configuredQuerySurvives) {
+            response.writeHead(400).end(`configured query changed: ${url.pathname}${url.search}`);
+            request.resume();
+            return;
+          }
+          const respondJson = (body: unknown) => {
+            response.writeHead(200, { "content-type": "application/json" });
+            response.end(JSON.stringify(body));
+          };
+          if (url.pathname === `${prefix}/v1beta/models/gemini-embedding-001:embedContent`) {
+            request.resume();
+            respondJson({ embedding: { values: [1, 0, 0] } });
+            return;
+          }
+          if (
+            url.pathname === `${prefix}/upload/v1beta/files` &&
+            url.searchParams.get("uploadType") === "multipart"
+          ) {
+            request.setEncoding("utf8");
+            for await (const chunk of request) uploadBody += chunk;
+            respondJson({ file: { name: "files/input-0" } });
+            return;
+          }
+          if (
+            url.pathname === `${prefix}/v1beta/models/gemini-embedding-001:asyncBatchEmbedContent`
+          ) {
+            let body = "";
+            request.setEncoding("utf8");
+            for await (const chunk of request) {
+              body += chunk;
+            }
+            createBody = JSON.parse(body) as unknown;
+            respondJson({
+              name: "batches/b-0",
+              done: false,
+              metadata: { state: "BATCH_STATE_PENDING" },
+            });
+            return;
+          }
+          if (url.pathname === `${prefix}/v1beta/batches/b-0`) {
+            respondJson({
+              name: "batches/b-0",
+              done: true,
+              metadata: { state: "BATCH_STATE_SUCCEEDED" },
+              response: { responsesFile: "files/output-0" },
+            });
+            return;
+          }
+          if (
+            url.pathname === `${prefix}/v1beta/files/output-0:download` &&
+            url.searchParams.get("alt") === "media"
+          ) {
+            response.writeHead(200, { "content-type": "application/jsonl" });
+            const line = JSON.stringify({
+              key: "0",
+              response: { embedding: { values: [1, 0, 0] } },
+            });
+            response.write(line.slice(0, 17));
+            response.end(line.slice(17));
+            return;
+          }
+          response.writeHead(404).end();
+        })().catch((error: unknown) => {
+          response.writeHead(500).end(error instanceof Error ? error.message : String(error));
+        });
+      });
+      const port = await listenLoopbackServer(server);
 
-      expect(result).toEqual(new Map([["r0", [1, 0, 0]]]));
-      expect(createBody).toMatchObject({ batch: { inputConfig: { file_name: "files/input-0" } } });
-      expect(authHeaders).toEqual(["test-key", "test-key", "test-key", "test-key"]);
-    } finally {
-      await closeServer(server);
-    }
-  });
+      try {
+        const adapter = await geminiMemoryEmbeddingProviderAdapter.create({
+          config: {},
+          provider: "gemini",
+          model: "gemini-embedding-001",
+          fallback: "none",
+          remote: {
+            baseUrl: `http://127.0.0.1:${port}${basePath}${query}`,
+            apiKey: "test-key",
+            headers: { "X-Proof-Tenant": "remote" },
+          },
+        });
+        await expect(adapter.provider.embed("hello", { inputType: "query" })).resolves.toEqual([
+          1, 0, 0,
+        ]);
+        const result = await adapter.runtime?.batchEmbed?.({
+          agentId: "main",
+          chunks: [{ text: "hello" }],
+          wait: true,
+          concurrency: 1,
+          pollIntervalMs: 1,
+          timeoutMs: 5_000,
+          debug: () => {},
+        });
+
+        expect(result).toEqual([[1, 0, 0]]);
+        const uploadedRequest = uploadBody.split("\r\n\r\n")[2]?.split("\r\n")[0];
+        expect(JSON.parse(uploadedRequest ?? "null")).toEqual({
+          key: "0",
+          request: {
+            content: { parts: [{ text: "hello" }] },
+            taskType: "RETRIEVAL_DOCUMENT",
+            model: "models/gemini-embedding-001",
+          },
+        });
+        expect(createBody).toMatchObject({
+          batch: { inputConfig: { file_name: "files/input-0" } },
+        });
+        expect(authHeaders).toEqual(Array(5).fill("test-key"));
+        expect(tenantHeaders).toEqual(Array(5).fill("remote"));
+        expect(observedUrls.map((value) => value.split("?")[0])).toEqual([
+          `POST ${prefix}/v1beta/models/gemini-embedding-001:embedContent`,
+          `POST ${prefix}/upload/v1beta/files`,
+          `POST ${prefix}/v1beta/models/gemini-embedding-001:asyncBatchEmbedContent`,
+          `GET ${prefix}/v1beta/batches/b-0`,
+          `GET ${prefix}/v1beta/files/output-0:download`,
+        ]);
+      } finally {
+        remoteHttp.mockRestore();
+        await closeServer(server);
+      }
+    },
+  );
 
   it("honors terminal LRO fields when metadata is stale", async () => {
     stubBatchFetch((stage) =>

--- a/extensions/google/embedding-batch.ts
+++ b/extensions/google/embedding-batch.ts
@@ -7,8 +7,8 @@ import {
   debugEmbeddingsLog,
   EmbeddingBatchUnavailableError,
   formatBatchErrorDetail,
-  normalizeBatchBaseUrl,
   readEmbeddingBatchJsonl,
+  resolveEmbeddingEndpointUrl,
   withRemoteHttpResponse,
   type EmbeddingBatchExecutionParams,
 } from "openclaw/plugin-sdk/memory-core-host-engine-embeddings";
@@ -82,30 +82,32 @@ function hashText(text: string): string {
   return crypto.createHash("sha256").update(text).digest("hex");
 }
 
-function getGeminiVersionedRouteBase(baseUrl: string, route: "upload" | "download"): string | null {
-  const trimmed = baseUrl.replace(/\/$/, "");
-  const match = trimmed.match(/^(.*)\/(v\d+(?:alpha|beta)?)$/);
-  return match ? `${match[1]}/${route}/${match[2]}` : null;
-}
-
-function getGeminiUploadUrl(baseUrl: string): string {
-  return getGeminiVersionedRouteBase(baseUrl, "upload") ?? `${baseUrl.replace(/\/$/, "")}/upload`;
-}
-
-function getGeminiDownloadUrl(baseUrl: string, fileId: string): string {
-  const file = fileId.startsWith("files/") ? fileId : `files/${fileId}`;
-  const trimmed = baseUrl.replace(/\/$/, "");
-  let officialGoogleOrigin = false;
-  try {
-    officialGoogleOrigin =
-      new URL(trimmed).origin.toLowerCase() === "https://generativelanguage.googleapis.com";
-  } catch {
-    // Custom base URLs are preserved below.
+function getGeminiBatchFileUrl(
+  baseUrl: string,
+  route: "upload" | "download",
+  fileId: string,
+): string {
+  const base = new URL(baseUrl);
+  const pathname = base.pathname.replace(/\/+$/, "");
+  // Google file routes precede the API version; custom download gateways own their prefix.
+  if (route === "upload" || base.origin === "https://generativelanguage.googleapis.com") {
+    const version = pathname.match(/^(.*)\/(v\d+(?:alpha|beta)?)$/);
+    base.pathname = version
+      ? `${version[1]}/${route}/${version[2]}`
+      : route === "upload"
+        ? `${pathname}/upload`
+        : pathname;
   }
-  const downloadBase = officialGoogleOrigin
-    ? (getGeminiVersionedRouteBase(trimmed, "download") ?? trimmed)
-    : trimmed;
-  return `${downloadBase}/${file}:download?alt=media`;
+  const endpoint =
+    route === "upload"
+      ? fileId
+      : `${fileId.startsWith("files/") ? fileId : `files/${fileId}`}:download`;
+  const url = new URL(resolveEmbeddingEndpointUrl(base.href, endpoint));
+  url.searchParams.set(
+    route === "upload" ? "uploadType" : "alt",
+    route === "upload" ? "multipart" : "media",
+  );
+  return url.href;
 }
 
 function getGeminiBatchState(operation: GeminiBatchOperation): GeminiBatchState {
@@ -180,7 +182,7 @@ async function submitGeminiBatch(params: {
   requests: GeminiBatchRequest[];
   agentId: string;
 }): Promise<GeminiBatchOperation> {
-  const baseUrl = normalizeBatchBaseUrl(params.gemini);
+  const baseUrl = params.gemini.baseUrl;
   const jsonl = params.requests
     .map((request) =>
       JSON.stringify({
@@ -192,7 +194,7 @@ async function submitGeminiBatch(params: {
   const displayName = `memory-embeddings-${hashText(String(Date.now()))}`;
   const uploadPayload = buildGeminiUploadBody({ jsonl, displayName });
 
-  const uploadUrl = `${getGeminiUploadUrl(baseUrl)}/files?uploadType=multipart`;
+  const uploadUrl = getGeminiBatchFileUrl(baseUrl, "upload", "files");
   debugEmbeddingsLog("memory embeddings: gemini batch upload", {
     uploadUrl,
     baseUrl,
@@ -230,7 +232,10 @@ async function submitGeminiBatch(params: {
     },
   };
 
-  const batchEndpoint = `${baseUrl}/${params.gemini.modelPath}:asyncBatchEmbedContent`;
+  const batchEndpoint = resolveEmbeddingEndpointUrl(
+    baseUrl,
+    `${params.gemini.modelPath}:asyncBatchEmbedContent`,
+  );
   debugEmbeddingsLog("memory embeddings: gemini batch create", {
     batchEndpoint,
     fileId,
@@ -265,11 +270,10 @@ async function fetchGeminiBatchStatus(params: {
   batchName: string;
   signal?: AbortSignal;
 }): Promise<GeminiBatchOperation> {
-  const baseUrl = normalizeBatchBaseUrl(params.gemini);
   const name = params.batchName.startsWith("batches/")
     ? params.batchName
     : `batches/${params.batchName}`;
-  const statusUrl = `${baseUrl}/${name}`;
+  const statusUrl = resolveEmbeddingEndpointUrl(params.gemini.baseUrl, name);
   debugEmbeddingsLog("memory embeddings: gemini batch status", { statusUrl });
   return await withRemoteHttpResponse({
     url: statusUrl,
@@ -323,8 +327,7 @@ async function fetchGeminiBatchOutput(params: {
   errors: string[];
   byCustomId: Map<string, number[]>;
 }): Promise<void> {
-  const baseUrl = normalizeBatchBaseUrl(params.gemini);
-  const downloadUrl = getGeminiDownloadUrl(baseUrl, params.fileId);
+  const downloadUrl = getGeminiBatchFileUrl(params.gemini.baseUrl, "download", params.fileId);
   debugEmbeddingsLog("memory embeddings: gemini batch download", { downloadUrl });
   await withRemoteHttpResponse({
     url: downloadUrl,

--- a/extensions/google/embedding-provider.ts
+++ b/extensions/google/embedding-provider.ts
@@ -251,39 +251,33 @@ async function fetchGeminiEmbeddingPayload(params: {
 }
 
 function normalizeGeminiBaseUrl(raw: string): string {
-  const trimmed = raw.replace(/\/+$/, "");
-  const openAiIndex = trimmed.indexOf("/openai");
-  if (openAiIndex > -1) {
-    const queryIndex = trimmed.indexOf("?", openAiIndex);
-    return normalizeGoogleApiBaseUrl(
-      `${trimmed.slice(0, openAiIndex)}${queryIndex < 0 ? "" : trimmed.slice(queryIndex)}`,
-    );
-  }
-  return normalizeGoogleApiBaseUrl(trimmed);
-}
-
-function buildGeminiModelPath(model: string): string {
-  return model.startsWith("models/") ? model : `models/${model}`;
-}
-
-function normalizeGoogleApiBaseUrl(baseUrl: string): string {
-  const trimmed = baseUrl.trim().replace(/\/+$/, "");
+  const trimmed = raw.trim();
   if (!trimmed) {
     return DEFAULT_GOOGLE_API_BASE_URL;
   }
   try {
     const url = new URL(trimmed);
     url.hash = "";
+    // OpenAI endpoint aliases and trailing slashes belong to the path, not tenant query values.
+    const openAiIndex = url.pathname.indexOf("/openai");
+    url.pathname = (openAiIndex < 0 ? url.pathname : url.pathname.slice(0, openAiIndex)).replace(
+      /\/+$/,
+      "",
+    );
     if (
       url.origin.toLowerCase() === "https://generativelanguage.googleapis.com" &&
-      url.pathname.replace(/\/+$/, "") === ""
+      url.pathname === "/"
     ) {
       url.pathname = "/v1beta";
     }
-    return url.toString().replace(/\/+$/, "");
+    return url.search ? url.href : url.href.replace(/\/$/, "");
   } catch {
     return trimmed;
   }
+}
+
+function buildGeminiModelPath(model: string): string {
+  return model.startsWith("models/") ? model : `models/${model}`;
 }
 
 export async function createGeminiEmbeddingProvider(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Gemini memory embedding batches fail through a configured gateway whose base URL includes query parameters. Batch upload, creation, polling, and download can append their route inside the query instead of the pathname. Query values ending in `/` or containing `/openai` can also be altered before either direct or batch requests are sent.

## Why This Change Was Made

Normalize the embedding destination once as a parsed URL, applying the existing OpenAI-compatible path alias and trailing-slash normalization only to its pathname. Reuse the shared embedding endpoint resolver for batch creation and polling, and replace three file-route helpers with one parsed URL builder for upload and download.

This preserves Google's official versioned file routes, custom gateway download prefixes, configured query values, and existing credential-destination and SSRF checks. The separate Google chat URL policy is unchanged. No configuration, dependency, public SDK, or storage surface is added. Production LOC: +47/-50 (net -3); tests: +173/-76 (net +97).

The existing adapter includes its normalized base URL in embedding cache identity. That value changes for the corrected query inputs, including a trailing pathname slash before a query; this change adds no cache schema or migration.

## User Impact

Gemini embedding gateways can keep their query-based routing parameters throughout direct embedding and the complete asynchronous batch lifecycle, including URLs with custom prefixes or an OpenAI-compatible path suffix.

## Evidence

Candidate head: `2b78e15a10094c2df8574c960552eb022d11ef60`. The production source is identical to the tested `28eca6f972fe43fcc32fa15dbdaae5876cf2a0b5` head; the follow-up is the two test-only corrections described below.

On the original main baseline `be8b6ff3c4697c045d9277356018846e777fbcdc`, the focused regression matrix had five failures and two passing controls. With this repair, all seven cases pass. The HTTP cases exercise the public Gemini memory adapter, the real remote HTTP/SSRF guard, and a loopback server observing direct embedding plus upload, batch creation, status polling, and chunked JSONL download. Assertions cover observed paths, preserved query values, request headers, uploaded JSONL, batch file binding, and returned vectors.

All 101 tests across the six focused suites pass: Google embedding batch, embedding provider, memory adapter, Google API policy, shared embedding remote client, and shared remote HTTP. The test process explicitly clears host provider-key variables for deterministic fixture auth; no credential-resolution behavior or assertion was changed. Formatting and `git diff --check` pass.

The Google API route contracts were checked against the official `googleapis/js-genai` v2.17.1 [batch](https://github.com/googleapis/js-genai/blob/v2.17.1/src/batches.ts), [upload](https://github.com/googleapis/js-genai/blob/v2.17.1/src/_api_client.ts), and [download](https://github.com/googleapis/js-genai/blob/v2.17.1/src/node/_node_downloader.ts) source and Google API documentation. The locally shared installed SDK is 2.13.0; this is not claimed as execution against 2.17.1. The initial regression matrix uses real loopback HTTP; the additional authenticated Google run is described below. Local typed lint was deferred under severe host CPU contention, and exact-head hosted lint, production types, test types, build, and full CI have now passed.

The same raw-string batch URL assembly is present in stable `v2026.7.1-2`; this is an existing bug, not a claim that the frozen baseline introduced it. Independent source/proof review found no blocking issue, and the P2 autoreview is clean.

The first hosted CI run caught a missing pair of braces in the test fixture's `for await` loop and the public adapter's nullable-provider type. The follow-up adds the braces and an explicit provider-availability assertion before use, without changing production code or weakening the test. [Full CI on the updated head](https://github.com/openclaw/openclaw/actions/runs/33049661954) passed: 51 jobs, 30 successful and 21 skipped. The complete exact-head check inventory was 98 checks, 49 successful and 49 skipped, with no pending or failed check.

The completed ClawSweeper review requested accepted provider-route evidence. On this exact head, an authenticated run used the real public Gemini memory adapter, the normal SSRF guard and its pinned dispatcher against Google with `gemini-embedding-001`, synthetic text `hello`, and base URL `https://generativelanguage.googleapis.com/v1beta?prettyPrint=false`. Google documents `prettyPrint` as a [standard query parameter](https://docs.cloud.google.com/apis/docs/system-parameters). The observer forwarded the real request unchanged apart from a 30-second probe timeout, recording only status, route classes, query parameters, and vector counts.

| Actual stage | Observed result |
| --- | --- |
| Direct embedding | HTTP 200; 3,072 finite vector elements |
| Multipart file upload | HTTP 200; `prettyPrint=false` and `uploadType=multipart` preserved |
| Async batch creation | HTTP 200; exactly one one-row batch admitted |
| Batch polling | HTTP 200; `prettyPrint=false` preserved; reached `BATCH_STATE_SUCCEEDED` |
| Output download | HTTP 200; `prettyPrint=false` and `alt=media` preserved; adapter returned one vector with 3,072 finite elements |

The complete functional path finished in 164 seconds, without resubmission. This is actual Google acceptance, not the loopback fixture; custom gateway prefix and query-value variants remain covered by the deterministic regression matrix. Both ClawSweeper rank-up requests—accepted provider routes and completed exact-head checks—are now addressed.

Cleanup caveat: the probe exited 2 during cleanup, not during embedding. Batch deletion returned HTTP 200 followed by GET 404. Input-file deletion returned HTTP 200, but the verification GET returned 403, so the probe stopped before attempting output-file deletion. A bounded file-metadata listing found no matching task-window artifact and no next page; no further deletion was attempted without an exact ownership match. Generated output deletion therefore remains unverified. This was synthetic test data only, and no credential or resource identifier is included here. Google's [batch documentation](https://ai.google.dev/gemini-api/docs/batch-api#retrieving-results) describes a default six-week result-retention period; it does not establish that deleting a job deletes its generated output.
