### PR TITLE
fix(slack): preserve user names in rich-text mentions

### DIFF
--- a/extensions/slack/src/blocks-fallback.ts
+++ b/extensions/slack/src/blocks-fallback.ts
@@ -19,6 +19,7 @@ type SlackNativeDataFallbackFormat = "plain" | "mrkdwn-safe";
 
 type RenderSlackBlockFallbackOptions = {
   nativeDataFormat?: SlackNativeDataFallbackFormat;
+  nativeReferenceFormat?: SlackNativeDataFallbackFormat;
 };
 
 type SlackBlockLike = {
@@ -81,8 +82,21 @@ function readTextValue(
   return normalizeOptionalString(value) ?? readTextObject(value, options);
 }
 
-function renderSlackRichTextLeaf(element: SlackRichTextElement): string {
+function renderSlackRichTextElement(
+  value: unknown,
+  renderReference: (text: string) => string,
+): string {
+  const element = asOptionalRecord(value) as SlackRichTextElement | undefined;
+  if (!element) {
+    return "";
+  }
   switch (element.type) {
+    case "rich_text_section":
+    case "rich_text_preformatted":
+    case "rich_text_quote":
+      return renderSlackRichTextElements(element.elements, "", renderReference);
+    case "rich_text_list":
+      return renderSlackRichTextElements(element.elements, "\n", renderReference);
     case "text":
       return typeof element.text === "string" ? escapeSlackMrkdwn(element.text) : "";
     case "link":
@@ -91,19 +105,19 @@ function renderSlackRichTextLeaf(element: SlackRichTextElement): string {
       );
     case "user": {
       const userId = normalizeOptionalString(element.user_id);
-      return userId ? escapeSlackMrkdwn(`<@${userId}>`) : "";
+      return userId ? renderReference(`<@${userId}>`) : "";
     }
     case "channel": {
       const channelId = normalizeOptionalString(element.channel_id);
-      return channelId ? escapeSlackMrkdwn(`<#${channelId}>`) : "";
+      return channelId ? renderReference(`<#${channelId}>`) : "";
     }
     case "usergroup": {
       const usergroupId = normalizeOptionalString(element.usergroup_id);
-      return usergroupId ? escapeSlackMrkdwn(`<!subteam^${usergroupId}>`) : "";
+      return usergroupId ? renderReference(`<!subteam^${usergroupId}>`) : "";
     }
     case "broadcast": {
       const range = normalizeOptionalString(element.range);
-      return range ? escapeSlackMrkdwn(`<!${range}>`) : "";
+      return range ? renderReference(`<!${range}>`) : "";
     }
     case "emoji": {
       const name = normalizeOptionalString(element.name);
@@ -116,28 +130,18 @@ function renderSlackRichTextLeaf(element: SlackRichTextElement): string {
   }
 }
 
-function renderSlackRichTextElement(value: unknown): string {
-  const element = asOptionalRecord(value) as SlackRichTextElement | undefined;
-  if (!element) {
-    return "";
-  }
-  switch (element.type) {
-    case "rich_text_section":
-    case "rich_text_preformatted":
-    case "rich_text_quote":
-      return renderSlackRichTextElements(element.elements, "");
-    case "rich_text_list":
-      return renderSlackRichTextElements(element.elements, "\n");
-    default:
-      return renderSlackRichTextLeaf(element);
-  }
-}
-
-function renderSlackRichTextElements(value: unknown, separator: string): string {
+function renderSlackRichTextElements(
+  value: unknown,
+  separator: string,
+  renderReference: (text: string) => string,
+): string {
   if (!Array.isArray(value)) {
     return "";
   }
-  return value.map(renderSlackRichTextElement).filter(Boolean).join(separator);
+  return value
+    .map((element) => renderSlackRichTextElement(element, renderReference))
+    .filter(Boolean)
+    .join(separator);
 }
 
 function readImageText(block: SlackBlockLike): string | undefined {
@@ -235,7 +239,15 @@ export function renderSlackBlockFallbackText(
   }
   switch (block.type) {
     case "rich_text":
-      return normalizeOptionalString(renderSlackRichTextElements(block.elements, "\n"));
+      // Inbound references must survive for name resolution; literal text stays escaped
+      // so token-shaped text cannot become a native mention. Outbound remains escaped.
+      return normalizeOptionalString(
+        renderSlackRichTextElements(
+          block.elements,
+          "\n",
+          options.nativeReferenceFormat === "plain" ? (text) => text : escapeSlackMrkdwn,
+        ),
+      );
     case "header":
       return readTextObject(block.text, options);
     case "section":

--- a/extensions/slack/src/blocks.test.ts
+++ b/extensions/slack/src/blocks.test.ts
@@ -158,7 +158,7 @@ describe("buildSlackBlocksFallbackText", () => {
   });
 
   it("renders rich text and context without hidden metadata", () => {
-    const richText = renderSlackBlockFallbackText({
+    const richTextBlock = {
       type: "rich_text",
       block_id: "private-block-id",
       elements: [
@@ -185,12 +185,17 @@ describe("buildSlackBlocksFallbackText", () => {
                   url: "https://example.com/private-target",
                   text: "Second",
                 },
+                { type: "text", text: " for " },
+                { type: "usergroup", usergroup_id: "S123" },
+                { type: "text", text: " " },
+                { type: "broadcast", range: "here" },
               ],
             },
           ],
         },
       ],
-    });
+    };
+    const richText = renderSlackBlockFallbackText(richTextBlock);
     const context = renderSlackBlockFallbackText({
       type: "context",
       elements: [
@@ -200,7 +205,13 @@ describe("buildSlackBlocksFallbackText", () => {
     });
 
     expect(richText).toBe(
-      "Ask &lt;@U123&gt; &lt;!channel&gt; in &lt;#C123&gt; :wave:\nFirst\nSecond",
+      "Ask &lt;@U123&gt; &lt;!channel&gt; in &lt;#C123&gt; :wave:\nFirst\nSecond for &lt;!subteam^S123&gt; &lt;!here&gt;",
+    );
+    expect(renderSlackBlockFallbackText(richTextBlock, { nativeDataFormat: "plain" })).toBe(
+      richText,
+    );
+    expect(renderSlackBlockFallbackText(richTextBlock, { nativeReferenceFormat: "plain" })).toBe(
+      "Ask <@U123> &lt;!channel&gt; in <#C123> :wave:\nFirst\nSecond for <!subteam^S123> <!here>",
     );
     expect(richText).not.toContain("private-block-id");
     expect(richText).not.toContain("private-target");

--- a/extensions/slack/src/monitor.mentions.test.ts
+++ b/extensions/slack/src/monitor.mentions.test.ts
@@ -1,0 +1,94 @@
+import { resetInboundDedupe } from "openclaw/plugin-sdk/reply-runtime";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getSlackClient,
+  getSlackTestState,
+  resetSlackTestState,
+  runSlackMessageOnce,
+} from "./monitor.test-helpers.js";
+
+const { monitorSlackProvider } = await import("./monitor/provider.js");
+const { replyMock } = getSlackTestState();
+
+beforeEach(() => {
+  resetInboundDedupe();
+  resetSlackTestState();
+});
+
+describe("Slack inbound native mentions", () => {
+  const mentionSection = {
+    type: "rich_text_section",
+    elements: [
+      { type: "text", text: "Ask " },
+      { type: "user", user_id: "UTARGET" },
+      { type: "text", text: " now" },
+    ],
+  };
+
+  it.each([
+    { name: "text-only message", text: "Ask <@UTARGET> now", blocks: undefined },
+    {
+      name: "mirrored rich-text message",
+      text: "Ask <@UTARGET> now",
+      blocks: [{ type: "rich_text", elements: [mentionSection] }],
+    },
+    {
+      name: "rich-text message with truncated fallback",
+      text: "Ask",
+      blocks: [{ type: "rich_text", elements: [mentionSection] }],
+    },
+    {
+      name: "nested rich-text list",
+      text: "Ask",
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [{ type: "rich_text_list", style: "bullet", elements: [mentionSection] }],
+        },
+      ],
+    },
+    {
+      name: "literal mention-shaped rich text",
+      text: "Ask",
+      blocks: [
+        {
+          type: "rich_text",
+          elements: [
+            {
+              type: "rich_text_section",
+              elements: [{ type: "text", text: "Ask <@UTARGET> now" }],
+            },
+          ],
+        },
+      ],
+      expected: "Ask &lt;@UTARGET&gt; now",
+    },
+  ])(
+    "preserves mention semantics for $name before model dispatch",
+    async ({ text, blocks, expected }) => {
+      getSlackClient().users.info.mockResolvedValue({
+        user: { profile: { display_name: "Target Person" } },
+      });
+      await runSlackMessageOnce(
+        monitorSlackProvider,
+        {
+          event: {
+            type: "message",
+            channel: "D12345678",
+            channel_type: "im",
+            user: "USENDER",
+            ts: "1787800000.000100",
+            text,
+            blocks,
+          },
+        },
+        { awaitDispatch: true },
+      );
+
+      expect(replyMock).toHaveBeenCalledTimes(1);
+      expect(replyMock.mock.calls[0]?.[0]).toMatchObject({
+        RawBody: expected ?? "Ask <@UTARGET> (Target Person) now",
+      });
+    },
+  );
+});

--- a/extensions/slack/src/monitor/block-text.test.ts
+++ b/extensions/slack/src/monitor/block-text.test.ts
@@ -48,7 +48,7 @@ describe("resolveSlackBlocksText data visualizations", () => {
     ]);
 
     expect(resolved).toEqual({
-      text: "Ask &lt;@U123&gt;\nDeploy\nHealthy\nRun workflow\nChoose owner",
+      text: "Ask <@U123>\nDeploy\nHealthy\nRun workflow\nChoose owner",
       hasRichText: true,
       hasNativeData: false,
     });

--- a/extensions/slack/src/monitor/block-text.ts
+++ b/extensions/slack/src/monitor/block-text.ts
@@ -59,7 +59,10 @@ export function resolveSlackBlocksText(blocks: unknown[] | undefined): SlackBloc
     hasRichText ||= blockType === "rich_text";
     hasNativeData ||=
       blockType === "data_visualization" || blockType === "data_table" || blockType === "table";
-    const text = renderSlackBlockFallbackText(block, { nativeDataFormat: "plain" });
+    const text = renderSlackBlockFallbackText(block, {
+      nativeDataFormat: "plain",
+      nativeReferenceFormat: "plain",
+    });
     if (text) {
       parts.push(text);
     }


### PR DESCRIPTION
Closes #130815

## What Problem This Solves

Fixes an issue where users mentioning someone in an ordinary Slack rich-text message would give the agent an escaped user ID without the existing display-name annotation. Mirrored message blocks, shortened fallback text, and nested rich-text lists are affected.

## Why This Change Was Made

Preserve typed native references at Slack's inbound block-text projection, before the existing name resolver runs. Literal text, links, and date fallbacks keep their escaping; outgoing fallback bytes and the separate native-data formatting option stay unchanged. The recursive renderer now owns both container and leaf handling instead of maintaining a separate leaf switch.

This restores the existing mention-context behavior without changing admission, authentication, public SDK/configuration, persistence, or message selection. Production LOC: +41/-26 (net +15). The private projection option and recursive propagation preserve a necessary distinction between typed native references and literal token-shaped text; reusing the native-data option would change existing outbound callers. Tests: +109/-4.

Provenance: introduced by #104539 (`934a974c296f16104308a08c0fc51caac1776a3e`, July 11, 2026). Code/PR author @steipete; merger @steipete-oai; commit committer GitHub. No stable-release range is claimed.

## User Impact

The agent receives recognizable Slack user references with their resolved display names from native rich-text messages. Literal mention-shaped text remains unannotated, and outgoing fallback formatting is unchanged.

## Evidence

- Before editing production, the real ephemeral Gateway and native Slack SDK/Bolt path reproduced missing annotations in all three rich-text variants; the plain-text and literal-text controls passed. All events were admitted and replied to.
- The exact rebuilt candidate passes all five native mock-gateway cases. A fresh source-blind validator independently passed the same five behavioral clauses using new messages and IDs: five delivered events, five actual model requests, and five accepted Slack replies.
- Native mock-gateway verdict: `{"plain":true,"mirrored":true,"shortFallback":true,"nestedList":true,"literalText":true}`. This is mock Slack API + mock provider + real Gateway evidence, not Slack SaaS.
- Final focused owner run: 88 tests across six files, including monitor dispatch, block projection, outgoing fallback formatting, native-data fallbacks, reply blocks, and thread resolution.
- Independent run: 345 tests across nine files, adding actual thread/media context, mention lookup limits and unresolved-name behavior, and message-tool reads.
- Candidate `qaRuntime` build passed with the exact external Slack plugin output. The isolated Gateway and mock servers were stopped afterward.
- Full changed-code gate passed, including production/test typechecks, typed lint, three dead-export scans, and architecture guards. An initial test-only mock callback typing error was repaired by asserting the captured call directly; the final full gate and focused tests passed.
- Fresh complete-patch authenticated Codex review: no actionable findings. Exact-head CI will run on this PR before landing.

AI-assisted; implementation and proof personally inspected.
