### PR TITLE
fix(slack): record reasons for failed and omitted attachments

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -2147,6 +2147,8 @@ When a single Slack message contains multiple file attachments:
 - Downloaded media references are aggregated into the message context.
 - Processing order follows Slack's file order in the event payload.
 - A failure in one attachment's download does not block others.
+- Failed or blocked files remain in the agent context with a bounded reason, and each failed file produces one warning after any URL refresh retry.
+- Files beyond the eight-file limit are not downloaded. Their references carry an `omitted: 8-file limit` reason. Long unavailable-file lists are visibly truncated, while the notice retains the total unavailable attachment count.
 
 ### Size, download, and model limits
 

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -427,7 +427,7 @@ describe("monitorSlackProvider tool results", () => {
     }
 
     expect(replyMock).toHaveBeenCalledTimes(1);
-    expect(latestCtx?.RawBody).toBe("caption\n\n[slack forwarded image unavailable]");
+    expect(latestCtx?.RawBody).toBe("caption\n\n[slack attachment unavailable]");
     expect(mockFetch).toHaveBeenCalledOnce();
 
     if (process.env.OPENCLAW_SLACK_FORWARDED_IMAGE_PROOF === "1") {

--- a/extensions/slack/src/monitor/media.runtime.ts
+++ b/extensions/slack/src/monitor/media.runtime.ts
@@ -1,4 +1,7 @@
 // Slack plugin module implements media behavior.
+import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
+
+export const slackMediaLog = createSubsystemLogger("gateway/channels/slack").child("media");
 export { fetchWithRuntimeDispatcher } from "openclaw/plugin-sdk/runtime-fetch";
 export type { FetchLike } from "openclaw/plugin-sdk/media-runtime";
 export { saveRemoteMedia } from "openclaw/plugin-sdk/media-runtime";

--- a/extensions/slack/src/monitor/media.test.ts
+++ b/extensions/slack/src/monitor/media.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 // Slack tests cover media plugin behavior.
 import type { WebClient } from "@slack/web-api";
@@ -127,10 +130,12 @@ const saveRemoteMediaMock = vi.hoisted(() =>
 );
 const fetchWithRuntimeDispatcherMock = vi.hoisted(() => vi.fn());
 const logVerboseMock = vi.hoisted(() => vi.fn());
+const mediaWarnMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./media.runtime.js", () => ({
   fetchWithRuntimeDispatcher: fetchWithRuntimeDispatcherMock,
   saveRemoteMedia: saveRemoteMediaMock,
+  slackMediaLog: { warn: mediaWarnMock },
 }));
 
 vi.mock("./thread.runtime.js", () => ({
@@ -161,6 +166,7 @@ beforeEach(() => {
   readRemoteMediaBufferMock.mockClear();
   fetchWithRuntimeDispatcherMock.mockClear();
   logVerboseMock.mockClear();
+  mediaWarnMock.mockClear();
   saveMediaBufferMock.mockReset();
   saveMediaBufferMock.mockImplementation(
     async (
@@ -701,6 +707,7 @@ describe("resolveSlackMedia", () => {
       "https://files.slack.com/stale.jpg",
       "https://files.slack.com/fresh.jpg",
     ]);
+    expect(mediaWarnMock).not.toHaveBeenCalled();
   });
 
   it("rejects a refreshed URL when its file metadata fails caller admission", async () => {
@@ -742,23 +749,36 @@ describe("resolveSlackMedia", () => {
     ]);
   });
 
-  it("rejects HTML auth pages for non-HTML files", async () => {
-    mockFetch.mockResolvedValueOnce(
-      new Response("<!DOCTYPE html><html><body>login</body></html>", {
-        status: 200,
-        headers: { "content-type": "text/html; charset=utf-8" },
-      }),
-    );
+  it.each(["text/html; charset=utf-8", "image/jpeg"])(
+    "records blocked HTML auth pages for non-HTML files served as %s without retaining bytes",
+    async (contentType) => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), "slack-blocked-media-"));
+      const savedPath = path.join(dir, "test.jpg");
+      await fs.writeFile(savedPath, "<!DOCTYPE html><html><body>login</body></html>");
+      saveRemoteMediaMock.mockResolvedValueOnce({
+        ...createSavedMedia(savedPath, contentType),
+        fileName: "test.jpg",
+      });
+      const file = { url_private: "https://files.slack.com/test.jpg", name: "test.jpg" };
+      try {
+        const result = await resolveSlackAttachmentContent({
+          files: [file],
+          token: "xoxb-test-token",
+          maxBytes: 1024 * 1024,
+        });
 
-    const result = await resolveSlackMedia({
-      files: [{ url_private: "https://files.slack.com/test.jpg", name: "test.jpg" }],
-      token: "xoxb-test-token",
-      maxBytes: 1024 * 1024,
-    });
-
-    expect(result).toBeNull();
-    expect(saveRemoteMediaMock).toHaveBeenCalledTimes(1);
-  });
+        expect(result?.media).toEqual([]);
+        await expect(fs.stat(savedPath)).rejects.toMatchObject({ code: "ENOENT" });
+        expect(result?.files).toEqual([{ ...file, reason: "blocked: unexpected HTML content" }]);
+        expect(result).toMatchObject({ unavailableMediaCount: 1 });
+        expect(mediaWarnMock).toHaveBeenCalledExactlyOnceWith(
+          expect.stringContaining("blocked: unexpected HTML content"),
+        );
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("allows expected HTML uploads", async () => {
     saveMediaBufferMock.mockResolvedValue(createSavedMedia("/tmp/page.html", "text/html"));
@@ -961,8 +981,10 @@ describe("resolveSlackMedia", () => {
       mimetype: "image/jpeg",
     }));
 
+    const unavailableFiles = new Map<SlackFile, string>();
     const result = await resolveSlackMedia({
       files,
+      unavailableFiles,
       token: "xoxb-test-token",
       maxBytes: 1024 * 1024,
     });
@@ -971,6 +993,7 @@ describe("resolveSlackMedia", () => {
     expect(media).toHaveLength(8);
     expect(saveMediaBufferMock).toHaveBeenCalledTimes(8);
     expect(mockFetch).toHaveBeenCalledTimes(8);
+    expect([...unavailableFiles]).toEqual([[files[8], "omitted: 8-file limit"]]);
   });
 
   it("routes dispatcher-backed Slack media requests through runtime fetch", async () => {
@@ -1343,17 +1366,25 @@ describe("Slack message file intake", () => {
     expect(result?.rawBody).toContain("missing.png (image/png)");
   });
 
-  it("applies Slack's eight-file budget once across direct and forwarded sources", async () => {
-    const result = await resolveMessageFiles({
-      direct: Array.from({ length: 8 }, (_, index) => file(`FDIRECT${index}`)),
-      forwarded: [Array.from({ length: 8 }, (_, index) => file(`FFORWARDED${index}`))],
-    });
+  it.each([1, 8])(
+    "announces %i omitted files beyond the shared eight-file budget",
+    async (omitted) => {
+      const result = await resolveMessageFiles({
+        direct: Array.from({ length: 8 }, (_, index) => file(`FDIRECT${index}`)),
+        forwarded: [Array.from({ length: omitted }, (_, index) => file(`FFORWARDED${index}`))],
+      });
 
-    expect(mockFetch).toHaveBeenCalledTimes(8);
-    expect(result?.effectiveDirectMedia).toHaveLength(8);
-    expect(result?.rawBody).toContain("FDIRECT0.png");
-    expect(result?.rawBody).not.toContain("FFORWARDED0.png");
-  });
+      expect(mockFetch).toHaveBeenCalledTimes(8);
+      expect(result?.effectiveDirectMedia).toHaveLength(8);
+      expect(result?.rawBody).toContain("FDIRECT0.png");
+      for (let index = 0; index < omitted; index++) {
+        expect(result?.rawBody).toContain(
+          `FFORWARDED${index}.png (image/png, fileId: FFORWARDED${index}) unavailable (omitted: 8-file limit)`,
+        );
+      }
+      expect(mediaWarnMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("keeps forwarded images before their files without letting failures shift later attachments", async () => {
     mockFetch.mockImplementation(async (input) => {
@@ -1395,6 +1426,21 @@ describe("Slack message file intake", () => {
     expect(result?.rawBody).toContain("FFAILED.png (image/png, fileId: FFAILED)");
   });
 
+  it("bounds omission text while retaining the total unavailable count", async () => {
+    const result = await resolveMessageFiles({
+      direct: Array.from({ length: 48 }, (_, index) => file(`FFILE${index}`)),
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(8);
+    expect(result?.effectiveDirectMedia).toHaveLength(8);
+    expect(result?.rawBody).toContain(
+      "FFILE8.png (image/png, fileId: FFILE8) unavailable (omitted: 8-file limit)",
+    );
+    expect(result?.rawBody).toContain("… (file references truncated)");
+    expect(result?.rawBody).toContain("[slack 40 attachments unavailable]");
+    expect(expectDefined(result, "Slack message content").rawBody.length).toBeLessThan(2600);
+  });
+
   it("preserves distinct files without Slack file identifiers", async () => {
     const first = { ...file("FIRST"), id: undefined };
     const second = { ...file("SECOND"), id: undefined };
@@ -1415,7 +1461,9 @@ describe("Slack message file intake", () => {
 
     expect(mockFetch).not.toHaveBeenCalled();
     expect(result?.effectiveDirectMedia).toBeNull();
-    expect(result?.rawBody).toBe("Attached files\n[Slack file: file (fileId: FUNTRUSTED)]");
+    expect(result?.rawBody).toBe(
+      "Attached files\n[Slack file: file (fileId: FUNTRUSTED) unavailable (no private download URL)]\n\n[slack attachment unavailable]",
+    );
   });
 
   it("ignores richer metadata beyond the existing forwarded-attachment trust limit", async () => {
@@ -1429,7 +1477,9 @@ describe("Slack message file intake", () => {
 
     expect(mockFetch).not.toHaveBeenCalled();
     expect(result?.effectiveDirectMedia).toBeNull();
-    expect(result?.rawBody).toBe("Attached files\n[Slack file: file (fileId: FLATE)]");
+    expect(result?.rawBody).toBe(
+      "Attached files\n[Slack file: file (fileId: FLATE) unavailable (no private download URL)]\n\n[slack attachment unavailable]",
+    );
   });
 });
 
@@ -1443,6 +1493,41 @@ describe("resolveSlackAttachmentContent", () => {
     globalThis.fetch = originalFetch;
     vi.restoreAllMocks();
   });
+
+  it.each(["direct", "forwarded"])(
+    "records one bounded reason and warning for a failed %s file after URL refresh",
+    async (source) => {
+      const file = {
+        id: "FFAILED",
+        name: "missing.png",
+        url_private: "https://files.slack.com/stale.png",
+      };
+      const client = {
+        files: {
+          info: vi.fn(async () => ({ file: { url_private: "https://files.slack.com/fresh.png" } })),
+        },
+      } as unknown as WebClient;
+      mockFetch.mockRejectedValueOnce(new Error("stale URL"));
+      mockFetch.mockRejectedValueOnce(new Error(`Download denied\n${"detail ".repeat(100)}`));
+      const result = await resolveSlackAttachmentContent({
+        ...(source === "direct"
+          ? { files: [file] }
+          : { attachments: [{ is_share: true, files: [file] }] }),
+        client,
+        token: "xoxb-test-token",
+        maxBytes: 1024,
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result?.media).toEqual([]);
+      const reason = `Download denied ${"detail ".repeat(100)}`.slice(0, 200);
+      expect.soft(result?.files).toEqual([{ ...file, reason }]);
+      expect.soft(result).toMatchObject({ unavailableMediaCount: 1 });
+      expect(mediaWarnMock).toHaveBeenCalledExactlyOnceWith(
+        `slack: file missing.png (fileId: FFAILED) unavailable (${reason})`,
+      );
+    },
+  );
 
   it("ignores non-forwarded attachments", async () => {
     const result = await resolveSlackAttachmentContent({
@@ -1477,7 +1562,7 @@ describe("resolveSlackAttachmentContent", () => {
     expect(result).toEqual({
       text: "[Forwarded message from Bob]\nPlease review this",
       media: [],
-      unavailableImageCount: 0,
+      unavailableMediaCount: 0,
     });
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -1490,8 +1575,33 @@ describe("resolveSlackAttachmentContent", () => {
       maxBytes: 1024 * 1024,
     });
 
-    expect(result).toEqual({ text: "", media: [], unavailableImageCount: 0, files: [file] });
+    expect(result).toEqual({
+      text: "",
+      media: [],
+      unavailableMediaCount: 1,
+      files: [{ ...file, reason: "no private download URL" }],
+    });
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("redacts download credentials before exposing a failure reason or warning", async () => {
+    mockFetch.mockRejectedValueOnce(
+      new Error(
+        "Download failed at https://files.slack.com/file.png?token=synthetic-private-query-value",
+      ),
+    );
+    const result = await resolveSlackAttachmentContent({
+      files: [{ name: "file.png", url_private: "https://files.slack.com/file.png" }],
+      token: "xoxb-test-token",
+      maxBytes: 1024,
+    });
+
+    expect(result?.files?.[0]).toMatchObject({
+      reason: expect.stringContaining("Download failed"),
+    });
+    expect(JSON.stringify(result)).not.toContain("synthetic-private-query-value");
+    expect(mediaWarnMock).toHaveBeenCalledOnce();
+    expect(mediaWarnMock.mock.calls[0]?.[0]).not.toContain("synthetic-private-query-value");
   });
 
   it("skips forwarded image URLs on non-Slack hosts", async () => {
@@ -1532,7 +1642,7 @@ describe("resolveSlackAttachmentContent", () => {
           placeholder: "[Forwarded image: forwarded.jpg]",
         },
       ],
-      unavailableImageCount: 0,
+      unavailableMediaCount: 0,
     });
     const firstCall = requireMockCall(mockFetch, 0, "fetch");
     expect(firstCall[0]).toBe("https://files.slack.com/forwarded.jpg");
@@ -1553,7 +1663,7 @@ describe("resolveSlackAttachmentContent", () => {
     expect(result).toEqual({
       text: "",
       media: [],
-      unavailableImageCount: 1,
+      unavailableMediaCount: 1,
     });
     expect(saveMediaBufferMock).not.toHaveBeenCalled();
     expect(mockFetch).toHaveBeenCalledOnce();

--- a/extensions/slack/src/monitor/media.ts
+++ b/extensions/slack/src/monitor/media.ts
@@ -4,6 +4,7 @@ import type { WebClient as SlackWebClient } from "@slack/web-api";
 import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { normalizeHostname } from "openclaw/plugin-sdk/host-runtime";
+import { redactToolPayloadText } from "openclaw/plugin-sdk/logging-core";
 import { resolveRequestUrl } from "openclaw/plugin-sdk/request-url";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -13,7 +14,12 @@ import {
 import { formatSlackFileReference } from "../file-reference.js";
 import type { SlackAttachment, SlackFile } from "../types.js";
 import { MAX_SLACK_MEDIA_FILES, type SlackMediaResult } from "./media-types.js";
-import { type FetchLike, fetchWithRuntimeDispatcher, saveRemoteMedia } from "./media.runtime.js";
+import {
+  type FetchLike,
+  fetchWithRuntimeDispatcher,
+  saveRemoteMedia,
+  slackMediaLog,
+} from "./media.runtime.js";
 import { isGovSlackClient } from "./slack-client-kind.js";
 import { logVerbose } from "./thread.runtime.js";
 export type { SlackMediaResult } from "./media-types.js";
@@ -209,6 +215,13 @@ async function looksLikeHtmlFile(filePath: string): Promise<boolean> {
 
 const MAX_SLACK_MEDIA_CONCURRENCY = 3;
 const MAX_SLACK_FORWARDED_ATTACHMENTS = 8;
+const SLACK_MEDIA_LIMIT_REASON = `omitted: ${MAX_SLACK_MEDIA_FILES}-file limit`;
+
+function formatSlackMediaFailure(error: unknown): string {
+  // Download errors can contain URLs and response bodies; redact before bounding
+  // the text shared by diagnostics and model context, even with log redaction off.
+  return redactToolPayloadText(formatErrorMessage(error)).replace(/\s+/g, " ").slice(0, 200);
+}
 
 async function fetchFreshSlackFileUrl(params: {
   file: SlackFile;
@@ -249,7 +262,7 @@ async function downloadSlackMediaFile(params: {
   totalTimeoutMs?: number;
   abortSignal?: AbortSignal;
   govSlack: boolean;
-}): Promise<SlackMediaResult | null> {
+}): Promise<SlackMediaResult> {
   const { url: slackUrl, requestInit } = createSlackMediaRequest(
     params.url,
     params.token,
@@ -281,7 +294,7 @@ async function downloadSlackMediaFile(params: {
     const detectedMime = normalizeOptionalLowercaseString(saved.contentType?.split(";")[0]);
     if (detectedMime === "text/html" || (await looksLikeHtmlFile(saved.path))) {
       await fs.rm(saved.path, { force: true }).catch(() => undefined);
-      return null;
+      throw new Error("blocked: unexpected HTML content");
     }
   }
 
@@ -334,12 +347,15 @@ export async function resolveSlackMedia(params: {
   totalTimeoutMs?: number;
   abortSignal?: AbortSignal;
   preloadedMedia?: ReadonlyMap<SlackFile, SlackMediaResult>;
-  resolvedFiles?: Set<SlackFile>;
+  unavailableFiles?: Map<SlackFile, string>;
 }): Promise<SlackMediaResult[] | null> {
   const govSlack = isGovSlackClient(params.client);
   const files = params.files ?? [];
   const limitedFiles =
     files.length > MAX_SLACK_MEDIA_FILES ? files.slice(0, MAX_SLACK_MEDIA_FILES) : files;
+  for (const file of files.slice(MAX_SLACK_MEDIA_FILES)) {
+    params.unavailableFiles?.set(file, SLACK_MEDIA_LIMIT_REASON);
+  }
   const refreshFileUrl = (file: SlackFile) =>
     fetchFreshSlackFileUrl({
       file,
@@ -356,50 +372,27 @@ export async function resolveSlackMedia(params: {
         return preloaded;
       }
       const eventUrl = file.url_private_download ?? file.url_private;
-      const url = eventUrl ?? (await refreshFileUrl(file));
-      if (!url) {
-        return null;
+      let url = eventUrl ?? (await refreshFileUrl(file));
+      let reason = "no private download URL";
+      for (let attempt = 0; url && attempt < 2; attempt += 1) {
+        try {
+          return await downloadSlackMediaFile({ ...params, file, url, govSlack });
+        } catch (error) {
+          reason = formatSlackMediaFailure(error);
+        }
+        // Only a failed event URL gets the existing files.info retry. Record
+        // the final outcome once so a recovered download is not called unavailable.
+        url = attempt === 0 && eventUrl ? await refreshFileUrl(file) : null;
       }
-      const result = await downloadSlackMediaFile({
-        file,
-        url,
-        token: params.token,
-        maxBytes: params.maxBytes,
-        readIdleTimeoutMs: params.readIdleTimeoutMs,
-        totalTimeoutMs: params.totalTimeoutMs,
-        abortSignal: params.abortSignal,
-        govSlack,
-      }).catch(() => null);
-      if (result || !eventUrl) {
-        return result;
-      }
-
-      const freshUrl = await refreshFileUrl(file);
-      if (!freshUrl) {
-        return null;
-      }
-      const retryResult = await downloadSlackMediaFile({
-        file,
-        url: freshUrl,
-        token: params.token,
-        maxBytes: params.maxBytes,
-        readIdleTimeoutMs: params.readIdleTimeoutMs,
-        totalTimeoutMs: params.totalTimeoutMs,
-        abortSignal: params.abortSignal,
-        govSlack,
-      }).catch(() => null);
-      return retryResult;
+      params.unavailableFiles?.set(file, reason);
+      slackMediaLog.warn(`slack: file ${formatSlackFileReference(file)} unavailable (${reason})`);
+      return null;
     }),
     limit: MAX_SLACK_MEDIA_CONCURRENCY,
     errorMode: "stop",
     throwOnError: true,
   });
-  const resolved = results.filter((result, index): result is SlackMediaResult => {
-    if (result) {
-      params.resolvedFiles?.add(limitedFiles[index]!);
-    }
-    return result !== null;
-  });
+  const resolved = results.filter((result): result is SlackMediaResult => result !== null);
 
   return resolved.length > 0 ? resolved : null;
 }
@@ -418,8 +411,8 @@ export async function resolveSlackAttachmentContent(params: {
 }): Promise<{
   text: string;
   media: SlackMediaResult[];
-  files?: SlackFile[];
-  unavailableImageCount: number;
+  files?: (SlackFile & { reason: string })[];
+  unavailableMediaCount: number;
 } | null> {
   const forwardedAttachments = (params.attachments ?? [])
     .filter((attachment) => isForwardedSlackAttachment(attachment))
@@ -445,8 +438,10 @@ export async function resolveSlackAttachmentContent(params: {
       fileIds.add(fileId);
       return true;
     })
-    .slice(0, MAX_SLACK_MEDIA_FILES)
-    .map((file) => {
+    .map((file, index) => {
+      if (index >= MAX_SLACK_MEDIA_FILES) {
+        return file;
+      }
       const fileId = normalizeOptionalString(file.id);
       const preloaded =
         fileId &&
@@ -469,13 +464,15 @@ export async function resolveSlackAttachmentContent(params: {
       return downloadable ? Object.assign({}, file, downloadable) : file;
     });
   const pendingFiles = new Map<SlackFile | string, SlackFile>(
-    allFiles.map((file) => [normalizeOptionalString(file.id) ?? file, file]),
+    allFiles
+      .slice(0, MAX_SLACK_MEDIA_FILES)
+      .map((file) => [normalizeOptionalString(file.id) ?? file, file]),
   );
-  const resolvedFiles = new Set<SlackFile>();
+  const unavailableFileReasons = new Map<SlackFile, string>();
   const resolveFiles = (files?: SlackFile[]) =>
     resolveSlackMedia({
       ...params,
-      resolvedFiles,
+      unavailableFiles: unavailableFileReasons,
       files: files?.flatMap((file) => {
         const key = normalizeOptionalString(file.id) ?? file;
         const selected = pendingFiles.get(key);
@@ -486,7 +483,7 @@ export async function resolveSlackAttachmentContent(params: {
   const directMediaPromise = resolveFiles(params.files);
   const textBlocks: string[] = [];
   const attachmentMedia: SlackMediaResult[] = [];
-  let unavailableImageCount = 0;
+  let unavailableMediaCount = 0;
   const govSlack = isGovSlackClient(params.client);
 
   for (const att of forwardedAttachments) {
@@ -525,28 +522,36 @@ export async function resolveSlackAttachmentContent(params: {
           ...(saved.fileName ? { fileName: saved.fileName } : {}),
           placeholder: `[Forwarded image: ${label}]`,
         });
-      } catch {
-        unavailableImageCount += 1;
+      } catch (error) {
+        unavailableMediaCount += 1;
+        slackMediaLog.warn(
+          `slack: forwarded image unavailable (${formatSlackMediaFailure(error)})`,
+        );
       }
     }
     attachmentMedia.push(...((await resolveFiles(att.files)) ?? []));
   }
 
   const allMedia = [...((await directMediaPromise) ?? []), ...attachmentMedia];
-  const unavailableFiles = allFiles.filter((file) => !resolvedFiles.has(file));
+  const unavailableFiles = allFiles.flatMap((file, index) => {
+    const reason =
+      index >= MAX_SLACK_MEDIA_FILES ? SLACK_MEDIA_LIMIT_REASON : unavailableFileReasons.get(file);
+    return reason ? [{ ...file, reason }] : [];
+  });
+  unavailableMediaCount += unavailableFiles.length;
   const combinedText = textBlocks.join("\n\n");
   if (
     !combinedText &&
     allMedia.length === 0 &&
     allFiles.length === 0 &&
-    unavailableImageCount === 0
+    unavailableMediaCount === 0
   ) {
     return null;
   }
   return {
     text: combinedText,
     media: allMedia,
-    unavailableImageCount,
+    unavailableMediaCount,
     ...(unavailableFiles.length > 0 ? { files: unavailableFiles } : {}),
   };
 }

--- a/extensions/slack/src/monitor/message-handler/prepare-content.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-content.ts
@@ -5,6 +5,7 @@ import { runTasksWithConcurrency } from "openclaw/plugin-sdk/concurrency-runtime
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { formatSlackFileReference } from "../../file-reference.js";
 import type { SlackFile, SlackMessageEvent } from "../../types.js";
 import { resolveSlackMessageText } from "../block-text.js";
@@ -19,6 +20,7 @@ type SlackResolvedMessageContent = {
 const SLACK_MENTION_RESOLUTION_CONCURRENCY = 4;
 const SLACK_MENTION_RESOLUTION_MAX_LOOKUPS_PER_MESSAGE = 20;
 const SLACK_USER_MENTION_RE = /<@([A-Z0-9]+)(?:\|[^>]+)?>/gi;
+const MAX_SLACK_UNAVAILABLE_FILE_TEXT_CHARS = 2000;
 
 const loadSlackMediaModule = createLazyRuntimeModule(() => import("../media.js"));
 
@@ -118,7 +120,13 @@ export async function resolveSlackMessageContent(params: {
   const effectiveDirectMedia = attachmentContent?.media.length ? attachmentContent.media : null;
   const mediaPlaceholder = effectiveDirectMedia?.map((item) => item.placeholder).join(" ");
 
-  const fileOnlyFallback = attachmentContent?.files?.map(formatSlackFileReference).join(", ");
+  let fileOnlyFallback = attachmentContent?.files
+    ?.map((file) => `${formatSlackFileReference(file)} unavailable (${file.reason})`)
+    .join(", ");
+  // Excess files remain accounted for without adding an unbounded prompt block.
+  if (fileOnlyFallback && fileOnlyFallback.length > MAX_SLACK_UNAVAILABLE_FILE_TEXT_CHARS) {
+    fileOnlyFallback = `${truncateUtf16Safe(fileOnlyFallback, MAX_SLACK_UNAVAILABLE_FILE_TEXT_CHARS)}; … (file references truncated)`;
+  }
 
   let botAttachmentText: string | undefined;
   if (params.isBotMessage && !attachmentContent?.text) {
@@ -177,12 +185,12 @@ export async function resolveSlackMessageContent(params: {
     ]
       .filter(Boolean)
       .join("\n") || "";
-  const unavailableImageCount = attachmentContent?.unavailableImageCount ?? 0;
-  if (unavailableImageCount > 0) {
+  const unavailableMediaCount = attachmentContent?.unavailableMediaCount ?? 0;
+  if (unavailableMediaCount > 0) {
     rawBody = formatInboundMediaUnavailableText({
       body: rawBody,
       notice: `[slack ${
-        unavailableImageCount > 1 ? `${unavailableImageCount} forwarded images` : "forwarded image"
+        unavailableMediaCount > 1 ? `${unavailableMediaCount} attachments` : "attachment"
       } unavailable]`,
     });
   }

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -1956,7 +1956,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       );
 
       assertPrepared(prepared);
-      expect(prepared.ctxPayload.RawBody).toBe("caption\n\n[slack forwarded image unavailable]");
+      expect(prepared.ctxPayload.RawBody).toBe("caption\n\n[slack attachment unavailable]");
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -2100,17 +2100,18 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
 
   it("keeps a failed file recoverable when a sibling download reaches the agent", async () => {
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = vi.fn(
-      async (input: RequestInfo | URL) =>
-        new Response(Buffer.from("image contents"), {
-          status: 200,
-          headers: {
-            "content-type": "image/png",
-            ...(typeof input === "string" && input.includes("original-name.png")
-              ? { "content-disposition": 'attachment; filename="server-renamed.png"' }
-              : {}),
-          },
-        }),
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) =>
+      typeof input === "string" && input.includes("missing-contract.pdf")
+        ? new Response("Not Found", { status: 404 })
+        : new Response(Buffer.from("image contents"), {
+            status: 200,
+            headers: {
+              "content-type": "image/png",
+              ...(typeof input === "string" && input.includes("original-name.png")
+                ? { "content-disposition": 'attachment; filename="server-renamed.png"' }
+                : {}),
+            },
+          }),
     ) as typeof fetch;
     let downloadedPaths: string[] = [];
 
@@ -2131,7 +2132,12 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
               url_private_download: "https://files.slack.com/original-name.png",
             },
             { name: "original-name.png", mimetype: "image/png" },
-            { id: "F1", name: "missing-contract.pdf", mimetype: "application/pdf" },
+            {
+              id: "F1",
+              name: "missing-contract.pdf",
+              mimetype: "application/pdf",
+              url_private_download: "https://files.slack.com/missing-contract.pdf",
+            },
           ],
         }),
       );
@@ -2144,13 +2150,52 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
       expect(prepared.ctxPayload.RawBody).toContain("server-renamed.png (image/png)");
       expect(prepared.ctxPayload.RawBody?.match(/original-name\.png/g)).toHaveLength(1);
       expect(prepared.ctxPayload.BodyForAgent).toContain(
-        "missing-contract.pdf (application/pdf, fileId: F1)",
+        "missing-contract.pdf (application/pdf, fileId: F1) unavailable (",
       );
+      expect(prepared.ctxPayload.BodyForAgent).toContain("HTTP 404");
+      expect(prepared.ctxPayload.BodyForAgent).toContain("[slack 2 attachments unavailable]");
     } finally {
       globalThis.fetch = originalFetch;
       await Promise.all(
         downloadedPaths.map((downloadedPath) => fs.rm(downloadedPath, { force: true })),
       );
+    }
+  });
+
+  it("keeps the ninth file visible to the agent without downloading past the cap", async () => {
+    const originalFetch = globalThis.fetch;
+    const mockFetch = vi.fn(
+      async () =>
+        new Response(Buffer.from("image contents"), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    globalThis.fetch = mockFetch as typeof fetch;
+    let downloadedPaths: string[] = [];
+    try {
+      const prepared = await prepareWithDefaultCtx(
+        createSlackMessage({
+          text: "Inspect these files",
+          files: Array.from({ length: 9 }, (_, index) => ({
+            id: `FCAP${index}`,
+            name: `image-${index}.png`,
+            mimetype: "image/png",
+            url_private_download: `https://files.slack.com/image-${index}.png`,
+          })),
+        }),
+      );
+      assertPrepared(prepared);
+      downloadedPaths =
+        prepared.ctxPayload.media?.flatMap((media) => (media.path ? [media.path] : [])) ?? [];
+      expect(mockFetch).toHaveBeenCalledTimes(8);
+      expect(prepared.ctxPayload.media).toHaveLength(8);
+      expect(prepared.ctxPayload.BodyForAgent).toContain(
+        "image-8.png (image/png, fileId: FCAP8) unavailable (omitted: 8-file limit)",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      await Promise.all(downloadedPaths.map((filePath) => fs.rm(filePath, { force: true })));
     }
   });
 
@@ -2170,7 +2215,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
 
     assertPrepared(prepared);
     expect(prepared.ctxPayload.RawBody).toContain(
-      "[Slack file: forwarded-report.pdf (fileId: FFORWARD)]",
+      "[Slack file: forwarded-report.pdf (fileId: FFORWARD) unavailable (no private download URL)]",
     );
   });
 
@@ -2196,7 +2241,7 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
 
     assertPrepared(prepared);
     expect(prepared.ctxPayload.RawBody).toContain(
-      "[Slack file: direct-report.pdf (fileId: FDIRECT), shared-report.pdf (fileId: FSHARED), forwarded-report.pdf (fileId: FFORWARD)]",
+      "[Slack file: direct-report.pdf (fileId: FDIRECT) unavailable (no private download URL), shared-report.pdf (fileId: FSHARED) unavailable (no private download URL), forwarded-report.pdf (fileId: FFORWARD) unavailable (no private download URL)]",
     );
   });
 
@@ -2209,7 +2254,9 @@ Second paragraph should still reach the agent after Slack's preview cutoff.`;
     );
 
     assertPrepared(prepared);
-    expect(prepared.ctxPayload.RawBody).toContain("[Slack file: file]");
+    expect(prepared.ctxPayload.RawBody).toContain(
+      "[Slack file: file unavailable (no private download URL)]",
+    );
   });
 
   it("extracts attachment text for bot messages with empty text when allowBots is true (#27616)", async () => {


### PR DESCRIPTION
## What Problem This Solves

Three diagnostic gaps in Slack attachment handling (the outright disappearance of failed files was already fixed by `8c203185d7e`; these are the remaining holes):

1. Download exceptions were swallowed by `.catch(() => null)` with no log and no reason — the agent saw a bare file reference with no indication why the bytes were missing, and operators had nothing in the logs for the failure itself.
2. `unavailableImageCount` only counted forwarded `image_url` failures; direct file-download failures never incremented the accounting.
3. The documented 8-file cap silently truncated: a 9-file message produced neither media nor any record that the ninth file existed.

## Why This Change Was Made

The resolver now records outcomes where they happen instead of inferring unavailability from successful downloads: failed files keep a reason on their existing entry (redacted for model context even when log redaction is off, one line, bounded to 200 chars), each final failure logs one warning (a successful URL-refresh retry logs none), HTML-guard rejections keep their security behavior with a blocked-content reason, direct and forwarded failures share one unavailable count, and files beyond the selection cap surface as `omitted: 8-file limit` entries. Unavailable-file body text is bounded to 2,000 chars with explicit truncation wording. Dedup, preloaded-file identity, ordering, the 8-file limit itself, forwarded trust limits, auth, timeouts, and byte budgets are unchanged; the duplicated download-attempt blocks and success-only identity set were deleted (accounting mostly absorbed by that consolidation — net +16 production LOC). Docs updated in the Slack media reference.

## User Impact

The agent can now tell the difference between "file attached and readable", "file attached but unavailable (reason)", and "file omitted by the 8-file limit" — and operators get one warn per real download failure.

## Evidence

- Pre-fix proof: 9 failed / 234 passed with regression assertions on unmodified production — failures covered missing reasons/warnings/accounting for direct and forwarded failures, both HTML paths, omitted entries at standalone and combined caps, and the mixed-success and ninth-file agent bodies.
- Post-fix: 245 focused tests green; full `extensions/slack/src/monitor`: 50 files, 1,212 tests green; sibling `actions.download-file` contract: 22 green; focused suites re-run green after rebase onto latest `origin/main`.
- Changed-file gate exit 0 (both TypeScript lanes, lint, guards, zero runtime import cycles); `pnpm docs:list`, oxfmt, `git diff --check` green.
- Fresh Codex autoreview: no P0 findings.
