### PR TITLE
fix(plugins): compensate failed marketplace installs

### DIFF
--- a/src/cli/plugins-install-command.marketplace.test.ts
+++ b/src/cli/plugins-install-command.marketplace.test.ts
@@ -1,0 +1,133 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import * as pluginRegistry from "../plugins/plugin-registry.js";
+import { createColdPluginFixture } from "../plugins/test-helpers/cold-plugin-fixtures.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { runPluginInstallCommand } from "./plugins-install-command.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("marketplace install persistence", () => {
+  let stateDir: string;
+  let marketplace: string;
+  let configPath: string;
+  let targetDir: string;
+  const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    const root = tempDirs.make("openclaw-marketplace-compensation-");
+    stateDir = path.join(root, "state");
+    marketplace = path.join(root, "marketplace");
+    configPath = path.join(stateDir, "openclaw.json");
+    targetDir = path.join(stateDir, "extensions", "demo");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+    vi.stubEnv("OPENCLAW_HOME", root);
+    vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+    const sourceDir = path.join(marketplace, "demo");
+    await fs.mkdir(sourceDir, { recursive: true });
+    await fs.mkdir(stateDir, { recursive: true });
+    createColdPluginFixture({
+      rootDir: sourceDir,
+      pluginId: "demo",
+      manifest: {
+        configSchema: {
+          type: "object",
+          properties: { count: { type: "integer" } },
+          additionalProperties: false,
+        },
+      },
+    });
+    await fs.writeFile(
+      path.join(marketplace, "marketplace.json"),
+      JSON.stringify({ name: "fixture", plugins: [{ name: "demo", source: "./demo" }] }),
+    );
+    clearPluginMetadataLifecycleCaches();
+  });
+
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    clearPluginMetadataLifecycleCaches();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  const install = () =>
+    runPluginInstallCommand({
+      raw: "demo",
+      opts: { marketplace, force: true, acceptCapabilities: true },
+      allowInstallPolicyWarningPrompt: false,
+      invalidateRuntimeCache: false,
+      runtime,
+    });
+
+  it("removes the published payload and reports invalid configured settings", async () => {
+    const config = JSON.stringify({ plugins: { entries: { demo: { config: { count: "old" } } } } });
+    await fs.writeFile(configPath, config);
+
+    const installed = install();
+    await expect.soft(installed).resolves.toBeUndefined();
+    expect.soft(runtime.exit).toHaveBeenCalledWith(1);
+    expect
+      .soft(runtime.error)
+      .toHaveBeenCalledWith(expect.stringContaining("invalid configured settings"));
+    await expect.soft(fs.access(targetDir)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await fs.readdir(path.dirname(targetDir))).toEqual([]);
+    expect(await loadInstalledPluginIndexInstallRecords()).toEqual({});
+    expect(await fs.readFile(configPath, "utf8")).toBe(config);
+  });
+
+  it.each(["none", "refresh-warning", "after-commit"])(
+    "retains committed files and provenance with fault=%s",
+    async (fault) => {
+      await fs.writeFile(configPath, "{}");
+      if (fault === "refresh-warning") {
+        vi.spyOn(pluginRegistry, "refreshPluginRegistry").mockRejectedValueOnce(
+          new Error("refresh unavailable"),
+        );
+      }
+      if (fault === "after-commit") {
+        runtime.log.mockImplementation((message: string) => {
+          if (message === "Installed plugin: demo") {
+            throw new Error("success reporting failed");
+          }
+        });
+      }
+
+      await install();
+
+      if (fault === "after-commit") {
+        expect(runtime.exit).toHaveBeenCalledWith(1);
+        expect(runtime.error).toHaveBeenCalledWith("success reporting failed");
+      } else {
+        expect(runtime.exit).not.toHaveBeenCalled();
+        expect(runtime.error).not.toHaveBeenCalled();
+      }
+      await expect(fs.readFile(path.join(targetDir, "package.json"), "utf8")).resolves.toContain(
+        '"1.0.0"',
+      );
+      expect((await loadInstalledPluginIndexInstallRecords()).demo).toMatchObject({
+        source: "marketplace",
+        installPath: targetDir,
+        version: "1.0.0",
+        marketplaceName: "fixture",
+        marketplaceSource: marketplace,
+        marketplacePlugin: "demo",
+      });
+      expect(JSON.parse(await fs.readFile(configPath, "utf8")).plugins.entries.demo.enabled).toBe(
+        true,
+      );
+      expect(runtime.log).toHaveBeenCalledWith("Installed plugin: demo");
+      if (fault === "refresh-warning") {
+        expect(runtime.log).toHaveBeenCalledWith(
+          expect.stringContaining("Plugin registry refresh failed: refresh unavailable"),
+        );
+      }
+    },
+  );
+});

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -7,9 +7,15 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { createManagedPluginArtifactConsentHandler } from "../plugins/capability-consent.js";
 import { CLAWHUB_INSTALL_ERROR_CODE } from "../plugins/clawhub.js";
 import { resolveDefaultPluginExtensionsDir } from "../plugins/install-paths.js";
-import { persistPluginInstall } from "../plugins/install-persistence.js";
+import {
+  requestDeferredPluginInstall,
+  resolvePluginInstallTransaction,
+} from "../plugins/install-transaction.js";
 import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
-import { installManagedPluginSource } from "../plugins/management-service.js";
+import {
+  installManagedPluginSource,
+  persistManagedSourceInstall,
+} from "../plugins/management-service.js";
 import { installPluginFromMarketplace } from "../plugins/marketplace.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import { tracePluginLifecyclePhaseAsync } from "../plugins/plugin-lifecycle-trace.js";
@@ -130,15 +136,17 @@ async function runPluginInstallCommandUnlocked(
         : {}),
       ...capabilityConsent,
     });
-    const result = await installPluginFromMarketplace({
-      ...safetyOverrides,
-      marketplace: preflight.marketplace,
-      mode: installMode,
-      plugin: raw,
-      extensionsDir: resolveDefaultPluginExtensionsDir(),
-      logger: createPluginInstallLogger(runtime),
-      onBeforePluginArtifactCommit: artifactConsent.onBeforePluginArtifactCommit,
-    });
+    const result = await installPluginFromMarketplace(
+      requestDeferredPluginInstall({
+        ...safetyOverrides,
+        marketplace: preflight.marketplace,
+        mode: installMode,
+        plugin: raw,
+        extensionsDir: resolveDefaultPluginExtensionsDir(),
+        logger: createPluginInstallLogger(runtime),
+        onBeforePluginArtifactCommit: artifactConsent.onBeforePluginArtifactCommit,
+      }),
+    );
     if (!result.ok) {
       if (!isClawHubBlockedCliFailure(result)) {
         runtime.error(result.error);
@@ -154,12 +162,16 @@ async function runPluginInstallCommandUnlocked(
       marketplaceSource: result.marketplaceSource,
       marketplacePlugin: result.marketplacePlugin,
     });
-    await persistPluginInstall({
+    await persistManagedSourceInstall({
       snapshot,
       pluginId: result.pluginId,
       install,
+      transaction: resolvePluginInstallTransaction(result),
       invalidateRuntimeCache,
       runtime,
+    }).catch((error: unknown) => {
+      runtime.error(formatErrorMessage(error));
+      return runtime.exit(1);
     });
     return;
   }

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -1277,7 +1277,7 @@ function throwInstallFailure(result: {
   });
 }
 
-async function persistManagedSourceInstall(params: {
+export async function persistManagedSourceInstall(params: {
   snapshot: ConfigSnapshotForInstallPersist;
   pluginId: string;
   install: PluginInstallRecord;


### PR DESCRIPTION
## What Problem This Solves

Marketplace was the only plugin install source with no failed-install compensation. `installPluginFromMarketplace` publishes the staged tree to `~/.openclaw/extensions/<pluginId>` first, and the CLI then called `persistPluginInstall` bare. Any pre-commit persistence rejection (e.g. `Plugin "X" has invalid configured settings` when a config schema tightened between versions, ambiguous ownership, or a config-write conflict) left an orphan: files on disk with no install record. Discovery scans the extensions root record-independently, so the plugin the user was told failed to install loads on the next gateway start — while `openclaw plugins uninstall` refuses to remove it (no record) and re-running install fails with "plugin already exists (delete it first)". Manual `rm -rf` was the only exit. The error also escaped the CLI unwrapped.

## Why This Change Was Made

The marketplace branch now routes through the same compensation owner every other source uses: it requests the existing deferred source transaction (`requestDeferredPluginInstall`, forwarded by the marketplace installer) and hands it to `persistManagedSourceInstall`, which rolls back published files if persistence rejects before its authoritative `onCommitted` signal and finalizes without deleting committed files afterward. The audit-era ownership helper no longer exists at this base — #122984 replaced path/index inference with source transactions — so the fix uses the current mechanism instead of restoring removed code. The CLI now surfaces persistence failures via `runtime.error` + exit 1 like the other branches. A repository-wide sweep found exactly one other bare `persistPluginInstall` caller, `bundled-install.ts` — intentionally unchanged (it records an existing bundled path, publishes nothing, and must never delete the bundled tree).

Production +25/−13 (compensation routing + error surfacing, one `export` keyword); tests +133.

## User Impact

A failed marketplace install now cleans up after itself and reports the real error, instead of leaving an undeletable half-installed plugin that silently activates on the next gateway start.

## Evidence

- Pre-fix proof: the new regression drove the real schema validator through the bare CLI path — command rejected unwrapped, zero runtime callbacks, published target still on disk, extensions root contained the orphan. Success and post-commit-warning controls passed pre-fix.
- Post-fix: 270 tests green across 5 suites (new marketplace cases with real temp marketplace, real filesystem publication, real config/schema validation, real lifecycle lease, real SQLite records — no mocked installer/persistence/transaction; managed-source rollback cases; CLI install coverage; marketplace source handling; persistence warnings). A committed-then-late-reporting-fault case proves post-commit exceptions cannot delete committed payload or provenance. Focused suites re-run green after rebase onto latest `origin/main`.
- Production core typecheck, format, policy guards, dead-export scans green; affected test-typecheck shards and lint green directly (full aggregate blocked only by known worktree-environment resolution of `pako`/`playwright-core`, reproduced on byte-identical base config — CI is the authoritative gate).
- Fresh Codex autoreview: clean.
