### PR TITLE
fix(doctor): repair agent workspace and heartbeat values on the canonical roster shape

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2570,7 +2570,7 @@ src/commands/doctor/shared/empty-allowlist-policy.ts	14
 src/commands/doctor/shared/empty-allowlist-scan.ts	17
 src/commands/doctor/shared/include-migration-ownership.ts	2
 src/commands/doctor/shared/legacy-config-compat.ts	1
-src/commands/doctor/shared/legacy-config-core-migrate.ts	7
+src/commands/doctor/shared/legacy-config-core-migrate.ts	1
 src/commands/doctor/shared/legacy-config-core-normalizers.ts	18
 src/commands/doctor/shared/legacy-config-issues.ts	1
 src/commands/doctor/shared/legacy-config-migrate.ts	2

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -244,6 +244,8 @@ That stages grounded durable candidates into the short-term dreaming store while
 
     Doctor also warns when `plugins.allow` is non-empty and tool policy uses wildcard or plugin-owned tool entries. `tools.allow: ["*"]` only matches tools from plugins that actually load; it does not bypass the exclusive plugin allowlist.
 
+    `doctor --fix` removes `workspace: null` from `agents.entries.<id>` so normal workspace resolution can apply. It also removes invalid `heartbeat.activeHours` windows from agent entries and `agents.defaults`, preserving other heartbeat settings. Reconfigure a valid window if needed; without an explicit or inherited window, heartbeat hours are unrestricted. These repairs also apply after migrating a legacy `agents.list` roster.
+
   </Accordion>
   <Accordion title="2. Legacy config key migrations">
     When the config contains a deprecated key with an active migration, other commands refuse to run and ask you to run `openclaw doctor`. Doctor explains which legacy keys were found, shows the migration it applied, and rewrites `~/.openclaw/openclaw.json` with the updated schema. Gateway startup refuses legacy config formats and asks you to run `openclaw doctor --fix`; it does not rewrite `openclaw.json` on startup. Cron job store migrations are also handled by `openclaw doctor --fix`.

--- a/src/commands/doctor-config-flow.workspace-persistence.test.ts
+++ b/src/commands/doctor-config-flow.workspace-persistence.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import { loadAndMaybeMigrateDoctorConfig } from "./doctor-config-flow.js";
 import { createDoctorPrompter, type DoctorOptions } from "./doctor-prompter.js";
+import { normalizeCompatibilityConfigValues } from "./doctor/shared/legacy-config-core-migrate.js";
 
 async function prepareDoctorContext(configPath: string): Promise<DoctorHealthFlowContext> {
   const runtime: RuntimeEnv = { error: vi.fn(), exit: vi.fn(), log: vi.fn() };
@@ -51,6 +52,80 @@ async function prepareDoctorContext(configPath: string): Promise<DoctorHealthFlo
 describe("Doctor workspace persistence", () => {
   afterEach(() => {
     closeOpenClawStateDatabaseForTest();
+  });
+
+  it.each(["entries", "list", "noncanonical list"])(
+    "repairs workspace and heartbeat values from %s through snapshot, doctor, and write",
+    async (shape) => {
+      await withTempHome(async (home) => {
+        await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+          const agent = {
+            workspace: null,
+            heartbeat: { every: "30m", activeHours: { start: "99:99", end: "17:00" } },
+          };
+          const configPath = await writeOpenClawConfig(home, {
+            agents:
+              shape === "entries"
+                ? { entries: { ops: agent } }
+                : { list: [{ id: shape === "list" ? "ops" : " Ops ", ...agent }] },
+            gateway: { mode: "local" },
+            plugins: { enabled: false },
+          });
+          const before = await readConfigFileSnapshot();
+          expect(before.valid).toBe(false);
+          if (shape === "noncanonical list") {
+            expect(before.sourceConfig.agents?.list).toHaveLength(1);
+          } else {
+            expect(before.sourceConfig.agents?.entries?.ops).toEqual(agent);
+            expect(before.sourceConfig.agents).not.toHaveProperty("list");
+          }
+
+          const ctx = await prepareDoctorContext(configPath);
+          expect(ctx.configResult.shouldWriteConfig).toBe(true);
+          expect(ctx.cfg.agents?.entries?.ops).toEqual({ heartbeat: { every: "30m" } });
+          await runInitialConfigWriteHealth(ctx);
+
+          const saved = JSON.parse(await fs.readFile(configPath, "utf-8"));
+          expect(saved.agents.entries.ops).toEqual({ heartbeat: { every: "30m" } });
+          expect(saved.agents).not.toHaveProperty("list");
+          expect((await readConfigFileSnapshot()).valid).toBe(true);
+          expect((await prepareDoctorContext(configPath)).configResult.shouldWriteConfig).toBe(
+            false,
+          );
+        });
+      });
+    },
+  );
+
+  it("repairs a legacy candidate without writing when include ownership blocks migration", async () => {
+    await withTempHome(async (home) => {
+      await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+        const configPath = await writeOpenClawConfig(home, {
+          agents: {
+            list: [
+              { id: " Ops ", workspace: null, heartbeat: { activeHours: { start: "99:99" } } },
+            ],
+          },
+          diagnostics: { otel: { $include: "otel.json" } },
+          gateway: { mode: "local" },
+          plugins: { enabled: false },
+        });
+        const includePath = path.join(path.dirname(configPath), "otel.json");
+        await fs.writeFile(includePath, JSON.stringify({ protocol: "grpc" }));
+        const original = await fs.readFile(configPath, "utf-8");
+        const before = await readConfigFileSnapshot();
+        expect(before.sourceConfig.agents?.list).toHaveLength(1);
+        expect(normalizeCompatibilityConfigValues(before.sourceConfig).config.agents?.list).toEqual(
+          [{ id: " Ops ", heartbeat: {} }],
+        );
+
+        const ctx = await prepareDoctorContext(configPath);
+        expect(ctx.configResult.shouldWriteConfig).toBe(false);
+        await runInitialConfigWriteHealth(ctx);
+        expect(await fs.readFile(configPath, "utf-8")).toBe(original);
+        expect(JSON.parse(await fs.readFile(includePath, "utf-8"))).toEqual({ protocol: "grpc" });
+      });
+    });
   });
 
   it("keeps the legacy owner on the shared workspace across later health writes", async () => {

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -238,33 +238,33 @@ describe("normalizeCompatibilityConfigValues", () => {
     );
   });
 
-  it("removes null workspace values from agents.list entries", () => {
+  it("removes null workspace values from agents.entries", () => {
     const res = normalizeCompatibilityConfigValues({
       agents: {
-        list: [
-          { id: "main", workspace: null as unknown as string },
-          { id: "beta", workspace: "/beta" },
-          { id: "gamma" },
-        ],
+        entries: {
+          main: { workspace: null as unknown as string },
+          beta: { workspace: "/beta" },
+          gamma: {},
+        },
       },
     });
 
-    expect(res.config.agents?.list).toEqual([
-      { id: "main" },
-      { id: "beta", workspace: "/beta" },
-      { id: "gamma" },
-    ]);
-    expect(res.changes).toContain("Removed null workspace value from agents.list entry.");
+    expect(res.config.agents?.entries).toEqual({
+      main: {},
+      beta: { workspace: "/beta" },
+      gamma: {},
+    });
+    expect(res.changes).toContain("Removed null workspace value from agents.entries entry.");
   });
 
-  it("does not alter agents.list when no workspace is null", () => {
+  it("does not alter agents.entries when no workspace is null", () => {
     const res = normalizeCompatibilityConfigValues({
       agents: {
-        list: [{ id: "main", workspace: "/main" }, { id: "beta" }],
+        entries: { main: { workspace: "/main" }, beta: {} },
       },
     });
 
-    expect(res.config.agents?.list).toEqual([{ id: "main", workspace: "/main" }, { id: "beta" }]);
+    expect(res.config.agents?.entries).toEqual({ main: { workspace: "/main" }, beta: {} });
     expect(res.changes.some((change) => change.includes("workspace"))).toBe(false);
   });
 
@@ -278,26 +278,25 @@ describe("normalizeCompatibilityConfigValues", () => {
               activeHours: { start: "99:99", end: "17:00" },
             },
           },
-          list: [
-            {
-              id: "ops",
+          entries: {
+            ops: {
               heartbeat: {
                 prompt: "Check alerts",
                 activeHours: { start: "09:00", end: "not-a-time" },
               },
             },
-          ],
+          },
         },
       }),
     );
 
     expect(res.config.agents?.defaults?.heartbeat).toEqual({ every: "30m" });
-    expect(res.config.agents?.list?.[0]?.heartbeat).toEqual({ prompt: "Check alerts" });
+    expect(res.config.agents?.entries?.ops?.heartbeat).toEqual({ prompt: "Check alerts" });
     expect(res.changes).toContain(
       "Removed invalid agents.defaults.heartbeat.activeHours; heartbeats will use unrestricted hours until it is reconfigured.",
     );
     expect(res.changes).toContain(
-      "Removed invalid agents.list[0].heartbeat.activeHours; heartbeats will use unrestricted hours until it is reconfigured.",
+      "Removed invalid agents.entries.ops.heartbeat.activeHours; heartbeats will use unrestricted hours until it is reconfigured.",
     );
     expect(validateConfigObject(res.config).ok).toBe(true);
   });
@@ -309,6 +308,9 @@ describe("normalizeCompatibilityConfigValues", () => {
           heartbeat: {
             activeHours: { start: "09:00", end: "24:00", timezone: "user" },
           },
+        },
+        entries: {
+          ops: { heartbeat: { activeHours: { start: "22:00", end: "06:00" } } },
         },
       },
     });

--- a/src/commands/doctor/shared/legacy-config-core-migrate.ts
+++ b/src/commands/doctor/shared/legacy-config-core-migrate.ts
@@ -1,5 +1,7 @@
-import { migrateLegacyContextBudgetConfig } from "../../../config/legacy.context-budget.js";
 // Core doctor compatibility migration pipeline for current config objects.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { readAgentRosterProperty } from "../../../agents/agent-scope-config.js";
+import { migrateLegacyContextBudgetConfig } from "../../../config/legacy.context-budget.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { HeartbeatSchema } from "../../../config/zod-schema.agent-runtime.js";
 import { runPluginSetupConfigMigrations } from "../../../plugins/setup-registry.js";
@@ -12,88 +14,85 @@ import { normalizeLegacyOpenAICodexModelsAddMetadata } from "./legacy-config-cor
 import { stripRetiredTuningKnobs } from "./legacy-config-migrations.runtime.retired-media.js";
 import { migrateReservedMcpServerNames } from "./reserved-mcp-server-name-migrate.js";
 
+function repairAgentRoster(
+  cfg: OpenClawConfig,
+  repair: (agent: Record<string, unknown>, path: string) => Record<string, unknown>,
+): OpenClawConfig {
+  // Snapshot/legacy migration normally converts lists first; blocked include migrations
+  // can still leave a legacy list in doctor's best-effort candidate.
+  const roster = readAgentRosterProperty(cfg);
+  const values = roster?.value;
+  if (!roster || (!isRecord(values) && !Array.isArray(values))) {
+    return cfg;
+  }
+  if (Array.isArray(values) !== (roster.kind === "list")) {
+    return cfg;
+  }
+  let changed = false;
+  const entries = Object.entries(values).map(([key, agent]) => {
+    const path = roster.kind === "entries" ? `agents.entries.${key}` : `agents.list[${key}]`;
+    const next = isRecord(agent) ? repair(agent, path) : agent;
+    changed ||= next !== agent;
+    return [key, next] as const;
+  });
+  return changed
+    ? {
+        ...cfg,
+        agents: {
+          ...cfg.agents,
+          [roster.kind]:
+            roster.kind === "entries"
+              ? Object.fromEntries(entries)
+              : entries.map(([, agent]) => agent),
+        },
+      }
+    : cfg;
+}
+
 function repairInvalidHeartbeatActiveHours(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
-  const repairHeartbeat = (
-    heartbeat: unknown,
-    path: string,
-  ): { value: unknown; changed: boolean } => {
-    if (!heartbeat || typeof heartbeat !== "object" || Array.isArray(heartbeat)) {
-      return { value: heartbeat, changed: false };
+  const repairHeartbeat = (heartbeat: unknown, path: string): unknown => {
+    if (!isRecord(heartbeat) || !Object.hasOwn(heartbeat, "activeHours")) {
+      return heartbeat;
     }
-    const record = heartbeat as Record<string, unknown>;
-    if (!Object.hasOwn(record, "activeHours")) {
-      return { value: heartbeat, changed: false };
-    }
-    const result = HeartbeatSchema.safeParse({ activeHours: record.activeHours });
+    const result = HeartbeatSchema.safeParse({ activeHours: heartbeat.activeHours });
     if (result.success) {
-      return { value: heartbeat, changed: false };
+      return heartbeat;
     }
 
-    const { activeHours: _activeHours, ...rest } = record;
+    const { activeHours: _activeHours, ...rest } = heartbeat;
     changes.push(
       `Removed invalid ${path}.activeHours; heartbeats will use unrestricted hours until it is reconfigured.`,
     );
-    return { value: rest, changed: true };
+    return rest;
   };
 
   const defaultsHeartbeat = repairHeartbeat(
     cfg.agents?.defaults?.heartbeat,
     "agents.defaults.heartbeat",
   );
-  const agents = cfg.agents?.list;
-  let listChanged = false;
-  const nextAgents = Array.isArray(agents)
-    ? agents.map((agent, index) => {
-        if (!agent || typeof agent !== "object") {
-          return agent;
-        }
-        const repaired = repairHeartbeat(
-          (agent as Record<string, unknown>).heartbeat,
-          `agents.list[${index}].heartbeat`,
-        );
-        if (!repaired.changed) {
-          return agent;
-        }
-        listChanged = true;
-        return { ...agent, heartbeat: repaired.value };
-      })
-    : agents;
+  const next = repairAgentRoster(cfg, (agent, path) => {
+    const heartbeat = repairHeartbeat(agent.heartbeat, `${path}.heartbeat`);
+    return heartbeat === agent.heartbeat ? agent : { ...agent, heartbeat };
+  });
 
-  if (!defaultsHeartbeat.changed && !listChanged) {
-    return cfg;
+  if (defaultsHeartbeat === cfg.agents?.defaults?.heartbeat) {
+    return next;
   }
   return {
-    ...cfg,
+    ...next,
     agents: {
-      ...cfg.agents,
-      ...(defaultsHeartbeat.changed
-        ? {
-            defaults: {
-              ...cfg.agents?.defaults,
-              heartbeat: defaultsHeartbeat.value,
-            },
-          }
-        : {}),
-      ...(listChanged ? { list: nextAgents as typeof agents } : {}),
+      ...next.agents,
+      defaults: { ...next.agents?.defaults, heartbeat: defaultsHeartbeat },
     },
   } as OpenClawConfig;
 }
 
 function repairNullAgentWorkspaces(cfg: OpenClawConfig, changes: string[]): OpenClawConfig {
-  const agents = cfg.agents?.list;
-  if (!Array.isArray(agents)) {
-    return cfg;
-  }
-
   let repaired = 0;
-  const nextAgents = agents.map((agent) => {
-    if (
-      agent &&
-      typeof agent === "object" &&
-      (agent as Record<string, unknown>).workspace === null
-    ) {
+  const next = repairAgentRoster(cfg, (agent) => {
+    if (agent.workspace === null) {
       repaired += 1;
-      const { workspace: _workspace, ...rest } = agent as Record<string, unknown>;
+      const { workspace: _workspace, ...rest } = agent;
       return rest;
     }
     return agent;
@@ -104,17 +103,11 @@ function repairNullAgentWorkspaces(cfg: OpenClawConfig, changes: string[]): Open
   }
 
   changes.push(
-    `Removed null workspace value${repaired === 1 ? "" : "s"} from agents.list entr${
+    `Removed null workspace value${repaired === 1 ? "" : "s"} from agents.${readAgentRosterProperty(cfg)?.kind} entr${
       repaired === 1 ? "y" : "ies"
     }.`,
   );
-  return {
-    ...cfg,
-    agents: {
-      ...cfg.agents,
-      list: nextAgents as typeof agents,
-    },
-  };
+  return next;
 }
 
 /** Normalize current config through core, plugin setup, channel, and secret-ref migrations. */


### PR DESCRIPTION
## What Problem This Solves

Doctor's per-agent repairs — `repairNullAgentWorkspaces` and `repairInvalidHeartbeatActiveHours` (`src/commands/doctor/shared/legacy-config-core-migrate.ts`) — traversed only the retired `agents.list` roster shape. Snapshot loading converts legacy lists to canonical `agents.entries` **before** doctor's compatibility normalization runs (`src/config/io.snapshot.ts:187`), and the legacy migration deletes `agents.list` after building entries. So on every current config, both repairs were dead code: `workspace: null` and schema-invalid `heartbeat.activeHours` (e.g. `"99:99"`) survive `doctor --fix`, schema validation then rejects them (`src/config/zod-schema.agent-runtime.ts`), and unknown-key cleanup cannot compensate (it handles only unrecognized keys). Doctor fails to converge on repairs it already supports.

This is an incomplete prior migration: the workspace repair shipped reading `agents.list` (commit `2b752ac0d1f`, ancestor of stable v2026.7.1); the entries conversion (`edecdbd05ef`, 2026-07-21) never updated it, and the heartbeat repair (`77ec4c5420d`, 2026-07-30) was added on the stale shape.

## Why This Change Was Made

Reachability was verified, not assumed: `agents.list` is normally converted before these repairs, but is **not** strictly unreachable — a whitespace-padded legacy ID refuses read-time migration, and manual include-ownership of `diagnostics.otel.protocol` blocks the legacy migration step while doctor still runs the compatibility normalizer. So the fix keeps one shared immutable roster-traversal helper covering both shapes with canonical entries taking precedence, reusing `readAgentRosterProperty` and the canonical record guard — deleting the duplicated traversal/rebuild logic and redundant casts (net **−7** production lines). Repair semantics are unchanged: remove only null per-agent workspaces and schema-invalid active-hours windows; the separate `agents.defaults.heartbeat` repair still runs once.

## User Impact

`openclaw doctor --fix` now actually repairs null workspaces and invalid heartbeat windows on current configs instead of silently leaving them for schema validation to reject. The doctor guide documents canonical roster repairs and heartbeat window inheritance.

## Evidence

- Failing-first: canonical-shape null-workspace and invalid-activeHours regressions plus three real snapshot→doctor→write flow cases — pre-fix **5 failed / 82 passed**; post-fix focused runs **88 passed** (including a blocked-legacy boundary case asserting the normalizer repair and the no-write boundary), re-run green on rebased head 377a30d6f35.
- Doctor-wide scoped run (187 test files): 2,873 passed; the **4 failures in 2 untouched files were reproduced byte-for-byte with the modified module restored to base** (zai capability-consent readiness state and a child-process empty-stdout under the symlinked-node_modules worktree) — pre-existing, recorded as follow-ups, unchanged by this patch.
- `check-changed`: exit 0 — formatting, assertion/line ratchets (baseline entry shrunk 7→1, shrink-only maintenance), core + core-test typechecks, lint, dead-export scans, import cycles, guards.
- Codex autoreview of the final diff: no findings, verdict "patch is correct".
- LOC: production +59/−66 (**−7**); tests +77; docs +2.
