### PR TITLE
fix(android): serialize legacy gateway discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Android gateway discovery:** resolve nearby gateways one at a time on Android 12 and 13 so simultaneously advertised gateways are not silently omitted.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
 
 - **Control UI agent files:** keep confirmed saves and file metadata intact when older reads or list refreshes finish later, preserve newer drafts, and rebuild invalidated file lists without losing the open editor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,8 +69,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Android gateway discovery:** resolve nearby gateways one at a time on Android 12 and 13 so simultaneously advertised gateways are not silently omitted.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
+- **Android gateway discovery:** resolve nearby gateways one at a time on Android 12 and 13 so simultaneously advertised gateways are not silently omitted.
 
 - **Control UI agent files:** keep confirmed saves and file metadata intact when older reads or list refreshes finish later, preserve newer drafts, and rebuild invalidated file lists without losing the open editor.
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayDiscovery.kt
@@ -113,6 +113,9 @@ class GatewayDiscovery(
   private val availableNetworks = ConcurrentHashMap.newKeySet<Network>()
   private val serviceInfoCallbacks = ConcurrentHashMap<String, Any>()
 
+  // Legacy NSD callbacks share one handler and one resolve slot, which only a terminal callback releases.
+  private val legacyResolutions = ArrayDeque<LegacyResolution>()
+
   @Volatile private var lastWideAreaRcode: Int? = null
 
   @Volatile private var lastWideAreaCount: Int = 0
@@ -201,20 +204,24 @@ class GatewayDiscovery(
   }
 
   private fun resolve(serviceInfo: NsdServiceInfo) {
+    val id = stableId(BonjourEscapes.decode(serviceInfo.serviceName), "local.")
+    if (serviceInfoCallbacks.containsKey(id)) return
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
       // Android 14+ streams service updates; older releases require one-shot resolve calls.
-      resolveWithServiceInfoCallback(serviceInfo)
+      resolveWithServiceInfoCallback(id, serviceInfo)
     } else {
-      resolveLegacy(serviceInfo)
+      val resolution = LegacyResolution(id, serviceInfo)
+      serviceInfoCallbacks[id] = resolution
+      legacyResolutions.addLast(resolution)
+      if (legacyResolutions.size == 1) startNextLegacyResolution()
     }
   }
 
   @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-  private fun resolveWithServiceInfoCallback(serviceInfo: NsdServiceInfo) {
-    val serviceName = BonjourEscapes.decode(serviceInfo.serviceName)
-    val id = stableId(serviceName, "local.")
-    if (serviceInfoCallbacks.containsKey(id)) return
-
+  private fun resolveWithServiceInfoCallback(
+    id: String,
+    serviceInfo: NsdServiceInfo,
+  ) {
     val callback =
       object : NsdManager.ServiceInfoCallback {
         override fun onServiceInfoCallbackRegistrationFailed(errorCode: Int) {
@@ -245,7 +252,11 @@ class GatewayDiscovery(
 
   private fun unregisterServiceInfoCallback(id: String) {
     val callback = serviceInfoCallbacks.remove(id) ?: return
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) return
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+      // A lost active service still occupies the OS slot; queued services can be discarded immediately.
+      if (callback !== legacyResolutions.firstOrNull()) legacyResolutions.remove(callback as LegacyResolution)
+      return
+    }
     try {
       nsd.unregisterServiceInfoCallback(callback as NsdManager.ServiceInfoCallback)
     } catch (_: Throwable) {
@@ -253,25 +264,40 @@ class GatewayDiscovery(
     }
   }
 
-  private fun resolveLegacy(serviceInfo: NsdServiceInfo) {
-    val listener =
-      object : NsdManager.ResolveListener {
-        override fun onResolveFailed(
-          serviceInfo: NsdServiceInfo,
-          errorCode: Int,
-        ) {}
-
-        override fun onServiceResolved(resolved: NsdServiceInfo) {
-          upsertResolvedService(resolved)
-        }
+  @Suppress("DEPRECATION")
+  private fun startNextLegacyResolution() {
+    while (legacyResolutions.isNotEmpty()) {
+      val next = legacyResolutions.first()
+      try {
+        nsd.resolveService(next.serviceInfo, next)
+        return
+      } catch (_: Exception) {
+        serviceInfoCallbacks.remove(next.id, next)
+        legacyResolutions.removeFirst()
       }
+    }
+  }
 
-    try {
-      NsdManager::class.java
-        .getMethod("resolveService", NsdServiceInfo::class.java, NsdManager.ResolveListener::class.java)
-        .invoke(nsd, serviceInfo, listener)
-    } catch (_: Throwable) {
-      // ignore (best-effort)
+  private inner class LegacyResolution(
+    val id: String,
+    val serviceInfo: NsdServiceInfo,
+  ) : NsdManager.ResolveListener {
+    override fun onResolveFailed(
+      serviceInfo: NsdServiceInfo,
+      errorCode: Int,
+    ) {
+      finish(null)
+    }
+
+    override fun onServiceResolved(resolved: NsdServiceInfo) {
+      finish(resolved)
+    }
+
+    private fun finish(resolved: NsdServiceInfo?) {
+      // Loss/rediscovery may replace this identity while the old OS request is still completing.
+      if (serviceInfoCallbacks.remove(id, this) && resolved != null) upsertResolvedService(resolved)
+      legacyResolutions.removeFirst()
+      startNextLegacyResolution()
     }
   }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayDiscoveryTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewayDiscoveryTest.kt
@@ -1,5 +1,6 @@
 package ai.openclaw.app.gateway
 
+import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -11,7 +12,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import org.robolectric.shadows.ShadowNsdManager
 import org.xbill.DNS.Rcode
 import java.net.Inet6Address
 import java.net.InetAddress
@@ -58,16 +63,156 @@ class GatewayDiscoveryTest {
   @Test
   @Config(sdk = [33])
   fun discoveredGatewayPreservesLegacyAndroidHost() {
-    val service =
-      NsdServiceInfo().apply {
-        serviceName = "Gateway"
-        serviceType = "_openclaw-gw._tcp."
-        port = 18789
-        @Suppress("DEPRECATION")
-        host = InetAddress.getByName("127.0.0.1")
-      }
+    val harness = legacyDiscovery()
+    val service = legacyService("Gateway")
+    harness.listener.onServiceFound(service)
+    harness.resolvers(service).single().onServiceResolved(service)
 
-    assertEquals("127.0.0.1", discoverGateway(service).discoveredHost())
+    assertEquals("127.0.0.1", harness.discovery.discoveredHost())
+  }
+
+  @Test
+  @Config(sdk = [33])
+  fun legacyDiscoveryResolvesServicesThroughOnePlatformSlot() {
+    val harness = legacyDiscovery()
+    val services = listOf(legacyService("First"), legacyService("Second"), legacyService("Third"))
+    services.forEach(harness.listener::onServiceFound)
+
+    assertEquals(listOf(1, 0, 0), services.map { harness.resolvers(it).size })
+    harness.resolvers(services[0]).single().onServiceResolved(services[0])
+    assertEquals(listOf(1, 1, 0), services.map { harness.resolvers(it).size })
+    harness.resolvers(services[1]).single().onServiceResolved(services[1])
+    harness.resolvers(services[2]).single().onServiceResolved(services[2])
+
+    assertEquals(
+      services.map { it.serviceName },
+      harness.discovery.gateways.value
+        .map { it.name },
+    )
+  }
+
+  @Test
+  @Config(sdk = [33])
+  fun legacyDiscoveryAdvancesAfterResolutionFailure() {
+    val harness = legacyDiscovery()
+    val first = legacyService("First")
+    val second = legacyService("Second")
+    harness.listener.onServiceFound(first)
+    harness.listener.onServiceFound(second)
+    assertTrue(harness.resolvers(second).isEmpty())
+
+    harness.resolvers(first).single().onResolveFailed(first, NsdManager.FAILURE_INTERNAL_ERROR)
+    harness.resolvers(second).single().onServiceResolved(second)
+
+    assertEquals(
+      listOf("Second"),
+      harness.discovery.gateways.value
+        .map { it.name },
+    )
+  }
+
+  @Test
+  @Config(sdk = [33])
+  fun legacyDiscoverySkipsLostQueuedServices() {
+    val harness = legacyDiscovery()
+    val first = legacyService("First")
+    val lost = legacyService("Lost")
+    val last = legacyService("Last")
+    listOf(first, lost, last).forEach(harness.listener::onServiceFound)
+    harness.listener.onServiceLost(lost)
+    assertTrue(harness.resolvers(lost).isEmpty())
+    assertTrue(harness.resolvers(last).isEmpty())
+
+    harness.resolvers(first).single().onServiceResolved(first)
+    harness.resolvers(last).single().onServiceResolved(last)
+
+    assertTrue(harness.resolvers(lost).isEmpty())
+    assertEquals(
+      listOf("First", "Last"),
+      harness.discovery.gateways.value
+        .map { it.name },
+    )
+  }
+
+  @Test
+  @Config(sdk = [33])
+  fun legacyDiscoveryKeepsLostActiveSlotUntilItsTerminalCallback() {
+    val harness = legacyDiscovery()
+    val old = legacyService("Gateway", port = 18789)
+    val replacement = legacyService("Gateway", port = 18790)
+    harness.listener.onServiceFound(old)
+    val oldResolver = harness.resolvers(old).single()
+    harness.listener.onServiceLost(old)
+    harness.listener.onServiceFound(replacement)
+
+    assertEquals(1, harness.resolvers(replacement).size)
+    oldResolver.onServiceResolved(old)
+    assertTrue(
+      harness.discovery.gateways.value
+        .isEmpty(),
+    )
+    // The shadow retains completed listeners under the same name/type: these are cumulative registrations.
+    assertEquals(2, harness.resolvers(replacement).size)
+    harness.resolvers(replacement)[1].onServiceResolved(replacement)
+
+    assertEquals(
+      18790,
+      harness.discovery.gateways.value
+        .single()
+        .port,
+    )
+  }
+
+  @Test
+  @Config(sdk = [33])
+  fun legacyDiscoveryDoesNotReleasePlatformSlotWhenCoroutineScopeIsCancelled() {
+    val harness = legacyDiscovery()
+    val first = legacyService("First")
+    val second = legacyService("Second")
+    harness.listener.onServiceFound(first)
+    harness.listener.onServiceFound(second)
+
+    scope.cancel()
+    assertTrue(harness.resolvers(second).isEmpty())
+    harness.resolvers(first).single().onResolveFailed(first, NsdManager.FAILURE_INTERNAL_ERROR)
+    harness.resolvers(second).single().onServiceResolved(second)
+
+    assertEquals(
+      listOf("Second"),
+      harness.discovery.gateways.value
+        .map { it.name },
+    )
+  }
+
+  @Test
+  @Config(sdk = [33], shadows = [RejectingNsdResolveShadow::class])
+  fun legacyDiscoveryDrainsSynchronousRejectionsBeforeResumingCallbacks() {
+    val harness = legacyDiscovery()
+    val first = legacyService("First")
+    val next = legacyService("Next")
+    val tail = legacyService("Tail")
+    harness.listener.onServiceFound(first)
+    repeat(4096) { harness.listener.onServiceFound(legacyService("Rejected $it")) }
+    harness.listener.onServiceFound(next)
+    harness.listener.onServiceFound(tail)
+    val firstResolver = harness.resolvers(first).single()
+    assertTrue(harness.resolvers(next).isEmpty())
+    assertTrue(harness.resolvers(tail).isEmpty())
+
+    val nsd = harness.nsd as RejectingNsdResolveShadow
+    nsd.failuresRemaining = 4096
+    firstResolver.onServiceResolved(first)
+
+    assertEquals(0, nsd.failuresRemaining)
+    assertEquals(1, harness.resolvers(next).size)
+    assertTrue(harness.resolvers(tail).isEmpty())
+    harness.resolvers(next).single().onServiceResolved(next)
+    harness.resolvers(tail).single().onServiceResolved(tail)
+    assertEquals(
+      listOf("First", "Next", "Tail"),
+      harness.discovery.gateways.value
+        .map { it.name },
+    )
   }
 
   @Test
@@ -134,6 +279,25 @@ class GatewayDiscoveryTest {
       },
     )
 
+  private fun legacyDiscovery(): LegacyDiscoveryHarness {
+    val context = RuntimeEnvironment.getApplication()
+    val nsd = shadowOf(context.getSystemService(NsdManager::class.java))
+    val discovery = GatewayDiscovery(context, scope)
+    return LegacyDiscoveryHarness(discovery, nsd.getDiscoveryListeners("_openclaw-gw._tcp.")!!.single(), nsd)
+  }
+
+  private fun legacyService(
+    name: String,
+    port: Int = 18789,
+  ): NsdServiceInfo =
+    NsdServiceInfo().apply {
+      serviceName = name
+      serviceType = "_openclaw-gw._tcp."
+      this.port = port
+      @Suppress("DEPRECATION")
+      host = InetAddress.getByName("127.0.0.1")
+    }
+
   private fun discoverGateway(service: NsdServiceInfo): GatewayDiscovery {
     val discovery = GatewayDiscovery(RuntimeEnvironment.getApplication(), scope)
     GatewayDiscovery::class.java.getDeclaredMethod("upsertResolvedService", NsdServiceInfo::class.java).apply {
@@ -154,6 +318,32 @@ class GatewayDiscoveryTest {
       byteArrayOf(0xfe.toByte(), 0x80.toByte(), 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1),
       3,
     )
+}
+
+/** Injects only synchronous SDK rejection; normal NSD bookkeeping stays in the pinned platform shadow. */
+@Implements(NsdManager::class)
+class RejectingNsdResolveShadow : ShadowNsdManager() {
+  var failuresRemaining = 0
+
+  @Implementation
+  override fun resolveService(
+    serviceInfo: NsdServiceInfo,
+    listener: NsdManager.ResolveListener,
+  ) {
+    if (failuresRemaining > 0) {
+      failuresRemaining--
+      throw IllegalStateException("NSD service rejected resolution")
+    }
+    super.resolveService(serviceInfo, listener)
+  }
+}
+
+private data class LegacyDiscoveryHarness(
+  val discovery: GatewayDiscovery,
+  val listener: NsdManager.DiscoveryListener,
+  val nsd: ShadowNsdManager,
+) {
+  fun resolvers(service: NsdServiceInfo): List<NsdManager.ResolveListener> = nsd.getResolveListeners(service).orEmpty()
 }
 
 private data class StatusCase(


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users browsing nearby gateways in Android Gateway settings would see only some available gateways when several were advertised together on Android 12, 12L, or 13 (API 31–33).

On a real API 33 emulator, three task gateways were advertised before opening the ordinary app. Gateway settings showed only one. The production list still contained just that one after the full UI scan, although all three subsequently resolved successfully through the public Android SDK. The matched fixed replay exposes all three.

## Why This Change Was Made

Legacy Android NSD accepts only one active resolution per client; submitting another before the first finishes is rejected. Discovery now owns that slot through the real success or failure callback and queues other discovered services. Losing an active service invalidates its result without releasing the still-live platform slot; lost queued services are removed, and an old completion cannot overwrite a rediscovered service.

The queue reuses the existing service-identity registry and has one iterative drain for synchronous SDK rejection and asynchronous completion. This replaces reflective fire-and-forget resolution rather than adding retries, delays, configuration, or trust policy. Android 14+ streaming discovery, address selection, wide-area DNS, and process-owned discovery lifetime are unchanged.

Production LOC: **+51/-25 (net +26)**. Tests: **+199/-9 (net +190)**. Changelog: **+1**. Growth is the required ownership of the legacy platform slot and pending service generations; shared identity handling absorbs the old duplicate setup, and seven added lines are house-format wrapping.

## User Impact

Nearby gateway lists on supported older Android releases can expose all simultaneously advertised gateways instead of silently losing extra resolutions. Departed services are still removed. Pairing, credentials, permissions, connection policy, and settings do not change.

## Evidence

### Matched real Android flow

| Observation | Unchanged baseline | Fixed app |
| --- | --- | --- |
| Three real services advertised before app launch | Confirmed | Confirmed |
| Production list and real Gateway settings | Only 1 of 3 after complete UI scan | All 3 before independent resolution controls |
| Subsequent sequential Android SDK resolutions | All 3 succeeded with matching advertised ports | All 3 succeeded with matching advertised ports |
| Withdrawal of one published service | Observer loss and production removal confirmed | Observer loss and production removal confirmed; 2 remain |
| Fixture cleanup | No cleanup failures | No cleanup failures |
| JUnit | Intended missing-publication failure, 63.248 seconds | 1 test passed, 34.795 seconds |

The independent discovery observer establishes advertisement availability, not a count of the production listener's callbacks. Both runs capture the initial app observation before independent SDK controls, so those controls cannot warm the resolver cache first. No credentials were supplied and no gateway connection was attempted. Elapsed times identify the runs, not a performance comparison.

Both runs used the **same archived native test APK**, SHA256 `e4a44ab05d8ad2d45118c6dbbcc101af1e61face1bd2f2f285073f280628d8e8`, on actual API 33 Google APIs ARM64. The platform-specific fixture is disposable proof infrastructure and is **not included in this PR**. Each run ended before task-process and emulator cleanup. Startup and accessibility warnings are retained in the evidence; this is not a warning-free-log claim.

Fixed APK SHA256 `ab5d6b1bedf72371a283b8d7990bcacde40c61c3f7d43f81eb78a34f105a9ccd` was built from the reviewed source snapshot before commit. Its packaged metadata records baseline `9bd50c803cce88f2ab387ddaf6cc29b4ef004005`, not the later fix commit. All three files in `cb8f669a648a8dce6c33e32e1a38f7c8a74bbf32` were byte-compared with that reviewed source archive; production SHA256 is `35f11b430afce3f12c7432a9fedba425b6b5ad6e7a5e3d1638f4ef0c4bbd80c1`.

Before: one visible gateway despite three independently resolvable advertisements. After: all three visible before the SDK controls. Only synthetic task names, guest addresses, and empty credential fields appear in these unedited captures.

| Before | After |
| --- | --- |
| ![Before: only one of three advertised gateways is visible](https://github.com/user-attachments/assets/2ec72e5f-f639-4362-ac4a-3032b743d966) | ![After: all three advertised gateways are visible](https://github.com/user-attachments/assets/dee62e27-6eb9-491f-9d56-22b6ed72b8fb) |

### Regression and repository checks

- Original 11 owner cases: five intended failures on unchanged production, then all 11 passed with the fix; executed method sets were compared exactly.
- Both flavors: **22 tests each, 44 passing**, covering queue ownership, lost/rediscovered generations, scope cancellation, synchronous rejection, existing address/status behavior, Bonjour decoding, network-state tracking, and fleet selection.
- Both actual Android lint variants passed with no warnings/errors; all four unfiltered Kotlin-format checks, Play debug assembly, native localization verification, and canonical changed-file guard passed.
- Final isolated P2 autoreview and independent source/local/native review found no actionable findings. An earlier review correctly identified that the disposable API33-only driver must not land; it was moved out of the PR checkout without changing the matched fixture.

The additional synchronous-rejection case failed with `StackOverflowError` against the exact initial **unlanded recursive candidate**, then passed against the iterative fix in both flavors (65/85 ms). This is SDK-boundary unit stress evidence, **not a claim of a shipped or native app crash**.

The dependency contract was inspected directly in [Android 13 NsdService](https://android.googlesource.com/platform/packages/modules/Connectivity/+/refs/tags/android-13.0.0_r83/service-t/src/com/android/server/NsdService.java#404) and [NsdManager callback/resolve handling](https://android.googlesource.com/platform/packages/modules/Connectivity/+/refs/tags/android-13.0.0_r83/framework-t/src/android/net/nsd/NsdManager.java#736), with Android 12 corroboration. Modern discovery and wide-area DNS were inspected as unchanged siblings. This does not claim a live wide-area DNS query, Android 14+ native replay, or gateway authentication/transport proof.

Named follow-up outside this fix: Android's release-task heuristic also matches `Release` inside a debug test filter. The original 11-case replay used a single-match wildcard for that method and verified the exact executed names; no signing settings or credentials changed.

AI-assisted with Codex; source, tests, and native evidence independently reviewed.
