### PR TITLE
docs(codex): correct effort support and provenance in harness reference

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -758,13 +758,14 @@ be account-scoped. Use `/codex models` on a running gateway to see the live
 catalog for that harness and account.
 
 If discovery is temporarily unavailable or times out, the subscription route
-uses offline hints derived from the bundled OpenAI model manifest:
+uses offline hints derived from the bundled OpenAI model manifest, with Codex
+plugin fallbacks for `gpt-5.5` and `gpt-5.5-pro` reasoning efforts:
 
-| Model id      | Display name | Reasoning efforts                    |
-| ------------- | ------------ | ------------------------------------ |
-| `gpt-5.6-sol` | GPT-5.6 Sol  | low, medium, high, xhigh, max, ultra |
-| `gpt-5.5`     | GPT-5.5      | low, medium, high, xhigh             |
-| `gpt-5.5-pro` | gpt-5.5-pro  | medium, high, xhigh                  |
+| Model id      | Display name | Reasoning efforts             |
+| ------------- | ------------ | ----------------------------- |
+| `gpt-5.6-sol` | GPT-5.6 Sol  | low, medium, high, xhigh, max |
+| `gpt-5.5`     | GPT-5.5      | low, medium, high, xhigh      |
+| `gpt-5.5-pro` | gpt-5.5-pro  | medium, high, xhigh           |
 
 Offline hints never prove account entitlement. An authenticated discovery
 response remains authoritative even if it contains no visible models; HTTP
@@ -791,10 +792,10 @@ Available model IDs, input modalities, and reasoning efforts remain
 account-scoped. Run `/codex models` after starting or upgrading the gateway to
 inspect the actual public picker for your account.
 
-The app-server catalog can report `ultra`; OpenClaw reasoning controls currently
-expose levels through `max`. Hidden models can also appear in the app-server
-catalog for internal or specialized flows without being normal model-picker
-choices.
+The app-server catalog can report `ultra`; OpenClaw reasoning controls for the
+Codex runtime currently expose levels through `max`. Hidden models can also
+appear in the app-server catalog for internal or specialized flows without being
+normal model-picker choices.
 </Note>
 
 Tune discovery under `plugins.entries.codex.config.discovery`:


### PR DESCRIPTION
## What Problem This Solves

`docs/plugins/codex-harness-reference.md` contradicted shipped behavior in two places:

1. The offline reasoning-effort table claimed `gpt-5.6-sol` supports `ultra` under the Codex runtime. The bundled OpenAI manifest (`extensions/openai/openclaw.plugin.json:44-55`) has no `ultra`, and `src/auto-reply/thinking.ts:189-203` (pinned by `src/auto-reply/thinking.test.ts:125-139`) adds `ultra` only as OpenClaw's orchestration tier for the `openclaw`/`auto` runtimes — provider requests use `max`. The same doc's later note (through-`max` scoping) already contradicted the table. A user following the table gets a silently clamped effort.
2. The table's introduction attributed the `gpt-5.5`/`gpt-5.5-pro` effort lists to the bundled OpenAI manifest. Those manifest rows declare no efforts (`extensions/openai/openclaw.plugin.json:94-124`); the values actually come from Codex plugin fallbacks in `extensions/codex/src/app-server/reasoning-effort.ts:14-16,76-98`. Values were correct; provenance was wrong.

## Why This Change Was Made

Doctrine: prompt/docs text contradicting shipped behavior is a first-class defect. Docs are the operator's contract; a wrong effort table causes silent clamping surprises.

## User Impact

Operators reading the harness reference now see the real Codex-runtime effort ceiling for Sol (`max`) and the correct source of the GPT-5.5 effort hints. No code or behavior changes.

## Evidence

- Docs-only diff: `docs/plugins/codex-harness-reference.md` +11/−10 (one table row, its intro sentence, and the scoping note; column padding reflow).
- Source truth verified at base `88c684c13ef` and unchanged after rebase: manifest efforts, `thinking.ts` runtime gate + its test, `reasoning-effort.ts` fallbacks, `thread-model-selection.ts:137-148` delegation.
- Direct sibling Codex inspection at `../codex` `be6e8eac029`: `codex-rs/protocol/src/openai_models.rs:40-65` (wire `ultra` support) and `:721-734` (catalog presets copy model-supported efforts) — distinct from OpenClaw's runtime controls; the existing app-server-catalog paragraph is preserved and now explicitly scoped.
- `pnpm docs:list` passes (page remains indexed); `git diff --check` clean.
