### PR TITLE
fix(code-mode): host-policy denial no longer triggers read-only recovery

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -187,13 +187,20 @@ and correct across successive turns. A failed `exec` or `wait` does not automati
 end the agent run when OpenClaw's host execution record proves that no potentially
 mutating nested action started, including before a suspended run resumed.
 
+An exec host-policy rejection can carry this proof even after hooks, approval
+resolution, and tool implementation entry: the host owns the narrower fact that
+no command process or remote dispatch started. A corrected call runs the ordinary
+hooks and approvals again. Consumed voice confirmations stay consumed; recovery
+does not restore a grant or authorize replay.
+
 Catalog search, handle `describe()`, `skills.list()`, and `skills.read()` are
 read-only discovery. A guest error after only these operations still allows
 ordinary recovery from a failed `exec`; discovery does not count as a mutation.
 
 OpenClaw does not automatically replay a failed program. If earlier calls
 may have changed state or a failed call may have partially applied, OpenClaw
-first limits recovery to an authorized read-only inspection of the current state. It does
+deliberately permits one temporary read-only recovery attempt to inspect the
+current state. The internal instruction identifies OpenClaw as its source. It does
 not expose writes, sends, shell commands, or other mutations during that
 reconciliation. Cancellation, explicitly terminal tool outcomes, sandbox
 restrictions, approval requirements, and tool-policy denials retain their

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -59,6 +59,7 @@ import type { AgentToolResult } from "./runtime/index.js";
 import { createSessionSlug } from "./session-slug.js";
 import { maybeWrapCommandWithShellSnapshot } from "./shell-snapshot.js";
 import { createStreamingBinaryOutputSanitizer, getShellConfig } from "./shell-utils.js";
+import { registerTrustedToolNoStartError } from "./tool-result-error.js";
 import { withoutGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
 export { applyPathPrepend, normalizePathPrepend } from "../infra/path-prepend.js";
 
@@ -256,17 +257,23 @@ export function resolveExecTarget(params: {
 }) {
   const sandboxRequired = params.sandboxRequired === true;
   if (sandboxRequired && !params.sandboxAvailable) {
-    throw new Error("This session requires a sandbox, but its sandbox runtime is unavailable.");
+    throw registerTrustedToolNoStartError(
+      new Error("This session requires a sandbox, but its sandbox runtime is unavailable."),
+    );
   }
   if (sandboxRequired && params.elevatedRequested) {
-    throw new Error("Elevated execution is unavailable because this session requires a sandbox.");
+    throw registerTrustedToolNoStartError(
+      new Error("Elevated execution is unavailable because this session requires a sandbox."),
+    );
   }
   // Session isolation outranks every agent, session, and request-scoped host preference.
   const configuredTarget = sandboxRequired ? "auto" : (params.configuredTarget ?? "auto");
   const requestedTarget = params.requestedTarget ?? null;
   if (sandboxRequired && (requestedTarget === "gateway" || requestedTarget === "node")) {
-    throw new Error(
-      `exec host not allowed (requested ${renderExecTargetLabel(requestedTarget)}; this session requires a sandbox).`,
+    throw registerTrustedToolNoStartError(
+      new Error(
+        `exec host not allowed (requested ${renderExecTargetLabel(requestedTarget)}; this session requires a sandbox).`,
+      ),
     );
   }
   if (
@@ -288,10 +295,12 @@ export function resolveExecTarget(params: {
             : [renderExecTargetLabel(requestedTarget), "auto"],
       ),
     ).join(" or ");
-    throw new Error(
-      `exec host not allowed (requested ${renderExecTargetLabel(requestedTarget)}; ` +
-        `configured host is ${renderExecTargetLabel(configuredTarget)}; ` +
-        `set tools.exec.host=${allowedConfig} to allow this override).`,
+    throw registerTrustedToolNoStartError(
+      new Error(
+        `exec host not allowed (requested ${renderExecTargetLabel(requestedTarget)}; ` +
+          `configured host is ${renderExecTargetLabel(configuredTarget)}; ` +
+          `set tools.exec.host=${allowedConfig} to allow this override).`,
+      ),
     );
   }
   const selectedTarget = requestedTarget ?? configuredTarget;

--- a/src/agents/bash-tools.exec-target.test.ts
+++ b/src/agents/bash-tools.exec-target.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { requireValidExecTarget } from "../infra/exec-approvals.js";
 import { resolveExecTarget } from "./bash-tools.exec-runtime.js";
+import { consumeTrustedToolNoStartError } from "./tool-result-error.js";
 
 function expectExecTarget(
   actual: ReturnType<typeof resolveExecTarget>,
@@ -17,6 +19,42 @@ function expectExecTarget(
 }
 
 describe("resolveExecTarget", () => {
+  it("authenticates only the exact deliberate rejection once, not copies or invalid target syntax", () => {
+    let denied: unknown;
+    try {
+      resolveExecTarget({
+        configuredTarget: "gateway",
+        requestedTarget: "node",
+        elevatedRequested: false,
+        sandboxAvailable: false,
+      });
+    } catch (error) {
+      denied = error;
+    }
+    expect(denied).toBeInstanceOf(Error);
+    const error = denied as Error;
+    const serialized = JSON.stringify(error);
+    for (const copy of [
+      new Error(error.message),
+      Object.assign(new Error(error.message), error),
+      structuredClone(error),
+      JSON.parse(serialized),
+    ]) {
+      expect(consumeTrustedToolNoStartError(copy)).toBe(false);
+    }
+    expect(Object.keys(error)).toEqual([]);
+    expect(consumeTrustedToolNoStartError(error)).toBe(true);
+    expect(consumeTrustedToolNoStartError(error)).toBe(false);
+    let invalidError: unknown;
+    try {
+      requireValidExecTarget("invalid-host");
+    } catch (invalid) {
+      invalidError = invalid;
+    }
+    expect(invalidError).toBeInstanceOf(Error);
+    expect(consumeTrustedToolNoStartError(invalidError)).toBe(false);
+  });
+
   it("keeps implicit auto on sandbox when a sandbox runtime is available", () => {
     expectExecTarget(
       resolveExecTarget({

--- a/src/agents/code-mode.bridge.host-denial.test.ts
+++ b/src/agents/code-mode.bridge.host-denial.test.ts
@@ -1,0 +1,708 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { createMockPluginRegistry } from "../plugins/hooks.test-fixtures.js";
+import type { PluginHookBeforeToolCallEvent } from "../plugins/types.js";
+import { getProcessSupervisor } from "../process/supervisor/index.js";
+import {
+  authorizeClientVoiceConfirmation,
+  bindAuthorizedClientVoiceConfirmation,
+  checkClientVoiceToolConfirmationPolicy,
+  noteClientVoiceConfirmationUtterance,
+} from "../talk/client-voice-confirmation.js";
+import { resetClientVoiceConfirmationStateForTest } from "../talk/client-voice-confirmation.test-support.js";
+import * as clientVoiceSession from "../talk/client-voice-session.js";
+import { wrapToolWithBeforeToolCallHook } from "./agent-tools.before-tool-call.js";
+import { resetAdjustedParamsByToolCallIdForTests } from "./agent-tools.before-tool-call.state.js";
+import type { HookContext } from "./agent-tools.before-tool-call.types.js";
+import * as nodeHost from "./bash-tools.exec-host-node.js";
+import { createExecTool } from "./bash-tools.exec-run.js";
+import type { ExecToolDefaults } from "./bash-tools.exec-types.js";
+import * as codeModeBridge from "./code-mode-bridge.js";
+import { consumeRepairableCodeModeFailure } from "./code-mode-repair-provenance.js";
+import { createSubscribedCodeModeHarness } from "./code-mode.bridge.lifecycle.test-support.js";
+import { applyCodeModeCatalog } from "./code-mode.js";
+import {
+  pluginToolWithExecute,
+  resetCodeModeTestState,
+  resultDetails,
+  testing,
+} from "./code-mode.test-support.js";
+import { consumeTrustedToolNoStartError } from "./tool-result-error.js";
+import { createToolTerminalObserver } from "./tool-terminal-outcome.js";
+import { jsonResult, ToolInputError } from "./tools/common.js";
+import * as gatewayTool from "./tools/gateway.js";
+
+const sandbox = {
+  containerName: "test-sandbox",
+  workspaceDir: process.cwd(),
+  containerWorkdir: "/workspace",
+};
+const deniedCode = 'return await exec({ command: "printf host-denied", host: "node" });';
+
+function installBefore(
+  handler: (event: PluginHookBeforeToolCallEvent) => unknown = () => undefined,
+) {
+  const before = vi.fn(handler);
+  initializeGlobalHookRunner(
+    createMockPluginRegistry([
+      { hookName: "before_tool_call", handler: before as (...args: unknown[]) => unknown },
+    ]),
+  );
+  return before;
+}
+
+function createHostHarness(
+  options: Parameters<typeof createSubscribedCodeModeHarness>[0] & {
+    defaults?: ExecToolDefaults;
+    hookContext?: HookContext;
+    approvalMode?: "report";
+  },
+) {
+  const harness = createSubscribedCodeModeHarness(options);
+  const source = createExecTool({
+    host: "gateway",
+    security: "full",
+    ask: "off",
+    ...options.defaults,
+  });
+  const shell = wrapToolWithBeforeToolCallHook(
+    source,
+    { runId: harness.runId, sessionKey: harness.sessionKey, ...options.hookContext },
+    { approvalMode: options.approvalMode },
+  );
+  applyCodeModeCatalog({ ...harness, tools: [...harness.tools, shell] });
+  let nextCall = 0;
+  return {
+    ...harness,
+    source,
+    shell,
+    spawn: vi.spyOn(getProcessSupervisor(), "spawn"),
+    remote: vi.spyOn(nodeHost, "executeNodeHostCommand"),
+    run: async (code = deniedCode) =>
+      resultDetails(
+        await expectDefined(harness.tools[0], "outer exec").execute(`host-${nextCall++}`, { code }),
+      ),
+  };
+}
+
+describe("Code Mode subscribed host denial", () => {
+  afterEach(() => {
+    resetCodeModeTestState();
+    resetGlobalHookRunner();
+    resetAdjustedParamsByToolCallIdForTests();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    {
+      policy: "gateway",
+      defaults: { host: "gateway" },
+      args: { host: "node" },
+      error: "exec host not allowed",
+    },
+    {
+      policy: "auto-sandbox",
+      defaults: { host: "auto", sandbox },
+      args: { host: "gateway" },
+      error: "exec host not allowed",
+    },
+    {
+      policy: "required-missing",
+      defaults: { sandboxRequired: true },
+      args: {},
+      error: "sandbox runtime is unavailable",
+    },
+    {
+      policy: "required-elevation",
+      defaults: {
+        sandboxRequired: true,
+        sandbox,
+        elevated: { enabled: true, allowed: true, defaultLevel: "off" },
+      },
+      args: { elevated: true },
+      error: "Elevated execution is unavailable",
+    },
+    {
+      policy: "required-outside",
+      defaults: { sandboxRequired: true, sandbox },
+      args: { host: "gateway" },
+      error: "this session requires a sandbox",
+    },
+  ] satisfies Array<{ policy: string; defaults: ExecToolDefaults; args: object; error: string }>)(
+    "preserves operation no-start through the real subscriber for $policy",
+    async ({ policy, defaults, args, error }) => {
+      const before = installBefore();
+      const observeToolTerminal = vi.fn(createToolTerminalObserver(`run-code-mode-host-${policy}`));
+      const harness = createHostHarness({ name: `host-${policy}`, defaults, observeToolTerminal });
+      try {
+        const details = await harness.run(
+          `return await exec(${JSON.stringify({ command: "printf host-denied", ...args })});`,
+        );
+        expect(details).toMatchObject({
+          status: "failed",
+          failurePhase: "bridge",
+          bridgeDispatchStarted: true,
+        });
+        expect(details.error).toContain(error);
+        expect(before).toHaveBeenCalledOnce();
+        expect(observeToolTerminal).toHaveBeenCalledWith(
+          expect.objectContaining({ toolName: "exec", executionStarted: true, outcome: "failure" }),
+        );
+        expect(harness.spawn).not.toHaveBeenCalled();
+        expect(harness.remote).not.toHaveBeenCalled();
+        expect(harness.subscription.getItemLifecycle()).toMatchObject({
+          startedCount: 2,
+          completedCount: 2,
+          activeCount: 0,
+        });
+        const serialized = JSON.stringify(details);
+        for (const copy of [{ ...details }, structuredClone(details), JSON.parse(serialized)]) {
+          expect(consumeRepairableCodeModeFailure(copy)).toBe(false);
+        }
+        expect(consumeRepairableCodeModeFailure(details)).toBe(true);
+        expect(consumeRepairableCodeModeFailure(details)).toBe(false);
+      } finally {
+        harness.dispose();
+      }
+    },
+  );
+  it.each(["repair", "deny", "veto", "throw", "invalid"] as const)(
+    "judges final host arguments after one real hook: %s",
+    async (change) => {
+      const before = installBefore(() => {
+        if (change === "throw") {
+          throw new Error("hook failed");
+        }
+        if (change === "veto") {
+          return { block: true, blockReason: "hook veto" };
+        }
+        return {
+          params: {
+            command: "printf host-corrected",
+            host: change === "repair" ? "gateway" : "node",
+            ...(change === "invalid" ? { command: 42 } : {}),
+          },
+        };
+      });
+      const harness = createHostHarness({ name: `hook-${change}` });
+      try {
+        const details = await harness.run(
+          change === "repair"
+            ? deniedCode
+            : 'return await exec({ command: "printf initial", host: "gateway" });',
+        );
+        expect(before).toHaveBeenCalledOnce();
+        expect(harness.remote).not.toHaveBeenCalled();
+        expect(harness.spawn).toHaveBeenCalledTimes(change === "repair" ? 1 : 0);
+        expect(details.status).toBe(
+          change === "repair" || change === "veto" ? "completed" : "failed",
+        );
+        if (change === "veto") {
+          expect(details.value).toMatchObject({ status: "blocked", reason: "hook veto" });
+        }
+        if (change === "repair") {
+          expect(details.value).toMatchObject({ exitCode: 0, aggregated: "host-corrected" });
+        }
+        expect(consumeRepairableCodeModeFailure(details)).toBe(
+          change === "deny" || change === "invalid",
+        );
+      } finally {
+        harness.dispose();
+      }
+    },
+  );
+
+  it.each([
+    "allow-once",
+    "allow-always",
+    "deny",
+    "timeout",
+    "cancel",
+    "unavailable",
+    "report",
+  ] as const)("preserves approval callbacks and containment for %s", async (decision) => {
+    const resolutions: string[] = [];
+    const requests: string[] = [];
+    const before = installBefore(() => ({
+      requireApproval: {
+        title: "Confirm command",
+        description: "Review host command",
+        onResolution: (value: string) => resolutions.push(value),
+      },
+    }));
+    const rpc = vi.spyOn(gatewayTool, "callGatewayTool").mockImplementation(async (method) => {
+      requests.push(method);
+      if (decision === "unavailable") {
+        throw new Error("gateway unavailable");
+      }
+      if (method === "plugin.approval.request") {
+        return { id: "host-approval", status: "accepted" };
+      }
+      if (decision === "cancel") {
+        throw new Error("approval route closed");
+      }
+      return { id: "host-approval", decision: decision === "timeout" ? null : decision };
+    });
+    const harness = createHostHarness({
+      name: `approval-${decision}`,
+      ...(decision === "report" ? { approvalMode: "report" } : {}),
+    });
+    try {
+      const allowed = decision === "allow-once" || decision === "allow-always";
+      const details = await harness.run();
+      expect(details.status).toBe("failed");
+      expect(consumeRepairableCodeModeFailure(details)).toBe(allowed);
+      expect(before).toHaveBeenCalledOnce();
+      expect(resolutions).toEqual([
+        decision === "cancel" || decision === "unavailable" || decision === "report"
+          ? "cancelled"
+          : decision,
+      ]);
+      expect(requests).toEqual(
+        decision === "report"
+          ? []
+          : decision === "unavailable"
+            ? ["plugin.approval.request"]
+            : ["plugin.approval.request", "plugin.approval.waitDecision"],
+      );
+      expect(harness.spawn).not.toHaveBeenCalled();
+      expect(harness.remote).not.toHaveBeenCalled();
+      if (allowed) {
+        const corrected = await harness.run(
+          'return await exec({ command: "printf approved-correction", host: "gateway" });',
+        );
+        expect(corrected).toMatchObject({
+          status: "completed",
+          value: { exitCode: 0, aggregated: "approved-correction" },
+        });
+        expect(before).toHaveBeenCalledTimes(2);
+        expect(resolutions).toEqual([decision, decision]);
+        expect(rpc).toHaveBeenCalledTimes(4);
+        expect(harness.spawn).toHaveBeenCalledOnce();
+      }
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it("keeps the approved host snapshot frozen against later hook rewrites", async () => {
+    const approve = vi.fn(() => ({
+      params: { command: "printf approved", host: "node" },
+      requireApproval: { title: "Approve", description: "Exact host" },
+    }));
+    const rewrite = vi.fn(() => ({ params: { command: "printf changed", host: "gateway" } }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        { hookName: "before_tool_call", handler: approve, priority: 1 },
+        { hookName: "before_tool_call", handler: rewrite },
+      ]),
+    );
+    vi.spyOn(gatewayTool, "callGatewayTool").mockResolvedValue({
+      id: "frozen",
+      decision: "allow-once",
+    });
+    const harness = createHostHarness({ name: "approval-freeze" });
+    try {
+      const details = await harness.run();
+      expect(details.error).toContain("requested node");
+      expect(consumeRepairableCodeModeFailure(details)).toBe(true);
+      expect(approve).toHaveBeenCalledOnce();
+      expect(rewrite).toHaveBeenCalledOnce();
+      expect(harness.spawn).not.toHaveBeenCalled();
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it.each(["hook", "approval", "preparation", "completion"] as const)(
+    "does not resurrect cancellation-ignoring work across awaited %s",
+    async (boundary) => {
+      const entered = createDeferred();
+      const release = createDeferred();
+      const finished = createDeferred();
+      const pause = async () => {
+        entered.resolve();
+        await release.promise;
+        finished.resolve();
+      };
+      if (boundary === "hook") {
+        installBefore(pause);
+      }
+      if (boundary === "approval") {
+        installBefore(() => ({ requireApproval: { title: "Approve", description: "Wait" } }));
+        vi.spyOn(gatewayTool, "callGatewayTool").mockImplementation(async (method) => {
+          if (method === "plugin.approval.request") {
+            return { id: "late", status: "accepted" };
+          }
+          await pause();
+          return { id: "late", decision: "allow-once" };
+        });
+      }
+      const harness = createHostHarness({
+        name: `abort-${boundary}`,
+        ...(boundary === "completion" ? { onToolStreamBoundary: pause } : {}),
+      });
+      if (boundary === "preparation") {
+        initializeGlobalHookRunner(
+          createMockPluginRegistry([
+            { hookName: "resolve_exec_env", handler: pause },
+            {
+              hookName: "before_tool_call",
+              handler: () => ({ params: { command: "printf no", host: "node" } }),
+            },
+          ]),
+        );
+      }
+      const after = pluginToolWithExecute("after_abort", "Must not run after abort", async () =>
+        jsonResult({ ran: true }),
+      );
+      applyCodeModeCatalog({ ...harness, tools: [...harness.tools, harness.shell, after] });
+      try {
+        const code =
+          boundary === "preparation"
+            ? deniedCode.replace('host: "node"', 'host: "gateway"')
+            : deniedCode;
+        const running = harness.run(`${code.replace("return ", "")} await after_abort({});`);
+        await entered.promise;
+        harness.runAbortController.abort(new Error("cancel host test"));
+        const details = await running;
+        expect(details).toMatchObject({ status: "failed" });
+        expect(details.error).toMatch(/abort|cancel/i);
+        expect(consumeRepairableCodeModeFailure(details)).toBe(false);
+        release.resolve();
+        await finished.promise;
+        await vi.waitFor(() => expect(harness.subscription.getItemLifecycle().activeCount).toBe(0));
+        expect(harness.spawn).not.toHaveBeenCalled();
+        expect(harness.remote).not.toHaveBeenCalled();
+        expect(after.execute).not.toHaveBeenCalled();
+        expect(testing.activeRuns.size).toBe(0);
+      } finally {
+        release.resolve();
+        harness.dispose();
+      }
+    },
+  );
+
+  it("does not transfer the consumed fact when awaited completion replaces the error", async () => {
+    const replacement = new Error("completion observer failed");
+    const harness = createHostHarness({
+      name: "completion-replacement",
+      observeToolTerminal: () => {
+        throw replacement;
+      },
+    });
+    const execute = harness.source.execute;
+    let producerError: unknown;
+    // Capture the exact real producer object without minting or modifying its proof.
+    const capture = wrapToolWithBeforeToolCallHook(
+      {
+        ...harness.source,
+        execute: async (...args: Parameters<typeof execute>) => {
+          try {
+            return await execute(...args);
+          } catch (error) {
+            producerError = error;
+            throw error;
+          }
+        },
+      },
+      { runId: harness.runId },
+    );
+    applyCodeModeCatalog({ ...harness, tools: [...harness.tools, capture] });
+    try {
+      const details = await harness.run();
+      expect(details.error).toContain(replacement.message);
+      expect(producerError).toBeInstanceOf(Error);
+      expect(consumeTrustedToolNoStartError(producerError)).toBe(false);
+      expect(consumeTrustedToolNoStartError(replacement)).toBe(false);
+      expect(consumeRepairableCodeModeFailure(details)).toBe(false);
+      expect(harness.spawn).not.toHaveBeenCalled();
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it("ignores an after-tool plugin return without replacing the operation fact", async () => {
+    const after = vi.fn(() => ({ terminate: true, result: { status: "completed" } }));
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([{ hookName: "after_tool_call", handler: after }]),
+    );
+    const harness = createHostHarness({ name: "after-observer" });
+    try {
+      const details = await harness.run();
+      await vi.waitFor(() => expect(after).toHaveBeenCalledOnce());
+      expect(details.error).toContain("exec host not allowed");
+      expect(consumeRepairableCodeModeFailure(details)).toBe(true);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it.each([
+    "earlier",
+    "parked",
+    "mutation-first/settles-first",
+    "mutation-first/settles-last",
+    "denial-first/settles-first",
+    "denial-first/settles-last",
+    "late-settlement",
+  ] as const)("retains real whole-cell mutation history: %s", async (order) => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "code-mode-host-marker-"));
+    const marker = path.join(dir, "mutation.txt");
+    const mutated = createDeferred();
+    const denied = createDeferred();
+    const releaseLateMutation = createDeferred();
+    const lateMutationFinished = createDeferred();
+    const dispatchOrder: string[] = [];
+    const settlementOrder: string[] = [];
+    const runBridge = codeModeBridge.runBridgeRequest;
+    vi.spyOn(codeModeBridge, "runBridgeRequest").mockImplementation(async (params) => {
+      const name = String(params.request.args[0]);
+      dispatchOrder.push(name);
+      const settled = await runBridge(params);
+      settlementOrder.push(name);
+      if (name === "record_mutation") {
+        mutated.resolve();
+      }
+      if (name === "exec") {
+        denied.resolve();
+      }
+      return settled;
+    });
+    const mutationFirstSettlement = order.endsWith("settles-first");
+    const parallel = order.includes("/");
+    installBefore(async (event) => {
+      if (event.toolName === "exec" && parallel && mutationFirstSettlement) {
+        await mutated.promise;
+      }
+    });
+    const harness = createHostHarness({
+      name: `mutation-${order.replaceAll("/", "-")}`,
+    });
+    const mutation = pluginToolWithExecute(
+      "record_mutation",
+      "Append one mutation marker",
+      async () => {
+        if (order === "late-settlement") {
+          await releaseLateMutation.promise;
+        }
+        if (parallel && !mutationFirstSettlement) {
+          await denied.promise;
+        }
+        await fs.appendFile(marker, "applied\n");
+        lateMutationFinished.resolve();
+        return jsonResult({ applied: true });
+      },
+    );
+    applyCodeModeCatalog({ ...harness, tools: [...harness.tools, harness.shell, mutation] });
+    try {
+      const deny = deniedCode.replace("return await ", "").replace(/;$/, "");
+      const expressions = order.startsWith("denial-first")
+        ? [deny, "record_mutation({})"]
+        : ["record_mutation({})", deny];
+      const code =
+        order === "late-settlement"
+          ? `await Promise.all([record_mutation({}), ${deny}]);`
+          : parallel
+            ? `const results = await Promise.allSettled([${expressions.join(",")}]); throw new Error(results.find(r => r.status === "rejected").reason.message);`
+            : `await record_mutation({}); ${order === "parked" ? 'await yield_control("after mutation");' : ""} ${deniedCode}`;
+      let details = await harness.run(code);
+      if (order === "parked") {
+        expect(details.status).toBe("waiting");
+        const parked = expectDefined(
+          testing.activeRuns.get(String(details.runId)),
+          "real parked history",
+        );
+        expect(parked.bridgeDispatch.potentiallyMutatingDispatches).toBeGreaterThanOrEqual(1);
+        details = resultDetails(
+          await expectDefined(harness.tools[1], "wait").execute("resume-denial", {
+            runId: details.runId,
+          }),
+        );
+        expect(parked.bridgeDispatch.potentiallyMutatingDispatches).toBeGreaterThanOrEqual(1);
+      }
+      if (order === "late-settlement") {
+        expect(details.status).toBe("waiting");
+        const pending = expectDefined(
+          testing.activeRuns.get(String(details.runId)),
+          "pending mutation",
+        );
+        expect(pending.bridgeDispatch.potentiallyMutatingDispatches).toBe(1);
+        expect(consumeRepairableCodeModeFailure(details)).toBe(false);
+        await expect(fs.readFile(marker, "utf8")).rejects.toMatchObject({ code: "ENOENT" });
+        releaseLateMutation.resolve();
+        await lateMutationFinished.promise;
+        details = resultDetails(
+          await expectDefined(harness.tools[1], "wait").execute("settle-late", {
+            runId: details.runId,
+          }),
+        );
+        await vi.waitFor(() => expect(harness.subscription.getItemLifecycle().activeCount).toBe(0));
+        expect(pending.bridgeDispatch.potentiallyMutatingDispatches).toBe(1);
+      }
+      expect(details).toMatchObject({ status: "failed", bridgeDispatchStarted: true });
+      expect(details.error).toContain("exec host not allowed");
+      expect(await fs.readFile(marker, "utf8")).toBe("applied\n");
+      expect(mutation.execute).toHaveBeenCalledOnce();
+      if (parallel) {
+        expect(dispatchOrder).toEqual(
+          order.startsWith("denial-first")
+            ? ["exec", "record_mutation"]
+            : ["record_mutation", "exec"],
+        );
+        expect(settlementOrder).toEqual(
+          mutationFirstSettlement ? ["record_mutation", "exec"] : ["exec", "record_mutation"],
+        );
+      }
+      expect(consumeRepairableCodeModeFailure(details)).toBe(false);
+      expect(harness.spawn).not.toHaveBeenCalled();
+      expect(harness.remote).not.toHaveBeenCalled();
+    } finally {
+      mutated.resolve();
+      denied.resolve();
+      releaseLateMutation.resolve();
+      harness.dispose();
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["unbranded", "input-error", "security-deny"] as const)(
+    "does not grant operation proof to %s failures",
+    async (kind) => {
+      const harness = createHostHarness({
+        name: `untrusted-${kind}`,
+        ...(kind === "security-deny" ? { defaults: { security: "deny" } } : {}),
+      });
+      if (kind === "unbranded" || kind === "input-error") {
+        const error =
+          kind === "input-error"
+            ? new ToolInputError("exec host not allowed")
+            : new Error("exec host not allowed");
+        const target = pluginToolWithExecute("untrusted", "Post-start failure", async () => {
+          throw error;
+        });
+        applyCodeModeCatalog({ ...harness, tools: [...harness.tools, target] });
+      }
+      try {
+        const details = await harness.run(
+          kind === "unbranded" || kind === "input-error"
+            ? "await untrusted({});"
+            : `return await exec({ command: "printf no", host: "gateway" });`,
+        );
+        expect(details.status).toBe("failed");
+        expect(consumeRepairableCodeModeFailure(details)).toBe(false);
+        expect(harness.spawn).not.toHaveBeenCalled();
+        expect(harness.remote).not.toHaveBeenCalled();
+      } finally {
+        harness.dispose();
+      }
+    },
+  );
+  it("leaves the consumed voice grant consumed after host rejection and requires a new correction grant", async () => {
+    const harness = createHostHarness({ name: "voice-denial" });
+    const voiceSessionId = "host-denial-voice";
+    const binding = { agentId: "main", voiceSessionId, sessionKey: harness.sessionKey };
+    vi.spyOn(clientVoiceSession, "resolveClientVoiceRunBinding").mockImplementation((runId) =>
+      runId === harness.runId ? binding : undefined,
+    );
+    vi.spyOn(clientVoiceSession, "isClientVoiceSessionConfirmable").mockReturnValue(true);
+    // Explicit yieldMs keeps the granted final shape identical to the nested call.
+    const args = { command: "printf voice-denied", host: "node", yieldMs: 1000 };
+    const policy = {
+      agentId: "main",
+      voiceSessionId,
+      runId: harness.runId,
+      toolName: "exec",
+      toolParams: args,
+      isConfirmable: () => true,
+    };
+    const now = Date.now();
+    const challenge = checkClientVoiceToolConfirmationPolicy({ ...policy, now });
+    expect(challenge.allowed).toBe(false);
+    if (challenge.allowed) {
+      throw new Error("voice challenge expected");
+    }
+    const confirmationId = expectDefined(
+      challenge.reason.match(/VOICE_CONFIRMATION_REQUIRED:([^\s]+)/)?.[1],
+      "voice challenge id",
+    );
+    noteClientVoiceConfirmationUtterance({
+      agentId: "main",
+      voiceSessionId,
+      text: "yes",
+      timestamp: now + 1,
+    });
+    const grant = authorizeClientVoiceConfirmation({
+      agentId: "main",
+      voiceSessionId,
+      confirmationId,
+      now: now + 2,
+    });
+    bindAuthorizedClientVoiceConfirmation({ grant, runId: harness.runId });
+    try {
+      expect(checkClientVoiceToolConfirmationPolicy(policy).allowed).toBe(true);
+      const denied = await harness.run(`return await exec(${JSON.stringify(args)});`);
+      expect(denied.error).toContain("exec host not allowed");
+      expect(consumeRepairableCodeModeFailure(denied)).toBe(true);
+      expect(checkClientVoiceToolConfirmationPolicy(policy).allowed).toBe(false);
+      for (const input of [args, { ...args, host: "gateway" }]) {
+        const blocked = await harness.run(`return await exec(${JSON.stringify(input)});`);
+        expect(blocked).toMatchObject({
+          status: "completed",
+          value: { status: "blocked", deniedReason: "client-voice-confirmation" },
+        });
+        expect(JSON.stringify(blocked.value)).toContain("VOICE_CONFIRMATION_REQUIRED");
+        expect(consumeRepairableCodeModeFailure(blocked)).toBe(false);
+      }
+      expect(harness.spawn).not.toHaveBeenCalled();
+      expect(harness.remote).not.toHaveBeenCalled();
+    } finally {
+      harness.dispose();
+      resetClientVoiceConfirmationStateForTest();
+    }
+  });
+  it.each(["copy", "json", "reuse"] as const)(
+    "does not transfer a settled object's proof through %s",
+    async (mode) => {
+      const harness = createHostHarness({ name: `settled-${mode}` });
+      const runBridge = codeModeBridge.runBridgeRequest;
+      let first: Awaited<ReturnType<typeof runBridge>> | undefined;
+      vi.spyOn(codeModeBridge, "runBridgeRequest").mockImplementation(async (params) => {
+        const settled = await runBridge(params);
+        if (mode === "reuse") {
+          if (first) {
+            return first;
+          }
+          first = settled;
+          return settled;
+        }
+        first = settled;
+        const serialized = JSON.stringify(settled);
+        return mode === "json" ? JSON.parse(serialized) : { ...settled };
+      });
+      try {
+        const details = await harness.run();
+        expect(details.error).toContain("exec host not allowed");
+        expect(consumeRepairableCodeModeFailure(details)).toBe(mode === "reuse");
+        if (mode === "reuse") {
+          const reused = await harness.run();
+          expect(consumeRepairableCodeModeFailure(reused)).toBe(false);
+        } else {
+          expect(consumeTrustedToolNoStartError(first)).toBe(true);
+        }
+        expect(consumeTrustedToolNoStartError(first)).toBe(false);
+        expect(harness.spawn).not.toHaveBeenCalled();
+      } finally {
+        harness.dispose();
+      }
+    },
+  );
+});

--- a/src/agents/code-mode.bridge.lifecycle.test-support.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test-support.ts
@@ -1,0 +1,94 @@
+/** Real embedded subscriber/catalog executor shared by bridge lifecycle regressions. */
+import { createDiagnosticEmbeddedRunOwner } from "../logging/diagnostic-run-activity.js";
+import { createCodeModeTools } from "./code-mode.js";
+import { prepareEmbeddedAttemptStream } from "./embedded-agent-runner/run/attempt-stream-prepare.js";
+import type { EmbeddedRunAttemptParams } from "./embedded-agent-runner/run/types.js";
+import { clearActiveEmbeddedRun } from "./embedded-agent-runner/runs.js";
+import { createStubSessionHarness } from "./embedded-agent-subscribe.e2e-harness.js";
+import { clearToolSearchCatalog, createToolSearchCatalogRef } from "./tool-search.js";
+
+export function createSubscribedCodeModeHarness(params: {
+  name: string;
+  onBlockReplyFlush?: () => Promise<void>;
+  onToolResult?: EmbeddedRunAttemptParams["onToolResult"];
+  onBlockReply?: EmbeddedRunAttemptParams["onBlockReply"];
+  onPartialReply?: EmbeddedRunAttemptParams["onPartialReply"];
+  timeoutMs?: number;
+  observeToolTerminal?: EmbeddedRunAttemptParams["observeToolTerminal"];
+  onToolStreamBoundary?: EmbeddedRunAttemptParams["onToolStreamBoundary"];
+}) {
+  const runId = `run-code-mode-${params.name}`;
+  const sessionId = `session-code-mode-${params.name}`;
+  const sessionKey = `agent:main:${params.name}`;
+  const config = {
+    tools: { codeMode: { enabled: true, timeoutMs: params.timeoutMs ?? 1_500 } },
+  } as never;
+  const catalogRef = createToolSearchCatalogRef();
+  const runAbortController = new AbortController();
+  const { session, emit } = createStubSessionHarness();
+  const activeSession = Object.assign(session, {
+    agent: { hasQueuedMessages: () => false },
+    isStreaming: false,
+    messages: [],
+    pendingMessageCount: 0,
+  });
+  const stream = prepareEmbeddedAttemptStream({
+    attempt: {
+      config,
+      runId,
+      sessionId,
+      sessionKey,
+      onToolResult: params.onToolResult,
+      observeToolTerminal: params.observeToolTerminal,
+      onToolStreamBoundary: params.onToolStreamBoundary,
+      onPartialReply: params.onPartialReply,
+      blockReplyBreak: "message_end",
+    } as never,
+    activeSession: activeSession as never,
+    hookRunner: undefined as never,
+    hookAgentId: "main",
+    diagnosticTrace: {} as never,
+    diagnosticOwner: createDiagnosticEmbeddedRunOwner({ sessionId, sessionKey, runId }),
+    clientToolCallSlots: [],
+    toolSearchTargetTranscriptProjections: [],
+    isReplaySafeTool: () => false,
+    runAbortController,
+    abortRun: () => runAbortController.abort(),
+    markExternalAbort: () => undefined,
+    getRunState: () => ({
+      aborted: runAbortController.signal.aborted,
+      promptError: undefined,
+      timedOut: false,
+      yieldDetected: false,
+    }),
+    hasDeliveredSourceReply: () => false,
+    markSourceReplyDelivered: () => undefined,
+    onBlockReply: params.onBlockReply,
+    onBlockReplyFlush: params.onBlockReplyFlush,
+    sandboxSessionKey: sessionKey,
+    builtinToolNames: new Set(),
+    replaySafeToolNames: new Set(),
+  });
+  const context = {
+    config,
+    runtimeConfig: config,
+    sessionId,
+    sessionKey,
+    runId,
+    catalogRef,
+    abortSignal: runAbortController.signal,
+    executeTool: stream.toolSearchCatalogExecutor,
+  };
+  return {
+    ...context,
+    emit,
+    tools: createCodeModeTools(context),
+    runAbortController,
+    subscription: stream.subscription,
+    dispose: () => {
+      clearToolSearchCatalog(context);
+      stream.subscription.unsubscribe();
+      clearActiveEmbeddedRun(sessionId, stream.queueHandle, sessionKey);
+    },
+  };
+}

--- a/src/agents/code-mode.bridge.lifecycle.test.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test.ts
@@ -3,14 +3,10 @@ import { getEventListeners } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { createDiagnosticEmbeddedRunOwner } from "../logging/diagnostic-run-activity.js";
 import { buildExecApprovalPendingToolResult } from "./bash-tools.exec-host-shared.js";
 import { disposeAllCodeModeRuns } from "./code-mode-state.js";
-import {
-  addClientToolsToCodeModeCatalog,
-  applyCodeModeCatalog,
-  createCodeModeTools,
-} from "./code-mode.js";
+import { createSubscribedCodeModeHarness } from "./code-mode.bridge.lifecycle.test-support.js";
+import { addClientToolsToCodeModeCatalog, applyCodeModeCatalog } from "./code-mode.js";
 import {
   fakeTool,
   pluginToolWithExecute,
@@ -18,98 +14,11 @@ import {
   resultDetails,
   testing,
 } from "./code-mode.test-support.js";
-import { prepareEmbeddedAttemptStream } from "./embedded-agent-runner/run/attempt-stream-prepare.js";
 import { buildEmbeddedRunPayloads } from "./embedded-agent-runner/run/payloads.js";
-import type { EmbeddedRunAttemptParams } from "./embedded-agent-runner/run/types.js";
-import { clearActiveEmbeddedRun } from "./embedded-agent-runner/runs.js";
-import {
-  createStubSessionHarness,
-  emitAssistantTextDeltaAndEnd,
-} from "./embedded-agent-subscribe.e2e-harness.js";
+import { emitAssistantTextDeltaAndEnd } from "./embedded-agent-subscribe.e2e-harness.js";
 import { countActiveToolExecutions } from "./embedded-agent-subscribe.handlers.tools.js";
-import { clearToolSearchCatalog, createToolSearchCatalogRef } from "./tool-search.js";
+import { clearToolSearchCatalog } from "./tool-search.js";
 import { jsonResult } from "./tools/common.js";
-
-function createSubscribedCodeModeHarness(params: {
-  name: string;
-  onBlockReplyFlush?: () => Promise<void>;
-  onToolResult?: EmbeddedRunAttemptParams["onToolResult"];
-  onBlockReply?: EmbeddedRunAttemptParams["onBlockReply"];
-  onPartialReply?: EmbeddedRunAttemptParams["onPartialReply"];
-  timeoutMs?: number;
-}) {
-  const runId = `run-code-mode-${params.name}`;
-  const sessionId = `session-code-mode-${params.name}`;
-  const sessionKey = `agent:main:${params.name}`;
-  const config = {
-    tools: { codeMode: { enabled: true, timeoutMs: params.timeoutMs ?? 1_500 } },
-  } as never;
-  const catalogRef = createToolSearchCatalogRef();
-  const runAbortController = new AbortController();
-  const { session, emit } = createStubSessionHarness();
-  const activeSession = Object.assign(session, {
-    agent: { hasQueuedMessages: () => false },
-    isStreaming: false,
-    messages: [],
-    pendingMessageCount: 0,
-  });
-  const stream = prepareEmbeddedAttemptStream({
-    attempt: {
-      config,
-      runId,
-      sessionId,
-      sessionKey,
-      onToolResult: params.onToolResult,
-      onPartialReply: params.onPartialReply,
-      blockReplyBreak: "message_end",
-    } as never,
-    activeSession: activeSession as never,
-    hookRunner: undefined as never,
-    hookAgentId: "main",
-    diagnosticTrace: {} as never,
-    diagnosticOwner: createDiagnosticEmbeddedRunOwner({ sessionId, sessionKey, runId }),
-    clientToolCallSlots: [],
-    toolSearchTargetTranscriptProjections: [],
-    isReplaySafeTool: () => false,
-    runAbortController,
-    abortRun: () => runAbortController.abort(),
-    markExternalAbort: () => undefined,
-    getRunState: () => ({
-      aborted: runAbortController.signal.aborted,
-      promptError: undefined,
-      timedOut: false,
-      yieldDetected: false,
-    }),
-    hasDeliveredSourceReply: () => false,
-    markSourceReplyDelivered: () => undefined,
-    onBlockReply: params.onBlockReply,
-    onBlockReplyFlush: params.onBlockReplyFlush,
-    sandboxSessionKey: sessionKey,
-    builtinToolNames: new Set(),
-    replaySafeToolNames: new Set(),
-  });
-  const context = {
-    config,
-    runtimeConfig: config,
-    sessionId,
-    sessionKey,
-    runId,
-    catalogRef,
-    abortSignal: runAbortController.signal,
-    executeTool: stream.toolSearchCatalogExecutor,
-  };
-  return {
-    ...context,
-    emit,
-    tools: createCodeModeTools(context),
-    runAbortController,
-    subscription: stream.subscription,
-    dispose: () => {
-      stream.subscription.unsubscribe();
-      clearActiveEmbeddedRun(sessionId, stream.queueHandle, sessionKey);
-    },
-  };
-}
 
 describe("Code Mode subscribed bridge lifecycle", () => {
   afterEach(() => resetCodeModeTestState());

--- a/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-reconciliation.ts
@@ -4,7 +4,7 @@ import type { EmbeddedRunTerminalRetryState } from "./terminal-retry-state.js";
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
 const CODE_MODE_RECONCILIATION_PROMPT =
-  "The previous Code Mode mutation may have partially applied. Do not repeat or finish any mutation. Use only the available read-only inspection tools to determine the authoritative current state, then report exactly what applied, what did not, what remains unknown, and what work is still required.";
+  "OpenClaw activated this temporary read-only recovery attempt because the previous Code Mode mutation may have partially applied. This is the only recovery attempt. Do not repeat or finish any mutation. Use only the available read-only inspection tools to determine the authoritative current state, then report exactly what applied, what did not, what remains unknown, and what work is still required.";
 
 const RECONCILIATION_TOOL_NAMES = new Set(["read"]);
 

--- a/src/agents/embedded-agent-subscribe.raw-stream.test.ts
+++ b/src/agents/embedded-agent-subscribe.raw-stream.test.ts
@@ -53,11 +53,10 @@ describe("appendRawStream", () => {
     vi.stubEnv("OPENCLAW_RAW_STREAM_PATH", rawStreamPath);
 
     appendRawStream({ event: "test", ts: 1 });
+    // The async writer creates the file before its append completes.
     await vi.waitFor(() => {
-      expect(fs.existsSync(rawStreamPath)).toBe(true);
+      expect(fs.readFileSync(rawStreamPath, "utf8")).toBe('{"event":"test","ts":1}\n');
     });
-
-    expect(fs.readFileSync(rawStreamPath, "utf8")).toBe('{"event":"test","ts":1}\n');
     expect(unhandledRejections).toHaveLength(0);
   });
 

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -641,7 +641,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
         return result;
       } catch (error) {
         const trustedNoStart = consumeTrustedToolNoStartError(error);
-        const terminal = await handleToolExecutionEnd(ctx, {
+        await handleToolExecutionEnd(ctx, {
           type: "tool_execution_end",
           toolName: toolParams.toolName,
           toolCallId: toolParams.toolCallId,
@@ -650,7 +650,9 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
           result: buildToolLifecycleErrorResult(error),
           hideFromChannelProgress: toolParams.hideFromChannelProgress,
         } as never);
-        if (trustedNoStart && !terminal.executionStarted) {
+        // Operation-owned no-start proof survives generic implementation entry.
+        // Only relay the same error after completion succeeds; replacements cannot inherit it.
+        if (trustedNoStart) {
           registerTrustedToolNoStartError(error);
         }
         throw error;

--- a/src/agents/tool-result-error.ts
+++ b/src/agents/tool-result-error.ts
@@ -154,11 +154,12 @@ export function registerTrustedToolInputError(error: object): void {
   trustedToolInputErrors.add(error);
 }
 
-/** Authenticate a wrapper-owned failure that settled before tool implementation start. */
-export function registerTrustedToolNoStartError(error: unknown): void {
+/** Record host-owned proof that the protected operation never started, even if hooks ran. */
+export function registerTrustedToolNoStartError<T>(error: T): T {
   if (typeof error === "object" && error !== null) {
     trustedToolNoStartErrors.add(error);
   }
+  return error;
 }
 
 /** Consume one private no-start fact at the next authoritative lifecycle boundary. */

--- a/src/agents/tools/terminal-tool.test.ts
+++ b/src/agents/tools/terminal-tool.test.ts
@@ -13,6 +13,11 @@ import {
   resetAgentRunRegistryForTest,
 } from "../../infra/agent-run-registry.js";
 import { GATEWAY_OWNER_ONLY_CORE_TOOLS } from "../../security/dangerous-tools.js";
+import { wrapToolWithBeforeToolCallHook } from "../agent-tools.before-tool-call.js";
+import { consumeRepairableCodeModeFailure } from "../code-mode-repair-provenance.js";
+import { createSubscribedCodeModeHarness } from "../code-mode.bridge.lifecycle.test-support.js";
+import { applyCodeModeCatalog } from "../code-mode.js";
+import { resultDetails } from "../code-mode.test-support.js";
 import { compactToolOutputHint } from "../tool-schema-hints.js";
 import { withGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 import { createTerminalTool } from "./terminal-tool.js";
@@ -306,6 +311,35 @@ describe("terminal tool", () => {
       expect(approvalMocks.decide).not.toHaveBeenCalled();
     },
   );
+
+  it("preserves required-sandbox no-start through Code Mode before terminal input approval or write", async () => {
+    const { backend, manager, sessionId } = await openAgentTerminal();
+    const harness = createSubscribedCodeModeHarness({ name: "terminal-sandbox-denial" });
+    const terminal = wrapToolWithBeforeToolCallHook(
+      makeTool(manager, {
+        config: { agents: { defaults: { sandbox: { mode: "off" } } } },
+        execSession: { sandbox: "required" },
+      }),
+      { runId: harness.runId },
+    );
+    applyCodeModeCatalog({ ...harness, tools: [...harness.tools, terminal] });
+    try {
+      const details = resultDetails(
+        await harness.tools[0]!.execute("terminal-input", {
+          code: `return await terminal(${JSON.stringify({ action: "input", sessionId, data: "echo untouched\r" })});`,
+        }),
+      );
+      expect(details).toMatchObject({ status: "failed", bridgeDispatchStarted: true });
+      expect(details.error).toContain("sandbox runtime is unavailable");
+      expect(backend.writes).toEqual([]);
+      expect(approvalMocks.register).not.toHaveBeenCalled();
+      expect(approvalMocks.decide).not.toHaveBeenCalled();
+      expect(consumeRepairableCodeModeFailure(details)).toBe(true);
+    } finally {
+      harness.dispose();
+      manager.closeAgent(agentOwner, sessionId);
+    }
+  });
 
   it("rejects terminal input when the authoritative persisted session is missing", async () => {
     const { backend, manager, sessionId } = await openAgentTerminal();


### PR DESCRIPTION
Closes #130274 — host-policy rejection incorrectly restricted Code Mode recovery, and the recovery instruction did not identify its source.

## What Problem This Solves

Fixes an issue where a Code Mode agent requesting a disallowed exec host would lose its ordinary tools and enter read-only reconciliation even though no command process or remote dispatch had started. A straightforward host correction could then look like a broken tool installation. Genuine reconciliation also lacked explicit OpenClaw attribution.

## Why This Change Was Made

The rewrite records the exact protected-operation no-start fact at the four deliberate host/sandbox rejection sites, then preserves that private, one-shot fact through the real subscriber. Generic implementation and bridge entry remain truthfully marked as started; the repair does not pretend the lifecycle never ran or grant replay authority.

Only the owning error object qualifies. There is no broad catch, error-message/class matching, serialized flag, new registry, or SDK export. Earlier/parallel mutations still determine the whole-cell outcome. The existing recovery prompt now explains that OpenClaw deliberately activated one temporary read-only attempt, while preserving the no-repeat, inspect, and report instructions.

## User Impact

After a sole proven host rejection, the model can select a corrected command through its ordinary tool surface. The corrected call runs hooks and approvals again. Previously consumed voice confirmations remain consumed. Hook vetoes, approval denial/cancellation, ordinary post-start errors, and uncertain earlier mutations do not become safe to replay.

Host/sandbox policy, the audited read-only recovery set, the one-attempt gate, the one-second nested exec yield, and background-command result shapes are unchanged. This addresses the reported denial and attribution defects, not the optional proposals for a configurable yield cap or disabling reconciliation. Callers must still handle the returned execution status and continuation instead of assuming every command has completed. No config/env, schema/store, dependency, public protocol, or Plugin SDK capability was added.

## Evidence

**Real before/after flow:** exact frozen production baseline `36b3440194a11eda14f5f322d042996f1b1aa957` versus that baseline plus candidate patch SHA-256 `08f04b5469c7273dcf3f428a347483dfb235d9459c5dddb8f2e671d1539fc25c`. Both full builds used the same driver (`19a87cfb4a94cab3a3cbb1214b42241820e7443080cb3b9304fbcea91a6e9e6f`): isolated built Gateway, real agent loop/subscriber/QuickJS, Control UI composer, SQLite public history, local deterministic AIMock, and an independent command-receipt server. This is real runtime/UI proof with a mocked provider, not a live frontier-model test.

| Scenario | Before | After |
| --- | --- | --- |
| Sole forbidden node-host request under Gateway-host policy | 2 provider turns; restricted `read` surface; 0 task commands; correction could not run | 3 provider turns; normal Code Mode surface; model-selected corrected command runs exactly once; `HOST_ALLOWED_ONCE` reaches the user |
| One real mutation followed by host denial | One mutation, one read-only recovery attempt, no repeated write | Same containment; the actual recovery provider context explicitly identifies OpenClaw and its single temporary attempt |

Each flow begins with exactly one UI send. Public call/result pairing, terminal state, command receipts, and the actual marker file agree. Denied commands produce no receipt; real-subscriber tests additionally assert zero supervisor process admission and zero remote command dispatch. UI activity summaries are not used as OS command counts. All task services, ports, browser processes, and temporary state were cleaned up.

**Before: sole denial blocks ordinary correction**

![Before: host denial incorrectly restricts recovery and prevents the corrected command](https://github.com/user-attachments/assets/9b9d37ba-b8e8-4978-8cb9-7a68953fe99e)

https://github.com/user-attachments/assets/7917dd7f-5863-45be-941c-9cceebf40ce0

**After: denial remains visible and the corrected command succeeds once**

![After: visible host denial followed by the ordinary corrected command and successful output](https://github.com/user-attachments/assets/04eaf6ab-b629-4256-a707-899beceb1ee6)

https://github.com/user-attachments/assets/ad047f04-37b7-4e30-b269-d9472ee98d64

The before video is 3.6 seconds. The after video is a 2.4-second excerpt ending after the completed reply, before later expansion exposes temporary workspace metadata. Its final screenshot is an unaltered extracted frame. Both complete original video timelines, the published clips, and selected full-size images were inspected; no UI content was fabricated or modified.

**Earlier mutation still remains contained**

![After: one applied mutation is inspected without repeating or finishing it](https://github.com/user-attachments/assets/cec9797d-0109-4f57-bd83-95319b73f285)

**Regression proof:** five real-subscriber producer cases and the terminal-input sibling fail on pre-fix production only after the zero-dispatch and truthful-start checks pass. The final implementation passed **419 distinct tests across 17 files**, including actual subscriber transfer, four producer sites, auto+active-sandbox policy, hook repair/veto/throw, approval outcomes and approved-parameter freeze, consumed voice grants, awaited cancellation, completion replacement, prior/parallel/parked mutations in actual dispatch/settlement order, and exact-object/copy/serialization/reuse containment. The existing lifecycle fixture was extracted and reused rather than duplicated.

```bash
node scripts/run-vitest.mjs src/agents/bash-tools.exec-target.test.ts src/agents/code-mode.bridge.host-denial.test.ts src/agents/code-mode.bridge.lifecycle.test.ts src/agents/tools/terminal-tool.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/tool-result-error.test.ts src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts src/agents/code-mode.agent-loop.test.ts src/agents/exec-defaults.test.ts src/agents/code-mode.preflight-repair.test.ts src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts src/agents/agent-tools.before-tool-call.e2e.test.ts src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/bash-tools.exec-target.test.ts src/agents/bash-tools.exec-runtime.test.ts src/agents/bash-tools.exec.resolve-env-hook.test.ts src/agents/code-mode.bridge.host-denial.test.ts src/agents/bash-tools.exec.background-abort.test.ts src/agents/bash-tools.exec-host-node.cancellation.test.ts src/agents/tools/terminal-tool.test.ts
```

All used at most four workers, one test invocation at a time. Changed-file gates, docs inventory/MDX, `git diff --check`, and the full build passed. The build used the repository's direct full-build wrapper to avoid worktree dependency reconciliation:

```bash
OPENCLAW_BUILD_ALL_NO_PNPM=1 node --import ./scripts/tsx.mjs scripts/build-all.mts
```

The final build completed in 257.104 seconds with frozen source hashes. Fresh isolated Codex autoreview found no accepted/actionable findings at its **P0-only** threshold; this is not an all-priority review claim.

**Limits and failed attempts:** no real Docker sandbox, remote node, microphone, external approval service, or native Codex runtime is claimed. Those rejection/approval/voice contracts use the real policy owners with existing controlled fixtures. Initial test wiring, expected lifecycle item counts, cancellation outcome assumptions, and static type/brace issues were corrected without loosening assertions or policy. Three baseline Gateway fixture attempts failed on assumptions about fresh reconciliation context, public-history representation, and collapsed UI groups; the successful before and after used identical final driver assertions. Reconciliation's existing fresh-context behavior and broader effect journaling are outside this repair. No timeout, budget, baseline, or dependency was increased to make proof pass.

**Size:** production **+25/-13 (net +12)**; tests/support **+880/-98 (net +782)**; docs **+8/-1 (net +7)**, 11 files. Production growth is the exact producer registration and relay capability; the obsolete generic-entry veto and unused terminal binding are removed. No unrelated compression, branding-only class, broad exception wrapper, or new policy framework remains.

Thanks to @zhangguiping-xydt for the original repair and @tylerbrevard for the report. Preserve contributor credit: `Co-authored-by: zhang-guiping <zhang.guiping@xydigit.com>`.

## Delivery and CI repair

The unchanged host-denial rewrite was published at `a6f5cd6d1082895aa8443ecc00a593675fbedf1e`. [Initial CI run 33167002494, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33167002494) failed in [checks-node-compact-large-28](https://github.com/openclaw/openclaw/actions/runs/33167002494/job/98834849323): `src/agents/embedded-agent-subscribe.raw-stream.test.ts:60` read an empty file before its asynchronous append completed. This existing test waited only for file creation; the real `appendRegularFile` dependency still awaits stat/chmod/append after creating the file. The failure was not introduced by the host-denial repair.

Test-only commit `856e32ec9623b17a53401c8b6a6d718806d1883a` moves the **same exact-content assertion** into the existing `vi.waitFor`, preserving its timeout, payload/newline, real dependency, original test order, and unhandled-rejection check. A brief comment records the ordering. No runtime change, new seam, weaker assertion, timeout increase, or dependency change.

```bash
OPENCLAW_VITEST_MAX_WORKERS=4 node scripts/run-vitest.mjs src/agents/embedded-agent-subscribe.raw-stream.test.ts
node scripts/check-changed.mjs -- src/agents/embedded-agent-subscribe.raw-stream.test.ts
```

The full four-test file passed five consecutive runs (20 executions, **four distinct tests**): 5.90s, 1.89s, 1.88s, 1.82s, 1.84s. Focused changed-file gates and formatting passed. Fresh isolated autoreview of this 1080-byte test diff passed at the configured **P0-only** threshold (0.99); no broader-priority claim. All original ten file hashes remain unchanged, so their 419-test/build/Gateway evidence is retained. Total: **423 distinct tests across 18 files** across these local proofs.

Current published head: `126d49817728e4bb167a540ceed30e81ef328414`. A native wrapper guard required one mechanical rebase onto `d3a5f2333e607a2ed3bced0a3a4124922a142869`. All eleven accepted file hashes and the complete PR patch remain byte-identical. Focused rebase sanity passed 117 tests across five files in 46.82 seconds; no semantic conflict or source edit. The small CI synchronization repair is accepted in the same PR; the first red CI remains historical evidence, not a claimed pass. Final exact-head CI, native preparation, and native merge passed. One ClawSweeper re-review was already requested after the producer rewrite; no duplicate request was made for this test-only correction. The earlier production-growth concern is addressed by the private producer/relay justification above, and the stale terminal binding is removed.

AI-assisted maintainer rewrite; original contributor credit preserved. No CHANGELOG edit (release-generated).

**Land-ready proof:** [CI 33168351604, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33168351604) completed successfully on `126d49817728e4bb167a540ceed30e81ef328414`; [required openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33168351604/job/98842353038) is SUCCESS. The bounded native watcher exited0 GREEN. Native review-init → main baseline → PR-head checkout → artifact validation passed, then `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 131007` passed hosted gates and confirmed the remote branch already equals the prepared head (no extra push). No hosted gate override, CI rerun, or extra remote machine was used. Interim CI33168174283 was cancelled when the required tooling rebase superseded it; initial CI33167002494 remains a recorded failure. A metadata-only ClawSweeper dispatch cancellation briefly stopped the rollup watcher; the documented `--completion ci-run` mode tracked the actual CI workflow while native required-check validation remained intact.

Latest ClawSweeper review (2026-08-28 11:53 UTC) now covers the exact final head: https://github.com/openclaw/openclaw/pull/131007#issuecomment-5442281657. No actionable findings; all38 host-denial tests passed in its verification. Maintainer accepts the net+12 private producer/relay boundary with exact-object/one-shot containment tests intact. Its remaining exact-head CI requirement is satisfied by run33168351604. No literal Rank-up moves list or unresolved code finding remains.

**Landed:** [0e16f347ea9b3babe72caab918572b5a62c5f7f7](https://github.com/openclaw/openclaw/commit/0e16f347ea9b3babe72caab918572b5a62c5f7f7) via `scripts/pr merge-run 131007`. All eleven merged/main file hashes and the full landed patch match the accepted candidate; exact contributor trailer verified in the actual squash. The same focused117-test/five-file suite passed again on landed main in42.11s. Issue130274 auto-closed. Native cleanup removed the PR worktree; a fork-branch deletion404 warning was not retried.
