### PR TITLE
refactor(agents): simplify serialized suspension writes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1995,7 +1995,7 @@ src/agents/session-dirs.ts	2
 src/agents/session-model-auto-revert.ts	1
 src/agents/session-placement-admission.ts	1
 src/agents/session-raw-append-message.ts	2
-src/agents/session-suspension.ts	2
+src/agents/session-suspension.ts	1
 src/agents/session-tool-result-guard.ts	26
 src/agents/session-transcript-repair.ts	15
 src/agents/sessions/agent-session-base.ts	3

--- a/src/agents/session-suspension.test.ts
+++ b/src/agents/session-suspension.test.ts
@@ -1,6 +1,8 @@
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 // Verifies quota suspension records recovery state without blocking shared work.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { QuotaSuspension } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { enqueueCommandInLane, getCommandLaneSnapshot } from "../process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../process/command-queue.test-support.js";
@@ -140,34 +142,109 @@ describe("session suspension", () => {
     );
   });
 
-  it("rolls back a write that finishes after gateway shutdown begins", async () => {
-    const { fenceSessionSuspensionWritesForGatewayShutdown } =
-      await import("./session-suspension.js");
-    let releaseWrite: (() => void) | undefined;
-    let storeEntry: { quotaSuspension?: { suspendedAt: number } } = {};
+  it.each([
+    {
+      name: "the previous marker",
+      previousQuotaSuspension: {
+        schemaVersion: 1,
+        suspendedAt: 100,
+        reason: "manual",
+        failedProvider: "previous-provider",
+        failedModel: "previous-model",
+        summary: "previous briefing",
+        snapshotRef: "previous-snapshot",
+        laneId: "previous-lane",
+        expectedResumeBy: 500,
+        state: "resuming",
+      } satisfies QuotaSuspension,
+    },
+    { name: "an absent marker", previousQuotaSuspension: undefined },
+  ])(
+    "restores $name when a committed write finishes after shutdown",
+    async ({ previousQuotaSuspension }) => {
+      const { fenceSessionSuspensionWritesForGatewayShutdown } =
+        await import("./session-suspension.js");
+      const committed = createDeferred();
+      const releaseWrite = createDeferred();
+      let storeEntry: { quotaSuspension?: QuotaSuspension } = {
+        quotaSuspension: previousQuotaSuspension,
+      };
+      let writeCount = 0;
+      sessionAccessorMocks.patchSessionEntryCore.mockImplementation(async (_scope, update) => {
+        writeCount += 1;
+        const patch = update(storeEntry) as typeof storeEntry | null;
+        if (patch && "quotaSuspension" in patch) {
+          storeEntry = patch.quotaSuspension ? { quotaSuspension: patch.quotaSuspension } : {};
+        }
+        if (writeCount === 1) {
+          committed.resolve();
+          await releaseWrite.promise;
+        }
+        return storeEntry;
+      });
+
+      const suspension = recordSuspension();
+      await committed.promise;
+      try {
+        expect(storeEntry.quotaSuspension).toMatchObject({
+          reason: "quota_exhausted",
+          failedProvider: "openai",
+          failedModel: "gpt-5.6-sol",
+          state: "suspended",
+        });
+        fenceSessionSuspensionWritesForGatewayShutdown();
+      } finally {
+        releaseWrite.resolve();
+        await suspension;
+      }
+
+      expect(storeEntry.quotaSuspension).toEqual(previousQuotaSuspension);
+      expect(sessionAccessorMocks.patchSessionEntryCore).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it("serializes same-session writes until the previous committed write returns", async () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const committed = createDeferred();
+    const releaseWrite = createDeferred();
+    let storeEntry: { quotaSuspension?: QuotaSuspension } = {};
     let writeCount = 0;
     sessionAccessorMocks.patchSessionEntryCore.mockImplementation(async (_scope, update) => {
       writeCount += 1;
-      if (writeCount === 1) {
-        await new Promise<void>((resolve) => {
-          releaseWrite = resolve;
-        });
-      }
       const patch = update(storeEntry) as typeof storeEntry | null;
-      if (patch && "quotaSuspension" in patch) {
-        storeEntry = patch.quotaSuspension ? { quotaSuspension: patch.quotaSuspension } : {};
+      if (patch) {
+        storeEntry = { ...storeEntry, ...patch };
+      }
+      if (writeCount === 1) {
+        committed.resolve();
+        await releaseWrite.promise;
       }
       return storeEntry;
     });
 
-    const suspension = recordSuspension();
-    await vi.waitFor(() => expect(releaseWrite).toBeTypeOf("function"));
-    fenceSessionSuspensionWritesForGatewayShutdown();
-    releaseWrite?.();
-    await suspension;
+    const first = recordSuspension();
+    await committed.promise;
+    clock.mockReturnValue(2_000);
+    const second = recordSuspension(200);
+    try {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(sessionAccessorMocks.patchSessionEntryCore).toHaveBeenCalledOnce();
+      expect(storeEntry.quotaSuspension?.suspendedAt).toBe(1_000);
+    } finally {
+      releaseWrite.resolve();
+      await Promise.all([first, second]);
+    }
 
-    expect(storeEntry.quotaSuspension).toBeUndefined();
     expect(sessionAccessorMocks.patchSessionEntryCore).toHaveBeenCalledTimes(2);
+    expect(storeEntry.quotaSuspension).toMatchObject({
+      suspendedAt: 2_000,
+      expectedResumeBy: 2_200,
+      failedProvider: "openai",
+      failedModel: "gpt-5.6-sol",
+      state: "suspended",
+    });
   });
 
   it("blocks new state writes until gateway startup re-enables them", async () => {

--- a/src/agents/session-suspension.ts
+++ b/src/agents/session-suspension.ts
@@ -22,59 +22,26 @@ const log = createSubsystemLogger("session-suspension");
 const DEFAULT_QUOTA_SUSPENSION_RESUME_MS = 30 * 60 * 1000; // 30 min
 
 type SessionSuspensionRuntimeState = {
-  pendingSuspensionWrites: Map<
-    string,
-    {
-      generation: number;
-      previousQuotaSuspension: QuotaSuspension | undefined;
-      previousSnapshotCaptured: boolean;
-      activeCount: number;
-    }
-  >;
   suspensionWriteChain: Promise<void>;
   cleanupGeneration: number;
   cleanupActive: boolean;
 };
 
 /**
- * Keep timer shutdown state process-global so bundled gateway chunks cannot
- * leave one module copy scheduling lane resumes after another copy cleaned up.
+ * Bundled gateway chunks share one write queue and shutdown fence so one
+ * module copy cannot persist a suspension after another copy cleaned up.
  */
 const SESSION_SUSPENSION_STATE_KEY = Symbol.for("openclaw.sessionSuspensionRuntimeState");
 
 function getSessionSuspensionState(): SessionSuspensionRuntimeState {
-  const state = resolveGlobalSingleton<SessionSuspensionRuntimeState>(
+  return resolveGlobalSingleton<SessionSuspensionRuntimeState>(
     SESSION_SUSPENSION_STATE_KEY,
     () => ({
-      pendingSuspensionWrites: new Map<
-        string,
-        {
-          generation: number;
-          previousQuotaSuspension: QuotaSuspension | undefined;
-          previousSnapshotCaptured: boolean;
-          activeCount: number;
-        }
-      >(),
       suspensionWriteChain: Promise.resolve(),
       cleanupGeneration: 0,
       cleanupActive: false,
     }),
   );
-  if (!state.pendingSuspensionWrites) {
-    state.pendingSuspensionWrites = new Map<
-      string,
-      {
-        generation: number;
-        previousQuotaSuspension: QuotaSuspension | undefined;
-        previousSnapshotCaptured: boolean;
-        activeCount: number;
-      }
-    >();
-  }
-  if (state.suspensionWriteChain === undefined) {
-    state.suspensionWriteChain = Promise.resolve();
-  }
-  return state;
 }
 
 const deferredSessionSuspension = new AsyncLocalStorage<{
@@ -181,28 +148,7 @@ async function suspendSessionQueued(params: SessionSuspensionParams, queuedGener
     return;
   }
   const suspensionGeneration = state.cleanupGeneration;
-  const pendingWriteKey = `${storePath}\0${sessionKey}`;
-  const existingPendingWrite = state.pendingSuspensionWrites.get(pendingWriteKey);
-  const pendingWrite =
-    existingPendingWrite?.generation === suspensionGeneration
-      ? existingPendingWrite
-      : {
-          generation: suspensionGeneration,
-          previousQuotaSuspension: undefined as QuotaSuspension | undefined,
-          previousSnapshotCaptured: false,
-          activeCount: 0,
-        };
-  pendingWrite.activeCount += 1;
-  state.pendingSuspensionWrites.set(pendingWriteKey, pendingWrite);
-  const releasePendingWrite = () => {
-    pendingWrite.activeCount -= 1;
-    if (
-      pendingWrite.activeCount <= 0 &&
-      getSessionSuspensionState().pendingSuspensionWrites.get(pendingWriteKey) === pendingWrite
-    ) {
-      getSessionSuspensionState().pendingSuspensionWrites.delete(pendingWriteKey);
-    }
-  };
+  let previousQuotaSuspension: QuotaSuspension | undefined;
   // Assigned at the end of the try; the catch path returns, so every read
   // below sees the real patch outcome.
   let persistedSuspension: boolean;
@@ -214,10 +160,7 @@ async function suspendSessionQueued(params: SessionSuspensionParams, queuedGener
         if (getSessionSuspensionState().cleanupGeneration !== suspensionGeneration) {
           return null;
         }
-        if (!pendingWrite.previousSnapshotCaptured) {
-          pendingWrite.previousQuotaSuspension = entry.quotaSuspension;
-          pendingWrite.previousSnapshotCaptured = true;
-        }
+        previousQuotaSuspension = entry.quotaSuspension;
         return {
           quotaSuspension: {
             schemaVersion: 1,
@@ -239,7 +182,6 @@ async function suspendSessionQueued(params: SessionSuspensionParams, queuedGener
       sessionId: params.sessionId,
       error: err instanceof Error ? err.message : String(err),
     });
-    releasePendingWrite();
     return;
   }
 
@@ -256,7 +198,7 @@ async function suspendSessionQueued(params: SessionSuspensionParams, queuedGener
           entry.quotaSuspension.reason === params.reason &&
           entry.quotaSuspension.failedProvider === params.failedProvider &&
           entry.quotaSuspension.failedModel === params.failedModel
-            ? { quotaSuspension: pendingWrite.previousQuotaSuspension }
+            ? { quotaSuspension: previousQuotaSuspension }
             : null,
         {
           skipMaintenance: true,
@@ -269,11 +211,7 @@ async function suspendSessionQueued(params: SessionSuspensionParams, queuedGener
         error: err instanceof Error ? err.message : String(err),
       });
     }
-    releasePendingWrite();
-    return;
   }
-
-  releasePendingWrite();
 }
 
 function resetSessionSuspensionStateForTest(): void {
@@ -281,7 +219,6 @@ function resetSessionSuspensionStateForTest(): void {
   // Invalidate in-flight writes before clearing test state. Rewinding to a
   // reused generation lets a fire-and-forget suspension regain ownership.
   state.cleanupGeneration += 1;
-  state.pendingSuspensionWrites.clear();
   state.suspensionWriteChain = Promise.resolve();
   state.cleanupActive = false;
 }


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested internal cleanup of session suspension persistence. The process-wide write queue already serializes suspension writes, but the owner also maintains a per-session map, reference counts, and snapshot-capture flags for concurrent writes that cannot occur within that queue.

## Why This Change Was Made

Keep the existing queue as the single serialization owner and capture the previous suspension marker in the queued operation's local scope. Remove the redundant map, its initialization/compatibility branches, and its release bookkeeping. The private singleton and its promise chain were introduced together; no older singleton shape or supported runtime upgrade requires the missing-chain fallback.

The generation fence, shutdown/startup behavior, rejected-write recovery, rollback identity predicate, deferred fallback behavior, and canonical SQLite accessor remain unchanged. No schema, configuration, public API, protocol, dependency, or persistence-semantic change is intended. The retained tests now exercise rollback after an actual commit and overlapping same-session requests.

## User Impact

No user-visible behavior change. Suspension persistence and Gateway shutdown retain the same behavior with fewer internal states to maintain.

Production: +6/-68, net -62. Private test-reset support: -1. Tests: +95/-18. The assertion ratchet only records one removed production assertion. AI-assisted with Codex.

## Evidence

- The strengthened 10-case suite passes on unchanged production before applying the cleanup.
- The final integrated cleanup passes 254 tests across session suspension, model fallback/probing, Gateway close, and Gateway startup lanes in pinned Linux Node 24.19.0 / Vitest 4.1.11. Earlier local results used shared Vitest 4.1.10 and remain supplementary.
- Twenty-four paired scenarios execute the complete original/candidate suspension owners against the current real SQLite accessor and session resolver. All 48 databases reopen read-only with matching persisted rows and successful integrity checks. This is owner-boundary proof with controlled scheduling and error injection, not a live Gateway or provider run.
- Negative controls for removing serialization and discarding the prior marker fail the strengthened tests as intended. The existing same-timestamp collision reachable through the private test reset remains unchanged; ordinary Gateway restart preserves the queue and does not take that reset path.
- Fresh independent precommit review completed with no actionable findings against the final complete patch and 29 whole context files. The actual review input, source, proof, and reviewer-isolation checks were independently audited. A separate published-head review and ordinary exact-head CI are still required before landing.
- Full canonical changed checks passed on the final source in [the pinned Linux environment](https://github.com/openclaw/openclaw/actions/runs/33056067381), including production types, all 14 serial core-test type graphs, full core/scripts lint, and dead-export/architecture guards. All 34,261 tracked input files retained their hashes. The evidence archive was collected and independently checked before removing the owned worktree and stopping the lease.

Local full changed checks passed the initial guards and all three dead-export scans, then stopped on demonstrably stale installed Google SDK, Markdown, and TUI dependencies. The shared install was preserved; the isolated pinned-environment run subsequently passed the complete gate.

The first pinned Linux run passed the 10-case baseline, 254 candidate tests, 24 paired SQLite scenarios, dead-export scans, and production typechecking. Blacksmith then cancelled the Testbox workflow; runner teardown killed the test-typecheck process. The GitHub audit event confirms provider-issued cancellation, not an observed code or out-of-memory failure. Its incomplete gate is not counted as passing.

The recovery passed all semantic core/test graphs and found two lint errors in the cleanup: a now-useless terminal return and a test Promise executor implicitly returning the timer handle. Both were corrected without changing scheduling or rollback behavior. The final source passed typed lint, all 254 tests, 24 paired SQLite scenarios, and the complete canonical gate on the same owned machine with verified dependencies and whole-source inventories, without resource or concurrency overrides. The failed attempts remain recorded separately. Collection was independently audited by reopening all 48 archived databases read-only and comparing every persisted row with the paired scenario results.
