### PR TITLE
fix(sessions): identify refused transcript appends safely

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2709,7 +2709,7 @@ src/config/sessions/session-accessor.sqlite-title-probes.ts	2
 src/config/sessions/session-accessor.sqlite-transcript-message-append.ts	1
 src/config/sessions/session-accessor.sqlite-transcript-mirror.ts	1
 src/config/sessions/session-accessor.sqlite-transcript-store.ts	7
-src/config/sessions/session-accessor.sqlite-transcript-write.ts	7
+src/config/sessions/session-accessor.sqlite-transcript-write.ts	5
 src/config/sessions/session-accessor.sqlite-visible-cursor.ts	1
 src/config/sessions/session-accessor.transcript-range.ts	3
 src/config/sessions/session-accessor.transcript-turn.ts	1

--- a/src/agents/cli-runner.test-helpers.ts
+++ b/src/agents/cli-runner.test-helpers.ts
@@ -397,7 +397,7 @@ export function createCliRunnerPrepareFixture(prepareCliRun: PrepareCliRun) {
         now: Date.parse(entry.timestamp),
         message: entry.message,
       });
-      if (!appended) {
+      if (!appended.ok || !appended.value) {
         throw new Error("Could not append CLI fixture transcript message");
       }
     },

--- a/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
+++ b/src/agents/embedded-agent-runner/google-prompt-cache.test.ts
@@ -490,7 +490,7 @@ describe("google prompt cache", () => {
 
   it("propagates writer-claim rebound from cache entry persistence", async () => {
     const now = 2_500_000;
-    const takeoverError = new SessionTranscriptWriterClaimReboundError("agent:main:test");
+    const takeoverError = new SessionTranscriptWriterClaimReboundError();
     const sessionManager = {
       appendCustomEntry: vi.fn(async () => {
         throw takeoverError;

--- a/src/agents/sessions/agent-session-code-mode-source.test.ts
+++ b/src/agents/sessions/agent-session-code-mode-source.test.ts
@@ -483,7 +483,7 @@ describe("AgentSession runtime and transcript projections", () => {
     };
     const { tools, catalogRef } = createCodeModeHarness();
     registerHeadlessToolSearchCatalog({ catalogRef, tools: [] });
-    let reentrant: ReturnType<typeof appendTranscriptMessageSync<AgentMessage>>;
+    let reentrant: AgentMessage | undefined;
     initializeGlobalHookRunner(
       createMockPluginRegistry([
         {
@@ -492,10 +492,11 @@ describe("AgentSession runtime and transcript projections", () => {
             const { message } = event as { message: AgentMessage };
             if (message.role === "assistant" && message.stopReason === "toolUse" && !reentrant) {
               // Even the exact live object cannot borrow its outer append's private options.
-              reentrant = appendTranscriptMessageSync(scope, {
+              const outcome = appendTranscriptMessageSync(scope, {
                 message,
                 eventId: "reentrant_source",
               });
+              reentrant = outcome.ok ? outcome.value?.message : undefined;
             }
           },
         },
@@ -551,12 +552,10 @@ describe("AgentSession runtime and transcript projections", () => {
         { toolCallId: "mixed_other", details: { receivedOriginal: true } },
       ]);
       expect(reentrant).toMatchObject({
-        message: {
-          content: [
-            { arguments: { code: expect.not.stringContaining("API_TOKEN = computeToken()") } },
-            { arguments: { code: expect.not.stringContaining("API_TOKEN = computeToken()") } },
-          ],
-        },
+        content: [
+          { arguments: { code: expect.not.stringContaining("API_TOKEN = computeToken()") } },
+          { arguments: { code: expect.not.stringContaining("API_TOKEN = computeToken()") } },
+        ],
       });
       const stored = manager
         .getEntries()

--- a/src/agents/sessions/session-manager-persistence.ts
+++ b/src/agents/sessions/session-manager-persistence.ts
@@ -215,7 +215,13 @@ export class SessionManagerPersistence extends SessionManagerCore {
       parentId: entry.parentId,
       ...(options?.appendIntent === "active-branch" ? { appendIntent: options.appendIntent } : {}),
     } satisfies Parameters<typeof appendTranscriptMessageSync>[1]);
-    const result = appendTranscriptMessageSync(scope, appendOptions);
+    const outcome = appendTranscriptMessageSync(scope, appendOptions);
+    if (!outcome.ok) {
+      throw new Error(`Session transcript message was not persisted: ${entry.id}`, {
+        cause: outcome.error,
+      });
+    }
+    const result = outcome.value;
     if (!result) {
       throw new Error(`Session transcript message was not persisted: ${entry.id}`);
     }

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -16,6 +16,8 @@ import {
   updateSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { redactIdentifier } from "../../logging/redact-identifier.js";
 import {
   buildSessionContext,
   CURRENT_SESSION_VERSION,
@@ -756,7 +758,8 @@ describe("SessionManager.open", () => {
     const dir = tempDirs.make("openclaw-session-manager-");
     const storePath = path.join(dir, "sessions.json");
     const sessionId = "sqlite-prompt-release-rebound";
-    const sessionKey = "agent:main:dashboard:sqlite-prompt-release-rebound";
+    const sensitivePeer = "+15551234567";
+    const sessionKey = `agent:main:whatsapp:direct:${sensitivePeer}\n\x1b[31mspoof`;
     const marker = formatSqliteSessionFileMarker({ agentId: "main", sessionId, storePath });
     const scope = { agentId: "main", sessionId, sessionKey, storePath };
     await upsertSessionEntryCore(scope, { sessionFile: marker, sessionId, updatedAt: 10 });
@@ -777,19 +780,25 @@ describe("SessionManager.open", () => {
       { sessionId: "replacement-session", updatedAt: 20 },
     );
 
-    try {
-      sessionManager.appendCompaction("late summary", assistant.messageId, 42);
-      throw new Error("expected rebound compaction persistence to fail");
-    } catch (error) {
-      expect(error).toMatchObject({
-        cause: {
-          actualSessionId: "replacement-session",
-          code: "session-rebound",
-          expectedSessionId: sessionId,
-          sessionKey,
-        },
-      });
-    }
+    const expectedCause = {
+      actualSessionIdHash: redactIdentifier("replacement-session"),
+      agentIdHash: redactIdentifier(scope.agentId),
+      code: "session-rebound",
+      expectedSessionIdHash: redactIdentifier(sessionId),
+      sessionKeyHash: redactIdentifier(sessionKey),
+    };
+    const captureError = (run: () => unknown): unknown => {
+      try {
+        run();
+      } catch (error) {
+        return error;
+      }
+      throw new Error("expected rebound transcript persistence to fail");
+    };
+    const compactionError = captureError(() =>
+      sessionManager.appendCompaction("late summary", assistant.messageId, 42),
+    );
+    expect(compactionError).toMatchObject({ cause: expectedCause });
 
     const entriesBeforeRejectedAppends = sessionManager.getEntries();
     const leafBeforeRejectedAppends = sessionManager.getLeafId();
@@ -797,12 +806,26 @@ describe("SessionManager.open", () => {
     expect(() => sessionManager.branchWithSummary(null, "late summary")).toThrow(
       "entry was not persisted",
     );
-    expect(() => sessionManager.appendModelChange("openai", "gpt-5.5")).toThrow(
-      "entry was not persisted",
-    );
-    expect(() =>
+    const eventError = captureError(() => sessionManager.appendModelChange("openai", "gpt-5.5"));
+    const messageError = captureError(() =>
       sessionManager.appendMessage({ role: "user", content: "late message", timestamp: 1 }),
-    ).toThrow("message was not persisted");
+    );
+    for (const error of [eventError, messageError]) {
+      expect(error).toMatchObject({ cause: expectedCause });
+      const operatorFacingReason = formatErrorMessage(error);
+      for (const hash of Object.values(expectedCause).filter((value) =>
+        value.startsWith("sha256:"),
+      )) {
+        expect(operatorFacingReason).toContain(hash);
+      }
+      expect(operatorFacingReason).not.toContain(sessionKey);
+      expect(operatorFacingReason).not.toContain(sensitivePeer);
+      expect(operatorFacingReason).not.toContain("spoof");
+      expect(operatorFacingReason).not.toContain(sessionId);
+      expect(operatorFacingReason).not.toContain("replacement-session");
+      expect(operatorFacingReason).not.toContain("\n");
+      expect(operatorFacingReason).not.toContain("\x1b");
+    }
     expect(sessionManager.getEntries()).toEqual(entriesBeforeRejectedAppends);
     expect(sessionManager.getLeafId()).toBe(leafBeforeRejectedAppends);
     expect(sessionManager.getAppendParentId()).toBe(appendParentBeforeRejectedAppends);

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -125,13 +125,17 @@ export class SessionManager extends SessionManagerBranching {
     message: Message | CustomMessage | BashExecutionMessage,
     options?: Pick<AppendPersistenceOptions, "config">,
   ): string {
-    const result = appendTranscriptMessageSync(target, {
+    const outcome = appendTranscriptMessageSync(target, {
       cwd: process.cwd(),
       message,
       ...(options?.config ? { config: options.config } : {}),
     });
+    if (!outcome.ok) {
+      throw new Error("Session transcript message was not persisted", { cause: outcome.error });
+    }
+    const result = outcome.value;
     if (!result) {
-      throw new Error(`Session transcript message was not persisted: ${target.sessionId}`);
+      throw new Error("Session transcript message was not persisted");
     }
     return result.messageId;
   }

--- a/src/config/sessions/session-accessor.sqlite-contract.ts
+++ b/src/config/sessions/session-accessor.sqlite-contract.ts
@@ -99,17 +99,19 @@ export type TranscriptEventAppendOptions = {
   beforeCommitInTransaction?: () => void;
 };
 
-export type TranscriptEventAppendError =
+export type TranscriptAppendRefusal =
   | {
-      actualSessionId: string;
+      actualSessionIdHash: string;
+      agentIdHash: string;
       code: "session-rebound";
-      expectedSessionId: string;
-      sessionKey: string;
+      expectedSessionIdHash: string;
+      sessionKeyHash: string;
     }
   | {
+      agentIdHash: string;
       code: "session-entry-missing";
-      expectedSessionId: string;
-      sessionKey: string;
+      expectedSessionIdHash: string;
+      sessionKeyHash: string;
     };
 
 export type SessionTranscriptStats = {

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -488,7 +488,7 @@ export function ensureSessionEntrySync(
     emitCommittedSessionIdentityDiff(previous, current);
   }
   if (fencedScope.expectedWriterRunId !== undefined && !owned) {
-    throw new SessionTranscriptWriterClaimReboundError(scope.sessionKey);
+    throw new SessionTranscriptWriterClaimReboundError();
   }
   return owned;
 }

--- a/src/config/sessions/session-accessor.sqlite-transcript-write.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-write.ts
@@ -1,4 +1,5 @@
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
+import { redactIdentifier } from "../../logging/redact-identifier.js";
 import {
   openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
@@ -8,8 +9,8 @@ import { clearAllCliSessions } from "./cli-session-binding.js";
 import type {
   SessionTranscriptAccessScope,
   SessionTranscriptWriteScope,
+  TranscriptAppendRefusal,
   TranscriptEvent,
-  TranscriptEventAppendError,
   TranscriptEventAppendOptions,
   TranscriptMessageAppendOptions,
   TranscriptMessageAppendResult,
@@ -34,6 +35,7 @@ import {
   resolveSqliteTranscriptScope,
   runExclusiveSqliteSessionWrite,
   toDatabaseOptions,
+  type ResolvedTranscriptScope,
 } from "./session-accessor.sqlite-scope.js";
 import { appendTranscriptMessageInTransaction } from "./session-accessor.sqlite-transcript-message-append.js";
 import { readTranscriptMirrorFacts } from "./session-accessor.sqlite-transcript-mirror.js";
@@ -158,7 +160,7 @@ export function replaceTranscriptEventsSync(
     replaced = true;
   }, toDatabaseOptions(resolved));
   if (fencedScope.expectedWriterRunId !== undefined && !replaced) {
-    throw new SessionTranscriptWriterClaimReboundError(scope.sessionKey);
+    throw new SessionTranscriptWriterClaimReboundError();
   }
   return replaced;
 }
@@ -251,44 +253,18 @@ export function appendTranscriptEventSync(
   scope: SessionTranscriptWriteScope,
   event: TranscriptEvent,
   options: TranscriptEventAppendOptions = {},
-): Result<boolean, TranscriptEventAppendError> {
+): Result<boolean, TranscriptAppendRefusal> {
   assertNonMessageTranscriptEvent(event);
   // Every sync event append inherits and enforces the admitted writer claim.
   const fencedScope = withOwnedSessionTranscriptWriterFence(scope);
   const resolved = resolveSqliteTranscriptScope(fencedScope);
-  let result: Result<boolean, TranscriptEventAppendError> = ok(false);
+  let result: Result<boolean, TranscriptAppendRefusal> = ok(false);
   runOpenClawAgentWriteTransaction((database) => {
     options.beforeCommitInTransaction?.();
     const fresh = readSessionEntryRow(database, resolved.sessionKey);
-    if (!fresh) {
-      result = err({
-        code: "session-entry-missing",
-        expectedSessionId: resolved.sessionId,
-        sessionKey: resolved.sessionKey,
-      });
-      return;
-    }
-    if (fresh.entry.sessionId !== resolved.sessionId) {
-      result = err({
-        actualSessionId: fresh.entry.sessionId,
-        code: "session-rebound",
-        expectedSessionId: resolved.sessionId,
-        sessionKey: resolved.sessionKey,
-      });
-      return;
-    }
-    if (
-      (fencedScope.expectedLifecycleRevision !== undefined &&
-        fresh.entry.lifecycleRevision !== fencedScope.expectedLifecycleRevision) ||
-      (fencedScope.expectedWriterRunId !== undefined &&
-        (fresh.entry as InternalSessionEntry).activeWriterRunId !== fencedScope.expectedWriterRunId)
-    ) {
-      result = err({
-        actualSessionId: fresh.entry.sessionId,
-        code: "session-rebound",
-        expectedSessionId: resolved.sessionId,
-        sessionKey: resolved.sessionKey,
-      });
+    const refusal = resolveTranscriptAppendRefusal(fresh?.entry, resolved, fencedScope);
+    if (refusal) {
+      result = err(refusal);
       return;
     }
     result = ok(
@@ -300,7 +276,7 @@ export function appendTranscriptEventSync(
     );
   }, toDatabaseOptions(resolved));
   if (fencedScope.expectedWriterRunId !== undefined && !result.ok) {
-    throw new SessionTranscriptWriterClaimReboundError(scope.sessionKey);
+    throw new SessionTranscriptWriterClaimReboundError(result.error);
   }
   return result;
 }
@@ -360,29 +336,55 @@ export async function appendTranscriptMessage<TMessage>(
 export function appendTranscriptMessageSync<TMessage>(
   scope: SessionTranscriptWriteScope,
   options: TranscriptMessageAppendOptions<TMessage>,
-): TranscriptMessageAppendResult<TMessage> | undefined {
+): Result<TranscriptMessageAppendResult<TMessage> | undefined, TranscriptAppendRefusal> {
   // Every sync message append inherits and enforces the admitted writer claim.
   const fencedScope = withOwnedSessionTranscriptWriterFence(scope);
   const resolved = resolveSqliteTranscriptScope(fencedScope);
-  let result: TranscriptMessageAppendResult<TMessage> | undefined;
+  let result: Result<TranscriptMessageAppendResult<TMessage> | undefined, TranscriptAppendRefusal> =
+    ok(undefined);
   runOpenClawAgentWriteTransaction((database) => {
     const fresh = readSessionEntryRow(database, resolved.sessionKey);
-    if (
-      !fresh ||
-      fresh.entry.sessionId !== resolved.sessionId ||
-      (fencedScope.expectedLifecycleRevision !== undefined &&
-        fresh.entry.lifecycleRevision !== fencedScope.expectedLifecycleRevision) ||
-      (fencedScope.expectedWriterRunId !== undefined &&
-        (fresh.entry as InternalSessionEntry).activeWriterRunId !== fencedScope.expectedWriterRunId)
-    ) {
+    const refusal = resolveTranscriptAppendRefusal(fresh?.entry, resolved, fencedScope);
+    if (refusal) {
+      result = err(refusal);
       return;
     }
-    result = appendTranscriptMessageInTransaction(database, resolved, options);
+    result = ok(appendTranscriptMessageInTransaction(database, resolved, options));
   }, toDatabaseOptions(resolved));
-  if (fencedScope.expectedWriterRunId !== undefined && result === undefined) {
-    throw new SessionTranscriptWriterClaimReboundError(scope.sessionKey);
+  if (fencedScope.expectedWriterRunId !== undefined && !result.ok) {
+    throw new SessionTranscriptWriterClaimReboundError(result.error);
   }
   return result;
+}
+
+function resolveTranscriptAppendRefusal(
+  entry: InternalSessionEntry | undefined,
+  resolved: ResolvedTranscriptScope,
+  scope: SessionTranscriptWriteScope,
+): TranscriptAppendRefusal | undefined {
+  if (
+    entry &&
+    entry.sessionId === resolved.sessionId &&
+    (scope.expectedLifecycleRevision === undefined ||
+      entry.lifecycleRevision === scope.expectedLifecycleRevision) &&
+    (scope.expectedWriterRunId === undefined ||
+      entry.activeWriterRunId === scope.expectedWriterRunId)
+  ) {
+    return undefined;
+  }
+  const identity = {
+    agentIdHash: redactIdentifier(resolved.agentId),
+    expectedSessionIdHash: redactIdentifier(resolved.sessionId),
+    sessionKeyHash: redactIdentifier(resolved.sessionKey),
+  };
+  if (!entry) {
+    return { ...identity, code: "session-entry-missing" };
+  }
+  return {
+    ...identity,
+    actualSessionIdHash: redactIdentifier(entry.sessionId),
+    code: "session-rebound",
+  };
 }
 
 /** Runs read/append transcript work under one SQLite writer-queue critical section. */

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -6,6 +6,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { redactIdentifier } from "../../logging/redact-identifier.js";
 import {
   readSessionProgressCard,
   writeSessionProgressCard,
@@ -181,7 +183,7 @@ describe("session accessor seam", () => {
     });
   });
 
-  it("returns typed sync event append outcomes for missing, rebound, and duplicate rows", async () => {
+  it("returns typed sync append outcomes for missing, rebound, and duplicate rows", async () => {
     const scope = {
       agentId: "main",
       sessionId: "expected-session",
@@ -189,13 +191,17 @@ describe("session accessor seam", () => {
       storePath,
     };
     const event = { type: "custom", id: "typed-event", timestamp: 1 };
+    const identity = {
+      agentIdHash: redactIdentifier(scope.agentId),
+      expectedSessionIdHash: redactIdentifier(scope.sessionId),
+      sessionKeyHash: redactIdentifier(scope.sessionKey),
+    };
 
     expect(appendTranscriptEventSync(scope, event)).toEqual({
       ok: false,
       error: {
+        ...identity,
         code: "session-entry-missing",
-        expectedSessionId: scope.sessionId,
-        sessionKey: scope.sessionKey,
       },
     });
 
@@ -203,10 +209,22 @@ describe("session accessor seam", () => {
     expect(appendTranscriptEventSync(scope, event)).toEqual({
       ok: false,
       error: {
-        actualSessionId: "replacement-session",
+        ...identity,
+        actualSessionIdHash: redactIdentifier("replacement-session"),
         code: "session-rebound",
-        expectedSessionId: scope.sessionId,
-        sessionKey: scope.sessionKey,
+      },
+    });
+    expect(
+      appendTranscriptMessageSync(scope, {
+        eventId: "typed-message",
+        message: { role: "user", content: "late" },
+      }),
+    ).toEqual({
+      ok: false,
+      error: {
+        ...identity,
+        actualSessionIdHash: redactIdentifier("replacement-session"),
+        code: "session-rebound",
       },
     });
 
@@ -4391,10 +4409,11 @@ describe("session accessor seam", () => {
   });
 
   it("fences matching sync transcript mutations with the admitted writer claim", async () => {
+    const sensitivePeer = "+15551234567";
     const scope = {
       agentId: "main",
       sessionId: "session-owned-fence",
-      sessionKey: "agent:main:owned-fence",
+      sessionKey: `agent:main:owned-fence:${sensitivePeer}\n\x1b[31mspoof`,
       storePath,
     };
     replaceSessionEntrySync(scope, {
@@ -4417,9 +4436,42 @@ describe("session accessor seam", () => {
         expect(ensureSessionEntrySync(scope, { sessionId: scope.sessionId, updatedAt: 2 })).toBe(
           true,
         );
-        expect(() => replaceTranscriptEventsSync(scope, [])).toThrow(
-          SessionTranscriptWriterClaimReboundError,
+        const captureClaimError = (run: () => unknown): unknown => {
+          try {
+            run();
+          } catch (error) {
+            return error;
+          }
+          throw new Error("expected the writer claim to reject transcript persistence");
+        };
+        const replacementError = captureClaimError(() => replaceTranscriptEventsSync(scope, []));
+        const eventError = captureClaimError(() =>
+          appendTranscriptEventSync(scope, { type: "custom", id: "stale-event" }),
         );
+        const messageError = captureClaimError(() =>
+          appendTranscriptMessageSync(scope, {
+            eventId: "stale-message",
+            message: { role: "user", content: "late" },
+          }),
+        );
+        const expectedCause = {
+          actualSessionIdHash: redactIdentifier(scope.sessionId),
+          agentIdHash: redactIdentifier(scope.agentId),
+          code: "session-rebound",
+          expectedSessionIdHash: redactIdentifier(scope.sessionId),
+          sessionKeyHash: redactIdentifier(scope.sessionKey),
+        };
+        expect(eventError).toMatchObject({ cause: expectedCause });
+        expect(messageError).toMatchObject({ cause: expectedCause });
+        for (const error of [replacementError, eventError, messageError]) {
+          expect(error).toBeInstanceOf(SessionTranscriptWriterClaimReboundError);
+          const formatted = formatErrorMessage(error);
+          expect(formatted).not.toContain(scope.sessionKey);
+          expect(formatted).not.toContain(sensitivePeer);
+          expect(formatted).not.toContain("spoof");
+          expect(formatted).not.toContain("\n");
+          expect(formatted).not.toContain("\x1b");
+        }
       },
     );
 

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -2,6 +2,7 @@
 // through nested session-manager callbacks.
 import { AsyncLocalStorage } from "node:async_hooks";
 import path from "node:path";
+import type { TranscriptAppendRefusal } from "./session-accessor.sqlite-contract.js";
 
 type SessionTranscriptWriteTarget = {
   agentId?: string;
@@ -134,8 +135,8 @@ export function withOwnedSessionTranscriptWriterFence<T extends SessionTranscrip
 }
 
 export class SessionTranscriptWriterClaimReboundError extends Error {
-  constructor(sessionKey: string | undefined) {
-    super(`session writer claim changed before transcript persistence: ${sessionKey ?? "unknown"}`);
+  constructor(cause?: TranscriptAppendRefusal) {
+    super("session writer claim changed before transcript persistence", { cause });
     this.name = "SessionTranscriptWriterClaimReboundError";
   }
 }

--- a/src/gateway/server-methods/chat.inject.parentid.test.ts
+++ b/src/gateway/server-methods/chat.inject.parentid.test.ts
@@ -129,11 +129,11 @@ describe("gateway chat.inject transcript writes", () => {
       const messageId = await appendHelloAndRequireId(fixture);
       const last = await readLastTranscriptRecord(fixture);
 
-      expect(existing).toBeDefined();
+      expect(existing).toMatchObject({ ok: true });
       expect(last.type).toBe("message");
       expect(last).toHaveProperty("id", messageId);
       expect(last).toHaveProperty("message");
-      expect(last).toHaveProperty("parentId", existing?.messageId);
+      expect(last).toHaveProperty("parentId", existing.ok ? existing.value?.messageId : undefined);
     } finally {
       await cleanupFixture(fixture);
     }


### PR DESCRIPTION
Closes #130916

## What Problem This Solves

Refused synchronous transcript appends had two unsafe outcomes. Event appends exposed raw session identities through their structured cause. Message appends returned `undefined`, which lost the refusal type and made a session rebound look like a generic storage failure.

## Why This Change Was Made

The SQLite transcript-write owner now uses one commit-edge ownership check for event and message appends. Both paths return the existing `Result` shape with a `session-rebound` or `session-entry-missing` refusal. The refusal contains stable hashes for the agent, session key, expected session, and actual session instead of raw identifiers.

`SessionManager` preserves that safe refusal as the error cause. It no longer infers a refusal after the owner has dropped the reason.

This also removes two old type assertions from the shared owner path. Identity hashing runs only after a refusal, so successful append cost is unchanged.

## User Impact

Operators can identify and correlate a refused event or message append without exposing channel peers, session identifiers, newlines, or terminal control characters. This also holds when a stale owned-writer claim rejects the append. Compaction keeps classifying the outcome as `transcript_persistence_failed`.

## Evidence

### Live red and green proof

- Exact current-main revision tested before the repair: `69913572f4a84a79de1004a3a91fa87ced9cb95d`.
- Main result: event refusal exposed raw identities; message refusal had no cause. The real rebound row stayed authoritative and the transcript stayed unchanged.
- First repaired head: `e00284e318f1987b5d79e0134a80a9caa149ed88`.
- Correction red: its stale-writer path preserved `SessionTranscriptWriterClaimReboundError` but exposed the raw session key and lost the safe cause.
- First corrected head: `c9af0b263c9367f3a64d1777183e567f2c5c6f4b`.
- Consumer correction: exact-head CI found one reentrant test that still consumed the old direct message result. The test now unwraps the `ok` arm and checks the returned stored message.
- Exact final head: `99282da3d2a60de485f3111f1583135082deb296`.
- Final result: normal and stale-writer event and message refusals returned `session-rebound`, contained the expected stable hashes, exposed no raw identities or control characters, preserved the named writer-claim error and rebound row, wrote no transcript event, and the reentrant direct-append consumer passed.

### Tests and checks

```text
node scripts/run-vitest.mjs run src/config/sessions/session-accessor.test.ts src/agents/sessions/session-manager.test.ts src/agents/embedded-agent-runner/compact-reasons.test.ts src/gateway/server-methods/chat.inject.parentid.test.ts src/agents/embedded-agent-runner/google-prompt-cache.test.ts src/agents/sessions/agent-session-code-mode-source.test.ts
Result: PASS — 6 files, 213 tests

node scripts/run-oxlint.mjs <8 changed TypeScript files>
Result: PASS

Focused format, conflict-marker, max-lines, assertion-safety, coercion-helper, deprecated-API, import-cycle, database-first, native-schema, and git diff checks
Result: PASS
```

Hosted CI owns the full type-check and build. No local type-check or full build ran on this host.

### Change size

- Production: `+15` net lines.
- Tests and test support: `+74` net lines.
- Safety ratchet: two obsolete assertions removed from the baseline.

The production growth is the internal message `Result` cutover, two caller unwraps, and the typed cause accepted by the existing writer-claim error. The shared owner predicate replaces the duplicated event and message validation branches.

### Codex sibling contract

Direct source inspection at OpenAI Codex `6478a751fde8884b2fdc76486fe23175a8e795d4` confirms that native Codex rollout persistence is separate. Its recorder queues canonical items and retains failed writes for retry in [`codex-rs/rollout/src/recorder.rs`](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/rollout/src/recorder.rs#L970), while the core session calls that native owner in [`codex-rs/core/src/session/mod.rs`](https://github.com/openai/codex/blob/6478a751fde8884b2fdc76486fe23175a8e795d4/codex-rs/core/src/session/mod.rs#L3982). This PR changes only OpenClaw SQLite transcript refusal outcomes.
