### PR TITLE
refactor(mcp): simplify fixed idle runtime policy

### DIFF
--- a/src/agents/agent-bundle-mcp-manager-install.ts
+++ b/src/agents/agent-bundle-mcp-manager-install.ts
@@ -27,7 +27,6 @@ type RuntimeEntryParams = {
   agentDir?: string;
   cfg?: OpenClawConfig;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-  idleTtlMs: number;
   includeServerNames?: ReadonlySet<string>;
   excludeServerNames?: ReadonlySet<string>;
   safeServerNamesByServer?: ReadonlyMap<string, string>;
@@ -49,7 +48,6 @@ type SessionMcpRuntimeManagerInstall = {
     agentDir?: string;
     cfg?: OpenClawConfig;
     manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-    idleTtlMs: number;
     oauthRequesterNameSet: ReadonlySet<string>;
     mcpServers: Record<string, BundleMcpServerConfig>;
     resolverRequesterServerNames: readonly string[];
@@ -126,13 +124,11 @@ export function createSessionMcpRuntimeManagerInstall(
         })
       ) {
         store.runtimesBySessionId.delete(params.runtimeKey);
-        store.idleTtlMsBySessionId.delete(params.runtimeKey);
         store.connectionMetaByRuntimeKey.delete(params.runtimeKey);
         await existing.dispose();
       } else {
         reconcileReusableRetirement(params.sessionId, existing);
         existing.markUsed();
-        store.idleTtlMsBySessionId.set(params.runtimeKey, params.idleTtlMs);
         return existing;
       }
     }
@@ -151,7 +147,6 @@ export function createSessionMcpRuntimeManagerInstall(
       store.createInFlight.delete(params.runtimeKey);
       const staleRuntime = await inFlight.promise.catch(() => undefined);
       store.runtimesBySessionId.delete(params.runtimeKey);
-      store.idleTtlMsBySessionId.delete(params.runtimeKey);
       store.connectionMetaByRuntimeKey.delete(params.runtimeKey);
       await staleRuntime?.dispose();
     }
@@ -177,7 +172,6 @@ export function createSessionMcpRuntimeManagerInstall(
       reconcileReusableRetirement(params.sessionId, runtime);
       runtime.markUsed();
       store.runtimesBySessionId.set(params.runtimeKey, runtime);
-      store.idleTtlMsBySessionId.set(params.runtimeKey, params.idleTtlMs);
       return runtime;
     });
     store.createInFlight.set(params.runtimeKey, {
@@ -202,7 +196,6 @@ export function createSessionMcpRuntimeManagerInstall(
     agentDir?: string;
     cfg?: OpenClawConfig;
     manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-    idleTtlMs: number;
     safeServerNamesByServer: ReadonlyMap<string, string>;
     includeServerNames: ReadonlySet<string>;
     requesterConnect?: RequesterMcpConnect;
@@ -240,7 +233,6 @@ export function createSessionMcpRuntimeManagerInstall(
     ) {
       reconcileReusableRetirement(params.sessionId, existing);
       existing.markUsed();
-      store.idleTtlMsBySessionId.set(params.runtimeKey, params.idleTtlMs);
       store.connectionMetaByRuntimeKey.set(params.runtimeKey, {
         connectionHash,
         resolvedAt: store.now(),
@@ -249,7 +241,6 @@ export function createSessionMcpRuntimeManagerInstall(
     }
     if (existing) {
       store.runtimesBySessionId.delete(params.runtimeKey);
-      store.idleTtlMsBySessionId.delete(params.runtimeKey);
       store.connectionMetaByRuntimeKey.delete(params.runtimeKey);
       await existing.dispose();
     }
@@ -261,7 +252,6 @@ export function createSessionMcpRuntimeManagerInstall(
       agentDir: params.agentDir,
       cfg: params.cfg,
       manifestRegistry: params.manifestRegistry,
-      idleTtlMs: params.idleTtlMs,
       includeServerNames: params.includeServerNames,
       safeServerNamesByServer: params.safeServerNamesByServer,
       connectionOverrides: params.connectionOverrides,
@@ -295,7 +285,6 @@ export function createSessionMcpRuntimeManagerInstall(
     agentDir?: string;
     cfg?: OpenClawConfig;
     manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
-    idleTtlMs: number;
     oauthRequesterNameSet: ReadonlySet<string>;
     mcpServers: Record<string, BundleMcpServerConfig>;
     resolverRequesterServerNames: readonly string[];
@@ -353,7 +342,6 @@ export function createSessionMcpRuntimeManagerInstall(
     ) {
       reconcileReusableRetirement(params.sessionId, existing);
       existing.markUsed();
-      store.idleTtlMsBySessionId.set(params.runtimeKey, params.idleTtlMs);
       return existing;
     }
 
@@ -386,7 +374,6 @@ export function createSessionMcpRuntimeManagerInstall(
       agentDir: params.agentDir,
       cfg: params.cfg,
       manifestRegistry: params.manifestRegistry,
-      idleTtlMs: params.idleTtlMs,
       safeServerNamesByServer: params.safeServerNamesByServer,
       includeServerNames: activeNameSet,
       requesterConnect,

--- a/src/agents/agent-bundle-mcp-manager-lifecycle.ts
+++ b/src/agents/agent-bundle-mcp-manager-lifecycle.ts
@@ -29,7 +29,6 @@ type AdvertisedScopedCatalogEntry = {
 type SessionMcpRuntimeManagerStore = {
   runtimesBySessionId: Map<string, SessionMcpRuntime>;
   sessionIdBySessionKey: Map<string, string>;
-  idleTtlMsBySessionId: Map<string, number>;
   deferredRetirementSessionIds: Set<string>;
   // Reset/delete retirement survives late creation or reuse by the stopping run.
   requiredRetirementSessionIds: Set<string>;
@@ -74,7 +73,6 @@ export function createSessionMcpRuntimeManagerStore(
     // Keys are bare sessionId for static runtimes, or requester composite JSON keys.
     runtimesBySessionId: new Map<string, SessionMcpRuntime>(),
     sessionIdBySessionKey: new Map<string, string>(),
-    idleTtlMsBySessionId: new Map<string, number>(),
     deferredRetirementSessionIds: new Set<string>(),
     requiredRetirementSessionIds: new Set<string>(),
     // Manager-side only: connection hash + resolve time. Never stores raw url/headers.
@@ -188,18 +186,13 @@ export function createSessionMcpRuntimeManagerLifecycle(
     const nowMs = store.now();
     const expired: SessionMcpRuntime[] = [];
     for (const [runtimeKey, runtime] of store.runtimesBySessionId.entries()) {
-      const idleTtlMs =
-        store.idleTtlMsBySessionId.get(runtimeKey) ??
-        store.idleTtlMsBySessionId.get(runtime.sessionId) ??
-        DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS;
-      if (idleTtlMs <= 0 || (runtime.activeLeases ?? 0) > 0) {
+      if ((runtime.activeLeases ?? 0) > 0) {
         continue;
       }
-      if (nowMs - runtime.lastUsedAt < idleTtlMs) {
+      if (nowMs - runtime.lastUsedAt < DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS) {
         continue;
       }
       store.runtimesBySessionId.delete(runtimeKey);
-      store.idleTtlMsBySessionId.delete(runtimeKey);
       store.connectionMetaByRuntimeKey.delete(runtimeKey);
       expired.push(runtime);
     }
@@ -251,7 +244,6 @@ export function createSessionMcpRuntimeManagerLifecycle(
           return;
         }
         store.runtimesBySessionId.delete(runtimeKey);
-        store.idleTtlMsBySessionId.delete(runtimeKey);
         store.connectionMetaByRuntimeKey.delete(runtimeKey);
         await current.dispose();
       });
@@ -296,7 +288,6 @@ export function createSessionMcpRuntimeManagerLifecycle(
       runtime = await inFlight.promise.catch(() => undefined);
     }
     store.runtimesBySessionId.delete(runtimeKey);
-    store.idleTtlMsBySessionId.delete(runtimeKey);
     store.connectionMetaByRuntimeKey.delete(runtimeKey);
     if (runtime) {
       await runtime.dispose();

--- a/src/agents/agent-bundle-mcp-manager.ts
+++ b/src/agents/agent-bundle-mcp-manager.ts
@@ -13,10 +13,7 @@ import {
 } from "./agent-bundle-mcp-manager-lifecycle.js";
 import { assignSafeServerNames } from "./agent-bundle-mcp-names.js";
 import { loadSessionMcpConfig } from "./agent-bundle-mcp-runtime-config.js";
-import {
-  resolveSessionMcpRuntimeIdleTtlMs,
-  type CreateSessionMcpRuntime,
-} from "./agent-bundle-mcp-runtime-shared.js";
+import type { CreateSessionMcpRuntime } from "./agent-bundle-mcp-runtime-shared.js";
 import type { SessionMcpRuntime, SessionMcpRuntimeManager } from "./agent-bundle-mcp-types.js";
 import { revokeMcpAppModelContext } from "./mcp-app-model-context.js";
 import {
@@ -52,7 +49,6 @@ export function createSessionMcpRuntimeManager(
   const install = createSessionMcpRuntimeManagerInstall(lifecycle);
   const materializeRequesterScopedRuntime = async (
     params: Parameters<SessionMcpRuntimeManager["getOrCreate"]>[0] & {
-      idleTtlMs: number;
       mcpServers: Record<string, BundleMcpServerConfig>;
       oauthRequesterServerNames: readonly string[];
       resolverRequesterServerNames: readonly string[];
@@ -101,11 +97,8 @@ export function createSessionMcpRuntimeManager(
 
   const manager: SessionMcpRuntimeManager = {
     async getOrCreate(params) {
-      const idleTtlMs = resolveSessionMcpRuntimeIdleTtlMs();
       await lifecycle.sweepIdleRuntimes();
-      if (idleTtlMs > 0) {
-        lifecycle.ensureIdleSweepTimer();
-      }
+      lifecycle.ensureIdleSweepTimer();
       if (params.sessionKey) {
         store.sessionIdBySessionKey.set(params.sessionKey, params.sessionId);
       }
@@ -138,7 +131,6 @@ export function createSessionMcpRuntimeManager(
           agentDir: params.agentDir,
           cfg: params.cfg,
           manifestRegistry: params.manifestRegistry,
-          idleTtlMs,
           safeServerNamesByServer,
           toolOverrides: params.toolOverrides,
         });
@@ -157,7 +149,6 @@ export function createSessionMcpRuntimeManager(
             agentDir: params.agentDir,
             cfg: params.cfg,
             manifestRegistry: params.manifestRegistry,
-            idleTtlMs,
             excludeServerNames: scopedNameSet,
             safeServerNamesByServer,
             toolOverrides: params.toolOverrides,
@@ -173,7 +164,6 @@ export function createSessionMcpRuntimeManager(
           agentDir: params.agentDir,
           cfg: params.cfg,
           manifestRegistry: params.manifestRegistry,
-          idleTtlMs,
           includeServerNames: new Set(),
           safeServerNamesByServer,
           toolOverrides: params.toolOverrides,
@@ -184,7 +174,6 @@ export function createSessionMcpRuntimeManager(
       if (requesterSenderId) {
         const { runtimeKey, runtime: scopedRuntime } = await materializeRequesterScopedRuntime({
           ...params,
-          idleTtlMs,
           mcpServers: fullConfig.loaded.mcpServers,
           oauthRequesterServerNames,
           resolverRequesterServerNames,
@@ -209,7 +198,6 @@ export function createSessionMcpRuntimeManager(
             agentDir: params.agentDir,
             cfg: params.cfg,
             manifestRegistry: params.manifestRegistry,
-            idleTtlMs,
             includeServerNames: new Set(),
             safeServerNamesByServer,
             toolOverrides: params.toolOverrides,
@@ -232,11 +220,8 @@ export function createSessionMcpRuntimeManager(
       if (!requesterSenderId) {
         return undefined;
       }
-      const idleTtlMs = resolveSessionMcpRuntimeIdleTtlMs();
       await lifecycle.sweepIdleRuntimes();
-      if (idleTtlMs > 0) {
-        lifecycle.ensureIdleSweepTimer();
-      }
+      lifecycle.ensureIdleSweepTimer();
       if (params.sessionKey) {
         store.sessionIdBySessionKey.set(params.sessionKey, params.sessionId);
       }
@@ -261,7 +246,6 @@ export function createSessionMcpRuntimeManager(
       const scopedNameSet = new Set(requesterScopedServerNames);
       const { runtimeKey, runtime } = await materializeRequesterScopedRuntime({
         ...params,
-        idleTtlMs,
         mcpServers: fullConfig.loaded.mcpServers,
         oauthRequesterServerNames,
         resolverRequesterServerNames,
@@ -360,7 +344,6 @@ export function createSessionMcpRuntimeManager(
       const runtimes = Array.from(store.runtimesBySessionId.values());
       store.runtimesBySessionId.clear();
       store.sessionIdBySessionKey.clear();
-      store.idleTtlMsBySessionId.clear();
       store.deferredRetirementSessionIds.clear();
       store.requiredRetirementSessionIds.clear();
       store.connectionMetaByRuntimeKey.clear();
@@ -397,7 +380,6 @@ export function createSessionMcpRuntimeManager(
       createInFlight: store.createInFlight.size,
       requesterWorkChains: store.requesterWorkChains.size,
       sessionKeys: store.sessionIdBySessionKey.size,
-      idleTtl: store.idleTtlMsBySessionId.size,
       deferredRetirement: store.deferredRetirementSessionIds.size,
       advertisedScopedCatalogs: store.advertisedScopedCatalogBySessionId.size,
     }),

--- a/src/agents/agent-bundle-mcp-runtime-shared.ts
+++ b/src/agents/agent-bundle-mcp-runtime-shared.ts
@@ -48,7 +48,3 @@ export type CreateSessionMcpRuntime = (params: {
   configFingerprint?: string;
   toolOverrides?: Pick<SessionToolOverrides, "mcpServers" | "mcpToolsDeny">;
 }) => SessionMcpRuntime;
-
-export function resolveSessionMcpRuntimeIdleTtlMs(): number {
-  return DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS;
-}

--- a/src/agents/agent-bundle-mcp-runtime.test.ts
+++ b/src/agents/agent-bundle-mcp-runtime.test.ts
@@ -3314,6 +3314,99 @@ describe("requester-scoped MCP connection resolution", () => {
     vi.useRealTimers();
   });
 
+  it.each([
+    ["static", 1],
+    ["full", 2],
+    ["requester-only", 1],
+  ] as const)(
+    "expires %s runtimes at ten idle minutes while preserving reuse and active leases",
+    async (entrypoint, expectedExpired) => {
+      let nowMs = 100_000;
+      const clock = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+      const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
+      resolverTesting.setMcpServerConnectionResolversForTest([
+        {
+          serverName: "user-mail",
+          resolve: async () => ({ url: "https://mcp.example.test/user" }),
+        },
+      ]);
+      const manager = testing.createSessionMcpRuntimeManager({ enableIdleSweepTimer: false });
+      const sessionKey = "agent:test:session-fixed-idle";
+      const params: RuntimeParams = {
+        sessionId: "session-fixed-idle",
+        sessionKey,
+        workspaceDir: "/workspace",
+        ...(entrypoint === "static" ? {} : { requesterSenderId: "sender-a" }),
+        cfg: {
+          mcp: {
+            servers: {
+              shared: { command: "true" },
+              ...(entrypoint === "static"
+                ? {}
+                : { "user-mail": { transport: "streamable-http" as const } }),
+            },
+          },
+        },
+      };
+      const getRuntime = () =>
+        entrypoint === "requester-only"
+          ? manager.getOrCreateRequesterScoped(params)
+          : manager.getOrCreate(params);
+      try {
+        await getRuntime();
+        nowMs += 10 * 60 * 1000 - 1;
+        expect(await manager.sweepIdleRuntimes()).toBe(0);
+
+        const reused = expectDefined(await getRuntime(), "admitted MCP runtime");
+        expect(reused.lastUsedAt).toBe(nowMs);
+        nowMs += 10 * 60 * 1000 - 1;
+        expect(await manager.sweepIdleRuntimes()).toBe(0);
+        const release = expectDefined(reused.acquireLease, "MCP runtime lease")();
+        nowMs += 1;
+        expect(await manager.sweepIdleRuntimes()).toBe(0);
+        expect(manager.listSessionIds()).toContain(params.sessionId);
+
+        release();
+        expect(await manager.sweepIdleRuntimes()).toBe(expectedExpired);
+        expect(manager.listRuntimeKeys()).toEqual([]);
+        expect(manager.resolveSessionId(sessionKey)).toBeUndefined();
+      } finally {
+        await manager.disposeAll();
+        clock.mockRestore();
+      }
+    },
+  );
+
+  it("sweeps admitted runtimes on the fixed idle timer and stops maintenance after disposal", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(100_000);
+    const now = vi.fn(() => Date.now());
+    const manager = testing.createSessionMcpRuntimeManager({ now });
+    const params: RuntimeParams = {
+      sessionId: "session-idle-timer",
+      workspaceDir: "/workspace",
+      cfg: { mcp: { servers: {} } },
+    };
+    try {
+      await manager.getOrCreate(params);
+      await manager.getOrCreate(params);
+      now.mockClear();
+      await vi.advanceTimersByTimeAsync(10 * 60 * 1000 - 1);
+      expect(manager.listSessionIds()).toEqual([params.sessionId]);
+      expect(now).toHaveBeenCalledTimes(9);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(manager.listSessionIds()).toEqual([]);
+      expect(now).toHaveBeenCalledTimes(10);
+
+      await manager.disposeAll();
+      now.mockClear();
+      await vi.advanceTimersByTimeAsync(60 * 1000);
+      expect(now).not.toHaveBeenCalled();
+    } finally {
+      await manager.disposeAll();
+    }
+  });
+
   it("keys requester-scoped runtimes per sender while sharing static servers", async () => {
     const { testing: resolverTesting } = await import("./mcp-connection-resolver.js");
     resolverTesting.setMcpServerConnectionResolversForTest([
@@ -4144,7 +4237,6 @@ describe("requester-scoped MCP connection resolution", () => {
       createInFlight: 0,
       requesterWorkChains: 0,
       sessionKeys: 0,
-      idleTtl: 0,
       deferredRetirement: 0,
       advertisedScopedCatalogs: 0,
     });
@@ -4568,11 +4660,10 @@ describe("requester-scoped MCP connection resolution", () => {
       connectionMeta: 1,
       requesterWorkChains: 0,
       sessionKeys: 1,
-      idleTtl: 1,
     });
 
     now.mockClear();
-    nowMs += testing.resolveSessionMcpRuntimeIdleTtlMs() + 1;
+    nowMs += 10 * 60 * 1000 + 1;
     for (const [requesterSenderId, attemptedSessionId] of [
       [undefined, "session-missing"],
       ["  ", "session-blank"],

--- a/src/agents/agent-bundle-mcp-runtime.ts
+++ b/src/agents/agent-bundle-mcp-runtime.ts
@@ -40,7 +40,6 @@ import {
   loadSessionMcpConfig,
   resolveSessionMcpConfigSummary,
 } from "./agent-bundle-mcp-runtime-config.js";
-import { resolveSessionMcpRuntimeIdleTtlMs } from "./agent-bundle-mcp-runtime-shared.js";
 import type {
   McpCatalogTool,
   McpRequestOptions,
@@ -1141,7 +1140,6 @@ export const testing = {
   },
   setBundleMcpCatalogListTimeoutMsForTest,
   setBundleMcpDisposeTimeoutMsForTest,
-  resolveSessionMcpRuntimeIdleTtlMs,
   mergeMcpToolCatalogs,
 };
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The MCP session manager already uses a fixed ten-minute idle timeout, but still
carried per-runtime timeout bookkeeping. Every stored timeout had the same value,
and the branches for disabled idle expiry could no longer be reached.

## Why This Change Was Made

Use the existing fixed timeout directly at the lifecycle owner. Remove its
private map, constant resolver, argument forwarding, and always-true timer guards.
Keep the actual idle sweeper and its ordering, leases, requester capacity,
authority revalidation, retirement, and transport cleanup unchanged.

Conservative production LOC: **net -43**. Gross production-source change is
+5/-51; three removed test-support lines are excluded from production credit.
Tests: +94/-3. No generated files or moved code are counted.

## User Impact

No behavior or configuration change. Idle expiry remains ten minutes, the
maintenance interval remains one minute, active leases prevent idle expiry, and
the requester-runtime capacity remains 64. The older configurable timeout is
already retired in current code; this does not change its doctor migration or
remove another public option.

## Evidence

The new boundary and timer tests passed against unchanged production code, then
all four owner suites passed with the candidate: 127 tests. They cover static,
combined, and requester-only runtimes, reuse, the exact 599999/600000ms boundary,
active leases, the singleton timer, and disposal.

The same native protocol probe passed before and after the cleanup using actual
MCP SDK stdio and stateful loopback HTTP servers. Each transport completed two
tool calls, stayed open while leased at the idle boundary, closed after release
and expiry, and recreated a different connection. This is transport integration,
not a live-provider or real Codex-turn claim.

Pinned Linux repeated all 127 tests and the native probe with Node 24.19.0,
Vitest 4.1.11, and MCP SDK 1.30.0 after verifying the complete frozen workspace
dependency closure and candidate-owned source aliases. Local dependencies were
stale, so local success alone is not claimed as CI parity.

Full changed-code checks passed on pinned Linux, including core production and
test types, all three dead-export scans, formatting, typed lint, and the normal
guard inventory. All 34,214 tracked source files were unchanged after validation.
Complete isolated precommit review passed with no actionable findings. The proof
archive is preserved and the owned remote environment has been stopped.
