### PR TITLE
fix(agents): release cancelled runs during credential refresh

### DIFF
--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -299,13 +299,14 @@ async function runEmbeddedAgentInternal(
         noteLaneTaskProgress,
         () =>
           params.preparedModelRuntimeMode === "isolated-read-only"
-            ? acquireReadOnlyPreparedModelRuntime(preparedInput)
+            ? acquireReadOnlyPreparedModelRuntime(preparedInput, params.abortSignal)
             : acquireAgentRunPreparedModelRuntime(preparedInput, {
                 retainIdleRunOwner,
                 // Turns need only configured admission facts. Full live model inventory remains
                 // available through the snapshot's lazy control-plane loader.
                 catalogMode: "static",
                 ...(params.pluginGeneration ? { pluginGeneration: params.pluginGeneration } : {}),
+                abortSignal: params.abortSignal,
               }),
       );
       startupStages.mark("prepared-runtime");

--- a/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
+++ b/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
@@ -651,6 +651,7 @@ describe("prepared harness source delivery", () => {
     mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "ok" }]);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["ok"] }));
     useOpenAIPlatformAuthFixture();
+    const abortSignal = new AbortController().signal;
 
     const isolatedProbeParams: RunEmbeddedAgentInternalParams = {
       ...overflowBaseRunParams,
@@ -662,6 +663,7 @@ describe("prepared harness source delivery", () => {
       preparedModelRuntimeMode: "isolated-read-only",
       runId: "isolated-probe-generation",
       sessionKey: undefined,
+      abortSignal,
       workspaceDir,
     };
     const result = await withPreparedModelRuntimePluginGenerationScope(
@@ -671,6 +673,7 @@ describe("prepared harness source delivery", () => {
 
     expect(mockedAcquireAgentRunPreparedModelRuntime).toHaveBeenCalledWith(
       expect.objectContaining({ config, loadRuntimePlugins: true, workspaceDir }),
+      abortSignal,
     );
     expect(result.payloads).toEqual([{ text: "ok" }]);
     expect(release).toHaveBeenCalledOnce();

--- a/src/agents/isolated-completion.ts
+++ b/src/agents/isolated-completion.ts
@@ -460,7 +460,7 @@ export async function runIsolatedCompletion(
         },
       ],
     },
-    { catalogMode: "static" },
+    { catalogMode: "static", abortSignal: request.abortSignal },
   );
   const pluginRegistry = lease.snapshot.pluginRegistry;
   try {

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -88,6 +88,10 @@ export class PreparedModelRuntimeAuthPublicationOwner {
     return true;
   }
 
+  owners(transaction: PreparedModelRuntimeAuthTransaction): readonly PreparedModelRuntimeOwner[] {
+    return [...transaction.ownerGates.keys()];
+  }
+
   resolve(
     transaction: PreparedModelRuntimeAuthTransaction,
     owners: Map<string, PreparedModelRuntimeOwner>,
@@ -136,6 +140,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
       }>,
     ) => Promise<void>;
     commit?: () => void;
+    onOwnerFailure?: (error: unknown) => void;
   }): Promise<void> {
     while (this.#events.length > 0) {
       const events = this.#events.splice(0);
@@ -152,17 +157,30 @@ export class PreparedModelRuntimeAuthPublicationOwner {
       try {
         await params.publish(entries);
       } catch (error) {
-        // A newer mutation supersedes this failed batch and already belongs to this worker.
-        // Keep draining so its corrective generation is never left without a publication owner.
-        const failedOwnersCovered = entries.every(({ owner }) =>
-          this.#events.some(
-            (event) =>
-              event.affectsInheritedStores ||
-              owner.input.agentDir === event.agentDir ||
-              owner.input.inheritedAuthDir === event.agentDir,
-          ),
+        const failedOwners = entries.filter(
+          ({ owner }) =>
+            !this.#events.some(
+              (event) =>
+                event.affectsInheritedStores ||
+                owner.input.agentDir === event.agentDir ||
+                owner.input.inheritedAuthDir === event.agentDir,
+            ),
         );
-        if (!failedOwnersCovered) {
+        for (const { owner } of failedOwners) {
+          const gate = this.#transaction?.ownerGates.get(owner);
+          if (gate) {
+            if (owner.pending === gate.promise) {
+              owner.pending = undefined;
+            }
+            this.#transaction?.ownerGates.delete(owner);
+            gate.reject(error);
+          }
+        }
+        if (failedOwners.length > 0) {
+          params.onOwnerFailure?.(error);
+        }
+        // Newer events remain owned by this worker even when they target independent owners.
+        if (this.#events.length === 0) {
           throw error;
         }
       }

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -149,7 +149,23 @@ export class PreparedModelRuntimeAuthPublicationOwner {
           ),
         )
         .map((owner) => ({ owner, input: owner.input }));
-      await params.publish(entries);
+      try {
+        await params.publish(entries);
+      } catch (error) {
+        // A newer mutation supersedes this failed batch and already belongs to this worker.
+        // Keep draining so its corrective generation is never left without a publication owner.
+        const failedOwnersCovered = entries.every(({ owner }) =>
+          this.#events.some(
+            (event) =>
+              event.affectsInheritedStores ||
+              owner.input.agentDir === event.agentDir ||
+              owner.input.inheritedAuthDir === event.agentDir,
+          ),
+        );
+        if (!failedOwnersCovered) {
+          throw error;
+        }
+      }
     }
     // The queue check and commit share one synchronous section so no mutation can be orphaned.
     params.commit?.();

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -16,6 +16,7 @@ type PreparedModelRuntimeAuthTransaction = {
   adoptedBy?: PreparedModelRuntimeReplacementGateId;
   ownerGates: Map<PreparedModelRuntimeOwner, Deferred<PreparedModelRuntimeSnapshot>>;
   publicationQueued: boolean;
+  readyOwners: Set<PreparedModelRuntimeOwner>;
 };
 
 export class PreparedModelRuntimeAuthPublicationOwner {
@@ -29,8 +30,13 @@ export class PreparedModelRuntimeAuthPublicationOwner {
     this.#events.push(event);
     const transaction =
       this.#transaction ??
-      (this.#transaction = { ownerGates: new Map(), publicationQueued: false });
+      (this.#transaction = {
+        ownerGates: new Map(),
+        publicationQueued: false,
+        readyOwners: new Set(),
+      });
     for (const owner of invalidatedOwners) {
+      transaction.readyOwners.delete(owner);
       let gate = transaction.ownerGates.get(owner);
       if (!gate) {
         gate = createDeferredCore<PreparedModelRuntimeSnapshot>();
@@ -156,7 +162,16 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         .map((owner) => ({ owner, input: owner.input }));
       try {
         await params.publish(entries);
+        for (const { owner } of entries) {
+          if (!owner.needsRefresh) {
+            this.#transaction?.readyOwners.add(owner);
+          }
+        }
       } catch (error) {
+        if (this.#transaction?.adoptedBy) {
+          // The replacement transaction exclusively settles adopted gates from its own result.
+          throw error;
+        }
         const failedOwners = entries.filter(
           ({ owner }) =>
             !this.#events.some(
@@ -167,6 +182,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
             ),
         );
         for (const { owner } of failedOwners) {
+          this.#transaction?.readyOwners.delete(owner);
           const gate = this.#transaction?.ownerGates.get(owner);
           if (gate) {
             if (owner.pending === gate.promise) {
@@ -180,7 +196,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
           params.onOwnerFailure?.(error);
         }
         // Newer events remain owned by this worker even when they target independent owners.
-        if (this.#events.length === 0) {
+        if (this.#events.length === 0 && this.#transaction?.readyOwners.size === 0) {
           throw error;
         }
       }

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -1,0 +1,172 @@
+import { createDeferredCore, type Deferred } from "../shared/deferred.js";
+import { PreparedModelRuntimePublicationSupersededError } from "./prepared-model-runtime.errors.js";
+import { ownerKey, resolveConfiguredOwner } from "./prepared-model-runtime.owner.js";
+import type {
+  PreparedModelRuntimeOwner,
+  PreparedModelRuntimeReplacementGateId,
+  PreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.types.js";
+
+export type PreparedModelRuntimeAuthMutation = {
+  agentDir?: string;
+  affectsInheritedStores: boolean;
+};
+
+type PreparedModelRuntimeAuthTransaction = {
+  adoptedBy?: PreparedModelRuntimeReplacementGateId;
+  ownerGates: Map<PreparedModelRuntimeOwner, Deferred<PreparedModelRuntimeSnapshot>>;
+  publicationQueued: boolean;
+};
+
+export class PreparedModelRuntimeAuthPublicationOwner {
+  readonly #events: PreparedModelRuntimeAuthMutation[] = [];
+  #transaction: PreparedModelRuntimeAuthTransaction | undefined;
+
+  enqueue(
+    event: PreparedModelRuntimeAuthMutation,
+    invalidatedOwners: readonly PreparedModelRuntimeOwner[],
+  ): PreparedModelRuntimeAuthTransaction {
+    this.#events.push(event);
+    const transaction =
+      this.#transaction ??
+      (this.#transaction = { ownerGates: new Map(), publicationQueued: false });
+    for (const owner of invalidatedOwners) {
+      let gate = transaction.ownerGates.get(owner);
+      if (!gate) {
+        gate = createDeferredCore<PreparedModelRuntimeSnapshot>();
+        transaction.ownerGates.set(owner, gate);
+        void gate.promise.catch(() => undefined);
+      }
+      owner.pending = gate.promise;
+    }
+    return transaction;
+  }
+
+  claimPublication(transaction: PreparedModelRuntimeAuthTransaction): boolean {
+    if (transaction.publicationQueued) {
+      return false;
+    }
+    transaction.publicationQueued = true;
+    return true;
+  }
+
+  isCurrent(transaction: PreparedModelRuntimeAuthTransaction): boolean {
+    return this.#transaction === transaction;
+  }
+
+  adopt(gateId: PreparedModelRuntimeReplacementGateId): void {
+    if (this.#transaction) {
+      this.#transaction.adoptedBy = gateId;
+    }
+  }
+
+  adoptTransaction(
+    transaction: PreparedModelRuntimeAuthTransaction,
+    gateId: PreparedModelRuntimeReplacementGateId,
+  ): void {
+    if (this.#transaction === transaction) {
+      transaction.adoptedBy = gateId;
+    }
+  }
+
+  prepareAdoptedCommit(
+    gateId: PreparedModelRuntimeReplacementGateId,
+  ): PreparedModelRuntimeAuthTransaction | undefined {
+    const transaction = this.#transaction;
+    if (transaction?.adoptedBy !== gateId) {
+      return undefined;
+    }
+    this.clearOwnerGates(transaction);
+    return transaction;
+  }
+
+  prepareCommit(transaction: PreparedModelRuntimeAuthTransaction): boolean {
+    if (this.#transaction !== transaction) {
+      return false;
+    }
+    this.clearOwnerGates(transaction);
+    return true;
+  }
+
+  resolve(
+    transaction: PreparedModelRuntimeAuthTransaction,
+    owners: Map<string, PreparedModelRuntimeOwner>,
+  ): void {
+    if (this.#transaction === transaction) {
+      this.#transaction = undefined;
+    }
+    this.clearOwnerGates(transaction);
+    for (const [owner, gate] of transaction.ownerGates) {
+      const published =
+        owners.get(ownerKey(owner.input)) ?? resolveConfiguredOwner(owners, owner.input);
+      if (published?.snapshot && !published.needsRefresh && !published.pending) {
+        gate.resolve(published.snapshot);
+      } else {
+        gate.reject(
+          new PreparedModelRuntimePublicationSupersededError(
+            `prepared model runtime publication was superseded for ${owner.input.agentDir}`,
+          ),
+        );
+      }
+    }
+  }
+
+  reject(transaction: PreparedModelRuntimeAuthTransaction, error: Error): void {
+    if (this.#transaction === transaction) {
+      this.#transaction = undefined;
+    }
+    this.clearOwnerGates(transaction);
+    for (const gate of transaction.ownerGates.values()) {
+      gate.reject(error);
+    }
+  }
+
+  rejectAdopted(gateId: PreparedModelRuntimeReplacementGateId, error: Error): void {
+    if (this.#transaction?.adoptedBy === gateId) {
+      this.reject(this.#transaction, error);
+    }
+  }
+
+  async drain(params: {
+    owners: Map<string, PreparedModelRuntimeOwner>;
+    publish: (
+      entries: Array<{
+        owner: PreparedModelRuntimeOwner;
+        input: PreparedModelRuntimeOwner["input"];
+      }>,
+    ) => Promise<void>;
+    commit?: () => void;
+  }): Promise<void> {
+    while (this.#events.length > 0) {
+      const events = this.#events.splice(0);
+      const entries = [...params.owners.values()]
+        .filter((owner) =>
+          events.some(
+            (event) =>
+              event.affectsInheritedStores ||
+              owner.input.agentDir === event.agentDir ||
+              owner.input.inheritedAuthDir === event.agentDir,
+          ),
+        )
+        .map((owner) => ({ owner, input: owner.input }));
+      await params.publish(entries);
+    }
+    // The queue check and commit share one synchronous section so no mutation can be orphaned.
+    params.commit?.();
+  }
+
+  reset(error: Error): void {
+    if (this.#transaction) {
+      this.reject(this.#transaction, error);
+    }
+    this.#events.length = 0;
+  }
+
+  private clearOwnerGates(transaction: PreparedModelRuntimeAuthTransaction): void {
+    for (const [owner, gate] of transaction.ownerGates) {
+      if (owner.pending === gate.promise) {
+        owner.pending = undefined;
+      }
+    }
+  }
+}

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -18,15 +18,38 @@ type PreparedModelRuntimeAuthTransaction = {
   publicationQueued: boolean;
 };
 
+function partitionAuthMutationOwners(
+  mutations: readonly (readonly PreparedModelRuntimeOwner[])[],
+): PreparedModelRuntimeOwner[][] {
+  // Overlapping owner identities share one atomic failure boundary. Independent components
+  // retain FIFO order so one scoped credential failure cannot poison an unrelated owner.
+  const components: Set<PreparedModelRuntimeOwner>[] = [];
+  for (const invalidatedOwners of mutations) {
+    const target = new Set(invalidatedOwners);
+    let insertAt = components.length;
+    for (let index = components.length - 1; index >= 0; index -= 1) {
+      if (![...target].some((owner) => components[index]!.has(owner))) {
+        continue;
+      }
+      insertAt = index;
+      for (const owner of components[index]!) {
+        target.add(owner);
+      }
+      components.splice(index, 1);
+    }
+    components.splice(insertAt, 0, target);
+  }
+  return components.map((component) => Array.from(component));
+}
+
 export class PreparedModelRuntimeAuthPublicationOwner {
-  readonly #events: PreparedModelRuntimeAuthMutation[] = [];
+  readonly #events: (readonly PreparedModelRuntimeOwner[])[] = [];
   #transaction: PreparedModelRuntimeAuthTransaction | undefined;
 
   enqueue(
-    event: PreparedModelRuntimeAuthMutation,
     invalidatedOwners: readonly PreparedModelRuntimeOwner[],
   ): PreparedModelRuntimeAuthTransaction {
-    this.#events.push(event);
+    this.#events.push([...invalidatedOwners]);
     const transaction =
       this.#transaction ??
       (this.#transaction = {
@@ -86,50 +109,8 @@ export class PreparedModelRuntimeAuthPublicationOwner {
   resolve(
     transaction: PreparedModelRuntimeAuthTransaction,
     owners: Map<string, PreparedModelRuntimeOwner>,
-    entries?: readonly { owner: PreparedModelRuntimeOwner }[],
-    publishOwners?: (owners: readonly PreparedModelRuntimeOwner[]) => void,
   ): boolean {
     if (this.#transaction !== transaction) {
-      return false;
-    }
-    if (entries) {
-      if (transaction.adoptedBy) {
-        return false;
-      }
-      const completed = entries.flatMap(({ owner }) => {
-        const gate = transaction.ownerGates.get(owner);
-        return gate &&
-          owner.pending === gate.promise &&
-          owners.get(ownerKey(owner.input)) === owner &&
-          owner.snapshot &&
-          !owner.needsRefresh
-          ? [{ owner, gate, snapshot: owner.snapshot }]
-          : [];
-      });
-      if (completed.length === 0 || !publishOwners) {
-        return false;
-      }
-      // Publish the replacement projection before releasing exact-gate waiters. If projection
-      // construction fails, restoring pending keeps the failed generation unavailable.
-      for (const { owner } of completed) {
-        owner.pending = undefined;
-      }
-      try {
-        publishOwners(completed.map(({ owner }) => owner));
-      } catch (error) {
-        for (const { owner, gate } of completed) {
-          if (transaction.ownerGates.get(owner) === gate && owner.pending === undefined) {
-            owner.pending = gate.promise;
-          }
-        }
-        throw error;
-      }
-      for (const { owner, gate, snapshot } of completed) {
-        if (transaction.ownerGates.get(owner) === gate) {
-          transaction.ownerGates.delete(owner);
-          gate.resolve(snapshot);
-        }
-      }
       return false;
     }
     if (transaction.adoptedBy) {
@@ -157,6 +138,57 @@ export class PreparedModelRuntimeAuthPublicationOwner {
     return true;
   }
 
+  settleComponent(
+    transaction: PreparedModelRuntimeAuthTransaction,
+    componentOwners: readonly PreparedModelRuntimeOwner[],
+    owners: Map<string, PreparedModelRuntimeOwner>,
+    publishOwners: (owners: readonly PreparedModelRuntimeOwner[]) => void,
+  ): void {
+    if (this.#transaction !== transaction || transaction.adoptedBy) {
+      return;
+    }
+    const queuedOwners = new Set(this.#events.flat());
+    const unsettled = componentOwners.flatMap((owner) => {
+      const gate = transaction.ownerGates.get(owner);
+      return gate && !queuedOwners.has(owner) ? [{ owner, gate }] : [];
+    });
+    const completed = unsettled.flatMap(({ owner, gate }) =>
+      owner.pending === gate.promise &&
+      owners.get(ownerKey(owner.input)) === owner &&
+      owner.snapshot &&
+      !owner.needsRefresh
+        ? [{ owner, gate, snapshot: owner.snapshot }]
+        : [],
+    );
+    // Dispatch projection must become visible before exact-gate waiters resume.
+    for (const { owner } of completed) {
+      owner.pending = undefined;
+    }
+    try {
+      if (completed.length > 0) {
+        publishOwners(completed.map(({ owner }) => owner));
+      }
+    } catch (error) {
+      for (const { owner, gate } of completed) {
+        if (transaction.ownerGates.get(owner) === gate && owner.pending === undefined) {
+          owner.pending = gate.promise;
+        }
+      }
+      throw error;
+    }
+    for (const { owner, gate, snapshot } of completed) {
+      transaction.ownerGates.delete(owner);
+      gate.resolve(snapshot);
+    }
+    this.rejectComponentOwners(
+      transaction,
+      componentOwners,
+      new PreparedModelRuntimePublicationSupersededError(
+        "prepared model runtime auth publication owner was superseded",
+      ),
+    );
+  }
+
   reject(transaction: PreparedModelRuntimeAuthTransaction, error: Error): void {
     if (this.#transaction === transaction) {
       this.#transaction = undefined;
@@ -181,56 +213,34 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         input: PreparedModelRuntimeOwner["input"];
       }>,
     ) => Promise<void>;
-    publishOwners?: (owners: readonly PreparedModelRuntimeOwner[]) => void;
+    publishOwners: (owners: readonly PreparedModelRuntimeOwner[]) => void;
     commit?: () => void;
     onOwnerFailure?: (error: unknown) => void;
   }): Promise<void> {
     while (this.#events.length > 0) {
-      const events = this.#events.splice(0);
-      const entries = [...params.owners.values()]
-        .filter((owner) =>
-          events.some(
-            (event) =>
-              event.affectsInheritedStores ||
-              owner.input.agentDir === event.agentDir ||
-              owner.input.inheritedAuthDir === event.agentDir,
-          ),
-        )
-        .map((owner) => ({ owner, input: owner.input }));
-      try {
-        await params.publish(entries);
-      } catch (error) {
-        if (this.#transaction?.adoptedBy) {
-          // The replacement transaction exclusively settles adopted gates from its own result.
-          throw error;
-        }
-        const failedOwners = entries.filter(
-          ({ owner }) =>
-            !this.#events.some(
-              (event) =>
-                event.affectsInheritedStores ||
-                owner.input.agentDir === event.agentDir ||
-                owner.input.inheritedAuthDir === event.agentDir,
-            ),
+      const components = partitionAuthMutationOwners(this.#events.splice(0));
+      for (const componentOwners of components) {
+        const entries = componentOwners.flatMap((owner) =>
+          params.owners.get(ownerKey(owner.input)) === owner ? [{ owner, input: owner.input }] : [],
         );
-        for (const { owner } of failedOwners) {
-          const gate = this.#transaction?.ownerGates.get(owner);
-          if (gate) {
-            if (owner.pending === gate.promise) {
-              owner.pending = undefined;
-            }
-            this.#transaction?.ownerGates.delete(owner);
-            gate.reject(error);
+        try {
+          if (entries.length > 0) {
+            await params.publish(entries);
+          }
+          const transaction = this.#transaction;
+          if (transaction) {
+            this.settleComponent(transaction, componentOwners, params.owners, params.publishOwners);
+          }
+        } catch (error) {
+          if (this.#transaction?.adoptedBy) {
+            // The replacement transaction exclusively settles adopted gates from its own result.
+            throw error;
+          }
+          const transaction = this.#transaction;
+          if (transaction && this.rejectComponentOwners(transaction, componentOwners, error) > 0) {
+            params.onOwnerFailure?.(error);
           }
         }
-        if (failedOwners.length > 0) {
-          params.onOwnerFailure?.(error);
-        }
-        continue;
-      }
-      const transaction = this.#transaction;
-      if (transaction) {
-        this.resolve(transaction, params.owners, entries, params.publishOwners);
       }
     }
     // The queue check and commit share one synchronous section so no mutation can be orphaned.
@@ -250,5 +260,30 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         owner.pending = undefined;
       }
     }
+  }
+
+  private rejectComponentOwners(
+    transaction: PreparedModelRuntimeAuthTransaction,
+    componentOwners: readonly PreparedModelRuntimeOwner[],
+    error: unknown,
+  ): number {
+    const queuedOwners = new Set(this.#events.flat());
+    let rejected = 0;
+    for (const owner of componentOwners) {
+      if (queuedOwners.has(owner)) {
+        continue;
+      }
+      const gate = transaction.ownerGates.get(owner);
+      if (!gate) {
+        continue;
+      }
+      if (owner.pending === gate.promise) {
+        owner.pending = undefined;
+      }
+      transaction.ownerGates.delete(owner);
+      gate.reject(error);
+      rejected += 1;
+    }
+    return rejected;
   }
 }

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -16,7 +16,6 @@ type PreparedModelRuntimeAuthTransaction = {
   adoptedBy?: PreparedModelRuntimeReplacementGateId;
   ownerGates: Map<PreparedModelRuntimeOwner, Deferred<PreparedModelRuntimeSnapshot>>;
   publicationQueued: boolean;
-  readyOwners: Set<PreparedModelRuntimeOwner>;
 };
 
 export class PreparedModelRuntimeAuthPublicationOwner {
@@ -33,10 +32,8 @@ export class PreparedModelRuntimeAuthPublicationOwner {
       (this.#transaction = {
         ownerGates: new Map(),
         publicationQueued: false,
-        readyOwners: new Set(),
       });
     for (const owner of invalidatedOwners) {
-      transaction.readyOwners.delete(owner);
       let gate = transaction.ownerGates.get(owner);
       if (!gate) {
         gate = createDeferredCore<PreparedModelRuntimeSnapshot>();
@@ -86,24 +83,62 @@ export class PreparedModelRuntimeAuthPublicationOwner {
     return transaction;
   }
 
-  prepareCommit(transaction: PreparedModelRuntimeAuthTransaction): boolean {
-    if (this.#transaction !== transaction) {
-      return false;
-    }
-    this.clearOwnerGates(transaction);
-    return true;
-  }
-
-  owners(transaction: PreparedModelRuntimeAuthTransaction): readonly PreparedModelRuntimeOwner[] {
-    return [...transaction.ownerGates.keys()];
-  }
-
   resolve(
     transaction: PreparedModelRuntimeAuthTransaction,
     owners: Map<string, PreparedModelRuntimeOwner>,
-  ): void {
-    if (this.#transaction === transaction) {
+    entries?: readonly { owner: PreparedModelRuntimeOwner }[],
+    publishOwners?: (owners: readonly PreparedModelRuntimeOwner[]) => void,
+  ): boolean {
+    if (this.#transaction !== transaction) {
+      return false;
+    }
+    if (entries) {
+      if (transaction.adoptedBy) {
+        return false;
+      }
+      const completed = entries.flatMap(({ owner }) => {
+        const gate = transaction.ownerGates.get(owner);
+        return gate &&
+          owner.pending === gate.promise &&
+          owners.get(ownerKey(owner.input)) === owner &&
+          owner.snapshot &&
+          !owner.needsRefresh
+          ? [{ owner, gate, snapshot: owner.snapshot }]
+          : [];
+      });
+      if (completed.length === 0 || !publishOwners) {
+        return false;
+      }
+      // Publish the replacement projection before releasing exact-gate waiters. If projection
+      // construction fails, restoring pending keeps the failed generation unavailable.
+      for (const { owner } of completed) {
+        owner.pending = undefined;
+      }
+      try {
+        publishOwners(completed.map(({ owner }) => owner));
+      } catch (error) {
+        for (const { owner, gate } of completed) {
+          if (transaction.ownerGates.get(owner) === gate && owner.pending === undefined) {
+            owner.pending = gate.promise;
+          }
+        }
+        throw error;
+      }
+      for (const { owner, gate, snapshot } of completed) {
+        if (transaction.ownerGates.get(owner) === gate) {
+          transaction.ownerGates.delete(owner);
+          gate.resolve(snapshot);
+        }
+      }
+      return false;
+    }
+    if (transaction.adoptedBy) {
       this.#transaction = undefined;
+    } else if (transaction.ownerGates.size === 0) {
+      this.#transaction = undefined;
+      return true;
+    } else {
+      return false;
     }
     this.clearOwnerGates(transaction);
     for (const [owner, gate] of transaction.ownerGates) {
@@ -119,6 +154,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         );
       }
     }
+    return true;
   }
 
   reject(transaction: PreparedModelRuntimeAuthTransaction, error: Error): void {
@@ -145,6 +181,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         input: PreparedModelRuntimeOwner["input"];
       }>,
     ) => Promise<void>;
+    publishOwners?: (owners: readonly PreparedModelRuntimeOwner[]) => void;
     commit?: () => void;
     onOwnerFailure?: (error: unknown) => void;
   }): Promise<void> {
@@ -162,11 +199,6 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         .map((owner) => ({ owner, input: owner.input }));
       try {
         await params.publish(entries);
-        for (const { owner } of entries) {
-          if (!owner.needsRefresh) {
-            this.#transaction?.readyOwners.add(owner);
-          }
-        }
       } catch (error) {
         if (this.#transaction?.adoptedBy) {
           // The replacement transaction exclusively settles adopted gates from its own result.
@@ -182,7 +214,6 @@ export class PreparedModelRuntimeAuthPublicationOwner {
             ),
         );
         for (const { owner } of failedOwners) {
-          this.#transaction?.readyOwners.delete(owner);
           const gate = this.#transaction?.ownerGates.get(owner);
           if (gate) {
             if (owner.pending === gate.promise) {
@@ -195,10 +226,11 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         if (failedOwners.length > 0) {
           params.onOwnerFailure?.(error);
         }
-        // Newer events remain owned by this worker even when they target independent owners.
-        if (this.#events.length === 0 && this.#transaction?.readyOwners.size === 0) {
-          throw error;
-        }
+        continue;
+      }
+      const transaction = this.#transaction;
+      if (transaction) {
+        this.resolve(transaction, params.owners, entries, params.publishOwners);
       }
     }
     // The queue check and commit share one synchronous section so no mutation can be orphaned.

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -5,13 +5,13 @@ import { getPreparedModelRuntimeBorrowedSnapshot } from "./prepared-model-runtim
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
   PreparedModelRuntimePublicationSupersededError,
-  hasConfiguredOwnerMatching,
   ownerKey,
   normalizePreparedModelRuntimeInput,
   preparedModelRuntimeConfigsMatch,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
   resolveConfiguredOwner,
+  resolveConfiguredOwnerPublication,
   type PreparedModelRuntimeInput,
   type PreparedModelRuntimeLease,
   type PreparedModelRuntimeOwner,
@@ -155,7 +155,13 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
         }
         const canActivateConfiglessSetup =
           input.agentId !== undefined && isReservedSystemAgentId(input.agentId);
-        if (hasConfiguredOwnerMatching(context.owners, input) || !canActivateConfiglessSetup) {
+        const configuredOwner = resolveConfiguredOwnerPublication(context.owners, input);
+        if (configuredOwner.matches || !canActivateConfiglessSetup) {
+          const pending = configuredOwner.pending;
+          if (pending) {
+            await pending;
+            continue;
+          }
           throw error;
         }
         // First-run Model Setup uses the reserved system-agent identity before a configless gateway

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -1,4 +1,5 @@
 /** Agent-run lease admission for lifecycle-owned prepared model runtimes. */
+import { createAbortError, racePromiseWithAbortSignal } from "../infra/abort-signal.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { isReservedSystemAgentId } from "../system-agent/agent-id.js";
 import { getPreparedModelRuntimeBorrowedSnapshot } from "./prepared-model-runtime-generation-scope.js";
@@ -32,6 +33,14 @@ type PreparedModelRuntimeLeaseContext = {
   prepareSnapshot(input: PreparedModelRuntimeInput): Promise<PreparedModelRuntimeSnapshot>;
 };
 
+function throwIfLeaseAdmissionAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createAbortError("Prepared model runtime lease admission aborted", {
+      cause: signal.reason,
+    });
+  }
+}
+
 export async function acquirePreparedModelRuntimeLeaseFromOwners(
   rawInput: PreparedModelRuntimeInput,
   provenance: "run" | "ephemeral",
@@ -41,6 +50,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
     catalogMode?: PreparedModelRuntimeCatalogMode;
     pluginGeneration?: PreparedModelRuntimeOwner["pluginGeneration"];
     pluginMetadataSnapshot?: PluginMetadataSnapshot;
+    abortSignal?: AbortSignal;
   } = {},
 ): Promise<PreparedModelRuntimeLease> {
   let normalizedInput = normalizePreparedModelRuntimeInput({
@@ -67,11 +77,12 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
   let owner: PreparedModelRuntimeOwner;
   let snapshot: PreparedModelRuntimeSnapshot;
   for (;;) {
+    throwIfLeaseAdmissionAborted(options.abortSignal);
     // Replacement owns publication from synchronous staling through atomic generation commit.
     // Dynamic work arriving inside that window must retry after the new owners become visible.
     const replacement = context.getPendingReplacement();
     if (replacement) {
-      await replacement.promise;
+      await racePromiseWithAbortSignal(replacement.promise, options.abortSignal);
       if (context.getPendingReplacement()) {
         continue;
       }
@@ -84,7 +95,10 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
     if (provenance === "run" && context.getGatewayLifecycleActive() && options.pluginGeneration) {
       const configuredOwner = resolveConfiguredOwner(context.owners, input);
       if (configuredOwner?.pending) {
-        await configuredOwner.pending.catch(() => undefined);
+        await racePromiseWithAbortSignal(
+          configuredOwner.pending.catch(() => undefined),
+          options.abortSignal,
+        );
         continue;
       }
       if (
@@ -110,6 +124,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
         ) {
           // A turn may finish under its still-open parent lease after reload. Its historic
           // generation must never publish over the configured owner for newly admitted work.
+          throwIfLeaseAdmissionAborted(options.abortSignal);
           return { snapshot: borrowed, release: () => {} };
         }
         throw new PreparedModelRuntimeOwnerNotPublishedError(
@@ -129,7 +144,10 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
     if (existing?.pending && pluginGenerationChanged) {
       // Do not supersede active discovery. Wait for its owner to settle, then retry against
       // the published identity so same-generation callers still coalesce.
-      await existing.pending.catch(() => undefined);
+      await racePromiseWithAbortSignal(
+        existing.pending.catch(() => undefined),
+        options.abortSignal,
+      );
       continue;
     }
     if (
@@ -159,7 +177,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
         if (configuredOwner.matches || !canActivateConfiglessSetup) {
           const pending = configuredOwner.pending;
           if (pending) {
-            await pending;
+            await racePromiseWithAbortSignal(pending, options.abortSignal);
             continue;
           }
           throw error;
@@ -172,7 +190,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
       if (existing?.pending && !pluginGenerationChanged) {
         // Matching callers lease the immutable generation they joined even if a queued
         // mismatched caller publishes the next owner immediately after this one settles.
-        snapshot = await existing.pending;
+        snapshot = await racePromiseWithAbortSignal(existing.pending, options.abortSignal);
         if (existing.snapshot !== snapshot || existing.needsRefresh) {
           continue;
         }
@@ -180,21 +198,27 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
         break;
       }
       if (existing && !staleDynamicOwner && !pluginGenerationChanged) {
-        snapshot = await context.prepareSnapshot(input);
+        snapshot = await racePromiseWithAbortSignal(
+          context.prepareSnapshot(input),
+          options.abortSignal,
+        );
       } else {
         // Fresh keys publish a first generation; stale dynamic owners publish a distinct
         // replacement owner because existing leases retain their immutable snapshot, so
         // their release cannot delete the generation admitted for new work at this key.
-        snapshot = await publishModelRuntimeSnapshot(
-          input,
-          context.owners,
-          context.agentBuildCompletions,
-          context.getBuildTimeoutMs(),
-          undefined,
-          provenance,
-          options.catalogMode,
-          options.pluginGeneration,
-          options.pluginMetadataSnapshot,
+        snapshot = await racePromiseWithAbortSignal(
+          publishModelRuntimeSnapshot(
+            input,
+            context.owners,
+            context.agentBuildCompletions,
+            context.getBuildTimeoutMs(),
+            undefined,
+            provenance,
+            options.catalogMode,
+            options.pluginGeneration,
+            options.pluginMetadataSnapshot,
+          ),
+          options.abortSignal,
         );
       }
     } catch (error) {
@@ -216,9 +240,11 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
     owner = published;
     break;
   }
+  throwIfLeaseAdmissionAborted(options.abortSignal);
   if (owner.provenance !== provenance) {
     return { snapshot, release: () => {} };
   }
+  throwIfLeaseAdmissionAborted(options.abortSignal);
   if (provenance === "run" && options.retainIdleRunOwner) {
     context.retainedDirectRunOwners.retain(key, owner, context.owners);
   } else if (provenance === "run" && context.getGatewayLifecycleActive()) {

--- a/src/agents/prepared-model-runtime-materializations.ts
+++ b/src/agents/prepared-model-runtime-materializations.ts
@@ -13,7 +13,7 @@ type MaterializationMutationEvent = {
   affectsInheritedStores: boolean;
 };
 
-function configuredOwnersAreRequestVisible(
+export function configuredOwnersAreRequestVisible(
   owners: ReadonlyMap<string, PreparedModelRuntimeOwner>,
 ): boolean {
   for (const owner of owners.values()) {

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -240,7 +240,7 @@ describe("prepared reply dispatch runtime", () => {
     expect(configuredSelectedBefore).not.toBe(configuredRuntimeBefore?.inboundPluginRegistry);
   });
 
-  it("removes only the affected configured projection during an auth refresh", async () => {
+  it("waits only the affected configured projection during an auth refresh", async () => {
     mocks.configuredAgentIds = ["default", "worker"];
     const config = { agents: { defaults: { model: "openai/gpt-5.5" } } };
     await refreshPreparedModelRuntimeSnapshots(config, {
@@ -264,9 +264,7 @@ describe("prepared reply dispatch runtime", () => {
     const defaultRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
     const workerRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
     await expect(defaultRead).resolves.toBe(defaultRuntime);
-    await expect(workerRead).rejects.toThrow(
-      "prepared reply dispatch runtime owner was not published for worker",
-    );
+    await expect(workerRead).resolves.not.toBe(workerRuntime);
 
     await published.promise;
     unregister();
@@ -278,5 +276,38 @@ describe("prepared reply dispatch runtime", () => {
       workspaceDir: "/tmp/workspace-worker",
     });
     expect(refreshedWorker).not.toBe(workerRuntime);
+  });
+
+  it("keeps run admission pending while auth publication replaces its projection", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    const input = {
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      config,
+      workspaceDir: "/tmp/unused-workspace",
+    };
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    let finishAuthRefresh: (() => void) | undefined;
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
+      async () =>
+        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
+          finishAuthRefresh = () => resolve({ agentDir: input.agentDir, wrote: false });
+        }),
+    );
+
+    mocks.mutationListener?.({ agentDir: input.agentDir, affectsInheritedStores: false });
+    await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
+    const admission = acquireAgentRunPreparedModelRuntime(input);
+    const observed = admission.then(
+      () => "resolved",
+      () => "rejected",
+    );
+    await expect(Promise.race([observed, Promise.resolve("pending")])).resolves.toBe("pending");
+
+    finishAuthRefresh?.();
+    const lease = await admission;
+    expect(lease.snapshot).toMatchObject({ agentId: "default", agentDir: input.agentDir });
+    lease.release();
   });
 });

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -278,6 +278,41 @@ describe("prepared reply dispatch runtime", () => {
     expect(refreshedWorker).not.toBe(workerRuntime);
   });
 
+  it("keeps a rejected auth refresh projection unavailable without affecting siblings", async () => {
+    mocks.configuredAgentIds = ["default", "worker"];
+    await refreshPreparedModelRuntimeSnapshots(
+      {},
+      {
+        gatewayLifecycle: true,
+        catalogMode: "static",
+      },
+    );
+    const defaultRuntime = await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    const refreshFailed = createDeferred();
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      if (event.phase === "failed") {
+        refreshFailed.resolve();
+      }
+    });
+    mocks.discoverAuthStorage.mockImplementationOnce(() => {
+      throw new Error("auth refresh rejected");
+    });
+
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-worker",
+      affectsInheritedStores: false,
+    });
+    await refreshFailed.promise;
+    unregister();
+
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" })).rejects.toThrow(
+      "prepared reply dispatch runtime owner was not published for worker",
+    );
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" })).resolves.toBe(
+      defaultRuntime,
+    );
+  });
+
   it("keeps run admission pending while auth publication replaces its projection", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = {};

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -2,6 +2,7 @@
 // oxfmt-ignore
 import {
   getPreparedModelRuntimeMocks,
+  getPreparedModelRuntimeTestApi,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -313,16 +314,18 @@ describe("prepared reply dispatch runtime", () => {
     );
   });
 
-  it("keeps run admission pending while auth publication replaces its projection", async () => {
+  it("aborts run admission without retaining an owner after auth publication", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = {};
     const input = {
       agentId: "default",
       agentDir: "/tmp/unused-agent",
       config,
-      workspaceDir: "/tmp/unused-workspace",
+      workspaceDir: "/tmp/dynamic-workspace",
     };
     await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const testApi = getPreparedModelRuntimeTestApi();
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
     let finishAuthRefresh: (() => void) | undefined;
     mocks.ensureOpenClawModelsJson.mockImplementationOnce(
       async () =>
@@ -333,16 +336,23 @@ describe("prepared reply dispatch runtime", () => {
 
     mocks.mutationListener?.({ agentDir: input.agentDir, affectsInheritedStores: false });
     await vi.waitFor(() => expect(finishAuthRefresh).toBeDefined());
-    const admission = acquireAgentRunPreparedModelRuntime(input);
+    const abort = new AbortController();
+    const admission = acquireAgentRunPreparedModelRuntime(input, { abortSignal: abort.signal });
     const observed = admission.then(
       () => "resolved",
       () => "rejected",
     );
     await expect(Promise.race([observed, Promise.resolve("pending")])).resolves.toBe("pending");
+    abort.abort(new Error("request cancelled"));
+    await expect(admission).rejects.toMatchObject({ name: "AbortError" });
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
 
     finishAuthRefresh?.();
-    const lease = await admission;
+    await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+    const lease = await acquireAgentRunPreparedModelRuntime(input);
     expect(lease.snapshot).toMatchObject({ agentId: "default", agentDir: input.agentDir });
+    expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(2);
     lease.release();
   });
 });

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -6,6 +6,7 @@ import {
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import {
   acquireAgentRunPreparedModelRuntime,
@@ -921,6 +922,34 @@ describe("prepared model runtime snapshots", () => {
     expect(runtime).toBe(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }));
     expect(events.filter((phase) => phase === "published")).toHaveLength(1);
     expect(events).not.toContain("failed");
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("continues with a corrective auth mutation after the earlier build fails", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    const agentDir = "/tmp/unused-agent";
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const firstBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const secondBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const firstError = new Error("superseded auth build failed");
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(async () => await firstBuild.promise)
+      .mockImplementationOnce(async () => await secondBuild.promise);
+
+    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void dispatch.catch(() => undefined);
+    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+    firstBuild.reject(firstError);
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+    await expect(
+      Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    secondBuild.resolve({ agentDir, wrote: false });
+    await expect(dispatch).resolves.toMatchObject({ agentId: "default", agentDir });
     expect(mocks.warn).not.toHaveBeenCalled();
   });
 

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -780,42 +780,6 @@ describe("prepared model runtime snapshots", () => {
     expect(mocks.discoverModels).toHaveBeenCalledOnce();
   });
 
-  it("awaits auth invalidation queued during lifecycle publication", async () => {
-    mocks.configuredAgentIds = ["default"];
-    await refreshPreparedModelRuntimeSnapshots({});
-    let finishConfigRefresh: (() => void) | undefined;
-    let finishAuthRefresh: (() => void) | undefined;
-    mocks.ensureOpenClawModelsJson
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-            finishConfigRefresh = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-          }),
-      )
-      .mockImplementationOnce(
-        async () =>
-          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-            finishAuthRefresh = () => resolve({ agentDir: "/tmp/unused-agent", wrote: false });
-          }),
-      );
-
-    const publication = refreshPreparedModelRuntimeSnapshots({});
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
-    finishConfigRefresh?.();
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
-    let settled = false;
-    void publication.then(() => {
-      settled = true;
-    });
-    await Promise.resolve();
-    expect(settled).toBe(false);
-
-    finishAuthRefresh?.();
-    await publication;
-    expect(settled).toBe(true);
-  });
-
   it("defers an in-flight auth refresh to a superseding config publication", async () => {
     mocks.configuredAgentIds = ["default"];
     await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
@@ -866,8 +830,8 @@ describe("prepared model runtime snapshots", () => {
       }
     });
 
-    // The mutation queues an auth task; the synchronous stale edge of the config
-    // refresh opens the replacement gate before that task runs.
+    // The auth mutation starts first; the synchronous stale edge of the config refresh transfers
+    // its queued event to the replacement transaction before the auth task can publish.
     mocks.mutationListener?.({ affectsInheritedStores: true });
     await refreshPreparedModelRuntimeSnapshots(replacementConfig, { gatewayLifecycle: true });
     unregister();

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -876,15 +876,13 @@ describe("prepared model runtime snapshots", () => {
     expect(publishedSnapshots[0]).toMatchObject({ config: replacementConfig });
   });
 
-  it("invalidates and refreshes the affected owner at auth publication", async () => {
+  it("waits for the affected owner at auth publication", async () => {
     const config = {};
     const agentDir = "/tmp/prepared-model-runtime-auth";
     const first = await publishPreparedModelRuntimeSnapshot({ config, agentDir });
 
     mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    await expect(prepareModelRuntimeSnapshot({ config, agentDir })).rejects.toThrow(
-      "stale after auth mutation",
-    );
+    await expect(prepareModelRuntimeSnapshot({ config, agentDir })).resolves.not.toBe(first);
 
     await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
     const refreshed = await prepareModelRuntimeSnapshot({ config, agentDir });

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -6,7 +6,6 @@ import {
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createDeferred } from "../../test/helpers/promise.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import {
   acquireAgentRunPreparedModelRuntime,
@@ -922,34 +921,6 @@ describe("prepared model runtime snapshots", () => {
     expect(runtime).toBe(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }));
     expect(events.filter((phase) => phase === "published")).toHaveLength(1);
     expect(events).not.toContain("failed");
-    expect(mocks.warn).not.toHaveBeenCalled();
-  });
-
-  it("continues with a corrective auth mutation after the earlier build fails", async () => {
-    mocks.configuredAgentIds = ["default"];
-    const config = {};
-    const agentDir = "/tmp/unused-agent";
-    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
-    const firstBuild = createDeferred<{ agentDir: string; wrote: false }>();
-    const secondBuild = createDeferred<{ agentDir: string; wrote: false }>();
-    const firstError = new Error("superseded auth build failed");
-    mocks.ensureOpenClawModelsJson
-      .mockImplementationOnce(async () => await firstBuild.promise)
-      .mockImplementationOnce(async () => await secondBuild.promise);
-
-    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
-    void dispatch.catch(() => undefined);
-    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
-    firstBuild.reject(firstError);
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
-    await expect(
-      Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
-    ).resolves.toBe("pending");
-
-    secondBuild.resolve({ agentDir, wrote: false });
-    await expect(dispatch).resolves.toMatchObject({ agentId: "default", agentDir });
     expect(mocks.warn).not.toHaveBeenCalled();
   });
 

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -878,29 +878,50 @@ describe("prepared model runtime snapshots", () => {
     expect(mocks.warn).not.toHaveBeenCalled();
   });
 
-  it("rejects a deduplicated caller when an auth refresh is superseded", async () => {
+  it("keeps one dispatch gate across overlapping auth mutations", async () => {
+    mocks.configuredAgentIds = ["default"];
     const config = {};
-    const agentDir = "/tmp/prepared-model-runtime-auth-pending-superseded";
-    await publishPreparedModelRuntimeSnapshot({ config, agentDir });
+    const agentDir = "/tmp/unused-agent";
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const events: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      events.push(event.phase);
+    });
     let finishFirstRefresh: (() => void) | undefined;
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(
-      async () =>
-        await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
-          finishFirstRefresh = () => resolve({ agentDir, wrote: false });
-        }),
-    );
+    let finishSecondRefresh: (() => void) | undefined;
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(
+        async () =>
+          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
+            finishFirstRefresh = () => resolve({ agentDir, wrote: false });
+          }),
+      )
+      .mockImplementationOnce(
+        async () =>
+          await new Promise<{ agentDir: string; wrote: false }>((resolve) => {
+            finishSecondRefresh = () => resolve({ agentDir, wrote: false });
+          }),
+      );
 
     mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
     await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const deduplicated = publishPreparedModelRuntimeSnapshot({ config, agentDir });
+    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void dispatch.catch(() => undefined);
     mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
     finishFirstRefresh?.();
-
-    await expect(deduplicated).rejects.toThrow("superseded");
     await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
-    await expect(prepareModelRuntimeSnapshot({ config, agentDir })).resolves.toMatchObject({
-      agentDir,
-    });
+    await expect(
+      Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    finishSecondRefresh?.();
+    const runtime = await dispatch;
+    unregister();
+
+    expect(runtime).toBe(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }));
+    expect(events.filter((phase) => phase === "published")).toHaveLength(1);
+    expect(events).not.toContain("failed");
+    expect(mocks.warn).not.toHaveBeenCalled();
   });
 
   it("does not let a superseded owner hide a genuine sibling refresh failure", async () => {

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -453,6 +453,9 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
     owner.pendingPluginGeneration = params.reusePluginGenerations
       ? owner.pluginGeneration
       : undefined;
+    // Auth invalidation wraps this batch in a transaction-wide promise. The batch promise keeps
+    // its own supersession guard, then restores the outer promise until dispatch publication.
+    const previousPending = owner.pending;
     const generation = owner.generation;
     const key = ownerKey(input);
     let registered = params.owners.get(key) === owner;
@@ -471,12 +474,17 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         params.owners.get(key) === owner,
       key,
       generation,
+      previousPending,
       markRegistered: () => {
         registered = true;
       },
       owner,
     };
   });
+  const candidatePublications = new Map<
+    PreparedModelRuntimeOwner,
+    Promise<PreparedModelRuntimeSnapshot>
+  >();
   const groups = new Map<PreparedModelRuntimeOwner["catalogMode"], typeof candidates>();
   for (const candidate of candidates) {
     const group = groups.get(candidate.catalogMode);
@@ -584,7 +592,9 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         candidate.owner.snapshot = snapshot;
         results.set(candidate.owner, { ...result, snapshot });
         candidate.owner.pluginGeneration = result.pluginGeneration;
-        candidate.owner.pending = undefined;
+        if (candidate.owner.pending === candidatePublications.get(candidate.owner)) {
+          candidate.owner.pending = candidate.previousPending;
+        }
         candidate.owner.needsRefresh = false;
       }
     } catch (error) {
@@ -596,7 +606,9 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         if (!candidate.isCurrent()) {
           continue;
         }
-        candidate.owner.pending = undefined;
+        if (candidate.owner.pending === candidatePublications.get(candidate.owner)) {
+          candidate.owner.pending = candidate.previousPending;
+        }
         candidate.owner.needsRefresh = true;
         candidate.owner.refreshError = refreshError;
       }
@@ -614,6 +626,7 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
       }
       return results.get(candidate.owner)!.snapshot;
     });
+    candidatePublications.set(candidate.owner, pending);
     candidate.owner.pending = pending;
     void pending.catch(() => undefined);
   }

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -141,12 +141,15 @@ function findConfiguredOwnerCandidates(
       : identityCandidates;
 }
 
-/** Whether a configured owner matches the requesting runtime's identity/directory. */
-export function hasConfiguredOwnerMatching(
+export function resolveConfiguredOwnerPublication(
   owners: Map<string, PreparedModelRuntimeOwner>,
   rawInput: PreparedModelRuntimeInput,
-): boolean {
-  return findConfiguredOwnerCandidates(owners, rawInput).length > 0;
+): { matches: boolean; pending?: Promise<PreparedModelRuntimeSnapshot> } {
+  const candidates = findConfiguredOwnerCandidates(owners, rawInput);
+  return {
+    matches: candidates.length > 0,
+    pending: candidates.length === 1 ? candidates[0]?.pending : undefined,
+  };
 }
 
 export function resolveConfiguredOwner(

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -453,9 +453,6 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
     owner.pendingPluginGeneration = params.reusePluginGenerations
       ? owner.pluginGeneration
       : undefined;
-    // Auth invalidation wraps this batch in a transaction-wide promise. The batch promise keeps
-    // its own supersession guard, then restores the outer promise until dispatch publication.
-    const previousPending = owner.pending;
     const generation = owner.generation;
     const key = ownerKey(input);
     let registered = params.owners.get(key) === owner;
@@ -474,17 +471,12 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         params.owners.get(key) === owner,
       key,
       generation,
-      previousPending,
       markRegistered: () => {
         registered = true;
       },
       owner,
     };
   });
-  const candidatePublications = new Map<
-    PreparedModelRuntimeOwner,
-    Promise<PreparedModelRuntimeSnapshot>
-  >();
   const groups = new Map<PreparedModelRuntimeOwner["catalogMode"], typeof candidates>();
   for (const candidate of candidates) {
     const group = groups.get(candidate.catalogMode);
@@ -592,9 +584,6 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         candidate.owner.snapshot = snapshot;
         results.set(candidate.owner, { ...result, snapshot });
         candidate.owner.pluginGeneration = result.pluginGeneration;
-        if (candidate.owner.pending === candidatePublications.get(candidate.owner)) {
-          candidate.owner.pending = candidate.previousPending;
-        }
         candidate.owner.needsRefresh = false;
       }
     } catch (error) {
@@ -606,30 +595,12 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
         if (!candidate.isCurrent()) {
           continue;
         }
-        if (candidate.owner.pending === candidatePublications.get(candidate.owner)) {
-          candidate.owner.pending = candidate.previousPending;
-        }
         candidate.owner.needsRefresh = true;
         candidate.owner.refreshError = refreshError;
       }
       throw refreshError;
     }
   })();
-  for (const candidate of candidates) {
-    const pending = publication.then(() => {
-      // A newer auth publication may win while this batch finishes. Reject deduplicated callers
-      // at the owner boundary so the stale snapshot cannot escape despite being skipped at commit.
-      if (!candidate.isCurrent()) {
-        throw new PreparedModelRuntimePublicationSupersededError(
-          `prepared model runtime publication was superseded for ${candidate.input.agentDir}`,
-        );
-      }
-      return results.get(candidate.owner)!.snapshot;
-    });
-    candidatePublications.set(candidate.owner, pending);
-    candidate.owner.pending = pending;
-    void pending.catch(() => undefined);
-  }
   await publication;
 }
 

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -1,0 +1,111 @@
+// Preserve module setup before modules that consume it.
+// oxfmt-ignore
+import {
+  getPreparedModelRuntimeMocks,
+  resetPreparedModelRuntimeHarness,
+} from "./prepared-model-runtime.test-harness.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  loadPublishedGatewayReplyDispatchRuntime,
+  registerPreparedModelRuntimePublicationListener,
+  refreshPreparedModelRuntimeSnapshots,
+} from "./prepared-model-runtime.js";
+
+const mocks = getPreparedModelRuntimeMocks();
+
+describe("prepared model runtime reload auth adoption", () => {
+  beforeEach(() => {
+    resetPreparedModelRuntimeHarness();
+  });
+
+  it("commits auth invalidation inside the active lifecycle publication", async () => {
+    mocks.configuredAgentIds = ["default", "worker"];
+    const initialConfig = {};
+    const replacementConfig = { agents: { defaults: { model: "openai/gpt-5.5" } } };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const configBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const authBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const order: string[] = [];
+    const events: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      events.push(event.phase);
+      if (event.phase === "published") {
+        order.push("config-published");
+      }
+    });
+    let defaultBuildCount = 0;
+    mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
+      if (agentDir !== "/tmp/unused-agent") {
+        return { agentDir: String(agentDir), wrote: false };
+      }
+      defaultBuildCount += 1;
+      if (defaultBuildCount === 1) {
+        order.push("config-build-start");
+        return await configBuild.promise;
+      }
+      order.push("auth-drain-start");
+      return await authBuild.promise;
+    });
+
+    const publication = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+      gatewayLifecycle: true,
+    });
+    void publication.catch(() => undefined);
+    await vi.waitFor(() => expect(order).toContain("config-build-start"));
+    order.push("auth-mutation");
+    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
+    const affectedRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }).then(
+      (runtime) => {
+        order.push("affected-dispatch-resolved");
+        return runtime;
+      },
+    );
+    const siblingRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+    void affectedRead.catch(() => undefined);
+    void siblingRead.catch(() => undefined);
+    order.push("config-build-finish");
+    configBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    await vi.waitFor(() => expect(order).toContain("auth-drain-start"));
+    await expect(
+      Promise.race([publication.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+    await expect(
+      Promise.race([affectedRead.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    order.push("auth-drain-finish");
+    authBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    await expect(publication).resolves.toBeUndefined();
+    const [affectedRuntime, siblingRuntime] = await Promise.all([affectedRead, siblingRead]);
+    unregister();
+
+    expect(events.filter((phase) => phase === "published")).toHaveLength(1);
+    expect(events).not.toContain("failed");
+    expect(mocks.warn).not.toHaveBeenCalled();
+    expect(affectedRuntime?.config).toBe(replacementConfig);
+    expect(siblingRuntime?.config).toBe(replacementConfig);
+    expect(order).toEqual([
+      "config-build-start",
+      "auth-mutation",
+      "config-build-finish",
+      "auth-drain-start",
+      "auth-drain-finish",
+      "config-published",
+      "affected-dispatch-resolved",
+    ]);
+    const buildCountAfterPublication = mocks.ensureOpenClawModelsJson.mock.calls.length;
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(buildCountAfterPublication);
+    const lease = await acquireAgentRunPreparedModelRuntime({
+      agentId: "default",
+      agentDir: "/tmp/unused-agent",
+      config: replacementConfig,
+      workspaceDir: "/tmp/unused-workspace",
+    });
+    expect(lease.snapshot.config).toBe(replacementConfig);
+    lease.release();
+  });
+});

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -258,4 +258,77 @@ describe("prepared model runtime reload auth adoption", () => {
     expect(mocks.warn).toHaveBeenCalledOnce();
     expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining(workerError.message));
   });
+
+  it("commits a successful owner when the final independent owner fails", async () => {
+    mocks.configuredAgentIds = ["default", "worker", "research"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const workerBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const researchBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const researchError = new Error("final research auth build failed");
+    mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
+      if (agentDir === "/tmp/configured-worker") {
+        return await workerBuild.promise;
+      }
+      if (agentDir === "/tmp/configured-research") {
+        return await researchBuild.promise;
+      }
+      return { agentDir: String(agentDir), wrote: false };
+    });
+
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-worker",
+      affectsInheritedStores: false,
+    });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
+    const workerDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+    void workerDispatch.catch(() => undefined);
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-research",
+      affectsInheritedStores: false,
+    });
+    const researchDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" });
+    void researchDispatch.catch(() => undefined);
+    workerBuild.resolve({ agentDir: "/tmp/configured-worker", wrote: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(5));
+    researchBuild.reject(researchError);
+
+    await expect(workerDispatch).resolves.toMatchObject({ agentId: "worker" });
+    await expect(researchDispatch).rejects.toBe(researchError);
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" })).rejects.toThrow(
+      "prepared reply dispatch runtime owner was not published for research",
+    );
+  });
+
+  it("lets an adopting reload settle the gate after the obsolete auth build fails", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const initialConfig = {};
+    const replacementConfig = { plugins: {} };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const authBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const configBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const obsoleteAuthError = new Error("obsolete auth build failed");
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(async () => await authBuild.promise)
+      .mockImplementationOnce(async () => await configBuild.promise);
+
+    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void authWaiter.catch(() => undefined);
+    const reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+      gatewayLifecycle: true,
+    });
+    void reload.catch(() => undefined);
+    authBuild.reject(obsoleteAuthError);
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+    await expect(
+      Promise.race([authWaiter.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    configBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    await expect(reload).resolves.toBeUndefined();
+    await expect(authWaiter).resolves.toMatchObject({ config: replacementConfig });
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -108,4 +108,77 @@ describe("prepared model runtime reload auth adoption", () => {
     expect(lease.snapshot.config).toBe(replacementConfig);
     lease.release();
   });
+
+  it("adopts an in-flight auth gate into a same-owner config reload", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const initialConfig = {};
+    const replacementConfig = { plugins: {} };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const authBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const configBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const events: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      events.push(event.phase);
+    });
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(async () => await authBuild.promise)
+      .mockImplementationOnce(async () => await configBuild.promise);
+
+    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void authWaiter.catch(() => undefined);
+    const reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+      gatewayLifecycle: true,
+    });
+    void reload.catch(() => undefined);
+    authBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+    await expect(
+      Promise.race([authWaiter.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    configBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    await expect(reload).resolves.toBeUndefined();
+    const runtime = await authWaiter;
+    unregister();
+
+    expect(runtime?.config).toBe(replacementConfig);
+    expect(events.filter((phase) => phase === "published")).toHaveLength(1);
+    expect(events).not.toContain("failed");
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("rejects an adopted auth gate when config reload fails and permits recovery", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const initialConfig = {};
+    const replacementConfig = { plugins: {} };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const authBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const reloadError = new Error("replacement config failed");
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(async () => await authBuild.promise)
+      .mockRejectedValueOnce(reloadError);
+
+    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const authWaiter = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void authWaiter.catch(() => undefined);
+    const reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+      gatewayLifecycle: true,
+    });
+    void reload.catch(() => undefined);
+    authBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+
+    await expect(reload).rejects.toBe(reloadError);
+    await expect(authWaiter).rejects.toBe(reloadError);
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" })).rejects.toThrow(
+      "prepared reply dispatch runtime owner was not published for default",
+    );
+
+    await refreshPreparedModelRuntimeSnapshots(replacementConfig, { gatewayLifecycle: true });
+    await expect(
+      loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+    ).resolves.toMatchObject({ config: replacementConfig });
+  });
 });

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -181,4 +181,81 @@ describe("prepared model runtime reload auth adoption", () => {
       loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
     ).resolves.toMatchObject({ config: replacementConfig });
   });
+
+  it("continues with a corrective auth mutation after the earlier build fails", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    const agentDir = "/tmp/unused-agent";
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const firstBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const secondBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const firstError = new Error("superseded auth build failed");
+    mocks.ensureOpenClawModelsJson
+      .mockImplementationOnce(async () => await firstBuild.promise)
+      .mockImplementationOnce(async () => await secondBuild.promise);
+
+    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void dispatch.catch(() => undefined);
+    mocks.mutationListener?.({ agentDir, affectsInheritedStores: false });
+    firstBuild.reject(firstError);
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(3));
+    await expect(
+      Promise.race([dispatch.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    secondBuild.resolve({ agentDir, wrote: false });
+    await expect(dispatch).resolves.toMatchObject({ agentId: "default", agentDir });
+    expect(mocks.warn).not.toHaveBeenCalled();
+  });
+
+  it("publishes an independent queued owner after another auth build fails", async () => {
+    mocks.configuredAgentIds = ["default", "worker", "research"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const workerBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const researchBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const workerError = new Error("worker auth build failed");
+    mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
+      if (agentDir === "/tmp/configured-worker") {
+        return await workerBuild.promise;
+      }
+      if (agentDir === "/tmp/configured-research") {
+        return await researchBuild.promise;
+      }
+      return { agentDir: String(agentDir), wrote: false };
+    });
+
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-worker",
+      affectsInheritedStores: false,
+    });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
+    const workerDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+    void workerDispatch.catch(() => undefined);
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-research",
+      affectsInheritedStores: false,
+    });
+    const researchDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" });
+    void researchDispatch.catch(() => undefined);
+    workerBuild.reject(workerError);
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(5));
+    await expect(workerDispatch).rejects.toBe(workerError);
+    await expect(
+      Promise.race([researchDispatch.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+
+    researchBuild.resolve({ agentDir: "/tmp/configured-research", wrote: false });
+    await expect(researchDispatch).resolves.toMatchObject({
+      agentId: "research",
+      agentDir: "/tmp/configured-research",
+    });
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" })).rejects.toThrow(
+      "prepared reply dispatch runtime owner was not published for worker",
+    );
+    expect(mocks.warn).toHaveBeenCalledOnce();
+    expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining(workerError.message));
+  });
 });

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -275,53 +275,129 @@ describe("prepared model runtime reload auth adoption", () => {
     expect(mocks.warn).not.toHaveBeenCalled();
   });
 
-  it("publishes an independent queued owner after another auth build fails", async () => {
+  it.each([
+    { failedAgentId: "worker", successfulAgentId: "research" },
+    { failedAgentId: "research", successfulAgentId: "worker" },
+  ])(
+    "isolates simultaneous scoped auth failure for $failedAgentId",
+    async ({ failedAgentId, successfulAgentId }) => {
+      mocks.configuredAgentIds = ["default", "worker", "research"];
+      const config = {};
+      await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+      const agentDirs = {
+        research: "/tmp/configured-research",
+        worker: "/tmp/configured-worker",
+      } as const;
+      const builds = {
+        research: createDeferred<{ agentDir: string; wrote: false }>(),
+        worker: createDeferred<{ agentDir: string; wrote: false }>(),
+      };
+      const refreshError = new Error(`${failedAgentId} auth build failed`);
+      mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
+        const agentId =
+          agentDir === agentDirs.worker
+            ? "worker"
+            : agentDir === agentDirs.research
+              ? "research"
+              : undefined;
+        return agentId
+          ? await builds[agentId].promise
+          : { agentDir: String(agentDir), wrote: false };
+      });
+
+      mocks.mutationListener?.({
+        agentDir: agentDirs.worker,
+        affectsInheritedStores: false,
+      });
+      mocks.mutationListener?.({
+        agentDir: agentDirs.research,
+        affectsInheritedStores: false,
+      });
+      const dispatches = {
+        research: loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" }),
+        worker: loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" }),
+      };
+      void dispatches.research.catch(() => undefined);
+      void dispatches.worker.catch(() => undefined);
+      await vi.waitFor(() =>
+        expect(mocks.ensureOpenClawModelsJson.mock.calls.length).toBeGreaterThanOrEqual(4),
+      );
+      if (failedAgentId === "worker") {
+        builds.worker.reject(refreshError);
+      } else {
+        builds.worker.resolve({ agentDir: agentDirs.worker, wrote: false });
+      }
+      await vi.waitFor(() =>
+        expect(mocks.ensureOpenClawModelsJson.mock.calls.length).toBeGreaterThanOrEqual(5),
+      );
+      if (failedAgentId === "research") {
+        builds.research.reject(refreshError);
+      } else {
+        builds.research.resolve({ agentDir: agentDirs.research, wrote: false });
+      }
+
+      await expect(dispatches[failedAgentId]).rejects.toBe(refreshError);
+      await expect(dispatches[successfulAgentId]).resolves.toMatchObject({
+        agentId: successfulAgentId,
+        agentDir: agentDirs[successfulAgentId],
+      });
+      await expect(
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: failedAgentId }),
+      ).rejects.toThrow(
+        `prepared reply dispatch runtime owner was not published for ${failedAgentId}`,
+      );
+      expect(mocks.warn).toHaveBeenCalledOnce();
+      expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining(refreshError.message));
+    },
+  );
+
+  it("keeps transitively overlapping inherited auth mutations atomic", async () => {
     mocks.configuredAgentIds = ["default", "worker", "research"];
-    const config = {};
-    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
-    const workerBuild = createDeferred<{ agentDir: string; wrote: false }>();
-    const researchBuild = createDeferred<{ agentDir: string; wrote: false }>();
-    const workerError = new Error("worker auth build failed");
+    await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
+    const agentDirs = {
+      default: "/tmp/unused-agent",
+      research: "/tmp/configured-research",
+      worker: "/tmp/configured-worker",
+    } as const;
+    const builds = {
+      default: createDeferred<{ agentDir: string; wrote: false }>(),
+      research: createDeferred<{ agentDir: string; wrote: false }>(),
+      worker: createDeferred<{ agentDir: string; wrote: false }>(),
+    };
+    const refreshError = new Error("inherited research auth build failed");
     mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
-      if (agentDir === "/tmp/configured-worker") {
-        return await workerBuild.promise;
-      }
-      if (agentDir === "/tmp/configured-research") {
-        return await researchBuild.promise;
-      }
-      return { agentDir: String(agentDir), wrote: false };
+      const entry = Object.entries(agentDirs).find(
+        ([, configuredDir]) => configuredDir === agentDir,
+      );
+      return entry
+        ? await builds[entry[0] as keyof typeof builds].promise
+        : { agentDir: String(agentDir), wrote: false };
     });
 
-    mocks.mutationListener?.({
-      agentDir: "/tmp/configured-worker",
-      affectsInheritedStores: false,
-    });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
-    const workerDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
-    void workerDispatch.catch(() => undefined);
-    mocks.mutationListener?.({
-      agentDir: "/tmp/configured-research",
-      affectsInheritedStores: false,
-    });
-    const researchDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" });
-    void researchDispatch.catch(() => undefined);
-    workerBuild.reject(workerError);
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(5));
-    await expect(workerDispatch).rejects.toBe(workerError);
-    await expect(
-      Promise.race([researchDispatch.then(() => "settled"), Promise.resolve("pending")]),
-    ).resolves.toBe("pending");
-
-    researchBuild.resolve({ agentDir: "/tmp/configured-research", wrote: false });
-    await expect(researchDispatch).resolves.toMatchObject({
-      agentId: "research",
-      agentDir: "/tmp/configured-research",
-    });
-    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" })).rejects.toThrow(
-      "prepared reply dispatch runtime owner was not published for worker",
+    mocks.mutationListener?.({ agentDir: agentDirs.worker, affectsInheritedStores: false });
+    mocks.mutationListener?.({ agentDir: agentDirs.research, affectsInheritedStores: false });
+    mocks.mutationListener?.({ affectsInheritedStores: true });
+    const dispatches = Object.fromEntries(
+      Object.keys(agentDirs).map((agentId) => [
+        agentId,
+        loadPublishedGatewayReplyDispatchRuntime({ agentId }),
+      ]),
+    ) as Record<keyof typeof agentDirs, Promise<unknown>>;
+    for (const dispatch of Object.values(dispatches)) {
+      void dispatch.catch(() => undefined);
+    }
+    builds.default.resolve({ agentDir: agentDirs.default, wrote: false });
+    builds.worker.resolve({ agentDir: agentDirs.worker, wrote: false });
+    await vi.waitFor(() =>
+      expect(mocks.ensureOpenClawModelsJson.mock.calls.length).toBeGreaterThanOrEqual(6),
     );
+
+    builds.research.reject(refreshError);
+
+    await expect(dispatches.default).rejects.toBe(refreshError);
+    await expect(dispatches.worker).rejects.toBe(refreshError);
+    await expect(dispatches.research).rejects.toBe(refreshError);
     expect(mocks.warn).toHaveBeenCalledOnce();
-    expect(mocks.warn).toHaveBeenCalledWith(expect.stringContaining(workerError.message));
   });
 
   it("commits a successful owner when the final independent owner fails", async () => {
@@ -381,11 +457,10 @@ describe("prepared model runtime reload auth adoption", () => {
     unregister();
   });
 
-  it("rejects the exact gate when reply projection replacement fails", async () => {
-    mocks.configuredAgentIds = ["default"];
+  it("isolates reply projection replacement failure to its component", async () => {
+    mocks.configuredAgentIds = ["default", "worker", "research"];
     const config = {};
     await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
-    const authBuild = createDeferred<{ agentDir: string; wrote: false }>();
     const projectionError = new Error("reply projection replacement failed");
     const events: string[] = [];
     const unregister = registerPreparedModelRuntimePublicationListener((event) => {
@@ -396,17 +471,27 @@ describe("prepared model runtime reload auth adoption", () => {
       .mockImplementationOnce(() => {
         throw projectionError;
       });
-    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async () => await authBuild.promise);
 
-    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
-    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
-    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
-    void dispatch.catch(() => undefined);
-    authBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-worker",
+      affectsInheritedStores: false,
+    });
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-research",
+      affectsInheritedStores: false,
+    });
+    const workerDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+    const researchDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" });
+    void workerDispatch.catch(() => undefined);
+    void researchDispatch.catch(() => undefined);
 
-    await expect(dispatch).rejects.toBe(projectionError);
-    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" })).rejects.toThrow(
-      "prepared reply dispatch runtime owner was not published for default",
+    await expect(workerDispatch).rejects.toBe(projectionError);
+    await expect(researchDispatch).resolves.toMatchObject({
+      agentId: "research",
+      agentDir: "/tmp/configured-research",
+    });
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" })).rejects.toThrow(
+      "prepared reply dispatch runtime owner was not published for worker",
     );
     expect(events.filter((phase) => phase === "failed")).toHaveLength(1);
     replaceSpy.mockRestore();

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -12,6 +12,7 @@ import {
   registerPreparedModelRuntimePublicationListener,
   refreshPreparedModelRuntimeSnapshots,
 } from "./prepared-model-runtime.js";
+import { PreparedReplyDispatchPublicationOwner } from "./prepared-reply-dispatch-runtime.js";
 
 const mocks = getPreparedModelRuntimeMocks();
 
@@ -149,6 +150,70 @@ describe("prepared model runtime reload auth adoption", () => {
     expect(mocks.warn).not.toHaveBeenCalled();
   });
 
+  it("adopts remaining auth work after another owner already published", async () => {
+    mocks.configuredAgentIds = ["default", "worker", "research"];
+    const initialConfig = {};
+    const replacementConfig = { plugins: {} };
+    await refreshPreparedModelRuntimeSnapshots(initialConfig, { gatewayLifecycle: true });
+    const workerAuthBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const researchAuthBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const replacementWorkerBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    let replacementWorkerStarted = false;
+    const events: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      events.push(event.phase);
+    });
+    mocks.ensureOpenClawModelsJson.mockImplementation(async (config, agentDir) => {
+      if (config === initialConfig && agentDir === "/tmp/configured-worker") {
+        return await workerAuthBuild.promise;
+      }
+      if (config === initialConfig && agentDir === "/tmp/configured-research") {
+        return await researchAuthBuild.promise;
+      }
+      if (config === replacementConfig && agentDir === "/tmp/configured-worker") {
+        replacementWorkerStarted = true;
+        return await replacementWorkerBuild.promise;
+      }
+      return { agentDir: String(agentDir), wrote: false };
+    });
+
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-worker",
+      affectsInheritedStores: false,
+    });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
+    const firstWorkerRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+    mocks.mutationListener?.({
+      agentDir: "/tmp/configured-research",
+      affectsInheritedStores: false,
+    });
+    workerAuthBuild.resolve({ agentDir: "/tmp/configured-worker", wrote: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(5));
+    await expect(firstWorkerRead).resolves.toMatchObject({ config: initialConfig });
+
+    const reload = refreshPreparedModelRuntimeSnapshots(replacementConfig, {
+      gatewayLifecycle: true,
+    });
+    const adoptedWorkerRead = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
+    let adoptedWorkerSettled = false;
+    void adoptedWorkerRead.then(() => {
+      adoptedWorkerSettled = true;
+    });
+    await Promise.resolve();
+    expect(adoptedWorkerSettled).toBe(false);
+
+    researchAuthBuild.resolve({ agentDir: "/tmp/configured-research", wrote: false });
+    await vi.waitFor(() => expect(replacementWorkerStarted).toBe(true));
+    expect(adoptedWorkerSettled).toBe(false);
+    replacementWorkerBuild.resolve({ agentDir: "/tmp/configured-worker", wrote: false });
+    await expect(reload).resolves.toBeUndefined();
+    await expect(adoptedWorkerRead).resolves.toMatchObject({ config: replacementConfig });
+    unregister();
+
+    expect(events.filter((phase) => phase === "published")).toHaveLength(1);
+    expect(events).not.toContain("failed");
+  });
+
   it("rejects an adopted auth gate when config reload fails and permits recovery", async () => {
     mocks.configuredAgentIds = ["default"];
     const initialConfig = {};
@@ -266,6 +331,10 @@ describe("prepared model runtime reload auth adoption", () => {
     const workerBuild = createDeferred<{ agentDir: string; wrote: false }>();
     const researchBuild = createDeferred<{ agentDir: string; wrote: false }>();
     const researchError = new Error("final research auth build failed");
+    const events: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      events.push(event.phase);
+    });
     mocks.ensureOpenClawModelsJson.mockImplementation(async (_config, agentDir) => {
       if (agentDir === "/tmp/configured-worker") {
         return await workerBuild.promise;
@@ -283,6 +352,10 @@ describe("prepared model runtime reload auth adoption", () => {
     await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(4));
     const workerDispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "worker" });
     void workerDispatch.catch(() => undefined);
+    let workerSettled = false;
+    void workerDispatch.then(() => {
+      workerSettled = true;
+    });
     mocks.mutationListener?.({
       agentDir: "/tmp/configured-research",
       affectsInheritedStores: false,
@@ -291,6 +364,11 @@ describe("prepared model runtime reload auth adoption", () => {
     void researchDispatch.catch(() => undefined);
     workerBuild.resolve({ agentDir: "/tmp/configured-worker", wrote: false });
     await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(5));
+    await vi.waitFor(() => expect(workerSettled).toBe(true));
+    await expect(
+      Promise.race([researchDispatch.then(() => "settled"), Promise.resolve("pending")]),
+    ).resolves.toBe("pending");
+    expect(events).not.toContain("published");
     researchBuild.reject(researchError);
 
     await expect(workerDispatch).resolves.toMatchObject({ agentId: "worker" });
@@ -298,6 +376,41 @@ describe("prepared model runtime reload auth adoption", () => {
     await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "research" })).rejects.toThrow(
       "prepared reply dispatch runtime owner was not published for research",
     );
+    expect(events).not.toContain("published");
+    expect(events.filter((phase) => phase === "failed")).toHaveLength(1);
+    unregister();
+  });
+
+  it("rejects the exact gate when reply projection replacement fails", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, { gatewayLifecycle: true });
+    const authBuild = createDeferred<{ agentDir: string; wrote: false }>();
+    const projectionError = new Error("reply projection replacement failed");
+    const events: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      events.push(event.phase);
+    });
+    const replaceSpy = vi
+      .spyOn(PreparedReplyDispatchPublicationOwner.prototype, "replace")
+      .mockImplementationOnce(() => {
+        throw projectionError;
+      });
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async () => await authBuild.promise);
+
+    mocks.mutationListener?.({ agentDir: "/tmp/unused-agent", affectsInheritedStores: false });
+    await vi.waitFor(() => expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(2));
+    const dispatch = loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    void dispatch.catch(() => undefined);
+    authBuild.resolve({ agentDir: "/tmp/unused-agent", wrote: false });
+
+    await expect(dispatch).rejects.toBe(projectionError);
+    await expect(loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" })).rejects.toThrow(
+      "prepared reply dispatch runtime owner was not published for default",
+    );
+    expect(events.filter((phase) => phase === "failed")).toHaveLength(1);
+    replaceSpy.mockRestore();
+    unregister();
   });
 
   it("lets an adopting reload settle the gate after the obsolete auth build fails", async () => {

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -278,7 +278,7 @@ describe("prepared model runtime reload auth adoption", () => {
   it.each([
     { failedAgentId: "worker", successfulAgentId: "research" },
     { failedAgentId: "research", successfulAgentId: "worker" },
-  ])(
+  ] as const)(
     "isolates simultaneous scoped auth failure for $failedAgentId",
     async ({ failedAgentId, successfulAgentId }) => {
       mocks.configuredAgentIds = ["default", "worker", "research"];

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -296,6 +296,7 @@ export async function acquireAgentRunPreparedModelRuntime(
     catalogMode?: PreparedModelRuntimeCatalogMode;
     pluginGeneration?: PreparedModelRuntimeOwner["pluginGeneration"];
     pluginMetadataSnapshot?: PluginMetadataSnapshot;
+    abortSignal?: AbortSignal;
   } = {},
 ): Promise<PreparedModelRuntimeLease> {
   return await acquirePreparedModelRuntimeLeaseFromOwners(
@@ -309,11 +310,13 @@ export async function acquireAgentRunPreparedModelRuntime(
 /** Acquires an exact read-only generation scoped to the returned lease. */
 export async function acquireReadOnlyPreparedModelRuntime(
   rawInput: PreparedModelRuntimeInput,
+  abortSignal?: AbortSignal,
 ): Promise<PreparedModelRuntimeLease> {
   return await acquirePreparedModelRuntimeLeaseFromOwners(
     { ...rawInput, readOnly: true },
     "ephemeral",
     preparedModelRuntimeLeaseContext,
+    { abortSignal },
   );
 }
 

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -626,7 +626,7 @@ function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): voi
     return;
   }
   replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
-  const transaction = authPublication.enqueue(normalizedEvent, invalidatedOwners);
+  const transaction = authPublication.enqueue(invalidatedOwners);
   if (pendingModelRuntimeReplacement) {
     // The active config transaction drains this event before its atomic dispatch commit. Retire
     // the superseded build gate; queuing another task would make this commit depend on future work.

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -589,6 +589,10 @@ async function drainPendingAuthMutations(options: { commit?: () => void } = {}):
         reusePluginGenerations: true,
       }),
     commit: options.commit,
+    onOwnerFailure: (error) => {
+      const refreshError = toStringifiedError(error);
+      log.warn(`auth-triggered model runtime refresh failed: ${String(refreshError)}`);
+    },
   });
 }
 
@@ -652,7 +656,15 @@ function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): voi
         if (!authPublication.prepareCommit(transaction)) {
           return;
         }
-        replyDispatchPublication.rebuild(owners.values());
+        const transactionOwners = authPublication.owners(transaction);
+        replyDispatchPublication.replace(
+          owners.values(),
+          new Set(
+            transactionOwners.flatMap((owner) =>
+              owner.input.agentId ? [owner.input.agentId] : [],
+            ),
+          ),
+        );
         authPublication.resolve(transaction, owners);
         notifyPreparedModelRuntimePublication({ phase: "published" });
       },

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -9,7 +9,10 @@ import {
   type PreparedModelRuntimeAuthMutation,
 } from "./prepared-model-runtime-auth-publication.js";
 import { acquirePreparedModelRuntimeLeaseFromOwners } from "./prepared-model-runtime-lease.js";
-import { registerPreparedRuntimeAuthMaterializationPublisher } from "./prepared-model-runtime-materializations.js";
+import {
+  configuredOwnersAreRequestVisible,
+  registerPreparedRuntimeAuthMaterializationPublisher,
+} from "./prepared-model-runtime-materializations.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
   PreparedModelRuntimeOwnerRetention,
@@ -538,11 +541,11 @@ export function refreshPreparedModelRuntimeSnapshots(
     if (!isPublicationCurrent()) {
       return;
     }
-    await drainPendingAuthMutations({
+    await drainPendingAuthMutations(
       // The final queue check, dispatch rebuild, and replacement resolution are one synchronous
       // commit. A mutation before it is adopted; a mutation after it starts a new auth transaction.
-      commit: commitReplacement,
-    });
+      commitReplacement,
+    );
   }).then(commitReplacement, (error: unknown) => {
     const refreshError = toStringifiedError(error);
     if (isPublicationCurrent()) {
@@ -572,7 +575,7 @@ function enqueuePreparedModelRuntimePublication(task: () => Promise<void>): Prom
   return publication;
 }
 
-async function drainPendingAuthMutations(options: { commit?: () => void } = {}): Promise<void> {
+async function drainPendingAuthMutations(commit?: () => void): Promise<void> {
   await authPublication.drain({
     owners,
     publish: async (entries) =>
@@ -583,9 +586,11 @@ async function drainPendingAuthMutations(options: { commit?: () => void } = {}):
         buildTimeoutMs: modelRuntimeBuildTimeoutMs,
         reusePluginGenerations: true,
       }),
-    commit: options.commit,
+    publishOwners: (publishedOwners) => replyDispatchPublication.replace(publishedOwners),
+    commit,
     onOwnerFailure: (error) => {
       const refreshError = toStringifiedError(error);
+      notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });
       log.warn(`auth-triggered model runtime refresh failed: ${String(refreshError)}`);
     },
   });
@@ -642,27 +647,17 @@ function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): voi
       authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
       return;
     }
-    await drainPendingAuthMutations({
-      commit: () => {
-        if (pendingModelRuntimeReplacement) {
-          authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
-          return;
-        }
-        if (!authPublication.prepareCommit(transaction)) {
-          return;
-        }
-        const transactionOwners = authPublication.owners(transaction);
-        replyDispatchPublication.replace(
-          owners.values(),
-          new Set(
-            transactionOwners.flatMap((owner) =>
-              owner.input.agentId ? [owner.input.agentId] : [],
-            ),
-          ),
-        );
-        authPublication.resolve(transaction, owners);
+    await drainPendingAuthMutations(() => {
+      if (pendingModelRuntimeReplacement) {
+        authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
+        return;
+      }
+      if (!authPublication.resolve(transaction, owners)) {
+        return;
+      }
+      if (configuredOwnersAreRequestVisible(owners)) {
         notifyPreparedModelRuntimePublication({ phase: "published" });
-      },
+      }
     });
   });
   notifyPreparedModelRuntimePublication({ phase: "invalidated" });

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -597,6 +597,7 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
   };
   const staleError = new Error("prepared model runtime owner is stale after auth mutation");
   const invalidatedOwners: PreparedModelRuntimeOwner[] = [];
+  const invalidatedConfiguredAgentIds = new Set<string>();
   for (const owner of owners.values()) {
     if (
       !normalizedEvent.affectsInheritedStores &&
@@ -609,12 +610,16 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     owner.generation += 1;
     owner.needsRefresh = true;
     owner.refreshError = staleError;
+    if (owner.provenance === "configured" && owner.input.agentId) {
+      invalidatedConfiguredAgentIds.add(owner.input.agentId);
+    }
   }
   if (invalidatedOwners.length === 0) {
     // A first owner reads the already-published auth snapshot while it builds. Replaying an earlier
     // mutation would immediately stale that initial generation even though no prior owner existed.
     return;
   }
+  replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
   pendingAuthMutations.push(normalizedEvent);
   const publication = enqueuePreparedModelRuntimePublication(async () => {
     // A pending replacement gate means a queued config publication owns the next generation:

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -22,6 +22,7 @@ import {
   publishPreparedModelRuntimeOwnerBatch,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
+  resolveConfiguredOwnerPublication,
   resolvePublishedOwner,
   type PreparedModelRuntimeOwner,
   type PreparedModelRuntimeInput,
@@ -80,6 +81,12 @@ const pendingAuthMutations: AuthMutationEvent[] = [];
 
 const replyDispatchPublication = new PreparedReplyDispatchPublicationOwner({
   isGatewayLifecycleActive: () => gatewayLifecycleActive,
+  getPendingOwnerPublication: (agentId) =>
+    resolveConfiguredOwnerPublication(owners, {
+      agentId,
+      agentDir: ".",
+      config: {},
+    }).pending,
   getPendingReplacement: () => pendingModelRuntimeReplacement?.promise,
 });
 export const loadPublishedGatewayReplyDispatchRuntime = replyDispatchPublication.load;
@@ -589,8 +596,7 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     agentDir: normalizeOptionalDir(event.agentDir),
   };
   const staleError = new Error("prepared model runtime owner is stale after auth mutation");
-  let invalidatedOwner = false;
-  const invalidatedConfiguredAgentIds = new Set<string>();
+  const invalidatedOwners: PreparedModelRuntimeOwner[] = [];
   for (const owner of owners.values()) {
     if (
       !normalizedEvent.affectsInheritedStores &&
@@ -599,23 +605,18 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     ) {
       continue;
     }
-    invalidatedOwner = true;
+    invalidatedOwners.push(owner);
     owner.generation += 1;
     owner.needsRefresh = true;
     owner.refreshError = staleError;
-    if (owner.provenance === "configured" && owner.input.agentId) {
-      invalidatedConfiguredAgentIds.add(owner.input.agentId);
-    }
   }
-  if (!invalidatedOwner) {
+  if (invalidatedOwners.length === 0) {
     // A first owner reads the already-published auth snapshot while it builds. Replaying an earlier
     // mutation would immediately stale that initial generation even though no prior owner existed.
     return;
   }
-  replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
-  notifyPreparedModelRuntimePublication({ phase: "invalidated" });
   pendingAuthMutations.push(normalizedEvent);
-  void enqueuePreparedModelRuntimePublication(async () => {
+  const publication = enqueuePreparedModelRuntimePublication(async () => {
     // A pending replacement gate means a queued config publication owns the next generation:
     // it drains queued auth mutations against the new config and rebuilds/announces the
     // dispatch publication. Rebuilding here would revive stale owners with the old config or
@@ -629,7 +630,19 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     }
     replyDispatchPublication.rebuild(owners.values());
     notifyPreparedModelRuntimePublication({ phase: "published" });
-  }).catch((error: unknown) => {
+  });
+  for (const owner of invalidatedOwners) {
+    const pending = publication.then(() => owner.snapshot!);
+    owner.pending = pending;
+    const clearPending = () => {
+      if (owner.pending === pending) {
+        owner.pending = undefined;
+      }
+    };
+    void pending.then(clearPending, clearPending);
+  }
+  notifyPreparedModelRuntimePublication({ phase: "invalidated" });
+  void publication.catch((error: unknown) => {
     if (error instanceof PreparedModelRuntimePublicationSupersededError) {
       return;
     }

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -496,6 +496,21 @@ export function refreshPreparedModelRuntimeSnapshots(
   let publicationAgentIds = initialAgentIds;
   const isPublicationCurrent = () =>
     requestEpoch === refreshRequestEpoch && options.isPublicationCurrent?.() !== false;
+  const commitReplacement = () => {
+    if (
+      !isPublicationCurrent() ||
+      !replacement ||
+      pendingModelRuntimeReplacement !== replacement
+    ) {
+      return;
+    }
+    replyDispatchPublication.rebuild(owners.values());
+    pendingModelRuntimeReplacement = undefined;
+    replacement.resolve();
+    // Publication listeners may synchronously read the committed owner. Clear the lifecycle
+    // gate before announcing availability so they cannot observe a false missing generation.
+    notifyPreparedModelRuntimePublication({ phase: "published" });
+  };
   return enqueuePreparedModelRuntimePublication(async () => {
     if (!isPublicationCurrent()) {
       return;
@@ -515,39 +530,32 @@ export function refreshPreparedModelRuntimeSnapshots(
     if (!isPublicationCurrent()) {
       return;
     }
-    await drainPendingAuthMutations();
-    if (!isPublicationCurrent()) {
-      return;
+    await drainPendingAuthMutations({
+      // The final queue check, dispatch rebuild, and replacement resolution are one synchronous
+      // commit. A mutation before it is adopted; a mutation after it starts a new auth transaction.
+      commit: commitReplacement,
+    });
+  }).then(commitReplacement, (error: unknown) => {
+    const refreshError = toStringifiedError(error);
+    if (isPublicationCurrent()) {
+      // Candidate and queued auth builds may finish independently. A failed transaction must
+      // leave no owner from its partially published generation request-visible.
+      updateOwnersForScopedRefresh(owners, publicationAgentIds, refreshError, {
+        clearPending: true,
+        resetPluginGeneration: true,
+      });
     }
-    replyDispatchPublication.rebuild(owners.values());
-  }).then(
-    () => {
-      if (isPublicationCurrent() && replacement && pendingModelRuntimeReplacement === replacement) {
-        pendingModelRuntimeReplacement = undefined;
-        replacement.resolve();
-        // Publication listeners may synchronously read the committed owner. Clear the lifecycle
-        // gate before announcing availability so they cannot observe a false missing generation.
-        notifyPreparedModelRuntimePublication({ phase: "published" });
-      }
-    },
-    (error: unknown) => {
-      const refreshError = toStringifiedError(error);
-      if (isPublicationCurrent()) {
-        // Candidate and queued auth builds may finish independently. A failed transaction must
-        // leave no owner from its partially published generation request-visible.
-        updateOwnersForScopedRefresh(owners, publicationAgentIds, refreshError, {
-          clearPending: true,
-          resetPluginGeneration: true,
-        });
-      }
-      if (isPublicationCurrent() && replacement && pendingModelRuntimeReplacement === replacement) {
-        pendingModelRuntimeReplacement = undefined;
-        replacement.reject(refreshError);
-        notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });
-      }
-      throw refreshError;
-    },
-  );
+    if (
+      isPublicationCurrent() &&
+      replacement &&
+      pendingModelRuntimeReplacement === replacement
+    ) {
+      pendingModelRuntimeReplacement = undefined;
+      replacement.reject(refreshError);
+      notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });
+    }
+    throw refreshError;
+  });
 }
 
 function enqueuePreparedModelRuntimePublication(task: () => Promise<void>): Promise<void> {
@@ -559,7 +567,11 @@ function enqueuePreparedModelRuntimePublication(task: () => Promise<void>): Prom
   return publication;
 }
 
-async function drainPendingAuthMutations(): Promise<void> {
+async function drainPendingAuthMutations(
+  options: {
+    commit?: () => void;
+  } = {},
+): Promise<void> {
   while (pendingAuthMutations.length > 0) {
     const events = pendingAuthMutations.splice(0);
     for (const event of events) {
@@ -588,6 +600,9 @@ async function drainPendingAuthMutations(): Promise<void> {
       reusePluginGenerations: true,
     });
   }
+  // The queue check and commit share one synchronous section. A mutation cannot appear after the
+  // final drain but before its owning transaction publishes the resulting dispatch projection.
+  options.commit?.();
 }
 
 function invalidateForAuthMutation(event: AuthMutationEvent): void {
@@ -621,6 +636,15 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
   }
   replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
   pendingAuthMutations.push(normalizedEvent);
+  if (pendingModelRuntimeReplacement) {
+    // The active config transaction drains this event before its atomic dispatch commit. Retire
+    // the superseded build gate; queuing another task would make this commit depend on future work.
+    for (const owner of invalidatedOwners) {
+      owner.pending = undefined;
+    }
+    notifyPreparedModelRuntimePublication({ phase: "invalidated" });
+    return;
+  }
   const ownerPublications = new Map<
     PreparedModelRuntimeOwner,
     Promise<PreparedModelRuntimeSnapshot>
@@ -633,19 +657,20 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     if (pendingModelRuntimeReplacement) {
       return;
     }
-    await drainPendingAuthMutations();
-    if (pendingModelRuntimeReplacement) {
-      return;
-    }
-    for (const owner of invalidatedOwners) {
-      if (owner.pending === ownerPublications.get(owner)) {
-        owner.pending = undefined;
-      }
-    }
-    // No await may separate clearing the transaction gate from rebuilding its dispatch projection.
-    // Otherwise an admitted request can observe neither the pending owner nor the new publication.
-    replyDispatchPublication.rebuild(owners.values());
-    notifyPreparedModelRuntimePublication({ phase: "published" });
+    await drainPendingAuthMutations({
+      commit: () => {
+        if (pendingModelRuntimeReplacement) {
+          return;
+        }
+        for (const owner of invalidatedOwners) {
+          if (owner.pending === ownerPublications.get(owner)) {
+            owner.pending = undefined;
+          }
+        }
+        replyDispatchPublication.rebuild(owners.values());
+        notifyPreparedModelRuntimePublication({ phase: "published" });
+      },
+    });
   });
   for (const owner of invalidatedOwners) {
     const pending = publication.then(() => owner.snapshot!);

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -621,6 +621,10 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
   }
   replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
   pendingAuthMutations.push(normalizedEvent);
+  const ownerPublications = new Map<
+    PreparedModelRuntimeOwner,
+    Promise<PreparedModelRuntimeSnapshot>
+  >();
   const publication = enqueuePreparedModelRuntimePublication(async () => {
     // A pending replacement gate means a queued config publication owns the next generation:
     // it drains queued auth mutations against the new config and rebuilds/announces the
@@ -633,11 +637,19 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     if (pendingModelRuntimeReplacement) {
       return;
     }
+    for (const owner of invalidatedOwners) {
+      if (owner.pending === ownerPublications.get(owner)) {
+        owner.pending = undefined;
+      }
+    }
+    // No await may separate clearing the transaction gate from rebuilding its dispatch projection.
+    // Otherwise an admitted request can observe neither the pending owner nor the new publication.
     replyDispatchPublication.rebuild(owners.values());
     notifyPreparedModelRuntimePublication({ phase: "published" });
   });
   for (const owner of invalidatedOwners) {
     const pending = publication.then(() => owner.snapshot!);
+    ownerPublications.set(owner, pending);
     owner.pending = pending;
     const clearPending = () => {
       if (owner.pending === pending) {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -502,11 +502,7 @@ export function refreshPreparedModelRuntimeSnapshots(
   const isPublicationCurrent = () =>
     requestEpoch === refreshRequestEpoch && options.isPublicationCurrent?.() !== false;
   const commitReplacement = () => {
-    if (
-      !isPublicationCurrent() ||
-      !replacement ||
-      pendingModelRuntimeReplacement !== replacement
-    ) {
+    if (!isPublicationCurrent() || !replacement || pendingModelRuntimeReplacement !== replacement) {
       return;
     }
     const adoptedAuthTransaction = authPublication.prepareAdoptedCommit(replacement.gateId);
@@ -554,11 +550,7 @@ export function refreshPreparedModelRuntimeSnapshots(
         resetPluginGeneration: true,
       });
     }
-    if (
-      isPublicationCurrent() &&
-      replacement &&
-      pendingModelRuntimeReplacement === replacement
-    ) {
+    if (isPublicationCurrent() && replacement && pendingModelRuntimeReplacement === replacement) {
       pendingModelRuntimeReplacement = undefined;
       authPublication.rejectAdopted(replacement.gateId, refreshError);
       replacement.reject(refreshError);

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -4,6 +4,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { registerRuntimeAuthProfileStoreMutationListener } from "./auth-profiles/runtime-snapshots.js";
+import {
+  PreparedModelRuntimeAuthPublicationOwner,
+  type PreparedModelRuntimeAuthMutation,
+} from "./prepared-model-runtime-auth-publication.js";
 import { acquirePreparedModelRuntimeLeaseFromOwners } from "./prepared-model-runtime-lease.js";
 import { registerPreparedRuntimeAuthMaterializationPublisher } from "./prepared-model-runtime-materializations.js";
 import {
@@ -76,8 +80,7 @@ let gatewayLifecycleActive = false;
 let refreshTail: Promise<void> = Promise.resolve();
 let refreshRequestEpoch = 0;
 let pendingModelRuntimeReplacement: PreparedModelRuntimeReplacement | undefined;
-type AuthMutationEvent = { agentDir?: string; affectsInheritedStores: boolean };
-const pendingAuthMutations: AuthMutationEvent[] = [];
+const authPublication = new PreparedModelRuntimeAuthPublicationOwner();
 
 const replyDispatchPublication = new PreparedReplyDispatchPublicationOwner({
   isGatewayLifecycleActive: () => gatewayLifecycleActive,
@@ -375,6 +378,7 @@ export function markPreparedModelRuntimeSnapshotsStale(
   if (options.waitForReplacement) {
     const superseded = pendingModelRuntimeReplacement;
     pendingModelRuntimeReplacement = createPreparedModelRuntimeReplacement();
+    authPublication.adopt(pendingModelRuntimeReplacement.gateId);
     // Superseded readers retry against the newer replacement gate.
     superseded?.resolve();
   } else if (!options.preserveReplacementWait && pendingModelRuntimeReplacement) {
@@ -406,6 +410,7 @@ export function rejectPendingPreparedModelRuntimeReplacement(
   }
   pendingModelRuntimeReplacement = undefined;
   const replacementError = toStringifiedError(error);
+  authPublication.rejectAdopted(replacement.gateId, replacementError);
   replacement.reject(replacementError);
   notifyPreparedModelRuntimePublication({ phase: "failed", error: replacementError });
 }
@@ -504,8 +509,12 @@ export function refreshPreparedModelRuntimeSnapshots(
     ) {
       return;
     }
+    const adoptedAuthTransaction = authPublication.prepareAdoptedCommit(replacement.gateId);
     replyDispatchPublication.rebuild(owners.values());
     pendingModelRuntimeReplacement = undefined;
+    if (adoptedAuthTransaction) {
+      authPublication.resolve(adoptedAuthTransaction, owners);
+    }
     replacement.resolve();
     // Publication listeners may synchronously read the committed owner. Clear the lifecycle
     // gate before announcing availability so they cannot observe a false missing generation.
@@ -551,6 +560,7 @@ export function refreshPreparedModelRuntimeSnapshots(
       pendingModelRuntimeReplacement === replacement
     ) {
       pendingModelRuntimeReplacement = undefined;
+      authPublication.rejectAdopted(replacement.gateId, refreshError);
       replacement.reject(refreshError);
       notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });
     }
@@ -567,45 +577,22 @@ function enqueuePreparedModelRuntimePublication(task: () => Promise<void>): Prom
   return publication;
 }
 
-async function drainPendingAuthMutations(
-  options: {
-    commit?: () => void;
-  } = {},
-): Promise<void> {
-  while (pendingAuthMutations.length > 0) {
-    const events = pendingAuthMutations.splice(0);
-    for (const event of events) {
-      event.agentDir = normalizeOptionalDir(event.agentDir);
-    }
-    const entries: Array<{
-      owner: PreparedModelRuntimeOwner;
-      input: PreparedModelRuntimeInput;
-    }> = [];
-    for (const owner of owners.values()) {
-      const affected = events.some(
-        (event) =>
-          event.affectsInheritedStores ||
-          owner.input.agentDir === event.agentDir ||
-          owner.input.inheritedAuthDir === event.agentDir,
-      );
-      if (affected) {
-        entries.push({ owner, input: owner.input });
-      }
-    }
-    await publishPreparedModelRuntimeOwnerBatch({
-      entries,
-      owners,
-      agentBuildCompletions,
-      buildTimeoutMs: modelRuntimeBuildTimeoutMs,
-      reusePluginGenerations: true,
-    });
-  }
-  // The queue check and commit share one synchronous section. A mutation cannot appear after the
-  // final drain but before its owning transaction publishes the resulting dispatch projection.
-  options.commit?.();
+async function drainPendingAuthMutations(options: { commit?: () => void } = {}): Promise<void> {
+  await authPublication.drain({
+    owners,
+    publish: async (entries) =>
+      await publishPreparedModelRuntimeOwnerBatch({
+        entries,
+        owners,
+        agentBuildCompletions,
+        buildTimeoutMs: modelRuntimeBuildTimeoutMs,
+        reusePluginGenerations: true,
+      }),
+    commit: options.commit,
+  });
 }
 
-function invalidateForAuthMutation(event: AuthMutationEvent): void {
+function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): void {
   const normalizedEvent = {
     ...event,
     agentDir: normalizeOptionalDir(event.agentDir),
@@ -635,60 +622,56 @@ function invalidateForAuthMutation(event: AuthMutationEvent): void {
     return;
   }
   replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
-  pendingAuthMutations.push(normalizedEvent);
+  const transaction = authPublication.enqueue(normalizedEvent, invalidatedOwners);
   if (pendingModelRuntimeReplacement) {
     // The active config transaction drains this event before its atomic dispatch commit. Retire
     // the superseded build gate; queuing another task would make this commit depend on future work.
-    for (const owner of invalidatedOwners) {
-      owner.pending = undefined;
-    }
+    authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
     notifyPreparedModelRuntimePublication({ phase: "invalidated" });
     return;
   }
-  const ownerPublications = new Map<
-    PreparedModelRuntimeOwner,
-    Promise<PreparedModelRuntimeSnapshot>
-  >();
+  if (!authPublication.claimPublication(transaction)) {
+    notifyPreparedModelRuntimePublication({ phase: "invalidated" });
+    return;
+  }
   const publication = enqueuePreparedModelRuntimePublication(async () => {
     // A pending replacement gate means a queued config publication owns the next generation:
     // it drains queued auth mutations against the new config and rebuilds/announces the
     // dispatch publication. Rebuilding here would revive stale owners with the old config or
     // throw on them, emitting a spurious failed/published event that wedges chat metadata.
     if (pendingModelRuntimeReplacement) {
+      authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
       return;
     }
     await drainPendingAuthMutations({
       commit: () => {
         if (pendingModelRuntimeReplacement) {
+          authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
           return;
         }
-        for (const owner of invalidatedOwners) {
-          if (owner.pending === ownerPublications.get(owner)) {
-            owner.pending = undefined;
-          }
+        if (!authPublication.prepareCommit(transaction)) {
+          return;
         }
         replyDispatchPublication.rebuild(owners.values());
+        authPublication.resolve(transaction, owners);
         notifyPreparedModelRuntimePublication({ phase: "published" });
       },
     });
   });
-  for (const owner of invalidatedOwners) {
-    const pending = publication.then(() => owner.snapshot!);
-    ownerPublications.set(owner, pending);
-    owner.pending = pending;
-    const clearPending = () => {
-      if (owner.pending === pending) {
-        owner.pending = undefined;
-      }
-    };
-    void pending.then(clearPending, clearPending);
-  }
   notifyPreparedModelRuntimePublication({ phase: "invalidated" });
   void publication.catch((error: unknown) => {
+    if (!authPublication.isCurrent(transaction)) {
+      return;
+    }
+    if (pendingModelRuntimeReplacement) {
+      authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
+      return;
+    }
     if (error instanceof PreparedModelRuntimePublicationSupersededError) {
       return;
     }
     const refreshError = toStringifiedError(error);
+    authPublication.reject(transaction, refreshError);
     notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });
     log.warn(`auth-triggered model runtime refresh failed: ${String(refreshError)}`);
   });
@@ -698,6 +681,11 @@ registerRuntimeAuthProfileStoreMutationListener(invalidateForAuthMutation);
 registerPreparedRuntimeAuthMaterializationPublisher(owners, notifyPreparedModelRuntimePublication);
 
 function resetPreparedModelRuntimeSnapshotsForTest(): void {
+  authPublication.reset(
+    new PreparedModelRuntimePublicationSupersededError(
+      "prepared model runtime auth publication reset for test",
+    ),
+  );
   pendingModelRuntimeReplacement?.resolve();
   pendingModelRuntimeReplacement = undefined;
   owners.clear();
@@ -707,7 +695,6 @@ function resetPreparedModelRuntimeSnapshotsForTest(): void {
   gatewayLifecycleActive = false;
   refreshTail = Promise.resolve();
   refreshRequestEpoch = 0;
-  pendingAuthMutations.length = 0;
   replyDispatchPublication.clear();
   resetPreparedModelRuntimePublicationListenersForTest();
   modelRuntimeBuildTimeoutMs = DEFAULT_MODEL_RUNTIME_BUILD_TIMEOUT_MS;

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -73,6 +73,21 @@ function removeReplyDispatchRuntimeProjections(
   });
 }
 
+function replaceReplyDispatchRuntimeProjections(
+  publication: PreparedReplyDispatchPublication,
+  replacement: PreparedReplyDispatchPublication,
+  agentIds: ReadonlySet<string>,
+): PreparedReplyDispatchPublication {
+  return Object.freeze({
+    runtimes: Object.freeze(
+      [
+        ...publication.runtimes.filter((runtime) => !agentIds.has(runtime.agentId)),
+        ...replacement.runtimes,
+      ].toSorted((left, right) => left.agentId.localeCompare(right.agentId)),
+    ),
+  });
+}
+
 type PreparedReplyDispatchPublicationHost = Readonly<{
   isGatewayLifecycleActive: () => boolean;
   getPendingOwnerPublication: (agentId: string) => Promise<unknown> | undefined;
@@ -105,6 +120,19 @@ export class PreparedReplyDispatchPublicationOwner {
 
   remove(agentIds: ReadonlySet<string>): void {
     this.#publication = removeReplyDispatchRuntimeProjections(this.#publication, agentIds);
+  }
+
+  replace(owners: Iterable<PreparedModelRuntimeOwner>, agentIds: ReadonlySet<string>): void {
+    const replacements = buildReplyDispatchPublication(
+      [...owners].filter((owner) =>
+        owner.input.agentId ? agentIds.has(owner.input.agentId) : false,
+      ),
+    );
+    this.#publication = replaceReplyDispatchRuntimeProjections(
+      this.#publication,
+      replacements,
+      agentIds,
+    );
   }
 
   readonly load = async ({

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -116,14 +116,14 @@ export class PreparedReplyDispatchPublicationOwner {
       if (!this.host.isGatewayLifecycleActive()) {
         return undefined;
       }
-      const pendingOwner = this.host.getPendingOwnerPublication(agentId);
-      if (pendingOwner) {
-        await pendingOwner;
-        continue;
-      }
       const replacement = this.host.getPendingReplacement();
       if (replacement) {
         await replacement;
+        continue;
+      }
+      const pendingOwner = this.host.getPendingOwnerPublication(agentId);
+      if (pendingOwner) {
+        await pendingOwner;
         continue;
       }
       const matches = this.#publication.runtimes.filter((runtime) => runtime.agentId === agentId);

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -59,6 +59,20 @@ function buildReplyDispatchPublication(
   return Object.freeze({ runtimes: Object.freeze(runtimes) });
 }
 
+function removeReplyDispatchRuntimeProjections(
+  publication: PreparedReplyDispatchPublication,
+  agentIds: ReadonlySet<string>,
+): PreparedReplyDispatchPublication {
+  if (agentIds.size === 0) {
+    return publication;
+  }
+  return Object.freeze({
+    runtimes: Object.freeze(
+      publication.runtimes.filter((runtime) => !agentIds.has(runtime.agentId)),
+    ),
+  });
+}
+
 type PreparedReplyDispatchPublicationHost = Readonly<{
   isGatewayLifecycleActive: () => boolean;
   getPendingOwnerPublication: (agentId: string) => Promise<unknown> | undefined;
@@ -87,6 +101,10 @@ export class PreparedReplyDispatchPublicationOwner {
     this.#publication = this.host.isGatewayLifecycleActive()
       ? buildReplyDispatchPublication(owners)
       : EMPTY_REPLY_DISPATCH_PUBLICATION;
+  }
+
+  remove(agentIds: ReadonlySet<string>): void {
+    this.#publication = removeReplyDispatchRuntimeProjections(this.#publication, agentIds);
   }
 
   readonly load = async ({

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -59,22 +59,9 @@ function buildReplyDispatchPublication(
   return Object.freeze({ runtimes: Object.freeze(runtimes) });
 }
 
-function removeReplyDispatchRuntimeProjections(
-  publication: PreparedReplyDispatchPublication,
-  agentIds: ReadonlySet<string>,
-): PreparedReplyDispatchPublication {
-  if (agentIds.size === 0) {
-    return publication;
-  }
-  return Object.freeze({
-    runtimes: Object.freeze(
-      publication.runtimes.filter((runtime) => !agentIds.has(runtime.agentId)),
-    ),
-  });
-}
-
 type PreparedReplyDispatchPublicationHost = Readonly<{
   isGatewayLifecycleActive: () => boolean;
+  getPendingOwnerPublication: (agentId: string) => Promise<unknown> | undefined;
   getPendingReplacement: () => Promise<void> | undefined;
 }>;
 
@@ -102,10 +89,6 @@ export class PreparedReplyDispatchPublicationOwner {
       : EMPTY_REPLY_DISPATCH_PUBLICATION;
   }
 
-  remove(agentIds: ReadonlySet<string>): void {
-    this.#publication = removeReplyDispatchRuntimeProjections(this.#publication, agentIds);
-  }
-
   readonly load = async ({
     agentId,
   }: {
@@ -114,6 +97,11 @@ export class PreparedReplyDispatchPublicationOwner {
     for (;;) {
       if (!this.host.isGatewayLifecycleActive()) {
         return undefined;
+      }
+      const pendingOwner = this.host.getPendingOwnerPublication(agentId);
+      if (pendingOwner) {
+        await pendingOwner;
+        continue;
       }
       const replacement = this.host.getPendingReplacement();
       if (replacement) {

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createAbortError, racePromiseWithAbortSignal } from "../infra/abort-signal.js";
 import { resolvePublishedModelCatalogOwner } from "./prepared-model-catalog-owner.js";
 import { PreparedModelRuntimeOwnerNotPublishedError } from "./prepared-model-runtime.errors.js";
 import type {
@@ -137,21 +138,28 @@ export class PreparedReplyDispatchPublicationOwner {
 
   readonly load = async ({
     agentId,
+    abortSignal,
   }: {
     agentId: string;
+    abortSignal?: AbortSignal;
   }): Promise<PreparedReplyDispatchRuntime | undefined> => {
     for (;;) {
+      if (abortSignal?.aborted) {
+        throw createAbortError("Prepared reply dispatch admission aborted", {
+          cause: abortSignal.reason,
+        });
+      }
       if (!this.host.isGatewayLifecycleActive()) {
         return undefined;
       }
       const replacement = this.host.getPendingReplacement();
       if (replacement) {
-        await replacement;
+        await racePromiseWithAbortSignal(replacement, abortSignal);
         continue;
       }
       const pendingOwner = this.host.getPendingOwnerPublication(agentId);
       if (pendingOwner) {
-        await pendingOwner;
+        await racePromiseWithAbortSignal(pendingOwner, abortSignal);
         continue;
       }
       const matches = this.#publication.runtimes.filter((runtime) => runtime.agentId === agentId);

--- a/src/agents/prepared-reply-dispatch-runtime.ts
+++ b/src/agents/prepared-reply-dispatch-runtime.ts
@@ -123,16 +123,12 @@ export class PreparedReplyDispatchPublicationOwner {
     this.#publication = removeReplyDispatchRuntimeProjections(this.#publication, agentIds);
   }
 
-  replace(owners: Iterable<PreparedModelRuntimeOwner>, agentIds: ReadonlySet<string>): void {
-    const replacements = buildReplyDispatchPublication(
-      [...owners].filter((owner) =>
-        owner.input.agentId ? agentIds.has(owner.input.agentId) : false,
-      ),
-    );
+  replace(owners: readonly PreparedModelRuntimeOwner[]): void {
+    const replacements = buildReplyDispatchPublication(owners);
     this.#publication = replaceReplyDispatchRuntimeProjections(
       this.#publication,
       replacements,
-      agentIds,
+      new Set(replacements.runtimes.map((runtime) => runtime.agentId)),
     );
   }
 

--- a/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
@@ -2,6 +2,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { readAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { racePromiseWithAbortSignal } from "../../infra/abort-signal.js";
 import { createApprovalNativeRouteReporter } from "../../infra/approval-native-route-coordinator.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
@@ -148,6 +149,56 @@ beforeAll(globalBeforeAll0);
 
 describe("dispatchReplyFromConfig", () => {
   beforeEach(describe0BeforeEach0);
+
+  it("audits an aborted prepared-runtime wait as a skipped reply operation", async () => {
+    setNoAbort();
+    const abort = new AbortController();
+    const preparedLookup = vi.fn(({ abortSignal }: { abortSignal?: AbortSignal }) =>
+      racePromiseWithAbortSignal(new Promise<never>(() => {}), abortSignal),
+    );
+    const runtimeLoaders = await import("./dispatch-from-config.runtime-loaders.js");
+    const preparedLoader = vi.spyOn(runtimeLoaders, "loadPreparedModelRuntime").mockResolvedValue({
+      loadPublishedGatewayReplyDispatchRuntime: preparedLookup,
+    } as never);
+    const dispatch = withDispatchProcessedOutcomeSink(() =>
+      dispatchReplyFromConfig({
+        ctx: buildTestCtx({
+          Provider: "telegram",
+          ChatType: "direct",
+          SessionKey: "agent:main:main",
+        }),
+        cfg: emptyConfig,
+        dispatcher: createDispatcher(),
+        replyOptions: { abortSignal: abort.signal },
+        usePublishedModelRuntime: true,
+      }),
+    );
+    try {
+      await vi.waitFor(() => expect(preparedLookup).toHaveBeenCalledOnce());
+      abort.abort(new Error("request cancelled"));
+      const outcome = await dispatch;
+
+      expect(outcome.result).toMatchObject({
+        queuedFinal: false,
+        counts: { tool: 0, block: 0, final: 0 },
+      });
+      expect(outcome.processedOutcome).toEqual({
+        outcome: "skipped",
+        reason: "reply_operation_aborted",
+      });
+      expect(messageAuditEvents()[0]).toMatchObject({
+        status: "blocked",
+        outcome: "skipped",
+        reasonCode: "reply_operation_aborted",
+      });
+      expect(preparedLookup).toHaveBeenCalledWith({
+        agentId: "main",
+        abortSignal: abort.signal,
+      });
+    } finally {
+      preparedLoader.mockRestore();
+    }
+  });
 
   it("delivers plan status when verbose overrides preview suppression", async () => {
     setNoAbort();

--- a/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort-and-dedupe.test-utils.ts
@@ -9,6 +9,10 @@ import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import {
+  DispatchReplyOperationAbortedError,
+  runWithDispatchAbortSignal,
+} from "./dispatch-from-config.abort.js";
+import {
   acpMocks,
   agentEventMocks,
   createDispatcher,
@@ -150,6 +154,19 @@ beforeAll(globalBeforeAll0);
 describe("dispatchReplyFromConfig", () => {
   beforeEach(describe0BeforeEach0);
 
+  it("does not start dispatch work when the caller already aborted", async () => {
+    const abort = new AbortController();
+    const run = vi.fn();
+    const onWorkStarted = vi.fn();
+    abort.abort();
+
+    await expect(
+      runWithDispatchAbortSignal(abort.signal, run, onWorkStarted),
+    ).rejects.toBeInstanceOf(DispatchReplyOperationAbortedError);
+    expect(run).not.toHaveBeenCalled();
+    expect(onWorkStarted).not.toHaveBeenCalled();
+  });
+
   it("audits an aborted prepared-runtime wait as a skipped reply operation", async () => {
     setNoAbort();
     const abort = new AbortController();
@@ -167,7 +184,7 @@ describe("dispatchReplyFromConfig", () => {
           ChatType: "direct",
           SessionKey: "agent:main:main",
         }),
-        cfg: emptyConfig,
+        cfg: { ...emptyConfig, diagnostics: { enabled: true } },
         dispatcher: createDispatcher(),
         replyOptions: { abortSignal: abort.signal },
         usePublishedModelRuntime: true,
@@ -191,6 +208,12 @@ describe("dispatchReplyFromConfig", () => {
         outcome: "skipped",
         reasonCode: "reply_operation_aborted",
       });
+      expect(diagnosticMocks.logMessageProcessed).toHaveBeenCalledWith(
+        expect.objectContaining({
+          outcome: "skipped",
+          reason: "reply_operation_aborted",
+        }),
+      );
       expect(preparedLookup).toHaveBeenCalledWith({
         agentId: "main",
         abortSignal: abort.signal,

--- a/src/auto-reply/reply/dispatch-from-config.abort.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort.ts
@@ -1,4 +1,4 @@
-import { isAbortError } from "../../infra/abort-signal.js";
+import { isAbortError, racePromiseWithAbortSignal } from "../../infra/abort-signal.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import type { ReplyDispatcher } from "./reply-dispatcher.types.js";
 
@@ -20,44 +20,13 @@ export function runWithDispatchAbortSignal<T>(
   run: () => Promise<T> | T,
   onWorkStarted?: (work: Promise<unknown>) => void,
 ): Promise<T> {
-  if (signal?.aborted) {
-    return Promise.reject(new DispatchReplyOperationAbortedError());
-  }
-  const shouldStopForAbort = () => signal?.aborted === true;
-  let settled = false;
-  let abortHandler: (() => void) | undefined;
-  const work = Promise.resolve()
-    .then(run)
-    .then(
-      (value) => {
-        settled = true;
-        return value;
-      },
-      (error: unknown) => {
-        settled = true;
-        if (shouldStopForAbort() && isAbortError(error)) {
-          throw new DispatchReplyOperationAbortedError();
-        }
-        throw error;
-      },
-    );
+  const work = Promise.resolve().then(run);
   onWorkStarted?.(work);
-  if (!signal) {
-    return work;
-  }
-  const aborted = new Promise<never>((_, reject) => {
-    abortHandler = () => {
-      if (!settled && shouldStopForAbort()) {
-        reject(new DispatchReplyOperationAbortedError());
-      }
-    };
-    signal.addEventListener("abort", abortHandler, { once: true });
-  });
-  return Promise.race([work, aborted]).finally(() => {
-    settled = true;
-    if (abortHandler) {
-      signal.removeEventListener("abort", abortHandler);
+  return racePromiseWithAbortSignal(work, signal).catch((error: unknown) => {
+    if (signal?.aborted && isAbortError(error)) {
+      throw new DispatchReplyOperationAbortedError();
     }
+    throw error;
   });
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.abort.ts
+++ b/src/auto-reply/reply/dispatch-from-config.abort.ts
@@ -20,6 +20,9 @@ export function runWithDispatchAbortSignal<T>(
   run: () => Promise<T> | T,
   onWorkStarted?: (work: Promise<unknown>) => void,
 ): Promise<T> {
+  if (signal?.aborted) {
+    return Promise.reject(new DispatchReplyOperationAbortedError());
+  }
   const work = Promise.resolve().then(run);
   onWorkStarted?.(work);
   return racePromiseWithAbortSignal(work, signal).catch((error: unknown) => {

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -97,23 +97,9 @@ export async function gatherDispatchRequest(
     turnAdoptionState: turnAdoptionLifecycle ? turnAdoptionState : undefined,
   };
   const { cfg, dispatcher } = normalizedParams;
-  const finishReplyOperationAborted = () => {
-    noteDispatchProcessedOutcome({ outcome: "skipped", reason: "reply_operation_aborted" });
-    messageAuditTerminal?.note("skipped", { reason: "reply_operation_aborted" });
-    return {
-      status: "complete" as const,
-      result: {
-        queuedFinal: false,
-        counts: dispatcher.getQueuedCounts(),
-      },
-    };
-  };
   bindReplyDispatcherConversationContext(dispatcher, ctx.agentText);
   const replyOperationRunState: ReplyOperationRunState =
     resolveReplyOperationRunState(normalizedParams.replyOptions) ?? {};
-  if (params.replyOptions?.abortSignal?.aborted) {
-    return finishReplyOperationAborted();
-  }
   const diagnosticsEnabled = isDiagnosticsEnabled(cfg);
   const channel = normalizeLowercaseStringOrEmpty(ctx.Surface ?? ctx.Provider ?? "unknown");
   const chatId = ctx.To ?? ctx.From;
@@ -183,6 +169,19 @@ export async function gatherDispatchRequest(
     }
     messageLifecycle.markProcessed(outcome, opts);
   };
+  const finishReplyOperationAborted = () => {
+    recordProcessed("skipped", { reason: "reply_operation_aborted" });
+    return {
+      status: "complete" as const,
+      result: {
+        queuedFinal: false,
+        counts: dispatcher.getQueuedCounts(),
+      },
+    };
+  };
+  if (params.replyOptions?.abortSignal?.aborted) {
+    return finishReplyOperationAborted();
+  }
 
   const recordAgentDispatchStarted = () => {
     if (!diagnosticsEnabled || agentDispatchStartedAt > 0) {

--- a/src/auto-reply/reply/dispatch-from-config.gather.ts
+++ b/src/auto-reply/reply/dispatch-from-config.gather.ts
@@ -7,11 +7,13 @@ import {
   resolveAgentWorkspaceDir,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
+import type { PreparedReplyDispatchRuntime } from "../../agents/prepared-model-runtime.types.js";
 import { normalizeExplicitSessionKey } from "../../config/sessions/explicit-session-key-normalization.js";
 import {
   deriveInboundMessageHookContext,
   toPluginInboundClaimPair,
 } from "../../hooks/message-hook-mappers.js";
+import { isAbortError } from "../../infra/abort-signal.js";
 import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import {
@@ -95,10 +97,7 @@ export async function gatherDispatchRequest(
     turnAdoptionState: turnAdoptionLifecycle ? turnAdoptionState : undefined,
   };
   const { cfg, dispatcher } = normalizedParams;
-  bindReplyDispatcherConversationContext(dispatcher, ctx.agentText);
-  const replyOperationRunState: ReplyOperationRunState =
-    resolveReplyOperationRunState(normalizedParams.replyOptions) ?? {};
-  if (params.replyOptions?.abortSignal?.aborted) {
+  const finishReplyOperationAborted = () => {
     noteDispatchProcessedOutcome({ outcome: "skipped", reason: "reply_operation_aborted" });
     messageAuditTerminal?.note("skipped", { reason: "reply_operation_aborted" });
     return {
@@ -108,6 +107,12 @@ export async function gatherDispatchRequest(
         counts: dispatcher.getQueuedCounts(),
       },
     };
+  };
+  bindReplyDispatcherConversationContext(dispatcher, ctx.agentText);
+  const replyOperationRunState: ReplyOperationRunState =
+    resolveReplyOperationRunState(normalizedParams.replyOptions) ?? {};
+  if (params.replyOptions?.abortSignal?.aborted) {
+    return finishReplyOperationAborted();
   }
   const diagnosticsEnabled = isDiagnosticsEnabled(cfg);
   const channel = normalizeLowercaseStringOrEmpty(ctx.Surface ?? ctx.Provider ?? "unknown");
@@ -360,14 +365,23 @@ export async function gatherDispatchRequest(
   const preparedReplyDispatchAgentId = boundAcpDispatchSessionKey
     ? resolveSessionAgentId({ sessionKey, config: cfg, fallbackAgentId: ctx.AgentId })
     : sessionAgentId;
-  const preparedReplyDispatchRuntime = params.usePublishedModelRuntime
-    ? await traceReplyPhase("reply.load_prepared_dispatch_runtime", async () => {
-        const { loadPublishedGatewayReplyDispatchRuntime } = await loadPreparedModelRuntime();
-        return await loadPublishedGatewayReplyDispatchRuntime({
-          agentId: preparedReplyDispatchAgentId,
-        });
-      })
-    : undefined;
+  let preparedReplyDispatchRuntime: PreparedReplyDispatchRuntime | undefined;
+  try {
+    preparedReplyDispatchRuntime = params.usePublishedModelRuntime
+      ? await traceReplyPhase("reply.load_prepared_dispatch_runtime", async () => {
+          const { loadPublishedGatewayReplyDispatchRuntime } = await loadPreparedModelRuntime();
+          return await loadPublishedGatewayReplyDispatchRuntime({
+            agentId: preparedReplyDispatchAgentId,
+            abortSignal: params.replyOptions?.abortSignal,
+          });
+        })
+      : undefined;
+  } catch (error) {
+    if (params.replyOptions?.abortSignal?.aborted && isAbortError(error)) {
+      return finishReplyOperationAborted();
+    }
+    throw error;
+  }
   const workspaceDir =
     preparedReplyDispatchRuntime?.workspaceDir ?? resolveAgentWorkspaceDir(cfg, sessionAgentId);
   const replyOperationCoordinator = createDispatchReplyOperationCoordinator({

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -43,7 +43,11 @@ export async function runPreparedReply(
       allowGatewaySubagentBinding: true,
       workspaceDir: context.workspaceDir,
     },
-    { catalogMode: "static", pluginGeneration: dispatchRuntime.pluginGeneration },
+    {
+      catalogMode: "static",
+      pluginGeneration: dispatchRuntime.pluginGeneration,
+      abortSignal: params.opts?.abortSignal,
+    },
   );
   let leaseActive = true;
   try {

--- a/src/cron/isolated-agent/run.plugin-generation.test.ts
+++ b/src/cron/isolated-agent/run.plugin-generation.test.ts
@@ -60,7 +60,10 @@ describe("runCronIsolatedAgentTurn plugin generation carry", () => {
     await expect(runCronIsolatedAgentTurn(makeIsolatedAgentParamsFixture())).resolves.toMatchObject(
       { status: "ok" },
     );
-    expect(preparedRuntimeMocks.loadDispatchRuntime).toHaveBeenCalledWith({ agentId: "default" });
+    const dispatchAdmission = preparedRuntimeMocks.loadDispatchRuntime.mock.calls[0]?.[0] as {
+      abortSignal: AbortSignal;
+    };
+    expect(dispatchAdmission).toMatchObject({ agentId: "default", abortSignal: expect.anything() });
     expect(preparedRuntimeMocks.acquireRuntime).toHaveBeenCalledWith(
       {
         config,
@@ -69,7 +72,7 @@ describe("runCronIsolatedAgentTurn plugin generation carry", () => {
         allowGatewaySubagentBinding: true,
         workspaceDir: "/tmp/workspace",
       },
-      { catalogMode: "static", pluginGeneration },
+      { catalogMode: "static", pluginGeneration, abortSignal: dispatchAdmission.abortSignal },
     );
     expect(embeddedRunGeneration).toBe(pluginGeneration);
     expect(release).toHaveBeenCalledOnce();

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -67,10 +67,12 @@ type CronRunPluginGenerationLease = {
 async function acquireCronRunPluginGeneration(context: {
   agentId: string;
   workspaceDir: string;
+  abortSignal?: AbortSignal;
 }): Promise<CronRunPluginGenerationLease | undefined> {
   try {
     const dispatchRuntime = await loadPublishedGatewayReplyDispatchRuntime({
       agentId: context.agentId,
+      abortSignal: context.abortSignal,
     });
     if (!dispatchRuntime) {
       return undefined;
@@ -86,7 +88,11 @@ async function acquireCronRunPluginGeneration(context: {
         allowGatewaySubagentBinding: true,
         workspaceDir: context.workspaceDir,
       },
-      { catalogMode: "static", pluginGeneration: dispatchRuntime.pluginGeneration },
+      {
+        catalogMode: "static",
+        pluginGeneration: dispatchRuntime.pluginGeneration,
+        abortSignal: context.abortSignal,
+      },
     );
     let leaseActive = true;
     return {
@@ -331,7 +337,10 @@ export async function runCronIsolatedAgentTurn(params: {
           ),
         ),
       );
-    const pluginGenerationLease = await acquireCronRunPluginGeneration(prepared.context);
+    const pluginGenerationLease = await acquireCronRunPluginGeneration({
+      ...prepared.context,
+      abortSignal,
+    });
     let execution: Awaited<ReturnType<typeof runExecutionWithAdmission>>;
     try {
       execution = pluginGenerationLease

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -23,6 +23,7 @@ import {
 } from "../../auto-reply/reply/source-turn-id.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { isAbortError } from "../../infra/abort-signal.js";
 import { formatErrorMessageWithCode } from "../../infra/errors.js";
 import type { MediaFact } from "../../media/media-facts.js";
 import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
@@ -125,32 +126,35 @@ export function startAgentRunExecution(params: {
     await yieldAfterAgentAcceptedAck();
     let dispatched = false;
     let pendingRecovery: MainSessionRecoveryPendingTarget | undefined;
+    const finishUndispatchedAbort = async () => {
+      pendingRecovery = await prepared.restoreAdmittedRestartRecoveryInterrupted?.();
+      const stopReason = resolveAbortedAgentStopReason(prepared.activeRunAbort.entry);
+      setAbortedAgentDedupeEntries({
+        dedupe: params.context.dedupe,
+        keys: params.agentDedupeKeys,
+        agentId: params.activeSessionAgentId,
+        runId: params.runId,
+        stopReason,
+      });
+      params.io.emitFinal(
+        [
+          true,
+          {
+            runId: params.runId,
+            status: "timeout" as const,
+            summary: "aborted",
+            stopReason,
+            timeoutPhase: "queue" as const,
+            providerStarted: false,
+          },
+          undefined,
+        ],
+        { runId: params.runId },
+      );
+    };
     try {
       if (prepared.activeRunAbort.controller.signal.aborted) {
-        pendingRecovery = await prepared.restoreAdmittedRestartRecoveryInterrupted?.();
-        const stopReason = resolveAbortedAgentStopReason(prepared.activeRunAbort.entry);
-        setAbortedAgentDedupeEntries({
-          dedupe: params.context.dedupe,
-          keys: params.agentDedupeKeys,
-          agentId: params.activeSessionAgentId,
-          runId: params.runId,
-          stopReason,
-        });
-        params.io.emitFinal(
-          [
-            true,
-            {
-              runId: params.runId,
-              status: "timeout" as const,
-              summary: "aborted",
-              stopReason,
-              timeoutPhase: "queue" as const,
-              providerStarted: false,
-            },
-            undefined,
-          ],
-          { runId: params.runId },
-        );
+        await finishUndispatchedAbort();
         return;
       }
 
@@ -210,6 +214,7 @@ export function startAgentRunExecution(params: {
         : params.agentId;
       const replyDispatchRuntime = await loadPublishedGatewayReplyDispatchRuntime({
         agentId: params.activeSessionAgentId,
+        abortSignal: prepared.activeRunAbort.controller.signal,
       });
       if (!replyDispatchRuntime?.pluginGeneration) {
         throw new Error(
@@ -464,6 +469,10 @@ export function startAgentRunExecution(params: {
       );
       dispatched = true;
     } catch (err) {
+      if (prepared.activeRunAbort.controller.signal.aborted && isAbortError(err)) {
+        await finishUndispatchedAbort();
+        return;
+      }
       const renderedErr = formatErrorMessageWithCode(err);
       const error = errorShape(ErrorCodes.UNAVAILABLE, renderedErr);
       const payload = {

--- a/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { WebSocket } from "ws";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { resolveAgentDir } from "../agents/agent-scope.js";
+import { setRuntimeAuthProfileStoreSnapshot } from "../agents/auth-profiles/runtime-snapshots.js";
+import {
+  loadPublishedGatewayReplyDispatchRuntime,
+  registerPreparedModelRuntimePublicationListener,
+} from "../agents/prepared-model-runtime.js";
+import { installConnectedSessionStoreGatewaySuite } from "./test-helpers.connected-session-store.js";
+import {
+  agentCommandMock,
+  agentDiscoveryMock,
+  installGatewayTestHooks,
+  onceMessage,
+  prepareGatewayReplyRuntimeForTest,
+  testState,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const gatewaySuite = installConnectedSessionStoreGatewaySuite("openclaw-gw-auth-refresh-", {
+  client: {
+    id: "gateway-client",
+    version: "1.0.0",
+    platform: "test",
+    mode: "backend",
+  },
+});
+
+type AgentRpcFrame = {
+  type: "res";
+  id: string;
+  ok: boolean;
+  payload?: { runId?: string; status?: string };
+  error?: { code?: string; message?: string };
+};
+
+function sendAgentRpc(socket: WebSocket, params: { agentId: string; runId: string }) {
+  const accepted = onceMessage<AgentRpcFrame>(
+    socket,
+    (frame) =>
+      frame.type === "res" && frame.id === params.runId && frame.payload?.status === "accepted",
+  );
+  const final = onceMessage<AgentRpcFrame>(
+    socket,
+    (frame) =>
+      frame.type === "res" && frame.id === params.runId && frame.payload?.status !== "accepted",
+  );
+  socket.send(
+    JSON.stringify({
+      type: "req",
+      id: params.runId,
+      method: "agent",
+      params: {
+        agentId: params.agentId,
+        message: `dispatch ${params.runId}`,
+        idempotencyKey: params.runId,
+      },
+    }),
+  );
+  return { accepted, final };
+}
+
+function agentCommandCallsFor(runId: string) {
+  return vi
+    .mocked(agentCommandMock)
+    .mock.calls.filter(([options]) => (options as { runId?: string }).runId === runId);
+}
+
+async function prepareAuthDispatchAgents(affectedAgentId: string) {
+  testState.agentsConfig = {
+    list: [{ id: "main", default: true }, { id: affectedAgentId }],
+  };
+  agentDiscoveryMock.enabled = true;
+  agentDiscoveryMock.models = [{ id: "claude-opus-4-6", provider: "anthropic", input: ["text"] }];
+  const { clearConfigCache, clearRuntimeConfigSnapshot, getRuntimeConfig } =
+    await import("../config/io.js");
+  clearRuntimeConfigSnapshot();
+  clearConfigCache();
+  await prepareGatewayReplyRuntimeForTest({ force: true });
+  const config = getRuntimeConfig();
+  return {
+    agentDir: resolveAgentDir(config, affectedAgentId),
+    runtime: await loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId }),
+  };
+}
+
+describe("gateway agent auth refresh dispatch", () => {
+  beforeEach(() => {
+    vi.mocked(agentCommandMock).mockClear();
+  });
+
+  afterEach(() => {
+    testState.agentsConfig = undefined;
+  });
+
+  test("waits for an affected auth generation without blocking siblings", async () => {
+    const affectedAgentId = "auth-wait";
+    const affectedRunId = "idem-agent-auth-wait";
+    const siblingRunId = "idem-agent-auth-sibling";
+    const before = await prepareAuthDispatchAgents(affectedAgentId);
+    const publicationGate = createDeferred<{ agentDir: string; wrote: false }>();
+    const modelsConfig = await import("../agents/models-config.js");
+    const ensureOpenClawModelsJson = modelsConfig.ensureOpenClawModelsJson;
+    const ensureSpy = vi
+      .spyOn(modelsConfig, "ensureOpenClawModelsJson")
+      .mockImplementation(async (config, agentDir, options) =>
+        agentDir === before.agentDir
+          ? await publicationGate.promise
+          : await ensureOpenClawModelsJson(config, agentDir, options),
+      );
+    const published = createDeferred();
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      if (event.phase === "published") {
+        published.resolve();
+      }
+    });
+    try {
+      setRuntimeAuthProfileStoreSnapshot(
+        {
+          version: 1,
+          profiles: {
+            "anthropic:default": {
+              type: "api_key",
+              provider: "anthropic",
+              key: "fresh-generation-key",
+            },
+          },
+        },
+        before.agentDir,
+      );
+
+      const affected = sendAgentRpc(gatewaySuite.ws, {
+        agentId: affectedAgentId,
+        runId: affectedRunId,
+      });
+      await affected.accepted;
+      const sibling = sendAgentRpc(gatewaySuite.ws, { agentId: "main", runId: siblingRunId });
+      await sibling.accepted;
+      await expect(sibling.final).resolves.toMatchObject({ ok: true, payload: { status: "ok" } });
+      expect(agentCommandCallsFor(siblingRunId)).toHaveLength(1);
+      expect(agentCommandCallsFor(affectedRunId)).toHaveLength(0);
+      await expect(
+        Promise.race([affected.final.then(() => "settled"), Promise.resolve("pending")]),
+      ).resolves.toBe("pending");
+
+      publicationGate.resolve({ agentDir: before.agentDir, wrote: false });
+      await published.promise;
+      const after = await loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId });
+      expect(after).not.toBe(before.runtime);
+      await expect(affected.final).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "ok" },
+      });
+      const affectedCalls = agentCommandCallsFor(affectedRunId);
+      expect(affectedCalls).toHaveLength(1);
+      expect(affectedCalls[0]?.[4]).toMatchObject({
+        config: after?.config,
+        pluginGeneration: after?.pluginGeneration,
+      });
+    } finally {
+      unregister();
+      ensureSpy.mockRestore();
+    }
+  });
+
+  test("never reuses an affected projection after auth publication rejects", async () => {
+    const affectedAgentId = "auth-reject";
+    const runId = "idem-agent-auth-reject";
+    const before = await prepareAuthDispatchAgents(affectedAgentId);
+    const modelsConfig = await import("../agents/models-config.js");
+    const ensureOpenClawModelsJson = modelsConfig.ensureOpenClawModelsJson;
+    const ensureSpy = vi
+      .spyOn(modelsConfig, "ensureOpenClawModelsJson")
+      .mockImplementation(async (config, agentDir, options) => {
+        if (agentDir === before.agentDir) {
+          throw new Error("auth publication rejected");
+        }
+        return await ensureOpenClawModelsJson(config, agentDir, options);
+      });
+    const failed = createDeferred();
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      if (event.phase === "failed") {
+        failed.resolve();
+      }
+    });
+    try {
+      setRuntimeAuthProfileStoreSnapshot(
+        {
+          version: 1,
+          profiles: {
+            "anthropic:default": {
+              type: "api_key",
+              provider: "anthropic",
+              key: "rejected-generation-key",
+            },
+          },
+        },
+        before.agentDir,
+      );
+      await failed.promise;
+      await expect(
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId }),
+      ).rejects.toThrow(
+        `prepared reply dispatch runtime owner was not published for ${affectedAgentId}`,
+      );
+
+      const dispatched = sendAgentRpc(gatewaySuite.ws, { agentId: affectedAgentId, runId });
+      await expect(dispatched.accepted).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "accepted" },
+      });
+      await expect(dispatched.final).resolves.toMatchObject({
+        ok: false,
+        payload: { status: "error" },
+        error: {
+          code: "UNAVAILABLE",
+          message: expect.stringContaining(
+            `prepared reply dispatch runtime owner was not published for ${affectedAgentId}`,
+          ),
+        },
+      });
+      expect(agentCommandCallsFor(runId)).toHaveLength(0);
+    } finally {
+      unregister();
+      ensureSpy.mockRestore();
+    }
+  });
+});

--- a/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
@@ -7,6 +7,7 @@ import {
   loadPublishedGatewayReplyDispatchRuntime,
   registerPreparedModelRuntimePublicationListener,
 } from "../agents/prepared-model-runtime.js";
+import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import { installConnectedSessionStoreGatewaySuite } from "./test-helpers.connected-session-store.js";
 import {
   agentCommandMock,
@@ -14,6 +15,7 @@ import {
   installGatewayTestHooks,
   onceMessage,
   prepareGatewayReplyRuntimeForTest,
+  rpcReq,
   testState,
 } from "./test-helpers.js";
 
@@ -32,7 +34,13 @@ type AgentRpcFrame = {
   type: "res";
   id: string;
   ok: boolean;
-  payload?: { runId?: string; status?: string };
+  payload?: {
+    runId?: string;
+    status?: string;
+    stopReason?: string;
+    timeoutPhase?: string;
+    providerStarted?: boolean;
+  };
   error?: { code?: string; message?: string };
 };
 
@@ -95,11 +103,14 @@ describe("gateway agent auth refresh dispatch", () => {
     testState.agentsConfig = undefined;
   });
 
-  test("waits for an affected auth generation without blocking siblings", async () => {
+  test("aborts one affected waiter without cancelling shared auth publication", async () => {
     const affectedAgentId = "auth-wait";
-    const affectedRunId = "idem-agent-auth-wait";
+    const abortedRunId = "idem-agent-auth-aborted";
+    const waitingRunId = "idem-agent-auth-waiting";
     const siblingRunId = "idem-agent-auth-sibling";
+    const subsequentRunId = "idem-agent-auth-subsequent";
     const before = await prepareAuthDispatchAgents(affectedAgentId);
+    const activeWorkBefore = getActiveGatewayRootWorkCount();
     const publicationGate = createDeferred<{ agentDir: string; wrote: false }>();
     const modelsConfig = await import("../agents/models-config.js");
     const ensureOpenClawModelsJson = modelsConfig.ensureOpenClawModelsJson;
@@ -131,35 +142,71 @@ describe("gateway agent auth refresh dispatch", () => {
         before.agentDir,
       );
 
-      const affected = sendAgentRpc(gatewaySuite.ws, {
+      const aborted = sendAgentRpc(gatewaySuite.ws, {
         agentId: affectedAgentId,
-        runId: affectedRunId,
+        runId: abortedRunId,
       });
-      await affected.accepted;
+      const waiting = sendAgentRpc(gatewaySuite.ws, {
+        agentId: affectedAgentId,
+        runId: waitingRunId,
+      });
+      await Promise.all([aborted.accepted, waiting.accepted]);
       const sibling = sendAgentRpc(gatewaySuite.ws, { agentId: "main", runId: siblingRunId });
       await sibling.accepted;
       await expect(sibling.final).resolves.toMatchObject({ ok: true, payload: { status: "ok" } });
       expect(agentCommandCallsFor(siblingRunId)).toHaveLength(1);
-      expect(agentCommandCallsFor(affectedRunId)).toHaveLength(0);
+      expect(agentCommandCallsFor(abortedRunId)).toHaveLength(0);
+      expect(agentCommandCallsFor(waitingRunId)).toHaveLength(0);
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(activeWorkBefore + 2));
+
+      const abort = await rpcReq(gatewaySuite.ws, "chat.abort", {
+        sessionKey: `agent:${affectedAgentId}:main`,
+        runId: abortedRunId,
+      });
+      expect(abort).toMatchObject({
+        ok: true,
+        payload: { aborted: true, runIds: [abortedRunId] },
+      });
+      await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(activeWorkBefore + 1));
+      await expect(aborted.final).resolves.toMatchObject({
+        ok: true,
+        payload: {
+          status: "timeout",
+          stopReason: "rpc",
+          timeoutPhase: "queue",
+          providerStarted: false,
+        },
+      });
       await expect(
-        Promise.race([affected.final.then(() => "settled"), Promise.resolve("pending")]),
+        Promise.race([waiting.final.then(() => "settled"), Promise.resolve("pending")]),
       ).resolves.toBe("pending");
 
       publicationGate.resolve({ agentDir: before.agentDir, wrote: false });
       await published.promise;
       const after = await loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId });
       expect(after).not.toBe(before.runtime);
-      await expect(affected.final).resolves.toMatchObject({
+      await expect(waiting.final).resolves.toMatchObject({
         ok: true,
         payload: { status: "ok" },
       });
-      const affectedCalls = agentCommandCallsFor(affectedRunId);
+      const affectedCalls = agentCommandCallsFor(waitingRunId);
       expect(affectedCalls).toHaveLength(1);
       expect(affectedCalls[0]?.[4]).toMatchObject({
         config: after?.config,
         pluginGeneration: after?.pluginGeneration,
       });
+      const subsequent = sendAgentRpc(gatewaySuite.ws, {
+        agentId: affectedAgentId,
+        runId: subsequentRunId,
+      });
+      await subsequent.accepted;
+      await expect(subsequent.final).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "ok" },
+      });
+      expect(agentCommandCallsFor(subsequentRunId)).toHaveLength(1);
     } finally {
+      publicationGate.resolve({ agentDir: before.agentDir, wrote: false });
       unregister();
       ensureSpy.mockRestore();
     }

--- a/src/infra/abort-signal.test.ts
+++ b/src/infra/abort-signal.test.ts
@@ -1,6 +1,11 @@
 // Covers abort signal wait helpers.
 import { describe, expect, it } from "vitest";
-import { createAbortError, isAbortError, waitForAbortSignal } from "./abort-signal.js";
+import {
+  createAbortError,
+  isAbortError,
+  racePromiseWithAbortSignal,
+  waitForAbortSignal,
+} from "./abort-signal.js";
 
 describe("abort errors", () => {
   it("creates a named error with an optional cause", () => {
@@ -81,5 +86,62 @@ describe("waitForAbortSignal", () => {
     handler?.();
     await expect(task).resolves.toBeUndefined();
     expect(removed).toBe(1);
+  });
+});
+
+describe("racePromiseWithAbortSignal", () => {
+  it("preserves source settlement and removes the listener", async () => {
+    let handler: (() => void) | undefined;
+    let removed = 0;
+    const signal = {
+      aborted: false,
+      addEventListener: (_type: string, listener: () => void) => {
+        handler = listener;
+      },
+      removeEventListener: (_type: string, listener: () => void) => {
+        expect(listener).toBe(handler);
+        removed += 1;
+      },
+    } as unknown as AbortSignal;
+    const sourceError = new Error("source failed");
+
+    await expect(racePromiseWithAbortSignal(Promise.resolve("done"), signal)).resolves.toBe("done");
+    await expect(racePromiseWithAbortSignal(Promise.reject(sourceError), signal)).rejects.toBe(
+      sourceError,
+    );
+    expect(removed).toBe(2);
+  });
+
+  it("rejects with the abort reason as cause without cancelling the source", async () => {
+    const controller = new AbortController();
+    let resolveSource!: (value: string) => void;
+    const source = new Promise<string>((resolve) => {
+      resolveSource = resolve;
+    });
+    const raced = racePromiseWithAbortSignal(source, controller.signal);
+    const reason = new Error("caller stopped");
+
+    controller.abort(reason);
+    await expect(raced).rejects.toMatchObject({ name: "AbortError", cause: reason });
+    resolveSource("still alive");
+    await expect(source).resolves.toBe("still alive");
+  });
+
+  it("catches aborts that land while the listener is registered", async () => {
+    let aborted = false;
+    const signal = {
+      get aborted() {
+        return aborted;
+      },
+      reason: "registration race",
+      addEventListener: () => {
+        aborted = true;
+      },
+      removeEventListener: () => {},
+    } as unknown as AbortSignal;
+
+    await expect(
+      racePromiseWithAbortSignal(new Promise<never>(() => {}), signal),
+    ).rejects.toMatchObject({ name: "AbortError", cause: "registration race" });
   });
 });

--- a/src/infra/abort-signal.ts
+++ b/src/infra/abort-signal.ts
@@ -16,6 +16,32 @@ export function isAbortError(error: unknown): boolean {
   return message === "This operation was aborted";
 }
 
+export function racePromiseWithAbortSignal<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  const abortError = () => createAbortError("Operation aborted", { cause: signal.reason });
+  if (signal.aborted) {
+    return Promise.reject(abortError());
+  }
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_, reject) => {
+    onAbort = () => reject(abortError());
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+    }
+  });
+  return Promise.race([promise, aborted]).finally(() => {
+    if (onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  });
+}
+
 /** Resolves when the signal aborts, or immediately when no wait is needed. */
 export async function waitForAbortSignal(signal?: AbortSignal): Promise<void> {
   if (!signal || signal.aborted) {

--- a/src/infra/abort-signal.ts
+++ b/src/infra/abort-signal.ts
@@ -27,7 +27,7 @@ export function racePromiseWithAbortSignal<T>(
   if (signal.aborted) {
     return Promise.reject(abortError());
   }
-  let onAbort: (() => void) | undefined;
+  let onAbort!: () => void;
   const aborted = new Promise<never>((_, reject) => {
     onAbort = () => reject(abortError());
     signal.addEventListener("abort", onAbort, { once: true });
@@ -36,9 +36,7 @@ export function racePromiseWithAbortSignal<T>(
     }
   });
   return Promise.race([promise, aborted]).finally(() => {
-    if (onAbort) {
-      signal.removeEventListener("abort", onAbort);
-    }
+    signal.removeEventListener("abort", onAbort);
   });
 }
 


### PR DESCRIPTION
Related: #127850

## What Problem This Solves

Requests for an agent whose credentials were being refreshed could fail during the publication window. Cancelling a request already waiting for that refresh could also retain its Gateway admission until the shared publication finished.

## Why This Change Was Made

This carries #127850's owner-scoped atomic publication work across current `main`, preserving the contributor's eight authored commits and the existing scoped-refresh behavior. Caller-local cancellation now covers every accepted dispatch and lease-admission wait: the cancelled request releases promptly, while the shared publication continues for other pending and subsequent requests.

Rejected refreshes still fail closed. Compaction, media, catalog, and control-plane callers remain outside this repair.

The replacement is necessary because #127850 is uneditable by maintainers, conflicts with current `main`, and does not contain the accepted cancellation contract.

## User Impact

Requests affected by a credential refresh wait for the fresh committed runtime instead of failing in the publication window. Cancelling one request releases its Gateway admission without disrupting sibling requests or the shared refresh.

## Evidence

- Exact head: `11787ec39e8217a5c0f323f7c133d7e5b75d7416`.
- Owner/security contract accepted: https://github.com/openclaw/openclaw/pull/127850#issuecomment-5436646794
- Exact-head CI passed 126 jobs with 21 intentional skips and no failures: https://github.com/openclaw/openclaw/actions/runs/33069407734
- Current ClawSweeper review has no findings; its remaining rank-up move requested this focused native proof: https://github.com/openclaw/openclaw/pull/130856#issuecomment-5437171545
- Focused native Testbox lease `tbx_01m11tnbf6vmqg8ng3pwh9erc4` passed both Gateway auth-refresh scenarios (`2/2`). Delegated sync was confirmed, command exit was `0`, command duration was 1m45.383s, and total duration was 1m47.470s. The lease completed and became absent without a cleanup warning; its backing Actions run ended `cancelled` during expected one-shot teardown: https://github.com/openclaw/openclaw/actions/runs/33083580512
- Pre-fix Gateway proof showed an aborted affected waiter retaining root admission. Focused implementation, owner-isolation, post-rebase, and final owner/Gateway runs passed 199/199, 90/90, 102/102, and 63/63 tests respectively.
- Repair delta over #127850: production `+169/-100` (net `+69`); tests/support `+213/-17` (net `+196`), within the accepted ceiling.
- Full branch surface against the merge base: production `+693/-197` (net `+496`); tests/support `+1000/-64` (net `+936`).

The earlier full Testbox lease `tbx_01m11kmatqv5yn5enknpg76ztp` exited `1` after 1h36m and is failure evidence, not qualification evidence. Candidate/main differential proof found no branch regression. Separate follow-ups own:

- umask-sensitive worker-mode expectations;
- TUI PTY state synchronization;
- commands-shard heap isolation;
- runtime-plugin aggregate isolation;
- Testbox active-command lifecycle and downstream Node `ENOENT`.

No full remote-suite stamp was written or claimed.
