### PR TITLE
fix(llama): support embedding-only managed setup

### DIFF
--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -33,13 +33,19 @@ same provider; it never creates another provider namespace.
 ## Managed local server
 
 Choose **Managed local server** when OpenClaw should install, start, and stop
-the server. After consent, setup verifies a pinned llama.cpp build, downloads
-verified chat and embedding models, writes the loopback endpoint and
-`localService` definition, and probes the result before saving it.
+the server. After consent, setup verifies a pinned llama.cpp build, writes the
+loopback endpoint and `localService` definition, and probes the result before
+saving it.
 
 The default chat model is Gemma 4 E4B IT Q4_K_M (about 5.0 GB) with a 65,536
 token context cap. OpenClaw offers it only on machines with at least 16 GiB of
-RAM. The managed EmbeddingGemma model is about 0.3 GB. Setup discovery remains
+RAM. This setup downloads the chat model and the managed EmbeddingGemma model
+(about 0.3 GB).
+
+When `memory.search.provider` is `local` and chat setup cannot proceed or is
+declined, OpenClaw offers a separate embedding-only setup. It installs only the
+managed server and EmbeddingGemma after explicit consent. It does not add a
+llama.cpp chat model or change the current chat model. Setup discovery remains
 read-only and never installs or downloads anything.
 
 ### Use another managed GGUF

--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -48,9 +48,9 @@ managed server and EmbeddingGemma after explicit consent. It does not add a
 llama.cpp chat model or change the current chat model. Setup discovery remains
 read-only and never installs or downloads anything.
 
-If the current chat model uses an existing llama.cpp server, embedding-only
-setup leaves that provider unchanged. Choose another chat model before retrying
-if you want OpenClaw to replace it with an embedding-only managed server.
+If an existing llama.cpp server is configured, embedding-only setup leaves it
+unchanged. Move any chat routes to another provider and remove the existing
+server config before retrying if you want OpenClaw to manage embeddings.
 
 ### Use another managed GGUF
 

--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -48,9 +48,10 @@ managed server and EmbeddingGemma after explicit consent. It does not add a
 llama.cpp chat model or change the current chat model. Setup discovery remains
 read-only and never installs or downloads anything.
 
-If an existing llama.cpp server is configured, embedding-only setup leaves it
-unchanged. Move any chat routes to another provider and remove the existing
-server config before retrying if you want OpenClaw to manage embeddings.
+If any chat route uses llama.cpp, embedding-only setup leaves it unchanged.
+Move those routes to another provider before retrying. An existing external
+llama.cpp server config must also be removed before OpenClaw can manage
+embeddings.
 
 ### Use another managed GGUF
 

--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -48,10 +48,10 @@ managed server and EmbeddingGemma after explicit consent. It does not add a
 llama.cpp chat model or change the current chat model. Setup discovery remains
 read-only and never installs or downloads anything.
 
-If any chat route uses llama.cpp, embedding-only setup leaves it unchanged.
-Move those routes to another provider before retrying. An existing external
-llama.cpp server config must also be removed before OpenClaw can manage
-embeddings.
+If the llama.cpp provider has any configured chat models, embedding-only setup
+leaves it unchanged. Move any chat routes to another provider and remove those
+model entries before retrying. An existing external llama.cpp server config
+must also be removed before OpenClaw can manage embeddings.
 
 ### Use another managed GGUF
 

--- a/docs/plugins/llama-cpp.md
+++ b/docs/plugins/llama-cpp.md
@@ -48,6 +48,10 @@ managed server and EmbeddingGemma after explicit consent. It does not add a
 llama.cpp chat model or change the current chat model. Setup discovery remains
 read-only and never installs or downloads anything.
 
+If the current chat model uses an existing llama.cpp server, embedding-only
+setup leaves that provider unchanged. Choose another chat model before retrying
+if you want OpenClaw to replace it with an embedding-only managed server.
+
 ### Use another managed GGUF
 
 Add a model under `models.providers.llama-cpp.models`, select its

--- a/extensions/llama-cpp/README.md
+++ b/extensions/llama-cpp/README.md
@@ -28,8 +28,9 @@ with at least 16 GiB of RAM.
 When local memory search is configured and chat setup is unavailable or
 declined, OpenClaw offers a separate embedding-only setup. After explicit
 consent, it installs only the server and EmbeddingGemma. It leaves the current
-chat model unchanged. Move any llama.cpp chat routes first. Remove an existing
-external server config before retrying embedding-only setup.
+chat model unchanged. Move any llama.cpp chat routes and remove its configured
+chat model entries first. Remove an existing external server config before
+retrying embedding-only setup.
 
 Custom GGUF models remain supported through `params.modelPath`. Rerun llama.cpp
 setup after changing the model so OpenClaw can verify the file and regenerate

--- a/extensions/llama-cpp/README.md
+++ b/extensions/llama-cpp/README.md
@@ -28,7 +28,8 @@ with at least 16 GiB of RAM.
 When local memory search is configured and chat setup is unavailable or
 declined, OpenClaw offers a separate embedding-only setup. After explicit
 consent, it installs only the server and EmbeddingGemma. It leaves the current
-chat model unchanged.
+chat model unchanged. If the current chat model uses this llama.cpp provider,
+choose another chat model before retrying embedding-only setup.
 
 Custom GGUF models remain supported through `params.modelPath`. Rerun llama.cpp
 setup after changing the model so OpenClaw can verify the file and regenerate

--- a/extensions/llama-cpp/README.md
+++ b/extensions/llama-cpp/README.md
@@ -28,8 +28,8 @@ with at least 16 GiB of RAM.
 When local memory search is configured and chat setup is unavailable or
 declined, OpenClaw offers a separate embedding-only setup. After explicit
 consent, it installs only the server and EmbeddingGemma. It leaves the current
-chat model unchanged. If the current chat model uses this llama.cpp provider,
-choose another chat model before retrying embedding-only setup.
+chat model unchanged. If an existing llama.cpp server is configured, move any
+chat routes and remove that server config before retrying embedding-only setup.
 
 Custom GGUF models remain supported through `params.modelPath`. Rerun llama.cpp
 setup after changing the model so OpenClaw can verify the file and regenerate

--- a/extensions/llama-cpp/README.md
+++ b/extensions/llama-cpp/README.md
@@ -25,6 +25,11 @@ downloads Gemma 4 E4B IT Q4_K_M (approximately 5.0 GB) plus EmbeddingGemma
 (approximately 0.3 GB). The default chat download is offered only on machines
 with at least 16 GiB of RAM.
 
+When local memory search is configured and chat setup is unavailable or
+declined, OpenClaw offers a separate embedding-only setup. After explicit
+consent, it installs only the server and EmbeddingGemma. It leaves the current
+chat model unchanged.
+
 Custom GGUF models remain supported through `params.modelPath`. Rerun llama.cpp
 setup after changing the model so OpenClaw can verify the file and regenerate
 the managed router preset.

--- a/extensions/llama-cpp/README.md
+++ b/extensions/llama-cpp/README.md
@@ -28,8 +28,8 @@ with at least 16 GiB of RAM.
 When local memory search is configured and chat setup is unavailable or
 declined, OpenClaw offers a separate embedding-only setup. After explicit
 consent, it installs only the server and EmbeddingGemma. It leaves the current
-chat model unchanged. If an existing llama.cpp server is configured, move any
-chat routes and remove that server config before retrying embedding-only setup.
+chat model unchanged. Move any llama.cpp chat routes first. Remove an existing
+external server config before retrying embedding-only setup.
 
 Custom GGUF models remain supported through `params.modelPath`. Rerun llama.cpp
 setup after changing the model so OpenClaw can verify the file and regenerate

--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -198,6 +198,20 @@ describe("llama.cpp provider plugin", () => {
     expect(mocks.discoverServer).not.toHaveBeenCalled();
   });
 
+  it("keeps an embedding-only managed model inventory empty", async () => {
+    const provider = registerTextProvider();
+    const catalog = expectDefined(provider.catalog, "managed model catalog");
+    const options = configuredOptions();
+    options.config.models.providers[LLAMA_CPP_PROVIDER_ID].models = [];
+
+    const result = await catalog.run({
+      config: options.config,
+      env: {},
+    });
+
+    expect(result.provider?.models).toEqual([]);
+  });
+
   it("registers local embeddings through the generic provider contract", () => {
     const { config, registry } = createPluginRegistryFixture();
     registerVirtualTestPlugin({
@@ -284,11 +298,9 @@ describe("llama.cpp provider plugin", () => {
     );
     expect(mocks.prepareServer).toHaveBeenCalledWith(
       expect.objectContaining({
+        chatModel: { mode: "preserve" },
         embeddingModelPath: "/models/model.gguf",
       }),
-    );
-    expect(mocks.prepareServer).not.toHaveBeenCalledWith(
-      expect.objectContaining({ chatModelPath: expect.anything() }),
     );
     expect(result.runtime?.cacheKeyData).toEqual({
       provider: "local",
@@ -377,8 +389,11 @@ describe("llama.cpp provider plugin", () => {
       expect(result.defaultModel).toBe(`${LLAMA_CPP_PROVIDER_ID}/${DEFAULT_LLAMA_CPP_MODEL_ID}`);
       expect(mocks.prepareServer).toHaveBeenCalledWith(
         expect.objectContaining({
-          chatModelId: DEFAULT_LLAMA_CPP_MODEL_ID,
-          chatModelPath: "/models/chat.gguf",
+          chatModel: expect.objectContaining({
+            mode: "configure",
+            id: DEFAULT_LLAMA_CPP_MODEL_ID,
+            path: "/models/chat.gguf",
+          }),
           embeddingModelPath: "/models/embedding.gguf",
         }),
       );

--- a/extensions/llama-cpp/index.test.ts
+++ b/extensions/llama-cpp/index.test.ts
@@ -207,9 +207,14 @@ describe("llama.cpp provider plugin", () => {
     const result = await catalog.run({
       config: options.config,
       env: {},
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
     });
 
-    expect(result.provider?.models).toEqual([]);
+    if (!result || !("provider" in result)) {
+      throw new Error("managed catalog returned no provider");
+    }
+    expect(result.provider.models).toEqual([]);
   });
 
   it("registers local embeddings through the generic provider contract", () => {

--- a/extensions/llama-cpp/provider-policy-api.test.ts
+++ b/extensions/llama-cpp/provider-policy-api.test.ts
@@ -17,11 +17,13 @@ describe("llama.cpp embedding setup policy", () => {
   });
 
   it("accepts managed config produced by the models auth CLI without mutating it", () => {
-    const provider = buildLlamaCppProviderConfig(undefined, {
-      command: "/managed/llama-server",
-      baseUrl: "http://127.0.0.1:19432/v1",
-      healthUrl: "http://127.0.0.1:19432/health",
-      args: ["--models-preset", "/managed/models.ini"],
+    const provider = buildLlamaCppProviderConfig({
+      managed: {
+        command: "/managed/llama-server",
+        baseUrl: "http://127.0.0.1:19432/v1",
+        healthUrl: "http://127.0.0.1:19432/health",
+        args: ["--models-preset", "/managed/models.ini"],
+      },
     });
     const config: OpenClawConfig = { models: { providers: { "llama-cpp": provider } } };
     const configBefore = JSON.stringify(config);

--- a/extensions/llama-cpp/src/defaults.ts
+++ b/extensions/llama-cpp/src/defaults.ts
@@ -18,7 +18,6 @@ export function resolveLlamaCppSyntheticApiKey(): string {
 }
 
 export const DEFAULT_LLAMA_CPP_MODEL_ID = "gemma-4-e4b-it-q4_k_m";
-export const DEFAULT_LLAMA_CPP_MODEL_REF = `${LLAMA_CPP_PROVIDER_ID}/${DEFAULT_LLAMA_CPP_MODEL_ID}`;
 export const DEFAULT_LLAMA_CPP_MODEL_URI =
   "hf:unsloth/gemma-4-E4B-it-GGUF/gemma-4-E4B-it-Q4_K_M.gguf";
 export const DEFAULT_LLAMA_CPP_MODEL_REVISION = "bfc15c382204943c3a8fff0c750b94ae2364d7a3";

--- a/extensions/llama-cpp/src/defaults.ts
+++ b/extensions/llama-cpp/src/defaults.ts
@@ -128,19 +128,25 @@ function buildDefaultLlamaCppModel(): ModelDefinitionConfig {
 }
 
 export function buildLlamaCppProviderConfig(
-  existing?: ModelProviderConfig,
-  managed?: {
-    baseUrl: string;
-    command: string;
-    args: string[];
-    healthUrl: string;
-  },
+  params: {
+    existing?: ModelProviderConfig;
+    managed?: {
+      baseUrl: string;
+      command: string;
+      args: string[];
+      healthUrl: string;
+    };
+    modelInventory?: ModelDefinitionConfig[];
+  } = {},
 ): ModelProviderConfig {
+  const { existing, managed, modelInventory } = params;
   const defaultModel = buildDefaultLlamaCppModel();
   const configuredModels = existing?.models ?? [];
-  const models = configuredModels.some((model) => model.id === defaultModel.id)
-    ? configuredModels
-    : [...configuredModels, defaultModel];
+  const models =
+    modelInventory ??
+    (configuredModels.some((model) => model.id === defaultModel.id)
+      ? configuredModels
+      : [...configuredModels, defaultModel]);
   return {
     ...existing,
     baseUrl:

--- a/extensions/llama-cpp/src/embedding-provider.ts
+++ b/extensions/llama-cpp/src/embedding-provider.ts
@@ -148,6 +148,7 @@ async function prepareEmbeddingServer(
         download: true,
       });
       await prepareManagedLlamaServer({
+        chatModel: { mode: "preserve" },
         embeddingModelIsDefault,
         embeddingModelPath,
         port: resolveProviderPort(provider),

--- a/extensions/llama-cpp/src/managed-provider.ts
+++ b/extensions/llama-cpp/src/managed-provider.ts
@@ -91,7 +91,12 @@ export function registerLlamaCppProvider(api: OpenClawPluginApi): void {
       run: async (ctx) => {
         const configured = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
         return configured?.localService
-          ? { provider: buildLlamaCppProviderConfig(configured) }
+          ? {
+              provider: buildLlamaCppProviderConfig({
+                existing: configured,
+                modelInventory: configured.models,
+              }),
+            }
           : await discoverLlamaServerProvider(ctx);
       },
     },

--- a/extensions/llama-cpp/src/managed-server.test.ts
+++ b/extensions/llama-cpp/src/managed-server.test.ts
@@ -123,10 +123,13 @@ describe("managed llama-server", () => {
 
     try {
       await prepareManagedLlamaServer({
-        chatModelId: "chat-model",
-        chatModelPath: "/models/chat.gguf",
-        contextSize: 8192,
-        maxTokens: 2048,
+        chatModel: {
+          mode: "configure",
+          id: "chat-model",
+          path: "/models/chat.gguf",
+          contextSize: 8192,
+          maxTokens: 2048,
+        },
         embeddingModelIsDefault: true,
         embeddingModelPath: "/models/embedding.gguf",
         port: 19_432,
@@ -157,7 +160,13 @@ describe("managed llama-server", () => {
     });
 
     try {
+      await fs.writeFile(
+        presetPath,
+        "version = 1\n\n[stale-chat]\nmodel = /models/stale-chat.gguf\n\n" +
+          "[embeddinggemma-300m-qat-q8_0]\nmodel = /models/old-embedding.gguf\nembedding = true\n",
+      );
       await prepareManagedLlamaServer({
+        chatModel: { mode: "remove" },
         embeddingModelPath: "/models/custom-embedding.gguf",
         port: 19_432,
       });
@@ -194,6 +203,7 @@ describe("managed llama-server", () => {
       ]);
       await Promise.all([
         prepareManagedLlamaServer({
+          chatModel: { mode: "preserve" },
           embeddingModelPath,
           port: 19_434,
         }),

--- a/extensions/llama-cpp/src/managed-server.ts
+++ b/extensions/llama-cpp/src/managed-server.ts
@@ -17,7 +17,6 @@ import {
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_SHA256,
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL_SIZE_BYTES,
   DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
-  DEFAULT_LLAMA_CPP_MODEL_ID,
   DEFAULT_LLAMA_CPP_MODEL_REVISION,
   DEFAULT_LLAMA_CPP_MODEL_SHA256,
   DEFAULT_LLAMA_CPP_MODEL_SIZE_BYTES,
@@ -51,6 +50,17 @@ export type ManagedLlamaServer = {
   healthUrl: string;
   args: string[];
 };
+
+export type ManagedLlamaChatModel =
+  | { mode: "preserve" }
+  | { mode: "remove" }
+  | {
+      mode: "configure";
+      id: string;
+      path: string;
+      contextSize?: number;
+      maxTokens?: number;
+    };
 
 export type LlamaServerRuntimeFacts = {
   engine: "llama.cpp";
@@ -380,10 +390,7 @@ async function writePreset(presetPath: string, contents: string): Promise<void> 
 async function updatePreset(
   presetPath: string,
   params: {
-    chatModelId?: string;
-    chatModelPath?: string;
-    contextSize?: number;
-    maxTokens?: number;
+    chatModel: ManagedLlamaChatModel;
     embeddingModelIsDefault?: boolean;
     embeddingModelPath?: string;
     defaultEmbeddingModelPath?: string;
@@ -399,19 +406,17 @@ async function updatePreset(
         }
         throw error;
       });
-      if (params.chatModelId || params.chatModelPath) {
-        if (!params.chatModelId || !params.chatModelPath) {
-          throw new Error("llama.cpp chat model id and path must be provided together");
-        }
-      }
-      const chatSection = params.chatModelPath
-        ? renderChatModelSection({
-            id: params.chatModelId ?? DEFAULT_LLAMA_CPP_MODEL_ID,
-            modelPath: params.chatModelPath,
-            contextSize: params.contextSize,
-            maxTokens: params.maxTokens,
-          })
-        : readChatModelSection(existing);
+      const chatSection =
+        params.chatModel.mode === "preserve"
+          ? readChatModelSection(existing)
+          : params.chatModel.mode === "configure"
+            ? renderChatModelSection({
+                id: params.chatModel.id,
+                modelPath: params.chatModel.path,
+                contextSize: params.chatModel.contextSize,
+                maxTokens: params.chatModel.maxTokens,
+              })
+            : undefined;
       const embeddingSection = params.embeddingModelPath
         ? renderEmbeddingModelSection({
             isDefault: params.embeddingModelIsDefault,
@@ -459,10 +464,8 @@ async function findAvailableLlamaServerPort(preferred = LLAMA_CPP_DEFAULT_PORT):
 }
 
 export async function prepareManagedLlamaServer(params: {
-  chatModelId?: string;
-  chatModelPath?: string;
-  contextSize?: number;
-  maxTokens?: number;
+  // Runtime embedding refreshes preserve chat. Explicit embedding-only setup removes it.
+  chatModel: ManagedLlamaChatModel;
   embeddingModelIsDefault?: boolean;
   embeddingModelPath?: string;
   defaultEmbeddingModelPath?: string;
@@ -471,14 +474,7 @@ export async function prepareManagedLlamaServer(params: {
   const { command, asset } = await ensureLlamaServerInstalled();
   const { presetPath } = resolveManagedLlamaServerPaths(asset);
   await updatePreset(presetPath, {
-    ...(params.chatModelPath
-      ? {
-          chatModelId: params.chatModelId ?? DEFAULT_LLAMA_CPP_MODEL_ID,
-          chatModelPath: params.chatModelPath,
-        }
-      : {}),
-    contextSize: params.contextSize,
-    maxTokens: params.maxTokens,
+    chatModel: params.chatModel,
     embeddingModelIsDefault: params.embeddingModelIsDefault,
     embeddingModelPath: params.embeddingModelPath,
     defaultEmbeddingModelPath: params.defaultEmbeddingModelPath,
@@ -555,13 +551,16 @@ export async function ensureManagedLlamaServerForChat(params: {
       const configuredContext = params.model.params?.contextSize;
       const port = Number(new URL(params.provider.baseUrl).port);
       await prepareManagedLlamaServer({
-        chatModelId: params.model.id,
-        chatModelPath,
-        contextSize:
-          typeof configuredContext === "number" && configuredContext > 0
-            ? Math.floor(configuredContext)
-            : params.model.contextTokens,
-        maxTokens: params.model.maxTokens,
+        chatModel: {
+          mode: "configure",
+          id: params.model.id,
+          path: chatModelPath,
+          contextSize:
+            typeof configuredContext === "number" && configuredContext > 0
+              ? Math.floor(configuredContext)
+              : params.model.contextTokens,
+          maxTokens: params.model.maxTokens,
+        },
         defaultEmbeddingModelPath: path.join(cacheDir, DEFAULT_LLAMA_CPP_EMBEDDING_CACHE_FILE),
         port: Number.isInteger(port) && port > 0 ? port : undefined,
       });

--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -155,6 +155,63 @@ describe("llama.cpp managed setup", () => {
     expect(mocks.ensureModel).not.toHaveBeenCalledWith(expect.objectContaining({ download: true }));
   });
 
+  it("offers embedding-only setup for local memory below the chat RAM floor", async () => {
+    vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
+    const ctx = authContext(true);
+    ctx.config.memory = { search: { provider: "local" } };
+    ctx.config.agents = { defaults: { model: { primary: "openai/gpt-5.4" } } };
+
+    const result = await runLlamaCppSetup(ctx);
+
+    expect(ctx.prompter.confirm).toHaveBeenCalledWith({
+      message:
+        "OpenClaw can install a verified llama.cpp server and download only the local embedding model (about 0.3 GB). This will not install or change your chat model. Continue?",
+      initialValue: false,
+    });
+    expect(result.defaultModel).toBeUndefined();
+    expect(result.configPatch?.models?.providers?.[LLAMA_CPP_PROVIDER_ID]?.models).toEqual([]);
+    expect(ctx.config.agents.defaults.model).toEqual({ primary: "openai/gpt-5.4" });
+    expect(
+      mocks.ensureModel.mock.calls.filter(([options]) => options.download === true),
+    ).toHaveLength(1);
+    expect(mocks.prepareServer).toHaveBeenCalledWith({
+      chatModel: { mode: "remove" },
+      embeddingModelIsDefault: true,
+      embeddingModelPath: path.join(tempRoot, "embedding.gguf"),
+      port: undefined,
+    });
+  });
+
+  it("requires consent before embedding-only setup", async () => {
+    vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
+    const ctx = authContext(false);
+    ctx.config.memory = { search: { provider: "local" } };
+
+    await expect(runLlamaCppSetup(ctx)).resolves.toEqual({ profiles: [] });
+
+    expect(ctx.prompter.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("only the local embedding model"),
+      }),
+    );
+    expect(mocks.ensureModel).not.toHaveBeenCalledWith(expect.objectContaining({ download: true }));
+  });
+
+  it("offers embedding-only setup after the chat download is declined", async () => {
+    const ctx = authContext(false);
+    ctx.config.memory = { search: { provider: "local" } };
+    vi.mocked(ctx.prompter.confirm).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    const result = await runLlamaCppSetup(ctx);
+
+    expect(ctx.prompter.confirm).toHaveBeenCalledTimes(2);
+    expect(result.defaultModel).toBeUndefined();
+    expect(result.configPatch?.models?.providers?.[LLAMA_CPP_PROVIDER_ID]?.models).toEqual([]);
+    expect(
+      mocks.ensureModel.mock.calls.filter(([options]) => options.download === true),
+    ).toHaveLength(1);
+  });
+
   it("requires consent before installing and downloading", async () => {
     const ctx = authContext(false);
 
@@ -193,7 +250,7 @@ describe("llama.cpp managed setup", () => {
     ).toHaveLength(2);
     expect(mocks.prepareServer).toHaveBeenCalledWith(
       expect.objectContaining({
-        chatModelPath: modelPath,
+        chatModel: expect.objectContaining({ mode: "configure", path: modelPath }),
         embeddingModelPath: path.join(tempRoot, "embedding.gguf"),
       }),
     );
@@ -232,7 +289,13 @@ describe("llama.cpp managed setup", () => {
     expect(managed?.timeoutSeconds).toBe(321);
     expect(managed?.models[0]).toEqual(provider.models[0]);
     expect(mocks.prepareServer).toHaveBeenCalledWith(
-      expect.objectContaining({ chatModelId: "custom", chatModelPath: customModelPath }),
+      expect.objectContaining({
+        chatModel: expect.objectContaining({
+          mode: "configure",
+          id: "custom",
+          path: customModelPath,
+        }),
+      }),
     );
   });
 

--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -25,6 +25,7 @@ vi.mock("./managed-server.js", async (importOriginal) => ({
 }));
 
 import {
+  DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
   DEFAULT_LLAMA_CPP_MODEL_ID,
   DEFAULT_LLAMA_CPP_MODEL_SHA256,
   DEFAULT_LLAMA_CPP_MODEL_SIZE_BYTES,
@@ -32,7 +33,7 @@ import {
   LLAMA_CPP_PROVIDER_ID,
   meetsLlamaCppDefaultModelRamFloor,
 } from "./defaults.js";
-import { detectLlamaCppSetup, runLlamaCppSetup } from "./setup.js";
+import { detectLlamaCppSetup, prepareLlamaCppSetup, runLlamaCppSetup } from "./setup.js";
 
 const GIB = 1024 ** 3;
 let tempRoot: string;
@@ -181,6 +182,36 @@ describe("llama.cpp managed setup", () => {
     });
   });
 
+  it("does not detect chat from a cached model when the managed inventory is empty", async () => {
+    const command = path.join(tempRoot, "llama-server");
+    const preset = path.join(tempRoot, "models.ini");
+    const cachedDefault = path.join(tempRoot, DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE);
+    await Promise.all([
+      fs.writeFile(command, "binary"),
+      fs.writeFile(preset, "version = 1"),
+      fs.writeFile(cachedDefault, "GGUF"),
+    ]);
+    const cfg = config();
+    const provider = cfg.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+    if (!provider) {
+      throw new Error("missing fixture provider");
+    }
+    provider.localService = {
+      command,
+      args: ["--models-preset", preset],
+      healthUrl: "http://127.0.0.1:19432/health",
+    };
+
+    await expect(detectLlamaCppSetup({ config: cfg, env: {} })).resolves.toBeNull();
+    await expect(
+      prepareLlamaCppSetup({
+        config: cfg,
+        env: {},
+        modelRef: `${LLAMA_CPP_PROVIDER_ID}/${DEFAULT_LLAMA_CPP_MODEL_ID}`,
+      }),
+    ).resolves.toBeNull();
+  });
+
   it("does not offer the default download below the RAM floor", async () => {
     vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
     const ctx = authContext(true);
@@ -300,6 +331,45 @@ describe("llama.cpp managed setup", () => {
       );
       expect(mocks.ensureModel).not.toHaveBeenCalledWith(
         expect.objectContaining({ download: true }),
+      );
+      expect(ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID]).toBe(provider);
+    },
+  );
+
+  it.each(externalChatRoutes.slice(0, 2))(
+    "does not replace a managed llama.cpp provider used as $name",
+    async ({ agents }) => {
+      vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
+      const ctx = authContext(true);
+      ctx.config.memory = { search: { provider: "local" } };
+      ctx.config.agents = agents;
+      const provider = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+      if (!provider) {
+        throw new Error("missing managed provider fixture");
+      }
+      provider.localService = {
+        command: path.join(tempRoot, "llama-server"),
+        args: ["--models-preset", path.join(tempRoot, "models.ini")],
+        healthUrl: "http://127.0.0.1:19432/health",
+      };
+      provider.models = [
+        {
+          id: "external-chat",
+          name: "Managed chat",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 8192,
+          maxTokens: 2048,
+        },
+      ];
+
+      await expect(runLlamaCppSetup(ctx)).resolves.toEqual({ profiles: [] });
+
+      expect(ctx.prompter.confirm).not.toHaveBeenCalled();
+      expect(ctx.prompter.note).toHaveBeenCalledWith(
+        expect.stringContaining("chat routes"),
+        "Setup skipped",
       );
       expect(ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID]).toBe(provider);
     },

--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -125,6 +125,24 @@ const externalChatRoutes: Array<{
       },
     },
   },
+  {
+    name: "the default subagent model",
+    agents: {
+      defaults: {
+        model: { primary: "openai/gpt-5.4" },
+        subagents: { model: "llama-cpp/external-chat" },
+      },
+    },
+  },
+  {
+    name: "an agent subagent model",
+    agents: {
+      defaults: { model: { primary: "openai/gpt-5.4" } },
+      entries: {
+        helper: { subagents: { model: "llama-cpp/external-chat" } },
+      },
+    },
+  },
 ];
 
 describe("llama.cpp managed setup", () => {
@@ -336,7 +354,7 @@ describe("llama.cpp managed setup", () => {
     },
   );
 
-  it.each(externalChatRoutes.slice(0, 2))(
+  it.each(externalChatRoutes.filter(({ name }) => name !== "an agent primary"))(
     "does not replace a managed llama.cpp provider used as $name",
     async ({ agents }) => {
       vi.mocked(os.totalmem).mockReturnValue(8 * GIB);

--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -212,6 +212,38 @@ describe("llama.cpp managed setup", () => {
     ).toHaveLength(1);
   });
 
+  it("does not replace an active external llama.cpp chat provider for embeddings", async () => {
+    vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
+    const ctx = authContext(true);
+    ctx.config.memory = { search: { provider: "local" } };
+    ctx.config.agents = { defaults: { model: { primary: "llama-cpp/external-chat" } } };
+    const provider = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+    if (!provider) {
+      throw new Error("missing external provider fixture");
+    }
+    provider.models = [
+      {
+        id: "external-chat",
+        name: "External chat",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 2048,
+      },
+    ];
+
+    await expect(runLlamaCppSetup(ctx)).resolves.toEqual({ profiles: [] });
+
+    expect(ctx.prompter.confirm).not.toHaveBeenCalled();
+    expect(ctx.prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining("llama-cpp/external-chat"),
+      "Setup skipped",
+    );
+    expect(mocks.ensureModel).not.toHaveBeenCalledWith(expect.objectContaining({ download: true }));
+    expect(ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID]).toBe(provider);
+  });
+
   it("requires consent before installing and downloading", async () => {
     const ctx = authContext(false);
 

--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -91,6 +91,41 @@ function authContext(confirm: boolean): ProviderAuthContext {
   } as unknown as ProviderAuthContext;
 }
 
+function requestUnconfiguredLocalMemory(ctx: ProviderAuthContext): void {
+  ctx.config.memory = { search: { provider: "local" } };
+  delete ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+}
+
+const externalChatRoutes: Array<{
+  name: string;
+  agents: NonNullable<ProviderAppGuidedSetupContext["config"]["agents"]>;
+}> = [
+  {
+    name: "the default primary",
+    agents: { defaults: { model: { primary: "llama-cpp/external-chat" } } },
+  },
+  {
+    name: "a default fallback",
+    agents: {
+      defaults: {
+        model: {
+          primary: "openai/gpt-5.4",
+          fallbacks: ["llama-cpp/external-chat"],
+        },
+      },
+    },
+  },
+  {
+    name: "an agent primary",
+    agents: {
+      defaults: { model: { primary: "openai/gpt-5.4" } },
+      entries: {
+        helper: { model: { primary: "llama-cpp/external-chat" } },
+      },
+    },
+  },
+];
+
 describe("llama.cpp managed setup", () => {
   it("pins the default model identity and integrity", () => {
     expect(DEFAULT_LLAMA_CPP_MODEL_URI).toBe(
@@ -158,7 +193,7 @@ describe("llama.cpp managed setup", () => {
   it("offers embedding-only setup for local memory below the chat RAM floor", async () => {
     vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
     const ctx = authContext(true);
-    ctx.config.memory = { search: { provider: "local" } };
+    requestUnconfiguredLocalMemory(ctx);
     ctx.config.agents = { defaults: { model: { primary: "openai/gpt-5.4" } } };
 
     const result = await runLlamaCppSetup(ctx);
@@ -185,7 +220,7 @@ describe("llama.cpp managed setup", () => {
   it("requires consent before embedding-only setup", async () => {
     vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
     const ctx = authContext(false);
-    ctx.config.memory = { search: { provider: "local" } };
+    requestUnconfiguredLocalMemory(ctx);
 
     await expect(runLlamaCppSetup(ctx)).resolves.toEqual({ profiles: [] });
 
@@ -199,7 +234,7 @@ describe("llama.cpp managed setup", () => {
 
   it("offers embedding-only setup after the chat download is declined", async () => {
     const ctx = authContext(false);
-    ctx.config.memory = { search: { provider: "local" } };
+    requestUnconfiguredLocalMemory(ctx);
     vi.mocked(ctx.prompter.confirm).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 
     const result = await runLlamaCppSetup(ctx);
@@ -212,37 +247,63 @@ describe("llama.cpp managed setup", () => {
     ).toHaveLength(1);
   });
 
-  it("does not replace an active external llama.cpp chat provider for embeddings", async () => {
+  it("offers embedding-only setup for per-agent local memory intent", async () => {
     vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
     const ctx = authContext(true);
-    ctx.config.memory = { search: { provider: "local" } };
-    ctx.config.agents = { defaults: { model: { primary: "llama-cpp/external-chat" } } };
-    const provider = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
-    if (!provider) {
-      throw new Error("missing external provider fixture");
-    }
-    provider.models = [
-      {
-        id: "external-chat",
-        name: "External chat",
-        reasoning: false,
-        input: ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 8192,
-        maxTokens: 2048,
+    delete ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+    ctx.config.agents = {
+      defaults: { model: { primary: "openai/gpt-5.4" } },
+      entries: {
+        helper: { memory: { search: { provider: "local" } } },
       },
-    ];
+    };
 
-    await expect(runLlamaCppSetup(ctx)).resolves.toEqual({ profiles: [] });
+    const result = await runLlamaCppSetup(ctx);
 
-    expect(ctx.prompter.confirm).not.toHaveBeenCalled();
-    expect(ctx.prompter.note).toHaveBeenCalledWith(
-      expect.stringContaining("llama-cpp/external-chat"),
-      "Setup skipped",
+    expect(ctx.prompter.confirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("only the local embedding model"),
+      }),
     );
-    expect(mocks.ensureModel).not.toHaveBeenCalledWith(expect.objectContaining({ download: true }));
-    expect(ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID]).toBe(provider);
+    expect(result.configPatch?.models?.providers?.[LLAMA_CPP_PROVIDER_ID]?.models).toEqual([]);
   });
+
+  it.each(externalChatRoutes)(
+    "does not replace an external llama.cpp provider used as $name",
+    async ({ agents }) => {
+      vi.mocked(os.totalmem).mockReturnValue(8 * GIB);
+      const ctx = authContext(true);
+      ctx.config.memory = { search: { provider: "local" } };
+      ctx.config.agents = agents;
+      const provider = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+      if (!provider) {
+        throw new Error("missing external provider fixture");
+      }
+      provider.models = [
+        {
+          id: "external-chat",
+          name: "External chat",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 8192,
+          maxTokens: 2048,
+        },
+      ];
+
+      await expect(runLlamaCppSetup(ctx)).resolves.toEqual({ profiles: [] });
+
+      expect(ctx.prompter.confirm).not.toHaveBeenCalled();
+      expect(ctx.prompter.note).toHaveBeenCalledWith(
+        expect.stringContaining("existing llama.cpp server"),
+        "Setup skipped",
+      );
+      expect(mocks.ensureModel).not.toHaveBeenCalledWith(
+        expect.objectContaining({ download: true }),
+      );
+      expect(ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID]).toBe(provider);
+    },
+  );
 
   it("requires consent before installing and downloading", async () => {
     const ctx = authContext(false);

--- a/extensions/llama-cpp/src/setup.test.ts
+++ b/extensions/llama-cpp/src/setup.test.ts
@@ -25,7 +25,7 @@ vi.mock("./managed-server.js", async (importOriginal) => ({
 }));
 
 import {
-  DEFAULT_LLAMA_CPP_MODEL_REF,
+  DEFAULT_LLAMA_CPP_MODEL_ID,
   DEFAULT_LLAMA_CPP_MODEL_SHA256,
   DEFAULT_LLAMA_CPP_MODEL_SIZE_BYTES,
   DEFAULT_LLAMA_CPP_MODEL_URI,
@@ -205,7 +205,7 @@ describe("llama.cpp managed setup", () => {
     });
     expect(result.defaultModel).toBeUndefined();
     expect(result.configPatch?.models?.providers?.[LLAMA_CPP_PROVIDER_ID]?.models).toEqual([]);
-    expect(ctx.config.agents.defaults.model).toEqual({ primary: "openai/gpt-5.4" });
+    expect(ctx.config.agents?.defaults?.model).toEqual({ primary: "openai/gpt-5.4" });
     expect(
       mocks.ensureModel.mock.calls.filter(([options]) => options.download === true),
     ).toHaveLength(1);
@@ -320,7 +320,7 @@ describe("llama.cpp managed setup", () => {
 
     await expect(runLlamaCppSetup(ctx)).resolves.toMatchObject({
       profiles: [],
-      defaultModel: DEFAULT_LLAMA_CPP_MODEL_REF,
+      defaultModel: `${LLAMA_CPP_PROVIDER_ID}/${DEFAULT_LLAMA_CPP_MODEL_ID}`,
       configPatch: {
         models: {
           providers: {

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -70,10 +70,14 @@ function readPrimaryModel(config: ProviderAppGuidedSetupContext["config"]): stri
 
 function configuredCandidates(
   config: ProviderAppGuidedSetupContext["config"],
+  scope: "detection" | "setup",
 ): LlamaCppChatCandidate[] {
   const existing = config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+  const managedExisting = existing?.localService ? existing : undefined;
   const provider = buildLlamaCppProviderConfig({
-    existing: existing?.localService ? existing : undefined,
+    existing: managedExisting,
+    // Detection reports persisted inventory; interactive setup may still offer the default.
+    ...(managedExisting && scope === "detection" ? { modelInventory: managedExisting.models } : {}),
   });
   const primary = readPrimaryModel(config);
   const primaryId = primary?.startsWith(`${LLAMA_CPP_PROVIDER_ID}/`)
@@ -174,7 +178,7 @@ export async function detectLlamaCppSetup(ctx: ProviderAppGuidedSetupContext) {
   ) {
     return null;
   }
-  for (const candidate of configuredCandidates(ctx.config)) {
+  for (const candidate of configuredCandidates(ctx.config, "detection")) {
     if (await resolveCachedCandidate(candidate)) {
       return {
         modelRef: `${LLAMA_CPP_PROVIDER_ID}/${candidate.model.id}`,
@@ -218,6 +222,21 @@ function hasLocalMemoryIntent(config: ProviderAuthContext["config"]): boolean {
   );
 }
 
+function routesToLlamaCpp(
+  model: string | { primary?: string; fallbacks?: string[] } | undefined,
+): boolean {
+  const refs = typeof model === "string" ? [model] : [model?.primary, ...(model?.fallbacks ?? [])];
+  return refs.some((ref) => ref?.startsWith(`${LLAMA_CPP_PROVIDER_ID}/`) === true);
+}
+
+function hasLlamaCppChatRoute(config: ProviderAuthContext["config"]): boolean {
+  return (
+    routesToLlamaCpp(config.agents?.defaults?.model) ||
+    Object.values(config.agents?.entries ?? {}).some((agent) => routesToLlamaCpp(agent.model)) ||
+    config.agents?.list?.some((agent) => routesToLlamaCpp(agent.model)) === true
+  );
+}
+
 async function resolveSetupPlan(
   ctx: ProviderAuthContext,
   candidates: LlamaCppChatCandidate[],
@@ -249,9 +268,12 @@ async function resolveSetupPlan(
   }
 
   const existing = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
-  if (localMemoryIntent && existing && !existing.localService) {
+  if (
+    localMemoryIntent &&
+    ((existing && !existing.localService) || hasLlamaCppChatRoute(ctx.config))
+  ) {
     await ctx.prompter.note(
-      "Embedding-only setup cannot replace your existing llama.cpp server without changing its chat routes. Move those routes to another provider and remove the existing server config, then retry llama.cpp setup.",
+      "Embedding-only setup cannot replace an existing llama.cpp server or configured llama.cpp chat routes. Move those routes to another provider, remove any existing server config, then retry llama.cpp setup.",
       "Setup skipped",
     );
     return undefined;
@@ -275,7 +297,7 @@ async function resolveSetupPlan(
 export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
   const existing = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
   const managedExisting = existing?.localService ? existing : undefined;
-  const candidates = configuredCandidates(ctx.config);
+  const candidates = configuredCandidates(ctx.config, "setup");
   const plan = await resolveSetupPlan(ctx, candidates);
   if (!plan) {
     return { profiles: [] };

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -241,6 +241,15 @@ async function resolveSetupPlan(
     return undefined;
   }
 
+  const primaryModel = readPrimaryModel(ctx.config);
+  if (hasLocalMemoryIntent(ctx.config) && primaryModel?.startsWith(`${LLAMA_CPP_PROVIDER_ID}/`)) {
+    await ctx.prompter.note(
+      `Embedding-only setup cannot replace the provider while ${primaryModel} is your current chat model. Choose another chat model, then retry llama.cpp setup.`,
+      "Setup skipped",
+    );
+    return undefined;
+  }
+
   if (hasLocalMemoryIntent(ctx.config)) {
     const consent = await ctx.prompter.confirm({
       message:

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -209,7 +209,13 @@ export async function prepareLlamaCppSetup(
 }
 
 function hasLocalMemoryIntent(config: ProviderAuthContext["config"]): boolean {
-  return config.memory?.search?.provider === "local";
+  return (
+    config.memory?.search?.provider === "local" ||
+    Object.values(config.agents?.entries ?? {}).some(
+      (agent) => agent.memory?.search?.provider === "local",
+    ) ||
+    config.agents?.list?.some((agent) => agent.memory?.search?.provider === "local") === true
+  );
 }
 
 async function resolveSetupPlan(
@@ -224,6 +230,7 @@ async function resolveSetupPlan(
 
   candidate = candidates.find((entry) => entry.model.id === DEFAULT_LLAMA_CPP_MODEL_ID);
   const totalmemBytes = os.totalmem();
+  const localMemoryIntent = hasLocalMemoryIntent(ctx.config);
   if (candidate && meetsLlamaCppDefaultModelRamFloor(totalmemBytes)) {
     const consent = await ctx.prompter.confirm({
       message:
@@ -233,7 +240,7 @@ async function resolveSetupPlan(
     if (consent) {
       return { kind: "chat", candidate };
     }
-  } else if (!hasLocalMemoryIntent(ctx.config)) {
+  } else if (!localMemoryIntent) {
     await ctx.prompter.note(
       `This Gateway has ${formatRamGb(totalmemBytes)} GB RAM; the recommended model needs 16 GB+. Configure an existing smaller GGUF, use Ollama or LM Studio, or choose a cloud provider.`,
       "Setup skipped",
@@ -241,16 +248,16 @@ async function resolveSetupPlan(
     return undefined;
   }
 
-  const primaryModel = readPrimaryModel(ctx.config);
-  if (hasLocalMemoryIntent(ctx.config) && primaryModel?.startsWith(`${LLAMA_CPP_PROVIDER_ID}/`)) {
+  const existing = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+  if (localMemoryIntent && existing && !existing.localService) {
     await ctx.prompter.note(
-      `Embedding-only setup cannot replace the provider while ${primaryModel} is your current chat model. Choose another chat model, then retry llama.cpp setup.`,
+      "Embedding-only setup cannot replace your existing llama.cpp server without changing its chat routes. Move those routes to another provider and remove the existing server config, then retry llama.cpp setup.",
       "Setup skipped",
     );
     return undefined;
   }
 
-  if (hasLocalMemoryIntent(ctx.config)) {
+  if (localMemoryIntent) {
     const consent = await ctx.prompter.confirm({
       message:
         "OpenClaw can install a verified llama.cpp server and download only the local embedding model (about 0.3 GB). This will not install or change your chat model. Continue?",

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -222,21 +222,6 @@ function hasLocalMemoryIntent(config: ProviderAuthContext["config"]): boolean {
   );
 }
 
-function routesToLlamaCpp(
-  model: string | { primary?: string; fallbacks?: string[] } | undefined,
-): boolean {
-  const refs = typeof model === "string" ? [model] : [model?.primary, ...(model?.fallbacks ?? [])];
-  return refs.some((ref) => ref?.startsWith(`${LLAMA_CPP_PROVIDER_ID}/`) === true);
-}
-
-function hasLlamaCppChatRoute(config: ProviderAuthContext["config"]): boolean {
-  return (
-    routesToLlamaCpp(config.agents?.defaults?.model) ||
-    Object.values(config.agents?.entries ?? {}).some((agent) => routesToLlamaCpp(agent.model)) ||
-    config.agents?.list?.some((agent) => routesToLlamaCpp(agent.model)) === true
-  );
-}
-
 async function resolveSetupPlan(
   ctx: ProviderAuthContext,
   candidates: LlamaCppChatCandidate[],
@@ -268,10 +253,7 @@ async function resolveSetupPlan(
   }
 
   const existing = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
-  if (
-    localMemoryIntent &&
-    ((existing && !existing.localService) || hasLlamaCppChatRoute(ctx.config))
-  ) {
+  if (localMemoryIntent && existing && (!existing.localService || existing.models.length > 0)) {
     await ctx.prompter.note(
       "Embedding-only setup cannot replace an existing llama.cpp server or configured llama.cpp chat routes. Move those routes to another provider, remove any existing server config, then retry llama.cpp setup.",
       "Setup skipped",

--- a/extensions/llama-cpp/src/setup.ts
+++ b/extensions/llama-cpp/src/setup.ts
@@ -19,7 +19,6 @@ import {
   DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
   DEFAULT_LLAMA_CPP_MODEL_CACHE_FILE,
   DEFAULT_LLAMA_CPP_MODEL_ID,
-  DEFAULT_LLAMA_CPP_MODEL_REF,
   LLAMA_CPP_PROVIDER_ID,
   buildLlamaCppProviderConfig,
   meetsLlamaCppDefaultModelRamFloor,
@@ -31,11 +30,21 @@ import {
 import {
   ensureLlamaCppModel,
   prepareManagedLlamaServer,
+  type ManagedLlamaChatModel,
   type ManagedLlamaServer,
 } from "./managed-server.js";
 
 const BYTES_PER_GB = 1_000_000_000;
 const BYTES_PER_MB = 1_000_000;
+
+type LlamaCppChatCandidate = {
+  model: ModelDefinitionConfig;
+  provider: ModelProviderConfig;
+};
+
+type LlamaCppSetupPlan =
+  | { kind: "chat"; candidate: LlamaCppChatCandidate; cachedPath?: string }
+  | { kind: "embedding-only" };
 
 function formatDownloadProgress(
   label: string,
@@ -61,9 +70,11 @@ function readPrimaryModel(config: ProviderAppGuidedSetupContext["config"]): stri
 
 function configuredCandidates(
   config: ProviderAppGuidedSetupContext["config"],
-): Array<{ model: ModelDefinitionConfig; provider: ModelProviderConfig }> {
+): LlamaCppChatCandidate[] {
   const existing = config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
-  const provider = buildLlamaCppProviderConfig(existing?.localService ? existing : undefined);
+  const provider = buildLlamaCppProviderConfig({
+    existing: existing?.localService ? existing : undefined,
+  });
   const primary = readPrimaryModel(config);
   const primaryId = primary?.startsWith(`${LLAMA_CPP_PROVIDER_ID}/`)
     ? primary.slice(LLAMA_CPP_PROVIDER_ID.length + 1)
@@ -124,22 +135,24 @@ function readConfiguredPort(provider: ModelProviderConfig | undefined): number |
 function buildSetupResult(params: {
   config: ProviderAppGuidedSetupContext["config"];
   managed: ManagedLlamaServer;
+  plan: LlamaCppSetupPlan["kind"];
   defaultModel?: string;
 }): ProviderAuthResult {
   const existing = params.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
   const switchingFromExternal = Boolean(existing && !existing.localService);
   return {
     profiles: [],
-    defaultModel: params.defaultModel ?? DEFAULT_LLAMA_CPP_MODEL_REF,
+    ...(params.defaultModel ? { defaultModel: params.defaultModel } : {}),
     configPatch: {
       ...buildLlamaCppAuthProfileRemovalPatch(params.config),
       models: {
         mode: params.config.models?.mode ?? "merge",
         providers: {
-          [LLAMA_CPP_PROVIDER_ID]: buildLlamaCppProviderConfig(
-            switchingFromExternal ? undefined : existing,
-            params.managed,
-          ),
+          [LLAMA_CPP_PROVIDER_ID]: buildLlamaCppProviderConfig({
+            existing: switchingFromExternal ? undefined : existing,
+            managed: params.managed,
+            ...(params.plan === "embedding-only" ? { modelInventory: [] } : {}),
+          }),
         },
       },
     },
@@ -184,6 +197,7 @@ export async function prepareLlamaCppSetup(
   const rootUrl = baseUrl.replace(/\/v1$/u, "");
   return buildSetupResult({
     config: ctx.config,
+    plan: "chat",
     defaultModel: ctx.modelRef,
     managed: {
       command: existing.localService.command,
@@ -194,47 +208,91 @@ export async function prepareLlamaCppSetup(
   });
 }
 
-export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
-  const existing = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
-  const managedExisting = existing?.localService ? existing : undefined;
-  const candidates = configuredCandidates(ctx.config);
-  let selected = candidates[0];
-  let chatModelPath = selected ? await resolveCachedCandidate(selected) : undefined;
-  if (!chatModelPath) {
-    selected = candidates.find((candidate) => candidate.model.id === DEFAULT_LLAMA_CPP_MODEL_ID);
-    const totalmemBytes = os.totalmem();
-    if (!selected || !meetsLlamaCppDefaultModelRamFloor(totalmemBytes)) {
-      await ctx.prompter.note(
-        `This Gateway has ${formatRamGb(totalmemBytes)} GB RAM; the recommended model needs 16 GB+. Configure an existing smaller GGUF, use Ollama or LM Studio, or choose a cloud provider.`,
-        "Setup skipped",
-      );
-      return { profiles: [] };
-    }
+function hasLocalMemoryIntent(config: ProviderAuthContext["config"]): boolean {
+  return config.memory?.search?.provider === "local";
+}
+
+async function resolveSetupPlan(
+  ctx: ProviderAuthContext,
+  candidates: LlamaCppChatCandidate[],
+): Promise<LlamaCppSetupPlan | undefined> {
+  let candidate = candidates[0];
+  const cachedPath = candidate ? await resolveCachedCandidate(candidate) : undefined;
+  if (candidate && cachedPath) {
+    return { kind: "chat", candidate, cachedPath };
+  }
+
+  candidate = candidates.find((entry) => entry.model.id === DEFAULT_LLAMA_CPP_MODEL_ID);
+  const totalmemBytes = os.totalmem();
+  if (candidate && meetsLlamaCppDefaultModelRamFloor(totalmemBytes)) {
     const consent = await ctx.prompter.confirm({
       message:
         "OpenClaw will install a verified llama.cpp server and download Gemma 4 E4B IT Q4_K_M (about 5.0 GB) plus the local embedding model (about 0.3 GB). Continue?",
       initialValue: false,
     });
-    if (!consent) {
-      await ctx.prompter.note("Local model setup skipped.", "Setup skipped");
-      return { profiles: [] };
+    if (consent) {
+      return { kind: "chat", candidate };
+    }
+  } else if (!hasLocalMemoryIntent(ctx.config)) {
+    await ctx.prompter.note(
+      `This Gateway has ${formatRamGb(totalmemBytes)} GB RAM; the recommended model needs 16 GB+. Configure an existing smaller GGUF, use Ollama or LM Studio, or choose a cloud provider.`,
+      "Setup skipped",
+    );
+    return undefined;
+  }
+
+  if (hasLocalMemoryIntent(ctx.config)) {
+    const consent = await ctx.prompter.confirm({
+      message:
+        "OpenClaw can install a verified llama.cpp server and download only the local embedding model (about 0.3 GB). This will not install or change your chat model. Continue?",
+      initialValue: false,
+    });
+    if (consent) {
+      return { kind: "embedding-only" };
     }
   }
 
-  if (!selected) {
-    throw new Error("llama.cpp setup could not resolve a chat model");
+  await ctx.prompter.note("Local model setup skipped.", "Setup skipped");
+  return undefined;
+}
+
+export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<ProviderAuthResult> {
+  const existing = ctx.config.models?.providers?.[LLAMA_CPP_PROVIDER_ID];
+  const managedExisting = existing?.localService ? existing : undefined;
+  const candidates = configuredCandidates(ctx.config);
+  const plan = await resolveSetupPlan(ctx, candidates);
+  if (!plan) {
+    return { profiles: [] };
   }
 
   const progress = ctx.prompter.progress("Preparing managed llama.cpp server…");
   try {
     const cacheDir = resolveLlamaCppModelCacheDir(managedExisting);
-    chatModelPath ??= await ensureLlamaCppModel({
-      source: resolveLlamaCppModelSource(selected.model),
-      cacheDir,
-      download: true,
-      signal: ctx.signal,
-      onProgress: (status) => progress.update(formatDownloadProgress("Gemma 4 E4B", status)),
-    });
+    let chatModel: ManagedLlamaChatModel;
+    if (plan.kind === "chat") {
+      const chatModelPath =
+        plan.cachedPath ??
+        (await ensureLlamaCppModel({
+          source: resolveLlamaCppModelSource(plan.candidate.model),
+          cacheDir,
+          download: true,
+          signal: ctx.signal,
+          onProgress: (status) => progress.update(formatDownloadProgress("Gemma 4 E4B", status)),
+        }));
+      const configuredContext = plan.candidate.model.params?.contextSize;
+      chatModel = {
+        mode: "configure",
+        id: plan.candidate.model.id,
+        path: chatModelPath,
+        contextSize:
+          typeof configuredContext === "number" && configuredContext > 0
+            ? Math.floor(configuredContext)
+            : plan.candidate.model.contextTokens,
+        maxTokens: plan.candidate.model.maxTokens,
+      };
+    } else {
+      chatModel = { mode: "remove" };
+    }
     const embeddingModelPath = await ensureLlamaCppModel({
       source: DEFAULT_LLAMA_CPP_EMBEDDING_MODEL,
       cacheDir,
@@ -242,16 +300,8 @@ export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<Provid
       signal: ctx.signal,
       onProgress: (status) => progress.update(formatDownloadProgress("EmbeddingGemma", status)),
     });
-    const configuredContext = selected.model.params?.contextSize;
-    const contextSize =
-      typeof configuredContext === "number" && configuredContext > 0
-        ? Math.floor(configuredContext)
-        : selected.model.contextTokens;
     const managed = await prepareManagedLlamaServer({
-      chatModelId: selected.model.id,
-      chatModelPath,
-      contextSize,
-      maxTokens: selected.model.maxTokens,
+      chatModel,
       embeddingModelIsDefault: true,
       embeddingModelPath,
       port: readConfiguredPort(managedExisting),
@@ -268,7 +318,10 @@ export async function runLlamaCppSetup(ctx: ProviderAuthContext): Promise<Provid
     return buildSetupResult({
       config: ctx.config,
       managed,
-      defaultModel: `${LLAMA_CPP_PROVIDER_ID}/${selected.model.id}`,
+      plan: plan.kind,
+      ...(plan.kind === "chat"
+        ? { defaultModel: `${LLAMA_CPP_PROVIDER_ID}/${plan.candidate.model.id}` }
+        : {}),
     });
   } catch (error) {
     progress.stop("llama.cpp setup failed");


### PR DESCRIPTION
## Problem

Guided managed llama.cpp setup stopped below the 16 GiB chat-model RAM floor, even when `memory.search.provider` explicitly requested local embeddings. The operator saw `Setup skipped`, and `openclaw memory status --deep` could not initialize local memory.

Fixes #128880.

## Root cause

Managed setup had one hard-coded success shape: chat plus embeddings. The setup result always selected a llama.cpp chat model, the provider builder always restored the default chat catalog row, and the shared preset API could not distinguish preserving chat from intentionally removing it.

## Fix

- Select one explicit chat or embedding-only setup plan before downloads start.
- Offer embedding-only setup only for explicit local-memory intent and only after separate consent.
- Save embedding-only managed providers with `models: []` and no default-model change.
- Leave external providers and non-empty llama.cpp chat inventories untouched.
- Recognize local-memory intent from global and per-agent configuration.
- Make configured model inventory authoritative in the managed catalog.
- Give the shared preset owner explicit preserve, remove, and configure chat policies.
- Document the consent and unchanged-chat behavior.

Production code is +179/-96 lines (net +83). The added capability needs an explicit setup plan and two owner-boundary contracts; the preset refactor itself is net negative. The approved product contract makes an explicit empty managed inventory intentional.

## Proof

- The setup, catalog, and active-chat regressions failed before their owner-boundary repairs.
- `node scripts/run-vitest.mjs extensions/llama-cpp --reporter=verbose`: 12 files and 132 tests passed.
- Pinned formatter, whitespace, coercion-helper, and import-cycle checks passed.
- In a disposable Ubuntu 24.04 virtual machine with 8 GiB RAM, exact current `main` at `3ee363fc084` showed `Setup skipped` and `memory status --deep` failed because managed local embeddings were unavailable.
- Exact head `bbd1d79a4c8` obtained explicit embedding-only consent, downloaded one verified 328,577,056-byte GGUF, preserved `openai/gpt-5.4`, saved `models: []`, and generated an embedding-only preset.
- The managed server reported healthy, returned one real 768-value embedding, and returned changed input from a real hybrid memory search.
- Per-agent local-memory intent reached the explicit consent prompt and installed nothing after consent was declined.
- External and managed llama.cpp chat inventories stayed byte-for-byte unchanged and remained listed after setup refused unsafe replacement.
- The managed server, virtual machine, forwarded port, SSH key, and disposable state were stopped and removed after proof.
