### PR TITLE
test(config): preserve native environment across provider tests

### DIFF
--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -564,29 +564,18 @@ describe("web search provider config", () => {
 });
 
 describe("web search provider auto-detection", () => {
-  const savedEnv = { ...process.env };
-
   beforeEach(() => {
-    delete process.env.BRAVE_API_KEY;
-    delete process.env.FIRECRAWL_API_KEY;
-    delete process.env.GEMINI_API_KEY;
-    delete process.env.KIMI_API_KEY;
-    delete process.env.MINIMAX_API_KEY;
-    delete process.env.MINIMAX_CODE_PLAN_KEY;
-    delete process.env.MINIMAX_CODING_API_KEY;
-    delete process.env.MINIMAX_OAUTH_TOKEN;
-    delete process.env.MOONSHOT_API_KEY;
-    delete process.env.PERPLEXITY_API_KEY;
-    delete process.env.OPENROUTER_API_KEY;
-    delete process.env.SEARXNG_BASE_URL;
-    delete process.env.TAVILY_API_KEY;
-    delete process.env.XAI_API_KEY;
-    delete process.env.KIMI_API_KEY;
-    delete process.env.MOONSHOT_API_KEY;
+    for (const provider of mockWebSearchProviders) {
+      for (const envVar of provider.envVars) {
+        vi.stubEnv(envVar, undefined);
+      }
+    }
   });
 
   afterEach(() => {
-    process.env = { ...savedEnv };
+    // Preserve Node's native env object: later workers in this shared fork
+    // must inherit fixture env changes, including OPENCLAW_STATE_DIR.
+    vi.unstubAllEnvs();
     vi.restoreAllMocks();
   });
 


### PR DESCRIPTION
## What Problem This Solves

The merge gate has been intermittently red today: `src/config/sessions/session-transcript-reconcile.lifecycle.test.ts` (added in #130185) fails with `expected 1 to be 2` at its lease-count assertion — three consecutive failures on one PR's run ([#130956](https://github.com/openclaw/openclaw/pull/130956), attempts 1-3), while other runs pass. The lifecycle test itself is correct; the failure is **execution-order contamination** from a different file in the same non-isolated fork.

Root cause: `src/config/config.web-search-provider.test.ts` restored env by **replacing the `process.env` object** (`process.env = { ...savedEnv }`, from 3a3c2da9168f). Node treats `new Worker()` env inheritance natively: `internal/worker` passes `null` to the native WorkerImpl when `env === process.env` — but after the object swap, later per-key changes (like the lifecycle fixture's `OPENCLAW_STATE_DIR` set via `withEnvAsync`) reach the parent's JS object and **not the native environment the worker inherits**. The reconcile worker then resolves the **default** test state dir, claims its agent-DB lease in `openclaw-test-state/<pid>-<workerId>/state/openclaw.sqlite`, and the lifecycle test's count — querying the fixture state DB — sees only the parent's lease. Direct row evidence: worker lease UUIDs found in the fallback state DB, parent lease intact in the fixture DB (refuting parent-closure, path-canonicalization, lease-retry, and WAL-timing theories). Vitest's per-key env snapshot/restore machinery cannot undo an untracked replacement of the native-backed object (`test/non-isolated-runner.ts:477`).

Why CI "randomly" failed: vitest's cold ordering favors larger files, so the provider test often (not always) runs before the lifecycle test in the runtime-config fork. Running the pair in that order reproduces both failures deterministically on macOS and Linux.

## Why This Change Was Made

Fix at the producer, per the repo's tracked-env doctrine: the provider test now stubs its fixture providers' declared env keys individually with `vi.stubEnv` and restores with `vi.unstubAllEnvs` — never replacing the native env object. Reusing the existing provider fixture removes duplicated key inventory (net **−11** test lines). A comment records the cross-file worker-inheritance invariant. No production, lease-lifecycle, isolation-flag, sleep, or assertion-tolerance changes; the lifecycle test's assertions are untouched and remain the regression oracle when run after the former contamination producer.

## User Impact

None at runtime (test-only). Restores a reliably green core-runtime-config shard for every PR.

## Evidence

- Failing-first (unchanged source, ordered pair, one serial fork): macOS Node 26.5.0 — provider 33 pass, lifecycle **2 fail** at the exact CI assertion (line 176); same result with `--no-cache` and under Node 24. Containerized Linux (node:24-bookworm, aarch64, read-only source mount, isolated native esbuild/rolldown binaries, no remote lease): **33 pass / 2 fail** with the identical assertion.
- Post-fix: ordered pair **35/35** on macOS and Linux; broader sweep **1,042/1,042 tests across 92 files** (all session test files + the provider test) in one non-isolated serial fork. Re-verified 35/35 on the rebased head 4f537763ecb.
- Direct Node inspection: `internal/worker` env selection semantics confirmed on installed Node 26 and Linux Node 24.19.0; vitest 4.1.11 env proxy forwards per-key changes only.
- `check-changed` and Codex autoreview: pass, no findings.
- LOC: production 0; tests +8/−19 (net −11).
