### PR TITLE
fix(browser): click the first duplicate raw accessibility ref

### DIFF
--- a/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
@@ -133,6 +133,7 @@ describe.runIf(process.env.OPENCLAW_BROWSER_SNAPSHOT_E2E === "1")(
           { id: "raw-short", name: "Raw named control" },
           { id: "raw-empty", name: "" },
           { id: "raw-long", name: "x".repeat(901) },
+          { id: "raw-short-again", name: "Raw named control" },
         ];
         await page.evaluate((controls) => {
           for (const { id, name } of controls) {

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.test.ts
@@ -433,7 +433,7 @@ describe("pw-tools-core aria snapshot storage", () => {
       cdpUrl: "http://127.0.0.1:9222",
       targetId: "tab-1",
       refs: {
-        ax1: { role: "button", name: "OK" },
+        ax1: { role: "button", name: "OK", nth: 0 },
         ax2: { role: "button", name: "OK", nth: 1 },
         ax3: { role: "button", name: "" },
       },

--- a/extensions/browser/src/browser/pw-tools-core.snapshot.ts
+++ b/extensions/browser/src/browser/pw-tools-core.snapshot.ts
@@ -104,25 +104,21 @@ function buildStoredAriaRefs(
 ): Record<string, { role: string; name?: string; nth?: number; domMarker?: boolean }> {
   const refs: Record<string, { role: string; name?: string; nth?: number; domMarker?: boolean }> =
     {};
-  const counts = new Map<string, number>();
   const refsByKey = new Map<string, string[]>();
 
   for (const node of nodes) {
     const role = normalizeLowercaseStringOrEmpty(node.role) || "unknown";
     const name = node.name.trim();
     const key = `${role}:${name}`;
-    const nth = counts.get(key) ?? 0;
-    counts.set(key, nth + 1);
-    const refsForKey = refsByKey.get(key);
-    if (refsForKey) {
-      refsForKey.push(node.ref);
-    } else {
-      refsByKey.set(key, [node.ref]);
-    }
+    const refsForKey = refsByKey.get(key) ?? [];
+    const nth = refsForKey.length;
+    refsForKey.push(node.ref);
+    refsByKey.set(key, refsForKey);
     refs[node.ref] = {
       role,
       name,
-      ...(nth > 0 ? { nth } : {}),
+      // Keep index zero for duplicates; only singleton groups can omit nth.
+      nth,
       ...(markedRefs.has(node.ref) ? { domMarker: true } : {}),
     };
   }


### PR DESCRIPTION
Closes #130925
Related: #130879 (broader snapshot membership/ordering; intentionally remains open).

## What Problem This Solves

Fixes an issue where users clicking the first of multiple identically named controls would get a strict-mode error when raw accessibility refs fall back to role/name lookup. The later duplicate retained its ordinal, but the first one did not.

## Why This Change Was Made

The raw AX snapshot producer omitted index zero before it knew whether the group was unique. Store all ordinals, then let the existing singleton cleanup remove unnecessary indices, as the role-snapshot sibling already does. Derive each ordinal from the existing ref group and delete the redundant counter map. The action consumer, DOM-marker precedence, native refs, and target-cache contract are unchanged; there is no new fallback or configuration surface.

Best-fix verdict: repair the producer's incomplete duplicate metadata, not the strict locator consumer. Always choosing the first match downstream would hide ambiguous singleton refs and leave stored metadata wrong.

Provenance: the conditional ordinal is present in `e10f20032a01e34dc169e720aeb6408828831124` (2026-04-25; Peter Steinberger author/committer, MrKipler coauthor), and was carried forward by #130881. No associated PR for the original commit was found. This is not attributed to the latest unnamed-ref repair.

Production LOC: +6/−10 (net −4). Tests: +2/−1 (net +1). No new dependency, API, config, schema, or protocol surface.

## User Impact

The first and later duplicate raw AX fallback refs can select their corresponding controls when the snapshot and locator membership agree. Unique refs remain unindexed. This does not solve the distinct membership/ordering cases tracked in #130879 and does not claim that ordinary marker-backed clicks were broken.

Release-note context: Browser: preserve the first duplicate control's ordinal when resolving raw accessibility snapshot refs without DOM markers.

## Evidence

- Baseline: main `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`. Existing real-Chromium fixture passed. Adding only a second `Raw named control` button made it fail with unchanged production code: `getByRole('button', { name: 'Raw named control', exact: true }) resolved to 2 elements`.
- Candidate: 105 tests passed across `pw-role-snapshot.chromium.test.ts`, `pw-tools-core.snapshot.test.ts`, `pw-role-snapshot.test.ts`, and `pw-session.test.ts`. Chromium was explicitly enabled with `OPENCLAW_BROWSER_SNAPSHOT_E2E=1`; the test captures genuine AX nodes, removes backend IDs to select fallback, restores the target cache on another page wrapper, and asserts each click's output. Existing empty/long-name, singleton, DOM-marker, native-ref and cache cases remain covered.
- Siblings: 52 tests passed across `pw-session.page-cdp.test.ts`, `routes/agent.snapshot.test.ts`, `routes/agent.snapshot.local-managed.test.ts`, and `pw-tools-core.interactions.batch.test.ts`.
- Wider current-main QA: 64 CLI/configure/status tests passed (separate from the 157 browser assertions).
- Dependency contract personally inspected: installed Playwright-core 1.62.1 `lib/coreBundle.js` uses strict locator clicks and zero-based `nth` selection; `types/types.d.ts` documents `nth(0)`. Both raw-ARIA route entry points, ref storage/restoration, the action consumer, and normal role-snapshot siblings were inspected.
- Exact final diff passed Codex autoreview's P0 gate and an independent P0–P3 source/dependency review with no actionable findings. `git diff --check` and formatting passed.

Reproduction command in a provisioned checkout:

```sh
OPENCLAW_BROWSER_SNAPSHOT_E2E=1 node scripts/run-vitest.mjs run extensions/browser/src/browser/pw-role-snapshot.chromium.test.ts
```

Local proof limitations: macOS 26.6.2 / Node 24.19.0; the sparse worktree used a private dependency resolver to an existing checkout and Vitest 4.1.10, not the lockfile's 4.1.11. Playwright-core matched 1.62.1. The normal lint wrapper could not derive plugin SDK type inputs; this is not a full local build/type/lint pass. Exact-head hosted CI is required before native landing. This is real headless-Chromium owner-flow evidence, not an installed CLI/Gateway or authenticated channel/provider smoke. No visual UI layout changes or operator browser state are involved.
