### PR TITLE
fix(memory): honor mixed-case embedding header overrides

### DIFF
--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.test.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.test.ts
@@ -1,5 +1,5 @@
 // Memory Host SDK tests cover embeddings remote client behavior.
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveRemoteEmbeddingBearerClient } from "./embeddings-remote-client.js";
 import type { EmbeddingProviderOptions } from "./embeddings.types.js";
 
@@ -9,6 +9,10 @@ const configuredProvider = {
   headers: { "X-Provider-Tenant": "provider-a" },
   models: [],
 };
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("resolveRemoteEmbeddingBearerClient", () => {
   it.each<{
@@ -43,6 +47,7 @@ describe("resolveRemoteEmbeddingBearerClient", () => {
       tenant: "remote-b",
     },
   ])("$name", async ({ remote, authorization, tenant }) => {
+    vi.stubEnv("OPENAI_API_KEY", "");
     const client = await resolveRemoteEmbeddingBearerClient({
       provider: "openai",
       defaultBaseUrl: "https://api.openai.com/v1",
@@ -73,6 +78,46 @@ describe("resolveRemoteEmbeddingBearerClient", () => {
         },
       }),
     ).rejects.toThrow(/memory\.search\.remote\.apiKey|Authorization header/);
+  });
+
+  it("lets the last source replace mixed-case auth, tenant, and default headers", async () => {
+    const client = await resolveRemoteEmbeddingBearerClient({
+      provider: "openai",
+      defaultBaseUrl: configuredProvider.baseUrl,
+      options: {
+        config: {
+          models: {
+            providers: {
+              openai: {
+                ...configuredProvider,
+                headers: {
+                  Authorization: "first",
+                  authorization: "second",
+                  "X-Tenant": "first",
+                  "x-tenant": "second",
+                },
+              },
+            },
+          },
+        },
+        model: "fixture-embedding",
+        remote: {
+          headers: {
+            Authorization: "Bearer remote",
+            "X-Tenant": "remote",
+            "content-type": "application/json; charset=utf-8",
+            "X-Unchanged": "value",
+          },
+        },
+      },
+    });
+
+    expect(client.headers).toEqual({
+      "content-type": "application/json; charset=utf-8",
+      Authorization: "Bearer remote",
+      "X-Tenant": "remote",
+      "X-Unchanged": "value",
+    });
   });
 
   it("treats loopback address families as distinct credential destinations", async () => {
@@ -129,8 +174,8 @@ describe("resolveRemoteEmbeddingBearerClient", () => {
         remote: {
           apiKey: "sk-test",
           headers: {
-            originator: "openclaw",
-            "User-Agent": "openclaw",
+            Originator: "caller",
+            "user-agent": "caller",
           },
         },
       },

--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
@@ -51,27 +51,24 @@ export function resolveEmbeddingEndpointUrl(baseUrl: string, endpoint: string): 
   return url.toString();
 }
 
-function resolveEmbeddingHeaders(params: {
-  headers: Record<string, unknown> | undefined;
-  path: string;
-}): Record<string, string> {
-  const resolved: Record<string, string> = {};
-  for (const [name, value] of Object.entries(params.headers ?? {})) {
-    const header = resolveMemorySecretInputString({
-      value,
-      path: `${params.path}.${name}`,
-    });
-    if (header) {
-      resolved[name] = header;
+function resolveEmbeddingHeaders(
+  ...sources: Array<{ headers: Record<string, unknown> | undefined; path: string }>
+): Map<string, [string, string]> {
+  const resolved = new Map<string, [string, string]>();
+  for (const source of sources) {
+    // Retain each source's existing SecretRef and prototype-key handling.
+    const headers: Record<string, string> = {};
+    for (const [name, value] of Object.entries(source.headers ?? {})) {
+      const header = resolveMemorySecretInputString({ value, path: `${source.path}.${name}` });
+      if (header) {
+        headers[name] = header;
+      }
+    }
+    for (const entry of Object.entries(headers)) {
+      resolved.set(entry[0].toLowerCase(), entry);
     }
   }
   return resolved;
-}
-
-function hasAuthorizationHeader(headers: Record<string, string>): boolean {
-  return Object.entries(headers).some(
-    ([name, value]) => name.toLowerCase() === "authorization" && value.trim().length > 0,
-  );
 }
 
 /** Detect the native OpenAI embeddings API route that accepts attribution headers. */
@@ -105,20 +102,17 @@ export async function resolveRemoteEmbeddingBearerClient(params: {
     baseUrl,
     providerBaseUrl,
   });
-  const headerOverrides = Object.assign(
-    {},
-    providerOwnsDestination
-      ? resolveEmbeddingHeaders({
-          headers: providerConfig?.headers,
-          path: `models.providers.${params.provider}.headers`,
-        })
-      : undefined,
-    resolveEmbeddingHeaders({
+  const headerOverrides = resolveEmbeddingHeaders(
+    {
+      headers: providerOwnsDestination ? providerConfig?.headers : undefined,
+      path: `models.providers.${params.provider}.headers`,
+    },
+    {
       headers: remote?.headers,
       path: "memory.search.remote.headers",
-    }),
+    },
   );
-  const hasExplicitAuthorization = hasAuthorizationHeader(headerOverrides);
+  const hasExplicitAuthorization = headerOverrides.has("authorization");
   const apiKey = hasExplicitAuthorization
     ? undefined
     : remoteApiKey
@@ -138,13 +132,18 @@ export async function resolveRemoteEmbeddingBearerClient(params: {
       `${params.provider} embedding credentials are not configured for ${baseUrl}. Set memory.search.remote.apiKey or an Authorization header for this destination.`,
     );
   }
-  const headers: Record<string, string> = {
-    "Content-Type": "application/json",
-    ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
-    ...headerOverrides,
-  };
-  if (isNativeOpenAIEmbeddingRoute(params.provider, baseUrl)) {
-    Object.assign(headers, resolveOpenClawAttributionHeaders());
+  const entries: Array<[string, string]> = [["Content-Type", "application/json"]];
+  if (apiKey) {
+    entries.push(["Authorization", `Bearer ${apiKey}`]);
   }
+  entries.push(...headerOverrides.values());
+  if (isNativeOpenAIEmbeddingRoute(params.provider, baseUrl)) {
+    entries.push(...Object.entries(resolveOpenClawAttributionHeaders()));
+  }
+  // Fetch joins duplicate names; retain only the last source, but preserve its
+  // spelling so ordinary non-secret embedding cache identities stay unchanged.
+  const headers = Object.fromEntries(
+    new Map(entries.map((entry) => [entry[0].toLowerCase(), entry])).values(),
+  );
   return { baseUrl, headers, ssrfPolicy: buildRemoteBaseUrlPolicy(baseUrl) };
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users overriding memory embedding authentication or tenant headers could send both the provider default and the override when the header names used different capitalization. This affects the shared OpenAI, Mistral, DeepInfra, and Voyage embedding path, including custom compatible endpoints.

## Why This Change Was Made

HTTP header names are case-insensitive, but the shared client merged them as case-sensitive object keys. Fetch then combined the duplicate values instead of applying the intended last-source override. The existing shared owner now resolves ordered sources by case-insensitive identity while preserving the winning key spelling and value. Default headers, provider headers, remote overrides, and native OpenAI attribution keep their existing precedence; the obsolete authorization scan is removed.

Destination ownership, secret resolution, missing-credential errors, provider auth selection, and unchanged cache identities remain intact. Production changes are +35/-36 (net -1); tests are +48/-3 (net +45). The existing environment-dependent fixture now restores its scoped environment stub, without changing production authentication precedence.

Provenance: this case-sensitive merge already exists in stable `v2026.7.1`. The currently implicated lines were carried forward by [#127699](https://github.com/openclaw/openclaw/pull/127699), authored and merged by @steipete on 2026-08-24 ([8083d4dd3ff5](https://github.com/openclaw/openclaw/commit/8083d4dd3ff533d6ca2658d42761f70309d61254)); that change is not claimed as the original introduction. The original introducing actor was not established by the bounded history check.

Known follow-up: Google embeddings have a separate case-collision path, also reproduced in direct and batch requests. That path is not fixed here. Its public raw configuration accepts SecretInput values, so repairing the typed merge requires resolving that separate input contract without introducing incidental validation or secret-handling changes. Google source and tests remain untouched.

## User Impact

Remote embedding header overrides now replace differently capitalized provider defaults instead of producing combined authentication, tenant, or content-type values. Native OpenAI attribution likewise remains a single semantic header. Provider credentials are still not inherited by a different remote destination. No configuration option, dependency, public SDK API, or persistent-state change is introduced.

## Evidence

AI-assisted with Codex; the implementation and retained before/after evidence were independently reviewed.

Reviewed head: `5b791366f240eec42e94d9f5c93d2b2eaa021de7`. Its complete two-file diff exactly matches the reviewed and verified patch; production source is unchanged by the final test-only formatting pass. A publication-time check against current main `02a7ab923f92b99428f41a560e6352587c4f6f71` found no changes to this owner, its tests, or the four provider factories since the proof baseline.

- Captured the failure on pristine production source at be8b6ff3c4697c045d9277356018846e777fbcdc, then reran the same real HTTP fixture against the fix. The four shared providers plus native attribution cover 21 cases: 13 failed before, all 21 passed after. The fixed run made 20 requests through actual provider factories to an owned loopback server; every connection was checked against its exact host, port, and protocol. Native attribution was checked at client construction only, with no native API request.
- Wire coverage includes mixed-case authorization and tenant overrides, repeated A/a/A source ordering, content-type defaults, same-case controls, and a different provider path. All eight unchanged same-case/different-destination adapter cache identities matched the baseline exactly after replacing only the ephemeral fixture port.
- The focused regression file failed on original source with the two expected failures and six passing controls. Restoring the fix made all eight tests pass. Existing missing-destination-auth, loopback-family, and query-sensitive ownership checks remain in that passing file. Command: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs packages/memory-host-sdk/src/host/embeddings-remote-client.test.ts --configLoader runner --maxWorkers 1`.
- Formatting and `git diff --check` pass. No live external provider or credential was used; this repair concerns exact HTTP header composition, which the real local transport exercises directly.
- Local type-aware lint and broader compiler checks are not claimed: host CPU contention prevented those runs. The exact-head [full CI run](https://github.com/openclaw/openclaw/actions/runs/33048595679) is successful (82 jobs: 61 successful, 21 intentionally skipped), including build, production types, test types, lint, and the required merge gate. The [PR context and evidence check](https://github.com/openclaw/openclaw/actions/runs/33048595812) also passed. The required P2 autoreview and independent source/proof review completed with no findings on the final diff.

Final review follow-through: the [latest exact-head ClawSweeper review](https://github.com/openclaw/openclaw/pull/130774#issuecomment-5435810824) reports no correctness or security findings. Its rank-up request to finish hosted checks is satisfied by the runs above. Its Google scope decision is explicitly accepted as the named follow-up above; this PR does not claim that separate path is repaired. The inferred persistent-data-model warning does not describe this diff: only transient HTTP header composition changes, with no database/schema/storage operation or migration. The eight unchanged cache-identity controls also match the baseline exactly; no migration is required.
