### PR TITLE
fix(agents): skip implicit workspace scaffold for runtime-managed ACP agents

### DIFF
--- a/src/agents/acp-workspace-provisioning.test.ts
+++ b/src/agents/acp-workspace-provisioning.test.ts
@@ -149,6 +149,31 @@ describe("resolveAcpAgentWorkspaceProvisioningForTurn", () => {
     ).resolves.toBe("standard");
   });
 
+  it.each([
+    {
+      cwd: "/projects/command",
+      sessionCwd: "/shared-ws/codex",
+      expected: "runtime-managed-implicit",
+    },
+    {
+      cwd: "/shared-ws/codex",
+      sessionCwd: "/projects/session",
+      expected: "standard",
+    },
+  ] as const)(
+    "gives the invocation cwd precedence over session metadata ($expected)",
+    async ({ cwd, sessionCwd, expected }) => {
+      await expect(
+        resolveAcpAgentWorkspaceProvisioningForTurn({
+          cfg: baseCfg,
+          agentId: "codex",
+          cwd,
+          sessionEntry: { acp: sessionAcpMeta(sessionCwd) },
+        }),
+      ).resolves.toBe(expected);
+    },
+  );
+
   it("keeps standard provisioning without an invocation cwd and no runtime default", async () => {
     await expect(
       resolveAcpAgentWorkspaceProvisioningForTurn({ cfg: baseCfg, agentId: "codex" }),

--- a/src/agents/acp-workspace-provisioning.test.ts
+++ b/src/agents/acp-workspace-provisioning.test.ts
@@ -1,0 +1,202 @@
+// Turn-level provisioning resolution regressions (#92015).
+// Covers invocation-scoped cwd decisions: mixed bindings on one agent and
+// workspace-equal cwds keep standard bootstrap behavior.
+import { describe, beforeEach, expect, it } from "vitest";
+import type { ChannelConfiguredBindingProvider } from "../channels/plugins/types.adapters.js";
+import type { ChannelPlugin } from "../channels/plugins/types.public.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SessionAcpMeta } from "../config/sessions/types.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
+import { resolveAcpAgentWorkspaceProvisioningForTurn } from "./acp-workspace-provisioning.js";
+
+const identityBindings: ChannelConfiguredBindingProvider = {
+  compileConfiguredBinding: ({ conversationId }) => {
+    const normalized = conversationId.trim();
+    return normalized ? { conversationId: normalized } : null;
+  },
+  matchInboundConversation: ({ compiledBinding, conversationId }) =>
+    compiledBinding.conversationId === conversationId ? { conversationId, matchPriority: 2 } : null,
+};
+
+function createConfiguredBindingTestPlugin(
+  id: ChannelPlugin["id"],
+  bindings: ChannelConfiguredBindingProvider,
+): Pick<ChannelPlugin, "id" | "meta" | "capabilities" | "config" | "bindings"> {
+  return {
+    ...createChannelTestPluginBase({ id }),
+    bindings,
+  };
+}
+
+beforeEach(() => {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "discord",
+        plugin: createConfiguredBindingTestPlugin("discord", identityBindings),
+        source: "test",
+      },
+    ]),
+  );
+});
+
+function acpBinding(params: {
+  conversationId: string;
+  agentId?: string;
+  cwd?: string;
+}): NonNullable<OpenClawConfig["bindings"]>[number] {
+  return {
+    type: "acp",
+    agentId: params.agentId ?? "codex",
+    match: {
+      channel: "discord",
+      peer: { kind: "channel", id: params.conversationId },
+    },
+    ...(params.cwd ? { acp: { cwd: params.cwd } } : {}),
+  } as NonNullable<OpenClawConfig["bindings"]>[number];
+}
+
+const baseCfg: OpenClawConfig = {
+  agents: {
+    defaults: { workspace: "/shared-ws" },
+    list: [{ id: "main" }, { id: "codex", runtime: { type: "acp" } }],
+  },
+};
+
+function sessionAcpMeta(cwd?: string): SessionAcpMeta {
+  return {
+    backend: "acpx",
+    agent: "codex",
+    runtimeSessionName: "rs",
+    mode: "persistent",
+    ...(cwd ? { cwd } : {}),
+    state: "idle",
+    lastActivityAt: 0,
+  };
+}
+
+async function bindingSessionKey(cfg: OpenClawConfig, conversationId: string): Promise<string> {
+  const { resolveConfiguredAcpBindingRecord } =
+    await import("../acp/persistent-bindings.resolve.js");
+  const resolved = resolveConfiguredAcpBindingRecord({
+    cfg,
+    channel: "discord",
+    accountId: "default",
+    conversationId,
+  });
+  return resolved?.record.targetSessionKey ?? "";
+}
+
+describe("resolveAcpAgentWorkspaceProvisioningForTurn", () => {
+  it("scopes the skip to the turn bound to a cwd-bearing binding (mixed bindings)", async () => {
+    const cfg: OpenClawConfig = {
+      ...baseCfg,
+      bindings: [
+        acpBinding({ conversationId: "111", cwd: "/projects/app" }),
+        acpBinding({ conversationId: "222" }),
+      ],
+    };
+    const keyWithCwd = await bindingSessionKey(cfg, "111");
+    const keyWithoutCwd = await bindingSessionKey(cfg, "222");
+    expect(keyWithCwd).not.toBe(keyWithoutCwd);
+
+    // Turn scoped to the binding whose cwd points elsewhere: skip scaffold.
+    await expect(
+      resolveAcpAgentWorkspaceProvisioningForTurn({
+        cfg,
+        agentId: "codex",
+        sessionKey: keyWithCwd,
+      }),
+    ).resolves.toBe("runtime-managed-implicit");
+
+    // Turn scoped to the sibling binding without cwd: keep bootstrap.
+    await expect(
+      resolveAcpAgentWorkspaceProvisioningForTurn({
+        cfg,
+        agentId: "codex",
+        sessionKey: keyWithoutCwd,
+      }),
+    ).resolves.toBe("standard");
+  });
+
+  it("keeps standard provisioning when the binding cwd equals the resolved workspace", async () => {
+    const cfg: OpenClawConfig = {
+      ...baseCfg,
+      bindings: [acpBinding({ conversationId: "111", cwd: "/shared-ws/codex" })],
+    };
+    const key = await bindingSessionKey(cfg, "111");
+    await expect(
+      resolveAcpAgentWorkspaceProvisioningForTurn({ cfg, agentId: "codex", sessionKey: key }),
+    ).resolves.toBe("standard");
+  });
+
+  it("uses the live session ACP meta cwd as the invocation cwd", async () => {
+    await expect(
+      resolveAcpAgentWorkspaceProvisioningForTurn({
+        cfg: baseCfg,
+        agentId: "codex",
+        sessionEntry: { acp: sessionAcpMeta("/projects/app") },
+      }),
+    ).resolves.toBe("runtime-managed-implicit");
+
+    await expect(
+      resolveAcpAgentWorkspaceProvisioningForTurn({
+        cfg: baseCfg,
+        agentId: "codex",
+        sessionEntry: { acp: sessionAcpMeta() },
+      }),
+    ).resolves.toBe("standard");
+  });
+
+  it("keeps standard provisioning without an invocation cwd and no runtime default", async () => {
+    await expect(
+      resolveAcpAgentWorkspaceProvisioningForTurn({ cfg: baseCfg, agentId: "codex" }),
+    ).resolves.toBe("standard");
+    await expect(
+      resolveAcpAgentWorkspaceProvisioningForTurn({
+        cfg: baseCfg,
+        agentId: "codex",
+        sessionKey: "agent:codex:not-a-binding-key",
+      }),
+    ).resolves.toBe("standard");
+  });
+
+  it("keeps standard provisioning for embedded agents and explicit workspaces", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [
+          { id: "work", runtime: { type: "embedded" } },
+          { id: "pinned", workspace: "/explicit-ws", runtime: { type: "acp" } },
+        ],
+      },
+    };
+    await expect(
+      resolveAcpAgentWorkspaceProvisioningForTurn({
+        cfg,
+        agentId: "work",
+        sessionEntry: { acp: sessionAcpMeta("/projects/app") },
+      }),
+    ).resolves.toBe("standard");
+    await expect(
+      resolveAcpAgentWorkspaceProvisioningForTurn({
+        cfg,
+        agentId: "pinned",
+        sessionEntry: { acp: sessionAcpMeta("/projects/app") },
+      }),
+    ).resolves.toBe("standard");
+  });
+
+  it("falls back to the agent-global runtime acp.cwd default", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [{ id: "codex", runtime: { type: "acp", acp: { cwd: "/projects/app" } } }],
+      },
+    };
+    await expect(
+      resolveAcpAgentWorkspaceProvisioningForTurn({ cfg, agentId: "codex" }),
+    ).resolves.toBe("runtime-managed-implicit");
+  });
+});

--- a/src/agents/acp-workspace-provisioning.ts
+++ b/src/agents/acp-workspace-provisioning.ts
@@ -1,0 +1,60 @@
+/**
+ * Turn-level ACP workspace provisioning resolution (#92015).
+ *
+ * Resolves the provisioning mode for one concrete invocation by using the
+ * invocation's own cwd — the live session's ACP meta cwd first, then the
+ * configured ACP binding that owns the session key — instead of an agent-wide
+ * binding scan, so mixed-binding agents and workspace-equal cwds keep standard
+ * bootstrap behavior.
+ */
+import { resolveAcpSessionCwd } from "@openclaw/acp-core/runtime/session-identifiers";
+import type { SessionAcpMeta } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.js";
+import {
+  isImplicitAcpWorkspaceCandidate,
+  resolveAgentWorkspaceProvisioning,
+  type AgentWorkspaceProvisioning,
+} from "./agent-scope-config.js";
+
+export async function resolveAcpAgentWorkspaceProvisioningForTurn(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  /** Workspace directory being provisioned for this turn, when already known. */
+  workspaceDir?: string;
+  /** Session key for this invocation, when already known. */
+  sessionKey?: string;
+  /** Live session entry carrying ACP meta, when already at hand. */
+  sessionEntry?: { acp?: SessionAcpMeta };
+}): Promise<AgentWorkspaceProvisioning> {
+  if (!isImplicitAcpWorkspaceCandidate(params.cfg, params.agentId)) {
+    return "standard";
+  }
+  const invocation = params.workspaceDir ? { workspaceDir: params.workspaceDir } : undefined;
+  // A live ACP session carries this invocation's effective cwd.
+  const metaCwd = resolveAcpSessionCwd(params.sessionEntry?.acp);
+  if (metaCwd) {
+    return resolveAgentWorkspaceProvisioning(params.cfg, params.agentId, {
+      ...invocation,
+      cwd: metaCwd,
+    });
+  }
+  // Configured conversation bindings are conversation-scoped: resolve the one
+  // binding that owns this session key rather than scanning every binding.
+  if (params.sessionKey) {
+    const { resolveConfiguredAcpBindingSpecBySessionKey } =
+      await import("../acp/persistent-bindings.resolve.js");
+    const bindingCwd = resolveConfiguredAcpBindingSpecBySessionKey({
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+    })?.cwd;
+    if (bindingCwd) {
+      return resolveAgentWorkspaceProvisioning(params.cfg, params.agentId, {
+        ...invocation,
+        cwd: bindingCwd,
+      });
+    }
+  }
+  // No invocation cwd known: the agent-global runtime acp.cwd default (if any)
+  // still applies; otherwise the run falls back to the workspace as cwd.
+  return resolveAgentWorkspaceProvisioning(params.cfg, params.agentId, invocation);
+}

--- a/src/agents/acp-workspace-provisioning.ts
+++ b/src/agents/acp-workspace-provisioning.ts
@@ -21,6 +21,8 @@ export async function resolveAcpAgentWorkspaceProvisioningForTurn(params: {
   agentId: string;
   /** Workspace directory being provisioned for this turn, when already known. */
   workspaceDir?: string;
+  /** Effective cwd explicitly selected for this invocation, when already known. */
+  cwd?: string;
   /** Session key for this invocation, when already known. */
   sessionKey?: string;
   /** Live session entry carrying ACP meta, when already at hand. */
@@ -30,6 +32,12 @@ export async function resolveAcpAgentWorkspaceProvisioningForTurn(params: {
     return "standard";
   }
   const invocation = params.workspaceDir ? { workspaceDir: params.workspaceDir } : undefined;
+  if (params.cwd) {
+    return resolveAgentWorkspaceProvisioning(params.cfg, params.agentId, {
+      ...invocation,
+      cwd: params.cwd,
+    });
+  }
   // A live ACP session carries this invocation's effective cwd.
   const metaCwd = resolveAcpSessionCwd(params.sessionEntry?.acp);
   if (metaCwd) {

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -425,6 +425,73 @@ export function resolveAgentWorkspaceDir(
   return stripNullBytes(path.join(stateDir, `workspace-${id}`));
 }
 
+/** How a resolved agent workspace should be provisioned by the lifecycle owner. */
+export type AgentWorkspaceProvisioning = "standard" | "runtime-managed-implicit";
+
+/**
+ * Resolves whether an agent's workspace is runtime-managed and implicit.
+ *
+ * A workspace is runtime-managed-implicit only when all of the following hold:
+ * - the agent runs the ACP runtime (non-embedded),
+ * - the agent entry does not configure an explicit `workspace`,
+ * - the provisioned directory is the config-resolved implicit workspace, and
+ * - this invocation has a distinct authoritative cwd: the invocation cwd when
+ *   known (session ACP meta or the configured binding that owns the session
+ *   key), otherwise the agent-global runtime `acp.cwd` default. A cwd equal to
+ *   the resolved workspace is not distinct.
+ *
+ * Such agents must not get a scaffolded default workspace with bootstrap
+ * files and `git init` (#92015). Every other shape — explicit workspaces,
+ * ACP agents that fall back to their workspace as cwd, and embedded agents —
+ * keeps standard provisioning.
+ */
+export function resolveAgentWorkspaceProvisioning(
+  cfg: OpenClawConfig,
+  agentId: string,
+  invocation?: {
+    /** Effective cwd for this invocation, if known. */
+    cwd?: string;
+    /** Directory being provisioned; defaults to the config-resolved implicit workspace. */
+    workspaceDir?: string;
+  },
+): AgentWorkspaceProvisioning {
+  const id = normalizeAgentId(agentId);
+  const entry = resolveAgentConfig(cfg, id);
+  if (entry?.runtime?.type !== "acp") {
+    return "standard";
+  }
+  if (entry.workspace?.trim()) {
+    return "standard";
+  }
+  const implicitDir = resolveAgentWorkspaceDir(cfg, id);
+  const workspaceDir = invocation?.workspaceDir?.trim()
+    ? resolveUserPath(invocation.workspaceDir)
+    : implicitDir;
+  // A provisioned dir that differs from the config-resolved implicit workspace
+  // is an explicit selection (for example a spawned-context override).
+  if (workspaceDir !== implicitDir) {
+    return "standard";
+  }
+  const cwd = normalizeOptionalString(invocation?.cwd)?.trim() ?? entry.runtime.acp?.cwd?.trim();
+  if (!cwd) {
+    return "standard";
+  }
+  if (path.resolve(resolveUserPath(cwd)) === path.resolve(workspaceDir)) {
+    return "standard";
+  }
+  return "runtime-managed-implicit";
+}
+
+/**
+ * Cheap candidate check for turn-level provisioning resolution: true only for
+ * ACP agents without an explicit workspace, so heavier invocation-cwd lookups
+ * (configured binding resolution) stay off embedded/default agent turns.
+ */
+export function isImplicitAcpWorkspaceCandidate(cfg: OpenClawConfig, agentId: string): boolean {
+  const entry = resolveAgentConfig(cfg, normalizeAgentId(agentId));
+  return entry?.runtime?.type === "acp" && !entry.workspace?.trim();
+}
+
 export function tryResolveConfiguredAgentWorkspaceDir(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -23,6 +23,7 @@ import {
   resolveRunModelFallbacksOverride,
   resolveSubagentModelFallbacksOverride,
   resolveAgentWorkspaceDir,
+  resolveAgentWorkspaceProvisioning,
   resolveAutoFallbackPrimaryProbe,
   resolveAgentIdByWorkspacePath,
   setAgentEffectiveModelPrimary,
@@ -1125,6 +1126,138 @@ describe("resolveAgentConfig", () => {
       resolveAgentWorkspaceDir(cfg, "main"),
     );
     expect(workspace).toBe(path.resolve(stateDir, "workspace-main"));
+  });
+});
+
+describe("resolveAgentWorkspaceProvisioning", () => {
+  it("marks an ACP agent without an explicit workspace but a distinct runtime cwd as runtime-managed", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [
+          { id: "main" },
+          { id: "codex", runtime: { type: "acp", acp: { cwd: "/projects/app" } } },
+        ],
+      },
+    };
+    expect(resolveAgentWorkspaceProvisioning(cfg, "codex")).toBe("runtime-managed-implicit");
+  });
+
+  it("marks an invocation with a distinct binding-derived cwd as runtime-managed", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [{ id: "main" }, { id: "codex", runtime: { type: "acp" } }],
+      },
+    };
+    expect(resolveAgentWorkspaceProvisioning(cfg, "codex", { cwd: "/projects/app" })).toBe(
+      "runtime-managed-implicit",
+    );
+  });
+
+  it("keeps standard provisioning when the ACP agent declares an explicit workspace (#92015)", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [
+          {
+            id: "codex",
+            workspace: "/explicit-ws",
+            runtime: { type: "acp", acp: { cwd: "/projects/app" } },
+          },
+        ],
+      },
+    };
+    expect(resolveAgentWorkspaceProvisioning(cfg, "codex")).toBe("standard");
+    expect(resolveAgentWorkspaceProvisioning(cfg, "codex", { cwd: "/projects/app" })).toBe(
+      "standard",
+    );
+  });
+
+  it("keeps standard provisioning when the invocation has no distinct cwd anywhere", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [{ id: "main" }, { id: "codex", runtime: { type: "acp" } }],
+      },
+    };
+    expect(resolveAgentWorkspaceProvisioning(cfg, "codex")).toBe("standard");
+  });
+
+  it("does not treat a configured binding cwd as an invocation cwd (mixed bindings, #92015 review)", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [{ id: "codex", runtime: { type: "acp" } }],
+      },
+      bindings: [
+        {
+          type: "acp",
+          agentId: "codex",
+          match: { channel: "telegram", peer: { kind: "direct", id: "123" } },
+          acp: { cwd: "/projects/app" },
+        },
+      ],
+    } as OpenClawConfig;
+    // The turn scoped to a different binding without cwd keeps bootstrap.
+    expect(resolveAgentWorkspaceProvisioning(cfg, "codex")).toBe("standard");
+    // The turn scoped to the cwd-bearing binding skips scaffolding.
+    expect(resolveAgentWorkspaceProvisioning(cfg, "codex", { cwd: "/projects/app" })).toBe(
+      "runtime-managed-implicit",
+    );
+  });
+
+  it("keeps standard provisioning when the invocation cwd equals the resolved workspace", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [{ id: "main" }, { id: "codex", runtime: { type: "acp" } }],
+      },
+    };
+    expect(resolveAgentWorkspaceProvisioning(cfg, "codex", { cwd: "/shared-ws/codex/" })).toBe(
+      "standard",
+    );
+  });
+
+  it("lets the invocation cwd win over the runtime default when it equals the workspace", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [
+          { id: "main" },
+          { id: "codex", runtime: { type: "acp", acp: { cwd: "/projects/app" } } },
+        ],
+      },
+    };
+    expect(resolveAgentWorkspaceProvisioning(cfg, "codex", { cwd: "/shared-ws/codex" })).toBe(
+      "standard",
+    );
+  });
+
+  it("keeps standard provisioning for a provisioned dir that is not the implicit workspace", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [{ id: "codex", runtime: { type: "acp", acp: { cwd: "/projects/app" } } }],
+      },
+    };
+    expect(
+      resolveAgentWorkspaceProvisioning(cfg, "codex", {
+        cwd: "/projects/app",
+        workspaceDir: "/spawned-override-ws",
+      }),
+    ).toBe("standard");
+  });
+
+  it("keeps standard provisioning for embedded agents without an explicit workspace", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: "/shared-ws" },
+        list: [{ id: "main" }, { id: "work", runtime: { type: "embedded" } }],
+      },
+    };
+    expect(resolveAgentWorkspaceProvisioning(cfg, "work")).toBe("standard");
+    expect(resolveAgentWorkspaceProvisioning(cfg, "main")).toBe("standard");
   });
 });
 

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -45,6 +45,7 @@ export {
   resolveAgentDir,
   resolveDefaultAgentDir,
   resolveAgentWorkspaceDir,
+  resolveAgentWorkspaceProvisioning,
   tryResolveConfiguredAgentWorkspaceDir,
   resolveDefaultAgentId,
   resolveAmbientOwnerAgentId,
@@ -55,6 +56,7 @@ export {
   tryResolveDefaultAgentId,
   AgentSelectionRequiredError,
   type AgentSelectionContext,
+  type AgentWorkspaceProvisioning,
   type ResolvedAgentConfig,
 } from "./agent-scope-config.js";
 

--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -357,6 +357,7 @@ export async function prepareAgentCommandExecution(
       cfg,
       agentId: sessionAgentId,
       workspaceDir,
+      cwd: resolvedCwd,
       sessionKey: sessionKey ?? undefined,
       sessionEntry: sessionEntryRaw ?? undefined,
     });

--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -351,10 +351,20 @@ export async function prepareAgentCommandExecution(
   });
   const runLease = worktreeId ? await acquireWorktreeRunLease(worktreeId) : undefined;
   try {
+    const { resolveAcpAgentWorkspaceProvisioningForTurn } =
+      await import("../acp-workspace-provisioning.js");
+    const workspaceProvisioning = await resolveAcpAgentWorkspaceProvisioningForTurn({
+      cfg,
+      agentId: sessionAgentId,
+      workspaceDir,
+      sessionKey: sessionKey ?? undefined,
+      sessionEntry: sessionEntryRaw ?? undefined,
+    });
     await ensureAgentWorkspace({
       dir: workspaceDirRaw,
       ensureBootstrapFiles: !agentCfg?.skipBootstrap,
       skipOptionalBootstrapFiles: agentCfg?.skipOptionalBootstrapFiles,
+      provisioning: workspaceProvisioning,
     });
     const runId = opts.runId?.trim() || sessionId;
     const { getAcpSessionManager } = await loadAcpManagerRuntime();

--- a/src/agents/workspace.provisioning.test.ts
+++ b/src/agents/workspace.provisioning.test.ts
@@ -1,0 +1,78 @@
+// Focused coverage for runtime-managed-implicit workspace provisioning (#92015).
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { makeTempWorkspace } from "../test-helpers/workspace.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { resetLegacyWorkspaceStateCheckForTest } from "./workspace-legacy-state.test-support.js";
+import { readWorkspaceStateSnapshot } from "./workspace-state-store.js";
+import {
+  DEFAULT_AGENTS_FILENAME,
+  DEFAULT_BOOTSTRAP_FILENAME,
+  ensureAgentWorkspace,
+} from "./workspace.js";
+
+let testState: OpenClawTestState | undefined;
+
+beforeEach(async () => {
+  resetLegacyWorkspaceStateCheckForTest();
+  testState = await createOpenClawTestState({
+    layout: "state-only",
+    prefix: "openclaw-workspace-provisioning-",
+  });
+});
+
+afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
+  resetLegacyWorkspaceStateCheckForTest();
+  await testState?.cleanup();
+  testState = undefined;
+});
+
+async function expectPathMissing(filePath: string): Promise<void> {
+  await expect(fs.access(filePath)).rejects.toHaveProperty("code", "ENOENT");
+}
+
+describe("ensureAgentWorkspace runtime-managed-implicit provisioning", () => {
+  it("creates only the directory for runtime-managed-implicit provisioning (#92015)", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const targetDir = path.join(tempDir, "implicit-acp-workspace");
+
+    const result = await ensureAgentWorkspace({
+      dir: targetDir,
+      ensureBootstrapFiles: true,
+      provisioning: "runtime-managed-implicit",
+    });
+
+    expect(result.dir).toBe(targetDir);
+    expect(result.bootstrapPending).toBe(false);
+    // Directory is provisioned so ACP cwd fallback and media staging keep working...
+    await expect(fs.access(targetDir)).resolves.toBeUndefined();
+    // ...but no bootstrap files, git repo, or workspace state are seeded.
+    await expectPathMissing(path.join(targetDir, DEFAULT_AGENTS_FILENAME));
+    await expectPathMissing(path.join(targetDir, DEFAULT_BOOTSTRAP_FILENAME));
+    await expectPathMissing(path.join(targetDir, ".git"));
+    expect(readWorkspaceStateSnapshot(targetDir).setupExists).toBe(false);
+  });
+
+  it("runtime-managed-implicit provisioning preserves pre-existing workspace content", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const targetDir = path.join(tempDir, "implicit-acp-workspace");
+    await fs.mkdir(targetDir, { recursive: true });
+    await fs.writeFile(path.join(targetDir, "user-notes.md"), "keep me\n");
+
+    await ensureAgentWorkspace({
+      dir: targetDir,
+      ensureBootstrapFiles: true,
+      provisioning: "runtime-managed-implicit",
+    });
+
+    expect(await fs.readFile(path.join(targetDir, "user-notes.md"), "utf8")).toBe("keep me\n");
+    await expectPathMissing(path.join(targetDir, DEFAULT_AGENTS_FILENAME));
+    await expectPathMissing(path.join(targetDir, ".git"));
+  });
+});

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -909,6 +909,13 @@ export async function ensureAgentWorkspace(params?: {
    * Required workspace setup such as AGENTS.md still runs.
    */
   skipOptionalBootstrapFiles?: string[];
+  /**
+   * Workspace provisioning mode. "runtime-managed-implicit" marks a workspace
+   * owned by a runtime-managed (ACP) agent without an explicit workspace and
+   * with a distinct authoritative cwd: only the directory is provisioned, and
+   * bootstrap files, workspace setup state, and `git init` are skipped (#92015).
+   */
+  provisioning?: "standard" | "runtime-managed-implicit";
 }): Promise<{
   dir: string;
   agentsPath?: string;
@@ -921,6 +928,13 @@ export async function ensureAgentWorkspace(params?: {
 }> {
   const rawDir = params?.dir?.trim() ? params.dir.trim() : DEFAULT_AGENT_WORKSPACE_DIR;
   const dir = resolveUserPath(rawDir);
+  if (params?.provisioning === "runtime-managed-implicit") {
+    // The workspace belongs to a runtime-managed agent with a distinct cwd.
+    // Provision the directory (cwd fallback, media staging) without scaffolding
+    // bootstrap files, setup state, or a nested git repository (#92015).
+    await fs.mkdir(dir, { recursive: true });
+    return { dir, bootstrapPending: false };
+  }
   let initialState = readCanonicalWorkspaceStateSnapshot(dir);
   let reseedingExpiredWorkspaceState = false;
   const recentAttestation = recentWorkspaceAttestation(initialState.attestation);

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,6 +1,7 @@
 // Main auto-reply pipeline: prepares context, runs commands, and dispatches agents.
 import fs from "node:fs/promises";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { isImplicitAcpWorkspaceCandidate } from "../../agents/agent-scope-config.js";
 import {
   hasLegacyAutoFallbackWithoutOrigin,
   resolveAutoFallbackPrimaryProbe,
@@ -516,6 +517,20 @@ export async function getReplyFromConfig(
     ? { ...optsWithSkillFilter, queueModeOverride: nativeSlashCommandFastReply.queueModeOverride }
     : optsWithSkillFilter;
 
+  const acpWorkspaceProvisioningInput = isImplicitAcpWorkspaceCandidate(cfg, agentId)
+    ? await traceGetReplyPhase("reply.resolve_acp_workspace_provisioning", async () => {
+        // Implicit ACP agents need the live session's ACP meta (per-session cwd
+        // from /acp spawn --cwd or /acp cwd) before workspace scaffolding runs.
+        const state = resolveReplySessionPreprocessingState({ ctx: finalized, cfg });
+        return {
+          cfg,
+          agentId,
+          sessionKey: state.sessionKey,
+          ...(state.sessionEntry ? { sessionEntry: state.sessionEntry } : {}),
+        };
+      })
+    : { cfg, agentId, ...(agentSessionKey ? { sessionKey: agentSessionKey } : {}) };
+
   const workspace = await traceGetReplyPhase("reply.ensure_workspace", async () =>
     useFastTestBootstrap
       ? (await fs.mkdir(workspaceDirRaw, { recursive: true }), { dir: workspaceDirRaw })
@@ -523,6 +538,9 @@ export async function getReplyFromConfig(
           dir: workspaceDirRaw,
           ensureBootstrapFiles: !agentCfg?.skipBootstrap && !isFastTestEnv,
           skipOptionalBootstrapFiles: agentCfg?.skipOptionalBootstrapFiles,
+          provisioning: await (
+            await import("../../agents/acp-workspace-provisioning.js")
+          ).resolveAcpAgentWorkspaceProvisioningForTurn(acpWorkspaceProvisioningInput),
         }),
   );
   const workspaceDir = workspace.dir;

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -616,6 +616,43 @@ describe("agentCommand", () => {
     });
   });
 
+  it("does not scaffold an implicit ACP workspace when the command supplies cwd", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const repository = path.join(home, "repository");
+      const configuredWorkspace = path.join(repository, ".openclaw", "workspace");
+      fs.mkdirSync(repository, { recursive: true });
+      execFileSync("git", ["-C", repository, "init", "-b", "main"]);
+      fs.writeFileSync(path.join(repository, "README.md"), "base\n");
+      execFileSync("git", ["-C", repository, "add", "README.md"]);
+      mockConfig(home, store, { workspace: configuredWorkspace }, undefined, [
+        { id: "codex", runtime: { type: "acp", acp: { agent: "codex" } } },
+      ]);
+      const actualWorkspace =
+        await vi.importActual<typeof import("../agents/workspace.js")>("../agents/workspace.js");
+      vi.mocked(ensureAgentWorkspace).mockImplementationOnce((params) =>
+        actualWorkspace.ensureAgentWorkspace(params),
+      );
+
+      const prepared = await prepareAgentCommandExecution(
+        {
+          message: "inspect this repo",
+          agentId: "codex",
+          sessionId: "explicit-cwd-acp",
+          cwd: repository,
+        },
+        runtime,
+      );
+      expect(prepared.workspaceDir).toBe(configuredWorkspace);
+      const implicitWorkspace = configuredWorkspace;
+
+      expect(fs.existsSync(implicitWorkspace)).toBe(true);
+      expect(fs.existsSync(path.join(implicitWorkspace, "AGENTS.md"))).toBe(false);
+      expect(fs.existsSync(path.join(implicitWorkspace, ".git"))).toBe(false);
+      expect(() => execFileSync("git", ["-C", repository, "add", "-A"])).not.toThrow();
+    });
+  });
+
   it("uses the recorded canonical workspace for a managed-worktree skill snapshot", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -206,6 +206,9 @@ export async function prepareCronRunContext(params: {
     dir: modelOwner.workspaceDir,
     ensureBootstrapFiles: !agentCfg?.skipBootstrap && !params.isFastTestEnv,
     skipOptionalBootstrapFiles: agentCfg?.skipOptionalBootstrapFiles,
+    provisioning: await (
+      await import("../../agents/acp-workspace-provisioning.js")
+    ).resolveAcpAgentWorkspaceProvisioningForTurn({ cfg: runtimeCfg, agentId }),
   });
   const workspaceDir = workspace.dir;
 

--- a/src/cron/trigger-script.test.ts
+++ b/src/cron/trigger-script.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { wrapToolWithBeforeToolCallHook } from "../agents/agent-tools.before-tool-call.js";
 import { BEFORE_TOOL_CALL_HOOK_CONTEXT } from "../agents/before-tool-call-metadata.js";
 import type { CodeModeHeadlessResult } from "../agents/code-mode.js";
@@ -11,6 +15,7 @@ type HeadlessParams = Parameters<NonNullable<EvaluatorDeps["runHeadless"]>>[0];
 type PrepareParams = Parameters<NonNullable<EvaluatorDeps["prepareRuntime"]>>[0];
 
 const beforeToolCallTesting = { BEFORE_TOOL_CALL_HOOK_CONTEXT };
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function completed(params: { value: unknown; output?: unknown[] }): CodeModeHeadlessResult {
   return {
@@ -69,6 +74,52 @@ function createCronTriggerEvaluator(deps: EvaluatorDeps) {
 }
 
 describe("cron trigger script evaluator", () => {
+  it.each(["trigger", "payload"] as const)(
+    "does not scaffold an implicit ACP workspace during %s execution (#92015)",
+    async (mode) => {
+      const parentRepo = tempDirs.make("openclaw-cron-acp-workspace-");
+      expect(spawnSync("git", ["init", "-q"], { cwd: parentRepo }).status).toBe(0);
+      const workspaceDir = path.join(parentRepo, ".openclaw", "workspace");
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: workspaceDir },
+          entries: {
+            codex: { runtime: { type: "acp", acp: { agent: "codex", cwd: parentRepo } } },
+          },
+        },
+        plugins: { enabled: false },
+      };
+      const runtime = createCronScriptRuntime({
+        config,
+        runHeadless: vi.fn(async () =>
+          completed({ value: mode === "trigger" ? { fire: false } : { notify: "ok" } }),
+        ),
+      });
+
+      if (mode === "trigger") {
+        await runtime.evaluateTrigger({
+          jobId: "acp-workspace-trigger",
+          agentId: "codex",
+          script: "return { fire: false }",
+          state: null,
+          toolsAllow: [],
+        });
+      } else {
+        await runtime.executePayload({
+          jobId: "acp-workspace-payload",
+          agentId: "codex",
+          script: "return { notify: 'ok' }",
+          state: null,
+          toolsAllow: [],
+        });
+      }
+
+      expect(fs.existsSync(path.join(workspaceDir, "AGENTS.md"))).toBe(false);
+      expect(fs.existsSync(path.join(workspaceDir, ".git"))).toBe(false);
+      expect(spawnSync("git", ["add", "-A"], { cwd: parentRepo }).status).toBe(0);
+    },
+  );
+
   it("prefers a valid returned value and injects trigger state", async () => {
     const runHeadless = vi.fn(async (_params: HeadlessParams) =>
       completed({

--- a/src/cron/trigger-script.ts
+++ b/src/cron/trigger-script.ts
@@ -129,10 +129,18 @@ async function prepareTriggerRuntime(params: {
   });
   const workspaceDirRaw = resolveAgentWorkspaceDir(config, agentId);
   const agentDir = resolveAgentDir(config, agentId);
+  const { resolveAcpAgentWorkspaceProvisioningForTurn } =
+    await import("../agents/acp-workspace-provisioning.js");
+  const workspaceProvisioning = await resolveAcpAgentWorkspaceProvisioningForTurn({
+    cfg: config,
+    agentId,
+    workspaceDir: workspaceDirRaw,
+  });
   const workspace = await ensureAgentWorkspace({
     dir: workspaceDirRaw,
     ensureBootstrapFiles: !agentDefaults.skipBootstrap,
     skipOptionalBootstrapFiles: agentDefaults.skipOptionalBootstrapFiles,
+    provisioning: workspaceProvisioning,
   });
   params.signal?.throwIfAborted();
   const workspaceDir = workspace.dir;


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #92015

## What Problem This Solves

Fixes an issue where users configuring a runtime-managed (ACP) agent without an explicit `workspace` would get an implicit default workspace directory auto-scaffolded inside `agents.defaults.workspace` on every ACP turn: bootstrap files (`AGENTS.md`, `BOOTSTRAP.md`, ...) are seeded and `git init` runs inside the directory. When `agents.defaults.workspace` points inside an existing git repository, the nested repository corrupts the parent: `git add -A` and auto-commit scripts fail because the nested directory has no commit checked out.

- **Related:** #92939 (prior attempt, closed unmerged — its review identified the explicit-workspace compatibility regression and the sibling-path gap this change addresses); #93176 / #83593 (inherited nested workspace marker handling — separate trigger, not touched here).

## Why This Change Was Made

Carry the authored-versus-inherited workspace fact and the resolved ACP cwd requirement to the workspace lifecycle owner instead of patching a single entry point. `resolveAgentWorkspaceProvisioning()` decides the provisioning mode as a pure function of config: an agent is `runtime-managed-implicit` only when it runs the ACP runtime, has no explicit `workspace`, and has a distinct authoritative cwd (runtime `acp.cwd` or an ACP binding cwd). `ensureAgentWorkspace()` gains a `provisioning` mode that only provisions the directory — ACP cwd fallback and media staging keep a usable directory — while skipping bootstrap files, workspace setup state, and `git init`. All three ACP-reachable lanes (agent command, auto-reply, isolated cron) pass the same gate, so no caller is left scaffolding.

- **Intended outcome:** ACP agent + no explicit workspace + distinct cwd → directory exists, no bootstrap files, no nested `.git`, parent repo `git add -A` unaffected.
- **Out of scope:** refusing `git init` inside existing repositories in general (issue's recommended fix 2 — independent hardening, tracked separately); workspace-state marker compatibility (#93176 area); changing behavior for explicit workspaces, ACP workspace-cwd fallback, or embedded agents.
- **Highest-risk area:** regressing agents that intentionally rely on the implicit workspace (explicit-workspace ACP agents, ACP agents with no distinct cwd that use the workspace as cwd).
- **How is that risk mitigated?** The predicate requires the distinct-cwd condition, so workspace-cwd fallback keeps standard provisioning; the explicit-workspace and no-cwd shapes are locked by regression tests; all other `ensureAgentWorkspace` callers (setup/onboard/agent-create/gateway) are untouched.

## User Impact

Users running runtime-managed (ACP) agents no longer get unintended directory creation, template seeding, and nested git repositories inside their existing projects. Users who configure an explicit `workspace` for an ACP agent, or whose ACP agent falls back to its workspace as cwd, keep exactly the previous bootstrap behavior.

- **Success criteria:** predicate matrix regressions pass (`resolveAgentWorkspaceProvisioning`); runtime-managed-implicit mode creates the directory with no `AGENTS.md`/`BOOTSTRAP.md`/`.git`; agent-command, auto-reply, and cron lane suites pass; full `test:unit:fast` shows no new failures.
- **What should reviewers focus on?** `src/agents/agent-scope-config.ts` (`resolveAgentWorkspaceProvisioning`), the early branch in `src/agents/workspace.ts` (`ensureAgentWorkspace`), and the three lane call sites (`src/agents/command/prepare.ts`, `src/auto-reply/reply/get-reply.ts`, `src/cron/isolated-agent/run-prepare.ts`); fixtures in `src/agents/agent-scope.test.ts` and `src/agents/workspace.provisioning.test.ts`.

## Evidence

- **Real environment tested:** local checkout of `openclaw/openclaw` at `origin/main` (before) and on this branch (after), Node 24, focused runtime repro driving the real production functions (`resolveAgentWorkspaceDir` + `resolveAgentWorkspaceProvisioning` + `ensureAgentWorkspace`) in the exact composition the three ACP lanes use, with the issue's minimal reproduction config (parent git repo, `agents.defaults.workspace` inside it, ACP agent without workspace, ACP binding cwd elsewhere).
- **Exact steps or commands run after this patch:**
  ```bash
  node scripts/run-vitest.mjs src/agents/agent-scope.test.ts src/agents/workspace.provisioning.test.ts
  node scripts/run-vitest.mjs src/agents/workspace.test.ts
  node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts
  node scripts/run-vitest.mjs src/cron/isolated-agent.lane.test.ts
  node scripts/run-vitest.mjs src/auto-reply/reply/get-reply.fast-path.test.ts
  node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts
  node scripts/run-tsgo-core-test-shards.mjs   # core type shards
  npx oxlint --deny=warn --ignore-path=.oxlintignore <changed files>
  npx oxfmt --check <changed files>
  ```
- **Evidence after fix:**
  ```json
  {
    "mode": "fix",
    "dirExists": true,
    "agentsMdCreated": false,
    "bootstrapMdCreated": false,
    "nestedGitRepoCreated": false,
    "parentRepoAddFails": false
  }
  ```
- **Observed result after fix:** the implicit ACP workspace directory is provisioned (usable for cwd fallback/media staging) but no bootstrap files, no workspace setup state, and no nested `.git` are created; the parent repository's `git add -A` succeeds.
- **Before evidence (optional, visual changes encouraged):** same repro on pristine `origin/main`:
  ```json
  {
    "mode": "main",
    "agentsMdCreated": true,
    "bootstrapMdCreated": true,
    "nestedGitRepoCreated": true,
    "parentRepoAddFails": true
  }
  ```
- **What was not tested:** a live gateway boot with a real ACP harness session (no external ACP credentials in this environment); lane wiring is covered by the repo's own agent-command/auto-reply/cron test suites.
- **Proof tier:** L2
- **Proof limitations:** none — L2 via focused runtime repro against the real production composition plus lane regressions; the full gateway/channel path was not booted.
- **Review state:** Awaiting CI + maintainer review.
