### PR TITLE
fix(ui): group sessions by local calendar days

### DIFF
--- a/ui/src/lib/sessions/grouping.test.ts
+++ b/ui/src/lib/sessions/grouping.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment node
+import { execFileSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import {
@@ -400,6 +401,53 @@ describe("normalizeSessionsGroupBy", () => {
 });
 
 describe("groupSessionRows", () => {
+  it.each(["UTC", "America/Los_Angeles", "America/Santiago"])(
+    "groups complete local calendar days in %s",
+    (timeZone) => {
+      // Worker-thread TZ mutations do not reliably change V8's timezone. Start a
+      // process in the requested zone so real calendar/DST behavior owns the proof.
+      const output = execFileSync(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          "--input-type=module",
+          "--eval",
+          `
+          import { groupSessionRows } from ${JSON.stringify(new URL("./grouping.ts", import.meta.url).href)};
+          const dates = [[2026, 0, 1], [2026, 2, 9], [2026, 10, 2], [2026, 8, 6], [2026, 8, 7]];
+          const results = dates.map(([year, month, day]) => {
+            const at = (daysAgo, hour = 0, minute = 0) =>
+              new Date(year, month, day - daysAgo, hour, minute).getTime();
+            const rows = [
+              ["today", at(0)], ["yesterday", at(1)],
+              ["two-days-ago", at(2, 23, 59)], ["six-days-ago", at(6)],
+              ["older", at(7, 23, 59)], ["unknown", null],
+            ].map(([key, updatedAt]) => ({ key, updatedAt, kind: "direct" }));
+            return groupSessionRows({ mode: "date", now: at(0, 12), rows })
+              .map((group) => [group.id, group.rows.map((row) => row.key)]);
+          });
+          process.stdout.write(JSON.stringify(results));
+        `,
+        ],
+        {
+          cwd: new URL("../../../../", import.meta.url),
+          env: { ...process.env, TZ: timeZone },
+          encoding: "utf8",
+          timeout: 10_000,
+        },
+      );
+      const expected = [
+        ["today", ["today"]],
+        ["yesterday", ["yesterday"]],
+        ["week", ["two-days-ago", "six-days-ago"]],
+        ["older", ["older"]],
+        [UNGROUPED_ID, ["unknown"]],
+      ];
+      expect(JSON.parse(output)).toEqual(Array.from({ length: 5 }, () => expected));
+    },
+  );
+
   it("keeps known categories in order, appends extras, and puts ungrouped last", () => {
     const rows = [
       row({ key: "a", category: "Zulu" }),

--- a/ui/src/lib/sessions/grouping.ts
+++ b/ui/src/lib/sessions/grouping.ts
@@ -127,16 +127,17 @@ function dateBucketId(updatedAt: number | null | undefined, now: number): string
   if (typeof updatedAt !== "number" || !Number.isFinite(updatedAt) || updatedAt <= 0) {
     return UNGROUPED_ID;
   }
-  const startOfToday = new Date(now);
-  startOfToday.setHours(0, 0, 0, 0);
-  const dayMs = 24 * 60 * 60 * 1000;
-  if (updatedAt >= startOfToday.getTime()) {
+  const today = new Date(now);
+  // Calendar midnights can be 23 or 25 hours apart across daylight-saving changes.
+  const startOfDay = (daysAgo: number) =>
+    new Date(today.getFullYear(), today.getMonth(), today.getDate() - daysAgo).getTime();
+  if (updatedAt >= startOfDay(0)) {
     return "today";
   }
-  if (updatedAt >= startOfToday.getTime() - dayMs) {
+  if (updatedAt >= startOfDay(1)) {
     return "yesterday";
   }
-  if (updatedAt >= startOfToday.getTime() - 6 * dayMs) {
+  if (updatedAt >= startOfDay(6)) {
     return "week";
   }
   return "older";

--- a/ui/src/pages/sessions/view.test.ts
+++ b/ui/src/pages/sessions/view.test.ts
@@ -104,6 +104,54 @@ function sessionTableHeaders(container: HTMLElement): Array<string | undefined> 
 const SESSION_TABLE_HEADERS = ["", "Key", "Kind", "Status", "Updated", "Tokens", "Actions"];
 
 describe("sessions view", () => {
+  it("renders local calendar date headings with their session rows", async () => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(new Date(2026, 2, 9, 12).getTime());
+    const container = document.createElement("div");
+    try {
+      render(
+        renderSessions({
+          ...buildProps(
+            buildMultiResult([
+              { key: "today", kind: "direct", updatedAt: new Date(2026, 2, 9).getTime() },
+              { key: "yesterday", kind: "direct", updatedAt: new Date(2026, 2, 8).getTime() },
+              {
+                key: "two-days-ago",
+                kind: "direct",
+                updatedAt: new Date(2026, 2, 7, 23, 59).getTime(),
+              },
+              { key: "six-days-ago", kind: "direct", updatedAt: new Date(2026, 2, 3).getTime() },
+              { key: "older", kind: "direct", updatedAt: new Date(2026, 2, 2, 23, 59).getTime() },
+            ]),
+          ),
+          groupBy: "date",
+        }),
+        container,
+      );
+      await Promise.resolve();
+
+      expect(
+        [...container.querySelectorAll("tbody > tr")].map((row) =>
+          (
+            row.querySelector(".session-group-row__label") ?? row.querySelector(".session-link")
+          )?.textContent?.trim(),
+        ),
+      ).toEqual([
+        "Today",
+        "today",
+        "Yesterday",
+        "yesterday",
+        "This week",
+        "two-days-ago",
+        "six-days-ago",
+        "Older",
+        "older",
+      ]);
+    } finally {
+      clock.mockRestore();
+      render(null, container);
+    }
+  });
+
   it("makes every session sort header a keyboard-accessible button", async () => {
     const container = document.createElement("div");
     const onSortChange = vi.fn();


### PR DESCRIPTION
Closes #130944

## What Problem This Solves

Fixes an issue where users grouping Control UI sessions by date would see sessions under the wrong headings around daylight-saving changes. A session from yesterday could appear under This week, while the six-day boundary could move a session into Older too early.

## Why This Change Was Made

The shared date-grouping owner subtracted fixed 24-hour durations from local midnight, although local calendar days can be shorter or longer. Constructing each calendar-day boundary independently fixes Today, Yesterday, and the existing six-day This week window, including timezones where midnight is skipped. The Sessions renderer continues to consume the same canonical grouping result; no view-specific workaround, styling, configuration, persistence, or protocol change is needed.

Production LOC: +7/-6 (net +1, the invariant comment). Tests: +96/-0. The old elapsed-duration path is removed. Keeping runtime code neutral and adding behavior-level timezone and rendered-row coverage is preferable to another date library or a downstream rendering correction.

Provenance is clear: the faulty arithmetic entered in #100262, commit f607ba0691b2cfef658a40837ad5f8797aa9ab09, merged July 5, 2026. The blamed code author, PR author, and PR merger were all @steipete. The same arithmetic is present in stable tag v2026.7.1-2; this report does not claim a runtime test of that release.

## User Impact

Date groups now follow local calendar days across daylight-saving changes, preserving every session and the existing group order. Other grouping modes and sessions without activity timestamps retain their behavior. No operator action or migration is required.

AI-assisted implementation and test authoring, with source inspection, regression proof, and visual inspection.

## Evidence

Fresh verification against main at 9bd50c803cce88f2ab387ddaf6cc29b4ef004005 plus this three-file patch:

- `node scripts/run-vitest.mjs ui/src/lib/sessions/grouping.test.ts ui/src/pages/sessions/view.test.ts`: **84/84 passed**. Actual grouping runs in fresh processes for UTC, America/Los_Angeles, and America/Santiago, covering New Year, spring/fall transitions, skipped midnight, and the following day. The renderer test checks ordered headings and session placement.
- Targeted formatting and lint checks passed; `git diff --check` passed. Changed-check classification is `coreTests, ui`; broad CI/changed gates are not claimed by this focused run.
- Fresh isolated Codex autoreview exited successfully with no P0 findings. The reviewer assessed the supplied bundle; it did not independently rerun tests.
- Original production code with the final tests previously failed the Los Angeles and Santiago grouping regressions and the rendered grouping regression. The source-rendered Chromium proof also failed both spring/fall expectations before the fix; the identical run passed all 85 tests after the fix, including that temporary browser proof.
- Earlier full bundled Control UI proof passed **5/5 browser cases**: Los Angeles spring/fall, Santiago skipped midnight/the following day, and UTC. Each boots the app, opens Sessions, selects Filters → Date, checks the five rows under Today (1), Yesterday (1), This week (2), Older (1), and reloads to verify the choice persists. All 20 screenshots, five evidence files, and 15 representative frames from five videos were inspected; no unexpected state was found.

The browser recordings were captured on the earlier combined candidate based on ac71743ca44a1927ddf8bcd3b32d71b60e27c0ac, not this new branch head. The grouping owner, Sessions caller/view, and touched tests are unchanged between those bases; fresh focused proof above covers the rebased patch. Full-app browser proof uses mocked Gateway WebSocket responses and synthetic timestamps, not a real Gateway, provider, or channel. It covers desktop English at a fixed clock, not live midnight rollover or mobile layouts.


### Browser proof

Synthetic Sessions renderer fixtures in America/Los_Angeles at the fall DST transition; no personal session data. These pictures are renderer proof, not a full live Gateway session.

Before:

![Before: yesterday grouped under this week](https://github.com/user-attachments/assets/20edee92-dc01-4d4c-9ab4-3c687bb1b380)

After:

![After: calendar groups restored](https://github.com/user-attachments/assets/7b6ccbd6-71f3-426b-bee0-e4369441ee80)
