### PR TITLE
fix: release stalled captured provider responses promptly

### DIFF
--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -460,7 +460,9 @@ describe("github-copilot runtime auth", () => {
       try {
         const error = await Promise.race([
           rejection,
-          new Promise<undefined>((resolve) => setImmediate(() => resolve(undefined))),
+          new Promise<undefined>((resolve) => {
+            setImmediate(() => resolve(undefined));
+          }),
         ]);
         expect(error).toBeInstanceOf(CopilotRuntimeAuthError);
         expect(error).toMatchObject({

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -446,21 +446,36 @@ describe("github-copilot runtime auth", () => {
     ).rejects.toThrow("untrusted endpoints.api URL");
   });
 
-  it("explains how to recover from forbidden authentication", async () => {
-    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 403 }));
-    const rejection = resolveCopilotRuntimeAuth({
-      githubToken: "github-source-token",
-      fetchImpl: fetchImpl as typeof fetch,
-    });
+  it.each([false, true])(
+    "explains forbidden auth without waiting for capture (clone: %s)",
+    async (cloned) => {
+      const response = new Response(new ReadableStream<Uint8Array>(), { status: 403 });
+      const capture = cloned ? response.clone() : undefined;
+      const fetchImpl = vi.fn().mockResolvedValue(response);
+      const rejection = resolveCopilotRuntimeAuth({
+        githubToken: "github-source-token",
+        fetchImpl: fetchImpl as typeof fetch,
+      }).catch((error: unknown) => error);
 
-    await expect(rejection).rejects.toBeInstanceOf(CopilotRuntimeAuthError);
-    await expect(rejection).rejects.toMatchObject({
-      code: "github_copilot_auth_failed",
-      reason: "http_error",
-      status: 403,
-      message: expect.stringContaining("login-github-copilot"),
-    });
-  });
+      try {
+        const error = await Promise.race([
+          rejection,
+          new Promise<undefined>((resolve) => setImmediate(() => resolve(undefined))),
+        ]);
+        expect(error).toBeInstanceOf(CopilotRuntimeAuthError);
+        expect(error).toMatchObject({
+          code: "github_copilot_auth_failed",
+          reason: "http_error",
+          status: 403,
+          message: expect.stringContaining("login-github-copilot"),
+        });
+        expect(response.bodyUsed).toBe(true);
+      } finally {
+        await capture?.body?.cancel();
+        await rejection;
+      }
+    },
+  );
 
   it("maps a stalled response body to a runtime-auth timeout", async () => {
     const controller = new AbortController();

--- a/extensions/github-copilot/runtime-auth.ts
+++ b/extensions/github-copilot/runtime-auth.ts
@@ -59,12 +59,6 @@ function parseCopilotApiBaseUrl(value: unknown, domain: string): string {
   return url.href.replace(/\/+$/, "");
 }
 
-async function cancelUnreadResponseBody(response: Response): Promise<void> {
-  if (!response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
-  }
-}
-
 export async function resolveCopilotRuntimeAuth(params: {
   githubToken: string;
   env?: NodeJS.ProcessEnv;
@@ -95,7 +89,10 @@ export async function resolveCopilotRuntimeAuth(params: {
       signal,
     });
     if (!response.ok) {
-      await cancelUnreadResponseBody(response);
+      // A capture tee must not delay the already-known authentication failure.
+      if (!response.bodyUsed) {
+        void response.body?.cancel().catch(() => undefined);
+      }
       throw new CopilotRuntimeAuthError({ reason: "http_error", status: response.status });
     }
     const baseUrl = parseCopilotApiBaseUrl(

--- a/extensions/huggingface/models.test.ts
+++ b/extensions/huggingface/models.test.ts
@@ -12,15 +12,6 @@ function stubAbortSignalTimeout() {
   return vi.spyOn(AbortSignal, "timeout").mockReturnValue(controller.signal);
 }
 
-function responseFromReader(reader: ReadableStreamDefaultReader<Uint8Array>): Response {
-  return {
-    ok: true,
-    status: 200,
-    headers: new Headers({ "Content-Type": "application/json" }),
-    body: { getReader: () => reader },
-  } as Response;
-}
-
 afterEach(() => {
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
@@ -276,51 +267,44 @@ describe("huggingface models", () => {
 
   it("falls back to the static catalog when the discovery response exceeds the byte cap", async () => {
     const chunk = new Uint8Array(1024 * 1024);
-    const read = vi.fn(async () => ({ done: false as const, value: chunk }));
+    const pull = vi.fn((controller: ReadableStreamDefaultController<Uint8Array>) => {
+      controller.enqueue(chunk);
+    });
     const cancel = vi.fn(async () => undefined);
-    const releaseLock = vi.fn();
-    const reader = {
-      read,
-      cancel,
-      releaseLock,
-    } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+    // Disable prefetch so each pull records a chunk requested by the bounded reader.
+    const response = new Response(new ReadableStream({ pull, cancel }, { highWaterMark: 0 }), {
+      headers: { "Content-Type": "application/json" },
+    });
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => responseFromReader(reader)),
+      vi.fn(async () => response),
     );
 
     const models = await discoverHuggingfaceModels("hf_test_token");
 
     expect(models.map((m) => m.id)).toEqual(HUGGINGFACE_MODEL_CATALOG.map((m) => m.id));
     expect(cancel).toHaveBeenCalledTimes(1);
-    expect(releaseLock).toHaveBeenCalledTimes(1);
-    expect(read).toHaveBeenCalledTimes(5);
+    expect(response.body?.locked).toBe(false);
+    expect(response.bodyUsed).toBe(true);
+    expect(pull).toHaveBeenCalledTimes(5);
   });
 
   it("parses a valid bounded discovery response", async () => {
     const modelId = "test-org/test-model";
     const body = new TextEncoder().encode(JSON.stringify({ data: [{ id: modelId }] }));
-    const read = vi
-      .fn()
-      .mockResolvedValueOnce({ done: false, value: body })
-      .mockResolvedValueOnce({ done: true, value: undefined });
-    const cancel = vi.fn(async () => undefined);
-    const releaseLock = vi.fn();
-    const reader = {
-      read,
-      cancel,
-      releaseLock,
-    } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+    const response = new Response(body, { headers: { "Content-Type": "application/json" } });
+    const cancel = vi.spyOn(response.body!, "cancel");
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => responseFromReader(reader)),
+      vi.fn(async () => response),
     );
 
     const models = await discoverHuggingfaceModels("hf_test_token");
 
     expect(models.some((model) => model.id === modelId)).toBe(true);
     expect(cancel).not.toHaveBeenCalled();
-    expect(releaseLock).toHaveBeenCalledTimes(1);
+    expect(response.body?.locked).toBe(false);
+    expect(response.bodyUsed).toBe(true);
   });
 
   describe("isHuggingfacePolicyLocked", () => {

--- a/extensions/lmstudio/src/models.fetch.test.ts
+++ b/extensions/lmstudio/src/models.fetch.test.ts
@@ -1,0 +1,79 @@
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { fetchLmstudioModels } from "./models.fetch.js";
+
+const fetchWithSsrFGuardMock = vi.hoisted(() => vi.fn());
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
+  };
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
+  vi.resetModules();
+});
+
+afterEach(() => {
+  fetchWithSsrFGuardMock.mockReset();
+});
+
+describe("LM Studio model response release", () => {
+  const cancelTrackedResponse = (
+    text: string,
+    init: ResponseInit,
+  ): {
+    response: Response;
+    wasCanceled: () => boolean;
+  } => {
+    let canceled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(text));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+    return {
+      response: new Response(stream, init),
+      wasCanceled: () => canceled,
+    };
+  };
+
+  it.each([false, true])(
+    "releases guarded non-ok discovery without waiting for capture (retained clone: %s)",
+    async (retainCaptureClone) => {
+      const tracked = cancelTrackedResponse("unavailable", { status: 503 });
+      const captureClone = retainCaptureClone ? tracked.response.clone() : undefined;
+      const release = vi.fn(async () => undefined);
+      fetchWithSsrFGuardMock.mockResolvedValue({ response: tracked.response, release });
+      const request = fetchLmstudioModels({
+        baseUrl: "http://localhost:1234/v1",
+        ssrfPolicy: {},
+      });
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const result = await Promise.race([
+          request,
+          new Promise<never>((_resolve, reject) => {
+            timeout = setTimeout(
+              () => reject(new Error("LM Studio cleanup waited for the capture clone")),
+              500,
+            );
+          }),
+        ]);
+        expect(result).toMatchObject({ reachable: true, status: 503, models: [] });
+        expect(tracked.response.bodyUsed).toBe(true);
+        expect(release).toHaveBeenCalledOnce();
+      } finally {
+        clearTimeout(timeout);
+        await captureClone?.body?.cancel().catch(() => undefined);
+        await request;
+      }
+      expect(tracked.wasCanceled()).toBe(true);
+    },
+  );
+});

--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -66,12 +66,6 @@ type DiscoverLmstudioModelsParams = {
   fetchImpl?: typeof fetch;
 };
 
-async function cancelUnreadResponseBody(response: Response): Promise<void> {
-  if (!response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
-  }
-}
-
 async function fetchLmstudioEndpoint(params: {
   url: string;
   init?: RequestInit;
@@ -105,7 +99,10 @@ async function fetchLmstudioEndpoint(params: {
   return {
     response,
     release: async () => {
-      await cancelUnreadResponseBody(response);
+      // A capture tee must not delay the guard's bounded dispatcher release.
+      if (!response.bodyUsed) {
+        void response.body?.cancel().catch(() => undefined);
+      }
       await release();
     },
   };

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -593,40 +593,6 @@ describe("lmstudio-models", () => {
     expect(tracked.wasCanceled()).toBe(true);
   });
 
-  it.each([false, true])(
-    "releases guarded non-ok discovery without waiting for capture (retained clone: %s)",
-    async (retainCaptureClone) => {
-      const tracked = cancelTrackedResponse("unavailable", { status: 503 });
-      const captureClone = retainCaptureClone ? tracked.response.clone() : undefined;
-      const release = vi.fn(async () => undefined);
-      fetchWithSsrFGuardMock.mockResolvedValue({ response: tracked.response, release });
-      const request = fetchLmstudioModels({
-        baseUrl: "http://localhost:1234/v1",
-        ssrfPolicy: {},
-      });
-      let timeout: ReturnType<typeof setTimeout> | undefined;
-      try {
-        const result = await Promise.race([
-          request,
-          new Promise<never>((_resolve, reject) => {
-            timeout = setTimeout(
-              () => reject(new Error("LM Studio cleanup waited for the capture clone")),
-              500,
-            );
-          }),
-        ]);
-        expect(result).toMatchObject({ reachable: true, status: 503, models: [] });
-        expect(tracked.response.bodyUsed).toBe(true);
-        expect(release).toHaveBeenCalledOnce();
-      } finally {
-        clearTimeout(timeout);
-        await captureClone?.body?.cancel().catch(() => undefined);
-        await request;
-      }
-      expect(tracked.wasCanceled()).toBe(true);
-    },
-  );
-
   it.each([
     {
       name: "reports malformed model list JSON with an owned error",

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -593,20 +593,39 @@ describe("lmstudio-models", () => {
     expect(tracked.wasCanceled()).toBe(true);
   });
 
-  it("cancels guarded non-ok discovery bodies before releasing the dispatcher", async () => {
-    const tracked = cancelTrackedResponse("unavailable", { status: 503 });
-    const release = vi.fn(async () => undefined);
-    fetchWithSsrFGuardMock.mockResolvedValue({ response: tracked.response, release });
-
-    const result = await fetchLmstudioModels({
-      baseUrl: "http://localhost:1234/v1",
-      ssrfPolicy: {},
-    });
-
-    expect(result).toMatchObject({ reachable: true, status: 503, models: [] });
-    expect(tracked.wasCanceled()).toBe(true);
-    expect(release).toHaveBeenCalledOnce();
-  });
+  it.each([false, true])(
+    "releases guarded non-ok discovery without waiting for capture (retained clone: %s)",
+    async (retainCaptureClone) => {
+      const tracked = cancelTrackedResponse("unavailable", { status: 503 });
+      const captureClone = retainCaptureClone ? tracked.response.clone() : undefined;
+      const release = vi.fn(async () => undefined);
+      fetchWithSsrFGuardMock.mockResolvedValue({ response: tracked.response, release });
+      const request = fetchLmstudioModels({
+        baseUrl: "http://localhost:1234/v1",
+        ssrfPolicy: {},
+      });
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const result = await Promise.race([
+          request,
+          new Promise<never>((_resolve, reject) => {
+            timeout = setTimeout(
+              () => reject(new Error("LM Studio cleanup waited for the capture clone")),
+              500,
+            );
+          }),
+        ]);
+        expect(result).toMatchObject({ reachable: true, status: 503, models: [] });
+        expect(tracked.response.bodyUsed).toBe(true);
+        expect(release).toHaveBeenCalledOnce();
+      } finally {
+        clearTimeout(timeout);
+        await captureClone?.body?.cancel().catch(() => undefined);
+        await request;
+      }
+      expect(tracked.wasCanceled()).toBe(true);
+    },
+  );
 
   it.each([
     {

--- a/extensions/whatsapp/src/auto-reply.web-auto-reply.media-delivery.test.ts
+++ b/extensions/whatsapp/src/auto-reply.web-auto-reply.media-delivery.test.ts
@@ -146,20 +146,16 @@ describe("web auto-reply media delivery", () => {
   }
 
   function fetchResponse(body: Buffer | null, mime: string, status = 200): Response {
-    return {
-      ok: status < 400,
-      body: body ? true : null,
-      arrayBuffer: async () =>
-        body
-          ? body.buffer.slice(body.byteOffset, body.byteOffset + body.length)
-          : new ArrayBuffer(0),
-      headers: new Headers({ "content-type": mime }),
+    return new Response(body ? Uint8Array.from(body) : null, {
+      headers: { "content-type": mime },
       status,
-    } as unknown as Response;
+    });
   }
 
   function mockFetchMediaBuffer(buffer: Buffer, mime: string) {
-    return vi.spyOn(globalThis, "fetch").mockResolvedValue(fetchResponse(buffer, mime));
+    return vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => fetchResponse(buffer, mime));
   }
 
   async function expectCompressedImageWithinCap(params: {

--- a/extensions/whatsapp/src/media.test.ts
+++ b/extensions/whatsapp/src/media.test.ts
@@ -159,15 +159,9 @@ describe("web media loading", () => {
   });
 
   it("includes URL + status in fetch errors", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: false,
-      body: true,
-      text: async () => "Not Found",
-      headers: { get: () => null },
-      status: 404,
-      statusText: "Not Found",
-      url: "https://example.com/missing.jpg",
-    } as unknown as Response);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("Not Found", { status: 404, statusText: "Not Found" }));
 
     await expect(loadWebMedia("https://example.com/missing.jpg", 1024 * 1024)).rejects.toThrow(
       /Failed to fetch media from https:\/\/example\.com\/missing\.jpg.*HTTP 404/i,
@@ -201,15 +195,11 @@ describe("web media loading", () => {
   });
 
   it("respects maxBytes for raw URL fetches", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      body: true,
-      arrayBuffer: async () => Buffer.alloc(2048).buffer,
-      headers: {
-        get: (name: string) => (name === "content-type" ? "image/png" : null),
-      },
-      status: 200,
-    } as unknown as Response);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array(2048), { headers: { "content-type": "image/png" } }),
+      );
 
     await expect(loadWebMediaRaw("https://example.com/too-big.png", 1024)).rejects.toThrow(
       /exceeds maxBytes 1024/i,
@@ -232,24 +222,14 @@ describe("web media loading", () => {
 
   it("uses content-disposition filename when available", async () => {
     const pdfBytes = Buffer.from("%PDF-1.4");
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      body: true,
-      arrayBuffer: async () =>
-        pdfBytes.buffer.slice(pdfBytes.byteOffset, pdfBytes.byteOffset + pdfBytes.byteLength),
-      headers: {
-        get: (name: string) => {
-          if (name === "content-disposition") {
-            return 'attachment; filename="report.pdf"';
-          }
-          if (name === "content-type") {
-            return "application/pdf";
-          }
-          return null;
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(Uint8Array.from(pdfBytes), {
+        headers: {
+          "content-disposition": 'attachment; filename="report.pdf"',
+          "content-type": "application/pdf",
         },
-      },
-      status: 200,
-    } as unknown as Response);
+      }),
+    );
 
     const result = await loadWebMedia("https://example.com/download?id=1", 1024 * 1024);
 
@@ -265,16 +245,9 @@ describe("web media loading", () => {
       0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x02, 0x01, 0x44, 0x00, 0x3b,
     ]);
 
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      body: true,
-      arrayBuffer: async () =>
-        gifBytes.buffer.slice(gifBytes.byteOffset, gifBytes.byteOffset + gifBytes.byteLength),
-      headers: {
-        get: (name: string) => (name === "content-type" ? "image/gif" : null),
-      },
-      status: 200,
-    } as unknown as Response);
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(gifBytes, { headers: { "content-type": "image/gif" } }));
 
     const result = await loadWebMedia("https://example.com/animation.gif", 1024 * 1024);
 

--- a/src/agents/tools/pdf-native-providers.test.ts
+++ b/src/agents/tools/pdf-native-providers.test.ts
@@ -19,6 +19,7 @@ function makeAnthropicAnalyzeParams(
     prompt: string;
     pdfs: Array<{ base64: string; filename: string }>;
     maxTokens: number;
+    signal: AbortSignal;
     baseUrl: string;
     requestConfig: Parameters<typeof pdfNativeProviders.anthropicAnalyzePdf>[0]["requestConfig"];
   }> = {},
@@ -40,6 +41,7 @@ function makeGeminiAnalyzeParams(
     pdfs: Array<{ base64: string; filename: string }>;
     baseUrl: string;
     requestConfig: Parameters<typeof pdfNativeProviders.geminiAnalyzePdf>[0]["requestConfig"];
+    signal: AbortSignal;
   }> = {},
 ) {
   return {
@@ -63,8 +65,11 @@ describe("native PDF provider API calls", () => {
 
   const textResponse = (body: string, init?: ResponseInit): Response => new Response(body, init);
 
-  const mockFetchResponse = (response: Response) => {
-    const fetchMock = vi.fn().mockResolvedValue(response);
+  const mockFetchResponse = (response: Response, onFetch?: (init?: RequestInit) => void) => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      onFetch?.(init);
+      return response;
+    });
     global.fetch = Object.assign(fetchMock, { preconnect: vi.fn() }) as typeof global.fetch;
     return fetchMock;
   };
@@ -91,10 +96,15 @@ describe("native PDF provider API calls", () => {
   });
 
   it("anthropicAnalyzePdf sends correct request shape", async () => {
+    const parent = new AbortController();
+    let abortedAtFetch: boolean | undefined;
     const fetchMock = mockFetchResponse(
       jsonResponse({
         content: [{ type: "text", text: "Analysis of PDF" }],
       }),
+      (init) => {
+        abortedAtFetch = init?.signal?.aborted;
+      },
     );
 
     const result = await pdfNativeProviders.anthropicAnalyzePdf(
@@ -102,6 +112,7 @@ describe("native PDF provider API calls", () => {
         modelId: "claude-opus-4-6",
         prompt: "Summarize this document",
         maxTokens: 4096,
+        signal: parent.signal,
       }),
     );
 
@@ -114,7 +125,9 @@ describe("native PDF provider API calls", () => {
     expect(url).toContain("/v1/messages");
     expect(opts.headers.get("x-api-key")).toBe("test-key");
     expect(opts.signal).toBeInstanceOf(AbortSignal);
-    expect(opts.signal.aborted).toBe(false);
+    expect(abortedAtFetch).toBe(false);
+    expect(opts.signal.aborted).toBe(true);
+    expect(parent.signal.aborted).toBe(false);
     const body = JSON.parse(opts.body);
     expect(body.model).toBe("claude-opus-4-6");
     expect(body.messages[0].content).toHaveLength(2);
@@ -482,16 +495,22 @@ describe("native PDF provider API calls", () => {
   it("geminiAnalyzePdf sends correct request shape", async () => {
     // Gemini API keys belong in headers here, not query strings that are more
     // likely to leak through logs and URL diagnostics.
+    const parent = new AbortController();
+    let abortedAtFetch: boolean | undefined;
     const fetchMock = mockFetchResponse(
       jsonResponse({
         candidates: [{ content: { parts: [{ text: "Gemini PDF analysis" }] } }],
       }),
+      (init) => {
+        abortedAtFetch = init?.signal?.aborted;
+      },
     );
 
     const result = await pdfNativeProviders.geminiAnalyzePdf(
       makeGeminiAnalyzeParams({
         modelId: "gemini-2.5-pro",
         prompt: "Summarize this",
+        signal: parent.signal,
       }),
     );
 
@@ -506,7 +525,9 @@ describe("native PDF provider API calls", () => {
     expect(url).not.toContain("?key=");
     expect(opts.headers.get("x-goog-api-key")).toBe("test-key");
     expect(opts.signal).toBeInstanceOf(AbortSignal);
-    expect(opts.signal.aborted).toBe(false);
+    expect(abortedAtFetch).toBe(false);
+    expect(opts.signal.aborted).toBe(true);
+    expect(parent.signal.aborted).toBe(false);
     const body = JSON.parse(opts.body);
     expect(body.contents[0].parts).toHaveLength(2);
     expect(body.contents[0].parts[0].inline_data.mime_type).toBe("application/pdf");

--- a/src/gateway/portals/portal-service.test.ts
+++ b/src/gateway/portals/portal-service.test.ts
@@ -1,7 +1,8 @@
 import { request, type Server } from "node:http";
 import type { Duplex } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getFreePort } from "../../test-utils/ports.js";
+import { readResponseWithLimit } from "../../infra/http-body.js";
+import { withServer } from "../../plugin-sdk/test-helpers/http-test-server.js";
 import * as httpListen from "../server/http-listen.js";
 import { createGatewayPortalService, type GatewayPortalService } from "./portal-service.js";
 
@@ -35,14 +36,13 @@ async function getStatus(host: string, port: number, path: string): Promise<numb
   });
 }
 
-async function getDistinctFreePort(excluded: number): Promise<number> {
-  for (let attempt = 0; attempt < 10; attempt += 1) {
-    const port = await getFreePort();
-    if (port !== excluded) {
-      return port;
-    }
+function reportTargetPortCollision(server: Server, targetPort: number): void {
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Missing portal listener address");
   }
-  throw new Error("Failed to reserve a distinct test port");
+  // Keep the OS allocation owned; only the next collision check sees the target port.
+  vi.spyOn(server, "address").mockReturnValueOnce({ ...address, port: targetPort });
 }
 
 describe("portal open authority fence", () => {
@@ -109,67 +109,80 @@ describe("gateway portal service", () => {
   });
 
   it("retries a target-port collision before binding sibling hosts", async () => {
-    const targetPort = await getFreePort();
-    const acceptedPort = await getDistinctFreePort(targetPort);
-    const actualListen = httpListen.listenGatewayHttpServer;
-    const calls: Array<{ host: string; port: number }> = [];
-    let primaryAttempt = 0;
-    vi.spyOn(httpListen, "listenGatewayHttpServer").mockImplementation(async (params) => {
-      calls.push({ host: params.bindHost, port: params.port });
-      if (params.bindHost === "127.0.0.1" && params.port === 0) {
-        primaryAttempt += 1;
-        await actualListen({
-          ...params,
-          port: primaryAttempt === 1 ? targetPort : acceptedPort,
+    await withServer(
+      (_req, res) => res.end("target"),
+      async (targetUrl) => {
+        const targetPort = Number(new URL(targetUrl).port);
+        const actualListen = httpListen.listenGatewayHttpServer;
+        const calls: Array<{ host: string; port: number }> = [];
+        let primaryAttempt = 0;
+        vi.spyOn(httpListen, "listenGatewayHttpServer").mockImplementation(async (params) => {
+          calls.push({ host: params.bindHost, port: params.port });
+          await actualListen(params);
+          if (params.bindHost === "127.0.0.1" && params.port === 0) {
+            primaryAttempt += 1;
+            if (primaryAttempt === 1) {
+              reportTargetPortCollision(params.httpServer, targetPort);
+            }
+          }
         });
-        return;
-      }
-      await actualListen(params);
-    });
-    const { service, httpServers } = makeService(["127.0.0.1", "::1"]);
+        const { service, httpServers } = makeService(["127.0.0.1", "::1"]);
 
-    const portal = await service.open({ targetPort });
+        const portal = await service.open({ targetPort });
 
-    expect(portal.listenPort).toBe(acceptedPort);
-    expect(calls).toEqual([
-      { host: "127.0.0.1", port: 0 },
-      { host: "127.0.0.1", port: 0 },
-      { host: "::1", port: acceptedPort },
-    ]);
-    expect(httpServers).toHaveLength(2);
-    expect(httpServers.every((server) => server.listening)).toBe(true);
-    expect(await getStatus("127.0.0.1", portal.listenPort, `/?${portal.tokenQuery}`)).toBe(502);
+        expect(portal.listenPort).not.toBe(targetPort);
+        expect(calls).toEqual([
+          { host: "127.0.0.1", port: 0 },
+          { host: "127.0.0.1", port: 0 },
+          { host: "::1", port: portal.listenPort },
+        ]);
+        expect(httpServers).toHaveLength(2);
+        expect(httpServers.every((server) => server.listening)).toBe(true);
+        for (const server of httpServers) {
+          expect(server.address()).toMatchObject({ port: portal.listenPort });
+        }
+        const response = await fetch(portal.url);
+        expect(response.status).toBe(200);
+        expect((await readResponseWithLimit(response, 32)).toString("utf8")).toBe("target");
 
-    const ownedServers = [...httpServers];
-    await service.closeAll();
-    expect(httpServers).toEqual([]);
-    expect(ownedServers.every((server) => !server.listening && server.address() === null)).toBe(
-      true,
+        const ownedServers = [...httpServers];
+        await service.closeAll();
+        expect(httpServers).toEqual([]);
+        expect(ownedServers.every((server) => !server.listening && server.address() === null)).toBe(
+          true,
+        );
+      },
     );
   });
 
   it("cleans up when every allocation collides with the target port", async () => {
-    const targetPort = await getFreePort();
-    const actualListen = httpListen.listenGatewayHttpServer;
-    const attemptedServers = new Set<Server>();
-    const listen = vi
-      .spyOn(httpListen, "listenGatewayHttpServer")
-      .mockImplementation(async (params) => {
-        attemptedServers.add(params.httpServer);
-        await actualListen({ ...params, port: targetPort });
-      });
-    const { service, httpServers } = makeService(["127.0.0.1"]);
+    await withServer(
+      (_req, res) => res.end("target"),
+      async (targetUrl) => {
+        const targetPort = Number(new URL(targetUrl).port);
+        const actualListen = httpListen.listenGatewayHttpServer;
+        const attemptedServers = new Set<Server>();
+        const listen = vi
+          .spyOn(httpListen, "listenGatewayHttpServer")
+          .mockImplementation(async (params) => {
+            attemptedServers.add(params.httpServer);
+            await actualListen(params);
+            reportTargetPortCollision(params.httpServer, targetPort);
+          });
+        const { service, httpServers } = makeService(["127.0.0.1"]);
 
-    await expect(service.open({ targetPort })).rejects.toThrow(
-      `Portal listener repeatedly allocated target port ${targetPort}`,
+        await expect(service.open({ targetPort })).rejects.toThrow(
+          `Portal listener repeatedly allocated target port ${targetPort}`,
+        );
+
+        expect(listen).toHaveBeenCalledTimes(10);
+        expect(attemptedServers.size).toBe(1);
+        expect(httpServers).toEqual([]);
+        const [primaryServer] = attemptedServers;
+        expect(primaryServer?.listening).toBe(false);
+        expect(primaryServer?.address()).toBeNull();
+      },
     );
-
-    expect(listen).toHaveBeenCalledTimes(10);
-    expect(attemptedServers.size).toBe(1);
-    expect(httpServers).toEqual([]);
-    const [primaryServer] = attemptedServers;
-    expect(primaryServer?.listening).toBe(false);
-    expect(primaryServer?.address()).toBeNull();
   });
 
   it("updates an existing target without replacing its listener or token", async () => {

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -227,8 +227,7 @@ async function postCronWebhookStrict(params: {
     params.onDeliveryAccepted?.();
   } finally {
     const cleanup = async () => {
-      // Guard release closes the dispatcher, not an unread response stream.
-      // Keep response cleanup inside the request deadline; a non-settling
+      // Keep response cleanup before guard release inside the request deadline; a non-settling
       // stream cancellation must not retain the dispatcher or Gateway root.
       if (!result.response.bodyUsed) {
         const cancellation = result.response.body?.cancel();

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -142,7 +142,9 @@ describe("cancelUnreadResponseBody", () => {
     try {
       const completed = await Promise.race([
         cleanup.then(() => true),
-        new Promise<boolean>((resolve) => setImmediate(() => resolve(false))),
+        new Promise<boolean>((resolve) => {
+          setImmediate(() => resolve(false));
+        }),
       ]);
       expect(completed).toBe(true);
       expect(response.bodyUsed).toBe(true);

--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -133,6 +133,26 @@ describe("cancelUnreadResponseBody", () => {
 
     expect(cancel).not.toHaveBeenCalled();
   });
+
+  it("does not wait for a retained response clone to finish cancellation", async () => {
+    const cancel = vi.fn();
+    const response = new Response(makeStallingStream([], cancel));
+    const capture = response.clone();
+    const cleanup = cancelUnreadResponseBody(response);
+    try {
+      const completed = await Promise.race([
+        cleanup.then(() => true),
+        new Promise<boolean>((resolve) => setImmediate(() => resolve(false))),
+      ]);
+      expect(completed).toBe(true);
+      expect(response.bodyUsed).toBe(true);
+      expect(cancel).not.toHaveBeenCalled();
+    } finally {
+      await capture.body?.cancel();
+      await cleanup;
+    }
+    expect(cancel).toHaveBeenCalledOnce();
+  });
 });
 
 describe("readResponseWithLimit", () => {

--- a/src/infra/http-body.ts
+++ b/src/infra/http-body.ts
@@ -12,10 +12,11 @@ import { readChunkWithIdleTimeout, withResponseBodyTimeout } from "./http-respon
 
 export { readChunkWithIdleTimeout } from "./http-response-body-timeout.js";
 
-/** Cancels a response body only when no consumer has started reading it. */
+/** Requests cancellation only when no consumer has started reading the body. */
 export async function cancelUnreadResponseBody(response: Response | undefined): Promise<void> {
   if (response && !response.bodyUsed) {
-    await response.body?.cancel().catch(() => undefined);
+    // A capture tee must not delay errors or the caller's bounded dispatcher release.
+    void response.body?.cancel().catch(() => undefined);
   }
 }
 

--- a/src/infra/net/fetch-guard.release.test.ts
+++ b/src/infra/net/fetch-guard.release.test.ts
@@ -34,7 +34,7 @@ describe("guarded request release", () => {
     const releases: Array<() => Promise<void>> = [];
     const fetchImpl = async (input: RequestInfo | URL, init?: DispatcherAwareRequestInit) => {
       dispatchers.push(init?.dispatcher);
-      const url = String(input);
+      const url = input instanceof Request ? input.url : input.toString();
       const captured = createDeferredCore<CaptureEventRecord>();
       captures.set(new URL(url).pathname, captured);
       const response = await fetchWithRuntimeDispatcher(input, init);
@@ -59,9 +59,8 @@ describe("guarded request release", () => {
               }
             },
           }),
-          persistEventPayload: (_store, { data }) => ({
-            ...(Buffer.isBuffer(data) ? { dataText: data.toString("utf8") } : {}),
-          }),
+          persistEventPayload: (_store, { data }) =>
+            Buffer.isBuffer(data) ? { dataText: data.toString("utf8") } : {},
         },
       );
       return response;
@@ -140,9 +139,13 @@ describe("guarded request release", () => {
     );
   });
 
-  it.each(["signal", "init"] as const)(
-    "preserves cancellation from %s without a guard timeout",
-    async (source) => {
+  it.each(
+    (["signal", "init"] as const).flatMap((source) =>
+      [undefined, 5_000].map((timeoutMs) => ({ source, timeoutMs })),
+    ),
+  )(
+    "preserves cancellation from $source with timeout $timeoutMs",
+    async ({ source, timeoutMs }) => {
       const parent = new AbortController();
       const reason = new Error("caller stopped");
       await withServer(
@@ -150,6 +153,7 @@ describe("guarded request release", () => {
         async (baseUrl) => {
           const result = await fetchWithSsrFGuard({
             url: baseUrl,
+            timeoutMs,
             ...(source === "signal"
               ? { signal: parent.signal }
               : { init: { signal: parent.signal } }),
@@ -169,4 +173,31 @@ describe("guarded request release", () => {
       );
     },
   );
+
+  it("gives the explicit caller signal precedence over init.signal with a timeout", async () => {
+    const parent = new AbortController();
+    const ignored = new AbortController();
+    const reason = new Error("explicit caller stopped");
+    await withServer(
+      (_request, response) => response.write("unfinished"),
+      async (baseUrl) => {
+        const result = await fetchWithSsrFGuard({
+          url: baseUrl,
+          signal: parent.signal,
+          init: { signal: ignored.signal },
+          timeoutMs: 5_000,
+          policy: { allowPrivateNetwork: true },
+        });
+        const body = result.response.text();
+        try {
+          ignored.abort(new Error("ignored init signal"));
+          parent.abort(reason);
+          await expect(withinDeadline(body)).rejects.toBe(reason);
+        } finally {
+          parent.abort();
+          await result.release();
+        }
+      },
+    );
+  });
 });

--- a/src/infra/net/fetch-guard.release.test.ts
+++ b/src/infra/net/fetch-guard.release.test.ts
@@ -1,0 +1,172 @@
+import type { ServerResponse } from "node:http";
+import type { Dispatcher } from "undici";
+import { describe, expect, it } from "vitest";
+import { withServer } from "../../plugin-sdk/test-helpers/http-test-server.js";
+import { captureHttpExchange } from "../../proxy-capture/runtime.js";
+import type { CaptureEventRecord } from "../../proxy-capture/types.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { fetchWithSsrFGuard } from "./fetch-guard.js";
+import { PinnedDispatcherPool } from "./pinned-dispatcher-pool.js";
+import { fetchWithRuntimeDispatcher, type DispatcherAwareRequestInit } from "./runtime-fetch.js";
+
+async function withinDeadline<T>(operation: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error("guard release did not settle")), 1_000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+describe("guarded request release", () => {
+  it("ends only the released request while a captured sibling keeps its pooled transport", async () => {
+    const abandonedClosed = createDeferredCore();
+    const heldResponse = createDeferredCore<ServerResponse>();
+    const parent = new AbortController();
+    const pool = new PinnedDispatcherPool({ maxEntries: 1, idleTtlMs: 60_000 });
+    const dispatchers: Array<Dispatcher | undefined> = [];
+    const captures = new Map<string, ReturnType<typeof createDeferredCore<CaptureEventRecord>>>();
+    const releases: Array<() => Promise<void>> = [];
+    const fetchImpl = async (input: RequestInfo | URL, init?: DispatcherAwareRequestInit) => {
+      dispatchers.push(init?.dispatcher);
+      const url = String(input);
+      const captured = createDeferredCore<CaptureEventRecord>();
+      captures.set(new URL(url).pathname, captured);
+      const response = await fetchWithRuntimeDispatcher(input, init);
+      captureHttpExchange(
+        { url, method: "GET", response },
+        {
+          enabled: true,
+          required: false,
+          dbPath: "unused-memory-sink",
+          blobDir: "unused-memory-sink",
+          certDir: "unused-memory-sink",
+          sessionId: "guard-release-test",
+          sourceProcess: "test",
+        },
+        {
+          getStore: () => ({
+            upsertSession() {},
+            endSession() {},
+            recordEvent(event) {
+              if (event.kind === "response" || event.kind === "error") {
+                captured.resolve(event);
+              }
+            },
+          }),
+          persistEventPayload: (_store, { data }) => ({
+            ...(Buffer.isBuffer(data) ? { dataText: data.toString("utf8") } : {}),
+          }),
+        },
+      );
+      return response;
+    };
+
+    await withServer(
+      (request, response) => {
+        if (request.url === "/abandoned") {
+          request.socket.once("close", () => abandonedClosed.resolve());
+          response.writeHead(503);
+          response.write("unused error body");
+        } else if (request.url === "/held") {
+          response.write("kept");
+          heldResponse.resolve(response);
+        } else {
+          response.end("complete");
+        }
+      },
+      async (baseUrl) => {
+        let heldBody: Promise<string> | undefined;
+        const get = async (path: string) => {
+          const result = await fetchWithSsrFGuard({
+            url: `${baseUrl}${path}`,
+            fetchImpl,
+            signal: parent.signal,
+            timeoutMs: 5_000,
+            policy: { allowPrivateNetwork: true, hostnameAllowlist: ["127.0.0.1"] },
+            dispatcherPool: pool,
+          });
+          releases.push(result.release);
+          return result;
+        };
+        try {
+          const abandoned = await get("/abandoned");
+          const held = await get("/held");
+          heldBody = held.response.text();
+          void heldBody.catch(() => undefined);
+          expect(abandoned.response.status).toBe(503);
+          expect(held.dispatcherReused).toBe(true);
+          expect(dispatchers[0]).toBeDefined();
+          expect(dispatchers[1]).toBe(dispatchers[0]);
+
+          await withinDeadline(abandoned.release().then(() => abandonedClosed.promise));
+          expect(parent.signal.aborted).toBe(false);
+          expect(await withinDeadline(captures.get("/abandoned")!.promise)).toMatchObject({
+            kind: "error",
+          });
+
+          (await heldResponse.promise).end("-alive");
+          expect(await withinDeadline(heldBody)).toBe("kept-alive");
+          await held.release();
+          expect(await withinDeadline(captures.get("/held")!.promise)).toMatchObject({
+            kind: "response",
+            status: 200,
+            dataText: "kept-alive",
+          });
+
+          const completed = await get("/complete");
+          expect(completed.dispatcherReused).toBe(true);
+          expect(dispatchers[2]).toBe(dispatchers[0]);
+          expect(await completed.response.text()).toBe("complete");
+          await completed.release();
+          expect(await withinDeadline(captures.get("/complete")!.promise)).toMatchObject({
+            kind: "response",
+            status: 200,
+            dataText: "complete",
+          });
+          expect(parent.signal.aborted).toBe(false);
+        } finally {
+          parent.abort();
+          await heldBody?.catch(() => undefined);
+          await Promise.all(releases.map((release) => release()));
+          await pool.closeAll();
+        }
+      },
+    );
+  });
+
+  it.each(["signal", "init"] as const)(
+    "preserves cancellation from %s without a guard timeout",
+    async (source) => {
+      const parent = new AbortController();
+      const reason = new Error("caller stopped");
+      await withServer(
+        (_request, response) => response.write("unfinished"),
+        async (baseUrl) => {
+          const result = await fetchWithSsrFGuard({
+            url: baseUrl,
+            ...(source === "signal"
+              ? { signal: parent.signal }
+              : { init: { signal: parent.signal } }),
+            policy: { allowPrivateNetwork: true },
+          });
+          const body = result.response.text();
+          try {
+            parent.abort(reason);
+            await expect(withinDeadline(body)).rejects.toBe(reason);
+            await result.release();
+            expect(parent.signal.reason).toBe(reason);
+          } finally {
+            parent.abort();
+            await result.release();
+          }
+        },
+      );
+    },
+  );
+});

--- a/src/infra/net/fetch-guard.release.test.ts
+++ b/src/infra/net/fetch-guard.release.test.ts
@@ -5,6 +5,7 @@ import { withServer } from "../../plugin-sdk/test-helpers/http-test-server.js";
 import { captureHttpExchange } from "../../proxy-capture/runtime.js";
 import type { CaptureEventRecord } from "../../proxy-capture/types.js";
 import { createDeferredCore } from "../../shared/deferred.js";
+import { readResponseWithLimit } from "../http-body.js";
 import { fetchWithSsrFGuard } from "./fetch-guard.js";
 import { PinnedDispatcherPool } from "./pinned-dispatcher-pool.js";
 import { fetchWithRuntimeDispatcher, type DispatcherAwareRequestInit } from "./runtime-fetch.js";
@@ -80,7 +81,7 @@ describe("guarded request release", () => {
         }
       },
       async (baseUrl) => {
-        let heldBody: Promise<string> | undefined;
+        let heldBody: Promise<Buffer> | undefined;
         const get = async (path: string) => {
           const result = await fetchWithSsrFGuard({
             url: `${baseUrl}${path}`,
@@ -96,7 +97,7 @@ describe("guarded request release", () => {
         try {
           const abandoned = await get("/abandoned");
           const held = await get("/held");
-          heldBody = held.response.text();
+          heldBody = readResponseWithLimit(held.response, 32);
           void heldBody.catch(() => undefined);
           expect(abandoned.response.status).toBe(503);
           expect(held.dispatcherReused).toBe(true);
@@ -110,7 +111,7 @@ describe("guarded request release", () => {
           });
 
           (await heldResponse.promise).end("-alive");
-          expect(await withinDeadline(heldBody)).toBe("kept-alive");
+          expect((await withinDeadline(heldBody)).toString("utf8")).toBe("kept-alive");
           await held.release();
           expect(await withinDeadline(captures.get("/held")!.promise)).toMatchObject({
             kind: "response",
@@ -121,7 +122,9 @@ describe("guarded request release", () => {
           const completed = await get("/complete");
           expect(completed.dispatcherReused).toBe(true);
           expect(dispatchers[2]).toBe(dispatchers[0]);
-          expect(await completed.response.text()).toBe("complete");
+          expect((await readResponseWithLimit(completed.response, 32)).toString("utf8")).toBe(
+            "complete",
+          );
           await completed.release();
           expect(await withinDeadline(captures.get("/complete")!.promise)).toMatchObject({
             kind: "response",
@@ -159,7 +162,7 @@ describe("guarded request release", () => {
               : { init: { signal: parent.signal } }),
             policy: { allowPrivateNetwork: true },
           });
-          const body = result.response.text();
+          const body = readResponseWithLimit(result.response, 32);
           try {
             parent.abort(reason);
             await expect(withinDeadline(body)).rejects.toBe(reason);
@@ -188,7 +191,7 @@ describe("guarded request release", () => {
           timeoutMs: 5_000,
           policy: { allowPrivateNetwork: true },
         });
-        const body = result.response.text();
+        const body = readResponseWithLimit(result.response, 32);
         try {
           ignored.abort(new Error("ignored init signal"));
           parent.abort(reason);

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -1016,6 +1016,50 @@ describe("fetchWithSsrFGuard hardening", () => {
     }
   });
 
+  it.each(["/next", undefined])(
+    "settles redirects before retained capture cancellation (location: %s)",
+    async (location) => {
+      const cancel = vi.fn();
+      const response = new Response(new ReadableStream<Uint8Array>({ cancel }), {
+        status: 302,
+        headers: location ? { location } : {},
+      });
+      const capture = response.clone();
+      const fetchImpl = vi.fn().mockResolvedValueOnce(response).mockResolvedValueOnce(okResponse());
+      const request = fetchWithSsrFGuard({
+        url: "https://public.example/start",
+        fetchImpl,
+        lookupFn: createPublicLookup(),
+      }).then(
+        async (result) => {
+          try {
+            return await result.response.text();
+          } finally {
+            await result.release();
+          }
+        },
+        (error: unknown) => error,
+      );
+
+      try {
+        const result = await raceWithTimeoutResult(request, 500, undefined);
+        if (location) {
+          expect(result).toBe("ok");
+        } else {
+          expect(result).toBeInstanceOf(Error);
+          expect(result).toMatchObject({ message: "Redirect missing location header (302)" });
+        }
+        expect(fetchImpl).toHaveBeenCalledTimes(location ? 2 : 1);
+        expect(response.bodyUsed).toBe(true);
+        expect(cancel).not.toHaveBeenCalled();
+      } finally {
+        await capture.body?.cancel();
+        await request;
+      }
+      expect(cancel).toHaveBeenCalledOnce();
+    },
+  );
+
   it("strips sensitive headers when redirect crosses origins", async () => {
     const lookupFn = createPublicLookup();
     const fetchImpl = vi

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -3,6 +3,7 @@ import { toErrorObject as toLintErrorObject } from "@openclaw/normalization-core
 // trusted proxy modes, and safe header retention.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readResponseWithLimit } from "../http-body.js";
 import {
   fetchConfiguredLocalOriginWithSsrFGuard,
   fetchWithSsrFGuard,
@@ -1033,7 +1034,7 @@ describe("fetchWithSsrFGuard hardening", () => {
       }).then(
         async (result) => {
           try {
-            return await result.response.text();
+            return (await readResponseWithLimit(result.response, 32)).toString("utf8");
           } finally {
             await result.release();
           }

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -9,6 +9,7 @@ import {
   normalizeHeadersInitForFetch,
   normalizeRequestInitHeadersForFetch,
 } from "../fetch-headers.js";
+import { cancelUnreadResponseBody } from "../http-body.js";
 import {
   shouldUseConfiguredLocalOriginManagedProxyBypass,
   shouldResolveConfiguredLocalOriginManagedProxyBypass,
@@ -559,9 +560,14 @@ async function fetchWithSsrFGuardInternal(
 
     let dispatcher: Dispatcher | null = null;
     let dispatcherLease: PinnedDispatcherLease | undefined;
-    let activeResponse: Response | undefined;
-    const releaseDispatcher = async () =>
+    let response: Response | undefined;
+    const requestController = new AbortController();
+    const releaseDispatcher = async () => {
+      // Release only this hop's transport, including capture tees, before returning its pool lease.
+      requestController.abort();
+      await cancelUnreadResponseBody(response);
       await (dispatcherLease ? dispatcherLease.release() : closeDispatcher(dispatcher));
+    };
     // Resolve inside the redirect loop so exact-origin trust never carries across origins.
     const policyForUrl = resolveSsrFPolicyForUrl(parsedUrl, params.policy);
     const dispatcherPolicy = params.resolveDispatcherPolicy?.(parsedUrl) ?? params.dispatcherPolicy;
@@ -689,11 +695,14 @@ async function fetchWithSsrFGuardInternal(
         }
       }
 
+      const requestSignal = signal ?? currentInit?.signal;
       const init: DispatcherAwareRequestInit = {
         ...(currentInit ? { ...currentInit } : {}),
         redirect: "manual",
         ...(dispatcher ? { dispatcher } : {}),
-        ...(signal ? { signal } : {}),
+        signal: requestSignal
+          ? AbortSignal.any([requestSignal, requestController.signal])
+          : requestController.signal,
       };
 
       const supportsDispatcherInit =
@@ -708,10 +717,9 @@ async function fetchWithSsrFGuardInternal(
       // because the default global fetch path will not honor per-request
       // dispatchers.
       const shouldUseRuntimeFetch = Boolean(dispatcher) && !supportsDispatcherInit;
-      const response = shouldUseRuntimeFetch
+      response = shouldUseRuntimeFetch
         ? await fetchWithRuntimeDispatcher(parsedUrl.toString(), init)
         : await defaultFetch(parsedUrl.toString(), init);
-      activeResponse = response;
       const capturedByGlobalFetchPatch =
         !shouldUseRuntimeFetch &&
         isAmbientGlobalFetch({
@@ -765,8 +773,6 @@ async function fetchWithSsrFGuardInternal(
           throw new Error("Redirect loop detected");
         }
         visited.add(nextVisitKey);
-        await response.body?.cancel().catch(() => undefined);
-        activeResponse = undefined;
         await releaseDispatcher();
         currentUrl = nextUrl;
         continue;
@@ -786,7 +792,6 @@ async function fetchWithSsrFGuardInternal(
           `security: blocked URL fetch (${context}) targetOrigin=${parsedUrl.origin} reason=${err.message}`,
         );
       }
-      await activeResponse?.body?.cancel().catch(() => undefined);
       await finishRequest(releaseDispatcher);
       throw err;
     }

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -517,9 +517,10 @@ async function fetchWithSsrFGuardInternal(
       : DEFAULT_MAX_REDIRECTS;
   const mode = resolveGuardedFetchMode(params);
 
+  // Compose the caller signal before the deadline can mask init.signal.
   const { signal, cleanup, refresh } = buildTimeoutAbortSignal({
     timeoutMs: params.timeoutMs,
-    signal: params.signal,
+    signal: params.signal ?? params.init?.signal ?? undefined,
     operation: "fetchWithSsrFGuard",
     url: params.url,
   });
@@ -685,23 +686,20 @@ async function fetchWithSsrFGuardInternal(
                 timeoutMs,
               ),
           });
-          if (!dispatcherLease) {
-            dispatcher = createPinnedDispatcher(pinned, undefined, policyForUrl, timeoutMs);
-          } else {
-            dispatcher = dispatcherLease.dispatcher;
-          }
+          dispatcher = dispatcherLease
+            ? dispatcherLease.dispatcher
+            : createPinnedDispatcher(pinned, undefined, policyForUrl, timeoutMs);
         } else {
           dispatcher = createPinnedDispatcher(pinned, dispatcherPolicy, policyForUrl, timeoutMs);
         }
       }
 
-      const requestSignal = signal ?? currentInit?.signal;
       const init: DispatcherAwareRequestInit = {
         ...(currentInit ? { ...currentInit } : {}),
         redirect: "manual",
         ...(dispatcher ? { dispatcher } : {}),
-        signal: requestSignal
-          ? AbortSignal.any([requestSignal, requestController.signal])
+        signal: signal
+          ? AbortSignal.any([signal, requestController.signal])
           : requestController.signal,
       };
 

--- a/src/video-generation/dashscope-compatible.test.ts
+++ b/src/video-generation/dashscope-compatible.test.ts
@@ -360,7 +360,9 @@ describe("downloadDashscopeGeneratedVideos", () => {
   it("releases the guarded fetch when the remaining-budget resolver throws", async () => {
     vi.useFakeTimers();
     try {
+      const initialTimerCount = vi.getTimerCount();
       let requestSignal: AbortSignal | undefined;
+      let abortedAtFetch: boolean | undefined;
       const cancelBody = vi.fn();
       const timeoutMs = vi
         .fn<() => number>()
@@ -370,6 +372,7 @@ describe("downloadDashscopeGeneratedVideos", () => {
         });
       const fetchFn = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
         requestSignal = init?.signal ?? undefined;
+        abortedAtFetch = requestSignal?.aborted;
         return new Response(new ReadableStream({ cancel: cancelBody }), {
           status: 200,
           headers: { "content-type": "video/mp4" },
@@ -391,9 +394,9 @@ describe("downloadDashscopeGeneratedVideos", () => {
       expect(cancelBody.mock.calls[0]?.[0]).toMatchObject({
         message: "remaining-budget resolver failed",
       });
-      expect(requestSignal?.aborted).toBe(false);
-      await vi.advanceTimersByTimeAsync(100);
-      expect(requestSignal?.aborted).toBe(false);
+      expect(abortedAtFetch).toBe(false);
+      expect(requestSignal?.aborted).toBe(true);
+      expect(vi.getTimerCount()).toBe(initialTimerCount);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users discovering LM Studio models, reading live provider catalogs, or authenticating GitHub Copilot could wait for an unused error response body when HTTP capture retained a clone. Redirects could also stall before proceeding or reporting a missing/blocked destination.

Also fixes in-flight caller cancellation being lost when a guarded request supplies `init.signal` alongside a timeout, including native PDF requests. The caller signal must be selected before composing the deadline, rather than being replaced by its generated signal.

## Why This Change Was Made

Cancellation of one branch of a cloned response can remain pending until the capture branch finishes. Unread-body cleanup now requests cancellation without waiting for that unrelated consumer. The guarded request owns a fresh abort controller for each redirect hop and ends only that hop before returning its dispatcher lease. This also bounds the abandoned transport rather than merely making the status error prompt.

The core cancellation helper remains the canonical internal flow; duplicate one-use LM Studio and Copilot helpers are removed. Custom fetch implementations still receive response cancellation even if they ignore abort signals. Caller cancellation and its reason work with and without a timeout; an explicit top-level signal retains precedence over `init.signal`. Redirect authorization, pooled sibling requests, and completed captures are preserved. The public `release(): Promise<void>` signature and the shipped generic dispatcher graceful-close API are unchanged; no config, dependency, or storage changes are included.

The guard's awaited redirect cancellation is traceable to #121687, commit f09a33ce41244d48d22701cdc0e0c25f1d9b15e5 (2026-08-10; code/PR author and merger: @steipete). This identifies that guard regression, not a common origin for every affected provider helper.

## User Impact

Known HTTP failures and redirects settle promptly while guarded abandoned requests release their transport. Other in-flight requests sharing the same dispatcher and caller signal remain usable. Copilot's unguarded authentication request keeps its existing timeout/capture limits; this change promises prompt typed authentication errors, not immediate closure of that separate capture stream.

Callers can also cancel an in-flight request that combines a request-option signal with a deadline. The native PDF path is a current-main example, not a claimed stable-release PDF regression.

Existing reader-cancellation-before-release paths in streaming wrappers and prefix readers remain separate follow-ups. This is not a claim that all capture or streaming cancellation paths are repaired.

## Evidence

Reviewed corrective head: `fe2cb3cd0f28a607a435699576c3c3a95639e598`.

- Full frozen before/after proof used owned localhost HTTP servers, the public runtime/catalog paths, the real SSRF guard and dispatcher, and actual capture with an in-memory sink. This is live HTTP boundary proof, not authenticated LM Studio or Copilot service testing; no user models, service configuration, or credentials were used.
- LM Studio 503: original remained pending past the unchanged 500 ms observation deadline; final repaired runtime returned the correct reachable/503 result and observed the actual server-side socket close in 43 ms. Both runs left zero owned sockets/listeners.
- Seven sibling HTTP cases: five original known-error/redirect cases waited beyond 1 second; all seven final repaired cases passed. Catalog 401, successful redirect, missing-location, and blocked-host outcomes took 34/6/2/3 ms with their abandoned sockets closed. The blocked destination received zero requests; cross-origin credentials remained stripped. Copilot 403 returned its typed recovery hint in 5 ms before fixture EOF. Catalog/Copilot 200 controls passed, with zero owned sockets/timers/listeners after cleanup.
- Retained real TCP regression: original guard failed the 1-second release-and-close deadline; candidate passed. A held response on the same real pooled Agent and parent signal completed with its full capture, then a third request reused the dispatcher. The expanded six-case suite also proves caller signals with/without timeout and explicit top-level precedence. Before the producer fix, only `init.signal` plus timeout failed; afterward all six passed.
- Actual native PDF public request to an owned localhost HTTP server: abort after the server sent a response prefix was ignored beyond 1 second before the producer fix. The final request rejected with the exact caller reason and closed its socket in 6 ms, leaving zero owned sockets/listeners. This proves in-flight cancellation, not an authenticated vendor request or a claim that client-side body reading had already begun.
- **456 tests passed across 18 complete owner/sibling files**, covering HTTP body handling, SSRF/redirects, real release, dispatcher pooling/runtime fetch, live catalogs, capture, LM Studio, Copilot, Ollama, Hugging Face, native PDF, DashScope, and WhatsApp media. After the final test-only reader correction below, **167 tests across four complete files** passed again; these are overlapping reruns, not additional unique coverage. Formatting and targeted core type-aware lint passed. Fresh full-patch P0–P2 and independent source/proof review, including the final reader correction, found no actionable issues.
- The first hosted run passed build and production/test types and executed the retained TCP test against the frozen pinned installation, but failed lint and exposed post-release signal assertions and incomplete `Response` fixtures. The corrections preserve admission-live/owned-release-aborted state, cleared timer ownership, byte caps, cancellation, and media payload/error assertions using real response streams; no production fallback or weaker lint rule was added.
- The next full CI run at `9b9ab4a461529a1b4df9b38b268ea898b8de8d08` passed after one unchanged failed-job retry. Its first attempt had doctor process/hook timeouts amid broad 8–9× slowdown; the cause remains unknown, and the entire seven-group job plus gate passed on retry. The separate OpenGrep scan flagged five direct response reads in our owned test fixtures. Those reads now use the existing 32-byte bounded whole-body reader, with no new timer, truncation, suppression, or scan exclusion. Against the original guard, the modified tests still produced the four intended release/cancellation/redirect failures while 113 controls passed; restoring the candidate passed all 117, then the 167-test reader/guard scope.
- The reader-correction head passed the separate OpenGrep scan, then full CI exposed a pre-existing portal test allocation race before the retained TCP group could run. A controlled second-bind reproduction kept the original collision assertion: after the first listener closed, an owned competitor claimed its port, reproducing the exact `EADDRINUSE` error instead of the expected ten-collision terminal error. This was an intra-case allocation-order proof, not a full-file or cross-test culprit claim. The two fixtures now hold an owned target, leave actual socket allocation at port zero, and inject only the one-shot reported address needed to exercise collision handling. All ten attempts, real listener shutdown, both bind hosts, and exact bounded HTTP forwarding remain proved. The complete portal service/proxy files passed **36 tests before and after**, and targeted type-aware lint passed. No production retry or timeout was changed. Fresh full-patch P0–P2 and independent source/proof review, including this final test correction, found no actionable issues.
- The separate portal proxy retry-page tests still cover HTTP 502. Their local probe-and-release target assumption at `src/gateway/portals/portal-http-proxy.test.ts:513` is a named follow-up, not fixed here; the deterministic worker failure cases remain unchanged.
- Final exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/33059647790) passed on its first attempt: 147 jobs, 126 successful and 21 skipped, including the required gate, production/test types, and lint. The complete head inventory has no failed or pending checks; the two cancelled checks are ancillary label/dispatch runs. The [precise OpenGrep scan](https://github.com/openclaw/openclaw/actions/runs/33059647805) also passed. The final hosted job executed all 15 portal service tests and all six retained TCP cases (68 ms) after the frozen dependency installation using the Undici 8.10.0 pin. This fulfills the latest completed ClawSweeper review's exact-head transport/CI rank-up request; its newer started-only review is not a completed verdict.
- Local runtime used Undici 8.9.0. Local plugin lint stopped during declaration preparation on existing dependency mismatches, so no full local type/lint pass is claimed; the final hosted types/lint and pinned-transport checks above supply that required validation.
- Runtime production LOC is net **-2**; the stale cron cleanup comment correction removes one further line. Total production **+29/-32 (net -3)**; tests **+526/-182 (net +344)**, including the focused LM fetch-test split, replacement of incomplete response fixtures, and portal allocation-fixture correction.
