### PR TITLE
fix: stop suggesting unsupported cloud worker classes

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -121,6 +121,8 @@ The `settings.class: "beast"` value above is explicit, not a default. OpenClaw r
 
 Manage profiles in the Control UI under **Settings → Connections → Cloud workers**, or edit `cloudWorkers.profiles` directly in `openclaw.json` — both write the same config keys. The settings page lists each profile's backend, class, lifetime, and idle-stop in plain language, and shows whether it is advertised to `environments.list` or waiting on a Gateway restart. With no profiles configured it explains the feature, links back to this page, and starts the add flow.
 
+**Machine class** is a required text field. Enter a class accepted by the selected Crabbox backend and binary; the provider determines its effective sizing. Changing the backend or binary leaves the class unchanged, so verify that it is accepted before saving.
+
 Add a profile under `cloudWorkers.profiles` in `openclaw.json`:
 
 ```json

--- a/ui/src/e2e/cloud-workers-settings.e2e.test.ts
+++ b/ui/src/e2e/cloud-workers-settings.e2e.test.ts
@@ -76,7 +76,16 @@ suite.define(() => {
         "config.get": configResponse({}, "cloud-workers-1"),
         "environments.list": {
           environments: [],
-          profiles: [{ id: "build-fleet", providerId: "crabbox" }],
+          profiles: [
+            {
+              id: "build-fleet",
+              providerId: "crabbox",
+              machines: [
+                { id: "standard", label: "Standard", default: true },
+                { id: "fast", label: "Fast" },
+              ],
+            },
+          ],
         },
       },
     });
@@ -89,12 +98,34 @@ suite.define(() => {
       await page.getByText("No cloud worker profiles are configured.", { exact: true }).waitFor();
 
       await page.getByRole("button", { name: "Add profile" }).click();
+      expect(await page.getByRole("combobox", { name: "Machine class", exact: true }).count()).toBe(
+        0,
+      );
       await page.getByLabel("Profile ID").fill("build-fleet");
       await page.getByLabel("Crabbox backend").fill("hetzner");
       await waitForSettledFormControls(page, [
         { locator: page.getByLabel("Profile ID"), value: "build-fleet" },
         { locator: page.getByLabel("Crabbox backend"), value: "hetzner" },
       ]);
+      const machineClass = page.getByRole("textbox", { name: "Machine class", exact: true });
+      await expect.poll(() => machineClass.inputValue()).toBe("");
+      expect(await machineClass.getAttribute("list")).toBeNull();
+      expect(
+        await page
+          .locator("openclaw-cloud-workers-page datalist, openclaw-cloud-workers-page option")
+          .count(),
+      ).toBe(0);
+      for (const invalidClass of ["", " ", "x".repeat(129)]) {
+        await machineClass.fill(invalidClass);
+        await waitForSettledFormControls(page, [{ locator: machineClass, value: invalidClass }]);
+        await page.getByRole("button", { name: "Save" }).click();
+        await expect
+          .poll(() => page.getByRole("alert").textContent())
+          .toBe("Enter a machine class of 1 to 128 characters.");
+        expect(await gateway.getRequests("config.patch")).toHaveLength(0);
+      }
+      await machineClass.fill("standard");
+      await waitForSettledFormControls(page, [{ locator: machineClass, value: "standard" }]);
       await gateway.deferNext("config.patch");
       const addRequestCount = (await gateway.getRequests("config.patch")).length;
       await page.getByRole("button", { name: "Save" }).click();
@@ -118,14 +149,19 @@ suite.define(() => {
           },
         },
       });
+      // The saved snapshot includes provider-owned fields absent from this editor.
       const buildFleet = {
         provider: "crabbox",
         install: "bundle",
+        label: "Build fleet",
         settings: {
           provider: "hetzner",
           class: "standard",
           ttl: "8h",
           idleTimeout: "45m",
+          region: "eu-west-1",
+          resources: { cpu: 6, memoryGiB: 12 },
+          providerOptions: { image: "qa-base" },
         },
       };
       // Keep the mocked config.get consistent with the patch response: the
@@ -148,25 +184,30 @@ suite.define(() => {
       await page.getByText("Gateway restart required.", { exact: true }).waitFor();
 
       await page.getByRole("button", { name: "Edit" }).click();
-      await page.getByLabel("Machine class").selectOption("custom");
-      await page.getByLabel("Custom machine class").fill("ccx53");
+      await expect.poll(() => machineClass.inputValue()).toBe("standard");
+      await machineClass.fill("batch/ARM64.v2");
+      await page.getByLabel("Crabbox backend").fill("daytona");
       await page.getByLabel("Max lifetime").fill("12h");
       await page
         .locator(".settings-row")
         .filter({ hasText: "Desktop" })
         .locator("wa-switch")
         .click();
-      await page.getByLabel("Crabbox binary").fill("/opt/bin/crabbox");
+      await page.getByLabel("Crabbox binary").fill("/opt/bin/crabbox-draft");
       await waitForSettledFormControls(page, [
-        { locator: page.getByLabel("Machine class", { exact: true }), value: "custom" },
-        { locator: page.getByLabel("Custom machine class"), value: "ccx53" },
+        { locator: machineClass, value: "batch/ARM64.v2" },
+        { locator: page.getByLabel("Crabbox backend"), value: "daytona" },
         { locator: page.getByLabel("Max lifetime"), value: "12h" },
         {
           locator: page.getByRole("switch", { name: "Desktop", exact: true }),
           checked: true,
         },
-        { locator: page.getByLabel("Crabbox binary"), value: "/opt/bin/crabbox" },
+        { locator: page.getByLabel("Crabbox binary"), value: "/opt/bin/crabbox-draft" },
       ]);
+      expect(await page.getByRole("combobox", { name: "Machine class", exact: true }).count()).toBe(
+        0,
+      );
+      expect(await machineClass.getAttribute("list")).toBeNull();
       const saveButton = page.getByRole("button", { name: "Save" });
       const configGetCount = (await gateway.getRequests("config.get")).length;
       await gateway.deferNext("config.get");
@@ -193,31 +234,31 @@ suite.define(() => {
         cloudWorkers: {
           profiles: {
             "build-fleet": {
-              provider: "crabbox",
-              install: "bundle",
+              ...buildFleet,
               settings: {
-                provider: "hetzner",
-                class: "ccx53",
+                ...buildFleet.settings,
+                provider: "daytona",
+                class: "batch/ARM64.v2",
                 ttl: "12h",
                 idleTimeout: "45m",
                 setup: null,
                 desktop: true,
-                binary: "/opt/bin/crabbox",
+                binary: "/opt/bin/crabbox-draft",
               },
             },
           },
         },
       });
       const editedFleet = {
-        provider: "crabbox",
-        install: "bundle",
+        ...buildFleet,
         settings: {
-          provider: "hetzner",
-          class: "ccx53",
+          ...buildFleet.settings,
+          provider: "daytona",
+          class: "batch/ARM64.v2",
           ttl: "12h",
           idleTimeout: "45m",
           desktop: true,
-          binary: "/opt/bin/crabbox",
+          binary: "/opt/bin/crabbox-draft",
         },
       };
       // Keep the mocked config.get consistent with the patch response: the
@@ -236,14 +277,23 @@ suite.define(() => {
         config: { cloudWorkers: { profiles: { "build-fleet": editedFleet } } },
       });
 
-      await page.getByText(/Class: ccx53/).waitFor();
+      await page.getByText("Class: batch/ARM64.v2", { exact: false }).waitFor();
+      await page.getByRole("button", { name: "Edit", exact: true }).click();
+      await waitForSettledFormControls(page, [
+        { locator: machineClass, value: "batch/ARM64.v2" },
+        { locator: page.getByLabel("Crabbox backend"), value: "daytona" },
+        { locator: page.getByLabel("Crabbox binary"), value: "/opt/bin/crabbox-draft" },
+      ]);
+      await page.getByRole("button", { name: "Cancel" }).click();
 
       await page.getByRole("button", { name: "Add profile" }).click();
       await page.getByLabel("Profile ID").fill("pending");
       await page.getByLabel("Crabbox backend").fill("aws");
+      await machineClass.fill("custom");
       await waitForSettledFormControls(page, [
         { locator: page.getByLabel("Profile ID"), value: "pending" },
         { locator: page.getByLabel("Crabbox backend"), value: "aws" },
+        { locator: machineClass, value: "custom" },
       ]);
       await gateway.deferNext("config.patch");
       const pendingRequestCount = (await gateway.getRequests("config.patch")).length;
@@ -256,7 +306,7 @@ suite.define(() => {
             pending: {
               provider: "crabbox",
               install: "bundle",
-              settings: { provider: "aws", class: "standard" },
+              settings: { provider: "aws", class: "custom" },
             },
           },
         },
@@ -266,7 +316,7 @@ suite.define(() => {
         install: "bundle",
         settings: {
           provider: "aws",
-          class: "standard",
+          class: "custom",
           ttl: "8h",
           idleTimeout: "45m",
         },
@@ -286,6 +336,14 @@ suite.define(() => {
         },
       });
       await page.getByText("Restart required", { exact: true }).waitFor();
+      await page
+        .locator(".settings-row")
+        .filter({
+          has: page.locator("code", { hasText: /^pending$/ }),
+        })
+        .getByRole("button", { name: "Edit", exact: true })
+        .click();
+      await expect.poll(() => machineClass.inputValue()).toBe("custom");
     } finally {
       await context.close();
     }
@@ -316,9 +374,11 @@ suite.define(() => {
       const backend = page.getByLabel("Crabbox backend");
       await profileId.fill("reconnect-proof");
       await backend.fill("hetzner");
+      await page.getByLabel("Machine class", { exact: true }).fill("standard");
       await waitForSettledFormControls(page, [
         { locator: profileId, value: "reconnect-proof" },
         { locator: backend, value: "hetzner" },
+        { locator: page.getByLabel("Machine class", { exact: true }), value: "standard" },
       ]);
 
       await gateway.deferNext("config.patch");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2629,7 +2629,6 @@ export const en: TranslationMap = {
     idleFact: "Idle stop: {value}",
     desktopFact: "Desktop: {value}",
     providerList: "View supported backends",
-    customClass: "Custom…",
     fields: {
       profileId: "Profile ID",
       profileIdHelp: "Use letters, numbers, hyphens, or underscores.",
@@ -2637,9 +2636,8 @@ export const en: TranslationMap = {
       backendHelp: "The backend passed to Crabbox, such as AWS or Hetzner.",
       backendPlaceholder: "hetzner",
       machineClass: "Machine class",
-      machineClassHelp: "Choose a portable class or enter an exact provider instance type.",
-      customClass: "Custom machine class",
-      customClassPlaceholder: "c7a.24xlarge",
+      machineClassHelp:
+        "Enter a class accepted by the selected Crabbox backend and binary. The provider determines its effective sizing.",
       ttl: "Max lifetime",
       ttlHelp: "Use a positive Go duration such as 8h or 90m.",
       ttlPlaceholder: "8h",
@@ -2665,7 +2663,7 @@ export const en: TranslationMap = {
       profileExists: "Choose another profile ID; this one already exists.",
       profileMissing: "This profile changed or was removed. Reload the page and try again.",
       backend: "Enter a Crabbox backend, such as aws or hetzner.",
-      machineClass: "Choose a machine class or enter an instance type up to 128 characters.",
+      machineClass: "Enter a machine class of 1 to 128 characters.",
       ttl: "Enter a positive Go duration for max lifetime, such as 8h or 90m.",
       idleTimeout: "Enter a positive Go duration for idle stop, such as 45m.",
       binary: "Enter an absolute Crabbox binary path or leave the field empty.",

--- a/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.test.ts
@@ -26,6 +26,24 @@ const configuredProfile = {
 };
 
 describe("cloud worker settings state", () => {
+  it.each([undefined, ""])("requires an explicit class for an empty draft (%j)", (machineClass) => {
+    const profile = readCloudWorkerProfiles({
+      cloudWorkers: {
+        profiles: {
+          production: {
+            ...configuredProfile,
+            settings: { ...configuredProfile.settings, class: machineClass },
+          },
+        },
+      },
+    })[0];
+    const draft = createCloudWorkerDraft(machineClass === undefined ? undefined : profile);
+    expect(draft.machineClass).toBe("");
+    expect(
+      validateCloudWorkerDraft({ ...draft, id: "new-profile", backend: "hetzner" }, {}, null),
+    ).toBe("machineClass");
+  });
+
   it("distinguishes empty, advertised, and restart-required profiles", () => {
     expect(readCloudWorkerProfiles({})).toEqual([]);
     expect(
@@ -61,7 +79,13 @@ describe("cloud worker settings state", () => {
     ["idleTimeout", { idleTimeout: "0m" }],
     ["binary", { binary: "relative/crabbox" }],
   ] as const)("returns %s for an invalid add draft", (expected, patch) => {
-    const draft = { ...createCloudWorkerDraft(), id: "new-profile", backend: "hetzner", ...patch };
+    const draft = {
+      ...createCloudWorkerDraft(),
+      id: "new-profile",
+      backend: "hetzner",
+      machineClass: "standard",
+      ...patch,
+    };
     expect(validateCloudWorkerDraft(draft, { production: configuredProfile }, null)).toBe(expected);
   });
 
@@ -104,25 +128,38 @@ describe("cloud worker settings state", () => {
     });
   });
 
-  it("preserves forwarded setup environment while its setup command remains configured", () => {
-    const config = { cloudWorkers: { profiles: { production: configuredProfile } } };
-    const draft = createCloudWorkerDraft(readCloudWorkerProfiles(config)[0]);
+  it.each(["standard", "fast", "large", "beast", "custom", "batch/ARM64.v2", "x".repeat(128)])(
+    "preserves class %s and hidden settings when backend and binary change",
+    (machineClass) => {
+      const profile = {
+        ...configuredProfile,
+        settings: { ...configuredProfile.settings, class: machineClass },
+      };
+      const config = { cloudWorkers: { profiles: { production: profile } } };
+      const draft = {
+        ...createCloudWorkerDraft(readCloudWorkerProfiles(config)[0]),
+        backend: "hetzner",
+        binary: "/opt/crabbox-next",
+      };
 
-    expect(buildCloudWorkerUpsertPatch(config, draft, "production")).toMatchObject({
-      patch: {
-        cloudWorkers: {
-          profiles: {
-            production: {
-              settings: {
-                setup: "install-node",
-                setupEnv: ["OPENCLAW_WORKER_ARTIFACT_TOKEN"],
+      expect(buildCloudWorkerUpsertPatch(config, draft, "production")).toEqual({
+        patch: {
+          cloudWorkers: {
+            profiles: {
+              production: {
+                ...profile,
+                settings: {
+                  ...profile.settings,
+                  provider: "hetzner",
+                  binary: "/opt/crabbox-next",
+                },
               },
             },
           },
         },
-      },
-    });
-  });
+      });
+    },
+  );
 
   it.each([undefined, []])("keeps empty setup environment unchanged (%j)", (setupEnv) => {
     const existingSettings = Object.fromEntries(

--- a/ui/src/pages/cloud-workers/cloud-worker-config.ts
+++ b/ui/src/pages/cloud-workers/cloud-worker-config.ts
@@ -1,9 +1,6 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
-export const CLOUD_WORKER_MACHINE_CLASSES = ["standard", "fast", "large", "beast"] as const;
-const CLOUD_WORKER_MACHINE_CLASS_IDS = new Set<string>(CLOUD_WORKER_MACHINE_CLASSES);
-
 export type CloudWorkerProfileDraft = {
   id: string;
   backend: string;
@@ -13,7 +10,6 @@ export type CloudWorkerProfileDraft = {
   setup: string;
   desktop: boolean;
   binary: string;
-  customClass: boolean;
 };
 
 export type ConfiguredCloudWorkerProfile = {
@@ -92,17 +88,15 @@ export function readCloudWorkerProfiles(
 export function createCloudWorkerDraft(
   profile?: ConfiguredCloudWorkerProfile,
 ): CloudWorkerProfileDraft {
-  const machineClass = profile?.machineClass || "standard";
   return {
     id: profile?.id ?? "",
     backend: profile?.backend ?? "",
-    machineClass,
+    machineClass: profile?.machineClass ?? "",
     ttl: profile?.ttl || "8h",
     idleTimeout: profile?.idleTimeout || "45m",
     setup: profile?.setup ?? "",
     desktop: profile?.desktop ?? false,
     binary: profile?.binary ?? "",
-    customClass: !CLOUD_WORKER_MACHINE_CLASS_IDS.has(machineClass),
   };
 }
 

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -26,7 +26,6 @@ import { SubscriptionsController } from "../../lit/subscriptions-controller.ts";
 import {
   buildCloudWorkerDeletePatch,
   buildCloudWorkerUpsertPatch,
-  CLOUD_WORKER_MACHINE_CLASSES,
   cloudWorkerProfileStatus,
   createCloudWorkerDraft,
   readCloudWorkerProfiles,
@@ -41,9 +40,7 @@ type EditorState = { kind: "add" } | { kind: "edit"; profileId: string } | null;
 
 function formControlValue(event: Event): string {
   const target = event.currentTarget;
-  return target instanceof HTMLInputElement ||
-    target instanceof HTMLSelectElement ||
-    target instanceof HTMLTextAreaElement
+  return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement
     ? target.value
     : "";
 }
@@ -375,7 +372,6 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     const busy = this.busyProfileId !== null;
     const canSave = this.canManage();
     const editing = this.editor.kind === "edit";
-    const classMode = this.draft.customClass ? "custom" : this.draft.machineClass;
     return renderSettingsSection(
       {
         title: editing ? t("cloudWorkersPage.editProfile") : t("cloudWorkersPage.addProfile"),
@@ -414,41 +410,15 @@ class CloudWorkersPage extends OpenClawLightDomElement {
         renderSettingsRow({
           title: t("cloudWorkersPage.fields.machineClass"),
           description: t("cloudWorkersPage.fields.machineClassHelp"),
-          stacked: this.draft.customClass,
-          control: html`
-            <select
-              class="settings-select"
-              aria-label=${t("cloudWorkersPage.fields.machineClass")}
-              .value=${classMode}
-              ?disabled=${busy}
-              @change=${(event: Event) => {
-                const value = formControlValue(event);
-                this.patchDraft(
-                  value === "custom"
-                    ? { customClass: true, machineClass: "" }
-                    : { customClass: false, machineClass: value },
-                );
-              }}
-            >
-              ${CLOUD_WORKER_MACHINE_CLASSES.map(
-                (value) => html`<option value=${value}>${value}</option>`,
-              )}
-              <option value="custom">${t("cloudWorkersPage.customClass")}</option>
-            </select>
-            ${this.draft.customClass
-              ? html`<input
-                  class="settings-input mono"
-                  aria-label=${t("cloudWorkersPage.fields.customClass")}
-                  placeholder=${t("cloudWorkersPage.fields.customClassPlaceholder")}
-                  autocomplete="off"
-                  spellcheck="false"
-                  .value=${this.draft.machineClass}
-                  ?disabled=${busy}
-                  @input=${(event: Event) =>
-                    this.patchDraft({ machineClass: formControlValue(event) })}
-                />`
-              : nothing}
-          `,
+          control: html`<input
+            class="settings-input mono"
+            aria-label=${t("cloudWorkersPage.fields.machineClass")}
+            autocomplete="off"
+            spellcheck="false"
+            .value=${this.draft.machineClass}
+            ?disabled=${busy}
+            @input=${(event: Event) => this.patchDraft({ machineClass: formControlValue(event) })}
+          />`,
         }),
         renderSettingsRow({
           title: t("cloudWorkersPage.fields.ttl"),


### PR DESCRIPTION
Closes #130786
Related: #130766 (unsupported per-session class overrides) and #130684 (CPU/RAM in larger picker catalogs), both already merged and intentionally unchanged.

## What Problem This Solves

Fixes an issue where operators adding or editing Cloud worker profiles were offered a fixed machine-class list unrelated to their selected Crabbox backend and binary. New or empty drafts silently selected `standard` before the operator supplied a class.

## Why This Change Was Made

Use one Machine class text field and leave new drafts empty. Saved-profile discovery cannot authorize suggestions for an unsaved draft whose backend or binary differs, so this removes the preset/custom split instead of inventing another discovery or sizing contract. Provider-owned configuration and provisioning, reuse, and placement behavior stay unchanged.

## User Impact

Operators can enter any backend-accepted class, including the literal `custom`, without a mode switch. Existing spelling and case survive save/reopen; changing backend or binary leaves the class untouched. Empty/whitespace and classes longer than 128 characters still produce a visible validation error. Hidden settings, nested resources, and provider options are preserved. The [Cloud workers documentation](https://docs.openclaw.ai/gateway/cloud-workers) explains this behavior.

This is AI-assisted, maintainer-directed work. No new config option, schema, provider API, runtime route, or dependency is added. Native-size selection and catalog truncation are separate work.

## Evidence

The pre-fix regression had two failing empty-draft unit cases (`standard` instead of empty) and one failing browser case (the Machine class combobox still existed). The repaired code passed:

- `node scripts/run-vitest.mjs ui/src/pages/cloud-workers/cloud-worker-config.test.ts` — 24 tests.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/cloud-workers-settings.e2e.test.ts` — 7 tests, including add, invalid inputs, edit, backend/binary changes, hidden settings, save/reopen, literal `custom`, reconnect, deletion, and admin scope.
- Scoped oxfmt, oxlint/stylelint, UI production and test typechecks, and keyless i18n verification.
- `pnpm ui:build` — production bundle and precompressed/performance guards passed; rerun after rebase: startup JavaScript 333.0 KiB gzip against the existing 335.5 KiB limit.
- Fresh structured autoreview — no accepted/actionable findings. `git diff --check` passed.

The screenshots below are inspected Chromium captures of the actual editor with synthetic data and mocked Gateway responses: before, and after save/reopen. They are not live cloud provisioning evidence; no provider API behavior changes in this repair.

Production LOC: +14/-52 (net -38). Tests: +132/-35 (net +97). Docs: +2/-0. Only six files change. Exact-head hosted CI and native landing verification are recorded before merge.

![Before: new Cloud worker profile with an invented standard class and preset selector](https://github.com/user-attachments/assets/6cbf0763-6c04-485f-833b-3ff43e282655)

![After save and reopen: explicit class text retained with changed backend and binary](https://github.com/user-attachments/assets/333c2b2b-a747-4480-80d7-a6eed7e55d2b)

### Review follow-through

ClawSweeper’s P2 finding and rank-up move were first addressed in [the separate documentation correction](https://github.com/openclaw/openclaw/commit/27e0a9276f432437d93c771329f2cee50670e068). While CI ran, #130814 landed a fuller correction on main: OpenClaw requires `class`, and the direct Daytona backend currently rejects the forwarded class flag. The required conflict rebase preserves that landed warning, class explanation, providers-describe guidance, and credential guidance; the smaller docs commit became redundant and was dropped. The incorrect default claim is gone. This PR changes no runtime default, provider API, or catalog behavior.

ClawSweeper's automated browser probe did not observe its expected suite-title text within 30 seconds. The same command was independently rerun to completion on repair head `1dc772039a9`, whose settings UI and test source remains identical after the docs follow-up and conflict rebase: 7 passed in 27.00 seconds; the normal reporter prints aggregate counts rather than that suite title. These are Chromium tests with mocked Gateway responses, not cloud provisioning.

Post-commit unit verification again passed 24 tests, and the complete six-file changed gate finished its guards, dead-export scans, i18n, core-test/UI typechecks, and scoped lint. The first hosted CI attempt passed all four browser shards and the real-Gateway UI lane, but `checks-ui` hit a 1000 ms onboarding-resume wait timeout in the unchanged `first-run.test.ts`. That file passed all 16 tests in isolation, and the same code passed the main UI job in run 33049543664. The single unchanged failed-job retry passed in [CI run 33049756627, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33049756627/attempts/2), including the required CI gate. [Exact-head CI run 33051993519](https://github.com/openclaw/openclaw/actions/runs/33051993519) passed on `27e0a9276f432437d93c771329f2cee50670e068`: 69 successful jobs and 16 intentional skips, including the required CI gate, all four browser shards, UI unit tests, real-Gateway UI, build, docs, and core checks. Native review artifacts and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 130787` passed on that head before main acquired the conflicting documentation correction. The branch was then rebased to preserve #130814. Head `617e07600e1c53a65594041839367e45603f5747` retains the original repair’s exact patch ID; fresh independent review, the 24-unit/7-browser focused suites, UI build, and native review artifacts passed again. [Exact-head CI run 33054026572](https://github.com/openclaw/openclaw/actions/runs/33054026572) passed on that rebased head: 69 successful jobs and 16 intentional skips, including the required gate, all browser shards, UI unit tests, real-Gateway UI, build, docs, and core checks. Native preparation was repeated successfully on the exact head before merge. The latest completed ClawSweeper review reports no actionable findings; its remaining rank-up request for green exact-head CI is fulfilled. Follow-up: make that test await the existing initial-decision completion signal rather than module-import wall time. No timeouts, assertions, or source code were changed for the retry.

Landed via native squash merge as [fe2af3001c68a83fa7fe532ac15b420398f03a33](https://github.com/openclaw/openclaw/commit/fe2af3001c68a83fa7fe532ac15b420398f03a33). The landed patch ID matches the original reviewed repair. Subsequent main documentation updates in #130824 (removing the unsupported Daytona setup recipe) and #130828 (catalog probe recovery guidance) were also preserved; this PR’s final docs diff is only the two-line Configuration addition.
