### PR TITLE
fix(scripts): resolve worktree implementation dependencies

### DIFF
--- a/.github/workflows/docs-sync-publish.yml
+++ b/.github/workflows/docs-sync-publish.yml
@@ -12,6 +12,7 @@ on:
       - scripts/check-docs-mdx.mts
       - scripts/lib/mintlify-accordion.mjs
       - scripts/lib/tsx-cli-shim.mjs
+      - scripts/lib/local-check-runtime.mts
       - .github/workflows/docs-sync-publish.yml
   workflow_dispatch:
 

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -21,6 +21,7 @@ on:
       - "scripts/lib/plugin-npm-package-manifest.mjs"
       - "scripts/lib/plugin-npm-package-manifest.mts"
       - "scripts/lib/tsx-cli-shim.mjs"
+      - "scripts/lib/local-check-runtime.mts"
       - "scripts/lib/plugin-npm-release.ts"
       - "scripts/lib/plugin-publication-candidates.ts"
       - "scripts/lib/plugin-publication-collector.ts"

--- a/scripts/docs-sync-publish.mjs
+++ b/scripts/docs-sync-publish.mjs
@@ -34,6 +34,10 @@ const SYNC_SUPPORT_FILES = [
     target: path.join(".openclaw-sync", "lib", "tsx-cli-shim.mjs"),
   },
   {
+    source: path.join(ROOT, "scripts", "lib", "local-check-runtime.mts"),
+    target: path.join(".openclaw-sync", "lib", "local-check-runtime.mts"),
+  },
+  {
     source: path.join(ROOT, "scripts", "lib", "mintlify-accordion.mjs"),
     target: path.join(".openclaw-sync", "lib", "mintlify-accordion.mjs"),
   },

--- a/scripts/lib/local-check-runtime.mts
+++ b/scripts/lib/local-check-runtime.mts
@@ -24,6 +24,10 @@ type RepoToolOptions = {
   fileExists?: (candidate: string) => boolean;
   resolveCommonDir?: (cwd: string) => string | null;
 };
+type NodeModulesLinkOptions = Pick<RepoToolOptions, "cwd" | "fileExists"> & {
+  symlink?: typeof fs.symlinkSync;
+  platform?: NodeJS.Platform;
+};
 
 /** Return whether local check safeguards are enabled for an environment. */
 export function isLocalCheckEnabled(env: Env) {
@@ -81,10 +85,7 @@ export function ensureRepoToolNodeModulesLink(
     resolveCommonDir = resolveGitCommonDir,
     symlink = fs.symlinkSync,
     platform = process.platform,
-  }: RepoToolOptions & {
-    symlink?: typeof fs.symlinkSync;
-    platform?: NodeJS.Platform;
-  } = {},
+  }: RepoToolOptions & NodeModulesLinkOptions = {},
 ) {
   const localNodeModules = path.resolve(cwd, "node_modules");
   if (fileExists(localNodeModules)) {
@@ -102,10 +103,30 @@ export function ensureRepoToolNodeModulesLink(
     return null;
   }
 
+  return ensureRepoNodeModulesLink(primaryNodeModules, { cwd, fileExists, symlink, platform });
+}
+
+/** Make selected toolchain packages resolvable from dependency-less source paths. */
+export function ensureRepoNodeModulesLink(
+  modulesDir: string,
+  {
+    cwd = process.cwd(),
+    fileExists = fs.existsSync,
+    symlink = fs.symlinkSync,
+    platform = process.platform,
+  }: NodeModulesLinkOptions = {},
+) {
+  const localNodeModules = path.resolve(cwd, "node_modules");
+  if (fileExists(localNodeModules)) {
+    return localNodeModules;
+  }
+  if (!fileExists(modulesDir)) {
+    return null;
+  }
   try {
-    // Match run-vitest.mjs's hydrated-toolchain behavior: keep one stable link
-    // so compilers can resolve imports from worktree source paths.
-    symlink(primaryNodeModules, localNodeModules, platform === "win32" ? "junction" : "dir");
+    // Keep existing checkout dependencies locally owned; only absent modules
+    // reuse the selected installed toolchain, without reconciling dependencies.
+    symlink(modulesDir, localNodeModules, platform === "win32" ? "junction" : "dir");
   } catch (error) {
     // Another local runner may have installed the same stable link concurrently.
     if (!fileExists(localNodeModules)) {

--- a/scripts/lib/plugin-publication-candidates.ts
+++ b/scripts/lib/plugin-publication-candidates.ts
@@ -25,6 +25,7 @@ export const PLUGIN_NPM_RELEASE_AUTHORITY_PATHS = [
   "scripts/generate-npm-package-lock.mjs",
   "scripts/generate-npm-package-lock.mts",
   "scripts/lib/actions-artifact-archive.mjs",
+  "scripts/lib/local-check-runtime.mts",
   "scripts/lib/npm-json-output.mts",
   "scripts/lib/plugin-npm-package-manifest.mjs",
   "scripts/lib/plugin-npm-package-manifest.mts",

--- a/scripts/lib/tsx-cli-shim.mjs
+++ b/scripts/lib/tsx-cli-shim.mjs
@@ -4,6 +4,7 @@ import { createRequire } from "node:module";
 import { constants as osConstants } from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { ensureRepoNodeModulesLink } from "./local-check-runtime.mts";
 
 const FORWARDED_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP"];
 const DEFAULT_FORCE_KILL_DELAY_MS = 5_000;
@@ -40,7 +41,13 @@ function resolveTsxImport(checkoutRoot) {
   ].filter(Boolean)) {
     try {
       const require = createRequire(path.join(candidateRoot, "package.json"));
-      return pathToFileURL(require.resolve("tsx")).href;
+      const importUrl = pathToFileURL(require.resolve("tsx")).href;
+      const selectedModulesDir =
+        candidateRoot === hydratedTsxRoot
+          ? path.dirname(candidateRoot)
+          : path.join(candidateRoot, "node_modules");
+      ensureRepoNodeModulesLink(selectedModulesDir, { cwd: checkoutRoot });
+      return importUrl;
     } catch (error) {
       resolutionError = error;
     }

--- a/scripts/pr
+++ b/scripts/pr
@@ -51,6 +51,7 @@ pr_wrapper_components=(
   scripts/lib/plain-gh.mjs
   scripts/lib/direct-run.mjs
   scripts/lib/tsx-cli-shim.mjs
+  scripts/lib/local-check-runtime.mts
   scripts/verify-pr-hosted-gates.mjs
   scripts/verify-pr-hosted-gates.mts
   scripts/watch-pr-ci.mjs

--- a/test/scripts/direct-run-entrypoints.test.ts
+++ b/test/scripts/direct-run-entrypoints.test.ts
@@ -100,6 +100,13 @@ function writeTsxFixture(modulesDir: string, marker: string) {
     path.join(packageDir, "loader.mjs"),
     `process.env.OPENCLAW_TSX_FIXTURE_LOADER = ${JSON.stringify(marker)};\n`,
   );
+  const dependencyDir = path.join(modulesDir, "shim-dependency");
+  mkdirSync(dependencyDir, { recursive: true });
+  writeFileSync(
+    path.join(dependencyDir, "package.json"),
+    JSON.stringify({ name: "shim-dependency", type: "module", exports: "./index.js" }),
+  );
+  writeFileSync(path.join(dependencyDir, "index.js"), 'export const value = "loaded";\n');
 }
 
 function runShimFixture(
@@ -121,10 +128,14 @@ function runShimFixture(
       "scripts/lib/tsx-cli-shim.mjs",
       path.join(checkoutRoot, "scripts", "lib", "tsx-cli-shim.mjs"),
     );
+    copyFileSync(
+      "scripts/lib/local-check-runtime.mts",
+      path.join(checkoutRoot, "scripts", "lib", "local-check-runtime.mts"),
+    );
     writeFileSync(path.join(checkoutRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
     writeFileSync(
       implementationPath,
-      "process.stdout.write(JSON.stringify({ loader: process.env.OPENCLAW_TSX_FIXTURE_LOADER, args: process.argv.slice(2) }));\n",
+      'import { value } from "shim-dependency";\nprocess.stdout.write(JSON.stringify({ loader: process.env.OPENCLAW_TSX_FIXTURE_LOADER, dependency: value, args: process.argv.slice(2) }));\n',
     );
     writeTsxFixture(path.join(checkoutRoot, "node_modules"), "checkout");
     const modulesEnv = configureModules({ checkoutRoot, fixtureRoot });
@@ -149,7 +160,11 @@ function runShimFixture(
 function expectShimLoader(result: ReturnType<typeof runShimFixture>, loader: string) {
   expect(result.error).toBeUndefined();
   expect(result.status, result.stderr).toBe(0);
-  expect(JSON.parse(result.stdout)).toEqual({ loader, args: ["--hydrated-proof"] });
+  expect(JSON.parse(result.stdout)).toEqual({
+    loader,
+    dependency: "loaded",
+    args: ["--hydrated-proof"],
+  });
 }
 
 describe("script direct-run entrypoints", () => {
@@ -195,6 +210,29 @@ describe("script direct-run entrypoints", () => {
   it("falls back to checkout dependencies without an external modules directory", () => {
     expectShimLoader(runShimFixture(TSX_SHIM_WRAPPERS[3]), "checkout");
   });
+
+  it.each(["hydrated", "primary"] as const)(
+    "resolves implementation dependencies from the %s toolchain without local modules",
+    (source) => {
+      const result = runShimFixture(TSX_SHIM_WRAPPERS[0], ({ checkoutRoot, fixtureRoot }) => {
+        rmSync(path.join(checkoutRoot, "node_modules"), { recursive: true });
+        const primaryRoot = path.join(fixtureRoot, "primary");
+        const modulesDir = path.join(primaryRoot, "node_modules");
+        writeTsxFixture(modulesDir, source);
+        if (source === "hydrated") {
+          return { PNPM_CONFIG_MODULES_DIR: modulesDir };
+        }
+        const initialized = spawnSync(
+          "git",
+          ["init", "--quiet", "--separate-git-dir", path.join(primaryRoot, ".git"), checkoutRoot],
+          { encoding: "utf8" },
+        );
+        expect(initialized.status, initialized.stderr).toBe(0);
+        return {};
+      });
+      expectShimLoader(result, source);
+    },
+  );
 
   it("matches Windows drive paths case-insensitively", () => {
     expect(

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -627,6 +627,7 @@ describe("scripts/test-docker-all scheduler", () => {
     for (const fileName of [
       "docker-e2e-plan.mts",
       "docker-e2e-scenarios.mts",
+      "local-check-runtime.mts",
       "managed-child-process.mts",
       "official-external-channel-catalog.json",
       "release-version.mjs",

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -213,6 +213,7 @@ function installPrCliFixture(repoDir: string) {
     "scripts/lib/plain-gh.mjs",
     "scripts/lib/direct-run.mjs",
     "scripts/lib/tsx-cli-shim.mjs",
+    "scripts/lib/local-check-runtime.mts",
     "scripts/pr-lib/worktree.sh",
     "scripts/pr-lib/operation-lock.sh",
     "scripts/pr-lib/process-group-runner.mjs",

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -87,6 +87,10 @@ function makeMismatchedWrapperRepo() {
   cpSync("scripts/lib/plain-gh.mjs", join(canonical, "scripts", "lib", "plain-gh.mjs"));
   cpSync("scripts/lib/direct-run.mjs", join(canonical, "scripts", "lib", "direct-run.mjs"));
   cpSync("scripts/lib/tsx-cli-shim.mjs", join(canonical, "scripts", "lib", "tsx-cli-shim.mjs"));
+  cpSync(
+    "scripts/lib/local-check-runtime.mts",
+    join(canonical, "scripts", "lib", "local-check-runtime.mts"),
+  );
   writeFileSync(
     join(canonical, "scripts", "lib", "plain-gh.sh"),
     "resolve_plain_gh_bin() { printf '/usr/bin/true\\n'; }\ngh_plain() { :; }\n",
@@ -438,6 +442,7 @@ describe("scripts/pr wrappers", () => {
     writeFileSync(join(repo, "scripts", "lib", "plain-gh.mjs"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "lib", "direct-run.mjs"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "lib", "tsx-cli-shim.mjs"), "// canonical\n");
+    writeFileSync(join(repo, "scripts", "lib", "local-check-runtime.mts"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "watch-pr-ci.mjs"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "watch-pr-ci.mts"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "verify-pr-hosted-gates.mjs"), "// canonical\n");
@@ -454,36 +459,23 @@ describe("scripts/pr wrappers", () => {
     expect(git(repo, ["commit", "-m", "test: canonical wrapper"]).status).toBe(0);
     expect(git(repo, ["worktree", "add", "-b", "feature", linked]).status).toBe(0);
 
-    writeFileSync(join(linked, "scripts", "pr-lib", "merge.sh"), "# dirty linked\n");
-    const dirtyLinkedResult = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
-      cwd: linked,
-      encoding: "utf8",
-    });
-    expect(dirtyLinkedResult.status).toBe(1);
-    expect(dirtyLinkedResult.stderr).toContain("scripts/pr wrapper files have uncommitted changes");
-    expect(git(linked, ["restore", "scripts/pr-lib/merge.sh"]).status).toBe(0);
-
-    writeFileSync(join(linked, "scripts", "watch-pr-ci.mts"), "// dirty watcher\n");
-    const dirtyWatcherResult = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
-      cwd: linked,
-      encoding: "utf8",
-    });
-    expect(dirtyWatcherResult.status).toBe(1);
-    expect(dirtyWatcherResult.stderr).toContain(
-      "scripts/pr wrapper files have uncommitted changes",
-    );
-    expect(git(linked, ["restore", "scripts/watch-pr-ci.mts"]).status).toBe(0);
-
-    writeFileSync(join(linked, "scripts", "verify-pr-hosted-gates.mts"), "// dirty verifier\n");
-    const dirtyVerifierResult = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
-      cwd: linked,
-      encoding: "utf8",
-    });
-    expect(dirtyVerifierResult.status).toBe(1);
-    expect(dirtyVerifierResult.stderr).toContain(
-      "scripts/pr wrapper files have uncommitted changes",
-    );
-    expect(git(linked, ["restore", "scripts/verify-pr-hosted-gates.mts"]).status).toBe(0);
+    for (const component of [
+      "scripts/pr-lib/merge.sh",
+      "scripts/watch-pr-ci.mts",
+      "scripts/verify-pr-hosted-gates.mts",
+      "scripts/lib/local-check-runtime.mts",
+    ]) {
+      writeFileSync(join(linked, component), "# dirty linked\n");
+      const dirtyResult = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
+        cwd: linked,
+        encoding: "utf8",
+      });
+      expect(dirtyResult.status, component).toBe(1);
+      expect(dirtyResult.stderr, component).toContain(
+        "scripts/pr wrapper files have uncommitted changes",
+      );
+      expect(git(linked, ["restore", component]).status).toBe(0);
+    }
 
     // A dirty canonical checkout no longer blocks a linked worktree whose
     // committed wrapper matches the origin/main trust anchor; without that
@@ -499,8 +491,8 @@ describe("scripts/pr wrappers", () => {
     );
     expect(git(repo, ["restore", "scripts/pr-lib/merge.sh"]).status).toBe(0);
 
-    writeFileSync(join(linked, "scripts", "pr-lib", "merge.sh"), "# linked\n");
-    expect(git(linked, ["add", "scripts/pr-lib/merge.sh"]).status).toBe(0);
+    writeFileSync(join(linked, "scripts", "lib", "local-check-runtime.mts"), "// linked\n");
+    expect(git(linked, ["add", "scripts/lib/local-check-runtime.mts"]).status).toBe(0);
     expect(git(linked, ["commit", "-m", "test: linked wrapper"]).status).toBe(0);
 
     const result = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
@@ -513,6 +505,7 @@ describe("scripts/pr wrappers", () => {
     expect(result.stderr).toContain(
       "scripts/pr implementation differs between this worktree and the canonical checkout",
     );
+    expect(result.stderr).toContain("scripts/lib/local-check-runtime.mts");
   });
 
   it("runs the local wrapper when it matches origin/main and the canonical checkout is parked elsewhere", () => {
@@ -526,6 +519,7 @@ describe("scripts/pr wrappers", () => {
     writeFileSync(join(repo, "scripts", "lib", "plain-gh.mjs"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "lib", "direct-run.mjs"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "lib", "tsx-cli-shim.mjs"), "// canonical\n");
+    writeFileSync(join(repo, "scripts", "lib", "local-check-runtime.mts"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "watch-pr-ci.mjs"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "watch-pr-ci.mts"), "// canonical\n");
     writeFileSync(join(repo, "scripts", "verify-pr-hosted-gates.mjs"), "// canonical\n");

--- a/test/scripts/release-preflight.test.ts
+++ b/test/scripts/release-preflight.test.ts
@@ -132,6 +132,7 @@ function makeIsolatedPreflightFixture(params: Parameters<typeof makeReleaseFixtu
     "scripts/windows-cmd-helpers.mjs",
     "scripts/lib/error-format.mts",
     "scripts/lib/failed-trailer.mts",
+    "scripts/lib/local-check-runtime.mts",
     "scripts/lib/managed-child-process.mts",
     "scripts/lib/release-version.mjs",
     "scripts/lib/tsx-cli-shim.mjs",


### PR DESCRIPTION
Closes #130949

## What Problem This Solves

Fixes an issue where contributors running wrapped commands from a worktree without local `node_modules` would get module-resolution errors even though the primary checkout or configured external modules directory already contained the required packages. The wrapper could locate `tsx`, but the implementation could not resolve its own imports; the real MDX check and two subprocess regressions reproduced the failure.

## Why This Change Was Made

The shared bootstrap now makes the selected installed toolchain resolvable from the worktree by reusing the existing missing-`node_modules` link behavior. Existing local dependencies remain untouched, and no dependency installation or reconciliation is added. The docs mirror, docs/plugin workflow path filters, and plugin publication authority paths include the newly imported helper so copied and published script closures stay complete. The PR wrapper identity list also includes the helper, preserving the existing canonical/origin-main guard over its full import closure.

## User Impact

Wrapped scripts can reuse already installed packages from configured external modules or the primary checkout without requiring a separate worktree installation. Existing local dependency ownership and loader precedence remain unchanged. This affects development and publication tooling, not Gateway state, provider behavior, or public configuration.

## Evidence

The original QA pass recorded a failing real MDX command and two failing subprocess regressions before the repair. CI then exposed three isolated release-preflight fixtures missing the new static helper import ([run 33077700480, job 98536464770](https://github.com/openclaw/openclaw/actions/runs/33077700480/job/98536464770)). Local fail-before runs reproduced all three, one isolated Docker planner case, and the PR wrapper's missing dirty-helper guard. The repair completes all four selective fixture copiers and adds the helper to the existing wrapper identity list. Dirty and committed helper mismatches are covered without changing advisory/landing classifications or developer opt-in.

The expanded seven-file run recorded **214 passed, one skipped, and one failure**: an unchanged GC lock case printed its expected output but returned a null subprocess status. That exact case then passed unchanged on a targeted rerun in 1.13 seconds. All release-preflight, isolated Docker planning, wrapper, and original bootstrap/docs suites passed in the expanded run. This is not presented as one completely green seven-file invocation. Fresh formatting, scoped typed lint, Bash syntax, and whitespace checks pass.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/release-preflight.test.ts test/scripts/docker-all-scheduler.test.ts test/scripts/pr-wrappers.test.ts test/scripts/pr-operation-lock.test.ts test/scripts/direct-run-entrypoints.test.ts test/scripts/local-check-runtime.test.ts test/scripts/docs-sync-publish.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/pr-operation-lock.test.ts -t 'does not report removal when gc cleanup leaves the worktree'
node_modules/.bin/oxfmt --check test/scripts/docker-all-scheduler.test.ts test/scripts/pr-operation-lock.test.ts test/scripts/pr-wrappers.test.ts test/scripts/release-preflight.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json test/scripts/docker-all-scheduler.test.ts test/scripts/pr-operation-lock.test.ts test/scripts/pr-wrappers.test.ts test/scripts/release-preflight.test.ts
bash -n scripts/pr
git diff --check
```

The same tooling patch also passed the earlier combined clean Linux build and full script typecheck. Its real MDX check passed and the internal-link check reported **6,875 checked, zero broken**. Those runs used the earlier combined candidate at `ac71743ca44a1927ddf8bcd3b32d71b60e27c0ac`; they are supporting evidence, not current PR-head CI. No docs deployment or release workflow was executed. The original scoped independent review and the fresh incremental review of the five-file CI repair reported no actionable **P0** findings; their threshold did not cover lower priorities.

Tooling/workflow LOC: **+44/-8 (net +36)**, including +2 workflow-filter lines and +1 existing wrapper identity-list entry. Tests: **+69/-34 (net +35)**. Growth extracts the already-used link operation into the shared bootstrap owner and carries its import through the docs/release and trusted-wrapper closures; it adds no dependency or parallel bootstrap path. The CI repair itself adds one production list entry and reduces test LOC by three by consolidating existing dirty-component cases.

Blame traces the incomplete bootstrap to [the script TypeScript migration](https://github.com/openclaw/openclaw/pull/121005), commit `c70aee247e831d21895f5ea3dda7497c50af0721`, authored and merged by `@steipete`. [The hydrated-loader follow-up](https://github.com/openclaw/openclaw/pull/121149) extended loader selection but did not make implementation dependencies resolvable. Archive-first discovery followed by bounded live searches found no direct open duplicate. Required exact-head CI and the native landing workflow remain pending for the repaired candidate.

AI-assisted maintainer repair; source and proof inspected.
