### PR TITLE
fix(android): prevent native font setup collisions between tests

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeForegroundServiceTest.kt
@@ -175,7 +175,7 @@ class NodeForegroundServiceTest {
       assertEquals(2, Shadows.shadowOf(controller.get()).stopSelfResultId)
       assertNull(app.peekRuntime())
     } finally {
-      controller.destroy()
+      closeNodeServiceTestFixture(controller, app)
     }
   }
 
@@ -207,8 +207,7 @@ class NodeForegroundServiceTest {
       assertEquals(Service.START_NOT_STICKY, stopped)
       assertEquals(Service.START_STICKY, resumed)
     } finally {
-      controller.destroy()
-      app.peekRuntime()?.disconnect()
+      closeNodeServiceTestFixture(controller, app)
     }
   }
 
@@ -225,7 +224,7 @@ class NodeForegroundServiceTest {
       assertFalse(runtime.isForeground.value)
       assertFalse(prefs.voiceMicEnabled.value)
     } finally {
-      runtime.disconnect()
+      closeNodeRuntimeTestFixture(runtime)
     }
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeTestCleanup.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/NodeRuntimeTestCleanup.kt
@@ -1,0 +1,85 @@
+package ai.openclaw.app
+
+import ai.openclaw.app.chat.AndroidClientDatabases
+import android.os.Handler
+import android.os.Looper
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.job
+import kotlinx.coroutines.runBlocking
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ServiceController
+import org.robolectric.shadows.ShadowPausedLooper
+import org.robolectric.util.ReflectionHelpers
+
+internal fun closeNodeRuntimeTestFixture(runtime: NodeRuntime) = drainWithMainLooper { closeRuntime(runtime) }
+
+internal fun closeNodeServiceTestFixture(
+  controller: ServiceController<NodeForegroundService>,
+  app: NodeApp,
+) {
+  try {
+    controller.destroy()
+  } finally {
+    drainWithMainLooper {
+      // A canceled service can still be constructing the process runtime. Join its producer
+      // before taking the app's final runtime snapshot, including the asynchronous STOP task.
+      ReflectionHelpers
+        .getField<CoroutineScope>(controller.get(), "scope")
+        .coroutineContext.job
+        .join()
+      ReflectionHelpers
+        .getField<CoroutineScope>(app, "runtimeScope")
+        .coroutineContext.job
+        .cancelAndJoin()
+      app.peekRuntime()?.let { closeRuntime(it) }
+    }
+  }
+}
+
+private suspend fun closeRuntime(runtime: NodeRuntime) {
+  val databases = ReflectionHelpers.getField<AndroidClientDatabases>(runtime, "clientDatabases")
+  try {
+    try {
+      runtime.disconnect()
+    } finally {
+      ReflectionHelpers
+        .getField<CoroutineScope>(runtime, "scope")
+        .coroutineContext.job
+        .cancelAndJoin()
+    }
+  } finally {
+    try {
+      // Database initialization has its own IO scope. Await its real result before closing so
+      // native loading cannot escape this sandbox and initialization failures remain test failures.
+      databases.clientStateDatabase()
+    } finally {
+      databases.close()
+    }
+  }
+}
+
+private fun drainWithMainLooper(block: suspend () -> Unit) {
+  val mainLooper = Looper.getMainLooper()
+  val shadowLooper = shadowOf(mainLooper) as ShadowPausedLooper
+  val handler = Handler(mainLooper)
+  var completed = false
+  val wakeMain = Runnable { completed = true }
+  try {
+    runBlocking {
+      val cleanup = async(Dispatchers.Default) { block() }
+      cleanup.invokeOnCompletion { handler.post(wakeMain) }
+      // Robolectric's paused Main looper needs pumping while worker finalizers dispatch to it.
+      // Completion posts a wakeup so poll cannot strand Main after the last worker finishes.
+      while (!completed) {
+        shadowLooper.poll(0)
+        shadowLooper.idle()
+      }
+      cleanup.await()
+    }
+  } finally {
+    handler.removeCallbacks(wakeMain)
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/VoiceWakeRuntimeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/VoiceWakeRuntimeTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -21,6 +22,13 @@ import java.util.UUID
 
 @RunWith(RobolectricTestRunner::class)
 class VoiceWakeRuntimeTest {
+  private var runtimeUnderTest: NodeRuntime? = null
+
+  @After
+  fun closeRuntime() {
+    runtimeUnderTest?.let(::closeNodeRuntimeTestFixture)
+  }
+
   @Test
   fun disconnectedSaveDoesNotCreateLocalOverride() {
     val runtime = createTestRuntime()
@@ -173,7 +181,7 @@ class VoiceWakeRuntimeTest {
       )
     val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
     prefs.setVoiceWakeEnabled(true)
-    val runtime = NodeRuntime(app, prefs, mode = NodeRuntimeMode.ScreenshotFixture)
+    val runtime = NodeRuntime(app, prefs, mode = NodeRuntimeMode.ScreenshotFixture).also { runtimeUnderTest = it }
     val endpoint = GatewayEndpoint.manual("127.0.0.1", 18789)
     writeField(runtime, "connectedEndpoint", endpoint)
 
@@ -225,7 +233,7 @@ class VoiceWakeRuntimeTest {
         "openclaw.node.voicewake.runtime.test.${UUID.randomUUID()}",
         Context.MODE_PRIVATE,
       )
-    return NodeRuntime(app, SecurePrefs(app, securePrefsOverride = securePrefs))
+    return NodeRuntime(app, SecurePrefs(app, securePrefsOverride = securePrefs)).also { runtimeUnderTest = it }
   }
 
   private fun seedConnectedRuntime(runtime: NodeRuntime): GatewayEndpoint {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Android unit-test matrix could fail before the first VoiceWake test body when it followed the foreground-service tests. This was reproduced on main at `3255882803c78de5103d2d37f7698add84f34c5d` before this change. No introducing commit is claimed.

## Why This Change Was Made

The SDK 34 foreground-service fixture ended while its independently scoped database initializer was still copying Robolectric native fonts; the following SDK 36 sandbox then collided with that open font filesystem. Gateway disconnect is not process teardown, so the fix belongs in test-fixture ownership: join service/application producers before the final runtime snapshot, disconnect and join runtime work, then await the database initializer's real result before closing it.

The shared helper uses Robolectric's supported paused-Main polling API to process worker finalizers without changing dispatchers, clocks, or timeouts. Initialization failures still fail the test. VoiceWake cleanup covers factory-created and direct screenshot-mode runtimes, including assertion-failure paths; no production accessor was added.

## User Impact

This repairs test isolation without changing shipped app behavior. Gateway disconnect deliberately preserves process-owned storage for reconnects; changing that production lifecycle would be the wrong owner boundary. No live product-behavior claim is made.

## Evidence

- A read-only diagnostic captured the active SDK 34 database worker copying fonts across the class boundary; this was not inferred from the exception alone.
- A disposable, identical JUnit Suite replayed the original Node-before-Voice order on pristine main and the patch: **baseline 22/23 with the intended native-font setup failure; fixed 23/23**, same class and method ordering, empty fixed stdout/stderr. The diagnostic observer and disposable Suite are not included in this PR.
- An earlier 23/23 run used reverse class order despite identical Gradle filters; it is explicitly not used as original-order proof.
- The first broader matrix passed **141 tests per flavor (282 total)** across the 11 original owner/sibling classes, with Node before Voice and empty error streams. Both Android lint tasks also passed. The batch stopped on nine formatting errors in the new helper; the formatter changed only whitespace. The remaining style tasks and APK build were not reached in that attempt.
- Native verification and the normal local three-path changed-file gate passed on the formatted patch without generated changes.
- Codex P0–P2 review completed without actionable findings on both the final formatted patch and the exact committed branch.
- Final frozen-patch batch passed: **141 tests per flavor (282 total)** across the same 11 owner/sibling classes, both actual Android lint tasks, all four unfiltered module ktlint checks, and Play debug APK assembly. Both flavors naturally ran Node before Voice; the original two classes' method sequences match the failing baseline, and all test stdout/stderr sections are empty. Lint reported zero errors/warnings and three existing hints in unchanged files. The changed helper's style check actually executed; unchanged sibling checks used normal build-cache/up-to-date results where reported.
- An earlier configured remote changed gate timed out during synchronization and is not counted as passing proof; its lease was verified stopped before the normal local gate ran.

Current-main check at `1847e9ac9945a19d987a5ae1fe7450e8d74523ee`: the affected runtime owners, two test classes, Android build/dependency files, and shared Android asset inputs remain unchanged since the reproduced baseline. The intervening Android changes concern Canvas authority matching and generated string resources, not fixture shutdown.

Production delta: **+0/-0**. Tests and test support: **+98/-6**.

The exact committed branch received a clean Codex P0–P2 review. Hosted CI is pending; the local evidence above is not a claim that this PR is ready to merge.
