### PR TITLE
fix(configure): keep the existing primary model when adding a custom provider

### DIFF
--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -1,6 +1,8 @@
+import { createServer } from "node:http";
 // Configure gateway auth prompt tests cover interactive auth selection and model-aware auth config.
 import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
@@ -143,7 +145,6 @@ const mocks = vi.hoisted(() => ({
       };
     },
   ),
-  promptCustomApiConfig: vi.fn(),
   resolvePluginProvidersCore: vi.fn(() => []),
   resolveProviderPluginChoiceCore: vi.fn<() => unknown>(() => null),
   loadStaticManifestCatalogRowsForList: vi.fn<() => readonly NormalizedModelCatalogRow[]>(() => []),
@@ -188,10 +189,6 @@ vi.mock("./model-picker.js", () => ({
   applyPrimaryModel: mocks.applyPrimaryModel,
   promptModelAllowlist: mocks.promptModelAllowlist,
   promptDefaultModel: mocks.promptDefaultModel,
-}));
-
-vi.mock("./onboard-custom.js", () => ({
-  promptCustomApiConfig: mocks.promptCustomApiConfig,
 }));
 
 vi.mock("../plugins/providers.runtime.js", () => ({
@@ -857,46 +854,115 @@ describe("promptAuthConfig", () => {
     expect(result.agents?.entries?.ops).toBeUndefined();
   });
 
-  it("projects custom-provider model metadata onto the explicit target", async () => {
-    vi.clearAllMocks();
-    mocks.promptAuthChoiceGrouped.mockResolvedValue("custom-api-key");
-    mocks.promptCustomApiConfig.mockResolvedValue({
-      config: {
+  it.each<{
+    name: string;
+    explicit?: boolean;
+    defaultModel?: AgentModelConfig;
+    agentModel?: AgentModelConfig;
+    expectedModel: AgentModelConfig | undefined;
+  }>([
+    {
+      name: "preserves the existing primary and fallbacks",
+      defaultModel: { primary: "openai/gpt-5.6-luna", fallbacks: ["anthropic/sonnet-4.6"] },
+      expectedModel: { primary: "openai/gpt-5.6-luna", fallbacks: ["anthropic/sonnet-4.6"] },
+    },
+    {
+      name: "preserves a string primary",
+      defaultModel: "openai/gpt-5.6-luna",
+      expectedModel: "openai/gpt-5.6-luna",
+    },
+    {
+      name: "sets the primary when none exists",
+      expectedModel: { primary: "custom/llama3" },
+    },
+    {
+      name: "sets the primary while keeping existing fallbacks",
+      defaultModel: { fallbacks: ["anthropic/sonnet-4.6"] },
+      expectedModel: { primary: "custom/llama3", fallbacks: ["anthropic/sonnet-4.6"] },
+    },
+    {
+      name: "preserves the explicit target's primary",
+      explicit: true,
+      agentModel: { primary: "openai/gpt-5.6-luna", fallbacks: ["anthropic/sonnet-4.6"] },
+      expectedModel: { primary: "openai/gpt-5.6-luna", fallbacks: ["anthropic/sonnet-4.6"] },
+    },
+    {
+      name: "preserves the explicit target's inherited primary",
+      explicit: true,
+      defaultModel: { primary: "openai/gpt-5.6-luna" },
+      expectedModel: undefined,
+    },
+    {
+      name: "preserves inherited primary with agent-only fallbacks",
+      explicit: true,
+      defaultModel: { primary: "openai/gpt-5.6-luna" },
+      agentModel: { fallbacks: ["anthropic/sonnet-4.6"] },
+      expectedModel: { fallbacks: ["anthropic/sonnet-4.6"] },
+    },
+    {
+      name: "sets the explicit target's primary when none exists",
+      explicit: true,
+      expectedModel: { primary: "custom/llama3" },
+    },
+  ])(
+    "custom-provider setup $name",
+    async ({ explicit, defaultModel, agentModel, expectedModel }) => {
+      vi.clearAllMocks();
+      mocks.promptAuthChoiceGrouped.mockResolvedValue("custom-api-key");
+      await using server = createServer((_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end("{}");
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Expected a TCP listener");
+      }
+      const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+      const prompter: WizardPrompter = {
+        intro: vi.fn(),
+        outro: vi.fn(),
+        note: vi.fn(),
+        select: vi.fn().mockResolvedValueOnce("plaintext").mockResolvedValueOnce("openai"),
+        multiselect: vi.fn(),
+        text: vi
+          .fn()
+          .mockResolvedValueOnce(baseUrl)
+          .mockResolvedValueOnce("")
+          .mockResolvedValueOnce("llama3")
+          .mockResolvedValueOnce("custom")
+          .mockResolvedValueOnce("Custom"),
+        confirm: vi.fn().mockResolvedValue(false),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      };
+
+      const config: OpenClawConfig = {
         agents: {
-          ownership: "explicit" as const,
-          entries: {
-            main: {},
-            OPS: {
-              model: { primary: "custom/model" },
-              models: { "custom/model": { alias: "Custom" } },
-            },
-          },
+          ...(explicit ? { ownership: "explicit" } : {}),
+          defaults: { systemAgent: { agentId: "ops" }, model: defaultModel },
+          entries: { OPS: { model: agentModel } },
         },
-        models: { providers: { custom: { models: [{ id: "model" }] } } },
-      },
-      providerId: "custom",
-      modelId: "model",
-    });
+      };
+      const result = await promptAuthConfig(config, makeRuntime(), prompter, {
+        agentId: "ops",
+        agentDir: "/tmp/ops-agent",
+        workspaceDir: "/tmp/ops-workspace",
+      });
 
-    const config = {
-      agents: {
-        ownership: "explicit" as const,
-        defaults: { systemAgent: { agentId: "ops" } },
-        entries: { main: {}, OPS: {} },
-      },
-    };
-    const result = await promptAuthConfig(config, makeRuntime(), noopPrompter, {
-      agentId: "ops",
-      agentDir: "/tmp/ops-agent",
-      workspaceDir: "/tmp/ops-workspace",
-    });
-
-    expect(mocks.promptCustomApiConfig).toHaveBeenCalledWith(
-      expect.objectContaining({ target: expect.objectContaining({ agentId: "ops" }) }),
-    );
-    expect(result.agents?.entries?.OPS?.model).toEqual({ primary: "custom/model" });
-    expect(result.agents?.entries?.OPS?.models).toEqual({ "custom/model": { alias: "Custom" } });
-    expect(result.agents?.defaults?.model).toBeUndefined();
-    expect(result.models?.providers?.custom?.models).toEqual([{ id: "model" }]);
-  });
+      const modelOwner = explicit ? result.agents?.entries?.OPS : result.agents?.defaults;
+      expect(modelOwner?.model).toEqual(expectedModel);
+      expect(modelOwner?.models?.["custom/llama3"]).toEqual({ alias: "Custom" });
+      if (explicit) {
+        expect(result.agents?.defaults?.model).toEqual(defaultModel);
+        expect(result.agents?.defaults?.models).toBeUndefined();
+      }
+      expect(result.models?.providers?.custom).toMatchObject({
+        baseUrl,
+        api: "openai-completions",
+        models: [{ id: "llama3" }],
+      });
+    },
+  );
 });

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -1,5 +1,6 @@
 // Configure wizard model/auth selection and gateway auth config helpers.
 import { resolveMutableAgentEntry } from "../agents/agent-scope-config.js";
+import { resolveAgentEffectiveModelPrimary } from "../agents/agent-scope.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig, GatewayAuthConfig } from "../config/config.js";
@@ -234,7 +235,13 @@ export async function promptAuthConfig(
           });
 
     if (authChoice === "custom-api-key") {
-      const customResult = await promptCustomApiConfig({ prompter, runtime, config: next, target });
+      const customResult = await promptCustomApiConfig({
+        prompter,
+        runtime,
+        config: next,
+        target,
+        setAsPrimary: !resolveAgentEffectiveModelPrimary(next, target.agentId),
+      });
       next = customResult.config;
       break;
     }


### PR DESCRIPTION
## What Problem This Solves

`openclaw configure --section model` → Custom Provider silently replaced the operator's primary model. `docs/cli/configure.md:42` promises that adding or reauthenticating a provider preserves an existing primary (changing it is `models set` / `models auth login --set-default`), but configure's custom branch called `promptCustomApiConfig()` without `setAsPrimary` (`src/commands/configure.gateway-auth.ts:237`); the helper forwards explicit false only (`onboard-custom.ts:424`), so `applyCustomApiConfig()` invoked the real primary writer (`onboard-custom-config.ts:698-700`). History: `8d57d745cf5` established the preservation contract and wired the ordinary-provider flags but left the custom branch; `3f2d3f995` added the helper flag for onboarding's keep-model choice without wiring configure. The omission ships in stable v2026.7.1.

## Why This Change Was Made

The configure call site now owns its preservation decision: `setAsPrimary: !resolveAgentEffectiveModelPrimary(next, target.agentId)` — set primary only when none exists (the working first-setup path, which the docs don't protect and onboarding relies on), never replace an existing one. A complete caller inventory verified the shared helper default must not change: classic onboarding passes its explicit keep-model decision, explicit custom onboarding legitimately selects its model, and reset preflight discards the config. The existing resolver handles string/object primary forms, inheritance, and fallback-only overrides — no new resolver, helper, or config surface. Net **+7** production lines (one import + the flag).

## User Impact

Adding a custom provider through configure registers the provider/model alias without hijacking the operator's primary model, matching the documented contract. Fresh setups still get the new model as their first primary.

## Evidence

- Failing-first: the old test mocked the entire custom helper and started with no primary; replaced with eight table cases through the real `promptAuthConfig` flow (real custom prompt, credential prompt, endpoint verification against a disposable loopback HTTP server, config writer, agent projection; per-instance prompt stubs only). Pre-fix: **5 failed** (every existing-primary case showed `custom/llama3` replacing or shadowing the primary), 3 no-primary cases passed. Post-fix: all pass; re-run green on rebased head f2ae7463de2 (25 tests).
- Sibling suites (onboard-custom, wizard model-auth, non-interactive auth-choice): 127 passing tests across 6 files.
- `check-changed` full run exit 0 (twice; one lint fix in the new test's server-listen promise, no behavior change).
- Codex autoreview: clean, twice (fresh review after the test lint fix).
- Named follow-up (not claimed proven here): ordinary configure provider auth's `agentModelOverride` path (`provider-auth-choice.ts:600-602` + `configure.gateway-auth.ts:279-289`) deserves separate boundary proof for existing-explicit-primary cases.
