### PR TITLE
fix(imap): reject mail with missing DMARC alignment

### DIFF
--- a/extensions/imap/src/sender-gate.test.ts
+++ b/extensions/imap/src/sender-gate.test.ts
@@ -1,3 +1,4 @@
+import { authenticate } from "mailauth";
 import { simpleParser } from "mailparser";
 import { describe, expect, it, vi } from "vitest";
 import { resolveImapConfig } from "./config.js";
@@ -75,25 +76,54 @@ describe("IMAP sender admission", () => {
   it.each(["neutral", "temperror", "none"] as const)(
     "never dispatches on DMARC %s at the default verified threshold",
     async (result) => {
-      const mail = await message(["From: trusted@example.com", "To: reader@example.com"]);
-      const authenticator = vi.fn(async () => createImapAuthResult(result));
+      const mail = await message([
+        "From: trusted@example.com",
+        "To: reader+wrong-token@example.com",
+      ]);
+      const authentication =
+        result === "neutral"
+          ? createImapAuthResult(result)
+          : await authenticate(mail.raw, {
+              disableArc: true,
+              disableBimi: true,
+              resolver: async () => {
+                if (result === "temperror") {
+                  throw new Error("fixture DNS timeout");
+                }
+                return [];
+              },
+            });
+      expect(authentication.dmarc).toMatchObject({ status: { result } });
+      if (result !== "neutral") {
+        expect(authentication.dmarc).not.toHaveProperty("alignment");
+      }
+      const configured = account({
+        addressTokens: [{ token: "expected-token", senders: ["trusted@example.com"] }],
+      });
       await expect(
-        evaluateImapSender({ ...mail, account: account(), authenticator }),
-      ).resolves.toMatchObject({ accepted: false });
+        evaluateImapSender({
+          ...mail,
+          account: configured,
+          authenticator: async () => authentication,
+        }),
+      ).resolves.toMatchObject({ accepted: false, transient: result === "temperror" });
     },
   );
 
-  it("does not verify a passing DKIM signature that left message body bytes unsigned", async () => {
-    const result = createImapAuthResult("pass");
-    if (result.dmarc) {
-      result.dmarc.alignment.dkim.underSized = 32;
-    }
-    const mail = await message(["From: trusted@example.com", "To: reader@example.com"]);
-    const authenticator = vi.fn(async () => result);
-    await expect(
-      evaluateImapSender({ ...mail, account: account(), authenticator }),
-    ).resolves.toMatchObject({ accepted: false, reason: "dkim-unsigned-body" });
-  });
+  it.each(["pass", "fail"] as const)(
+    "rejects unsigned body bytes even with DMARC %s",
+    async (dmarc) => {
+      const result = createImapAuthResult(dmarc);
+      if (result.dmarc) {
+        result.dmarc.alignment.dkim.underSized = 32;
+      }
+      const mail = await message(["From: trusted@example.com", "To: reader@example.com"]);
+      const authenticator = vi.fn(async () => result);
+      await expect(
+        evaluateImapSender({ ...mail, account: account(), authenticator }),
+      ).resolves.toMatchObject({ accepted: false, reason: "dkim-unsigned-body" });
+    },
+  );
 
   it("accepts only configured Authentication-Results authorities", async () => {
     const configured = account({

--- a/extensions/imap/src/sender-gate.ts
+++ b/extensions/imap/src/sender-gate.ts
@@ -117,7 +117,8 @@ function mapImapAuthStrength(
   account: ImapAccountConfig,
 ): { strength: SenderStrength; reason: string; transient: boolean } {
   const dmarc = result?.dmarc && result.dmarc.status.result;
-  if (result?.dmarc && result.dmarc.alignment.dkim.underSized) {
+  // mailauth omits alignment when no DMARC policy exists or its DNS lookup fails.
+  if (result?.dmarc && result.dmarc.alignment?.dkim.underSized) {
     return { strength: "unverified", reason: "dkim-unsigned-body", transient: false };
   }
   if (dmarc === "pass") {


### PR DESCRIPTION
Closes #131057

## What Problem This Solves

Fixes an issue where an unsigned allowed-sender email could block the IMAP mailbox sweep instead of producing a sender rejection.

## Why This Change Was Made

Pinned mailauth 5.0.2 returns DMARC `none` or `temperror` before constructing alignment details. The sender policy now accounts for that documented runtime shape at the existing unsigned-body check, then classifies the result through the canonical policy. Sender thresholds, token handling, trusted-header rules, and transient-error classification are unchanged.

## User Impact

Missing DMARC policy is rejected at the default verified threshold, and DNS failures retain their transient classification. The mailbox no longer throws while reading absent alignment. DKIM signatures that leave body bytes unsigned remain insufficient, for both passing and failing DMARC.

## Evidence

- Two regressions using actual mailauth results failed before repair with the missing-alignment TypeError. The DNS resolver is a fixture; the mailauth result shape is not mocked.
- All 26 IMAP tests passed after repair, including both unsigned-body variants. Formatting and whitespace checks passed.
- Direct inspection covered mailauth's verifier, record lookup, authenticate API, and declarations; the declarations overstate alignment presence, while the runtime deliberately omits it for these outcomes.
- A real normal Gateway + GreenMail SMTP/IMAP diagnostic observed unsigned wrong-token UID 5 repeatedly block cursor 4. Final live rejection and subsequent-message progress passed with the separate scheduling/recovery fixes. [Inspect the exact-hash live proof](https://github.com/openclaw/openclaw/pull/131060#issuecomment-5442809674).
- Fresh isolated Codex autoreview found no actionable P0 findings. Production +2/-1 (net +1, the explanatory dependency-contract comment); executable production LOC unchanged. Tests +44/-14 (net +30).

Introduced with #130230, authored and merged by @steipete on August 26, 2026. No new policy, configuration, schema, or dependency change. AI-assisted.

Exact-head CI passed on attempt 2 of run 33098362305. The first startup-RSS overage and single unchanged diagnostic retry are recorded in the PR comments; no thresholds were changed. Latest ClawSweeper CI/dependency-inspection items are addressed with direct pinned-source inspection and completed proof.
