### PR TITLE
fix(onboard): preserve the remote gateway TLS pin for an unchanged endpoint

### DIFF
--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -79,6 +79,9 @@ preserves the remote TLS fingerprint and transport settings when you keep the
 same URL (ignoring surrounding whitespace). Changing the URL clears those
 endpoint settings. A newly confirmed discovery fingerprint replaces the saved
 pin only for the discovered URL, and your selected auth method still applies.
+Accepting a discovered direct connection selects direct transport. Choosing a
+discovered SSH tunnel clears saved transport settings for the suggested loopback
+URL, which may now reach a different host; start the displayed tunnel manually.
 
 Host-key verification is strict by default (`gateway.remote.sshHostKeyPolicy: "strict"`). Set it to `"openssh"` to delegate to your effective OpenSSH config instead; review your user and system SSH settings before enabling it.
 

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -74,6 +74,12 @@ Persist a remote target so CLI commands use it by default:
 
 When the Gateway is loopback-only, keep the URL at `ws://127.0.0.1:18789` and open the SSH tunnel first. In the macOS app's SSH-tunnel transport, the discovered Gateway hostname goes in `gateway.remote.sshTarget` (`user@host` or `user@host:port`); `gateway.remote.url` stays the local tunnel URL. If the remote port differs from the local one, set `gateway.remote.remotePort`.
 
+Running `openclaw configure --section gateway` or interactive onboarding again
+preserves the remote TLS fingerprint and transport settings when you keep the
+same URL (ignoring surrounding whitespace). Changing the URL clears those
+endpoint settings. A newly confirmed discovery fingerprint replaces the saved
+pin only for the discovered URL, and your selected auth method still applies.
+
 Host-key verification is strict by default (`gateway.remote.sshHostKeyPolicy: "strict"`). Set it to `"openssh"` to delegate to your effective OpenSSH config instead; review your user and system SSH settings before enabling it.
 
 For a Gateway already reachable on a trusted LAN or Tailnet, use direct mode:

--- a/src/commands/onboard-remote.test.ts
+++ b/src/commands/onboard-remote.test.ts
@@ -62,11 +62,12 @@ describe("promptRemoteGatewayConfig", () => {
   const envSnapshot = captureEnv(["OPENCLAW_ALLOW_INSECURE_PRIVATE_WS"]);
 
   async function runRemotePrompt(params: {
+    cfg?: OpenClawConfig;
     text: WizardPrompter["text"];
     selectResponses: Partial<Record<string, string>>;
     confirm: boolean;
   }) {
-    const cfg = {} as OpenClawConfig;
+    const cfg = params.cfg ?? {};
     const prompter = createPrompter({
       confirm: vi.fn(async () => params.confirm),
       select: createSelectPrompter(params.selectResponses),
@@ -88,6 +89,71 @@ describe("promptRemoteGatewayConfig", () => {
   afterEach(() => {
     envSnapshot.restore();
     delete process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS;
+  });
+
+  it.each([
+    { name: "unchanged URL", auth: "token", url: "wss://gateway.example/rpc" },
+    { name: "trimmed URL", auth: "token", url: " wss://gateway.example/rpc " },
+    { name: "changed host", auth: "token", url: "wss://other.example/rpc" },
+    { name: "changed path", auth: "token", url: "wss://gateway.example/other" },
+    { name: "password selection", auth: "password", url: "wss://gateway.example/rpc" },
+    { name: "auth disabled", auth: "off", url: "wss://gateway.example/rpc" },
+    {
+      name: "changed URL seeded by onboarding",
+      auth: "token",
+      url: "wss://other.example/rpc",
+      seededUrl: "wss://other.example/rpc",
+    },
+    {
+      name: "seeded URL edited back to the original endpoint",
+      auth: "token",
+      url: "wss://gateway.example/rpc",
+      seededUrl: "wss://other.example/rpc",
+    },
+    {
+      name: "seeded URL without a previously configured endpoint",
+      auth: "token",
+      url: "wss://other.example/rpc",
+      seededUrl: "wss://other.example/rpc",
+      noOriginalUrl: true,
+    },
+  ])("scopes saved remote settings for $name", async ({ auth, url, seededUrl, noOriginalUrl }) => {
+    const remote = {
+      url: noOriginalUrl ? undefined : " wss://gateway.example/rpc ",
+      transport: "direct" as const,
+      remotePort: 19443,
+      token: "existing-token",
+      password: "existing-password",
+      edgeAuth: { "X-Edge-Auth": "test-secret" },
+      tlsFingerprint: "ab".repeat(32),
+      sshTarget: "operator@gateway.example",
+      sshIdentity: "/tmp/test-identity",
+      sshHostKeyPolicy: "strict" as const,
+    };
+    const cfg: OpenClawConfig = {
+      gateway: { mode: "remote", remote: { ...remote, url: seededUrl ?? remote.url } },
+    };
+    detectBinary.mockResolvedValue(true);
+    const prompter = createPrompter({
+      confirm: vi.fn(async ({ message }) => message.startsWith("Use existing gateway")),
+      select: createSelectPrompter({ "Gateway auth": auth }),
+      text: vi.fn(async () => url),
+    });
+
+    const next = await promptRemoteGatewayConfig(cfg, prompter, {
+      secretInputMode: "plaintext",
+      ...(seededUrl ? { remoteOriginUrl: remote.url } : {}),
+    });
+
+    const unchanged = url.trim() === remote.url?.trim();
+    expect(next.gateway?.remote).toEqual({
+      ...(unchanged ? remote : {}),
+      url: url.trim(),
+      token: auth === "token" ? remote.token : undefined,
+      password: auth === "password" ? remote.password : undefined,
+    });
+    expect(cfg.gateway?.remote).toEqual({ ...remote, url: seededUrl ?? remote.url });
+    expect(discoverGatewayBeacons).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -116,46 +182,50 @@ describe("promptRemoteGatewayConfig", () => {
     expect(next.gateway?.remote?.edgeAuth).toEqual(expected);
   });
 
-  it("defaults discovered direct remote URLs to wss://", async () => {
-    detectBinary.mockResolvedValue(true);
-    discoverGatewayBeacons.mockResolvedValue([createGatewayDiscoveryBeacon()]);
+  it.each([undefined, "wss://gateway.tailnet.ts.net:18789", "wss://old.example/rpc"])(
+    "pins a trusted discovery endpoint with previous URL %s",
+    async (previousUrl) => {
+      detectBinary.mockResolvedValue(true);
+      discoverGatewayBeacons.mockResolvedValue([createGatewayDiscoveryBeacon()]);
 
-    const text: WizardPrompter["text"] = vi.fn(async (params) => {
-      if (params.message === "Gateway WebSocket URL") {
-        expect(params.initialValue).toBe("wss://gateway.tailnet.ts.net:18789");
-        expect(params.validate?.(String(params.initialValue))).toBeUndefined();
-        return String(params.initialValue);
-      }
-      if (params.message === "Gateway token") {
-        return "token-123";
-      }
-      return "";
-    }) as WizardPrompter["text"];
+      const text: WizardPrompter["text"] = vi.fn(async (params) => {
+        if (params.message === "Gateway WebSocket URL") {
+          expect(params.initialValue).toBe("wss://gateway.tailnet.ts.net:18789");
+          expect(params.validate?.(String(params.initialValue))).toBeUndefined();
+          return String(params.initialValue);
+        }
+        if (params.message === "Gateway token") {
+          return "token-123";
+        }
+        return "";
+      }) as WizardPrompter["text"];
 
-    const { next, prompter } = await runRemotePrompt({
-      text,
-      confirm: true,
-      selectResponses: {
-        "Select gateway": "0",
-        "Connection method": "direct",
-        "Gateway auth": "token",
-      },
-    });
+      const { next, prompter } = await runRemotePrompt({
+        cfg: { gateway: { remote: { url: previousUrl, tlsFingerprint: "sha256:old-pin" } } },
+        text,
+        confirm: true,
+        selectResponses: {
+          "Select gateway": "0",
+          "Connection method": "direct",
+          "Gateway auth": "token",
+        },
+      });
 
-    expect(next.gateway?.mode).toBe("remote");
-    expect(next.gateway?.remote?.url).toBe("wss://gateway.tailnet.ts.net:18789");
-    expect(next.gateway?.remote?.token).toBe("token-123");
-    expect(next.gateway?.remote?.tlsFingerprint).toBe("sha256:abc123");
-    expect(prompter.note).toHaveBeenCalledWith(
-      [
-        "Direct remote access defaults to TLS.",
-        "Using: wss://gateway.tailnet.ts.net:18789",
-        "TLS pin: sha256:abc123",
-        "If your gateway is loopback-only, choose SSH tunnel and keep ws://127.0.0.1:18789.",
-      ].join("\n"),
-      "Direct remote",
-    );
-  });
+      expect(next.gateway?.mode).toBe("remote");
+      expect(next.gateway?.remote?.url).toBe("wss://gateway.tailnet.ts.net:18789");
+      expect(next.gateway?.remote?.token).toBe("token-123");
+      expect(next.gateway?.remote?.tlsFingerprint).toBe("sha256:abc123");
+      expect(prompter.note).toHaveBeenCalledWith(
+        [
+          "Direct remote access defaults to TLS.",
+          "Using: wss://gateway.tailnet.ts.net:18789",
+          "TLS pin: sha256:abc123",
+          "If your gateway is loopback-only, choose SSH tunnel and keep ws://127.0.0.1:18789.",
+        ].join("\n"),
+        "Direct remote",
+      );
+    },
+  );
 
   it("falls back to manual URL entry when discovery trust is declined", async () => {
     detectBinary.mockResolvedValue(true);
@@ -204,62 +274,72 @@ describe("promptRemoteGatewayConfig", () => {
     expect(next.gateway?.remote?.tlsFingerprint).toBeUndefined();
   });
 
-  it("trusts discovery endpoint without fingerprint and omits tlsFingerprint", async () => {
-    detectBinary.mockResolvedValue(true);
-    discoverGatewayBeacons.mockResolvedValue([
-      {
-        instanceName: "gw",
-        displayName: "Gateway",
-        host: "gw.example",
-        port: 18789,
-      },
-    ]);
+  it.each([undefined, "sha256:existing-pin"])(
+    "trusts discovery without an advertised fingerprint and retains existing pin %s",
+    async (tlsFingerprint) => {
+      detectBinary.mockResolvedValue(true);
+      discoverGatewayBeacons.mockResolvedValue([
+        {
+          instanceName: "gw",
+          displayName: "Gateway",
+          host: "gw.example",
+          port: 18789,
+        },
+      ]);
 
-    const text: WizardPrompter["text"] = vi.fn(async (params) => {
-      if (params.message === "Gateway WebSocket URL") {
-        return String(params.initialValue);
-      }
-      return "";
-    }) as WizardPrompter["text"];
+      const text: WizardPrompter["text"] = vi.fn(async (params) => {
+        if (params.message === "Gateway WebSocket URL") {
+          return String(params.initialValue);
+        }
+        return "";
+      }) as WizardPrompter["text"];
 
-    const { next } = await runRemotePrompt({
-      text,
-      confirm: true,
-      selectResponses: {
-        "Select gateway": "0",
-        "Connection method": "direct",
-        "Gateway auth": "off",
-      },
-    });
+      const { next } = await runRemotePrompt({
+        cfg: { gateway: { remote: { url: "wss://gw.example:18789", tlsFingerprint } } },
+        text,
+        confirm: true,
+        selectResponses: {
+          "Select gateway": "0",
+          "Connection method": "direct",
+          "Gateway auth": "off",
+        },
+      });
 
-    expect(next.gateway?.remote?.url).toBe("wss://gw.example:18789");
-    expect(next.gateway?.remote?.tlsFingerprint).toBeUndefined();
-  });
+      expect(next.gateway?.remote?.url).toBe("wss://gw.example:18789");
+      expect(next.gateway?.remote?.tlsFingerprint).toBe(tlsFingerprint);
+    },
+  );
 
-  it("drops discovery tlsFingerprint when the URL is edited after trust confirmation", async () => {
-    detectBinary.mockResolvedValue(true);
-    discoverGatewayBeacons.mockResolvedValue([createGatewayDiscoveryBeacon()]);
+  it.each([undefined, "wss://old.example:443", "wss://other.example:443"])(
+    "scopes discovery and saved pins after URL edits with previous URL %s",
+    async (previousUrl) => {
+      detectBinary.mockResolvedValue(true);
+      discoverGatewayBeacons.mockResolvedValue([createGatewayDiscoveryBeacon()]);
 
-    const text: WizardPrompter["text"] = vi.fn(async (params) => {
-      if (params.message === "Gateway WebSocket URL") {
-        return "wss://other.example:443";
-      }
-      return "";
-    }) as WizardPrompter["text"];
+      const text: WizardPrompter["text"] = vi.fn(async (params) => {
+        if (params.message === "Gateway WebSocket URL") {
+          return "wss://other.example:443";
+        }
+        return "";
+      }) as WizardPrompter["text"];
 
-    const { next } = await runRemotePrompt({
-      text,
-      confirm: true,
-      selectResponses: {
-        "Select gateway": "0",
-        "Connection method": "direct",
-        "Gateway auth": "off",
-      },
-    });
+      const { next } = await runRemotePrompt({
+        cfg: { gateway: { remote: { url: previousUrl, tlsFingerprint: "sha256:old-pin" } } },
+        text,
+        confirm: true,
+        selectResponses: {
+          "Select gateway": "0",
+          "Connection method": "direct",
+          "Gateway auth": "off",
+        },
+      });
 
-    expect(next.gateway?.remote?.url).toBe("wss://other.example:443");
-    expect(next.gateway?.remote?.tlsFingerprint).toBeUndefined();
-  });
+      expect(next.gateway?.remote?.url).toBe("wss://other.example:443");
+      expect(next.gateway?.remote?.tlsFingerprint).toBe(
+        previousUrl === "wss://other.example:443" ? "sha256:old-pin" : undefined,
+      );
+    },
+  );
 
   it("does not route from TXT-only discovery metadata", async () => {
     detectBinary.mockResolvedValue(true);

--- a/src/commands/onboard-remote.test.ts
+++ b/src/commands/onboard-remote.test.ts
@@ -59,7 +59,7 @@ function createGatewayDiscoveryBeacon(): GatewayBonjourBeacon {
 }
 
 describe("promptRemoteGatewayConfig", () => {
-  const envSnapshot = captureEnv(["OPENCLAW_ALLOW_INSECURE_PRIVATE_WS"]);
+  const envSnapshot = captureEnv(["OPENCLAW_ALLOW_INSECURE_PRIVATE_WS", "OPENCLAW_GATEWAY_TOKEN"]);
 
   async function runRemotePrompt(params: {
     cfg?: OpenClawConfig;
@@ -88,7 +88,6 @@ describe("promptRemoteGatewayConfig", () => {
 
   afterEach(() => {
     envSnapshot.restore();
-    delete process.env.OPENCLAW_ALLOW_INSECURE_PRIVATE_WS;
   });
 
   it.each([
@@ -201,7 +200,16 @@ describe("promptRemoteGatewayConfig", () => {
       }) as WizardPrompter["text"];
 
       const { next, prompter } = await runRemotePrompt({
-        cfg: { gateway: { remote: { url: previousUrl, tlsFingerprint: "sha256:old-pin" } } },
+        cfg: {
+          gateway: {
+            remote: {
+              url: previousUrl,
+              transport: "ssh",
+              sshTarget: "operator@old.example",
+              tlsFingerprint: "sha256:old-pin",
+            },
+          },
+        },
         text,
         confirm: true,
         selectResponses: {
@@ -213,6 +221,7 @@ describe("promptRemoteGatewayConfig", () => {
 
       expect(next.gateway?.mode).toBe("remote");
       expect(next.gateway?.remote?.url).toBe("wss://gateway.tailnet.ts.net:18789");
+      expect(next.gateway?.remote?.transport).toBe("direct");
       expect(next.gateway?.remote?.token).toBe("token-123");
       expect(next.gateway?.remote?.tlsFingerprint).toBe("sha256:abc123");
       expect(prompter.note).toHaveBeenCalledWith(
@@ -226,6 +235,38 @@ describe("promptRemoteGatewayConfig", () => {
       );
     },
   );
+
+  it("does not retain a saved SSH route when discovery suggests a new manual tunnel", async () => {
+    detectBinary.mockResolvedValue(true);
+    discoverGatewayBeacons.mockResolvedValue([createGatewayDiscoveryBeacon()]);
+    const { next, prompter } = await runRemotePrompt({
+      cfg: {
+        gateway: {
+          remote: {
+            url: "ws://127.0.0.1:18789",
+            transport: "ssh",
+            sshTarget: "operator@old.example",
+            sshIdentity: "/tmp/old-identity",
+            sshHostKeyPolicy: "openssh",
+            remotePort: 19443,
+          },
+        },
+      },
+      text: vi.fn(async (params) => String(params.initialValue)),
+      confirm: true,
+      selectResponses: {
+        "Select gateway": "0",
+        "Connection method": "ssh",
+        "Gateway auth": "off",
+      },
+    });
+
+    expect(next.gateway?.remote).toEqual({ url: "ws://127.0.0.1:18789" });
+    expect(prompter.note).toHaveBeenCalledWith(
+      expect.stringContaining("<user>@gateway.tailnet.ts.net"),
+      "SSH tunnel",
+    );
+  });
 
   it("falls back to manual URL entry when discovery trust is declined", async () => {
     detectBinary.mockResolvedValue(true);

--- a/src/commands/onboard-remote.ts
+++ b/src/commands/onboard-remote.ts
@@ -56,7 +56,7 @@ export function validateGatewayWebSocketUrl(value: string): string | undefined {
 export async function promptRemoteGatewayConfig(
   cfg: OpenClawConfig,
   prompter: WizardPrompter,
-  options?: { secretInputMode?: SecretInputMode; edgeAuthOriginUrl?: string },
+  options?: { secretInputMode?: SecretInputMode; remoteOriginUrl?: string },
 ): Promise<OpenClawConfig> {
   let selectedBeacon: GatewayBonjourBeacon | null = null;
   let suggestedUrl = cfg.gateway?.remote?.url ?? DEFAULT_GATEWAY_URL;
@@ -285,9 +285,11 @@ export async function promptRemoteGatewayConfig(
     token = undefined;
     password = undefined;
   }
-  const edgeAuthOriginUrl = options?.edgeAuthOriginUrl ?? cfg.gateway?.remote?.url;
+  // An explicitly absent origin means onboarding had no saved endpoint before URL seeding.
+  const remoteOriginUrl =
+    options && "remoteOriginUrl" in options ? options.remoteOriginUrl : cfg.gateway?.remote?.url;
   const edgeAuth =
-    edgeAuthOriginUrl && gatewayOriginScope(url) === gatewayOriginScope(edgeAuthOriginUrl)
+    remoteOriginUrl && gatewayOriginScope(url) === gatewayOriginScope(remoteOriginUrl)
       ? cfg.gateway?.remote?.edgeAuth
       : undefined;
 
@@ -297,10 +299,12 @@ export async function promptRemoteGatewayConfig(
       ...cfg.gateway,
       mode: "remote",
       remote: {
+        // Pins and SSH settings stay with the same trimmed URL; explicit choices below take precedence.
+        ...(url === remoteOriginUrl?.trim() ? cfg.gateway?.remote : {}),
         url,
-        ...(edgeAuth !== undefined ? { edgeAuth } : {}),
-        ...(token !== undefined ? { token } : {}),
-        ...(password !== undefined ? { password } : {}),
+        edgeAuth,
+        token,
+        password,
         ...(pinnedDiscoveryFingerprint ? { tlsFingerprint: pinnedDiscoveryFingerprint } : {}),
       },
     },

--- a/src/commands/onboard-remote.ts
+++ b/src/commands/onboard-remote.ts
@@ -60,8 +60,9 @@ export async function promptRemoteGatewayConfig(
 ): Promise<OpenClawConfig> {
   let selectedBeacon: GatewayBonjourBeacon | null = null;
   let suggestedUrl = cfg.gateway?.remote?.url ?? DEFAULT_GATEWAY_URL;
-  let discoveryTlsFingerprint: string | undefined;
-  let trustedDiscoveryUrl: string | undefined;
+  let discoveryRemote:
+    | { url: string; transport: "direct" | "ssh"; tlsFingerprint?: string }
+    | undefined;
 
   const hasBonjourTool = (await detectBinary("dns-sd")) || (await detectBinary("avahi-browse"));
   const wantsDiscover = hasBonjourTool
@@ -138,10 +139,11 @@ export async function promptRemoteGatewayConfig(
           initialValue: false,
         });
         if (trusted) {
-          // Only pin discovery TLS when the user accepts the discovered endpoint;
-          // manual edits later clear the pin to avoid trusting a different host.
-          discoveryTlsFingerprint = fingerprint;
-          trustedDiscoveryUrl = suggestedUrl;
+          discoveryRemote = {
+            url: suggestedUrl,
+            transport: "direct",
+            ...(fingerprint ? { tlsFingerprint: fingerprint } : {}),
+          };
           await prompter.note(
             [
               t("wizard.remote.directDefaultsTls"),
@@ -157,6 +159,7 @@ export async function promptRemoteGatewayConfig(
         }
       } else {
         suggestedUrl = DEFAULT_GATEWAY_URL;
+        discoveryRemote = { url: suggestedUrl, transport: "ssh" };
         await prompter.note(
           [
             "Start a tunnel before using the CLI:",
@@ -175,8 +178,8 @@ export async function promptRemoteGatewayConfig(
     validate: (value) => validateGatewayWebSocketUrl(value),
   });
   const url = ensureWsUrl(urlInput);
-  const pinnedDiscoveryFingerprint =
-    discoveryTlsFingerprint && url === trustedDiscoveryUrl ? discoveryTlsFingerprint : undefined;
+  // Discovery choices belong only to the accepted URL, never a subsequent manual edit.
+  const selectedDiscovery = discoveryRemote?.url === url ? discoveryRemote : undefined;
 
   const authChoice = await prompter.select({
     message: t("wizard.remote.auth"),
@@ -299,13 +302,15 @@ export async function promptRemoteGatewayConfig(
       ...cfg.gateway,
       mode: "remote",
       remote: {
-        // Pins and SSH settings stay with the same trimmed URL; explicit choices below take precedence.
-        ...(url === remoteOriginUrl?.trim() ? cfg.gateway?.remote : {}),
+        // A newly suggested manual tunnel can reach another host behind the same loopback URL.
+        ...(url === remoteOriginUrl?.trim() && selectedDiscovery?.transport !== "ssh"
+          ? cfg.gateway?.remote
+          : {}),
         url,
         edgeAuth,
         token,
         password,
-        ...(pinnedDiscoveryFingerprint ? { tlsFingerprint: pinnedDiscoveryFingerprint } : {}),
+        ...(selectedDiscovery?.transport === "direct" ? selectedDiscovery : {}),
       },
     },
   };

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -252,7 +252,7 @@ export const en = {
       directAccessTitle: "Direct remote",
       enterUrlManually: "Enter URL manually",
       foundGateways: "Found {count} gateway(s)",
-      fingerprintMissing: "not advertised (connection will not be pinned)",
+      fingerprintMissing: "not advertised",
       gatewayPasswordStoredMessage: "Where is this gateway password stored?",
       gatewayTokenStoredMessage: "Where is this gateway token stored?",
       insecureRemoteUrl:

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -250,7 +250,7 @@ export const zh_CN = {
       directAccessTitle: "直接远程访问",
       enterUrlManually: "手动输入 URL",
       foundGateways: "找到 {count} 个 Gateway",
-      fingerprintMissing: "未公布（连接不会固定指纹）",
+      fingerprintMissing: "未公布",
       gatewayPasswordStoredMessage: "这个 Gateway 密码存在哪里？",
       gatewayTokenStoredMessage: "这个 Gateway 令牌存在哪里？",
       insecureRemoteUrl:

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -250,7 +250,7 @@ export const zh_TW = {
       directAccessTitle: "直接遠端存取",
       enterUrlManually: "手動輸入 URL",
       foundGateways: "找到 {count} 個 Gateway",
-      fingerprintMissing: "未公布（連線不會固定指紋）",
+      fingerprintMissing: "未公布",
       gatewayPasswordStoredMessage: "這個 Gateway 密碼存在哪裡？",
       gatewayTokenStoredMessage: "這個 Gateway 權杖存在哪裡？",
       insecureRemoteUrl:

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1078,11 +1078,14 @@ describe("runSetupWizard", () => {
           }),
         }),
         expect.any(Object),
-        {
-          secretInputMode: undefined,
-          remoteOriginUrl: storedUrl,
-        },
+        expect.any(Object),
       );
+      expect(
+        getMockCallArg(promptRemoteGatewayConfig, 0, 2, "remote prompt options"),
+      ).toStrictEqual({
+        secretInputMode: undefined,
+        remoteOriginUrl: storedUrl,
+      });
       expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining(remoteCredential));
     },
   );

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -1004,78 +1004,88 @@ describe("runSetupWizard", () => {
   });
 
   it.each([
-    { name: "token", optionKey: "remoteToken", remoteKey: "token" },
-    { name: "password", optionKey: "remotePassword", remoteKey: "password" },
-  ])("seeds interactive remote $name auth from command flags", async ({ optionKey, remoteKey }) => {
-    const remoteCredential = "REDACTED";
-    readConfigFileSnapshot.mockResolvedValueOnce({
-      path: "/tmp/.openclaw/openclaw.json",
-      exists: true,
-      raw: "{}",
-      parsed: {},
-      resolved: {},
-      sourceConfigBeforeMigrations: {},
-      valid: true,
-      config: {
-        gateway: {
-          remote: {
-            url: "wss://stored.example.com:18789",
-            token: { source: "env", provider: "default", id: "STORED_GATEWAY_TOKEN" },
-            password: { source: "env", provider: "default", id: "STORED_GATEWAY_PASSWORD" },
+    { name: "token", optionKey: "remoteToken", remoteKey: "token", hasStoredUrl: true },
+    { name: "password", optionKey: "remotePassword", remoteKey: "password", hasStoredUrl: true },
+    {
+      name: "token without a saved endpoint",
+      optionKey: "remoteToken",
+      remoteKey: "token",
+      hasStoredUrl: false,
+    },
+  ])(
+    "seeds interactive remote $name auth from command flags",
+    async ({ optionKey, remoteKey, hasStoredUrl }) => {
+      const storedUrl = hasStoredUrl ? "wss://stored.example.com:18789" : undefined;
+      const remoteCredential = "REDACTED";
+      readConfigFileSnapshot.mockResolvedValueOnce({
+        path: "/tmp/.openclaw/openclaw.json",
+        exists: true,
+        raw: "{}",
+        parsed: {},
+        resolved: {},
+        sourceConfigBeforeMigrations: {},
+        valid: true,
+        config: {
+          gateway: {
+            remote: {
+              url: storedUrl,
+              token: { source: "env", provider: "default", id: "STORED_GATEWAY_TOKEN" },
+              password: { source: "env", provider: "default", id: "STORED_GATEWAY_PASSWORD" },
+            },
           },
         },
-      },
-      issues: [],
-      warnings: [],
-      legacyIssues: [],
-    });
-    const prompter = buildWizardPrompter({});
-    const runtime = createRuntime();
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      });
+      const prompter = buildWizardPrompter({});
+      const runtime = createRuntime();
 
-    if (remoteKey === "password") {
-      vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", "ambient-gateway-token");
-    }
-    try {
-      await runSetupWizard(
-        {
-          acceptRisk: true,
-          flow: "advanced",
-          mode: "remote",
-          remoteUrl: " wss://flag.example.com:18789 ",
-          [optionKey]: ` ${remoteCredential} `,
-        },
-        runtime,
-        prompter,
-      );
-    } finally {
       if (remoteKey === "password") {
-        vi.unstubAllEnvs();
+        vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", "ambient-gateway-token");
       }
-    }
-
-    expect(probeGatewayReachable).toHaveBeenCalledWith({
-      url: "wss://flag.example.com:18789",
-      token: remoteKey === "token" ? remoteCredential : undefined,
-      ...(remoteKey === "password" ? { password: remoteCredential } : {}),
-    });
-    expect(promptRemoteGatewayConfig).toHaveBeenCalledWith(
-      expect.objectContaining({
-        gateway: expect.objectContaining({
-          remote: {
-            url: "wss://flag.example.com:18789",
-            token: remoteKey === "token" ? remoteCredential : undefined,
-            password: remoteKey === "password" ? remoteCredential : undefined,
+      try {
+        await runSetupWizard(
+          {
+            acceptRisk: true,
+            flow: "advanced",
+            mode: "remote",
+            remoteUrl: " wss://flag.example.com:18789 ",
+            [optionKey]: ` ${remoteCredential} `,
           },
+          runtime,
+          prompter,
+        );
+      } finally {
+        if (remoteKey === "password") {
+          vi.unstubAllEnvs();
+        }
+      }
+
+      expect(probeGatewayReachable).toHaveBeenCalledWith({
+        url: "wss://flag.example.com:18789",
+        token: remoteKey === "token" ? remoteCredential : undefined,
+        ...(remoteKey === "password" ? { password: remoteCredential } : {}),
+      });
+      expect(promptRemoteGatewayConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gateway: expect.objectContaining({
+            remote: {
+              url: "wss://flag.example.com:18789",
+              token: remoteKey === "token" ? remoteCredential : undefined,
+              password: remoteKey === "password" ? remoteCredential : undefined,
+            },
+          }),
         }),
-      }),
-      expect.any(Object),
-      {
-        secretInputMode: undefined,
-        edgeAuthOriginUrl: "wss://stored.example.com:18789",
-      },
-    );
-    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining(remoteCredential));
-  });
+        expect.any(Object),
+        {
+          secretInputMode: undefined,
+          remoteOriginUrl: storedUrl,
+        },
+      );
+      expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining(remoteCredential));
+    },
+  );
 
   it("uses the configured remote password for the setup reachability probe", async () => {
     const remotePassword = "remote-password"; // pragma: allowlist secret
@@ -1263,7 +1273,7 @@ describe("runSetupWizard", () => {
       expect.any(Object),
       {
         secretInputMode: undefined,
-        edgeAuthOriginUrl: "wss://stored.example.com:18789",
+        remoteOriginUrl: "wss://stored.example.com:18789",
       },
     );
   });

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -462,9 +462,7 @@ async function runSetupWizardOnce(
     const { logConfigUpdated } = await loadConfigLoggingModule();
     let nextConfig = await promptRemoteGatewayConfig(remoteSeedConfig, prompter, {
       secretInputMode: opts.secretInputMode,
-      ...(opts.remoteUrl !== undefined && storedRemoteUrl
-        ? { edgeAuthOriginUrl: storedRemoteUrl }
-        : {}),
+      ...(opts.remoteUrl !== undefined ? { remoteOriginUrl: storedRemoteUrl } : {}),
     });
     nextConfig = opts.skipBootstrap ? applySkipBootstrapConfig(nextConfig) : nextConfig;
     nextConfig = onboardHelpers.applyWizardMetadata(nextConfig, { command: "onboard", mode });


### PR DESCRIPTION
> **REVIEW REQUIRED — endpoint trust scoping. Prepared by the auto-QA campaign; intentionally left as a draft for maintainer review, not autonomous landing.**

## What Problem This Solves

Reconfiguring a working remote gateway interactively silently discarded its TLS certificate pin. `promptRemoteGatewayConfig()` reconstructed `gateway.remote` from scratch, including only a pin discovered in the current invocation — so `openclaw configure --section gateway` → Remote → decline discovery → keep URL → keep credential reported "Remote gateway configured" while removing `tlsFingerprint` (and `transport`/`remotePort`/SSH routing fields). Private-certificate connections then break outright; CA connections lose the explicit fingerprint check (`gateway/tls-fingerprint.ts:26`; `websocket-transport.ts:137,162`). The non-interactive sibling already preserves the whole remote block for an unchanged URL (`6d39d3cf0ba`); the interactive defect ships in stable v2026.7.1-2.

## Why This Change Was Made

The interactive producer now preserves the remote block **only** when the chosen URL exactly equals the original URL after whitespace trimming — no hostname/port/path equivalence is inferred, so trust never follows a changed endpoint. Key scoping decisions for review: classic onboarding can pre-seed a changed URL into the producer's input, so comparison uses the **original configured URL** (the internal `edgeAuthOriginUrl` option renamed to `remoteOriginUrl` and reused for both trust decisions — comparing the seeded URL would transfer an old pin and SSH routing to a different endpoint); omitted-vs-explicitly-absent original URLs are distinguished so a partial config can't attach old trust to a newly seeded URL; explicit auth selection overwrites both credential slots and separately-scoped edge auth (the spread can't bypass its scope check); a confirmed discovery pin wins only for its exact confirmed URL. Full field matrix (all 10 `gateway.remote` schema fields × unchanged/changed URL) in the worker report and tests. The "not advertised" discovery prompt no longer implies a saved pin is useless (en/zh-CN/zh-TW); `docs/gateway/remote.md` documents reconfiguration behavior.

## User Impact

Re-running the wizard against an unchanged remote endpoint keeps its certificate pin, transport, and SSH routing; changing the endpoint still clears them all.

## Evidence

- Failing-first: unchanged-pinned-endpoint case fails pre-fix (pin gone); URL-change still clears; discovery still sets; seeded-URL scenarios (changed seed, edited-back-to-original, no-original-URL) all covered.
- Existing discovery tests re-tabled without weakened assertions; non-interactive sibling suite untouched and green.
- `check-changed` and Codex autoreview: pass/clean.
- LOC: production +14/−12 (**+2**, both comment lines — preservation absorbed into existing caller/auth construction); tests +90 net; docs +6.
- Named adjacent follow-up: an existing env-secret-ref test assigns `OPENCLAW_GATEWAY_TOKEN` outside its capture/restore list (test-isolation cleanup candidate).
