### PR TITLE
fix(feishu): mark server-transcribed audio so core skips duplicate ASR

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2195,6 +2195,37 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
   });
 
+  it("marks server-transcribed audio at the reply boundary without local transcription", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockDownloadMessageResourceFeishu.mockResolvedValueOnce({
+      saved: { path: "/tmp/server-voice.ogg", contentType: "audio/ogg" },
+    });
+
+    await dispatchMessage({
+      cfg: createFeishuTestConfig({ dmPolicy: "open" }),
+      event: createFeishuTestEvent({
+        messageId: "msg-audio-server-transcript",
+        senderOpenId: "ou-voice",
+        messageType: "audio",
+        content: JSON.stringify({
+          file_key: "file_audio_payload",
+          duration: 1200,
+          speech_to_text: " supplied transcript ",
+        }),
+      }),
+    });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockTranscribeFirstAudio).not.toHaveBeenCalled();
+    const { ctx } = mockCallArg<{
+      ctx: { RawBody: string; media: Array<{ kind: string; transcribed: boolean }> };
+    }>(mockDispatchReplyFromConfig, 0, 0);
+    expect(ctx.RawBody).toBe("supplied transcript");
+    expect(ctx.media).toEqual([
+      expect.objectContaining({ path: "/tmp/server-voice.ogg", kind: "audio", transcribed: true }),
+    ]);
+  });
+
   it("transcribes inbound audio before building the agent turn", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockDownloadMessageResourceFeishu.mockResolvedValueOnce({

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -126,7 +126,7 @@ function isFeishuTopicSessionScope(
   return scope === "group_topic" || scope === "group_topic_sender";
 }
 
-async function resolveFeishuAudioPreflightTranscript(params: {
+async function resolveFeishuAudioTranscript(params: {
   cfg: ClawdbotConfig;
   mediaList: FeishuMediaInfo[];
   content: string;
@@ -134,7 +134,7 @@ async function resolveFeishuAudioPreflightTranscript(params: {
   chatType: "direct" | "group";
   log: (msg: string) => void;
 }): Promise<string | undefined> {
-  if (params.messageType !== "audio" || params.content.trim()) {
+  if (params.messageType !== "audio") {
     return undefined;
   }
   const audioMedia = params.mediaList.filter(
@@ -143,6 +143,11 @@ async function resolveFeishuAudioPreflightTranscript(params: {
   );
   if (audioMedia.length === 0) {
     return undefined;
+  }
+  // Audio content is the server transcript. Return it for the shared marker path,
+  // but only after the media check so failed downloads retain their notice.
+  if (params.content.trim()) {
+    return params.content;
   }
 
   try {
@@ -1042,7 +1047,7 @@ export async function handleFeishuMessage(params: {
       return;
     }
 
-    const audioTranscript = await resolveFeishuAudioPreflightTranscript({
+    const audioTranscript = await resolveFeishuAudioTranscript({
       cfg: effectiveCfg,
       mediaList,
       content: ctx.content,
@@ -1050,14 +1055,14 @@ export async function handleFeishuMessage(params: {
       chatType: isGroup ? "group" : "direct",
       log,
     });
-    const preflightAudioIndex =
+    const transcribedAudioIndex =
       audioTranscript === undefined
         ? -1
         : mediaList.findIndex(
             (media) => media.kind === "audio" || media.contentType?.startsWith("audio/"),
           );
     const inboundMedia = await toInboundMediaFactsWithMetadata(mediaList, {
-      transcribed: (_media, index) => index === preflightAudioIndex,
+      transcribed: (_media, index) => index === transcribedAudioIndex,
     });
     const requiredMentionTargets =
       isGroup && ctx.senderType === "bot" && ctx.senderOpenId


### PR DESCRIPTION
## What Problem This Solves

Feishu accepts server-supplied speech-to-text for audio messages (`extensions/feishu/src/bot-content.ts:186-192`, pinned by `bot.helpers.test.ts`, promised in `docs/channels/feishu.md:715-723`: server transcripts avoid another ASR call). But the attachment's `transcribed` marker was only ever set from a **local preflight** result — and local preflight is skipped exactly when server text is present. So a server-transcribed audio attachment reached core media understanding unmarked, and with audio understanding enabled, core ran a **second ASR on the same audio** (duplicating provider cost/latency and appending a second, possibly different transcript) — the exact thing the docs promise does not happen.

Verified by a synthetic boundary probe before fixing: an audio event with `speech_to_text` produced one dispatch, zero local preflight calls, the transcript in the body, and `media[0].transcribed === false`; a core probe confirmed unmarked audio triggers exactly one ASR invocation and marked audio zero.

Scope note: current upstream Feishu docs list only `file_key`/`duration` for received audio, so whether Feishu populates this field today is unverified — but the consumer, its test, and the docs promise have shipped since `29741f696a7` (present in stable v2026.4.25), making this OpenClaw's own accepted-input contract. The repair is dormant-safe: if the field never arrives, nothing changes.

## Why This Change Was Made

Record the fact where it happens: the transcript helper (`bot.ts:129-166`, renamed `resolveFeishuAudioTranscript`) now returns either the accepted server transcript or the local preflight result, and the caller marks the audio attachment through the **same existing marker path** for both sources — no parallel policy, no core body-text skip rule, no new config. The server-text return sits after the downloaded-audio check so failed downloads still return `undefined`, preserving the transcript text plus the `[feishu attachment unavailable]` notice.

## User Impact

Feishu operators with audio understanding enabled no longer risk a duplicate ASR call (cost, latency, conflicting second transcript) for audio the server already transcribed. Local preflight behavior and download-failure notices are unchanged.

## Evidence

- Failing-first regression `marks server-transcribed audio at the reply boundary without local transcription` (`bot.test.ts`): pre-fix 1 failed (`transcribed: false` at the reply boundary, zero preflight calls, body intact); post-fix passes alongside the existing local-preflight and download-failure cases.
- Full scope: 97 Feishu files / 1,871 tests + `src/media-understanding/apply.test.ts` (77 tests) — all pass; re-run green on rebased head. Core's marked-audio-no-ASR and captioned-audio-transcription tests untouched and green.
- `check-changed` static gate (extension typechecks, lint, doctor-contract tests, plugin boundaries, dead-export scans, import cycles): pass, exit 0.
- Codex autoreview of the final diff: `findings: []`, verdict "patch is correct".
- Production LOC +10/−5 (one guarded return branch + ordering comment, two renames); tests +31.
- `docs/channels/feishu.md` checked and left unchanged — its conditional promise now accurately describes shipped behavior.
