### PR TITLE
fix(ui): keep retained chats visible after peer-tab deletion

### DIFF
--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import type { ApplicationContext } from "../app/context.ts";
 import {
   chatSessionListResponse,
   controlUiSessionUrl,
@@ -17,8 +18,114 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
+type ChatFlowTestApp = HTMLElement & { runtime?: { context: ApplicationContext } };
 
 suite.define(() => {
+  it("keeps an unrelated retained transcript after another tab deletes a session", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const sessionA = "agent:main:session-a";
+    const sessionB = "agent:main:session-b";
+    const deletedSession = "agent:main:session-c";
+    const sessionAText = "Session A survives the peer deletion.";
+    const sessionBText = "Session B keeps the first pane retained.";
+    const historyCases = {
+      cases: [
+        {
+          match: { sessionKey: sessionA },
+          response: {
+            messages: [{ role: "assistant", content: [{ type: "text", text: sessionAText }] }],
+            sessionId: "session-a",
+          },
+        },
+        {
+          match: { sessionKey: sessionB },
+          response: {
+            messages: [{ role: "assistant", content: [{ type: "text", text: sessionBText }] }],
+            sessionId: "session-b",
+          },
+        },
+      ],
+    };
+    const sessionListResponse = chatSessionListResponse([
+      { key: sessionA, kind: "direct", label: "Session A", updatedAt: 3 },
+      { key: sessionB, kind: "direct", label: "Session B", updatedAt: 2 },
+      { key: deletedSession, kind: "direct", label: "Session C", updatedAt: 1 },
+    ]);
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "chat.history": historyCases,
+        "chat.startup": historyCases,
+        "sessions.list": sessionListResponse,
+      },
+      sessionKey: sessionA,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionA));
+      await page.getByText(sessionAText, { exact: true }).waitFor({ timeout: 10_000 });
+
+      const sessionLink = (sessionKey: string) =>
+        page.locator(
+          `.sidebar-recent-session[data-session-key="${sessionKey}"] a.sidebar-recent-session__link`,
+        );
+      await sessionLink(sessionB).click();
+      await page.getByText(sessionBText, { exact: true }).waitFor({ timeout: 10_000 });
+      const historyRequestsBeforePeerDelete = (await gateway.getRequests("chat.history")).length;
+      const startupRequestsBeforePeerDelete = (await gateway.getRequests("chat.startup")).length;
+      await page.evaluate(() => {
+        window.addEventListener("storage", (event) => {
+          if (event.key === "openclaw.control.chatSnapshots.invalidate.v1") {
+            document.documentElement.dataset.snapshotInvalidationReceived = "true";
+          }
+        });
+      });
+
+      const peer = await context.newPage();
+      try {
+        await installMockGateway(peer, {
+          methodResponses: {
+            "sessions.delete": { deleted: true, ok: true },
+            "sessions.list": sessionListResponse,
+          },
+          sessionKey: deletedSession,
+        });
+        await peer.goto(`${suite.server.baseUrl}sessions`);
+        await peer.waitForFunction(() =>
+          Boolean((document.querySelector("openclaw-app") as ChatFlowTestApp).runtime),
+        );
+        await expect(
+          peer.evaluate(async (sessionKey) => {
+            const sessions = (document.querySelector("openclaw-app") as ChatFlowTestApp).runtime
+              ?.context.sessions;
+            if (!sessions) {
+              throw new Error("session capability unavailable");
+            }
+            return sessions.delete(sessionKey, { agentId: "main" });
+          }, deletedSession),
+        ).resolves.toMatchObject({ deleted: true });
+        await page.waitForFunction(
+          () => document.documentElement.dataset.snapshotInvalidationReceived === "true",
+        );
+      } finally {
+        await peer.close();
+      }
+
+      await sessionLink(sessionA).click();
+      await page.getByText(sessionAText, { exact: true }).waitFor({ timeout: 10_000 });
+      await Promise.all([
+        expectRequestCountStable(gateway, "chat.history", historyRequestsBeforePeerDelete),
+        expectRequestCountStable(gateway, "chat.startup", startupRequestsBeforePeerDelete),
+      ]);
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
   it("restores reasoning and tool activity after navigating away from a session", async () => {
     const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     if (artifactDir) {

--- a/ui/src/pages/chat/session-snapshot-invalidation-events.ts
+++ b/ui/src/pages/chat/session-snapshot-invalidation-events.ts
@@ -4,7 +4,6 @@ type SnapshotInvalidationListener = (invalidation: SnapshotInvalidation) => void
 
 const SNAPSHOT_INVALIDATION_STORAGE_KEY = "openclaw.control.chatSnapshots.invalidate.v1";
 const invalidationListeners = new Set<SnapshotInvalidationListener>();
-let broadcastVersion = 0;
 
 function notifySnapshotInvalidation(invalidation: SnapshotInvalidation): Promise<void> {
   return Promise.all(
@@ -12,16 +11,33 @@ function notifySnapshotInvalidation(invalidation: SnapshotInvalidation): Promise
   ).then(() => undefined);
 }
 
-function broadcastSnapshotInvalidation(): void {
+function broadcastSnapshotInvalidation(invalidation: SnapshotInvalidation): void {
   try {
-    localStorage.setItem(SNAPSHOT_INVALIDATION_STORAGE_KEY, String(++broadcastVersion));
+    localStorage.setItem(SNAPSHOT_INVALIDATION_STORAGE_KEY, JSON.stringify(invalidation));
     localStorage.removeItem(SNAPSHOT_INVALIDATION_STORAGE_KEY);
   } catch {}
 }
 
+function parseSnapshotInvalidation(value: string): SnapshotInvalidation {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      "sessionKey" in parsed &&
+      typeof parsed.sessionKey === "string" &&
+      parsed.sessionKey
+    ) {
+      return { sessionKey: parsed.sessionKey };
+    }
+  } catch {}
+  // Counter values from older tabs carried no scope, so they still retire every snapshot.
+  return {};
+}
+
 export function publishSnapshotInvalidation(invalidation: SnapshotInvalidation): Promise<void> {
   const notified = notifySnapshotInvalidation(invalidation);
-  broadcastSnapshotInvalidation();
+  broadcastSnapshotInvalidation(invalidation);
   return notified;
 }
 
@@ -33,10 +49,11 @@ export function subscribeSnapshotInvalidation(listener: SnapshotInvalidationList
 if (typeof window !== "undefined") {
   window.addEventListener("storage", (event) => {
     if (event.key === SNAPSHOT_INVALIDATION_STORAGE_KEY && event.newValue !== null) {
-      // The cross-tab signal carries no session identifiers; peers safely drop all memory state.
-      void notifySnapshotInvalidation({}).catch((error: unknown) => {
-        console.error("[chat-snapshot-cache] cross-tab invalidation failed", error);
-      });
+      void notifySnapshotInvalidation(parseSnapshotInvalidation(event.newValue)).catch(
+        (error: unknown) => {
+          console.error("[chat-snapshot-cache] cross-tab invalidation failed", error);
+        },
+      );
     }
   });
 }

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -15,7 +15,10 @@ import {
   CHAT_SNAPSHOT_METADATA_STORE_NAME,
   CHAT_SNAPSHOT_STORE_NAME,
 } from "./session-snapshot-database.ts";
-import { clearStoredChatSnapshots } from "./session-snapshot-invalidation.ts";
+import {
+  clearStoredChatSnapshots,
+  deleteStoredChatSnapshot,
+} from "./session-snapshot-invalidation.ts";
 import { SessionSnapshotStore } from "./session-snapshot-store.ts";
 
 function snapshot(message: unknown, sessionId = "session-1"): ChatSessionSnapshot {
@@ -433,7 +436,7 @@ describe("persistent chat session snapshots", () => {
     database.close();
   });
 
-  it("broadcasts invalidation and clears active memory for a peer-tab signal", async () => {
+  it("broadcasts invalidation and clears active memory for current and legacy peers", async () => {
     const sessionKey = "agent:main:cross-tab";
     const memoryCache: ChatMessageCache = new Map();
     const store = new SessionSnapshotStore(memoryCache);
@@ -450,27 +453,77 @@ describe("persistent chat session snapshots", () => {
 
     try {
       await clearStoredChatSnapshots();
-      expect(setItem).toHaveBeenCalledWith(
-        "openclaw.control.chatSnapshots.invalidate.v1",
-        expect.any(String),
-      );
+      const currentBroadcastValue = setItem.mock.calls.findLast(
+        ([key]) => key === "openclaw.control.chatSnapshots.invalidate.v1",
+      )?.[1];
+      if (currentBroadcastValue === undefined) {
+        throw new Error("expected full-cache invalidation broadcast");
+      }
+      expect(currentBroadcastValue).toBe("{}");
 
+      for (const peerValue of [currentBroadcastValue, "1"]) {
+        cacheChatSessionSnapshot(
+          memoryCache,
+          { assistantAgentId: "main", agentsList: null, hello: null },
+          { sessionKey },
+          snapshot("refilled"),
+        );
+        await store.flush();
+        window.dispatchEvent(
+          new StorageEvent("storage", {
+            key: "openclaw.control.chatSnapshots.invalidate.v1",
+            newValue: peerValue,
+          }),
+        );
+
+        expect(memoryCache.size).toBe(0);
+        expect(store.readSavedAt(sessionKey)).toBeNull();
+      }
+    } finally {
+      store.disconnect();
+      await store.whenIdle();
+    }
+  });
+
+  it("keeps unrelated peer-tab memory when one session snapshot is deleted", async () => {
+    const deletedSessionKey = "agent:main:deleted-in-peer";
+    const retainedSessionKey = "agent:main:retained-in-peer";
+    const memoryCache: ChatMessageCache = new Map();
+    const store = new SessionSnapshotStore(memoryCache);
+    store.connect();
+    observeChatCache(memoryCache, store);
+    const cacheSnapshot = (sessionKey: string) =>
       cacheChatSessionSnapshot(
         memoryCache,
         { assistantAgentId: "main", agentsList: null, hello: null },
         { sessionKey },
-        snapshot("refilled"),
+        snapshot(sessionKey),
       );
+    cacheSnapshot(deletedSessionKey);
+    cacheSnapshot(retainedSessionKey);
+    await store.flush();
+    const setItem = vi.spyOn(localStorage, "setItem");
+
+    try {
+      await deleteStoredChatSnapshot(deletedSessionKey);
+      const broadcastValue = setItem.mock.calls.findLast(
+        ([key]) => key === "openclaw.control.chatSnapshots.invalidate.v1",
+      )?.[1];
+      expect(broadcastValue).toBeDefined();
+
+      cacheSnapshot(deletedSessionKey);
       await store.flush();
       window.dispatchEvent(
         new StorageEvent("storage", {
           key: "openclaw.control.chatSnapshots.invalidate.v1",
-          newValue: "other-tab",
+          newValue: broadcastValue,
         }),
       );
 
-      expect(memoryCache.size).toBe(0);
-      expect(store.readSavedAt(sessionKey)).toBeNull();
+      expect(store.readSavedAt(deletedSessionKey)).toBeNull();
+      expect(store.readSavedAt(retainedSessionKey)).not.toBeNull();
+      expect(memoryCache.has(deletedSessionKey)).toBe(false);
+      expect(memoryCache.has(retainedSessionKey)).toBe(true);
     } finally {
       store.disconnect();
       await store.whenIdle();

--- a/ui/src/pages/chat/session-snapshot-store.ts
+++ b/ui/src/pages/chat/session-snapshot-store.ts
@@ -347,6 +347,7 @@ export class SessionSnapshotStore implements ChatCacheObserver {
     this.pending.delete(sessionKey);
     this.hydratedSnapshots.delete(sessionKey);
     this.savedAtBySession.delete(sessionKey);
+    this.memoryCache?.delete(sessionKey);
   }
 
   async flush(): Promise<void> {


### PR DESCRIPTION
Closes #131016

## What Problem This Solves

Fixes an issue where users returning to a retained chat would see an empty/new-session pane after an unrelated session was deleted in another Control UI tab. The transcript remained valid on the Gateway, but the peer deletion cleared every mounted chat projection in the first tab.

## Why This Change Was Made

Cross-tab snapshot invalidations now carry the optional session key that already scopes same-tab invalidations. The receiving boundary validates that payload, keeps credential/full-cache clears global, and treats legacy numeric or malformed signals as global for safe mixed-version behavior. Scoped invalidation also evicts the deleted session from memory without touching sibling transcripts.

**Simplicity proof:** the production change is +26/−8 lines. The net addition is the smallest owner-level protocol parser needed to preserve session scope across the browser storage boundary while retaining the existing global compatibility path; no reload, retry, or retained-pane special case was added.

## User Impact

Deleting Session C in another tab no longer blanks retained Session A. Returning to Session A is immediate and does not issue another `chat.history` or `chat.startup` request. The deleted session's persistent and in-memory snapshot state is still retired.

## Evidence

- Matched 1280×900 Chromium proof uses the same two-tab `sessions.delete` flow on base and the PR head; screenshots are attached below.

| Before — base treats Session C's deletion as global and Session A opens blank | After — scoped invalidation keeps Session A's retained transcript visible |
| --- | --- |
| ![Blank retained Session A after a peer-tab deletion](https://github.com/user-attachments/assets/efcc7963-4de7-4ad0-ad71-4904bf7a4655) | ![Retained Session A transcript preserved after a peer-tab deletion](https://github.com/user-attachments/assets/7d20934e-3759-46f1-8b87-b4b70e086c50) |

- `node scripts/run-vitest.mjs ui/src/pages/chat/session-snapshot-store.test.ts --reporter=dot` — 18/18 passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.history-recovery.e2e.test.ts --reporter=dot` — 8/8 passed after the final rebase.
- `node scripts/check-changed.mjs` — passed formatting, repository guards, dead-code, i18n, core/UI typechecks, and changed-file lint.
- Two consecutive native Codex reviews and one independent cold review were clean after all accepted findings were fixed.

AI-assisted: yes. I reviewed the implementation, reproduction, tests, and proof.
