### PR TITLE
improve(installer): reduce Windows Git clone downloads

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1657,7 +1657,9 @@ function New-TransactionalGitCheckout {
     $retainStaging = $false
 
     try {
-        git clone $RepoUrl $stagingDir
+        # Keep ref metadata for later updates while avoiding file blobs. Git
+        # warns and falls back to a full clone when the server cannot filter.
+        git clone --filter=blob:none $RepoUrl $stagingDir
         if ($LASTEXITCODE -ne 0) {
             throw "git clone failed with exit code $LASTEXITCODE"
         }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -895,7 +895,7 @@ function Ensure-Git {
 function Test-GitFilterSupport {
     try {
         $help = (& git clone -h 2>&1 | Out-String)
-        return $help -match '(?m)\s--filter(?:[ =]|$)'
+        return $help -match '(?m)\s--(?:\[no-\])?filter(?:[ =]|$)'
     } catch {
         return $false
     }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -892,6 +892,15 @@ function Ensure-Git {
     return $false
 }
 
+function Test-GitFilterSupport {
+    try {
+        $help = (& git clone -h 2>&1 | Out-String)
+        return $help -match '(?m)\s--filter(?:[ =]|$)'
+    } catch {
+        return $false
+    }
+}
+
 function Get-OpenClawCommandPath {
     $openclawCmd = Get-Command openclaw.cmd -ErrorAction SilentlyContinue
     if ($openclawCmd -and $openclawCmd.Source) {
@@ -1657,9 +1666,15 @@ function New-TransactionalGitCheckout {
     $retainStaging = $false
 
     try {
-        # Keep ref metadata for later updates while avoiding file blobs. Git
-        # warns and falls back to a full clone when the server cannot filter.
-        git clone --filter=blob:none $RepoUrl $stagingDir
+        # Keep ref metadata for later updates while avoiding file blobs when
+        # the local Git client supports partial clones. Git warns and falls
+        # back to a full clone when the server cannot filter.
+        $cloneArgs = @("clone")
+        if (Test-GitFilterSupport) {
+            $cloneArgs += "--filter=blob:none"
+        }
+        $cloneArgs += @($RepoUrl, $stagingDir)
+        & git @cloneArgs
         if ($LASTEXITCODE -ne 0) {
             throw "git clone failed with exit code $LASTEXITCODE"
         }

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -722,7 +722,7 @@ describe("install.ps1 failure handling", () => {
           "$script:AliasReplacement = $null",
           "function git {",
           "  if ($args[0] -eq 'clone' -and $args[1] -eq '-h') {",
-          "    if ($script:GitFilterSupport) { Write-Output '  --filter <args>' }",
+          "    if ($script:GitFilterSupport) { Write-Output '  --[no-]filter <args>' }",
           "    $global:LASTEXITCODE = 129",
           "    return",
           "  }",
@@ -1284,7 +1284,7 @@ describe("install.ps1 failure handling", () => {
       'Invoke-NpmCommand -Arguments @("install", "-g", "--force", $pnpmSpec)',
     );
     expect(gitFilterSupportBody).toContain("git clone -h");
-    expect(gitFilterSupportBody).toContain("--filter");
+    expect(gitFilterSupportBody).toContain("filter");
     expect(transactionalCloneBody).toContain('$cloneArgs += "--filter=blob:none"');
     expect(transactionalCloneBody).toContain("& git @cloneArgs");
     expect(gitInstallBody.indexOf("New-TransactionalGitCheckout")).toBeLessThan(

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -1271,7 +1271,7 @@ describe("install.ps1 failure handling", () => {
     expect(ensurePnpmBody).toContain(
       'Invoke-NpmCommand -Arguments @("install", "-g", "--force", $pnpmSpec)',
     );
-    expect(transactionalCloneBody).toContain("git clone $RepoUrl $stagingDir");
+    expect(transactionalCloneBody).toContain("git clone --filter=blob:none $RepoUrl $stagingDir");
     expect(gitInstallBody.indexOf("New-TransactionalGitCheckout")).toBeLessThan(
       gitInstallBody.indexOf("Ensure-Pnpm -RepoDir $RepoDir"),
     );

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -715,10 +715,18 @@ describe("install.ps1 failure handling", () => {
           '$sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("openclaw-transactional-clone-" + [guid]::NewGuid().ToString("N"))',
           "New-Item -ItemType Directory -Path $sandbox | Out-Null",
           "$script:CloneMode = 'success'",
+          "$script:GitFilterSupport = $true",
+          "$script:LastCloneArgs = @()",
           "$script:ConcurrentRepo = $null",
           "$script:AliasPath = $null",
           "$script:AliasReplacement = $null",
           "function git {",
+          "  if ($args[0] -eq 'clone' -and $args[1] -eq '-h') {",
+          "    if ($script:GitFilterSupport) { Write-Output '  --filter <args>' }",
+          "    $global:LASTEXITCODE = 129",
+          "    return",
+          "  }",
+          "  if ($args[0] -eq 'clone') { $script:LastCloneArgs = @($args) }",
           "  $target = $args[-1]",
           "  New-Item -ItemType Directory -Force -Path (Join-Path $target '.git') | Out-Null",
           "  Set-Content -LiteralPath (Join-Path $target 'checkout.marker') -Value 'complete'",
@@ -738,11 +746,14 @@ describe("install.ps1 failure handling", () => {
           "  $successRepo = Join-Path $sandbox 'success'",
           "  New-TransactionalGitCheckout -RepoUrl 'https://example.invalid/openclaw.git' -RepoDir $successRepo",
           "  if (-not (Test-Path -LiteralPath (Join-Path $successRepo 'checkout.marker'))) { throw 'complete checkout was not published' }",
+          "  if ($script:LastCloneArgs -notcontains '--filter=blob:none') { throw 'supported Git did not use a filtered clone' }",
           "",
           "  $emptyRepo = Join-Path $sandbox 'empty'",
           "  New-Item -ItemType Directory -Path $emptyRepo | Out-Null",
+          "  $script:GitFilterSupport = $false",
           "  New-TransactionalGitCheckout -RepoUrl 'https://example.invalid/openclaw.git' -RepoDir $emptyRepo",
           "  if (-not (Test-Path -LiteralPath (Join-Path $emptyRepo 'checkout.marker'))) { throw 'empty destination was not populated' }",
+          "  if ($script:LastCloneArgs -contains '--filter=blob:none') { throw 'unsupported Git used a filtered clone' }",
           "",
           "  $aliasTarget = Join-Path $sandbox 'alias-target'",
           "  $script:AliasReplacement = Join-Path $sandbox 'alias-replacement'",
@@ -1244,6 +1255,7 @@ describe("install.ps1 failure handling", () => {
     const pnpmVersionBody = extractFunctionBody(source, "Get-RepoPnpmVersion");
     const pnpmVersionMatchBody = extractFunctionBody(source, "Test-PnpmCommandMatchesVersion");
     const ensurePnpmBody = extractFunctionBody(source, "Ensure-Pnpm");
+    const gitFilterSupportBody = extractFunctionBody(source, "Test-GitFilterSupport");
     const transactionalCloneBody = extractFunctionBody(source, "New-TransactionalGitCheckout");
     const gitInstallBody = extractFunctionBody(source, "Install-OpenClawFromGit");
     const nodeOptionsBody = extractFunctionBody(source, "Resolve-NodeOptionsWithMinOldSpace");
@@ -1271,7 +1283,10 @@ describe("install.ps1 failure handling", () => {
     expect(ensurePnpmBody).toContain(
       'Invoke-NpmCommand -Arguments @("install", "-g", "--force", $pnpmSpec)',
     );
-    expect(transactionalCloneBody).toContain("git clone --filter=blob:none $RepoUrl $stagingDir");
+    expect(gitFilterSupportBody).toContain("git clone -h");
+    expect(gitFilterSupportBody).toContain("--filter");
+    expect(transactionalCloneBody).toContain('$cloneArgs += "--filter=blob:none"');
+    expect(transactionalCloneBody).toContain("& git @cloneArgs");
     expect(gitInstallBody.indexOf("New-TransactionalGitCheckout")).toBeLessThan(
       gitInstallBody.indexOf("Ensure-Pnpm -RepoDir $RepoDir"),
     );


### PR DESCRIPTION
## What Problem This Solves

Fixes Windows source installs downloading every repository blob even though the installer can use a blobless checkout, creating unnecessary download time and disk use.

Related: #123823

## Why This Change Was Made

The PowerShell installer requests a blobless Git clone when the installed Git advertises either the legacy `--filter` or modern `--[no-]filter` help form. Older Git clients and remotes that cannot serve filtering retain the normal full-clone path and transactional cleanup behavior.

AI-assisted disclosure: This PR was prepared with Codex. I reviewed and understand the change; the prompt and session context are available in the authoring conversation.

## User Impact

Supported Windows Git installations download less data and use less temporary disk space during a fresh source install, while incompatible clients and remotes continue through the full-clone fallback.

## Evidence

- Exact PR head: `e876ca360acf6e89fa916d34f6b5eeb6f83918a4`
- Rebased onto current main `ae0e25c5038ff715a665951f1f093c6e6abaa9a9`; `git range-diff` preserved all three commits exactly.
- Secretless exact-head Windows proof: https://github.com/jason-allen-oneal/openclaw/actions/runs/33133984113
  - Ran on `windows-latest` with Git for Windows 2.55.0.windows.5 and Node 24.19.0.
  - The real `New-TransactionalGitCheckout` path completed a local filter-capable Git remote clone and reported `partialclonefilter=blob:none` with a materialized checkout.
  - The compatibility fallback used a filter-disabled local remote and a client-help path without filter support; the delegated real Git clone completed with no `--filter=blob:none` argument and a materialized checkout.
  - Proof marker: `real-windows-filter-proof=filtered-clone-and-compatible-fallback-verified`.
- The existing focused PowerShell installer coverage includes both capability-selection branches. A separate earlier proof attempt stopped in the unchanged `Resolve-PhysicalDirectoryPath` helper; upstream main contains the same helper source, so that baseline failure was left untouched rather than repaired or chased.
- `git diff --check` passed.
- No unrelated CI or test jobs were rerun; failures already matching the main baseline were left untouched.
- No merge or deployment has been performed.

## Maintainer validation

This PR is not merged. Maintainers can review the exact head and linked Windows proof run. This body update is the requested ClawSweeper re-review trigger.
