### PR TITLE
fix(ui): preserve literal JSON in chat and tool details

### DIFF
--- a/ui/src/pages/chat/components/chat-json-text.test.ts
+++ b/ui/src/pages/chat/components/chat-json-text.test.ts
@@ -1,0 +1,174 @@
+/* @vitest-environment jsdom */
+
+import { nothing, render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { toSanitizedMarkdownHtml } from "../../../components/markdown.ts";
+import { renderGroupedMessage } from "./chat-message-bubble.ts";
+import type { SidebarContent } from "./chat-sidebar.ts";
+import { renderToolCard } from "./chat-tool-cards.ts";
+
+// Keep these as literal source text: parsing expected values would repeat the
+// rounding and duplicate-key loss that the display must not introduce.
+const jsonSources = [
+  {
+    name: "object numeric lexemes",
+    text: '{"id":9007199254740993,"overflow":1e400,"decimal":0.1234567890123456789,"zero":-0}',
+  },
+  {
+    name: "array numeric lexemes",
+    text: "[9007199254740993,1e400,0.1234567890123456789,-0]",
+  },
+  { name: "duplicate keys", text: '{"state":"before","state":"after"}' },
+  {
+    name: "escaped strings",
+    text: String.raw`{"quoted":"say \"hello\"","slash":"\/","unicode":"\u0061","backslash":"\\"}`,
+  },
+  { name: "literal Markdown", text: '{"text":"**stars**"}' },
+  { name: "ordinary formatted JSON", text: '{\n  "count": 42,\n  "ready": true\n}' },
+];
+
+const containers: HTMLElement[] = [];
+
+function createContainer() {
+  const container = document.createElement("div");
+  document.body.append(container);
+  containers.push(container);
+  return container;
+}
+
+afterEach(() => {
+  for (const container of containers.splice(0)) {
+    render(nothing, container);
+    container.remove();
+  }
+});
+
+describe.each(["user", "assistant", "toolResult"])("%s JSON message text", (role) => {
+  function renderMessage(text: string, isStreaming = false) {
+    const container = createContainer();
+    render(
+      renderGroupedMessage(
+        {
+          role,
+          content: text,
+          ...(role === "toolResult" ? { toolName: "lookup", toolCallId: "json-result" } : {}),
+        },
+        "json-message",
+        { isStreaming, showReasoning: false, isToolMessageExpanded: () => true },
+      ),
+      container,
+    );
+    return container;
+  }
+
+  it.each(jsonSources)("preserves $name in the expanded JSON disclosure", ({ text }) => {
+    const container = renderMessage(text);
+    const disclosure = container.querySelector<HTMLDetailsElement>(".chat-json-collapse");
+    expect(disclosure).not.toBeNull();
+    disclosure!.querySelector<HTMLElement>("summary")!.click();
+    expect(disclosure!.open).toBe(true);
+    expect(disclosure!.querySelector("code")?.textContent).toBe(text);
+    expect(disclosure!.querySelector("strong")).toBeNull();
+  });
+
+  it.each([19_999, 20_000, 20_001])(
+    "retains the JSON disclosure boundary at %i characters",
+    (size) => {
+      const text = '{"text":"' + "x".repeat(size - 11) + '"}';
+      expect(text).toHaveLength(size);
+      const container = renderMessage(text);
+      const disclosure = container.querySelector<HTMLDetailsElement>(".chat-json-collapse");
+      if (size <= 20_000) {
+        expect(disclosure).not.toBeNull();
+        disclosure!.querySelector<HTMLElement>("summary")!.click();
+        expect(disclosure!.open).toBe(true);
+        expect(disclosure!.querySelector("code")?.textContent).toBe(text);
+      } else {
+        expect(disclosure).toBeNull();
+        expect(container.textContent).toContain(text);
+      }
+    },
+  );
+
+  it("keeps explicitly fenced JSON literal without another disclosure", () => {
+    const text = '{"id":9007199254740993,"text":"**stars**"}';
+    const fenced = "```json\n" + text + "\n```";
+    const container = renderMessage(fenced);
+    expect(container.querySelector(".chat-json-collapse")).toBeNull();
+    // Tool cards show raw output; authored message Markdown consumes its fence.
+    expect(container.querySelector("pre code")?.textContent?.trimEnd()).toBe(
+      role === "toolResult" ? fenced : text,
+    );
+    expect(container.querySelector("pre strong")).toBeNull();
+  });
+
+  if (role === "assistant") {
+    it("does not auto-disclose a streaming JSON message", () => {
+      const text = "[9007199254740993,1e400,-0]";
+      const container = renderMessage(text, true);
+      expect(container.querySelector(".chat-json-collapse")).toBeNull();
+      expect(container.textContent).toContain(text);
+    });
+  }
+
+  it("keeps invalid JSON as ordinary message output", () => {
+    const text = '{"count": }';
+    const container = renderMessage(text);
+    expect(container.querySelector(".chat-json-collapse")).toBeNull();
+    expect(container.textContent).toContain(text);
+  });
+});
+
+describe("tool JSON details", () => {
+  function openToolDetails(text: string) {
+    const container = createContainer();
+    const openSidebar = vi.fn<(content: SidebarContent) => void>();
+    render(
+      renderToolCard(
+        { id: "json-tool", name: "lookup", outputText: text, completed: true },
+        { expanded: true, onToggleExpanded: vi.fn(), onOpenSidebar: openSidebar },
+      ),
+      container,
+    );
+    expect(container.querySelector(".chat-tool-card__block code")?.textContent).toBe(text);
+    container.querySelector<HTMLButtonElement>(".chat-tool-card__action-btn")!.click();
+    expect(openSidebar).toHaveBeenCalledOnce();
+    const content = openSidebar.mock.calls[0]?.[0];
+    expect(content?.kind).toBe("markdown");
+    if (content?.kind !== "markdown") {
+      throw new Error("Expected tool details Markdown");
+    }
+    expect(content.rawText).toBe(text);
+    const panel = createContainer();
+    panel.innerHTML = toSanitizedMarkdownHtml(content.content);
+    return panel;
+  }
+
+  it.each(jsonSources)("preserves $name after opening tool details", ({ text }) => {
+    const panel = openToolDetails(text);
+    expect(panel.querySelector("pre code")?.textContent?.trimEnd()).toBe(text);
+    expect(panel.querySelector("pre strong")).toBeNull();
+  });
+
+  it.each([19_999, 20_000, 20_001])("keeps %i-character JSON output literal in details", (size) => {
+    const text = '{"text":"**stars**' + "x".repeat(size - 20) + '"}';
+    expect(text).toHaveLength(size);
+    const panel = openToolDetails(text);
+    expect(panel.querySelector("pre code")?.textContent?.trimEnd()).toBe(text);
+    expect(panel.querySelector("pre strong")).toBeNull();
+  });
+
+  it("keeps explicitly fenced JSON output literal in details", () => {
+    const text = '{"id":9007199254740993,"text":"**stars**"}';
+    const panel = openToolDetails("```json\n" + text + "\n```");
+    expect(panel.querySelector("pre code")?.textContent?.trimEnd()).toBe(text);
+    expect(panel.querySelector("pre strong")).toBeNull();
+  });
+
+  it("keeps invalid JSON as ordinary detail output", () => {
+    const text = '{"count": }';
+    const panel = openToolDetails(text);
+    expect(panel.querySelector("pre code")).toBeNull();
+    expect(panel.textContent).toContain(text);
+  });
+});

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -114,10 +114,6 @@ function renderInlineToolCards(
   `;
 }
 
-/**
- * Max characters for auto-detecting and pretty-printing JSON.
- * Prevents DoS from large JSON payloads in assistant/tool messages.
- */
 type ReplyPreview = {
   sourceMessageId?: string;
   senderLabel?: string | null;
@@ -564,7 +560,7 @@ export function renderGroupedMessage(
                                 >${jsonSummaryLabel(jsonResult.parsed)}</span
                               >
                             </summary>
-                            <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
+                            <pre class="chat-json-content"><code>${jsonResult.text}</code></pre>
                           </details>`
                         : bodyMarkdown
                           ? renderMarkdownText(
@@ -635,7 +631,7 @@ export function renderGroupedMessage(
                     <span class="chat-json-badge">${t("chat.codeBlock.jsonBadge")}</span>
                     <span class="chat-json-label">${jsonSummaryLabel(jsonResult.parsed)}</span>
                   </summary>
-                  <pre class="chat-json-content"><code>${jsonResult.pretty}</code></pre>
+                  <pre class="chat-json-content"><code>${jsonResult.text}</code></pre>
                 </details>`
               : bodyMarkdown
                 ? normalizedRole === "user"

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -36,7 +36,7 @@ const MAX_JSON_AUTOPARSE_CHARS = 20_000;
  * Must start with `{`/`[` and end with `}`/`]` and parse successfully.
  * Size-capped to prevent render-loop DoS from large JSON messages.
  */
-export function detectJson(text: string): { parsed: unknown; pretty: string } | null {
+export function detectJson(text: string): { parsed: unknown; text: string } | null {
   const trimmed = text.trim();
 
   // Enforce size cap to prevent UI freeze from multi-MB JSON payloads
@@ -50,7 +50,8 @@ export function detectJson(text: string): { parsed: unknown; pretty: string } | 
   ) {
     try {
       const parsed = JSON.parse(trimmed);
-      return { parsed, pretty: JSON.stringify(parsed, null, 2) };
+      // Parsing is only for the summary; reserialization loses numeric precision and duplicate keys.
+      return { parsed, text: trimmed };
     } catch {
       return null;
     }

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -64,7 +64,9 @@ function formatToolOutputForSidebar(text: string): string {
   const trimmed = text.trim();
   if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
     try {
-      return "```json\n" + JSON.stringify(JSON.parse(trimmed), null, 2) + "\n```";
+      JSON.parse(trimmed);
+      // Keep the source literal: reserialization can change numbers, escapes, and duplicate keys.
+      return "```json\n" + trimmed + "\n```";
     } catch {
       return text;
     }


### PR DESCRIPTION
Closes #131058.

## What Problem This Solves

Fixes an issue where users inspecting JSON in Control UI chat disclosures or tool details would see different values from the original message: large integers and decimals were rounded, an overflowing exponent became `null`, negative zero changed, duplicate keys disappeared, and escape spellings were rewritten. Composer requests, inline tool output, and raw message text retained the source, so the same message could contradict itself on screen.

## Why This Change Was Made

Keep parsing solely for JSON classification and summary labels, then display the original trimmed text through the existing literal-code surfaces. Remove the regenerated `pretty` representation and its orphaned comment. A new lossless parser or data field is unnecessary because the original source string already belongs to the display owner.

The existing 20,000-character chat auto-disclosure cap and streaming behavior remain unchanged. Tool details deliberately retain their existing larger-JSON code presentation instead of sharing the capped detector. Stored messages, protocol, configuration, and tool argument generation are unchanged.

## User Impact

JSON disclosures and tool details now show the actual source values, keys, escapes, and indentation. Compact JSON stays compact rather than being automatically re-indented; existing horizontal scrolling and code wrapping remain available. This repairs presentation corruption, not a demonstrated loss of stored message data.

## Evidence

- Authentic baseline: 16 failing literal-text assertions and 7 passing controls. The final 45-case regression matrix plus 271 neighboring tests passes: **316 tests in 5 files**.
- Real production-bundle Chromium before/after proof: assistant disclosure, user disclosure, and Open Details changed from incorrect to exact text; actual composer requests and inline tool output stayed exact.
- Covers objects/arrays, unsafe integers, exponents, long decimals, negative zero, repeated keys, escaped strings, literal Markdown punctuation, malformed/fenced JSON, streaming, and 19,999/20,000/20,001-character boundaries. Assertions compare literal text rather than parsing it again.
- Full changed gate passed, including core-test/UI typechecks, changed-file lint/style checks, i18n verification, dependency/format guards, and dead-export scans.
- Fresh isolated Codex review found no actionable P0–P2 findings. Independent source-blind validation passed all six clauses in the production browser: independently authored literals, changed fixtures, real composer send, actual clipboard reads, tool details/raw views, reopen/reload, format controls, and exact 19,999/20,000/20,001-character boundaries. AI-assisted implementation. This is a real browser with synthetic Gateway fixtures, not a live model/provider or storage-persistence test. Code surfaces may add a single display-framing newline; copied payloads remain exact. One optional mouse-copy interaction was intercepted by another visible group; keyboard activation of the same button passed and was recorded as such.

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-json-text.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-tool-cards.test.ts ui/src/pages/chat/components/chat-tool-cards.outcome.test.ts ui/src/pages/chat/components/chat-tool-cards.node.test.ts
node scripts/check-changed.mjs -- CHANGELOG.md ui/src/pages/chat/components/chat-message-markdown.ts ui/src/pages/chat/components/chat-message-bubble.ts ui/src/pages/chat/components/chat-tool-cards.ts ui/src/pages/chat/components/chat-json-text.test.ts
```

Before: the inline result and details disagree.

![Before: tool details rewrite JSON values](https://github.com/user-attachments/assets/4a0edeec-97c5-4bee-94fd-b11568f0733a)

After: both surfaces retain the original JSON text.

![After: tool details preserve original JSON values](https://github.com/user-attachments/assets/9bdba13a-ec50-4c75-a23f-694b785e23b6)

Production LOC: **+8/-9 (net -1)**. Tests: **+174/-0**. No dependency, configuration, SDK, or storage growth. The changed gate also checked the unchanged changelog; release-note context is recorded here.

Provenance: transcript auto-disclosure was introduced in #41503 (author and merger @BunsDev, 2026-03-12), then carried forward by the later Control UI extraction; the sidebar formatter predates it. Both faulty paths are present in stable `v2026.7.1-2` by source inspection. The recorded browser baseline is `aa0647d06d27e1a9abd0a607abfc3c85649f710d`.
