### PR TITLE
fix(installer): avoid restarting the gateway twice after source installs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3596,15 +3596,9 @@ refresh_gateway_service_if_loaded() {
         return 0
     fi
 
-    if run_quiet_step "Restarting gateway service" "$claw" gateway restart; then
-        ui_success "Gateway service restarted"
-    else
-        local user_claw
-        user_claw="$(openclaw_command_for_user "$claw")"
-        ui_warn "Gateway service restart failed; continuing. Run: ${user_claw} gateway restart"
-        return 0
-    fi
-
+    # `gateway install --force` activates the replacement service. Keep the
+    # explicit lifecycle restart in the finalization phase so doctor/plugin
+    # changes can still be applied without restarting twice here.
     run_quiet_step "Probing gateway service" "$claw" gateway status --deep || true
 }
 

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3359,7 +3359,7 @@ EOF
         is_gateway_daemon_loaded() { return 0; }
         run_quiet_step() {
           case "$1" in
-            "Restarting gateway service"|"Checking gateway service") return 1 ;;
+            "Checking gateway service") return 1 ;;
             *) return 0 ;;
           esac
         }
@@ -3372,8 +3372,42 @@ EOF
 
     const quotedBin = openclawBin.replace(/ /g, "\\ ");
     expect(result?.status).toBe(0);
-    expect(result?.stdout).toContain(`Run: ${quotedBin} gateway restart`);
+    expect(result?.stdout).not.toContain(`Run: ${quotedBin} gateway restart`);
     expect(result?.stdout).toContain(`Run: ${quotedBin} gateway status --deep`);
+  });
+
+  it("does not explicitly restart after force-installing a loaded gateway", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-gateway-transition-"));
+    const openclawBin = join(tmp, "openclaw");
+    const commandLog = join(tmp, "commands.log");
+    writeFileSync(openclawBin, '#!/bin/sh\nprintf "%s\\n" "$*" >> "$COMMAND_LOG"\n');
+    chmodSync(openclawBin, 0o755);
+
+    try {
+      const result = runInstallShell(
+        `
+          set -euo pipefail
+          source "${SCRIPT_PATH}"
+          OPENCLAW_BIN=${JSON.stringify(openclawBin)}
+          is_gateway_daemon_loaded() { return 0; }
+          run_quiet_step() {
+            local title="$1"
+            shift
+            "$@"
+          }
+          refresh_gateway_service_if_loaded
+        `,
+        { COMMAND_LOG: commandLog },
+      );
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(readFileSync(commandLog, "utf8").trim().split("\n")).toEqual([
+        "gateway install --force",
+        "gateway status --deep",
+      ]);
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
   });
 
   it("refreshes the shell command cache after loading a persisted PATH update", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users installing OpenClaw from a Git checkout on macOS or Linux restart an already activated Gateway service twice during one source install, adding avoidable downtime and lifecycle noise.

Related: #130919

## Why This Change Was Made

The source installer now lets `gateway install --force` own the activation transition and retains the later restart only when doctor or plugin finalization requires it. The final health check and existing failure handling remain unchanged; the Windows PowerShell flow is outside this PR.

AI-assisted disclosure: This PR was prepared with Codex. I reviewed and understand the change; the prompt and session context are available in the authoring conversation.

## User Impact

Source installs perform one fewer redundant Gateway restart while preserving service activation, post-doctor finalization, and final health verification. There is no change to package installation or update semantics.

## Evidence

- `pnpm test -- test/scripts/install-sh.test.ts`
- `bash -n scripts/install.sh`
- `git diff --check`
- ClawSweeper requested a real macOS/Linux after-fix transcript; the exact-head external transcript is recorded below.
- No merge or deployment has been performed.

## Maintainer validation (2026-08-27)

- Exact head: a66f6adce310b4f96f89ebabc2b816bf5ddc2739.
- Secretless exact-head Linux proof: https://github.com/jason-allen-oneal/openclaw/actions/runs/33105851807
- The real scripts/install.sh entrypoint ran twice from an isolated local Git source. The first install created and loaded a real systemd user gateway service; the second install exercised the loaded-service transition.
- Transcript: service-loaded=true; Refreshing loaded gateway service; Gateway service metadata refreshed; Gateway daemon detected; restarting; Gateway restarted; refresh=verified; finalization=verified; final-health=verified.
- The final deep gateway health check reported the systemd user service enabled, runtime running, and connectivity probe ok.
- No unrelated CI or test jobs were rerun; failures already matching the main baseline remain untouched.