### PR TITLE
fix(runtime): isolate experience review foreground admission

### DIFF
--- a/src/skills/workshop/experience-review.admission.test.ts
+++ b/src/skills/workshop/experience-review.admission.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
+import { resolveSessionLane } from "../../agents/embedded-agent-runner/lanes.js";
+import type { EmbeddedForegroundPromptContext } from "../../agents/embedded-agent-runner/run/params.js";
+import {
+  clearActiveEmbeddedRun,
+  queueEmbeddedAgentMessageWithOutcome,
+  setActiveEmbeddedRun,
+} from "../../agents/embedded-agent-runner/runs.js";
+import {
+  createEmbeddedRunHandle,
+  testing as embeddedRunsTesting,
+} from "../../agents/embedded-agent-runner/runs.test-support.js";
+import { enqueueCommandInLane } from "../../process/command-queue.js";
+import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
+import { runSkillExperienceReview } from "./experience-review.js";
+
+const runEmbeddedAgent = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/embedded-agent.js", () => ({ runEmbeddedAgent }));
+vi.mock("../../agents/run-session-target.js", () => ({
+  resolveAgentRunSessionTarget: vi.fn(
+    async (params: { agentId?: string; sessionId: string; sessionKey: string }) => ({
+      agentId: params.agentId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      storePath: "/tmp/session-store.json",
+    }),
+  ),
+}));
+vi.mock("../../agents/sessions/index.js", () => ({
+  SessionManager: {
+    open: vi.fn(() => ({ getEntries: () => [] })),
+    fromEntries: vi.fn(() => ({})),
+  },
+}));
+
+afterEach(() => {
+  runEmbeddedAgent.mockReset();
+  embeddedRunsTesting.resetActiveEmbeddedRuns();
+  resetCommandQueueStateForTest();
+});
+
+describe("experience review foreground admission", () => {
+  it("starts a foreground turn while review is active without steering user instructions", async () => {
+    const foregroundSessionId = "foreground-session";
+    const foregroundSessionKey = "agent:main:discord:channel:review-admission";
+    const foregroundPromptCacheKey = "foreground-cache-prefix";
+    const reviewStarted = createDeferred();
+    const releaseReview = createDeferred();
+    const foregroundStarted = createDeferred();
+    const releaseForeground = createDeferred();
+    const reviewInstructions: string[] = [];
+    const foregroundInstructions: string[] = [];
+    let reviewParams: Record<string, unknown> | undefined;
+
+    runEmbeddedAgent.mockImplementation(async (params: Record<string, unknown>) => {
+      reviewParams = params;
+      const sessionId = String(params.sessionId);
+      const sessionKey = String(params.sessionKey);
+      const reviewHandle = createEmbeddedRunHandle({
+        runId: String(params.runId),
+        queueMessage: async (text) => {
+          reviewInstructions.push(text);
+        },
+      });
+      return await enqueueCommandInLane(resolveSessionLane(sessionKey), async () => {
+        reviewInstructions.push(String(params.prompt));
+        setActiveEmbeddedRun(sessionId, reviewHandle, sessionKey);
+        reviewStarted.resolve();
+        try {
+          await releaseReview.promise;
+          return {};
+        } finally {
+          clearActiveEmbeddedRun(sessionId, reviewHandle, sessionKey);
+        }
+      });
+    });
+
+    const foregroundPromptContext: EmbeddedForegroundPromptContext = {
+      agentId: "main",
+      agentDir: "/tmp/workspace",
+      workspaceDir: "/tmp/workspace",
+      cwd: "/tmp/workspace",
+      sandboxSessionKey: foregroundSessionKey,
+      trigger: "user",
+      promptCacheKey: foregroundPromptCacheKey,
+    };
+    const config = { skills: { workshop: { autonomous: { mode: "propose" as const } } } };
+    const review = runSkillExperienceReview(
+      {
+        ctx: {
+          agentId: "main",
+          runId: "foreground-run",
+          sessionId: foregroundSessionId,
+          sessionKey: foregroundSessionKey,
+          workspaceDir: "/tmp/workspace",
+          modelProviderId: "openai",
+          modelId: "gpt-test",
+          foregroundPromptContext,
+        },
+        config,
+      },
+      { getCurrentConfig: () => config },
+    );
+    let reviewSettled = false;
+    void review.then(
+      () => {
+        reviewSettled = true;
+      },
+      () => {
+        reviewSettled = true;
+      },
+    );
+    let foreground: Promise<unknown> | undefined;
+    try {
+      await reviewStarted.promise;
+      const queueOutcome = queueEmbeddedAgentMessageWithOutcome(
+        foregroundSessionId,
+        "foreground-user-instruction",
+      );
+      foreground = enqueueCommandInLane(resolveSessionLane(foregroundSessionKey), async () => {
+        foregroundInstructions.push("foreground-system-instruction");
+        foregroundStarted.resolve();
+        await releaseForeground.promise;
+      });
+
+      await withTestTimeout(
+        foregroundStarted.promise,
+        1_000,
+        "foreground turn waited behind the active experience review",
+      );
+
+      expect(reviewSettled).toBe(false);
+      expect(queueOutcome).toMatchObject({ queued: false, reason: "no_active_run" });
+      expect(reviewInstructions).not.toContain("foreground-user-instruction");
+      expect(foregroundInstructions).toEqual(["foreground-system-instruction"]);
+      expect(reviewParams).toMatchObject({
+        promptCacheKey: foregroundPromptCacheKey,
+        sandboxSessionKey: foregroundSessionKey,
+        sessionPersistence: "detached",
+      });
+      expect(reviewParams?.sessionId).not.toBe(foregroundSessionId);
+      expect(reviewParams?.sessionKey).not.toBe(foregroundSessionKey);
+    } finally {
+      releaseForeground.resolve();
+      releaseReview.resolve();
+      await Promise.allSettled([review, ...(foreground ? [foreground] : [])]);
+    }
+  });
+});

--- a/src/skills/workshop/experience-review.apply.test.ts
+++ b/src/skills/workshop/experience-review.apply.test.ts
@@ -139,7 +139,13 @@ describe("experience review auto apply", () => {
     expect(observed).toEqual([
       ["assistant", false, false, false, undefined],
       ["tool", false, false, false, undefined],
-      ["lifecycle", false, false, false, "agent:main:main"],
+      [
+        "lifecycle",
+        false,
+        false,
+        false,
+        expect.stringMatching(/^agent:main:skill-workshop-review:incognito-/),
+      ],
     ]);
     expect(getAgentRunContext(reviewRunId)).toBeUndefined();
   });

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -413,6 +413,8 @@ async function runSkillExperienceReviewInner(
   });
   const foregroundSession = SessionManager.open(sessionTarget, workspaceDir);
   const detachedSession = SessionManager.fromEntries(foregroundSession.getEntries(), workspaceDir);
+  const reviewSessionId = randomUUID();
+  const reviewSessionKey = `agent:${sessionTarget.agentId}:skill-workshop-review:incognito-${reviewSessionId}`;
   const { listWritableWorkspaceSkillSummaries } = await import("./workspace-skill-read.js");
   const existingSkills = listWritableWorkspaceSkillSummaries(workspaceDir, {
     config,
@@ -429,12 +431,12 @@ async function runSkillExperienceReviewInner(
   let outcome: "applied" | "proposed" | "nothing";
   let proposalId: string | undefined;
   let usage: { inputTokens: number; cachedInputTokens: number; outputTokens: number } | undefined;
-  // The warm review reuses the foreground session identity for prompt caching.
-  // Keep every review event and lifecycle transition out of that user-visible session.
+  // The review reads the foreground snapshot and keeps its prompt-cache affinity,
+  // but owns an incognito run identity so foreground admission and steering stay independent.
   registerAgentRunContext(runId, {
     agentId: foregroundPromptContext.agentId,
-    sessionId,
-    sessionKey,
+    sessionId: reviewSessionId,
+    sessionKey: reviewSessionKey,
     isControlUiVisible: false,
     projectSessionActive: false,
     projectSessionLifecycle: false,
@@ -447,9 +449,8 @@ async function runSkillExperienceReviewInner(
         runEmbeddedAgent({
           ...foregroundPromptContext,
           preparedRunAdmission,
-          sessionId,
-          sessionKey,
-          sessionTarget,
+          sessionId: reviewSessionId,
+          sessionKey: reviewSessionKey,
           sessionManager: detachedSession,
           sessionPersistence: "detached",
           // Never occupy the foreground agent lane after the idle gate opens.
@@ -482,7 +483,7 @@ async function runSkillExperienceReviewInner(
             sessionKey,
             ...(candidate.ctx.runId ? { runId: candidate.ctx.runId } : {}),
           },
-          // The review shares the foreground session, so its MCP runtime stays warm for the next turn.
+          // Foreground prompt context keeps provider cache affinity without sharing admission.
           verboseLevel: "off",
           suppressToolErrorWarnings: true,
           ...(capability ? { cronCreatorAuthorityCapability: capability } : {}),


### PR DESCRIPTION
Closes #131018

## What Problem This Solves

Autonomous Skill Workshop experience review reused the foreground session's admission identity. The hidden review therefore became active foreground work, occupied the same session lane, and accepted steering intended for a newly arriving user turn. In the reported incident, the user turn waited 107 seconds and then inherited the review-only `skill_workshop` constraint.

## Why This Change Was Made

The review still needs the foreground semantic identity, prompt-cache affinity, sandbox policy, MCP context, and a detached transcript snapshot. Those warm resources are separate from admission ownership.

This change gives the review an incognito admission identity and threads it through the complete transient ownership path:

- session lane and admitted run context
- active-run registration, aliases, snapshots, and diagnostics
- timeout abandonment and terminal cleanup
- detached auxiliary placement admission

Worker placement remains authoritative for real sessions. A detached review uses the existing sessionless-local auxiliary contract, so it neither claims the foreground placement nor creates synthetic durable placement state.

## User Impact

A foreground message can start while an autonomous experience review is still active. It cannot be queued into the hidden review, inherit its instructions, overwrite its active-run snapshot, or collide with its placement claim.

## Evidence

- Real incident: the hidden review started at 15:40:36 UTC; the user message arrived at 15:41:02; foreground execution began at 15:42:49, a 107-second admission delay.
- Pre-fix proof: the new concurrency regression timed out with `foreground turn waited behind the active experience review` on the prior source.
- Post-fix concurrency proof: the review remains active while the foreground session lane starts within the test bound; steering returns `no_active_run`; foreground text never enters the review prompt.
- Placement proof: with an active foreground worker turn claim, the detached review executes locally, creates no placement row, and leaves the foreground claim unchanged.
- Cache/resource proof: foreground semantic identity, `promptCacheKey`, `sandboxSessionKey`, provider/MCP context, and detached transcript behavior remain unchanged.
- Focused tests: 84 passed across the changed admission, lifecycle, snapshot, cleanup, Skill Workshop, and real worker-placement boundaries.
- `pnpm check:changed` passed, including formatting, dependency and API guards, dead exports, core/core-test typecheck, type-aware lint, schema guards, and import-cycle checks.
- Independent exact-head Codex review found no concrete regression after the placement repair.

## Reviewability

- 18 files, +386/-32
- production: 11 files, +74/-27
- tests: 7 files, +312/-5
- no public API, configuration, schema, generated output, new framework, or unrelated cleanup
- rollback: revert this single commit

The diff exceeds the normal file-count budget because one admission identity crosses the lane, placement, registry, snapshot, timeout, diagnostic, and cleanup owners. Splitting those surfaces would leave a partial identity path and recreate the bug class. Each production change is the smallest propagation or cleanup point for that one invariant; tests are grouped at the owning boundaries.

## Owner Acceptance Card

- Intended behavior: hidden experience reviews never own or contaminate foreground admission.
- Changed boundary: transient embedded-run admission identity only; foreground semantic/cache/tool-policy identity remains intact.
- Blast radius: embedded runner lifecycle and local auxiliary worker-placement admission for detached isolated runs.
- Strongest evidence: pre-fix red concurrency proof, current-head concurrency and real placement-store regressions, 84 focused tests, full changed-file gate, and independent review.
- Known gap/falsifier: no installed-Gateway Discord replay was run on this unmerged head; a foreground turn waiting, steering into the review, or losing its placement/cache identity would falsify the fix.
- Rollback: revert the single commit.
- Why one change: every touched production surface consumes or releases the same admission identity invariant.

## Disclosure

AI-assisted: yes. I reviewed the implementation, scope, tests, and ownership change and understand the result.
