### PR TITLE
fix(plugins): report ClawHub tags as floating install sources

### DIFF
--- a/src/plugins/install-source-info.test.ts
+++ b/src/plugins/install-source-info.test.ts
@@ -3,6 +3,27 @@ import { describe, expect, it } from "vitest";
 import { describePluginInstallSource } from "./install-source-info.js";
 
 describe("describePluginInstallSource", () => {
+  it.each([
+    [undefined, false],
+    ["latest", false],
+    ["beta", false],
+    ["1.2.3", true],
+    ["1.2.3-beta.4", true],
+    ["2026.7.1-2", true],
+    ["v1.2.3", true],
+  ])("classifies ClawHub selector %s with exactVersion=%s", (version, exactVersion) => {
+    const spec = `clawhub:demo${version ? `@${version}` : ""}`;
+    expect(describePluginInstallSource({ clawhubSpec: spec })).toEqual({
+      clawhub: {
+        spec,
+        packageName: "demo",
+        ...(version ? { version } : {}),
+        exactVersion,
+      },
+      warnings: exactVersion ? [] : ["clawhub-spec-floating"],
+    });
+  });
+
   it("marks exact npm specs with integrity as fully pinned", () => {
     expect(
       describePluginInstallSource({

--- a/src/plugins/install-source-info.ts
+++ b/src/plugins/install-source-info.ts
@@ -1,7 +1,11 @@
 /** Describes package-authored plugin install source metadata and pinning warnings. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
-import { parseRegistryNpmSpec, type ParsedRegistryNpmSpec } from "../infra/npm-registry-spec.js";
+import {
+  isExactSemverVersion,
+  parseRegistryNpmSpec,
+  type ParsedRegistryNpmSpec,
+} from "../infra/npm-registry-spec.js";
 import type { PluginPackageInstall } from "./manifest.js";
 import { normalizePluginInstallDefaultChoice } from "./plugin-install-default-choice.js";
 
@@ -103,14 +107,15 @@ export function describePluginInstallSource(
   if (clawhubSpec) {
     const parsed = parseClawHubPluginSpec(clawhubSpec);
     if (parsed) {
-      if (!parsed.version) {
+      const exactVersion = parsed.version ? isExactSemverVersion(parsed.version) : false;
+      if (!exactVersion) {
         warnings.push("clawhub-spec-floating");
       }
       clawhub = {
         spec: clawhubSpec,
         packageName: parsed.name,
         ...(parsed.version ? { version: parsed.version } : {}),
-        exactVersion: Boolean(parsed.version),
+        exactVersion,
       };
     } else {
       warnings.push("invalid-clawhub-spec");


### PR DESCRIPTION
Closes #130914

## What Problem This Solves

Fixes an issue where plugin catalog consumers would see ClawHub selectors such as `@latest` and `@beta` described as exact versions, without a floating-source warning. Those tags can resolve to different releases over time.

## Why This Change Was Made

The shared install-source metadata producer now uses the existing exact-semver classifier for both exactness and the floating-source warning. This fixes installed-plugin index and provider catalog metadata together, without changing installation, tag selection, or trust policy. Fixing either consumer separately would duplicate policy and leave the other incorrect.

## User Impact

Plugin diagnostics and provider setup catalogs correctly distinguish ClawHub tags from exact versions. Exact stable, prerelease, correction, and `v`-prefixed versions keep their existing classification. No configuration, schema, or public API change.

## Evidence

On current-main base `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`, 120 focused tests passed across the metadata owner, both parsers, provider catalog, and installed-plugin index:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/install-source-info.test.ts src/infra/clawhub-spec.test.ts src/infra/npm-registry-spec.test.ts src/plugins/provider-install-catalog.test.ts src/plugins/installed-plugin-index.test.ts
node_modules/.bin/oxfmt --check src/plugins/install-source-info.ts src/plugins/install-source-info.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/plugins/install-source-info.test.ts src/plugins/install-source-info.ts
git diff --check
```

The new latest/beta cases failed before the repair. The implicated owner, parsers, and metadata consumers are unchanged from that reproduced base. A clean Linux probe also discovered seven real temporary plugin manifests through both actual consumers: all14 checks passed, and plugin runtime code remained unexecuted. This is filesystem/API proof, not live ClawHub service proof; no external service behavior changes. That broader candidate also passed build/type checks. Fresh isolated Codex autoreview of this separate patch is clean at the configured P0 threshold. Exact-head PR CI will provide the final integration gate.

Production: +8/-3 (net+5: four import-formatting lines and one shared classification fact). Tests: +21/-0. No new helper, export, dependency, or alternate flow.

Provenance: the faulty presence check is in commit 11daaad3d06c853fee2b12a8c09cda65c2267eaf (May2, authored and committed by @vincentkoc); no associated PR was returned by GitHub. The same source exists in stable tag v2026.7.1-2.

AI-assisted maintainer repair; source, tests, and runtime evidence were inspected.
