### PR TITLE
refactor(twitch): use canonical outbound message adapter

### DIFF
--- a/extensions/twitch/src/outbound.test.ts
+++ b/extensions/twitch/src/outbound.test.ts
@@ -169,10 +169,11 @@ describe("outbound", () => {
       const { sendMessageTwitchInternal } = await import("./send.js");
 
       setupAccountContext();
+      const receipt = twitchTestReceipt("twitch-msg-123");
       vi.mocked(sendMessageTwitchInternal).mockResolvedValue({
         ok: true,
         messageId: "twitch-msg-123",
-        receipt: twitchTestReceipt("twitch-msg-123"),
+        receipt,
       });
 
       const proofResults = await verifyChannelMessageAdapterCapabilityProofs({
@@ -186,7 +187,11 @@ describe("outbound", () => {
               text: "Hello Twitch!",
               accountId: "default",
             });
-            expect(result?.receipt?.platformMessageIds).toEqual(["twitch-msg-123"]);
+            expect(result?.receipt).toBe(receipt);
+            expect(result).toMatchObject({
+              messageId: "twitch-msg-123",
+              timestamp: expect.any(Number),
+            });
           },
           media: async () => {
             const result = await twitchMessageAdapter.send?.media?.({
@@ -196,7 +201,12 @@ describe("outbound", () => {
               mediaUrl: "https://example.com/image.png",
               accountId: "default",
             });
-            expect(result?.receipt?.platformMessageIds).toEqual(["twitch-msg-123"]);
+            expect(result?.receipt).toBe(receipt);
+            expect(result).toMatchObject({
+              messageId: "twitch-msg-123",
+              timestamp: expect.any(Number),
+            });
+            expect(result?.receipt.parts.map((part) => part.kind)).toEqual(["text"]);
             expect(sendMessageTwitchInternal).toHaveBeenLastCalledWith(
               "testchannel",
               "image https://example.com/image.png",
@@ -226,40 +236,6 @@ describe("outbound", () => {
         { capability: "reconcileUnknownSend", status: "not_declared" },
         { capability: "afterSendSuccess", status: "not_declared" },
         { capability: "afterCommit", status: "not_declared" },
-      ]);
-    });
-
-    it("adapts outbound progress into message receipts", async () => {
-      const progress = {
-        channel: "twitch",
-        messageId: "twitch-progress-1",
-        receipt: twitchTestReceipt("twitch-progress-1"),
-      };
-      const sendText = twitchOutbound.sendText;
-      if (!sendText) {
-        throw new Error("Twitch text sending is not available.");
-      }
-      const sendSpy = vi.spyOn(twitchOutbound, "sendText").mockImplementationOnce(async (ctx) => {
-        await ctx.onDeliveryResult?.(progress);
-        return progress;
-      });
-      const onDeliveryResult = vi.fn();
-
-      try {
-        await twitchMessageAdapter.send?.text?.({
-          cfg: mockConfig,
-          to: "#testchannel",
-          text: "Hello Twitch!",
-          accountId: "default",
-          onDeliveryResult,
-        });
-      } finally {
-        sendSpy.mockRestore();
-      }
-
-      expect(onDeliveryResult).toHaveBeenCalledOnce();
-      expect(onDeliveryResult.mock.calls[0]?.[0]?.receipt.platformMessageIds).toEqual([
-        "twitch-progress-1",
       ]);
     });
   });

--- a/extensions/twitch/src/outbound.ts
+++ b/extensions/twitch/src/outbound.ts
@@ -5,12 +5,7 @@
  * Supports text and media (URL) sending with markdown stripping and chunking.
  */
 
-import {
-  createMessageReceiptFromOutboundResults,
-  defineChannelMessageAdapter,
-  type ChannelMessageSendResult,
-  type MessageReceiptPartKind,
-} from "openclaw/plugin-sdk/channel-outbound";
+import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/channel-outbound";
 import { normalizeStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { resolveTwitchAccountContext } from "./config.js";
@@ -204,65 +199,7 @@ export const twitchOutbound: ChannelOutboundAdapter = {
   },
 };
 
-function toTwitchMessageSendResult(
-  result: OutboundDeliveryResult,
-  kind: MessageReceiptPartKind,
-): ChannelMessageSendResult {
-  const receipt =
-    result.receipt ??
-    createMessageReceiptFromOutboundResults({
-      results: result.messageId ? [{ channel: "twitch", messageId: result.messageId }] : [],
-      kind,
-    });
-  return {
-    messageId: result.messageId || receipt.primaryPlatformMessageId,
-    receipt,
-  };
-}
-
-export const twitchMessageAdapter = defineChannelMessageAdapter({
+export const twitchMessageAdapter = createChannelMessageAdapterFromOutbound({
   id: "twitch",
-  durableFinal: {
-    capabilities: {
-      text: true,
-      media: true,
-      messageSendingHooks: true,
-    },
-  },
-  send: {
-    text: async (ctx) => {
-      if (!twitchOutbound.sendText) {
-        throw new Error("Twitch text sending is not available.");
-      }
-      const { onDeliveryResult, ...outboundCtx } = ctx;
-      const result = await twitchOutbound.sendText({
-        ...outboundCtx,
-        ...(onDeliveryResult
-          ? {
-              onDeliveryResult: async (progress) => {
-                await onDeliveryResult(toTwitchMessageSendResult(progress, "text"));
-              },
-            }
-          : {}),
-      });
-      return toTwitchMessageSendResult(result, "text");
-    },
-    media: async (ctx) => {
-      if (!twitchOutbound.sendMedia) {
-        throw new Error("Twitch media sending is not available.");
-      }
-      const { onDeliveryResult, ...outboundCtx } = ctx;
-      const result = await twitchOutbound.sendMedia({
-        ...outboundCtx,
-        ...(onDeliveryResult
-          ? {
-              onDeliveryResult: async (progress) => {
-                await onDeliveryResult(toTwitchMessageSendResult(progress, "media"));
-              },
-            }
-          : {}),
-      });
-      return toTwitchMessageSendResult(result, "media");
-    },
-  },
+  outbound: twitchOutbound,
 });


### PR DESCRIPTION
## What Problem This Solves

Twitch manually projected its `ChannelOutboundAdapter` into a message adapter even though the plugin SDK already owns that conversion through `createChannelMessageAdapterFromOutbound`.

The private bridge duplicated receipt construction, text/media dispatch, and delivery-result projection. That extra layer could drift from the shared adapter while obscuring that Twitch media is intentionally sent as a text message containing the media URL.

## Why This Change Was Made

This replaces the Twitch-only bridge with the canonical plugin SDK adapter and removes the redundant conversion tests. Twitch keeps its existing outbound implementation as the sole transport owner.

The canonical adapter also preserves the existing outbound timestamp on normalized message results; this is an intentional additive diagnostic field. Receipt identity, message IDs, media-as-text behavior, target resolution, and platform calls remain unchanged.

## User Impact

No user-visible behavior change is intended. Twitch text and media sends use the same transport path and results with one less internal translation layer.

## Evidence

- Focused owner and sibling coverage passes 55/55 tests across Twitch outbound/send/client-manager behavior and the shared outbound bridge.
- The complete two-path changed gate passes extension production/test types, scoped lint, plugin boundaries, dead-code checks, doctor checks, database/media/runtime-sidecar guards, and import-cycle checks.
- A full repository build passes all assets, nine unified tsdown targets, 64 external plugins, CLI bootstrap, 48 runtime postbuild modules, 147 SDK subpaths, UI/sidecars, and startup metadata.
- The Twitch hot-entry import profile passes 1/1 with max RSS 129.30 MB, baseline 43.11 MB, and delta 86.19 MB.
- Fresh isolated review reports no actionable findings.
- Production: +3/-66, net -63 lines. Tests: +13/-37, net -24 lines. Total: net -87 lines.
- No Zalo, Zalo-user, WhatsApp, shared plugin SDK, configuration, protocol, persistence, dependency, or public API change.

`CHANGELOG.md` is release-owned; this behavior-preserving internal cleanup needs no release entry.
