### PR TITLE
fix(release): keep Windows packaged-fresh on validated Node

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -896,15 +896,17 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      # Windows Server 2025 with Node 24.19 can crash in libuv fs-event on RUNNER~1.
+      # Keep only packaged-fresh on the last validated Node until an upstream fix ships.
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ matrix.os_id == 'windows' && matrix.suite == 'packaged-fresh' && '24.15.0' || env.NODE_VERSION }}
 
       - name: Setup pnpm
         uses: ./workflow/.github/actions/setup-pnpm-store-cache
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ matrix.os_id == 'windows' && matrix.suite == 'packaged-fresh' && '24.15.0' || env.NODE_VERSION }}
           package-manager-file: workflow/package.json
           lockfile-path: workflow/pnpm-lock.yaml
           cache-mode: off

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -63,6 +63,23 @@ describe("cross-OS release checks workflow", () => {
     expect(workflow).not.toContain("TSX_VERSION");
   });
 
+  it("pins only Windows packaged-fresh checks to the known-good Node release", () => {
+    const workflow = readWorkflow(WORKFLOW_PATH);
+    const prepare = job(workflow, "prepare");
+    const consumer = job(workflow, "cross_os_release_checks");
+    const windowsPackagedFreshNodeVersion =
+      "${{ matrix.os_id == 'windows' && matrix.suite == 'packaged-fresh' && '24.15.0' || env.NODE_VERSION }}";
+
+    expect(step(prepare, "Setup Node.js").with?.["node-version"]).toBe("${{ env.NODE_VERSION }}");
+    expect(step(prepare, "Setup pnpm").with?.["node-version"]).toBe("${{ env.NODE_VERSION }}");
+    expect(step(consumer, "Setup Node.js").with?.["node-version"]).toBe(
+      windowsPackagedFreshNodeVersion,
+    );
+    expect(step(consumer, "Setup pnpm").with?.["node-version"]).toBe(
+      windowsPackagedFreshNodeVersion,
+    );
+  });
+
   it("retries only an interrupted Windows dashboard probe", () => {
     const workflow = readWorkflow(WORKFLOW_PATH);
     const consumer = job(workflow, "cross_os_release_checks");


### PR DESCRIPTION
## What Problem This Solves

Fixes a release-check failure where Windows packaged-fresh validation can crash inside Node 24.19.0's libuv filesystem watcher on Windows Server 2025 after the Gateway has accepted the agent RPC.

## Why This Change Was Made

The cross-OS release workflow now uses Node 24.15.0 only for the Windows packaged-fresh matrix entry, consistently across `actions/setup-node` and pnpm setup. Every other platform and suite remains on the workflow's Node 24.19.0 default.

This is a release-runner compatibility fix for the upstream assertion tracked in https://github.com/nodejs/node/issues/63638; it does not change the release candidate.

## User Impact

Release operators can complete the Windows packaged-fresh gate without exposing that lane to the known Node 24.19.0 watcher crash. Other release checks continue validating the current default runtime.

## Evidence

- Before: release-check run `33086883217` reproduced the same `src\win\fs-event.c:72` assertion on both attempts after successful install, onboarding, Gateway startup, and agent RPC acceptance.
- Regression proof: the pre-fix workflow supplied `${{ env.NODE_VERSION }}` to both consumer setup steps; the new contract assertion failed on both.
- `node scripts/run-vitest.mjs test/scripts/openclaw-cross-os-release-workflow.test.ts` - 14/14 passed.
- `actionlint .github/workflows/openclaw-cross-os-release-checks-reusable.yml` - passed.
- `oxfmt --check` for both changed files - passed.
- Fresh autoreview - no accepted/actionable findings.
- Local `check:changed` completed all guards and formatting, then the root test typecheck could not resolve unrelated files omitted by the task's sparse worktree. Exact-head CI is required before landing.
