### PR TITLE
fix(ui): avoid duplicate Draft control on desktop

### DIFF
--- a/ui/src/e2e/new-session-page.capability-menu.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.capability-menu.e2e.test.ts
@@ -7,6 +7,44 @@ import {
 const suite = createNewSessionPageE2eSuite();
 
 suite.define(() => {
+  it.each([
+    {
+      name: "desktop",
+      viewport: { width: 1280, height: 900 },
+      composerVisible: true,
+      railVisible: false,
+    },
+    {
+      name: "mobile",
+      viewport: { width: 390, height: 844 },
+      composerVisible: false,
+      railVisible: true,
+    },
+  ])("shows Draft once on $name", async ({ viewport, composerVisible, railVisible }) => {
+    await suite.withPage({ viewport }, async ({ page }) => {
+      await installMockGateway(page, {
+        allowedSessionVisibilities: ["shared", "draft"],
+        hasMultipleSessionSharingIdentities: true,
+        operatorScopes: ["operator.read", "operator.write", "operator.admin"],
+      });
+
+      await page.goto(`${suite.server.baseUrl}new`);
+      const composer = page.locator(".new-session-page__composer");
+      await composer.getByRole("button", { name: "Add attachment" }).click();
+      await composer
+        .locator("wa-dropdown.agent-chat__capability-menu")
+        .getByRole("menuitem", { name: "Draft" })
+        .click();
+
+      await expect
+        .poll(() => composer.locator(".new-session-page__visibility--draft").isVisible())
+        .toBe(composerVisible);
+      await expect
+        .poll(() => page.locator(".new-session-page__draft-toggle").isVisible())
+        .toBe(railVisible);
+    });
+  });
+
   it("creates the first turn with Draft and selected capabilities atomically", async () => {
     await suite.withPage({ viewport: { width: 555, height: 1200 } }, async ({ page }) => {
       const config = {

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -26,7 +26,7 @@ openclaw-new-session-page {
   z-index: 45;
 }
 
-.new-session-page__incognito-rail .new-session-page__draft-tooltip {
+.new-session-page__draft-toggle {
   display: none;
 }
 
@@ -77,10 +77,6 @@ html.openclaw-native-macos .new-session-page__incognito-rail {
     display: flex;
     align-items: center;
     gap: 8px;
-  }
-
-  .new-session-page__incognito-rail .new-session-page__draft-tooltip {
-    display: inline-flex;
   }
 
   .new-session-page__draft-toggle {


### PR DESCRIPTION
Fixes #130840

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users enabling Draft on `/new` saw the Draft indicator twice on desktop: once in the top-right page rail and again inside the composer. The top-right control was introduced for the narrow mobile layout and should not appear on desktop.

## Why This Change Was Made

The mobile composer work in #130308 scoped the top-right Draft control with a `max-width: 560px` rule, but its desktop rule hid the `openclaw-tooltip` host. The tooltip sets its own inline `display: contents`, overriding that rule and exposing the nested button at every width.

This change keeps the existing mobile breakpoint as the single owner of the responsive behavior and gates the actual Draft button instead: hidden by default, shown at 560 px and below. The composer chip keeps the inverse existing rule, so each viewport has exactly one Draft control.

## User Impact

- Desktop `/new`: Draft appears only in the composer.
- Mobile `/new`: Draft remains in the top-right page rail and stays out of the composer.
- Draft selection and session behavior are unchanged.

Production CSS is net -4 lines. The regression adds no production seam.

## Evidence

Fixture-driven browser proof used the real `/new` page at 1280×900 and 390×844 viewports. Draft was enabled through the composer capability menu before each capture. All four captures were inspected.

### Desktop — before / after

| Before: duplicated | After: composer only |
| --- | --- |
| <img alt="Desktop new session before, with Draft in the top-right rail and composer" src="https://github.com/user-attachments/assets/a977f9a0-7388-4b76-b608-478c798b01a3" width="520"> | <img alt="Desktop new session after, with Draft only in the composer" src="https://github.com/user-attachments/assets/027a5008-5fac-44a8-8290-504dbd4e5d6a" width="520"> |

### Mobile — before / after

| Before: top-right only | After: top-right only |
| --- | --- |
| <img alt="Mobile new session before, with Draft only in the top-right rail" src="https://github.com/user-attachments/assets/22262ae9-e572-4115-b5e9-a0e80ce07752" width="300"> | <img alt="Mobile new session after, with Draft only in the top-right rail" src="https://github.com/user-attachments/assets/9cce79dd-ea5b-41ef-b987-d1515c09ea78" width="300"> |

The table-driven browser regression covers both viewport contracts and would fail against the pre-fix CSS because the desktop rail button is visible. No local test, lint, typecheck, or build gates were run under the workstation constraint; repository CI owns executable validation for this head.
