### PR TITLE
fix(memory): honor memory.search.cache.maxEntries so the embedding cache prune can run

### DIFF
--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -536,6 +536,25 @@ describe("memory search config", () => {
     expect(resolveMemorySearchSyncConfig(cfg, "main")).toStrictEqual(expected.sync);
   });
 
+  it("honors memory.search.cache.maxEntries so the cache prune can run", () => {
+    // Regression: maxEntries was hardcoded to the default, so the resolved value
+    // was always undefined and pruneEmbeddingCacheIfNeeded() returned early on
+    // every install, letting memory_embedding_cache grow without bound.
+    const withCap = asConfig({
+      memory: {
+        search: {
+          provider: "openai",
+          cache: { maxEntries: 5_000 },
+        },
+      },
+      agents: { defaults: {} },
+    });
+    expect(resolveMemorySearchConfig(withCap, "main")?.cache).toStrictEqual({
+      enabled: true,
+      maxEntries: 5_000,
+    });
+  });
+
   it("merges defaults and overrides", () => {
     const cfg = asConfig({
       memory: {

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -128,7 +128,7 @@ const DEFAULT_MMR_LAMBDA = 0.7;
 const DEFAULT_TEMPORAL_DECAY_ENABLED = true;
 const DEFAULT_TEMPORAL_DECAY_HALF_LIFE_DAYS = 30;
 const DEFAULT_CACHE_ENABLED = true;
-const DEFAULT_CACHE_MAX_ENTRIES = undefined;
+const DEFAULT_CACHE_MAX_ENTRIES: number | undefined = undefined;
 const DEFAULT_SOURCES: Array<"memory" | "sessions"> = ["memory"];
 export const DEFAULT_MEMORY_EMBEDDING_PROVIDER = "openai";
 const DEFAULT_REMOTE_BATCH_POLL_INTERVAL_MS = 2_000;
@@ -293,7 +293,8 @@ function mergeConfig(
   };
   const cache = {
     enabled: overrides?.cache?.enabled ?? defaults?.cache?.enabled ?? DEFAULT_CACHE_ENABLED,
-    maxEntries: DEFAULT_CACHE_MAX_ENTRIES,
+    maxEntries:
+      overrides?.cache?.maxEntries ?? defaults?.cache?.maxEntries ?? DEFAULT_CACHE_MAX_ENTRIES,
   };
 
   const minScore = clampNumber(query.minScore, 0, 1);

--- a/src/config/dead-config-keys.test.ts
+++ b/src/config/dead-config-keys.test.ts
@@ -119,7 +119,6 @@ describe("dead config keys", () => {
     "memory.qmd",
     "memory.search.qmd",
     "agents.entries.test.memory.search.qmd",
-    "memory.search.cache.maxEntries",
     "agents.defaults.runRetries",
     "agents.entries.test.memory.search.chunking",
     "agents.entries.test.runRetries",

--- a/src/config/schema.help.models.ts
+++ b/src/config/schema.help.models.ts
@@ -250,6 +250,8 @@ export const MODEL_FIELD_HELP: Record<string, string> = {
     "Minimum relevance score threshold for including memory results in final recall output. Increase to reduce weak/noisy matches, or lower when you need more permissive retrieval.",
   "memory.search.cache.enabled":
     "Caches computed chunk embeddings in SQLite so reindexing and incremental updates run faster (default: true). Keep this enabled unless investigating cache correctness or minimizing disk usage.",
+  "memory.search.cache.maxEntries":
+    "Caps how many embedding cache rows are kept, evicting the least recently updated ones once the cap is exceeded (default: unlimited). Set this when the cache grows past the disk you want to spend on it.",
   memory: "Built-in memory configuration (global).",
   "memory.citations":
     'Controls citation visibility in replies: "auto" shows citations when useful, "on" always shows them, and "off" hides them. Keep "auto" for a balanced signal-to-noise default.',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -509,6 +509,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "memory.search.query.maxResults": "Memory Search Max Results",
   "memory.search.query.minScore": "Memory Search Min Score",
   "memory.search.cache.enabled": "Memory Search Embedding Cache",
+  "memory.search.cache.maxEntries": "Embedding Cache Max Entries",
   memory: "Memory",
   "memory.citations": "Memory Citations Mode",
   auth: "Auth",

--- a/src/config/types.memory.ts
+++ b/src/config/types.memory.ts
@@ -98,5 +98,7 @@ export type MemorySearchConfig = {
   cache?: {
     /** Cache chunk embeddings in SQLite (default: true). */
     enabled?: boolean;
+    /** Cap on cached embedding rows; oldest are evicted past it (default: unlimited). */
+    maxEntries?: number;
   };
 };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -843,6 +843,7 @@ export const MemorySearchSchema = z
     cache: z
       .object({
         enabled: z.boolean().optional(),
+        maxEntries: z.number().int().positive().optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## What Problem This Solves

`memory.search.cache.maxEntries` is wired everywhere except the one line that reads it, so
`pruneEmbeddingCacheIfNeeded()` is dead code on every install and `memory_embedding_cache`
grows without bound.

The eviction path is fully built already:

- `manager-embedding-ops.ts:411` — `pruneEmbeddingCacheIfNeeded()` deletes the oldest rows past the cap
- `manager-sync-ops.ts:602` — calls it on every sync
- `memory-schema.ts:670` — a dedicated `idx_memory_embedding_cache_updated_at` index exists for exactly this ordering
- `cli-status.runtime.ts:448` — surfaces `Cache cap` when the value is a number
- `types.memory.ts` — `store.cache.maxEntries` is declared (though `store.cache` is not in the zod schema, so that path is unreachable)

But the resolver hardcodes the default instead of reading config, unlike every sibling field
in the same object:

```ts
// src/agents/memory-search.ts
const DEFAULT_CACHE_MAX_ENTRIES = undefined;

const cache = {
  enabled: overrides?.cache?.enabled ?? defaults?.cache?.enabled ?? DEFAULT_CACHE_ENABLED,
  maxEntries: DEFAULT_CACHE_MAX_ENTRIES,   // ignores overrides and defaults
};
```

`maxEntries` is therefore always `undefined`, and the guard at the top of the prune returns early
every time:

```ts
const max = this.cache.maxEntries;
if (!max || max <= 0) {
  return;
}
```

`dead-config-keys.test.ts` also asserted the key must be rejected by config validation, so an
operator could not set it even if the resolver honored it.

## Evidence

Measured on a production host running 2026.7.2-beta.7, 7 agents, provider
`gemini/gemini-embedding-001` at 3072 dims, `memory.search.cache.enabled: true`:

| | rows | size |
|---|---|---|
| `memory_embedding_cache` (largest agent) | 7,025 | 443.7 MB |
| all 7 agent databases (cache + chunk columns) | 20,277 vectors | 1,277 MB |

Age distribution of that cache — nothing is ever evicted, so it is almost entirely stale:

```
last 7d      102 rows     6.4 MB
7-30d        753 rows    47.6 MB
30-90d     6,170 rows   389.7 MB   <- 88%
>90d           0 rows
```

28% of the rows (1,952) hash to chunks that no longer exist in the index at all.

The cap that would have bounded this is reachable in the code and unreachable from config.

### Test proves the defect

`src/agents/memory-search.test.ts` gains a case asserting a configured cap survives resolution.
Against the pre-patch resolver it fails:

```
AssertionError: expected { Object (enabled, maxEntries) } to strictly equal
  { enabled: true, maxEntries: 5000 }
```

With the patch it passes. The existing assertion that an unconfigured cache resolves to
`{ enabled: true, maxEntries: undefined }` still passes untouched, which is the
backward-compatibility check: absent config keeps today's unlimited behavior.

## What Changed

- `src/agents/memory-search.ts` — read `overrides` then `defaults` then the default, matching `enabled` on the line above
- `src/config/zod-schema.agent-runtime.ts` — accept `maxEntries` as a positive integer under `memory.search.cache`
- `src/config/types.memory.ts` — declare `maxEntries` on the reachable `cache` (the one the resolver reads)
- `src/config/dead-config-keys.test.ts` — drop the key, now that it is live
- `src/config/schema.labels.ts`, `src/config/schema.help.models.ts` — label and help text
- `src/agents/memory-search.test.ts` — regression test above

Default stays `undefined`, so no install changes behavior until an operator sets a cap.

I left `store.cache` in `types.memory.ts` alone: it is unreachable (absent from the zod schema)
and removing it is a separate cleanup.
