### PR TITLE
fix: surface delivered heartbeat alerts in target session context

### DIFF
--- a/src/auto-reply/reply/session-system-events.ts
+++ b/src/auto-reply/reply/session-system-events.ts
@@ -10,7 +10,10 @@ import {
   formatZonedTimestamp,
   resolveTimezone,
 } from "../../infra/format-time/format-datetime.ts";
-import { isExecCompletionEvent } from "../../infra/heartbeat-events-filter.js";
+import {
+  isExecCompletionEvent,
+  isHeartbeatDeliveryAwarenessEvent,
+} from "../../infra/heartbeat-events-filter.js";
 // Records system-level session events for restarts, forks, and resets.
 import { selectAgentSystemEvents } from "../../infra/system-event-ownership.js";
 import {
@@ -29,14 +32,15 @@ function selectGenericSystemEvents(
   events: readonly SystemEvent[],
   options?: { suppressHeartbeatOwnedEvents?: boolean },
 ): SystemEvent[] {
-  // Exec completions and tagged cron events own dedicated heartbeat prompts
-  // (buildExecEventPrompt / buildCronEventPrompt). During heartbeat runs, leave
-  // cron entries queued for that owner; ordinary turns still drain them as the
-  // fallback when a heartbeat was skipped before it could consume the event.
+  // Exec/cron events own dedicated heartbeat prompts. Heartbeat delivery
+  // awareness stays queued for the next ordinary target turn.
   return events.filter(
     (event) =>
       !isExecCompletionEvent(event.text) &&
-      !(options?.suppressHeartbeatOwnedEvents === true && isCronContextSystemEvent(event)),
+      !(
+        options?.suppressHeartbeatOwnedEvents === true &&
+        (isCronContextSystemEvent(event) || isHeartbeatDeliveryAwarenessEvent(event))
+      ),
   );
 }
 

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -8,6 +8,7 @@ import {
 import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 
 const MAX_EXEC_EVENT_PROMPT_CHARS = 8_000;
+export const HEARTBEAT_DELIVERY_CONTEXT_KEY_PREFIX = "heartbeat-delivery:";
 const STRUCTURED_EXEC_COMPLETION_EVENT_RE =
   /^exec (completed|failed) \(([a-z0-9_-]{1,64}), (code -?\d+|signal [^)]+)\)(?: :: ([\s\S]*))?$/i;
 
@@ -180,6 +181,10 @@ export function isExecCompletionEvent(evt: string): boolean {
     /^exec finished(?::|\s*\()/.test(normalized) ||
     STRUCTURED_EXEC_COMPLETION_EVENT_RE.test(trimmed)
   );
+}
+
+export function isHeartbeatDeliveryAwarenessEvent(event: { contextKey?: string | null }): boolean {
+  return event.contextKey?.startsWith(HEARTBEAT_DELIVERY_CONTEXT_KEY_PREFIX) ?? false;
 }
 
 // Returns true when a system event should be treated as real cron reminder content.

--- a/src/infra/heartbeat-runner-delivery.ts
+++ b/src/infra/heartbeat-runner-delivery.ts
@@ -108,7 +108,7 @@ function resolveHeartbeatTargetProjection(params: {
 
 function queueHeartbeatTargetAwareness(params: {
   projection: HeartbeatTargetProjection;
-  payloads: readonly NormalizedOutboundPayload[];
+  payload: NormalizedOutboundPayload;
 }) {
   try {
     // Recheck the exact pre-send lifecycle before publishing awareness. Resets
@@ -124,11 +124,8 @@ function queueHeartbeatTargetAwareness(params: {
       return;
     }
     const deliveredText = resolveMirroredTranscriptText({
-      text: params.payloads
-        .map((payload) => payload.hookContent ?? resolveOutboundPayloadMirrorText(payload))
-        .filter((text) => text.trim())
-        .join("\n"),
-      mediaUrls: params.payloads.flatMap((payload) => payload.mediaUrls),
+      text: params.payload.hookContent ?? resolveOutboundPayloadMirrorText(params.payload),
+      mediaUrls: params.payload.mediaUrls,
     });
     if (!deliveredText) {
       return;
@@ -553,8 +550,7 @@ export async function finalizeHeartbeatOutcome(params: {
     deps: params.opts.deps,
     silent: normalized.silent,
     onDeliveredPayload: targetProjection
-      ? (payload) =>
-          queueHeartbeatTargetAwareness({ projection: targetProjection, payloads: [payload] })
+      ? (payload) => queueHeartbeatTargetAwareness({ projection: targetProjection, payload })
       : undefined,
   }).catch((error: unknown) => {
     recordUnconfirmedAlert(formatErrorMessage(error));

--- a/src/infra/heartbeat-runner-delivery.ts
+++ b/src/infra/heartbeat-runner-delivery.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   hasOutboundReplyContent,
   resolveSendableOutboundReplyParts,
@@ -8,13 +9,19 @@ import { copyReplyPayloadMetadata, getReplyPayloadMetadata } from "../auto-reply
 import { buildRecoverablePendingFinalDeliveryText } from "../auto-reply/reply/pending-final-delivery.js";
 import { isSilentReplyPayloadText } from "../auto-reply/tokens.js";
 import { sendDurableMessageBatchCore } from "../channels/message/runtime.js";
-import { patchSessionEntryCore } from "../config/sessions/session-accessor.js";
+import {
+  loadExactSessionEntryReadOnly,
+  patchSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
+import { resolveMirroredTranscriptText } from "../config/sessions/transcript-mirror.js";
 import type { SessionEntry } from "../config/sessions/types.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { formatErrorMessage } from "./errors.js";
 import {
   normalizeHeartbeatReply,
   normalizeHeartbeatToolNotification,
 } from "./heartbeat-delivery-normalization.js";
+import { HEARTBEAT_DELIVERY_CONTEXT_KEY_PREFIX } from "./heartbeat-events-filter.js";
 import { emitHeartbeatEvent, resolveIndicatorType } from "./heartbeat-events.js";
 import { handleHeartbeatFailureNotice } from "./heartbeat-failure-notice.js";
 import { persistHeartbeatOutcome } from "./heartbeat-outcome-store.js";
@@ -33,8 +40,13 @@ import {
   type HeartbeatRunResult,
 } from "./heartbeat-wake.js";
 import type { resolveAgentOutboundIdentity } from "./outbound/identity.js";
+import {
+  resolveOutboundPayloadMirrorText,
+  type NormalizedOutboundPayload,
+} from "./outbound/payloads.js";
 import type { buildOutboundSessionContext } from "./outbound/session-context.js";
-import { consumeSelectedSystemEventEntries } from "./system-events.js";
+import { withSystemEventOwner } from "./system-event-ownership.js";
+import { consumeSelectedSystemEventEntries, enqueueSystemEvent } from "./system-events.js";
 
 const log = heartbeatLog;
 
@@ -48,6 +60,98 @@ const CLEARED_PENDING_FINAL_DELIVERY_FIELDS = {
 
 const FIRST_HEARTBEAT_ALERT_PREAMBLE =
   'First heartbeat alert: your bot runs periodic background checks and messages you only when something needs attention. Set agents.defaults.heartbeat.target: "none" to keep these internal.';
+const MAX_HEARTBEAT_TARGET_AWARENESS_CHARS = 1_000;
+
+type HeartbeatTargetProjection = {
+  agentId: string;
+  sessionKey: string;
+  storePath: string;
+  expectedSessionId: string;
+  expectedLifecycleRevision: string | undefined;
+  idempotencyKey: string;
+};
+
+function resolveHeartbeatTargetProjection(params: {
+  agentId: string;
+  storePath: string;
+  runSessionKey: string;
+  targetSessionKey?: string;
+  startedAt: number;
+}): HeartbeatTargetProjection | undefined {
+  const sessionKey = params.targetSessionKey?.trim();
+  if (!sessionKey || sessionKey === params.runSessionKey) {
+    return undefined;
+  }
+  try {
+    if (resolveAgentIdFromSessionKey(sessionKey, params.agentId) !== params.agentId) {
+      return undefined;
+    }
+    const entry = loadExactSessionEntryReadOnly({ storePath: params.storePath, sessionKey })?.entry;
+    if (!entry?.sessionId) {
+      return undefined;
+    }
+    return {
+      agentId: params.agentId,
+      sessionKey,
+      storePath: params.storePath,
+      expectedSessionId: entry.sessionId,
+      expectedLifecycleRevision: entry.lifecycleRevision,
+      idempotencyKey: `${HEARTBEAT_DELIVERY_CONTEXT_KEY_PREFIX}${params.startedAt}:${params.runSessionKey}`,
+    };
+  } catch (error) {
+    log.warn("heartbeat: failed to resolve existing target session projection", {
+      error: formatErrorMessage(error),
+    });
+    return undefined;
+  }
+}
+
+function queueHeartbeatTargetAwareness(params: {
+  projection: HeartbeatTargetProjection;
+  payloads: readonly NormalizedOutboundPayload[];
+}) {
+  try {
+    // Recheck the exact pre-send lifecycle before publishing awareness. Resets
+    // can preserve sessionId while rotating lifecycleRevision.
+    const latest = loadExactSessionEntryReadOnly({
+      storePath: params.projection.storePath,
+      sessionKey: params.projection.sessionKey,
+    })?.entry;
+    if (
+      latest?.sessionId !== params.projection.expectedSessionId ||
+      latest.lifecycleRevision !== params.projection.expectedLifecycleRevision
+    ) {
+      return;
+    }
+    const deliveredText = resolveMirroredTranscriptText({
+      text: params.payloads
+        .map((payload) => payload.hookContent ?? resolveOutboundPayloadMirrorText(payload))
+        .filter((text) => text.trim())
+        .join("\n"),
+      mediaUrls: params.payloads.flatMap((payload) => payload.mediaUrls),
+    });
+    if (!deliveredText) {
+      return;
+    }
+    const text = truncateUtf16Safe(deliveredText, MAX_HEARTBEAT_TARGET_AWARENESS_CHARS);
+    const suffix = text.length < deliveredText.length ? "\n[truncated]" : "";
+    enqueueSystemEvent(
+      `A heartbeat delivered this message to this channel:\n${text}${suffix}`,
+      withSystemEventOwner(
+        {
+          sessionKey: params.projection.sessionKey,
+          contextKey: params.projection.idempotencyKey,
+        },
+        params.projection.agentId,
+      ),
+    );
+  } catch (error) {
+    // Platform delivery already succeeded; projection remains best-effort bookkeeping.
+    log.warn("heartbeat: failed to queue target session awareness", {
+      error: formatErrorMessage(error),
+    });
+  }
+}
 
 // Clear pending-final only when this run produced it: the agent run stamps
 // createdAt during the run, so createdAt >= run start means we own it. An older
@@ -424,6 +528,13 @@ export async function finalizeHeartbeatOutcome(params: {
     }
   }
 
+  const targetProjection = resolveHeartbeatTargetProjection({
+    agentId,
+    storePath,
+    runSessionKey,
+    targetSessionKey: delivery.targetSessionKey,
+    startedAt,
+  });
   const send = await sendDurableMessageBatchCore({
     cfg,
     channel: delivery.channel,
@@ -441,6 +552,10 @@ export async function finalizeHeartbeatOutcome(params: {
     ],
     deps: params.opts.deps,
     silent: normalized.silent,
+    onDeliveredPayload: targetProjection
+      ? (payload) =>
+          queueHeartbeatTargetAwareness({ projection: targetProjection, payloads: [payload] })
+      : undefined,
   }).catch((error: unknown) => {
     recordUnconfirmedAlert(formatErrorMessage(error));
     throw error;

--- a/src/infra/heartbeat-runner-prompt.ts
+++ b/src/infra/heartbeat-runner-prompt.ts
@@ -13,6 +13,7 @@ import {
   buildExecEventPrompt,
   isCronSystemEvent,
   isExecCompletionEvent,
+  isHeartbeatDeliveryAwarenessEvent,
   isRelayableExecCompletionEvent,
 } from "./heartbeat-events-filter.js";
 import {
@@ -101,7 +102,7 @@ export async function resolveHeartbeatPreflight(params: {
   const pendingEventEntries = selectAgentSystemEvents(
     peekSystemEventEntries(session.sessionKey),
     params.agentId,
-  );
+  ).filter((event) => !isHeartbeatDeliveryAwarenessEvent(event));
   const turnSourceDeliveryContext = resolveSystemEventDeliveryContext(pendingEventEntries);
   const hasTaggedCronEvents = pendingEventEntries.some((event) =>
     event.contextKey?.startsWith("cron:"),

--- a/src/infra/heartbeat-runner.isolated-session-mirror.test.ts
+++ b/src/infra/heartbeat-runner.isolated-session-mirror.test.ts
@@ -1,7 +1,13 @@
 // Covers isolated heartbeat outbound session routing and base-session bookkeeping.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { heartbeatRunnerWhatsAppPlugin } from "../../test/helpers/infra/heartbeat-runner-channel-plugins.js";
+import { drainFormattedSystemEvents } from "../auto-reply/reply/session-system-events.js";
+import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { resolveHeartbeatPreflight } from "./heartbeat-runner-prompt.js";
 import { runHeartbeatOnce } from "./heartbeat-runner.js";
 import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
 import {
@@ -10,9 +16,26 @@ import {
   seedSessionStore,
   withTempHeartbeatSandbox,
 } from "./heartbeat-runner.test-utils.js";
+import { resetSystemEventsForTest } from "./system-events.js";
 
+type MockDeliveryRequest = {
+  payloads?: Array<{ text?: string; mediaUrl?: string; mediaUrls?: string[] }>;
+  onDeliveredPayload?: (payload: { text: string; mediaUrls: string[] }) => void;
+};
+
+const beforeMockDeliveryCompletion = vi.hoisted(() => vi.fn(async () => {}));
 const deliverOutboundPayloadsInternal = vi.hoisted(() =>
-  vi.fn().mockResolvedValue([{ channel: "whatsapp", messageId: "msg-1" }]),
+  vi.fn(async (request: MockDeliveryRequest) => {
+    const payload = request.payloads?.[0];
+    request.onDeliveredPayload?.({
+      text: payload?.text ?? "",
+      mediaUrls: [payload?.mediaUrl, ...(payload?.mediaUrls ?? [])].filter((url): url is string =>
+        Boolean(url),
+      ),
+    });
+    await beforeMockDeliveryCompletion();
+    return [{ channel: "whatsapp", messageId: "msg-1" }];
+  }),
 );
 
 vi.mock("./outbound/deliver.js", () => ({
@@ -23,7 +46,10 @@ vi.mock("./outbound/deliver.js", () => ({
 installHeartbeatRunnerTestRuntime();
 
 afterEach(() => {
+  beforeMockDeliveryCompletion.mockReset();
+  beforeMockDeliveryCompletion.mockResolvedValue(undefined);
   deliverOutboundPayloadsInternal.mockClear();
+  resetSystemEventsForTest();
 });
 
 type DeliveryRequest = {
@@ -59,6 +85,45 @@ function makeIsolatedLastTargetConfig(tmpDir: string, storePath: string): OpenCl
     channels: { whatsapp: { allowFrom: ["*"] } },
     session: { store: storePath },
   };
+}
+
+function installTargetResolverOnlyWhatsApp() {
+  const plugin: ChannelPlugin = {
+    ...heartbeatRunnerWhatsAppPlugin,
+    capabilities: {
+      ...heartbeatRunnerWhatsAppPlugin.capabilities,
+      chatTypes: ["direct"],
+    },
+    messaging: {
+      ...heartbeatRunnerWhatsAppPlugin.messaging,
+      targetResolver: { looksLikeId: () => true },
+    },
+  };
+  setActivePluginRegistry(createTestRegistry([{ pluginId: "whatsapp", plugin, source: "test" }]));
+}
+
+async function seedExistingHeartbeatTarget(params: { tmpDir: string; storePath: string }) {
+  installTargetResolverOnlyWhatsApp();
+  const cfg = makeIsolatedLastTargetConfig(params.tmpDir, params.storePath);
+  cfg.session = { ...cfg.session, dmScope: "per-channel-peer" };
+  const baseSessionKey = resolveMainSessionKey(cfg);
+  const target = "+15551234567";
+  const targetSessionKey = `agent:main:whatsapp:direct:${target}`;
+  const nowMs = Date.now();
+  const delivery = {
+    updatedAt: nowMs - 1_000,
+    lastChannel: "whatsapp",
+    lastProvider: "whatsapp",
+    lastTo: target,
+  };
+  await seedSessionStore(params.storePath, baseSessionKey, {
+    ...delivery,
+    sessionId: "base-session",
+  });
+  const replaceTargetSession = (sessionId: string) =>
+    seedSessionStore(params.storePath, targetSessionKey, { ...delivery, sessionId });
+  await replaceTargetSession("target-session");
+  return { cfg, nowMs, target, targetSessionKey, replaceTargetSession };
 }
 
 describe("runHeartbeatOnce - isolated heartbeat outbound session mirror", () => {
@@ -158,6 +223,120 @@ describe("runHeartbeatOnce - isolated heartbeat outbound session mirror", () => 
           policyKey: baseSessionKey,
         },
       });
+    });
+  });
+
+  it("queues a successful direct alert for the next ordinary target turn", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const { cfg, nowMs, target, targetSessionKey } = await seedExistingHeartbeatTarget({
+        tmpDir,
+        storePath,
+      });
+      replySpy.mockResolvedValueOnce({ text: "Status needs attention." });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      const deliveryRequest = latestDeliveryRequest();
+      expect(deliveryRequest).toMatchObject({
+        channel: "whatsapp",
+        to: target,
+      });
+      const nextHeartbeatPreflight = await resolveHeartbeatPreflight({
+        cfg,
+        agentId: "main",
+        heartbeat: { isolatedSession: true },
+        sessionKey: targetSessionKey,
+      });
+      expect(nextHeartbeatPreflight.pendingEventEntries).toHaveLength(0);
+      await expect(
+        drainFormattedSystemEvents({
+          cfg,
+          agentId: "main",
+          sessionKey: targetSessionKey,
+          isMainSession: false,
+          isNewSession: false,
+          suppressHeartbeatOwnedEvents: true,
+        }),
+      ).resolves.toBeUndefined();
+      const awareness = await drainFormattedSystemEvents({
+        cfg,
+        agentId: "main",
+        sessionKey: targetSessionKey,
+        isMainSession: false,
+        isNewSession: false,
+      });
+      expect(awareness).toContain("A heartbeat delivered this message to this channel:");
+      expect(awareness).toContain("Status needs attention.");
+    });
+  });
+
+  it("does not project a direct alert when platform delivery fails", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const { cfg, nowMs, targetSessionKey } = await seedExistingHeartbeatTarget({
+        tmpDir,
+        storePath,
+      });
+      replySpy.mockResolvedValueOnce({ text: "Status needs attention." });
+      deliverOutboundPayloadsInternal.mockRejectedValueOnce(new Error("channel unavailable"));
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+
+      expect(result.status).toBe("failed");
+      await expect(
+        drainFormattedSystemEvents({
+          cfg,
+          agentId: "main",
+          sessionKey: targetSessionKey,
+          isMainSession: false,
+          isNewSession: false,
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  it("does not attach an alert to a target session reset during delivery", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const { cfg, nowMs, targetSessionKey, replaceTargetSession } =
+        await seedExistingHeartbeatTarget({ tmpDir, storePath });
+      replySpy.mockResolvedValueOnce({ text: "Status needs attention." });
+      beforeMockDeliveryCompletion.mockImplementationOnce(() =>
+        replaceTargetSession("replacement-session"),
+      );
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      await expect(
+        drainFormattedSystemEvents({
+          cfg,
+          agentId: "main",
+          sessionKey: targetSessionKey,
+          isMainSession: false,
+          isNewSession: false,
+        }),
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/src/infra/heartbeat-runner.isolated-session-mirror.test.ts
+++ b/src/infra/heartbeat-runner.isolated-session-mirror.test.ts
@@ -1,10 +1,13 @@
 // Covers isolated heartbeat outbound session routing and base-session bookkeeping.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { heartbeatRunnerWhatsAppPlugin } from "../../test/helpers/infra/heartbeat-runner-channel-plugins.js";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
+import { clearSessionResetRuntimeState } from "../auto-reply/reply/session-reset-cleanup.js";
 import { drainFormattedSystemEvents } from "../auto-reply/reply/session-system-events.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { buildChannelOutboundSessionRoute } from "../plugin-sdk/core.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import { resolveHeartbeatPreflight } from "./heartbeat-runner-prompt.js";
@@ -24,9 +27,11 @@ type MockDeliveryRequest = {
 };
 
 const beforeMockDeliveryCompletion = vi.hoisted(() => vi.fn(async () => {}));
+const beforeMockDeliveryConfirmation = vi.hoisted(() => vi.fn(async () => {}));
 const deliverOutboundPayloadsInternal = vi.hoisted(() =>
   vi.fn(async (request: MockDeliveryRequest) => {
     const payload = request.payloads?.[0];
+    await beforeMockDeliveryConfirmation();
     request.onDeliveredPayload?.({
       text: payload?.text ?? "",
       mediaUrls: [payload?.mediaUrl, ...(payload?.mediaUrls ?? [])].filter((url): url is string =>
@@ -46,6 +51,8 @@ vi.mock("./outbound/deliver.js", () => ({
 installHeartbeatRunnerTestRuntime();
 
 afterEach(() => {
+  beforeMockDeliveryConfirmation.mockReset();
+  beforeMockDeliveryConfirmation.mockResolvedValue(undefined);
   beforeMockDeliveryCompletion.mockReset();
   beforeMockDeliveryCompletion.mockResolvedValue(undefined);
   deliverOutboundPayloadsInternal.mockClear();
@@ -87,7 +94,7 @@ function makeIsolatedLastTargetConfig(tmpDir: string, storePath: string): OpenCl
   };
 }
 
-function installTargetResolverOnlyWhatsApp() {
+function installWhatsAppRoute(options?: { exact?: boolean }) {
   const plugin: ChannelPlugin = {
     ...heartbeatRunnerWhatsAppPlugin,
     capabilities: {
@@ -97,13 +104,33 @@ function installTargetResolverOnlyWhatsApp() {
     messaging: {
       ...heartbeatRunnerWhatsAppPlugin.messaging,
       targetResolver: { looksLikeId: () => true },
+      ...(options?.exact === true
+        ? {
+            resolveOutboundSessionRoute: ({ cfg, agentId, accountId, target }) =>
+              buildChannelOutboundSessionRoute({
+                cfg,
+                agentId,
+                channel: "whatsapp",
+                accountId,
+                recipientSessionExact: true,
+                peer: { kind: "direct", id: target },
+                chatType: "direct",
+                from: target,
+                to: target,
+              }),
+          }
+        : {}),
     },
   };
   setActivePluginRegistry(createTestRegistry([{ pluginId: "whatsapp", plugin, source: "test" }]));
 }
 
-async function seedExistingHeartbeatTarget(params: { tmpDir: string; storePath: string }) {
-  installTargetResolverOnlyWhatsApp();
+async function seedExistingHeartbeatTarget(params: {
+  tmpDir: string;
+  storePath: string;
+  exactRoute?: boolean;
+}) {
+  installWhatsAppRoute({ exact: params.exactRoute ?? true });
   const cfg = makeIsolatedLastTargetConfig(params.tmpDir, params.storePath);
   cfg.session = { ...cfg.session, dmScope: "per-channel-peer" };
   const baseSessionKey = resolveMainSessionKey(cfg);
@@ -120,10 +147,14 @@ async function seedExistingHeartbeatTarget(params: { tmpDir: string; storePath: 
     ...delivery,
     sessionId: "base-session",
   });
-  const replaceTargetSession = (sessionId: string) =>
-    seedSessionStore(params.storePath, targetSessionKey, { ...delivery, sessionId });
-  await replaceTargetSession("target-session");
-  return { cfg, nowMs, target, targetSessionKey, replaceTargetSession };
+  const replaceTargetLifecycle = (lifecycleRevision: string) =>
+    seedSessionStore(params.storePath, targetSessionKey, {
+      ...delivery,
+      sessionId: "target-session",
+      lifecycleRevision,
+    });
+  await replaceTargetLifecycle("target-lifecycle-1");
+  return { cfg, nowMs, target, targetSessionKey, replaceTargetLifecycle };
 }
 
 describe("runHeartbeatOnce - isolated heartbeat outbound session mirror", () => {
@@ -232,6 +263,84 @@ describe("runHeartbeatOnce - isolated heartbeat outbound session mirror", () => 
         tmpDir,
         storePath,
       });
+      const completionEntered = createDeferred();
+      const releaseCompletion = createDeferred();
+      beforeMockDeliveryCompletion.mockImplementationOnce(async () => {
+        completionEntered.resolve();
+        await releaseCompletion.promise;
+      });
+      replySpy.mockResolvedValueOnce({ text: "Status needs attention." });
+
+      const heartbeat = runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+      let result!: Awaited<ReturnType<typeof runHeartbeatOnce>>;
+      let pendingEventCount: number | undefined;
+      let heartbeatModeAwareness: string | undefined;
+      let awareness: string | undefined;
+      try {
+        await withTestTimeout(
+          completionEntered.promise,
+          5_000,
+          "heartbeat delivery confirmation was not observed",
+        );
+        const nextHeartbeatPreflight = await resolveHeartbeatPreflight({
+          cfg,
+          agentId: "main",
+          sessionKey: targetSessionKey,
+          heartbeat: { isolatedSession: true },
+        });
+        pendingEventCount = nextHeartbeatPreflight.pendingEventEntries.length;
+        heartbeatModeAwareness = await drainFormattedSystemEvents({
+          cfg,
+          agentId: "main",
+          sessionKey: targetSessionKey,
+          isMainSession: false,
+          isNewSession: false,
+          suppressHeartbeatOwnedEvents: true,
+        });
+        awareness = await drainFormattedSystemEvents({
+          cfg,
+          agentId: "main",
+          sessionKey: targetSessionKey,
+          isMainSession: false,
+          isNewSession: false,
+        });
+      } finally {
+        releaseCompletion.resolve();
+        result = await withTestTimeout(heartbeat, 5_000, "heartbeat did not finish delivery");
+      }
+
+      expect(result.status).toBe("ran");
+      expect(latestDeliveryRequest()).toMatchObject({ channel: "whatsapp", to: target });
+      expect(pendingEventCount).toBe(0);
+      expect(heartbeatModeAwareness).toBeUndefined();
+      expect(awareness).toContain("A heartbeat delivered this message to this channel:");
+      expect(awareness).toContain("Status needs attention.");
+      await expect(
+        drainFormattedSystemEvents({
+          cfg,
+          agentId: "main",
+          sessionKey: targetSessionKey,
+          isMainSession: false,
+          isNewSession: false,
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  it("does not project an alert from an inexact fallback route", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const { cfg, nowMs, target, targetSessionKey } = await seedExistingHeartbeatTarget({
+        tmpDir,
+        storePath,
+        exactRoute: false,
+      });
       replySpy.mockResolvedValueOnce({ text: "Status needs attention." });
 
       const result = await runHeartbeatOnce({
@@ -244,18 +353,7 @@ describe("runHeartbeatOnce - isolated heartbeat outbound session mirror", () => 
       });
 
       expect(result.status).toBe("ran");
-      const deliveryRequest = latestDeliveryRequest();
-      expect(deliveryRequest).toMatchObject({
-        channel: "whatsapp",
-        to: target,
-      });
-      const nextHeartbeatPreflight = await resolveHeartbeatPreflight({
-        cfg,
-        agentId: "main",
-        heartbeat: { isolatedSession: true },
-        sessionKey: targetSessionKey,
-      });
-      expect(nextHeartbeatPreflight.pendingEventEntries).toHaveLength(0);
+      expect(latestDeliveryRequest()).toMatchObject({ channel: "whatsapp", to: target });
       await expect(
         drainFormattedSystemEvents({
           cfg,
@@ -263,18 +361,8 @@ describe("runHeartbeatOnce - isolated heartbeat outbound session mirror", () => 
           sessionKey: targetSessionKey,
           isMainSession: false,
           isNewSession: false,
-          suppressHeartbeatOwnedEvents: true,
         }),
       ).resolves.toBeUndefined();
-      const awareness = await drainFormattedSystemEvents({
-        cfg,
-        agentId: "main",
-        sessionKey: targetSessionKey,
-        isMainSession: false,
-        isNewSession: false,
-      });
-      expect(awareness).toContain("A heartbeat delivered this message to this channel:");
-      expect(awareness).toContain("Status needs attention.");
     });
   });
 
@@ -309,13 +397,65 @@ describe("runHeartbeatOnce - isolated heartbeat outbound session mirror", () => 
     });
   });
 
-  it("does not attach an alert to a target session reset during delivery", async () => {
+  it("lets a reset clear awareness after delivery is identified", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
-      const { cfg, nowMs, targetSessionKey, replaceTargetSession } =
+      const { cfg, nowMs, targetSessionKey } = await seedExistingHeartbeatTarget({
+        tmpDir,
+        storePath,
+      });
+      const completionEntered = createDeferred();
+      const releaseCompletion = createDeferred();
+      beforeMockDeliveryCompletion.mockImplementationOnce(async () => {
+        completionEntered.resolve();
+        await releaseCompletion.promise;
+      });
+      replySpy.mockResolvedValueOnce({ text: "Status needs attention." });
+
+      const heartbeat = runHeartbeatOnce({
+        cfg,
+        deps: {
+          getReplyFromConfig: replySpy,
+          getQueueSize: () => 0,
+          nowMs: () => nowMs,
+        },
+      });
+      let result!: Awaited<ReturnType<typeof runHeartbeatOnce>>;
+      let systemEventsCleared: number | undefined;
+      try {
+        await withTestTimeout(
+          completionEntered.promise,
+          5_000,
+          "heartbeat delivery confirmation was not observed",
+        );
+        systemEventsCleared = clearSessionResetRuntimeState([targetSessionKey], {
+          agentId: "main",
+        }).systemEventsCleared;
+      } finally {
+        releaseCompletion.resolve();
+        result = await withTestTimeout(heartbeat, 5_000, "heartbeat did not finish delivery");
+      }
+
+      expect(result.status).toBe("ran");
+      expect(systemEventsCleared).toBe(1);
+      await expect(
+        drainFormattedSystemEvents({
+          cfg,
+          agentId: "main",
+          sessionKey: targetSessionKey,
+          isMainSession: false,
+          isNewSession: false,
+        }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  it("does not attach an alert after the target lifecycle resets during delivery", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+      const { cfg, nowMs, targetSessionKey, replaceTargetLifecycle } =
         await seedExistingHeartbeatTarget({ tmpDir, storePath });
       replySpy.mockResolvedValueOnce({ text: "Status needs attention." });
-      beforeMockDeliveryCompletion.mockImplementationOnce(() =>
-        replaceTargetSession("replacement-session"),
+      beforeMockDeliveryConfirmation.mockImplementationOnce(() =>
+        replaceTargetLifecycle("target-lifecycle-2"),
       );
 
       const result = await runHeartbeatOnce({

--- a/src/infra/outbound/outbound-session.test.ts
+++ b/src/infra/outbound/outbound-session.test.ts
@@ -112,19 +112,37 @@ describe("resolveOutboundSessionRoute", () => {
       name: "group binding collapses an exact room into main",
       globalSession: { groupScope: "per-group" as const },
       peer: { kind: "group" as const, id: "team-room" },
+      bindingAgentId: "main",
       bindingSession: { groupScope: "main" as const },
       pluginBaseKey: "agent:main:bound-channel:group:team-room",
       pluginSessionKey: "agent:main:bound-channel:group:team-room",
       expectedSessionKey: "agent:main:main",
+      expectedBaseSessionKey: "agent:main:main",
+      expectedRecipientSessionExact: true,
     },
     {
       name: "DM binding collapses an exact peer into main and preserves its thread",
       globalSession: { dmScope: "per-channel-peer" as const },
       peer: { kind: "direct" as const, id: "alice" },
+      bindingAgentId: "main",
       bindingSession: { dmScope: "main" as const },
       pluginBaseKey: "agent:main:bound-channel:direct:alice",
       pluginSessionKey: "agent:main:bound-channel:direct:alice:thread:topic-1",
       expectedSessionKey: "agent:main:main:thread:topic-1",
+      expectedBaseSessionKey: "agent:main:main",
+      expectedRecipientSessionExact: true,
+    },
+    {
+      name: "cross-agent binding downgrades an agent-local exact route",
+      globalSession: { dmScope: "per-channel-peer" as const },
+      peer: { kind: "direct" as const, id: "alice" },
+      bindingAgentId: "other",
+      bindingSession: { dmScope: "per-channel-peer" as const },
+      pluginBaseKey: "agent:main:bound-channel:direct:alice",
+      pluginSessionKey: "agent:main:bound-channel:direct:alice",
+      expectedSessionKey: "agent:main:bound-channel:direct:alice",
+      expectedBaseSessionKey: "agent:main:bound-channel:direct:alice",
+      expectedRecipientSessionExact: false,
     },
   ])("applies $name before returning the canonical route", async (testCase) => {
     const plugin = {
@@ -146,7 +164,7 @@ describe("resolveOutboundSessionRoute", () => {
         session: testCase.globalSession,
         bindings: [
           {
-            agentId: "main",
+            agentId: testCase.bindingAgentId,
             match: { channel: "bound-channel", peer: testCase.peer },
             session: testCase.bindingSession,
           },
@@ -159,7 +177,8 @@ describe("resolveOutboundSessionRoute", () => {
     });
 
     expect(route?.sessionKey).toBe(testCase.expectedSessionKey);
-    expect(route?.baseSessionKey).toBe("agent:main:main");
+    expect(route?.baseSessionKey).toBe(testCase.expectedBaseSessionKey);
+    expect(route?.recipientSessionExact).toBe(testCase.expectedRecipientSessionExact);
   });
 
   async function expectResolvedRoute(params: {

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -242,8 +242,12 @@ export async function resolveOutboundSessionRoute(
     ? (params.cfg.session?.dmScope ?? "main")
     : (params.cfg.session?.groupScope ?? "per-group");
   const bindingScope = isDirect ? bindingRoute.dmScope : bindingRoute.groupScope;
-  return bindingScope !== globalScope &&
-    normalizeAgentId(bindingRoute.agentId) === normalizeAgentId(params.agentId)
+  if (normalizeAgentId(bindingRoute.agentId) !== normalizeAgentId(params.agentId)) {
+    // Another agent owns the canonical inbound session. Keep the transport
+    // route, but never authorize this agent-local candidate as exact.
+    return { ...route, recipientSessionExact: false };
+  }
+  return bindingScope !== globalScope
     ? rebaseOutboundSessionRoute(route, bindingRoute.sessionKey)
     : route;
 }

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -42,7 +42,6 @@ import { resolveSessionDeliveryTarget, type SessionDeliveryTarget } from "./targ
 type OutboundTarget = {
   channel: string;
   to?: string;
-  /** Candidate conversation session for post-send heartbeat awareness. */
   targetSessionKey?: string;
   chatType?: ChatType;
   reason?: string;
@@ -498,6 +497,13 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
   if (delivery.channel === "none" || !delivery.to) {
     return delivery;
   }
+  const rejectDelivery = (reason: string) =>
+    buildNoHeartbeatDeliveryTarget({
+      reason,
+      accountId: delivery.accountId,
+      lastChannel: delivery.lastChannel,
+      lastAccountId: delivery.lastAccountId,
+    });
   const deliveryTo = delivery.to;
   const plugin = resolveOutboundChannelPlugin({
     channel: delivery.channel,
@@ -514,12 +520,7 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
       chatType: delivery.chatType,
     })
   ) {
-    return buildNoHeartbeatDeliveryTarget({
-      reason: "no-route",
-      accountId: delivery.accountId,
-      lastChannel: delivery.lastChannel,
-      lastAccountId: delivery.lastAccountId,
-    });
+    return rejectDelivery("no-route");
   }
   if (!resolveSessionRoute && !plugin?.messaging?.targetResolver) {
     return delivery;
@@ -543,20 +544,10 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
   if (targetResolution?.ok) {
     routeResolvedTarget = targetResolution.target;
   } else if (targetResolution && isReservedTargetLiteralError(targetResolution.error)) {
-    return buildNoHeartbeatDeliveryTarget({
-      reason: ownerRouteMustBeDirect ? "no-route" : "no-target",
-      accountId: delivery.accountId,
-      lastChannel: delivery.lastChannel,
-      lastAccountId: delivery.lastAccountId,
-    });
+    return rejectDelivery(ownerRouteMustBeDirect ? "no-route" : "no-target");
   }
   if (routeResolvedTarget?.kind === "user" && heartbeat?.directPolicy === "block") {
-    return buildNoHeartbeatDeliveryTarget({
-      reason: "dm-blocked",
-      accountId: delivery.accountId,
-      lastChannel: delivery.lastChannel,
-      lastAccountId: delivery.lastAccountId,
-    });
+    return rejectDelivery("dm-blocked");
   }
   if (
     ownerRouteMustBeDirect &&
@@ -565,12 +556,10 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
       to: routeResolvedTarget?.to ?? deliveryTo,
     })
   ) {
-    return buildNoHeartbeatDeliveryTarget({
-      reason: "no-route",
-      accountId: delivery.accountId,
-      lastChannel: delivery.lastChannel,
-      lastAccountId: delivery.lastAccountId,
-    });
+    return rejectDelivery("no-route");
+  }
+  if (!resolveSessionRoute) {
+    return delivery;
   }
   const route = await (async () => {
     try {
@@ -593,12 +582,7 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
     return delivery;
   }
   if (route.chatType === "direct" && heartbeat?.directPolicy === "block") {
-    return buildNoHeartbeatDeliveryTarget({
-      reason: "dm-blocked",
-      accountId: delivery.accountId,
-      lastChannel: delivery.lastChannel,
-      lastAccountId: delivery.lastAccountId,
-    });
+    return rejectDelivery("dm-blocked");
   }
   if (
     ownerRouteMustBeDirect &&
@@ -608,21 +592,13 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
       chatType: normalizeChatType(route.chatType),
     })
   ) {
-    return buildNoHeartbeatDeliveryTarget({
-      reason: "no-route",
-      accountId: delivery.accountId,
-      lastChannel: delivery.lastChannel,
-      lastAccountId: delivery.lastAccountId,
-    });
+    return rejectDelivery("no-route");
   }
   return {
     ...delivery,
-    // Core fallback routes synthesize `user:`/`channel:` addresses for session
-    // identity only. Keep the plugin's raw delivery address unless its own
-    // route hook explicitly owns transport canonicalization.
-    to: resolveSessionRoute ? route.to : delivery.to,
-    chatType: resolveSessionRoute ? route.chatType : delivery.chatType,
-    threadId: resolveSessionRoute ? (route.threadId ?? delivery.threadId) : delivery.threadId,
+    to: route.to,
+    chatType: route.chatType,
+    threadId: route.threadId ?? delivery.threadId,
     ...(route.recipientSessionExact === true ? { targetSessionKey: route.sessionKey } : {}),
   };
 }

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -42,6 +42,8 @@ import { resolveSessionDeliveryTarget, type SessionDeliveryTarget } from "./targ
 type OutboundTarget = {
   channel: string;
   to?: string;
+  /** Candidate conversation session for post-send heartbeat awareness. */
+  targetSessionKey?: string;
   chatType?: ChatType;
   reason?: string;
   accountId?: string;
@@ -570,9 +572,6 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
       lastAccountId: delivery.lastAccountId,
     });
   }
-  if (!resolveSessionRoute) {
-    return delivery;
-  }
   const route = await (async () => {
     try {
       return await resolveOutboundSessionRoute({
@@ -618,9 +617,13 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
   }
   return {
     ...delivery,
-    to: route.to,
-    chatType: route.chatType,
-    threadId: route.threadId ?? delivery.threadId,
+    // Core fallback routes synthesize `user:`/`channel:` addresses for session
+    // identity only. Keep the plugin's raw delivery address unless its own
+    // route hook explicitly owns transport canonicalization.
+    to: resolveSessionRoute ? route.to : delivery.to,
+    chatType: resolveSessionRoute ? route.chatType : delivery.chatType,
+    threadId: resolveSessionRoute ? (route.threadId ?? delivery.threadId) : delivery.threadId,
+    targetSessionKey: route.sessionKey,
   };
 }
 

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -623,7 +623,7 @@ export async function resolveHeartbeatDeliveryTargetWithSessionRoute(params: {
     to: resolveSessionRoute ? route.to : delivery.to,
     chatType: resolveSessionRoute ? route.chatType : delivery.chatType,
     threadId: resolveSessionRoute ? (route.threadId ?? delivery.threadId) : delivery.threadId,
-    targetSessionKey: route.sessionKey,
+    ...(route.recipientSessionExact === true ? { targetSessionKey: route.sessionKey } : {}),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

A heartbeat could deliver an alert to a channel while the model in that same conversation never learned that the alert was sent. The next user turn therefore lacked important context.

## Root cause

Heartbeat delivery did not join the existing target-session awareness path. Isolated cron delivery already had equivalent behavior, but heartbeat delivery stopped after the channel send and run bookkeeping.

## Fix

- Carry a target session only when the channel plugin proves that the outbound recipient maps to the exact inbound session.
- Snapshot the existing target session ID and lifecycle revision before delivery.
- Queue bounded awareness at the identified-send boundary, before later delivery bookkeeping can yield.
- Recheck the target lifecycle before queueing and fail closed for inexact routes, cross-agent bindings, resets, failed sends, and missing sessions.
- Keep the event for the next ordinary target turn, consume it once, and clear it through the existing reset path.
- Reuse the existing transient system-event queue. This adds no schema, durable store, compatibility path, or fallback reader.

## Evidence

- Current-main red: on `69913572f4a84a79de1004a3a91fa87ced9cb95d`, the boundary suite delivered the alert but the target-session awareness assertion failed. Result: 2 failed and 5 passed.
- Exact-head green: [run 33241119339](https://github.com/obviyus/clawdbot/actions/runs/33241119339) tested `0ecca78e88d730dccbe8dc83c23a015c6cdaacdc` through one real ephemeral Gateway with a synthetic channel bus and mock provider.
- The scenario created the target session, delivered exactly one isolated heartbeat alert, exposed the awareness text once on the immediate ordinary turn, exposed no copy on the following turn, and kept the target session ID unchanged.
- Local coverage: 160 focused route and delivery tests passed. All 310 heartbeat-runner tests passed.
- Repository checks: Oxlint, Oxfmt, max-lines, assertion-safety, coercion, deprecated-API, import-cycle, conflict-marker, and diff checks passed. Hosted CI owns type-check and full-build coverage.

## Scope

- Production: +151 / -47, net +104.
- Tests: +341 / -3, net +338.
- The production growth is the exact-route and lifecycle boundary required to prevent wrong-session disclosure. The routing refactor removes 21 net lines from the touched target resolver.
- Durable recovery across a Gateway restart remains outside this transient system-event contract.
