### PR TITLE
fix(codex): let collector waits finish their full timeout

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -13,7 +13,7 @@ import {
   toCodexDynamicToolProgressResponse,
   toCodexDynamicToolProtocolResponse,
 } from "./dynamic-tool-execution.js";
-import type { CodexDynamicToolCallResponse } from "./protocol.js";
+import type { CodexDynamicToolCallParams, CodexDynamicToolCallResponse } from "./protocol.js";
 
 const CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 90_000;
 const CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
@@ -27,102 +27,62 @@ describe("dynamic tool execution helpers", () => {
     vi.useRealTimers();
   });
 
-  it("keeps explicit dynamic tool timeouts above the default bridge deadline", () => {
-    const timeoutMs = CODEX_DYNAMIC_TOOL_TIMEOUT_MS + 1_000;
-
+  it.each<{
+    name: string;
+    tool: string;
+    arguments: CodexDynamicToolCallParams["arguments"];
+    timeoutMs: number;
+  }>([
+    {
+      name: "keeps explicit dynamic tool timeouts above the default bridge deadline",
+      tool: "image_generate",
+      arguments: { prompt: "cat", timeoutMs: CODEX_DYNAMIC_TOOL_TIMEOUT_MS + 1_000 },
+      timeoutMs: CODEX_DYNAMIC_TOOL_TIMEOUT_MS + 1_000,
+    },
+    {
+      name: "ignores partial dynamic tool timeout strings",
+      tool: "session_status",
+      arguments: { timeoutMs: "1abc" },
+      timeoutMs: CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
+    },
+    {
+      name: "honors timeoutSeconds when timeoutMs is absent",
+      tool: "session_status",
+      arguments: { timeoutSeconds: 30 },
+      timeoutMs: 60_000,
+    },
+    {
+      name: "prefers timeoutMs over timeoutSeconds",
+      tool: "session_status",
+      arguments: { timeoutMs: 5_000, timeoutSeconds: 30 },
+      timeoutMs: 5_000,
+    },
+    {
+      name: "ignores non-positive timeoutSeconds",
+      tool: "session_status",
+      arguments: { timeoutSeconds: -1 },
+      timeoutMs: CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
+    },
+    {
+      name: "rejects fractional timeoutSeconds and falls back to the default",
+      tool: "session_status",
+      arguments: { timeoutSeconds: 1.5 },
+      timeoutMs: CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
+    },
+  ])("$name", ({ tool, arguments: args, timeoutMs }) => {
     expect(
       resolveDynamicToolCallTimeoutMs({
         call: {
           threadId: "thread-1",
           turnId: "turn-1",
-          callId: "call-long",
+          callId: "call-timeout",
           namespace: null,
-          tool: "image_generate",
-          arguments: { prompt: "cat", timeoutMs },
+          tool,
+          arguments: args,
         },
         config: undefined,
       }),
     ).toBe(timeoutMs);
-  });
-
-  it("ignores partial dynamic tool timeout strings", () => {
-    expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-partial-timeout",
-          namespace: null,
-          tool: "session_status",
-          arguments: { timeoutMs: "1abc" },
-        },
-        config: undefined,
-      }),
-    ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
-  });
-
-  it("honors timeoutSeconds when timeoutMs is absent", () => {
-    expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-seconds",
-          namespace: null,
-          tool: "session_status",
-          arguments: { timeoutSeconds: 30 },
-        },
-        config: undefined,
-      }),
-    ).toBe(60_000);
-  });
-
-  it("prefers timeoutMs over timeoutSeconds", () => {
-    expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-both",
-          namespace: null,
-          tool: "session_status",
-          arguments: { timeoutMs: 5_000, timeoutSeconds: 30 },
-        },
-        config: undefined,
-      }),
-    ).toBe(5_000);
-  });
-
-  it("ignores non-positive timeoutSeconds", () => {
-    expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-bad-seconds",
-          namespace: null,
-          tool: "session_status",
-          arguments: { timeoutSeconds: -1 },
-        },
-        config: undefined,
-      }),
-    ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
-  });
-
-  it("rejects fractional timeoutSeconds and falls back to the default", () => {
-    expect(
-      resolveDynamicToolCallTimeoutMs({
-        call: {
-          threadId: "thread-1",
-          turnId: "turn-1",
-          callId: "call-fractional-seconds",
-          namespace: null,
-          tool: "session_status",
-          arguments: { timeoutSeconds: 1.5 },
-        },
-        config: undefined,
-      }),
-    ).toBe(CODEX_DYNAMIC_TOOL_TIMEOUT_MS);
   });
 
   it("uses configured image generation timeouts for Codex dynamic tool calls", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.test.ts
@@ -438,6 +438,40 @@ describe("dynamic tool execution helpers", () => {
     });
   });
 
+  it.each([
+    { tool: "session_status", deadlineMs: 600_000 },
+    { tool: "agents_wait", deadlineMs: 630_000 },
+  ])("enforces the resolved $tool cap at $deadlineMs ms", async ({ tool, deadlineMs }) => {
+    vi.useFakeTimers();
+    const call = {
+      threadId: "thread-1",
+      turnId: "turn-1",
+      callId: "call-capped-timeout",
+      namespace: null,
+      tool,
+      arguments: { timeoutSeconds: 1_000 },
+    };
+    const onTimeout = vi.fn();
+    const response = handleDynamicToolCallWithTimeout({
+      call,
+      toolBridge: { handleToolCall: vi.fn(() => new Promise<never>(() => {})) },
+      signal: new AbortController().signal,
+      timeoutMs: resolveDynamicToolCallTimeoutMs({ call, config: undefined }),
+      onTimeout,
+    });
+
+    await vi.advanceTimersByTimeAsync(deadlineMs - 1);
+    expect(onTimeout).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+
+    await expect(response).resolves.toMatchObject({
+      success: false,
+      diagnosticTerminalReason: "timed_out",
+    });
+    expect(onTimeout).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it("marks a timeout during pre-execution hooks as unstarted", async () => {
     vi.useFakeTimers();
     const observeToolTerminal = vi.fn(() => ({
@@ -558,49 +592,61 @@ describe("dynamic tool execution helpers", () => {
     expect((await response).sideEffectEvidence).toBe(true);
   });
 
-  it("lets a structured sessions_send timeout win after setup work", async () => {
-    vi.useFakeTimers();
-    const call = {
-      threadId: "thread-1",
-      turnId: "turn-1",
-      callId: "call-session-send-timeout",
-      namespace: null,
-      tool: "sessions_send",
-      arguments: { sessionKey: "agent:child", message: "ping", timeoutSeconds: 1 },
-    };
-    const structuredTimeout: CodexDynamicToolCallResponse = {
-      success: true,
-      contentItems: [
-        {
-          type: "inputText" as const,
-          text: JSON.stringify({
-            runId: "run-child",
-            status: "timeout",
-            sentBeforeError: true,
-          }),
+  it.each([
+    { tool: "sessions_send", timeoutSeconds: 1, completionMs: 6_000 },
+    { tool: "agents_wait", timeoutSeconds: 600, completionMs: 600_000 },
+    { tool: "agents_wait", timeoutSeconds: 600, completionMs: 605_000 },
+  ])(
+    "preserves the $tool result after $completionMs ms",
+    async ({ tool, timeoutSeconds, completionMs }) => {
+      vi.useFakeTimers();
+      const call = {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-structured-timeout",
+        namespace: null,
+        tool,
+        arguments: { timeoutSeconds },
+      };
+      const structuredTimeout: CodexDynamicToolCallResponse = {
+        success: true,
+        contentItems: [
+          {
+            type: "inputText" as const,
+            text: JSON.stringify(
+              tool === "agents_wait"
+                ? { completed: [], pending: ["run-child"] }
+                : {
+                    runId: "run-child",
+                    status: "timeout",
+                    sentBeforeError: true,
+                  },
+            ),
+          },
+        ],
+      };
+      const response = handleDynamicToolCallWithTimeout({
+        call,
+        toolBridge: {
+          handleToolCall: vi.fn(
+            () =>
+              new Promise<CodexDynamicToolCallResponse>((resolve) => {
+                // Inner tool deadlines can start after setup; the outer watchdog
+                // must preserve their result through the completion grace period.
+                setTimeout(() => resolve(structuredTimeout), completionMs);
+              }),
+          ),
         },
-      ],
-    };
-    const response = handleDynamicToolCallWithTimeout({
-      call,
-      toolBridge: {
-        handleToolCall: vi.fn(
-          () =>
-            new Promise<CodexDynamicToolCallResponse>((resolve) => {
-              // sessions_send can spend time resolving/snapshotting the target
-              // before its own timeoutSeconds wait starts.
-              setTimeout(() => resolve(structuredTimeout), 6_000);
-            }),
-        ),
-      },
-      signal: new AbortController().signal,
-      timeoutMs: resolveDynamicToolCallTimeoutMs({ call, config: undefined }),
-    });
+        signal: new AbortController().signal,
+        timeoutMs: resolveDynamicToolCallTimeoutMs({ call, config: undefined }),
+      });
 
-    await vi.advanceTimersByTimeAsync(6_000);
+      await vi.advanceTimersByTimeAsync(completionMs);
 
-    await expect(response).resolves.toEqual(structuredTimeout);
-  });
+      await expect(response).resolves.toEqual(structuredTimeout);
+      expect(vi.getTimerCount()).toBe(0);
+    },
+  );
 
   it("reports pre-execution cancellations to the private result observer", async () => {
     const controller = new AbortController();

--- a/extensions/codex/src/app-server/dynamic-tool-execution.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-execution.ts
@@ -141,8 +141,8 @@ function formatDynamicToolTimeoutDetails(params: {
 }
 
 /**
- * Runs a dynamic tool call with run-abort and per-call timeout handling,
- * returning a Codex protocol response instead of throwing.
+ * Runs a dynamic tool call with run-abort and the budget prepared by
+ * resolveDynamicToolCallTimeoutMs, preserving tool-specific completion grace.
  */
 export async function handleDynamicToolCallWithTimeout(params: {
   call: CodexDynamicToolCallParams;
@@ -255,7 +255,7 @@ export async function handleDynamicToolCallWithTimeout(params: {
     resolveAbort = resolve;
   });
   const timeoutPromise = new Promise<CodexDynamicToolRuntimeResponse>((resolve) => {
-    const timeoutMs = clampDynamicToolTimeoutMs(params.timeoutMs);
+    const { timeoutMs } = params;
     timeout = setTimeout(() => {
       timedOut = true;
       const timeoutDetails = formatDynamicToolTimeoutDetails({ call: params.call, timeoutMs });


### PR DESCRIPTION
Closes #130938

Related: #111605 (the merged swarm-wait budget change).

## What Problem This Solves

Fixes an issue where users waiting for collector subagents through the Codex harness receive a tool RPC timeout when requesting the supported 600-second wait. Instead of receiving the normal result listing unfinished children, the wait is aborted at its own deadline.

## Why This Change Was Made

The timeout resolver already gives `agents_wait` a 630-second outer budget, including completion grace, but the executor reapplied the generic 600-second cap. This change removes that duplicate decision and uses the resolver's prepared budget in both normal Codex attempts and side questions.

Generic tools retain their existing 600-second maximum. Cancellation, result projection, and timer cleanup remain unchanged. There are no configuration, protocol, dependency, persistence, or plugin SDK changes. Production LOC: +3/-3 (net zero); tests: +133/-127 (net +6).

## User Impact

Codex collector waits can use the documented full 600-second budget and return the structured pending-child result. Other tools keep their existing timeout policies. This restores the [documented swarm wait behavior](https://docs.openclaw.ai/tools/swarm) without introducing a new setting or extending the collector's own wait limit.

## Evidence

Before the fix, the regression cases returning a collector result at 600,000 ms and 605,000 ms both failed: the executor returned `success: false` with `OpenClaw dynamic tool call timed out after 600000ms while running tool agents_wait.` The existing `sessions_send` setup-delay case passed. After the fix, all cases pass; additional tests enforce the generic 600-second cap, the collector's 630-second outer cap, and timer cleanup.

CI on the first PR head exposed the repository max-lines limit (1,031 counted lines, maximum 1,000). Consolidating six existing timeout-argument cases into a typed table preserves every case name, input, and expected result, reduces the file to 997 counted lines, and passes the same repository lint configuration. The cleanup changes tests only; no suppression or weaker assertion was added.

After that test-only cleanup, all **288 tests passed across six files in 29.32 seconds**. Scoped formatting and `git diff --check` passed. A fresh isolated Codex autoreview considered the cleanup together with the complete final PR patch and found no issues at its P0-only threshold; it confirmed all six cases preserve their relevant inputs and assertions. The full typed-lint wrapper was also attempted, but failed before linting while preparing plugin SDK declarations because the existing shared dependency versions lack `markdown-it` StateInline and `pi-tui` TuiMainScreen exports. Dependencies were not installed or reconciled in the worktree. Exact-head hosted CI remains required.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE=0 \
node scripts/run-vitest.mjs \
  extensions/codex/src/app-server/dynamic-tool-execution.test.ts \
  extensions/codex/src/app-server/dynamic-tool-execution.owner-timeout.test.ts \
  extensions/codex/src/app-server/dynamic-tools.test.ts \
  extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts \
  extensions/codex/src/app-server/side-question.test.ts \
  src/agents/tools/agents-wait-tool.test.ts \
  --configLoader runner --no-cache
```

A separate real-clock runtime proof completed at **600,043 ms**, between `2026-08-27T08:06:01.043Z` and `2026-08-27T08:16:01.088Z`. It registered a queued collector and required task row through canonical APIs in disposable SQLite state, then ran the actual Codex dynamic bridge, resolver, executor, and collector. It returned `{"completed":[],"pending":["<run-id>"]}` successfully; the 630,000 ms watchdog did not fire, and both durable rows remained queued. No fake timers or registry mocks were used. This was runtime boundary proof, not a live model or Codex app-server session. It ran on the earlier QA candidate based on `ac71743ca44a1927ddf8bcd3b32d71b60e27c0ac`; the production patch is byte-identical to this patch; subsequent changes only consolidate the test cases. The timeout owner, normal caller, and collector remain unchanged in the newer baseline; side-question drift is an unrelated `requestOptions()` correction.

Timeout policy remains with the resolver; cancellation, ordering, and cleanup are unchanged. No full build, current-head typecheck, or green hosted CI result is claimed here.

| Evidence surface | Source and conclusion |
| --- | --- |
| Timeout policy owner | `extensions/codex/src/app-server/dynamic-tool-execution.ts:503`: resolves generic caps and collector completion grace before dispatch. |
| Removed duplicate policy | `extensions/codex/src/app-server/dynamic-tool-execution.ts:258`: executor now uses the resolved budget without reclamping it. |
| Normal request entry | `extensions/codex/src/app-server/run-attempt-server-requests.ts:209,238`: resolves the budget, then invokes the executor. |
| Sibling entry | `extensions/codex/src/app-server/side-question.ts:602,615`: uses the same resolver and executor. |
| Collector callee | `src/agents/tools/agents-wait-tool.ts:211,286`: returns current pending/completed state at its own bounded deadline. |
| Transport envelope | `extensions/codex/src/app-server/client.ts:42,895`: separate 660-second request timeout remains above the 630-second collector budget. |
| Existing and added coverage | `dynamic-tool-execution.test.ts`, `dynamic-tool-execution.owner-timeout.test.ts`, `dynamic-tools.test.ts`, `run-attempt.dynamic-tools.test.ts`, `side-question.test.ts`, and `agents-wait-tool.test.ts`. |
| Current upstream Codex contract | Personally inspected `openai/codex` at `694edc23b22b4696400dc47663ecacd437623870`: `codex-rs/core/src/tools/handlers/dynamic.rs:137,216,227` waits for and projects the host response; `codex-rs/app-server/src/dynamic_tools.rs:18,38` forwards it. No upstream requirement imposes this duplicate cap. |

The best fix is to preserve the single timeout-policy owner. Raising the generic executor cap would duplicate policy again and potentially widen unrelated tool limits; adding a tool-name exception in the executor would repeat the resolver's responsibility. Neither is needed.

Provenance: the older executor clamp traces to `a4c2e7f5cf1b42cc27e1d0f1573fe75c9d591875` (Peter Steinberger, 2026-05-27). The conflicting collector grace was introduced in #111605, “improve(swarm): close out wait, phase, and worker follow-ups,” merged as `7d4dccf959789331bc12cad908376ba12a3955ed` on 2026-07-20. Live GitHub metadata identifies @steipete as both that PR's author and merger. The bug is the incomplete interaction between these two policies, not the collector implementation.

AI-assisted. Bounded Gitcrawl and live GitHub searches found no matching open duplicate at verification time. The open neighboring PRs #120077 (collector structured-output exposure) and #119056 (restart replay fencing) address different invariants and do not touch this timeout owner.
