### PR TITLE
fix(ui): restore sidebar cue test typecheck

### DIFF
--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -31,7 +31,7 @@ suite.define(() => {
     let cueStyle = { background: "", boxShadow: "", duration: "", name: "" };
     await expect
       .poll(async () => {
-        const state = await textarea.evaluate((element) => {
+        const state = await textarea.evaluate((element: HTMLTextAreaElement) => {
           const inputElement = element.closest<HTMLElement>(".agent-chat__input");
           const style = inputElement ? getComputedStyle(inputElement) : null;
           return {


### PR DESCRIPTION
Related: #128677, #130881

## What Problem This Solves

Resolves a problem where the UI test typecheck fails after the composer prefill-cue tests were changed to observe focus, value, and attention styling together. This main-branch failure also blocks unrelated browser automation work in #130881.

## Why This Change Was Made

The selector targets the rendered textarea, but Playwright's evaluator defaults its element type to `HTMLElement | SVGElement`. Giving the callback its actual `HTMLTextAreaElement` parameter type makes `.value` type-safe while retaining the single atomic browser observation. This follows the typed evaluator pattern already used for the avatar image in the same test file.

The change does not add a cast, suppression, fallback, timeout, or runtime guard. Splitting the value read into another browser call would weaken the timing-sensitive cue test and is unnecessary. Production LOC: +0/-0. Tests: +1/-1.

## User Impact

No runtime or visual behavior changes. This restores the developer/CI typecheck without removing any sidebar assertions. The existing normal-motion and reduced-motion flows remain covered. Test-only repair; no changelog entry.

## Evidence

- Published head: `69f391d8d619767f38de0a69b66000d411019678`.
- Provenance: commit `9b4d4d08cf72ded1397bdef98a15ef90889eef91` from #128677 introduced the untyped value read. The browser PR does not change this file. [The failed CI job](https://github.com/openclaw/openclaw/actions/runs/33065975611/job/98496310084) reports TS2339 at `ui/src/e2e/sidebar-interactions.e2e.test.ts:45`.
- Reproduced the same TS2339 on fresh main `3ee363fc084b2d63b695129345238e2afac21dec` before editing. The identical canonical owning test-type shard passed after the one-line repair: `node scripts/run-tsgo.mjs -b test/tsconfig/tsconfig.core.test.ui-pages-e2e.json --builders 1`.
- The existing full sidebar E2E file passed all 6 tests in 13.64 seconds using Google Chrome for Testing 151.0.7922.34, isolated browser contexts, the temporary bundled UI, and a mocked Gateway WebSocket: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-interactions.e2e.test.ts --maxWorkers 1`. This is real Chromium UI proof, not an external Gateway/provider/channel test. Both cue helper callers passed; browser/server cleanup completed.
- Focused formatting, type-aware lint, and `git diff --check` passed. Broader exact-head CI is pending; the local UI test shard is not represented as the full repository typecheck.
- Direct inspection of Playwright 1.62.1's generic evaluator contract and the actual textarea renderer supports the callback type. An independent test review, P2 autoreview, and a separate standalone Codex P0–P3 review found no actionable issues.

No new dependencies, configuration, production code, or unrelated issue closures.
