### PR TITLE
fix(codex): preserve disabled MCP transports

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -1938,7 +1938,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
             mcp_servers: {
               "arbitrary.server": { enabled: false },
               "local helper": { enabled: false },
-              "request-only": { enabled: false },
+              "request-only": { command: "request-mcp", enabled: false },
             },
             web_search: "disabled",
           }),
@@ -2062,7 +2062,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
       "skills.include_instructions": false,
       "tools.experimental_request_user_input.enabled": false,
       "tools.update_plan.enabled": false,
-      mcp_servers: { inherited: { enabled: false } },
+      mcp_servers: { inherited: { command: "unsafe", enabled: false } },
       web_search: "disabled",
     });
   });

--- a/extensions/codex/src/app-server/thread-lifecycle.restricted-mcp.real-binary.live.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.restricted-mcp.real-binary.live.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { withTempDir } from "openclaw/plugin-sdk/test-env";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveCodexAppServerRuntimeOptions } from "./config.js";
+import { createIsolatedCodexAppServerClient } from "./shared-client.js";
+import {
+  createAppServerOptions,
+  createParams,
+  resetThreadLifecycleTestFixtures,
+  startOrResumeThread,
+} from "./thread-lifecycle.test-fixtures.js";
+
+const LIVE =
+  process.env.OPENCLAW_LIVE_TEST === "1" && process.env.OPENCLAW_LIVE_CODEX_RESTRICTED_MCP === "1";
+const describeLive = LIVE ? describe : describe.skip;
+
+afterEach(() => {
+  resetThreadLifecycleTestFixtures();
+});
+
+describeLive("Codex restricted MCP real-binary lifecycle", () => {
+  it("starts with inherited MCP disabled and exposes no tools", async () => {
+    await withTempDir("openclaw-codex-restricted-mcp-", async (root) => {
+      const agentDir = path.join(root, "agent");
+      const workspace = path.join(root, "workspace");
+      const launchMarker = path.join(root, "mcp-launched");
+      await fs.mkdir(workspace, { recursive: true });
+      const launchScript = `require("node:fs").writeFileSync(${JSON.stringify(launchMarker)}, "launched")`;
+
+      const runtime = resolveCodexAppServerRuntimeOptions({ env: {} });
+      const client = await createIsolatedCodexAppServerClient({
+        startOptions: runtime.start,
+        agentDir,
+        authProfileId: null,
+        timeoutMs: 60_000,
+      });
+      const request = vi.spyOn(client, "request");
+      try {
+        const params = createParams(path.join(root, "session.jsonl"), workspace);
+        params.toolsAllow = ["openclaw"];
+        params.signal = AbortSignal.timeout(60_000);
+        const binding = await startOrResumeThread({
+          client,
+          params,
+          signal: params.signal,
+          cwd: workspace,
+          dynamicTools: [],
+          config: {
+            mcp_servers: {
+              inherited: {
+                command: process.execPath,
+                args: ["-e", launchScript],
+                cwd: workspace,
+                env: { RESTRICTED_MCP_TEST: "1" },
+              },
+            },
+          },
+          appServer: { ...createAppServerOptions(), start: runtime.start },
+          nativeCodeModeEnabled: false,
+          userMcpServersEnabled: false,
+          hostSystemAgentActive: true,
+        });
+        expect(request.mock.calls.find(([method]) => method === "thread/start")?.[1]).toMatchObject(
+          {
+            environments: [],
+            dynamicTools: [],
+            config: {
+              mcp_servers: {
+                inherited: {
+                  command: process.execPath,
+                  args: ["-e", launchScript],
+                  cwd: workspace,
+                  env: { RESTRICTED_MCP_TEST: "1" },
+                  enabled: false,
+                },
+              },
+            },
+          },
+        );
+        const status = await client.request(
+          "mcpServerStatus/list",
+          { threadId: binding.threadId, detail: "toolsAndAuthOnly" },
+          { timeoutMs: 60_000 },
+        );
+
+        expect(status.data).toEqual([
+          expect.objectContaining({ name: "inherited", serverInfo: null, tools: {} }),
+        ]);
+        await expect(fs.stat(launchMarker)).rejects.toMatchObject({ code: "ENOENT" });
+      } finally {
+        await client.closeAndWait();
+      }
+    });
+  }, 120_000);
+});

--- a/extensions/codex/src/app-server/thread-lifecycle.restricted-mcp.real-binary.live.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.restricted-mcp.real-binary.live.test.ts
@@ -37,13 +37,13 @@ describeLive("Codex restricted MCP real-binary lifecycle", () => {
       });
       const request = vi.spyOn(client, "request");
       try {
+        const signal = AbortSignal.timeout(60_000);
         const params = createParams(path.join(root, "session.jsonl"), workspace);
         params.toolsAllow = ["openclaw"];
-        params.signal = AbortSignal.timeout(60_000);
         const binding = await startOrResumeThread({
           client,
           params,
-          signal: params.signal,
+          signal,
           cwd: workspace,
           dynamicTools: [],
           config: {

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -538,7 +538,12 @@ describe("Codex delegation capability", () => {
       "tools.experimental_request_user_input.enabled": true,
       "tools.update_plan.enabled": true,
       mcp_servers: {
-        "local-example": { command: "example-mcp" },
+        "local-example": {
+          command: "example-mcp",
+          args: ["--stdio"],
+          cwd: "/repo/mcp",
+          env: { MCP_MODE: "restricted" },
+        },
       },
       web_search: "live",
     };
@@ -580,7 +585,15 @@ describe("Codex delegation capability", () => {
         expect(request.config?.[disabledFeature]).toBe(false);
       }
       expect(request.config?.web_search).toBe("disabled");
-      expect(request.config?.mcp_servers).toEqual({ "local-example": { enabled: false } });
+      expect(request.config?.mcp_servers).toEqual({
+        "local-example": {
+          command: "example-mcp",
+          args: ["--stdio"],
+          cwd: "/repo/mcp",
+          env: { MCP_MODE: "restricted" },
+          enabled: false,
+        },
+      });
       expect(request.developerInstructions).toContain("`message(action=send)`");
       expect(request.developerInstructions).not.toContain("`spawn_agent`");
       expect(request.developerInstructions).not.toContain("`tool_search`");
@@ -608,7 +621,14 @@ describe("Codex delegation capability", () => {
       expect(normal.config?.["features.multi_agent_v2"]).toBe(true);
       expect(normal.config?.["features.plugins"]).toBe(true);
       expect(normal.config?.["tools.update_plan.enabled"]).toBe(false);
-      expect(normal.config?.mcp_servers).toEqual({ "local-example": { command: "example-mcp" } });
+      expect(normal.config?.mcp_servers).toEqual({
+        "local-example": {
+          command: "example-mcp",
+          args: ["--stdio"],
+          cwd: "/repo/mcp",
+          env: { MCP_MODE: "restricted" },
+        },
+      });
       expect(normal.developerInstructions).toContain("`spawn_agent`");
     }
   });
@@ -3667,7 +3687,7 @@ describe("Codex app-server supervised branch lifecycle", () => {
         project_doc_max_bytes: 0,
         mcp_servers: {
           inherited: { enabled: false },
-          "request-only": { enabled: false },
+          "request-only": { command: "request-mcp", enabled: false },
         },
       });
     }

--- a/extensions/codex/src/app-server/thread-requests.ts
+++ b/extensions/codex/src/app-server/thread-requests.ts
@@ -444,12 +444,8 @@ export function buildCodexRuntimeThreadConfigForRun(
     ...(options.restrictedToolSurfaceInheritedMcpServerNames ?? []),
     ...(isJsonObject(configMcpServers) ? Object.keys(configMcpServers) : []),
   ];
-  // Per-thread configs deep-merge; drop server launch details before the
-  // final disabled-server patch so a delivery turn cannot retain MCP access.
-  const restrictedRunConfig =
-    restrictedToolSurface && isJsonObject(configMcpServers)
-      ? { ...config, mcp_servers: {} }
-      : config;
+  // Codex validates each transport before it applies `enabled`. Preserve the
+  // transport here; the deny patch below disables it and attestation proves it stayed inactive.
   const webSearchConfig = resolveCodexWebSearchPlan({
     config: params.config,
     disableTools: params.disableTools,
@@ -458,7 +454,7 @@ export function buildCodexRuntimeThreadConfigForRun(
     webSearchAllowed: options.webSearchAllowed,
   }).threadConfig;
   const baseConfig = buildCodexRuntimeThreadConfig(
-    mergeCodexThreadConfigs(restrictedRunConfig, webSearchConfig),
+    mergeCodexThreadConfigs(config, webSearchConfig),
     options,
   );
   const runtimeConfig =


### PR DESCRIPTION
## Summary

- Preserve request-local MCP transport fields on restricted Codex threads.
- Override only `enabled: false` and keep all existing restricted feature and tool denials.
- Add request-shape coverage and a real `@openai/codex 0.150.1` lifecycle regression.

## Root cause

The restricted thread projector cleared `mcp_servers` before it merged the disabled-server patch. Codex validates `command` or `url` before it applies `enabled`, so the resulting `{ enabled: false }` entry failed with `invalid transport` before thread startup.

## Fix

The canonical deep merge now retains each request-local MCP transport and overrides `enabled` to `false`. The existing post-start attestation still requires `serverInfo: null`, an empty tool catalog, and an exact disabled-server inventory before execution can continue.

## Proof

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/thread-lifecycle.binding.test.ts` — 292 tests passed.
- `OPENCLAW_LIVE_TEST=1 OPENCLAW_LIVE_CODEX_RESTRICTED_MCP=1 node --import tsx scripts/test-live.mts -- extensions/codex/src/app-server/thread-lifecycle.restricted-mcp.real-binary.live.test.ts` — exact Codex 0.150.1 thread startup passed.
- The live regression confirms `environments: []`, the retained stdio transport, `enabled: false`, no server process launch, `serverInfo: null`, and zero exposed tools.
- Production code delta: 3 additions and 7 deletions.

Thanks @noelillinger for the exact reproduction and upstream contract evidence.

Fixes #124713
