### PR TITLE
chore(shared): add test coverage for escapeRegExp [AI-assisted]

### DIFF
--- a/src/shared/regexp.test.ts
+++ b/src/shared/regexp.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { escapeRegExp } from "./regexp.js";
+
+describe("escapeRegExp", () => {
+  it("leaves plain text unchanged", () => {
+    expect(escapeRegExp("hello world 123")).toBe("hello world 123");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(escapeRegExp("")).toBe("");
+  });
+
+  it("escapes each regex special character", () => {
+    const specials = [".", "*", "+", "?", "^", "$", "{", "}", "(", ")", "|", "[", "]", "\\"];
+    for (const char of specials) {
+      expect(escapeRegExp(char)).toBe(`\\${char}`);
+    }
+  });
+
+  it("escapes a mix of special characters within a longer string", () => {
+    expect(escapeRegExp("a.b*c?[d]")).toBe("a\\.b\\*c\\?\\[d\\]");
+  });
+
+  it("produces a pattern that matches the original string literally", () => {
+    const value = "1+1=2 (maybe?) [test]";
+    const pattern = new RegExp(escapeRegExp(value));
+
+    expect(pattern.test(value)).toBe(true);
+    expect(pattern.test("1+1=3")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`src/shared/regexp.ts` exports `escapeRegExp`, a small pure utility used at 18+ call sites across the codebase, including security-relevant paths like `src/logging/secret-redaction-registry.ts` (secret redaction) and `src/infra/exec-allowlist-pattern.ts` (exec allowlist matching). Unlike every other file in `src/shared/` (60+ files, each with a co-located `*.test.ts`), it had no test coverage at all, so a regression in its escaping logic (e.g. missing a special character from the escape set) could silently break redaction or allowlist matching with no test to catch it.

## Why This Change Was Made

Added `src/shared/regexp.test.ts` covering: no-op on plain text, empty-string input, each individual regex special character (`. * + ? ^ $ { } ( ) | [ ] \`), a string with multiple special characters mixed in, and a round-trip property test (the escaped output, compiled as a `RegExp`, matches the original string literally and only that string). This is a test-only addition with no production code changes.

## User Impact

No user-facing behavior change. This closes a test-coverage gap on a utility used in security-sensitive code paths (secret redaction, exec allowlisting), giving reviewers and future contributors a safety net against silent regressions there.

## Evidence

Ran the new test file locally:

```
$ pnpm vitest run src/shared/regexp.test.ts

 Test Files  1 passed (1)
      Tests  5 passed (5)
```

---

**AI-assisted disclosure:** This PR was prepared with an AI coding agent (Claude, via Claude Code) as part of the contributor's first-PR onboarding. The gap (missing test file, out of step with the rest of `src/shared/`) was found by an AI search agent; I (the human author) reviewed the target function, its call sites, and the generated test cases before committing, and confirmed I understand what the code does.

- [x] Marked as AI-assisted in the title
- [x] Evidence section included above
- [x] Confirmed understanding of what the code does
- [x] Focused, single-purpose change (test-only, one file)