### PR TITLE
fix(update): retain registry failures in update status

### DIFF
--- a/src/infra/update-check.test.ts
+++ b/src/infra/update-check.test.ts
@@ -606,6 +606,53 @@ describe("formatGitInstallLabel", () => {
 });
 
 describe("checkUpdateStatus registry behavior", () => {
+  it.each([
+    { channel: "stable", tag: "latest" },
+    { channel: "beta", tag: "beta" },
+    { channel: "dev", tag: "dev" },
+  ] as const)("preserves $channel registry failures in status", async ({ channel, tag }) => {
+    for (const queryTag of channel === "beta" ? ["beta", "latest"] : [tag]) {
+      mockHttp.intercept({
+        url: `https://registry.npmjs.org/openclaw/${queryTag}`,
+        reply: { status: 503, body: "unavailable" },
+      });
+    }
+
+    const status = await checkUpdateStatus({
+      root: null,
+      includeRegistry: true,
+      registryChannel: channel,
+      timeoutMs: 1000,
+    });
+
+    expect(status.registry).toEqual({ latestVersion: null, tag, error: "HTTP 503" });
+  });
+
+  it.each(["beta", "latest"])(
+    "uses the available beta-channel target when %s fails",
+    async (failedTag) => {
+      const selectedTag = failedTag === "beta" ? "latest" : "beta";
+      for (const tag of ["beta", "latest"]) {
+        mockHttp.intercept({
+          url: `https://registry.npmjs.org/openclaw/${tag}`,
+          reply:
+            tag === failedTag
+              ? { status: 503, body: "unavailable" }
+              : { json: { version: "2026.6.6" } },
+        });
+      }
+
+      const status = await checkUpdateStatus({
+        root: null,
+        includeRegistry: true,
+        registryChannel: "beta",
+        timeoutMs: 1000,
+      });
+
+      expect(status.registry).toEqual({ latestVersion: "2026.6.6", tag: selectedTag });
+    },
+  );
+
   it("reports unsupported_git_channel for Git status without querying npm", async () => {
     await withTestDir({ prefix: "openclaw-update-check-git-channel-" }, async (root) => {
       await fs.writeFile(

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -485,6 +485,7 @@ async function fetchNpmRegistryVersionForChannel(params: {
   return {
     latestVersion: res.version,
     tag: res.tag,
+    error: res.error,
     ...(res.reason ? { error: res.reason, reason: res.reason } : {}),
   };
 }
@@ -521,11 +522,7 @@ export async function resolveNpmChannelTag(params: {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
   runCommand?: NpmMetadataCommandRunner;
-}): Promise<{
-  tag: string;
-  version: string | null;
-  reason?: ExtendedStableFailureReason;
-}> {
+}): Promise<NpmTagStatus & { reason?: ExtendedStableFailureReason }> {
   const channelTag = channelToNpmTag(params.channel);
   if (params.channel === "extended-stable") {
     const resolved = await resolveExtendedStablePackage({
@@ -545,7 +542,7 @@ export async function resolveNpmChannelTag(params: {
     runCommand: params.runCommand,
   });
   if (params.channel !== "beta") {
-    return { tag: channelTag, version: channelStatus.version };
+    return channelStatus;
   }
 
   const latestStatus = await fetchNpmTagVersion({
@@ -557,16 +554,16 @@ export async function resolveNpmChannelTag(params: {
     runCommand: params.runCommand,
   });
   if (!latestStatus.version) {
-    return { tag: channelTag, version: channelStatus.version };
+    return channelStatus;
   }
   if (!channelStatus.version) {
-    return { tag: "latest", version: latestStatus.version };
+    return latestStatus;
   }
   const cmp = compareSemverStrings(channelStatus.version, latestStatus.version);
   if (cmp != null && cmp < 0) {
-    return { tag: "latest", version: latestStatus.version };
+    return latestStatus;
   }
-  return { tag: channelTag, version: channelStatus.version };
+  return channelStatus;
 }
 
 export function compareSemverStrings(a: string | null, b: string | null): number | null {


### PR DESCRIPTION
Closes #130928

## What Problem This Solves

Fixes an issue where users checking `openclaw update status` or `openclaw status` would receive an incomplete update summary when the stable, beta, or dev registry lookup failed. JSON omitted the failure, and human output omitted the existing unknown-status diagnostic.

## Why This Change Was Made

Channel selection rebuilt the selected registry response with only its tag and version, discarding its error. Returning the selected response intact and preserving its error in the status adapter repairs the shared owner without changing version selection, extended-stable diagnostics, or successful beta fallback.

The lossy resolver originated in [3d5ffee](https://github.com/openclaw/openclaw/commit/3d5ffee07fa78b7d7b3f9bdb13df81b861f9960f) (author/committer @steipete, 2026-01-20) and became visible in channel-aware status through [d68ca42](https://github.com/openclaw/openclaw/commit/d68ca425bd983e1d28fb5427bb77b8796290196a) (author/committer @vincentkoc, 2026-05-02).

## User Impact

Failed lookups now retain `registry.error` in JSON and display `npm latest unknown`, `npm beta unknown`, or `npm dev unknown`. When either beta or latest succeeds, beta-channel selection still uses that available result without leaking the failed alternative's error. No settings, storage, installation, or automatic-update behavior changes.

## Evidence

The new boundary regressions failed before the fix for all three channels because `error: "HTTP 503"` was missing. After porting onto `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`, **69 tests passed across four shards**, covering registry errors, both successful beta alternatives, existing status formatting, channel selection, and CLI option handling:

```sh
node scripts/run-vitest.mjs src/infra/update-check.test.ts src/commands/status.update.test.ts src/commands/status.update-channel.test.ts src/cli/update-cli.option-collisions.test.ts
```

**Twelve actual built-CLI cases also passed** on the earlier QA candidate based on `ac71743ca44a1927ddf8bcd3b32d71b60e27c0ac`: real public npm success; HTTP 503 responses injected through an isolated HTTPS proxy; JSON/human diagnostics for stable/beta/dev; and both beta fallback directions with the healthy target fetched from public npm. No package update ran. The affected owner, callers, transport, and tests are unchanged between that baseline and the current PR base; this earlier runtime proof is separate from the fresh test run above.

Fresh independent review reported no P0 issues; its scope was P0-only. Production **+7/−10 lines (net −3)**; regression tests **+47 lines**. The repair removes five lossy response reconstructions and reuses the existing result type.

AI-assisted maintainer repair; source and proof inspected.
