### PR TITLE
fix(plugins): roll back managed npm install state on thrown failures

### DIFF
--- a/src/plugins/install-managed-npm.ts
+++ b/src/plugins/install-managed-npm.ts
@@ -192,6 +192,7 @@ export async function installPluginFromManagedNpmRoot(
       }
     | undefined;
   let deferredTransaction = false;
+  let installSucceeded = false;
   try {
     rollbackSnapshot = await createManagedNpmPluginInstallRollbackSnapshot({ npmRoot });
   } catch (error) {
@@ -218,27 +219,6 @@ export async function installPluginFromManagedNpmRoot(
     }
     const managedOverrides = await readOpenClawManagedNpmRootOverrides();
     rollbackPeerDependencySnapshot ??= await readManagedNpmRootPeerDependencySnapshot({ npmRoot });
-    const rollbackFailedManagedNpmInstall = async (
-      failure: Extract<InstallPluginResult, { ok: false }>,
-    ): Promise<Extract<InstallPluginResult, { ok: false }>> => {
-      await rollbackManagedNpmPluginInstall({
-        npmRoot,
-        packageName: params.packageName,
-        targetDir: installRoot,
-        timeoutMs,
-        logger,
-        peerDependencySnapshot: rollbackPeerDependencySnapshot,
-        // Once the poisoned tree has been quarantined, restoring this snapshot
-        // would recreate the crash loop that the recovery attempt is repairing.
-        snapshot: recovery ? undefined : rollbackSnapshot,
-      });
-      await rollbackManagedNpmRootPreparedDependency({
-        packageName: params.packageName,
-        preparedDependency: prepared,
-        logger,
-      });
-      return failure;
-    };
     const quarantineForRecovery = async (
       cause: NonNullable<typeof recovery>["cause"],
     ): Promise<Extract<InstallPluginResult, { ok: false }> | null> => {
@@ -246,10 +226,10 @@ export async function installPluginFromManagedNpmRoot(
         const quarantine = await quarantineManagedNpmProjectRebuildArtifacts({ npmRoot });
         recovery = { cause, quarantine };
       } catch (error) {
-        return await rollbackFailedManagedNpmInstall({
+        return {
           ok: false,
           error: `${cause.error}, but OpenClaw could not quarantine ${npmRoot} for rebuild: ${String(error)}`,
-        });
+        };
       }
       logger.warn?.(
         `${cause.error}; quarantined ${formatManagedNpmProjectQuarantineArtifacts(recovery.quarantine.movedArtifactNames)} at ${recovery.quarantine.quarantineDir} and rebuilding once before retrying.`,
@@ -288,7 +268,7 @@ export async function installPluginFromManagedNpmRoot(
     });
     const initialPeerSync = await syncManagedPeerDependenciesForInstall();
     if (!initialPeerSync.ok) {
-      return await rollbackFailedManagedNpmInstall({ ok: false, error: initialPeerSync.error });
+      return { ok: false, error: initialPeerSync.error };
     }
     const npmInstallArgs = [
       "npm",
@@ -328,10 +308,10 @@ export async function installPluginFromManagedNpmRoot(
       });
       const aliasRetryPeerSync = await syncManagedPeerDependenciesForInstall();
       if (!aliasRetryPeerSync.ok) {
-        return await rollbackFailedManagedNpmInstall({
+        return {
           ok: false,
           error: aliasRetryPeerSync.error,
-        });
+        };
       }
       install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
     }
@@ -350,16 +330,16 @@ export async function installPluginFromManagedNpmRoot(
       const error = recovery
         ? `npm install failed after managed npm project recovery (quarantine: ${recovery.quarantine.quarantineDir}): ${formatNpmCommandFailureOutput(install)}. Original ${recovery.cause.kind === "npm-corruption" ? "npm" : "verification"} error: ${recovery.cause.error}`
         : `npm install failed: ${formatNpmCommandFailureOutput(install)}`;
-      return await rollbackFailedManagedNpmInstall({
+      return {
         ok: false,
         error,
-      });
+      };
     }
     let settledManagedPeerDependencies = false;
     for (let peerSyncPass = 0; peerSyncPass < 10; peerSyncPass += 1) {
       const peerSync = await syncManagedPeerDependenciesForInstall();
       if (!peerSync.ok) {
-        return await rollbackFailedManagedNpmInstall({ ok: false, error: peerSync.error });
+        return { ok: false, error: peerSync.error };
       }
       const syncedPeerDependencies = peerSync.changed;
       if (!syncedPeerDependencies) {
@@ -368,32 +348,32 @@ export async function installPluginFromManagedNpmRoot(
       }
       install = await runCommandWithTimeout(npmInstallArgs, npmInstallOptions);
       if (install.code !== 0) {
-        return await rollbackFailedManagedNpmInstall({
+        return {
           ok: false,
           error: `npm install failed after syncing managed peer dependencies: ${formatNpmCommandFailureOutput(install)}`,
-        });
+        };
       }
     }
     if (!settledManagedPeerDependencies) {
       const peerSync = await syncManagedPeerDependenciesForInstall();
       if (!peerSync.ok) {
-        return await rollbackFailedManagedNpmInstall({ ok: false, error: peerSync.error });
+        return { ok: false, error: peerSync.error };
       }
       settledManagedPeerDependencies = !peerSync.changed;
     }
     if (!settledManagedPeerDependencies) {
-      return await rollbackFailedManagedNpmInstall({
+      return {
         ok: false,
         error:
           "npm install could not settle managed peer dependencies after 10 sync passes; refusing to leave a partially reconciled plugin dependency tree.",
-      });
+      };
     }
     const packageManifestResult = await readOptionalPackageManifest({
       runtime,
       packageDir: installRoot,
     });
     if (!packageManifestResult.ok) {
-      return await rollbackFailedManagedNpmInstall(packageManifestResult);
+      return packageManifestResult;
     }
     const requiredPlatformPackageNames = resolveRequiredPlatformPackageNames(
       packageManifestResult.manifest
@@ -401,10 +381,10 @@ export async function installPluginFromManagedNpmRoot(
         : undefined,
     );
     if (!requiredPlatformPackageNames.ok) {
-      return await rollbackFailedManagedNpmInstall({
+      return {
         ok: false,
         error: requiredPlatformPackageNames.error,
-      });
+      };
     }
     let incompletePlatformPackages: Awaited<ReturnType<typeof listMissingRequiredPlatformPackages>>;
     try {
@@ -413,10 +393,10 @@ export async function installPluginFromManagedNpmRoot(
         requiredPackageNames: requiredPlatformPackageNames.packageNames,
       });
     } catch (error) {
-      return await rollbackFailedManagedNpmInstall({
+      return {
         ok: false,
         error: `Failed to verify platform-specific npm dependencies for ${params.packageName}: ${String(error)}`,
-      });
+      };
     }
     if (incompletePlatformPackages.length > 0) {
       const incompletePlatformPackageNames = incompletePlatformPackages.map((entry) => entry.name);
@@ -440,10 +420,10 @@ export async function installPluginFromManagedNpmRoot(
           },
         });
       } catch (error) {
-        return await rollbackFailedManagedNpmInstall({
+        return {
           ok: false,
           error: `Failed to repair missing or incomplete current-platform package(s) ${incompletePlatformPackageNames.join(", ")}: ${String(error)}`,
-        });
+        };
       } finally {
         if (freshCacheDir) {
           try {
@@ -456,10 +436,10 @@ export async function installPluginFromManagedNpmRoot(
         }
       }
       if (install.code !== 0) {
-        return await rollbackFailedManagedNpmInstall({
+        return {
           ok: false,
           error: `npm install failed while repairing missing or incomplete current-platform package(s) ${incompletePlatformPackageNames.join(", ")}: ${formatNpmCommandFailureOutput(install)}`,
-        });
+        };
       }
       let stillIncompletePlatformPackages: typeof incompletePlatformPackages;
       try {
@@ -468,16 +448,16 @@ export async function installPluginFromManagedNpmRoot(
           requiredPackageNames: requiredPlatformPackageNames.packageNames,
         });
       } catch (error) {
-        return await rollbackFailedManagedNpmInstall({
+        return {
           ok: false,
           error: `Failed to verify repaired platform-specific npm dependencies for ${params.packageName}: ${String(error)}`,
-        });
+        };
       }
       if (stillIncompletePlatformPackages.length > 0) {
-        return await rollbackFailedManagedNpmInstall({
+        return {
           ok: false,
           error: `npm install reported success but left required current-platform package(s) missing or incomplete: ${stillIncompletePlatformPackages.map((entry) => entry.name).join(", ")}`,
-        });
+        };
       }
     }
     if (params.packageName !== "openclaw") {
@@ -497,16 +477,16 @@ export async function installPluginFromManagedNpmRoot(
         logger,
       });
     } catch (error) {
-      return await rollbackFailedManagedNpmInstall({
+      return {
         ok: false,
         error: `Failed to repair openclaw peer links after npm install: ${String(error)}`,
-      });
+      };
     }
     if (await auditDeclaredOpenClawHostDependency({ packageDir: installRoot })) {
-      return await rollbackFailedManagedNpmInstall({
+      return {
         ok: false,
         error: formatUnresolvedOpenClawPeerLinkError(params.packageName),
-      });
+      };
     }
 
     let installedDependency: ManagedNpmRootInstalledDependency | null;
@@ -516,10 +496,10 @@ export async function installPluginFromManagedNpmRoot(
         packageName: params.packageName,
       });
     } catch (error) {
-      return await rollbackFailedManagedNpmInstall({
+      return {
         ok: false,
         error: `Failed to verify npm install metadata for ${params.packageName}: ${String(error)}`,
-      });
+      };
     }
     const resolutionVerification = verifyInstalledNpmResolution({
       packageName: params.packageName,
@@ -527,10 +507,10 @@ export async function installPluginFromManagedNpmRoot(
       installed: installedDependency,
     });
     if (resolutionVerification.kind === "conflict") {
-      return await rollbackFailedManagedNpmInstall({
+      return {
         ok: false,
         error: resolutionVerification.error,
-      });
+      };
     }
     if (resolutionVerification.kind === "incomplete") {
       if (!recovery) {
@@ -543,10 +523,10 @@ export async function installPluginFromManagedNpmRoot(
         }
         return await runManagedNpmInstall(prepared);
       }
-      return await rollbackFailedManagedNpmInstall({
+      return {
         ok: false,
         error: `npm install metadata remained incomplete after managed npm project recovery (quarantine: ${recovery.quarantine.quarantineDir}): ${resolutionVerification.error}`,
-      });
+      };
     }
 
     const newRootPackageDirs = await listNewManagedNpmRootPackageDirs({
@@ -587,27 +567,47 @@ export async function installPluginFromManagedNpmRoot(
       emitSuccessSecurityEvent: false,
     });
     if (!result.ok) {
-      return await rollbackFailedManagedNpmInstall(result);
+      return result;
     }
-    try {
-      await params.onBeforePluginArtifactCommit?.({
-        pluginId: result.pluginId,
-        ...(policyMode === "update" ? { currentArtifactDir: installRoot } : {}),
-        stagedArtifactDir: installRoot,
-        mode: policyMode,
-      });
-    } catch (error) {
-      await rollbackFailedManagedNpmInstall({
-        ok: false,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      throw error;
-    }
+    await params.onBeforePluginArtifactCommit?.({
+      pluginId: result.pluginId,
+      ...(policyMode === "update" ? { currentArtifactDir: installRoot } : {}),
+      stagedArtifactDir: installRoot,
+      mode: policyMode,
+    });
     return {
       ...result,
       npmResolution: params.npmResolution,
       ...(params.integrityDrift ? { integrityDrift: params.integrityDrift } : {}),
     };
+  };
+
+  const rollback = async () => {
+    await rollbackManagedNpmPluginInstall({
+      npmRoot,
+      packageName: params.packageName,
+      targetDir: installRoot,
+      timeoutMs,
+      logger,
+      peerDependencySnapshot: rollbackPeerDependencySnapshot,
+      // Restoring a quarantined tree would recreate the corruption being repaired.
+      snapshot: recovery ? undefined : rollbackSnapshot,
+    });
+    if (preparedDependency) {
+      await rollbackManagedNpmRootPreparedDependency({
+        packageName: params.packageName,
+        preparedDependency,
+        logger,
+      });
+    }
+  };
+  const cleanup = async () => {
+    await cleanupManagedNpmRootPreparedDependency({
+      packageName: params.packageName,
+      preparedDependency,
+      logger,
+    });
+    await cleanupManagedNpmPluginInstallRollbackSnapshot({ snapshot: rollbackSnapshot, logger });
   };
 
   try {
@@ -622,22 +622,12 @@ export async function installPluginFromManagedNpmRoot(
     }
     preparedDependency = dependencyResult;
     const result = await runManagedNpmInstall(preparedDependency);
+    installSucceeded = result.ok;
     if (!result.ok || !isPluginInstallCommitDeferred(params)) {
       return result;
     }
     deferredTransaction = true;
     let settled = false;
-    const cleanup = async () => {
-      await cleanupManagedNpmRootPreparedDependency({
-        packageName: params.packageName,
-        preparedDependency,
-        logger,
-      });
-      await cleanupManagedNpmPluginInstallRollbackSnapshot({
-        snapshot: rollbackSnapshot,
-        logger,
-      });
-    };
     return attachPluginInstallTransaction(
       { ...result },
       {
@@ -653,35 +643,18 @@ export async function installPluginFromManagedNpmRoot(
             return;
           }
           settled = true;
-          await rollbackManagedNpmPluginInstall({
-            npmRoot,
-            packageName: params.packageName,
-            targetDir: installRoot,
-            timeoutMs,
-            logger,
-            peerDependencySnapshot: rollbackPeerDependencySnapshot,
-            snapshot: recovery ? undefined : rollbackSnapshot,
-          });
-          await rollbackManagedNpmRootPreparedDependency({
-            packageName: params.packageName,
-            preparedDependency: dependencyResult,
-            logger,
-          });
+          await rollback();
           await cleanup();
         },
       },
     );
   } finally {
     if (!deferredTransaction) {
-      await cleanupManagedNpmRootPreparedDependency({
-        packageName: params.packageName,
-        preparedDependency,
-        logger,
-      });
-      await cleanupManagedNpmPluginInstallRollbackSnapshot({
-        snapshot: rollbackSnapshot,
-        logger,
-      });
+      // Returned failures and throws must restore the snapshot before cleanup discards it.
+      if (!installSucceeded && preparedDependency) {
+        await rollback();
+      }
+      await cleanup();
     }
   }
 }

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -2895,6 +2895,53 @@ describe("installPluginFromNpmSpec", () => {
     ).rejects.toHaveProperty("code", "ENOENT");
   });
 
+  it.each(["npm", "npm-pack"] as const)(
+    "restores the managed project after a post-install throw from %s and allows retry",
+    async (source) => {
+      const stateDir = suiteTempRootTracker.makeTempDir();
+      const npmRoot = path.join(stateDir, "npm");
+      const packageName = "throw-rollback-package";
+      const pluginId = "throw-rollback-plugin";
+      const spec = `${packageName}@1.0.0`;
+      const archivePath = path.join(stateDir, "plugin.tgz");
+      fs.writeFileSync(archivePath, "fixture archive", "utf8");
+      const npmProjectRoot = resolvePluginNpmProjectDir({ npmDir: npmRoot, packageName });
+      writeInstalledNpmPlugin({
+        npmRoot: npmProjectRoot,
+        packageName: "existing-package",
+        version: "1.0.0",
+      });
+      fs.writeFileSync(path.join(npmProjectRoot, "package.json"), '{"private":true}\n');
+      fs.writeFileSync(path.join(npmProjectRoot, "package-lock.json"), '{"lockfileVersion":3}\n');
+      const projectBefore = readTextFileTree(npmProjectRoot);
+      mockNpmViewAndInstallMany([
+        { spec, packArchivePath: archivePath, packageName, pluginId, version: "1.0.0", npmRoot },
+      ]);
+      const failure = new Error("post-install logger failure");
+      const info = vi.fn((message: string) => {
+        if (message.startsWith("Plugin manifest id")) {
+          expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, packageName))).toBe(true);
+          throw failure;
+        }
+      });
+      const install = () => {
+        const params = requestDeferredPluginInstall({ npmDir: npmRoot, logger: { info } });
+        return source === "npm"
+          ? installPluginFromNpmSpec({ ...params, spec })
+          : installPluginFromNpmPackArchive({ ...params, archivePath });
+      };
+
+      await expect(install()).rejects.toBe(failure);
+      expect.soft(readTextFileTree(npmProjectRoot)).toEqual(projectBefore);
+
+      info.mockImplementation(() => {});
+      const retry = await install();
+      expect(retry).toMatchObject({ ok: true, pluginId });
+      await resolvePluginInstallTransaction(retry)?.commit();
+      expect(fs.existsSync(resolveTestPluginPackageDir(npmRoot, packageName))).toBe(true);
+    },
+  );
+
   it("does not fail rollback snapshots on plugin-local openclaw peer symlinks", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
     const npmProjectRoot = resolvePluginNpmProjectDir({


### PR DESCRIPTION
## What Problem This Solves

Managed npm plugin installs rolled back cleanly on returned-error paths, but a **thrown** failure between "npm install succeeded" and "install record written" skipped rollback entirely: the outer `try` in `src/plugins/install-managed-npm.ts` had no catch, and its `finally` ran cleanup variants that **delete** the rollback snapshot without restoring it (`install-managed-npm-state.ts` cleanup vs rollback distinction; npm-pack cleanup also discards its staged-archive backup instead of restoring it).

Consequence: the new payload plus mutated `package.json`/`package-lock.json` remain in the managed root with **no install record**. A normal retry then fails with `plugin already exists: <target> (delete it first)` — the availability check (`src/infra/install-target.ts:43-44`) consults directory existence, not the ledger. Recovery requires CLI `--force` (update mode) or manual deletion.

Real escaping throw sites enumerated in the verification pass include: installed-package validation info callbacks, peer-link directory I/O (`install-installed-package.ts:254-258`, `plugin-peer-link.ts:256-282`), unguarded host-peer repair filesystem work (`npm-managed-root.ts:1053-1084,1185-1297`), new-root package enumeration (`install-managed-npm-state.ts:490-516`), manifest descriptor-close failures, and sanitized non-exit exec failures (`src/process/exec-runner.ts:432-448`). History check (`fda5254e99f`, `3eb8b3a0f83`, `5a643e35431`) confirms snapshots were introduced precisely to preserve managed roots on failed validation — throw paths were an omission, not intentional; stable `v2026.6.1` ships the same gap.

## Why This Change Was Made

Rollback responsibility must cover every non-success exit, not just returned errors. Instead of adding a catch beside the existing per-site rollback calls, the fix makes one canonical owner: a single `rollback()` closure (snapshot + prepared-archive restoration) shared by the deferred-transaction rollback and the outer `finally`, which now restores every prepared attempt that did not succeed **before** cleanup discards its backup. All ~20 scattered `rollbackFailedManagedNpmInstall(...)` wrapper calls are deleted; returned errors now return plainly and throws propagate unchanged (exception identity preserved). Quarantine semantics are preserved (a quarantined tree is never restored); the artifact-consent catch's rollback+rethrow is absorbed by the same owner.

## User Impact

A plugin install that fails mid-validation (I/O error, crash in a validation callback, peer-link failure) now leaves the managed npm root byte-for-byte restored, and an ordinary retry succeeds — no more `plugin already exists` dead end requiring `--force` or manual `rm -rf`.

## Evidence

- Regression (fails pre-fix): table-driven npm + npm-pack cases in `src/plugins/install.npm-spec.test.ts` injecting a throw from the validation-stage info callback after confirming the package was installed. Pre-fix: **2 failed** (new package + mutated manifest/lock + leaked npm-pack archive left behind; retries fail). Post-fix: **2 passed** — byte-for-byte project restoration, sibling package preserved, exception identity unchanged, retry succeeds and commits.
- Owner/sibling suites: `install.npm-spec.test.ts` + `management-service.install-compensation.test.ts` + `install-shared.test.ts` — 89 tests pass (covers prior returned-error rollback, npm-pack deferred commit/rollback, recovery/quarantine, retained generations, persistence compensation). Re-run green on the rebased head bb545c49475.
- Production LOC **−27** (+79/−106); tests +47. No state-module, schema, docs, or dependency changes.
- Scoped gates: tsgo plugins-platform project, oxlint on touched files, import-cycles, database-first, schema-version, and related repo guards all pass. `check-changed` reached an unrelated pre-existing UI e2e type error on main (`ui/src/e2e/sidebar-interactions.e2e.test.ts:45` TS2339 from 9b4d4d08cf7, untouched by this PR) — noted as a follow-up.
- Codex autoreview on the final diff: no findings.
- Limitation: proof uses the existing simulated-npm command fixture with real filesystem rollback; no live npm registry run. Rollback-I/O-failure recovery (best-effort warnings in `install-managed-npm-state.ts:54-68`) is an intentionally untouched named follow-up.
