### PR TITLE
fix(ci): route trusted dispatch lint to matrix runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2590,7 +2590,7 @@ jobs:
     name: ${{ matrix.check_name }}
     needs: [preflight]
     if: ${{ !cancelled() && always() && needs.preflight.outputs.run_check == 'true' }}
-    runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'ubuntu-24.04' || (vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && (github.run_attempt > 1 || (matrix.task != 'lint' && matrix.task != 'test-types' && matrix.task != 'dependencies'))) && 'ubuntu-24.04' || github.event_name == 'workflow_dispatch' && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
+    runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'ubuntu-24.04' || (vars.OPENCLAW_CI_RUNNER_BACKEND == 'hybrid' && (github.event_name == 'workflow_dispatch' || github.run_attempt > 1 || (matrix.task != 'lint' && matrix.task != 'test-types' && matrix.task != 'dependencies'))) && 'ubuntu-24.04' || (github.event_name == 'workflow_dispatch' && inputs.release_gate) && 'ubuntu-24.04' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && (matrix.runner || 'blacksmith-4vcpu-ubuntu-2404') || 'ubuntu-24.04') }}
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -107,6 +107,7 @@ function evaluateWorkflowExpression(
     headRepository?: string;
     hostedRunnerProfileContract?: boolean;
     matrix?: Record<string, unknown>;
+    releaseGate?: boolean;
     repository: string;
     runCheck?: boolean;
     runnerBackend?: "" | "blacksmith" | "github" | "hybrid";
@@ -145,6 +146,9 @@ function evaluateWorkflowExpression(
               },
             }
           : {},
+    },
+    inputs: {
+      release_gate: context.releaseGate ?? false,
     },
     matrix: context.matrix ?? {},
     needs: {
@@ -3627,6 +3631,42 @@ NODE
         },
       ),
     ).toBe(96);
+  });
+
+  it("honors trusted dispatch runner selection for check shards", () => {
+    const runsOn = readCiWorkflow().jobs["check-shard"]["runs-on"];
+    const lintMatrix = {
+      runner: "blacksmith-32vcpu-ubuntu-2404",
+      task: "lint",
+    };
+    const evaluateDispatch = (
+      runnerBackend: "blacksmith" | "github" | "hybrid",
+      releaseGate = false,
+    ) =>
+      evaluateWorkflowExpression(runsOn, {
+        eventName: "workflow_dispatch",
+        matrix: lintMatrix,
+        releaseGate,
+        repository: "openclaw/openclaw",
+        runAttempt: 1,
+        runnerBackend,
+      });
+
+    expect(evaluateDispatch("blacksmith")).toBe("blacksmith-32vcpu-ubuntu-2404");
+    expect(evaluateDispatch("blacksmith", true)).toBe("ubuntu-24.04");
+    expect(evaluateDispatch("github")).toBe("ubuntu-24.04");
+    expect(evaluateDispatch("hybrid")).toBe("ubuntu-24.04");
+    expect(
+      evaluateWorkflowExpression(runsOn, {
+        authorAssociation: "NONE",
+        eventName: "pull_request",
+        headRepository: "openclaw/openclaw",
+        matrix: lintMatrix,
+        repository: "openclaw/openclaw",
+        runAttempt: 1,
+        runnerBackend: "blacksmith",
+      }),
+    ).toBe("ubuntu-24.04");
   });
 
   it("encodes GitHub, Blacksmith, and hybrid runner-backend shapes", () => {


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-validation problem where ordinary trusted CI dispatches configured for Blacksmith still forced `check-shard` onto GitHub-hosted runners. The 2026.9.1 beta validation lint job was externally shut down twice with exit 143 and no lint diagnostic.

## Why This Change Was Made

Ordinary canonical `workflow_dispatch` runs now honor the configured matrix runner for `check-shard`. GitHub and hybrid profiles remain hosted, untrusted pull requests remain hosted, and the exact-head `release_gate` fallback remains explicitly hosted.

## User Impact

No product runtime behavior changes. Maintainers can validate frozen release candidates using the repository's configured Blacksmith lint runner without weakening contributor trust routing or release-gate isolation.

## Evidence

- Before fix: the focused runner evaluator received `ubuntu-24.04` for a canonical Blacksmith lint dispatch instead of `blacksmith-32vcpu-ubuntu-2404`.
- After fix: ordinary Blacksmith dispatch selects `blacksmith-32vcpu-ubuntu-2404`; Blacksmith `release_gate`, GitHub, hybrid, and untrusted pull request cases select `ubuntu-24.04`.
- `pnpm exec vitest run test/scripts/ci-workflow-guards.test.ts`: 137 passed, 2 skipped.
- `actionlint .github/workflows/ci.yml`: passed.
- `python3 scripts/check-composite-action-input-interpolation.py`: passed.
- `node scripts/check-no-conflict-markers.mjs`: passed.
- `pnpm exec oxfmt --check test/scripts/ci-workflow-guards.test.ts .github/workflows/ci.yml`: passed.
- `git diff --check`: passed.
- Autoreview: clean, no accepted/actionable findings.
- Full `pnpm check:workflows` could not install pinned `pre-commit==4.6.2` from the host's configured Python index; the directly invoked actionlint and repository workflow guard surfaces above passed.
- Failure evidence: CI run 33075615602 attempts 1 and 2 used GitHub Actions runners for `check-lint`; both ended during `Run check shard` after runner shutdown, with no lint finding.
- Dependency audit: inspected `openai/codex` at `a6e63f9f32525d171676ac49c4e87ab00d76f0ce`, including `codex-cli/bin/codex.js:16-107` and `codex-cli/bin/codex.js:195-248`; this CI-only change does not alter Codex package selection or process exit semantics.
