### PR TITLE
fix(browser): stop reporting failed nested batches as successful

### DIFF
--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -384,6 +384,10 @@ profiles; send actions individually there.
   `stopOnError` is the default, the array ends at the first failure; with
   `--continue` it covers every action. Any failed entry makes the CLI exit
   nonzero; pass `--json` to preserve the full ordered response for scripts.
+- Nested batches occupy one parent result. If a child action fails, that result
+  reports the first child error. Each batch applies its own `stopOnError`:
+  continuing inside a nested batch does not make it successful or make its
+  parent continue.
 
 ## Wait power-ups
 

--- a/extensions/browser/src/browser/pw-tools-core.interactions.batch.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.batch.test.ts
@@ -1,5 +1,11 @@
 // Browser tests cover pw tools core.interactions.batch plugin behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SsrFBlockedError } from "../infra/net/ssrf.js";
+import {
+  BrowserObservedDialogBlockedError,
+  isBrowserObservedDialogBlockedError,
+} from "./pw-session-contracts.js";
+import { isPolicyDenyNavigationError } from "./pw-session-navigation.js";
 
 let page: {
   evaluate: ReturnType<typeof vi.fn>;
@@ -24,8 +30,7 @@ const getPageForTargetId = vi.fn(async () => {
 const ensurePageState = vi.fn(() => {});
 const assertPageNavigationCompletedSafely = vi.fn(async () => {});
 const forceDisconnectPlaywrightForTarget = vi.fn(async () => {});
-const isBrowserObservedDialogBlockedError = vi.fn(() => false);
-const isPolicyDenyNavigationError = vi.fn(() => false);
+const quarantineBlockedNavigationTarget = vi.fn(async () => {});
 const markObservedDialogsHandledRemotelyForPage = vi.fn(() => ({}));
 const refLocator = vi.fn(() => {
   if (!locator) {
@@ -56,6 +61,7 @@ vi.mock("./pw-session.js", () => ({
   isBrowserObservedDialogBlockedError,
   isPolicyDenyNavigationError,
   markObservedDialogsHandledRemotelyForPage,
+  quarantineBlockedNavigationTarget,
   refLocator,
   restoreRoleRefsForTarget,
   wasBrowserNavigationSourcePreservedAfterPolicyDenial,
@@ -422,5 +428,167 @@ describe("batchViaPlaywright", () => {
       ssrfPolicy,
       browserProxyMode: "explicit-browser-proxy",
     });
+  });
+
+  it.each([
+    { innerStopOnError: undefined, outerStopOnError: undefined },
+    { innerStopOnError: false, outerStopOnError: undefined },
+    { innerStopOnError: undefined, outerStopOnError: false },
+    { innerStopOnError: false, outerStopOnError: false },
+  ])(
+    "reports nested failure with inner stop=$innerStopOnError and outer stop=$outerStopOnError",
+    async ({ innerStopOnError, outerStopOnError }) => {
+      locator!.fill!.mockRejectedValueOnce(new Error("not editable"));
+
+      const result = await batchViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        targetId: "tab-1",
+        stopOnError: outerStopOnError,
+        actions: [
+          {
+            kind: "batch",
+            stopOnError: innerStopOnError,
+            actions: [
+              { kind: "type", ref: "1", text: "value" },
+              { kind: "hover", ref: "2" },
+            ],
+          },
+          { kind: "press", key: "Enter" },
+        ],
+      });
+
+      expect(result.results).toEqual([
+        { ok: false, error: "not editable" },
+        ...(outerStopOnError === false ? [{ ok: true }] : []),
+      ]);
+      expect(locator!.hover).toHaveBeenCalledTimes(innerStopOnError === false ? 1 : 0);
+      expect(page!.keyboard.press).toHaveBeenCalledTimes(outerStopOnError === false ? 1 : 0);
+    },
+  );
+
+  it("propagates a failed grandchild through each batch boundary", async () => {
+    locator!.fill!.mockRejectedValueOnce(new Error("not editable"));
+
+    const result = await batchViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      actions: [
+        {
+          kind: "batch",
+          actions: [{ kind: "batch", actions: [{ kind: "type", ref: "1", text: "value" }] }],
+        },
+        { kind: "press", key: "Enter" },
+      ],
+    });
+
+    expect(result).toEqual({ results: [{ ok: false, error: "not editable" }] });
+    expect(page!.keyboard.press).not.toHaveBeenCalled();
+  });
+
+  it("reports the first nested failure after all continue-on-error actions run", async () => {
+    locator!.fill!.mockRejectedValueOnce(new Error("first failure"));
+    locator!.hover!.mockRejectedValueOnce(new Error("second failure"));
+
+    const result = await batchViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      actions: [
+        {
+          kind: "batch",
+          stopOnError: false,
+          actions: [
+            { kind: "type", ref: "1", text: "value" },
+            { kind: "hover", ref: "2" },
+            { kind: "press", key: "Enter" },
+          ],
+        },
+      ],
+    });
+
+    expect(result).toEqual({ results: [{ ok: false, error: "first failure" }] });
+    expect(locator!.hover).toHaveBeenCalledOnce();
+    expect(page!.keyboard.press).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { reason: "navigation", nested: false, stopOnError: false },
+    { reason: "closed", nested: false, stopOnError: false },
+    { reason: "navigation", nested: true, stopOnError: undefined },
+    { reason: "closed", nested: true, stopOnError: undefined },
+    { reason: "navigation", nested: true, stopOnError: false },
+    { reason: "closed", nested: true, stopOnError: false },
+  ])(
+    "preserves failure and $reason abort details (nested=$nested, stop=$stopOnError)",
+    async ({ reason, nested, stopOnError }) => {
+      locator!.fill!.mockRejectedValueOnce(new Error("action failed"));
+      locator!.click!.mockImplementationOnce(() => {
+        if (reason === "navigation") {
+          setPageUrl("https://example.com/next");
+        } else {
+          setPageClosed(true);
+        }
+        if (!nested) {
+          throw new Error("action failed");
+        }
+      });
+
+      const result = await batchViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        stopOnError,
+        actions: [
+          nested
+            ? {
+                kind: "batch",
+                stopOnError: false,
+                actions: [
+                  { kind: "type", ref: "1", text: "value" },
+                  { kind: "click", ref: "2" },
+                  { kind: "hover", ref: "3" },
+                ],
+              }
+            : { kind: "click", ref: "1" },
+          { kind: "press", key: "Enter" },
+        ],
+      });
+      const url = reason === "navigation" ? "https://example.com/next" : "https://example.com";
+
+      expect(result).toEqual({
+        results: [
+          {
+            ok: false,
+            error: "action failed",
+            ...(reason === "navigation" ? { navigated: true, url } : {}),
+          },
+        ],
+        aborted: { reason, afterAction: 1, url, skipped: 1 },
+      });
+      expect(locator!.hover).not.toHaveBeenCalled();
+      expect(page!.keyboard.press).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    new SsrFBlockedError("browser navigation blocked by policy"),
+    new BrowserObservedDialogBlockedError({ dialogs: { pending: [], recent: [] } }),
+  ])("preserves $name identity through permissive nested batches", async (error) => {
+    locator!.fill!.mockRejectedValueOnce(error);
+
+    await expect(
+      batchViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        stopOnError: false,
+        actions: [
+          {
+            kind: "batch",
+            stopOnError: false,
+            actions: [
+              { kind: "type", ref: "1", text: "value" },
+              { kind: "hover", ref: "2" },
+            ],
+          },
+          { kind: "press", key: "Enter" },
+        ],
+      }),
+    ).rejects.toBe(error);
+    expect(locator!.hover).not.toHaveBeenCalled();
+    expect(page!.keyboard.press).not.toHaveBeenCalled();
   });
 });

--- a/extensions/browser/src/browser/pw-tools-core.interactions.execution.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.execution.ts
@@ -215,8 +215,8 @@ async function executeSingleAction(
         targetId: effectiveTargetId,
       });
       break;
-    case "batch":
-      await batchViaPlaywright({
+    case "batch": {
+      const batch = await batchViaPlaywright({
         cdpUrl,
         targetId: effectiveTargetId,
         ...navigationPolicy,
@@ -226,7 +226,14 @@ async function executeSingleAction(
         depth: depth + 1,
         signal,
       });
+      // A nested batch is one parent action; surface its first failure so each
+      // level applies its own stopOnError without discarding the child outcome.
+      const failure = batch.results.find((result) => !result.ok);
+      if (failure) {
+        throw new Error(failure.error);
+      }
       break;
+    }
     default:
       throw new Error(`Unsupported batch action kind: ${(action as { kind: string }).kind}`);
   }
@@ -436,6 +443,7 @@ export async function batchViaPlaywright(
         return finishAborted("closed", index, currentMainFrameUrl(), opts.actions.length - index);
       }
       navigationsAtLastDispatch = mainFrameNavigations;
+      let result: BrowserBatchActionResult;
       try {
         await executeSingleAction(
           action,
@@ -446,18 +454,7 @@ export async function batchViaPlaywright(
           depth,
           opts.signal,
         );
-        results.push({ ok: true });
-        if (page.isClosed?.()) {
-          return finishAborted(
-            "closed",
-            index + 1,
-            currentMainFrameUrl(),
-            opts.actions.length - index - 1,
-          );
-        }
-        if (mainFrameNavigations > navigationsAtLastDispatch) {
-          return finishNavigation(index + 1, opts.actions.length - index - 1);
-        }
+        result = { ok: true };
       } catch (err) {
         if (isBrowserObservedDialogBlockedError(err)) {
           throw err;
@@ -465,22 +462,22 @@ export async function batchViaPlaywright(
         if (isPolicyDenyNavigationError(err)) {
           throw err;
         }
-        const message = formatErrorMessage(err);
-        results.push({ ok: false, error: message });
-        if (page.isClosed?.()) {
-          return finishAborted(
-            "closed",
-            index + 1,
-            currentMainFrameUrl(),
-            opts.actions.length - index - 1,
-          );
-        }
-        if (mainFrameNavigations > navigationsAtLastDispatch) {
-          return finishNavigation(index + 1, opts.actions.length - index - 1);
-        }
-        if (opts.stopOnError !== false) {
-          break;
-        }
+        result = { ok: false, error: formatErrorMessage(err) };
+      }
+      results.push(result);
+      if (page.isClosed?.()) {
+        return finishAborted(
+          "closed",
+          index + 1,
+          currentMainFrameUrl(),
+          opts.actions.length - index - 1,
+        );
+      }
+      if (mainFrameNavigations > navigationsAtLastDispatch) {
+        return finishNavigation(index + 1, opts.actions.length - index - 1);
+      }
+      if (!result.ok && opts.stopOnError !== false) {
+        break;
       }
     }
     return { results };


### PR DESCRIPTION
Closes #130808

<details>
<summary>Additional instructions</summary>

This branch is in the same repository, so maintainers can edit it through their
repository access. GitHub's fork-collaboration flag applies only to cross-repository PRs.

</details>

## What Problem This Solves

Fixes an issue where users running nested browser batches would receive false success and execute later actions after a child action failed, despite default stop-on-error behavior. The CLI and agent tool share the affected Browser HTTP action runtime.

## Why This Change Was Made

The recursive dispatcher now surfaces the first failed child outcome through the parent's existing error path after the child finishes under its own continuation policy. One shared post-action path records the outcome, handles page closure/navigation, then applies stop-on-error; it replaces duplicated success/failure finalization.

No result schema, configuration, SDK, authentication, or existing-session behavior changes. Production LOC: +27/-30 (net -3); tests: +170/-2 (net +168); docs: +4.

Provenance: the result-discarding recursive dispatch was restored in [61d171a](https://github.com/openclaw/openclaw/commit/61d171ab0b2fe4abc9afe89c518586274b4b76c2) on March 14, 2026 (author and committer: Peter Steinberger). The later interaction-module split carried it forward; stable `v2026.7.1` also contains the discard.

## User Impact

Nested failures remain visible, and parent batches stop unless explicitly configured to continue. Inner and outer continuation settings remain independent. Navigation, closure, policy denials, and modal-dialog errors retain their existing safety behavior.

## Evidence

- Authentic pre-fix Browser HTTP `/snapshot` → `/act` proof using isolated Chromium and pinned Playwright 1.62.1: five nested cases fail, while three flat/success controls pass. The unchanged probe passes all eight cases after the repair, including both continuation flags and deeper nesting. It observes actual sentinel output, not only acknowledgements.
- Six new owner regressions failed before the repair. The final focused owner/sibling suite passes 129 tests in six files, independently rerun with the same result. It covers all nested continuation combinations, failure followed by navigation/closure, real policy/dialog error identity, normalization, and the CLI consumer.
- A fresh source-blind validator passed all six behavior-contract clauses: 17 checks across 78 public API requests. It varied real DOM/input effects, independent continuation settings, three/five nesting levels, failure followed by navigation/closure, and invalid inputs. Both validator-created tabs were disposed.
- The full 24-phase changed-file gate passed. After the final test-only safety-coverage expansion, test type checks, typed lint, formatting, and both source/assertion ratchets passed again. Production and docs stayed unchanged.
- Authenticated Codex review of the complete final patch and caller/callee evidence found no actionable P0–P2 findings.

Real browser proof used task-owned ports, profile, credentials, and HTML only; all were cleaned up. No operator browser or gateway was changed.

Validation limits: this is real source-runtime Browser API proof, not packaged-release or existing-session batch proof. The disposable launcher exited 1 while redundantly closing an already-closed browser context after shutdown; independent checks confirmed all owned processes/ports were gone and temporary state/authentication removed. This was harness cleanup, not a failed behavior check.

Named follow-up: the pre-existing friendly-error mapper can describe a non-editable button as not found/not visible because it matches Playwright call-log text. This repair preserves that existing diagnostic while preventing it from being lost; diagnostic wording belongs to a separate repair.
