### PR TITLE
fix(cli): show real options in lazy command help

### DIFF
--- a/src/cli/program/commander-parse-facts.ts
+++ b/src/cli/program/commander-parse-facts.ts
@@ -94,11 +94,15 @@ function getRootCommand(command: Command): Command {
   return root;
 }
 
-/** Classify a possible child token only after Commander owns its active command node. */
+/** Resolve lazy help before classifying a possible child on Commander's active command node. */
 export function getCommanderSubcommandFact(
   command: Command,
   args: readonly string[],
 ): { kind: "defer" } | { kind: "unknown"; name: string } | undefined {
+  const helpRequested = args.includes("-h") || args.includes("--help");
+  if (helpRequested && lazyCommands.has(command)) {
+    return { kind: "defer" };
+  }
   const firstArgument = command.args[0];
   const matchesChild = command.commands.some(
     (child) => child.name() === firstArgument || child.aliases().includes(firstArgument ?? ""),
@@ -110,10 +114,6 @@ export function getCommanderSubcommandFact(
     matchesChild
   ) {
     return undefined;
-  }
-  const helpRequested = args.includes("-h") || args.includes("--help");
-  if (helpRequested && lazyCommands.has(command)) {
-    return { kind: "defer" };
   }
   return command.commands.length > 0 ? { kind: "unknown", name: firstArgument } : undefined;
 }

--- a/src/cli/program/openclaw-command.help.test.ts
+++ b/src/cli/program/openclaw-command.help.test.ts
@@ -1,0 +1,43 @@
+import { CommanderError } from "commander";
+import { describe, expect, it, vi } from "vitest";
+import { OpenClawCommand } from "./openclaw-command.js";
+import { registerLazyCommand } from "./register-lazy-command.js";
+
+describe("lazy command help", () => {
+  it.each(["--help", "-h"])("loads nested leaf options without executing for %s", async (flag) => {
+    const action = vi.fn();
+    let stdout = "";
+    const program = new OpenClawCommand().name("openclaw").exitOverride();
+    program.configureOutput({
+      writeOut: (text) => {
+        stdout += text;
+      },
+    });
+    const parent = program.command("browser");
+    registerLazyCommand({
+      program: parent,
+      name: "inspect",
+      description: "Lazy placeholder",
+      register: () => {
+        parent
+          .command("inspect")
+          .description("Inspect the selected target")
+          .argument("<target>")
+          .option("--details", "Include target details")
+          .action(action);
+      },
+    });
+
+    const error = await program
+      .parseAsync(["browser", "inspect", flag], { from: "user" })
+      .catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(CommanderError);
+    expect(error).toMatchObject({ code: "commander.helpDisplayed", exitCode: 0 });
+    expect(stdout).toContain("Inspect the selected target");
+    expect(stdout).toContain("<target>");
+    expect(stdout).toContain("--details");
+    expect(stdout).not.toContain("Lazy placeholder");
+    expect(action).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #130948

<details>
<summary>Additional instructions</summary>

This same-repository branch is editable by maintainers with repository write access. Implemented with AI assistance; the author owns the change and verification.

</details>

## What Problem This Solves

Fixes an issue where users asking for lazy command help, such as `openclaw browser batch --help`, would see only the placeholder's generic help option instead of the command's real flags. This hid `--actions`, `--actions-file`, `--continue`, and `--target-id` despite those options being supported.

## Why This Change Was Made

The canonical Commander classifier now defers help for a marked lazy placeholder before its operand-related early returns. Its existing lazy action loads the real command and reparses the original invocation; the real command then owns help, validation, and exit behavior. No duplicated option lists or browser-specific exception is needed.

The incomplete ordering was carried in #124707 (`b80d55a7f6dc934656ced152145b2449e25aac5e`, authored and merged by @steipete on August 16). This does not claim a last-known-good release. Production LOC: +5/-5, net zero. Tests: +43/-0. No configuration, dependencies, public arguments, persistence, or protocol changes.

## User Impact

Both `--help` and `-h` show real nested-command options without executing the command, requiring a configured provider, or connecting to a Gateway. Existing unknown-command errors and ordinary non-lazy parsing remain owned by Commander.

## Evidence

- Built baseline `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`: `node openclaw.mjs browser batch --help` exited 0 but listed only generic help. Rebuilt candidate: the same command exits 0 and displays all four batch options.
- The two new regression cases genuinely fail before the reorder. They use the real `OpenClawCommand` and lazy registration, assert a nested leaf's real description, required argument and option, and verify the action is never called.
- Final focused CLI/parser proof: 9 files, 204 passing tests. Earlier independent verification passed 232 owner/parser/browser tests on the same production change; final independent inspection confirmed the strengthened nested-leaf test closes its coverage finding.
- Candidate `node --import tsx scripts/build-all.mts cliStartup` completed successfully, including native built-module import checks.
- Final `node scripts/check-changed.mjs -- src/cli/program/commander-parse-facts.ts src/cli/program/openclaw-command.help.test.ts` passed all selected formatting, core/core-test typechecking, lint, and guards.
- Source-blind built-CLI validation passed all four contract clauses across 21 invocations: 17 help successes and four expected validation errors, zero configured-Gateway connections, no timeouts, and empty isolated state throughout. Long/short help, sibling screenshot/browser/root help, unknown children, and missing batch actions were exercised.
- Final authenticated Codex review: no accepted P0–P2 findings. Review covered the owner, real lazy registration, parser/reparse boundaries, and regression tests.

The repair keeps a single canonical lazy-loading flow rather than eagerly importing all commands or maintaining duplicate help metadata. Scope is CLI help/parsing only; no browser action semantics change. macOS 26.6.2 / Node.js 26.7.0 source-build proof; hosted CI supplies the separate Linux checks.

### Review follow-through

[Exact-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33078031434/attempts/2) passed for `a38d8557b8f22c2dea1b601cb8c02c6c8c913e86`, including the required `openclaw/ci-gate`. The first build job failed only the existing startup-memory check: `plugins list --json` measured a 401.9 MB median against a 401 MB effective ceiling. Exact-base and contemporaneous main measurements showed comparable variation; one targeted retry passed at 400.4 MB with the same source, environment, and limit. No threshold was raised or check disabled.

The reviewer's Commander dependency gap was checked directly against the installed, pinned Commander 15.0.0 source: `lib/command.js:1562–1648` invokes `_outputHelpIfRequested` before mandatory-option validation and action dispatch; `lib/command.js:2700–2708` renders help and exits successfully. This supports retaining the existing lazy-loader/reparse flow as the owner of the fix.

The reviewer's CLI probe stopped before command execution because its checkout lacked `dist/entry.(m)js`; it did not exercise the changed parser. The successful candidate `cliStartup` build and source-blind built-CLI runs above cover that environment gap. The local build preceded the commit, and both changed source-file hashes were verified byte-identical to the committed PR. Captured command-specific output excerpt (exit 0; empty stderr):

```text
$ node openclaw.mjs browser batch --help
Usage: openclaw browser batch [options]

Run a batch of browser actions in one call (default: stop on first error)

Options:
  --actions <json>       JSON array of act requests
  --actions-file <path>  Read JSON array from a file (- for stdin)
  --continue             Continue through all actions instead of stopping on
                         first error
  -h, --help             Display help for command
  --target-id <id>       Tab reference: suggested target id, tab id, label, raw
                         target id, or unique raw prefix
```

This addresses the review's dependency/CI items and its rank-up request to retain built-CLI output. No source change or replacement review was needed.

