### PR TITLE
fix(ui): align task progress and goal chevrons

### DIFF
--- a/ui/src/e2e/board-split-transcript.e2e.test.ts
+++ b/ui/src/e2e/board-split-transcript.e2e.test.ts
@@ -256,11 +256,11 @@ describeControlUiE2e("Board split transcript restore", () => {
       expect(
         frame.rowGap,
         `first frame width=${frame.width}px; assistant-to-user gap=${frame.assistantUserGap}px`,
-      ).toBeGreaterThanOrEqual(0);
+      ).toBeGreaterThanOrEqual(-0.01);
       expect(
         frame.assistantUserGap,
         `assistant text overlaps the user bubble at width=${frame.width}px`,
-      ).toBeGreaterThanOrEqual(0);
+      ).toBeGreaterThanOrEqual(-0.01);
     } finally {
       contexts.delete(context);
       await context.close();

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -4191,17 +4191,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           trailingCenterDelta:
             iconCenter(".session-progress-card__summary-chevron svg") -
             iconCenter(".agent-chat__goal-expand svg"),
-          trailingControlWidthDelta:
-            rect(".session-progress-card__summary-chevron").width -
-            rect(".agent-chat__goal-expand").width,
-          trailingPaddingDelta:
-            Number.parseFloat(
-              getComputedStyle(document.querySelector(".session-progress-card__summary")!)
-                .paddingRight,
-            ) -
-            Number.parseFloat(
-              getComputedStyle(document.querySelector(".agent-chat__goal-row")!).paddingRight,
-            ),
         };
       });
       expect(collapsed.countLeft).toBeGreaterThan(collapsed.currentRight);
@@ -4210,8 +4199,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         0.5,
       );
       expect(Math.abs(collapsed.trailingCenterDelta)).toBeLessThan(0.5);
-      expect(Math.abs(collapsed.trailingControlWidthDelta)).toBeLessThan(0.5);
-      expect(Math.abs(collapsed.trailingPaddingDelta)).toBeLessThan(0.5);
       const closedRowCenters = await page.evaluate(() => {
         const centerY = (selector: string) => {
           const bounds = document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3997,7 +3997,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
                   <span class="agent-chat__goal-objective">Ship the aligned stack</span>
                 </span>
                 <span class="agent-chat__goal-elapsed">14m</span>
-                <span class="agent-chat__goal-actions"></span>
+                <span class="agent-chat__goal-actions">
+                  <button class="agent-chat__goal-action agent-chat__goal-expand">${iconSvg()}</button>
+                </span>
               </div>
             </div>
           </div>
@@ -4090,6 +4092,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             left(".chat-queue__copy"),
             left(".agent-chat__goal-label"),
           ],
+          trailingCenterDelta:
+            centerX(".session-progress-card__summary-chevron svg") -
+            centerX(".agent-chat__goal-expand svg"),
         };
       });
       expect(
@@ -4098,6 +4103,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(
         Math.max(...openStackAxes.contentLefts) - Math.min(...openStackAxes.contentLefts),
       ).toBeLessThan(0.5);
+      expect(Math.abs(openStackAxes.trailingCenterDelta)).toBeLessThan(0.5);
       expect(
         await page
           .locator(".session-progress-card__body")
@@ -4182,6 +4188,20 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             iconCenter(".chat-queue__leading svg"),
             iconCenter(".agent-chat__goal-icon svg"),
           ],
+          trailingCenterDelta:
+            iconCenter(".session-progress-card__summary-chevron svg") -
+            iconCenter(".agent-chat__goal-expand svg"),
+          trailingControlWidthDelta:
+            rect(".session-progress-card__summary-chevron").width -
+            rect(".agent-chat__goal-expand").width,
+          trailingPaddingDelta:
+            Number.parseFloat(
+              getComputedStyle(document.querySelector(".session-progress-card__summary")!)
+                .paddingRight,
+            ) -
+            Number.parseFloat(
+              getComputedStyle(document.querySelector(".agent-chat__goal-row")!).paddingRight,
+            ),
         };
       });
       expect(collapsed.countLeft).toBeGreaterThan(collapsed.currentRight);
@@ -4189,6 +4209,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
       expect(Math.max(...collapsed.iconCenters) - Math.min(...collapsed.iconCenters)).toBeLessThan(
         0.5,
       );
+      expect(Math.abs(collapsed.trailingCenterDelta)).toBeLessThan(0.5);
+      expect(Math.abs(collapsed.trailingControlWidthDelta)).toBeLessThan(0.5);
+      expect(Math.abs(collapsed.trailingPaddingDelta)).toBeLessThan(0.5);
       const closedRowCenters = await page.evaluate(() => {
         const centerY = (selector: string) => {
           const bounds = document.querySelector<HTMLElement>(selector)!.getBoundingClientRect();

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -151,8 +151,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
+  width: var(--chat-stack-trailing-control-size);
+  height: var(--chat-stack-trailing-control-size);
   padding: 0;
   color: var(--muted);
   background: none;
@@ -298,9 +298,7 @@
   width: 100%;
   min-width: 0;
   min-height: 42px;
-  /* The chevron is 18px while queue/goal actions occupy 24px. The 3px
-     compensation keeps all trailing centers on one vertical stack column. */
-  padding: 8px calc(var(--chat-stack-trailing-inset) + 3px) 8px var(--chat-stack-leading-inset);
+  padding: 8px var(--chat-stack-trailing-inset) 8px var(--chat-stack-leading-inset);
   border: 0;
   border-radius: 0;
   background: transparent;
@@ -370,8 +368,8 @@
 
 .session-progress-card__summary-chevron {
   display: grid;
-  width: 18px;
-  height: 18px;
+  width: var(--chat-stack-trailing-control-size);
+  height: var(--chat-stack-trailing-control-size);
   place-items: center;
   color: var(--muted);
   transition:

--- a/ui/src/styles/chat/composer-queue.css
+++ b/ui/src/styles/chat/composer-queue.css
@@ -4,6 +4,7 @@
   --chat-queue-divider: color-mix(in srgb, var(--text-strong) 6%, transparent);
   --chat-stack-icon-size: 14px;
   --chat-stack-leading-inset: 13px;
+  --chat-stack-trailing-control-size: 24px;
   --chat-stack-trailing-inset: 8px;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Task progress disclosure above a Pursuing goal row could drift from the goal chevron's trailing axis when the progress card was collapsed. The two rows used different control boxes and compensating padding, so alignment depended on separate values staying in sync.

## Why This Change Was Made

In this PR, the composer stack owns one `24px` trailing-control token. Both the goal action and the Task progress chevron consume that slot, and both rows use the same trailing inset. This removes the progress-only padding compensation while preserving the open and collapsed interactions.

## User Impact

Task progress and Pursuing goal disclosure chevrons now remain pinned to the same right-hand axis whether the progress card is collapsed or open.

## Evidence

The deterministic `/chat` mock used an English active goal, a Task progress card that starts collapsed and can be opened, and an active run with the composer Stop control. The mock fixture was kept out of the branch.

Before, the progress header used an `18px` trailing box with `11px` right padding while the goal row used a `24px` box with `8px` padding. After, both use the shared `24px` slot and `8px` inset.

### Before — collapsed

![Before: collapsed Task progress above the Pursuing goal row](https://github.com/user-attachments/assets/944e3a20-1fa3-4bfb-8472-cd5b0c3a5096)

### Before — open

![Before: open Task progress above the Pursuing goal row](https://github.com/user-attachments/assets/d43fd647-666b-4dcc-a1d9-6022dd6080d7)

### After — collapsed

![After: collapsed Task progress and Pursuing goal chevrons share the trailing slot](https://github.com/user-attachments/assets/aafdbd5a-d175-4f99-993e-ddd635c932a4)

### After — open

![After: open Task progress and Pursuing goal chevrons share the trailing slot](https://github.com/user-attachments/assets/4d6f487c-b25f-4793-8184-f169a05379d8)

Focused regression (failed before the production fix because the trailing control widths differed by `6px`; passes on this head):

```text
PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts -- -t "keeps a ten-step task panel full-width with a fixed header and an internal list scroll"
Test Files  1 passed (1)
Tests  1 passed | 103 skipped (104)
```

Renderer tolerance follow-up:

- The resize assertion predates this PR (introduced in #126610) and compares `getBoundingClientRect()` edge differences.
- Current `main` passed the focused test 3/3 locally; this PR head reproduced CI immediately with `rowGap = -0.000022888px` while the visible assistant-to-user gap remained `53.999977px`.
- Both non-overlap comparisons now allow `0.01px` of floating-point/renderer noise, still failing any material overlap. The repaired case passed 3/3, and the complete file passed 6/6.

Also passed:

- targeted Oxfmt check
- targeted Stylelint
- `git diff --check origin/main...HEAD`
- autoreview on `gpt-5.6-sol`, `high`, standard service tier: no accepted/actionable findings

Production LOC: `+6/-7` (net `-1`) | Tests: `+24/-1`

AI-assisted: yes; the owner CSS, caller markup, existing browser regression, pre-fix failure, running mock, screenshots, and final branch diff were inspected directly.

