### PR TITLE
refactor(channels): consolidate account logout cleanup

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -619,7 +619,7 @@ extensions/line/src/flex-templates/basic-cards.ts	19
 extensions/line/src/flex-templates/common.ts	2
 extensions/line/src/flex-templates/media-control-cards.ts	35
 extensions/line/src/flex-templates/schedule-cards.ts	28
-extensions/line/src/gateway.ts	4
+extensions/line/src/gateway.ts	1
 extensions/line/src/group-keys.ts	1
 extensions/line/src/markdown-to-line.ts	7
 extensions/line/src/monitor-durable.ts	1
@@ -878,7 +878,7 @@ extensions/mxc/src/fs-bridge.ts	1
 extensions/nextcloud-talk/src/approval-auth.ts	1
 extensions/nextcloud-talk/src/channel.ts	2
 extensions/nextcloud-talk/src/doctor.ts	2
-extensions/nextcloud-talk/src/gateway.ts	8
+extensions/nextcloud-talk/src/gateway.ts	2
 extensions/nextcloud-talk/src/inbound.ts	9
 extensions/nextcloud-talk/src/message-actions.ts	3
 extensions/nextcloud-talk/src/message-adapter.ts	2
@@ -1267,7 +1267,6 @@ extensions/telegram/src/bot/delivery.resolve-media.ts	1
 extensions/telegram/src/bot/helpers.ts	2
 extensions/telegram/src/callback-query-answer-state.ts	1
 extensions/telegram/src/channel-actions.ts	1
-extensions/telegram/src/channel.ts	1
 extensions/telegram/src/client-fetch.ts	5
 extensions/telegram/src/doctor-contract.ts	3
 extensions/telegram/src/doctor.ts	12

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -939,6 +939,19 @@ unrelated inbound runtime helpers.
 
     For channels that accept both canonical top-level DM keys and legacy nested keys, use the helpers from `plugin-sdk/channel-config-helpers`: `resolveChannelDmAccess`, `resolveChannelDmPolicy`, `resolveChannelDmAllowFrom`, and `normalizeChannelDmPolicy` keep account-local values ahead of inherited root values. Pair the same resolver with doctor repair through `normalizeLegacyDmAliases` so runtime and migration read the same contract.
 
+    Config-backed logout handlers can use `clearAccountFieldsFromConfigSection`
+    from `openclaw/plugin-sdk/channel-config-helpers`. Pass `cfg`, `sectionKey`,
+    `accountId`, and the plugin-owned `fields` to remove. It returns
+    `{ nextConfig, changed, cleared }` without writing config or resolving
+    credentials. Root fields clear together only for the exact `default` account
+    when at least one value is truthy. Nested fields use `clearAccountEntryFields`
+    semantics: an empty account ID selects `accounts.default`, and empty or
+    whitespace strings are removed without reporting `cleared` unless
+    `markClearedOnFieldPresence: true` is set. Unchanged config retains its object
+    identity; cleanup prunes only branches it changes. Keep file-reference
+    selection, persistence, environment reporting, and other logout side effects
+    in the plugin.
+
     If a channel intentionally applies stricter DM session routing than the
     global config, expose that behavior through `security.dmRouting` so Doctor
     and security audit resolve the same session owner as runtime. The optional

--- a/extensions/line/src/channel.logout.test.ts
+++ b/extensions/line/src/channel.logout.test.ts
@@ -1,90 +1,52 @@
 // Line tests cover channel.logout plugin behavior.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OpenClawConfig, PluginRuntime, ResolvedLineAccount } from "../api.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../api.js";
+import { resolveLineAccount } from "./accounts.js";
 import { lineGatewayAdapter } from "./gateway.js";
 import { setLineRuntime } from "./runtime.js";
 
 const DEFAULT_ACCOUNT_ID = "default";
+let tempDir: string;
 
-type LineRuntimeMocks = {
-  replaceConfigFile: ReturnType<typeof vi.fn>;
-  resolveLineAccount: ReturnType<typeof vi.fn>;
-};
-
-function createRuntime(): { runtime: PluginRuntime; mocks: LineRuntimeMocks } {
-  const replaceConfigFile = vi.fn(async () => {});
-  const resolveLineAccount = vi.fn(
-    ({ cfg, accountId }: { cfg: OpenClawConfig; accountId?: string }) => {
-      const lineConfig = (cfg.channels?.line ?? {}) as {
-        tokenFile?: string;
-        secretFile?: string;
-        channelAccessToken?: string;
-        channelSecret?: string;
-        accounts?: Record<string, Record<string, unknown>>;
-      };
-      const entry =
-        accountId && accountId !== DEFAULT_ACCOUNT_ID
-          ? (lineConfig.accounts?.[accountId] ?? {})
-          : lineConfig;
-      const credentials = entry as {
-        channelAccessToken?: unknown;
-        channelSecret?: unknown;
-        secretFile?: unknown;
-        tokenFile?: unknown;
-      };
-      const hasToken = Boolean(credentials.channelAccessToken) || Boolean(credentials.tokenFile);
-      const hasSecret = Boolean(credentials.channelSecret) || Boolean(credentials.secretFile);
-      return { tokenSource: hasToken && hasSecret ? "config" : "none" };
-    },
-  );
-
-  const runtime = {
-    config: { replaceConfigFile },
-  } as unknown as PluginRuntime;
-
-  return { runtime, mocks: { replaceConfigFile, resolveLineAccount } };
-}
-
-function resolveAccount(
-  resolveLineAccount: LineRuntimeMocks["resolveLineAccount"],
-  cfg: OpenClawConfig,
-  accountId: string,
-): ResolvedLineAccount {
-  const resolver = resolveLineAccount as unknown as (params: {
-    cfg: OpenClawConfig;
-    accountId?: string;
-  }) => ResolvedLineAccount;
-  return resolver({ cfg, accountId });
-}
-
-async function runLogoutScenario(params: { cfg: OpenClawConfig; accountId: string }): Promise<{
-  result: Awaited<ReturnType<NonNullable<typeof lineGatewayAdapter.logoutAccount>>>;
-  mocks: LineRuntimeMocks;
-}> {
-  const { runtime, mocks } = createRuntime();
+async function runLogoutScenario(params: { cfg: OpenClawConfig; accountId: string }) {
+  const original = structuredClone(params.cfg);
+  const runtime = createPluginRuntimeMock();
   setLineRuntime(runtime);
-  const account = resolveAccount(mocks.resolveLineAccount, params.cfg, params.accountId);
   const result = await lineGatewayAdapter.logoutAccount!({
     accountId: params.accountId,
     cfg: params.cfg,
-    account,
+    account: resolveLineAccount(params),
     runtime: createRuntimeEnv(),
   });
-  return { result, mocks };
+  expect(params.cfg).toEqual(original);
+  return { result, mocks: { replaceConfigFile: vi.mocked(runtime.config.replaceConfigFile) } };
 }
 
 describe("linePlugin gateway.logoutAccount", () => {
-  beforeEach(() => {
-    setLineRuntime(createRuntime().runtime);
+  beforeEach(async () => {
+    vi.stubEnv("LINE_CHANNEL_ACCESS_TOKEN", "");
+    vi.stubEnv("LINE_CHANNEL_SECRET", "");
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-line-logout-"));
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await fs.rm(tempDir, { recursive: true, force: true });
   });
 
   it("clears tokenFile/secretFile on default account logout", async () => {
     const cfg: OpenClawConfig = {
       channels: {
         line: {
-          tokenFile: "/tmp/token",
-          secretFile: "/tmp/secret",
+          channelAccessToken: "",
+          channelSecret: "",
+          tokenFile: path.join(tempDir, "token"),
+          secretFile: path.join(tempDir, "secret"),
         },
       },
     };
@@ -107,8 +69,8 @@ describe("linePlugin gateway.logoutAccount", () => {
         line: {
           accounts: {
             primary: {
-              tokenFile: "/tmp/token",
-              secretFile: "/tmp/secret",
+              tokenFile: path.join(tempDir, "token"),
+              secretFile: path.join(tempDir, "secret"),
             },
           },
         },
@@ -147,5 +109,46 @@ describe("linePlugin gateway.logoutAccount", () => {
     expect(result.cleared).toBe(false);
     expect(result.loggedOut).toBe(true);
     expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("counts empty named credential fields as cleared and preserves sibling config", async () => {
+    const sibling = { channelAccessToken: "keep-token", name: "Other" };
+    const cfg: OpenClawConfig = {
+      channels: {
+        line: {
+          name: "LINE",
+          accounts: {
+            primary: {
+              channelAccessToken: "",
+              channelSecret: "",
+              tokenFile: "",
+              secretFile: "",
+              name: "Primary",
+            },
+            other: sibling,
+          },
+        },
+        telegram: { enabled: false },
+      },
+    };
+    const { result, mocks } = await runLogoutScenario({ cfg, accountId: "primary" });
+
+    expect(result).toEqual({
+      cleared: true,
+      envToken: false,
+      loggedOut: true,
+    });
+    expect(mocks.replaceConfigFile).toHaveBeenCalledExactlyOnceWith({
+      nextConfig: {
+        channels: {
+          line: {
+            name: "LINE",
+            accounts: { primary: { name: "Primary" }, other: sibling },
+          },
+          telegram: { enabled: false },
+        },
+      },
+      afterWrite: { mode: "auto" },
+    });
   });
 });

--- a/extensions/line/src/gateway.ts
+++ b/extensions/line/src/gateway.ts
@@ -1,13 +1,11 @@
 // Line plugin module implements gateway behavior.
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
-import type { PluginRuntime } from "openclaw/plugin-sdk/channel-core";
+import { clearAccountFieldsFromConfigSection } from "openclaw/plugin-sdk/channel-config-helpers";
+import type { ChannelPlugin, PluginRuntime } from "openclaw/plugin-sdk/channel-core";
 import { createAccountStatusSink } from "openclaw/plugin-sdk/channel-outbound";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { clearAccountEntryFields, type ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveLineAccount } from "./accounts.js";
 import { getLineRuntime } from "./runtime.js";
-import type { LineConfig, ResolvedLineAccount } from "./types.js";
+import type { ResolvedLineAccount } from "./types.js";
 
 const loadLineProbeRuntime = createLazyRuntimeModule(() => import("./probe.runtime.js"));
 const loadLineMonitorRuntime = createLazyRuntimeModule(() => import("./monitor.runtime.js"));
@@ -67,66 +65,22 @@ export const lineGatewayAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>[
   },
   logoutAccount: async ({ accountId, cfg }) => {
     const envToken = process.env.LINE_CHANNEL_ACCESS_TOKEN?.trim() ?? "";
-    const nextCfg = { ...cfg } as OpenClawConfig;
-    const lineConfig = (cfg.channels?.line ?? {}) as LineConfig;
-    const nextLine = { ...lineConfig };
-    let cleared = false;
-    let changed = false;
-
-    if (accountId === DEFAULT_ACCOUNT_ID) {
-      if (
-        nextLine.channelAccessToken ||
-        nextLine.channelSecret ||
-        nextLine.tokenFile ||
-        nextLine.secretFile
-      ) {
-        delete nextLine.channelAccessToken;
-        delete nextLine.channelSecret;
-        delete nextLine.tokenFile;
-        delete nextLine.secretFile;
-        cleared = true;
-        changed = true;
-      }
-    }
-
-    const accountCleanup = clearAccountEntryFields({
-      accounts: nextLine.accounts,
+    const { nextConfig, changed, cleared } = clearAccountFieldsFromConfigSection({
+      cfg,
+      sectionKey: "line",
       accountId,
       fields: ["channelAccessToken", "channelSecret", "tokenFile", "secretFile"],
       markClearedOnFieldPresence: true,
     });
-    if (accountCleanup.changed) {
-      changed = true;
-      if (accountCleanup.cleared) {
-        cleared = true;
-      }
-      if (accountCleanup.nextAccounts) {
-        nextLine.accounts = accountCleanup.nextAccounts;
-      } else {
-        delete nextLine.accounts;
-      }
-    }
-
     if (changed) {
-      if (Object.keys(nextLine).length > 0) {
-        nextCfg.channels = { ...nextCfg.channels, line: nextLine };
-      } else {
-        const nextChannels = { ...nextCfg.channels };
-        delete (nextChannels as Record<string, unknown>).line;
-        if (Object.keys(nextChannels).length > 0) {
-          nextCfg.channels = nextChannels;
-        } else {
-          delete nextCfg.channels;
-        }
-      }
       await getLineRuntime().config.replaceConfigFile({
-        nextConfig: nextCfg,
+        nextConfig,
         afterWrite: { mode: "auto" },
       });
     }
 
     const resolved = resolveLineAccount({
-      cfg: changed ? nextCfg : cfg,
+      cfg: nextConfig,
       accountId,
     });
     const loggedOut = resolved.tokenSource === "none";

--- a/extensions/nextcloud-talk/src/channel-api.ts
+++ b/extensions/nextcloud-talk/src/channel-api.ts
@@ -1,6 +1,4 @@
 // Nextcloud Talk API module exposes the plugin public contract.
 export type { ChannelPlugin } from "openclaw/plugin-sdk/channel-plugin-common";
-export type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-export { clearAccountEntryFields } from "openclaw/plugin-sdk/channel-plugin-common";
 export { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 export { buildChannelConfigSchema } from "openclaw/plugin-sdk/channel-config-schema";

--- a/extensions/nextcloud-talk/src/gateway.logout.test.ts
+++ b/extensions/nextcloud-talk/src/gateway.logout.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveNextcloudTalkAccount } from "./accounts.js";
+import { nextcloudTalkGatewayAdapter } from "./gateway.js";
+import { setNextcloudTalkRuntime } from "./runtime.js";
+import type { CoreConfig } from "./types.js";
+
+let tempDir: string;
+
+beforeEach(async () => {
+  vi.stubEnv("NEXTCLOUD_TALK_BOT_SECRET", "");
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-nextcloud-logout-"));
+});
+
+afterEach(async () => {
+  vi.unstubAllEnvs();
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+async function logout(cfg: OpenClawConfig & CoreConfig, accountId: string) {
+  const original = structuredClone(cfg);
+  const runtime = createPluginRuntimeMock();
+  setNextcloudTalkRuntime(runtime);
+  const result = await nextcloudTalkGatewayAdapter.logoutAccount!({
+    cfg,
+    accountId,
+    account: resolveNextcloudTalkAccount({ cfg, accountId }),
+    runtime: createRuntimeEnv(),
+  });
+  expect(cfg).toEqual(original);
+  return { result, write: vi.mocked(runtime.config.replaceConfigFile) };
+}
+
+describe("Nextcloud Talk logout", () => {
+  it.each(["default", "primary"])(
+    "preserves file credentials and other accounts for %s",
+    async (accountId) => {
+      const remaining = {
+        baseUrl: "https://cloud.example.com",
+        botSecretFile: path.join(tempDir, "secret"),
+        apiUser: "api-user",
+        apiPassword: "api-password",
+        apiPasswordFile: path.join(tempDir, "api-password"),
+        name: "Keep",
+      };
+      const account = { ...remaining, botSecret: "remove" };
+      const other = { botSecret: "keep", name: "Other" };
+      const cfg: OpenClawConfig & CoreConfig = {
+        channels: {
+          "nextcloud-talk":
+            accountId === "default"
+              ? { ...account, accounts: { other } }
+              : { accounts: { primary: account, other } },
+          telegram: { enabled: false },
+        },
+      };
+      const { result, write } = await logout(cfg, accountId);
+      expect(result).toEqual({ cleared: true, envSecret: false, loggedOut: false });
+      expect(write).toHaveBeenCalledExactlyOnceWith({
+        nextConfig: {
+          channels: {
+            "nextcloud-talk":
+              accountId === "default"
+                ? { ...remaining, accounts: { other } }
+                : { accounts: { primary: remaining, other } },
+            telegram: { enabled: false },
+          },
+        },
+        afterWrite: { mode: "auto" },
+      });
+    },
+  );
+});

--- a/extensions/nextcloud-talk/src/gateway.ts
+++ b/extensions/nextcloud-talk/src/gateway.ts
@@ -1,15 +1,11 @@
 // Nextcloud Talk plugin module implements gateway behavior.
+import { clearAccountFieldsFromConfigSection } from "openclaw/plugin-sdk/channel-config-helpers";
 import {
   createAccountStatusSink,
   runPassiveAccountLifecycle,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { resolveNextcloudTalkAccount, type ResolvedNextcloudTalkAccount } from "./accounts.js";
-import {
-  clearAccountEntryFields,
-  DEFAULT_ACCOUNT_ID,
-  type ChannelPlugin,
-  type OpenClawConfig,
-} from "./channel-api.js";
+import type { ChannelPlugin } from "./channel-api.js";
 import { monitorNextcloudTalkProvider } from "./monitor-runtime.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
 import type { CoreConfig } from "./types.js";
@@ -48,60 +44,22 @@ export const nextcloudTalkGatewayAdapter: NonNullable<
     });
   },
   logoutAccount: async ({ accountId, cfg }) => {
-    const nextCfg = { ...cfg } as OpenClawConfig;
-    const nextSection = cfg.channels?.["nextcloud-talk"]
-      ? { ...cfg.channels["nextcloud-talk"] }
-      : undefined;
-    let cleared = false;
-    let changed = false;
-
-    if (nextSection) {
-      if (accountId === DEFAULT_ACCOUNT_ID && nextSection.botSecret) {
-        delete nextSection.botSecret;
-        cleared = true;
-        changed = true;
-      }
-      const accountCleanup = clearAccountEntryFields({
-        accounts: nextSection.accounts as Record<string, object> | undefined,
-        accountId,
-        fields: ["botSecret"],
-      });
-      if (accountCleanup.changed) {
-        changed = true;
-        if (accountCleanup.cleared) {
-          cleared = true;
-        }
-        if (accountCleanup.nextAccounts) {
-          nextSection.accounts = accountCleanup.nextAccounts as Record<string, unknown>;
-        } else {
-          delete nextSection.accounts;
-        }
-      }
-    }
-
-    if (changed) {
-      if (nextSection && Object.keys(nextSection).length > 0) {
-        nextCfg.channels = { ...nextCfg.channels, "nextcloud-talk": nextSection };
-      } else {
-        const nextChannels = { ...nextCfg.channels } as Record<string, unknown>;
-        delete nextChannels["nextcloud-talk"];
-        if (Object.keys(nextChannels).length > 0) {
-          nextCfg.channels = nextChannels as OpenClawConfig["channels"];
-        } else {
-          delete nextCfg.channels;
-        }
-      }
-    }
+    const { nextConfig, changed, cleared } = clearAccountFieldsFromConfigSection({
+      cfg,
+      sectionKey: "nextcloud-talk",
+      accountId,
+      fields: ["botSecret"],
+    });
 
     const resolved = resolveNextcloudTalkAccount({
-      cfg: changed ? (nextCfg as CoreConfig) : (cfg as CoreConfig),
+      cfg: nextConfig as CoreConfig,
       accountId,
     });
     const loggedOut = resolved.secretSource === "none";
 
     if (changed) {
       await getNextcloudTalkRuntime().config.replaceConfigFile({
-        nextConfig: nextCfg,
+        nextConfig,
         afterWrite: { mode: "auto" },
       });
     }

--- a/extensions/telegram/src/channel.gateway.test.ts
+++ b/extensions/telegram/src/channel.gateway.test.ts
@@ -1,12 +1,15 @@
 // Telegram tests cover channel.gateway plugin behavior.
-import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import {
   createPluginRuntimeMock,
   createStartAccountContext,
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  createPluginStateKeyedStoreForTests,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { createOpenClawTestState, type OpenClawTestState } from "openclaw/plugin-sdk/test-state";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { readCachedTelegramBotInfo, writeCachedTelegramBotInfo } from "./bot-info-cache.js";
 import type { TelegramBotInfo } from "./bot-info.js";
@@ -24,7 +27,7 @@ import { withTelegramStartupProbeSlot } from "./startup-probe-limiter.js";
 const probeTelegram = vi.fn();
 const monitorTelegramProvider = vi.fn();
 const sendMessageTelegram = vi.fn();
-const tempRoots: string[] = [];
+let testState: OpenClawTestState;
 
 const startupBotInfo: TelegramBotInfo = {
   id: 123456,
@@ -42,94 +45,11 @@ const startupBotInfo: TelegramBotInfo = {
   allows_users_to_create_topics: false,
 };
 
-async function useTempStateDir(): Promise<string> {
-  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tg-channel-"));
-  tempRoots.push(stateDir);
-  vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
-  return stateDir;
-}
-
-type MemoryPluginStateEntry<T> = { key: string; value: T; createdAt: number; expiresAt?: number };
-
-function createMemoryPluginStateStore<T>(
-  maxEntries: number,
-  defaultTtlMs: number | undefined,
-  entries: Map<string, MemoryPluginStateEntry<unknown>>,
-) {
-  type Entry = { key: string; value: T; createdAt: number; expiresAt?: number };
-  const typedEntries = entries as Map<string, Entry>;
-  const readEntry = (key: string): Entry | undefined => {
-    const entry = typedEntries.get(key);
-    if (!entry) {
-      return undefined;
-    }
-    if (entry.expiresAt !== undefined && entry.expiresAt <= Date.now()) {
-      typedEntries.delete(key);
-      return undefined;
-    }
-    return entry;
-  };
-  const writeEntry = (key: string, value: T, opts?: { ttlMs?: number }): void => {
-    const createdAt = Date.now();
-    const entry: Entry = { key, value, createdAt };
-    const ttlMs = opts?.ttlMs ?? defaultTtlMs;
-    if (ttlMs !== undefined) {
-      entry.expiresAt = createdAt + ttlMs;
-    }
-    typedEntries.set(key, entry);
-    while (typedEntries.size > maxEntries) {
-      const oldestKey = typedEntries.keys().next().value;
-      if (oldestKey === undefined) {
-        break;
-      }
-      typedEntries.delete(oldestKey);
-    }
-  };
-  return {
-    async register(key: string, value: T, opts?: { ttlMs?: number }) {
-      writeEntry(key, value, opts);
-    },
-    async registerIfAbsent(key: string, value: T, opts?: { ttlMs?: number }) {
-      if (readEntry(key)) {
-        return false;
-      }
-      writeEntry(key, value, opts);
-      return true;
-    },
-    async lookup(key: string) {
-      return readEntry(key)?.value;
-    },
-    async consume(key: string) {
-      const value = readEntry(key)?.value;
-      typedEntries.delete(key);
-      return value;
-    },
-    async delete(key: string) {
-      return typedEntries.delete(key);
-    },
-    async entries() {
-      return [...typedEntries.keys()]
-        .map((key) => readEntry(key))
-        .filter((entry): entry is Entry => Boolean(entry));
-    },
-    async clear() {
-      typedEntries.clear();
-    },
-  };
-}
-
 function installTelegramRuntime() {
-  const keyedStores = new Map<string, Map<string, MemoryPluginStateEntry<unknown>>>();
   const runtime = createPluginRuntimeMock({
     state: {
-      openKeyedStore: ((options) => {
-        let entries = keyedStores.get(options.namespace);
-        if (!entries) {
-          entries = new Map();
-          keyedStores.set(options.namespace, entries);
-        }
-        return createMemoryPluginStateStore(options.maxEntries, options.defaultTtlMs, entries);
-      }) as TelegramRuntime["state"]["openKeyedStore"],
+      openKeyedStore: <T>(options: Parameters<TelegramRuntime["state"]["openKeyedStore"]>[0]) =>
+        createPluginStateKeyedStoreForTests<T>("telegram", { ...options, env: testState.env }),
     },
   });
   const telegramRuntime = {
@@ -256,8 +176,10 @@ async function releaseStartupProbeControls(releaseProbe: Array<() => void>) {
   }
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.useRealTimers();
+  resetPluginStateStoreForTests();
+  testState = await createOpenClawTestState({ label: "telegram-channel" });
 });
 
 afterEach(async () => {
@@ -267,10 +189,9 @@ afterEach(async () => {
   probeTelegram.mockReset();
   monitorTelegramProvider.mockReset();
   sendMessageTelegram.mockReset();
+  resetPluginStateStoreForTests();
   vi.unstubAllEnvs();
-  await Promise.all(
-    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
-  );
+  await testState.cleanup();
 });
 
 describe("telegramPlugin gateway startup", () => {
@@ -421,7 +342,6 @@ describe("telegramPlugin gateway startup", () => {
   });
 
   it("caches successful startup probe botInfo for later restarts", async () => {
-    await useTempStateDir();
     installTelegramRuntime();
     probeTelegram.mockResolvedValue({
       ok: true,
@@ -448,7 +368,6 @@ describe("telegramPlugin gateway startup", () => {
   });
 
   it("refreshes cached startup botInfo before monitor startup", async () => {
-    await useTempStateDir();
     installTelegramRuntime();
     const refreshedBotInfo = {
       ...startupBotInfo,
@@ -487,7 +406,6 @@ describe("telegramPlugin gateway startup", () => {
   });
 
   it("falls back to cached startup botInfo when refresh fails without auth failure", async () => {
-    await useTempStateDir();
     installTelegramRuntime();
     await writeCachedTelegramBotInfo({
       accountId: "ops",
@@ -510,7 +428,6 @@ describe("telegramPlugin gateway startup", () => {
   });
 
   it("deletes cached startup botInfo when the account token changes", async () => {
-    await useTempStateDir();
     installTelegramRuntime();
     await writeCachedTelegramBotInfo({
       accountId: "ops",
@@ -534,7 +451,6 @@ describe("telegramPlugin gateway startup", () => {
   });
 
   it("keeps cached startup botInfo when unrelated Telegram config changes", async () => {
-    await useTempStateDir();
     installTelegramRuntime();
     await writeCachedTelegramBotInfo({
       accountId: "ops",
@@ -558,7 +474,6 @@ describe("telegramPlugin gateway startup", () => {
   });
 
   it("deletes cached startup botInfo when the account is removed", async () => {
-    await useTempStateDir();
     installTelegramRuntime();
     await writeCachedTelegramBotInfo({
       accountId: "ops",
@@ -581,9 +496,10 @@ describe("telegramPlugin gateway startup", () => {
   });
 
   it("deletes cached startup botInfo when logout clears the account token", async () => {
-    await useTempStateDir();
-    installTelegramRuntime();
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    const runtime = installTelegramRuntime();
     const cfg = createTelegramConfig("ops");
+    const original = structuredClone(cfg);
     const account = telegramPlugin.config.resolveAccount(cfg, "ops");
     await writeCachedTelegramBotInfo({
       accountId: "ops",
@@ -591,19 +507,63 @@ describe("telegramPlugin gateway startup", () => {
       botInfo: startupBotInfo,
     });
 
-    await telegramPlugin.gateway?.logoutAccount?.({
+    const result = await telegramPlugin.gateway?.logoutAccount?.({
       accountId: "ops",
       account,
       cfg,
       runtime: createRuntimeEnvMock(),
     });
 
+    expect(result).toEqual({ cleared: true, envToken: false, loggedOut: true });
+    expect(runtime.config.replaceConfigFile).toHaveBeenCalledExactlyOnceWith({
+      nextConfig: {},
+      afterWrite: { mode: "auto" },
+    });
+    expect(cfg).toEqual(original);
     await expect(
       readCachedTelegramBotInfo({
         accountId: "ops",
         botToken: "123456:bad-token",
       }),
     ).resolves.toBeNull();
+  });
+
+  it("preserves token files and sibling config when logout clears an inline token", async () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
+    const stateDir = testState.stateDir;
+    const runtime = installTelegramRuntime();
+    const remaining = { tokenFile: path.join(stateDir, "missing-token"), name: "Ops" };
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          botToken: "root-token",
+          accounts: { ops: { ...remaining, botToken: "remove" }, other: { botToken: "keep" } },
+        },
+        line: { enabled: false },
+      },
+    };
+    const original = structuredClone(cfg);
+    const result = await telegramPlugin.gateway?.logoutAccount?.({
+      accountId: "ops",
+      account: telegramPlugin.config.resolveAccount(cfg, "ops"),
+      cfg,
+      runtime: createRuntimeEnvMock(),
+    });
+
+    expect(result).toEqual({ cleared: true, envToken: false, loggedOut: false });
+    expect(runtime.config.replaceConfigFile).toHaveBeenCalledExactlyOnceWith({
+      nextConfig: {
+        channels: {
+          telegram: {
+            botToken: "root-token",
+            accounts: { ops: remaining, other: { botToken: "keep" } },
+          },
+          line: { enabled: false },
+        },
+      },
+      afterWrite: { mode: "auto" },
+    });
+    expect(cfg).toEqual(original);
   });
 
   it("uses the built-in startup probe timeout", async () => {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -4,10 +4,10 @@ import {
   buildDmGroupAccountAllowlistAdapter,
   createNestedAllowlistOverrideResolver,
 } from "openclaw/plugin-sdk/allowlist-config-edit";
+import { clearAccountFieldsFromConfigSection } from "openclaw/plugin-sdk/channel-config-helpers";
 import {
   buildChannelOutboundSessionRoute,
   buildThreadAwareOutboundSessionRoute,
-  clearAccountEntryFields,
   createChatChannelPlugin,
 } from "openclaw/plugin-sdk/channel-core";
 import {
@@ -1155,54 +1155,20 @@ export const telegramPlugin = createChatChannelPlugin({
       },
       logoutAccount: async ({ accountId, cfg }) => {
         const envToken = process.env.TELEGRAM_BOT_TOKEN?.trim() ?? "";
-        const nextCfg = { ...cfg } as OpenClawConfig;
-        const nextTelegram = cfg.channels?.telegram ? { ...cfg.channels.telegram } : undefined;
-        let cleared = false;
-        let changed = false;
-        if (nextTelegram) {
-          if (accountId === DEFAULT_ACCOUNT_ID && nextTelegram.botToken) {
-            delete nextTelegram.botToken;
-            cleared = true;
-            changed = true;
-          }
-          const accountCleanup = clearAccountEntryFields({
-            accounts: nextTelegram.accounts,
-            accountId,
-            fields: ["botToken"],
-          });
-          if (accountCleanup.changed) {
-            changed = true;
-            if (accountCleanup.cleared) {
-              cleared = true;
-            }
-            if (accountCleanup.nextAccounts) {
-              nextTelegram.accounts = accountCleanup.nextAccounts;
-            } else {
-              delete nextTelegram.accounts;
-            }
-          }
-        }
-        if (changed) {
-          if (nextTelegram && Object.keys(nextTelegram).length > 0) {
-            nextCfg.channels = { ...nextCfg.channels, telegram: nextTelegram };
-          } else {
-            const nextChannels = { ...nextCfg.channels };
-            delete nextChannels.telegram;
-            if (Object.keys(nextChannels).length > 0) {
-              nextCfg.channels = nextChannels;
-            } else {
-              delete nextCfg.channels;
-            }
-          }
-        }
+        const { nextConfig, changed, cleared } = clearAccountFieldsFromConfigSection({
+          cfg,
+          sectionKey: "telegram",
+          accountId,
+          fields: ["botToken"],
+        });
         const resolved = resolveTelegramAccount({
-          cfg: changed ? nextCfg : cfg,
+          cfg: nextConfig,
           accountId,
         });
         const loggedOut = resolved.tokenSource === "none";
         if (changed) {
           await getTelegramRuntime().config.replaceConfigFile({
-            nextConfig: nextCfg,
+            nextConfig,
             afterWrite: { mode: "auto" },
           });
         }

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -320,7 +320,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: exact-session deletion parameters and synchronous companion mutation contract.
       // +2: canonical session-model selection and auxiliary runtime-auth preparation.
       // +1: identifier authentication input type for external channel plugins.
-      4346,
+      // +1: shared channel-account logout config cleanup.
+      4347,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -417,7 +418,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       //     (exec-approval-text-sanitize) to break the exec-approvals cycle.
       // +2: bounded ask_user owner-order map builder and option resolver.
       // +2: canonical session-model selection and auxiliary runtime-auth preparation.
-      2582,
+      // +1: shared channel-account logout config cleanup.
+      2583,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/channels/plugins/config-helpers.test.ts
+++ b/src/channels/plugins/config-helpers.test.ts
@@ -1,6 +1,7 @@
 // Config helper tests cover channel plugin config merge and selection helpers.
 import { describe, expect, it } from "vitest";
-import { clearAccountEntryFields } from "./config-helpers.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { clearAccountEntryFields, clearAccountFieldsFromConfigSection } from "./config-helpers.js";
 
 describe("clearAccountEntryFields", () => {
   it("clears configured values and removes empty account entries", () => {
@@ -107,5 +108,84 @@ describe("clearAccountEntryFields", () => {
       changed: false,
       cleared: false,
     });
+  });
+});
+
+describe("clearAccountFieldsFromConfigSection", () => {
+  function clear(cfg: OpenClawConfig, accountId = "default", markClearedOnFieldPresence = false) {
+    const original = structuredClone(cfg);
+    const result = clearAccountFieldsFromConfigSection({
+      cfg,
+      sectionKey: "sample",
+      accountId,
+      fields: ["token", "secret"],
+      markClearedOnFieldPresence,
+    });
+    expect(cfg).toEqual(original);
+    return result;
+  }
+
+  it.each(["token", "   ", { source: "env", provider: "default", id: "SAMPLE_TOKEN" }])(
+    "clears the entire root field group for truthy value %j",
+    (token) => {
+      const cfg: OpenClawConfig = {
+        channels: {
+          sample: { token, secret: "", accounts: {}, name: "Keep" },
+          other: { enabled: false },
+        },
+      };
+      expect(clear(cfg)).toEqual({
+        nextConfig: {
+          channels: { sample: { accounts: {}, name: "Keep" }, other: { enabled: false } },
+        },
+        changed: true,
+        cleared: true,
+      });
+    },
+  );
+
+  it.each([false, true])(
+    "preserves nested field-presence reporting with mode %s",
+    (markClearedOnFieldPresence) => {
+      const sibling = { token: "keep" };
+      const cfg: OpenClawConfig = {
+        channels: {
+          sample: { accounts: { primary: { token: "   ", secret: "", name: "Keep" }, sibling } },
+        },
+      };
+      expect(clear(cfg, "primary", markClearedOnFieldPresence)).toEqual({
+        nextConfig: { channels: { sample: { accounts: { primary: { name: "Keep" }, sibling } } } },
+        changed: true,
+        cleared: markClearedOnFieldPresence,
+      });
+    },
+  );
+
+  it("normalizes an empty nested account id without clearing root fields", () => {
+    const cfg: OpenClawConfig = {
+      channels: { sample: { token: "root", accounts: { default: { token: "nested" } } } },
+    };
+    expect(clear(cfg, "")).toEqual({
+      nextConfig: { channels: { sample: { token: "root" } } },
+      changed: true,
+      cleared: true,
+    });
+  });
+
+  it.each([
+    {},
+    { channels: {} },
+    { channels: { sample: { accounts: {} } } },
+    { channels: { sample: { token: "", secret: "" } } },
+  ])("returns original config without pruning a no-op %j", (cfg) => {
+    const result = clear(cfg);
+    expect(result).toEqual({ nextConfig: cfg, changed: false, cleared: false });
+    expect(result.nextConfig).toBe(cfg);
+  });
+
+  it("prunes changed empty account, channel, and channels objects", () => {
+    expect(clear({ channels: { sample: { accounts: { default: { token: "remove" } } } } })).toEqual(
+      { nextConfig: {}, changed: true, cleared: true },
+    );
   });
 });

--- a/src/channels/plugins/config-helpers.ts
+++ b/src/channels/plugins/config-helpers.ts
@@ -191,3 +191,57 @@ export function clearAccountEntryFields<TAccountEntry extends object>(params: {
     cleared,
   };
 }
+
+/** Clear plugin-selected account fields and prune only the config branches changed by cleanup. */
+export function clearAccountFieldsFromConfigSection(params: {
+  cfg: OpenClawConfig;
+  sectionKey: string;
+  accountId: string;
+  fields: string[];
+  markClearedOnFieldPresence?: boolean;
+}): { nextConfig: OpenClawConfig; changed: boolean; cleared: boolean } {
+  // SAFETY: Channel sections are config objects; the account helper checks nested entries.
+  const section = params.cfg.channels?.[params.sectionKey] as
+    | (ChannelSection & Record<string, unknown>)
+    | undefined;
+  const nextSection = { ...section };
+  // Root fields clear as a group only for the explicit default account and a
+  // truthy value. Nested cleanup retains its own empty-id and presence semantics.
+  const clearedRoot =
+    params.accountId === DEFAULT_ACCOUNT_ID &&
+    params.fields.some((field) => Boolean(nextSection[field]));
+  if (clearedRoot) {
+    for (const field of params.fields) {
+      delete nextSection[field];
+    }
+  }
+  const accountCleanup = clearAccountEntryFields({
+    accounts: nextSection.accounts,
+    accountId: params.accountId,
+    fields: params.fields,
+    markClearedOnFieldPresence: params.markClearedOnFieldPresence,
+  });
+  if (!clearedRoot && !accountCleanup.changed) {
+    return { nextConfig: params.cfg, changed: false, cleared: false };
+  }
+  if (accountCleanup.changed) {
+    if (accountCleanup.nextAccounts) {
+      nextSection.accounts = accountCleanup.nextAccounts;
+    } else {
+      delete nextSection.accounts;
+    }
+  }
+  const nextChannels = { ...params.cfg.channels };
+  if (Object.keys(nextSection).length > 0) {
+    nextChannels[params.sectionKey] = nextSection;
+  } else {
+    delete nextChannels[params.sectionKey];
+  }
+  const nextConfig = { ...params.cfg };
+  if (Object.keys(nextChannels).length > 0) {
+    nextConfig.channels = nextChannels;
+  } else {
+    delete nextConfig.channels;
+  }
+  return { nextConfig, changed: true, cleared: clearedRoot || accountCleanup.cleared };
+}

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -8,7 +8,7 @@ const mocks = vi.hoisted(() => ({
   getChannelPluginCatalogEntry: vi.fn(),
   listChannelPluginCatalogEntries: vi.fn(),
   resolveChannelDefaultAccountId: vi.fn(),
-  getChannelPlugin: vi.fn(),
+  getLoadedChannelPlugin: vi.fn(),
   listChannelPlugins: vi.fn(),
   normalizeChannelId: vi.fn(),
   loadConfig: vi.fn(),
@@ -41,7 +41,7 @@ vi.mock("../channels/plugins/helpers.js", () => ({
 }));
 
 vi.mock("../channels/plugins/index.js", () => ({
-  getChannelPlugin: mocks.getChannelPlugin,
+  getLoadedChannelPlugin: mocks.getLoadedChannelPlugin,
   listChannelPlugins: mocks.listChannelPlugins,
   normalizeChannelId: mocks.normalizeChannelId,
 }));
@@ -136,7 +136,7 @@ describe("channel-auth", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.normalizeChannelId.mockReturnValue("whatsapp");
-    mocks.getChannelPlugin.mockReturnValue(plugin);
+    mocks.getLoadedChannelPlugin.mockReturnValue(plugin);
     mocks.getChannelPluginCatalogEntry.mockReturnValue(undefined);
     mocks.listChannelPluginCatalogEntries.mockReturnValue([]);
     mocks.loadConfig.mockReturnValue({ channels: { whatsapp: {} } });
@@ -399,7 +399,7 @@ describe("channel-auth", () => {
     mocks.loadConfig.mockReturnValue({ channels: { whatsapp: {}, zalouser: {} } });
     mocks.listChannelPlugins.mockReturnValue([plugin, zaloPlugin]);
     mocks.normalizeChannelId.mockImplementation((value) => value);
-    mocks.getChannelPlugin.mockImplementation((value) =>
+    mocks.getLoadedChannelPlugin.mockImplementation((value) =>
       value === "whatsapp"
         ? plugin
         : value === "zalouser"
@@ -441,7 +441,7 @@ describe("channel-auth", () => {
   });
 
   it("throws when channel does not support login", async () => {
-    mocks.getChannelPlugin.mockReturnValueOnce({
+    mocks.getLoadedChannelPlugin.mockReturnValueOnce({
       auth: {},
       gateway: { logoutAccount: mocks.logoutAccount },
       config: { resolveAccount: mocks.resolveAccount },
@@ -467,7 +467,7 @@ describe("channel-auth", () => {
         npmSpec: "@openclaw/whatsapp",
       },
     };
-    mocks.getChannelPlugin.mockReturnValueOnce(undefined);
+    mocks.getLoadedChannelPlugin.mockReturnValueOnce(undefined);
     mocks.listChannelPluginCatalogEntries.mockReturnValueOnce([catalogEntry]);
     mocks.loadChannelSetupPluginRegistrySnapshotForChannel
       .mockReturnValueOnce({
@@ -519,7 +519,7 @@ describe("channel-auth", () => {
         npmSpec: "@openclaw/whatsapp",
       },
     };
-    mocks.getChannelPlugin.mockReturnValueOnce(undefined);
+    mocks.getLoadedChannelPlugin.mockReturnValueOnce(undefined);
     mocks.listChannelPluginCatalogEntries.mockReturnValueOnce([catalogEntry]);
     mocks.ensureChannelSetupPluginInstalled.mockResolvedValueOnce({
       cfg: {
@@ -571,7 +571,7 @@ describe("channel-auth", () => {
 
   it("resolves explicit channel login through the catalog when registry normalize misses", async () => {
     mocks.normalizeChannelId.mockReturnValueOnce(undefined).mockReturnValue("whatsapp");
-    mocks.getChannelPlugin.mockReturnValueOnce(undefined);
+    mocks.getLoadedChannelPlugin.mockReturnValueOnce(undefined);
     mocks.listChannelPluginCatalogEntries.mockReturnValueOnce([
       {
         id: "whatsapp",
@@ -647,7 +647,7 @@ describe("channel-auth", () => {
   });
 
   it("throws when channel does not support logout", async () => {
-    mocks.getChannelPlugin.mockReturnValueOnce({
+    mocks.getLoadedChannelPlugin.mockReturnValueOnce({
       auth: { login: mocks.login },
       gateway: {},
       config: { resolveAccount: mocks.resolveAccount },

--- a/src/commands/channel-setup/channel-plugin-resolution.test.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
+import { createPluginRuntimeStore } from "../../plugin-sdk/runtime-store.js";
 
 const mocks = vi.hoisted(() => ({
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
@@ -269,6 +270,44 @@ describe("resolveInstallableChannelPlugin", () => {
     expect(snapshotRequest?.workspaceDir).toBe("/tmp/workspace");
   });
 
+  it("initializes a cold bundled plugin through the scoped snapshot before logout", async () => {
+    const runtimeStore = createPluginRuntimeStore<{ cleared: boolean; loggedOut: boolean }>(
+      "runtime not initialized",
+    );
+    const plugin: ChannelPlugin = {
+      ...createPlugin("telegram"),
+      gateway: { logoutAccount: async () => runtimeStore.getRuntime() },
+    };
+    mocks.getChannelPlugin.mockReturnValue(plugin);
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      createCatalogEntry({ id: "telegram", pluginId: "telegram", origin: "bundled" }),
+    ]);
+    mocks.loadChannelSetupPluginRegistrySnapshotForChannel.mockImplementation(() => {
+      runtimeStore.setRuntime({ cleared: true, loggedOut: true });
+      return { channels: [{ plugin }], channelSetups: [] };
+    });
+
+    const result = await resolveInstallableChannelPlugin({
+      cfg: {},
+      runtime: {} as never,
+      rawChannel: "telegram",
+      allowInstall: false,
+      supports: (candidate) => Boolean(candidate.gateway?.logoutAccount),
+    });
+
+    await expect(
+      result.plugin?.gateway?.logoutAccount?.({
+        cfg: result.cfg,
+        accountId: "default",
+        account: {},
+        runtime: {} as never,
+      }),
+    ).resolves.toEqual({ cleared: true, loggedOut: true });
+    expect(result.configChanged).toBe(false);
+    expect(result.pluginInstalled).toBe(false);
+    expect(result.supportsRequestedCapability).toBe(true);
+  });
+
   it("returns an existing plugin that lacks the requested capability without reinstalling", async () => {
     const catalogEntry = createCatalogEntry({
       id: "openclaw-weixin",
@@ -278,7 +317,7 @@ describe("resolveInstallableChannelPlugin", () => {
     const installedPlugin = createPlugin("openclaw-weixin");
 
     mocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
-    mocks.getChannelPlugin.mockReturnValue(installedPlugin);
+    mocks.getLoadedChannelPlugin.mockReturnValue(installedPlugin);
 
     const result = await resolveInstallableChannelPlugin({
       cfg: { plugins: { enabled: true } },

--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -5,11 +5,7 @@ import {
   listRawChannelPluginCatalogEntries,
   type ChannelPluginCatalogEntry,
 } from "../../channels/plugins/catalog.js";
-import {
-  getChannelPlugin,
-  getLoadedChannelPlugin,
-  normalizeChannelId,
-} from "../../channels/plugins/index.js";
+import { getLoadedChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -170,7 +166,9 @@ export async function resolveInstallableChannelPlugin(params: {
     };
   }
 
-  const existing = getChannelPlugin(channelId);
+  // Bundled plugin metadata is not runtime-bound; load it through the scoped registry
+  // before returning a plugin that callers can execute.
+  const existing = getLoadedChannelPlugin(channelId);
   if (existing) {
     return {
       cfg: nextCfg,

--- a/src/plugin-sdk/channel-config-helpers.ts
+++ b/src/plugin-sdk/channel-config-helpers.ts
@@ -21,6 +21,8 @@ import type { ChannelConfigAdapter } from "../channels/plugins/types.adapters.js
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 
+export { clearAccountFieldsFromConfigSection } from "../channels/plugins/config-helpers.js";
+
 export {
   ensureOpenDmPolicyAllowFromWildcard,
   normalizeChannelDmPolicy,


### PR DESCRIPTION
## What Problem This Solves

Telegram, LINE, and Nextcloud Talk each implemented the same account-logout config mutation locally: clone the channel section, remove root or nested credential fields, prune empty branches, preserve unrelated config, and decide whether the logout counted as cleared.

Those parallel implementations duplicated the ownership boundary while making subtle contracts—default-account root cleanup, nested empty-ID handling, no-op object identity, and mutation-only pruning—easy to drift.

Source-blind CLI validation also exposed a producer bug in the existing local logout path: a cold bundled channel could be returned from metadata before its runtime binding was initialized, so logout failed before reaching credential cleanup.

## Why This Change Was Made

This adds one shared plugin SDK helper, `clearAccountFieldsFromConfigSection`, that performs only the shared config transformation and returns `{ nextConfig, changed, cleared }`. Telegram, LINE, and Nextcloud Talk now use that helper while retaining plugin-owned credential resolution, environment reporting, persistence order, Telegram cache cleanup, token-file handling, and logout result semantics.

Root fields still clear as a group only for the exact default account when at least one configured value is truthy. Nested account cleanup keeps its established empty-ID and field-presence behavior, unchanged inputs retain object identity, and only branches changed by cleanup are pruned.

The local channel resolver now returns only a loaded plugin after its scoped registry snapshot has initialized the runtime. Install, trust, workspace, auto-enable, and compatibility policy remain owned by the existing setup flow.

## User Impact

Channel logout keeps the same config, credential, cache, and reporting contracts with one canonical mutation path. Local CLI logout now also initializes a cold bundled plugin before invoking its logout handler instead of failing with `runtime not initialized`.

## Evidence

- Baseline owner coverage passes 33/33 before the shared helper is introduced.
- Final coverage passes 81/81: 43 owner/plugin tests, 28 CLI/Gateway tests, and 10 plugin SDK surface tests.
- The runtime-binding regression is captured RED before the producer fix; final grouped coverage passes 114/114 tests across eight owner and sibling files.
- Tests use the real channel account resolvers and canonical private-local plugin state fixtures while proving sibling config, file references, cache deletion, environment reporting, and no-op identity remain intact. Source review preserves config write order, while Gateway teardown-barrier coverage protects lifecycle ordering.
- Fresh final isolated P0 review reports no actionable findings at 0.98 confidence.
- Production: +87/-157, net -70 lines. Tests: +339/-179, net +160 lines. Tooling: +4/-2. Docs: +13/-0. Shrink-only assertion baseline: +2/-3. Overall: net +104 lines.
- The plugin SDK surface adds one function, with no changes to existing signatures: +1 source-defined export budget and +1 callable budget, no entrypoint change, and no generated API baseline edit. The canonical API render reports one addition and zero existing-surface changes.
- No CLI command/option, channel entrypoint, credential source, configuration schema, protocol, persistence format, dependency, environment variable, or existing public signature change.
- The complete 16-path changed gate passes all five routed production/test type projects, core and extension lint, formatting, SDK surface, dependency, dead-export, database, runtime-sidecar, import-cycle, webhook, pairing, and eight remaining canonical guards. The scripts-lint phase reports 29 diagnostics that are byte-for-byte identical on the built unchanged baseline; no script or scripts config is changed or waived here.
- Fresh isolated P0 review of the final runtime-binding repair reports no actionable findings at 0.98 confidence; the original 13-file helper patch retains its prior clean final review.
- A new exact-head full build passes assets, nine unified tsdown targets, 64 external plugins, CLI bootstrap, 48 runtime postbuild modules, 147 SDK subpaths, 772 finalized UI sidecars, and startup metadata; build and runtime-postbuild stamps match the exact repaired head.
- Repeated exact-head channel entrypoint profiles pass 3/3 with no failures or timeouts: LINE 143.78 MB max RSS, Nextcloud Talk 126.34 MB, and Telegram 396.66 MB against a 42.91 MB Node-only baseline. These are cold-entry memory observations, not before/after improvement claims.
- Source-blind CLI validation runs all 15 isolated cases without timeout or command failure. The changed F1 contract passes 9/9 real-removal diagnostics across three plugins and three config layouts: channel projection, sibling config, required file references, physical files, and removal state all remain correct. Three initial no-op cases preserve config bytes and modification time. The nine removal cases also add unrelated global agents/metadata fields (F2), and all 15 cases still lack an explicit completed/no-op operator outcome (F3), so the broader strict contract remains transparently failing rather than being claimed as fully green.

Named follow-ups:

- Prevent runtime compatibility/default config from leaking into no-op channel CLI writes.
- Report a completed local logout/no-op outcome explicitly to the operator.
- Restore typed `.mts` coverage for scripts and resolve the current scripts-lint diagnostics.
- Make post-tool watchdog boundary tests use deterministic clocks.
