### PR TITLE
fix(cron): load target rows by id in admission and receipt paths

### DIFF
--- a/src/cron/service/runtime-store.ts
+++ b/src/cron/service/runtime-store.ts
@@ -5,7 +5,7 @@ import { cronStoreKey } from "../store/key.js";
 import {
   deleteCronJobRowInDatabase,
   loadedCronStoreFromRows,
-  loadCronRows,
+  loadCronRowsByIds,
   upsertCronJobRow,
 } from "../store/row-codec.js";
 import {
@@ -64,7 +64,7 @@ export function commitCronRuntimeRows<T>(params: {
   const jobIds = new Set(params.jobIds);
   const committed = runOpenClawStateWriteTransaction(
     ({ db }) => {
-      const rows = loadCronRows(db, storeKey, jobIds);
+      const rows = loadCronRowsByIds(db, storeKey, jobIds);
       const rowsByJobId = new Map(rows.map((row) => [row.job_id, row] as const));
       const loadedJobs = loadedCronStoreFromRows(rows).store.jobs;
       const { repairJobIds } = loadCronRuntimeAuthorities({ db, storeKey, jobs: loadedJobs });

--- a/src/cron/store/row-codec.targeted-load.test.ts
+++ b/src/cron/store/row-codec.targeted-load.test.ts
@@ -1,0 +1,117 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import type { CronJob } from "../types.js";
+import { cronStoreKey } from "./key.js";
+import { loadCronRows, loadCronRowsByIds, replaceCronRows } from "./row-codec.js";
+
+function makeJob(id: string): CronJob {
+  return {
+    id,
+    name: id,
+    enabled: true,
+    createdAtMs: 1,
+    updatedAtMs: 1,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "agentTurn", message: id },
+    state: {},
+  };
+}
+
+async function withStore(
+  jobs: CronJob[],
+  fn: (db: ReturnType<typeof openOpenClawStateDatabase>["db"], storeKey: string) => void,
+) {
+  const fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cron-targeted-load-"));
+  const handle = openOpenClawStateDatabase({ path: path.join(fixtureRoot, "state.sqlite") });
+  const storeKey = cronStoreKey(handle.path);
+  try {
+    replaceCronRows(handle.db, storeKey, { version: 1, jobs });
+    fn(handle.db, storeKey);
+  } finally {
+    handle.walMaintenance.close();
+    await fs.rm(fixtureRoot, { recursive: true, force: true });
+  }
+}
+
+describe("loadCronRowsByIds targeted loader", () => {
+  it.each([
+    ["single id", ["job-2"]],
+    ["subset of ids", ["job-1", "job-3"]],
+    ["all ids", ["job-1", "job-2", "job-3"]],
+  ])("returns only the requested rows for %s", async (_label, ids: string[]) => {
+    const jobs = [makeJob("job-1"), makeJob("job-2"), makeJob("job-3")];
+    await withStore(jobs, (db, storeKey) => {
+      const rows = loadCronRowsByIds(db, storeKey, ids);
+      expect(new Set(rows.map((r) => r.job_id))).toEqual(new Set(ids));
+      expect(loadCronRows(db, storeKey).length).toBe(3);
+    });
+  });
+
+  it("preserves store sort order even when ids are requested out of order", async () => {
+    const jobs = [makeJob("alpha"), makeJob("beta"), makeJob("gamma")];
+    await withStore(jobs, (db, storeKey) => {
+      const rows = loadCronRowsByIds(db, storeKey, ["gamma", "alpha"]);
+      expect(rows.map((r) => r.job_id)).toEqual(["alpha", "gamma"]);
+    });
+  });
+
+  it("returns rows identical to a full-scan filter (parity invariant)", async () => {
+    const jobs = [makeJob("job-1"), makeJob("job-2"), makeJob("job-3"), makeJob("job-4")];
+    await withStore(jobs, (db, storeKey) => {
+      const requested = ["job-4", "job-1", "job-2"];
+      const targeted = loadCronRowsByIds(db, storeKey, requested);
+      const filtered = loadCronRows(db, storeKey).filter((r) => requested.includes(r.job_id));
+      expect(targeted).toEqual(filtered);
+    });
+  });
+
+  it("deduplicates repeated ids", async () => {
+    const jobs = [makeJob("job-1"), makeJob("job-2")];
+    await withStore(jobs, (db, storeKey) => {
+      const rows = loadCronRowsByIds(db, storeKey, ["job-1", "job-1", "job-2", "job-1"]);
+      expect(rows.map((r) => r.job_id)).toEqual(["job-1", "job-2"]);
+    });
+  });
+
+  it("returns an empty array for an empty id set", async () => {
+    await withStore([makeJob("job-1")], (db, storeKey) => {
+      expect(loadCronRowsByIds(db, storeKey, [])).toEqual([]);
+    });
+  });
+
+  it("returns an empty array when none of the requested ids exist", async () => {
+    await withStore([makeJob("job-1")], (db, storeKey) => {
+      expect(loadCronRowsByIds(db, storeKey, ["missing-1", "missing-2"])).toEqual([]);
+    });
+  });
+
+  it("packs the id set into one JSON array when it exceeds the IN-list limit", async () => {
+    const jobCount = 501;
+    const jobs = Array.from({ length: jobCount }, (_, i) => makeJob(`job-${i}`));
+    await withStore(jobs, (db, storeKey) => {
+      const requested = jobs.map((job) => job.id);
+      const targeted = loadCronRowsByIds(db, storeKey, requested);
+      const filtered = loadCronRows(db, storeKey).filter((row) =>
+        new Set(requested).has(row.job_id),
+      );
+      expect(targeted).toEqual(filtered);
+      expect(targeted.length).toBe(jobCount);
+    });
+  });
+
+  it("uses the indexed IN query for a set at the limit boundary", async () => {
+    const jobCount = 500;
+    const jobs = Array.from({ length: jobCount }, (_, i) => makeJob(`job-${i}`));
+    await withStore(jobs, (db, storeKey) => {
+      const requested = jobs.map((job) => job.id);
+      const targeted = loadCronRowsByIds(db, storeKey, requested);
+      expect(targeted.length).toBe(jobCount);
+      expect(targeted.map((r) => r.job_id)).toEqual(requested);
+    });
+  });
+});

--- a/src/cron/store/row-codec.ts
+++ b/src/cron/store/row-codec.ts
@@ -239,6 +239,50 @@ export function readCronJobsFingerprint(db: DatabaseSync, storeKey: string): str
   return fingerprintCronJobRows(rows);
 }
 
+/**
+ * Maximum number of job IDs to expand into a single SQLite `IN (...)` predicate.
+ * Mirrors the 500-bind limit used by `session-accessor.sqlite-entry-cache.ts` to
+ * stay below SQLite's variable cap. Larger sets use `sqliteStringSet`, which
+ * binds the IDs as one JSON array consumed via `json_each`, so the read stays
+ * bounded to the requested rows instead of widening to a full-store scan.
+ */
+const MAX_CRON_IN_QUERY_IDS = 500;
+
+/** Loads only the rows for the given job IDs, avoiding a full-store scan. */
+export function loadCronRowsByIds(
+  db: DatabaseSync,
+  storeKey: string,
+  jobIds: Iterable<string>,
+): CronJobRow[] {
+  const ids = [...new Set(jobIds)];
+  if (ids.length === 0) {
+    return [];
+  }
+  // SQLite replaces lone surrogates in bound IDs with U+FFFD, so a malformed
+  // target can otherwise match the replacement-character job. Keep exact caller
+  // identity by filtering the SQL result against the requested ID set.
+  const idSet = new Set(ids);
+  const predicate =
+    ids.length > MAX_CRON_IN_QUERY_IDS
+      ? // Above the bind cap, pack the IDs into one JSON array consumed via
+        // json_each so the read stays bounded to the requested rows instead of
+        // widening to a full-store scan.
+        sqliteStringSet(ids)
+      : ids;
+  const rows = executeSqliteQuerySync(
+    db,
+    getCronStoreKysely(db)
+      .selectFrom("cron_jobs")
+      .selectAll()
+      .where("store_key", "=", storeKey)
+      .where("job_id", "in", predicate)
+      .orderBy("sort_order", "asc")
+      .orderBy("updated_at", "asc")
+      .orderBy("job_id", "asc"),
+  ).rows;
+  return rows.filter((row) => idSet.has(row.job_id));
+}
+
 /** Materializes retired ownership within the caller's write transaction. */
 export function materializeCronRowAgentOwners(
   db: DatabaseSync,

--- a/src/cron/store/run-receipt-store.ts
+++ b/src/cron/store/run-receipt-store.ts
@@ -25,7 +25,7 @@ import { OPENCLAW_STATE_SCHEMA_SQL } from "../../state/openclaw-state-schema.js"
 import { resolveCronJobConfigRevision } from "../config-revision.js";
 import type { CronJob } from "../types.js";
 import { cronStoreKey } from "./key.js";
-import { loadedCronStoreFromRows, loadCronRows } from "./row-codec.js";
+import { loadedCronStoreFromRows, loadCronRowsByIds } from "./row-codec.js";
 
 /**
  * Receipt/lease lifecycle (the SQLite status is `running` for the first three rows):
@@ -276,8 +276,11 @@ function receiptFromRow(row: CronRunReceiptRow): CronRunReceipt {
 }
 
 function currentJob(database: DatabaseSync, storeKey: string, jobId: string): CronJob | undefined {
-  const rows = loadCronRows(database, storeKey, new Set([jobId]));
-  return loadedCronStoreFromRows(rows).store.jobs[0];
+  const rows = loadCronRowsByIds(database, storeKey, [jobId]);
+  if (rows.length === 0) {
+    return undefined;
+  }
+  return loadedCronStoreFromRows(rows).store.jobs.find((job) => job.id === jobId);
 }
 
 function sameOwner(left: CronRunReceiptRow, right: CronRunReceiptOwnerObservation): boolean {


### PR DESCRIPTION
Related to #127257

## What Problem This Solves

When many cron jobs become due at the same timer tick, each admitted run re-reads and decodes the entire cron job store from SQLite before doing its work, so the per-wave effort scales as Θ(D·N) instead of Θ(D+N). This adds a SQL-level targeted row loader so the runtime commit and receipt validation paths read only the rows they actually need.

- Problem: `commitCronRuntimeRows` and receipt `currentJob` validation each called `loadCronRows` (a full `SELECT * FROM cron_jobs WHERE store_key = ?`), then filtered down to a single target job in JavaScript. With D due jobs in an N-job store this produces D full-store scans.
- Solution: Add `loadCronRowsByIds(db, storeKey, jobIds)` using `WHERE store_key = ? AND job_id IN (...)`, and switch both call sites to it. The `IN` list is capped at 500 entries (matching the repository's existing `session-accessor.sqlite-entry-cache.ts` precedent); larger sets pack the IDs into one JSON array consumed via `json_each`, so the read stays bounded to the requested rows instead of widening to a full-store scan. Both paths also filter the SQL result against the requested ID set so a lone-surrogate target cannot match the replacement-character job (matching `loadCronRows`).
- What changed: `src/cron/store/row-codec.ts` (new `loadCronRowsByIds` with 500-bind cap and `json_each` large-set path), `src/cron/service/runtime-store.ts` (`commitCronRuntimeRows`), `src/cron/store/run-receipt-store.ts` (`currentJob`).
- What did NOT change: The per-admission `ensureLoaded(forceReload: true)` full-store reload (the dominant Θ(D·N) term) is intentionally left for a follow-up. Reservation batch loads, all receipt CAS / concurrent disable-delete / overlap fences, and store normalization/quarantine semantics are unchanged.

## Why This Change Was Made

The issue identifies multiple O(N) sites that compound into Θ(D·N) per due wave. This PR addresses the two sites where a single target job is read but the whole store is loaded: the runtime-row commit (`commitCronRuntimeRows`) and receipt current-job validation (`currentJob`). Both now use a SQL-level indexed lookup so per-run reads are proportional to the requested set.

The per-admission `ensureLoaded(forceReload)` reload is the larger remaining term but it also serves as a cross-process consistency gate (re-normalizing, re-quarantining, and detecting concurrent disable/delete). Replacing it with a targeted reload changes scheduler freshness and transaction ownership boundaries that the issue marks as review-required, so it is scoped to a follow-up rather than rushed here.

The `IN`-list cap was added because `commitCronRuntimeRows` is also called by the startup backoff path (`deferPendingBackoffMissedCronSlots` in `timer-catchup.ts`), which passes every resident cron job ID. Without a cap, a sufficiently large store could exceed SQLite's `SQLITE_MAX_VARIABLE_NUMBER` limit and fail scheduler maintenance. The 500 threshold mirrors the existing `session-accessor.sqlite-entry-cache.ts` boundary; above it the loader packs the IDs into one JSON array consumed via `json_each` (one bound parameter, SQL-level filtering), so no caller sees a regression and the read never widens to a full-store scan.

- Alternative considered: in-JS filter is already what exists; the SQL-level `WHERE job_id IN (...)` is strictly better and reuses the established kysely pattern used elsewhere (`src/gateway/worker-environments/placement-store.ts`).
- Risk: None to fence semantics — both call sites remain inside the same write transaction / lock, read the same rows by primary key, and the query ordering matches `loadCronRows` exactly (verified by a parity test). The 500-bind cap is a safety bound only; the `json_each` fallback path produces identical results.

## User Impact

Installations with large cron stores and synchronized due waves will see reduced SQLite read load and write-lock pressure per admitted run. No configuration or behavior change; all scheduling, receipt, and concurrency fences behave identically.

## Evidence

`node --import tsx` running the production loader against a 200-job store, comparing full scan vs targeted load:

```text
N (store size): 200
loadCronRows (full scan) returned rows: 200
loadCronRowsByIds (targeted, 1 id) returned rows: 1
loadCronRowsByIds (empty id set) returned rows: 0
targeted job_id match: true
```

Caller-path proof — SQL-level interception of `db.prepare` confirming both changed callers use the bounded `IN` lookup (not a full-store scan) against a 200-job store:

```text
=== Path 1: Receipt validation (claimCronRunReceiptInDatabase) ===
Target job: job-50 in a 200-job store
Claimed receipt job: job-50
SQL SELECTs on cron_jobs: 1
  [0] select * from "cron_jobs" where "store_key" = ? and "job_id" in (?) order by "sort_order" asc, "updated_at" asc, "job_id" asc
Uses IN predicate (targeted load): true

=== Path 2: Runtime commit (loadCronRowsByIds for single target) ===
Target job: job-75 in a 200-job store
Rows loaded: 1 (expected 1, not 200)
SQL SELECTs on cron_jobs: 1
  [0] select * from "cron_jobs" where "store_key" = ? and "job_id" in (?) order by "sort_order" asc, "updated_at" asc, "job_id" asc
Uses IN predicate (targeted load): true

=== Path 3: Large-set path (600 IDs > 500 limit) ===
Store size: 600, requested: 600 IDs
Rows loaded: 600
SQL SELECTs on cron_jobs: 1
  [0] select * from "cron_jobs" where "store_key" = ? and "job_id" in (SELECT value FROM json_each(?)) order by "sort_order" asc, "updated_at" asc, "job_id" asc
Uses json_each bounded read: true
```

Path 1 exercises the receipt claim flow (`prepareCronRunReceiptClaim` → `claimCronRunReceiptInDatabase` → `validateCurrentJob` → `currentJob` → `loadCronRowsByIds`), confirming the receipt validation path uses the targeted `IN` query rather than the previous full-store scan. Path 2 exercises the runtime commit read (`loadCronRowsByIds` inside the write-transaction context that `commitCronRuntimeRows` uses), loading 1 row instead of 200. Path 3 confirms that sets exceeding the 500-bind cap pack the IDs into one JSON array consumed via `json_each`, keeping the read bounded to the requested rows (no full-store scan).

Large-set boundary proof (600 IDs exceeding the 500-bind cap, verifying parity):

```text
--- Large-set boundary (N=600, exceeds 500-bind limit) ---
loadCronRowsByIds returned rows: 600
full-scan filter returned rows: 600
parity (targeted === full-scan filter): true
all 600 jobs returned: true

--- Boundary (exactly 500 IDs, uses indexed IN query) ---
loadCronRowsByIds returned rows: 500
all 500 requested returned: true
```

Parity matrix (targeted loader vs full-scan filter):

```
input variant                              => loadCronRowsByIds result
single id ["job-2"]                        => 1 row, job_id=job-2
subset ["job-1","job-3"]                   => 2 rows, matches full-scan filter
all ids                                    => 3 rows, matches full-scan filter
out-of-order ["gamma","alpha"]             => ["alpha","gamma"] (store sort order preserved)
duplicates ["job-1","job-1","job-2"]       => ["job-1","job-2"] (deduped)
empty []                                   => [] (no SQL issued)
non-existent ["missing-1","missing-2"]     => []
>500 ids (json_each bounded read)          => all requested rows, matches full-scan filter
```

Focused regression test (`src/cron/store/row-codec.targeted-load.test.ts`, 10 cases) passes, including a deep-equality parity assertion that `loadCronRowsByIds(db, key, S)` equals `loadCronRows(db, key).filter(r => S.includes(r.job_id))` for any subset, plus dedicated tests for the 500-bind boundary (large-set `json_each` path and at-limit indexed query). Existing cron store suites (including `runtime-store.test.ts`'s 33,000-ID bounded-read assertion) remain green.

What was not tested: An end-to-end 10,000-job all-due timer wave with instrumented SQL statement counts (the issue's repro) — the per-admission `ensureLoaded(forceReload)` still does a full-store reload, so a wave-level Θ(D·N)→Θ(D) benchmark would not yet pass and is deferred to the follow-up.

## AI Assistance

- AI-assisted: Yes
- Tools: Codex (gpt-5.6-sol)
- Prompts / session excerpts: open-source-pr skill workflow — issue analysis, root-cause traversal, targeted loader implementation, adversarial self-review (subagent simulating ClawSweeper flagged the admission-reload scope gap, leading to the phase-1 scoping and `Related to` closure). Follow-up round 1: ClawSweeper P1 finding on unbounded `IN` list for whole-store callers resolved by adding a 500-bind cap with full-scan fallback (matching `session-accessor.sqlite-entry-cache.ts` precedent), plus large-set boundary proof and regression tests. Follow-up round 2: ClawSweeper requested caller-path evidence; added SQL-interception proof confirming receipt validation (`claimCronRunReceiptInDatabase`) and runtime commit (`loadCronRowsByIds` in write-transaction context) both emit `WHERE job_id IN (?)` targeted queries, while sets exceeding 500 fall back to a full-scan `SELECT` without `IN`. Follow-up round 3 (conflict resolution): rebased onto `origin/main`, which added a `cron_job_runtime_authorities` repair step in `commitCronRuntimeRows` and a 33,000-ID bounded-read regression test; resolved the two textual conflicts by keeping the targeted `loadCronRowsByIds` call sites alongside main's authority repair, and replaced the large-set full-scan fallback with a `json_each` bounded read (one bound parameter) so the loader never widens past the requested rows — aligning with main's new bounded-read contract.
- Confirmed understanding of code changes: Yes — `loadCronRowsByIds` reuses `getCronStoreKysely` + `executeSqliteQuerySync` with the same `orderBy` as `loadCronRows`; both call sites swap `loadCronRows().filter()` for the indexed query with no fence-semantic change; sets exceeding 500 IDs use `sqliteStringSet` (`json_each`, one bound parameter) and both paths filter the SQL result against the requested ID set to stay below SQLite variable limits and preserve exact caller identity.
- autoreview: N/A (not configured in this environment)
