### PR TITLE
fix(doctor): scan all configured agent session stores

### DIFF
--- a/src/commands/doctor-heartbeat-main-session-repair.ts
+++ b/src/commands/doctor-heartbeat-main-session-repair.ts
@@ -5,13 +5,11 @@ import { asNullableObjectRecord } from "@openclaw/normalization-core/record-coer
 import type { note } from "../../packages/terminal-core/src/note.js";
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
 import { formatSessionArchiveTimestamp } from "../config/sessions/artifacts.js";
-import { resolveMainSessionKey } from "../config/sessions/main-session.js";
 import {
   resolveSessionFilePathCore,
   type resolveSessionFilePathOptions,
 } from "../config/sessions/paths.js";
 import type { SessionEntry } from "../config/sessions/types.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { updateLegacySessionStore } from "../infra/state-migrations.legacy-session-store.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { clearTuiLastSessionPointers } from "../tui/tui-last-session.js";
@@ -278,7 +276,7 @@ if (process.env.VITEST || process.env.NODE_ENV === "test") {
  * prevents moving a newly-human main session.
  */
 export async function repairHeartbeatPoisonedMainSession(params: {
-  cfg: OpenClawConfig;
+  mainKey: string;
   mainEntry?: SessionEntry;
   isSessionKeyOccupied: (sessionKey: string) => boolean;
   absoluteStorePath: string;
@@ -288,7 +286,7 @@ export async function repairHeartbeatPoisonedMainSession(params: {
   warnings: string[];
   changes: string[];
 }): Promise<boolean> {
-  const mainKey = resolveMainSessionKey(params.cfg);
+  const mainKey = params.mainKey;
   const mainEntry = params.mainEntry;
   if (!mainEntry?.sessionId) {
     return false;

--- a/src/commands/doctor-heartbeat-main-session-repair.ts
+++ b/src/commands/doctor-heartbeat-main-session-repair.ts
@@ -9,6 +9,7 @@ import {
   resolveSessionFilePathCore,
   type resolveSessionFilePathOptions,
 } from "../config/sessions/paths.js";
+import { applySessionEntryLifecycleMutation } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { updateLegacySessionStore } from "../infra/state-migrations.legacy-session-store.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
@@ -28,6 +29,10 @@ type DoctorPrompterLike = {
   }) => Promise<boolean>;
   note?: typeof note;
 };
+
+type HeartbeatMainSessionStore =
+  | { kind: "legacy"; path: string }
+  | { kind: "sqlite"; agentId: string; path: string };
 
 type TranscriptHeartbeatSummary = {
   inspectedMessages: number;
@@ -279,7 +284,7 @@ export async function repairHeartbeatPoisonedMainSession(params: {
   mainKey: string;
   mainEntry?: SessionEntry;
   isSessionKeyOccupied: (sessionKey: string) => boolean;
-  absoluteStorePath: string;
+  store: HeartbeatMainSessionStore;
   stateDir: string;
   sessionPathOpts: ReturnType<typeof resolveSessionFilePathOptions>;
   prompter: DoctorPrompterLike;
@@ -299,6 +304,9 @@ export async function repairHeartbeatPoisonedMainSession(params: {
       params.sessionPathOpts,
     );
   } catch {
+    transcriptPath = undefined;
+  }
+  if (transcriptPath && !fs.existsSync(transcriptPath)) {
     transcriptPath = undefined;
   }
   const candidate = resolveHeartbeatMainSessionRepairCandidate({
@@ -342,19 +350,38 @@ export async function repairHeartbeatPoisonedMainSession(params: {
     return false;
   }
   let movedEntry: SessionEntry | undefined;
-  await updateLegacySessionStore(params.absoluteStorePath, (currentStore) => {
-    const currentEntry = currentStore[mainKey];
-    const currentCandidate = resolveHeartbeatMainSessionRepairCandidate({
-      entry: currentEntry,
-      transcriptPath,
+  if (params.store.kind === "sqlite") {
+    const result = await applySessionEntryLifecycleMutation({
+      agentId: params.store.agentId,
+      removals: [
+        {
+          archiveRemovedTranscript: false,
+          expectedEntry: mainEntry,
+          sessionKey: mainKey,
+        },
+      ],
+      skipMaintenance: true,
+      storePath: params.store.path,
+      upserts: [{ entry: mainEntry, sessionKey: recoveredKey }],
     });
-    if (!currentCandidate || "declineReason" in currentCandidate) {
-      return;
+    if (result.removedSessionKeys.includes(mainKey)) {
+      movedEntry = mainEntry;
     }
-    if (moveHeartbeatMainSessionEntry({ store: currentStore, mainKey, recoveredKey })) {
-      movedEntry = currentEntry;
-    }
-  });
+  } else {
+    await updateLegacySessionStore(params.store.path, (currentStore) => {
+      const currentEntry = currentStore[mainKey];
+      const currentCandidate = resolveHeartbeatMainSessionRepairCandidate({
+        entry: currentEntry,
+        transcriptPath,
+      });
+      if (!currentCandidate || "declineReason" in currentCandidate) {
+        return;
+      }
+      if (moveHeartbeatMainSessionEntry({ store: currentStore, mainKey, recoveredKey })) {
+        movedEntry = currentEntry;
+      }
+    });
+  }
   if (!movedEntry) {
     params.warnings.push(`- Main session ${mainKey} changed before repair could move it.`);
     return false;

--- a/src/commands/doctor-heartbeat-main-session-repair.ts
+++ b/src/commands/doctor-heartbeat-main-session-repair.ts
@@ -362,7 +362,7 @@ export async function repairHeartbeatPoisonedMainSession(params: {
       ],
       skipMaintenance: true,
       storePath: params.store.path,
-      upserts: [{ entry: mainEntry, sessionKey: recoveredKey }],
+      upserts: [{ entry: mainEntry, requiresRemovalSessionKey: mainKey, sessionKey: recoveredKey }],
     });
     if (result.removedSessionKeys.includes(mainKey)) {
       movedEntry = mainEntry;

--- a/src/commands/doctor-session-state-providers.test.ts
+++ b/src/commands/doctor-session-state-providers.test.ts
@@ -1,10 +1,17 @@
 // Doctor session state provider tests cover route-state repair through the public doctor path.
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
+import {
+  loadSessionEntryReadOnly,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import {
   createPluginSessionStateDoctorScanner,
   runPluginSessionStateDoctorRepairs,
@@ -60,7 +67,7 @@ async function runDoctor(params: {
     }
     await runPluginSessionStateDoctorRepairs({
       scan: scanner.result(),
-      absoluteStorePath: storePath,
+      store: { kind: "legacy", path: storePath },
       prompter: { confirmRuntimeRepair, note: vi.fn() },
       warnings,
       changes,
@@ -187,6 +194,63 @@ describe("doctor session state provider routes", () => {
     expect(repaired.cliSessionBindings).toEqual({
       "claude-cli": { sessionId: "claude-session" },
     });
+  });
+
+  it("repairs a non-default SQLite row without creating a legacy store", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-route-sqlite-"));
+    const legacyStorePath = path.join(root, "sessions.json");
+    const sqliteStorePath = resolveSqliteTargetFromSessionStorePath(legacyStorePath, {
+      agentId: "ops",
+      defaultAgentId: "ops",
+    }).path;
+    const sessionKey = "agent:ops:telegram:direct:2";
+    const staleEntry = entry({
+      model: "gpt-5.4",
+      modelOverride: "gpt-5.4",
+      modelOverrideSource: "auto",
+      modelProvider: "openai-codex",
+      providerOverride: "openai-codex",
+    });
+    const cfg = {
+      agents: {
+        defaults: { model: { primary: "github-copilot/gpt-5-mini" } },
+        entries: { main: {}, ops: {} },
+      },
+    } satisfies OpenClawConfig;
+    try {
+      await upsertSessionEntryCore(
+        {
+          agentId: "ops",
+          defaultAgentId: "ops",
+          sessionKey,
+          storePath: legacyStorePath,
+        },
+        staleEntry,
+      );
+      const scanner = createPluginSessionStateDoctorScanner({ cfg, env: {} });
+      scanner.scanEntry(sessionKey, staleEntry);
+
+      await runPluginSessionStateDoctorRepairs({
+        scan: scanner.result(),
+        store: { kind: "sqlite", agentId: "ops", path: sqliteStorePath },
+        prompter: { confirmRuntimeRepair: vi.fn(async () => true), note: vi.fn() },
+        warnings: [],
+        changes: [],
+      });
+
+      const repaired = loadSessionEntryReadOnly({
+        agentId: "ops",
+        sessionKey,
+        storePath: sqliteStorePath,
+      });
+      expect(repaired?.providerOverride).toBeUndefined();
+      expect(repaired?.modelOverride).toBeUndefined();
+      expect(repaired?.modelProvider).toBeUndefined();
+      expect(fsSync.existsSync(legacyStorePath)).toBe(false);
+    } finally {
+      closeOpenClawAgentDatabasesForTest();
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it("leaves explicit user owner choices for manual review", async () => {

--- a/src/commands/doctor-session-state-providers.test.ts
+++ b/src/commands/doctor-session-state-providers.test.ts
@@ -46,6 +46,7 @@ vi.mock("../plugins/doctor-contract-registry.js", async () => {
 });
 
 async function runDoctor(params: {
+  agentId?: string;
   cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
   confirm?: boolean;
@@ -59,6 +60,7 @@ async function runDoctor(params: {
   const confirmRuntimeRepair = vi.fn(async () => params.confirm ?? true);
   try {
     const scanner = createPluginSessionStateDoctorScanner({
+      agentId: params.agentId,
       cfg: params.cfg,
       env: params.env ?? {},
     });
@@ -149,6 +151,39 @@ describe("doctor session state provider routes", () => {
     } satisfies OpenClawConfig;
 
     const result = await runDoctor({ cfg, store });
+
+    expect(result.store).toEqual(store);
+    expect(result.confirmRuntimeRepair).not.toHaveBeenCalled();
+  });
+
+  it("uses the inspected agent route for a store-local global session", async () => {
+    const store = {
+      global: entry({
+        model: "gpt-5.4",
+        modelProvider: "openai-codex",
+        providerOverride: "openai-codex",
+      }),
+    };
+    const cfg = {
+      agents: {
+        entries: {
+          main: { model: "github-copilot/gpt-5.4-mini" },
+          ops: { model: "openai/gpt-5.4" },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            agentRuntime: { id: "codex-cli" },
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+          },
+        },
+      },
+      session: { scope: "global" },
+    } satisfies OpenClawConfig;
+
+    const result = await runDoctor({ agentId: "ops", cfg, store });
 
     expect(result.store).toEqual(store);
     expect(result.confirmRuntimeRepair).not.toHaveBeenCalled();

--- a/src/commands/doctor-session-state-providers.ts
+++ b/src/commands/doctor-session-state-providers.ts
@@ -16,6 +16,7 @@ import {
 } from "../agents/model-selection.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { SessionEntry } from "../config/sessions.js";
+import { applySessionEntryReplacements } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { updateLegacySessionStore } from "../infra/state-migrations.legacy-session-store.js";
 import { listPluginDoctorSessionRouteStateOwners } from "../plugins/doctor-contract-registry.js";
@@ -484,10 +485,14 @@ function groupRepairsByOwner(
   return grouped;
 }
 
+type DoctorSessionStateStore =
+  | { kind: "legacy"; path: string }
+  | { kind: "sqlite"; agentId: string; path: string };
+
 /** Prompts for and applies plugin-owned session route state repairs to the session store. */
 export async function runPluginSessionStateDoctorRepairs(params: {
   scan: DoctorSessionRouteStateScan;
-  absoluteStorePath: string;
+  store: DoctorSessionStateStore;
   prompter: DoctorPrompterLike;
   warnings: string[];
   changes: string[];
@@ -511,22 +516,46 @@ export async function runPluginSessionStateDoctorRepairs(params: {
         let repaired = 0;
         const repairedAt = Date.now();
         const repairsByKey = new Map(repairs.map((repair) => [repair.key, repair]));
-        await updateLegacySessionStore(params.absoluteStorePath, (currentStore) => {
-          for (const [key, repair] of repairsByKey) {
-            const current = currentStore[key];
-            if (
-              isRecord(current) &&
-              applySessionRouteStateRepair({
-                sessionKey: key,
-                entry: current,
-                repair,
-                now: repairedAt,
-              })
-            ) {
-              repaired += 1;
+        if (params.store.kind === "sqlite") {
+          repaired = await applySessionEntryReplacements<number>({
+            agentId: params.store.agentId,
+            sessionKeys: [...repairsByKey.keys()],
+            storePath: params.store.path,
+            update: (currentEntries) => {
+              const replacements = currentEntries.flatMap(({ entry, sessionKey }) => {
+                const repair = repairsByKey.get(sessionKey);
+                return repair &&
+                  isRecord(entry) &&
+                  applySessionRouteStateRepair({
+                    sessionKey,
+                    entry,
+                    repair,
+                    now: repairedAt,
+                  })
+                  ? [{ entry, sessionKey }]
+                  : [];
+              });
+              return { replacements, result: replacements.length };
+            },
+          });
+        } else {
+          await updateLegacySessionStore(params.store.path, (currentStore) => {
+            for (const [key, repair] of repairsByKey) {
+              const current = currentStore[key];
+              if (
+                isRecord(current) &&
+                applySessionRouteStateRepair({
+                  sessionKey: key,
+                  entry: current,
+                  repair,
+                  now: repairedAt,
+                })
+              ) {
+                repaired += 1;
+              }
             }
-          }
-        });
+          });
+        }
         if (repaired > 0) {
           params.changes.push(
             `- Cleared stale ${ownerLabel} session routing state for ${countSessionLabel(

--- a/src/commands/doctor-session-state-providers.ts
+++ b/src/commands/doctor-session-state-providers.ts
@@ -58,17 +58,22 @@ function repairExample(repair: DoctorSessionRouteStateRepair): string {
   return `${repair.key} (${repair.reasons.join(", ")})`;
 }
 
-function resolveSessionAgentId(cfg: OpenClawConfig, sessionKey: string): string | undefined {
-  return parseAgentSessionKey(sessionKey)?.agentId ?? tryResolveDefaultAgentId(cfg);
+function resolveSessionAgentId(
+  cfg: OpenClawConfig,
+  sessionKey: string,
+  storeAgentId?: string,
+): string | undefined {
+  return parseAgentSessionKey(sessionKey)?.agentId ?? storeAgentId ?? tryResolveDefaultAgentId(cfg);
 }
 
 /** Resolves the currently configured provider/model/runtime route for a session key. */
 function resolveConfiguredDoctorSessionStateRoute(params: {
+  agentId?: string;
   cfg: OpenClawConfig;
   sessionKey: string;
   env?: NodeJS.ProcessEnv;
 }): DoctorSessionRouteState | undefined {
-  const agentId = resolveSessionAgentId(params.cfg, params.sessionKey);
+  const agentId = resolveSessionAgentId(params.cfg, params.sessionKey, params.agentId);
   if (!agentId) {
     return undefined;
   }
@@ -338,6 +343,7 @@ function scanEntryForOwner(params: {
 
 /** Streams session entries into compact plugin-owned route-state findings. */
 export function createPluginSessionStateDoctorScanner(params: {
+  agentId?: string;
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }) {
@@ -357,13 +363,14 @@ export function createPluginSessionStateDoctorScanner(params: {
       if (owners.length === 0) {
         return;
       }
-      const agentId = resolveSessionAgentId(params.cfg, key);
+      const agentId = resolveSessionAgentId(params.cfg, key, params.agentId);
       if (!agentId) {
         return;
       }
       let route = routeByAgentId.get(agentId);
       if (!route) {
         route = resolveConfiguredDoctorSessionStateRoute({
+          agentId,
           cfg: params.cfg,
           sessionKey: key,
           env: params.env,

--- a/src/commands/doctor-state-integrity.test-support.ts
+++ b/src/commands/doctor-state-integrity.test-support.ts
@@ -28,8 +28,12 @@ export async function noteStateIntegrity(
   return noteStateIntegrityRaw(withMainAgentRoster(cfg), prompter, configPath);
 }
 
-export function setupSessionState(cfg: OpenClawConfig, env: NodeJS.ProcessEnv, homeDir: string) {
-  const agentId = "main";
+export function setupSessionState(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv,
+  homeDir: string,
+  agentId = "main",
+) {
   const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId, env, () => homeDir);
   const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
   fs.mkdirSync(sessionsDir, { recursive: true });
@@ -72,9 +76,10 @@ export function hasRepairPromptMessage(
 export function writeSessionStore(
   cfg: OpenClawConfig,
   sessions: Record<string, { sessionId: string; updatedAt: number } & Record<string, unknown>>,
+  agentId = "main",
 ) {
-  setupSessionState(cfg, process.env, process.env.HOME ?? "");
-  const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId: "main" });
+  setupSessionState(cfg, process.env, process.env.HOME ?? "", agentId);
+  const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
   fs.writeFileSync(storePath, JSON.stringify(sessions, null, 2));
 }
 

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -106,18 +106,6 @@ describe("structured state integrity findings", () => {
     });
   });
 
-  it("skips default-owned session repairs for an ambiguous roster", async () => {
-    fs.mkdirSync(path.join(tempHome, ".openclaw"), { recursive: true });
-    await noteStateIntegrityRaw(
-      { agents: { entries: { alpha: {}, beta: {} } } },
-      { confirmRuntimeRepair: vi.fn(async () => false), note: noteMock },
-    );
-
-    expect(stateIntegrityText()).toContain(
-      "Skipped default-agent session and transcript integrity checks because the agent roster does not have exactly one default.",
-    );
-  });
-
   it("reports permissive state and config file permissions as structured findings", () => {
     if (process.platform === "win32") {
       return;

--- a/src/commands/doctor-state-integrity.transcripts.test.ts
+++ b/src/commands/doctor-state-integrity.transcripts.test.ts
@@ -8,7 +8,11 @@ import {
   resolveSessionStorePathCore,
   resolveSessionTranscriptsDirForAgent,
 } from "../config/sessions/paths.js";
-import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
+import {
+  listSessionEntryKeysReadOnly,
+  loadSessionEntryReadOnly,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -291,6 +295,37 @@ describe("doctor transcript and heartbeat session repairs", () => {
     expect(text).toContain("1/1 recent sessions are missing transcripts");
     expect(text).toContain(sqliteStorePath);
     expect(text).not.toContain(path.join(path.dirname(storePath), "openclaw-agent.ops.sqlite"));
+  });
+
+  it("moves a non-default SQLite heartbeat main session without recreating sessions.json", async () => {
+    const cfg: OpenClawConfig = { agents: { entries: { main: {}, ops: {} } } };
+    setupSessionState(cfg, process.env, tempHome, "ops");
+    const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId: "ops" });
+    const mainKey = "agent:ops:main";
+    await upsertSessionEntryCore(
+      { agentId: "ops", sessionKey: mainKey, storePath },
+      {
+        heartbeatIsolatedBaseSessionKey: mainKey,
+        sessionId: "sqlite-heartbeat-ops",
+        updatedAt: Date.now(),
+      },
+    );
+    const confirmRuntimeRepair = vi.fn(async (params: { message: string }) =>
+      params.message.startsWith("Move heartbeat-owned main session"),
+    );
+
+    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
+
+    const keys = listSessionEntryKeysReadOnly({ agentId: "ops", storePath });
+    const recoveredKey = keys.find((key) => key.startsWith("agent:ops:heartbeat-recovered-"));
+    expect(keys).not.toContain(mainKey);
+    if (!recoveredKey) {
+      throw new Error("expected recovered SQLite heartbeat session key");
+    }
+    expect(
+      loadSessionEntryReadOnly({ agentId: "ops", sessionKey: recoveredKey, storePath })?.sessionId,
+    ).toBe("sqlite-heartbeat-ops");
+    expect(fs.existsSync(storePath)).toBe(false);
   });
 
   it("moves a heartbeat-poisoned main session and clears stale TUI restore pointers", async () => {

--- a/src/commands/doctor-state-integrity.transcripts.test.ts
+++ b/src/commands/doctor-state-integrity.transcripts.test.ts
@@ -77,10 +77,17 @@ describe("doctor transcript and heartbeat session repairs", () => {
   });
 
   it("detects orphan transcripts and offers archival remediation", async () => {
-    const cfg: OpenClawConfig = {};
-    setupSessionState(cfg, process.env, process.env.HOME ?? "");
-    const sessionsDir = resolveSessionTranscriptsDirForAgent("main", process.env, () => tempHome);
-    fs.writeFileSync(path.join(sessionsDir, "orphan-session.jsonl"), '{"type":"session"}\n');
+    const cfg: OpenClawConfig = { agents: { entries: { alpha: {}, beta: {} } } };
+    const sessionsDirs = ["alpha", "beta"].map((agentId) => {
+      setupSessionState(cfg, process.env, process.env.HOME ?? "", agentId);
+      const sessionsDir = resolveSessionTranscriptsDirForAgent(
+        agentId,
+        process.env,
+        () => tempHome,
+      );
+      fs.writeFileSync(path.join(sessionsDir, `orphan-${agentId}.jsonl`), '{"type":"session"}\n');
+      return sessionsDir;
+    });
     const confirmRuntimeRepair = vi.fn(async (params: { message: string }) =>
       params.message.includes("This only renames them to *.deleted.<timestamp>."),
     );
@@ -88,16 +95,21 @@ describe("doctor transcript and heartbeat session repairs", () => {
     expect(stateIntegrityText()).toContain(
       "These .jsonl files are no longer referenced by sessions.json",
     );
-    expect(stateIntegrityText()).toContain("Examples: orphan-session.jsonl");
-    const archivePrompt = repairPromptCalls(confirmRuntimeRepair).find((prompt) =>
+    expect(stateIntegrityText()).toContain("Examples: orphan-alpha.jsonl");
+    expect(stateIntegrityText()).toContain("Examples: orphan-beta.jsonl");
+    const archivePrompts = repairPromptCalls(confirmRuntimeRepair).filter((prompt) =>
       prompt.message?.includes("This only renames them to *.deleted.<timestamp>."),
     );
-    expect(archivePrompt?.requiresInteractiveConfirmation).toBe(true);
-    const files = fs.readdirSync(sessionsDir);
-    const archivedOrphanTranscripts = files.filter((name) =>
-      name.startsWith("orphan-session.jsonl.deleted."),
-    );
-    expect(archivedOrphanTranscripts.length).toBeGreaterThan(0);
+    expect(archivePrompts).toHaveLength(2);
+    expect(archivePrompts.every((prompt) => prompt.requiresInteractiveConfirmation)).toBe(true);
+    for (const [index, sessionsDir] of sessionsDirs.entries()) {
+      const agentId = index === 0 ? "alpha" : "beta";
+      expect(
+        fs
+          .readdirSync(sessionsDir)
+          .some((name) => name.startsWith(`orphan-${agentId}.jsonl.deleted.`)),
+      ).toBe(true);
+    }
   });
 
   it("uses SQLite session rows for transcript integrity without orphan false positives", async () => {
@@ -220,16 +232,28 @@ describe("doctor transcript and heartbeat session repairs", () => {
   );
 
   it("prints openclaw-only verification hints when recent sessions are missing transcripts", async () => {
-    const cfg: OpenClawConfig = {};
-    writeSessionStore(cfg, {
-      "agent:main:main": {
-        sessionId: "missing-transcript",
-        updatedAt: Date.now(),
-      },
-    });
+    const cfg: OpenClawConfig = { agents: { entries: { alpha: {}, beta: {} } } };
+    for (const agentId of ["alpha", "beta"]) {
+      writeSessionStore(
+        cfg,
+        {
+          [`agent:${agentId}:missing`]: {
+            sessionId: `missing-${agentId}`,
+            updatedAt: Date.now(),
+          },
+        },
+        agentId,
+      );
+      const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId });
+      await upsertSessionEntryCore(
+        { agentId, sessionKey: `agent:${agentId}:sqlite`, storePath },
+        { sessionId: `sqlite-${agentId}`, updatedAt: Date.now() },
+      );
+    }
     const text = await runStateIntegrityText(cfg);
-    expect(text).toContain("recent sessions are missing transcripts");
-    expect(text).toMatch(/openclaw sessions --store ".*openclaw-agent\.sqlite"/);
+    expect(text.match(/recent sessions are missing transcripts/g)).toHaveLength(2);
+    expect(text).toContain(path.join("agents", "alpha", "agent", "openclaw-agent.sqlite"));
+    expect(text).toContain(path.join("agents", "beta", "agent", "openclaw-agent.sqlite"));
     expect(text).toMatch(
       /openclaw sessions cleanup --store ".*openclaw-agent\.sqlite" --dry-run --fix-missing/,
     );

--- a/src/commands/doctor-state-integrity.transcripts.test.ts
+++ b/src/commands/doctor-state-integrity.transcripts.test.ts
@@ -267,6 +267,32 @@ describe("doctor transcript and heartbeat session repairs", () => {
     expect(text).not.toContain(" ls ");
   });
 
+  it("preserves a non-main compatibility owner for a fixed legacy store", async () => {
+    const storePath = path.join(tempHome, "fixed-store", "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { sessionStore: { agentId: "ops" } },
+        entries: { main: {}, ops: {} },
+      },
+      session: { store: storePath },
+    };
+    writeSessionStore(
+      cfg,
+      {
+        "agent:ops:missing": {
+          sessionId: "missing-ops",
+          updatedAt: Date.now(),
+        },
+      },
+      "ops",
+    );
+    const text = await runStateIntegrityText(cfg);
+    const sqliteStorePath = path.join(path.dirname(storePath), "openclaw-agent.sqlite");
+    expect(text).toContain("1/1 recent sessions are missing transcripts");
+    expect(text).toContain(sqliteStorePath);
+    expect(text).not.toContain(path.join(path.dirname(storePath), "openclaw-agent.ops.sqlite"));
+  });
+
   it("moves a heartbeat-poisoned main session and clears stale TUI restore pointers", async () => {
     const cfg: OpenClawConfig = {};
     setupSessionState(cfg, process.env, tempHome);

--- a/src/commands/doctor-state-integrity.transcripts.test.ts
+++ b/src/commands/doctor-state-integrity.transcripts.test.ts
@@ -50,6 +50,18 @@ vi.mock("../channels/plugins/persisted-auth-state.js", () => ({
   hasBundledChannelPersistedAuthState: () => false,
 }));
 
+const routeStateOwnerState = vi.hoisted(() => ({ owners: [] as Array<Record<string, unknown>> }));
+
+vi.mock("../plugins/doctor-contract-registry.js", async () => {
+  const actual = await vi.importActual<typeof import("../plugins/doctor-contract-registry.js")>(
+    "../plugins/doctor-contract-registry.js",
+  );
+  return {
+    ...actual,
+    listPluginDoctorSessionRouteStateOwners: vi.fn(() => routeStateOwnerState.owners),
+  };
+});
+
 describe("doctor transcript and heartbeat session repairs", () => {
   let envSnapshot: ReturnType<typeof captureEnv>;
   let tempHome = "";
@@ -70,6 +82,7 @@ describe("doctor transcript and heartbeat session repairs", () => {
     deleteTestEnvValue("OPENCLAW_OAUTH_DIR");
     deleteTestEnvValue("OPENCLAW_AGENT_DIR");
     fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    routeStateOwnerState.owners = [];
     noteMock.mockClear();
   });
 
@@ -325,6 +338,67 @@ describe("doctor transcript and heartbeat session repairs", () => {
     expect(
       loadSessionEntryReadOnly({ agentId: "ops", sessionKey: recoveredKey, storePath })?.sessionId,
     ).toBe("sqlite-heartbeat-ops");
+    expect(fs.existsSync(storePath)).toBe(false);
+  });
+
+  it("moves a plugin-repaired SQLite heartbeat row without restoring stale state", async () => {
+    routeStateOwnerState.owners = [
+      {
+        authProfilePrefixes: ["openai-codex:"],
+        cliSessionKeys: ["codex-cli"],
+        id: "codex",
+        label: "Codex",
+        providerIds: ["openai-codex"],
+        runtimeIds: ["codex-cli"],
+      },
+    ];
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { model: { primary: "github-copilot/gpt-5.4-mini" } },
+        entries: { main: {}, ops: {} },
+      },
+    };
+    setupSessionState(cfg, process.env, tempHome, "ops");
+    const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId: "ops" });
+    const mainKey = "agent:ops:main";
+    await upsertSessionEntryCore(
+      { agentId: "ops", sessionKey: mainKey, storePath },
+      {
+        heartbeatIsolatedBaseSessionKey: mainKey,
+        model: "gpt-5.4",
+        modelOverride: "gpt-5.4",
+        modelOverrideSource: "auto",
+        modelProvider: "openai-codex",
+        providerOverride: "openai-codex",
+        sessionId: "sqlite-combined-ops",
+        updatedAt: Date.now(),
+      },
+    );
+    const confirmRuntimeRepair = vi.fn(
+      async (params: { message: string }) =>
+        params.message.startsWith("Clear stale Codex") ||
+        params.message.startsWith("Move heartbeat-owned main session"),
+    );
+
+    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
+
+    const keys = listSessionEntryKeysReadOnly({ agentId: "ops", storePath });
+    const recoveredKeys = keys.filter((key) => key.startsWith("agent:ops:heartbeat-recovered-"));
+    expect(keys).not.toContain(mainKey);
+    expect(recoveredKeys).toHaveLength(1);
+    const recoveredKey = recoveredKeys[0];
+    if (!recoveredKey) {
+      throw new Error("expected one recovered combined-repair session key");
+    }
+    const recovered = loadSessionEntryReadOnly({
+      agentId: "ops",
+      sessionKey: recoveredKey,
+      storePath,
+    });
+    expect(recovered?.sessionId).toBe("sqlite-combined-ops");
+    expect(recovered?.providerOverride).toBeUndefined();
+    expect(recovered?.modelOverride).toBeUndefined();
+    expect(recovered?.modelProvider).toBeUndefined();
     expect(fs.existsSync(storePath)).toBe(false);
   });
 

--- a/src/commands/doctor-state-integrity.transcripts.test.ts
+++ b/src/commands/doctor-state-integrity.transcripts.test.ts
@@ -341,6 +341,44 @@ describe("doctor transcript and heartbeat session repairs", () => {
     expect(fs.existsSync(storePath)).toBe(false);
   });
 
+  it("does not create a recovery row when the SQLite main entry changes during confirmation", async () => {
+    const cfg: OpenClawConfig = { agents: { entries: { main: {}, ops: {} } } };
+    setupSessionState(cfg, process.env, tempHome, "ops");
+    const storePath = resolveSessionStorePathCore(cfg.session?.store, { agentId: "ops" });
+    const mainKey = "agent:ops:main";
+    await upsertSessionEntryCore(
+      { agentId: "ops", sessionKey: mainKey, storePath },
+      {
+        heartbeatIsolatedBaseSessionKey: mainKey,
+        sessionId: "sqlite-heartbeat-race-ops",
+        updatedAt: 1,
+      },
+    );
+    const confirmRuntimeRepair = vi.fn(async (params: { message: string }) => {
+      if (!params.message.startsWith("Move heartbeat-owned main session")) {
+        return false;
+      }
+      await upsertSessionEntryCore(
+        { agentId: "ops", sessionKey: mainKey, storePath },
+        { lastInteractionAt: 2, updatedAt: 2 },
+      );
+      return true;
+    });
+
+    await noteStateIntegrity(cfg, { confirmRuntimeRepair, note: noteMock });
+
+    const keys = listSessionEntryKeysReadOnly({ agentId: "ops", storePath });
+    expect(keys).toEqual([mainKey]);
+    expect(keys.filter((key) => key.startsWith("agent:ops:heartbeat-recovered-"))).toStrictEqual(
+      [],
+    );
+    expect(
+      loadSessionEntryReadOnly({ agentId: "ops", sessionKey: mainKey, storePath })
+        ?.lastInteractionAt,
+    ).toBe(2);
+    expect(fs.existsSync(storePath)).toBe(false);
+  });
+
   it("moves a plugin-repaired SQLite heartbeat row without restoring stale state", async () => {
     routeStateOwnerState.owners = [
       {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -1348,7 +1348,8 @@ export async function noteStateIntegrity(
     });
     const mainRecoveryWedged: MainSessionRecoveryIntegrityCandidate[] = [];
     const wedgedSubagentSessions: Array<{ key: string; reason: string }> = [];
-    const pluginStateScanner = createPluginSessionStateDoctorScanner({ cfg, env });
+    const sqlitePluginStateScanner = createPluginSessionStateDoctorScanner({ cfg, env });
+    const legacyPluginStateScanner = createPluginSessionStateDoctorScanner({ cfg, env });
     let mainEntry: SessionEntry | undefined;
     let sqliteNewKeyIndex = 0;
     const recent: Array<{ entry: SessionEntry; order: number; sessionKey: string }> = [];
@@ -1365,7 +1366,6 @@ export async function noteStateIntegrity(
     };
     const inspectMergedEntry = (sessionKey: string, entry: SessionEntry, order: number) => {
       addRecent(sessionKey, entry, order);
-      pluginStateScanner.scanEntry(sessionKey, entry);
       if (sessionKey === mainKey) {
         mainEntry = entry;
       }
@@ -1380,6 +1380,7 @@ export async function noteStateIntegrity(
       { agentId, storePath: sqliteStorePath },
       ({ entry, sessionKey }) => {
         sqliteSessionKeys.add(sessionKey);
+        sqlitePluginStateScanner.scanEntry(sessionKey, entry);
         const order = legacyOrder.get(sessionKey) ?? legacyEntries.length + sqliteNewKeyIndex++;
         inspectMergedEntry(sessionKey, entry, order);
         const recovery = inspectMainSessionRecoveryEntry(sessionKey, entry);
@@ -1393,6 +1394,7 @@ export async function noteStateIntegrity(
       if (sqliteSessionKeys.has(sessionKey)) {
         continue;
       }
+      legacyPluginStateScanner.scanEntry(sessionKey, entry);
       inspectMergedEntry(sessionKey, entry, legacyOrder.get(sessionKey) ?? mergedEntryCount);
       mergedEntryCount += 1;
     }
@@ -1505,8 +1507,15 @@ export async function noteStateIntegrity(
       }
 
       await runPluginSessionStateDoctorRepairs({
-        scan: pluginStateScanner.result(),
-        absoluteStorePath,
+        scan: sqlitePluginStateScanner.result(),
+        store: { kind: "sqlite", agentId, path: sqliteStorePath },
+        prompter,
+        warnings,
+        changes,
+      });
+      await runPluginSessionStateDoctorRepairs({
+        scan: legacyPluginStateScanner.result(),
+        store: { kind: "legacy", path: absoluteStorePath },
         prompter,
         warnings,
         changes,

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -10,7 +10,7 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { note } from "../../packages/terminal-core/src/note.js";
 import { isSharedAuthStoreOwner } from "../agents/agent-delete-safety.js";
 import {
-  listAgentEntries,
+  listAgentIds,
   resolveDefaultAgentDir,
   tryResolveDefaultAgentId,
 } from "../agents/agent-scope.js";
@@ -25,13 +25,14 @@ import {
   isSubagentRecoveryWedgedEntry,
 } from "../agents/subagents/registry/subagent-recovery-state.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { resolveSessionStoreCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import { resolveOAuthDir, resolveStateDir } from "../config/paths.js";
 import {
   formatSessionArchiveTimestamp,
   isPrimarySessionTranscriptFileName,
 } from "../config/sessions/artifacts.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
-import { resolveMainSessionKey } from "../config/sessions/main-session.js";
+import { resolveCanonicalMainSessionKey } from "../config/sessions/main-session-key.js";
 import {
   resolveSessionFilePathCore,
   resolveSessionFilePathOptions,
@@ -44,6 +45,7 @@ import {
   scanDoctorSessionEntriesStrict,
 } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
+import { resolveSessionStoreTargets, type SessionStoreTarget } from "../config/sessions/targets.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
@@ -201,16 +203,10 @@ function formatOrphanAgentDirPreview(entries: OrphanAgentDir[], limit = 3): stri
 }
 
 function listOrphanAgentDirs(cfg: OpenClawConfig, stateDir: string): OrphanAgentDir[] {
-  const configuredIds = new Set<string>();
+  const configuredIds = new Set(listAgentIds(cfg));
   const sharedAuthOwnership = resolveSharedAuthStoreOwnership();
   const sharedAuthDbPath = resolveSharedAuthStorePath();
   const defaultAgentId = tryResolveDefaultAgentId(cfg);
-  if (defaultAgentId) {
-    configuredIds.add(normalizeAgentId(defaultAgentId));
-  }
-  for (const entry of listAgentEntries(cfg)) {
-    configuredIds.add(normalizeAgentId(entry.id));
-  }
 
   const agentsRoot = path.join(stateDir, "agents");
   const liveDefaultAgentDir = defaultAgentId ? resolveDefaultAgentDir(cfg) : undefined;
@@ -1079,18 +1075,16 @@ export async function noteStateIntegrity(
   const stateDir = resolveStateDir(env, homedir);
   const defaultStateDir = path.join(homedir(), ".openclaw");
   const oauthDir = resolveOAuthDir(env, stateDir);
-  const agentId = tryResolveDefaultAgentId(cfg);
-  const sessionsDir = agentId
-    ? resolveSessionTranscriptsDirForAgent(agentId, env, homedir)
+  const runtimeAgentId = tryResolveDefaultAgentId(cfg);
+  const runtimeSessionsDir = runtimeAgentId
+    ? resolveSessionTranscriptsDirForAgent(runtimeAgentId, env, homedir)
     : undefined;
-  const storePath = agentId
-    ? resolveSessionStorePathCore(cfg.session?.store, { agentId })
+  const runtimeStorePath = runtimeAgentId
+    ? resolveSessionStorePathCore(cfg.session?.store, { agentId: runtimeAgentId })
     : undefined;
-  const storeDir = storePath ? path.dirname(storePath) : undefined;
-  const absoluteStorePath = storePath ? path.resolve(storePath) : undefined;
+  const runtimeStoreDir = runtimeStorePath ? path.dirname(runtimeStorePath) : undefined;
   const displayStateDir = shortenHomePath(stateDir);
   const displayOauthDir = shortenHomePath(oauthDir);
-  const displaySessionsDir = sessionsDir ? shortenHomePath(sessionsDir) : undefined;
   const displayConfigPath = configPath ? shortenHomePath(configPath) : undefined;
   const requireOAuthDir = shouldRequireOAuthDir(cfg, env);
   const cloudSyncedStateDir = detectMacCloudSyncedStateDir(stateDir);
@@ -1224,11 +1218,11 @@ export async function noteStateIntegrity(
 
   if (stateDirExists) {
     const dirCandidates = new Map<string, RuntimeDirLabel>();
-    if (sessionsDir) {
-      dirCandidates.set(sessionsDir, "Sessions dir");
+    if (runtimeSessionsDir) {
+      dirCandidates.set(runtimeSessionsDir, "Sessions dir");
     }
-    if (storeDir) {
-      dirCandidates.set(storeDir, "Session store dir");
+    if (runtimeStoreDir) {
+      dirCandidates.set(runtimeStoreDir, "Session store dir");
     }
     if (requireOAuthDir) {
       dirCandidates.set(oauthDir, "OAuth dir");
@@ -1313,300 +1307,318 @@ export async function noteStateIntegrity(
     );
   }
 
-  if (!agentId || !sessionsDir || !storePath || !absoluteStorePath || !displaySessionsDir) {
-    warnings.push(
-      "- Skipped default-agent session and transcript integrity checks because the agent roster does not have exactly one default.",
+  const compatibilityAgentId = resolveSessionStoreCompatibilityAgentId(cfg);
+  const sessionTargets = resolveSessionStoreTargets(cfg, { allAgents: true }, { env }).toSorted(
+    (left, right) =>
+      left.agentId === compatibilityAgentId ? -1 : right.agentId === compatibilityAgentId ? 1 : 0,
+  );
+
+  const inspectAgentSessionIntegrity = async (
+    target: SessionStoreTarget,
+    inspectLegacyStore: boolean,
+  ) => {
+    const { agentId, storePath } = target;
+    const sessionsDir = resolveSessionTranscriptsDirForAgent(agentId, env, homedir);
+    const absoluteStorePath = path.resolve(storePath);
+    const displaySessionsDir = shortenHomePath(sessionsDir);
+
+    const sqliteStorePath = resolveSqliteTargetFromSessionStorePath(absoluteStorePath, {
+      agentId,
+    }).path;
+    // A successful SQLite import archives sessions.json. Its continued presence
+    // is therefore the explicit signal that pre-import rows still need inspection.
+    const legacyStore =
+      inspectLegacyStore && existsFile(absoluteStorePath)
+        ? loadLegacySessionStore(absoluteStorePath)
+        : {};
+    const legacyEntries = Object.entries(legacyStore).filter(
+      (candidate): candidate is [string, SessionEntry] =>
+        candidate[1] != null && typeof candidate[1] === "object",
     );
-    if (warnings.length > 0) {
-      noteFn(warnings.join("\n"), "State integrity");
-    }
-    if (changes.length > 0) {
-      noteFn(changes.join("\n"), "Doctor changes");
-    }
-    return;
-  }
-
-  const sqliteStorePath = resolveSqliteTargetFromSessionStorePath(absoluteStorePath, {
-    agentId,
-  }).path;
-  // A successful SQLite import archives sessions.json. Its continued presence
-  // is therefore the explicit signal that pre-import rows still need inspection.
-  const legacyStore = existsFile(absoluteStorePath)
-    ? loadLegacySessionStore(absoluteStorePath)
-    : {};
-  const legacyEntries = Object.entries(legacyStore).filter(
-    (candidate): candidate is [string, SessionEntry] =>
-      candidate[1] != null && typeof candidate[1] === "object",
-  );
-  const legacyOrder = new Map(legacyEntries.map(([sessionKey], index) => [sessionKey, index]));
-  const sqliteSessionKeys = new Set<string>();
-  const isSessionKeyOccupied = (sessionKey: string) =>
-    sqliteSessionKeys.has(sessionKey) || legacyOrder.has(sessionKey);
-  const mainKey = resolveMainSessionKey(cfg);
-  const mainRecoveryWedged: MainSessionRecoveryIntegrityCandidate[] = [];
-  const wedgedSubagentSessions: Array<{ key: string; reason: string }> = [];
-  const pluginStateScanner = createPluginSessionStateDoctorScanner({ cfg, env });
-  let mainEntry: SessionEntry | undefined;
-  let sqliteNewKeyIndex = 0;
-  const recent: Array<{ entry: SessionEntry; order: number; sessionKey: string }> = [];
-  const addRecent = (sessionKey: string, entry: SessionEntry, order: number) => {
-    recent.push({ entry, order, sessionKey });
-    recent.sort((left, right) => {
-      const leftUpdated = typeof left.entry.updatedAt === "number" ? left.entry.updatedAt : 0;
-      const rightUpdated = typeof right.entry.updatedAt === "number" ? right.entry.updatedAt : 0;
-      return rightUpdated - leftUpdated || left.order - right.order;
+    const legacyOrder = new Map(legacyEntries.map(([sessionKey], index) => [sessionKey, index]));
+    const sqliteSessionKeys = new Set<string>();
+    const isSessionKeyOccupied = (sessionKey: string) =>
+      sqliteSessionKeys.has(sessionKey) || legacyOrder.has(sessionKey);
+    const mainKey = resolveCanonicalMainSessionKey({
+      agentId,
+      mainKey: cfg.session?.mainKey,
+      sessionScope: cfg.session?.scope,
     });
-    if (recent.length > 5) {
-      recent.pop();
-    }
-  };
-  const inspectMergedEntry = (sessionKey: string, entry: SessionEntry, order: number) => {
-    addRecent(sessionKey, entry, order);
-    pluginStateScanner.scanEntry(sessionKey, entry);
-    if (sessionKey === mainKey) {
-      mainEntry = entry;
-    }
-    if (isSubagentRecoveryWedgedEntry(entry)) {
-      wedgedSubagentSessions.push({
-        key: sessionKey,
-        reason: formatSubagentRecoveryWedgedReason(entry),
+    const mainRecoveryWedged: MainSessionRecoveryIntegrityCandidate[] = [];
+    const wedgedSubagentSessions: Array<{ key: string; reason: string }> = [];
+    const pluginStateScanner = createPluginSessionStateDoctorScanner({ cfg, env });
+    let mainEntry: SessionEntry | undefined;
+    let sqliteNewKeyIndex = 0;
+    const recent: Array<{ entry: SessionEntry; order: number; sessionKey: string }> = [];
+    const addRecent = (sessionKey: string, entry: SessionEntry, order: number) => {
+      recent.push({ entry, order, sessionKey });
+      recent.sort((left, right) => {
+        const leftUpdated = typeof left.entry.updatedAt === "number" ? left.entry.updatedAt : 0;
+        const rightUpdated = typeof right.entry.updatedAt === "number" ? right.entry.updatedAt : 0;
+        return rightUpdated - leftUpdated || left.order - right.order;
       });
-    }
-  };
-  const sqliteEntryCount = scanDoctorSessionEntriesStrict(
-    { agentId, storePath: absoluteStorePath },
-    ({ entry, sessionKey }) => {
-      sqliteSessionKeys.add(sessionKey);
-      const order = legacyOrder.get(sessionKey) ?? legacyEntries.length + sqliteNewKeyIndex++;
-      inspectMergedEntry(sessionKey, entry, order);
-      const recovery = inspectMainSessionRecoveryEntry(sessionKey, entry);
-      if (recovery) {
-        mainRecoveryWedged.push(recovery);
+      if (recent.length > 5) {
+        recent.pop();
       }
-    },
-  );
-  let mergedEntryCount = sqliteEntryCount;
-  for (const [sessionKey, entry] of legacyEntries) {
-    if (sqliteSessionKeys.has(sessionKey)) {
-      continue;
-    }
-    inspectMergedEntry(sessionKey, entry, legacyOrder.get(sessionKey) ?? mergedEntryCount);
-    mergedEntryCount += 1;
-  }
-  const sessionPathOpts = resolveSessionFilePathOptions({ agentId, storePath });
-  await noteMainSessionRecoveryIntegrity({
-    storePath: absoluteStorePath,
-    wedged: mainRecoveryWedged,
-    warnings,
-    changes,
-    confirmRepair: (params) => prompter.confirmRuntimeRepair(params),
-    countLabel,
-  });
-  if (mergedEntryCount > 0) {
-    const recentTranscriptCandidates = recent
-      .map(({ entry, sessionKey }) => [sessionKey, entry] as const)
-      .filter(([key]) => !isSlashRoutingSessionKey(key));
-    const missing = recentTranscriptCandidates.filter(([key, entry]) => {
-      if (sqliteSessionKeys.has(key)) {
-        return false;
+    };
+    const inspectMergedEntry = (sessionKey: string, entry: SessionEntry, order: number) => {
+      addRecent(sessionKey, entry, order);
+      pluginStateScanner.scanEntry(sessionKey, entry);
+      if (sessionKey === mainKey) {
+        mainEntry = entry;
       }
-      const sessionId = entry.sessionId;
-      if (!sessionId) {
-        return false;
+      if (isSubagentRecoveryWedgedEntry(entry)) {
+        wedgedSubagentSessions.push({
+          key: sessionKey,
+          reason: formatSubagentRecoveryWedgedReason(entry),
+        });
       }
-      const legacySessionFile = (entry as SessionEntry & { sessionFile?: string }).sessionFile;
-      if (parseSqliteSessionFileMarker(legacySessionFile)) {
-        return false;
-      }
-      const transcriptPath = resolveSessionFilePathCore(sessionId, entry, sessionPathOpts);
-      return !existsFile(transcriptPath);
-    });
-    if (missing.length > 0) {
-      warnings.push(
-        [
-          `- ${missing.length}/${recentTranscriptCandidates.length} recent sessions are missing transcripts.`,
-          `  Verify sessions in store: ${formatCliCommand(`openclaw sessions --store "${sqliteStorePath}"`)}`,
-          `  Preview cleanup impact: ${formatCliCommand(`openclaw sessions cleanup --store "${sqliteStorePath}" --dry-run --fix-missing`)}`,
-          `  Prune missing entries: ${formatCliCommand(`openclaw sessions cleanup --store "${sqliteStorePath}" --enforce --fix-missing`)}`,
-        ].join("\n"),
-      );
-    }
-
-    if (wedgedSubagentSessions.length > 0) {
-      const wedgedCount = countLabel(wedgedSubagentSessions.length, "wedged subagent session");
-      warnings.push(
-        [
-          `- Found ${wedgedCount} with automatic restart recovery tombstoned.`,
-          "  OpenClaw will not auto-resume these child sessions on restart; reconcile their task records instead.",
-          `  Examples: ${wedgedSubagentSessions
-            .slice(0, 3)
-            .map(({ key }) => key)
-            .join(", ")}`,
-          `  Fix: ${formatCliCommand("openclaw tasks maintenance --apply")}`,
-        ].join("\n"),
-      );
-      const repairWedged = await prompter.confirmRuntimeRepair({
-        message: `Clear stale aborted recovery flags for ${wedgedCount}?`,
-        initialValue: true,
-      });
-      if (repairWedged) {
-        let repaired = 0;
-        const repairedAt = Date.now();
-        const sqliteKeys = wedgedSubagentSessions
-          .map(({ key }) => key)
-          .filter((key) => sqliteSessionKeys.has(key));
-        for (const sessionKeys of iterateDoctorSessionKeyBatches(sqliteKeys)) {
-          repaired += await applySessionEntryReplacements<number>({
-            sessionKeys,
-            storePath: absoluteStorePath,
-            update: (currentEntries) => {
-              const replacements = currentEntries.flatMap(({ entry, sessionKey }) =>
-                clearWedgedSubagentRecoveryAbort(entry, repairedAt) ? [{ entry, sessionKey }] : [],
-              );
-              return { replacements, result: replacements.length };
-            },
-          });
+    };
+    const sqliteEntryCount = scanDoctorSessionEntriesStrict(
+      { agentId, storePath: absoluteStorePath },
+      ({ entry, sessionKey }) => {
+        sqliteSessionKeys.add(sessionKey);
+        const order = legacyOrder.get(sessionKey) ?? legacyEntries.length + sqliteNewKeyIndex++;
+        inspectMergedEntry(sessionKey, entry, order);
+        const recovery = inspectMainSessionRecoveryEntry(sessionKey, entry);
+        if (recovery) {
+          mainRecoveryWedged.push(recovery);
         }
-        const legacyKeys = wedgedSubagentSessions
-          .map(({ key }) => key)
-          .filter((key) => !sqliteSessionKeys.has(key));
-        if (legacyKeys.length > 0 && existsFile(absoluteStorePath)) {
-          await updateLegacySessionStore(absoluteStorePath, (currentStore) => {
-            for (const key of legacyKeys) {
-              const current = currentStore[key];
-              if (current && clearWedgedSubagentRecoveryAbort(current, repairedAt)) {
-                repaired += 1;
-                currentStore[key] = current;
-              }
-            }
-          });
-        }
-        if (repaired > 0) {
-          changes.push(
-            `- Cleared aborted restart-recovery flags for ${countLabel(
-              repaired,
-              "wedged subagent session",
-            )}.`,
-          );
-        }
-      }
-
-      const wedgedReasons = wedgedSubagentSessions.map(({ reason }) => reason);
-      const visibleWedgedReasons = uniqueStrings(wedgedReasons).slice(0, 2);
-      if (visibleWedgedReasons.length > 0) {
-        warnings.push(visibleWedgedReasons.map((reason) => `  Reason: ${reason}`).join("\n"));
-      }
-    }
-
-    await runPluginSessionStateDoctorRepairs({
-      scan: pluginStateScanner.result(),
-      absoluteStorePath,
-      prompter,
-      warnings,
-      changes,
-    });
-
-    const heartbeatMainMoved = await repairHeartbeatPoisonedMainSession({
-      cfg,
-      mainEntry,
-      isSessionKeyOccupied,
-      absoluteStorePath,
-      stateDir,
-      sessionPathOpts,
-      prompter,
-      warnings,
-      changes,
-    });
-
-    for (const warning of describeHeartbeatSessionTargetIssues(cfg)) {
-      warnings.push(warning);
-    }
-
-    // SQLite-owned transcripts live in the agent DB after import.
-    // Do not require the archived legacy JSONL for those sessions.
-    if (!heartbeatMainMoved && mainEntry?.sessionId && !sqliteSessionKeys.has(mainKey)) {
-      const transcriptPath = resolveSessionFilePathCore(
-        mainEntry.sessionId,
-        mainEntry,
-        sessionPathOpts,
-      );
-      if (!existsFile(transcriptPath)) {
-        warnings.push(
-          `- Main session transcript missing (${shortenHomePath(transcriptPath)}). History will appear to reset.`,
-        );
-      } else {
-        const lineCount = countJsonlLines(transcriptPath);
-        if (lineCount <= 1) {
-          warnings.push(
-            `- Main session transcript has only ${lineCount} line. Session history may not be appending.`,
-          );
-        }
-      }
-    }
-  }
-
-  // SQLite transcript ownership is repaired by the import/migration workflow.
-  // Never offer generic file archival against a live canonical session store.
-  if (sqliteEntryCount === 0 && existsDir(sessionsDir)) {
-    const referencedTranscriptPaths = new Set<string>();
-    for (const [, entry] of legacyEntries) {
-      if (!entry?.sessionId) {
+      },
+    );
+    let mergedEntryCount = sqliteEntryCount;
+    for (const [sessionKey, entry] of legacyEntries) {
+      if (sqliteSessionKeys.has(sessionKey)) {
         continue;
       }
-      try {
-        referencedTranscriptPaths.add(
-          resolveComparableTranscriptPath(
-            resolveSessionFilePathCore(entry.sessionId, entry, sessionPathOpts),
-          ),
-        );
-      } catch {
-        // ignore invalid legacy paths
-      }
+      inspectMergedEntry(sessionKey, entry, legacyOrder.get(sessionKey) ?? mergedEntryCount);
+      mergedEntryCount += 1;
     }
-    const sessionDirEntries = fs.readdirSync(sessionsDir, { withFileTypes: true });
-    const orphanTranscriptPaths = sessionDirEntries
-      .filter((entry) => entry.isFile() && isPrimarySessionTranscriptFileName(entry.name))
-      .map((entry) => path.join(sessionsDir, entry.name))
-      .filter(
-        (filePath) => !referencedTranscriptPaths.has(resolveComparableTranscriptPath(filePath)),
-      );
-    if (orphanTranscriptPaths.length > 0) {
-      const orphanCount = countLabel(orphanTranscriptPaths.length, "orphan transcript file");
-      const orphanPreview = formatFilePreview(orphanTranscriptPaths);
-      warnings.push(
-        [
-          `- Found ${orphanCount} in ${displaySessionsDir}.`,
-          "  These .jsonl files are no longer referenced by sessions.json, so they are not part of any active session history.",
-          "  Doctor can archive them safely by renaming each file to *.deleted.<timestamp>.",
-          `  Examples: ${orphanPreview}`,
-        ].join("\n"),
-      );
-      const archiveOrphans = await prompter.confirmRuntimeRepair({
-        message: `Archive ${orphanCount} in ${displaySessionsDir}? This only renames them to *.deleted.<timestamp>.`,
-        initialValue: false,
-        requiresInteractiveConfirmation: true,
+    const sessionPathOpts = resolveSessionFilePathOptions({ agentId, storePath });
+    await noteMainSessionRecoveryIntegrity({
+      storePath: absoluteStorePath,
+      wedged: mainRecoveryWedged,
+      warnings,
+      changes,
+      confirmRepair: (params) => prompter.confirmRuntimeRepair(params),
+      countLabel,
+    });
+    if (mergedEntryCount > 0) {
+      const recentTranscriptCandidates = recent
+        .map(({ entry, sessionKey }) => [sessionKey, entry] as const)
+        .filter(([key]) => !isSlashRoutingSessionKey(key));
+      const missing = recentTranscriptCandidates.filter(([key, entry]) => {
+        if (sqliteSessionKeys.has(key)) {
+          return false;
+        }
+        const sessionId = entry.sessionId;
+        if (!sessionId) {
+          return false;
+        }
+        const legacySessionFile = (entry as SessionEntry & { sessionFile?: string }).sessionFile;
+        if (parseSqliteSessionFileMarker(legacySessionFile)) {
+          return false;
+        }
+        const transcriptPath = resolveSessionFilePathCore(sessionId, entry, sessionPathOpts);
+        return !existsFile(transcriptPath);
       });
-      if (archiveOrphans) {
-        let archived = 0;
-        const archivedAt = formatSessionArchiveTimestamp();
-        for (const orphanPath of orphanTranscriptPaths) {
-          const archivedPath = `${orphanPath}.deleted.${archivedAt}`;
-          try {
-            fs.renameSync(orphanPath, archivedPath);
-            archived += 1;
-          } catch (err) {
-            warnings.push(
-              `- Failed to archive orphan transcript ${shortenHomePath(orphanPath)}: ${String(err)}`,
+      if (missing.length > 0) {
+        warnings.push(
+          [
+            `- ${missing.length}/${recentTranscriptCandidates.length} recent sessions are missing transcripts.`,
+            `  Verify sessions in store: ${formatCliCommand(`openclaw sessions --store "${sqliteStorePath}"`)}`,
+            `  Preview cleanup impact: ${formatCliCommand(`openclaw sessions cleanup --store "${sqliteStorePath}" --dry-run --fix-missing`)}`,
+            `  Prune missing entries: ${formatCliCommand(`openclaw sessions cleanup --store "${sqliteStorePath}" --enforce --fix-missing`)}`,
+          ].join("\n"),
+        );
+      }
+
+      if (wedgedSubagentSessions.length > 0) {
+        const wedgedCount = countLabel(wedgedSubagentSessions.length, "wedged subagent session");
+        warnings.push(
+          [
+            `- Found ${wedgedCount} with automatic restart recovery tombstoned.`,
+            "  OpenClaw will not auto-resume these child sessions on restart; reconcile their task records instead.",
+            `  Examples: ${wedgedSubagentSessions
+              .slice(0, 3)
+              .map(({ key }) => key)
+              .join(", ")}`,
+            `  Fix: ${formatCliCommand("openclaw tasks maintenance --apply")}`,
+          ].join("\n"),
+        );
+        const repairWedged = await prompter.confirmRuntimeRepair({
+          message: `Clear stale aborted recovery flags for ${wedgedCount}?`,
+          initialValue: true,
+        });
+        if (repairWedged) {
+          let repaired = 0;
+          const repairedAt = Date.now();
+          const sqliteKeys = wedgedSubagentSessions
+            .map(({ key }) => key)
+            .filter((key) => sqliteSessionKeys.has(key));
+          for (const sessionKeys of iterateDoctorSessionKeyBatches(sqliteKeys)) {
+            repaired += await applySessionEntryReplacements<number>({
+              sessionKeys,
+              storePath: absoluteStorePath,
+              update: (currentEntries) => {
+                const replacements = currentEntries.flatMap(({ entry, sessionKey }) =>
+                  clearWedgedSubagentRecoveryAbort(entry, repairedAt)
+                    ? [{ entry, sessionKey }]
+                    : [],
+                );
+                return { replacements, result: replacements.length };
+              },
+            });
+          }
+          const legacyKeys = wedgedSubagentSessions
+            .map(({ key }) => key)
+            .filter((key) => !sqliteSessionKeys.has(key));
+          if (legacyKeys.length > 0 && existsFile(absoluteStorePath)) {
+            await updateLegacySessionStore(absoluteStorePath, (currentStore) => {
+              for (const key of legacyKeys) {
+                const current = currentStore[key];
+                if (current && clearWedgedSubagentRecoveryAbort(current, repairedAt)) {
+                  repaired += 1;
+                  currentStore[key] = current;
+                }
+              }
+            });
+          }
+          if (repaired > 0) {
+            changes.push(
+              `- Cleared aborted restart-recovery flags for ${countLabel(
+                repaired,
+                "wedged subagent session",
+              )}.`,
             );
           }
         }
-        if (archived > 0) {
-          changes.push(
-            `- Archived ${countLabel(archived, "orphan transcript file")} in ${displaySessionsDir} as .deleted timestamped backups.`,
+
+        const wedgedReasons = wedgedSubagentSessions.map(({ reason }) => reason);
+        const visibleWedgedReasons = uniqueStrings(wedgedReasons).slice(0, 2);
+        if (visibleWedgedReasons.length > 0) {
+          warnings.push(visibleWedgedReasons.map((reason) => `  Reason: ${reason}`).join("\n"));
+        }
+      }
+
+      await runPluginSessionStateDoctorRepairs({
+        scan: pluginStateScanner.result(),
+        absoluteStorePath,
+        prompter,
+        warnings,
+        changes,
+      });
+
+      const heartbeatMainMoved = await repairHeartbeatPoisonedMainSession({
+        mainKey,
+        mainEntry,
+        isSessionKeyOccupied,
+        absoluteStorePath,
+        stateDir,
+        sessionPathOpts,
+        prompter,
+        warnings,
+        changes,
+      });
+
+      // SQLite-owned transcripts live in the agent DB after import.
+      // Do not require the archived legacy JSONL for those sessions.
+      if (!heartbeatMainMoved && mainEntry?.sessionId && !sqliteSessionKeys.has(mainKey)) {
+        const transcriptPath = resolveSessionFilePathCore(
+          mainEntry.sessionId,
+          mainEntry,
+          sessionPathOpts,
+        );
+        if (!existsFile(transcriptPath)) {
+          warnings.push(
+            `- Main session transcript missing (${shortenHomePath(transcriptPath)}). History will appear to reset.`,
           );
+        } else {
+          const lineCount = countJsonlLines(transcriptPath);
+          if (lineCount <= 1) {
+            warnings.push(
+              `- Main session transcript has only ${lineCount} line. Session history may not be appending.`,
+            );
+          }
         }
       }
     }
+
+    // SQLite transcript ownership is repaired by the import/migration workflow.
+    // Never offer generic file archival against a live canonical session store.
+    if (sqliteEntryCount === 0 && inspectLegacyStore && existsDir(sessionsDir)) {
+      const referencedTranscriptPaths = new Set<string>();
+      for (const [, entry] of legacyEntries) {
+        if (!entry?.sessionId) {
+          continue;
+        }
+        try {
+          referencedTranscriptPaths.add(
+            resolveComparableTranscriptPath(
+              resolveSessionFilePathCore(entry.sessionId, entry, sessionPathOpts),
+            ),
+          );
+        } catch {
+          // ignore invalid legacy paths
+        }
+      }
+      const sessionDirEntries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+      const orphanTranscriptPaths = sessionDirEntries
+        .filter((entry) => entry.isFile() && isPrimarySessionTranscriptFileName(entry.name))
+        .map((entry) => path.join(sessionsDir, entry.name))
+        .filter(
+          (filePath) => !referencedTranscriptPaths.has(resolveComparableTranscriptPath(filePath)),
+        );
+      if (orphanTranscriptPaths.length > 0) {
+        const orphanCount = countLabel(orphanTranscriptPaths.length, "orphan transcript file");
+        const orphanPreview = formatFilePreview(orphanTranscriptPaths);
+        warnings.push(
+          [
+            `- Found ${orphanCount} in ${displaySessionsDir}.`,
+            "  These .jsonl files are no longer referenced by sessions.json, so they are not part of any active session history.",
+            "  Doctor can archive them safely by renaming each file to *.deleted.<timestamp>.",
+            `  Examples: ${orphanPreview}`,
+          ].join("\n"),
+        );
+        const archiveOrphans = await prompter.confirmRuntimeRepair({
+          message: `Archive ${orphanCount} in ${displaySessionsDir}? This only renames them to *.deleted.<timestamp>.`,
+          initialValue: false,
+          requiresInteractiveConfirmation: true,
+        });
+        if (archiveOrphans) {
+          let archived = 0;
+          const archivedAt = formatSessionArchiveTimestamp();
+          for (const orphanPath of orphanTranscriptPaths) {
+            const archivedPath = `${orphanPath}.deleted.${archivedAt}`;
+            try {
+              fs.renameSync(orphanPath, archivedPath);
+              archived += 1;
+            } catch (err) {
+              warnings.push(
+                `- Failed to archive orphan transcript ${shortenHomePath(orphanPath)}: ${String(err)}`,
+              );
+            }
+          }
+          if (archived > 0) {
+            changes.push(
+              `- Archived ${countLabel(archived, "orphan transcript file")} in ${displaySessionsDir} as .deleted timestamped backups.`,
+            );
+          }
+        }
+      }
+    }
+  };
+
+  // A fixed store can map to several agent-owned SQLite targets but only one legacy JSON file.
+  // Scan that file once under the compatibility owner so full-store work is not repeated.
+  const inspectedLegacyStores = new Set<string>();
+  for (const target of sessionTargets) {
+    const legacyStorePath = path.resolve(target.storePath);
+    await inspectAgentSessionIntegrity(target, !inspectedLegacyStores.has(legacyStorePath));
+    inspectedLegacyStores.add(legacyStorePath);
+  }
+  for (const warning of describeHeartbeatSessionTargetIssues(cfg)) {
+    warnings.push(warning);
   }
 
   if (warnings.length > 0) {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -1324,6 +1324,8 @@ export async function noteStateIntegrity(
 
     const sqliteStorePath = resolveSqliteTargetFromSessionStorePath(absoluteStorePath, {
       agentId,
+      defaultAgentId: compatibilityAgentId,
+      env,
     }).path;
     // A successful SQLite import archives sessions.json. Its continued presence
     // is therefore the explicit signal that pre-import rows still need inspection.
@@ -1375,7 +1377,7 @@ export async function noteStateIntegrity(
       }
     };
     const sqliteEntryCount = scanDoctorSessionEntriesStrict(
-      { agentId, storePath: absoluteStorePath },
+      { agentId, storePath: sqliteStorePath },
       ({ entry, sessionKey }) => {
         sqliteSessionKeys.add(sessionKey);
         const order = legacyOrder.get(sessionKey) ?? legacyEntries.length + sqliteNewKeyIndex++;
@@ -1396,7 +1398,7 @@ export async function noteStateIntegrity(
     }
     const sessionPathOpts = resolveSessionFilePathOptions({ agentId, storePath });
     await noteMainSessionRecoveryIntegrity({
-      storePath: absoluteStorePath,
+      storePath: sqliteStorePath,
       wedged: mainRecoveryWedged,
       warnings,
       changes,
@@ -1458,8 +1460,9 @@ export async function noteStateIntegrity(
             .filter((key) => sqliteSessionKeys.has(key));
           for (const sessionKeys of iterateDoctorSessionKeyBatches(sqliteKeys)) {
             repaired += await applySessionEntryReplacements<number>({
+              agentId,
               sessionKeys,
-              storePath: absoluteStorePath,
+              storePath: sqliteStorePath,
               update: (currentEntries) => {
                 const replacements = currentEntries.flatMap(({ entry, sessionKey }) =>
                   clearWedgedSubagentRecoveryAbort(entry, repairedAt)

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -1516,7 +1516,9 @@ export async function noteStateIntegrity(
         mainKey,
         mainEntry,
         isSessionKeyOccupied,
-        absoluteStorePath,
+        store: sqliteSessionKeys.has(mainKey)
+          ? { kind: "sqlite", agentId, path: sqliteStorePath }
+          : { kind: "legacy", path: absoluteStorePath },
         stateDir,
         sessionPathOpts,
         prompter,

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -1348,8 +1348,8 @@ export async function noteStateIntegrity(
     });
     const mainRecoveryWedged: MainSessionRecoveryIntegrityCandidate[] = [];
     const wedgedSubagentSessions: Array<{ key: string; reason: string }> = [];
-    const sqlitePluginStateScanner = createPluginSessionStateDoctorScanner({ cfg, env });
-    const legacyPluginStateScanner = createPluginSessionStateDoctorScanner({ cfg, env });
+    const sqlitePluginStateScanner = createPluginSessionStateDoctorScanner({ agentId, cfg, env });
+    const legacyPluginStateScanner = createPluginSessionStateDoctorScanner({ agentId, cfg, env });
     let mainEntry: SessionEntry | undefined;
     let sqliteNewKeyIndex = 0;
     const recent: Array<{ entry: SessionEntry; order: number; sessionKey: string }> = [];

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -42,6 +42,7 @@ import {
 import {
   applySessionEntryReplacements,
   iterateDoctorSessionKeyBatches,
+  loadExactSessionEntryReadOnly,
   scanDoctorSessionEntriesStrict,
 } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
@@ -1520,6 +1521,13 @@ export async function noteStateIntegrity(
         warnings,
         changes,
       });
+      if (sqliteSessionKeys.has(mainKey)) {
+        mainEntry = loadExactSessionEntryReadOnly({
+          agentId,
+          sessionKey: mainKey,
+          storePath: sqliteStorePath,
+        })?.entry;
+      }
 
       const heartbeatMainMoved = await repairHeartbeatPoisonedMainSession({
         mainKey,

--- a/src/config/sessions/session-accessor.lifecycle-types.ts
+++ b/src/config/sessions/session-accessor.lifecycle-types.ts
@@ -140,6 +140,8 @@ export class SessionEntryLifecycleUpsertConflictError extends Error {
 
 export type SessionEntryLifecycleUpsert = {
   sessionKey: string;
+  /** Apply this upsert only when the named removal was projected in the same mutation. */
+  requiresRemovalSessionKey?: string;
   /** Authoritative route observation for this write; omitted writes preserve valid evidence. */
   routeContext?: ConversationRouteContext | null;
   resetBoundary?: SessionResetBoundaryRequest;

--- a/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle-state.ts
@@ -376,6 +376,14 @@ export async function projectSessionEntryLifecycleMutation(
     if (!sessionKey) {
       continue;
     }
+    if (
+      upsert.requiresRemovalSessionKey &&
+      !projectedRemovals.some(
+        (removal) => removal.sessionKey === upsert.requiresRemovalSessionKey?.trim(),
+      )
+    ) {
+      continue;
+    }
     const expectedEntry = store[sessionKey] ? cloneSessionEntry(store[sessionKey]) : undefined;
     if (upsert.resetBoundary && !expectedEntry) {
       throw new Error(


### PR DESCRIPTION
## Summary

- Scan session and transcript integrity for every configured agent.
- Keep state, OAuth, permission, and filesystem-wide checks outside the agent loop.
- Deduplicate physical SQLite targets and scan fixed legacy stores once.

Closes #130742

## Problem

Doctor selected one default agent before entering its session-store scan. Non-default agent stores were invisible. On current main, canonical roster migration broadens the omission: a two-agent roster has no retained raw default marker, so State integrity skips both stores.

## Root cause

The global State integrity checks and the agent-owned session scan shared one function scope. The scan inherited one `tryResolveDefaultAgentId()` result instead of using the canonical all-agent session-store resolver.

## Fix

The global checks still run once. The agent-owned scan now consumes `resolveSessionStoreTargets(..., { allAgents: true })`, uses an explicit per-agent main key, deduplicates physical SQLite targets, and reads a fixed legacy JSON store once under its compatibility owner.

## Maintainer decision

Ayaan explicitly approved extending these existing guarded Doctor repairs to every configured agent store. He directed squash merge only after every landing gate passes.

## Proof

- Red on `baa3c3e6846`: the real `openclaw doctor --non-interactive` CLI skipped session and transcript integrity for a two-agent roster with real missing and orphan transcript state in both stores.
- Green on exact head `7509db999957`: the same real CLI reported one missing transcript and one orphan transcript for each agent.
- Anti-cheat on exact head `7509db999957`: with the default agent healthy and the only missing and orphan state under the non-default agent, Doctor reported only that non-default store.
- Global proof: state permissions, config permissions, OAuth directory, and multiple-state-directory warnings each appeared once.

Redacted exact-head output:

```text
State integrity
- 1/2 recent sessions are missing transcripts.
  Verify sessions in store: openclaw sessions --store "<state>/agents/alpha/agent/openclaw-agent.sqlite"
- Found 1 orphan transcript file in <state>/agents/alpha/sessions.
  Examples: orphan-alpha.jsonl
- 1/2 recent sessions are missing transcripts.
  Verify sessions in store: openclaw sessions --store "<state>/agents/beta/agent/openclaw-agent.sqlite"
- Found 1 orphan transcript file in <state>/agents/beta/sessions.
  Examples: orphan-beta.jsonl
```

Redacted anti-cheat output:

```text
State integrity
- 1/2 recent sessions are missing transcripts.
  Verify sessions in store: openclaw sessions --store "<state>/agents/beta/agent/openclaw-agent.sqlite"
- Found 1 orphan transcript file in <state>/agents/beta/sessions.
  Examples: orphan-beta.jsonl
```

Canonical repair proof on exact head `e0f28f6d68cc`:

```text
Before: {"legacyStoreExists":false,"modelOverride":"gpt-5.4","modelProvider":"openai-codex","providerOverride":"openai-codex","sessionId":"stale-plugin-route-beta"}
Doctor: Found stale Codex session routing state in 1 session.
Doctor changes: Cleared stale Codex session routing state for 1 session.
After: {"legacyStoreExists":false,"modelOverride":null,"modelProvider":null,"providerOverride":null,"sessionId":"stale-plugin-route-beta"}
```

## Tests

- `node scripts/run-vitest.mjs src/commands/doctor-state-integrity.transcripts.test.ts src/commands/doctor-state-integrity.test.ts`
- Fixed-store regression: 1 test failed on prior head `29542fd6331`.
- SQLite heartbeat regression: 1 test failed on prior head `6f5bbdacea7`.
- Combined repair regression: plugin cleanup plus heartbeat recovery leaves one cleared recovered row and no original row.
- Concurrent-update regression: a changed main row produces no recovery copy.
- Focused Doctor suites: 53 tests pass on `7509db999957`.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json <changed files>`
- `oxfmt --check <changed files>`
- Hosted CI owns type checking and the full changed-path gate.

## Upstream contract

Codex keeps its own rollouts under `CODEX_HOME/sessions` as JSONL files and rejects resume before a rollout exists. This repair does not change Codex protocol or persistence behavior.
