### PR TITLE
fix(ui): prevent lost avatars and stuck identity saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI agent identity:** wait for a selected avatar to finish decoding before saving identity edits, preserve editable drafts after an interrupted save reconnects, and release decoded image resources on fallback paths.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
 
 - **Control UI agent files:** keep confirmed saves and file metadata intact when older reads or list refreshes finish later, preserve newer drafts, and rebuild invalidated file lists without losing the open editor.

--- a/ui/src/e2e/agent-identity-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/agent-identity-lifecycle.e2e.test.ts
@@ -1,0 +1,209 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI agent identity lifecycle",
+  startServerBeforeBrowser: true,
+});
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "agent-identity-lifecycle",
+);
+const overviewPath = "settings/agents/main/overview";
+
+async function capture(page: Page, state: string) {
+  if (!captureUiProof) {
+    return;
+  }
+  await mkdir(proofDir, { recursive: true });
+  await page.locator(".agent-identity-editor__avatar").scrollIntoViewIfNeeded();
+  await page.screenshot({
+    animations: "disabled",
+    fullPage: true,
+    path: path.join(proofDir, `${process.env.OPENCLAW_UI_PROOF_LABEL ?? "current"}-${state}.png`),
+  });
+}
+
+function identityResponses(name: string, avatar = "") {
+  const identity = { name, avatar };
+  const config = { agents: { entries: { main: { default: true, identity } } } };
+  return {
+    "agents.list": {
+      agents: [{ id: "main", name, identity }],
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+    },
+    "agent.identity.get": {
+      agentId: "main",
+      name,
+      avatar,
+      avatarStatus: avatar ? "data" : "none",
+    },
+    "config.get": {
+      config,
+      sourceConfig: config,
+      runtimeConfig: config,
+      hash: `identity-${name}`,
+      issues: [],
+      raw: JSON.stringify(config),
+      valid: true,
+    },
+  };
+}
+
+async function publishIdentity(gateway: MockGatewayControls, name: string, avatar = "") {
+  for (const [method, response] of Object.entries(identityResponses(name, avatar))) {
+    await gateway.setMethodResponse(method, response);
+  }
+}
+
+async function openIdentity(page: Page) {
+  const gateway = await installMockGateway(page, {
+    assistantName: "QA agent",
+    defaultAgentId: "main",
+    featureMethods: ["agents.list", "agents.update", "agent.identity.get", "config.get"],
+    methodResponses: identityResponses("QA agent"),
+    operatorScopes: ["operator.admin", "operator.read", "operator.write"],
+  });
+  expect((await page.goto(`${suite.server.baseUrl}${overviewPath}`))?.status()).toBe(200);
+  const editor = page.locator("openclaw-agents-page .agent-identity-editor");
+  const name = editor.getByRole("textbox", { name: "Display name" });
+  const actions = page.locator(".agent-identity-editor__actions");
+  const save = actions.getByRole("button");
+  await expect.poll(() => name.inputValue()).toBe("QA agent");
+  await gateway.waitForRequest("config.get");
+  return { gateway, editor, name, actions, save };
+}
+
+suite.define(() => {
+  it("saves the selected image with a dirty name after native image decoding finishes", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { width: 1440, height: 1000 } },
+      async ({ page }) => {
+        await page.addInitScript(() => {
+          const decode = globalThis.createImageBitmap.bind(globalThis);
+          Object.defineProperty(globalThis, "createImageBitmap", {
+            value: async (...args: Parameters<typeof createImageBitmap>) => {
+              if (args[0] instanceof File && args[0].name === "qa-avatar.png") {
+                await new Promise<void>((resolve) => {
+                  window.addEventListener("qa-release-avatar-decode", () => resolve(), {
+                    once: true,
+                  });
+                  document.documentElement.setAttribute("data-qa-avatar-decoding", "pending");
+                });
+              }
+              return decode(...args);
+            },
+          });
+        });
+        const { gateway, editor, name, actions, save } = await openIdentity(page);
+        const png = await page.evaluate(() => {
+          const canvas = document.createElement("canvas");
+          canvas.width = 96;
+          canvas.height = 96;
+          const context = canvas.getContext("2d")!;
+          context.fillStyle = "rgb(30 144 255)";
+          context.fillRect(0, 0, 96, 96);
+          context.fillStyle = "white";
+          context.fillRect(24, 24, 48, 48);
+          return canvas.toDataURL("image/png").split(",")[1]!;
+        });
+        await name.fill("QA image agent");
+        await actions.locator('input[type="file"]').setInputFiles({
+          name: "qa-avatar.png",
+          mimeType: "image/png",
+          buffer: Buffer.from(png, "base64"),
+        });
+        await page.locator('html[data-qa-avatar-decoding="pending"]').waitFor();
+        await gateway.deferNext("agents.update");
+        await save.click();
+        await expect.poll(async () => (await save.textContent())?.trim()).toBe("Saving…");
+        await page.evaluate(
+          () =>
+            new Promise<void>((resolve) => {
+              requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+            }),
+        );
+        await capture(page, "decode-pending");
+        expect(await gateway.getRequests("agents.update")).toHaveLength(0);
+
+        await page.evaluate(() => window.dispatchEvent(new Event("qa-release-avatar-decode")));
+        const request = await gateway.waitForRequest("agents.update");
+        expect(request.params).toMatchObject({
+          agentId: "main",
+          name: "QA image agent",
+          avatar: expect.stringMatching(/^data:image\/(?:webp|png);base64,/),
+        });
+        const avatar = (request.params as { avatar: string }).avatar;
+        await publishIdentity(gateway, "QA image agent", avatar);
+        await gateway.resolveDeferred("agents.update", { ok: true });
+        await expect.poll(async () => (await save.textContent())?.trim()).toBe("Save");
+        await expect.poll(() => save.isDisabled()).toBe(true);
+        await expect.poll(() => name.inputValue()).toBe("QA image agent");
+        await expect.poll(() => editor.locator("img").getAttribute("src")).toBe(avatar);
+        await expect
+          .poll(() =>
+            editor.locator("img").evaluate((image: HTMLImageElement) => image.naturalWidth),
+          )
+          .toBeGreaterThan(0);
+        await capture(page, "saved-image");
+        expect(await gateway.getRequests("agents.update")).toHaveLength(1);
+
+        await page.reload();
+        await expect.poll(() => name.inputValue()).toBe("QA image agent");
+        await expect.poll(() => editor.locator("img").getAttribute("src")).toBe(avatar);
+        await expect.poll(() => save.isDisabled()).toBe(true);
+        expect(await gateway.getRequests("agents.update")).toHaveLength(0);
+      },
+    );
+  });
+
+  it("unlocks an interrupted save and preserves the editable draft for retry after reconnect", async () => {
+    await suite.withPage(
+      { locale: "en-US", serviceWorkers: "block", viewport: { width: 1440, height: 1000 } },
+      async ({ page }) => {
+        const { gateway, name, save } = await openIdentity(page);
+        await name.fill("QA retry agent");
+        await gateway.deferNext("agents.update");
+        await save.click();
+        await gateway.waitForRequest("agents.update");
+        await expect.poll(async () => (await save.textContent())?.trim()).toBe("Saving…");
+        await gateway.setOnline(false);
+        await page.getByText("Actions are unavailable while the Gateway reconnects.").waitFor();
+        // Retire the response owned by the closed socket before deferring the retry.
+        await gateway.resolveDeferred("agents.update", { ok: true });
+
+        const connectsBefore = (await gateway.getRequests("connect")).length;
+        await gateway.setOnline(true);
+        await gateway.waitForRequest("connect", { after: connectsBefore });
+        await name.waitFor();
+        await capture(page, "reconnected-save");
+        await expect.poll(async () => (await save.textContent())?.trim()).toBe("Save");
+        await expect.poll(() => name.inputValue()).toBe("QA retry agent");
+        await expect.poll(() => name.isEnabled()).toBe(true);
+        await expect.poll(() => save.isEnabled()).toBe(true);
+        await name.fill("QA retried agent");
+        await gateway.deferNext("agents.update");
+        const updatesBefore = (await gateway.getRequests("agents.update")).length;
+        await save.click();
+        const retry = await gateway.waitForRequest("agents.update", { after: updatesBefore });
+        expect(retry.params).toEqual({ agentId: "main", name: "QA retried agent" });
+        await publishIdentity(gateway, "QA retried agent");
+        await gateway.resolveDeferred("agents.update", { ok: true });
+        await expect.poll(async () => (await save.textContent())?.trim()).toBe("Save");
+        await expect.poll(() => save.isDisabled()).toBe(true);
+        await expect.poll(() => name.inputValue()).toBe("QA retried agent");
+        expect(await gateway.getRequests("agents.update")).toHaveLength(2);
+        await capture(page, "reconnected-retry-saved");
+      },
+    );
+  });
+});

--- a/ui/src/pages/agents/agent-identity-lifecycle.test.ts
+++ b/ui/src/pages/agents/agent-identity-lifecycle.test.ts
@@ -1,0 +1,98 @@
+/* @vitest-environment jsdom */
+
+import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+import type { ApplicationContext, ApplicationGatewaySnapshot } from "../../app/context.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
+import { gatewayHelloForMethods } from "../../test-helpers/gateway-methods.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import * as identityActions from "./identity-actions.ts";
+import "./agents-page.ts";
+
+type TestAgentsPage = HTMLElement &
+  Parameters<typeof identityActions.resetIdentityDraft>[0] & {
+    context: ApplicationContext;
+    readonly connected: boolean;
+    agentsSelectedId: string | null;
+    saveIdentityDraft: () => void;
+    gateway: {
+      applySnapshot: (
+        snapshot: ApplicationGatewaySnapshot,
+        binding: { initial: boolean; sourceChanged: boolean },
+      ) => void;
+    };
+  };
+
+it.each(["saved", "disconnected"] as const)(
+  "retires an identity save across a same-client reconnect: %s",
+  async (outcome) => {
+    const update = createDeferred();
+    const request = vi.fn(async () => {
+      await update.promise;
+      if (outcome === "disconnected") {
+        throw new Error("Connection closed");
+      }
+      return {};
+    });
+    const client = createTestGatewayClient(request);
+    const snapshot: ApplicationGatewaySnapshot = {
+      client,
+      phase: "connected",
+      offlineStable: false,
+      canvasPluginSurfaceUrl: null,
+      hello: gatewayHelloForMethods(["agents.update"]),
+      assistantAgentId: null,
+      sessionKey: "main",
+      lastError: null,
+      lastErrorCode: null,
+    };
+    const page = document.createElement("openclaw-agents-page") as TestAgentsPage;
+    const runExternalMutation: ApplicationContext["runtimeConfig"]["runExternalMutation"] = (
+      task,
+    ) =>
+      task(client).then(
+        (value) => ({ ok: true as const, value, refresh: { ok: true as const } }),
+        (error: unknown) => ({
+          ok: false as const,
+          reason: "unavailable" as const,
+          error: String(error),
+        }),
+      );
+    page.context = {
+      gateway: { snapshot },
+      agents: { refreshList: async () => undefined },
+      agentIdentity: { invalidate: () => undefined, ensure: async () => undefined },
+      runtimeConfig: { runExternalMutation },
+    } as unknown as ApplicationContext;
+    const setConnected = (connected: boolean) =>
+      page.gateway.applySnapshot(
+        { ...snapshot, phase: connected ? "connected" : "stopped" },
+        { initial: false, sourceChanged: false },
+      );
+    setConnected(true);
+    page.agentsSelectedId = "main";
+    page.identityDraft.name = "Agent Smith";
+
+    const save = vi.spyOn(identityActions, "saveIdentityDraft");
+    page.saveIdentityDraft();
+    const pendingSave = save.mock.results[0]?.value;
+    save.mockRestore();
+    await waitForFast(() => expect(request).toHaveBeenCalledOnce());
+    const savingBeforeDisconnect = page.identitySaving;
+    setConnected(false);
+    setConnected(true);
+    const savingAfterReconnect = page.identitySaving;
+    update.resolve();
+    await pendingSave;
+
+    expect(savingBeforeDisconnect).toBe(true);
+    expect(request).toHaveBeenCalledWith("agents.update", {
+      agentId: "main",
+      name: "Agent Smith",
+    });
+    expect(savingAfterReconnect).toBe(false);
+    expect(page.connected).toBe(true);
+    expect(page.identitySaving).toBe(false);
+    expect(page.identityDraft.name).toBe("Agent Smith");
+  },
+);

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -372,6 +372,7 @@ class AgentsPage
     this.agentFilesLoading = false;
     this.agentFileSaving = false;
     this.agentIdentityLoading = false;
+    this.identitySaving = false;
     this.agentSkillsLoading = false;
     this.toolsCatalogLoading = false;
     this.toolsCatalogLoadingAgentId = null;

--- a/ui/src/pages/agents/avatar-image.test.ts
+++ b/ui/src/pages/agents/avatar-image.test.ts
@@ -4,7 +4,39 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { fileToAvatarDataUrl } from "./avatar-image.ts";
 
 describe("fileToAvatarDataUrl", () => {
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it.each(["encoded", "missing context", "failed draw"])(
+    "releases the decoded bitmap when the canvas is %s",
+    async (outcome) => {
+      const close = vi.fn();
+      vi.stubGlobal(
+        "createImageBitmap",
+        vi.fn().mockResolvedValue({ width: 80, height: 80, close }),
+      );
+      const drawImage = vi.fn(() => {
+        if (outcome === "failed draw") {
+          throw new Error("Canvas draw failed");
+        }
+      });
+      vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(
+        outcome === "missing context"
+          ? null
+          : ({ drawImage } as unknown as CanvasRenderingContext2D),
+      );
+      vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue(
+        "data:image/png;base64,AQID",
+      );
+      const file = new File([new Uint8Array([1, 2, 3])], "avatar.png", { type: "image/png" });
+
+      await expect(fileToAvatarDataUrl(file)).resolves.toMatch(/^data:image\/png;base64,/u);
+
+      expect(close).toHaveBeenCalledOnce();
+    },
+  );
 
   it("rejects fallback encodings that would consume the identity bootstrap budget", async () => {
     vi.stubGlobal("createImageBitmap", vi.fn().mockRejectedValue(new Error("unsupported")));

--- a/ui/src/pages/agents/avatar-image.ts
+++ b/ui/src/pages/agents/avatar-image.ts
@@ -29,23 +29,26 @@ export async function fileToAvatarDataUrl(file: File): Promise<string | null> {
   }
   try {
     const bitmap = await createImageBitmap(file);
-    const scale = Math.min(1, AVATAR_TARGET_SIZE / Math.max(bitmap.width, bitmap.height));
-    const width = Math.max(1, Math.round(bitmap.width * scale));
-    const height = Math.max(1, Math.round(bitmap.height * scale));
-    const canvas = document.createElement("canvas");
-    canvas.width = width;
-    canvas.height = height;
-    const context = canvas.getContext("2d");
-    if (!context) {
-      return readFileAsDataUrl(file);
+    try {
+      const scale = Math.min(1, AVATAR_TARGET_SIZE / Math.max(bitmap.width, bitmap.height));
+      const width = Math.max(1, Math.round(bitmap.width * scale));
+      const height = Math.max(1, Math.round(bitmap.height * scale));
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      const context = canvas.getContext("2d");
+      if (!context) {
+        return readFileAsDataUrl(file);
+      }
+      context.drawImage(bitmap, 0, 0, width, height);
+      // toDataURL silently falls back to PNG when WebP is unsupported.
+      const encoded = canvas.toDataURL("image/webp", 0.8);
+      return boundAvatarDataUrl(
+        encoded.startsWith("data:image/webp") ? encoded : canvas.toDataURL("image/png"),
+      );
+    } finally {
+      bitmap.close();
     }
-    context.drawImage(bitmap, 0, 0, width, height);
-    bitmap.close();
-    // toDataURL silently falls back to PNG when WebP is unsupported.
-    const encoded = canvas.toDataURL("image/webp", 0.8);
-    return boundAvatarDataUrl(
-      encoded.startsWith("data:image/webp") ? encoded : canvas.toDataURL("image/png"),
-    );
   } catch {
     // Non-rasterizable images (e.g. SVG without intrinsic size) pass through
     // unscaled; the size gate above still bounds the persisted payload.

--- a/ui/src/pages/agents/identity-actions.test.ts
+++ b/ui/src/pages/agents/identity-actions.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createRuntimeConfigCapability } from "../../lib/config/runtime-config-capability.ts";
@@ -52,20 +53,113 @@ describe("agent identity actions", () => {
   });
 
   it("drops an avatar decode that completes after the selected agent resets", async () => {
-    let resolveAvatar!: (value: string | null) => void;
-    fileToAvatarDataUrlMock.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveAvatar = resolve;
-      }),
-    );
+    const avatar = createDeferred<string | null>();
+    fileToAvatarDataUrlMock.mockReturnValueOnce(avatar.promise);
     const state = host();
 
     selectIdentityAvatar(state, {} as File);
     resetIdentityDraft(state);
-    resolveAvatar("data:image/png;base64,stale");
+    avatar.resolve("data:image/png;base64,stale");
     await Promise.resolve();
 
     expect(state.identityDraft.avatar).toBeNull();
+  });
+
+  it("keeps the latest avatar selection when an older decode settles first", async () => {
+    const first = createDeferred<string | null>();
+    const second = createDeferred<string | null>();
+    fileToAvatarDataUrlMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const state = host();
+
+    selectIdentityAvatar(state, {} as File);
+    selectIdentityAvatar(state, {} as File);
+    first.resolve("data:image/png;base64,old");
+    await first.promise;
+    expect(state.identityDraft.avatar).toBeNull();
+
+    second.resolve("data:image/png;base64,new");
+    await second.promise;
+    expect(state.identityDraft.avatar).toBe("data:image/png;base64,new");
+  });
+
+  it.each([
+    { outcome: "decoded", avatar: "data:image/png;base64,new" },
+    { outcome: "unusable", avatar: null },
+    { outcome: "agent reset", avatar: "data:image/png;base64,stale" },
+  ])("waits for the picked avatar before saving: $outcome", async ({ outcome, avatar }) => {
+    const conversion = createDeferred<string | null>();
+    const update = createDeferred<object>();
+    fileToAvatarDataUrlMock.mockReturnValueOnce(conversion.promise);
+    const request = vi.fn(async (method: string) => {
+      if (method === "agents.update") {
+        return update.promise;
+      }
+      if (method === "config.get") {
+        return { config: {}, raw: "{}", hash: "saved", valid: true, issues: [] };
+      }
+      throw new Error(`Unexpected method ${method}`);
+    });
+    const client = { request } as unknown as GatewayBrowserClient;
+    const runtimeConfig = createRuntimeConfigCapability({
+      snapshot: {
+        client,
+        phase: "connected",
+        sessionKey: "main",
+        hello: gatewayHelloForMethods(["config.set"]),
+      },
+      subscribe: () => () => undefined,
+    });
+    const state = host();
+    state.identityDraft.name = "Agent Smith";
+    let current = true;
+    selectIdentityAvatar(state, {} as File);
+    const saving = saveIdentityDraft({
+      host: state,
+      expectedClient: client,
+      agentId: "main",
+      agents: {
+        refreshList: vi.fn(async () => undefined),
+      } as unknown as ApplicationContext["agents"],
+      agentIdentity: {
+        invalidate: vi.fn(),
+        ensure: vi.fn(async () => undefined),
+      } as unknown as ApplicationContext["agentIdentity"],
+      runtimeConfig,
+      canDispatch: () => true,
+      isCurrent: () => current,
+      onSaved: vi.fn(),
+    });
+    const savingDuringDecode = state.identitySaving;
+    const requestsDuringDecode = request.mock.calls.length;
+    if (outcome === "agent reset") {
+      current = false;
+      resetIdentityDraft(state);
+    }
+    conversion.resolve(avatar);
+    await conversion.promise;
+    update.resolve({});
+    await saving;
+    runtimeConfig.dispose();
+
+    expect(savingDuringDecode).toBe(true);
+    expect(requestsDuringDecode).toBe(0);
+    expect(state.identitySaving).toBe(false);
+    if (outcome === "decoded") {
+      expect(request).toHaveBeenCalledWith("agents.update", {
+        agentId: "main",
+        name: "Agent Smith",
+        avatar,
+      });
+      expect(state.identityDraft).toEqual({ name: null, emoji: null, avatar: null });
+      expect(state.identityError).toBeNull();
+    } else {
+      expect(request).not.toHaveBeenCalled();
+      expect(state.identityDraft.name).toBe(outcome === "agent reset" ? null : "Agent Smith");
+      expect(state.identityDraft.avatar).toBeNull();
+      if (outcome === "unusable") {
+        expect(state.identityError).toBeTruthy();
+      }
+    }
   });
 
   it("flushes a pending config draft before agents.update and refreshes afterward", async () => {

--- a/ui/src/pages/agents/identity-actions.ts
+++ b/ui/src/pages/agents/identity-actions.ts
@@ -13,16 +13,10 @@ type AgentIdentityEditorHost = {
   identityError: string | null;
 };
 
-const avatarSelectionEpochs = new WeakMap<AgentIdentityEditorHost, number>();
-
-function advanceAvatarSelectionEpoch(host: AgentIdentityEditorHost): number {
-  const epoch = (avatarSelectionEpochs.get(host) ?? 0) + 1;
-  avatarSelectionEpochs.set(host, epoch);
-  return epoch;
-}
+const avatarSelections = new WeakMap<AgentIdentityEditorHost, Promise<string | null>>();
 
 export function resetIdentityDraft(host: AgentIdentityEditorHost) {
-  advanceAvatarSelectionEpoch(host);
+  avatarSelections.delete(host);
   host.identityDraft = { name: null, emoji: null, avatar: null };
   host.identitySaving = false;
   host.identityError = null;
@@ -38,18 +32,20 @@ export function setIdentityDraftField(
 }
 
 export function selectIdentityAvatar(host: AgentIdentityEditorHost, file: File) {
-  const epoch = advanceAvatarSelectionEpoch(host);
-  void fileToAvatarDataUrl(file).then((dataUrl) => {
-    if (avatarSelectionEpochs.get(host) !== epoch) {
-      return;
+  const selection = fileToAvatarDataUrl(file).then((dataUrl) => {
+    if (avatarSelections.get(host) !== selection) {
+      return null;
     }
+    avatarSelections.delete(host);
     if (dataUrl) {
       host.identityDraft = { ...host.identityDraft, avatar: dataUrl };
       host.identityError = null;
     } else {
       host.identityError = t("agents.identity.imageUnusable");
     }
+    return dataUrl;
   });
+  avatarSelections.set(host, selection);
 }
 
 /** Persist the draft via agents.update, then refresh the roster and the
@@ -66,22 +62,31 @@ export async function saveIdentityDraft(params: {
   onSaved: () => void;
 }) {
   const { host, expectedClient, agentId, agents, agentIdentity, runtimeConfig } = params;
-  const draft = host.identityDraft;
-  // Set/replace only: agents.update has no explicit clear operation. Keep a
-  // blank edit visible and unsaved instead of pretending it removed a field.
-  const name = draft.name?.trim();
-  const emoji = draft.emoji?.trim();
-  const avatar = draft.avatar ?? undefined;
-  if ((draft.name !== null && !name) || (draft.emoji !== null && !emoji)) {
-    return;
-  }
-  if (!name && !emoji && !avatar) {
-    resetIdentityDraft(host);
-    return;
-  }
   host.identitySaving = true;
   host.identityError = null;
   try {
+    // A picked image is part of this save even before decoding publishes its
+    // draft. Failed or retired conversions must not become partial saves.
+    const selection = avatarSelections.get(host);
+    if (selection && !(await selection)) {
+      return;
+    }
+    if (!params.isCurrent()) {
+      return;
+    }
+    const draft = host.identityDraft;
+    // Set/replace only: agents.update has no explicit clear operation. Keep a
+    // blank edit visible and unsaved instead of pretending it removed a field.
+    const name = draft.name?.trim();
+    const emoji = draft.emoji?.trim();
+    const avatar = draft.avatar ?? undefined;
+    if ((draft.name !== null && !name) || (draft.emoji !== null && !emoji)) {
+      return;
+    }
+    if (!name && !emoji && !avatar) {
+      resetIdentityDraft(host);
+      return;
+    }
     const mutation = await runtimeConfig.runExternalMutation(
       (client) => {
         if (client !== expectedClient) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users editing an agent's name and choosing an avatar could silently save only the name when they clicked Save before image decoding finished. Also fixes an identity editor that remained stuck on Saving after its Gateway connection dropped and reconnected during a save.

## Why This Change Was Made

The identity editor owned image conversion and saving independently. Save could snapshot the draft before its selected image existed, then reset the draft and retire that conversion. The pending conversion is now the selection's canonical owner: Save claims its busy state, waits for that exact selection, and checks the current operation before taking the draft snapshot. Failed or retired conversions cannot become partial saves.

The page's connection invalidation now releases the old save's busy state while retaining editable drafts. Existing generation checks still fence stale completions, and agent/client replacement still retires pending selections. Bitmap disposal is also paired with the successful decode in `finally`, including missing-canvas and drawing-error fallback paths.

Best-fix judgment: keep the existing config write coordinator and page connection owner; a new view-level busy flag or downstream retry would duplicate ownership. The numeric selection epoch is removed in favor of the actual pending operation. Production delta is **+50/-41 (net +9)**; tests are **+441/-8**, plus one changelog line. The growth represents pending-operation and resource ownership, with no new config, API, protocol, schema, dependency, or identity-clearing semantics.

The editor was introduced in #106058 (`9086389527b17e7e1ea5a2583f4a76948a4887c4`); its save-state reset was not added to the already-existing connection invalidator. This PR does not implement the independent null-clearing contract in #119930 or the hovercard refresh in #126392.

## User Impact

Saving a selected avatar together with other identity edits waits for conversion and sends them together. If conversion fails, the draft and visible error remain. After reconnect, the interrupted draft can be edited and retried. Existing set/replace-only behavior is unchanged.

## Evidence

Baseline: `6c10672d95072cc1a4b645c519a4513621cd940a`.

- Before the production patch: seven owner regression failures and two mocked Chromium failures, for premature update dispatch, stuck Saving after reconnect, and missing bitmap disposal. All are green after the repair.
- Final focused owner and sibling proof: **157 tests passed across 11 files**, including agent file lifecycle, profile avatar processing, and the config write coordinator. The reconnect cases live in a focused lifecycle file; they were reverified failing with the old invalidator before restoring the fix. No max-lines suppression was added.
- Chromium: **2/2 passed**, using a real PNG and native image decoding with controlled timing. Assertions cover the update payload, visible decoded image, reload, reconnect, draft editing, and successful retry. Transport and server state are mocked; these are not real-profile or real-Gateway results.
- Final full UI unit run: **10,821 passed, 67 skipped** across 756 files. An earlier candidate run had **10,819 passed, 2 failed, 67 skipped**; untouched main reproduced those exact two route/resource-base failures (**10,810 passed, 2 failed, 67 skipped**). Both minimal producer-before-consumer runs reproduce the failure, while the browser test alone passes. The serialized mock-Gateway fixture leaves an empty resource-base global in the shared test window. This remains a separate order-sensitive test-lifecycle follow-up; the passing final order does not mean this PR repaired it.
- Fresh structured Codex review: no P0 findings. Independent hands-on production review: no actionable findings.
- Complete changed-file gate: **passed**, including core-test and UI typechecks, type-aware lint, UI styles, i18n, formatting, and repository guards. The initial max-lines failure was fixed by moving the reconnect cases to their focused lifecycle file, not by adding a suppression.
- Hosted product CI is **skipped while this PR is a draft**; the local results above are not an exact-head hosted-CI claim. Re-run the normal PR checks when the live-proof blocker is resolved and the PR is ready for review.

**Draft / live-proof blocker:** real-profile Chrome verification remains outstanding. The configured extension relay is unavailable, the documented direct attachment fallback returns HTTP 403, and no usable Chrome approval window is available. No browser access policy was changed and no operator Gateway was modified. Do not treat the deterministic Chromium evidence as live-profile proof or this PR as merge-ready.

Before: Save dispatches before the selected image finishes decoding.

![Before: Saving while the selected image is still pending](https://github.com/user-attachments/assets/23c817df-19a1-43ec-ae0b-26503be7dabc)

After: the image and name are saved together and the decoded avatar is visible.

![After: saved image and display name](https://github.com/user-attachments/assets/79921a38-9810-4980-9af6-c871b43f8e84)

Before: reconnect leaves the interrupted editor stuck on Saving.

![Before: Saving remains stuck after reconnect](https://github.com/user-attachments/assets/c0204b68-bc05-42cb-b439-b8bcc3cd207a)

After: reconnect retains the draft and enables editing and Save again.

![After: editable draft and enabled Save after reconnect](https://github.com/user-attachments/assets/d65ecf82-95c6-406c-9956-4f13c2f23456)

All captures use synthetic QA data. The emoji input's right border is clipped in both before and after captures; named follow-up: migrate the constrained identity fields to canonical Settings input sizing after rendered-geometry proof. This PR does not claim to fix that existing layout defect.
