### PR TITLE
fix: frozen releases fail when newer plugins are absent

### DIFF
--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -29,7 +29,6 @@ const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.mjs", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/doctor.ts", 1],
-  ["@openclaw/daytona-sandbox:dangerous-exec:src/upload.ts", 1],
   ["@openclaw/discord:dangerous-exec:src/voice/audio.ts", 1],
   ["@openclaw/imessage:dangerous-exec:src/client.ts", 1],
   ["@openclaw/llama-cpp-provider:dangerous-exec:src/llama-server-install.ts", 1],
@@ -55,15 +54,16 @@ const REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>(
   REVIEWED_CODEX_SOURCE_LAYOUTS.flatMap((layout) => [...layout]),
 );
 
-// Generated chunks can contain multiple reviewed execution sites. Counts are
-// part of the contract so an added or missing site fails the release scan.
-const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+// Packed source files and generated chunks can contain reviewed execution sites.
+// Counts are part of the contract so an added or missing site fails the release scan.
+const OPTIONAL_REVIEWED_PUBLISHABLE_PACKED_PATH_CRITICAL_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/acpx:dangerous-exec:dist/mcp-proxy.mjs", 1],
   ["@openclaw/acpx:dangerous-exec:dist/service-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/api.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/dynamic-tools-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/shared-client-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/transport-stdio-<hash>.js", 1],
+  ["@openclaw/daytona-sandbox:dangerous-exec:src/upload.ts", 1],
   ["@openclaw/llama-cpp-provider:dangerous-exec:dist/index.js", 1],
   ["@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js", 1],
   ["@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js", 1],
@@ -212,7 +212,7 @@ function isReviewedPublishableCriticalFinding(key: string): boolean {
   return (
     REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.has(key) ||
     REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS.has(key) ||
-    OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS.has(key)
+    OPTIONAL_REVIEWED_PUBLISHABLE_PACKED_PATH_CRITICAL_FINDING_COUNTS.has(key)
   );
 }
 
@@ -223,10 +223,11 @@ function expectedOptionalReviewedFindingsForPackedPath(
   const normalizedPath = normalizePackedFindingPath(packedPath);
   const keyPrefix = `${packageName}:`;
   const keySuffix = `:${normalizedPath}`;
-  return [...OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS].flatMap(([key, count]) =>
-    key.startsWith(keyPrefix) && key.endsWith(keySuffix)
-      ? Array.from({ length: count }, () => key)
-      : [],
+  return [...OPTIONAL_REVIEWED_PUBLISHABLE_PACKED_PATH_CRITICAL_FINDING_COUNTS].flatMap(
+    ([key, count]) =>
+      key.startsWith(keyPrefix) && key.endsWith(keySuffix)
+        ? Array.from({ length: count }, () => key)
+        : [],
   );
 }
 
@@ -518,6 +519,20 @@ describe("publishable plugin npm package install security scan", () => {
     ).toEqual(["@openclaw/codex:dangerous-exec:dist/shared-client-<hash>.js"]);
     expect(
       expectedOptionalReviewedFindingsForPackedPath("@openclaw/codex", "dist/client-retired.js"),
+    ).toEqual([]);
+  });
+
+  it("reviews only the exact packed Daytona upload path", () => {
+    const uploadFinding = "@openclaw/daytona-sandbox:dangerous-exec:src/upload.ts";
+
+    expect(
+      expectedOptionalReviewedFindingsForPackedPath("@openclaw/daytona-sandbox", "src/upload.ts"),
+    ).toEqual([uploadFinding]);
+    expect(
+      expectedOptionalReviewedFindingsForPackedPath(
+        "@openclaw/daytona-sandbox",
+        "src/relocated/upload.ts",
+      ),
     ).toEqual([]);
   });
 

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -29,6 +29,7 @@ const REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS = new Map<string, nu
   ["@openclaw/acpx:dangerous-exec:src/runtime-internals/mcp-proxy.mjs", 1],
   ["@openclaw/codex:dangerous-exec:src/app-server/transport-stdio.ts", 1],
   ["@openclaw/codex:dangerous-exec:src/doctor.ts", 1],
+  ["@openclaw/daytona-sandbox:dangerous-exec:src/upload.ts", 1],
   ["@openclaw/discord:dangerous-exec:src/voice/audio.ts", 1],
   ["@openclaw/imessage:dangerous-exec:src/client.ts", 1],
   ["@openclaw/llama-cpp-provider:dangerous-exec:src/llama-server-install.ts", 1],
@@ -54,19 +55,21 @@ const REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS = new Map<string, number>(
   REVIEWED_CODEX_SOURCE_LAYOUTS.flatMap((layout) => [...layout]),
 );
 
-// Packed source files and generated chunks can contain reviewed execution sites.
-// Counts are part of the contract so an added or missing site fails the release scan.
-const OPTIONAL_REVIEWED_PUBLISHABLE_PACKED_PATH_CRITICAL_FINDING_COUNTS = new Map<string, number>([
+// Generated chunks can contain multiple reviewed execution sites. Counts are
+// part of the contract so an added or missing site fails the release scan.
+const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS = new Map<string, number>([
   ["@openclaw/acpx:dangerous-exec:dist/mcp-proxy.mjs", 1],
   ["@openclaw/acpx:dangerous-exec:dist/service-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/api.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/dynamic-tools-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/shared-client-<hash>.js", 1],
   ["@openclaw/codex:dangerous-exec:dist/transport-stdio-<hash>.js", 1],
-  ["@openclaw/daytona-sandbox:dangerous-exec:src/upload.ts", 1],
   ["@openclaw/llama-cpp-provider:dangerous-exec:dist/index.js", 1],
   ["@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js", 1],
   ["@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js", 1],
+]);
+const FROZEN_REVISION_ALLOWED_ABSENT_REQUIRED_REVIEWED_PACKAGES = new Set([
+  "@openclaw/daytona-sandbox",
 ]);
 
 function parseNpmPackFiles(raw: string, packageName: string): string[] {
@@ -212,7 +215,7 @@ function isReviewedPublishableCriticalFinding(key: string): boolean {
   return (
     REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.has(key) ||
     REVIEWED_CODEX_SOURCE_CRITICAL_FINDING_COUNTS.has(key) ||
-    OPTIONAL_REVIEWED_PUBLISHABLE_PACKED_PATH_CRITICAL_FINDING_COUNTS.has(key)
+    OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS.has(key)
   );
 }
 
@@ -223,11 +226,10 @@ function expectedOptionalReviewedFindingsForPackedPath(
   const normalizedPath = normalizePackedFindingPath(packedPath);
   const keyPrefix = `${packageName}:`;
   const keySuffix = `:${normalizedPath}`;
-  return [...OPTIONAL_REVIEWED_PUBLISHABLE_PACKED_PATH_CRITICAL_FINDING_COUNTS].flatMap(
-    ([key, count]) =>
-      key.startsWith(keyPrefix) && key.endsWith(keySuffix)
-        ? Array.from({ length: count }, () => key)
-        : [],
+  return [...OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS].flatMap(([key, count]) =>
+    key.startsWith(keyPrefix) && key.endsWith(keySuffix)
+      ? Array.from({ length: count }, () => key)
+      : [],
   );
 }
 
@@ -465,7 +467,11 @@ describe("publishable plugin npm package install security scan", () => {
           key.slice(0, key.indexOf(":")),
         ),
       ),
-    ].filter((packageName) => !publishablePackageNames.has(packageName));
+    ].filter(
+      (packageName) =>
+        !publishablePackageNames.has(packageName) &&
+        !FROZEN_REVISION_ALLOWED_ABSENT_REQUIRED_REVIEWED_PACKAGES.has(packageName),
+    );
 
     expect(missingPackages.toSorted()).toStrictEqual([]);
   });
@@ -522,18 +528,18 @@ describe("publishable plugin npm package install security scan", () => {
     ).toEqual([]);
   });
 
-  it("reviews only the exact packed Daytona upload path", () => {
+  it("requires the exact Daytona upload finding when the package is present", () => {
     const uploadFinding = "@openclaw/daytona-sandbox:dangerous-exec:src/upload.ts";
 
+    expect(REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.get(uploadFinding)).toBe(1);
     expect(
-      expectedOptionalReviewedFindingsForPackedPath("@openclaw/daytona-sandbox", "src/upload.ts"),
+      requiredReviewedFindingsForPackage("@openclaw/daytona-sandbox", [uploadFinding]),
     ).toEqual([uploadFinding]);
     expect(
-      expectedOptionalReviewedFindingsForPackedPath(
-        "@openclaw/daytona-sandbox",
-        "src/relocated/upload.ts",
+      isReviewedPublishableCriticalFinding(
+        "@openclaw/daytona-sandbox:dangerous-exec:src/relocated/upload.ts",
       ),
-    ).toEqual([]);
+    ).toBe(false);
   });
 
   it("attributes generated Codex findings to their enclosing source region", () => {

--- a/src/plugins/npm-install-security-scan.release.test.ts
+++ b/src/plugins/npm-install-security-scan.release.test.ts
@@ -68,9 +68,12 @@ const OPTIONAL_REVIEWED_PUBLISHABLE_DIST_CRITICAL_FINDING_COUNTS = new Map<strin
   ["@openclaw/slack:dynamic-code-execution:dist/outbound-payload.test-harness-<hash>.js", 1],
   ["@openclaw/voice-call:dangerous-exec:dist/runtime-entry-<hash>.js", 1],
 ]);
-const FROZEN_REVISION_ALLOWED_ABSENT_REQUIRED_REVIEWED_PACKAGES = new Set([
-  "@openclaw/daytona-sandbox",
-]);
+// This candidate predates Daytona. Pinning the exact SHA makes later candidates
+// fail closed when the required package is absent.
+const FROZEN_REVISION_ALLOWED_ABSENT_REQUIRED_REVIEWED_PACKAGES = new Map<
+  string,
+  ReadonlySet<string>
+>([["94e637a94d610f2c0f61d37b9e349e5a0b9dfd29", new Set(["@openclaw/daytona-sandbox"])]]);
 
 function parseNpmPackFiles(raw: string, packageName: string): string[] {
   const parsed = JSON.parse(raw) as unknown;
@@ -304,6 +307,31 @@ function listFindExtensionPackageFiles(): string[] | null {
     .toSorted();
 }
 
+function resolveCandidateRevision(): string {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  const revision = result.stdout.trim();
+  if (result.status !== 0 || !/^[0-9a-f]{40}$/u.test(revision)) {
+    throw new Error("Could not resolve the exact candidate Git revision.");
+  }
+  return revision;
+}
+
+function isAllowedAbsentRequiredReviewedPackage(
+  candidateRevision: string,
+  packageName: string,
+): boolean {
+  return (
+    FROZEN_REVISION_ALLOWED_ABSENT_REQUIRED_REVIEWED_PACKAGES.get(candidateRevision)?.has(
+      packageName,
+    ) === true
+  );
+}
+
 function collectPublishablePluginPackages(): PublishablePluginPackage[] {
   return listPublishablePluginPackageDirs()
     .flatMap((packageDir) => {
@@ -461,6 +489,7 @@ describe("publishable plugin npm package install security scan", () => {
     const publishablePackageNames = new Set(
       publishablePluginPackages.map((plugin) => plugin.packageName),
     );
+    const candidateRevision = resolveCandidateRevision();
     const missingPackages = [
       ...new Set(
         [...REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.keys()].map((key) =>
@@ -470,7 +499,7 @@ describe("publishable plugin npm package install security scan", () => {
     ].filter(
       (packageName) =>
         !publishablePackageNames.has(packageName) &&
-        !FROZEN_REVISION_ALLOWED_ABSENT_REQUIRED_REVIEWED_PACKAGES.has(packageName),
+        !isAllowedAbsentRequiredReviewedPackage(candidateRevision, packageName),
     );
 
     expect(missingPackages.toSorted()).toStrictEqual([]);
@@ -529,6 +558,7 @@ describe("publishable plugin npm package install security scan", () => {
   });
 
   it("requires the exact Daytona upload finding when the package is present", () => {
+    const frozenRevision = "94e637a94d610f2c0f61d37b9e349e5a0b9dfd29";
     const uploadFinding = "@openclaw/daytona-sandbox:dangerous-exec:src/upload.ts";
 
     expect(REQUIRED_REVIEWED_PUBLISHABLE_CRITICAL_FINDING_COUNTS.get(uploadFinding)).toBe(1);
@@ -540,6 +570,16 @@ describe("publishable plugin npm package install security scan", () => {
         "@openclaw/daytona-sandbox:dangerous-exec:src/relocated/upload.ts",
       ),
     ).toBe(false);
+    expect(
+      isAllowedAbsentRequiredReviewedPackage(frozenRevision, "@openclaw/daytona-sandbox"),
+    ).toBe(true);
+    expect(
+      isAllowedAbsentRequiredReviewedPackage(
+        "04e637a94d610f2c0f61d37b9e349e5a0b9dfd29",
+        "@openclaw/daytona-sandbox",
+      ),
+    ).toBe(false);
+    expect(isAllowedAbsentRequiredReviewedPackage(frozenRevision, "@openclaw/discord")).toBe(false);
   });
 
   it("attributes generated Codex findings to their enclosing source region", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Full Release Validation rejects a frozen release candidate when a publishable plugin exists only in newer trusted tooling.

For `2026.9.1-beta.1`, the frozen Code SHA predates `@openclaw/daytona-sandbox`, but current trusted tooling treated Daytona's reviewed `src/upload.ts` finding as required and failed Plugin Prerelease run 33086881897.

## Why This Change Was Made

Daytona's exact `src/upload.ts` finding remains required and count-bounded whenever the package exists. A narrow provenance map permits the package to be absent only at exact candidate SHA `94e637a94d610f2c0f61d37b9e349e5a0b9dfd29`, which predates Daytona. Any other revision fails closed if the package is missing. Unknown or relocated Daytona findings remain unreviewed.

This changes trusted release validation only; it does not modify Daytona, the plugin registry, or the frozen release candidate.

## User Impact

Maintainers can validate frozen release candidates against newer trusted tooling without requiring plugins that did not exist at the candidate Code SHA.

## Evidence

- Pre-fix trusted test against Code SHA `94e637a94d610f2c0f61d37b9e349e5a0b9dfd29`: 102 passed, 1 failed; the only missing required package was `@openclaw/daytona-sandbox`.
- Corrected trusted test against current main with Daytona present: 105/105 passed; exact `src/upload.ts` remains required with count `1`.
- Corrected trusted test against Code SHA `94e637a94d610f2c0f61d37b9e349e5a0b9dfd29` with Daytona absent: 104/104 passed.
- The absence exception accepts only the exact Code SHA plus Daytona package; another SHA or package is rejected.
- A relocated Daytona path resolves no reviewed finding.
- `pnpm format -- src/plugins/npm-install-security-scan.release.test.ts`
- `OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1 node scripts/check-changed.mjs -- src/plugins/npm-install-security-scan.release.test.ts`
- Autoreview: clean, no actionable findings.

Release candidate Code SHA remains unchanged.
