### PR TITLE
fix(test): gateway connection-liveness test flakes under CI shard load

### DIFF
--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
@@ -64,11 +64,29 @@ describe.sequential("authenticated request connection liveness", () => {
     const held = new Promise<void>((resolve) => {
       releaseHandler = resolve;
     });
-    runtime.beforeHandler.mockReturnValue(held);
+    // dispatch() is fire-and-forget behind a lazy server-methods import, so the
+    // handler start and the response are awaited as events; a polling deadline
+    // here loses to a slow first module load and leaks the call into the
+    // sibling case.
+    let handlerStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      handlerStarted = resolve;
+    });
+    runtime.beforeHandler.mockImplementation(() => {
+      handlerStarted();
+      return held;
+    });
     const state = createGatewayConnectionState({ cfg: {} });
     const client = createClient();
     state.clients.add(client);
-    const send = vi.fn((_frame: unknown) => ({ kind: "sent" }) as const);
+    let respondedWith!: (frame: unknown) => void;
+    const responded = new Promise<unknown>((resolve) => {
+      respondedWith = resolve;
+    });
+    const send = vi.fn((frame: unknown) => {
+      respondedWith(frame);
+      return { kind: "sent" } as const;
+    });
     const context = {
       getRuntimeConfig: () => ({}),
       logGateway: { error: vi.fn() },
@@ -93,16 +111,15 @@ describe.sequential("authenticated request connection liveness", () => {
       { type: "req", id: testCase.method, method: testCase.method, params: testCase.params },
       client,
     );
-    await vi.waitFor(() => expect(runtime.beforeHandler).toHaveBeenCalledOnce());
+    await started;
+    expect(runtime.beforeHandler).toHaveBeenCalledOnce();
 
     state.clients.delete(client);
     state.sessionEventSubscribers.unsubscribe(client.connId);
     state.sessionMessageSubscribers.unsubscribeAll(client.connId);
     releaseHandler();
 
-    await vi.waitFor(() =>
-      expect(send).toHaveBeenCalledWith(expect.objectContaining({ id: testCase.method, ok: true })),
-    );
+    expect(await responded).toEqual(expect.objectContaining({ id: testCase.method, ok: true }));
     testCase.assertEmpty(state);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a CI flake where `authenticated-request-dispatch.connection-liveness.test.ts` intermittently failed on shard `agentic-gateway-core-3` (e.g. run 33061841674, 2026-08-27): "rejects a late 'sessions.subscribe' mutation after disconnect cleanup" reported the guard mock called 0 times while the `sessions.messages.subscribe` sibling reported 2 calls, both at the same assertion line. The file passes solo locally, so the failure only appears under shard load.

## Why This Change Was Made

The dispatcher is intentionally fire-and-forget: `dispatch()` returns before the handler runs, and `executeRequest` first awaits the lazy `loadGatewayServerMethods()` dynamic import (`src/gateway/server/ws-connection/authenticated-request-dispatch.ts`). In the test, that import resolves through the `vi.mock` factory, which itself dynamically imports the real `sessions-subscriptions.js` module graph. The test bounded that unbounded first load with `vi.waitFor`'s default 1s polling deadline. On a loaded CI worker the first load exceeded 1s: case 1 failed with 0 calls, its still-pending dispatch leaked past the sibling case's `mockReset`, and the leaked invocation plus case 2's own dispatch produced "called 2 times".

The fix removes the polling deadlines entirely: the guard mock resolves an explicit "handler started" promise and the `send` mock resolves a "responded" promise with the actual frame, so the test waits on the events themselves. No deadline exists to race, and a test case can no longer end with its dispatch still in flight, which also eliminates the cross-case leak. Assertions are unchanged in intent and strictly tighter (`toHaveBeenCalledOnce` is now a synchronous check).

## User Impact

None at runtime; test-only change. Removes a false-negative gateway shard flake from PR and main CI.

## Evidence

- Reproduced the exact CI signature pre-fix by injecting a 1.5s delay into the mock factory (simulating shard load): case 1 "expected once, got 0", case 2 "expected once, got 2", both at the old `vi.waitFor` line.
- The fixed test passes under the identical injected 1.5s delay.
- `pnpm test src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts` green, plus 5 consecutive repeat runs green.
- `node scripts/check-changed.mjs -- <file>` green (knip, core-test typecheck shards, lint); oxfmt clean.
- Codex autoreview on the diff: no findings.

Production LOC: +0/-0 | Tests: +23/-6
