### PR TITLE
fix(reply): resume follow-up work after stuck-session recovery

### DIFF
--- a/src/auto-reply/reply/queue.in-flight.test.ts
+++ b/src/auto-reply/reply/queue.in-flight.test.ts
@@ -4,10 +4,12 @@ import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   completeFollowupRunLifecycle,
   enqueueFollowupRun,
+  FollowupRunDeferredError,
   getFollowupQueueDepth,
   scheduleFollowupDrain,
 } from "./queue.js";
 import { createQueueTestRun as createRun } from "./queue.test-helpers.js";
+import { prepareStaleFollowupDrainRetirement } from "./queue/drain.js";
 import { clearFollowupQueue, getExistingFollowupQueue } from "./queue/state.js";
 import type { FollowupRun, QueueDropPolicy, QueueSettings } from "./queue/types.js";
 
@@ -247,5 +249,101 @@ describe("followup queue in-flight ownership", () => {
 
     await expect.poll(() => getExistingFollowupQueue(key)).toBeUndefined();
     expect(groupCompletions.map((complete) => complete.mock.calls.length)).toEqual([1, 1]);
+  });
+
+  it("moves pending overflow state without replaying an active summary delivery", async () => {
+    const key = createKey("summary-recovery");
+    const settings: QueueSettings = {
+      mode: "followup",
+      debounceMs: 0,
+      cap: 1,
+      dropPolicy: "summarize",
+    };
+    const activeEntered = createDeferred();
+    const releaseZombie = createDeferred();
+    const calls: string[] = [];
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run.prompt);
+      if (calls.length === 1) {
+        activeEntered.resolve();
+        await releaseZombie.promise;
+      }
+    };
+
+    try {
+      enqueueFollowupRun(
+        key,
+        createRun({ prompt: "summary-active" }),
+        settings,
+        "none",
+        undefined,
+        false,
+      );
+      enqueueFollowupRun(
+        key,
+        createRun({ prompt: "summary-pending" }),
+        settings,
+        "none",
+        undefined,
+        false,
+      );
+      scheduleFollowupDrain(key, runFollowup);
+      await activeEntered.promise;
+      enqueueFollowupRun(key, createRun({ prompt: "item-pending" }), settings, "none", runFollowup);
+
+      const retire = prepareStaleFollowupDrainRetirement(key);
+      expect(retire).toBeTypeOf("function");
+      retire?.();
+      await vi.waitFor(() => expect(calls).toHaveLength(3));
+
+      expect(calls[0]).toContain("summary-active");
+      expect(calls[1]).toContain("summary-pending");
+      expect(calls[2]).toBe("item-pending");
+      releaseZombie.resolve();
+      await vi.waitFor(() => expect(getExistingFollowupQueue(key)).toBeUndefined());
+      expect(calls).toHaveLength(3);
+    } finally {
+      releaseZombie.resolve();
+    }
+  });
+
+  it("rejects stale retirement after the same source enters a new drain generation", async () => {
+    const key = createKey("generation-recovery");
+    const settings = createSettings("old");
+    const firstEntered = createDeferred();
+    const secondEntered = createDeferred();
+    const releaseFirst = createDeferred();
+    const releaseSecond = createDeferred();
+    const run = createRun({ prompt: "retry-same-source" });
+    let attempts = 0;
+    const runFollowup = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        firstEntered.resolve();
+        await releaseFirst.promise;
+        throw new FollowupRunDeferredError();
+      }
+      secondEntered.resolve();
+      await releaseSecond.promise;
+    };
+
+    try {
+      enqueueFollowupRun(key, run, settings, "none", runFollowup);
+      await firstEntered.promise;
+      const queue = getExistingFollowupQueue(key);
+      const retireFirstGeneration = prepareStaleFollowupDrainRetirement(key);
+      releaseFirst.resolve();
+      await secondEntered.promise;
+
+      retireFirstGeneration?.();
+      expect(getExistingFollowupQueue(key)).toBe(queue);
+      expect(run.queueAbortSignal?.aborted).toBe(false);
+      expect(attempts).toBe(2);
+    } finally {
+      releaseFirst.resolve();
+      releaseSecond.resolve();
+    }
+    await vi.waitFor(() => expect(getExistingFollowupQueue(key)).toBeUndefined());
+    expect(attempts).toBe(2);
   });
 });

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -132,6 +132,93 @@ export function kickFollowupDrainIfIdle(key: string): void {
   scheduleFollowupDrain(key, cb);
 }
 
+type FollowupQueueState = NonNullable<ReturnType<typeof FOLLOWUP_QUEUES.get>>;
+
+/** Capture one exact active drain generation for post-recovery retirement. */
+export function prepareStaleFollowupDrainRetirement(key: string): (() => void) | undefined {
+  const queue = FOLLOWUP_QUEUES.get(key);
+  if (!queue?.draining) {
+    return undefined;
+  }
+  const drainOwner = queue.drainOwner;
+  if (!drainOwner) {
+    return undefined;
+  }
+  const activeSources = new Set(queue.inFlight);
+  if (activeSources.size === 0) {
+    return undefined;
+  }
+  // Recovery awaits owner cleanup before redeeming this closure. Revalidation
+  // prevents an old recovery from fencing a queue that advanced to fresh work.
+  return () => {
+    if (
+      FOLLOWUP_QUEUES.get(key) !== queue ||
+      !queue.draining ||
+      queue.drainOwner !== drainOwner ||
+      activeSources.size !== queue.inFlight.size ||
+      ![...activeSources].every((source) => queue.inFlight.has(source))
+    ) {
+      return;
+    }
+
+    // Active identities may already be side-effecting, so remove rather than replay them.
+    removeQueuedItemsByRef(queue.items, [...activeSources]);
+    const activeSummarySources = [...activeSources].filter((source) =>
+      queue.activeSummarySources.has(source),
+    );
+    consumeQueueSummaryDelivery(
+      queue,
+      { droppedCount: activeSummarySources.length, sources: activeSummarySources },
+      false,
+    );
+    const replacement = {
+      ...queue,
+      abortController: new AbortController(),
+      items: [...queue.items],
+      draining: false,
+      drainOwner: undefined,
+      inFlight: new Set<FollowupRun>(),
+      summaryLines: [...queue.summaryLines],
+      summarySources: [...queue.summarySources],
+      activeSummarySources: new WeakSet<FollowupRun>(),
+      summaryElisions: queue.summaryElisions.map((entry) => ({
+        ...entry,
+        sources: [...entry.sources],
+        summaryLines: [...entry.summaryLines],
+        // A late summary delivery must not resolve an old source into pending state.
+        sourceRefs: new WeakMap<FollowupRun, FollowupRun>(),
+      })),
+    };
+    for (const source of [
+      ...replacement.items,
+      ...replacement.summarySources,
+      ...replacement.summaryElisions.flatMap((entry) => entry.sources),
+    ]) {
+      source.queueAbortSignal = replacement.abortController.signal;
+    }
+    const hasPendingWork = replacement.items.length > 0 || replacement.droppedCount > 0;
+    if (hasPendingWork) {
+      FOLLOWUP_QUEUES.set(key, replacement);
+    } else {
+      FOLLOWUP_QUEUES.delete(key);
+      clearFollowupDrainCallback(key);
+    }
+    queue.items.length = 0;
+    queue.droppedCount = 0;
+    queue.summaryLines = [];
+    queue.summarySources = [];
+    queue.summaryElisions = [];
+    queue.evictedSummaryCount = 0;
+    queue.abortController.abort();
+    for (const source of activeSources) {
+      completeFollowupRunLifecycle(source);
+    }
+    if (hasPendingWork) {
+      kickFollowupDrainIfIdle(key);
+    }
+  };
+}
+
 type OriginRoutingMetadata = Pick<
   FollowupRun,
   | "originatingChannel"
@@ -687,6 +774,7 @@ function resolveQueuedCronCreatorAuthorityUnavailable(
 
 type FollowupQueueSummaryState = {
   cap: number;
+  inFlight: Set<FollowupRun>;
   droppedCount: number;
   summaryLines: string[];
   summarySources: FollowupRun[];
@@ -751,7 +839,7 @@ function createQueueSummaryDelivery(params: {
 
 function consumeQueueSummaryDelivery(
   queue: FollowupQueueSummaryState,
-  delivery: QueueSummaryDelivery,
+  delivery: Pick<QueueSummaryDelivery, "droppedCount" | "sources">,
   completeLifecycles = true,
 ): void {
   let consumedCount = delivery.sources.length === 0 ? delivery.droppedCount : 0;
@@ -835,6 +923,7 @@ async function runQueueSummaryDelivery(
   );
   for (const source of protectedSources) {
     queue.activeSummarySources.add(source);
+    queue.inFlight.add(source);
   }
   let admitted = false;
   let deferredBeforeAdmission = false;
@@ -902,6 +991,7 @@ async function runQueueSummaryDelivery(
         ? new Set(protectedSources)
         : inheritedActiveSources;
     for (const source of protectedSources) {
+      queue.inFlight.delete(source);
       if (deferredBeforeAdmission && deferredCarryover.has(source)) {
         continue;
       }
@@ -918,16 +1008,21 @@ async function runQueueSummaryDelivery(
 }
 
 async function dropAbortedFollowups(
-  items: FollowupRun[],
+  queue: Pick<FollowupQueueState, "inFlight" | "items">,
   runFollowup: (run: FollowupRun) => Promise<void>,
 ): Promise<number> {
   let dropped = 0;
-  for (let index = items.length - 1; index >= 0; index -= 1) {
-    const item = expectDefined(items[index], "items entry at index");
+  for (let index = queue.items.length - 1; index >= 0; index -= 1) {
+    const item = expectDefined(queue.items[index], "items entry at index");
     if (isFollowupRunAborted(item)) {
-      await runFollowup(item);
-      completeFollowupRunLifecycle(item);
-      items.splice(index, 1);
+      queue.inFlight.add(item);
+      try {
+        await runFollowup(item);
+        completeFollowupRunLifecycle(item);
+        removeQueuedItemsByRef(queue.items, [item]);
+      } finally {
+        queue.inFlight.delete(item);
+      }
       dropped += 1;
     }
   }
@@ -998,15 +1093,20 @@ function resolveOverflowSummarySourceGroup(queue: {
 }
 
 async function drainProtectedPriorityFollowup(
-  items: FollowupRun[],
+  queue: Pick<FollowupQueueState, "inFlight" | "items">,
   runFollowup: (run: FollowupRun) => Promise<void>,
 ): Promise<boolean> {
-  const priority = items.find((item) => item.protectFromQueueOverflow === true);
+  const priority = queue.items.find((item) => item.protectFromQueueOverflow === true);
   if (!priority) {
     return false;
   }
-  await runFollowup(priority);
-  removeQueuedItemsByRef(items, [priority]);
+  queue.inFlight.add(priority);
+  try {
+    await runFollowup(priority);
+    removeQueuedItemsByRef(queue.items, [priority]);
+  } finally {
+    queue.inFlight.delete(priority);
+  }
   return true;
 }
 
@@ -1276,6 +1376,8 @@ export function scheduleFollowupDrain(
   if (!queue) {
     return;
   }
+  const drainOwner = {};
+  queue.drainOwner = drainOwner;
   const effectiveRunFollowup = FOLLOWUP_RUN_CALLBACKS.get(key) ?? runFollowup;
   const reserveOptions = {
     inFlight: queue.inFlight,
@@ -1292,7 +1394,7 @@ export function scheduleFollowupDrain(
     try {
       const collectState = { forceIndividualCollect: false };
       while (queue.items.length > 0 || queue.droppedCount > 0) {
-        await dropAbortedFollowups(queue.items, effectiveRunFollowup);
+        await dropAbortedFollowups(queue, effectiveRunFollowup);
         if (queue.items.length === 0 && queue.droppedCount === 0) {
           break;
         }
@@ -1301,7 +1403,7 @@ export function scheduleFollowupDrain(
           break;
         }
         await waitForQueueDebounce(queue, queue.abortController.signal);
-        await dropAbortedFollowups(queue.items, effectiveRunFollowup);
+        await dropAbortedFollowups(queue, effectiveRunFollowup);
         if (queue.items.length === 0 && queue.droppedCount === 0) {
           break;
         }
@@ -1309,7 +1411,7 @@ export function scheduleFollowupDrain(
           waitingForSteer = true;
           break;
         }
-        if (await drainProtectedPriorityFollowup(queue.items, effectiveRunFollowup)) {
+        if (await drainProtectedPriorityFollowup(queue, effectiveRunFollowup)) {
           continue;
         }
         if (queue.droppedCount > 0 && queue.items.some((item) => item.steerAnchor)) {
@@ -1529,24 +1631,25 @@ export function scheduleFollowupDrain(
         defaultRuntime.error?.(`followup queue drain failed for ${key}: ${String(err)}`);
       }
     } finally {
-      queue.draining = false;
-      const hasPendingQueueWork = queue.items.length > 0 || queue.droppedCount > 0;
-      if (waitingForSteer && hasPendingQueueWork) {
-        if (!queue.items.some((item) => item.steerPending)) {
+      // A recovery or explicit clear can replace this generation while its
+      // callback is still settling. Only the current owner may reschedule or
+      // mutate the key-scoped callback registry.
+      if (FOLLOWUP_QUEUES.get(key) === queue) {
+        queue.draining = false;
+        delete queue.drainOwner;
+        const hasPendingQueueWork = queue.items.length > 0 || queue.droppedCount > 0;
+        if (waitingForSteer && hasPendingQueueWork) {
+          if (!queue.items.some((item) => item.steerPending)) {
+            scheduleFollowupDrain(key, effectiveRunFollowup);
+          }
+        } else if (retryDeferred && hasPendingQueueWork) {
           scheduleFollowupDrain(key, effectiveRunFollowup);
-        }
-      } else if (retryDeferred && hasPendingQueueWork) {
-        scheduleFollowupDrain(key, effectiveRunFollowup);
-      } else if (!hasPendingQueueWork) {
-        // Only remove the map entry if it still points to this queue instance.
-        // clearSessionQueues can replace the entry mid-drain; deleting
-        // unconditionally would orphan the replacement queue.
-        if (FOLLOWUP_QUEUES.get(key) === queue) {
+        } else if (!hasPendingQueueWork) {
           FOLLOWUP_QUEUES.delete(key);
           clearFollowupDrainCallback(key);
+        } else {
+          scheduleFollowupDrain(key, effectiveRunFollowup);
         }
-      } else {
-        scheduleFollowupDrain(key, effectiveRunFollowup);
       }
     }
   };
@@ -1558,7 +1661,10 @@ export function scheduleFollowupDrain(
   void runWithGatewayIndependentRootWorkContinuation(() =>
     runOutsidePreparedModelRuntimePluginGenerationScope(drainQueuedFollowups),
   ).catch((err: unknown) => {
-    queue.draining = false;
+    if (FOLLOWUP_QUEUES.get(key) === queue && queue.drainOwner === drainOwner) {
+      queue.draining = false;
+      delete queue.drainOwner;
+    }
     defaultRuntime.error?.(`followup queue drain admission failed for ${key}: ${String(err)}`);
   });
 }

--- a/src/auto-reply/reply/queue/state.ts
+++ b/src/auto-reply/reply/queue/state.ts
@@ -21,6 +21,8 @@ type FollowupQueueState = {
   abortController: AbortController;
   items: FollowupRun[];
   draining: boolean;
+  /** Exact operational drain generation; recovery may retire only this owner. */
+  drainOwner?: object;
   /** Identities retained in `items` while delivery awaits; pending cap and depth must exclude them. */
   inFlight: Set<FollowupRun>;
   lastEnqueuedAt: number;

--- a/src/logging/diagnostic-stuck-session-followup-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-followup-recovery.integration.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { resolveEmbeddedSessionLane } from "../agents/embedded-agent-runner/lanes.js";
+import { testing as embeddedRunTesting } from "../agents/embedded-agent-runner/runs.test-support.js";
+import {
+  clearSessionQueues,
+  enqueueFollowupRun,
+  type FollowupRun,
+  type QueueSettings,
+} from "../auto-reply/reply/queue.js";
+import { createQueueTestRun } from "../auto-reply/reply/queue.test-helpers.js";
+import { createReplyOperation } from "../auto-reply/reply/reply-run-registry.js";
+import { testing as replyRunTesting } from "../auto-reply/reply/reply-run-registry.test-support.js";
+import { enqueueCommandInLane } from "../process/command-queue.js";
+import { resetCommandQueueStateForTest } from "../process/command-queue.test-support.js";
+import { recoverStuckDiagnosticSession } from "./diagnostic-stuck-session-recovery.runtime.js";
+
+describe("stuck session follow-up recovery", () => {
+  const queueKeys = new Set<string>();
+
+  afterEach(() => {
+    clearSessionQueues([...queueKeys]);
+    queueKeys.clear();
+    embeddedRunTesting.resetActiveEmbeddedRuns();
+    replyRunTesting.resetReplyRunRegistry();
+    resetCommandQueueStateForTest();
+  });
+
+  it.each(["followup", "collect"] as const)(
+    "continues pending %s work after force-clearing a wedged drain",
+    async (mode) => {
+      vi.useFakeTimers();
+      const sessionKey = `agent:main:wedged-${mode}-drain`;
+      const sessionId = `wedged-${mode}-drain-session`;
+      const settings: QueueSettings = { mode, debounceMs: 0, cap: 50 };
+      const activeEntered = createDeferred();
+      const releaseZombie = createDeferred();
+      const activeSettled = vi.fn();
+      const calls: string[] = [];
+      queueKeys.add(sessionKey);
+
+      const runFollowup = async (run: FollowupRun) => {
+        calls.push(run.prompt);
+        if (calls.length === 1) {
+          activeEntered.resolve();
+          await releaseZombie.promise;
+        }
+      };
+
+      try {
+        const active = createQueueTestRun({ prompt: "active" });
+        active.turnAdoptionLifecycle = {
+          onAdopted: async () => {},
+          onSettled: activeSettled,
+        };
+        enqueueFollowupRun(sessionKey, active, settings, "none", runFollowup);
+        await activeEntered.promise;
+        enqueueFollowupRun(
+          sessionKey,
+          createQueueTestRun({ prompt: "pending" }),
+          settings,
+          "none",
+          runFollowup,
+        );
+
+        const operation = createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+        operation.attachBackend({ kind: "embedded", cancel: () => {}, isStreaming: () => true });
+        operation.setPhase("running");
+        const recovery = recoverStuckDiagnosticSession({
+          sessionId,
+          sessionKey,
+          ageMs: 720_000,
+          queueDepth: 1,
+          allowActiveAbort: true,
+        });
+        await vi.advanceTimersByTimeAsync(15_100);
+
+        await expect(recovery).resolves.toMatchObject({
+          status: "aborted",
+          action: "abort_embedded_run",
+          forceCleared: true,
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(calls).toHaveLength(2);
+        expect(calls[0]).toContain("active");
+        expect(calls[1]).toContain("pending");
+        expect(activeSettled).toHaveBeenCalledOnce();
+
+        releaseZombie.resolve();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(calls).toHaveLength(2);
+        expect(activeSettled).toHaveBeenCalledOnce();
+      } finally {
+        releaseZombie.resolve();
+        await vi.runOnlyPendingTimersAsync();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("does not retire a fresh source that became active while recovery was settling", async () => {
+    vi.useFakeTimers();
+    const sessionKey = "agent:main:fresh-followup-owner";
+    const sessionId = "fresh-followup-owner-session";
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const firstEntered = createDeferred();
+    const secondEntered = createDeferred();
+    const releaseFirst = createDeferred();
+    const releaseSecond = createDeferred();
+    const calls: string[] = [];
+    queueKeys.add(sessionKey);
+
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run.prompt);
+      if (calls.length === 1) {
+        firstEntered.resolve();
+        await releaseFirst.promise;
+      } else if (calls.length === 2) {
+        secondEntered.resolve();
+        await releaseSecond.promise;
+      }
+    };
+
+    try {
+      enqueueFollowupRun(
+        sessionKey,
+        createQueueTestRun({ prompt: "stale" }),
+        settings,
+        "none",
+        runFollowup,
+      );
+      await firstEntered.promise;
+      enqueueFollowupRun(
+        sessionKey,
+        createQueueTestRun({ prompt: "fresh" }),
+        settings,
+        "none",
+        runFollowup,
+      );
+
+      const operation = createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+      operation.attachBackend({ kind: "embedded", cancel: () => {}, isStreaming: () => true });
+      operation.setPhase("running");
+      const recovery = recoverStuckDiagnosticSession({
+        sessionId,
+        sessionKey,
+        ageMs: 720_000,
+        queueDepth: 1,
+        allowActiveAbort: true,
+      });
+      releaseFirst.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      await secondEntered.promise;
+      await vi.advanceTimersByTimeAsync(15_100);
+
+      await expect(recovery).resolves.toMatchObject({ forceCleared: true });
+      expect(calls).toEqual(["stale", "fresh"]);
+      releaseSecond.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(calls).toEqual(["stale", "fresh"]);
+    } finally {
+      releaseFirst.resolve();
+      releaseSecond.resolve();
+      await vi.runOnlyPendingTimersAsync();
+      vi.useRealTimers();
+    }
+  });
+
+  it("continues pending work after releasing an ownerless stale lane task", async () => {
+    const sessionKey = "agent:main:ownerless-lane-followup";
+    const sessionId = "ownerless-lane-followup-session";
+    const settings: QueueSettings = { mode: "followup", debounceMs: 0, cap: 50 };
+    const activeEntered = createDeferred();
+    const releaseZombie = createDeferred();
+    const laneEntered = createDeferred();
+    const releaseLaneTask = createDeferred();
+    const calls: string[] = [];
+    queueKeys.add(sessionKey);
+
+    const runFollowup = async (run: FollowupRun) => {
+      calls.push(run.prompt);
+      if (calls.length === 1) {
+        activeEntered.resolve();
+        await releaseZombie.promise;
+      }
+    };
+    const laneTask = enqueueCommandInLane(resolveEmbeddedSessionLane(sessionKey), async () => {
+      laneEntered.resolve();
+      await releaseLaneTask.promise;
+    });
+
+    try {
+      await laneEntered.promise;
+      enqueueFollowupRun(
+        sessionKey,
+        createQueueTestRun({ prompt: "active" }),
+        settings,
+        "none",
+        runFollowup,
+      );
+      await activeEntered.promise;
+      enqueueFollowupRun(
+        sessionKey,
+        createQueueTestRun({ prompt: "pending" }),
+        settings,
+        "none",
+        runFollowup,
+      );
+
+      await expect(
+        recoverStuckDiagnosticSession({
+          sessionId,
+          sessionKey,
+          ageMs: 300_000,
+          queueDepth: 1,
+        }),
+      ).resolves.toMatchObject({
+        status: "released",
+        action: "release_lane",
+        reason: "stale_lane_task",
+      });
+      await vi.waitFor(() => expect(calls).toEqual(["active", "pending"]));
+
+      releaseZombie.resolve();
+      await vi.waitFor(() => expect(calls).toEqual(["active", "pending"]));
+    } finally {
+      releaseZombie.resolve();
+      releaseLaneTask.resolve();
+      await laneTask;
+    }
+  });
+});

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -11,6 +11,7 @@ import {
   resolveActiveEmbeddedRunHandleSessionIdBySessionFile,
 } from "../agents/embedded-agent-runner/runs.js";
 import { recoverTerminalSessionPlacementTurn } from "../agents/session-placement-admission.js";
+import { prepareStaleFollowupDrainRetirement } from "../auto-reply/reply/queue/drain.js";
 import {
   getCommandLaneActiveTaskIds,
   getCommandLaneSnapshot,
@@ -187,6 +188,7 @@ export async function recoverStuckDiagnosticSession(
         fileActiveWorkSessionId ??
         params.sessionId)
       : (fileActiveWorkSessionId ?? params.sessionId);
+    const retireStaleFollowupDrain = prepareStaleFollowupDrainRetirement(key);
     const sessionLane = key ? resolveEmbeddedSessionLane(key) : null;
     const preAbortActiveTaskIds = new Set(
       sessionLane ? getCommandLaneActiveTaskIds(sessionLane) : [],
@@ -335,6 +337,7 @@ export async function recoverStuckDiagnosticSession(
         // after the ownerless-lane window and only if no fresh task appeared.
         if (!laneStartedFreshTask && params.ageMs >= staleActiveLaneTaskReleaseMs) {
           const released = resetCommandLane(sessionLane);
+          retireStaleFollowupDrain?.();
           return reportRecoveryOutcome({
             status: "released",
             action: "release_lane",
@@ -378,6 +381,7 @@ export async function recoverStuckDiagnosticSession(
     const clearStaleSession = !aborted && released === 0 && !activeSessionId;
 
     if (aborted || forceCleared || released > 0 || clearStaleSession) {
+      retireStaleFollowupDrain?.();
       const action = aborted || forceCleared ? "abort_embedded_run" : "release_lane";
       const stoppedFields = formatStoppedCronSessionDiagnosticFields(
         resolveCronSessionDiagnosticContext({ sessionKey: params.sessionKey, activeSessionId }),


### PR DESCRIPTION
Fixes #130810

## What Problem This Solves

Fixes an issue where inbound messages queued behind a wedged session could remain silently stranded after stuck-session recovery. Recovery released the embedded run and command lane, but a non-settling follow-up callback could keep the separate follow-up queue marked as draining forever, so later accepted work never received a reply.

## Why This Change Was Made

The follow-up queue now owns an explicit identity for each drain generation. Stuck-session recovery captures that exact queue owner before waiting for run cleanup, then revalidates the queue, owner, and active source identities before transferring only pending work into a fresh queue generation. The active source is retired without replay, pending items and collect/overflow summary state are preserved, and the stale drain's late `finally` cannot delete, reorder, or reschedule the replacement with its old callback.

This owner-boundary transfer is necessary because an ordinary drain kick is intentionally a no-op while `draining` is true, clearing the old queue would discard accepted pending work, and the stale callback is specifically the operation that may never settle after the bounded run abort. The additional production state and transfer logic (+141/-29, net +112) express that previously missing lifecycle ownership; no config, schema, protocol, storage, or provider behavior changes.

## User Impact

After stuck-session recovery, queued inbound messages continue in FIFO order instead of silently remaining behind a zombie drain. Work that may already be side-effecting is not replayed, and a fresh drain generation that starts during recovery is left untouched.

## Evidence

- **Exact current-main red:** on `6b1eacad93819efeb324e056aa57a782d6280bd5`, the unchanged owner-boundary regression failed 3/4. Follow-up, collect, and ownerless-lane cases observed only the active source; accepted pending work never ran.
- **Exact rebased-head green:** on `a1c77b5d6231b61047cbf6b647d45bf7680b8b0f`, the same regression passed 4/4. The broader queue, recovery, finalizer, collect, overflow, cleanup, and current-main peer-isolation set passed 217/217.
- **Live-proof reuse:** the rebased commit has the same stable patch ID (`8a854770cf599b520246be824e75bfcfa9c96971`) as the live-proven head below, and `git range-diff` reports it unchanged. The live mock-Gateway result remains under the 24-hour reuse window; the exact rebased head also passed the focused race suite against current main.
- **Ephemeral mock-Gateway verdict (PASS, exact head `600e101e9f14bf4ed03f59e38cca88bc6bf49eaa`):** a real built Gateway accepted a baseline turn, an active `queueMode=followup` turn, and two later follow-ups through `chat.send`; replies were observed through persisted `chat.history`. A proof-only environment-gated fault held the active follow-up's outer finalizer after its reply committed, reproducing a non-settling drain callback without changing the submitted source.
- **Observed recovery boundary:** before recovery the real queue was `draining=true`, had a drain owner, `inFlight=1`, `items=3`, and `droppedCount=0`. Production `recoverStuckDiagnosticSession` returned `status=aborted`, `action=abort_embedded_run`, `forceCleared=true`. The replacement queue then drained and disappeared.
- **Delivery/result assertions:** provider execution counts were active=1, pending-first=1, pending-second=1. Persisted assistant history was exactly `BASELINE`, `ACTIVE`, `PENDING_FIRST`, `PENDING_SECOND`; the active source committed once, both pending replies committed once in FIFO order, and releasing the late old finalizer produced no replay or duplicate.
- **Current-main compatibility:** the contributor commit was replayed onto `main` at `6b1eacad93819efeb324e056aa57a782d6280bd5`. The replay preserved the newer `conversationRoutePeerId` collect-key discriminator. The exact rebased head passed 217/217 adjacent tests.
- **Proof limitations:** this uses Gateway `chat.send`/`chat.history` and a deterministic mock OpenAI provider, not authenticated Slack or a live model. The watchdog age decision was bypassed by invoking the production recovery runtime directly. The finalizer fault was proof-only because the reporter's rare original wedge is not safely reproducible on demand. These substitutions are the mock-Gateway alternative requested by review, not a claim of live Slack proof.
- **Focused green (fresh local run):** `diagnostic-stuck-session-followup-recovery.integration.test.ts` passed 4/4, covering follow-up/collect continuation after force-clear, fresh-owner fencing, and ownerless stale-lane release. `queue.in-flight.test.ts` passed 6/6, covering overflow, collect, `drop:new`, active summary non-replay, and stale-generation rejection.
- **Owner-boundary red check (not live):** with the new stale-owner retirement points and active lifecycle settlement temporarily disabled, `diagnostic-stuck-session-followup-recovery.integration.test.ts` produced 3 failures / 1 pass. The failures showed pending ownerless-lane work did not advance and active follow-up/collect lifecycles did not settle.
- **Broader focused green:** final queue identity, stuck-recovery integration, and queue-owner shards passed 11/11; the logging runtime/integration plus queue-owner suites passed 59/59; the wider adjacent queue/recovery set passed 180/180.
- **Sibling/race coverage:** the tests cover individual and collect modes, an active source that must not replay, pending FIFO continuation, summary/overflow migration, a fresh owner appearing during recovery, idempotent lifecycle settlement, ownerless stale-lane release, and a zombie drain settling after replacement.
- **Static validation:** messaging and plugins-platform exact test type graphs passed; the core production type check passed; the first 18 `check:changed` gates passed, including dead-export analysis; oxlint, schema-version, database-first, runtime-sidecar, import-cycle (0 cycles), webhook/auth guards, and `git diff --check` passed.
- **Exact-head CI:** [run 33242005100](https://github.com/openclaw/openclaw/actions/runs/33242005100) is green for `a1c77b5d6231b61047cbf6b647d45bf7680b8b0f`, including `openclaw/ci-gate`, production/test type checks, lint, guards, and changed-config shards.
- **Final local ClawSweeper:** exact-head review passed with `patch is correct`, zero findings, cleared security, no maintainer decision, and zero Rank-up moves.
- **Full core test type graph:** attempted once; it ran for 749 seconds without emitting a type error, then was manually stopped (exit 130) because the full graph did not finish in the available local window. The affected exact type graphs above completed successfully. This is not reported as a passing full type-graph run.
- **Review:** one `codex review --base origin/main` attempt ran for about 48 minutes without reporting a finding and was stopped. Independent best-fix and history/provenance source reviews completed; they confirmed the follow-up queue lifecycle as the canonical owner and found no equivalent current-main or open-PR fix.

<details>
<summary><strong>Inspectable redacted mock-Gateway verdict JSON</strong></summary>

The JSON below is the proof harness verdict emitted by the exact-head run. Only ephemeral session/lane identifiers were redacted; assertion values, observed history, request counts, recovery fields, harness substitutions, and limitations are unchanged.

```json
{
  "verdict": "PASS",
  "headSha": "600e101e9f14bf4ed03f59e38cca88bc6bf49eaa",
  "harness": {
    "gateway": "ephemeral child",
    "channel": "Gateway chat.send + persisted chat.history (qa-channel configured but not used for delivery)",
    "provider": "mock-openai",
    "recoveryTrigger": "proof-only loopback control invoking production recovery runtime",
    "fault": "proof-only environment-gated followup-runner finalizer holds the active reply owner past the 15s recovery settle window"
  },
  "reporterPath": [
    "baseline active turn",
    "active follow-up produces one reply, then its outer followup-runner finalizer deterministically wedges",
    "two later inbound messages are accepted into the same follow-up queue",
    "production stuck-session recovery force-clears the old owner",
    "replacement drain delivers both pending replies once and FIFO",
    "late old follow-up finalizer completion cannot replay or mutate the fresh generation"
  ],
  "recovery": {
    "status": "aborted",
    "action": "abort_embedded_run",
    "sessionKey": "[redacted ephemeral session key]",
    "activeSessionId": "[redacted ephemeral session id]",
    "activeWorkKind": "embedded_run",
    "aborted": false,
    "drained": false,
    "forceCleared": true,
    "released": 0,
    "lane": "[redacted ephemeral lane]"
  },
  "queueBeforeRecovery": {
    "key": "[redacted ephemeral queue key]",
    "draining": true,
    "hasDrainOwner": true,
    "inFlight": 1,
    "items": 3,
    "droppedCount": 0
  },
  "chatHistoryAssistantTexts": [
    "PR130911_BASELINE_READY",
    "PR130911_WEDGED_ACTIVE_REPLY",
    "PR130911_PENDING_FIRST_OK",
    "PR130911_PENDING_SECOND_OK"
  ],
  "providerRequestCounts": {
    "activeRequestsIncludingToolContinuations": 1,
    "pendingFirst": 1,
    "pendingSecond": 1
  },
  "assertions": {
    "baselineInboundAccepted": true,
    "activeInboundAccepted": true,
    "pendingInboundAccepted": true,
    "realQueueObserved": true,
    "recoveryForceCleared": true,
    "activeInitialProviderExecutionCountOne": true,
    "activeFaultExecutionCountOne": true,
    "activeCommittedDeliveryExactlyOnce": true,
    "noUnexpectedFaultTextDelivered": true,
    "firstPendingProviderExecutionCountOne": true,
    "secondPendingProviderExecutionCountOne": true,
    "firstPendingDeliveredExactlyOnce": true,
    "secondPendingDeliveredExactlyOnce": true,
    "pendingDeliveredFifo": true,
    "lateZombieProducedNoDuplicate": true,
    "freshQueueDrained": true,
    "sessionRegistryRowObserved": true
  },
  "limitations": [
    "Gateway chat.send/chat.history and mock-openai replace authenticated Slack transport and a live model",
    "the watchdog decision time is bypassed; the production recoverStuckDiagnosticSession runtime is invoked directly",
    "the environment-gated followup finalizer wait is deterministic fault injection because the reporter could not reproduce the original rare trigger on demand"
  ]
}
```

</details>

<details>
<summary><strong>Inspectable terminal trace excerpts</strong></summary>

Exact-head mock-Gateway run:

```text
RUN  v4.1.11
PASS  PR #130911 stuck follow-up mock-Gateway proof
  resumes pending qa-channel replies once and in FIFO order without replaying the wedged source
Test Files  1 passed (1)
Tests       1 passed (1)
Duration    45.06s (tests 41.67s)
```

Temporary current-main merge result (`74d1852f730c3f095184808256179a36c3d9e4fd` + PR head):

```text
Automatic merge went well; stopped before committing as requested

diagnostic-stuck-session-followup-recovery.integration.test.ts
Test Files  1 passed (1)
Tests       4 passed (4)

queue.in-flight.test.ts
Test Files  1 passed (1)
Tests       6 passed (6)
```

</details>

Production LOC: +141/-29 (net +112) | Tests: +330/-0

<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>
