### PR TITLE
fix(usage): usage view stays on "cache is rebuilding" when sessions are archived

### DIFF
--- a/src/infra/session-cost-usage-aggregation.ts
+++ b/src/infra/session-cost-usage-aggregation.ts
@@ -53,6 +53,8 @@ type UsageCostJsonlCheckpoint = {
   kind: "jsonl";
   parsedOffset: number;
   observedSize: number;
+  // Checkpoints follow scanned-file identity, not archive activity time.
+  // Otherwise discovery and per-session refreshes invalidate each other.
   observedMtimeMs: number;
   device: number;
   inode: number;
@@ -162,7 +164,7 @@ export function isUsageCostRollupFresh(params: {
   if (checkpoint.kind === "jsonl") {
     return (
       checkpoint.observedSize === params.file.size &&
-      checkpoint.observedMtimeMs === params.file.mtimeMs &&
+      checkpoint.observedMtimeMs === params.file.contentMtimeMs &&
       checkpoint.device === params.file.device &&
       checkpoint.inode === params.file.inode
     );
@@ -435,7 +437,7 @@ async function scanJsonlUsageRollup(params: {
     kind: "jsonl",
     parsedOffset: processedOffset,
     observedSize: params.file.size,
-    observedMtimeMs: params.file.mtimeMs,
+    observedMtimeMs: params.file.contentMtimeMs,
     device: params.file.device ?? 0,
     inode: params.file.inode ?? 0,
     anchorHash,

--- a/src/infra/session-cost-usage-collection.ts
+++ b/src/infra/session-cost-usage-collection.ts
@@ -42,7 +42,10 @@ export type UsageCostTranscriptFile = {
   filePath: string;
   kind: "jsonl" | "sqlite";
   size: number;
+  /** Session activity time; compressed archives keep source mtime for ranges and ordering. */
   mtimeMs: number;
+  /** Scanned file identity time; compressed archives use the materialized file mtime. */
+  contentMtimeMs: number;
   sessionId?: string;
   device?: number;
   inode?: number;
@@ -102,6 +105,7 @@ async function listUsageCountedTranscriptFileStats(
             kind: "jsonl",
             size: materializedStats.size,
             mtimeMs: stats.mtimeMs,
+            contentMtimeMs: materializedStats.mtimeMs,
             device: materializedStats.dev,
             inode: materializedStats.ino,
           };
@@ -117,6 +121,7 @@ async function listUsageCountedTranscriptFileStats(
         kind: "jsonl",
         size: stats.size,
         mtimeMs: stats.mtimeMs,
+        contentMtimeMs: stats.mtimeMs,
         device: stats.dev,
         inode: stats.ino,
       };
@@ -159,6 +164,7 @@ function listUsageCountedSqliteTranscriptStats(
       filePath: formatCanonicalUsageCostSqliteMarker(marker),
       kind: "sqlite",
       mtimeMs,
+      contentMtimeMs: mtimeMs,
       sessionId: marker.sessionId,
       size: stats.sizeBytes,
       eventCount: stats.eventCount,
@@ -203,6 +209,7 @@ export async function resolveUsageCostTranscriptFile(
       filePath: formatCanonicalUsageCostSqliteMarker(marker),
       kind: "sqlite",
       mtimeMs: stats.lastMutationAtMs ?? 0,
+      contentMtimeMs: stats.lastMutationAtMs ?? 0,
       sessionId: marker.sessionId,
       size: stats.sizeBytes,
       eventCount: stats.eventCount,
@@ -219,6 +226,7 @@ export async function resolveUsageCostTranscriptFile(
         kind: "jsonl",
         size: materializedStats.size,
         mtimeMs: archiveStats.mtimeMs,
+        contentMtimeMs: materializedStats.mtimeMs,
         device: materializedStats.dev,
         inode: materializedStats.ino,
       };
@@ -233,6 +241,7 @@ export async function resolveUsageCostTranscriptFile(
         kind: "jsonl",
         size: stats.size,
         mtimeMs: stats.mtimeMs,
+        contentMtimeMs: stats.mtimeMs,
         device: stats.dev,
         inode: stats.ino,
       }

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -2451,12 +2451,12 @@ describe("session cost usage", () => {
     });
   });
 
-  it("keeps compressed archive rollup identity stable for direct session queries", async () => {
-    const root = await makeSessionCostRoot("session-compressed-archive");
+  it("keeps a compressed archive fresh across usage paths", async () => {
+    const root = await makeSessionCostRoot("archive-cross-path-freshness");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
     const encoded = encodeSessionArchiveContent(
-      transcriptText("sess-compressed", {
+      transcriptText("sess-cross-path", {
         type: "message",
         timestamp: "2026-02-12T10:00:00.000Z",
         message: {
@@ -2470,22 +2470,39 @@ describe("session cost usage", () => {
     }
     const archivePath = path.join(
       sessionsDir,
-      `sess-compressed.jsonl.reset.2026-02-12T11-00-00.000Z${encoded.suffix}`,
+      `sess-cross-path.jsonl.deleted.2026-02-12T11-00-00.000Z${encoded.suffix}`,
     );
     await fs.writeFile(archivePath, encoded.bytes);
+    // Keep activity time distinct from the materialized file identity.
+    const archivedAt = new Date("2026-02-12T11:00:00.000Z");
+    await fs.utimes(archivePath, archivedAt, archivedAt);
 
     await withStateDir(root, async () => {
-      const first = await loadSessionCostSummary({
-        sessionId: "sess-compressed",
-        sessionFile: archivePath,
-      });
-      const repeat = await loadSessionCostSummary({
-        sessionId: "sess-compressed",
-        sessionFile: archivePath,
-      });
+      const discovered = await discoverAllSessions({ includeFirstUserMessage: false });
+      expect(discovered).toHaveLength(1);
+      const session = requireValue(
+        discovered[0],
+        "expected the compressed archive to be discovered",
+      );
+      expect(session.mtime).toBe(archivedAt.getTime());
 
-      expect(first?.totalTokens).toBe(10);
-      expect(repeat?.totalTokens).toBe(10);
+      for (let round = 0; round < 3; round += 1) {
+        await loadCostUsageSummary({});
+        const { cacheStatus } = await loadSessionCostSummariesFromCache({
+          sessions: [{ sessionId: session.sessionId, sessionFile: session.sessionFile }],
+        });
+        const direct = await loadSessionCostSummary({
+          sessionId: session.sessionId,
+          sessionFile: archivePath,
+        });
+        expect(cacheStatus).toMatchObject({
+          cachedFiles: 1,
+          pendingFiles: 0,
+          staleFiles: 0,
+          status: "fresh",
+        });
+        expect(direct?.totalTokens).toBe(10);
+      }
     });
   });
 


### PR DESCRIPTION
Closes #130912

🤖 **AI-assisted** — authored with Claude Code (Claude Opus 5). The contributor reviewed the change and validated it against a live Gateway.

## What Problem This Solves

Compressed archived transcripts can leave the Control UI Usage page on “Usage cache is rebuilding” forever. The page calls `usage.cost` and `sessions.usage`; each route recorded a different freshness timestamp for the same archive rollup.

## Why This Change Was Made

Transcript discovery already owns both facts that differ for a compressed archive:

- `mtimeMs` is the source archive activity time used for range filtering and ordering.
- `contentMtimeMs` is the materialized JSONL file time used with its path, size, device, and inode for cache freshness.

The descriptor now carries both required facts. JSONL checkpoints write and compare `contentMtimeMs`. Plain JSONL and SQLite inputs set both times to the same value.

This keeps the repair at the identity owner. It does not add a timestamp fallback or change the SQLite schema. Existing rebuildable rows self-heal on their next refresh, so the rollup version does not need a global bump.

The separate compressed-archive session-ID defect remains tracked in #130918.

## User Impact

The Usage page settles to fresh after archived sessions are compressed. OpenClaw stops rescanning the same archived transcripts on every page refresh. No configuration, migration, or operator action is required.

## Evidence

Exact current-main red proof used `e6efad25278fcd1d65b0310e4c53673b0650f72c`. Exact repaired-head green proof used `c66e94af9f97467ec3256ed1d65ffe440b8cdb55`.

A real isolated Gateway loaded one backdated zstd archive. Six rounds called both `usage.cost` and `sessions.usage` with unique ranges, then the repaired head reused the same archive and persisted cache.

| Revision | `usage.cost` | `sessions.usage` |
| --- | --- | --- |
| Main, 6 rounds | `refreshing`, 1 stale, 1 pending | `refreshing`, 1 stale, 1 pending, 0 cached |
| Head, 6 rounds | `fresh`, 0 stale, 0 pending, 1 cached | `fresh`, 0 stale, 0 pending, 1 cached |

The head's `refreshedAt` value stayed unchanged across all 12 calls, which confirms that the cache stopped rewriting the archive rollup.

Local validation:

- `node scripts/run-vitest.mjs src/infra/session-cost-usage.test.ts src/infra/session-cost-usage-cache.sqlite.test.ts src/infra/session-cost-usage-refresh.test.ts` — 68 passed.
- `node scripts/run-vitest.mjs src/config/sessions/archive-compression.test.ts src/gateway/server-methods/usage.sessions-usage-cache.test.ts` — 15 passed.
- Focused formatting and Oxlint passed.
- Max-lines, assertion-safety, database-first, import-cycle, conflict-marker, and diff checks passed.
- Both exact revisions completed full builds and built-CLI smoke checks on isolated Linux state.

Judged line count: production +13/-2, net +11; tests +31/-14, net +17. The production growth is the required second identity fact at the owner boundary.
