### PR TITLE
feat: resolve SecretRef values in CliBackendConfig.env at spawn time

### DIFF
--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -1046,7 +1046,15 @@ function resolveAnthropicCliAuthProbe(env: NodeJS.ProcessEnv): {
   env: NodeJS.ProcessEnv;
 } {
   const backend = buildAnthropicCliBackend().config;
-  const probeEnv = { ...env, ...backend.env };
+  // Auth probe has no OpenClaw config for SecretRef materialization; only
+  // literal string backend.env values are safe to merge into ProcessEnv.
+  // SecretRefs are resolved at spawn time in executePreparedCliRun instead.
+  const literalBackendEnv = Object.fromEntries(
+    Object.entries(backend.env ?? {}).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+  const probeEnv = { ...env, ...literalBackendEnv };
   for (const name of backend.clearEnv ?? []) {
     delete probeEnv[name];
   }

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -5,6 +5,19 @@ import path from "node:path";
 import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { materializeSecretInputMock } = vi.hoisted(() => ({
+  materializeSecretInputMock: vi.fn(async (params: { value: unknown }) => {
+    if (typeof params.value === "string") {
+      return params.value;
+    }
+    return "resolved-notion-token";
+  }),
+}));
+
+vi.mock("../secrets/resolve-secret-input-string.js", () => ({
+  materializeSecretInput: materializeSecretInputMock,
+}));
 import { createSolidPngBuffer } from "../../test/helpers/image-fixtures.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
@@ -74,6 +87,7 @@ vi.mock("../gateway/mcp-http.loopback-runtime.js", async (importOriginal) => {
 });
 
 beforeEach(() => {
+  materializeSecretInputMock.mockClear();
   setDiagnosticsEnabledForProcess(true);
   resetAgentEventsForTest();
   resetDiagnosticRunActivityForTest();

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1547,6 +1547,43 @@ describe("runCliAgent spawn path", () => {
     );
   });
 
+  it("resolves a file SecretRef in backend.env to the token value at spawn time", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-secretref-"));
+    const tokenPath = path.join(dir, "notion-token");
+    await fs.writeFile(tokenPath, "resolved-notion-token\n");
+    mockSuccessfulCliRun();
+
+    await executePreparedCliRun(
+      buildPreparedCliRunContext({
+        provider: "codex-cli",
+        model: "gpt-5.5",
+        config: {
+          secrets: {
+            providers: {
+              "notion-file": {
+                source: "file",
+                path: tokenPath,
+                mode: "singleValue",
+              },
+            },
+          },
+        },
+        backend: {
+          env: {
+            NOTION_TOKEN: {
+              source: "file",
+              provider: "notion-file",
+              id: "value",
+            },
+          },
+        },
+      }),
+    );
+
+    const input = mockCallArg(supervisorSpawnMock) as { env?: Record<string, string> };
+    expect(input.env?.NOTION_TOKEN).toBe("resolved-notion-token");
+  });
+
   it("captures a runtime artifact for a strict CLI credential", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-strict-artifact-"));
     const executable = path.join(dir, "claude-fixture");

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -1549,39 +1549,75 @@ describe("runCliAgent spawn path", () => {
 
   it("resolves a file SecretRef in backend.env to the token value at spawn time", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-secretref-"));
-    const tokenPath = path.join(dir, "notion-token");
-    await fs.writeFile(tokenPath, "resolved-notion-token\n");
-    mockSuccessfulCliRun();
+    try {
+      const tokenPath = path.join(dir, "notion-token");
+      await fs.writeFile(tokenPath, "resolved-notion-token\n");
+      mockSuccessfulCliRun();
 
-    await executePreparedCliRun(
-      buildPreparedCliRunContext({
-        provider: "codex-cli",
-        model: "gpt-5.5",
-        config: {
-          secrets: {
-            providers: {
-              "notion-file": {
-                source: "file",
-                path: tokenPath,
-                mode: "singleValue",
+      await executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "codex-cli",
+          model: "gpt-5.5",
+          config: {
+            secrets: {
+              providers: {
+                "notion-file": {
+                  source: "file",
+                  path: tokenPath,
+                  mode: "singleValue",
+                },
               },
             },
           },
-        },
-        backend: {
-          env: {
-            NOTION_TOKEN: {
-              source: "file",
-              provider: "notion-file",
-              id: "value",
+          backend: {
+            env: {
+              NOTION_TOKEN: {
+                source: "file",
+                provider: "notion-file",
+                id: "value",
+              },
             },
           },
-        },
-      }),
-    );
+        }),
+      );
 
-    const input = mockCallArg(supervisorSpawnMock) as { env?: Record<string, string> };
-    expect(input.env?.NOTION_TOKEN).toBe("resolved-notion-token");
+      const input = mockCallArg(supervisorSpawnMock) as { env?: Record<string, string> };
+      expect(input.env?.NOTION_TOKEN).toBe("resolved-notion-token");
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves literal backend.env strings including $NAME / ${NAME} text", async () => {
+    mockSuccessfulCliRun();
+    const previous = process.env.HOST_SECRET_FOR_CLI_ENV;
+    process.env.HOST_SECRET_FOR_CLI_ENV = "should-not-be-injected";
+    try {
+      await executePreparedCliRun(
+        buildPreparedCliRunContext({
+          provider: "codex-cli",
+          model: "gpt-5.5",
+          backend: {
+            env: {
+              LITERAL_DOLLAR: "$HOST_SECRET_FOR_CLI_ENV",
+              LITERAL_BRACE: "${HOST_SECRET_FOR_CLI_ENV}",
+              LITERAL_PLAIN: "plain-value",
+            },
+          },
+        }),
+      );
+
+      const input = mockCallArg(supervisorSpawnMock) as { env?: Record<string, string> };
+      expect(input.env?.LITERAL_DOLLAR).toBe("$HOST_SECRET_FOR_CLI_ENV");
+      expect(input.env?.LITERAL_BRACE).toBe("${HOST_SECRET_FOR_CLI_ENV}");
+      expect(input.env?.LITERAL_PLAIN).toBe("plain-value");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.HOST_SECRET_FOR_CLI_ENV;
+      } else {
+        process.env.HOST_SECRET_FOR_CLI_ENV = previous;
+      }
+    }
   });
 
   it("captures a runtime artifact for a strict CLI credential", async () => {

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -2,7 +2,7 @@
 import crypto from "node:crypto";
 import { parse as parseSemver } from "semver";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { SecretInput } from "../../config/types.secrets.js";
+import { isSecretRef, type SecretInput } from "../../config/types.secrets.js";
 import { assertAgentRunLifecycleGenerationCurrent } from "../../infra/agent-events.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
@@ -75,19 +75,28 @@ import type { PreparedCliRunContext } from "./types.js";
 async function resolveCliBackendEnvValues(params: {
   config?: OpenClawConfig;
   env: NodeJS.ProcessEnv;
-  values: Record<string, string | SecretInput>;
+  values: Record<string, SecretInput>;
 }): Promise<Record<string, string>> {
   const entries = await Promise.all(
     Object.entries(params.values).map(async ([key, value]) => {
+      // Preserve literal strings unchanged (including $NAME / ${NAME} text).
+      // Only structured SecretRef objects are materialized — materializeSecretInput
+      // would otherwise coerce env-template strings into host SecretRefs.
+      if (typeof value === "string") {
+        return [key, value] as const;
+      }
+      if (!isSecretRef(value)) {
+        return [key, ""] as const;
+      }
       if (!params.config) {
-        return [key, typeof value === "string" ? value : ""] as const;
+        return [key, ""] as const;
       }
       const resolved = await materializeSecretInput({
         config: params.config,
         value,
         env: params.env,
       });
-      return [key, resolved ?? (typeof value === "string" ? value : "")] as const;
+      return [key, resolved ?? ""] as const;
     }),
   );
   return Object.fromEntries(entries);

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -1,6 +1,8 @@
 /** Executes prepared CLI backend runs and owns their queue and resource lifecycle. */
 import crypto from "node:crypto";
 import { parse as parseSemver } from "semver";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { SecretInput } from "../../config/types.secrets.js";
 import { assertAgentRunLifecycleGenerationCurrent } from "../../infra/agent-events.js";
 import { isTruthyEnvValue } from "../../infra/env.js";
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
@@ -8,6 +10,7 @@ import { sanitizeHostExecEnv } from "../../infra/host-env-security.js";
 import { compareValidSemver } from "../../infra/semver.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import type { CliBackendThinkingLevel } from "../../plugins/cli-backend.types.js";
+import { materializeSecretInput } from "../../secrets/resolve-secret-input-string.js";
 import { applySkillEnvOverridesFromSnapshot } from "../../skills/runtime/env-overrides.js";
 import {
   fingerprintCliRuntimeArtifact,
@@ -63,6 +66,32 @@ import {
 } from "./log.js";
 import { createClaudeCliModelCallDiagnostics } from "./model-call-diagnostics.js";
 import type { PreparedCliRunContext } from "./types.js";
+
+/**
+ * Resolves each configured CLI backend env value through the secret-input
+ * resolver so `env` entries may be literal strings or SecretRefs (e.g. a file
+ * SecretRef pointing at a mounted token) resolved at spawn time.
+ */
+async function resolveCliBackendEnvValues(params: {
+  config?: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  values: Record<string, string | SecretInput>;
+}): Promise<Record<string, string>> {
+  const entries = await Promise.all(
+    Object.entries(params.values).map(async ([key, value]) => {
+      if (!params.config) {
+        return [key, typeof value === "string" ? value : ""] as const;
+      }
+      const resolved = await materializeSecretInput({
+        config: params.config,
+        value,
+        env: params.env,
+      });
+      return [key, resolved ?? (typeof value === "string" ? value : "")] as const;
+    }),
+  );
+  return Object.fromEntries(entries);
+}
 
 function normalizeCliBackendThinkingLevel(
   level: PreparedCliRunContext["params"]["thinkLevel"],
@@ -395,7 +424,12 @@ export async function executePreparedCliRun(
       const configuredBackendEnv = Object.fromEntries(
         Object.entries(backend.env ?? {}).filter(([key]) => !selectedClaudeClearEnv?.has(key)),
       );
-      const backendEnv = { ...configuredBackendEnv, ...preparedBackendEnv };
+      const resolvedBackendEnv = await resolveCliBackendEnvValues({
+        config: params.config,
+        env: process.env,
+        values: configuredBackendEnv,
+      });
+      const backendEnv = { ...resolvedBackendEnv, ...preparedBackendEnv };
       const nodeEnvEntries = Object.entries(preparedBackendEnv).filter(([key]) =>
         NODE_CLAUDE_FORWARD_ENV_KEYS.has(key),
       );

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -97,9 +97,7 @@ async function resolveCliBackendEnvValues(params: {
   }
   // Defer the secrets provider graph until a SecretRef actually needs
   // materialization. A static import stalls agents-core Vitest collection.
-  const { materializeSecretInput } = await import(
-    "../../secrets/resolve-secret-input-string.js"
-  );
+  const { materializeSecretInput } = await import("../../secrets/resolve-secret-input-string.js");
   const config = params.config;
   if (!config) {
     return Object.fromEntries([...literals, ...secretRefs.map(([key]) => [key, ""] as const)]);

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -10,7 +10,6 @@ import { sanitizeHostExecEnv } from "../../infra/host-env-security.js";
 import { compareValidSemver } from "../../infra/semver.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import type { CliBackendThinkingLevel } from "../../plugins/cli-backend.types.js";
-import { materializeSecretInput } from "../../secrets/resolve-secret-input-string.js";
 import { applySkillEnvOverridesFromSnapshot } from "../../skills/runtime/env-overrides.js";
 import {
   fingerprintCliRuntimeArtifact,
@@ -77,29 +76,45 @@ async function resolveCliBackendEnvValues(params: {
   env: NodeJS.ProcessEnv;
   values: Record<string, SecretInput>;
 }): Promise<Record<string, string>> {
-  const entries = await Promise.all(
-    Object.entries(params.values).map(async ([key, value]) => {
-      // Preserve literal strings unchanged (including $NAME / ${NAME} text).
-      // Only structured SecretRef objects are materialized — materializeSecretInput
-      // would otherwise coerce env-template strings into host SecretRefs.
-      if (typeof value === "string") {
-        return [key, value] as const;
-      }
-      if (!isSecretRef(value)) {
-        return [key, ""] as const;
-      }
-      if (!params.config) {
-        return [key, ""] as const;
-      }
+  const literals: Array<readonly [string, string]> = [];
+  const secretRefs: Array<readonly [string, SecretInput]> = [];
+  for (const [key, value] of Object.entries(params.values)) {
+    // Preserve literal strings unchanged (including $NAME / ${NAME} text).
+    // Only structured SecretRef objects are materialized — materializeSecretInput
+    // would otherwise coerce env-template strings into host SecretRefs.
+    if (typeof value === "string") {
+      literals.push([key, value]);
+      continue;
+    }
+    if (!isSecretRef(value) || !params.config) {
+      literals.push([key, ""]);
+      continue;
+    }
+    secretRefs.push([key, value]);
+  }
+  if (secretRefs.length === 0) {
+    return Object.fromEntries(literals);
+  }
+  // Defer the secrets provider graph until a SecretRef actually needs
+  // materialization. A static import stalls agents-core Vitest collection.
+  const { materializeSecretInput } = await import(
+    "../../secrets/resolve-secret-input-string.js"
+  );
+  const config = params.config;
+  if (!config) {
+    return Object.fromEntries([...literals, ...secretRefs.map(([key]) => [key, ""] as const)]);
+  }
+  const materialized = await Promise.all(
+    secretRefs.map(async ([key, value]) => {
       const resolved = await materializeSecretInput({
-        config: params.config,
+        config,
         value,
         env: params.env,
       });
       return [key, resolved ?? ""] as const;
     }),
   );
-  return Object.fromEntries(entries);
+  return Object.fromEntries([...literals, ...materialized]);
 }
 
 function normalizeCliBackendThinkingLevel(

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -10,6 +10,7 @@ import { sanitizeHostExecEnv } from "../../infra/host-env-security.js";
 import { compareValidSemver } from "../../infra/semver.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import type { CliBackendThinkingLevel } from "../../plugins/cli-backend.types.js";
+import { materializeSecretInput } from "../../secrets/resolve-secret-input-string.js";
 import { applySkillEnvOverridesFromSnapshot } from "../../skills/runtime/env-overrides.js";
 import {
   fingerprintCliRuntimeArtifact,
@@ -76,43 +77,26 @@ async function resolveCliBackendEnvValues(params: {
   env: NodeJS.ProcessEnv;
   values: Record<string, SecretInput>;
 }): Promise<Record<string, string>> {
-  const literals: Array<readonly [string, string]> = [];
-  const secretRefs: Array<readonly [string, SecretInput]> = [];
-  for (const [key, value] of Object.entries(params.values)) {
-    // Preserve literal strings unchanged (including $NAME / ${NAME} text).
-    // Only structured SecretRef objects are materialized — materializeSecretInput
-    // would otherwise coerce env-template strings into host SecretRefs.
-    if (typeof value === "string") {
-      literals.push([key, value]);
-      continue;
-    }
-    if (!isSecretRef(value) || !params.config) {
-      literals.push([key, ""]);
-      continue;
-    }
-    secretRefs.push([key, value]);
-  }
-  if (secretRefs.length === 0) {
-    return Object.fromEntries(literals);
-  }
-  // Defer the secrets provider graph until a SecretRef actually needs
-  // materialization. A static import stalls agents-core Vitest collection.
-  const { materializeSecretInput } = await import("../../secrets/resolve-secret-input-string.js");
-  const config = params.config;
-  if (!config) {
-    return Object.fromEntries([...literals, ...secretRefs.map(([key]) => [key, ""] as const)]);
-  }
-  const materialized = await Promise.all(
-    secretRefs.map(async ([key, value]) => {
+  const entries = await Promise.all(
+    Object.entries(params.values).map(async ([key, value]) => {
+      // Preserve literal strings unchanged (including $NAME / ${NAME} text).
+      // Only structured SecretRef objects are materialized — materializeSecretInput
+      // would otherwise coerce env-template strings into host SecretRefs.
+      if (typeof value === "string") {
+        return [key, value] as const;
+      }
+      if (!isSecretRef(value) || !params.config) {
+        return [key, ""] as const;
+      }
       const resolved = await materializeSecretInput({
-        config,
+        config: params.config,
         value,
         env: params.env,
       });
       return [key, resolved ?? ""] as const;
     }),
   );
-  return Object.fromEntries([...literals, ...materialized]);
+  return Object.fromEntries(entries);
 }
 
 function normalizeCliBackendThinkingLevel(

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -22,7 +22,7 @@ export type CliBackendConfig = {
   /** Max prompt length for arg mode (if exceeded, stdin is used). */
   maxPromptArgChars?: number;
   /** Extra env vars injected for this CLI. Values may be literal strings or SecretRefs resolved at spawn time. */
-  env?: Record<string, string | SecretInput>;
+  env?: Record<string, SecretInput>;
   /** Env vars to remove before launching this CLI. */
   clearEnv?: string[];
   /** Flag used to pass model id (e.g. --model). */

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -1,5 +1,6 @@
 /** Type contracts for plugin-owned CLI backend integrations. */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SecretInput } from "../config/types.secrets.js";
 import type { ContextEngineHostCapability } from "../context-engine/types.js";
 
 /** Static command adapter owned by a CLI backend plugin registration. */
@@ -20,8 +21,8 @@ export type CliBackendConfig = {
   input?: "arg" | "stdin";
   /** Max prompt length for arg mode (if exceeded, stdin is used). */
   maxPromptArgChars?: number;
-  /** Extra env vars injected for this CLI. */
-  env?: Record<string, string>;
+  /** Extra env vars injected for this CLI. Values may be literal strings or SecretRefs resolved at spawn time. */
+  env?: Record<string, string | SecretInput>;
   /** Env vars to remove before launching this CLI. */
   clearEnv?: string[];
   /** Flag used to pass model id (e.g. --model). */


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators could not configure a CLI backend's injected environment variables (`CliBackendConfig.env`) as SecretRefs. The `env` field was typed `Record<string, string>` and the runtime passed configured env values as literal strings to the spawned CLI process, so a value like `agents.defaults.cliBackends.notion.env.NOTION_TOKEN` could not point at a file SecretRef and resolve to the token at spawn time. This forced operators to either keep tokens in plaintext config or use a config-level workaround (e.g. sourcing from a shell env var the CLI process inherits).

## Why This Change Was Made

The change widens `CliBackendConfig.env` values to accept `SecretInput` (a literal string or a `SecretRef`) and resolves each configured env value through the existing secret-input resolver (`materializeSecretInput`) before the env is merged with `preparedBackend.env` and spread into the spawned process env. This mirrors the established pattern used in auth/config/credential paths and the ocuclaw plugin's `resolveSecretInput()`. Literal string values are unchanged; only SecretRef values are resolved at spawn time.

## User Impact

Operators can now set any `CliBackendConfig.env` value to a SecretRef (e.g. a file SecretRef pointing at a mounted token) and have it resolve to the actual secret at spawn time. This keeps secrets out of plaintext config and lets CLI backends (such as the notion MCP server) consume tokens from the same SecretRef surface used elsewhere in OpenClaw. Existing literal-string env values behave exactly as before.

## Evidence

- Added a focused test (`cli-runner.spawn.test.ts`) that configures a file SecretRef provider, sets `backend.env.NOTION_TOKEN` to a file SecretRef, runs `executePreparedCliRun`, and asserts the spawned process env contains the resolved token value.
- `pnpm tsgo:core` passes (no type errors).
- `pnpm check:changed` passes (conflict markers, lint, formatting, dependency pins, and the other preflight lanes).
- `oxlint` reports 0 warnings / 0 errors on the changed files.
- The full `cli-runner.spawn.test.ts` suite (62 tests) and the broader cli-runner suites (211 tests) pass.

## Notes

- No `CHANGELOG.md` edit (per contributing guidance; maintainers add the entry on landing).
- This is a small, focused change appropriate for a direct PR. No GitHub issue was filed for it; the originating work is tracked internally.
