### PR TITLE
fix(ui): remove model-loading gap from new-session composer

### DIFF
--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -9,12 +9,18 @@ import {
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
-const captureCatalogRetryProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const catalogRetryProofDir = path.join(
   process.cwd(),
   ".artifacts",
   "control-ui-e2e",
   "new-session-catalog-retry",
+);
+const skeletonGapProofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "new-session-skeleton-gap",
 );
 
 function catalogDiscoveryRequests(
@@ -30,6 +36,67 @@ function catalogDiscoveryRequests(
 }
 
 suite.define(() => {
+  it("keeps composer actions fixed while model metadata loads", async () => {
+    if (captureUiProof) {
+      await mkdir(skeletonGapProofDir, { recursive: true });
+    }
+    const context = await suite.browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      agentModel: "openai/gpt-5.6-luna",
+      heldMethods: ["chat.metadata"],
+      models: [
+        {
+          available: true,
+          id: "gpt-5.6-luna",
+          name: "GPT-5.6 Luna",
+          provider: "openai",
+          reasoning: true,
+        },
+      ],
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      const modelSkeleton = page.locator(".chat-controls__model-trigger-skeleton");
+      await expect.poll(() => modelSkeleton.isVisible()).toBe(true);
+      const modelTrigger = page.locator(
+        '.new-session-page__composer [data-chat-model-select="true"]',
+      );
+      const actions = page.locator(".new-session-page__composer .agent-chat__composer-actions");
+      const loadingModelBox = await modelTrigger.boundingBox();
+      const loadingActionsBox = await actions.boundingBox();
+      expect(loadingModelBox).not.toBeNull();
+      expect(loadingActionsBox).not.toBeNull();
+      expect(
+        (loadingActionsBox?.x ?? 0) - ((loadingModelBox?.x ?? 0) + (loadingModelBox?.width ?? 0)),
+      ).toBeLessThan(16);
+      if (captureUiProof) {
+        await page.screenshot({
+          animations: "disabled",
+          fullPage: true,
+          path: path.join(skeletonGapProofDir, "after.png"),
+        });
+      }
+
+      await gateway.resolveDeferred("chat.metadata");
+      const effortPicker = page.locator(
+        ".new-session-page__composer .chat-controls__effort-picker:not(.chat-controls__effort-picker--reserved)",
+      );
+      await expect.poll(() => effortPicker.isVisible()).toBe(true);
+      const readyActionsBox = await actions.boundingBox();
+      expect(readyActionsBox).not.toBeNull();
+      expect(readyActionsBox?.x).toBeCloseTo(loadingActionsBox?.x ?? 0, 0);
+      expect(readyActionsBox?.width).toBeCloseTo(loadingActionsBox?.width ?? 0, 0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("selects a context window before creating a session", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
@@ -222,14 +289,14 @@ suite.define(() => {
   });
 
   it("recovers a failed CLI-agent catalog without reloading model metadata for its retry", async () => {
-    if (captureCatalogRetryProof) {
+    if (captureUiProof) {
       await mkdir(catalogRetryProofDir, { recursive: true });
     }
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
-      ...(captureCatalogRetryProof
+      ...(captureUiProof
         ? { recordVideo: { dir: catalogRetryProofDir, size: { height: 900, width: 1280 } } }
         : {}),
     });
@@ -301,7 +368,7 @@ suite.define(() => {
       ).toBe("GPT-5.6 Luna");
       expect(await page.getByText("Models unavailable", { exact: true }).count()).toBe(0);
       await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
-      if (captureCatalogRetryProof) {
+      if (captureUiProof) {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
@@ -351,7 +418,7 @@ suite.define(() => {
         page.locator('[data-chat-model-target="anthropic"] .chat-controls__model-option-name'),
       ).toBe("Claude Code");
       expect(await errorState.count()).toBe(0);
-      if (captureCatalogRetryProof) {
+      if (captureUiProof) {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -1099,6 +1099,14 @@ wa-popover.new-session-page__project-popover::part(body) {
   cursor: default;
 }
 
+/* The trailing actions already own the stable right edge on /new. Collapse the
+   empty effort slot while loading unless the open model menu needs its anchor. */
+.new-session-page__composer
+  .chat-controls__model-settings:not(:has(.chat-controls__model-picker[open]))
+  .chat-controls__effort-picker--reserved {
+  display: none;
+}
+
 /* Phones (and short landscape): match the chat thread's mobile inset, and
    anchor menus to the trigger row instead of their trigger — a near
    viewport-wide panel under a non-leftmost trigger would otherwise run past


### PR DESCRIPTION
Closes #130817

## What Problem This Solves

Fixes an issue where users opening `/new` would see an unexplained empty slot between the model-loading skeleton and the microphone while model metadata was pending.

## Why This Change Was Made

The `/new` composer now collapses its hidden effort-picker reservation while the model picker is closed, while preserving that reservation when the menu is open and still needs a stable anchor. This chooses the no-gap loading state instead of a second skeleton because the trailing mic/Start actions already own a fixed right edge, so the eventual effort picker can grow leftward without moving them.

## User Impact

The approved model skeleton now sits flush with the microphone during initial loading. When model metadata arrives, the reasoning/effort picker appears without shifting the microphone or Start button.

## Evidence

Rebased onto `origin/main` at `527edf8316f52791dfb61d17d9f4c3120a06ea68`; exact PR head: `46637b18e1f1c4ea192ca7cd289e8f7b0d245490`.

Desktop 1280×900, mocked Gateway with `chat.metadata` held in the loading state. Both captures were inspected locally.

Before:

![Before: reserved effort slot leaves a gap](https://github.com/user-attachments/assets/44b426ce-a601-49da-8840-47f46537d03f)

After, exact rebased head:

![After: loading skeleton sits next to the microphone](https://github.com/user-attachments/assets/e16bf964-95e6-460d-89d5-0877eaec6aff)

- Regression proof: the new browser assertion measured an 88.9 px gap on the pre-fix code and passes after the fix.
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs ui/src/e2e/new-session-page.model-catalog.e2e.test.ts --run -t 'keeps composer actions fixed while model metadata loads'` - 1 passed on the exact rebased head; attached capture inspected.
- `node_modules/.bin/oxfmt --check ui/src/e2e/new-session-page.model-catalog.e2e.test.ts ui/src/styles/new-session.css` - passed.
- `node --import tsx scripts/run-stylelint.mts ui/src/styles/new-session.css` - passed.
- Fresh Codex autoreview (`gpt-5.6-sol`, high) - clean, no actionable findings.
- Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33055679571 - green.
- `git diff --check origin/main...HEAD` - passed.

Production LOC: +8/-0. Tests: +72/-5. The production growth is the page-owned layout exception; moving the policy into shared controls would broaden behavior and add state plumbing.

AI-assisted: yes. The implementation and proof were reviewed and understood before submission.
