### PR TITLE
fix(memory): preserve line endings when forgetting entries

### DIFF
--- a/extensions/memory-core/src/memory-forget.test.ts
+++ b/extensions/memory-core/src/memory-forget.test.ts
@@ -178,35 +178,142 @@ describe("memory forget", () => {
     ]);
   });
 
-  it("durably tombstones an unresolved explicit session without inventing artifacts", async () => {
-    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# Long-Term Memory\nKeep this.\n");
+  it.each([
+    { label: "LF", content: "# Long-Term Memory\nKeep this.\n" },
+    { label: "CRLF", content: "# Long-Term Memory\r\nKeep this.\r\n" },
+    { label: "mixed newlines", content: "# Long-Term Memory\r\nKeep this.\n" },
+  ])(
+    "durably tombstones an unresolved explicit session without changing $label artifacts",
+    async ({ content }) => {
+      const memoryPath = path.join(workspaceDir, "MEMORY.md");
+      await fs.writeFile(memoryPath, content);
+      const backup = {
+        key: "unrelated-backup",
+        value: {
+          createdAt: "2026-08-25T00:00:00.000Z",
+          content,
+          contentHash: createHash("sha256").update(content).digest("hex"),
+        },
+      };
+      await writeMemoryCoreWorkspaceEntries({
+        namespace: DREAMING_MEMORY_BACKUP_NAMESPACE,
+        workspaceDir,
+        entries: [backup],
+      });
+      const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
+      db.prepare(
+        `INSERT INTO memory_index_chunks
+        (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+       VALUES ('unrelated', 'MEMORY.md', 'memory', 1, 2,
+         'unrelated-hash', 'test', 'Keep this.', '[1,0]', 1)`,
+      ).run();
 
-    const preview = await forgetMemoryEntries({
-      cfg,
-      agentId: "main",
-      sessionIds: ["unknown-session"],
-      dryRun: true,
-    });
-    expect(preview).toMatchObject({
-      sessionIds: ["unknown-session"],
-      sessionResolutions: [{ sessionId: "unknown-session", source: "unresolved" }],
-    });
-    expect(Object.values(preview.artifacts).every((count) => count === 0)).toBe(true);
-    expect(listMemorySessionTombstones({ agentId: "main" })).toEqual([]);
+      const preview = await forgetMemoryEntries({
+        cfg,
+        agentId: "main",
+        sessionIds: ["unknown-session"],
+        dryRun: true,
+      });
+      expect(preview).toMatchObject({
+        sessionIds: ["unknown-session"],
+        sessionResolutions: [{ sessionId: "unknown-session", source: "unresolved" }],
+      });
+      expect(Object.values(preview.artifacts).every((count) => count === 0)).toBe(true);
+      expect(listMemorySessionTombstones({ agentId: "main" })).toEqual([]);
 
-    const report = await forgetMemoryEntries({
-      cfg,
-      agentId: "main",
-      sessionIds: ["unknown-session"],
-    });
-    expect(report).toEqual({ ...preview, dryRun: false });
-    const tombstones = listMemorySessionTombstones({ agentId: "main" });
-    expect(tombstones).toMatchObject([{ sessionId: "unknown-session", reason: "forgotten" }]);
-    expect(
-      await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["unknown-session"] }),
-    ).toEqual(report);
-    expect(listMemorySessionTombstones({ agentId: "main" })).toEqual(tombstones);
-  });
+      const report = await forgetMemoryEntries({
+        cfg,
+        agentId: "main",
+        sessionIds: ["unknown-session"],
+      });
+      expect(report).toEqual({ ...preview, dryRun: false });
+      const tombstones = listMemorySessionTombstones({ agentId: "main" });
+      expect(tombstones).toMatchObject([{ sessionId: "unknown-session", reason: "forgotten" }]);
+      expect(
+        await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["unknown-session"] }),
+      ).toEqual(report);
+      expect(listMemorySessionTombstones({ agentId: "main" })).toEqual(tombstones);
+      expect(await fs.readFile(memoryPath, "utf8")).toBe(content);
+      expect(db.prepare("SELECT id FROM memory_index_chunks").all()).toEqual([{ id: "unrelated" }]);
+      expect(
+        await readMemoryCoreWorkspaceEntries({
+          namespace: DREAMING_MEMORY_BACKUP_NAMESPACE,
+          workspaceDir,
+        }),
+      ).toEqual([backup]);
+    },
+  );
+
+  it.each([
+    { label: "LF", targetEnding: "\n", survivorEnding: "\n" },
+    { label: "CRLF", targetEnding: "\r\n", survivorEnding: "\r\n" },
+    { label: "mixed", targetEnding: "\r\n", survivorEnding: "\n" },
+  ])(
+    "preserves surviving line endings when purging $label corpus, memory, and backups",
+    async ({ targetEnding, survivorEnding }) => {
+      const memoryPath = path.join(workspaceDir, "MEMORY.md");
+      const corpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
+      const corpusPath = path.join(corpusDir, "2026-08-26.txt");
+      const quotation = "User: Remove this selected private fact.";
+      const retainedMemory = "# Long-Term Memory\r\nKeep this.\nAnother retained line.\r\n";
+      const content = `${retainedMemory}- Candidate: ${quotation}\r\n`;
+      const retainedCorpus = `[main/sessions/main/survivor#L1] User: Keep this unrelated fact.${survivorEnding}`;
+      await fs.mkdir(corpusDir, { recursive: true });
+      await fs.writeFile(memoryPath, content);
+      await fs.writeFile(
+        corpusPath,
+        `[main/sessions/main/target#L1] ${quotation}${targetEnding}${retainedCorpus}`,
+      );
+      await writeMemoryCoreWorkspaceEntries({
+        namespace: DREAMING_MEMORY_BACKUP_NAMESPACE,
+        workspaceDir,
+        entries: [
+          {
+            key: "backup",
+            value: {
+              createdAt: "2026-08-25T00:00:00.000Z",
+              content,
+              contentHash: createHash("sha256").update(content).digest("hex"),
+            },
+          },
+        ],
+      });
+
+      const preview = await forgetMemoryEntries({
+        cfg,
+        agentId: "main",
+        sessionIds: ["target"],
+        dryRun: true,
+      });
+      expect(preview.artifacts).toMatchObject({
+        memoryFiles: 1,
+        memoryLines: 1,
+        sessionCorpusFiles: 1,
+        sessionCorpusLines: 1,
+        backups: 1,
+      });
+      expect(await fs.readFile(memoryPath, "utf8")).toBe(content);
+      const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
+      expect(report).toEqual({ ...preview, dryRun: false });
+      expect(await fs.readFile(memoryPath, "utf8")).toBe(retainedMemory);
+      expect(await fs.readFile(corpusPath, "utf8")).toBe(retainedCorpus);
+      expect(
+        await readMemoryCoreWorkspaceEntries({
+          namespace: DREAMING_MEMORY_BACKUP_NAMESPACE,
+          workspaceDir,
+        }),
+      ).toEqual([
+        {
+          key: "backup",
+          value: {
+            createdAt: "2026-08-25T00:00:00.000Z",
+            content: retainedMemory,
+            contentHash: createHash("sha256").update(retainedMemory).digest("hex"),
+          },
+        },
+      ]);
+    },
+  );
 
   it("removes staged backfill entries when their source session is forgotten", async () => {
     await seedSession("backfilled");

--- a/extensions/memory-core/src/memory-forget.ts
+++ b/extensions/memory-core/src/memory-forget.ts
@@ -151,7 +151,8 @@ function scrubMemoryContent(params: {
   corpusSnippets: ReadonlySet<string>;
   agentId: string;
 }): { content: string; removedEntries: number; removedLines: number } {
-  const lines = params.content.split(/\r?\n/u);
+  // Preserve surviving line endings so unrelated artifacts do not enter the purge plan.
+  const lines = params.content.split("\n");
   const corpusSnippets = [...params.corpusSnippets];
   let removedEntries = 0;
   let removedLines = 0;
@@ -402,12 +403,12 @@ async function forgetWorkspaceMemory(
     }
     const absolutePath = path.join(corpusDir, file.name);
     const content = await fs.readFile(absolutePath, "utf8");
-    const lines = content.split(/\r?\n/u);
+    const lines = content.split("\n");
     const retained = lines.filter((line) => {
       if (!referencesSession(line, params.agentId, sessionIds)) {
         return true;
       }
-      const snippet = /^\[[^\]]+#L\d+\]\s*(.+)$/u.exec(line)?.[1]?.trim();
+      const snippet = /^\[[^\]]+#L\d+\]\s*(.+)$/u.exec(line.trimEnd())?.[1]?.trim();
       // Ingestion only admits snippets of at least 12 characters; shorter
       // malformed corpus rows must never trigger broad substring deletion.
       if (snippet && snippet.length >= 12) {


### PR DESCRIPTION
Closes #130942

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw memory forget` would see unrelated memory files, backups, and indexed chunks scheduled for changes when their files used CRLF or mixed line endings. A selector with no matching content could produce a nonzero deletion preview, and selected deletions rewrote surviving line endings.

## Why This Change Was Made

The deletion owner discarded carriage returns when splitting lines and mistook the resulting byte differences for deletion work. Preserve each surviving line's original ending in memory/backup scrubbing and corpus filtering, trimming only the temporary corpus-quotation parsing input so selected CRLF quotations still match.

This repairs the shared producer of file rewrites and index invalidation without adding a second path. It changes no options, dependencies, schemas, migrations, session selection, or tombstone policy. Production: **+4/-3, net +1**; executable LOC is neutral, with one added invariant comment. Tests: **+134/-27, net +107**.

The faulty split/join originated in `9d9dc3127521d556c37865e4f78ba20ee95fe8e3`, [#130151](https://github.com/openclaw/openclaw/pull/130151), authored and merged by @steipete on August 26, 2026, and was retained by [#130451](https://github.com/openclaw/openclaw/pull/130451). The affected owner and caller are unchanged at main `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`.

## User Impact

Forgetting a session preserves surviving file bytes and unrelated backups, indexed chunks, and cached embeddings. Unmatched previews no longer count newline normalization as deletion work. LF, CRLF, and mixed-newline inputs share the same deletion path.

## Evidence

Before production edits, the real deletion-boundary regression reported **3 failures and 1 passing LF control**. Expanded coverage caught a CRLF quotation-extraction regression in the first candidate; the final targeted run changed from **2 failed / 1 passed** to **3 passed**. The completed owner/sibling suite on baseline `ac71743ca44a1927ddf8bcd3b32d71b60e27c0ac` plus this repair passed **124 tests across four files**:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/memory-core/src/memory-forget.test.ts extensions/memory-core/src/memory-forget-curated-writes.test.ts extensions/memory-core/src/memory-entry-origins.test.ts extensions/memory-core/src/cli.test.ts
```

A clean Linux build passed **five actual CLI invocations** using disposable HOME/state/workspace directories, real SQLite, and no CLI/store mocks: cold initialization, unmatched preview, selected preview, selected deletion, and repeat deletion. Both previews preserved complete snapshots, including configuration, files, backups, indexes, plugin state, and tombstones. Apply removed the selected marked entry and quotation, corpus row, two chunks, two FTS rows, and two cached embeddings, and scrubbed/rehashed one matching backup. Unrelated state and surviving mixed-newline bytes stayed intact; repeat deletion reported zero artifact changes. The tested memory-forget production source is identical to this repair.

Cold initialization separately recorded an existing Matrix doctor migration receipt before the fixture was seeded. Subsequent snapshot assertions did not filter or ignore any plugin-state rows. Named follow-up: **CLI dry-run startup migration writes outside the selected plugin**; this patch does not change that startup policy.

The first fresh main-based run had **123 passed / 1 timeout** in 352.21 seconds: the existing CLI index-corruption test exceeded 120 seconds. With no source, assertion, mock, or timeout changes, the adjacent corruption checks passed **2/2**, then the original four-file command passed **124/124** in 197.74 seconds. Transform/import time fell substantially, but the exact original stall is not established; the initial failure remains disclosed. The fresh autoreview reported no actionable findings at its configured **P0-only threshold**, not an all-severity approval. Exact-head CI and the remaining landing gates are still pending.

AI-assisted maintainer repair; source and proof inspected.
