### PR TITLE
refactor(models): simplify status auth projection

### DIFF
--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -133,36 +133,6 @@ type StatusSyntheticAuth = {
   expiresAt?: number;
 };
 
-type StatusProviderRouteAuth =
-  | {
-      /** Provider artifact unavailable; retain the shipped provider-wide behavior. */
-      kind: "legacy";
-      evaluation: ModelAuthAvailabilityEvaluation;
-      usesCodexRuntimeAuth: boolean;
-      runtimeAvailability?: AgentHarnessRuntimeAvailability;
-    }
-  | {
-      kind: "route";
-      route: ProviderModelRouteCandidate;
-      evaluation: ModelAuthAvailabilityEvaluation;
-      usesCodexRuntimeAuth: boolean;
-      runtimeAvailability?: AgentHarnessRuntimeAvailability;
-    }
-  | {
-      kind: "indeterminate";
-      evaluation: ModelAuthAvailabilityEvaluation;
-      usesCodexRuntimeAuth: boolean;
-      runtimeAvailability?: AgentHarnessRuntimeAvailability;
-    }
-  | {
-      kind: "incompatible";
-      code: string;
-      message: string;
-      evaluation: ModelAuthAvailabilityEvaluation;
-      usesCodexRuntimeAuth: false;
-      runtimeAvailability?: undefined;
-    };
-
 type StatusProviderUseRef = {
   provider: string;
   model: string;
@@ -175,8 +145,16 @@ type StatusProviderUse = {
   provider: string;
   model: string;
   allowCodexRuntimeFallback: boolean;
-  routeAuth: StatusProviderRouteAuth;
+  evaluation: ModelAuthAvailabilityEvaluation;
+  usesCodexRuntimeAuth: boolean;
+  runtimeAvailability?: AgentHarnessRuntimeAvailability;
+  runtimeIncompatibility?: { code: string; message: string };
 };
+
+function resolveStatusProviderUseIncompatibility(usage: StatusProviderUse) {
+  const routeResolution = usage.evaluation.routeResolution;
+  return routeResolution?.kind === "incompatible" ? routeResolution : usage.runtimeIncompatibility;
+}
 
 type StatusRuntimeAuthStatus = "usable" | "missing" | "indeterminate";
 
@@ -704,79 +682,44 @@ export async function modelsStatusCommand(
                   availability: resolver.resolveProviderAuthAvailability(usage.provider, ref),
                   routeResolution: null,
                 };
-          const routeAuth: StatusProviderRouteAuth = await (async () => {
-            if (rawEvaluation.routeResolution?.kind === "incompatible") {
-              return {
-                kind: "incompatible",
-                code: rawEvaluation.routeResolution.code,
-                message: rawEvaluation.routeResolution.message,
-                evaluation: rawEvaluation,
-                usesCodexRuntimeAuth: false,
-              };
-            }
-            const usesCodexRuntimeAuth =
-              usage.allowCodexRuntimeFallback &&
-              resolveAgentHarnessPolicy({
-                provider: usage.provider,
-                modelId: usage.model,
-                ...(rawEvaluation.selectedRoute
-                  ? {
-                      modelApi: rawEvaluation.selectedRoute.api,
-                      modelBaseUrl: rawEvaluation.selectedRoute.baseUrl,
-                    }
-                  : {}),
-                config: cfg,
-                agentId: workspaceAgentId,
-              }).runtime === "codex";
-            if (
-              usesCodexRuntimeAuth &&
-              usage.provider !== OPENAI_PROVIDER_ID &&
-              usage.provider !== "codex"
-            ) {
-              return {
-                kind: "incompatible",
-                code: "unsupported-codex-runtime-provider",
-                message: `The Codex runtime does not support provider ${usage.provider}.`,
-                evaluation: rawEvaluation,
-                usesCodexRuntimeAuth: false,
-              };
-            }
-            const runtimeAvailability = usesCodexRuntimeAuth
-              ? await resolveCodexRuntimeAvailability(usage.provider)
+          const providerRouteIncompatible = rawEvaluation.routeResolution?.kind === "incompatible";
+          const requestedCodexRuntimeAuth =
+            !providerRouteIncompatible &&
+            usage.allowCodexRuntimeFallback &&
+            resolveAgentHarnessPolicy({
+              provider: usage.provider,
+              modelId: usage.model,
+              ...(rawEvaluation.selectedRoute
+                ? {
+                    modelApi: rawEvaluation.selectedRoute.api,
+                    modelBaseUrl: rawEvaluation.selectedRoute.baseUrl,
+                  }
+                : {}),
+              config: cfg,
+              agentId: workspaceAgentId,
+            }).runtime === "codex";
+          const runtimeIncompatibility =
+            requestedCodexRuntimeAuth &&
+            usage.provider !== OPENAI_PROVIDER_ID &&
+            usage.provider !== "codex"
+              ? {
+                  code: "unsupported-codex-runtime-provider",
+                  message: `The Codex runtime does not support provider ${usage.provider}.`,
+                }
               : undefined;
-            const evaluation = rawEvaluation;
-            if (evaluation.selectedRoute) {
-              return {
-                kind: "route",
-                route: evaluation.selectedRoute,
-                evaluation,
-                usesCodexRuntimeAuth,
-                runtimeAvailability,
-              };
-            }
-            if (
-              evaluation.routeResolution?.kind === "routes" ||
-              evaluation.routeResolution?.kind === "indeterminate"
-            ) {
-              return {
-                kind: "indeterminate",
-                evaluation,
-                usesCodexRuntimeAuth,
-                runtimeAvailability,
-              };
-            }
-            return {
-              kind: "legacy",
-              evaluation,
-              usesCodexRuntimeAuth,
-              runtimeAvailability,
-            };
-          })();
+          const usesCodexRuntimeAuth =
+            requestedCodexRuntimeAuth && runtimeIncompatibility === undefined;
+          const runtimeAvailability = usesCodexRuntimeAuth
+            ? await resolveCodexRuntimeAvailability(usage.provider)
+            : undefined;
           return {
             provider: usage.provider,
             model: usage.model,
             allowCodexRuntimeFallback: usage.allowCodexRuntimeFallback,
-            routeAuth,
+            evaluation: rawEvaluation,
+            usesCodexRuntimeAuth,
+            runtimeAvailability,
+            runtimeIncompatibility,
           };
         }),
       );
@@ -786,7 +729,7 @@ export async function modelsStatusCommand(
     const cliRuntimeAuthUsages = providerUses
       // Codex harness auth is already modeled by the selected OpenAI route.
       // CLI-runtime aliases are only for distinct backends such as Gemini CLI.
-      .filter((usage) => usage.allowCodexRuntimeFallback && !usage.routeAuth.usesCodexRuntimeAuth)
+      .filter((usage) => usage.allowCodexRuntimeFallback && !usage.usesCodexRuntimeAuth)
       .map((usage) => {
         const runtimeProvider = resolveCliRuntimeExecutionProvider({
           provider: usage.provider,
@@ -825,9 +768,7 @@ export async function modelsStatusCommand(
     );
     const codexProvider = normalizeProviderId(OPENAI_PROVIDER_ID);
     const codexProviderAlias = aliasMap[codexProvider] ?? codexProvider;
-    let codexRuntimeAuthUsages = providerUses.filter(
-      (usage) => usage.routeAuth.usesCodexRuntimeAuth,
-    );
+    let codexRuntimeAuthUsages = providerUses.filter((usage) => usage.usesCodexRuntimeAuth);
     if (codexRuntimeAuthUsages.length > 0) {
       syntheticProvidersToProbe.add(codexProvider);
       syntheticProvidersToProbe.add(codexProviderAlias);
@@ -885,7 +826,7 @@ export async function modelsStatusCommand(
         profiles: { ...store.profiles, ...syntheticProfiles },
       });
       providerUses = await resolveProviderUses(authResolver);
-      codexRuntimeAuthUsages = providerUses.filter((usage) => usage.routeAuth.usesCodexRuntimeAuth);
+      codexRuntimeAuthUsages = providerUses.filter((usage) => usage.usesCodexRuntimeAuth);
     }
 
     const applied = getShellEnvAppliedKeys();
@@ -1003,12 +944,12 @@ export async function modelsStatusCommand(
       if (cliRuntimeAuthProvider) {
         return authResolver.resolveProviderAuthAvailability(cliRuntimeAuthProvider) !== false;
       }
-      if (usage.routeAuth.kind === "incompatible") {
+      if (resolveStatusProviderUseIncompatibility(usage)) {
         // Route contract failures are reported separately from missing auth.
         return true;
       }
       // Unknown evidence is reported as indeterminate, not missing auth.
-      return usage.routeAuth.evaluation.availability !== false;
+      return usage.evaluation.availability !== false;
     };
     const codexRuntimeUsagesByProvider = new Map<string, StatusProviderUse[]>();
     for (const usage of codexRuntimeAuthUsages) {
@@ -1019,18 +960,18 @@ export async function modelsStatusCommand(
     const runtimeAuthRouteEntries: Array<readonly [string, StatusRuntimeAuthRoute]> = [
       ...Array.from(codexRuntimeUsagesByProvider.entries()).map(([provider, usages]) => {
         const representative =
-          usages.find((usage) => usage.routeAuth.evaluation.availability === true) ?? usages[0];
+          usages.find((usage) => usage.evaluation.availability === true) ?? usages[0];
         const effective = resolveRuntimeAuthRouteEffective(
           codexProvider,
-          representative?.routeAuth.evaluation,
+          representative?.evaluation,
         );
-        const availabilities = usages.map((usage) => usage.routeAuth.evaluation.availability);
+        const availabilities = usages.map((usage) => usage.evaluation.availability);
         const authStatus = availabilities.every((availability) => availability === true)
           ? "usable"
           : availabilities.some((availability) => availability === false)
             ? "missing"
             : "indeterminate";
-        const runtimeAvailability = representative?.routeAuth.runtimeAvailability;
+        const runtimeAvailability = representative?.runtimeAvailability;
         const route: StatusRuntimeAuthRoute =
           runtimeAvailability?.status === "unavailable"
             ? {
@@ -1081,15 +1022,16 @@ export async function modelsStatusCommand(
       const cliRuntimeAuthProvider = resolveCliRuntimeAuthProvider(usage);
       const evaluation = cliRuntimeAuthProvider
         ? authResolver.evaluateModelAuth(cliRuntimeAuthProvider)
-        : usage.routeAuth.evaluation;
-      if (usage.routeAuth.kind === "incompatible") {
+        : usage.evaluation;
+      const incompatibility = resolveStatusProviderUseIncompatibility(usage);
+      if (incompatibility) {
         return [
           {
             kind: "incompatible" as const,
             provider: usage.provider,
             model: usage.model,
-            code: usage.routeAuth.code,
-            message: usage.routeAuth.message,
+            code: incompatibility.code,
+            message: incompatibility.message,
           },
         ];
       }
@@ -1104,10 +1046,10 @@ export async function modelsStatusCommand(
           },
         ];
       }
-      if (usage.routeAuth.kind !== "route" || evaluation.availability) {
+      if (!usage.evaluation.selectedRoute || evaluation.availability) {
         return [];
       }
-      const authRequirement = usage.routeAuth.route.authRequirement;
+      const authRequirement = usage.evaluation.selectedRoute.authRequirement;
       return [
         {
           kind: "missing-auth" as const,
@@ -1293,13 +1235,13 @@ export async function modelsStatusCommand(
     const checkStatus = (() => {
       type RequirementHealth = "ok" | "expiring" | "missing" | "indeterminate";
       const resolveRouteAuthHealth = (usage: StatusProviderUse): RequirementHealth => {
-        if (usage.routeAuth.kind === "incompatible") {
+        if (resolveStatusProviderUseIncompatibility(usage)) {
           return "missing";
         }
         const cliRuntimeAuthProvider = resolveCliRuntimeAuthProvider(usage);
         const evaluation = cliRuntimeAuthProvider
           ? authResolver.evaluateModelAuth(cliRuntimeAuthProvider)
-          : usage.routeAuth.evaluation;
+          : usage.evaluation;
         if (evaluation.availability === undefined) {
           return "indeterminate";
         }


### PR DESCRIPTION
## What Problem This Solves

`models status` wrapped the canonical model-auth evaluation in a second private discriminated union for legacy, selected-route, indeterminate, and incompatible states. The wrapper copied availability and route-resolution facts that the canonical evaluation already owns, then forced every JSON, check, and text projection to unpack them again.

That duplicate representation made the status command harder to reason about and easier for sibling projections to drift without adding a distinct policy or runtime capability.

## Why This Change Was Made

This keeps the canonical `ModelAuthAvailabilityEvaluation` on each provider use and carries only the status-command-specific runtime facts beside it: whether Codex runtime auth is active, its availability, and any runtime-only incompatibility.

A single helper resolves canonical route incompatibility versus runtime incompatibility. Existing provider evaluation timing, CLI runtime selection, fallback rules, auth probing, and output projection remain unchanged; this does not add caching or move evaluation ownership.

## User Impact

No user-visible behavior change is intended. JSON, `--check`, and plain-text model status output retain the same contract with one private translation layer removed.

## Evidence

- Focused owner and sibling coverage passes 251/251 tests across status JSON/check/text output, auth availability/index/overview, runtime aliases, CLI routing, and parser behavior.
- The complete one-path changed gate passes core production/test types, type-aware lint, import-cycle checks, Knip scans, and database/state/auth/media/plugin guards.
- Fresh isolated review reports no actionable findings.
- Production: +60/-118, net -58 lines. Tests: unchanged. Total: net -58 lines.
- No CLI option, output schema, provider policy, auth timing, cache behavior, public API, configuration, protocol, persistence, or dependency change.
- A clean full repository build passes assets, unified package output, external plugins, CLI bootstrap, runtime postbuild, 147 SDK subpaths, UI, and startup metadata; both build stamps match the exact committed head.
- Four source-blind isolated CLI probes pass with expected exit codes 1/1/0/1: JSON reports the expected missing-auth fields, plain output is the exact selected model, and stderr is empty.
- The upstream Codex [auth distinction](https://github.com/openai/codex/blob/4cb8d8679c051663c27827d3c2f15289671f864b/codex-rs/login/src/auth/manager.rs#L482) and [account-status contract](https://github.com/openai/codex/blob/4cb8d8679c051663c27827d3c2f15289671f864b/codex-rs/app-server/src/request_processors/account_processor.rs#L1036) were inspected directly; this cleanup preserves unknown versus missing state and API-key versus backend auth distinctions, with no Codex runtime/auth contract change.

`CHANGELOG.md` is release-owned; this behavior-preserving internal cleanup needs no release entry.
