### PR TITLE
fix(ci): provide rg fixture for PR lock tests

### DIFF
--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -1225,6 +1225,16 @@ describePosix("scripts/pr per-PR operation lock", () => {
     ({ wrapper, command, failure }) => {
       const repoDir = createRepo();
       const { binDir, cli } = installPrCliFixture(repoDir);
+      const rg = writeFixtureFile(binDir, "rg", [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'if [ "$#" -ne 4 ] || [ "$1" != "-n" ] || [ "$2" != "-i" ]; then',
+        '  echo "unexpected fixture rg call: $*" >&2',
+        "  exit 99",
+        "fi",
+        'exec grep -n -i -E -- "$3" "$4"',
+      ]);
+      chmodSync(rg, 0o755);
       const worktreeDir = join(repoDir, ".worktrees", "pr-42");
       const lifecycle = join(repoDir, "lifecycle.log");
       const ownerFile = join(repoDir, "owner-oid");
@@ -1339,8 +1349,9 @@ describePosix("scripts/pr per-PR operation lock", () => {
         },
       );
       const output = `${result.stdout}\n${result.stderr}`;
-      const events = readFileSync(lifecycle, "utf8");
       expect(result.error, output).toBeUndefined();
+      expect(existsSync(lifecycle), output).toBe(true);
+      const events = readFileSync(lifecycle, "utf8");
       expect(git("rev-parse", "HEAD")).toBe(canonicalHead);
       expect(existsSync(worktreeDir)).toBe(failure === "merge");
       if (failure === "merge") {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the GitHub-hosted `core-tooling-2` release-gate shard failed all five native PR lock cleanup cases because the runner did not provide `rg`. The fixture exited during command preflight before writing `lifecycle.log`, and the unconditional log read masked the actionable `Missing required command(s): rg` error.

## Why This Change Was Made

The affected matrix now installs a local, functional `rg` fixture that supports only the exercised `rg -n -i <pattern> <file>` form, delegates matching to `grep -E`, and fails unknown argument shapes. The test also verifies the subprocess result and lifecycle-file existence before reading the file, so future fixture failures preserve their real diagnostics.

## User Impact

No production behavior changes. GitHub-hosted PR lock validation now has the same required command surface as Blacksmith, and fixture failures report their actual cause instead of an opaque missing-log error.

## Evidence

- Before, GitHub-hosted run `33047386910` failed all five cases in `checks-node-core-tooling-2`: https://github.com/openclaw/openclaw/actions/runs/33047386910/job/98434820422
- The same 73-test file passed on Blacksmith, where `rg` was already installed: https://github.com/openclaw/openclaw/actions/runs/33042313598/job/98418660903
- Focused five-case matrix: 5/5 passed.
- Full `test/scripts/pr-operation-lock.test.ts`: 73 collected, 72 passed, 1 skipped.
- Exact-head release gate `33051269547` passed on `4c69eeef37e9359f19d0bb7b7401f8381ea0baa8` with no retries:
  - all five PR lock cleanup cases passed;
  - `checks-node-core-tooling-2`: 1,051 passed, 4 skipped;
  - `openclaw/ci-gate`: passed.
- Targeted format and lint, `git diff --check`, and privacy scan passed.
- Fresh Claude fable-5/high autoreview: clean, no P0/P1 findings.
- ClawSweeper reviewed the exact head with no findings; its exact-head CI rank-up move is satisfied by run `33051269547`.

AI-assisted: yes. The maintainer reviewed the implementation and evidence.
