### PR TITLE
fix(ui): stop dismissed lazy retries from reloading the page

### DIFF
--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -70,7 +70,6 @@ import {
   type OptionalCustomElement,
   TERMINAL_PANEL_ELEMENT,
 } from "./lazy-custom-element.ts";
-import { hasStoredLazyShellAction } from "./lazy-shell-action.ts";
 import { postNativeNavState, type NativeNavState } from "./native-nav-state.ts";
 import { readNativeHistoryState, type NativeHistoryState } from "./native-web-chrome.ts";
 import { resolveOnboardingMode } from "./onboarding-mode.ts";
@@ -81,11 +80,7 @@ import {
   pushServerUiPrefs,
 } from "./server-prefs.ts";
 import { setSettingsChangeListener } from "./settings.ts";
-import {
-  isStaleChunkImportError,
-  retryStaleChunkReloadWhenReachable,
-  scheduleStaleChunkReload,
-} from "./stale-chunk-reload.ts";
+import { isStaleChunkImportError, scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
 
 type AppSidebarElement = HTMLElement & {
   dismissTransientMenus: () => boolean;
@@ -157,8 +152,7 @@ class OpenClawShell
   readonly lazyCustomElements = new LazyCustomElementRequestController(
     this,
     () => this.shellChrome.cancelPendingLazyAction(),
-    () =>
-      hasStoredLazyShellAction() ? retryStaleChunkReloadWhenReachable() : Promise.resolve(false),
+    (canReload) => this.shellChrome.retryPendingLazyAction(canReload),
   );
   // Gates lazy-action replay on the element being rendered; while the shell is
   // still splash-gated, replaying would loop through the open handlers forever.

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -61,6 +61,7 @@ import {
 } from "./navigation-surface.ts";
 import { isBrowserPanelAvailable, isDesktopPanelAvailable } from "./panel-availability.ts";
 import { NAV_WIDTH_MAX, NAV_WIDTH_MIN } from "./settings.ts";
+import { retryStaleChunkReloadWhenReachable } from "./stale-chunk-reload.ts";
 
 type DebugOverlayElement = HTMLElement & {
   toggle: () => void;
@@ -690,6 +691,16 @@ export class ShellChromeOwner {
       replay();
       this.clearPendingLazyAction(event);
     });
+  }
+
+  retryPendingLazyAction(canReload: () => boolean): Promise<boolean> {
+    const event = this.pendingLazyAction;
+    return event
+      ? retryStaleChunkReloadWhenReachable({
+          canReload: () =>
+            canReload() && this.pendingLazyAction === event && persistLazyShellAction(event),
+        })
+      : Promise.resolve(false);
   }
 
   private dispatchLazyShellEvent(event: LazyShellEvent): boolean {

--- a/ui/src/app/app-shell-chrome.ts
+++ b/ui/src/app/app-shell-chrome.ts
@@ -703,10 +703,8 @@ export class ShellChromeOwner {
       : Promise.resolve(false);
   }
 
-  private dispatchLazyShellEvent(event: LazyShellEvent): boolean {
-    return window.dispatchEvent(
-      new CustomEvent(event.eventType, { cancelable: true, detail: event.detail }),
-    );
+  private dispatchLazyShellEvent({ eventType, detail }: LazyShellEvent): boolean {
+    return window.dispatchEvent(new CustomEvent(eventType, { cancelable: true, detail }));
   }
 
   private clearPendingLazyAction(event: LazyShellEvent): void {

--- a/ui/src/app/lazy-custom-element.test.ts
+++ b/ui/src/app/lazy-custom-element.test.ts
@@ -59,7 +59,9 @@ describe("optional custom element requests", () => {
   function createRequestHarness() {
     const requestUpdate = vi.fn();
     const host = { requestUpdate, updateComplete: Promise.resolve(true) };
-    const retryStale = vi.fn(async () => false);
+    const retryStale = vi
+      .fn<(canReload: () => boolean) => Promise<boolean>>()
+      .mockResolvedValue(false);
     const requests = new LazyCustomElementRequestController(host, undefined, retryStale);
     return { requests, retryStale };
   }
@@ -228,9 +230,11 @@ describe("optional custom element requests", () => {
     expect(requests.visibleState).toMatchObject({ stale: true });
 
     requests.retry();
+    expect(retryStale.mock.calls[0]?.[0]?.()).toBe(true);
 
     await waitForFast(() => expect(continuation).toHaveBeenCalledOnce());
     expect(retryStale).toHaveBeenCalledOnce();
+    expect(retryStale.mock.calls[0]?.[0]?.()).toBe(false);
     expect(element.loadModule).toHaveBeenCalledTimes(2);
   });
 

--- a/ui/src/app/lazy-custom-element.ts
+++ b/ui/src/app/lazy-custom-element.ts
@@ -72,7 +72,8 @@ export class LazyCustomElementRequestController {
   constructor(
     private readonly host: UpdatingHost,
     private readonly onClose?: () => void,
-    private readonly retryStale = retryStaleChunkReloadWhenReachable,
+    private readonly retryStale = (canReload: () => boolean) =>
+      retryStaleChunkReloadWhenReachable({ canReload }),
   ) {}
 
   get visibleState(): LazyCustomElementRequestState | undefined {
@@ -142,7 +143,8 @@ export class LazyCustomElementRequestController {
     } satisfies LazyCustomElementRequest;
     this.current = retryRequest;
     this.host.requestUpdate();
-    void (request.stale ? this.retryStale() : Promise.resolve(false)).then((reloading) => {
+    const canReload = () => this.current === retryRequest;
+    void (request.stale ? this.retryStale(canReload) : Promise.resolve(false)).then((reloading) => {
       if (!reloading && this.current === retryRequest) {
         this.load(retryRequest);
       }

--- a/ui/src/app/lazy-shell-action.test.ts
+++ b/ui/src/app/lazy-shell-action.test.ts
@@ -15,8 +15,30 @@ import {
   stubRenderedWhenDefined,
 } from "./app-host.test-support.ts";
 import "./app-host.ts";
-import { DEBUG_OVERLAY_ELEMENT, KEYBOARD_SHORTCUTS_ELEMENT } from "./lazy-custom-element.ts";
-import { readLazyShellAction } from "./lazy-shell-action.ts";
+import {
+  DEBUG_OVERLAY_ELEMENT,
+  KEYBOARD_SHORTCUTS_ELEMENT,
+  type LazyCustomElementRequestController,
+} from "./lazy-custom-element.ts";
+import { readLazyShellAction, SHELL_APPROVALS_OPEN_EVENT } from "./lazy-shell-action.ts";
+
+const recovery = vi.hoisted(() => ({ reload: vi.fn(), pending: new Array<Promise<boolean>>() }));
+vi.mock("./stale-chunk-reload.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./stale-chunk-reload.ts")>();
+  return {
+    ...actual,
+    retryStaleChunkReloadWhenReachable: (
+      deps: Parameters<typeof actual.retryStaleChunkReloadWhenReachable>[0],
+    ) => {
+      const pending = actual.retryStaleChunkReloadWhenReachable({
+        ...deps,
+        reload: recovery.reload,
+      });
+      recovery.pending.push(pending);
+      return pending;
+    },
+  };
+});
 
 const storageKey = "openclaw:lazy-event";
 
@@ -34,7 +56,41 @@ async function withConnectedShell(shell: ShellLifecycle, run: () => void | Promi
   }
 }
 
-afterEach(resetAppHostTestGlobals);
+afterEach(() => {
+  resetAppHostTestGlobals();
+  vi.restoreAllMocks();
+  recovery.reload.mockClear();
+  recovery.pending.length = 0;
+});
+
+type PaletteShell = HTMLElement &
+  ShellLifecycle & {
+    commandPaletteElement: TestOptionalCustomElement;
+    lazyCustomElements: LazyCustomElementRequestController;
+    openPalette(): void;
+    restorePendingLazyAction(): void;
+    resetForContextEpoch(): void;
+  };
+
+function paletteShell(element: TestOptionalCustomElement, open: () => void): PaletteShell {
+  const shell = document.createElement("openclaw-app-shell") as PaletteShell;
+  shell.commandPaletteElement = element;
+  Object.defineProperty(shell, "updateComplete", { get: () => Promise.resolve(true) });
+  Object.defineProperty(shell, "commandPalette", {
+    get: () =>
+      customElements.get(element.tagName)
+        ? { isOpen: false, openPalette: open, togglePalette: open }
+        : undefined,
+  });
+  stubRenderedWhenDefined(shell);
+  return shell;
+}
+
+function stalePalette() {
+  return createLazyElementSpec("command palette", {
+    firstError: new Error("Failed to fetch dynamically imported module: palette-old.js"),
+  });
+}
 
 describe("lazy shell action storage", () => {
   it.each([
@@ -53,6 +109,116 @@ describe("lazy shell action storage", () => {
 });
 
 describe("shell lazy events", () => {
+  it.each(["unavailable", "denied", "replacement-write-failed"] as const)(
+    "retries in place without replaying an older action when storage is %s",
+    async (mode) => {
+      const storage = createStorageMock();
+      if (mode === "replacement-write-failed") {
+        storage.setItem(storageKey, JSON.stringify({ eventType: SHELL_APPROVALS_OPEN_EVENT }));
+      }
+      vi.stubGlobal("sessionStorage", mode === "unavailable" ? null : storage);
+      if (mode === "denied") {
+        Object.defineProperty(globalThis, "sessionStorage", {
+          configurable: true,
+          get() {
+            throw new DOMException("Storage blocked", "SecurityError");
+          },
+        });
+      }
+      const head = vi.fn(async () => new Response(null, { status: 200 }));
+      vi.stubGlobal("fetch", head);
+      const open = vi.fn();
+      const shell = paletteShell(stalePalette(), open);
+      if (mode === "replacement-write-failed") {
+        vi.spyOn(storage, "setItem").mockImplementation(() => {
+          throw new DOMException("Storage full", "QuotaExceededError");
+        });
+      }
+
+      await withConnectedShell(shell, async () => {
+        shell.openPalette();
+        await vi.waitFor(() => expect(shell.lazyCustomElements.visibleState?.status).toBe("error"));
+        shell.lazyCustomElements.retry();
+        await Promise.all(recovery.pending);
+
+        await vi.waitFor(() => expect(open).toHaveBeenCalledOnce());
+        expect(recovery.reload).not.toHaveBeenCalled();
+        expect(head).not.toHaveBeenCalled();
+        expect(readLazyShellAction()).toBeNull();
+      });
+    },
+  );
+
+  it.each(["close", "context-replaced", "disconnected", "new-request"] as const)(
+    "does not reload a retired retry after %s while the document probe is pending",
+    async (retirement) => {
+      vi.stubGlobal("sessionStorage", createStorageMock());
+      let resolveHead = (_response: Response): void => {
+        throw new Error("Document probe not started");
+      };
+      const head = vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveHead = resolve;
+          }),
+      );
+      vi.stubGlobal("fetch", head);
+      const open = vi.fn();
+      const shell = paletteShell(stalePalette(), open);
+
+      await withConnectedShell(shell, async () => {
+        shell.openPalette();
+        await vi.waitFor(() => expect(shell.lazyCustomElements.visibleState?.status).toBe("error"));
+        shell.lazyCustomElements.retry();
+        await vi.waitFor(() => expect(head).toHaveBeenCalledOnce());
+
+        if (retirement === "close") {
+          shell.lazyCustomElements.close();
+        } else if (retirement === "context-replaced") {
+          shell.resetForContextEpoch();
+        } else if (retirement === "disconnected") {
+          shell.disconnectedCallback();
+        } else {
+          shell.lazyCustomElements.request(createLazyElementSpec("new request"));
+        }
+        resolveHead(new Response(null, { status: 200 }));
+        await expect(Promise.all(recovery.pending)).resolves.toEqual([false]);
+
+        expect(recovery.reload).not.toHaveBeenCalled();
+        expect(open).not.toHaveBeenCalled();
+      });
+    },
+  );
+
+  it("repairs stale stored intent before reloading and replays the current action once", async () => {
+    const storage = createStorageMock();
+    vi.stubGlobal("sessionStorage", storage);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 200 })),
+    );
+    const element = stalePalette();
+    const open = vi.fn();
+    const shell = paletteShell(element, open);
+
+    shell.openPalette();
+    await vi.waitFor(() => expect(shell.lazyCustomElements.visibleState?.status).toBe("error"));
+    storage.setItem(storageKey, "{}");
+    shell.lazyCustomElements.retry();
+    await expect(Promise.all(recovery.pending)).resolves.toEqual([true]);
+    expect(recovery.reload).toHaveBeenCalledOnce();
+    expect(readLazyShellAction()).toEqual({ eventType: COMMAND_PALETTE_OPEN_EVENT });
+
+    const replacement = paletteShell(element, open);
+    await withConnectedShell(replacement, async () => {
+      replacement.restorePendingLazyAction();
+      await vi.waitFor(() => expect(open).toHaveBeenCalledOnce());
+      replacement.restorePendingLazyAction();
+      expect(open).toHaveBeenCalledOnce();
+      expect(readLazyShellAction()).toBeNull();
+    });
+  });
+
   it("requests the keyboard shortcuts dialog even from a focused text input", async () => {
     const requested = vi.fn();
     const toggled = vi.fn();

--- a/ui/src/app/lazy-shell-action.ts
+++ b/ui/src/app/lazy-shell-action.ts
@@ -23,15 +23,7 @@ const eventTypes = [
 ] as const;
 
 export type LazyShellEvent = {
-  eventType:
-    | typeof COMMAND_PALETTE_OPEN_EVENT
-    | typeof DEBUG_OVERLAY_REQUEST_EVENT
-    | typeof KEYBOARD_SHORTCUTS_REQUEST_EVENT
-    | typeof TERMINAL_PANEL_TOGGLE_EVENT
-    | typeof BROWSER_PANEL_TOGGLE_EVENT
-    | typeof DESKTOP_PANEL_TOGGLE_EVENT
-    | typeof CUSTODIAN_PANEL_TOGGLE_EVENT
-    | typeof SHELL_APPROVALS_OPEN_EVENT;
+  eventType: (typeof eventTypes)[number];
   detail?: object;
 };
 
@@ -43,14 +35,6 @@ export function lazyShellEvent(
   return detail !== null && typeof detail === "object" && !Array.isArray(detail)
     ? { eventType, detail }
     : { eventType };
-}
-
-export function hasStoredLazyShellAction(): boolean {
-  try {
-    return getSafeSessionStorage()?.getItem(STORAGE_KEY) !== null;
-  } catch {
-    return false;
-  }
 }
 
 export function readLazyShellAction(): LazyShellEvent | null {
@@ -82,21 +66,22 @@ export function readLazyShellAction(): LazyShellEvent | null {
   return null;
 }
 
-function writeStoredAction(value?: string): void {
+export function persistLazyShellAction(event: LazyShellEvent): boolean {
   try {
     const storage = getSafeSessionStorage();
-    if (value === undefined) {
-      storage?.removeItem(STORAGE_KEY);
-    } else {
-      storage?.setItem(STORAGE_KEY, value);
+    if (!storage) {
+      return false;
     }
+    storage.setItem(STORAGE_KEY, JSON.stringify(event));
+    return true;
   } catch {}
-}
-
-export function persistLazyShellAction(event: LazyShellEvent): void {
-  writeStoredAction(JSON.stringify(event));
+  // A failed replacement must not leave a superseded action to replay on reload.
+  clearLazyShellAction();
+  return false;
 }
 
 export function clearLazyShellAction(): void {
-  writeStoredAction();
+  try {
+    getSafeSessionStorage()?.removeItem(STORAGE_KEY);
+  } catch {}
 }

--- a/ui/src/app/stale-chunk-reload.test.ts
+++ b/ui/src/app/stale-chunk-reload.test.ts
@@ -331,6 +331,28 @@ describe("retryStaleChunkReloadWhenReachable single-shot", () => {
 });
 
 describe("retryStaleChunkReloadWhenReachable", () => {
+  it.each(["before", "during"] as const)(
+    "does not reload when recovery is retired %s the document probe",
+    async (retirement) => {
+      const response = deferred<boolean>();
+      const probe = vi.fn(() => response.promise);
+      const reload = vi.fn();
+      let current = retirement === "during";
+      const pending = retryStaleChunkReloadWhenReachable({
+        canReload: () => current,
+        probe,
+        reload,
+      });
+
+      current = false;
+      response.resolve(true);
+
+      await expect(pending).resolves.toBe(false);
+      expect(reload).not.toHaveBeenCalled();
+      expect(probe).toHaveBeenCalledTimes(retirement === "during" ? 1 : 0);
+    },
+  );
+
   it("reloads immediately when the gateway already answers", async () => {
     const reload = vi.fn();
     const probe = vi.fn().mockResolvedValue(true);

--- a/ui/src/app/stale-chunk-reload.ts
+++ b/ui/src/app/stale-chunk-reload.ts
@@ -10,6 +10,7 @@
 // only recovery path there.
 import { CONTROL_UI_BUILD_INFO } from "../build-info.ts";
 import { t } from "../i18n/index.ts";
+import { getSafeSessionStorage } from "../local-storage.ts";
 
 const RELOAD_GUARD_STORAGE_KEY = "openclaw.controlUi.staleChunkReloadBuildId";
 // Bounds document probes across rapid re-renders of the same error state.
@@ -57,15 +58,6 @@ function reloadControlUiDocument(): void {
   // The pre-app mount recovery strips this one-shot cache buster before bootstrap.
   url.searchParams.set("openclaw_mount_recovery", String(Date.now()));
   window.location.replace(url.href);
-}
-
-function sessionStorageOrNull(): Pick<Storage, "getItem" | "setItem"> | null {
-  try {
-    return window.sessionStorage;
-  } catch {
-    // Storage can be disabled; recovery then stays manual via the Retry button.
-    return null;
-  }
 }
 
 function probeControlUiDocument(buildId?: string): Promise<boolean> {
@@ -128,7 +120,7 @@ function persistGuardBuildId(
  * app webviews) instead of the recoverable panel error.
  */
 export async function scheduleStaleChunkReload(deps: StaleChunkReloadDeps = {}): Promise<boolean> {
-  const storage = deps.storage === undefined ? sessionStorageOrNull() : deps.storage;
+  const storage = deps.storage === undefined ? getSafeSessionStorage() : deps.storage;
   const buildId = deps.buildId ?? CONTROL_UI_BUILD_INFO.buildId;
   // One automatic reload per build id: if the reloaded document still fails
   // with the same build, the build itself is broken and reloading cannot help.
@@ -202,9 +194,9 @@ async function probeWithinDeadline(
 
 /**
  * User-initiated retry that survives the restart which caused the stale chunk:
- * poll until the gateway answers, then reload. Returns false only when it stays
- * unreachable for the whole window, so callers keep the recoverable panel error
- * instead of navigating into a fatal error page.
+ * poll until the gateway answers, then reload if the caller still owns recovery.
+ * Unreachable or retired requests keep the current document instead of navigating
+ * into a fatal error page or discarding a newer action.
  */
 export async function retryStaleChunkReloadWhenReachable(
   deps: StaleChunkReloadDeps & {
@@ -212,8 +204,12 @@ export async function retryStaleChunkReloadWhenReachable(
     intervalMs?: number;
     probe?: () => Promise<boolean>;
     wait?: (ms: number) => Promise<void>;
+    canReload?: () => boolean;
   } = {},
 ): Promise<boolean> {
+  if (deps.canReload?.() === false) {
+    return false;
+  }
   const now = deps.now ?? Date.now;
   const probe = deps.probe ?? probeControlUiDocument;
   const wait =
@@ -235,6 +231,10 @@ export async function retryStaleChunkReloadWhenReachable(
     // rather than "never ask"; the probe's own abort bounds that case.
     const reachable = remaining > 0 ? await probeWithinDeadline(probe, remaining) : await probe();
     if (reachable) {
+      // The probe may outlive Close, a new request, or a failed replay-state write.
+      if (deps.canReload?.() === false) {
+        return false;
+      }
       (deps.reload ?? reloadControlUiDocument)();
       return true;
     }

--- a/ui/src/e2e/lazy-custom-element-recovery.e2e.test.ts
+++ b/ui/src/e2e/lazy-custom-element-recovery.e2e.test.ts
@@ -24,7 +24,7 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
 });
 
-async function installChunkFailure(page: Page, chunk: RegExp) {
+async function installChunkFailure(page: Page, chunk: RegExp, manualProbe?: Promise<void>) {
   let headCount = 0;
   let chunkRequestCount = 0;
   await page.route("**/*", async (route) => {
@@ -37,6 +37,7 @@ async function installChunkFailure(page: Page, chunk: RegExp) {
       await route.fulfill({ status: 503 });
       return;
     }
+    await manualProbe;
     await route.fallback();
   });
   await page.route(chunk, async (route: Route) => {
@@ -145,6 +146,93 @@ const focusedCases = [
 ];
 
 suite.define(() => {
+  it("does not reload after a lazy surface is dismissed during its retry probe", async () => {
+    let releaseProbe = () => {};
+    const manualProbe = new Promise<void>((resolve) => {
+      releaseProbe = resolve;
+    });
+    try {
+      await suite.withPage(
+        { locale: "en-US", serviceWorkers: "block", viewport },
+        async ({ page }) => {
+          await page.addInitScript(() => {
+            const observed = window as Window & { completedHeadFrames?: number };
+            const originalFetch = window.fetch;
+            window.fetch = async (...args) => {
+              const response = await originalFetch(...args);
+              if (args[1]?.method === "HEAD") {
+                // Observe the frame after the real fetch and its reload promise chain settle.
+                requestAnimationFrame(() => {
+                  observed.completedHeadFrames = (observed.completedHeadFrames ?? 0) + 1;
+                });
+              }
+              return response;
+            };
+          });
+          const failure = await installChunkFailure(
+            page,
+            /\/assets\/command-palette-[^/?]+\.js(?:\?.*)?$/u,
+            manualProbe,
+          );
+          await installMockGateway(page);
+          let documentRequests = 0;
+          page.on("request", (request) => {
+            if (request.resourceType() === "document") {
+              documentRequests += 1;
+            }
+          });
+          await page.goto(`${suite.server.baseUrl}chat`);
+          await waitForControlUiGatewayReady(page);
+          await page.keyboard.press("ControlOrMeta+k");
+          const error = await expectRealChunkFailure(page, "command palette");
+          await expect.poll(failure.headCount).toBe(1);
+          if (captureUiProof) {
+            await mkdir(artifactDir, { recursive: true });
+            await page.screenshot({ path: path.join(artifactDir, "dismissed-retry-before.png") });
+          }
+
+          const reloaded = new Promise<void>((resolve) => {
+            page.once("domcontentloaded", () => resolve());
+          });
+          await error.getByRole("button", { name: "Retry", exact: true }).click();
+          await expect.poll(failure.headCount).toBe(2);
+          await page.keyboard.press("Escape");
+          const paletteModal = page.locator('openclaw-modal-dialog[label="command palette"]');
+          await expect.poll(() => paletteModal.count()).toBe(0);
+          releaseProbe();
+          await expect
+            .poll(
+              async () =>
+                documentRequests > 1 ||
+                (await page.evaluate(
+                  () =>
+                    (window as Window & { completedHeadFrames?: number }).completedHeadFrames ?? 0,
+                )) >= 2,
+            )
+            .toBe(true);
+          if (documentRequests > 1) {
+            await reloaded;
+          }
+          await waitForControlUiGatewayReady(page);
+          if (captureUiProof) {
+            await page.screenshot({ path: path.join(artifactDir, "dismissed-retry-after.png") });
+          }
+          console.info("LAZY_RETRY_DISMISSED", {
+            documentRequests,
+            headCount: failure.headCount(),
+          });
+          expect(documentRequests).toBe(1);
+          expect(await paletteModal.count()).toBe(0);
+          expect(
+            await page.evaluate(() => sessionStorage.getItem("openclaw:lazy-event")),
+          ).toBeNull();
+        },
+      );
+    } finally {
+      releaseProbe();
+    }
+  });
+
   for (const testCase of focusedCases) {
     it(`reloads the focused ${testCase.name} after its real hashed chunk fails`, async () => {
       await suite.withPage(
@@ -222,8 +310,8 @@ suite.define(() => {
       await expect.poll(failure.chunkRequestCount).toBe(2);
       expect(await page.locator("openclaw-command-palette").count()).toBe(1);
       if (captureUiProof) {
-        await page.waitForTimeout(250);
         await page.screenshot({
+          animations: "disabled",
           fullPage: true,
           path: path.join(artifactDir, "recovered.png"),
         });


### PR DESCRIPTION
Related: #127733 (the separate storage-denied handoff gap remains unresolved).

## What Problem This Solves

Fixes an issue where users who pressed Retry on a failed lazy-loaded panel could close the dialog or choose another action, then unexpectedly have the entire page reload when the earlier reachability probe finished. The retired request could also replay an obsolete saved action.

## Why This Change Was Made

The lazy request controller now carries its current-request check through the asynchronous document probe. The shell action owner permits navigation only while the same request and pending event still own recovery and the exact event was successfully saved for replay. The URL-owned standalone document paths retain their existing recovery behavior.

The saved-action writer reports actual persistence success and clears an obsolete record after a failed replacement. This removes the separate raw-presence predicate that treated unavailable storage as a saved action, reuses the shared guarded storage accessor, and derives the event type from its existing canonical list. Production is +44/-54 (net -10); tests are +286/-6.

## User Impact

Close and replacement actions remain authoritative while Retry waits for the Gateway. A dismissed request cannot later navigate the page or replay an old panel action. With working storage, an active action still reloads into the fresh UI and replays once.

When the action cannot be saved, recovery retains the visible error and in-memory intent rather than navigating without it. This is an explicit change to degraded behavior. **It does not solve permanently retired assets when session storage is denied:** two real Retry clicks in that case still show the error; Close clears the pending action. #127733 remains the named follow-up for an action-preserving cross-document handoff. No new URL, cookie, storage format or alternate handoff is introduced here.

## Evidence

- Before the repair, the owner regression selection had 11 failures and 80 passes. The real browser Retry-then-Close scenario made a second document request. The final candidate passes 91 owner tests and all five fresh-bundle browser cases; that dismissed Retry makes only one document request.
- Browser cases exercise real Chromium, HTTP asset requests and reachability probes with the canonical synthetic Gateway fixture. They cover cancellation and replacement as well as working recovery paths. They do not claim native WebKit or a live provider.
- An additional permanent-old-hash check keeps the old module URL at 404. With working storage, a fresh document serves a different module hash, opens the command palette once and clears saved intent. With denied storage, it preserves the exact pending object and visible error without reloading; this is limitation proof, not successful recovery proof.
- Both production builds pass unchanged startup budgets with eight startup requests. The actual-identity build measures 342,591 gzip bytes against the existing 344,620-byte enforcement limit. No payload reduction is claimed; the controlled comparison adds 162 raw startup bytes and 959 total-JavaScript gzip bytes.
- All 21 selected changed checks pass. Fresh cumulative Codex autoreview has no P0 findings; independent ownership and storage-failure review found no actionable issue in the cancellation fix. The broader handoff limitation above is retained explicitly.

Baseline stale-module dialog before the interaction (synthetic test data):

![Baseline stale-module dialog](https://github.com/user-attachments/assets/cfb2c16f-b326-4992-aeb2-10d3f4405787)

Candidate after Retry then Close: the original document remains visible; the request count, rather than the still image alone, proves no later reload:

![Candidate retains the document after Retry then Close](https://github.com/user-attachments/assets/ad8993a5-d368-485d-8dd2-7025550a26e0)
