### PR TITLE
fix(update): LaunchAgent refresh no longer self-identifies as Gateway

### DIFF
--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -387,9 +387,15 @@ describe("successful update finalization ordering", () => {
     }
   });
 
-  it("removes inherited operator overrides from the managed install environment", async () => {
+  it("removes operator overrides and process identity from the managed install environment", async () => {
     const programArguments = ["/usr/bin/node", "/tmp/openclaw-update/dist/index.js", "gateway"];
-    const managedEnvironment = { ANTHROPIC_API_KEY: "managed-provider", MANAGED_VALUE: "base" };
+    const managedEnvironment = {
+      ANTHROPIC_API_KEY: "managed-provider",
+      MANAGED_VALUE: "base",
+      OPENCLAW_SERVICE_MARKER: "openclaw",
+      OPENCLAW_SERVICE_KIND: "gateway",
+      OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.work",
+    };
     const effectiveEnvironment = {
       ...managedEnvironment,
       ANTHROPIC_API_KEY: "drop-in-provider",
@@ -438,6 +444,9 @@ describe("successful update finalization ordering", () => {
       expect(installEnv?.OPENCLAW_PROFILE).toBeUndefined();
       expect(installEnv?.OPENCLAW_STATE_DIR).toBeUndefined();
       expect(installEnv?.OPENCLAW_CONFIG_PATH).toBeUndefined();
+      expect(installEnv?.OPENCLAW_SERVICE_MARKER).toBeUndefined();
+      expect(installEnv?.OPENCLAW_SERVICE_KIND).toBeUndefined();
+      expect(installEnv?.OPENCLAW_LAUNCHD_LABEL).toBe("ai.openclaw.work");
     } finally {
       vi.unstubAllEnvs();
     }

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -53,6 +53,7 @@ import {
   resolveUpdatedGatewayRestartPort,
   restoreWindowsTaskAutoStartOrExit,
   shouldPrepareUpdatedInstallRestart,
+  stripGatewayServiceMarkerEnv,
   tryInstallShellCompletion,
   type PreManagedServiceStop,
 } from "./update-command-service.js";
@@ -428,6 +429,9 @@ export async function finishUpdate(params: {
           serviceState.command,
           params.ownedManagedUpdateEnv ?? process.env,
         );
+        if (gatewayServiceInstallEnv) {
+          gatewayServiceInstallEnv = stripGatewayServiceMarkerEnv(gatewayServiceInstallEnv);
+        }
         gatewayPort = resolveUpdatedGatewayRestartPort({
           config: restartConfigSnapshot.valid ? restartConfigSnapshot.config : undefined,
           processEnv: process.env,


### PR DESCRIPTION
Closes #131011

## What Problem This Solves

Fixes an issue where operators updating a managed macOS source install would see post-update LaunchAgent environment refresh fail because the updated child incorrectly identified itself as the running Gateway service.

The core update and Doctor work could complete, but final service convergence logged `Refusing to install LaunchAgent ai.openclaw.gateway from inside ai.openclaw.gateway` and required an external recovery path.

## Why This Change Was Made

After reconstructing the managed service install environment, update finalization now applies the existing Gateway process-marker scrubber. This removes process-only service identity while preserving the LaunchAgent label and other selectors required to refresh the intended managed definition.

The repair stays at the environment-ownership boundary and adds no config, schema, protocol, or timeout behavior.

## User Impact

Managed macOS source/dev updates can refresh their LaunchAgent definition without treating the post-update child as an in-service self-install. Operators no longer hit this finalization error or need standalone service recovery for this cause.

## Evidence

- Real before-fix observation on macOS 26.6.2 / Apple Silicon after updating to exact source commit `50629db9f00aeade24b301682016351fe7e34737`: post-update service refresh failed with the self-install refusal recorded in #131011.
- Real after-fix managed-LaunchAgent proof on the same macOS 26.6.2 / Apple Silicon host at exact PR head `51a6cf0f198ba74936ea9a25f5c438adf8bfc79a`: the production updater stopped the owned LaunchAgent, completed its source build and Doctor, spawned the updated child as `<node> <pr-worktree>/dist/index.js gateway install --force`, and exited 0 with `Gateway: restarted and verified.` and `Update Result: OK` in 464.78 seconds. There was no self-install refusal and no service-refresh failure.
- Post-refresh verification at the same PR head: LaunchAgent loaded/running after a second supervisor run; `/health` returned `{"ok":true,"status":"live"}`; `/readyz` returned `ready:true` with no failing checks; deep read-only RPC was healthy and reported build ID `2026.8.1-51a6cf0f198b-2026-08-27T21-39-42.829Z`; config audit was clean; plugin drift was empty; plugin Doctor passed; runtime health reported 19 loaded plugins with zero errors/unavailable; and the config SHA-256 was unchanged from the pre-proof snapshot. A redacted transcript is attached in the PR comments.
- The extended managed-install boundary regression fails on current `main` because the reconstructed install environment contains `OPENCLAW_SERVICE_MARKER="openclaw"`; it passes with the fix while proving `OPENCLAW_LAUNCHD_LABEL` remains intact.
- `node scripts/run-vitest.mjs src/cli/update-cli/update-command-post-update.test.ts` — 13 passed at exact PR head after the real proof.
- `node scripts/run-vitest.mjs src/cli/update-cli` — 214 passed, 1 skipped.
- `node scripts/check-changed.mjs -- src/cli/update-cli/update-command-post-update.ts src/cli/update-cli/update-command-post-update.test.ts` — passed.
- Repository autoreview: no accepted/actionable findings; patch assessed correct with 0.99 confidence.

Production delta: +4/−0. Test delta: +11/−2. The production growth reuses the existing marker scrubber after the managed-definition merge; no new helper or test-only seam was added.

AI-assisted: yes. I reviewed the implementation and understand the environment ownership and LaunchAgent safety boundary.
