### PR TITLE
refactor(plugins): consolidate capability provider resolution

### DIFF
--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -881,6 +881,10 @@ describe("resolvePluginCapabilityProviders", () => {
         generateImage: async () => ({ images: [] }),
       },
     } as never);
+    addCapabilityProvider(loaded, "imageGenerationProviders", {
+      id: "xai",
+      provider: { defaultModel: "shadowed-model" },
+    });
     mocks.loadPluginManifestRegistryCore.mockReturnValue({
       plugins: [
         {
@@ -906,6 +910,8 @@ describe("resolvePluginCapabilityProviders", () => {
     });
 
     expectResolvedCapabilityProviderIds(providers, ["xai", "fal"]);
+    expect(providers[0]).toBe(active.imageGenerationProviders[0]?.provider);
+    expect(providers[1]).toBe(loaded.imageGenerationProviders[0]?.provider);
     expect(mocks.resolveRuntimePluginRegistry).toHaveBeenCalledWith();
     expectActiveRegistryLookup(["fal", "xai"]);
   });

--- a/src/plugins/capability-provider-runtime.ts
+++ b/src/plugins/capability-provider-runtime.ts
@@ -31,34 +31,11 @@ type CapabilityProviderRegistryKey =
   | "videoGenerationProviders"
   | "musicGenerationProviders";
 
-type CapabilityContractKey =
-  | "embeddingProviders"
-  | "speechProviders"
-  | "realtimeTranscriptionProviders"
-  | "realtimeVoiceProviders"
-  | "mediaUnderstandingProviders"
-  | "transcriptSourceProviders"
-  | "imageGenerationProviders"
-  | "videoGenerationProviders"
-  | "musicGenerationProviders";
-
 export type CapabilityProviderFor<K extends CapabilityProviderRegistryKey> =
   PluginRegistry[K][number]["provider"];
 type CapabilityPluginResolution = {
   runtimePluginIds: string[];
   bundledCompatPluginIds: string[];
-};
-
-const CAPABILITY_CONTRACT_KEY: Record<CapabilityProviderRegistryKey, CapabilityContractKey> = {
-  embeddingProviders: "embeddingProviders",
-  speechProviders: "speechProviders",
-  realtimeTranscriptionProviders: "realtimeTranscriptionProviders",
-  realtimeVoiceProviders: "realtimeVoiceProviders",
-  mediaUnderstandingProviders: "mediaUnderstandingProviders",
-  transcriptSourceProviders: "transcriptSourceProviders",
-  imageGenerationProviders: "imageGenerationProviders",
-  videoGenerationProviders: "videoGenerationProviders",
-  musicGenerationProviders: "musicGenerationProviders",
 };
 
 function shouldMergeManifestProvidersWhenActive(key: CapabilityProviderRegistryKey): boolean {
@@ -98,13 +75,12 @@ function resolveCapabilityPluginIds(params: {
   providerId?: string;
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "index" | "plugins">;
 }): CapabilityPluginResolution {
-  const contractKey = CAPABILITY_CONTRACT_KEY[params.key];
   const snapshot = loadCapabilityManifestSnapshot(params);
   const availableContractPlugins = snapshot.plugins.filter(
     (plugin) =>
       hasManifestContractValue({
         plugin,
-        contract: contractKey,
+        contract: params.key,
         value: params.providerId,
       }) &&
       isManifestPluginAvailableForControlPlane({
@@ -179,30 +155,6 @@ function findProviderById<K extends CapabilityProviderRegistryKey>(
     }
   }
   return undefined;
-}
-
-function mergeCapabilityProviders<K extends CapabilityProviderRegistryKey>(
-  left: PluginRegistry[K],
-  right: PluginRegistry[K],
-): CapabilityProviderFor<K>[] {
-  const merged = new Map<string, CapabilityProviderFor<K>>();
-  const unnamed: CapabilityProviderFor<K>[] = [];
-  const addEntries = (entries: PluginRegistry[K]) => {
-    for (const entry of entries) {
-      const provider = entry.provider as CapabilityProviderFor<K> & { id?: string };
-      if (!provider.id) {
-        unnamed.push(provider);
-        continue;
-      }
-      if (!merged.has(provider.id)) {
-        merged.set(provider.id, provider);
-      }
-    }
-  };
-
-  addEntries(left);
-  addEntries(right);
-  return [...merged.values(), ...unnamed];
 }
 
 function mergeCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>(
@@ -460,23 +412,14 @@ function loadCapabilityProviderEntries<K extends CapabilityProviderRegistryKey>(
     (registry?.[params.key] ?? []).filter((entry) =>
       allowedPluginIds.has(entry.pluginId),
     ) as PluginRegistry[K];
-  const loadedRegistry = getLoadedRuntimePluginRegistry({
-    env: params.loadOptions.env,
-    loadOptions: params.loadOptions,
-    workspaceDir: params.loadOptions.workspaceDir,
-    requiredPluginIds: params.loadOptions.onlyPluginIds,
-  });
-  const loadedEntries = filterAllowedEntries(loadedRegistry);
-  const coldRegistry = loadedRegistry
-    ? undefined
-    : resolveRuntimePluginRegistry(params.loadOptions);
-  const coldEntries = filterAllowedEntries(coldRegistry);
-  const entries =
-    loadedEntries.length > 0 && coldEntries.length > 0
-      ? mergeCapabilityProviderEntries(loadedEntries, coldEntries)
-      : loadedEntries.length > 0
-        ? loadedEntries
-        : coldEntries;
+  const registry =
+    getLoadedRuntimePluginRegistry({
+      env: params.loadOptions.env,
+      loadOptions: params.loadOptions,
+      workspaceDir: params.loadOptions.workspaceDir,
+      requiredPluginIds: params.loadOptions.onlyPluginIds,
+    }) ?? resolveRuntimePluginRegistry(params.loadOptions);
+  const entries = filterAllowedEntries(registry);
   const missingRequested =
     params.requested && params.requested.size > 0 ? new Set(params.requested) : undefined;
   if (missingRequested) {
@@ -645,7 +588,9 @@ export function resolvePluginCapabilityProviders<K extends CapabilityProviderReg
           entries: requestedLoadedProviders,
         })
       : requestedLoadedProviders;
-  return mergeCapabilityProviders(activeProviders, mergeLoadedProviders);
+  return mergeCapabilityProviderEntries(activeProviders, mergeLoadedProviders).map(
+    (entry) => entry.provider as CapabilityProviderFor<K>,
+  );
 }
 
 export function prepareMediaCapabilityProviders(params: {
@@ -670,7 +615,7 @@ export function prepareMediaCapabilityProviders(params: {
       params.pluginMetadataSnapshot.plugins.some((plugin) =>
         hasManifestContractValue({
           plugin,
-          contract: CAPABILITY_CONTRACT_KEY[key],
+          contract: key,
         }),
       )
     ) {


### PR DESCRIPTION
## What Problem This Solves

Capability-provider resolution maintained two parallel merge implementations: one merged registry entries and another repeated the same first-wins/unnamed-provider rules after projecting entries down to providers. The same module also mapped every registry key to an identical contract key and modeled a loaded-plus-cold registry combination that its own selection flow cannot produce.

Those duplicate representations made ordering and fallback behavior harder to verify without adding a distinct policy or capability.

## Why This Change Was Made

This keeps capability providers as registry entries through the canonical merge, then projects the merged entries to providers once. Manifest lookup now uses the registry key directly, and registry selection chooses the already-loaded registry or the cold fallback before applying the existing allowlist filter.

Load order, configured-plugin policy, aliases, first-wins precedence, unnamed providers, requested-provider loading, bundled compatibility, and external fallback behavior remain unchanged.

## User Impact

No user-visible behavior change is intended. Capability providers resolve in the same order with one canonical merge path and less private policy surface.

## Evidence

- Baseline owner coverage passes 66/66 before the production change, including duplicate-provider and object-identity assertions.
- Final owner and sibling coverage passes 117/117 tests across nine files and five routed shards.
- The focused merge regression proves that the active provider retains first precedence and identity, the loaded fallback provider remains second, and a later duplicate is shadowed.
- Fresh isolated P0 review reports no actionable findings.
- Production: +13/-68, net -55 lines. Tests: +6/-0. Total: net -49 lines.
- No public API, import surface, configuration, plugin policy, provider alias, protocol, persistence, dependency, or storage change.
- The complete changed-path gate passes all routed types, lint, formatting, dependency, dead-export, and architecture guards.
- A full repository build passes assets, unified package output, external plugins, CLI bootstrap, runtime postbuild, SDK subpaths, UI, and startup metadata; the build, runtime-postbuild, and build-info stamps all match the exact committed head.
