### PR TITLE
fix(media): record dispositions for dropped native-vision attachments

### DIFF
--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -943,42 +943,41 @@ export async function runCapability(params: {
     if (shouldLogVerbose()) {
       logVerbose("Skipping image understanding: primary model supports vision natively");
     }
-    const model = params.activeModel?.model?.trim();
-    const reason = "primary model supports vision natively";
-    // Native hydration resolves local paths and media-store refs only; a
-    // remote-URL-only image is never delivered that way, so claiming the
-    // handoff would suppress its marker while it silently vanishes.
+    const attempt = {
+      type: "provider" as const,
+      provider: activeProvider,
+      model: params.activeModel?.model?.trim() || undefined,
+      outcome: "skipped" as const,
+      reason: "primary model supports vision natively",
+    };
+    // Native hydration ignores understanding limits but only resolves local paths
+    // and media-store refs. Selected and dropped remote URLs both need failure
+    // markers; claiming a handoff would silently hide them.
     const nativeDeliverable = (item: MediaAttachment) =>
       Boolean(item.path) ||
       (Boolean(item.url) && classifyMediaReferenceSource(item.url ?? "").isMediaStoreUrl);
+    const attachmentDispositions = buildDispositions(
+      { kind: "handed-to-native-vision" },
+      { kind: "not-selected" },
+    );
+    for (const item of params.media) {
+      if (attachmentDispositions[item.index] && !nativeDeliverable(item)) {
+        attachmentDispositions[item.index] = {
+          kind: "failed",
+          reason: "remote-url image is not natively deliverable",
+        };
+      }
+    }
     return {
       outputs: [],
       decision: await buildDecision(
         "skipped",
-        selection.selected.map((item) => {
-          if (!nativeDeliverable(item)) {
-            return { attachmentIndex: item.index, attempts: [] };
-          }
-          const attempt = {
-            type: "provider" as const,
-            provider: activeProvider,
-            model: model || undefined,
-            outcome: "skipped" as const,
-            reason,
-          };
-          return {
-            attachmentIndex: item.index,
-            attempts: [attempt],
-            chosen: attempt,
-          };
-        }),
-        {
-          ...buildDispositions({ kind: "handed-to-native-vision" }),
-          ...createAttachmentDispositions(
-            selection.selected.filter((item) => !nativeDeliverable(item)).map((item) => item.index),
-            { kind: "failed", reason: "remote-url image is not natively deliverable" },
-          ),
-        },
+        selection.selected.map((item) =>
+          nativeDeliverable(item)
+            ? { attachmentIndex: item.index, attempts: [attempt], chosen: attempt }
+            : { attachmentIndex: item.index, attempts: [] },
+        ),
+        attachmentDispositions,
       ),
     };
   }

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -231,45 +231,78 @@ describe("runCapability image skip", () => {
     );
   });
 
-  it("markers remote-url-only images instead of claiming native handoff", async () => {
-    await withMediaFixture(
-      {
-        filePrefix: "openclaw-image-url-only-no-handoff",
-        extension: "png",
-        mediaType: "image/png",
-        fileContents: Buffer.from("image"),
-      },
-      async ({ ctx, mediaPath }) => {
-        const msgCtx = ctx as MsgContext;
-        msgCtx.Body = "please inspect both images";
-        msgCtx.media = [
-          { path: mediaPath, contentType: "image/png" },
-          { url: "https://cdn.example.test/photos/second.png", contentType: "image/png" },
-        ];
+  it.each([
+    {
+      label: "selected",
+      policy: { mode: "all", maxAttachments: 4 },
+      selectedIndexes: [0, 1, 2, 3],
+    },
+    { label: "dropped by default", policy: undefined, selectedIndexes: [0] },
+    {
+      label: "dropped when preferring the last image",
+      policy: { mode: "all", maxAttachments: 1, prefer: "last" },
+      selectedIndexes: [3],
+    },
+  ] as const)(
+    "markers $label remote-url-only images instead of claiming native handoff",
+    async ({ policy, selectedIndexes }) => {
+      await withMediaFixture(
+        {
+          filePrefix: "openclaw-image-url-only-no-handoff",
+          extension: "png",
+          mediaType: "image/png",
+          fileContents: Buffer.from("image"),
+        },
+        async ({ ctx, mediaPath }) => {
+          const msgCtx = ctx as MsgContext;
+          msgCtx.Body = "please inspect these images";
+          msgCtx.media = [
+            { path: mediaPath, contentType: "image/png" },
+            { url: "https://cdn.example.test/photos/second.png", contentType: "image/png" },
+            { path: mediaPath, contentType: "image/png" },
+            { url: "media://inbound/fourth.png", contentType: "image/png" },
+          ];
 
-        const result = await applyMediaUnderstanding({
-          ctx: msgCtx,
-          cfg: {
-            tools: { media: { image: { attachments: { mode: "all", maxAttachments: 4 } } } },
-          } as unknown as OpenClawConfig,
-          agentDir: "/tmp",
-          workspaceDir: path.dirname(mediaPath),
-          activeModel: { provider: "openai", model: "gpt-4.1" },
-        });
+          const result = await applyMediaUnderstanding({
+            ctx: msgCtx,
+            cfg: {
+              tools: { media: { image: { attachments: policy } } },
+            },
+            agentDir: "/tmp",
+            workspaceDir: path.dirname(mediaPath),
+            activeModel: { provider: "openai", model: "gpt-4.1" },
+          });
 
-        const imageDecision = result.decisions.find((decision) => decision.capability === "image");
-        expect(imageDecision?.outcome).toBe("skipped");
-        expect(imageDecision?.attachmentDispositions).toMatchObject({
-          0: { kind: "handed-to-native-vision" },
-          1: { kind: "failed" },
-        });
-        // Local image stays suppressed (native hydration owns it); the
-        // remote-url image renders its failure despite nativeVisionActive.
-        expect(msgCtx.Body).toContain("[Image attachment could not be analyzed]");
-        expect(msgCtx.Body).not.toContain("not processed");
-      },
-    );
-  });
+          const imageDecision = result.decisions.find(
+            (decision) => decision.capability === "image",
+          );
+          expect(msgCtx.Body).toContain("[Image attachment could not be analyzed]");
+          expect(msgCtx.BodyForAgent).toContain("[Image attachment could not be analyzed]");
+          expect(imageDecision?.outcome).toBe("skipped");
+          expect(imageDecision?.attachments.map(({ attachmentIndex }) => attachmentIndex)).toEqual(
+            selectedIndexes,
+          );
+          expect(imageDecision?.attachmentDispositions).toEqual(
+            Object.fromEntries(
+              [0, 1, 2, 3].map((index) => [
+                index,
+                index === 1
+                  ? { kind: "failed", reason: "remote-url image is not natively deliverable" }
+                  : {
+                      kind: (selectedIndexes as readonly number[]).includes(index)
+                        ? "handed-to-native-vision"
+                        : "not-selected",
+                    },
+              ]),
+            ),
+          );
+          // Native hydration owns local paths and media-store refs, even when
+          // understanding drops them. Only the remote URL needs a failure marker.
+          expect(msgCtx.Body).not.toContain("not processed");
+        },
+      );
+    },
+  );
 
   it("runs explicit image models untouched by native-vision probe failure", async () => {
     await withMediaFixture(


### PR DESCRIPTION
## What Problem This Solves

When the primary model supports vision natively, the image-understanding runner short-circuits and marks attachments "handed-to-native-vision". But that disposition was applied to **selected and dropped** attachments alike, while the correction for remote-URL-only images (which native hydration can never deliver — it only resolves local paths and media-store refs) filtered only the *selected* list. A dropped remote-URL image therefore kept the handoff claim, which renders no marker — so the attachment silently vanished: not analyzed, not delivered, and no record in the agent prompt. The code's own comment admitted this case "silently vanishes".

User path: vision-capable primary model, default `maxAttachments` (1), a message with two images where the second carries only an `http(s)` URL (common for Slack/Discord/Teams URL-only facts) — the agent answers as if image 2 never existed.

## Why This Change Was Made

The native-vision branch now builds selected handoffs plus dropped `not-selected` dispositions, then applies the existing `failed` / `remote-url image is not natively deliverable` correction across **every** nondeliverable image in the map. Dropped local paths and media-store refs deliberately keep `not-selected` with suppressed markers, because native hydration considers the complete image fact list independently of understanding selection (`embedded-agent-runner/run/images.ts`, `attempt-prompt-submit.ts`) — they DO reach the model. No new disposition kind, renderer branch, or config. The identical skip attempt is now constructed once instead of per-image (net −1 production LOC).

Sibling branches swept and clean: non-native image/audio/video execution, no-model, disabled/scope-denied, and the apply-capability exception boundary all already record dropped attachments as `not-selected` or an explicit disabling disposition; documents are owned by file extraction with its own typed outcomes.

## User Impact

An image the pipeline can neither analyze nor deliver now leaves a visible `[Image attachment could not be analyzed]`-class marker in the agent prompt instead of disappearing without trace.

## Evidence

- Pre-fix proof: 2 failed / 24 passed in `runner.vision-skip.test.ts` — both dropped-URL cases missing the failure marker in `Body`/`BodyForAgent`; the selected-URL case passed (isolating the exact defect).
- Post-fix: full `src/media-understanding` suite 517 tests green (34 files); focused suite re-run green after rebase onto latest `origin/main`.
- Complete changed-file gate exit 0 on retry after a worktree-only dependency link repair (typecheck lanes, lint, dead-export scans, schema/storage/media/sidecar guards, import cycles).
- Fresh Codex autoreview: clean, no accepted/actionable findings.
- Native-input boundary confirmed against sibling Codex source (`../codex/codex-rs/protocol/src/user_input.rs:25`, `models.rs:1734`): OpenClaw owns which images reach the model input; docs contract (`docs/nodes/media-understanding.md:271`) unchanged.
