### PR TITLE
fix(imessage): replay approval reactions after transient Gateway failures

### DIFF
--- a/extensions/imessage/src/approval-reaction-poller.test.ts
+++ b/extensions/imessage/src/approval-reaction-poller.test.ts
@@ -4,6 +4,7 @@ import { pollPendingIMessageApprovalReactions } from "./approval-reaction-poller
 import {
   clearIMessageApprovalReactionTargetsForTest,
   registerIMessageApprovalReactionTarget as registerIMessageApprovalReactionTargetRaw,
+  resolveIMessageApprovalReactionTargetWithPersistence,
 } from "./approval-reactions.js";
 import type { IMessageRpcClient } from "./client.js";
 
@@ -326,7 +327,7 @@ describe("iMessage approval reaction poller", () => {
     expect(logVerboseMessage.mock.calls.flat().join(" ")).not.toContain("decision=allow-once");
   });
 
-  it("stops scanning after an authorized resolver failure", async () => {
+  it("propagates an authorized resolver failure and retries it on the next poll", async () => {
     resolverMocks.resolveApprovalOverGateway.mockRejectedValueOnce(new Error("gateway down"));
     registerIMessageApprovalReactionTarget({
       accountId,
@@ -361,11 +362,12 @@ describe("iMessage approval reaction poller", () => {
         ],
       }),
     ]);
+    const pollParams = buildPollParams(request, { cfg: buildApprovalConfig(APPROVER) });
 
-    await pollPendingIMessageApprovalReactions(
-      buildPollParams(request, { cfg: buildApprovalConfig(APPROVER) }),
-    );
-
+    // The transient failure aborts the cycle before the later 👎 is resolved:
+    // first-answer ordering must survive the retry, and the caller
+    // (monitor-provider) logs the throw and re-polls on the next interval.
+    await expect(pollPendingIMessageApprovalReactions(pollParams)).rejects.toThrow("gateway down");
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(1);
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith({
       accountId,
@@ -377,5 +379,30 @@ describe("iMessage approval reaction poller", () => {
       senderId: "+15551230000",
       gatewayUrl: undefined,
     });
+    // The binding stays registered for the next interval's retry.
+    await expect(
+      resolveIMessageApprovalReactionTargetWithPersistence({
+        accountId,
+        conversation: { chatId: 42, chatGuid: "iMessage;+;chat-guid" },
+        messageId: "msg-1",
+        reactionKey: "👍",
+      }),
+    ).resolves.toBeTruthy();
+
+    // Next interval: the retried 👍 resolves first; the later 👎 then finds no
+    // binding and never reaches the resolver.
+    await pollPendingIMessageApprovalReactions(pollParams);
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(2);
+    expect(resolverMocks.resolveApprovalOverGateway.mock.calls[1]?.[0]).toEqual(
+      resolverMocks.resolveApprovalOverGateway.mock.calls[0]?.[0],
+    );
+    await expect(
+      resolveIMessageApprovalReactionTargetWithPersistence({
+        accountId,
+        conversation: { chatId: 42, chatGuid: "iMessage;+;chat-guid" },
+        messageId: "msg-1",
+        reactionKey: "👍",
+      }),
+    ).resolves.toBeNull();
   });
 });

--- a/extensions/imessage/src/approval-reactions.test.ts
+++ b/extensions/imessage/src/approval-reactions.test.ts
@@ -1077,49 +1077,6 @@ describe("iMessage approval reactions", () => {
     ).resolves.toBeNull();
   });
 
-  it("propagates transient Gateway errors for durable ingress retry", async () => {
-    registerIMessageApprovalReactionTarget({
-      accountId: "default",
-      conversation: { handle: "+15551230000" },
-      messageId: "pending-approval",
-      approvalId: "exec-pending",
-      allowedDecisions: ["allow-once", "deny"],
-    });
-    const gatewayError = new Error("Gateway 503 Service Unavailable");
-    resolverMocks.resolveApprovalOverGateway.mockRejectedValueOnce(gatewayError);
-    resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
-
-    // Transient errors must throw so the durable ingress drain releases the
-    // claim and replays the reaction; committing or dropping it here would
-    // lose the operator's click.
-    await expect(
-      maybeResolveIMessageApprovalReaction({
-        cfg: {
-          channels: { imessage: { allowFrom: ["+15551230000"] } },
-        },
-        accountId: "default",
-        message: buildTapbackReactionPayload({
-          sender: "+15551230000",
-          reaction_emoji: "👍",
-          reacted_to_guid: "pending-approval",
-        }),
-        bodyText: "",
-      }),
-    ).rejects.toBe(gatewayError);
-    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
-      expect.objectContaining({ approvalId: "exec-pending" }),
-    );
-    // The binding should NOT be cleared yet (not-found is the terminal case).
-    await expect(
-      resolveIMessageApprovalReactionTargetWithPersistence({
-        accountId: "default",
-        conversation: { handle: "+15551230000" },
-        messageId: "pending-approval",
-        reactionKey: "👍",
-      }),
-    ).resolves.toBeTruthy();
-  });
-
   it("clears a losing surface and reports the canonical first-answer outcome", async () => {
     registerIMessageApprovalReactionTarget({
       accountId: "default",

--- a/extensions/imessage/src/approval-reactions.test.ts
+++ b/extensions/imessage/src/approval-reactions.test.ts
@@ -1077,6 +1077,49 @@ describe("iMessage approval reactions", () => {
     ).resolves.toBeNull();
   });
 
+  it("keeps the durable claim alive on transient Gateway errors", async () => {
+    registerIMessageApprovalReactionTarget({
+      accountId: "default",
+      conversation: { handle: "+15551230000" },
+      messageId: "pending-approval",
+      approvalId: "exec-pending",
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    const gatewayError = new Error("Gateway 503 Service Unavailable");
+    resolverMocks.resolveApprovalOverGateway.mockRejectedValueOnce(gatewayError);
+    resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
+
+    const handled = await maybeResolveIMessageApprovalReaction({
+      cfg: {
+        channels: { imessage: { allowFrom: ["+15551230000"] } },
+      },
+      accountId: "default",
+      message: buildTapbackReactionPayload({
+        sender: "+15551230000",
+        reaction_emoji: "👍",
+        reacted_to_guid: "pending-approval",
+      }),
+      bodyText: "",
+    });
+
+    // Transient errors should return handled:false so the durable ingress
+    // while(true) loop retries via iMessageApprovalControlBindings.wait(),
+    // rather than committing the claim and losing the operator's click.
+    expect(handled).toBe(false);
+    expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
+      expect.objectContaining({ approvalId: "exec-pending" }),
+    );
+    // The binding should NOT be cleared yet (not-found is the terminal case).
+    await expect(
+      resolveIMessageApprovalReactionTargetWithPersistence({
+        accountId: "default",
+        conversation: { handle: "+15551230000" },
+        messageId: "pending-approval",
+        reactionKey: "👍",
+      }),
+    ).resolves.toBeTruthy();
+  });
+
   it("clears a losing surface and reports the canonical first-answer outcome", async () => {
     registerIMessageApprovalReactionTarget({
       accountId: "default",

--- a/extensions/imessage/src/approval-reactions.test.ts
+++ b/extensions/imessage/src/approval-reactions.test.ts
@@ -1077,7 +1077,7 @@ describe("iMessage approval reactions", () => {
     ).resolves.toBeNull();
   });
 
-  it("keeps the durable claim alive on transient Gateway errors", async () => {
+  it("propagates transient Gateway errors for durable ingress retry", async () => {
     registerIMessageApprovalReactionTarget({
       accountId: "default",
       conversation: { handle: "+15551230000" },
@@ -1089,23 +1089,23 @@ describe("iMessage approval reactions", () => {
     resolverMocks.resolveApprovalOverGateway.mockRejectedValueOnce(gatewayError);
     resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
 
-    const handled = await maybeResolveIMessageApprovalReaction({
-      cfg: {
-        channels: { imessage: { allowFrom: ["+15551230000"] } },
-      },
-      accountId: "default",
-      message: buildTapbackReactionPayload({
-        sender: "+15551230000",
-        reaction_emoji: "👍",
-        reacted_to_guid: "pending-approval",
+    // Transient errors must throw so the durable ingress drain releases the
+    // claim and replays the reaction; committing or dropping it here would
+    // lose the operator's click.
+    await expect(
+      maybeResolveIMessageApprovalReaction({
+        cfg: {
+          channels: { imessage: { allowFrom: ["+15551230000"] } },
+        },
+        accountId: "default",
+        message: buildTapbackReactionPayload({
+          sender: "+15551230000",
+          reaction_emoji: "👍",
+          reacted_to_guid: "pending-approval",
+        }),
+        bodyText: "",
       }),
-      bodyText: "",
-    });
-
-    // Transient errors should return handled:false so the durable ingress
-    // while(true) loop retries via iMessageApprovalControlBindings.wait(),
-    // rather than committing the claim and losing the operator's click.
-    expect(handled).toBe(false);
+    ).rejects.toBe(gatewayError);
     expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledWith(
       expect.objectContaining({ approvalId: "exec-pending" }),
     );

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -57,7 +57,7 @@ type IMessageApprovalReactionHandleResult =
   | {
       handled: true;
       stopPolling: true;
-      stopPollingReason: "resolved" | "not-found" | "resolver-error";
+      stopPollingReason: "resolved" | "not-found";
     };
 
 type IMessageApprovalReactionTarget = ApprovalReactionTargetRecord & {
@@ -593,14 +593,11 @@ export async function handleIMessageApprovalReaction(params: {
     params.logVerboseMessage?.(
       `imessage: approval reaction failed id=${target.approvalId} sender=${event.actorHandle}: ${String(error)}`,
     );
-    // A transient Gateway 5xx/network/auth error must not silently drop the
-    // operator's approval click. Unlike the NotFound case (which is terminal
-    // and stops polling), transient errors should keep the durable ingress
-    // claim alive so the while(true) loop in monitor-provider.ts:1398-1417
-    // retries via iMessageApprovalControlBindings.wait(). This is the same
-    // fix pattern as matrix (#129879) and signal (#130134): throw or return
-    // handled:false to avoid committing the durable claim prematurely.
-    return { handled: false };
+    // A transient Gateway 5xx/network/auth error is not terminal: propagate it
+    // so the durable ingress drain releases the claim and replays the reaction
+    // under its retry policy, as the signal (#130134) and matrix (#129879)
+    // owners do. Returning any result here would commit or drop the claim.
+    throw error;
   }
 }
 

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -593,10 +593,8 @@ export async function handleIMessageApprovalReaction(params: {
     params.logVerboseMessage?.(
       `imessage: approval reaction failed id=${target.approvalId} sender=${event.actorHandle}: ${String(error)}`,
     );
-    // A transient Gateway 5xx/network/auth error is not terminal: propagate it
-    // so the durable ingress drain releases the claim and replays the reaction
-    // under its retry policy, as the signal (#130134) and matrix (#129879)
-    // owners do. Returning any result here would commit or drop the claim.
+    // Non-terminal resolver errors must reach the durable ingress drain.
+    // Returning here would commit the claim and lose the operator's reaction.
     throw error;
   }
 }

--- a/extensions/imessage/src/approval-reactions.ts
+++ b/extensions/imessage/src/approval-reactions.ts
@@ -593,7 +593,14 @@ export async function handleIMessageApprovalReaction(params: {
     params.logVerboseMessage?.(
       `imessage: approval reaction failed id=${target.approvalId} sender=${event.actorHandle}: ${String(error)}`,
     );
-    return { handled: true, stopPolling: true, stopPollingReason: "resolver-error" };
+    // A transient Gateway 5xx/network/auth error must not silently drop the
+    // operator's approval click. Unlike the NotFound case (which is terminal
+    // and stops polling), transient errors should keep the durable ingress
+    // claim alive so the while(true) loop in monitor-provider.ts:1398-1417
+    // retries via iMessageApprovalControlBindings.wait(). This is the same
+    // fix pattern as matrix (#129879) and signal (#130134): throw or return
+    // handled:false to avoid committing the durable claim prematurely.
+    return { handled: false };
   }
 }
 

--- a/extensions/imessage/src/monitor.approval-reaction-replay.test.ts
+++ b/extensions/imessage/src/monitor.approval-reaction-replay.test.ts
@@ -4,13 +4,11 @@
 // Everything here is real (SQLite queue, monitor, drain, approval-reaction
 // resolution) except the one true external boundary: the Gateway
 // approval-resolution call.
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import {
   closeOpenClawStateDatabaseForTest,
   createChannelIngressQueueForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearIMessageApprovalReactionTargetsForTest,
@@ -58,10 +56,10 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
   vi.restoreAllMocks();
 });
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 async function withQueue<T>(fn: (queue: IMessageIngressQueue) => Promise<T>): Promise<T> {
-  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-imessage-ingress-replay-"));
-  const stateDir = await fs.realpath(created);
+  const stateDir = tempDirs.make("openclaw-imessage-ingress-replay-");
   const queue = createChannelIngressQueueForTests<IMessageIngressPayload>({
     channelId: "imessage",
     accountId: "default",
@@ -71,7 +69,6 @@ async function withQueue<T>(fn: (queue: IMessageIngressQueue) => Promise<T>): Pr
     return await fn(queue);
   } finally {
     closeOpenClawStateDatabaseForTest();
-    await fs.rm(stateDir, { recursive: true, force: true });
   }
 }
 

--- a/extensions/imessage/src/monitor.approval-reaction-replay.test.ts
+++ b/extensions/imessage/src/monitor.approval-reaction-replay.test.ts
@@ -1,0 +1,201 @@
+// IMessage durable-ingress replay proof: a transient Gateway failure during
+// approval-reaction resolution must release the real SQLite claim so the real
+// drain redelivers the operator's reaction once the Gateway recovers.
+// Everything here is real (SQLite queue, monitor, drain, approval-reaction
+// resolution) except the one true external boundary: the Gateway
+// approval-resolution call.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  closeOpenClawStateDatabaseForTest,
+  createChannelIngressQueueForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearIMessageApprovalReactionTargetsForTest,
+  maybeResolveIMessageApprovalReaction,
+  registerIMessageApprovalReactionTarget,
+} from "./approval-reactions.js";
+import { createIMessageDurableIngress } from "./monitor/ingress.js";
+import type { IMessagePayload } from "./monitor/types.js";
+import { installIMessageStateRuntimeForTest } from "./test-support/runtime.js";
+
+const resolverMocks = vi.hoisted(() => ({
+  resolveApprovalOverGateway: vi.fn(),
+  isApprovalNotFoundError: vi.fn(() => false),
+}));
+
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway: resolverMocks.resolveApprovalOverGateway,
+}));
+vi.mock("openclaw/plugin-sdk/error-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/error-runtime")>(
+    "openclaw/plugin-sdk/error-runtime",
+  );
+  return {
+    ...actual,
+    isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
+  };
+});
+
+vi.useRealTimers();
+
+type IMessageIngressQueue = NonNullable<
+  Parameters<typeof createIMessageDurableIngress>[0]["queue"]
+>;
+type IMessageIngressPayload = Parameters<IMessageIngressQueue["enqueue"]>[1];
+
+beforeEach(() => {
+  clearIMessageApprovalReactionTargetsForTest();
+  installIMessageStateRuntimeForTest();
+  resolverMocks.resolveApprovalOverGateway.mockReset();
+  resolverMocks.isApprovalNotFoundError.mockReset();
+  resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
+});
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+});
+
+async function withQueue<T>(fn: (queue: IMessageIngressQueue) => Promise<T>): Promise<T> {
+  const created = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-imessage-ingress-replay-"));
+  const stateDir = await fs.realpath(created);
+  const queue = createChannelIngressQueueForTests<IMessageIngressPayload>({
+    channelId: "imessage",
+    accountId: "default",
+    stateDir,
+  });
+  try {
+    return await fn(queue);
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function buildReactionIngressRow(): { message: IMessagePayload } {
+  return {
+    message: {
+      id: 42,
+      guid: "guid-reaction-1",
+      chat_id: 7,
+      sender: "+15551230000",
+      is_reaction: true,
+      reaction_emoji: "👍",
+      reacted_to_guid: "pending-approval",
+    } as IMessagePayload,
+  };
+}
+
+describe("iMessage approval reaction durable replay", () => {
+  it(
+    "releases the claim and replays a reaction after a transient Gateway failure",
+    { timeout: 30_000 },
+    async () => {
+      await withQueue(async (queue) => {
+        // The iMessage drain reclaims a released row with no backoff window, so
+        // the released-pending state is not stably observable. Hold the
+        // redelivered attempt open instead: reaching it at all proves the drain
+        // released and reclaimed the claim rather than completing it.
+        let openSecondAttempt = () => {};
+        const secondAttemptGate = new Promise<void>((resolve) => {
+          openSecondAttempt = resolve;
+        });
+        resolverMocks.resolveApprovalOverGateway
+          .mockRejectedValueOnce(new Error("gateway 503"))
+          .mockImplementationOnce(async () => {
+            await secondAttemptGate;
+            return {
+              applied: true,
+              approval: { status: "allowed", decision: "allow-once", reason: "user" },
+            };
+          });
+        registerIMessageApprovalReactionTarget({
+          accountId: "default",
+          conversation: { chatId: 7, handle: "+15551230000" },
+          messageId: "pending-approval",
+          approvalId: "approval-abc-123",
+          approvalKind: "exec",
+          allowedDecisions: ["allow-once", "deny"],
+        });
+
+        const cfg = {
+          channels: { imessage: { allowFrom: ["+15551230000"] } },
+        } as Parameters<typeof maybeResolveIMessageApprovalReaction>[0]["cfg"];
+        const chatLaneDispatch = vi.fn(async () => ({ kind: "completed" as const }));
+        const monitor = createIMessageDurableIngress({
+          accountId: "default",
+          queue,
+          // Mirrors the monitor-provider ownership mapping for the reaction
+          // path: a handled reaction completes the claim, anything else falls
+          // through to the chat lane, and a thrown resolver error escapes into
+          // the real drain. The chat lane completes like production would, so
+          // a fall-through finishes the claim without any replay.
+          dispatchPriority: async (message) => {
+            const handled = await maybeResolveIMessageApprovalReaction({
+              cfg,
+              accountId: "default",
+              message,
+              bodyText: "",
+            });
+            return handled ? { kind: "completed" as const } : undefined;
+          },
+          dispatch: chatLaneDispatch,
+          runtime: { error: vi.fn(), log: vi.fn() },
+        });
+        monitor.start();
+        const reactionRow = buildReactionIngressRow();
+
+        try {
+          await monitor.receive(reactionRow);
+          // The first attempt throws into the real drain; the drain releases
+          // the claim and redelivers the same row. A completed or dropped
+          // claim could never produce this second call.
+          await vi.waitFor(
+            () => expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(2),
+            { timeout: 15_000 },
+          );
+
+          // The reaction must stay in the approval lane: falling through to
+          // the chat lane would complete the claim without any replay.
+          expect(chatLaneDispatch).not.toHaveBeenCalled();
+
+          // Redelivery carried the identical resolution request.
+          expect(resolverMocks.resolveApprovalOverGateway.mock.calls[1]?.[0]).toEqual(
+            resolverMocks.resolveApprovalOverGateway.mock.calls[0]?.[0],
+          );
+          expect(resolverMocks.resolveApprovalOverGateway.mock.calls[1]?.[0]).toEqual(
+            expect.objectContaining({
+              approvalId: "approval-abc-123",
+              approvalKind: "exec",
+              decision: "allow-once",
+              channel: "imessage",
+              accountId: "default",
+            }),
+          );
+
+          // The redelivered row stays claimed (not completed, not lost) while
+          // its delivery is still open.
+          expect(await queue.listClaims()).toHaveLength(1);
+
+          // Let the replayed attempt resolve the approval and complete the row.
+          openSecondAttempt();
+          await monitor.waitForIdle();
+          expect(await queue.listPending({ limit: "all" })).toHaveLength(0);
+          expect(await queue.listClaims()).toHaveLength(0);
+
+          // The completion tombstone is durable: the same reaction can never
+          // dispatch a third time.
+          await monitor.receive(reactionRow);
+          await monitor.waitForIdle();
+          expect(resolverMocks.resolveApprovalOverGateway).toHaveBeenCalledTimes(2);
+        } finally {
+          openSecondAttempt();
+          await monitor.stop();
+        }
+      });
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

An iMessage approval tapback was lost when the Gateway approval request failed temporarily. The channel returned a terminal handled result, so the durable ingress queue completed the reaction instead of replaying it.

Signal already uses the correct replay path on current `main`. This PR aligns iMessage with Signal and Matrix.

Fixes #131003.

## Why This Change Was Made

iMessage now throws every non-NotFound resolver error to the shared durable ingress drain. The drain records the failure, releases the claim, and replays the same reaction under its bounded retry policy.

NotFound remains terminal and clears the expired binding. The obsolete `resolver-error` result was removed. The poller now preserves the binding and retries on its next interval.

## User Impact

An approval reaction now survives a temporary Gateway failure. The operator does not need to tap the approval again after the Gateway recovers.

## Evidence

- Current `main` at `6b1eacad93819efeb324e056aa57a782d6280bd5`: the iMessage SQLite replay contract failed because the resolver ran once instead of twice.
- Exact head `0db5a1a146e99073acf506bff5312f37bf12daa5`: the Signal and iMessage SQLite replay contracts passed.
- The replay proof uses the real channel owner, SQLite queue, monitor, drain, retry, completion, and tombstone. Only the external Gateway approval call is fault-injected.
- The first request fails. The second request is identical and succeeds. A duplicate ingress event cannot cause a third approval execution.
- Focused channel tests: 61 passed. Final iMessage poller and durable replay tests: 8 passed.
- Formatting, focused Oxlint, import cycles, plugin boundaries, dependency guards, database-first guard, dead-code scan, assertion safety, max-lines, and test temporary-directory checks passed.
- Effective delta: production +4/-2, with one return replaced by one throw; tests +230/-5.

## Redacted iMessage-to-Gateway replay trace

The exact-head proof ran an isolated Gateway over authenticated WebSockets. The first Gateway call committed the approval, but the harness dropped its response. The durable iMessage drain released and reclaimed the reaction. The replay reached the Gateway, received the recorded terminal result, and completed the queue once.

```json
{
  "head": "0db5a1a146e99073acf506bff5312f37bf12daa5",
  "requestReplayEqual": true,
  "gatewayResults": [
    { "attempt": 1, "applied": true, "observedByChannel": false },
    { "attempt": 2, "applied": false, "terminalStatus": "allowed" }
  ],
  "queue": ["claimed", "released", "reclaimed", "completed", "duplicate-suppressed"],
  "approvalResolvedEvents": 1,
  "resolverCallsAfterDuplicate": 2,
  "result": "pass"
}
```
