### PR TITLE
docs: remove unsupported Daytona cloud-worker setup recipe

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -85,37 +85,10 @@ Keep the token out of repository config and shell arguments.
 ### Daytona
 
 <Warning>
-Direct Daytona cloud-worker dispatch is currently incompatible with this integration: OpenClaw requires `settings.class` and forwards it as `--class`, but Crabbox's direct Daytona backend rejects that flag because the snapshot controls sizing. The example below passes OpenClaw's profile validation but cannot provision a direct Daytona worker. Use another supported backend until this incompatibility is resolved.
+Direct Daytona cloud-worker dispatch is currently unsupported. OpenClaw requires a non-empty `settings.class` and forwards it as `--class`, but Crabbox's direct Daytona backend rejects that flag because the snapshot controls sizing. Omitting the class fails OpenClaw's profile validation; setting it to `beast` or another value does not resolve the incompatibility.
 </Warning>
 
-The bundled Crabbox provider can also lease [Daytona](https://www.daytona.io) sandboxes as cloud workers (`settings.provider: "daytona"`). Unlike AWS, Daytona needs no separate `crabbox login` step: export `DAYTONA_API_KEY` (from the [Daytona dashboard](https://app.daytona.io/dashboard/keys)) in the Gateway process's environment before Crabbox allocates a lease. Verify it without provisioning anything:
-
-```bash
-DAYTONA_API_KEY=<key> crabbox doctor --provider daytona --json
-```
-
-A `daytona-fallback auth=ready control_plane=ready inventory=ready` finding confirms the key authenticates; `mutation=false` means the check is read-only. Daytona leases are Linux-only (`target: linux`) and reachable over SSH like any other Crabbox `ssh-lease` provider. Crabbox's default Daytona snapshot already ships Node.js and `npx`, so `settings.setup` is optional here — keep it only if your own snapshot needs it, as an idempotent guard like the AWS example above.
-
-```json
-{
-  "cloudWorkers": {
-    "profiles": {
-      "daytona": {
-        "provider": "crabbox",
-        "install": "bundle",
-        "settings": {
-          "provider": "daytona",
-          "class": "beast",
-          "ttl": "8h",
-          "idleTimeout": "45m"
-        }
-      }
-    }
-  }
-}
-```
-
-The `settings.class: "beast"` value above is explicit, not a default. OpenClaw rejects an omitted or empty class before calling Crabbox; this validation requirement does not make `beast` a supported Daytona sizing option. `crabbox providers describe daytona --json` lists the provider's flags and limitations. Provide `DAYTONA_API_KEY` as an environment variable on the Gateway process (for example through a systemd `EnvironmentFile`), the same way other credential-bearing provider secrets are supplied — never in `openclaw.json` itself.
+Use another supported backend, such as the AWS profile in [Configuration](/gateway/cloud-workers#configuration), for cloud-worker sessions until this integration is compatible. For standalone Crabbox usage, see its [Daytona provider documentation](https://github.com/openclaw/crabbox/blob/main/docs/providers/daytona.md); those instructions are not an OpenClaw cloud-worker setup recipe.
 
 ## Configuration
 


### PR DESCRIPTION
## What Problem This Solves

Fixes contradictory guidance left in the Daytona Cloud Workers section after #130814: a warning correctly says direct dispatch cannot work, but the following text still claims the provider can lease Daytona workers and supplies an unusable profile example.

Follow-up to #130814, addressing its late ClawSweeper finding: https://github.com/openclaw/openclaw/pull/130814#issuecomment-5436273254.

## Why This Change Was Made

Replace the remaining affirmative direct-provisioning claim and unusable recipe with one concise unsupported-state explanation. Retain the verified class-validation versus backend-flag distinction, link to the supported AWS configuration, and distinguish standalone Crabbox documentation from an OpenClaw cloud-worker setup.

This is docs-only. It does not select a runtime default or adopt either unpublished Daytona integration proposal. The coordinated runtime/setup repair must replace this unsupported-state section only when its working contract is integrated.

## User Impact

Operators receive one unambiguous outcome: the current direct-Daytona integration is unsupported, and neither omitting the class nor selecting `beast` fixes it. The page no longer invites them to copy a known-unusable provisioning profile.

## Evidence

- Same source-backed invariant verified for #130814: OpenClaw's real parser/provider entry points reject omission, warmup always forwards `--class`, and Crabbox's direct Daytona flag parser rejects any explicit `--class` because snapshot sizing is authoritative.
- Focused provider/schema suites passed 209 tests on the preceding docs-only PR head; no runtime or test source changes are included here.
- `node scripts/check-docs-mdx.mjs docs/gateway/cloud-workers.md`, `node_modules/.bin/oxfmt --check docs/gateway/cloud-workers.md`, and `git diff --check` pass for this change.
- The internal Configuration anchor exists on the same page. The external link targets the directly inspected upstream Daytona provider documentation.
- Removed units: unusable JSON profile, affirmative provisioning/setup copy, and associated direct-setup auth/snapshot instructions. Their future replacement belongs to the coordinated runtime repair. No unrelated Machine0 picker, settings-editor, discovery, or catalog-limit changes.
- No successful authenticated Daytona allocation or end-to-end dispatch is claimed. This change removes the invalid recipe rather than claiming to repair the integration.

Production and test LOC: +0/-0. Documentation-only net deletion.

AI-assisted documentation correction.
