### PR TITLE
test: stop replacing the native process.env object

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -87,12 +87,10 @@ function modelDiscoveryResponse(body: unknown, init?: ResponseInit): Response {
 }
 
 describe("bedrock mantle discovery", () => {
-  const originalEnv = process.env;
   let testRegionIndex = 0;
   let testRegion = "";
 
   beforeEach(() => {
-    process.env = { ...originalEnv };
     vi.restoreAllMocks();
     discoveryDebugSpy.mockClear();
     discoveryLoggerState.debugEnabled = true;
@@ -101,7 +99,6 @@ describe("bedrock mantle discovery", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    process.env = originalEnv;
   });
 
   // ---------------------------------------------------------------------------

--- a/extensions/copilot/src/auth-bridge.test.ts
+++ b/extensions/copilot/src/auth-bridge.test.ts
@@ -1,7 +1,7 @@
 // Copilot tests cover auth bridge plugin behavior.
 import { createHash } from "node:crypto";
 import { join, resolve } from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveCopilotAuth, tokenFingerprint } from "./auth-bridge.js";
 
 function cleanEnv(): NodeJS.ProcessEnv {
@@ -456,20 +456,16 @@ describe("resolveCopilotAuth - env var fallbacks", () => {
 });
 
 describe("resolveCopilotAuth - defaults wiring", () => {
-  let originalEnv: NodeJS.ProcessEnv;
-
   beforeEach(() => {
-    originalEnv = process.env;
-    process.env = { ...originalEnv };
-    delete process.env.GITHUB_TOKEN;
-    delete process.env.OPENCLAW_GITHUB_TOKEN;
-    delete process.env.COPILOT_GITHUB_TOKEN;
-    delete process.env.GH_TOKEN;
-    delete process.env.OPENCLAW_HOME;
+    vi.stubEnv("GITHUB_TOKEN", undefined);
+    vi.stubEnv("OPENCLAW_GITHUB_TOKEN", undefined);
+    vi.stubEnv("COPILOT_GITHUB_TOKEN", undefined);
+    vi.stubEnv("GH_TOKEN", undefined);
+    vi.stubEnv("OPENCLAW_HOME", undefined);
   });
 
   afterEach(() => {
-    process.env = originalEnv;
+    vi.unstubAllEnvs();
   });
 
   it("uses process.env when env is not injected", () => {

--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -18,10 +18,10 @@ vi.mock("openclaw/plugin-sdk/media-runtime", () => ({
 import { buildMinimaxSpeechProvider } from "./speech-provider.js";
 
 function clearMinimaxAuthEnv() {
-  delete process.env.MINIMAX_API_KEY;
-  delete process.env.MINIMAX_OAUTH_TOKEN;
-  delete process.env.MINIMAX_CODE_PLAN_KEY;
-  delete process.env.MINIMAX_CODING_API_KEY;
+  vi.stubEnv("MINIMAX_API_KEY", undefined);
+  vi.stubEnv("MINIMAX_OAUTH_TOKEN", undefined);
+  vi.stubEnv("MINIMAX_CODE_PLAN_KEY", undefined);
+  vi.stubEnv("MINIMAX_CODING_API_KEY", undefined);
 }
 
 function minimaxPortalStore(): AuthProfileStore {
@@ -93,7 +93,6 @@ describe("buildMinimaxSpeechProvider", () => {
   });
 
   describe("isConfigured", () => {
-    const savedEnv = { ...process.env };
     let tempStateDir: string;
     let tempAgentDir: string;
     let tokenPlanEnvConfigured = false;
@@ -119,15 +118,15 @@ describe("buildMinimaxSpeechProvider", () => {
       tempStateDir = await mkdtemp(path.join(tmpdir(), "openclaw-minimax-tts-auth-"));
       tempAgentDir = path.join(tempStateDir, "agents", "main", "agent");
       await mkdir(tempAgentDir, { recursive: true });
-      process.env.OPENCLAW_STATE_DIR = tempStateDir;
-      process.env.OPENCLAW_AGENT_DIR = tempAgentDir;
+      vi.stubEnv("OPENCLAW_STATE_DIR", tempStateDir);
+      vi.stubEnv("OPENCLAW_AGENT_DIR", tempAgentDir);
       clearMinimaxAuthEnv();
       clearRuntimeAuthProfileStoreSnapshots();
     });
 
     afterEach(async () => {
       clearRuntimeAuthProfileStoreSnapshots();
-      process.env = { ...savedEnv };
+      vi.unstubAllEnvs();
       await rm(tempStateDir, { recursive: true, force: true });
     });
 
@@ -163,16 +162,14 @@ describe("buildMinimaxSpeechProvider", () => {
   });
 
   describe("resolveConfig", () => {
-    const savedEnv = { ...process.env };
-
     afterEach(() => {
-      process.env = { ...savedEnv };
+      vi.unstubAllEnvs();
     });
 
     it("returns defaults when rawConfig is empty", () => {
-      delete process.env.MINIMAX_API_HOST;
-      delete process.env.MINIMAX_TTS_MODEL;
-      delete process.env.MINIMAX_TTS_VOICE_ID;
+      vi.stubEnv("MINIMAX_API_HOST", undefined);
+      vi.stubEnv("MINIMAX_TTS_MODEL", undefined);
+      vi.stubEnv("MINIMAX_TTS_VOICE_ID", undefined);
       const config = resolveProviderConfig({ rawConfig: {}, cfg: {} as never, timeoutMs: 30000 });
       expect(config.baseUrl).toBe("https://api.minimax.io");
       expect(config.model).toBe("speech-2.8-hd");
@@ -205,9 +202,9 @@ describe("buildMinimaxSpeechProvider", () => {
     });
 
     it("keeps trusted MINIMAX_API_HOST fallback for TTS baseUrl", () => {
-      process.env.MINIMAX_API_HOST = "https://api.minimax.io/anthropic";
-      process.env.MINIMAX_TTS_MODEL = "speech-01-turbo";
-      process.env.MINIMAX_TTS_VOICE_ID = "Chinese (Mandarin)_Gentle_Boy";
+      vi.stubEnv("MINIMAX_API_HOST", "https://api.minimax.io/anthropic");
+      vi.stubEnv("MINIMAX_TTS_MODEL", "speech-01-turbo");
+      vi.stubEnv("MINIMAX_TTS_VOICE_ID", "Chinese (Mandarin)_Gentle_Boy");
       const config = resolveProviderConfig({ rawConfig: {}, cfg: {} as never, timeoutMs: 30000 });
       expect(config.baseUrl).toBe("https://api.minimax.io");
       expect(config.model).toBe("speech-01-turbo");
@@ -215,7 +212,7 @@ describe("buildMinimaxSpeechProvider", () => {
     });
 
     it("derives the TTS host from minimax-portal OAuth config", () => {
-      delete process.env.MINIMAX_API_HOST;
+      vi.stubEnv("MINIMAX_API_HOST", undefined);
       const config = resolveProviderConfig({
         rawConfig: {},
         cfg: {
@@ -355,7 +352,6 @@ describe("buildMinimaxSpeechProvider", () => {
 
   describe("synthesize", () => {
     const savedFetch = globalThis.fetch;
-    const savedEnv = { ...process.env };
     let tempStateDir: string;
     let tempAgentDir: string;
 
@@ -363,11 +359,8 @@ describe("buildMinimaxSpeechProvider", () => {
       tempStateDir = await mkdtemp(path.join(tmpdir(), "openclaw-minimax-tts-synth-"));
       tempAgentDir = path.join(tempStateDir, "agents", "main", "agent");
       await mkdir(tempAgentDir, { recursive: true });
-      process.env = {
-        ...savedEnv,
-        OPENCLAW_AGENT_DIR: tempAgentDir,
-        OPENCLAW_STATE_DIR: tempStateDir,
-      };
+      vi.stubEnv("OPENCLAW_AGENT_DIR", tempAgentDir);
+      vi.stubEnv("OPENCLAW_STATE_DIR", tempStateDir);
       clearMinimaxAuthEnv();
       clearRuntimeAuthProfileStoreSnapshots();
       vi.stubGlobal("fetch", vi.fn());
@@ -376,7 +369,7 @@ describe("buildMinimaxSpeechProvider", () => {
 
     afterEach(async () => {
       globalThis.fetch = savedFetch;
-      process.env = { ...savedEnv };
+      vi.unstubAllEnvs();
       clearRuntimeAuthProfileStoreSnapshots();
       vi.restoreAllMocks();
       await rm(tempStateDir, { recursive: true, force: true });

--- a/extensions/synology-chat/src/core.test.ts
+++ b/extensions/synology-chat/src/core.test.ts
@@ -7,7 +7,7 @@ import {
   runSetupWizardConfigure,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { WizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { listAccountIds, resolveAccount } from "./accounts.js";
 import { SynologyChatChannelConfigSchema } from "./config-schema.js";
 import {
@@ -32,7 +32,6 @@ const synologyChatSetupPlugin = {
 };
 
 const synologyChatConfigure = createPluginSetupWizardConfigure(synologyChatSetupPlugin);
-const originalEnv = { ...process.env };
 
 function createSynologySetupPrompter(params: { allowedUserIds?: string } = {}) {
   return createTestWizardPrompter({
@@ -77,23 +76,20 @@ async function expectDmAuthorization(params: {
   }
 }
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+beforeEach(() => {
+  vi.stubEnv("SYNOLOGY_CHAT_TOKEN", undefined);
+  vi.stubEnv("SYNOLOGY_CHAT_INCOMING_URL", undefined);
+  vi.stubEnv("SYNOLOGY_NAS_HOST", undefined);
+  vi.stubEnv("SYNOLOGY_ALLOWED_USER_IDS", undefined);
+  vi.stubEnv("SYNOLOGY_RATE_LIMIT", undefined);
+  vi.stubEnv("OPENCLAW_BOT_NAME", undefined);
+});
+
 describe("synology-chat core", () => {
-  afterAll(() => {
-    vi.unstubAllEnvs();
-    process.env = { ...originalEnv };
-  });
-
-  beforeEach(() => {
-    vi.unstubAllEnvs();
-    process.env = { ...originalEnv };
-    delete process.env.SYNOLOGY_CHAT_TOKEN;
-    delete process.env.SYNOLOGY_CHAT_INCOMING_URL;
-    delete process.env.SYNOLOGY_NAS_HOST;
-    delete process.env.SYNOLOGY_ALLOWED_USER_IDS;
-    delete process.env.SYNOLOGY_RATE_LIMIT;
-    delete process.env.OPENCLAW_BOT_NAME;
-  });
-
   it("exports hosted media and dangerous compatibility fields in the JSON schema", () => {
     const properties = (SynologyChatChannelConfigSchema.schema.properties ?? {}) as Record<
       string,

--- a/extensions/voice-call/src/config.test.ts
+++ b/extensions/voice-call/src/config.test.ts
@@ -1,5 +1,5 @@
 // Voice Call tests cover config plugin behavior.
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   VoiceCallConfigSchema,
   resolveTwilioAuthToken,
@@ -45,18 +45,17 @@ function requireElevenLabsTtsConfig(config: Pick<VoiceCallConfig, "tts">) {
 }
 
 describe("validateProviderConfig", () => {
-  const originalEnv = { ...process.env };
   const clearProviderEnv = () => {
-    delete process.env.TWILIO_ACCOUNT_SID;
-    delete process.env.TWILIO_AUTH_TOKEN;
-    delete process.env.TWILIO_FROM_NUMBER;
-    delete process.env.TELNYX_API_KEY;
-    delete process.env.TELNYX_CONNECTION_ID;
-    delete process.env.TELNYX_PUBLIC_KEY;
-    delete process.env.PLIVO_AUTH_ID;
-    delete process.env.PLIVO_AUTH_TOKEN;
-    delete process.env.NGROK_AUTHTOKEN;
-    delete process.env.NGROK_DOMAIN;
+    vi.stubEnv("TWILIO_ACCOUNT_SID", undefined);
+    vi.stubEnv("TWILIO_AUTH_TOKEN", undefined);
+    vi.stubEnv("TWILIO_FROM_NUMBER", undefined);
+    vi.stubEnv("TELNYX_API_KEY", undefined);
+    vi.stubEnv("TELNYX_CONNECTION_ID", undefined);
+    vi.stubEnv("TELNYX_PUBLIC_KEY", undefined);
+    vi.stubEnv("PLIVO_AUTH_ID", undefined);
+    vi.stubEnv("PLIVO_AUTH_TOKEN", undefined);
+    vi.stubEnv("NGROK_AUTHTOKEN", undefined);
+    vi.stubEnv("NGROK_DOMAIN", undefined);
   };
 
   beforeEach(() => {
@@ -64,8 +63,7 @@ describe("validateProviderConfig", () => {
   });
 
   afterEach(() => {
-    // Restore original env
-    process.env = { ...originalEnv };
+    vi.unstubAllEnvs();
   });
 
   describe("provider credential sources", () => {

--- a/extensions/xiaomi/speech-provider.test.ts
+++ b/extensions/xiaomi/speech-provider.test.ts
@@ -42,10 +42,8 @@ describe("buildXiaomiSpeechProvider", () => {
   });
 
   describe("isConfigured", () => {
-    const savedEnv = { ...process.env };
-
     afterEach(() => {
-      process.env = { ...savedEnv };
+      vi.unstubAllEnvs();
     });
 
     it("returns true when apiKey is in provider config", () => {
@@ -55,17 +53,17 @@ describe("buildXiaomiSpeechProvider", () => {
     });
 
     it("returns false when no apiKey is available", () => {
-      delete process.env.XIAOMI_API_KEY;
+      vi.stubEnv("XIAOMI_API_KEY", undefined);
       expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30000 })).toBe(false);
     });
 
     it("returns true when XIAOMI_API_KEY env var is set", () => {
-      process.env.XIAOMI_API_KEY = "sk-env";
+      vi.stubEnv("XIAOMI_API_KEY", "sk-env");
       expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30000 })).toBe(true);
     });
 
     it.each(["", "   "])("returns false when XIAOMI_API_KEY is blank", (apiKey) => {
-      process.env.XIAOMI_API_KEY = apiKey;
+      vi.stubEnv("XIAOMI_API_KEY", apiKey);
       expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 30000 })).toBe(false);
     });
   });

--- a/src/infra/windows-install-roots.test.ts
+++ b/src/infra/windows-install-roots.test.ts
@@ -18,6 +18,7 @@ import {
 } from "./windows-install-roots.js";
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
   execFileSyncMock.mockReset();
 });
@@ -36,20 +37,11 @@ describe("getWindowsInstallRoots", () => {
       const value = valueName ? values[valueName] : undefined;
       return value ? `${valueName}    REG_SZ    ${value}\r\n` : "";
     });
-    const originalEnv = process.env;
-    let roots;
-    try {
-      process.env = {
-        ...originalEnv,
-        SystemRoot: "C:\\PoisonedWindows",
-        ProgramFiles: "C:\\Poisoned Programs",
-        "ProgramFiles(x86)": "C:\\Poisoned Programs (x86)",
-        ProgramW6432: "C:\\Poisoned Programs",
-      };
-      roots = getWindowsInstallRoots();
-    } finally {
-      process.env = originalEnv;
-    }
+    vi.stubEnv("SystemRoot", "C:\\PoisonedWindows");
+    vi.stubEnv("ProgramFiles", "C:\\Poisoned Programs");
+    vi.stubEnv("ProgramFiles(x86)", "C:\\Poisoned Programs (x86)");
+    vi.stubEnv("ProgramW6432", "C:\\Poisoned Programs");
+    const roots = getWindowsInstallRoots();
 
     expect(roots).toEqual({
       systemRoot: "D:\\Windows",

--- a/src/tui/theme/theme.test.ts
+++ b/src/tui/theme/theme.test.ts
@@ -3,7 +3,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import chalk from "chalk";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
-import { afterAll, afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 
 const originalChalkLevel = chalk.level;
 chalk.level = 3;
@@ -15,14 +15,13 @@ const stripAnsi = (str: string) =>
   str.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, "g"), "");
 
 let themeImportCase = 0;
-const originalEnv = { ...process.env };
 
 afterAll(() => {
   chalk.level = originalChalkLevel;
 });
 
 afterEach(() => {
-  process.env = { ...originalEnv };
+  vi.unstubAllEnvs();
 });
 
 type ThemeEnvOverrides = {
@@ -74,18 +73,10 @@ function readActivePalette(mod: ThemeModule) {
 
 async function importThemeWithEnv(env: ThemeEnvOverrides) {
   if (Object.hasOwn(env, "OPENCLAW_THEME")) {
-    if (env.OPENCLAW_THEME === undefined) {
-      delete process.env.OPENCLAW_THEME;
-    } else {
-      process.env.OPENCLAW_THEME = env.OPENCLAW_THEME;
-    }
+    vi.stubEnv("OPENCLAW_THEME", env.OPENCLAW_THEME);
   }
   if (Object.hasOwn(env, "COLORFGBG")) {
-    if (env.COLORFGBG === undefined) {
-      delete process.env.COLORFGBG;
-    } else {
-      process.env.COLORFGBG = env.COLORFGBG;
-    }
+    vi.stubEnv("COLORFGBG", env.COLORFGBG);
   }
   const mod = await importFreshModule<ThemeModule>(
     import.meta.url,


### PR DESCRIPTION
## What Problem This Solves

#130975 proved that a test assigning `process.env = {...}` severs Node's native env inheritance for every later `worker_threads.Worker` spawned in the same fork (`internal/worker` passes `null` to the native WorkerImpl only while `env === process.env`) — that single producer made the core-runtime-config merge gate intermittently red. This sweep completes the invariant across all remaining producers: eight more test files replaced the native env object (voice-call, copilot, amazon-bedrock-mantle, xiaomi, minimax, synology-chat, tui theme, plus `src/infra/windows-install-roots.test.ts` found by an AST scan beyond the original grep). Each was a latent instance of the same worker-inheritance hazard.

## Why This Change Was Made

Every offender now uses per-key `vi.stubEnv`/`vi.unstubAllEnvs` (with `undefined` stubs for deletions), preserving each test's exact semantics; `amazon-bedrock-mantle` needed no env hooks at all (inputs are injected) so its snapshot/replace hooks were deleted; `synology-chat`'s old hooks covered only the first describe while later describes also mutated env — all blocks now get cleanup. `test/scripts/test-env-mutation-report.test.ts` is deliberately untouched: its assignment is an inert template literal parsed by the scanner under test, not a live env mutation.

Dependency behavior verified against installed Vitest 4.1.11 sources (stubEnv records-then-deletes for undefined; unstubAllEnvs restores value/absence; the meta-env proxy forwards per key to the captured native object) and a direct Node Worker probe (pre-fix: a worker inherited a stale native value after the object swap; post-pattern: workers inherit later per-key values; verified with the sentinel both absent and preseeded).

A syntax-level lint guard was evaluated and deliberately skipped under repo lint policy: the advisory env-mutation scanner recognizes only specific spellings and any assignment rule has easy equivalent-expression bypasses (empty objects, aliases, `Reflect`). The durable option — a non-writable native env descriptor installed in test setup — is named follow-up work needing setup-path coverage across all projects (unit-fast and UI projects don't share the runner setup).

## User Impact

None at runtime (test-only, net −39 lines). Removes the whole latent class behind today's merge-gate flakiness: no test can silently break worker env inheritance for files that run after it.

## Evidence

- All 259 tests across the eight converted files pass, plus the six scanner tests; spot re-run green on rebased head 1fc95cffc89.
- Post-sweep scans: `rg 'process\.env\s*=(?!=)'` finds only the inert scanner fixture; a disposable TypeScript AST scan of 11,484 tracked test files finds zero executable direct env assignments; bracket-target and reflective-replacement searches clean.
- `check-changed` on all eight files: exit 0 (guards, formatting, dead-export scans, core + plugin test typechecks, targeted lint).
- Codex autoreview: no findings.
- LOC: tests +65/−104 (net −39); production 0.
