### PR TITLE
fix(slack): preserve table formatting in edits and previews

### DIFF
--- a/extensions/slack/src/actions.blocks.test.ts
+++ b/extensions/slack/src/actions.blocks.test.ts
@@ -1,6 +1,13 @@
 // Slack tests cover actions.blocks plugin behavior.
-import { describe, expect, it } from "vitest";
+import {
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import type { MarkdownTableMode } from "openclaw/plugin-sdk/config-contracts";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createSlackEditTestClient, createSlackSendTestClient } from "./blocks.test-helpers.js";
+import { slackSetupPlugin } from "./channel.setup.js";
 import { countSlackTextUtf8Bytes } from "./truncate.js";
 
 const { editSlackMessage, editSlackRenderedMessage, sendSlackMessage } =
@@ -69,6 +76,75 @@ describe("sendSlackMessage blocks", () => {
 });
 
 describe("editSlackMessage blocks", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "slack", source: "test", plugin: slackSetupPlugin }]),
+    );
+  });
+  afterEach(() => resetPluginRuntimeStateForTest());
+
+  const table = "| Name | Value |\n| --- | --- |\n| Beta | 2 |";
+  const codeTable = "```\n| Name | Value |\n| ---- | ----- |\n| Beta | 2     |\n```";
+  const bulletTable = "*Beta*\n• Value: 2";
+
+  it.each<{
+    name: string;
+    channelMode?: MarkdownTableMode;
+    accountMode?: MarkdownTableMode;
+    useDefaultAccount?: boolean;
+    expected: string;
+  }>([
+    { name: "default code tables", expected: codeTable },
+    { name: "channel code tables", channelMode: "code", expected: codeTable },
+    { name: "channel bullet tables", channelMode: "bullets", expected: bulletTable },
+    { name: "disabled tables", channelMode: "off", expected: table },
+    {
+      name: "account bullet override",
+      channelMode: "off",
+      accountMode: "bullets",
+      expected: bulletTable,
+    },
+    {
+      name: "account disabled override",
+      channelMode: "code",
+      accountMode: "off",
+      expected: table,
+    },
+    {
+      name: "configured default account override",
+      channelMode: "off",
+      accountMode: "bullets",
+      useDefaultAccount: true,
+      expected: bulletTable,
+    },
+  ])(
+    "preserves $name when editing authored Markdown",
+    async ({ channelMode, accountMode, useDefaultAccount, expected }) => {
+      const client = createSlackEditTestClient();
+
+      await editSlackMessage("C123", "171234.567", table, {
+        token: "xoxb-test",
+        client,
+        accountId: useDefaultAccount ? undefined : "work",
+        cfg: {
+          channels: {
+            slack: {
+              defaultAccount: "work",
+              markdown: { tables: channelMode },
+              accounts: { work: { markdown: { tables: accountMode } } },
+            },
+          },
+        },
+      });
+
+      expect(client.chat.update).toHaveBeenCalledExactlyOnceWith({
+        channel: "C123",
+        ts: "171234.567",
+        text: expected,
+      });
+    },
+  );
+
   it("renders authored Markdown using the same mrkdwn dialect as sends", async () => {
     const client = createSlackEditTestClient();
 

--- a/extensions/slack/src/actions.ts
+++ b/extensions/slack/src/actions.ts
@@ -2,11 +2,12 @@
 import type { Block, KnownBlock, WebClient } from "@slack/web-api";
 import { normalizeAccountId } from "openclaw/plugin-sdk/account-resolution";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { requireRuntimeConfig } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { z } from "zod";
-import { resolveSlackAccount } from "./accounts.js";
+import { resolveDefaultSlackAccountId, resolveSlackAccount } from "./accounts.js";
 import { SLACK_PRIVATE_ACTION_DELIVERY_RESULT } from "./action-threading.js";
 import type { SlackAuthoredTextPlacement } from "./authored-text.js";
 import { buildSlackBlocksFallbackText } from "./blocks-fallback.js";
@@ -389,7 +390,11 @@ export async function editSlackMessage(
   content: string,
   opts: SlackActionClientOpts & { blocks?: (Block | KnownBlock)[] } = {},
 ) {
-  await editSlackRenderedMessage(channelId, messageId, normalizeSlackOutboundText(content), opts);
+  const accountId =
+    opts.accountId ?? (opts.cfg ? resolveDefaultSlackAccountId(opts.cfg) : undefined);
+  const tableMode = resolveMarkdownTableMode({ cfg: opts.cfg, channel: "slack", accountId });
+  const text = normalizeSlackOutboundText(content, { tableMode });
+  await editSlackRenderedMessage(channelId, messageId, text, opts);
 }
 
 // Finalized previews already contain Slack mrkdwn; a second Markdown render changes its meaning.

--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -56,6 +56,11 @@ describe("chunkSlackMrkdwnText", () => {
 });
 
 describe("normalizeSlackOutboundText", () => {
+  it("leaves table parsing off for callers without an authored-text table mode", () => {
+    const table = "| Name | Value |\n| --- | --- |\n| Beta | 2 |";
+    expect(normalizeSlackOutboundText(table)).toBe(table);
+  });
+
   it("marks assistant-authored transcript role headers after parsing Markdown", () => {
     expect(normalizeSlackOutboundText("**user**[Thu 2026-07-02] question")).toBe(
       "`user[Thu 2026-07-02]` question",

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -425,7 +425,10 @@ function buildSlackRenderOptions() {
   };
 }
 
-function markdownToSlackMrkdwn(markdown: string, options: SlackMarkdownOptions = {}): string {
+export function normalizeSlackOutboundText(
+  markdown: string,
+  options: SlackMarkdownOptions = {},
+): string {
   const ir = makeSlackEmphasisStylesSafe(
     markdownToIR(markdown ?? "", {
       assistantTranscriptRoleHeaders: true,
@@ -436,11 +439,9 @@ function markdownToSlackMrkdwn(markdown: string, options: SlackMarkdownOptions =
       tableMode: options.tableMode,
     }),
   );
-  return renderMarkdownWithMarkers(ir, buildSlackRenderOptions(), SLACK_FORMAT_PROFILE);
-}
-
-export function normalizeSlackOutboundText(markdown: string): string {
-  return protectSlackAssistantTranscriptRoleHeaders(markdownToSlackMrkdwn(markdown ?? ""));
+  return protectSlackAssistantTranscriptRoleHeaders(
+    renderMarkdownWithMarkers(ir, buildSlackRenderOptions(), SLACK_FORMAT_PROFILE),
+  );
 }
 
 /** Chunk already-rendered Slack mrkdwn without splitting entities or code markers. */

--- a/extensions/slack/src/message-action-dispatch.test.ts
+++ b/extensions/slack/src/message-action-dispatch.test.ts
@@ -1,5 +1,11 @@
 // Slack tests cover message action dispatch plugin behavior.
-import { describe, expect, it, vi } from "vitest";
+import {
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { slackSetupPlugin } from "./channel.setup.js";
 import { handleSlackMessageAction } from "./message-action-dispatch.js";
 import { extractSlackToolSend } from "./message-actions.js";
 import { renderSlackMessagePresentationFallbackText } from "./presentation-fallback.js";
@@ -83,7 +89,20 @@ function largeTablePresentation() {
   };
 }
 
+const paddedMarkdownTable = [
+  `| ${"H".repeat(200)} | Value |`,
+  "| --- | --- |",
+  ...Array.from({ length: 20 }, () => "| x | 2 |"),
+].join("\n");
+
 describe("handleSlackMessageAction", () => {
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "slack", source: "test", plugin: slackSetupPlugin }]),
+    );
+  });
+  afterEach(() => resetPluginRuntimeStateForTest());
+
   it("defaults reactions to the current inbound Slack message", async () => {
     const invoke = createInvokeSpy();
     const toolContext = { currentMessageId: "171234.567" };
@@ -267,6 +286,10 @@ describe("handleSlackMessageAction", () => {
     { name: "ASCII", message: `${"x".repeat(4_000)}TAIL` },
     { name: "multibyte", message: `${"😀".repeat(1_000)}TAIL` },
     { name: "expanded Slack markdown", message: `${"&".repeat(801)}TAIL` },
+    {
+      name: "padded Markdown table",
+      message: paddedMarkdownTable,
+    },
   ])("rejects oversized $name text-only edits before sending", async ({ message }) => {
     const invoke = createInvokeSpy();
 
@@ -284,6 +307,34 @@ describe("handleSlackMessageAction", () => {
 
     expect(invoke).not.toHaveBeenCalled();
   });
+
+  it.each(["off", "bullets"] as const)(
+    "measures the account's %s table rendering before rejecting an edit",
+    async (tables) => {
+      const invoke = createInvokeSpy();
+      await handleSlackMessageAction({
+        providerId: "slack",
+        ctx: {
+          action: "edit",
+          cfg: {
+            channels: {
+              slack: {
+                defaultAccount: "work",
+                markdown: { tables: "code" },
+                accounts: { work: { markdown: { tables } } },
+              },
+            },
+          },
+          params: { channelId: "C1", messageId: "171234.567", message: paddedMarkdownTable },
+        } as never,
+        invoke: invoke as never,
+      });
+      expect(firstAction(invoke)).toMatchObject({
+        action: "editMessage",
+        content: paddedMarkdownTable,
+      });
+    },
+  );
 
   it("accepts a text-only edit at Slack's exact byte limit", async () => {
     const invoke = createInvokeSpy();

--- a/extensions/slack/src/message-action-dispatch.ts
+++ b/extensions/slack/src/message-action-dispatch.ts
@@ -8,6 +8,7 @@ import {
   normalizeLegacyInteractiveReply,
   normalizeMessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { readPositiveIntegerParam, readStringParam } from "openclaw/plugin-sdk/param-readers";
 import {
   normalizeOptionalLowercaseString,
@@ -232,9 +233,14 @@ export async function handleSlackMessageAction(params: {
     const accessibleContent = renderedPresentation.usesPresentationTextFallback
       ? renderSlackMessagePresentationFallbackText({ text: content, presentation })
       : resolveSlackPresentationText(content, presentation);
+    const tableMode = resolveMarkdownTableMode({
+      cfg,
+      channel: "slack",
+      accountId: accountId ?? resolveDefaultSlackAccountId(cfg),
+    });
     if (
       !blocks &&
-      countSlackTextUtf8Bytes(normalizeSlackOutboundText(accessibleContent)) >
+      countSlackTextUtf8Bytes(normalizeSlackOutboundText(accessibleContent, { tableMode })) >
         SLACK_EDIT_TEXT_MAX_BYTES
     ) {
       const editSubject = renderedPresentation.usesPresentationTextFallback

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -1,7 +1,13 @@
-import type { GetReplyOptions, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 // Slack tests cover dispatch.preview fallback plugin behavior.
+import {
+  createTestRegistry,
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import type { GetReplyOptions, ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { slackSetupPlugin } from "../../channel.setup.js";
 
 const FINAL_REPLY_TEXT = "final answer";
 const THREAD_TS = "thread-1";
@@ -1131,6 +1137,9 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "slack", source: "test", plugin: slackSetupPlugin }]),
+    );
     createSlackDraftStreamMock.mockReset();
     deliverRepliesMock.mockReset();
     finalizeSlackPreviewEditMock.mockReset();
@@ -1183,6 +1192,8 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     stopSlackStreamMock.mockResolvedValue({});
     emitSlackMessageSentHooksMock.mockClear();
   });
+
+  afterEach(() => resetPluginRuntimeStateForTest());
 
   it("forwards durable ingress ownership into reply options", async () => {
     const turnAdoptionLifecycle = {
@@ -1635,6 +1646,41 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     expect(draftStream.clear).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["code", "```\n| Name | Value |\n| ---- | ----- |\n| Beta | 2     |\n```"],
+    ["bullets", "*Beta*\n• Value: 2"],
+    ["off", "| Name | Value |\n| --- | --- |\n| Beta | 2 |"],
+  ] as const)(
+    "preserves %s table mode when finalizing authored preview text",
+    async (tables, expected) => {
+      const { normalizeSlackOutboundText } =
+        await vi.importActual<typeof import("../../format.js")>("../../format.js");
+      normalizeSlackOutboundTextMock.mockImplementation(normalizeSlackOutboundText);
+      try {
+        finalizeSlackPreviewEditMock.mockResolvedValueOnce(undefined);
+        mockedDispatchSequence = [
+          { kind: "final", payload: { text: "| Name | Value |\n| --- | --- |\n| Beta | 2 |" } },
+        ];
+
+        await dispatchPreparedSlackMessage(
+          createPreparedSlackMessage({
+            cfg: { channels: { slack: { markdown: { tables } } } },
+          }),
+        );
+
+        expect(finalizeSlackPreviewEditMock).toHaveBeenCalledOnce();
+        expectMockCallArgFields(finalizeSlackPreviewEditMock, 0, "table preview edit", {
+          channelId: "C123",
+          messageId: "171234.567",
+          text: expected,
+        });
+        expect(deliverRepliesMock).not.toHaveBeenCalled();
+      } finally {
+        normalizeSlackOutboundTextMock.mockImplementation((value: string) => value.trim());
+      }
+    },
+  );
+
   it("finalizes native chart blocks without re-escaping accessible preview text", async () => {
     const draftStream = createDraftStreamStub();
     const accessibleText =
@@ -1732,7 +1778,9 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     await dispatchPreparedSlackMessage(createPreparedSlackMessage());
 
     expect(normalizeSlackOutboundTextMock).toHaveBeenCalledTimes(1);
-    expect(normalizeSlackOutboundTextMock).toHaveBeenCalledWith("**Summary**");
+    expect(normalizeSlackOutboundTextMock).toHaveBeenCalledWith("**Summary**", {
+      tableMode: "code",
+    });
     expectMockCallArgFields(finalizeSlackPreviewEditMock, 0, "block preview edit params", {
       text: "**Summary**",
     });

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -12,6 +12,7 @@ import {
   deliverWithFinalizableLivePreviewAdapter,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
+import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import {
   buildTtsSupplementMediaPayload,
   getReplyPayloadTtsSupplement,
@@ -233,7 +234,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     const previewFinalText =
       replyRenderPlan.mode === "single" && replyRenderPlan.textIsSlackMrkdwn
         ? trimmedFinalText
-        : normalizeSlackOutboundText((replySourceText ?? "").trim());
+        : normalizeSlackOutboundText((replySourceText ?? "").trim(), {
+            tableMode: resolveMarkdownTableMode({
+              cfg,
+              channel: "slack",
+              accountId: account.accountId,
+            }),
+          });
     const previewFinalTextFitsEdit =
       countSlackTextUtf8Bytes(previewFinalText) <= SLACK_EDIT_TEXT_MAX_BYTES;
     const shouldRestoreTtsSupplementTextForPreviewFallback =

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -121,7 +121,7 @@ export function resolveSlackReplyDeliveryMessages(params: {
     });
   }
   if (outsideText) {
-    messages.push({ text: outsideText });
+    messages.push({ text: outsideText, authoredTextPlacement: "outside-blocks" });
   }
   return messages;
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

This uses a branch in the same repository; maintainers retain their existing repository write access.

</details>

## What Problem This Solves

Fixes an issue where users see correctly formatted Slack tables become literal Markdown after an edit or streamed final update. The native update succeeds, so the agent receives no indication that formatting was lost. Streamed finalization could also replace correctly rendered bold/link text with authored Markdown.

Closes #130978.

## Why This Change Was Made

Plain-authored edits, edit-size preflight, and preview finalization now pass the existing resolved channel/account table mode through the canonical normalizer. The no-block reply producer also carries its already-known `outside-blocks` placement, so consumers no longer mistake authored text for already-rendered Slack text.

The one-use Markdown wrapper was removed and its work absorbed into the existing normalizer. Already-rendered edits and default-off normalization used for readback/progress are preserved; there is no new configuration, SDK surface, dependency, or persistence change.

## User Impact

Plain-authored sends and subsequent edits/final preview updates agree under the default, explicit `code`, `bullets`, `off`, and account-override modes. Edits whose rendered code table exceeds the existing 4,000-byte limit now fail before modifying the target; the same authored table remains valid when its configured bullets/off rendering fits. Native URL button text is preserved byte-for-byte.

Named follow-up, not fixed here: **native Block Kit authored section table-mode propagation**. `buildSlackAuthoredTextBlocks` still renders section text without the configured table mode. That separate pre-existing producer was identified by source review, not newly proved through Slack SaaS or a native table-with-controls scenario. This PR leaves those native section bytes unchanged.

## Evidence

AI-assisted repair, with a clean independent Codex review of the complete nine-file patch and full owner/caller/sibling context.

Baseline `9bd50c803cce88f2ab387ddaf6cc29b4ef004005` was built and exercised before production edits. In the default-mode action scenario, accepted message `1700000000.000101` changed from a fenced, padded table on send to a raw pipe table on same-ID edit. In a separate normal-identity streaming scenario, accepted message `1700000000.000103` changed from `*bold* and <https://example.com|docs>` in the draft update to `**bold** and [docs](https://example.com)` in the final update. The final candidate preserves the intended rendering in both paths.

Actual Gateway + native Slack ingress + real Slack SDK + mock Slack API/provider verdict (each mode also passed bold/link send/edit/readback and native button byte preservation):

```json
{
  "kind": "mock-gateway-native-sdk",
  "liveSlackSaaS": false,
  "pass": true,
  "modes": [
    {"mode":"default","tableEditId":"1700000000.000130","sendEditReadEqual":true,"tablePreviewId":"1700000000.000125","finalUpdateCorrect":true,"sizeGuard":"rejected; zero target updates; original readback"},
    {"mode":"code","tableEditId":"1700000000.000161","sendEditReadEqual":true,"tablePreviewId":"1700000000.000156","finalUpdateCorrect":true,"sizeGuard":"rejected; zero target updates; original readback"},
    {"mode":"bullets","tableEditId":"1700000000.000192","sendEditReadEqual":true,"tablePreviewId":"1700000000.000187","finalUpdateCorrect":true,"sizeGuard":"accepted complete; matching readback"},
    {"mode":"off","tableEditId":"1700000000.000222","sendEditReadEqual":true,"tablePreviewId":"1700000000.000217","finalUpdateCorrect":true,"sizeGuard":"accepted complete; matching readback"},
    {"mode":"account override","tableEditId":"1700000000.000252","sendEditReadEqual":true,"tablePreviewId":"1700000000.000247","finalUpdateCorrect":true,"sizeGuard":"accepted complete; matching readback"}
  ]
}
```

The probes bind edits/readback to the message ID returned by the actual tool receipt, not incidental progress posts. Preview checks inspect the last accepted update to the original partial-message ID. Oversize cases wait for the final error notice and read back the unchanged original message before advancing. The mock supplies `chat.update` and exact inclusive history semantics over previously accepted messages because the pinned mock lacks those operations; it does not inject expected rendering. This is mock-gateway channel proof, not Slack SaaS/UI proof.

Independent source-blind validation passed **all six contract clauses, 32 fresh native cases and 22 checks**. It changed table contents rather than repeating identical input, bound edits/readback to actual receipt IDs, checked final streamed table/bold-link updates, and independently exercised a 477-byte authored table whose code rendering is 4,693 bytes. Default/code rejected with final notices and unchanged target readback; bullets/off retained every ordered row. Native button actions bytes also matched. Incidental mock `chat.delete` failures were retained separately; progress cleanup is not claimed as proven by this fixture.

Focused regression/sibling suite: **318 tests passed in seven files**, including draft-stream, rendered update, and reply-block controls. New regression assertions were observed failing before their respective owner repairs.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/slack/src/actions.blocks.test.ts extensions/slack/src/message-action-dispatch.test.ts extensions/slack/src/format.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts extensions/slack/src/draft-stream.test.ts extensions/slack/src/send.update.test.ts extensions/slack/src/reply-blocks.test.ts
```

The full nine-file `check-changed` gate passed, including extension production/test typechecks, typed lint, Knip, plugin boundaries, database-first, media/sidecar, and import-cycle guards. Candidate `qaRuntime` build and `git diff --check` passed. [Exact-head CI 33083586087](https://github.com/openclaw/openclaw/actions/runs/33083586087) completed successfully at `06e51c4386293749bc37a355264d7367a8b28f00`: 30 jobs passed and 21 were scope-skipped, including a successful required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33083586087/job/98559030201).

Production delta: **+30/-11, net +19**. Tests: **+185/-5, net +180**. The positive production delta is the existing mode/account context forwarded across three distinct authored-text boundaries; globally changing normalization's default would alter readback/progress and already-rendered contracts. The private wrapper was deleted, the existing options type reused, and the producer placement repair is a net-zero-line fact-forwarding change. No new parallel rendering path was added.

History/provenance: #116915 (`184c13d01ced6d89fd4f166564f6fa2c2dd43a87`, author and merger @steipete) carried the authored edit omission forward. #104539 (`934a974c296f16104308a08c0fc51caac1776a3e`, author @steipete, merger @steipete-oai) introduced the relevant no-block placement/classification pair. The Slack source has no drift between the tested main baseline and the subsequently inspected main state after #130951. No stable-release regression range is claimed.
