### PR TITLE
fix(plugins): inspect activation routes

### DIFF
--- a/src/cli/plugins-cli.inspect.test.ts
+++ b/src/cli/plugins-cli.inspect.test.ts
@@ -188,6 +188,7 @@ describe("plugins cli inspect", () => {
       expect(buildPluginDiagnosticsReportMock).toHaveBeenLastCalledWith({
         config: {},
         onlyPluginIds: ["openclaw-mem0"],
+        toolDiscovery: true,
       });
       expect(pluginsCliRuntimeLogs.at(-1)).toContain("Gateway discovery:\nmem0-runtime-discovery");
     }

--- a/src/cli/plugins-inspect-command.ts
+++ b/src/cli/plugins-inspect-command.ts
@@ -152,6 +152,7 @@ export async function runPluginsInspectCommand(
             buildPluginDiagnosticsReport({
               config: cfg,
               ...loggerParams,
+              toolDiscovery: true,
             }),
           { command: "inspect", all: true },
         )
@@ -274,6 +275,7 @@ export async function runPluginsInspectCommand(
             config: cfg,
             ...loggerParams,
             onlyPluginIds: [targetPlugin.id],
+            toolDiscovery: true,
           }),
         { command: "inspect", pluginId: targetPlugin.id },
       )

--- a/src/plugins/loader.node-host-commands.test.ts
+++ b/src/plugins/loader.node-host-commands.test.ts
@@ -14,6 +14,51 @@ afterAll(cleanupPluginLoaderFixturesForTest);
 // The node host resolves its registry via loadPluginRegistryHandle (activate:false).
 // Static nodeHostCommands (e.g. the browser plugin's browser.proxy) must register
 // there too, or headless meeting/browser nodes silently lose their surface.
+it("registers HTTP routes in tool discovery without activating channel runtime", () => {
+  useNoBundledPlugins();
+  const plugin = writePlugin({
+    id: "http-route-discovery",
+    body: `module.exports = {
+      id: "http-route-discovery",
+      register(api) {
+        if (api.registrationMode === "tool-discovery") {
+          api.registerHttpRoute({ path: "/discovery", auth: "plugin", handler: async () => true });
+        }
+      },
+    };`,
+  });
+  const config = {
+    plugins: {
+      load: { paths: [plugin.file] },
+      allow: [plugin.id],
+    },
+  };
+
+  const snapshot = loadOpenClawPlugins({
+    cache: false,
+    activate: false,
+    workspaceDir: plugin.dir,
+    config,
+    onlyPluginIds: [plugin.id],
+  });
+  const diagnostics = loadOpenClawPlugins({
+    cache: false,
+    activate: false,
+    toolDiscovery: true,
+    workspaceDir: plugin.dir,
+    config,
+    onlyPluginIds: [plugin.id],
+  });
+
+  expect(snapshot.httpRoutes).toHaveLength(0);
+  expect(diagnostics.httpRoutes).toHaveLength(1);
+  expect(diagnostics.httpRoutes[0]).toMatchObject({ path: "/discovery", pluginId: plugin.id });
+  expect(diagnostics.channels).toHaveLength(0);
+});
+
+// The node host resolves its registry via loadPluginRegistryHandle (activate:false).
+// Static nodeHostCommands (e.g. the browser plugin's browser.proxy) must register
+// there too, or headless meeting/browser nodes silently lose their surface.
 it("registers static nodeHostCommands without activation", () => {
   useNoBundledPlugins();
   const plugin = writePlugin({

--- a/src/plugins/loader.node-host-commands.test.ts
+++ b/src/plugins/loader.node-host-commands.test.ts
@@ -11,8 +11,52 @@ import {
 afterEach(resetPluginLoaderTestStateForTest);
 afterAll(cleanupPluginLoaderFixturesForTest);
 
-// The node host resolves its registry via loadPluginRegistryHandle (activate:false).
-// Static nodeHostCommands (e.g. the browser plugin's browser.proxy) must register
+it("registers HTTP routes in tool discovery without activating channel runtime", () => {
+  useNoBundledPlugins();
+  const plugin = writePlugin({
+    id: "http-route-discovery",
+    body: `module.exports = {
+      id: "http-route-discovery",
+      register(api) {
+        if (api.registrationMode === "tool-discovery") {
+          api.registerHttpRoute({
+            path: "/discovery",
+            auth: "plugin",
+            handler: async () => true,
+          });
+        }
+      },
+    };`,
+  });
+  const config = {
+    plugins: {
+      load: { paths: [plugin.file] },
+      allow: [plugin.id],
+    },
+  };
+
+  const snapshot = loadOpenClawPlugins({
+    cache: false,
+    activate: false,
+    workspaceDir: plugin.dir,
+    config,
+    onlyPluginIds: [plugin.id],
+  });
+  const diagnostics = loadOpenClawPlugins({
+    cache: false,
+    activate: false,
+    toolDiscovery: true,
+    workspaceDir: plugin.dir,
+    config,
+    onlyPluginIds: [plugin.id],
+  });
+
+  expect(snapshot.httpRoutes).toHaveLength(0);
+  expect(diagnostics.httpRoutes).toHaveLength(1);
+  expect(diagnostics.httpRoutes[0]).toMatchObject({ path: "/discovery", pluginId: plugin.id });
+  expect(diagnostics.channels).toHaveLength(0);
+});
+
 // there too, or headless meeting/browser nodes silently lose their surface.
 it("registers HTTP routes in tool discovery without activating channel runtime", () => {
   useNoBundledPlugins();

--- a/src/plugins/status.ts
+++ b/src/plugins/status.ts
@@ -196,6 +196,8 @@ type PluginReportParams = {
   env?: NodeJS.ProcessEnv;
   logger?: PluginLogger;
   metadataSnapshot?: PluginMetadataSnapshot;
+  /** Run plugin registration in the non-activating tool-discovery mode. */
+  toolDiscovery?: boolean;
 };
 
 function buildPluginReport(
@@ -276,6 +278,9 @@ function buildPluginReport(
               loadModules,
               cache: false,
               onlyPluginIds,
+              ...(params?.toolDiscovery !== undefined
+                ? { toolDiscovery: params.toolDiscovery }
+                : {}),
             }),
           ),
         { surface: "status", onlyPluginCount: onlyPluginIds?.length },


### PR DESCRIPTION
Closes #130773

## What Problem This Solves

`openclaw plugins inspect <plugin> --runtime --json` reported `httpRouteCount: 0` for channel plugins whose inbound routes are registered from `registerFull`. The inspect command loaded the plugin with ordinary non-activating discovery, which intentionally skipped `registerFull`, so operators received a false diagnostic even while the Gateway served the route.

## Root Cause

The loader already has a non-activating `tool-discovery` registration mode. `defineChannelPluginEntry` runs `registerFull` in that mode while omitting channel runtime wiring and long-lived activation side effects. Runtime plugin inspection did not request this mode, so route registration callbacks were not executed.

## Fix

- Add an internal `toolDiscovery` status-report option.
- Pass it only from explicit `plugins inspect --runtime` paths, for both single-plugin and `--all` inspection.
- Keep ordinary snapshots, Gateway loading, and unrelated non-activating registry callers unchanged.
- Exercise a route-bearing plugin through the loader to verify ordinary discovery reports no route while tool discovery reports the route without activating a channel.

## User Impact

Operators using runtime inspection now see HTTP routes registered by activation-capable channel plugins instead of a misleading zero. The diagnostic load remains non-activating: channel runtime registration is not performed.

## Evidence

- Exact head: `9ee66e994`.
- Focused tests passed: `46` focused tests across plugin status, CLI inspect, loader, and plugin SDK channel-entry suites.
- Loader regression: ordinary discovery produced `httpRoutes: 0`; explicit `toolDiscovery: true` produced one `/discovery` route and zero activated channels.
- CLI regression: both plugin-id and display-name runtime inspection forward `toolDiscovery: true`.
- `pnpm check:changed -- src/plugins/status.ts src/cli/plugins-inspect-command.ts src/cli/plugins-cli.inspect.test.ts src/plugins/loader.node-host-commands.test.ts` passed, including core typecheck, core-test typecheck, lint, formatting, dependency guards, dead-code checks, and import-cycle checks.

## Scope And Risk

This is scoped to the explicit runtime inspection command. Other plugin loading paths retain their existing registration mode and activation behavior. `tool-discovery` is already an established loader mode and channel-entry contract; this change only selects it for the command that needs activation-derived diagnostics.

AI-assisted implementation; I reviewed the loader registration plan, channel-entry registration contract, status projection, CLI inspect path, existing tool-discovery consumers, and focused regression output.



## Exact-head runtime proof

On exact head `079e6560d`, an isolated temporary route-bearing plugin was loaded through the real `src/entry.ts plugins inspect route-demo --runtime --json` CLI with a temporary config and state directory. The redacted result was:

```json
{
  "pluginId": "route-demo",
  "status": "loaded",
  "httpRouteCount": 1,
  "pluginHttpRoutes": 1,
  "channelIds": 0,
  "diagnostics": []
}
```

The fixture registers its route only for `tool-discovery`, so `channelIds: 0` confirms no channel runtime registration. This proof exercises the real CLI, status projection, runtime load-options propagation, loader registration plan, and plugin registry route counter.