### PR TITLE
fix(plugins): report registerFull routes in runtime inspection

### DIFF
--- a/src/cli/plugins-cli.inspect.test.ts
+++ b/src/cli/plugins-cli.inspect.test.ts
@@ -188,6 +188,7 @@ describe("plugins cli inspect", () => {
       expect(buildPluginDiagnosticsReportMock).toHaveBeenLastCalledWith({
         config: {},
         onlyPluginIds: ["openclaw-mem0"],
+        runtimeInspection: true,
       });
       expect(pluginsCliRuntimeLogs.at(-1)).toContain("Gateway discovery:\nmem0-runtime-discovery");
     }

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -140,6 +140,11 @@ export async function runPluginsInspectCommand(
   );
   const loggerParams = opts.json ? { logger: quietPluginJsonLogger } : {};
   const runtimeInspect = opts.runtime === true;
+  const runtimeReportParams = {
+    config: cfg,
+    ...loggerParams,
+    runtimeInspection: true,
+  };
   if (opts.all) {
     if (id) {
       failPluginInspect("Pass either a plugin id or --all, not both.", opts.json);
@@ -148,11 +153,7 @@ export async function runPluginsInspectCommand(
     const report = runtimeInspect
       ? tracePluginLifecyclePhase(
           "runtime plugin registry load",
-          () =>
-            buildPluginDiagnosticsReport({
-              config: cfg,
-              ...loggerParams,
-            }),
+          () => buildPluginDiagnosticsReport(runtimeReportParams),
           { command: "inspect", all: true },
         )
       : tracePluginLifecyclePhase(
@@ -271,8 +272,7 @@ export async function runPluginsInspectCommand(
         "runtime plugin registry load",
         () =>
           buildPluginDiagnosticsReport({
-            config: cfg,
-            ...loggerParams,
+            ...runtimeReportParams,
             onlyPluginIds: [targetPlugin.id],
           }),
         { command: "inspect", pluginId: targetPlugin.id },

--- a/src/plugins/status.runtime-inspection.test.ts
+++ b/src/plugins/status.runtime-inspection.test.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { withEnv } from "../test-utils/env.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  makePluginLoaderTempDir,
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+import { buildPluginDiagnosticsReport } from "./status.js";
+
+describe("plugin runtime inspection", () => {
+  afterEach(() => {
+    resetPluginLoaderTestStateForTest();
+  });
+
+  afterAll(() => {
+    cleanupPluginLoaderFixturesForTest();
+  });
+
+  it("captures full registrations through the non-activating inspection mode", () => {
+    const pluginDir = makePluginLoaderTempDir();
+    const registrationModePath = path.join(pluginDir, "registration-mode.txt");
+    const plugin = writePlugin({
+      id: "runtime-inspection-route",
+      dir: pluginDir,
+      body: `module.exports = {
+  id: "runtime-inspection-route",
+  register(api) {
+    require("node:fs").writeFileSync(
+      ${JSON.stringify(registrationModePath)},
+      api.registrationMode,
+      "utf8",
+    );
+    if (api.registrationMode === "tool-discovery") {
+      api.registerHttpRoute({
+        path: "/runtime-inspection",
+        auth: "plugin",
+        handler() { return true; },
+      });
+    }
+  },
+};\n`,
+    });
+    const stateDir = makePluginLoaderTempDir();
+    const config = {
+      plugins: {
+        load: { paths: [plugin.file] },
+        allow: [plugin.id],
+      },
+    };
+
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      useNoBundledPlugins();
+      const params = { config, workspaceDir: plugin.dir, env: process.env };
+
+      const diagnostics = buildPluginDiagnosticsReport(params);
+      expect(diagnostics.plugins.find((entry) => entry.id === plugin.id)?.httpRoutes).toBe(0);
+      expect(fs.readFileSync(registrationModePath, "utf8")).toBe("discovery");
+
+      const runtimeInspectionParams = { ...params, runtimeInspection: true };
+      const runtimeInspection = buildPluginDiagnosticsReport(runtimeInspectionParams);
+      expect(runtimeInspection.plugins.find((entry) => entry.id === plugin.id)?.httpRoutes).toBe(1);
+      expect(fs.readFileSync(registrationModePath, "utf8")).toBe("tool-discovery");
+    });
+  });
+});

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -191,6 +191,8 @@ type PluginReportParams = {
   config?: OpenClawConfig;
   effectiveOnly?: boolean;
   onlyPluginIds?: readonly string[];
+  /** Capture full registrations without starting channel runtime sidecars. */
+  runtimeInspection?: boolean;
   workspaceDir?: string;
   /** Use an explicit env when plugin roots should resolve independently from process.env. */
   env?: NodeJS.ProcessEnv;
@@ -276,6 +278,7 @@ function buildPluginReport(
               loadModules,
               cache: false,
               onlyPluginIds,
+              toolDiscovery: params?.runtimeInspection,
             }),
           ),
         { surface: "status", onlyPluginCount: onlyPluginIds?.length },


### PR DESCRIPTION
Closes #130773

AI-assisted.

## What Problem This Solves

Fixes an issue where operators running `openclaw plugins inspect <id> --runtime --json` saw zero HTTP routes when a channel plugin registered its working webhook route from `registerFull`.

## Why This Change Was Made

Runtime inspection now uses the existing non-activating tool-discovery mode. This captures full plugin registrations while it keeps channel runtime sidecars stopped. Other status, doctor, hook, and plugin discovery paths keep their current lightweight behavior.

## User Impact

Operators can trust the runtime HTTP-route count when they verify an installed plugin. Normal plugin discovery does not activate extra channel runtime work.

## Evidence

- Live red on OpenClaw `06038f9df838948294bd3484dcb216834cef810c` with the public `@sprintcx/openclaw-cliq` plugin source at `cc4607fd1c2ea4a5f179b3250155956f585e753a`: runtime inspection reported `httpRouteCount: 0` while `GET /cliq/webhook` returned `405` with `Allow: POST` from the isolated Gateway.
- Live green on exact head `54adfe6d43dc2ebe7bc32b4f0a58726b48f51cce` with the same plugin and isolated Gateway flow: runtime inspection reported `httpRouteCount: 1`; `GET /cliq/webhook` still returned `405` with `Allow: POST` and `Method Not Allowed`; the owned Gateway stopped and the port closed after proof.
- The new owner-boundary regression failed before the production change with `expected 0 to be 1`.
- Focused tests pass: `node scripts/run-vitest.mjs src/plugins/status.runtime-inspection.test.ts src/cli/plugins-cli.inspect.test.ts src/plugins/status.test.ts src/plugins/loader.cli-metadata.test.ts src/plugin-sdk/core.test.ts src/plugin-sdk/channel-entry-contract.test.ts`. The Plugin SDK cases verify that tool discovery calls `registerFull` without calling `setRuntime` or loading the channel runtime sidecar.
- Focused format, Oxlint, max-lines, assertion-safety, import-cycle, runtime-sidecar, and plugin-boundary checks pass.
