### PR TITLE
Android: refresh branding on config.changed

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -173,6 +173,10 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
+// Broadcast by the gateway after every persisted config write. It is not part of the
+// generated GatewayEvent catalog, so the raw wire name is matched directly.
+internal const val CONFIG_CHANGED_EVENT = "config.changed"
+
 private const val MAX_PENDING_NOTIFICATION_EVENTS = 128
 private const val NODE_APPROVAL_COMMAND_FRESH_MS = 30_000L
 private const val CRON_RUN_TRACKING_POLL_MS = 2_000L
@@ -5181,6 +5185,12 @@ class NodeRuntime private constructor(
     }
     if (event == GatewayEvent.VoicewakeChanged.rawValue) {
       applyVoiceWakeWords(payloadJson)
+    }
+    if (event == CONFIG_CHANGED_EVENT) {
+      // Hash-only notice broadcast after every persisted config write; the protocol
+      // directs clients to re-read through config.get, which the branding refresh does.
+      // Not in the generated GatewayEvent catalog, so match the raw wire name.
+      scope.launch { refreshBrandingFromGateway() }
     }
     if (event == GatewayEvent.UsersPrefsChanged.rawValue) {
       // The gateway targets this event at connections bound to the caller's own


### PR DESCRIPTION
## What Problem This Solves

Closes #128926.

The gateway broadcasts a hash-only `config.changed` notice after every persisted config write, and the documented client contract is that connected clients re-read their snapshot when it arrives. iOS implements exactly that; **Android has no `config.changed` handling anywhere**.

Verified independently against current `main`:

- `grep -c 'config.changed' apps/android/**` → **0 occurrences**, versus iOS's explicit handler in `NodeAppModel.swift` that calls `refreshBrandingFromGateway`.
- `NodeRuntime.refreshBrandingFromGateway()` runs once per connect, and `_gatewayAccentArgb` is only nulled and refetched around reconnects.
- The event is genuinely broadcast: `src/gateway/server-broadcast.ts` lists `"config.changed": [READ_SCOPE]` immediately above `"users.prefs.changed"`, which Android *does* already handle.

So changing the accent in Control UI while a phone is connected leaves the phone on the old accent until it disconnects and reconnects, diverging from iOS and from the documented contract.

## What Changed

`handleGatewayEvent` now refreshes branding on `config.changed`, directly mirroring the iOS handler and sitting next to the existing `users.prefs.changed` branch that already calls the same refresh.

`config.changed` is **not** in the generated `GatewayEvent` enum — `GatewayProtocol.kt` is emitted by `scripts/protocol-gen-kotlin.ts` from the gateway event catalog and carries a "do not edit by hand" header, and this event is not part of that catalog. Rather than hand-edit generated output or regenerate protocol files for every platform inside a focused bug fix, the raw wire name is matched via a named constant — the same approach this function already uses for `update.available` and `chat`, and the same approach iOS uses (`case "config.changed":`).

## What Did NOT Change (scope boundary)

- No generated protocol file is touched, and the gateway event catalog is not modified.
- `refreshBrandingFromGateway()` itself is unchanged — it already guards and applies the accent, so `config.changed` simply reuses the existing path.
- No other config-derived state is wired up; this restores the documented refresh contract for the snapshot Android already reads.

## Evidence

Built from upstream `main` at `a4ef5726`.

```
> Task :app:ktlintMainSourceSetCheck
BUILD SUCCESSFUL in 1m 10s

> Task :app:compilePlayDebugKotlin
BUILD SUCCESSFUL in 1m 46s
```

Not verified, stated plainly: **there is no unit test.** `handleGatewayEvent` is private on a ~9,000-line class whose constructor pulls in the full app graph, and there is no existing seam that drives gateway events into `NodeRuntime` from unit tests — the sibling `users.prefs.changed` branch this change sits beside has no unit test either. I also have no paired Android device or emulator here, so the end-to-end "change accent in Control UI, watch the phone update" flow is unverified. What is verified is that the handler is wired to the same refresh iOS uses, that the event is really broadcast by the gateway, and that the code compiles and lints clean.

If a maintainer would prefer this event registered in the generated catalog instead (so it becomes `GatewayEvent.ConfigChanged` across all platforms), say so and I'll redo it that way — it's a larger, cross-platform change, which is why I didn't reach for it here.

AI-assisted: yes (Claude). Verified locally (compile + ktlint). I understand what the code does.
