### PR TITLE
fix(otel): preserve trailing slashes in collector query values

### DIFF
--- a/extensions/diagnostics-otel/README.md
+++ b/extensions/diagnostics-otel/README.md
@@ -14,7 +14,7 @@ Restart the Gateway after installing or updating the plugin.
 
 ## Configure
 
-Enable the plugin and set the OTLP endpoint in `plugins.entries.diagnostics-otel.config`.
+Enable the plugin, set `diagnostics.otel.enabled` to `true`, and set the collector URL in `diagnostics.otel.endpoint`.
 
 The full config surface, metric names, span names, and collector examples live in the docs:
 

--- a/extensions/diagnostics-otel/src/service-exporter.ts
+++ b/extensions/diagnostics-otel/src/service-exporter.ts
@@ -16,7 +16,7 @@ import type {
 
 export function normalizeEndpoint(endpoint?: string): string | undefined {
   const trimmed = endpoint?.trim();
-  return trimmed ? trimmed.replace(/\/+$/, "") : undefined;
+  return trimmed || undefined;
 }
 
 const SIGNAL_QUALIFIED_OTLP_PATH_PATTERN = /\/v1\/(traces|metrics|logs)$/iu;
@@ -30,12 +30,12 @@ function appendOrReplaceSignalPath(value: string, path: string): string {
 
 function resolveSharedOtelUrl(endpoint: string, path: string): string {
   const endpointWithoutQueryOrFragment = endpoint.split(/[?#]/, 1)[0] ?? endpoint;
-  const matchedSignal = endpointWithoutQueryOrFragment
-    .replace(/\/+$/u, "")
-    .match(SIGNAL_QUALIFIED_OTLP_PATH_PATTERN)?.[1];
+  // Trim path separators here, never slash bytes belonging to a collector query.
+  const base = endpointWithoutQueryOrFragment.replace(/\/+$/u, "");
+  const matchedSignal = base.match(SIGNAL_QUALIFIED_OTLP_PATH_PATTERN)?.[1];
   const requestedSignal = path.slice(path.lastIndexOf("/") + 1);
   if (matchedSignal?.toLowerCase() === requestedSignal.toLowerCase()) {
-    return endpoint;
+    return endpoint === endpointWithoutQueryOrFragment ? base : endpoint;
   }
   if (/[?#]/u.test(endpoint)) {
     const url = new URL(endpoint);
@@ -45,11 +45,6 @@ function resolveSharedOtelUrl(endpoint: string, path: string): string {
   return appendOrReplaceSignalPath(endpoint, path);
 }
 
-function normalizeSignalEndpoint(endpoint?: string): string | undefined {
-  const trimmed = endpoint?.trim();
-  return trimmed || undefined;
-}
-
 export function resolveSignalOtelUrl(params: {
   signalEndpoint?: string;
   signalEnvEndpoint?: string;
@@ -57,7 +52,7 @@ export function resolveSignalOtelUrl(params: {
   endpoint?: string;
   path: string;
 }): string | undefined {
-  const signalEndpoint = normalizeSignalEndpoint(params.signalEndpoint ?? params.signalEnvEndpoint);
+  const signalEndpoint = normalizeEndpoint(params.signalEndpoint ?? params.signalEnvEndpoint);
   const endpoint = signalEndpoint ?? params.endpoint;
   // OTLP parses nonblank env values verbatim even when explicit config takes precedence.
   const signalEnvEndpoint = params.signalEnvEndpoint?.trim() ? params.signalEnvEndpoint : undefined;

--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -9,8 +9,6 @@
 // Collector-boundary cases run owned mode, which now composes private providers and never
 // registers global SDK state; teardown still restores the preloaded globals for trace cases.
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { createServer, type IncomingHttpHeaders } from "node:http";
-import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { context, diag, DiagLogLevel, metrics, propagation, trace } from "@opentelemetry/api";
@@ -40,6 +38,7 @@ import {
   createOtelContext,
   emitRealSdkSignals,
   startOtelService,
+  startOtlpReceiver,
   stopStartedOtelServices,
 } from "./service.test-helpers.js";
 
@@ -199,43 +198,6 @@ function captureOtelDiagnostics(): string[] {
   return messages;
 }
 
-async function startOtlpReceiver() {
-  const requests: Array<{
-    contentType: string | undefined;
-    headers: IncomingHttpHeaders;
-    method: string | undefined;
-    url: string;
-  }> = [];
-  const server = createServer((request, response) => {
-    request.resume();
-    request.on("end", () => {
-      requests.push({
-        contentType: request.headers["content-type"],
-        headers: request.headers,
-        method: request.method,
-        url: request.url ?? "",
-      });
-      response.writeHead(200, { "content-type": "application/x-protobuf" });
-      response.end();
-    });
-  });
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const { port } = server.address() as AddressInfo;
-  return {
-    endpoint: `http://127.0.0.1:${port}`,
-    requests,
-    async close() {
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-        server.closeIdleConnections();
-      });
-    },
-  };
-}
-
 function releasePreloadedOtelGlobals() {
   context.disable();
   logs.disable();
@@ -305,7 +267,7 @@ const SHARED_ENDPOINT_ROUTING_CASES = [
 
 test.each(
   SHARED_ENDPOINT_ROUTING_CASES.flatMap((entry) =>
-    (["config", "environment"] as const).map((source) => ({ ...entry, source })),
+    (["config", "environment"] as const).map((source) => Object.assign({ source }, entry)),
   ),
 )(
   "routes real exporters from a shared $label endpoint in $source",

--- a/extensions/diagnostics-otel/src/service.otlp-export.test.ts
+++ b/extensions/diagnostics-otel/src/service.otlp-export.test.ts
@@ -274,11 +274,42 @@ const SHARED_ENDPOINT_ROUTING_CASES = [
       "/api/public/otel/v1/logs",
     ],
   },
+  {
+    label: "signal-qualified path with trailing slash",
+    suffix: "/api/public/otel/v1/traces/",
+    expected: [
+      "/api/public/otel/v1/traces",
+      "/api/public/otel/v1/metrics",
+      "/api/public/otel/v1/logs",
+    ],
+  },
+  {
+    label: "custom path with query slash",
+    suffix: "/api/public/otel/?tenant=team/",
+    expected: [
+      "/api/public/otel/v1/traces?tenant=team/",
+      "/api/public/otel/v1/metrics?tenant=team/",
+      "/api/public/otel/v1/logs?tenant=team/",
+    ],
+  },
+  {
+    label: "signal path with query slash",
+    suffix: "/api/public/otel/v1/traces/?tenant=team/",
+    expected: [
+      "/api/public/otel/v1/traces/?tenant=team/",
+      "/api/public/otel/v1/metrics?tenant=team/",
+      "/api/public/otel/v1/logs?tenant=team/",
+    ],
+  },
 ] as const;
 
-test.each(SHARED_ENDPOINT_ROUTING_CASES)(
-  "routes real exporters from a shared $label endpoint",
-  async ({ suffix, expected }) => {
+test.each(
+  SHARED_ENDPOINT_ROUTING_CASES.flatMap((entry) =>
+    (["config", "environment"] as const).map((source) => ({ ...entry, source })),
+  ),
+)(
+  "routes real exporters from a shared $label endpoint in $source",
+  async ({ suffix, expected, source }) => {
     const receiver = await startOtlpReceiver();
     releasePreloadedOtelGlobals();
     const { service, ctx } = await startOtelService({
@@ -286,6 +317,12 @@ test.each(SHARED_ENDPOINT_ROUTING_CASES)(
       traces: true,
       metrics: true,
       logs: true,
+      configure: (serviceContext) => {
+        if (source === "environment") {
+          delete serviceContext.config.diagnostics!.otel!.endpoint;
+          process.env.OTEL_EXPORTER_OTLP_ENDPOINT = `${receiver.endpoint}${suffix}`;
+        }
+      },
     });
 
     try {

--- a/extensions/diagnostics-otel/src/service.test-helpers.ts
+++ b/extensions/diagnostics-otel/src/service.test-helpers.ts
@@ -1,3 +1,5 @@
+import { createServer, type IncomingHttpHeaders } from "node:http";
+import type { AddressInfo } from "node:net";
 import {
   createChildDiagnosticTraceContext,
   createDiagnosticTraceContext,
@@ -213,6 +215,43 @@ export async function stopStartedOtelServices() {
   const services = [...startedServices];
   startedServices.clear();
   await Promise.all(services.map(({ service, ctx }) => Promise.resolve(service.stop?.(ctx))));
+}
+
+export async function startOtlpReceiver() {
+  const requests: Array<{
+    contentType: string | undefined;
+    headers: IncomingHttpHeaders;
+    method: string | undefined;
+    url: string;
+  }> = [];
+  const server = createServer((request, response) => {
+    request.resume();
+    request.on("end", () => {
+      requests.push({
+        contentType: request.headers["content-type"],
+        headers: request.headers,
+        method: request.method,
+        url: request.url ?? "",
+      });
+      response.writeHead(200, { "content-type": "application/x-protobuf" });
+      response.end();
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const { port } = server.address() as AddressInfo;
+  return {
+    endpoint: `http://127.0.0.1:${port}`,
+    requests,
+    async close() {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeIdleConnections();
+      });
+    },
+  };
 }
 
 export function createTestTrace(spanId: string, parentSpanId?: string): DiagnosticTraceContext {


### PR DESCRIPTION
Closes #130933

## What Problem This Solves

Fixes an issue where operators using a shared OTLP collector endpoint whose query value ends in `/` would send traces, metrics, and logs with a modified value. For example, `/otel?tenant=team/` became `/otel/v1/traces?tenant=team`. Both configuration and environment endpoints were affected.

## Why This Change Was Made

The endpoint normalizer stripped trailing slashes from the entire URL before separating the query; the fix moves that operation into the existing signal-path owner and removes the duplicate endpoint normalizer. It preserves documented signal routing and exact signal-specific URLs, and corrects the README to point to the actual `diagnostics.otel` configuration.

The existing HTTP collector fixture now lives in the service test helper module. Its behavior and all regression cases and assertions are unchanged; the table uses the existing `Object.assign` pattern.

## User Impact

Shared collector URLs retain their query values across all three signals, without a new option or migration. Existing path trailing-slash handling remains intact. Invalid endpoints consisting only of slashes now fail URL validation instead of accidentally selecting the localhost exporter default.

## Evidence

The real HTTP collector regression failed in four combinations before the production change: config/environment endpoints, each with custom and signal-qualified paths. The complete service and real-export suites subsequently passed **285 tests** on the original candidate, including existing endpoint, TLS, protocol, startup, and shutdown coverage.

On August 27, an isolated Linux live run exercised a real Gateway agent RPC, a live provider, QA-channel reply delivery, and an actual OTLP HTTP collector. The existing `otel-trace-smoke` scenario passed **1/1**, with zero failures or skips. The collector decoded **16 spans, 44 metrics, and 17 logs**; every signal preserved `?tenant=team/`, with no scenario privacy-sentinel leak. The tested exporter source matches this patch. This proof does not cover native external-channel ingress or independently inspect persisted transcripts.

Fresh-dependency builds and plugin/plugin-test type checks passed on the combined validation candidate containing the identical OTel patch. Fresh review of the focused patch reported no P0 findings at its configured P0-only threshold. **Fresh current-main focused tests: 285 passed across two files.**

CI then caught `no-map-spread` and a 1,033-line test file exceeding the 1,000-line limit. Both were reproduced locally and repaired without changing production code. The repository syntax lint, line-count and assertion-safety checks, scoped formatting, and whitespace checks now pass. **After the test-helper move, all 314 tests across its six consuming suites pass**, with zero failures or skips. A fresh P0-only review of that follow-up reported no findings. The full local type-aware lint command remains blocked before lint by existing dependency declaration errors in Google, Markdown, and TUI types; this is not claimed as a passing type check. Required exact-head CI remains the landing gate.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  extensions/diagnostics-otel/src/service.test.ts \
  extensions/diagnostics-otel/src/service.otlp-export.test.ts \
  extensions/diagnostics-otel/src/service.restart.test.ts \
  extensions/diagnostics-otel/src/service-exporter-health.integration.test.ts \
  extensions/diagnostics-otel/src/service-disabled.integration.test.ts \
  extensions/diagnostics-otel/src/service.plugin-usage-attribution.test.ts
```

The affected plugin files are unchanged between the tested baseline and current main `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`. Copy-aware blame traces the faulty normalization to [the original diagnostics exporter commit](https://github.com/openclaw/openclaw/commit/5c4079f66cc0308c21647ae4831d132481bac5a0), dated January 20, 2026; the bug also exists in stable tag `v2026.7.1-2`.

Production: **+6/−11, net −5 LOC**. Tests and test support: **+80/−42, net +38 LOC**, or **+41/−3** after discounting the unchanged collector fixture move. README: **+1/−1**. No dependency, schema, or new configuration changes.

AI-assisted maintainer repair; source and runtime evidence inspected.
