### PR TITLE
fix: keep portal retry-page tests on an owned target port

### DIFF
--- a/src/gateway/portals/portal-http-proxy.test.ts
+++ b/src/gateway/portals/portal-http-proxy.test.ts
@@ -510,23 +510,16 @@ describe("portal HTTP proxy", () => {
     expect(body).toBe("streamed request");
   });
 
-  it("shows a retry page while the target is down", async () => {
-    const unavailableTarget = createServer();
-    await new Promise<void>((resolve) => {
-      unavailableTarget.listen(0, "127.0.0.1", resolve);
-    });
-    const port = (unavailableTarget.address() as AddressInfo).port;
-    await new Promise<void>((resolve) => {
-      unavailableTarget.close(() => resolve());
-    });
-    const portal = await portalService().open({ targetPort: port });
+  it("shows a retry page when the target closes the connection", async () => {
+    targetHandler = (_req, res) => res.destroy();
+    const portal = await portalService().open({ targetPort });
 
     const result = await httpCall({
       port: portal.listenPort,
       headers: { Cookie: portalAuthCookie(portal) },
     });
     expect(result.status).toBe(502);
-    expect(result.body).toContain(`Waiting for the app on port ${port}…`);
+    expect(result.body).toContain(`Waiting for the app on port ${targetPort}…`);
     expect(result.body).toContain('http-equiv="refresh" content="2"');
   });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where portal retry-page tests could contact an unrelated server when another listener reclaimed the test's released target port. The fixture assumed that closing a temporary listener reserved its port for the later proxy request.

## Why This Change Was Made

Reuse the suite-owned target server and have it close the connection before sending response headers. The fixture keeps ownership of its listener instead of releasing the target port before the request. This preserves the local proxy's generic request-error path and removes the temporary listen/close sequence.

The stimulus deliberately changes from a refused connection to a closed connection. This does not claim direct `ECONNREFUSED` coverage; both reach the same errno-independent retry-page handler. The existing 502 status, target-port text, and two-second refresh assertions remain intact.

## User Impact

No runtime or user-visible behavior changes. Portal tests no longer depend on an unowned port remaining unused. Production changes: 0 lines. Test changes: +4/-11, net -7.

## Evidence

Reviewed head: `8cb60314afaea730c273d382afc10d28e5e3b625`.

- Controlled before proof used a real competing listener to reclaim the released port. In the full original-order proxy suite, 26 tests passed and the retry-page test failed with HTTP 200 instead of the expected 502.
- After the fixture change, the full proxy and service sibling suites passed: 42 tests across 2 files, including the existing HTTP, WebSocket, worker, and streaming cases.
- Targeted formatting and `git diff --check` passed.
- Local typed lint did not reach lint execution: SDK declaration preparation failed on missing types in the shared dependency install (`FinishReason.TOO_MANY_TOOL_CALLS`, `markdown-it` exports, and `TuiMainScreen`). No dependency files or gate settings were changed. The exact-head hosted lint and test-type checks subsequently passed.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33076277322) passed on its first attempt: 52 jobs (30 successful, 22 skipped), including lint, test types, and the required gate. The [hosted portal test job](https://github.com/openclaw/openclaw/actions/runs/33076277322/job/98531494794) ran all 27 proxy tests successfully (381 ms). The precise regression scan also passed.
- Codex P2 autoreview completed with no actionable findings. Independent source and proof review approved the final diff and the recorded before/after results.

Focused verification commands:

```sh
node scripts/run-vitest.mjs src/gateway/portals/portal-http-proxy.test.ts src/gateway/portals/portal-service.test.ts --configLoader runner --maxWorkers 1
node_modules/.bin/oxfmt --check src/gateway/portals/portal-http-proxy.test.ts
git diff --check
```
