### PR TITLE
test(ui): type the composer textarea in the sidebar prefill e2e evaluate

### DIFF
--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -31,7 +31,7 @@ suite.define(() => {
     let cueStyle = { background: "", boxShadow: "", duration: "", name: "" };
     await expect
       .poll(async () => {
-        const state = await textarea.evaluate((element) => {
+        const state = await textarea.evaluate((element: HTMLTextAreaElement) => {
           const inputElement = element.closest<HTMLElement>(".agent-chat__input");
           const style = inputElement ? getComputedStyle(inputElement) : null;
           return {


### PR DESCRIPTION
## What Problem This Solves

`ui/src/e2e/sidebar-interactions.e2e.test.ts:45` reads `element.value` inside a `textarea.evaluate` whose callback element is typed `HTMLElement`, so the `test/tsconfig/tsconfig.core.test.ui-pages-e2e.json` typecheck lane fails with TS2339 (`Property 'value' does not exist on type 'HTMLElement'`). Introduced by 9b4d4d08cf7. Any developer or agent whose `pnpm check:changed` classification reaches this lane hits a red gate on untouched code — two independent workers tripped over it today with pure `src/` changes.

## Why This Change Was Made

Static-analysis fix that strengthens the owning type contract: the locator targets `.agent-chat__composer-combobox > textarea`, so the evaluate callback is annotated `HTMLTextAreaElement` — the real element type — rather than casting or probing.

## User Impact

None at runtime (test-only typing). Restores a green `check-changed` typecheck lane for everyone.

## Evidence

- Pre-fix at origin/main c7672984653: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.ui-pages-e2e.json` fails with the TS2339 above.
- Post-fix: same command exits 0; `oxfmt --check` clean; one-line diff (+1/−1, test-only).
