### PR TITLE
fix(exec): stop cancelled commands before process admission

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -54,11 +54,13 @@ import {
   resetGatewayWorkAdmission,
   tryBeginGatewaySuspendAdmission,
 } from "../process/gateway-work-admission.js";
+import type { ProcessSupervisor } from "../process/supervisor/types.js";
 import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import type {
   ExecApprovalFollowupFactory,
   ExecApprovalFollowupOutcome,
@@ -213,6 +215,22 @@ const resolveExecHostApprovalContextMock = vi.hoisted(() =>
   ),
 );
 const runExecProcessMock = vi.hoisted(() => vi.fn());
+const startupCancellationMocks = vi.hoisted(() => ({
+  spawn: vi.fn<ProcessSupervisor["spawn"]>(),
+  prepare: vi.fn<() => void>(),
+}));
+
+vi.mock("../process/supervisor/index.js", () => ({
+  getProcessSupervisor: () => ({ spawn: startupCancellationMocks.spawn }),
+}));
+
+vi.mock("./shell-snapshot.js", () => ({
+  maybeWrapCommandWithShellSnapshot: async (input: { command: string }) => {
+    startupCancellationMocks.prepare();
+    return input.command;
+  },
+}));
+
 const markBackgroundedMock = vi.hoisted(() => vi.fn());
 const sendExecApprovalFollowupResultMock = vi.hoisted(() =>
   vi.fn<SendExecApprovalFollowupResult>(async () => undefined),
@@ -420,7 +438,8 @@ vi.mock("./bash-tools.exec-runtime.js", () => ({
   runExecProcess: runExecProcessMock,
 }));
 
-vi.mock("./bash-process-registry.js", () => ({
+vi.mock("./bash-process-registry.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./bash-process-registry.js")>()),
   getActiveBackgroundExecSessionCount: vi.fn(() => 0),
   markBackgrounded: markBackgroundedMock,
   tail: vi.fn((value) => value),
@@ -555,6 +574,8 @@ describe("processGatewayAllowlist", () => {
       askFallback: "deny",
     });
     runExecProcessMock.mockReset();
+    startupCancellationMocks.spawn.mockReset();
+    startupCancellationMocks.prepare.mockReset();
     markBackgroundedMock.mockReset();
     sendExecApprovalFollowupResultMock.mockReset();
     enforceStrictInlineEvalApprovalBoundaryMock.mockReset();
@@ -583,6 +604,7 @@ describe("processGatewayAllowlist", () => {
   });
 
   afterEach(() => {
+    resetProcessRegistryForTests();
     resetGatewayWorkAdmission();
   });
 
@@ -3139,6 +3161,50 @@ EOF`,
       "external side effects may already have completed",
     );
     expect(requireSentFollowupText(0)).toContain("Verify the resulting state before retrying");
+  });
+
+  it("does not spawn or send a detached followup after cancellation during startup", async () => {
+    const controller = new AbortController();
+    mockApprovedDetachedExec({
+      outcome: { status: "completed", exitCode: 0, timedOut: false, aggregated: "done" },
+    });
+    const runtime = await vi.importActual<typeof import("./bash-tools.exec-runtime.js")>(
+      "./bash-tools.exec-runtime.js",
+    );
+    runExecProcessMock.mockImplementation(runtime.runExecProcess);
+    startupCancellationMocks.prepare.mockImplementationOnce(() =>
+      controller.abort(new Error("cancelled while preparing")),
+    );
+    startupCancellationMocks.spawn.mockImplementationOnce(async (input) => ({
+      runId: input.runId ?? "cancelled-startup",
+      pid: 1234,
+      startedAtMs: Date.now(),
+      cancel: vi.fn(),
+      wait: async () => ({
+        reason: "exit",
+        exitCode: 0,
+        exitSignal: null,
+        durationMs: 0,
+        stdout: "",
+        stderr: "",
+        timedOut: false,
+        noOutputTimedOut: false,
+      }),
+    }));
+
+    const result = await runGatewayAllowlist({
+      command: "find . -maxdepth 1",
+      turnSourceChannel: "feishu",
+      signal: controller.signal,
+      env: { PATH: "/usr/bin:/bin" },
+    });
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    await vi.waitFor(() => expect(startupCancellationMocks.prepare).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(0));
+
+    expect(startupCancellationMocks.spawn.mock.calls.length).toBe(0);
+    expect(markBackgroundedMock).not.toHaveBeenCalled();
+    expect(sendExecApprovalFollowupResultMock).not.toHaveBeenCalled();
   });
 
   it("drops detached execution and follow-up when the owning run is aborted", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1514,10 +1514,6 @@ export async function processGatewayAllowlist(
               message: bindingDenied,
             };
           }
-          if (params.signal?.aborted) {
-            return { status: "run-aborted" as const };
-          }
-
           let run: Awaited<ReturnType<typeof runExecProcess>>;
           let finalBindingDenied: string | undefined;
           const finalBindingDeniedError = new Error("gateway approval changed before spawn");
@@ -1540,6 +1536,7 @@ export async function processGatewayAllowlist(
               scopeKey: params.scopeKey,
               sessionKey: params.notifySessionKey ?? params.sessionKey,
               timeoutSec: effectiveTimeout,
+              startupSignal: params.signal,
               beforeSpawn: async () => {
                 finalBindingDenied = await resolveGatewayExecApprovalDrift({
                   binding: approvalMutableFileBinding,
@@ -1553,6 +1550,9 @@ export async function processGatewayAllowlist(
               },
             });
           } catch (error) {
+            if (params.signal?.aborted) {
+              return { status: "run-aborted" as const };
+            }
             if (error === finalBindingDeniedError && finalBindingDenied) {
               return { status: "operand-drift" as const, message: finalBindingDenied };
             }

--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -580,7 +580,6 @@ export function createExecTool(
           });
         }
 
-        signal?.throwIfAborted();
         run = await runExecProcess({
           command: params.command,
           execCommand: execCommandOverride,
@@ -604,13 +603,9 @@ export function createExecTool(
           notifyDeliveryContext,
           timeoutSec: effectiveTimeout,
           processContinuationAvailable: allowBackground,
+          startupSignal: signal,
           onUpdate,
-          beforeSpawn: async () => {
-            signal?.throwIfAborted();
-            const denied = await revalidateGatewayApproval?.();
-            signal?.throwIfAborted();
-            return denied;
-          },
+          beforeSpawn: revalidateGatewayApproval,
           onSettledBeforeNotify: settlement.settle,
         });
         discardPreparedSandboxWorkdir = null;

--- a/src/agents/bash-tools.exec-runtime.test.ts
+++ b/src/agents/bash-tools.exec-runtime.test.ts
@@ -200,6 +200,48 @@ describe("runExecProcess cursor tracking", () => {
 });
 
 describe("sandbox exec preparation failures", () => {
+  it.each([
+    { mode: "child", usePty: false, cancelCheck: 1, expectedSpawns: 0 },
+    { mode: "PTY", usePty: true, cancelCheck: 1, expectedSpawns: 0 },
+    { mode: "PTY fallback", usePty: true, cancelCheck: 2, expectedSpawns: 1 },
+  ])(
+    "does not start $mode after cancellation during final admission",
+    async ({ usePty, cancelCheck, expectedSpawns }) => {
+      const controller = new AbortController();
+      let checks = 0;
+      supervisorMock.spawn.mockImplementation(async (input: SpawnInput) => {
+        if (input.mode === "pty") {
+          throw new Error("PTY unavailable");
+        }
+        return runtimeManagedRun(input);
+      });
+
+      await expect(
+        runExecProcess({
+          command: "echo should-not-run",
+          workdir: process.cwd(),
+          env: {},
+          usePty,
+          warnings: [],
+          maxOutput: 1000,
+          pendingMaxOutput: 1000,
+          notifyOnExit: false,
+          timeoutSec: null,
+          startupSignal: controller.signal,
+          beforeSpawn: async () => {
+            if (++checks === cancelCheck) {
+              controller.abort(new Error("cancelled during admission"));
+            }
+            return undefined;
+          },
+        }),
+      ).rejects.toThrow("cancelled during admission");
+
+      expect(supervisorMock.spawn.mock.calls.length).toBe(expectedSpawns);
+      expect(checks).toBe(cancelCheck);
+    },
+  );
+
   it("keeps turn authority out of process lifetime while preserving foreground updates", async () => {
     const exit = createDeferred<RunExit>();
     const identity = {

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -645,6 +645,7 @@ function wrapPosixCommandWithPathPrepend(
 
 /** Starts a host or sandbox exec process and registers it for polling/backgrounding. */
 export async function runExecProcess({
+  startupSignal: initialStartupSignal,
   onUpdate: initialOnUpdate,
   beforeSpawn: initialBeforeSpawn,
   onSettledBeforeNotify: initialOnSettledBeforeNotify,
@@ -683,6 +684,8 @@ export async function runExecProcess({
   timeoutSec: number | null;
   /** Whether exec may return a supervised session for later continuation. */
   processContinuationAvailable?: boolean;
+  /** Cancels startup only; background process lifetime belongs to the supervisor. */
+  startupSignal?: AbortSignal;
   onUpdate?: (partialResult: AgentToolResult<ExecToolDetails>) => void;
   /** Runs after process finalization and before the exit wake is queued. */
   onSettledBeforeNotify?: (outcome: ExecProcessOutcome) => void;
@@ -737,6 +740,7 @@ export async function runExecProcess({
   // Foreground delivery keeps its caller context only until yield, abort, or exit.
   // Clearing the callback also releases the completed turn's captured authority.
   let onUpdate = initialOnUpdate && AsyncLocalStorage.bind(initialOnUpdate);
+  let startupSignal = initialStartupSignal;
   let beforeSpawn = initialBeforeSpawn;
   let onSettledBeforeNotify = initialOnSettledBeforeNotify;
 
@@ -949,15 +953,21 @@ export async function runExecProcess({
   };
 
   const assertPreSpawnAuthorized = async () => {
+    startupSignal?.throwIfAborted();
     const denied = await beforeSpawn?.();
+    startupSignal?.throwIfAborted();
     if (denied) {
       throw new ExecProcessPreflightError(denied);
     }
   };
-  const spawn = (input: SpawnInput) =>
-    withoutGatewayToolCallerIdentity(() => supervisor.spawn(input));
+  const spawn = (input: SpawnInput) => {
+    // No await between the final cancellation check and supervisor admission.
+    startupSignal?.throwIfAborted();
+    return withoutGatewayToolCallerIdentity(() => supervisor.spawn(input));
+  };
 
   try {
+    startupSignal?.throwIfAborted();
     const spawnSpec = await prepareSpawnSpec();
     usingPty = spawnSpec.mode === "pty";
     const spawnBase = {
@@ -981,6 +991,7 @@ export async function runExecProcess({
           ptyCommand: spawnSpec.ptyCommand,
         });
       } catch (err) {
+        startupSignal?.throwIfAborted();
         const warning = `Warning: PTY spawn failed (${String(err)}); retrying without PTY for \`${opts.command}\`.`;
         logWarn(
           `exec: PTY spawn failed (${String(err)}); retrying without PTY for "${opts.command}".`,
@@ -1024,6 +1035,7 @@ export async function runExecProcess({
     });
     throw error;
   } finally {
+    startupSignal = undefined;
     beforeSpawn = undefined;
   }
   session.stdin = managedRun.stdin;

--- a/src/agents/bash-tools.exec-task-wiring.test.ts
+++ b/src/agents/bash-tools.exec-task-wiring.test.ts
@@ -25,6 +25,7 @@ describe("exec background task wiring", () => {
 
   it("does not spawn when the turn closes during asynchronous process preparation", async () => {
     const abortController = new AbortController();
+    const finalizeExec = vi.fn<NonNullable<BashSandboxConfig["finalizeExec"]>>();
     const preparationStarted = createDeferred();
     const preparation =
       createDeferred<Awaited<ReturnType<NonNullable<BashSandboxConfig["buildExecSpec"]>>>>();
@@ -41,6 +42,7 @@ describe("exec background task wiring", () => {
           preparationStarted.resolve();
           return await preparation.promise;
         },
+        finalizeExec,
       },
     });
     try {
@@ -56,10 +58,17 @@ describe("exec background task wiring", () => {
         argv: [process.execPath, "-e", ""],
         env: process.env,
         stdinMode: "pipe-closed",
+        finalizeToken: "cancelled-startup",
       });
       await settled;
       expect(spawn.mock.calls.length).toBe(0);
       await expect(execution).rejects.toThrow("turn closed during preparation");
+      expect(finalizeExec).toHaveBeenCalledExactlyOnceWith({
+        token: "cancelled-startup",
+        status: "failed",
+        exitCode: null,
+        timedOut: false,
+      });
       expect(taskTracking.createBackgroundExecTask).not.toHaveBeenCalled();
     } finally {
       spawn.mockRestore();


### PR DESCRIPTION
Closes #130940

## What Problem This Solves

Fixes an issue where users cancelling a run could still have an approved gateway command start when cancellation arrived during asynchronous process preparation or the final approval check. The detached approval path could then background that command and send a completion follow-up.

## Why This Change Was Made

The foreground caller already checked cancellation, but the shared exec startup owner did not receive the signal, leaving detached approvals and retry admission dependent on caller-specific checks. Both callers now pass a startup-only signal to the runtime, which rechecks it after awaited work and synchronously before each supervisor admission, including PTY fallback. Cancellation also settles detached admission as `run-aborted`, rather than reporting a spawn failure.

The change removes redundant caller checks, preserves the existing caller-identity boundary, and clears startup authority once startup settles. Processes already admitted to the supervisor keep their current lifetime; this does not attach turn cancellation to running background commands or change approval policy, configuration, or persistence. The guarantee is before supervisor admission, not cancellation of every asynchronous native-adapter step after admission.

## User Impact

Cancelled commands no longer begin through the affected detached preparation/admission path. Sandbox startup cleanup still runs exactly once, while legitimate background commands continue after the parent turn ends. This is also the release-note context; no changelog file is changed.

## Evidence

Four regressions failed on unchanged main at `9bd50c803cce88f2ab387ddaf6cc29b4ef004005` before production edits: the actual detached caller/runtime admitted one process after cancellation, and child, PTY, and fallback owner cases returned process handles instead of rejecting cancellation. The same four cases pass with the repair. Existing foreground preparation coverage was extended to assert exactly-once sandbox finalization rather than adding another overlapping test.

Focused verification passed all 178 tests across six suites:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/bash-tools.exec-foreground-failures.test.ts \
  src/agents/bash-tools.exec-runtime.test.ts \
  src/agents/bash-tools.exec-host-gateway.test.ts \
  src/agents/bash-tools.exec-task-wiring.test.ts \
  src/agents/bash-tools.exec.background-abort.test.ts \
  src/agents/bash-tools.exec-host-node.cancellation.test.ts
```

A separate real-process run on the final source passed five scenarios with no supervisor mocks and disposable home/state: foreground success, foreground cancellation after real output, cancelled child and PTY admission with no sentinel execution, and an already-running background command completing after parent cancellation. Two native PTY fallback scenarios were explicitly skipped because macOS reports the safe unavailable-shell fault as a terminal exit rather than a spawn rejection. The fallback admission boundary remains covered by the focused regression test; native fallback is not claimed as proven.

Targeted typed lint, formatting, and `git diff --check` passed. Fresh isolated Codex autoreview completed with no actionable findings at its default P0 threshold. The full changed-file gate passed its first 17 guard/format/dead-code checks, then stopped in core typechecking: the installed Google SDK lacks `FinishReason.TOO_MANY_TOOL_CALLS`; the same run also reported missing `markdown-it` type exports and `pi-tui` `TuiMainScreen`. No exec-source error was reported. The shared dependency installation was left untouched; a current dependency environment, native preparation, and exact-head CI remain landing requirements.

Production changes: +20/-13 lines, net +7. Tests: +118/-1, net +117. The production growth carries and releases the shared startup cancellation signal and preserves detached terminal classification after removing duplicate caller checks.

AI-assisted implementation and review.
