### PR TITLE
fix: deliver slash command replies during active runs

### DIFF
--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -43,6 +43,7 @@ type DefineChatCommandInput = {
   category?: CommandCategory;
   /** Progressive disclosure tier. Defaults to "standard". */
   tier?: CommandTier;
+  activeRunSafe?: true;
 };
 
 /**
@@ -84,6 +85,7 @@ export function defineChatCommand(command: DefineChatCommandInput): ChatCommandD
     scope,
     category: command.category,
     tier: command.tier,
+    activeRunSafe: command.activeRunSafe,
   };
 }
 
@@ -258,6 +260,7 @@ export function buildBuiltinChatCommands(
     ),
     defineBuiltinCommand("status", "Show current status.", "status", "essential", {
       acceptsArgs: true,
+      activeRunSafe: true,
     }),
     defineBuiltinCommand("goal", "Show or control the current goal.", "status", "standard", {
       args: [
@@ -535,7 +538,9 @@ export function buildBuiltinChatCommands(
       ],
       argsMenu: "auto",
     }),
-    defineBuiltinCommand("stop", "Stop the current run.", "session", "essential"),
+    defineBuiltinCommand("stop", "Stop the current run.", "session", "essential", {
+      activeRunSafe: true,
+    }),
     defineBuiltinCommand("restart", "Restart OpenClaw.", "tools", "power"),
     defineBuiltinCommand("activation", "Set group activation mode.", "management", "power", {
       args: [
@@ -572,6 +577,7 @@ export function buildBuiltinChatCommands(
       ],
     }),
     defineBuiltinCommand("think", "Set thinking level.", "options", "essential", {
+      activeRunSafe: true,
       args: [
         defineCommandArgument("level", "Thinking level", {
           choices: ({ provider, model, catalog, agentRuntime }) =>

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -9,8 +9,9 @@ import {
 import { getChannelPlugin, getLoadedChannelPlugin } from "../channels/plugins/index.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { SkillCommandSpec } from "../skills/types.js";
+import type { CommandTurnContext } from "./command-turn-context.js";
 import { listChatCommands, listChatCommandsForConfig } from "./commands-registry-list.js";
-import { normalizeCommandBody } from "./commands-registry-normalize.js";
+import { normalizeCommandBody, resolveTextCommand } from "./commands-registry-normalize.js";
 import { getChatCommands } from "./commands-registry.data.js";
 import type {
   ChatCommandDefinition,
@@ -201,6 +202,35 @@ export function findCommandByNativeName(
       supportsNativeProvider(command, provider) &&
       mapNativeCommandNames(command).some(({ normalizedName }) => normalizedName === normalized),
   );
+}
+
+/** Returns true only when the command owner permits handler work beside an active run. */
+export function isActiveRunSafeCommandTurn(params: {
+  commandTurn: CommandTurnContext;
+  cfg: OpenClawConfig;
+  provider?: string;
+}): boolean {
+  const { commandTurn } = params;
+  if (
+    (commandTurn.kind !== "native" && commandTurn.kind !== "text-slash") ||
+    !commandTurn.authorized
+  ) {
+    return false;
+  }
+  const command =
+    commandTurn.kind === "native"
+      ? commandTurn.commandName
+        ? findCommandByNativeName(commandTurn.commandName, params.provider, {
+            includeBundledChannelFallback: false,
+          })
+        : undefined
+      : (
+          resolveTextCommand(commandTurn.body ?? "", params.cfg) ??
+          (commandTurn.commandName
+            ? resolveTextCommand(`/${commandTurn.commandName}`, params.cfg)
+            : null)
+        )?.command;
+  return command?.activeRunSafe === true;
 }
 
 /** Formats a command and optional raw argument string as slash-command text. */

--- a/src/auto-reply/commands-registry.types.ts
+++ b/src/auto-reply/commands-registry.types.ts
@@ -81,6 +81,8 @@ export type ChatCommandDefinition = {
   category?: CommandCategory;
   /** Progressive disclosure tier. Defaults to "standard" when omitted. */
   tier?: CommandTier;
+  /** Handler is safe to resolve while another run owns the session execution slot. */
+  activeRunSafe?: true;
 };
 
 /** Provider-facing native command registration shape. */

--- a/src/auto-reply/reply-payload.test.ts
+++ b/src/auto-reply/reply-payload.test.ts
@@ -1,6 +1,20 @@
 // Reply payload tests cover internal reply metadata contracts.
 import { describe, expect, it } from "vitest";
-import { isReplyPayloadTerminalContent, readPairingQrReplyChannelData } from "./reply-payload.js";
+import {
+  isCommandReplyForDelivery,
+  isReplyPayloadTerminalContent,
+  markCommandReplyForDelivery,
+  readPairingQrReplyChannelData,
+} from "./reply-payload.js";
+
+describe("command reply delivery", () => {
+  it("requires a non-empty reply whose payloads were all produced by the command owner", () => {
+    expect(isCommandReplyForDelivery(undefined)).toBe(false);
+    expect(isCommandReplyForDelivery([])).toBe(false);
+    expect(isCommandReplyForDelivery([{ text: "unmarked" }])).toBe(false);
+    expect(isCommandReplyForDelivery(markCommandReplyForDelivery({ text: "ack" }))).toBe(true);
+  });
+});
 
 describe("pairing QR reply channel data", () => {
   it("reads the private pairing QR payload metadata", () => {

--- a/src/auto-reply/reply-payload.test.ts
+++ b/src/auto-reply/reply-payload.test.ts
@@ -13,6 +13,10 @@ describe("command reply delivery", () => {
     expect(isCommandReplyForDelivery([])).toBe(false);
     expect(isCommandReplyForDelivery([{ text: "unmarked" }])).toBe(false);
     expect(isCommandReplyForDelivery(markCommandReplyForDelivery({ text: "ack" }))).toBe(true);
+
+    const marked = { text: "ack" };
+    markCommandReplyForDelivery(marked);
+    expect(isCommandReplyForDelivery([marked, { text: "unmarked" }])).toBe(false);
   });
 });
 

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -292,6 +292,8 @@ export type ReplyPayloadMetadata = {
   channelReplyTransformOwner?: object;
   /** Exact dispatcher that already ran its full normalization before side effects. */
   replyDispatcherNormalizationOwner?: object;
+  /** The command owner produced this terminal reply without starting an agent run. */
+  commandReply?: true;
   /** Exact key for replacing a runtime-owned assistant row after media materialization. */
   assistantTranscriptIdempotencyKey?: string;
   /** Opaque owner for one final-delivery transcript capture on a shared dispatcher. */
@@ -385,13 +387,28 @@ export function markReplyPayloadForSourceSuppressionDelivery<T extends object>(p
 export function markCommandReplyForDelivery(
   reply: ReplyPayload | ReplyPayload[] | undefined,
 ): ReplyPayload | ReplyPayload[] | undefined {
+  const markPayload = (payload: ReplyPayload): ReplyPayload =>
+    setReplyPayloadMetadata(markReplyPayloadForSourceSuppressionDelivery(payload), {
+      commandReply: true,
+    });
   if (!reply) {
     return reply;
   }
   if (Array.isArray(reply)) {
-    return reply.map((payload) => markReplyPayloadForSourceSuppressionDelivery(payload));
+    return reply.map(markPayload);
   }
-  return markReplyPayloadForSourceSuppressionDelivery(reply);
+  return markPayload(reply);
+}
+
+/** Returns true only when a command owner produced every payload in a non-empty reply. */
+export function isCommandReplyForDelivery(
+  reply: ReplyPayload | ReplyPayload[] | undefined,
+): boolean {
+  const payloads = Array.isArray(reply) ? reply : reply ? [reply] : [];
+  return (
+    payloads.length > 0 &&
+    payloads.every((payload) => getReplyPayloadMetadata(payload)?.commandReply === true)
+  );
 }
 
 /** Returns true for internal status/notice payloads, not assistant answer content. */

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -1300,6 +1300,65 @@ describe("dispatchReplyFromConfig ACP abort", () => {
     expect(getActiveReplyRunCount()).toBe(0);
   });
 
+  it("delivers a directive acknowledgement while its terminal path stays serialized", async () => {
+    const sessionKey = "agent:main:directive-reply-active";
+    const activeOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "active-session",
+      resetTriggered: false,
+    });
+    activeOperation.setPhase("running");
+
+    const acknowledgement = { text: "Thinking level set to high.", isStatusNotice: true };
+    const dispatcher = createDispatcher();
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        CommandAuthorized: true,
+        CommandSource: "text",
+        CommandTurn: {
+          kind: "text-slash",
+          source: "text",
+          authorized: true,
+          commandName: "think",
+          body: "/think high",
+        },
+        SessionKey: sessionKey,
+        Body: "/think high",
+        RawBody: "/think high",
+        CommandBody: "/think high",
+        BodyForAgent: "/think high",
+      }),
+      cfg: {
+        diagnostics: { enabled: true },
+        session: { sendPolicy: { default: "allow" } },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver: async (_resolverCtx, options) => {
+        await options.onBlockReply?.(acknowledgement);
+        return undefined;
+      },
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(dispatcher.sendBlockReply).toHaveBeenCalledWith(acknowledgement);
+      });
+      expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+      expect(replyRunRegistry.get(sessionKey)).toBe(activeOperation);
+      await expect(
+        raceWithTimeoutResult(
+          dispatchPromise.then(() => "settled" as const),
+          100,
+          "pending" as const,
+        ),
+      ).resolves.toBe("pending");
+    } finally {
+      activeOperation.complete();
+    }
+    await expect(dispatchPromise).resolves.toMatchObject({ queuedFinal: false });
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
   it("admits authorized native /status on the source while the target has an active run", async () => {
     const sourceSessionKey = "agent:main:telegram:slash:user-auth";
     const targetSessionKey = "agent:main:telegram:group:status-target";

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -1334,7 +1334,7 @@ describe("dispatchReplyFromConfig ACP abort", () => {
       } as OpenClawConfig,
       dispatcher,
       replyResolver: async (_resolverCtx, options) => {
-        await options.onBlockReply?.(acknowledgement);
+        await options?.onBlockReply?.(acknowledgement);
         return undefined;
       },
     });

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -9,6 +9,7 @@ import type {
   AcpRuntimeTurnInput,
 } from "../../plugin-sdk/acp-runtime.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
+import { markCommandReplyForDelivery } from "../reply-payload.js";
 import {
   acpManagerRuntimeMocks,
   acpMocks,
@@ -1235,6 +1236,67 @@ describe("dispatchReplyFromConfig ACP abort", () => {
     expect(replyRunRegistry.get(targetSessionKey)).toBe(targetOperation);
     expect(replyRunRegistry.get(sourceSessionKey)).toBeUndefined();
     targetOperation.complete();
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
+  it("delivers an authorized text command acknowledgement while its session operation is active", async () => {
+    const sessionKey = "agent:main:command-reply-active";
+    const activeOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "active-session",
+      resetTriggered: false,
+    });
+    activeOperation.setPhase("running");
+
+    const acknowledgement = { text: "Thinking level set to high." };
+    const replyResolver = vi.fn(async () => markCommandReplyForDelivery(acknowledgement));
+    const dispatcher = createDispatcher();
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        CommandAuthorized: true,
+        CommandSource: "text",
+        CommandTurn: {
+          kind: "text-slash",
+          source: "text",
+          authorized: true,
+          commandName: "think",
+          body: "/think high",
+        },
+        SessionKey: sessionKey,
+        Body: "/think high",
+        RawBody: "/think high",
+        CommandBody: "/think high",
+        BodyForAgent: "/think high",
+      }),
+      cfg: {
+        diagnostics: { enabled: true },
+        session: { sendPolicy: { default: "allow" } },
+      } as OpenClawConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    try {
+      type DispatchOutcome =
+        | { status: "settled"; result: Awaited<typeof dispatchPromise> }
+        | { status: "pending" };
+      const outcome = await raceWithTimeoutResult<DispatchOutcome>(
+        dispatchPromise.then((result) => ({ status: "settled" as const, result })),
+        200,
+        { status: "pending" as const },
+      );
+
+      expect(outcome).toMatchObject({
+        status: "settled",
+        result: { queuedFinal: true },
+      });
+      expect(replyResolver).toHaveBeenCalledOnce();
+      expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(acknowledgement);
+      expect(replyRunRegistry.get(sessionKey)).toBe(activeOperation);
+    } finally {
+      activeOperation.complete();
+      await dispatchPromise;
+    }
     expect(getActiveReplyRunCount()).toBe(0);
   });
 

--- a/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-abort.test.ts
@@ -1300,6 +1300,63 @@ describe("dispatchReplyFromConfig ACP abort", () => {
     expect(getActiveReplyRunCount()).toBe(0);
   });
 
+  it("keeps an executable /bash command behind active-session admission", async () => {
+    const sessionKey = "agent:main:executable-command-active";
+    const activeOperation = createReplyOperation({
+      sessionKey,
+      sessionId: "active-session",
+      resetTriggered: false,
+    });
+    activeOperation.setPhase("running");
+
+    const callerAbort = new AbortController();
+    const replyResolver = vi.fn(async () =>
+      markCommandReplyForDelivery({ text: "Shell command completed." }),
+    );
+    const dispatchPromise = dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        CommandAuthorized: true,
+        CommandSource: "text",
+        CommandTurn: {
+          kind: "text-slash",
+          source: "text",
+          authorized: true,
+          commandName: "bash",
+          body: "/bash echo unsafe",
+        },
+        SessionKey: sessionKey,
+        Body: "/bash echo unsafe",
+        RawBody: "/bash echo unsafe",
+        CommandBody: "/bash echo unsafe",
+        BodyForAgent: "/bash echo unsafe",
+      }),
+      cfg: {
+        diagnostics: { enabled: true },
+        session: { sendPolicy: { default: "allow" } },
+      } as OpenClawConfig,
+      dispatcher: createDispatcher(),
+      replyOptions: { abortSignal: callerAbort.signal },
+      replyResolver,
+    });
+
+    try {
+      await expect(
+        raceWithTimeoutResult(
+          dispatchPromise.then(() => "settled" as const),
+          100,
+          "pending" as const,
+        ),
+      ).resolves.toBe("pending");
+      expect(replyResolver).not.toHaveBeenCalled();
+    } finally {
+      callerAbort.abort();
+      activeOperation.complete();
+    }
+    await dispatchPromise;
+    expect(replyResolver).not.toHaveBeenCalled();
+    expect(getActiveReplyRunCount()).toBe(0);
+  });
+
   it("delivers a directive acknowledgement while its terminal path stays serialized", async () => {
     const sessionKey = "agent:main:directive-reply-active";
     const activeOperation = createReplyOperation({

--- a/src/auto-reply/reply/dispatch-from-config.acp-tail.ts
+++ b/src/auto-reply/reply/dispatch-from-config.acp-tail.ts
@@ -1,0 +1,81 @@
+import { runWithDispatchAbortSignal } from "./dispatch-from-config.abort.js";
+import { createReplyDispatchEvent } from "./dispatch-from-config.events.js";
+import type { PrepareDispatchExecutionReadyState } from "./dispatch-from-config.prepare-execution.js";
+import type { DispatchFromConfigResult } from "./dispatch-from-config.types.js";
+
+export async function handleAcpDispatchTailAfterReset(
+  state: PrepareDispatchExecutionReadyState,
+): Promise<{ status: "complete"; result: DispatchFromConfigResult } | undefined> {
+  if (state.ctx.AcpDispatchTailAfterReset !== true) {
+    return undefined;
+  }
+  // Command handling prepared a trailing prompt after ACP in-place reset.
+  // Route that tail through ACP now (same turn) instead of embedded dispatch.
+  state.ctx.AcpDispatchTailAfterReset = false;
+  const hookRunner = state.hookRunner;
+  if (!hookRunner?.hasHooks("reply_dispatch", { dispatchKind: state.dispatchKind })) {
+    return undefined;
+  }
+  const tailDispatchResult = await state.runWithDispatchLifecycleAdmission(
+    async () =>
+      await runWithDispatchAbortSignal(
+        state.getDispatchAbortSignal(),
+        () =>
+          hookRunner.runReplyDispatch(
+            createReplyDispatchEvent({
+              ctx: state.ctx,
+              runId: state.params.replyOptions?.runId,
+              sessionKey: state.acpDispatchSessionKey,
+              toolsAllow: state.params.replyOptions?.toolsAllow,
+              images: state.params.replyOptions?.images,
+              inboundAudio: state.inboundAudio,
+              sessionTtsAuto: state.sessionTtsAuto,
+              ttsChannel: state.deliveryChannel,
+              suppressUserDelivery: state.suppressHookUserDelivery,
+              suppressReplyLifecycle: state.suppressHookReplyLifecycle,
+              sourceReplyDeliveryMode: state.sourceReplyDeliveryMode,
+              shouldRouteToOriginating: state.shouldRouteToOriginating,
+              originatingChannel: state.routeReplyChannel,
+              originatingTo: state.routeReplyTo,
+              originatingAccountId: state.replyContextAccountId,
+              originatingThreadId: state.routeReplyThreadId,
+              originatingChatType: state.replyRoute.chatType,
+              shouldSendToolSummaries: state.shouldSendToolSummaries,
+              shouldSendFullToolDetails: state.shouldEmitFullVerboseProgress(),
+              sendPolicy: state.sendPolicy,
+              isTailDispatch: true,
+            }),
+            {
+              cfg: state.cfg,
+              dispatchKind: state.dispatchKind,
+              dispatcher: state.dispatchHookDispatcher,
+              abortSignal:
+                state.getPreDispatchAbortSignal() ?? state.params.replyOptions?.abortSignal,
+              onReplyStart: state.params.replyOptions?.onReplyStart,
+              onAgentRunStart: state.params.replyOptions?.onAgentRunStart,
+              userTurnTranscriptRecorder: state.params.replyOptions?.userTurnTranscriptRecorder,
+              prepareAssistantTranscriptMessage:
+                state.params.replyOptions?.prepareAssistantTranscriptMessage,
+              recordProcessed: state.recordProcessed,
+              markIdle: state.markIdle,
+            },
+          ),
+        state.trackDispatchLifecycleWork,
+      ),
+  );
+  if (!tailDispatchResult?.handled) {
+    return undefined;
+  }
+  state.recordAgentDispatchCompleted("completed");
+  state.completeDispatchReplyOperation();
+  return {
+    status: "complete",
+    result: state.attachSourceReplyDeliveryMode({
+      queuedFinal: tailDispatchResult.queuedFinal,
+      counts: tailDispatchResult.counts,
+      ...(state.routeState.sessionMetadataChangesForResult
+        ? { sessionMetadataChanges: state.routeState.sessionMetadataChangesForResult }
+        : {}),
+    }),
+  };
+}

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -677,7 +677,7 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
   }
 
   const dispatchAcquisition = await state.ensureDispatchReplyOperation(
-    state.explicitCommandTurnCtx ? "command_resolution" : "dispatch",
+    state.activeRunSafeCommandTurn ? "command_resolution" : "dispatch",
   );
   if (dispatchAcquisition.status === "aborted") {
     return { status: "complete" as const, result: state.finishReplyOperationAbortedDispatch() };

--- a/src/auto-reply/reply/dispatch-from-config.choose-route.ts
+++ b/src/auto-reply/reply/dispatch-from-config.choose-route.ts
@@ -676,7 +676,9 @@ export async function chooseDispatchRoute(state: PrepareDispatchOperationReadySt
     }
   }
 
-  const dispatchAcquisition = await state.ensureDispatchReplyOperation("dispatch");
+  const dispatchAcquisition = await state.ensureDispatchReplyOperation(
+    state.explicitCommandTurnCtx ? "command_resolution" : "dispatch",
+  );
   if (dispatchAcquisition.status === "aborted") {
     return { status: "complete" as const, result: state.finishReplyOperationAbortedDispatch() };
   }

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -10,6 +10,7 @@ import { cleanDeferredFinalText } from "../../tts/captioned-final.js";
 import {
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
+  isCommandReplyForDelivery,
   isReplyPayloadStatusNotice,
   readAskUserQuestionId,
 } from "../reply-payload.js";
@@ -627,7 +628,10 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
   }
   const sessionMetadataChanges = takeCommandSessionMetadataChanges(ctx);
   notifySessionMetadataChanges(sessionMetadataChanges);
-  const finalDispatchAcquisition = await state.ensureDispatchReplyOperation("dispatch");
+  const resolvedCommandReply = isCommandReplyForDelivery(replyResult);
+  const finalDispatchAcquisition = resolvedCommandReply
+    ? ({ status: "ready" } as const)
+    : await state.ensureDispatchReplyOperation("dispatch");
   if (finalDispatchAcquisition.status === "aborted") {
     return { status: "complete" as const, result: state.finishReplyOperationAbortedDispatch() };
   }

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -17,7 +17,7 @@ import {
 import { buildTerminalAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
 import { takeCommandSessionMetadataChanges } from "./command-session-metadata.js";
 import { runWithDispatchAbortSignal } from "./dispatch-from-config.abort.js";
-import { createReplyDispatchEvent } from "./dispatch-from-config.events.js";
+import { handleAcpDispatchTailAfterReset } from "./dispatch-from-config.acp-tail.js";
 import type { InternalReplyResolverOptions } from "./dispatch-from-config.events.js";
 import {
   hasAskUserPayload,
@@ -45,7 +45,6 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     getAgentRunTerminalOutcome,
     getDispatchAbortOperation,
     getDispatchAbortSignal,
-    hookRunner,
     isDispatchOperationAborted,
     markInboundDedupeReplayUnsafe,
     markProgress,
@@ -55,7 +54,6 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     onToolResultFromReplyOptions,
     params,
     reasoningPayloadsEnabled,
-    recordAgentDispatchCompleted,
     replyConfig,
     replyRoute,
     resolveToolDeliveryPayload,
@@ -647,73 +645,9 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
     };
   }
 
-  if (ctx.AcpDispatchTailAfterReset === true) {
-    // Command handling prepared a trailing prompt after ACP in-place reset.
-    // Route that tail through ACP now (same turn) instead of embedded dispatch.
-    ctx.AcpDispatchTailAfterReset = false;
-    if (hookRunner?.hasHooks("reply_dispatch", { dispatchKind: state.dispatchKind })) {
-      const tailDispatchResult = await runWithDispatchLifecycleAdmission(
-        async () =>
-          await runWithDispatchAbortSignal(
-            getDispatchAbortSignal(),
-            () =>
-              hookRunner.runReplyDispatch(
-                createReplyDispatchEvent({
-                  ctx,
-                  runId: params.replyOptions?.runId,
-                  sessionKey: state.acpDispatchSessionKey,
-                  toolsAllow: params.replyOptions?.toolsAllow,
-                  images: params.replyOptions?.images,
-                  inboundAudio: state.inboundAudio,
-                  sessionTtsAuto,
-                  ttsChannel: deliveryChannel,
-                  suppressUserDelivery: state.suppressHookUserDelivery,
-                  suppressReplyLifecycle: state.suppressHookReplyLifecycle,
-                  sourceReplyDeliveryMode: state.sourceReplyDeliveryMode,
-                  shouldRouteToOriginating,
-                  originatingChannel: state.routeReplyChannel,
-                  originatingTo: state.routeReplyTo,
-                  originatingAccountId: state.replyContextAccountId,
-                  originatingThreadId: state.routeReplyThreadId,
-                  originatingChatType: replyRoute.chatType,
-                  shouldSendToolSummaries: state.shouldSendToolSummaries,
-                  shouldSendFullToolDetails: state.shouldEmitFullVerboseProgress(),
-                  sendPolicy: state.sendPolicy,
-                  isTailDispatch: true,
-                }),
-                {
-                  cfg,
-                  dispatchKind: state.dispatchKind,
-                  dispatcher: state.dispatchHookDispatcher,
-                  abortSignal:
-                    state.getPreDispatchAbortSignal() ?? params.replyOptions?.abortSignal,
-                  onReplyStart: params.replyOptions?.onReplyStart,
-                  onAgentRunStart: params.replyOptions?.onAgentRunStart,
-                  userTurnTranscriptRecorder: params.replyOptions?.userTurnTranscriptRecorder,
-                  prepareAssistantTranscriptMessage:
-                    params.replyOptions?.prepareAssistantTranscriptMessage,
-                  recordProcessed: state.recordProcessed,
-                  markIdle: state.markIdle,
-                },
-              ),
-            trackDispatchLifecycleWork,
-          ),
-      );
-      if (tailDispatchResult?.handled) {
-        recordAgentDispatchCompleted("completed");
-        state.completeDispatchReplyOperation();
-        return {
-          status: "complete" as const,
-          result: state.attachSourceReplyDeliveryMode({
-            queuedFinal: tailDispatchResult.queuedFinal,
-            counts: tailDispatchResult.counts,
-            ...(state.routeState.sessionMetadataChangesForResult
-              ? { sessionMetadataChanges: state.routeState.sessionMetadataChangesForResult }
-              : {}),
-          }),
-        };
-      }
-    }
+  const acpTailResult = await handleAcpDispatchTailAfterReset(state);
+  if (acpTailResult) {
+    return acpTailResult;
   }
   const nextState = extendPreparedDispatchState(state, {
     deliberateSilentTerminalReply,

--- a/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
@@ -303,7 +303,7 @@ export function createDispatchReplyOperationCoordinator(params: {
   };
 
   const ensureDispatchReplyOperation = async (
-    phase: "pre_dispatch" | "dispatch",
+    phase: "pre_dispatch" | "command_resolution" | "dispatch",
     hasPluginOwnedBinding = false,
   ): Promise<DispatchReplyOperationAcquisition> => {
     // Archive restoration belongs to pre-dispatch ownership resolution. Later calls only upgrade admission.
@@ -330,7 +330,7 @@ export function createDispatchReplyOperationCoordinator(params: {
         storePath: params.operationSessionStoreEntry.storePath,
       }));
     }
-    if (phase === "dispatch") {
+    if (phase !== "pre_dispatch") {
       // The next full reply operation revalidates the persisted session. Drop
       // the hook-only lease after its queued delivery settles so a waiting
       // lifecycle mutation cannot commit while that delivery is still active.
@@ -348,7 +348,7 @@ export function createDispatchReplyOperationCoordinator(params: {
       return dispatchReplyOperation ? { status: "ready" } : { status: "busy" };
     }
     if (
-      phase === "dispatch" &&
+      phase !== "pre_dispatch" &&
       preDispatchAbortOperation?.result &&
       preDispatchAbortOperation.result.kind !== "completed" &&
       !dispatchReplyOperation
@@ -379,9 +379,10 @@ export function createDispatchReplyOperationCoordinator(params: {
       // gets a chance to steer the active backend.
       return { status: "ready" };
     }
-    const allowActivePreDispatch = phase === "pre_dispatch" && replyTurnKind === "visible";
+    const allowActiveResolution =
+      replyTurnKind === "visible" && (phase === "pre_dispatch" || phase === "command_resolution");
     const allowGatewayQueueResolution =
-      phase === "dispatch" &&
+      phase !== "pre_dispatch" &&
       replyTurnKind === "visible" &&
       params.replyOptions?.turnAdoptionLifecycle !== undefined &&
       activeReplyOperation !== undefined &&
@@ -392,14 +393,14 @@ export function createDispatchReplyOperationCoordinator(params: {
       return { status: "ready" };
     }
     const allowSlackRoutedThreadBypass =
-      phase === "dispatch" &&
+      phase !== "pre_dispatch" &&
       shouldLetSlackRoutedThreadBypassBusyReplyOperation({
         activeOperation: replyRunRegistry.get(params.dispatchOperationSessionKey),
         ctx: params.ctx,
         routeThreadId: params.routeThreadId,
       });
     const lifecycleOnlyAbortController =
-      allowActivePreDispatch || allowSlackRoutedThreadBypass ? new AbortController() : undefined;
+      allowActiveResolution || allowSlackRoutedThreadBypass ? new AbortController() : undefined;
     const onLifecycleInterrupt = () => {
       preDispatchLifecycleInterrupted = true;
       lifecycleOnlyAbortController?.abort();
@@ -417,8 +418,8 @@ export function createDispatchReplyOperationCoordinator(params: {
       routeThreadId: params.routeThreadId,
       originatingLeafEntryId: params.replyOptions?.turnAdoptionLifecycle?.originatingLeafEntryId,
       upstreamAbortSignal: params.replyOptions?.abortSignal,
-      waitForActive: !allowActivePreDispatch && !allowSlackRoutedThreadBypass,
-      retainLifecycleAdmissionOnActive: allowActivePreDispatch || allowSlackRoutedThreadBypass,
+      waitForActive: !allowActiveResolution && !allowSlackRoutedThreadBypass,
+      retainLifecycleAdmissionOnActive: allowActiveResolution || allowSlackRoutedThreadBypass,
       onLifecycleInterrupt,
     });
     if (
@@ -467,17 +468,21 @@ export function createDispatchReplyOperationCoordinator(params: {
           originatingLeafEntryId:
             params.replyOptions?.turnAdoptionLifecycle?.originatingLeafEntryId,
           upstreamAbortSignal: params.replyOptions?.abortSignal,
-          waitForActive: !allowActivePreDispatch && !allowSlackRoutedThreadBypass,
-          retainLifecycleAdmissionOnActive: allowActivePreDispatch || allowSlackRoutedThreadBypass,
+          waitForActive: !allowActiveResolution && !allowSlackRoutedThreadBypass,
+          retainLifecycleAdmissionOnActive: allowActiveResolution || allowSlackRoutedThreadBypass,
           onLifecycleInterrupt,
         });
       }
     }
     if (admission.status === "skipped") {
-      if (allowActivePreDispatch && admission.reason === "active-run") {
+      if (allowActiveResolution && admission.reason === "active-run") {
         preDispatchAbortOperation = admission.activeOperation;
         preDispatchLifecycleAdmission = admission.lifecycleAdmission;
-        preDispatchLifecycleAbortController = lifecycleOnlyAbortController;
+        if (phase === "pre_dispatch") {
+          preDispatchLifecycleAbortController = lifecycleOnlyAbortController;
+        } else {
+          dispatchLifecycleAbortController = lifecycleOnlyAbortController;
+        }
         return { status: "ready" };
       }
       if (

--- a/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
+++ b/src/auto-reply/reply/dispatch-from-config.prepare-context.ts
@@ -26,6 +26,8 @@ import {
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { resolveSilentReplyPolicyFromPolicies } from "../../shared/silent-reply-policy.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
+import { resolveCommandTurnContext } from "../command-turn-context.js";
+import { isActiveRunSafeCommandTurn } from "../commands-registry.js";
 import type { ReplyPayload } from "../reply-payload.js";
 import { resolveConversationBindingContextFromMessage } from "./conversation-binding-input.js";
 import { capturePendingConversationTurnReply } from "./conversation-turn-capture.js";
@@ -377,6 +379,13 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
         }
       : result;
   const explicitCommandTurnCtx = isExplicitSourceReplyCommand(ctx, cfg);
+  const activeRunSafeCommandTurn =
+    explicitCommandTurnCtx &&
+    isActiveRunSafeCommandTurn({
+      commandTurn: resolveCommandTurnContext(ctx),
+      cfg,
+      provider: ctx.Provider ?? ctx.Surface,
+    });
   const unauthorizedTextSlashSourceReplyCtx =
     (chatType === "group" || chatType === "channel") && isUnauthorizedTextSlashCommand(ctx);
   const noVisibleReplyFallbackDirected = isDirectedSourceReplyTurn(ctx, cfg, chatType === "direct");
@@ -540,6 +549,7 @@ export async function prepareDispatchOperationContext(state: PrepareDispatchDeli
     commentaryPayloadsEnabled,
     attachSourceReplyDeliveryMode,
     explicitCommandTurnCtx,
+    activeRunSafeCommandTurn,
     shouldDeliverPluginBindingReply,
     inboundDedupeClaim,
     commitInboundDedupeIfClaimed,

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -2045,7 +2045,7 @@ describe("handleInlineActions", () => {
     expect(toolExecute).toHaveBeenCalled();
   });
 
-  it("marks command-handler terminal replies with deliverDespiteSourceReplySuppression so they are not dropped under message_tool_only delivery (#87107)", async () => {
+  it("marks command-handler terminal replies for direct delivery (#87107)", async () => {
     const typing = createTypingController();
     handleCommandsMock.mockResolvedValueOnce({
       shouldContinue: false,
@@ -2080,12 +2080,12 @@ describe("handleInlineActions", () => {
       throw new Error("expected reply");
     }
     expect(result.reply).toEqual({ text: "⚙️ Compacted (76k → 934 tokens)" });
-    // Reply must carry deliverDespiteSourceReplySuppression so dispatch-from-config
-    // does not silently `continue` past it when sourceReplyDeliveryMode is
-    // "message_tool_only" (Feishu group / WebChat default).
-    expect(
-      getReplyPayloadMetadata(result.reply as object)?.deliverDespiteSourceReplySuppression,
-    ).toBe(true);
+    // Source suppression keeps the existing message-tool contract; command
+    // provenance permits final delivery beside an active session operation.
+    expect(getReplyPayloadMetadata(result.reply as object)).toMatchObject({
+      commandReply: true,
+      deliverDespiteSourceReplySuppression: true,
+    });
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -389,7 +389,6 @@ describe("handleInlineActions", () => {
     });
     expect(getReplyPayloadMetadata(delivered as object)).toEqual({
       assistantMessageIndex: 7,
-      commandReply: true,
       deliverDespiteSourceReplySuppression: true,
     });
   });

--- a/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skip-when-config-empty.test.ts
@@ -389,6 +389,7 @@ describe("handleInlineActions", () => {
     });
     expect(getReplyPayloadMetadata(delivered as object)).toEqual({
       assistantMessageIndex: 7,
+      commandReply: true,
       deliverDespiteSourceReplySuppression: true,
     });
   });


### PR DESCRIPTION
Closes #125838

## What Problem This Solves

Slash commands such as `/status`, `/think`, and `/stop` could complete during an active session run but leave no visible acknowledgement.

## Root Cause

The shared dispatcher required a second active-session admission after command resolution. That admission serialized the command-owned reply behind the run it was reporting on or stopping.

## Fix

- Record private provenance on terminal replies produced by the command owner.
- Let only registry-declared active-run-safe commands resolve through the existing lifecycle lease.
- Skip only the redundant final admission when every non-empty reply payload has command provenance.
- Keep `/bash`, plugin commands, unmarked, empty, mixed-origin, Gateway-owned, and ordinary agent replies on the serialized path.
- Move the existing ACP reset-tail phase into its own owner helper so the dispatcher remains below the line-count limit.

## Evidence

- Branch base and current merge target: `f95420efc7c2e602048dd82e40eb7a0ac56c2f1e`.
- Exact candidate: `04db808d3816d1dc22af679b0b135581de33a17a`.
- Parent head `f909fb59b0645de4249fe2215cf1838d3ddb4dee` passed the full isolated Linux build and Gateway scenario before the safety gate was added.
- Focused proof passed 122 tests on patch-identical head `0b232fc5eac419bc7f51eb43a0bce34ca5ea6cb1`, including safe `/think` delivery during an active run and a red-before-fix `/bash` case that cannot reach command handling before serialized admission. Stable patch id: `eeb8611252d97979d0bd8182564612b9a4cfa7bd`.
- Type-aware lint, formatting, max-lines, import-cycle, and whitespace checks passed.
- Exact current-main merge-tree proof completed without conflicts as tree `e7d36f195f6a0ea10b3be1659209883776d096bf`.
- The Gateway scenario passed with one scenario and zero failures; the later safety patch only narrows which commands can enter that proven active-run path.
- Telegram Test Server witness on `f254c621cdf133c9ebfcb09552c696417ef979a2`: a delayed run stayed active while `/think high` and `/status` produced visible replies; an ordinary turn stayed serialized; `/stop` produced a visible acknowledgement and cleared the run. Three provider requests confirmed the flow was live. Later commits rebase the same fix, move the ACP tail unchanged, and narrow active-run admission to the three declared safe commands.

```json
{"schemaVersion":1,"proofKind":"mock-channel-api+mock-provider+ephemeral-gateway","target":{"repository":"Alix-007/openclaw","immutableHead":"f909fb59b0645de4249fe2215cf1838d3ddb4dee","patchIdenticalHead":"04db808d3816d1dc22af679b0b135581de33a17a"},"observed":{"statusReplyVisible":true,"activeRunPreservedAfterStatus":true,"thinkReplyVisible":true,"activeRunPreservedAfterThink":true,"ordinaryTurnQuietWindowMs":1500,"activeRunPreservedAfterOrdinaryTurn":true,"abortReplyVisible":true,"activeRunAfterAbort":false,"executableCommandSerializedOnPatchIdenticalHead":true},"result":"pass"}
```

## Scope

- Raw production delta: `+180/-89` (net `+91`).
- The owner-helper extraction contributes `+85/-70` (net `+15`) and primarily moves the existing ACP reset-tail phase.
- Tests: `+204/-8` (net `+196`).
- No compatibility shim, channel-specific policy, fallback, configuration, protocol, or parallel dispatch path was added.
- AI-assisted: yes. The shared dispatch lifecycle, reply metadata owner, callers, sibling admission paths, tests, history, current main, and Codex command contract were reviewed.
