### PR TITLE
fix(matrix): automatic replies lose native table formatting

### DIFF
--- a/docs/concepts/markdown-formatting.md
+++ b/docs/concepts/markdown-formatting.md
@@ -27,6 +27,7 @@ splits formatting mid-span.
 
 | Channel                                                          | Renderer                                                                             | Notes                                                                                    |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| Matrix                                                           | HTML tags, including native tables                                                   | Automatic replies, direct sends, and media captions use the same formatter               |
 | Slack                                                            | mrkdwn tokens (`*bold*`, `_italic_`, `` `code` ``, code fences)                      | Links become `<url\|label>`; autolink disabled during parse to avoid double-linking      |
 | Telegram                                                         | HTML tags (`<b>`, `<i>`, `<s>`, `<code>`, `<pre><code>`, `<a href>`, `<tg-spoiler>`) | Also supports rich-message tables and headings (`<h1>`-`<h6>`) when `richMessages` is on |
 | Signal                                                           | plain text + `text-style` ranges                                                     | Links render as `label (url)` when the label differs from the URL                        |
@@ -62,9 +63,10 @@ channel and optionally per account:
 | `block`   | Keep native tables where the transport supports them; falls back to `code` otherwise |
 | `off`     | Disable table parsing; raw table text passes through unchanged                       |
 
-Per-channel plugin defaults: Signal, WhatsApp, and Matrix default to
-`bullets`; Mattermost defaults to `off`; Telegram defaults to `block` (which
-resolves to `code` unless the account has `richMessages` enabled). Any
+Per-channel plugin defaults: Matrix defaults to `block` (native tables);
+Mattermost defaults to `off`; Signal and WhatsApp default to `bullets`;
+Telegram defaults to `block` (which resolves to `code` unless the account
+has `richMessages` enabled). Any
 channel without an explicit plugin default falls back to `code`.
 
 ```yaml

--- a/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-reply-dispatcher.ts
@@ -48,13 +48,11 @@ export function createMatrixReplyDispatcher(config: {
   client: MatrixClient;
   roomId: string;
   runtime: RuntimeEnv;
-  textLimit: number;
   replyToMode: ReplyToMode;
   threadTarget?: string;
   replyToEventId?: string;
   accountId: string;
   mediaLocalRoots: readonly string[];
-  tableMode: Parameters<typeof deliverMatrixReplies>[0]["tableMode"];
   logVerboseMessage: (message: string) => void;
 }) {
   const {
@@ -68,13 +66,11 @@ export function createMatrixReplyDispatcher(config: {
     client,
     roomId,
     runtime,
-    textLimit,
     replyToMode,
     threadTarget,
     replyToEventId,
     accountId,
     mediaLocalRoots,
-    tableMode,
     logVerboseMessage,
   } = config;
   const quietDraftStreaming = streaming === "quiet" || streaming === "progress";
@@ -172,14 +168,12 @@ export function createMatrixReplyDispatcher(config: {
               roomId,
               client,
               runtime,
-              textLimit,
               replyToMode,
               hasRepliedRef,
               threadId: threadTarget,
               replyToId: threadTarget ?? replyToEventId ?? undefined,
               accountId,
               mediaLocalRoots,
-              tableMode,
             }),
           );
         }
@@ -294,14 +288,12 @@ export function createMatrixReplyDispatcher(config: {
                     roomId,
                     client,
                     runtime,
-                    textLimit,
                     replyToMode,
                     hasRepliedRef,
                     threadId: threadTarget,
                     replyToId: threadTarget ?? replyToEventId ?? undefined,
                     accountId,
                     mediaLocalRoots,
-                    tableMode,
                   }),
               });
               return fallbackResult.visibleReplySent;
@@ -395,14 +387,12 @@ export function createMatrixReplyDispatcher(config: {
               roomId,
               client,
               runtime,
-              textLimit,
               replyToMode,
               hasRepliedRef,
               threadId: threadTarget,
               replyToId: threadTarget ?? replyToEventId ?? undefined,
               accountId,
               mediaLocalRoots,
-              tableMode,
             });
           if (reusesDraftAsFinalText) {
             draftController.markDraftConsumed();
@@ -440,14 +430,12 @@ export function createMatrixReplyDispatcher(config: {
             roomId,
             client,
             runtime,
-            textLimit,
             replyToMode,
             hasRepliedRef,
             threadId: threadTarget,
             replyToId: threadTarget ?? replyToEventId ?? undefined,
             accountId,
             mediaLocalRoots,
-            tableMode,
           });
         const draftContent = draftStream.content();
         if (shouldRedactDraft && draftEventId && draftContent) {
@@ -468,14 +456,12 @@ export function createMatrixReplyDispatcher(config: {
           roomId,
           client,
           runtime,
-          textLimit,
           replyToMode,
           hasRepliedRef,
           threadId: threadTarget,
           replyToId: threadTarget ?? replyToEventId ?? undefined,
           accountId,
           mediaLocalRoots,
-          tableMode,
         }),
       );
     },

--- a/extensions/matrix/src/matrix/monitor/handler-types.ts
+++ b/extensions/matrix/src/matrix/monitor/handler-types.ts
@@ -44,7 +44,6 @@ export type MatrixMonitorHandlerParams = {
   blockStreamingEnabled: boolean;
   dmEnabled: boolean;
   dmPolicy: "open" | "pairing" | "allowlist" | "disabled";
-  textLimit: number;
   mediaMaxBytes: number;
   historyLimit: number;
   startupMs: number;

--- a/extensions/matrix/src/matrix/monitor/handler.audio-preflight.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.audio-preflight.test.ts
@@ -62,7 +62,6 @@ function createAudioPreflightHarness(
     getMemberDisplayName: async () => "Frank",
     startupMs: Date.now() - 120_000,
     startupGraceMs: 60_000,
-    textLimit: 4000,
     mediaMaxBytes: 5 * 1024 * 1024,
     replyToMode: "first",
     ...overrides,

--- a/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.media-failure.test.ts
@@ -50,7 +50,6 @@ function createMediaFailureHarness() {
     getMemberDisplayName: async () => "Gum",
     startupMs: Date.now() - 120_000,
     startupGraceMs: 60_000,
-    textLimit: 4000,
     mediaMaxBytes: 5 * 1024 * 1024,
     replyToMode: "first",
   });

--- a/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test-helpers.ts
@@ -78,7 +78,6 @@ type MatrixHandlerTestHarnessOptions = {
   blockStreamingEnabled?: boolean;
   dmEnabled?: boolean;
   dmPolicy?: "pairing" | "allowlist" | "open" | "disabled";
-  textLimit?: number;
   mediaMaxBytes?: number;
   startupMs?: number;
   startupGraceMs?: number;
@@ -372,7 +371,6 @@ export function createMatrixHandlerTestHarness(
     blockStreamingEnabled: options.blockStreamingEnabled ?? false,
     dmEnabled: options.dmEnabled ?? true,
     dmPolicy,
-    textLimit: options.textLimit ?? 8_000,
     mediaMaxBytes: options.mediaMaxBytes ?? 10_000_000,
     startupMs: options.startupMs ?? 0,
     startupGraceMs: options.startupGraceMs ?? 0,

--- a/extensions/matrix/src/matrix/monitor/handler.thread-root-media.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.thread-root-media.test.ts
@@ -55,7 +55,6 @@ describe("createMatrixRoomMessageHandler thread root media", () => {
       getMemberDisplayName: async () => "Gum",
       startupMs: Date.now() - 120_000,
       startupGraceMs: 60_000,
-      textLimit: 4000,
       mediaMaxBytes: 5 * 1024 * 1024,
       replyToMode: "first",
     });

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -58,7 +58,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
     streaming,
     previewToolProgressEnabled,
     blockStreamingEnabled,
-    textLimit,
     historyLimit,
     startupMs,
     startupGraceMs,
@@ -355,11 +354,6 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         replyTarget,
         sharedDmContextNotice,
       } = inboundContext;
-      const tableMode = core.channel.text.resolveMarkdownTableMode({
-        cfg,
-        channel: "matrix",
-        accountId: _route.accountId,
-      });
       const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, _route.agentId);
       const { onModelSelected, ...prefixOptions } = createReplyPrefixOptions({
         cfg,
@@ -428,13 +422,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         client,
         roomId,
         runtime,
-        textLimit,
         replyToMode,
         threadTarget,
         replyToEventId: replyToEventId ?? undefined,
         accountId: _route.accountId,
         mediaLocalRoots,
-        tableMode,
         logVerboseMessage,
       });
       const { deliverReply, onReplyError, turnDispatcherOptions } = replyDispatcher;

--- a/extensions/matrix/src/matrix/monitor/index.test-helpers.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test-helpers.ts
@@ -87,9 +87,6 @@ const hoisted = vi.hoisted(() => {
     aliasesResolved: true,
   }));
   const getMemberDisplayName = vi.fn(async () => "Bot");
-  const resolveTextChunkLimit = vi.fn<
-    (cfg: unknown, channel: unknown, accountId?: unknown) => number
-  >(() => 4000);
   const logger = {
     info: vi.fn(),
     warn: vi.fn(),
@@ -208,7 +205,6 @@ const hoisted = vi.hoisted(() => {
     releaseSharedClientInstance,
     resolveSharedMatrixClient: lease.start,
     resolveSharedMatrixClientImpl,
-    resolveTextChunkLimit,
     runMatrixStartupMaintenance,
     runRegisteredMonitorRetirement,
     setMatrixRuntime,
@@ -259,10 +255,6 @@ vi.mock("../../runtime.js", () => ({
     channel: {
       mentions: {
         buildMentionRegexes: () => [],
-      },
-      text: {
-        resolveTextChunkLimit: (cfg: unknown, channel: unknown, accountId?: unknown) =>
-          hoisted.resolveTextChunkLimit(cfg, channel, accountId),
       },
     },
     system: {

--- a/extensions/matrix/src/matrix/monitor/index.test.ts
+++ b/extensions/matrix/src/matrix/monitor/index.test.ts
@@ -102,7 +102,6 @@ describe("monitorMatrixProvider", () => {
     hoisted.accountConfig.dm = {};
     delete (hoisted.accountConfig as { streaming?: unknown }).streaming;
     delete (hoisted.accountConfig as { rooms?: Record<string, unknown> }).rooms;
-    hoisted.resolveTextChunkLimit.mockReset().mockReturnValue(4000);
     hoisted.acquireSharedMatrixClient
       .mockReset()
       .mockImplementation(hoisted.acquireSharedMatrixClientImpl);
@@ -192,7 +191,6 @@ describe("monitorMatrixProvider", () => {
     await monitorMatrixProvider({ abortSignal: abortController.signal });
 
     expect(hoisted.callOrder).toStrictEqual([]);
-    expect(hoisted.resolveTextChunkLimit).not.toHaveBeenCalled();
     expect(hoisted.createMatrixRoomMessageHandler).not.toHaveBeenCalled();
     expect(hoisted.acquireSharedMatrixClient).not.toHaveBeenCalled();
   });
@@ -494,23 +492,6 @@ describe("monitorMatrixProvider", () => {
       expect.objectContaining({ startClient: false }),
     );
     expect(hoisted.stopThreadBindingManager).toHaveBeenCalledTimes(1);
-  });
-
-  it("resolves text chunk limit for the effective Matrix account", async () => {
-    await startMonitorAndAbortAfterStartup();
-
-    expect(mockCallArg(hoisted.resolveTextChunkLimit, 0, 0)).toEqual({
-      channels: {
-        matrix: {
-          dm: {
-            allowFrom: [],
-          },
-          groupAllowFrom: [],
-        },
-      },
-    });
-    expect(mockCallArg(hoisted.resolveTextChunkLimit, 0, 1)).toBe("matrix");
-    expect(mockCallArg(hoisted.resolveTextChunkLimit, 0, 2)).toBe("default");
   });
 
   it("starts monitoring without waiting for best-effort deviceId backfill", async () => {

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -265,7 +265,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
   const dmPolicyRaw = dmConfig?.policy ?? "pairing";
   const dmPolicy = allowlistOnly && dmPolicyRaw !== "disabled" ? "allowlist" : dmPolicyRaw;
   const dmSessionScope = dmConfig?.sessionScope ?? "per-user";
-  const textLimit = core.channel.text.resolveTextChunkLimit(cfg, "matrix", effectiveAccountId);
   const globalGroupChatHistoryLimit = (
     cfg.messages as { groupChat?: { historyLimit?: number } } | undefined
   )?.groupChat?.historyLimit;
@@ -423,7 +422,6 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       blockStreamingEnabled,
       dmEnabled,
       dmPolicy,
-      textLimit,
       mediaMaxBytes,
       historyLimit,
       startupMs,

--- a/extensions/matrix/src/matrix/monitor/replies.file-boundary.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.file-boundary.test.ts
@@ -57,7 +57,6 @@ describe("deliverMatrixReplies file boundary", () => {
       roomId: "!room:example.org",
       client,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "off",
       mediaLocalRoots: [tempDir],
     });

--- a/extensions/matrix/src/matrix/monitor/replies.formatting.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.formatting.test.ts
@@ -1,0 +1,318 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  resolveMarkdownTableMode,
+  type MarkdownTableMode,
+} from "openclaw/plugin-sdk/markdown-table-runtime";
+import { mediaKindFromMime } from "openclaw/plugin-sdk/media-runtime";
+import {
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+  type PluginRuntime,
+  type RuntimeEnv,
+} from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  chunkMarkdownTextWithMode,
+  resolveChunkMode,
+  resolveTextChunkLimit,
+} from "openclaw/plugin-sdk/reply-chunking";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { matrixPlugin } from "../../channel.js";
+import { setMatrixRuntime } from "../../runtime.js";
+import type { CoreConfig } from "../../types.js";
+import type { MatrixClient } from "../sdk.js";
+import { sendMessageMatrix } from "../send.js";
+import { deliverMatrixReplies } from "./replies.js";
+
+const table = "| Name | Status |\n|---|---|\n| Alpha | Ready |";
+const runtimeEnv = {} as RuntimeEnv;
+const defaultCfg = { channels: { matrix: {} } } as CoreConfig;
+
+function createClient() {
+  let nextId = 0;
+  const sendMessage = vi.fn(
+    async (_roomId: string, _content: Record<string, unknown>) => `$sent-${++nextId}`,
+  );
+  const uploadContent = vi.fn(async () => "mxc://example.org/fixture");
+  const client = {
+    prepareRoomForMessageSend: async () => "m.room.message",
+    getUserId: async () => "@bot:example.org",
+    sendMessage,
+    uploadContent,
+  } as unknown as MatrixClient;
+  return { client, sendMessage, uploadContent };
+}
+
+describe("Matrix automatic reply table presentation", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "matrix", source: "test", plugin: matrixPlugin }]),
+    );
+    setMatrixRuntime({
+      channel: {
+        text: {
+          resolveMarkdownTableMode,
+          resolveTextChunkLimit,
+          resolveChunkMode,
+          chunkMarkdownTextWithMode,
+        },
+      },
+      logging: { shouldLogVerbose: () => false },
+      media: { mediaKindFromMime },
+    } as unknown as PluginRuntime);
+  });
+
+  afterEach(() => {
+    resetPluginRuntimeStateForTest();
+  });
+
+  it.each([
+    { name: "plugin default", mode: undefined, expected: "<table>" },
+    { name: "explicit native tables", mode: "block", expected: "<table>" },
+    { name: "explicit code tables", mode: "code", expected: "<pre><code>" },
+    { name: "explicit bullet tables", mode: "bullets", expected: "<strong>Alpha</strong>" },
+    { name: "disabled table parsing", mode: "off", expected: "| Name | Status |" },
+  ] satisfies Array<{ name: string; mode: MarkdownTableMode | undefined; expected: string }>)(
+    "uses the same native output for automatic and direct sends with $name",
+    async ({ mode, expected }) => {
+      const cfg = {
+        channels: { matrix: mode ? { markdown: { tables: mode } } : {} },
+      } as CoreConfig;
+      const direct = createClient();
+      await sendMessageMatrix("!room:example.org", table, { cfg, client: direct.client });
+      const directContent = direct.sendMessage.mock.calls[0]?.[1];
+      expect(directContent?.formatted_body).toContain(expected);
+
+      const automatic = createClient();
+      const result = await deliverMatrixReplies({
+        cfg,
+        replies: [{ text: table }],
+        roomId: "!room:example.org",
+        client: automatic.client,
+        runtime: runtimeEnv,
+        replyToMode: "off",
+      });
+
+      expect(result.visibleReplySent).toBe(true);
+      expect(automatic.sendMessage).toHaveBeenCalledOnce();
+      const automaticContent = automatic.sendMessage.mock.calls[0]?.[1];
+      expect(automaticContent?.formatted_body).toContain(expected);
+      expect(automaticContent).toEqual(directContent);
+    },
+  );
+
+  it("keeps a native table within a long automatic reply while preserving code examples", async () => {
+    const text = `${"Paragraph content. ".repeat(250)}\n\n${table}\n\n\`\`\`md\n${table}\n\`\`\`\n\n    indented code`;
+    const automatic = createClient();
+    const result = await deliverMatrixReplies({
+      cfg: defaultCfg,
+      replies: [{ text }],
+      roomId: "!room:example.org",
+      client: automatic.client,
+      runtime: runtimeEnv,
+      replyToMode: "off",
+    });
+
+    const contents = automatic.sendMessage.mock.calls.map((call) => call[1]);
+    expect(result.visibleReplySent).toBe(true);
+    expect(contents.length).toBeGreaterThan(1);
+    expect(contents.every((content) => String(content.body).length <= 4000)).toBe(true);
+    expect(contents.some((content) => String(content.formatted_body).includes("<table>"))).toBe(
+      true,
+    );
+    expect(
+      contents.some((content) =>
+        String(content.formatted_body).includes('<pre><code class="language-md">'),
+      ),
+    ).toBe(true);
+    expect(
+      contents.some((content) =>
+        String(content.formatted_body).includes("<pre><code>indented code"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps native tables in automatic media captions", async () => {
+    await withTempDir("matrix-native-table-caption-", async (tempDir) => {
+      const localRoot = await fs.realpath(tempDir);
+      const mediaPath = path.join(localRoot, "attachment.txt");
+      await fs.writeFile(mediaPath, "caption attachment fixture");
+      const { client, sendMessage, uploadContent } = createClient();
+
+      await deliverMatrixReplies({
+        cfg: defaultCfg,
+        replies: [{ text: table, mediaUrl: mediaPath }],
+        roomId: "!room:example.org",
+        client,
+        runtime: runtimeEnv,
+        replyToMode: "off",
+        mediaLocalRoots: [localRoot],
+      });
+
+      expect(uploadContent).toHaveBeenCalledOnce();
+      expect(sendMessage).toHaveBeenCalledOnce();
+      expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
+        msgtype: "m.file",
+        filename: "attachment.txt",
+        formatted_body: expect.stringContaining("<table>"),
+      });
+    });
+  });
+
+  it.each([false, true])(
+    "keeps first-reply relations and receipts across chunks (separate dispatch: %s)",
+    async (separateDispatch) => {
+      const { client, sendMessage } = createClient();
+      const hasRepliedRef = { value: false };
+      const delivery = {
+        cfg: defaultCfg,
+        roomId: "!room:example.org",
+        client,
+        runtime: runtimeEnv,
+        replyToMode: "first" as const,
+        replyToId: "$incoming",
+        hasRepliedRef,
+      };
+      const first = await deliverMatrixReplies({
+        ...delivery,
+        replies: [
+          { text: "Visible paragraph. ".repeat(400) },
+          ...(!separateDispatch ? [{ text: "Next payload" }] : []),
+        ],
+      });
+      const firstCount = sendMessage.mock.calls.length - (separateDispatch ? 0 : 1);
+      expect(firstCount).toBeGreaterThan(1);
+      expect(first.messageIds).toEqual(
+        sendMessage.mock.calls.map((_, index) => `$sent-${index + 1}`),
+      );
+      expect(first.receipt?.primaryPlatformMessageId).toBe("$sent-1");
+      expect(first.content).toBe(
+        sendMessage.mock.calls.map(([, content]) => content.body).join("\n"),
+      );
+      expect(hasRepliedRef.value).toBe(true);
+      for (const [, content] of sendMessage.mock.calls.slice(0, firstCount)) {
+        expect(content["m.relates_to"]).toEqual({ "m.in_reply_to": { event_id: "$incoming" } });
+      }
+
+      if (separateDispatch) {
+        await deliverMatrixReplies({ ...delivery, replies: [{ text: "Next payload" }] });
+      }
+      expect(sendMessage).toHaveBeenCalledTimes(firstCount + 1);
+      expect(sendMessage.mock.calls[firstCount]?.[1].body).toBe("Next payload");
+      expect(sendMessage.mock.calls[firstCount]?.[1]["m.relates_to"]).toBeUndefined();
+    },
+  );
+
+  it("preserves native thread fallback on every chunk with implicit replies disabled", async () => {
+    const { client, sendMessage } = createClient();
+    await deliverMatrixReplies({
+      cfg: defaultCfg,
+      replies: [{ text: "Thread paragraph. ".repeat(400) }],
+      roomId: "!room:example.org",
+      client,
+      runtime: runtimeEnv,
+      replyToMode: "off",
+      threadId: "$thread",
+      replyToId: "$incoming",
+    });
+    expect(sendMessage.mock.calls.length).toBeGreaterThan(1);
+    for (const [, content] of sendMessage.mock.calls) {
+      expect(content["m.relates_to"]).toEqual({
+        rel_type: "m.thread",
+        event_id: "$thread",
+        is_falling_back: true,
+        "m.in_reply_to": { event_id: "$incoming" },
+      });
+    }
+  });
+
+  it("uses the account limit and canonical bullet fallback for an oversized native table", async () => {
+    const rows = Array.from({ length: 40 }, (_, index) => `| Item${index} | Ready${index} |`);
+    const text = `| Name | Status |\n|---|---|\n${rows.join("\n")}`;
+    const cfg = {
+      channels: {
+        matrix: { accounts: { ops: { textChunkLimit: 256, streaming: { chunkMode: "newline" } } } },
+      },
+    } as CoreConfig;
+    const automatic = createClient();
+    const direct = createClient();
+    await sendMessageMatrix("!room:example.org", text, {
+      cfg,
+      accountId: "ops",
+      client: direct.client,
+    });
+    await deliverMatrixReplies({
+      cfg,
+      accountId: "ops",
+      replies: [{ text }],
+      roomId: "!room:example.org",
+      client: automatic.client,
+      runtime: runtimeEnv,
+      replyToMode: "off",
+    });
+    const bodies = automatic.sendMessage.mock.calls.map(([, content]) => content);
+    expect(bodies).toEqual(direct.sendMessage.mock.calls.map(([, content]) => content));
+    expect(bodies.length).toBeGreaterThan(1);
+    expect(bodies.every((content) => String(content.body).length <= 256)).toBe(true);
+    const visible = bodies.map((content) => content.body).join("\n");
+    for (let index = 0; index < rows.length; index++) {
+      expect(visible).toContain(`Item${index}`);
+      expect(visible).toContain(`Ready${index}`);
+    }
+    expect(
+      bodies.some((content) => String(content.formatted_body).includes("<strong>Item0</strong>")),
+    ).toBe(true);
+  });
+
+  it("retains the accepted event and first-reply slot when a later chunk fails", async () => {
+    const { client, sendMessage } = createClient();
+    sendMessage.mockImplementation(async () => {
+      if (sendMessage.mock.calls.length === 2) {
+        throw new Error("second wire event failed");
+      }
+      return "$accepted";
+    });
+    const hasRepliedRef = { value: false };
+    const error = await deliverMatrixReplies({
+      cfg: defaultCfg,
+      replies: [{ text: "Visible paragraph. ".repeat(400) }],
+      roomId: "!room:example.org",
+      client,
+      runtime: runtimeEnv,
+      replyToMode: "first",
+      replyToId: "$incoming",
+      hasRepliedRef,
+    }).catch((caught: unknown) => caught);
+
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(hasRepliedRef.value).toBe(true);
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      deliveryResult: {
+        messageIds: ["$accepted"],
+        visibleReplySent: true,
+        content: sendMessage.mock.calls[0]?.[1].body,
+        receipt: { parts: [expect.objectContaining({ replyToId: "$incoming" })] },
+      },
+    });
+  });
+
+  it("preserves significant whitespace in an automatic text reply", async () => {
+    const { client, sendMessage } = createClient();
+    const text = "    indented code\n\nHard break  \nnext line";
+    await deliverMatrixReplies({
+      cfg: defaultCfg,
+      replies: [{ text }],
+      roomId: "!room:example.org",
+      client,
+      runtime: runtimeEnv,
+      replyToMode: "off",
+    });
+    expect(sendMessage.mock.calls[0]?.[1]).toMatchObject({
+      body: text,
+      formatted_body: "<pre><code>indented code\n</code></pre>\n<p>Hard break<br>\nnext line</p>",
+    });
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -4,18 +4,8 @@ import type { PluginRuntime, RuntimeEnv } from "../../../runtime-api.js";
 import type { MatrixClient } from "../sdk.js";
 
 const sendMessageMatrixMock = vi.hoisted(() => vi.fn());
-const chunkMatrixTextMock = vi.hoisted(() =>
-  vi.fn((text: string, _opts?: unknown) => ({
-    trimmedText: text.trim(),
-    convertedText: text,
-    singleEventLimit: 4000,
-    fitsInSingleEvent: true,
-    chunks: text ? [text] : [],
-  })),
-);
 
 vi.mock("../send.js", () => ({
-  chunkMatrixText: (text: string, opts?: unknown) => chunkMatrixTextMock(text, opts),
   sendMessageMatrix: (to: string, message: string, opts?: unknown) =>
     sendMessageMatrixMock(to, message, opts),
 }));
@@ -104,13 +94,6 @@ describe("deliverMatrixReplies", () => {
     nextMessageId = 0;
     sendMessageMatrixMock.mockReset().mockImplementation(resolveMockMatrixSend);
     setMatrixRuntime(runtimeStub);
-    chunkMatrixTextMock.mockReset().mockImplementation((text: string) => ({
-      trimmedText: text.trim(),
-      convertedText: text,
-      singleEventLimit: 4000,
-      fitsInSingleEvent: true,
-      chunks: text ? [text] : [],
-    }));
   });
 
   const offModeReplyCases: Array<{
@@ -170,7 +153,6 @@ describe("deliverMatrixReplies", () => {
         roomId: "!room:example.org",
         client,
         runtime: runtimeEnv,
-        textLimit: 4000,
         replyToMode: "off",
         replyToId: "$ambient",
         threadId,
@@ -189,67 +171,6 @@ describe("deliverMatrixReplies", () => {
     },
   );
 
-  it("keeps replyToId on first reply only when replyToMode=first", async () => {
-    chunkMatrixTextMock.mockImplementation((text: string) => ({
-      trimmedText: text.trim(),
-      convertedText: text,
-      singleEventLimit: 4000,
-      fitsInSingleEvent: true,
-      chunks: text.split("|"),
-    }));
-
-    await deliverMatrixReplies({
-      cfg,
-      replies: [
-        { text: "first-a|first-b", replyToId: "reply-1" },
-        { text: "second", replyToId: "reply-2" },
-      ],
-      roomId: "room:1",
-      client: {} as MatrixClient,
-      runtime: runtimeEnv,
-      textLimit: 4000,
-      replyToMode: "first",
-    });
-
-    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(3);
-    expect(sendOptions(0).replyToId).toBe("reply-1");
-    expect(sendOptions(0).threadId).toBeUndefined();
-    expect(sendOptions(1).replyToId).toBe("reply-1");
-    expect(sendOptions(1).threadId).toBeUndefined();
-    expect(sendOptions(2).replyToId).toBeUndefined();
-    expect(sendOptions(2).threadId).toBeUndefined();
-  });
-
-  it("shares the first reply across separately dispatched, chunked payloads", async () => {
-    chunkMatrixTextMock.mockImplementation((text: string) => ({
-      trimmedText: text.trim(),
-      convertedText: text,
-      singleEventLimit: 4000,
-      fitsInSingleEvent: true,
-      chunks: text.split("|"),
-    }));
-    const hasRepliedRef = { value: false };
-    const delivery = {
-      cfg,
-      roomId: "room:1",
-      client: {} as MatrixClient,
-      runtime: runtimeEnv,
-      textLimit: 4000,
-      replyToMode: "first" as const,
-      replyToId: "reply-1",
-      hasRepliedRef,
-    };
-
-    await deliverMatrixReplies({ ...delivery, replies: [{ text: "first-a|first-b" }] });
-    await deliverMatrixReplies({ ...delivery, replies: [{ text: "second" }] });
-
-    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(3);
-    expect(sendOptions(0).replyToId).toBe("reply-1");
-    expect(sendOptions(1).replyToId).toBe("reply-1");
-    expect(sendOptions(2).replyToId).toBeUndefined();
-    expect(hasRepliedRef.value).toBe(true);
-  });
-
   it.each(["first", "off"] as const)(
     "preserves explicit replies after shared reply state is consumed when replyToMode=%s",
     async (replyToMode) => {
@@ -259,7 +180,6 @@ describe("deliverMatrixReplies", () => {
         roomId: "room:1",
         client: {} as MatrixClient,
         runtime: runtimeEnv,
-        textLimit: 4000,
         replyToMode,
         replyToId: "ambient-reply",
         hasRepliedRef,
@@ -302,7 +222,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:1",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "first" as const,
       replyToId: "reply-1",
       hasRepliedRef,
@@ -320,74 +239,6 @@ describe("deliverMatrixReplies", () => {
     expect(hasRepliedRef.value).toBe(true);
   });
 
-  it("returns ordered provider receipts and visible content for a chunked reply", async () => {
-    chunkMatrixTextMock.mockImplementation((text: string) => ({
-      trimmedText: text.trim(),
-      convertedText: text,
-      singleEventLimit: 4000,
-      fitsInSingleEvent: true,
-      chunks: text.split("|"),
-    }));
-
-    const result = await deliverMatrixReplies({
-      cfg,
-      replies: [{ text: "first|second" }],
-      roomId: "room:1",
-      client: {} as MatrixClient,
-      runtime: runtimeEnv,
-      textLimit: 4000,
-      replyToMode: "off",
-    });
-
-    expect(result).toMatchObject({
-      messageIds: ["mx-1", "mx-2"],
-      visibleReplySent: true,
-      content: "first\nsecond",
-    });
-    expect(result.receipt?.primaryPlatformMessageId).toBe("mx-1");
-  });
-
-  it("preserves the accepted prefix when a later Matrix event fails", async () => {
-    chunkMatrixTextMock.mockImplementation((text: string) => ({
-      trimmedText: text.trim(),
-      convertedText: text,
-      singleEventLimit: 4000,
-      fitsInSingleEvent: true,
-      chunks: text.split("|"),
-    }));
-    let sendCount = 0;
-    sendMessageMatrixMock.mockImplementation(async (...args: unknown[]) => {
-      sendCount += 1;
-      if (sendCount === 2) {
-        throw new Error("second event failed");
-      }
-      return await resolveMockMatrixSend(
-        String(args[0]),
-        String(args[1]),
-        args[2] as Record<string, unknown> | undefined,
-      );
-    });
-
-    const error = await deliverMatrixReplies({
-      cfg,
-      replies: [{ text: "first|second", replyToId: "reply-1" }],
-      roomId: "room:1",
-      client: {} as MatrixClient,
-      runtime: runtimeEnv,
-      textLimit: 4000,
-      replyToMode: "first",
-    }).catch((caught: unknown) => caught);
-
-    expect(error).toMatchObject({
-      code: "CHANNEL_PARTIAL_DELIVERY",
-      deliveryResult: {
-        messageIds: ["mx-1"],
-        visibleReplySent: true,
-        content: "first",
-      },
-    });
-  });
-
   it("returns an explicit non-visible result when every reply is suppressed", async () => {
     const result = await deliverMatrixReplies({
       cfg,
@@ -395,7 +246,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:1",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "off",
     });
 
@@ -415,7 +265,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:3",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "first",
       replyToId: "reply-thread",
       threadId: "thread-77",
@@ -441,7 +290,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:2",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "all",
       mediaLocalRoots: ["/tmp/openclaw-matrix-test"],
     });
@@ -473,7 +321,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:2",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "off",
     });
 
@@ -488,7 +335,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:2",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "off",
     });
 
@@ -507,7 +353,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:2",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "off",
     });
 
@@ -517,34 +362,6 @@ describe("deliverMatrixReplies", () => {
       visibleReplySent: false,
       suppression: { reason: "no_visible_result" },
     });
-  });
-
-  it("keeps replyToId when threadId is set so Matrix can send fallback metadata", async () => {
-    chunkMatrixTextMock.mockImplementation((text: string) => ({
-      trimmedText: text.trim(),
-      convertedText: text,
-      singleEventLimit: 4000,
-      fitsInSingleEvent: true,
-      chunks: text.split("|"),
-    }));
-
-    await deliverMatrixReplies({
-      cfg,
-      replies: [{ text: "hello|thread" }],
-      roomId: "room:3",
-      client: {} as MatrixClient,
-      runtime: runtimeEnv,
-      textLimit: 4000,
-      replyToMode: "off",
-      threadId: "thread-77",
-      replyToId: "reply-thread",
-    });
-
-    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(2);
-    expect(sendOptions(0).replyToId).toBe("reply-thread");
-    expect(sendOptions(0).threadId).toBe("thread-77");
-    expect(sendOptions(1).replyToId).toBe("reply-thread");
-    expect(sendOptions(1).threadId).toBe("thread-77");
   });
 
   it("suppresses reasoning-only text before Matrix sends", async () => {
@@ -561,7 +378,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:5",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "off",
     });
 
@@ -580,7 +396,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:5",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "off",
     });
 
@@ -603,7 +418,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:5",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "off",
     });
 
@@ -615,27 +429,6 @@ describe("deliverMatrixReplies", () => {
     expect(sendCall(4)[1]).toBe("Visible answer");
     expect(sendCall(5)[1]).toBe("Visible alias answer");
     expect(sendCall(6)[1]).toBe("Visible final answer");
-  });
-
-  it("preserves significant whitespace in visible Markdown replies", async () => {
-    const text = "    indented Markdown code\n\nVisible line with a hard break  \nnext line";
-
-    await deliverMatrixReplies({
-      cfg,
-      replies: [{ text }],
-      roomId: "room:5",
-      client: {} as MatrixClient,
-      runtime: runtimeEnv,
-      textLimit: 4000,
-      replyToMode: "off",
-    });
-
-    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(1);
-    expect(sendCall(0)[1]).toBe(text);
-    expect(chunkMatrixTextMock).toHaveBeenCalledWith(
-      text,
-      expect.objectContaining({ preserveWhitespace: true }),
-    );
   });
 
   it("delivers Matrix media without a reasoning-only caption", async () => {
@@ -650,7 +443,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:5",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "off",
     });
 
@@ -659,7 +451,7 @@ describe("deliverMatrixReplies", () => {
     expect(sendOptions(0).mediaUrl).toBe("https://example.com/a.jpg");
   });
 
-  it("uses supplied cfg for chunking and send delivery without reloading runtime config", async () => {
+  it("uses supplied cfg for send delivery without reloading runtime config", async () => {
     const explicitCfg = {
       channels: {
         matrix: {
@@ -681,18 +473,11 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:4",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "all",
       accountId: "ops",
     });
 
     expect(loadConfigMock).not.toHaveBeenCalled();
-    expect(chunkMatrixTextMock).toHaveBeenCalledWith("hello", {
-      cfg: explicitCfg,
-      accountId: "ops",
-      tableMode: "code",
-      preserveWhitespace: true,
-    });
     expect(sendCall(0)[0]).toBe("room:4");
     expect(sendCall(0)[1]).toBe("hello");
     expect(sendOptions(0).cfg).toBe(explicitCfg);
@@ -709,7 +494,6 @@ describe("deliverMatrixReplies", () => {
       roomId: "room:6",
       client: {} as MatrixClient,
       runtime: runtimeEnv,
-      textLimit: 4000,
       replyToMode: "off",
     });
 

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -13,9 +13,9 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-chunking";
 import { getMatrixRuntime } from "../../runtime.js";
 import type { MatrixClient } from "../sdk.js";
-import { chunkMatrixText, sendMessageMatrix } from "../send.js";
+import { sendMessageMatrix } from "../send.js";
 import type { MatrixSendResult } from "../send/types.js";
-import type { MarkdownTableMode, OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
+import type { OpenClawConfig, ReplyPayload, RuntimeEnv } from "./runtime-api.js";
 
 export type MatrixReplyDeliveryResult = {
   messageIds?: string[];
@@ -114,23 +114,14 @@ export async function deliverMatrixReplies(params: {
   roomId: string;
   client: MatrixClient;
   runtime: RuntimeEnv;
-  textLimit: number;
   replyToMode: "off" | "first" | "all" | "batched";
   hasRepliedRef?: { value: boolean };
   threadId?: string;
   replyToId?: string;
   accountId?: string;
   mediaLocalRoots?: readonly string[];
-  tableMode?: MarkdownTableMode;
 }): Promise<MatrixReplyDeliveryResult> {
   const core = getMatrixRuntime();
-  const tableMode =
-    params.tableMode ??
-    core.channel.text.resolveMarkdownTableMode({
-      cfg: params.cfg,
-      channel: "matrix",
-      accountId: params.accountId,
-    });
   const logVerbose = (message: string) => {
     if (core.logging.shouldLogVerbose()) {
       params.runtime.log?.(message);
@@ -173,25 +164,15 @@ export async function deliverMatrixReplies(params: {
       };
 
       if (mediaUrls.length === 0) {
-        const { chunks } = chunkMatrixText(rawText, {
+        // The send owner prepares native formatting and reports each accepted chunk.
+        await sendMessageMatrix(params.roomId, rawText, {
+          client: params.client,
           cfg: params.cfg,
+          replyToId: replyToIdForReply,
+          threadId: params.threadId,
           accountId: params.accountId,
-          tableMode,
-          preserveWhitespace: true,
+          onDeliveryResult,
         });
-        for (const chunk of chunks) {
-          if (!chunk.trim()) {
-            continue;
-          }
-          await sendMessageMatrix(params.roomId, chunk, {
-            client: params.client,
-            cfg: params.cfg,
-            replyToId: replyToIdForReply,
-            threadId: params.threadId,
-            accountId: params.accountId,
-            onDeliveryResult,
-          });
-        }
         continue;
       }
 

--- a/extensions/matrix/src/matrix/monitor/runtime-api.ts
+++ b/extensions/matrix/src/matrix/monitor/runtime-api.ts
@@ -5,7 +5,7 @@
 export type { NormalizedLocation } from "openclaw/plugin-sdk/channel-inbound";
 export type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";
 export type { BlockReplyContext, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-export type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+export type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 export type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 export {
   addAllowlistUserEntriesFromConfigEntry,


### PR DESCRIPTION
Closes #130819

<details>
<summary>Additional instructions</summary>

This is a same-repository branch; repository maintainers retain normal branch access.

</details>

## What Problem This Solves

Fixes an issue where users receiving automatic Matrix replies would see tables rendered as code blocks when using the plugin's existing default or explicit native-table mode. Direct sends of the same Markdown already produced native tables.

## Why This Change Was Made

Automatic replies were resolving table mode without Matrix's native-table capability, then formatting and chunking text before sending it through a sender that performs both operations again. The monitor now passes visible text once to the canonical Matrix sender, matching direct sends and media captions. The duplicate preprocessing and unused private table-mode/chunk-limit plumbing are removed; accepted-event callbacks still own receipts and first-reply state.

Best-fix judgment: keep formatting and chunking at the sender that already owns native capabilities, account settings, transport limits, and accepted events. Adding another native-capability flag to the monitor would retain the duplicate conversion and chunking paths. No public configuration, default, protocol, SDK, authentication, security, or storage contract changes.

Provenance: the mismatch became visible when #113199 added native tables and the `block` default on 2026-07-24, commit `21103ff8e91c4d8335a4369a0fb0a2b351ee62ac`, authored and merged by @steipete. The old monitor preprocessing predates that change. This does not claim a prior stable release's automatic native tables worked.

## User Impact

Automatic replies now emit native table HTML under the existing Matrix default, consistently with direct sends and captions. Existing explicit code, bullets, and off modes remain supported, as do account chunk limits, reply/thread relations, and partial-delivery receipts. The Markdown-formatting documentation now describes Matrix's existing native-table default and shared formatter accurately.

Production LOC: +9/-53 (net -44). Tests/support: +319/-250 (net +69, including the new 318-line test). Docs: +5/-3 (net +2). Six chunk-mock tests are replaced by real sender/formatter boundary coverage.

## Evidence

### Before and after

The pre-fix real-send regression matrix failed three native-table cases and passed seven controls. An isolated real Gateway with a mock model provider and Crabline Matrix homeserver then reproduced the normal inbound `/sync` → handler → automatic reply → accepted message PUT flow: the inbound message was observed, but the accepted output was `<pre><code>` rather than `<table>`.

After the repair and successful eight-phase QA runtime build, the identical Gateway driver produced native `<table>` HTML with the requested Name/Status headers and Alpha/Ready cells. Both runs used driver SHA-256 `214e36443b6c3650b3109d110d844cc77b6a46d72a818d23048a5abd88083314`.

An independent source-blind validator authored fresh inputs for default, block, code, bullets, and off modes. All five runs observed real inbound handling and one accepted native Matrix message in a fresh synthetic room. Table headers/cells, surrounding prose/emphasis/links, and table-shaped fenced examples behaved as specified. All disposable Gateway/provider/homeserver processes were cleaned up.

Compact verdict summary from the recorded Gateway and source-blind observations:

```json
{
  "realGateway": true,
  "mockTransport": true,
  "mockProvider": true,
  "liveMatrixAccount": false,
  "baseline": { "inboundObserved": true, "nativeTable": false },
  "candidate": { "inboundObserved": true, "nativeTable": true },
  "sourceBlind": { "modesPassed": 5, "acceptedMessages": 5, "freshRooms": 5 }
}
```

### Verification chronology

- Before the final test-only refinements: the complete Matrix suite passed 130 files / 2,075 tests; the full changed-file gate passed extension and test typechecks, lint, dead-export checks, and ownership/runtime guards.
- After adding explicit second-payload count/body assertions and correcting the account newline fixture to `streaming.chunkMode`: all 13 real-send cases passed, as did extension-test typecheck, scoped lint, formatting, and `git diff --check`.
- An independent reviewer then ran five final files: 249 tests passed, including reply, file-boundary, monitor, handler, and the 13 new formatting cases. All 16 file hashes were unchanged across that execution.
- Final complete-patch Codex review at P0–P2 found no actionable findings. Production/runtime bytes did not change after the native Gateway proof; the final full-suite claim is deliberately limited to the chronology above. Exact-head hosted CI remains the landing gate.

Real-send controls cover all table modes, long replies with fenced/indented code, native file captions, account limits and oversized-table fallback, same/separate first-reply dispatches, native thread fallback, second-event failure retaining accepted receipts, and significant whitespace.

### Limits and follow-up

This is native protocol payload proof using isolated mock transport/provider services, not a Matrix-client UI, screenshot, production-provider, or real-account claim. Code/bullets modes retain the existing converter's heading-to-paragraph normalization; no stronger heading-level preservation is claimed.

The initial default full build completed runtime/SDK phases but failed an unrelated UI step because the borrowed dependency closure resolved pako 2 instead of the UI-pinned pako 3. No dependency override or UI workaround was made; the scoped QA runtime build passed. Two initial Gateway fixture attempts also used the wrong mock-provider base URL; those setup failures are excluded from the before/after result.

Named adjacent documentation follow-up: the existing spoiler paragraph omits Matrix native spoilers. This PR intentionally limits its docs correction to tables and does not change spoiler behavior, edited/redacted context caches, or persistence.
