### PR TITLE
test(codex): make post-tool watchdog timing deterministic

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.turn-watches.test.ts
@@ -1567,7 +1567,7 @@ describe("runCodexAppServerAttempt turn watches", () => {
         id: "call-1",
         tool: "message",
       }),
-      expectedReason: undefined,
+      expectedReason: "notification:item/completed",
       expectedItemType: undefined,
     },
     {
@@ -1587,57 +1587,65 @@ describe("runCodexAppServerAttempt turn watches", () => {
       const harness = createStartedThreadHarness();
       const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
       const params = makeTestParams({ timeoutMs: 60_000 });
+      const completionIdleTimeoutMs = 80;
 
       let settled = false;
       const run = runCodexAppServerAttempt(params, {
         turnCompletionIdleTimeoutMs: 5,
-        postToolRawAssistantCompletionIdleTimeoutMs: 80,
+        postToolRawAssistantCompletionIdleTimeoutMs: completionIdleTimeoutMs,
         turnTerminalIdleTimeoutMs: 200,
       }).finally(() => {
         settled = true;
       });
       await harness.waitForMethod("turn/start");
 
-      const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
-        success?: boolean;
-      };
-      expect(toolResult.success).toBe(false);
-      await harness.notify(completion);
+      // Keep startup I/O on real time, then switch before the tool handoff arms its watches.
+      // Switching after the completion notification would preserve the wall-clock race.
+      const clockStartedAt = Date.now();
+      vi.useFakeTimers();
+      vi.setSystemTime(clockStartedAt);
+      try {
+        const toolResult = (await harness.handleServerRequest(makeDynamicToolCallRequest())) as {
+          success?: boolean;
+        };
+        expect(toolResult.success).toBe(false);
+        await harness.notify(completion);
 
-      await new Promise((resolve) => {
-        setTimeout(resolve, 20);
-      });
-      expect(settled).toBe(false);
-      expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(
-        false,
-      );
+        await vi.advanceTimersByTimeAsync(completionIdleTimeoutMs - 1);
+        expect(settled).toBe(false);
+        expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(
+          false,
+        );
 
-      const result = await run;
-      expect(projectAttemptResult(result)).toMatchObject({
-        aborted: true,
-        timedOut: true,
-        promptError: "codex app-server turn idle timed out waiting for turn/completed",
-      });
-      const completionWarnCall = warn.mock.calls.find(
-        ([message]) => message === "codex app-server turn idle timed out waiting for completion",
-      );
-      expect(completionWarnCall).toBeDefined();
-      const completionWarnData = completionWarnCall?.[1] as
-        | { lastActivityReason?: string; lastNotificationItemType?: string; timeoutMs?: number }
-        | undefined;
-      expect(completionWarnData?.timeoutMs).toBe(80);
-      if (expectedReason) {
+        await vi.advanceTimersByTimeAsync(1);
+        const completionWarnCall = warn.mock.calls.find(
+          ([message]) => message === "codex app-server turn idle timed out waiting for completion",
+        );
+        expect(completionWarnCall).toBeDefined();
+        const completionWarnData = completionWarnCall?.[1] as
+          | { lastActivityReason?: string; lastNotificationItemType?: string; timeoutMs?: number }
+          | undefined;
+        expect(completionWarnData?.timeoutMs).toBe(completionIdleTimeoutMs);
         expect(completionWarnData?.lastActivityReason).toBe(expectedReason);
+        if (expectedItemType) {
+          expect(completionWarnData?.lastNotificationItemType).toBe(expectedItemType);
+        }
+
+        const result = await run;
+        expect(projectAttemptResult(result)).toMatchObject({
+          aborted: true,
+          timedOut: true,
+          promptError: "codex app-server turn idle timed out waiting for turn/completed",
+        });
+        expect(
+          warn.mock.calls.some(
+            ([message]) =>
+              message === "codex app-server turn idle timed out waiting for terminal event",
+          ),
+        ).toBe(false);
+      } finally {
+        vi.useRealTimers();
       }
-      if (expectedItemType) {
-        expect(completionWarnData?.lastNotificationItemType).toBe(expectedItemType);
-      }
-      expect(
-        warn.mock.calls.some(
-          ([message]) =>
-            message === "codex app-server turn idle timed out waiting for terminal event",
-        ),
-      ).toBe(false);
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a flaky Codex post-tool watchdog test whose real-time 20 ms observation window could cross its 80 ms completion deadline on a loaded runner, even though the runtime behavior was correct.

## Why This Change Was Made

The test now switches to fake time only after startup I/O and before the tool handoff arms the completion watches. It advances to 79 ms to prove the run is still pending, then crosses the exact 80 ms boundary and verifies the canonical completion-timeout diagnostics. Production behavior is unchanged.

## User Impact

No user-visible or runtime behavior changes. CI now verifies the post-tool deadline deterministically instead of depending on host scheduling.

## Evidence

- Final focused owner suite: 96/96 passed.
- Final changed-file gate: exit 0; all routed extension-test type, lint, boundary, package, dead-code, and format checks passed.
- Diff-scoped deslop pass: clean.
- Isolated autoreview: no findings, 0.99 confidence.
- Installed Vitest 4.1.11 clears native timers when fake time is enabled, so switching after startup removes the original wall-clock watch before the handoff reschedules it; no mixed-clock timer remains.
- Direct upstream Codex contract inspection confirmed that dynamic tool responses are submitted into the thread, successful responses map to `item/completed`, canonical completion side effects run before the notification is emitted, and raw response-item completion remains a separate event path.
- Production LOC: +0/-0. Tests: +47/-39.
