### PR TITLE
fix(release): restore changelog-only evidence validation

### DIFF
--- a/.github/workflows/full-release-validation.yml
+++ b/.github/workflows/full-release-validation.yml
@@ -1251,6 +1251,8 @@ jobs:
           sparse-checkout: |
             scripts/full-release-validation-state.mjs
             scripts/full-release-validation-policy.mjs
+            scripts/release-ci-summary.mjs
+            scripts/lib/plain-gh.mjs
           sparse-checkout-cone-mode: false
           persist-credentials: false
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -9724,6 +9724,30 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(telegramProvenanceHelper).not.toContain(".baseRefName ==");
   });
 
+  it("checks out the complete Release Decision evidence validator closure", () => {
+    const workflow = readWorkflow(".github/workflows/full-release-validation.yml");
+    const checkout = workflow.jobs.release_decision.steps.find(
+      (step: WorkflowStep) => step.name === "Checkout release decision tooling",
+    );
+    const sparseCheckoutPaths = String(checkout?.with?.["sparse-checkout"] ?? "")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    expect(sparseCheckoutPaths).toEqual([
+      "scripts/full-release-validation-state.mjs",
+      "scripts/full-release-validation-policy.mjs",
+      "scripts/release-ci-summary.mjs",
+      "scripts/lib/plain-gh.mjs",
+    ]);
+    for (const sparsePath of sparseCheckoutPaths) {
+      expect({ sparsePath, exists: existsSync(sparsePath) }).toEqual({
+        sparsePath,
+        exists: true,
+      });
+    }
+  });
+
   it("keeps maturity scorecard release docs opt-in from release checks", () => {
     const releaseWorkflow = readReleaseChecksWorkflow();
     const job = releaseWorkflow.jobs.maturity_scorecard_release_checks;


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/actions/runs/33050093683

## What Problem This Solves

Fixes an issue where changelog-only Full Release Validation would reject valid reusable Code-SHA evidence during Release Decision because the job did not check out its evidence validator.

## Why This Change Was Made

Release Decision now checks out the same complete state-validator dependency closure as the execution-plan, diagnostic-drain, and summary jobs. A workflow guard freezes that contract so a future sparse-checkout edit cannot silently recreate the runtime module failure.

## User Impact

Release operators can validate a changelog-only Release SHA by reusing the already-green Code-SHA matrix instead of receiving a false provenance mismatch. Product code, release candidate content, permissions, and publication behavior are unchanged.

## Evidence

- FRV `33050093683` attempts 1 and 2: target resolution, reusable evidence selection, immutable plan sealing, and Diagnostic Drain passed; Release Decision failed before evidence revalidation because `scripts/release-ci-summary.mjs` was absent from its sparse checkout.
- Regression test failed before the workflow fix with a two-path checkout versus the required four-path validator closure, then passed after the fix.
- `test/scripts/ci-workflow-guards.test.ts`: 133 passed, 2 skipped.
- Focused Release Decision/Diagnostic Drain package-acceptance contract: passed.
- `pnpm lint:scripts`, focused formatting, and `git diff --check`: passed.
- Fresh isolated autoreview: no accepted or actionable findings.
- Local `pnpm check:workflows` is blocked before lint by the configured Python index not serving pinned `pre-commit==4.6.2`; hosted Workflow Sanity remains required.
- Local root test typecheck reaches only the shared-checkout `pako` declaration gap; no dependency install or shared-link mutation was performed in this worktree.

AI-assisted: yes. I reviewed and understand the change.
