### PR TITLE
fix(media): bound local reads and invalidate cleaned attachment paths

### DIFF
--- a/src/media-understanding/attachments.cache.test.ts
+++ b/src/media-understanding/attachments.cache.test.ts
@@ -1,8 +1,8 @@
-// Attachment cache tests cover MIME detection after local and remote bytes are available.
+// Attachment cache tests cover bounded reads, MIME detection, and temporary-file ownership.
 import fs from "node:fs/promises";
 import path from "node:path";
 import JSZip from "jszip";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it, vi } from "vitest";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { MediaAttachmentCache } from "./attachments.js";
 
@@ -35,7 +35,7 @@ const PNG_1X1 = Buffer.from(
 );
 const AMBIGUOUS_WEBM = Buffer.from("1a45dfa3874282847765626d", "hex");
 
-describe("media understanding attachment MIME detection", () => {
+describe("media understanding attachment cache", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     buildRandomTempFilePathMock.mockReset();
@@ -78,6 +78,111 @@ describe("media understanding attachment MIME detection", () => {
 
     expect(result.mime).toBe("image/png");
   });
+
+  it("bounds bytes consumed when a local file grows after stat", async () => {
+    await withTestDir({ prefix: "openclaw-media-cache-growth-" }, async (base) => {
+      const attachmentPath = path.join(base, "growing.png");
+      await fs.writeFile(attachmentPath, PNG_1X1);
+      const maxBytes = PNG_1X1.length;
+      const open = fs.open.bind(fs);
+      let consumed = 0;
+      let grew = false;
+      const growBeforeRead = async () => {
+        if (!grew) {
+          grew = true;
+          await fs.appendFile(attachmentPath, Buffer.alloc(4096));
+        }
+      };
+      vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+        const handle = await open(...args);
+        const read = handle.read.bind(handle);
+        vi.spyOn(handle, "read").mockImplementation(async (...readArgs) => {
+          await growBeforeRead();
+          const result = await read(...readArgs);
+          consumed += result.bytesRead;
+          return result;
+        });
+        const readFile = handle.readFile.bind(handle);
+        vi.spyOn(handle, "readFile").mockImplementation(async (...readArgs) => {
+          await growBeforeRead();
+          const result = await readFile(...readArgs);
+          consumed += result.length;
+          return result;
+        });
+        return handle;
+      });
+      const cache = new MediaAttachmentCache([{ index: 0, path: attachmentPath }], {
+        localPathRoots: [base],
+        includeDefaultLocalPathRoots: false,
+      });
+
+      await expect(
+        cache.getBuffer({ attachmentIndex: 0, maxBytes, timeoutMs: 1000 }),
+      ).rejects.toMatchObject({ reason: "maxBytes" });
+      expect(consumed).toBeGreaterThan(0);
+      expect(consumed).toBeLessThanOrEqual(maxBytes + 1);
+    });
+  });
+
+  it.each(["local", "staged"] as const)(
+    "enforces a zero-byte path limit for %s files",
+    async (source) => {
+      expectTypeOf<Parameters<MediaAttachmentCache["getPath"]>[0]>().toEqualTypeOf<{
+        attachmentIndex: number;
+        maxBytes: number;
+        timeoutMs: number;
+      }>();
+      await withTestDir({ prefix: "openclaw-media-cache-path-limit-" }, async (base) => {
+        const attachmentPath = path.join(base, "photo.png");
+        await fs.writeFile(attachmentPath, PNG_1X1);
+        buildRandomTempFilePathMock.mockReturnValue(path.join(base, "staged.png"));
+        readRemoteMediaBufferMock.mockResolvedValue({ buffer: PNG_1X1, fileName: "photo.png" });
+        const attachment =
+          source === "local"
+            ? { index: 0, path: attachmentPath }
+            : { index: 0, url: "https://example.com/photo.png" };
+        const cache = new MediaAttachmentCache([attachment], { localPathRoots: [base] });
+        const request = { attachmentIndex: 0, maxBytes: PNG_1X1.length, timeoutMs: 1000 };
+        try {
+          await expect(cache.getPath(request)).resolves.toHaveProperty("path");
+          await expect(cache.getPath({ ...request, maxBytes: 0 })).rejects.toMatchObject({
+            reason: "maxBytes",
+          });
+        } finally {
+          await cache.cleanup();
+        }
+      });
+    },
+  );
+
+  it.each(["cache", "returned"] as const)(
+    "restages files after %s cleanup",
+    async (cleanupOwner) => {
+      await withTestDir({ prefix: "openclaw-media-cache-restage-" }, async (base) => {
+        buildRandomTempFilePathMock
+          .mockReturnValueOnce(path.join(base, "first.png"))
+          .mockReturnValueOnce(path.join(base, "second.png"));
+        readRemoteMediaBufferMock.mockResolvedValue({ buffer: PNG_1X1, fileName: "photo.png" });
+        const cache = new MediaAttachmentCache([
+          { index: 0, url: "https://example.com/photo.png" },
+        ]);
+        const request = { attachmentIndex: 0, maxBytes: PNG_1X1.length, timeoutMs: 1000 };
+        try {
+          const first = await cache.getPath(request);
+          await (cleanupOwner === "cache" ? cache.cleanup() : first.cleanup?.());
+          await expect(fs.stat(first.path)).rejects.toMatchObject({ code: "ENOENT" });
+          const second = await cache.getPath(request);
+          await expect(fs.readFile(second.path)).resolves.toEqual(PNG_1X1);
+          await first.cleanup?.();
+          expect((await cache.getPath(request)).path).toBe(second.path);
+          expect(readRemoteMediaBufferMock).toHaveBeenCalledTimes(1);
+        } finally {
+          await cache.cleanup();
+        }
+        expect(await fs.readdir(base)).toEqual([]);
+      });
+    },
+  );
 
   it("uses fetched audio metadata when declared MIME is stale for ambiguous WebM", async () => {
     const url = "https://example.com/voice.webm";
@@ -132,9 +237,9 @@ describe("media understanding attachment MIME detection", () => {
       });
       const cache = new MediaAttachmentCache([{ index: 0, url: "https://example.com/photo.png" }]);
 
-      await expect(cache.getPath({ attachmentIndex: 0, timeoutMs: 1_000 })).rejects.toBe(
-        writeError,
-      );
+      await expect(
+        cache.getPath({ attachmentIndex: 0, maxBytes: 1024, timeoutMs: 1_000 }),
+      ).rejects.toBe(writeError);
       await cache.cleanup();
 
       expect(await fs.readdir(base)).toEqual([]);
@@ -156,7 +261,7 @@ describe("media understanding attachment MIME detection", () => {
       });
       vi.spyOn(fs, "unlink").mockRejectedValueOnce(cleanupError);
       const cache = new MediaAttachmentCache([{ index: 0, url: "https://example.com/photo.png" }]);
-      const request = { attachmentIndex: 0, timeoutMs: 1_000 };
+      const request = { attachmentIndex: 0, maxBytes: 1024, timeoutMs: 1_000 };
 
       await expect(cache.getPath(request)).rejects.toBe(writeError);
       expect(await fs.readdir(base)).toEqual(["failed.png"]);

--- a/src/media-understanding/attachments.cache.ts
+++ b/src/media-understanding/attachments.cache.ts
@@ -15,6 +15,7 @@ import { MediaUnderstandingSkipError } from "../../packages/media-understanding-
 import { resolveStateDir } from "../config/paths.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { isAbortError } from "../infra/abort-signal.js";
+import { readFileHandleBounded } from "../infra/fs-safe-advanced.js";
 import { FsSafeError, openLocalFileSafely } from "../infra/fs-safe.js";
 import type { SsrFPolicy } from "../infra/net/ssrf.js";
 import {
@@ -328,14 +329,14 @@ export class MediaAttachmentCache {
   /** Returns a local path for providers that cannot accept buffers, creating a temp file if needed. */
   async getPath(params: {
     attachmentIndex: number;
-    maxBytes?: number;
+    maxBytes: number;
     timeoutMs: number;
   }): Promise<MediaPathResult> {
     const entry = await this.ensureEntry(params.attachmentIndex);
     if (entry.resolvedPath) {
       try {
         const size = await this.ensureLocalStat(entry);
-        if (entry.resolvedPath && params.maxBytes && size !== undefined && size > params.maxBytes) {
+        if (entry.resolvedPath && size !== undefined && size > params.maxBytes) {
           throw new MediaUnderstandingSkipError(
             "maxBytes",
             `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${params.maxBytes}`,
@@ -355,7 +356,7 @@ export class MediaAttachmentCache {
       try {
         const size = await this.ensureLocalStat(entry);
         if (entry.resolvedPath) {
-          if (params.maxBytes && size !== undefined && size > params.maxBytes) {
+          if (size !== undefined && size > params.maxBytes) {
             throw new MediaUnderstandingSkipError(
               "maxBytes",
               `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${params.maxBytes}`,
@@ -371,7 +372,7 @@ export class MediaAttachmentCache {
     }
 
     if (entry.tempPath) {
-      if (params.maxBytes && entry.bufferResult && entry.bufferResult.size > params.maxBytes) {
+      if (entry.bufferResult && entry.bufferResult.size > params.maxBytes) {
         throw new MediaUnderstandingSkipError(
           "maxBytes",
           `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${params.maxBytes}`,
@@ -380,12 +381,7 @@ export class MediaAttachmentCache {
       return { path: entry.tempPath, cleanup: entry.tempCleanup };
     }
 
-    const maxBytes = params.maxBytes ?? Number.POSITIVE_INFINITY;
-    const bufferResult = await this.getBuffer({
-      attachmentIndex: params.attachmentIndex,
-      maxBytes,
-      timeoutMs: params.timeoutMs,
-    });
+    const bufferResult = await this.getBuffer(params);
     const extension = path.extname(bufferResult.fileName || "") || "";
     const tmpPath = buildRandomTempFilePath({
       prefix: "openclaw-media",
@@ -394,6 +390,10 @@ export class MediaAttachmentCache {
     // Keep failed staging owned when model fallback retries the same attachment.
     const previousCleanup = entry.tempCleanup;
     entry.tempCleanup = async () => {
+      // Returned cleanup callbacks may outlive a restaged file; invalidate only their path.
+      if (entry.tempPath === tmpPath) {
+        entry.tempPath = undefined;
+      }
       await previousCleanup?.();
       await fs.unlink(tmpPath).catch(() => {});
     };
@@ -584,13 +584,7 @@ export class MediaAttachmentCache {
           `Attachment ${params.attachmentIndex + 1} path is outside allowed roots.`,
         );
       }
-      const buffer = await opened.handle.readFile();
-      if (buffer.length > params.maxBytes) {
-        throw new MediaUnderstandingSkipError(
-          "maxBytes",
-          `Attachment ${params.attachmentIndex + 1} exceeds maxBytes ${params.maxBytes}`,
-        );
-      }
+      const buffer = await readFileHandleBounded(opened.handle, params.maxBytes);
       return { buffer, filePath: opened.realPath };
     } catch (err) {
       if (err instanceof FsSafeError) {

--- a/src/media-understanding/media-understanding-misc.test.ts
+++ b/src/media-understanding/media-understanding-misc.test.ts
@@ -446,33 +446,6 @@ describe("media understanding attachments SSRF", () => {
     });
   });
 
-  it("enforces maxBytes after reading local attachments", async () => {
-    await withLocalAttachmentCache(
-      "openclaw-media-cache-max-bytes-",
-      async ({ cache, canonicalAttachmentPath }) => {
-        const originalOpen = fs.open.bind(fs);
-        const openSpy = vi.spyOn(fs, "open");
-
-        openSpy.mockImplementation(async (filePath, flags) => {
-          const handle = await originalOpen(filePath, flags);
-          const candidatePath = await fs.realpath(String(filePath)).catch(() => String(filePath));
-          if (candidatePath !== canonicalAttachmentPath) {
-            return handle;
-          }
-          const mockedHandle = handle as typeof handle & {
-            readFile: typeof handle.readFile;
-          };
-          mockedHandle.readFile = (async () => Buffer.alloc(2048, 1)) as typeof handle.readFile;
-          return mockedHandle;
-        });
-
-        await expect(
-          cache.getBuffer({ attachmentIndex: 0, maxBytes: 1024, timeoutMs: 1000 }),
-        ).rejects.toThrow(/exceeds maxBytes 1024/i);
-      },
-    );
-  });
-
   it("opens local attachments with nofollow on posix", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/media-understanding/runtime.local-input.test.ts
+++ b/src/media-understanding/runtime.local-input.test.ts
@@ -1,0 +1,62 @@
+// Exercise the file API with real cache, filesystem, root policy, and MIME detection.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { withTestDir } from "../test-helpers/temp-dir.js";
+import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
+import { prepareImageDescriptionInput } from "./runtime.js";
+
+vi.mock("./runner.js", async () => {
+  return {
+    ...(await import("./runner.attachments.js")),
+    buildProviderRegistry: vi.fn(),
+    runCapability: vi.fn(),
+  };
+});
+
+vi.mock("./provider-registry.js", () => ({
+  buildMediaUnderstandingRegistry: vi.fn(),
+  getMediaUnderstandingProvider: vi.fn(),
+  normalizeMediaProviderId: vi.fn(),
+}));
+vi.mock("./image-runtime.js", () => ({ describeImageWithModel: vi.fn() }));
+
+describe("local image preparation", () => {
+  it("rejects oversized local images before provider preparation", async () => {
+    await withTestDir({ prefix: "openclaw-image-input-limit-" }, async (base) => {
+      const filePath = path.join(base, "oversized.png");
+      await fs.writeFile(filePath, Buffer.alloc(DEFAULT_MAX_BYTES.image + 1));
+      await expect(
+        prepareImageDescriptionInput({ filePath, cfg: {} }).then(() => "accepted"),
+      ).rejects.toMatchObject({
+        reason: "maxBytes",
+      });
+    });
+  });
+
+  it.skipIf(process.platform === "win32")("keeps rejecting local image symlinks", async () => {
+    await withTestDir({ prefix: "openclaw-image-input-roots-" }, async (base) => {
+      const allowed = path.join(base, "allowed");
+      const outside = path.join(base, "outside.png");
+      const filePath = path.join(allowed, "linked.png");
+      await fs.mkdir(allowed);
+      await fs.writeFile(outside, "outside");
+      await fs.symlink(outside, filePath);
+      await expect(prepareImageDescriptionInput({ filePath, cfg: {} })).rejects.toThrow();
+    });
+  });
+
+  it("accepts an explicitly supplied local image and classifies its bytes", async () => {
+    await withTestDir({ prefix: "openclaw-image-input-local-" }, async (base) => {
+      const buffer = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=",
+        "base64",
+      );
+      const filePath = path.join(base, "photo.jpg");
+      await fs.writeFile(filePath, buffer);
+      await expect(
+        prepareImageDescriptionInput({ filePath, mime: "application/pdf", cfg: {} }),
+      ).resolves.toEqual({ buffer, fileName: "photo.jpg", mime: "image/png" });
+    });
+  });
+});

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -30,7 +30,6 @@ const mocks = vi.hoisted(() => {
     normalizeMediaProviderId: vi.fn((provider: string) => provider.trim().toLowerCase()),
     buildMediaUnderstandingRegistry: vi.fn(() => new Map()),
     getMediaUnderstandingProvider: vi.fn(),
-    readLocalFileSafely: vi.fn(async () => ({ buffer: Buffer.from("image") })),
     describeImageWithModel: vi.fn(async () => ({ text: "generic image ok", model: "vision" })),
     convertHeicToJpeg: vi.fn(async () => Buffer.from("jpeg-normalized")),
     runCapability: vi.fn(),
@@ -55,10 +54,6 @@ vi.mock("./provider-registry.js", () => ({
   normalizeMediaProviderId: mocks.normalizeMediaProviderId,
   buildMediaUnderstandingRegistry: mocks.buildMediaUnderstandingRegistry,
   getMediaUnderstandingProvider: mocks.getMediaUnderstandingProvider,
-}));
-
-vi.mock("../infra/fs-safe.js", () => ({
-  readLocalFileSafely: mocks.readLocalFileSafely,
 }));
 
 vi.mock("./image-runtime.js", () => ({
@@ -91,8 +86,6 @@ describe("media-understanding runtime", () => {
     mocks.normalizeMediaProviderId.mockReset();
     mocks.buildMediaUnderstandingRegistry.mockReset();
     mocks.getMediaUnderstandingProvider.mockReset();
-    mocks.readLocalFileSafely.mockReset();
-    mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("image") });
     mocks.describeImageWithModel.mockReset();
     mocks.describeImageWithModel.mockResolvedValue({ text: "generic image ok", model: "vision" });
     mocks.convertHeicToJpeg.mockReset();
@@ -523,6 +516,12 @@ describe("media-understanding runtime", () => {
   });
 
   it("uses the generic model-backed image runtime for explicit models without media hooks", async () => {
+    mocks.getBuffer.mockResolvedValue({
+      buffer: Buffer.from("image"),
+      fileName: "sample.jpg",
+      mime: "image/jpeg",
+      size: 5,
+    });
     mocks.buildProviderRegistry.mockReturnValue(
       new Map([["zai", { id: "zai", capabilities: ["image"] }]]),
     );
@@ -553,28 +552,6 @@ describe("media-understanding runtime", () => {
     });
   });
 
-  it("prefers local image bytes over conflicting explicit MIME metadata", async () => {
-    mocks.readLocalFileSafely.mockResolvedValue({ buffer: PNG_1X1 });
-
-    await describeImageFileWithModel({
-      filePath: "/tmp/sample.jpg",
-      mime: "application/pdf",
-      provider: "zai",
-      model: "glm-4.6v",
-      prompt: "Describe it",
-      cfg: {} as OpenClawConfig,
-      agentDir: "/tmp/agent",
-    });
-
-    expect(mocks.describeImageWithModel).toHaveBeenCalledWith(
-      expect.objectContaining({
-        buffer: PNG_1X1,
-        fileName: "sample.jpg",
-        mime: "image/png",
-      }),
-    );
-  });
-
   it.each([
     {
       name: "HEIC",
@@ -594,7 +571,12 @@ describe("media-understanding runtime", () => {
   ])(
     "normalizes local $name explicit image descriptions before provider execution",
     async (testCase) => {
-      mocks.readLocalFileSafely.mockResolvedValue({ buffer: testCase.bytes });
+      mocks.getBuffer.mockResolvedValue({
+        buffer: testCase.bytes,
+        fileName: "sample.bin",
+        mime: testCase.mime,
+        size: testCase.bytes.length,
+      });
 
       await describeImageFileWithModel({
         filePath: "/tmp/sample.bin",
@@ -693,13 +675,12 @@ describe("media-understanding runtime", () => {
       }),
     ).resolves.toEqual({ text: "generic image ok", model: "vision" });
 
-    expect(mocks.readLocalFileSafely).not.toHaveBeenCalled();
     expect(mocks.normalizeMediaAttachments).toHaveBeenCalledWith({
       media: [{ url: "https://httpbin.org/image/png", contentType: "image/*" }],
     });
     expect(mocks.createMediaAttachmentCache).toHaveBeenCalledWith(
       [{ index: 0, url: "https://httpbin.org/image/png", mime: "image/png" }],
-      { ssrfPolicy: undefined },
+      { localPathRoots: undefined, ssrfPolicy: undefined },
     );
     expect(mocks.getBuffer).toHaveBeenCalledWith({
       attachmentIndex: 0,
@@ -750,7 +731,12 @@ describe("media-understanding runtime", () => {
     mocks.buildProviderRegistry.mockReturnValue(
       new Map([["gemini", { id: "gemini", capabilities: ["image"], describeImage }]]),
     );
-    mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("image-bytes") });
+    mocks.getBuffer.mockResolvedValue({
+      buffer: Buffer.from("image-bytes"),
+      fileName: "sample.jpg",
+      mime: "image/jpeg",
+      size: 11,
+    });
 
     await expect(
       describeImageFileWithModel({
@@ -796,7 +782,12 @@ describe("media-understanding runtime", () => {
   });
 
   it("resolves the agent directory when direct image description only names an agent", async () => {
-    mocks.readLocalFileSafely.mockResolvedValue({ buffer: Buffer.from("image-bytes") });
+    mocks.getBuffer.mockResolvedValue({
+      buffer: Buffer.from("image-bytes"),
+      fileName: "sample.jpg",
+      mime: "image/jpeg",
+      size: 11,
+    });
 
     await describeImageFileWithModel({
       filePath: "/tmp/sample.jpg",

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -1,11 +1,10 @@
 // Public file-oriented media-understanding runtime for image, audio, video, and
 // structured extraction calls outside normal channel message handling.
 import path from "node:path";
-import { detectMime, kindFromMime, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
+import { kindFromMime, mimeTypeFromFilePath } from "@openclaw/media-core/mime";
 import { hasHttpUrlPrefix } from "@openclaw/net-policy/url-protocol";
 import { resolveAgentDir, resolveDefaultAgentDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { readLocalFileSafely } from "../infra/fs-safe.js";
 import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
 import { normalizeImageDescriptionInput } from "./image-input-normalize.js";
 import { describeImageWithModel } from "./image-runtime.js";
@@ -331,25 +330,11 @@ async function readImageDescriptionInput(params: {
   cfg: OpenClawConfig;
   timeoutMs: number;
 }): Promise<{ buffer: Buffer; fileName: string; mime?: string }> {
-  const remoteRef =
-    params.mediaUrl ??
-    (isRemoteMediaReference(params.filePath) ? params.filePath.trim() : undefined);
-  if (!remoteRef) {
-    const { buffer } = await readLocalFileSafely({ filePath: params.filePath });
-    return {
-      buffer,
-      fileName: basenameFromMediaReference(params.filePath),
-      mime: await detectMime({
-        buffer,
-        filePath: params.filePath,
-        headerMime: concreteMime(params.mime),
-      }),
-    };
-  }
   const attachments = normalizeMediaAttachments(
     buildFileContext({ ...params, capability: "image" }),
   );
   const cache = createMediaAttachmentCache(attachments, {
+    localPathRoots: params.mediaUrl ? undefined : resolveFileLocalRoots(params.filePath),
     ssrfPolicy: params.cfg.tools?.web?.fetch?.ssrfPolicy,
   });
   try {
@@ -360,7 +345,7 @@ async function readImageDescriptionInput(params: {
     });
     return {
       buffer: media.buffer,
-      fileName: media.fileName || basenameFromMediaReference(remoteRef),
+      fileName: media.fileName || basenameFromMediaReference(params.mediaUrl ?? params.filePath),
       // The attachment cache has already resolved MIME from bytes, filename, and headers.
       // Keep the caller hint only as a fallback for cache implementations with no MIME result.
       mime: media.mime ?? concreteMime(params.mime),


### PR DESCRIPTION
## What Problem This Solves

Four violations of one invariant — local media file reads must respect the caller's byte limit, exactly as the remote branch already does — plus a cache lifecycle leak, all in `src/media-understanding`:

1. **Unbounded explicit-image local input**: `runtime.ts` read local files through `readLocalFileSafely` with no `maxBytes` (installed `@openclaw/fs-safe` confirms omitted limits do a whole-file `readFile`), while the remote path used the cache with `DEFAULT_MAX_BYTES.image`. History (`538605ff44d`) shows a helper substitution, not an unlimited-input contract.
2. **TOCTOU allocation before rejection**: `attachments.cache.ts` local reads checked the opened stat, then did a full `handle.readFile()`, then checked length — a growing file was fully loaded before rejection (measured: 4,164 bytes consumed with `maxBytes` 68).
3. **Wrong-direction default**: `getPath` made `maxBytes` optional, defaulting to `Infinity`, and truthiness checks ignored a zero limit. The only production caller already supplies the resolved limit.
4. **Stale path after cleanup**: `cleanup()` cleared cleanup responsibility but left `tempPath`, so a post-cleanup `getPath` returned a deleted file's path.

## Why This Change Was Made

The attachment cache is the canonical local byte-read owner, so the fix consolidates rather than guards: the explicit-image local branch and its separate MIME read path in `runtime.ts` are deleted and routed through the same cache policy as the remote API (the explicit-file selected-directory allowance is preserved via `localPathRoots`; history `9f2b760d336`/`5d1f7bf0589` confirms that policy is intentional). Cache local reads keep opened-handle + canonical-root checks and now use the existing `readFileHandleBounded` helper (consumes at most `maxBytes + 1` bytes). `getPath.maxBytes` is required and zero-enforced. The cleanup callback invalidates its own `tempPath` only (guarded so retained callbacks cannot invalidate a later restaged file, preserving the failed-staging retry chain from `fd3a919063b`).

## User Impact

An oversized or concurrently-growing local attachment can no longer be fully loaded into memory before rejection, the local and remote image-description APIs now enforce the same byte limit, and a cleaned-up attachment can no longer hand a deleted temp path to a provider CLI.

## Evidence

- Regressions fail pre-fix (production files replayed at exact base): **6 failed** — growth read 4,164 bytes with limit 68; zero limits accepted nonempty paths; both cleanup routes returned deleted paths; oversized local image accepted. Post-fix focused run: **40 passed**.
- Full suite `src/media-understanding`: **527 passed, 5 platform skips**, re-run green on rebased head 4bd4cd8c303. An obsolete readFile-only mock test ("enforces maxBytes after reading local attachments", history `566fb73d9da`) was replaced by a real-file growth test measuring actual bytes consumed at the filesystem boundary.
- Production LOC **−21** (+14/−35); tests +131. Remote fetch limits, retry policy, SSRF behavior, provider selection, SDK exports/types, and persistence unchanged; sibling bounded-read call sites (`apply.ts`, `agent-turn-attachments.ts`, provider entries) verified already compliant.
- Targeted test typecheck (includes the required `getPath.maxBytes` type assertion), oxlint, oxfmt, `git diff --check`, and the eight post-typecheck repo guards (schema-version, database-first, media-download helper, sidecar loaders, import cycles, webhook body order, pairing guards) all pass. `check-changed`'s aggregate lane stops at a pre-existing UI e2e type error on main (`ui/src/e2e/sidebar-interactions.e2e.test.ts:45`, TS2339 from `9b4d4d08cf7`, reproduced at exact base with media files unchanged) — separate follow-up.
- Fresh Codex autoreview of the final diff: clean, no actionable findings.
- Named follow-ups (deliberately out of scope): transcript-output whole-file read in `runner.entries.ts` (output-resource policy, review-required); `getPath` does not claim to freeze externally mutable files for the consuming CLI (existing contract preserved).
