### PR TITLE
fix(android): keep question answers when reading earlier messages

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt
@@ -28,26 +28,43 @@ internal object AndroidScreenshotFixture {
   const val cronJobId = "android-release-digest"
   const val cronJobName = "Android release digest"
 
-  private val pendingQuestion =
-    System.currentTimeMillis().let { nowMs ->
-      QuestionRecord(
-        id = "android-screenshot-question",
-        questions =
-          listOf(
-            Question(
-              questionId = "release_note",
-              header = "Release note",
-              question = "What should the release note mention?",
-              options = emptyList(),
+  fun createRequester(): (String, String?) -> String {
+    // A runtime gets a fresh lifetime; list refreshes and scene re-entry keep its exact record.
+    val pendingQuestion =
+      System.currentTimeMillis().let { nowMs ->
+        QuestionRecord(
+          id = "android-screenshot-question",
+          questions =
+            listOf(
+              Question(
+                questionId = "release_note",
+                header = "Release note",
+                question = "What should the release note mention?",
+                options = emptyList(),
+              ),
             ),
-          ),
-        agentId = "main",
-        sessionKey = mainSessionKey,
-        createdAtMs = nowMs,
-        expiresAtMs = nowMs + 600_000,
-        status = "pending",
-      )
+          agentId = "main",
+          sessionKey = mainSessionKey,
+          createdAtMs = nowMs,
+          expiresAtMs = nowMs + 600_000,
+          status = "pending",
+        )
+      }
+    return { method, paramsJson ->
+      when (method) {
+        "health" -> buildJsonObject { put("ok", JsonPrimitive(true)) }.toString()
+        "chat.history" -> chatHistory()
+        "sessions.list" -> sessionList(paramsJson)
+        "chat.metadata" -> chatMetadata()
+        "question.list" -> Json.encodeToString(QuestionListResult(listOf(pendingQuestion)))
+        "cron.list" -> cronList()
+        "cron.get" -> cronJob().toString()
+        "cron.runs" -> cronRuns()
+        "openclaw.chat" -> systemAgentChat(paramsJson)
+        else -> error("Screenshot fixture does not implement gateway method $method with params $paramsJson")
+      }
     }
+  }
 
   val agents =
     listOf(
@@ -124,23 +141,6 @@ internal object AndroidScreenshotFixture {
           ),
         ),
     )
-
-  fun request(
-    method: String,
-    paramsJson: String?,
-  ): String =
-    when (method) {
-      "health" -> buildJsonObject { put("ok", JsonPrimitive(true)) }.toString()
-      "chat.history" -> chatHistory()
-      "sessions.list" -> sessionList(paramsJson)
-      "chat.metadata" -> chatMetadata()
-      "question.list" -> Json.encodeToString(QuestionListResult(listOf(pendingQuestion)))
-      "cron.list" -> cronList()
-      "cron.get" -> cronJob().toString()
-      "cron.runs" -> cronRuns()
-      "openclaw.chat" -> systemAgentChat(paramsJson)
-      else -> error("Screenshot fixture does not implement gateway method $method with params $paramsJson")
-    }
 
   private fun systemAgentChat(paramsJson: String?): String {
     val message =

--- a/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt
@@ -1,5 +1,9 @@
 package ai.openclaw.app
 
+import ai.openclaw.app.gateway.Question
+import ai.openclaw.app.gateway.QuestionListResult
+import ai.openclaw.app.gateway.QuestionRecord
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
@@ -23,6 +27,27 @@ internal object AndroidScreenshotFixture {
   const val primarySessionTitle = "Android release planning"
   const val cronJobId = "android-release-digest"
   const val cronJobName = "Android release digest"
+
+  private val pendingQuestion =
+    System.currentTimeMillis().let { nowMs ->
+      QuestionRecord(
+        id = "android-screenshot-question",
+        questions =
+          listOf(
+            Question(
+              questionId = "release_note",
+              header = "Release note",
+              question = "What should the release note mention?",
+              options = emptyList(),
+            ),
+          ),
+        agentId = "main",
+        sessionKey = mainSessionKey,
+        createdAtMs = nowMs,
+        expiresAtMs = nowMs + 600_000,
+        status = "pending",
+      )
+    }
 
   val agents =
     listOf(
@@ -109,6 +134,7 @@ internal object AndroidScreenshotFixture {
       "chat.history" -> chatHistory()
       "sessions.list" -> sessionList(paramsJson)
       "chat.metadata" -> chatMetadata()
+      "question.list" -> Json.encodeToString(QuestionListResult(listOf(pendingQuestion)))
       "cron.list" -> cronList()
       "cron.get" -> cronJob().toString()
       "cron.runs" -> cronRuns()
@@ -260,6 +286,15 @@ internal object AndroidScreenshotFixture {
       put(
         "messages",
         buildJsonArray {
+          repeat(24) { index ->
+            add(
+              chatMessage(
+                role = "assistant",
+                content = "Earlier discussion ${index + 1}: keep the release note concise and describe the user-visible change.",
+                timestamp = 1_783_550_000_000 + index * 10_000L,
+              ),
+            )
+          }
           add(chatMessage("user", "What is blocking the Android release?", 1_783_555_020_000))
           add(
             chatMessage(

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -8,6 +8,7 @@ import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatProgressCard
+import ai.openclaw.app.chat.ChatQuestionDraft
 import ai.openclaw.app.chat.ChatQuestionPrompt
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.ChatSwarmGroup
@@ -1858,15 +1859,20 @@ class MainViewModel private constructor(
     ensureRuntime().deleteChatOutboxCommand(id)
   }
 
+  fun updateChatQuestionDraft(
+    prompt: ChatQuestionPrompt,
+    update: (ChatQuestionDraft) -> ChatQuestionDraft,
+  ) = ensureRuntime().updateChatQuestionDraft(prompt, update)
+
   fun resolveChatQuestion(
-    id: String,
+    prompt: ChatQuestionPrompt,
     answers: Map<String, List<String>>,
   ) {
-    ensureRuntime().resolveChatQuestion(id, answers)
+    ensureRuntime().resolveChatQuestion(prompt, answers)
   }
 
-  fun skipChatQuestion(id: String) {
-    ensureRuntime().skipChatQuestion(id)
+  fun skipChatQuestion(prompt: ChatQuestionPrompt) {
+    ensureRuntime().skipChatQuestion(prompt)
   }
 
   suspend fun listBackgroundTasks(agentId: String): List<BackgroundTask> = ensureRuntime().listBackgroundTasks(agentId)

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -12,6 +12,7 @@ import ai.openclaw.app.chat.ChatMessage
 import ai.openclaw.app.chat.ChatOutboxItem
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatProgressCard
+import ai.openclaw.app.chat.ChatQuestionDraft
 import ai.openclaw.app.chat.ChatQuestionPrompt
 import ai.openclaw.app.chat.ChatSessionDeletion
 import ai.openclaw.app.chat.ChatSessionEntry
@@ -2900,12 +2901,17 @@ class NodeRuntime private constructor(
 
   fun deleteChatOutboxCommand(id: String) = chat.deleteOutboxCommand(id)
 
-  fun resolveChatQuestion(
-    id: String,
-    answers: Map<String, List<String>>,
-  ) = chat.resolveQuestion(id, answers)
+  fun updateChatQuestionDraft(
+    prompt: ChatQuestionPrompt,
+    update: (ChatQuestionDraft) -> ChatQuestionDraft,
+  ) = chat.updateQuestionDraft(prompt, update)
 
-  fun skipChatQuestion(id: String) = chat.skipQuestion(id)
+  fun resolveChatQuestion(
+    prompt: ChatQuestionPrompt,
+    answers: Map<String, List<String>>,
+  ) = chat.resolveQuestion(prompt, answers)
+
+  fun skipChatQuestion(prompt: ChatQuestionPrompt) = chat.skipQuestion(prompt)
 
   private fun applyScreenshotFixture() {
     check(BuildConfig.DEBUG) { "Android screenshot fixtures require a debug build" }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -765,6 +765,7 @@ class NodeRuntime private constructor(
   private val chatCommandOutbox = chatStores.commandOutbox
   private val clientDatabases = chatStores.clientDatabases
   private val externalTranscriptCache = chatStores.externalTranscriptCache
+  private val screenshotRequester by lazy { AndroidScreenshotFixture.createRequester() }
   private val gatewayAuthLifecycleLock = Any()
   private var gatewayAuthResetInProgress = false
   private var gatewayConnectOperationsInFlight = 0
@@ -1512,7 +1513,7 @@ class NodeRuntime private constructor(
           NodeRuntimeMode.Live -> operatorSession.captureRequestLease(gatewayId)
           NodeRuntimeMode.ScreenshotFixture ->
             GatewaySession.RequestLease(endpointStableId = AndroidScreenshotFixture.gatewayId) { method, paramsJson, _ ->
-              AndroidScreenshotFixture.request(method, paramsJson)
+              screenshotRequester(method, paramsJson)
             }
         }
       },
@@ -1950,7 +1951,7 @@ class NodeRuntime private constructor(
         ChatController(
           scope = scope,
           json = json,
-          requestGateway = AndroidScreenshotFixture::request,
+          requestGateway = screenshotRequester,
           gatewayAdvertisesMethod = { _ -> true },
           gatewayAdvertisesCapability = { _ -> true },
         )
@@ -2967,7 +2968,7 @@ class NodeRuntime private constructor(
     // Screenshot mode parses gateway-shaped fixtures so UI navigation covers the live data contract.
     val list =
       json
-        .parseToJsonElement(AndroidScreenshotFixture.request("cron.list", null))
+        .parseToJsonElement(screenshotRequester("cron.list", null))
         .asObjectOrNull()
     return parseCronJobs(list?.get("jobs") as? JsonArray)
   }
@@ -2978,7 +2979,7 @@ class NodeRuntime private constructor(
   ) {
     val detail =
       json
-        .parseToJsonElement(AndroidScreenshotFixture.request("cron.get", cronJobGetParams(detailRequest.id)))
+        .parseToJsonElement(screenshotRequester("cron.get", cronJobGetParams(detailRequest.id)))
         .asObjectOrNull()
         ?.let(::parseGatewayCronJobDetail)
         ?.takeIf { it.id == detailRequest.id }
@@ -2993,7 +2994,7 @@ class NodeRuntime private constructor(
   private fun publishScreenshotCronHistory(request: CronJobDetailRequest) {
     val history =
       json
-        .parseToJsonElement(AndroidScreenshotFixture.request("cron.runs", cronJobGetParams(request.id)))
+        .parseToJsonElement(screenshotRequester("cron.runs", cronJobGetParams(request.id)))
         .asObjectOrNull()
     val runs = parseGatewayCronRunHistory(history?.get("entries") as? JsonArray)
     cronRunHistoryRequestGuard.publishIfCurrent(request) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatController.kt
@@ -3306,24 +3306,42 @@ class ChatController internal constructor(
     }
   }
 
-  fun resolveQuestion(
-    id: String,
-    answers: Map<String, List<String>>,
-  ) = resolveQuestion(id = id, answers = answers, cancel = false)
+  fun updateQuestionDraft(
+    expected: ChatQuestionPrompt,
+    update: (ChatQuestionDraft) -> ChatQuestionDraft,
+  ) {
+    synchronized(questionStateLock) {
+      // Draft edits use the current value, but only the same live question may receive them.
+      // They do not invalidate an in-flight question.list reconciliation.
+      _questions.value =
+        _questions.value.map { prompt ->
+          if (prompt.promptOwner === expected.promptOwner && prompt.record == expected.record && prompt.status() == ChatQuestionStatus.Pending) {
+            prompt.copy(draft = update(prompt.draft))
+          } else {
+            prompt
+          }
+        }
+    }
+  }
 
-  fun skipQuestion(id: String) = resolveQuestion(id = id, answers = null, cancel = true)
+  fun resolveQuestion(
+    expected: ChatQuestionPrompt,
+    answers: Map<String, List<String>>,
+  ) = resolveQuestion(expected = expected, answers = answers, cancel = false)
+
+  fun skipQuestion(expected: ChatQuestionPrompt) = resolveQuestion(expected = expected, answers = null, cancel = true)
 
   private fun resolveQuestion(
-    id: String,
+    expected: ChatQuestionPrompt,
     answers: Map<String, List<String>>?,
     cancel: Boolean,
   ) {
     val gatewayId = currentCacheScope()?.gatewayId
-    var claimed = false
+    var claimedOwner: Any? = null
     updateQuestions { prompts ->
       prompts.map { prompt ->
-        if (prompt.record.id == id && prompt.status() == ChatQuestionStatus.Pending) {
-          claimed = true
+        if (prompt.promptOwner === expected.promptOwner && prompt.status() == ChatQuestionStatus.Pending) {
+          claimedOwner = prompt.promptOwner
           prompt.copy(submitting = true, skipping = cancel, errorText = null)
         } else {
           prompt
@@ -3332,12 +3350,13 @@ class ChatController internal constructor(
     }
     // updateQuestions owns the question-state lock, so competing answer/skip callbacks
     // observe the first claim as Submitting and cannot launch a second mutation.
-    if (!claimed) return
+    // Terminal fanout preserves this owner; replacement or gateway retirement does not.
+    val owner = claimedOwner ?: return
     scope.launch {
       try {
         val params =
           buildJsonObject {
-            put("id", JsonPrimitive(id))
+            put("id", JsonPrimitive(expected.record.id))
             if (cancel) {
               put("cancel", JsonPrimitive(true))
             } else {
@@ -3356,15 +3375,19 @@ class ChatController internal constructor(
               )
             }
           }
-        requestGatewayBound(gatewayId, "question.resolve", params.toString())
+        val result = json.parseToJsonElement(requestGatewayBound(gatewayId, "question.resolve", params.toString())).jsonObject
+        val status = if (cancel) "cancelled" else "answered"
+        check(result["status"].asStringOrNull() == status) { "Invalid question.resolve response" }
+        // The Gateway owns normalized answers, including secret-store markers; never retain submitted values as the outcome.
+        val resolvedAnswers = if (cancel) null else json.decodeFromJsonElement<QuestionAnswers>(result.getValue("answers"))
         updateQuestions { prompts ->
           prompts.map { prompt ->
-            if (prompt.record.id == id) {
+            if (prompt.promptOwner === owner) {
               prompt.copy(
                 record =
                   prompt.record.copy(
-                    status = if (cancel) "cancelled" else "answered",
-                    answers = answers?.let(::QuestionAnswers),
+                    status = status,
+                    answers = resolvedAnswers,
                   ),
                 submitting = false,
                 skipping = false,
@@ -3380,7 +3403,7 @@ class ChatController internal constructor(
       } catch (error: Throwable) {
         updateQuestions { prompts ->
           prompts.map { prompt ->
-            if (prompt.record.id == id) {
+            if (prompt.promptOwner === owner) {
               prompt.copy(submitting = false, skipping = false, errorText = error.message ?: "Question failed")
             } else {
               prompt
@@ -3452,11 +3475,7 @@ class ChatController internal constructor(
       if (!questionRefreshIsCurrent(refreshGeneration, stateRevision, gatewayScope)) return false
       return synchronized(questionStateLock) {
         if (!questionRefreshIsCurrentLocked(refreshGeneration, stateRevision)) return@synchronized false
-        if (_questions.value.isNotEmpty()) {
-          _questions.value = emptyList()
-          questionStateRevision += 1
-        }
-        syncQuestionEvictionsLocked()
+        publishQuestionsLocked(emptyList())
         true
       }
     }
@@ -3539,11 +3558,7 @@ class ChatController internal constructor(
             terminalObservedAtMs = nowMs.takeIf { record.status != "pending" || nowMs >= record.expiresAtMs },
           )
         } + retainedPrompts
-      if (next != current) {
-        _questions.value = next
-        questionStateRevision += 1
-      }
-      syncQuestionEvictionsLocked()
+      publishQuestionsLocked(next)
       unresolvedIds.isEmpty()
     }
   }
@@ -3597,6 +3612,11 @@ class ChatController internal constructor(
     // Gateway terminal state is monotonic. A delayed requested/list replay must not
     // make an already resolved question actionable again.
     if ((prompt.record.status != "pending" || prompt.recoveryUnavailable) && record.status == "pending") return prompt
+    // Outcome fields can change within one request; a replaced definition or lifetime owns new input.
+    val sameQuestion = record.copy(status = prompt.record.status, answers = prompt.record.answers, resolvedBy = prompt.record.resolvedBy) == prompt.record
+    if (!sameQuestion) {
+      return ChatQuestionPrompt(record = record, terminalObservedAtMs = nowMs.takeIf { record.status != "pending" || nowMs >= record.expiresAtMs })
+    }
     return prompt.copy(
       record = record.copy(answers = record.answers ?: prompt.record.answers),
       submitting = prompt.submitting && record.status == "pending",
@@ -3638,13 +3658,26 @@ class ChatController internal constructor(
 
   private fun updateQuestions(transform: (List<ChatQuestionPrompt>) -> List<ChatQuestionPrompt>) {
     synchronized(questionStateLock) {
-      val current = _questions.value
-      val next = transform(current)
-      if (next == current) return
+      publishQuestionsLocked(transform(_questions.value))
+    }
+  }
+
+  private fun publishQuestionsLocked(prompts: List<ChatQuestionPrompt>): Boolean {
+    // Terminal cards remain in history, but must not retain unsent (possibly secret) input.
+    val next =
+      prompts.map { prompt ->
+        when (prompt.status()) {
+          ChatQuestionStatus.Pending, ChatQuestionStatus.Submitting -> prompt
+          else -> prompt.copy(draft = ChatQuestionDraft())
+        }
+      }
+    val changed = next != _questions.value
+    if (changed) {
       _questions.value = next
       questionStateRevision += 1
-      syncQuestionEvictionsLocked()
     }
+    syncQuestionEvictionsLocked()
+    return changed
   }
 
   private fun syncQuestionEvictionsLocked(nowMs: Long = System.currentTimeMillis()) {
@@ -3679,12 +3712,7 @@ class ChatController internal constructor(
                   it
                 }
               }
-            if (next != current) {
-              _questions.value = next
-              questionStateRevision += 1
-              shouldRefresh = true
-            }
-            syncQuestionEvictionsLocked()
+            shouldRefresh = publishQuestionsLocked(next)
           }
           // The local deadline is only a presentation fallback. Reconcile outside
           // the state lock in case another surface supplied the terminal outcome.
@@ -3698,10 +3726,7 @@ class ChatController internal constructor(
   private fun clearQuestions() {
     synchronized(questionStateLock) {
       questionRefreshGeneration += 1
-      if (_questions.value.isEmpty()) return
-      _questions.value = emptyList()
-      questionStateRevision += 1
-      syncQuestionEvictionsLocked()
+      publishQuestionsLocked(emptyList())
     }
   }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatQuestion.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/chat/ChatQuestion.kt
@@ -21,6 +21,9 @@ data class ChatQuestionPrompt(
   val errorText: String? = null,
   val terminalObservedAtMs: Long? = null,
   val recoveryUnavailable: Boolean = false,
+  // Process-only input can contain secrets; it must not enter saved or persisted state.
+  val draft: ChatQuestionDraft = ChatQuestionDraft(),
+  internal val promptOwner: Any = Any(),
 ) {
   fun status(nowMs: Long = System.currentTimeMillis()): ChatQuestionStatus =
     if (recoveryUnavailable) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatQuestionCard.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -42,11 +41,12 @@ import kotlinx.coroutines.delay
 @Composable
 internal fun ChatQuestionCard(
   prompt: ChatQuestionPrompt,
-  onSubmit: (String, Map<String, List<String>>) -> Unit,
-  onSkip: (String) -> Unit,
+  onDraftChanged: (ChatQuestionPrompt, (ChatQuestionDraft) -> ChatQuestionDraft) -> Unit,
+  onSubmit: (ChatQuestionPrompt, Map<String, List<String>>) -> Unit,
+  onSkip: (ChatQuestionPrompt) -> Unit,
   modifier: Modifier = Modifier,
 ) {
-  var draft by remember(prompt.record.id) { mutableStateOf(ChatQuestionDraft()) }
+  val draft = prompt.draft
   var nowMs by remember(prompt.record.id) { mutableLongStateOf(System.currentTimeMillis()) }
   val status = prompt.status(nowMs)
   val pending = status == ChatQuestionStatus.Pending
@@ -76,7 +76,7 @@ internal fun ChatQuestionCard(
           question = question,
           draft = draft,
           enabled = pending,
-          onDraftChanged = { draft = it },
+          onDraftChanged = { update -> onDraftChanged(prompt, update) },
         )
       }
       QuestionFooter(
@@ -131,7 +131,7 @@ private fun QuestionSection(
   question: Question,
   draft: ChatQuestionDraft,
   enabled: Boolean,
-  onDraftChanged: (ChatQuestionDraft) -> Unit,
+  onDraftChanged: ((ChatQuestionDraft) -> ChatQuestionDraft) -> Unit,
 ) {
   Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
     Text(
@@ -144,7 +144,7 @@ private fun QuestionSection(
     question.options.forEach { option ->
       val selected = option.label in draft.selectedOptions[question.questionId].orEmpty()
       Surface(
-        onClick = { onDraftChanged(draft.toggle(question, option.label)) },
+        onClick = { onDraftChanged { it.toggle(question, option.label) } },
         enabled = enabled,
         shape = RoundedCornerShape(ClawTheme.radii.row),
         color = if (selected) ClawTheme.colors.surfacePressed else ClawTheme.colors.surface,
@@ -175,7 +175,7 @@ private fun QuestionSection(
       val secret = question.isSecret == true
       OutlinedTextField(
         value = draft.otherText[question.questionId].orEmpty(),
-        onValueChange = { onDraftChanged(draft.setOther(question, it)) },
+        onValueChange = { value -> onDraftChanged { it.setOther(question, value) } },
         modifier = Modifier.fillMaxWidth(),
         enabled = enabled,
         label = { Text(if (secret) nativeString("Secret value") else nativeString("Other answer")) },
@@ -195,8 +195,8 @@ private fun QuestionFooter(
   draft: ChatQuestionDraft,
   status: ChatQuestionStatus,
   nowMs: Long,
-  onSubmit: (String, Map<String, List<String>>) -> Unit,
-  onSkip: (String) -> Unit,
+  onSubmit: (ChatQuestionPrompt, Map<String, List<String>>) -> Unit,
+  onSkip: (ChatQuestionPrompt) -> Unit,
 ) {
   val answers = draft.answers(prompt.record.questions)
   if (status == ChatQuestionStatus.Pending || status == ChatQuestionStatus.Submitting) {
@@ -208,13 +208,13 @@ private fun QuestionFooter(
       )
       Spacer(Modifier.weight(1f))
       TextButton(
-        onClick = { onSkip(prompt.record.id) },
+        onClick = { onSkip(prompt) },
         enabled = status == ChatQuestionStatus.Pending,
       ) {
         Text(nativeString("Skip"))
       }
       Button(
-        onClick = { answers?.let { onSubmit(prompt.record.id, it) } },
+        onClick = { answers?.let { onSubmit(prompt, it) } },
         enabled = answers != null && status == ChatQuestionStatus.Pending,
       ) {
         Text(
@@ -240,9 +240,7 @@ internal fun terminalQuestionAnswer(
   if (status == ChatQuestionStatus.Cancelled) return nativeString("Skipped")
   if (status == ChatQuestionStatus.Expired) return nativeString("Expired")
   if (status == ChatQuestionStatus.Unavailable) return nativeString("Unavailable")
-  // Secret questions never echo answer text into the persisted timeline; the
-  // record only carries a synthetic marker, but masking here keeps the summary
-  // honest for every secret producer, not just store-bound ones.
+  // Secret terminal summaries never echo submitted answer text.
   if (question.isSecret != true) {
     prompt.record.answers?.answers?.get(question.questionId)?.takeIf { it.isNotEmpty() }?.let {
       return it.joinToString(", ")

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -19,6 +19,7 @@ import ai.openclaw.app.chat.ChatOutboxStatus
 import ai.openclaw.app.chat.ChatPendingToolCall
 import ai.openclaw.app.chat.ChatPlanStepStatus
 import ai.openclaw.app.chat.ChatProgressCard
+import ai.openclaw.app.chat.ChatQuestionDraft
 import ai.openclaw.app.chat.ChatQuestionPrompt
 import ai.openclaw.app.chat.ChatSessionEntry
 import ai.openclaw.app.chat.ChatSubagentActivity
@@ -745,6 +746,7 @@ fun ChatScreen(
       onRetryOutbox = viewModel::retryChatOutboxCommand,
       onDeleteOutbox = viewModel::deleteChatOutboxCommand,
       onResolveQuestion = viewModel::resolveChatQuestion,
+      onQuestionDraftChanged = viewModel::updateChatQuestionDraft,
       onSkipQuestion = viewModel::skipChatQuestion,
       onStarterPrompt = { prompt -> inputDrafts[composerOwner] = prompt },
       onReplyMessage = { value -> viewModel.setChatReplyDraft(value, composerOwner) },
@@ -1322,8 +1324,9 @@ private fun ChatMessageList(
   recoveryOutboxItems: List<ChatOutboxItem>,
   onRetryOutbox: (String) -> Unit,
   onDeleteOutbox: (String) -> Unit,
-  onResolveQuestion: (String, Map<String, List<String>>) -> Unit,
-  onSkipQuestion: (String) -> Unit,
+  onResolveQuestion: (ChatQuestionPrompt, Map<String, List<String>>) -> Unit,
+  onQuestionDraftChanged: (ChatQuestionPrompt, (ChatQuestionDraft) -> ChatQuestionDraft) -> Unit,
+  onSkipQuestion: (ChatQuestionPrompt) -> Unit,
   onStarterPrompt: (String) -> Unit,
   onReplyMessage: (String) -> Unit,
   sessionActionsEnabled: Boolean,
@@ -1448,7 +1451,7 @@ private fun ChatMessageList(
               moreWorkingCount = item.moreWorkingCount,
             )
           is ChatTimelineItem.QuestionPrompt ->
-            ChatQuestionCard(prompt = item.prompt, onSubmit = onResolveQuestion, onSkip = onSkipQuestion)
+            ChatQuestionCard(prompt = item.prompt, onDraftChanged = onQuestionDraftChanged, onSubmit = onResolveQuestion, onSkip = onSkipQuestion)
           is ChatTimelineItem.TurnRecapSummary -> ChatTurnRecapRow(item.recap)
           is ChatTimelineItem.SystemNotice -> ChatSystemNoticeRow(item)
           is ChatTimelineItem.SystemDivider -> ChatSystemDividerRow(item)

--- a/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotFixtureRuntimeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotFixtureRuntimeTest.kt
@@ -1,0 +1,62 @@
+package ai.openclaw.app
+
+import ai.openclaw.app.chat.ChatQuestionPrompt
+import ai.openclaw.app.chat.ChatQuestionStatus
+import ai.openclaw.app.gateway.QuestionListResult
+import ai.openclaw.app.gateway.QuestionRecord
+import android.os.SystemClock
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.LooperMode
+import org.robolectric.shadows.ShadowSystemClock
+import java.time.Duration
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], instrumentedPackages = ["ai.openclaw.app.AndroidScreenshotFixture"])
+@LooperMode(LooperMode.Mode.PAUSED)
+class AndroidScreenshotFixtureRuntimeTest {
+  @After
+  fun restoreScene() {
+    AndroidScreenshotFixture.configure(AndroidScreenshotScene.Home)
+  }
+
+  @Test
+  fun newRuntimeGetsFreshQuestionWhileExistingRequesterKeepsItsRecord() {
+    val firstCreatedAtMs = SystemClock.uptimeMillis()
+    val firstRequester = newRuntimeRequester()
+    val first = question(firstRequester)
+    // Instrument only the fixture: its System clock must share Robolectric's virtual time.
+    assertEquals("Fixture clock must be controlled before testing expiry", firstCreatedAtMs, first.createdAtMs)
+    assertEquals(firstCreatedAtMs + 600_000, first.expiresAtMs)
+    assertEquals(ChatQuestionStatus.Pending, ChatQuestionPrompt(first).status(firstCreatedAtMs))
+
+    ShadowSystemClock.advanceBy(Duration.ofSeconds(1))
+    assertEquals("Repeated lists must preserve the complete record", first, question(firstRequester))
+    AndroidScreenshotFixture.configure(AndroidScreenshotScene.Home)
+    AndroidScreenshotFixture.configure(AndroidScreenshotScene.Chat)
+    assertEquals("Scene re-entry must not restart a runtime's question", first, question(firstRequester))
+
+    ShadowSystemClock.advanceBy(Duration.ofMinutes(10))
+    val secondCreatedAtMs = SystemClock.uptimeMillis()
+    assertEquals(ChatQuestionStatus.Expired, ChatQuestionPrompt(first).status(secondCreatedAtMs))
+    val secondRequester = newRuntimeRequester()
+    val second = question(secondRequester)
+    assertEquals("A new runtime must not inherit an expired singleton question", secondCreatedAtMs, second.createdAtMs)
+    assertEquals(secondCreatedAtMs + 600_000, second.expiresAtMs)
+    assertEquals(ChatQuestionStatus.Pending, ChatQuestionPrompt(second).status(secondCreatedAtMs))
+
+    ShadowSystemClock.advanceBy(Duration.ofSeconds(1))
+    AndroidScreenshotFixture.configure(AndroidScreenshotScene.Home)
+    assertEquals("A new runtime must not replace an older requester's record", first, question(firstRequester))
+    assertEquals("The new runtime must keep its own stable record", second, question(secondRequester))
+  }
+
+  private fun newRuntimeRequester(): (String, String?) -> String = AndroidScreenshotFixture.createRequester()
+
+  private fun question(request: (String, String?) -> String): QuestionRecord = Json.decodeFromString<QuestionListResult>(request("question.list", "{}")).questions.single()
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotFixtureTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotFixtureTest.kt
@@ -98,12 +98,12 @@ class AndroidScreenshotFixtureTest {
   }
 
   @Test
-  fun providesDeterministicChatHistory() {
+  fun providesDeterministicRecentChatHistory() {
     val history =
       json
         .parseToJsonElement(AndroidScreenshotFixture.request("chat.history", null))
         .jsonObject
-    val messages = history["messages"]?.jsonArray.orEmpty()
+    val messages = history["messages"]?.jsonArray.orEmpty().takeLast(10)
 
     assertEquals(
       listOf(

--- a/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotFixtureTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/AndroidScreenshotFixtureTest.kt
@@ -10,32 +10,33 @@ import org.junit.Test
 
 class AndroidScreenshotFixtureTest {
   private val json = Json { ignoreUnknownKeys = true }
+  private val request = AndroidScreenshotFixture.createRequester()
 
   @Test
   fun providesDeterministicProductionScreenData() {
     val sessions =
       json
-        .parseToJsonElement(AndroidScreenshotFixture.request("sessions.list", null))
+        .parseToJsonElement(request("sessions.list", null))
         .jsonObject["sessions"]
         ?.jsonArray
         .orEmpty()
     val metadata =
       json
-        .parseToJsonElement(AndroidScreenshotFixture.request("chat.metadata", null))
+        .parseToJsonElement(request("chat.metadata", null))
         .jsonObject
     val cronJobs =
       json
-        .parseToJsonElement(AndroidScreenshotFixture.request("cron.list", null))
+        .parseToJsonElement(request("cron.list", null))
         .jsonObject["jobs"]
         ?.jsonArray
         .orEmpty()
     val cronDetail =
       json
-        .parseToJsonElement(AndroidScreenshotFixture.request("cron.get", null))
+        .parseToJsonElement(request("cron.get", null))
         .jsonObject
     val cronRunEntries =
       json
-        .parseToJsonElement(AndroidScreenshotFixture.request("cron.runs", null))
+        .parseToJsonElement(request("cron.runs", null))
         .jsonObject["entries"]
         ?.jsonArray
     val parsedCronRuns = parseGatewayCronRunHistory(cronRunEntries)
@@ -74,13 +75,13 @@ class AndroidScreenshotFixtureTest {
       val params = "{\"spawnedBy\":\"${AndroidScreenshotFixture.mainSessionKey}\"}"
       val sessions =
         json
-          .parseToJsonElement(AndroidScreenshotFixture.request("sessions.list", params))
+          .parseToJsonElement(request("sessions.list", params))
           .jsonObject["sessions"]
           ?.jsonArray
           .orEmpty()
       val metadata =
         json
-          .parseToJsonElement(AndroidScreenshotFixture.request("chat.metadata", null))
+          .parseToJsonElement(request("chat.metadata", null))
           .jsonObject
       assertEquals("true", metadata["swarmEnabled"]?.jsonPrimitive?.content)
       assertEquals(5, sessions.size)
@@ -101,7 +102,7 @@ class AndroidScreenshotFixtureTest {
   fun providesDeterministicRecentChatHistory() {
     val history =
       json
-        .parseToJsonElement(AndroidScreenshotFixture.request("chat.history", null))
+        .parseToJsonElement(request("chat.history", null))
         .jsonObject
     val messages = history["messages"]?.jsonArray.orEmpty().takeLast(10)
 
@@ -166,7 +167,7 @@ class AndroidScreenshotFixtureTest {
     val greeting =
       json
         .parseToJsonElement(
-          AndroidScreenshotFixture.request(
+          request(
             "openclaw.chat",
             """{"sessionId":"android-settings-openclaw-test"}""",
           ),
@@ -174,7 +175,7 @@ class AndroidScreenshotFixtureTest {
     val response =
       json
         .parseToJsonElement(
-          AndroidScreenshotFixture.request(
+          request(
             "openclaw.chat",
             """{"sessionId":"android-settings-openclaw-test","message":"Check status"}""",
           ),
@@ -199,7 +200,7 @@ class AndroidScreenshotFixtureTest {
   fun rejectsUnexpectedGatewayCalls() {
     val error =
       assertThrows(IllegalStateException::class.java) {
-        AndroidScreenshotFixture.request("gateway.unexpected", null)
+        request("gateway.unexpected", null)
       }
 
     assertEquals(

--- a/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatQuestionTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/chat/ChatQuestionTest.kt
@@ -9,6 +9,7 @@ import ai.openclaw.app.gateway.QuestionGetResult
 import ai.openclaw.app.gateway.QuestionListResult
 import ai.openclaw.app.gateway.QuestionOption
 import ai.openclaw.app.gateway.QuestionRecord
+import ai.openclaw.app.gateway.QuestionSecretStore
 import ai.openclaw.app.ui.chat.questionCountdown
 import ai.openclaw.app.ui.chat.terminalQuestionAnswer
 import kotlinx.coroutines.CompletableDeferred
@@ -210,7 +211,7 @@ class ChatQuestionTest {
       val pending = record(expiresAtMs = Long.MAX_VALUE)
       val controller =
         createScriptedChatController {
-          respond("question.list", json.encodeToString(QuestionListResult(listOf(pending.copy(createdAtMs = 2_000)))))
+          respond("question.list", json.encodeToString(QuestionListResult(listOf(pending))))
           respond("question.resolve") {
             resolveStarted.complete(Unit)
             resolveResponse.await()
@@ -218,7 +219,7 @@ class ChatQuestionTest {
         }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
-      controller.resolveQuestion(pending.id, mapOf("meal" to listOf("Pizza")))
+      controller.resolveQuestion(controller.onlyQuestion, mapOf("meal" to listOf("Pizza")))
       runCurrent()
       resolveStarted.await()
       controller.handleGatewayEvent("health", null)
@@ -226,8 +227,9 @@ class ChatQuestionTest {
 
       assertEquals(ChatQuestionStatus.Submitting, controller.onlyQuestion.status(nowMs = 3_000))
       assertFalse(controller.onlyQuestion.answeredLocally)
-      resolveResponse.complete("{}")
+      resolveResponse.complete("""{"status":"answered","answers":{"answers":{"meal":["Pizza"]}}}""")
       advanceUntilIdle()
+      assertEquals(ChatQuestionStatus.Answered, controller.onlyQuestion.status())
     }
 
   @Test
@@ -516,7 +518,7 @@ class ChatQuestionTest {
             }
             json.encodeToString(QuestionGetResult(recovered))
           }
-          respond("question.resolve", "{}")
+          respond("question.resolve", """{"status":"cancelled"}""")
         }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(recovering))
@@ -533,7 +535,7 @@ class ChatQuestionTest {
       finalGetStarted.await()
       assertEquals(4, getCalls)
 
-      controller.skipQuestion(unrelated.id)
+      controller.skipQuestion(controller.questions.value.single { it.record.id == unrelated.id })
       runCurrent()
       releaseFinalGet.complete(Unit)
       runCurrent()
@@ -564,7 +566,7 @@ class ChatQuestionTest {
             if (getCalls < 5) error("temporary question.get failure")
             json.encodeToString(QuestionGetResult(recovered))
           }
-          respond("question.resolve", "{}")
+          respond("question.resolve", """{"status":"cancelled"}""")
         }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(recovering))
@@ -576,7 +578,7 @@ class ChatQuestionTest {
       runCurrent()
       assertEquals(3, getCalls)
 
-      controller.skipQuestion(unrelated.id)
+      controller.skipQuestion(controller.questions.value.single { it.record.id == unrelated.id })
       runCurrent()
       advanceTimeBy(4_000)
       runCurrent()
@@ -661,12 +663,14 @@ class ChatQuestionTest {
   fun missingQuestionNotFoundHasUnknownTerminalOutcome() =
     runTest {
       val pending = record(expiresAtMs = Long.MAX_VALUE)
+      val releaseLookup = CompletableDeferred<Unit>()
       var getCalls = 0
       val controller =
         createScriptedChatController {
           respond("question.list", json.encodeToString(QuestionListResult(emptyList())))
           respond("question.get") {
             getCalls += 1
+            releaseLookup.await()
             throw GatewayRequestRejected(
               GatewaySession.ErrorShape(
                 code = "INVALID_REQUEST",
@@ -684,9 +688,16 @@ class ChatQuestionTest {
         }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+      runCurrent()
+      val rendered = controller.onlyQuestion
+      controller.updateQuestionDraft(rendered) { it.setOther(question, "Unsent answer") }
+      releaseLookup.complete(Unit)
       advanceUntilIdle()
 
       assertEquals(ChatQuestionStatus.Unavailable, controller.onlyQuestion.status())
+      assertEquals(ChatQuestionDraft(), controller.onlyQuestion.draft)
+      controller.updateQuestionDraft(rendered) { it.setOther(question, "Stale input") }
+      assertEquals(ChatQuestionDraft(), controller.onlyQuestion.draft)
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       controller.handleGatewayEvent("health", null)
@@ -706,12 +717,12 @@ class ChatQuestionTest {
           respond("question.list", json.encodeToString(QuestionListResult(listOf(pending))))
           respond("question.resolve") { params ->
             resolveParams = params
-            "{}"
+            """{"status":"cancelled"}"""
           }
         }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
-      controller.skipQuestion(pending.id)
+      controller.skipQuestion(controller.onlyQuestion)
       advanceUntilIdle()
 
       val params = json.parseToJsonElement(checkNotNull(resolveParams)).jsonObject
@@ -732,12 +743,12 @@ class ChatQuestionTest {
           respond("question.resolve") {
             resolveStarted.complete(Unit)
             releaseResolve.await()
-            "{}"
+            """{"status":"cancelled"}"""
           }
         }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
-      controller.skipQuestion(pending.id)
+      controller.skipQuestion(controller.onlyQuestion)
       runCurrent()
       resolveStarted.await()
 
@@ -769,21 +780,257 @@ class ChatQuestionTest {
             resolveParams.add(checkNotNull(params))
             requestStarted.complete(Unit)
             releaseRequest.await()
-            "{}"
+            """{"status":"answered","answers":{"answers":{"meal":["Pizza"]}}}"""
           }
         }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
-      controller.resolveQuestion(pending.id, mapOf("meal" to listOf("Pizza")))
+      val rendered = controller.onlyQuestion
+      controller.resolveQuestion(rendered, mapOf("meal" to listOf("Pizza")))
       runCurrent()
       requestStarted.await()
-      controller.skipQuestion(pending.id)
+      controller.skipQuestion(rendered)
       releaseRequest.complete(Unit)
       advanceUntilIdle()
 
       assertEquals(1, resolveParams.size)
       assertFalse("cancel" in resolveParams.single())
       assertEquals(ChatQuestionStatus.Answered, controller.onlyQuestion.status())
+    }
+
+  @Test
+  fun pendingDraftEditsComposeAndSurviveRefreshAndSessionNavigation() =
+    runTest {
+      val pending = record()
+      val listResponse = CompletableDeferred<String>()
+      val controller =
+        createScriptedChatController {
+          respond("question.list") { listResponse.await() }
+        }
+      controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+      runCurrent()
+      val rendered = controller.onlyQuestion
+      controller.updateQuestionDraft(rendered) { it.toggle(question, "Pizza") }
+      controller.updateQuestionDraft(rendered) { it.setOther(question, "Salad") }
+      controller.switchSession("agent:main:other")
+      controller.switchSession("agent:main:main")
+      listResponse.complete(json.encodeToString(QuestionListResult(listOf(pending, record(id = "second")))))
+      runCurrent()
+
+      val retained = controller.questions.value.single { it.record.id == pending.id }
+      assertEquals(mapOf("meal" to listOf("Pizza", "Salad")), retained.draft.answers(pending.questions))
+      assertEquals(2, controller.questions.value.size)
+    }
+
+  @Test
+  fun replacedQuestionRejectsOldDraftEvenWhenOriginalDefinitionReturns() =
+    runTest {
+      val pending = record()
+      val replacements =
+        listOf(
+          pending.copy(questions = listOf(question.copy(question = "Choose lunch"))),
+          pending.copy(agentId = "other"),
+          pending.copy(sessionKey = "agent:main:other"),
+          pending.copy(runId = "other-run"),
+          pending.copy(createdAtMs = 2_000),
+          pending.copy(expiresAtMs = Long.MAX_VALUE - 1),
+        )
+      for (replacement in replacements) {
+        var listed = pending
+        val controller =
+          createScriptedChatController {
+            respond("question.list") { json.encodeToString(QuestionListResult(listOf(listed))) }
+          }
+        controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+        runCurrent()
+        val rendered = controller.onlyQuestion
+        controller.updateQuestionDraft(rendered) { it.setOther(question, "Original draft") }
+        listed = replacement
+        controller.handleGatewayEvent("question.requested", json.encodeToString(replacement))
+        runCurrent()
+        assertEquals(ChatQuestionDraft(), controller.onlyQuestion.draft)
+
+        listed = pending
+        controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+        runCurrent()
+        controller.updateQuestionDraft(rendered) { it.setOther(question, "Stale input") }
+        assertEquals(ChatQuestionDraft(), controller.onlyQuestion.draft)
+        controller.updateQuestionDraft(controller.onlyQuestion) { it.setOther(question, "Current input") }
+        assertEquals(mapOf("meal" to listOf("Current input")), controller.onlyQuestion.draft.answers(pending.questions))
+        controller.onGatewayScopeChanging()
+      }
+    }
+
+  @Test
+  fun gatewayRetirementDropsDraftAndRejectsOldInputAfterIdenticalQuestionReload() =
+    runTest {
+      val pending = record()
+      val controller =
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(listOf(pending))))
+        }
+      controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+      runCurrent()
+      val rendered = controller.onlyQuestion
+      controller.updateQuestionDraft(rendered) { it.setOther(question, "Draft on old gateway") }
+      controller.onGatewayScopeChanging()
+      assertTrue(controller.questions.value.isEmpty())
+      controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+      runCurrent()
+      controller.updateQuestionDraft(rendered) { it.setOther(question, "Stale input") }
+      assertEquals(ChatQuestionDraft(), controller.onlyQuestion.draft)
+    }
+
+  @Test
+  fun terminalQuestionClearsSecretDraftAndRejectsRetainedInputCallbacks() =
+    runTest {
+      val secret = question.copy(options = emptyList(), multiSelect = false, isSecret = true, secretStore = QuestionSecretStore("TASK_TOKEN", "secret"))
+      val pending = record().copy(questions = listOf(secret), runId = "task-secret-run")
+      for (terminal in listOf("answered", "cancelled", "expired")) {
+        var listed = listOf(pending)
+        val controller =
+          createScriptedChatController {
+            respond("question.list") { json.encodeToString(QuestionListResult(listed)) }
+          }
+        controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+        runCurrent()
+        val rendered = controller.onlyQuestion
+        controller.updateQuestionDraft(rendered) { it.setOther(secret, "task-only-secret-value") }
+        assertTrue(
+          controller.onlyQuestion.draft.otherText
+            .isNotEmpty(),
+        )
+        listed = emptyList()
+        val outcome = if (terminal == "answered") ",\"answers\":{\"answers\":{\"meal\":[\"stored\"]}}" else ""
+        controller.handleGatewayEvent("question.resolved", """{"id":"ask_123","status":"$terminal"$outcome}""")
+        runCurrent()
+        assertEquals(ChatQuestionDraft(), controller.onlyQuestion.draft)
+        controller.updateQuestionDraft(rendered) { it.setOther(secret, "Stale input") }
+        assertEquals(ChatQuestionDraft(), controller.onlyQuestion.draft)
+      }
+    }
+
+  @Test
+  fun failedQuestionSubmissionPreservesDraftAndBlocksEditsDuringSubmission() =
+    runTest {
+      val pending = record()
+      val response = CompletableDeferred<String>()
+      val controller =
+        createScriptedChatController {
+          respond("question.list", json.encodeToString(QuestionListResult(listOf(pending))))
+          respond("question.resolve") { response.await() }
+        }
+      controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+      runCurrent()
+      val rendered = controller.onlyQuestion
+      controller.updateQuestionDraft(rendered) { it.setOther(question, "Try again") }
+      controller.resolveQuestion(controller.onlyQuestion, checkNotNull(controller.onlyQuestion.draft.answers(pending.questions)))
+      runCurrent()
+      controller.updateQuestionDraft(rendered) { it.setOther(question, "Cannot edit while submitting") }
+      response.completeExceptionally(IllegalStateException("Gateway unavailable"))
+      runCurrent()
+
+      assertEquals(ChatQuestionStatus.Pending, controller.onlyQuestion.status())
+      assertEquals("Gateway unavailable", controller.onlyQuestion.errorText)
+      assertEquals(mapOf("meal" to listOf("Try again")), controller.onlyQuestion.draft.answers(pending.questions))
+    }
+
+  @Test
+  fun replacedQuestionDoesNotInheritAnOlderSubmissionClaim() =
+    runTest {
+      val pending = record()
+      val response = CompletableDeferred<String>()
+      var listed = pending
+      val controller =
+        createScriptedChatController {
+          respond("question.list") { json.encodeToString(QuestionListResult(listOf(listed))) }
+          respond("question.resolve") { response.await() }
+        }
+      controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+      runCurrent()
+      controller.updateQuestionDraft(controller.onlyQuestion) { it.setOther(question, "Original answer") }
+      controller.resolveQuestion(controller.onlyQuestion, mapOf("meal" to listOf("Original answer")))
+      runCurrent()
+      assertEquals(ChatQuestionStatus.Submitting, controller.onlyQuestion.status())
+
+      listed = pending.copy(questions = listOf(question.copy(question = "Choose lunch")))
+      controller.handleGatewayEvent("question.requested", json.encodeToString(listed))
+      runCurrent()
+      val replacement = controller.onlyQuestion
+      response.complete("""{"status":"answered","answers":{"answers":{"meal":["Original answer"]}}}""")
+      runCurrent()
+
+      assertEquals(ChatQuestionStatus.Pending, replacement.status())
+      assertEquals(ChatQuestionDraft(), replacement.draft)
+      assertEquals(replacement, controller.onlyQuestion)
+    }
+
+  @Test
+  fun retiredQuestionResolutionCannotMutateReloadedQuestionWithSameId() =
+    runTest {
+      for (fails in listOf(false, true)) {
+        val pending = record()
+        val response = CompletableDeferred<String>()
+        val controller =
+          createScriptedChatController {
+            respond("question.list", json.encodeToString(QuestionListResult(listOf(pending))))
+            respond("question.resolve") { response.await() }
+          }
+        controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+        runCurrent()
+        controller.resolveQuestion(controller.onlyQuestion, mapOf("meal" to listOf("Pizza")))
+        runCurrent()
+        assertEquals(ChatQuestionStatus.Submitting, controller.onlyQuestion.status())
+        controller.onGatewayScopeChanging()
+        controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+        runCurrent()
+        val replacement = controller.onlyQuestion
+        if (fails) {
+          response.completeExceptionally(IllegalStateException("Retired request failed"))
+        } else {
+          response.complete("""{"status":"answered","answers":{"answers":{"meal":["Pizza"]}}}""")
+        }
+        runCurrent()
+        assertEquals(replacement, controller.onlyQuestion)
+      }
+    }
+
+  @Test
+  fun secretResolutionResponsePreservesAuthoritativeAnswerAfterResolvedEvent() =
+    runTest {
+      val secret = question.copy(options = emptyList(), multiSelect = false, isSecret = true, secretStore = QuestionSecretStore("TASK_TOKEN", "secret"))
+      val pending = record().copy(questions = listOf(secret), runId = "task-secret-run")
+      val stored = QuestionAnswers(mapOf("meal" to listOf("stored")))
+      val resolveStarted = CompletableDeferred<Unit>()
+      val resolveResponse = CompletableDeferred<String>()
+      var listed = listOf(pending)
+      val controller =
+        createScriptedChatController {
+          respond("question.list") { json.encodeToString(QuestionListResult(listed)) }
+          respond("question.resolve") {
+            resolveStarted.complete(Unit)
+            resolveResponse.await()
+          }
+        }
+
+      controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
+      runCurrent()
+      controller.resolveQuestion(controller.onlyQuestion, mapOf("meal" to listOf("task-only-secret-value")))
+      runCurrent()
+      resolveStarted.await()
+      listed = emptyList()
+      controller.handleGatewayEvent(
+        "question.resolved",
+        """{"id":"ask_123","status":"answered","answers":{"answers":{"meal":["stored"]}}}""",
+      )
+      runCurrent()
+      assertEquals(stored, controller.onlyQuestion.record.answers)
+
+      resolveResponse.complete("""{"status":"answered","answers":{"answers":{"meal":["stored"]}}}""")
+      advanceUntilIdle()
+
+      assertEquals(ChatQuestionStatus.Answered, controller.onlyQuestion.status())
+      assertEquals(stored, controller.onlyQuestion.record.answers)
     }
 
   @Test
@@ -817,13 +1064,13 @@ class ChatQuestionTest {
           respond("question.resolve") {
             resolveStarted.complete(Unit)
             releaseResolve.await()
-            "{}"
+            """{"status":"answered","answers":{"answers":{"meal":["Pizza"]}}}"""
           }
         }
 
       controller.handleGatewayEvent("question.requested", json.encodeToString(pending))
       runCurrent()
-      controller.resolveQuestion(pending.id, mapOf("meal" to listOf("Pizza")))
+      controller.resolveQuestion(controller.onlyQuestion, mapOf("meal" to listOf("Pizza")))
       runCurrent()
       resolveStarted.await()
       controller.handleGatewayEvent("health", null)

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatQuestionDraftLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatQuestionDraftLayoutTest.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.After
@@ -86,7 +87,13 @@ class ChatQuestionDraftLayoutTest {
         .getDeclaredField("chat")
         .apply { isAccessible = true }
         .get(runtime) as ChatController
-    question = Json.decodeFromString<QuestionListResult>(AndroidScreenshotFixture.request("question.list", "{}")).questions.single()
+    @Suppress("UNCHECKED_CAST")
+    val request =
+      ChatController::class.java
+        .getDeclaredField("requestGateway")
+        .apply { isAccessible = true }
+        .get(controller) as suspend (String, String?) -> String
+    question = runBlocking { Json.decodeFromString<QuestionListResult>(request("question.list", "{}")).questions.single() }
     originalAnimatorScale = Settings.Global.getString(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE)
     Settings.Global.putFloat(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 0f)
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatQuestionDraftLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatQuestionDraftLayoutTest.kt
@@ -1,0 +1,239 @@
+package ai.openclaw.app.ui.chat
+
+import ai.openclaw.app.AndroidScreenshotFixture
+import ai.openclaw.app.AndroidScreenshotScene
+import ai.openclaw.app.MainViewModel
+import ai.openclaw.app.NodeApp
+import ai.openclaw.app.NodeRuntime
+import ai.openclaw.app.NodeRuntimeMode
+import ai.openclaw.app.SecurePrefs
+import ai.openclaw.app.chat.ChatController
+import ai.openclaw.app.chat.ChatQuestionPrompt
+import ai.openclaw.app.chat.ChatQuestionStatus
+import ai.openclaw.app.gateway.QuestionListResult
+import ai.openclaw.app.gateway.QuestionRecord
+import ai.openclaw.app.ui.design.ClawDesignTheme
+import android.content.Context
+import android.os.Looper
+import android.provider.Settings
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasSetTextAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipeDown
+import androidx.compose.ui.test.swipeUp
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w360dp-h800dp-420dpi")
+class ChatQuestionDraftLayoutTest {
+  @get:Rule
+  val composeRule = createComposeRule()
+
+  private lateinit var app: NodeApp
+  private lateinit var prefs: SecurePrefs
+  private lateinit var runtime: NodeRuntime
+  private lateinit var controller: ChatController
+  private lateinit var question: QuestionRecord
+  private var originalRuntime: NodeRuntime? = null
+  private val viewModelStore = ViewModelStore()
+  private var originalAnimatorScale: String? = null
+
+  @Before
+  fun setUp() {
+    app = RuntimeEnvironment.getApplication() as NodeApp
+    prefs = SecurePrefs(app, app.getSharedPreferences("chat-question-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    AndroidScreenshotFixture.configure(AndroidScreenshotScene.Chat)
+    runtime = NodeRuntime(app, prefs, NodeRuntimeMode.ScreenshotFixture)
+    originalRuntime = app.peekRuntime()
+    setApplicationRuntime(runtime)
+    controller =
+      NodeRuntime::class.java
+        .getDeclaredField("chat")
+        .apply { isAccessible = true }
+        .get(runtime) as ChatController
+    question = Json.decodeFromString<QuestionListResult>(AndroidScreenshotFixture.request("question.list", "{}")).questions.single()
+    originalAnimatorScale = Settings.Global.getString(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE)
+    Settings.Global.putFloat(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, 0f)
+  }
+
+  @After
+  fun tearDown() {
+    runtime.disconnect()
+    composeRule.waitForIdle()
+    viewModelStore.clear()
+    setApplicationRuntime(originalRuntime)
+    AndroidScreenshotFixture.configure(AndroidScreenshotScene.Home)
+    Settings.Global.putString(app.contentResolver, Settings.Global.ANIMATOR_DURATION_SCALE, originalAnimatorScale)
+    shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  @Test
+  fun unsentQuestionAnswerSurvivesReadingEarlierMessages() {
+    val history = showPendingQuestion()
+    val answer = composeRule.onNode(hasSetTextAction() and hasText("Other answer"))
+    answer.assertIsDisplayed().performTextReplacement("Mention the keyboard fix")
+    answer.assertTextContains("Mention the keyboard fix")
+    composeRule.onNodeWithText("Submit").assertIsEnabled()
+    composeRule.onNode(hasSetTextAction() and hasText("Other answer").not()).performClick()
+    assertQuestionUnchanged()
+
+    val visitedMessages = mutableSetOf<String>()
+    repeat(12) {
+      history.performTouchInput { swipeDown(durationMillis = 500) }
+      composeRule.waitForIdle()
+      composeRule.onAllNodes(hasText("Earlier discussion", substring = true)).fetchSemanticsNodes().forEach { node ->
+        if (node.boundsInRoot.height > 0f) {
+          node.config.getOrNull(SemanticsProperties.Text)?.forEach { visitedMessages += it.text }
+        }
+      }
+      assertQuestionUnchanged()
+    }
+    assertTrue("Must read more than eight distinct earlier messages: $visitedMessages", visitedMessages.size > 8)
+    answer.assertIsNotDisplayed()
+    repeat(12) {
+      history.performTouchInput { swipeUp(durationMillis = 500) }
+      composeRule.waitForIdle()
+      assertQuestionUnchanged()
+    }
+    composeRule.onNodeWithText(question.questions.single().question).assertIsDisplayed()
+    answer.assertIsDisplayed().assertTextContains("Mention the keyboard fix")
+    composeRule.onNodeWithText("Submit").assertIsEnabled()
+  }
+
+  @Test
+  fun retiredRenderedSubmitCannotAnswerReloadedQuestion() {
+    assertRetiredActionCannotResolveReloadedQuestion("Submit")
+  }
+
+  @Test
+  fun retiredRenderedSkipCannotCancelReloadedQuestion() {
+    assertRetiredActionCannotResolveReloadedQuestion("Skip")
+  }
+
+  private fun assertRetiredActionCannotResolveReloadedQuestion(label: String) {
+    showPendingQuestion()
+    composeRule
+      .onNode(hasSetTextAction() and hasText("Other answer"))
+      .performTextReplacement("Mention the keyboard fix")
+    val action = composeRule.onNode(hasText(label) and hasClickAction())
+    action.assertIsDisplayed().assertIsEnabled()
+    val retainedClick = checkNotNull(action.fetchSemanticsNode().config[SemanticsActions.OnClick].action)
+    lateinit var replacement: ChatQuestionPrompt
+    composeRule.runOnIdle {
+      controller.onGatewayScopeChanging()
+      assertTrue(controller.questions.value.isEmpty())
+      controller.applyMainSessionKey(checkNotNull(question.sessionKey))
+      controller.handleGatewayEvent("question.requested", Json.encodeToString(question))
+      assertQuestionUnchanged()
+      replacement = controller.questions.value.single()
+      assertTrue(replacement.draft.otherText.isEmpty())
+      assertNull(replacement.errorText)
+      // Replay the actual rendered action after retirement, before Compose can replace its callback.
+      retainedClick()
+    }
+    composeRule.waitForIdle()
+    assertEquals("Retired $label must not claim the reloaded prompt", replacement, controller.questions.value.single())
+
+    composeRule
+      .onNode(hasSetTextAction() and hasText("Other answer"))
+      .performTextReplacement("Use the current question")
+    action.assertIsEnabled().performClick()
+    composeRule.waitUntil {
+      controller.questions.value
+        .single()
+        .errorText != null
+    }
+    assertTrue(
+      "The current action must reach the existing Gateway boundary",
+      controller.questions.value
+        .single()
+        .errorText
+        .orEmpty()
+        .startsWith("Screenshot fixture does not implement gateway method question.resolve"),
+    )
+  }
+
+  private fun showPendingQuestion(): SemanticsNodeInteraction {
+    val viewModel = MainViewModel(app, prefs, SavedStateHandle())
+    viewModelStore.put("chat", viewModel)
+    viewModel.enterScreenshotFixtureMode(AndroidScreenshotScene.Chat)
+    composeRule.setContent {
+      ClawDesignTheme {
+        Box(Modifier.size(width = 360.dp, height = 800.dp).clipToBounds()) {
+          ChatScreen(
+            viewModel = viewModel,
+            talkActive = false,
+            showSidebarButton = true,
+            onOpenSidebar = {},
+            onToggleTalk = {},
+            onOpenSessions = {},
+            onOpenDashboard = {},
+            onOpenGatewaySettings = {},
+          )
+        }
+      }
+    }
+    composeRule.waitUntil { viewModel.chatMessages.value.size >= 24 }
+    composeRule.waitForIdle()
+    assertTrue(viewModel.chatQuestions.value.isEmpty())
+    composeRule.onNodeWithText("Draft a short status update for the team.").assertIsDisplayed()
+    controller.handleGatewayEvent("question.requested", Json.encodeToString(question))
+    composeRule.waitUntil {
+      viewModel.chatQuestions.value
+        .singleOrNull()
+        ?.record == question
+    }
+    val history = composeRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.ScrollToIndex))
+    repeat(3) { history.performTouchInput { swipeUp(durationMillis = 500) } }
+    return history
+  }
+
+  private fun assertQuestionUnchanged() {
+    val prompt = controller.questions.value.single()
+    assertEquals("Scrolling must not replace or remove the pending question", question, prompt.record)
+    assertEquals(ChatQuestionStatus.Pending, prompt.status())
+    assertTrue("Fixture must remain within the real pending question lifetime", System.currentTimeMillis() < question.expiresAtMs)
+  }
+
+  private fun setApplicationRuntime(value: NodeRuntime?) {
+    NodeApp::class.java
+      .getDeclaredField("runtimeInstance")
+      .apply { isAccessible = true }
+      .set(app, value)
+  }
+}


### PR DESCRIPTION
Fresh independent manual validation is complete: Q1–Q3 passed on the same final app across two separately prepared cases. Exact-head CI, fresh review disposition, and the native landing workflow remain required before merge.

## What Problem This Solves

Fixes an issue where Android users typing an answer to an agent question would lose their unsent answer after scrolling up to read earlier messages, even though the same question was still pending. Returning to the question showed an empty field and disabled Submit.

## Why This Change Was Made

The answer lived in the question card's disposable Compose state. It now belongs to the existing process-local question prompt. The card applies narrow edits to that owner's latest draft, and retired prompts cannot receive captured input or Submit/Skip callbacks. Terminal and unavailable questions clear their unsent input; drafts are never saved or serialized.

The same owner handles asynchronous completion and retains the Gateway's canonical resolution response instead of overwriting it with submitted input. The old view-local draft and duplicate question-publication paths are removed. Runtime changes are +114/-72 (net +42), justified by process-local input and interaction ownership, including one additional line for fixture-runtime ownership. Screenshot fixture support is +51/-16 (net +35, including dispatcher moves); tests are +585/-29.

The process-local owner is preferable to saveable state, which could persist sensitive input; timestamps do not establish a canonical request instance; clearing on every session switch would discard still-pending global or retained questions.

## User Impact

Users can read earlier chat messages without discarding an in-progress answer. Existing question selection, session filtering, expiry, permissions, storage, and wire protocol remain unchanged.

Named maintainer follow-ups remain: cross-client question-instance identity, Android terminal-ID reuse after server retention, and Apple canonical question-answer handling. The protocol still identifies requests and terminal events by reusable ID rather than a server-validated instance, and the existing Android terminal-replay guard can suppress a later reused ID. This change does not claim to solve those limitations or establish that Apple is unaffected.

## Evidence

On the real Android MainActivity at baseline `3255882803c78de5103d2d37f7698add84f34c5d`, typing a 24-character answer, reading 24 earlier messages, and returning changed the answer length from 24 to zero while the complete question record stayed unchanged and unexpired. The regression exercises the full ChatScreen with actual input, scrolling, offscreen removal, and return.

The same compiled instrumentation APK (`cdccfd887800`) ran against preserved baseline app `7756b76db9df` and final candidate app `428932fd0188` on Android 36. The baseline reached the intended answer-loss assertion in 112.558 seconds; the fixed run passed in 149.335 seconds with all 24 characters retained and Submit semantically enabled. Each phase has five raw screenshots and 21 serialized UI hierarchies, including all 16 outward scroll steps; independent inspection reconstructed all 24 visited rows and confirmed the question disappeared offscreen. The final app was built from `b41d37b4ec4d` plus the exact reviewed patch subsequently committed as `757c851a99f1`; its build stamp remains `b41d37b4ec4d`, not `757c851a99f1`. This proves draft retention and enablement, not live Gateway answer delivery.

Historical source: [#110372](https://github.com/openclaw/openclaw/pull/110372) added the view-local draft in [d7de67a](https://github.com/openclaw/openclaw/commit/d7de67ae027dcb86c7b39272df526ffacc4d0a46), authored and merged by @steipete on July 18, 2026. The frozen baseline retains that declaration; uninterrupted current-line ancestry was not reconstructed across the shallow history boundary.

ClawSweeper's fixture-lifetime finding and Rank-up move are addressed: each fixture runtime captures one requester owning a fresh pending question; repeated reads and scene/locale reconfiguration keep that runtime's exact record stable, with normal ten-minute expiry. The singleton record and static dispatch path are removed. A deterministic requester-boundary test first failed on the old API (fresh creation time expected 601100, received 100), then passed with the factory binding; it also checks same-owner stability, legitimate expiry, and old/new owner isolation. This is not a two-runtime database integration test or a ten-minute native soak. No protocol, persisted state, timeout, or expiry policy was changed.

The final source passed 298 tests across both Android flavors in two batches (262 owner/sibling tests plus 36 timeline tests), including draft lifecycle, canonical response ordering, stale rendered Submit/Skip callbacks, fresh-action controls, fixture lifetime, and reconnect/session coverage. Both Android lint tasks passed with zero errors or warnings and three existing unrelated hints. All four module ktlint checks, Play debug assembly, required native localization verification, and the ordinary eleven-path changed-file gate passed. Full P2 review of the exact committed branch reported no actionable findings within the stated scope; the earlier two consciously deferred protocol/lifetime findings remain documented above.

Fresh independent source-blind Q1–Q3 validation passed on the same final app across two separately prepared cases. The validator entered two different answers, moved each question entirely offscreen, and returned to its exact unchanged draft. A fresh empty → filled → cleared control showed Submit visibly disabled → enabled → disabled; this manual check establishes visual enablement, not accessibility flags or backend delivery. Both holders exited after their documented Stop commands, and the task emulator and ADB server were shut down with saved key metadata unchanged.

Earlier missing-control captures, an expired prepared case whose handoff window the coordinator missed, and an aborted diagnostic remain recorded separately, not counted as passing behavior. The diagnostic identified an untimed Android activity-launch idle wait in the disposable operator setup. Its test-only launch/lifecycle cleanup repair changed neither this app nor the accepted native replay. A post-terminal framework accessibility dead-handler warning was retained; the logs are not claimed warning-free. Earlier interactive checks on the previous APK are not reused here. No live Gateway delivery is claimed.

Same native scenario, after reading earlier messages and returning:

Baseline: the unsent answer is lost and Submit is disabled.

![Baseline after returning to the pending question: empty answer and disabled Submit](https://github.com/user-attachments/assets/fe44e938-1c18-465b-83de-c5c83e9efe73)

Fixed: the unsent answer remains and Submit is enabled.

![Fixed after returning to the pending question: retained answer and enabled Submit](https://github.com/user-attachments/assets/cb17321c-05f1-4f44-80eb-9bc6171c24bf)

AI-assisted implementation and review used Codex; the source, tests, artifacts, and observed results were independently checked.
