### PR TITLE
fix(ci): run changed-path-facts in fast routing checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2070,10 +2070,10 @@ jobs:
               ;;
             contracts-plugins-ci-routing)
               pnpm test:contracts:plugins
-              pnpm test src/commands/status.scan-result.test.ts src/scripts/ci-changed-scope*.test.ts test/scripts/changed-lanes.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/ci-run-node-test-shard.test.ts test/scripts/ci-workflow-guards.test.ts test/scripts/run-vitest.test.ts test/scripts/test-projects.test.ts
+              pnpm test src/commands/status.scan-result.test.ts src/scripts/ci-changed-scope*.test.ts test/scripts/changed-lanes.test.ts test/scripts/changed-path-facts.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/ci-run-node-test-shard.test.ts test/scripts/ci-workflow-guards.test.ts test/scripts/run-vitest.test.ts test/scripts/test-projects.test.ts
               ;;
             ci-routing)
-              pnpm test src/commands/status.scan-result.test.ts src/scripts/ci-changed-scope*.test.ts test/scripts/changed-lanes.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/ci-run-node-test-shard.test.ts test/scripts/ci-workflow-guards.test.ts test/scripts/run-vitest.test.ts test/scripts/test-projects.test.ts
+              pnpm test src/commands/status.scan-result.test.ts src/scripts/ci-changed-scope*.test.ts test/scripts/changed-lanes.test.ts test/scripts/changed-path-facts.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/ci-run-node-test-shard.test.ts test/scripts/ci-workflow-guards.test.ts test/scripts/run-vitest.test.ts test/scripts/test-projects.test.ts
               ;;
             coercion-helpers)
               pnpm check:coercion-helpers

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -19,6 +19,12 @@ import { runInNewContext } from "node:vm";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import {
+  detectChangedScope,
+  detectNodeFastScope,
+  shouldRunNativeI18n,
+  writeGitHubOutput,
+} from "../../scripts/ci-changed-scope.mjs";
 import { NATIVE_I18N_LOCALES } from "../../scripts/native-i18n-locales.ts";
 import { resolvePnpmRunner } from "../../scripts/pnpm-runner.mts";
 import { SUPPORTED_LOCALES } from "../../ui/src/i18n/lib/registry.ts";
@@ -243,6 +249,7 @@ function runCiManifestFixture(options: {
   runnerBackend?: "blacksmith" | "github" | "hybrid";
   runnerProfile?: "blacksmith" | "github" | "hybrid";
   targetHostedRunnerProfileContract?: boolean;
+  scopeEnv?: Record<string, string>;
 }) {
   const root = mkdtempSync(path.join(tmpdir(), "openclaw-ci-manifest-"));
   try {
@@ -450,6 +457,7 @@ function runCiManifestFixture(options: {
         OPENCLAW_CI_RUN_SKILLS_PYTHON: "true",
         OPENCLAW_CI_RUN_WINDOWS: "true",
         OPENCLAW_CI_WORKFLOW_REVISION: "b".repeat(40),
+        ...options.scopeEnv,
       },
     });
     const outputs = Object.fromEntries(
@@ -6951,6 +6959,126 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       },
     ]);
   });
+
+  it.each([
+    {
+      label: "test-only routing",
+      changedPath: "test/scripts/changed-path-facts.test.ts",
+      taskOverride: null,
+    },
+    {
+      label: "source-only routing",
+      changedPath: "scripts/lib/changed-path-facts.mjs",
+      taskOverride: null,
+    },
+    {
+      label: "legacy combined contract and routing task",
+      changedPath: "test/scripts/changed-path-facts.test.ts",
+      taskOverride: "contracts-plugins-ci-routing",
+    },
+  ])(
+    "executes standalone changed-path-facts coverage for $label",
+    ({ changedPath, taskOverride }) => {
+      const root = tempDirs.make("openclaw-fast-ci-routing-");
+      const scopeOutput = path.join(root, "scope.out");
+      const changedPaths = [changedPath];
+      writeGitHubOutput(
+        detectChangedScope(changedPaths),
+        scopeOutput,
+        undefined,
+        detectNodeFastScope(changedPaths),
+        shouldRunNativeI18n(changedPaths),
+        changedPaths,
+      );
+      const scopeEnv = Object.fromEntries(
+        readFileSync(scopeOutput, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => {
+            const separator = line.indexOf("=");
+            return [
+              `OPENCLAW_CI_${line.slice(0, separator).toUpperCase()}`,
+              line.slice(separator + 1),
+            ];
+          }),
+      );
+      const manifest = runCiManifestFixture({
+        bundledPlanner: true,
+        eventName: "pull_request",
+        historicalCompatibility: false,
+        changedPaths,
+        scopeEnv: { ...scopeEnv, OPENCLAW_CI_DOCS_CHANGED: "false" },
+      });
+      expect(manifest.status, manifest.output).toBe(0);
+      expect(
+        Object.entries(manifest.outputs)
+          .filter(([key, value]) => key.startsWith("run_") && value === "true")
+          .map(([key]) => key)
+          .sort(),
+      ).toEqual([
+        "run_checks_fast_core",
+        "run_format_check",
+        "run_node",
+        "run_protocol_event_coverage",
+      ]);
+      for (const matrix of [
+        "checks_node_core_nondist_matrix",
+        "plugin_contracts_matrix",
+        "channel_contracts_matrix",
+        "checks_windows_matrix",
+        "macos_node_matrix",
+        "android_matrix",
+      ]) {
+        expect(JSON.parse(expectDefined(manifest.outputs[matrix], matrix)).include, matrix).toEqual(
+          [],
+        );
+      }
+      const fastTasks = JSON.parse(
+        expectDefined(manifest.outputs.checks_fast_core_matrix, "fast checks matrix"),
+      ).include as Array<{ task: string }>;
+      expect(fastTasks.map(({ task }) => task)).toEqual([
+        "baseline-ratchets",
+        "coercion-helpers",
+        "ci-routing",
+      ]);
+      const routingTask = expectDefined(
+        fastTasks.find(({ task }) => task === "ci-routing"),
+        "CI routing task",
+      );
+      const runStep = readCiWorkflow().jobs["checks-fast-core"].steps.find(
+        (step: WorkflowStep) => step.name === "Run ${{ matrix.task }} (${{ matrix.runtime }})",
+      );
+      const fakeBin = path.join(root, "bin");
+      const callsPath = path.join(root, "pnpm-calls.jsonl");
+      mkdirSync(fakeBin);
+      writeExecutable(path.join(fakeBin, "pnpm"), [
+        "#!/usr/bin/env node",
+        'require("node:fs").appendFileSync(process.env.PNPM_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n");',
+      ]);
+      // The current manifest selects ci-routing; exercise the retained combined Bash case directly.
+      const run = spawnSync("bash", ["-c", runStep.run], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+          PNPM_CALLS: callsPath,
+          TASK: taskOverride ?? routingTask.task,
+        },
+      });
+      expect(run.status, `${run.stdout}${run.stderr}`).toBe(0);
+      const calls = readFileSync(callsPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as string[]);
+      expect(calls.map(([command]) => command)).toEqual(
+        taskOverride ? ["test:contracts:plugins", "test"] : ["test"],
+      );
+      expect(
+        calls.find(([command]) => command === "test"),
+        "executed routing test argv",
+      ).toContain("test/scripts/changed-path-facts.test.ts");
+    },
+  );
 
   it("uses target-owned CI plans and capabilities for older release checkouts", () => {
     const androidRun = readCiWorkflow().jobs.android.steps.find(

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4382,7 +4382,7 @@ NODE
       const tarball = path.join(registry, "cache-proof-dep-1.0.0.tgz");
       const registryScript = String.raw`
 const { createHash } = require("node:crypto");
-const { readFileSync, writeFileSync } = require("node:fs");
+const { readFileSync, renameSync, writeFileSync } = require("node:fs");
 const { createServer } = require("node:http");
 const tarballPath = process.argv[1];
 const readyPath = process.argv[2];
@@ -4417,7 +4417,12 @@ const server = createServer((request, response) => {
   response.statusCode = 404;
   response.end();
 });
-server.listen(0, "127.0.0.1", () => writeFileSync(readyPath, String(server.address().port)));
+server.listen(0, "127.0.0.1", () => {
+  // Publish the complete port before existence can signal readiness to the parent.
+  const pendingPath = readyPath + ".tmp";
+  writeFileSync(pendingPath, String(server.address().port));
+  renameSync(pendingPath, readyPath);
+});
 `;
       const registryServer = spawn(process.execPath, ["-e", registryScript, tarball, readyFile], {
         stdio: "ignore",

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1677,18 +1677,22 @@ describe("scripts/test-projects changed-target routing", () => {
   });
 
   it("prints wrapper help without starting a broad local suite", () => {
-    const result = spawnSync(
-      process.execPath,
-      ["--import", "tsx", "scripts/test-projects.mts", "--help"],
-      {
-        encoding: "utf8",
-        timeout: 5_000,
-      },
-    );
+    withTinyFileTree({}, (tempDir) => {
+      const result = spawnSync(
+        process.execPath,
+        ["--import", "tsx", "scripts/test-projects.mts", "--help"],
+        {
+          encoding: "utf8",
+          // Own the child's tsx cache so unrelated host transforms cannot delay help.
+          env: { ...process.env, TMPDIR: tempDir, TMP: tempDir, TEMP: tempDir },
+          timeout: 5_000,
+        },
+      );
 
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("Usage: node --import tsx scripts/test-projects.mts");
-    expect(result.stderr).not.toContain("[test] starting");
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Usage: node --import tsx scripts/test-projects.mts");
+      expect(result.stderr).not.toContain("[test] starting");
+    });
   });
 
   it("allows explicit split Vitest config targets without treating them as unmatched tests", () => {


### PR DESCRIPTION
Related: #130790 — classify the maintainer activity helper without all-plugin checks (landed separately).

<details>
<summary>Additional instructions</summary>

This is a same-repository branch that maintainers can update.

</details>

## What Problem This Solves

Resolves a problem where changes to the shared changed-path classifier or its standalone tests could pass fast-only CI without running that standalone suite. The normal Node test, build, plugin/channel contract, and platform test matrices are disabled for these changes, so no other selected job supplied the missing coverage.

## Why This Change Was Made

The scope classifier already admits both files to fast CI routing, but the workflow's explicit test commands omitted `test/scripts/changed-path-facts.test.ts`. Add that suite to both `ci-routing` and the retained `contracts-plugins-ci-routing` command, preserving classification, the standalone suite, and all product matrices.

Full landing validation also exposed two test-fixture defects, repaired in a separate test-only commit: give the real help child a temporary/cache directory owned by its existing cleanup fixture, and publish the registry's complete ready payload through a same-directory temporary file plus rename. The help invocation and 5000 ms limit remain unchanged; the registry consumer, pinned pnpm bootstrap, installation, hardlink/archive, offline reconciliation, and importer-drift assertions are preserved.

## User Impact

Developers can rely on fast CI to run the changed-path classifier's standalone tests when either its source or tests change. The two fixture repairs keep this validation independent of unrelated host cache history and readiness publication timing. There is no runtime or product behavior change.

Tooling/workflow LOC: +2/-2 (net 0). Tests/support: +150/-13 (net +137). Runtime production LOC: 0. No new production seam, configuration, dependency, or test case was added by the fixture-repair commit.

## Evidence

The three new routing cases execute the real scope classifier, workflow manifest, and workflow Bash with a pnpm argument recorder. They cover source-only changes, test-only changes, and the retained combined task, while verifying that alternate test matrices stay disabled. Before the workflow fix all three failed because the executed test arguments omitted the standalone suite; afterward all three passed.

```sh
OPENCLAW_VITEST_MAX_WORKERS=4 OPENCLAW_TEST_PROJECTS_PARALLEL=1 \
  node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts \
  -t 'executes standalone changed-path-facts coverage' --reporter=verbose
```

The prior full routing run found 836 passing tests, two failures, and two existing skips. The two failures were reproduced and repaired at their fixture owners:

| Fixture | Before | After |
| --- | --- | --- |
| Real wrapper help | `ETIMEDOUT` after 5006 ms, no output | Passed in 1144 ms with the same 5000 ms limit |
| Registry ready publication | A deterministic pause between file creation and payload write exposed an empty ready marker, constructing the observed `http://127.0.0.1/cache-proof-dep` URL | The same probe keeps the ready path absent until publication; the final payload matches the live port and metadata returns HTTP 200 |

The readiness probe executes the extracted registry fixture script and injects the open-before-write interleaving. This matches Node's [separate open and write operations](https://github.com/nodejs/node/blob/v26.7.0/src/node_file.cc#L2563); it changes no repository source or test assertions. The help repair uses the same child-temp ownership pattern already present in the workflow-shell fixture; it does not disable tsx caching or clear the shared host cache.

The canonical pinned-pnpm fixture repair from #130653 (dependency/tooling refresh, merge `b4d6aff0988bf6c761275334141a916c1687b4c6`) is included in the base and preserved. The repaired real registry fixture now passes all its installation and offline assertions.

Focused verification: **5 passed** across the two repaired fixtures and three routing regressions:

```sh
OPENCLAW_VITEST_MAX_WORKERS=4 OPENCLAW_TEST_PROJECTS_PARALLEL=1 \
  node scripts/run-vitest.mjs test/scripts/test-projects.test.ts \
  test/scripts/ci-workflow-guards.test.ts \
  -t 'prints wrapper help without starting a broad local suite|preserves pnpm hard links and validates cached importers offline|executes standalone changed-path-facts coverage' \
  --reporter=verbose
```

Final verification executed the actual parsed workflow Bash with `TASK=ci-routing`, `OPENCLAW_VITEST_MAX_WORKERS=4`, and `OPENCLAW_TEST_PROJECTS_PARALLEL=1`: **838 passed, 2 existing Linux-only skips, 13 files**, exit 0 in 587.13 seconds. No test filter or additional disabled assertions were used. The exact selected command is:

```sh
pnpm test src/commands/status.scan-result.test.ts src/scripts/ci-changed-scope*.test.ts test/scripts/changed-lanes.test.ts test/scripts/changed-path-facts.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/ci-run-node-test-shard.test.ts test/scripts/ci-workflow-guards.test.ts test/scripts/run-vitest.test.ts test/scripts/test-projects.test.ts
```

These final gates also passed:

```sh
node scripts/check-changed.mjs -- .github/workflows/ci.yml test/scripts/ci-workflow-guards.test.ts test/scripts/test-projects.test.ts
node --import tsx scripts/check-workflows.mts
node_modules/.bin/oxfmt --check .github/workflows/ci.yml test/scripts/ci-workflow-guards.test.ts test/scripts/test-projects.test.ts
git diff --check
```

The changed-file gate included root test typechecking, script lint, and applicable guards. Workflow validation included actionlint, zizmor, composite-input interpolation, and conflict checks. The repository-pinned dependency install passed after rebasing onto main commit `21b41efc7bb83dbdba9ce57c2d7140f6c20014e2`; no dependency files changed. No build, product E2E, or UI proof was needed for this internal CI/test-only change.

AI-assisted. The implementation and fixture contracts were inspected directly. Fresh isolated Codex autoreview found no accepted/actionable findings in the fixture repair; the unchanged routing patch also has a clean precommit autoreview.

Named follow-up from the audit, outside these two repaired fixtures: restore preexisting `OPENCLAW_TEST_PROJECTS_LEAF_SHARDS` and `OPENCLAW_TEST_SKIP_FULL_EXTENSIONS_SHARD` values in the existing serial-untargeted-run test. That test currently deletes those values without restoring them; this is not the cause of either reproduced failure.
