### PR TITLE
fix(gmail): keep forwarding alive across watcher restarts

### DIFF
--- a/docs/cli/webhooks.md
+++ b/docs/cli/webhooks.md
@@ -104,7 +104,7 @@ This command connects Gmail transport but does not create a restricted reader ag
 openclaw webhooks gmail run --account you@example.com
 ```
 
-Starts the Gmail watch and runs `gog gmail watch serve` plus periodic watch renewal in the foreground. An unexpected exit of the initial serve process schedules a restart after 2 seconds. Stop with Ctrl-C; investigate repeated exits in the logs.
+Starts the Gmail watch and runs `gog gmail watch serve` plus periodic watch renewal in the foreground. Unexpected serve-process exits continue to restart after 5 seconds. A bind conflict stops restarts; run only one watcher per listener and stop the other watcher before retrying. Ctrl-C or SIGTERM cancels pending restarts and renewal work and shuts down the serve process tree. Investigate repeated exits in the logs.
 
 `run` accepts the same Pub/Sub, OpenClaw delivery, `gog gmail watch serve`, and Tailscale flags as `setup`, except:
 

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -263,26 +263,6 @@ const respawnWithPackagedCompileCacheIfNeeded = () => {
   );
 };
 
-// Codex owns the relay timeout by PID. Keep the launcher as that exact process
-// so a timeout cannot strand a compile-cache respawn child.
-const waitingForCompileCacheRespawn =
-  !(process.platform !== "win32" && isNativeHookRelayInvocation(process.argv)) &&
-  (respawnWithoutCompileCacheIfNeeded() || respawnWithPackagedCompileCacheIfNeeded());
-
-// https://nodejs.org/api/module.html#module-compile-cache
-if (
-  !waitingForCompileCacheRespawn &&
-  module.enableCompileCache &&
-  !isNodeCompileCacheDisabled() &&
-  !isSourceCheckoutLauncher()
-) {
-  try {
-    module.enableCompileCache(resolvePackagedCompileCacheDirectory());
-  } catch {
-    // Ignore errors
-  }
-}
-
 const getErrorMessage = (err) =>
   err && typeof err === "object" && "message" in err && typeof err.message === "string"
     ? err.message
@@ -425,6 +405,24 @@ const consumeLauncherRootOptionToken = (args, index) => {
     return isLauncherRootOptionValueToken(args[index + 1]) ? 2 : 1;
   }
   return 0;
+};
+
+// Mirror the entry's foreground Gmail policy before any built modules can load.
+// A compile-cache wrapper would kill its owner before descendant cleanup finishes.
+const isForegroundGmailRunInvocation = (argv) => {
+  const args = argv.slice(2);
+  const commandPath = [];
+  for (let index = 0; index < args.length && commandPath.length < 3; index += 1) {
+    const consumed = consumeLauncherRootOptionToken(args, index);
+    if (consumed > 0) {
+      index += consumed - 1;
+    } else if (!args[index] || args[index].startsWith("-")) {
+      break;
+    } else {
+      commandPath.push(args[index]);
+    }
+  }
+  return commandPath.join(" ") === "webhooks gmail run";
 };
 
 const hasLauncherContainerTarget = (argv) => {
@@ -768,6 +766,27 @@ const tryOutputPrecomputedCommandHelp = () => {
   process.stdout.write(precomputed);
   return true;
 };
+
+// Codex owns the relay timeout by PID. Keep the launcher as that exact process
+// so a timeout cannot strand a compile-cache respawn child.
+const waitingForCompileCacheRespawn =
+  !isForegroundGmailRunInvocation(process.argv) &&
+  !(process.platform !== "win32" && isNativeHookRelayInvocation(process.argv)) &&
+  (respawnWithoutCompileCacheIfNeeded() || respawnWithPackagedCompileCacheIfNeeded());
+
+// https://nodejs.org/api/module.html#module-compile-cache
+if (
+  !waitingForCompileCacheRespawn &&
+  module.enableCompileCache &&
+  !isNodeCompileCacheDisabled() &&
+  !isSourceCheckoutLauncher()
+) {
+  try {
+    module.enableCompileCache(resolvePackagedCompileCacheDirectory());
+  } catch {
+    // Ignore errors
+  }
+}
 
 if (!waitingForCompileCacheRespawn) {
   if (!isHelpFastPathDisabled() && (await tryOutputBareRootHelp())) {

--- a/src/cli/respawn-policy.ts
+++ b/src/cli/respawn-policy.ts
@@ -1,6 +1,6 @@
 // CLI respawn skip policy for help, interactive TTY commands, and foreground Gateway runs.
 import { resolveCliArgvInvocation } from "./argv-invocation.js";
-import { getCommandPositionalsWithRootOptions } from "./argv.js";
+import { getCommandPathWithRootOptions, getCommandPositionalsWithRootOptions } from "./argv.js";
 
 const GATEWAY_RUN_BOOLEAN_FLAGS = [
   "--allow-unconfigured",
@@ -28,6 +28,11 @@ const GATEWAY_RUN_VALUE_FLAGS = [
 ] as const;
 
 const INTERACTIVE_TTY_COMMANDS = new Set(["tui", "terminal", "chat"]);
+
+/** Gmail owns a shutdown grace period longer than the generic respawn wrapper allows. */
+export function isForegroundGmailRunArgv(argv: string[]): boolean {
+  return getCommandPathWithRootOptions(argv, 3).join(" ") === "webhooks gmail run";
+}
 
 export function isNativeHookRelayArgv(argv: string[]): boolean {
   const { commandPath } = resolveCliArgvInvocation(argv);
@@ -77,6 +82,7 @@ export function shouldSkipRespawnForArgv(
   return (
     invocation.hasHelpOrVersion ||
     isInteractiveTtyCommandArgv(argv) ||
+    isForegroundGmailRunArgv(argv) ||
     shouldKeepNativeHookRelayInProcess(argv, platform) ||
     (invocation.primary === "gateway" && isForegroundGatewayRunArgv(argv))
   );
@@ -90,6 +96,7 @@ export function shouldSkipStartupEnvironmentRespawnForArgv(
   const invocation = resolveCliArgvInvocation(argv);
   return (
     invocation.hasHelpOrVersion ||
+    isForegroundGmailRunArgv(argv) ||
     // Codex owns the relay subprocess timeout. A detached startup respawn can
     // outlive the launcher when Codex kills it, stranding the relay child.
     shouldKeepNativeHookRelayInProcess(argv, platform) ||

--- a/src/entry.compile-cache.test.ts
+++ b/src/entry.compile-cache.test.ts
@@ -166,6 +166,26 @@ describe("entry compile cache", () => {
     ).toBeDefined();
   });
 
+  it.each(["linux", "win32"] as const)(
+    "keeps foreground Gmail cleanup in process with inherited compile cache on %s",
+    async (platform) => {
+      const root = tempDirs.make("openclaw-compile-cache-gmail-");
+      const entryFile = path.join(root, "src", "entry.ts");
+      await fs.mkdir(path.dirname(entryFile), { recursive: true });
+      await fs.writeFile(entryFile, "export {};\n", "utf8");
+
+      expect(
+        buildOpenClawCompileCacheRespawnPlan({
+          currentFile: entryFile,
+          env: { NODE_COMPILE_CACHE: "/tmp/openclaw-cache" },
+          installRoot: root,
+          argv: ["node", entryFile, "webhooks", "--profile", "fixture", "gmail", "run"],
+          platform,
+        }),
+      ).toBeUndefined();
+    },
+  );
+
   it("keeps interactive no-cache respawn plans attached to the terminal", async () => {
     const root = tempDirs.make("openclaw-compile-cache-interactive-");
     const entryFile = path.join(root, "dist", "entry.js");

--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import {
+  isForegroundGmailRunArgv,
   isTerminalInteractiveRespawnArgv,
   shouldKeepNativeHookRelayInProcess,
 } from "./cli/respawn-policy.js";
@@ -120,7 +121,7 @@ function buildOpenClawCompileCacheRespawnPlan(params: {
   const env = params.env ?? process.env;
   const argv = params.argv ?? process.argv;
   const platform = params.platform ?? process.platform;
-  if (shouldKeepNativeHookRelayInProcess(argv, platform)) {
+  if (isForegroundGmailRunArgv(argv) || shouldKeepNativeHookRelayInProcess(argv, platform)) {
     return undefined;
   }
   if (!isSourceCheckoutInstallRoot(params.installRoot)) {

--- a/src/entry.respawn.test.ts
+++ b/src/entry.respawn.test.ts
@@ -49,6 +49,34 @@ describe("buildCliRespawnPlan", () => {
     ).toBeNull();
   });
 
+  it.each(["darwin", "linux", "win32"] as const)(
+    "leaves foreground Gmail shutdown with its lifecycle owner on %s",
+    (platform) => {
+      for (const args of [
+        ["webhooks", "gmail", "run", "--account", "fixture@example.com"],
+        ["--profile", "fixture", "webhooks", "gmail", "run"],
+      ]) {
+        expect(
+          buildCliRespawnPlan({
+            argv: ["node", "openclaw", ...args],
+            env: {},
+            execArgv: [],
+            autoNodeExtraCaCerts: "/etc/ssl/certs/ca-certificates.crt",
+            platform,
+          }),
+        ).toBeNull();
+      }
+      expect(
+        buildCliRespawnPlan({
+          argv: ["node", "openclaw", "webhooks", "gmail", "setup"],
+          env: {},
+          execArgv: [],
+          platform,
+        }),
+      ).not.toBeNull();
+    },
+  );
+
   it("adds NODE_EXTRA_CA_CERTS and warning suppression in one respawn", () => {
     const plan = buildCliRespawnPlan({
       argv: ["node", "openclaw", "status"],

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -235,7 +235,6 @@ type GmailWatcherRestartParams = {
     error: (msg: string) => void;
   };
   onSkipped?: () => void;
-  isCancelled?: () => boolean;
   signal?: AbortSignal;
 };
 
@@ -3856,9 +3855,9 @@ describe("gateway Gmail hot reload handlers", () => {
     const [restartParams] = hoisted.startGmailWatcherWithLogs.mock.calls[0] ?? [];
     expect(restartParams).toMatchObject({ cfg: nextConfig });
     expect(restartParams?.signal).toBe(abortController.signal);
-    expect(restartParams?.isCancelled?.()).toBe(false);
+    expect(restartParams?.signal?.aborted).toBe(false);
     abortController.abort();
-    expect(restartParams?.isCancelled?.()).toBe(true);
+    expect(restartParams?.signal?.aborted).toBe(true);
     expect(clearGmailRestartAbortController).toHaveBeenCalledWith(abortController);
   });
 

--- a/src/gateway/server-reload-hot.ts
+++ b/src/gateway/server-reload-hot.ts
@@ -661,7 +661,6 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
             await startGmailWatcherWithLogs({
               cfg: nextConfig,
               log: params.logHooks,
-              isCancelled: () => restartAbortController.signal.aborted,
               signal: restartAbortController.signal,
               onSkipped: () =>
                 params.logHooks.info(

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -921,7 +921,6 @@ export async function startGatewaySidecars(params: {
           await startGmailWatcherWithLogs({
             cfg: params.cfg,
             log: params.logHooks,
-            isCancelled: isStopped,
             signal,
           });
         },

--- a/src/hooks/gmail-ops.test.ts
+++ b/src/hooks/gmail-ops.test.ts
@@ -1,11 +1,15 @@
 import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 
 const mocks = vi.hoisted(() => ({
   ensureDependency: vi.fn(),
   ensureTailscaleEndpoint: vi.fn(),
   getRuntimeConfig: vi.fn(),
+  replaceConfigFile: vi.fn(),
   runCommandWithTimeout: vi.fn(),
+  killProcessTree: vi.fn(),
   spawn: vi.fn(),
   defaultRuntime: {
     log: vi.fn(),
@@ -27,11 +31,16 @@ vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: mocks.runCommandWithTimeout,
 }));
 
+vi.mock("../process/kill-tree.js", () => ({
+  killProcessTree: mocks.killProcessTree,
+}));
+
 vi.mock("../config/config.js", async () => {
   const actual = await vi.importActual<typeof import("../config/config.js")>("../config/config.js");
   return {
     ...actual,
     getRuntimeConfig: mocks.getRuntimeConfig,
+    replaceConfigFile: mocks.replaceConfigFile,
   };
 });
 
@@ -54,105 +63,272 @@ vi.mock("../infra/executable-path.js", () => ({
 }));
 
 const { runGmailService } = await import("./gmail-ops.js");
+const { stopGmailWatcher } = await import("./gmail-watcher.js");
 
-function createGmailConfig(account = "me@example.com", renewEveryMinutes?: number) {
+const commandSuccess = { code: 0, stdout: "", stderr: "" };
+const signals = ["SIGINT", "SIGTERM"] as const;
+
+function createGmailConfig() {
   return {
     hooks: {
       enabled: true,
       token: "hook-token",
       gmail: {
-        account,
+        account: "me@example.com",
         topic: "projects/demo/topics/gmail",
         pushToken: "push-token",
         tailscale: { mode: "off" as const },
-        renewEveryMinutes,
+        renewEveryMinutes: 1,
       },
     },
   };
 }
 
+type WatcherChild = EventEmitter & {
+  pid: number;
+  alive: boolean;
+  stderr: PassThrough;
+};
+
+function exitChild(child: WatcherChild, code: number | null = 1, signal: string | null = null) {
+  child.alive = false;
+  child.emit("exit", code, signal);
+  child.emit("close", code, signal);
+}
+
 describe("runGmailService", () => {
+  let children: WatcherChild[];
+  let signalBaselines: Map<(typeof signals)[number], ReturnType<typeof process.rawListeners>>;
+
+  function shutdownHandler(signal: (typeof signals)[number]) {
+    const added = process
+      .rawListeners(signal)
+      .filter((fn) => !signalBaselines.get(signal)?.includes(fn));
+    expect(added).toHaveLength(1);
+    return () => added[0]!(signal);
+  }
+
+  function expectSignalsDetached() {
+    for (const signal of signals) {
+      expect(process.rawListeners(signal)).toEqual(signalBaselines.get(signal));
+    }
+  }
+
   beforeEach(() => {
-    mocks.ensureDependency.mockResolvedValue(undefined);
-    mocks.ensureTailscaleEndpoint.mockResolvedValue(undefined);
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    signalBaselines = new Map(signals.map((signal) => [signal, process.rawListeners(signal)]));
+    children = [];
+    mocks.ensureDependency.mockReset().mockResolvedValue(undefined);
+    mocks.ensureTailscaleEndpoint.mockReset().mockResolvedValue(undefined);
     mocks.getRuntimeConfig.mockReturnValue(createGmailConfig());
-    mocks.runCommandWithTimeout.mockReset();
-    mocks.defaultRuntime.log.mockReset();
-    mocks.defaultRuntime.error.mockReset();
-    mocks.spawn.mockReset();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("logs rejected renewal commands", async () => {
-    vi.useFakeTimers();
-    mocks.runCommandWithTimeout
-      .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
-      .mockRejectedValue(new Error("renewal failed"));
-
-    const child = new EventEmitter();
-    const kill = vi.fn(() => {
-      child.emit("exit", null, "SIGTERM");
-      return true;
+    mocks.runCommandWithTimeout.mockReset().mockResolvedValue(commandSuccess);
+    mocks.spawn.mockReset().mockImplementation(() => {
+      const child = Object.assign(new EventEmitter(), {
+        pid: 9000 + children.length,
+        alive: true,
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        kill: vi.fn((signal: string) => {
+          queueMicrotask(() => exitChild(child, null, signal));
+          return true;
+        }),
+      });
+      children.push(child);
+      return child;
     });
-    mocks.spawn.mockReturnValue(Object.assign(child, { kill, killed: false }));
+    mocks.killProcessTree.mockImplementation((pid: number) => {
+      const child = children.find((candidate) => candidate.pid === pid);
+      if (child?.alive) {
+        queueMicrotask(() => exitChild(child, null, "SIGTERM"));
+      }
+    });
+  });
 
-    const existingSigintListeners = new Set(process.rawListeners("SIGINT"));
-    let shutdown: (() => void) | undefined;
+  afterEach(async () => {
     try {
-      await runGmailService({});
-      shutdown = process
+      const handler = process
         .rawListeners("SIGINT")
-        .find((listener) => !existingSigintListeners.has(listener)) as (() => void) | undefined;
+        .find((fn) => !signalBaselines.get("SIGINT")?.includes(fn));
+      handler?.("SIGINT");
+      await vi.advanceTimersByTimeAsync(10_000);
+      await stopGmailWatcher();
+      expectSignalsDetached();
+      expect(children.filter((child) => child.alive)).toHaveLength(0);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
-      await vi.advanceTimersByTimeAsync(720 * 60_000);
-
-      expect(mocks.defaultRuntime.error).toHaveBeenCalledWith(
-        "gmail watch renew failed: Error: renewal failed",
+  it("replaces the foreground watcher after two sequential unexpected exits", async () => {
+    const config = createGmailConfig();
+    config.hooks.enabled = false;
+    config.hooks.gmail.account = "";
+    const originalConfig = structuredClone(config);
+    mocks.getRuntimeConfig.mockReturnValue(config);
+    await runGmailService({ account: "override@example.com", port: 9876, includeBody: false });
+    expect(children).toHaveLength(1);
+    for (let index = 0; index < 2; index++) {
+      exitChild(children[index]!);
+      // Both the old 2s loop and shared 5s lifecycle have had time to restart.
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(children).toHaveLength(index + 2);
+      expect(children.filter((child) => child.alive)).toHaveLength(1);
+    }
+    for (const [, args] of mocks.spawn.mock.calls) {
+      expect(args).toEqual(
+        expect.arrayContaining(["--account", "override@example.com", "--port", "9876"]),
       );
-    } finally {
-      shutdown?.();
+      expect(args).not.toContain("--include-body");
     }
+    await vi.advanceTimersByTimeAsync(50_000);
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(2);
+    expect(mocks.runCommandWithTimeout.mock.calls[1]?.[0]).toContain("override@example.com");
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(config).toEqual(originalConfig);
   });
 
-  it("keeps a stalled foreground renewal single-flight", async () => {
-    vi.useFakeTimers();
-    let resolveRenewal!: (value: { code: number; stdout: string; stderr: string }) => void;
-    const renewal = new Promise<{ code: number; stdout: string; stderr: string }>((resolve) => {
-      resolveRenewal = resolve;
-    });
-    mocks.getRuntimeConfig.mockReturnValue(createGmailConfig("me@example.com", 1));
+  it("continues periodic renewal after a rejected command", async () => {
     mocks.runCommandWithTimeout
-      .mockResolvedValueOnce({ code: 0, stdout: "", stderr: "" })
-      .mockImplementation(async () => await renewal);
-
-    const child = new EventEmitter();
-    const kill = vi.fn(() => {
-      child.emit("exit", null, "SIGTERM");
-      return true;
-    });
-    mocks.spawn.mockReturnValue(Object.assign(child, { kill, killed: false }));
-
-    const existingSigintListeners = new Set(process.rawListeners("SIGINT"));
-    let shutdown: (() => void) | undefined;
-    try {
-      await runGmailService({});
-      shutdown = process
-        .rawListeners("SIGINT")
-        .find((listener) => !existingSigintListeners.has(listener)) as (() => void) | undefined;
-
-      await vi.advanceTimersByTimeAsync(60_000);
-      expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(2);
-      await vi.advanceTimersByTimeAsync(60_000);
-      const callsWhileStalled = mocks.runCommandWithTimeout.mock.calls.length;
-      resolveRenewal({ code: 0, stdout: "", stderr: "" });
-      await Promise.resolve();
-
-      expect(callsWhileStalled).toBe(2);
-    } finally {
-      shutdown?.();
-    }
+      .mockResolvedValueOnce(commandSuccess)
+      .mockRejectedValueOnce(new Error("renewal failed"));
+    await runGmailService({});
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(3);
+    expect(children.filter((child) => child.alive)).toHaveLength(1);
   });
+
+  it("keeps renewal single-flight and cancels it on shutdown", async () => {
+    const renewal = createDeferred<typeof commandSuccess>();
+    let renewalSignal: AbortSignal | undefined;
+    mocks.runCommandWithTimeout
+      .mockResolvedValueOnce(commandSuccess)
+      .mockImplementationOnce((_args, options: { signal: AbortSignal }) => {
+        renewalSignal = options.signal;
+        options.signal.addEventListener("abort", () => renewal.resolve(commandSuccess), {
+          once: true,
+        });
+        return renewal.promise;
+      });
+    await runGmailService({});
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(2);
+    shutdownHandler("SIGTERM")();
+    expect(renewalSignal?.aborted).toBe(true);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(2);
+    expect(children[0]?.alive).toBe(false);
+    expectSignalsDetached();
+  });
+
+  it.each(
+    signals.flatMap((signal) =>
+      ["replacement", "restart delay"].map((phase) => ({ signal, phase })),
+    ),
+  )(
+    "$signal stops the watcher during $phase without restarting or renewing",
+    async ({ signal, phase }) => {
+      await runGmailService({});
+      exitChild(children[0]!);
+      await vi.advanceTimersByTimeAsync(phase === "replacement" ? 5_000 : 1_000);
+      const countAtShutdown = children.length;
+      const shutdown = shutdownHandler(signal);
+      shutdown();
+      shutdown();
+      shutdownHandler(signal === "SIGINT" ? "SIGTERM" : "SIGINT")();
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(children).toHaveLength(countAtShutdown);
+      expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(1);
+      expect(mocks.killProcessTree).toHaveBeenCalledTimes(
+        (process.platform === "win32" ? 0 : 1) + (phase === "replacement" ? 1 : 0),
+      );
+      if (phase === "replacement") {
+        expect(mocks.killProcessTree).toHaveBeenCalledWith(
+          children[1]!.pid,
+          expect.objectContaining({ graceMs: 3_000 }),
+        );
+        expect(children[1]?.alive).toBe(false);
+      }
+      expectSignalsDetached();
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it.each(
+    signals.flatMap((signal) => ["tailscale", "watch"].map((boundary) => ({ signal, boundary }))),
+  )(
+    "$signal cancels in-flight $boundary startup without a late child",
+    async ({ signal, boundary }) => {
+      const pending = createDeferred<typeof commandSuccess>();
+      let startupSignal: AbortSignal | undefined;
+      if (boundary === "tailscale") {
+        mocks.ensureTailscaleEndpoint.mockImplementation((options: { signal: AbortSignal }) => {
+          startupSignal = options.signal;
+          return pending.promise;
+        });
+      } else {
+        mocks.runCommandWithTimeout.mockImplementation(
+          (_args, options: { signal: AbortSignal }) => {
+            startupSignal = options.signal;
+            return pending.promise;
+          },
+        );
+      }
+      const starting = runGmailService({ tailscale: boundary === "tailscale" ? "serve" : "off" });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(startupSignal).toBeDefined();
+      shutdownHandler(signal)();
+      expect(startupSignal?.aborted).toBe(true);
+      // The boundary deliberately settles late, even after cancellation.
+      pending.resolve(commandSuccess);
+      await starting;
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(children).toHaveLength(0);
+      expectSignalsDetached();
+      expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(boundary === "tailscale" ? 0 : 1);
+    },
+  );
+
+  it.each(["tailscale", "spawn"])(
+    "cleans up signals after %s startup failure",
+    async (boundary) => {
+      if (boundary === "tailscale") {
+        mocks.ensureTailscaleEndpoint.mockRejectedValueOnce(new Error("fixture setup failed"));
+      } else {
+        mocks.spawn.mockImplementationOnce(() => {
+          throw new Error("fixture setup failed");
+        });
+      }
+      await expect(
+        runGmailService({ tailscale: boundary === "tailscale" ? "serve" : "off" }),
+      ).rejects.toThrow("fixture setup failed");
+      expect(children).toHaveLength(0);
+      expectSignalsDetached();
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
+
+  it.each(["initial", "replacement"])(
+    "halts restarts after a split bind error on the %s child",
+    async (phase) => {
+      await runGmailService({});
+      if (phase === "replacement") {
+        exitChild(children[0]!);
+        await vi.advanceTimersByTimeAsync(5_000);
+      }
+      const countBeforeBind = children.length;
+      const child = children.at(-1)!;
+      child.stderr.emit("data", Buffer.from("address alre"));
+      child.alive = false;
+      child.emit("exit", 1, null);
+      child.stderr.emit("data", Buffer.from("ady in use\n"));
+      child.emit("close", 1, null);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(children).toHaveLength(countBeforeBind);
+      expect(children.filter((candidate) => candidate.alive)).toHaveLength(0);
+      // Another watcher can own forwarding, so watch renewal must remain active.
+      expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(2);
+    },
+  );
 });

--- a/src/hooks/gmail-ops.ts
+++ b/src/hooks/gmail-ops.ts
@@ -1,5 +1,4 @@
 // Gmail hook ops helpers run Gmail setup and watcher support commands.
-import { spawn } from "node:child_process";
 import { formatCliCommand } from "../cli/command-format.js";
 import {
   getRuntimeConfig,
@@ -22,10 +21,9 @@ import {
   resolveProjectIdFromGogCredentials,
   runGcloud,
 } from "./gmail-setup-utils.js";
+import { startGmailWatcherService, stopGmailWatcher } from "./gmail-watcher.js";
 import {
   buildDefaultHookUrl,
-  buildGogWatchServeLogArgs,
-  buildGogWatchServeArgs,
   buildGogWatchStartArgs,
   buildTopicPath,
   DEFAULT_GMAIL_LABEL,
@@ -44,7 +42,6 @@ import {
   normalizeServePath,
   parseTopicPath,
   resolveGogExecutable,
-  resolveGogServeInvocation,
   resolveGmailHookRuntimeConfig,
 } from "./gmail.js";
 
@@ -192,14 +189,7 @@ export async function runGmailSetup(opts: GmailSetupOptions) {
 
   await ensureSubscription(projectId, subscription, topicName, pushEndpoint);
 
-  await startGmailWatch(
-    {
-      account: opts.account,
-      label,
-      topic: topicPath,
-    },
-    true,
-  );
+  await startGmailWatch({ account: opts.account, label, topic: topicPath });
 
   const nextConfig: OpenClawConfig = {
     ...baseConfig,
@@ -304,95 +294,53 @@ export async function runGmailService(opts: GmailRunOptions) {
   }
 
   const runtimeConfig = resolved.value;
-
-  if (runtimeConfig.tailscale.mode !== "off") {
-    await ensureDependency("tailscale", ["tailscale"]);
-    await ensureTailscaleEndpoint({
-      mode: runtimeConfig.tailscale.mode,
-      path: runtimeConfig.tailscale.path,
-      port: runtimeConfig.serve.port,
-      target: runtimeConfig.tailscale.target,
-    });
-  }
-
-  await startGmailWatch(runtimeConfig);
-
-  let shuttingDown = false;
-  let child = spawnGogServe(runtimeConfig);
-
-  const renewMs = runtimeConfig.renewEveryMinutes * 60_000;
-  let renewalInFlight: Promise<void> | null = null;
-  const renewTimer = setInterval(() => {
-    if (shuttingDown || renewalInFlight) {
-      return;
-    }
-    const renewal = startGmailWatch(runtimeConfig)
-      .catch((err: unknown) => {
-        defaultRuntime.error(`gmail watch renew failed: ${String(err)}`);
-      })
-      .finally(() => {
-        if (renewalInFlight === renewal) {
-          renewalInFlight = null;
-        }
-      });
-    renewalInFlight = renewal;
-  }, renewMs);
-
+  const controller = new AbortController();
+  let shutdownTask: Promise<void> | undefined;
   const detachSignals = () => {
     process.off("SIGINT", shutdown);
     process.off("SIGTERM", shutdown);
   };
 
   const shutdown = () => {
-    if (shuttingDown) {
+    if (controller.signal.aborted) {
       return;
     }
-    shuttingDown = true;
-    detachSignals();
-    clearInterval(renewTimer);
-    child.kill("SIGTERM");
+    controller.abort();
+    shutdownTask = stopGmailWatcher()
+      .catch((err: unknown) => {
+        defaultRuntime.error(`gmail watcher shutdown failed: ${String(err)}`);
+      })
+      .finally(detachSignals);
   };
 
+  // Own signals before async startup so cancellation cannot leave a late serve child behind.
+  // Keep the handlers through shutdown so repeated signals share the same cleanup.
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
 
-  child.on("exit", () => {
-    if (shuttingDown) {
-      detachSignals();
-      return;
+  try {
+    if (runtimeConfig.tailscale.mode !== "off") {
+      await ensureDependency("tailscale", ["tailscale"]);
     }
-    defaultRuntime.log("gog watch serve exited; restarting in 2s");
-    setTimeout(() => {
-      if (shuttingDown) {
-        return;
-      }
-      child = spawnGogServe(runtimeConfig);
-    }, 2000);
-  });
+    const result = await startGmailWatcherService(runtimeConfig, { signal: controller.signal });
+    if (!result.started && !controller.signal.aborted) {
+      throw new Error(result.reason ?? "gmail watcher failed to start");
+    }
+  } catch (err) {
+    shutdown();
+    throw err;
+  } finally {
+    if (controller.signal.aborted) {
+      await shutdownTask;
+    }
+  }
 }
 
-function spawnGogServe(cfg: GmailHookRuntimeConfig) {
-  const args = buildGogWatchServeArgs(cfg);
-  defaultRuntime.log(`Starting gog ${buildGogWatchServeLogArgs(cfg).join(" ")}`);
-  const invocation = resolveGogServeInvocation(args);
-  return spawn(invocation.command, invocation.args, {
-    stdio: "inherit",
-    windowsHide: invocation.windowsHide,
-    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
-  });
-}
-
-async function startGmailWatch(
-  cfg: Pick<GmailHookRuntimeConfig, "account" | "label" | "topic">,
-  fatal = false,
-) {
+async function startGmailWatch(cfg: Pick<GmailHookRuntimeConfig, "account" | "label" | "topic">) {
   const args = [resolveGogExecutable(), ...buildGogWatchStartArgs(cfg)];
   const result = await runCommandWithTimeout(args, { timeoutMs: 120_000 });
   if (result.code !== 0) {
     const message = result.stderr || result.stdout || "gog watch start failed";
-    if (fatal) {
-      throw new Error(message);
-    }
-    defaultRuntime.error(message);
+    throw new Error(message);
   }
 }

--- a/src/hooks/gmail-watcher-lifecycle.test.ts
+++ b/src/hooks/gmail-watcher-lifecycle.test.ts
@@ -31,21 +31,17 @@ describe("startGmailWatcherWithLogs", () => {
   });
 
   it("passes cancellation state to watcher startup", async () => {
-    const isCancelled = vi.fn(() => true);
     const abortController = new AbortController();
+    abortController.abort();
     startGmailWatcherMock.mockResolvedValue({ started: false, reason: "startup cancelled" });
 
     await startGmailWatcherWithLogs({
       cfg: {},
       log,
-      isCancelled,
       signal: abortController.signal,
     });
 
-    expect(startGmailWatcherMock).toHaveBeenCalledWith(
-      {},
-      { isCancelled, signal: abortController.signal },
-    );
+    expect(startGmailWatcherMock).toHaveBeenCalledWith({}, { signal: abortController.signal });
   });
 
   it("logs startup success", async () => {

--- a/src/hooks/gmail-watcher-lifecycle.ts
+++ b/src/hooks/gmail-watcher-lifecycle.ts
@@ -15,7 +15,6 @@ export async function startGmailWatcherWithLogs(params: {
   cfg: OpenClawConfig;
   log: GMailWatcherLog;
   onSkipped?: () => void;
-  isCancelled?: () => boolean;
   signal?: AbortSignal;
 }) {
   if (isTruthyEnvValue(process.env.OPENCLAW_SKIP_GMAIL_WATCHER)) {
@@ -27,7 +26,6 @@ export async function startGmailWatcherWithLogs(params: {
 
   try {
     const gmailResult = await startGmailWatcher(params.cfg, {
-      isCancelled: params.isCancelled,
       signal: params.signal,
     });
     if (gmailResult.started) {

--- a/src/hooks/gmail-watcher.integration.test.ts
+++ b/src/hooks/gmail-watcher.integration.test.ts
@@ -9,6 +9,7 @@ import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { startGmailWatcher, stopGmailWatcher } from "./gmail-watcher.js";
 
 const describePosix = process.platform === "win32" ? describe.skip : describe;
 
@@ -26,7 +27,6 @@ describePosix("gmail-watcher process-tree shutdown (integration)", () => {
   let savedPath: string | undefined;
   let gogPid: number | undefined;
   let helperPid: number | undefined;
-  let stopWatcher: (() => Promise<void>) | undefined;
 
   beforeAll(() => {
     tmpDir = mkdtempSync(join(tmpdir(), "openclaw-gog-integration-"));
@@ -61,7 +61,7 @@ describePosix("gmail-watcher process-tree shutdown (integration)", () => {
 
   afterAll(async () => {
     try {
-      await stopWatcher?.();
+      await stopGmailWatcher();
     } catch {
       // Force cleanup below; this test must not leave subprocesses behind on failure.
     }
@@ -86,9 +86,6 @@ describePosix("gmail-watcher process-tree shutdown (integration)", () => {
   });
 
   it("stopGmailWatcher removes gog and its credential-helper descendant", async () => {
-    const { startGmailWatcher, stopGmailWatcher } = await import("./gmail-watcher.js");
-    stopWatcher = stopGmailWatcher;
-
     const result = await startGmailWatcher({
       hooks: {
         enabled: true,
@@ -99,7 +96,7 @@ describePosix("gmail-watcher process-tree shutdown (integration)", () => {
           pushToken: "integration-push-token",
         },
       },
-    } as never);
+    });
 
     expect(result.started).toBe(true);
 

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -1,7 +1,10 @@
 // Gmail watcher tests cover watcher events and Gmail hook message flow.
 import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 
 // Tracks spawned children by pid so the killProcessTree mock can emit close on them.
 const spawnRegistry = new Map<number, EventEmitter>();
@@ -61,17 +64,14 @@ function createGmailConfig(account = "me@example.com", renewEveryMinutes?: numbe
 }
 
 function deferredCommandResult() {
-  let resolve!: (result: { code: number; stdout: string; stderr: string }) => void;
-  const promise = new Promise<{ code: number; stdout: string; stderr: string }>((settle) => {
-    resolve = settle;
-  });
-  return { promise, resolve };
+  return createDeferred<{ code: number; stdout: string; stderr: string }>();
 }
 
 type MockWatcherChild = EventEmitter & {
   kill: ReturnType<typeof vi.fn>;
   pid?: number;
-  stderr: EventEmitter;
+  stdout: PassThrough;
+  stderr: PassThrough;
 };
 
 let nextMockPid = 1234;
@@ -80,9 +80,13 @@ function createMockWatcherChild(spawned = true): MockWatcherChild {
   const child = new EventEmitter();
   const pid = spawned ? nextMockPid++ : undefined;
   const mockedChild = Object.assign(child, {
-    stderr: new EventEmitter(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
     kill: vi.fn(() => {
-      queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
+      queueMicrotask(() => {
+        child.emit("exit", null, "SIGTERM");
+        child.emit("close", null, "SIGTERM");
+      });
       return true;
     }),
     ...(pid !== undefined ? { pid } : {}),
@@ -122,16 +126,7 @@ describe("startGmailWatcher", () => {
         queueMicrotask(() => child.emit("close", 0, null));
       }
     });
-    mocks.spawn.mockImplementation(() => {
-      const child = new EventEmitter();
-      return Object.assign(child, {
-        kill: vi.fn(() => {
-          queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
-          return true;
-        }),
-        killed: false,
-      });
-    });
+    mocks.spawn.mockImplementation(() => createMockWatcherChild(false));
   });
 
   afterEach(async () => {
@@ -142,29 +137,20 @@ describe("startGmailWatcher", () => {
   it("does not let a stale cancelled startup clear newer watcher config", async () => {
     vi.useFakeTimers();
     try {
-      let oldCancelled = false;
+      const oldController = new AbortController();
       const oldWatchStart = deferredCommandResult();
-      const spawnedChildren: Array<
-        EventEmitter & { kill: ReturnType<typeof vi.fn>; killed: boolean }
-      > = [];
+      const spawnedChildren: MockWatcherChild[] = [];
       mocks.runCommandWithTimeout
         .mockImplementationOnce(async () => await oldWatchStart.promise)
         .mockResolvedValue({ code: 0, stdout: "", stderr: "" });
       mocks.spawn.mockImplementation(() => {
-        const child = new EventEmitter();
-        const mockedChild = Object.assign(child, {
-          kill: vi.fn(() => {
-            queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
-            return true;
-          }),
-          killed: false,
-        });
-        spawnedChildren.push(mockedChild);
-        return mockedChild;
+        const child = createMockWatcherChild(false);
+        spawnedChildren.push(child);
+        return child;
       });
 
       const staleStart = startGmailWatcher(createGmailConfig(), {
-        isCancelled: () => oldCancelled,
+        signal: oldController.signal,
       });
 
       expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(1);
@@ -174,7 +160,7 @@ describe("startGmailWatcher", () => {
       });
       expect(mocks.spawn).toHaveBeenCalledTimes(1);
 
-      oldCancelled = true;
+      oldController.abort();
       oldWatchStart.resolve({ code: 0, stdout: "", stderr: "" });
       await expect(staleStart).resolves.toEqual({
         started: false,
@@ -211,7 +197,7 @@ describe("startGmailWatcher", () => {
     });
 
     await Promise.resolve();
-    expect(watchStartSignal).toBeDefined();
+    expect(watchStartSignal).toBe(controller.signal);
     controller.abort();
     expect(watchStartSignal?.aborted).toBe(true);
 
@@ -223,7 +209,7 @@ describe("startGmailWatcher", () => {
   });
 
   it("aborts tailscale setup and does not spawn gog serve when cancelled in flight", async () => {
-    let cancelled = false;
+    const controller = new AbortController();
     let tailscaleSignal: AbortSignal | undefined;
     mocks.runCommandWithTimeout.mockImplementation(
       async (_args, options: { signal?: AbortSignal }) =>
@@ -250,18 +236,17 @@ describe("startGmailWatcher", () => {
         },
       } as never,
       {
-        isCancelled: () => cancelled,
+        signal: controller.signal,
       },
     );
 
     await vi.waitFor(() => {
       expect(tailscaleSignal).toBeDefined();
     });
-    cancelled = true;
+    controller.abort();
 
-    await vi.waitFor(() => {
-      expect(tailscaleSignal?.aborted).toBe(true);
-    });
+    expect(tailscaleSignal).toBe(controller.signal);
+    expect(tailscaleSignal?.aborted).toBe(true);
 
     await expect(startPromise).resolves.toEqual({
       started: false,
@@ -272,20 +257,11 @@ describe("startGmailWatcher", () => {
 
   it("kills existing watcher process on re-entry before spawning new one", async () => {
     mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
-    const spawnedChildren: Array<
-      EventEmitter & { kill: ReturnType<typeof vi.fn>; killed: boolean }
-    > = [];
+    const spawnedChildren: MockWatcherChild[] = [];
     mocks.spawn.mockImplementation(() => {
-      const child = new EventEmitter();
-      const mockedChild = Object.assign(child, {
-        kill: vi.fn(() => {
-          queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
-          return true;
-        }),
-        killed: false,
-      });
-      spawnedChildren.push(mockedChild);
-      return mockedChild;
+      const child = createMockWatcherChild(false);
+      spawnedChildren.push(child);
+      return child;
     });
 
     // First start
@@ -425,16 +401,7 @@ describe("startGmailWatcher", () => {
       expect(mocks.spawn).toHaveBeenCalledTimes(1);
 
       // Now spawn a normal child for the second start so re-entry triggers settle
-      mocks.spawn.mockImplementation(() => {
-        const child = new EventEmitter();
-        return Object.assign(child, {
-          kill: vi.fn(() => {
-            queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
-            return true;
-          }),
-          killed: false,
-        });
-      });
+      mocks.spawn.mockImplementation(() => createMockWatcherChild(false));
 
       // Re-entry starts settle on stubbornChild; advance past the 8 s final
       // timeout (stubbornChild never emits exit), then verify the outcome.
@@ -456,17 +423,11 @@ describe("startGmailWatcher", () => {
     vi.useFakeTimers();
     try {
       mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
-      const spawnedChildren: Array<EventEmitter & { kill: ReturnType<typeof vi.fn> }> = [];
+      const spawnedChildren: MockWatcherChild[] = [];
       mocks.spawn.mockImplementation(() => {
-        const child = new EventEmitter();
-        const mockedChild = Object.assign(child, {
-          kill: vi.fn(() => {
-            queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
-            return true;
-          }),
-        });
-        spawnedChildren.push(mockedChild);
-        return mockedChild;
+        const child = createMockWatcherChild(false);
+        spawnedChildren.push(child);
+        return child;
       });
 
       // First start
@@ -490,16 +451,66 @@ describe("startGmailWatcher", () => {
     }
   });
 
-  it("calls killProcessTree (not proc.kill) when stopping the gog watcher", async () => {
+  it("ignores a retired child's late close while replacement startup is pending", async () => {
+    vi.useFakeTimers();
+    const pendingStart = deferredCommandResult();
+    const children = await startMockWatcher();
+    mocks.killProcessTree.mockImplementation(() => {});
+    mocks.runCommandWithTimeout.mockImplementationOnce(() => pendingStart.promise);
+    const restarting = startGmailWatcher(createGmailConfig("new@example.com"));
+    try {
+      await vi.advanceTimersByTimeAsync(8_000);
+      expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(2);
+      const retired = expectDefined(children[0], "retired watcher");
+      retired.emit("exit", 1, null);
+      retired.emit("close", 1, null);
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(children).toHaveLength(1);
+      expect(mocks.killProcessTree).toHaveBeenCalledTimes(1);
+      pendingStart.resolve({ code: 0, stdout: "", stderr: "" });
+      await restarting;
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(children).toHaveLength(2);
+      expect(mocks.spawn.mock.calls[1]?.[1]).toContain("new@example.com");
+    } finally {
+      pendingStart.resolve({ code: 0, stdout: "", stderr: "" });
+      await restarting;
+      const stopping = stopGmailWatcher();
+      await vi.advanceTimersByTimeAsync(8_000);
+      await stopping;
+      for (const child of children) {
+        child.stdout.destroy();
+        child.stderr.destroy();
+      }
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves the shutdown grace period when the watcher exits before its descendants", async () => {
+    vi.useFakeTimers();
     mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
     const child = createMockWatcherChild();
     mocks.spawn.mockReturnValueOnce(child);
+    mocks.killProcessTree.mockImplementation(() => {
+      queueMicrotask(() => {
+        child.emit("exit", 0, null);
+        child.emit("close", 0, null);
+      });
+    });
 
     await startGmailWatcher(createGmailConfig());
     expect(mocks.spawn).toHaveBeenCalledTimes(1);
 
-    await stopGmailWatcher();
+    let stopped = false;
+    const stopping = stopGmailWatcher().then(() => {
+      stopped = true;
+    });
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(stopped).toBe(false);
+    await vi.advanceTimersByTimeAsync(25);
+    await stopping;
 
+    expect(mocks.killProcessTree).toHaveBeenCalledTimes(1);
     expect(mocks.killProcessTree).toHaveBeenCalledWith(
       child.pid,
       expect.objectContaining({ graceMs: 3_000 }),
@@ -508,28 +519,88 @@ describe("startGmailWatcher", () => {
     expect(child.kill).not.toHaveBeenCalled();
   });
 
+  it.each(["darwin", "win32"] as const)(
+    "restarts initial and replacement children with inherited pipes on %s",
+    async (platform) => {
+      vi.useFakeTimers();
+      await withMockedPlatform(platform, async () => {
+        const children = await startMockWatcher();
+        // Descendants keep both pipes open after exit, even if tree cleanup fails.
+        mocks.killProcessTree.mockImplementation(() => {});
+        try {
+          for (let index = 0; index < 2; index++) {
+            const child = expectDefined(children[index], "watcher child");
+            let closedStreams = 0;
+            for (const stream of [child.stdout, child.stderr]) {
+              stream.once("close", () => {
+                if (++closedStreams === 2) {
+                  child.emit("close", null, "SIGKILL");
+                }
+              });
+            }
+            child.emit("exit", null, "SIGKILL");
+            await vi.advanceTimersByTimeAsync(6_100);
+            expect(children).toHaveLength(index + 2);
+            expect(child.stdout.destroyed).toBe(true);
+            expect(child.stderr.destroyed).toBe(true);
+            if (platform === "win32") {
+              expect(mocks.killProcessTree).not.toHaveBeenCalled();
+            } else {
+              expect(mocks.killProcessTree).toHaveBeenCalledTimes(index + 1);
+              expect(mocks.killProcessTree).toHaveBeenLastCalledWith(child.pid, {
+                force: true,
+                detached: true,
+              });
+            }
+          }
+          await vi.advanceTimersByTimeAsync(6_000);
+          expect(children).toHaveLength(3);
+        } finally {
+          const stopping = stopGmailWatcher();
+          await vi.advanceTimersByTimeAsync(8_000);
+          await stopping;
+          for (const child of children) {
+            child.stdout.destroy();
+            child.stderr.destroy();
+          }
+          vi.useRealTimers();
+        }
+      });
+    },
+  );
+
+  it("does not taskkill an exited Windows child while inherited pipes drain", async () => {
+    vi.useFakeTimers();
+    await withMockedPlatform("win32", async () => {
+      const children = await startMockWatcher();
+      const child = expectDefined(children[0], "watcher child");
+      Object.assign(child, { exitCode: 1, signalCode: null });
+      child.emit("exit", 1, null);
+      const stopping = stopGmailWatcher();
+      try {
+        await vi.advanceTimersByTimeAsync(8_000);
+        await stopping;
+        expect(mocks.killProcessTree).not.toHaveBeenCalled();
+        expect(child.stdout.destroyed).toBe(true);
+        expect(child.stderr.destroyed).toBe(true);
+        expect(children).toHaveLength(1);
+      } finally {
+        child.stdout.destroy();
+        child.stderr.destroy();
+        vi.useRealTimers();
+      }
+    });
+  });
+
   it("swallows stdout and stderr stream errors without crashing", async () => {
     mocks.runCommandWithTimeout.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
-    let stdout: EventEmitter | undefined;
-    let stderr: EventEmitter | undefined;
     mocks.spawn.mockImplementation(() => {
-      const child = new EventEmitter();
-      stdout = new EventEmitter();
-      stderr = new EventEmitter();
-      const mockedChild = Object.assign(child, {
-        stdout,
-        stderr,
-        kill: vi.fn(() => {
-          queueMicrotask(() => child.emit("exit", null, "SIGTERM"));
-          return true;
-        }),
-        killed: false,
-      });
+      const child = createMockWatcherChild(false);
       queueMicrotask(() => {
-        stdout?.emit("error", new Error("stdout read failed"));
-        stderr?.emit("error", new Error("stderr read failed"));
+        child.stdout.emit("error", new Error("stdout read failed"));
+        child.stderr.emit("error", new Error("stderr read failed"));
       });
-      return mockedChild;
+      return child;
     });
 
     await expect(startGmailWatcher(createGmailConfig())).resolves.toEqual({ started: true });

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -9,6 +9,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import process from "node:process";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { releaseChildProcessOutputAfterExit } from "../process/child-process.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import { killProcessTree } from "../process/kill-tree.js";
 import { hasBinary } from "../skills/loading/config.js";
@@ -34,13 +35,6 @@ let renewalAbortController: AbortController | null = null;
 let shuttingDown = false;
 let currentConfig: GmailHookRuntimeConfig | null = null;
 let respawnTimeout: ReturnType<typeof setTimeout> | null = null;
-
-/**
- * Check if gog binary is available
- */
-function isGogAvailable(): boolean {
-  return hasBinary("gog");
-}
 
 /**
  * Start the Gmail watch (registers with Gmail API)
@@ -124,13 +118,19 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
     log.error(`gog process error: ${String(err)}`);
   });
 
-  // `close` follows stdio drain, so late stderr participates in restart classification.
-  child.on("close", (code, signal) => {
-    // If a newer watcher has replaced this child, do not respawn.
-    if (watcherProcess !== null && watcherProcess !== child) {
-      return;
+  const releaseOutput = releaseChildProcessOutputAfterExit(child);
+  child.once("exit", () => {
+    // The detached POSIX group remains ours after its leader dies. Windows
+    // taskkill requires a live root PID; only bound inherited-pipe drain there.
+    if (!shuttingDown && watcherProcess === child && process.platform !== "win32" && child.pid) {
+      killProcessTree(child.pid, { force: true, detached: true });
     }
-    if (shuttingDown) {
+  });
+
+  // `close` follows bounded stdio drain, so late stderr still classifies bind failures.
+  child.once("close", (code, signal) => {
+    releaseOutput();
+    if (shuttingDown || watcherProcess !== child) {
       return;
     }
     if (spawnFailed) {
@@ -164,6 +164,11 @@ function spawnGogServe(cfg: GmailHookRuntimeConfig): ChildProcess {
  * and resolve on exit/close/error or a final 8 s safety timeout.
  */
 function settleProcess(proc: ChildProcess): Promise<void> {
+  // A Windows root PID can be reused after exit, even while inherited pipes
+  // delay close. The spawn owner's bounded drain releases those pipes safely.
+  if (process.platform === "win32" && (proc.exitCode != null || proc.signalCode != null)) {
+    return Promise.resolve();
+  }
   return new Promise<void>((resolve) => {
     let settled = false;
     let processSettled = false;
@@ -180,6 +185,9 @@ function settleProcess(proc: ChildProcess): Promise<void> {
       if (finalTimeout) {
         clearTimeout(finalTimeout);
       }
+      proc.removeListener("exit", settleAfterEscalation);
+      proc.removeListener("close", settleAfterEscalation);
+      proc.removeListener("error", settleAfterEscalation);
       resolve();
     };
     const settleAfterEscalation = () => {
@@ -256,14 +264,7 @@ type GmailWatcherStartResult = {
   reason?: string;
 };
 
-type GmailWatcherCancellation = {
-  dispose: () => void;
-  isCancelled: () => boolean;
-  signal?: AbortSignal;
-};
-
 type GmailWatcherStartOptions = {
-  isCancelled?: () => boolean;
   signal?: AbortSignal;
 };
 
@@ -274,56 +275,6 @@ function cancelledGmailWatcherStart(
     currentConfig = null;
   }
   return { started: false, reason: "startup cancelled" };
-}
-
-function isGmailWatcherStartCancelled(options: GmailWatcherStartOptions): boolean {
-  return options.signal?.aborted === true || options.isCancelled?.() === true;
-}
-
-function createGmailWatcherCancellation(
-  options: GmailWatcherStartOptions,
-): GmailWatcherCancellation {
-  if (!options.signal && !options.isCancelled) {
-    return {
-      dispose: () => {},
-      isCancelled: () => false,
-    };
-  }
-
-  const abortController = new AbortController();
-  const abort = () => {
-    if (!abortController.signal.aborted) {
-      abortController.abort();
-    }
-  };
-  const onAbort = () => abort();
-  options.signal?.addEventListener("abort", onAbort, { once: true });
-
-  let cancelPoll: ReturnType<typeof setInterval> | null = null;
-  if (options.isCancelled) {
-    cancelPoll = setInterval(() => {
-      if (options.isCancelled?.()) {
-        abort();
-      }
-    }, 100);
-    cancelPoll.unref?.();
-  }
-
-  if (isGmailWatcherStartCancelled(options)) {
-    abort();
-  }
-
-  return {
-    dispose: () => {
-      if (cancelPoll) {
-        clearInterval(cancelPoll);
-        cancelPoll = null;
-      }
-      options.signal?.removeEventListener("abort", onAbort);
-    },
-    isCancelled: () => abortController.signal.aborted || isGmailWatcherStartCancelled(options),
-    signal: abortController.signal,
-  };
 }
 
 /**
@@ -344,8 +295,7 @@ export async function startGmailWatcher(
   }
 
   // Check if gog is available
-  const gogAvailable = isGogAvailable();
-  if (!gogAvailable) {
+  if (!hasBinary("gog")) {
     return { started: false, reason: "gog binary not found" };
   }
 
@@ -355,8 +305,15 @@ export async function startGmailWatcher(
     return { started: false, reason: resolved.error };
   }
 
-  const runtimeConfig = resolved.value;
-  if (isGmailWatcherStartCancelled(options)) {
+  return startGmailWatcherService(resolved.value, options);
+}
+
+/** Start the shared watcher lifecycle after the caller resolves config and prerequisites. */
+export async function startGmailWatcherService(
+  runtimeConfig: GmailHookRuntimeConfig,
+  options: GmailWatcherStartOptions = {},
+): Promise<GmailWatcherStartResult> {
+  if (options.signal?.aborted) {
     return cancelledGmailWatcherStart(runtimeConfig);
   }
   currentConfig = runtimeConfig;
@@ -376,33 +333,28 @@ export async function startGmailWatcher(
       const oldProcess = watcherProcess;
       watcherProcess = null;
       await settleProcess(oldProcess);
-      // Remove lingering spawnGogServe listeners so a late exit (after the
-      // settleProcess timeout) cannot trigger a duplicate respawn while
-      // watcherProcess is null and shuttingDown is false.
-      oldProcess.removeAllListeners();
     }
     shuttingDown = false;
   }
 
   // Set up Tailscale endpoint if needed
   if (runtimeConfig.tailscale.mode !== "off") {
-    const cancellation = createGmailWatcherCancellation(options);
     try {
       await ensureTailscaleEndpoint({
         mode: runtimeConfig.tailscale.mode,
         path: runtimeConfig.tailscale.path,
         port: runtimeConfig.serve.port,
-        signal: cancellation.signal,
+        signal: options.signal,
         target: runtimeConfig.tailscale.target,
       });
       log.info(
         `tailscale ${runtimeConfig.tailscale.mode} configured for port ${runtimeConfig.serve.port}`,
       );
-      if (cancellation.isCancelled()) {
+      if (options.signal?.aborted) {
         return cancelledGmailWatcherStart(runtimeConfig);
       }
     } catch (err) {
-      if (cancellation.isCancelled()) {
+      if (options.signal?.aborted) {
         return cancelledGmailWatcherStart(runtimeConfig);
       }
       log.error(`tailscale setup failed: ${String(err)}`);
@@ -410,16 +362,12 @@ export async function startGmailWatcher(
         started: false,
         reason: `tailscale setup failed: ${String(err)}`,
       };
-    } finally {
-      cancellation.dispose();
     }
   }
 
   // Start the Gmail watch (register with Gmail API)
-  const cancellation = createGmailWatcherCancellation(options);
-  const watchStarted = await startGmailWatch(runtimeConfig, { signal: cancellation.signal });
-  cancellation.dispose();
-  if (cancellation.isCancelled()) {
+  const watchStarted = await startGmailWatch(runtimeConfig, { signal: options.signal });
+  if (options.signal?.aborted) {
     return cancelledGmailWatcherStart(runtimeConfig);
   }
   if (!watchStarted) {
@@ -427,9 +375,6 @@ export async function startGmailWatcher(
   }
 
   // Spawn the gog serve process
-  if (isGmailWatcherStartCancelled(options)) {
-    return cancelledGmailWatcherStart(runtimeConfig);
-  }
   shuttingDown = false;
   watcherProcess = spawnGogServe(runtimeConfig);
   const renewMs = runtimeConfig.renewEveryMinutes * 60_000;

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -823,6 +823,60 @@ describe("openclaw launcher", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32").each([true, false])(
+    "preserves foreground Gmail shutdown grace with compile cache (source=%s)",
+    async (sourceCheckout) => {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      if (sourceCheckout) {
+        await addGitMarker(fixtureRoot);
+      }
+      const readyPath = path.join(fixtureRoot, "gmail-ready.json");
+      const stoppedPath = path.join(fixtureRoot, "gmail-stopped.txt");
+      await fs.writeFile(
+        path.join(fixtureRoot, "dist", "entry.js"),
+        [
+          'import { writeFileSync } from "node:fs";',
+          `process.on("SIGTERM", () => setTimeout(() => { writeFileSync(${JSON.stringify(stoppedPath)}, "stopped"); process.exit(0); }, 3025));`,
+          `writeFileSync(${JSON.stringify(readyPath)}, JSON.stringify({ pid: process.pid }));`,
+          "setInterval(() => {}, 1000);",
+        ].join("\n"),
+      );
+      const launcher = spawn(
+        process.execPath,
+        [
+          path.join(fixtureRoot, "openclaw.mjs"),
+          "webhooks",
+          "--profile",
+          "fixture",
+          "gmail",
+          "run",
+        ],
+        {
+          cwd: fixtureRoot,
+          env: launcherEnv({ NODE_COMPILE_CACHE: path.join(fixtureRoot, ".node-cache") }),
+          stdio: "ignore",
+        },
+      );
+      let ownerPid: number | undefined;
+      try {
+        ownerPid = (await waitForJsonFile<{ pid: number }>(readyPath, 5000)).pid;
+        launcher.kill("SIGTERM");
+        await expect(waitForProcessExit(launcher, "foreground Gmail", 5000)).resolves.toEqual({
+          code: 0,
+          signal: null,
+        });
+        await expect(fs.readFile(stoppedPath, "utf8")).resolves.toBe("stopped");
+        expect(isProcessAlive(ownerPid)).toBe(false);
+      } finally {
+        for (const pid of [ownerPid, launcher.pid]) {
+          if (isProcessAlive(pid)) {
+            process.kill(pid!, "SIGKILL");
+          }
+        }
+      }
+    },
+  );
+
   it.runIf(process.platform !== "win32").each([
     { signal: "SIGINT" as const, exitCode: 130 },
     { signal: "SIGTERM" as const, exitCode: 143 },


### PR DESCRIPTION
Closes #130852

<details>
<summary>Additional instructions</summary>

This branch is in the main repository and is editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw webhooks gmail run` would silently lose forwarding after the replacement watcher exited: the command stayed alive and renewed Gmail watches with no serve process left. It also fixes recovery getting stuck when an exited watcher leaves descendants holding its output pipes open.

## Why This Change Was Made

The foreground CLI now uses the existing resolved-config Gmail watcher lifecycle shared with Gateway startup and reload. That owner handles every replacement, bounded output drain, bind-error classification, single-flight renewal, and process-tree cleanup; the CLI still owns option resolution, prerequisites, and signals. This removes the duplicate foreground supervisor and redundant cancellation polling/controller rather than maintaining two restart policies. Built-CLI proof also caught the generic startup wrapper terminating this foreground owner after two seconds, before its three-second cleanup finished. Foreground Gmail now stays in the invoking process across ordinary and compile-cache startup, while one-shot setup keeps its existing wrapper behavior.

Unexpected POSIX leader exits clean up only that active watcher's owned process group. Windows does not run `taskkill` against an already-exited root PID. Normal shutdown retains its three-second grace period, late stderr still classifies bind conflicts, and CLI overrides remain usable with hooks disabled without rewriting config. Setup registration remains fatal on failure; watcher renewal-error policy is unchanged. No new configuration flags, schemas, protocols, or dependencies.

## User Impact

Foreground forwarding recovers after repeated unexpected watcher exits using the shared five-second restart delay. Ctrl-C/SIGTERM cancels pending startup, restarts, and renewal work and waits for tree cleanup. Bind conflicts stop restart attempts with an actionable log message. See [the webhook CLI reference](https://docs.openclaw.ai/cli/webhooks).

The separate degraded OAuth/renewal-health behavior requested in #96088 is not fixed or closed by this change.

## Evidence

The pre-fix regression failed with **expected third child, got two**, and the same failure reproduced independently from stable tag `v2026.7.1`. The inherited-pipe fixture recorded `originalExited=true`, `originalClosed=false`, `spawned=1`, and a live resistant helper after seven seconds; no replacement arrived before its twelve-second deadline. The Windows dead-root termination regression also failed before the repair.

Final local proof:

- 71 focused tests passed across `gmail-ops.test.ts`, `gmail-watcher.test.ts`, `gmail-watcher-lifecycle.test.ts`, `cli/webhooks-cli.test.ts`, and `process/child-process.test.ts` using `node scripts/run-vitest.mjs` with those explicit paths.
- 11 Gateway cancellation/startup/reload tests passed using `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts src/gateway/server-reload-handlers.test.ts -t 'Gmail watcher|Gmail restart|post-ready sidecar teardown'`; 306 unrelated tests were intentionally unselected.
- The real fake-gog process-tree integration test passed. Its heavy import now occurs during collection rather than consuming the test's 15-second runtime budget; no timeout increase.
- An additional 138 launcher/CLI tests passed (one opt-in real-Bun case skipped). Seven new startup-policy and compile-cache shutdown cases failed before the wrapper repair; both source and packaged launcher fixtures now complete their 3.025-second cleanup and exit 0. The fixture-only launcher lane uses its documented `OPENCLAW_E2E_SKIP_BUILD=1` because it supplies its own entry files.
- Core tsgo; plugins-platform, gateway-root, core-other and root test tsgo; scoped oxlint; formatting; assertion safety; import-cycle checks; and `git diff --check` passed.

`pnpm build` passed on final head `f2db9972eb855f8d14c0286c9476130bb506876b` (11m 0.4s). The actual built `openclaw.mjs webhooks gmail run` then passed offline process proof on macOS with an isolated HOME/config/state, a fake `gog` first on a minimal PATH, explicit fixture options, and `--tailscale off`. Kernel sandboxing denied network access to the command and all descendants. Two forced watcher exits produced exactly one replacement each; earlier SIGTERM-resistant pipe-holding helpers were gone before the next watcher became ready. SIGTERM exited the CLI with code 0, all three watchers and all three helpers were already gone before harness cleanup, and config bytes were unchanged. The checked-in launcher fixtures separately cover source and packaged compile-cache startup.

Fresh independent Codex autoreview of the combined final patch, including the built-CLI shutdown correction, completed with no actionable P0 findings. Source review covered the CLI producer, shared owner, Gateway cancellation callers, process output drain/tree cleanup, existing sibling tests, current main, and Node's child-process exit/close ordering. A recursive foreground callback was rejected because it would retain divergent renewal, bind, cancellation, and shutdown behavior; a new supervisor abstraction was unnecessary.

Production LOC: **+115/-199 (net -84)**. Tests: **+516/-175 (net +341)**. Twenty production lines are a pure move of launcher bootstrap execution below its existing argument-parser definitions. Docs: **+1/-1**. The regression tests exercise observable restart/renewal/termination outcomes and add no test-only production seam.

Provenance: carried forward; original introduction unknown. Blame reaches shallow boundary `e357203be5721f55434e7fc9891268e5c6afdd38` (2026-07-12, Vincent Koc), which does not establish introduction. Stable-tag source independently exhibits the defect. Current main's unrelated model-runtime reload changes are in disjoint hunks.

Proof limits: all account/topic/token values are fixtures. No live Gmail account, real gog, Gateway, cloud setup, or email delivery was used or tested, as explicitly required for this task. Windows behavior is modeled in tests, not verified on native Windows. This is process lifecycle proof, not end-to-end email delivery.

AI-assisted; maintainer reviewed and understood the ownership and behavior changes. No release/version/changelog changes.
