### PR TITLE
fix(ui): UI commands stall on large tsx caches

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
-import { runTsxCliShim } from "./lib/tsx-cli-shim.mjs";
+import { runUiCli } from "./ui.mts";
 
-await runTsxCliShim(import.meta.url, { implementation: "./ui.mts", detached: false });
+// Native imports avoid loader startup and leave process lifetime with the UI owner.
+runUiCli();

--- a/scripts/ui.mts
+++ b/scripts/ui.mts
@@ -409,7 +409,7 @@ function resolveScriptAction(action: string): "dev" | "build" | "test" | null {
   return null;
 }
 
-function main(argv: string[] = process.argv.slice(2)): void {
+export function runUiCli(argv: string[] = process.argv.slice(2)): void {
   const [action, ...rest] = argv;
   if (!action) {
     usage();
@@ -501,5 +501,5 @@ export function isDirectScriptExecution(
 const isDirectExecution = isDirectScriptExecution();
 
 if (isDirectExecution) {
-  main();
+  runUiCli();
 }

--- a/ui/src/build-info-normalizers.ts
+++ b/ui/src/build-info-normalizers.ts
@@ -1,8 +1,8 @@
 // Shared build identity normalization for the runtime artifact and Vite config.
-// Vite loads this module before source-package aliases exist, so use the canonical source path.
-import { asRecord } from "../../packages/normalization-core/src/record-coerce.js";
-import { normalizeNullableString } from "../../packages/normalization-core/src/string-coerce.js";
-import { truncateUtf16Safe } from "../../packages/normalization-core/src/utf16-slice.js";
+// Vite and native Node need explicit source paths before source-package aliases exist.
+import { asRecord } from "../../packages/normalization-core/src/record-coerce.ts";
+import { normalizeNullableString } from "../../packages/normalization-core/src/string-coerce.ts";
+import { truncateUtf16Safe } from "../../packages/normalization-core/src/utf16-slice.ts";
 import type { ControlUiBuildInfo } from "./build-info-types.ts";
 
 type ControlUiBuildMetadata = Pick<


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This same-repository branch remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where developers starting UI commands would wait several seconds before pnpm even started when the shared tsx transform cache had grown large. The existing wrapper lifecycle tests consequently failed their three-second readiness checks before any SIGTERM, SIGHUP, or descendant-cleanup assertion could run.

The same three failures reproduced on macOS arm64 with Node 24.19.0 and Node 26.7.0. This is a pre-existing launcher regression, not a pnpm version migration or a reason to raise the tests' timeouts.

## Why This Change Was Made

The documented JavaScript launcher now calls the existing UI lifecycle owner through a native-Node-compatible TypeScript import closure. Three relative imports identify their actual `.ts` source files, removing the launcher's unnecessary tsx bootstrap and redundant supervisor without changing the implementation of pnpm selection, foreground process handling, signal forwarding, descendant cleanup, or build validation.

The shared tsx shim is unchanged. No cache is cleared or disabled, no environment is forced, and no dependency or baseline is changed. The existing tests are unchanged.

Provenance: the unnecessary supervisor was introduced by the JavaScript-to-TypeScript tooling migration in https://github.com/openclaw/openclaw/pull/121005 (2026-08-09; code/PR author and merger: @steipete). The later build-info import needed `.js`-to-`.ts` resolution, but its dependency-free leaf modules do not need a transpiler.

## User Impact

UI commands can reach their pnpm child promptly without depending on the size of a shared transform cache. In the same host environment, real wrapper readiness improved from 7.79 seconds to 173 ms on Node 24 and 164 ms on Node 26, while signal-preserving shutdown continued to work. There is no visual UI, configuration, or persistent-data behavior change.

Production/tooling LOC: **+9/-8 (net +1 comment; executable LOC neutral)**. Tests/test support: **+0/-0**.

## Evidence

Before editing at `0924fd9a0c401464d6257ca59a160d1b292f5441`, the following exact command reproduced **3 failed / 28 passed**, stopping in the tooling group:

```bash
pnpm test test/scripts/ui.test.ts test/scripts/control-ui-performance.test.ts ui/src/app/vite-config.node.test.ts ui/src/app/control-ui-chunking.test.ts
```

The failures were the existing SIGTERM, SIGHUP, and descendant-cleanup cases at `test/scripts/ui.test.ts:347` and `:396`, all at readiness. The same package-script entrypoint and target order reproduced them on Node 26.7.0.

A diagnostic trace of installed tsx 4.23.12 identified `FileCache.getDiskCacheIndex()` performing a synchronous `readdirSync` of 716,596 cache entries before the first TypeScript transform: **6.28 seconds** on Node 24. Node 26 repeated the same mechanism with 719,336 entries and an **11.04-second** directory scan. Plain Node startup and Git discovery were only tens of milliseconds. The real wrapper missed the unchanged 3,000 ms deadline, became ready at 7.79 seconds, then exited correctly on SIGTERM; the pnpm fixture itself was not the bottleneck.

After the repair on the investigation base:

- The unchanged ordered tests passed **57/57 on Node 24.19.0** and **57/57 on Node 26.7.0**.
- pnpm runner, build-identity, build-info writer, and UI build-info sibling tests passed **40/40**.
- Real Node 24/26 readiness and signal probes, plus Bun 1.4.0 launch/signal probes, passed without cache or environment changes.
- The canonical UI build passed both existing validators, including 770 finalized sidecars and unchanged compressed-asset budgets.
- The complete classified `check:changed` gate passed, including core-test/UI/scripts typechecks, scoped lint, guards, script erasability, and dead-export checks.
- Isolated Codex autoreview reported no accepted/actionable findings at the default P0 threshold.

```bash
pnpm ui:build
```

```bash
pnpm test test/scripts/pnpm-runner.test.ts test/scripts/build-identity.test.ts test/scripts/write-build-info.test.ts ui/src/build-info.test.ts
```

```bash
node scripts/check-changed.mjs -- scripts/ui.js scripts/ui.mts ui/src/build-info-normalizers.ts
```

Node 22 and Windows execution were not available for the initial local proof; portable Windows pnpm argument contracts passed in the sibling tests. A full-repository build/test sweep was not used as a substitute for the focused process-boundary proof. Broader upstream tsx cache indexing remains a separate dependency follow-up, not part of this patch.

Refreshed after the mechanical rebase onto `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`, at exact head `4b60d450f00622f76422b32dc76300b8f3c07920`:

- The literal ordered `pnpm test` command above passed **61/61** with the host's current Node 26.7.0 default. The same package-script entrypoint (`node --import tsx scripts/test-projects.mts`, same four targets/order) passed **61/61** when explicitly invoked with installed Node 24.19.0.
- The sibling command above passed **40/40**.
- Canonical `pnpm ui:build` passed both validators: **772 finalized sidecars**, startup JS **342,555 B** under the current main-derived **344,620 B** enforcement limit, startup CSS **42.6 KiB** under **45 KiB**. This PR changes no performance baselines or validator policy.
- Fresh real wrapper readiness/SIGTERM probes passed on Node 24 and Node 26. The three source files remain the only diff; the shared shim, pnpm resolver, tests, dependencies, and baselines remain unchanged.
- A fresh isolated review of the committed patch completed clean at the default P0 threshold. The full classified check above is investigation-base proof; it was not rerun merely for the mechanical rebase. Exact-head hosted CI is required before landing; current status is recorded below.

AI-assisted (Codex).


### CI diagnosis and bounded retry

The first exact-head [CI attempt](https://github.com/openclaw/openclaw/actions/runs/33076565371/attempts/1) failed [build-artifacts job98532451830](https://github.com/openclaw/openclaw/actions/runs/33076565371/job/98532451830) at the built-CLI startup-memory check. `plugins list --json` had a 401.21484375 MB median against the existing 401 MB ceiling. The build itself completed; the failure was in the subsequent artifact checks.

The successful publication-base [CI run33074529883](https://github.com/openclaw/openclaw/actions/runs/33074529883) and both PR attempts measured the existing median of three independent cold-home executions, with a 400 MB base limit plus 1 MB tolerance:

| Measurement | Samples (MB) | Median (MB) | Result |
| --- | --- | ---: | --- |
| Base9bd50c8 | 401.203125,399.8046875,400.19140625 | 400.19140625 | Pass |
| PR attempt1 | 401.21484375,401.84375,371.765625 | 401.21484375 | Fail |
| PR attempt2 | 399.81640625,402.328125,400.40625 | 400.40625 | Pass |

One maintainer-authorized diagnostic retry of the failed job was requested with `gh run rerun 33076565371 --job 98532451830`. [Attempt2](https://github.com/openclaw/openclaw/actions/runs/33076565371/attempts/2) completed successfully, including [build-artifacts job98539406088](https://github.com/openclaw/openclaw/actions/runs/33076565371/job/98539406088) and aggregate `openclaw/ci-gate` job98540744311. The entire exact-head CI run is green. Both attempts checked synthetic merge02cf9378, merging head `4b60d450f00622f76422b32dc76300b8f3c07920` into base `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`, on `blacksmith-32vcpu-ubuntu-2404` with the unchanged 401 MB ceiling. Retry artifact9649136669 confirms the samples, limit, and successful command exits. No new workflow dispatch, source push, routing change, threshold/baseline adjustment, or environment workaround was used.

The original median overage was not reproduced by this single same-budget retry. The cause of the near-threshold startup-memory variance is not established; investigating it remains a named follow-up outside this launcher repair. The memory check and CLI/plugin runtime source are unchanged by this PR.

ClawSweeper found no concrete correctness or security defect and rated the patch 4/6. Its cross-platform rank-up request is accounted for: both hosted Windows lanes passed; `checks-node-compat-node22` completed as **skipped** by CI classification, not passed. Node22 execution remains an explicit proof gap under this focused validation scope. The selected CI gates, Node24/26 owner-boundary proof, and original Bun proof are complete; no extra workflow dispatch is being added for the optional rank-up. Native review artifacts are refreshed for the exact unchanged head before preparation.
