### PR TITLE
fix(whatsapp): replay approval reactions after transient Gateway failures

### DIFF
--- a/extensions/whatsapp/src/approval-reactions.test.ts
+++ b/extensions/whatsapp/src/approval-reactions.test.ts
@@ -423,6 +423,37 @@ describe("WhatsApp approval reactions", () => {
     ).resolves.toBeNull();
   });
 
+  it("propagates transient Gateway errors for durable ingress replay", async () => {
+    registerExecApprovalTarget({
+      remoteJid: "15551230000@s.whatsapp.net",
+      approvalId: "exec-transient",
+    });
+    const gatewayError = new Error("Gateway 503 Service Unavailable");
+    resolverMocks.resolveWhatsAppApproval.mockRejectedValueOnce(gatewayError);
+    resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
+
+    // Transient errors must throw so the durable ingress drain releases the
+    // claim and replays the reaction; swallowing them here would drop the
+    // operator's click with no retry owner.
+    await expect(
+      maybeResolveWhatsAppApprovalReaction({
+        cfg: approvalConfig(["+15551230000"]),
+        accountId: "default",
+        msg: buildReactionMessage({ remoteJid: "15551230000@s.whatsapp.net" }),
+        resolveInboundJid: async () => "+15551230000",
+      }),
+    ).rejects.toBe(gatewayError);
+    // The binding should NOT be cleared yet (not-found is the terminal case).
+    await expect(
+      resolveWhatsAppApprovalReactionTargetWithPersistence({
+        accountId: "default",
+        remoteJid: "15551230000@s.whatsapp.net",
+        messageId: "approval-message",
+        reactionKey: "👍",
+      }),
+    ).resolves.toBeTruthy();
+  });
+
   it("does not attribute a peer DM fromMe reaction to the peer", async () => {
     registerWhatsAppApprovalReactionTarget({
       accountId: "default",

--- a/extensions/whatsapp/src/approval-reactions.ts
+++ b/extensions/whatsapp/src/approval-reactions.ts
@@ -542,7 +542,11 @@ export async function maybeResolveWhatsAppApprovalReaction(params: {
     params.logVerboseMessage?.(
       `whatsapp: approval reaction failed id=${target.approvalId} sender=${actorId}: ${String(error)}`,
     );
-    return true;
+    // A transient Gateway 5xx/network/auth error is not terminal: propagate it
+    // so the caller can route the reaction into the durable ingress, whose
+    // drain releases the claim and replays it under its retry policy — the
+    // same owner boundary as signal (#130134) and matrix (#129879).
+    throw error;
   }
 }
 

--- a/extensions/whatsapp/src/inbound/message-delivery.ts
+++ b/extensions/whatsapp/src/inbound/message-delivery.ts
@@ -421,6 +421,24 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
     if (context.skipRecentOutboundEcho === true) {
       return "completed";
     }
+    // Approval reactions own their event before normalization: reaction
+    // payloads do not normalize into ordinary inbound messages, and a
+    // transient Gateway failure must propagate to the drain so it releases
+    // the claim and replays the reaction once the Gateway recovers.
+    if (
+      await maybeResolveWhatsAppApprovalReaction({
+        cfg: options.loadConfig?.() ?? options.cfg,
+        accountId: options.accountId,
+        msg,
+        selfJid: self.jid,
+        selfLid: self.lid,
+        resolveInboundJid,
+        resolveReactionTargetJids,
+        logVerboseMessage: (message) => logWhatsAppVerbose(options.verbose, message),
+      })
+    ) {
+      return "completed";
+    }
     const prepared = await preparation;
     if (prepared === null) {
       return "completed";
@@ -491,8 +509,14 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
       rememberBaileysMessage(msg.key?.remoteJid, msg.key?.id, msg.message);
 
       const receiveOrder = nextReceiveOrder++;
-      if (
-        await maybeResolveWhatsAppApprovalReaction({
+      // Fast path: resolve approval reactions before admission. A transient
+      // Gateway failure must fall through to durable admission instead — the
+      // drain-side resolution below replays it under the queue's retry policy.
+      // Never let the throw escape this loop: sibling messages in the same
+      // upsert batch still need their own delivery.
+      let approvalReactionResolved = false;
+      try {
+        approvalReactionResolved = await maybeResolveWhatsAppApprovalReaction({
           cfg: options.loadConfig?.() ?? options.cfg,
           accountId: options.accountId,
           msg,
@@ -501,8 +525,14 @@ export function createWhatsAppMessageDeliveryCoordinator(options: WhatsAppMessag
           resolveInboundJid,
           resolveReactionTargetJids,
           logVerboseMessage: (message) => logWhatsAppVerbose(options.verbose, message),
-        })
-      ) {
+        });
+      } catch (error) {
+        inboundLogger.warn(
+          { error: formatError(error) },
+          "whatsapp approval reaction resolution failed; admitting reaction for durable replay",
+        );
+      }
+      if (approvalReactionResolved) {
         continue;
       }
 

--- a/extensions/whatsapp/src/monitor-inbox.approval-reaction-replay.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.approval-reaction-replay.test.ts
@@ -19,21 +19,13 @@ import {
 
 const resolverMocks = vi.hoisted(() => ({
   resolveWhatsAppApproval: vi.fn(),
-  isApprovalNotFoundError: vi.fn(() => false),
 }));
 
 vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
   resolveApprovalOverGateway: resolverMocks.resolveWhatsAppApproval,
 }));
-vi.mock("openclaw/plugin-sdk/error-runtime", async () => {
-  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/error-runtime")>(
-    "openclaw/plugin-sdk/error-runtime",
-  );
-  return {
-    ...actual,
-    isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
-  };
-});
+// error-runtime stays real: the injected "gateway 503" Error is genuinely not
+// an approval-not-found, so the real classifier drives the transient path.
 
 installWebMonitorInboxUnitTestHooks();
 
@@ -68,8 +60,6 @@ describe("WhatsApp approval reaction durable replay", () => {
   beforeEach(() => {
     clearWhatsAppApprovalReactionTargetsForTest();
     resolverMocks.resolveWhatsAppApproval.mockReset();
-    resolverMocks.isApprovalNotFoundError.mockReset();
-    resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
   });
 
   it(
@@ -130,7 +120,9 @@ describe("WhatsApp approval reaction durable replay", () => {
         // resolves nothing and delivers nothing new. Give the upsert fast
         // path and the admission dedupe check time to settle, then assert.
         sock.ev.emit("messages.upsert", buildApprovalReactionUpsert());
-        await new Promise((resolve) => setTimeout(resolve, 1_500));
+        await new Promise((resolve) => {
+          setTimeout(resolve, 1_500);
+        });
         expect(resolverMocks.resolveWhatsAppApproval).toHaveBeenCalledTimes(2);
         expect(onMessage).toHaveBeenCalledTimes(1);
       } finally {

--- a/extensions/whatsapp/src/monitor-inbox.approval-reaction-replay.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.approval-reaction-replay.test.ts
@@ -1,0 +1,141 @@
+// WhatsApp durable-ingress replay proof: a transient Gateway failure during
+// approval-reaction resolution must not consume the reaction. The upsert fast
+// path falls through to durable admission, and the real SQLite-backed drain
+// redelivers the operator's reaction once the Gateway recovers. Everything
+// here is real (monitor, admission, queue, drain, approval-reaction
+// resolution) except the socket and the one true external boundary: the
+// Gateway approval-resolution call.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearWhatsAppApprovalReactionTargetsForTest,
+  registerWhatsAppApprovalReactionTarget,
+} from "./approval-reactions.js";
+import {
+  installWebMonitorInboxUnitTestHooks,
+  startInboxMonitor,
+  waitForMessageCalls,
+  type InboxOnMessage,
+} from "./monitor-inbox.test-harness.js";
+
+const resolverMocks = vi.hoisted(() => ({
+  resolveWhatsAppApproval: vi.fn(),
+  isApprovalNotFoundError: vi.fn(() => false),
+}));
+
+vi.mock("openclaw/plugin-sdk/approval-gateway-runtime", () => ({
+  resolveApprovalOverGateway: resolverMocks.resolveWhatsAppApproval,
+}));
+vi.mock("openclaw/plugin-sdk/error-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/error-runtime")>(
+    "openclaw/plugin-sdk/error-runtime",
+  );
+  return {
+    ...actual,
+    isApprovalNotFoundError: resolverMocks.isApprovalNotFoundError,
+  };
+});
+
+installWebMonitorInboxUnitTestHooks();
+
+function buildApprovalReactionUpsert() {
+  return {
+    type: "notify",
+    messages: [
+      {
+        key: { id: "reaction-1", remoteJid: "15551230000@s.whatsapp.net", fromMe: false },
+        message: {
+          reactionMessage: {
+            text: "👍",
+            key: { remoteJid: "15551230000@s.whatsapp.net", id: "approval-message" },
+          },
+        },
+        messageTimestamp: 1_700_000_000,
+        pushName: "Tester",
+      },
+      // A sibling in the same batch: the transient failure must not abort the
+      // upsert loop before this ordinary message is delivered.
+      {
+        key: { id: "batch-2", remoteJid: "15551230000@s.whatsapp.net", fromMe: false },
+        message: { conversation: "batch survivor" },
+        messageTimestamp: 1_700_000_001,
+        pushName: "Tester",
+      },
+    ],
+  };
+}
+
+describe("WhatsApp approval reaction durable replay", () => {
+  beforeEach(() => {
+    clearWhatsAppApprovalReactionTargetsForTest();
+    resolverMocks.resolveWhatsAppApproval.mockReset();
+    resolverMocks.isApprovalNotFoundError.mockReset();
+    resolverMocks.isApprovalNotFoundError.mockReturnValue(false);
+  });
+
+  it(
+    "releases the claim and replays a reaction after a transient Gateway failure",
+    { timeout: 30_000 },
+    async () => {
+      registerWhatsAppApprovalReactionTarget({
+        accountId: "default",
+        remoteJid: "15551230000@s.whatsapp.net",
+        messageId: "approval-message",
+        approvalId: "exec-replay",
+        approvalKind: "exec",
+        allowedDecisions: ["allow-once", "deny"],
+      });
+      // First resolution attempt (the upsert fast path) fails like a transient
+      // Gateway 503; the redelivered drain attempt resolves the approval.
+      resolverMocks.resolveWhatsAppApproval
+        .mockRejectedValueOnce(new Error("gateway 503"))
+        .mockResolvedValue({
+          applied: true,
+          approval: { status: "allowed", decision: "allow-once" },
+        });
+      const onMessage = vi.fn();
+      const { listener, sock } = await startInboxMonitor(onMessage as InboxOnMessage);
+
+      try {
+        sock.ev.emit("messages.upsert", buildApprovalReactionUpsert());
+
+        // A swallowed failure would resolve nothing and never produce this
+        // second call: the reaction only reaches the resolver again when the
+        // durable drain replays it.
+        await vi.waitFor(
+          () => expect(resolverMocks.resolveWhatsAppApproval).toHaveBeenCalledTimes(2),
+          { timeout: 15_000 },
+        );
+
+        // Redelivery carried the identical resolution request.
+        expect(resolverMocks.resolveWhatsAppApproval.mock.calls[1]?.[0]).toEqual(
+          resolverMocks.resolveWhatsAppApproval.mock.calls[0]?.[0],
+        );
+        expect(resolverMocks.resolveWhatsAppApproval.mock.calls[1]?.[0]).toEqual(
+          expect.objectContaining({
+            approvalId: "exec-replay",
+            approvalKind: "exec",
+            decision: "allow-once",
+            channel: "whatsapp",
+            accountId: "default",
+          }),
+        );
+
+        // The reaction never leaks into the chat pipeline; only the batch
+        // sibling is delivered as an ordinary message.
+        await waitForMessageCalls(onMessage, 1);
+        const delivered = onMessage.mock.calls[0]?.[0] as { payload?: { body?: string } };
+        expect(delivered.payload?.body).toBe("batch survivor");
+
+        // The completion tombstone is durable: re-emitting the same reaction
+        // resolves nothing and delivers nothing new. Give the upsert fast
+        // path and the admission dedupe check time to settle, then assert.
+        sock.ev.emit("messages.upsert", buildApprovalReactionUpsert());
+        await new Promise((resolve) => setTimeout(resolve, 1_500));
+        expect(resolverMocks.resolveWhatsAppApproval).toHaveBeenCalledTimes(2);
+        expect(onMessage).toHaveBeenCalledTimes(1);
+      } finally {
+        await listener.close();
+      }
+    },
+  );
+});


### PR DESCRIPTION
## What Problem This Solves

A transient Gateway 5xx/network/auth error during a WhatsApp approval reaction silently dropped the operator's approval click. `maybeResolveWhatsAppApprovalReaction` swallowed the error with `return true` (`extensions/whatsapp/src/approval-reactions.ts:545`), and the upsert consumer (`extensions/whatsapp/src/inbound/message-delivery.ts`) skipped the message before durable admission — so the reaction never reached the durable ingress queue, no retry owner ever saw it, and the click was lost with only a verbose log.

This is the WhatsApp instance of the invariant already fixed for matrix (#129879), signal (#130134), and iMessage (#130893); the signal repair intentionally left WhatsApp separate because its approval check runs pre-ingress.

Fixes #131004.

## Why This Change Was Made

A naive one-line `throw` would be worse here: the approval check runs in the `messages.upsert` loop before durable admission, so an escaping throw would abort the loop and drop sibling messages in the same batch. The repair therefore routes the failure into the existing durable ingress as the retry owner:

1. `approval-reactions.ts` — non-NotFound resolver errors now `throw` (NotFound stays terminal: binding cleared, reaction consumed).
2. `message-delivery.ts` upsert fast path — catches the transient throw, logs it, and falls through to normal durable admission instead of `continue`, keeping the batch loop alive.
3. `message-delivery.ts` `processDurableInboundMessage` — resolves approval reactions inside the durable dispatch (before normalization, since reaction payloads do not normalize into ordinary inbound messages). A transient failure there propagates to the real drain, which releases the claim and replays the reaction under the queue's retry policy.

## User Impact

WhatsApp approval reactions now survive transient Gateway failures: the operator's 👍 is replayed once the Gateway recovers instead of vanishing. Sibling messages in the same upsert batch are unaffected.

## Evidence

- **Qualified mock-gateway harness (verdict below)**: a REAL ephemeral gateway process (dist build of this branch, whatsapp plugin loaded, isolated state dir, real approval store / reviewer custody / record visibility) + the REAL message-delivery coordinator + REAL SQLite durable ingress queue; only the Baileys socket/session (the channel transport boundary) is mocked. A real pending exec approval is requested on the gateway with a whatsapp turn-source; the reaction's first resolution attempts target a dead local port (`ECONNREFUSED`, transient), then the config flips to the live port and the durable drain replays and resolves the approval on the gateway. Transcript:

  ```text
  [proof] exec approval requested on real gateway: id=whatsapp-replay-proof-1787857153862
  [proof] reaction upsert emitted while the coordinator config points at a dead port
  whatsapp: approval reaction failed id=... sender=+15551230000: Error: connect ECONNREFUSED 127.0.0.1:1  (x3)
  [proof] durable rows after transient failure: pending=1 claims=0
  [proof] coordinator config flipped to the live gateway port; waiting for durable replay
  [proof] approval decision after replay: {"id":"...","decision":"allow-once","createdAtMs":...,"expiresAtMs":...}
  [proof] chat deliveries observed: []
  whatsapp: approval reaction applied id=... sender=+15551230000 status=allowed decision=allow-once
  VERDICT {"transientFailureInjected":true,"replayResolvedApproval":true,"reactionReachedChatLane":false}
  ```

  Verdict JSON: `{"approvalId":"whatsapp-replay-proof-1787857153862","transientFailureInjected":true,"replayResolvedApproval":true,"decisionResult":{"decision":"allow-once"},"reactionReachedChatLane":false}` — the transient failure never tombstones the reaction, the released claim is redelivered, the approval is decided `allow-once` on the real gateway, and nothing leaks into the chat lane.


- New `extensions/whatsapp/src/monitor-inbox.approval-reaction-replay.test.ts`: real inbox monitor, real SQLite ingress queue, real drain, real approval-reaction resolution — only the socket and the Gateway approval-resolution call are mocked. Proves: the transient failure falls through to durable admission, the drain redelivers with an identical resolution request (`approvalId`/`approvalKind`/`decision`/`channel`), the replayed attempt resolves, the reaction never leaks into the chat pipeline, a sibling message in the same upsert batch is still delivered, and the completion tombstone blocks any third dispatch.
- Regression proof: the replay test fails against pre-fix code (single swallowed call, no redelivery) and passes with the fix; the rewritten unit test (`propagates transient Gateway errors for durable ingress replay`) also fails pre-fix.
- `node scripts/run-vitest.mjs extensions/whatsapp/src/monitor-inbox extensions/whatsapp/src/approval-reactions.test.ts extensions/whatsapp/src/question-reactions.test.ts extensions/whatsapp/src/inbound.test.ts extensions/whatsapp/src/inbound` — 359 passed.
- `pnpm tsgo:extensions` and `pnpm tsgo:test:extensions` green; `oxfmt --check` clean on all touched files.

## Changelog context

Behavior fix: WhatsApp approval reactions now survive transient Gateway failures instead of silently dropping the operator's click.


