### PR TITLE
fix(models): keep OpenCode fallback aligned with catalog lifecycle

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -945,7 +945,7 @@ extensions/openai/video-generation-provider.ts	3
 extensions/opencode-go/provider-policy-api.ts	1
 extensions/opencode-go/reasoning-sanitizer.ts	2
 extensions/opencode-go/stream-termination.ts	9
-extensions/opencode/provider-catalog.ts	3
+extensions/opencode/provider-catalog.ts	2
 extensions/opencode/provider-policy-api.ts	1
 extensions/opencode/session-catalog-plugin.ts	1
 extensions/opencode/stream.ts	3
@@ -3464,7 +3464,7 @@ src/plugin-sdk/provider-auth-login-flow-runtime.ts	6
 src/plugin-sdk/provider-auth-result.ts	4
 src/plugin-sdk/provider-auth-runtime.ts	1
 src/plugin-sdk/provider-auth.ts	1
-src/plugin-sdk/provider-catalog-live-runtime.ts	3
+src/plugin-sdk/provider-catalog-live-runtime.ts	2
 src/plugin-sdk/provider-catalog-shared.ts	4
 src/plugin-sdk/provider-enable-config.ts	2
 src/plugin-sdk/provider-entry.ts	3

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -369,6 +369,20 @@ catalog, API-key auth, and dynamic model resolution.
     upstream response is not an OpenAI-compatible `{ data: [{ id, object }] }`
     shape.
 
+    For a separate authoritative metadata feed, the same
+    `provider-catalog-live-runtime` subpath exposes `ProviderCatalogSnapshot`:
+    each entry pairs a runtime model with its lifecycle status.
+    `projectUpstreamProviderCatalogSnapshot` rebuilds that snapshot from a
+    trusted seed and accepted upstream rows, dropping withdrawn upstream-only
+    models. `projectProviderCatalogSnapshotRows` intersects advertised IDs with
+    active snapshot entries, deduplicating in endpoint order;
+    `listProviderCatalogSnapshotEntries` projects the same lifecycle facts for
+    catalog consumers. Keep seed lifecycle policy and model-specific decoration
+    in the owning plugin. Derive static fallback eligibility after refreshing
+    metadata so the first failed or fully filtered discovery uses current status.
+    Public metadata never establishes account entitlement or expands the
+    credential scope of discovery.
+
     When `ctx.providerIds` is present, it contains the normalized provider
     identities selected for that catalog owner. Return `null` before resolving
     credentials or making network requests when the hook serves none of them;

--- a/docs/providers/opencode-go.md
+++ b/docs/providers/opencode-go.md
@@ -74,48 +74,28 @@ interactive onboarding or pass the shared OpenCode API key directly.
 ## Catalog
 
 Run `openclaw models list --provider opencode-go` for the current model list.
-OpenClaw combines the models available to your Go account with authoritative
-metadata from `https://models.opencode.ai/api.json`, so new upstream models
-appear without an OpenClaw update. The upstream catalog is downloaded and
+OpenClaw combines Go's advertised model IDs with authoritative metadata from
+`https://models.opencode.ai/api.json`, so new upstream models appear without an
+OpenClaw update when they use a supported transport on the trusted OpenCode
+endpoint. The upstream catalog is downloaded and
 cached only when OpenCode Zen or Go is configured or explicitly selected with
 OpenCode credentials; it is never fetched at startup or while using unrelated
 providers.
 
-Current active rows:
+Example refs include `opencode-go/deepseek-v4-flash`, `opencode-go/kimi-k3`, and
+`opencode-go/qwen3.8-max`. Use the CLI for the current lineup rather than treating
+these examples as an inventory. OpenClaw excludes deprecated rows from active
+discovery and applies refreshed lifecycle status to its offline fallback.
+Bundled preview rows stay hidden until accepted upstream metadata supplies them.
+Existing explicit refs in the bundled seed remain resolvable.
 
-| Model ref                       | Context   | Max output | Inputs      | Transport |
-| ------------------------------- | --------- | ---------- | ----------- | --------- |
-| `opencode-go/deepseek-v4-flash` | 1M        | 384K       | Text        | Chat      |
-| `opencode-go/deepseek-v4-pro`   | 1M        | 384K       | Text        | Chat      |
-| `opencode-go/glm-5.1`           | 202,752   | 32,768     | Text        | Chat      |
-| `opencode-go/glm-5.2`           | 1M        | 131,072    | Text        | Chat      |
-| `opencode-go/gpt-5.6-luna`      | 1.05M     | 128,000    | Text, image | Responses |
-| `opencode-go/grok-4.5`          | 500,000   | 500,000    | Text, image | Chat      |
-| `opencode-go/hy3`               | 256,000   | 64,000     | Text        | Chat      |
-| `opencode-go/kimi-k2.6`         | 262,144   | 65,536     | Text, image | Chat      |
-| `opencode-go/kimi-k2.7-code`    | 262,144   | 262,144    | Text, image | Chat      |
-| `opencode-go/kimi-k3`           | 1,048,576 | 131,072    | Text, image | Chat      |
-| `opencode-go/mimo-v2.5`         | 1M        | 128,000    | Text, image | Chat      |
-| `opencode-go/mimo-v2.5-pro`     | 1,048,576 | 128,000    | Text        | Chat      |
-| `opencode-go/minimax-m2.7`      | 204,800   | 131,072    | Text        | Messages  |
-| `opencode-go/minimax-m3`        | 1M        | 131,072    | Text, image | Messages  |
-| `opencode-go/ox-alpha-free`     | 1M        | 131,072    | Text, image | Chat      |
-| `opencode-go/qwen3.6-plus`      | 1M        | 65,536     | Text, image | Messages  |
-| `opencode-go/qwen3.7-max`       | 1M        | 65,536     | Text        | Messages  |
-| `opencode-go/qwen3.7-plus`      | 1M        | 65,536     | Text, image | Messages  |
-| `opencode-go/qwen3.8-max`       | 1M        | 131,072    | Text, image | Messages  |
-
-Current upstream preview models appear while available. Deprecated refs remain
-resolvable only for existing explicit configurations and are not recommended.
-
-Ox Alpha Free is free for a limited time, but accessing the Go catalog still
-requires a paid OpenCode Go subscription.
+The Go model-list endpoint is a general inventory, not an account-entitlement
+check. A successful listing does not grant access: inference still requires an
+active Go subscription, including for promotional models.
 
 ## Privacy
 
-OpenCode lists zero data retention and no model training for Ox Alpha Free.
-Privacy policies vary by model: some routes retain data for up to 30 days, and
-the Muse Spark 1.2 Contributor route permits model training. Review the current
+Retention and training policies vary by model. Review the current
 [OpenCode Go privacy table](https://opencode.ai/docs/go/#privacy) before using a
 model, because provider policy can change independently of OpenClaw.
 

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -99,40 +99,36 @@ provider ids split so upstream per-model routing stays correct.
 
 ### Zen
 
-| Property         | Value                                                                                                                                              |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Runtime provider | `opencode`                                                                                                                                         |
-| Example models   | `opencode/gpt-5.6-sol`, `opencode/kimi-k3`, `opencode/gemini-3.6-flash`, `opencode/minimax-m3`, `opencode/big-pickle`, `opencode/x-preview-f-free` |
+| Property         | Value                                                                    |
+| ---------------- | ------------------------------------------------------------------------ |
+| Runtime provider | `opencode`                                                               |
+| Example models   | `opencode/gpt-5.6-sol`, `opencode/kimi-k3`, `opencode/deepseek-v4-flash` |
 
-Run `openclaw models list --provider opencode` for the current active list,
-which also includes the promoted free-tier rows `opencode/big-pickle`,
-`opencode/deepseek-v4-flash-free`, `opencode/laguna-s-2.1-free`,
-`opencode/ling-3.0-tiny-free`, `opencode/longcat-2.0-free`,
-`opencode/mimo-v2.5-free`,
-`opencode/nemotron-3-ultra-free`, `opencode/north-mini-code-free`, and
-`opencode/x-preview-f-free` (Ox Alpha Free).
+Run `openclaw models list --provider opencode` for the current active list.
+Model availability and promotional routes can change independently of OpenClaw.
 
 Live discovery combines the models available to your OpenCode account with
 authoritative model metadata from `https://models.opencode.ai/api.json`.
 OpenClaw fetches and caches that catalog only when OpenCode Zen or Go is
 configured or explicitly selected with OpenCode credentials; startup and
 unrelated providers never download it. New upstream models become available
-without an OpenClaw update. A key-scoped response can omit models unavailable
-to that workspace. Deprecated explicit refs remain resolvable for existing
-configurations but are not shown as current recommendations.
-
-Ox Alpha Free is available for a limited time. OpenCode says this model has
-zero data retention and is not used for model training; see the current
-[OpenCode Zen pricing and policy](https://opencode.ai/docs/zen/).
+without an OpenClaw update when their metadata describes a supported transport
+on the trusted OpenCode endpoint. A key-scoped response can omit models
+unavailable to that workspace. Metadata and lifecycle status refresh together;
+deprecated models are excluded from active discovery and its offline fallback.
+Deprecated explicit refs remain resolvable for existing configurations but are
+not shown as current recommendations.
 
 ### Go
 
-| Property         | Value                                                                                                     |
-| ---------------- | --------------------------------------------------------------------------------------------------------- |
-| Runtime provider | `opencode-go`                                                                                             |
-| Example models   | `opencode-go/kimi-k3`, `opencode-go/gpt-5.6-luna`, `opencode-go/qwen3.8-max`, `opencode-go/ox-alpha-free` |
+| Property         | Value                                                                             |
+| ---------------- | --------------------------------------------------------------------------------- |
+| Runtime provider | `opencode-go`                                                                     |
+| Example models   | `opencode-go/kimi-k3`, `opencode-go/deepseek-v4-flash`, `opencode-go/qwen3.8-max` |
 
-See [OpenCode Go](/providers/opencode-go) for the full Go model table.
+See [OpenCode Go](/providers/opencode-go) for discovery, routing, and access
+requirements. Go's model-list endpoint advertises its general lineup; listing
+a model does not prove your account can run it.
 
 ## Advanced configuration
 
@@ -173,7 +169,7 @@ See [OpenCode Go](/providers/opencode-go) for the full Go model table.
 
 <CardGroup cols={2}>
   <Card title="OpenCode Go" href="/providers/opencode-go" icon="server">
-    Full Go catalog reference.
+    Go catalog discovery and access requirements.
   </Card>
   <Card title="Model selection" href="/concepts/model-providers" icon="layers">
     Choosing providers, model refs, and failover behavior.

--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -58,7 +58,7 @@ function upstreamModel(id: string, overrides: Record<string, unknown> = {}) {
 
 function createCatalogFetchGuard(params: {
   upstreamModels: Record<string, unknown>;
-  liveModelIds: string[];
+  liveModelIds: string[] | (() => string[]);
 }) {
   return vi.fn(async ({ url }: { url: string }) => ({
     response: new Response(
@@ -72,7 +72,12 @@ function createCatalogFetchGuard(params: {
                 models: params.upstreamModels,
               },
             }
-          : { data: params.liveModelIds.map((id) => ({ id, object: "model" })) },
+          : {
+              data: (typeof params.liveModelIds === "function"
+                ? params.liveModelIds()
+                : params.liveModelIds
+              ).map((id) => ({ id, object: "model" })),
+            },
       ),
     ),
     finalUrl: url,
@@ -532,6 +537,59 @@ describe("opencode-go provider plugin", () => {
       ACTIVE_MODEL_IDS.toSorted(),
     );
   });
+
+  it.each([
+    ["retired seed", "failed"],
+    ["retired seed", "filtered"],
+    ["activated preview", "failed"],
+  ] as const)(
+    "uses refreshed %s lifecycle on the first fallback after %s model advertising",
+    async (lifecycle, advertising) => {
+      const retired = lifecycle === "retired seed";
+      const modelId = retired ? "deepseek-v4-pro" : "hy3-preview";
+      const provider = await registerSingleProviderPlugin(plugin);
+      const fetchGuard = createCatalogFetchGuard({
+        upstreamModels: {
+          [modelId]: upstreamModel(modelId, retired ? { status: "deprecated" } : {}),
+        },
+        liveModelIds: () => {
+          if (advertising === "failed") {
+            throw new Error("model advertising unavailable");
+          }
+          return [modelId];
+        },
+      });
+
+      try {
+        expect(buildStaticOpencodeGoProviderConfig().models.map((model) => model.id)).toEqual(
+          ACTIVE_MODEL_IDS,
+        );
+        const fallback = await buildOpencodeGoLiveProviderConfig({
+          apiKey: "runtime-key",
+          discoveryApiKey: "discovery-key",
+          fetchGuard,
+        });
+
+        expect(fallback.apiKey).toBe("runtime-key");
+        expect(fallback.models.map((model) => model.id).toSorted()).toEqual(
+          (retired
+            ? ACTIVE_MODEL_IDS.filter((id) => id !== modelId)
+            : [...ACTIVE_MODEL_IDS, modelId]
+          ).toSorted(),
+        );
+        expect(provider.resolveDynamicModel?.({ modelId } as never)).toMatchObject({
+          id: modelId,
+        });
+      } finally {
+        clearLiveCatalogCacheForTests();
+        await buildOpencodeGoLiveProviderConfig({
+          discoveryApiKey: "discovery-key",
+          fetchGuard: createCatalogFetchGuard({ upstreamModels: {}, liveModelIds: [] }),
+        });
+        clearLiveCatalogCacheForTests();
+      }
+    },
+  );
 
   it("does not synthesize a stream when the runtime provides none", async () => {
     const provider = await registerSingleProviderPlugin(plugin);

--- a/extensions/opencode-go/opencode-go.live.test.ts
+++ b/extensions/opencode-go/opencode-go.live.test.ts
@@ -1,8 +1,8 @@
-import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
+import { completeSimple, type Model } from "openclaw/plugin-sdk/llm";
+import { extractNonEmptyAssistantText, isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
 import { describe, expect, it } from "vitest";
 import {
   buildOpencodeGoLiveProviderConfig,
-  buildStaticOpencodeGoProviderConfig,
   listOpencodeGoModelCatalogEntries,
 } from "./provider-catalog.js";
 
@@ -15,7 +15,7 @@ const describeLive = LIVE ? describe : describe.skip;
 type ModelsResponse = { data?: Array<{ id?: unknown; object?: unknown }> };
 
 describeLive("OpenCode Go live dynamic catalog", () => {
-  it("loads authorized current models from upstream metadata without expanding its offline seed", async () => {
+  it("discovers the active advertised models with trusted upstream metadata", async () => {
     const response = await fetch(OPENCODE_GO_MODELS_URL, {
       headers: {
         accept: "application/json",
@@ -31,31 +31,45 @@ describeLive("OpenCode Go live dynamic catalog", () => {
       .filter((id): id is string => typeof id === "string" && id.trim().length > 0)
       .map((id) => id.trim().toLowerCase())
       .toSorted();
-    const offlineIds = new Set(
-      buildStaticOpencodeGoProviderConfig().models.map((model) => model.id),
-    );
     const live = await buildOpencodeGoLiveProviderConfig({
       apiKey: OPENCODE_API_KEY,
       discoveryApiKey: OPENCODE_API_KEY,
     });
-    const discoveredIds = live.models.map((model) => model.id);
-    const advertisedIds = new Set(liveIds);
+    const discoveredIds = live.models.map((model) => model.id).toSorted();
     const trustedRows = listOpencodeGoModelCatalogEntries();
+    const activeIds = new Set(
+      trustedRows.filter((row) => !row.status).map((row) => row.id.toLowerCase()),
+    );
 
     expect(discoveredIds.length).toBeGreaterThan(0);
-    expect(discoveredIds.every((id) => advertisedIds.has(id))).toBe(true);
     expect(new Set(discoveredIds).size).toBe(discoveredIds.length);
-    expect(discoveredIds.some((id) => !offlineIds.has(id))).toBe(true);
-    expect(discoveredIds).not.toContain("hy3-preview");
-    expect(trustedRows.find((row) => row.id === "hy3-preview")?.status).toBe("preview");
-    if (advertisedIds.has("ox-alpha-free")) {
-      expect(live.models.find((model) => model.id === "ox-alpha-free")).toMatchObject({
-        api: "openai-completions",
-        baseUrl: "https://opencode.ai/zen/go/v1",
-        contextWindow: 1_000_000,
-        maxTokens: 131_072,
-        input: ["text", "image"],
-      });
-    }
+    expect(discoveredIds).toEqual([...new Set(liveIds)].filter((id) => activeIds.has(id)));
   }, 30_000);
+
+  it("runs a discovered Go model with the account credential", async () => {
+    const provider = await buildOpencodeGoLiveProviderConfig({ apiKey: OPENCODE_API_KEY });
+    const row = provider.models.find((model) => model.id === "gpt-5.6-luna");
+    if (!row || row.api !== "openai-responses" || !row.contextWindow) {
+      throw new Error("OpenCode Go catalog lacks the GPT 5.6 Luna Responses route");
+    }
+    const input = row.input.filter((kind) => kind === "text" || kind === "image");
+    expect(input).toEqual(row.input);
+    const model: Model<"openai-responses"> = {
+      ...row,
+      api: row.api,
+      contextWindow: row.contextWindow,
+      provider: "opencode-go",
+      baseUrl: row.baseUrl ?? provider.baseUrl,
+      input,
+    };
+    const result = await completeSimple(
+      model,
+      { messages: [{ role: "user", content: "Reply with exactly: ok", timestamp: Date.now() }] },
+      { apiKey: OPENCODE_API_KEY, maxTokens: 128 },
+    );
+    if (result.stopReason === "error") {
+      throw new Error(result.errorMessage || "OpenCode Go inference returned an error");
+    }
+    expect(extractNonEmptyAssistantText(result.content)).toMatch(/^ok[.!]?$/i);
+  }, 120_000);
 });

--- a/extensions/opencode-go/provider-catalog.ts
+++ b/extensions/opencode-go/provider-catalog.ts
@@ -1,19 +1,19 @@
-// Opencode Go provider module implements model/runtime integration.
 import type { ModelCatalogEntry } from "openclaw/plugin-sdk/agent-runtime";
 import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import {
   buildLiveModelProviderConfig,
   fetchLiveProviderModelIds,
   getCachedUpstreamProviderCatalog,
-  projectUpstreamProviderCatalogModel,
+  listProviderCatalogSnapshotEntries,
+  projectProviderCatalogSnapshotRows,
+  projectUpstreamProviderCatalogSnapshot,
   type LiveModelCatalogFetchGuard,
+  type ProviderCatalogSnapshot,
+  type ProjectedUpstreamProviderCatalogModel as OpencodeGoModelDefinition,
   type UpstreamProviderCatalog,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-model-shared";
-import type {
-  ModelDefinitionConfig,
-  ModelProviderConfig,
-} from "openclaw/plugin-sdk/provider-model-shared";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const PROVIDER_ID = "opencode-go";
@@ -29,82 +29,50 @@ const OPENCODE_GO_MODELS_ENDPOINT = "https://opencode.ai/zen/go/v1/models";
 const OPENCODE_UPSTREAM_CATALOG_ENDPOINT = "https://models.opencode.ai/api.json";
 const OPENCODE_GO_MODELS_TIMEOUT_MS = 5_000;
 const OPENCODE_GO_MODELS_CACHE_TTL_MS = 60_000;
-type OpencodeGoModelDefinition = ModelDefinitionConfig & {
-  provider: typeof PROVIDER_ID;
-  api: NonNullable<ModelDefinitionConfig["api"]>;
-  baseUrl: string;
-  input: Array<"text" | "image">;
-};
-
 const OPENCODE_GO_MANIFEST_PROVIDER = manifest.modelCatalog.providers[PROVIDER_ID];
-const OPENCODE_GO_SEED_MODELS = OPENCODE_GO_MANIFEST_PROVIDER.models.map((model) => {
-  const inheritedTransport = {
-    ...model,
-    provider: PROVIDER_ID,
-    api: "api" in model ? model.api : OPENCODE_GO_MANIFEST_PROVIDER.api,
-    baseUrl: "baseUrl" in model ? model.baseUrl : OPENCODE_GO_MANIFEST_PROVIDER.baseUrl,
-  };
-  // SAFETY: Bundled manifest rows supply model metadata, and inherited provider transport is filled above.
-  const hydrated = inheritedTransport as OpencodeGoModelDefinition;
-  // SAFETY: Compatibility normalization preserves the hydrated model's provider, transport, and input shape.
-  return normalizeModelCompat(hydrated) as OpencodeGoModelDefinition;
-});
-const OPENCODE_GO_SEED_MODEL_BY_ID = new Map(
-  OPENCODE_GO_SEED_MODELS.map((model) => [model.id.toLowerCase(), model]),
+const OPENCODE_GO_SEED_CATALOG: ProviderCatalogSnapshot = new Map(
+  OPENCODE_GO_MANIFEST_PROVIDER.models.map((row) => {
+    const inheritedTransport = {
+      ...row,
+      provider: PROVIDER_ID,
+      api: "api" in row ? row.api : OPENCODE_GO_MANIFEST_PROVIDER.api,
+      baseUrl: "baseUrl" in row ? row.baseUrl : OPENCODE_GO_MANIFEST_PROVIDER.baseUrl,
+    };
+    // SAFETY: Bundled rows and inherited transport supply the complete runtime model shape.
+    const hydrated = inheritedTransport as OpencodeGoModelDefinition;
+    // SAFETY: Normalization preserves the hydrated model's transport and input shape.
+    const model = normalizeModelCompat(hydrated) as OpencodeGoModelDefinition;
+    return [
+      model.id.toLowerCase(),
+      {
+        model,
+        ...("status" in row && (row.status === "deprecated" || row.status === "preview")
+          ? { status: row.status }
+          : {}),
+      },
+    ];
+  }),
 );
-const OPENCODE_GO_MODEL_BY_ID = new Map(OPENCODE_GO_SEED_MODEL_BY_ID);
-const OPENCODE_GO_SEED_MODEL_STATUS = new Map<string, "deprecated" | "preview">(
-  manifest.modelCatalog.providers[PROVIDER_ID].models.flatMap((model) =>
-    "status" in model && (model.status === "deprecated" || model.status === "preview")
-      ? [[model.id, model.status] as const]
-      : [],
-  ),
-);
-const OPENCODE_GO_MODEL_STATUS = new Map(OPENCODE_GO_SEED_MODEL_STATUS);
+let opencodeGoCatalog = OPENCODE_GO_SEED_CATALOG;
 
 function listStaticOpencodeGoModels(): OpencodeGoModelDefinition[] {
-  return OPENCODE_GO_SEED_MODELS.filter((model) => !OPENCODE_GO_MODEL_STATUS.has(model.id));
+  return [...OPENCODE_GO_SEED_CATALOG.values()]
+    .filter(({ model }) => !opencodeGoCatalog.get(model.id)?.status)
+    .map(({ model }) => model);
 }
 
 function cacheUpstreamOpencodeGoModels(catalog: UpstreamProviderCatalog): void {
-  const currentModels = new Map(
-    OPENCODE_GO_SEED_MODELS.map((model) => [model.id.toLowerCase(), model]),
-  );
-  const currentStatuses = new Map(OPENCODE_GO_SEED_MODEL_STATUS);
-  for (const upstreamModel of Object.values(catalog.models)) {
-    const projected = projectUpstreamProviderCatalogModel({
-      providerId: PROVIDER_ID,
-      provider: catalog,
-      model: upstreamModel,
-      anthropicBaseUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
-      defaultBaseUrl: OPENCODE_GO_OPENAI_BASE_URL,
-    });
-    if (!projected) {
-      continue;
-    }
-    const normalized = normalizeModelCompat({
-      ...projected,
-      ...(projected.api === "anthropic-messages" && projected.id.startsWith("qwen")
-        ? { compat: { ...projected.compat, thinkingFormat: "qwen" as const } }
-        : {}),
-    });
-    // SAFETY: The shared projector validates transport and limits; normalization preserves those model fields.
-    const model = normalized as OpencodeGoModelDefinition;
-    currentModels.set(model.id.toLowerCase(), model);
-    if (upstreamModel.status === "deprecated") {
-      currentStatuses.set(model.id, "deprecated");
-    } else {
-      currentStatuses.delete(model.id);
-    }
-  }
-  OPENCODE_GO_MODEL_BY_ID.clear();
-  for (const [id, model] of currentModels) {
-    OPENCODE_GO_MODEL_BY_ID.set(id, model);
-  }
-  OPENCODE_GO_MODEL_STATUS.clear();
-  for (const [id, status] of currentStatuses) {
-    OPENCODE_GO_MODEL_STATUS.set(id, status);
-  }
+  opencodeGoCatalog = projectUpstreamProviderCatalogSnapshot({
+    providerId: PROVIDER_ID,
+    provider: catalog,
+    seed: OPENCODE_GO_SEED_CATALOG,
+    anthropicBaseUrl: OPENCODE_GO_ANTHROPIC_BASE_URL,
+    defaultBaseUrl: OPENCODE_GO_OPENAI_BASE_URL,
+    decorateModel: (model) =>
+      model.api === "anthropic-messages" && model.id.startsWith("qwen")
+        ? { ...model, compat: { ...model.compat, thinkingFormat: "qwen" } }
+        : model,
+  });
 }
 
 type FetchOpencodeGoLiveModelIdsParams = {
@@ -145,7 +113,6 @@ export async function resolveOpencodeGoStarterModel(params: {
 export async function buildOpencodeGoLiveProviderConfig(
   params: FetchOpencodeGoLiveModelIdsParams = {},
 ): Promise<ModelProviderConfig> {
-  const fallbackModels = listStaticOpencodeGoModels();
   if (!params.apiKey && !params.discoveryApiKey) {
     return buildStaticOpencodeGoProviderConfig();
   }
@@ -169,7 +136,7 @@ export async function buildOpencodeGoLiveProviderConfig(
       api: "openai-completions",
       baseUrl: OPENCODE_GO_OPENAI_BASE_URL,
     },
-    models: fallbackModels,
+    models: listStaticOpencodeGoModels(),
     apiKey: params.apiKey,
     discoveryApiKey: params.discoveryApiKey,
     fetchGuard: params.fetchGuard,
@@ -177,58 +144,17 @@ export async function buildOpencodeGoLiveProviderConfig(
     timeoutMs: OPENCODE_GO_MODELS_TIMEOUT_MS,
     ttlMs: OPENCODE_GO_MODELS_CACHE_TTL_MS,
     auditContext: "opencode-go-model-discovery",
-    projectRows: (rows) => {
-      const seen = new Set<string>();
-      const models: OpencodeGoModelDefinition[] = [];
-      for (const row of rows) {
-        if (!row || typeof row !== "object" || Array.isArray(row)) {
-          continue;
-        }
-        const object = "object" in row ? row.object : undefined;
-        if (object !== undefined && object !== "model") {
-          continue;
-        }
-        const id = "id" in row ? row.id : undefined;
-        const modelId = typeof id === "string" ? id.trim().toLowerCase() : "";
-        if (!modelId || seen.has(modelId) || OPENCODE_GO_MODEL_STATUS.has(modelId)) {
-          continue;
-        }
-        seen.add(modelId);
-        const model = OPENCODE_GO_MODEL_BY_ID.get(modelId);
-        if (model) {
-          models.push(model);
-        }
-      }
-      return models;
-    },
+    projectRows: (rows) => projectProviderCatalogSnapshotRows(rows, opencodeGoCatalog),
   });
 }
 
 export function listOpencodeGoModelCatalogEntries(): ModelCatalogEntry[] {
-  return [...OPENCODE_GO_MODEL_BY_ID.values()].map((model) => {
-    const entry: ModelCatalogEntry = {
-      provider: model.provider,
-      id: model.id,
-      name: model.name,
-      api: model.api,
-      baseUrl: model.baseUrl,
-      reasoning: model.reasoning,
-      input: model.input,
-      contextWindow: model.contextWindow,
-      contextTokens: model.contextTokens,
-      compat: model.compat,
-    };
-    const status = OPENCODE_GO_MODEL_STATUS.get(model.id);
-    if (status) {
-      entry.status = status;
-    }
-    return entry;
-  });
+  return listProviderCatalogSnapshotEntries(opencodeGoCatalog);
 }
 
 export function resolveOpencodeGoModel(modelId: string): ProviderRuntimeModel | undefined {
-  const normalizedModelId = modelId.trim().toLowerCase();
-  return OPENCODE_GO_SEED_MODEL_BY_ID.get(normalizedModelId);
+  // Public upstream metadata does not establish another account's Go entitlement.
+  return OPENCODE_GO_SEED_CATALOG.get(modelId.trim().toLowerCase())?.model;
 }
 
 export function isOpencodeGoKimiNoReasoningModelId(modelId: unknown): boolean {

--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -521,6 +521,47 @@ describe("opencode provider plugin", () => {
     expectSeedModels(fallback.models);
   });
 
+  it.each(["failed", "filtered"] as const)(
+    "uses refreshed lifecycle on the first fallback after %s model advertising",
+    async (advertising) => {
+      const retiredId = "big-pickle";
+      const provider = await registerSingleProviderPlugin(plugin);
+      const fetchGuard = createCatalogFetchGuard({
+        metadata: [{ id: retiredId, status: "deprecated" }],
+        advertised: () => {
+          if (advertising === "failed") {
+            throw new Error("model advertising unavailable");
+          }
+          return [retiredId];
+        },
+      });
+
+      try {
+        expectSeedModels((await buildOpencodeZenLiveProviderConfig()).models);
+        const fallback = await buildOpencodeZenLiveProviderConfig({
+          apiKey: "runtime-key",
+          discoveryApiKey: "discovery-key",
+          fetchGuard,
+        });
+
+        expect(fallback.apiKey).toBe("runtime-key");
+        expect(fallback.models.map((model) => model.id)).toEqual(
+          OFFLINE_MODEL_IDS.filter((id) => id !== retiredId),
+        );
+        expect(provider.resolveDynamicModel?.({ modelId: retiredId } as never)).toMatchObject({
+          id: retiredId,
+        });
+      } finally {
+        clearLiveCatalogCacheForTests();
+        await prepareOpencodeZenModel({
+          modelId: retiredId,
+          fetchGuard: createCatalogFetchGuard({ metadata: [], advertised: [] }),
+        });
+        clearLiveCatalogCacheForTests();
+      }
+    },
+  );
+
   it.each([
     [["claude-opus-5"], "opencode/claude-opus-5"],
     [["gpt-5.6-sol"], undefined],

--- a/extensions/opencode/opencode.live.test.ts
+++ b/extensions/opencode/opencode.live.test.ts
@@ -1,4 +1,3 @@
-// Opencode tests cover opencode plugin behavior.
 import {
   completeSimple,
   type AssistantMessage,
@@ -17,28 +16,43 @@ const OPENCODE_ZEN_MODELS_URL = "https://opencode.ai/zen/v1/models";
 const OPENCODE_API_KEY =
   process.env.OPENCODE_API_KEY?.trim() || process.env.OPENCODE_ZEN_API_KEY?.trim() || "";
 const LIVE_MODEL_ID =
-  process.env.OPENCLAW_LIVE_OPENCODE_DEEPSEEK_MODEL?.trim() || "deepseek-v4-flash-free";
+  process.env.OPENCLAW_LIVE_OPENCODE_DEEPSEEK_MODEL?.trim() || "deepseek-v4-flash";
 const LIVE = isLiveTestEnabled(["OPENCODE_LIVE_TEST"]) && OPENCODE_API_KEY.length > 0;
 const describeLive = LIVE ? describe : describe.skip;
-const describeCatalogLive = LIVE ? describe : describe.skip;
 
 type OpencodeModelsResponse = {
   data?: Array<{ id?: unknown; object?: unknown }>;
 };
 
-function resolveOpencodeDeepSeekLiveModel(): Model<"openai-completions"> {
-  return {
-    id: LIVE_MODEL_ID,
-    name: LIVE_MODEL_ID,
-    api: "openai-completions",
+async function resolveOpencodeDeepSeekLiveModel() {
+  const provider = await buildOpencodeZenLiveProviderConfig({ apiKey: OPENCODE_API_KEY });
+  const row = provider.models.find((model) => model.id === LIVE_MODEL_ID);
+  if (
+    !row ||
+    row.api !== "openai-completions" ||
+    !row.contextWindow ||
+    !row.reasoning ||
+    !row.compat?.supportsTools
+  ) {
+    throw new Error(`OpenCode catalog lacks a reasoning/tool-capable chat model: ${LIVE_MODEL_ID}`);
+  }
+  const input = row.input.filter((kind) => kind === "text" || kind === "image");
+  expect(input).toEqual(row.input);
+  const reasoning = (["low", "medium", "high", "max"] as const).find((effort) =>
+    row.compat?.supportedReasoningEfforts?.includes(effort),
+  );
+  if (!reasoning) {
+    throw new Error(`OpenCode catalog has no supported reasoning effort for ${LIVE_MODEL_ID}`);
+  }
+  const model: Model<"openai-completions"> = {
+    ...row,
+    api: row.api,
+    contextWindow: row.contextWindow,
     provider: "opencode",
-    baseUrl: "https://opencode.ai/zen/v1",
-    reasoning: true,
-    input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 65_536,
-    maxTokens: 8192,
+    baseUrl: row.baseUrl ?? provider.baseUrl,
+    input,
   };
+  return { model, reasoning };
 }
 
 function liveEchoTool(): Tool {
@@ -70,7 +84,10 @@ function hasReasoningContentReplay(message: AssistantMessage): boolean {
 
 async function fetchOpencodeZenModelIds(): Promise<string[]> {
   const response = await fetch(OPENCODE_ZEN_MODELS_URL, {
-    headers: { "accept-encoding": "identity" },
+    headers: {
+      authorization: `Bearer ${OPENCODE_API_KEY}`,
+      "accept-encoding": "identity",
+    },
   });
   expect(response.ok).toBe(true);
   const json = (await response.json()) as OpencodeModelsResponse;
@@ -85,7 +102,7 @@ async function fetchOpencodeZenModelIds(): Promise<string[]> {
   return modelIds;
 }
 
-describeCatalogLive("opencode Zen live catalog drift", () => {
+describeLive("opencode Zen live catalog drift", () => {
   it("discovers active live ids from authoritative metadata without hardcoding the catalog", async () => {
     const liveIds = await fetchOpencodeZenModelIds();
     const discovered = await buildOpencodeZenLiveProviderConfig({
@@ -96,30 +113,22 @@ describeCatalogLive("opencode Zen live catalog drift", () => {
     expect(new Set(discoveredIds).size).toBe(discoveredIds.length);
 
     const trustedRows = listOpencodeZenModelCatalogEntries();
-    const trustedIdSet = new Set(trustedRows.map((row) => row.id));
-    const missingTrustedMetadata = liveIds.filter((id) => !trustedIdSet.has(id));
-    const deprecatedIds = new Set(
-      trustedRows.filter((row) => row.status === "deprecated").map((row) => row.id),
+    const activeIds = new Set(
+      trustedRows.filter((row) => !row.status).map((row) => row.id.toLowerCase()),
     );
 
-    expect(missingTrustedMetadata).toEqual([]);
-    expect(discoveredIds.every((id) => liveIds.includes(id) && !deprecatedIds.has(id))).toBe(true);
-    expect(discovered.models.find((model) => model.id === "x-preview-f-free")).toMatchObject({
-      api: "openai-completions",
-      contextWindow: 1_000_000,
-      maxTokens: 131_072,
-      compat: { supportedReasoningEfforts: ["low", "high", "max"] },
-    });
+    expect(discoveredIds.length).toBeGreaterThan(0);
+    expect(discoveredIds).toEqual(liveIds.filter((id) => activeIds.has(id)));
   }, 30_000);
 });
 
 describeLive("opencode plugin live", () => {
-  it("accepts DeepSeek V4 tier-suffixed thinking replay after a tool call", async () => {
-    const model = resolveOpencodeDeepSeekLiveModel();
+  it("accepts discovered DeepSeek V4 thinking replay after a tool call", async () => {
+    const { model, reasoning } = await resolveOpencodeDeepSeekLiveModel();
     const tool = liveEchoTool();
     const firstOptions = {
       apiKey: OPENCODE_API_KEY,
-      reasoning: "low",
+      reasoning,
       maxTokens: 128,
     } as const;
 
@@ -173,7 +182,7 @@ describeLive("opencode plugin live", () => {
       },
       {
         apiKey: OPENCODE_API_KEY,
-        reasoning: "low",
+        reasoning,
         maxTokens: 64,
       },
     );

--- a/extensions/opencode/provider-catalog.ts
+++ b/extensions/opencode/provider-catalog.ts
@@ -4,15 +4,16 @@ import {
   buildLiveModelProviderConfig,
   fetchLiveProviderModelIds,
   getCachedUpstreamProviderCatalog,
-  projectUpstreamProviderCatalogModel,
+  listProviderCatalogSnapshotEntries,
+  projectProviderCatalogSnapshotRows,
+  projectUpstreamProviderCatalogSnapshot,
   type LiveModelCatalogFetchGuard,
+  type ProviderCatalogSnapshot,
+  type ProjectedUpstreamProviderCatalogModel as OpencodeZenModelDefinition,
   type UpstreamProviderCatalog,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-model-shared";
-import type {
-  ModelDefinitionConfig,
-  ModelProviderConfig,
-} from "openclaw/plugin-sdk/provider-model-shared";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const PROVIDER_ID = "opencode";
@@ -23,13 +24,6 @@ const OPENCODE_UPSTREAM_CATALOG_ENDPOINT = "https://models.opencode.ai/api.json"
 const OPENCODE_ZEN_MODELS_TIMEOUT_MS = 5_000;
 const OPENCODE_ZEN_MODELS_CACHE_TTL_MS = 60_000;
 
-type OpencodeZenModelDefinition = ModelDefinitionConfig & {
-  provider: typeof PROVIDER_ID;
-  api: NonNullable<ModelDefinitionConfig["api"]>;
-  baseUrl: string;
-  input: Array<"text" | "image">;
-};
-
 type FetchOpencodeZenLiveModelIdsParams = {
   apiKey?: string;
   discoveryApiKey?: string;
@@ -37,68 +31,47 @@ type FetchOpencodeZenLiveModelIdsParams = {
   signal?: AbortSignal;
 };
 
-type OpencodeZenModelLifecycle = {
-  status?: "deprecated";
-  replacedBy?: string;
-};
-
 const OPENCODE_ZEN_MANIFEST_PROVIDER = manifest.modelCatalog.providers.opencode;
-const OPENCODE_ZEN_SEED_MODELS = OPENCODE_ZEN_MANIFEST_PROVIDER.models.map((model) =>
-  normalizeModelCompat({
-    ...model,
-    provider: PROVIDER_ID,
-    api: model.api ?? OPENCODE_ZEN_MANIFEST_PROVIDER.api,
-    baseUrl: model.baseUrl ?? OPENCODE_ZEN_MANIFEST_PROVIDER.baseUrl,
-  } as OpencodeZenModelDefinition),
-) as OpencodeZenModelDefinition[];
-const OPENCODE_ZEN_MODEL_BY_ID = new Map(
-  OPENCODE_ZEN_SEED_MODELS.map((model) => [model.id, model]),
+const OPENCODE_ZEN_SEED_CATALOG: ProviderCatalogSnapshot = new Map(
+  OPENCODE_ZEN_MANIFEST_PROVIDER.models.map((row) => {
+    // SAFETY: Bundled rows and inherited transport supply the complete runtime model shape.
+    const model = normalizeModelCompat({
+      ...row,
+      provider: PROVIDER_ID,
+      api: row.api ?? OPENCODE_ZEN_MANIFEST_PROVIDER.api,
+      baseUrl: row.baseUrl ?? OPENCODE_ZEN_MANIFEST_PROVIDER.baseUrl,
+    } as OpencodeZenModelDefinition) as OpencodeZenModelDefinition;
+    return [
+      model.id,
+      {
+        model,
+        ...("status" in row && row.status === "deprecated"
+          ? { status: "deprecated" as const }
+          : {}),
+        ...("replacedBy" in row && typeof row.replacedBy === "string"
+          ? { replacedBy: row.replacedBy }
+          : {}),
+      },
+    ];
+  }),
 );
-const OPENCODE_ZEN_MODEL_LIFECYCLE_BY_ID = new Map<string, OpencodeZenModelLifecycle>(
-  OPENCODE_ZEN_MANIFEST_PROVIDER.models.map((model) => [
-    model.id,
-    {
-      ...("status" in model && model.status === "deprecated"
-        ? { status: "deprecated" as const }
-        : {}),
-      ...("replacedBy" in model && typeof model.replacedBy === "string"
-        ? { replacedBy: model.replacedBy }
-        : {}),
-    },
-  ]),
-);
-
-function isActiveOpencodeZenModel(model: OpencodeZenModelDefinition): boolean {
-  return OPENCODE_ZEN_MODEL_LIFECYCLE_BY_ID.get(model.id)?.status !== "deprecated";
-}
+let opencodeZenCatalog = OPENCODE_ZEN_SEED_CATALOG;
 
 function listStaticOpencodeZenModels(): OpencodeZenModelDefinition[] {
-  return OPENCODE_ZEN_SEED_MODELS.filter(isActiveOpencodeZenModel);
+  return [...OPENCODE_ZEN_SEED_CATALOG.values()]
+    .filter(({ model }) => opencodeZenCatalog.get(model.id)?.status !== "deprecated")
+    .map(({ model }) => model);
 }
 
 function cacheUpstreamOpencodeZenModels(catalog: UpstreamProviderCatalog): void {
-  OPENCODE_ZEN_MODEL_BY_ID.clear();
-  OPENCODE_ZEN_MODEL_LIFECYCLE_BY_ID.clear();
-  for (const model of OPENCODE_ZEN_SEED_MODELS) {
-    OPENCODE_ZEN_MODEL_BY_ID.set(model.id, model);
-  }
-  for (const upstreamModel of Object.values(catalog.models)) {
-    const projected = projectUpstreamProviderCatalogModel({
-      providerId: PROVIDER_ID,
-      provider: catalog,
-      model: upstreamModel,
-      anthropicBaseUrl: OPENCODE_ZEN_ANTHROPIC_BASE_URL,
-      defaultBaseUrl: OPENCODE_ZEN_OPENAI_BASE_URL,
-    });
-    if (!projected) {
-      continue;
-    }
-    const model = normalizeModelCompat(projected) as OpencodeZenModelDefinition;
-    OPENCODE_ZEN_MODEL_BY_ID.set(model.id.toLowerCase(), model);
-    if (upstreamModel.status === "deprecated") {
-      OPENCODE_ZEN_MODEL_LIFECYCLE_BY_ID.set(model.id, { status: "deprecated" });
-    }
-  }
+  opencodeZenCatalog = projectUpstreamProviderCatalogSnapshot({
+    providerId: PROVIDER_ID,
+    provider: catalog,
+    // Zen refreshes lifecycle entirely from upstream; Go retains omitted seed lifecycle.
+    seed: new Map(Array.from(OPENCODE_ZEN_SEED_CATALOG, ([id, { model }]) => [id, { model }])),
+    anthropicBaseUrl: OPENCODE_ZEN_ANTHROPIC_BASE_URL,
+    defaultBaseUrl: OPENCODE_ZEN_OPENAI_BASE_URL,
+  });
 }
 
 export async function prepareOpencodeZenModel(params: {
@@ -147,40 +120,9 @@ export async function resolveOpencodeZenStarterModel(params: {
   return liveModelIds.includes(preferredModelId) ? params.preferredModelRef : undefined;
 }
 
-function readLiveModelId(row: unknown): string | undefined {
-  if (!row || typeof row !== "object" || Array.isArray(row)) {
-    return undefined;
-  }
-  if ("object" in row && row.object !== undefined && row.object !== "model") {
-    return undefined;
-  }
-  if (!("id" in row) || typeof row.id !== "string") {
-    return undefined;
-  }
-  return row.id.trim().toLowerCase() || undefined;
-}
-
-function projectOpencodeZenLiveModels(rows: readonly unknown[]): OpencodeZenModelDefinition[] {
-  const seen = new Set<string>();
-  const models: OpencodeZenModelDefinition[] = [];
-  for (const row of rows) {
-    const modelId = readLiveModelId(row);
-    if (!modelId || seen.has(modelId)) {
-      continue;
-    }
-    seen.add(modelId);
-    const model = OPENCODE_ZEN_MODEL_BY_ID.get(modelId);
-    if (model && isActiveOpencodeZenModel(model)) {
-      models.push(model);
-    }
-  }
-  return models;
-}
-
 export async function buildOpencodeZenLiveProviderConfig(
   params: FetchOpencodeZenLiveModelIdsParams = {},
 ): Promise<ModelProviderConfig> {
-  const fallbackModels = listStaticOpencodeZenModels();
   if (!params.apiKey && !params.discoveryApiKey) {
     return buildStaticOpencodeZenProviderConfig();
   }
@@ -204,7 +146,7 @@ export async function buildOpencodeZenLiveProviderConfig(
       api: "openai-completions",
       baseUrl: OPENCODE_ZEN_OPENAI_BASE_URL,
     },
-    models: fallbackModels,
+    models: listStaticOpencodeZenModels(),
     apiKey: params.apiKey,
     discoveryApiKey: params.discoveryApiKey,
     fetchGuard: params.fetchGuard,
@@ -212,32 +154,16 @@ export async function buildOpencodeZenLiveProviderConfig(
     timeoutMs: OPENCODE_ZEN_MODELS_TIMEOUT_MS,
     ttlMs: OPENCODE_ZEN_MODELS_CACHE_TTL_MS,
     auditContext: "opencode-zen-model-discovery",
-    projectRows: projectOpencodeZenLiveModels,
+    projectRows: (rows) => projectProviderCatalogSnapshotRows(rows, opencodeZenCatalog),
   });
 }
 
 export function listOpencodeZenModelCatalogEntries(): ModelCatalogEntry[] {
-  return Array.from(OPENCODE_ZEN_MODEL_BY_ID.values(), (model) => {
-    const lifecycle = OPENCODE_ZEN_MODEL_LIFECYCLE_BY_ID.get(model.id);
-    return {
-      provider: model.provider,
-      id: model.id,
-      name: model.name,
-      api: model.api,
-      baseUrl: model.baseUrl,
-      reasoning: model.reasoning,
-      input: model.input,
-      contextWindow: model.contextWindow,
-      contextTokens: model.contextTokens,
-      compat: model.compat,
-      ...(lifecycle?.status ? { status: lifecycle.status } : {}),
-      ...(lifecycle?.replacedBy ? { replacedBy: lifecycle.replacedBy } : {}),
-    };
-  });
+  return listProviderCatalogSnapshotEntries(opencodeZenCatalog);
 }
 
 export function resolveOpencodeZenModel(modelId: string): ProviderRuntimeModel | undefined {
-  return OPENCODE_ZEN_MODEL_BY_ID.get(modelId.trim().toLowerCase());
+  return opencodeZenCatalog.get(modelId.trim().toLowerCase())?.model;
 }
 
 function normalizeBaseUrl(baseUrl: string | undefined): string {

--- a/src/plugin-sdk/provider-catalog-live-normalize.internal.ts
+++ b/src/plugin-sdk/provider-catalog-live-normalize.internal.ts
@@ -1,36 +1,9 @@
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "./provider-model-shared.js";
 
-export type UpstreamProviderCatalogModel = {
+export type UpstreamProviderCatalogModel = Record<string, unknown> & {
   id: string;
-  name: string;
-  status?: string;
-  reasoning?: boolean;
-  tool_call?: boolean;
-  attachment?: boolean;
-  reasoning_options?: ReadonlyArray<{ type: string; values?: ReadonlyArray<string | null> }>;
-  modalities?: { input?: readonly string[]; output?: readonly string[] };
-  provider?: { npm?: string; api?: string };
-  limit: { context: number; input?: number; output: number };
-  cost?: {
-    input: number;
-    output: number;
-    cache_read?: number;
-    cache_write?: number;
-    tiers?: ReadonlyArray<{
-      input: number;
-      output: number;
-      cache_read?: number;
-      cache_write?: number;
-      tier: { type: string; size: number };
-    }>;
-    context_over_200k?: {
-      input: number;
-      output: number;
-      cache_read?: number;
-      cache_write?: number;
-    };
-  };
+  limit: Record<string, unknown> & { context: number; output: number };
 };
 
 export type UpstreamProviderCatalog = {
@@ -46,6 +19,14 @@ export type ProjectedUpstreamProviderCatalogModel = ModelDefinitionConfig & {
   baseUrl: string;
   input: Array<"text" | "image">;
 };
+
+export function readLiveModelCatalogId(row: unknown): string | undefined {
+  const record = readLiveModelCatalogRecord(row);
+  if (record?.object !== undefined && record.object !== "model") {
+    return undefined;
+  }
+  return readLiveModelCatalogStringField(record, "id");
+}
 
 export function readLiveModelCatalogRecord(body: unknown): Record<string, unknown> | undefined {
   return asOptionalRecord(body);
@@ -381,42 +362,44 @@ function readUpstreamProviderCatalogCostValue(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
 }
 
-function buildUpstreamProviderCatalogCost(
-  rawCost: UpstreamProviderCatalogModel["cost"],
-): ModelDefinitionConfig["cost"] {
-  const cost = {
+function readUpstreamProviderCatalogCost(rawCost: Record<string, unknown> | undefined) {
+  return {
     input: readUpstreamProviderCatalogCostValue(rawCost?.input),
     output: readUpstreamProviderCatalogCostValue(rawCost?.output),
     cacheRead: readUpstreamProviderCatalogCostValue(rawCost?.cache_read),
     cacheWrite: readUpstreamProviderCatalogCostValue(rawCost?.cache_write),
   };
-  const upstreamTiers = (rawCost?.tiers ?? [])
-    .filter(
-      (tier) =>
-        tier.tier?.type === "context" && Number.isSafeInteger(tier.tier.size) && tier.tier.size > 0,
-    )
-    .toSorted((left, right) => left.tier.size - right.tier.size);
-  if (upstreamTiers.length === 0 && rawCost?.context_over_200k) {
-    upstreamTiers.push({
-      ...rawCost.context_over_200k,
-      tier: { type: "context", size: 200_000 },
-    });
+}
+
+function buildUpstreamProviderCatalogCost(value: unknown): ModelDefinitionConfig["cost"] {
+  const rawCost = readLiveModelCatalogRecord(value);
+  const cost = readUpstreamProviderCatalogCost(rawCost);
+  const upstreamTiers = (Array.isArray(rawCost?.tiers) ? rawCost.tiers : [])
+    .flatMap((rawTier) => {
+      const row = readLiveModelCatalogRecord(rawTier);
+      const tier = readLiveModelCatalogRecord(row?.tier);
+      const size = readLiveModelCatalogPositiveSafeIntegerField(tier, "size");
+      return tier?.type === "context" && size
+        ? [{ size, cost: readUpstreamProviderCatalogCost(row) }]
+        : [];
+    })
+    .toSorted((left, right) => left.size - right.size);
+  const legacyCost = readLiveModelCatalogRecord(rawCost?.context_over_200k);
+  if (upstreamTiers.length === 0 && legacyCost) {
+    upstreamTiers.push({ size: 200_000, cost: readUpstreamProviderCatalogCost(legacyCost) });
   }
   const firstTier = upstreamTiers[0];
   if (!firstTier) {
     return cost;
   }
   const tieredPricing: NonNullable<ModelDefinitionConfig["cost"]["tieredPricing"]> = [
-    { ...cost, range: [0, firstTier.tier.size] },
+    { ...cost, range: [0, firstTier.size] },
   ];
   for (const [index, tier] of upstreamTiers.entries()) {
-    const nextThreshold = upstreamTiers[index + 1]?.tier.size;
+    const nextThreshold = upstreamTiers[index + 1]?.size;
     tieredPricing.push({
-      input: readUpstreamProviderCatalogCostValue(tier.input),
-      output: readUpstreamProviderCatalogCostValue(tier.output),
-      cacheRead: readUpstreamProviderCatalogCostValue(tier.cache_read),
-      cacheWrite: readUpstreamProviderCatalogCostValue(tier.cache_write),
-      range: nextThreshold ? [tier.tier.size, nextThreshold] : [tier.tier.size],
+      ...tier.cost,
+      range: nextThreshold ? [tier.size, nextThreshold] : [tier.size],
     });
   }
   return { ...cost, tieredPricing };
@@ -429,6 +412,16 @@ function parseUpstreamProviderCatalogUrl(value: string): URL | undefined {
     return undefined;
   }
 }
+
+const UPSTREAM_PROVIDER_API_BY_PACKAGE = new Map<
+  string,
+  ProjectedUpstreamProviderCatalogModel["api"]
+>([
+  ["@ai-sdk/anthropic", "anthropic-messages"],
+  ["@ai-sdk/google", "google-generative-ai"],
+  ["@ai-sdk/openai", "openai-responses"],
+  ["@ai-sdk/openai-compatible", "openai-completions"],
+]);
 
 /** Projects authoritative provider-owned model metadata into its runtime transport and capabilities. */
 export function projectUpstreamProviderCatalogModel(params: {
@@ -452,13 +445,7 @@ export function projectUpstreamProviderCatalogModel(params: {
     readLiveModelCatalogStringField(modelProvider, "npm") ??
     params.provider.npm ??
     "@ai-sdk/openai-compatible";
-  const apiByPackage: Record<string, ProjectedUpstreamProviderCatalogModel["api"]> = {
-    "@ai-sdk/anthropic": "anthropic-messages",
-    "@ai-sdk/google": "google-generative-ai",
-    "@ai-sdk/openai": "openai-responses",
-    "@ai-sdk/openai-compatible": "openai-completions",
-  };
-  const api = apiByPackage[npm];
+  const api = UPSTREAM_PROVIDER_API_BY_PACKAGE.get(npm);
   if (!api) {
     return undefined;
   }
@@ -514,7 +501,7 @@ export function projectUpstreamProviderCatalogModel(params: {
     baseUrl,
     reasoning: readLiveModelCatalogBooleanField(model, "reasoning") ?? false,
     input,
-    cost: buildUpstreamProviderCatalogCost(params.model?.cost),
+    cost: buildUpstreamProviderCatalogCost(model.cost),
     contextWindow,
     ...(contextTokens && contextTokens <= contextWindow ? { contextTokens } : {}),
     maxTokens,

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -11,6 +11,7 @@ import {
   buildOpenAICompatibleLiveModels,
   isUpstreamProviderCatalogModel,
   readLiveModelCatalogBooleanField,
+  readLiveModelCatalogId,
   readLiveModelCatalogPositiveSafeIntegerField,
   readLiveModelCatalogRecord,
   readLiveModelCatalogStringField,
@@ -48,7 +49,12 @@ export {
   readLiveModelCatalogPositiveSafeIntegerField,
   readLiveModelCatalogStringField,
 };
-export { projectUpstreamProviderCatalogModel } from "./provider-catalog-live-normalize.internal.js";
+export {
+  listProviderCatalogSnapshotEntries,
+  projectProviderCatalogSnapshotRows,
+  projectUpstreamProviderCatalogSnapshot,
+  type ProviderCatalogSnapshot,
+} from "./provider-catalog-snapshot.internal.js";
 export type {
   ProjectedUpstreamProviderCatalogModel,
   UpstreamProviderCatalog,
@@ -183,21 +189,6 @@ function readDefaultLiveModelCatalogRows(body: unknown): readonly unknown[] {
     return (body as { data: unknown[] }).data;
   }
   throw new Error("Live model catalog response must be an array or { data: [] }");
-}
-
-function readDefaultLiveModelId(row: unknown): string | undefined {
-  if (!row || typeof row !== "object" || Array.isArray(row)) {
-    return undefined;
-  }
-  const candidate = row as { id?: unknown; object?: unknown };
-  if (candidate.object !== undefined && candidate.object !== "model") {
-    return undefined;
-  }
-  if (typeof candidate.id !== "string") {
-    return undefined;
-  }
-  const modelId = candidate.id.trim();
-  return modelId || undefined;
 }
 
 function normalizeLiveModelCatalogRequestApiKey(value: string | undefined): string | undefined {
@@ -544,7 +535,7 @@ export async function fetchLiveProviderModelIds(
   params: FetchLiveProviderModelIdsParams,
 ): Promise<string[]> {
   const rows = await fetchLiveProviderModelRows(params);
-  const readModelId = params.readModelId ?? readDefaultLiveModelId;
+  const readModelId = params.readModelId ?? readLiveModelCatalogId;
   const seen = new Set<string>();
   const modelIds: string[] = [];
   for (const row of rows) {

--- a/src/plugin-sdk/provider-catalog-live-upstream.test.ts
+++ b/src/plugin-sdk/provider-catalog-live-upstream.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi, type MockedFunction } from "vitest";
+import { projectUpstreamProviderCatalogModel } from "./provider-catalog-live-normalize.internal.js";
 import {
   clearLiveCatalogCacheForTests,
   getCachedUpstreamProviderCatalog,
-  projectUpstreamProviderCatalogModel,
   type LiveModelCatalogFetchGuard,
   type UpstreamProviderCatalog,
 } from "./provider-catalog-live-runtime.js";
@@ -19,6 +19,12 @@ function buildFetchGuard(body: unknown): {
   }));
   return { fetchGuard, release };
 }
+
+const UPSTREAM_TIER_COST = { input: 4, output: 12, cache_read: 1, cache_write: 2 };
+const UPSTREAM_CONTEXT_TIER = {
+  ...UPSTREAM_TIER_COST,
+  tier: { type: "context", size: 200_000 },
+};
 
 describe("shared upstream provider metadata catalogs", () => {
   beforeEach(() => clearLiveCatalogCacheForTests());
@@ -86,101 +92,147 @@ describe("shared upstream provider metadata catalogs", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
-  it("projects authoritative upstream pricing, reasoning, tool, and modality metadata", () => {
-    const provider: UpstreamProviderCatalog = {
-      id: "opencode-go",
-      api: "https://opencode.ai/zen/go/v1",
-      npm: "@ai-sdk/openai-compatible",
-      models: {},
-    };
-    const model = projectUpstreamProviderCatalogModel({
-      providerId: provider.id,
-      provider,
-      model: {
+  it.each([
+    ["modern tiers", { tiers: [UPSTREAM_CONTEXT_TIER] }, true],
+    ["legacy tier", { context_over_200k: UPSTREAM_TIER_COST }, true],
+    ["object tiers", { tiers: {} }, false],
+    ["null tier", { tiers: [null] }, false],
+    ["mixed tiers", { tiers: [null, UPSTREAM_CONTEXT_TIER] }, true],
+    [
+      "malformed tiers with legacy pricing",
+      { tiers: {}, context_over_200k: UPSTREAM_TIER_COST },
+      true,
+    ],
+    [
+      "modern tiers before legacy pricing",
+      {
+        tiers: [UPSTREAM_CONTEXT_TIER],
+        context_over_200k: { ...UPSTREAM_TIER_COST, input: 99 },
+      },
+      true,
+    ],
+  ] as const)(
+    "projects pricing, reasoning, tools, and modalities from %s JSON",
+    async (_name, pricing, hasTiers) => {
+      const { fetchGuard } = buildFetchGuard({
+        "opencode-go": {
+          id: "opencode-go",
+          api: "https://opencode.ai/zen/go/v1",
+          npm: "@ai-sdk/openai-compatible",
+          models: {
+            "frontier-model": {
+              id: "frontier-model",
+              name: "Frontier Model",
+              reasoning: true,
+              tool_call: true,
+              reasoning_options: [{ type: "effort", values: ["low", "high", "high", null] }],
+              modalities: { input: ["text", "image", "video"] },
+              provider: { npm: "@ai-sdk/openai" },
+              limit: { context: 1_000_000, input: 900_000, output: 128_000 },
+              cost: { input: 2, output: 6, cache_read: 0.5, cache_write: 1, ...pricing },
+            },
+          },
+        },
+      });
+      const provider = await getCachedUpstreamProviderCatalog({
+        endpoint: "https://models.opencode.ai/api.json",
+        providerId: "opencode-go",
+        fetchGuard,
+      });
+      const upstreamModel = provider?.models["frontier-model"];
+      if (!provider || !upstreamModel) {
+        throw new Error("expected upstream provider model");
+      }
+      const model = projectUpstreamProviderCatalogModel({
+        providerId: provider.id,
+        provider,
+        model: upstreamModel,
+      });
+
+      expect(model).toEqual({
         id: "frontier-model",
         name: "Frontier Model",
+        provider: "opencode-go",
+        api: "openai-responses",
+        baseUrl: "https://opencode.ai/zen/go/v1",
         reasoning: true,
-        tool_call: true,
-        reasoning_options: [{ type: "effort", values: ["low", "high", "high", null] }],
-        modalities: { input: ["text", "image", "video"] },
-        provider: { npm: "@ai-sdk/openai" },
-        limit: { context: 1_000_000, input: 900_000, output: 128_000 },
+        input: ["text", "image"],
+        contextWindow: 1_000_000,
+        contextTokens: 900_000,
+        maxTokens: 128_000,
+        thinkingLevelMap: { off: null },
         cost: {
           input: 2,
           output: 6,
-          cache_read: 0.5,
-          cache_write: 1,
-          tiers: [
-            {
-              input: 4,
-              output: 12,
-              cache_read: 1,
-              cache_write: 2,
-              tier: { type: "context", size: 200_000 },
-            },
-          ],
+          cacheRead: 0.5,
+          cacheWrite: 1,
+          ...(hasTiers
+            ? {
+                tieredPricing: [
+                  { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 1, range: [0, 200_000] },
+                  { input: 4, output: 12, cacheRead: 1, cacheWrite: 2, range: [200_000] },
+                ],
+              }
+            : {}),
         },
-      },
-    });
-
-    expect(model).toEqual({
-      id: "frontier-model",
-      name: "Frontier Model",
-      provider: "opencode-go",
-      api: "openai-responses",
-      baseUrl: "https://opencode.ai/zen/go/v1",
-      reasoning: true,
-      input: ["text", "image"],
-      contextWindow: 1_000_000,
-      contextTokens: 900_000,
-      maxTokens: 128_000,
-      thinkingLevelMap: { off: null },
-      cost: {
-        input: 2,
-        output: 6,
-        cacheRead: 0.5,
-        cacheWrite: 1,
-        tieredPricing: [
-          { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 1, range: [0, 200_000] },
-          { input: 4, output: 12, cacheRead: 1, cacheWrite: 2, range: [200_000] },
-        ],
-      },
-      compat: {
-        supportsUsageInStreaming: true,
-        maxTokensField: "max_tokens",
-        supportsTools: true,
-        supportsReasoningEffort: true,
-        supportedReasoningEfforts: ["low", "high"],
-      },
-    });
-  });
+        compat: {
+          supportsUsageInStreaming: true,
+          maxTokensField: "max_tokens",
+          supportsTools: true,
+          supportsReasoningEffort: true,
+          supportedReasoningEfforts: ["low", "high"],
+        },
+      });
+    },
+  );
 
   it.each([
     ["@ai-sdk/openai-compatible", "openai-completions", "https://opencode.ai/zen/v1"],
     ["@ai-sdk/openai", "openai-responses", "https://opencode.ai/zen/v1"],
     ["@ai-sdk/anthropic", "anthropic-messages", "https://opencode.ai/zen"],
     ["@ai-sdk/google", "google-generative-ai", "https://opencode.ai/zen/v1"],
-  ])("projects upstream %s transport without guessing from model ids", (npm, api, baseUrl) => {
-    const provider: UpstreamProviderCatalog = {
-      id: "opencode",
-      api: "https://opencode.ai/zen/v1",
-      npm: "@ai-sdk/openai-compatible",
-      models: {},
-    };
-
-    expect(
-      projectUpstreamProviderCatalogModel({
+    ["@unsupported/sdk", undefined, undefined],
+    ["constructor", undefined, undefined],
+  ] as const)(
+    "projects only supported upstream %s transport from JSON",
+    async (npm, api, baseUrl) => {
+      const { fetchGuard } = buildFetchGuard({
+        opencode: {
+          id: "opencode",
+          api: "https://opencode.ai/zen/v1",
+          npm: "@ai-sdk/openai-compatible",
+          models: {
+            "opaque-preview-id": {
+              id: "opaque-preview-id",
+              name: "Opaque Preview",
+              provider: { npm },
+              limit: { context: 128_000, output: 8192 },
+            },
+          },
+        },
+      });
+      const provider = await getCachedUpstreamProviderCatalog({
+        endpoint: "https://models.opencode.ai/api.json",
+        providerId: "opencode",
+        fetchGuard,
+      });
+      const upstreamModel = provider?.models["opaque-preview-id"];
+      if (!provider || !upstreamModel) {
+        throw new Error("expected upstream provider model");
+      }
+      const model = projectUpstreamProviderCatalogModel({
         providerId: provider.id,
         provider,
-        model: {
-          id: "opaque-preview-id",
-          name: "Opaque Preview",
-          provider: { npm },
-          limit: { context: 128_000, output: 8192 },
-        },
-      }),
-    ).toMatchObject({ api, baseUrl });
-  });
+        model: upstreamModel,
+      });
+
+      if (api === undefined) {
+        expect(model).toBeUndefined();
+      } else {
+        expect(model).toMatchObject({ api, baseUrl });
+      }
+    },
+  );
 
   it("rejects upstream metadata that would redirect authenticated inference to another origin", () => {
     const provider: UpstreamProviderCatalog = {

--- a/src/plugin-sdk/provider-catalog-snapshot.internal.ts
+++ b/src/plugin-sdk/provider-catalog-snapshot.internal.ts
@@ -1,0 +1,92 @@
+import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
+import { normalizeModelCompat } from "../plugins/provider-model-compat.js";
+import {
+  projectUpstreamProviderCatalogModel,
+  readLiveModelCatalogId,
+  type ProjectedUpstreamProviderCatalogModel,
+  type UpstreamProviderCatalog,
+} from "./provider-catalog-live-normalize.internal.js";
+
+export type ProviderCatalogSnapshot = ReadonlyMap<
+  string,
+  {
+    model: ProjectedUpstreamProviderCatalogModel;
+    status?: "deprecated" | "preview";
+    replacedBy?: string;
+  }
+>;
+
+/** Rebuilds public metadata from trusted seeds without retaining withdrawn upstream rows. */
+export function projectUpstreamProviderCatalogSnapshot(params: {
+  providerId: string;
+  provider: UpstreamProviderCatalog;
+  seed: ProviderCatalogSnapshot;
+  anthropicBaseUrl: string;
+  defaultBaseUrl: string;
+  decorateModel?: (
+    model: ProjectedUpstreamProviderCatalogModel,
+  ) => ProjectedUpstreamProviderCatalogModel;
+}): ProviderCatalogSnapshot {
+  const snapshot = new Map(params.seed);
+  for (const upstreamModel of Object.values(params.provider.models)) {
+    const projected = projectUpstreamProviderCatalogModel({
+      providerId: params.providerId,
+      provider: params.provider,
+      model: upstreamModel,
+      anthropicBaseUrl: params.anthropicBaseUrl,
+      defaultBaseUrl: params.defaultBaseUrl,
+    });
+    if (!projected) {
+      continue;
+    }
+    const decorated = params.decorateModel ? params.decorateModel(projected) : projected;
+    // SAFETY: Normalization preserves the projector's validated transport and model shape.
+    const model = normalizeModelCompat(decorated) as ProjectedUpstreamProviderCatalogModel;
+    // Replace lifecycle with the same accepted row; rejected metadata leaves its seed untouched.
+    snapshot.set(model.id.toLowerCase(), {
+      model,
+      ...(upstreamModel.status === "deprecated" ? { status: "deprecated" } : {}),
+    });
+  }
+  return snapshot;
+}
+
+/** Intersects advertised ids with active trusted metadata, retaining endpoint order. */
+export function projectProviderCatalogSnapshotRows(
+  rows: readonly unknown[],
+  snapshot: ProviderCatalogSnapshot,
+): ProjectedUpstreamProviderCatalogModel[] {
+  const seen = new Set<string>();
+  const models: ProjectedUpstreamProviderCatalogModel[] = [];
+  for (const row of rows) {
+    const id = readLiveModelCatalogId(row)?.toLowerCase();
+    if (!id || seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    const entry = snapshot.get(id);
+    if (entry && !entry.status) {
+      models.push(entry.model);
+    }
+  }
+  return models;
+}
+
+export function listProviderCatalogSnapshotEntries(
+  snapshot: ProviderCatalogSnapshot,
+): ModelCatalogEntry[] {
+  return Array.from(snapshot.values(), ({ model, status, replacedBy }) => ({
+    provider: model.provider,
+    id: model.id,
+    name: model.name,
+    api: model.api,
+    baseUrl: model.baseUrl,
+    reasoning: model.reasoning,
+    input: model.input,
+    contextWindow: model.contextWindow,
+    contextTokens: model.contextTokens,
+    compat: model.compat,
+    ...(status ? { status } : {}),
+    ...(replacedBy ? { replacedBy } : {}),
+  }));
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users browsing OpenCode models could see a newly deprecated seed model recommended, or an activated Go preview omitted, when the first discovery request failed or returned only filtered rows. Zen and Go captured their offline fallback before refreshing lifecycle and maintained parallel maps for model metadata and status.

The same owner-boundary audit reproduced two upstream JSON admission defects: malformed pricing tiers could throw after the row passed validation, and a package name such as `constructor` could escape a plain object's transport allowlist through its prototype. These were reproduced with JSON fixtures, not observed incidents in the current public feed.

## Why This Change Was Made

Use one snapshot entry for each model and its lifecycle. The shared SDK projects accepted upstream metadata, intersects active trusted entries with advertised IDs, and projects catalog entries. Each plugin retains its snapshot and policy: Zen refreshes omitted seed lifecycle from upstream; Go retains omitted preview/deprecated seed lifecycle and owns Qwen thinking decoration. Refresh starts from the trusted seed, so withdrawn upstream-only rows disappear.

Fallback eligibility is calculated after metadata refresh. Pricing normalization now treats unvalidated fields as unknown and reads valid modern or legacy tiers through the existing canonical guards. A closed Map owns the four supported transport packages. Replaced the unshipped single-row public SDK projector with the snapshot contract in the existing runtime subpath; the row implementation remains internal. No new dependency, subpath, configuration/default, manifest model, protocol, or persistence surface.

Go explicit dynamic resolution remains seed-only: public metadata and a general model inventory do not establish account entitlement. The anonymous metadata cache remains separate from credential-scoped discovery, with provider-owned credential precedence unchanged. Trusted-origin checks, advisory discovery failure behavior, guarded network limits, and lazy provider selection stay intact.

## User Impact

Active recommendations and their first offline fallback agree with refreshed lifecycle status. Existing explicit deprecated seed refs remain resolvable. Docs now use bounded examples and current discovery commands instead of volatile promotional inventories and copied pricing/privacy claims. Go's general model list is explicitly not an entitlement check.

## Evidence

- Baseline: 131 tests across 11 files passed. Ten added cases failed against the original production code for the intended reasons: five lifecycle/fallback cases, four malformed pricing cases, and one prototype transport case. Candidate: all 144 tests across the same 11 files passed.
- Existing sibling coverage retains Zen/Go auth routing, cache partitioning, failed and filtered discovery, seed-only Go resolution, lifecycle refresh and withdrawn rows, Qwen decoration, URL normalization, reasoning sanitation and stream termination, plus shared JSON, pagination, transport, and scope contracts.
- Live tests now compare the exact active trusted/advertised intersection, use the same authenticated Zen list request, and select actual discovered runtime metadata. Zen retains the DeepSeek reasoning/tool-result replay; Go adds actual inference so a successful general listing cannot masquerade as account-access proof.
- Authenticated live proof passed on an isolated temporary HOME with only the OpenCode credential: Zen discovery plus DeepSeek V4 Flash reasoning/tool-result replay (2/2), and Go discovery plus GPT 5.6 Luna Responses inference returning `ok` (2/2). The initial Go DeepSeek attempt returned an account-level regional opt-in restriction; consent settings were not changed. Go's smoke now exercises an already-accessible Responses model instead.
- Remote proof limitation: the direct AWS lease lost SSH after syncing and registering its runner; the hydration workflow was cancelled before running and both owned leases are confirmed released. The alternate Testbox backend lacked authentication. These results are local live-provider proof, not Linux/Crabbox execution; normal hosted CI remains required.
- Direct upstream source inspection at anomalyco/opencode `c2eacd72afc4a4984564c393e15ab30011057269`: `packages/core/src/models-dev.ts` pricing/model schemas; Zen `/v1/models` uses Bearer/workspace filtering; Go `/v1/models` advertises the general lineup independently of the request. Current [Zen](https://opencode.ai/docs/zen/) and [Go](https://opencode.ai/docs/go/) documentation was checked before replacing the stale inventories.
- Full canonical build: all 15 phases passed, including SDK declarations/exports, control-plane import checks, and UI output. The only subsequent production edit renames a shadowed callback variable.
- Local changed gates passed core/core-test typechecks, SDK exports/surface, ownership and ratchet guards, formatting, all changed core/plugin lint, and the remaining architecture guards. Extension and extension-test typechecks are blocked only by the unchanged missing `@daytona/sdk` in the shared worktree install; exact-head hosted CI must supply that proof before merge.
- Independent Codex autoreview completed without actionable findings at its P0 threshold; the maintainer owner/caller/sibling audit also reviewed lower-priority architecture concerns. Production LOC: +238/−316 (**−78**). Tests: +310/−136 (+174); docs: +50/−60; generated assertion allowances: +2/−2.
- Exact-head [CI 33049615872](https://github.com/openclaw/openclaw/actions/runs/33049615872) passed for `ff2471ea2e539d29d7f1182d14ad0a18fcbc76d9`, including production/test extension typechecks and the required gate. Fresh stable-release verification still resolves `v2026.7.1-2`; the removed row projector is unshipped.

Best-fix verdict: one paired snapshot fixes the lifecycle ownership problem and removes duplicate projection rather than guarding each fallback consumer. Folding Go entitlement into public metadata was rejected because the upstream endpoint is a general inventory. Evidence map: plugin registration/catalog hooks call the provider catalog owners; these call shared guarded discovery, upstream parsing, and model compatibility normalization; both Zen and Go and the SDK JSON/scope/pagination suites cover the shared invariant. Relevant source is unchanged on current main. No config/default, database, or protocol changes; the removed SDK row projector was not present in a stable release.

Regression provenance: the early fallback capture and upstream parser defects originated in #129831 / `63d9c69c117` (code author, PR author, and merger @steipete; August 26, 2026). This repair removes the duplicate lifecycle structure rather than adding downstream special cases for individual model IDs.

Release-note context belongs in this PR body and squash message; the root changelog is release-owned.

ClawSweeper follow-through (07:31 UTC review): its Rank-up move and hosted-validation request are satisfied by the successful exact-head CI above. The maintainer independently refreshed the pinned upstream pricing/model schema and both endpoint implementations over the network (all HTTP 200), in addition to the authenticated after-fix tests. See [upstream schema](https://github.com/anomalyco/opencode/blob/c2eacd72afc4a4984564c393e15ab30011057269/packages/core/src/models-dev.ts), [Zen filtering](https://github.com/anomalyco/opencode/blob/c2eacd72afc4a4984564c393e15ab30011057269/packages/console/app/src/routes/zen/v1/models.ts), and [Go inventory](https://github.com/anomalyco/opencode/blob/c2eacd72afc4a4984564c393e15ab30011057269/packages/console/app/src/routes/zen/go/v1/models.ts). Its unauthenticated CLI probe exhausted a 30-second window while cold-building; that is not claimed as a successful CLI probe or a provider regression. The separately completed build, focused command CI, and authenticated owner-level tests are the proof used here. The stored-data warning is a docs-text false positive: this patch changes no SQLite, vector, embedding, or persistent schema.
