### PR TITLE
fix(auth): make Codex logout recovery actionable

### DIFF
--- a/scripts/e2e/mock-openai-server.mjs
+++ b/scripts/e2e/mock-openai-server.mjs
@@ -183,8 +183,12 @@ function readResponseEntry(value, label) {
     if (value.fail.mode === "drop" && value.fail.status !== undefined) {
       throw new Error(`${label} fail cannot combine status and drop`);
     }
+    const message = value.fail.message ?? "mantis injected fault";
+    if (typeof message !== "string" || !message.trim() || message.length > 2_000) {
+      throw new Error(`${label} fail message is invalid`);
+    }
     return {
-      fail: value.fail.mode === "drop" ? { mode: "drop" } : { status },
+      fail: value.fail.mode === "drop" ? { mode: "drop" } : { status, message },
       chunkDelayMs,
     };
   }
@@ -276,7 +280,7 @@ function writeInjectedFailure(res, fail) {
     res.destroy();
     return;
   }
-  writeJson(res, fail.status, { error: { message: "mantis injected fault" } });
+  writeJson(res, fail.status, { error: { message: fail.message } });
 }
 
 function splitResponseText(text) {

--- a/src/agents/auth-profiles/oauth-refresh-failure.test.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.test.ts
@@ -151,6 +151,34 @@ describe("oauth refresh failure hints", () => {
     });
   });
 
+  it("classifies provider requests to log in again", () => {
+    expect(
+      classifyOAuthRefreshFailure(
+        "OAuth token refresh failed for openai: Your session ended. Please log in again.",
+      ),
+    ).toEqual({
+      provider: "openai",
+      reason: "sign_in_again",
+    });
+  });
+
+  it("classifies refresh failures preserved in failover raw error metadata", () => {
+    expect(
+      classifyOAuthRefreshFailureError(
+        new FailoverError("Authentication refresh failed", {
+          reason: "auth_permanent",
+          provider: "openai",
+          profileId: "openai:work",
+          rawError: "OAuth token refresh failed for openai: refresh_token_invalidated",
+        }),
+      ),
+    ).toEqual({
+      provider: "openai",
+      profileId: "openai:work",
+      reason: "token_invalidated",
+    });
+  });
+
   it("classifies claude-cli subprocess 401 OAuth expiry as a provider refresh failure", () => {
     // Error message format emitted by the claude subprocess when its stored
     // OAuth token has expired, forwarded through the FailoverError message.

--- a/src/agents/auth-profiles/oauth-refresh-failure.ts
+++ b/src/agents/auth-profiles/oauth-refresh-failure.ts
@@ -1,4 +1,5 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 /**
@@ -153,7 +154,11 @@ export function classifyOAuthRefreshFailureReason(
   if (lower.includes("token_invalidated")) {
     return "token_invalidated";
   }
-  if (lower.includes("signing in again") || lower.includes("sign in again")) {
+  if (
+    lower.includes("signing in again") ||
+    lower.includes("sign in again") ||
+    lower.includes("log in again")
+  ) {
     return "sign_in_again";
   }
   if (lower.includes("invalid refresh token")) {
@@ -202,6 +207,18 @@ export function classifyOAuthRefreshFailureError(err: unknown): OAuthRefreshFail
         ...(profileId ? { profileId } : {}),
         reason: candidate.reason,
       };
+    }
+    const record = asOptionalRecord(candidate);
+    const rawError = record?.rawError;
+    if (typeof rawError === "string") {
+      const classified = classifyOAuthRefreshFailure(rawError);
+      if (classified) {
+        const rawProfileId = record?.profileId;
+        const profileId = sanitizeOAuthRefreshFailureProfileId(
+          typeof rawProfileId === "string" ? rawProfileId : undefined,
+        );
+        return { ...classified, ...(profileId ? { profileId } : {}) };
+      }
     }
     if (seen.has(candidate)) {
       return null;

--- a/src/agents/embedded-agent-runner/run/auth-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.test.ts
@@ -605,42 +605,45 @@ describe("createEmbeddedRunAuthController", () => {
     });
   });
 
-  it("preserves OAuth mode when billing-disabled profiles are all unavailable", async () => {
-    const harness = createMutableAuthControllerHarness();
-    const profileId = "custom-openai:oauth";
-    const controller = createMutableEmbeddedRunAuthController({
-      harness,
-      setRuntimeApiKey: vi.fn(),
-      profileCandidates: [profileId],
-      fallbackConfigured: true,
-      authStore: {
-        version: 1,
-        profiles: {
-          [profileId]: {
-            type: "oauth",
-            provider: "custom-openai",
-            access: "access-token",
-            refresh: "refresh-token",
-            expires: Date.now() + 60_000,
+  it.each(["billing", "auth_permanent"] as const)(
+    "preserves OAuth mode when %s-disabled profiles are all unavailable",
+    async (disabledReason) => {
+      const harness = createMutableAuthControllerHarness();
+      const profileId = "custom-openai:oauth";
+      const controller = createMutableEmbeddedRunAuthController({
+        harness,
+        setRuntimeApiKey: vi.fn(),
+        profileCandidates: [profileId],
+        fallbackConfigured: true,
+        authStore: {
+          version: 1,
+          profiles: {
+            [profileId]: {
+              type: "oauth",
+              provider: "custom-openai",
+              access: "access-token",
+              refresh: "refresh-token",
+              expires: Date.now() + 60_000,
+            },
+          },
+          usageStats: {
+            [profileId]: {
+              disabledUntil: Date.now() + 60_000,
+              disabledReason,
+            },
           },
         },
-        usageStats: {
-          [profileId]: {
-            disabledUntil: Date.now() + 60_000,
-            disabledReason: "billing",
-          },
-        },
-      },
-    });
+      });
 
-    const error = await controller.initializeAuthProfile().catch((err: unknown) => err);
+      const error = await controller.initializeAuthProfile().catch((err: unknown) => err);
 
-    expect(error).toBeInstanceOf(FailoverError);
-    expect(error).toMatchObject({
-      reason: "billing",
-      authMode: "oauth",
-    });
-  });
+      expect(error).toBeInstanceOf(FailoverError);
+      expect(error).toMatchObject({
+        reason: disabledReason,
+        authMode: "oauth",
+      });
+    },
+  );
 
   it("only enables transient cooldown probing when every automatic profile is transiently cooled", () => {
     const now = Date.now();

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -481,7 +481,10 @@ export function createEmbeddedRunAuthController(params: {
       });
     if (params.fallbackConfigured) {
       const authMode =
-        reason === "billing"
+        reason === "billing" ||
+        reason === "auth" ||
+        reason === "auth_permanent" ||
+        reason === "session_expired"
           ? resolveSubscriptionAuthModeForProfiles({
               store: params.authStore,
               profileIds: failoverParams.allInCooldown

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -77,6 +77,37 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads.map((payload) => payload.text)).not.toContain(errorJson);
   });
 
+  it("turns returned OpenAI refresh failures into Codex login recovery", () => {
+    const payloads = buildPayloads({
+      provider: "openai",
+      lastAssistant: makeAssistant({
+        stopReason: "error",
+        errorMessage: "OAuth token refresh failed for openai: refresh_token_invalidated",
+        content: [],
+      }),
+    });
+
+    expect(payloads).toEqual([
+      {
+        text: expect.stringContaining("/login codex"),
+        isError: true,
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                {
+                  label: "Log in to Codex",
+                  action: { type: "command", command: "/login codex" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]);
+  });
+
   it("suppresses mutating tool warnings when an assistant error reply already covers the turn", () => {
     const payloads = buildPayloads({
       assistantTexts: [errorJson],

--- a/src/agents/embedded-agent-runner/run/payloads.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.ts
@@ -2,6 +2,7 @@
  * Builds embedded-agent payload objects from attempt inputs and outcomes.
  */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { buildCodexLoginRecovery } from "../../../auto-reply/codex-login-recovery.js";
 import type { SourceReplyDeliveryMode } from "../../../auto-reply/get-reply-options.types.js";
 import {
   createHeartbeatToolResponsePayload,
@@ -33,6 +34,7 @@ import {
   sanitizeAssistantFinalAnswerText,
   sanitizeAssistantVisibleText,
 } from "../../../shared/text/assistant-visible-text.js";
+import { classifyOAuthRefreshFailure } from "../../auth-profiles/oauth-refresh-failure.js";
 import {
   BILLING_ERROR_USER_MESSAGE,
   formatAssistantErrorText,
@@ -219,19 +221,25 @@ export function buildEmbeddedRunPayloads(params: {
   const rawErrorMessage = lastAssistantNeedsErrorSurface
     ? normalizeOptionalString(assistantForPayload?.errorMessage)
     : undefined;
+  const oauthRefreshFailure = rawErrorMessage ? classifyOAuthRefreshFailure(rawErrorMessage) : null;
+  const codexLoginRecovery = buildCodexLoginRecovery({
+    provider: oauthRefreshFailure?.provider ?? params.provider,
+    oauthReason: oauthRefreshFailure?.reason,
+  });
   const errorText =
     assistantForPayload && lastAssistantNeedsErrorSurface
       ? suppressFailureArtifacts
         ? undefined
         : lastAssistantErrored || rawErrorMessage
-          ? formatUserFacingAssistantErrorText(assistantForPayload, {
+          ? (codexLoginRecovery?.hint ??
+            formatUserFacingAssistantErrorText(assistantForPayload, {
               cfg: params.config,
               sessionKey: params.sessionKey,
               provider: params.provider,
               providerOwner: params.providerOwner,
               model: params.model,
               authMode: params.authMode,
-            })
+            }))
           : formatAssistantErrorText(assistantForPayload, {
               cfg: params.config,
               sessionKey: params.sessionKey,
@@ -262,7 +270,11 @@ export function buildEmbeddedRunPayloads(params: {
     isTimeoutErrorMessage(rawErrorMessage) &&
     errorText === SYNTHESIZED_TIMEOUT_ERROR_TEXT;
   if (errorText && !deferAssistantTimeoutError) {
-    replyItems.push({ text: errorText, isError: true });
+    replyItems.push({
+      text: errorText,
+      isError: true,
+      ...(codexLoginRecovery ? { presentation: codexLoginRecovery.presentation } : {}),
+    });
   }
   const reasoningText =
     suppressAssistantArtifacts || runAborted || lastAssistantNeedsErrorSurface

--- a/src/agents/model-fallback-attempt.ts
+++ b/src/agents/model-fallback-attempt.ts
@@ -641,6 +641,8 @@ export function throwFallbackFailureSummary(params: {
     reason: lastAttempt?.reason ?? "unknown",
     provider: lastAttempt?.provider,
     model: lastAttempt?.model,
+    // Recovery must not infer OAuth from the provider after candidate errors collapse here.
+    authMode: lastAttempt?.authMode,
     status: lastAttempt?.status,
     code: lastAttempt?.code,
     cause: params.lastError instanceof Error ? params.lastError : undefined,

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -400,7 +400,10 @@ async function runWithModelFallbackInternal<T>(
           profileIds,
         });
         const authMode =
-          decision.reason === "billing"
+          decision.reason === "billing" ||
+          decision.reason === "auth" ||
+          decision.reason === "auth_permanent" ||
+          decision.reason === "session_expired"
             ? resolveSubscriptionAuthModeForProfiles({ store: authStore, profileIds })
             : undefined;
 

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -486,24 +486,32 @@ function createOverrideFailureRun(params: {
 function makeSingleProviderStore(params: {
   provider: string;
   usageStat: NonNullable<AuthProfileStore["usageStats"]>[string];
-  credentialType?: "api_key" | "token";
+  credentialType?: "api_key" | "oauth" | "token";
 }): AuthProfileStore {
   const profileId = `${params.provider}:default`;
   return {
     version: AUTH_STORE_VERSION,
     profiles: {
       [profileId]:
-        params.credentialType === "token"
+        params.credentialType === "oauth"
           ? {
-              type: "token",
+              type: "oauth",
               provider: params.provider,
-              token: "test-token",
+              access: "test-access",
+              refresh: "test-refresh",
+              expires: Date.now() + 60_000,
             }
-          : {
-              type: "api_key",
-              provider: params.provider,
-              key: "test-key",
-            },
+          : params.credentialType === "token"
+            ? {
+                type: "token",
+                provider: params.provider,
+                token: "test-token",
+              }
+            : {
+                type: "api_key",
+                provider: params.provider,
+                key: "test-key",
+              },
     },
     usageStats: {
       [profileId]: params.usageStat,
@@ -524,8 +532,8 @@ async function expectSkippedUnavailableProvider(params: {
   providerPrefix: string;
   usageStat: NonNullable<AuthProfileStore["usageStats"]>[string];
   expectedReason: string;
-  credentialType?: "api_key" | "token";
-  expectedAuthMode?: "token";
+  credentialType?: "api_key" | "oauth" | "token";
+  expectedAuthMode?: "oauth" | "token";
 }) {
   const provider = `${params.providerPrefix}-${crypto.randomUUID()}`;
   const cfg = makeProviderFallbackCfg(provider);
@@ -3451,6 +3459,39 @@ describe("runWithModelFallback", () => {
     expect(result.attempts[0]?.authMode).toBe("oauth");
   });
 
+  it("preserves auth mode metadata after fallback exhaustion", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.6-sol",
+            fallbacks: ["openai/gpt-5.6-terra"],
+          },
+        },
+      },
+    });
+    const run = vi.fn().mockRejectedValue(
+      new FailoverError("OpenAI OAuth unavailable", {
+        reason: "auth_permanent",
+        provider: "openai",
+        authMode: "oauth",
+      }),
+    );
+
+    const error = requireFallbackSummaryError(
+      await captureRejection(
+        runWithModelFallback({
+          cfg,
+          provider: "openai",
+          model: "gpt-5.6-sol",
+          run,
+        }),
+      ),
+    );
+
+    expect(error.authMode).toBe("oauth");
+  });
+
   it("falls back on model-not-found error shapes", async () => {
     const cases: Array<{
       name: string;
@@ -3572,6 +3613,19 @@ describe("runWithModelFallback", () => {
         cooldownUntil: Date.now() + 5 * 60_000,
       },
       expectedReason: "unknown",
+    });
+  });
+
+  it("preserves OAuth mode when auth-disabled profiles are skipped", async () => {
+    await expectSkippedUnavailableProvider({
+      providerPrefix: "auth-disabled",
+      usageStat: {
+        disabledUntil: Date.now() + 5 * 60_000,
+        disabledReason: "auth_permanent",
+      },
+      expectedReason: "auth_permanent",
+      credentialType: "oauth",
+      expectedAuthMode: "oauth",
     });
   });
 

--- a/src/auto-reply/codex-login-recovery.ts
+++ b/src/auto-reply/codex-login-recovery.ts
@@ -1,0 +1,53 @@
+import type { OAuthRefreshFailureReason } from "../agents/auth-profiles/oauth-refresh-failure.js";
+import type { FailoverReason } from "../agents/failover/signal.js";
+import type { MessagePresentation } from "../interactive/payload.js";
+
+export type CodexLoginRecoveryEvidence = {
+  provider?: string | null;
+  oauthReason?: OAuthRefreshFailureReason | null;
+  failoverReason?: FailoverReason;
+  authMode?: string;
+};
+
+export type CodexLoginRecovery = {
+  hint: string;
+  presentation: MessagePresentation;
+};
+
+const AUTH_PROFILE_LOGIN_REASONS = new Set<FailoverReason>([
+  "auth",
+  "auth_permanent",
+  "session_expired",
+]);
+
+/** Builds login recovery only from OAuth evidence, never from a provider name alone. */
+export function buildCodexLoginRecovery(
+  evidence: CodexLoginRecoveryEvidence,
+): CodexLoginRecovery | undefined {
+  const provider = evidence.provider?.trim().toLowerCase().replace(/_/gu, "-");
+  const needsLogin =
+    evidence.oauthReason !== null && evidence.oauthReason !== undefined
+      ? true
+      : evidence.authMode === "oauth" &&
+        evidence.failoverReason !== undefined &&
+        AUTH_PROFILE_LOGIN_REASONS.has(evidence.failoverReason);
+  if ((provider !== "openai" && provider !== "codex") || !needsLogin) {
+    return undefined;
+  }
+  return {
+    hint: "OpenAI needs a new login. Send `/login codex` from a private chat or Web UI session. Where shown, you can also select **Log in to Codex**.",
+    presentation: {
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [
+            {
+              label: "Log in to Codex",
+              action: { type: "command", command: "/login codex" },
+            },
+          ],
+        },
+      ],
+    },
+  };
+}

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -1,5 +1,8 @@
 import { sanitizeForLog } from "../../../packages/terminal-core/src/ansi.js";
-import { classifyOAuthRefreshFailureError } from "../../agents/auth-profiles/oauth-refresh-failure.js";
+import {
+  classifyOAuthRefreshFailure,
+  classifyOAuthRefreshFailureError,
+} from "../../agents/auth-profiles/oauth-refresh-failure.js";
 import {
   isCompactionFailureError,
   isLikelyContextOverflowError,
@@ -203,7 +206,8 @@ export async function handleAgentExecutionError(params: {
   const isContextOverflow =
     !isBilling && (failoverReason === "context_overflow" || isLikelyContextOverflowError(message));
   const isCompactionFailure = !isBilling && isCompactionFailureError(message);
-  const oauthRefreshFailure = classifyOAuthRefreshFailureError(err);
+  const oauthRefreshFailure =
+    classifyOAuthRefreshFailureError(err) ?? classifyOAuthRefreshFailure(message);
   const hasAuthProfileFailoverFailure = buildAuthProfileFailoverFailureText(err) !== null;
   const providerRequestError =
     !isBilling &&
@@ -440,12 +444,11 @@ export async function handleAgentExecutionError(params: {
   const userFacingMessage = isTransientHttp
     ? renderUserFacingText(message, { errorContext: true })
     : message;
-  const externalRunFailureReply =
+  const externalRunFailureCandidate =
     !isBilling &&
     !(isRateLimit && !isOverloaded) &&
     !rateLimitOrOverloadedCopy &&
-    !isContextOverflow &&
-    !params.shouldSurfaceToControlUi
+    !isContextOverflow
       ? buildExternalRunFailureReply(
           { message, error: err },
           {
@@ -456,6 +459,10 @@ export async function handleAgentExecutionError(params: {
             failoverFacts,
           },
         )
+      : undefined;
+  const externalRunFailureReply =
+    !params.shouldSurfaceToControlUi || externalRunFailureCandidate?.presentation
+      ? externalRunFailureCandidate
       : undefined;
   const fallbackText = isBilling
     ? renderBillingReplyCopy({
@@ -477,10 +484,10 @@ export async function handleAgentExecutionError(params: {
         ? rateLimitOrOverloadedCopy
         : isContextOverflow
           ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
-          : params.shouldSurfaceToControlUi
-            ? renderControlUiAgentFailureCopy(userFacingMessage)
-            : (externalRunFailureReply?.text ??
-              (turn.isHeartbeat
+          : (externalRunFailureReply?.text ??
+            (params.shouldSurfaceToControlUi
+              ? renderControlUiAgentFailureCopy(userFacingMessage)
+              : turn.isHeartbeat
                 ? HEARTBEAT_EXTERNAL_RUN_FAILURE_TEXT
                 : GENERIC_EXTERNAL_RUN_FAILURE_TEXT));
   const userVisibleFallbackText = resolveExternalRunFailureTextForConversation({
@@ -518,6 +525,11 @@ export async function handleAgentExecutionError(params: {
   await params.modelPatch.fail(err);
   return {
     kind: "final",
-    payload: markAgentRunFailureReplyPayload({ text: userVisibleFallbackText }),
+    payload: markAgentRunFailureReplyPayload({
+      text: userVisibleFallbackText,
+      ...(externalRunFailureReply?.presentation
+        ? { presentation: externalRunFailureReply.presentation }
+        : {}),
+    }),
   };
 }

--- a/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
@@ -11,8 +11,23 @@ import {
   createMinimalRunAgentTurnParams,
   createTestFallbackSummaryError,
 } from "./agent-runner-execution.test-support.js";
+import { buildKnownAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
 
 const state = setupAgentRunnerExecutionTestState();
+
+const CODEX_LOGIN_PRESENTATION = {
+  blocks: [
+    {
+      type: "buttons",
+      buttons: [
+        {
+          label: "Log in to Codex",
+          action: { type: "command", command: "/login codex" },
+        },
+      ],
+    },
+  ],
+};
 
 describe("executeAgentTurn: authentication failures", () => {
   it("surfaces gateway reauth guidance without a profile id", async () => {
@@ -47,8 +62,55 @@ describe("executeAgentTurn: authentication failures", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(
-        "⚠️ Model login expired on the gateway for openai. Send `/login codex` from a private chat or Web UI session to pair a new Codex login, or re-auth with `openclaw models auth login --provider openai` in a terminal, then try again.",
+        "⚠️ OpenAI needs a new login. Send `/login codex` from a private chat or Web UI session. Where shown, you can also select **Log in to Codex**. You can also re-auth with `openclaw models auth login --provider openai` on the gateway.",
       );
+      expect(result.payload.presentation).toEqual(CODEX_LOGIN_PRESENTATION);
+    }
+  });
+
+  it("adds Codex login recovery to raw forwarded refresh failures", async () => {
+    const message = "OAuth token refresh failed for openai: refresh_token_invalidated";
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError(message, {
+        reason: "auth_permanent",
+        provider: "openai",
+        model: "gpt-5.6-sol",
+        status: 401,
+        rawError: message,
+      }),
+    );
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.presentation).toEqual(CODEX_LOGIN_PRESENTATION);
+    }
+  });
+
+  it("keeps Codex login recovery actionable on Control UI turns", async () => {
+    state.isInternalMessageChannelMock.mockReturnValue(true);
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new OAuthRefreshFailureError({ provider: "openai", message: "refresh_token_reused" }),
+    );
+    const followupRun = createFollowupRun();
+    followupRun.run.messageProvider = "webchat";
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(
+      createMinimalRunAgentTurnParams({
+        followupRun,
+        sessionCtx: { Provider: "webchat", MessageSid: "msg" } as unknown as TemplateContext,
+      }),
+    );
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ OpenAI needs a new login. Send `/login codex` from a private chat or Web UI session. Where shown, you can also select **Log in to Codex**. You can also re-auth with `openclaw models auth login --provider openai` on the gateway.",
+      );
+      expect(result.payload.presentation).toEqual(CODEX_LOGIN_PRESENTATION);
     }
   });
 
@@ -67,9 +129,23 @@ describe("executeAgentTurn: authentication failures", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toBe(
-        "⚠️ Model login expired on the gateway for openai. Send `/login codex` from a private chat or Web UI session to pair a new Codex login, or re-auth with `openclaw models auth login --provider openai --profile-id 'openai:user@example.com'` in a terminal, then try again.",
+        "⚠️ OpenAI needs a new login. Send `/login codex` from a private chat or Web UI session. Where shown, you can also select **Log in to Codex**. You can also re-auth with `openclaw models auth login --provider openai --profile-id 'openai:user@example.com'` on the gateway.",
       );
+      expect(result.payload.presentation).toEqual(CODEX_LOGIN_PRESENTATION);
     }
+  });
+
+  it("preserves Codex login recovery in known failure payloads", () => {
+    const payload = buildKnownAgentRunFailureReplyPayload({
+      err: new OAuthRefreshFailureError({
+        provider: "openai",
+        message: "refresh_token_invalidated",
+      }),
+      sessionCtx: { Provider: "telegram", ChatType: "direct" } as TemplateContext,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(payload?.presentation).toEqual(CODEX_LOGIN_PRESENTATION);
   });
 
   it("preserves OAuth profile guidance through failover wrappers", async () => {
@@ -96,6 +172,7 @@ describe("executeAgentTurn: authentication failures", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toContain("--profile-id 'openai:user@example.com'");
+      expect(result.payload.presentation).toEqual(CODEX_LOGIN_PRESENTATION);
     }
   });
 
@@ -135,6 +212,7 @@ describe("executeAgentTurn: authentication failures", () => {
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.text).toContain("--profile-id 'openai:user@example.com'");
+      expect(result.payload.presentation).toEqual(CODEX_LOGIN_PRESENTATION);
     }
   });
 
@@ -160,10 +238,60 @@ describe("executeAgentTurn: authentication failures", () => {
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
-      expect(result.payload.text).toContain(
-        "openclaw models auth login --provider openai` in a terminal",
-      );
+      expect(result.payload.text).toContain("openclaw models auth login --provider openai");
       expect(result.payload.text).not.toContain("user@example.com");
+      expect(result.payload.presentation).toEqual(CODEX_LOGIN_PRESENTATION);
+    }
+  });
+
+  it("keeps disabled OpenAI OAuth profiles actionable on later turns", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(
+      new FailoverError("All OpenAI auth profiles are unavailable", {
+        reason: "auth_permanent",
+        provider: "openai",
+        model: "gpt-5.6-sol",
+        authMode: "oauth",
+        authProfileFailure: { allInCooldown: true },
+      }),
+    );
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toContain("/login codex");
+      expect(result.payload.presentation).toEqual(CODEX_LOGIN_PRESENTATION);
+    }
+  });
+
+  it.each([
+    {
+      label: "OpenAI API-key failures",
+      error: new FailoverError("invalid API key", {
+        reason: "auth_permanent",
+        provider: "openai",
+        model: "gpt-5.5",
+        authMode: "api-key",
+        authProfileFailure: { allInCooldown: true },
+      }),
+    },
+    {
+      label: "transient OpenAI refresh failures",
+      error: new OAuthRefreshFailureError({
+        provider: "openai",
+        message: "temporary upstream issue",
+      }),
+    },
+  ])("does not offer Codex login for $label", async ({ error }) => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(error);
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.presentation).toBeUndefined();
     }
   });
 

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -3,6 +3,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   buildOAuthRefreshFailureLoginCommand,
+  classifyOAuthRefreshFailure,
   classifyOAuthRefreshFailureError,
   formatOAuthRefreshFailureLoginCommandMarkdown,
 } from "../../agents/auth-profiles/oauth-refresh-failure.js";
@@ -33,6 +34,7 @@ import { buildProviderAuthRecoveryHint } from "../../agents/provider-auth-recove
 import { resolveSilentReplyPolicy } from "../../config/silent-reply.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { buildCodexLoginRecovery } from "../codex-login-recovery.js";
 import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
@@ -46,6 +48,8 @@ export function resolveReplyFailoverFacts(error: unknown, message: string) {
     : null;
   return {
     reason: classification?.kind === "reason" ? classification.reason : undefined,
+    provider: described.provider,
+    authMode: described.authMode,
     providerRequestError: resolveProviderRequestFailureCopy({
       classification,
       facet: classifyProviderRequestFacets({
@@ -81,7 +85,7 @@ const EXTERNAL_RUN_FAILURE_DETAIL_MAX_CHARS = 900;
 const AGENT_FAILED_BEFORE_REPLY_TEXT = "Agent failed before reply:";
 const PREFLIGHT_COMPACTION_FAILURE_PREFIX = "Preflight compaction required but failed:";
 
-type ExternalRunFailureReply = {
+type ExternalRunFailureReply = Pick<ReplyPayload, "text" | "presentation"> & {
   text: string;
   isGenericRunnerFailure: boolean;
 };
@@ -195,14 +199,6 @@ function formatForwardedExternalRunFailureText(message: string): string {
   return `⚠️ Agent failed before reply: ${detail}${/[.!?]$/u.test(detail) ? "" : "."} Please try again, or use /new to start a fresh session.`;
 }
 
-function supportsChannelCodexLogin(provider: string | null | undefined): boolean {
-  if (!provider) {
-    return false;
-  }
-  const normalizedProvider = provider.trim().toLowerCase().replace(/_/gu, "-");
-  return normalizedProvider === "openai" || normalizedProvider === "codex";
-}
-
 export function buildExternalRunFailureReply(
   input: ExternalRunFailureInput,
   options?: {
@@ -219,23 +215,29 @@ export function buildExternalRunFailureReply(
   const failoverFacts =
     options?.failoverFacts ??
     resolveReplyFailoverFacts(error ?? normalizedMessage, normalizedMessage);
-  const oauthRefreshFailure = classifyOAuthRefreshFailureError(error);
+  const oauthRefreshFailure =
+    classifyOAuthRefreshFailureError(error) ?? classifyOAuthRefreshFailure(normalizedMessage);
+  const codexLoginRecovery = buildCodexLoginRecovery({
+    provider: oauthRefreshFailure?.provider ?? failoverFacts.provider,
+    oauthReason: oauthRefreshFailure?.reason,
+    failoverReason: failoverFacts.reason,
+    authMode: failoverFacts.authMode,
+  });
   if (oauthRefreshFailure) {
     const loginCommand = buildOAuthRefreshFailureLoginCommand(oauthRefreshFailure.provider, {
       profileId: options?.includeAuthProfileId ? oauthRefreshFailure.profileId : undefined,
     });
     const loginCommandMarkdown = formatOAuthRefreshFailureLoginCommandMarkdown(loginCommand);
     const providerText = oauthRefreshFailure.provider ? ` for ${oauthRefreshFailure.provider}` : "";
-    const supportsCodexLogin = supportsChannelCodexLogin(oauthRefreshFailure.provider);
-    const channelLoginHint = supportsCodexLogin
-      ? "Send `/login codex` from a private chat or Web UI session to pair a new Codex login, or re-auth"
-      : "Re-auth";
-    const retryLoginHint = supportsCodexLogin
+    const retryLoginHint = codexLoginRecovery
       ? "send `/login codex` from a private chat or Web UI session to pair a new Codex login, or re-auth"
       : "re-auth";
     if (oauthRefreshFailure.reason) {
       return {
-        text: `⚠️ Model login expired on the gateway${providerText}. ${channelLoginHint} with ${loginCommandMarkdown} in a terminal, then try again.`,
+        text: codexLoginRecovery
+          ? `⚠️ ${codexLoginRecovery.hint} You can also re-auth with ${loginCommandMarkdown} on the gateway.`
+          : `⚠️ Model login expired on the gateway${providerText}. Re-auth with ${loginCommandMarkdown} in a terminal, then try again.`,
+        ...(codexLoginRecovery ? { presentation: codexLoginRecovery.presentation } : {}),
         isGenericRunnerFailure: false,
       };
     }
@@ -246,7 +248,13 @@ export function buildExternalRunFailureReply(
   }
   const authProfileFailoverFailure = buildAuthProfileFailoverFailureText(error);
   if (authProfileFailoverFailure) {
-    return { text: authProfileFailoverFailure, isGenericRunnerFailure: false };
+    return {
+      text: codexLoginRecovery
+        ? `${codexLoginRecovery.hint}\n\n${authProfileFailoverFailure}`
+        : authProfileFailoverFailure,
+      ...(codexLoginRecovery ? { presentation: codexLoginRecovery.presentation } : {}),
+      isGenericRunnerFailure: false,
+    };
   }
   const cliMaxTurnsError = findCliMaxTurnsError(error);
   if (cliMaxTurnsError) {
@@ -476,5 +484,8 @@ export function buildKnownAgentRunFailureReplyPayload(params: {
       isGenericRunnerFailure: false,
       cfg: params.cfg,
     }),
+    ...(externalRunFailureReply.presentation
+      ? { presentation: externalRunFailureReply.presentation }
+      : {}),
   });
 }

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -817,6 +817,7 @@ describe("CronService failure alerts", () => {
 
         const alert = alertCallArg(sendCronFailureAlert);
         expect(alert.text).toContain("Cause: auth_permanent");
+        expect(alert.text).toContain("/login codex");
         expect(alert.presentation).toEqual({
           blocks: [
             {

--- a/src/cron/service/failure-alerts.ts
+++ b/src/cron/service/failure-alerts.ts
@@ -6,6 +6,7 @@ import {
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { classifyOAuthRefreshFailure } from "../../agents/auth-profiles/oauth-refresh-failure.js";
 import type { FailoverReason } from "../../agents/failover/signal.js";
+import { buildCodexLoginRecovery } from "../../auto-reply/codex-login-recovery.js";
 import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
 import { normalizeAnyChannelId } from "../../channels/registry-normalize.js";
 import { resolveTargetPrefixedChannel } from "../../infra/outbound/channel-target-prefix.js";
@@ -270,27 +271,16 @@ function emitFailureAlert(
     ...detailLines,
   ].join("\n");
   const oauthRefreshFailure = params.error ? classifyOAuthRefreshFailure(params.error) : null;
+  const codexLoginRecovery =
+    params.status === "error" && (errorReason === "auth" || errorReason === "auth_permanent")
+      ? buildCodexLoginRecovery({
+          provider: oauthRefreshFailure?.provider,
+          oauthReason: oauthRefreshFailure?.reason,
+        })
+      : undefined;
   const payload: ReplyPayload = {
-    text,
-    ...(params.status === "error" &&
-    (errorReason === "auth" || errorReason === "auth_permanent") &&
-    oauthRefreshFailure?.provider === "openai"
-      ? {
-          presentation: {
-            blocks: [
-              {
-                type: "buttons" as const,
-                buttons: [
-                  {
-                    label: "Log in to Codex",
-                    action: { type: "command" as const, command: "/login codex" },
-                  },
-                ],
-              },
-            ],
-          },
-        }
-      : {}),
+    text: codexLoginRecovery ? `${text}\n${codexLoginRecovery.hint}` : text,
+    ...(codexLoginRecovery ? { presentation: codexLoginRecovery.presentation } : {}),
   };
 
   transportFailureAlert(state, {

--- a/test/scripts/e2e-mock-config-limits.test.ts
+++ b/test/scripts/e2e-mock-config-limits.test.ts
@@ -304,7 +304,7 @@ describe("mock OpenAI response markers", () => {
       hold: true,
       responses: [
         { text: "first response" },
-        { fail: { status: 429 } },
+        { fail: { status: 429, message: "OAuth token refresh failed for openai: invalid_grant" } },
         { text: "third response" },
       ],
       default: { text: "default response" },
@@ -329,7 +329,9 @@ describe("mock OpenAI response markers", () => {
           expect((await first.json()).output?.[0]?.content?.[0]?.text).toBe("first response");
           const second = await request();
           expect(second.status).toBe(429);
-          expect(await second.json()).toEqual({ error: { message: "mantis injected fault" } });
+          expect(await second.json()).toEqual({
+            error: { message: "OAuth token refresh failed for openai: invalid_grant" },
+          });
           const third = await request();
           expect((await third.json()).output?.[0]?.content?.[0]?.text).toBe("third response");
           const fourth = await request();


### PR DESCRIPTION
## Problem

Hard OpenAI OAuth failures had split recovery ownership. Automation alerts carried a **Log in to Codex** action, while normal turns, returned provider errors, Control UI turns, and later retries showed text-only failures. Later retries also lost the credential mode after an OAuth profile entered permanent auth cooldown.

## Root cause

- Cron built its own recovery button instead of using a shared auth-recovery payload.
- Normal failure formatters returned text only.
- Returned assistant errors rewrote OAuth failures before presentation was attached.
- Failover summaries dropped `authMode`, so later disabled-profile errors could not safely distinguish OAuth from API-key auth.
- Wrapped provider failures kept the exact refresh error in `rawError`, but the OAuth classifier only followed `cause`.

## Fix

- Add one canonical Codex login recovery descriptor with actionable fallback text and a typed `/login codex` button.
- Apply it to thrown failures, returned provider errors, Control UI text, later OAuth-profile failures, and automation alerts.
- Preserve OAuth mode through auth-profile and model-fallback summaries.
- Classify exact OAuth failures from structured causes, raw messages, and bounded `rawError` metadata.
- Keep API-key failures and transient refresh failures free of the Codex login action.
- Extend the E2E mock provider so a real channel run can reproduce exact provider failure text.

## Security

- The button is an explicit command action; it does not start OAuth by itself.
- Existing owner/admin authorization remains the only login authority.
- Telegram groups still reject device-code delivery and tell the owner to use a DM.
- No token, account, bot, host, or device-code material is included in this PR.

## Proof

- Regression red before the fix:
  - returned provider error: expected `/login codex` action, received generic refresh text;
  - normal, raw-wrapper, and Control UI cases: expected a presentation action, received none.
- Focused Vitest: 304 tests passed across auth classification, normal failures, returned errors, cron alerts, auth lifecycle, model fallback, and E2E mock controls.
- Static gates: format, Oxlint, import cycles, assertion safety, max-lines, auth pairing boundaries, deprecated APIs, coercion helpers, conflict markers, and test temp paths passed.
- Exact-head ClawSweeper at `c737d903364`: patch correct, zero findings, security cleared, no maintainer decision, and no rank-up moves.
- Typecheck/build: not run locally by repository host policy; hosted CI owns these gates.

### Telegram Test Server E2E

- Current `main`, owner DM: one provider request produced text-only auth failure and no callback button.
- Exact head `c737d903364`, owner DM: the failed turn showed **Log in to Codex**; the real callback click completed; a private OpenAI device-code prompt arrived.
- Exact head `c737d903364`, group: the failed turn showed the same button; clicking it returned DM-only guidance; zero device-code messages appeared in the group.
- The runner released its lease and the post-run doctor returned `ok: true`.

## Codex contract

- `../codex/codex-rs/login/src/auth/manager.rs:1614-1665` treats invalidated refresh tokens as permanent and revoked.
- `../codex/codex-rs/login/src/device_code_auth.rs:149-178,181-232` owns the explicit 15-minute device prompt, token exchange, validation, and persistence.

## Change size

- Production: +103 net lines. The growth carries one new cross-surface recovery capability and preserves the OAuth ownership fact across failure aggregation.
- Tests: +247 net lines.
- Tooling: +4 net lines.
- No config, schema, persistence, or public Plugin SDK surface changed.
