### PR TITLE
fix(ci): enforce Control UI locale parity for manual CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       run_format_check: ${{ steps.manifest.outputs.run_format_check }}
       compatibility_target: ${{ steps.manifest.outputs.compatibility_target }}
       run_control_ui_i18n: ${{ steps.manifest.outputs.run_control_ui_i18n }}
-      strict_control_ui_i18n: ${{ steps.changed_scope.outputs.strict_control_ui_i18n }}
+      strict_control_ui_i18n: ${{ github.event_name == 'workflow_dispatch' && !inputs.release_gate && 'true' || steps.changed_scope.outputs.strict_control_ui_i18n }}
       run_ui_tests: ${{ steps.manifest.outputs.run_ui_tests }}
       ui_e2e_matrix: ${{ steps.manifest.outputs.ui_e2e_matrix }}
       run_native_i18n: ${{ steps.manifest.outputs.run_native_i18n }}
@@ -2317,8 +2317,8 @@ jobs:
           fi
 
       - name: Check Control UI locale parity
-        # Source-only drift stays advisory because the post-merge bot owns
-        # repair. Generated locale changes and full release CI remain strict.
+        # Automatic source-only drift stays advisory because the post-merge bot owns
+        # repair. Generated locale changes and ordinary manual/release CI stay strict.
         continue-on-error: ${{ needs.preflight.outputs.strict_control_ui_i18n != 'true' }}
         run: pnpm ui:i18n:check
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -8381,7 +8381,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(bunSmoke.run).toContain("bun openclaw.mjs status --json --timeout 1");
   });
 
-  it("keeps source-only Control UI locale drift advisory", () => {
+  it("keeps automatic source-only Control UI locale drift advisory and manual CI strict", () => {
     const workflow = readCiWorkflow();
     const workflowSource = readFileSync(".github/workflows/ci.yml", "utf8");
     const buildArtifactSteps = workflow.jobs["build-artifacts"].steps;
@@ -8410,6 +8410,31 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(localeJob.env.COMPATIBILITY_TARGET).toBe(
       "${{ needs.preflight.outputs.compatibility_target }}",
     );
+    expect(workflow.jobs.preflight.outputs.strict_control_ui_i18n).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && !inputs.release_gate && 'true' || steps.changed_scope.outputs.strict_control_ui_i18n }}",
+    );
+    expect(
+      evaluateWorkflowExpression(
+        "${{ github.event_name == 'workflow_dispatch' && !inputs.release_gate && 'true' || 'false' }}",
+        {
+          eventName: "workflow_dispatch",
+          releaseGate: false,
+          repository: "openclaw/openclaw",
+          runAttempt: 1,
+        },
+      ),
+    ).toBe("true");
+    expect(
+      evaluateWorkflowExpression(
+        "${{ github.event_name == 'workflow_dispatch' && !inputs.release_gate && 'true' || 'false' }}",
+        {
+          eventName: "workflow_dispatch",
+          releaseGate: true,
+          repository: "openclaw/openclaw",
+          runAttempt: 1,
+        },
+      ),
+    ).toBe("false");
     expect(sourceStep["continue-on-error"]).toBeUndefined();
     const compatibilityWithoutVerify = runControlUiI18nSourceFixture({
       compatibilityTarget: true,


### PR DESCRIPTION
## What Problem This Solves

Ordinary manually dispatched full CI could treat Control UI locale parity as advisory. A run could therefore succeed while generated locale files were stale.

## Root cause

The preflight job skipped changed-scope detection for ordinary `workflow_dispatch` runs. Its Control UI strictness output still read only from that skipped step. The existing native locale output already handled this dispatch case correctly.

## Fix

Use the existing native-locale dispatch rule for the Control UI strictness output. Ordinary manual runs are strict. Exact-head `release_gate` runs keep their changed-scope behavior. Pull request and push routing is unchanged.

## Evidence

- Current `main` at `214d55e99b374f4fadc4a6bfae0fb8d25c99e1ca`: [manual run 33239782024](https://github.com/obviyus/clawdbot/actions/runs/33239782024) used `workflow_dispatch`, `release_gate=false`, and one controlled fallback mismatch. Source verification passed. Locale parity reported drift and exited 1. The current workflow treated that failure as advisory.
- Proven head `31c61fc2f17cc70e419af7fcd133ca66b5fa810f`: [manual run 33168537436](https://github.com/qingminglong/openclaw/actions/runs/33168537436) used the same event and mismatch. Source verification passed. Locale parity reported drift and exited 1. The Control UI locale job failed as required. Current head `33bd70efc408a7f9836a22d373bfb6d3f70e1728` keeps the same workflow behavior after rebasing onto current `main` and clarifying the policy text.
- Anti-cheat: the mismatch changed one generated fallback entry. `pnpm ui:i18n:verify` passed, while `pnpm ui:i18n:check` failed with `control-ui catalog fallback baseline drift detected` on both revisions.

## Validation

- `node scripts/run-vitest.mjs run test/scripts/ci-workflow-guards.test.ts`: 166 tests passed on the rebased head.
- The regression test fails on the pre-fix workflow output and passes on this head.
- Changed-file formatting, workflow checks, script lint, repository ratchets, and `git diff --check` passed.
- Delta: workflow config `+1/-1`; tests `+25/-0`; production code `+0/-0`.

## Scope

This proof covers ordinary manual CI and the Control UI locale parity boundary. It does not claim that the final PR tree contains a real locale mismatch.
