### PR TITLE
fix(android): keep settings controls reachable with the keyboard open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
 
 - **Control UI agent files:** keep confirmed saves and file metadata intact when older reads or list refreshes finish later, preserve newer drafts, and rebuild invalidated file lists without losing the open editor.

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/SettingsScreens.kt
@@ -94,15 +94,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
@@ -2341,7 +2337,6 @@ internal fun SettingsDetailFrame(
 ) {
   ClawScaffold(
     contentPadding = PaddingValues(start = ClawTheme.spacing.lg, top = 14.dp, end = ClawTheme.spacing.lg, bottom = 6.dp),
-    contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal),
   ) {
     LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(10.dp), contentPadding = PaddingValues(bottom = 4.dp)) {
       item {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsDetailInsetsTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/SettingsDetailInsetsTest.kt
@@ -1,0 +1,120 @@
+package ai.openclaw.app.ui
+
+import ai.openclaw.app.ui.design.ClawDesignTheme
+import ai.openclaw.app.ui.design.ClawPrimaryButton
+import ai.openclaw.app.ui.design.ClawTextField
+import android.view.View
+import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], qualifiers = "w700dp-h1000dp-420dpi")
+class SettingsDetailInsetsTest {
+  @get:Rule
+  val composeRule = createComposeRule()
+
+  @Test
+  fun keyboardInsetsResizeSettingsWithoutNavigation() = verifyInsets(NavigationSuiteType.None)
+
+  @Test
+  fun navigationBarInsetsAreNotAppliedTwice() = verifyInsets(NavigationSuiteType.NavigationBar)
+
+  @Test
+  fun navigationRailLeavesBottomInsetsToSettings() = verifyInsets(NavigationSuiteType.NavigationRail)
+
+  private fun verifyInsets(navigationType: NavigationSuiteType) {
+    lateinit var view: View
+    var observedBottomInsets: Pair<Int, Int>? = null
+    composeRule.setContent {
+      val activity = requireNotNull(LocalActivity.current)
+      val localView = LocalView.current
+      val density = LocalDensity.current
+      val imeBottom = WindowInsets.ime.getBottom(density)
+      val safeBottom = WindowInsets.safeDrawing.getBottom(density)
+      LaunchedEffect(activity) { WindowCompat.setDecorFitsSystemWindows(activity.window, false) }
+      SideEffect {
+        view = localView
+        observedBottomInsets = imeBottom to safeBottom
+      }
+      ClawDesignTheme {
+        NavigationSuiteScaffold(navigationSuiteItems = {}, layoutType = navigationType) {
+          Box(Modifier.fillMaxSize().testTag("settings-host")) {
+            SettingsDetailFrame(title = "Gateway", subtitle = "", icon = Icons.Default.Settings, onBack = {}) {
+              repeat(20) { index -> ClawTextField("Field $index", {}, "") }
+              ClawTextField("Unsubmitted draft", {}, "Password", modifier = Modifier.testTag("last-field"))
+              ClawPrimaryButton(text = "Save", onClick = {})
+            }
+          }
+        }
+      }
+    }
+    composeRule.waitForIdle()
+    val density = view.resources.displayMetrics.density
+    val navigationBottom = (24 * density).toInt()
+    val keyboardBottom = (320 * density).toInt()
+
+    // Deliver platform insets, rather than shrinking a fake viewport that would hide the defect.
+    for (imeBottom in listOf(0, keyboardBottom, 0)) {
+      composeRule.runOnIdle {
+        val insets =
+          WindowInsetsCompat
+            .Builder()
+            .setInsets(WindowInsetsCompat.Type.navigationBars(), Insets.of(0, 0, 0, navigationBottom))
+            .setInsets(WindowInsetsCompat.Type.ime(), Insets.of(0, 0, 0, imeBottom))
+            .setVisible(WindowInsetsCompat.Type.ime(), imeBottom > 0)
+            .build()
+        ViewCompat.dispatchApplyWindowInsets(view, insets)
+      }
+      composeRule.waitForIdle()
+      composeRule.runOnIdle {
+        assertEquals("Compose must observe the delivered insets before geometry is judged", imeBottom to maxOf(navigationBottom, imeBottom), observedBottomInsets)
+      }
+      composeRule.onNodeWithText("Save").performScrollTo()
+      val host = composeRule.onNodeWithTag("settings-host").getUnclippedBoundsInRoot()
+      val viewport = composeRule.onNode(hasScrollAction()).getUnclippedBoundsInRoot()
+      val ancestorBottom = if (navigationType == NavigationSuiteType.NavigationBar) navigationBottom else 0
+      val remainingBottom = (maxOf(navigationBottom, imeBottom) - ancestorBottom) / density
+      assertEquals(
+        "$navigationType must consume the remaining bottom inset (IME=$imeBottom)",
+        host.bottom.value - remainingBottom - 6.dp.value,
+        viewport.bottom.value,
+        1f / density,
+      )
+      val button = composeRule.onNodeWithText("Save").getUnclippedBoundsInRoot()
+      val editor = composeRule.onNodeWithTag("last-field").getUnclippedBoundsInRoot()
+      org.junit.Assert.assertTrue("Save must be reachable", button.bottom <= viewport.bottom)
+      org.junit.Assert.assertTrue("Last field must be reachable with Save", editor.top >= viewport.top && editor.bottom <= viewport.bottom)
+    }
+  }
+}


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled through this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where users editing Android settings could not scroll the final form fields and actions above the keyboard. In Gateway settings, the Password field and Save & Connect button remained covered even at the end of the scrollable form.

## Why This Change Was Made

Settings details overrode the shared scaffold to exclude bottom insets. Removing that override restores the existing safe-drawing policy, which accounts for the keyboard and system bars while respecting insets already consumed by phone or rail navigation. The repair removes five production lines and adds no padding policy, configuration, authentication behavior, or dependency.

## User Impact

Settings form fields and actions remain reachable while entering text, and bottom system insets are handled consistently across navigation layouts. Entered drafts and connection behavior are unchanged.

## Evidence

The same three regression tests fail before the repair and pass afterward. They exercise the real settings frame and Material navigation scaffold, observe Compose's delivered platform insets, and check viewport and complete-control geometry with the keyboard closed, open, and dismissed. No-navigation and rail cases expose omitted bottom system insets; the navigation-bar case passes its closed-keyboard control and fails after receiving keyboard insets.

- Both Android flavors: 120 owner/sibling tests each, all passing; both actual app lint tasks, all four unfiltered Kotlin style-check modules, and Play debug APK assembly pass.
- Native localization verification and the normal changed-file gate pass. Independent source review and full autoreview found no actionable defects.
- Real API36 phone portrait with official Gboard, using the existing synthetic DEBUG Gateway screen: the baseline leaves the complete Password and Save & Connect controls below the keyboard after verified scroll end. The unchanged native test passes on the repair, including dismissal and retained draft.
- With the keyboard open, the same 1080×2400 window and 883px IME inset leave a 1517px boundary. The fixed 126px-high Password field at 1202–1328 and action at 1332–1458 fit fully above that boundary. Neither test nor manual observations submit credentials or connect to a service.
- A source-blind manual repeat passes all three Settings clauses: complete controls are reachable with the keyboard closed and open, reverse-scroll/return verifies the real scroll end, and two distinct harmless drafts survive keyboard dismissal. The baseline manual run reproduced the covered controls. No connection action was pressed.

Before: the form has reached its scroll end, but Password and Save & Connect remain covered by Gboard.

![Before: final connection controls remain below the keyboard](https://github.com/user-attachments/assets/5788655a-f96b-45d9-8172-0748256308dc)

After: with the same keyboard and verified scroll-end condition, both complete controls are reachable above it.

![After: complete Password and Save & Connect controls above Gboard](https://github.com/user-attachments/assets/3e601836-b7ef-4364-8a27-1ead48dbb3c3)

Native proof is phone-portrait coverage; navigation-rail coverage is deterministic Compose coverage, not native tablet proof. Synthetic connection labels do not prove an external backend connection. The disposable native harness is not part of this PR.

Production LOC: +0/−5; tests: +120/−0; changelog: +1. The tested app was built from base `9bd50c803cce88f2ab387ddaf6cc29b4ef004005` plus the reviewed change. All three committed files in `4945645b916dc159b8b3bc636d4b91de95a22166` are byte-identical to the archived source used for that app; its packaged commit stamp remains the pre-commit base. Shallow history does not establish the introducing commit.

Validation notes: an initial changed-file check inherited remote routing and was interrupted, without remote proof being claimed. The completed canonical local check used the existing pinned SwiftLint 0.65.0 after a version mismatch. No check or assertion was bypassed. Existing informational autoboxing hints are unrelated to this change.

AI-assisted with Codex; source, device evidence, and final scope independently reviewed.
