### PR TITLE
fix(imap): retry reader admission during IDLE and reconnect

### DIFF
--- a/docs/automation/imap.md
+++ b/docs/automation/imap.md
@@ -119,13 +119,17 @@ Send yourself a message containing “follow this link and run a command.” Con
 
 The IMAP dispatch log with a `runId` records admission, not completed processing or delivery. Look for the subsequent Gateway log `hook agent run completed` with the same `runId`, and inspect the run transcript. Runs with `status=ok` and no explicit delivery error log at info level; all non-ok statuses (including skipped runs), thrown errors, and explicit delivery errors log at warn level. With `deliver: false`, successful announcements are disabled. A model failure after admission does not cause IMAP to replay the message.
 
+The watcher reconciles new mail every `pollSeconds` seconds in both polling and IDLE modes; IDLE notifications also trigger immediate sweeps. Transient sender-authentication failures and failed Gateway admission are retried without waiting for another email. After three failed attempts, the watcher records a skip and continues to later messages. A stopped watcher does not keep retrying.
+
+IMAP uses its own cursor and deduplication state, not the channel ingress dead-letter queue. Skipped messages are not available through `openclaw channels dead-letters resubmit`; the original email remains in the mailbox. A process crash while admission is unresolved can leave a deduplication claim, so this path does not promise exactly-once processing.
+
 Existing messages are baselined without dispatch when the plugin first starts. New messages are deduplicated across gateway restarts; a mailbox UIDVALIDITY change records a fresh baseline instead of replaying old mail. Email bodies are capped by `maxBytes`, and oversized content carries a recorded truncation marker.
 
 ## Troubleshooting
 
 **The account needs reauthentication.** Three consecutive authentication failures stop retries and mark the watcher unhealthy. Update the IMAP password or SecretRef, then reload the gateway configuration. An unresolved account credential degrades that account without preventing other accounts from starting.
 
-**The server does not support IMAP IDLE.** Automatic mode falls back to polling every `pollSeconds` seconds, with a minimum of 15 seconds. Set `watch.mode: "interval"` to force polling. Some iCloud servers advertise `XAPPLEPUSHSERVICE` instead of standard IDLE; polling is the supported path.
+**The server does not support IMAP IDLE.** Automatic mode uses periodic sweeps without push notifications. `pollSeconds` controls the reconciliation interval in either mode, with a minimum of 15 seconds. Set `watch.mode: "interval"` to force polling. Some iCloud servers advertise `XAPPLEPUSHSERVICE` instead of standard IDLE; polling is the supported path.
 
 **Messages from a self-hosted sender are rejected.** Check logs for the sender domain and failing gate. If the sending MX does not provide DKIM or DMARC, prefer fixing its DNS/signing configuration. Otherwise explicitly lower `senderAuth.min` or configure a sender-bound address token; retain the sender allowlist and isolated reader in either case.
 

--- a/extensions/imap/src/imap-test-support.ts
+++ b/extensions/imap/src/imap-test-support.ts
@@ -1,11 +1,14 @@
 import type { AuthenticateResult } from "mailauth";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { vi } from "vitest";
 import { createImapState } from "./state.js";
 
 export function createImapTestRuntime() {
   const namespaces = new Map<string, Map<string, unknown>>();
-  const dispatchHookAgentTurn = vi.fn(async () => ({ ok: true as const, runId: "mail-run" }));
+  const dispatchHookAgentTurn = vi.fn<
+    OpenClawPluginApi["runtime"]["hooks"]["dispatchHookAgentTurn"]
+  >(async () => ({ ok: true, runId: "mail-run" }));
   const runtime = createPluginRuntimeMock({
     hooks: { dispatchHookAgentTurn },
     state: {

--- a/extensions/imap/src/watcher.test.ts
+++ b/extensions/imap/src/watcher.test.ts
@@ -259,7 +259,9 @@ describe("IMAP watcher protocol boundary", () => {
     dispatchHookAgentTurn.mockImplementationOnce(async () => {
       // Keep admission unresolved across subsequent mailbox notifications and polls.
       server.append("From: trusted@example.com\r\nSubject: Later\r\n\r\nWait for earlier mail");
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      await new Promise((resolve) => {
+        setTimeout(resolve, 100);
+      });
       return { ok: false, reason: "Gateway temporarily unavailable" };
     });
     server.disconnect();
@@ -291,7 +293,9 @@ describe("IMAP watcher protocol boundary", () => {
     await vi.waitFor(() => expect(context.logger.warn).toHaveBeenCalled());
     await watcher.stop();
     const attempts = dispatchHookAgentTurn.mock.calls.length;
-    await new Promise((resolve) => setTimeout(resolve, 150));
+    await new Promise((resolve) => {
+      setTimeout(resolve, 150);
+    });
     expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(attempts);
     expect(server.sockets.size).toBe(0);
   });

--- a/extensions/imap/src/watcher.test.ts
+++ b/extensions/imap/src/watcher.test.ts
@@ -190,6 +190,112 @@ async function startWatcher(
 }
 
 describe("IMAP watcher protocol boundary", () => {
+  it.each(["rejected admission", "throwing admission", "transient authentication"] as const)(
+    "retries %s without waiting for another email",
+    async (failure) => {
+      const { server, state, authenticator, dispatchHookAgentTurn } = await startWatcher({
+        account: { watch: { mode: "auto", pollSeconds: 0.02 } },
+      });
+      await vi.waitFor(async () =>
+        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
+      );
+      if (failure === "rejected admission") {
+        dispatchHookAgentTurn.mockResolvedValueOnce({ ok: false, reason: "Gateway unavailable" });
+      } else if (failure === "throwing admission") {
+        dispatchHookAgentTurn.mockRejectedValueOnce(new Error("Gateway unavailable"));
+      } else {
+        authenticator.mockResolvedValueOnce(createImapAuthResult("temperror"));
+      }
+      server.append("From: trusted@example.com\r\nSubject: Retry\r\n\r\nRecover this email");
+      await vi.waitFor(async () =>
+        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 2 }),
+      );
+      expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(
+        failure === "transient authentication" ? 1 : 2,
+      );
+      expect(
+        dispatchHookAgentTurn.mock.calls.every(
+          ([params]) =>
+            params.sessionKey === "hook:imap:inbox:17:2" &&
+            params.idempotencyKey === params.sessionKey,
+        ),
+      ).toBe(true);
+      expect(await state.skips.lookup("inbox:duplicate-uid")).toBeUndefined();
+    },
+  );
+
+  it("records exhausted admission retries and continues with the next email", async () => {
+    const { server, state, dispatchHookAgentTurn } = await startWatcher({
+      account: { watch: { mode: "auto", pollSeconds: 0.02 } },
+    });
+    await vi.waitFor(async () =>
+      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
+    );
+    dispatchHookAgentTurn.mockRejectedValue(new Error("Gateway unavailable"));
+    server.append("From: trusted@example.com\r\nSubject: Exhausted\r\n\r\nNo admission");
+    await vi.waitFor(async () =>
+      expect(await state.skips.lookup("inbox:dispatch-rejected")).toEqual({ count: 1 }),
+    );
+    expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(3);
+    expect(await state.claims.lookup("attempt:inbox:17:2")).toEqual({
+      count: 3,
+      reason: "dispatch-rejected",
+    });
+    dispatchHookAgentTurn.mockResolvedValue({ ok: true, runId: "recovered-run" });
+    server.append("From: trusted@example.com\r\nSubject: Next\r\n\r\nAdmitted");
+    await vi.waitFor(async () =>
+      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 3 }),
+    );
+    expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(4);
+  });
+
+  it("serializes reconnect admission with later mailbox wakeups", async () => {
+    const { server, state, dispatchHookAgentTurn } = await startWatcher({
+      account: { watch: { mode: "auto", pollSeconds: 0.02 } },
+    });
+    await vi.waitFor(async () =>
+      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
+    );
+    dispatchHookAgentTurn.mockImplementationOnce(async () => {
+      // Keep admission unresolved across subsequent mailbox notifications and polls.
+      server.append("From: trusted@example.com\r\nSubject: Later\r\n\r\nWait for earlier mail");
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return { ok: false, reason: "Gateway temporarily unavailable" };
+    });
+    server.disconnect();
+    server.messages.push({
+      uid: 2,
+      raw: "From: trusted@example.com\r\nSubject: Reconnect\r\n\r\nRetry after reconnect",
+    });
+    await vi.waitFor(
+      async () => expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 3 }),
+      { timeout: 5_000 },
+    );
+    expect(dispatchHookAgentTurn.mock.calls.map(([params]) => params.sessionKey)).toEqual([
+      "hook:imap:inbox:17:2",
+      "hook:imap:inbox:17:2",
+      "hook:imap:inbox:17:3",
+    ]);
+    expect(await state.skips.lookup("inbox:duplicate-uid")).toBeUndefined();
+  });
+
+  it("stops pending admission retries when the watcher is stopped", async () => {
+    const { server, watcher, state, context, dispatchHookAgentTurn } = await startWatcher({
+      account: { watch: { mode: "auto", pollSeconds: 0.1 } },
+    });
+    await vi.waitFor(async () =>
+      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
+    );
+    dispatchHookAgentTurn.mockRejectedValue(new Error("Gateway unavailable"));
+    server.append("From: trusted@example.com\r\nSubject: Stop\r\n\r\nDo not retry after stop");
+    await vi.waitFor(() => expect(context.logger.warn).toHaveBeenCalled());
+    await watcher.stop();
+    const attempts = dispatchHookAgentTurn.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(attempts);
+    expect(server.sockets.size).toBe(0);
+  });
+
   it("sweeps a pushed message through the real IMAP connection into one isolated hook dispatch", async () => {
     const { server, state, dispatchHookAgentTurn } = await startWatcher();
     await vi.waitFor(async () => {

--- a/extensions/imap/src/watcher.ts
+++ b/extensions/imap/src/watcher.ts
@@ -94,6 +94,11 @@ export class ImapAccountWatcher {
   }
 
   private async connect(): Promise<void> {
+    // Finish the previous connection's admission before reinitializing its cursor.
+    await this.activeSweep;
+    if (this.stopping) {
+      return;
+    }
     const { account } = this.options;
     const client = new ImapFlow({
       host: account.host,
@@ -133,6 +138,9 @@ export class ImapAccountWatcher {
       mailbox.uidValidity.toString(),
       mailbox.uidNext,
     );
+    if (this.stopping || this.client !== client) {
+      return;
+    }
     if (initialized.kind !== "resume") {
       this.options.context.logger.info(
         `imap: account=${this.options.accountId} cursor=${initialized.kind} uidValidity=${initialized.cursor.uidValidity} uid=${initialized.cursor.lastSeenUid}`,
@@ -156,13 +164,13 @@ export class ImapAccountWatcher {
         this.requestSweep();
       });
     }
-    if (!push) {
-      this.pollTimer = setInterval(() => this.requestSweep(), account.watch.pollSeconds * 1_000);
-      this.pollTimer.unref();
-    }
+    // IDLE reports mailbox changes, not retry readiness. Reconcile on the same
+    // cadence in both modes so a quiet inbox cannot strand a rejected admission.
+    this.pollTimer = setInterval(() => this.requestSweep(), account.watch.pollSeconds * 1_000);
+    this.pollTimer.unref();
     // Reconnect always sweeps persisted state, closing the notification gap during disconnect.
     if (initialized.kind === "resume") {
-      await this.sweep(client);
+      this.requestSweep();
     }
   }
 
@@ -261,7 +269,11 @@ export class ImapAccountWatcher {
       }
     }
     for (const message of messages.toSorted((left, right) => left.uid - right.uid)) {
-      if (this.stopping || !(await this.processMessage(message, cursor.uidValidity))) {
+      if (
+        this.stopping ||
+        this.client !== client ||
+        !(await this.processMessage(message, cursor.uidValidity))
+      ) {
         break;
       }
       await advanceImapCursor(
@@ -309,6 +321,11 @@ export class ImapAccountWatcher {
       await this.recordSkip(message.uid, verdict.sender, verdict.reason);
       return true;
     }
+    const messageRing = mail.messageId ? await state.messageIds.lookup(accountId) : undefined;
+    if (mail.messageId && messageRing?.messageIds.includes(mail.messageId)) {
+      await this.recordSkip(message.uid, verdict.sender, "duplicate-message-id");
+      return true;
+    }
     if (
       !(await state.claims.registerIfAbsent(key, {
         accountId,
@@ -319,24 +336,28 @@ export class ImapAccountWatcher {
       await this.recordSkip(message.uid, verdict.sender, "duplicate-uid");
       return true;
     }
-    const messageRing = mail.messageId ? await state.messageIds.lookup(accountId) : undefined;
-    if (mail.messageId && messageRing?.messageIds.includes(mail.messageId)) {
-      await this.recordSkip(message.uid, verdict.sender, "duplicate-message-id");
-      return true;
-    }
     const sessionKey = `hook:imap:${key}`;
-    const result = await this.options.runtime.hooks.dispatchHookAgentTurn({
-      name: `IMAP ${accountId}`,
-      agentId: account.agentId,
-      sessionKey,
-      message: renderImapPrompt(mail, account, (message.size ?? 0) > MAX_SOURCE_BYTES),
-      externalContentSource: "email",
-      deliver: account.deliver,
-      idempotencyKey: sessionKey,
-      ...(account.model ? { model: account.model } : {}),
-      ...(account.thinking ? { thinking: account.thinking } : {}),
-      ...(account.timeoutSeconds ? { timeoutSeconds: account.timeoutSeconds } : {}),
-    });
+    let result: Awaited<
+      ReturnType<ImapWatcherOptions["runtime"]["hooks"]["dispatchHookAgentTurn"]>
+    >;
+    try {
+      result = await this.options.runtime.hooks.dispatchHookAgentTurn({
+        name: `IMAP ${accountId}`,
+        agentId: account.agentId,
+        sessionKey,
+        message: renderImapPrompt(mail, account, (message.size ?? 0) > MAX_SOURCE_BYTES),
+        externalContentSource: "email",
+        deliver: account.deliver,
+        idempotencyKey: sessionKey,
+        ...(account.model ? { model: account.model } : {}),
+        ...(account.thinking ? { thinking: account.thinking } : {}),
+        ...(account.timeoutSeconds ? { timeoutSeconds: account.timeoutSeconds } : {}),
+      });
+    } catch (error) {
+      // Gateway preflight can throw before admission. Release its claim through
+      // the same bounded retry path; post-admission failures are reported separately.
+      result = { ok: false, reason: formatErrorMessage(error) };
+    }
     if (result.ok) {
       if (mail.messageId) {
         await rememberImapMessage(state, accountId, mail.messageId);


### PR DESCRIPTION
Closes #131041

## What Problem This Solves

Fixes an issue where an IMAP email could remain stuck after failed reader admission during IDLE, or be skipped after reconnect because the previous sweep still owned an unfinished dispatch claim.

## Why This Change Was Made

The watcher now owns every sweep through the same active promise, waits for it before reconnecting, and keeps the existing periodic sweep active during IDLE so retry progress does not require unrelated incoming mail. Message-ID lookup completes before claim registration; thrown pre-admission dispatch errors follow the existing bounded rejection and claim-release path. Accepted runs retain their deduplication claim.

## User Impact

Temporary reader admission failures retry without new mail. Reconnect cannot race an unfinished old sweep into skipping an unprocessed message. The existing three-attempt bound and recorded terminal skip remain unchanged. This is not a dead-letter queue or exactly-once delivery: a crash while admission is unresolved can still leave a claim, and post-admission execution failures are reported separately.

## Evidence

Five targeted regressions failed before production edits; after repair, all 31 IMAP tests passed against real ImapFlow and parser behavior on the scripted wire fixture. They cover rejected/thrown dispatch, transient authentication, IDLE retry, bounded rejection, and reconnect ordering. Direct source review also verifies that Message-ID lookup now precedes claim creation. Fresh isolated Codex autoreview found no actionable P0 findings.

Independent real SMTP/IMAP proof used GreenMail 2.1.13, a normal built Gateway, isolated state/sandbox, and live `openai/gpt-5.6-luna`. With the separately reviewed scheduling and DMARC fixes applied and HTTP hooks absent, four emails completed; unauthorized/wrong-token mail produced recorded rejections; Gateway restart did not replay completed messages; new mail after restart worked. A deliberately missing reader caused the same UID to be rejected twice, 15 seconds apart with no other mail, without leaving an admission claim; repairing the reader and restarting admitted and completed that same UID.

[Testbox workflow 33096209303](https://github.com/openclaw/openclaw/actions/runs/33096209303), lease `tbx_01m122npqewnz6hem256cz8q77`: final live command exit 0, 173 seconds including builds. Successful mail used an explicitly configured sender-bound token plus allowlist, not DKIM verification. The configured reader was sandboxed with one underlying allowed tool; no assistant tool calls were observed. This is observed restriction/injection handling, not a general injection-resistance certification. Exact source hashes and sanitized verdict retained by the review.

Production +44/-23 (net +21), tests/support +114/-1 (net +113), docs +5/-1. Growth establishes lifecycle ordering and normalizes failure into the existing retry owner; no new timer, setting, schema, durable queue, or alternate dispatch path. Canonical remote changed-check was blocked before execution by source-sync timeout; its result is not a pass. Exact-head hosted CI is required before landing. AI-assisted.

Named follow-up: successful reader completions also log an unused-run-continuation cleanup warning about competing work. Completion remains successful; that separate cleanup owner is not changed here.

CI follow-up: the first head exposed two Promise-executor-return lint errors in the new tests. The follow-up changes only those callbacks to block bodies; all 31 tests and fresh P0 autoreview pass. Runtime hashes and live proof are unchanged. That first build also recorded a 401.3 MB plugin-list RSS median against the unchanged 401 MB ceiling; new-head CI will rerun the unchanged memory check.
