### PR TITLE
fix(discord): keep mention labels literal in text substitution

### DIFF
--- a/extensions/discord/src/monitor/message-text.test.ts
+++ b/extensions/discord/src/monitor/message-text.test.ts
@@ -126,6 +126,32 @@ describe("resolveDiscordMessageText", () => {
     expect(text).toBe("Hello @Alice Wonderland and @bob!");
   });
 
+  it.each(["a$'b", "$&", "big$$money", "a$`b"])(
+    "preserves literal mention labels containing %s",
+    (label) => {
+      const text = resolveDiscordMessageText(
+        asMessage({
+          content: "Hello <@1> and <@!1>, meet <@2>!",
+          mentionedUsers: [
+            { id: "1", globalName: label, username: "fallback" },
+            { id: "2", username: label },
+          ],
+        }),
+      );
+      expect(text).toBe(`Hello @${label} and @${label}, meet @${label}!`);
+    },
+  );
+
+  it.each([undefined, ""])("uses the user ID when mention names are %s", (name) => {
+    const text = resolveDiscordMessageText(
+      asMessage({
+        content: "Hello <@1> and <@!1>!",
+        mentionedUsers: [{ id: "1", globalName: name, username: name }],
+      }),
+    );
+    expect(text).toBe("Hello @1 and @1!");
+  });
+
   it("leaves content unchanged if no mentions present", () => {
     const text = resolveDiscordMessageText(
       asMessage({ content: "Hello world", mentionedUsers: [] }),

--- a/extensions/discord/src/monitor/message-text.ts
+++ b/extensions/discord/src/monitor/message-text.ts
@@ -74,8 +74,8 @@ function resolveDiscordMentions(text: string, message: Message): string {
   }
   let out = text;
   for (const user of mentions) {
-    const label = user.globalName || user.username;
-    out = out.replace(new RegExp(`<@!?${user.id}>`, "g"), `@${label}`);
+    const label = user.globalName || user.username || user.id;
+    out = out.replace(new RegExp(`<@!?${user.id}>`, "g"), () => `@${label}`);
   }
   return out;
 }


### PR DESCRIPTION
## What Problem This Solves

Discord inbound mention substitution passes user-controlled display names as the replacement string to `String.prototype.replace`, which interprets `$` sequences. Any message mentioning a user whose name contains a `$` pattern gets silently corrupted before it reaches the agent, channel history, and reply/forward context:

- a name containing `$$` (e.g. `big$$money`) renders as `big$money`;
- a crafted name of `$'` duplicates the trailing half of the message; `` $` `` duplicates the leading half; `$&` reinserts the raw `<@id>` markup — a mild injection vector, since a mentioned user's name can rewrite other people's message text as the agent sees it.

The same site rendered `@undefined` when a mention payload carried neither `globalName` nor `username`.

## Why This Change Was Made

`resolveDiscordMentions` ([message-text.ts](extensions/discord/src/monitor/message-text.ts)) is the shared projection used by the message body, history entries, and reply/forward context, so the corruption propagated everywhere Discord text is read. The fix keeps the label literal by using a replacer callback (`() => `@${label}``) and falls back to the user ID for nameless users, matching the existing `@id` conventions in `message-forwarded.ts:112` and `format.ts:38`. Sibling channels are unaffected: Slack strips mentions with a static replacement and Telegram mentions are already plain text; a repo-wide sweep found this to be the only dynamic-regex + templated-replacement site in the channel plugins. The defect exists in shipped stable `v2026.6.1`.

Production LOC: +2/−2 (net 0); tests +26.

## User Impact

Discord messages mentioning users with `$` sequences in their names now reach the agent verbatim, and a crafted display name can no longer duplicate or rewrite message content. Nameless mention payloads render as `@<id>` instead of `@undefined`.

## Evidence

- Node-level reproduction on pre-fix code confirmed suffix/prefix duplication, raw-markup reinsertion, `$$`→`$` collapse, and `@undefined`.
- New regressions cover display names and usernames, `<@id>`/`<@!id>` markup, repeated mentions, all four active `$` substitution patterns, and absent/empty names; 6 fail on pre-fix code, 25/25 pass post-fix (`node scripts/run-vitest.mjs extensions/discord/src/monitor/message-text`, re-run green after rebase onto latest `origin/main`).
- check-changed extension lanes green locally (formatting, types, lint, dead-export scans); import-cycles guard green.
- Codex autoreview: clean, no accepted/actionable findings.
