### PR TITLE
fix(ci): resolve locale targets in one request

### DIFF
--- a/.github/workflows/control-ui-locale-refresh.yml
+++ b/.github/workflows/control-ui-locale-refresh.yml
@@ -67,24 +67,27 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${TOKEN_PREFLIGHT_ONLY}" == "true" ]]; then
-            sha="${WORKFLOW_SHA}"
+            source_ref="${WORKFLOW_SHA}"
           else
-            sha="$(
-              timeout --signal=TERM --kill-after=10s 60s \
-                gh api --method GET "repos/${REPOSITORY}/commits/${DEFAULT_BRANCH}" --jq .sha
-            )"
+            source_ref="${DEFAULT_BRANCH}"
           fi
+          repository_owner="${REPOSITORY%%/*}"
+          repository_name="${REPOSITORY#*/}"
+          source="$(
+            timeout --signal=TERM --kill-after=10s 60s \
+              gh api graphql \
+                -f query='query($owner: String!, $name: String!, $ref: String!, $configRef: String!) { repository(owner: $owner, name: $name) { revision: object(expression: $ref) { ... on Commit { oid } } config: object(expression: $configRef) { ... on Blob { text } } } }' \
+                -F owner="${repository_owner}" \
+                -F name="${repository_name}" \
+                -F ref="${source_ref}" \
+                -F configRef="${source_ref}:scripts/lib/control-ui-i18n-config.json"
+          )"
+          sha="$(jq -er '.data.repository.revision.oid' <<< "${source}")"
           if [[ ! "${sha}" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Unable to resolve the locale refresh source to an exact commit." >&2
             exit 1
           fi
-          locale_config="$(
-            timeout --signal=TERM --kill-after=10s 60s \
-              gh api --method GET \
-                -H "Accept: application/vnd.github.raw+json" \
-                "repos/${REPOSITORY}/contents/scripts/lib/control-ui-i18n-config.json?ref=${sha}"
-          )"
-          locales="$(jq -ce '[.[].locale] | select(length > 0 and all(.[]; type == "string" and length > 0))' <<< "${locale_config}")"
+          locales="$(jq -ce '.data.repository.config.text | fromjson | [.[].locale] | select(length > 0 and all(.[]; type == "string" and length > 0))' <<< "${source}")"
           echo "locales=${locales}" >> "${GITHUB_OUTPUT}"
           echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2354,9 +2354,14 @@ NODE
       );
       expect(resolveBase.outputs.sha).toBe("${{ steps.base.outputs.sha }}");
       expect(resolveStep.env.GH_TOKEN).toBe("${{ github.token }}");
-      expect(resolveStep.run).toContain(
-        'gh api --method GET "repos/${REPOSITORY}/commits/${DEFAULT_BRANCH}" --jq .sha',
-      );
+      if (ownerWorkflow === controlUiWorkflow) {
+        expect(resolveStep.run.match(/gh api/gu)).toHaveLength(1);
+        expect(resolveStep.run).toContain("gh api graphql");
+      } else {
+        expect(resolveStep.run).toContain(
+          'gh api --method GET "repos/${REPOSITORY}/commits/${DEFAULT_BRANCH}" --jq .sha',
+        );
+      }
       expect(resolveStep.run).toContain('[[ ! "${sha}" =~ ^[0-9a-f]{40}$ ]]');
 
       const checkoutSteps = (
@@ -2381,11 +2386,13 @@ NODE
     expect(controlUiResolveStep.run).toContain(
       'if [[ "${TOKEN_PREFLIGHT_ONLY}" == "true" ]]; then',
     );
-    expect(controlUiResolveStep.run).toContain('sha="${WORKFLOW_SHA}"');
+    expect(controlUiResolveStep.run).toContain('source_ref="${WORKFLOW_SHA}"');
     expect(controlUiResolveStep.run).toContain(
-      "contents/scripts/lib/control-ui-i18n-config.json?ref=${sha}",
+      '-F configRef="${source_ref}:scripts/lib/control-ui-i18n-config.json"',
     );
-    expect(controlUiResolveStep.run).toContain("jq -ce '[.[].locale]");
+    expect(controlUiResolveStep.run).toContain(
+      "jq -ce '.data.repository.config.text | fromjson | [.[].locale]",
+    );
 
     for (const preflight of [controlUiPreflight, nativePreflight]) {
       expect(preflight.needs).toBe("resolve-base");


### PR DESCRIPTION
Related: #130070

## What Problem This Solves

Fixes the post-merge Control UI locale refresh failure from run `33097316649`, where resolving the default-branch commit and locale config in two GitHub API requests hit the workflow's network rate limit.

## Why This Change Was Made

The resolver now fetches the exact commit and canonical locale JSON in one GraphQL request. This preserves the data-only trust boundary and halves the API request count before the refresh matrix starts.

## User Impact

New locale source changes can reach the post-merge translation workflow instead of stopping during target planning.

## Evidence

- The merged workflow failed in `resolve-base` with HTTP 429 before any locale job started.
- Normal reference mode returned current `main` commit `ce0fafefcedc` and all 20 canonical locale targets in one GraphQL request.
- Token-preflight reference mode returned exact workflow commit `5567390ea565` and the same 20 targets in one GraphQL request.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts --configLoader runner test/scripts/ci-workflow-guards.test.ts -t "keeps locale refresh matrices alive"` — passed.
- `pnpm check:workflows` — passed.
- Formatting and `git diff --check` passed.

AI-assisted. I reviewed the workflow and understand the single-request resolution path.
