### PR TITLE
fix(configure): preserve unrelated gateway auth policy across reconfiguration

### DIFF
--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -53,6 +53,7 @@ When configure starts from a provider auth choice, the default-model and model-p
 
 ## Other notes
 
+- Gateway reconfiguration preserves existing `gateway.auth.allowTailscale`, `gateway.auth.rateLimit`, and `gateway.auth.identityScopes` policies. The selected auth mode replaces its credentials or trusted-proxy settings and removes fields belonging to other auth modes.
 - After local config writes, configure installs selected downloadable plugins when the chosen setup path requires them. Remote gateway config does not install local plugin packages.
 - Channel-oriented services (Slack/Discord/Matrix/Microsoft Teams) prompt for channel/room allowlists during setup. You can enter names or IDs; the wizard resolves names to IDs when possible.
 - Choosing **Reinstall** keeps the existing Gateway service in place while you select its runtime and configure validates authentication and prepares the replacement. Cancelling or failing during preparation leaves the existing service installed.

--- a/src/commands/configure.gateway-auth.test.ts
+++ b/src/commands/configure.gateway-auth.test.ts
@@ -1,5 +1,6 @@
 // Configure gateway auth tests cover gateway auth config generation and token handling.
 import { describe, expect, it } from "vitest";
+import type { GatewayAuthConfig } from "../config/config.js";
 import { buildGatewayAuthConfig } from "./configure.gateway-auth.js";
 
 function expectGeneratedTokenFromInput(
@@ -22,6 +23,59 @@ function expectGeneratedTokenFromInput(
 }
 
 describe("buildGatewayAuthConfig", () => {
+  describe.each(["token", "password", "trusted-proxy", undefined] as const)(
+    "existing mode %s",
+    (existingMode) => {
+      it.each(["token", "password", "trusted-proxy"] as const)(
+        "preserves unrelated policy and replaces mode-owned fields for %s",
+        (mode) => {
+          const modeFields = {
+            token: { token: "selected-token" },
+            password: { password: "selected-password" },
+            "trusted-proxy": { trustedProxy: { userHeader: "x-forwarded-user" } },
+          };
+          const policy: GatewayAuthConfig = {
+            allowTailscale: false,
+            rateLimit: {
+              maxAttempts: 3,
+              windowMs: 20_000,
+              lockoutMs: 90_000,
+              exemptLoopback: false,
+            },
+            identityScopes: { "operator@example.test": ["operator.read", "operator.write"] },
+          };
+          const existing = existingMode
+            ? ({
+                ...policy,
+                mode: existingMode,
+                ...{
+                  token: {
+                    token: { source: "env" as const, provider: "default", id: "OLD_TOKEN" },
+                  },
+                  password: { password: "old-password" },
+                  "trusted-proxy": {
+                    trustedProxy: {
+                      userHeader: "x-old-user",
+                      requiredHeaders: ["x-old-required"],
+                      allowUsers: ["old@example.test"],
+                    },
+                  },
+                }[existingMode],
+              } satisfies GatewayAuthConfig)
+            : undefined;
+          const original = structuredClone(existing);
+
+          expect(buildGatewayAuthConfig({ existing, mode, ...modeFields[mode] })).toEqual({
+            ...(existingMode ? policy : {}),
+            mode,
+            ...modeFields[mode],
+          });
+          expect(existing).toEqual(original);
+        },
+      );
+    },
+  );
+
   it("preserves allowTailscale when switching to token", () => {
     const result = buildGatewayAuthConfig({
       existing: {
@@ -34,34 +88,6 @@ describe("buildGatewayAuthConfig", () => {
     });
 
     expect(result).toEqual({ mode: "token", token: "abc", allowTailscale: true });
-  });
-
-  it("drops password when switching to token", () => {
-    const result = buildGatewayAuthConfig({
-      existing: {
-        mode: "password",
-        password: "secret", // pragma: allowlist secret
-        allowTailscale: false,
-      },
-      mode: "token",
-      token: "abc",
-    });
-
-    expect(result).toEqual({
-      mode: "token",
-      token: "abc",
-      allowTailscale: false,
-    });
-  });
-
-  it("drops token when switching to password", () => {
-    const result = buildGatewayAuthConfig({
-      existing: { mode: "token", token: "abc" },
-      mode: "password",
-      password: "secret", // pragma: allowlist secret
-    });
-
-    expect(result).toEqual({ mode: "password", password: "secret" }); // pragma: allowlist secret
   });
 
   it("does not silently omit password when literal string is provided", () => {

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -165,7 +165,7 @@ function resolveConfiguredProviderFromAuthChange(params: {
   );
 }
 
-/** Build gateway auth config, preserving Tailscale allowance and generating missing tokens. */
+/** Preserve unrelated auth policy; replace mode-owned credentials and proxy settings. */
 export function buildGatewayAuthConfig(params: {
   existing?: GatewayAuthConfig;
   mode: GatewayAuthChoice;
@@ -177,11 +177,10 @@ export function buildGatewayAuthConfig(params: {
     allowUsers?: string[];
   };
 }): GatewayAuthConfig | undefined {
-  const allowTailscale = params.existing?.allowTailscale;
-  const base: GatewayAuthConfig = {};
-  if (typeof allowTailscale === "boolean") {
-    base.allowTailscale = allowTailscale;
-  }
+  const base: GatewayAuthConfig = { ...params.existing };
+  delete base.token;
+  delete base.password;
+  delete base.trustedProxy;
 
   if (params.mode === "token") {
     if (isSecretRef(params.token)) {

--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -82,8 +82,13 @@ async function runGatewayPrompt(params: {
   mocks.password.mockImplementation(async () => params.textQueue.shift());
   mocks.randomToken.mockReturnValue(params.randomToken ?? "generated-token");
   mocks.confirm.mockResolvedValue(params.confirmResult ?? true);
+  const { buildGatewayAuthConfig } = await vi.importActual<
+    typeof import("./configure.gateway-auth.js")
+  >("./configure.gateway-auth.js");
   mocks.buildGatewayAuthConfig.mockImplementation((input) =>
-    params.authConfigFactory ? params.authConfigFactory(input as Record<string, unknown>) : input,
+    params.authConfigFactory
+      ? params.authConfigFactory(input as Record<string, unknown>)
+      : buildGatewayAuthConfig(input),
   );
 
   const result = await promptGatewayConfig(params.baseConfig ?? {}, makeRuntime());
@@ -110,6 +115,33 @@ async function runTrustedProxyPrompt(params: {
 }
 
 describe("promptGatewayConfig", () => {
+  it.each(["token", "trusted-proxy"] as const)(
+    "keeps existing auth policy through the real %s config builder",
+    async (mode) => {
+      const policy = {
+        allowTailscale: false,
+        rateLimit: { maxAttempts: 3, exemptLoopback: false },
+        identityScopes: { "operator@example.test": ["operator.read" as const] },
+      };
+      const { result } = await runGatewayPrompt({
+        baseConfig: { gateway: { auth: { ...policy, mode: "token", token: "old-token" } } },
+        selectQueue: ["loopback", mode, "off", "plaintext"],
+        textQueue:
+          mode === "token"
+            ? ["18789", "new-token"]
+            : ["18789", "x-forwarded-user", "", "", "10.0.0.1"],
+      });
+
+      expect(result.config.gateway?.auth).toEqual({
+        ...policy,
+        mode,
+        ...(mode === "token"
+          ? { token: "new-token" }
+          : { trustedProxy: { userHeader: "x-forwarded-user" } }),
+      });
+    },
+  );
+
   it("generates a token when the prompt returns undefined", async () => {
     const { result } = await runGatewayPrompt({
       selectQueue: ["loopback", "token", "off", "plaintext"],

--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -9,7 +9,6 @@ const mocks = vi.hoisted(() => ({
   select: vi.fn(),
   confirm: vi.fn(),
   resolveGatewayPort: vi.fn(),
-  buildGatewayAuthConfig: vi.fn(),
   note: vi.fn(),
   randomToken: vi.fn(),
   getTailnetHostname: vi.fn(),
@@ -32,10 +31,6 @@ vi.mock("./configure.shared.js", () => ({
 
 vi.mock("../../packages/terminal-core/src/note.js", () => ({
   note: mocks.note,
-}));
-
-vi.mock("./configure.gateway-auth.js", () => ({
-  buildGatewayAuthConfig: mocks.buildGatewayAuthConfig,
 }));
 
 vi.mock("../infra/tailscale.js", () => ({
@@ -67,7 +62,6 @@ async function runGatewayPrompt(params: {
   baseConfig?: OpenClawConfig;
   randomToken?: string;
   confirmResult?: boolean;
-  authConfigFactory?: (input: Record<string, unknown>) => Record<string, unknown>;
 }) {
   vi.clearAllMocks();
   mocks.resolveGatewayPort.mockReturnValue(18789);
@@ -82,25 +76,7 @@ async function runGatewayPrompt(params: {
   mocks.password.mockImplementation(async () => params.textQueue.shift());
   mocks.randomToken.mockReturnValue(params.randomToken ?? "generated-token");
   mocks.confirm.mockResolvedValue(params.confirmResult ?? true);
-  const { buildGatewayAuthConfig } = await vi.importActual<
-    typeof import("./configure.gateway-auth.js")
-  >("./configure.gateway-auth.js");
-  mocks.buildGatewayAuthConfig.mockImplementation((input) =>
-    params.authConfigFactory
-      ? params.authConfigFactory(input as Record<string, unknown>)
-      : buildGatewayAuthConfig(input),
-  );
-
-  const result = await promptGatewayConfig(params.baseConfig ?? {}, makeRuntime());
-  const authConfigCall = mocks.buildGatewayAuthConfig.mock.calls[0];
-  if (!authConfigCall) {
-    throw new Error("expected gateway auth config call");
-  }
-  const [call] = authConfigCall;
-  if (!call) {
-    throw new Error("expected gateway auth config input");
-  }
-  return { result, call };
+  return promptGatewayConfig(params.baseConfig ?? {}, makeRuntime());
 }
 
 async function runTrustedProxyPrompt(params: {
@@ -110,12 +86,11 @@ async function runTrustedProxyPrompt(params: {
   return runGatewayPrompt({
     selectQueue: ["loopback", "trusted-proxy", params.tailscaleMode ?? "off"],
     textQueue: params.textQueue,
-    authConfigFactory: ({ mode, trustedProxy }) => ({ mode, trustedProxy }),
   });
 }
 
 describe("promptGatewayConfig", () => {
-  it.each(["token", "trusted-proxy"] as const)(
+  it.each(["token", "password", "trusted-proxy"] as const)(
     "keeps existing auth policy through the real %s config builder",
     async (mode) => {
       const policy = {
@@ -123,47 +98,47 @@ describe("promptGatewayConfig", () => {
         rateLimit: { maxAttempts: 3, exemptLoopback: false },
         identityScopes: { "operator@example.test": ["operator.read" as const] },
       };
-      const { result } = await runGatewayPrompt({
+      const result = await runGatewayPrompt({
         baseConfig: { gateway: { auth: { ...policy, mode: "token", token: "old-token" } } },
         selectQueue: ["loopback", mode, "off", "plaintext"],
         textQueue:
-          mode === "token"
-            ? ["18789", "new-token"]
-            : ["18789", "x-forwarded-user", "", "", "10.0.0.1"],
+          mode === "trusted-proxy"
+            ? ["18789", "x-forwarded-user", "", "", "10.0.0.1"]
+            : ["18789", `new-${mode}`],
       });
 
       expect(result.config.gateway?.auth).toEqual({
         ...policy,
         mode,
-        ...(mode === "token"
-          ? { token: "new-token" }
-          : { trustedProxy: { userHeader: "x-forwarded-user" } }),
+        ...{
+          token: { token: "new-token" },
+          password: { password: "new-password" },
+          "trusted-proxy": { trustedProxy: { userHeader: "x-forwarded-user" } },
+        }[mode],
       });
     },
   );
 
   it("generates a token when the prompt returns undefined", async () => {
-    const { result } = await runGatewayPrompt({
+    const result = await runGatewayPrompt({
       selectQueue: ["loopback", "token", "off", "plaintext"],
       textQueue: ["18789", undefined],
       randomToken: "generated-token",
-      authConfigFactory: ({ mode, token, password }) => ({ mode, token, password }),
     });
     expect(result.token).toBe("generated-token");
+    expect(result.config.gateway?.auth).toEqual({ mode: "token", token: result.token });
     expect(mocks.password).toHaveBeenCalledWith(
       expect.objectContaining({ message: "Gateway token (blank to generate)" }),
     );
   });
 
   it("does not set password to literal 'undefined' when prompt returns undefined", async () => {
-    const { call } = await runGatewayPrompt({
+    const result = await runGatewayPrompt({
       selectQueue: ["loopback", "password", "off"],
       textQueue: ["18789", undefined],
       randomToken: "unused",
-      authConfigFactory: ({ mode, token, password }) => ({ mode, token, password }),
     });
-    expect(call.password).not.toBe("undefined");
-    expect(call.password).toBe("");
+    expect(result.config.gateway?.auth).toEqual({ mode: "password" });
     expect(mocks.password).toHaveBeenCalledWith(
       expect.objectContaining({
         message: "Gateway password",
@@ -173,7 +148,7 @@ describe("promptGatewayConfig", () => {
   });
 
   it("prompts for trusted-proxy configuration when trusted-proxy mode selected", async () => {
-    const { result, call } = await runTrustedProxyPrompt({
+    const result = await runTrustedProxyPrompt({
       textQueue: [
         "18789",
         "x-forwarded-user",
@@ -183,32 +158,33 @@ describe("promptGatewayConfig", () => {
       ],
     });
 
-    expect(call.mode).toBe("trusted-proxy");
-    expect(call.trustedProxy).toEqual({
-      userHeader: "x-forwarded-user",
-      requiredHeaders: ["x-forwarded-proto", "x-forwarded-host"],
-      allowUsers: ["nick@example.com"],
+    expect(result.config.gateway?.auth).toEqual({
+      mode: "trusted-proxy",
+      trustedProxy: {
+        userHeader: "x-forwarded-user",
+        requiredHeaders: ["x-forwarded-proto", "x-forwarded-host"],
+        allowUsers: ["nick@example.com"],
+      },
     });
     expect(result.config.gateway?.bind).toBe("loopback");
     expect(result.config.gateway?.trustedProxies).toEqual(["10.0.1.10", "192.168.1.5"]);
   });
 
   it("handles trusted-proxy with no optional fields", async () => {
-    const { result, call } = await runTrustedProxyPrompt({
+    const result = await runTrustedProxyPrompt({
       textQueue: ["18789", "x-remote-user", "", "", "10.0.0.1"],
     });
 
-    expect(call.mode).toBe("trusted-proxy");
-    expect(call.trustedProxy).toEqual({
-      userHeader: "x-remote-user",
-      // requiredHeaders and allowUsers should be undefined when empty
+    expect(result.config.gateway?.auth).toEqual({
+      mode: "trusted-proxy",
+      trustedProxy: { userHeader: "x-remote-user" },
     });
     expect(result.config.gateway?.bind).toBe("loopback");
     expect(result.config.gateway?.trustedProxies).toEqual(["10.0.0.1"]);
   });
 
   it("forces tailscale off when trusted-proxy is selected", async () => {
-    const { result } = await runTrustedProxyPrompt({
+    const result = await runTrustedProxyPrompt({
       tailscaleMode: "serve",
       textQueue: ["18789", "x-forwarded-user", "", "", "10.0.0.1"],
     });
@@ -219,12 +195,11 @@ describe("promptGatewayConfig", () => {
 
   it("adds Tailscale origin to controlUi.allowedOrigins when tailscale serve is enabled", async () => {
     mocks.getTailnetHostname.mockResolvedValue("my-host.tail1234.ts.net");
-    const { result } = await runGatewayPrompt({
+    const result = await runGatewayPrompt({
       // bind=loopback, auth=token, tailscale=serve
       selectQueue: ["loopback", "token", "serve", "plaintext"],
       textQueue: ["18789", "my-token"],
       confirmResult: true,
-      authConfigFactory: ({ mode, token }) => ({ mode, token }),
     });
     expect(result.config.gateway?.controlUi?.allowedOrigins).toEqual([
       "https://my-host.tail1234.ts.net",
@@ -233,12 +208,11 @@ describe("promptGatewayConfig", () => {
 
   it("adds Tailscale origin to controlUi.allowedOrigins when tailscale funnel is enabled", async () => {
     mocks.getTailnetHostname.mockResolvedValue("my-host.tail1234.ts.net");
-    const { result } = await runGatewayPrompt({
+    const result = await runGatewayPrompt({
       // bind=loopback, auth=password (funnel requires password), tailscale=funnel
       selectQueue: ["loopback", "password", "funnel"],
       textQueue: ["18789", "my-password"],
       confirmResult: true,
-      authConfigFactory: ({ mode, password }) => ({ mode, password }),
     });
     expect(result.config.gateway?.controlUi?.allowedOrigins).toEqual([
       "https://my-host.tail1234.ts.net",
@@ -247,18 +221,17 @@ describe("promptGatewayConfig", () => {
 
   it("does not add Tailscale origin when getTailnetHostname fails", async () => {
     mocks.getTailnetHostname.mockRejectedValue(new Error("not found"));
-    const { result } = await runGatewayPrompt({
+    const result = await runGatewayPrompt({
       selectQueue: ["loopback", "token", "serve", "plaintext"],
       textQueue: ["18789", "my-token"],
       confirmResult: true,
-      authConfigFactory: ({ mode, token }) => ({ mode, token }),
     });
     expect(result.config.gateway?.controlUi?.allowedOrigins).toBeUndefined();
   });
 
   it("does not duplicate Tailscale origin if already present", async () => {
     mocks.getTailnetHostname.mockResolvedValue("my-host.tail1234.ts.net");
-    const { result } = await runGatewayPrompt({
+    const result = await runGatewayPrompt({
       baseConfig: {
         gateway: {
           controlUi: {
@@ -269,7 +242,6 @@ describe("promptGatewayConfig", () => {
       selectQueue: ["loopback", "token", "serve", "plaintext"],
       textQueue: ["18789", "my-token"],
       confirmResult: true,
-      authConfigFactory: ({ mode, token }) => ({ mode, token }),
     });
     const origins = result.config.gateway?.controlUi?.allowedOrigins ?? [];
     const tsOriginCount = origins.filter(
@@ -280,11 +252,10 @@ describe("promptGatewayConfig", () => {
 
   it("formats IPv6 Tailscale fallback addresses as valid HTTPS origins", async () => {
     mocks.getTailnetHostname.mockResolvedValue("fd7a:115c:a1e0::12");
-    const { result } = await runGatewayPrompt({
+    const result = await runGatewayPrompt({
       selectQueue: ["loopback", "token", "serve", "plaintext"],
       textQueue: ["18789", "my-token"],
       confirmResult: true,
-      authConfigFactory: ({ mode, token }) => ({ mode, token }),
     });
     expect(result.config.gateway?.controlUi?.allowedOrigins).toEqual([
       "https://[fd7a:115c:a1e0::12]",
@@ -295,16 +266,18 @@ describe("promptGatewayConfig", () => {
     const previous = process.env.OPENCLAW_GATEWAY_TOKEN;
     process.env.OPENCLAW_GATEWAY_TOKEN = "env-gateway-token";
     try {
-      const { call, result } = await runGatewayPrompt({
+      const result = await runGatewayPrompt({
         selectQueue: ["loopback", "token", "off", "ref"],
         textQueue: ["18789", "OPENCLAW_GATEWAY_TOKEN"],
-        authConfigFactory: ({ mode, token }) => ({ mode, token }),
       });
 
-      expect(call.token).toEqual({
-        source: "env",
-        provider: "default",
-        id: "OPENCLAW_GATEWAY_TOKEN",
+      expect(result.config.gateway?.auth).toEqual({
+        mode: "token",
+        token: {
+          source: "env",
+          provider: "default",
+          id: "OPENCLAW_GATEWAY_TOKEN",
+        },
       });
       expect(result.token).toBeUndefined();
     } finally {


### PR DESCRIPTION
> **REVIEW REQUIRED — gateway security configuration. Prepared by the auto-QA campaign; intentionally left as a draft for maintainer review, not autonomous landing.**

## What Problem This Solves

`openclaw configure --section gateway` silently deleted existing Gateway auth **policies**: `buildGatewayAuthConfig()` rebuilt auth from an empty object preserving only `allowTailscale`, so an operator's explicitly configured `rateLimit` and `identityScopes` vanished on any pass through the wizard — even selecting the same auth mode. Startup then fell back to default rate limits (`src/gateway/server-runtime-state-prepare.ts:361`) and verified identities lost their grants (`ws-connection/connect-admission.ts:105`). The empty-base defect ships in stable v2026.7.1-2 (there affecting `rateLimit`; `identityScopes` postdates that schema). Classic and non-interactive onboarding already spread the existing auth block — configure was the divergent owner.

## Why This Change Was Made

The builder now starts from a shallow copy of existing auth, deletes mode-owned fields, and applies the selected mode — adopting the siblings' independent-policy preservation while keeping configure's existing credential cleanup (which the siblings lack). The special-case `allowTailscale` branch is deleted. Net **−1** production line. Complete field classification (from `zod-schema.gateway.ts:116`): `mode`/`token`/`password`/`trustedProxy` are mode-owned (replaced; stale mode credentials removed), `allowTailscale`/`identityScopes`/`rateLimit` are independent policy (preserved verbatim, including explicit false). Fresh configs invent no policies.

**Deliberately unchanged + named follow-up:** same-mode trusted-proxy reconfiguration still replaces the whole `trustedProxy` block from the prompted fields, omitting unprompted `allowLoopback`/`deviceAutoApprove` — that nested trust-boundary ownership needs a security-owner decision (it interacts with the audit's separate finding that the wizard never surfaces the `allowLoopback` opt-in at all).

## User Impact

Reconfiguring the gateway no longer silently strips brute-force rate limiting or identity scope grants. Mode switches still cleanly remove the abandoned mode's credentials.

## Evidence

- Failing-first: existing `rateLimit` + `identityScopes` survive a same-mode pass (pre-fix: deleted); mode-switch matrix (token/password/trusted-proxy × all three, plus fresh config) covered in builder + prompt + gateway wizard tests.
- Behavior matrix in the worker report covers every transition; the input config is never mutated.
- `check-changed` full gates: pass. Codex autoreview: clean.
- LOC: production +5/−6 (**−1**); tests +58; docs +1 (configure reference note).
