### PR TITLE
docs(gateway): define external supervisor acceptance rules

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -186,6 +186,12 @@ Protocol version `1` supports the `consume` operation. Consumption validates the
 
 Valid machine requests return JSON with exit code `0`, including non-restart results. Invalid arguments return `reason: "invalid-expected-pid"` with exit code `2`; state-store failures return `reason: "store-unavailable"` with exit code `1`. Supervisors should probe `capabilities` on the exact runtime or launcher they will use rather than infer support from an OpenClaw version string or read the private SQLite schema directly.
 
+External supervisor implementations should also apply these acceptance rules:
+
+- Bound capability probes with a timeout that accounts for full CLI cold-start latency on the deployed runtime and storage, rather than assuming warm-start timing.
+- If capability negotiation or handoff consumption refuses replacement, exit promptly with a nonzero status so the process manager's recovery policy can run. Do not remain alive without a Gateway child or listener.
+- Treat supervisor process liveness as distinct from replacement readiness. Report success only after the new Gateway owns its listener and reaches `/readyz`; `/healthz` proves liveness only.
+
 ### Gateway profiling
 
 - `OPENCLAW_GATEWAY_STARTUP_TRACE=1` logs phase timings during startup, including per-phase `eventLoopMax` delay and plugin lookup-table timings (installed-index, manifest registry, startup planning, owner-map work).

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -190,7 +190,7 @@ External supervisor implementations should also apply these acceptance rules:
 
 - Bound capability probes with a timeout that accounts for full CLI cold-start latency on the deployed runtime and storage, rather than assuming warm-start timing.
 - If capability negotiation or handoff consumption refuses replacement, exit promptly with a nonzero status so the process manager's recovery policy can run. Do not remain alive without a Gateway child or listener.
-- Treat supervisor process liveness as distinct from replacement readiness. Report success only after the new Gateway owns its listener and reaches `/readyz`; `/healthz` proves liveness only.
+- Treat supervisor process liveness as distinct from replacement startup and channel readiness. Report success only after the new Gateway owns its listener and `/startupz` returns `status: "started"`; monitor `/readyz` separately for configured-channel health, while `/healthz` proves liveness only.
 
 ### Gateway profiling
 


### PR DESCRIPTION
## What Problem This Solves

The external-supervisor reference documents the restart-handoff protocol but omits the acceptance criteria for its consumer. A supervisor can reject a valid slow cold-start probe, remain alive after refusing a replacement, or mistake process liveness or channel readiness for a successfully started replacement Gateway.

Fixes #130888.

## Why This Change Was Made

Add the acceptance rules beside the existing machine protocol: allow a bounded cold-start-tolerant capability probe, make the supervisor exit nonzero when it refuses a replacement, and accept the replacement only when its process owns the configured listener and `/startupz` reports `status: started`. Keep `/readyz` for ongoing channel health and `/healthz` for liveness.

The supervisor's refusal exit is its own contract. Valid `restart-handoff consume` JSON results still include non-restart outcomes with exit 0; this patch does not change the upstream CLI protocol or prescribe a new timeout value.

## User Impact

External supervisors can distinguish a started replacement Gateway from an idle wrapper or an unrelated health signal. Documentation +6/-0; production and tests +0/-0. Runtime, configuration, and stored handoff data are unchanged.

## Evidence

Reviewed the command registration and consume contract, handoff owner, startup checker, HTTP probe projection and routing, plus the related registration and HTTP lifecycle tests. The existing lifecycle case shows `/startupz` returning `started` while an unhealthy configured channel keeps `/readyz` at 503. Stable `v2026.8.1` has the same startup and machine-command contracts.

The linked issue's 13-second cold capability probe and idle-wrapper observation are reporter evidence from an external supervisor, not a new upstream timing test. No external supervisor implementation changes here.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33081279906) passed for `3d889121bcc39a43e13f9273ce8221348f9cd654`, including the documentation check. Trusted main tooling parsed the actual candidate page as MDX and passed its explicit-config formatter check; the complete PR diff passed `git diff --check`. Independent Codex review of the complete candidate found no P0 defects. No links, headings, or executable examples changed, and no fork scripts or configuration were executed.

Thanks @1052326311.
