### PR TITLE
fix(runtime): isolate experience review foreground admission

### DIFF
--- a/src/skills/workshop/experience-review.admission.test.ts
+++ b/src/skills/workshop/experience-review.admission.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
+import { resolveSessionLane } from "../../agents/embedded-agent-runner/lanes.js";
+import type { EmbeddedForegroundPromptContext } from "../../agents/embedded-agent-runner/run/params.js";
+import {
+  clearActiveEmbeddedRun,
+  queueEmbeddedAgentMessageWithOutcome,
+  setActiveEmbeddedRun,
+} from "../../agents/embedded-agent-runner/runs.js";
+import {
+  createEmbeddedRunHandle,
+  testing as embeddedRunsTesting,
+} from "../../agents/embedded-agent-runner/runs.test-support.js";
+import { enqueueCommandInLane } from "../../process/command-queue.js";
+import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
+import { runSkillExperienceReview } from "./experience-review.js";
+
+const runEmbeddedAgent = vi.hoisted(() => vi.fn());
+
+vi.mock("../../agents/embedded-agent.js", () => ({ runEmbeddedAgent }));
+vi.mock("../../agents/run-session-target.js", () => ({
+  resolveAgentRunSessionTarget: vi.fn(
+    async (params: { agentId?: string; sessionId: string; sessionKey: string }) => ({
+      agentId: params.agentId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      storePath: "/tmp/session-store.json",
+    }),
+  ),
+}));
+vi.mock("../../agents/sessions/index.js", () => ({
+  SessionManager: {
+    open: vi.fn(() => ({ getEntries: () => [] })),
+    fromEntries: vi.fn(() => ({})),
+  },
+}));
+
+afterEach(() => {
+  runEmbeddedAgent.mockReset();
+  embeddedRunsTesting.resetActiveEmbeddedRuns();
+  resetCommandQueueStateForTest();
+});
+
+describe("experience review foreground admission", () => {
+  it("starts a foreground turn while review is active without steering user instructions", async () => {
+    const foregroundSessionId = "foreground-session";
+    const foregroundSessionKey = "agent:main:discord:channel:review-admission";
+    const foregroundPromptCacheKey = "foreground-cache-prefix";
+    const reviewStarted = createDeferred();
+    const releaseReview = createDeferred();
+    const foregroundStarted = createDeferred();
+    const releaseForeground = createDeferred();
+    const reviewInstructions: string[] = [];
+    const foregroundInstructions: string[] = [];
+    let reviewParams: Record<string, unknown> | undefined;
+
+    runEmbeddedAgent.mockImplementation(async (params: Record<string, unknown>) => {
+      reviewParams = params;
+      const sessionId = String(params.sessionId);
+      const sessionKey = String(params.sessionKey);
+      const reviewHandle = createEmbeddedRunHandle({
+        runId: String(params.runId),
+        queueMessage: async (text) => {
+          reviewInstructions.push(text);
+        },
+      });
+      return await enqueueCommandInLane(resolveSessionLane(sessionKey), async () => {
+        reviewInstructions.push(String(params.prompt));
+        setActiveEmbeddedRun(sessionId, reviewHandle, sessionKey);
+        reviewStarted.resolve();
+        try {
+          await releaseReview.promise;
+          return {};
+        } finally {
+          clearActiveEmbeddedRun(sessionId, reviewHandle, sessionKey);
+        }
+      });
+    });
+
+    const foregroundPromptContext: EmbeddedForegroundPromptContext = {
+      agentId: "main",
+      agentDir: "/tmp/workspace",
+      workspaceDir: "/tmp/workspace",
+      cwd: "/tmp/workspace",
+      sandboxSessionKey: foregroundSessionKey,
+      trigger: "user",
+      promptCacheKey: foregroundPromptCacheKey,
+    };
+    const config = { skills: { workshop: { autonomous: { mode: "propose" as const } } } };
+    const review = runSkillExperienceReview(
+      {
+        ctx: {
+          agentId: "main",
+          runId: "foreground-run",
+          sessionId: foregroundSessionId,
+          sessionKey: foregroundSessionKey,
+          workspaceDir: "/tmp/workspace",
+          modelProviderId: "openai",
+          modelId: "gpt-test",
+          foregroundPromptContext,
+        },
+        config,
+      },
+      { getCurrentConfig: () => config },
+    );
+    let reviewSettled = false;
+    void review.then(
+      () => {
+        reviewSettled = true;
+      },
+      () => {
+        reviewSettled = true;
+      },
+    );
+    let foreground: Promise<unknown> | undefined;
+    try {
+      await reviewStarted.promise;
+      const queueOutcome = queueEmbeddedAgentMessageWithOutcome(
+        foregroundSessionId,
+        "foreground-user-instruction",
+      );
+      foreground = enqueueCommandInLane(resolveSessionLane(foregroundSessionKey), async () => {
+        foregroundInstructions.push("foreground-system-instruction");
+        foregroundStarted.resolve();
+        await releaseForeground.promise;
+      });
+
+      await withTestTimeout(
+        foregroundStarted.promise,
+        1_000,
+        "foreground turn waited behind the active experience review",
+      );
+
+      expect(reviewSettled).toBe(false);
+      expect(queueOutcome).toMatchObject({ queued: false, reason: "no_active_run" });
+      expect(reviewInstructions).not.toContain("foreground-user-instruction");
+      expect(foregroundInstructions).toEqual(["foreground-system-instruction"]);
+      expect(reviewParams).toMatchObject({
+        promptCacheKey: foregroundPromptCacheKey,
+        sandboxSessionKey: foregroundSessionKey,
+        sessionPersistence: "detached",
+      });
+      expect(reviewParams?.sessionId).not.toBe(foregroundSessionId);
+      expect(reviewParams?.sessionKey).not.toBe(foregroundSessionKey);
+    } finally {
+      releaseForeground.resolve();
+      releaseReview.resolve();
+      await Promise.allSettled([review, ...(foreground ? [foreground] : [])]);
+    }
+  });
+});

--- a/src/skills/workshop/experience-review.apply.test.ts
+++ b/src/skills/workshop/experience-review.apply.test.ts
@@ -139,7 +139,13 @@ describe("experience review auto apply", () => {
     expect(observed).toEqual([
       ["assistant", false, false, false, undefined],
       ["tool", false, false, false, undefined],
-      ["lifecycle", false, false, false, "agent:main:main"],
+      [
+        "lifecycle",
+        false,
+        false,
+        false,
+        expect.stringMatching(/^agent:main:skill-workshop-review:incognito-/),
+      ],
     ]);
     expect(getAgentRunContext(reviewRunId)).toBeUndefined();
   });

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -413,6 +413,8 @@ async function runSkillExperienceReviewInner(
   });
   const foregroundSession = SessionManager.open(sessionTarget, workspaceDir);
   const detachedSession = SessionManager.fromEntries(foregroundSession.getEntries(), workspaceDir);
+  const reviewSessionId = randomUUID();
+  const reviewSessionKey = `agent:${sessionTarget.agentId}:skill-workshop-review:incognito-${reviewSessionId}`;
   const { listWritableWorkspaceSkillSummaries } = await import("./workspace-skill-read.js");
   const existingSkills = listWritableWorkspaceSkillSummaries(workspaceDir, {
     config,
@@ -429,12 +431,12 @@ async function runSkillExperienceReviewInner(
   let outcome: "applied" | "proposed" | "nothing";
   let proposalId: string | undefined;
   let usage: { inputTokens: number; cachedInputTokens: number; outputTokens: number } | undefined;
-  // The warm review reuses the foreground session identity for prompt caching.
-  // Keep every review event and lifecycle transition out of that user-visible session.
+  // The review reads the foreground snapshot and keeps its prompt-cache affinity,
+  // but owns an incognito run identity so foreground admission and steering stay independent.
   registerAgentRunContext(runId, {
     agentId: foregroundPromptContext.agentId,
-    sessionId,
-    sessionKey,
+    sessionId: reviewSessionId,
+    sessionKey: reviewSessionKey,
     isControlUiVisible: false,
     projectSessionActive: false,
     projectSessionLifecycle: false,
@@ -447,9 +449,8 @@ async function runSkillExperienceReviewInner(
         runEmbeddedAgent({
           ...foregroundPromptContext,
           preparedRunAdmission,
-          sessionId,
-          sessionKey,
-          sessionTarget,
+          sessionId: reviewSessionId,
+          sessionKey: reviewSessionKey,
           sessionManager: detachedSession,
           sessionPersistence: "detached",
           // Never occupy the foreground agent lane after the idle gate opens.
@@ -482,7 +483,7 @@ async function runSkillExperienceReviewInner(
             sessionKey,
             ...(candidate.ctx.runId ? { runId: candidate.ctx.runId } : {}),
           },
-          // The review shares the foreground session, so its MCP runtime stays warm for the next turn.
+          // Foreground prompt context keeps provider cache affinity without sharing admission.
           verboseLevel: "off",
           suppressToolErrorWarnings: true,
           ...(capability ? { cronCreatorAuthorityCapability: capability } : {}),


### PR DESCRIPTION
## Summary

- give autonomous Skill Workshop experience reviews a fresh incognito session identity
- preserve the foreground provider prompt-cache key and detached transcript snapshot
- add a concurrency regression covering admission and prompt-steering isolation

## What Problem This Solves

An autonomous experience review reused the foreground session ID and key. The embedded runner therefore registered the hidden review as the foreground session's active run and acquired the same session lane. In the reported incident, a user message waited 107 seconds for admission and was then steered into the review-only `skill_workshop` prompt.

Closes #131018.

## Why This Change Was Made

PR #130013 intentionally preserved foreground prompt-cache affinity, and PR #130217 hid detached review presentation, but neither separated foreground admission ownership from the review run. The existing incognito review pattern is the smallest ownership seam: the review still reads a detached snapshot and keeps the explicit prompt-cache key, while its session lane and active-run registry identity no longer match the foreground turn.

## User Impact

Foreground messages can start while an autonomous experience review is still active. They are no longer queued behind that review or injected into its review-only instruction context.

## Evidence

- Live incident: the hidden review began at 15:40:36 UTC; a user message arrived at 15:41:02 and foreground execution did not begin until 15:42:49, a 107-second admission delay.
- Source reproduction before editing: the review acquired the foreground session lane and registered an active embedded run under the foreground session ID/key; the new regression then timed out waiting for a concurrent foreground turn.
- Fixed behavior: the regression keeps the review unresolved and active, starts the foreground lane within a 1-second bound, receives `no_active_run` for foreground steering, and proves the user instruction never enters the review prompt.
- Cache behavior: the regression verifies the original explicit `promptCacheKey` and `sandboxSessionKey` still reach the review runner unchanged.

## Testing

- Red proof on pre-fix source: the new concurrency regression timed out waiting for foreground admission while the review held the foreground lane.
- `node scripts/run-vitest.mjs src/skills/workshop/experience-review.admission.test.ts src/skills/workshop/experience-review.apply.test.ts src/skills/workshop/experience-review.test.ts src/agents/embedded-agent-runner/runs.steering.test.ts src/auto-reply/reply/reply-turn-admission.test.ts` — 110 passed across 3 shards.
- `pnpm test:changed` — 35 passed for the published 3-file commit.
- `pnpm check:changed` — passed, including core/core-test typecheck, type-aware lint, formatting, dead-export, dependency, import-cycle, and repository policy gates.
- Independent clean local review: no actionable P0-P2 findings.

## Impact & Risks

- Scope is limited to 3 files: 9 production additions/8 removals and 158 test additions/1 removal.
- No public API, configuration, queue framework, `/stop`, compaction, or delivery behavior changes.
- The explicit foreground `promptCacheKey` and `sandboxSessionKey` remain unchanged; only review admission/steering identity becomes incognito.

## Reviewer Guidance

- `src/skills/workshop/experience-review.ts`: verify the synthetic session identity is used only for the embedded review run and lifecycle context.
- `src/skills/workshop/experience-review.admission.test.ts`: verify the review remains active while foreground admission succeeds and user text cannot steer into it.
- `src/skills/workshop/experience-review.apply.test.ts`: verify hidden lifecycle events now carry the incognito review session key.

## Disclosure

This change was developed with AI assistance. Source reproduction, focused tests, changed-file gates, diff/stat review, and an independent local review were completed before publication.
