### PR TITLE
fix: preserve native session ownership during cleanup and attachment

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -255,6 +255,12 @@ sent through the Gateway so it shares the same session-store writer as runtime
 traffic. Use `--store <path>` for explicit offline repair of a legacy store
 selector.
 
+Offline cleanup loads trusted, permitted harness plugins so their session-owned
+resources are reclaimed with the deleted rows, even if the agent now uses a
+different model. Explicitly disabled or untrusted plugins are not run. If their
+resources may remain, cleanup prints a warning on stderr without changing the
+JSON result. Dry runs do not load harness plugins.
+
 `openclaw sessions cleanup --all-agents --dry-run --json`:
 
 ```json

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -1008,6 +1008,10 @@ if another turn or native child is active, wait for it to finish and retry.
 Use [Codex supervision](/plugins/codex-supervision) or native Codex to continue
 threads in a shared user home or on another app-server.
 
+Native child threads controlled by a parent cannot be attached with `/codex
+resume` or `/codex bind`. OpenClaw reports that restriction and keeps the current
+binding. Continue the child through its native parent instead.
+
 Codex cannot replace a thread's dynamic tool catalog during resume. If that
 catalog differs from the current harness tools, its metadata cannot be read,
 or Codex cannot confirm that it applied the configuration, OpenClaw reports

--- a/extensions/codex/src/app-server/client-runtime.test.ts
+++ b/extensions/codex/src/app-server/client-runtime.test.ts
@@ -25,6 +25,7 @@ const {
   claimCodexAppServerLiveThread,
   consumeCodexAppServerLiveThread,
   ensureCodexAppServerClientRuntime,
+  hasCodexAppServerLiveThread,
   isCodexAppServerLiveThreadClaimed,
   protectCodexAppServerLiveThread,
   releaseCodexAppServerLiveThread,
@@ -332,99 +333,125 @@ describe("Codex app-server client runtime", () => {
     expect(isCodexAppServerLiveThreadClaimed(client, "thread-reclaimed")).toBe(false);
   });
 
-  it("blocks same-thread replacement until its claimed unsubscribe is acknowledged", async () => {
-    let acknowledgeUnsubscribe: (() => void) | undefined;
-    const unsubscribeAcknowledged = new Promise<void>((resolve) => {
-      acknowledgeUnsubscribe = resolve;
-    });
-    const request = vi.fn(async (method: string) => {
-      if (method === "thread/unsubscribe") {
-        await unsubscribeAcknowledged;
+  it.each([
+    { claimed: true, unpinDuringRelease: false },
+    { claimed: false, unpinDuringRelease: false },
+    { claimed: false, unpinDuringRelease: true },
+  ])(
+    "blocks same-thread replacement until unsubscribe is acknowledged (claimed: $claimed, unpin: $unpinDuringRelease)",
+    async ({ claimed, unpinDuringRelease }) => {
+      let acknowledgeUnsubscribe: (() => void) | undefined;
+      const unsubscribeAcknowledged = new Promise<void>((resolve) => {
+        acknowledgeUnsubscribe = resolve;
+      });
+      const request = vi.fn(async (method: string) => {
+        if (method === "thread/unsubscribe") {
+          await unsubscribeAcknowledged;
+        }
+        return {};
+      });
+      const client = {
+        request,
+        addCloseHandler: vi.fn(),
+        addNotificationHandler: vi.fn(),
+        addRequestHandler: vi.fn(),
+      } as unknown as CodexAppServerClient;
+      ensureCodexAppServerClientRuntime(client, { agentDir: "/tmp/agent" });
+      const unprotect = unpinDuringRelease
+        ? protectCodexAppServerLiveThread(client, "thread-transition")
+        : undefined;
+      await retainCodexAppServerLiveThread(client, "thread-transition");
+      const previous = claimed
+        ? await consumeCodexAppServerLiveThread(client, "thread-transition")
+        : undefined;
+      const release = () =>
+        previous
+          ? previous.release("thread-transition")
+          : unsubscribeCodexAppServerLiveThread(client, "thread-transition", 5_000);
+      const releasing = release();
+      const duplicateRelease = release();
+      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+      unprotect?.();
+      const overlappingPhysicalRelease = unsubscribeCodexAppServerLiveThread(
+        client,
+        "thread-transition",
+        5_000,
+      );
+      await Promise.resolve();
+      expect(request).toHaveBeenCalledOnce();
+      const replacement = retainCodexAppServerLiveThread(
+        client,
+        "thread-transition",
+        previous?.release,
+      );
+      const blockedClaim = consumeCodexAppServerLiveThread(client, "thread-transition");
+      let replacementPublished = false;
+      void replacement.then(() => {
+        replacementPublished = true;
+      });
+      await Promise.resolve();
+
+      expect(replacementPublished).toBe(false);
+      expect(isCodexAppServerLiveThreadClaimed(client, "thread-transition")).toBe(claimed);
+      acknowledgeUnsubscribe?.();
+
+      await expect(releasing).resolves.toBeUndefined();
+      await expect(duplicateRelease).resolves.toBeUndefined();
+      await expect(overlappingPhysicalRelease).resolves.toBeUndefined();
+      await expect(replacement).resolves.toBe(false);
+      await expect(blockedClaim).resolves.toBeUndefined();
+      await client.request(
+        "thread/resume",
+        { threadId: "thread-transition" },
+        { timeoutMs: 5_000 },
+      );
+      await expect(
+        retainCodexAppServerLiveThread(client, "thread-transition", previous?.release),
+      ).resolves.toBe(true);
+      const successor = await consumeCodexAppServerLiveThread(client, "thread-transition");
+      await successor?.release("thread-transition");
+      expect(request.mock.calls.map(([method]) => method)).toEqual([
+        "thread/unsubscribe",
+        "thread/resume",
+        "thread/unsubscribe",
+      ]);
+    },
+  );
+
+  it.each([false, true])(
+    "finishes a thread when its direct physical unsubscribe succeeds (claimed: %s)",
+    async (claimed) => {
+      const request = vi.fn(async () => ({}));
+      request.mockRejectedValueOnce(new Error("unsubscribe unavailable"));
+      const client = {
+        request,
+        addCloseHandler: vi.fn(),
+        addNotificationHandler: vi.fn(),
+        addRequestHandler: vi.fn(),
+      } as unknown as CodexAppServerClient;
+      ensureCodexAppServerClientRuntime(client, { agentDir: "/tmp/agent" });
+      await retainCodexAppServerLiveThread(client, "thread-direct");
+      if (claimed) {
+        await consumeCodexAppServerLiveThread(client, "thread-direct");
       }
-      return {};
-    });
-    const client = {
-      request,
-      addCloseHandler: vi.fn(),
-      addNotificationHandler: vi.fn(),
-      addRequestHandler: vi.fn(),
-    } as unknown as CodexAppServerClient;
-    ensureCodexAppServerClientRuntime(client, { agentDir: "/tmp/agent" });
-    await retainCodexAppServerLiveThread(client, "thread-transition");
-    const previous = await consumeCodexAppServerLiveThread(client, "thread-transition");
-    const releasing = previous?.release("thread-transition");
-    const duplicateRelease = previous?.release("thread-transition");
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-    const overlappingPhysicalRelease = unsubscribeCodexAppServerLiveThread(
-      client,
-      "thread-transition",
-      5_000,
-    );
-    await Promise.resolve();
-    expect(request).toHaveBeenCalledOnce();
-    const replacement = retainCodexAppServerLiveThread(
-      client,
-      "thread-transition",
-      previous?.release,
-    );
-    const blockedClaim = consumeCodexAppServerLiveThread(client, "thread-transition");
-    let replacementPublished = false;
-    void replacement.then(() => {
-      replacementPublished = true;
-    });
-    await Promise.resolve();
 
-    expect(replacementPublished).toBe(false);
-    expect(isCodexAppServerLiveThreadClaimed(client, "thread-transition")).toBe(true);
-    acknowledgeUnsubscribe?.();
+      const failedRelease = unsubscribeCodexAppServerLiveThread(client, "thread-direct", 5_000);
+      const failedJoin = unsubscribeCodexAppServerLiveThread(client, "thread-direct", 5_000);
+      await expect(Promise.all([failedRelease, failedJoin])).rejects.toThrow(
+        "unsubscribe unavailable",
+      );
+      expect(request).toHaveBeenCalledOnce();
+      expect(hasCodexAppServerLiveThread(client, "thread-direct")).toBe(true);
+      await unsubscribeCodexAppServerLiveThread(client, "thread-direct", 5_000);
 
-    await expect(releasing).resolves.toBeUndefined();
-    await expect(duplicateRelease).resolves.toBeUndefined();
-    await expect(overlappingPhysicalRelease).resolves.toBeUndefined();
-    await expect(replacement).resolves.toBe(false);
-    await expect(blockedClaim).resolves.toBeUndefined();
-    await client.request("thread/resume", { threadId: "thread-transition" }, { timeoutMs: 5_000 });
-    await expect(
-      retainCodexAppServerLiveThread(client, "thread-transition", previous?.release),
-    ).resolves.toBe(true);
-    const successor = await consumeCodexAppServerLiveThread(client, "thread-transition");
-    await successor?.release("thread-transition");
-    expect(request.mock.calls.map(([method]) => method)).toEqual([
-      "thread/unsubscribe",
-      "thread/resume",
-      "thread/unsubscribe",
-    ]);
-  });
-
-  it("finishes a claimed thread when its direct physical unsubscribe succeeds", async () => {
-    const request = vi.fn(async () => ({}));
-    request.mockRejectedValueOnce(new Error("unsubscribe unavailable"));
-    const client = {
-      request,
-      addCloseHandler: vi.fn(),
-      addNotificationHandler: vi.fn(),
-      addRequestHandler: vi.fn(),
-    } as unknown as CodexAppServerClient;
-    ensureCodexAppServerClientRuntime(client, { agentDir: "/tmp/agent" });
-    await retainCodexAppServerLiveThread(client, "thread-direct");
-    await consumeCodexAppServerLiveThread(client, "thread-direct");
-
-    const failedRelease = unsubscribeCodexAppServerLiveThread(client, "thread-direct", 5_000);
-    const failedJoin = unsubscribeCodexAppServerLiveThread(client, "thread-direct", 5_000);
-    await expect(Promise.all([failedRelease, failedJoin])).rejects.toThrow(
-      "unsubscribe unavailable",
-    );
-    expect(request).toHaveBeenCalledOnce();
-    expect(isCodexAppServerLiveThreadClaimed(client, "thread-direct")).toBe(true);
-    await unsubscribeCodexAppServerLiveThread(client, "thread-direct", 5_000);
-
-    expect(request).toHaveBeenLastCalledWith(
-      "thread/unsubscribe",
-      { threadId: "thread-direct" },
-      { timeoutMs: 5_000 },
-    );
-    expect(isCodexAppServerLiveThreadClaimed(client, "thread-direct")).toBe(false);
-  });
+      expect(request).toHaveBeenLastCalledWith(
+        "thread/unsubscribe",
+        { threadId: "thread-direct" },
+        { timeoutMs: 5_000 },
+      );
+      expect(hasCodexAppServerLiveThread(client, "thread-direct")).toBe(false);
+    },
+  );
 
   it("clears claimed ownership when Codex closes the thread or its physical client", async () => {
     const harness = createClientHarness();

--- a/extensions/codex/src/app-server/client-runtime.ts
+++ b/extensions/codex/src/app-server/client-runtime.ts
@@ -311,14 +311,9 @@ export async function retainCodexAppServerLiveThread(
   const pendingRelease = runtime.releasingThreads.get(threadId);
   if (pendingRelease) {
     await pendingRelease.completion;
-    if (
-      runtime.closed ||
-      (claimed !== undefined && runtime.claimedThreads.get(threadId) !== claimed)
-    ) {
-      // The pending operation unsubscribed this exact active generation;
-      // publishing it again without thread/resume would invent ownership.
-      return false;
-    }
+    // The pending operation released this subscription. Publishing it again
+    // without a subsequent thread/resume would invent native ownership.
+    return false;
   }
   runtime.retainedThreads.delete(threadId);
   const retained: RetainedLiveThread = {
@@ -492,7 +487,7 @@ export function isCodexAppServerLiveThreadClaimed(
   return runtime !== undefined && !runtime.closed && runtime.claimedThreads.has(threadId);
 }
 
-/** Release the exact physical subscription and finish only its observed claim generation. */
+/** Release the exact physical subscription and finish only its observed ownership generation. */
 export async function unsubscribeCodexAppServerLiveThread(
   client: CodexAppServerClient,
   threadId: string,
@@ -501,6 +496,7 @@ export async function unsubscribeCodexAppServerLiveThread(
 ): Promise<void> {
   const runtime = configuredClients.get(client);
   const claimed = runtime?.claimedThreads.get(threadId);
+  const retained = runtime?.retainedThreads.get(threadId);
   let transition = runtime?.releasingThreads.get(threadId);
   if (transition?.physicalRelease) {
     await transition.physicalRelease;
@@ -508,7 +504,10 @@ export async function unsubscribeCodexAppServerLiveThread(
     return;
   }
   const physicalRelease = Promise.resolve().then(async () => {
-    if (claimed !== undefined && runtime?.claimedThreads.get(threadId) !== claimed) {
+    if (
+      (claimed !== undefined && runtime?.claimedThreads.get(threadId) !== claimed) ||
+      (retained !== undefined && runtime?.retainedThreads.get(threadId) !== retained)
+    ) {
       return;
     }
     assertCurrent?.();
@@ -525,8 +524,12 @@ export async function unsubscribeCodexAppServerLiveThread(
   }
   try {
     await physicalRelease;
-    // Warm/compaction/native-child cleanup can release directly. Their exact
-    // successful RPC ends only the claim generation observed before it began.
+    // Direct cleanup also owns idle entries; a successful RPC ends only the
+    // retained or claimed generation observed before it began.
+    if (retained !== undefined && runtime?.retainedThreads.get(threadId) === retained) {
+      runtime.retainedThreads.delete(threadId);
+      scheduleRetainedThreadEviction(client, runtime);
+    }
     if (claimed !== undefined && runtime?.claimedThreads.get(threadId) === claimed) {
       runtime.claimedThreads.delete(threadId);
     }
@@ -574,11 +577,9 @@ export function protectCodexAppServerLiveThread(
       if (retained) {
         // A detached child is live activity, not parent idleness. Its terminal
         // delivery starts the parent's normal warm-session retention window.
+        retained.expiresAt = Date.now() + CODEX_APP_SERVER_LIVE_THREAD_IDLE_TIMEOUT_MS;
         runtime.retainedThreads.delete(threadId);
-        runtime.retainedThreads.set(threadId, {
-          ...retained,
-          expiresAt: Date.now() + CODEX_APP_SERVER_LIVE_THREAD_IDLE_TIMEOUT_MS,
-        });
+        runtime.retainedThreads.set(threadId, retained);
       }
     } else {
       runtime.protectedThreads.set(threadId, count - 1);

--- a/extensions/codex/src/app-server/protocol-validators.ts
+++ b/extensions/codex/src/app-server/protocol-validators.ts
@@ -16,6 +16,7 @@ import type {
   CodexDynamicToolCallParams,
   CodexErrorNotification,
   CodexModelListResponse,
+  CodexThread,
   CodexThreadForkResponse,
   CodexThreadForkParams,
   CodexThreadResumeResponse,
@@ -347,6 +348,26 @@ export function assertCodexThreadForkParams(value: unknown): CodexThreadForkPara
 export function assertCodexThreadResumeResponse(value: unknown): CodexThreadResumeResponse {
   const normalized = normalizeWithDefaults(threadResumeResponseSchema, value);
   return assertCodexShape(validateThreadResumeResponse, normalized, "thread/resume response");
+}
+
+export class CodexThreadDirectInputError extends Error {
+  constructor(threadId: string) {
+    super(
+      `Codex thread ${threadId} is controlled by its parent and cannot accept direct input. ` +
+        "Continue its parent thread, or use /new for a separate OpenClaw session.",
+    );
+    this.name = "CodexThreadDirectInputError";
+  }
+}
+
+/** Native V2 children allow observation, but only their parent may supply turn input. */
+export function assertCodexThreadAcceptsDirectInput(
+  thread: Pick<CodexThread, "id" | "canAcceptDirectInput">,
+): void {
+  // Unloaded threads report null; only an explicit native refusal is conclusive.
+  if (thread.canAcceptDirectInput === false) {
+    throw new CodexThreadDirectInputError(thread.id);
+  }
 }
 
 /** Asserts and normalizes a Codex turn/start response. */

--- a/extensions/codex/src/app-server/protocol.ts
+++ b/extensions/codex/src/app-server/protocol.ts
@@ -436,6 +436,7 @@ export type CodexThread = {
   createdAt?: number | null;
   updatedAt?: number | null;
   status?: CodexThreadStatus | null;
+  canAcceptDirectInput?: boolean | null;
   modelProvider?: string | null;
   cwd?: string | null;
   source?: CodexSessionSource | null;

--- a/extensions/codex/src/app-server/request.test.ts
+++ b/extensions/codex/src/app-server/request.test.ts
@@ -429,6 +429,67 @@ describe("requestCodexAppServerJson sandbox guard", () => {
     expect(secondRequest).not.toHaveBeenCalled();
   });
 
+  it("does not resume or publish a control attachment after its passive preflight times out", async () => {
+    const { codexControlRequest } = await import("../command-rpc.js");
+    vi.useFakeTimers();
+    let releasePreflight!: () => void;
+    const preflight = new Promise<void>((resolve) => {
+      releasePreflight = resolve;
+    });
+    const request = vi.fn(async (_method: string) => ({ thread: { id: "thread-1" } }));
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({ request });
+    const onResponse = vi.fn();
+
+    const result = codexControlRequest(
+      {},
+      "thread/resume",
+      { threadId: "thread-1" },
+      {
+        authProfileId: null,
+        timeoutMs: 50,
+        beforeRequest: async (send) => {
+          await send({
+            method: "thread/read",
+            requestParams: { threadId: "thread-1", includeTurns: false },
+          });
+          await preflight;
+        },
+        onResponse,
+      },
+    );
+    const settled = result.then(
+      (value) => ({ status: "fulfilled", value }),
+      (error: unknown) => ({ status: "rejected", error }),
+    );
+    await vi.advanceTimersByTimeAsync(50);
+    expect(await settled).toMatchObject({
+      status: "rejected",
+      error: expect.objectContaining({ message: expect.stringContaining("timed out") }),
+    });
+    releasePreflight();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/read"]);
+    expect(onResponse).not.toHaveBeenCalled();
+    expect(sharedClientMocks.releaseLeasedSharedCodexAppServerClient).toHaveBeenCalledOnce();
+    expect(sharedClientMocks.retireSharedCodexAppServerClientIfCurrent).not.toHaveBeenCalled();
+  });
+
+  it("revokes scoped requests and mutation authority when their client lease ends", async () => {
+    const request = vi.fn(async () => ({ ok: true }));
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({ request });
+    const retained = await withCodexAppServerJsonClient({}, async (send, _client, scope) => {
+      await send({ method: "thread/read", requestParams: { threadId: "thread-1" } });
+      return { send, assertCurrent: scope.assertCurrent };
+    });
+
+    expect(retained.assertCurrent).toThrow();
+    await expect(
+      retained.send({ method: "thread/resume", requestParams: { threadId: "thread-1" } }),
+    ).rejects.toThrow();
+    expect(request).toHaveBeenCalledOnce();
+  });
+
   it("blocks thread starts with sandbox environments when exec host=node is active", async () => {
     const params = {
       cwd: "/workspace",

--- a/extensions/codex/src/app-server/request.ts
+++ b/extensions/codex/src/app-server/request.ts
@@ -108,6 +108,14 @@ export type CodexAppServerScopedRequest = <T = JsonValue | undefined>(request: {
   requestParams?: unknown;
 }) => Promise<T>;
 
+/** A scoped guard rejected the request before it reached the physical client. */
+export class CodexAppServerScopedRequestRejectedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CodexAppServerScopedRequestRejectedError";
+  }
+}
+
 const CODEX_USAGE_ISOLATED_SHUTDOWN = { forceKillDelayMs: 200, exitTimeoutMs: 300 } as const;
 const CODEX_ACCOUNT_READ_MAX_TIMEOUT_MS = 4_000;
 const CODEX_ACCOUNT_READ_DEADLINE_MARGIN_MS = 250;
@@ -200,7 +208,11 @@ export async function withCodexAppServerJsonClient<T>(
     // to the conservative graceful/force-kill window used elsewhere.
     isolatedShutdown?: { exitTimeoutMs?: number; forceKillDelayMs?: number };
   },
-  run: (request: CodexAppServerScopedRequest, client: CodexAppServerClient) => Promise<T>,
+  run: (
+    request: CodexAppServerScopedRequest,
+    client: CodexAppServerClient,
+    scope: { assertCurrent: () => void },
+  ) => Promise<T>,
 ): Promise<T> {
   const timeoutMs = params.timeoutMs ?? 60_000;
   const timeoutMessage = params.timeoutMessage ?? "codex app-server request timed out";
@@ -209,7 +221,7 @@ export async function withCodexAppServerJsonClient<T>(
   const isPastDeadline = () => deadline !== undefined && Date.now() >= deadline;
   const throwIfAbandoned = () => {
     if (timeoutController.signal.aborted || isPastDeadline()) {
-      throw new Error(timeoutMessage);
+      throw new CodexAppServerScopedRequestRejectedError(timeoutMessage);
     }
   };
   const remainingTimeoutMs = () => {
@@ -238,8 +250,17 @@ export async function withCodexAppServerJsonClient<T>(
             config: params.config,
             abandonSignal: timeoutController.signal,
           });
-          try {
+          let scopeActive = true;
+          const assertCurrent = () => {
             throwIfAbandoned();
+            if (!scopeActive) {
+              throw new CodexAppServerScopedRequestRejectedError(
+                "Codex app-server request scope is closed",
+              );
+            }
+          };
+          try {
+            assertCurrent();
             const scopedRequest: CodexAppServerScopedRequest = async <R>(request: {
               method: string;
               requestParams?: unknown;
@@ -252,15 +273,16 @@ export async function withCodexAppServerJsonClient<T>(
                 sessionId: params.sessionId,
               });
               if (sandboxBlock) {
-                throw new Error(sandboxBlock);
+                throw new CodexAppServerScopedRequestRejectedError(sandboxBlock);
               }
-              throwIfAbandoned();
+              assertCurrent();
               return await client.request<R>(request.method, request.requestParams, {
                 timeoutMs: remainingTimeoutMs(),
                 signal: timeoutController.signal,
+                assertCurrent,
               });
             };
-            return await run(scopedRequest, client);
+            return await run(scopedRequest, client, { assertCurrent });
           } catch (error) {
             if (!isCodexAppServerStartSelectionChangedError(error) || attempt > 0) {
               throw error;
@@ -270,6 +292,7 @@ export async function withCodexAppServerJsonClient<T>(
             }
             throwIfAbandoned();
           } finally {
+            scopeActive = false;
             if (params.isolated) {
               // Wait for the child to actually exit (with a SIGKILL fallback) so
               // the parent process doesn't hang on an orphaned codex app-server.

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -628,14 +628,20 @@ export function releaseCodexAppServerClientLease(lease: CodexAppServerClientLeas
   return client ? releaseLeasedSharedCodexAppServerClient(client) : false;
 }
 
-/** Retries one config-loading request after moving its lease to the current owner. */
+export type CodexAppServerLeasedRequestOptions = {
+  timeoutMs: number;
+  signal?: AbortSignal;
+  assertCurrent: () => void;
+};
+
+/** Retries one config-loading operation with a shared deadline and current client lease. */
 export async function withLeasedCodexAppServerClientStartSelectionRetry<T>(params: {
   lease: CodexAppServerClientLease;
   options?: CodexAppServerClientOptions;
   signal?: AbortSignal;
   run: (
     client: CodexAppServerClient,
-    requestOptions: { timeoutMs: number; signal?: AbortSignal },
+    requestOptions: () => CodexAppServerLeasedRequestOptions,
   ) => Promise<T>;
   onClientChange: (client: CodexAppServerClient) => void;
 }): Promise<T> {
@@ -663,8 +669,21 @@ export async function withLeasedCodexAppServerClientStartSelectionRetry<T>(param
     };
   };
   for (let attempt = 0; attempt < 2; attempt += 1) {
+    const attemptClient = client;
+    let scopeActive = true;
+    const assertCurrent = () => {
+      if (!scopeActive || params.lease.client !== attemptClient) {
+        throw new CodexAppServerStartupError("aborted", "Codex app-server request scope is closed");
+      }
+    };
     try {
-      return await params.run(client, requestOptions());
+      requestOptions();
+      return await params.run(client, () => {
+        assertCurrent();
+        // Sample the deadline before each request or commit. Cleanup keeps the
+        // lease-only assertion so an accepted native operation can finish safely.
+        return { ...requestOptions(), assertCurrent };
+      });
     } catch (error) {
       if (!isCodexAppServerStartSelectionChangedError(error) || attempt > 0) {
         throw error;
@@ -687,6 +706,8 @@ export async function withLeasedCodexAppServerClientStartSelectionRetry<T>(param
       });
       params.lease.client = client;
       params.onClientChange(client);
+    } finally {
+      scopeActive = false;
     }
   }
   throw new Error("Codex app-server selection retry loop exited unexpectedly");

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -44,16 +44,16 @@ type SelectionRetryParams = {
   options: { timeoutMs?: number; abandonSignal?: AbortSignal };
   run: (
     client: unknown,
-    requestOptions: { timeoutMs: number; signal?: AbortSignal },
+    requestOptions: () => { timeoutMs: number; signal?: AbortSignal },
   ) => Promise<unknown>;
   onClientChange: (client: unknown) => void;
 };
 const withLeasedCodexAppServerClientStartSelectionRetryMock = vi.fn(
   async (params: SelectionRetryParams) =>
-    await params.run(params.lease.client, {
+    await params.run(params.lease.client, () => ({
       timeoutMs: params.options.timeoutMs ?? 60_000,
       signal: params.options.abandonSignal,
-    }),
+    })),
 );
 
 function supervisionConnectionFingerprint(): string {
@@ -549,10 +549,10 @@ describe("runCodexAppServerSideQuestion", () => {
     withLeasedCodexAppServerClientStartSelectionRetryMock.mockReset();
     withLeasedCodexAppServerClientStartSelectionRetryMock.mockImplementation(
       async (params: SelectionRetryParams) =>
-        await params.run(params.lease.client, {
+        await params.run(params.lease.client, () => ({
           timeoutMs: params.options.timeoutMs ?? 60_000,
           signal: params.options.abandonSignal,
-        }),
+        })),
     );
     resolveCodexProviderWebSearchSupportForClientMock.mockResolvedValue("supported");
 
@@ -982,10 +982,10 @@ describe("runCodexAppServerSideQuestion", () => {
         expect(params.lease.client).toBe(initialClient);
         params.lease.client = replacementClient;
         params.onClientChange(replacementClient);
-        return await params.run(replacementClient, {
+        return await params.run(replacementClient, () => ({
           timeoutMs: params.options.timeoutMs ?? 60_000,
           signal: params.options.abandonSignal,
-        });
+        }));
       },
     );
 

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -756,7 +756,7 @@ export async function runCodexAppServerSideQuestion(
               ephemeral: true,
               threadSource: "user",
             },
-            requestOptions,
+            requestOptions(),
           );
         },
         onClientChange: rebindClientHandlers,

--- a/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-adoption.ts
@@ -7,6 +7,7 @@ import {
 } from "./auth-start-options.js";
 import { isCodexAppServerLiveThreadClaimed } from "./client-runtime.js";
 import { resolveCodexAppServerClientInstanceId } from "./client.js";
+import { assertCodexThreadAcceptsDirectInput } from "./protocol-validators.js";
 import { isJsonObject } from "./protocol.js";
 import {
   sessionBindingIdentity,
@@ -17,7 +18,10 @@ import { captureExclusiveSharedCodexAppServerClient } from "./shared-client.js";
 import { shouldRotateCodexGpt56MultiAgentBinding } from "./thread-binding-policy.js";
 import { isContextEngineBindingCompatible } from "./thread-context-engine.js";
 import { codexDynamicToolsFingerprint } from "./thread-fingerprints.js";
-import { CodexThreadBindingConflictError } from "./thread-lifecycle-errors.js";
+import {
+  CodexAdoptedThreadActiveError,
+  CodexThreadBindingConflictError,
+} from "./thread-lifecycle-errors.js";
 import { resolveCodexThreadAgentDir, resumeExistingCodexThread } from "./thread-lifecycle-io.js";
 import type {
   CodexAppServerThreadLifecycleBinding,
@@ -26,6 +30,26 @@ import type {
 } from "./thread-lifecycle-types.js";
 import { releaseCodexConsumedLiveThread } from "./thread-lifecycle-warm.js";
 import { withExclusiveCodexAppServerThread } from "./thread-ownership.js";
+
+/** Passive refusal must precede releasing or acquiring any native subscription. */
+export async function assertAdoptedCodexThreadResumeAllowed(
+  params: CodexStartOrResumeThreadParams,
+  threadId: string,
+  context: Pick<CodexThreadRequestContext, "lifecycleTiming" | "throwIfAborted">,
+): Promise<void> {
+  const { thread } = await context.lifecycleTiming.measure("thread-read-adoption-status", () =>
+    params.client.request(
+      "thread/read",
+      { threadId, includeTurns: false },
+      { signal: params.signal },
+    ),
+  );
+  context.throwIfAborted();
+  assertCodexThreadAcceptsDirectInput(thread);
+  if (thread.status?.type === "active") {
+    throw new CodexAdoptedThreadActiveError();
+  }
+}
 
 /** Preserve attach's native-queue-before-binding-lease order when consuming pending intent. */
 export async function withCodexThreadLifecycleBinding(
@@ -180,6 +204,7 @@ async function preparePendingCodexThreadResume(
   if (thread.id !== binding.threadId || (statusType !== "idle" && statusType !== "notLoaded")) {
     throw fail("the native thread is not idle; wait for its current run to finish");
   }
+  assertCodexThreadAcceptsDirectInput(thread);
   let unloaded = statusType === "notLoaded";
   const dispose = params.client.addNotificationHandler((notification) => {
     if (

--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -27,7 +27,11 @@ import {
   mergeCodexThreadConfigs,
   type CodexPluginThreadConfig,
 } from "./plugin-thread-config.js";
-import { assertCodexThreadStartResponse } from "./protocol-validators.js";
+import {
+  assertCodexThreadAcceptsDirectInput,
+  assertCodexThreadStartResponse,
+  CodexThreadDirectInputError,
+} from "./protocol-validators.js";
 import type { CodexThread, JsonObject } from "./protocol.js";
 import type { CodexAppServerThreadBinding } from "./session-binding.js";
 import {
@@ -191,19 +195,6 @@ export async function resumeExistingCodexThread(
     // Keep ownership accounting atomic with the resume request: a
     // pre-aborted request retains no subscription, so it must not reserve.
     throwIfAborted();
-    if (resumeBinding.preserveNativeModel === true) {
-      const current = await lifecycleTiming.measure("thread-read-adoption-status", () =>
-        params.client.request(
-          "thread/read",
-          { threadId: resumeBinding.threadId, includeTurns: false },
-          { signal: params.signal },
-        ),
-      );
-      throwIfAborted();
-      if (current.thread.status?.type === "active") {
-        throw new CodexAdoptedThreadActiveError();
-      }
-    }
     resumeReservation = params.reserveResumeThread?.(resumeBinding.threadId);
     const response = await lifecycleTiming.measure("thread-resume-request", () =>
       resumeCodexAppServerThread({
@@ -218,6 +209,7 @@ export async function resumeExistingCodexThread(
       }),
     );
     resumeResponseAccepted = true;
+    assertCodexThreadAcceptsDirectInput(response.thread);
     context.assertResumeConfiguration?.();
     if (resumeBinding.pendingResumeConfiguration) {
       await attestCodexPluginThreadApps({
@@ -395,7 +387,11 @@ export async function resumeExistingCodexThread(
         );
       }
     }
-    if (resumeBinding.pendingResumeConfiguration || params.signal?.aborted) {
+    if (
+      resumeBinding.pendingResumeConfiguration ||
+      error instanceof CodexThreadDirectInputError ||
+      params.signal?.aborted
+    ) {
       throw error;
     }
     embeddedAgentLog.warn("codex app-server thread resume failed; starting a new thread", {

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -35,6 +35,7 @@ import {
   shouldStartTransientNoToolThread,
 } from "./thread-fingerprints.js";
 import {
+  assertAdoptedCodexThreadResumeAllowed,
   resumePendingCodexThread,
   withCodexThreadLifecycleBinding,
 } from "./thread-lifecycle-adoption.js";
@@ -680,6 +681,11 @@ export async function startOrResumeThread(
         });
         if (warmReuse.binding) {
           return warmReuse.binding;
+        }
+        // Native adoption must be checked before releasing any retained owner;
+        // a passive refusal neither acquires nor authorizes dropping a subscription.
+        if (binding.preserveNativeModel === true) {
+          await assertAdoptedCodexThreadResumeAllowed(params, binding.threadId, requestContext);
         }
         // Codex cold-resumes a changed idle thread after its last subscriber
         // leaves; resume_running_thread shuts down the old cached session.

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -313,6 +313,7 @@ async function createManualResumeFixture(
     omitCatalog?: boolean;
     competingLease?: "read" | "release" | "resume";
     wireClient?: boolean;
+    parentControlledAfterAttach?: boolean;
   } = {},
 ) {
   const dynamicTools = options.dynamicTools ?? [];
@@ -358,6 +359,9 @@ async function createManualResumeFixture(
       return {
         thread: {
           ...thread,
+          ...(options.parentControlledAfterAttach && resumes > 0
+            ? { canAcceptDirectInput: false }
+            : {}),
           status: options.active
             ? { type: "active", activeFlags: [] }
             : { type: options.cold ? "notLoaded" : "idle" },
@@ -438,10 +442,22 @@ async function createManualResumeFixture(
     resolveCodexCommandDeps({
       bindingStore: testCodexAppServerBindingStore,
       codexControlRequest: async (_pluginConfig, method, requestParams, requestOptions) => {
+        await requestOptions?.beforeRequest?.(
+          <T>({
+            method: preflightMethod,
+            requestParams: preflightParams,
+          }: {
+            method: string;
+            requestParams?: unknown;
+          }) => client.request<T>(preflightMethod, preflightParams, { timeoutMs: 60_000 }),
+        );
         const result = await client.request<JsonValue>(method, requestParams, {
           timeoutMs: 60_000,
         });
-        await requestOptions?.onResponse?.(result, client, { authProfileId: undefined });
+        await requestOptions?.onResponse?.(result, client, {
+          authProfileId: undefined,
+          assertCurrent: () => undefined,
+        });
         return result;
       },
     }),
@@ -957,7 +973,13 @@ describe("Codex app-server thread lifecycle bindings", () => {
           fixture.request.mock.calls
             .map(([method]) => method)
             .filter((method) => method !== "skills/list"),
-        ).toEqual(["thread/resume", "thread/read", "thread/unsubscribe", "thread/resume"]);
+        ).toEqual([
+          "thread/read",
+          "thread/resume",
+          "thread/read",
+          "thread/unsubscribe",
+          "thread/resume",
+        ]);
       } finally {
         fixture.close();
       }
@@ -976,6 +998,10 @@ describe("Codex app-server thread lifecycle bindings", () => {
       error: "immutable native tool catalog",
     },
     { options: { active: true }, error: "native thread is not idle" },
+    {
+      options: { parentControlledAfterAttach: true },
+      error: "controlled by its parent",
+    },
   ])(
     "preserves pending manual resume when native configuration cannot be attested: $options",
     async ({ options, error }) => {
@@ -1024,7 +1050,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
           fixture.request.mock.calls
             .map(([method]) => method)
             .filter((method) => method !== "skills/list"),
-        ).toEqual(["thread/resume"]);
+        ).toEqual(["thread/read", "thread/resume"]);
       } finally {
         fixture.close();
       }
@@ -1163,7 +1189,10 @@ describe("Codex app-server thread lifecycle bindings", () => {
       });
       release.resolve();
       await expect(starting).rejects.toThrow("acquiring a pending resume configuration");
-      expect(fixture.request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+      expect(fixture.request.mock.calls.map(([method]) => method)).toEqual([
+        "thread/read",
+        "thread/resume",
+      ]);
     } finally {
       release.resolve();
       await blocker;

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -7,7 +7,12 @@ import { GPT5_BEHAVIOR_CONTRACT as CODEX_GPT5_BEHAVIOR_CONTRACT } from "openclaw
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { codexCatalogHomeId } from "../session-catalog-home-id.js";
 import { resolveCodexAppServerHomeDir } from "./auth-start-options.js";
+import {
+  ensureCodexAppServerClientRuntime,
+  retainCodexAppServerLiveThread,
+} from "./client-runtime.js";
 import { CodexAppServerRpcError } from "./client.js";
+import { createFakeCodexAppServerClient } from "./codex-app-server.test-fixtures.js";
 import { createCodexTestHostCapabilities } from "./host-capability.test-support.js";
 import { buildCodexAppServerConnectionFingerprint } from "./plugin-app-cache-key.js";
 import type { CodexPluginThreadConfig } from "./plugin-thread-config.js";
@@ -3344,38 +3349,62 @@ describe("Codex app-server adopted thread lifecycle", () => {
     });
   });
 
-  it("rejects an adopted thread that is active in another runner before reserving it", async () => {
-    const sessionFile = path.join(tempDir, "session.jsonl");
-    const workspaceDir = path.join(tempDir, "workspace");
-    const params = createThreadLifecycleParams(sessionFile, workspaceDir);
-    const { threadId } = await seedAdoptedThreadBinding(params, workspaceDir);
-    const request = vi.fn(async (method: string, _requestParams?: unknown) => {
-      if (method === "thread/read") {
-        return {
-          thread: {
-            ...threadStartResult(threadId).thread,
-            status: { type: "active" },
-          },
-        };
+  it.each([
+    { status: "active", canAcceptDirectInput: true, error: "active in another runner" },
+    { status: "idle", canAcceptDirectInput: false, error: "controlled by its parent" },
+  ])(
+    "preserves retained adopted ownership when native preflight rejects: $status",
+    async ({ status, canAcceptDirectInput, error }) => {
+      const sessionFile = path.join(tempDir, "session.jsonl");
+      const workspaceDir = path.join(tempDir, "workspace");
+      const params = createThreadLifecycleParams(sessionFile, workspaceDir);
+      const { identity, threadId } = await seedAdoptedThreadBinding(params, workspaceDir);
+      const harness = createFakeCodexAppServerClient(async (method: string) => {
+        if (method === "thread/read") {
+          return {
+            thread: {
+              ...threadStartResult(threadId).thread,
+              status: { type: status },
+              canAcceptDirectInput,
+            },
+          };
+        }
+        if (method === "thread/unsubscribe") {
+          return { status: "unsubscribed" };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      });
+      ensureCodexAppServerClientRuntime(harness.client, { agentDir: workspaceDir });
+      await testCodexAppServerBindingStore.mutate(identity, {
+        kind: "patch",
+        threadId,
+        patch: { clientId: harness.client.getInstanceId() },
+      });
+      const release = vi.fn();
+      await retainCodexAppServerLiveThread(harness.client, threadId, release);
+      const reserveResumeThread = vi.fn(() => ({ release: vi.fn() }));
+      const before = await testCodexAppServerBindingStore.read(identity);
+      try {
+        await expect(
+          startOrResumeThread({
+            client: harness.client,
+            reserveResumeThread,
+            params,
+            cwd: workspaceDir,
+            dynamicTools: [],
+            appServer: createThreadLifecycleAppServerOptions(),
+          }),
+        ).rejects.toThrow(error);
+
+        expect(harness.request.mock.calls.map(([method]) => method)).toEqual(["thread/read"]);
+        expect(release).not.toHaveBeenCalled();
+        expect(await testCodexAppServerBindingStore.read(identity)).toEqual(before);
+        expect(reserveResumeThread).not.toHaveBeenCalled();
+      } finally {
+        harness.close();
       }
-      throw new Error(`unexpected method: ${method}`);
-    });
-    const reserveResumeThread = vi.fn(() => ({ release: vi.fn() }));
-
-    await expect(
-      startOrResumeThread({
-        client: { request } as never,
-        reserveResumeThread,
-        params,
-        cwd: workspaceDir,
-        dynamicTools: [],
-        appServer: createThreadLifecycleAppServerOptions(),
-      }),
-    ).rejects.toThrow("active in another runner");
-
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/read"]);
-    expect(reserveResumeThread).not.toHaveBeenCalled();
-  });
+    },
+  );
 });
 
 describe("Codex app-server supervised branch lifecycle", () => {

--- a/extensions/codex/src/app-server/thread-ownership.ts
+++ b/extensions/codex/src/app-server/thread-ownership.ts
@@ -125,16 +125,24 @@ export async function rollbackCodexAppServerBindingSubscription(
 /** Releases only the physical client and native thread recorded by the displaced binding owner. */
 export async function releaseCodexAppServerBindingSubscription(
   binding: Pick<CodexAppServerThreadBinding, "threadId" | "clientId">,
-  options: { allowUntracked?: boolean } = {},
+  options: { allowUntracked?: boolean; assertCurrent?: () => void } = {},
 ): Promise<void> {
+  options.assertCurrent?.();
   const clientLease = retainSharedCodexAppServerClientByInstanceId(binding.clientId);
   if (!clientLease) {
     return;
   }
   try {
-    if (await releaseCodexAppServerLiveThread(clientLease.client, binding.threadId)) {
+    if (
+      await releaseCodexAppServerLiveThread(
+        clientLease.client,
+        binding.threadId,
+        options.assertCurrent,
+      )
+    ) {
       return;
     }
+    options.assertCurrent?.();
     // Evicted idle owners also disappear from the registry. Only an explicit
     // claimed generation proves an active turn still owns its subscription.
     if (isCodexAppServerLiveThreadClaimed(clientLease.client, binding.threadId)) {
@@ -148,6 +156,7 @@ export async function releaseCodexAppServerBindingSubscription(
     const unsubscribed = await unsubscribeCodexThreadBestEffort(clientLease.client, {
       threadId: binding.threadId,
       timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+      assertCurrent: options.assertCurrent,
     });
     if (!unsubscribed) {
       await closeCodexStartupClientBestEffort(clientLease.client);

--- a/extensions/codex/src/app-server/thread-resume.ts
+++ b/extensions/codex/src/app-server/thread-resume.ts
@@ -5,6 +5,7 @@ import {
   CodexAppServerUnsafeSubscriptionError,
   unsubscribeCodexThreadBestEffort,
 } from "./attempt-client-cleanup.js";
+import { isCodexAppServerStartupError } from "./attempt-timeouts.js";
 import {
   CodexAppServerRpcError,
   isCodexAppServerOverloadError,
@@ -13,6 +14,7 @@ import {
 } from "./client.js";
 import { assertCodexThreadResumeResponse } from "./protocol-validators.js";
 import type { CodexThreadResumeParams, CodexThreadResumeResponse } from "./protocol.js";
+import { CodexAppServerScopedRequestRejectedError } from "./request.js";
 import { isCodexAppServerStartSelectionChangedError } from "./shared-client.js";
 
 /** Resumes one thread, releasing or isolating every possible native subscription. */
@@ -26,22 +28,27 @@ export async function resumeCodexAppServerThread(params: {
   /** Identifies ownership rejection by the request's physical pre-write fence only. */
   isPrewriteOwnershipError?: (error: unknown) => boolean;
   onSubscriptionReleased?: () => void;
+  requestResume?: (request: CodexThreadResumeParams) => Promise<unknown>;
 }): Promise<CodexThreadResumeResponse> {
   const threadId = params.request.threadId;
   let response: CodexThreadResumeResponse;
   try {
     response = assertCodexThreadResumeResponse(
-      await params.client.request("thread/resume", params.request, {
-        ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
-        ...(params.signal ? { signal: params.signal } : {}),
-        assertCurrent: params.assertCurrent,
-      }),
+      await (params.requestResume
+        ? params.requestResume(params.request)
+        : params.client.request("thread/resume", params.request, {
+            ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+            ...(params.signal ? { signal: params.signal } : {}),
+            assertCurrent: params.assertCurrent,
+          })),
     );
     assertCodexThreadResumeSubscription(threadId, response.thread.id);
   } catch (error) {
     if (
       params.isPrewriteOwnershipError?.(error) ||
       isCodexAppServerStartSelectionChangedError(error) ||
+      isCodexAppServerStartupError(error) ||
+      error instanceof CodexAppServerScopedRequestRejectedError ||
       isCodexAppServerPrewriteRequestCancellationError(error) ||
       isCodexAppServerOverloadError(error)
     ) {

--- a/extensions/codex/src/command-handler-bindings.ts
+++ b/extensions/codex/src/command-handler-bindings.ts
@@ -5,10 +5,19 @@ import {
 } from "openclaw/plugin-sdk/model-session-runtime";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
-import { consumeCodexAppServerLiveThread } from "./app-server/client-runtime.js";
+import { closeCodexStartupClientBestEffort } from "./app-server/attempt-client-cleanup.js";
+import {
+  consumeCodexAppServerLiveThread,
+  hasCodexAppServerLiveThread,
+  type CodexAppServerLiveThreadOwnership,
+} from "./app-server/client-runtime.js";
 import type { CodexAppServerClient } from "./app-server/client.js";
 import { isCodexFastServiceTier } from "./app-server/config.js";
-import { assertCodexThreadResumeResponse } from "./app-server/protocol-validators.js";
+import {
+  assertCodexThreadAcceptsDirectInput,
+  assertCodexThreadResumeResponse,
+} from "./app-server/protocol-validators.js";
+import type { CodexThread } from "./app-server/protocol.js";
 import {
   assertCodexBindingMayBeReplaced,
   createCodexSessionGenerationSupersededError,
@@ -348,7 +357,7 @@ export async function resumeThread(
         const commitResumedThread = async (
           value: unknown,
           client: CodexAppServerClient,
-          { authProfileId }: { authProfileId?: string },
+          { authProfileId, assertCurrent }: { authProfileId?: string; assertCurrent: () => void },
         ) => {
           const response = assertCodexThreadResumeResponse(value);
           const effectiveThreadId = response.thread.id;
@@ -367,33 +376,39 @@ export async function resumeThread(
             agentDir: scope.agentDir,
             config: ctx.config,
           });
-          const bindingBeforeCommit = await deps.bindingStore.read(identity);
-          assertCodexBindingMayBeReplaced(
-            bindingBeforeCommit,
-            "committing a different resumed thread",
-          );
           const clientId = client.getInstanceId();
-          const sameOwner = isSameCodexAppServerThreadOwner(bindingBeforeCommit, {
-            threadId: effectiveThreadId,
-            clientId,
-          });
-          const sameThreadBinding =
-            bindingBeforeCommit?.threadId === effectiveThreadId ? bindingBeforeCommit : undefined;
-          pendingResumeConfiguration =
-            sameThreadBinding?.preserveNativeModel !== true &&
-            (!sameThreadBinding?.dynamicToolsFingerprint ||
-              !sameThreadBinding.webSearchThreadConfigFingerprint ||
-              sameThreadBinding.pendingResumeConfiguration === true);
           let retained = false;
+          let sameOwner = false;
+          let knownOwnership: CodexAppServerLiveThreadOwnership | undefined;
           try {
-            const knownOwnership = sameOwner
+            const bindingBeforeCommit = await deps.bindingStore.read(identity);
+            assertCodexBindingMayBeReplaced(
+              bindingBeforeCommit,
+              "committing a different resumed thread",
+            );
+            sameOwner = isSameCodexAppServerThreadOwner(bindingBeforeCommit, {
+              threadId: effectiveThreadId,
+              clientId,
+            });
+            const sameThreadBinding =
+              bindingBeforeCommit?.threadId === effectiveThreadId ? bindingBeforeCommit : undefined;
+            pendingResumeConfiguration =
+              sameThreadBinding?.preserveNativeModel !== true &&
+              (!sameThreadBinding?.dynamicToolsFingerprint ||
+                !sameThreadBinding.webSearchThreadConfigFingerprint ||
+                sameThreadBinding.pendingResumeConfiguration === true);
+            assertCurrent();
+            assertCodexThreadAcceptsDirectInput(response.thread);
+            knownOwnership = sameOwner
               ? await consumeCodexAppServerLiveThread(client, effectiveThreadId)
               : undefined;
+            assertCurrent();
             retained = await retainCodexAppServerBindingSubscription(
               client,
               effectiveThreadId,
               knownOwnership,
             );
+            assertCurrent();
             if (!retained) {
               throw new Error("Codex resumed thread lost its native subscription owner.");
             }
@@ -402,26 +417,45 @@ export async function resumeThread(
               // is gone; otherwise another session can claim and lose it.
               await releaseCodexAppServerBindingSubscription(bindingBeforeCommit);
             }
-            const committed = await deps.bindingStore.mutate(identity, {
-              kind: "set",
-              binding: {
-                ...sameThreadBinding,
-                threadId: effectiveThreadId,
-                clientId,
-                cwd: resumedCwd,
-                rolloutPath: response.thread.path ?? sameThreadBinding?.rolloutPath,
-                pendingResumeConfiguration: pendingResumeConfiguration ? true : undefined,
-                authProfileId,
-                model: response.model,
-                modelProvider,
-                historyCoveredThrough: new Date().toISOString(),
+            assertCurrent();
+            const committed = await deps.bindingStore.mutate(
+              identity,
+              {
+                kind: "set",
+                binding: {
+                  ...sameThreadBinding,
+                  threadId: effectiveThreadId,
+                  clientId,
+                  cwd: resumedCwd,
+                  rolloutPath: response.thread.path ?? sameThreadBinding?.rolloutPath,
+                  pendingResumeConfiguration: pendingResumeConfiguration ? true : undefined,
+                  authProfileId,
+                  model: response.model,
+                  modelProvider,
+                  historyCoveredThrough: new Date().toISOString(),
+                },
               },
-            });
+              assertCurrent,
+            );
             if (!committed) {
               throw new Error("Codex thread binding changed while attaching the resumed thread.");
             }
           } catch (error) {
-            if (!sameOwner) {
+            if (sameOwner && knownOwnership && !retained) {
+              // Deadline expiry after consuming an idle owner must restore its exact claim.
+              if (
+                !(await retainCodexAppServerBindingSubscription(
+                  client,
+                  effectiveThreadId,
+                  knownOwnership,
+                ))
+              ) {
+                await closeCodexStartupClientBestEffort(client);
+              }
+            } else if (
+              (retained && !sameOwner) ||
+              !hasCodexAppServerLiveThread(client, effectiveThreadId)
+            ) {
               await rollbackCodexAppServerBindingSubscription(client, effectiveThreadId, retained);
             }
             throw error;
@@ -441,6 +475,13 @@ export async function resumeThread(
             authProfileId: currentBinding?.authProfileId,
             sessionKey: ctx.sessionKey,
             sessionId: ctx.sessionId,
+            beforeRequest: async (request) => {
+              const { thread } = await request<{ thread: CodexThread }>({
+                method: "thread/read",
+                requestParams: { threadId: normalizedThreadId, includeTurns: false },
+              });
+              assertCodexThreadAcceptsDirectInput(thread);
+            },
             onResponse: commitResumedThread,
           },
         );

--- a/extensions/codex/src/command-rpc.test.ts
+++ b/extensions/codex/src/command-rpc.test.ts
@@ -25,7 +25,8 @@ import { codexControlRequest, type CodexControlRequestOptions } from "./command-
 const requestCodexAppServerJsonMock = vi.hoisted(() => vi.fn());
 const withCodexAppServerJsonClientMock = vi.hoisted(() => vi.fn());
 
-vi.mock("./app-server/request.js", () => ({
+vi.mock("./app-server/request.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./app-server/request.js")>()),
   requestCodexAppServerJson: requestCodexAppServerJsonMock,
   withCodexAppServerJsonClient: withCodexAppServerJsonClientMock,
 }));
@@ -37,6 +38,29 @@ describe("Codex command RPC helpers", () => {
   let harness: ReturnType<typeof createClientHarness>;
   let previousPluginRegistry: ReturnType<typeof getActivePluginRegistry>;
   const sessionKey = "agent:main:control";
+  const resumeResponse = {
+    thread: {
+      id: "thread-1",
+      sessionId: "session-1",
+      projectId: null,
+      cliVersion: "0.150.1",
+      createdAt: 1,
+      updatedAt: 1,
+      cwd: "/repo",
+      ephemeral: false,
+      modelProvider: "openai",
+      preview: "",
+      source: "appServer",
+      status: { type: "idle" },
+      turns: [],
+    },
+    model: "gpt-5.5",
+    modelProvider: "openai",
+    cwd: "/repo",
+    approvalPolicy: "never",
+    approvalsReviewer: "user",
+    sandbox: { type: "dangerFullAccess" },
+  };
 
   beforeEach(async () => {
     previousPluginRegistry = getActivePluginRegistry();
@@ -57,13 +81,16 @@ describe("Codex command RPC helpers", () => {
     setAuthStore({ version: 1, profiles: {} });
     harness = createClientHarness();
     requestCodexAppServerJsonMock.mockReset();
-    requestCodexAppServerJsonMock.mockResolvedValue({ thread: { id: "thread-1" } });
+    requestCodexAppServerJsonMock.mockResolvedValue(resumeResponse);
     withCodexAppServerJsonClientMock.mockReset();
     withCodexAppServerJsonClientMock.mockImplementation(
       async (
         _options: Parameters<typeof withCodexAppServerJsonClient>[0],
         run: Parameters<typeof withCodexAppServerJsonClient>[1],
-      ) => await run(requestCodexAppServerJsonMock, harness.client),
+      ) =>
+        await run(requestCodexAppServerJsonMock, harness.client, {
+          assertCurrent: () => undefined,
+        }),
     );
   });
 
@@ -118,9 +145,14 @@ describe("Codex command RPC helpers", () => {
       agentDir,
     });
     expect(acquiredOptions().authProfileId).toBeUndefined();
-    expect(onResponse).toHaveBeenCalledWith({ thread: { id: "thread-1" } }, harness.client, {
-      authProfileId: undefined,
-    });
+    expect(onResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ thread: expect.objectContaining({ id: "thread-1" }) }),
+      harness.client,
+      {
+        authProfileId: undefined,
+        assertCurrent: expect.any(Function),
+      },
+    );
   });
 
   it.each(["oauth", "token"] as const)(
@@ -177,6 +209,7 @@ describe("Codex command RPC helpers", () => {
       );
       expect(onResponse).toHaveBeenCalledWith(expect.anything(), harness.client, {
         authProfileId: "openai:ready",
+        assertCurrent: expect.any(Function),
       });
     },
   );

--- a/extensions/codex/src/command-rpc.ts
+++ b/extensions/codex/src/command-rpc.ts
@@ -7,6 +7,7 @@ import {
 import { resolveSessionModelRef } from "openclaw/plugin-sdk/model-session-runtime";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { getSessionEntry, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
+import { closeCodexStartupClientBestEffort } from "./app-server/attempt-client-cleanup.js";
 import { prepareCodexAppServerAuthBinding } from "./app-server/auth-binding.js";
 import {
   resolveCodexAppServerAuthProfileId,
@@ -32,7 +33,13 @@ import type {
   CodexAppServerRequestResult,
   JsonValue,
 } from "./app-server/protocol.js";
-import { requestCodexAppServerJson, withCodexAppServerJsonClient } from "./app-server/request.js";
+import { isJsonObject } from "./app-server/protocol.js";
+import {
+  requestCodexAppServerJson,
+  withCodexAppServerJsonClient,
+  type CodexAppServerScopedRequest,
+} from "./app-server/request.js";
+import { resumeCodexAppServerThread } from "./app-server/thread-resume.js";
 
 export type SafeValue<T> = { ok: true; value: T } | { ok: false; error: string };
 
@@ -50,10 +57,11 @@ export type CodexControlRequestOptions = {
   isolated?: boolean;
   startOptions?: CodexAppServerStartOptions;
   timeoutMs?: number;
+  beforeRequest?: (request: CodexAppServerScopedRequest) => Promise<void>;
   onResponse?: (
     response: unknown,
     client: CodexAppServerClient,
-    auth: { authProfileId?: string },
+    auth: { authProfileId?: string; assertCurrent: () => void },
   ) => Promise<void>;
 };
 
@@ -213,14 +221,36 @@ export async function codexControlRequest(
     isolated: options.isolated,
     ...auth.clientOptions,
   };
-  if (options.onResponse) {
-    return await withCodexAppServerJsonClient(controlRequestOptions, async (request, client) => {
-      const response = await request({ method, requestParams });
-      // Subscription-producing control requests must publish their exact
-      // physical-client ownership before this shared lease can be released.
-      await options.onResponse!(response, client, { authProfileId: auth.authProfileId });
-      return response;
-    });
+  if (options.onResponse || options.beforeRequest) {
+    return await withCodexAppServerJsonClient(
+      controlRequestOptions,
+      async (request, client, scope) => {
+        await options.beforeRequest?.(request);
+        scope.assertCurrent();
+        let response: unknown;
+        if (method === "thread/resume") {
+          if (!isJsonObject(requestParams) || typeof requestParams.threadId !== "string") {
+            throw new Error("Codex thread/resume requires a thread id.");
+          }
+          response = await resumeCodexAppServerThread({
+            client,
+            request: { ...requestParams, threadId: requestParams.threadId },
+            requestResume: () => request({ method, requestParams }),
+            abandonClient: () => closeCodexStartupClientBestEffort(client),
+          });
+        } else {
+          response = await request({ method, requestParams });
+        }
+        // Subscription-producing control requests must publish their exact
+        // physical-client ownership before this shared lease can be released.
+        await options.onResponse?.(response, client, {
+          authProfileId: auth.authProfileId,
+          assertCurrent: scope.assertCurrent,
+        });
+        scope.assertCurrent();
+        return response;
+      },
+    );
   }
   return await requestCodexAppServerJson({ method, requestParams, ...controlRequestOptions });
 }

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -26,7 +26,7 @@ import {
   isCodexAppServerLiveThreadClaimed,
   retainCodexAppServerLiveThread,
 } from "./app-server/client-runtime.js";
-import type { CodexAppServerClient } from "./app-server/client.js";
+import { CodexAppServerRpcError, type CodexAppServerClient } from "./app-server/client.js";
 import type { CodexComputerUseStatus } from "./app-server/computer-use.js";
 import type { CodexAppServerStartOptions } from "./app-server/config.js";
 import { codexNativeSubagentMonitorRuntime } from "./app-server/native-subagent-monitor.js";
@@ -152,6 +152,7 @@ function createThreadResumeResponse(params: {
   cwd?: string;
   model?: string;
   modelProvider?: string;
+  canAcceptDirectInput?: boolean | null;
 }) {
   const cwd = params.cwd ?? "/repo";
   const modelProvider = params.modelProvider ?? "openai";
@@ -168,6 +169,9 @@ function createThreadResumeResponse(params: {
       modelProvider,
       preview: "",
       source: "appServer",
+      ...(params.canAcceptDirectInput !== undefined
+        ? { canAcceptDirectInput: params.canAcceptDirectInput }
+        : {}),
       status: { type: "idle" },
       turns: [],
     },
@@ -185,6 +189,16 @@ async function writeTestBinding(
   binding: CodexAppServerThreadBinding,
 ): Promise<void> {
   await testCodexAppServerBindingStore.mutate(identity, { kind: "set", binding });
+}
+
+async function completeResumeControlRequest(
+  options: CodexControlRequestOptions | undefined,
+  response: ReturnType<typeof createThreadResumeResponse>,
+  client: CodexAppServerClient,
+  auth: { authProfileId?: string } = {},
+) {
+  await options?.beforeRequest?.(async <T>() => ({ thread: response.thread }) as T);
+  await options?.onResponse?.(response, client, { ...auth, assertCurrent: () => undefined });
 }
 
 function createResumeControlRequest(
@@ -205,7 +219,7 @@ function createResumeControlRequest(
       options?: CodexControlRequestOptions,
     ) => {
       const value = typeof response === "function" ? await response() : response;
-      await options?.onResponse?.(value, harness.client, auth);
+      await completeResumeControlRequest(options, value, harness.client, auth);
       return value;
     },
   );
@@ -674,39 +688,241 @@ describe("codex command", () => {
     expect(codexPluginsManagementIo.current()["google-calendar"]?.enabled).toBe(true);
   });
 
-  it("attaches the current session to an existing Codex thread", async () => {
-    const sessionFile = path.join(tempDir, "session.jsonl");
-    const codexControlRequest = createResumeControlRequest(
-      createThreadResumeResponse({ threadId: "thread-123" }),
-    );
-    const deps = createDeps({ codexControlRequest });
+  it.each([undefined, null, true])(
+    "attaches an interactive or unknown-capability thread (%s)",
+    async (canAcceptDirectInput) => {
+      const sessionFile = path.join(tempDir, "session.jsonl");
+      const codexControlRequest = createResumeControlRequest(
+        createThreadResumeResponse({ threadId: "thread-123", canAcceptDirectInput }),
+      );
+      const deps = createDeps({ codexControlRequest });
 
-    await expect(
-      handleCodexCommand(createContext("resume thread-123", sessionFile), { deps }),
-    ).resolves.toEqual({
-      text: "Attached this OpenClaw session to Codex thread thread-123. The next turn will validate its tools and apply this session's configuration before continuing.",
-    });
+      await expect(
+        handleCodexCommand(createContext("resume thread-123", sessionFile), { deps }),
+      ).resolves.toEqual({
+        text: "Attached this OpenClaw session to Codex thread thread-123. The next turn will validate its tools and apply this session's configuration before continuing.",
+      });
 
-    expect(codexControlRequest).toHaveBeenCalledExactlyOnceWith(
-      undefined,
-      "thread/resume",
-      { threadId: "thread-123", excludeTurns: true },
-      expect.objectContaining({
-        agentDir: path.join(tempDir, "agents", "main", "agent"),
-        sessionId: "session-1",
-      }),
-    );
-    await expect(
-      testCodexAppServerBindingStore.read({
-        kind: "session",
-        agentId: "main",
-        sessionId: "session-1",
-      }),
-    ).resolves.toMatchObject({
-      threadId: "thread-123",
-      historyCoveredThrough: expect.any(String),
-    });
-  });
+      expect(codexControlRequest).toHaveBeenCalledExactlyOnceWith(
+        undefined,
+        "thread/resume",
+        { threadId: "thread-123", excludeTurns: true },
+        expect.objectContaining({
+          agentDir: path.join(tempDir, "agents", "main", "agent"),
+          sessionId: "session-1",
+        }),
+      );
+      await expect(
+        testCodexAppServerBindingStore.read({
+          kind: "session",
+          agentId: "main",
+          sessionId: "session-1",
+        }),
+      ).resolves.toMatchObject({
+        threadId: "thread-123",
+        historyCoveredThrough: expect.any(String),
+      });
+    },
+  );
+
+  it.each([
+    { knownBeforeResume: true, sameOwner: false },
+    { knownBeforeResume: true, sameOwner: true },
+    { knownBeforeResume: false, sameOwner: false },
+    { knownBeforeResume: false, sameOwner: true },
+  ])(
+    "rejects a parent-owned child without displacing the current owner (preflight: $knownBeforeResume, same owner: $sameOwner)",
+    async ({ knownBeforeResume, sameOwner }) => {
+      const harness = createClientHarness();
+      ensureCodexAppServerClientRuntime(harness.client, { agentDir: tempDir });
+      const threadId = "thread-parent-owned";
+      const existingThreadId = sameOwner ? threadId : "thread-existing";
+      const identity = { kind: "session" as const, agentId: "main", sessionId: "session-1" };
+      const release = vi.fn(async () => undefined);
+      await retainCodexAppServerLiveThread(harness.client, existingThreadId, release);
+      await writeTestBinding(identity, {
+        threadId: existingThreadId,
+        clientId: harness.client.getInstanceId(),
+        cwd: "/repo",
+      });
+      const before = await testCodexAppServerBindingStore.read(identity);
+      const response = createThreadResumeResponse({ threadId, canAcceptDirectInput: false });
+      const request = vi.spyOn(harness.client, "request").mockImplementation(async (method) => {
+        if (method === "thread/read") {
+          return {
+            thread: { ...response.thread, canAcceptDirectInput: knownBeforeResume ? false : null },
+          } as never;
+        }
+        if (method === "thread/resume") {
+          return response as never;
+        }
+        if (method === "thread/unsubscribe") {
+          return {} as never;
+        }
+        throw new Error(`unexpected Codex method ${method}`);
+      });
+      const sharedClientRuntime = await import("./app-server/shared-client.js");
+      const retainClient = vi
+        .spyOn(sharedClientRuntime, "retainSharedCodexAppServerClientByInstanceId")
+        .mockReturnValue({ client: harness.client, release: vi.fn() });
+      const codexControlRequest = vi.fn(
+        async (
+          _pluginConfig: unknown,
+          method: string,
+          controlParams: unknown,
+          options?: CodexControlRequestOptions,
+        ) => {
+          await options?.beforeRequest?.(
+            async <T>({
+              method: scopedMethod,
+              requestParams: scopedParams,
+            }: {
+              method: string;
+              requestParams?: unknown;
+            }) => await harness.client.request<T>(scopedMethod, scopedParams),
+          );
+          const value = await harness.client.request(method, controlParams);
+          await options?.onResponse?.(value, harness.client, { assertCurrent: () => undefined });
+          return value;
+        },
+      );
+
+      try {
+        const result = await runCommand(`resume ${threadId}`, { codexControlRequest });
+
+        expect(result.text).toContain("controlled by its parent");
+        await expect(testCodexAppServerBindingStore.read(identity)).resolves.toEqual(before);
+        expect(release).not.toHaveBeenCalled();
+        const mutations = request.mock.calls
+          .map(([method]) => method)
+          .filter((method) => method !== "thread/read");
+        expect(mutations).toEqual(
+          knownBeforeResume
+            ? []
+            : sameOwner
+              ? ["thread/resume"]
+              : ["thread/resume", "thread/unsubscribe"],
+        );
+        await expect(
+          consumeCodexAppServerLiveThread(harness.client, existingThreadId),
+        ).resolves.toEqual(expect.objectContaining({ release: expect.any(Function) }));
+      } finally {
+        retainClient.mockRestore();
+        harness.client.close();
+      }
+    },
+  );
+
+  it.each([
+    { retainedBeforeResume: false, failure: "deadline" },
+    { retainedBeforeResume: true, failure: "deadline" },
+    { retainedBeforeResume: false, failure: "read" },
+    { retainedBeforeResume: true, failure: "read" },
+    { retainedBeforeResume: true, failure: "resume" },
+  ])(
+    "cleans up a rejected same-client resume only when no native owner remains (retained: $retainedBeforeResume, failure: $failure)",
+    async ({ retainedBeforeResume, failure }) => {
+      const { codexControlRequest } = await import("./command-rpc.js");
+      const sharedClientRuntime = await import("./app-server/shared-client.js");
+      const harness = createClientHarness();
+      ensureCodexAppServerClientRuntime(harness.client, { agentDir: tempDir });
+      const threadId = "thread-same-client-resume";
+      const identity = { kind: "session" as const, agentId: "main", sessionId: "session-1" };
+      const release = vi.fn(async () => undefined);
+      if (retainedBeforeResume) {
+        await retainCodexAppServerLiveThread(harness.client, threadId, release);
+      }
+      const releaseSibling = vi.fn(async () => undefined);
+      await retainCodexAppServerLiveThread(harness.client, "thread-sibling", releaseSibling);
+      await writeTestBinding(identity, {
+        threadId,
+        clientId: harness.client.getInstanceId(),
+        cwd: "/repo",
+      });
+      const before = await testCodexAppServerBindingStore.read(identity);
+      const acquireClient = vi
+        .spyOn(sharedClientRuntime, "getLeasedSharedCodexAppServerClient")
+        .mockResolvedValue(harness.client);
+      const releaseLease = vi.spyOn(sharedClientRuntime, "releaseLeasedSharedCodexAppServerClient");
+      const response = createThreadResumeResponse({ threadId, canAcceptDirectInput: true });
+      let resumeAccepted = false;
+      const request = vi.spyOn(harness.client, "request").mockImplementation(async (method) => {
+        if (method === "thread/read") {
+          return { thread: response.thread } as never;
+        }
+        if (method === "thread/resume") {
+          resumeAccepted = true;
+          if (failure === "resume") {
+            throw new CodexAppServerRpcError(
+              { code: -32_603, message: "resume response assembly failed" },
+              method,
+            );
+          }
+          return response as never;
+        }
+        if (method === "thread/unsubscribe") {
+          return {} as never;
+        }
+        throw new Error(`unexpected Codex method ${method}`);
+      });
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const startedAt = Date.now();
+      try {
+        const result = await runCommand(
+          `resume ${threadId}`,
+          {
+            codexControlRequest,
+            bindingStore: {
+              ...testCodexAppServerBindingStore,
+              read: async (bindingIdentity) => {
+                if (resumeAccepted) {
+                  if (failure === "read") {
+                    throw new Error("Invalid Codex app-server binding row");
+                  }
+                  vi.setSystemTime(startedAt + 1_001);
+                }
+                return await testCodexAppServerBindingStore.read(bindingIdentity);
+              },
+            },
+          },
+          {},
+          { pluginConfig: { appServer: { requestTimeoutMs: 1_000 } } },
+        );
+
+        const keepsExistingOwner = retainedBeforeResume && failure !== "resume";
+        expect(result.text).toContain(
+          failure === "resume"
+            ? "resume response assembly failed"
+            : failure === "read"
+              ? "Invalid Codex app-server binding row"
+              : "timed out",
+        );
+        expect(request.mock.calls.map(([method]) => method)).toEqual(
+          keepsExistingOwner
+            ? ["thread/read", "thread/resume"]
+            : ["thread/read", "thread/resume", "thread/unsubscribe"],
+        );
+        expect(release).not.toHaveBeenCalled();
+        expect(releaseSibling).not.toHaveBeenCalled();
+        expect(releaseLease).toHaveBeenCalledExactlyOnceWith(harness.client);
+        expect(harness.stdinDestroyed).toBe(false);
+        await expect(testCodexAppServerBindingStore.read(identity)).resolves.toEqual(before);
+        await expect(consumeCodexAppServerLiveThread(harness.client, threadId)).resolves.toEqual(
+          keepsExistingOwner
+            ? expect.objectContaining({ release: expect.any(Function) })
+            : undefined,
+        );
+        await expect(
+          consumeCodexAppServerLiveThread(harness.client, "thread-sibling"),
+        ).resolves.toEqual(expect.objectContaining({ release: expect.any(Function) }));
+      } finally {
+        releaseLease.mockRestore();
+        acquireClient.mockRestore();
+        harness.client.close();
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("publishes manual resume ownership on its responding physical client before returning", async () => {
     const harness = createClientHarness();
@@ -719,7 +935,7 @@ describe("codex command", () => {
         _params: unknown,
         options?: CodexControlRequestOptions,
       ) => {
-        await options?.onResponse?.(response, harness.client, {});
+        await completeResumeControlRequest(options, response, harness.client);
         return response;
       },
     );
@@ -776,7 +992,7 @@ describe("codex command", () => {
         _params: unknown,
         options?: CodexControlRequestOptions,
       ) => {
-        await options?.onResponse?.(response, harness.client, {});
+        await completeResumeControlRequest(options, response, harness.client);
         return response;
       },
     );
@@ -852,7 +1068,7 @@ describe("codex command", () => {
           _params: unknown,
           options?: CodexControlRequestOptions,
         ) => {
-          await options?.onResponse?.(response, replacement.client, {});
+          await completeResumeControlRequest(options, response, replacement.client);
           return response;
         },
       );
@@ -926,7 +1142,7 @@ describe("codex command", () => {
         _params: unknown,
         options?: CodexControlRequestOptions,
       ) => {
-        await options?.onResponse?.(response, harness.client, {});
+        await completeResumeControlRequest(options, response, harness.client);
         return response;
       },
     );
@@ -1025,11 +1241,11 @@ describe("codex command", () => {
           _params: unknown,
           options?: CodexControlRequestOptions,
         ) => {
-          const resumed = await harness.client.request("thread/resume", {
+          await harness.client.request("thread/resume", {
             threadId: "thread-active-resume",
             excludeTurns: true,
           });
-          await options?.onResponse?.(resumed, harness.client, {});
+          await completeResumeControlRequest(options, response, harness.client);
           return response;
         },
       );
@@ -5818,6 +6034,14 @@ describe("codex command", () => {
         if (method === "thread/unsubscribe") {
           return {} as never;
         }
+        if (method === "thread/read") {
+          return {
+            thread: createThreadResumeResponse({
+              threadId: "thread-original-context",
+              cwd: tempDir,
+            }).thread,
+          } as never;
+        }
         if (method === "thread/resume") {
           return createThreadResumeResponse({
             threadId: "thread-original-context",
@@ -5927,7 +6151,12 @@ describe("codex command", () => {
         handled: true,
         reply: { text: "Original context kept" },
       });
-      expect(operations).toEqual(["thread/unsubscribe", "thread/resume", "turn/start"]);
+      expect(operations).toEqual([
+        "thread/unsubscribe",
+        "thread/read",
+        "thread/resume",
+        "turn/start",
+      ]);
       expect(request.mock.calls.find(([method]) => method === "thread/resume")?.[1]).toMatchObject({
         threadId: originalBinding.threadId,
       });

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -111,8 +111,16 @@ vi.mock("./app-server/shared-client.js", () => ({
   }),
   withLeasedCodexAppServerClientStartSelectionRetry: async (params: {
     lease: { client?: unknown };
-    run: (client: unknown) => Promise<unknown>;
-  }) => await params.run(params.lease.client),
+    options?: { timeoutMs?: number };
+    run: (
+      client: unknown,
+      requestOptions: () => { timeoutMs: number; assertCurrent: () => void },
+    ) => Promise<unknown>;
+  }) =>
+    await params.run(params.lease.client, () => ({
+      timeoutMs: params.options?.timeoutMs ?? 60_000,
+      assertCurrent: () => undefined,
+    })),
 }));
 vi.mock("openclaw/plugin-sdk/exec-approvals-runtime", async (importOriginal) => {
   const actual =
@@ -250,6 +258,9 @@ async function createSameThreadClientMigrationFixture(
   const replacementClient = {
     getInstanceId: () => "client-after-migration",
     request: vi.fn(async (method: string) => {
+      if (method === "thread/read") {
+        return { thread: conversationThreadStartResult("thread-migrated").thread };
+      }
       operations.push(`replacement:${method}`);
       if (method === "thread/resume") {
         return conversationThreadStartResult("thread-migrated");
@@ -348,7 +359,7 @@ const NETWORK_PROXY_CONFIG_PATCH = NETWORK_PROXY_RUNTIME.networkProxy?.configPat
 const NETWORK_PROXY_CONFIG_FINGERPRINT =
   NETWORK_PROXY_RUNTIME.networkProxy?.configFingerprint ?? "missing";
 
-function conversationThreadStartResult(threadId: string) {
+function conversationThreadStartResult(threadId: string, canAcceptDirectInput?: boolean | null) {
   return {
     approvalPolicy: "never",
     approvalsReviewer: "user",
@@ -372,6 +383,7 @@ function conversationThreadStartResult(threadId: string) {
       projectId: null,
       cliVersion: "0.149.0",
       source: "unknown",
+      ...(canAcceptDirectInput !== undefined ? { canAcceptDirectInput } : {}),
       agentNickname: null,
       agentRole: null,
       gitInfo: null,
@@ -1056,6 +1068,9 @@ describe("codex conversation binding", () => {
       "thread/resume",
     );
     const request = vi.fn(async (method: string) => {
+      if (method === "thread/read") {
+        return { thread: conversationThreadStartResult("thread-structured-resume-failure").thread };
+      }
       if (method === "thread/resume") {
         throw rejection;
       }
@@ -1082,6 +1097,7 @@ describe("codex conversation binding", () => {
     ).rejects.toBe(rejection);
 
     expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
       "thread/resume",
       "thread/unsubscribe",
     ]);
@@ -1089,51 +1105,230 @@ describe("codex conversation binding", () => {
     await expect(readCodexAppServerBinding(sessionFile)).resolves.toBeUndefined();
   });
 
-  it("drops a retained native child before applying bound-only apps and sandbox policy", async () => {
-    const sessionFile = path.join(tempDir, "retained-child-session.jsonl");
-    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
-    const client = {
-      getInstanceId: () => "client-native-child",
-      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
-        requests.push({ method, params: requestParams });
-        if (method === "thread/unsubscribe") {
-          return {};
+  it.each([undefined, null, true])(
+    "reconfigures a retained interactive or unknown-capability thread (%s)",
+    async (canAcceptDirectInput) => {
+      const sessionFile = path.join(tempDir, "retained-child-session.jsonl");
+      const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+      const client = {
+        getInstanceId: () => "client-native-child",
+        request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+          if (method === "thread/read") {
+            return {
+              thread: conversationThreadStartResult("thread-native-child", canAcceptDirectInput)
+                .thread,
+            };
+          }
+          requests.push({ method, params: requestParams });
+          if (method === "thread/unsubscribe") {
+            return {};
+          }
+          if (method === "thread/resume") {
+            return conversationThreadStartResult("thread-native-child", canAcceptDirectInput);
+          }
+          throw new Error(`unexpected method: ${method}`);
+        }),
+        addNotificationHandler: vi.fn(() => () => undefined),
+        addRequestHandler: vi.fn(() => () => undefined),
+        addCloseHandler: vi.fn(() => () => undefined),
+      } as unknown as CodexAppServerClient;
+      ensureCodexAppServerClientRuntime(client, { agentDir: tempDir });
+      await retainCodexAppServerLiveThread(client, "thread-native-child");
+      sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(client);
+
+      await startCodexConversationThread({
+        pluginConfig: { appServer: { sandbox: "read-only" } },
+        sessionFile,
+        threadId: "thread-native-child",
+        workspaceDir: tempDir,
+      });
+
+      expect(requests.map(({ method }) => method)).toEqual(["thread/unsubscribe", "thread/resume"]);
+      expect(requests[0]?.params).toEqual({ threadId: "thread-native-child" });
+      expect(requests[1]?.params).toMatchObject({
+        threadId: "thread-native-child",
+        sandbox: "read-only",
+        config: {
+          project_doc_max_bytes: 131_072,
+          apps: { _default: { enabled: false } },
+          "features.apps": false,
+        },
+      });
+      await expect(consumeCodexAppServerLiveThread(client, "thread-native-child")).resolves.toEqual(
+        expect.objectContaining({ release: expect.any(Function) }),
+      );
+    },
+  );
+
+  it.each(["preflight", "commit", "retention", "binding-read"] as const)(
+    "preserves the current owner when attachment fails during %s",
+    async (expiresDuring) => {
+      const sharedClientRuntime = await import("./app-server/shared-client.js");
+      const actualSharedClientRuntime = await vi.importActual<
+        typeof import("./app-server/shared-client.js")
+      >("./app-server/shared-client.js");
+      const retry = vi
+        .spyOn(sharedClientRuntime, "withLeasedCodexAppServerClientStartSelectionRetry")
+        .mockImplementation(
+          actualSharedClientRuntime.withLeasedCodexAppServerClientStartSelectionRetry,
+        );
+      const sessionFile = path.join(tempDir, "expired-attachment.jsonl");
+      const threadId = "thread-expired-attachment";
+      const existingThreadId = expiresDuring === "commit" ? "thread-previous-attachment" : threadId;
+      const harness = createClientHarness();
+      ensureCodexAppServerClientRuntime(harness.client, { agentDir: tempDir });
+      const release = vi.fn(async () => undefined);
+      await retainCodexAppServerLiveThread(harness.client, existingThreadId, release);
+      const releaseSibling = vi.fn(async () => undefined);
+      await retainCodexAppServerLiveThread(harness.client, "thread-sibling", releaseSibling);
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: existingThreadId,
+        clientId: harness.client.getInstanceId(),
+        cwd: tempDir,
+      });
+      const before = await readCodexAppServerBinding(sessionFile);
+      const response = conversationThreadStartResult(threadId, true);
+      sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(harness.client);
+      sharedClientMocks.retainSharedCodexAppServerClientByInstanceId.mockReturnValue({
+        client: harness.client,
+        release: vi.fn(),
+      });
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const startedAt = Date.now();
+      let resumeAccepted = false;
+      const request = vi.spyOn(harness.client, "request").mockImplementation(async (method) => {
+        if (method === "thread/read") {
+          if (expiresDuring === "preflight") {
+            vi.setSystemTime(startedAt + 1_001);
+          }
+          return { thread: response.thread } as never;
         }
         if (method === "thread/resume") {
-          return conversationThreadStartResult("thread-native-child");
+          resumeAccepted = true;
+          return response as never;
         }
-        throw new Error(`unexpected method: ${method}`);
-      }),
-      addNotificationHandler: vi.fn(() => () => undefined),
-      addRequestHandler: vi.fn(() => () => undefined),
-      addCloseHandler: vi.fn(() => () => undefined),
-    } as unknown as CodexAppServerClient;
-    ensureCodexAppServerClientRuntime(client, { agentDir: tempDir });
-    await retainCodexAppServerLiveThread(client, "thread-native-child");
-    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(client);
+        if (method === "thread/unsubscribe") {
+          return {} as never;
+        }
+        throw new Error(`unexpected Codex method ${method}`);
+      });
 
-    await startCodexConversationThread({
-      pluginConfig: { appServer: { sandbox: "read-only" } },
-      sessionFile,
-      threadId: "thread-native-child",
-      workspaceDir: tempDir,
-    });
+      try {
+        await expect(
+          startCodexConversationThreadImpl({
+            pluginConfig: { appServer: { requestTimeoutMs: 1_000 } },
+            sessionFile,
+            threadId,
+            workspaceDir: tempDir,
+            bindingStore: {
+              ...testCodexAppServerBindingStore,
+              read: async (identity) => {
+                if (resumeAccepted) {
+                  if (expiresDuring === "binding-read") {
+                    throw new Error("Invalid Codex app-server binding row");
+                  }
+                  if (expiresDuring === "retention") {
+                    vi.setSystemTime(startedAt + 1_001);
+                  }
+                }
+                return await testCodexAppServerBindingStore.read(identity);
+              },
+              mutate: async (...args) => {
+                if (expiresDuring === "commit") {
+                  vi.setSystemTime(startedAt + 1_001);
+                }
+                return await testCodexAppServerBindingStore.mutate(...args);
+              },
+            },
+          }),
+        ).rejects.toThrow(
+          expiresDuring === "binding-read" ? "Invalid Codex app-server binding row" : "timed out",
+        );
 
-    expect(requests.map(({ method }) => method)).toEqual(["thread/unsubscribe", "thread/resume"]);
-    expect(requests[0]?.params).toEqual({ threadId: "thread-native-child" });
-    expect(requests[1]?.params).toMatchObject({
-      threadId: "thread-native-child",
-      sandbox: "read-only",
-      config: {
-        project_doc_max_bytes: 131_072,
-        apps: { _default: { enabled: false } },
-        "features.apps": false,
-      },
-    });
-    await expect(consumeCodexAppServerLiveThread(client, "thread-native-child")).resolves.toEqual(
-      expect.objectContaining({ release: expect.any(Function) }),
-    );
-  });
+        expect(request.mock.calls.map(([method]) => method)).toEqual(
+          expiresDuring === "preflight"
+            ? ["thread/read"]
+            : ["thread/read", "thread/resume", "thread/unsubscribe"],
+        );
+        expect(release).toHaveBeenCalledTimes(expiresDuring === "preflight" ? 0 : 1);
+        expect(releaseSibling).not.toHaveBeenCalled();
+        expect(harness.stdinDestroyed).toBe(false);
+        await expect(
+          consumeCodexAppServerLiveThread(harness.client, "thread-sibling"),
+        ).resolves.toEqual(expect.objectContaining({ release: expect.any(Function) }));
+        await expect(readCodexAppServerBinding(sessionFile)).resolves.toEqual(before);
+        await expect(consumeCodexAppServerLiveThread(harness.client, threadId)).resolves.toEqual(
+          expiresDuring === "preflight"
+            ? expect.objectContaining({ release: expect.any(Function) })
+            : undefined,
+        );
+      } finally {
+        retry.mockRestore();
+        harness.client.close();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([
+    { knownBeforeResume: true, sameOwner: false },
+    { knownBeforeResume: true, sameOwner: true },
+    { knownBeforeResume: false, sameOwner: false },
+  ])(
+    "rejects binding a parent-owned child without displacing the current owner (preflight: $knownBeforeResume, same owner: $sameOwner)",
+    async ({ knownBeforeResume, sameOwner }) => {
+      const sessionFile = path.join(tempDir, "parent-owned-session.jsonl");
+      const harness = createClientHarness();
+      ensureCodexAppServerClientRuntime(harness.client, { agentDir: tempDir });
+      const threadId = "thread-parent-owned";
+      const existingThreadId = sameOwner ? threadId : "thread-existing";
+      const release = vi.fn(async () => undefined);
+      await retainCodexAppServerLiveThread(harness.client, existingThreadId, release);
+      await writeCodexAppServerBinding(sessionFile, {
+        threadId: existingThreadId,
+        clientId: harness.client.getInstanceId(),
+        cwd: tempDir,
+      });
+      const before = await readCodexAppServerBinding(sessionFile);
+      const response = conversationThreadStartResult(threadId, false);
+      const request = vi.spyOn(harness.client, "request").mockImplementation(async (method) => {
+        if (method === "thread/read") {
+          return {
+            thread: { ...response.thread, canAcceptDirectInput: knownBeforeResume ? false : null },
+          } as never;
+        }
+        if (method === "thread/resume") {
+          return response as never;
+        }
+        if (method === "thread/unsubscribe") {
+          return {} as never;
+        }
+        throw new Error(`unexpected Codex method ${method}`);
+      });
+      sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(harness.client);
+      sharedClientMocks.retainSharedCodexAppServerClientByInstanceId.mockReturnValue({
+        client: harness.client,
+        release: vi.fn(),
+      });
+
+      try {
+        await expect(
+          startCodexConversationThread({ sessionFile, threadId, workspaceDir: tempDir }),
+        ).rejects.toThrow("controlled by its parent");
+
+        await expect(readCodexAppServerBinding(sessionFile)).resolves.toEqual(before);
+        expect(release).not.toHaveBeenCalled();
+        expect(
+          request.mock.calls.map(([method]) => method).filter((method) => method !== "thread/read"),
+        ).toEqual(knownBeforeResume ? [] : ["thread/resume", "thread/unsubscribe"]);
+        await expect(
+          consumeCodexAppServerLiveThread(harness.client, existingThreadId),
+        ).resolves.toEqual(expect.objectContaining({ release: expect.any(Function) }));
+      } finally {
+        harness.client.close();
+      }
+    },
+  );
 
   it("never resumes or unsubscribes an actively claimed native child for a conversation", async () => {
     const sessionFile = path.join(tempDir, "active-child-session.jsonl");
@@ -1187,9 +1382,72 @@ describe("codex conversation binding", () => {
     }
   });
 
+  it.each([
+    { sessionKey: undefined, knownBeforeResume: true },
+    { sessionKey: "agent:main:dashboard:incognito-child", knownBeforeResume: true },
+    { sessionKey: undefined, knownBeforeResume: false },
+    { sessionKey: "agent:main:dashboard:incognito-child", knownBeforeResume: false },
+  ])(
+    "preserves a stored child binding when direct input is refused (session: $sessionKey, preflight: $knownBeforeResume)",
+    async ({ sessionKey, knownBeforeResume }) => {
+      const sessionFile = path.join(tempDir, "stored-child.jsonl");
+      const harness = createClientHarness();
+      ensureCodexAppServerClientRuntime(harness.client, { agentDir: tempDir });
+      const threadId = "thread-parent-owned";
+      const release = vi.fn(async () => undefined);
+      if (knownBeforeResume) {
+        await retainCodexAppServerLiveThread(harness.client, threadId, release);
+      }
+      await writeTestConversationBinding(sessionFile, { threadId, cwd: tempDir });
+      const before = await readTestConversationBinding(sessionFile);
+      const request = vi.spyOn(harness.client, "request").mockImplementation(async (method) => {
+        if (method === "thread/read") {
+          return {
+            thread: conversationThreadStartResult(threadId, knownBeforeResume ? false : null)
+              .thread,
+          } as never;
+        }
+        if (method === "thread/resume") {
+          return conversationThreadStartResult(threadId, false) as never;
+        }
+        if (method === "thread/unsubscribe") {
+          return {} as never;
+        }
+        throw new Error(`unexpected Codex method ${method}`);
+      });
+      sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue(harness.client);
+      const { event, ctx } = boundConversationClaim(sessionFile, sessionKey);
+
+      try {
+        await expect(handleCodexConversationInboundClaim(event, ctx)).resolves.toMatchObject({
+          handled: true,
+          reply: { text: expect.stringContaining("controlled by its parent") },
+        });
+        await expect(readTestConversationBinding(sessionFile)).resolves.toEqual(before);
+        expect(request.mock.calls.map(([method]) => method)).toEqual(
+          knownBeforeResume
+            ? ["thread/read"]
+            : ["thread/read", "thread/resume", "thread/unsubscribe"],
+        );
+        expect(release).not.toHaveBeenCalled();
+        const ownership = await consumeCodexAppServerLiveThread(harness.client, threadId);
+        if (knownBeforeResume) {
+          expect(ownership).toEqual(expect.objectContaining({ release: expect.any(Function) }));
+        } else {
+          expect(ownership).toBeUndefined();
+        }
+      } finally {
+        harness.client.close();
+      }
+    },
+  );
+
   it("keeps a retained native child owned when its pre-resume unsubscribe fails", async () => {
     const sessionFile = path.join(tempDir, "failed-child-session.jsonl");
     const request = vi.fn(async (method: string) => {
+      if (method === "thread/read") {
+        return { thread: conversationThreadStartResult("thread-failed-child").thread };
+      }
       if (method === "thread/unsubscribe") {
         throw new Error("native child unsubscribe failed");
       }
@@ -1214,7 +1472,10 @@ describe("codex conversation binding", () => {
       }),
     ).rejects.toThrow("native child unsubscribe failed");
 
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/unsubscribe"]);
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/read",
+      "thread/unsubscribe",
+    ]);
     await expect(consumeCodexAppServerLiveThread(client, "thread-failed-child")).resolves.toEqual(
       expect.objectContaining({ release: expect.any(Function) }),
     );
@@ -2555,10 +2816,14 @@ describe("codex conversation binding", () => {
     let notificationHandler: ((notification: unknown) => void) | undefined;
     sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
       request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
-        requests.push({ method, params: requestParams });
         if (method === "thread/resume") {
+          requests.push({ method, params: requestParams });
           return conversationThreadStartResult("thread-target");
         }
+        if (method === "thread/read") {
+          return { thread: conversationThreadStartResult("thread-target").thread };
+        }
+        requests.push({ method, params: requestParams });
         if (method === "turn/start") {
           setImmediate(() =>
             notificationHandler?.({
@@ -3463,6 +3728,9 @@ describe("codex conversation binding", () => {
       );
       let unsubscribed = false;
       const request = vi.fn(async (method: string) => {
+        if (method === "thread/read") {
+          return { thread: conversationThreadStartResult("thread-1").thread };
+        }
         if (method === "thread/resume") {
           throw rejection;
         }
@@ -3487,7 +3755,9 @@ describe("codex conversation binding", () => {
         },
       });
       expect(request.mock.calls.map(([method]) => method)).toEqual(
-        cleaned ? ["thread/resume", "thread/unsubscribe"] : ["thread/resume"],
+        cleaned
+          ? ["thread/read", "thread/resume", "thread/unsubscribe"]
+          : ["thread/read", "thread/resume"],
       );
       expect(sharedClientMocks.retireSharedCodexAppServerClientIfCurrent).not.toHaveBeenCalled();
       expect(closeAndWait).not.toHaveBeenCalled();
@@ -3509,6 +3779,9 @@ describe("codex conversation binding", () => {
         cwd: tempDir,
       });
       const request = vi.fn(async (method: string) => {
+        if (method === "thread/read") {
+          return { thread: conversationThreadStartResult("thread-1").thread };
+        }
         if (method === "thread/resume") {
           throw new Error("thread not found: thread-1");
         }
@@ -3537,7 +3810,10 @@ describe("codex conversation binding", () => {
         reply: { text: "Codex app-server turn failed: thread not found: thread-1" },
       });
 
-      expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/resume"]);
+      expect(request.mock.calls.map(([method]) => method)).toEqual([
+        "thread/read",
+        "thread/resume",
+      ]);
       expect(sharedClientMocks.retireSharedCodexAppServerClientIfCurrent).toHaveBeenCalledOnce();
       expect(sharedClientMocks.retireSharedCodexAppServerClientIfCurrent).toHaveBeenCalledWith(
         client,

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -33,6 +33,7 @@ import {
 import { resolveCodexAppServerAuthProfileIdForAgent } from "./app-server/auth-bridge.js";
 import {
   consumeCodexAppServerLiveThread,
+  hasCodexAppServerLiveThread,
   isCodexAppServerClientRuntimeLive,
   isCodexAppServerLiveThreadClaimed,
   releaseCodexAppServerLiveThread,
@@ -56,10 +57,15 @@ import {
   mergeCodexThreadConfigs,
 } from "./app-server/plugin-thread-config.js";
 import { buildCodexProjectDocThreadConfig } from "./app-server/project-doc-thread-config.js";
-import { assertCodexThreadStartResponse } from "./app-server/protocol-validators.js";
+import {
+  assertCodexThreadAcceptsDirectInput,
+  assertCodexThreadStartResponse,
+  CodexThreadDirectInputError,
+} from "./app-server/protocol-validators.js";
 import type {
   CodexServiceTier,
   CodexThreadResumeResponse,
+  CodexThreadStartParams,
   CodexThreadStartResponse,
   CodexTurnStartResponse,
   JsonObject,
@@ -89,6 +95,7 @@ import {
   withLeasedCodexAppServerClientStartSelectionRetry,
   type CodexAppServerClientLease,
   type CodexAppServerClientOptions,
+  type CodexAppServerLeasedRequestOptions,
 } from "./app-server/shared-client.js";
 import {
   CODEX_NATIVE_PERSONALITY_NONE,
@@ -329,7 +336,7 @@ async function startCodexConversationThread(
       agentId: params.agentId,
     });
   } else {
-    await createThread({
+    await bindThread({
       pluginConfig: params.pluginConfig,
       bindingStore: params.bindingStore,
       identity,
@@ -648,48 +655,25 @@ function codexConversationSandboxOrPermissions(
   return networkProxy ? { config } : { sandbox, config };
 }
 
-async function requestNewConversationBindingThread(
-  params: CodexThreadBindingParams,
-  resolved: CodexThreadBindingRuntime,
-): Promise<CodexThreadStartResponse> {
-  return await withLeasedCodexAppServerClientStartSelectionRetry({
-    lease: resolved.clientLease,
-    options: resolved.clientOptions,
-    run: async (client, requestOptions) =>
-      await client.request(
-        "thread/start",
-        {
-          cwd: resolved.workspaceDir,
-          ...(resolved.model ? { model: resolved.model } : {}),
-          ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
-          personality: CODEX_NATIVE_PERSONALITY_NONE,
-          ...buildThreadRequestRuntimeOptions(params, resolved),
-          developerInstructions: CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS,
-          experimentalRawEvents: true,
-          ...(params.incognito ? { ephemeral: true } : {}),
-        },
-        requestOptions,
-      ),
-    onClientChange: (client) => {
-      resolved.client = client;
-    },
-  });
-}
-
 async function writeThreadBindingFromResponse(
   params: CodexThreadBindingParams,
   resolved: CodexThreadBindingRuntime,
   response: CodexThreadResumeResponse | CodexThreadStartResponse,
+  requestOptions: () => CodexAppServerLeasedRequestOptions,
 ): Promise<void> {
-  const current = await params.bindingStore.read(params.identity);
-  assertCodexBindingMayBeReplaced(current, "storing a conversation-bound Codex thread");
-  const trackSubscription = !params.incognito && isCodexAppServerClientRuntimeLive(resolved.client);
-  const sameOwner = isSameCodexAppServerThreadOwner(current, {
-    threadId: response.thread.id,
-    clientId: resolved.client.getInstanceId(),
-  });
   let retained = false;
+  let sameOwner = false;
   try {
+    const current = await params.bindingStore.read(params.identity);
+    assertCodexBindingMayBeReplaced(current, "storing a conversation-bound Codex thread");
+    const trackSubscription =
+      !params.incognito && isCodexAppServerClientRuntimeLive(resolved.client);
+    sameOwner = isSameCodexAppServerThreadOwner(current, {
+      threadId: response.thread.id,
+      clientId: resolved.client.getInstanceId(),
+    });
+    requestOptions();
+    assertCodexThreadAcceptsDirectInput(response.thread);
     if (trackSubscription) {
       retained = await retainCodexAppServerBindingSubscription(resolved.client, response.thread.id);
       if (!retained) {
@@ -697,35 +681,44 @@ async function writeThreadBindingFromResponse(
       }
     }
     if (current && !sameOwner) {
+      const { assertCurrent } = requestOptions();
       // Keep the old identity visible until its sole native subscription is
       // released; a concurrent owner must not adopt it between clear and cleanup.
-      await releaseCodexAppServerBindingSubscription(current);
+      await releaseCodexAppServerBindingSubscription(current, { assertCurrent });
     }
-    const committed = await params.bindingStore.mutate(params.identity, {
-      kind: "set",
-      binding: {
-        threadId: response.thread.id,
-        clientId: resolved.client.getInstanceId(),
-        cwd: resolved.workspaceDir,
-        authProfileId: params.authProfileId,
-        model: response.model ?? resolved.model ?? params.model,
-        modelProvider: normalizeCodexAppServerBindingModelProvider({
+    requestOptions();
+    const committed = await params.bindingStore.mutate(
+      params.identity,
+      {
+        kind: "set",
+        binding: {
+          threadId: response.thread.id,
+          clientId: resolved.client.getInstanceId(),
+          cwd: resolved.workspaceDir,
           authProfileId: params.authProfileId,
-          modelProvider: response.modelProvider ?? resolved.modelProvider ?? params.modelProvider,
-          ...resolved.agentLookup,
-        }),
-        serviceTier: params.serviceTier ?? resolved.runtime.serviceTier ?? undefined,
-        networkProxyProfileName: resolved.runtime.networkProxy?.profileName,
-        networkProxyConfigFingerprint: resolved.runtime.networkProxy?.configFingerprint,
+          model: response.model ?? resolved.model ?? params.model,
+          modelProvider: normalizeCodexAppServerBindingModelProvider({
+            authProfileId: params.authProfileId,
+            modelProvider: response.modelProvider ?? resolved.modelProvider ?? params.modelProvider,
+            ...resolved.agentLookup,
+          }),
+          serviceTier: params.serviceTier ?? resolved.runtime.serviceTier ?? undefined,
+          networkProxyProfileName: resolved.runtime.networkProxy?.profileName,
+          networkProxyConfigFingerprint: resolved.runtime.networkProxy?.configFingerprint,
+        },
       },
-    });
+      requestOptions,
+    );
     if (!committed) {
       throw new Error("Codex conversation binding changed while storing its thread.");
     }
   } catch (error) {
-    // A newly started/resumed Codex thread is already subscribed before its
-    // response arrives; failed ownership commits must release that exact thread.
-    if (trackSubscription && !sameOwner) {
+    // A matching stored binding may already have lost its idle subscription.
+    // Keep existing live owners, but never leave an accepted resume untracked.
+    if (
+      (retained && !sameOwner) ||
+      !hasCodexAppServerLiveThread(resolved.client, response.thread.id)
+    ) {
       await rollbackCodexAppServerBindingSubscription(
         resolved.client,
         response.thread.id,
@@ -745,66 +738,75 @@ async function attachExistingThread(
     bindingStore: params.bindingStore,
     identity: params.identity,
     threadId: params.threadId,
-    run: async () => {
-      const current = await params.bindingStore.read(params.identity);
-      assertCodexBindingMayBeReplaced(current, "attaching a conversation-bound Codex thread");
-      const resolved = await resolveThreadBindingRuntime(params);
-      try {
-        // Codex applies network-proxy permission profiles at thread/start. Resuming
-        // an arbitrary existing thread cannot prove that profile is active.
-        const response: CodexThreadResumeResponse | CodexThreadStartResponse = resolved.runtime
-          .networkProxy
-          ? await requestNewConversationBindingThread(params, resolved)
-          : await withLeasedCodexAppServerClientStartSelectionRetry({
-              lease: resolved.clientLease,
-              options: resolved.clientOptions,
-              run: async (client, requestOptions) => {
-                if (isCodexAppServerLiveThreadClaimed(client, params.threadId)) {
-                  throw new Error(
-                    `Codex thread ${params.threadId} has an active run; stop it before binding its conversation.`,
-                  );
-                }
-                // Codex ignores resume config while any connection is still
-                // subscribed; completed native children otherwise inherit app permissions.
-                await releaseCodexAppServerLiveThread(client, params.threadId);
-                if (isCodexAppServerLiveThreadClaimed(client, params.threadId)) {
-                  throw new Error(
-                    `Codex thread ${params.threadId} has an active run; stop it before binding its conversation.`,
-                  );
-                }
-                return await resumeCodexAppServerThread({
-                  client,
-                  abandonClient: async () => closeCodexStartupClientBestEffort(client),
-                  request: {
-                    threadId: params.threadId,
-                    cwd: resolved.workspaceDir,
-                    ...(resolved.model ? { model: resolved.model } : {}),
-                    ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
-                    personality: CODEX_NATIVE_PERSONALITY_NONE,
-                    ...buildThreadRequestRuntimeOptions(params, resolved),
-                  },
-                  ...requestOptions,
-                });
-              },
-              onClientChange: (client) => {
-                resolved.client = client;
-              },
-            });
-        await writeThreadBindingFromResponse(params, resolved, response);
-      } finally {
-        releaseCodexAppServerClientLease(resolved.clientLease);
-      }
-    },
+    run: () => bindThread(params, params.threadId),
   });
 }
 
-async function createThread(params: CodexThreadBindingParams): Promise<void> {
+async function bindThread(params: CodexThreadBindingParams, threadId?: string): Promise<void> {
   const current = await params.bindingStore.read(params.identity);
-  assertCodexBindingMayBeReplaced(current, "creating a conversation-bound Codex thread");
+  assertCodexBindingMayBeReplaced(current, "binding a conversation-bound Codex thread");
   const resolved = await resolveThreadBindingRuntime(params);
   try {
-    const response = await requestNewConversationBindingThread(params, resolved);
-    await writeThreadBindingFromResponse(params, resolved, response);
+    await withLeasedCodexAppServerClientStartSelectionRetry({
+      lease: resolved.clientLease,
+      options: resolved.clientOptions,
+      run: async (client, requestOptions) => {
+        const request = {
+          cwd: resolved.workspaceDir,
+          ...(resolved.model ? { model: resolved.model } : {}),
+          ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
+          personality: CODEX_NATIVE_PERSONALITY_NONE,
+          ...buildThreadRequestRuntimeOptions(params, resolved),
+        } satisfies CodexThreadStartParams;
+        let response: CodexThreadResumeResponse | CodexThreadStartResponse;
+        // Codex applies network-proxy permission profiles at thread/start. Resuming
+        // an arbitrary existing thread cannot prove that profile is active.
+        if (threadId && !resolved.runtime.networkProxy) {
+          if (isCodexAppServerLiveThreadClaimed(client, threadId)) {
+            throw new Error(
+              `Codex thread ${threadId} has an active run; stop it before binding its conversation.`,
+            );
+          }
+          const { thread } = await client.request(
+            "thread/read",
+            { threadId, includeTurns: false },
+            requestOptions(),
+          );
+          assertCodexThreadAcceptsDirectInput(thread);
+          const { assertCurrent } = requestOptions();
+          // Codex ignores resume config while any connection is still
+          // subscribed; interactive threads must drop the previous configuration.
+          await releaseCodexAppServerLiveThread(client, threadId, assertCurrent);
+          if (isCodexAppServerLiveThreadClaimed(client, threadId)) {
+            throw new Error(
+              `Codex thread ${threadId} has an active run; stop it before binding its conversation.`,
+            );
+          }
+          response = await resumeCodexAppServerThread({
+            client,
+            abandonClient: () => closeCodexStartupClientBestEffort(client),
+            request: { ...request, threadId },
+            requestResume: (resumeRequest) =>
+              client.request("thread/resume", resumeRequest, requestOptions()),
+          });
+        } else {
+          response = await client.request(
+            "thread/start",
+            {
+              ...request,
+              developerInstructions: CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS,
+              experimentalRawEvents: true,
+              ...(params.incognito ? { ephemeral: true } : {}),
+            },
+            requestOptions(),
+          );
+        }
+        await writeThreadBindingFromResponse(params, resolved, response, requestOptions);
+      },
+      onClientChange: (client) => {
+        resolved.client = client;
+      },
+    });
   } finally {
     releaseCodexAppServerClientLease(resolved.clientLease);
   }
@@ -899,7 +901,19 @@ async function runBoundTurn(params: {
     | undefined;
   let ownsNativeSubscription = false;
   let turnSucceeded = false;
+  const assertResumeInputAllowed = async () => {
+    const { thread } = await client.request(
+      "thread/read",
+      { threadId, includeTurns: false },
+      { timeoutMs: runtime.requestTimeoutMs },
+    );
+    assertCodexThreadAcceptsDirectInput(thread);
+  };
   try {
+    if (!networkProxyBindingChanged && binding.clientId !== client.getInstanceId()) {
+      // A new client may already retain this parent's child; check before claiming it.
+      await assertResumeInputAllowed();
+    }
     if (!params.incognito && isCodexAppServerClientRuntimeLive(client)) {
       const ownership = await consumeCodexAppServerLiveThread(client, threadId);
       if (ownership) {
@@ -931,7 +945,7 @@ async function runBoundTurn(params: {
                 experimentalRawEvents: true,
                 ...(params.incognito ? { ephemeral: true } : {}),
               },
-              requestOptions,
+              requestOptions(),
             ),
           onClientChange: (nextClient) => {
             client = nextClient;
@@ -940,6 +954,7 @@ async function runBoundTurn(params: {
       );
       threadId = response.thread.id;
       ownsNativeSubscription = true;
+      assertCodexThreadAcceptsDirectInput(response.thread);
       if (
         liveThreadOwnership &&
         (liveThreadOwnership.threadId !== threadId || liveThreadOwnership.client !== client)
@@ -997,6 +1012,9 @@ async function runBoundTurn(params: {
       binding.clientId !== client.getInstanceId() ||
       (isCodexAppServerClientRuntimeLive(client) && !params.incognito && !liveThreadOwnership)
     ) {
+      if (binding.clientId === client.getInstanceId()) {
+        await assertResumeInputAllowed();
+      }
       const response = await withLeasedCodexAppServerClientStartSelectionRetry({
         lease: clientLease,
         options: clientOptions,
@@ -1024,7 +1042,8 @@ async function runBoundTurn(params: {
               ...codexConversationSandboxOrPermissions(modelScopedRuntime, sandbox),
               ...(serviceTier ? { serviceTier } : {}),
             },
-            ...requestOptions,
+            requestResume: (request) =>
+              requestClient.request("thread/resume", request, requestOptions()),
           }),
         onClientChange: (nextClient) => {
           client = nextClient;
@@ -1032,6 +1051,7 @@ async function runBoundTurn(params: {
       });
       threadId = response.thread.id;
       ownsNativeSubscription = true;
+      assertCodexThreadAcceptsDirectInput(response.thread);
       if (
         !isSameCodexAppServerThreadOwner(binding, {
           threadId,
@@ -1113,6 +1133,20 @@ async function runBoundTurn(params: {
     };
   } catch (error) {
     if (isCodexAppServerOverloadError(error) && error.method === "thread/resume") {
+      throw error;
+    }
+    if (error instanceof CodexThreadDirectInputError) {
+      if (params.incognito && ownsNativeSubscription) {
+        // Resume can reveal a cold child's capability only after subscribing.
+        // Release that subscription without clearing the preserved binding.
+        const released = await unsubscribeCodexThreadBestEffort(client, {
+          threadId,
+          timeoutMs: CODEX_APP_SERVER_UNSUBSCRIBE_TIMEOUT_MS,
+        });
+        if (!released) {
+          await retireUnsafeCodexTurnClientBestEffort(client, "parent-owned thread unsubscribe");
+        }
+      }
       throw error;
     }
     if (
@@ -1301,7 +1335,7 @@ async function prepareConversationBinding(
     if (threadId && !options.forceNew) {
       await attachExistingThread({ ...bindingParams, threadId });
     } else {
-      await createThread(bindingParams);
+      await bindThread(bindingParams);
     }
     const stored = await params.bindingStore.read(identity);
     if (!stored) {

--- a/extensions/codex/src/conversation-control.test.ts
+++ b/extensions/codex/src/conversation-control.test.ts
@@ -72,8 +72,16 @@ vi.mock("./app-server/shared-client.js", () => ({
   }),
   withLeasedCodexAppServerClientStartSelectionRetry: async (params: {
     lease: { client?: unknown };
-    run: (client: unknown) => Promise<unknown>;
-  }) => await params.run(params.lease.client),
+    options?: { timeoutMs?: number };
+    run: (
+      client: unknown,
+      requestOptions: () => { timeoutMs: number; assertCurrent: () => void },
+    ) => Promise<unknown>;
+  }) =>
+    await params.run(params.lease.client, () => ({
+      timeoutMs: params.options?.timeoutMs ?? 60_000,
+      assertCurrent: () => undefined,
+    })),
 }));
 
 describe("codex conversation controls", () => {

--- a/src/commands/sessions-cleanup.harness.test.ts
+++ b/src/commands/sessions-cleanup.harness.test.ts
@@ -1,0 +1,209 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setRuntimeConfigSnapshot } from "../config/config.js";
+import {
+  appendTranscriptMessageSync,
+  loadSessionEntry,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginStateSyncKeyedStore } from "../plugin-state/plugin-state-store.js";
+import * as pluginModuleRuntime from "../plugins/loader-module-runtime.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { getActivePluginRegistry } from "../plugins/runtime.js";
+import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { createNonExitingRuntime } from "../runtime.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { sessionsCleanupCommand } from "./sessions-cleanup.js";
+
+const OWNER_PLUGIN_ID = "cleanup-owner";
+const HARNESS_ID = "cleanup-runtime";
+const STORE_OPTIONS = {
+  namespace: "session-bindings",
+  maxEntries: 10,
+  overflowPolicy: "reject-new",
+} as const;
+
+function writeCleanupPlugins(bundledRoot: string) {
+  const owner = writePlugin({
+    id: OWNER_PLUGIN_ID,
+    dir: path.join(bundledRoot, OWNER_PLUGIN_ID),
+    filename: "index.cjs",
+    body: `require("node:fs").writeFileSync(require("node:path").join(__dirname, "loaded"), "loaded");
+      module.exports = {
+      id: ${JSON.stringify(OWNER_PLUGIN_ID)},
+      register(api) {
+        api.registerAgentHarness({
+          id: ${JSON.stringify(HARNESS_ID)},
+          label: "Cleanup owner",
+          supports: () => ({ supported: false }),
+          async runAttempt() { throw new Error("cleanup must not run an agent turn"); },
+          async withSessionDeletion(params, run) {
+            params.assertCurrent();
+            const bindings = api.runtime.state.openSyncKeyedStore(${JSON.stringify(STORE_OPTIONS)});
+            const key = JSON.stringify([params.agentId, params.sessionKey, params.sessionId]);
+            const previous = bindings.lookup(key);
+            return await run({
+              commit() {
+                params.assertCurrent();
+                bindings.delete(key);
+              },
+              rollback() {
+                params.assertCurrent();
+                if (previous !== undefined) bindings.register(key, previous);
+              },
+            });
+          },
+        });
+      },
+    };`,
+  });
+  fs.writeFileSync(
+    path.join(owner.dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: owner.id,
+      activation: { onStartup: false, onAgentHarnesses: [HARNESS_ID] },
+      configSchema: { type: "object", additionalProperties: false },
+    }),
+  );
+  fs.writeFileSync(
+    path.join(owner.dir, "package.json"),
+    JSON.stringify({ name: `@openclaw/${owner.id}`, openclaw: { extensions: ["./index.cjs"] } }),
+  );
+  const unrelated = writePlugin({
+    id: "unrelated-cleanup-plugin",
+    body: `require("node:fs").writeFileSync(require("node:path").join(__dirname, "loaded"), "loaded");
+      module.exports = { id: "unrelated-cleanup-plugin", register() {} };`,
+  });
+  return { owner, unrelated };
+}
+
+beforeEach(() => {
+  // Reuse Vitest's real runtime graph; Jiti would compile a second host graph on first deletion.
+  vi.spyOn(pluginModuleRuntime, "createLazyPluginRuntime").mockImplementation(
+    ({ runtimeOptions }) => createPluginRuntime(runtimeOptions),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  resetPluginLoaderTestStateForTest();
+});
+
+afterAll(() => {
+  cleanupPluginLoaderFixturesForTest();
+});
+
+describe("offline sessions cleanup harness ownership", () => {
+  it.each([
+    { label: "recorded", metadata: "recorded", activation: "enabled" },
+    { label: "legacy", metadata: "legacy", activation: "enabled" },
+    { label: "implicitly permitted", metadata: "recorded", activation: "implicit" },
+    { label: "explicitly disabled", metadata: "recorded", activation: "disabled" },
+    { label: "explicitly disabled legacy", metadata: "legacy", activation: "disabled" },
+    { label: "globally disabled", metadata: "recorded", activation: "globally-disabled" },
+    { label: "denylisted", metadata: "recorded", activation: "denylisted" },
+    { label: "outside the allowlist", metadata: "recorded", activation: "not-allowlisted" },
+  ] as const)(
+    "reclaims allowed $label ownership and reports policy exclusions without running unrelated plugins",
+    async ({ metadata, activation }) => {
+      await withOpenClawTestState({ label: "offline-harness-cleanup" }, async (state) => {
+        const bundledRoot = state.path("bundled-plugins");
+        const { owner, unrelated } = writeCleanupPlugins(bundledRoot);
+        vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", undefined);
+        vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", bundledRoot);
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: { model: { primary: "other-provider/other-model" } },
+            entries: { main: { default: true, workspace: state.workspaceDir } },
+          },
+          plugins: {
+            enabled: activation !== "globally-disabled",
+            allow: activation === "not-allowlisted" ? [unrelated.id] : [owner.id, unrelated.id],
+            ...(activation === "denylisted" ? { deny: [owner.id] } : {}),
+            entries: {
+              ...(activation === "implicit"
+                ? {}
+                : { [owner.id]: { enabled: activation !== "disabled" } }),
+              [unrelated.id]: { enabled: true },
+            },
+            load: { paths: [unrelated.file] },
+            slots: { memory: "none" },
+          },
+          session: {
+            maintenance: {
+              mode: "warn",
+              pruneAfter: "1d",
+              preserveRecent: false,
+              maxDiskBytes: false,
+            },
+          },
+        };
+        setRuntimeConfigSnapshot(cfg, cfg);
+        const storePath = path.join(state.sessionsDir(), "sessions.json");
+        const sessionKey = "agent:main:cleanup-owned";
+        const siblingKey = "agent:main:cleanup-kept";
+        const sessionId = "shared-physical-id";
+        const scope = { agentId: "main", sessionKey, storePath };
+        const entry = {
+          sessionId,
+          updatedAt: Date.now() - 40 * 24 * 60 * 60 * 1000,
+          ...(metadata === "recorded" ? { agentHarnessId: HARNESS_ID } : {}),
+        };
+        await replaceSessionEntry(scope, entry);
+        appendTranscriptMessageSync(
+          { ...scope, sessionId },
+          { message: { role: "user", content: "Stored cleanup fixture" } },
+        );
+        await replaceSessionEntry(scope, entry);
+        await replaceSessionEntry(
+          { ...scope, sessionKey: siblingKey },
+          {
+            sessionId,
+            updatedAt: Date.now(),
+            ...(metadata === "recorded" ? { agentHarnessId: HARNESS_ID } : {}),
+          },
+        );
+        const bindings = createPluginStateSyncKeyedStore<{ threadId: string }>(
+          owner.id,
+          STORE_OPTIONS,
+        );
+        const key = JSON.stringify(["main", sessionKey, sessionId]);
+        const siblingBindingKey = JSON.stringify(["main", siblingKey, sessionId]);
+        bindings.register(key, { threadId: "removed-thread" });
+        bindings.register(siblingBindingKey, { threadId: "kept-thread" });
+        const runtime = createNonExitingRuntime();
+        vi.spyOn(runtime, "writeJson").mockImplementation(() => {});
+        const warnings = vi.spyOn(runtime, "error").mockImplementation(() => {});
+        const activeRegistry = getActivePluginRegistry();
+        expect(loadSessionEntry({ ...scope, readConsistency: "latest" })).toMatchObject(entry);
+
+        await sessionsCleanupCommand({ store: storePath, enforce: true, json: true }, runtime);
+
+        expect(loadSessionEntry({ ...scope, readConsistency: "latest" })).toBeUndefined();
+        if (activation !== "enabled" && activation !== "implicit") {
+          expect(bindings.lookup(key)).toEqual({ threadId: "removed-thread" });
+          expect(fs.existsSync(path.join(owner.dir, "loaded"))).toBe(false);
+          expect(warnings.mock.calls.flat().join("\n")).toContain(owner.id);
+          expect(warnings.mock.calls.flat().join("\n")).toContain("not cleaned");
+        } else {
+          expect(bindings.lookup(key)).toBeUndefined();
+          expect(bindings.entries()).toMatchObject([
+            { key: siblingBindingKey, value: { threadId: "kept-thread" } },
+          ]);
+          expect(warnings).not.toHaveBeenCalled();
+        }
+        expect(loadSessionEntry({ ...scope, sessionKey: siblingKey })?.sessionId).toBe(sessionId);
+        expect(bindings.lookup(siblingBindingKey)).toEqual({ threadId: "kept-thread" });
+        expect(fs.existsSync(path.join(unrelated.dir, "loaded"))).toBe(false);
+        expect(getActivePluginRegistry()).toBe(activeRegistry);
+      });
+    },
+  );
+});

--- a/src/commands/sessions-cleanup.runtime.ts
+++ b/src/commands/sessions-cleanup.runtime.ts
@@ -1,0 +1,134 @@
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
+import {
+  resolveSessionCleanupAction,
+  runSessionsCleanup,
+  type SessionStoreTarget,
+  type SessionsCleanupOptions,
+} from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withActivatedPluginIds } from "../plugins/activation-context.js";
+import { resolveManifestActivationPluginIds } from "../plugins/activation-planner.js";
+import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
+import { loadPluginRegistryHandle } from "../plugins/loader.js";
+import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+type CleanupRunResult = Awaited<ReturnType<typeof runSessionsCleanup>>;
+
+function prepareCleanupHarnessOwners(config: OpenClawConfig, workspaceDir: string) {
+  const metadata = loadPluginMetadataSnapshot({ config, workspaceDir });
+  const harnessOwners = metadata.plugins.flatMap((plugin) => {
+    const runtime = plugin.activation?.onAgentHarnesses?.[0];
+    return runtime ? [{ plugin, runtime }] : [];
+  });
+  const pluginIds = harnessOwners
+    .flatMap(({ plugin, runtime }) =>
+      resolveManifestActivationPluginIds({
+        config,
+        workspaceDir,
+        manifestRecords: [plugin],
+        trigger: { kind: "agentHarness", runtime },
+        requireExplicitManifestOwnerTrust: true,
+      }),
+    )
+    .toSorted();
+  // Persisted sessions outlive model selection. Include every permitted harness
+  // owner so concurrent rows and legacy entries do not lose their cleanup owner.
+  const registry = loadPluginRegistryHandle({
+    config: withActivatedPluginIds({ config, pluginIds }),
+    activationSourceConfig: config,
+    workspaceDir,
+    onlyPluginIds: pluginIds,
+    manifestRegistry: metadata.manifestRegistry,
+    discovery: metadata.discovery,
+    installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(metadata.index),
+    throwOnLoadError: true,
+  });
+  return {
+    registry,
+    excludedOwners: harnessOwners
+      .filter(({ plugin }) => !pluginIds.includes(plugin.id))
+      .map(({ plugin }) => plugin),
+  };
+}
+
+function warnUnavailableCleanupOwners(
+  owners: ReturnType<typeof prepareCleanupHarnessOwners>,
+  result: CleanupRunResult,
+  runtime: RuntimeEnv,
+): void {
+  const summary = result.appliedSummaries[0];
+  const preview = result.previewResults[0];
+  if (
+    owners.excludedOwners.length === 0 ||
+    !summary ||
+    !preview ||
+    summary.missing +
+      summary.dmScopeRetired +
+      summary.modelRunPruned +
+      summary.pruned +
+      summary.capped ===
+      0
+  ) {
+    return;
+  }
+  const candidateHarnessIds = new Set<string>();
+  let hasLegacyCandidate = false;
+  for (const [key, entry] of Object.entries(preview.beforeStore)) {
+    const action = resolveSessionCleanupAction({ ...preview, key });
+    if (!entry.sessionId || action === "keep" || action === "archive-dashboard") {
+      continue;
+    }
+    if (entry.agentHarnessId) {
+      candidateHarnessIds.add(entry.agentHarnessId);
+    } else {
+      hasLegacyCandidate = true;
+    }
+  }
+  const excluded = owners.excludedOwners.filter(
+    (plugin) =>
+      hasLegacyCandidate ||
+      plugin.activation?.onAgentHarnesses?.some((id) => candidateHarnessIds.has(id)),
+  );
+  if (excluded.length > 0) {
+    runtime.error(
+      `Warning: native session resources were not cleaned for unavailable harness owners: ${excluded
+        .map((plugin) => plugin.id)
+        .toSorted()
+        .join(", ")}. ` +
+        "Their plugins are disabled or not trusted; resources may remain. Enable or trust those plugins and use their repair flow.",
+    );
+  }
+}
+
+/** Owns plugin preparation only for the local destructive CLI path. */
+export async function runLocalSessionsCleanup(
+  params: { cfg: OpenClawConfig; opts: SessionsCleanupOptions; targets: SessionStoreTarget[] },
+  runtime: RuntimeEnv,
+): Promise<CleanupRunResult> {
+  const ownersByWorkspace = new Map<string, ReturnType<typeof prepareCleanupHarnessOwners>>();
+  const results: CleanupRunResult[] = [];
+  for (const target of params.targets) {
+    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, target.agentId);
+    let owners = ownersByWorkspace.get(workspaceDir);
+    if (!owners) {
+      owners = prepareCleanupHarnessOwners(params.cfg, workspaceDir);
+      ownersByWorkspace.set(workspaceDir, owners);
+    }
+    const result = await withPluginRuntimeRegistryScope(owners.registry, () =>
+      runSessionsCleanup({ ...params, targets: [target] }),
+    );
+    warnUnavailableCleanupOwners(owners, result, runtime);
+    results.push(result);
+  }
+  const first = results[0];
+  if (!first) {
+    return await runSessionsCleanup(params);
+  }
+  return {
+    mode: first.mode,
+    previewResults: results.flatMap((result) => result.previewResults),
+    appliedSummaries: results.flatMap((result) => result.appliedSummaries),
+  };
+}

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   enforceSessionDiskBudget: vi.fn(),
   resolveSessionCleanupAction: vi.fn(),
   runSessionsCleanup: vi.fn(),
+  runLocalSessionsCleanup: vi.fn(),
   serializeSessionCleanupResult: vi.fn(),
   callGateway: vi.fn(),
 }));
@@ -26,6 +27,10 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: mocks.loadConfig,
   loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("./sessions-cleanup.runtime.js", () => ({
+  runLocalSessionsCleanup: mocks.runLocalSessionsCleanup,
 }));
 
 vi.mock("./session-store-targets.js", () => ({
@@ -85,6 +90,7 @@ function gatewayTransportError(kind: "closed" | "timeout", code?: number): Gatew
 describe("sessionsCleanupCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.runLocalSessionsCleanup.mockImplementation((params) => mocks.runSessionsCleanup(params));
     mocks.loadConfig.mockReturnValue({ session: { store: "/cfg/sessions.json" } });
     mocks.resolveSessionStoreTargets.mockReturnValue([
       { agentId: "main", storePath: "/resolved/sessions.json" },
@@ -286,6 +292,7 @@ describe("sessionsCleanupCommand", () => {
 
     expect(mocks.callGateway).toHaveBeenCalledOnce();
     expect(mocks.runSessionsCleanup).not.toHaveBeenCalled();
+    expect(mocks.runLocalSessionsCleanup).not.toHaveBeenCalled();
   });
 
   it("keeps explicit offline store cleanup local", async () => {
@@ -330,6 +337,7 @@ describe("sessionsCleanupCommand", () => {
     expect(gatewayCall?.method).toBe("sessions.cleanup");
     expect(gatewayCall?.params.enforce).toBe(true);
     expect(gatewayCall?.requiredMethods).toEqual(["sessions.cleanup"]);
+    expect(mocks.runLocalSessionsCleanup).not.toHaveBeenCalled();
     expect(mocks.updateSessionStore).not.toHaveBeenCalled();
     expect(logs).toHaveLength(1);
     expect(JSON.parse(logs[0] ?? "{}")).toEqual({
@@ -452,6 +460,7 @@ describe("sessionsCleanupCommand", () => {
       wouldMutate: true,
     });
     expect(mocks.runSessionsCleanup).toHaveBeenCalled();
+    expect(mocks.runLocalSessionsCleanup).not.toHaveBeenCalled();
     expect(mocks.callGateway).not.toHaveBeenCalled();
     expect(mocks.updateSessionStore).not.toHaveBeenCalled();
   });

--- a/src/commands/sessions-cleanup.ts
+++ b/src/commands/sessions-cleanup.ts
@@ -311,11 +311,15 @@ export async function sessionsCleanupCommand(opts: SessionsCleanupOptions, runti
   if (!targets) {
     return;
   }
-  const { mode, previewResults, appliedSummaries } = await runSessionsCleanup({
-    cfg,
-    opts,
-    targets,
-  });
+  const cleanupParams = { cfg, opts, targets };
+  let cleanupResult;
+  if (opts.dryRun) {
+    cleanupResult = await runSessionsCleanup(cleanupParams);
+  } else {
+    const { runLocalSessionsCleanup } = await import("./sessions-cleanup.runtime.js");
+    cleanupResult = await runLocalSessionsCleanup(cleanupParams, runtime);
+  }
+  const { mode, previewResults, appliedSummaries } = cleanupResult;
 
   if (opts.dryRun) {
     if (opts.json) {

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -2048,7 +2048,7 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
         keyStartInclusive: "session-key:dev:",
         keyEndExclusive: "session-key:dev;",
         limit: 100,
-      }).find((row) => asOptionalRecord(row.value)?.sessionId === sessionId);
+      }).find((entry) => asOptionalRecord(entry.value)?.sessionId === sessionId);
       // Lease acquisition refreshes the KV write timestamp even when binding content is unchanged.
       return row ? { key: row.key, value: row.value } : undefined;
     };

--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -1990,6 +1990,7 @@ async function verifyCodexSubagentProbe(params: {
 
 async function verifyCodexNativeSubagentBridgeProbe(params: {
   client: GatewayClient;
+  events: EventFrame[];
   sessionKey: string;
 }): Promise<void> {
   const runId = randomUUID();
@@ -2030,6 +2031,54 @@ async function verifyCodexNativeSubagentBridgeProbe(params: {
       text,
     )}; events=${JSON.stringify(events)}; tasks=${JSON.stringify(codexNativeTasks)}`,
   ).toBeDefined();
+
+  const parentControlledChild = events.some(
+    (event) => event.stream === "codex_app_server.item" && event.data?.type === "subAgentActivity",
+  );
+  if (parentControlledChild) {
+    // Native task IDs record the child thread at creation; model output is not
+    // authoritative enough to select the thread for this ownership probe.
+    const childThreadId = deliveredTask?.sourceId?.match(/^codex-thread:(.+)$/)?.[1];
+    expect(childThreadId).toBeTypeOf("string");
+    const sessionId = await readCodexHarnessSessionId(params);
+    const readBinding = () => {
+      const row = pluginStateEntriesInKeyRange({
+        pluginId: "codex",
+        namespace: "app-server-thread-bindings",
+        keyStartInclusive: "session-key:dev:",
+        keyEndExclusive: "session-key:dev;",
+        limit: 100,
+      }).find((row) => asOptionalRecord(row.value)?.sessionId === sessionId);
+      // Lease acquisition refreshes the KV write timestamp even when binding content is unchanged.
+      return row ? { key: row.key, value: row.value } : undefined;
+    };
+    const bindingBefore = readBinding();
+    expect(bindingBefore).toBeDefined();
+    const threadIdBefore = asOptionalRecord(
+      asOptionalRecord(bindingBefore?.value)?.binding,
+    )?.threadId;
+    expect(threadIdBefore).toBeTypeOf("string");
+    expect(threadIdBefore).not.toBe(childThreadId);
+    await requestCodexCommandText({
+      ...params,
+      command: `/codex resume ${childThreadId}`,
+      expectedText: "controlled by its parent",
+    });
+    expect(readBinding()).toEqual(bindingBefore);
+    await requestAgentText({
+      client: params.client,
+      sessionKey: params.sessionKey,
+      message: "Reply exactly PARENT-STILL-ATTACHED and nothing else.",
+      expectedReply: "PARENT-STILL-ATTACHED",
+    });
+    expect(readBinding()?.key).toBe(bindingBefore?.key);
+    expect(asOptionalRecord(asOptionalRecord(readBinding()?.value)?.binding)?.threadId).toBe(
+      threadIdBefore,
+    );
+    logCodexLiveStep("native-subagent-direct-input:rejected", { childThreadId });
+  } else {
+    logCodexLiveStep("native-subagent-direct-input:legacy-not-applicable");
+  }
 
   function listCodexNativeTasks() {
     return listTaskRecords().filter(
@@ -2313,7 +2362,11 @@ describeLive("gateway live (Codex harness)", () => {
               logCodexLiveStep("subagent-probe:start", { sessionKey });
               await verifyCodexSubagentProbe({ client: activeClient, sessionKey });
               logCodexLiveStep("native-subagent-bridge-probe:start", { sessionKey });
-              await verifyCodexNativeSubagentBridgeProbe({ client: activeClient, sessionKey });
+              await verifyCodexNativeSubagentBridgeProbe({
+                client: activeClient,
+                events: gatewayEvents,
+                sessionKey,
+              });
               logCodexLiveStep("subagent-probe:done");
               if (CODEX_HARNESS_SUBAGENT_ONLY) {
                 return;


### PR DESCRIPTION
Related: #128366, #130701; integrates the failed-resume cleanup from #130862.

## What Problem This Solves

Fixes an issue where operators using offline session cleanup would delete the session but leave its native Codex binding consuming capacity. It also fixes attachment of parent-controlled native children: OpenClaw reported a successful attachment even though Codex does not allow direct input to those children.

Interrupted attachment could additionally outlive its request deadline or release retained native ownership before a passive refusal. These failures share the same boundary: a durable binding must have the right live owner, and a failed operation must not publish or abandon ownership implicitly.

## Why This Change Was Made

Offline cleanup now prepares the trusted harness owners in an operation-scoped plugin registry, independent of the agent's current model. Disabled or untrusted plugins remain excluded, with a warning when their resources may remain. Dry runs stay lightweight and the JSON result is unchanged.

The Codex plugin checks native direct-input capability before releasing existing ownership and again after resume. Create and attach share one binding flow; deadline checks remain valid through commit, while cleanup retains exact physical-client authority. Native child observation and monitoring remain available. Structured resume failures now also revoke the exact retained subscription after unsubscribe; a pending retention cannot resurrect it. No configuration, schema, or protocol-version changes are added.

Codex contract checked against current source and the managed 0.150.1 runtime: [native direct-input ownership](https://github.com/openai/codex/blob/89650c66f2f3ff0d028d3f5d6d0b187b2ed49be5/codex-rs/app-server/src/request_processors/thread_input.rs#L11). An explicit false forbids direct input; an unloaded or older thread's unknown capability is not treated as a refusal.

## User Impact

Offline cleanup actually frees permitted harness resources. Attempting to resume or bind a parent-controlled child produces an actionable refusal and preserves the current OpenClaw conversation. Expired or failed attachments do not publish a binding or leave an untracked native subscription behind.

## Evidence

- The original built-CLI reproduction left one Codex binding after deleting its session. The candidate removed the session and binding, returned capacity to zero, and kept stdout valid JSON.
- Real Control UI baseline, Gateway, and Codex 0.150.1 with native V2: reproduced the misleading attached response and verified that the child replaced the original native binding. Before video attached in the proof comment.
- Rebased head: 1,025 focused and sibling tests pass, including four accepted-attachment regressions and four retained-unsubscribe regressions that first failed before their fixes. Plugin production/test types, formatting, and lint pass. Fresh independent Codex review reports no remaining actionable P0–P2 findings. The complete changed-file gate and [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33062154877) pass.
- Final head `18a35c20d8fd11da533135c93ccf48c8e80bd798`: combined Linux build passed (5m14.7s), then real Gateway + Codex 0.150.1 + public Sol V2 completed in local-container run `run_e46819be787d` (exit 0). All 16 changed production-file hashes match. UI parent/child creation, refused child attachment, exact binding preservation, same-native-thread continuation, ordinary turns, reset/status, deletion, sibling continuation, and native-history resume passed. Built offline cleanup also passed in that run. Inspected before/after media is attached below.

Follow-up decisions remain separate: optimistic conflict handling for parent-fork SQLite writes, and how automatic continuations should preserve history when native thread configuration cannot be safely reapplied. Neither behavior is changed here.

Production LOC: +566/-213 (net +353); tests: +1192/-229 (net +963); docs: +10. The added production code owns two previously missing boundaries: generic offline CLI harness preparation (including trust exclusions and warnings), and native capability/deadline/subscription accounting through binding commit. Duplicate conversation create/attach flow was removed; existing plugin activation, scoped registry, and exact-client ownership primitives are reused. No new settings, persistent stores, or dependencies.

Provenance: the offline direct-cleanup path was carried forward by #105355 (e357203be57, 2026-07-12, code/PR author and merger @vincentkoc); this identifies the existing boundary, not the original introduction. Native attachment ownership was carried forward in #120740 and #128366 (45dd558d923c and 0924fd9a0c40, code/PR author and merger @steipete). Codex V2's direct-input restriction makes the missing admission check visible.

ClawSweeper follow-through: the supported Codex source was directly inspected, completed exact-head live proof is recorded above, and production growth is explained. The automated serialized/vector-data flag is a false positive: the new cleanup module composes existing registry and cleanup APIs; no persisted format, schema, embedding metadata, or migration changes. An initial mixed agent-API/UI recorder caused an intentional tool-catalog rotation; the final recorder creates and continues through the same UI and retains the exact-ID assertion.
