### PR TITLE
fix(auto-reply): clarify unaddressed ambient room events

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -332,7 +332,7 @@ function createGatewayDrainingError(): Error {
 }
 
 const ROOM_EVENT_MESSAGE_TOOL_DIRECTIVE =
-  "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way.";
+  "Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking. To respond visibly, use message(action=send); your final text here stays private either way.";
 
 function createInboundBody<T extends string>(body: T) {
   return { Body: body, RawBody: body, CommandBody: body };
@@ -3753,9 +3753,12 @@ describe("runPreparedReply media-only handling", () => {
       expect(heartbeatRun.sourceReplyDeliveryMode).toBe(stableMode);
       expect(roomEventRun.extraSystemPrompt).toBe(expectedPrompt);
       expect(requireRunReplyAgentCall(0).followupRun.currentInboundContext?.text).toContain(
-        "your final text here stays private either way",
+        "You were not explicitly tagged or mentioned in this room event",
       );
       expect(roomEventRun.extraSystemPromptStatic).toBe(expectedPrompt);
+      expect(roomEventRun.extraSystemPromptStatic).not.toContain(
+        "You were not explicitly tagged or mentioned in this room event",
+      );
       expect(primaryRun.extraSystemPromptStatic).toBe(roomEventRun.extraSystemPromptStatic);
       expect(heartbeatRun.extraSystemPromptStatic).toBe(roomEventRun.extraSystemPromptStatic);
       expect(roomEventRun.cliSessionBindingFacts).toEqual({

--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -174,7 +174,7 @@ describe("buildReplyPromptEnvelope", () => {
           "#35674 Other: I wish I could enjoy 5.5",
           "#35675 User ->#35674: Are you fr fr",
         ].join("\n"),
-        "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way.",
+        "Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking. To respond visibly, use message(action=send); your final text here stays private either way.",
       ].join("\n\n"),
     );
     // Each room-event fact appears exactly once per request: kind lives in the
@@ -191,7 +191,7 @@ describe("buildReplyPromptEnvelope", () => {
           JSON.stringify({ message_id: "35676", inbound_event_kind: "room_event" }, null, 2),
           "```",
         ].join("\n"),
-        "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way.",
+        "Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking. To respond visibly, use message(action=send); your final text here stays private either way.",
       ].join("\n\n"),
     );
     expect(envelope.currentInboundContext?.resumableText).not.toContain(
@@ -256,7 +256,7 @@ describe("buildReplyPromptEnvelope", () => {
     expect(envelope.currentInboundContext?.text).toContain("Alice: old context");
     expect(envelope.queuedBody).toBe("#2002 Bob: current note");
     expect(envelope.currentInboundContext?.text).toContain(
-      "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Reply only when you are directly addressed or have concrete value to add.",
+      "Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking.",
     );
     expect(envelope.currentInboundContext?.text).not.toContain("message(action=send)");
     expect(envelope.currentInboundContext?.text).not.toContain(

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -13,6 +13,8 @@ import type { MsgContext, TemplateContext } from "../templating.js";
 import { appendChannelPromptContext } from "./channel-prompt-context.js";
 
 const ROOM_EVENT_PROMPT = "[OpenClaw room event]";
+const ROOM_EVENT_PARTICIPATION_RULE =
+  "Treat this message as observed room activity, not a request. You were not explicitly tagged or mentioned in this room event. Default: stay silent. Only respond if you have something useful, substantial, or important to add. A previous mention or reply is not an invitation to keep talking.";
 const RESUMABLE_ROOM_CONTEXT_OMITTED_PREFIXES = [
   "Conversation context (chronological, selected for current message):",
   "Chat history since last reply:",
@@ -154,8 +156,8 @@ function resolvePerTurnDeliveryDirective(params: {
 }): string | undefined {
   if (params.inboundEventKind === "room_event") {
     return params.sourceReplyDeliveryMode === "message_tool_only"
-      ? "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Send a visible reply via message(action=send) only when you are directly addressed or have concrete value to add; your final text here stays private either way."
-      : "Treat the current message as observed room activity. Default: no reply; most room events need no response from you. Reply only when you are directly addressed or have concrete value to add.";
+      ? `${ROOM_EVENT_PARTICIPATION_RULE} To respond visibly, use message(action=send); your final text here stays private either way.`
+      : ROOM_EVENT_PARTICIPATION_RULE;
   }
   if (
     params.inboundEventKind === "user_request" &&


### PR DESCRIPTION
## What Problem This Solves

Ambient group rooms correctly submit unmentioned chatter as `room_event`, but the per-turn instruction still let the model reply whenever it believed it had "concrete value." One addressed exchange made the topic salient, so the model rationalized several later room events as separate chances to speak.

## Root Cause

The live HamVerBot trace showed the envelope and queue were correct:

- `requireMention` remained disabled and `unmentionedInbound` remained `room_event`.
- The session had no activation override.
- Later unaddressed messages stayed room events through queued follow-up execution.
- Every unwanted visible reply came from an explicit `message(action=send)` call.

The missing fact was proximal: each room-event decision did not state plainly that the current message had not addressed the agent. The older "concrete value" wording was too easy to interpret broadly during an active discussion.

## Fix

Every room event now says:

- the current message is observed room activity, not a request;
- the agent was not explicitly tagged or mentioned;
- silence is the default;
- visible participation requires useful, substantial, or important information;
- an earlier mention or reply is not an invitation to keep talking.

The existing message-tool-only delivery rule stays unchanged. Mentioned messages, replies to the bot, commands, ambient observation, queueing, and history remain unchanged.

## Evidence

- Before: the live HamVerBot session produced three unsolicited replies within about 50 seconds, plus a fourth attempted send.
- Focused prompt and queued-room-event tests: 136 passed.
- Prompt-cache and provider-prefix regressions: 18 passed.
- Cache contract: the new rule stays in `currentInboundContext`; `extraSystemPromptStatic` and CLI session binding facts remain byte-stable across room events, normal turns, and heartbeats.
- Prompt snapshot check: current.
- Production delta: +4/-2. Tests: +8/-5.
- Exact-head Linux build: `d6f970961e21982bc4259590217e531b0ba77ef2` on [Testbox run 33074899473](https://github.com/openclaw/openclaw/actions/runs/33074899473).
- Telegram Test Server, real `claude-sonnet-4-6`: `requireMention=false`, `unmentionedInbound=room_event`, and `visibleReplies=message_tool`.
- Timeline: one addressed turn produced `ACK_6271`; three later unmentioned messages each reached the CLI backend; no Telegram bot message appeared after those room events.
- Anti-cheat: four completed Telegram user sends, four real Claude turns, one persistent bot reply, and the reply completed before the first unmentioned message.

Related: #121914
