### PR TITLE
docs: clarify Daytona cloud-worker class incompatibility

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -84,6 +84,10 @@ Keep the token out of repository config and shell arguments.
 
 ### Daytona
 
+<Warning>
+Direct Daytona cloud-worker dispatch is currently incompatible with this integration: OpenClaw requires `settings.class` and forwards it as `--class`, but Crabbox's direct Daytona backend rejects that flag because the snapshot controls sizing. The example below passes OpenClaw's profile validation but cannot provision a direct Daytona worker. Use another supported backend until this incompatibility is resolved.
+</Warning>
+
 The bundled Crabbox provider can also lease [Daytona](https://www.daytona.io) sandboxes as cloud workers (`settings.provider: "daytona"`). Unlike AWS, Daytona needs no separate `crabbox login` step: export `DAYTONA_API_KEY` (from the [Daytona dashboard](https://app.daytona.io/dashboard/keys)) in the Gateway process's environment before Crabbox allocates a lease. Verify it without provisioning anything:
 
 ```bash
@@ -111,7 +115,7 @@ A `daytona-fallback auth=ready control_plane=ready inventory=ready` finding conf
 }
 ```
 
-`class` defaults to `beast` (Crabbox's own default for this provider) when omitted; `crabbox providers describe daytona --json` lists the full flag set. Provide `DAYTONA_API_KEY` as an environment variable on the Gateway process (for example through a systemd `EnvironmentFile`), the same way other credential-bearing provider secrets are supplied — never in `openclaw.json` itself.
+The `settings.class: "beast"` value above is explicit, not a default. OpenClaw rejects an omitted or empty class before calling Crabbox; this validation requirement does not make `beast` a supported Daytona sizing option. `crabbox providers describe daytona --json` lists the provider's flags and limitations. Provide `DAYTONA_API_KEY` as an environment variable on the Gateway process (for example through a systemd `EnvironmentFile`), the same way other credential-bearing provider secrets are supplied — never in `openclaw.json` itself.
 
 ## Configuration
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators following the Daytona Cloud Workers guide are told that omitting `settings.class` selects `beast`, but OpenClaw rejects the profile before invoking Crabbox. The existing explicit `beast` example also must not be presented as working direct-Daytona provisioning: Crabbox rejects an explicit `--class` because its Daytona snapshot owns resource sizing.

Related: #130282 (the original Daytona cloud-worker documentation).

## Why This Change Was Made

Correct the documentation to match the current integration rather than introducing runtime defaults. State that the example's class is explicit, explain the validation-versus-provider distinction, and put a direct-Daytona incompatibility warning before the setup instructions.

This is an interim docs-only correction. The separate Daytona runtime/setup repair should replace the warning and example together when its working contract is integrated. No per-session discovery, Machine0 picker, settings editor, catalog output limit, configuration schema, or runtime behavior changes are included.

## User Impact

Operators no longer mistake the Crabbox CLI's generic default metadata for an OpenClaw profile default, or assume that setting `beast` repairs direct Daytona dispatch. The guide directs them to another supported backend until the integration is compatible.

## Evidence

- Read the complete Crabbox profile parser/provider, machine-options caller, core profile schema and lifecycle callers, relevant provider/schema/warm-image tests, and documentation/history.
- The requirement predates the docs sentence. `parseCrabboxProfile` rejects missing/blank class, `resolveCrabboxProvisionProfile` validates before applying an override, and `buildCrabboxWarmupArgs` always forwards `--class`.
- Direct source probes verified omitted classes are rejected for AWS, Daytona, Hetzner, and Machine0, including with a per-session override. The Daytona JSON example passes the core schema and OpenClaw parser. Provider timeout/discovery/provision entry points reject omission before any CLI invocation.
- Upstream Crabbox `internal/providers/daytona/backend_ssh.go` rejects explicitly supplied `--class`; its `TestApplyDaytonaProviderFlagsRejectsResourceNoops` test protects that contract. Credentialless `crabbox providers describe daytona --json` reports generic `beast` metadata but an unmapped class catalog; it is not proof of provider acceptance.
- Focused provider/schema suites passed: 203 tests during investigation. No runtime or tests were changed.
- `node scripts/check-docs-mdx.mjs docs/gateway/cloud-workers.md` and `git diff --check` passed. Post-rebase validation is recorded in the landing proof comment.
- No cloud allocation or authenticated Daytona end-to-end success is claimed. The documentation explicitly records the incompatibility instead.

Production LOC: +0/-0. Tests: +0/-0. Documentation: +5/-1 in one file.

AI-assisted documentation correction.
