### PR TITLE
refactor(ui): reuse protocol file response types

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -4,6 +4,7 @@ import type {
   CronListParams,
   CronRunLogEntry as ProtocolCronRunLogEntry,
   CronRunsParams,
+  SessionsFilesListResult as ProtocolSessionsFilesListResult,
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { AgentsListResult as ProtocolAgentsListResult } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import type { ChannelsStatusResult } from "../../../packages/gateway-protocol/src/schema/channels.js";
@@ -23,6 +24,12 @@ import type {
   SessionsPatchResultBase,
 } from "../../../src/shared/session-types.js";
 export type {
+  AgentsFileEntry as AgentFileEntry,
+  AgentsFilesListResult,
+  AgentsFilesGetResult,
+  AgentsFilesSetResult,
+  SessionsFilesGetResult as SessionWorkspaceGetResult,
+  SessionsFilesSetResult as SessionWorkspaceSetResult,
   CronJob,
   CronRunLogEntry,
   UpdateAvailable,
@@ -302,70 +309,6 @@ export type AgentIdentityResult = {
   emoji?: string;
 };
 
-export type AgentFileEntry = {
-  name: string;
-  path: string;
-  missing: boolean;
-  // Absence is a normal workspace state (optional profile files, MEMORY.md before
-  // anything is written); the editor offers these for creation instead of flagging them.
-  expectedAbsent?: boolean;
-  size?: number;
-  updatedAtMs?: number;
-  content?: string;
-};
-
-export type AgentsFilesListResult = {
-  agentId: string;
-  workspace: string;
-  files: AgentFileEntry[];
-};
-
-export type AgentsFilesGetResult = {
-  agentId: string;
-  workspace: string;
-  file: AgentFileEntry;
-};
-
-export type AgentsFilesSetResult = {
-  ok: true;
-  agentId: string;
-  workspace: string;
-  file: AgentFileEntry;
-};
-
-type SessionWorkspaceFileEntry = {
-  path: string;
-  workspacePath?: string;
-  name: string;
-  kind: "modified" | "read";
-  missing: boolean;
-  size?: number;
-  updatedAtMs?: number;
-  content?: string;
-  /** sha256 hex of the file bytes; the CAS token for sessions.files.set. */
-  hash?: string;
-  mimeType?: string;
-  contentEncoding?: "utf8" | "base64";
-  previewKind?: "text" | "image" | "unsupported";
-};
-
-type SessionWorkspaceBrowserEntry = {
-  path: string;
-  name: string;
-  kind: "file" | "directory";
-  sessionKind?: "modified" | "read" | "mixed";
-  size?: number;
-  updatedAtMs?: number;
-};
-
-type SessionWorkspaceBrowserResult = {
-  path: string;
-  parentPath?: string;
-  search?: string;
-  entries: SessionWorkspaceBrowserEntry[];
-  truncated?: boolean;
-};
-
 type SessionWorkspaceArtifactEntry = {
   id: string;
   type: string;
@@ -378,25 +321,9 @@ type SessionWorkspaceArtifactEntry = {
   };
 };
 
-export type SessionWorkspaceListResult = {
-  sessionKey: string;
-  root?: string;
-  gitCheckout?: boolean;
-  files: SessionWorkspaceFileEntry[];
-  browser?: SessionWorkspaceBrowserResult;
+// The workspace view joins file results with separately fetched artifacts.
+export type SessionWorkspaceListResult = ProtocolSessionsFilesListResult & {
   artifacts?: SessionWorkspaceArtifactEntry[];
-};
-
-export type SessionWorkspaceGetResult = {
-  sessionKey: string;
-  root?: string;
-  file: SessionWorkspaceFileEntry;
-};
-
-export type SessionWorkspaceSetResult = {
-  sessionKey: string;
-  root?: string;
-  file: SessionWorkspaceFileEntry;
 };
 
 export type ArtifactDownloadResult = {

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -11,6 +11,7 @@ import {
   controlUiSessionUrl,
   createChatFlowE2eSuite,
   installMockGateway,
+  pauseVirtualClock,
 } from "./chat-flow.test-support.ts";
 
 const proofDir = path.join(
@@ -536,6 +537,8 @@ suite.define(() => {
         viewport: { height: 900, width: 1280 },
       },
       async ({ page }) => {
+        // Browser RPC time must not consume the hover-delay assertion windows.
+        await page.clock.install();
         await installMockGateway(page, {
           featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
           methodResponses: {
@@ -559,6 +562,7 @@ suite.define(() => {
             () => customElements.get("openclaw-session-progress-hovercard-provider") === undefined,
           ),
         ).toBe(true);
+        await pauseVirtualClock(page);
 
         const pointer = async (
           locator: typeof first,
@@ -574,9 +578,11 @@ suite.define(() => {
           });
 
         await first.hover();
+        await expect.poll(() => first.getAttribute("aria-haspopup")).toBe("dialog");
         expect(await card.count()).toBe(0);
-        await page.waitForTimeout(300);
+        await page.clock.runFor(449);
         expect(await card.count()).toBe(0);
+        await page.clock.runFor(1);
         await card.waitFor({ state: "visible" });
         const firstBounds = await first.boundingBox();
         expect(firstBounds).not.toBeNull();
@@ -586,21 +592,29 @@ suite.define(() => {
           clientX: (firstBounds?.x ?? 0) + (firstBounds?.width ?? 0),
           clientY: (firstBounds?.y ?? 0) + (firstBounds?.height ?? 0) / 2,
         });
-        await page.waitForTimeout(150);
+        await page.clock.runFor(219);
         expect(await card.count()).toBe(1);
         await page.mouse.move(
           (cardBounds?.x ?? 0) + (cardBounds?.width ?? 0) / 2,
           (cardBounds?.y ?? 0) + (cardBounds?.height ?? 0) / 2,
         );
+        await page.clock.runFor(1);
         expect(await card.count()).toBe(1);
         await page.mouse.move(900, 800);
-        await page.waitForTimeout(50);
+        await page.clock.runFor(99);
         expect(await card.count()).toBe(1);
-        await expect.poll(() => card.count()).toBe(0);
-        await page.waitForTimeout(300);
+        await page.clock.runFor(1);
+        expect(
+          await card.evaluateAll((cards) =>
+            cards.every((element) => element.getAttribute("data-open") === "false"),
+          ),
+        ).toBe(true);
+        await page.clock.runFor(300);
+        expect(await card.count()).toBe(0);
 
         await first.hover();
         await first.locator("a.sidebar-recent-session__link").focus();
+        await page.clock.runFor(1);
         await card.waitFor({ state: "visible" });
         await expect
           .poll(() => card.locator(".session-hovercard__title").textContent())
@@ -608,28 +622,34 @@ suite.define(() => {
         await page.keyboard.press("Escape");
         await expect.poll(() => card.count()).toBe(0);
         await page.mouse.move(900, 800);
-        await page.waitForTimeout(300);
+        await page.clock.runFor(300);
 
         await first.hover();
         expect(await card.count()).toBe(0);
+        await page.clock.runFor(449);
+        expect(await card.count()).toBe(0);
+        await page.clock.runFor(1);
         await card.waitFor({ state: "visible" });
 
         await second.hover();
-        await page.waitForTimeout(40);
+        await page.clock.runFor(79);
         expect(await card.locator(".session-hovercard__title").textContent()).toBe(
           "First timing row",
         );
-        await expect
-          .poll(() => card.locator(".session-hovercard__title").textContent())
-          .toBe("Second timing row");
+        await page.clock.runFor(1);
+        expect(await card.locator(".session-hovercard__title").textContent()).toBe(
+          "Second timing row",
+        );
 
         await card.hover();
         expect(await card.count()).toBe(1);
         await page.mouse.move(900, 800);
-        await expect.poll(() => card.count()).toBe(0);
-        await page.waitForTimeout(300);
+        await page.clock.runFor(100);
+        await page.clock.runFor(300);
+        expect(await card.count()).toBe(0);
 
         await first.hover();
+        await page.clock.runFor(450);
         await card.waitFor({ state: "visible" });
         await first
           .getByRole("button", { name: "Open session menu: First timing row" })
@@ -639,7 +659,7 @@ suite.define(() => {
           .poll(() => page.locator("openclaw-session-menu").getByRole("menuitem").count())
           .toBeGreaterThan(0);
         await second.dispatchEvent("pointerover", { pointerType: "mouse" });
-        await page.waitForTimeout(500);
+        await page.clock.runFor(500);
         expect(await card.count()).toBe(0);
       },
     );


### PR DESCRIPTION
## What Problem This Solves

The Control UI duplicates agent-file and session-workspace response shapes already owned by the gateway protocol. Maintaining both copies creates unnecessary drift risk when file metadata evolves. This is a maintainer-requested cleanup, not a claimed user-facing bug fix.

## Why This Change Was Made

Reuse the existing protocol types for seven UI exports and remove their copied declarations. The UI keeps its existing exported names and its separate artifact metadata: the workspace view combines `sessions.files.list` with separately fetched `artifacts.list` results. No new helper, module, runtime import, protocol version, schema, dependency, or public field is introduced.

Ordinary CI exposed a flaky existing hovercard assertion: a 40 ms sleep after a real hover did not mean the browser was still before its 80 ms timer. The test now reuses the existing virtual-clock helper, preserves all eight scenarios and real pointer/keyboard/menu interactions, and checks the exact cold-open and sweep boundaries. Native CSS transitions remain enabled; one close-deadline browser evaluation accepts a closed card or a card already removed by its normal opacity transition.

Production LOC: **+9/-82 (net -73)**. Tests: **+33/-13 (net +20)**. The only production change is `ui/src/api/types.ts`; an adjacent correction keeps the existing hovercard timing test deterministic.

## User Impact

No user-visible behavior or layout change. File editing, expected-absent files, nested workspace browsing, image metadata, CAS hashes, and artifact joins retain their existing contracts. This change was AI-assisted with Codex; the source, callers, dependency types, and actual proof were inspected directly.

## Evidence

- The final two-file candidate passed all 19 canonical changed checks in a pinned Linux environment, including complete UI/core-test type checks, typed lint, formatting, UI styles/i18n, dependency guards, and all three dead-export scans.
- All **41 retained tests** passed: agent-file editing (10), file lifecycle (8), and session-workspace behavior (23). No tests were removed or weakened.
- Exact TypeScript 6.0.3 / TypeBox 1.3.16 compiler proof preserved all **100 UI exports**. The seven reused shapes passed recursive structure, optional/readonly/literal/index-signature, excess-property, nested-rejection, and bidirectional-assignability checks with `exactOptionalPropertyTypes` both enabled and disabled. Runtime type erasure was byte-identical.
- Three real production UI builds—baseline, repeated baseline, and candidate—ran sequentially at the **same path**, with identical supported build metadata. All asset/performance validators passed. Every filename and byte hash across **all 1,827 output files** matched exactly, including JavaScript, CSS, source maps, gzip and Brotli assets. No output normalization or exclusions were used. All 34,208 tracked source paths were fenced before/after; only the intended type file differed.
- Authenticated, isolated read-only Codex precommit review is complete with no remaining actionable findings. The original scoped type-contract partition A is retained with every owner/artifact hash revalidated; the necessary revised partition B reviews the complete current two-file diff and timing owners after its CSS-cleanup finding was reproduced and fixed. Fresh published-head independent review and ordinary exact-head CI remain required before landing.

The pinned environment was Linux Node 24.19.0, Vitest 4.1.11 and Vite 8.2.1, with the frozen dependency fingerprint and all package/build source inputs verified before dependency reuse. The owned [Testbox run](https://github.com/openclaw/openclaw/actions/runs/33046876162) was stopped after its commands completed; delegated command exit codes, not the lease workflow's cleanup status, are the execution proof.

Commands exercised:

```sh
node scripts/check-changed.mjs --staged --timed
node scripts/run-vitest.mjs ui/src/pages/agents/files.test.ts ui/src/pages/agents/agent-file-lifecycle.test.ts ui/src/pages/chat/components/chat-session-workspace.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-progress-hovercard.e2e.test.ts
node scripts/ui.js build
```

An initial comparison built baseline and candidate in different directories: both builds passed, but their output comparison failed. Investigation localized the executable difference to redundant memoized TypeBox initialization calls; the original logs and generated code were retained. The controlled same-path repeat above then proved literal full-output equality. This PR neither changes the bundler nor claims path-independent build determinism. No live external API or screenshot-based behavior claim is made for this type-only change.

## Adjacent CI timing repair

The original [ordinary CI run](https://github.com/openclaw/openclaw/actions/runs/33049784158) failed the existing cold/bridge/sweep/menu test: it observed the second row where its wall-clock assertion still expected the first. No blind CI retry was used. Bounded browser observations measured the RPC overhead and confirmed the unchanged 80 ms timer, but did not reproduce that chance failure; the hosted failure remains the pre-fix reproduction.

The revised test passed all eight scenarios in the pinned [browser proof environment](https://github.com/openclaw/openclaw/actions/runs/33054558052). Four deliberate timing mutations were rejected: sweep 80→0 and 80→160, and cold-open 450→0 and 450→900. Each failed at its intended pre-/at-deadline assertion, and the original runtime bytes were restored. No production timer, CSS rule, timeout, or test-only production seam changes.

That machine's backing workflow was later cancelled by the provider during the changed gate; the interrupted attempt is retained as a failure. A single [recovery environment](https://github.com/openclaw/openclaw/actions/runs/33056231208), hydrated from this PR's published branch to preserve its dependency cohort, completed all 19 checks and final source fences. No memory/concurrency override or CI retry was used to obtain that result.

The recovery machine was stopped after the final gate and review completed; no proof lease remains active.

Review caught a second clock-domain issue in the first correction: pausing JavaScript does not pause CSS. A real Chromium trace showed the card marked closed at virtual 100 ms, then removed by a native opacity transition without further virtual-clock advance. The final close assertion performs one browser evaluation accepting either valid state; the 99 ms mounted assertion and later removal assertion remain. The original review finding and diagnostic records are retained rather than relabeled clean.

Provenance: the wall-clock assertion is carried from commit `434fd0c106902` (2026-08-23, code author Vyctor H. Brzezowski, #125068). No merger or automation-trigger attribution is inferred from blame. This is a test-only repair; no new operator-visible behavior is claimed.

## ClawSweeper disposition

The [latest available ClawSweeper review](https://github.com/openclaw/openclaw/pull/130789#issuecomment-5435996603) found no source defects and requested ordinary review and exact-head CI completion; it contains no separate rank-up moves. The local integrated review and final checks above are complete. A fresh independent published-head review and ordinary CI on the updated head remain required before landing; the old failed run is not being treated as green.
