### PR TITLE
fix(agents): direct commands skip proactive compaction

### DIFF
--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -34,7 +34,11 @@ existing recovery outcome.
 
 Auto-compaction is on by default. It runs when the session nears the context limit, or when the model returns a context-overflow error (in which case OpenClaw compacts and retries).
 
-Set `agents.defaults.compaction.enabled: false` to disable the embedded runtime's proactive threshold compaction. OpenClaw's preflight and overflow-recovery compaction paths remain available, as does manual `/compact`.
+Normal replies check session usage before the next turn. Successful direct commands using the built-in OpenClaw runtime, including `openclaw agent --local`, run the same usage-based maintenance after recording the completed turn and protecting any pending reply. The following command then uses the compacted context. This works in safeguard mode even when memory flush is disabled; native runtimes retain their own compaction ownership.
+
+If direct-command post-turn compaction fails, OpenClaw logs a warning and returns the completed reply while the run and session are still current. Cancellation, restart, or a replaced session still stops that result from being returned.
+
+Set `agents.defaults.compaction.enabled: false` to disable the embedded runtime's proactive threshold compaction and direct-command post-turn maintenance. OpenClaw's preflight and overflow-recovery compaction paths remain available, as does manual `/compact`.
 
 You will see:
 

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -211,12 +211,15 @@ When splitting a long transcript into compaction chunks, OpenClaw keeps assistan
 
 ## When auto-compaction happens
 
-Two triggers in the embedded OpenClaw agent:
+The built-in OpenClaw runtime has three scheduling paths:
 
 1. **Overflow recovery**: the model returns a context-overflow error (`request_too_large`, `context length exceeded`, `input exceeds the maximum number of tokens`, `input token count exceeds the maximum number of input tokens`, `input is too long for the model`, `ollama error: context length exceeded`, and other provider-shaped variants) - compact, then retry. When the provider reports the attempted token count, OpenClaw forwards that observed count into overflow-recovery compaction; if the provider confirms overflow but exposes no parseable count, OpenClaw passes a minimally over-budget synthetic count to compaction engines and diagnostics. If overflow recovery still fails, OpenClaw surfaces explicit guidance and preserves the current session mapping instead of silently rotating to a fresh session id - retry the message, run `/compact`, or run `/new`.
-2. **Threshold maintenance**: after a successful turn, when the current context exceeds the model window minus OpenClaw's built-in headroom for prompts and the next model output.
+2. **Usage-based maintenance**: normal replies check projected usage before their turn; successful direct commands, including `agent --local` and Gateway agent RPC runs, check after the completed turn is persisted and any pending final reply is protected. Both use the active model budget and shared maintenance headroom. Disabling memory flush does not disable this compaction. Direct-command maintenance respects `compaction.enabled: false` and skips a second compaction when the completed run already compacted.
+3. **Session-internal threshold maintenance**: default-mode sessions can also compact when actual context usage exceeds the model window minus the session reserve. Safeguard mode disables this competing session-internal path and leaves proactive scheduling to the maintenance owner above.
 
-Two additional guards run outside these two triggers:
+The persisted `contextBudgetStatus` is a pre-prompt pressure estimate, not an execution command. Its `route` and `shouldCompact` fields can report pressure while the provider attempt is still admitted. Use completed compaction counts and transcript entries to verify that compaction actually happened.
+
+Two additional guards run outside these paths:
 
 - **Preflight local compaction**: set `agents.defaults.compaction.maxActiveTranscriptBytes` to a positive byte threshold (bytes or a string like `"20mb"`) to trigger local compaction before opening the next run once the active transcript reaches that size. Normal semantic compaction still runs. For Codex app-server sessions, the same threshold caps native rollout transcripts and oversized native threads restart fresh. Unset or `0` disables the guard.
 - **Mid-turn precheck**: set `agents.defaults.compaction.midTurnPrecheck.enabled: true` (default `false`) to add a tool-loop guard. After a tool result is appended and before the next model call, OpenClaw estimates prompt pressure using the same preflight budget logic used at turn start. If context no longer fits, the guard does not compact inline - it raises a structured mid-turn precheck signal, stops the current prompt submission, and lets the outer run loop use the existing recovery path (truncate oversized tool results when that is enough, or trigger the configured compaction mode and retry). Works with both `default` and `safeguard` compaction modes, including provider-backed safeguard compaction. Independent of `maxActiveTranscriptBytes`: the byte-size guard runs before a turn opens, mid-turn precheck runs later, after new tool results are appended.
@@ -238,7 +241,7 @@ Two additional guards run outside these two triggers:
 
 OpenClaw enforces a built-in reserve for embedded runs and caps it against the active model context window so it cannot consume the whole prompt budget. This keeps small-context local models from entering compaction from the first token while leaving enough headroom for multi-turn housekeeping such as the memory flush.
 
-Set `enabled: false` to disable threshold-driven auto-compaction inside the embedded agent runtime. OpenClaw's preflight and overflow-recovery compaction paths remain available, and manual `/compact` continues to work.
+Set `enabled: false` to disable threshold-driven auto-compaction inside the embedded agent runtime and direct-command post-turn maintenance. OpenClaw's reply preflight and overflow-recovery compaction paths remain available, and manual `/compact` continues to work.
 
 Manual `/compact` uses `agents.defaults.compaction.keepRecentTokens` (default: `20000`) and keeps that recent-tail cut point.
 

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -1,340 +1,33 @@
-/** Tests agent command compaction rotation and persisted transcript/session updates. */
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+/** Tests CLI compaction rotation and persisted transcript/session updates. */
+import { describe, expect, it } from "vitest";
 import type { InternalSessionEntry, SessionEntry } from "../config/sessions.js";
-import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
-import { SessionWorkStartInvalidatedError } from "../config/sessions/lifecycle.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
-  appendTranscriptEvent,
-  appendTranscriptMessage,
+  agentCommand,
+  agentCommandFromGatewayIngress,
+  compactionTestRuntime,
+  compactionTestState as state,
+  findCompactionSessionEntry as findStoredSessionEntry,
+  makeCompactionResult as makeResult,
+  readCompactionLifecyclePhases as readLifecyclePhases,
+  registerAgentCommandCompactionTestHooks,
+  requireCompactionStorePath as requireStorePath,
+  COMPACTION_ERROR,
+  GATEWAY_INGRESS_ARGS,
+  type ProviderModelNormalizationParams,
+} from "./agent-command.compaction.test-support.js";
+
+const {
+  createSessionDiffBaselineCaptureClaim,
+  formatSqliteSessionFileMarker,
   listSessionEntriesCore,
   loadTranscriptEvents,
   replaceSessionEntry,
-} from "../config/sessions/session-accessor.js";
-import { createSessionDiffBaselineCaptureClaim } from "../config/sessions/session-diff-baseline-capture.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
-import { defaultRuntime } from "../runtime.js";
-import type { runAgentAttempt } from "./command/attempt-execution.runtime.js";
-import type { EmbeddedAgentRunResult } from "./embedded-agent.js";
-import type { loadManifestModelCatalog } from "./model-catalog.js";
-import type { ModelFallbackRunOptions } from "./model-fallback-attempt.js";
-import { createAgentRunRestartAbortError } from "./run-termination.js";
+  SessionWorkStartInvalidatedError,
+} = compactionTestRuntime;
 
-type ProviderModelNormalizationParams = { provider: string; context: { modelId: string } };
-type LoadManifestModelCatalogParams = Parameters<typeof loadManifestModelCatalog>[0];
-type RunAgentAttempt = typeof runAgentAttempt;
-type CaptureSessionDiffBaseline =
-  (typeof import("../sessions/session-diff.js"))["captureSessionDiffBaseline"];
-type CliCompactionParams = {
-  pluginGeneration?: unknown;
-  sessionId: string;
-  sessionEntry?: SessionEntry;
-  sessionKey: string;
-  sessionStore?: Record<string, SessionEntry>;
-  storePath?: string;
-};
-
-const state = vi.hoisted(() => ({
-  cfg: undefined as OpenClawConfig | undefined,
-  workspaceDir: undefined as string | undefined,
-  agentDir: undefined as string | undefined,
-  runAgentAttemptMock: vi.fn<RunAgentAttempt>(),
-  loadManifestModelCatalogMock: vi.fn((_params: LoadManifestModelCatalogParams) => []),
-  normalizeProviderModelIdWithRuntimeMock: vi.fn(
-    (_params: ProviderModelNormalizationParams) => undefined,
-  ),
-  runCliTurnCompactionLifecycleMock: vi.fn(
-    async (params: CliCompactionParams) => params.sessionEntry,
-  ),
-  runMemoryFlushIfNeededMock: vi.fn(async (params: { sessionEntry?: SessionEntry }) => ({
-    sessionEntry: params.sessionEntry,
-    outcome: "completed" as const,
-  })),
-  deliverAgentCommandResultMock: vi.fn(),
-  emitAgentEventMock: vi.fn(),
-  deliveryFreshEntries: [] as Array<SessionEntry | undefined>,
-  captureSessionDiffBaselineMock: vi.fn<CaptureSessionDiffBaseline>(),
-}));
-
-vi.mock("../sessions/session-diff.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../sessions/session-diff.js")>()),
-  captureSessionDiffBaseline: (params: Parameters<CaptureSessionDiffBaseline>[0]) =>
-    state.captureSessionDiffBaselineMock(params),
-}));
-
-vi.mock("../config/io.js", () => ({
-  getRuntimeConfig: () => state.cfg,
-  readConfigFileSnapshotForWrite: async () => ({ snapshot: { valid: false } }),
-}));
-
-vi.mock("./agent-runtime-config.js", () => ({
-  resolveAgentRuntimeConfig: async () => ({
-    loadedRaw: state.cfg,
-    sourceConfig: state.cfg,
-    cfg: state.cfg,
-  }),
-}));
-
-vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
-  isPluginMetadataSnapshotCompatible: () => false,
-  resolvePluginMetadataSnapshot: () => ({ plugins: [] }),
-}));
-
-vi.mock("./agent-scope.js", async () => {
-  const actual = await vi.importActual<typeof import("./agent-scope.js")>("./agent-scope.js");
-  return {
-    ...actual,
-    clearAutoFallbackPrimaryProbeSelection: vi.fn(),
-    entryMatchesAutoFallbackPrimaryProbe: () => false,
-    hasSessionAutoModelFallbackProvenance: () => false,
-    listAgentIds: () => ["main"],
-    markAutoFallbackPrimaryProbe: vi.fn(),
-    resolveAutoFallbackPrimaryProbe: () => undefined,
-    resolveAgentConfig: () => undefined,
-    resolveAgentDir: () => state.agentDir ?? "/tmp/openclaw-agent",
-    resolveDefaultAgentId: () => "main",
-    resolveEffectiveModelFallbacks: () => undefined,
-    resolveSessionAgentId: () => "main",
-    resolveAgentWorkspaceDir: () => state.workspaceDir ?? "/tmp/openclaw-workspace",
-  };
-});
-
-vi.mock("./model-catalog.js", () => ({
-  loadManifestModelCatalog: (params: LoadManifestModelCatalogParams) =>
-    state.loadManifestModelCatalogMock(params),
-}));
-
-vi.mock("./model-catalog.runtime.js", () => ({
-  loadProviderScopedThinkingCatalog: vi.fn(async () => []),
-  loadPreparedModelCatalogSnapshot: vi.fn(async () => ({
-    entries: [],
-    routeVariants: [],
-  })),
-}));
-
-vi.mock("./provider-model-normalization.runtime.js", () => ({
-  normalizeProviderModelIdWithRuntime: (params: {
-    provider: string;
-    context: { modelId: string };
-  }) => state.normalizeProviderModelIdWithRuntimeMock(params),
-}));
-
-vi.mock("./harness/runtime-plugin.js", () => ({
-  ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
-}));
-
-vi.mock("./runtime-plugins.js", () => ({
-  withAgentPluginRegistry: ({ run }: { run: () => unknown }) => run(),
-}));
-
-vi.mock("./workspace.js", () => ({
-  ensureAgentWorkspace: vi.fn(async () => undefined),
-}));
-
-vi.mock("./auth-profiles/store.js", async () => {
-  const actual = await vi.importActual<typeof import("./auth-profiles/store.js")>(
-    "./auth-profiles/store.js",
-  );
-  return {
-    ...actual,
-    ensureAuthProfileStore: () => ({ profiles: {} }),
-    saveAuthProfileStore: vi.fn(),
-    updateAuthProfileStoreWithLock: vi.fn(async () => ({ profiles: {} })),
-  };
-});
-
-vi.mock("../acp/control-plane/manager.js", () => ({
-  getAcpSessionManager: () => ({
-    resolveSession: () => null,
-  }),
-}));
-
-vi.mock("../skills/runtime/remote.js", () => ({
-  getRemoteSkillEligibility: () => ({ enabled: false, reason: "test" }),
-}));
-
-vi.mock("../skills/runtime/session-snapshot.js", () => ({
-  resolveReusableWorkspaceSkillSnapshot: () => ({
-    shouldRefresh: true,
-    snapshot: {
-      prompt: "",
-      skills: [],
-      resolvedSkills: [],
-      version: 0,
-    },
-  }),
-}));
-
-vi.mock("./exec-defaults.js", () => ({
-  resolveNodeExecEligibility: () => ({ canExec: false }),
-}));
-
-vi.mock("./model-fallback-runner.js", () => ({
-  runWithModelFallback: async (params: {
-    provider: string;
-    model: string;
-    run: (provider: string, model: string, options: ModelFallbackRunOptions) => Promise<unknown>;
-  }) => ({
-    result: await params.run(params.provider, params.model, {
-      modelRoutingProvenance: {
-        requestedProvider: params.provider,
-        requestedModel: params.model,
-        stage: "initial",
-      },
-    }),
-    provider: params.provider,
-    model: params.model,
-    attempts: [],
-  }),
-}));
-
-vi.mock("./command/attempt-execution.runtime.js", async () => {
-  const actual = await vi.importActual<typeof import("./command/attempt-execution.runtime.js")>(
-    "./command/attempt-execution.runtime.js",
-  );
-  return {
-    ...actual,
-    runAgentAttempt: (...args: Parameters<RunAgentAttempt>) => state.runAgentAttemptMock(...args),
-  };
-});
-
-vi.mock("./command/cli-compaction.js", () => ({
-  runCliTurnCompactionLifecycle: (params: CliCompactionParams) =>
-    state.runCliTurnCompactionLifecycleMock(params),
-}));
-
-vi.mock("../auto-reply/reply/agent-runner-memory.js", () => ({
-  runMemoryFlushIfNeeded: (params: { sessionEntry?: SessionEntry }) =>
-    state.runMemoryFlushIfNeededMock(params),
-}));
-
-vi.mock("../infra/agent-events.js", async () => {
-  const actual = await vi.importActual<typeof import("../infra/agent-events.js")>(
-    "../infra/agent-events.js",
-  );
-  return {
-    ...actual,
-    emitAgentEvent: (...args: Parameters<typeof actual.emitAgentEvent>) => {
-      state.emitAgentEventMock(...args);
-      return actual.emitAgentEvent(...args);
-    },
-  };
-});
-
-vi.mock("./command/delivery.runtime.js", () => ({
-  deliverAgentCommandResult: (params: unknown) => state.deliverAgentCommandResultMock(params),
-}));
-
-let agentCommand: typeof import("./agent-command.js").agentCommand;
-let agentCommandFromGatewayIngress: typeof import("./agent-command.js").agentCommandFromGatewayIngress;
-
-beforeAll(async () => {
-  ({ agentCommand, agentCommandFromGatewayIngress } = await import("./agent-command.js"));
-});
-
-beforeEach(async () => {
-  vi.clearAllMocks();
-  state.loadManifestModelCatalogMock.mockReturnValue([]);
-  state.normalizeProviderModelIdWithRuntimeMock.mockImplementation(() => undefined);
-  state.runCliTurnCompactionLifecycleMock.mockImplementation(
-    async (params: CliCompactionParams) => params.sessionEntry,
-  );
-  state.deliveryFreshEntries = [];
-  state.deliverAgentCommandResultMock.mockImplementation(
-    async (params: {
-      resolveFreshSessionEntryForDelivery?: () => Promise<SessionEntry | undefined>;
-    }) => {
-      state.deliveryFreshEntries.push(await params.resolveFreshSessionEntryForDelivery?.());
-      return { deliverySucceeded: true };
-    },
-  );
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rotation-e2e-"));
-  state.workspaceDir = path.join(tmpDir, "workspace");
-  state.agentDir = path.join(tmpDir, "agent");
-  await fs.mkdir(state.workspaceDir, { recursive: true });
-  await fs.mkdir(state.agentDir, { recursive: true });
-  state.cfg = {
-    session: {
-      store: path.join(tmpDir, "sessions.json"),
-    },
-    agents: {
-      defaults: {
-        models: {
-          "openai/gpt-5.5": {},
-        },
-      },
-    },
-  } as OpenClawConfig;
-});
-
-afterEach(async () => {
-  const storePath = state.cfg?.session?.store;
-  state.cfg = undefined;
-  state.workspaceDir = undefined;
-  state.agentDir = undefined;
-  if (storePath) {
-    await fs.rm(path.dirname(storePath), { recursive: true, force: true });
-  }
-});
-
-function makeResult(params: {
-  sessionId: string;
-  sessionFile?: string;
-  text: string;
-  compactionCount?: number;
-  runner?: "cli" | "embedded";
-  payloads?: EmbeddedAgentRunResult["payloads"];
-}): EmbeddedAgentRunResult {
-  return {
-    payloads: params.payloads ?? [{ text: params.text }],
-    meta: {
-      durationMs: 1,
-      stopReason: "end_turn",
-      executionTrace: {
-        runner: params.runner ?? "cli",
-        fallbackUsed: false,
-        winnerProvider: "openai",
-        winnerModel: "gpt-5.5",
-      },
-      finalAssistantVisibleText: params.text,
-      agentMeta: {
-        sessionId: params.sessionId,
-        ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
-        provider: "openai",
-        model: "gpt-5.5",
-        ...(params.compactionCount ? { compactionCount: params.compactionCount } : {}),
-      },
-    },
-  };
-}
-
-function requireStorePath(): string {
-  const storePath = state.cfg?.session?.store;
-  if (!storePath) {
-    throw new Error("missing test session store path");
-  }
-  return storePath;
-}
-
-function findStoredSessionEntry(sessionKey: string): SessionEntry | undefined {
-  return listSessionEntriesCore({ storePath: requireStorePath() }).find(
-    (candidate) => candidate.sessionKey === sessionKey,
-  )?.entry;
-}
-
-function readLifecyclePhases(): Array<string | undefined> {
-  return state.emitAgentEventMock.mock.calls
-    .map(([event]) => event as { stream?: string; data?: { phase?: string } })
-    .filter((event) => event.stream === "lifecycle")
-    .map((event) => event.data?.phase);
-}
-
-const COMPACTION_ERROR =
-  "CLI transcript compaction failed for openai/gpt-5.5: Summarization failed: Connection error.";
-const GATEWAY_INGRESS_ARGS = [defaultRuntime, undefined, {}] as const;
+// Register hooks for this file, not as a cached support-module side effect.
+registerAgentCommandCompactionTestHooks();
 
 describe("agentCommand compaction transcript rotation", () => {
   it.each([
@@ -519,91 +212,6 @@ describe("agentCommand compaction transcript rotation", () => {
         type: "message",
         message: expect.objectContaining({ role: "assistant" }),
       }),
-    );
-  });
-
-  it("keeps embedded transcript ownership and flushes once for gateway ingress", async () => {
-    const storePath = requireStorePath();
-    const sessionId = "embedded-projected-final";
-    const sessionKey = `agent:main:explicit:${sessionId}`;
-    await replaceSessionEntry(
-      { sessionKey, storePath },
-      {
-        sessionId,
-        updatedAt: Date.now(),
-        totalTokens: 180_000,
-        totalTokensFresh: true,
-        totalTokensVersion: 1,
-      },
-    );
-    state.runAgentAttemptMock.mockImplementationOnce(async (attempt) => {
-      if (!attempt.userTurnTranscriptRecorder) {
-        throw new Error("missing embedded user-turn transcript recorder");
-      }
-      await attempt.userTurnTranscriptRecorder.persistApproved();
-      await appendTranscriptMessage(
-        { agentId: "main", sessionId, sessionKey, storePath },
-        {
-          message: {
-            role: "assistant",
-            content: [{ type: "text", text: "[Thu 2026-08-13 16:39 PDT] OVERRIDE-OK" }],
-            api: "ollama",
-            provider: "ollama",
-            model: "llama3.2:latest",
-            timestamp: Date.now(),
-          },
-          cwd: state.workspaceDir,
-        },
-      );
-      await appendTranscriptEvent(
-        { agentId: "main", sessionId, sessionKey, storePath },
-        {
-          type: "custom",
-          customType: "openclaw:bootstrap-context:full",
-          data: { runId: "embedded-run" },
-        },
-      );
-      return makeResult({
-        sessionId,
-        text: "OVERRIDE-OK",
-        runner: "embedded",
-      });
-    });
-
-    await agentCommandFromGatewayIngress(
-      {
-        message: "Reply with exactly: OVERRIDE-OK",
-        sessionId,
-        sessionKey,
-        cwd: state.workspaceDir,
-        allowModelOverride: false,
-      },
-      ...GATEWAY_INGRESS_ARGS,
-    );
-
-    const events = (await loadTranscriptEvents({
-      agentId: "main",
-      sessionId,
-      storePath,
-    })) as Array<{
-      type?: unknown;
-      customType?: unknown;
-      message?: { role?: unknown; api?: unknown };
-    }>;
-    const assistantEvents = events.filter(
-      (event) => event.type === "message" && event.message?.role === "assistant",
-    );
-    expect(assistantEvents).toHaveLength(1);
-    expect(assistantEvents.filter((event) => event.message?.api === "cli")).toHaveLength(0);
-    expect(
-      events.filter(
-        (event) =>
-          event.type === "custom" && event.customType === "openclaw:bootstrap-context:full",
-      ),
-    ).toHaveLength(1);
-    expect(state.runMemoryFlushIfNeededMock).toHaveBeenCalledOnce();
-    expect(state.runMemoryFlushIfNeededMock).toHaveBeenCalledWith(
-      expect.objectContaining({ sessionEntry: expect.objectContaining({ totalTokens: 180_000 }) }),
     );
   });
 
@@ -817,52 +425,6 @@ describe("agentCommand compaction transcript rotation", () => {
   });
 
   it.each([
-    ["restart-during-compaction", "reply owned by restart recovery"],
-    ["restart-after-successful-compaction", "reply owned by restart recovery after compaction"],
-    ["stale-during-compaction", "reply owned by the next gateway lifecycle"],
-  ] as const)("does not deliver or clear the pending final for %s", async (sessionId, text) => {
-    const restart = sessionId !== "stale-during-compaction";
-    const sessionKey = `agent:main:explicit:${sessionId}`;
-    const abortController = new AbortController();
-    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text }));
-    state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(async (params) => {
-      expect(params.sessionEntry).toMatchObject({
-        pendingFinalDelivery: { kind: "replayable", text },
-      });
-      if (restart) {
-        abortController.abort(createAgentRunRestartAbortError());
-      } else {
-        rotateAgentEventLifecycleGeneration();
-      }
-      if (sessionId === "restart-after-successful-compaction") {
-        return params.sessionEntry;
-      }
-      throw new Error(COMPACTION_ERROR);
-    });
-
-    await expect(
-      agentCommand({
-        message: "room message",
-        sessionId,
-        sessionKey,
-        cwd: state.workspaceDir,
-        channel: "discord",
-        to: "discord:dm:123",
-        accountId: "main",
-        deliver: true,
-        abortSignal: abortController.signal,
-      }),
-    ).rejects.toThrow(
-      restart ? "agent run aborted for restart" : "Agent run belongs to a stale gateway lifecycle",
-    );
-
-    expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
-    expect(findStoredSessionEntry(sessionKey)).toMatchObject({
-      pendingFinalDelivery: { kind: "replayable", text },
-    });
-  });
-
-  it.each([
     ["empty payloads", "empty", []],
     ["a silent NO_REPLY payload", "silent", [{ text: "NO_REPLY" }]],
     ["a reasoning-only payload", "reasoning", [{ text: "hidden reasoning", isReasoning: true }]],
@@ -987,28 +549,6 @@ describe("agentCommand compaction transcript rotation", () => {
     const compaction = state.runCliTurnCompactionLifecycleMock.mock.calls[0]?.[0];
     expect(compaction?.sessionId).toBe(successor.sessionId);
     expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
-  });
-
-  it("keeps post-turn compaction failures fatal for no-delivery runs", async () => {
-    const sessionId = "no-delivery-compaction-failure";
-    const sessionKey = `agent:main:explicit:${sessionId}`;
-    state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text: "local final" }));
-    state.runCliTurnCompactionLifecycleMock.mockRejectedValueOnce(new Error(COMPACTION_ERROR));
-
-    await expect(
-      agentCommand({
-        message: "local model run",
-        sessionId,
-        sessionKey,
-        cwd: state.workspaceDir,
-        channel: "discord",
-        to: "discord:dm:123",
-        accountId: "main",
-        deliver: false,
-      }),
-    ).rejects.toThrow("Summarization failed: Connection error");
-
-    expect(state.runCliTurnCompactionLifecycleMock).toHaveBeenCalledOnce();
   });
 
   it("resumes the next turn from the rotated successor", async () => {

--- a/src/agents/agent-command.compaction.test-support.ts
+++ b/src/agents/agent-command.compaction.test-support.ts
@@ -1,0 +1,392 @@
+/** Shared mocks and per-file lifecycle for agent-command compaction tests. */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeAll, beforeEach, vi } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
+import { SessionWorkStartInvalidatedError } from "../config/sessions/lifecycle.js";
+import {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  listSessionEntriesCore,
+  loadTranscriptEvents,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import { createSessionDiffBaselineCaptureClaim } from "../config/sessions/session-diff-baseline-capture.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { rotateAgentEventLifecycleGeneration } from "../infra/agent-events.js";
+import { defaultRuntime } from "../runtime.js";
+import type { runAgentAttempt } from "./command/attempt-execution.runtime.js";
+import type { EmbeddedAgentRunResult } from "./embedded-agent.js";
+import type { loadManifestModelCatalog } from "./model-catalog.js";
+import type { ModelFallbackRunOptions } from "./model-fallback-attempt.js";
+import { createAgentRunRestartAbortError } from "./run-termination.js";
+
+type ProviderModelNormalizationParams = { provider: string; context: { modelId: string } };
+type LoadManifestModelCatalogParams = Parameters<typeof loadManifestModelCatalog>[0];
+type RunAgentAttempt = typeof runAgentAttempt;
+type RunSessionCompaction =
+  (typeof import("../auto-reply/reply/agent-runner-memory.js"))["runSessionCompactionIfNeeded"];
+type CaptureSessionDiffBaseline =
+  (typeof import("../sessions/session-diff.js"))["captureSessionDiffBaseline"];
+type CliCompactionParams = {
+  pluginGeneration?: unknown;
+  sessionId: string;
+  sessionEntry?: SessionEntry;
+  sessionKey: string;
+  sessionStore?: Record<string, SessionEntry>;
+  storePath?: string;
+};
+
+const compactionTestState = vi.hoisted(() => ({
+  cfg: undefined as OpenClawConfig | undefined,
+  workspaceDir: undefined as string | undefined,
+  agentDir: undefined as string | undefined,
+  runAgentAttemptMock: vi.fn<RunAgentAttempt>(),
+  loadManifestModelCatalogMock: vi.fn((_params: LoadManifestModelCatalogParams) => []),
+  normalizeProviderModelIdWithRuntimeMock: vi.fn(
+    (_params: ProviderModelNormalizationParams) => undefined,
+  ),
+  runCliTurnCompactionLifecycleMock: vi.fn(
+    async (params: CliCompactionParams) => params.sessionEntry,
+  ),
+  runMemoryFlushIfNeededMock: vi.fn(async (params: { sessionEntry?: SessionEntry }) => ({
+    sessionEntry: params.sessionEntry,
+    outcome: "completed" as const,
+  })),
+  runSessionCompactionIfNeededMock: vi.fn<RunSessionCompaction>(
+    async (params) => params.sessionEntry,
+  ),
+  deliverAgentCommandResultMock: vi.fn(),
+  emitAgentEventMock: vi.fn(),
+  deliveryFreshEntries: [] as Array<SessionEntry | undefined>,
+  captureSessionDiffBaselineMock: vi.fn<CaptureSessionDiffBaseline>(),
+}));
+
+vi.mock("../sessions/session-diff.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../sessions/session-diff.js")>()),
+  captureSessionDiffBaseline: (params: Parameters<CaptureSessionDiffBaseline>[0]) =>
+    compactionTestState.captureSessionDiffBaselineMock(params),
+}));
+
+vi.mock("../config/io.js", () => ({
+  getRuntimeConfig: () => compactionTestState.cfg,
+  readConfigFileSnapshotForWrite: async () => ({ snapshot: { valid: false } }),
+}));
+
+vi.mock("./agent-runtime-config.js", () => ({
+  resolveAgentRuntimeConfig: async () => ({
+    loadedRaw: compactionTestState.cfg,
+    sourceConfig: compactionTestState.cfg,
+    cfg: compactionTestState.cfg,
+  }),
+}));
+
+vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
+  isPluginMetadataSnapshotCompatible: () => false,
+  resolvePluginMetadataSnapshot: () => ({ plugins: [] }),
+}));
+
+vi.mock("./agent-scope.js", async () => {
+  const actual = await vi.importActual<typeof import("./agent-scope.js")>("./agent-scope.js");
+  return {
+    ...actual,
+    clearAutoFallbackPrimaryProbeSelection: vi.fn(),
+    entryMatchesAutoFallbackPrimaryProbe: () => false,
+    hasSessionAutoModelFallbackProvenance: () => false,
+    listAgentIds: () => ["main"],
+    markAutoFallbackPrimaryProbe: vi.fn(),
+    resolveAutoFallbackPrimaryProbe: () => undefined,
+    resolveAgentConfig: () => undefined,
+    resolveAgentDir: () => compactionTestState.agentDir ?? "/tmp/openclaw-agent",
+    resolveDefaultAgentId: () => "main",
+    resolveEffectiveModelFallbacks: () => undefined,
+    resolveSessionAgentId: () => "main",
+    resolveAgentWorkspaceDir: () => compactionTestState.workspaceDir ?? "/tmp/openclaw-workspace",
+  };
+});
+
+vi.mock("./model-catalog.js", () => ({
+  loadManifestModelCatalog: (params: LoadManifestModelCatalogParams) =>
+    compactionTestState.loadManifestModelCatalogMock(params),
+}));
+
+vi.mock("./model-catalog.runtime.js", () => ({
+  loadProviderScopedThinkingCatalog: vi.fn(async () => []),
+  loadPreparedModelCatalogSnapshot: vi.fn(async () => ({
+    entries: [],
+    routeVariants: [],
+  })),
+}));
+
+vi.mock("./provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: (params: {
+    provider: string;
+    context: { modelId: string };
+  }) => compactionTestState.normalizeProviderModelIdWithRuntimeMock(params),
+}));
+
+vi.mock("./harness/runtime-plugin.js", () => ({
+  ensureSelectedAgentHarnessPlugin: vi.fn(async () => undefined),
+}));
+
+vi.mock("./runtime-plugins.js", () => ({
+  withAgentPluginRegistry: ({ run }: { run: () => unknown }) => run(),
+}));
+
+vi.mock("./workspace.js", () => ({
+  ensureAgentWorkspace: vi.fn(async () => undefined),
+}));
+
+vi.mock("./auth-profiles/store.js", async () => {
+  const actual = await vi.importActual<typeof import("./auth-profiles/store.js")>(
+    "./auth-profiles/store.js",
+  );
+  return {
+    ...actual,
+    ensureAuthProfileStore: () => ({ profiles: {} }),
+    saveAuthProfileStore: vi.fn(),
+    updateAuthProfileStoreWithLock: vi.fn(async () => ({ profiles: {} })),
+  };
+});
+
+vi.mock("../acp/control-plane/manager.js", () => ({
+  getAcpSessionManager: () => ({
+    resolveSession: () => null,
+  }),
+}));
+
+vi.mock("../skills/runtime/remote.js", () => ({
+  getRemoteSkillEligibility: () => ({ enabled: false, reason: "test" }),
+}));
+
+vi.mock("../skills/runtime/session-snapshot.js", () => ({
+  resolveReusableWorkspaceSkillSnapshot: () => ({
+    shouldRefresh: true,
+    snapshot: {
+      prompt: "",
+      skills: [],
+      resolvedSkills: [],
+      version: 0,
+    },
+  }),
+}));
+
+vi.mock("./exec-defaults.js", () => ({
+  resolveNodeExecEligibility: () => ({ canExec: false }),
+}));
+
+vi.mock("./model-fallback-runner.js", () => ({
+  runWithModelFallback: async (params: {
+    provider: string;
+    model: string;
+    run: (provider: string, model: string, options: ModelFallbackRunOptions) => Promise<unknown>;
+  }) => ({
+    result: await params.run(params.provider, params.model, {
+      modelRoutingProvenance: {
+        requestedProvider: params.provider,
+        requestedModel: params.model,
+        stage: "initial",
+      },
+    }),
+    provider: params.provider,
+    model: params.model,
+    attempts: [],
+  }),
+}));
+
+vi.mock("./command/attempt-execution.runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("./command/attempt-execution.runtime.js")>(
+    "./command/attempt-execution.runtime.js",
+  );
+  return {
+    ...actual,
+    runAgentAttempt: (...args: Parameters<RunAgentAttempt>) =>
+      compactionTestState.runAgentAttemptMock(...args),
+  };
+});
+
+vi.mock("./command/cli-compaction.js", () => ({
+  runCliTurnCompactionLifecycle: (params: CliCompactionParams) =>
+    compactionTestState.runCliTurnCompactionLifecycleMock(params),
+}));
+
+vi.mock("../auto-reply/reply/agent-runner-memory.js", () => ({
+  runMemoryFlushIfNeeded: (params: { sessionEntry?: SessionEntry }) =>
+    compactionTestState.runMemoryFlushIfNeededMock(params),
+  runSessionCompactionIfNeeded: (params: Parameters<RunSessionCompaction>[0]) =>
+    compactionTestState.runSessionCompactionIfNeededMock(params),
+}));
+
+vi.mock("../infra/agent-events.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/agent-events.js")>(
+    "../infra/agent-events.js",
+  );
+  return {
+    ...actual,
+    emitAgentEvent: (...args: Parameters<typeof actual.emitAgentEvent>) => {
+      compactionTestState.emitAgentEventMock(...args);
+      return actual.emitAgentEvent(...args);
+    },
+  };
+});
+
+vi.mock("./command/delivery.runtime.js", () => ({
+  deliverAgentCommandResult: (params: unknown) =>
+    compactionTestState.deliverAgentCommandResultMock(params),
+}));
+
+let agentCommand: typeof import("./agent-command.js").agentCommand;
+let agentCommandFromGatewayIngress: typeof import("./agent-command.js").agentCommandFromGatewayIngress;
+
+// Each leaf calls this during collection; hooks must belong to that file even
+// when the shared worker has already evaluated a support module.
+export function registerAgentCommandCompactionTestHooks(): void {
+  beforeAll(async () => {
+    ({ agentCommand, agentCommandFromGatewayIngress } = await import("./agent-command.js"));
+  });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Failed tests can leave once queues unconsumed. Reset only fixture-owned
+    // mocks; Vitest restores their constructor implementations along with clearing queues.
+    for (const mock of [
+      compactionTestState.runAgentAttemptMock,
+      compactionTestState.loadManifestModelCatalogMock,
+      compactionTestState.normalizeProviderModelIdWithRuntimeMock,
+      compactionTestState.runCliTurnCompactionLifecycleMock,
+      compactionTestState.runMemoryFlushIfNeededMock,
+      compactionTestState.runSessionCompactionIfNeededMock,
+      compactionTestState.deliverAgentCommandResultMock,
+      compactionTestState.captureSessionDiffBaselineMock,
+    ]) {
+      mock.mockReset();
+    }
+    compactionTestState.deliveryFreshEntries = [];
+    compactionTestState.deliverAgentCommandResultMock.mockImplementation(
+      async (params: {
+        resolveFreshSessionEntryForDelivery?: () => Promise<SessionEntry | undefined>;
+      }) => {
+        compactionTestState.deliveryFreshEntries.push(
+          await params.resolveFreshSessionEntryForDelivery?.(),
+        );
+        return { deliverySucceeded: true };
+      },
+    );
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rotation-e2e-"));
+    compactionTestState.workspaceDir = path.join(tmpDir, "workspace");
+    compactionTestState.agentDir = path.join(tmpDir, "agent");
+    await fs.mkdir(compactionTestState.workspaceDir, { recursive: true });
+    await fs.mkdir(compactionTestState.agentDir, { recursive: true });
+    compactionTestState.cfg = {
+      session: {
+        store: path.join(tmpDir, "sessions.json"),
+      },
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.5": {},
+          },
+        },
+      },
+    } as OpenClawConfig;
+  });
+
+  afterEach(async () => {
+    const storePath = compactionTestState.cfg?.session?.store;
+    compactionTestState.cfg = undefined;
+    compactionTestState.workspaceDir = undefined;
+    compactionTestState.agentDir = undefined;
+    if (storePath) {
+      await fs.rm(path.dirname(storePath), { recursive: true, force: true });
+    }
+  });
+}
+
+function makeCompactionResult(params: {
+  sessionId: string;
+  sessionFile?: string;
+  text: string;
+  compactionCount?: number;
+  agentHarnessId?: string;
+  runner?: "cli" | "embedded";
+  payloads?: EmbeddedAgentRunResult["payloads"];
+}): EmbeddedAgentRunResult {
+  return {
+    payloads: params.payloads ?? [{ text: params.text }],
+    meta: {
+      durationMs: 1,
+      stopReason: "end_turn",
+      executionTrace: {
+        runner: params.runner ?? "cli",
+        fallbackUsed: false,
+        winnerProvider: "openai",
+        winnerModel: "gpt-5.5",
+      },
+      finalAssistantVisibleText: params.text,
+      agentMeta: {
+        sessionId: params.sessionId,
+        ...(params.sessionFile ? { sessionFile: params.sessionFile } : {}),
+        provider: "openai",
+        model: "gpt-5.5",
+        ...(params.compactionCount ? { compactionCount: params.compactionCount } : {}),
+        ...(params.agentHarnessId ? { agentHarnessId: params.agentHarnessId } : {}),
+      },
+    },
+  };
+}
+
+function requireCompactionStorePath(): string {
+  const storePath = compactionTestState.cfg?.session?.store;
+  if (!storePath) {
+    throw new Error("missing test session store path");
+  }
+  return storePath;
+}
+
+function findCompactionSessionEntry(sessionKey: string): SessionEntry | undefined {
+  return listSessionEntriesCore({ storePath: requireCompactionStorePath() }).find(
+    (candidate) => candidate.sessionKey === sessionKey,
+  )?.entry;
+}
+
+function readCompactionLifecyclePhases(): Array<string | undefined> {
+  return compactionTestState.emitAgentEventMock.mock.calls
+    .map(([event]) => event as { stream?: string; data?: { phase?: string } })
+    .filter((event) => event.stream === "lifecycle")
+    .map((event) => event.data?.phase);
+}
+
+const COMPACTION_ERROR =
+  "CLI transcript compaction failed for openai/gpt-5.5: Summarization failed: Connection error.";
+const GATEWAY_INGRESS_ARGS = [defaultRuntime, undefined, {}] as const;
+
+// Vitest rewrites imported references, but not re-export specifiers. Materialize
+// these runtime bindings after its hoisted mocks register, or exports become undefined.
+const compactionTestRuntime = {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  createAgentRunRestartAbortError,
+  createSessionDiffBaselineCaptureClaim,
+  formatSqliteSessionFileMarker,
+  listSessionEntriesCore,
+  loadTranscriptEvents,
+  replaceSessionEntry,
+  rotateAgentEventLifecycleGeneration,
+  SessionWorkStartInvalidatedError,
+};
+
+export {
+  agentCommand,
+  agentCommandFromGatewayIngress,
+  compactionTestRuntime,
+  compactionTestState,
+  findCompactionSessionEntry,
+  makeCompactionResult,
+  readCompactionLifecyclePhases,
+  requireCompactionStorePath,
+  COMPACTION_ERROR,
+  GATEWAY_INGRESS_ARGS,
+};
+export type { ProviderModelNormalizationParams };

--- a/src/agents/agent-command.embedded-maintenance.test.ts
+++ b/src/agents/agent-command.embedded-maintenance.test.ts
@@ -1,0 +1,531 @@
+/** Tests proactive embedded maintenance and final-reply lifecycle safety. */
+import { randomUUID } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
+import {
+  agentCommand,
+  agentCommandFromGatewayIngress,
+  compactionTestRuntime,
+  compactionTestState as state,
+  findCompactionSessionEntry as findStoredSessionEntry,
+  makeCompactionResult as makeResult,
+  readCompactionLifecyclePhases as readLifecyclePhases,
+  registerAgentCommandCompactionTestHooks,
+  requireCompactionStorePath as requireStorePath,
+  COMPACTION_ERROR,
+  GATEWAY_INGRESS_ARGS,
+} from "./agent-command.compaction.test-support.js";
+import type { EmbeddedAgentRunResult } from "./embedded-agent.js";
+
+const {
+  appendTranscriptEvent,
+  appendTranscriptMessage,
+  createAgentRunRestartAbortError,
+  loadTranscriptEvents,
+  replaceSessionEntry,
+  rotateAgentEventLifecycleGeneration,
+} = compactionTestRuntime;
+
+// Register hooks for this file, not as a cached support-module side effect.
+registerAgentCommandCompactionTestHooks();
+
+describe("agentCommand embedded maintenance", () => {
+  it("compacts persisted embedded turns before final delivery with memory flush disabled", async () => {
+    const storePath = requireStorePath();
+    const sessionId = "embedded-proactive-compaction";
+    const successorSessionId = "embedded-proactive-successor";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    const model = "gpt-5.6-luna";
+    const text = "answer generated before proactive compaction";
+    state.cfg = {
+      ...state.cfg,
+      agents: {
+        defaults: {
+          model: { primary: `openai/${model}` },
+          models: { [`openai/${model}`]: {} },
+          compaction: { mode: "safeguard", memoryFlush: { enabled: false } },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://example.test",
+            api: "openai-responses",
+            models: [
+              {
+                id: model,
+                name: "GPT-5.6 Luna",
+                reasoning: false,
+                input: ["text"],
+                contextWindow: 1_050_000,
+                maxTokens: 128_000,
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              },
+            ],
+          },
+        },
+      },
+    };
+    await replaceSessionEntry(
+      { sessionKey, storePath },
+      { sessionId, updatedAt: Date.now(), compactionCount: 4 },
+    );
+    const lastCallUsage = {
+      input: 3,
+      output: 26,
+      cacheRead: 904_813,
+      cacheWrite: 53,
+      total: 904_895,
+    };
+    const completed = makeResult({ sessionId, text, runner: "embedded" });
+    completed.meta.agentMeta = {
+      sessionId,
+      provider: "openai",
+      model,
+      agentHarnessId: "openclaw",
+      contextTokens: 922_000,
+      promptTokens: 904_869,
+      usage: lastCallUsage,
+      lastCallUsage,
+    };
+    state.runAgentAttemptMock.mockImplementationOnce(async (params) => {
+      await params.userTurnTranscriptRecorder?.persistApproved();
+      await appendTranscriptMessage(
+        { agentId: "main", sessionId, sessionKey, storePath },
+        {
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text }],
+            api: "openai-responses",
+            provider: "openai",
+            model,
+            stopReason: "stop",
+            timestamp: Date.now(),
+            usage: {
+              ...lastCallUsage,
+              totalTokens: lastCallUsage.total,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+          },
+          cwd: state.workspaceDir,
+        },
+      );
+      params.onSuccessfulAuthProfile?.({
+        authProfileId: "openai:completed",
+        authProfileIdSource: "user",
+      });
+      return completed;
+    });
+    state.runSessionCompactionIfNeededMock.mockImplementationOnce(async (params) => {
+      expect(findStoredSessionEntry(sessionKey)?.pendingFinalDelivery).toMatchObject({
+        kind: "replayable",
+        text,
+      });
+      expect(params).toMatchObject({
+        agentHarnessId: "openclaw",
+        promptForEstimate: "",
+        followupRun: {
+          run: {
+            sessionId,
+            provider: "openai",
+            model,
+            senderIsOwner: false,
+            authProfileId: "openai:completed",
+            authProfileIdSource: "user",
+          },
+        },
+      });
+      expect(params.authorize?.()).toBe(true);
+      if (!params.sessionEntry || !params.sessionStore) {
+        throw new Error("compaction fixture needs a persisted session");
+      }
+      const successor: SessionEntry = {
+        ...params.sessionEntry,
+        sessionId: successorSessionId,
+        compactionCount: 5,
+        totalTokens: 12_000,
+        totalTokensFresh: true,
+      };
+      await replaceSessionEntry({ sessionKey, storePath }, successor);
+      params.sessionStore[sessionKey] = successor;
+      return successor;
+    });
+
+    await agentCommandFromGatewayIngress(
+      {
+        message: "Recall the marker.",
+        sessionId,
+        sessionKey,
+        cwd: state.workspaceDir,
+        channel: "discord",
+        to: "discord:dm:123",
+        accountId: "main",
+        deliver: true,
+        allowModelOverride: false,
+      },
+      ...GATEWAY_INGRESS_ARGS,
+    );
+
+    expect(state.runSessionCompactionIfNeededMock).toHaveBeenCalledOnce();
+    expect(state.runCliTurnCompactionLifecycleMock).not.toHaveBeenCalled();
+    expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        result: expect.objectContaining({
+          meta: expect.objectContaining({
+            agentMeta: expect.objectContaining({
+              sessionId: successorSessionId,
+              compactionCount: 1,
+              compactionTokensAfter: 12_000,
+              promptTokens: 904_869,
+              usage: lastCallUsage,
+              lastCallUsage,
+            }),
+          }),
+        }),
+      }),
+    );
+    expect(state.deliveryFreshEntries.at(-1)?.sessionId).toBe(successorSessionId);
+    expect(findStoredSessionEntry(sessionKey)?.pendingFinalDelivery).toBeUndefined();
+  });
+
+  const excludedEmbeddedRuns: Array<{
+    name: string;
+    opts?: Partial<Parameters<typeof agentCommand>[0]>;
+    agentHarnessId?: string;
+    meta?: Partial<EmbeddedAgentRunResult["meta"]>;
+    compactionCount?: number;
+    observeAuth?: boolean;
+    enabled?: boolean;
+  }> = [
+    { name: "native harness ownership", agentHarnessId: "codex" },
+    { name: "an unavailable auth selection", observeAuth: false },
+    { name: "disabled proactive compaction", enabled: false },
+    { name: "already completed in-run compaction", compactionCount: 1 },
+    { name: "a yielded turn", meta: { yielded: true } },
+    { name: "an aborted turn", meta: { aborted: true } },
+    { name: "a heartbeat", opts: { bootstrapContextRunKind: "heartbeat" } },
+    { name: "a raw model run", opts: { modelRun: true } },
+    { name: "preserved user-facing state", opts: { preserveUserFacingSessionModelState: true } },
+    { name: "hidden session effects", opts: { sessionEffects: "internal" } },
+  ];
+  it.each(excludedEmbeddedRuns)("does not add command compaction for $name", async (testCase) => {
+    const sessionId = "excluded-embedded-compaction";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    state.cfg = {
+      ...state.cfg,
+      agents: {
+        ...state.cfg?.agents,
+        defaults: {
+          ...state.cfg?.agents?.defaults,
+          compaction: { enabled: testCase.enabled, memoryFlush: { enabled: false } },
+        },
+      },
+    };
+    const completed = makeResult({
+      sessionId,
+      text: "completed answer",
+      runner: "embedded",
+      agentHarnessId: testCase.agentHarnessId ?? "openclaw",
+      compactionCount: testCase.compactionCount,
+    });
+    completed.meta = { ...completed.meta, ...testCase.meta };
+    state.runAgentAttemptMock.mockImplementationOnce(async (params) => {
+      if (testCase.observeAuth !== false) {
+        params.onSuccessfulAuthProfile?.({});
+      }
+      return completed;
+    });
+
+    await agentCommand({ message: "continue", sessionId, sessionKey, ...testCase.opts });
+
+    expect(state.runSessionCompactionIfNeededMock).not.toHaveBeenCalled();
+    expect(state.runCliTurnCompactionLifecycleMock).not.toHaveBeenCalled();
+    if (testCase.observeAuth === false) {
+      expect(state.deliverAgentCommandResultMock).toHaveBeenCalledOnce();
+    }
+  });
+
+  it("keeps an observed ambient auth selection and a memory-flush successor for compaction", async () => {
+    const sessionId = "ambient-auth-compaction";
+    const successorSessionId = "memory-flush-successor";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    state.runAgentAttemptMock.mockImplementationOnce(async (params) => {
+      params.onSuccessfulAuthProfile?.({});
+      return makeResult({
+        sessionId,
+        text: "answer",
+        runner: "embedded",
+        agentHarnessId: "openclaw",
+      });
+    });
+    state.runMemoryFlushIfNeededMock.mockImplementationOnce(async (params) => {
+      const successor = {
+        ...params.sessionEntry,
+        sessionId: successorSessionId,
+        updatedAt: Date.now(),
+      };
+      await replaceSessionEntry({ sessionKey, storePath: requireStorePath() }, successor);
+      return { sessionEntry: successor, outcome: "completed" };
+    });
+
+    await agentCommand({ message: "continue", sessionId, sessionKey });
+
+    expect(state.runSessionCompactionIfNeededMock).toHaveBeenCalledOnce();
+    const compaction = state.runSessionCompactionIfNeededMock.mock.calls[0]?.[0];
+    expect(compaction).toMatchObject({
+      sessionEntry: { sessionId: successorSessionId },
+      followupRun: { run: { sessionId: successorSessionId } },
+    });
+    expect(compaction?.followupRun.run.authProfileId).toBeUndefined();
+    expect(compaction?.followupRun.run.authProfileIdSource).toBeUndefined();
+  });
+
+  it("keeps embedded transcript ownership and flushes once for gateway ingress", async () => {
+    const storePath = requireStorePath();
+    const sessionId = "embedded-projected-final";
+    const sessionKey = `agent:main:explicit:${sessionId}`;
+    await replaceSessionEntry(
+      { sessionKey, storePath },
+      {
+        sessionId,
+        updatedAt: Date.now(),
+        totalTokens: 180_000,
+        totalTokensFresh: true,
+        totalTokensVersion: 1,
+      },
+    );
+    state.runAgentAttemptMock.mockImplementationOnce(async (attempt) => {
+      if (!attempt.userTurnTranscriptRecorder) {
+        throw new Error("missing embedded user-turn transcript recorder");
+      }
+      await attempt.userTurnTranscriptRecorder.persistApproved();
+      await appendTranscriptMessage(
+        { agentId: "main", sessionId, sessionKey, storePath },
+        {
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "[Thu 2026-08-13 16:39 PDT] OVERRIDE-OK" }],
+            api: "ollama",
+            provider: "ollama",
+            model: "llama3.2:latest",
+            timestamp: Date.now(),
+          },
+          cwd: state.workspaceDir,
+        },
+      );
+      await appendTranscriptEvent(
+        { agentId: "main", sessionId, sessionKey, storePath },
+        {
+          type: "custom",
+          customType: "openclaw:bootstrap-context:full",
+          data: { runId: "embedded-run" },
+        },
+      );
+      return makeResult({
+        sessionId,
+        text: "OVERRIDE-OK",
+        runner: "embedded",
+      });
+    });
+
+    await agentCommandFromGatewayIngress(
+      {
+        message: "Reply with exactly: OVERRIDE-OK",
+        sessionId,
+        sessionKey,
+        cwd: state.workspaceDir,
+        allowModelOverride: false,
+      },
+      ...GATEWAY_INGRESS_ARGS,
+    );
+
+    const events = (await loadTranscriptEvents({
+      agentId: "main",
+      sessionId,
+      storePath,
+    })) as Array<{
+      type?: unknown;
+      customType?: unknown;
+      message?: { role?: unknown; api?: unknown };
+    }>;
+    const assistantEvents = events.filter(
+      (event) => event.type === "message" && event.message?.role === "assistant",
+    );
+    expect(assistantEvents).toHaveLength(1);
+    expect(assistantEvents.filter((event) => event.message?.api === "cli")).toHaveLength(0);
+    expect(
+      events.filter(
+        (event) =>
+          event.type === "custom" && event.customType === "openclaw:bootstrap-context:full",
+      ),
+    ).toHaveLength(1);
+    expect(state.runMemoryFlushIfNeededMock).toHaveBeenCalledOnce();
+    expect(state.runMemoryFlushIfNeededMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionEntry: expect.objectContaining({ totalTokens: 180_000 }) }),
+    );
+  });
+
+  it.each(
+    (
+      [
+        ["restart-during-compaction", "reply owned by restart recovery"],
+        ["restart-after-successful-compaction", "reply owned by restart recovery after compaction"],
+        ["stale-during-compaction", "reply owned by the next gateway lifecycle"],
+      ] as const
+    ).flatMap(([phase, text]) =>
+      (["cli", "embedded"] as const).map((runner) => ({ phase, text, runner })),
+    ),
+  )(
+    "does not deliver or clear the pending final for $runner $phase",
+    async ({ phase, text, runner }) => {
+      const sessionId = `${runner}-${phase}`;
+      const restart = phase !== "stale-during-compaction";
+      const sessionKey = `agent:main:explicit:${sessionId}`;
+      const abortController = new AbortController();
+      state.runAgentAttemptMock.mockImplementationOnce(async (params) => {
+        if (runner === "embedded") {
+          params.onSuccessfulAuthProfile?.({});
+        }
+        return makeResult({ sessionId, text, runner, agentHarnessId: "openclaw" });
+      });
+      const compact = async (params: { sessionEntry?: SessionEntry }) => {
+        expect(params.sessionEntry).toMatchObject({
+          pendingFinalDelivery: { kind: "replayable", text },
+        });
+        if (restart) {
+          abortController.abort(createAgentRunRestartAbortError());
+        } else {
+          rotateAgentEventLifecycleGeneration();
+        }
+        if (phase === "restart-after-successful-compaction") {
+          return params.sessionEntry;
+        }
+        throw new Error(COMPACTION_ERROR);
+      };
+      if (runner === "embedded") {
+        state.runSessionCompactionIfNeededMock.mockImplementationOnce(compact);
+      } else {
+        state.runCliTurnCompactionLifecycleMock.mockImplementationOnce(compact);
+      }
+
+      await expect(
+        agentCommand({
+          message: "room message",
+          sessionId,
+          sessionKey,
+          cwd: state.workspaceDir,
+          channel: "discord",
+          to: "discord:dm:123",
+          accountId: "main",
+          deliver: true,
+          abortSignal: abortController.signal,
+        }),
+      ).rejects.toThrow(
+        restart
+          ? "agent run aborted for restart"
+          : "Agent run belongs to a stale gateway lifecycle",
+      );
+
+      expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+      expect(findStoredSessionEntry(sessionKey)).toMatchObject({
+        pendingFinalDelivery: { kind: "replayable", text },
+      });
+    },
+  );
+
+  it.each(["cli", "embedded"] as const)(
+    "preserves the %s maintenance failure policy for local replies",
+    async (runner) => {
+      const sessionId = `${runner}-no-delivery-compaction-failure`;
+      const sessionKey = `agent:main:explicit:${sessionId}`;
+      state.runAgentAttemptMock.mockImplementationOnce(async (params) => {
+        params.onSuccessfulAuthProfile?.({});
+        return makeResult({ sessionId, text: "local final", runner, agentHarnessId: "openclaw" });
+      });
+      const compact =
+        runner === "embedded"
+          ? state.runSessionCompactionIfNeededMock
+          : state.runCliTurnCompactionLifecycleMock;
+      compact.mockRejectedValueOnce(new Error(COMPACTION_ERROR));
+
+      const command = agentCommand({
+        message: "local model run",
+        sessionId,
+        sessionKey,
+        cwd: state.workspaceDir,
+        json: true,
+        deliver: false,
+      });
+      if (runner === "cli") {
+        await expect(command).rejects.toThrow("Summarization failed: Connection error");
+        expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+      } else {
+        await command;
+        expect(state.deliverAgentCommandResultMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            opts: expect.objectContaining({ json: true, deliver: false }),
+            payloads: [{ text: "local final" }],
+          }),
+        );
+        expect(readLifecyclePhases()).toContain("end");
+        expect(readLifecyclePhases()).not.toContain("error");
+      }
+      expect(compact).toHaveBeenCalledOnce();
+      expect(findStoredSessionEntry(sessionKey)?.pendingFinalDelivery).toBeUndefined();
+    },
+  );
+
+  it.each(["abort", "rebound", "revision change"] as const)(
+    "does not print a completed embedded reply after %s during maintenance",
+    async (fault) => {
+      const sessionId = "invalidated-local-maintenance";
+      const sessionKey = `agent:main:explicit:${sessionId}`;
+      const controller = new AbortController();
+      const cancelled = new Error("maintenance cancelled");
+      const failure = new Error(COMPACTION_ERROR);
+      state.runAgentAttemptMock.mockImplementationOnce(async (params) => {
+        params.onSuccessfulAuthProfile?.({});
+        return makeResult({
+          sessionId,
+          text: "local final",
+          runner: "embedded",
+          agentHarnessId: "openclaw",
+        });
+      });
+      state.runSessionCompactionIfNeededMock.mockImplementationOnce(async ({ sessionEntry }) => {
+        if (!sessionEntry) {
+          throw new Error("maintenance fixture requires a persisted session");
+        }
+        if (fault === "abort") {
+          controller.abort(cancelled);
+        } else {
+          await replaceSessionEntry(
+            { sessionKey, storePath: requireStorePath() },
+            {
+              ...sessionEntry,
+              sessionId: fault === "rebound" ? "replacement-session" : sessionId,
+              lifecycleRevision: randomUUID(),
+            },
+          );
+        }
+        throw failure;
+      });
+
+      await expect(
+        agentCommand({
+          message: "local model run",
+          sessionId,
+          sessionKey,
+          cwd: state.workspaceDir,
+          json: true,
+          deliver: false,
+          abortSignal: controller.signal,
+        }),
+      ).rejects.toBe(fault === "abort" ? cancelled : failure);
+
+      expect(state.runSessionCompactionIfNeededMock).toHaveBeenCalledOnce();
+      expect(state.deliverAgentCommandResultMock).not.toHaveBeenCalled();
+      expect(readLifecyclePhases()).not.toContain("end");
+    },
+  );
+});

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -33,6 +33,7 @@ import { clearRuntimeAuthProfileStoreSnapshots } from "../auth-profiles/runtime-
 import { saveAuthProfileStore } from "../auth-profiles/store.js";
 import { testing as cliBackendsTesting } from "../cli-backends.test-support.js";
 import { createCronCreatorAuthorityCapability } from "../cron-creator-authority-context.js";
+import type { RunEmbeddedAgentInternalParams } from "../embedded-agent-runner/run/internal-params.js";
 import type { EmbeddedAgentRunResult } from "../embedded-agent.js";
 import { FailoverError } from "../failover-error.js";
 import type { ModelFallbackAttemptProvenance } from "../model-fallback.types.js";
@@ -3664,6 +3665,40 @@ describe("CLI attempt execution", () => {
     });
     expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { reportedId: "openai:configured", source: "user" },
+    { reportedId: "openai:rotated", source: "auto" },
+    { reportedId: undefined, source: undefined },
+  ] as const)(
+    "reports successful maintenance auth $reportedId without artifact capture",
+    async ({ reportedId, source }) => {
+      const onSuccessfulAuthProfile = vi.fn();
+      runEmbeddedAgentMock.mockImplementationOnce(
+        async (params: RunEmbeddedAgentInternalParams) => {
+          expect(params.onSuccessfulAuthBinding).toBeUndefined();
+          params.onSuccessfulAuthProfile?.(reportedId);
+          return { meta: { durationMs: 1 } } satisfies EmbeddedAgentRunResult;
+        },
+      );
+
+      await runStoredAttempt({
+        sessionEntry: makeSessionEntry("maintenance-auth", {
+          authProfileOverride: "openai:stale",
+          authProfileOverrideSource: "auto",
+        }),
+        sessionKey: "agent:main:direct:maintenance-auth",
+        modelOverride: "gpt-5.6-luna",
+        configuredAuthProfileId: "openai:configured",
+        onSuccessfulAuthProfile,
+      });
+
+      expect(onSuccessfulAuthProfile).toHaveBeenCalledExactlyOnceWith({
+        authProfileId: reportedId,
+        authProfileIdSource: source,
+      });
+    },
+  );
 
   it("replaces a stale automatic session profile with the configured model profile", async () => {
     const embeddedArg = await runOpenClawEmbeddedAttemptForTest({

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -549,6 +549,10 @@ export function runAgentAttempt(params: {
   onUserMessagePersisted?: (message: Extract<AgentMessage, { role: "user" }>) => void;
   onContextEngineTurnCandidate?: (facts: ContextEngineTurnAttemptFacts) => void;
   onLifecycleGenerationChanged?: (lifecycleGeneration: string) => void;
+  onSuccessfulAuthProfile?: (selection: {
+    authProfileId?: string;
+    authProfileIdSource?: "auto" | "user";
+  }) => void;
 }) {
   const sessionAuthProfileId = params.sessionEntry?.authProfileOverride?.trim();
   const sessionAuthProfileSource = resolveSessionAuthProfileOverrideSource(params.sessionEntry);
@@ -1261,6 +1265,17 @@ export function runAgentAttempt(params: {
     contextEngineLogicalTurnLease: params.contextEngineLogicalTurnLease,
     onContextEngineTurnCandidate: params.onContextEngineTurnCandidate,
     onUserMessagePersisted: params.onUserMessagePersisted,
+    onSuccessfulAuthProfile: params.onSuccessfulAuthProfile
+      ? (successfulProfileId) =>
+          params.onSuccessfulAuthProfile?.({
+            authProfileId: successfulProfileId,
+            authProfileIdSource: successfulProfileId
+              ? successfulProfileId === authProfileId
+                ? harnessAuthSelection.authProfileIdSource
+                : "auto"
+              : undefined,
+          })
+      : undefined,
     onExecutionStarted: (info) => {
       params.opts.onExecutionStarted?.();
       if (info?.lifecycleGeneration) {

--- a/src/agents/command/post-run.ts
+++ b/src/agents/command/post-run.ts
@@ -2,9 +2,10 @@ import { getReplyPayloadMetadata } from "../../auto-reply/reply-payload.js";
 import type { FollowupRun } from "../../auto-reply/reply/queue.js";
 import type { CliDeps } from "../../cli/deps.types.js";
 import { resolveSessionAuthProfileOverrideSource } from "../../config/sessions/auth-profile-override-provenance.js";
+import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import { buildRestartRecoveryClaimCleanupPatch } from "../../config/sessions/restart-recovery-state.js";
 import type { RestartRecoveryTerminalDeliveryEvidenceResult } from "../../config/sessions/restart-recovery-types.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+import { resolveFreshSessionTotalTokens, type SessionEntry } from "../../config/sessions/types.js";
 import { assertAgentRunLifecycleGenerationCurrent } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -17,6 +18,7 @@ import {
   shouldPersistCurrentRunSessionCleanup,
 } from "../agent-command-restart-recovery.js";
 import { normalizeAgentRunTerminalDeliverySnapshot } from "../agent-run-terminal-delivery.js";
+import { OPENCLAW_AGENT_RUNTIME_ID } from "../agent-runtime-id.js";
 import { isHeartbeatLifecycleRunKind } from "../bootstrap-mode.js";
 import { persistPendingFinalDeliveryMarker } from "../pending-final-delivery-marker.js";
 import type { AgentRunSessionTarget } from "../run-session-target.js";
@@ -98,6 +100,7 @@ export async function finalizeEmbeddedAgentCommand(params: {
   } = params.attempt;
   const { resolvedVerboseLevel, skillsSnapshot, runContext } = params.embeddedSessionState;
   const effectiveCwd = cwd ?? workspaceDir;
+  const isHeartbeatLifecycleRun = isHeartbeatLifecycleRunKind(params.opts.bootstrapContextRunKind);
   let sessionEntry = params.sessionEntry;
   let result = params.attempt.result;
   let { runOwnedSessionId, sessionReboundDuringRun } = params.sessionOwnership;
@@ -145,9 +148,6 @@ export async function finalizeEmbeddedAgentCommand(params: {
       });
     }
     if (sessionStore && sessionKey && !params.suppressVisibleSessionEffects) {
-      const isHeartbeatLifecycleRun = isHeartbeatLifecycleRunKind(
-        params.opts.bootstrapContextRunKind,
-      );
       const { updateSessionStoreAfterAgentRun } = await loadSessionStoreRuntime();
       await updateSessionStoreAfterAgentRun({
         cfg,
@@ -244,6 +244,7 @@ export async function finalizeEmbeddedAgentCommand(params: {
     // Embedded runs own transcript persistence; CLI runs must prove their explicit append succeeded.
     const turnTranscriptPersisted =
       transcriptPersistenceRunner === "embedded" || persistedCliTurnTranscript;
+    let followupRun: FollowupRun | undefined;
     if (
       turnTranscriptPersisted &&
       sessionEntry &&
@@ -253,7 +254,11 @@ export async function finalizeEmbeddedAgentCommand(params: {
     ) {
       const flushProvider = result.meta.agentMeta?.provider ?? fallbackProvider;
       const flushModel = result.meta.agentMeta?.model ?? fallbackModel;
-      const followupRun: FollowupRun = {
+      const maintenanceAuthProfile = params.attempt.maintenanceAuthProfile ?? {
+        authProfileId: sessionEntry.authProfileOverride?.trim() || undefined,
+        authProfileIdSource: resolveSessionAuthProfileOverrideSource(sessionEntry),
+      };
+      followupRun = {
         prompt: "",
         enqueuedAt: Date.now(),
         run: {
@@ -268,8 +273,7 @@ export async function finalizeEmbeddedAgentCommand(params: {
           config: cfg,
           provider: flushProvider,
           model: flushModel,
-          authProfileId: sessionEntry.authProfileOverride?.trim() || undefined,
-          authProfileIdSource: resolveSessionAuthProfileOverrideSource(sessionEntry),
+          ...maintenanceAuthProfile,
           blockReplyBreak: "message_end",
           skillsSnapshot,
           thinkLevel: effectiveTurnThinkLevel,
@@ -296,11 +300,12 @@ export async function finalizeEmbeddedAgentCommand(params: {
         sessionKey,
         runtimePolicySessionKey: sessionKey,
         storePath,
-        isHeartbeat: isHeartbeatLifecycleRunKind(params.opts.bootstrapContextRunKind),
+        isHeartbeat: isHeartbeatLifecycleRun,
         abortSignal: params.opts.abortSignal,
         onSessionIdChanged: params.opts.onSessionIdChanged,
       });
       sessionEntry = memoryFlushResult.sessionEntry ?? sessionEntry;
+      followupRun.run.sessionId = sessionEntry.sessionId;
       if (sessionEntry.sessionId !== runOwnedSessionId) {
         runOwnedSessionId = sessionEntry.sessionId;
         publishSessionOwnership();
@@ -324,62 +329,6 @@ export async function finalizeEmbeddedAgentCommand(params: {
     });
     sessionEntry = pendingFinalDeliveryMarker.sessionEntry;
 
-    const canSafelyRunPostTurnCompaction =
-      params.opts.deliver !== true ||
-      !pendingFinalDeliveryMarker.hasSendableFinalPayload ||
-      pendingFinalDeliveryMarker.pendingFinalDeliveryMarkerPersisted;
-    if (
-      persistedCliTurnTranscript &&
-      !params.suppressVisibleSessionEffects &&
-      canSafelyRunPostTurnCompaction
-    ) {
-      try {
-        const compactedSessionEntry = await (
-          await loadCliCompactionRuntime()
-        ).runCliTurnCompactionLifecycle({
-          cfg,
-          sessionId: sessionEntry?.sessionId ?? effectiveSessionId,
-          sessionKey: sessionKey ?? effectiveSessionId,
-          sessionEntry,
-          sessionStore,
-          storePath,
-          sessionAgentId,
-          workspaceDir,
-          cwd: effectiveCwd,
-          agentDir,
-          provider: result.meta.agentMeta?.provider ?? provider,
-          model: result.meta.agentMeta?.model ?? model,
-          skillsSnapshot,
-          messageChannel,
-          agentAccountId: runContext.accountId,
-          senderIsOwner: params.opts.senderIsOwner,
-          thinkLevel: effectiveTurnThinkLevel,
-          extraSystemPrompt: params.opts.extraSystemPrompt,
-          pluginGeneration: params.prepared.commandRuntimeContext?.pluginGeneration,
-        });
-        throwAgentRunRestartAbortReason(params.opts.abortSignal?.reason);
-        assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
-        sessionEntry = compactedSessionEntry;
-        runOwnedSessionId = compactedSessionEntry?.sessionId ?? runOwnedSessionId;
-        publishSessionOwnership();
-      } catch (error) {
-        throwAgentRunRestartAbortReason(params.opts.abortSignal?.reason);
-        throwAgentRunRestartAbortReason(error);
-        assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
-        if (
-          params.opts.deliver !== true ||
-          !pendingFinalDeliveryMarker.pendingFinalDeliveryMarkerPersisted ||
-          !pendingFinalDeliveryMarker.hasSendableFinalPayload
-        ) {
-          throw error;
-        }
-        log.warn(
-          `Post-turn transcript compaction failed for ${sessionKey ?? sessionId}; continuing final delivery: ${formatErrorMessage(error)}`,
-        );
-      }
-    }
-
-    const { deliverAgentCommandResult } = await loadDeliveryRuntime();
     const resolveFreshSessionEntryForDelivery =
       sessionStore && sessionKey && !params.suppressVisibleSessionEffects
         ? async (): Promise<SessionEntry | undefined> => {
@@ -397,6 +346,154 @@ export async function finalizeEmbeddedAgentCommand(params: {
             return freshEntry;
           }
         : undefined;
+    const canSafelyRunPostTurnCompaction =
+      params.opts.deliver !== true ||
+      !pendingFinalDeliveryMarker.hasSendableFinalPayload ||
+      pendingFinalDeliveryMarker.pendingFinalDeliveryMarkerPersisted;
+    const agentMeta = result.meta.agentMeta;
+    // In-run compaction already owns this turn's reduction; its lastCallUsage can
+    // still describe the old prompt and must not trigger another housekeeping pass.
+    let embeddedCompactionRun =
+      followupRun &&
+      transcriptPersistenceRunner === "embedded" &&
+      agentMeta?.agentHarnessId === OPENCLAW_AGENT_RUNTIME_ID &&
+      sessionEntry?.sessionId === runOwnedSessionId &&
+      !fallbackExhausted &&
+      terminal.outcome.status === "ok" &&
+      !resultErrorPayload &&
+      !result.meta.yielded &&
+      !result.meta.aborted &&
+      (agentMeta.compactionCount ?? 0) === 0 &&
+      !isHeartbeatLifecycleRun &&
+      cfg.agents?.defaults?.compaction?.enabled !== false &&
+      !params.preserveUserFacingSessionModelState &&
+      !sessionReboundDuringRun &&
+      params.opts.modelRun !== true &&
+      params.opts.promptMode !== "none"
+        ? followupRun
+        : undefined;
+    if (embeddedCompactionRun && params.attempt.maintenanceAuthProfile === undefined) {
+      log.warn(
+        "Post-turn compaction skipped: completed embedded run did not report its auth selection.",
+      );
+      embeddedCompactionRun = undefined;
+    }
+    if (
+      (persistedCliTurnTranscript || embeddedCompactionRun) &&
+      !params.suppressVisibleSessionEffects &&
+      canSafelyRunPostTurnCompaction
+    ) {
+      const lifecycleRevisionBefore = sessionEntry?.lifecycleRevision;
+      try {
+        const compactionCountBefore = sessionEntry?.compactionCount ?? 0;
+        const authorize = () => {
+          throwAgentRunRestartAbortReason(params.opts.abortSignal?.reason);
+          assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+          return params.opts.abortSignal?.aborted !== true && !sessionReboundDuringRun;
+        };
+        const compactedSessionEntry = embeddedCompactionRun
+          ? await (
+              await loadAgentRunnerMemoryRuntime()
+            ).runSessionCompactionIfNeeded({
+              cfg,
+              followupRun: embeddedCompactionRun,
+              promptForEstimate: "",
+              sessionEntry,
+              sessionStore,
+              sessionKey,
+              runtimePolicySessionKey: sessionKey,
+              storePath,
+              defaultModel: embeddedCompactionRun.run.model,
+              isHeartbeat: false,
+              agentHarnessId: agentMeta?.agentHarnessId,
+              abortSignal: params.opts.abortSignal,
+              onSessionIdChanged: params.opts.onSessionIdChanged,
+              authorize,
+            })
+          : await (
+              await loadCliCompactionRuntime()
+            ).runCliTurnCompactionLifecycle({
+              cfg,
+              sessionId: sessionEntry?.sessionId ?? effectiveSessionId,
+              sessionKey: sessionKey ?? effectiveSessionId,
+              sessionEntry,
+              sessionStore,
+              storePath,
+              sessionAgentId,
+              workspaceDir,
+              cwd: effectiveCwd,
+              agentDir,
+              provider: agentMeta?.provider ?? provider,
+              model: agentMeta?.model ?? model,
+              skillsSnapshot,
+              messageChannel,
+              agentAccountId: runContext.accountId,
+              senderIsOwner: params.opts.senderIsOwner,
+              thinkLevel: effectiveTurnThinkLevel,
+              extraSystemPrompt: params.opts.extraSystemPrompt,
+              pluginGeneration: params.prepared.commandRuntimeContext?.pluginGeneration,
+            });
+        throwAgentRunRestartAbortReason(params.opts.abortSignal?.reason);
+        assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+        sessionEntry = compactedSessionEntry;
+        runOwnedSessionId = compactedSessionEntry?.sessionId ?? runOwnedSessionId;
+        publishSessionOwnership();
+        const completedCompactions =
+          (compactedSessionEntry?.compactionCount ?? 0) - compactionCountBefore;
+        if (
+          embeddedCompactionRun &&
+          compactedSessionEntry &&
+          agentMeta &&
+          completedCompactions > 0
+        ) {
+          // These facts describe maintenance after the reply; preserve its original provider usage.
+          result = {
+            ...result,
+            meta: {
+              ...result.meta,
+              agentMeta: {
+                ...agentMeta,
+                sessionId: runOwnedSessionId,
+                sessionFile: formatSqliteSessionFileMarker({
+                  agentId: sessionAgentId,
+                  sessionId: runOwnedSessionId,
+                  storePath,
+                }),
+                compactionCount: (agentMeta.compactionCount ?? 0) + completedCompactions,
+                compactionTokensAfter: resolveFreshSessionTotalTokens(compactedSessionEntry),
+                contextBudgetStatus: undefined,
+              },
+            },
+          };
+        }
+      } catch (error) {
+        throwAgentRunRestartAbortReason(params.opts.abortSignal?.reason);
+        throwAgentRunRestartAbortReason(error);
+        assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+        if (embeddedCompactionRun) {
+          // Housekeeping must not erase a completed local reply, but stale ownership
+          // is not an ordinary compactor failure and must still stop final delivery.
+          params.opts.abortSignal?.throwIfAborted();
+          const currentEntry = await resolveFreshSessionEntryForDelivery?.();
+          params.opts.abortSignal?.throwIfAborted();
+          assertAgentRunLifecycleGenerationCurrent(lifecycleGeneration);
+          if (!currentEntry || currentEntry.lifecycleRevision !== lifecycleRevisionBefore) {
+            throw error;
+          }
+        } else if (
+          params.opts.deliver !== true ||
+          !pendingFinalDeliveryMarker.pendingFinalDeliveryMarkerPersisted ||
+          !pendingFinalDeliveryMarker.hasSendableFinalPayload
+        ) {
+          throw error;
+        }
+        log.warn(
+          `Post-turn transcript compaction failed for ${sessionKey ?? sessionId}; continuing final delivery: ${formatErrorMessage(error)}`,
+        );
+      }
+    }
+
+    const { deliverAgentCommandResult } = await loadDeliveryRuntime();
     const deliveryParams = {
       cfg,
       deps: params.deps,

--- a/src/agents/command/run-embedded-attempt.ts
+++ b/src/agents/command/run-embedded-attempt.ts
@@ -212,6 +212,9 @@ export async function runEmbeddedAgentAttempt(params: {
   );
 
   let result: AgentAttemptResult;
+  let maintenanceAuthProfile:
+    | { authProfileId?: string; authProfileIdSource?: "auto" | "user" }
+    | undefined;
   let fallbackProvider = provider;
   let fallbackModel = model;
   let fallbackExhausted = false;
@@ -332,6 +335,7 @@ export async function runEmbeddedAgentAttempt(params: {
           fallbackTrajectoryRecorder?.recordEvent("model.fallback_step", step);
         },
         runCandidate: async (providerOverride, modelOverride, runOptions) => {
+          maintenanceAuthProfile = undefined;
           attemptMediaTaskIds = sessionKey
             ? getGeneratedMediaTaskIdsForSessionKey(sessionKey)
             : new Set<string>();
@@ -504,6 +508,10 @@ export async function runEmbeddedAgentAttempt(params: {
             contextEngineLogicalTurnLease: runOptions.contextEngineLogicalTurnLease,
             onContextEngineTurnCandidate: runOptions.onContextEngineTurnCandidate,
             onUserMessagePersisted: attemptLifecycleCallbacks.onUserMessagePersisted,
+            onSuccessfulAuthProfile: (selection) => {
+              // Absence is a valid ambient-auth result; only an uncalled observer is unknown.
+              maintenanceAuthProfile = selection;
+            },
             onLifecycleGenerationChanged: (nextLifecycleGeneration) => {
               lifecycleGeneration = nextLifecycleGeneration;
               params.onLifecycleGenerationChanged(nextLifecycleGeneration);
@@ -565,9 +573,8 @@ export async function runEmbeddedAgentAttempt(params: {
         }
         liveSwitchRetries += 1;
         if (liveSwitchRetries > MAX_LIVE_SWITCH_RETRIES) {
-          log.error(
-            `Live session model switch in subagent run ${runId}: exceeded maximum retries (${MAX_LIVE_SWITCH_RETRIES})`,
-          );
+          const retryLimitMessage = `Exceeded maximum live model switch retries (${MAX_LIVE_SWITCH_RETRIES})`;
+          log.error(`Live session model switch in subagent run ${runId}: ${retryLimitMessage}`);
           if (!attemptLifecycleState.lifecycleEnded) {
             emitAgentEvent({
               runId,
@@ -582,12 +589,7 @@ export async function runEmbeddedAgentAttempt(params: {
             });
           }
           await fallbackTrajectoryRecorder?.flush();
-          throw new Error(
-            `Exceeded maximum live model switch retries (${MAX_LIVE_SWITCH_RETRIES})`,
-            {
-              cause: err,
-            },
-          );
+          throw new Error(retryLimitMessage, { cause: err });
         }
         const switchRef = normalizeAgentCommandModelRef(
           cfg,
@@ -689,6 +691,7 @@ export async function runEmbeddedAgentAttempt(params: {
     sessionEntry,
     lifecycleGeneration,
     effectiveTurnThinkLevel,
+    maintenanceAuthProfile,
     internalSessionTarget,
     attemptExecutionRuntime,
     messageChannel,

--- a/src/agents/embedded-agent-runner/run/internal-params.ts
+++ b/src/agents/embedded-agent-runner/run/internal-params.ts
@@ -5,6 +5,8 @@ import type { RunEmbeddedAgentParams } from "./params.js";
 
 export type RunEmbeddedAgentInternalParams = RunEmbeddedAgentParams & {
   onSuccessfulAuthBinding?: (binding: AgentExecutionAuthBinding) => void;
+  /** Maintenance needs the winning profile, not native runtime artifact capture. */
+  onSuccessfulAuthProfile?: (profileId: string | undefined) => void;
   authProfileStateMode?: "read-write" | "read-only";
   /** Prepare only the requested candidate with this runtime; fallbacks keep their own policy. */
   agentHarnessRuntimePreparationHint?: string;

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.test.ts
@@ -118,6 +118,35 @@ async function resolveTerminalText(overrides: TerminalInputOverrides): Promise<s
 }
 
 describe("terminal resolution", () => {
+  it.each(["openai:selected", undefined])(
+    "reports the successful profile %s privately for command maintenance",
+    async (authProfileId) => {
+      const text = "The turn completed.";
+      const assistant = buildEmbeddedRunnerAssistant({ content: [{ type: "text", text }] });
+      const attempt = makeEmbeddedRunnerAttempt({
+        assistantTexts: [text],
+        lastAssistant: assistant,
+        currentAttemptAssistant: assistant,
+      });
+      const onSuccessfulAuthProfile = vi.fn();
+      const resolved = await resolveEmbeddedRunTerminal(
+        makeTerminalInput({
+          attempt,
+          attemptAssistant: assistant,
+          payloadsWithToolMedia: [{ text }],
+          authProfileId,
+          runParams: { authProfileStateMode: "read-only", onSuccessfulAuthProfile },
+        }),
+      );
+
+      expect(resolved.action).toBe("complete");
+      expect(onSuccessfulAuthProfile).toHaveBeenCalledExactlyOnceWith(authProfileId);
+      if (resolved.action === "complete") {
+        expect(resolved.result.meta.agentMeta).not.toHaveProperty("authProfileId");
+      }
+    },
+  );
+
   it.each([
     {
       reason: "auth" as const,

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.ts
@@ -6,7 +6,6 @@ import type { AssistantMessage } from "../../../llm/types.js";
 import type { ProviderRouteOverridePresence } from "../../../plugin-sdk/provider-model-types.js";
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import type { AuthProfileFailureReason, AuthProfileStore } from "../../auth-profiles.js";
-import type { AgentExecutionAuthBinding } from "../../execution-auth-binding.js";
 import type { ResolvedProviderAuth } from "../../model-auth.js";
 import { log } from "../logger.js";
 import type { EmbeddedRunReplayState } from "../replay-state.js";
@@ -39,7 +38,7 @@ import {
   TRUNCATED_REPLY_NOTICE_TEXT,
   YIELD_DIAGNOSTIC_TEXT,
 } from "./incomplete-turn-resolution.js";
-import type { RunEmbeddedAgentParams } from "./params.js";
+import type { RunEmbeddedAgentInternalParams as TerminalRunParams } from "./internal-params.js";
 import {
   isEmbeddedRunTerminalAbort,
   isEmbeddedRunTerminalInterrupted,
@@ -79,11 +78,6 @@ export function createTerminalToolPresentationTracker() {
     read: () => value,
   };
 }
-
-type TerminalRunParams = RunEmbeddedAgentParams & {
-  authProfileStateMode?: "read-write" | "read-only";
-  onSuccessfulAuthBinding?: (binding: AgentExecutionAuthBinding) => void;
-};
 
 type TerminalResolution =
   | { action: "retry" }
@@ -583,6 +577,7 @@ function completeEmbeddedRun(
     pluginHarnessOwnsAuthBootstrap: input.pluginHarnessOwnsAuthBootstrap,
     onSuccessfulAuthBinding: input.runParams.onSuccessfulAuthBinding,
   });
+  input.runParams.onSuccessfulAuthProfile?.(input.authProfileId);
   const replayInvalid = input.resolveReplayInvalid(null);
   const yieldHasContinuation =
     input.attempt.yieldDetected && hasYieldContinuationEvidence(input.attempt);

--- a/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
+++ b/src/auto-reply/reply/agent-runner-direct-runtime-config.test.ts
@@ -37,7 +37,7 @@ const resolveReplyToModeMock = vi.fn();
 const createReplyToModeFilterForChannelMock = vi.fn();
 const createReplyMediaContextMock = vi.fn();
 const createReplyMediaPathNormalizerMock = vi.fn();
-const runPreflightCompactionIfNeededMock = vi.fn();
+const runSessionCompactionIfNeededMock = vi.fn();
 const runMemoryFlushIfNeededMock = vi.fn();
 const executeAgentTurnMock = vi.fn();
 const prepareGitCoauthorAttributionMock = vi.fn();
@@ -77,8 +77,7 @@ vi.mock("./reply-media-paths.js", () => ({
 }));
 
 vi.mock("./agent-runner-memory.js", () => ({
-  runPreflightCompactionIfNeeded: (...args: unknown[]) =>
-    runPreflightCompactionIfNeededMock(...args),
+  runSessionCompactionIfNeeded: (...args: unknown[]) => runSessionCompactionIfNeededMock(...args),
   runMemoryFlushIfNeeded: (...args: unknown[]) => runMemoryFlushIfNeededMock(...args),
 }));
 
@@ -269,7 +268,7 @@ describe("runReplyAgent runtime config", () => {
     createReplyToModeFilterForChannelMock.mockReset();
     createReplyMediaContextMock.mockReset();
     createReplyMediaPathNormalizerMock.mockReset();
-    runPreflightCompactionIfNeededMock.mockReset();
+    runSessionCompactionIfNeededMock.mockReset();
     runMemoryFlushIfNeededMock.mockReset();
     executeAgentTurnMock.mockReset();
     prepareGitCoauthorAttributionMock.mockReset();
@@ -280,7 +279,7 @@ describe("runReplyAgent runtime config", () => {
     resolveReplyToModeMock.mockReturnValue("all");
     createReplyToModeFilterForChannelMock.mockReturnValue((payload: unknown) => payload);
     createReplyMediaPathNormalizerMock.mockReturnValue((payload: unknown) => payload);
-    runPreflightCompactionIfNeededMock.mockRejectedValue(sentinelError);
+    runSessionCompactionIfNeededMock.mockRejectedValue(sentinelError);
     runMemoryFlushIfNeededMock.mockResolvedValue({ sessionEntry: undefined, outcome: "skipped" });
     executeAgentTurnMock.mockResolvedValue({
       runId: "runtime-config-test",
@@ -319,17 +318,17 @@ describe("runReplyAgent runtime config", () => {
       requesterSenderUsername: undefined,
       requesterSenderE164: undefined,
     });
-    expect(runPreflightCompactionIfNeededMock).toHaveBeenCalledTimes(1);
+    expect(runSessionCompactionIfNeededMock).toHaveBeenCalledTimes(1);
     expect(runMemoryFlushIfNeededMock).toHaveBeenCalledTimes(1);
     expect(runMemoryFlushIfNeededMock.mock.invocationCallOrder[0]).toBeLessThan(
-      runPreflightCompactionIfNeededMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+      runSessionCompactionIfNeededMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
     const memoryCall = requireMaintenanceCall(runMemoryFlushIfNeededMock, "runMemoryFlushIfNeeded");
     expect(memoryCall.cfg).toBe(freshCfg);
     expect(memoryCall.followupRun).toBe(followupRun);
     const preflightCall = requireMaintenanceCall(
-      runPreflightCompactionIfNeededMock,
-      "runPreflightCompactionIfNeeded",
+      runSessionCompactionIfNeededMock,
+      "runSessionCompactionIfNeeded",
     );
     expect(preflightCall.cfg).toBe(freshCfg);
     expect(preflightCall.followupRun).toBe(followupRun);
@@ -349,8 +348,8 @@ describe("runReplyAgent runtime config", () => {
     await expect(runReplyAgent(replyParams)).rejects.toBe(sentinelError);
 
     const preflightCall = requireMaintenanceCall(
-      runPreflightCompactionIfNeededMock,
-      "runPreflightCompactionIfNeeded",
+      runSessionCompactionIfNeededMock,
+      "runSessionCompactionIfNeeded",
     );
     expect(preflightCall.sessionKey).toBe("agent:main:main");
     expect(preflightCall.runtimePolicySessionKey).toBe(runtimePolicySessionKey);
@@ -365,7 +364,7 @@ describe("runReplyAgent runtime config", () => {
     prepareGitCoauthorAttributionMock.mockImplementation((params: { currentProfileId?: string }) =>
       params.currentProfileId === "profile-ada" ? attribution : undefined,
     );
-    runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
+    runSessionCompactionIfNeededMock.mockResolvedValue(undefined);
     await withTestDir({ prefix: "openclaw-coauthor-owner-" }, async (tempDir) => {
       const storePath = join(tempDir, "sessions.json");
       const runCase = async (
@@ -435,7 +434,7 @@ describe("runReplyAgent runtime config", () => {
       ...freshCfg,
       agents: { defaults: { compaction: { notifyUser: true } } },
     });
-    runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
+    runSessionCompactionIfNeededMock.mockResolvedValue(undefined);
     runMemoryFlushIfNeededMock.mockImplementation(
       async (params: {
         replyOperation: ReplyOperation;
@@ -485,7 +484,7 @@ describe("runReplyAgent runtime config", () => {
       replyParams.opts = { onBlockReply };
       const replyOperation = createReplyOperation();
       replyParams.replyOperation = replyOperation;
-      runPreflightCompactionIfNeededMock.mockImplementation(
+      runSessionCompactionIfNeededMock.mockImplementation(
         async (params: { sessionEntry?: unknown }) => params.sessionEntry,
       );
       runMemoryFlushIfNeededMock.mockImplementation(
@@ -578,7 +577,7 @@ describe("runReplyAgent runtime config", () => {
       sessionEntry,
       outcome: "exhausted",
     });
-    runPreflightCompactionIfNeededMock.mockImplementation(
+    runSessionCompactionIfNeededMock.mockImplementation(
       async (params: { sessionEntry?: typeof sessionEntry }) => {
         expect(params.sessionEntry?.sessionId).toBe("session-1");
         return { ...params.sessionEntry, compactionCount: 5 };
@@ -600,7 +599,7 @@ describe("runReplyAgent runtime config", () => {
       sessionEntry: { sessionId: "session-1", updatedAt: 1, compactionCount: 4 },
       outcome: "exhausted",
     });
-    runPreflightCompactionIfNeededMock.mockRejectedValue(
+    runSessionCompactionIfNeededMock.mockRejectedValue(
       new Error("Preflight compaction required but failed: context_overflow"),
     );
 
@@ -625,7 +624,7 @@ describe("runReplyAgent runtime config", () => {
       sessionEntry: { sessionId: "session-1", updatedAt: 1, compactionCount: 4 },
       outcome: "exhausted",
     });
-    runPreflightCompactionIfNeededMock.mockRejectedValue(
+    runSessionCompactionIfNeededMock.mockRejectedValue(
       new Error("Preflight compaction required but failed: auth profile mismatch"),
     );
 
@@ -648,7 +647,7 @@ describe("runReplyAgent runtime config", () => {
       });
       const runState: ReplyOperationRunState = {};
       replyParams.opts = { [REPLY_OPERATION_RUN_STATE]: runState };
-      runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
+      runSessionCompactionIfNeededMock.mockResolvedValue(undefined);
       runMemoryFlushIfNeededMock.mockImplementation(
         async (params: { replyOperation: ReplyOperation }) => {
           expect(params.replyOperation[abortMethod]()).toBe(true);
@@ -678,7 +677,7 @@ describe("runReplyAgent runtime config", () => {
       });
       const runState: ReplyOperationRunState = {};
       replyParams.opts = { [REPLY_OPERATION_RUN_STATE]: runState };
-      runPreflightCompactionIfNeededMock.mockResolvedValue(undefined);
+      runSessionCompactionIfNeededMock.mockResolvedValue(undefined);
       executeAgentTurnMock.mockResolvedValue({
         runId: "cancelled-runtime-config-test",
         outcome: { kind: "aborted", reason },
@@ -697,7 +696,7 @@ describe("runReplyAgent runtime config", () => {
     });
     const codexMessage =
       "You've reached your Codex subscription usage limit. Codex did not return a reset time for this limit. Run /codex account for current usage details.";
-    runPreflightCompactionIfNeededMock.mockRejectedValue(
+    runSessionCompactionIfNeededMock.mockRejectedValue(
       new FailoverError(codexMessage, {
         reason: "rate_limit",
         provider: "openai",
@@ -721,7 +720,7 @@ describe("runReplyAgent runtime config", () => {
       shouldFollowup: false,
       isActive: false,
     });
-    runPreflightCompactionIfNeededMock.mockRejectedValue(
+    runSessionCompactionIfNeededMock.mockRejectedValue(
       new Error("Preflight compaction required but failed: auth profile mismatch"),
     );
     runMemoryFlushIfNeededMock.mockResolvedValue({ sessionEntry: undefined, outcome: "skipped" });

--- a/src/auto-reply/reply/agent-runner-execute.ts
+++ b/src/auto-reply/reply/agent-runner-execute.ts
@@ -17,7 +17,7 @@ import {
   type RunReplyAgentParams,
 } from "./agent-runner-core.js";
 import { executeAgentTurn } from "./agent-runner-execution.js";
-import { runMemoryFlushIfNeeded, runPreflightCompactionIfNeeded } from "./agent-runner-memory.js";
+import { runMemoryFlushIfNeeded, runSessionCompactionIfNeeded } from "./agent-runner-memory.js";
 import { finalizeReplyAgentRun } from "./agent-runner-result.js";
 import { buildThreadingToolContext } from "./agent-runner-utils.js";
 import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
@@ -222,7 +222,7 @@ export async function executePreparedReplyAgentRun(
   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   try {
     activeSessionEntry = await traceAgentPhase("reply.preflight_compaction", () =>
-      runPreflightCompactionIfNeeded({
+      runSessionCompactionIfNeeded({
         cfg,
         followupRun,
         promptForEstimate: followupRun.prompt,
@@ -233,7 +233,9 @@ export async function executePreparedReplyAgentRun(
         runtimePolicySessionKey,
         storePath,
         isHeartbeat,
-        replyOperation,
+        abortSignal: replyOperation.abortSignal,
+        onCompactionStart: () => replyOperation.setPhase("preflight_compacting"),
+        onSessionIdChanged: (sessionId) => replyOperation.updateSessionId(sessionId),
         onCompactionNotice: sendDirectCompactionNotice,
       }),
     );

--- a/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.preflight-stale-tokens.test.ts
@@ -9,24 +9,23 @@ import {
   registerMemoryCapability,
   type MemoryFlushPlanResolver,
 } from "../../plugins/memory-state.test-fixtures.js";
-import { runPreflightCompactionIfNeeded as runPreflightCompactionIfNeededRaw } from "./agent-runner-memory.js";
+import { runSessionCompactionIfNeeded as runSessionCompactionIfNeededRaw } from "./agent-runner-memory.js";
 import { setAgentRunnerMemoryTestDeps } from "./agent-runner-memory.test-support.js";
 import {
   createTestFollowupRun,
   withTestModelContextTokens,
   writeTestSessionStore,
 } from "./agent-runner.test-fixtures.js";
-import type { ReplyOperation } from "./reply-run-registry.js";
 
 const compactEmbeddedAgentSessionMock = vi.fn();
 
-type PreflightCompactionTestParams = Parameters<typeof runPreflightCompactionIfNeededRaw>[0] & {
+type PreflightCompactionTestParams = Parameters<typeof runSessionCompactionIfNeededRaw>[0] & {
   modelContextTokens?: number;
 };
 
-async function runPreflightCompactionIfNeeded(params: PreflightCompactionTestParams) {
+async function runSessionCompactionIfNeeded(params: PreflightCompactionTestParams) {
   const { modelContextTokens, ...runParams } = params;
-  return await runPreflightCompactionIfNeededRaw({
+  return await runSessionCompactionIfNeededRaw({
     ...runParams,
     cfg: withTestModelContextTokens({
       cfg: runParams.cfg,
@@ -37,39 +36,11 @@ async function runPreflightCompactionIfNeeded(params: PreflightCompactionTestPar
   });
 }
 
-function createReplyOperation(): ReplyOperation {
-  return {
-    key: "test",
-    sessionId: "session",
-    abortSignal: new AbortController().signal,
-    resetTriggered: false,
-    phase: "queued",
-    result: null,
-    startedAtMs: Date.now(),
-    lastActivityAtMs: Date.now(),
-    recordActivity: vi.fn(),
-    setPhase: vi.fn(),
-    updateSessionId: vi.fn(),
-    attachBackend: vi.fn(),
-    detachBackend: vi.fn(),
-    freezeAbort: vi.fn(),
-    retainFailureUntilComplete: vi.fn(),
-    complete: vi.fn(),
-    completeThen: vi.fn((afterClear: () => void) => {
-      afterClear();
-    }),
-    completeWithAfterClearBarrier: vi.fn(),
-    fail: vi.fn(),
-    abortByUser: vi.fn(),
-    abortForRestart: vi.fn(),
-  } as unknown as ReplyOperation;
-}
-
 function registerMemoryFlushPlanResolverForTest(resolver: MemoryFlushPlanResolver): void {
   registerMemoryCapability("memory-core", { flushPlanResolver: resolver });
 }
 
-describe("runPreflightCompactionIfNeeded stale totalTokens gating", () => {
+describe("runSessionCompactionIfNeeded stale totalTokens gating", () => {
   let rootDir = "";
 
   beforeEach(async () => {
@@ -104,7 +75,7 @@ describe("runPreflightCompactionIfNeeded stale totalTokens gating", () => {
   });
 
   async function runWithEntry(sessionEntry: SessionEntry, sessionFile: string) {
-    return await runPreflightCompactionIfNeeded({
+    return await runSessionCompactionIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({
         sessionId: "session",
@@ -118,7 +89,7 @@ describe("runPreflightCompactionIfNeeded stale totalTokens gating", () => {
       sessionKey: "agent:main:main",
       storePath: path.join(rootDir, "sessions.json"),
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      abortSignal: new AbortController().signal,
     });
   }
 
@@ -227,7 +198,7 @@ describe("runPreflightCompactionIfNeeded stale totalTokens gating", () => {
       };
       await writeTestSessionStore(storePath, "main", sessionEntry);
 
-      const result = await runPreflightCompactionIfNeeded({
+      const result = await runSessionCompactionIfNeeded({
         cfg: {
           agents: {
             list: [{ id: "ops", default: true }, { id: "worker" }],
@@ -249,7 +220,7 @@ describe("runPreflightCompactionIfNeeded stale totalTokens gating", () => {
         sessionKey: "main",
         storePath,
         isHeartbeat: false,
-        replyOperation: createReplyOperation(),
+        abortSignal: new AbortController().signal,
       });
 
       expect(result).toBe(sessionEntry);

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import type { runEmbeddedAgentEntry } from "../../agents/embedded-agent-runner/run-entry.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
@@ -29,7 +30,7 @@ import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import type { ReplyPayload } from "../types.js";
 import {
   runMemoryFlushIfNeeded as runMemoryFlushIfNeededRaw,
-  runPreflightCompactionIfNeeded as runPreflightCompactionIfNeededRaw,
+  runSessionCompactionIfNeeded as runSessionCompactionIfNeededRaw,
 } from "./agent-runner-memory.js";
 import { setAgentRunnerMemoryTestDeps } from "./agent-runner-memory.test-support.js";
 import {
@@ -70,13 +71,13 @@ async function runMemoryFlushIfNeeded(params: MemoryFlushTestParams) {
   });
 }
 
-type PreflightCompactionTestParams = Parameters<typeof runPreflightCompactionIfNeededRaw>[0] & {
+type PreflightCompactionTestParams = Parameters<typeof runSessionCompactionIfNeededRaw>[0] & {
   modelContextTokens?: number;
 };
 
-async function runPreflightCompactionIfNeeded(params: PreflightCompactionTestParams) {
+async function runSessionCompactionIfNeeded(params: PreflightCompactionTestParams) {
   const { modelContextTokens, ...runParams } = params;
-  return await runPreflightCompactionIfNeededRaw({
+  return await runSessionCompactionIfNeededRaw({
     ...runParams,
     cfg: withTestModelContextTokens({
       cfg: runParams.cfg,
@@ -180,6 +181,14 @@ function createReplyOperation(): TestReplyOperation {
     markDeferredMaintenanceWaitEnded: vi.fn(),
     markWaitingForGlobalLane: vi.fn(),
     markGlobalLaneWaitEnded: vi.fn(),
+  };
+}
+
+function createCompactionLifecycle(replyOperation: ReplyOperation) {
+  return {
+    abortSignal: replyOperation.abortSignal,
+    onCompactionStart: () => replyOperation.setPhase("preflight_compacting"),
+    onSessionIdChanged: (sessionId: string) => replyOperation.updateSessionId(sessionId),
   };
 }
 
@@ -362,7 +371,7 @@ describe("runMemoryFlushIfNeeded", () => {
     overrides: Partial<PreflightCompactionTestParams> = {},
   ) {
     const sessionKey = overrides.sessionKey ?? "main";
-    return await runPreflightCompactionIfNeeded({
+    return await runSessionCompactionIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({ sessionId: "session", sessionKey }),
       defaultModel: "anthropic/claude-opus-4-6",
@@ -372,7 +381,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey,
       storePath: path.join(rootDir, "sessions.json"),
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      ...createCompactionLifecycle(createReplyOperation()),
       ...overrides,
     });
   }
@@ -1582,7 +1591,7 @@ describe("runMemoryFlushIfNeeded", () => {
       reason: "no real conversation messages",
     });
     await expect(
-      runPreflightCompactionIfNeeded({
+      runSessionCompactionIfNeeded({
         cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
         followupRun: createTestFollowupRun({
           sessionId: "session",
@@ -1596,7 +1605,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey: "agent:main:main",
         storePath: path.join(rootDir, "sessions.json"),
         isHeartbeat: false,
-        replyOperation: createReplyOperation(),
+        ...createCompactionLifecycle(createReplyOperation()),
         onCompactionNotice,
       }),
     ).rejects.toThrow("Preflight compaction required but failed: no real conversation messages");
@@ -1628,7 +1637,7 @@ describe("runMemoryFlushIfNeeded", () => {
     };
 
     await expect(
-      runPreflightCompactionIfNeeded({
+      runSessionCompactionIfNeeded({
         cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
         followupRun: createTestFollowupRun({
           sessionId: "session",
@@ -1642,7 +1651,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey: "agent:main:main",
         storePath: path.join(rootDir, "sessions.json"),
         isHeartbeat: false,
-        replyOperation: createReplyOperation(),
+        ...createCompactionLifecycle(createReplyOperation()),
       }),
     ).rejects.toThrow(
       "Preflight compaction required but failed: deferred to background context-engine maintenance",
@@ -1729,7 +1738,7 @@ describe("runMemoryFlushIfNeeded", () => {
       const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
 
       await expect(
-        runPreflightCompactionIfNeeded({
+        runSessionCompactionIfNeeded({
           cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
           followupRun: createTestFollowupRun({
             sessionId: "session",
@@ -1743,7 +1752,7 @@ describe("runMemoryFlushIfNeeded", () => {
           sessionKey: "agent:main:telegram:group:redacted",
           storePath: path.join(rootDir, "sessions.json"),
           isHeartbeat: false,
-          replyOperation: createReplyOperation(),
+          ...createCompactionLifecycle(createReplyOperation()),
         }),
       ).rejects.toThrow(`Preflight compaction required but failed: ${reason}`);
 
@@ -1782,7 +1791,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
 
     await expect(
-      runPreflightCompactionIfNeeded({
+      runSessionCompactionIfNeeded({
         cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
         followupRun: createTestFollowupRun({
           sessionId: "session",
@@ -1796,7 +1805,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey: "agent:main:telegram:group:redacted",
         storePath: path.join(rootDir, "sessions.json"),
         isHeartbeat: false,
-        replyOperation: createReplyOperation(),
+        ...createCompactionLifecycle(createReplyOperation()),
       }),
     ).rejects.toThrow(
       "Preflight compaction required but failed: thread not found: <codex-thread-id>",
@@ -1837,7 +1846,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const sessionStore = { "agent:main:telegram:group:redacted": sessionEntry };
 
     await expect(
-      runPreflightCompactionIfNeeded({
+      runSessionCompactionIfNeeded({
         cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
         followupRun: createTestFollowupRun({
           sessionId: "session",
@@ -1851,7 +1860,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey: "agent:main:telegram:group:redacted",
         storePath: path.join(rootDir, "sessions.json"),
         isHeartbeat: false,
-        replyOperation: createReplyOperation(),
+        ...createCompactionLifecycle(createReplyOperation()),
       }),
     ).rejects.toThrow("Preflight compaction required but failed: auth profile mismatch");
 
@@ -1871,7 +1880,7 @@ describe("runMemoryFlushIfNeeded", () => {
         compactionCount: 0,
       };
 
-      await runPreflightCompactionIfNeeded({
+      await runSessionCompactionIfNeeded({
         cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
         followupRun: createTestFollowupRun({
           authProfileId: "anthropic:claude@martian.engineering",
@@ -1886,7 +1895,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionStore: { "agent:main:main": sessionEntry },
         sessionKey: "agent:main:main",
         isHeartbeat: false,
-        replyOperation: createReplyOperation(),
+        ...createCompactionLifecycle(createReplyOperation()),
       });
 
       const compactCall = requireCompactEmbeddedAgentSessionCall();
@@ -1895,6 +1904,189 @@ describe("runMemoryFlushIfNeeded", () => {
       expect(compactCall.contextTokenBudget).toBe(258_000);
     },
   );
+  it.each([
+    {
+      label: "below threshold",
+      totalTokens: 897_999,
+      shouldCompact: false,
+      requestedRuntime: "openclaw",
+    },
+    {
+      label: "at threshold",
+      totalTokens: 898_000,
+      shouldCompact: true,
+      requestedRuntime: "openclaw",
+    },
+    {
+      label: "reported pressure",
+      totalTokens: 904_869,
+      shouldCompact: true,
+      requestedRuntime: "openclaw",
+    },
+    {
+      label: "reported pressure after a runtime fallback",
+      totalTokens: 904_869,
+      shouldCompact: true,
+      requestedRuntime: "codex",
+    },
+  ] as const)(
+    "applies session compaction at $label with memory flush disabled",
+    async ({ totalTokens, shouldCompact, requestedRuntime }) => {
+      // A disabled memory plugin supplies no flush plan; compaction still owns its budget.
+      registerMemoryFlushPlanResolverForTest(() => null);
+      const sessionEntry = createFlushSessionEntry({
+        totalTokens,
+        compactionCount: 0,
+        agentHarnessId: requestedRuntime,
+        agentRuntimeOverride: requestedRuntime,
+        lifecycleRevision: "owned-generation",
+      });
+      const authorize = () => true;
+      const overrides: Partial<PreflightCompactionTestParams> = {
+        cfg: {
+          agents: {
+            defaults: { compaction: { mode: "safeguard", memoryFlush: { enabled: false } } },
+          },
+          tools: { deny: ["*"] },
+          models: {
+            providers: {
+              openai: {
+                agentRuntime: { id: requestedRuntime },
+                baseUrl: "https://chatgpt.com/backend-api",
+                api: "openai-chatgpt-responses",
+                models: [
+                  {
+                    id: "gpt-5.6-luna",
+                    name: "Context budget test",
+                    reasoning: true,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 1_050_000,
+                    contextTokens: 922_000,
+                    maxTokens: 128_000,
+                  },
+                ],
+              },
+            },
+          },
+        },
+        followupRun: createTestFollowupRun({
+          provider: "openai",
+          model: "gpt-5.6-luna",
+          workspaceDir: rootDir,
+          agentDir: rootDir,
+        }),
+        defaultModel: "openai/gpt-5.6-luna",
+        modelContextTokens: 922_000,
+        promptForEstimate: "",
+        authorize,
+        ...(requestedRuntime === "codex" ? { agentHarnessId: "openclaw" } : {}),
+      };
+
+      const flush = await runDefaultMemoryFlush(sessionEntry, overrides);
+      expect(flush.outcome).toBe("skipped");
+      await runDefaultPreflight(sessionEntry, overrides);
+
+      expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(shouldCompact ? 1 : 0);
+      if (shouldCompact) {
+        expect(requireCompactEmbeddedAgentSessionCall()).toMatchObject({
+          agentHarnessId: "openclaw",
+          contextTokenBudget: 922_000,
+          currentTokenCount: totalTokens,
+          force: true,
+          forcePreflight: true,
+          preflightRequired: true,
+          preflightCompactionTrigger: "tokens",
+        });
+        expect(incrementCompactionCountMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            expectedSession: { sessionId: "session", lifecycleRevision: "owned-generation" },
+            authorize,
+          }),
+        );
+      }
+    },
+  );
+
+  it.each([
+    { stage: "before start", invalidation: "authorization" },
+    { stage: "before start", invalidation: "abort" },
+    { stage: "after start notice", invalidation: "authorization" },
+    { stage: "after start notice", invalidation: "abort" },
+    { stage: "after awaited compactor", invalidation: "authorization" },
+    { stage: "after awaited compactor", invalidation: "abort" },
+  ] as const)(
+    "rejects $invalidation invalidation $stage without accounting or adopting compaction",
+    async ({ stage, invalidation }) => {
+      const sessionEntry = createFlushSessionEntry();
+      const sessionStore = { main: sessionEntry };
+      const followupRun = createTestFollowupRun({ workspaceDir: rootDir });
+      const controller = new AbortController();
+      let authorized = true;
+      const invalidate = () => {
+        if (invalidation === "authorization") {
+          authorized = false;
+        } else {
+          controller.abort(new Error("caller aborted"));
+        }
+      };
+      const compactorStarted = createDeferred();
+      const releaseCompactor = createDeferred();
+      compactEmbeddedAgentSessionMock.mockImplementationOnce(async () => {
+        compactorStarted.resolve();
+        await releaseCompactor.promise;
+        return { ok: true, compacted: true, result: { tokensAfter: 42, sessionId: "successor" } };
+      });
+      const onCompactionStart = vi.fn();
+      const onSessionIdChanged = vi.fn();
+      const onCompactionNotice = vi.fn(async (phase: string) => {
+        if (stage === "after start notice" && phase === "start") {
+          invalidate();
+        }
+      });
+      if (stage === "before start") {
+        invalidate();
+      }
+      if (stage !== "after awaited compactor") {
+        releaseCompactor.resolve();
+      }
+
+      const pending = runDefaultPreflight(sessionEntry, {
+        followupRun,
+        sessionStore,
+        abortSignal: controller.signal,
+        authorize: () => authorized,
+        onCompactionStart,
+        onSessionIdChanged,
+        onCompactionNotice,
+      });
+      if (stage === "after awaited compactor") {
+        await compactorStarted.promise;
+        invalidate();
+        releaseCompactor.resolve();
+      }
+      await expect(pending).rejects.toThrow(
+        invalidation === "authorization"
+          ? "Session compaction maintenance is no longer active"
+          : "caller aborted",
+      );
+
+      expect(onCompactionStart).toHaveBeenCalledTimes(stage === "before start" ? 0 : 1);
+      if (stage === "before start") {
+        expect(onCompactionNotice).not.toHaveBeenCalled();
+      }
+      expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(
+        stage === "after awaited compactor" ? 1 : 0,
+      );
+      expect(incrementCompactionCountMock).not.toHaveBeenCalled();
+      expect(onSessionIdChanged).not.toHaveBeenCalled();
+      expect(refreshQueuedFollowupSessionMock).not.toHaveBeenCalled();
+      expect(sessionStore.main).toBe(sessionEntry);
+      expect(followupRun.run.sessionId).toBe("session");
+    },
+  );
+
   it("preflight compacts a fresh session when the current prompt estimate pushes the next request over budget", async () => {
     registerMemoryFlushPlanResolverForTest(() =>
       createModifiedMemoryFlushPlan({ softThresholdTokens: 0, reserveTokensFloor: 10 }),
@@ -1940,7 +2132,7 @@ describe("runMemoryFlushIfNeeded", () => {
       compactionCount: 0,
     };
 
-    await runPreflightCompactionIfNeeded({
+    await runSessionCompactionIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({
         provider: "anthropic",
@@ -1954,7 +2146,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionStore: { "agent:main:main": sessionEntry },
       sessionKey: "agent:main:main",
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      ...createCompactionLifecycle(createReplyOperation()),
     });
 
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
@@ -1994,7 +2186,7 @@ describe("runMemoryFlushIfNeeded", () => {
     };
     const sessionStore = { [sessionKey]: sessionEntry };
     const run = () =>
-      runPreflightCompactionIfNeeded({
+      runSessionCompactionIfNeeded({
         cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
         followupRun: createTestFollowupRun({
           provider: "anthropic",
@@ -2010,7 +2202,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey,
         storePath,
         isHeartbeat: false,
-        replyOperation: createReplyOperation(),
+        ...createCompactionLifecycle(createReplyOperation()),
       });
 
     await run();
@@ -2059,7 +2251,7 @@ describe("runMemoryFlushIfNeeded", () => {
     };
     const sessionStore = { [sessionKey]: sessionEntry };
     const run = () =>
-      runPreflightCompactionIfNeeded({
+      runSessionCompactionIfNeeded({
         cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
         followupRun: createTestFollowupRun({
           provider: "anthropic",
@@ -2075,7 +2267,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey,
         storePath,
         isHeartbeat: false,
-        replyOperation: createReplyOperation(),
+        ...createCompactionLifecycle(createReplyOperation()),
       });
 
     await run();
@@ -2149,7 +2341,7 @@ describe("runMemoryFlushIfNeeded", () => {
       modelContextTokens: 100,
       sessionStore,
       sessionKey: "agent:main:main",
-      replyOperation,
+      ...createCompactionLifecycle(replyOperation),
     });
 
     expect(entry?.sessionId).toBe("session-rotated");
@@ -2338,7 +2530,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const replyOperation = createReplyOperation();
 
     await expect(
-      runPreflightCompactionIfNeeded({
+      runSessionCompactionIfNeeded({
         cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
         followupRun: createTestFollowupRun({
           sessionId: "session",
@@ -2351,7 +2543,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey: "main",
         storePath: path.join(rootDir, "sessions.json"),
         isHeartbeat: false,
-        replyOperation,
+        ...createCompactionLifecycle(replyOperation),
       }),
     ).rejects.toThrow("Preflight compaction required but failed: plugin already stored this turn");
 
@@ -2387,7 +2579,7 @@ describe("runMemoryFlushIfNeeded", () => {
       agentHarnessId: "openclaw",
     };
 
-    const entry = await runPreflightCompactionIfNeeded({
+    const entry = await runSessionCompactionIfNeeded({
       cfg: {
         models: {
           providers: {
@@ -2408,7 +2600,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey: "main",
       storePath: path.join(rootDir, "sessions.json"),
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      ...createCompactionLifecycle(createReplyOperation()),
     });
 
     expect(entry).toBe(sessionEntry);
@@ -2434,7 +2626,7 @@ describe("runMemoryFlushIfNeeded", () => {
       agentHarnessId: "openclaw",
     };
 
-    const entry = await runPreflightCompactionIfNeeded({
+    const entry = await runSessionCompactionIfNeeded({
       cfg: {
         models: {
           providers: {
@@ -2455,7 +2647,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey: "main",
       storePath: path.join(rootDir, "sessions.json"),
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      ...createCompactionLifecycle(createReplyOperation()),
     });
 
     expect(entry).toBe(sessionEntry);
@@ -2481,7 +2673,7 @@ describe("runMemoryFlushIfNeeded", () => {
       agentRuntimeOverride: "claude-cli",
     };
 
-    const entry = await runPreflightCompactionIfNeeded({
+    const entry = await runSessionCompactionIfNeeded({
       cfg: {
         models: {
           providers: {
@@ -2503,7 +2695,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey: "main",
       storePath: path.join(rootDir, "sessions.json"),
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      ...createCompactionLifecycle(createReplyOperation()),
     });
 
     expect(entry).toBe(sessionEntry);
@@ -2527,7 +2719,7 @@ describe("runMemoryFlushIfNeeded", () => {
       agentRuntimeOverride: "openclaw",
     };
 
-    const entry = await runPreflightCompactionIfNeeded({
+    const entry = await runSessionCompactionIfNeeded({
       cfg: {
         models: {
           providers: {
@@ -2548,7 +2740,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey: "main",
       storePath: path.join(rootDir, "sessions.json"),
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      ...createCompactionLifecycle(createReplyOperation()),
     });
 
     expect(entry).toBe(sessionEntry);
@@ -2648,7 +2840,7 @@ describe("runMemoryFlushIfNeeded", () => {
         reason: "guard_blocked",
       });
 
-      const entry = await runPreflightCompactionIfNeeded({
+      const entry = await runSessionCompactionIfNeeded({
         cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
         followupRun: createTestFollowupRun({
           provider: "openai",
@@ -2663,7 +2855,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey,
         storePath,
         isHeartbeat: false,
-        replyOperation: createReplyOperation(),
+        ...createCompactionLifecycle(createReplyOperation()),
       });
 
       expect(entry).toBe(sessionEntry);
@@ -2691,7 +2883,7 @@ describe("runMemoryFlushIfNeeded", () => {
       agentRuntimeOverride: "openclaw",
     };
 
-    await runPreflightCompactionIfNeeded({
+    await runSessionCompactionIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({
         provider: "openai",
@@ -2706,7 +2898,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey: "main",
       storePath: path.join(rootDir, "sessions.json"),
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      ...createCompactionLifecycle(createReplyOperation()),
     });
 
     expect(requireCompactEmbeddedAgentSessionCall().currentTokenCount).toBeGreaterThan(100_000);
@@ -2756,7 +2948,7 @@ describe("runMemoryFlushIfNeeded", () => {
         agentRuntimeOverride: "openclaw",
       };
 
-      await runPreflightCompactionIfNeeded({
+      await runSessionCompactionIfNeeded({
         cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
         followupRun: createTestFollowupRun({
           provider: "openai",
@@ -2771,7 +2963,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey: "main",
         storePath: path.join(rootDir, "sessions.json"),
         isHeartbeat: false,
-        replyOperation: createReplyOperation(),
+        ...createCompactionLifecycle(createReplyOperation()),
       });
 
       expect(compactEmbeddedAgentSessionMock).toHaveBeenCalledTimes(shouldCompact ? 1 : 0);
@@ -3056,7 +3248,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const sessionStore = { main: sessionEntry };
     const replyOperation = createReplyOperation();
 
-    const entry = await runPreflightCompactionIfNeeded({
+    const entry = await runSessionCompactionIfNeeded({
       cfg: {
         agents: {
           defaults: {
@@ -3078,7 +3270,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey: "main",
       storePath: path.join(rootDir, "sessions.json"),
       isHeartbeat: false,
-      replyOperation,
+      ...createCompactionLifecycle(replyOperation),
     });
 
     expect(entry?.compactionCount).toBe(1);
@@ -3118,7 +3310,7 @@ describe("runMemoryFlushIfNeeded", () => {
       const sessionStore = { [sessionKey]: sessionEntry };
       const replyOperation = createReplyOperation();
 
-      const entry = await runPreflightCompactionIfNeeded({
+      const entry = await runSessionCompactionIfNeeded({
         cfg: {
           agents: {
             defaults: {
@@ -3139,7 +3331,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey,
         storePath,
         isHeartbeat: false,
-        replyOperation,
+        ...createCompactionLifecycle(replyOperation),
       });
 
       expect(entry?.compactionCount).toBe(1);
@@ -3197,7 +3389,7 @@ describe("runMemoryFlushIfNeeded", () => {
     };
     const replyOperation = createReplyOperation();
 
-    const entry = await runPreflightCompactionIfNeeded({
+    const entry = await runSessionCompactionIfNeeded({
       cfg: {
         agents: {
           defaults: {
@@ -3218,7 +3410,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey,
       storePath,
       isHeartbeat: false,
-      replyOperation,
+      ...createCompactionLifecycle(replyOperation),
     });
 
     expect(entry).toBe(sessionEntry);
@@ -3288,7 +3480,7 @@ describe("runMemoryFlushIfNeeded", () => {
       isHeartbeat: false,
       replyOperation: createReplyOperation(),
     });
-    const preflightEntry = await runPreflightCompactionIfNeeded({
+    const preflightEntry = await runSessionCompactionIfNeeded({
       cfg,
       followupRun,
       defaultModel: "anthropic/claude-opus-4-6",
@@ -3298,7 +3490,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey,
       storePath,
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      ...createCompactionLifecycle(createReplyOperation()),
     });
 
     expect(flushResult).toEqual({ sessionEntry, outcome: "skipped" });
@@ -3359,7 +3551,7 @@ describe("runMemoryFlushIfNeeded", () => {
       promptComponentOffset: inboundPrompt.length + 2,
     });
 
-    const entry = await runPreflightCompactionIfNeeded({
+    const entry = await runSessionCompactionIfNeeded({
       cfg: {
         agents: {
           defaults: {
@@ -3378,7 +3570,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey,
       storePath,
       isHeartbeat: false,
-      replyOperation,
+      ...createCompactionLifecycle(replyOperation),
     });
 
     expect(entry?.compactionCount).toBe(1);
@@ -3412,7 +3604,7 @@ describe("runMemoryFlushIfNeeded", () => {
       compactionCount: 0,
     };
 
-    await runPreflightCompactionIfNeeded({
+    await runSessionCompactionIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({
         sessionId: sessionEntry.sessionId,
@@ -3425,7 +3617,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey,
       storePath: durableStorePath,
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      ...createCompactionLifecycle(createReplyOperation()),
     });
 
     const expectedStorePath = resolveSessionStorePathForScope({
@@ -3506,7 +3698,7 @@ describe("runMemoryFlushIfNeeded", () => {
       totalTokensFresh: false,
     };
 
-    await runPreflightCompactionIfNeeded({
+    await runSessionCompactionIfNeeded({
       cfg: { agents: { defaults: { compaction: { memoryFlush: {} } } } },
       followupRun: createTestFollowupRun({ sessionId: "session", sessionKey }),
       defaultModel: "anthropic/claude-opus-4-6",
@@ -3516,7 +3708,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey,
       storePath,
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      ...createCompactionLifecycle(createReplyOperation()),
     });
 
     expect(compactEmbeddedAgentSessionMock).not.toHaveBeenCalled();
@@ -3590,7 +3782,7 @@ describe("runMemoryFlushIfNeeded", () => {
       result: { kind: "server-endpoint", tokensBefore: 8_614, tokensAfter: 736 },
     });
 
-    await runPreflightCompactionIfNeeded({
+    await runSessionCompactionIfNeeded({
       cfg: {
         agents: {
           defaults: {
@@ -3613,7 +3805,7 @@ describe("runMemoryFlushIfNeeded", () => {
       sessionKey: "main",
       storePath: path.join(rootDir, "sessions.json"),
       isHeartbeat: false,
-      replyOperation: createReplyOperation(),
+      ...createCompactionLifecycle(createReplyOperation()),
       onCompactionNotice,
     });
 
@@ -3643,7 +3835,7 @@ describe("runMemoryFlushIfNeeded", () => {
     const onCompactionNotice = vi.fn();
 
     await expect(
-      runPreflightCompactionIfNeeded({
+      runSessionCompactionIfNeeded({
         cfg: {
           agents: {
             defaults: {
@@ -3666,7 +3858,7 @@ describe("runMemoryFlushIfNeeded", () => {
         sessionKey: "main",
         storePath: path.join(rootDir, "sessions.json"),
         isHeartbeat: false,
-        replyOperation: createReplyOperation(),
+        ...createCompactionLifecycle(createReplyOperation()),
         onCompactionNotice,
       }),
     ).rejects.toThrow("count update failed");

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -274,10 +274,18 @@ type FollowupRuntimeParams = {
   >;
   sessionKey?: string;
   runtimePolicySessionKey?: string;
+  agentHarnessId?: string;
 };
 
 function followupUsesCliRuntime(params: FollowupRuntimeParams, runtimeId: string): boolean {
   const provider = params.followupRun.run.provider;
+  if (params.agentHarnessId) {
+    return isCliRuntimeAliasForProvider({
+      provider,
+      runtime: params.agentHarnessId,
+      cfg: params.cfg,
+    });
+  }
   if (isCliProvider(provider, params.cfg)) {
     return true;
   }
@@ -296,6 +304,9 @@ function resolveFollowupContextConfigProvider(params: FollowupRuntimeParams): st
 }
 
 function resolveFollowupAgentRuntimeId(params: FollowupRuntimeParams): string {
+  if (params.agentHarnessId) {
+    return params.agentHarnessId;
+  }
   const matchingSessionEntry =
     params.sessionEntry?.sessionId === params.followupRun.run.sessionId
       ? params.sessionEntry
@@ -711,8 +722,8 @@ async function estimatePromptTokensFromSessionTranscript(params: {
   }
 }
 
-/** Runs preflight compaction when session state exceeds configured thresholds. */
-export async function runPreflightCompactionIfNeeded(params: {
+/** Compacts session context before a reply or after a completed direct command. */
+export async function runSessionCompactionIfNeeded(params: {
   cfg: OpenClawConfig;
   followupRun: FollowupRun;
   promptForEstimate?: string;
@@ -723,13 +734,24 @@ export async function runPreflightCompactionIfNeeded(params: {
   runtimePolicySessionKey?: string;
   storePath?: string;
   isHeartbeat: boolean;
-  replyOperation: ReplyOperation;
+  /** Completed commands carry the actual harness, not the originally requested runtime. */
+  agentHarnessId?: string;
+  abortSignal?: AbortSignal;
+  authorize?: () => boolean;
+  onCompactionStart?: () => void;
+  onSessionIdChanged?: (sessionId: string) => void;
   onCompactionNotice?: (phase: CompactionNoticePhase, text?: string) => Promise<void> | void;
 }): Promise<SessionEntry | undefined> {
   const deps = {
     compactEmbeddedAgentSession: memoryDeps.compactEmbeddedAgentSession,
     incrementCompactionCount: memoryDeps.incrementCompactionCount,
     refreshQueuedFollowupSession: memoryDeps.refreshQueuedFollowupSession,
+  };
+  const assertActive = () => {
+    params.abortSignal?.throwIfAborted();
+    if (params.authorize?.() === false) {
+      throw new Error("Session compaction maintenance is no longer active");
+    }
   };
   if (!params.sessionKey) {
     return params.sessionEntry;
@@ -748,7 +770,9 @@ export async function runPreflightCompactionIfNeeded(params: {
     sessionEntry: entry,
     sessionKey: params.sessionKey,
     runtimePolicySessionKey: params.runtimePolicySessionKey,
+    agentHarnessId: params.agentHarnessId,
   };
+  assertActive();
   const runtimeId = resolveFollowupAgentRuntimeId(runtimeParams);
   const isCli = followupUsesCliRuntime(runtimeParams, runtimeId);
   const ownsNativeCompaction = followupOwnsNativeCompaction(runtimeParams, runtimeId);
@@ -775,12 +799,10 @@ export async function runPreflightCompactionIfNeeded(params: {
 
   const contextWindowTokens = resolveMemoryFlushContextWindowTokens({
     cfg: params.cfg,
-    provider: resolveFollowupContextConfigProvider({
-      cfg: params.cfg,
-      followupRun: params.followupRun,
-      sessionEntry: entry,
-      sessionKey: params.sessionKey,
-      runtimePolicySessionKey: params.runtimePolicySessionKey,
+    provider: resolveContextConfigProviderForRuntime({
+      provider: params.followupRun.run.provider,
+      runtimeId,
+      config: params.cfg,
     }),
     modelId: params.followupRun.run.model ?? params.defaultModel,
   });
@@ -921,7 +943,8 @@ export async function runPreflightCompactionIfNeeded(params: {
       `maxActiveTranscriptBytes=${maxActiveTranscriptBytes ?? "undefined"}`,
   );
 
-  params.replyOperation.setPhase("preflight_compacting");
+  assertActive();
+  params.onCompactionStart?.();
   const notifyCompaction = async (phase: CompactionNoticePhase, text?: string) => {
     try {
       if (text) {
@@ -946,8 +969,13 @@ export async function runPreflightCompactionIfNeeded(params: {
     terminalCompactionNoticeSent = true;
     await notifyCompaction(phase, text);
   };
+  // Provider work can outlive the caller; never account against a replacement session row.
+  const expectedSession = params.authorize
+    ? { sessionId: entry.sessionId, lifecycleRevision: entry.lifecycleRevision }
+    : undefined;
   try {
     await notifyStartCompaction();
+    assertActive();
     const result = await deps.compactEmbeddedAgentSession({
       sessionId: entry.sessionId,
       sessionKey: compactionSessionKey,
@@ -982,11 +1010,12 @@ export async function runPreflightCompactionIfNeeded(params: {
       authProfileIdSource: params.followupRun.run.authProfileIdSource,
       sessionEntry: entry,
       agentHarnessId:
-        entry.sessionId === params.followupRun.run.sessionId
+        params.agentHarnessId ??
+        (entry.sessionId === params.followupRun.run.sessionId
           ? entry.modelSelectionLocked === true
             ? resolvePersistedSessionRuntimeId(entry)
             : runtimeId
-          : undefined,
+          : undefined),
       modelSelectionLocked: entry.modelSelectionLocked === true,
       thinkLevel: params.followupRun.run.thinkLevel,
       bashElevated: params.followupRun.run.bashElevated,
@@ -999,8 +1028,9 @@ export async function runPreflightCompactionIfNeeded(params: {
       contextTokenBudget: contextWindowTokens,
       currentTokenCount: tokenCountForCompaction ?? freshPersistedTokens,
       ownerNumbers: params.followupRun.run.ownerNumbers,
-      abortSignal: params.replyOperation.abortSignal,
+      abortSignal: params.abortSignal,
     });
+    assertActive();
 
     if (!result?.ok) {
       const reason = result?.reason ?? "not_compacted";
@@ -1026,7 +1056,7 @@ export async function runPreflightCompactionIfNeeded(params: {
       throw new Error(`Preflight compaction required but failed: ${reason}`);
     }
 
-    await deps.incrementCompactionCount({
+    const compactionCount = await deps.incrementCompactionCount({
       agentId: compactionAgentId,
       cfg: params.cfg,
       sessionEntry: entry,
@@ -1036,11 +1066,17 @@ export async function runPreflightCompactionIfNeeded(params: {
       tokensAfter: result.result?.tokensAfter,
       newSessionId: result.result?.sessionId,
       compactionKind: result.compactionKind,
+      ...(expectedSession ? { expectedSession, authorize: params.authorize } : {}),
     });
+    assertActive();
+    if (expectedSession && compactionCount === undefined) {
+      throw new Error("Session changed before compaction maintenance could be recorded");
+    }
     await appendPostCompactionRefreshPrompt({
       cfg: params.cfg,
       followupRun: params.followupRun,
     });
+    assertActive();
     const serverNotice =
       result.compactionKind === "server-endpoint" &&
       typeof result.result?.tokensBefore === "number" &&
@@ -1048,11 +1084,12 @@ export async function runPreflightCompactionIfNeeded(params: {
         ? `🧹 Server-side compaction complete (${formatTokenCount(result.result.tokensBefore)} → ${formatTokenCount(result.result.tokensAfter)})`
         : undefined;
     await notifyTerminalCompaction("end", serverNotice);
+    assertActive();
     entry = params.sessionStore?.[params.sessionKey] ?? entry;
     if (entry) {
       const previousSessionId = params.followupRun.run.sessionId;
       params.followupRun.run.sessionId = entry.sessionId;
-      params.replyOperation.updateSessionId(entry.sessionId);
+      params.onSessionIdChanged?.(entry.sessionId);
       const queueKey = params.followupRun.run.sessionKey ?? params.sessionKey;
       if (queueKey) {
         params.followupRun.run.sessionFile = queueKey;

--- a/src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.final-media-runreplyagent.test.ts
@@ -78,7 +78,7 @@ vi.mock("./agent-runner-memory.js", () => ({
     sessionEntry,
     outcome: "skipped",
   }),
-  runPreflightCompactionIfNeeded: async ({ sessionEntry }: { sessionEntry?: unknown }) =>
+  runSessionCompactionIfNeeded: async ({ sessionEntry }: { sessionEntry?: unknown }) =>
     sessionEntry,
 }));
 

--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -261,7 +261,7 @@ vi.mock("./agent-runner-memory.js", () => ({
     sessionEntry,
     outcome: "skipped",
   }),
-  runPreflightCompactionIfNeeded: async ({ sessionEntry }: { sessionEntry?: unknown }) =>
+  runSessionCompactionIfNeeded: async ({ sessionEntry }: { sessionEntry?: unknown }) =>
     sessionEntry,
 }));
 

--- a/src/auto-reply/reply/followup-turn-admission.test.ts
+++ b/src/auto-reply/reply/followup-turn-admission.test.ts
@@ -22,7 +22,7 @@ vi.mock("./agent-runner-auto-fallback.js", () => ({
 }));
 
 vi.mock("./agent-runner-memory.js", () => ({
-  runPreflightCompactionIfNeeded: (...args: unknown[]) => state.preflight(...args),
+  runSessionCompactionIfNeeded: (...args: unknown[]) => state.preflight(...args),
 }));
 
 vi.mock("./agent-runner-utils.js", () => ({
@@ -89,6 +89,8 @@ function createRun(overrides: Partial<FollowupRun> = {}): FollowupRun {
 function createOperation(sessionId = "queued-session") {
   return {
     sessionId,
+    abortSignal: new AbortController().signal,
+    setPhase: vi.fn(),
     abortForRestart: vi.fn(() => true),
     retainFailureUntilComplete: vi.fn(),
     fail: vi.fn(),

--- a/src/auto-reply/reply/followup-turn-admission.ts
+++ b/src/auto-reply/reply/followup-turn-admission.ts
@@ -14,7 +14,7 @@ import type { ReplyPayload } from "../types.js";
 import { resolveRunAfterAutoFallbackPrimaryProbeRecheck } from "./agent-runner-auto-fallback.js";
 import { resolveAdmittedRunSessionFile } from "./agent-runner-core.js";
 import { buildPreflightCompactionFailureText } from "./agent-runner-failure-reply.js";
-import { runPreflightCompactionIfNeeded } from "./agent-runner-memory.js";
+import { runSessionCompactionIfNeeded } from "./agent-runner-memory.js";
 import {
   resolveQueuedReplyExecutionConfig,
   resolveQueuedReplyRuntimeConfig,
@@ -374,7 +374,7 @@ export async function admitFollowupTurn(params: {
         : undefined;
     const preflightEntry = session.current();
     try {
-      activeEntry = await runPreflightCompactionIfNeeded({
+      activeEntry = await runSessionCompactionIfNeeded({
         cfg: config,
         followupRun: turn.queued,
         promptForEstimate: turn.queued.prompt,
@@ -384,7 +384,9 @@ export async function admitFollowupTurn(params: {
         sessionKey: replySessionKey,
         storePath: params.defaults.storePath,
         isHeartbeat: params.defaults.opts?.isHeartbeat === true,
-        replyOperation: operation,
+        abortSignal: operation.abortSignal,
+        onCompactionStart: () => operation.setPhase("preflight_compacting"),
+        onSessionIdChanged: (sessionId) => operation.updateSessionId(sessionId),
         onCompactionNotice: notifyPreflightCompaction,
       });
       if (compactionNoticeGenerationInvalidated) {

--- a/src/auto-reply/reply/session-updates.lifecycle.test.ts
+++ b/src/auto-reply/reply/session-updates.lifecycle.test.ts
@@ -187,6 +187,25 @@ describe("session-updates lifecycle hooks", () => {
 
   it("recreates a complete persisted row when compaction updates a missing store row", async () => {
     const { storePath, sessionKey, sessionStore, entry } = await createFixture();
+    entry.contextBudgetStatus = {
+      schemaVersion: 1,
+      source: "pre-prompt-estimate",
+      updatedAt: 1,
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      route: "compact_only",
+      shouldCompact: true,
+      estimatedPromptTokens: 97_000,
+      contextTokenBudget: 96_000,
+      promptBudgetBeforeReserve: 76_000,
+      reserveTokens: 20_000,
+      effectiveReserveTokens: 20_000,
+      remainingPromptBudgetTokens: 0,
+      overflowTokens: 21_000,
+      toolResultReducibleChars: 0,
+      messageCount: 4,
+      unwindowedMessageCount: 4,
+    };
     await applySessionEntryLifecycleMutation({
       storePath,
       removals: [{ sessionKey }],
@@ -217,6 +236,8 @@ describe("session-updates lifecycle hooks", () => {
     expect(persisted?.usageFamilySessionIds).toEqual(["s1", "s2"]);
     expect(persisted?.compactionCount).toBe(1);
     expect(persisted?.totalTokens).toBe(123);
+    expect(persisted?.contextBudgetStatus).toBeUndefined();
+    expect(sessionStore[sessionKey]?.contextBudgetStatus).toBeUndefined();
     expect(persisted?.updatedAt).toBeGreaterThanOrEqual(entry.updatedAt);
   });
 

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -368,6 +368,7 @@ export async function incrementCompactionCount(params: {
   const updates: Partial<SessionEntry> = {
     compactionCount: nextCount,
     updatedAt: now,
+    ...(incrementBy > 0 ? { contextBudgetStatus: undefined } : {}),
   };
   if (compactionKind === "context-engine") {
     clearAllCliSessions(updates);

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1041,6 +1041,14 @@ describe("scripts/test-projects changed-target routing", () => {
   it.each([
     ["src/agents/agent-scope.test.ts", "test/vitest/vitest.agents-core.config.ts"],
     [
+      "src/agents/agent-command.compaction-rotation.test.ts",
+      "test/vitest/vitest.agents-core.config.ts",
+    ],
+    [
+      "src/agents/agent-command.embedded-maintenance.test.ts",
+      "test/vitest/vitest.agents-core.config.ts",
+    ],
+    [
       "src/agents/embedded-agent-runner/run.before-agent-reply-cron.test.ts",
       "test/vitest/vitest.agents-embedded-agent.config.ts",
     ],
@@ -1075,6 +1083,18 @@ describe("scripts/test-projects changed-target routing", () => {
         watchMode: false,
       },
     ]);
+  });
+
+  it("keeps split command compaction and model-switch tests in the runtime owner shard", () => {
+    const targets = [
+      "src/agents/agent-command.compaction-rotation.test.ts",
+      "src/agents/agent-command.embedded-maintenance.test.ts",
+      "src/agents/agent-command.live-model-switch.test.ts",
+    ];
+    expectSingleVitestRunPlan(buildVitestRunPlans(targets), {
+      config: "test/vitest/vitest.agents-core.config.ts",
+      includePatterns: targets,
+    });
   });
 
   it("routes every split incomplete-turn test to its dedicated serial shard", () => {

--- a/test/vitest-unit-fast-config.test.ts
+++ b/test/vitest-unit-fast-config.test.ts
@@ -237,6 +237,14 @@ describe("unit-fast vitest lane", () => {
   });
 
   it("keeps obvious stateful files out of the unit-fast lane", () => {
+    for (const file of [
+      "src/agents/agent-command.compaction-rotation.test.ts",
+      "src/agents/agent-command.embedded-maintenance.test.ts",
+    ]) {
+      expect(isUnitFastTestFile(file), file).toBe(false);
+      expect(resolveUnitFastTestIncludePattern(file), file).toBeNull();
+      expect(resolveUnitFastIsolatedTestIncludePattern(file), file).toBeNull();
+    }
     expect(isUnitFastTestFile("src/plugin-sdk/temp-path.test.ts")).toBe(false);
     expect(isUnitFastTestFile("src/agents/openai-transport-stream.base.test.ts")).toBe(false);
     expect(

--- a/test/vitest/vitest.unit-fast-paths.mjs
+++ b/test/vitest/vitest.unit-fast-paths.mjs
@@ -166,6 +166,10 @@ const broadUnitFastCandidateGlobs = [
 ];
 const ownerRoutedUnitTestPatterns = [
   ...cliProcessTestFiles,
+  // Command compaction tests need the scoped runtime registry even when their
+  // mocks live in a shared helper.
+  "src/agents/agent-command.compaction-rotation.test.ts",
+  "src/agents/agent-command.embedded-maintenance.test.ts",
   "src/agents/embedded-agent-runner/run.incomplete-turn.*.test.ts",
   "src/agents/embedded-agent-runner/run/attempt.abort-race.test.ts",
   "src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts",


### PR DESCRIPTION
Closes #130716

## What Problem This Solves

Fixes an issue where users running repeated built-in `agent --local` commands would keep sending an oversized conversation without proactive compaction when using safeguard mode, including with memory flush disabled. A persisted `contextBudgetStatus` could correctly report pressure while the next command still sent unreduced history.

## Why This Change Was Made

The pressure estimate is intentionally diagnostic, not a compaction command. Normal replies already have a usage-based maintenance owner, but direct commands did not invoke it. This change shares that owner: replies keep pre-turn maintenance, while successful built-in commands compact after transcript persistence and protection of pending final delivery. This prepares reduced context for the next command without rebinding an already-admitted turn.

Maintenance uses the actual completed harness, model, and privately observed auth profile. Native harnesses retain their own compaction; the narrow profile observer does not enable native runtime-artifact capture. Accounting revalidates the caller lifecycle and expected session generation, adopts an owned successor, and clears stale pressure diagnostics. Original provider usage remains separate from subsequent compaction metadata. The old reply-only helper name is removed without an alias; there is no second threshold or compactor.

Ordinary post-turn compaction failures retain the completed local reply only after reloading the authoritative session and checking its identity/revision and the caller's abort/lifecycle state. Canceled, restarted, replaced, or stale work remains fenced. Generic CLI-backend failure behavior is unchanged.

## User Impact

Long-running direct built-in sessions now receive usage-based proactive maintenance, including safeguard mode with memory flush disabled. Explicit `compaction.enabled: false` remains an opt-out. Heartbeats, hidden/raw/model-only runs, incomplete or rebound runs, and turns that already compacted do not receive a second pass. Near the threshold, successful commands can take longer because they now perform the missing summary work; their completed answer is preserved on an ordinary summarization failure.

No new configuration, dependency, SQLite schema, or protocol surface is introduced. Native Codex setup and compaction are unchanged. Documentation: https://docs.openclaw.ai/concepts/compaction and https://docs.openclaw.ai/reference/session-management-compaction.

## Evidence

### Real command and Gateway flows

Fresh isolated HOME/state/config/workspace, actual built CLI and SQLite, public `openai/gpt-5.6-luna` fixture, loopback HTTP mock provider, safeguard, 64,000 active context budget, 128,000 model window, disabled memory flush, and `tools.deny: ["*"]`. All runs recorded zero tool calls. Provider usage and summary text were scripted: this proves execution, persistence, and next-request context, not real model reasoning or server limits.

| Scenario | Compactions after 45,000-token turn | Next request input bytes | Old prefix copies in next request | Completed reply |
| --- | ---: | ---: | ---: | --- |
| Baseline | 0 | 206,876 | 850 | Returned |
| Repaired | 1 | 84,168 | 0 | Returned |
| Explicitly disabled | 0 | 206,890 | 850 | Returned |
| Summary HTTP 503 | 0 | 206,876 | 850 | Returned with warning |

The repaired run recorded 15,686 tokens after compaction, a persisted summary containing the original fact, and a valid retained-history cut point. It cleared the previous pressure diagnostic without rewriting the completed request's 45,000 prompt-token usage. The injected failure retained original history rather than claiming a compaction occurred.

A separate real Gateway `agent` RPC flow passed the same boundary checks, with the next request reduced to 72,835 bytes. Its 30-second Control UI video shows usage progressing from 12k to 24k and then one auto-threshold checkpoint at 45,000 → 15,686 tokens. Paired screenshots show baseline zero checkpoints versus repaired one checkpoint. Every image and decoded video frame set was inspected; all data is synthetic. Only task-owned isolated servers were started, and they have been stopped.

Baseline source: `036e635c71cba06cae81722a803b3e61276d3ab3`. The full build and behavior runs preceded only a behavior-neutral retry-message deduplication and test-suite organization/fixture cleanup; those final changes receive focused tests, static checks, and independent review below. Production configuration, state, credentials, native setup, and running services were never changed.

### Regression, ownership, and validation

The command-boundary regression failed against unchanged production code: expected one shared maintenance invocation, observed zero. Validation also reproduced and fixed loss of an already-successful local reply on ordinary housekeeping failure. The focused owner/sibling suite passed 445 tests across 13 files; subsequent auth/maintenance checks passed 124 tests, and the expanded command boundary passed all 46 cases before being split around one shared fixture.

Coverage includes the 897,999 / 898,000 / 904,869 threshold boundary under a 922,000 active budget, disabled memory flush, actual built-in execution despite configured native runtime, selected/ambient auth, successor adoption, pending-final preservation, abort/restart/revision fencing, and diagnostic invalidation. Existing tests still prove heuristic pressure does not short-circuit provider submission.

The full `pnpm build` passed, including declarations, SDK export/bootstrap guards, and matching Control UI assets; zero ineffective dynamic-import warnings. Earlier test typing and max-lines failures were repaired rather than suppressed or worked around. The test split preserves all 46 command cases and shares one mock/setup owner; owned one-shot mock queues are reset between cases.

Final local verification passed:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/agent-command.compaction-rotation.test.ts src/agents/agent-command.embedded-maintenance.test.ts src/agents/agent-command.live-model-switch.test.ts
```

All 172 tests passed in the canonical `agents-core` shared worker. The routing/config tests (`test/scripts/test-projects.test.ts` and `test/vitest-unit-fast-config.test.ts`) also passed all 299 cases. Their regressions keep both split suites in the runtime-owning lane; no broader metadata mocks or forced test config were used.

```bash
node scripts/check-changed.mjs
```

The full changed-scope check passed, including core/script/test types, full core/scripts lint, schema/legacy-store guards, and zero runtime import cycles. The final fixture-binding adjustment was followed by another successful `pnpm tsgo:core:test`, focused lint on all three fixture/suite files, and the 172-test run above. Final isolated Codex autoreview reported no actionable findings at its configured P0 threshold.

The actual command exercised by the local replay was `node dist/index.js agent --local --session-key agent:main:compaction-proof --message-file <synthetic-turn-file> --thinking off --json`; the Gateway replay used the same CLI without `--local`. Inspected before/after screenshots and the Gateway flow video are attached below. The screenshots inspect the recorded state after the tiny follow-up turn; the checkpoint records the preceding threshold-crossing turn. Exact-head hosted CI is required before landing.

Native ownership was personally checked against upstream Codex commit `d47e5cc0e2bbd35774dff15c83570519735d2ac4`, `codex-rs/core/src/session/context_window.rs:23–90` and `codex-rs/core/src/compact.rs:64–171`. The native artifact-capture coupling was checked in `extensions/codex/src/app-server/run-attempt-connection.ts:77–82` and `extensions/codex/src/app-server/shared-client.ts:769–782`. Stable `v2026.7.1-2` was compared at source level, not replayed as a binary. Provenance (made visible): [#110297 — avoid synthetic overflow in tool-heavy sessions](https://github.com/openclaw/openclaw/pull/110297), authored and merged by @joshavant on 2026-07-20, intentionally removed heuristic synthetic overflow. This repair preserves that policy instead of reverting it.

Size/ownership: production net +154 lines (+224/-70 after discounting a 17-line relocation). Growth implements the previously missing command-maintenance capability, private winning-auth transfer, lifecycle/delivery fences, and result accounting; existing followup context and settlement paths are reused. Tests/support: +1,345/-605 (net +740), including the relocated shared fixture and two suites; test-routing configuration adds 4 lines, separately from runtime production. Configuration surface: added 0, removed 0; the existing direct-command default behavior is repaired, with its explicit opt-out preserved.

Separate follow-up recorded: **Align reply context-pressure diagnostics**. Ordinary reply accounting does not forward the fresh diagnostic like direct-command accounting; this telemetry gap is not the cause of the compaction defect and is not turned into a runtime trigger here. A second named tooling follow-up, **Run explicitly requested untracked tests**, covers disagreement between fast-lane on-demand classification and tracked-only discovery. The empty fast-lane attempt was not counted as proof; both split suites now run through their existing scoped-runtime ownership contract.

![Before: no compaction checkpoint after the local command sequence](https://github.com/user-attachments/assets/54946099-8066-4a0e-a28e-3ca88673c200)

![After: one auto-threshold checkpoint with the preserved summary](https://github.com/user-attachments/assets/a1ad4f11-ddad-48ba-8650-06f1ce70fe28)

https://github.com/user-attachments/assets/2e0c0707-f86a-4a46-a06e-9bbf6f156de4