### PR TITLE
fix(docs): accept YAML front matter terminators

### DIFF
--- a/scripts/docs-list.js
+++ b/scripts/docs-list.js
@@ -96,7 +96,7 @@ function extractMetadata(fullPath) {
     return { summary: null, readWhen: [], error: "missing front matter" };
   }
 
-  const endIndex = content.indexOf("\n---", 3);
+  const endIndex = content.search(/\r?\n(?:---|\.\.\.)(?:\r?\n|$)/u);
   if (endIndex === -1) {
     return { summary: null, readWhen: [], error: "unterminated front matter" };
   }

--- a/scripts/docs-list.js
+++ b/scripts/docs-list.js
@@ -17,6 +17,11 @@ const DOCS_MAP_EXCLUDED_DIRS = new Set([
   "snippets",
 ]);
 const DOCS_MAP_EXCLUDED_FILES = new Set(["AGENTS.md", "CLAUDE.md", "docs_map.md"]);
+const FRONTMATTER_TERMINATOR = /^(?:---|\.\.\.)(?:[ \t]+(?:#[^\r\n]*)?)?[ \t]*$/u;
+const FRONTMATTER_END = new RegExp(
+  `\\r?\\n${FRONTMATTER_TERMINATOR.source.slice(1, -1)}(?:\\r?\\n|$)`,
+  "u",
+);
 
 function assertDocsDir(docsDir) {
   if (!existsSync(docsDir)) {
@@ -96,7 +101,7 @@ function extractMetadata(fullPath) {
     return { summary: null, readWhen: [], error: "missing front matter" };
   }
 
-  const endIndex = content.search(/\r?\n(?:---|\.\.\.)(?:[ \t]+(?:#[^\r\n]*)?)?[ \t]*(?:\r?\n|$)/u);
+  const endIndex = content.search(FRONTMATTER_END);
   if (endIndex === -1) {
     return { summary: null, readWhen: [], error: "unterminated front matter" };
   }
@@ -175,7 +180,7 @@ function stripFrontmatter(raw) {
   }
   const lines = raw.split(/\r?\n/u);
   for (let index = 1; index < lines.length; index += 1) {
-    if (lines[index] === "---" || lines[index] === "...") {
+    if (FRONTMATTER_TERMINATOR.test(lines[index])) {
       return lines.slice(index + 1).join("\n");
     }
   }

--- a/scripts/docs-list.js
+++ b/scripts/docs-list.js
@@ -96,7 +96,7 @@ function extractMetadata(fullPath) {
     return { summary: null, readWhen: [], error: "missing front matter" };
   }
 
-  const endIndex = content.search(/\r?\n(?:---|\.\.\.)(?:\r?\n|$)/u);
+  const endIndex = content.search(/\r?\n(?:---|\.\.\.)(?:[ \t]+(?:#[^\r\n]*)?)?[ \t]*(?:\r?\n|$)/u);
   if (endIndex === -1) {
     return { summary: null, readWhen: [], error: "unterminated front matter" };
   }

--- a/test/scripts/docs-list.test.ts
+++ b/test/scripts/docs-list.test.ts
@@ -56,6 +56,24 @@ read_when: "Read this page when the hint is inline."
     expect(output).toContain("Read when: Read this page when the hint is inline.");
   });
 
+  it("accepts YAML document end markers in front matter", () => {
+    const tempRepoRoot = makeTempRepoRoot("openclaw-docs-list-yaml-end-");
+    mkdirSync(path.join(tempRepoRoot, "docs"), { recursive: true });
+    writeFileSync(
+      path.join(tempRepoRoot, "docs", "page.md"),
+      `---
+summary: "YAML document end page"
+...
+`,
+      "utf8",
+    );
+
+    const output = runDocsList(tempRepoRoot);
+
+    expect(output).toContain("page.md - YAML document end page");
+    expect(output).not.toContain("unterminated front matter");
+  });
+
   it("renders the publish docs map on demand without creating a mirror", () => {
     const tempRepoRoot = makeTempRepoRoot("openclaw-docs-headings-");
     mkdirSync(path.join(tempRepoRoot, "docs", "nested"), { recursive: true });

--- a/test/scripts/docs-list.test.ts
+++ b/test/scripts/docs-list.test.ts
@@ -145,6 +145,27 @@ summary: "Page"
     expect(existsSync(path.join(tempRepoRoot, "docs", "docs_map.md"))).toBe(false);
   });
 
+  it("strips annotated front matter terminators from the docs map", () => {
+    const tempRepoRoot = makeTempRepoRoot("openclaw-docs-headings-frontmatter-");
+    const docsDir = path.join(tempRepoRoot, "docs");
+    mkdirSync(docsDir, { recursive: true });
+    writeFileSync(
+      path.join(docsDir, "page.md"),
+      `---
+summary: "Annotated page"
+# This metadata comment must not become a heading
+... # end
+# Visible title
+`,
+      "utf8",
+    );
+
+    const output = runDocsList(tempRepoRoot, ["--headings"]);
+
+    expect(output).toContain("  - H1: Visible title");
+    expect(output).not.toContain("metadata comment must not become a heading");
+  });
+
   it("normalizes injected Windows paths for nested page routes", () => {
     const tempRepoRoot = makeTempRepoRoot("openclaw-docs-headings-windows-");
     const docsDir = path.join(tempRepoRoot, "docs");

--- a/test/scripts/docs-list.test.ts
+++ b/test/scripts/docs-list.test.ts
@@ -74,6 +74,39 @@ summary: "YAML document end page"
     expect(output).not.toContain("unterminated front matter");
   });
 
+  it("preserves suffixes and line endings on front matter terminators", () => {
+    const tempRepoRoot = makeTempRepoRoot("openclaw-docs-list-terminator-suffixes-");
+    mkdirSync(path.join(tempRepoRoot, "docs"), { recursive: true });
+    const cases = [
+      [
+        "annotated.md",
+        '---\r\nsummary: "Annotated closing delimiter"\r\n--- # end\r\n',
+        "Annotated closing delimiter",
+      ],
+      [
+        "whitespace.md",
+        '---\nsummary: "Whitespace closing delimiter"\n---   \n',
+        "Whitespace closing delimiter",
+      ],
+      [
+        "document-end-comment.md",
+        '---\r\nsummary: "Document end comment"\r\n... # end\r\n',
+        "Document end comment",
+      ],
+    ] as const;
+
+    for (const [fileName, content] of cases) {
+      writeFileSync(path.join(tempRepoRoot, "docs", fileName), content, "utf8");
+    }
+
+    const output = runDocsList(tempRepoRoot);
+
+    for (const [fileName, , summary] of cases) {
+      expect(output).toContain(`${fileName} - ${summary}`);
+    }
+    expect(output).not.toContain("unterminated front matter");
+  });
+
   it("renders the publish docs map on demand without creating a mirror", () => {
     const tempRepoRoot = makeTempRepoRoot("openclaw-docs-headings-");
     mkdirSync(path.join(tempRepoRoot, "docs", "nested"), { recursive: true });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where `docs:list` reports valid Markdown pages as `[unterminated front matter]` when their YAML front matter uses the standard document-end marker `...`.

## Why This Change Was Made

The metadata reader and heading-map generator now share terminator recognition for `---` and `...` front matter delimiters with valid horizontal-whitespace or YAML comment suffixes, including LF and CRLF input. Lookalike text such as `---not` is not treated as a closing delimiter.

## User Impact

Docs-aware tooling lists pages using `...` front matter and existing annotated or whitespace-suffixed terminators with their summary and read hints, while generated heading maps exclude front-matter comments instead of publishing them as headings.

## Evidence

- Current head: `3af5ef5494abfbc7e9743b9ff72e4793bb355b58`.
- Final claim-matched real CLI behavior proof (exact head): an isolated docs fixture with CRLF `... # end` after a front-matter comment and LF `--- # end` produced the following actual output:
  ```text
  node scripts/docs-list.js
  annotated.md - Annotated docs page
  dash.md - Dash docs page

  node scripts/docs-list.js --headings
  annotated.md -> H1: Visible title
  dash.md -> H1: Dash title
  ```
  The heading map contained no `metadata comment` heading, and neither page was reported as `unterminated front matter`.
- Regression tests: `node scripts/run-vitest.mjs test/scripts/docs-list.test.ts` (7 tests passed), including annotated `...` heading-map stripping, bare `...`, suffixes, and LF/CRLF input.
- Supporting checks: targeted `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.scripts.json scripts/docs-list.js test/scripts/docs-list.test.ts`, `oxfmt --check scripts/docs-list.js test/scripts/docs-list.test.ts`, and `git diff --check` passed.
- Proof boundary: this PR covers local docs metadata discovery and generated heading-map extraction; it does not change published docs content or Mintlify rendering.

AI-assisted contribution: implemented and reviewed with Codex.