### PR TITLE
fix(gateway): approval card never appears for Codex node execution started from a single Control UI window

### DIFF
--- a/src/gateway/node-invoke-plugin-policy.test-helpers.ts
+++ b/src/gateway/node-invoke-plugin-policy.test-helpers.ts
@@ -1,0 +1,219 @@
+/** Shared harness for node invoke plugin-policy tests. */
+import { expect, vi } from "vitest";
+import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { PluginRegistry } from "../plugins/registry-types.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import type { OpenClawPluginNodeInvokePolicyContext } from "../plugins/types.js";
+import type { ExecApprovalManager } from "./exec-approval-manager.js";
+import { applyPluginNodeInvokePolicy } from "./node-invoke-plugin-policy.js";
+import type { NodeInvokeResult, NodeSession } from "./node-registry.js";
+import type { GatewayClient, GatewayRequestContext } from "./server-methods/types.js";
+
+export const DEMO_PLUGIN_ID = "demo";
+export const DEMO_COMMAND = "demo.read";
+export const DEMO_PARAMS = { path: "/tmp/x" };
+
+export function createNodeSession(): NodeSession {
+  return {
+    nodeId: "node-1",
+    connId: "conn-1",
+    client: {} as NodeSession["client"],
+    declaredCaps: [],
+    caps: [],
+    declaredCommands: ["demo.read"],
+    commands: ["demo.read"],
+    declaredNodePluginTools: [],
+    nodePluginTools: [],
+    nodeSkills: [],
+    connectedAtMs: 0,
+  };
+}
+
+export function nodeCommandsConfig(commands: { allow?: string[]; deny?: string[] }) {
+  return { gateway: { nodes: { commands } } };
+}
+
+export function createContext(opts?: {
+  pluginApprovalManager?: ExecApprovalManager<PluginApprovalRequestPayload>;
+  getApprovalClientConnIds?: GatewayRequestContext["getApprovalClientConnIds"];
+  getRuntimeConfig?: GatewayRequestContext["getRuntimeConfig"];
+  nodeSession?: NodeSession;
+  hasExecApprovalClients?: GatewayRequestContext["hasExecApprovalClients"];
+  forwardPluginApprovalRequest?: GatewayRequestContext["forwardPluginApprovalRequest"];
+  pluginApprovalIosPushDelivery?: GatewayRequestContext["pluginApprovalIosPushDelivery"];
+  validateAgentRuntimeApprovalAuthority?: GatewayRequestContext["validateAgentRuntimeApprovalAuthority"];
+}) {
+  const nodeSession = opts?.nodeSession ?? createNodeSession();
+  const invoke = vi.fn(
+    async (params?: {
+      onDispatchReady?: (invokeId: string) => void;
+      onProgress?: (chunk: string) => void;
+      isDispatchAuthorized?: () => boolean;
+    }): Promise<NodeInvokeResult> => {
+      params?.onDispatchReady?.("invoke-1");
+      return {
+        ok: true,
+        payload: { ok: true, value: 1 },
+        payloadJSON: null,
+        error: null,
+      };
+    },
+  );
+  return {
+    context: {
+      getRuntimeConfig:
+        opts?.getRuntimeConfig ?? (() => nodeCommandsConfig({ allow: [DEMO_COMMAND] })),
+      nodeRegistry: {
+        get: () => nodeSession,
+        getForPairingGeneration: () => nodeSession,
+        invoke,
+      },
+      broadcast: vi.fn(),
+      broadcastToConnIds: vi.fn(),
+      pluginApprovalManager: opts?.pluginApprovalManager,
+      getApprovalClientConnIds: opts?.getApprovalClientConnIds,
+      hasExecApprovalClients: opts?.hasExecApprovalClients,
+      forwardPluginApprovalRequest: opts?.forwardPluginApprovalRequest,
+      pluginApprovalIosPushDelivery: opts?.pluginApprovalIosPushDelivery,
+      validateAgentRuntimeApprovalAuthority: opts?.validateAgentRuntimeApprovalAuthority,
+    } as unknown as GatewayRequestContext,
+    invoke,
+  };
+}
+
+type ApprovalClientLookup = NonNullable<GatewayRequestContext["getApprovalClientConnIds"]>;
+
+export function createApprovalClient(params: {
+  connId: string;
+  clientId: string;
+  deviceId?: string;
+}): GatewayClient {
+  return {
+    connId: params.connId,
+    connect: {
+      client: { id: params.clientId },
+      device: params.deviceId ? { id: params.deviceId } : undefined,
+      scopes: ["operator.approvals"],
+    },
+  } as GatewayClient;
+}
+
+export function createApprovalClientLookup(clients: GatewayClient[]): ApprovalClientLookup {
+  return (opts = {}) =>
+    new Set(
+      clients
+        .filter((client) => {
+          if (opts.excludeConnId && client.connId === opts.excludeConnId) {
+            return false;
+          }
+          return opts.filter?.(client, opts.record) ?? true;
+        })
+        .map((client) => client.connId)
+        .filter((connId): connId is string => typeof connId === "string" && connId.length > 0),
+    );
+}
+
+export function createOperatorClient(connId = "conn-requester"): GatewayClient {
+  return createApprovalClient({
+    connId,
+    clientId: "client-owner",
+    deviceId: "device-owner",
+  });
+}
+
+export type NodeInvokePolicyRegistration = PluginRegistry["nodeInvokePolicies"][number];
+type NodeInvokePolicyHandler = NodeInvokePolicyRegistration["policy"]["handle"];
+export type PluginApprovalRecord = ReturnType<
+  ExecApprovalManager<PluginApprovalRequestPayload>["listPendingRecords"]
+>[number];
+
+export function createDemoPolicy(handle: NodeInvokePolicyHandler): NodeInvokePolicyRegistration {
+  return {
+    pluginId: DEMO_PLUGIN_ID,
+    policy: {
+      commands: [DEMO_COMMAND],
+      handle,
+    },
+    pluginConfig: { enabled: true },
+    source: "test",
+  };
+}
+
+export function createApprovalRequestPolicy(params?: {
+  timeoutMs?: number;
+  title?: string;
+  description?: string;
+  toolName?: string;
+  agentId?: string;
+  allowedDecisions?: readonly ("allow-once" | "allow-always" | "deny")[];
+}): NodeInvokePolicyRegistration {
+  return createDemoPolicy(async (ctx: OpenClawPluginNodeInvokePolicyContext) => {
+    const approval = await ctx.approvals?.request({
+      title: params?.title ?? "Sensitive action",
+      description: params?.description ?? "Needs approval",
+      ...(params?.toolName === undefined ? {} : { toolName: params.toolName }),
+      ...(params?.agentId === undefined ? {} : { agentId: params.agentId }),
+      ...(params?.allowedDecisions === undefined
+        ? {}
+        : { allowedDecisions: params.allowedDecisions }),
+      ...(params?.timeoutMs === undefined ? {} : { timeoutMs: params.timeoutMs }),
+    });
+    return { ok: true, payload: approval ?? null };
+  });
+}
+
+export function setDangerousDemoCommandRegistry(policies: NodeInvokePolicyRegistration[] = []) {
+  const registry = createEmptyPluginRegistry();
+  registry.nodeHostCommands.push({
+    pluginId: DEMO_PLUGIN_ID,
+    command: {
+      command: DEMO_COMMAND,
+      dangerous: true,
+      handle: async () => "{}",
+    },
+    source: "test",
+  });
+  registry.nodeInvokePolicies.push(...policies);
+  setActivePluginRegistry(registry);
+}
+
+export async function invokeDemoPolicy(
+  context: GatewayRequestContext,
+  client: GatewayClient | null = null,
+) {
+  return await applyPluginNodeInvokePolicy({
+    context,
+    client,
+    nodeSession: createNodeSession(),
+    command: DEMO_COMMAND,
+    params: DEMO_PARAMS,
+  });
+}
+
+export async function expectSinglePendingApproval(
+  manager: ExecApprovalManager<PluginApprovalRequestPayload>,
+): Promise<PluginApprovalRecord> {
+  await vi.waitFor(() => {
+    expect(manager.listPendingRecords()).toHaveLength(1);
+  });
+  const [record] = manager.listPendingRecords();
+  if (!record) {
+    throw new Error("expected pending approval");
+  }
+  return record;
+}
+
+export async function expectApprovalResolution(
+  resultPromise: ReturnType<typeof applyPluginNodeInvokePolicy>,
+  manager: ExecApprovalManager<PluginApprovalRequestPayload>,
+  record: PluginApprovalRecord,
+) {
+  expect(manager.resolve(record.id, "allow-once")).toBe(true);
+  await expect(resultPromise).resolves.toStrictEqual({
+    ok: true,
+    payload: { id: record.id, decision: "allow-once" },
+  });
+  expect(manager.getSnapshot(record.id)?.consumedDecision).toBe("allow-once");
+  expect(manager.consumeAllowOnce(record.id)).toBe(false);
+}

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -14,19 +14,30 @@ import {
   type PluginApprovalRequestPayload,
 } from "../infra/plugin-approvals.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
-import type { PluginRegistry } from "../plugins/registry-types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import type { OpenClawPluginNodeInvokePolicyContext } from "../plugins/types.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { applyPluginNodeInvokePolicy } from "./node-invoke-plugin-policy.js";
-import type { NodeInvokeResult, NodeSession } from "./node-registry.js";
+import {
+  createApprovalClient,
+  createApprovalClientLookup,
+  createApprovalRequestPolicy,
+  createContext,
+  createDemoPolicy,
+  createNodeSession,
+  createOperatorClient,
+  DEMO_COMMAND,
+  DEMO_PARAMS,
+  DEMO_PLUGIN_ID,
+  expectApprovalResolution,
+  expectSinglePendingApproval,
+  invokeDemoPolicy,
+  nodeCommandsConfig,
+  setDangerousDemoCommandRegistry,
+} from "./node-invoke-plugin-policy.test-helpers.js";
 import { listPendingOperatorApprovals } from "./operator-approval-store.js";
-import type { GatewayClient, GatewayRequestContext } from "./server-methods/types.js";
 
-const DEMO_PLUGIN_ID = "demo";
-const DEMO_COMMAND = "demo.read";
-const DEMO_PARAMS = { path: "/tmp/x" };
 const tempDirs: string[] = [];
 
 const hasApprovalTurnSourceRouteMock = vi.hoisted(() =>
@@ -39,209 +50,6 @@ const hasApprovalTurnSourceRouteMock = vi.hoisted(() =>
 vi.mock("../infra/approval-turn-source.js", () => ({
   hasApprovalTurnSourceRoute: hasApprovalTurnSourceRouteMock,
 }));
-function createNodeSession(): NodeSession {
-  return {
-    nodeId: "node-1",
-    connId: "conn-1",
-    client: {} as NodeSession["client"],
-    declaredCaps: [],
-    caps: [],
-    declaredCommands: ["demo.read"],
-    commands: ["demo.read"],
-    declaredNodePluginTools: [],
-    nodePluginTools: [],
-    nodeSkills: [],
-    connectedAtMs: 0,
-  };
-}
-
-function nodeCommandsConfig(commands: { allow?: string[]; deny?: string[] }) {
-  return { gateway: { nodes: { commands } } };
-}
-
-function createContext(opts?: {
-  pluginApprovalManager?: ExecApprovalManager<PluginApprovalRequestPayload>;
-  getApprovalClientConnIds?: GatewayRequestContext["getApprovalClientConnIds"];
-  getRuntimeConfig?: GatewayRequestContext["getRuntimeConfig"];
-  nodeSession?: NodeSession;
-  hasExecApprovalClients?: GatewayRequestContext["hasExecApprovalClients"];
-  forwardPluginApprovalRequest?: GatewayRequestContext["forwardPluginApprovalRequest"];
-  pluginApprovalIosPushDelivery?: GatewayRequestContext["pluginApprovalIosPushDelivery"];
-  validateAgentRuntimeApprovalAuthority?: GatewayRequestContext["validateAgentRuntimeApprovalAuthority"];
-}) {
-  const nodeSession = opts?.nodeSession ?? createNodeSession();
-  const invoke = vi.fn(
-    async (params?: {
-      onDispatchReady?: (invokeId: string) => void;
-      onProgress?: (chunk: string) => void;
-      isDispatchAuthorized?: () => boolean;
-    }): Promise<NodeInvokeResult> => {
-      params?.onDispatchReady?.("invoke-1");
-      return {
-        ok: true,
-        payload: { ok: true, value: 1 },
-        payloadJSON: null,
-        error: null,
-      };
-    },
-  );
-  return {
-    context: {
-      getRuntimeConfig:
-        opts?.getRuntimeConfig ?? (() => nodeCommandsConfig({ allow: [DEMO_COMMAND] })),
-      nodeRegistry: {
-        get: () => nodeSession,
-        getForPairingGeneration: () => nodeSession,
-        invoke,
-      },
-      broadcast: vi.fn(),
-      broadcastToConnIds: vi.fn(),
-      pluginApprovalManager: opts?.pluginApprovalManager,
-      getApprovalClientConnIds: opts?.getApprovalClientConnIds,
-      hasExecApprovalClients: opts?.hasExecApprovalClients,
-      forwardPluginApprovalRequest: opts?.forwardPluginApprovalRequest,
-      pluginApprovalIosPushDelivery: opts?.pluginApprovalIosPushDelivery,
-      validateAgentRuntimeApprovalAuthority: opts?.validateAgentRuntimeApprovalAuthority,
-    } as unknown as GatewayRequestContext,
-    invoke,
-  };
-}
-
-type ApprovalClientLookup = NonNullable<GatewayRequestContext["getApprovalClientConnIds"]>;
-
-function createApprovalClient(params: {
-  connId: string;
-  clientId: string;
-  deviceId?: string;
-}): GatewayClient {
-  return {
-    connId: params.connId,
-    connect: {
-      client: { id: params.clientId },
-      device: params.deviceId ? { id: params.deviceId } : undefined,
-      scopes: ["operator.approvals"],
-    },
-  } as GatewayClient;
-}
-
-function createApprovalClientLookup(clients: GatewayClient[]): ApprovalClientLookup {
-  return (opts = {}) =>
-    new Set(
-      clients
-        .filter((client) => {
-          if (opts.excludeConnId && client.connId === opts.excludeConnId) {
-            return false;
-          }
-          return opts.filter?.(client, opts.record) ?? true;
-        })
-        .map((client) => client.connId)
-        .filter((connId): connId is string => typeof connId === "string" && connId.length > 0),
-    );
-}
-
-function createOperatorClient(connId = "conn-requester"): GatewayClient {
-  return createApprovalClient({
-    connId,
-    clientId: "client-owner",
-    deviceId: "device-owner",
-  });
-}
-
-type NodeInvokePolicyRegistration = PluginRegistry["nodeInvokePolicies"][number];
-type NodeInvokePolicyHandler = NodeInvokePolicyRegistration["policy"]["handle"];
-type PluginApprovalRecord = ReturnType<
-  ExecApprovalManager<PluginApprovalRequestPayload>["listPendingRecords"]
->[number];
-
-function createDemoPolicy(handle: NodeInvokePolicyHandler): NodeInvokePolicyRegistration {
-  return {
-    pluginId: DEMO_PLUGIN_ID,
-    policy: {
-      commands: [DEMO_COMMAND],
-      handle,
-    },
-    pluginConfig: { enabled: true },
-    source: "test",
-  };
-}
-
-function createApprovalRequestPolicy(params?: {
-  timeoutMs?: number;
-  title?: string;
-  description?: string;
-  toolName?: string;
-  agentId?: string;
-  allowedDecisions?: readonly ("allow-once" | "allow-always" | "deny")[];
-}): NodeInvokePolicyRegistration {
-  return createDemoPolicy(async (ctx: OpenClawPluginNodeInvokePolicyContext) => {
-    const approval = await ctx.approvals?.request({
-      title: params?.title ?? "Sensitive action",
-      description: params?.description ?? "Needs approval",
-      ...(params?.toolName === undefined ? {} : { toolName: params.toolName }),
-      ...(params?.agentId === undefined ? {} : { agentId: params.agentId }),
-      ...(params?.allowedDecisions === undefined
-        ? {}
-        : { allowedDecisions: params.allowedDecisions }),
-      ...(params?.timeoutMs === undefined ? {} : { timeoutMs: params.timeoutMs }),
-    });
-    return { ok: true, payload: approval ?? null };
-  });
-}
-
-function setDangerousDemoCommandRegistry(policies: NodeInvokePolicyRegistration[] = []) {
-  const registry = createEmptyPluginRegistry();
-  registry.nodeHostCommands.push({
-    pluginId: DEMO_PLUGIN_ID,
-    command: {
-      command: DEMO_COMMAND,
-      dangerous: true,
-      handle: async () => "{}",
-    },
-    source: "test",
-  });
-  registry.nodeInvokePolicies.push(...policies);
-  setActivePluginRegistry(registry);
-}
-
-async function invokeDemoPolicy(
-  context: GatewayRequestContext,
-  client: GatewayClient | null = null,
-) {
-  return await applyPluginNodeInvokePolicy({
-    context,
-    client,
-    nodeSession: createNodeSession(),
-    command: DEMO_COMMAND,
-    params: DEMO_PARAMS,
-  });
-}
-
-async function expectSinglePendingApproval(
-  manager: ExecApprovalManager<PluginApprovalRequestPayload>,
-): Promise<PluginApprovalRecord> {
-  await vi.waitFor(() => {
-    expect(manager.listPendingRecords()).toHaveLength(1);
-  });
-  const [record] = manager.listPendingRecords();
-  if (!record) {
-    throw new Error("expected pending approval");
-  }
-  return record;
-}
-
-async function expectApprovalResolution(
-  resultPromise: ReturnType<typeof applyPluginNodeInvokePolicy>,
-  manager: ExecApprovalManager<PluginApprovalRequestPayload>,
-  record: PluginApprovalRecord,
-) {
-  expect(manager.resolve(record.id, "allow-once")).toBe(true);
-  await expect(resultPromise).resolves.toStrictEqual({
-    ok: true,
-    payload: { id: record.id, decision: "allow-once" },
-  });
-  expect(manager.getSnapshot(record.id)?.consumedDecision).toBe("allow-once");
-  expect(manager.consumeAllowOnce(record.id)).toBe(false);
-}
 
 describe("applyPluginNodeInvokePolicy", () => {
   beforeEach(() => {
@@ -733,9 +541,9 @@ describe("applyPluginNodeInvokePolicy", () => {
 
   it.each([false, true])("routes approvals for synthetic=%s", async (synthetic) => {
     const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
-    const visibleConnIds = new Set(
-      synthetic ? ["conn-owner-approval", "conn-requester"] : ["conn-owner-approval"],
-    );
+    // The carried connection is turn provenance, never this approval's
+    // presenter, so it stays eligible as a reviewer for both provenance shapes.
+    const visibleConnIds = new Set(["conn-owner-approval", "conn-requester"]);
     const getApprovalClientConnIds = createApprovalClientLookup([
       createOperatorClient(),
       createOperatorClient("conn-owner-approval"),
@@ -763,6 +571,27 @@ describe("applyPluginNodeInvokePolicy", () => {
       "plugin.approval.requested",
       expect.objectContaining({ id: record.id }),
       visibleConnIds,
+      { dropIfSlow: true },
+    );
+
+    await expectApprovalResolution(resultPromise, manager, record);
+  });
+
+  it("keeps a sole-reviewer operator requester routable instead of no-route denying", async () => {
+    const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
+    const requester = createOperatorClient();
+    setDangerousDemoCommandRegistry([createApprovalRequestPolicy()]);
+    const { context } = createContext({
+      pluginApprovalManager: manager,
+      getApprovalClientConnIds: createApprovalClientLookup([requester]),
+    });
+    const resultPromise = invokeDemoPolicy(context, requester);
+
+    const record = await expectSinglePendingApproval(manager);
+    expect(context.broadcastToConnIds).toHaveBeenCalledWith(
+      "plugin.approval.requested",
+      expect.objectContaining({ id: record.id }),
+      new Set(["conn-requester"]),
       { dropIfSlow: true },
     );
 

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -192,9 +192,11 @@ function createApprovalRuntime(params: {
         decisionPromise,
         respond,
         context: params.context,
-        // Internal calls retain the operator's connection as provenance; it is
-        // still a reviewer, not the transport requester to exclude from delivery.
-        clientConnId: params.client?.internal?.syntheticClient ? undefined : params.client?.connId,
+        // The carried connection is turn/invoke provenance, never this
+        // approval's presenter: policy approvals are minted here, not requested
+        // by the client, so the connection stays eligible as a reviewer. A
+        // sole-reviewer operator would otherwise be excluded from delivery and
+        // the request auto-denied as no-route.
         requestEventName: "plugin.approval.requested",
         requestEvent,
         twoPhase: false,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an operator driving a Codex paired-device or cloud-node session from a single Control UI window would have every turn fail immediately with "Codex node execution requires one-time approval" — the required approval card was never shown anywhere, so there was nothing to approve.

## Why This Change Was Made

Turn-driven plugin approvals (the `node.invoke` policy path, e.g. the Codex exec-server launch gate) carried the operator connection that submitted the turn as the approval's requester, and request delivery excluded that connection from the reviewer recipient set. The exclusion is only meaningful for RPC-ingress approval requests, where the requesting client presents its own prompt and a broadcast would duplicate it. On the node-invoke policy path the approval is minted gateway-side and is never presented through the requester's RPC response — so with a single connected operator client, the only eligible reviewer was excluded, the recipient set came up empty, webchat turns have no turn-source fallback route, and the gateway auto-denied the request as `no-route` before anyone could see it.

The fix stops passing the requester connection to delivery on this path (removing the earlier partial carve-out that skipped exclusion only for synthetic in-process clients — the code comment there already described the correct invariant). RPC-ingress approval paths (`exec.approval.request`, `plugin.approval.request`, system-agent) keep their requester exclusion.

Production delta: net −1 line of code (comment expanded). The test-harness extraction into `node-invoke-plugin-policy.test-helpers.ts` keeps the test file under the max-lines lint cap.

## User Impact

An operator working in one Control UI window can now approve Codex node execution from that same window. Previously this required a second connected approval-capable client (another Control UI window or the TUI) — with one window the turn always failed with no visible approval anywhere, the worst kind of silent dead-end.

## Evidence

- Live failure record (production gateway, before fix): three consecutive `kind=plugin` approvals for "Run Codex execution on node" auto-denied with `status=denied, terminal_reason=no-route` at 23:28/23:34/23:39 on 2026-08-26, each while exactly one Control UI connection (the requester) was connected. `requested_by_client_id=openclaw-control-ui` on each record confirms the operator's own connection was bound as requester.
- Live behavior after fix (gateway running a packaged build of this branch): the same flow delivers the approval card to the requesting window on every attempt; state DB shows an uninterrupted run of `status=allowed, decision=allow-once, resolved by user` plugin approvals, and Codex remote-exec turns complete end-to-end on the paired node.
- Regression tests, both verified failing on unfixed code:
  - `keeps a sole-reviewer operator requester routable instead of no-route denying` — reproduces the exact production scenario (requester is the only connected reviewer); pre-fix the record is auto-denied before it can pend.
  - `routes approvals for synthetic=%s` — updated so real-connection and synthetic provenance now route identically (pre-fix the real-connection case excluded the requester).
- `src/gateway/node-invoke-plugin-policy.test.ts` full suite (93 tests) plus sibling approval suites (`approval-shared`, `exec-approvals`, `exec-approval-manager`, `nodes.invoke`, `terminal`, receipts — 470+ tests) pass; `node scripts/check-changed.mjs --base origin/main` exits 0.
- Autoreview (codex, gpt-5.6-sol, high): clean, no findings.
