### PR TITLE
fix(telegram): preserve literal backticks in inbound code

### DIFF
--- a/extensions/telegram/src/bot/body-helpers.inbound.test.ts
+++ b/extensions/telegram/src/bot/body-helpers.inbound.test.ts
@@ -152,6 +152,43 @@ describe("joinTelegramTextParts", () => {
     expect(parsed.text).toBe(result.text);
     expect(parsed.links.map((link) => link.href)).toEqual([messageUrl, captionUrl]);
   });
+
+  it.each([
+    "npm test",
+    "a`b",
+    "`npm",
+    "npm`",
+    "`npm`",
+    "``npm```",
+    "`",
+    " npm",
+    "npm ",
+    " npm ",
+    " ",
+    "   ",
+  ])("preserves literal inline code %j from joined text and captions", (code) => {
+    const prefix = "😀 Code: ";
+    const text = `${prefix}${code} end`;
+    const entities: MessageEntity[] = [
+      { type: "code", offset: prefix.length, length: code.length },
+    ];
+    const result = joinTelegramTextParts(
+      [
+        asTelegramMessage({ text, entities }),
+        asTelegramMessage({ caption: text, caption_entities: entities }),
+      ],
+      "\n",
+    );
+
+    const parsed = markdownToIR(renderTelegramTextEntities(result.text, result.entities));
+
+    expect(parsed.text).toBe(result.text);
+    expect(
+      parsed.styles
+        .filter((span) => span.style === "code")
+        .map((span) => parsed.text.slice(span.start, span.end)),
+    ).toEqual([code, code]);
+  });
 });
 
 describe("renderTelegramTextEntities quoted blocks", () => {

--- a/extensions/telegram/src/bot/inbound-text-entities.ts
+++ b/extensions/telegram/src/bot/inbound-text-entities.ts
@@ -61,10 +61,9 @@ function longestBacktickRun(text: string): number {
 
 function markdownInlineCodeDelimiters(content: string): [string, string] {
   const delimiter = "`".repeat(longestBacktickRun(content) + 1);
-  if (content.startsWith(" ") || content.endsWith(" ")) {
-    return [`${delimiter} `, ` ${delimiter}`];
-  }
-  return [delimiter, delimiter];
+  // Padding keeps literal edge backticks separate from the Markdown delimiters.
+  const padding = /^[ `]|[ `]$/u.test(content) ? " " : "";
+  return [`${delimiter}${padding}`, `${padding}${delimiter}`];
 }
 
 function markdownPreAffixes(


### PR DESCRIPTION
Closes #130799

## What Problem This Solves

Fixes an issue where users sending Telegram messages with native inline-code formatting would lose literal edge backticks or produce broken code spans in the agent's input. The same entity renderer handles message text, captions, and poll descriptions.

## Why This Change Was Made

The encoder already chooses a delimiter longer than the longest backtick run in the content. Without separation at the edges, those runs join the delimiters anyway. Compute one padding value for space or backtick edges and use it on both sides, replacing the existing special-case branch.

This repairs the Telegram presentation producer without changing core normalization, message routing, authentication, configuration, persistence, or public SDK contracts. Existing whitespace behavior and preformatted blocks remain unchanged. Production: +3/-4, net **-1**; regression tests: +37.

Provenance: the affected encoder behavior originates in #83873 (@jason-allen-oneal, merged by @obviyus) and is present in stable `v2026.7.1`. The later renderer extraction in `70f84286c9ae20fd47dcf775b55ebb99296794de` carried it forward.

## User Impact

Literal backticks selected as part of Telegram monospace text remain code content in the agent's input, including document captions and poll descriptions. No operator action or configuration change is required.

## Evidence

- Before editing production, the regression table failed in five edge-backtick cases; ordinary/internal-backtick and existing whitespace cases passed. The final focused run passes **152 tests in 6 files**, including joined text/caption UTF-16 offsets, all-space controls, buffered replies, media carriers, and prompt context.
- A real built Gateway consumed native Telegram `getUpdates` over HTTP through grammY and sent requests to a local mock model provider. Assertions inspect the **raw provider request**, not the mock's summarized prompt. Four edge cases change from failing to passing; two ordinary/internal-backtick controls remain passing. Native document-caption and poll-description cases also pass.
- Baseline and candidate private QA builds and the full changed-file checks passed, including production/test typechecks, extension lint, boundary guards, and zero runtime import cycles.
- A source-blind verifier passed all six scoped clauses with fresh text, caption, and poll-description payloads, UTF-16 checks, and a repeated-request check. It retained 14 valid responses (including the explicitly out-of-scope whitespace diagnostic) and two invalid-input responses. The latter are **harness-interface sanity checks**, not product validation-policy claims. One missing validator response was excluded and replaced by a fresh successful probe.
- Independent source review and the required isolated Codex review found no actionable findings.

```json
{
  "proof": "real Gateway, native Telegram Bot API mock, raw mock-provider HTTP capture",
  "baseline": { "edgeCasesFailed": 4, "controlsPassed": 2 },
  "candidate": { "edgeCasesPassed": 4, "controlsPassed": 2, "captionPassed": true, "pollDescriptionPassed": true },
  "sourceBlind": { "clausesPassed": 6, "failures": 0, "knownWhitespaceDiagnostic": "out_of_scope" },
  "knownUnchangedDiagnostic": "core input normalization collapses repeated horizontal spaces",
  "liveTelegramSaaS": false,
  "ownedRuntimeCleanup": "complete"
}
```

The separate whitespace diagnostic fails identically before and after: core `stripPromptThinkingDirectives` collapses repeated horizontal spaces before inference. The Telegram encoder preserves its existing whitespace contract; this PR does not broaden into that core owner or claim universal whitespace preservation. Live Telegram SaaS and Desktop were not exercised; the proof uses the real Gateway/channel pipeline with local external endpoints.
