### PR TITLE
fix(hooks): load linked hooks and nested packs

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -348,27 +348,41 @@ Directory discovery merges hooks by **name** using these rules:
 | Extra directories | `hooks.internal.load.extraDirs`; same source policy as managed hooks. Later extra directories win over earlier ones; the managed directory wins over extra directories. |
 | Workspace         | `<workspace>/hooks/`; can add names but cannot replace bundled, plugin, or managed names. Explicit opt-in required.                                                     |
 
-Each scanned directory contains child hook directories or child packages whose
-`package.json` declares `openclaw.hooks`. The scanner does not treat the scan
-root itself as a hook. For example, with
-`/opt/openclaw-hook-library/my-hook/HOOK.md`, add the parent directory:
+Bundled, managed, workspace, and plugin hook locations are collection
+directories: discovery inspects their immediate children for hooks or packages
+whose `package.json` declares `openclaw.hooks`.
+
+Each explicit `hooks.internal.load.extraDirs` path can instead be a pack root,
+a single-hook root, or a collection directory. A pack root loads only its
+declared hook paths, including nested paths such as `./hooks/my-hook`. Each
+path must point directly to a hook; discovery does not recurse into another
+pack or collection. A recognized pack with no valid hooks stays empty rather
+than scanning unlisted children. A single-hook root loads its own `HOOK.md`
+and handler. Only an ordinary collection root gets the immediate-child scan.
+
+For example, to select `/opt/openclaw-hook-library/my-hook/HOOK.md` directly,
+add that hook's directory:
 
 ```json
 {
   "hooks": {
     "internal": {
       "load": {
-        "extraDirs": ["/opt/openclaw-hook-library"]
+        "extraDirs": ["/opt/openclaw-hook-library/my-hook"]
       }
     }
   }
 }
 ```
 
-Only add trusted directories: this also opens selection beyond named entries.
+To scan the library's immediate children instead, add
+`/opt/openclaw-hook-library`. Only add trusted directories: any extra path
+opens hook-name selection across discovery sources beyond named entries,
+even when that path selects a single hook or pack.
 Handler files must stay within their hook directory; package and plugin hook
 paths must stay within their package root. Symlinks escaping those boundaries
-are rejected. Restart after changing hook files, metadata, or configuration.
+are rejected. Restart after changing hook files, metadata, or configuration,
+then verify the handler's actual side effect; inventory alone does not prove execution.
 
 ### Hook packs
 
@@ -380,7 +394,7 @@ unified installer:
 openclaw plugins install <path-or-spec>
 ```
 
-Installation and update flags, npm restrictions, linked-directory caveats, and
+Installation and update flags, npm restrictions, linked-root behavior and trust, and
 the deprecated `hooks install` / `hooks update` aliases are documented in
 [Install and update hook packs](/cli/hooks#install-and-update-hook-packs).
 
@@ -720,12 +734,16 @@ JSON output fields, exit behavior, and install/update aliases.
 
 Check the report's `workspaceDir` and `managedHooksDir` with
 `openclaw hooks list --json`. Confirm you are inspecting the intended host,
-profile, and agent. The hook must be a child directory containing `HOOK.md` and
-one supported handler file; a metadata file alone is insufficient.
+profile, and agent. Each hook needs `HOOK.md` and one supported handler file;
+a metadata file alone is insufficient. Collection locations inspect immediate
+children. An explicit extra path or linked root can itself be a hook or pack.
+For a pack, verify that `openclaw.hooks` lists the intended hook directories
+directly: nested packs and collections are not followed, and rejected entries
+do not cause unlisted children to be scanned.
 
 Check duplicate names and containment warnings in Gateway logs. A workspace
 hook cannot override a bundled or managed hook. For extra directories and
-linked packs, verify the scan-root layout described under
+linked packs, verify the root layout described under
 [Hook discovery](/automation/hooks#hook-discovery).
 
 ### Hook not eligible

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -198,7 +198,7 @@ sandbox the installed handler.
 
 | Option                                 | Effect for hook packs                                                                                                                       |
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `-l, --link`                           | Add a local directory to `hooks.internal.load.extraDirs` instead of copying it. See the layout limitation below.                            |
+| `-l, --link`                           | Add the exact local hook or pack root to `hooks.internal.load.extraDirs` instead of copying it. Single hooks and nested pack layouts work.  |
 | `--pin`                                | Record the resolved exact npm `name@version` in install state when available; does not apply to local paths.                                |
 | `--force`                              | Acknowledge a non-ClawHub source and allow replacement of an existing copied install. For links it acknowledges the source without copying. |
 | `--acknowledge-install-policy-warning` | Acknowledge an operator `security.installPolicy` warning without its prompt. Blocks and policy failures still stop the install.             |
@@ -209,13 +209,17 @@ installs require `--force`; global `--yes` is not a substitute for that gate.
 Review the source before supplying either acknowledgement.
 
 <Warning>
-A linked hook path is a **scan directory**, not a symlink install. The scanner
-looks at its immediate child directories, not the linked root's own `HOOK.md`
-or `openclaw.hooks` declaration. A linked pack works with hook directories as
-direct children; a single-hook root or a pack with only nested `hooks/<name>`
-directories can install successfully yet remain undiscovered. Prefer copied
-installation for those layouts, and always verify `hooks list` after linking.
-Extra directories also make directory-hook name selection open-ended.
+A linked hook runs directly from the supplied path; linking does not copy it
+or create a symlink. A single-hook root loads its own `HOOK.md` and handler.
+A pack loads only the hook directories listed in `openclaw.hooks`, including
+nested paths such as `./hooks/my-hook`. Declared paths must stay inside the
+pack and point directly to hooks; discovery does not recurse into nested packs
+or collections, or scan unlisted children, even when all declared paths are rejected.
+
+Only link trusted code. Extra directories still make directory-hook name
+selection open-ended across discovery sources, not just within the linked
+pack. Restart the Gateway after linking or editing hook code, check
+`hooks list`, and [verify the handler's actual side effect](/automation/hooks#quick-start).
 </Warning>
 
 ### Update behavior

--- a/src/hooks/hooks-install.test.ts
+++ b/src/hooks/hooks-install.test.ts
@@ -1,94 +1,149 @@
-// Hook install command tests cover hook installation workflow behavior.
+// Hook installs must preserve discovery and execution across copied and linked layouts.
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { installHooksFromPath } from "./install.js";
+import { loadConfigForInstall } from "../cli/plugins-install-config.js";
+import { tryInstallHookPackFromLocalPath } from "../cli/plugins-install-hook-fallback.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { pinConfigDir } from "../utils.js";
+import { readHookInstalls } from "./installs.js";
 import {
   clearInternalHooks,
   createInternalHookEvent,
   triggerInternalHook,
 } from "./internal-hooks.js";
 import { loadInternalHooks } from "./loader.js";
+import { loadWorkspaceHookEntries } from "./workspace.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+async function writeHook(hookDir: string, name: string): Promise<void> {
+  await fs.mkdir(hookDir, { recursive: true });
+  await fs.writeFile(
+    path.join(hookDir, "HOOK.md"),
+    [
+      "---",
+      `name: ${name}`,
+      'description: "Test hook"',
+      'metadata: {"openclaw":{"events":["command:new"]}}',
+      "---",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  await fs.writeFile(
+    path.join(hookDir, "handler.js"),
+    `export default async function(event) { event.messages.push(${JSON.stringify(name)}); }\n`,
+    "utf-8",
+  );
+}
 
-describe("hooks install (e2e)", () => {
-  let workspaceDir: string;
+describe.each([
+  { mode: "copied", link: false },
+  { mode: "linked", link: true },
+])("hooks install ($mode)", ({ link }) => {
+  let state: OpenClawTestState;
 
   beforeEach(async () => {
-    const baseDir = tempDirs.make("openclaw-hooks-e2e-");
-    workspaceDir = path.join(baseDir, "workspace");
-    await fs.mkdir(workspaceDir, { recursive: true });
-  });
-
-  it("installs a hook pack and triggers the handler", async () => {
-    const baseDir = tempDirs.make("openclaw-hooks-e2e-");
-    const packDir = path.join(baseDir, "hook-pack");
-    const hookDir = path.join(packDir, "hooks", "hello-hook");
-    await fs.mkdir(hookDir, { recursive: true });
-
-    await fs.writeFile(
-      path.join(packDir, "package.json"),
-      JSON.stringify(
-        {
-          name: "@acme/hello-hooks",
-          version: "0.0.0",
-          openclaw: { hooks: ["./hooks/hello-hook"] },
-        },
-        null,
-        2,
-      ),
-      "utf-8",
-    );
-
-    await fs.writeFile(
-      path.join(hookDir, "HOOK.md"),
-      [
-        "---",
-        'name: "hello-hook"',
-        'description: "Test hook"',
-        'metadata: {"openclaw":{"events":["command:new"]}}',
-        "---",
-        "",
-        "# Hello Hook",
-        "",
-      ].join("\n"),
-      "utf-8",
-    );
-
-    await fs.writeFile(
-      path.join(hookDir, "handler.js"),
-      "export default async function(event) { event.messages.push('hook-ok'); }\n",
-      "utf-8",
-    );
-
-    const hooksDir = path.join(baseDir, "managed-hooks");
-    const installResult = await installHooksFromPath({ path: packDir, hooksDir });
-    expect(installResult.ok).toBe(true);
-    if (!installResult.ok) {
-      return;
-    }
-
+    state = await createOpenClawTestState({ label: "hooks-install", layout: "split" });
+    pinConfigDir();
     clearInternalHooks();
-    const bundledHooksDir = path.join(baseDir, "bundled-none");
-    await fs.mkdir(bundledHooksDir, { recursive: true });
-    const loaded = await loadInternalHooks(
-      {
-        hooks: {
-          internal: {
-            enabled: true,
-            load: { extraDirs: [hooksDir] },
-          },
-        },
-      },
-      workspaceDir,
-      { managedHooksDir: hooksDir, bundledHooksDir },
-    );
-    expect(loaded).toBeGreaterThanOrEqual(1);
-
-    const event = createInternalHookEvent("command", "new", "test-session");
-    await triggerInternalHook(event);
-    expect(event.messages).toContain("hook-ok");
+    await state.writeConfig({
+      agents: { defaults: { workspace: state.workspaceDir } },
+      plugins: { enabled: false },
+    });
   });
+
+  afterEach(async () => {
+    try {
+      await loadInternalHooks({ hooks: { internal: { enabled: false } } }, state.workspaceDir);
+      clearInternalHooks();
+    } finally {
+      await state.cleanup();
+      pinConfigDir();
+    }
+  });
+
+  it.each([
+    { layout: "single hook", hookPath: ".", hookPackId: "hello-hook" },
+    { layout: "conventional pack", hookPath: "./hooks/hello-hook", hookPackId: "hello-hooks" },
+    { layout: "direct-child pack", hookPath: "./hello-hook", hookPackId: "hello-hooks" },
+  ])(
+    "discovers and triggers only installed hooks from a $layout",
+    async ({ hookPath, hookPackId }) => {
+      const sourceDir = state.path("sources", "hook-pack");
+      await writeHook(path.resolve(sourceDir, hookPath), "hello-hook");
+      await writeHook(state.path("sources", "adjacent-hook"), "adjacent-hook");
+      if (hookPath !== ".") {
+        await fs.writeFile(
+          path.join(sourceDir, "package.json"),
+          JSON.stringify({
+            name: "@acme/hello-hooks",
+            version: "0.0.0",
+            openclaw: { hooks: [hookPath] },
+          }),
+          "utf-8",
+        );
+        // A package manifest selects its hooks; neither root nor nested siblings are implicit hooks.
+        await writeHook(path.join(sourceDir, "unlisted-root"), "unlisted-root");
+        await writeHook(path.join(sourceDir, "hooks", "unlisted-nested"), "unlisted-nested");
+      }
+
+      const snapshot = await loadConfigForInstall({
+        rawSpec: sourceDir,
+        normalizedSpec: sourceDir,
+        resolvedPath: sourceDir,
+      });
+      const installResult = await tryInstallHookPackFromLocalPath({
+        snapshot,
+        resolvedPath: sourceDir,
+        installMode: "install",
+        safetyOverrides: { config: snapshot.config },
+        link,
+      });
+      expect(installResult).toEqual({ ok: true });
+
+      const installed = await readConfigFileSnapshot();
+      expect(installed.valid).toBe(true);
+      expect(installed.config.hooks?.internal).toMatchObject({
+        enabled: true,
+        entries: { "hello-hook": { enabled: true } },
+      });
+      expect(installed.config.hooks?.internal?.load?.extraDirs ?? []).toEqual(
+        link ? [sourceDir] : [],
+      );
+      const installPath = link ? sourceDir : state.statePath("hooks", hookPackId);
+      expect(readHookInstalls()).toEqual({
+        [hookPackId]: expect.objectContaining({
+          source: "path",
+          sourcePath: sourceDir,
+          installPath,
+          hooks: ["hello-hook"],
+        }),
+      });
+      await expect(
+        fs.readFile(path.resolve(installPath, hookPath, "handler.js"), "utf-8"),
+      ).resolves.toContain("hello-hook");
+
+      const options = { bundledHooksDir: state.path("bundled-none") };
+      const discovered = loadWorkspaceHookEntries(state.workspaceDir, {
+        ...options,
+        config: installed.config,
+      });
+      const loaded = await loadInternalHooks(installed.config, state.workspaceDir, options);
+      const event = createInternalHookEvent("command", "new", "test-session");
+      await triggerInternalHook(event);
+      expect({
+        discovered: discovered.map((entry) => entry.hook.name).toSorted(),
+        loaded,
+        messages: event.messages.toSorted(),
+      }).toEqual({
+        discovered: ["hello-hook"],
+        loaded: 1,
+        messages: ["hello-hook"],
+      });
+    },
+  );
 });

--- a/src/hooks/workspace.test.ts
+++ b/src/hooks/workspace.test.ts
@@ -1,12 +1,14 @@
 // Hook workspace tests cover workspace hook discovery and path handling.
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { MANIFEST_KEY } from "../compat/legacy-names.js";
 import { loadWorkspaceHookEntries } from "./workspace.js";
 
 const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const discoveryModes = ["collection", "extra root"] as const;
 
 vi.mock("../logging/subsystem.js", () => ({
   createSubsystemLogger: () => ({ warn: warnMock }),
@@ -33,7 +35,7 @@ function setupHardlinkHookWorkspace(hookName: string): {
   hookDir: string;
   outsideDir: string;
 } {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-workspace-hardlink-"));
+  const root = tempDirs.make("openclaw-hooks-workspace-hardlink-");
   const hooksRoot = path.join(root, "hooks");
   fs.mkdirSync(hooksRoot, { recursive: true });
 
@@ -60,11 +62,17 @@ function hookNames(entries: ReturnType<typeof loadWorkspaceHookEntries>): string
   return entries.map((entry) => entry.hook.name);
 }
 
-function loadWorkspaceEntriesFromHooksRoot(hooksRoot: string) {
-  const workspaceDir = path.dirname(hooksRoot);
+function loadWorkspaceEntriesFromHooksRoot(hooksRoot: string, extraRoot?: string) {
+  const workspaceDir = extraRoot
+    ? path.join(path.dirname(hooksRoot), "empty-workspace")
+    : path.dirname(hooksRoot);
   return loadWorkspaceHookEntries(workspaceDir, {
     managedHooksDir: path.join(workspaceDir, "managed-none"),
     bundledHooksDir: path.join(workspaceDir, "bundled-none"),
+    config: {
+      plugins: { enabled: false },
+      hooks: { internal: { load: { extraDirs: extraRoot ? [extraRoot] : [] } } },
+    },
   });
 }
 
@@ -100,27 +108,49 @@ describe("hooks workspace", () => {
     warnMock.mockClear();
   });
 
-  it("ignores package.json hook paths that traverse outside package directory", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-workspace-"));
+  it.each(discoveryModes)(
+    "rejects package traversal without scanning unlisted children (%s)",
+    (mode) => {
+      const root = tempDirs.make("openclaw-hooks-workspace-");
+      const hooksRoot = path.join(root, "hooks");
+      fs.mkdirSync(hooksRoot, { recursive: true });
+
+      const pkgDir = path.join(hooksRoot, "pkg");
+      fs.mkdirSync(pkgDir, { recursive: true });
+
+      writePlainHook(root, "outside");
+      writePlainHook(pkgDir, "unlisted");
+
+      writeHookPackageManifest(pkgDir, ["../../outside"]);
+
+      const entries = loadWorkspaceEntriesFromHooksRoot(
+        hooksRoot,
+        mode === "extra root" ? pkgDir : undefined,
+      );
+      expect(hookNames(entries)).toEqual([]);
+    },
+  );
+
+  it.each(discoveryModes)("does not recurse into declared packs or collections (%s)", (mode) => {
+    const root = tempDirs.make("openclaw-hooks-workspace-nested-");
     const hooksRoot = path.join(root, "hooks");
-    fs.mkdirSync(hooksRoot, { recursive: true });
-
     const pkgDir = path.join(hooksRoot, "pkg");
-    fs.mkdirSync(pkgDir, { recursive: true });
+    const nestedPack = path.join(pkgDir, "nested-pack");
+    writePlainHook(nestedPack, "nested-hook");
+    writeHookPackageManifest(nestedPack, ["./nested-hook"]);
+    writePlainHook(path.join(pkgDir, "nested-collection"), "collection-hook");
+    writePlainHook(pkgDir, "unlisted");
+    writeHookPackageManifest(pkgDir, ["./nested-pack", "./nested-collection"]);
 
-    const outsideHookDir = path.join(root, "outside");
-    fs.mkdirSync(outsideHookDir, { recursive: true });
-    fs.writeFileSync(path.join(outsideHookDir, "HOOK.md"), "---\nname: outside\n---\n");
-    fs.writeFileSync(path.join(outsideHookDir, "handler.js"), "export default async () => {};\n");
-
-    writeHookPackageManifest(pkgDir, ["../outside"]);
-
-    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
-    expect(hookNames(entries)).not.toContain("outside");
+    const entries = loadWorkspaceEntriesFromHooksRoot(
+      hooksRoot,
+      mode === "extra root" ? pkgDir : undefined,
+    );
+    expect(hookNames(entries)).toEqual([]);
   });
 
   it("accepts package.json hook paths within package directory", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-workspace-ok-"));
+    const root = tempDirs.make("openclaw-hooks-workspace-ok-");
     const hooksRoot = path.join(root, "hooks");
     fs.mkdirSync(hooksRoot, { recursive: true });
 
@@ -138,7 +168,7 @@ describe("hooks workspace", () => {
   });
 
   it("warns, skips oversized metadata, and continues discovering other hooks", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-oversized-mixed-"));
+    const root = tempDirs.make("openclaw-hooks-oversized-mixed-");
     const hooksRoot = path.join(root, "hooks");
     fs.mkdirSync(hooksRoot, { recursive: true });
 
@@ -158,7 +188,7 @@ describe("hooks workspace", () => {
   });
 
   it("loads hooks whose metadata sits exactly at the byte limit", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-exact-limit-"));
+    const root = tempDirs.make("openclaw-hooks-exact-limit-");
     const hooksRoot = path.join(root, "hooks");
     fs.mkdirSync(hooksRoot, { recursive: true });
 
@@ -180,45 +210,54 @@ describe("hooks workspace", () => {
     expect(warnMock).not.toHaveBeenCalled();
   });
 
-  it("still loads a plain hook when its package.json is oversized", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-oversized-compat-"));
-    const hooksRoot = path.join(root, "hooks");
-    fs.mkdirSync(hooksRoot, { recursive: true });
+  it.each(discoveryModes)(
+    "still loads a plain hook when its package.json is oversized (%s)",
+    (mode) => {
+      const root = tempDirs.make("openclaw-hooks-oversized-compat-");
+      const hooksRoot = path.join(root, "hooks");
+      fs.mkdirSync(hooksRoot, { recursive: true });
 
-    const hookDir = writePlainHook(hooksRoot, "compat-hook");
-    const manifestPath = path.join(hookDir, "package.json");
-    fs.writeFileSync(manifestPath, "x".repeat(METADATA_MAX_BYTES + 1), "utf8");
+      const hookDir = writePlainHook(hooksRoot, "compat-hook");
+      const manifestPath = path.join(hookDir, "package.json");
+      fs.writeFileSync(manifestPath, "x".repeat(METADATA_MAX_BYTES + 1), "utf8");
 
-    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
-    expect(hookNames(entries)).toContain("compat-hook");
-    expect(oversizedMetadataWarnings(manifestPath)).toHaveLength(1);
-  });
+      const entries = loadWorkspaceEntriesFromHooksRoot(
+        hooksRoot,
+        mode === "extra root" ? hookDir : undefined,
+      );
+      expect(hookNames(entries)).toContain("compat-hook");
+      expect(oversizedMetadataWarnings(manifestPath)).toHaveLength(1);
+    },
+  );
 
-  it("ignores package.json hook paths that escape via symlink", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-workspace-link-"));
-    const hooksRoot = path.join(root, "hooks");
-    fs.mkdirSync(hooksRoot, { recursive: true });
+  it.each(discoveryModes)(
+    "rejects package symlink escapes without scanning unlisted children (%s)",
+    (mode) => {
+      const root = tempDirs.make("openclaw-hooks-workspace-link-");
+      const hooksRoot = path.join(root, "hooks");
+      fs.mkdirSync(hooksRoot, { recursive: true });
 
-    const pkgDir = path.join(hooksRoot, "pkg");
-    const outsideDir = path.join(root, "outside");
-    const linkedDir = path.join(pkgDir, "linked");
-    fs.mkdirSync(pkgDir, { recursive: true });
-    fs.mkdirSync(outsideDir, { recursive: true });
-    fs.writeFileSync(path.join(outsideDir, "HOOK.md"), "---\nname: outside\n---\n");
-    fs.writeFileSync(path.join(outsideDir, "handler.js"), "export default async () => {};\n");
-    try {
+      const pkgDir = path.join(hooksRoot, "pkg");
+      const outsideDir = path.join(root, "outside");
+      const linkedDir = path.join(pkgDir, "linked");
+      fs.mkdirSync(pkgDir, { recursive: true });
+      fs.mkdirSync(outsideDir, { recursive: true });
+      fs.writeFileSync(path.join(outsideDir, "HOOK.md"), "---\nname: outside\n---\n");
+      fs.writeFileSync(path.join(outsideDir, "handler.js"), "export default async () => {};\n");
       fs.symlinkSync(outsideDir, linkedDir, process.platform === "win32" ? "junction" : "dir");
-    } catch {
-      return;
-    }
 
-    writeHookPackageManifest(pkgDir, ["./linked"]);
+      writePlainHook(pkgDir, "unlisted");
+      writeHookPackageManifest(pkgDir, ["./linked"]);
 
-    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
-    expect(hookNames(entries)).not.toContain("outside");
-  });
+      const entries = loadWorkspaceEntriesFromHooksRoot(
+        hooksRoot,
+        mode === "extra root" ? pkgDir : undefined,
+      );
+      expect(hookNames(entries)).toEqual([]);
+    },
+  );
 
-  it("ignores hooks with hardlinked HOOK.md aliases", () => {
+  it.each(discoveryModes)("ignores hooks with hardlinked HOOK.md aliases (%s)", (mode) => {
     if (process.platform === "win32") {
       return;
     }
@@ -234,13 +273,15 @@ describe("hooks workspace", () => {
       return;
     }
 
-    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
-    const names = hookNames(entries);
-    expect(names).not.toContain("hardlink-hook");
-    expect(names).not.toContain("outside");
+    writePlainHook(hookDir, "unlisted");
+    const entries = loadWorkspaceEntriesFromHooksRoot(
+      hooksRoot,
+      mode === "extra root" ? hookDir : undefined,
+    );
+    expect(hookNames(entries)).toEqual([]);
   });
 
-  it("ignores hooks with hardlinked handler aliases", () => {
+  it.each(discoveryModes)("ignores hooks with hardlinked handler aliases (%s)", (mode) => {
     if (process.platform === "win32") {
       return;
     }
@@ -254,12 +295,16 @@ describe("hooks workspace", () => {
       return;
     }
 
-    const entries = loadWorkspaceEntriesFromHooksRoot(hooksRoot);
-    expect(hookNames(entries)).not.toContain("hardlink-handler-hook");
+    writePlainHook(hookDir, "unlisted");
+    const entries = loadWorkspaceEntriesFromHooksRoot(
+      hooksRoot,
+      mode === "extra root" ? hookDir : undefined,
+    );
+    expect(hookNames(entries)).toEqual([]);
   });
 
   it("does not let workspace hooks override managed hooks with the same name", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-collision-"));
+    const root = tempDirs.make("openclaw-hooks-collision-");
     const workspaceDir = path.join(root, "workspace");
     const managedHooksDir = path.join(root, "managed-hooks");
     const workspaceHookDir = path.join(workspaceDir, "hooks", "session-memory");
@@ -289,7 +334,7 @@ describe("hooks workspace", () => {
   });
 
   it("treats configured extraDirs as managed hook sources", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hooks-extra-"));
+    const root = tempDirs.make("openclaw-hooks-extra-");
     const workspaceDir = path.join(root, "workspace");
     const extraHookDir = path.join(root, "shared-hooks", "shared-hook");
     fs.mkdirSync(extraHookDir, { recursive: true });

--- a/src/hooks/workspace.ts
+++ b/src/hooks/workspace.ts
@@ -68,7 +68,6 @@ function loadHookFromDir(params: {
   hookDir: string;
   source: HookSource;
   pluginId?: string;
-  nameHint?: string;
 }): LoadedHook | null {
   const hookMdPath = path.join(params.hookDir, "HOOK.md");
   const content = readRootFileUtf8({
@@ -83,7 +82,7 @@ function loadHookFromDir(params: {
   try {
     const frontmatter = parseHookFrontmatter(content);
 
-    const name = frontmatter.name || params.nameHint || path.basename(params.hookDir);
+    const name = frontmatter.name || path.basename(params.hookDir);
     const description = frontmatter.description || "";
 
     const handlerCandidates = ["handler.ts", "handler.js", "index.ts", "index.js"];
@@ -132,64 +131,36 @@ function loadHookFromDir(params: {
   }
 }
 
-/**
- * Scan a directory for hooks (subdirectories containing HOOK.md)
- */
-function loadHooksFromDir(params: {
-  dir: string;
+function loadHooksFromCandidate(params: {
+  hookDir: string;
   source: HookSource;
   pluginId?: string;
-}): LoadedHook[] {
-  const { dir, source, pluginId } = params;
-
-  if (!fs.existsSync(dir)) {
-    return [];
-  }
-
-  const stat = fs.statSync(dir);
-  if (!stat.isDirectory()) {
-    return [];
+}): LoadedHook[] | null {
+  const { hookDir, source, pluginId } = params;
+  const manifest = readHookPackageManifest(hookDir);
+  const packageHooks = manifest ? resolvePackageHooks(manifest) : [];
+  if (packageHooks.length === 0) {
+    if (!fs.existsSync(path.join(hookDir, "HOOK.md"))) {
+      return null;
+    }
+    const hook = loadHookFromDir(params);
+    return hook ? [hook] : [];
   }
 
   const hooks: LoadedHook[] = [];
-  const entries = fs.readdirSync(dir, { withFileTypes: true });
-
-  for (const entry of entries) {
-    if (!entry.isDirectory()) {
+  for (const hookPath of packageHooks) {
+    const resolvedHookDir = resolveContainedDir(hookDir, hookPath);
+    if (!resolvedHookDir) {
+      log.warn(
+        `Ignoring out-of-package hook path "${hookPath}" in ${hookDir} (must be within package directory)`,
+      );
       continue;
     }
-
-    const hookDir = path.join(dir, entry.name);
-    const manifest = readHookPackageManifest(hookDir);
-    const packageHooks = manifest ? resolvePackageHooks(manifest) : [];
-
-    if (packageHooks.length > 0) {
-      for (const hookPath of packageHooks) {
-        const resolvedHookDir = resolveContainedDir(hookDir, hookPath);
-        if (!resolvedHookDir) {
-          log.warn(
-            `Ignoring out-of-package hook path "${hookPath}" in ${hookDir} (must be within package directory)`,
-          );
-          continue;
-        }
-        const hook = loadHookFromDir({
-          hookDir: resolvedHookDir,
-          source,
-          pluginId,
-          nameHint: path.basename(resolvedHookDir),
-        });
-        if (hook) {
-          hooks.push(hook);
-        }
-      }
-      continue;
-    }
-
+    // Pack entries are hook leaves, never another pack or a collection to scan.
     const hook = loadHookFromDir({
-      hookDir,
+      hookDir: resolvedHookDir,
       source,
       pluginId,
-      nameHint: entry.name,
     });
     if (hook) {
       hooks.push(hook);
@@ -203,25 +174,33 @@ function loadHookEntriesFromDir(params: {
   dir: string;
   source: HookSource;
   pluginId?: string;
+  includeRoot?: boolean;
 }): HookEntry[] {
-  const hooks = loadHooksFromDir({
-    dir: params.dir,
-    source: params.source,
-    pluginId: params.pluginId,
-  });
-  return hooks.map(({ hook, frontmatter }) => {
-    const entry: HookEntry = {
-      hook: {
-        ...hook,
-        source: params.source,
-        pluginId: params.pluginId,
-      },
-      frontmatter,
-      metadata: resolveHookManifestMetadata(frontmatter),
-      invocation: resolveHookInvocationPolicy(frontmatter),
-    };
-    return entry;
-  });
+  const { dir, source, pluginId } = params;
+  if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+    return [];
+  }
+  const rootHooks = params.includeRoot
+    ? loadHooksFromCandidate({ hookDir: dir, source, pluginId })
+    : null;
+  // null means a collection. A recognized root with rejected hooks stays empty;
+  // falling back to children would execute code its manifest did not select.
+  const hooks =
+    rootHooks ??
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      if (!entry.isDirectory()) {
+        return [];
+      }
+      return (
+        loadHooksFromCandidate({ hookDir: path.join(dir, entry.name), source, pluginId }) ?? []
+      );
+    });
+  return hooks.map(({ hook, frontmatter }) => ({
+    hook,
+    frontmatter,
+    metadata: resolveHookManifestMetadata(frontmatter),
+    invocation: resolveHookInvocationPolicy(frontmatter),
+  }));
 }
 
 function discoverWorkspaceHookEntries(
@@ -253,6 +232,7 @@ function discoverWorkspaceHookEntries(
     return loadHookEntriesFromDir({
       dir: resolved,
       source: "openclaw-managed",
+      includeRoot: true,
     });
   });
   const pluginHooks = pluginHookDirs.flatMap(({ dir, pluginId }) =>


### PR DESCRIPTION
Closes #130783

<details>
<summary>Additional instructions</summary>

Maintainers can update this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where operators linking a local internal hook or hook pack would get a successful install but no execution of the intended hook when its descriptor or pack manifest was at the linked root. Linked packs with direct-child hooks could also execute adjacent hooks that were not declared in the pack manifest.

## Why This Change Was Made

Resolve explicit extra roots through the same hook-or-pack candidate resolver used for collection children. A pack loads only its declared, contained hook leaves; a single hook loads itself; an ordinary collection keeps its immediate-child scan. Recognized roots whose entries are rejected stay empty instead of scanning unlisted children.

This keeps the exact linked path and existing installer/persistence intact. Rewriting it to the parent would expose unrelated siblings, while recursive scanning would ignore pack ownership. Bundled, managed, workspace, and plugin collection semantics, source precedence, enablement, bounded metadata reads, and handler containment remain unchanged. No config option, SQLite change, dependency, compatibility shim, or new production export.

## User Impact

`openclaw plugins install --link` now works for both a bare hook root and a conventional package declaring nested paths such as `./hooks/hello-hook`. Linked and copied packs honor the same declared hook selection. Existing collection directories still work. The CLI and automation docs now describe supported roots, restart/verification steps, and the unchanged trust/open-ended selection behavior.

Release-note context: fix successful-but-undiscovered local hook links and prevent linked packs from loading undeclared adjacent hooks.

## Evidence

The regression uses isolated HOME/config/workspace/SQLite state and real production boundaries: local hook installation, config persistence/reload, install provenance, discovery, dynamic handler import, and event dispatch. No installer, discovery, persistence, or handler-import mocks.

| Layout | Before: copy | Before: link | After: copy and link |
| --- | --- | --- | --- |
| Bare hook root | Intended handler runs | No handler found or run | Only intended handler runs |
| Pack declaring `./hooks/hello-hook` | Intended handler runs | Intended handler missed; unlisted direct child runs when present | Only declared handler runs |
| Pack declaring `./hello-hook` | Only intended handler runs | Intended and unlisted direct child both run | Only declared handler runs |

The six-case matrix demonstrably failed on pre-fix source. Six additional explicit-root boundary cases also failed before the repair: traversal, nested pack/collection recursion, oversized package metadata with a plain hook, symlink escape, hardlinked descriptor, and hardlinked handler. Collection-mode counterparts remain covered. The existing traversal fixture was corrected to point at a real outside hook, and workspace fixtures now clean up their temporary directories.

Validation completed locally:

```bash
node scripts/run-vitest.mjs src/hooks/workspace.test.ts src/hooks/hooks-install.test.ts src/hooks/loader.test.ts src/hooks/plugin-hooks.test.ts src/hooks/policy.test.ts src/hooks/configured.test.ts src/hooks/install.test.ts src/cli/plugins-cli.install.test.ts --reporter=verbose
```

289 tests passed across eight files. Final owner rerun after fixture cleanup and lint correction:

```bash
node scripts/run-vitest.mjs src/hooks/workspace.test.ts src/hooks/hooks-install.test.ts --reporter=verbose
```

23 tests passed, including all six install-to-dispatch cases. The changed-scope gate passed core and core-test typechecks and initial guards, then caught a test-only `sort()` lint violation. It was corrected to `toSorted()`; exact changed-file lint/formatting and every remaining classified guard passed afterward, including import cycles and state/schema guards. `git diff --check` passed. Fresh independent Codex autoreview reported no P0 findings before commit.

Production LOC: +48/-68 (net -20). Tests: +236/-136 (net +100). Docs: +41/-19 (net +22). The refactor removes the old scan wrapper, redundant basename hints, and duplicate source restamping.

Pre-fix source was `3708934c637a3c219c000c9963c1d100949338d9`; the affected files were unchanged on checked main `5f3324587e40cea0ec0cd80c9840533f990e9240`. The mismatch dates to the original linked-pack support in commit `3a6ee5ee00176c88aee32bb8bfd543780014c079` (2026-01-17, author and committer Peter Steinberger); later refactors carried it forward.

### Built CLI proof

`pnpm build` passed, including CLI bootstrap checks, all 147 public SDK export checks, UI build/performance checks, and zero ineffective dynamic import diagnostics. On macOS with Node 26.7.0 and pnpm 11.22.0, all six layout cases then passed through the built CLI:

```bash
pnpm openclaw plugins install <fixture-hook-or-pack> --force --link
```

The copied comparisons used the same command without `--link`. Each was followed by:

```bash
pnpm openclaw hooks list --json
```

```bash
pnpm openclaw hooks info hello-hook --json
```

All 18 CLI calls exited 0. Every list/info result contained only `hello-hook`, marked managed/loadable, with its exact handler path. Links retained precisely the supplied root; copies used managed targets without an extra root. A fresh Node process then loaded each CLI-persisted config/SQLite record through the real loader and dispatched `command:new`: all six loaded exactly one handler and produced exactly `["hello-hook"]`, never a decoy.

Each case had separate temporary HOME, OpenClaw home/state/config/workspace/cache/log paths, an allowlisted child environment, disabled unrelated plugins, and an empty bundled-hook directory. Reports used supported implicit-local fallback against a reserved non-listening fixture port; no operator Gateway was contacted or changed. All fixture roots, sockets, and child processes were cleaned up. The source checkout's tracked bytes were unchanged by build/proof.

This is built-CLI plus clean-process loader/dispatch proof, not running-Gateway startup or channel-delivery proof. No cross-platform or packaged-distribution installation is claimed. Exact-head CI will be verified before landing.

AI-assisted implementation and verification.
