### PR TITLE
fix(ui): prevent mock Gateway tests from leaking into routing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2114,6 +2114,7 @@
     "@shikijs/engine-oniguruma": "4.4.3",
     "@types/express": "5.0.6",
     "@types/hosted-git-info": "3.0.5",
+    "@types/jsdom": "30.0.0",
     "@types/markdown-it": "14.2.0",
     "@types/mdast": "4.0.4",
     "@types/ms": "2.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,6 +287,9 @@ importers:
       '@types/hosted-git-info':
         specifier: 3.0.5
         version: 3.0.5
+      '@types/jsdom':
+        specifier: 30.0.0
+        version: 30.0.0
       '@types/markdown-it':
         specifier: 14.2.0
         version: 14.2.0
@@ -5720,6 +5723,9 @@ packages:
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
+  '@types/jsdom@30.0.0':
+    resolution: {integrity: sha512-uAHGxujGE0cDaKGdK28zgDotFtNA7MKq5DXl8LrfdxdCI8VHcg15oJz+amHTChPNI5JpgEPQWc2xFdrw3em/nQ==}
+
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
@@ -5788,6 +5794,9 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/tough-cookie@4.0.5':
+    resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -9426,6 +9435,9 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  undici-types@8.10.0:
+    resolution: {integrity: sha512-ibvdovq3nCFs8Msrd95BW+zUOq+aOVbT+wpHUoPWhztbHEoPc6oof51iFDB6Es8lTKvNvVW9jNSAB8dwrKTMGg==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
@@ -13359,6 +13371,13 @@ snapshots:
 
   '@types/http-errors@2.0.5': {}
 
+  '@types/jsdom@30.0.0':
+    dependencies:
+      '@types/node': 26.2.0
+      '@types/tough-cookie': 4.0.5
+      parse5: 8.0.1
+      undici-types: 8.10.0
+
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
@@ -13439,6 +13458,8 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 26.2.0
+
+  '@types/tough-cookie@4.0.5': {}
 
   '@types/trusted-types@2.0.7': {}
 
@@ -17496,6 +17517,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
+
+  undici-types@8.10.0: {}
 
   undici-types@8.3.0: {}
 

--- a/ui/src/test-helpers/control-ui-e2e.deferral.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.deferral.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
-import { expect, it } from "vitest";
+import { expect } from "vitest";
 import { createControlUiMockGatewayInitScript } from "./control-ui-e2e.ts";
+import { mockGatewayTest as it } from "./mock-gateway-page.test-support.ts";
 
 type ResponseFrame = {
   type: string;
@@ -10,22 +11,20 @@ type ResponseFrame = {
   error?: { message: string };
 };
 
-it.each(["resolve", "reject"] as const)(
+it.for(["resolve", "reject"] as const)(
   "%ss every held request without changing one-shot deferrals",
-  async (outcome) => {
+  async (outcome, { gatewayPage }) => {
+    const { window, execute } = gatewayPage;
     const catalog = { environments: [], profiles: [{ id: "aws" }] };
     const scenario = {
       heldMethods: ["environments.list"],
       deferredMethods: ["models.list"],
       methodResponses: { "environments.list": catalog },
     };
-    const priorWebSocket = window.WebSocket;
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Exercise the serialized browser transport, including its closure boundary.
-    new Function(createControlUiMockGatewayInitScript(scenario))();
+    execute(createControlUiMockGatewayInitScript(scenario));
     const sockets = [
-      new WebSocket("ws://mock-gateway/first"),
-      new WebSocket("ws://mock-gateway/second"),
+      new window.WebSocket("ws://mock-gateway/first"),
+      new window.WebSocket("ws://mock-gateway/second"),
     ] as const;
     const frames: ResponseFrame[] = [];
     for (const socket of sockets) {
@@ -43,7 +42,7 @@ it.each(["resolve", "reject"] as const)(
     const send = (socket: WebSocket, id: string, method: string) =>
       socket.send(JSON.stringify({ type: "req", id, method }));
     const gateway = (
-      window as Window & {
+      window as typeof window & {
         openclawControlUiE2eGateway?: {
           resolveDeferred: (method: string) => void;
           rejectDeferred: (method: string, error: { message: string }) => void;
@@ -51,60 +50,52 @@ it.each(["resolve", "reject"] as const)(
         };
       }
     ).openclawControlUiE2eGateway;
-    try {
-      if (!gateway) {
-        throw new Error("Mock Gateway was not installed");
-      }
-      await flush();
-      send(sockets[0], "catalog-first", "environments.list");
-      send(sockets[1], "catalog-replacement", "environments.list");
-      send(sockets[0], "model-held", "models.list");
-      send(sockets[0], "model-next", "models.list");
-      await flush();
-      expect(frames.map((frame) => frame.id)).toEqual(["model-next"]);
-
-      if (outcome === "resolve") {
-        gateway.resolveDeferred("environments.list");
-      } else {
-        gateway.rejectDeferred("environments.list", { message: "catalog unavailable" });
-      }
-      expect(frames.filter((frame) => frame.id.startsWith("catalog-"))).toEqual(
-        ["catalog-first", "catalog-replacement"].map((id) =>
-          expect.objectContaining(
-            outcome === "resolve"
-              ? { id, ok: true, payload: catalog }
-              : {
-                  id,
-                  ok: false,
-                  error: expect.objectContaining({ message: "catalog unavailable" }),
-                },
-          ),
-        ),
-      );
-      send(sockets[1], "catalog-after-release", "environments.list");
-      await flush();
-      expect(frames.at(-1)).toMatchObject({
-        id: "catalog-after-release",
-        ok: true,
-        payload: catalog,
-      });
-      gateway.resolveDeferred("models.list");
-      expect(frames.at(-1)).toMatchObject({ id: "model-held", ok: true });
-
-      gateway.deferNext("environments.list");
-      send(sockets[0], "catalog-one-shot", "environments.list");
-      send(sockets[0], "catalog-unblocked", "environments.list");
-      await flush();
-      expect(frames.at(-1)).toMatchObject({ id: "catalog-unblocked", ok: true });
-      expect(frames.some((frame) => frame.id === "catalog-one-shot")).toBe(false);
-      gateway.resolveDeferred("environments.list");
-      expect(frames.at(-1)).toMatchObject({ id: "catalog-one-shot", ok: true });
-    } finally {
-      for (const socket of sockets) {
-        socket.close();
-      }
-      window.WebSocket = priorWebSocket;
-      window.sessionStorage.clear();
+    if (!gateway) {
+      throw new Error("Mock Gateway was not installed");
     }
+    await flush();
+    send(sockets[0], "catalog-first", "environments.list");
+    send(sockets[1], "catalog-replacement", "environments.list");
+    send(sockets[0], "model-held", "models.list");
+    send(sockets[0], "model-next", "models.list");
+    await flush();
+    expect(frames.map((frame) => frame.id)).toEqual(["model-next"]);
+
+    if (outcome === "resolve") {
+      gateway.resolveDeferred("environments.list");
+    } else {
+      gateway.rejectDeferred("environments.list", { message: "catalog unavailable" });
+    }
+    expect(frames.filter((frame) => frame.id.startsWith("catalog-"))).toEqual(
+      ["catalog-first", "catalog-replacement"].map((id) =>
+        expect.objectContaining(
+          outcome === "resolve"
+            ? { id, ok: true, payload: catalog }
+            : {
+                id,
+                ok: false,
+                error: expect.objectContaining({ message: "catalog unavailable" }),
+              },
+        ),
+      ),
+    );
+    send(sockets[1], "catalog-after-release", "environments.list");
+    await flush();
+    expect(frames.at(-1)).toMatchObject({
+      id: "catalog-after-release",
+      ok: true,
+      payload: catalog,
+    });
+    gateway.resolveDeferred("models.list");
+    expect(frames.at(-1)).toMatchObject({ id: "model-held", ok: true });
+
+    gateway.deferNext("environments.list");
+    send(sockets[0], "catalog-one-shot", "environments.list");
+    send(sockets[0], "catalog-unblocked", "environments.list");
+    await flush();
+    expect(frames.at(-1)).toMatchObject({ id: "catalog-unblocked", ok: true });
+    expect(frames.some((frame) => frame.id === "catalog-one-shot")).toBe(false);
+    gateway.resolveDeferred("environments.list");
+    expect(frames.at(-1)).toMatchObject({ id: "catalog-one-shot", ok: true });
   },
 );

--- a/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts
@@ -1,8 +1,9 @@
 /* @vitest-environment jsdom */
 // Exercises the serialized mock gateway exactly as a page would: the init
 // script installs MockWebSocket on window, and requests flow over it.
-import { describe, expect, it } from "vitest";
+import { describe, expect } from "vitest";
 import { createControlUiMockGatewayInitScript } from "./control-ui-e2e.ts";
+import { mockGatewayTest as it } from "./mock-gateway-page.test-support.ts";
 
 type ResponseFrame = {
   event?: string;
@@ -24,14 +25,15 @@ function waitForMockCycle(): Promise<void> {
 }
 
 describe("mock gateway stateful config", () => {
-  it("takes existing mock sockets offline without closing their replacement", async () => {
+  it("takes existing mock sockets offline without closing their replacement", async ({
+    gatewayPage,
+  }) => {
+    const { window, execute } = gatewayPage;
     const passthroughPrefix = "ws://source-ui/?token=";
     const script = createControlUiMockGatewayInitScript({
       webSocketPassthroughPrefixes: [passthroughPrefix],
     });
-    window.sessionStorage.clear();
-    const priorWebSocket = window.WebSocket;
-    class PassthroughWebSocket extends EventTarget {
+    class PassthroughWebSocket extends window.EventTarget {
       static readonly CLOSED = 3;
       static readonly CLOSING = 2;
       static readonly CONNECTING = 0;
@@ -44,44 +46,42 @@ describe("mock gateway stateful config", () => {
     }
     window.WebSocket = PassthroughWebSocket as unknown as typeof WebSocket;
 
-    try {
-      // oxlint-disable-next-line typescript/no-implied-eval -- Exercises the serialized browser fixture.
-      new Function(script)();
+    execute(script);
 
-      const passthrough = new WebSocket(`${passthroughPrefix}vite`);
-      const first = new WebSocket("ws://mock-gateway/first");
-      const second = new WebSocket("ws://mock-gateway/second");
-      await flushMockTimers();
-      expect(passthrough.readyState).toBe(WebSocket.OPEN);
-      expect(first.readyState).toBe(WebSocket.OPEN);
-      expect(second.readyState).toBe(WebSocket.OPEN);
+    const passthrough = new window.WebSocket(`${passthroughPrefix}vite`);
+    const first = new window.WebSocket("ws://mock-gateway/first");
+    const second = new window.WebSocket("ws://mock-gateway/second");
+    await flushMockTimers();
+    expect(passthrough.readyState).toBe(window.WebSocket.OPEN);
+    expect(first.readyState).toBe(window.WebSocket.OPEN);
+    expect(second.readyState).toBe(window.WebSocket.OPEN);
 
-      let replacement: WebSocket | undefined;
-      first.addEventListener("close", () => {
-        replacement = new WebSocket("ws://mock-gateway/replacement");
-      });
+    let replacement: WebSocket | undefined;
+    first.addEventListener("close", () => {
+      replacement = new window.WebSocket("ws://mock-gateway/replacement");
+    });
 
-      const controls = (
-        window as Window & {
-          openclawControlUiE2eGateway?: { setOnline: (online: boolean) => void };
-        }
-      ).openclawControlUiE2eGateway;
-      expect(controls).toBeDefined();
-      controls?.setOnline(false);
+    const controls = (
+      window as typeof window & {
+        openclawControlUiE2eGateway?: { setOnline: (online: boolean) => void };
+      }
+    ).openclawControlUiE2eGateway;
+    expect(controls).toBeDefined();
+    controls?.setOnline(false);
 
-      expect(passthrough.readyState).toBe(WebSocket.OPEN);
-      expect(first.readyState).toBe(WebSocket.CLOSED);
-      expect(second.readyState).toBe(WebSocket.CLOSED);
-      expect(replacement?.readyState).toBe(WebSocket.CONNECTING);
+    expect(passthrough.readyState).toBe(window.WebSocket.OPEN);
+    expect(first.readyState).toBe(window.WebSocket.CLOSED);
+    expect(second.readyState).toBe(window.WebSocket.CLOSED);
+    expect(replacement?.readyState).toBe(window.WebSocket.CONNECTING);
 
-      controls?.setOnline(true);
-      expect(replacement?.readyState).toBe(WebSocket.OPEN);
-    } finally {
-      window.WebSocket = priorWebSocket;
-    }
+    controls?.setOnline(true);
+    expect(replacement?.readyState).toBe(window.WebSocket.OPEN);
   });
 
-  it("round-trips config.set through config.get with an advancing hash", async () => {
+  it("round-trips config.set through config.get with an advancing hash", async ({
+    gatewayPage,
+  }) => {
+    const { window, execute } = gatewayPage;
     const raw = '{\n  "logging": {\n    "level": "info"\n  }\n}\n';
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
@@ -95,11 +95,9 @@ describe("mock gateway stateful config", () => {
       },
     });
     // Execute the generated init script the way the browser <script> tag does.
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -174,19 +172,18 @@ describe("mock gateway stateful config", () => {
     const json5Reloaded = await request("get-json5", "config.get", {});
     expect(json5Reloaded).toMatchObject({ raw: json5Raw, hash: "mock-config-hash-3" });
     expect(json5Reloaded.config).toEqual({ logging: { level: "warn" } });
-
-    socket.close();
   });
 
-  it("leaves config methods untouched when the scenario has no raw fixture", async () => {
+  it("leaves config methods untouched when the scenario has no raw fixture", async ({
+    gatewayPage,
+  }) => {
+    const { window, execute } = gatewayPage;
     const script = createControlUiMockGatewayInitScript({
       methodResponses: { "config.set": { custom: true } },
     });
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -197,10 +194,12 @@ describe("mock gateway stateful config", () => {
     await flushMockTimers();
     const response = frames.find((frame) => frame.type === "res" && frame.id === "set-1");
     expect(response?.payload).toEqual({ custom: true });
-    socket.close();
   });
 
-  it("hydrates legacy persisted config state without losing revision hashes", async () => {
+  it("hydrates legacy persisted config state without losing revision hashes", async ({
+    gatewayPage,
+  }) => {
+    const { window, execute } = gatewayPage;
     const raw = '{"logging":{"level":"info"}}';
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
@@ -214,15 +213,13 @@ describe("mock gateway stateful config", () => {
         },
       },
     });
-    window.sessionStorage.clear();
     window.sessionStorage.setItem(
       "openclaw.control-ui-e2e.configState",
       JSON.stringify({ raw, revision: 2 }),
     );
-    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -236,18 +233,18 @@ describe("mock gateway stateful config", () => {
       configRevisionHash: "fixture-hash",
       appliedConfigHash: "fixture-applied-hash",
     });
-    socket.close();
   });
 });
 
 describe("mock gateway stateful sessions", () => {
-  it("acknowledges broad session observation with the real Gateway response", async () => {
+  it("acknowledges broad session observation with the real Gateway response", async ({
+    gatewayPage,
+  }) => {
+    const { window, execute } = gatewayPage;
     const script = createControlUiMockGatewayInitScript({});
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -262,21 +259,21 @@ describe("mock gateway stateful sessions", () => {
     expect(frames.find((frame) => frame.id === "subscribe-events")?.payload).toEqual({
       subscribed: true,
     });
-    socket.close();
   });
 
-  it("makes a successfully adopted catalog session visible to the next sessions.list", async () => {
+  it("makes a successfully adopted catalog session visible to the next sessions.list", async ({
+    gatewayPage,
+  }) => {
+    const { window, execute } = gatewayPage;
     const sessionKey = "agent:main:adopted-codex";
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
         "sessions.catalog.continue": { sessionKey },
       },
     });
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Exercises the serialized Gateway initialization exactly as the browser does.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -310,10 +307,12 @@ describe("mock gateway stateful sessions", () => {
         expect.objectContaining({ key: sessionKey, hasActiveRun: false, status: "done" }),
       ],
     });
-    socket.close();
   });
 
-  it("publishes a catalog adoption only after its deferred response succeeds", async () => {
+  it("publishes a catalog adoption only after its deferred response succeeds", async ({
+    gatewayPage,
+  }) => {
+    const { window, execute } = gatewayPage;
     const sessionKey = "agent:main:deferred-catalog-adoption";
     const script = createControlUiMockGatewayInitScript({
       deferredMethods: ["sessions.catalog.continue"],
@@ -321,11 +320,9 @@ describe("mock gateway stateful sessions", () => {
         "sessions.catalog.continue": { sessionKey },
       },
     });
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Exercises the serialized Gateway initialization exactly as the browser does.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -377,10 +374,10 @@ describe("mock gateway stateful sessions", () => {
         expect.objectContaining({ key: sessionKey }),
       ],
     });
-    socket.close();
   });
 
-  it("does not publish a rejected catalog adoption to sessions.list", async () => {
+  it("does not publish a rejected catalog adoption to sessions.list", async ({ gatewayPage }) => {
+    const { window, execute } = gatewayPage;
     const sessionKey = "agent:main:rejected-adoption";
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
@@ -389,11 +386,9 @@ describe("mock gateway stateful sessions", () => {
         },
       },
     });
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Exercises the serialized Gateway initialization exactly as the browser does.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -422,21 +417,19 @@ describe("mock gateway stateful sessions", () => {
     const listed = frames.find((frame) => frame.id === "list-after-rejected-adoption")?.payload;
     expect(listed).toMatchObject({ count: 1, sessions: [{ key: "main" }] });
     expect(JSON.stringify(listed)).not.toContain(sessionKey);
-    socket.close();
   });
 
-  it("makes a newly created session visible to the next sessions.list", async () => {
+  it("makes a newly created session visible to the next sessions.list", async ({ gatewayPage }) => {
+    const { window, execute } = gatewayPage;
     const sessionKey = "agent:main:created-session";
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
         "sessions.create": { key: sessionKey, runStarted: true },
       },
     });
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -477,10 +470,10 @@ describe("mock gateway stateful sessions", () => {
         }),
       ],
     });
-    socket.close();
   });
 
-  it("does not publish a rejected session creation to sessions.list", async () => {
+  it("does not publish a rejected session creation to sessions.list", async ({ gatewayPage }) => {
+    const { window, execute } = gatewayPage;
     const sessionKey = "agent:main:rejected-session";
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
@@ -489,11 +482,9 @@ describe("mock gateway stateful sessions", () => {
         },
       },
     });
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -522,10 +513,12 @@ describe("mock gateway stateful sessions", () => {
     const listed = frames.find((frame) => frame.id === "list-after-rejection")?.payload;
     expect(listed).toMatchObject({ count: 1, sessions: [{ key: "main" }] });
     expect(JSON.stringify(listed)).not.toContain(sessionKey);
-    socket.close();
   });
 
-  it("cycles subscription-scoped session events and stops after unsubscribe", async () => {
+  it("cycles subscription-scoped session events and stops after unsubscribe", async ({
+    gatewayPage,
+  }) => {
+    const { window, execute } = gatewayPage;
     const sessionKey = "agent:main:sidebar-narration-demo";
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
@@ -573,11 +566,9 @@ describe("mock gateway stateful sessions", () => {
         ],
       },
     });
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -652,10 +643,10 @@ describe("mock gateway stateful sessions", () => {
     const eventCount = frames.filter((frame) => frame.type === "event").length;
     await waitForMockCycle();
     expect(frames.filter((frame) => frame.type === "event")).toHaveLength(eventCount);
-    socket.close();
   });
 
-  it("keeps archive filtering opt-in for static session fixtures", async () => {
+  it("keeps archive filtering opt-in for static session fixtures", async ({ gatewayPage }) => {
+    const { window, execute } = gatewayPage;
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
         "sessions.list": {
@@ -668,11 +659,9 @@ describe("mock gateway stateful sessions", () => {
         "sessions.patch": { ok: true },
       },
     });
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -695,10 +684,10 @@ describe("mock gateway stateful sessions", () => {
       count: 1,
       sessions: [{ key: "agent:main:research", archived: false }],
     });
-    socket.close();
   });
 
-  it("moves archive patches between active and archived session lists", async () => {
+  it("moves archive patches between active and archived session lists", async ({ gatewayPage }) => {
+    const { window, execute } = gatewayPage;
     const script = createControlUiMockGatewayInitScript({
       methodResponses: {
         "sessions.list": {
@@ -715,11 +704,9 @@ describe("mock gateway stateful sessions", () => {
       },
       sessionArchiveFiltering: true,
     });
-    window.sessionStorage.clear();
-    // oxlint-disable-next-line typescript/no-implied-eval -- Executes the generated init script standalone, proving it captures no module closures.
-    new Function(script)();
+    execute(script);
 
-    const socket = new WebSocket("ws://mock-gateway");
+    const socket = new window.WebSocket("ws://mock-gateway");
     const frames: ResponseFrame[] = [];
     socket.addEventListener("message", (event) => {
       frames.push(JSON.parse(String((event as MessageEvent).data)) as ResponseFrame);
@@ -762,6 +749,5 @@ describe("mock gateway stateful sessions", () => {
     expect(keys(await request("list-8", "sessions.list", { archived: true }))).toEqual([
       "agent:main:research",
     ]);
-    socket.close();
   });
 });

--- a/ui/src/test-helpers/mock-gateway-page.test-support.ts
+++ b/ui/src/test-helpers/mock-gateway-page.test-support.ts
@@ -1,0 +1,28 @@
+import { Script } from "node:vm";
+import { JSDOM, type DOMWindow } from "jsdom";
+import { it } from "vitest";
+
+type MockGatewayPage = {
+  window: DOMWindow;
+  execute: (script: string) => void;
+  close: () => void;
+};
+
+export const mockGatewayTest = it.extend<{ gatewayPage: MockGatewayPage }>({
+  gatewayPage: async ({}, use) => {
+    const dom = new JSDOM("", { url: "http://mock-control-ui/", runScripts: "outside-only" });
+    try {
+      await use({
+        window: dom.window,
+        execute: (script) => {
+          new Script(script).runInContext(dom.getInternalVMContext());
+        },
+        close: () => dom.window.close(),
+      });
+    } finally {
+      // The serialized script owns page globals, listeners and queued work.
+      // Close its realm even on assertion failure; never install it in Vitest's shared window.
+      dom.window.close();
+    }
+  },
+});

--- a/ui/src/test-helpers/mock-gateway-page.test-support.ts
+++ b/ui/src/test-helpers/mock-gateway-page.test-support.ts
@@ -9,14 +9,15 @@ type MockGatewayPage = {
 };
 
 export const mockGatewayTest = it.extend<{ gatewayPage: MockGatewayPage }>({
-  // oxlint-disable-next-line no-empty-pattern -- Vitest requires destructuring to discover fixture dependencies.
-  gatewayPage: async ({}, use) => {
+  gatewayPage: async ({ task }, use) => {
     const dom = new JSDOM("", { url: "http://mock-control-ui/", runScripts: "outside-only" });
     try {
       await use({
         window: dom.window,
         execute: (script) => {
-          new Script(script).runInContext(dom.getInternalVMContext());
+          new Script(script, { filename: `mock-gateway:${task.name}` }).runInContext(
+            dom.getInternalVMContext(),
+          );
         },
         close: () => dom.window.close(),
       });

--- a/ui/src/test-helpers/mock-gateway-page.test-support.ts
+++ b/ui/src/test-helpers/mock-gateway-page.test-support.ts
@@ -9,6 +9,7 @@ type MockGatewayPage = {
 };
 
 export const mockGatewayTest = it.extend<{ gatewayPage: MockGatewayPage }>({
+  // oxlint-disable-next-line no-empty-pattern -- Vitest requires destructuring to discover fixture dependencies.
   gatewayPage: async ({}, use) => {
     const dom = new JSDOM("", { url: "http://mock-control-ui/", runScripts: "outside-only" });
     try {

--- a/ui/src/test-helpers/mock-gateway-page.test.ts
+++ b/ui/src/test-helpers/mock-gateway-page.test.ts
@@ -40,7 +40,9 @@ it("retires queued Gateway work and listeners when its page closes", async ({ ga
   );
   const storage = window.sessionStorage;
   const socket = new window.WebSocket("ws://mock-gateway");
-  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
   expect(socket.readyState).toBe(window.WebSocket.OPEN);
   const responses: string[] = [];
   socket.addEventListener("message", (event) => responses.push(String(event.data)));
@@ -58,7 +60,9 @@ it("retires queued Gateway work and listeners when its page closes", async ({ ga
   });
   gatewayPage.close();
   window.dispatchEvent(new window.Event("fixture-probe"));
-  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
 
   expect(storage.getItem("openclaw.control-ui-e2e.configState")).toBeNull();
   expect(responses).toEqual([]);

--- a/ui/src/test-helpers/mock-gateway-page.test.ts
+++ b/ui/src/test-helpers/mock-gateway-page.test.ts
@@ -1,0 +1,66 @@
+import { expect } from "vitest";
+import { createControlUiMockGatewayInitScript } from "./control-ui-e2e.ts";
+import { mockGatewayTest as it } from "./mock-gateway-page.test-support.ts";
+
+it("keeps serialized Gateway globals and storage out of the host realm", ({ gatewayPage }) => {
+  const keys = [
+    "WebSocket",
+    "JSON5",
+    "__OPENCLAW_CONTROL_UI_BASE_PATH__",
+    "openclawControlUiE2eGateway",
+  ];
+  const descriptors = () => keys.map((key) => Object.getOwnPropertyDescriptor(globalThis, key));
+  const before = descriptors();
+  const hostStorage = Object.entries(sessionStorage);
+  gatewayPage.execute(createControlUiMockGatewayInitScript({}));
+  gatewayPage.window.sessionStorage.setItem("fixture-only", "owned");
+
+  expect(gatewayPage.window).not.toBe(globalThis.window);
+  expect(
+    Object.getOwnPropertyDescriptor(gatewayPage.window, "openclawControlUiE2eGateway")?.value,
+  ).toBeDefined();
+  expect(descriptors()).toEqual(before);
+  expect(Object.entries(sessionStorage)).toEqual(hostStorage);
+});
+
+it("retires queued Gateway work and listeners when its page closes", async ({ gatewayPage }) => {
+  const { window, execute } = gatewayPage;
+  execute(
+    createControlUiMockGatewayInitScript({
+      methodResponses: {
+        "config.get": {
+          raw: '{"count":1}',
+          config: { count: 1 },
+          hash: "original",
+          valid: true,
+          issues: [],
+        },
+      },
+    }),
+  );
+  const storage = window.sessionStorage;
+  const socket = new window.WebSocket("ws://mock-gateway");
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  expect(socket.readyState).toBe(window.WebSocket.OPEN);
+  const responses: string[] = [];
+  socket.addEventListener("message", (event) => responses.push(String(event.data)));
+  socket.send(
+    JSON.stringify({
+      type: "req",
+      id: "queued-write",
+      method: "config.set",
+      params: { raw: '{"count":2}', baseHash: "original" },
+    }),
+  );
+  let listenerCalls = 0;
+  window.addEventListener("fixture-probe", () => {
+    listenerCalls += 1;
+  });
+  gatewayPage.close();
+  window.dispatchEvent(new window.Event("fixture-probe"));
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+  expect(storage.getItem("openclaw.control-ui-e2e.configState")).toBeNull();
+  expect(responses).toEqual([]);
+  expect(listenerCalls).toBe(0);
+});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Control UI routing tests fail depending on which mock-Gateway tests ran first. Running the serialized deferral tests before the browser routing tests on current main reliably leaves an empty base-path override behind, causing the two routing tests to return the wrong path.

## Why This Change Was Made

The serialized Gateway fixture installs browser globals, listeners, storage, and timers. Restoring only WebSocket or clearing storage cannot retire that page lifetime. Both serialized transport suites now execute the unchanged initialization script in a fresh JSDOM VM realm supplied by a shared Vitest fixture. A finally block closes that realm, including on assertion failure. Per-test partial cleanup and implied-eval suppressions are removed.

Production routing, the shared Vitest isolation setting, ordinary socket disconnect semantics, and Vite passthrough are unchanged. The fix uses the existing jsdom dependency and its documented outside-only VM/close lifecycle, rather than introducing a production teardown API or compensating in routing consumers. It adds pinned dev-only `@types/jsdom` declarations; no runtime dependency changes.

## User Impact

No user-visible product change. Developers get order-independent Control UI checks and deterministic retirement of queued mock-Gateway work. No changelog or screenshots are applicable to this test-only repair.

## Evidence

- On baseline `aa0647d06d27e1a9abd0a607abfc3c85649f710d`, the original single-worker order (deferral suite, then browser routing suite) reproduces two routing failures; the deferral tests themselves pass.
- With the fix, the same ordered owner/sibling run plus the serialized config/session suite and new lifetime regressions passes all 19 tests across four files.
- Temporarily disabling page cleanup makes the lifetime regression fail: a queued config write survives teardown. Cleanup was restored before the final passing run. The final regression also directly observes the mock socket for late responses, independently of storage teardown.
- Coverage retains config round trips, held and one-shot deferred requests, session creation/adoption, archive filtering, unsubscribe, offline replacement sockets, and Vite passthrough. New checks verify host globals/storage are untouched and page closure retires queued work and listeners.
- Independent owner review accepted the realm boundary; its test-strengthening feedback was applied. Structured Codex autoreview reports no blocking findings.
- Full shared UI suite: 10,916 tests passed, 66 skipped; 744 files passed and 18 skipped. Run used one worker and disabled file parallelism and cache so shared-state ordering remained in scope.
- The first changed gate caught missing jsdom declarations. After adding the dev-only types, a fresh UI type check and then the normal incremental UI type checks pass. Focused lint and the final 19-test owner/sibling rerun pass. Structured Codex review covers the complete six-file patch and the later lint-only follow-up, with no blocking findings.
- Complete six-file changed gate passed: all 95 npm package-lock targets, dependency/ownership guards, core/UI/test/plugin/script type checks, full lint, and zero runtime import cycles.
- Final-head stress: all ten shuffled seeds (11, 29, 47, 83, 101, 137, 173, 211, 257, 307) passed all 19 tests, for 190 passing executions across 40 file runs.
- Hosted CI caught a suppression-inventory failure; the fixture now uses Vitest's built-in task context to name generated scripts, removing the exception entirely. Authentic local RED became GREEN: all 23 relevant tests, types, focused lint, review and the final changed-file gate pass.
- A separate startup-memory gate failed at 401.7 MiB against a 401 MiB ceiling. The exact main baseline independently failed the same check at 402.02 MiB (run 33094744720); no runtime/build/startup code or runtime resolution changed here, and the ceiling is unchanged.
- Hosted CI on `4689d81a2947e01174f58232837bb53cd11c1dcb` is green: [run 33099198074, attempt 2](https://github.com/openclaw/openclaw/actions/runs/33099198074). Both initially failed jobs passed the single failed-jobs retry on the unchanged head. Build, including the unchanged startup-memory gate, passed; the required `openclaw/ci-gate` succeeded. No threshold, assertion, or test environment was weakened.
- The latest ClawSweeper review reports no correctness finding; its sole rank-up move was waiting for exact-head CI, now satisfied. Its attached execution also passed all 19 focused owner/sibling tests.

Named follow-up — Gateway place-label ownership, now repaired separately in draft #131118: the failed browser shard reported `Gateway · local` instead of the advertised machine name. All affected product, existing E2E, and browser-fixture paths are byte-identical to this PR's baseline, and this new JSDOM unit fixture is not loaded by Chromium E2E. The original six-test suite passed three focused repetitions, but two controlled Chromium orderings reproduced real baseline defects: recovery-scope initialization can clear a completed name without changing the discovery Task's arguments, and Browse captures an old label before discovery completes. The Task dependency contract was inspected directly. The separate fix makes that Task the canonical name owner and renders the open browser's current label; retries do not fix these races. The hosted log cannot identify which ordering produced its symptom.

The other failed job exceeded the pinned old-reader test's 300-second budget after 355 seconds. Its synchronous body returned normally after pinned-reader and reopened-candidate assertions; Vitest's elapsed-time check then rejected it. No SQLite assertion failed. The test is byte-identical to baseline/current main, and the log lacks stage timings to distinguish fetch, worktree, or TypeScript child startup cost. No timeout, test environment, storage, or assertion was changed here. Named follow-up: the hosted Node-shard raw-tsx entry path bypasses the canonical tooling registration, so the later tooling-cache repair does not cover that path; this is a verified bootstrap coverage gap, not proof of the 355-second cause.

Production LOC: +0/-0. Tests/test support: +251/-174. Dev manifest: +1; lockfile: +23. No application code changed.

Provenance: the shared-window installation pattern is present in #107458 (`d6fc3d34e2010997d4f67807b30c336347808f31`, July 14), authored and merged by @steipete; #130468 (`fc6cf5e6907dd9fde31fcb454002cffcf5d465d4`, August 27 UTC), also authored and merged by @steipete, carried it into the deferral suite that reproduces the routing failure. This is a fixture-lifetime defect, not evidence of a production routing regression.

Related but distinct: #120554 improves reconnect/catalog E2E deferrals and remains owned by its author. This repair does not copy or replace that work.
