### PR TITLE
fix(doctor): surface unreadable legacy plugin state instead of silently skipping migration

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -106,6 +106,11 @@ artifact. Plan-based migrations can use
 `openclaw/plugin-sdk/runtime-doctor-migrations` to preserve existing move, copy, preview,
 and plugin-state import behavior.
 
+For single-file imports, `defineLegacyJsonStateMigration(...)` skips missing
+sources (`ENOENT`) and values the plugin parser rejects with `null`. Other read
+errors and invalid JSON reach Doctor's detection or migration warnings; the
+source remains untouched so the operator can fix it and retry.
+
 Use `phase: "after-session-repair"` when a migration needs canonical session
 ownership evidence. Ordinary Doctor detects these migrations; `--fix` applies
 them after session repair under SQLite maintenance ownership. The context

--- a/src/infra/state-migrations.legacy-json.test.ts
+++ b/src/infra/state-migrations.legacy-json.test.ts
@@ -1,0 +1,134 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { defineLegacyJsonStateMigration } from "../plugin-sdk/runtime-doctor-migrations.js";
+import type { PluginDoctorStateMigration } from "../plugins/doctor-contract-module.js";
+import { EMPTY_LEGACY_SESSION_SURFACES } from "../plugins/legacy-session-surfaces.types.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import {
+  autoMigrateLegacyPluginDoctorState,
+  detectLegacyStateMigrations,
+  resetAutoMigrateLegacyStateDirForTest,
+} from "./state-migrations.js";
+
+const registry = vi.hoisted(() => ({
+  entries: [] as Array<{ pluginId: string; migration: PluginDoctorStateMigration }>,
+}));
+
+vi.mock("../plugins/doctor-contract-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/doctor-contract-registry.js")>();
+  return {
+    ...actual,
+    listPluginDoctorStateMigrationEntries: () => registry.entries,
+  };
+});
+
+describe("legacy JSON plugin migration diagnostics", () => {
+  let state: OpenClawTestState;
+  let sourcePath: string;
+
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "legacy-json-doctor" });
+    sourcePath = state.statePath("legacy.json");
+    registry.entries = [
+      {
+        pluginId: "fixture",
+        migration: defineLegacyJsonStateMigration({
+          id: "fixture-json",
+          label: "Fixture legacy state",
+          resolvePath: (stateDir) => path.join(stateDir, "legacy.json"),
+          parse: (value) => (Array.isArray(value) ? value : null),
+          namespace: "legacy",
+          maxEntries: 10,
+          describeEntries: () => ({
+            preview: ["Fixture legacy state"],
+            change: () => "Imported fixture legacy state",
+          }),
+          toRows: (values) => values.map((value, index) => ({ key: String(index), value })),
+        }),
+      },
+    ];
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    registry.entries = [];
+    resetAutoMigrateLegacyStateDirForTest();
+    await state.cleanup();
+  });
+
+  describe.each(["detection", "migration"] as const)("%s", (phase) => {
+    it.each([
+      { fault: "EACCES", expectedError: "EACCES" },
+      { fault: "EIO", expectedError: "EIO" },
+      { fault: "invalid JSON", expectedError: "SyntaxError" },
+      { fault: "ENOENT", expectedError: null },
+      { fault: "unrecognized shape", expectedError: null },
+    ])(
+      "reports $fault without importing or archiving the source",
+      async ({ fault, expectedError }) => {
+        const source = fault === "invalid JSON" ? "{" : "{}";
+        if (fault !== "ENOENT") {
+          await fs.writeFile(sourcePath, source, "utf8");
+        }
+        const readFile = fs.readFile.bind(fs);
+        let sourceReads = 0;
+        vi.spyOn(fs, "readFile").mockImplementation(async (filePath, options) => {
+          if (filePath === sourcePath) {
+            sourceReads++;
+            // Let detection succeed, then fail the direct migration read.
+            if (phase === "migration" && sourceReads === 1) {
+              return '[{"disabled":true}]';
+            }
+            if (fault === "EACCES" || fault === "EIO") {
+              throw Object.assign(new Error(`${fault}: read ${sourcePath}`), { code: fault });
+            }
+          }
+          return readFile(filePath, options);
+        });
+
+        let warnings: string[];
+        if (phase === "detection") {
+          const detected = await detectLegacyStateMigrations({
+            cfg: {},
+            env: state.env,
+            homedir: () => state.home,
+            pluginSessionStoreAgentIds: [],
+            legacySessionSurfaces: EMPTY_LEGACY_SESSION_SURFACES,
+          });
+          expect(detected.pluginPlans?.hasLegacy).toBe(false);
+          warnings = detected.warnings;
+        } else {
+          const result = await autoMigrateLegacyPluginDoctorState({
+            config: {},
+            env: state.env,
+            homedir: () => state.home,
+          });
+          expect(result.changes).toEqual([]);
+          expect(sourceReads).toBe(2);
+          warnings = result.warnings;
+        }
+
+        expect(warnings).toEqual(
+          expectedError
+            ? [
+                expect.stringContaining(
+                  `Failed ${phase === "detection" ? "detecting" : "migrating"} Fixture legacy state:`,
+                ),
+              ]
+            : [],
+        );
+        if (expectedError) {
+          expect(warnings[0]).toContain(expectedError);
+        }
+        if (fault !== "ENOENT") {
+          await expect(readFile(sourcePath, "utf8")).resolves.toBe(source);
+        }
+        await expect(fs.stat(`${sourcePath}.migrated`)).rejects.toMatchObject({ code: "ENOENT" });
+      },
+    );
+  });
+});

--- a/src/plugin-sdk/runtime-doctor-migrations.ts
+++ b/src/plugin-sdk/runtime-doctor-migrations.ts
@@ -10,6 +10,7 @@ import fs from "node:fs/promises";
 import { asObjectRecord } from "../config/channel-compat-normalization.js";
 import type { CompatMutationResult } from "../config/channel-compat-normalization.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { hasErrnoCode } from "../infra/errno.js";
 import type { OpenKeyedStoreOptions } from "../plugin-state/plugin-state-store.js";
 import type { PluginDoctorStateMigration } from "../plugins/doctor-contract-module.js";
 import { archiveLegacyStateSource } from "../plugins/doctor-state-migration-fs.js";
@@ -324,7 +325,10 @@ export function defineLegacyJsonStateMigration<TSource>(params: {
   const readSource = async (filePath: string): Promise<TSource | null> => {
     try {
       return params.parse(JSON.parse(await fs.readFile(filePath, "utf8")) as unknown);
-    } catch {
+    } catch (error) {
+      if (!hasErrnoCode(error, "ENOENT")) {
+        throw error;
+      }
       return null;
     }
   };


### PR DESCRIPTION
## What Problem This Solves

The shared plugin migration helper `defineLegacyJsonStateMigration` (`src/plugin-sdk/runtime-doctor-migrations.ts:324-355`) converted **every** read, JSON-parse, and plugin-parser exception into `null` — including `EACCES` and transient I/O errors. Detection then reported "no migration", and direct migration returned empty changes/warnings. The caller boundaries that already convert thrown detector failures into visible Doctor warnings (`src/infra/state-migrations.doctor.ts:253-268`, `:951-973`) never saw the error.

Consequence (probed with injected EACCES pre-fix: `{"detected":null,"migrated":{"changes":[],"warnings":[]}}`): an unreadable legacy Active Memory `session-toggles.json` silently vanishes from `doctor --fix` — no warning, no migration — and runtime treats the absent opt-outs as enabled (`extensions/active-memory/session-policy.ts:31-43`). Device Pair notification subscriptions share the helper. This is the silent-failure class: an action ends with neither a visible outcome nor a recorded non-outcome.

The core sibling already does this right: `src/infra/state-migrations.runtime-state.ts:69-75` reports both read and JSON-syntax failures.

## Why This Change Was Made

Minimal owner-level distinction instead of a new warning channel: `ENOENT` (source legitimately absent) still yields `null`/clean skip, and intentional parser `null` still skips migration — every other exception now propagates unchanged to the existing Doctor warning boundaries, which do their established job. Public signature, row selection, imports, archive, and persistence behavior are unchanged. The SDK migration doc gains the absence-vs-error distinction.

## User Impact

`openclaw doctor` now tells the operator when legacy plugin state exists but cannot be read or parsed, instead of silently pretending there is nothing to migrate — protecting Active Memory session opt-outs and Device Pair notification subscriptions from disappearing without a trace.

## Evidence

- Failing-first Doctor-boundary regressions (`src/infra/state-migrations.legacy-json.test.ts`, +134 lines): pre-fix **6 failed / 4 passed** (EACCES, EIO, malformed JSON each silent in detection and direct migration; ENOENT and parser-null controls passed); post-fix **10 passed**. Assertions exercise the real Doctor warning boundaries and verify source preservation with no archive.
- Real-filesystem probe (no mocks): chmod-000 produced EACCES for both helper methods, original source bytes survived, no archive appeared; actual removal yielded clean skips. Disposable temp dir only.
- Requested suites: **580 passed / 3 skipped** across infra migrations, SDK helper, Active Memory and Device Pair migration contracts. Focused re-run green on rebased head ee35c1e6a90.
- `check-changed`: all guards, formatting, SDK surface checks, dead-export scans, four typecheck stages green; one lint finding in the new test itself (`no-base-to-string`) fixed by using direct path equality; targeted lint re-run exit 0; remaining repo guards (import cycles, database-first, pairing, webhook order) all green.
- Codex autoreview (`--mode uncommitted`), both passes: no findings; reviewer confirmed absence/parser-null skips, both warning boundaries, and unchanged persistence/archive/signature behavior.
- Production LOC **+5/−1** (errno distinction + existing-helper import); tests +134; docs +5.
- Named follow-up (out of scope, preserved behavior): `src/plugins/doctor-state-migration-fs.ts:5-12` suppresses stat errors in `legacyStateFileExists` — separate audit scope.
