### PR TITLE
fix: cancel browser downloads when saving the output fails

### DIFF
--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -275,6 +275,8 @@ openclaw browser dialog --dismiss --dialog-id d1
 
 Managed Chrome profiles save ordinary click-triggered downloads into the OpenClaw downloads directory (`/tmp/openclaw/downloads` by default, or the configured temp root). Use `waitfordownload` or `download` when the agent needs to wait for a specific file and return its path; those explicit waiters own the next download. Uploads accept files from the OpenClaw temp uploads root and OpenClaw-managed inbound media, including `media://inbound/<id>` and sandbox-relative `media/inbound/<id>` references. Nested media refs, traversal, and arbitrary local paths are rejected.
 
+If saving a download fails, OpenClaw requests cancellation of the transfer and reports the original save error. Correct the output path or filesystem problem before starting a new download.
+
 When an action opens a modal dialog, the action response returns `blockedByDialog` with `browserState.dialogs.pending`; pass `--dialog-id` to answer it directly. Dialogs handled outside OpenClaw appear under `browserState.dialogs.recent`.
 
 Batch actions:

--- a/extensions/browser/src/browser/pw-download-cancel.chromium.test.ts
+++ b/extensions/browser/src/browser/pw-download-cancel.chromium.test.ts
@@ -43,93 +43,117 @@ describe.runIf(runChromiumProof)("managed Chromium download cancellation", () =>
   const cleanup: Array<() => Promise<void>> = [];
 
   afterEach(async () => {
+    const errors: unknown[] = [];
     for (const dispose of cleanup.splice(0).toReversed()) {
-      await dispose();
+      await dispose().catch((error: unknown) => errors.push(error));
+    }
+    if (errors.length) {
+      throw new AggregateError(errors, "Chromium download fixture cleanup failed");
     }
   });
 
-  it("cancels a download already being streamed without publishing its output", async () => {
-    const rootDir = tempDirs.make("openclaw-download-stream-cancel-");
-    cleanup.push(async () => await fs.rm(rootDir, { recursive: true, force: true }));
-    let closeDownloadResponse: (() => void) | undefined;
-    const downloadServer = createServer((request, response) => {
-      if (request.url === "/stream.bin") {
-        response.writeHead(200, {
-          "content-disposition": 'attachment; filename="stream.bin"',
-          "content-type": "application/octet-stream",
-        });
-        response.write("partially downloaded bytes");
-        closeDownloadResponse = () => response.destroy();
-        return;
+  it.each(["caller abort", "invalid output directory"])(
+    "cancels a streaming download after %s without publishing output",
+    async (failure) => {
+      const rootDir = tempDirs.make("openclaw-download-stream-cancel-");
+      cleanup.push(async () => await fs.rm(rootDir, { recursive: true, force: true }));
+      let closeDownloadResponse: (() => void) | undefined;
+      let responseClosed = false;
+      const downloadServer = createServer((request, response) => {
+        if (request.url === "/stream.bin") {
+          response.writeHead(200, {
+            "content-disposition": 'attachment; filename="stream.bin"',
+            "content-type": "application/octet-stream",
+          });
+          response.write("partially downloaded bytes");
+          response.once("close", () => {
+            responseClosed = true;
+          });
+          closeDownloadResponse = () => response.destroy();
+          return;
+        }
+        response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+        response.end('<a id="download" href="/stream.bin" download>Download</a>');
+      });
+      const downloadPort = await listen(downloadServer);
+      cleanup.push(async () => {
+        closeDownloadResponse?.();
+        await closeServer(downloadServer);
+      });
+
+      const cdpPort = await getFreePort();
+      const context = await getPlaywrightCore().chromium.launchPersistentContext(
+        path.join(rootDir, "profile"),
+        {
+          headless: true,
+          executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+          args: [`--remote-debugging-port=${cdpPort}`],
+        },
+      );
+      cleanup.push(async () => await context.close());
+      const page = context.pages()[0] ?? (await context.newPage());
+      await page.goto(`http://127.0.0.1:${downloadPort}/`);
+      const cdpUrl = `http://127.0.0.1:${cdpPort}`;
+      const targetId = await readTargetId(page);
+      cleanup.push(async () => await closePlaywrightBrowserConnection({ cdpUrl }));
+      cleanup.push(async () => closeDownloadResponse?.());
+
+      const controlledPage = await getPageForTargetId({ cdpUrl, targetId });
+      const saveStarted = createDeferred<void>();
+      let cancellationCount = 0;
+      controlledPage.once("download", (download) => {
+        const saveAs = download.saveAs.bind(download);
+        const cancel = download.cancel.bind(download);
+        download.saveAs = async (outputPath) => {
+          saveStarted.resolve();
+          await saveAs(outputPath);
+        };
+        download.cancel = async () => {
+          cancellationCount += 1;
+          await cancel();
+        };
+      });
+
+      const outputRoot = path.join(rootDir, "downloads");
+      if (failure === "invalid output directory") {
+        await fs.writeFile(outputRoot, "not a directory");
       }
-      response.writeHead(200, { "content-type": "text/html; charset=utf-8" });
-      response.end('<a id="download" href="/stream.bin" download>Download</a>');
-    });
-    const downloadPort = await listen(downloadServer);
-    cleanup.push(async () => {
-      closeDownloadResponse?.();
-      await closeServer(downloadServer);
-    });
+      const outputPath = path.join(outputRoot, "cancelled.bin");
+      const controller = new AbortController();
+      const reason = new Error("streaming download aborted");
+      const capture = waitForDownloadViaPlaywright({
+        cdpUrl,
+        targetId,
+        path: outputPath,
+        rootDir: outputRoot,
+        timeoutMs: 5_000,
+        signal: controller.signal,
+      });
+      const outcome = capture.then(
+        () => "resolved" as const,
+        (error: unknown) => error,
+      );
+      await expect.poll(() => ensurePageState(controlledPage).downloadWaiterDepth).toBe(1);
+      await page.locator("#download").click();
+      if (failure === "caller abort") {
+        await Promise.race([saveStarted.promise, capture]);
+        controller.abort(reason);
+        await expect(outcome).resolves.toBe(reason);
+        await expect.poll(async () => await fs.readdir(outputRoot)).toEqual([]);
+        await expect(fs.access(outputPath)).rejects.toMatchObject({ code: "ENOENT" });
+      } else {
+        await expect(outcome).resolves.toMatchObject({
+          message: "Invalid path: must stay within output directory",
+        });
+        await expect(fs.readFile(outputRoot, "utf8")).resolves.toBe("not a directory");
+      }
 
-    const cdpPort = await getFreePort();
-    const context = await getPlaywrightCore().chromium.launchPersistentContext(
-      path.join(rootDir, "profile"),
-      {
-        headless: true,
-        executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
-        args: [`--remote-debugging-port=${cdpPort}`],
-      },
-    );
-    cleanup.push(async () => await context.close());
-    const page = context.pages()[0] ?? (await context.newPage());
-    await page.goto(`http://127.0.0.1:${downloadPort}/`);
-    const cdpUrl = `http://127.0.0.1:${cdpPort}`;
-    const targetId = await readTargetId(page);
-    cleanup.push(async () => await closePlaywrightBrowserConnection({ cdpUrl }));
-
-    const controlledPage = await getPageForTargetId({ cdpUrl, targetId });
-    const saveStarted = createDeferred<void>();
-    let cancellationCount = 0;
-    controlledPage.once("download", (download) => {
-      const saveAs = download.saveAs.bind(download);
-      const cancel = download.cancel.bind(download);
-      download.saveAs = async (outputPath) => {
-        saveStarted.resolve();
-        await saveAs(outputPath);
-      };
-      download.cancel = async () => {
-        cancellationCount += 1;
-        await cancel();
-      };
-    });
-
-    const outputRoot = path.join(rootDir, "downloads");
-    const outputPath = path.join(outputRoot, "cancelled.bin");
-    const controller = new AbortController();
-    const reason = new Error("streaming download aborted");
-    const capture = waitForDownloadViaPlaywright({
-      cdpUrl,
-      targetId,
-      path: outputPath,
-      rootDir: outputRoot,
-      timeoutMs: 5_000,
-      signal: controller.signal,
-    });
-    const outcome = capture.then(
-      () => "resolved" as const,
-      (error: unknown) => error,
-    );
-    await expect.poll(() => ensurePageState(controlledPage).downloadWaiterDepth).toBe(1);
-    await page.locator("#download").click();
-    await saveStarted.promise;
-    controller.abort(reason);
-
-    expect(cancellationCount).toBe(1);
-    await expect(outcome).resolves.toBe(reason);
-    await expect.poll(async () => await fs.readdir(outputRoot)).toEqual([]);
-    await expect(fs.access(outputPath)).rejects.toMatchObject({ code: "ENOENT" });
-    expect(ensurePageState(controlledPage).downloadWaiterDepth).toBe(0);
-  }, 20_000);
+      expect.soft(cancellationCount).toBe(1);
+      await expect.poll(() => responseClosed).toBe(true);
+      expect(ensurePageState(controlledPage).downloadWaiterDepth).toBe(0);
+    },
+    20_000,
+  );
 
   it("does not let a cancelled waiter capture and write a later download", async () => {
     const rootDir = tempDirs.make("openclaw-download-cancel-");

--- a/extensions/browser/src/browser/pw-download-capture.ts
+++ b/extensions/browser/src/browser/pw-download-capture.ts
@@ -65,6 +65,13 @@ export async function saveBrowserDownload(
       opts.signal?.throwIfAborted();
       onReadyToPublish?.();
     },
+  }).catch((error: unknown) => {
+    // Admission failures can belong to a superseded waiter. Only failed saves
+    // cancel here; an aborted capture already owns its cancellation.
+    if (!opts.signal?.aborted) {
+      void download.cancel?.().catch(() => {});
+    }
+    throw error;
   });
   return { ...candidate, path: savedPath };
 }

--- a/extensions/browser/src/browser/pw-session.test.ts
+++ b/extensions/browser/src/browser/pw-session.test.ts
@@ -657,15 +657,20 @@ describe("pw-session ensurePageState", () => {
     ensurePageState(page);
     const capture = beginActionDownloadCaptureOnPage(page);
     const error = new Error("action download save failed");
+    const cancel = vi.fn(async () => {
+      throw new Error("browser disconnected during cancellation");
+    });
 
     handlers.get("download")?.[0]?.({
       suggestedFilename: () => "failed.txt",
       saveAs: vi.fn(async () => {
         throw error;
       }),
+      cancel,
     });
 
     await expect(capture.drain()).rejects.toBe(error);
+    expect(cancel).toHaveBeenCalledOnce();
     capture.dispose();
   });
 

--- a/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -358,6 +358,7 @@ describe("pw-tools-core", () => {
   it("lets only the latest overlapping explicit waiter save the download", async () => {
     const harness = createDownloadEventHarness();
     const state = sessionMocks.ensurePageState();
+    const cancel = vi.fn(async () => {});
     const saveAs = vi.fn(async (outPath: string) => {
       await fs.writeFile(outPath, "latest-content", "utf8");
     });
@@ -380,10 +381,12 @@ describe("pw-tools-core", () => {
       url: () => "https://example.com/latest.bin",
       suggestedFilename: () => "latest.bin",
       saveAs,
+      cancel,
     });
 
     await expect(first).rejects.toThrow("superseded by another waiter");
     await expect(latest).resolves.toMatchObject({ suggestedFilename: "latest.bin" });
+    expect(cancel).not.toHaveBeenCalled();
     expect(saveAs).toHaveBeenCalledOnce();
     expect(state.downloadWaiterDepth).toBe(0);
     expect(harness.activeHandlerCount()).toBe(0);


### PR DESCRIPTION
Fixes #131044

## What Problem This Solves

Fixes an issue where users downloading a file would leave the browser transferring data after OpenClaw reported that the output could not be saved, for example when the output directory is actually a regular file.

## Why This Change Was Made

The shared download saver now requests native cancellation when an admitted save fails, while preserving the original save error. The cancellation belongs after admission: a superseded explicit waiter must not cancel the winning waiter's download, and an already-aborted capture already owns cancellation. The existing atomic publication boundary is unchanged.

This also covers action-owned downloads that call the shared saver directly. Routing only the capture promise's rejection through its cancellation handler would miss that sibling and run after capture cleanup has already marked it done. Production changes are +7/-0 lines; tests are +111/-79 (net +32); docs are +2/-0. The small production increase represents the missing failure-side resource cleanup at the existing owner, without a new helper or parallel flow.

## User Impact

Failed saves request cancellation promptly and retain the actionable filesystem error. Successful saves, caller cancellation, deadlines, superseded waiters, and completed publication retain their existing behavior. Documentation now tells operators to correct the output path or filesystem problem before starting another download.

Release-note context: browser downloads no longer keep transferring after an output-save failure. No new configuration, dependency, storage schema, or public API is introduced.

## Evidence

- Before the fix at `aa0647d06d27e1a9abd0a607abfc3c85649f710d`, a real Chromium/CDP download from a streaming HTTP fixture returned the original output-path error but made zero native cancellation calls and left the HTTP response open. A separate action-owned regression also failed because cancellation was never requested.
- On committed head `dfe43968cd10c1abaad2f9f2c3b5bde8c58ebae6`, the broad browser pass passed **202 tests in 15 files**, with no failures or skips, including **21 genuine Chromium cases**. The download cases verify caller cancellation, save-failure cancellation with HTTP response closure, and a subsequent download unaffected by a cancelled waiter. Focused coverage also preserves the original error if cancellation itself rejects and proves a superseded waiter does not cancel the winner.
- Additional committed-head QA passed **159 CLI/onboarding tests in 5 files** and **103 channel setup/doctor-gateway tests in 2 files**: **464 distinct tests total**, no failures or skips. The earlier 78-test focused pass is a subset, not an additional count.
- Dependency contracts were inspected in installed Playwright 1.62.1: download cancellation delegates to the artifact and Chromium's `Browser.cancelDownload`. The existing fs-safe output owner still controls staging, validation, and publication.
- Independent browser review found no actionable P0–P3 findings after correcting the documentation to say cancellation is requested. Configured Codex autoreview reported no P0 findings; that review intentionally excluded lower severities.
- Local proof used the canonical Vitest configuration with existing installed dependencies: Node 24.20, Playwright 1.62.1 matching the lockfile, and Vitest 4.1.10 versus lockfile 4.1.11. The sparse checkout's normal test/changed-check wrapper lacked `tsx`; targeted lint could not derive SDK type inputs. Formatting and diff checks passed. Hosted exact-head CI remains the required lint/typecheck/build/test gate; these local gaps are not treated as passed checks.
- Follow-up on the same commit in the isolated native PR worktree: a frozen-lockfile install supplied Vitest **4.1.11**, and the normal `scripts/run-vitest.mjs` wrapper passed the focused **78 tests in 5 files**, including all three real Chromium download cases, without configuration or assertion adaptations. This closes the focused test-wrapper/version gap above; hosted CI still owns the full lint/typecheck/build/test gates.
- An earlier Chromium fixture timeout remains unexplained. The fixture's diagnostics and cleanup are improved here, but this PR does not claim to have proved or fixed that timeout's root cause.

History: the ordinary-save failure path existed in the original capture implementation (#89416) and was carried forward by cancellation/publication repair #128651 and deadline repair #129899. This is a separate failure-side cleanup gap, not a rollback of those ownership boundaries.

AI-assisted implementation and review with Codex; all evidence and the final diff were inspected by the responsible maintainer workflow.
