### PR TITLE
fix(release): restore bundled plugin package validation

### DIFF
--- a/extensions/openshell/.npmignore
+++ b/extensions/openshell/.npmignore
@@ -1,0 +1,12 @@
+.DS_Store
+dist/.boundary-tsc.tsbuildinfo
+**/*.map
+**/*.test.ts
+**/*.test.tsx
+**/*.spec.ts
+**/*.spec.tsx
+**/*.test-helpers.ts
+**/*.test-harness.ts
+**/*.test-support.ts
+src/test-*.ts
+src/test-support/

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -503,6 +503,8 @@ describe("bundled plugin metadata", () => {
           env: {
             anyOf: ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_USER_TOKEN"],
           },
+          specifier: "./configured-state",
+          exportName: "hasConfiguredSlackChannelState",
         },
       },
       {

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -29,6 +29,7 @@ const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.mjs", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/doctor.ts", 1],
+  ["@openclaw/daytona-sandbox:dangerous-exec:src/upload.ts", 1],
   ["@openclaw/discord:dangerous-exec:src/voice/audio.ts", 1],
   ["@openclaw/imessage:dangerous-exec:src/client.ts", 1],
   ["@openclaw/llama-cpp-provider:dangerous-exec:src/llama-server-install.ts", 1],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation's agentic-plugin lane failed against current bundled plugin metadata and publishable package contents.

The lane reported three regressions:

- Slack's configured-state runtime hook was present in its package manifest but absent from the bundled metadata expectation.
- OpenShell's publishable package included `backend.e2e.test-support.ts`, which the release security scan correctly treated as executable test support.
- Daytona's fixed-executable `tar` invocation was not recorded in the release scan's exact reviewed-finding inventory.

## Why This Change Was Made

The repair updates the authoritative metadata expectation, excludes OpenShell test-only sources at the npm package boundary, and records Daytona's reviewed finding with an exact count. Unknown, relocated, or count-changed security findings still fail closed.

## User Impact

There is no runtime behavior change. Release qualification can complete against the current bundled plugin set, and published OpenShell packages no longer include test support.

Production runtime LOC: +0/-0. Packaging configuration: +12/-0. Tests/release inventory: +3/-0.

## Evidence

Original failure:

- Full Release Validation: https://github.com/openclaw/openclaw/actions/runs/33057199578
- Failed child job: https://github.com/openclaw/openclaw/actions/runs/33058466211/job/98471311578

Final head validation:

- `src/plugins/bundled-plugin-metadata.test.ts`: 37/37 passed.
- `src/plugins/npm-install-security-scan.release.test.ts`: 104/104 passed.
- OpenShell `npm pack --dry-run --json --ignore-scripts`: 11 files, no test/spec/test-support paths.
- Daytona `npm pack --dry-run --json --ignore-scripts`: `src/upload.ts` remains packaged and covered by the exact reviewed-finding count.
- `git diff --check`, core lint, extension lint, extension production/test type checks, dead-export scans, database-first guard, media helper guard, runtime-sidecar guard, and import-cycle guard passed.
- Independent review found no P0/P1/P2 issues.

Local environment gaps:

- `pnpm tsgo:core:test` reached unrelated UI config and could not resolve the shared install's `pako` declaration. Exact-head CI remains required.
- The structured autoreview helper could not start because the standalone Codex CLI is not installed on this host. The independent review above covered the complete patch.
