### PR TITLE
fix(release): reuse protected tooling lineage evidence

### DIFF
--- a/scripts/github/find-reusable-release-validation.sh
+++ b/scripts/github/find-reusable-release-validation.sh
@@ -329,7 +329,10 @@ for ((index = 0; index < run_count; index += 1)); do
           )
         else
           .manifestVersion == 3
-          and .workflowRefProof == "manifest-v3-protected-tag-exact-sha"
+          and (
+            .workflowRefProof == "manifest-v3-protected-tag-exact-sha"
+            or .workflowRefProof == "manifest-v3-protected-tag-tooling-lineage"
+          )
           and (.workflowRef | test("^release-ci/[0-9a-f]{12}-[1-9][0-9]*$"))
           and (.workflowRef | startswith("release-ci/\($parent.workflowSha[0:12])-"))
         end

--- a/test/scripts/find-reusable-release-validation.test.ts
+++ b/test/scripts/find-reusable-release-validation.test.ts
@@ -667,6 +667,71 @@ describe("scripts/github/find-reusable-release-validation.sh", () => {
     });
   });
 
+  it("reuses strict evidence produced by an ancestor of the protected tooling tag", () => {
+    const { clone, priorSha } = getSharedRepo();
+    const producerSha = "d".repeat(40);
+    const trustedWorkflowRef = `release-publish/${VERIFIER_SHA.slice(0, 12)}-456`;
+    const producerRef = `release-ci/${producerSha.slice(0, 12)}-122`;
+    const record = normalizedEvidence({
+      producerSha,
+      targetSha: priorSha,
+      trustedWorkflowRef,
+      workflowRef: producerRef,
+    });
+    record.current.workflowRefProof = "manifest-v3-protected-tag-tooling-lineage";
+    record.root.workflowRefProof = "manifest-v3-protected-tag-tooling-lineage";
+    const { binDir, fixtures, validatorPath } = setUpFixtures([{ record, runId: "111" }]);
+
+    const result = runResolver({
+      binDir,
+      fixtures,
+      repoDir: clone,
+      targetSha: priorSha,
+      trustedWorkflowRef,
+      validatorPath,
+      verifierOnMain: false,
+      workflowRef: `release-ci/${VERIFIER_SHA.slice(0, 12)}-123`,
+    });
+
+    expect(result.status).toBe(0);
+    expect(parseOutput(result.stdout)).toMatchObject({
+      evidence_run_id: "111",
+      reuse: "true",
+    });
+  });
+
+  it.each(["manifest-v3-protected-tag-diverged", "protected-tag-tooling-lineage"])(
+    "rejects unrecognized protected tooling proof %s",
+    (workflowRefProof) => {
+      const { clone, priorSha } = getSharedRepo();
+      const trustedWorkflowRef = `release-publish/${VERIFIER_SHA.slice(0, 12)}-456`;
+      const producerRef = `release-ci/${VERIFIER_SHA.slice(0, 12)}-122`;
+      const record = normalizedEvidence({
+        producerSha: VERIFIER_SHA,
+        targetSha: priorSha,
+        trustedWorkflowRef,
+        workflowRef: producerRef,
+      });
+      record.current.workflowRefProof = workflowRefProof;
+      record.root.workflowRefProof = workflowRefProof;
+      const { binDir, fixtures, validatorPath } = setUpFixtures([{ record, runId: "111" }]);
+
+      const result = runResolver({
+        binDir,
+        fixtures,
+        repoDir: clone,
+        targetSha: priorSha,
+        trustedWorkflowRef,
+        validatorPath,
+        verifierOnMain: false,
+        workflowRef: `release-ci/${VERIFIER_SHA.slice(0, 12)}-123`,
+      });
+
+      expect(result.status).toBe(0);
+      expect(parseOutput(result.stdout)).toMatchObject({ reuse: "false" });
+    },
+  );
+
   it.each([
     {
       label: "moved protected tag",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where changelog-only release validation rejected already-validated Code-SHA evidence when the protected verifier accepted its producer through trusted tooling ancestry.

## Why This Change Was Made

The reuse selector now accepts both protected-tag proof variants emitted by the shared evidence validator: exact verifier SHA and verified tooling lineage. All manifest-v3, canonical `release-ci/*` ref, producer SHA prefix, verifier source, child identity, and terminal-success requirements remain unchanged.

## User Impact

Release operators can reuse immutable product validation after a trusted verifier-only tooling update instead of launching a fresh product matrix for an unchanged candidate.

## Evidence

- Pre-fix regression: the tooling-lineage case was the sole failure in the focused suite (`1 failed, 51 passed`).
- Post-fix: `test/scripts/find-reusable-release-validation.test.ts` passed `52/52`.
- Existing exact-SHA protected-tag reuse remains covered.
- New negative cases reject malformed and diverged proof names.
- `bash -n scripts/github/find-reusable-release-validation.sh`: passed.
- Focused formatting, oxlint, `git diff --check`, and changed-file policy guards passed.
- The changed-file root typecheck reached only known sparse-worktree missing Android, Convex, and UI config files plus the shared `pako` declaration gap; it emitted no touched-file diagnostic.
- Autoreview: no accepted or actionable findings.

AI-assisted: yes. The maintainer reviewed the implementation and evidence.
