### PR TITLE
fix(codex): clean up subscriptions after failed thread resumes

### DIFF
--- a/extensions/codex/src/app-server/attempt-startup-retry.test.ts
+++ b/extensions/codex/src/app-server/attempt-startup-retry.test.ts
@@ -24,6 +24,7 @@ import {
   clearSharedCodexAppServerClient,
   clearSharedCodexAppServerClientAndWait,
   getLeasedSharedCodexAppServerClient,
+  releaseLeasedSharedCodexAppServerClient,
 } from "./shared-client.js";
 import { createCodexTestModel } from "./test-support.js";
 
@@ -35,12 +36,13 @@ vi.mock("./desktop-generation.js", () => ({
 const tempRoots = new Set<string>();
 
 async function createStartupFailureFixture(
-  mode: "transient" | "contention" | "persistent" | "unsupported",
+  mode: "transient" | "contention" | "persistent" | "unsupported" | "overload",
 ) {
   const root = path.join(os.tmpdir(), `openclaw-codex-startup-retry-${randomUUID()}`);
   tempRoots.add(root);
   const fixturePath = path.join(root, "startup-failure.mjs");
   const spawnCountPath = path.join(root, "spawn-count");
+  const requestLogPath = path.join(root, "requests.log");
   const codexHome = path.join(root, "codex-home");
   await fs.mkdir(root, { recursive: true });
   await fs.writeFile(
@@ -48,7 +50,7 @@ async function createStartupFailureFixture(
     [
       'import fs from "node:fs";',
       'import readline from "node:readline";',
-      "const [spawnCountPath, mode, codexHome] = process.argv.slice(2);",
+      "const [spawnCountPath, mode, codexHome, requestLogPath] = process.argv.slice(2);",
       'const attempt = Number(fs.existsSync(spawnCountPath) ? fs.readFileSync(spawnCountPath, "utf8") : 0) + 1;',
       'fs.writeFileSync(spawnCountPath, String(attempt), "utf8");',
       "const startedAtPath = `${spawnCountPath}.started-at`;",
@@ -62,6 +64,11 @@ async function createStartupFailureFixture(
       '  lines.on("line", (line) => {',
       "    const message = JSON.parse(line);",
       "    if (message.id === undefined) return;",
+      "    fs.appendFileSync(requestLogPath, `${message.method}\\n`);",
+      '    if (mode === "overload" && message.method === "thread/resume") {',
+      '      process.stdout.write(`${JSON.stringify({ id: message.id, error: { code: -32001, message: "Server overloaded; retry later." } })}\\n`);',
+      "      return;",
+      "    }",
       '    const result = message.method === "initialize"',
       '      ? { userAgent: `openclaw/${mode === "unsupported" ? "0.1.0" : "0.149.0"} (macOS; test)` }',
       `      : ${JSON.stringify(threadStartResult("thread-recovered", "/repo"))};`,
@@ -75,11 +82,11 @@ async function createStartupFailureFixture(
     appServer: {
       transport: "stdio",
       command: process.execPath,
-      args: [fixturePath, spawnCountPath, mode, codexHome],
+      args: [fixturePath, spawnCountPath, mode, codexHome, requestLogPath],
       requestTimeoutMs: 5_000,
     },
   } satisfies CodexPluginConfig;
-  return { root, spawnCountPath, pluginConfig };
+  return { root, spawnCountPath, requestLogPath, pluginConfig };
 }
 
 function startFixtureAttempt(fixture: Awaited<ReturnType<typeof createStartupFailureFixture>>) {
@@ -201,5 +208,58 @@ describe("Codex app-server startup retry", () => {
       /app-server .* or newer is required/i,
     );
     expect(await fs.readFile(fixture.spawnCountPath, "utf8")).toBe("1");
+  });
+
+  it("preserves the shared client and binding after resume overload exhausts", async () => {
+    const fixture = await createStartupFailureFixture("overload");
+    const sibling = await startFixtureAttempt(fixture);
+    sibling.turnRoute.release();
+    const identity = {
+      kind: "session" as const,
+      agentId: "agent-1",
+      sessionId: "session-1",
+      sessionKey: "agent:agent-1:session-1",
+    };
+    try {
+      const binding = await testCodexAppServerBindingStore.read(identity);
+      expect(binding?.threadId).toBe("thread-recovered");
+      const requestsBeforeResume = await fs.readFile(fixture.requestLogPath, "utf8");
+
+      await expect(startFixtureAttempt(fixture)).rejects.toMatchObject({
+        name: "CodexAppServerRpcError",
+        code: -32_001,
+        method: "thread/resume",
+      });
+      const requests = await fs.readFile(fixture.requestLogPath, "utf8");
+      expect(new Set(requests.slice(requestsBeforeResume.length).trim().split("\n"))).toEqual(
+        new Set(["thread/resume"]),
+      );
+      await expect(testCodexAppServerBindingStore.read(identity)).resolves.toEqual(binding);
+
+      await expect(
+        sibling.client.request("thread/read", {
+          threadId: "thread-recovered",
+          includeTurns: false,
+        }),
+      ).resolves.toMatchObject({ thread: { id: "thread-recovered" } });
+      sibling.releaseSharedClientLease();
+      expect(sibling.client.getCloseError()).toBeUndefined();
+
+      const reacquired = await getLeasedSharedCodexAppServerClient({
+        startOptions: resolveCodexAppServerRuntimeOptions({ pluginConfig: fixture.pluginConfig })
+          .start,
+        agentDir: path.join(fixture.root, "agent"),
+      });
+      try {
+        expect(reacquired).toBe(sibling.client);
+        expect(reacquired.getCloseError()).toBeUndefined();
+        expect(await fs.readFile(fixture.spawnCountPath, "utf8")).toBe("1");
+      } finally {
+        releaseLeasedSharedCodexAppServerClient(reacquired);
+      }
+    } finally {
+      sibling.releaseSharedClientLease();
+      await sibling.client.closeAndWait();
+    }
   });
 });

--- a/extensions/codex/src/app-server/attempt-startup.ts
+++ b/extensions/codex/src/app-server/attempt-startup.ts
@@ -30,6 +30,7 @@ import { ensureCodexAppServerClientRuntime } from "./client-runtime.js";
 import {
   isCodexAppServerBrokenPipeError,
   isCodexAppServerConnectionClosedError,
+  isCodexAppServerOverloadError,
   isCodexAppServerRequestTimeoutError,
   type CodexAppServerClient,
 } from "./client.js";
@@ -689,7 +690,7 @@ export async function startCodexAttemptThread(params: {
       releaseSharedClientLease,
     };
   } catch (error) {
-    if (params.signal.aborted || shouldClearSharedClientAfterStartupAbandon(error)) {
+    if (params.signal.aborted || isCodexAppServerStartupError(error)) {
       releaseSharedClientLease?.();
       releaseSharedClientLease = undefined;
       await closeCodexStartupClientBestEffort(startupClientForAbandonedRequestCleanup);
@@ -713,19 +714,16 @@ export async function startCodexAttemptThread(params: {
   }
 }
 
-function shouldClearSharedClientAfterStartupAbandon(error: unknown): boolean {
-  return isCodexAppServerStartupError(error);
-}
-
 function shouldClearSharedClientAfterStartupRace(error: unknown): boolean {
-  return (
-    shouldClearSharedClientAfterStartupAbandon(error) || isCodexAppServerRequestTimeoutError(error)
-  );
+  return isCodexAppServerStartupError(error) || isCodexAppServerRequestTimeoutError(error);
 }
 
 function shouldClearSharedClientAfterStartupFailure(params: {
   error: unknown;
   spawnedBy: EmbeddedRunAttemptParams["spawnedBy"];
 }): boolean {
+  if (isCodexAppServerOverloadError(params.error)) {
+    return false;
+  }
   return isCodexAppServerBrokenPipeError(params.error) || !params.spawnedBy;
 }

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -80,6 +80,13 @@ export function resolveCodexAppServerClientInstanceId(client: object): string {
 
 export { CodexAppServerRpcError } from "./rpc-error.js";
 
+/** Codex rejects this exact code before enqueueing, including mutating requests. */
+export function isCodexAppServerOverloadError(error: unknown): error is CodexAppServerRpcError {
+  return (
+    error instanceof CodexAppServerRpcError && error.code === CODEX_APP_SERVER_OVERLOADED_ERROR_CODE
+  );
+}
+
 class CodexAppServerLocalRequestCancellationError extends Error {
   readonly code = "CODEX_APP_SERVER_LOCAL_REQUEST_CANCELLED";
 
@@ -501,8 +508,7 @@ export class CodexAppServerClient {
         // Codex emits -32001 only when ingress rejects a request before enqueue,
         // so retrying mutating methods cannot duplicate server-side work.
         if (
-          !(error instanceof CodexAppServerRpcError) ||
-          error.code !== CODEX_APP_SERVER_OVERLOADED_ERROR_CODE ||
+          !isCodexAppServerOverloadError(error) ||
           retry >= CODEX_APP_SERVER_OVERLOAD_MAX_RETRIES
         ) {
           throw error;

--- a/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts
@@ -949,8 +949,8 @@ describe("runCodexAppServerAttempt native hook relay", () => {
     });
     const harness = createStartedThreadHarness(async (method) => {
       if (method === "thread/resume") {
-        // Only a structured RPC rejection proves Codex holds no resume
-        // subscription, so the run may fall back to a fresh thread.
+        // Exact unsubscribe after the structured RPC failure proves the resume
+        // subscription is released before falling back to a fresh thread.
         throw new CodexAppServerRpcError({ code: -32_000, message: "resume failed" }, method);
       }
       return undefined;

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -6,13 +6,12 @@ import {
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
   closeCodexStartupClientBestEffort,
   CodexAppServerUnsafeSubscriptionError,
-  isCodexAppServerUnsafeSubscriptionError,
   unsubscribeCodexThreadBestEffort,
 } from "./attempt-client-cleanup.js";
 import { resolveCodexAppServerLocalHomeDir } from "./auth-start-options.js";
 import {
   CodexAppServerRpcError,
-  isCodexAppServerConnectionClosedError,
+  isCodexAppServerOverloadError,
   resolveCodexAppServerClientInstanceId,
 } from "./client.js";
 import { isMessageOnlyCodexSourceReply } from "./dynamic-tool-profile.js";
@@ -31,7 +30,6 @@ import {
 import { assertCodexThreadStartResponse } from "./protocol-validators.js";
 import type { CodexThread, JsonObject } from "./protocol.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
-import { isCodexAppServerStartSelectionChangedError } from "./shared-client.js";
 import {
   fingerprintCodexThreadConfig,
   readActiveCodexTurnIdsFromResume,
@@ -132,6 +130,9 @@ export async function resumeExistingCodexThread(
     clearCurrentBinding,
   } = context;
   let resumeReservation: { release: () => void } | undefined;
+  let resumeResponseAccepted = false;
+  const abandonClient =
+    params.abandonClient ?? (() => closeCodexStartupClientBestEffort(params.client));
   try {
     const authProfileId =
       resumeBinding.connectionScope === "supervision"
@@ -209,17 +210,14 @@ export async function resumeExistingCodexThread(
         client: params.client,
         // Retiring the exact client keeps an indeterminate resume
         // subscription from ever re-entering the shared pool.
-        abandonClient: async () => {
-          context.assertResumeOwnership?.();
-          await (
-            params.abandonClient ?? (() => closeCodexStartupClientBestEffort(params.client))
-          )();
-        },
+        abandonClient,
         request: resumeParams,
         signal: params.signal,
         assertCurrent: context.assertResumeOwnership,
+        isPrewriteOwnershipError: (error) => error instanceof CodexAdoptedThreadActiveError,
       }),
     );
+    resumeResponseAccepted = true;
     context.assertResumeConfiguration?.();
     if (resumeBinding.pendingResumeConfiguration) {
       await attestCodexPluginThreadApps({
@@ -245,7 +243,7 @@ export async function resumeExistingCodexThread(
         );
       } catch (error) {
         context.assertResumeOwnership?.();
-        await (params.abandonClient ?? (() => closeCodexStartupClientBestEffort(params.client)))();
+        await abandonClient();
         throw new CodexRestrictedToolSurfaceAttestationError(error);
       }
     }
@@ -360,7 +358,12 @@ export async function resumeExistingCodexThread(
     };
   } catch (error) {
     resumeReservation?.release();
-    if (isCodexAppServerStartSelectionChangedError(error)) {
+    // Pre-write ownership conflicts and unsafe helper outcomes cannot rotate
+    // the binding. Overload is an exact pre-enqueue rejection, not a stale thread.
+    if (
+      !resumeResponseAccepted &&
+      (!(error instanceof CodexAppServerRpcError) || isCodexAppServerOverloadError(error))
+    ) {
       throw error;
     }
     if (error instanceof CodexRestrictedToolSurfaceAttestationError) {
@@ -369,42 +372,30 @@ export async function resumeExistingCodexThread(
       }
       throw error;
     }
-    if (error instanceof CodexAdoptedThreadActiveError) {
-      // The passive preflight does not subscribe, so cleanup would target
-      // another runner's ownership and can turn a clear conflict into rotation.
-      throw error;
+    if (resumeResponseAccepted) {
+      const subscriptionReleased = await unsubscribeCodexThreadBestEffort(params.client, {
+        threadId: resumeBinding.threadId,
+        timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+        assertCurrent: context.assertResumeOwnership,
+      }).catch(() => false);
+      if (!subscriptionReleased) {
+        // Revoked cleanup authority cannot block retiring the exact client;
+        // detachment leaves sibling leases alive while preventing that client from being reacquired.
+        try {
+          await abandonClient();
+        } catch (abandonError) {
+          throw new CodexAppServerUnsafeSubscriptionError(
+            "Codex thread/resume client could not be retired",
+            { cause: abandonError },
+          );
+        }
+        throw new CodexAppServerUnsafeSubscriptionError(
+          "Codex thread/resume subscription cleanup failed",
+          { cause: error },
+        );
+      }
     }
-    if (isCodexAppServerUnsafeSubscriptionError(error)) {
-      // The resume client is already retired; a fresh start here would
-      // race the possibly-live subscription on the abandoned process.
-      throw error;
-    }
-    // A structured RPC rejection proves Codex never subscribed the
-    // resume, so the best-effort unsubscribe below is cosmetic for that
-    // case. Only post-acceptance failures must prove the release.
-    const resumeRejected = error instanceof CodexAppServerRpcError;
-    context.assertResumeOwnership?.();
-    const subscriptionReleased = await unsubscribeCodexThreadBestEffort(params.client, {
-      threadId: resumeBinding.threadId,
-      timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
-      assertCurrent: context.assertResumeOwnership,
-    });
-    if (
-      !subscriptionReleased &&
-      !resumeRejected &&
-      !isCodexAppServerConnectionClosedError(error) &&
-      !params.signal?.aborted
-    ) {
-      throw new CodexAppServerUnsafeSubscriptionError(
-        "Codex thread/resume subscription cleanup failed",
-        { cause: error },
-      );
-    }
-    if (
-      resumeBinding.pendingResumeConfiguration ||
-      isCodexAppServerConnectionClosedError(error) ||
-      params.signal?.aborted
-    ) {
+    if (resumeBinding.pendingResumeConfiguration || params.signal?.aborted) {
       throw error;
     }
     embeddedAgentLog.warn("codex app-server thread resume failed; starting a new thread", {

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -415,7 +415,8 @@ async function createManualResumeFixture(
   } else {
     Object.assign(client, {
       initialize: async () => undefined,
-      addTransportExitHandler: () => () => undefined,
+      // This fake closes and exits together; notify the pool's physical-client registry too.
+      addTransportExitHandler: client.addCloseHandler.bind(client),
       setThreadSessionRequestGuard: () => undefined,
       close: () => harness.close(),
     });
@@ -495,6 +496,59 @@ async function createManualResumeFixture(
 }
 
 setupRunAttemptTestHooks();
+
+async function createLeasedLifecycleWireClient(
+  agentDir: string,
+  respond: (request: RpcRequest) => unknown,
+) {
+  const wire = createClientHarness();
+  const appendWrites = wire.writes.push.bind(wire.writes);
+  vi.spyOn(wire.writes, "push").mockImplementation((...messages) => {
+    const count = appendWrites(...messages);
+    for (const message of messages) {
+      const request = JSON.parse(message) as RpcRequest;
+      void Promise.resolve()
+        .then(() => respond(request))
+        .then(
+          (result) => wire.send({ id: request.id, result }),
+          (error: unknown) =>
+            wire.send({
+              id: request.id,
+              error:
+                error instanceof CodexAppServerRpcError
+                  ? { code: error.code, message: error.message }
+                  : { code: -32603, message: String(error) },
+            }),
+        );
+    }
+    return count;
+  });
+  vi.spyOn(wire.client, "initialize").mockResolvedValue(undefined);
+  const start = vi.spyOn(CodexAppServerClient, "start").mockReturnValueOnce(wire.client);
+  try {
+    await getLeasedSharedCodexAppServerClient({
+      startOptions: { ...createThreadLifecycleAppServerOptions().start, command: process.execPath },
+      authProfileId: null,
+      agentDir,
+      config: {},
+    });
+  } finally {
+    start.mockRestore();
+  }
+  // Preserve the wire harness's live transport getters.
+  return Object.assign(wire, {
+    start: (sessionFile: string, workspaceDir: string) =>
+      startOrResumeThread({
+        client: wire.client,
+        params: { ...createParams(sessionFile, workspaceDir), agentDir },
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+        userMcpServersEnabled: false,
+        signal: new AbortController().signal,
+      }),
+  });
+}
 
 describe("Codex app-server thread lifecycle bindings", () => {
   it("persists the native rollout path across thread start and resume", async () => {
@@ -1018,7 +1072,14 @@ describe("Codex app-server thread lifecycle bindings", () => {
       const fixture = await createManualResumeFixture({ cold: true, competingLease });
       const before = await readCodexAppServerBinding(fixture.sessionFile);
       try {
-        await expect(fixture.start()).rejects.toThrow("another runner");
+        await expect(fixture.start()).rejects.toMatchObject(
+          competingLease === "resume"
+            ? {
+                name: "CodexAppServerUnsafeSubscriptionError",
+                cause: { name: "CodexAdoptedThreadActiveError" },
+              }
+            : { name: "CodexAdoptedThreadActiveError" },
+        );
         expect(await readCodexAppServerBinding(fixture.sessionFile)).toEqual(before);
         expect(fixture.request.mock.calls.some(([method]) => method === "thread/start")).toBe(
           false,
@@ -2627,12 +2688,12 @@ describe("Codex app-server thread lifecycle bindings", () => {
     const appServer = createThreadLifecycleAppServerOptions();
     const request = vi.fn(async (method: string, _requestParams?: unknown) => {
       if (method === "thread/resume") {
-        // Only a structured RPC rejection proves Codex holds no resume
-        // subscription; anything else retires the client instead.
         throw new CodexAppServerRpcError({ code: -32_000, message: "stale thread" }, method);
       }
       if (method === "thread/unsubscribe") {
-        return { status: "not_subscribed" };
+        // Pre-acceptance rejection has no membership, but the exact cleanup RPC
+        // makes that fact observable before stale-binding recovery continues.
+        return { status: "notSubscribed" };
       }
       if (method === "thread/start") {
         const response = threadStartResult("thread-new");
@@ -2666,7 +2727,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(binding.modelProvider).toBe("lmstudio");
   });
 
-  it("falls back to a fresh thread when a rejected resume also fails unsubscribe", async () => {
+  it("fails closed when a structured resume failure cannot release its subscription", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     await writeCodexAppServerBinding(sessionFile, {
@@ -2678,33 +2739,147 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
     const request = vi.fn(async (method: string) => {
       if (method === "thread/resume") {
-        throw new CodexAppServerRpcError({ code: -32_000, message: "thread not found" }, method);
+        throw new CodexAppServerRpcError({ code: -32_603, message: "resume failed" }, method);
       }
       if (method === "thread/unsubscribe") {
         throw new Error("unsubscribe rejected");
       }
       if (method === "thread/start") {
-        return threadStartResult("thread-recovered");
+        throw new Error("unsafe resume must not start a replacement thread");
       }
       throw new Error(`unexpected method: ${method}`);
     });
 
-    // The RPC rejection already proves no resume subscription exists, so a
-    // failing cosmetic unsubscribe must not block stale-binding recovery.
-    const binding = await startOrResumeThread({
-      client: { request } as never,
-      params: createParams(sessionFile, workspaceDir),
-      cwd: workspaceDir,
-      dynamicTools: [],
-      appServer: createThreadLifecycleAppServerOptions(),
-    });
+    await expect(
+      startOrResumeThread({
+        client: { request } as never,
+        params: createParams(sessionFile, workspaceDir),
+        cwd: workspaceDir,
+        dynamicTools: [],
+        appServer: createThreadLifecycleAppServerOptions(),
+      }),
+    ).rejects.toMatchObject({ name: "CodexAppServerUnsafeSubscriptionError" });
 
-    expect(binding.threadId).toBe("thread-recovered");
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/resume",
       "thread/unsubscribe",
-      "thread/start",
     ]);
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toMatchObject({
+      threadId: "thread-existing",
+    });
+  });
+
+  it("retires an ownership-lost resume client while preserving its binding and draining siblings", async () => {
+    const sessionFile = path.join(tempDir, "ownership-lost-session.jsonl");
+    const workspaceDir = path.join(tempDir, "ownership-lost-workspace");
+    const agentDir = path.join(tempDir, "agent");
+    const threadId = "thread-ownership-lost";
+    const rolloutPath = path.join(agentDir, "codex-home", "sessions", `rollout-${threadId}.jsonl`);
+    await fs.mkdir(path.dirname(rolloutPath), { recursive: true });
+    await fs.writeFile(
+      rolloutPath,
+      `${JSON.stringify({ type: "session_meta", payload: { id: threadId, dynamic_tools: [] } })}\n`,
+    );
+    const response = threadStartResult(threadId, { cwd: workspaceDir });
+    let releaseSibling: (() => void) | undefined;
+    const wire = await createLeasedLifecycleWireClient(agentDir, (request) => {
+      if (request.method === "thread/read") {
+        return { thread: { ...response.thread, path: rolloutPath, status: { type: "notLoaded" } } };
+      }
+      if (request.method === "thread/unsubscribe") {
+        return { status: "unsubscribed" };
+      }
+      if (request.method === "thread/resume") {
+        // The response is valid, but another lease revokes the adoption proof
+        // after the physical resume write and before configuration is committed.
+        releaseSibling = retainSharedCodexAppServerClientIfCurrent(wire.client);
+        return response;
+      }
+      throw new Error(`unexpected method: ${request.method}`);
+    });
+    try {
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId,
+        clientId: wire.client.getInstanceId(),
+        cwd: workspaceDir,
+        model: response.model,
+        modelProvider: "openai",
+        dynamicToolsFingerprint: "[]",
+        pendingResumeConfiguration: true,
+      });
+      const originalBinding = await readCodexAppServerBinding(sessionFile);
+      await expect(wire.start(sessionFile, workspaceDir)).rejects.toMatchObject({
+        name: "CodexAppServerUnsafeSubscriptionError",
+      });
+
+      await expect(readCodexAppServerBinding(sessionFile)).resolves.toEqual(originalBinding);
+      expect(wire.writes.map((message) => (JSON.parse(message) as RpcRequest).method)).toEqual([
+        "thread/read",
+        "thread/unsubscribe",
+        "thread/resume",
+      ]);
+      expect(releaseSibling).toBeTypeOf("function");
+      const retained = retainSharedCodexAppServerClientIfCurrent(wire.client);
+      retained?.();
+      expect(retained).toBeUndefined();
+      expect(releaseLeasedSharedCodexAppServerClient(wire.client)).toBe(true);
+      expect(wire.stdinDestroyed).toBe(false);
+      await expect(
+        wire.client.request("thread/read", { threadId, includeTurns: false }),
+      ).resolves.toMatchObject({
+        thread: { id: threadId },
+      });
+      releaseSibling?.();
+      expect(wire.stdinDestroyed).toBe(true);
+    } finally {
+      releaseSibling?.();
+      releaseLeasedSharedCodexAppServerClient(wire.client);
+      wire.client.close();
+    }
+  });
+
+  it("preserves the bound thread and shared client after an exact overload rejection", async () => {
+    const sessionFile = path.join(tempDir, "overloaded-session.jsonl");
+    const workspaceDir = path.join(tempDir, "overloaded-workspace");
+    const agentDir = path.join(tempDir, "agent");
+    const overload = new CodexAppServerRpcError(
+      { code: -32_001, message: "queue full" },
+      "thread/resume",
+    );
+    const wire = await createLeasedLifecycleWireClient(agentDir, (request) => {
+      if (request.method === "thread/resume") {
+        throw overload;
+      }
+      throw new Error(`unexpected method: ${request.method}`);
+    });
+    try {
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: "thread-overloaded",
+        clientId: wire.client.getInstanceId(),
+        cwd: workspaceDir,
+        model: "gpt-5.4-codex",
+        modelProvider: "openai",
+        dynamicToolsFingerprint: "[]",
+      });
+      const originalBinding = await readCodexAppServerBinding(sessionFile);
+      await expect(wire.start(sessionFile, workspaceDir)).rejects.toMatchObject({
+        name: "CodexAppServerRpcError",
+        code: -32_001,
+        message: overload.message,
+      });
+
+      await expect(readCodexAppServerBinding(sessionFile)).resolves.toEqual(originalBinding);
+      expect(
+        new Set(wire.writes.map((message) => (JSON.parse(message) as RpcRequest).method)),
+      ).toEqual(new Set(["thread/resume"]));
+      const retained = retainSharedCodexAppServerClientIfCurrent(wire.client);
+      expect(retained).toBeTypeOf("function");
+      retained?.();
+      expect(wire.stdinDestroyed).toBe(false);
+    } finally {
+      releaseLeasedSharedCodexAppServerClient(wire.client);
+      wire.client.close();
+    }
   });
 
   it("keeps the bound local provider when stale fingerprints force a fresh thread", async () => {

--- a/extensions/codex/src/app-server/thread-resume.test.ts
+++ b/extensions/codex/src/app-server/thread-resume.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { CodexAppServerRpcError, type CodexAppServerClient } from "./client.js";
+import { createClientHarness } from "./test-support.js";
+import { CodexAdoptedThreadActiveError } from "./thread-lifecycle-errors.js";
 import { resumeCodexAppServerThread } from "./thread-resume.js";
 import { CODEX_APP_SERVER_VERSION } from "./version.js";
 
@@ -44,8 +46,10 @@ function resumeResponse(threadId: string, restoredTurns = 0) {
   };
 }
 
-function createClient(requestImpl: (params: unknown) => unknown) {
-  const request = vi.fn(async (_method: string, params: unknown) => await requestImpl(params));
+function createClient(requestImpl: (method: string, params: unknown) => unknown) {
+  const request = vi.fn(
+    async (method: string, params: unknown) => await requestImpl(method, params),
+  );
   const client = { request } as unknown as CodexAppServerClient;
   return {
     client,
@@ -69,13 +73,132 @@ describe("resumeCodexAppServerThread", () => {
     expect(abandonClient).not.toHaveBeenCalled();
   });
 
-  it("leaves a proven RPC rejection on the reusable client", async () => {
+  it.each(["unsubscribed", "notSubscribed", "notLoaded"] as const)(
+    "releases a structured RPC failure with native status %s and keeps the client reusable",
+    async (status) => {
+      const rejection = new CodexAppServerRpcError(
+        { code: -32_603, message: "resume response assembly failed" },
+        "thread/resume",
+      );
+      const { client, request } = createClient(async (method) => {
+        if (method === "thread/resume") {
+          throw rejection;
+        }
+        return { status };
+      });
+      const abandonClient = vi.fn(async () => undefined);
+      const assertCurrent = vi.fn();
+
+      await expect(
+        resumeCodexAppServerThread({
+          client,
+          abandonClient,
+          request: { threadId: "thread-1", excludeTurns: true },
+          assertCurrent,
+        }),
+      ).rejects.toBe(rejection);
+      expect(request.mock.calls.map(([method]) => method)).toEqual([
+        "thread/resume",
+        "thread/unsubscribe",
+      ]);
+      expect(abandonClient).not.toHaveBeenCalled();
+      expect(request).toHaveBeenLastCalledWith(
+        "thread/unsubscribe",
+        { threadId: "thread-1" },
+        { timeoutMs: 5_000, assertCurrent },
+      );
+    },
+  );
+
+  it("preserves an exact overload rejection without releasing the subscription", async () => {
     const rejection = new CodexAppServerRpcError(
-      { code: -32_000, message: "thread not found" },
+      { code: -32_001, message: "resume response assembly failed" },
       "thread/resume",
     );
-    const { client } = createClient(async () => {
+    const { client, request } = createClient(async () => {
       throw rejection;
+    });
+    const abandonClient = vi.fn(async () => undefined);
+
+    await expect(
+      resumeCodexAppServerThread({ client, abandonClient, request: { threadId: "thread-1" } }),
+    ).rejects.toBe(rejection);
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+    expect(abandonClient).not.toHaveBeenCalled();
+  });
+
+  it("preserves a physical pre-write ownership rejection without cleanup or retirement", async () => {
+    const harness = createClientHarness();
+    const rejection = new CodexAdoptedThreadActiveError();
+    const abandonClient = vi.fn(async () => undefined);
+    try {
+      await expect(
+        resumeCodexAppServerThread({
+          client: harness.client,
+          abandonClient,
+          request: { threadId: "thread-1" },
+          assertCurrent: () => {
+            throw rejection;
+          },
+          isPrewriteOwnershipError: (error) => error instanceof CodexAdoptedThreadActiveError,
+        }),
+      ).rejects.toBe(rejection);
+      expect(harness.writes).toEqual([]);
+      expect(harness.client.getCloseError()).toBeUndefined();
+      expect(abandonClient).not.toHaveBeenCalled();
+    } finally {
+      harness.client.close();
+    }
+  });
+
+  it("retires the exact client after a written structured failure loses cleanup ownership", async () => {
+    const harness = createClientHarness();
+    let current = true;
+    const abandonClient = vi.fn(async () => harness.client.close());
+    try {
+      const resume = resumeCodexAppServerThread({
+        client: harness.client,
+        abandonClient,
+        request: { threadId: "thread-1" },
+        assertCurrent: () => {
+          if (!current) {
+            throw new CodexAdoptedThreadActiveError();
+          }
+        },
+        isPrewriteOwnershipError: (error) => error instanceof CodexAdoptedThreadActiveError,
+      });
+      const failure = expect(resume).rejects.toMatchObject({
+        name: "CodexAppServerUnsafeSubscriptionError",
+        cause: { code: -32_603, message: "resume response assembly failed" },
+      });
+      const writtenText = harness.writes[0];
+      expect(writtenText).toBeDefined();
+      const written = JSON.parse(writtenText ?? "");
+      expect(written).toMatchObject({ method: "thread/resume", params: { threadId: "thread-1" } });
+      current = false;
+      harness.send({
+        id: written.id,
+        error: { code: -32_603, message: "resume response assembly failed" },
+      });
+      await failure;
+      expect(harness.writes).toHaveLength(1);
+      expect(abandonClient).toHaveBeenCalledOnce();
+      expect(harness.client.getCloseError()).toBeDefined();
+    } finally {
+      harness.client.close();
+    }
+  });
+
+  it("retires the exact client when structured RPC cleanup cannot release the thread", async () => {
+    const rejection = new CodexAppServerRpcError(
+      { code: -32_603, message: "resume response assembly failed" },
+      "thread/resume",
+    );
+    const { client, request } = createClient(async (method) => {
+      if (method === "thread/resume") {
+        throw rejection;
+      }
+      throw new Error("thread unsubscribe failed");
     });
     const abandonClient = vi.fn(async () => undefined);
 
@@ -85,8 +208,15 @@ describe("resumeCodexAppServerThread", () => {
         abandonClient,
         request: { threadId: "thread-1", excludeTurns: true },
       }),
-    ).rejects.toBe(rejection);
-    expect(abandonClient).not.toHaveBeenCalled();
+    ).rejects.toMatchObject({
+      name: "CodexAppServerUnsafeSubscriptionError",
+      cause: rejection,
+    });
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/resume",
+      "thread/unsubscribe",
+    ]);
+    expect(abandonClient).toHaveBeenCalledOnce();
   });
 
   it("keeps the shared client after cancellation before the resume write", async () => {

--- a/extensions/codex/src/app-server/thread-resume.ts
+++ b/extensions/codex/src/app-server/thread-resume.ts
@@ -1,10 +1,13 @@
 /** Owns Codex thread/resume subscription safety. */
 import {
   assertCodexThreadResumeSubscription,
+  CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
   CodexAppServerUnsafeSubscriptionError,
+  unsubscribeCodexThreadBestEffort,
 } from "./attempt-client-cleanup.js";
 import {
   CodexAppServerRpcError,
+  isCodexAppServerOverloadError,
   isCodexAppServerPrewriteRequestCancellationError,
   type CodexAppServerClient,
 } from "./client.js";
@@ -12,7 +15,7 @@ import { assertCodexThreadResumeResponse } from "./protocol-validators.js";
 import type { CodexThreadResumeParams, CodexThreadResumeResponse } from "./protocol.js";
 import { isCodexAppServerStartSelectionChangedError } from "./shared-client.js";
 
-/** Resumes one thread and retires the physical client when acceptance is indeterminate. */
+/** Resumes one thread, releasing or isolating every possible native subscription. */
 export async function resumeCodexAppServerThread(params: {
   client: CodexAppServerClient;
   abandonClient: () => Promise<void>;
@@ -20,6 +23,9 @@ export async function resumeCodexAppServerThread(params: {
   timeoutMs?: number;
   signal?: AbortSignal;
   assertCurrent?: () => void;
+  /** Identifies ownership rejection by the request's physical pre-write fence only. */
+  isPrewriteOwnershipError?: (error: unknown) => boolean;
+  onSubscriptionReleased?: () => void;
 }): Promise<CodexThreadResumeResponse> {
   const threadId = params.request.threadId;
   let response: CodexThreadResumeResponse;
@@ -33,17 +39,26 @@ export async function resumeCodexAppServerThread(params: {
     );
     assertCodexThreadResumeSubscription(threadId, response.thread.id);
   } catch (error) {
-    params.assertCurrent?.();
     if (
+      params.isPrewriteOwnershipError?.(error) ||
       isCodexAppServerStartSelectionChangedError(error) ||
-      isCodexAppServerPrewriteRequestCancellationError(error)
+      isCodexAppServerPrewriteRequestCancellationError(error) ||
+      isCodexAppServerOverloadError(error)
     ) {
       throw error;
     }
     if (error instanceof CodexAppServerRpcError) {
-      // A structured RPC error proves Codex rejected the resume, so the client
-      // holds no hidden subscription and can safely stay in the shared pool.
-      throw error;
+      // Codex can subscribe before later response assembly fails. A completed
+      // RPC lets this attempt release only its exact thread without retiring siblings.
+      const subscriptionReleased = await unsubscribeCodexThreadBestEffort(params.client, {
+        threadId,
+        timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+        assertCurrent: params.assertCurrent,
+      }).catch(() => false);
+      if (subscriptionReleased) {
+        params.onSubscriptionReleased?.();
+        throw error;
+      }
     }
     try {
       await params.abandonClient();

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -134,7 +134,7 @@ import {
   isCodexAppServerLiveThreadClaimed,
   retainCodexAppServerLiveThread,
 } from "./app-server/client-runtime.js";
-import type { CodexAppServerClient } from "./app-server/client.js";
+import { CodexAppServerRpcError, type CodexAppServerClient } from "./app-server/client.js";
 import { resolveCodexAppServerRuntimeOptions } from "./app-server/config.js";
 import { codexNativeSubagentMonitorRuntime } from "./app-server/native-subagent-monitor.js";
 import type { JsonValue } from "./app-server/protocol.js";
@@ -1047,6 +1047,46 @@ describe("codex conversation binding", () => {
     expect(bindingAfterStart?.threadId).toBe("thread-new");
     expect(bindingAfterStart?.networkProxyProfileName).toBe(NETWORK_PROXY_PROFILE_NAME);
     expect(bindingAfterStart?.networkProxyConfigFingerprint).toBe(NETWORK_PROXY_CONFIG_FINGERPRINT);
+  });
+
+  it("releases a structured initial-attach resume failure before reusing the client", async () => {
+    const sessionFile = path.join(tempDir, "structured-resume-failure.jsonl");
+    const rejection = new CodexAppServerRpcError(
+      { code: -32_603, message: "resume response assembly failed" },
+      "thread/resume",
+    );
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/resume") {
+        throw rejection;
+      }
+      if (method === "thread/unsubscribe") {
+        return { status: "unsubscribed" };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+    const client = {
+      getInstanceId: () => "client-structured-resume-failure",
+      request,
+      addNotificationHandler: vi.fn(() => () => undefined),
+      addRequestHandler: vi.fn(() => () => undefined),
+      addCloseHandler: vi.fn(() => () => undefined),
+    } as unknown as CodexAppServerClient;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(client);
+
+    await expect(
+      startCodexConversationThread({
+        sessionFile,
+        threadId: "thread-structured-resume-failure",
+        workspaceDir: tempDir,
+      }),
+    ).rejects.toBe(rejection);
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/resume",
+      "thread/unsubscribe",
+    ]);
+    expect(sharedClientMocks.retireSharedCodexAppServerClientIfCurrent).not.toHaveBeenCalled();
+    await expect(readCodexAppServerBinding(sessionFile)).resolves.toBeUndefined();
   });
 
   it("drops a retained native child before applying bound-only apps and sandbox policy", async () => {
@@ -3406,6 +3446,58 @@ describe("codex conversation binding", () => {
   });
 
   it.each([
+    { label: "structured failure", code: -32_603, cleaned: true },
+    { label: "overload rejection", code: -32_001, cleaned: false },
+  ])(
+    "preserves incognito reconnect $label without redundant cleanup",
+    async ({ code, cleaned }) => {
+      const sessionFile = path.join(tempDir, "incognito-reconnect.jsonl");
+      await writeTestConversationBinding(sessionFile, { threadId: "thread-1", cwd: tempDir });
+      const binding = await readTestConversationBinding(sessionFile);
+      const rejection = new CodexAppServerRpcError(
+        {
+          code,
+          message: cleaned ? "resume response assembly failed" : "thread not found: thread-1",
+        },
+        "thread/resume",
+      );
+      let unsubscribed = false;
+      const request = vi.fn(async (method: string) => {
+        if (method === "thread/resume") {
+          throw rejection;
+        }
+        if (method === "thread/unsubscribe" && cleaned && !unsubscribed) {
+          unsubscribed = true;
+          return { status: "unsubscribed" };
+        }
+        throw new Error(`unexpected cleanup or fallback: ${method}`);
+      });
+      const closeAndWait = vi.fn(async () => true);
+      const client = { request, closeAndWait, getInstanceId: () => "reconnected-client" };
+      sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(client);
+      const { event, ctx } = boundConversationClaim(
+        sessionFile,
+        "agent:main:dashboard:incognito-reconnect",
+      );
+
+      await expect(handleCodexConversationInboundClaim(event, ctx)).resolves.toEqual({
+        handled: true,
+        reply: {
+          text: `Codex app-server turn failed: ${rejection.message}`,
+        },
+      });
+      expect(request.mock.calls.map(([method]) => method)).toEqual(
+        cleaned ? ["thread/resume", "thread/unsubscribe"] : ["thread/resume"],
+      );
+      expect(sharedClientMocks.retireSharedCodexAppServerClientIfCurrent).not.toHaveBeenCalled();
+      expect(closeAndWait).not.toHaveBeenCalled();
+      await expect(readTestConversationBinding(sessionFile)).resolves.toEqual(
+        cleaned ? undefined : binding,
+      );
+    },
+  );
+
+  it.each([
     { label: "ordinary", sessionKey: undefined },
     { label: "incognito", sessionKey: "agent:main:dashboard:incognito-resume-failure" },
   ])(
@@ -3418,7 +3510,7 @@ describe("codex conversation binding", () => {
       });
       const request = vi.fn(async (method: string) => {
         if (method === "thread/resume") {
-          throw new Error("conversation resume response timed out");
+          throw new Error("thread not found: thread-1");
         }
         if (method === "thread/unsubscribe") {
           throw new Error("detached client must not receive another cleanup request");
@@ -3442,7 +3534,7 @@ describe("codex conversation binding", () => {
 
       await expect(handleCodexConversationInboundClaim(event, ctx)).resolves.toEqual({
         handled: true,
-        reply: { text: "Codex app-server turn failed: conversation resume response timed out" },
+        reply: { text: "Codex app-server turn failed: thread not found: thread-1" },
       });
 
       expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -26,11 +26,11 @@ import {
   CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
   closeCodexStartupClientBestEffort,
   interruptCodexTurnAndWaitBestEffort,
+  isCodexAppServerUnsafeSubscriptionError,
   retireUnsafeCodexTurnClientBestEffort,
   unsubscribeCodexThreadBestEffort,
 } from "./app-server/attempt-client-cleanup.js";
 import { resolveCodexAppServerAuthProfileIdForAgent } from "./app-server/auth-bridge.js";
-import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import {
   consumeCodexAppServerLiveThread,
   isCodexAppServerClientRuntimeLive,
@@ -40,6 +40,7 @@ import {
 } from "./app-server/client-runtime.js";
 import {
   isCodexAppServerIndeterminateRequestCancellationError,
+  isCodexAppServerOverloadError,
   type CodexAppServerClient,
 } from "./app-server/client.js";
 import {
@@ -771,9 +772,10 @@ async function attachExistingThread(
                     `Codex thread ${params.threadId} has an active run; stop it before binding its conversation.`,
                   );
                 }
-                return await client.request(
-                  CODEX_CONTROL_METHODS.resumeThread,
-                  {
+                return await resumeCodexAppServerThread({
+                  client,
+                  abandonClient: async () => closeCodexStartupClientBestEffort(client),
+                  request: {
                     threadId: params.threadId,
                     cwd: resolved.workspaceDir,
                     ...(resolved.model ? { model: resolved.model } : {}),
@@ -781,18 +783,13 @@ async function attachExistingThread(
                     personality: CODEX_NATIVE_PERSONALITY_NONE,
                     ...buildThreadRequestRuntimeOptions(params, resolved),
                   },
-                  requestOptions,
-                );
+                  ...requestOptions,
+                });
               },
               onClientChange: (client) => {
                 resolved.client = client;
               },
             });
-        if (!resolved.runtime.networkProxy && response.thread.id !== params.threadId) {
-          throw new Error(
-            `Codex conversation resume returned ${response.thread.id} for ${params.threadId}.`,
-          );
-        }
         await writeThreadBindingFromResponse(params, resolved, response);
       } finally {
         releaseCodexAppServerClientLease(resolved.clientLease);
@@ -890,7 +887,8 @@ async function runBoundTurn(params: {
   const clientLease: CodexAppServerClientLease = { client };
   let activeTurnId: string | undefined;
   let activeTurnCleanup: () => void = () => undefined;
-  let retiredUnsafeClient: CodexAppServerClient | undefined;
+  // Released or retired subscriptions need no further cleanup on that physical client.
+  let isolatedSubscriptionClient: CodexAppServerClient | undefined;
   let turnRoute: CodexThreadRouteReservation | undefined;
   let liveThreadOwnership:
     | {
@@ -1005,11 +1003,12 @@ async function runBoundTurn(params: {
         run: async (requestClient, requestOptions) =>
           await resumeCodexAppServerThread({
             client: requestClient,
+            onSubscriptionReleased: () => {
+              isolatedSubscriptionClient = requestClient;
+            },
             abandonClient: async () => {
-              // A retired connection may still serve sibling leases; remember
-              // its identity so incognito cleanup never retires it a second time.
-              retiredUnsafeClient = requestClient;
               await closeCodexStartupClientBestEffort(requestClient);
+              isolatedSubscriptionClient = requestClient;
             },
             request: {
               threadId,
@@ -1113,6 +1112,9 @@ async function runBoundTurn(params: {
       },
     };
   } catch (error) {
+    if (isCodexAppServerOverloadError(error) && error.method === "thread/resume") {
+      throw error;
+    }
     if (
       (error instanceof CodexConversationTurnTimeoutError && activeTurnId) ||
       (turnRoute && isCodexAppServerIndeterminateRequestCancellationError(error))
@@ -1126,8 +1128,8 @@ async function runBoundTurn(params: {
       if (!completed) {
         // Retirement detaches the physical client while sibling leases finish;
         // never send another cleanup request or retire that detached client twice.
-        retiredUnsafeClient = client;
         await retireUnsafeCodexTurnClientBestEffort(client, "turn interrupt");
+        isolatedSubscriptionClient = client;
       }
     }
     if (params.incognito) {
@@ -1135,7 +1137,7 @@ async function runBoundTurn(params: {
         kind: "clear",
         threadId,
       });
-      if (bindingReleased && retiredUnsafeClient !== client) {
+      if (bindingReleased && isolatedSubscriptionClient !== client) {
         const unsubscribed = await unsubscribeCodexThreadBestEffort(client, {
           threadId,
           timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
@@ -1152,7 +1154,7 @@ async function runBoundTurn(params: {
     try {
       if (
         ownsNativeSubscription &&
-        retiredUnsafeClient !== client &&
+        isolatedSubscriptionClient !== client &&
         !params.incognito &&
         isCodexAppServerClientRuntimeLive(client)
       ) {
@@ -1394,6 +1396,9 @@ async function projectConversationSourceHistory(
 }
 
 function isCodexThreadNotFoundError(error: unknown): boolean {
+  if (isCodexAppServerOverloadError(error) || isCodexAppServerUnsafeSubscriptionError(error)) {
+    return false;
+  }
   const message = formatErrorMessage(error);
   return (
     /\bthread not found:/iu.test(message) ||


### PR DESCRIPTION
Related: #130701
Related: #130855

## What Problem This Solves

Fixes an issue where users resuming a paginated Codex thread could receive a structured native error after Codex had already subscribed the shared connection, leaving OpenClaw with hidden thread membership. The conversation-bound initial attach used a separate raw resume path with the same leak, and a failed cleanup could either return an unsafe client to the pool or retire a healthy client after an exact pre-enqueue overload.

## Why This Change Was Made

`resumeCodexAppServerThread` is now the canonical subscription owner for lifecycle and conversation initial-attach resumes. A completed structured error performs one bounded unsubscribe for the exact requested thread; `unsubscribed`, `notSubscribed`, and `notLoaded` all prove that physical client reusable. If cleanup cannot be proven—including ownership revocation after the resume write—the exact client is gracefully retired while active sibling leases drain, and no replacement thread starts from that attempt.

The request owner separately preserves two proven pre-acceptance outcomes: a physical pre-write ownership rejection performs no cleanup, and Codex error `-32001` is treated as the exact upstream pre-enqueue overload contract. That overload now survives the top-level startup owner without unsubscribe, stale-binding fallback, process replacement, or shared-client retirement. Conversation reconnect records the exact client whose subscription was already released or retired so incognito cleanup cannot unsubscribe twice.

Manual `/codex resume` has pre-existing retained/claimed-owner behavior and remains deliberately separate; #130855 records its live-proven ownership-aware follow-up rather than applying an unsafe blanket unsubscribe here.

## User Impact

Failed native resumes no longer leave hidden subscriptions on reusable shared clients. Healthy sibling turns keep their existing process lease when only the affected client must drain, existing bindings remain intact after unsafe or overloaded resumes, and conversation initial attachment uses the same exact-thread cleanup rules as reconnect and lifecycle paths.

## Evidence

Direct dependency inspection used exact Codex 0.150.1 source commit `90854393966b21e9ebfd21b122334eb09a20c93d`:

- running resume adds connection membership before fallible backwards-cursor assembly in `codex-rs/app-server/src/request_processors/thread_lifecycle.rs:743-768`;
- cold resume attaches before later response reconstruction and initial-page work in `codex-rs/app-server/src/request_processors/thread_processor.rs:3814-3907`;
- `-32001` is emitted before processor enqueue;
- native unsubscribe statuses are `unsubscribed`, `notSubscribed`, and `notLoaded`.

Before the repair, both the canonical helper and conversation initial attach returned `-32603`, then the first external exact unsubscribe returned `unsubscribed`, proving hidden membership at the real OpenClaw caller boundary.

Fresh isolated native-process proof against the final working tree and published Codex 0.150.1:

```json
{
  "nativeVersion": "codex-cli 0.150.1",
  "sourceCommit": "90854393966b21e9ebfd21b122334eb09a20c93d",
  "postAcceptance": {
    "helperExternalProbe": "notSubscribed",
    "initialAttachExternalProbe": "notSubscribed"
  },
  "preAcceptanceMissingThread": {
    "rpcCode": -32600,
    "externalProbe": "notLoaded",
    "clientReused": true
  },
  "ownershipRevokedAfterWrite": {
    "result": "CodexAppServerUnsafeSubscriptionError",
    "retiredClientProbe": ["unsubscribed", "notSubscribed"],
    "activeSiblingLeaseRemainedOpen": true
  },
  "targetHistoryByteIdentical": true,
  "projectionRestored": true,
  "schemaUnchanged": true,
  "allNativeProcessesExitedZero": true
}
```

Local validation:

- `node scripts/run-vitest.mjs extensions/codex/src/conversation-binding.test.ts extensions/codex/src/app-server/attempt-startup.test.ts extensions/codex/src/app-server/attempt-startup-retry.test.ts extensions/codex/src/app-server/client.test.ts extensions/codex/src/app-server/thread-resume.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts extensions/codex/src/app-server/run-attempt.native-hook-relay.test.ts --cache=false` — 7 files, 325 tests passed.
- `node scripts/check-changed.mjs -- <10 changed files>` — formatting, extension/test typechecks, lint, plugin boundaries, guards, dead exports, and runtime cycle checks passed.
- Three independent adversarial reviews challenged upstream subscription semantics, physical-client ownership races, active sibling drainage, overload handling, initial/reconnect cleanup, and test value. Each final pass reported no patch-specific blocker.
- Fresh structured autoreview reported no accepted/actionable findings.
- Post-rebase `pnpm test:extension codex` — all 16 chunks passed, 185 executed files and 4,345 tests; the previous legacy agent-registry schema contamination did not recur.
- `git diff --check` — passed.
- Rebased head `4cb202837805d941e11e61ccfc8904faab57dd72` preserves the exact pre-rebase patch bytes (SHA-256 `d14195b69c0906b2155d619a0235c9028228f2ba0a6d43c0ae6cfce63d513e9a`); no code/test fixes were needed, so the clean final autoreview remains applicable under the explicit work order.
- Final native boundary command: `OPENCLAW_CODEX_RESUME_PROOF_ROOT=/tmp/magical-banach-native-proof-01501 ./node_modules/.bin/tsx .artifacts/codex-resume/boundary-probe.ts > /tmp/magical-banach-boundary-01501-post-rebase.json`. This uses the real native process with isolated fixture history; it is not an authenticated model/channel run. The ignored proof script is not part of the PR.
- Broader replacement quarantine remains separate follow-up work; manual resume ownership is recorded in #130855 and neither is silently claimed fixed here.

Production LOC: +95/-80 (net +15) | Tests: +492/-35. The production growth records four ownership facts that were previously conflated: exact overload rejection, exact subscription release, post-write authority-loss isolation, and caller-visible cleanup provenance. Lifecycle and startup owners were simplified net-negative to absorb most of the new behavior.

Provenance: the invalid “structured RPC rejection proves no subscription” assumption was introduced in #101376 (`554d772c1a83f037de902117755b18f29684f111`, authored and merged by @steipete on 2026-07-07) and carried forward through the ownership-fence repair in #130701. This PR corrects that dependency premise without reverting the ownership fence.

AI-assisted: yes. The implementation, native proof, dependency-source inspection, and independent reviews were all manually checked before publication.
