### PR TITLE
fix(ui): keep the new-session composer within easy reach on mobile

### DIFF
--- a/ui/src/e2e/new-session-page.responsive-welcome.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.responsive-welcome.e2e.test.ts
@@ -1,0 +1,62 @@
+import { expect, it } from "vitest";
+import {
+  createNewSessionPageE2eSuite,
+  installMockGateway,
+} from "./new-session-page.test-support.ts";
+
+const suite = createNewSessionPageE2eSuite();
+
+suite.define(() => {
+  it("keeps empty-state suggestions desktop-only across viewport changes", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        methodResponses: {
+          "sessions.list": {
+            count: 0,
+            defaults: { contextTokens: null, model: null, modelProvider: null },
+            path: "",
+            sessions: [],
+            ts: Date.now(),
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}new`);
+      const suggestions = page.locator(".agent-chat__suggestion:visible");
+      await expect.poll(() => suggestions.count()).toBe(4);
+
+      await page.setViewportSize({ width: 390, height: 844 });
+      await expect.poll(() => suggestions.count()).toBe(0);
+
+      await page.setViewportSize({ width: 1280, height: 900 });
+      await expect.poll(() => suggestions.count()).toBe(4);
+    });
+  });
+
+  it("keeps recent sessions visible on phone layouts", async () => {
+    await suite.withPage({ viewport: { width: 390, height: 844 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        methodResponses: {
+          "sessions.list": {
+            count: 1,
+            defaults: { contextTokens: null, model: null, modelProvider: null },
+            path: "",
+            sessions: [
+              {
+                key: "agent:main:dashboard:recent",
+                kind: "direct",
+                label: "Recent work",
+                updatedAt: Date.now(),
+              },
+            ],
+            ts: Date.now(),
+          },
+        },
+      });
+
+      await page.goto(`${suite.server.baseUrl}new`);
+      await expect.poll(() => page.locator(".agent-chat__recent").count()).toBe(1);
+      await expect.poll(() => page.locator(".agent-chat__recent").isVisible()).toBe(true);
+    });
+  });
+});

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -1140,6 +1140,10 @@ wa-popover.new-session-page__project-popover::part(body) {
 }
 
 @media (max-width: 560px) {
+  .new-session-page .agent-chat__welcome-secondary:has(.agent-chat__suggestions) {
+    display: none;
+  }
+
   .agent-chat__input--mobile-toolbar .new-session-page__start-submit {
     width: var(--chat-composer-send-size);
     min-width: var(--chat-composer-send-size);


### PR DESCRIPTION
Fixes #130854

## What Problem This Solves

Operators opening `/new` without recent sessions on a phone-sized viewport saw four canned suggestion chips below the composer. The chips occupied the bottom action area and pushed the composer away from easy thumb reach.

## Why This Change Was Made

The `/new` page already owns a canonical 560 px phone layout. This fix keeps the policy in that layout owner: at phone widths, CSS hides only the welcome secondary block whose content is the canned suggestion fallback. Recent sessions remain visible, ordinary chat is unaffected, desktop `/new` retains all four suggestions, and viewport changes update immediately without JavaScript breakpoint state.

The incoming implementation added a `matchMedia` lifecycle and a shared renderer flag, but that duplicated a CSS-owned breakpoint and pushed `new-session-page.ts` over the repository's max-lines gate. The landed shape removes those paths entirely.

## User Impact

- Mobile `/new` with no recent sessions: suggestion chips are removed from layout and accessibility/focus behavior; the composer remains at the bottom.
- Mobile `/new` with recent sessions: recents remain visible.
- Desktop `/new`: all four suggestion actions remain unchanged.
- Ordinary chat, model setup, incognito behavior, and session creation remain unchanged.

## Evidence

Exact GPG-verified head: `473706e496552ff556c098eb5eee322ff7d37ba9`, rebased onto `origin/main@4f9466af6f54f7928638c6949d2c1e24259c17db`.

- `node scripts/run-vitest.mjs ui/src/e2e/new-session-page.responsive-welcome.e2e.test.ts --run` - 2 passed after final rebase: desktop -> mobile -> desktop suggestions, plus mobile recents preservation.
- `node scripts/check-changed.mjs -- <five reviewed paths>` - passed formatting, max-lines ratchet, guards, i18n, tsgo, oxlint, stylelint, and dead-code checks on the identical reviewed tree.
- Fresh Codex autoreview (`gpt-5.6-sol`, high) after final rebase - clean.
- GitHub commit verification: `verified=true`, reason `valid`, GPG signature present.
- `git diff --check` - passed.

### Exact-tree visual proof

Both captures were inspected from the same byte-identical CSS/test tree before the final mechanical rebase.

| Mobile 390×844: no suggestions, composer at bottom | Desktop 1280×900: four suggestions retained |
| --- | --- |
| <img alt="Mobile new-session without suggestion chips and with the composer at the bottom" src="https://github.com/user-attachments/assets/814ba556-6a9c-46d7-8eb0-fb3935ec11f0" width="300"> | <img alt="Desktop new-session retaining four suggestion actions" src="https://github.com/user-attachments/assets/d731d67e-d791-4d5c-8bf1-cb86fd0434ce" width="520"> |

Production LOC: +4/-0. Tests: +62/-0. The production change is the page-owned responsive rule; no new runtime state, shared component API, or lifecycle subscription remains.
