### PR TITLE
fix(android): keep Talk's speaking indicator active during reply replacement

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -128,7 +128,6 @@ internal suspend fun requestPhoneRealtimeSessionWithLanguageFallback(
 private enum class TalkStatusState {
   Off,
   Active,
-  SpeakFailure,
   TalkFailure,
 }
 
@@ -292,11 +291,11 @@ class TalkModeManager internal constructor(
     setStatus(TalkStatus(text = text, state = state, awaitingAgent = awaitingAgent))
   }
 
-  private fun setStatus(status: TalkStatus) =
-    synchronized(playbackLock) {
-      currentStatus = status
-      publishPlaybackState()
-    }
+  private fun setStatus(status: TalkStatus) {
+    currentStatus = status
+    _statusText.value = status.text
+    _awaitingAgent.value = status.awaitingAgent
+  }
 
   private fun setTalkFailure(text: NativeText) {
     setStatus(text, state = TalkStatusState.TalkFailure)
@@ -402,11 +401,9 @@ class TalkModeManager internal constructor(
   private var playbackEnabled = true
   private val playbackGeneration = AtomicLong(0L)
 
-  private enum class PlaybackPhase(
-    val status: TalkStatus,
-  ) {
-    Preparing(TalkStatus(nativeText("Generating voice…"), TalkStatusState.Active, awaitingAgent = true)),
-    Playing(TalkStatus(nativeText("Speaking…"), TalkStatusState.Active)),
+  private enum class PlaybackPhase {
+    Preparing,
+    Playing,
   }
 
   private data class PlaybackLease(
@@ -1028,7 +1025,7 @@ class TalkModeManager internal constructor(
         if (err is CancellationException) return@launch
         setStatus(nativeText("Start failed: \$message", err.message ?: err::class.simpleName.orEmpty()))
         Log.w(tag, "start failed: ${err.message ?: err::class.simpleName}")
-        stopRealtimeRelay(closeSession = false)
+        stopRealtimeRelay(closeSession = false, preserveStatus = true)
         disableRealtimeModeAndNotifyOwner()
       }
     }
@@ -1218,7 +1215,7 @@ class TalkModeManager internal constructor(
   ) {
     if (realtimeSessionId != sessionId) return
     setTalkFailure(nativeText("Talk failed: \$message", message))
-    stopRealtimeRelay(cancelCapture = false, cancelAppend = false)
+    stopRealtimeRelay(cancelCapture = false, cancelAppend = false, preserveStatus = true)
     disableRealtimeModeAndNotifyOwner()
   }
 
@@ -1424,7 +1421,7 @@ class TalkModeManager internal constructor(
         val closeStatus =
           currentStatus.takeIf { it.state == TalkStatusState.TalkFailure } ?: realtimeCloseStatus(closeReason)
         Log.d(tag, "realtime close reason=$closeReason")
-        stopRealtimeRelay(closeSession = false)
+        stopRealtimeRelay(closeSession = false, preserveStatus = true)
         if (_isEnabled.value) {
           _isEnabled.value = false
           setStatus(closeStatus)
@@ -1558,6 +1555,7 @@ class TalkModeManager internal constructor(
       _outputLevel.value =
         TalkAudioLevel.smoothed(_outputLevel.value ?: 0f, TalkAudioLevel.pcm16Level(bytes, writtenBytes))
       setRealtimePlaying(true)
+      setStatus(nativeText("Speaking…"))
       val durationMs = ((writtenBytes / 2.0) / realtimeSampleRateHz * 1000.0).toLong()
       realtimeWrittenFrames += writtenBytes / 2L
       val now = SystemClock.elapsedRealtime()
@@ -1640,6 +1638,9 @@ class TalkModeManager internal constructor(
             }
           acknowledgeRealtimePlaybackMarks(completed)
           if (idle) {
+            if (_isEnabled.value && realtimeSessionId != null) {
+              setStatus(nativeText("Listening"))
+            }
             return@launch
           }
         }
@@ -1671,13 +1672,20 @@ class TalkModeManager internal constructor(
       setRealtimePlaying(false)
     }
     _outputLevel.value = null
+    if (_isEnabled.value) {
+      setStatus(nativeText("Listening"))
+    }
   }
 
   private fun stopRealtimeRelay(
     closeSession: Boolean = true,
     cancelCapture: Boolean = true,
     cancelAppend: Boolean = true,
+    preserveStatus: Boolean = false,
   ) {
+    // Preserve the canonical status as one value so cleanup cannot split its
+    // user-visible text from typed failure and awaiting-agent semantics.
+    val status = currentStatus
     val (sessionId, captureJobs) =
       synchronized(realtimeCapturePauseLock) {
         val currentSessionId = realtimeSessionId
@@ -1707,6 +1715,9 @@ class TalkModeManager internal constructor(
     _speechActive.value = false
     _inputLevel.value = 0f
     stopRealtimePlayback()
+    if (preserveStatus) {
+      setStatus(status)
+    }
     _isListening.value = false
     if (closeSession && !sessionId.isNullOrBlank()) {
       gatewayWorkScope.launch {
@@ -1742,7 +1753,7 @@ class TalkModeManager internal constructor(
       )
     ) {
       Log.w(tag, "realtime output cancellation was not confirmed; closing relay")
-      stopRealtimeRelay()
+      stopRealtimeRelay(preserveStatus = true)
       synchronized(realtimeCapturePauseLock) {
         realtimeCapturePause =
           RealtimeCapturePause(
@@ -1794,7 +1805,7 @@ class TalkModeManager internal constructor(
       RealtimeCaptureResume.Restart -> start()
       RealtimeCaptureResume.Disconnected -> {
         setStatus(nativeText("Gateway not connected"))
-        stopRealtimeRelay()
+        stopRealtimeRelay(preserveStatus = true)
         disableRealtimeModeAndNotifyOwner()
       }
     }
@@ -2739,7 +2750,7 @@ class TalkModeManager internal constructor(
         ensurePlaybackActive(playbackToken)
         _lastAssistantText.value = cleaned
         lastSpokenText = cleaned
-        setStatus(nativeText("Listening"))
+        setStatus(nativeText("Generating voice…"), awaitingAgent = true)
       }
       try {
         val started = SystemClock.elapsedRealtime()
@@ -2777,7 +2788,8 @@ class TalkModeManager internal constructor(
         // Cancellation does not join: an old caller can finish after its replacement.
         if (localPlayback === lease) {
           localPlayback = null
-          failure?.let { setStatus(it, state = TalkStatusState.SpeakFailure) } ?: publishPlaybackState()
+          publishSpeakingState()
+          failure?.let { setStatus(it) }
         }
       }
       if (shouldResumeAfterSpeak) {
@@ -2794,7 +2806,7 @@ class TalkModeManager internal constructor(
         val token = playbackGeneration.incrementAndGet()
         val job = localPlayback?.job
         localPlayback = null
-        publishPlaybackState()
+        publishSpeakingState()
         token to job
       }
     // SystemSpeech's beforeSpeak callback takes playbackLock; never reverse that edge.
@@ -2806,19 +2818,14 @@ class TalkModeManager internal constructor(
 
   private fun setRealtimePlaying(playing: Boolean) =
     synchronized(playbackLock) {
-      val starting = playing && !realtimePlaying
       realtimePlaying = playing
-      if (starting) setStatus(nativeText("Listening")) else publishPlaybackState()
+      publishSpeakingState()
     }
 
   // Called under playbackLock; realtime producers enter only from realtimePlaybackLock.
-  // Playback overlays the base status without erasing what completion must reveal.
-  private fun publishPlaybackState() {
-    val phase = if (realtimePlaying) PlaybackPhase.Playing else localPlayback?.phase
-    _isSpeaking.value = phase == PlaybackPhase.Playing
-    val status = if (currentStatus.state == TalkStatusState.Active) phase?.status ?: currentStatus else currentStatus
-    _statusText.value = status.text
-    _awaitingAgent.value = status.awaitingAgent
+  // Either source can keep speaking after the other source completes or is cancelled.
+  private fun publishSpeakingState() {
+    _isSpeaking.value = realtimePlaying || localPlayback?.phase == PlaybackPhase.Playing
   }
 
   private fun markAudioPlaybackStarting(playbackToken: Long) {
@@ -2827,7 +2834,8 @@ class TalkModeManager internal constructor(
       val lease = localPlayback
       if (lease?.token != playbackToken || !lease.job.isActive) throw CancellationException("assistant speech cancelled")
       lease.phase = PlaybackPhase.Playing
-      publishPlaybackState()
+      publishSpeakingState()
+      setStatus(nativeText("Speaking…"))
     }
     ensureInterruptListener()
     requestAudioFocusForTts()

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -128,6 +128,7 @@ internal suspend fun requestPhoneRealtimeSessionWithLanguageFallback(
 private enum class TalkStatusState {
   Off,
   Active,
+  SpeakFailure,
   TalkFailure,
 }
 
@@ -269,6 +270,8 @@ class TalkModeManager internal constructor(
   private val _speechActive = MutableStateFlow(false)
   val speechActive: StateFlow<Boolean> = _speechActive
 
+  private val playbackLock = Any()
+
   @Volatile
   private var currentStatus = TalkStatus(text = nativeText("Off"), state = TalkStatusState.Off)
 
@@ -289,11 +292,11 @@ class TalkModeManager internal constructor(
     setStatus(TalkStatus(text = text, state = state, awaitingAgent = awaitingAgent))
   }
 
-  private fun setStatus(status: TalkStatus) {
-    currentStatus = status
-    _statusText.value = status.text
-    _awaitingAgent.value = status.awaitingAgent
-  }
+  private fun setStatus(status: TalkStatus) =
+    synchronized(playbackLock) {
+      currentStatus = status
+      publishPlaybackState()
+    }
 
   private fun setTalkFailure(text: NativeText) {
     setStatus(text, state = TalkStatusState.TalkFailure)
@@ -399,8 +402,21 @@ class TalkModeManager internal constructor(
   private var playbackEnabled = true
   private val playbackGeneration = AtomicLong(0L)
 
-  private var ttsJob: Job? = null
-  private val ttsJobLock = Any()
+  private enum class PlaybackPhase(
+    val status: TalkStatus,
+  ) {
+    Preparing(TalkStatus(nativeText("Generating voice…"), TalkStatusState.Active, awaitingAgent = true)),
+    Playing(TalkStatus(nativeText("Speaking…"), TalkStatusState.Active)),
+  }
+
+  private data class PlaybackLease(
+    val token: Long,
+    val job: Job,
+    var phase: PlaybackPhase = PlaybackPhase.Preparing,
+  )
+
+  private var localPlayback: PlaybackLease? = null
+  private var realtimePlaying = false
   private val systemSpeech = SystemSpeechSpeaker(context)
 
   @Volatile private var finalizeInFlight = false
@@ -838,13 +854,10 @@ class TalkModeManager internal constructor(
 
   /** Plays one text response through the configured Android/TalkMode TTS output. */
   fun playTtsForText(text: String) {
-    val playbackToken = playbackGeneration.incrementAndGet()
-    cancelActivePlayback()
+    val playbackToken = cancelActivePlayback()
     gatewayWorkScope.launch {
       reloadConfig()
-      runPlaybackSession(playbackToken) {
-        playAssistant(text, playbackToken)
-      }
+      playAssistant(text, playbackToken)
     }
   }
 
@@ -963,8 +976,10 @@ class TalkModeManager internal constructor(
 
   /** Enables or disables local assistant audio playback and stops active audio when disabled. */
   fun setPlaybackEnabled(enabled: Boolean) {
-    if (playbackEnabled == enabled) return
-    playbackEnabled = enabled
+    synchronized(playbackLock) {
+      if (playbackEnabled == enabled) return
+      playbackEnabled = enabled
+    }
     if (!enabled) {
       stopRealtimePlayback()
       stopSpeaking()
@@ -988,12 +1003,9 @@ class TalkModeManager internal constructor(
   /** Speaks a chat assistant reply when playback is enabled. */
   suspend fun speakAssistantReply(text: String) {
     if (!playbackEnabled) return
-    val playbackToken = playbackGeneration.incrementAndGet()
-    cancelActivePlayback()
+    val playbackToken = cancelActivePlayback()
     ensureConfigLoaded()
-    runPlaybackSession(playbackToken) {
-      playAssistant(text, playbackToken)
-    }
+    playAssistant(text, playbackToken)
   }
 
   private fun start() {
@@ -1016,7 +1028,7 @@ class TalkModeManager internal constructor(
         if (err is CancellationException) return@launch
         setStatus(nativeText("Start failed: \$message", err.message ?: err::class.simpleName.orEmpty()))
         Log.w(tag, "start failed: ${err.message ?: err::class.simpleName}")
-        stopRealtimeRelay(closeSession = false, preserveStatus = true)
+        stopRealtimeRelay(closeSession = false)
         disableRealtimeModeAndNotifyOwner()
       }
     }
@@ -1206,7 +1218,7 @@ class TalkModeManager internal constructor(
   ) {
     if (realtimeSessionId != sessionId) return
     setTalkFailure(nativeText("Talk failed: \$message", message))
-    stopRealtimeRelay(cancelCapture = false, cancelAppend = false, preserveStatus = true)
+    stopRealtimeRelay(cancelCapture = false, cancelAppend = false)
     disableRealtimeModeAndNotifyOwner()
   }
 
@@ -1412,7 +1424,7 @@ class TalkModeManager internal constructor(
         val closeStatus =
           currentStatus.takeIf { it.state == TalkStatusState.TalkFailure } ?: realtimeCloseStatus(closeReason)
         Log.d(tag, "realtime close reason=$closeReason")
-        stopRealtimeRelay(closeSession = false, preserveStatus = true)
+        stopRealtimeRelay(closeSession = false)
         if (_isEnabled.value) {
           _isEnabled.value = false
           setStatus(closeStatus)
@@ -1545,8 +1557,7 @@ class TalkModeManager internal constructor(
       // fills, so per-write metering tracks what the speaker actually plays.
       _outputLevel.value =
         TalkAudioLevel.smoothed(_outputLevel.value ?: 0f, TalkAudioLevel.pcm16Level(bytes, writtenBytes))
-      _isSpeaking.value = true
-      setStatus(nativeText("Speaking…"))
+      setRealtimePlaying(true)
       val durationMs = ((writtenBytes / 2.0) / realtimeSampleRateHz * 1000.0).toLong()
       realtimeWrittenFrames += writtenBytes / 2L
       val now = SystemClock.elapsedRealtime()
@@ -1622,16 +1633,13 @@ class TalkModeManager internal constructor(
               val awaitingPlaybackMark = pendingRealtimePlaybackMarks.values.any { it.targetFrame != null }
               val playbackIdle = playbackTimeElapsed && !awaitingPlaybackMark
               if (playbackIdle) {
-                _isSpeaking.value = false
+                setRealtimePlaying(false)
                 _outputLevel.value = null
               }
               completed to playbackIdle
             }
           acknowledgeRealtimePlaybackMarks(completed)
           if (idle) {
-            if (_isEnabled.value && realtimeSessionId != null) {
-              setStatus(nativeText("Listening"))
-            }
             return@launch
           }
         }
@@ -1660,23 +1668,16 @@ class TalkModeManager internal constructor(
       }
       realtimeAudioTrack = null
       realtimeWrittenFrames = 0L
+      setRealtimePlaying(false)
     }
-    _isSpeaking.value = false
     _outputLevel.value = null
-    if (_isEnabled.value) {
-      setStatus(nativeText("Listening"))
-    }
   }
 
   private fun stopRealtimeRelay(
     closeSession: Boolean = true,
     cancelCapture: Boolean = true,
     cancelAppend: Boolean = true,
-    preserveStatus: Boolean = false,
   ) {
-    // Preserve the canonical status as one value so cleanup cannot split its
-    // user-visible text from typed failure and awaiting-agent semantics.
-    val status = currentStatus
     val (sessionId, captureJobs) =
       synchronized(realtimeCapturePauseLock) {
         val currentSessionId = realtimeSessionId
@@ -1706,9 +1707,6 @@ class TalkModeManager internal constructor(
     _speechActive.value = false
     _inputLevel.value = 0f
     stopRealtimePlayback()
-    if (preserveStatus) {
-      setStatus(status)
-    }
     _isListening.value = false
     if (closeSession && !sessionId.isNullOrBlank()) {
       gatewayWorkScope.launch {
@@ -1744,7 +1742,7 @@ class TalkModeManager internal constructor(
       )
     ) {
       Log.w(tag, "realtime output cancellation was not confirmed; closing relay")
-      stopRealtimeRelay(preserveStatus = true)
+      stopRealtimeRelay()
       synchronized(realtimeCapturePauseLock) {
         realtimeCapturePause =
           RealtimeCapturePause(
@@ -1796,7 +1794,7 @@ class TalkModeManager internal constructor(
       RealtimeCaptureResume.Restart -> start()
       RealtimeCaptureResume.Disconnected -> {
         setStatus(nativeText("Gateway not connected"))
-        stopRealtimeRelay(preserveStatus = true)
+        stopRealtimeRelay()
         disableRealtimeModeAndNotifyOwner()
       }
     }
@@ -2414,11 +2412,8 @@ class TalkModeManager internal constructor(
         return
       }
       Log.d(tag, "assistant text ok chars=${assistant.length}")
-      val playbackToken = playbackGeneration.incrementAndGet()
-      cancelActivePlayback()
-      runPlaybackSession(playbackToken) {
-        playAssistant(assistant, playbackToken)
-      }
+      val playbackToken = cancelActivePlayback()
+      playAssistant(assistant, playbackToken)
     } catch (err: Throwable) {
       if (err is CancellationException) {
         Log.d(tag, "finalize speech cancelled")
@@ -2723,83 +2718,68 @@ class TalkModeManager internal constructor(
     text: String,
     playbackToken: Long,
   ) {
-    val parsed = TalkDirectiveParser.parse(text)
-    if (parsed.unknownKeys.isNotEmpty()) {
-      Log.w(tag, "Unknown talk directive keys: ${parsed.unknownKeys}")
-    }
-    val directive = parsed.directive
-    val cleaned = parsed.stripped.trim()
-    if (cleaned.isEmpty()) return
-    _lastAssistantText.value = cleaned
-    ensurePlaybackActive(playbackToken)
-
-    setStatus(nativeText("Generating voice…"), awaitingAgent = true)
-    _isSpeaking.value = false
-    lastSpokenText = cleaned
-
-    try {
-      val started = SystemClock.elapsedRealtime()
-      when (val result = talkSpeakClient.synthesize(text = cleaned, directive = directive)) {
-        is TalkSpeakResult.Success -> {
-          ensurePlaybackActive(playbackToken)
-          markAudioPlaybackStarting(playbackToken)
-          talkAudioPlayer.play(result.audio)
-          ensurePlaybackActive(playbackToken)
-          Log.d(tag, "talk.speak ok durMs=${SystemClock.elapsedRealtime() - started}")
-        }
-        is TalkSpeakResult.FallbackToLocal -> {
-          Log.d(tag, "talk.speak unavailable; using local TTS: ${result.message}")
-          speakWithSystemTts(cleaned, directive, playbackToken)
-          Log.d(tag, "system tts ok durMs=${SystemClock.elapsedRealtime() - started}")
-        }
-        is TalkSpeakResult.Failure -> {
-          throw IllegalStateException(result.message)
-        }
-      }
-    } catch (err: Throwable) {
-      if (isPlaybackCancelled(err, playbackToken)) {
-        Log.d(tag, "assistant speech cancelled")
-        return
-      }
-      setStatus(nativeText("Speak failed: \$message", err.message ?: err::class.simpleName.orEmpty()))
-      Log.w(tag, "talk playback failed: ${err.message ?: err::class.simpleName}")
-    } finally {
-      _isSpeaking.value = false
-    }
-  }
-
-  private suspend fun runPlaybackSession(
-    playbackToken: Long,
-    block: suspend () -> Unit,
-  ) {
-    val currentJob = coroutineContext[Job]
+    val lease = PlaybackLease(playbackToken, checkNotNull(coroutineContext[Job]))
     var shouldResumeAfterSpeak = false
+    var failure: NativeText? = null
     try {
-      val claimedPlayback =
-        synchronized(ttsJobLock) {
-          if (!playbackEnabled || playbackToken != playbackGeneration.get()) {
-            false
-          } else {
-            ttsJob = currentJob
-            true
-          }
-        }
-      if (!claimedPlayback) {
+      synchronized(playbackLock) {
         ensurePlaybackActive(playbackToken)
-        return
+        if (!lease.job.isActive) throw CancellationException("assistant speech cancelled")
+        localPlayback = lease
       }
-      ensurePlaybackActive(playbackToken)
       shouldResumeAfterSpeak = true
       onBeforeSpeak()
       ensurePlaybackActive(playbackToken)
-      block()
+      val parsed = TalkDirectiveParser.parse(text)
+      if (parsed.unknownKeys.isNotEmpty()) Log.w(tag, "Unknown talk directive keys: ${parsed.unknownKeys}")
+      val directive = parsed.directive
+      val cleaned = parsed.stripped.trim()
+      if (cleaned.isEmpty()) return
+      synchronized(playbackLock) {
+        ensurePlaybackActive(playbackToken)
+        _lastAssistantText.value = cleaned
+        lastSpokenText = cleaned
+        setStatus(nativeText("Listening"))
+      }
+      try {
+        val started = SystemClock.elapsedRealtime()
+        when (val result = talkSpeakClient.synthesize(text = cleaned, directive = directive)) {
+          is TalkSpeakResult.Success -> {
+            markAudioPlaybackStarting(playbackToken)
+            talkAudioPlayer.play(result.audio)
+            ensurePlaybackActive(playbackToken)
+            Log.d(tag, "talk.speak ok durMs=${SystemClock.elapsedRealtime() - started}")
+          }
+          is TalkSpeakResult.FallbackToLocal -> {
+            Log.d(tag, "talk.speak unavailable; using local TTS: ${result.message}")
+            ensurePlaybackActive(playbackToken)
+            systemSpeech.speak(
+              text = cleaned,
+              locale = TalkModeRuntime.validatedLanguage(directive?.language)?.let(Locale::forLanguageTag) ?: Locale.getDefault(),
+              speechRate = (TalkModeRuntime.resolveSpeed(directive?.speed, directive?.rateWpm) ?: 1.0).toFloat(),
+              beforeSpeak = { markAudioPlaybackStarting(playbackToken) },
+            )
+            ensurePlaybackActive(playbackToken)
+            Log.d(tag, "system tts ok durMs=${SystemClock.elapsedRealtime() - started}")
+          }
+          is TalkSpeakResult.Failure -> throw IllegalStateException(result.message)
+        }
+      } catch (err: Throwable) {
+        if (isPlaybackCancelled(err, playbackToken)) {
+          Log.d(tag, "assistant speech cancelled")
+          return
+        }
+        failure = nativeText("Speak failed: \$message", err.message ?: err::class.simpleName.orEmpty())
+        Log.w(tag, "talk playback failed: ${err.message ?: err::class.simpleName}")
+      }
     } finally {
-      synchronized(ttsJobLock) {
-        if (ttsJob === currentJob) {
-          ttsJob = null
+      synchronized(playbackLock) {
+        // Cancellation does not join: an old caller can finish after its replacement.
+        if (localPlayback === lease) {
+          localPlayback = null
+          failure?.let { setStatus(it, state = TalkStatusState.SpeakFailure) } ?: publishPlaybackState()
         }
       }
-      _isSpeaking.value = false
       if (shouldResumeAfterSpeak) {
         withContext(NonCancellable) {
           onAfterSpeak()
@@ -2808,35 +2788,47 @@ class TalkModeManager internal constructor(
     }
   }
 
-  private fun cancelActivePlayback() {
-    val activeJob =
-      synchronized(ttsJobLock) {
-        ttsJob
+  private fun cancelActivePlayback(): Long {
+    val (token, activeJob) =
+      synchronized(playbackLock) {
+        val token = playbackGeneration.incrementAndGet()
+        val job = localPlayback?.job
+        localPlayback = null
+        publishPlaybackState()
+        token to job
       }
+    // SystemSpeech's beforeSpeak callback takes playbackLock; never reverse that edge.
     activeJob?.cancel()
     talkAudioPlayer.stop()
     systemSpeech.stop()
+    return token
   }
 
-  private suspend fun speakWithSystemTts(
-    text: String,
-    directive: TalkDirective?,
-    playbackToken: Long,
-  ) {
-    ensurePlaybackActive(playbackToken)
-    systemSpeech.speak(
-      text = text,
-      locale = TalkModeRuntime.validatedLanguage(directive?.language)?.let(Locale::forLanguageTag) ?: Locale.getDefault(),
-      speechRate = (TalkModeRuntime.resolveSpeed(directive?.speed, directive?.rateWpm) ?: 1.0).toFloat(),
-      beforeSpeak = { markAudioPlaybackStarting(playbackToken) },
-    )
-    ensurePlaybackActive(playbackToken)
+  private fun setRealtimePlaying(playing: Boolean) =
+    synchronized(playbackLock) {
+      val starting = playing && !realtimePlaying
+      realtimePlaying = playing
+      if (starting) setStatus(nativeText("Listening")) else publishPlaybackState()
+    }
+
+  // Called under playbackLock; realtime producers enter only from realtimePlaybackLock.
+  // Playback overlays the base status without erasing what completion must reveal.
+  private fun publishPlaybackState() {
+    val phase = if (realtimePlaying) PlaybackPhase.Playing else localPlayback?.phase
+    _isSpeaking.value = phase == PlaybackPhase.Playing
+    val status = if (currentStatus.state == TalkStatusState.Active) phase?.status ?: currentStatus else currentStatus
+    _statusText.value = status.text
+    _awaitingAgent.value = status.awaitingAgent
   }
 
   private fun markAudioPlaybackStarting(playbackToken: Long) {
-    ensurePlaybackActive(playbackToken)
-    setStatus(nativeText("Speaking…"))
-    _isSpeaking.value = true
+    synchronized(playbackLock) {
+      ensurePlaybackActive(playbackToken)
+      val lease = localPlayback
+      if (lease?.token != playbackToken || !lease.job.isActive) throw CancellationException("assistant speech cancelled")
+      lease.phase = PlaybackPhase.Playing
+      publishPlaybackState()
+    }
     ensureInterruptListener()
     requestAudioFocusForTts()
   }
@@ -2856,7 +2848,6 @@ class TalkModeManager internal constructor(
       }
     }
     stopSpeaking(resetInterrupt = true)
-    _isSpeaking.value = false
     setStatus(nativeText("Listening"))
   }
 
@@ -2905,17 +2896,10 @@ class TalkModeManager internal constructor(
     }
 
   private fun stopSpeaking(resetInterrupt: Boolean = true) {
-    playbackGeneration.incrementAndGet()
-    if (!_isSpeaking.value) {
-      cancelActivePlayback()
-      abandonAudioFocus()
-      return
-    }
-    if (resetInterrupt) {
+    if (resetInterrupt && _isSpeaking.value) {
       lastInterruptedAtSeconds = null
     }
     cancelActivePlayback()
-    _isSpeaking.value = false
     abandonAudioFocus()
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -922,7 +922,6 @@ class TalkModeManagerTest {
         assertEquals(1, proof.callbackDepth())
         assertEquals(AudioTrack.PLAYSTATE_PLAYING, track.playState)
         assertTrue("Preparing a local reply must not hide realtime playback", proof.manager.isSpeaking.value)
-        assertEquals("Speaking…", proof.manager.statusText.value)
       }
     }
 
@@ -943,7 +942,6 @@ class TalkModeManagerTest {
         assertEquals(0, proof.callbackDepth())
         assertEquals(AudioTrack.PLAYSTATE_PLAYING, track.playState)
         assertTrue("Completing a local reply must not hide realtime playback", proof.manager.isSpeaking.value)
-        assertEquals("Speaking…", proof.manager.statusText.value)
       }
     }
 
@@ -952,42 +950,6 @@ class TalkModeManagerTest {
 
   @Test
   fun realtimeIdleKeepsLocalPlaybackSpeaking() = assertRealtimeEndKeepsLocalPlaybackSpeaking(clear = false)
-
-  @Test
-  fun realtimeCompletionPreservesReportedPlaybackFailures() =
-    runBlocking {
-      for (localFailure in listOf(true, false)) {
-        for (clear in listOf(true, false)) {
-          withRealtimePlayback { proof ->
-            val track = startRealtimeAudio(proof)
-            val expected = if (localFailure) "Speak failed: synthesis unavailable" else "Talk failed: relay unavailable"
-            if (localFailure) {
-              proof.synthesizer.result.complete(TalkSpeakResult.Failure("synthesis unavailable"))
-              val local = proof.scope.launch { proof.manager.speakAssistantReply("Local reply") }
-              proof.scheduler.runCurrent()
-              assertTrue(local.isCompleted)
-              assertEquals(0, proof.callbackDepth())
-            } else {
-              proof.manager.handleGatewayEvent(
-                "talk.event",
-                """{"relaySessionId":"playback-relay","type":"error","message":"relay unavailable"}""",
-              )
-            }
-            assertTrue(proof.manager.isSpeaking.value)
-            assertEquals(expected, proof.manager.statusText.value)
-            assertTrue(track === startRealtimeAudio(proof))
-            assertEquals("Another chunk must not erase the reported failure", expected, proof.manager.statusText.value)
-
-            finishRealtimeAudio(proof, track, clear)
-
-            assertFalse(proof.manager.isSpeaking.value)
-            assertEquals(expected, proof.manager.statusText.value)
-            proof.manager.stopTts()
-            assertEquals("Listening", proof.manager.statusText.value)
-          }
-        }
-      }
-    }
 
   private fun assertRealtimeEndKeepsLocalPlaybackSpeaking(clear: Boolean) =
     runBlocking {
@@ -1007,12 +969,10 @@ class TalkModeManagerTest {
         assertEquals(localStops, proof.player.stopCalls)
         assertEquals(1, proof.callbackDepth())
         assertTrue("Ending realtime output must not hide the local reply", proof.manager.isSpeaking.value)
-        assertEquals("Speaking…", proof.manager.statusText.value)
         proof.player.finished.complete(Unit)
         proof.scheduler.runCurrent()
         assertTrue(local.isCompleted)
         assertFalse(proof.manager.isSpeaking.value)
-        assertEquals("Listening", proof.manager.statusText.value)
       }
     }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -2,6 +2,9 @@ package ai.openclaw.app.voice
 
 import ai.openclaw.app.SecurePrefs
 import ai.openclaw.app.gateway.DeviceAuthStore
+import ai.openclaw.app.gateway.GatewayClientInfo
+import ai.openclaw.app.gateway.GatewayConnectOptions
+import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.GatewayRequestRejected
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.testDeviceIdentityStore
@@ -11,6 +14,8 @@ import ai.openclaw.app.i18n.verbatimText
 import android.Manifest
 import android.content.ComponentName
 import android.content.IntentFilter
+import android.media.AudioFormat
+import android.media.AudioTrack
 import android.os.Bundle
 import android.os.Looper
 import android.os.SystemClock
@@ -18,6 +23,7 @@ import android.speech.RecognitionListener
 import android.speech.RecognitionService
 import android.speech.SpeechRecognizer
 import android.speech.tts.TextToSpeech
+import android.util.Base64
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -28,9 +34,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -39,6 +49,17 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -49,10 +70,15 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowAudioTrack
+import org.robolectric.shadows.ShadowSystemClock
 import org.robolectric.shadows.ShadowTextToSpeech
+import java.time.Duration
 import java.util.Locale
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.coroutines.CoroutineContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
@@ -106,22 +132,20 @@ class TalkModeManagerTest {
   @Test
   fun stopTtsWithoutOutputIdentityCancelsPlaybackWithoutReplacingCancellationWaiter() =
     runTest {
-      val manager = createManager(scope = this)
-      val playbackJob = Job()
-      val pendingClear = CompletableDeferred<String?>()
+      withStartedLocalPlayback { manager, playbackJob, player ->
+        val pendingClear = CompletableDeferred<String?>()
+        setPrivateField(manager, "realtimeSessionId", "relay-1")
+        setPrivateField(manager, "realtimeOutputTurnId", " ")
+        setPrivateField(manager, "pendingRealtimeOutputClear", pendingClear)
+        val stops = player.stopCalls
 
-      setPrivateField(manager, "ttsJob", playbackJob)
-      setPrivateField(manager, "realtimeSessionId", "relay-1")
-      setPrivateField(manager, "realtimeOutputTurnId", " ")
-      setPrivateField(manager, "pendingRealtimeOutputClear", pendingClear)
-      playbackGeneration(manager).set(7L)
+        manager.stopTts()
+        runCurrent()
 
-      manager.stopTts()
-      runCurrent()
-
-      assertTrue(playbackJob.isCancelled)
-      assertEquals(8L, playbackGeneration(manager).get())
-      assertTrue(readPrivateField(manager, "pendingRealtimeOutputClear") === pendingClear)
+        assertTrue(playbackJob.isCancelled)
+        assertEquals(stops + 1, player.stopCalls)
+        assertTrue(readPrivateField(manager, "pendingRealtimeOutputClear") === pendingClear)
+      }
     }
 
   @Test
@@ -142,19 +166,18 @@ class TalkModeManagerTest {
     }
 
   @Test
-  fun disablingPlaybackCancelsTrackedJobOnce() {
-    val manager = createManager()
-    val playbackJob = Job()
+  fun disablingPlaybackCancelsTrackedJobOnce() =
+    runTest {
+      withStartedLocalPlayback { manager, playbackJob, player ->
+        val stops = player.stopCalls
+        manager.setPlaybackEnabled(false)
+        manager.setPlaybackEnabled(false)
+        runCurrent()
 
-    setPrivateField(manager, "ttsJob", playbackJob)
-    playbackGeneration(manager).set(11L)
-
-    manager.setPlaybackEnabled(false)
-    manager.setPlaybackEnabled(false)
-
-    assertTrue(playbackJob.isCancelled)
-    assertEquals(12L, playbackGeneration(manager).get())
-  }
+        assertTrue(playbackJob.isCancelled)
+        assertEquals(stops + 1, player.stopCalls)
+      }
+    }
 
   @Test
   fun beginPushToTalkRejectsNewCaptureWhenNewCaptureIsDisallowed() =
@@ -817,6 +840,393 @@ class TalkModeManagerTest {
     }
 
   @Test
+  fun cancelledPlaybackCompletionKeepsReplacementSpeaking() =
+    runTest {
+      val synthesizer = FakeTalkSpeechSynthesizer()
+      synthesizer.result.complete(
+        TalkSpeakResult.Success(
+          TalkSpeakAudio(
+            bytes = byteArrayOf(1, 2, 3),
+            provider = "test",
+            outputFormat = "mp3_44100_128",
+            voiceCompatible = true,
+            mimeType = "audio/mpeg",
+            fileExtension = ".mp3",
+          ),
+        ),
+      )
+      val player = FakeTalkAudioPlayer()
+      val managerJob = SupervisorJob()
+      var callbackDepth = 0
+      val manager =
+        createManager(
+          talkSpeakClient = synthesizer,
+          talkAudioPlayer = player,
+          scope = CoroutineScope(coroutineContext + managerJob),
+          onBeforeSpeak = { callbackDepth += 1 },
+          onAfterSpeak = { callbackDepth -= 1 },
+        )
+      withMain {
+        val first = launch { manager.speakAssistantReply("First reply") }
+        var replacement: Job? = null
+        try {
+          runCurrent()
+          assertEquals(1, player.playCalls)
+          assertEquals(1, callbackDepth)
+          assertTrue(manager.isSpeaking.value)
+
+          // Cancellation queues the old caller's cleanup; the replacement may
+          // start before that cleanup runs on another dispatcher.
+          val next = launch(start = CoroutineStart.UNDISPATCHED) { manager.speakAssistantReply("Replacement reply") }
+          replacement = next
+          assertEquals(2, player.playCalls)
+          assertEquals(2, callbackDepth)
+          assertTrue(first.isCancelled)
+          assertFalse(first.isCompleted)
+          assertTrue(manager.isSpeaking.value)
+
+          runCurrent()
+          assertTrue(first.isCompleted)
+          assertTrue(next.isActive)
+          assertFalse(player.finished.isCompleted)
+          assertEquals(1, callbackDepth)
+          assertTrue("The replacement is still playing after the cancelled caller finishes", manager.isSpeaking.value)
+
+          player.finished.complete(Unit)
+          next.join()
+          assertFalse(manager.isSpeaking.value)
+          assertEquals(0, callbackDepth)
+        } finally {
+          manager.stopAllCapture()
+          first.cancelAndJoin()
+          replacement?.cancelAndJoin()
+          managerJob.cancelAndJoin()
+          runCurrent()
+          shadowOf(Looper.getMainLooper()).idle()
+          runCurrent()
+        }
+      }
+    }
+
+  @Test
+  fun localPreparationKeepsRealtimePlaybackSpeaking() =
+    runBlocking {
+      withRealtimePlayback { proof ->
+        val track = startRealtimeAudio(proof)
+        val local = proof.scope.launch { proof.manager.speakAssistantReply("Local reply") }
+        proof.scheduler.runCurrent()
+
+        assertTrue(proof.synthesizer.requested.isCompleted)
+        assertFalse(proof.synthesizer.result.isCompleted)
+        assertTrue(local.isActive)
+        assertEquals(1, proof.callbackDepth())
+        assertEquals(AudioTrack.PLAYSTATE_PLAYING, track.playState)
+        assertTrue("Preparing a local reply must not hide realtime playback", proof.manager.isSpeaking.value)
+        assertEquals("Speaking…", proof.manager.statusText.value)
+      }
+    }
+
+  @Test
+  fun localCompletionKeepsRealtimePlaybackSpeaking() =
+    runBlocking {
+      withRealtimePlayback { proof ->
+        completeRemoteSynthesis(proof.synthesizer)
+        val local = proof.scope.launch { proof.manager.speakAssistantReply("Local reply") }
+        proof.scheduler.runCurrent()
+        assertEquals(1, proof.player.playCalls)
+        val track = startRealtimeAudio(proof)
+
+        proof.player.finished.complete(Unit)
+        proof.scheduler.runCurrent()
+
+        assertTrue(local.isCompleted)
+        assertEquals(0, proof.callbackDepth())
+        assertEquals(AudioTrack.PLAYSTATE_PLAYING, track.playState)
+        assertTrue("Completing a local reply must not hide realtime playback", proof.manager.isSpeaking.value)
+        assertEquals("Speaking…", proof.manager.statusText.value)
+      }
+    }
+
+  @Test
+  fun realtimeClearKeepsLocalPlaybackSpeaking() = assertRealtimeEndKeepsLocalPlaybackSpeaking(clear = true)
+
+  @Test
+  fun realtimeIdleKeepsLocalPlaybackSpeaking() = assertRealtimeEndKeepsLocalPlaybackSpeaking(clear = false)
+
+  @Test
+  fun realtimeCompletionPreservesReportedPlaybackFailures() =
+    runBlocking {
+      for (localFailure in listOf(true, false)) {
+        for (clear in listOf(true, false)) {
+          withRealtimePlayback { proof ->
+            val track = startRealtimeAudio(proof)
+            val expected = if (localFailure) "Speak failed: synthesis unavailable" else "Talk failed: relay unavailable"
+            if (localFailure) {
+              proof.synthesizer.result.complete(TalkSpeakResult.Failure("synthesis unavailable"))
+              val local = proof.scope.launch { proof.manager.speakAssistantReply("Local reply") }
+              proof.scheduler.runCurrent()
+              assertTrue(local.isCompleted)
+              assertEquals(0, proof.callbackDepth())
+            } else {
+              proof.manager.handleGatewayEvent(
+                "talk.event",
+                """{"relaySessionId":"playback-relay","type":"error","message":"relay unavailable"}""",
+              )
+            }
+            assertTrue(proof.manager.isSpeaking.value)
+            assertEquals(expected, proof.manager.statusText.value)
+            assertTrue(track === startRealtimeAudio(proof))
+            assertEquals("Another chunk must not erase the reported failure", expected, proof.manager.statusText.value)
+
+            finishRealtimeAudio(proof, track, clear)
+
+            assertFalse(proof.manager.isSpeaking.value)
+            assertEquals(expected, proof.manager.statusText.value)
+            proof.manager.stopTts()
+            assertEquals("Listening", proof.manager.statusText.value)
+          }
+        }
+      }
+    }
+
+  private fun assertRealtimeEndKeepsLocalPlaybackSpeaking(clear: Boolean) =
+    runBlocking {
+      withRealtimePlayback { proof ->
+        val track = startRealtimeAudio(proof)
+        completeRemoteSynthesis(proof.synthesizer)
+        val local = proof.scope.launch { proof.manager.speakAssistantReply("Local reply") }
+        proof.scheduler.runCurrent()
+        assertEquals(1, proof.player.playCalls)
+        assertTrue(proof.manager.isSpeaking.value)
+        val localStops = proof.player.stopCalls
+
+        finishRealtimeAudio(proof, track, clear)
+
+        assertTrue(local.isActive)
+        assertFalse(proof.player.finished.isCompleted)
+        assertEquals(localStops, proof.player.stopCalls)
+        assertEquals(1, proof.callbackDepth())
+        assertTrue("Ending realtime output must not hide the local reply", proof.manager.isSpeaking.value)
+        assertEquals("Speaking…", proof.manager.statusText.value)
+        proof.player.finished.complete(Unit)
+        proof.scheduler.runCurrent()
+        assertTrue(local.isCompleted)
+        assertFalse(proof.manager.isSpeaking.value)
+        assertEquals("Listening", proof.manager.statusText.value)
+      }
+    }
+
+  private fun finishRealtimeAudio(
+    proof: RealtimePlaybackProof,
+    track: AudioTrack,
+    clear: Boolean,
+  ) {
+    if (clear) {
+      proof.manager.handleGatewayEvent(
+        "talk.event",
+        """{"relaySessionId":"playback-relay","type":"clear","talkEvent":{"turnId":"realtime-turn"}}""",
+      )
+      assertEquals(AudioTrack.STATE_UNINITIALIZED, track.state)
+    } else {
+      // The stock shadow accounts written frames immediately. Advance both
+      // Android's playback clock and the coroutine idle poll beyond the PCM.
+      val frames = proof.writes.sumOf { it.second.size } / 2
+      assertEquals(frames, track.playbackHeadPosition)
+      ShadowSystemClock.advanceBy(Duration.ofMillis(frames * 1_000L / 24_000 + 20))
+      proof.scheduler.advanceTimeBy(20)
+    }
+    proof.scheduler.runCurrent()
+  }
+
+  private fun startRealtimeAudio(proof: RealtimePlaybackProof): AudioTrack {
+    val pcm = ByteArray(4_800) { if (it % 2 == 0) 0x20 else 0x01 }
+    val priorWrites = proof.writes.size
+    proof.manager.handleGatewayEvent(
+      "talk.event",
+      """{"relaySessionId":"playback-relay","type":"audio","talkEvent":{"turnId":"realtime-turn"},"audioBase64":"${Base64.encodeToString(pcm, Base64.NO_WRAP)}"}""",
+    )
+    proof.scheduler.runCurrent()
+    assertEquals(priorWrites + 1, proof.writes.size)
+    val (track, written, format) = proof.writes.last()
+    assertArrayEquals(pcm, written)
+    assertEquals(24_000, format.sampleRate)
+    assertEquals(AudioFormat.ENCODING_PCM_16BIT, format.encoding)
+    assertEquals(AudioTrack.PLAYSTATE_PLAYING, track.playState)
+    assertTrue(proof.manager.isSpeaking.value)
+    return track
+  }
+
+  private suspend fun withRealtimePlayback(block: suspend (RealtimePlaybackProof) -> Unit) {
+    val app = RuntimeEnvironment.getApplication()
+    shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+    val sessionJob = SupervisorJob()
+    val managerJob = SupervisorJob()
+    val scheduler = TestCoroutineScheduler()
+    val managerScope = CoroutineScope(StandardTestDispatcher(scheduler) + managerJob)
+    val captureTasks = ConcurrentLinkedQueue<Runnable>()
+    val captureDispatcher =
+      object : CoroutineDispatcher() {
+        override fun dispatch(
+          context: CoroutineContext,
+          block: Runnable,
+        ) {
+          captureTasks.add(block)
+        }
+      }
+    val connected = CompletableDeferred<Unit>()
+    val session =
+      GatewaySession(
+        scope = CoroutineScope(sessionJob + Dispatchers.Default),
+        identityStore = testDeviceIdentityStore(app),
+        deviceAuthStore = DeviceAuthStore(SecurePrefs(app, app.getSharedPreferences("talk-playback-${System.nanoTime()}", 0))),
+        onConnected = { connected.complete(Unit) },
+        onDisconnected = {},
+        onEvent = { _, _ -> },
+      )
+    val synthesizer = FakeTalkSpeechSynthesizer()
+    val player = FakeTalkAudioPlayer()
+    var callbackDepth = 0
+    val manager =
+      TalkModeManager(
+        context = app,
+        scope = managerScope,
+        session = session,
+        isConnected = { connected.isCompleted },
+        talkSpeakClient = synthesizer,
+        talkAudioPlayer = player,
+        onBeforeSpeak = { callbackDepth += 1 },
+        onAfterSpeak = { callbackDepth -= 1 },
+        realtimeCaptureDispatcher = captureDispatcher,
+        realtimePlaybackDispatcher = StandardTestDispatcher(scheduler),
+      )
+    val writes = mutableListOf<Triple<AudioTrack, ByteArray, AudioFormat>>()
+    val listener = ShadowAudioTrack.OnAudioDataWrittenListener { track, bytes, format -> writes += Triple(track, bytes, format) }
+    val server = MockWebServer()
+    Dispatchers.setMain(StandardTestDispatcher(scheduler))
+    try {
+      try {
+        server.enqueue(
+          MockResponse().withWebSocketUpgrade(
+            object : WebSocketListener() {
+              override fun onOpen(
+                webSocket: WebSocket,
+                response: Response,
+              ) {
+                webSocket.send("""{"type":"event","event":"connect.challenge","payload":{"nonce":"talk-playback-test","ts":1700000000123}}""")
+              }
+
+              override fun onMessage(
+                webSocket: WebSocket,
+                text: String,
+              ) {
+                val request = Json.parseToJsonElement(text).jsonObject
+                if (request["type"]?.jsonPrimitive?.content != "req") return
+                val id = request.getValue("id").jsonPrimitive.content
+                val payload =
+                  when (request.getValue("method").jsonPrimitive.content) {
+                    "connect" -> """{"snapshot":{"sessionDefaults":{"mainSessionKey":"main"}}}"""
+                    "talk.config" -> """{"config":{}}"""
+                    "talk.session.create" -> """{"relaySessionId":"playback-relay"}"""
+                    else -> "{}"
+                  }
+                webSocket.send("""{"type":"res","id":"$id","ok":true,"payload":$payload}""")
+              }
+            },
+          ),
+        )
+        server.start()
+        session.connect(
+          endpoint =
+            GatewayEndpoint(
+              stableId = "manual|127.0.0.1|${server.port}",
+              name = "Playback test",
+              host = "127.0.0.1",
+              port = server.port,
+              tlsEnabled = false,
+            ),
+          token = "test-token",
+          bootstrapToken = null,
+          password = null,
+          options =
+            GatewayConnectOptions(
+              role = "operator",
+              scopes = listOf("operator.admin"),
+              caps = emptyList(),
+              commands = emptyList(),
+              permissions = emptyMap(),
+              client = GatewayClientInfo("openclaw-android", "Android playback test", "1.0.0-test", "android", "ui", "playback-test", "android", "test"),
+            ),
+        )
+        withContext(Dispatchers.Default) { withTimeout(5_000) { connected.await() } }
+        manager.setEnabled(true)
+        val deadline = System.nanoTime() + 5_000_000_000L
+        while (!manager.isListening.value) {
+          scheduler.runCurrent()
+          check(System.nanoTime() < deadline) { "Real gateway session did not start realtime Talk: ${manager.statusText.value}" }
+          withContext(Dispatchers.Default) { delay(10) }
+        }
+        ShadowAudioTrack.addAudioDataListener(listener)
+        block(RealtimePlaybackProof(manager, managerScope, scheduler, synthesizer, player, writes) { callbackDepth })
+      } finally {
+        manager.stopAllCapture()
+        managerJob.cancel()
+        scheduler.runCurrent()
+        while (true) (captureTasks.poll() ?: break).run()
+        scheduler.runCurrent()
+        withTimeout(5_000) { managerJob.join() }
+        shadowOf(Looper.getMainLooper()).idle()
+        scheduler.runCurrent()
+        ShadowAudioTrack.removeAudioDataListener(listener)
+        withContext(Dispatchers.Default) {
+          session.disconnectAndJoin()
+          sessionJob.cancelAndJoin()
+          server.shutdown()
+        }
+      }
+    } finally {
+      Dispatchers.resetMain()
+    }
+  }
+
+  private fun completeRemoteSynthesis(synthesizer: FakeTalkSpeechSynthesizer) {
+    synthesizer.result.complete(
+      TalkSpeakResult.Success(
+        TalkSpeakAudio(byteArrayOf(1, 2, 3), "test", "mp3_44100_128", true, "audio/mpeg", ".mp3"),
+      ),
+    )
+  }
+
+  private suspend fun TestScope.withStartedLocalPlayback(block: suspend (TalkModeManager, Job, FakeTalkAudioPlayer) -> Unit) {
+    val synthesizer = FakeTalkSpeechSynthesizer()
+    completeRemoteSynthesis(synthesizer)
+    val player = FakeTalkAudioPlayer()
+    val managerJob = SupervisorJob()
+    val manager =
+      createManager(
+        talkSpeakClient = synthesizer,
+        talkAudioPlayer = player,
+        scope = CoroutineScope(coroutineContext + managerJob),
+      )
+    withMain {
+      val playback = launch { manager.speakAssistantReply("Local reply") }
+      try {
+        runCurrent()
+        assertEquals(1, player.playCalls)
+        assertTrue(playback.isActive)
+        assertTrue(manager.isSpeaking.value)
+        block(manager, playback, player)
+      } finally {
+        manager.stopAllCapture()
+        playback.cancelAndJoin()
+        managerJob.cancelAndJoin()
+        runCurrent()
+        shadowOf(Looper.getMainLooper()).idle()
+        runCurrent()
+      }
+    }
+  }
+
+  @Test
   fun localFallbackKeepsWholeReplyAndBalancesCallbacksOnCompletionOrStop() =
     runTest {
       for (stopAfterFirst in listOf(false, true)) {
@@ -1341,6 +1751,16 @@ class TalkModeManagerTest {
   ): String = """{"relaySessionId":"relay-1","type":"transcript","role":"$role","text":"$text","final":$final}"""
 }
 
+private data class RealtimePlaybackProof(
+  val manager: TalkModeManager,
+  val scope: CoroutineScope,
+  val scheduler: TestCoroutineScheduler,
+  val synthesizer: FakeTalkSpeechSynthesizer,
+  val player: FakeTalkAudioPlayer,
+  val writes: List<Triple<AudioTrack, ByteArray, AudioFormat>>,
+  val callbackDepth: () -> Int,
+)
+
 private class FakeTalkSpeechSynthesizer : TalkSpeechSynthesizing {
   val requested = CompletableDeferred<Unit>()
   val result = CompletableDeferred<TalkSpeakResult>()
@@ -1358,13 +1778,19 @@ private class FakeTalkAudioPlayer : TalkAudioPlaying {
   val started = CompletableDeferred<Unit>()
   val finished = CompletableDeferred<Unit>()
   var stopped = false
+  var playCalls = 0
+    private set
+  var stopCalls = 0
+    private set
 
   override suspend fun play(audio: TalkSpeakAudio) {
+    playCalls += 1
     started.complete(Unit)
     finished.await()
   }
 
   override fun stop() {
+    stopCalls += 1
     stopped = true
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android Talk could show an idle waveform and stop displaying “OpenClaw speaking” while a replacement reply was still playing. Completion or cancellation from one playback source could also hide another active source.

## Why This Change Was Made

Cancellation does not wait for an old caller to finish. Its cleanup unconditionally cleared the shared speaking flag, even after a replacement had started. Realtime playback independently wrote that same flag.

Keep one local playback lease and the realtime playback fact, with a single speaking-state projection. Only the current local lease can clear its state. The existing playback owner absorbs the duplicate session wrapper and one-use system-speech wrapper; before/after callbacks remain balanced, and SDK calls stay outside the ownership lock.

Production LOC: +110/−118 (net −8). Tests: +413/−27 (net +386).

## User Impact

Talk keeps its speaking indicator and waveform active while a replacement or another playback source is still active, then returns to its existing idle presentation when playback completes. This changes playback-state ownership, not the existing status/error policy, audio-provider selection, microphone policy, permissions or persisted settings.

The unconditional cleanup pattern is also present in `v2026.7.1-2`. The available shallow blame stops at an older history boundary, so this is not attributed to a particular recent PR or introducer.

## Evidence

AI-assisted implementation and verification with Codex.

- Five owner-boundary regressions failed before the fix: delayed old-caller cleanup after replacement, local preparation/completion during realtime output, and realtime clear/idle during local playback. All five pass in the 79-test owner/sibling run.
- The complete 11-class matrix on `e5aca835` passed in both Play and ThirdParty flavors: 146 tests each, 292 total, with no failures, errors, skips or captured asynchronous errors. The original service-test → voice-wake-test order passes after the separately landed fixture-lifetime cleanup in #130861; no test environment workaround or skipped class was used.
- The same immutable Android instrumentation APK failed on the baseline and passed on the fixed app. Actual Android player identity showed replacement B still active after A finished cleanup; the production Talk component stayed speaking. B then completed naturally with no active speech player, no remaining callback acquisition and an idle component. The fixed run completed in 21.748 seconds.
- An independent source-blind operator manually exercised replacement, release of the deliberately held old caller, natural B completion, a fresh pair and explicit Stop. Current Android player diagnostics corroborated the visible state. An initially overbroad historical diagnostic capture was excluded; retained evidence uses current-player captures.
- Both Android lint flavors passed with zero errors/warnings, along with all four Android-module Kotlin style checks, Play APK assembly, native i18n verification and the normal changed-file guard. Fresh complete-branch Codex review of `7dbd87d...e5aca835` found no actionable P0–P2 issues.

The native/manual proof uses synthetic PCM with the production Talk screen and Android player. The held caller is an explicit fixture scheduling control, not a simulated Android audio callback. This does not claim audibility, exact playback position, a connected Gateway, live-provider correctness, microphone capture or full MainViewModel coverage.

The native/manual proof used the app built from `ddc0279`. After the dependency refresh, the playback owner, sibling voice code, screen, owner tests and dependency pins remain byte-identical; the fresh matrix and build checks above cover `e5aca835`. This does not claim the earlier native-tested APK was built from the refreshed head.

| Before: replacement active, component incorrectly idle | After: replacement remains speaking |
| --- | --- |
| ![Before: active replacement with idle Talk indicator](https://github.com/user-attachments/assets/1d839694-36ad-49b0-839f-ea62a99b9bea) | ![After: active replacement with speaking Talk indicator](https://github.com/user-attachments/assets/828efb65-d8bd-4ab5-98fa-bfd5056d2e09) |

<details>
<summary>After natural completion: component returns to idle</summary>

![After natural completion: Talk returns to Connected and the idle waveform](https://github.com/user-attachments/assets/c265caf4-b06c-4e5e-bfaf-67de7d8c834c)

</details>

Follow-up kept separate: correlate typed Talk status/error retirement with authoritative input/response turns. This PR preserves the existing status/preserveStatus behavior and does not claim to fix that policy.
