### PR TITLE
feat(cli): limit docs search results

### DIFF
--- a/docs/cli/docs.md
+++ b/docs/cli/docs.md
@@ -26,6 +26,8 @@ openclaw docs <query...> [--json] [--limit <count>]
 
 With no query, `openclaw docs` prints the docs entrypoint URL and a sample search command instead of running a search.
 
+Omit `--limit` to show all results returned by the search service. The limit applies to displayed results and does not reduce the downloaded response size.
+
 ## Examples
 
 ```bash

--- a/docs/cli/docs.md
+++ b/docs/cli/docs.md
@@ -15,13 +15,14 @@ Search the live OpenClaw docs index from the terminal.
 ```bash
 openclaw docs                              # print docs entrypoint and example search
 openclaw docs --json                       # print the same guidance as JSON
-openclaw docs <query...> [--json]          # search the live docs index
+openclaw docs <query...> [--json] [--limit <count>]
 ```
 
-| Argument/option | Description                                                                        |
-| --------------- | ---------------------------------------------------------------------------------- |
-| `[query...]`    | Free-form search query. Multi-word queries are joined with spaces and sent as one. |
-| `--json`        | Emit one machine-readable JSON object on stdout.                                   |
+| Argument/option   | Description                                                                        |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| `[query...]`      | Free-form search query. Multi-word queries are joined with spaces and sent as one. |
+| `--json`          | Emit one machine-readable JSON object on stdout.                                   |
+| `--limit <count>` | Return at most this many results. The value must be a positive integer.            |
 
 With no query, `openclaw docs` prints the docs entrypoint URL and a sample search command instead of running a search.
 
@@ -30,6 +31,7 @@ With no query, `openclaw docs` prints the docs entrypoint URL and a sample searc
 ```bash
 openclaw docs browser existing-session
 openclaw docs browser existing-session --json
+openclaw docs plugin --limit 5
 openclaw docs sandbox allowHostControl
 openclaw docs gateway token secretref
 ```

--- a/src/cli/docs-cli.ts
+++ b/src/cli/docs-cli.ts
@@ -5,6 +5,7 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import { docsSearchCommand } from "../commands/docs.js";
 import { defaultRuntime } from "../runtime.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
+import { parseStrictPositiveIntOption } from "./program/helpers.js";
 
 export function registerDocsCli(program: Command) {
   program
@@ -12,14 +13,20 @@ export function registerDocsCli(program: Command) {
     .description("Search the live OpenClaw docs")
     .argument("[query...]", "Search query")
     .option("--json", "Output JSON", false)
+    .option("--limit <count>", "Maximum results to return", (value: string) =>
+      parseStrictPositiveIntOption(value, "--limit"),
+    )
     .addHelpText(
       "after",
       () =>
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/docs", "docs.openclaw.ai/cli/docs")}\n`,
     )
-    .action(async (queryParts: string[], opts: { json?: boolean }) => {
+    .action(async (queryParts: string[], opts: { json?: boolean; limit?: number }) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
-        await docsSearchCommand(queryParts, defaultRuntime, { json: Boolean(opts.json) });
+        await docsSearchCommand(queryParts, defaultRuntime, {
+          json: Boolean(opts.json),
+          limit: opts.limit,
+        });
       });
     });
 }

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -101,6 +101,7 @@ describe("docsSearchCommand", () => {
       new Response(
         JSON.stringify({
           results: [
+            { title: "Invalid result without a link" },
             { title: "CLI reference", link: "https://docs.openclaw.ai/cli" },
             { title: "Plugin guide", link: "https://docs.openclaw.ai/plugins" },
           ],

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -96,6 +96,27 @@ describe("docsSearchCommand", () => {
     });
   });
 
+  it("limits normalized search results before rendering", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          results: [
+            { title: "CLI reference", link: "https://docs.openclaw.ai/cli" },
+            { title: "Plugin guide", link: "https://docs.openclaw.ai/plugins" },
+          ],
+        }),
+      ),
+    );
+    const runtime = makeRuntime();
+
+    await docsSearchCommand(["openclaw"], runtime, { json: true, limit: 1 });
+
+    expect(JSON.parse(String(runtime.log.mock.calls[0]?.[0]))).toEqual({
+      query: "openclaw",
+      results: [{ title: "CLI reference", link: "https://docs.openclaw.ai/cli" }],
+    });
+  });
+
   it("emits one JSON object for the docs homepage", async () => {
     const runtime = makeRuntime();
 

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -122,7 +122,7 @@ function parseDocsSearchResults(raw: unknown): DocResult[] {
 export async function docsSearchCommand(
   queryParts: string[],
   runtime: RuntimeEnv,
-  options: { json?: boolean } = {},
+  options: { json?: boolean; limit?: number } = {},
 ) {
   const query = queryParts.join(" ").trim();
   if (!query) {
@@ -151,6 +151,9 @@ export async function docsSearchCommand(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Docs search failed: ${message}`, { cause: error });
+  }
+  if (options.limit !== undefined) {
+    results = results.slice(0, options.limit);
   }
 
   if (options.json) {


### PR DESCRIPTION
Closes #141956

## What Problem This Solves

Resolves a problem where operators and scripts using `openclaw docs` could not bound the number of search results, producing more output than needed for focused terminal and JSON workflows.

## Why This Change Was Made

Add a strict positive-integer `--limit <count>` option at the CLI boundary and apply it after the live docs response is normalized. The current search endpoint ignores a `limit` query parameter, so client-side slicing preserves the existing request contract and output ordering.

## User Impact

Operators can now request a predictable maximum number of docs results in both human-readable and JSON output. Invalid fractional, zero, and negative values fail with the existing CLI integer validation.

## Evidence

- Parent-red: the focused result-limit regression returned 2 results when 1 was requested.
- Exact-branch green: `pnpm vitest run src/commands/docs.test.ts` (`9 passed`).
- Real CLI: `pnpm openclaw docs plugin --limit 3 --json` returned exactly 3 normalized results.
- Live API preflight confirmed the server currently ignores `limit=3`, validating the owner choice to slice locally.
- Invalid real CLI input `--limit 1.5` exited 1 with the positive-integer error.
- Docs MDX validation passed for 792 files; formatting and `git diff --check` passed.
- Autoreview completed cleanly with no actionable findings.
- Runtime LOC: `+13/-3` (net `+10`); tests: `+21/-0`; docs: `+7/-5`.
- AI-assisted: yes. I reviewed the CLI, command, and live response behavior and understand the change.

### After-fix CLI proof (2026-08-28)

Ran the built CLI from PR head `5b620155666b4e7c71d6ab30ceaa99e6ff1517a5` against the live docs search endpoint:

```console
$ pnpm openclaw docs plugin --limit 1 --json
{
  "query": "plugin",
  "results": [
    {
      "title": "Admin HTTP RPC plugin",
      "link": "https://docs.openclaw.ai/plugins/admin-http-rpc",
      "snippet": "Expose selected Gateway control-plane methods through the bundled, opt-in admin-http-rpc plugin"
    }
  ]
}
```

Exit status: `0`. The live response contains exactly one result, proving the new public flag at the actual CLI/output boundary.