### PR TITLE
fix(qa): integrated audit validation matches safe inspection

### DIFF
--- a/extensions/qa-lab/src/execution-identity-storage-inspection.test.ts
+++ b/extensions/qa-lab/src/execution-identity-storage-inspection.test.ts
@@ -14,9 +14,16 @@ describe("inspectQaExecutionIdentityStorage", () => {
       const database = new DatabaseSync(databasePath);
       database.exec(`
         CREATE TABLE execution_identity_contexts (context_id TEXT PRIMARY KEY);
-        CREATE TABLE execution_decision_facts (receipt_id TEXT PRIMARY KEY);
+        CREATE TABLE execution_decision_facts (
+          receipt_id TEXT PRIMARY KEY,
+          run_id TEXT NOT NULL,
+          action_family TEXT NOT NULL,
+          reason_code TEXT NOT NULL
+        );
         INSERT INTO execution_identity_contexts VALUES ('context-1'), ('context-2');
-        INSERT INTO execution_decision_facts VALUES ('receipt-1');
+        INSERT INTO execution_decision_facts VALUES
+          ('receipt-1', 'run-1', 'message', 'message_suppressed_inbound_metadata_echo'),
+          ('receipt-2', 'run-1', 'model-routing', 'model_route_selected');
       `);
       database.close();
 
@@ -26,6 +33,20 @@ describe("inspectQaExecutionIdentityStorage", () => {
             runtimeEnv: { OPENCLAW_STATE_DIR: stateDir },
           } as never,
         }),
+      ).toEqual({ contextCount: 2, decisionCount: 2 });
+      expect(
+        inspectQaExecutionIdentityStorage(
+          {
+            gateway: {
+              runtimeEnv: { OPENCLAW_STATE_DIR: stateDir },
+            } as never,
+          },
+          {
+            runId: "run-1",
+            actionFamily: "message",
+            reasonCode: "message_suppressed_inbound_metadata_echo",
+          },
+        ),
       ).toEqual({ contextCount: 2, decisionCount: 1 });
     } finally {
       await fs.rm(stateDir, { force: true, recursive: true });

--- a/extensions/qa-lab/src/execution-identity-storage-inspection.ts
+++ b/extensions/qa-lab/src/execution-identity-storage-inspection.ts
@@ -5,6 +5,7 @@ import type { QaSuiteRuntimeEnv } from "./suite-runtime-types.js";
 function tableCount(
   database: ReturnType<typeof openNodeSqliteDatabase>,
   tableName: "execution_identity_contexts" | "execution_decision_facts",
+  decisionFilter?: { actionFamily: string; reasonCode: string; runId: string },
 ): number {
   const table = database
     .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
@@ -12,18 +13,29 @@ function tableCount(
   if (!table) {
     return 0;
   }
-  const countSql =
+  const row =
     tableName === "execution_identity_contexts"
-      ? "SELECT COUNT(*) AS count FROM execution_identity_contexts"
-      : "SELECT COUNT(*) AS count FROM execution_decision_facts";
-  const row = database.prepare(countSql).get() as {
-    count: number;
-  };
-  return row.count;
+      ? database.prepare("SELECT COUNT(*) AS count FROM execution_identity_contexts").get()
+      : decisionFilter
+        ? database
+            .prepare(
+              `SELECT COUNT(*) AS count FROM execution_decision_facts
+               WHERE run_id = ? AND action_family = ? AND reason_code = ?`,
+            )
+            .get(decisionFilter.runId, decisionFilter.actionFamily, decisionFilter.reasonCode)
+        : database.prepare("SELECT COUNT(*) AS count FROM execution_decision_facts").get();
+  return (
+    row as {
+      count: number;
+    }
+  ).count;
 }
 
 /** Return only bounded row counts for deterministic no-synthetic-run proof. */
-export function inspectQaExecutionIdentityStorage(env: Pick<QaSuiteRuntimeEnv, "gateway">): {
+export function inspectQaExecutionIdentityStorage(
+  env: Pick<QaSuiteRuntimeEnv, "gateway">,
+  decisionFilter?: { actionFamily: string; reasonCode: string; runId: string },
+): {
   contextCount: number;
   decisionCount: number;
 } {
@@ -37,7 +49,7 @@ export function inspectQaExecutionIdentityStorage(env: Pick<QaSuiteRuntimeEnv, "
   try {
     return {
       contextCount: tableCount(database, "execution_identity_contexts"),
-      decisionCount: tableCount(database, "execution_decision_facts"),
+      decisionCount: tableCount(database, "execution_decision_facts", decisionFilter),
     };
   } finally {
     database.close();

--- a/qa/scenarios/channels/message-delivery-decision-inspection.yaml
+++ b/qa/scenarios/channels/message-delivery-decision-inspection.yaml
@@ -35,7 +35,8 @@ scenario:
             alsoAllow: [message]
   successCriteria:
     - A QA Channel reply records queued, platform-started, and delivered as attribution-only owner-native receipts.
-    - A message-tool metadata echo records one exact intentional-suppression fact without a visible outbound message.
+    - A message-tool metadata echo records one exact private suppression fact without a visible outbound message.
+    - Public inspection reports the private generic fact as explicitly unknown without exposing its reason.
     - JSON and human CLI inspection expose no raw sender, conversation, message content, or platform message id.
     - Both receipt sets remain stable after a lifecycle-owned Gateway restart.
   docsRefs:
@@ -125,26 +126,26 @@ flow:
                 async: true
                 expr: >-
                   runQaCli(env, ['audit', '--run', deliveryRunId, '--explain', '--json'], { timeoutMs: 60000, json: true }).then((value) => {
-                    const decisions = Array.isArray(value.decisions) ? value.decisions : [];
-                    const receiptIds = decisions.map((receipt) => receipt.receiptId);
+                    const decisions = Array.isArray(value.decisionDisplays) ? value.decisionDisplays : [];
+                    const selectorIds = decisions.map((receipt) => receipt.selectorId);
                     const exactLifecycle = ['message_queued', 'message_platform_started', 'message_delivered'].every((reason) => decisions.filter((receipt) => receipt.decision?.reasonCode === reason).length === 1);
-                    const uniqueReceiptIds = receiptIds.every((id) => typeof id === 'string' && id.length > 0) && new Set(receiptIds).size === decisions.length;
-                    return exactLifecycle && uniqueReceiptIds ? value : undefined;
+                    const uniqueSelectorIds = selectorIds.every((id) => typeof id === 'string' && id.length > 0) && new Set(selectorIds).size === decisions.length;
+                    return exactLifecycle && uniqueSelectorIds ? value : undefined;
                   }).catch(() => undefined)
             - 60000
             - 250
         - set: deliveryMessageReceipts
           value:
-            expr: "deliveryInspect.decisions.filter((receipt) => receipt.action?.family === 'message')"
-        - set: deliveryReceiptIds
+            expr: "deliveryInspect.decisionDisplays.filter((receipt) => receipt.action?.family === 'message')"
+        - set: deliverySelectorIds
           value:
-            expr: "deliveryInspect.decisions.map((receipt) => receipt.receiptId)"
+            expr: "deliveryInspect.decisionDisplays.map((receipt) => receipt.selectorId)"
         - assert:
-            expr: "['message_queued', 'message_platform_started', 'message_delivered'].every((reason) => deliveryInspect.decisions.filter((receipt) => receipt.decision?.reasonCode === reason).length === 1)"
+            expr: "['message_queued', 'message_platform_started', 'message_delivered'].every((reason) => deliveryInspect.decisionDisplays.filter((receipt) => receipt.decision?.reasonCode === reason).length === 1)"
             message: delivery lifecycle receipt cardinality was not exactly one per required stage
         - assert:
-            expr: "deliveryReceiptIds.every((id) => typeof id === 'string' && id.length > 0) && new Set(deliveryReceiptIds).size === deliveryInspect.decisions.length"
-            message: delivery receipt ids were empty or duplicated
+            expr: "deliverySelectorIds.every((id) => typeof id === 'string' && id.length > 0) && new Set(deliverySelectorIds).size === deliveryInspect.decisionDisplays.length"
+            message: delivery selector ids were empty or duplicated
         - set: deliveryText
           value:
             expr: "await runQaCli(env, ['audit', '--run', deliveryRunId, '--explain'], { timeoutMs: 60000 })"
@@ -154,7 +155,7 @@ flow:
         - assert:
             expr: "deliveryPrivacySentinels.every((sentinel) => !JSON.stringify(deliveryInspect).includes(sentinel) && !deliveryText.includes(sentinel))"
             message: delivery JSON or human inspection exposed a raw sender, conversation, message id, or content sentinel
-      detailsExpr: "`delivery lifecycle counts=1/1/1; receiptIds=nonempty-unique; privacy=json+human-pass`"
+      detailsExpr: "`delivery lifecycle counts=1/1/1; selectorIds=nonempty-unique; privacy=json+human-pass`"
 
     - name: records intentional message-tool suppression
       actions:
@@ -196,48 +197,48 @@ flow:
                 async: true
                 expr: >-
                   runQaCli(env, ['audit', '--run', suppressionRunId, '--explain', '--json'], { timeoutMs: 60000, json: true }).then((value) => {
-                    const decisions = Array.isArray(value.decisions) ? value.decisions : [];
-                    const suppression = decisions.filter((receipt) => receipt.decision?.reasonCode === 'message_suppressed_inbound_metadata_echo');
-                    const receiptIds = decisions.map((receipt) => receipt.receiptId);
-                    const uniqueReceiptIds = receiptIds.every((id) => typeof id === 'string' && id.length > 0) && new Set(receiptIds).size === decisions.length;
-                    return suppression.length === 1 && suppression[0]?.action?.family === 'message' && suppression[0]?.decision?.outcome === 'not-applicable' && suppression[0]?.enforcement?.coverageState === 'attribution-only' && uniqueReceiptIds ? value : undefined;
+                    const decisions = Array.isArray(value.decisionDisplays) ? value.decisionDisplays : [];
+                    const selectorIds = decisions.map((receipt) => receipt.selectorId);
+                    const uniqueSelectorIds = selectorIds.every((id) => typeof id === 'string' && id.length > 0) && new Set(selectorIds).size === decisions.length;
+                    const unverified = decisions.filter((receipt) => receipt.provenance?.state === 'unverified' && receipt.decision?.outcome === 'unknown' && receipt.decision?.reasonCode === 'decision_fact_display_unverified' && receipt.enforcement?.coverageState === 'unknown');
+                    return value.coverage?.state === 'unknown' && value.coverage?.missingEvidence?.includes('decision.display_provenance') && unverified.length > 0 && uniqueSelectorIds ? value : undefined;
                   }).catch(() => undefined)
             - 60000
             - 250
-        - set: suppressionReceipts
+        - set: suppressionStorage
           value:
-            expr: "suppressionInspect.decisions.filter((receipt) => receipt.decision?.reasonCode === 'message_suppressed_inbound_metadata_echo')"
-        - set: suppressionReceiptIds
+            expr: "inspectQaExecutionIdentityStorage(env, { runId: suppressionRunId, actionFamily: 'message', reasonCode: 'message_suppressed_inbound_metadata_echo' })"
+        - set: suppressionSelectorIds
           value:
-            expr: "suppressionInspect.decisions.map((receipt) => receipt.receiptId)"
+            expr: "suppressionInspect.decisionDisplays.map((receipt) => receipt.selectorId)"
         - assert:
-            expr: "suppressionReceipts.length === 1 && suppressionReceipts[0].action?.family === 'message' && suppressionReceipts[0].decision?.outcome === 'not-applicable' && suppressionReceipts[0].enforcement?.coverageState === 'attribution-only'"
-            message: suppression receipt cardinality or semantics were incorrect
+            expr: "suppressionStorage.decisionCount === 1 && suppressionInspect.coverage.state === 'unknown' && suppressionInspect.coverage.missingEvidence.includes('decision.display_provenance')"
+            message: suppression fact cardinality or public unknown coverage was incorrect
         - assert:
-            expr: "suppressionReceiptIds.every((id) => typeof id === 'string' && id.length > 0) && new Set(suppressionReceiptIds).size === suppressionInspect.decisions.length"
-            message: suppression receipt ids were empty or duplicated
+            expr: "suppressionSelectorIds.every((id) => typeof id === 'string' && id.length > 0) && new Set(suppressionSelectorIds).size === suppressionInspect.decisionDisplays.length"
+            message: suppression selector ids were empty or duplicated
         - set: suppressionText
           value:
             expr: "await runQaCli(env, ['audit', '--run', suppressionRunId, '--explain'], { timeoutMs: 60000 })"
         - assert:
-            expr: "suppressionText.includes('message_suppressed_inbound_metadata_echo')"
-            message: intentional suppression receipt missing from JSON or human output
+            expr: "suppressionText.includes('decision_fact_display_unverified') && !suppressionText.includes('message_suppressed_inbound_metadata_echo') && !JSON.stringify(suppressionInspect).includes('message_suppressed_inbound_metadata_echo')"
+            message: public inspection did not keep the private suppression reason explicitly unknown
         - assert:
             expr: "suppressionPrivacySentinels.every((sentinel) => !JSON.stringify(suppressionInspect).includes(sentinel) && !suppressionText.includes(sentinel))"
             message: suppression JSON or human inspection exposed a raw sender, conversation, inbound message id, or content sentinel
         - assert:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length === suppressionOutboundStart"
             message: suppression path did not retain exact zero visible outbound messages
-      detailsExpr: "`suppression receipts=1; receiptIds=nonempty-unique; visibleOutbound=0; privacy=json+human-pass`"
+      detailsExpr: "`suppression facts=1; publicCoverage=unknown; selectorIds=nonempty-unique; visibleOutbound=0; privacy=json+human-pass`"
 
     - name: preserves delivery and suppression receipts across restart
       actions:
         - set: deliveryDecisionsBeforeRestart
           value:
-            expr: "JSON.stringify(deliveryInspect.decisions)"
+            expr: "JSON.stringify(deliveryInspect.decisionDisplays)"
         - set: suppressionDecisionsBeforeRestart
           value:
-            expr: "JSON.stringify(suppressionInspect.decisions)"
+            expr: "JSON.stringify(suppressionInspect.decisionDisplays)"
         - assert:
             expr: "typeof env.gateway.restartAfterStateMutation === 'function'"
             message: QA Gateway does not expose lifecycle-owned restart
@@ -257,6 +258,9 @@ flow:
         - set: suppressionAfterRestart
           value:
             expr: "await runQaCli(env, ['audit', '--run', suppressionRunId, '--explain', '--json'], { timeoutMs: 60000, json: true })"
+        - set: suppressionStorageAfterRestart
+          value:
+            expr: "inspectQaExecutionIdentityStorage(env, { runId: suppressionRunId, actionFamily: 'message', reasonCode: 'message_suppressed_inbound_metadata_echo' })"
         - set: deliveryTextAfterRestart
           value:
             expr: "await runQaCli(env, ['audit', '--run', deliveryRunId, '--explain'], { timeoutMs: 60000 })"
@@ -264,18 +268,18 @@ flow:
           value:
             expr: "await runQaCli(env, ['audit', '--run', suppressionRunId, '--explain'], { timeoutMs: 60000 })"
         - assert:
-            expr: "JSON.stringify(deliveryAfterRestart.decisions) === deliveryDecisionsBeforeRestart && JSON.stringify(suppressionAfterRestart.decisions) === suppressionDecisionsBeforeRestart && deliveryTextAfterRestart.includes('message_delivered') && suppressionTextAfterRestart.includes('message_suppressed_inbound_metadata_echo')"
+            expr: "JSON.stringify(deliveryAfterRestart.decisionDisplays) === deliveryDecisionsBeforeRestart && JSON.stringify(suppressionAfterRestart.decisionDisplays) === suppressionDecisionsBeforeRestart && deliveryTextAfterRestart.includes('message_delivered') && suppressionTextAfterRestart.includes('decision_fact_display_unverified') && !suppressionTextAfterRestart.includes('message_suppressed_inbound_metadata_echo')"
             message: message delivery decisions changed across Gateway restart
         - assert:
-            expr: "['message_queued', 'message_platform_started', 'message_delivered'].every((reason) => deliveryAfterRestart.decisions.filter((receipt) => receipt.decision?.reasonCode === reason).length === 1) && deliveryAfterRestart.decisions.every((receipt) => typeof receipt.receiptId === 'string' && receipt.receiptId.length > 0) && new Set(deliveryAfterRestart.decisions.map((receipt) => receipt.receiptId)).size === deliveryAfterRestart.decisions.length"
-            message: restarted delivery inspection lost exact lifecycle cardinality or unique receipt ids
+            expr: "['message_queued', 'message_platform_started', 'message_delivered'].every((reason) => deliveryAfterRestart.decisionDisplays.filter((receipt) => receipt.decision?.reasonCode === reason).length === 1) && deliveryAfterRestart.decisionDisplays.every((receipt) => typeof receipt.selectorId === 'string' && receipt.selectorId.length > 0) && new Set(deliveryAfterRestart.decisionDisplays.map((receipt) => receipt.selectorId)).size === deliveryAfterRestart.decisionDisplays.length"
+            message: restarted delivery inspection lost exact lifecycle cardinality or unique selector ids
         - assert:
-            expr: "suppressionAfterRestart.decisions.filter((receipt) => receipt.decision?.reasonCode === 'message_suppressed_inbound_metadata_echo' && receipt.action?.family === 'message' && receipt.decision?.outcome === 'not-applicable' && receipt.enforcement?.coverageState === 'attribution-only').length === 1 && suppressionAfterRestart.decisions.every((receipt) => typeof receipt.receiptId === 'string' && receipt.receiptId.length > 0) && new Set(suppressionAfterRestart.decisions.map((receipt) => receipt.receiptId)).size === suppressionAfterRestart.decisions.length"
-            message: restarted suppression inspection lost exact receipt semantics or unique receipt ids
+            expr: "suppressionStorageAfterRestart.decisionCount === 1 && suppressionAfterRestart.coverage.state === 'unknown' && suppressionAfterRestart.coverage.missingEvidence.includes('decision.display_provenance') && suppressionAfterRestart.decisionDisplays.some((receipt) => receipt.provenance?.state === 'unverified' && receipt.decision?.reasonCode === 'decision_fact_display_unverified') && suppressionAfterRestart.decisionDisplays.every((receipt) => typeof receipt.selectorId === 'string' && receipt.selectorId.length > 0) && new Set(suppressionAfterRestart.decisionDisplays.map((receipt) => receipt.selectorId)).size === suppressionAfterRestart.decisionDisplays.length"
+            message: restarted suppression inspection lost exact private fact, explicit unknown coverage, or unique selector ids
         - assert:
             expr: "deliveryPrivacySentinels.every((sentinel) => !JSON.stringify(deliveryAfterRestart).includes(sentinel) && !deliveryTextAfterRestart.includes(sentinel)) && suppressionPrivacySentinels.every((sentinel) => !JSON.stringify(suppressionAfterRestart).includes(sentinel) && !suppressionTextAfterRestart.includes(sentinel))"
             message: restarted JSON or human inspection exposed a raw sender, conversation, message id, or content sentinel
         - assert:
             expr: "state.getSnapshot().messages.filter((message) => message.direction === 'outbound').length === suppressionOutboundStart"
             message: suppression path produced a visible outbound message after restart
-      detailsExpr: "`restart-stable decisions=byte-identical; receiptIds=nonempty-unique; privacy=json+human-pass`"
+      detailsExpr: "`restart-stable decisions=byte-identical; selectorIds=nonempty-unique; privacy=json+human-pass`"

--- a/test/e2e/qa-lab/runtime/agent-run-identity-inspection.ts
+++ b/test/e2e/qa-lab/runtime/agent-run-identity-inspection.ts
@@ -2,35 +2,18 @@
 import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { setTimeout as sleep } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { WebSocket, type ClientOptions, type RawData } from "ws";
+import { WebSocket, type ClientOptions } from "ws";
 import {
   QA_EVIDENCE_FILENAME,
   type QaEvidenceSummaryJson,
 } from "../../../../extensions/qa-lab/src/evidence-summary.js";
 import { startQaGatewayChild } from "../../../../extensions/qa-lab/src/gateway-child.js";
 import { startQaMockOpenAiServer } from "../../../../extensions/qa-lab/src/providers/mock-openai/server.js";
-import { buildDeviceAuthPayloadV3 } from "../../../../packages/gateway-client/src/device-auth.js";
-import {
-  GATEWAY_CLIENT_IDS,
-  GATEWAY_CLIENT_MODES,
-} from "../../../../packages/gateway-protocol/src/client-info.js";
 import type { AuditRunInspectResult } from "../../../../packages/gateway-protocol/src/index.js";
-import {
-  MIN_CLIENT_PROTOCOL_VERSION,
-  PROTOCOL_VERSION,
-} from "../../../../packages/gateway-protocol/src/index.js";
-import {
-  loadOrCreateDeviceIdentity,
-  publicKeyRawBase64UrlFromPem,
-  signDevicePayload,
-  type DeviceIdentity,
-} from "../../../../src/infra/device-identity.js";
 import { formatErrorMessage } from "../../../../src/infra/errors.js";
 import { createQaScriptEvidenceWriter, type QaScriptEvidenceStatus } from "./script-evidence.js";
 
@@ -57,12 +40,6 @@ const IDENTITY_FIELDS = [
   "Assurance",
 ] as const;
 const FRAME_TIMEOUT_MS = 20_000;
-const GATEWAY_SCOPES = [
-  "operator.admin",
-  "operator.pairing",
-  "operator.read",
-  "operator.write",
-] as const;
 
 type ProducerOptions = {
   artifactBase: string;
@@ -76,209 +53,32 @@ type ProofResult = {
   status: QaScriptEvidenceStatus;
 };
 
-type RawGatewayClient = {
-  frames: unknown[];
-  socket: WebSocket;
-};
-
-function rawDataText(data: RawData): string {
-  if (Array.isArray(data)) {
-    return Buffer.concat(data.map((chunk) => Buffer.from(chunk))).toString("utf8");
-  }
-  return Buffer.isBuffer(data) ? data.toString("utf8") : Buffer.from(data).toString("utf8");
-}
-
-async function openRawGatewayClient(
+async function assertUntrustedProxyHeadersRejected(
   url: string,
-  headers?: Record<string, string>,
-): Promise<RawGatewayClient> {
-  const socket = new WebSocket(url, headers ? ({ headers } satisfies ClientOptions) : undefined);
-  const frames: unknown[] = [];
-  socket.on("message", (data) => frames.push(parseJson(rawDataText(data), "Gateway frame")));
-  await new Promise<void>((resolve, reject) => {
-    socket.once("open", resolve);
-    socket.once("error", reject);
-  });
-  return { frames, socket };
-}
-
-async function waitForFrame(
-  client: RawGatewayClient,
-  predicate: (frame: unknown) => boolean,
-  startIndex = 0,
-): Promise<Record<string, unknown>> {
-  const deadline = Date.now() + FRAME_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    const frame = client.frames.slice(startIndex).find(predicate);
-    if (isRecord(frame)) {
-      return frame;
-    }
-    await sleep(20);
-  }
-  throw new Error(`timed out waiting for Gateway frame: ${JSON.stringify(client.frames)}`);
-}
-
-function responseFor(id: string) {
-  return (frame: unknown) => isRecord(frame) && frame.type === "res" && frame.id === id;
-}
-
-async function closeRawGatewayClient(client: RawGatewayClient): Promise<void> {
-  if (client.socket.readyState === WebSocket.CLOSED) {
-    return;
-  }
-  await new Promise<void>((resolve) => {
-    client.socket.once("close", () => resolve());
-    client.socket.close();
-    setTimeout(resolve, 1_000).unref();
-  });
-}
-
-async function connectRawDevice(params: {
-  device: DeviceIdentity;
-  headers?: Record<string, string>;
-  token?: string;
-  wsUrl: string;
-}): Promise<{ client: RawGatewayClient; connected: boolean }> {
-  const client = await openRawGatewayClient(params.wsUrl, params.headers);
-  const challenge = await waitForFrame(
-    client,
-    (frame) => isRecord(frame) && frame.type === "event" && frame.event === "connect.challenge",
-  );
-  const challengePayload = challenge.payload;
-  if (!isRecord(challengePayload) || typeof challengePayload.nonce !== "string") {
-    throw new Error("Gateway connect challenge omitted its nonce");
-  }
-  const clientInfo = {
-    id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,
-    mode: GATEWAY_CLIENT_MODES.BACKEND,
-    platform: "linux",
-    version: "qa-local-user-ingress",
-  } as const;
-  const signedAt = Date.now();
-  const devicePayload = buildDeviceAuthPayloadV3({
-    deviceId: params.device.deviceId,
-    clientId: clientInfo.id,
-    clientMode: clientInfo.mode,
-    role: "operator",
-    scopes: [...GATEWAY_SCOPES],
-    signedAtMs: signedAt,
-    token: params.token,
-    nonce: challengePayload.nonce,
-    platform: clientInfo.platform,
-  });
-  const requestId = `connect-${randomUUID()}`;
-  const startIndex = client.frames.length;
-  client.socket.send(
-    JSON.stringify({
-      type: "req",
-      id: requestId,
-      method: "connect",
-      params: {
-        minProtocol: MIN_CLIENT_PROTOCOL_VERSION,
-        maxProtocol: PROTOCOL_VERSION,
-        client: clientInfo,
-        role: "operator",
-        scopes: [...GATEWAY_SCOPES],
-        caps: [],
-        ...(params.token ? { auth: { token: params.token } } : {}),
-        device: {
-          id: params.device.deviceId,
-          publicKey: publicKeyRawBase64UrlFromPem(params.device.publicKeyPem),
-          signature: signDevicePayload(params.device.privateKeyPem, devicePayload),
-          signedAt,
-          nonce: challengePayload.nonce,
-        },
-      },
-    }),
-  );
-  const response = await waitForFrame(client, responseFor(requestId), startIndex);
-  return { client, connected: response.ok === true };
-}
-
-async function rawGatewayRequest<T>(
-  client: RawGatewayClient,
-  method: string,
-  params: unknown,
-): Promise<T> {
-  const requestId = `request-${randomUUID()}`;
-  const startIndex = client.frames.length;
-  client.socket.send(JSON.stringify({ type: "req", id: requestId, method, params }));
-  const response = await waitForFrame(client, responseFor(requestId), startIndex);
-  if (response.ok !== true) {
-    throw new Error(`${method} failed: ${JSON.stringify(response.error)}`);
-  }
-  return response.payload as T;
-}
-
-async function approveDeviceIfNeeded(
-  gateway: Awaited<ReturnType<typeof startQaGatewayChild>>,
-  deviceId: string,
+  headers: Record<string, string>,
 ): Promise<void> {
-  const deadline = Date.now() + FRAME_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    const pairings = (await gateway.call("device.pair.list", {})) as {
-      pending?: Array<{ deviceId?: string; requestId?: string }>;
-    };
-    const pending = pairings.pending?.find((candidate) => candidate.deviceId === deviceId);
-    if (pending?.requestId) {
-      await gateway.call("device.pair.approve", { requestId: pending.requestId });
-      return;
-    }
-    await sleep(50);
-  }
-  throw new Error(`device pairing request was not visible for ${deviceId}`);
-}
-
-async function createFakeTailscaleBinary(): Promise<{
-  binaryDir: string;
-  cleanup: () => Promise<void>;
-}> {
-  const binaryDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-i1-tailscale-"));
-  try {
-    const binaryPath = path.join(binaryDir, "tailscale");
-    await fs.writeFile(
-      binaryPath,
-      `#!/bin/sh
-if [ "$1" = "--version" ]; then
-  echo "qa-tailscale 1.0"
-  exit 0
-fi
-echo '{"UserProfile":{"LoginName":"operator@example.com","DisplayName":"Operator"}}'
-`,
-      { encoding: "utf8", mode: 0o755 },
-    );
-    return {
-      binaryDir,
-      cleanup: async () => await fs.rm(binaryDir, { force: true, recursive: true }),
-    };
-  } catch (error) {
-    await fs.rm(binaryDir, { force: true, recursive: true });
-    throw error;
-  }
-}
-
-async function runGatewayTurn(
-  client: RawGatewayClient,
-  message: string,
-  sessionKey: string,
-): Promise<string> {
-  const started = await rawGatewayRequest<{ runId?: unknown; status?: unknown }>(client, "agent", {
-    sessionKey,
-    message,
-    deliver: false,
-    idempotencyKey: randomUUID(),
+  await new Promise<void>((resolve, reject) => {
+    const socket = new WebSocket(url, { headers } satisfies ClientOptions);
+    const timeout = setTimeout(() => {
+      socket.terminate();
+      reject(new Error("timed out waiting for spoofed proxy-header rejection"));
+    }, FRAME_TIMEOUT_MS);
+    socket.once("open", () => {
+      clearTimeout(timeout);
+      socket.terminate();
+      reject(new Error("Gateway accepted proxy-shaped headers from an untrusted peer"));
+    });
+    socket.once("unexpected-response", (_request, response) => {
+      clearTimeout(timeout);
+      response.resume();
+      if (response.statusCode === 403) {
+        resolve();
+      } else {
+        reject(new Error(`spoofed proxy headers returned HTTP ${response.statusCode}`));
+      }
+    });
+    socket.once("error", () => undefined);
   });
-  if (started.status !== "accepted" || typeof started.runId !== "string") {
-    throw new Error(`profiled Gateway run did not start: ${JSON.stringify(started)}`);
-  }
-  const terminal = await rawGatewayRequest<{ status?: unknown }>(client, "agent.wait", {
-    runId: started.runId,
-    timeoutMs: 60_000,
-  });
-  if (terminal.status !== "ok") {
-    throw new Error(`profiled Gateway run did not finish: ${JSON.stringify(terminal)}`);
-  }
-  return started.runId;
 }
 
 async function updateExecutionIdentityConfig(
@@ -352,8 +152,15 @@ function assertTextProjection(text: string) {
 
 function assertJsonProjection(result: AuditRunInspectResult, runId: string) {
   const context = requireIdentityContext(result);
-  if (result.run.runId !== runId || result.coverage.state !== context.coverageState) {
-    throw new Error(`audit JSON projection did not preserve exact-run coverage: ${runId}`);
+  if (result.run.runId !== runId) {
+    throw new Error(`audit JSON projection selected the wrong run: ${runId}`);
+  }
+  if (
+    result.coverage.state !== "unknown" ||
+    !result.coverage.missingEvidence.includes("decision.display_provenance") ||
+    !result.decisionDisplays.some((receipt) => receipt.provenance.state === "unverified")
+  ) {
+    throw new Error(`audit JSON projection overstated generic decision coverage: ${runId}`);
   }
   if (
     context.ingress.kind !== "local-cli" ||
@@ -375,10 +182,7 @@ function assertJsonProjection(result: AuditRunInspectResult, runId: string) {
   }
 }
 
-function assertGatewayIdentityProjection(
-  result: AuditRunInspectResult,
-  expected: { coverage: "attribution-only" | "unattributed"; invoker: "absent" | "present" },
-) {
+function assertProfilelessGatewayIdentityProjection(result: AuditRunInspectResult) {
   const context = requireIdentityContext(result);
   if (
     context.ingress.kind !== "gateway-client" ||
@@ -388,24 +192,15 @@ function assertGatewayIdentityProjection(
     throw new Error("Gateway run did not retain its authenticated connection ingress");
   }
   if (
-    context.invoker.state !== expected.invoker ||
-    context.coverageState !== expected.coverage ||
+    context.invoker.state !== "absent" ||
+    context.coverageState !== "unattributed" ||
     context.representedSubject !== undefined
   ) {
     throw new Error(
       `Gateway identity projection fabricated or lost a subject: ${JSON.stringify(context)}`,
     );
   }
-  if (expected.invoker === "present") {
-    if (
-      context.invoker.principal?.kind !== "person" ||
-      context.invoker.principal.displayLabel !== "Operator" ||
-      !context.assurance.some((item) => item.kind === "durable-profile") ||
-      !context.assurance.some((item) => item.kind === "tailscale-whois")
-    ) {
-      throw new Error("profiled Gateway run omitted its durable Tailscale attribution");
-    }
-  } else if (context.assurance.some((item) => item.kind === "durable-profile")) {
+  if (context.assurance.some((item) => item.kind === "durable-profile")) {
     throw new Error("profileless Gateway run fabricated durable profile assurance");
   }
 }
@@ -605,10 +400,8 @@ async function runRepeatedIngressTurns(
 
 async function runProof(options: ProducerOptions): Promise<string> {
   const mock = await startQaMockOpenAiServer();
-  let fakeTailscale: Awaited<ReturnType<typeof createFakeTailscaleBinary>> | undefined;
   let gateway: Awaited<ReturnType<typeof startQaGatewayChild>> | undefined;
   try {
-    fakeTailscale = await createFakeTailscaleBinary();
     gateway = await startQaGatewayChild({
       repoRoot: options.repoRoot,
       useRepoCli: true,
@@ -623,9 +416,6 @@ async function runProof(options: ProducerOptions): Promise<string> {
           auth: { ...cfg.gateway?.auth, allowTailscale: true },
         },
       }),
-      runtimeEnvPatch: {
-        PATH: `${fakeTailscale.binaryDir}${path.delimiter}${process.env.PATH ?? ""}`,
-      },
     });
     await gateway.restartAfterStateMutation(async () => {
       await runLocalTurn(gateway!, "Reply exactly: IDENTITY-DISABLED-FRESH");
@@ -677,47 +467,16 @@ async function runProof(options: ProducerOptions): Promise<string> {
     }
     const profilelessRunId = profilelessStarted.runId;
 
-    const device = loadOrCreateDeviceIdentity({
-      path: path.join(gateway.tempRoot, "i1-profiled-device.sqlite"),
-    });
-    const tailscaleHeaders = {
+    await assertUntrustedProxyHeadersRejected(gateway.wsUrl, {
       "tailscale-user-login": "operator@example.com",
       "tailscale-user-name": "Operator",
       "x-forwarded-for": "100.64.0.11",
       "x-forwarded-host": "gateway.qa.test",
       "x-forwarded-proto": "https",
-    };
-    let profiled = await connectRawDevice({
-      device,
-      headers: tailscaleHeaders,
-      wsUrl: gateway.wsUrl,
     });
-    if (!profiled.connected) {
-      await approveDeviceIfNeeded(gateway, device.deviceId);
-      await closeRawGatewayClient(profiled.client);
-      profiled = await connectRawDevice({
-        device,
-        headers: tailscaleHeaders,
-        wsUrl: gateway.wsUrl,
-      });
-    }
-    if (!profiled.connected) {
-      throw new Error(
-        `Tailscale-profiled Gateway client failed: ${JSON.stringify(profiled.client.frames)}`,
-      );
-    }
-    const profiledSessionKey = `agent:qa:i1-profiled-${randomUUID()}`;
-    const profiledRunId = await runGatewayTurn(
-      profiled.client,
-      "Reply exactly: I1-PROFILED",
-      profiledSessionKey,
-    );
-    await closeRawGatewayClient(profiled.client);
 
     const profilelessText = await gateway.runCli(["audit", "--run", profilelessRunId, "--explain"]);
-    const profiledText = await gateway.runCli(["audit", "--run", profiledRunId, "--explain"]);
     assertTextProjection(profilelessText);
-    assertTextProjection(profiledText);
     if (
       !profilelessText.includes("Invoker [absent]") ||
       !profilelessText.includes("Represented subject [absent]") ||
@@ -725,34 +484,13 @@ async function runProof(options: ProducerOptions): Promise<string> {
     ) {
       throw new Error("profileless text inspection fabricated an operator subject");
     }
-    if (
-      !profiledText.includes("Invoker [present]") ||
-      !profiledText.includes("Represented subject [absent]")
-    ) {
-      throw new Error(
-        `profiled text inspection omitted durable operator attribution: ${profiledText}`,
-      );
-    }
     const profilelessBefore = parseJson(
       await gateway.runCli(["audit", "--run", profilelessRunId, "--explain", "--json"]),
       "profileless Gateway inspection",
     ) as AuditRunInspectResult;
-    const profiledBefore = parseJson(
-      await gateway.runCli(["audit", "--run", profiledRunId, "--explain", "--json"]),
-      "profiled Gateway inspection",
-    ) as AuditRunInspectResult;
-    assertGatewayIdentityProjection(profilelessBefore, {
-      coverage: "unattributed",
-      invoker: "absent",
-    });
-    assertGatewayIdentityProjection(profiledBefore, {
-      coverage: "attribution-only",
-      invoker: "present",
-    });
+    assertProfilelessGatewayIdentityProjection(profilelessBefore);
     const profilelessContext = normalizedContextJson(profilelessBefore);
-    const profiledContext = normalizedContextJson(profiledBefore);
     assertPersistedContextBytes(gateway, profilelessRunId, profilelessContext);
-    assertPersistedContextBytes(gateway, profiledRunId, profiledContext);
 
     const listed = (await gateway.call("sessions.list", {})) as {
       sessions?: Array<{
@@ -763,7 +501,6 @@ async function runProof(options: ProducerOptions): Promise<string> {
     const profilelessSession = listed.sessions?.find(
       (session) => session.key === profilelessSessionKey,
     );
-    const profiledSession = listed.sessions?.find((session) => session.key === profiledSessionKey);
     if (profilelessSession?.createdActor !== undefined) {
       throw new Error("profileless Gateway session fabricated a human creator");
     }
@@ -774,21 +511,6 @@ async function runProof(options: ProducerOptions): Promise<string> {
       profilelessCreator.labelPersisted
     ) {
       throw new Error("profileless Gateway session persisted a fabricated creator");
-    }
-    if (
-      profiledSession?.createdActor?.type !== "human" ||
-      !profiledSession.createdActor.id ||
-      profiledSession.createdActor.label !== "Operator"
-    ) {
-      throw new Error("profiled Gateway session lost its current profile display projection");
-    }
-    const profiledCreator = inspectPersistedSessionCreator(gateway, profiledSessionKey);
-    if (
-      profiledCreator.type !== "human" ||
-      profiledCreator.id !== profiledSession.createdActor.id ||
-      profiledCreator.labelPersisted
-    ) {
-      throw new Error("profiled Gateway session did not persist only its authenticated profile id");
     }
 
     const repeatedRunId = `identity-repeated-${randomUUID()}`;
@@ -857,18 +579,13 @@ async function runProof(options: ProducerOptions): Promise<string> {
     if (afterContext !== beforeContext) {
       throw new Error("normalized execution identity context bytes changed across Gateway restart");
     }
-    for (const [gatewayRunId, expectedContext, expectedIdentity] of [
-      [profilelessRunId, profilelessContext, { coverage: "unattributed", invoker: "absent" }],
-      [profiledRunId, profiledContext, { coverage: "attribution-only", invoker: "present" }],
-    ] as const) {
-      const afterGateway = parseJson(
-        await gateway.runCli(["audit", "--run", gatewayRunId, "--explain", "--json"]),
-        `post-restart Gateway run ${gatewayRunId}`,
-      ) as AuditRunInspectResult;
-      assertGatewayIdentityProjection(afterGateway, expectedIdentity);
-      if (normalizedContextJson(afterGateway) !== expectedContext) {
-        throw new Error(`Gateway execution changed across restart: ${gatewayRunId}`);
-      }
+    const profilelessAfter = parseJson(
+      await gateway.runCli(["audit", "--run", profilelessRunId, "--explain", "--json"]),
+      `post-restart Gateway run ${profilelessRunId}`,
+    ) as AuditRunInspectResult;
+    assertProfilelessGatewayIdentityProjection(profilelessAfter);
+    if (normalizedContextJson(profilelessAfter) !== profilelessContext) {
+      throw new Error(`Gateway execution changed across restart: ${profilelessRunId}`);
     }
     for (const [executionId, expectedContext] of repeatedBeforeRestart) {
       const afterExact = parseJson(
@@ -906,11 +623,11 @@ async function runProof(options: ProducerOptions): Promise<string> {
         {
           runId,
           gatewayRuns: {
-            profiled: { runId: profiledRunId, contextSha256: sha256(profiledContext) },
             profileless: {
               runId: profilelessRunId,
               contextSha256: sha256(profilelessContext),
             },
+            spoofedProxyHeadersRejected: true,
           },
           repeatedRunId,
           repeatedExecutions: repeatedRows.map((row) => ({
@@ -939,11 +656,10 @@ async function runProof(options: ProducerOptions): Promise<string> {
       "utf8",
     );
     const repeatedDetails = `repeated run=${repeatedRunId} executions=${repeatedRows.map((row) => row.execution_id).join(",")}; exact selection passed`;
-    return `local run=${runId}; profiled Gateway run=${profiledRunId}; profileless Gateway run=${profilelessRunId}; ${repeatedDetails}; Gateway pid=${gateway.pid ?? "unknown"}; text+JSON and persisted bytes passed before/after replacement; normalized context sha256=${sha256(beforeContext)}`;
+    return `local run=${runId}; profileless Gateway run=${profilelessRunId}; spoofed proxy headers rejected; ${repeatedDetails}; Gateway pid=${gateway.pid ?? "unknown"}; text+JSON and persisted bytes passed before/after replacement; normalized context sha256=${sha256(beforeContext)}`;
   } finally {
     await gateway?.stop().catch(() => undefined);
     await mock.stop();
-    await fakeTailscale?.cleanup();
   }
 }
 

--- a/test/e2e/qa-lab/runtime/agent-run-identity-repeated-turn-child.ts
+++ b/test/e2e/qa-lab/runtime/agent-run-identity-repeated-turn-child.ts
@@ -38,8 +38,11 @@ async function main() {
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
-  main().catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : String(error));
-    process.exitCode = 1;
-  });
+  main().then(
+    () => process.exit(0),
+    (error: unknown) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    },
+  );
 }

--- a/test/e2e/qa-lab/runtime/autonomous-task-lifecycle-receipts.ts
+++ b/test/e2e/qa-lab/runtime/autonomous-task-lifecycle-receipts.ts
@@ -439,19 +439,23 @@ async function runProof(options: ProducerOptions): Promise<string> {
     }
 
     const db = new DatabaseSync(stateDatabasePath(gateway), { readOnly: true });
-    let genericCount = 0;
+    let ownerDuplicateCount = 0;
     try {
-      if (hasSqliteColumns(db, "execution_decision_facts", ["receipt_id"])) {
-        genericCount = (
-          db.prepare("SELECT COUNT(*) AS count FROM execution_decision_facts").get() as {
-            count: number;
-          }
+      if (hasSqliteColumns(db, "execution_decision_facts", ["owner"])) {
+        ownerDuplicateCount = (
+          db
+            .prepare(
+              `SELECT COUNT(*) AS count
+               FROM execution_decision_facts
+               WHERE owner IN ('cron_run_receipts', 'task_runs', 'flow_runs')`,
+            )
+            .get() as { count: number }
         ).count;
       }
     } finally {
       db.close();
     }
-    if (genericCount !== 0) {
+    if (ownerDuplicateCount !== 0) {
       throw new Error("owner lifecycle rows were duplicated into execution_decision_facts");
     }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the integrated execution-audit QA packet failed against canonical main after later receipt and ingress-hardening work changed the public inspection contract and added legitimate generic decision facts.

## Why This Change Was Made

The QA verifiers now consume the safe `decisionDisplays`/`selectorId` projection, require explicit unknown provenance for private generic facts, scope owner-native duplicate checks to the owner tables under test, and reject spoofed proxy attribution on an ordinary Gateway listener. The QA-only SQLite inspector gained an exact run/action/reason filter so the scenario can prove the private suppression fact without exposing it through public RPC/CLI output.

The repeated-turn child exits after its recorder shutdown, avoiding a hang from process-wide handles warmed by the two-turn runtime proof. No production runtime, schema, config, or public contract changes.

## User Impact

No user-visible behavior change. The integrated-main audit validation packet once again verifies the current privacy, attribution, restart, receipt, and no-duplicate contracts instead of asserting superseded internal projections.

## Evidence

- Canonical base: `9fc503730b1b9c22f3d14391360ad220bf4027f3`; all 19 required implementation merge SHAs were verified as ancestors before validation.
- Pre-fix integrated run: three real-flow failures reproduced in `agent-run-identity-inspection`, `message-delivery-decision-inspection`, and `autonomous-task-lifecycle-receipts`; the other three lanes passed.
- Focused unit proof: `extensions/qa-lab/src/execution-identity-storage-inspection.test.ts`, `packages/gateway-protocol/src/schema/audit-run.test.ts`, and `src/audit/execution-owner-lifecycle-receipts.test.ts` — 19/19 passed.
- Post-fix real-flow proof: all six lanes passed. One concurrent subagent lane hit an infrastructure-only partial `dist/` rebuild race, then passed on the one permitted direct retry after the build stabilized.
- Local `pnpm tsgo:all` passed after a clean `pnpm install` restored missing workspace dependencies.
- Normal 90-minute Testbox heavy gate: exit 0 in 32m08s — https://github.com/openclaw/openclaw/actions/runs/33091777933
- Exact-head PR CI: 151 checks passed. `build-artifacts` missed the `plugins list --json` startup-memory ceiling by 0.1 MB (401.1 MB measured vs 401 MB effective, samples 356.8–424.9 MB); the dependent `openclaw/ci-gate` therefore failed. This is non-attributable to the QA-only patch and was recorded without rerun or rebase as required — https://github.com/openclaw/openclaw/actions/runs/33095515607
- Ordinary Autoreview: clean, no accepted/actionable findings.
- TruffleHog 3.97.1 over `9fc5037..08edcc2`: 0 verified/unknown secrets, scan errors fail closed.
- Production LOC: `+0/-0`. QA/test/test-support: `+150/-390` (net `-240`).
- Codex contract inspected at `openai/codex@f1087ff151b06e781ecb086068d45fcc62d02da3`: `codex-rs/app-server-protocol/src/protocol/v2/item.rs`, `codex-rs/app-server-protocol/src/protocol/common.rs`, `codex-rs/protocol/src/protocol.rs`, and `codex-rs/app-server/src/bespoke_event_handling.rs`. Approval requests retain thread/turn/item identity; denied/timed-out and aborted outcomes map distinctly through the app-server bridge.

### Repair ownership

- Root cause: integrated QA verifiers retained pre-safe-projection assumptions while later merged implementation PRs intentionally restricted generic receipt display, added other generic decision producers, and hardened forwarded-header trust.
- Owner: QA Lab scenario/runtime verification boundary.
- Canonical repair: validate current public-safe output, use exact QA-only storage proof where private fact existence is required, and scope duplicate assertions to the owner-native families under test.
- Removed paths: synthetic Tailscale binary/device-pairing proxy simulation and obsolete private receipt-field assertions.
- Sibling coverage: local CLI admission, profileless Gateway admission, untrusted proxy rejection, repeated execution selection, SQLite opt-in/lazy ensure, owner-native approvals/task lifecycle, channel delivery/suppression, subagent lineage, RPC/CLI projection, privacy/redaction, pagination selectors, restart durability, no duplicates, and explicit unknown/unattributed/unsupported states.
