### PR TITLE
fix(device-pair): verify retained subscribers before archiving the migration source

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -229,6 +229,8 @@ the container normally.
 
 `openclaw doctor --fix` is the only owner for persistent file-to-SQLite migrations. It validates and claims each recognized source, writes and verifies canonical rows, records a migration receipt, then removes the retired source. Runtime code does not perform lazy imports or fallback reads.
 
+Device Pair and Active Memory legacy JSON imports check namespace capacity before writing. If the missing entries do not fit, doctor warns and leaves the source unchanged. These imports also verify that source keys and pre-existing destination keys remain in SQLite before reporting completion and archiving the source. A retention warning keeps the source available for inspection and retry; do not delete it to silence the warning, because it may contain state that SQLite did not retain. Resolve the capacity problem before rerunning `openclaw doctor --fix`.
+
 Doctor also reports when shared auth still uses the legacy `agents/main/agent/openclaw-agent.sqlite` owner. `openclaw doctor --fix` copies its auth profile and runtime-state rows into `state/openclaw.sqlite`, verifies the exact payloads, removes the source rows, and records the new ownership only after the transaction succeeds. Auth resolution has no dual-read fallback: before migration the legacy database is complete; after migration the shared state database is complete. Once relocated, deleting `main` no longer risks fleet credentials.
 
 For the retired QMD memory backend, including config rewrites and derived

--- a/extensions/active-memory/doctor-contract-api.test.ts
+++ b/extensions/active-memory/doctor-contract-api.test.ts
@@ -69,6 +69,45 @@ describe("active-memory doctor state migration", () => {
     await fs.rm(stateDir, { recursive: true, force: true });
   });
 
+  it("preserves oversized legacy opt-outs without writing or archiving on repeated repairs", async () => {
+    const sourcePath = path.join(stateDir, "plugins", "active-memory", "session-toggles.json");
+    await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+    const source = JSON.stringify({
+      sessions: Object.fromEntries(
+        Array.from({ length: 10_001 }, (_, index) => [
+          `session-${index}`,
+          { disabled: true, updatedAt: index + 1 },
+        ]),
+      ),
+    });
+    await fs.writeFile(sourcePath, source);
+    const migration = expectDefined(stateMigrations[0], "active-memory state migration");
+    const params = {
+      config: {},
+      env,
+      stateDir,
+      oauthDir: path.join(stateDir, "oauth"),
+      context: createDoctorContext(env),
+    };
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      await expect(migration.migrateLegacyState(params)).resolves.toEqual({
+        changes: [],
+        warnings: [
+          "Skipped Active Memory session toggle migration because plugin state has room for 10000 of 10001 missing entries; left legacy source in place",
+        ],
+      });
+      await expect(
+        params.context
+          .openPluginStateKeyedStore({ namespace: "session-toggles", maxEntries: 10_000 })
+          .entries(),
+      ).resolves.toEqual([]);
+      await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe(source);
+      await expect(fs.access(`${sourcePath}.migrated`)).rejects.toThrow();
+      await expect(migration.detectLegacyState(params)).resolves.not.toBeNull();
+    }
+  });
+
   it("imports legacy session opt-outs into plugin state", async () => {
     const sourcePath = path.join(stateDir, "plugins", "active-memory", "session-toggles.json");
     await fs.mkdir(path.dirname(sourcePath), { recursive: true });

--- a/extensions/device-pair/doctor-contract-api.test.ts
+++ b/extensions/device-pair/doctor-contract-api.test.ts
@@ -157,12 +157,17 @@ describe("device-pair doctor notify migration", () => {
     await expect(store.lookup(notifySubscriberStoreKey(first))).resolves.toEqual(canonical);
   });
 
-  it("imports legacy notify subscribers into plugin state", async () => {
+  it.each([
+    {},
+    { accountId: "telegram-default" },
+    { messageThreadId: 271 },
+    { accountId: "telegram-default", messageThreadId: 0 },
+    { accountId: "telegram-default", messageThreadId: "271" },
+  ])("imports legacy notify subscribers into plugin state (%j)", async (target) => {
     const sourcePath = path.join(stateDir, DEVICE_PAIR_NOTIFY_LEGACY_STATE_FILE);
     const subscriber: NotifySubscription = {
       to: "chat-123",
-      accountId: "telegram-default",
-      messageThreadId: 271,
+      ...target,
       mode: "persistent",
       addedAtMs: 1,
     };

--- a/extensions/device-pair/doctor-contract-api.test.ts
+++ b/extensions/device-pair/doctor-contract-api.test.ts
@@ -57,6 +57,106 @@ describe("device-pair doctor notify migration", () => {
     };
   }
 
+  function openSubscribers() {
+    return createDoctorContext(env).openPluginStateKeyedStore<NotifySubscription>({
+      namespace: DEVICE_PAIR_NOTIFY_SUBSCRIBER_NAMESPACE,
+      maxEntries: DEVICE_PAIR_NOTIFY_SUBSCRIBER_MAX_ENTRIES,
+    });
+  }
+
+  function legacySubscribers(count: number): NotifySubscription[] {
+    return Array.from({ length: count }, (_, index) => ({
+      to: `chat-${index}`,
+      accountId: "telegram-default",
+      messageThreadId: 271,
+      mode: "persistent",
+      addedAtMs: index + 1,
+    }));
+  }
+
+  it.each([1023, 1024])("retains and archives %i legacy subscribers", async (count) => {
+    const sourcePath = path.join(stateDir, DEVICE_PAIR_NOTIFY_LEGACY_STATE_FILE);
+    const subscribers = legacySubscribers(count);
+    await fs.writeFile(sourcePath, JSON.stringify({ subscribers }));
+    const migration = expectDefined(stateMigrations[0], "device-pair state migration");
+
+    const result = await migration.migrateLegacyState(migrationParams());
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      `Migrated Device Pair notify subscribers -> plugin state (${count} imported, 0 already present)`,
+      expect.stringContaining("Archived Device Pair notify-state legacy source"),
+    ]);
+    expect((await openSubscribers().entries()).map(({ key }) => key).toSorted()).toEqual(
+      subscribers.map(notifySubscriberStoreKey).toSorted(),
+    );
+    await expect(fs.access(sourcePath)).rejects.toThrow();
+    await expect(fs.access(`${sourcePath}.migrated`)).resolves.toBeUndefined();
+    await expect(migration.detectLegacyState(migrationParams())).resolves.toBeNull();
+  });
+
+  it.each([0, 1])(
+    "refuses overflow without losing source or destination rows (%i existing)",
+    async (existingCount) => {
+      const sourcePath = path.join(stateDir, DEVICE_PAIR_NOTIFY_LEGACY_STATE_FILE);
+      const subscribers = legacySubscribers(1025 - existingCount);
+      const source = JSON.stringify({ subscribers });
+      await fs.writeFile(sourcePath, source);
+      const store = openSubscribers();
+      if (existingCount) {
+        await store.register("existing", { to: "existing", mode: "once", addedAtMs: 0 });
+      }
+      const before = await store.entries();
+      const migration = expectDefined(stateMigrations[0], "device-pair state migration");
+
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const result = await migration.migrateLegacyState(migrationParams());
+        expect({ result, retained: (await store.entries()).length }).toEqual({
+          result: {
+            changes: [],
+            warnings: [expect.stringContaining("left legacy source in place")],
+          },
+          retained: existingCount,
+        });
+        expect(await store.entries()).toEqual(before);
+        await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe(source);
+        await expect(fs.access(`${sourcePath}.migrated`)).rejects.toThrow();
+        await expect(migration.detectLegacyState(migrationParams())).resolves.not.toBeNull();
+      }
+      if (existingCount) {
+        await store.delete("existing");
+        const result = await migration.migrateLegacyState(migrationParams());
+        expect(result.warnings).toEqual([]);
+        expect((await store.entries()).map(({ key }) => key).toSorted()).toEqual(
+          subscribers.map(notifySubscriberStoreKey).toSorted(),
+        );
+        await expect(fs.readFile(`${sourcePath}.migrated`, "utf8")).resolves.toBe(source);
+        await expect(migration.detectLegacyState(migrationParams())).resolves.toBeNull();
+      }
+    },
+  );
+
+  it("counts distinct missing keys and preserves existing subscriber values", async () => {
+    const sourcePath = path.join(stateDir, DEVICE_PAIR_NOTIFY_LEGACY_STATE_FILE);
+    const subscribers = legacySubscribers(1024);
+    const first = expectDefined(subscribers[0], "first subscriber");
+    const canonical = { ...first, mode: "once" as const };
+    const store = openSubscribers();
+    await store.register(notifySubscriberStoreKey(first), canonical);
+    await fs.writeFile(sourcePath, JSON.stringify({ subscribers: [...subscribers, first] }));
+    const migration = expectDefined(stateMigrations[0], "device-pair state migration");
+
+    const result = await migration.migrateLegacyState(migrationParams());
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      "Migrated Device Pair notify subscribers -> plugin state (1023 imported, 2 already present)",
+      expect.stringContaining("Archived Device Pair notify-state legacy source"),
+    ]);
+    expect(await store.entries()).toHaveLength(1024);
+    await expect(store.lookup(notifySubscriberStoreKey(first))).resolves.toEqual(canonical);
+  });
+
   it("imports legacy notify subscribers into plugin state", async () => {
     const sourcePath = path.join(stateDir, DEVICE_PAIR_NOTIFY_LEGACY_STATE_FILE);
     const subscriber: NotifySubscription = {

--- a/extensions/device-pair/doctor-contract-api.ts
+++ b/extensions/device-pair/doctor-contract-api.ts
@@ -25,6 +25,10 @@ export const stateMigrations: PluginDoctorStateMigration[] = [
     parse: normalizeLegacyNotifyState,
     namespace: DEVICE_PAIR_NOTIFY_SUBSCRIBER_NAMESPACE,
     maxEntries: DEVICE_PAIR_NOTIFY_SUBSCRIBER_MAX_ENTRIES,
+    capacityPrecheck: {
+      warning: ({ available, missing }) =>
+        `Skipped Device Pair notify subscriber migration because plugin state has room for ${available} of ${missing} missing entries; left legacy source in place`,
+    },
     archiveLabel: "Device Pair notify-state",
     describeEntries: (state, { filePath }) => ({
       preview: [

--- a/extensions/device-pair/notify-state.ts
+++ b/extensions/device-pair/notify-state.ts
@@ -61,8 +61,8 @@ export function normalizeLegacyNotifyState(raw: unknown): LegacyNotifyStateFile 
         : Date.now();
     subscribers.push({
       to,
-      accountId,
-      messageThreadId,
+      ...(accountId ? { accountId } : {}),
+      ...(messageThreadId != null ? { messageThreadId } : {}),
       mode,
       addedAtMs,
     });

--- a/src/plugin-sdk/runtime-doctor-migrations.test.ts
+++ b/src/plugin-sdk/runtime-doctor-migrations.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelLegacyStateMigrationPlan } from "../channels/plugins/legacy-state-migration.types.js";
-import { definePluginDoctorMigrationFromPlans } from "./runtime-doctor-migrations.js";
+import {
+  createPluginStateKeyedStore,
+  resetPluginStateStoreForTests,
+} from "../plugin-state/plugin-state-store.js";
+import {
+  defineLegacyJsonStateMigration,
+  definePluginDoctorMigrationFromPlans,
+  type PluginDoctorStateMigrationContext,
+} from "./runtime-doctor-migrations.js";
 
 const runLegacyMigrationPlans = vi.hoisted(() => vi.fn());
 const executorModuleLoads = vi.hoisted(() => vi.fn());
@@ -8,6 +19,69 @@ const executorModuleLoads = vi.hoisted(() => vi.fn());
 vi.mock("../infra/state-migrations.plugin-state.js", () => {
   executorModuleLoads();
   return { runLegacyMigrationPlans };
+});
+
+describe("defineLegacyJsonStateMigration retention", () => {
+  let stateDir: string;
+  let env: NodeJS.ProcessEnv;
+  let context: PluginDoctorStateMigrationContext;
+
+  beforeEach(async () => {
+    resetPluginStateStoreForTests();
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-json-migration-"));
+    env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    context = {
+      openPluginStateKeyedStore: (options) =>
+        createPluginStateKeyedStore("migration-fixture", { ...options, env }),
+    };
+  });
+
+  afterEach(async () => {
+    resetPluginStateStoreForTests();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it.each(["imported", "pre-existing"])(
+    "preserves the source and warns when a row is evicted (%s)",
+    async (evicted) => {
+      const sourcePath = path.join(stateDir, "legacy.json");
+      const rows = ["first", "second", ...(evicted === "imported" ? ["third"] : [])].map((key) => ({
+        key,
+        value: key,
+      }));
+      const source = JSON.stringify(rows);
+      await fs.writeFile(sourcePath, source);
+      const store = context.openPluginStateKeyedStore({ namespace: "entries", maxEntries: 2 });
+      if (evicted === "pre-existing") {
+        await store.register("existing", "canonical");
+      }
+      const migration = defineLegacyJsonStateMigration({
+        id: "retention-fixture",
+        label: "Fixture entries",
+        resolvePath: () => sourcePath,
+        parse: (value) => value as typeof rows,
+        namespace: "entries",
+        maxEntries: 2,
+        describeEntries: () => ({
+          preview: ["legacy entries"],
+          change: ({ imported }) => `Migrated ${imported} entries`,
+        }),
+        toRows: (entries) => entries,
+      });
+      const params = { config: {}, env, stateDir, oauthDir: stateDir, context };
+
+      const result = await migration.migrateLegacyState(params);
+
+      expect(await store.entries()).toHaveLength(2);
+      expect(result).toEqual({
+        changes: [],
+        warnings: [expect.stringContaining("failed to retain every required entry (1 missing)")],
+      });
+      await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe(source);
+      await expect(fs.access(`${sourcePath}.migrated`)).rejects.toThrow();
+      await expect(migration.detectLegacyState(params)).resolves.not.toBeNull();
+    },
+  );
 });
 
 const migrationInput = {

--- a/src/plugin-sdk/runtime-doctor-migrations.ts
+++ b/src/plugin-sdk/runtime-doctor-migrations.ts
@@ -369,8 +369,8 @@ export function defineLegacyJsonStateMigration<TSource>(params: {
         maxEntries: params.maxEntries,
         ...(params.overflowPolicy ? { overflowPolicy: params.overflowPolicy } : {}),
       });
+      const existingKeys = new Set((await store.entries()).map((entry) => entry.key));
       if (params.capacityPrecheck) {
-        const existingKeys = new Set((await store.entries()).map((entry) => entry.key));
         const missingKeys = new Set(
           rows.map((row) => row.key).filter((key) => !existingKeys.has(key)),
         );
@@ -385,6 +385,17 @@ export function defineLegacyJsonStateMigration<TSource>(params: {
         if (await store.registerIfAbsent(row.key, row.value)) {
           imported++;
         }
+      }
+      // Successful inserts can evict earlier rows. Verify source and existing keys
+      // before reporting completion or removing the source from future doctor runs.
+      const retainedKeys = new Set((await store.entries()).map((entry) => entry.key));
+      const expectedKeys = new Set([...existingKeys, ...rows.map((row) => row.key)]);
+      const missing = [...expectedKeys].filter((key) => !retainedKeys.has(key)).length;
+      if (missing > 0) {
+        warnings.push(
+          `Incomplete ${params.label} migration: plugin state failed to retain every required entry (${missing} missing); left legacy source in place`,
+        );
+        return { changes, warnings };
       }
       const change = description.change({
         imported,


### PR DESCRIPTION
> **REVIEW REQUIRED — persistent-state retention semantics. Prepared by the auto-QA campaign; intentionally left as a draft for maintainer review, not autonomous landing.**

## What Problem This Solves

Device Pair's doctor migration could silently lose subscribers and still report success. The legacy `device-pair-notify.json` writer (stable v2026.6.1 `notify.ts:218-239`) appended unique subscribers without a cap, but the migration imports into a keyed-store namespace capped at 1,024 rows with `evict-oldest` semantics — and `pluginStateRegisterIfAbsent` returns `true` even when the insert evicted an older row. The shared importer counted successes and archived the source. With 1,025 legacy subscribers: all 1,025 report imported, one is silently gone, the source is renamed `.migrated`, and reruns can no longer discover it. The evicted subscriber stops receiving pairing notifications with no record anywhere (audit finding F-D2; defect originated in `ba447d5afc1`, survived the importer consolidation in `10e60fa0ce6`).

## Why This Change Was Made

The completion/archive boundary is the owner — not the store's eviction policy, which is unchanged. Two established sibling patterns are applied:

1. **Capacity precheck** (Active Memory's existing pattern, `extensions/active-memory/doctor-contract-api.ts:101`): Device Pair now opts into the shared importer's distinct-missing-key precheck — over-capacity input produces a visible warning, zero writes, and a preserved source.
2. **Retained-key verification before archive** (the older plan executor's pattern, `src/infra/state-migrations.plugin-state.ts:448-480`): the shared importer now reads initial destination keys once and verifies the union of initial + source keys after insertion. Missing keys — including eviction of an unrelated pre-existing canonical row — produce an incomplete-migration warning, no success message, and no archive, so the detector still finds the source on rerun.

No changes to `evict-oldest`, `registerIfAbsent`'s contract, the 1,024 cap, schema, or config surface. Warnings flow through the existing doctor boundaries; `docs/cli/doctor.md` documents the operator-visible behavior.

## User Impact

An operator upgrading with more than 1,024 legacy Device Pair subscribers now gets a visible doctor warning with the source preserved for retry, instead of a silently truncated subscriber list and a falsely completed migration. Full behavior matrix (under/at/over cap, seeded destination, duplicate keys, retry semantics, Active Memory 10k-cap unchanged, cache-only no-op) is in the test suite and worker report.

## Evidence

- Failing-first at both layers: Device Pair contract tests pre-fix **2 failed** (1,025 sources → "1025 imported", archive emitted, no warning, 1,024 rows retained; seeded-destination case falsely archived); shared-importer tests pre-fix **2 failed** (real SQLite eviction cases reported success). Post-fix: 15/15 focused.
- Broad suites: 669 passed / 3 platform skips across infra migrations, plugin-sdk, Device Pair (87), Active Memory.
- `check-changed` on all touched files: exit 0 (typecheck lanes, SDK surface/boundary checks, guards, targeted lint — one `.sort()`→`.toSorted()` lint correction in tests).
- Codex autoreview: clean, no findings (re-run after the frozen-bundle correction).
- LOC: production +17 (`doctor-contract-api.ts` +4, shared importer +13), tests +217, docs +2.
