### PR TITLE
fix(plugin-sdk): load helpers from the installed Discord plugin

### DIFF
--- a/src/plugin-sdk/discord.test.ts
+++ b/src/plugin-sdk/discord.test.ts
@@ -75,7 +75,7 @@ const mocks = vi.hoisted(() => {
     componentEditResult,
     runtimeModule,
     runtimeConfig,
-    loadBundledPluginPublicSurfaceModuleSyncCore: vi.fn((params: { artifactBasename: string }) => {
+    loadBundledPluginPublicSurfaceModuleSync: vi.fn((params: { artifactBasename: string }) => {
       if (params.artifactBasename === "runtime-api.js") {
         return runtimeModule;
       }
@@ -84,17 +84,8 @@ const mocks = vi.hoisted(() => {
   };
 });
 
-vi.mock("./facade-loader.js", () => ({
-  createLazyFacadeObjectValue: (load: () => object) =>
-    new Proxy(
-      {},
-      {
-        get(_target, property) {
-          return Reflect.get(load(), property);
-        },
-      },
-    ),
-  loadBundledPluginPublicSurfaceModuleSyncCore: mocks.loadBundledPluginPublicSurfaceModuleSyncCore,
+vi.mock("./facade-runtime.js", () => ({
+  loadBundledPluginPublicSurfaceModuleSync: mocks.loadBundledPluginPublicSurfaceModuleSync,
 }));
 
 vi.mock("./runtime-config-snapshot.js", () => ({

--- a/src/plugin-sdk/discord.ts
+++ b/src/plugin-sdk/discord.ts
@@ -11,10 +11,8 @@ import type {
 import type { ChannelPlugin } from "./channel-core.js";
 import type { MessageReceipt } from "./channel-outbound.js";
 import type { OpenClawConfig } from "./config-contracts.js";
-import {
-  createLazyFacadeObjectValue,
-  loadBundledPluginPublicSurfaceModuleSyncCore,
-} from "./facade-loader.js";
+import { createLazyFacadeObjectValue } from "./facade-loader.js";
+import { loadBundledPluginPublicSurfaceModuleSync } from "./facade-runtime.js";
 import { getRuntimeConfig, getRuntimeConfigSnapshot } from "./runtime-config-snapshot.js";
 
 /**
@@ -198,14 +196,14 @@ type DiscordRuntimeFacadeModule = {
 };
 
 function loadDiscordApiFacadeModule(): DiscordApiFacadeModule {
-  return loadBundledPluginPublicSurfaceModuleSyncCore<DiscordApiFacadeModule>({
+  return loadBundledPluginPublicSurfaceModuleSync<DiscordApiFacadeModule>({
     dirName: "discord",
     artifactBasename: "api.js",
   });
 }
 
 function loadDiscordRuntimeFacadeModule(): DiscordRuntimeFacadeModule {
-  return loadBundledPluginPublicSurfaceModuleSyncCore<DiscordRuntimeFacadeModule>({
+  return loadBundledPluginPublicSurfaceModuleSync<DiscordRuntimeFacadeModule>({
     dirName: "discord",
     artifactBasename: "runtime-api.js",
   });

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -9,6 +9,7 @@ import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-meta
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { setTestEnvValue } from "../test-utils/env.js";
 import {
   evaluateBundledPluginPublicSurfaceAccess,
   resolveBundledPluginPublicSurfaceAccess as resolveActivationCheckBundledPluginPublicSurfaceAccess,
@@ -117,6 +118,81 @@ afterEach(() => {
 });
 
 describe("plugin-sdk facade runtime", () => {
+  it.each([
+    {
+      artifactBasename: "api.js",
+      exportName: "normalizeDiscordMessagingTarget",
+      invoke: (sdk: typeof import("./discord.js")) => sdk.normalizeDiscordMessagingTarget("123456"),
+      value: (generation: string) => `${generation}:123456`,
+    },
+    {
+      artifactBasename: "runtime-api.js",
+      exportName: "collectDiscordAuditChannelIds",
+      invoke: (sdk: typeof import("./discord.js")) =>
+        sdk.collectDiscordAuditChannelIds({ cfg: {} }),
+      value: (generation: string) => ({ channelIds: [generation], unresolvedChannels: [] }),
+    },
+  ])(
+    "loads public Discord $artifactBasename from an external plugin across lifecycle changes",
+    async ({ artifactBasename, exportName, invoke, value }) => {
+      const root = fs.realpathSync(createTempDirSync("openclaw-discord-facade-installed-"));
+      const pluginDir = path.join(root, "plugin");
+      setTestEnvValue("OPENCLAW_STATE_DIR", path.join(root, "state"));
+      // Source checkouts contain Discord; packaged hosts resolve this excluded plugin through the registry.
+      setTestEnvValue("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
+      setRuntimeConfigSnapshot({});
+      // Keep the synchronous loader on Vitest's real source module graph.
+      testing.setFacadeActivationCheckRuntimeForTest(
+        await import("./facade-activation-check.runtime.js"),
+      );
+      const sdk = await import("./discord.js");
+      expect(() => invoke(sdk)).toThrow(
+        `Unable to resolve bundled plugin public surface discord/${artifactBasename}`,
+      );
+
+      writeJsonFile(path.join(pluginDir, "package.json"), {
+        name: "@openclaw/discord",
+        version: "0.0.0",
+        type: "commonjs",
+        openclaw: { extensions: ["./index.js"] },
+      });
+      writeJsonFile(path.join(pluginDir, "openclaw.plugin.json"), {
+        id: "discord",
+        channels: ["discord"],
+        configSchema: { type: "object", properties: {} },
+      });
+      fs.writeFileSync(path.join(pluginDir, "index.js"), "module.exports = {};\n");
+      const artifactPath = path.join(pluginDir, artifactBasename);
+      fs.writeFileSync(
+        artifactPath,
+        `const value = require("./value.cjs"); exports.${exportName} = () => value;\n`,
+      );
+      const writeValue = (generation: string) =>
+        fs.writeFileSync(
+          path.join(pluginDir, "value.cjs"),
+          `module.exports = ${JSON.stringify(value(generation))};\n`,
+        );
+      writeValue("installed");
+      setRuntimeConfigSnapshot({
+        plugins: { load: { paths: [pluginDir] }, entries: { discord: { enabled: false } } },
+      });
+      clearPluginMetadataLifecycleCaches();
+
+      // Deprecated compatibility helpers do not require plugin activation.
+      expect(invoke(sdk)).toEqual(value("installed"));
+      writeValue("replacement");
+      expect(invoke(sdk)).toEqual(value("installed"));
+      clearPluginMetadataLifecycleCaches();
+      expect(invoke(sdk)).toEqual(value("replacement"));
+
+      fs.linkSync(artifactPath, path.join(pluginDir, "hardlink.js"));
+      clearPluginMetadataLifecycleCaches();
+      expect(() => invoke(sdk)).toThrow(
+        `Unable to open bundled plugin public surface ${artifactPath}`,
+      );
+    },
+  );
+
   it("reuses successful facade locations without repeating filesystem probes", () => {
     const dir = createBundledPluginDir("openclaw-facade-location-cache-", "cached");
     useBundledPluginDirOverrideForTest(dir);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where plugin developers calling the retained Discord SDK helpers could get `MissingPublicSurfaceError` even when the Discord plugin was installed correctly. The core package still exports this deprecated compatibility surface but intentionally does not bundle Discord.

## Why This Change Was Made

Both the API and runtime wrappers now use the existing registry-aware facade loader. The bundled-only resolver could not find an external plugin; the shared loader already owns installed-plugin discovery, filesystem boundaries and lifecycle cache invalidation. Lazy object construction remains in the lightweight facade helper.

This preserves the published compatibility API without adding a second resolver, new activation rules, configuration or dependencies. Production is +4/-6 (net -2); tests are +79/-12.

## User Impact

Installed Discord plugins can supply the existing public helpers through their own package. Missing plugins still report an error; resolution continues to use the existing lifecycle caches. The deprecated subpath remains available for its documented consumers; this does not add a new SDK surface or activate disabled plugins.

## Evidence

- A canonical package from exact main `9bd50c803cce88f2ab387ddaf6cc29b4ef004005` exported the Discord SDK but contained no bundled Discord files. Both public wrappers failed. The same packed host's existing registry-aware loader resolved a valid external Discord package root. Relevant source and package ownership are unchanged at candidate base `e8c332592dcf2431b04ddb5ae48836735b1bd849`.
- Before the production change, both new public-wrapper regressions failed at the installed-plugin call. The same tests pass after the two-call repair. Final focused suite: 44 tests across the facade runtime, bundled loader, public Discord contracts/forwarding and browser siblings.
- The integration cases use generated inert CommonJS external packages with actual metadata discovery. They cover missing/install/replacement lifecycle behavior and the existing hardlink boundary. Vitest uses the existing activation-runtime test binding to the real source module; it does not substitute registry records or resolution.
- On unchanged head `24c297de511722fce32c6ef75d55f946dfc5e32f`, the canonical frozen-lockfile install and full build pass, all 44 focused tests pass, and all 33 changed checks pass. Fresh restricted Codex autoreview reports no P0 findings; independent source review reports no actionable findings.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33087183653) passes on attempt 2. The first attempt had three checkout failures before tests, including one explicit HTTP 429; only failed jobs were retried after backoff. No source or gate was changed to obtain the pass.
- The canonical package built from that run's unchanged build artifact and verified synthetic merge `5ce9d8887d0d8e855ec6b10b51c204b0ca5be310` passes tarball and import-graph checks. It retains the public SDK export and excludes bundled Discord. Package SHA-256: `31bbfe2276cf2513f538fb3d38a6c64c486cfbf024e85cd2b034fb453f280d4b`.
- **Remaining gate: packaged runtime completion.** The isolated current package resolves and imports the public module, but the first `normalizeDiscordMessagingTarget` call timed out at 120 seconds under Node 26.7. A separate 30-second diagnostic observed progressing module loading, not an idle deadlock; it does not establish the timeout's cause or a runtime pass. No timeout increase, source workaround or merge has followed. An independent clean Linux package-install proof is being prepared.

The retained baseline and current local replay use a real packed host with the documented local-source external plugin and isolated state, not a clean-machine Discord npm installation. The current replay grants reads only to its consumer fixture and Node installation; source checkouts and the unexcluded CI plugin tree are inaccessible. All packed JavaScript remains byte-identical to the CI artifact. No Discord account, channel or provider traffic was used: this change concerns package resolution, not transport behavior.
