### PR TITLE
fix(android): blank widgets on mapped-address pinned gateways

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -1971,9 +1971,7 @@ class GatewaySession(
     val scheme = parsed?.scheme ?: "http"
     val port = parsed?.port?.takeIf { it > 0 } ?: if (scheme.equals("https", ignoreCase = true)) 443 else 80
     val usesFallbackHost = host.isBlank() || isLoopbackGatewayHost(host)
-    val gatewayOrigin = "http://${formatGatewayAuthority(endpoint.host.trim().trimEnd('.'), endpoint.port)}".toHttpUrlOrNull()
-    val surfaceOrigin = "http://${formatGatewayAuthority(host.trimEnd('.'), port)}".toHttpUrlOrNull()
-    val isGatewayAuthority = usesFallbackHost || (gatewayOrigin != null && surfaceOrigin == gatewayOrigin)
+    val isGatewayAuthority = usesFallbackHost || endpoint.matchesGatewayAuthority(host, port)
     val path = parsed?.rawPath.orEmpty()
     val capability = path.removePrefix("/__openclaw__/cap/")
     val isRootCapability = path != capability && capability.isNotEmpty() && !capability.contains('/')
@@ -2174,7 +2172,15 @@ internal fun shouldPauseGatewayReconnectAfterAuthFailure(
   }
 }
 
-/** Builds the gateway WebSocket URL from endpoint authority and TLS policy. */
+private fun GatewayEndpoint.matchesGatewayAuthority(
+  surfaceHost: String,
+  surfacePort: Int,
+): Boolean =
+  "http://${formatGatewayAuthority(host.trim().trimEnd('.'), port)}".toHttpUrlOrNull()?.let {
+    it == "http://${formatGatewayAuthority(surfaceHost.trim().trimEnd('.'), surfacePort)}".toHttpUrlOrNull()
+  } == true
+
+/** Retains pins for the same TLS authority, canonicalizing numeric hosts without adding DNS aliases. */
 internal fun gatewayTlsFingerprintForCanvasSurface(
   fingerprint: String?,
   surfaceUrl: String,
@@ -2185,11 +2191,8 @@ internal fun gatewayTlsFingerprintForCanvasSurface(
   val surface = runCatching { java.net.URI(surfaceUrl) }.getOrNull() ?: return null
   if (!surface.scheme.equals("https", ignoreCase = true)) return null
   val surfaceHost = surface.host?.trim()?.trimEnd('.') ?: return null
-  val gatewayHost = endpoint.host.trim().trimEnd('.')
-  val surfacePort = surface.port.takeIf { it > 0 } ?: 443
-  return fingerprint.takeIf {
-    surfaceHost.equals(gatewayHost, ignoreCase = true) && surfacePort == endpoint.port
-  }
+  if (!surfaceHost.equals(endpoint.host.trim().trimEnd('.'), ignoreCase = true) && ':' !in surfaceHost && ':' !in endpoint.host) return null
+  return fingerprint.takeIf { endpoint.matchesGatewayAuthority(surfaceHost, surface.port.takeIf { it > 0 } ?: 443) }
 }
 
 internal fun buildGatewayWebSocketUrl(

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -169,33 +169,50 @@ class GatewaySessionInvokeTest {
   @Test
   fun canvasRoutePinsOnlyTheConnectedTlsEndpoint() {
     val fingerprint = "ab".repeat(32)
-    val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 7443)
 
-    assertEquals(
-      fingerprint,
-      gatewayTlsFingerprintForCanvasSurface(
-        fingerprint = fingerprint,
-        surfaceUrl = "https://gateway.example:7443/__openclaw__/cap/token",
-        endpoint = endpoint,
-        isTlsConnection = true,
-      ),
+    data class RouteCase(
+      val host: String,
+      val surfaceOrigin: String,
+      val matches: Boolean,
+      val port: Int = 7443,
+      val tls: Boolean = true,
+      val pin: String? = fingerprint,
     )
-    assertNull(
-      gatewayTlsFingerprintForCanvasSurface(
-        fingerprint = fingerprint,
-        surfaceUrl = "https://canvas.example:7443/__openclaw__/cap/token",
-        endpoint = endpoint,
-        isTlsConnection = true,
-      ),
-    )
-    assertNull(
-      gatewayTlsFingerprintForCanvasSurface(
-        fingerprint = fingerprint,
-        surfaceUrl = "https://gateway.example:9443/__openclaw__/cap/token",
-        endpoint = endpoint,
-        isTlsConnection = true,
-      ),
-    )
+    val cases =
+      listOf(
+        RouteCase("gateway.example", "https://gateway.example:7443", true),
+        RouteCase("GATEWAY.example.", "https://gateway.EXAMPLE:7443", true),
+        RouteCase(" gateway.example. ", "https://gateway.example.:7443", true),
+        RouteCase("gateway.example", "https://gateway.example", true, port = 443),
+        RouteCase("192.0.2.10", "https://192.0.2.10:7443", true),
+        RouteCase("[2001:db8::10]", "https://[2001:db8::10]:7443", true),
+        RouteCase("gateway.example", "https://canvas.example:7443", false),
+        RouteCase("gateway.example", "https://gateway.example:9443", false),
+        RouteCase("gateway.example", "http://gateway.example:7443", false),
+        RouteCase("localhost", "https://127.0.0.1:7443", false),
+        RouteCase("bücher.example", "https://xn--bcher-kva.example:7443", false),
+        RouteCase("192.0.2.10", "https://192.0.2.11:7443", false),
+        RouteCase("2001:db8::10", "https://[2001:db8::11]:7443", false),
+        RouteCase("::ffff:192.0.2.10", "https://192.0.2.11:7443", false),
+        RouteCase("gateway.example", "https://gateway.example:7443", false, tls = false),
+        RouteCase("gateway.example", "https://gateway.example:7443", false, pin = null),
+        RouteCase("::ffff:192.0.2.10", "https://192.0.2.10:7443", true),
+        RouteCase("192.0.2.10", "https://[::ffff:192.0.2.10]:7443", true),
+        RouteCase("2001:db8::10", "https://[2001:db8::10]:7443", true),
+        RouteCase("2001:0db8:0:0:0:0:0:10", "https://[2001:db8::10]:7443", true),
+      )
+    for (case in cases) {
+      assertEquals(
+        "Gateway ${case.host}:${case.port}, surface ${case.surfaceOrigin}",
+        fingerprint.takeIf { case.matches },
+        gatewayTlsFingerprintForCanvasSurface(
+          fingerprint = case.pin,
+          surfaceUrl = "${case.surfaceOrigin}/__openclaw__/cap/token",
+          endpoint = GatewayEndpoint.manual(host = case.host, port = case.port),
+          isTlsConnection = case.tls,
+        ),
+      )
+    }
   }
 
   @Test
@@ -349,6 +366,8 @@ class GatewaySessionInvokeTest {
         val explicitRoutes =
           listOf(
             "https://canvas.example:9443$capabilityPath",
+            "https://CANVAS.example.:443$capabilityPath",
+            "http://CANVAS.example.:80$capabilityPath",
             "http://canvas.example:${server.port}$capabilityPath",
             "$origin$contextPath$capabilityPath",
             "$origin/custom$capabilityPath",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users connected to a certificate-pinned gateway through an IPv4-mapped IPv6 address would see blank Android inline widgets, even though the gateway connection succeeded. Initial widget documents and documents loaded after refreshing the canvas capability were both affected.

## Why This Change Was Made

The gateway transport canonicalizes numeric addresses, but the canvas certificate handoff compared the advertised host with the original endpoint as text. An endpoint such as `::ffff:192.0.2.10` therefore connected to the same numeric authority advertised as `192.0.2.10`, yet lost its already accepted certificate pin at the widget boundary.

Reuse the canvas URL normalizer's existing authority comparison for certificate handoff, while retaining the pin caller's stricter DNS-name policy. Numeric address spellings can identify the same authority; different DNS names, including Unicode/punycode aliases, do not gain shared trust. TLS, HTTPS, fingerprint presence, and effective-port checks remain required. No DNS lookup, new dependency, certificate fallback, redirect exception, or custom-header policy is introduced.

Production LOC: **+12/-9 (net +3)**. Tests: **+44/-25 (net +19)**. The shared-owner consolidation was net-neutral before the required formatter expanded its signature; it removes the duplicated authority comparison without changing the normalizer's existing behavior.

Provenance: the textual pin comparison was introduced in [native inline widget support, #109212](https://github.com/openclaw/openclaw/pull/109212), commit [28a3540](https://github.com/openclaw/openclaw/commit/28a3540f3283b0700ffde4ffaa0a5f7303d73a09), authored and merged by @steipete. Directly inspected pinned [OkHttp 5.5.0 numeric host canonicalization](https://github.com/square/okhttp/blob/parent-5.5.0/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/-HostnamesCommon.kt#L285-L311) and [HttpUrl host parsing](https://github.com/square/okhttp/blob/parent-5.5.0/okhttp/src/commonJvmAndroid/kotlin/okhttp3/HttpUrl.kt#L989-L995); the real Android proof also observes the mapped input reaching the IPv4 wire authority.

## User Impact

Android inline widgets retain the certificate already accepted for their gateway when equivalent numeric address spellings appear in the advertised canvas URL. Both initial load and capability refresh work without relaxing trust for another hostname, port, or certificate.

This is an Android repair. The analogous Apple certificate-handoff path remains a named follow-up requiring Foundation/URLSession-specific identity proof. External canvas port rewriting, pure-IPv6 server URL formatting, and the separate blank SSL-error presentation are not changed here.

## Evidence

The regression was reproduced before the production edit. The existing pin test failed for a mapped numeric endpoint whose advertised IPv4 surface should retain the accepted pin. Its expanded 20-case table now covers both mapped directions, IPv6 spelling, existing DNS case/trailing-dot/default-port handling, IDNA rejection, foreign hosts/ports, HTTP, non-TLS sessions, and missing pins. Existing real WebSocket hello/refresh tests also preserve explicit external/custom routes and raw proxy context paths.

Actual API36 Android component integration used real pinned WSS, HTTPS documents, the production resolver, and the production `ChatInlineWidget` WebView. The same unchanged instrumentation APK was used before and after: before, the mapped WSS connection succeeded but both documents lost the pin and stayed blank; after, the whole test passed and both documents visibly rendered. Ordinary IPv4 rendered in both runs. A wrong gateway fingerprint still failed specifically during TLS before HTTP upgrade; old capabilities returned404 after refresh; foreign-host metadata inherited no pin and was never fetched. Document requests carried no Authorization or custom access headers. This proves production-component integration, not the complete onboarding/chat UI or native IPv6 transport.

A separate source-blind operator validation passed all three canvas scenarios. The validator independently observed the ordinary-address document, then chose the mapped-address connection and performed two real refreshes: hello → refreshed → hello. Each visible document had a matching fresh HTTP200 receipt, and both operator refreshes had matching gateway refresh receipts. An independently supplied incorrect fingerprint was compared with the fresh test server's public certificate and rejected explicitly before the gateway handshake or any document request. The validator inspected its own live screenshots and per-case network receipts, without source, diffs, test assertions, or implementation-review output. This is additional fixed-app operator proof, not a claim that the source-blind validator reran the baseline.

The tested fixed APK was built from the exact source tree later committed as `e6dc6b308f629f4966a06c5ef9580833598d8ecc`; it was not rebuilt merely to stamp that later commit identifier into build metadata.

Before: mapped-address initial document.

![Before: mapped-address gateway connects but its initial widget is blank](https://github.com/user-attachments/assets/a3438fcf-1f93-4ed0-988c-7d5f69917d62)

After: initial document and the distinct document after capability refresh.

![After: mapped-address initial widget renders with the accepted gateway certificate](https://github.com/user-attachments/assets/14285850-1c41-4289-8d43-d4d5276fc697)

![After: the distinct refreshed widget document renders with the accepted gateway certificate](https://github.com/user-attachments/assets/f459f42e-fe7c-4c70-b2bd-29b13640dc25)

Validation on the exact two-file change:

- Both Android flavors: **334 tests passed**, zero failures/errors/skips, covering all gateway tests plus chat message-content and media-player siblings.
- Both actual Android lint variants passed with no warnings/errors; all four ktlint tasks and Play debug assembly passed.
- Native localization verification and the normal exact-path changed-file guard passed.
- Independent source/dependency review and fresh full P0–P2 review of the committed branch found no actionable issues.
- Matched device regression: unchanged baseline failed at the intended pin assertion; fixed run passed **1 test in 5.829s**, with every screenshot personally inspected and independently reviewed.

<details>
<summary>Local validation commands</summary>

From `apps/android`, using the installed JDK21/Android SDK:

```sh
./gradlew --no-daemon --max-workers=1 --build-cache \
  :app:testPlayDebugUnitTest --tests 'ai.openclaw.app.gateway.*' \
  --tests ai.openclaw.app.chat.ChatMessageContentParsingTest \
  --tests ai.openclaw.app.ui.chat.ChatMediaPlayerTest \
  :app:testThirdPartyDebugUnitTest --tests 'ai.openclaw.app.gateway.*' \
  --tests ai.openclaw.app.chat.ChatMessageContentParsingTest \
  --tests ai.openclaw.app.ui.chat.ChatMediaPlayerTest \
  :app:lintPlayDebug :app:lintThirdPartyDebug \
  :app:ktlintCheck :benchmark:ktlintCheck :wear:ktlintCheck :wear-shared:ktlintCheck \
  :app:assemblePlayDebug
```

From the repository root:

```sh
node --import tsx scripts/native-app-i18n.ts verify
node scripts/check-changed.mjs -- \
  apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt \
  apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
```

The disposable Android integration fixture and its screenshots are proof artifacts, not additions to the shipped app or production test API.

</details>
