### PR TITLE
refactor(agents): compose session tools from definitions

### DIFF
--- a/src/agents/sessions/tools/index.test.ts
+++ b/src/agents/sessions/tools/index.test.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import type { AgentTool } from "../../runtime/index.js";
+import {
+  allToolNames,
+  createAllTools,
+  createCodingTools,
+  createReadOnlyTools,
+  createTool,
+  createToolDefinition,
+  type ToolName,
+  type ToolsOptions,
+} from "./index.js";
+
+const names: ToolName[] = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+const factories = [
+  {
+    name: "selected",
+    create: (cwd: string, options?: ToolsOptions) =>
+      names.map((name) => createTool(name, cwd, options)),
+    names,
+  },
+  { name: "coding", create: createCodingTools, names: ["read", "bash", "edit", "write"] },
+  { name: "read-only", create: createReadOnlyTools, names: ["read", "grep", "find", "ls"] },
+  {
+    name: "all",
+    create: (cwd: string, options?: ToolsOptions) => Object.values(createAllTools(cwd, options)),
+    names,
+  },
+] satisfies Array<{
+  name: string;
+  create: (cwd: string, options?: ToolsOptions) => AgentTool[];
+  names: string[];
+}>;
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function requireTool(tools: AgentTool[], name: string): AgentTool {
+  const tool = tools.find((entry) => entry.name === name);
+  if (!tool) {
+    throw new Error(`Missing ${name} tool`);
+  }
+  return tool;
+}
+
+describe("session tool factories", () => {
+  it("keeps ordered tool sets independent of the mutable exported inventory", () => {
+    const savedNames = [...allToolNames];
+    allToolNames.clear();
+    try {
+      for (const factory of factories) {
+        expect(factory.create("/workspace").map((tool) => tool.name)).toEqual(factory.names);
+      }
+      expect(
+        Object.entries(createAllTools("/workspace")).map(([key, tool]) => [key, tool.name]),
+      ).toEqual(names.map((name) => [name, name]));
+    } finally {
+      for (const name of savedNames) {
+        allToolNames.add(name);
+      }
+    }
+  });
+
+  it.each([createTool, createToolDefinition])("rejects unknown names", (create) => {
+    expect(() => create("missing" as ToolName, "/workspace")).toThrow("Unknown tool name: missing");
+  });
+
+  it.each(factories)("$name preserves injected read operations", async (factory) => {
+    const cwd = tempDirs.make("openclaw-tool-factories-read-");
+    const tools = factory.create(cwd, {
+      read: {
+        operations: {
+          access: async () => {},
+          readFile: async (absolutePath) => Buffer.from(`remote:${absolutePath}`),
+        },
+      },
+    });
+
+    const result = await requireTool(tools, "read").execute("read", { path: "virtual.txt" });
+
+    expect(result.content).toEqual([
+      { type: "text", text: `remote:${path.join(cwd, "virtual.txt")}` },
+    ]);
+  });
+
+  it.each(factories.filter((factory) => factory.names.includes("bash")))(
+    "$name preserves shell options and file operations",
+    async (factory) => {
+      const cwd = tempDirs.make("openclaw-tool-factories-files-");
+      const tools = factory.create(cwd, {
+        bash: {
+          commandPrefix: "prepare",
+          operations: {
+            exec: async (command, executionCwd, { onData }) => {
+              onData(Buffer.from(`${executionCwd}:${command}`));
+              return { exitCode: 0 };
+            },
+          },
+        },
+      });
+      const written = await requireTool(tools, "write").execute("write", {
+        path: "nested/file.txt",
+        content: "before\n",
+      });
+      expect(written.details).toMatchObject({ changed: true, created: true });
+      const read = await requireTool(tools, "read").execute("read", { path: "nested/file.txt" });
+      expect(read.content).toEqual([{ type: "text", text: "before\n" }]);
+
+      const edit = requireTool(tools, "edit");
+      const input = edit.prepareArguments?.({
+        path: "nested/file.txt",
+        oldText: "before",
+        newText: "after",
+      });
+      await edit.execute("edit", input);
+      await expect(fs.readFile(path.join(cwd, "nested/file.txt"), "utf8")).resolves.toBe("after\n");
+
+      const shell = await requireTool(tools, "bash").execute("bash", { command: "run" });
+      expect(shell.content).toEqual([{ type: "text", text: `${cwd}:prepare\nrun` }]);
+    },
+  );
+
+  it.each(factories.filter((factory) => factory.names.includes("find")))(
+    "$name preserves injected discovery operations",
+    async (factory) => {
+      const cwd = tempDirs.make("openclaw-tool-factories-discovery-");
+      const tools = factory.create(cwd, {
+        find: { operations: { exists: () => true, glob: () => [path.join(cwd, "remote.ts")] } },
+        ls: {
+          operations: {
+            exists: () => true,
+            stat: (absolutePath) => ({ isDirectory: () => absolutePath === cwd }),
+            readdir: () => ["remote.ts"],
+          },
+        },
+      });
+
+      const found = await requireTool(tools, "find").execute("find", { pattern: "*.ts" });
+      const listed = await requireTool(tools, "ls").execute("ls", {});
+      expect(found.content).toEqual([{ type: "text", text: "remote.ts" }]);
+      expect(listed.content).toEqual([{ type: "text", text: "remote.ts" }]);
+    },
+  );
+});

--- a/src/agents/sessions/tools/index.ts
+++ b/src/agents/sessions/tools/index.ts
@@ -5,13 +5,14 @@
  */
 import type { AgentTool } from "../../runtime/index.js";
 import type { ToolDefinition } from "../extensions/types.js";
-import { type BashToolOptions, createBashTool, createBashToolDefinition } from "./bash.js";
-import { createEditTool, createEditToolDefinition, type EditToolOptions } from "./edit.js";
-import { createFindTool, createFindToolDefinition, type FindToolOptions } from "./find.js";
-import { createGrepTool, createGrepToolDefinition, type GrepToolOptions } from "./grep.js";
-import { createLsTool, createLsToolDefinition, type LsToolOptions } from "./ls.js";
-import { createReadTool, createReadToolDefinition, type ReadToolOptions } from "./read.js";
-import { createWriteTool, createWriteToolDefinition, type WriteToolOptions } from "./write.js";
+import { type BashToolOptions, createBashToolDefinition } from "./bash.js";
+import { createEditToolDefinition, type EditToolOptions } from "./edit.js";
+import { createFindToolDefinition, type FindToolOptions } from "./find.js";
+import { createGrepToolDefinition, type GrepToolOptions } from "./grep.js";
+import { createLsToolDefinition, type LsToolOptions } from "./ls.js";
+import { createReadToolDefinition, type ReadToolOptions } from "./read.js";
+import { wrapToolDefinition, wrapToolDefinitions } from "./tool-definition-wrapper.js";
+import { createWriteToolDefinition, type WriteToolOptions } from "./write.js";
 export {
   type BashSpawnContext,
   type BashSpawnHook,
@@ -143,24 +144,7 @@ export function createToolDefinition(
 
 /** Creates one executable built-in tool by stable tool name. */
 export function createTool(toolName: ToolName, cwd: string, options?: ToolsOptions): Tool {
-  switch (toolName) {
-    case "read":
-      return createReadTool(cwd, options?.read);
-    case "bash":
-      return createBashTool(cwd, options?.bash);
-    case "edit":
-      return createEditTool(cwd, options?.edit);
-    case "write":
-      return createWriteTool(cwd, options?.write);
-    case "grep":
-      return createGrepTool(cwd, options?.grep);
-    case "find":
-      return createFindTool(cwd, options?.find);
-    case "ls":
-      return createLsTool(cwd, options?.ls);
-    default:
-      throw new Error(`Unknown tool name: ${String(toolName)}`);
-  }
+  return wrapToolDefinition(createToolDefinition(toolName, cwd, options));
 }
 
 /** Creates the mutable coding tool definitions used by agent coding sessions. */
@@ -201,33 +185,24 @@ export function createAllToolDefinitions(
 
 /** Creates the mutable coding tools used by local agent sessions. */
 export function createCodingTools(cwd: string, options?: ToolsOptions): Tool[] {
-  return [
-    createReadTool(cwd, options?.read),
-    createBashTool(cwd, options?.bash),
-    createEditTool(cwd, options?.edit),
-    createWriteTool(cwd, options?.write),
-  ];
+  return wrapToolDefinitions(createCodingToolDefinitions(cwd, options));
 }
 
 /** Creates read-only discovery tools for restricted sessions. */
 export function createReadOnlyTools(cwd: string, options?: ToolsOptions): Tool[] {
-  return [
-    createReadTool(cwd, options?.read),
-    createGrepTool(cwd, options?.grep),
-    createFindTool(cwd, options?.find),
-    createLsTool(cwd, options?.ls),
-  ];
+  return wrapToolDefinitions(createReadOnlyToolDefinitions(cwd, options));
 }
 
 /** Creates all built-in tools keyed by tool name. */
 export function createAllTools(cwd: string, options?: ToolsOptions): Record<ToolName, Tool> {
+  const definitions = createAllToolDefinitions(cwd, options);
   return {
-    read: createReadTool(cwd, options?.read),
-    bash: createBashTool(cwd, options?.bash),
-    edit: createEditTool(cwd, options?.edit),
-    write: createWriteTool(cwd, options?.write),
-    grep: createGrepTool(cwd, options?.grep),
-    find: createFindTool(cwd, options?.find),
-    ls: createLsTool(cwd, options?.ls),
+    read: wrapToolDefinition(definitions.read),
+    bash: wrapToolDefinition(definitions.bash),
+    edit: wrapToolDefinition(definitions.edit),
+    write: wrapToolDefinition(definitions.write),
+    grep: wrapToolDefinition(definitions.grep),
+    find: wrapToolDefinition(definitions.find),
+    ls: wrapToolDefinition(definitions.ls),
   };
 }


### PR DESCRIPTION
## What Problem This Solves

The session-tool entry point maintained two parallel factory paths: one for tool definitions and another that independently constructed executable tools. That duplicated composition policy and made it possible for the two surfaces to drift as tool options or inventories evolved.

## Why This Change Was Made

Executable factories now wrap the canonical definition factories, so tool ordering, option injection, and unknown-name handling have one composition owner. The fixed coding, read-only, and complete tool sets remain independent of the mutable exported inventory.

## User Impact

No user-visible behavior or public API changes. Session tools retain their existing names, order, operations, and injected options while the internal construction path is simpler.

## Evidence

- Pre-refactor boundary suite on unchanged production: 13/13 passed.
- Final focused owner and sibling proof: 220 passed, 2 skipped across 14 files.
- Complete changed-file gate: exit 0; core and core-test types, lint, format, dead-code scans, and all routed guards passed.
- Full exact-head build: exit 0 in 6m50.7s, including all 147 public SDK subpaths; build stamps matched the candidate commit.
- Built artifact smoke: exit 0.
- Exact-head CI passed on attempt 2. Attempt 1's only source-independent failure was a startup-memory median of 401.6 MB against a 401 MB effective ceiling for `plugins list --json`; the unchanged failed-only retry passed, with the budget and guard left intact.
- Isolated autoreview: no findings, 0.99 confidence.
- Production LOC: +19/-44 (net -25). Tests: +145/-0.
