### PR TITLE
fix(installer): avoid checking out the wrong Git ref during pinned installs

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1091,27 +1091,24 @@ checkout_git_openclaw_ref() {
       tag_probe_status=$?
     fi
 
-    if (( tag_probe_status == 2 )); then
+    if (( tag_probe_status == 0 )); then
+      if ! git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
+        fail "Could not fetch requested git tag: ${ref}"
+      fi
+      if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
+        git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
+        GIT_REF_KIND="immutable"
+        return 0
+      fi
+      if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+        git -C "$repo_dir" checkout --detach "$ref"
+        GIT_REF_KIND="immutable"
+        return 0
+      fi
       fail "Requested git version not found: ${ref}"
-    fi
-    if (( tag_probe_status != 0 )); then
+    elif (( tag_probe_status != 2 )); then
       fail "Could not resolve requested git tag: ${ref}"
     fi
-
-    if ! git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
-      fail "Could not fetch requested git tag: ${ref}"
-    fi
-    if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
-      git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
-      GIT_REF_KIND="immutable"
-      return 0
-    fi
-    if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
-      git -C "$repo_dir" checkout --detach "$ref"
-      GIT_REF_KIND="immutable"
-      return 0
-    fi
-    fail "Requested git version not found: ${ref}"
   fi
 
   if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -92,6 +92,7 @@ JSON=0
 RUN_ONBOARD=0
 SET_NPM_PREFIX=0
 PNPM_CMD=()
+GIT_REF_KIND=""
 FRESH_GIT_MIN_FREE_KIB=$((6 * 1024 * 1024))
 
 print_usage() {
@@ -1019,6 +1020,10 @@ resolve_git_openclaw_ref() {
 checkout_git_openclaw_ref() {
   local repo_dir="$1"
   local ref="$2"
+  local branch_probe_status=0
+  local tag_probe_status=0
+
+  GIT_REF_KIND=""
 
   if [[ -z "$ref" ]]; then
     return 0
@@ -1028,29 +1033,59 @@ checkout_git_openclaw_ref() {
     git -C "$repo_dir" fetch --no-tags origin main
     git -C "$repo_dir" checkout main
     if [[ "$GIT_UPDATE" == "1" ]]; then
-      git -C "$repo_dir" pull --rebase --no-tags || true
+      if ! git -C "$repo_dir" rebase origin/main; then
+        git -C "$repo_dir" rebase --abort >/dev/null 2>&1 || true
+        fail "Could not update repository from origin/main"
+      fi
     fi
+    GIT_REF_KIND="moving"
     return 0
   fi
 
   if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
     git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"
     git -C "$repo_dir" checkout -B "$ref" "origin/$ref"
-    if [[ "$GIT_UPDATE" == "1" ]]; then
-      git -C "$repo_dir" pull --rebase --no-tags || true
-    fi
+    GIT_REF_KIND="moving"
     return 0
+  else
+    branch_probe_status=$?
   fi
 
-  git -C "$repo_dir" fetch --tags origin
+  if (( branch_probe_status != 2 )); then
+    fail "Could not resolve requested git branch: ${ref}"
+  fi
+
+  if git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}" >/dev/null 2>&1; then
+    tag_probe_status=0
+  else
+    tag_probe_status=$?
+  fi
+
+  if (( tag_probe_status == 2 )); then
+    if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+      git -C "$repo_dir" checkout --detach "$ref"
+      GIT_REF_KIND="immutable"
+      return 0
+    fi
+    fail "Requested git version not found: ${ref}"
+  fi
+  if (( tag_probe_status != 0 )); then
+    fail "Could not resolve requested git tag: ${ref}"
+  fi
+
+  if ! git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
+    fail "Could not fetch requested git tag: ${ref}"
+  fi
 
   if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
     git -C "$repo_dir" checkout --detach "$ref"
+    GIT_REF_KIND="immutable"
     return 0
   fi
 
   if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
     git -C "$repo_dir" checkout --detach "$ref"
+    GIT_REF_KIND="immutable"
     return 0
   fi
 
@@ -1060,6 +1095,16 @@ checkout_git_openclaw_ref() {
 git_install_lockfile_flag() {
   local repo_dir="$1"
   local ref="$2"
+  local ref_kind="${3:-$GIT_REF_KIND}"
+
+  if [[ "$ref_kind" == "moving" ]]; then
+    echo "--no-frozen-lockfile"
+    return 0
+  fi
+  if [[ "$ref_kind" == "immutable" ]]; then
+    echo "--frozen-lockfile"
+    return 0
+  fi
 
   if [[ "$ref" == "main" ]] || git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
     echo "--no-frozen-lockfile"
@@ -1649,7 +1694,7 @@ install_openclaw_from_git() {
   activate_repo_pnpm_version "$repo_dir"
 
   local install_lockfile_flag
-  install_lockfile_flag="$(git_install_lockfile_flag "$repo_dir" "$git_ref")"
+  install_lockfile_flag="$(git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND")"
   emit_json step name dependencies status start
   CI="${CI:-true}" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"
   emit_json step name dependencies status ok

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1017,11 +1017,43 @@ resolve_git_openclaw_ref() {
   esac
 }
 
+verify_git_rebase_recovery() {
+  local repo_dir="$1"
+  local expected_head="$2"
+  local expected_status="$3"
+  local actual_head=""
+  local actual_status=""
+  local rebase_merge=""
+  local rebase_apply=""
+
+  if ! git -C "$repo_dir" rebase --abort >/dev/null 2>&1; then
+    return 1
+  fi
+  if ! actual_head="$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)"; then
+    return 1
+  fi
+  if ! actual_status="$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null)"; then
+    return 1
+  fi
+  if ! rebase_merge="$(git -C "$repo_dir" rev-parse --git-path rebase-merge 2>/dev/null)"; then
+    return 1
+  fi
+  if ! rebase_apply="$(git -C "$repo_dir" rev-parse --git-path rebase-apply 2>/dev/null)"; then
+    return 1
+  fi
+
+  [[ "$actual_head" == "$expected_head" ]] || return 1
+  [[ "$actual_status" == "$expected_status" ]] || return 1
+  [[ ! -d "$rebase_merge" && ! -d "$rebase_apply" ]]
+}
+
 checkout_git_openclaw_ref() {
   local repo_dir="$1"
   local ref="$2"
   local branch_probe_status=0
   local tag_probe_status=0
+  local original_head=""
+  local original_status=""
 
   GIT_REF_KIND=""
 
@@ -1033,9 +1065,17 @@ checkout_git_openclaw_ref() {
     git -C "$repo_dir" fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"
     git -C "$repo_dir" checkout main
     if [[ "$GIT_UPDATE" == "1" ]]; then
+      if ! original_head="$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)"; then
+        fail "Could not record repository state before updating from origin/main"
+      fi
+      if ! original_status="$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null)"; then
+        fail "Could not record repository state before updating from origin/main"
+      fi
       if ! git -C "$repo_dir" rebase origin/main; then
-        git -C "$repo_dir" rebase --abort >/dev/null 2>&1 || true
-        fail "Could not update repository from origin/main"
+        if verify_git_rebase_recovery "$repo_dir" "$original_head" "$original_status"; then
+          fail "Could not update repository from origin/main; the checkout was restored to its pre-update state"
+        fi
+        fail "Could not update repository from origin/main; checkout recovery was not verified. Run git -C \"$repo_dir\" rebase --abort and inspect the checkout before retrying"
       fi
     fi
     GIT_REF_KIND="moving"

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1078,7 +1078,7 @@ checkout_git_openclaw_ref() {
   fi
 
   if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
-    git -C "$repo_dir" checkout --detach "$ref"
+    git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
     GIT_REF_KIND="immutable"
     return 0
   fi

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1021,12 +1021,16 @@ verify_git_rebase_recovery() {
   local repo_dir="$1"
   local expected_head="$2"
   local expected_status="$3"
+  local git_dir
 
-  git -C "$repo_dir" rebase --abort >/dev/null 2>&1 &&
-    [[ "$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)" == "$expected_head" ]] &&
+  git_dir="$(git -C "$repo_dir" rev-parse --absolute-git-dir)" || return 1
+  if [[ -d "$git_dir/rebase-merge" || -d "$git_dir/rebase-apply" ]]; then
+    git -C "$repo_dir" rebase --abort >/dev/null 2>&1 || return 1
+  fi
+
+  [[ "$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)" == "$expected_head" ]] &&
     [[ "$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null)" == "$expected_status" ]] &&
-    [[ ! -d "$(git -C "$repo_dir" rev-parse --git-path rebase-merge)" ]] &&
-    [[ ! -d "$(git -C "$repo_dir" rev-parse --git-path rebase-apply)" ]]
+    [[ ! -d "$git_dir/rebase-merge" && ! -d "$git_dir/rebase-apply" ]]
 }
 
 checkout_git_openclaw_ref() {

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1030,7 +1030,7 @@ checkout_git_openclaw_ref() {
   fi
 
   if [[ "$ref" == "main" ]]; then
-    git -C "$repo_dir" fetch --no-tags origin main
+    git -C "$repo_dir" fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"
     git -C "$repo_dir" checkout main
     if [[ "$GIT_UPDATE" == "1" ]]; then
       if ! git -C "$repo_dir" rebase origin/main; then

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1082,6 +1082,38 @@ checkout_git_openclaw_ref() {
     return 0
   fi
 
+  # A normalized release selector names an immutable tag. Resolve that tag
+  # before looking for an arbitrary branch with the same short name.
+  if [[ "$ref" == v[0-9]* ]]; then
+    if git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}" >/dev/null 2>&1; then
+      tag_probe_status=0
+    else
+      tag_probe_status=$?
+    fi
+
+    if (( tag_probe_status == 2 )); then
+      fail "Requested git version not found: ${ref}"
+    fi
+    if (( tag_probe_status != 0 )); then
+      fail "Could not resolve requested git tag: ${ref}"
+    fi
+
+    if ! git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
+      fail "Could not fetch requested git tag: ${ref}"
+    fi
+    if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
+      git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
+      GIT_REF_KIND="immutable"
+      return 0
+    fi
+    if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+      git -C "$repo_dir" checkout --detach "$ref"
+      GIT_REF_KIND="immutable"
+      return 0
+    fi
+    fail "Requested git version not found: ${ref}"
+  fi
+
   if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
     git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"
     git -C "$repo_dir" checkout -B "$ref" "origin/$ref"

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1021,39 +1021,20 @@ verify_git_rebase_recovery() {
   local repo_dir="$1"
   local expected_head="$2"
   local expected_status="$3"
-  local actual_head=""
-  local actual_status=""
-  local rebase_merge=""
-  local rebase_apply=""
 
-  if ! git -C "$repo_dir" rebase --abort >/dev/null 2>&1; then
-    return 1
-  fi
-  if ! actual_head="$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)"; then
-    return 1
-  fi
-  if ! actual_status="$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null)"; then
-    return 1
-  fi
-  if ! rebase_merge="$(git -C "$repo_dir" rev-parse --git-path rebase-merge 2>/dev/null)"; then
-    return 1
-  fi
-  if ! rebase_apply="$(git -C "$repo_dir" rev-parse --git-path rebase-apply 2>/dev/null)"; then
-    return 1
-  fi
-
-  [[ "$actual_head" == "$expected_head" ]] || return 1
-  [[ "$actual_status" == "$expected_status" ]] || return 1
-  [[ ! -d "$rebase_merge" && ! -d "$rebase_apply" ]]
+  git -C "$repo_dir" rebase --abort >/dev/null 2>&1 &&
+    [[ "$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)" == "$expected_head" ]] &&
+    [[ "$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null)" == "$expected_status" ]] &&
+    [[ ! -d "$(git -C "$repo_dir" rev-parse --git-path rebase-merge)" ]] &&
+    [[ ! -d "$(git -C "$repo_dir" rev-parse --git-path rebase-apply)" ]]
 }
 
 checkout_git_openclaw_ref() {
   local repo_dir="$1"
   local ref="$2"
-  local branch_probe_status=0
-  local tag_probe_status=0
   local original_head=""
   local original_status=""
+  local namespaces=(heads tags)
 
   GIT_REF_KIND=""
 
@@ -1082,105 +1063,43 @@ checkout_git_openclaw_ref() {
     return 0
   fi
 
-  # A normalized release selector names an immutable tag. Resolve that tag
-  # before looking for an arbitrary branch with the same short name.
+  # Normalized release selectors prefer immutable tags. A same-name branch
+  # remains a fallback for operator-supplied v-prefixed branch names.
   if [[ "$ref" == v[0-9]* ]]; then
-    if git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}" >/dev/null 2>&1; then
-      tag_probe_status=0
-    else
-      tag_probe_status=$?
-    fi
+    namespaces=(tags heads)
+  fi
 
-    if (( tag_probe_status == 0 )); then
-      if ! git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
-        fail "Could not fetch requested git tag: ${ref}"
-      fi
-      if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
+  local namespace=""
+  local probe_status=0
+  for namespace in "${namespaces[@]}"; do
+    if git -C "$repo_dir" ls-remote --exit-code origin "refs/${namespace}/${ref}" >/dev/null 2>&1; then
+      if [[ "$namespace" == "heads" ]]; then
+        git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"
+        git -C "$repo_dir" checkout -B "$ref" "origin/$ref"
+        GIT_REF_KIND="moving"
+      else
+        git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"
+        git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null ||
+          fail "Requested git version is not a commit: ${ref}"
         git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
         GIT_REF_KIND="immutable"
-        return 0
       fi
-      if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
-        git -C "$repo_dir" checkout --detach "$ref"
-        GIT_REF_KIND="immutable"
-        return 0
-      fi
-      fail "Requested git version not found: ${ref}"
-    elif (( tag_probe_status != 2 )); then
-      fail "Could not resolve requested git tag: ${ref}"
-    fi
-  fi
-
-  if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
-    git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"
-    git -C "$repo_dir" checkout -B "$ref" "origin/$ref"
-    GIT_REF_KIND="moving"
-    return 0
-  else
-    branch_probe_status=$?
-  fi
-
-  if (( branch_probe_status != 2 )); then
-    fail "Could not resolve requested git branch: ${ref}"
-  fi
-
-  if git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}" >/dev/null 2>&1; then
-    tag_probe_status=0
-  else
-    tag_probe_status=$?
-  fi
-
-  if (( tag_probe_status == 2 )); then
-    if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
-      git -C "$repo_dir" checkout --detach "$ref"
-      GIT_REF_KIND="immutable"
       return 0
+    else
+      probe_status=$?
     fi
-    fail "Requested git version not found: ${ref}"
-  fi
-  if (( tag_probe_status != 0 )); then
-    fail "Could not resolve requested git tag: ${ref}"
-  fi
-
-  if ! git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
-    fail "Could not fetch requested git tag: ${ref}"
-  fi
-
-  if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
-    git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
-    GIT_REF_KIND="immutable"
-    return 0
-  fi
-
-  if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
-    git -C "$repo_dir" checkout --detach "$ref"
-    GIT_REF_KIND="immutable"
-    return 0
-  fi
+    (( probe_status == 2 )) || fail "Could not resolve requested git ref: ${ref}"
+  done
 
   fail "Requested git version not found: ${ref}"
 }
 
 git_install_lockfile_flag() {
-  local repo_dir="$1"
-  local ref="$2"
-  local ref_kind="${3:-$GIT_REF_KIND}"
-
-  if [[ "$ref_kind" == "moving" ]]; then
+  if [[ "$1" == "moving" ]]; then
     echo "--no-frozen-lockfile"
-    return 0
-  fi
-  if [[ "$ref_kind" == "immutable" ]]; then
+  else
     echo "--frozen-lockfile"
-    return 0
   fi
-
-  if [[ "$ref" == "main" ]] || git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
-    echo "--no-frozen-lockfile"
-    return 0
-  fi
-
-  echo "--frozen-lockfile"
 }
 
 repo_pnpm_spec() {
@@ -1747,6 +1666,11 @@ install_openclaw_from_git() {
   else
     log "Repo is dirty; skipping git checkout/update"
     emit_json step name git-update status warn reason dirty
+    if git -C "$repo_dir" symbolic-ref --quiet HEAD >/dev/null; then
+      GIT_REF_KIND="moving"
+    else
+      GIT_REF_KIND="immutable"
+    fi
   fi
 
   if [[ -n "${REQUIRED_COMPATIBLE_VERSION:-}" ]]; then
@@ -1763,7 +1687,7 @@ install_openclaw_from_git() {
   activate_repo_pnpm_version "$repo_dir"
 
   local install_lockfile_flag
-  install_lockfile_flag="$(git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND")"
+  install_lockfile_flag="$(git_install_lockfile_flag "$GIT_REF_KIND")"
   emit_json step name dependencies status start
   CI="${CI:-true}" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"
   emit_json step name dependencies status ok

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2632,12 +2632,16 @@ verify_git_rebase_recovery() {
     local repo_dir="$1"
     local expected_head="$2"
     local expected_status="$3"
+    local git_dir
 
-    git -C "$repo_dir" rebase --abort >/dev/null 2>&1 &&
-        [[ "$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)" == "$expected_head" ]] &&
+    git_dir="$(git -C "$repo_dir" rev-parse --absolute-git-dir)" || return 1
+    if [[ -d "$git_dir/rebase-merge" || -d "$git_dir/rebase-apply" ]]; then
+        git -C "$repo_dir" rebase --abort >/dev/null 2>&1 || return 1
+    fi
+
+    [[ "$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)" == "$expected_head" ]] &&
         [[ "$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null)" == "$expected_status" ]] &&
-        [[ ! -d "$(git -C "$repo_dir" rev-parse --git-path rebase-merge)" ]] &&
-        [[ ! -d "$(git -C "$repo_dir" rev-parse --git-path rebase-apply)" ]]
+        [[ ! -d "$git_dir/rebase-merge" && ! -d "$git_dir/rebase-apply" ]]
 }
 
 checkout_git_openclaw_ref() {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2697,6 +2697,42 @@ checkout_git_openclaw_ref() {
         return 0
     fi
 
+    # A normalized release selector names an immutable tag. Resolve that tag
+    # before looking for an arbitrary branch with the same short name.
+    if [[ "$ref" == v[0-9]* ]]; then
+        if git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}" >/dev/null 2>&1; then
+            tag_probe_status=0
+        else
+            tag_probe_status=$?
+        fi
+
+        if (( tag_probe_status == 2 )); then
+            ui_error "Requested git version not found: ${ref}"
+            return 1
+        fi
+        if (( tag_probe_status != 0 )); then
+            ui_error "Could not resolve requested git tag: ${ref}"
+            return 1
+        fi
+
+        if ! run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
+            ui_error "Could not fetch requested git tag: ${ref}"
+            return 1
+        fi
+        if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
+            run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
+            GIT_REF_KIND="immutable"
+            return 0
+        fi
+        if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+            run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
+            GIT_REF_KIND="immutable"
+            return 0
+        fi
+        ui_error "Requested git version not found: ${ref}"
+        return 1
+    fi
+
     if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
         run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"
         run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout -B "$ref" "origin/$ref"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2632,39 +2632,20 @@ verify_git_rebase_recovery() {
     local repo_dir="$1"
     local expected_head="$2"
     local expected_status="$3"
-    local actual_head=""
-    local actual_status=""
-    local rebase_merge=""
-    local rebase_apply=""
 
-    if ! git -C "$repo_dir" rebase --abort >/dev/null 2>&1; then
-        return 1
-    fi
-    if ! actual_head="$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)"; then
-        return 1
-    fi
-    if ! actual_status="$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null)"; then
-        return 1
-    fi
-    if ! rebase_merge="$(git -C "$repo_dir" rev-parse --git-path rebase-merge 2>/dev/null)"; then
-        return 1
-    fi
-    if ! rebase_apply="$(git -C "$repo_dir" rev-parse --git-path rebase-apply 2>/dev/null)"; then
-        return 1
-    fi
-
-    [[ "$actual_head" == "$expected_head" ]] || return 1
-    [[ "$actual_status" == "$expected_status" ]] || return 1
-    [[ ! -d "$rebase_merge" && ! -d "$rebase_apply" ]]
+    git -C "$repo_dir" rebase --abort >/dev/null 2>&1 &&
+        [[ "$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)" == "$expected_head" ]] &&
+        [[ "$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null)" == "$expected_status" ]] &&
+        [[ ! -d "$(git -C "$repo_dir" rev-parse --git-path rebase-merge)" ]] &&
+        [[ ! -d "$(git -C "$repo_dir" rev-parse --git-path rebase-apply)" ]]
 }
 
 checkout_git_openclaw_ref() {
     local repo_dir="$1"
     local ref="$2"
-    local branch_probe_status=0
-    local tag_probe_status=0
     local original_head=""
     local original_status=""
+    local namespaces=(heads tags)
 
     GIT_REF_KIND=""
 
@@ -2697,91 +2678,49 @@ checkout_git_openclaw_ref() {
         return 0
     fi
 
-    # A normalized release selector names an immutable tag. Resolve that tag
-    # before looking for an arbitrary branch with the same short name.
+    # Normalized release selectors prefer immutable tags. A same-name branch
+    # remains a fallback for operator-supplied v-prefixed branch names.
     if [[ "$ref" == v[0-9]* ]]; then
-        if git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}" >/dev/null 2>&1; then
-            tag_probe_status=0
-        else
-            tag_probe_status=$?
-        fi
+        namespaces=(tags heads)
+    fi
 
-        if (( tag_probe_status == 0 )); then
-            if ! run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
-                ui_error "Could not fetch requested git tag: ${ref}"
-                return 1
-            fi
-            if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
+    local namespace=""
+    local probe_status=0
+    for namespace in "${namespaces[@]}"; do
+        if git -C "$repo_dir" ls-remote --exit-code origin "refs/${namespace}/${ref}" >/dev/null 2>&1; then
+            if [[ "$namespace" == "heads" ]]; then
+                run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"
+                run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout -B "$ref" "origin/$ref"
+                GIT_REF_KIND="moving"
+            else
+                run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"
+                if ! git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
+                    ui_error "Requested git version is not a commit: ${ref}"
+                    return 1
+                fi
                 run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
                 GIT_REF_KIND="immutable"
-                return 0
             fi
-            if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
-                run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
-                GIT_REF_KIND="immutable"
-                return 0
-            fi
-            ui_error "Requested git version not found: ${ref}"
-            return 1
-        elif (( tag_probe_status != 2 )); then
-            ui_error "Could not resolve requested git tag: ${ref}"
-            return 1
-        fi
-    fi
-
-    if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
-        run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"
-        run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout -B "$ref" "origin/$ref"
-        GIT_REF_KIND="moving"
-        return 0
-    else
-        branch_probe_status=$?
-    fi
-
-    if (( branch_probe_status != 2 )); then
-        ui_error "Could not resolve requested git branch: ${ref}"
-        return 1
-    fi
-
-    if git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}" >/dev/null 2>&1; then
-        tag_probe_status=0
-    else
-        tag_probe_status=$?
-    fi
-
-    if (( tag_probe_status == 2 )); then
-        if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
-            run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
-            GIT_REF_KIND="immutable"
             return 0
+        else
+            probe_status=$?
         fi
-        ui_error "Requested git version not found: ${ref}"
-        return 1
-    fi
-    if (( tag_probe_status != 0 )); then
-        ui_error "Could not resolve requested git tag: ${ref}"
-        return 1
-    fi
-
-    if ! run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
-        ui_error "Could not fetch requested git tag: ${ref}"
-        return 1
-    fi
-
-    if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
-        run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
-        GIT_REF_KIND="immutable"
-        return 0
-    fi
-
-    if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
-        run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
-        GIT_REF_KIND="immutable"
-        return 0
-    fi
+        if (( probe_status != 2 )); then
+            ui_error "Could not resolve requested git ref: ${ref}"
+            return 1
+        fi
+    done
 
     ui_error "Requested git version not found: ${ref}"
     return 1
+}
+
+git_install_lockfile_flag() {
+    if [[ "$1" == "moving" ]]; then
+        echo "--no-frozen-lockfile"
+    else
+        echo "--frozen-lockfile"
+    fi
 }
 
 validate_git_checkout_head() {
@@ -2879,28 +2818,6 @@ NODE
         ui_info "Inspect the destination for partial files, move it or choose another --git-dir, then retry."
         return 1
     fi
-}
-
-git_install_lockfile_flag() {
-    local repo_dir="$1"
-    local ref="$2"
-    local ref_kind="${3:-$GIT_REF_KIND}"
-
-    if [[ "$ref_kind" == "moving" ]]; then
-        echo "--no-frozen-lockfile"
-        return 0
-    fi
-    if [[ "$ref_kind" == "immutable" ]]; then
-        echo "--frozen-lockfile"
-        return 0
-    fi
-
-    if [[ "$ref" == "main" ]] || git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
-        echo "--no-frozen-lockfile"
-        return 0
-    fi
-
-    echo "--frozen-lockfile"
 }
 
 repo_pnpm_spec() {
@@ -3383,13 +3300,18 @@ install_openclaw_from_git() {
         checkout_git_openclaw_ref "$repo_dir" "$git_ref"
     else
         ui_info "Repo has local changes; skipping git checkout/update"
+        if git -C "$repo_dir" symbolic-ref --quiet HEAD >/dev/null; then
+            GIT_REF_KIND="moving"
+        else
+            GIT_REF_KIND="immutable"
+        fi
     fi
 
     cleanup_legacy_submodules "$repo_dir"
     activate_repo_pnpm_version "$repo_dir"
 
     local install_lockfile_flag
-    install_lockfile_flag="$(git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND")"
+    install_lockfile_flag="$(git_install_lockfile_flag "$GIT_REF_KIND")"
     CI="${CI:-true}" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"
 
     if ! run_quiet_step "Building UI" run_pnpm -C "$repo_dir" ui:build; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1397,6 +1397,7 @@ VERBOSE="${OPENCLAW_VERBOSE:-0}"
 VERIFY_INSTALL="${OPENCLAW_VERIFY_INSTALL:-0}"
 OPENCLAW_BIN=""
 PNPM_CMD=()
+GIT_REF_KIND=""
 HELP=0
 
 print_usage() {
@@ -2630,6 +2631,10 @@ resolve_git_openclaw_ref() {
 checkout_git_openclaw_ref() {
     local repo_dir="$1"
     local ref="$2"
+    local branch_probe_status=0
+    local tag_probe_status=0
+
+    GIT_REF_KIND=""
 
     if [[ -z "$ref" ]]; then
         return 0
@@ -2639,29 +2644,64 @@ checkout_git_openclaw_ref() {
         run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin main
         run_quiet_step "Checking out main" git -C "$repo_dir" checkout main
         if [[ "$GIT_UPDATE" == "1" ]]; then
-            run_quiet_step "Updating repository" git -C "$repo_dir" pull --rebase --no-tags || true
+            if ! run_quiet_step "Updating repository" git -C "$repo_dir" rebase origin/main; then
+                git -C "$repo_dir" rebase --abort >/dev/null 2>&1 || true
+                ui_error "Could not update repository from origin/main"
+                return 1
+            fi
         fi
+        GIT_REF_KIND="moving"
         return 0
     fi
 
     if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
         run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"
         run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout -B "$ref" "origin/$ref"
-        if [[ "$GIT_UPDATE" == "1" ]]; then
-            run_quiet_step "Updating repository" git -C "$repo_dir" pull --rebase --no-tags || true
-        fi
+        GIT_REF_KIND="moving"
         return 0
+    else
+        branch_probe_status=$?
     fi
 
-    run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --tags origin
+    if (( branch_probe_status != 2 )); then
+        ui_error "Could not resolve requested git branch: ${ref}"
+        return 1
+    fi
+
+    if git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}" >/dev/null 2>&1; then
+        tag_probe_status=0
+    else
+        tag_probe_status=$?
+    fi
+
+    if (( tag_probe_status == 2 )); then
+        if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+            run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
+            GIT_REF_KIND="immutable"
+            return 0
+        fi
+        ui_error "Requested git version not found: ${ref}"
+        return 1
+    fi
+    if (( tag_probe_status != 0 )); then
+        ui_error "Could not resolve requested git tag: ${ref}"
+        return 1
+    fi
+
+    if ! run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
+        ui_error "Could not fetch requested git tag: ${ref}"
+        return 1
+    fi
 
     if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
         run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
+        GIT_REF_KIND="immutable"
         return 0
     fi
 
     if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
         run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
+        GIT_REF_KIND="immutable"
         return 0
     fi
 
@@ -2769,6 +2809,16 @@ NODE
 git_install_lockfile_flag() {
     local repo_dir="$1"
     local ref="$2"
+    local ref_kind="${3:-$GIT_REF_KIND}"
+
+    if [[ "$ref_kind" == "moving" ]]; then
+        echo "--no-frozen-lockfile"
+        return 0
+    fi
+    if [[ "$ref_kind" == "immutable" ]]; then
+        echo "--frozen-lockfile"
+        return 0
+    fi
 
     if [[ "$ref" == "main" ]] || git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then
         echo "--no-frozen-lockfile"
@@ -3264,7 +3314,7 @@ install_openclaw_from_git() {
     activate_repo_pnpm_version "$repo_dir"
 
     local install_lockfile_flag
-    install_lockfile_flag="$(git_install_lockfile_flag "$repo_dir" "$git_ref")"
+    install_lockfile_flag="$(git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND")"
     CI="${CI:-true}" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"
 
     if ! run_quiet_step "Building UI" run_pnpm -C "$repo_dir" ui:build; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2628,11 +2628,43 @@ resolve_git_openclaw_ref() {
     esac
 }
 
+verify_git_rebase_recovery() {
+    local repo_dir="$1"
+    local expected_head="$2"
+    local expected_status="$3"
+    local actual_head=""
+    local actual_status=""
+    local rebase_merge=""
+    local rebase_apply=""
+
+    if ! git -C "$repo_dir" rebase --abort >/dev/null 2>&1; then
+        return 1
+    fi
+    if ! actual_head="$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)"; then
+        return 1
+    fi
+    if ! actual_status="$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null)"; then
+        return 1
+    fi
+    if ! rebase_merge="$(git -C "$repo_dir" rev-parse --git-path rebase-merge 2>/dev/null)"; then
+        return 1
+    fi
+    if ! rebase_apply="$(git -C "$repo_dir" rev-parse --git-path rebase-apply 2>/dev/null)"; then
+        return 1
+    fi
+
+    [[ "$actual_head" == "$expected_head" ]] || return 1
+    [[ "$actual_status" == "$expected_status" ]] || return 1
+    [[ ! -d "$rebase_merge" && ! -d "$rebase_apply" ]]
+}
+
 checkout_git_openclaw_ref() {
     local repo_dir="$1"
     local ref="$2"
     local branch_probe_status=0
     local tag_probe_status=0
+    local original_head=""
+    local original_status=""
 
     GIT_REF_KIND=""
 
@@ -2644,9 +2676,20 @@ checkout_git_openclaw_ref() {
         run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"
         run_quiet_step "Checking out main" git -C "$repo_dir" checkout main
         if [[ "$GIT_UPDATE" == "1" ]]; then
+            if ! original_head="$(git -C "$repo_dir" rev-parse --verify HEAD 2>/dev/null)"; then
+                ui_error "Could not record repository state before updating from origin/main"
+                return 1
+            fi
+            if ! original_status="$(git -C "$repo_dir" status --porcelain=v1 --untracked-files=all 2>/dev/null)"; then
+                ui_error "Could not record repository state before updating from origin/main"
+                return 1
+            fi
             if ! run_quiet_step "Updating repository" git -C "$repo_dir" rebase origin/main; then
-                git -C "$repo_dir" rebase --abort >/dev/null 2>&1 || true
-                ui_error "Could not update repository from origin/main"
+                if verify_git_rebase_recovery "$repo_dir" "$original_head" "$original_status"; then
+                    ui_error "Could not update repository from origin/main; the checkout was restored to its pre-update state"
+                else
+                    ui_error "Could not update repository from origin/main; checkout recovery was not verified. Run git -C \"$repo_dir\" rebase --abort and inspect the checkout before retrying"
+                fi
                 return 1
             fi
         fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2694,7 +2694,7 @@ checkout_git_openclaw_ref() {
     fi
 
     if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
-        run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
+        run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
         GIT_REF_KIND="immutable"
         return 0
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2706,31 +2706,27 @@ checkout_git_openclaw_ref() {
             tag_probe_status=$?
         fi
 
-        if (( tag_probe_status == 2 )); then
+        if (( tag_probe_status == 0 )); then
+            if ! run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
+                ui_error "Could not fetch requested git tag: ${ref}"
+                return 1
+            fi
+            if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
+                run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
+                GIT_REF_KIND="immutable"
+                return 0
+            fi
+            if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
+                run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
+                GIT_REF_KIND="immutable"
+                return 0
+            fi
             ui_error "Requested git version not found: ${ref}"
             return 1
-        fi
-        if (( tag_probe_status != 0 )); then
+        elif (( tag_probe_status != 2 )); then
             ui_error "Could not resolve requested git tag: ${ref}"
             return 1
         fi
-
-        if ! run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"; then
-            ui_error "Could not fetch requested git tag: ${ref}"
-            return 1
-        fi
-        if git -C "$repo_dir" rev-parse --verify --quiet "refs/tags/${ref}^{commit}" >/dev/null; then
-            run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "refs/tags/${ref}"
-            GIT_REF_KIND="immutable"
-            return 0
-        fi
-        if git -C "$repo_dir" rev-parse --verify --quiet "${ref}^{commit}" >/dev/null; then
-            run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "$ref"
-            GIT_REF_KIND="immutable"
-            return 0
-        fi
-        ui_error "Requested git version not found: ${ref}"
-        return 1
     fi
 
     if git -C "$repo_dir" ls-remote --exit-code --heads origin "$ref" >/dev/null 2>&1; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2641,7 +2641,7 @@ checkout_git_openclaw_ref() {
     fi
 
     if [[ "$ref" == "main" ]]; then
-        run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin main
+        run_quiet_step "Fetching requested version" git -C "$repo_dir" fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"
         run_quiet_step "Checking out main" git -C "$repo_dir" checkout main
         if [[ "$GIT_UPDATE" == "1" ]]; then
             if ! run_quiet_step "Updating repository" git -C "$repo_dir" rebase origin/main; then

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -1094,6 +1094,56 @@ describe("install-cli.sh", () => {
     expect(result.stdout).toContain("remote=");
   });
 
+  it("restores an existing main checkout after a failed rebase", () => {
+    const result = runInstallCliShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      tmp="$(mktemp -d)"
+      remote="$tmp/remote.git"
+      seed="$tmp/seed"
+      repo="$tmp/repo"
+      git init --bare -q "$remote"
+      git init -q --initial-branch=main "$seed"
+      git -C "$seed" config user.email test@example.invalid
+      git -C "$seed" config user.name test
+      printf 'base\\n' > "$seed/state.txt"
+      git -C "$seed" add state.txt
+      git -C "$seed" commit -qm base
+      git -C "$seed" remote add origin "$remote"
+      git -C "$seed" push -q -u origin main
+      git --git-dir="$remote" symbolic-ref HEAD refs/heads/main
+      git clone -q "$remote" "$repo"
+      git -C "$repo" config user.email test@example.invalid
+      git -C "$repo" config user.name test
+      printf 'remote\\n' > "$seed/state.txt"
+      git -C "$seed" commit -qam remote
+      git -C "$seed" push -q origin main
+      printf 'local\\n' > "$repo/state.txt"
+      git -C "$repo" commit -qam local
+      printf 'keep this user change\\n' > "$repo/user-note.txt"
+      expected_head="$(git -C "$repo" rev-parse HEAD)"
+      expected_status="$(git -C "$repo" status --porcelain=v1 --untracked-files=all)"
+      set +e
+      output="$(checkout_git_openclaw_ref "$repo" main 2>&1)"
+      status=$?
+      set -e
+      [[ "$status" -ne 0 ]]
+      actual_head="$(git -C "$repo" rev-parse HEAD)"
+      actual_status="$(git -C "$repo" status --porcelain=v1 --untracked-files=all)"
+      rebase_merge="$(git -C "$repo" rev-parse --git-path rebase-merge)"
+      rebase_apply="$(git -C "$repo" rev-parse --git-path rebase-apply)"
+      [[ "$actual_head" == "$expected_head" ]]
+      [[ "$actual_status" == "$expected_status" ]]
+      [[ "$(cat "$repo/user-note.txt")" == "keep this user change" ]]
+      [[ ! -d "$rebase_merge" && ! -d "$rebase_apply" ]]
+      [[ "$output" == *"restored to its pre-update state"* ]]
+      printf 'recovery=head-restored status-clean rebase-state-cleared\\n'
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("recovery=head-restored status-clean rebase-state-cleared");
+  });
+
   it("uses non-frozen lockfile installs only for moving git refs", () => {
     const result = runInstallCliShell(`
       set -euo pipefail

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -997,7 +997,9 @@ describe("install-cli.sh", () => {
   });
 
   it("fetches exact git refs and avoids redundant update probes", () => {
-    expect(script).toContain('git -C "$repo_dir" fetch --no-tags origin main');
+    expect(script).toContain(
+      'git -C "$repo_dir" fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"',
+    );
     expect(script).toContain(
       'git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"',
     );
@@ -1006,6 +1008,7 @@ describe("install-cli.sh", () => {
     );
     expect(script).toContain('git -C "$repo_dir" checkout --detach "refs/tags/${ref}"');
     expect(script).toContain('git -C "$repo_dir" rebase origin/main');
+    expect(script).not.toContain('git -C "$repo_dir" fetch --no-tags origin main');
     expect(script).not.toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
 
     const branchCheckIndex = script.indexOf('ls-remote --exit-code --heads origin "$ref"');
@@ -1047,6 +1050,48 @@ describe("install-cli.sh", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("checkout=refs/tags/v2026.5.12");
+  });
+
+  it("updates a stale existing main checkout from the remote tracking ref", () => {
+    const result = runInstallCliShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      tmp="$(mktemp -d)"
+      remote="$tmp/remote.git"
+      source_repo="$tmp/source"
+      repo="$tmp/repo"
+      git init --bare -q "$remote"
+      git init -q --initial-branch=main "$source_repo"
+      git -C "$source_repo" config user.email test@example.invalid
+      git -C "$source_repo" config user.name test
+      printf 'base\\n' > "$source_repo/state.txt"
+      git -C "$source_repo" add state.txt
+      git -C "$source_repo" commit -qm base
+      git -C "$source_repo" remote add origin "$remote"
+      git -C "$source_repo" push -q -u origin main
+      git --git-dir="$remote" symbolic-ref HEAD refs/heads/main
+      git clone -q "$remote" "$repo"
+      git -C "$repo" config user.email test@example.invalid
+      git -C "$repo" config user.name test
+      printf 'target\\n' > "$source_repo/state.txt"
+      git -C "$source_repo" commit -qam target
+      git -C "$source_repo" push -q origin main
+      base="$(git -C "$repo" rev-parse HEAD)"
+      stale_tracking="$(git -C "$repo" rev-parse refs/remotes/origin/main)"
+      [[ "$base" == "$stale_tracking" ]]
+      GIT_UPDATE=1
+      checkout_git_openclaw_ref "$repo" main
+      head="$(git -C "$repo" rev-parse HEAD)"
+      tracking="$(git -C "$repo" rev-parse refs/remotes/origin/main)"
+      remote_head="$(git --git-dir="$remote" rev-parse refs/heads/main)"
+      printf 'head=%s\\ntracking=%s\\nremote=%s\\n' "$head" "$tracking" "$remote_head"
+      [[ "$head" == "$remote_head" && "$tracking" == "$remote_head" && "$head" != "$base" ]]
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("head=");
+    expect(result.stdout).toContain("tracking=");
+    expect(result.stdout).toContain("remote=");
   });
 
   it("uses non-frozen lockfile installs only for moving git refs", () => {

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -996,18 +996,25 @@ describe("install-cli.sh", () => {
     expect(result.stdout).toContain("main=main");
   });
 
-  it("fetches moving git refs without tags for git installs", () => {
+  it("fetches exact git refs and avoids redundant update probes", () => {
     expect(script).toContain('git -C "$repo_dir" fetch --no-tags origin main');
     expect(script).toContain(
       'git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"',
     );
-    expect(script).toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
+    expect(script).toContain(
+      'git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}"',
+    );
+    expect(script).toContain('git -C "$repo_dir" rebase origin/main');
+    expect(script).not.toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
 
     const branchCheckIndex = script.indexOf('ls-remote --exit-code --heads origin "$ref"');
-    const tagFetchIndex = script.indexOf("fetch --tags origin");
+    const tagFetchIndex = script.indexOf(
+      'fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"',
+    );
     expect(branchCheckIndex).toBeGreaterThan(-1);
     expect(tagFetchIndex).toBeGreaterThan(-1);
     expect(branchCheckIndex).toBeLessThan(tagFetchIndex);
+    expect(script).toContain('git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND"');
   });
 
   it("uses non-frozen lockfile installs only for moving git refs", () => {

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -1178,6 +1178,65 @@ describe("install-cli.sh", () => {
     expect(result.stdout).toContain("recovery=head-restored status-clean rebase-state-cleared");
   });
 
+  it("verifies unchanged state when a hook refuses rebase before it starts", () => {
+    const result = runInstallCliShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      tmp="$(mktemp -d)"
+      trap 'rm -rf "$tmp"' EXIT
+      remote="$tmp/remote.git"
+      seed="$tmp/seed"
+      repo="$tmp/repo"
+      git init --bare -q "$remote"
+      git init -q --initial-branch=main "$seed"
+      git -C "$seed" config user.email test@example.invalid
+      git -C "$seed" config user.name test
+      printf 'base\\n' > "$seed/state.txt"
+      git -C "$seed" add state.txt
+      git -C "$seed" commit -qm base
+      git -C "$seed" remote add origin "$remote"
+      git -C "$seed" push -q -u origin main
+      git --git-dir="$remote" symbolic-ref HEAD refs/heads/main
+      git clone -q "$remote" "$repo"
+      printf 'remote\\n' > "$seed/state.txt"
+      git -C "$seed" commit -qam remote
+      git -C "$seed" push -q origin main
+      git -C "$repo" config user.email test@example.invalid
+      git -C "$repo" config user.name test
+      printf 'local\\n' > "$repo/local.txt"
+      git -C "$repo" add local.txt
+      git -C "$repo" commit -qm local
+      cat > "$repo/.git/hooks/pre-rebase" <<'HOOK'
+#!/usr/bin/env bash
+exit 42
+HOOK
+      chmod +x "$repo/.git/hooks/pre-rebase"
+      printf 'keep this user change\\n' > "$repo/user-note.txt"
+      expected_head="$(git -C "$repo" rev-parse HEAD)"
+      expected_status="$(git -C "$repo" status --porcelain=v1 --untracked-files=all)"
+      set +e
+      output="$(GIT_UPDATE=1 checkout_git_openclaw_ref "$repo" main 2>&1)"
+      status=$?
+      set -e
+      actual_head="$(git -C "$repo" rev-parse HEAD)"
+      actual_status="$(git -C "$repo" status --porcelain=v1 --untracked-files=all)"
+      rebase_merge="$(git -C "$repo" rev-parse --git-path rebase-merge)"
+      rebase_apply="$(git -C "$repo" rev-parse --git-path rebase-apply)"
+      [[ "$status" -ne 0 ]]
+      [[ "$actual_head" == "$expected_head" ]]
+      [[ "$actual_status" == "$expected_status" ]]
+      [[ "$(cat "$repo/user-note.txt")" == "keep this user change" ]]
+      [[ ! -d "$rebase_merge" && ! -d "$rebase_apply" ]]
+      [[ "$output" == *"restored to its pre-update state"* ]]
+      printf 'hook-refusal=head-verified status-verified rebase-state-absent\\n'
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "hook-refusal=head-verified status-verified rebase-state-absent",
+    );
+  });
+
   it("uses non-frozen lockfile installs only for moving git refs", () => {
     const result = runInstallCliShell(`
       set -euo pipefail

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -996,65 +996,17 @@ describe("install-cli.sh", () => {
     expect(result.stdout).toContain("main=main");
   });
 
-  it("fetches exact git refs and avoids redundant update probes", () => {
+  it("keeps ref resolution and rebase failures explicit", () => {
     expect(script).toContain(
       'git -C "$repo_dir" fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"',
     );
     expect(script).toContain(
       'git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"',
     );
-    expect(script).toContain(
-      'git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}"',
-    );
+    expect(script).toContain('git -C "$repo_dir" ls-remote --exit-code origin');
     expect(script).toContain('git -C "$repo_dir" checkout --detach "refs/tags/${ref}"');
     expect(script).toContain('git -C "$repo_dir" rebase origin/main');
-    expect(script).not.toContain('git -C "$repo_dir" fetch --no-tags origin main');
     expect(script).not.toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
-
-    const releaseTagProbeIndex = script.indexOf(
-      'ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}"',
-    );
-    const branchCheckIndex = script.indexOf('ls-remote --exit-code --heads origin "$ref"');
-    const tagFetchIndex = script.lastIndexOf(
-      'fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"',
-    );
-    expect(releaseTagProbeIndex).toBeGreaterThan(-1);
-    expect(branchCheckIndex).toBeGreaterThan(-1);
-    expect(tagFetchIndex).toBeGreaterThan(-1);
-    expect(releaseTagProbeIndex).toBeLessThan(branchCheckIndex);
-    expect(branchCheckIndex).toBeLessThan(tagFetchIndex);
-    expect(script).toContain('git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND"');
-  });
-
-  it("checks out a fetched tag through its fully qualified ref", () => {
-    const result = runInstallCliShell(`
-      set -euo pipefail
-      source "${SCRIPT_PATH}"
-      ref=v2026.5.12
-      checked_out=""
-      git() {
-        if [[ "$1" == "-C" && "$3" == "ls-remote" && "$5" == "--heads" ]]; then
-          return 2
-        fi
-        if [[ "$1" == "-C" && "$3" == "ls-remote" && "$5" == "--tags" ]]; then
-          return 0
-        fi
-        if [[ "$1" == "-C" && "$3" == "rev-parse" && "$6" == "refs/tags/$ref^{commit}" ]]; then
-          return 0
-        fi
-        if [[ "$1" == "-C" && "$3" == "checkout" ]]; then
-          checked_out="$5"
-          [[ "$5" == "refs/tags/$ref" ]]
-          return
-        fi
-        return 0
-      }
-      checkout_git_openclaw_ref /repo "$ref"
-      printf 'checkout=%s\n' "$checked_out"
-    `);
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("checkout=refs/tags/v2026.5.12");
   });
 
   it("prefers a release tag over a same-named branch", () => {
@@ -1226,21 +1178,13 @@ describe("install-cli.sh", () => {
     const result = runInstallCliShell(`
       set -euo pipefail
       source "${SCRIPT_PATH}"
-      git() {
-        if [[ "$1" == "-C" && "$3" == "ls-remote" && "\${7:-}" == "feature" ]]; then
-          return 0
-        fi
-        return 1
-      }
-      printf 'main=%s\\n' "$(git_install_lockfile_flag /repo main)"
-      printf 'branch=%s\\n' "$(git_install_lockfile_flag /repo feature)"
-      printf 'tag=%s\\n' "$(git_install_lockfile_flag /repo v2026.5.12)"
+      printf 'moving=%s\\n' "$(git_install_lockfile_flag moving)"
+      printf 'immutable=%s\\n' "$(git_install_lockfile_flag immutable)"
     `);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("main=--no-frozen-lockfile");
-    expect(result.stdout).toContain("branch=--no-frozen-lockfile");
-    expect(result.stdout).toContain("tag=--frozen-lockfile");
+    expect(result.stdout).toContain("moving=--no-frozen-lockfile");
+    expect(result.stdout).toContain("immutable=--frozen-lockfile");
     expect(script).toContain(
       'CI="${CI:-true}" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"',
     );

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -1095,6 +1095,41 @@ describe("install-cli.sh", () => {
     expect(result.stdout).toContain("selected=");
   });
 
+  it("falls back to a v-prefixed branch when no matching release tag exists", () => {
+    const result = runInstallCliShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      tmp="$(mktemp -d)"
+      remote="$tmp/remote.git"
+      seed="$tmp/seed"
+      repo="$tmp/repo"
+      ref=v2-hotfix
+      git init --bare -q "$remote"
+      git init -q --initial-branch=main "$seed"
+      git -C "$seed" config user.email test@example.invalid
+      git -C "$seed" config user.name test
+      printf 'base\\n' > "$seed/state.txt"
+      git -C "$seed" add state.txt
+      git -C "$seed" commit -qm base
+      git -C "$seed" remote add origin "$remote"
+      git -C "$seed" push -q -u origin main
+      git -C "$seed" checkout -qb "$ref"
+      printf 'branch\\n' > "$seed/state.txt"
+      git -C "$seed" commit -qam branch
+      branch_head="$(git -C "$seed" rev-parse HEAD)"
+      git -C "$seed" push -q origin "refs/heads/$ref"
+      git clone -q "$remote" "$repo"
+      checkout_git_openclaw_ref "$repo" "$ref"
+      selected="$(git -C "$repo" rev-parse HEAD)"
+      printf 'selected=%s branch=%s kind=%s\\n' "$selected" "$branch_head" "$GIT_REF_KIND"
+      [[ "$selected" == "$branch_head" && "$GIT_REF_KIND" == "moving" ]]
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("kind=moving");
+    expect(result.stdout).toContain("selected=");
+  });
+
   it("updates a stale existing main checkout from the remote tracking ref", () => {
     const result = runInstallCliShell(`
       set -euo pipefail

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -1014,6 +1014,7 @@ describe("install-cli.sh", () => {
       set -euo pipefail
       source "${SCRIPT_PATH}"
       tmp="$(mktemp -d)"
+      trap 'rm -rf "$tmp"' EXIT
       remote="$tmp/remote.git"
       seed="$tmp/seed"
       repo="$tmp/repo"
@@ -1052,6 +1053,7 @@ describe("install-cli.sh", () => {
       set -euo pipefail
       source "${SCRIPT_PATH}"
       tmp="$(mktemp -d)"
+      trap 'rm -rf "$tmp"' EXIT
       remote="$tmp/remote.git"
       seed="$tmp/seed"
       repo="$tmp/repo"
@@ -1087,6 +1089,7 @@ describe("install-cli.sh", () => {
       set -euo pipefail
       source "${SCRIPT_PATH}"
       tmp="$(mktemp -d)"
+      trap 'rm -rf "$tmp"' EXIT
       remote="$tmp/remote.git"
       source_repo="$tmp/source"
       repo="$tmp/repo"
@@ -1129,6 +1132,7 @@ describe("install-cli.sh", () => {
       set -euo pipefail
       source "${SCRIPT_PATH}"
       tmp="$(mktemp -d)"
+      trap 'rm -rf "$tmp"' EXIT
       remote="$tmp/remote.git"
       seed="$tmp/seed"
       repo="$tmp/repo"

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -1011,12 +1011,17 @@ describe("install-cli.sh", () => {
     expect(script).not.toContain('git -C "$repo_dir" fetch --no-tags origin main');
     expect(script).not.toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
 
+    const releaseTagProbeIndex = script.indexOf(
+      'ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}"',
+    );
     const branchCheckIndex = script.indexOf('ls-remote --exit-code --heads origin "$ref"');
-    const tagFetchIndex = script.indexOf(
+    const tagFetchIndex = script.lastIndexOf(
       'fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"',
     );
+    expect(releaseTagProbeIndex).toBeGreaterThan(-1);
     expect(branchCheckIndex).toBeGreaterThan(-1);
     expect(tagFetchIndex).toBeGreaterThan(-1);
+    expect(releaseTagProbeIndex).toBeLessThan(branchCheckIndex);
     expect(branchCheckIndex).toBeLessThan(tagFetchIndex);
     expect(script).toContain('git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND"');
   });
@@ -1050,6 +1055,44 @@ describe("install-cli.sh", () => {
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("checkout=refs/tags/v2026.5.12");
+  });
+
+  it("prefers a release tag over a same-named branch", () => {
+    const result = runInstallCliShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      tmp="$(mktemp -d)"
+      remote="$tmp/remote.git"
+      seed="$tmp/seed"
+      repo="$tmp/repo"
+      ref=v2026.5.12
+      git init --bare -q "$remote"
+      git init -q --initial-branch=main "$seed"
+      git -C "$seed" config user.email test@example.invalid
+      git -C "$seed" config user.name test
+      printf 'tag\n' > "$seed/state.txt"
+      git -C "$seed" add state.txt
+      git -C "$seed" commit -qm tag
+      tag_head="$(git -C "$seed" rev-parse HEAD)"
+      git -C "$seed" remote add origin "$remote"
+      git -C "$seed" push -q -u origin main
+      git -C "$seed" tag "$ref"
+      git -C "$seed" push -q origin "refs/tags/$ref"
+      git -C "$seed" checkout -qb "$ref"
+      printf 'branch\n' > "$seed/state.txt"
+      git -C "$seed" commit -qam branch
+      branch_head="$(git -C "$seed" rev-parse HEAD)"
+      git -C "$seed" push -q origin "refs/heads/$ref"
+      git clone -q "$remote" "$repo"
+      checkout_git_openclaw_ref "$repo" "$ref"
+      selected="$(git -C "$repo" rev-parse HEAD)"
+      printf 'selected=%s tag=%s branch=%s kind=%s\n' "$selected" "$tag_head" "$branch_head" "$GIT_REF_KIND"
+      [[ "$selected" == "$tag_head" && "$selected" != "$branch_head" && "$GIT_REF_KIND" == "immutable" ]]
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("kind=immutable");
+    expect(result.stdout).toContain("selected=");
   });
 
   it("updates a stale existing main checkout from the remote tracking ref", () => {

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -1004,6 +1004,7 @@ describe("install-cli.sh", () => {
     expect(script).toContain(
       'git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}"',
     );
+    expect(script).toContain('git -C "$repo_dir" checkout --detach "refs/tags/${ref}"');
     expect(script).toContain('git -C "$repo_dir" rebase origin/main');
     expect(script).not.toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
 
@@ -1015,6 +1016,37 @@ describe("install-cli.sh", () => {
     expect(tagFetchIndex).toBeGreaterThan(-1);
     expect(branchCheckIndex).toBeLessThan(tagFetchIndex);
     expect(script).toContain('git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND"');
+  });
+
+  it("checks out a fetched tag through its fully qualified ref", () => {
+    const result = runInstallCliShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      ref=v2026.5.12
+      checked_out=""
+      git() {
+        if [[ "$1" == "-C" && "$3" == "ls-remote" && "$5" == "--heads" ]]; then
+          return 2
+        fi
+        if [[ "$1" == "-C" && "$3" == "ls-remote" && "$5" == "--tags" ]]; then
+          return 0
+        fi
+        if [[ "$1" == "-C" && "$3" == "rev-parse" && "$6" == "refs/tags/$ref^{commit}" ]]; then
+          return 0
+        fi
+        if [[ "$1" == "-C" && "$3" == "checkout" ]]; then
+          checked_out="$5"
+          [[ "$5" == "refs/tags/$ref" ]]
+          return
+        fi
+        return 0
+      }
+      checkout_git_openclaw_ref /repo "$ref"
+      printf 'checkout=%s\n' "$checked_out"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("checkout=refs/tags/v2026.5.12");
   });
 
   it("uses non-frozen lockfile installs only for moving git refs", () => {

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3788,6 +3788,56 @@ EOF
     expect(result.stdout).toContain("remote=");
   });
 
+  it("restores an existing main checkout after a failed rebase", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      tmp="$(mktemp -d)"
+      remote="$tmp/remote.git"
+      seed="$tmp/seed"
+      repo="$tmp/repo"
+      git init --bare -q "$remote"
+      git init -q --initial-branch=main "$seed"
+      git -C "$seed" config user.email test@example.invalid
+      git -C "$seed" config user.name test
+      printf 'base\\n' > "$seed/state.txt"
+      git -C "$seed" add state.txt
+      git -C "$seed" commit -qm base
+      git -C "$seed" remote add origin "$remote"
+      git -C "$seed" push -q -u origin main
+      git --git-dir="$remote" symbolic-ref HEAD refs/heads/main
+      git clone -q "$remote" "$repo"
+      git -C "$repo" config user.email test@example.invalid
+      git -C "$repo" config user.name test
+      printf 'remote\\n' > "$seed/state.txt"
+      git -C "$seed" commit -qam remote
+      git -C "$seed" push -q origin main
+      printf 'local\\n' > "$repo/state.txt"
+      git -C "$repo" commit -qam local
+      printf 'keep this user change\\n' > "$repo/user-note.txt"
+      expected_head="$(git -C "$repo" rev-parse HEAD)"
+      expected_status="$(git -C "$repo" status --porcelain=v1 --untracked-files=all)"
+      set +e
+      output="$(checkout_git_openclaw_ref "$repo" main 2>&1)"
+      status=$?
+      set -e
+      [[ "$status" -ne 0 ]]
+      actual_head="$(git -C "$repo" rev-parse HEAD)"
+      actual_status="$(git -C "$repo" status --porcelain=v1 --untracked-files=all)"
+      rebase_merge="$(git -C "$repo" rev-parse --git-path rebase-merge)"
+      rebase_apply="$(git -C "$repo" rev-parse --git-path rebase-apply)"
+      [[ "$actual_head" == "$expected_head" ]]
+      [[ "$actual_status" == "$expected_status" ]]
+      [[ "$(cat "$repo/user-note.txt")" == "keep this user change" ]]
+      [[ ! -d "$rebase_merge" && ! -d "$rebase_apply" ]]
+      [[ "$output" == *"restored to its pre-update state"* ]]
+      printf 'recovery=head-restored status-clean rebase-state-cleared\\n'
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("recovery=head-restored status-clean rebase-state-cleared");
+  });
+
   it("uses non-frozen lockfile installs only for moving git refs", () => {
     const result = runInstallShell(`
       set -euo pipefail

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3876,6 +3876,66 @@ EOF
     expect(result.stdout).toContain("recovery=head-restored status-clean rebase-state-cleared");
   });
 
+  it("verifies unchanged state when a hook refuses rebase before it starts", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      run_quiet_step() { shift; "$@"; }
+      tmp="$(mktemp -d)"
+      trap 'rm -rf "$tmp"' EXIT
+      remote="$tmp/remote.git"
+      seed="$tmp/seed"
+      repo="$tmp/repo"
+      git init --bare -q "$remote"
+      git init -q --initial-branch=main "$seed"
+      git -C "$seed" config user.email test@example.invalid
+      git -C "$seed" config user.name test
+      printf 'base\\n' > "$seed/state.txt"
+      git -C "$seed" add state.txt
+      git -C "$seed" commit -qm base
+      git -C "$seed" remote add origin "$remote"
+      git -C "$seed" push -q -u origin main
+      git --git-dir="$remote" symbolic-ref HEAD refs/heads/main
+      git clone -q "$remote" "$repo"
+      printf 'remote\\n' > "$seed/state.txt"
+      git -C "$seed" commit -qam remote
+      git -C "$seed" push -q origin main
+      git -C "$repo" config user.email test@example.invalid
+      git -C "$repo" config user.name test
+      printf 'local\\n' > "$repo/local.txt"
+      git -C "$repo" add local.txt
+      git -C "$repo" commit -qm local
+      cat > "$repo/.git/hooks/pre-rebase" <<'HOOK'
+#!/usr/bin/env bash
+exit 42
+HOOK
+      chmod +x "$repo/.git/hooks/pre-rebase"
+      printf 'keep this user change\\n' > "$repo/user-note.txt"
+      expected_head="$(git -C "$repo" rev-parse HEAD)"
+      expected_status="$(git -C "$repo" status --porcelain=v1 --untracked-files=all)"
+      set +e
+      output="$(GIT_UPDATE=1 checkout_git_openclaw_ref "$repo" main 2>&1)"
+      status=$?
+      set -e
+      actual_head="$(git -C "$repo" rev-parse HEAD)"
+      actual_status="$(git -C "$repo" status --porcelain=v1 --untracked-files=all)"
+      rebase_merge="$(git -C "$repo" rev-parse --git-path rebase-merge)"
+      rebase_apply="$(git -C "$repo" rev-parse --git-path rebase-apply)"
+      [[ "$status" -ne 0 ]]
+      [[ "$actual_head" == "$expected_head" ]]
+      [[ "$actual_status" == "$expected_status" ]]
+      [[ "$(cat "$repo/user-note.txt")" == "keep this user change" ]]
+      [[ ! -d "$rebase_merge" && ! -d "$rebase_apply" ]]
+      [[ "$output" == *"restored to its pre-update state"* ]]
+      printf 'hook-refusal=head-verified status-verified rebase-state-absent\\n'
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain(
+      "hook-refusal=head-verified status-verified rebase-state-absent",
+    );
+  });
+
   it("uses non-frozen lockfile installs only for moving git refs", () => {
     const result = runInstallShell(`
       set -euo pipefail

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3684,7 +3684,9 @@ EOF
   });
 
   it("fetches exact git refs and avoids redundant update probes", () => {
-    expect(script).toContain('git -C "$repo_dir" fetch --no-tags origin main');
+    expect(script).toContain(
+      'git -C "$repo_dir" fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"',
+    );
     expect(script).toContain(
       'git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"',
     );
@@ -3695,6 +3697,7 @@ EOF
       'run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "refs/tags/${ref}"',
     );
     expect(script).toContain('git -C "$repo_dir" rebase origin/main');
+    expect(script).not.toContain('git -C "$repo_dir" fetch --no-tags origin main');
     expect(script).not.toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
 
     const branchCheckIndex = script.indexOf('ls-remote --exit-code --heads origin "$ref"');
@@ -3740,6 +3743,49 @@ EOF
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("checkout=refs/tags/v2026.5.12");
+  });
+
+  it("updates a stale existing main checkout from the remote tracking ref", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      tmp="$(mktemp -d)"
+      remote="$tmp/remote.git"
+      source_repo="$tmp/source"
+      repo="$tmp/repo"
+      git init --bare -q "$remote"
+      git init -q --initial-branch=main "$source_repo"
+      git -C "$source_repo" config user.email test@example.invalid
+      git -C "$source_repo" config user.name test
+      printf 'base\\n' > "$source_repo/state.txt"
+      git -C "$source_repo" add state.txt
+      git -C "$source_repo" commit -qm base
+      git -C "$source_repo" remote add origin "$remote"
+      git -C "$source_repo" push -q -u origin main
+      git --git-dir="$remote" symbolic-ref HEAD refs/heads/main
+      git clone -q "$remote" "$repo"
+      git -C "$repo" config user.email test@example.invalid
+      git -C "$repo" config user.name test
+      printf 'target\\n' > "$source_repo/state.txt"
+      git -C "$source_repo" commit -qam target
+      git -C "$source_repo" push -q origin main
+      base="$(git -C "$repo" rev-parse HEAD)"
+      stale_tracking="$(git -C "$repo" rev-parse refs/remotes/origin/main)"
+      [[ "$base" == "$stale_tracking" ]]
+      run_quiet_step() { shift; "$@"; }
+      GIT_UPDATE=1
+      checkout_git_openclaw_ref "$repo" main
+      head="$(git -C "$repo" rev-parse HEAD)"
+      tracking="$(git -C "$repo" rev-parse refs/remotes/origin/main)"
+      remote_head="$(git --git-dir="$remote" rev-parse refs/heads/main)"
+      printf 'head=%s\\ntracking=%s\\nremote=%s\\n' "$head" "$tracking" "$remote_head"
+      [[ "$head" == "$remote_head" && "$tracking" == "$remote_head" && "$head" != "$base" ]]
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("head=");
+    expect(result.stdout).toContain("tracking=");
+    expect(result.stdout).toContain("remote=");
   });
 
   it("uses non-frozen lockfile installs only for moving git refs", () => {

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3792,6 +3792,45 @@ EOF
     expect(result.stdout).toContain("selected=");
   });
 
+  it("falls back to a v-prefixed branch when no matching release tag exists", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      run_quiet_step() {
+        shift
+        "$@"
+      }
+      tmp="$(mktemp -d)"
+      remote="$tmp/remote.git"
+      seed="$tmp/seed"
+      repo="$tmp/repo"
+      ref=v2-hotfix
+      git init --bare -q "$remote"
+      git init -q --initial-branch=main "$seed"
+      git -C "$seed" config user.email test@example.invalid
+      git -C "$seed" config user.name test
+      printf 'base\\n' > "$seed/state.txt"
+      git -C "$seed" add state.txt
+      git -C "$seed" commit -qm base
+      git -C "$seed" remote add origin "$remote"
+      git -C "$seed" push -q -u origin main
+      git -C "$seed" checkout -qb "$ref"
+      printf 'branch\\n' > "$seed/state.txt"
+      git -C "$seed" commit -qam branch
+      branch_head="$(git -C "$seed" rev-parse HEAD)"
+      git -C "$seed" push -q origin "refs/heads/$ref"
+      git clone -q "$remote" "$repo"
+      checkout_git_openclaw_ref "$repo" "$ref"
+      selected="$(git -C "$repo" rev-parse HEAD)"
+      printf 'selected=%s branch=%s kind=%s\\n' "$selected" "$branch_head" "$GIT_REF_KIND"
+      [[ "$selected" == "$branch_head" && "$GIT_REF_KIND" == "moving" ]]
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("kind=moving");
+    expect(result.stdout).toContain("selected=");
+  });
+
   it("updates a stale existing main checkout from the remote tracking ref", () => {
     const result = runInstallShell(`
       set -euo pipefail

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3683,71 +3683,19 @@ EOF
     expect(result.stdout).toContain("main=main");
   });
 
-  it("fetches exact git refs and avoids redundant update probes", () => {
+  it("keeps ref resolution and rebase failures explicit", () => {
     expect(script).toContain(
       'git -C "$repo_dir" fetch --no-tags origin "refs/heads/main:refs/remotes/origin/main"',
     );
     expect(script).toContain(
       'git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"',
     );
-    expect(script).toContain(
-      'git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}"',
-    );
+    expect(script).toContain('git -C "$repo_dir" ls-remote --exit-code origin');
     expect(script).toContain(
       'run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "refs/tags/${ref}"',
     );
     expect(script).toContain('git -C "$repo_dir" rebase origin/main');
-    expect(script).not.toContain('git -C "$repo_dir" fetch --no-tags origin main');
     expect(script).not.toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
-
-    const releaseTagProbeIndex = script.indexOf(
-      'ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}"',
-    );
-    const branchCheckIndex = script.indexOf('ls-remote --exit-code --heads origin "$ref"');
-    const tagFetchIndex = script.lastIndexOf(
-      'fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"',
-    );
-    expect(releaseTagProbeIndex).toBeGreaterThan(-1);
-    expect(branchCheckIndex).toBeGreaterThan(-1);
-    expect(tagFetchIndex).toBeGreaterThan(-1);
-    expect(releaseTagProbeIndex).toBeLessThan(branchCheckIndex);
-    expect(branchCheckIndex).toBeLessThan(tagFetchIndex);
-    expect(script).toContain('git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND"');
-  });
-
-  it("checks out a fetched tag through its fully qualified ref", () => {
-    const result = runInstallShell(`
-      set -euo pipefail
-      source "${SCRIPT_PATH}"
-      ref=v2026.5.12
-      checked_out=""
-      git() {
-        if [[ "$1" == "-C" && "$3" == "ls-remote" && "$5" == "--heads" ]]; then
-          return 2
-        fi
-        if [[ "$1" == "-C" && "$3" == "ls-remote" && "$5" == "--tags" ]]; then
-          return 0
-        fi
-        if [[ "$1" == "-C" && "$3" == "rev-parse" && "$6" == "refs/tags/$ref^{commit}" ]]; then
-          return 0
-        fi
-        if [[ "$1" == "-C" && "$3" == "checkout" ]]; then
-          checked_out="$5"
-          [[ "$5" == "refs/tags/$ref" ]]
-          return
-        fi
-        return 0
-      }
-      run_quiet_step() {
-        shift
-        "$@"
-      }
-      checkout_git_openclaw_ref /repo "$ref"
-      printf 'checkout=%s\n' "$checked_out"
-    `);
-
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain("checkout=refs/tags/v2026.5.12");
   });
 
   it("prefers a release tag over a same-named branch", () => {
@@ -3928,21 +3876,13 @@ EOF
     const result = runInstallShell(`
       set -euo pipefail
       source "${SCRIPT_PATH}"
-      git() {
-        if [[ "$1" == "-C" && "$3" == "ls-remote" && "\${7:-}" == "feature" ]]; then
-          return 0
-        fi
-        return 1
-      }
-      printf 'main=%s\\n' "$(git_install_lockfile_flag /repo main)"
-      printf 'branch=%s\\n' "$(git_install_lockfile_flag /repo feature)"
-      printf 'tag=%s\\n' "$(git_install_lockfile_flag /repo v2026.5.12)"
+      printf 'moving=%s\\n' "$(git_install_lockfile_flag moving)"
+      printf 'immutable=%s\\n' "$(git_install_lockfile_flag immutable)"
     `);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("main=--no-frozen-lockfile");
-    expect(result.stdout).toContain("branch=--no-frozen-lockfile");
-    expect(result.stdout).toContain("tag=--frozen-lockfile");
+    expect(result.stdout).toContain("moving=--no-frozen-lockfile");
+    expect(result.stdout).toContain("immutable=--frozen-lockfile");
     expect(script).toContain(
       'CI="${CI:-true}" run_quiet_step "Installing dependencies" run_pnpm -C "$repo_dir" install "$install_lockfile_flag"',
     );

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3691,6 +3691,9 @@ EOF
     expect(script).toContain(
       'git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}"',
     );
+    expect(script).toContain(
+      'run_quiet_step "Checking out ${ref}" git -C "$repo_dir" checkout --detach "refs/tags/${ref}"',
+    );
     expect(script).toContain('git -C "$repo_dir" rebase origin/main');
     expect(script).not.toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
 
@@ -3702,6 +3705,41 @@ EOF
     expect(tagFetchIndex).toBeGreaterThan(-1);
     expect(branchCheckIndex).toBeLessThan(tagFetchIndex);
     expect(script).toContain('git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND"');
+  });
+
+  it("checks out a fetched tag through its fully qualified ref", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      ref=v2026.5.12
+      checked_out=""
+      git() {
+        if [[ "$1" == "-C" && "$3" == "ls-remote" && "$5" == "--heads" ]]; then
+          return 2
+        fi
+        if [[ "$1" == "-C" && "$3" == "ls-remote" && "$5" == "--tags" ]]; then
+          return 0
+        fi
+        if [[ "$1" == "-C" && "$3" == "rev-parse" && "$6" == "refs/tags/$ref^{commit}" ]]; then
+          return 0
+        fi
+        if [[ "$1" == "-C" && "$3" == "checkout" ]]; then
+          checked_out="$5"
+          [[ "$5" == "refs/tags/$ref" ]]
+          return
+        fi
+        return 0
+      }
+      run_quiet_step() {
+        shift
+        "$@"
+      }
+      checkout_git_openclaw_ref /repo "$ref"
+      printf 'checkout=%s\n' "$checked_out"
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("checkout=refs/tags/v2026.5.12");
   });
 
   it("uses non-frozen lockfile installs only for moving git refs", () => {

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3707,6 +3707,7 @@ EOF
         "$@"
       }
       tmp="$(mktemp -d)"
+      trap 'rm -rf "$tmp"' EXIT
       remote="$tmp/remote.git"
       seed="$tmp/seed"
       repo="$tmp/repo"
@@ -3749,6 +3750,7 @@ EOF
         "$@"
       }
       tmp="$(mktemp -d)"
+      trap 'rm -rf "$tmp"' EXIT
       remote="$tmp/remote.git"
       seed="$tmp/seed"
       repo="$tmp/repo"
@@ -3784,6 +3786,7 @@ EOF
       set -euo pipefail
       source "${SCRIPT_PATH}"
       tmp="$(mktemp -d)"
+      trap 'rm -rf "$tmp"' EXIT
       remote="$tmp/remote.git"
       source_repo="$tmp/source"
       repo="$tmp/repo"
@@ -3827,6 +3830,7 @@ EOF
       set -euo pipefail
       source "${SCRIPT_PATH}"
       tmp="$(mktemp -d)"
+      trap 'rm -rf "$tmp"' EXIT
       remote="$tmp/remote.git"
       seed="$tmp/seed"
       repo="$tmp/repo"

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3683,18 +3683,25 @@ EOF
     expect(result.stdout).toContain("main=main");
   });
 
-  it("fetches moving git refs without tags for git installs", () => {
+  it("fetches exact git refs and avoids redundant update probes", () => {
     expect(script).toContain('git -C "$repo_dir" fetch --no-tags origin main');
     expect(script).toContain(
       'git -C "$repo_dir" fetch --no-tags origin "refs/heads/${ref}:refs/remotes/origin/${ref}"',
     );
-    expect(script).toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
+    expect(script).toContain(
+      'git -C "$repo_dir" ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}"',
+    );
+    expect(script).toContain('git -C "$repo_dir" rebase origin/main');
+    expect(script).not.toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
 
     const branchCheckIndex = script.indexOf('ls-remote --exit-code --heads origin "$ref"');
-    const tagFetchIndex = script.indexOf("fetch --tags origin");
+    const tagFetchIndex = script.indexOf(
+      'fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"',
+    );
     expect(branchCheckIndex).toBeGreaterThan(-1);
     expect(tagFetchIndex).toBeGreaterThan(-1);
     expect(branchCheckIndex).toBeLessThan(tagFetchIndex);
+    expect(script).toContain('git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND"');
   });
 
   it("uses non-frozen lockfile installs only for moving git refs", () => {

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3700,12 +3700,17 @@ EOF
     expect(script).not.toContain('git -C "$repo_dir" fetch --no-tags origin main');
     expect(script).not.toContain('git -C "$repo_dir" pull --rebase --no-tags || true');
 
+    const releaseTagProbeIndex = script.indexOf(
+      'ls-remote --exit-code --tags origin "refs/tags/${ref}" "refs/tags/${ref}^{}"',
+    );
     const branchCheckIndex = script.indexOf('ls-remote --exit-code --heads origin "$ref"');
-    const tagFetchIndex = script.indexOf(
+    const tagFetchIndex = script.lastIndexOf(
       'fetch --no-tags origin "refs/tags/${ref}:refs/tags/${ref}"',
     );
+    expect(releaseTagProbeIndex).toBeGreaterThan(-1);
     expect(branchCheckIndex).toBeGreaterThan(-1);
     expect(tagFetchIndex).toBeGreaterThan(-1);
+    expect(releaseTagProbeIndex).toBeLessThan(branchCheckIndex);
     expect(branchCheckIndex).toBeLessThan(tagFetchIndex);
     expect(script).toContain('git_install_lockfile_flag "$repo_dir" "$git_ref" "$GIT_REF_KIND"');
   });
@@ -3743,6 +3748,48 @@ EOF
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("checkout=refs/tags/v2026.5.12");
+  });
+
+  it("prefers a release tag over a same-named branch", () => {
+    const result = runInstallShell(`
+      set -euo pipefail
+      source "${SCRIPT_PATH}"
+      run_quiet_step() {
+        shift
+        "$@"
+      }
+      tmp="$(mktemp -d)"
+      remote="$tmp/remote.git"
+      seed="$tmp/seed"
+      repo="$tmp/repo"
+      ref=v2026.5.12
+      git init --bare -q "$remote"
+      git init -q --initial-branch=main "$seed"
+      git -C "$seed" config user.email test@example.invalid
+      git -C "$seed" config user.name test
+      printf 'tag\n' > "$seed/state.txt"
+      git -C "$seed" add state.txt
+      git -C "$seed" commit -qm tag
+      tag_head="$(git -C "$seed" rev-parse HEAD)"
+      git -C "$seed" remote add origin "$remote"
+      git -C "$seed" push -q -u origin main
+      git -C "$seed" tag "$ref"
+      git -C "$seed" push -q origin "refs/tags/$ref"
+      git -C "$seed" checkout -qb "$ref"
+      printf 'branch\n' > "$seed/state.txt"
+      git -C "$seed" commit -qam branch
+      branch_head="$(git -C "$seed" rev-parse HEAD)"
+      git -C "$seed" push -q origin "refs/heads/$ref"
+      git clone -q "$remote" "$repo"
+      checkout_git_openclaw_ref "$repo" "$ref"
+      selected="$(git -C "$repo" rev-parse HEAD)"
+      printf 'selected=%s tag=%s branch=%s kind=%s\n' "$selected" "$tag_head" "$branch_head" "$GIT_REF_KIND"
+      [[ "$selected" == "$tag_head" && "$selected" != "$branch_head" && "$GIT_REF_KIND" == "immutable" ]]
+    `);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("kind=immutable");
+    expect(result.stdout).toContain("selected=");
   });
 
   it("updates a stale existing main checkout from the remote tracking ref", () => {


### PR DESCRIPTION
## What Problem This Solves

A source install can request a pinned release tag but check out a same-name branch instead. An existing source checkout can also hide a failed `main` rebase and continue with conflicts.

Related: #127352
Related: #127411

## Why This Change Was Made

Both POSIX installers now use one ordered ref-resolution flow. Release-shaped selectors check the qualified tag first, then fall back to a branch only when the tag is absent. Other selectors retain branch-first behavior.

The selected ref kind is carried into lockfile selection, so tag installs stay frozen and moving branches remain updateable without a second remote lookup.

`main` updates now refresh `refs/remotes/origin/main` explicitly. A failed rebase aborts and verifies the original HEAD, porcelain state, and cleared rebase metadata before the installer reports a safe failure.

AI-assisted disclosure: This PR was prepared with Codex. The contributor reviewed and understood the original change. Maintainer verification rebased and simplified it against current `main` while preserving the intended behavior and contributor credit.

## User Impact

Pinned source installs select the requested release commit even when a branch has the same name. Moving branches still work when no matching release tag exists. Failed updates stop only after the original checkout is restored, or report that recovery could not be verified.

## Evidence

- Exact current main: `944cff7cefe25c9d919b42e7d82200a3cb98d13a`.
- Exact PR head: `68b5bcc182b909407c6395dc63688349a9fc5078`.
- The same real POSIX driver ran both `scripts/install-cli.sh` and `scripts/install.sh` against both revisions with separate bare Git remotes and unique commit markers.
- Current main selected the colliding branch in both installers and hid a conflicting rebase while leaving `UU state.txt`.
- The PR head selected the qualified tag commit, carried `immutable`, and chose `--frozen-lockfile`.
- The PR head fell back to a v-prefixed branch only when the tag was absent, carried `moving`, and chose `--no-frozen-lockfile`.
- Moving-main refresh and clean rebase passed in both installers.
- Conflicting rebase failed only after both installers restored the original HEAD and porcelain state, preserved `user-note.txt`, and cleared `rebase-merge` and `rebase-apply`.
- A rejecting `pre-rebase` hook failed with the saved HEAD and porcelain state verified, no rebase metadata present, and no impossible abort advice.
- `node scripts/run-vitest.mjs test/scripts/install-cli.test.ts test/scripts/install-sh.test.ts`: 238 tests passed.
- Every new bare-Git fixture removes its temporary repository on `EXIT`; the repository temp-creation report found no new warning.
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/install-cli.sh scripts/install.sh test/scripts/install-cli.test.ts test/scripts/install-sh.test.ts`: passed.
- `pnpm lint:scripts`, repository guards, and `git diff --check`: passed.
- Production installer delta: +154/-61, net +93. The branch keeps two mirrored implementations because each POSIX installer must run as a standalone downloaded script; the ordered flow remains smaller than the contributor version.
- No local build or type check ran on this host. Exact-head GitHub CI owns those checks.
