### PR TITLE
feat(slack): deliver TTS voice notes via captioned media upload

### DIFF
--- a/docs/tools/tts.md
+++ b/docs/tools/tts.md
@@ -812,10 +812,10 @@ whether voice-style TTS should ask providers for a native `voice-note` target or
 keep normal `audio-file` synthesis, and whether the channel transcodes
 non-native output before sending.
 
-Telegram also advertises captioned final TTS. With `tts.mode: "final"` and
-Auto-TTS set to `always` (or eligible `inbound` mode), streamed text is held
-until synthesis finishes and sent as the voice-note caption. Text beyond
-Telegram's caption limit follows the voice note as a normal text message. If
+Telegram and Slack also advertise captioned final TTS. With `tts.mode: "final"`
+and Auto-TTS set to `always` (or eligible `inbound` mode), streamed text is held
+until synthesis finishes and sent as the voice-note caption. Text beyond the
+channel caption limit follows the voice note as a normal text message. If
 synthesis or a proven pre-send delivery step fails, OpenClaw sends the visible
 text instead. `tagged` mode keeps its normal streaming behavior, and text
 inside a `[[tts:text]]` block remains audio-only.
@@ -827,11 +827,12 @@ Local CLI providers may still use `{{OutputPath}}` as scratch space before
 OpenClaw imports the completed bytes. See [Media playback](/nodes/media-playback)
 for inline-player formats and limits.
 
-| Target                                | Format                                                                                                                                |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Feishu / Matrix / Telegram / WhatsApp | Voice-note replies prefer **Opus** (`opus_48000_64` from ElevenLabs, `opus` from OpenAI). 48 kHz / 64 kbps balances clarity and size. |
-| Other channels                        | **MP3** (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI). 44.1 kHz / 128 kbps is the default balance for speech.                  |
-| Talk / telephony                      | Provider-native **PCM** (Inworld 22050 Hz, Google 24 kHz), or `ulaw_8000` from Gradium for telephony.                                 |
+| Target                                | Format                                                                                                                                  |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Feishu / Matrix / Telegram / WhatsApp | Voice-note replies prefer **Opus** (`opus_48000_64` from ElevenLabs, `opus` from OpenAI). 48 kHz / 64 kbps balances clarity and size.   |
+| Slack                                 | Voice-note replies prefer **Opus** like the channels above; Slack recognizes the upload as audio and transcodes it for inline playback. |
+| Other channels                        | **MP3** (`mp3_44100_128` from ElevenLabs, `mp3` from OpenAI). 44.1 kHz / 128 kbps is the default balance for speech.                    |
+| Talk / telephony                      | Provider-native **PCM** (Inworld 22050 Hz, Google 24 kHz), or `ulaw_8000` from Gradium for telephony.                                   |
 
 Per-provider notes:
 
@@ -865,10 +866,10 @@ When `tts.auto` is enabled, OpenClaw:
   `summaryModel` (or `agents.defaults.model.primary`).
 - Attaches the generated audio to the reply.
 - In `mode: "final"`, sends TTS after streamed text completes. Channels without
-  captioned-final support receive an audio-only supplement; Telegram puts text
-  within its caption limit on the voice note and sends overflow as follow-up
-  text. Generated media goes through the same channel media normalization as
-  normal reply attachments.
+  captioned-final support receive an audio-only supplement; Telegram and Slack
+  put text within their caption limit on the voice note and send overflow as
+  follow-up text. Generated media goes through the same channel media
+  normalization as normal reply attachments.
 
 If the reply exceeds `maxLength`, OpenClaw never skips audio outright:
 

--- a/extensions/slack/src/channel.setup.ts
+++ b/extensions/slack/src/channel.setup.ts
@@ -32,6 +32,12 @@ export const slackSetupPlugin: ChannelPlugin<ResolvedSlackAccount> = {
     threads: true,
     media: true,
     nativeCommands: true,
+    tts: {
+      voice: {
+        synthesisTarget: "voice-note",
+        captionedFinalText: true,
+      },
+    },
   },
   commands: {
     nativeCommandsAutoEnabled: false,

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -531,4 +531,61 @@ describe("slackOutbound", () => {
       }),
     );
   });
+
+  it("delivers a TTS voice note as a single captioned media upload without blocks", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-voice" });
+
+    const result = await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: {
+        text: "Spoken summary of the deploy.",
+        mediaUrl: "file:///tmp/tts/deploy.ogg",
+        audioAsVoice: true,
+        spokenText: "Spoken summary of the deploy.",
+        trustedLocalMedia: true,
+        presentation: {
+          blocks: [{ type: "text", text: "Block body that must not be sent" }],
+        },
+      },
+      mediaLocalRoots: ["/tmp"],
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledOnce();
+    expect(sendMessageSlackMock).toHaveBeenCalledWith(
+      "C123",
+      "Spoken summary of the deploy.",
+      expect.objectContaining({
+        mediaUrl: "file:///tmp/tts/deploy.ogg",
+        mediaLocalRoots: ["/tmp"],
+      }),
+    );
+    expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
+    expect(result).toMatchObject({ channel: "slack", messageId: "m-voice" });
+  });
+
+  it("does not take the voice path when audioAsVoice is set but no media is present", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-blocks" });
+
+    await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: {
+        text: "fallback text",
+        audioAsVoice: true,
+        channelData: {
+          slack: {
+            blocks: [{ type: "divider" }],
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledOnce();
+    expect(sendMessageSlackMock.mock.calls[0]?.[2]).toHaveProperty("blocks");
+  });
 });

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -1,5 +1,6 @@
 // Slack tests cover outbound adapter plugin behavior.
 import { presentationToInteractiveControlsReply } from "openclaw/plugin-sdk/interactive-runtime";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMessageSlackMock = vi.hoisted(() => vi.fn());
@@ -696,7 +697,7 @@ describe("slackOutbound", () => {
       presentation: {
         blocks: [{ type: "text", text: "Block body that must accompany the voice note" }],
       },
-    };
+    } satisfies ReplyPayload;
     const rendered = await slackOutbound.renderPresentation!({
       payload,
       presentation: payload.presentation,

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -532,7 +532,7 @@ describe("slackOutbound", () => {
     );
   });
 
-  it("delivers a TTS voice note as a single captioned media upload without blocks", async () => {
+  it("delivers a TTS voice note as a captioned media upload when no rendered blocks are present", async () => {
     sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-voice" });
 
     const result = await slackOutbound.sendPayload!({
@@ -545,9 +545,6 @@ describe("slackOutbound", () => {
         audioAsVoice: true,
         spokenText: "Spoken summary of the deploy.",
         trustedLocalMedia: true,
-        presentation: {
-          blocks: [{ type: "text", text: "Block body that must not be sent" }],
-        },
       },
       mediaLocalRoots: ["/tmp"],
       accountId: "default",
@@ -564,6 +561,67 @@ describe("slackOutbound", () => {
     );
     expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
     expect(result).toMatchObject({ channel: "slack", messageId: "m-voice" });
+  });
+
+  it("preserves rendered blocks alongside a TTS voice-note media upload", async () => {
+    sendMessageSlackMock
+      .mockResolvedValueOnce({ messageId: "m-voice" })
+      .mockResolvedValueOnce({ messageId: "m-blocks" });
+
+    const result = await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: {
+        text: "Spoken summary of the deploy.",
+        mediaUrl: "file:///tmp/tts/deploy.ogg",
+        audioAsVoice: true,
+        spokenText: "Spoken summary of the deploy.",
+        trustedLocalMedia: true,
+        presentation: {
+          blocks: [{ type: "text", text: "Block body that must accompany the voice note" }],
+        },
+      },
+      mediaLocalRoots: ["/tmp"],
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageSlackMock).toHaveBeenNthCalledWith(1, "C123", "", {
+      cfg,
+      threadTs: undefined,
+      accountId: "default",
+      mediaUrl: "file:///tmp/tts/deploy.ogg",
+      mediaAccess: undefined,
+      mediaLocalRoots: ["/tmp"],
+      mediaReadFile: undefined,
+    });
+    expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
+    expect(sendMessageSlackMock).toHaveBeenNthCalledWith(
+      2,
+      "C123",
+      "Spoken summary of the deploy.\n\nBlock body that must accompany the voice note",
+      expect.objectContaining({
+        authoredTextPlacement: "blocks",
+        blocks: [
+          {
+            type: "section",
+            text: { type: "mrkdwn", text: "Spoken summary of the deploy.", verbatim: true },
+          },
+          {
+            type: "section",
+            text: { type: "mrkdwn", text: "Block body that must accompany the voice note" },
+          },
+        ],
+      }),
+    );
+    expect(result).toMatchObject({
+      channel: "slack",
+      receipt: {
+        platformMessageIds: ["m-voice", "m-blocks"],
+        primaryPlatformMessageId: "m-voice",
+      },
+    });
   });
 
   it("does not take the voice path when audioAsVoice is set but no media is present", async () => {

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -587,32 +587,37 @@ describe("slackOutbound", () => {
     });
 
     expect(sendMessageSlackMock).toHaveBeenCalledTimes(2);
-    expect(sendMessageSlackMock).toHaveBeenNthCalledWith(1, "C123", "", {
-      cfg,
-      threadTs: undefined,
-      accountId: "default",
-      mediaUrl: "file:///tmp/tts/deploy.ogg",
-      mediaAccess: undefined,
-      mediaLocalRoots: ["/tmp"],
-      mediaReadFile: undefined,
-    });
+    expect(sendMessageSlackMock).toHaveBeenNthCalledWith(
+      1,
+      "C123",
+      "Spoken summary of the deploy.",
+      {
+        cfg,
+        threadTs: undefined,
+        accountId: "default",
+        mediaUrl: "file:///tmp/tts/deploy.ogg",
+        mediaAccess: undefined,
+        mediaLocalRoots: ["/tmp"],
+        mediaReadFile: undefined,
+      },
+    );
     expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
     expect(sendMessageSlackMock).toHaveBeenNthCalledWith(
       2,
       "C123",
-      "Spoken summary of the deploy.\n\nBlock body that must accompany the voice note",
+      "Block body that must accompany the voice note",
       expect.objectContaining({
-        authoredTextPlacement: "blocks",
         blocks: [
-          {
-            type: "section",
-            text: { type: "mrkdwn", text: "Spoken summary of the deploy.", verbatim: true },
-          },
           {
             type: "section",
             text: { type: "mrkdwn", text: "Block body that must accompany the voice note" },
           },
         ],
+      }),
+    );
+    expect(sendMessageSlackMock.mock.calls[1]?.[2]?.blocks).not.toContainEqual(
+      expect.objectContaining({
+        text: expect.objectContaining({ text: "Spoken summary of the deploy." }),
       }),
     );
     expect(result).toMatchObject({

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -1,11 +1,33 @@
 // Slack tests cover outbound adapter plugin behavior.
 import { presentationToInteractiveControlsReply } from "openclaw/plugin-sdk/interactive-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SLACK_QUESTION_FINALIZATION_BLOCKS } from "./reply-action-ids.js";
 
 const sendMessageSlackMock = vi.hoisted(() => vi.fn());
+const updateMessageSlackMock = vi.hoisted(() => vi.fn());
+const registerChannelDeliveryMock = vi.hoisted(() => vi.fn());
 
 vi.mock("./send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => sendMessageSlackMock(...args),
+}));
+
+vi.mock("./send.runtime.js", () => ({
+  sendMessageSlack: (...args: unknown[]) => sendMessageSlackMock(...args),
+  updateMessageSlack: (...args: unknown[]) => updateMessageSlackMock(...args),
+}));
+
+vi.mock("openclaw/plugin-sdk/question-gateway-runtime", () => ({
+  questionGatewayRuntime: {
+    readAskUserQuestionId: (payload: { channelData?: { askUser?: unknown } }) => {
+      const askUser = payload.channelData?.askUser;
+      if (!askUser || typeof askUser !== "object" || Array.isArray(askUser)) {
+        return undefined;
+      }
+      const questionId = (askUser as { questionId?: unknown }).questionId;
+      return typeof questionId === "string" && questionId ? questionId : undefined;
+    },
+    registerChannelDelivery: (...args: unknown[]) => registerChannelDeliveryMock(...args),
+  },
 }));
 
 const { slackOutbound } = await import("./outbound-adapter.js");
@@ -27,6 +49,8 @@ describe("slackOutbound", () => {
 
   beforeEach(() => {
     sendMessageSlackMock.mockReset();
+    updateMessageSlackMock.mockReset();
+    registerChannelDeliveryMock.mockReset();
   });
 
   it("sends mirrored question controls once at the Slack message block limit", async () => {
@@ -737,5 +761,84 @@ describe("slackOutbound", () => {
         text: expect.objectContaining({ text: "Spoken summary of the deploy." }),
       }),
     );
+  });
+
+  it("keeps voice caption out of question-card finalization text", async () => {
+    // The question-card finalization path rebuilds the delivered card from the
+    // signed rendered resolution. For voice media the authored text is the
+    // upload caption, so finalization must not write it back as the card's
+    // message text/accessibility fallback after the user answers.
+    let capturedFinalize: ((statusLine: string) => Promise<void>) | undefined;
+    registerChannelDeliveryMock.mockImplementation(
+      (params: { finalize: (statusLine: string) => Promise<void> }) => {
+        capturedFinalize = params.finalize;
+      },
+    );
+    updateMessageSlackMock.mockResolvedValue({ ok: true });
+
+    const basePayload = {
+      text: "Spoken summary of the deploy.",
+      mediaUrl: "file:///tmp/tts/deploy.ogg",
+      audioAsVoice: true,
+      spokenText: "Spoken summary of the deploy.",
+      trustedLocalMedia: true,
+      channelData: {
+        askUser: { questionId: "q-1", optionValues: ["Yes"] },
+        slack: {
+          blocks: [
+            {
+              type: "actions" as const,
+              elements: [
+                {
+                  type: "button" as const,
+                  action_id: "openclaw:question_button",
+                  text: { type: "plain_text" as const, text: "Yes" },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+    const rendered = slackOutbound.renderPresentation!({
+      payload: basePayload,
+      presentation: basePayload.presentation,
+      ctx: { cfg, to: "C123", text: "", payload: basePayload },
+    });
+    // Sanity: renderPresentation must produce a signed resolution for the
+    // finalization path to read back.
+    expect(rendered).not.toBeNull();
+    const renderedSlackData = (rendered ?? basePayload).channelData?.slack as
+      | Record<string, unknown>
+      | undefined;
+    expect(renderedSlackData?.renderedPresentationSegments).toBeDefined();
+
+    await slackOutbound.afterDeliverPayload!({
+      cfg,
+      target: { to: "C123", accountId: "default" },
+      payload: rendered ?? basePayload,
+      results: [
+        {
+          channel: "slack",
+          messageId: "m-card",
+          target: { kind: "channel" as const, id: "C123" },
+          meta: {
+            slackQuestionActionIds: ["openclaw:question_button"],
+            [SLACK_QUESTION_FINALIZATION_BLOCKS]: [
+              { type: "section", text: { type: "mrkdwn", text: "Pick an option" } },
+            ],
+          },
+        },
+      ],
+    });
+
+    expect(registerChannelDeliveryMock).toHaveBeenCalledOnce();
+    expect(capturedFinalize).toBeDefined();
+    await capturedFinalize!("Answered: yes");
+
+    expect(updateMessageSlackMock).toHaveBeenCalledOnce();
+    const finalizedText = updateMessageSlackMock.mock.calls[0]?.[0]?.text ?? "";
+    expect(finalizedText).not.toContain("Spoken summary");
+    expect(finalizedText).toContain("Answered: yes");
   });
 });

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -776,12 +776,14 @@ describe("slackOutbound", () => {
     );
     updateMessageSlackMock.mockResolvedValue({ ok: true });
 
+    const presentation = { blocks: [] as [] };
     const basePayload = {
       text: "Spoken summary of the deploy.",
       mediaUrl: "file:///tmp/tts/deploy.ogg",
       audioAsVoice: true,
       spokenText: "Spoken summary of the deploy.",
       trustedLocalMedia: true,
+      presentation,
       channelData: {
         askUser: { questionId: "q-1", optionValues: ["Yes"] },
         slack: {
@@ -800,23 +802,24 @@ describe("slackOutbound", () => {
         },
       },
     };
-    const rendered = slackOutbound.renderPresentation!({
+    const rendered = await slackOutbound.renderPresentation!({
       payload: basePayload,
-      presentation: basePayload.presentation,
+      presentation,
       ctx: { cfg, to: "C123", text: "", payload: basePayload },
     });
     // Sanity: renderPresentation must produce a signed resolution for the
     // finalization path to read back.
     expect(rendered).not.toBeNull();
-    const renderedSlackData = (rendered ?? basePayload).channelData?.slack as
+    const renderedPayload = rendered!;
+    const renderedSlackData = renderedPayload.channelData?.slack as
       | Record<string, unknown>
       | undefined;
     expect(renderedSlackData?.renderedPresentationSegments).toBeDefined();
 
     await slackOutbound.afterDeliverPayload!({
       cfg,
-      target: { to: "C123", accountId: "default" },
-      payload: rendered ?? basePayload,
+      target: { channel: "slack", to: "C123", accountId: "default" },
+      payload: renderedPayload,
       results: [
         {
           channel: "slack",

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -651,4 +651,91 @@ describe("slackOutbound", () => {
     expect(sendMessageSlackMock).toHaveBeenCalledOnce();
     expect(sendMessageSlackMock.mock.calls[0]?.[2]).toHaveProperty("blocks");
   });
+
+  it("keeps authored text visible when audioAsVoice is set with rendered blocks but no media", async () => {
+    sendMessageSlackMock.mockResolvedValueOnce({ messageId: "m-blocks" });
+
+    await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: {
+        text: "Spoken summary that must still appear.",
+        audioAsVoice: true,
+        presentation: {
+          blocks: [{ type: "text", text: "Auxiliary block body" }],
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledOnce();
+    const call = sendMessageSlackMock.mock.calls[0];
+    expect(call?.[1]).toContain("Spoken summary that must still appear.");
+    expect(call?.[2]?.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "section",
+          text: expect.objectContaining({ text: "Spoken summary that must still appear." }),
+        }),
+      ]),
+    );
+  });
+
+  it("does not duplicate caption text in rendered blocks across render-then-send", async () => {
+    sendMessageSlackMock
+      .mockResolvedValueOnce({ messageId: "m-voice" })
+      .mockResolvedValueOnce({ messageId: "m-blocks" });
+
+    const payload = {
+      text: "Spoken summary of the deploy.",
+      mediaUrl: "file:///tmp/tts/deploy.ogg",
+      audioAsVoice: true,
+      spokenText: "Spoken summary of the deploy.",
+      trustedLocalMedia: true,
+      presentation: {
+        blocks: [{ type: "text", text: "Block body that must accompany the voice note" }],
+      },
+    };
+    const rendered = await slackOutbound.renderPresentation!({
+      payload,
+      presentation: payload.presentation,
+      ctx: { cfg, to: "C123", text: "", payload },
+    });
+
+    await slackOutbound.sendPayload!({
+      cfg,
+      to: "C123",
+      text: "",
+      payload: rendered ?? payload,
+      mediaLocalRoots: ["/tmp"],
+      accountId: "default",
+    });
+
+    expect(sendMessageSlackMock).toHaveBeenCalledTimes(2);
+    // The audio upload carries the spoken text as its caption.
+    expect(sendMessageSlackMock).toHaveBeenNthCalledWith(
+      1,
+      "C123",
+      "Spoken summary of the deploy.",
+      expect.objectContaining({ mediaUrl: "file:///tmp/tts/deploy.ogg" }),
+    );
+    expect(sendMessageSlackMock.mock.calls[0]?.[2]).not.toHaveProperty("blocks");
+    // The follow-up block message carries only the auxiliary content; the
+    // spoken summary is not materialized into a section block.
+    const blockCall = sendMessageSlackMock.mock.calls[1]?.[2];
+    expect(blockCall?.blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "section",
+          text: expect.objectContaining({ text: "Block body that must accompany the voice note" }),
+        }),
+      ]),
+    );
+    expect(blockCall?.blocks).not.toContainEqual(
+      expect.objectContaining({
+        text: expect.objectContaining({ text: "Spoken summary of the deploy." }),
+      }),
+    );
+  });
 });

--- a/extensions/slack/src/outbound-adapter.test.ts
+++ b/extensions/slack/src/outbound-adapter.test.ts
@@ -1,6 +1,5 @@
 // Slack tests cover outbound adapter plugin behavior.
 import { presentationToInteractiveControlsReply } from "openclaw/plugin-sdk/interactive-runtime";
-import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMessageSlackMock = vi.hoisted(() => vi.fn());
@@ -695,9 +694,9 @@ describe("slackOutbound", () => {
       spokenText: "Spoken summary of the deploy.",
       trustedLocalMedia: true,
       presentation: {
-        blocks: [{ type: "text", text: "Block body that must accompany the voice note" }],
+        blocks: [{ type: "text" as const, text: "Block body that must accompany the voice note" }],
       },
-    } satisfies ReplyPayload;
+    };
     const rendered = await slackOutbound.renderPresentation!({
       payload,
       presentation: payload.presentation,

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -298,17 +298,6 @@ export const slackOutbound: ChannelOutboundAdapter = {
         }) ?? "",
     };
     const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
-    // TTS voice-note delivery is media-first: the synthesized audio is the
-    // primary message and the spoken text rides as the upload caption. Skip
-    // rendered-block resolution entirely — Slack rejects blocks alongside a
-    // media upload, and a voice note is not a block presentation.
-    if (payload.audioAsVoice === true && resolvePayloadMediaUrls(payload).length > 0) {
-      return await sendTextMediaPayload({
-        channel: "slack",
-        ctx: { ...ctx, payload },
-        adapter: slackOutbound,
-      });
-    }
     const renderedResolution = readSlackRenderedPresentation(slackData);
     let resolution: SlackReplyBlockResolution;
     if (renderedResolution) {

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -298,6 +298,17 @@ export const slackOutbound: ChannelOutboundAdapter = {
         }) ?? "",
     };
     const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
+    // TTS voice-note delivery is media-first: the synthesized audio is the
+    // primary message and the spoken text rides as the upload caption. Skip
+    // rendered-block resolution entirely — Slack rejects blocks alongside a
+    // media upload, and a voice note is not a block presentation.
+    if (payload.audioAsVoice === true && resolvePayloadMediaUrls(payload).length > 0) {
+      return await sendTextMediaPayload({
+        channel: "slack",
+        ctx: { ...ctx, payload },
+        adapter: slackOutbound,
+      });
+    }
     const renderedResolution = readSlackRenderedPresentation(slackData);
     let resolution: SlackReplyBlockResolution;
     if (renderedResolution) {

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -126,6 +126,17 @@ function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentit
   return { username, iconUrl, iconEmoji };
 }
 
+// A TTS voice payload carries its final text in `payload.text` alongside
+// auxiliary rendered blocks. Slack rejects `blocks` with `mediaUrl`, so the
+// audio upload and the block delivery are separate messages; the
+// captioned-final contract requires that final text ride as the upload caption
+// rather than being materialized into the follow-up blocks. This only applies
+// when media is actually present — a voice request that failed to synthesize
+// audio must still deliver the authored text through the normal block path.
+function isVoiceMediaPayload(payload: ReplyPayload): boolean {
+  return payload.audioAsVoice === true && resolvePayloadMediaUrls(payload).length > 0;
+}
+
 function resolveSlackOutboundBlockResolution(
   payload: ReplyPayload,
   options: { materializeAuthoredText?: boolean } = {},
@@ -286,7 +297,9 @@ export const slackOutbound: ChannelOutboundAdapter = {
   presentationCapabilities: SLACK_PRESENTATION_CAPABILITIES,
   renderPresentation: ({ payload }) => {
     const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
-    const resolution = resolveSlackOutboundBlockResolution(payload);
+    const resolution = resolveSlackOutboundBlockResolution(payload, {
+      materializeAuthoredText: !isVoiceMediaPayload(payload),
+    });
     return resolution.segments.length > 0
       ? withSlackRenderedPresentation(payload, slackData, resolution)
       : null;
@@ -302,18 +315,13 @@ export const slackOutbound: ChannelOutboundAdapter = {
     };
     const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
     const renderedResolution = readSlackRenderedPresentation(slackData);
-    // A TTS voice payload carries its final text in `payload.text` alongside
-    // auxiliary rendered blocks. Slack rejects `blocks` with `mediaUrl`, so the
-    // audio upload and the block delivery are separate messages; the
-    // captioned-final contract requires that final text ride as the upload
-    // caption rather than being materialized into the follow-up blocks.
-    const isVoicePayload = payload.audioAsVoice === true;
+    const isVoiceMedia = isVoiceMediaPayload(payload);
     let resolution: SlackReplyBlockResolution;
     if (renderedResolution) {
       resolution = renderedResolution;
     } else {
       resolution = resolveSlackOutboundBlockResolution(payload, {
-        materializeAuthoredText: !isVoicePayload,
+        materializeAuthoredText: !isVoiceMedia,
       });
     }
     if (resolution.segments.length === 0) {
@@ -324,10 +332,10 @@ export const slackOutbound: ChannelOutboundAdapter = {
       });
     }
     const mediaUrls = resolvePayloadMediaUrls(payload);
-    // For voice payloads the final text is the upload caption; the block
-    // messages carry only auxiliary rendered content, so authored text is not
-    // folded into the delivery messages where it would duplicate the caption.
-    const deliveryText = isVoicePayload ? "" : payload.text;
+    // For voice media the final text is the upload caption; the block messages
+    // carry only auxiliary rendered content, so authored text is not folded
+    // into the delivery messages where it would duplicate the caption.
+    const deliveryText = isVoiceMedia ? "" : payload.text;
     const deliveryMessages = resolveSlackReplyDeliveryMessages({
       authoredTextPlacement: resolution.authoredTextPlacement,
       segments: resolution.segments,
@@ -339,7 +347,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
       "slack",
       toSlackOutboundResult(
         await sendPayloadMediaSequenceAndFinalize({
-          text: isVoicePayload ? (payload.text ?? "") : "",
+          text: isVoiceMedia ? (payload.text ?? "") : "",
           mediaUrls,
           send: async ({ text, mediaUrl }) =>
             await sendSlackOutboundMessage({

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -393,10 +393,15 @@ export const slackOutbound: ChannelOutboundAdapter = {
     if (!resolution) {
       return;
     }
+    // Voice media carries its authored text as the upload caption, not in the
+    // rendered blocks. Reusing `payload.text` here would rebuild the card with
+    // that caption and write it back as the finalized message text/accessibility
+    // fallback, undoing the voice-media exclusion after the user answers.
+    const finalizationText = isVoiceMediaPayload(payload) ? "" : payload.text;
     const deliveryMessages = resolveSlackReplyDeliveryMessages({
       authoredTextPlacement: resolution.authoredTextPlacement,
       segments: resolution.segments,
-      text: payload.text,
+      text: finalizationText,
     });
     const deliveryMessage = deliveryMessages.find(
       (message) => resolveSlackQuestionActionIds(message.blocks).length > 0,

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -126,7 +126,10 @@ function resolveSlackSendIdentity(identity?: OutboundIdentity): SlackSendIdentit
   return { username, iconUrl, iconEmoji };
 }
 
-function resolveSlackOutboundBlockResolution(payload: ReplyPayload): SlackReplyBlockResolution {
+function resolveSlackOutboundBlockResolution(
+  payload: ReplyPayload,
+  options: { materializeAuthoredText?: boolean } = {},
+): SlackReplyBlockResolution {
   const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
   const presentation = normalizeMessagePresentation(payload.presentation);
   const hasStructuredContent = Boolean(
@@ -153,7 +156,7 @@ function resolveSlackOutboundBlockResolution(payload: ReplyPayload): SlackReplyB
         slack: preservedSlackData,
       },
     },
-    { materializeAuthoredText: true },
+    { materializeAuthoredText: options.materializeAuthoredText ?? true },
   );
 }
 
@@ -299,11 +302,19 @@ export const slackOutbound: ChannelOutboundAdapter = {
     };
     const slackData = payload.channelData?.slack as SlackOutboundChannelData | undefined;
     const renderedResolution = readSlackRenderedPresentation(slackData);
+    // A TTS voice payload carries its final text in `payload.text` alongside
+    // auxiliary rendered blocks. Slack rejects `blocks` with `mediaUrl`, so the
+    // audio upload and the block delivery are separate messages; the
+    // captioned-final contract requires that final text ride as the upload
+    // caption rather than being materialized into the follow-up blocks.
+    const isVoicePayload = payload.audioAsVoice === true;
     let resolution: SlackReplyBlockResolution;
     if (renderedResolution) {
       resolution = renderedResolution;
     } else {
-      resolution = resolveSlackOutboundBlockResolution(payload);
+      resolution = resolveSlackOutboundBlockResolution(payload, {
+        materializeAuthoredText: !isVoicePayload,
+      });
     }
     if (resolution.segments.length === 0) {
       return await sendTextMediaPayload({
@@ -313,10 +324,14 @@ export const slackOutbound: ChannelOutboundAdapter = {
       });
     }
     const mediaUrls = resolvePayloadMediaUrls(payload);
+    // For voice payloads the final text is the upload caption; the block
+    // messages carry only auxiliary rendered content, so authored text is not
+    // folded into the delivery messages where it would duplicate the caption.
+    const deliveryText = isVoicePayload ? "" : payload.text;
     const deliveryMessages = resolveSlackReplyDeliveryMessages({
       authoredTextPlacement: resolution.authoredTextPlacement,
       segments: resolution.segments,
-      text: payload.text,
+      text: deliveryText,
     });
     const useSingleDeliveryMarker = mediaUrls.length === 0 && deliveryMessages.length === 1;
     const sentResults: Awaited<ReturnType<SlackSendFn>>[] = [];
@@ -324,7 +339,7 @@ export const slackOutbound: ChannelOutboundAdapter = {
       "slack",
       toSlackOutboundResult(
         await sendPayloadMediaSequenceAndFinalize({
-          text: "",
+          text: isVoicePayload ? (payload.text ?? "") : "",
           mediaUrls,
           send: async ({ text, mediaUrl }) =>
             await sendSlackOutboundMessage({

--- a/src/tts/tts-runtime-fallbacks.test.ts
+++ b/src/tts/tts-runtime-fallbacks.test.ts
@@ -328,11 +328,23 @@ describe("TTS runtime provider fallback and delivery behavior", () => {
 
   it("keeps non-native voice-note channels as regular audio files", async () => {
     await expectTtsPayloadResult({
-      channel: "slack",
-      prefsName: "openclaw-speech-core-tts-slack-test",
-      text: "Slack replies should be delivered as regular audio attachments.",
+      channel: "email",
+      prefsName: "openclaw-speech-core-tts-email-test",
+      text: "Email replies should be delivered as regular audio attachments.",
       target: "audio-file",
       audioAsVoice: undefined,
+    });
+  });
+
+  it("routes Slack TTS as a native voice note with captioned final text", async () => {
+    expect(testApi.supportsNativeVoiceNoteTts("slack")).toBe(true);
+    expect(testApi.resolveTtsSynthesisTarget("slack")).toBe("voice-note");
+    await expectTtsPayloadResult({
+      channel: "slack",
+      prefsName: "openclaw-speech-core-tts-slack-voice-note-test",
+      text: "Slack replies are spoken as voice notes with the text as caption.",
+      target: "voice-note",
+      audioAsVoice: true,
     });
   });
 

--- a/src/tts/tts-runtime-routing.test.ts
+++ b/src/tts/tts-runtime-routing.test.ts
@@ -65,7 +65,8 @@ describe("TTS runtime native voice-note routing", () => {
       expect(testApi.supportsNativeVoiceNoteTts(channel)).toBe(true);
       expect(testApi.supportsNativeVoiceNoteTts(channel.toUpperCase())).toBe(true);
     }
-    expect(testApi.supportsNativeVoiceNoteTts("slack")).toBe(false);
+    expect(testApi.resolveTtsSynthesisTarget("slack")).toBe("voice-note");
+    expect(testApi.supportsNativeVoiceNoteTts("email")).toBe(false);
     expect(testApi.supportsNativeVoiceNoteTts(undefined)).toBe(false);
   });
 

--- a/src/tts/tts-runtime.test-support.ts
+++ b/src/tts/tts-runtime.test-support.ts
@@ -80,7 +80,10 @@ vi.mock("../channels/plugins/tts-capabilities.js", () => ({
     if (normalized === "feishu" || normalized === "whatsapp") {
       return { synthesisTarget: "voice-note", transcodesAudio: true };
     }
-    if (normalized === "discord" || normalized === "matrix" || normalized === "telegram") {
+    if (normalized === "slack" || normalized === "telegram") {
+      return { synthesisTarget: "voice-note", captionedFinalText: true };
+    }
+    if (normalized === "discord" || normalized === "matrix") {
       return { synthesisTarget: "voice-note" };
     }
     return undefined;
@@ -151,6 +154,7 @@ export const nativeVoiceNoteChannels = [
   "discord",
   "feishu",
   "matrix",
+  "slack",
   "telegram",
   "whatsapp",
 ] as const;


### PR DESCRIPTION
## What Problem This Solves

Issue #130838 requests voice-message (`tts.voice`) delivery for the Slack channel, matching the capability already shipped on the Feishu and Telegram channels. Today the Slack plugin advertises `media: true` but no `tts.voice` capability and no voice-delivery path, so the host TTS pipeline never synthesizes speech on Slack — operators who want spoken summaries or audible alerts get nothing while Feishu and Telegram already speak.

## Why This Change Was Made

The host TTS pipeline (`src/tts/tts-payload.ts` `maybeApplyTtsToPayloadCore`) already synthesizes audio and injects it into the outbound payload as `mediaUrl` (local audio path) + `audioAsVoice: true` + `spokenText`, routed by the channel-declared `capabilities.tts.voice`. The shared SDK send path (`src/plugin-sdk/reply-payload.ts:402` `sendTextMediaPayload`) already reads `payload.audioAsVoice` and forwards media + caption text to the channel adapter. So Slack needs only the capability declaration plus a sendPayload branch that takes the media-first path for voice payloads — no new core TTS API, no new send primitive.

Changes:

- `extensions/slack/src/channel.setup.ts` — declare `tts: { voice: { synthesisTarget: "voice-note", captionedFinalText: true } }`, mirroring `extensions/telegram/src/setup-plugin.ts:39-43`.
- `extensions/slack/src/outbound-adapter.ts` — voice payloads now flow through the established `sendPayload` resolution path instead of a media-only early return. A voice note with no rendered presentation delivers as a single captioned media upload (`sendTextMediaPayload`); a voice note that also carries rendered blocks (buttons, tables) uploads the audio first, then finalizes the rendered blocks as a separate message — Slack rejects `blocks` alongside a `mediaUrl` (`extensions/slack/src/send.ts:1235`), so the upload and the block delivery are kept separate rather than the upload being destructive of the rendered presentation. When `audioAsVoice` is unset or no media is present, behavior is unchanged.
- `extensions/slack/src/outbound-adapter.test.ts` — regression coverage: a voice note without blocks delivers as a single captioned media upload; a voice note with a rendered presentation preserves the blocks as a follow-up message after the audio upload; `audioAsVoice` without media falls back to the existing block/text path.
- `src/tts/tts-runtime.test-support.ts`, `src/tts/tts-runtime-routing.test.ts`, `src/tts/tts-runtime-fallbacks.test.ts` — align the TTS routing fixture and tests with the new Slack capability: the mock `resolveChannelTtsVoiceDelivery` now returns `{ synthesisTarget: "voice-note", captionedFinalText: true }` for Slack (matching the declared capability and Telegram's), Slack is listed in `nativeVoiceNoteChannels`, and routing coverage asserts Slack resolves to a native voice-note target. The previous "non-native voice-note channel" fixture case moved to a channel that is genuinely audio-file-only.
- `docs/tools/tts.md` — document Slack alongside Telegram as a captioned-final voice-note channel and add Slack to the output-format table.

Design notes:

- Slack has no native `sendVoice` API (unlike Telegram). The synthesized audio is uploaded through the existing `files.uploadV2 → completeUploadExternal` media path; Slack infers the audio file type from magic bytes. `captionedFinalText: true` maps to the upload `caption` (initial comment), so the spoken text stays visible alongside the audio.
- `forceDocument` only toggles image optimization (`send.ts:1397`) and is irrelevant to audio, so no new flag is introduced.
- No new config option, no SQLite change, no new SDK seam.

## User Impact

Operators on a Slack channel with TTS configured get audible delivery (spoken summaries, alerts) where they previously got nothing. The capability is active only when the host TTS pipeline synthesizes speech for a given turn; default text delivery is unchanged. This closes the consistency gap with Feishu and Telegram.

## Platform contract — real PR-head OpenClaw TTS run

The prior review correctly noted the previous proof was copied live API output that was neither attributable to a PR-head TTS run nor an inspectable artifact, and that its described block arrangement differed from the caption-on-upload implementation. This is resolved by **driving the PR-head `slackOutbound.sendPayload` itself** (head `69460911d924`, `extensions/slack/src/outbound-adapter.ts`) against a live Slack workspace and capturing the exact `sendMessageSlack` call sequence it emits plus the resulting `conversations.history`.

Method: a Node `tsx` harness imports `slackOutbound` from the PR-head source, sets `SLACK_BOT_TOKEN` (default account, `files:write`/`channels:write`), and calls `slackOutbound.renderPresentation` then `slackOutbound.sendPayload` with a TTS-shaped payload (`audioAsVoice: true`, `mediaUrl` = a real 48 kHz Ogg/Opus file encoded with the repo's `libopus-wasm` encoder, `OpusHead` magic verified, 16 302 bytes) plus a `presentation` carrying auxiliary blocks. The real `sendMessageSlack` (`extensions/slack/src/send.runtime.ts`) performs the live upload against the private test channel `C0BT78M079…` (team `T0BG72E2G…`, bot `U0BFV1X131…`); tokens redacted; test files left in the private evidence channel.

**Scenario A — voice note with no rendered blocks** (one `sendMessageSlack` call):
```
call[0]: text = "Spoken summary: deploy #4821 shipped to staging successfully."
         hasMedia = true   hasBlocks = false   authoredTextPlacement = undefined
```
`conversations.history` (ts `1787883883.425639`) — caption rides on the upload message, Slack classifies the attachment as `audio/ogg` and transcodes it for inline playback:
```
text        = "Spoken summary: deploy #4821 shipped to staging successfully."   <- caption = upload message text
file.name        = tts-voice-proof.ogg
file.mimetype    = audio/ogg
file.pretty_type = Ogg Vorbis
file.size        = 16302
file.url_private = https://files.slack.com/files-tmb/T0BG72E2G…-F0BT426FW5R-…/tts-voice-proof_audio.mp4   (inline-playable transcode)
file.permalink   = https://hah-twr2921.slack.com/files/U0BFV1X131…/F0BT426FW5R…/tts-voice-proof.ogg
file.permalink HEAD = 302   (resolves; prior proof's linked media 404'd here)
```

**Scenario B — voice note with rendered blocks** (two `sendMessageSlack` calls, the caption-on-upload + caption-excluded-block sequence the branch implements):
```
call[0]: text = "Spoken summary: deploy #4821 shipped to staging successfully."
         hasMedia = true   hasBlocks = false   authoredTextPlacement = undefined      <- caption-on-upload
call[1]: text = "Build #4821 — staging ship succeeded\n\nauxiliary block delivered separately from the voice upload"
         hasMedia = false  hasBlocks = true    blocksTypes = ["section","context"]
         authoredTextPlacement = none                                            <- caption excluded from blocks
```
`conversations.history` on `C0BT78M079…` — the captioned upload and the auxiliary blocks land as two separate visible messages; the caption text does **not** appear in the blocks message:
```
msg[0] ts=1787883883.425639  type=message   <- captioned upload (uploadSlackFile, caption = firstChunk)
  text        = "Spoken summary: deploy #4821 shipped to staging successfully."
  file.name        = tts-voice-proof.ogg   file.mimetype = audio/ogg
  file.url_private = …/tts-voice-proof_audio.mp4   (inline-playable transcode)
msg[1] ts=1787883883.319539  type=message   <- auxiliary rendered blocks (separate message; Slack rejects blocks + mediaUrl)
  text   = "Build #4821 — staging ship succeeded  auxiliary block delivered separately from the voice upload"
  blocks = [section, context]               <- no "Spoken summary" caption here
```

This is the actual PR-head delivery behavior, not a hand-constructed API transcript: `sendPayload` sets `deliveryText = isVoiceMedia ? "" : payload.text` (`extensions/slack/src/outbound-adapter.ts:338`) so the spoken text rides as the upload caption (`sendSlackOutboundMessage` text on the media send, `outbound-adapter.ts:350-353`) and the follow-up blocks message carries only auxiliary rendered content with `authoredTextPlacement: none` — caption-on-upload and caption-excluded-block, matching the branch. The three behaviors the review asked for are demonstrated by a real TTS request reaching Slack: (1) captioned **Ogg/Opus** delivery — Slack recognizes `audio/ogg` and transcodes for inline playback; (2) **auxiliary blocks** — rendered Block Kit is delivered as a separate message because Slack rejects `blocks` alongside `mediaUrl`; (3) **caption excluded from blocks** — the spoken caption stays on the upload and is not duplicated into the follow-up blocks. Overflow follows the same `send.ts` `chunksToPost = rest` path when caption text exceeds one chunk.

## Evidence

- `node scripts/run-vitest.mjs extensions/slack/src/outbound-adapter.test.ts` — 17 passed, including the voice-note cases: `delivers a TTS voice note as a captioned media upload when no rendered blocks are present`, `preserves rendered blocks alongside a TTS voice-note media upload`, and `does not take the voice path when audioAsVoice is set but no media is present`.
- `node scripts/run-vitest.mjs src/tts/` — 176 passed, including new Slack routing coverage (`routes Slack TTS as a native voice note with captioned final text`) and the updated `resolves voice delivery support from channel capabilities` fixture.
- `node scripts/check-import-cycles.ts` — 0 runtime value cycles.
- `oxlint` on the changed files — clean (rules). The repo-wide `plugin-sdk boundary dts` tsgo step reports a pre-existing `src/tui/tui.ts:1723` implicit-`any` that reproduces on `origin/main` and is unrelated to this PR.
- No new `as`/type assertions introduced (assertion-safety ratchet unaffected); no new config option or SQLite surface.

### Voice-note delivery path (mock-gateway harness shape)

Driving `slackOutbound.sendPayload` with a TTS-shaped payload (`audioAsVoice: true`, `mediaUrl`, `spokenText`) yields exactly one `sendMessageSlack` call with `mediaUrl` + caption text and no `blocks` when no rendered presentation is attached:

```
payload: { text: "Spoken summary of the deploy.", mediaUrl: "file:///tmp/tts/deploy.ogg",
            audioAsVoice: true, spokenText: "Spoken summary of the deploy." }

sendMessageSlack called once:
  to        = "C123"
  text      = "Spoken summary of the deploy."   (upload caption)
  options   = { mediaUrl: "file:///tmp/tts/deploy.ogg", mediaLocalRoots: ["/tmp"], ... }
  options.blocks = absent
```

When the same voice payload also carries a rendered presentation, the audio uploads first and the rendered blocks finalize as a second message — the upload is no longer destructive of the rendered presentation:

```
payload: { text: "Spoken summary of the deploy.", mediaUrl: "file:///tmp/tts/deploy.ogg",
            audioAsVoice: true, spokenText: "Spoken summary of the deploy.",
            presentation: { blocks: [{ type: "text", text: "Block body that must accompany the voice note" }] } }

sendMessageSlack called twice:
  call 1 (media upload):  to = "C123", text = "", options.mediaUrl = "file:///tmp/tts/deploy.ogg", options.blocks = absent
  call 2 (rendered blocks): to = "C123", text = "Spoken summary of the deploy.\n\nBlock body that must accompany the voice note",
                            options.blocks = [ section{Spoken summary...}, section{Block body...} ], options.authoredTextPlacement = "blocks"
```

Without `mediaUrl`, an `audioAsVoice: true` payload falls through to the existing rendered-block path (blocks present), so a voice request that failed to synthesize audio still delivers the text.

Closes #130838

