### PR TITLE
fix(heartbeat): preserve wake outcomes and emit busy skips

### DIFF
--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -224,6 +224,11 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
 
   const getSize = opts.deps?.getQueueSize ?? getQueueSize;
   if (getSize(CommandLane.Main) > 0) {
+    emitHeartbeatEvent({
+      status: "skipped",
+      reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
+      durationMs: Date.now() - startedAt,
+    });
     return { kind: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT } as const;
   }
 
@@ -318,6 +323,11 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
         mainSessionRecovery.view.status === "recoverable")) ||
     hasCurrentRestartRecoveryDelivery
   ) {
+    emitHeartbeatEvent({
+      status: "skipped",
+      reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
+      durationMs: Date.now() - startedAt,
+    });
     return { kind: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT } as const;
   }
   const HEARTBEAT_DEFER_WINDOW_MS = 30_000;
@@ -334,6 +344,11 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
     recentSessionEntry?.updatedAt &&
     startedAt - recentSessionEntry.updatedAt < HEARTBEAT_DEFER_WINDOW_MS
   ) {
+    emitHeartbeatEvent({
+      status: "skipped",
+      reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
+      durationMs: Date.now() - startedAt,
+    });
     return { kind: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT } as const;
   }
 

--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -371,7 +371,20 @@ export function startHeartbeatRunner(opts: {
     if (agentOutcomes.some((outcome) => outcome.ran)) {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
-    return { status: "skipped", reason: isInterval ? "not-due" : "disabled" };
+    // Preserve per-agent guard results: wake-layer retry/retention keys off
+    // their reason, and the earliest guard deadline owns the next attempt.
+    const firstGuardSkip = agentOutcomes
+      .map((outcome) => outcome.result)
+      .filter((result) => result?.status === "skipped")
+      .filter((result) => result.retryAtMs !== undefined)
+      .toSorted((left, right) => (left.retryAtMs ?? Infinity) - (right.retryAtMs ?? Infinity))[0];
+    return (
+      firstGuardSkip ??
+      agentOutcomes.find((outcome) => outcome.result)?.result ?? {
+        status: "skipped",
+        reason: isInterval ? "not-due" : "disabled",
+      }
+    );
   };
 
   const wakeHandler: HeartbeatWakeHandler = async (params: HeartbeatWakeRequest) =>

--- a/src/infra/heartbeat-runner.broadcast-outcomes.test.ts
+++ b/src/infra/heartbeat-runner.broadcast-outcomes.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { getLastHeartbeatEvent, resetHeartbeatEventsForTest } from "./heartbeat-events.js";
+import { startHeartbeatRunner } from "./heartbeat-runner.js";
+import * as heartbeatWake from "./heartbeat-wake.js";
+
+describe("heartbeat broadcast outcomes", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    resetHeartbeatEventsForTest();
+  });
+
+  afterEach(async () => {
+    // A failed assertion must not leave retained work for the next runner.
+    const dispose = heartbeatWake.setHeartbeatWakeHandler(async () => ({
+      status: "skipped",
+      reason: "disabled",
+    }));
+    await vi.runAllTimersAsync();
+    dispose();
+    resetHeartbeatEventsForTest();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function startRunner() {
+    const register = vi.spyOn(heartbeatWake, "setHeartbeatWakeHandler");
+    const runOnce = vi
+      .fn<NonNullable<Parameters<typeof startHeartbeatRunner>[0]["runOnce"]>>()
+      .mockResolvedValue({ status: "ran", durationMs: 1 });
+    const cfg = {
+      agents: {
+        defaults: { heartbeat: { every: "30m" } },
+        list: [{ id: "main" }, { id: "ops" }],
+      },
+    } as OpenClawConfig;
+    const runner = startHeartbeatRunner({ cfg, runOnce });
+    onTestFinished(() => runner.stop());
+    const run = register.mock.calls[0]?.[0];
+    if (!run) {
+      throw new Error("Expected the runner to register a wake handler");
+    }
+    return { run, runOnce };
+  }
+
+  it("retains an untargeted task through min-spacing and dispatches its payload at the deadline", async () => {
+    const { run, runOnce } = startRunner();
+    await run({ source: "manual", intent: "manual" });
+    runOnce.mockClear();
+    vi.setSystemTime(1);
+    const wake = {
+      source: "cron",
+      intent: "task",
+      reason: "heartbeat-task:inbox",
+      tasks: [{ jobId: "inbox", name: "Inbox", prompt: "Check inbox" }],
+    } as const;
+
+    expect.soft(await run(wake)).toEqual({
+      status: "skipped",
+      reason: "min-spacing",
+      retryAtMs: 30_000,
+    });
+    expect(getLastHeartbeatEvent()).toBeNull();
+    heartbeatWake.requestHeartbeat({ ...wake, coalesceMs: 0 });
+    await vi.advanceTimersByTimeAsync(29_998);
+    expect(runOnce).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runOnce).toHaveBeenCalledTimes(2);
+    expect(
+      runOnce.mock.calls.map(([opts]) => ({ agentId: opts.agentId, tasks: opts.tasks })),
+    ).toEqual(["main", "ops"].map((agentId) => ({ agentId, tasks: wake.tasks })));
+  });
+
+  it.each([
+    { intent: "task", reason: "min-spacing", runs: 1, retryAtMs: 30_000 },
+    { intent: "scheduled", reason: "not-due", runs: 1, retryAtMs: 30 * 60_000 },
+    { intent: "immediate", reason: "flood", runs: 5, retryAtMs: 60_001 },
+  ] as const)("preserves the earliest $reason deadline across agents", async (testCase) => {
+    const { run } = startRunner();
+    for (let i = 0; i < testCase.runs; i++) {
+      await run({ source: "manual", intent: "manual", agentId: "ops" });
+    }
+    vi.setSystemTime(5_000);
+    for (let i = 0; i < testCase.runs; i++) {
+      await run({ source: "manual", intent: "manual", agentId: "main" });
+    }
+    vi.setSystemTime(10_000);
+
+    expect(await run({ source: "interval", intent: testCase.intent, reason: "interval" })).toEqual({
+      status: "skipped",
+      reason: testCase.reason,
+      retryAtMs: testCase.retryAtMs,
+    });
+  });
+
+  it.each([
+    { status: "skipped", reason: "quiet-hours" },
+    { status: "failed", reason: "agent-tool-failure" },
+  ] as const)("prefers a guard deferral over a sibling $reason outcome", async (terminal) => {
+    const { run, runOnce } = startRunner();
+    await run({ source: "manual", intent: "manual", agentId: "ops" });
+    vi.setSystemTime(1);
+    runOnce.mockResolvedValue(terminal);
+
+    expect(await run({ source: "cron", intent: "task" })).toEqual({
+      status: "skipped",
+      reason: "min-spacing",
+      retryAtMs: 30_000,
+    });
+  });
+
+  it.each([
+    { status: "skipped", reason: "quiet-hours" },
+    { status: "failed", reason: "agent-tool-failure" },
+  ] as const)("preserves the first $reason outcome when no agent can retry", async (result) => {
+    const { run, runOnce } = startRunner();
+    runOnce
+      .mockResolvedValueOnce(result)
+      .mockResolvedValue({ status: "skipped", reason: "disabled" });
+
+    expect(await run({ source: "cron", intent: "task" })).toEqual(result);
+  });
+
+  it("preserves the busy retry fast path even when another agent ran", async () => {
+    const { run, runOnce } = startRunner();
+    const busy = {
+      status: "skipped",
+      reason: heartbeatWake.HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
+    } as const;
+    runOnce.mockResolvedValueOnce(busy);
+
+    expect(await run({ source: "cron", intent: "task" })).toEqual(busy);
+    expect(runOnce).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -1,5 +1,5 @@
 // Covers heartbeat skipping while session lanes or cron jobs are busy.
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearActiveEmbeddedRun,
   preemptAndDrainEmbeddedHeartbeatRun,
@@ -19,6 +19,7 @@ import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/run
 import { CommandLane } from "../process/lanes.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { getAgentEventLifecycleGeneration } from "./agent-events.js";
+import { getLastHeartbeatEvent, resetHeartbeatEventsForTest } from "./heartbeat-events.js";
 import { type HeartbeatDeps, runHeartbeatOnce } from "./heartbeat-runner.js";
 import { seedMainSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
 import {
@@ -53,11 +54,14 @@ afterAll(() => {
 });
 
 beforeEach(() => {
+  resetHeartbeatEventsForTest();
   embeddedRunTesting.resetActiveEmbeddedRuns();
   resetSystemEventsForTest();
   resetCronActiveJobs();
   replyRunRegistryTesting.resetReplyRunRegistry();
 });
+
+afterEach(() => resetHeartbeatEventsForTest());
 
 function createHeartbeatTelegramConfig(storePath: string): OpenClawConfig {
   return {
@@ -134,6 +138,10 @@ describe("heartbeat runner skips when target session lane is busy", () => {
         const result = await runHeartbeat(cfg, replySpy, { intent });
 
         expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+        expect(getLastHeartbeatEvent()).toMatchObject({
+          ...result,
+          durationMs: expect.any(Number),
+        });
         expect(replySpy).not.toHaveBeenCalled();
       });
     },
@@ -160,6 +168,7 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       const result = await runHeartbeat(cfg, replySpy, { intent: "immediate" });
 
       expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+      expect(getLastHeartbeatEvent()).toMatchObject({ ...result, durationMs: expect.any(Number) });
       expect(replySpy).not.toHaveBeenCalled();
     });
   });
@@ -188,6 +197,10 @@ describe("heartbeat runner skips when target session lane is busy", () => {
         const result = await runHeartbeat(cfg, replySpy, { intent });
 
         expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+        expect(getLastHeartbeatEvent()).toMatchObject({
+          ...result,
+          durationMs: expect.any(Number),
+        });
         expect(replySpy).not.toHaveBeenCalled();
       });
     },
@@ -313,35 +326,32 @@ describe("heartbeat runner skips when target session lane is busy", () => {
     });
   });
 
-  it("returns requests-in-flight when session lane has queued work", async () => {
-    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
-      const cfg = createHeartbeatTelegramConfig(storePath);
-      const sessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
+  it.each(["main", "session"])(
+    "records requests-in-flight when the %s lane has queued work",
+    async (busyLane) => {
+      await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+        const cfg = createHeartbeatTelegramConfig(storePath);
+        const sessionKey = await seedHeartbeatTelegramSession(storePath, cfg);
 
-      enqueueSystemEvent("Exec completed (test-id, code 0) :: test output", {
-        sessionKey,
+        enqueueSystemEvent("Exec completed (test-id, code 0) :: test output", {
+          sessionKey,
+        });
+
+        const getQueueSize = vi.fn((lane?: string) =>
+          Number(busyLane === "main" ? lane === CommandLane.Main : lane?.startsWith("session:")),
+        );
+
+        const result = await runHeartbeat(cfg, replySpy, {}, { getQueueSize });
+
+        expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+        expect(getLastHeartbeatEvent()).toMatchObject({
+          ...result,
+          durationMs: expect.any(Number),
+        });
+        expect(replySpy).not.toHaveBeenCalled();
       });
-
-      // main lane idle (0), session lane busy (1)
-      const getQueueSize = vi.fn((lane?: string) => {
-        if (!lane || lane === "main") {
-          return 0;
-        }
-        if (lane.startsWith("session:")) {
-          return 1;
-        }
-        return 0;
-      });
-
-      const result = await runHeartbeat(cfg, replySpy, {}, { getQueueSize });
-
-      expect(result.status).toBe("skipped");
-      if (result.status === "skipped") {
-        expect(result.reason).toBe(HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT);
-      }
-      expect(replySpy).not.toHaveBeenCalled();
-    });
-  });
+    },
+  );
 
   it("returns requests-in-flight when the target session has an active reply run", async () => {
     await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
@@ -534,6 +544,26 @@ describe("heartbeat runner skips when target session lane is busy", () => {
       } finally {
         operation.complete();
       }
+    });
+  });
+
+  it("records a busy skip while a recent final delivery is pending", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig(storePath);
+      await seedHeartbeatTelegramSession(storePath, cfg, {
+        updatedAt: Date.now(),
+        pendingFinalDelivery: {
+          kind: "replayable",
+          text: "The requested report is ready.",
+          createdAt: Date.now(),
+        },
+      });
+
+      const result = await runHeartbeat(cfg, replySpy);
+
+      expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT });
+      expect(getLastHeartbeatEvent()).toMatchObject({ ...result, durationMs: expect.any(Number) });
+      expect(replySpy).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Two silent-outcome defects in the heartbeat owner, one shared invariant: every wake decision must keep a preserved outcome (for the wake layer's retry/retention) and an observable record (for operators).

1. **Broadcast wakes flatten per-agent guard results.** `heartbeat-runner-scheduler.ts` discarded each agent's real skip result and returned `not-due`/`disabled`. `"disabled"` is in neither retryable-reason set in `heartbeat-wake.ts`, so an untargeted, non-interval wake (reachable via `resolveCronHeartbeatWake` preserveUntargeted and `PluginRuntime.requestHeartbeatNow`) whose agents all deferred on `min-spacing`/`flood` was dropped outright — including any queued task payload, which the task-retention branch never saw because the reason check fails first. Even for interval wakes, the real `retryAtMs` was lost, so retries fell back to the 60s idle grace instead of the actual guard deadline.
2. **Three silent skips violate the file's own documented emit invariant.** `heartbeat-runner-execution.ts` states at the quiet-hours skip that "every sibling skip past this point emits", and `docs/help/troubleshooting.md` / `docs/gateway/troubleshooting.md` promise `requests-in-flight` is observable via `system heartbeat last` — yet the main-lane-busy, main-session-recovery, and recent-pending-final-delivery skips returned without emitting, hiding the skip from operators.

## Why This Change Was Made

The broadcast branch now mirrors the targeted branch's contract: prefer the earliest guard deadline among per-agent skip results, else preserve the first real result, and only synthesize the generic fallback when no per-agent result exists (empty roster). The runtime-busy fast path and any-agent-ran precedence are unchanged. The three execution-owner skips now record the same `requests-in-flight` outcome they return, matching every sibling skip in the function. Scheduler-level `not-due`/`min-spacing` deferral emits were deliberately NOT added (they fire every tick and would flood the event record — separate design question).

Production LOC +29/−1 (three five-line emits + the aggregation with its ownership comment); tests +195/−28.

## User Impact

Scheduled task payloads riding untargeted wakes survive spacing/flood deferral instead of silently vanishing; retries fire at the true guard deadline; and `system heartbeat last` now shows busy-skip reasons the docs already promise.

## Evidence

- Found by a read-only heartbeat audit at main 3708934c637, verified by orchestrator reads of scheduler/wake/execution before the work order.
- Pre-fix regression proof: 15 failed / 20 passed — the untargeted task wake returned `disabled` instead of `min-spacing` with zero dispatches at its deadline; all seven new busy/recovery event assertions observed `null`. Post-fix: 208 tests green across seven heartbeat suites (scheduler, broadcast outcomes, busy-session lane, wake, cooldown, stale-exec, defaults); re-run green after rebase onto latest `origin/main`.
- Tests exercise the real scheduler/wake dispatch boundary with injected agent execution and fake time, and read the real heartbeat event singleton used by the `system.heartbeat.last` RPC — no new production seam.
- Full changed gate passed locally (exit 0: formatting, typechecks, lint incl. `no-array-sort` → `toSorted`, export/storage/import-cycle/webhook/pairing guards). Fresh Codex autoreview: clean.
