### PR TITLE
fix(a2a): close request connections after outbound sends

### DIFF
--- a/extensions/a2a/src/outbound.test.ts
+++ b/extensions/a2a/src/outbound.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import * as ssrfRuntime from "openclaw/plugin-sdk/ssrf-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { sendA2aChannelText } from "./outbound.js";
 import type { A2aCoreConfig, A2aPeerConfig } from "./types.js";
 
@@ -28,8 +29,38 @@ function parseA2aRequestBody(body: BodyInit | null | undefined): Record<string, 
   return JSON.parse(body) as Record<string, unknown>;
 }
 
-afterEach(() => {
-  vi.restoreAllMocks();
+const guardedFetch = ssrfRuntime.fetchWithSsrFGuard;
+const releases: { release: Mock<() => Promise<void>>; cleanup: () => Promise<void> }[] = [];
+let completedReleases = 0;
+
+beforeEach(() => {
+  releases.length = 0;
+  completedReleases = 0;
+  vi.spyOn(ssrfRuntime, "fetchWithSsrFGuard").mockImplementation(async (params) => {
+    const result = await guardedFetch(params);
+    const release = vi.fn(async () => {
+      await result.release();
+      completedReleases += 1;
+    });
+    releases.push({ release, cleanup: result.release });
+    return { ...result, release };
+  });
+});
+
+afterEach(async () => {
+  try {
+    for (const { release } of releases) {
+      expect(release).toHaveBeenCalledOnce();
+    }
+    expect(completedReleases).toBe(releases.length);
+  } finally {
+    try {
+      // Failed lifecycle assertions must still dispose the real guard timers.
+      await Promise.all(releases.map(({ cleanup }) => cleanup()));
+    } finally {
+      vi.restoreAllMocks();
+    }
+  }
 });
 
 describe("A2A outbound channel delivery", () => {
@@ -91,12 +122,13 @@ describe("A2A outbound channel delivery", () => {
           error: { code: -32601, message: "Method not found" },
         }),
       )
-      .mockResolvedValueOnce(
-        createA2aJsonResponse({
+      .mockImplementationOnce(async () => {
+        expect(completedReleases).toBe(1);
+        return createA2aJsonResponse({
           jsonrpc: "2.0",
           result: { task: { id: "legacy-task-1" } },
-        }),
-      );
+        });
+      });
     const cfg = createA2aOutboundConfig({
       token: "inbound-token",
       url: "https://hermes.example/a2a/v1",
@@ -182,7 +214,9 @@ describe("A2A outbound channel delivery", () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(createA2aJsonResponse({}, { status: 503 }))
-      .mockResolvedValueOnce(createA2aJsonResponse({ error: { code: "invalid" } }));
+      .mockResolvedValueOnce(createA2aJsonResponse({ error: { code: "invalid" } }))
+      .mockResolvedValueOnce(new Response("{invalid JSON"))
+      .mockResolvedValueOnce(createA2aJsonResponse({}));
 
     await expect(sendA2aChannelText({ cfg, to: "hermes", text: "hello" })).rejects.toThrow(
       "HTTP 503",
@@ -190,6 +224,12 @@ describe("A2A outbound channel delivery", () => {
     await expect(sendA2aChannelText({ cfg, to: "hermes", text: "hello" })).rejects.toThrow(
       "invalid A2A JSON-RPC response",
     );
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await expect(sendA2aChannelText({ cfg, to: "hermes", text: "hello" })).rejects.toThrow(
+      SyntaxError,
+    );
+    await expect(sendA2aChannelText({ cfg, to: "hermes", text: "hello" })).rejects.toThrow(
+      "A2A response without a result",
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(4);
   });
 });

--- a/extensions/a2a/src/outbound.ts
+++ b/extensions/a2a/src/outbound.ts
@@ -75,7 +75,7 @@ export async function sendA2aChannelText(
   for (let attempt = 0; attempt < 2; attempt += 1) {
     // Peer URLs are operator config, but they still leave the Gateway: the shared
     // guard keeps that egress on the same SSRF policy as every other plugin call.
-    const { response } = await fetchWithSsrFGuard({
+    const { response, release } = await fetchWithSsrFGuard({
       url: peer.url,
       timeoutMs: A2A_OUTBOUND_TIMEOUT_MS,
       signal,
@@ -89,31 +89,38 @@ export async function sendA2aChannelText(
         body: JSON.stringify(request),
       },
     });
-    if (!response.ok) {
-      throw new Error(`outbound A2A request to peer ${peerName} failed (HTTP ${response.status})`);
-    }
-
-    const parsed = A2aOutboundResponseSchema.safeParse(await response.json());
-    if (!parsed.success) {
-      throw new Error(`peer ${peerName} returned an invalid A2A JSON-RPC response`);
-    }
-
-    if (parsed.data.error) {
-      if (attempt === 0 && parsed.data.error.code === -32601) {
-        // Hermes-generation A2A 0.3 peers only expose the shipped dotted method.
-        request.method = "message/send";
-        continue;
+    try {
+      if (!response.ok) {
+        throw new Error(
+          `outbound A2A request to peer ${peerName} failed (HTTP ${response.status})`,
+        );
       }
-      throw new Error(
-        `outbound A2A request to peer ${peerName} failed: ${parsed.data.error.message}`,
-      );
-    }
 
-    if (!parsed.data.result) {
-      throw new Error(`peer ${peerName} returned an A2A response without a result`);
-    }
+      const parsed = A2aOutboundResponseSchema.safeParse(await response.json());
+      if (!parsed.success) {
+        throw new Error(`peer ${peerName} returned an invalid A2A JSON-RPC response`);
+      }
 
-    return { to: params.to, messageId: parsed.data.result.task?.id ?? messageId };
+      if (parsed.data.error) {
+        if (attempt === 0 && parsed.data.error.code === -32601) {
+          // Hermes-generation A2A 0.3 peers only expose the shipped dotted method.
+          request.method = "message/send";
+          continue;
+        }
+        throw new Error(
+          `outbound A2A request to peer ${peerName} failed: ${parsed.data.error.message}`,
+        );
+      }
+
+      if (!parsed.data.result) {
+        throw new Error(`peer ${peerName} returned an A2A response without a result`);
+      }
+
+      return { to: params.to, messageId: parsed.data.result.task?.id ?? messageId };
+    } finally {
+      // Each attempt owns its guard lease, including before the compatibility retry.
+      await release();
+    }
   }
 
   throw new Error(`outbound A2A request to peer ${peerName} exhausted its compatibility retry`);


### PR DESCRIPTION
Related: #130008, #130804

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators sending messages through the A2A plugin would leave request-owned connections and timeout resources alive after the send returned, including successful sends and failed peer responses. The compatibility retry also started its second request without releasing the first.

This affects the current-main A2A plugin introduced in #130008, not the latest stable release (`v2026.7.1-2`, which does not contain this plugin).

## Why This Change Was Made

The outbound sender discarded the SSRF guard's `release` handle. It now owns that handle in a per-attempt `try/finally`, awaiting cleanup before returning, throwing, or retrying. Both channel entry points receive only a parsed receipt, so cleanup belongs here rather than in a downstream caller.

The base includes the landed shared guard repair #130804 (`d62f0b8993961dcf39df0f8c8617f700cb0c54ab`), which releases unread response transports. No A2A-specific cancellation workaround or new SDK helper is needed. The shared 30-second deadline across both attempts, payloads, message IDs, compatibility fallback, authentication, SSRF policy, and zero-redirect behavior are unchanged.

Production LOC: +30/-23, net +7. The growth is the per-attempt ownership boundary, one lifecycle comment, and formatter wrapping; an outer cleanup block would miss the first attempt, and a new helper would add unnecessary surface. Tests: +49/-9, net +40, extending the existing outbound cases.

## User Impact

A2A sends release their request resources promptly on success, HTTP errors, malformed JSON, invalid response shapes, JSON-RPC errors, missing results, and compatibility retries. Successful receipts and peer-facing protocol behavior stay the same. No configuration, dependency, public API, security policy, or persistence changes.

## Evidence

Reviewed candidate: `d026a96734647867909dadb4d8e22971a5f413b7`, based on the landed guard repair `d62f0b8993961dcf39df0f8c8617f700cb0c54ab`.

- Retained regression: the original sender failed 5 of 6 outbound tests for omitted release and retry-before-release. The tests forward the real guard, retain the existing request/policy assertions, and clean up handles even after failed assertions.
- Final owner suite on the base containing #130804: `node scripts/run-vitest.mjs extensions/a2a` — **7 files, 93 tests passed**, one worker, 18.67 seconds.
- Real loopback HTTP proof through the actual outbound sender and SSRF guard, using a synthetic peer and an unchanged 500 ms socket-close observation bound:

  | Case | Original sender | Final candidate |
  |---|---|---|
  | Successful receipt | Request dispatcher and TCP connection left open | Closed in 21 ms |
  | HTTP 503 with an unread, trickling body | Request dispatcher and TCP connection left open | Closed in 5 ms |
  | Malformed JSON | Request dispatcher and TCP connection left open | Closed in 2 ms |
  | Compatibility retry | Both connections left open; first lease unreleased before retry | Both closed in 4 ms; first release completed before retry |

  All five request-owned dispatchers completed close and were destroyed; the server observed zero open TCP connections before harness teardown. The successful process exited naturally in 0.76 seconds, with its listener closed and owned sockets/intervals cleared. This is synthetic real-HTTP transport proof, not an external A2A service or Gateway end-to-end run; no total timer-count claim.
- The intermediate A2A-only patch passed three HTTP cases but still retained the unread 503 connection on the old guard. That result was preserved, and the last case was rerun successfully only after the canonical #130804 fix landed.
- Formatting and `git diff --check` passed. Final independent source and real-behavior review approved the exact patch; fresh Codex P2 review reported no findings.

Exact-head [hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/33062483770) on `d026a96734647867909dadb4d8e22971a5f413b7`, including type and lint gates. The [hosted test job](https://github.com/openclaw/openclaw/actions/runs/33062483770/job/98484679670) passed all six outbound tests in 11 ms on Node 24.19.0 after a frozen-lockfile install with the repository's Undici 8.10.0 pin. Precise OpenGrep and Security Sensitive Guard also passed.

Local proof used Node 26.7.0 and installed Undici 8.9.0; it is distinct from the hosted pinned-dependency test run. Local typed lint was deferred because its wrapper requires cold package-boundary declaration preparation outside the bounded local proof scope; the hosted type/lint gates passed, and no preparation or type gate was bypassed.

AI-assisted with Codex.
