### PR TITLE
fix(nextcloud-talk): record non-outcomes for dropped inbound events

### DIFF
--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -163,7 +163,7 @@ Provider options:
 - `channels.nextcloud-talk.replyToMode`: reply-reference mode (`off | first | all | batched`; default: `all`). Named accounts can override it with `channels.nextcloud-talk.accounts.<id>.replyToMode`.
 - `channels.nextcloud-talk.responsePrefix`: outbound reply prefix.
 - `channels.nextcloud-talk.markdown.tables`: markdown table rendering mode (`off | bullets | code | block`).
-- `channels.nextcloud-talk.mediaMaxMb`: inbound media cap (MB).
+- `channels.nextcloud-talk.mediaMaxMb`: media size cap (MB). Currently unused: inbound file shares are not downloaded — non-message webhook events (reactions, file shares) are acknowledged and logged instead.
 - `channels.nextcloud-talk.network.dangerouslyAllowPrivateNetwork`: allow private/internal Nextcloud hosts past the SSRF guard.
 - `channels.nextcloud-talk.accounts.<id>`: per-account overrides (same keys); `defaultAccount` picks the default. Env vars `NEXTCLOUD_TALK_BOT_SECRET` / `NEXTCLOUD_TALK_API_PASSWORD` apply to the default account only.
 

--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -163,7 +163,6 @@ Provider options:
 - `channels.nextcloud-talk.replyToMode`: reply-reference mode (`off | first | all | batched`; default: `all`). Named accounts can override it with `channels.nextcloud-talk.accounts.<id>.replyToMode`.
 - `channels.nextcloud-talk.responsePrefix`: outbound reply prefix.
 - `channels.nextcloud-talk.markdown.tables`: markdown table rendering mode (`off | bullets | code | block`).
-- `channels.nextcloud-talk.mediaMaxMb`: media size cap (MB). Currently unused: inbound file shares are not downloaded — non-message webhook events (reactions, file shares) are acknowledged and logged instead.
 - `channels.nextcloud-talk.network.dangerouslyAllowPrivateNetwork`: allow private/internal Nextcloud hosts past the SSRF guard.
 - `channels.nextcloud-talk.accounts.<id>`: per-account overrides (same keys); `defaultAccount` picks the default. Env vars `NEXTCLOUD_TALK_BOT_SECRET` / `NEXTCLOUD_TALK_API_PASSWORD` apply to the default account only.
 

--- a/docs/channels/nextcloud-talk.md
+++ b/docs/channels/nextcloud-talk.md
@@ -84,7 +84,7 @@ Minimal config:
 
 - Bots cannot initiate DMs. The user must message the bot first.
 - The webhook URL must be reachable from the Nextcloud server; set `webhookPublicUrl` when the gateway sits behind a proxy. Webhook requests are HMAC-SHA256 signed with the bot secret; invalid signatures are rejected and rate limited.
-- HTTP 200 is returned only after the raw event is durably stored; storage failures return HTTP 500. The durable `200` carries `x-openclaw-delivery-accepted: durable` (signature, validation, and storage-error responses omit it), so reverse proxies can require the marker to distinguish OpenClaw acceptance from a generic `200`.
+- Message webhooks return HTTP 200 only after the raw event is durably stored; storage failures return HTTP 500. The durable `200` carries `x-openclaw-delivery-accepted: durable`, so reverse proxies can require the marker to distinguish OpenClaw acceptance from a generic `200`. Unsupported non-message events return HTTP 200 without the marker and are logged as ignored.
 - Media uploads are not supported by the bot API; outbound media is appended as an `Attachment: <url>` line.
 - The webhook payload does not distinguish DMs from rooms; set `apiUser` + `apiPassword` to enable room-type lookups (cached about 5 minutes). Without them, every conversation is treated as a room.
 - Outbound requests go through the SSRF guard. For a Nextcloud host on a trusted private/internal network, opt in with `channels.nextcloud-talk.network.dangerouslyAllowPrivateNetwork: true`.

--- a/extensions/nextcloud-talk/src/inbound.behavior.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.behavior.test.ts
@@ -150,6 +150,21 @@ describe("nextcloud-talk inbound behavior", () => {
     warnMissingProviderGroupPolicyFallbackOnceMock.mockReturnValue(undefined);
   });
 
+  it("logs the drop when an inbound message has an empty body", async () => {
+    const runtime = createRuntimeEnv();
+    await handleNextcloudTalkInbound({
+      message: createMessage({ text: "", mediaType: "application/pdf" }),
+      account: createAccount(),
+      config: { channels: { "nextcloud-talk": {} } } as CoreConfig,
+      runtime,
+    });
+
+    expect(runtime.log).toHaveBeenCalledWith(
+      "nextcloud-talk: drop empty message body (mediaType=application/pdf) target=user-1",
+    );
+    expect(sendMessageNextcloudTalkMock).not.toHaveBeenCalled();
+  });
+
   it("issues a DM pairing challenge and sends the challenge text", async () => {
     const issueChallenge = vi.fn(
       async (params: { sendPairingReply: (text: string) => Promise<void> }) => {

--- a/extensions/nextcloud-talk/src/inbound.ts
+++ b/extensions/nextcloud-talk/src/inbound.ts
@@ -137,6 +137,12 @@ export async function handleNextcloudTalkInbound(params: {
 
   const rawBody = message.text?.trim() ?? "";
   if (!rawBody) {
+    logInboundDrop({
+      log: (messageLocal) => runtime.log?.(messageLocal),
+      channel: CHANNEL_ID,
+      reason: `empty message body (mediaType=${message.mediaType})`,
+      target: message.senderId,
+    });
     return;
   }
 

--- a/extensions/nextcloud-talk/src/types.ts
+++ b/extensions/nextcloud-talk/src/types.ts
@@ -80,8 +80,6 @@ export type NextcloudTalkAccountConfig = {
   streaming?: ChannelDeliveryStreamingConfig;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
-  /** Media upload max size in MB. */
-  mediaMaxMb?: number;
   /** Network policy overrides for self-hosted Nextcloud Talk on trusted private/internal hosts. */
   network?: NextcloudTalkNetworkConfig;
 };

--- a/extensions/nextcloud-talk/src/webhook-spool.test.ts
+++ b/extensions/nextcloud-talk/src/webhook-spool.test.ts
@@ -30,12 +30,16 @@ function createRawEvent(params?: { messageId?: string; roomToken?: string; text?
   return JSON.stringify(payload);
 }
 
-function startSpool(queue: NextcloudTalkIngressQueue, deliver: NextcloudTalkIngressDeliver) {
+function startSpool(
+  queue: NextcloudTalkIngressQueue,
+  deliver: NextcloudTalkIngressDeliver,
+  log = vi.fn(),
+) {
   return createNextcloudTalkWebhookSpool({
     accountId: "default",
     queue,
     deliver,
-    runtime: { error: vi.fn(), log: vi.fn() },
+    runtime: { error: vi.fn(), log },
     pollIntervalMs: 60_000,
     adoptionStallTimeoutMs: 5_000,
     legacyReplayStore: null,
@@ -368,37 +372,12 @@ describe("Nextcloud Talk durable ingress", () => {
     });
   });
 
-  it("ignores non-message events before they consume the message id", async () => {
-    await withQueue(async (queue) => {
-      const deliver = vi.fn();
-      const spool = startSpool(queue, deliver);
-      try {
-        const ignored = JSON.stringify({ type: "Update", object: { id: "msg-edit" } });
-        await expect(spool.receive(ignored)).resolves.toBe("ignored");
-        expect(await queue.listPending({ limit: "all" })).toEqual([]);
-        expect(deliver).not.toHaveBeenCalled();
-      } finally {
-        await spool.stop();
-      }
-    });
-  });
-
-  it("records the non-outcome when acknowledging a non-message event", async () => {
+  it("logs non-message events before they consume the message id", async () => {
     await withQueue(async (queue) => {
       const deliver = vi.fn();
       const log = vi.fn();
-      const spool = createNextcloudTalkWebhookSpool({
-        accountId: "default",
-        queue,
-        deliver,
-        runtime: { error: vi.fn(), log },
-        pollIntervalMs: 60_000,
-        adoptionStallTimeoutMs: 5_000,
-        legacyReplayStore: null,
-      });
+      const spool = startSpool(queue, deliver, log);
       try {
-        // A file share arrives as a non-Note Create activity and is acked
-        // without a durable row; the drop must leave a visible log reason.
         const fileShare = JSON.stringify({
           type: "Create",
           actor: { type: "Person", id: "alice", name: "Alice" },

--- a/extensions/nextcloud-talk/src/webhook-spool.test.ts
+++ b/extensions/nextcloud-talk/src/webhook-spool.test.ts
@@ -382,4 +382,44 @@ describe("Nextcloud Talk durable ingress", () => {
       }
     });
   });
+
+  it("records the non-outcome when acknowledging a non-message event", async () => {
+    await withQueue(async (queue) => {
+      const deliver = vi.fn();
+      const log = vi.fn();
+      const spool = createNextcloudTalkWebhookSpool({
+        accountId: "default",
+        queue,
+        deliver,
+        runtime: { error: vi.fn(), log },
+        pollIntervalMs: 60_000,
+        adoptionStallTimeoutMs: 5_000,
+        legacyReplayStore: null,
+      });
+      try {
+        // A file share arrives as a non-Note Create activity and is acked
+        // without a durable row; the drop must leave a visible log reason.
+        const fileShare = JSON.stringify({
+          type: "Create",
+          actor: { type: "Person", id: "alice", name: "Alice" },
+          object: {
+            type: "Document",
+            id: "file-1",
+            name: "report.pdf",
+            content: "",
+            mediaType: "application/pdf",
+          },
+          target: { type: "Collection", id: "room-1", name: "Room 1" },
+        });
+        await expect(spool.receive(fileShare)).resolves.toBe("ignored");
+        expect(log).toHaveBeenCalledWith(
+          "nextcloud-talk: ignored non-message webhook event (type=Create objectType=Document)",
+        );
+        expect(await queue.listPending({ limit: "all" })).toEqual([]);
+        expect(deliver).not.toHaveBeenCalled();
+      } finally {
+        await spool.stop();
+      }
+    });
+  });
 });

--- a/extensions/nextcloud-talk/src/webhook-spool.ts
+++ b/extensions/nextcloud-talk/src/webhook-spool.ts
@@ -30,17 +30,13 @@ import {
 
 const NEXTCLOUD_TALK_INGRESS_POLL_INTERVAL_MS = 500;
 
-/** Best-effort event identity for the ignored-event log; never throws. */
 function describeIgnoredWebhookEvent(rawEvent: string): string {
-  try {
-    const envelope = parseRawObject(rawEvent);
-    const type = typeof envelope.type === "string" ? envelope.type : "unknown";
-    const object = isRecord(envelope.object) ? envelope.object : null;
-    const objectType = typeof object?.type === "string" ? object.type : "unknown";
-    return `type=${type} objectType=${objectType}`;
-  } catch {
-    return "unparseable payload";
-  }
+  // Admission already parsed ignored envelopes; this read selects bounded log fields only.
+  const envelope = parseRawObject(rawEvent);
+  const type = typeof envelope.type === "string" ? envelope.type : "unknown";
+  const object = isRecord(envelope.object) ? envelope.object : null;
+  const objectType = typeof object?.type === "string" ? object.type : "unknown";
+  return `type=${type} objectType=${objectType}`;
 }
 
 const NextcloudTalkWebhookPayloadSchema: z.ZodType<NextcloudTalkWebhookPayload> = z.object({
@@ -228,9 +224,8 @@ export function createNextcloudTalkWebhookSpool(options: {
         await startAfterMigration;
         const result = await monitor.admit(rawEvent);
         if (result.kind === "ignored") {
-          // Non-message events (reactions, file-share Documents, system
-          // activities) are acknowledged without a durable row; record the
-          // non-outcome so an operator's shared file is never silently lost.
+          // These events are acknowledged without a durable row. Keep that intentional
+          // non-outcome visible without inventing message content for the agent.
           options.runtime.log?.(
             `nextcloud-talk: ignored non-message webhook event (${describeIgnoredWebhookEvent(rawEvent)})`,
           );

--- a/extensions/nextcloud-talk/src/webhook-spool.ts
+++ b/extensions/nextcloud-talk/src/webhook-spool.ts
@@ -29,6 +29,21 @@ import {
 
 const NEXTCLOUD_TALK_INGRESS_POLL_INTERVAL_MS = 500;
 
+/** Best-effort event identity for the ignored-event log; never throws. */
+function describeIgnoredWebhookEvent(rawEvent: string): string {
+  try {
+    const envelope = parseRawObject(rawEvent);
+    const object = envelope.object;
+    const objectType =
+      object !== null && typeof object === "object" && !Array.isArray(object)
+        ? (object as Record<string, unknown>).type
+        : undefined;
+    return `type=${String(envelope.type ?? "unknown")} objectType=${String(objectType ?? "unknown")}`;
+  } catch {
+    return "unparseable payload";
+  }
+}
+
 const NextcloudTalkWebhookPayloadSchema: z.ZodType<NextcloudTalkWebhookPayload> = z.object({
   type: z.enum(["Create", "Update", "Delete"]),
   actor: z.object({
@@ -213,7 +228,16 @@ export function createNextcloudTalkWebhookSpool(options: {
       const receiveTask = (async () => {
         await startAfterMigration;
         const result = await monitor.admit(rawEvent);
-        return result.kind === "ignored" ? "ignored" : "accepted";
+        if (result.kind === "ignored") {
+          // Non-message events (reactions, file-share Documents, system
+          // activities) are acknowledged without a durable row; record the
+          // non-outcome so an operator's shared file is never silently lost.
+          options.runtime.log?.(
+            `nextcloud-talk: ignored non-message webhook event (${describeIgnoredWebhookEvent(rawEvent)})`,
+          );
+          return "ignored";
+        }
+        return "accepted";
       })();
       inFlightReceives.add(receiveTask);
       void receiveTask.then(

--- a/extensions/nextcloud-talk/src/webhook-spool.ts
+++ b/extensions/nextcloud-talk/src/webhook-spool.ts
@@ -4,6 +4,7 @@ import {
   type ChannelIngressQueue,
   type ChannelIngressMonitorLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
+import { isRecord } from "openclaw/plugin-sdk/channel-secret-basic-runtime";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { resolvePersistentDedupePluginStateNamespace } from "openclaw/plugin-sdk/persistent-dedupe";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -33,12 +34,10 @@ const NEXTCLOUD_TALK_INGRESS_POLL_INTERVAL_MS = 500;
 function describeIgnoredWebhookEvent(rawEvent: string): string {
   try {
     const envelope = parseRawObject(rawEvent);
-    const object = envelope.object;
-    const objectType =
-      object !== null && typeof object === "object" && !Array.isArray(object)
-        ? (object as Record<string, unknown>).type
-        : undefined;
-    return `type=${String(envelope.type ?? "unknown")} objectType=${String(objectType ?? "unknown")}`;
+    const type = typeof envelope.type === "string" ? envelope.type : "unknown";
+    const object = isRecord(envelope.object) ? envelope.object : null;
+    const objectType = typeof object?.type === "string" ? object.type : "unknown";
+    return `type=${type} objectType=${objectType}`;
   } catch {
     return "unparseable payload";
   }


### PR DESCRIPTION
## What Problem This Solves

Nextcloud Talk had two silent non-outcomes:

1. Signed non-message webhooks, including file shares with `object.type: "Document"`, returned HTTP 200 but produced no durable row, agent turn, or operator log.
2. Messages whose normalized body was empty returned from inbound handling without an operator log.

Fixes #131005.

## Root Cause

`inspectNextcloudTalkWebhookEnvelope` intentionally returns no ingress facts for events that cannot become messages. The durable spool converted that result to `ignored` without logging it. The inbound handler had a separate bare return for empty normalized text.

## Fix

- Log ignored non-message events at the durable spool branch that owns the acknowledgement decision.
- Route empty-body messages through the existing `logInboundDrop` formatter.
- Preserve the transport contract: ignored events still return HTTP 200 without a durable marker, empty messages still send nothing, and no synthetic message content enters the agent.
- Correct the channel reference for ignored HTTP 200 responses.
- Remove `mediaMaxMb` from the docs and local account type because the strict plugin schema never accepted that key.

## Evidence

The same source-blind driver used the real local webhook server, HMAC-SHA256 verification, durable SQLite ingress queue, and inbound handler on both revisions.

| Scenario | Current main `e6efad25278f` | Repaired head `a0c49e877094` |
| --- | --- | --- |
| Signed `Create` / `Document` event | HTTP 200, no durable marker, no queue row, no delivery, no log | HTTP 200, no durable marker, no queue row, no delivery, ignored-event log with `type=Create objectType=Document` |
| Signed empty `Note` message | HTTP 200 with durable marker, queue completes, no send, no log | HTTP 200 with durable marker, queue completes, no send, empty-body drop log |

The anti-cheat checks bound each result to the exact Git revision, verified the signature path, inspected queue state, and required input-specific log details.

## Validation

- Regression tests on current main: exactly 2 missing-log assertions failed; 18 sibling assertions passed.
- Focused repaired tests: 24 passed.
- Full Nextcloud Talk plugin suite: 161 passed across 26 files.
- Targeted Oxfmt and Oxlint checks passed.
- Repository conflict, max-line, assertion-safety, coercion, deprecated-API, plugin-boundary, database-first, import-cycle, media-download, runtime-sidecar, and duplicate-coverage guards passed.
- Docs MDX, link, glossary, and formatting checks passed.
- Local build and typecheck were not run on this host; exact-head CI owns them.

## Review Surface

- Production TypeScript: +22 net.
- Tests and test support: +34 net.
- Documentation: -1 net.
- No new public API, configuration, persistence, protocol, dependency, or feature surface.

## Changelog Context

Nextcloud Talk now records why non-message webhook events and empty-body messages do not reach the agent, instead of acknowledging and dropping them silently.
