### PR TITLE
fix(status): show healthy channels as OK in deep health

### DIFF
--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -19,12 +19,16 @@ openclaw status --usage --agent work
 | Flag                    | Description                                                                                                     |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
 | `--all`                 | Full diagnosis (read-only, pasteable). Includes security audit, plugin compatibility, and memory-vector probes. |
-| `--deep`                | Runs live probes (WhatsApp Web + Telegram + Discord + Slack + Signal). Also enables the security audit.         |
+| `--deep`                | Requests channel health (live probes where supported). Also enables the security audit.                         |
 | `--usage`               | Prints normalized provider usage windows as `X% left`.                                                          |
 | `--agent <id>`          | Selects the agent auth/profile scope for `--usage`. Required when an explicit multi-agent fleet has no default. |
 | `--json`                | Machine-readable output.                                                                                        |
 | `--timeout <ms>`        | Probe timeout in milliseconds (default: `10000`).                                                               |
 | `--verbose` / `--debug` | Also print the raw Gateway target resolution before the report.                                                 |
+
+Channels without a probe, such as WhatsApp, report lifecycle health instead.
+In the Health table, `healthy` is `OK`; degraded lifecycle states and failed
+probes remain `WARN`. A lifecycle `OK` does not mean a live probe ran.
 
 Plain `openclaw status` stays on the fast read-only path and marks memory as
 `not checked` instead of unavailable when it skips memory inspection. Heavy

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -292,6 +292,65 @@ describe("status.command-sections", () => {
     ]);
   });
 
+  it.each([
+    { account: {}, status: "ok(OK)", detail: "healthy" },
+    {
+      account: { probe: { ok: false, error: "sync rejected" } },
+      status: "warn(WARN)",
+      detail: "failed (unknown) - sync rejected",
+    },
+    {
+      account: { healthState: "blocked" },
+      status: "warn(WARN)",
+      detail: "blocked",
+    },
+    {
+      account: { healthState: "unknown" },
+      status: "warn(WARN)",
+      detail: "unknown",
+    },
+    {
+      account: { statusState: "unstable" },
+      status: "warn(WARN)",
+      detail: "auth stabilizing",
+    },
+    {
+      account: { configured: false },
+      status: "muted(OFF)",
+      detail: "not configured",
+    },
+  ])("classifies the real channel health detail $detail", ({ account, status, detail }) => {
+    const health: HealthSummary = {
+      ok: true,
+      ts: 0,
+      durationMs: 42,
+      heartbeatSeconds: 60,
+      defaultAgentId: "main",
+      agents: [],
+      sessions: { path: "/tmp/sessions.json", count: 0, recent: [] },
+      channels: {
+        whatsapp: {
+          accountId: "default",
+          configured: true,
+          linked: true,
+          healthState: "healthy",
+          ...account,
+        },
+      },
+      channelOrder: ["whatsapp"],
+      channelLabels: { whatsapp: "WhatsApp" },
+    };
+    const rows = buildStatusHealthRows({
+      health,
+      formatHealthChannelLines,
+      ok: (value) => `ok(${value})`,
+      warn: (value) => `warn(${value})`,
+      muted: (value) => `muted(${value})`,
+    });
+
+    expect(rows).toContainEqual({ Item: "WhatsApp", Status: status, Detail: detail });
+  });
+
   it("marks activated plugin service failures as warnings in deep health rows", () => {
     const health: HealthSummary = {
       ok: true,

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -299,19 +299,16 @@ export function buildStatusHealthRows(params: {
     const detail = line.slice(colon + 1).trim();
     const normalized = normalizeLowercaseStringOrEmpty(detail);
     // Channel health format is string-based; classify known prefixes into table status chips.
-    const status = normalized.startsWith("ok")
-      ? params.ok("OK")
-      : normalized.startsWith("failed")
-        ? params.warn("WARN")
+    const status =
+      normalized === "healthy" || normalized.startsWith("ok") || normalized.startsWith("configured")
+        ? params.ok("OK")
         : normalized.startsWith("not configured")
           ? params.muted("OFF")
-          : normalized.startsWith("configured")
-            ? params.ok("OK")
-            : normalized.startsWith("linked")
-              ? params.ok("LINKED")
-              : normalized.startsWith("not linked")
-                ? params.warn("UNLINKED")
-                : params.warn("WARN");
+          : normalized.startsWith("linked")
+            ? params.ok("LINKED")
+            : normalized.startsWith("not linked")
+              ? params.warn("UNLINKED")
+              : params.warn("WARN");
     rows.push({ Item: item, Status: status, Detail: detail });
   }
   return rows;


### PR DESCRIPTION
Closes #130793

## What Problem This Solves

Fixes an issue where operators running `openclaw status --deep` would see a warning for a healthy channel when its health comes from lifecycle state rather than an active probe. A healthy WhatsApp account could appear as `WARN | healthy`.

## Why This Change Was Made

The shared health formatter already preserves degraded states and failed probes, then returns passive `healthy` when no probe result exists. The Health-table classifier now recognizes that exact successful state. Existing successful classifications share one branch, and a redundant failure branch is removed; unknown and failed states still default to warnings.

The change belongs entirely to status presentation. Channel health policy, lifecycle decisions, JSON output, `status --all`, authentication, configuration, and storage are unchanged. Documentation now distinguishes lifecycle health from active probes.

## User Impact

Healthy lifecycle reports display `OK | healthy`; blocked and unknown reports remain warnings. Seeing lifecycle `OK` does not imply that an active channel probe ran.

## Evidence

- Baseline main: `0a633d836fbab3acdbbdd020b83099665fec4f0b`. The real formatter regression failed as intended: 1 failure / 17 passes.
- Owner and independent checks each passed 48 tests across `status.command-sections.test.ts` and `health-format.test.ts`.
- The canonical CLI-startup build passed all seven phases. Actual built CLI against an isolated mock Gateway reproduced `WARN | healthy` before the fix, then returned `OK | healthy` afterward; the blocked control stayed `WARN | blocked`. Both commands exited 0 and requested `health` with `probe: true`.
- A separate source-blind validator passed four contract clauses across six native CLI runs, including transitions between healthy, blocked, and unknown modes. Every run exited 0 and made a fresh probe request. Owned fixture services and processes were cleaned up.
- Independent source review and complete final Codex review found no actionable findings.
- Full changed-scope validation passed, including production/test types, lint, guards, and import-cycle checks. The first local attempt lacked the prepared UI dependency link and resolved the wrong `pako` version; linking the existing exact UI dependency tree fixed that prerequisite without source changes, and the complete gate passed on retry.
- No live WhatsApp service was exercised. The evidence covers the actual CLI and its existing Gateway health contract.

Production LOC: +8/-11 (net -3). Tests: +59. Docs: +5/-1.

Provenance: the older table classifier traces to `72dcf9422138` (Peter Steinberger, April 6); lifecycle-health formatting in #117300 and #117410 made the missing successful classification visible. The separate auxiliary diagnostics in #117220 are not changed here.
