### PR TITLE
fix(setup): treat superseded catalog refresh as activation success

### DIFF
--- a/src/system-agent/setup-inference-activate.ts
+++ b/src/system-agent/setup-inference-activate.ts
@@ -6,6 +6,7 @@ import {
   type CodexCliApiKeyCredential,
   readCodexCliActiveApiKey,
 } from "../agents/cli-credentials.js";
+import { PreparedModelRuntimePublicationSupersededError } from "../agents/prepared-model-runtime.errors.js";
 import { loadAgentRuntimePluginRegistryHandle } from "../agents/runtime-plugins.js";
 import { applyAutoLocalModelLean } from "../config/local-model-lean-auto.js";
 import { createMergePatch } from "../config/merge-patch.js";
@@ -40,6 +41,7 @@ import {
   SetupInferenceOwnerDriftError,
   invalidSetupConfigError,
   resolveSetupInferenceWorkspace,
+  setupInferenceLog,
   throwIfSetupInferenceCancelled,
 } from "./setup-inference-core.js";
 import { revalidateStableSetupInferenceOwner } from "./setup-inference-owner.js";
@@ -629,8 +631,15 @@ async function activateSetupInferenceUnredacted(
             .refreshPreparedModelRuntimeSnapshots;
         await refreshPreparedModelRuntimeSnapshots(codexReloadedRuntimeConfig);
       } catch (error) {
-        throw new SetupInferenceActivationIndeterminateError(
-          `Inference activation committed, but the prepared model catalog could not be refreshed (${error instanceof Error ? error.message : String(error)}). Restart the Gateway before using the new inference route.`,
+        if (!(error instanceof PreparedModelRuntimePublicationSupersededError)) {
+          throw new SetupInferenceActivationIndeterminateError(
+            `Inference activation committed, but the prepared model catalog could not be refreshed (${error instanceof Error ? error.message : String(error)}). Restart the Gateway before using the new inference route.`,
+          );
+        }
+        // Our config commit can trigger a hot reload of the same or newer config.
+        // That lifecycle publication owns the refresh; losing ownership is not activation failure.
+        setupInferenceLog.info(
+          "Prepared model catalog refresh superseded by a newer publication; activation proceeding.",
         );
       }
     }

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -14,6 +14,7 @@ import {
   type AgentExecutionAuthBinding,
 } from "../agents/execution-auth-binding.js";
 import { ensureSelectedAgentHarnessPlugin } from "../agents/harness/runtime-plugin.js";
+import { PreparedModelRuntimePublicationSupersededError } from "../agents/prepared-model-runtime.errors.js";
 import { detectInferenceBackends } from "../commands/onboard-inference.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -4586,6 +4587,50 @@ describe("activateSetupInference", () => {
       configHarness.currentRuntime(),
     );
   });
+
+  it.each([
+    { outcome: "succeeds", errorType: PreparedModelRuntimePublicationSupersededError },
+    { outcome: "remains indeterminate", errorType: Error },
+  ])(
+    "$outcome after a committed Codex catalog refresh rejects with $errorType.name",
+    async ({ errorType }) => {
+      const configHarness = createPreRosterConfigTransformHarness();
+      const refreshError = new errorType("prepared model runtime publication was superseded");
+      const refreshPreparedModelRuntimeSnapshots = vi.fn(async () => {
+        expect(configHarness.current().agents?.defaults?.model).toBe("openai/gpt-5.6-sol");
+        throw refreshError;
+      });
+      const activation = activateCodexSetup({
+        workspace: "/tmp/work",
+        deps: {
+          readConfigFileSnapshot: configHarness.readSnapshot as never,
+          transformConfigWithPendingPluginInstalls: configHarness.transform as never,
+          refreshPreparedModelRuntimeSnapshots,
+        },
+      });
+
+      if (errorType === PreparedModelRuntimePublicationSupersededError) {
+        await expect(activation).resolves.toMatchObject({
+          ok: true,
+          modelRef: "openai/gpt-5.6-sol",
+          lines: ["Inference verified: openai/gpt-5.6-sol"],
+        });
+        expect(mocks.appendAudit).toHaveBeenCalledOnce();
+      } else {
+        await expect(activation).rejects.toBeInstanceOf(SetupInferenceActivationIndeterminateError);
+        await expect(activation).rejects.toThrow(
+          new SetupInferenceActivationIndeterminateError(
+            `Inference activation committed, but the prepared model catalog could not be refreshed (${refreshError.message}). Restart the Gateway before using the new inference route.`,
+          ),
+        );
+        expect(mocks.appendAudit).not.toHaveBeenCalled();
+      }
+      expect(refreshPreparedModelRuntimeSnapshots).toHaveBeenCalledOnce();
+      expect(refreshPreparedModelRuntimeSnapshots).toHaveBeenCalledWith(
+        configHarness.currentRuntime(),
+      );
+    },
+  );
 
   it("probes a newly loaded Codex harness inside an older Gateway registry scope", async () => {
     const oldRegistry = createEmptyPluginRegistry();


### PR DESCRIPTION
## What Problem This Solves

A fully successful Codex inference activation can be reported to the operator as a failure. Live-reproduced on a real gateway with a fresh profile: `openclaw.setup.activate` verified inference, committed config, then failed the RPC after 91s with

```
SetupInferenceActivationIndeterminateError: Inference activation committed, but the prepared model
catalog could not be refreshed (prepared model runtime publication was superseded for <agentDir>).
Restart the Gateway before using the new inference route.
```

The gateway log proves the race: the activation's own config commit triggered `[reload] config change detected` → `[reload] config hot reload applied` 20ms before the activation's post-commit catalog refresh observed itself superseded. Immediately afterwards a real agent turn succeeded in 18.9s with no restart — the error is a false alarm on the default onboarding path, so the Mac app presents a successful activation as failed and tells the operator to restart for nothing.

## Why This Change Was Made

[setup-inference-activate.ts](src/system-agent/setup-inference-activate.ts) wrapped every post-commit refresh error as indeterminate. But `PreparedModelRuntimePublicationSupersededError` specifically means a newer lifecycle publication for that agent dir took ownership of the refresh — here, the hot reload republishing from the config this activation just committed. Losing publication ownership is not activation failure: readers stay behind the owner's replacement gate, and the successor is keyed to equal-or-newer config. The fix narrows the catch: the typed supersede error logs one info line and continues through the normal success and audit path; every other error keeps the indeterminate wrap and restart guidance. Owner semantics in `prepared-model-runtime` are untouched (other callers rely on the rejection to avoid consuming stale snapshots).

Production LOC +11/−2 (net +9: typed branch, import, ownership comment, info log); tests +45.

## User Impact

Onboarding through the gateway RPC (the Mac app path) no longer shows a spurious "activation failed / restart the Gateway" after a successful activation when the config-reload republish wins the refresh race — a race that widens under load (the live repro had 10s event-loop stalls).

## Evidence

- Live reproduction at main 3708934c637 (fresh profile obt900, real Codex activation): log-proven reload-vs-refresh race, followed by a successful agent turn with no restart.
- New regression: injected refresh throwing `PreparedModelRuntimePublicationSupersededError` → activation resolves with the normal "Inference verified" lines and completed audit (fails pre-fix with the indeterminate error). Control test: a plain `Error` with identical message text still yields `SetupInferenceActivationIndeterminateError` (protects the remaining contract).
- `node scripts/run-vitest.mjs src/system-agent/setup-inference`: 142 tests green (re-run after rebase onto latest `origin/main`).
- check-changed lanes green locally (core production/test typecheck shards, lint, guards, import cycles); Codex autoreview clean.
- Sibling Codex source inspected at `../codex` `be6e8eac029` (`codex-rs/app-server/src/request_processors/catalog_processor.rs:160,:256`; `app-server-protocol/src/protocol/v2/model.rs:43`): the supersede error is OpenClaw publication control flow, not a Codex JSON-RPC error.
