### PR TITLE
fix: built-in updates no longer stall during Doctor finalization

### DIFF
--- a/src/cli/update-cli/update-command-finalize.ts
+++ b/src/cli/update-cli/update-command-finalize.ts
@@ -182,8 +182,8 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
     });
   }
 
-  const completedPluginUpdate = await withPluginLifecycleLease({}, async () => {
-    const initialPluginUpdate = await withPrePluginUpdateDoctorEnv(async () => {
+  const initialPluginUpdate = await withPluginLifecycleLease({}, async () => {
+    return await withPrePluginUpdateDoctorEnv(async () => {
       await runTimedFinalizePhase({
         finalizationStartedAt,
         phaseTimings,
@@ -251,26 +251,26 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
               : "completed",
       });
     });
-    return await runTimedFinalizePhase({
-      finalizationStartedAt,
-      phaseTimings,
-      phase: "targetConfigConvergence",
-      run: async () =>
-        await completePostCorePluginUpdate({
-          root,
-          pluginUpdate: initialPluginUpdate,
-          freshDoctorRequired: initialPluginUpdate.changed,
-          yes: opts.yes === true,
-          json: opts.json === true,
-          timeoutMs: timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS,
-        }),
-      outcome: (result) =>
-        result.pluginUpdate.status === "error"
-          ? "failed"
-          : result.pluginUpdate.status === "warning"
-            ? "warning"
-            : "completed",
-    });
+  });
+  const completedPluginUpdate = await runTimedFinalizePhase({
+    finalizationStartedAt,
+    phaseTimings,
+    phase: "targetConfigConvergence",
+    run: async () =>
+      await completePostCorePluginUpdate({
+        root,
+        pluginUpdate: initialPluginUpdate,
+        freshDoctorRequired: initialPluginUpdate.changed,
+        yes: opts.yes === true,
+        json: opts.json === true,
+        timeoutMs: timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS,
+      }),
+    outcome: (result) =>
+      result.pluginUpdate.status === "error"
+        ? "failed"
+        : result.pluginUpdate.status === "warning"
+          ? "warning"
+          : "completed",
   });
   const pluginUpdate = completedPluginUpdate.pluginUpdate;
   configSnapshot = completedPluginUpdate.configSnapshot;

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -243,43 +243,43 @@ export async function finishUpdate(params: {
 
   if (!pluginsUpdatedInFreshProcess) {
     await withOwnedManagedUpdateEnv(params.ownedManagedUpdateEnv, async () => {
-      await withPluginLifecycleLease({}, async () => {
-        postUpdateConfigSnapshot = await readConfigFileSnapshot({
-          skipPluginValidation: true,
-          suppressFutureVersionWarning: shouldResumePostCoreInFreshProcess,
-        });
-        postUpdateConfigSnapshot = await persistRequestedUpdateChannel({
-          configSnapshot: postUpdateConfigSnapshot,
-          requestedChannel: params.requestedChannel,
-        });
-        const restoredConfig = restoreDroppedPreUpdateChannels(
-          postUpdateConfigSnapshot,
-          params.configSnapshot.valid
-            ? {
-                sourceConfig: params.configSnapshot.sourceConfig,
-                authoredConfig: isRecord(params.configSnapshot.parsed)
-                  ? (params.configSnapshot.parsed as OpenClawConfig)
-                  : params.configSnapshot.sourceConfig,
-              }
-            : undefined,
-        );
-        postUpdateConfigSnapshot = restoredConfig.snapshot;
-        // Current-process post-core convergence still reports the pre-update
-        // VERSION. During downgrades, pin compatibility checks to the installed
-        // target so incompatible newer plugins are disabled before restart.
-        const postUpdateInstalledVersion = await readPackageVersion(postUpdateRoot);
-        const versionComparison =
-          postUpdateInstalledVersion && VERSION
-            ? compareSemverStrings(VERSION, postUpdateInstalledVersion)
-            : null;
-        const compatibilityDowngradeTarget =
-          versionComparison != null && versionComparison > 0 ? postUpdateInstalledVersion : null;
-        const previousCompatibilityHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
-        if (compatibilityDowngradeTarget) {
-          process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatibilityDowngradeTarget;
-        }
-        try {
-          const initialPluginUpdate = await updatePluginsAfterCoreUpdate({
+      // Current-process post-core convergence still reports the pre-update
+      // VERSION. During downgrades, pin compatibility checks to the installed
+      // target so incompatible newer plugins are disabled before restart.
+      const postUpdateInstalledVersion = await readPackageVersion(postUpdateRoot);
+      const versionComparison =
+        postUpdateInstalledVersion && VERSION
+          ? compareSemverStrings(VERSION, postUpdateInstalledVersion)
+          : null;
+      const compatibilityDowngradeTarget =
+        versionComparison != null && versionComparison > 0 ? postUpdateInstalledVersion : null;
+      const previousCompatibilityHostVersion = process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+      if (compatibilityDowngradeTarget) {
+        process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = compatibilityDowngradeTarget;
+      }
+      try {
+        const initialPluginUpdate = await withPluginLifecycleLease({}, async () => {
+          postUpdateConfigSnapshot = await readConfigFileSnapshot({
+            skipPluginValidation: true,
+            suppressFutureVersionWarning: shouldResumePostCoreInFreshProcess,
+          });
+          postUpdateConfigSnapshot = await persistRequestedUpdateChannel({
+            configSnapshot: postUpdateConfigSnapshot,
+            requestedChannel: params.requestedChannel,
+          });
+          const restoredConfig = restoreDroppedPreUpdateChannels(
+            postUpdateConfigSnapshot,
+            params.configSnapshot.valid
+              ? {
+                  sourceConfig: params.configSnapshot.sourceConfig,
+                  authoredConfig: isRecord(params.configSnapshot.parsed)
+                    ? (params.configSnapshot.parsed as OpenClawConfig)
+                    : params.configSnapshot.sourceConfig,
+                }
+              : undefined,
+          );
+          postUpdateConfigSnapshot = restoredConfig.snapshot;
+          return await updatePluginsAfterCoreUpdate({
             root: postUpdateRoot,
             channel: params.channel,
             configSnapshot: postUpdateConfigSnapshot,
@@ -289,31 +289,29 @@ export async function finishUpdate(params: {
             timeoutMs: params.updateStepTimeoutMs,
             pluginInstallRecords: params.preUpdatePluginInstallRecords,
           });
-          const completedPluginUpdate = await completePostCorePluginUpdate({
-            root: postUpdateRoot,
-            pluginUpdate: initialPluginUpdate,
-            // Aggregate plugin changes and core install changes independently require fresh doctor.
-            freshDoctorRequired:
-              didCoreUpdateChangeInstall(params.result) || initialPluginUpdate.changed,
-            yes: params.opts.yes === true,
-            json: params.opts.json === true,
-            timeoutMs: params.updateStepTimeoutMs,
-            ...(params.packageUpdateNodeRunner
-              ? { nodeRunner: params.packageUpdateNodeRunner }
-              : {}),
-          });
-          postCorePluginUpdate = completedPluginUpdate.pluginUpdate;
-          postUpdateConfigSnapshot = completedPluginUpdate.configSnapshot;
-        } finally {
-          if (compatibilityDowngradeTarget) {
-            if (previousCompatibilityHostVersion === undefined) {
-              delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
-            } else {
-              process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = previousCompatibilityHostVersion;
-            }
+        });
+        const completedPluginUpdate = await completePostCorePluginUpdate({
+          root: postUpdateRoot,
+          pluginUpdate: initialPluginUpdate,
+          // Aggregate plugin changes and core install changes independently require fresh doctor.
+          freshDoctorRequired:
+            didCoreUpdateChangeInstall(params.result) || initialPluginUpdate.changed,
+          yes: params.opts.yes === true,
+          json: params.opts.json === true,
+          timeoutMs: params.updateStepTimeoutMs,
+          ...(params.packageUpdateNodeRunner ? { nodeRunner: params.packageUpdateNodeRunner } : {}),
+        });
+        postCorePluginUpdate = completedPluginUpdate.pluginUpdate;
+        postUpdateConfigSnapshot = completedPluginUpdate.configSnapshot;
+      } finally {
+        if (compatibilityDowngradeTarget) {
+          if (previousCompatibilityHostVersion === undefined) {
+            delete process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION;
+          } else {
+            process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION = previousCompatibilityHostVersion;
           }
         }
-      });
+      }
     });
   }
 

--- a/src/cli/update-cli/update-command-resume.test.ts
+++ b/src/cli/update-cli/update-command-resume.test.ts
@@ -1,0 +1,143 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { defaultRuntime } from "../../runtime.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+
+const mocks = vi.hoisted(() => ({
+  completePluginUpdate: vi.fn(),
+  readConfig: vi.fn(),
+  runFreshDoctor: vi.fn(),
+  updatePlugins: vi.fn(),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  readConfigFileSnapshot: mocks.readConfig,
+}));
+vi.mock("../../plugins/installed-plugin-index-records.js", () => ({
+  loadInstalledPluginIndexInstallRecords: vi.fn(async () => ({})),
+}));
+vi.mock("../../plugins/installed-plugin-index-store.js", () => ({
+  readPersistedInstalledPluginIndex: vi.fn(async () => null),
+}));
+vi.mock("./shared.js", () => ({
+  readPackageVersion: vi.fn(async () => "2026.8.1"),
+}));
+vi.mock("./update-command-config.js", () => ({
+  createUpdateConfigSnapshot: vi.fn(async () => undefined),
+  persistRequestedUpdateChannel: vi.fn(async ({ configSnapshot }) => configSnapshot),
+  readPostCorePreUpdateSourceConfig: vi.fn(async () => undefined),
+  restoreDroppedPreUpdateChannels: vi.fn((snapshot) => ({ snapshot, changed: false })),
+}));
+vi.mock("./update-command-fresh-doctor.js", () => ({
+  completePostCorePluginUpdate: mocks.completePluginUpdate,
+  runUpdateFinalizationDoctorInFreshProcess: mocks.runFreshDoctor,
+}));
+vi.mock("./update-command-plugins.js", () => ({
+  updatePluginsAfterCoreUpdate: mocks.updatePlugins,
+}));
+vi.mock("./update-command-post-core.js", () => ({
+  POST_CORE_UPDATE_INSTALL_RECORDS_PATH_ENV: "OPENCLAW_UPDATE_POST_CORE_INSTALL_RECORDS_PATH",
+  POST_CORE_UPDATE_RESULT_PATH_ENV: "OPENCLAW_UPDATE_POST_CORE_RESULT_PATH",
+  POST_CORE_UPDATE_STARTED_AT_ENV: "OPENCLAW_UPDATE_POST_CORE_STARTED_AT_MS",
+  readPostCorePluginInstallRecordsFile: vi.fn(async () => undefined),
+  resolvePostCoreUpdateStartedAtMs: vi.fn(async () => undefined),
+  writePostCorePluginUpdateResultFile: vi.fn(async () => undefined),
+}));
+
+import { resumePostCoreUpdate } from "./update-command-resume.js";
+
+async function probePluginLease(scriptPath: string, stateDir: string): Promise<string> {
+  const child = spawn(process.execPath, ["--import", "tsx", scriptPath, stateDir], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  child.stdout.setEncoding("utf8").on("data", (chunk: string) => (stdout += chunk));
+  child.stderr.setEncoding("utf8").on("data", (chunk: string) => (stderr += chunk));
+  return await new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        reject(new Error(`lease probe exited ${code ?? signal}: ${stderr}`));
+      }
+    });
+  });
+}
+
+const configSnapshot = {
+  valid: true,
+  parsed: {},
+  config: {},
+  runtimeConfig: {},
+  sourceConfig: {},
+  warnings: [],
+  issues: [],
+  legacyIssues: [],
+};
+
+const pluginUpdate = {
+  status: "ok",
+  changed: true,
+  sync: { changed: false, switchedToBundled: [], switchedToNpm: [], warnings: [], errors: [] },
+  npm: { changed: false, outcomes: [] },
+  integrityDrifts: [],
+  warnings: [],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("resumePostCoreUpdate plugin lifecycle lease", () => {
+  it("releases the lease before each Doctor subprocess boundary", async () => {
+    await withOpenClawTestState({ label: "update-resume-lease" }, async (state) => {
+      const leaseModuleUrl = pathToFileURL(
+        path.resolve("src/plugins/plugin-lifecycle-lease.ts"),
+      ).href;
+      const probeScript = await state.writeText(
+        "probe-plugin-lease.mts",
+        `
+          import { withPluginLifecycleLease } from ${JSON.stringify(leaseModuleUrl)};
+          const env = { ...process.env, OPENCLAW_STATE_DIR: process.argv[2] };
+          try {
+            await withPluginLifecycleLease({ env, leaseMs: 1_000, waitMs: 0 }, async () => {});
+            process.stdout.write("acquired");
+          } catch (error) {
+            process.stdout.write(error?.code ?? String(error));
+          }
+        `,
+      );
+      const probe = () => probePluginLease(probeScript, state.stateDir);
+      vi.stubEnv("OPENCLAW_COMPATIBILITY_HOST_VERSION", "previous");
+      mocks.readConfig.mockResolvedValue(configSnapshot);
+      mocks.runFreshDoctor.mockImplementation(async () => {
+        await expect(probe()).resolves.toBe("acquired");
+      });
+      mocks.updatePlugins.mockImplementation(async () => {
+        await expect(probe()).resolves.toBe("OPENCLAW_STATE_LEASE_TIMEOUT");
+        return pluginUpdate;
+      });
+      mocks.completePluginUpdate.mockImplementation(async () => {
+        await expect(probe()).resolves.toBe("acquired");
+        return { pluginUpdate, configSnapshot };
+      });
+      vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined as never);
+
+      await resumePostCoreUpdate({
+        root: "/tmp/openclaw",
+        channel: "dev",
+        opts: { yes: true },
+        timeoutMs: 1_000,
+      });
+
+      expect(mocks.runFreshDoctor).toHaveBeenCalledOnce();
+      expect(mocks.updatePlugins).toHaveBeenCalledOnce();
+      expect(mocks.completePluginUpdate).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/cli/update-cli/update-command-resume.ts
+++ b/src/cli/update-cli/update-command-resume.ts
@@ -39,10 +39,6 @@ type ResumePostCoreUpdateParams = {
 };
 
 export async function resumePostCoreUpdate(params: ResumePostCoreUpdateParams): Promise<void> {
-  return await withPluginLifecycleLease({}, async () => await resumePostCoreUpdateUnlocked(params));
-}
-
-async function resumePostCoreUpdateUnlocked(params: ResumePostCoreUpdateParams): Promise<void> {
   if (
     params.channel !== "stable" &&
     params.channel !== "extended-stable" &&
@@ -53,6 +49,7 @@ async function resumePostCoreUpdateUnlocked(params: ResumePostCoreUpdateParams):
     defaultRuntime.exit(1);
     return;
   }
+  const channel = params.channel;
 
   const requestedChannelInput = process.env[POST_CORE_UPDATE_REQUESTED_CHANNEL_ENV]?.trim() ?? "";
   const requestedChannel = requestedChannelInput
@@ -88,43 +85,45 @@ async function resumePostCoreUpdateUnlocked(params: ResumePostCoreUpdateParams):
   // The fresh process owns the updated migration contracts. Repair before
   // plugin convergence writes config, or newly retired plugin keys can block
   // the update before doctor gets a chance to migrate them.
-  configSnapshot = await readConfigFileSnapshot({
-    skipPluginValidation: true,
-    suppressFutureVersionWarning: true,
-  });
-  configSnapshot = await persistRequestedUpdateChannel({
-    configSnapshot,
-    requestedChannel,
-  });
-  const restoredConfig = restoreDroppedPreUpdateChannels(configSnapshot, preUpdateSourceConfig);
-  const parentPluginInstallRecords = await readPostCorePluginInstallRecordsFile(
-    process.env[POST_CORE_UPDATE_INSTALL_RECORDS_PATH_ENV],
-  );
-  // The updated doctor may have repaired or removed plugin installs before this process resumed.
-  const currentPluginInstallRecords = await loadInstalledPluginIndexInstallRecords();
-  const persistedPluginIndex = await readPersistedInstalledPluginIndex();
-  const hasForwardedUpdateStart = Boolean(process.env[POST_CORE_UPDATE_STARTED_AT_ENV]?.trim());
-  const currentIndexIsAuthoritative =
-    Object.keys(currentPluginInstallRecords).length > 0 ||
-    Boolean(
-      persistedPluginIndex &&
-      hasForwardedUpdateStart &&
-      updateStartedAtMs !== undefined &&
-      persistedPluginIndex.generatedAtMs >= updateStartedAtMs,
+  const initialPluginUpdate = await withPluginLifecycleLease({}, async () => {
+    configSnapshot = await readConfigFileSnapshot({
+      skipPluginValidation: true,
+      suppressFutureVersionWarning: true,
+    });
+    configSnapshot = await persistRequestedUpdateChannel({
+      configSnapshot,
+      requestedChannel,
+    });
+    const restoredConfig = restoreDroppedPreUpdateChannels(configSnapshot, preUpdateSourceConfig);
+    const parentPluginInstallRecords = await readPostCorePluginInstallRecordsFile(
+      process.env[POST_CORE_UPDATE_INSTALL_RECORDS_PATH_ENV],
     );
-  const pluginInstallRecords = currentIndexIsAuthoritative
-    ? currentPluginInstallRecords
-    : parentPluginInstallRecords;
+    // The updated doctor may have repaired or removed plugin installs before this process resumed.
+    const currentPluginInstallRecords = await loadInstalledPluginIndexInstallRecords();
+    const persistedPluginIndex = await readPersistedInstalledPluginIndex();
+    const hasForwardedUpdateStart = Boolean(process.env[POST_CORE_UPDATE_STARTED_AT_ENV]?.trim());
+    const currentIndexIsAuthoritative =
+      Object.keys(currentPluginInstallRecords).length > 0 ||
+      Boolean(
+        persistedPluginIndex &&
+        hasForwardedUpdateStart &&
+        updateStartedAtMs !== undefined &&
+        persistedPluginIndex.generatedAtMs >= updateStartedAtMs,
+      );
+    const pluginInstallRecords = currentIndexIsAuthoritative
+      ? currentPluginInstallRecords
+      : parentPluginInstallRecords;
 
-  const initialPluginUpdate = await updatePluginsAfterCoreUpdate({
-    root: params.root,
-    channel: params.channel,
-    configSnapshot: restoredConfig.snapshot,
-    configChanged: restoredConfig.changed,
-    restoredAuthoredChannels: restoredConfig.authoredChannels,
-    opts: params.opts,
-    timeoutMs: params.timeoutMs,
-    pluginInstallRecords,
+    return await updatePluginsAfterCoreUpdate({
+      root: params.root,
+      channel,
+      configSnapshot: restoredConfig.snapshot,
+      configChanged: restoredConfig.changed,
+      restoredAuthoredChannels: restoredConfig.authoredChannels,
+      opts: params.opts,
+      timeoutMs: params.timeoutMs,
+      pluginInstallRecords,
+    });
   });
   const { pluginUpdate } = await completePostCorePluginUpdate({
     root: params.root,


### PR DESCRIPTION
Closes #130954

## What Problem This Solves

The built-in updater could finish core installation, then wait ten minutes and fail because a fresh Doctor subprocess tried to acquire `core:plugin-lifecycle/global` while its parent still held and renewed that same lease.

## Fix

Hold the plugin lifecycle lease only around parent-side config/plugin mutation. Release it before any fresh Doctor subprocess, then continue from authoritative post-Doctor state.

The same ownership rule is required in the three supported entry paths:

- post-core resume
- `update finalize` / `update repair`
- current-process fallback

No lease timeout, consent rule, schema, or public API changes.

## Evidence

- [Real updater proof](https://github.com/openclaw/openclaw/pull/130980#issuecomment-5441094805): stable-to-dev update completed successfully on the macOS host that reproduced the timeout twice. The three production files on that proven head are byte-identical to this rebased head; the later revision only replaced oversized mock tests with one focused regression.
- Resume regression uses a real child process and SQLite lease: Doctor probes acquire before and after mutation, while a concurrent probe during plugin mutation receives `OPENCLAW_STATE_LEASE_TIMEOUT`.
- `node scripts/run-vitest.mjs src/cli/update-cli/update-command-resume.test.ts` — 1 passed.
- `node scripts/run-vitest.mjs src/plugins/plugin-lifecycle-lease.test.ts` — 5 passed.
- `node scripts/check-changed.mjs -- <four changed files>` — passed.
- Three independent scope reviews found no redundant production path or P0/P1/P2 defect. The repository autoreview wrapper was also attempted, but both configured CLI engines failed before reviewing code due local Codex cache-schema and Claude OAuth errors.

## Reviewability

- 4 files, +261/−121 (previously 6 files, +484/−129)
- production: +118/−121, entirely lease-boundary movement
- tests: one 143-line process-boundary regression
- rollback: revert this single commit

AI-assisted: yes. I reviewed the implementation and understand the ownership change.

