### PR TITLE
fix(code-mode): resume work after safe reconciliation

### DIFF
--- a/src/agents/code-mode-bridge.ts
+++ b/src/agents/code-mode-bridge.ts
@@ -12,6 +12,7 @@ import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { redactCodeModeCatalogIds, type CodeModeCatalogProjection } from "./code-mode-catalog.js";
 import { boundCodeModeValue } from "./code-mode-json.js";
 import type { CodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
+import { codeModeMutationReplayKey } from "./code-mode-repair-provenance.js";
 import type { PendingBridgeRequest, SettledBridgeRequest } from "./code-mode-runtime.js";
 import { readCodeModeSkill } from "./code-mode-skills.js";
 import { consumeMcpCodeModeGuestResult } from "./mcp-content.js";
@@ -399,6 +400,17 @@ export async function runBridgeRequest(params: {
 }): Promise<SettledBridgeRequest> {
   const catalogProjection = params.catalogProjection;
   try {
+    if (
+      params.ctx.codeModeReconciliationReplayFence?.mutationKeys.includes(
+        codeModeMutationReplayKey(params.request),
+      )
+    ) {
+      const error = new ToolInputError(
+        "Blocked a replay of a Code Mode mutation with an uncertain outcome.",
+      );
+      registerTrustedToolNoStartError(error);
+      throw error;
+    }
     const values = Array.isArray(params.request.args) ? params.request.args : [];
     let value: unknown;
     switch (params.request.method) {

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -14,7 +14,10 @@ import {
   createCodeModeNamespaceRuntime,
   type CodeModeNamespaceRuntime,
 } from "./code-mode-namespaces.js";
-import { registerRepairableCodeModeFailure } from "./code-mode-repair-provenance.js";
+import {
+  registerRepairableCodeModeFailure,
+  registerUncertainCodeModeMutations,
+} from "./code-mode-repair-provenance.js";
 import {
   CODE_MODE_WORKER_WATCHDOG_GRACE_MS,
   codeModeFailureCode,
@@ -38,6 +41,7 @@ import {
   codeModeWaitingReason,
   createCodeModeBridgeDispatchState,
   createPendingBridgeStates,
+  codeModeMutationReplayKeys,
   disposeCodeModeRun,
   isCodeModeBridgeRepairEligible,
   pendingBridgeRequestsReplaySafe,
@@ -60,6 +64,23 @@ import type { AgentToolUpdateCallback } from "./runtime/index.js";
 import { resolveSwarmConfig } from "./subagents/swarm/swarm-config.js";
 import { ToolSearchRuntime, type ToolSearchToolContext } from "./tool-search.js";
 import { ToolInputError } from "./tools/common.js";
+
+function registerCodeModeExecFailureProvenance(
+  result: { status: string },
+  bridgeDispatch: CodeModeBridgeDispatchState,
+): void {
+  if (result.status !== "failed") {
+    return;
+  }
+  if (isCodeModeBridgeRepairEligible(bridgeDispatch)) {
+    registerRepairableCodeModeFailure(result);
+    return;
+  }
+  const mutationKeys = codeModeMutationReplayKeys(bridgeDispatch);
+  if (mutationKeys) {
+    registerUncertainCodeModeMutations(result, mutationKeys);
+  }
+}
 
 export async function runCodeModeExec(params: {
   toolCallId: string;
@@ -146,7 +167,7 @@ export async function runCodeModeExec(params: {
         params.signal,
       ),
     );
-    return await settleCodeModeResult({
+    const settled = await settleCodeModeResult({
       result,
       output: result.output,
       replaySafe: params.restartSafe,
@@ -163,9 +184,11 @@ export async function runCodeModeExec(params: {
       signal: params.signal,
       onUpdate: params.onUpdate,
     });
+    registerCodeModeExecFailureProvenance(settled, bridgeDispatch);
+    return settled;
   } catch (error) {
     const code = params.signal?.aborted ? ("aborted" as const) : codeModeFailureCode(error);
-    return {
+    const failed = {
       status: "failed" as const,
       error: params.signal?.aborted ? "code mode execution aborted" : codeModeFailureMessage(error),
       code,
@@ -179,6 +202,8 @@ export async function runCodeModeExec(params: {
       replaySafe: params.restartSafe,
       telemetry: telemetry(runtime),
     };
+    registerCodeModeExecFailureProvenance(failed, bridgeDispatch);
+    return failed;
   } finally {
     approvalWait.dispose();
   }
@@ -574,9 +599,6 @@ async function settleCodeModeResult(params: {
     replaySafe: params.replaySafe,
     telemetry: telemetry(params.runtime),
   };
-  if (finalized.status === "failed" && isCodeModeBridgeRepairEligible(params.bridgeDispatch)) {
-    registerRepairableCodeModeFailure(finalized);
-  }
   return finalized;
 }
 

--- a/src/agents/code-mode-repair-provenance.ts
+++ b/src/agents/code-mode-repair-provenance.ts
@@ -1,6 +1,6 @@
 import { stableStringify } from "@openclaw/normalization-core";
 import { sha256Hex } from "../infra/crypto-digest.js";
-import type { PendingBridgeRequest } from "./code-mode-runtime.js";
+import type { PendingBridgeRequest } from "./code-mode-worker-types.js";
 
 const repairableFailureDetails = new WeakSet<object>();
 const uncertainMutationKeysByDetails = new WeakMap<object, readonly string[]>();

--- a/src/agents/code-mode-repair-provenance.ts
+++ b/src/agents/code-mode-repair-provenance.ts
@@ -1,4 +1,21 @@
+import { stableStringify } from "@openclaw/normalization-core";
+import { sha256Hex } from "../infra/crypto-digest.js";
+import type { PendingBridgeRequest } from "./code-mode-runtime.js";
+
 const repairableFailureDetails = new WeakSet<object>();
+const uncertainMutationKeysByDetails = new WeakMap<object, readonly string[]>();
+
+export type CodeModeReconciliationReplayFence = {
+  code: string;
+  mutationKeys: readonly string[];
+};
+
+/** Identify the bridged operation independently of its guest JavaScript source. */
+export function codeModeMutationReplayKey(request: PendingBridgeRequest): string {
+  const args =
+    request.method === "callValue" ? [request.args[0], request.args[1] ?? {}] : request.args;
+  return `${request.method}:${sha256Hex(stableStringify(args))}`;
+}
 
 /** Attach host-only repair authority to one finalized Code Mode failure payload. */
 export function registerRepairableCodeModeFailure(details: object): void {
@@ -10,4 +27,33 @@ export function consumeRepairableCodeModeFailure(details: unknown): boolean {
   return (
     typeof details === "object" && details !== null && repairableFailureDetails.delete(details)
   );
+}
+
+/** Attach the bounded set of bridged mutations whose outcomes may be uncertain. */
+export function registerUncertainCodeModeMutations(
+  details: object,
+  mutationKeys: readonly string[],
+): void {
+  uncertainMutationKeysByDetails.set(details, [...mutationKeys]);
+}
+
+/** Consume host-only mutation identities from the exact finalized failure payload. */
+export function consumeUncertainCodeModeMutations(details: unknown): readonly string[] | undefined {
+  if (typeof details !== "object" || details === null) {
+    return undefined;
+  }
+  const mutationKeys = uncertainMutationKeysByDetails.get(details);
+  uncertainMutationKeysByDetails.delete(details);
+  return mutationKeys;
+}
+
+/** Preserve host-only failure provenance when timeout normalization clones a result. */
+export function copyCodeModeFailureProvenance(source: object, target: object): void {
+  if (repairableFailureDetails.has(source)) {
+    repairableFailureDetails.add(target);
+  }
+  const mutationKeys = uncertainMutationKeysByDetails.get(source);
+  if (mutationKeys) {
+    uncertainMutationKeysByDetails.set(target, mutationKeys);
+  }
 }

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -8,6 +8,7 @@ import { runBridgeRequest } from "./code-mode-bridge.js";
 import type { CodeModeCatalogProjection } from "./code-mode-catalog.js";
 import { CODE_MODE_EXEC_TOOL_NAME, CODE_MODE_WAIT_TOOL_NAME } from "./code-mode-control-tools.js";
 import type { CodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
+import { codeModeMutationReplayKey } from "./code-mode-repair-provenance.js";
 import {
   enforceSnapshotPayloadLimits,
   type CodeModeConfig,
@@ -23,6 +24,8 @@ import { ToolInputError } from "./tools/common.js";
 export type CodeModeBridgeDispatchState = {
   started: boolean;
   potentiallyMutatingDispatches: number;
+  potentiallyMutatingCallKeys: Map<string, number>;
+  mutationCallKeysComplete: boolean;
 };
 
 export type PendingBridgeState = PendingBridgeRequest & {
@@ -56,6 +59,7 @@ type CodeModeRunState = {
 
 const MAX_ACTIVE_CODE_MODE_RUNS = 64;
 const MAX_AGENT_WAIT_SNAPSHOT_TTL_WINDOWS = 4;
+const MAX_MUTATION_REPLAY_FENCE_KEYS = 64;
 const BRIDGE_CLOSED_MESSAGE = "Code Mode tool canceled, expired, or owner lost; start a new run.";
 
 export const activeRuns = new Map<string, CodeModeRunState>();
@@ -65,12 +69,56 @@ let nextPendingBridgeSettlementSequence = 0;
 let activeRunExpiryTimer: ReturnType<typeof setTimeout> | undefined;
 
 export function createCodeModeBridgeDispatchState(): CodeModeBridgeDispatchState {
-  return { started: false, potentiallyMutatingDispatches: 0 };
+  return {
+    started: false,
+    potentiallyMutatingDispatches: 0,
+    potentiallyMutatingCallKeys: new Map(),
+    mutationCallKeysComplete: true,
+  };
 }
 
 /** Read the host-only side-effect classification for one Code Mode run. */
 export function isCodeModeBridgeRepairEligible(state: CodeModeBridgeDispatchState): boolean {
   return state.started && state.potentiallyMutatingDispatches === 0;
+}
+
+/** Return every uncertain bridged mutation, or fail closed if the bounded set overflowed. */
+export function codeModeMutationReplayKeys(
+  state: CodeModeBridgeDispatchState,
+): readonly string[] | undefined {
+  if (!state.mutationCallKeysComplete) {
+    return undefined;
+  }
+  const keys = [...state.potentiallyMutatingCallKeys.keys()].toSorted();
+  return keys.length > 0 ? keys : undefined;
+}
+
+function recordPotentiallyMutatingCall(
+  state: CodeModeBridgeDispatchState,
+  request: PendingBridgeRequest,
+): string {
+  const key = codeModeMutationReplayKey(request);
+  const count = state.potentiallyMutatingCallKeys.get(key);
+  if (count !== undefined) {
+    state.potentiallyMutatingCallKeys.set(key, count + 1);
+  } else if (state.potentiallyMutatingCallKeys.size < MAX_MUTATION_REPLAY_FENCE_KEYS) {
+    state.potentiallyMutatingCallKeys.set(key, 1);
+  } else {
+    state.mutationCallKeysComplete = false;
+  }
+  return key;
+}
+
+function releasePotentiallyMutatingCall(state: CodeModeBridgeDispatchState, key: string): void {
+  const count = state.potentiallyMutatingCallKeys.get(key);
+  if (count === undefined) {
+    return;
+  }
+  if (count === 1) {
+    state.potentiallyMutatingCallKeys.delete(key);
+  } else {
+    state.potentiallyMutatingCallKeys.set(key, count - 1);
+  }
 }
 
 // One unreferenced timer owns parked snapshots even when no later exec or wait
@@ -374,6 +422,10 @@ export function createPendingBridgeStates(params: {
         params.bridgeDispatch.potentiallyMutatingDispatches += 1;
       }
     }
+    const mutationKey =
+      tracksDispatch && !recoverySafe
+        ? recordPotentiallyMutatingCall(params.bridgeDispatch, request)
+        : undefined;
     const bridgeCall = runBridgeRequest({
       runtime: params.runtime,
       catalogProjection: params.catalogProjection,
@@ -403,6 +455,9 @@ export function createPendingBridgeStates(params: {
             0,
             params.bridgeDispatch.potentiallyMutatingDispatches - 1,
           );
+          if (mutationKey) {
+            releasePotentiallyMutatingCall(params.bridgeDispatch, mutationKey);
+          }
         }
         state.settledSequence = ++nextPendingBridgeSettlementSequence;
         state.settled = settled;

--- a/src/agents/code-mode-worker.ts
+++ b/src/agents/code-mode-worker.ts
@@ -4,6 +4,7 @@ import { Worker } from "node:worker_threads";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { copyCodeModeFailureProvenance } from "./code-mode-repair-provenance.js";
 import type { CodeModeFailureCode, CodeModeWorkerResult } from "./code-mode-runtime.js";
 
 let quickJsWasmModulePromise: Promise<WebAssembly.Module> | undefined;
@@ -52,10 +53,12 @@ export function normalizeCodeModeTimeoutResult<
     result.code === "timeout" &&
     !String(result.error).includes("timeout exceeded")
   ) {
-    return {
+    const normalized = {
       ...result,
       error: "code mode timeout exceeded",
     } as T;
+    copyCodeModeFailureProvenance(result, normalized);
+    return normalized;
   }
   return result;
 }

--- a/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
@@ -42,7 +42,9 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
           lastAssistant: mutationAssistant,
           currentAttemptAssistant: mutationAssistant,
           currentAttemptCompletedAssistant: mutationAssistant,
-          codeModeReconciliationCandidate: true,
+          codeModeReconciliationCandidate: {
+            code: "return await apply_patch({});",
+          },
           itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
         }),
       )
@@ -83,6 +85,9 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
     });
     expect(mockedRunEmbeddedAttempt.mock.calls[2]?.[0]).toMatchObject({
       forceCodeModeReconciliationTools: undefined,
+      codeModeReconciliationReplayFence: {
+        code: "return await apply_patch({});",
+      },
       prompt: expect.stringContaining("Continue the original task from the reconciled state"),
     });
   });

--- a/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
@@ -46,7 +46,12 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
           itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
         }),
       )
-      .mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["The first hunk applied."] }))
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          assistantTexts: ["The first hunk applied."],
+          toolMetas: [{ toolName: "read", isError: false }],
+        }),
+      )
       .mockResolvedValueOnce(
         makeAttemptResult({ assistantTexts: ["Finished the remaining work."] }),
       );

--- a/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
@@ -23,7 +23,7 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
     useOpenAIPlatformAuthFixture();
   });
 
-  it("continues a settled partial mutation with one read-only attempt", async () => {
+  it("resumes ordinary work after one settled read-only reconciliation", async () => {
     const mutationAssistant = buildEmbeddedRunnerAssistant({
       stopReason: "toolUse",
       content: [
@@ -46,7 +46,10 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
           itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
         }),
       )
-      .mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["The first hunk applied."] }));
+      .mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["The first hunk applied."] }))
+      .mockResolvedValueOnce(
+        makeAttemptResult({ assistantTexts: ["Finished the remaining work."] }),
+      );
 
     await runEmbeddedAgent({
       ...overflowBaseRunParams,
@@ -62,13 +65,17 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
       runId: "run-code-mode-reconciliation",
     });
 
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
     expect(
       mockedRunEmbeddedAttempt.mock.calls[0]?.[0].forceCodeModeReconciliationTools,
     ).toBeFalsy();
     expect(mockedRunEmbeddedAttempt.mock.calls[1]?.[0]).toMatchObject({
       forceCodeModeReconciliationTools: true,
       prompt: expect.stringContaining("may have partially applied"),
+    });
+    expect(mockedRunEmbeddedAttempt.mock.calls[2]?.[0]).toMatchObject({
+      forceCodeModeReconciliationTools: undefined,
+      prompt: expect.stringContaining("Continue the original task from the reconciled state"),
     });
   });
 });

--- a/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
@@ -49,6 +49,9 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
       .mockResolvedValueOnce(
         makeAttemptResult({
           assistantTexts: ["The first hunk applied."],
+          currentAttemptCompletedAssistant: buildEmbeddedRunnerAssistant({
+            content: [{ type: "text", text: "The first hunk applied." }],
+          }),
           toolMetas: [{ toolName: "read", isError: false }],
         }),
       )

--- a/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.code-mode-reconciliation.test-support.ts
@@ -44,6 +44,7 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
           currentAttemptCompletedAssistant: mutationAssistant,
           codeModeReconciliationCandidate: {
             code: "return await apply_patch({});",
+            mutationKeys: ["callValue:mutation"],
           },
           itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
         }),
@@ -87,6 +88,7 @@ describe("runEmbeddedAgent Code Mode reconciliation", () => {
       forceCodeModeReconciliationTools: undefined,
       codeModeReconciliationReplayFence: {
         code: "return await apply_patch({});",
+        mutationKeys: ["callValue:mutation"],
       },
       prompt: expect.stringContaining("Continue the original task from the reconciled state"),
     });

--- a/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-dispatch-preparation.ts
@@ -55,9 +55,21 @@ export async function prepareAndDispatchEmbeddedRunAttempt(input: {
     provider,
     modelId,
   } = input;
-  const params = input.terminalRetryState.forceCodeModeReconciliationTools
-    ? { ...runInput.runParams, forceCodeModeReconciliationTools: true }
-    : runInput.runParams;
+  const reconciliationState = {
+    ...(input.terminalRetryState.forceCodeModeReconciliationTools
+      ? { forceCodeModeReconciliationTools: true }
+      : {}),
+    ...(input.terminalRetryState.codeModeReconciliationReplayFence
+      ? {
+          codeModeReconciliationReplayFence:
+            input.terminalRetryState.codeModeReconciliationReplayFence,
+        }
+      : {}),
+  };
+  const params =
+    Object.keys(reconciliationState).length > 0
+      ? { ...runInput.runParams, ...reconciliationState }
+      : runInput.runParams;
   const {
     workspaceResolution,
     workspaceDir,

--- a/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session-prepare.ts
@@ -49,7 +49,11 @@ import { buildAfterTurnRuntimeContext } from "./attempt-prompt-helpers.js";
 import { resolveExistingAttemptTranscriptState } from "./attempt-transcript-helpers.js";
 import type { EmbeddedAttemptTranscriptLifecycle } from "./attempt-transcript-lifecycle.js";
 import { createUserTranscriptContextRegistry } from "./attempt-user-transcript-context-registry.js";
-import { installCodeModeOutcomeHook } from "./code-mode-outcome.js";
+import {
+  installCodeModeOutcomeHook,
+  installCodeModeReconciliationReplayFence,
+  type CodeModeReconciliationReplayFence,
+} from "./code-mode-outcome.js";
 import { installMessageToolOnlyTerminalHook } from "./message-tool-terminal.js";
 import { reconcilePrePersistedCurrentUserTurn } from "./pre-persisted-user-turn.js";
 import { resolveSessionBoundaryPromptCacheKey } from "./session-boundary-prompt-cache-key.js";
@@ -222,7 +226,7 @@ export async function prepareEmbeddedAttemptAgentSession(input: {
   };
   setActiveSessionSystemPrompt(input.initialSystemPrompt);
   let didDeliverSourceReplyViaMessageTool = false;
-  let codeModeReconciliationCandidate = false;
+  let codeModeReconciliationCandidate: CodeModeReconciliationReplayFence | undefined;
   let codeModeReconciliationReadAuthorized = false;
   const markSourceReplyDelivered = () => {
     didDeliverSourceReplyViaMessageTool = true;
@@ -243,11 +247,17 @@ export async function prepareEmbeddedAttemptAgentSession(input: {
     sessionKey: attempt.sessionKey,
   });
   if (input.clientToolPreparation.codeModeControlsEnabledForRun) {
+    if (attempt.codeModeReconciliationReplayFence) {
+      installCodeModeReconciliationReplayFence({
+        agent: activeSession.agent,
+        fence: attempt.codeModeReconciliationReplayFence,
+      });
+    }
     installCodeModeOutcomeHook({
       agent: activeSession.agent,
-      onReconciliationCandidate: () => {
+      onReconciliationCandidate: (fence) => {
         if (codeModeReconciliationReadAuthorized) {
-          codeModeReconciliationCandidate = true;
+          codeModeReconciliationCandidate = fence;
         }
       },
     });

--- a/src/agents/embedded-agent-runner/run/attempt-session.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session.test.ts
@@ -12,6 +12,7 @@ const hoisted = vi.hoisted(() => ({
   createPreparedEmbeddedAgentSettingsManager: vi.fn(),
   getGlobalHookRunner: vi.fn(),
   installCodeModeOutcomeHook: vi.fn(),
+  installCodeModeReconciliationReplayFence: vi.fn(),
   installMessageToolOnlyTerminalHook: vi.fn(),
   prepareEmbeddedAttemptClientTools: vi.fn(),
   resolveEffectiveCompactionMode: vi.fn(),
@@ -61,6 +62,7 @@ vi.mock("./attempt-client-tools.js", () => ({
 }));
 vi.mock("./code-mode-outcome.js", () => ({
   installCodeModeOutcomeHook: hoisted.installCodeModeOutcomeHook,
+  installCodeModeReconciliationReplayFence: hoisted.installCodeModeReconciliationReplayFence,
 }));
 vi.mock("./message-tool-terminal.js", () => ({
   installMessageToolOnlyTerminalHook: hoisted.installMessageToolOnlyTerminalHook,
@@ -126,7 +128,7 @@ function createInput(options?: {
     replaySafeTools: new Set(allCustomTools),
   };
   let onDeliveredSourceReply: (() => void) | undefined;
-  let onReconciliationCandidate: (() => void) | undefined;
+  let onReconciliationCandidate: ((fence: { code: string }) => void) | undefined;
 
   hoisted.createPreparedEmbeddedAgentSettingsManager.mockReturnValue(settingsManager);
   hoisted.resolveEffectiveCompactionMode.mockReturnValue("safeguard");
@@ -153,7 +155,7 @@ function createInput(options?: {
     },
   );
   hoisted.installCodeModeOutcomeHook.mockImplementation(
-    (input: { onReconciliationCandidate?: () => void }) => {
+    (input: { onReconciliationCandidate?: typeof onReconciliationCandidate }) => {
       onReconciliationCandidate = input.onReconciliationCandidate;
       events.push("install-code-mode-outcome");
     },
@@ -190,7 +192,10 @@ function createInput(options?: {
       transcriptLifecycle: transcriptLifecycle as never,
       sessionManager: sessionManager as never,
     },
-    markCodeModeReconciliationCandidate: () => onReconciliationCandidate?.(),
+    markCodeModeReconciliationCandidate: () =>
+      onReconciliationCandidate?.({
+        code: "return await apply_patch({});",
+      }),
     onDeliveredSourceReply: () => onDeliveredSourceReply?.(),
     resourceLoader,
     setActiveToolsByName,
@@ -246,10 +251,12 @@ describe("prepareEmbeddedAttemptAgentSession", () => {
     expect(result.hasDeliveredSourceReply()).toBe(false);
     fixture.onDeliveredSourceReply();
     expect(result.hasDeliveredSourceReply()).toBe(true);
-    expect(result.getCodeModeReconciliationCandidate()).toBe(false);
+    expect(result.getCodeModeReconciliationCandidate()).toBeUndefined();
     result.setCodeModeReconciliationReadAuthorized(true);
     fixture.markCodeModeReconciliationCandidate();
-    expect(result.getCodeModeReconciliationCandidate()).toBe(true);
+    expect(result.getCodeModeReconciliationCandidate()).toEqual({
+      code: "return await apply_patch({});",
+    });
   });
 
   it("does not install Code Mode outcome handling when the run kept direct tools", async () => {
@@ -275,7 +282,7 @@ describe("prepareEmbeddedAttemptAgentSession", () => {
     });
     result.setCodeModeReconciliationReadAuthorized(finalReadAllowed);
     fixture.markCodeModeReconciliationCandidate();
-    expect(result.getCodeModeReconciliationCandidate()).toBe(false);
+    expect(result.getCodeModeReconciliationCandidate()).toBeUndefined();
   });
 
   it("leaves overflow recovery with the session when no model budget was resolved", async () => {

--- a/src/agents/embedded-agent-runner/run/attempt-session.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-session.test.ts
@@ -128,7 +128,9 @@ function createInput(options?: {
     replaySafeTools: new Set(allCustomTools),
   };
   let onDeliveredSourceReply: (() => void) | undefined;
-  let onReconciliationCandidate: ((fence: { code: string }) => void) | undefined;
+  let onReconciliationCandidate:
+    | ((fence: { code: string; mutationKeys: readonly string[] }) => void)
+    | undefined;
 
   hoisted.createPreparedEmbeddedAgentSettingsManager.mockReturnValue(settingsManager);
   hoisted.resolveEffectiveCompactionMode.mockReturnValue("safeguard");
@@ -195,6 +197,7 @@ function createInput(options?: {
     markCodeModeReconciliationCandidate: () =>
       onReconciliationCandidate?.({
         code: "return await apply_patch({});",
+        mutationKeys: ["callValue:mutation"],
       }),
     onDeliveredSourceReply: () => onDeliveredSourceReply?.(),
     resourceLoader,
@@ -256,6 +259,7 @@ describe("prepareEmbeddedAttemptAgentSession", () => {
     fixture.markCodeModeReconciliationCandidate();
     expect(result.getCodeModeReconciliationCandidate()).toEqual({
       code: "return await apply_patch({});",
+      mutationKeys: ["callValue:mutation"],
     });
   });
 

--- a/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-catalog.ts
@@ -100,6 +100,7 @@ export function prepareEmbeddedAttemptToolCatalog(input: {
         catalogRef: preparedToolBase.toolSearchCatalogRef,
         abortSignal: input.abortSignal,
         forceRestartSafeTools: attempt.forceRestartSafeTools,
+        codeModeReconciliationReplayFence: attempt.codeModeReconciliationReplayFence,
         toolExecutionAllow: attempt.toolExecutionAllow,
         executeTool: input.executeCodeModeTool,
         codeModeSkills,

--- a/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
@@ -143,7 +143,9 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
                       type: "toolCall",
                       id: "replay",
                       name: "exec",
-                      arguments: { code: "return await apply_patch({});" },
+                      arguments: {
+                        code: "// harmless source rewrite\nreturn await apply_patch({});",
+                      },
                     },
                     {
                       type: "toolCall",
@@ -196,6 +198,7 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
 
     expect(firstAttempt.codeModeReconciliationCandidate).toEqual({
       code: "return await apply_patch({});",
+      mutationKeys: [expect.stringMatching(/^callValue:/)],
     });
     expect(appliedChanges).toEqual(["first hunk applied"]);
     expect(applyPatch.execute).toHaveBeenCalledOnce();

--- a/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
@@ -39,8 +39,8 @@ const model: Model = {
   maxTokens: 8_192,
 };
 
-function streamAssistant(content: AssistantMessage["content"]) {
-  const message: AssistantMessage = {
+function buildAssistant(content: AssistantMessage["content"]): AssistantMessage {
+  return {
     role: "assistant",
     content,
     api: model.api,
@@ -57,6 +57,10 @@ function streamAssistant(content: AssistantMessage["content"]) {
     stopReason: content.some((entry) => entry.type === "toolCall") ? "toolUse" : "stop",
     timestamp: Date.now(),
   };
+}
+
+function streamAssistant(content: AssistantMessage["content"]) {
+  const message = buildAssistant(content);
   const stream = createAssistantMessageEventStream();
   queueMicrotask(() => {
     stream.push({
@@ -111,6 +115,8 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
       const subscription = baseSubscribe(params);
       if (attemptPhase === "reconciliation") {
         subscription.toolMetas.push({ toolName: "read", isError: false });
+        subscription.getCurrentAttemptAssistant = () =>
+          buildAssistant([{ type: "text", text: "first hunk applied" }]);
       }
       return subscription;
     });

--- a/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
@@ -102,7 +102,7 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
     ]);
 
     const providerContexts: Context[] = [];
-    let reconciliationAttempt = false;
+    let attemptPhase: "mutation" | "reconciliation" | "continuation" = "mutation";
     const createSession = () => {
       const session = createDefaultEmbeddedSession();
       const options = hoisted.createAgentSessionMock.mock.calls.at(-1)?.[0] as {
@@ -118,13 +118,18 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
             return streamAssistant([{ type: "text", text: "first hunk applied" }]);
           }
           return streamAssistant([
-            reconciliationAttempt
+            attemptPhase === "reconciliation"
               ? { type: "toolCall", id: "observe", name: "read", arguments: { value: "file" } }
               : {
-                  type: "toolCall",
-                  id: "mutate",
+                  type: "toolCall" as const,
+                  id: attemptPhase === "continuation" ? "continue" : "mutate",
                   name: "exec",
-                  arguments: { code: "return await apply_patch({});" },
+                  arguments: {
+                    code:
+                      attemptPhase === "continuation"
+                        ? "return await write({});"
+                        : "return await apply_patch({});",
+                  },
                 },
           ]);
         },
@@ -178,8 +183,8 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
     ).toBe(true);
     expect(recoveryPrompt).toContain("may have partially applied");
 
-    reconciliationAttempt = true;
-    await createContextEngineAttemptRunner({
+    attemptPhase = "reconciliation";
+    const reconciliationAttempt = await createContextEngineAttemptRunner({
       contextEngine: createContextEngineBootstrapAndAssemble(),
       createSession,
       sessionKey: "agent:main:main",
@@ -202,5 +207,38 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
     expect(message.execute).not.toHaveBeenCalled();
     expect(shell.execute).not.toHaveBeenCalled();
     expect(appliedChanges).toEqual(["first hunk applied"]);
+
+    let continuationPrompt: string | undefined;
+    expect(
+      activateCodeModeReconciliation({
+        attempt: reconciliationAttempt,
+        hostOwnsToolSurface: true,
+        retryState,
+        activateInternalPrompt: (prompt) => {
+          continuationPrompt = prompt;
+        },
+      }),
+    ).toBe(true);
+    expect(retryState.forceCodeModeReconciliationTools).toBe(false);
+
+    attemptPhase = "continuation";
+    await createContextEngineAttemptRunner({
+      contextEngine: createContextEngineBootstrapAndAssemble(),
+      createSession,
+      sessionKey: "agent:main:main",
+      tempPaths,
+      attemptOverrides: {
+        config: { tools: { codeMode: true } },
+        disableMessageTool: false,
+        disableTools: false,
+        forceCodeModeReconciliationTools: retryState.forceCodeModeReconciliationTools,
+        model,
+        prompt: continuationPrompt,
+      },
+    });
+
+    expect(providerContexts).toHaveLength(5);
+    expect(write.execute).toHaveBeenCalledOnce();
+    expect(applyPatch.execute).toHaveBeenCalledOnce();
   });
 });

--- a/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
@@ -87,7 +87,7 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
     await cleanupTempPaths(tempPaths);
   });
 
-  it("settles a real partial bridge mutation before exposing only core read", async () => {
+  it("settles a partial bridge mutation, fences its replay, and allows different work", async () => {
     const appliedChanges: string[] = [];
     const read = fakeTool("read", "Inspect current file contents");
     const applyPatch = pluginToolWithExecute("apply_patch", "Apply a patch", async () => {
@@ -134,21 +134,33 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
           if (assistantTurn++ > 0) {
             return streamAssistant([{ type: "text", text: "first hunk applied" }]);
           }
-          return streamAssistant([
+          return streamAssistant(
             attemptPhase === "reconciliation"
-              ? { type: "toolCall", id: "observe", name: "read", arguments: { value: "file" } }
-              : {
-                  type: "toolCall" as const,
-                  id: attemptPhase === "continuation" ? "continue" : "mutate",
-                  name: "exec",
-                  arguments: {
-                    code:
-                      attemptPhase === "continuation"
-                        ? "return await write({});"
-                        : "return await apply_patch({});",
-                  },
-                },
-          ]);
+              ? [{ type: "toolCall", id: "observe", name: "read", arguments: { value: "file" } }]
+              : attemptPhase === "continuation"
+                ? [
+                    {
+                      type: "toolCall",
+                      id: "replay",
+                      name: "exec",
+                      arguments: { code: "return await apply_patch({});" },
+                    },
+                    {
+                      type: "toolCall",
+                      id: "continue",
+                      name: "exec",
+                      arguments: { code: "return await write({});" },
+                    },
+                  ]
+                : [
+                    {
+                      type: "toolCall",
+                      id: "mutate",
+                      name: "exec",
+                      arguments: { code: "return await apply_patch({});" },
+                    },
+                  ],
+          );
         },
       });
       session.agent = agent as typeof session.agent;
@@ -182,7 +194,9 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
       },
     });
 
-    expect(firstAttempt.codeModeReconciliationCandidate).toBe(true);
+    expect(firstAttempt.codeModeReconciliationCandidate).toEqual({
+      code: "return await apply_patch({});",
+    });
     expect(appliedChanges).toEqual(["first hunk applied"]);
     expect(applyPatch.execute).toHaveBeenCalledOnce();
 
@@ -252,6 +266,7 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
         disableMessageTool: false,
         disableTools: false,
         forceCodeModeReconciliationTools: retryState.forceCodeModeReconciliationTools,
+        codeModeReconciliationReplayFence: retryState.codeModeReconciliationReplayFence,
         model,
         prompt: continuationPrompt,
       },

--- a/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts
@@ -103,6 +103,17 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
 
     const providerContexts: Context[] = [];
     let attemptPhase: "mutation" | "reconciliation" | "continuation" = "mutation";
+    const baseSubscribe = hoisted.subscribeEmbeddedAgentSessionMock.getMockImplementation();
+    if (!baseSubscribe) {
+      throw new Error("missing embedded subscription test implementation");
+    }
+    hoisted.subscribeEmbeddedAgentSessionMock.mockImplementation((params) => {
+      const subscription = baseSubscribe(params);
+      if (attemptPhase === "reconciliation") {
+        subscription.toolMetas.push({ toolName: "read", isError: false });
+      }
+      return subscription;
+    });
     const createSession = () => {
       const session = createDefaultEmbeddedSession();
       const options = hoisted.createAgentSessionMock.mock.calls.at(-1)?.[0] as {
@@ -207,6 +218,9 @@ describe("runEmbeddedAttempt Code Mode reconciliation boundary", () => {
     expect(message.execute).not.toHaveBeenCalled();
     expect(shell.execute).not.toHaveBeenCalled();
     expect(appliedChanges).toEqual(["first hunk applied"]);
+    expect(reconciliationAttempt.toolMetas).toEqual([
+      expect.objectContaining({ toolName: "read", isError: false }),
+    ]);
 
     let continuationPrompt: string | undefined;
     expect(

--- a/src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { registerRepairableCodeModeFailure } from "../../code-mode-repair-provenance.js";
+import {
+  registerRepairableCodeModeFailure,
+  registerUncertainCodeModeMutations,
+} from "../../code-mode-repair-provenance.js";
 import type { Agent } from "../../runtime/index.js";
 import { installCodeModeOutcomeHook } from "./code-mode-outcome.js";
 
@@ -20,6 +23,8 @@ function createOutcome(
   };
   if (options.noToolStarted) {
     registerRepairableCodeModeFailure(details);
+  } else if (options.bridgeStarted) {
+    registerUncertainCodeModeMutations(details, ["callValue:mutation"]);
   }
   const toolCall = {
     type: "toolCall" as const,
@@ -81,6 +86,7 @@ describe("Code Mode outcome safety", () => {
     ).resolves.toMatchObject({ isError: true, terminate: true });
     expect(onReconciliationCandidate).toHaveBeenCalledWith({
       code: "return await apply_patch({});",
+      mutationKeys: ["callValue:mutation"],
     });
   });
 

--- a/src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts
@@ -25,12 +25,12 @@ function createOutcome(
     type: "toolCall" as const,
     id: "call-1",
     name: options.toolName ?? "exec",
-    arguments: {},
+    arguments: { code: "return await apply_patch({});" },
   };
   return {
     assistantMessage: { role: "assistant", content: [toolCall], timestamp: 1 },
     toolCall,
-    args: {},
+    args: { code: "return await apply_patch({});" },
     result: {
       content: [{ type: "text", text: JSON.stringify(details) }],
       details,
@@ -79,7 +79,9 @@ describe("Code Mode outcome safety", () => {
     await expect(
       agent.afterToolOutcome?.(createOutcome({ bridgeStarted: true })),
     ).resolves.toMatchObject({ isError: true, terminate: true });
-    expect(onReconciliationCandidate).toHaveBeenCalledOnce();
+    expect(onReconciliationCandidate).toHaveBeenCalledWith({
+      code: "return await apply_patch({});",
+    });
   });
 
   it("cannot grant reconciliation from a wait failure", async () => {

--- a/src/agents/embedded-agent-runner/run/code-mode-outcome.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-outcome.ts
@@ -3,21 +3,24 @@ import {
   CODE_MODE_WAIT_TOOL_NAME,
   isCodeModeExecTool,
 } from "../../code-mode-control-tools.js";
-import { consumeRepairableCodeModeFailure } from "../../code-mode-repair-provenance.js";
+import {
+  consumeRepairableCodeModeFailure,
+  consumeUncertainCodeModeMutations,
+  type CodeModeReconciliationReplayFence,
+} from "../../code-mode-repair-provenance.js";
 import { readCode } from "../../code-mode-runtime.js";
 import type { AfterToolCallResult, Agent } from "../../runtime/index.js";
 import { readToolResultDetails } from "../../tool-result-error.js";
 
-export type CodeModeReconciliationReplayFence = {
-  code: string;
-};
+export type { CodeModeReconciliationReplayFence } from "../../code-mode-repair-provenance.js";
 
 function readCodeModeReconciliationReplayFence(
   args: unknown,
+  mutationKeys: readonly string[],
 ): CodeModeReconciliationReplayFence | undefined {
   try {
     const input = readCode(args);
-    return { code: input.code };
+    return { code: input.code, mutationKeys };
   } catch {
     return undefined;
   }
@@ -27,7 +30,7 @@ function matchesCodeModeReconciliationReplayFence(
   args: unknown,
   fence: CodeModeReconciliationReplayFence,
 ): boolean {
-  const input = readCodeModeReconciliationReplayFence(args);
+  const input = readCodeModeReconciliationReplayFence(args, []);
   return input?.code === fence.code;
 }
 
@@ -71,6 +74,7 @@ export function installCodeModeOutcomeHook(params: {
     const details = readToolResultDetails(context.result);
     // Capability is host-minted on this exact result object; guest-supplied fields cannot grant it.
     const noToolStarted = consumeRepairableCodeModeFailure(details);
+    const uncertainMutationKeys = consumeUncertainCodeModeMutations(details);
     let prior: AfterToolCallResult | undefined;
     try {
       prior = await previousAfterToolOutcome?.(context, signal);
@@ -112,7 +116,9 @@ export function installCodeModeOutcomeHook(params: {
       isCodeModeExec &&
       context.assistantMessage.content.filter((entry) => entry.type === "toolCall").length === 1
     ) {
-      const fence = readCodeModeReconciliationReplayFence(context.args);
+      const fence = uncertainMutationKeys
+        ? readCodeModeReconciliationReplayFence(context.args, uncertainMutationKeys)
+        : undefined;
       if (fence) {
         params.onReconciliationCandidate?.(fence);
       }

--- a/src/agents/embedded-agent-runner/run/code-mode-outcome.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-outcome.ts
@@ -1,15 +1,63 @@
 import {
   CODE_MODE_EXEC_TOOL_NAME,
   CODE_MODE_WAIT_TOOL_NAME,
+  isCodeModeExecTool,
 } from "../../code-mode-control-tools.js";
 import { consumeRepairableCodeModeFailure } from "../../code-mode-repair-provenance.js";
+import { readCode } from "../../code-mode-runtime.js";
 import type { AfterToolCallResult, Agent } from "../../runtime/index.js";
 import { readToolResultDetails } from "../../tool-result-error.js";
+
+export type CodeModeReconciliationReplayFence = {
+  code: string;
+};
+
+function readCodeModeReconciliationReplayFence(
+  args: unknown,
+): CodeModeReconciliationReplayFence | undefined {
+  try {
+    const input = readCode(args);
+    return { code: input.code };
+  } catch {
+    return undefined;
+  }
+}
+
+function matchesCodeModeReconciliationReplayFence(
+  args: unknown,
+  fence: CodeModeReconciliationReplayFence,
+): boolean {
+  const input = readCodeModeReconciliationReplayFence(args);
+  return input?.code === fence.code;
+}
+
+/** Reject the exact uncertain exec before it can reach the Code Mode bridge again. */
+export function installCodeModeReconciliationReplayFence(params: {
+  agent: Agent;
+  fence: CodeModeReconciliationReplayFence;
+}): void {
+  const previousBeforeToolCall = params.agent.beforeToolCall?.bind(params.agent);
+  params.agent.beforeToolCall = async (context, signal) => {
+    const tool = params.agent.state.tools.find((entry) => entry.name === context.toolCall.name);
+    if (
+      tool &&
+      isCodeModeExecTool(tool) &&
+      matchesCodeModeReconciliationReplayFence(context.args, params.fence)
+    ) {
+      return {
+        block: true,
+        reason:
+          "Blocked an exact replay of the Code Mode mutation with an uncertain outcome. Continue only with work that readback proved did not happen.",
+      };
+    }
+    return await previousBeforeToolCall?.(context, signal);
+  };
+}
 
 /** Preserve the model's ordinary error recovery without replaying uncertain mutations. */
 export function installCodeModeOutcomeHook(params: {
   agent: Agent;
-  onReconciliationCandidate?: () => void;
+  onReconciliationCandidate?: (fence: CodeModeReconciliationReplayFence) => void;
 }): void {
   const previousAfterToolOutcome = params.agent.afterToolOutcome?.bind(params.agent);
 
@@ -64,7 +112,10 @@ export function installCodeModeOutcomeHook(params: {
       isCodeModeExec &&
       context.assistantMessage.content.filter((entry) => entry.type === "toolCall").length === 1
     ) {
-      params.onReconciliationCandidate?.();
+      const fence = readCodeModeReconciliationReplayFence(context.args);
+      if (fence) {
+        params.onReconciliationCandidate?.(fence);
+      }
     }
 
     // Agent core owns ordinary continuation; only uncertain side effects need a restricted retry.

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
@@ -13,6 +13,7 @@ function eligibleAttempt() {
   return makeEmbeddedRunnerAttempt({
     codeModeReconciliationCandidate: {
       code: "return await apply_patch({});",
+      mutationKeys: ["callValue:mutation"],
     },
     itemLifecycle: { startedCount: 2, completedCount: 2, activeCount: 0 },
   });

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
@@ -11,7 +11,9 @@ import { createEmbeddedRunTerminalRetryState } from "./terminal-retry-state.js";
 
 function eligibleAttempt() {
   return makeEmbeddedRunnerAttempt({
-    codeModeReconciliationCandidate: true,
+    codeModeReconciliationCandidate: {
+      code: "return await apply_patch({});",
+    },
     itemLifecycle: { startedCount: 2, completedCount: 2, activeCount: 0 },
   });
 }

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
@@ -57,4 +57,41 @@ describe("Code Mode reconciliation", () => {
       ].filter((name) => isCodeModeReconciliationTool({ name })),
     ).toEqual(["read"]);
   });
+
+  it("releases the read-only restriction after a clean reconciliation report", () => {
+    const retryState = createEmbeddedRunTerminalRetryState();
+    retryState.forceCodeModeReconciliationTools = true;
+    let prompt = "";
+
+    expect(
+      activateCodeModeReconciliation({
+        attempt: { ...eligibleAttempt(), assistantTexts: ["Only the first hunk applied."] },
+        hostOwnsToolSurface: true,
+        retryState,
+        activateInternalPrompt: (value) => {
+          prompt = value;
+        },
+      }),
+    ).toBe(true);
+    expect(retryState.forceCodeModeReconciliationTools).toBe(false);
+    expect(prompt).toContain("Continue the original task from the reconciled state");
+  });
+
+  it.each([
+    ["failed read", { lastToolError: { toolName: "read", message: "read failed" } }],
+    ["terminal tool", { toolMetas: [{ toolName: "read", terminate: true }] }],
+    ["empty report", { assistantTexts: [] }],
+  ])("keeps reconciliation restricted after a %s", (_label, overrides) => {
+    const retryState = createEmbeddedRunTerminalRetryState();
+    retryState.forceCodeModeReconciliationTools = true;
+    expect(
+      activateCodeModeReconciliation({
+        attempt: { ...eligibleAttempt(), assistantTexts: ["Observed state."], ...overrides },
+        hostOwnsToolSurface: true,
+        retryState,
+        activateInternalPrompt: () => undefined,
+      }),
+    ).toBe(false);
+    expect(retryState.forceCodeModeReconciliationTools).toBe(true);
+  });
 });

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
@@ -65,7 +65,11 @@ describe("Code Mode reconciliation", () => {
 
     expect(
       activateCodeModeReconciliation({
-        attempt: { ...eligibleAttempt(), assistantTexts: ["Only the first hunk applied."] },
+        attempt: {
+          ...eligibleAttempt(),
+          assistantTexts: ["Only the first hunk applied."],
+          toolMetas: [{ toolName: "read", isError: false }],
+        },
         hostOwnsToolSurface: true,
         retryState,
         activateInternalPrompt: (value) => {
@@ -78,9 +82,16 @@ describe("Code Mode reconciliation", () => {
   });
 
   it.each([
-    ["failed read", { lastToolError: { toolName: "read", message: "read failed" } }],
+    [
+      "failed read",
+      {
+        lastToolError: { toolName: "read", message: "read failed" },
+        toolMetas: [{ toolName: "read", isError: true }],
+      },
+    ],
     ["terminal tool", { toolMetas: [{ toolName: "read", terminate: true }] }],
-    ["empty report", { assistantTexts: [] }],
+    ["text-only report", { toolMetas: [] }],
+    ["empty report", { assistantTexts: [], toolMetas: [{ toolName: "read", isError: false }] }],
   ])("keeps reconciliation restricted after a %s", (_label, overrides) => {
     const retryState = createEmbeddedRunTerminalRetryState();
     retryState.forceCodeModeReconciliationTools = true;

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { makeEmbeddedRunnerAttempt } from "../../test-helpers/embedded-agent-runner-e2e-fixtures.js";
+import {
+  buildEmbeddedRunnerAssistant,
+  makeEmbeddedRunnerAttempt,
+} from "../../test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import {
   activateCodeModeReconciliation,
   isCodeModeReconciliationTool,
@@ -68,6 +71,9 @@ describe("Code Mode reconciliation", () => {
         attempt: {
           ...eligibleAttempt(),
           assistantTexts: ["Only the first hunk applied."],
+          currentAttemptCompletedAssistant: buildEmbeddedRunnerAssistant({
+            content: [{ type: "text", text: "Only the first hunk applied." }],
+          }),
           toolMetas: [{ toolName: "read", isError: false }],
         },
         hostOwnsToolSurface: true,
@@ -98,6 +104,36 @@ describe("Code Mode reconciliation", () => {
     expect(
       activateCodeModeReconciliation({
         attempt: { ...eligibleAttempt(), assistantTexts: ["Observed state."], ...overrides },
+        hostOwnsToolSurface: true,
+        retryState,
+        activateInternalPrompt: () => undefined,
+      }),
+    ).toBe(false);
+    expect(retryState.forceCodeModeReconciliationTools).toBe(true);
+  });
+
+  it("keeps reconciliation restricted when the only report preceded the read", () => {
+    const retryState = createEmbeddedRunTerminalRetryState();
+    retryState.forceCodeModeReconciliationTools = true;
+    expect(
+      activateCodeModeReconciliation({
+        attempt: {
+          ...eligibleAttempt(),
+          assistantTexts: ["I will inspect the current state."],
+          currentAttemptCompletedAssistant: buildEmbeddedRunnerAssistant({
+            content: [
+              { type: "text", text: "I will inspect the current state." },
+              {
+                type: "toolCall",
+                id: "reconciliation-read",
+                name: "read",
+                arguments: { path: "src/index.ts" },
+              },
+            ],
+            stopReason: "toolUse",
+          }),
+          toolMetas: [{ toolName: "read", isError: false }],
+        },
         hostOwnsToolSurface: true,
         retryState,
         activateInternalPrompt: () => undefined,

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
@@ -60,6 +60,16 @@ function hasCodeModeReconciliationReport(attempt: EmbeddedRunAttemptResult): boo
   );
 }
 
+function hasSuccessfulCodeModeReconciliationRead(attempt: EmbeddedRunAttemptResult): boolean {
+  return attempt.toolMetas.some(
+    (entry) =>
+      normalizeToolPolicyName(entry.toolName) === "read" &&
+      entry.isError !== true &&
+      entry.terminate !== true &&
+      entry.asyncStarted !== true,
+  );
+}
+
 export function activateCodeModeReconciliation(params: {
   attempt: EmbeddedRunAttemptResult;
   hostOwnsToolSurface: boolean;
@@ -78,6 +88,7 @@ export function activateCodeModeReconciliation(params: {
       params.attempt.toolMetas.some(
         (entry) => entry.isError === true || entry.terminate === true,
       ) ||
+      !hasSuccessfulCodeModeReconciliationRead(params.attempt) ||
       !hasCodeModeReconciliationReport(params.attempt)
     ) {
       return false;

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
@@ -44,7 +44,7 @@ function shouldRetryCodeModeReconciliation(
   params: Parameters<typeof isQuiescentCodeModeRecoveryAttempt>[0],
 ): boolean {
   return (
-    params.attempt.codeModeReconciliationCandidate === true &&
+    params.attempt.codeModeReconciliationCandidate !== undefined &&
     isQuiescentCodeModeRecoveryAttempt(params)
   );
 }
@@ -110,6 +110,8 @@ export function activateCodeModeReconciliation(params: {
     return false;
   }
   params.retryState.codeModeReconciliationAttempts += 1;
+  params.retryState.codeModeReconciliationReplayFence =
+    params.attempt.codeModeReconciliationCandidate;
   params.retryState.forceCodeModeReconciliationTools = true;
   params.activateInternalPrompt(CODE_MODE_RECONCILIATION_PROMPT);
   return true;

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
@@ -49,14 +49,14 @@ function shouldRetryCodeModeReconciliation(
   );
 }
 
-function hasCodeModeReconciliationReport(attempt: EmbeddedRunAttemptResult): boolean {
-  if (attempt.assistantTexts.some((text) => text.trim().length > 0)) {
-    return true;
-  }
-  return Boolean(
-    attempt.currentAttemptAssistant?.content.some(
-      (entry) => entry.type === "text" && entry.text.trim().length > 0,
-    ),
+function hasCompletedCodeModeReconciliationReport(attempt: EmbeddedRunAttemptResult): boolean {
+  const assistant = attempt.currentAttemptCompletedAssistant;
+  // A tool-use assistant can contain pre-read commentary. Only the later completed
+  // non-tool-use message proves the report was produced after the read result.
+  return (
+    assistant?.stopReason === "stop" &&
+    !assistant.content.some((entry) => entry.type === "toolCall") &&
+    assistant.content.some((entry) => entry.type === "text" && entry.text.trim().length > 0)
   );
 }
 
@@ -89,7 +89,7 @@ export function activateCodeModeReconciliation(params: {
         (entry) => entry.isError === true || entry.terminate === true,
       ) ||
       !hasSuccessfulCodeModeReconciliationRead(params.attempt) ||
-      !hasCodeModeReconciliationReport(params.attempt)
+      !hasCompletedCodeModeReconciliationReport(params.attempt)
     ) {
       return false;
     }

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
@@ -5,6 +5,8 @@ import type { EmbeddedRunAttemptResult } from "./types.js";
 
 const CODE_MODE_RECONCILIATION_PROMPT =
   "The previous Code Mode mutation may have partially applied. Do not repeat or finish any mutation. Use only the available read-only inspection tools to determine the authoritative current state, then report exactly what applied, what did not, what remains unknown, and what work is still required.";
+const CODE_MODE_POST_RECONCILIATION_PROMPT =
+  "The previous uncertain Code Mode mutation has now been reconciled through read-only inspection. Continue the original task from the reconciled state. Do not repeat the failed mutation. Apply only work that the reconciliation established did not happen; if any target remains unknown, inspect it again before mutating it.";
 
 const RECONCILIATION_TOOL_NAMES = new Set(["read"]);
 
@@ -12,7 +14,7 @@ export function isCodeModeReconciliationTool(tool: { name?: string }): boolean {
   return RECONCILIATION_TOOL_NAMES.has(normalizeToolPolicyName(tool.name ?? ""));
 }
 
-function shouldRetryCodeModeReconciliation(params: {
+function isQuiescentCodeModeRecoveryAttempt(params: {
   attempt: EmbeddedRunAttemptResult;
   hostOwnsToolSurface: boolean;
   aborted: boolean;
@@ -21,7 +23,6 @@ function shouldRetryCodeModeReconciliation(params: {
 }): boolean {
   const { attempt } = params;
   return (
-    attempt.codeModeReconciliationCandidate === true &&
     params.hostOwnsToolSurface &&
     !params.aborted &&
     !params.timedOut &&
@@ -39,6 +40,26 @@ function shouldRetryCodeModeReconciliation(params: {
   );
 }
 
+function shouldRetryCodeModeReconciliation(
+  params: Parameters<typeof isQuiescentCodeModeRecoveryAttempt>[0],
+): boolean {
+  return (
+    params.attempt.codeModeReconciliationCandidate === true &&
+    isQuiescentCodeModeRecoveryAttempt(params)
+  );
+}
+
+function hasCodeModeReconciliationReport(attempt: EmbeddedRunAttemptResult): boolean {
+  if (attempt.assistantTexts.some((text) => text.trim().length > 0)) {
+    return true;
+  }
+  return Boolean(
+    attempt.currentAttemptAssistant?.content.some(
+      (entry) => entry.type === "text" && entry.text.trim().length > 0,
+    ),
+  );
+}
+
 export function activateCodeModeReconciliation(params: {
   attempt: EmbeddedRunAttemptResult;
   hostOwnsToolSurface: boolean;
@@ -46,6 +67,27 @@ export function activateCodeModeReconciliation(params: {
   activateInternalPrompt: (prompt: string) => void;
 }): boolean {
   const terminal = projectAgentRunAttemptTerminal(params.attempt.terminal);
+  if (params.retryState.forceCodeModeReconciliationTools) {
+    if (
+      !isQuiescentCodeModeRecoveryAttempt({
+        attempt: params.attempt,
+        hostOwnsToolSurface: params.hostOwnsToolSurface,
+        ...terminal,
+      }) ||
+      params.attempt.lastToolError !== undefined ||
+      params.attempt.toolMetas.some(
+        (entry) => entry.isError === true || entry.terminate === true,
+      ) ||
+      !hasCodeModeReconciliationReport(params.attempt)
+    ) {
+      return false;
+    }
+    // The clean readback is the state boundary the failed mutation could not provide.
+    // The original admitted run continues to own every resumed tool call.
+    params.retryState.forceCodeModeReconciliationTools = false;
+    params.activateInternalPrompt(CODE_MODE_POST_RECONCILIATION_PROMPT);
+    return true;
+  }
   if (
     params.retryState.codeModeReconciliationAttempts >= 1 ||
     !shouldRetryCodeModeReconciliation({

--- a/src/agents/embedded-agent-runner/run/params.ts
+++ b/src/agents/embedded-agent-runner/run/params.ts
@@ -184,6 +184,8 @@ export type RunEmbeddedAgentParams = {
   forceRestartSafeTools?: boolean;
   /** Restrict one internal post-mutation recovery attempt to audited core reads. */
   forceCodeModeReconciliationTools?: boolean;
+  /** Exact uncertain Code Mode exec that resumed attempts must reject before execution. */
+  codeModeReconciliationReplayFence?: import("./code-mode-outcome.js").CodeModeReconciliationReplayFence;
   /** Preserve Code Mode controls for a replay-safe restart recovery turn. */
   forceCodeModeTools?: boolean;
   /** Internal one-shot model probe mode: no tools, no workspace/chat prompt policy. */

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -496,6 +496,7 @@ export async function dispatchEmbeddedRunAttempt(input: {
     swarmOutputSchema: params.swarmOutputSchema,
     forceRestartSafeTools: params.forceRestartSafeTools,
     forceCodeModeReconciliationTools: params.forceCodeModeReconciliationTools,
+    codeModeReconciliationReplayFence: params.codeModeReconciliationReplayFence,
     forceCodeModeTools: params.forceCodeModeTools,
     forceMessageTool: params.forceMessageTool,
     enableHeartbeatTool: params.enableHeartbeatTool,

--- a/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-retry-state.ts
@@ -1,3 +1,5 @@
+import type { CodeModeReconciliationReplayFence } from "./code-mode-outcome.js";
+
 export const MAX_BEFORE_AGENT_FINALIZE_REVISIONS = 3;
 
 export type EmbeddedRunTerminalRetryState = {
@@ -9,6 +11,7 @@ export type EmbeddedRunTerminalRetryState = {
   beforeFinalizeRevisionAttempts: number;
   codeModeReconciliationAttempts: number;
   forceCodeModeReconciliationTools: boolean;
+  codeModeReconciliationReplayFence?: CodeModeReconciliationReplayFence;
 };
 
 export function createEmbeddedRunTerminalRetryState(): EmbeddedRunTerminalRetryState {

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -354,8 +354,8 @@ export type EmbeddedRunAttemptResult = {
    * how config-enabled code mode stays visible as a no-op on harness routes.
    */
   codeModeEngaged?: boolean;
-  /** Host-authenticated request for one bounded post-mutation inspection attempt. */
-  codeModeReconciliationCandidate?: boolean;
+  /** Host-authenticated request and exact replay fence for post-mutation inspection. */
+  codeModeReconciliationCandidate?: import("./code-mode-outcome.js").CodeModeReconciliationReplayFence;
   /** Completed assistant round trips observed during this attempt. */
   assistantTurns?: number;
   /** Inner bridge call counts from this attempt's tool-search/code-mode catalog. */

--- a/src/agents/tool-search-types.ts
+++ b/src/agents/tool-search-types.ts
@@ -3,6 +3,7 @@ import type { TSchema } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginToolMcpMeta } from "../plugins/tools.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
+import type { CodeModeReconciliationReplayFence } from "./code-mode-repair-provenance.js";
 import type { CodeModeSkill } from "./code-mode-skills.js";
 import type { AgentToolResult, AgentToolUpdateCallback } from "./runtime/index.js";
 import type { ToolDefinition } from "./sessions/index.js";
@@ -102,6 +103,7 @@ export type ToolSearchToolContext = {
   abortSignal?: AbortSignal;
   executeTool?: ToolSearchCatalogToolExecutor;
   forceRestartSafeTools?: boolean;
+  codeModeReconciliationReplayFence?: CodeModeReconciliationReplayFence;
   /** Set when the run executes only these tools; swarm globals gate on `sessions_spawn`. */
   toolExecutionAllow?: readonly string[];
   codeModeSkills?: readonly CodeModeSkill[];


### PR DESCRIPTION
Related: #128028

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## Summary

### High Level TLDR

Code Mode already refuses to replay a mutation whose effects are uncertain and runs one host-enforced read-only reconciliation attempt. The missing transition was after that successful readback: the run returned the reconciliation report as its final answer instead of continuing the original task.

This change keeps the no-replay boundary, accepts only a clean and quiescent read-only reconciliation result, then restores the ordinary tool surface under the original admitted run while retaining a host-owned fence against the uncertain Code Mode program. The exact failed program is rejected before bridge I/O; distinctly established remaining work can proceed. Failed, empty, active, asynchronous, delivered, spawned, approval, timeout, abort, and plugin-owned recovery paths remain restricted.

## Why this follow-up exists

Issue #128028 documented the original read-only reconciliation gap, which was fixed by #128071.

One follow-up remained: after reconciliation successfully establishes the authoritative state, the agent reports its findings but does not resume the original task.

This PR addresses that separate continuation gap. It restores ordinary tools only after a successful read and completed reconciliation report, while a host-owned replay fence blocks the uncertain mutation from being repeated.

Tracking issue: https://github.com/openclaw/openclaw/issues/128028

## What Problem This Solves

Fixes an issue where users running Code Mode would receive a status-only response and have to send another message after a nested tool failure, even when OpenClaw had already completed its bounded read-only reconciliation.

A redacted audit of the available agent state found:

| Audited result | Count | Share |
| --- | ---: | ---: |
| Distinct hard-stop incidents | 67 | 100% |
| Reconciliation attempts | 68 | — |
| Sessions affected | 10 | — |
| Owner/tool rejection before effects | 46 | 68.7% |
| Read-only or read-only-followed-by-JS failure | 8 | 11.9% |
| Real or possible earlier mutation | 13 | 19.4% |

The prior no-start and read-only fixes cover 54/67 historical incidents (80.6%) with ordinary continuation. The remaining 13/67 (19.4%) require reconciliation followed by a fresh continuation. This change maps all 67/67 audited incidents to a continuation path: 54 immediate and 13 after bounded readback. That is projected historical-path coverage, not a claim that every future tool failure can complete successfully; reconciliation failures still fail closed.

The same audit found two status-only occurrences after the earlier no-start repair was deployed: one navigation-policy rejection and one unsupported exec argument. Private chat, message, run, session, account, filesystem, and database identifiers are intentionally omitted.

## Root Cause

`activateCodeModeReconciliation` correctly latched `forceCodeModeReconciliationTools=true` after an uncertain bridge failure. The next attempt exposed only the audited core `read` tool and prohibited replay of the uncertain mutation. Nothing owned the inverse transition after that attempt succeeded, so the latch stayed set and the embedded loop finalized the readback report as the turn's terminal answer.

Before the production change, the new end-to-end regression failed with:

```text
expected "vi.fn()" to be called 3 times, but got 2 times
```

The two observed attempts were the failed mutation and restricted reconciliation. The missing third attempt was ordinary continuation.

ClawSweeper then identified a second gap at head `7b59df07ade5`: after readback, prompt text prohibited replay but the host no longer did. The new forbidden-path regression failed before the fence with:

```text
expected "vi.fn()" to be called once, but got 2 times
```

The second `apply_patch` call was the exact uncertain Code Mode program reaching the bridge again. All identifiers and targets in this proof are synthetic.

## Why This Change Was Made

The existing reconciliation owner now handles both state transitions:

1. uncertain mutation -> one host-owned, read-only reconciliation attempt;
2. clean reconciliation report -> ordinary continuation under the same admitted run;
3. every resumed attempt retains the captured uncertain program as a host-owned replay fence.

The second transition requires the attempt to be quiescent, host-owned, not aborted or timed out, free of prompt/tool/terminal errors, free of active or async work, and free of client calls, yield, approval, child-session acceptance, message delivery, cron creation, or runtime continuation. It also requires completed, successful, nonterminal `read` metadata plus a completed non-tool-use assistant report produced afterward; accumulated text or pre-read commentary cannot release the restriction.

OpenClaw does not replay the failed Code Mode call. The continuation prompt still directs the model to use authoritative observed state, while the agent-loop pre-execution hook independently rejects the same captured program before any Code Mode bridge effect. The fence survives all later attempts in the admitted run and does not block a different program for work that readback established remains.

No configuration, protocol, plugin SDK, SQLite, migration, persistence, or channel surface changes.

## User Impact

After a potentially partial Code Mode mutation, users should see the same bounded read-only safety pass and then have the agent continue the original work automatically. A new user message is no longer required solely to escape the reconciliation status report.

## Real behavior proof

Closest feasible deterministic environment: the real embedded agent loop, Code Mode bridge, tool catalog, and tool-surface preparation with a scripted model.

The owner-boundary scenario performs a partial `apply_patch`, proves the read-only attempt exposes only `read`, then deliberately submits both the exact prior program and a distinct remaining `write`. The host rejects the replay before bridge I/O and permits the distinct work. Observed result:

```text
provider attempts: 3
partial mutation calls: 1
readback calls: 1
blocked exact replays: 1
remaining write calls: 1
replayed bridge mutations: 0
```

The full run-loop regression also observes three attempts and verifies that `forceCodeModeReconciliationTools` is true only for the middle attempt.

Safety regressions prove the restriction remains latched after a failed read, terminal tool result, text-only/no-tool report, empty report, or commentary emitted before the read without a later completed report. Existing coverage also rejects active tools, async work, delivery, child sessions, approvals, yields, plugin-owned transport, and unsettled lifecycle state.

## Verification

- Failing-before continuation regression: 2 attempts observed where 3 were required.
- Failing-before ordering regression: pre-read commentary plus a successful read incorrectly released the latch (`expected false`, received `true`).
- Failing-before replay regression: the identical post-read program reached `apply_patch` twice; after the fix it is blocked before bridge execution while a distinct `write` runs once.
- Focused Code Mode/owner/run-loop suites: 204 tests passed.
- `pnpm check:changed`: passed all core/core-test formatting, production and test typecheck, lint, boundary, schema, database-first, cycle, dead-export, and guard lanes.
- `pnpm build`: passed in 4m20.7s.
- `pnpm format:check` and `git diff --check`: passed.
- The prior exact-head GitHub run completed with 211 checks: 157 successful, 53 skipped, 1 neutral, 0 failed, 0 pending. Current-head CI and ClawSweeper re-review are tracked separately on the PR.

Earlier managed deployment proof for pre-fence head `7b59df07ade5` (`oc-update --skip-codex`):

- updater completed successfully and applied this PR at `7b59df07ade5ac7f209306662a5af8ad6fd528a6` together with complementary transport-drop PR #130721;
- the deployed reconciliation owner is byte-identical to this PR (`sha256 baae7ad3508ed8aa4c6627697bb9d5bc42ccfb371122513ef3e1274a66115fd8`);
- replacement Gateway is active/running with zero service restarts, RPC health reports `ok: true`, the selected Telegram account is configured/running/connected with no pending restart, and the live state database passes `PRAGMA quick_check`;
- the deployed aggregate-tree continuation regression passed (2 tests passed, 150 unrelated tests skipped).

Performance proof used Node v25.9.0, one warmup through normal focused-test development runs, and five measured samples of the same scripted three-response workload:

| Head | Wall samples (s) | Median wall | Median max RSS |
| --- | --- | ---: | ---: |
| baseline | 12.99, 12.96, 12.81, 12.65, 12.74 | 12.81s | 1,414,600 KiB |
| final | 13.55, 12.81, 13.46, 13.36, 12.75 | 13.36s | 1,407,788 KiB |

The measured +0.55s (+4.3%) median harness time is the intended additional model attempt in the uncertain-mutation recovery class. Ordinary turns and failures already proven side-effect-free do not enter this path.

Direct Codex source check at `2f108f9fd970ed73df7e984d3a661acc02f33abc` confirmed that native Codex Code Mode is a separate runtime: `codex-rs/core/src/tools/code_mode/execute_handler.rs:29-74` parses and starts a native cell, while `codex-rs/core/src/tools/registry.rs:500-654` owns native pre-tool and handler-executed lifecycle outcomes. This PR changes only OpenClaw's embedded reconciliation loop and does not alter or infer a Codex protocol contract.

Production/test LOC delta, excluding moves and generated output:

- production: +147 / -13 (net +134), required for the guarded continuation transition, executed-read evidence gate, and host-owned replay fence carried through the existing attempt lifecycle;
- tests/test support: +220 / -32 (net +188).

## What was not tested

- Current replay-fence head `ec2beb231d8c` has not been deployed; the managed proof above applies to the earlier continuation head. No update was run as part of this review-fix pass.
- No private production transcript was replayed through the patched binary; the audit was read-only and all public evidence is redacted.
- No private live Telegram/provider turn was injected. The behavior is provider- and channel-agnostic; deterministic embedded-run coverage exercises the owner boundary, while the managed deployment proof confirms the selected Telegram transport remained connected without exposing private channel data.
- This does not make a failed reconciliation permissive. If readback cannot complete cleanly, the run remains restricted and surfaces the incomplete state.
