### PR TITLE
fix(browser): handle concurrent first-use extension pairing

### DIFF
--- a/extensions/browser/src/attached-browser-tool-runtime.ts
+++ b/extensions/browser/src/attached-browser-tool-runtime.ts
@@ -105,7 +105,6 @@ export async function createAttachedBrowserToolRuntime(
   };
   resolved.extensionRelayPorts = {};
   resolved.extensionRelayInternalTokens = {};
-  delete resolved.extensionRelayToken;
 
   const bridge = await startBrowserBridgeServer({
     resolved,

--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -2,8 +2,8 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withEnv, withTempDir } from "openclaw/plugin-sdk/test-env";
+import { describe, expect, it, vi } from "vitest";
 import type { BrowserConfig, BrowserProfileConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
 import {
@@ -15,55 +15,6 @@ import {
 import { getBrowserProfileCapabilities } from "./profile-capabilities.js";
 
 const BROWSER_HEADLESS_ENV_KEY = "OPENCLAW_BROWSER_HEADLESS";
-
-// Isolate the extension relay secret (read from stateDir/credentials) so the
-// extension-token assertions do not pick up a developer's real secret file.
-let isolatedStateDir = "";
-let openClawState: OpenClawTestState;
-beforeEach(async () => {
-  openClawState = await createOpenClawTestState({
-    layout: "state-only",
-    prefix: "openclaw-cfg-",
-  });
-  isolatedStateDir = openClawState.stateDir;
-});
-afterEach(async () => {
-  await openClawState.cleanup();
-});
-
-/** Write a relay secret into the isolated state dir's credentials directory. */
-function writeRelaySecret(token: string): void {
-  const dir = path.join(isolatedStateDir, "credentials");
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, "browser-extension-relay.secret"), `${token}\n`);
-}
-
-function withEnv<T>(env: Record<string, string | undefined>, fn: () => T): T {
-  const snapshot = new Map<string, string | undefined>();
-  for (const [key] of Object.entries(env)) {
-    snapshot.set(key, process.env[key]);
-  }
-
-  try {
-    for (const key of Object.keys(env)) {
-      const value = env[key];
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-    return fn();
-  } finally {
-    for (const [key, value] of snapshot) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
-    }
-  }
-}
 
 function resolveRequiredProfile(config: BrowserConfig, profileName: string) {
   const profile = resolveProfile(resolveBrowserConfig(config), profileName);
@@ -125,8 +76,7 @@ describe("browser config", () => {
     // Relay port sits just below the CDP allocation range (controlPort + 8).
     expect(chrome?.cdpPort).toBe(resolved.extensionRelayDefaultPort);
     expect(resolved.extensionRelayDefaultPort).toBe(resolved.controlPort + 8);
-    // No host-local relay secret exists yet (isolated state dir), so the relay
-    // cdpUrl carries no Basic credentials until pairing/startup creates one.
+    // Only a running relay supplies the process-local Basic credential.
     expect(chrome?.cdpUrl).toBe(`http://127.0.0.1:${resolved.extensionRelayDefaultPort}`);
     expect(chrome?.cdpIsLoopback).toBe(true);
   });
@@ -202,11 +152,28 @@ describe("browser config", () => {
     expect(() => resolveBrowserConfig({ profiles })).toThrow(/extension.*relay.*port/i);
   });
 
-  it("keeps the host-local relay key out of the extension cdpUrl", () => {
-    const relayKey = "a".repeat(64);
-    writeRelaySecret(relayKey);
+  it.each([
+    { name: "empty", content: "" },
+    { name: "malformed", content: "not-a-relay-key\n" },
+    { name: "valid", content: `${"a1".repeat(32)}\n` },
+  ])("normalizes config independently of a $name relay secret", async ({ content }) => {
+    await withTempDir("openclaw-config-relay-", async (dir) => {
+      const stateDir = fs.realpathSync(dir);
+      const credentials = path.join(stateDir, "credentials");
+      fs.mkdirSync(credentials, { mode: 0o700 });
+      const secretPath = path.join(credentials, "browser-extension-relay.secret");
+      withEnv({ OPENCLAW_STATE_DIR: stateDir, OPENCLAW_OAUTH_DIR: credentials }, () => {
+        const withoutSecret = resolveBrowserConfig(undefined);
+        fs.writeFileSync(secretPath, content, { flag: "wx", mode: 0o600 });
+        expect(resolveBrowserConfig(undefined)).toEqual(withoutSecret);
+        expect(fs.readFileSync(secretPath, "utf8")).toBe(content);
+      });
+    });
+  });
+
+  it("keeps the lifecycle's host-local relay key out of the extension cdpUrl", () => {
     const resolved = resolveBrowserConfig(undefined);
-    expect(resolved.extensionRelayToken).toBe(relayKey);
+    resolved.extensionRelayToken = "a1".repeat(32);
     const chrome = resolveProfile(resolved, "chrome");
     expect(chrome?.cdpUrl).toBe(`http://127.0.0.1:${resolved.extensionRelayDefaultPort}`);
 

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -36,7 +36,6 @@ import {
   DEFAULT_OPENCLAW_BROWSER_ENABLED,
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
 } from "./constants.js";
-import { resolveExtensionRelayToken } from "./extension-relay/relay-auth.js";
 import { DEFAULT_UPLOAD_DIR } from "./paths.js";
 
 export {
@@ -97,7 +96,7 @@ export type ResolvedBrowserConfig = {
   };
   /** Per-profile process-only Basic credentials for internal browser clients. */
   extensionRelayInternalTokens: Record<string, string>;
-  /** Persistent relay HMAC key (absent until pairing or relay startup creates it). */
+  /** Host-local HMAC key last adopted by the relay lifecycle, not raw config resolution. */
   extensionRelayToken?: string;
 };
 
@@ -417,9 +416,6 @@ export function resolveBrowserConfig(
 
   const headless = cfg?.headless === true;
   const headlessSource = typeof cfg?.headless === "boolean" ? "config" : "default";
-  // Host-local HMAC key (created lazily by relay startup / pairing). Null
-  // here just means the extension driver has not been used on this host yet.
-  const extensionRelayToken = resolveExtensionRelayToken() ?? undefined;
   const noSandbox = cfg?.noSandbox === true;
   const attachOnly = cfg?.attachOnly === true;
   const executablePath = normalizeExecutablePath(cfg?.executablePath);
@@ -488,7 +484,6 @@ export function resolveBrowserConfig(
       allowLegacyAuth: cfg?.extensionRelay?.allowLegacyAuth ?? true,
     },
     extensionRelayInternalTokens: {},
-    ...(extensionRelayToken ? { extensionRelayToken } : {}),
   };
 }
 

--- a/extensions/browser/src/browser/extension-pairing.test.ts
+++ b/extensions/browser/src/browser/extension-pairing.test.ts
@@ -1,4 +1,6 @@
-import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
+import fs from "node:fs";
+import path from "node:path";
+import { withEnvAsync, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import { relayTestKey } from "../../chrome-extension/relay-key.test-support.js";
 import { buildBrowserExtensionPairing } from "./extension-pairing.js";
@@ -7,6 +9,33 @@ const RELAY_KEY = relayTestKey(5);
 const ensureToken = async () => RELAY_KEY;
 
 describe("buildBrowserExtensionPairing", () => {
+  it("pairs with the first writer's key when its file is already open but empty", async () => {
+    await withTempDir("openclaw-pairing-", async (dir) => {
+      const stateDir = fs.realpathSync(dir);
+      const credentials = path.join(stateDir, "credentials");
+      fs.mkdirSync(credentials, { mode: 0o700 });
+      const secretPath = path.join(credentials, "browser-extension-relay.secret");
+      await withEnvAsync(
+        { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_OAUTH_DIR: credentials },
+        async () => {
+          const fd = fs.openSync(secretPath, "wx", 0o600);
+          try {
+            const before = fs.fstatSync(fd);
+            const pairing = buildBrowserExtensionPairing({ cfg: {}, localTransport: "gateway" });
+            fs.writeFileSync(fd, `${RELAY_KEY}\n`);
+            const result = await pairing;
+            expect(new URL(result.pairingString).hash).toBe(`#${RELAY_KEY}`);
+            expect(result.topology).toBe("local");
+            expect(fs.readFileSync(secretPath, "utf8")).toBe(`${RELAY_KEY}\n`);
+            expect(fs.statSync(secretPath)).toMatchObject({ dev: before.dev, ino: before.ino });
+          } finally {
+            fs.closeSync(fd);
+          }
+        },
+      );
+    });
+  });
+
   it("preserves the standalone host relay for local manual pairing compatibility", async () => {
     await withEnvAsync({ OPENCLAW_GATEWAY_PORT: undefined }, async () => {
       await expect(

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
@@ -7,7 +7,7 @@ import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
-import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
+import { withEnvAsync, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it } from "vitest";
 import { WebSocket, type RawData } from "ws";
 import { parsePairingString } from "../../../chrome-extension/modules/relay-core.js";
@@ -51,10 +51,41 @@ afterEach(async () => {
 });
 
 describe.sequential("local Gateway extension relay wakeup", () => {
+  it.each([
+    { name: "disabled Browser", enabled: false, driver: "extension" as const },
+    { name: "no extension profiles", enabled: true, driver: "openclaw" as const },
+  ])("leaves the relay key absent with $name", async ({ enabled, driver }) => {
+    await withTempDir("openclaw-relay-service-", async (dir) => {
+      const stateDir = await fs.realpath(dir);
+      const credentials = path.join(stateDir, "credentials");
+      const config = {
+        gateway: { auth: { mode: "token" as const, token: "gateway-integration-test" } },
+        browser: { enabled, profiles: { chrome: { driver, cdpPort: 18799 } } },
+      };
+      setRuntimeConfigSnapshot(config, config);
+      await withEnvAsync(
+        { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_OAUTH_DIR: credentials },
+        async () => {
+          try {
+            const state = await startBrowserControlServiceFromConfig();
+            expect(state !== null).toBe(enabled);
+            await expect(
+              fs.stat(path.join(credentials, "browser-extension-relay.secret")),
+            ).rejects.toMatchObject({ code: "ENOENT" });
+          } finally {
+            await stopBrowserControlService();
+          }
+        },
+      );
+    });
+  });
+
   it.each([false, true])(
     "authenticates the extension while a browser request is already waiting: %s",
     async (browserRequestAlreadyWaiting) => {
-      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-relay-wakeup-"));
+      const stateDir = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-relay-wakeup-")),
+      );
       try {
         const gatewayPort = await getFreePort();
         let relayPort = await getFreePort();
@@ -84,6 +115,7 @@ describe.sequential("local Gateway extension relay wakeup", () => {
         await withEnvAsync(
           {
             OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_OAUTH_DIR: path.join(stateDir, "credentials"),
             OPENCLAW_GATEWAY_PORT: String(gatewayPort),
           },
           async () => {
@@ -106,7 +138,6 @@ describe.sequential("local Gateway extension relay wakeup", () => {
               const pairing = await buildBrowserExtensionPairing({
                 cfg: config,
                 localTransport: "gateway",
-                ensureToken: async () => RELAY_KEY,
               });
               expect(pairing).toMatchObject({ relayPort, topology: "local" });
               const parsed = parsePairingString(pairing.pairingString);

--- a/extensions/browser/src/browser/extension-relay/relay-auth.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-auth.test.ts
@@ -3,66 +3,115 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  ensureExtensionRelayToken,
-  readExtensionRelayToken,
-  resolveExtensionRelayToken,
-} from "./relay-auth.js";
+import { ensureExtensionRelayToken, readExtensionRelayToken } from "./relay-auth.js";
 
 let stateDir = "";
-const prevStateDir = process.env.OPENCLAW_STATE_DIR;
+let secretPath = "";
+let env: NodeJS.ProcessEnv;
 
 beforeEach(() => {
   stateDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-relay-auth-")));
-  process.env.OPENCLAW_STATE_DIR = stateDir;
+  secretPath = path.join(stateDir, "credentials", "browser-extension-relay.secret");
+  env = { OPENCLAW_STATE_DIR: stateDir };
 });
 afterEach(() => {
-  if (prevStateDir === undefined) {
-    delete process.env.OPENCLAW_STATE_DIR;
-  } else {
-    process.env.OPENCLAW_STATE_DIR = prevStateDir;
-  }
   fs.rmSync(stateDir, { recursive: true, force: true });
 });
 
 describe("extension relay host-local secret", () => {
   it("returns null before the secret is created", () => {
-    expect(readExtensionRelayToken()).toBeNull();
-    expect(resolveExtensionRelayToken()).toBeNull();
+    expect(readExtensionRelayToken(env)).toBeNull();
   });
 
   it("creates a 64-hex secret on ensure and persists it privately", async () => {
-    const token = await ensureExtensionRelayToken();
+    const token = await ensureExtensionRelayToken(env);
     expect(token).toMatch(/^[0-9a-f]{64}$/);
-    const secretPath = path.join(stateDir, "credentials", "browser-extension-relay.secret");
     expect(fs.existsSync(secretPath)).toBe(true);
     if (process.platform !== "win32") {
       expect(fs.statSync(secretPath).mode & 0o777).toBe(0o600);
     }
   });
 
-  it("is stable across calls (does not rotate on read)", async () => {
-    const first = await ensureExtensionRelayToken();
-    await expect(ensureExtensionRelayToken()).resolves.toBe(first);
-    expect(readExtensionRelayToken()).toBe(first);
+  it.each([
+    { name: "private directory", mode: 0o700, symlink: false },
+    { name: "0750 directory", mode: 0o750, symlink: false },
+    { name: "symlinked directory", mode: 0o750, symlink: true },
+  ])("reuses a valid key without mutating its $name", async ({ mode, symlink }) => {
+    const first = await ensureExtensionRelayToken(env);
+    const credentials = path.dirname(secretPath);
+    if (process.platform !== "win32") {
+      fs.chmodSync(credentials, mode);
+    }
+    if (symlink) {
+      const target = path.join(stateDir, "credential-target");
+      fs.renameSync(credentials, target);
+      fs.symlinkSync(target, credentials, "junction");
+    }
+    const before = fs.statSync(secretPath);
+    const bytes = fs.readFileSync(secretPath);
+    await expect(ensureExtensionRelayToken(env)).resolves.toBe(first);
+    expect(readExtensionRelayToken(env)).toBe(first);
+    expect(fs.readFileSync(secretPath)).toEqual(bytes);
+    expect(fs.statSync(secretPath)).toMatchObject({
+      dev: before.dev,
+      ino: before.ino,
+      mode: before.mode,
+    });
+    expect(fs.lstatSync(credentials).isSymbolicLink()).toBe(symlink);
+    if (process.platform !== "win32") {
+      expect(fs.statSync(credentials).mode & 0o777).toBe(mode);
+    }
   });
 
-  it("adopts the first writer's token under concurrent creation", async () => {
-    const [first, second] = await Promise.all([
-      ensureExtensionRelayToken(),
-      ensureExtensionRelayToken(),
-    ]);
-    expect(second).toBe(first);
-    expect(readExtensionRelayToken()).toBe(first);
+  it.each([
+    { name: "simultaneous first callers", writerStarted: false },
+    { name: "a writer already in progress", writerStarted: true },
+  ])("adopts the first writer's token with $name", async ({ writerStarted }) => {
+    const writerToken = "a1".repeat(32);
+    fs.mkdirSync(path.dirname(secretPath), { mode: 0o700 });
+    const fd = writerStarted ? fs.openSync(secretPath, "wx", 0o600) : undefined;
+    try {
+      const before = fd === undefined ? undefined : fs.fstatSync(fd);
+      const tokens = Promise.all([ensureExtensionRelayToken(env), ensureExtensionRelayToken(env)]);
+      // Hold the first writer's empty file until both callers have started.
+      if (fd !== undefined) {
+        fs.writeFileSync(fd, `${writerToken}\n`);
+      }
+      const [first, second] = await tokens;
+      expect(second).toBe(first);
+      expect(readExtensionRelayToken(env)).toBe(first);
+      if (before) {
+        expect(first).toBe(writerToken);
+        expect(fs.readFileSync(secretPath, "utf8")).toBe(`${writerToken}\n`);
+        expect(fs.statSync(secretPath)).toMatchObject({ dev: before.dev, ino: before.ino });
+      }
+    } finally {
+      if (fd !== undefined) {
+        fs.closeSync(fd);
+      }
+    }
+  });
+
+  it.each([
+    { name: "empty", content: "" },
+    { name: "whitespace", content: " \n\t" },
+    { name: "malformed", content: "not-a-relay-token\n" },
+  ])("rejects a persistent $name secret without replacing it", async ({ content }) => {
+    fs.mkdirSync(path.dirname(secretPath), { mode: 0o700 });
+    fs.writeFileSync(secretPath, content, { flag: "wx", mode: 0o600 });
+    const before = fs.statSync(secretPath);
+    await expect(ensureExtensionRelayToken(env)).rejects.toThrow();
+    expect(fs.readFileSync(secretPath, "utf8")).toBe(content);
+    expect(fs.statSync(secretPath)).toMatchObject({ dev: before.dev, ino: before.ino });
   });
 
   it("gives different hosts (state dirs) different secrets", async () => {
-    const a = await ensureExtensionRelayToken();
+    const a = await ensureExtensionRelayToken(env);
     const otherDir = fs.realpathSync(
       fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-relay-auth-2-")),
     );
     try {
-      const b = await ensureExtensionRelayToken({ ...process.env, OPENCLAW_STATE_DIR: otherDir });
+      const b = await ensureExtensionRelayToken({ OPENCLAW_STATE_DIR: otherDir });
       expect(b).not.toBe(a);
     } finally {
       fs.rmSync(otherDir, { recursive: true, force: true });

--- a/extensions/browser/src/browser/extension-relay/relay-auth.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-auth.test.ts
@@ -64,12 +64,20 @@ describe("extension relay host-local secret", () => {
   });
 
   it.each([
-    { name: "simultaneous first callers", writerStarted: false },
-    { name: "a writer already in progress", writerStarted: true },
-  ])("adopts the first writer's token with $name", async ({ writerStarted }) => {
+    { name: "simultaneous first callers", writerStarted: false, symlink: false },
+    { name: "a writer already in progress", writerStarted: true, symlink: false },
+    { name: "a writer in progress through a directory alias", writerStarted: true, symlink: true },
+  ])("adopts the first writer's token with $name", async ({ writerStarted, symlink }) => {
     const writerToken = "a1".repeat(32);
-    fs.mkdirSync(path.dirname(secretPath), { mode: 0o700 });
-    const fd = writerStarted ? fs.openSync(secretPath, "wx", 0o600) : undefined;
+    const credentials = path.dirname(secretPath);
+    const target = symlink ? path.join(stateDir, "credential-target") : credentials;
+    fs.mkdirSync(target, { mode: 0o700 });
+    if (symlink) {
+      fs.symlinkSync(target, credentials, "junction");
+    }
+    const fd = writerStarted
+      ? fs.openSync(path.join(target, path.basename(secretPath)), "wx", 0o600)
+      : undefined;
     try {
       const before = fd === undefined ? undefined : fs.fstatSync(fd);
       const tokens = Promise.all([ensureExtensionRelayToken(env), ensureExtensionRelayToken(env)]);
@@ -80,6 +88,7 @@ describe("extension relay host-local secret", () => {
       const [first, second] = await tokens;
       expect(second).toBe(first);
       expect(readExtensionRelayToken(env)).toBe(first);
+      expect(fs.lstatSync(credentials).isSymbolicLink()).toBe(symlink);
       if (before) {
         expect(first).toBe(writerToken);
         expect(fs.readFileSync(secretPath, "utf8")).toBe(`${writerToken}\n`);
@@ -92,6 +101,15 @@ describe("extension relay host-local secret", () => {
     }
   });
 
+  it("rejects creating a missing key through a symlinked credential directory", async () => {
+    const target = path.join(stateDir, "credential-target");
+    fs.mkdirSync(target, { mode: 0o700 });
+    fs.symlinkSync(target, path.dirname(secretPath), "junction");
+    await expect(ensureExtensionRelayToken(env)).rejects.toThrow("must not be a symlink");
+    expect(fs.readdirSync(target)).toEqual([]);
+    expect(fs.lstatSync(path.dirname(secretPath)).isSymbolicLink()).toBe(true);
+  });
+
   it.each([
     { name: "empty", content: "" },
     { name: "whitespace", content: " \n\t" },
@@ -100,7 +118,9 @@ describe("extension relay host-local secret", () => {
     fs.mkdirSync(path.dirname(secretPath), { mode: 0o700 });
     fs.writeFileSync(secretPath, content, { flag: "wx", mode: 0o600 });
     const before = fs.statSync(secretPath);
-    await expect(ensureExtensionRelayToken(env)).rejects.toThrow();
+    await expect(ensureExtensionRelayToken(env)).rejects.toMatchObject({
+      cause: expect.any(Error),
+    });
     expect(fs.readFileSync(secretPath, "utf8")).toBe(content);
     expect(fs.statSync(secretPath)).toMatchObject({ dev: before.dev, ino: before.ino });
   });

--- a/extensions/browser/src/browser/extension-relay/relay-auth.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-auth.ts
@@ -9,11 +9,7 @@
  */
 import crypto from "node:crypto";
 import path from "node:path";
-import {
-  createSecretFileAtomic,
-  readSecretFile,
-  tryReadSecretFileSync,
-} from "openclaw/plugin-sdk/secret-file";
+import { createSecretFileAtomic, tryReadSecretFileSync } from "openclaw/plugin-sdk/secret-file";
 import { resolveOAuthDir } from "openclaw/plugin-sdk/state-paths";
 
 const RELAY_SECRET_FILE = "browser-extension-relay.secret";
@@ -53,44 +49,38 @@ export async function ensureExtensionRelayToken(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string> {
   const secretPath = resolveExtensionRelaySecretPath(env);
-  const existing = readExtensionRelayToken(env);
-  if (existing) {
-    return existing;
-  }
-  const token = crypto.randomBytes(32).toString("hex");
-  try {
-    await createSecretFileAtomic({
-      rootDir: path.dirname(secretPath),
-      filePath: secretPath,
-      content: `${token}\n`,
-    });
-    return token;
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "secret-exists") {
-      throw err;
-    }
-    // Another process created it first; its exclusive async write may still be
-    // finishing after the final name appears, so adopt it with a bounded reread.
-    for (let attempt = 0; attempt < RELAY_SECRET_REREAD_ATTEMPTS; attempt += 1) {
-      try {
-        const winner = normalizeToken(
-          await readSecretFile(secretPath, "browser extension relay secret"),
-        );
-        if (winner) {
-          return winner;
-        }
-      } catch {
-        // Retry only inside the bounded first-writer handoff window.
+  let createError: unknown;
+  for (let attempt = 0; attempt < RELAY_SECRET_REREAD_ATTEMPTS; attempt += 1) {
+    try {
+      const winner = readExtensionRelayToken(env);
+      if (winner) {
+        return winner;
       }
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, RELAY_SECRET_REREAD_DELAY_MS);
-      });
+    } catch {
+      // An exclusive writer can expose an empty final file before ensure starts;
+      // even the first read belongs inside this bounded handoff.
     }
-    throw new Error("extension relay secret exists but is unreadable/malformed", { cause: err });
+    if (attempt === 0) {
+      const token = crypto.randomBytes(32).toString("hex");
+      try {
+        await createSecretFileAtomic({
+          rootDir: path.dirname(secretPath),
+          filePath: secretPath,
+          content: `${token}\n`,
+        });
+        return token;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== "secret-exists") {
+          throw err;
+        }
+        createError = err;
+      }
+    }
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, RELAY_SECRET_REREAD_DELAY_MS);
+    });
   }
-}
-
-/** Resolve the relay token for config (read-only; null until first ensured). */
-export function resolveExtensionRelayToken(env: NodeJS.ProcessEnv = process.env): string | null {
-  return readExtensionRelayToken(env);
+  throw new Error("extension relay secret exists but is unreadable/malformed", {
+    cause: createError,
+  });
 }

--- a/extensions/browser/src/browser/extension-relay/relay-auth.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-auth.ts
@@ -49,18 +49,21 @@ export async function ensureExtensionRelayToken(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string> {
   const secretPath = resolveExtensionRelaySecretPath(env);
-  let createError: unknown;
+  let lastError: unknown;
   for (let attempt = 0; attempt < RELAY_SECRET_REREAD_ATTEMPTS; attempt += 1) {
+    let canCreate = false;
     try {
       const winner = readExtensionRelayToken(env);
       if (winner) {
         return winner;
       }
-    } catch {
+      canCreate = attempt === 0;
+    } catch (err) {
       // An exclusive writer can expose an empty final file before ensure starts;
-      // even the first read belongs inside this bounded handoff.
+      // retry adoption without invoking the stricter credential creation guards.
+      lastError = err;
     }
-    if (attempt === 0) {
+    if (canCreate) {
       const token = crypto.randomBytes(32).toString("hex");
       try {
         await createSecretFileAtomic({
@@ -73,7 +76,7 @@ export async function ensureExtensionRelayToken(
         if ((err as NodeJS.ErrnoException).code !== "secret-exists") {
           throw err;
         }
-        createError = err;
+        lastError = err;
       }
     }
     await new Promise<void>((resolve) => {
@@ -81,6 +84,6 @@ export async function ensureExtensionRelayToken(
     });
   }
   throw new Error("extension relay secret exists but is unreadable/malformed", {
-    cause: createError,
+    cause: lastError,
   });
 }

--- a/extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
 import { resolveProfile, type ResolvedBrowserConfig } from "../config.js";
+import { refreshResolvedBrowserConfigFromDisk } from "../resolved-config-refresh.js";
 import {
   beginProfileTransition,
   getOrCreateProfileRuntime,
@@ -10,12 +11,15 @@ import {
 import type { BrowserServerState } from "../server-context.types.js";
 import type { ExtensionRelayHandle } from "./relay-server.js";
 
-const readExtensionRelayTokenMock = vi.fn();
 const ensureExtensionRelayTokenMock = vi.fn();
 vi.mock("./relay-auth.js", () => ({
-  readExtensionRelayToken: () => readExtensionRelayTokenMock(),
   ensureExtensionRelayToken: () => ensureExtensionRelayTokenMock(),
-  resolveExtensionRelayToken: () => readExtensionRelayTokenMock(),
+}));
+
+vi.mock("../config-refresh-source.js", () => ({
+  loadBrowserConfigForRuntimeRefresh: () => ({
+    browser: { profiles: { chrome: { driver: "extension", cdpPort: RELAY_PORT } } },
+  }),
 }));
 
 const startExtensionRelayServerMock = vi.fn();
@@ -82,8 +86,7 @@ function deferred() {
 describe("extension relay lifecycle", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    readExtensionRelayTokenMock.mockReturnValue(ROTATED_TOKEN);
-    ensureExtensionRelayTokenMock.mockReturnValue(ROTATED_TOKEN);
+    ensureExtensionRelayTokenMock.mockResolvedValue(ROTATED_TOKEN);
     startExtensionRelayServerMock.mockImplementation(async ({ port, token, allowLegacyAuth }) => ({
       port,
       token,
@@ -139,6 +142,20 @@ describe("extension relay lifecycle", () => {
     expect(startExtensionRelayServerMock).toHaveBeenCalledOnce();
   });
 
+  it("retains the adopted key when config refreshes during relay startup", async () => {
+    const { profile, state } = createState(OLD_TOKEN);
+    const replacement = createHandle(ROTATED_TOKEN);
+    startExtensionRelayServerMock.mockImplementationOnce(async () => {
+      refreshResolvedBrowserConfigFromDisk({ current: state, refreshConfigFromDisk: true });
+      return replacement;
+    });
+
+    await expect(ensureExtensionRelayForProfile(state, profile)).resolves.toBe(replacement);
+    expect(state.resolved.extensionRelayToken).toBe(ROTATED_TOKEN);
+    expect(state.extensionRelays?.get(PROFILE_NAME)).toBe(replacement);
+    expect(replacement.close).not.toHaveBeenCalled();
+  });
+
   it("coalesces concurrent rebinds to one exact relay handle", async () => {
     const oldRelay = createHandle(OLD_TOKEN);
     const { profile, state } = createState(OLD_TOKEN, oldRelay);
@@ -192,7 +209,7 @@ describe("extension relay lifecycle", () => {
       run: async (signal) => await ensureExtensionRelayForProfile(state, profile, signal),
     });
     void sibling.catch(() => {});
-    await expect.poll(() => readExtensionRelayTokenMock.mock.calls.length).toBe(2);
+    await expect.poll(() => ensureExtensionRelayTokenMock.mock.calls.length).toBe(2);
     firstController.abort(new Error("first browser request cancelled"));
     releaseStart.resolve();
 
@@ -241,7 +258,7 @@ describe("extension relay lifecycle", () => {
     void sibling.catch((error: unknown) => {
       siblingError = error;
     });
-    await expect.poll(() => readExtensionRelayTokenMock.mock.calls.length).toBe(2);
+    await expect.poll(() => ensureExtensionRelayTokenMock.mock.calls.length).toBe(2);
     siblingController.abort(new Error("sibling browser request cancelled"));
     try {
       await expect

--- a/extensions/browser/src/browser/extension-relay/relay-lifecycle.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-lifecycle.ts
@@ -76,8 +76,8 @@ export async function ensureExtensionRelayForProfile(
     }
     // The host-local HMAC key can rotate while Browser control stays up.
     // Resolve one canonical desired profile after adopting the live key.
-    const { ensureExtensionRelayToken, readExtensionRelayToken } = await import("./relay-auth.js");
-    const token = readExtensionRelayToken() ?? (await ensureExtensionRelayToken());
+    const { ensureExtensionRelayToken } = await import("./relay-auth.js");
+    const token = await ensureExtensionRelayToken();
     if (state.resolved.extensionRelayToken !== token) {
       state.resolved = { ...state.resolved, extensionRelayToken: token };
     }

--- a/extensions/browser/src/browser/resolved-config-refresh.ts
+++ b/extensions/browser/src/browser/resolved-config-refresh.ts
@@ -117,6 +117,8 @@ function applyResolvedConfig(
     // Only an exact live relay owns its process-local CDP credential; stale
     // config snapshots must never resurrect closed or replaced credentials.
     extensionRelayInternalTokens,
+    // Config refresh must not erase the lifecycle's key while a relay is starting.
+    extensionRelayToken: current.resolved.extensionRelayToken,
   };
   for (const [name, runtime] of current.profiles) {
     const actor = getProfileLifecycle(runtime);

--- a/extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts
+++ b/extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts
@@ -318,10 +318,9 @@ describe("server-context hot-reload profiles", () => {
   it("keeps only exact live relay credentials stable across repeated profile refreshes", () => {
     const { state, runtime, relay } = createExtensionRelayFixture();
     const expectedUrl = runtime.profile.cdpUrl;
-    const freshPersistentKey = resolveBrowserConfig(buildConfig().browser).extensionRelayToken;
     state.resolved = {
       ...state.resolved,
-      extensionRelayToken: "stale-persistent-key",
+      extensionRelayToken: relay.token,
       extensionRelayInternalTokens: {
         chrome: relay.internalToken,
         orphaned: "closed-relay-credential",
@@ -340,7 +339,7 @@ describe("server-context hot-reload profiles", () => {
       expect(state.resolved.extensionRelayInternalTokens).toEqual({
         chrome: relay.internalToken,
       });
-      expect(state.resolved.extensionRelayToken).toBe(freshPersistentKey);
+      expect(state.resolved.extensionRelayToken).toBe(relay.token);
       expect(getProfileLifecycle(runtime).configRevision).toBe(0);
       expect(runtime.lastTargetId).toBe("shared-tab");
     }

--- a/extensions/browser/src/control-service.ts
+++ b/extensions/browser/src/control-service.ts
@@ -31,7 +31,7 @@ async function startBrowserControlServiceUnlocked(): Promise<BrowserServerState 
   if (!isDefaultBrowserPluginEnabled(browserCfg)) {
     return null;
   }
-  let resolved = resolveBrowserConfig(browserCfg.browser, browserCfg);
+  const resolved = resolveBrowserConfig(browserCfg.browser, browserCfg);
   if (!resolved.enabled) {
     return null;
   }
@@ -52,8 +52,6 @@ async function startBrowserControlServiceUnlocked(): Promise<BrowserServerState 
   if (hasExtensionProfiles) {
     const { ensureExtensionRelayToken } = await import("./browser/extension-relay/relay-auth.js");
     await ensureExtensionRelayToken();
-    const refreshed = loadBrowserConfigForRuntimeRefresh();
-    resolved = resolveBrowserConfig(refreshed.browser, refreshed);
   }
 
   const state = await ensureBrowserControlRuntime({


### PR DESCRIPTION
**Current proof status:** Maintainer inspection is complete for `b37b80f52190195cc48ee7a5fb28f9448f09d742`; the focused repair is approved for landing through the required native gates. Updated-head CI and the built public-bin pairing smoke pass. The failed developer-launcher smoke remains separately recorded below.

Closes #130784 — browser pairing fails while another process initializes the relay key.

Related: #128379 — standalone extension-relay feature; this independently fixes the pre-existing race on main and does not add or modify that feature.

**Runtime proof update:** The new candidate's built public CLI entrypoint passes pairing in 11,093 ms within the unchanged 30-second budget. The failed developer source-launcher smoke remains recorded below as a separate tooling follow-up; it is not relabeled as passing.

<details>
<summary>Additional instructions</summary>

This is a same-repository branch, so maintainers can take over and update it.

</details>

## What Problem This Solves

Fixes an issue where users pairing the browser extension or starting its relay could receive an empty-secret-file error when another local process had created the shared key file but was still writing it. Pairing could also fail during browser config resolution before reaching the token-creation owner.

## Why This Change Was Made

The token owner now puts the first read and all subsequent reads inside one bounded first-writer handoff, retaining exclusive creation and the same canonical credential reader. Browser config normalization no longer reads persistent credentials; the relay lifecycle owns the adopted key and carries that fact across config refreshes.

A valid initial read still returns without invoking creation, preserving existing credential-directory permissions and layouts. Simply removing that fast read would unnecessarily chmod existing directories or reject previously accepted symlinked credential directories. The alternate reread path, private forwarding alias, redundant config reload, and now-unneeded attached-runtime cleanup are removed.

## User Impact

Concurrent first-use initialization and pairing can adopt the first writer's completed key instead of failing immediately. Existing valid keys remain stable, and persistent empty, whitespace, or malformed credentials still fail without being replaced. No configuration option, dependency, database schema, authentication policy, or wire protocol is added or changed.

This is only the race repair. It does not publish the standalone daemon or native wake-up work in #128379.

## Evidence

### Original failing and passing reproductions

On source base `19762af88e31f1502b6fe969514035142dd25087` with installed `@openclaw/fs-safe` `0.5.6`, a separate synthetic writer exclusively opened the final key filename, signaled that it was still empty, and completed its write after the reader started. Before the repair, both direct initialization and real pairing rejected in approximately 1 ms. The new owner regression failed at the unprotected read; the pairing regression failed at the earlier config read.

The unchanged subprocess reproductions pass after the repair and retain the writer's inode and final key. Tests use real descriptors and the actual SDK, not a mocked secret-file reader or a new production test seam. No operator credentials, configuration, or Gateway services were accessed or changed.

### Directory-alias handoff completion

Current head: `b37b80f52190195cc48ee7a5fb28f9448f09d742`, retaining base `fa16a4f80ea3bb1bdd68b3c0a13a6ca24b366190` without another rebase. The original commit remains intact; this is a two-file follow-up, so old-head CI cannot substitute for new-head CI.

An existing credential-directory alias exposed one incomplete case: when the initial read threw while the writer's real file was empty, attempt zero still tried creation. The creation guard correctly refused the symlinked root, preventing adoption even after the writer finished. Creation is now enabled only after the first canonical read completes successfully with no valid token. A thrown read stays in validated adoption; the existing create guard remains unchanged.

The existing real-descriptor concurrency table now includes a writer in progress through a directory alias. On prior source `5e999c7`, this case failed with the expected symlink-root error (one failed, twelve passed). After the fix all thirteen owner tests pass. A new negative test confirms a missing key is not created through the alias; persistent-invalid tests also verify a retained error cause. No mocks or production test seam were added.

On the exact source committed as this head:

- Combined eleven-file owner/config/pairing/lifecycle/refresh/service/CLI/gateway and secret-file/auth sibling run: **184 passed, one Windows-only skip**, 32.17 seconds.
- The unchanged independent alias-writer reproduction changed from `adopted=false` to `adopted=true`, preserving inode, final key, and alias. Original independent owner/pairing probes also pass in **36 ms / 37 ms**, preserving inode and final key.
- Both plugin production/test type checks, targeted lint, two-file formatting, and `git diff --check` passed.
- Fresh isolated Codex autoreview of the follow-up: **no actionable P0 findings**, with the owner/caller and directly inspected fs-safe contracts supplied. The reviewer did not independently run tests.
- After commit, **`pnpm build:ci-artifacts` passed in 2m32s**. This canonical profile builds runtime/CLI artifacts, scoped SDK declarations and exports, assets/UI, native control-plane loads, and startup metadata. `dist/build-info.json` matches this full head. Full global declaration emission was not repeated for this private control-flow change with unchanged signatures.
- The unchanged isolated built-bin harness passed on this exact build/head with a fresh synthetic key, no profiling/cache/security overrides, and the same **30-second** bound:

```json
{
  "proof": "built application public bin; not the pnpm source launcher",
  "command": "node openclaw.mjs browser extension pair --json",
  "nodeVersion": "v26.7.0",
  "head": "b37b80f52190195cc48ee7a5fb28f9448f09d742",
  "buildCommit": "b37b80f52190195cc48ee7a5fb28f9448f09d742",
  "timeoutSeconds": 30,
  "timedOut": false,
  "exitCode": 0,
  "elapsedMs": 11093,
  "returnedPairing": true,
  "paired": true,
  "sameInode": true,
  "finalTokenUnchanged": true,
  "fileModeUnchanged": true
}
```

The full 25-check local gate and five doctor guard tests below belong to the original head only. For this bounded follow-up, the canonical changed-file classifier was inspected; production/test types, targeted lint, formatting, regressions, and runtime build were rerun locally. Updated-head hosted CI supplied the global gates. No assertion, timeout, or gate was weakened.

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay/relay-auth.test.ts extensions/browser/src/browser/config.test.ts extensions/browser/src/browser/extension-pairing.test.ts extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts extensions/browser/src/browser/control-service.plugin-disabled.test.ts extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts extensions/browser/src/attached-browser-tool-runtime.test.ts extensions/browser/src/cli/browser-cli-extension.test.ts src/infra/secret-file.test.ts extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts --maxWorkers=1 --no-file-parallelism
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/browser/src/browser/extension-relay/relay-auth.ts extensions/browser/src/browser/extension-relay/relay-auth.test.ts
pnpm build:ci-artifacts
```

The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/130832#issuecomment-5436671616) requested built pairing proof and direct fs-safe confirmation. Built-bin evidence is above; installed `@openclaw/fs-safe` 0.5.6 was directly inspected: `dist/secret-file.js` rejects empty contents, treats only absence as missing, and forbids a symlink creation root; `dist/pinned-write.js:117-145` exclusively opens the final name before writing. Both requests are addressed without weakening that dependency contract. The maintainer independently inspected the alias refinement and reran its reproduction before approving native landing.

Exact-head [CI run 33058047739](https://github.com/openclaw/openclaw/actions/runs/33058047739) passed on attempt 1 at `b37b80f52190195cc48ee7a5fb28f9448f09d742`: 30 successful jobs and 21 intentional skips. Required [`openclaw/ci-gate` job 98471251243](https://github.com/openclaw/openclaw/actions/runs/33058047739/job/98471251243) passed. `node scripts/watch-pr-ci.mjs 130832 b37b80f52190195cc48ee7a5fb28f9448f09d742` exited 0 with `GREEN`; early failure-state rollups were cancelled label/dispatch automation, not failures in this CI run. No retry or gate bypass was used.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/130832#issuecomment-5436671616), reviewed at 09:25 UTC on this exact `b37b80f5` head, reports no correctness or security findings and accepts the recorded built-application proof. Its only rank-up move is completion of exact-head checks; CI run 33058047739 and required gate 98471251243 are now successful. The maintainer independently inspected this head and approved native landing. The bot's separate help probe used an unbuilt source tree missing `dist/entry`; it does not supersede the observed exact-build pairing result. No redundant re-review was requested.

### Original candidate verification (superseded head)

Original candidate: `5e999c77c0d76711bfeaac6b1d9595a0134d7b38` on refreshed base `fa16a4f80ea3bb1bdd68b3c0a13a6ca24b366190`.

The rebase was conflict-free and patch-identical: `git range-diff` reports equality, with stable patch ID `2af913b5aa5e85b9d2b72a21171147c0c61d8762` before and after. The browser source and secret-file owner did not change in the base refresh. All build/test/check results below were rerun on this exact candidate; the pre-commit review applies to the unchanged patch.

- `pnpm build`: **passed**, 18m 13s. Includes all nine unified bundle invocations, native loading of 48 plugin control-plane modules, CLI bootstrap import guard, SDK exports, UI size budgets, and startup metadata. No `INEFFECTIVE_DYNAMIC_IMPORT` warning.
- Browser owner/config/pairing/lifecycle/refresh/service/CLI boundary run: **146 tests passed, one Windows-only skip** across nine files.
- Secret-file and real relay-authentication sibling run: **36 tests passed**.
- Full changed-file gate: **all 25 checks passed**, about 25 minutes; its **five doctor-contract guard tests passed**. Combined with the two focused runs, this is **187 passing tests and one Windows-only skip**. No gates, assertions, or limits were weakened.
- Pre-commit Codex autoreview of the unchanged patch: no actionable findings at its configured **P0** threshold. This is not a claim about a broader review threshold.
- Unchanged subprocess reproductions: direct initialization adopted the first writer's key in **37 ms**; real pairing completed in **38 ms**. Both preserved the inode and final bytes.
- `git diff --check origin/main...HEAD`: passed.

```bash
node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay/relay-auth.test.ts extensions/browser/src/browser/config.test.ts extensions/browser/src/browser/extension-pairing.test.ts extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts extensions/browser/src/browser/server-context.hot-reload-profiles.test.ts extensions/browser/src/browser/control-service.plugin-disabled.test.ts extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts extensions/browser/src/attached-browser-tool-runtime.test.ts extensions/browser/src/cli/browser-cli-extension.test.ts --maxWorkers=1 --no-file-parallelism
```

```bash
node scripts/run-vitest.mjs src/infra/secret-file.test.ts extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts --maxWorkers=1 --no-file-parallelism
```

```bash
pnpm build
```

```bash
node scripts/check-changed.mjs --base origin/main --timed
```

<details>
<summary>All 25 candidate check results</summary>

All passed: conflict markers; max-lines ratchet; assertion-safety ratchet; changelog attributions; doctor deprecation registry; guarded plugin wildcard re-exports; plugin-SDK wildcard re-exports; duplicate-scan coverage; coercion-helper declarations; dependency pins; changed-file formatting; doctor declaration/closure tests; deprecated API usage; plugin boundaries; package patches; dead exports; warning-only test-temp report; plugin production types; plugin test types; both changed-file lint batches; database-first legacy stores; media-download helpers; runtime-sidecar loaders; runtime import cycles (**zero cycles**).

The warning-only temp report flags an existing `mkdtemp` fixture now wrapped in `realpath`. This is not a new directory lifetime; its existing `finally` cleanup remains.

</details>

### Original candidate built application proof and developer-launcher follow-up

The results in this section belong to `5e999c77c0d76711bfeaac6b1d9595a0134d7b38`; they are preserved as historical evidence, not new-head proof.

The initial smoke used `pnpm openclaw browser extension pair --json`, which starts the TypeScript developer source runner before the built application. With isolated home, state, config, and credentials directories and a synthetic preexisting key, its fixed **30-second** budget expired without pairing JSON. Only the owned process group was terminated. That original result remains a failure; no timeout increase or warmed retry was used.

```json
{
  "command": "pnpm openclaw browser extension pair --json",
  "head": "5e999c77c0d76711bfeaac6b1d9595a0134d7b38",
  "timeoutSeconds": 30,
  "timedOut": true,
  "exitCode": 143,
  "elapsedMs": 30302,
  "returnedPairing": false,
  "paired": false,
  "sameInode": true,
  "finalTokenUnchanged": true
}
```

One separate instrumented diagnostic of that same command and unchanged budget expired **before the built CLI launched**. It observed 17.70 seconds of sampled wall time in tsx transform-cache directory enumeration and 3.58 seconds in source-runner artifact checks. No plugin command registration or relay code ran. Those measurements attribute the diagnostic only, not the uninstrumented run's exact time distribution.

The package's public `bin` is `openclaw.mjs`; `scripts/run-node.mts:1234-1235` invokes that same file after developer-runner preparation. I inspected both entrypoints and verified that `dist/build-info.json` names this exact candidate. A fresh isolated smoke then exercised the real built application through its public bin, with a new random synthetic key, no profiling/cache/security overrides, and the same **30-second** bound:

```json
{
  "command": "node openclaw.mjs browser extension pair --json",
  "nodeVersion": "v26.7.0",
  "head": "5e999c77c0d76711bfeaac6b1d9595a0134d7b38",
  "buildCommit": "5e999c77c0d76711bfeaac6b1d9595a0134d7b38",
  "timeoutSeconds": 30,
  "timedOut": false,
  "exitCode": 0,
  "elapsedMs": 26109,
  "returnedPairing": true,
  "paired": true,
  "sameInode": true,
  "finalTokenUnchanged": true,
  "fileModeUnchanged": true
}
```

This supplied the original candidate's built-application proof rather than substituting source tests or green CI for it. It is not an npm-install or live-Chrome-profile claim. The application entrypoint and all credential validation remain unchanged; no application path or security check was bypassed.

**Named follow-up: developer CLI pre-launch cache-index latency.** The failed `pnpm` source-launcher smoke remains open tooling work, separately recorded for investigation. No shared caches were deleted, dependencies changed, or timeouts raised. The inspected launcher/dependency paths are outside this PR's unchanged 12-file browser-plugin scope.

Exact-head hosted [CI run 33054205774](https://github.com/openclaw/openclaw/actions/runs/33054205774) passed on its first non-draft attempt; required `openclaw/ci-gate` [job 98458292604](https://github.com/openclaw/openclaw/actions/runs/33054205774/job/98458292604) passed. The earlier draft-triggered run was skipped.

### Scope and contracts

Current full PR: production **+38/-51 (net -13)**; tests **+212/-100 (net +112)** across the same 12 files. The two-file follow-up is production **+9/-6 (net +3)** and tests **+26/-6 (net +20)**. The iteration-local creation decision records the successful first read inside the existing owner loop; it adds no helper or alternate credential path. The loop remains bounded to 50 attempts with a 10 ms delay. Only a successful first read with no valid token may enable exclusive creation; thrown reads only retry adoption, and other write failures propagate. Terminal failures retain the underlying read/create error. All adoption attempts use `readExtensionRelayToken`, so validation stays at its existing owner rather than being bypassed by a separate read path.

The broader standalone-relay feature and its active worktree remain separate. The regressions cover actual isolated source pairing and loopback protocol flows. No real Chrome UI or live operator Gateway proof is claimed. AI-assisted implementation and review; no agent transcripts or credential-bearing logs are included.
