### PR TITLE
fix(secrets): validate import values before writing

### DIFF
--- a/src/cli/secrets-store-cli.test.ts
+++ b/src/cli/secrets-store-cli.test.ts
@@ -21,23 +21,22 @@ const mocks = await vi.hoisted(async () => {
 });
 
 vi.mock("../runtime.js", () => ({ defaultRuntime: mocks.defaultRuntime }));
-vi.mock("../secrets/store/secret-store.js", async (importOriginal) => ({
-  // Import the real validation error: the CLI classifies size/empty failures by it,
-  // and a stub class would silently change the mapped exit code.
-  SecretStoreValidationError: (
-    await importOriginal<typeof import("../secrets/store/secret-store.js")>()
-  ).SecretStoreValidationError,
-  normalizeSecretAllowedHosts: (
-    await importOriginal<typeof import("../secrets/store/secret-store.js")>()
-  ).normalizeSecretAllowedHosts,
-  SECRET_STORE_VALUE_MAX_BYTES: 64 * 1024,
-  listSecretStoreEntries: (params: unknown) => mocks.list(params),
-  readSecretStoreValue: (params: unknown) => mocks.read(params),
-  writeSecretStoreEntry: (params: unknown) => mocks.write(params),
-  updateSecretStoreAllowedHosts: (params: unknown) => mocks.updateHosts(params),
-  deleteSecretStoreEntry: (params: unknown) => mocks.remove(params),
-  purgeExpiredSecretStoreEntries: () => mocks.purge(),
-}));
+vi.mock("../secrets/store/secret-store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../secrets/store/secret-store.js")>();
+  return {
+    // Keep validation real while observing whether the CLI reaches a store mutation.
+    SecretStoreValidationError: actual.SecretStoreValidationError,
+    assertSecretStoreValue: actual.assertSecretStoreValue,
+    normalizeSecretAllowedHosts: actual.normalizeSecretAllowedHosts,
+    SECRET_STORE_VALUE_MAX_BYTES: actual.SECRET_STORE_VALUE_MAX_BYTES,
+    listSecretStoreEntries: (params: unknown) => mocks.list(params),
+    readSecretStoreValue: (params: unknown) => mocks.read(params),
+    writeSecretStoreEntry: (params: unknown) => mocks.write(params),
+    updateSecretStoreAllowedHosts: (params: unknown) => mocks.updateHosts(params),
+    deleteSecretStoreEntry: (params: unknown) => mocks.remove(params),
+    purgeExpiredSecretStoreEntries: () => mocks.purge(),
+  };
+});
 vi.mock("../infra/gateway-lock.js", () => ({
   readActiveGatewayLockIdentity: () => mocks.gatewayIdentity(),
 }));
@@ -124,6 +123,58 @@ describe("secrets store CLI", () => {
       await fs.rm(dir, { recursive: true, force: true });
     }
   });
+
+  it.each(["secret", "env"])("validates an empty %s value during set dry-run", async (kind) => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-store-empty-"));
+    const valueFile = path.join(root, "empty.txt");
+    await fs.writeFile(valueFile, "");
+    try {
+      const command = createProgram().parseAsync(
+        [
+          "secrets",
+          "store",
+          "set",
+          "SERVICE_VALUE",
+          "--kind",
+          kind,
+          "--value-file",
+          valueFile,
+          "--dry-run",
+        ],
+        { from: "user" },
+      );
+      if (kind === "secret") {
+        await expect(command).rejects.toThrow("__exit__:2");
+        expect(mocks.runtimeErrors.join("\n")).toContain("Secret store value is empty");
+      } else {
+        await command;
+        expect(mocks.runtimeLogs.join("\n")).toContain("Would set SERVICE_VALUE (env)");
+      }
+      expect(mocks.write).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["--dry-run", "--yes"])(
+    "rejects an empty imported secret before any entry is written with %s",
+    async (mode) => {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-store-invalid-import-"));
+      const dotenvPath = path.join(root, "values.env");
+      await fs.writeFile(dotenvPath, "SERVICE_MODE=production\nSERVICE_API_KEY=\n");
+      try {
+        await expect(
+          createProgram().parseAsync(["secrets", "store", "import", "--from", dotenvPath, mode], {
+            from: "user",
+          }),
+        ).rejects.toThrow("__exit__:2");
+        expect(mocks.runtimeErrors.join("\n")).toContain("Secret store value is empty");
+        expect(mocks.write).not.toHaveBeenCalled();
+      } finally {
+        await fs.rm(root, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("refuses get for secret entries without reading their values", async () => {
     mocks.list.mockReturnValue([{ name: "SERVICE_API_KEY", kind: "secret" }]);
@@ -224,6 +275,7 @@ describe("secrets store CLI", () => {
         'SERVICE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----',
         "multiline-body",
         '-----END PRIVATE KEY-----"',
+        "SERVICE_EMPTY=",
       ].join("\n"),
       "utf8",
     );
@@ -236,7 +288,7 @@ describe("secrets store CLI", () => {
       await fs.rm(root, { recursive: true, force: true });
     }
 
-    expect(mocks.write).toHaveBeenCalledTimes(2);
+    expect(mocks.write).toHaveBeenCalledTimes(3);
     expect(mocks.write.mock.calls[0]?.[0]).toMatchObject({
       name: "SERVICE_URL",
       value: "https://service.test/path with spaces",
@@ -246,6 +298,11 @@ describe("secrets store CLI", () => {
       name: "SERVICE_PRIVATE_KEY",
       value: "-----BEGIN PRIVATE KEY-----\nmultiline-body\n-----END PRIVATE KEY-----",
       kind: "secret",
+    });
+    expect(mocks.write.mock.calls[2]?.[0]).toMatchObject({
+      name: "SERVICE_EMPTY",
+      value: "",
+      kind: "env",
     });
     const output = [...mocks.runtimeLogs, ...mocks.runtimeErrors].join("\n");
     expect(output).not.toContain("multiline-body");

--- a/src/cli/secrets-store-cli.ts
+++ b/src/cli/secrets-store-cli.ts
@@ -266,12 +266,7 @@ export function registerSecretStoreCli(secrets: Command): void {
               ).readSecretStoreInput({
                 valueFile: options.valueFile,
               });
-        if (Buffer.byteLength(value, "utf8") > storeModule.SECRET_STORE_VALUE_MAX_BYTES) {
-          throw new SecretStoreCliFailure(
-            2,
-            `Value exceeds ${storeModule.SECRET_STORE_VALUE_MAX_BYTES} UTF-8 bytes.`,
-          );
-        }
+        storeModule.assertSecretStoreValue(value, kind);
         if (options.dryRun) {
           defaultRuntime.log(`Would ${kind === "secret" ? "write" : "set"} ${name} (${kind}).`);
           return;
@@ -392,12 +387,7 @@ export function registerSecretStoreCli(secrets: Command): void {
         });
         const storeModule = await import("../secrets/store/secret-store.js");
         for (const entry of normalized) {
-          if (Buffer.byteLength(entry.value, "utf8") > storeModule.SECRET_STORE_VALUE_MAX_BYTES) {
-            throw new SecretStoreCliFailure(
-              2,
-              `${entry.name} exceeds ${storeModule.SECRET_STORE_VALUE_MAX_BYTES} UTF-8 bytes.`,
-            );
-          }
+          storeModule.assertSecretStoreValue(entry.value, entry.kind);
         }
         if (options.dryRun) {
           defaultRuntime.log(`Would import ${normalized.length} team store entries.`);

--- a/src/secrets/store/secret-store.ts
+++ b/src/secrets/store/secret-store.ts
@@ -99,7 +99,7 @@ function assertSecretStoreMutationName(name: string): void {
   }
 }
 
-function assertSecretStoreValue(value: string, kind: SecretStoreKind): void {
+export function assertSecretStoreValue(value: string, kind: SecretStoreKind): void {
   const bytes = Buffer.byteLength(value, "utf8");
   if (bytes > SECRET_STORE_VALUE_MAX_BYTES) {
     throw new SecretStoreValidationError(


### PR DESCRIPTION
Closes #131040

## What Problem This Solves

Fixes an issue where secret-store dry-runs reported success for empty protected credentials, and an import wrote earlier valid entries before rejecting a later empty credential.

## Why This Change Was Made

The CLI now calls the store's existing pure value validator before reporting dry-run success and before writing any import entry. This removes two incomplete copies of the size check while keeping the store authoritative. Empty environment values remain valid; no schema, storage transaction, retention, custody, or configuration changes were made.

## User Impact

Invalid protected values consistently return validation exit code 2, and deterministic value-validation failures cannot leave partially imported entries. This does not promise transaction-wide rollback for unrelated database failures. The separate post-commit retention-reporting issue #127544 is unchanged.

## Evidence

- Before production edits, the new parser/CLI regressions produced three intended failures and ten passes. After repair, CLI/store suites passed 31 tests.
- Real normal dist-backed CLI and isolated SQLite proof on Blacksmith Testbox: seven before/after cases, including both dry-runs, invalid writes/imports, valid import, and empty environment entries. Invalid import retained an earlier row before repair and left zero rows afterward; legitimate operations still succeed. Synthetic inputs only; values omitted from proof output.
- [Testbox workflow 33095755658](https://github.com/openclaw/openclaw/actions/runs/33095755658), lease `tbx_01m122c5psq6369bwwdh2yve9n`: wrapper exit 0; normal CLI builds passed before/after. Lease stopped after proof; Actions cleanup state is not the command verdict.
- Scoped formatting, oxlint, whitespace, and dead-export checks passed. Full local changed-check reached core typechecking, then stopped on pre-existing installed `pi-tui`/`markdown-it` dependency drift; exact-head hosted CI is required before landing.
- Fresh isolated Codex autoreview completed with no actionable findings at its configured P0 threshold. Direct owner/caller/sibling review covered CLI preflight, store mutation validation, and Gateway store callers.
- Production +3/-13 (net -10); tests +75/-18 (net +57). No test-only production seam: the exported validator is consumed by the production CLI.

The prior empty-value validation change is commit `b067a4dce343c239d3bc183a8f471ef65c7b5ea5` / #121947; this repair aligns CLI preflight with that established store contract. AI-assisted; listed secops owner direction verified.
