### PR TITLE
fix(skills): stop experience reviews from blocking chats

### DIFF
--- a/docs/tools/self-learning.md
+++ b/docs/tools/self-learning.md
@@ -70,9 +70,10 @@ Experience review starts only when all of these conditions hold:
 A later foreground completion in the same session restarts the quiet period.
 Only one experience review runs at a time. The foreground answer is never delayed.
 
-The reviewer continues the finished turn from the same transcript prefix. This
-lets the provider reuse the foreground prompt cache. Its appended review message
-and tool results never enter the foreground transcript or session record.
+The reviewer continues the finished turn from the same transcript prefix, but
+runs under a private detached session identity. This keeps the foreground session
+available while the provider reuses its prompt cache. The review message and tool
+results never enter the foreground transcript or session record.
 
 The reviewer is detached and biased toward small, well-evidenced captures. It
 receives an authoritative receipt of the skills the foreground run actually
@@ -210,9 +211,10 @@ after a substantial turn, not after every message. The review can make more
 than one provider request while it inspects or drafts its single proposal.
 
 The review forks the foreground transcript in memory and appends one small user
-message. It uses the same provider, model, auth profile, session identity,
-bootstrap context, skills prompt, and tool schemas. The provider can reuse the
-finished turn's cached request prefix. Review writes remain detached.
+message. It uses a private detached session identity while preserving the
+foreground provider, model, auth profile, bootstrap context, skills prompt, tool
+schemas, and prompt-cache affinity. The provider can reuse the finished turn's
+cached request prefix without making the review part of the foreground session.
 
 The reviewer reuses the foreground provider, model, and available auth identity,
 with model fallbacks disabled. Provider pricing and data-handling terms apply to

--- a/src/agents/embedded-agent-runner/run/attempt-finalize.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-finalize.ts
@@ -368,9 +368,8 @@ export async function completeEmbeddedAttemptAfterTurn(
   });
   runtime.anthropicPayloadLogger?.recordUsage(state.messagesSnapshot, state.promptError);
 
-  // A detached run (skill experience review) writes no transcript or session record and
-  // runs under the foreground session key; firing agent_end here would let plugins observe
-  // it as a foreground turn and let the review schedule a successor review of itself.
+  // A detached run (such as skill experience review) writes no transcript or session record.
+  // Firing agent_end would expose maintenance as a normal turn and schedule successor work.
   if (
     attempt.operation !== "settled-tool-finalization" &&
     attempt.sessionPersistence !== "detached" &&

--- a/src/agents/embedded-agent-runner/run/attempt.skills-policy.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.skills-policy.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveInternalSessionEffectsIdentity } from "../../../config/sessions/internal-session-key.js";
 import { createFixtureSkillEntry } from "../../../skills/test-support/test-helpers.js";
 import {
   runSkillExperienceReview,
@@ -178,7 +179,7 @@ describe("runEmbeddedAttempt skill policy projections", () => {
     expect(snapshots[1]).toEqual(snapshots[0]);
   });
 
-  it("keeps review prompt digests equal while transcript and store stay unchanged", async () => {
+  it("keeps review prompt digests equal on a private session without persistence", async () => {
     const sessionRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-review-parity-"));
     tempPaths.push(sessionRoot);
     const transcriptFile = path.join(sessionRoot, "transcript.jsonl");
@@ -218,23 +219,35 @@ describe("runEmbeddedAttempt skill policy projections", () => {
       },
     ] as AnyAgentTool[];
 
+    const foregroundSession = {
+      sessionId: "embedded-session",
+      sessionKey: "agent:main:main",
+    };
+    const reviewSession = resolveInternalSessionEffectsIdentity({
+      agentId: "main",
+      runId: "skill-workshop-review:prompt-parity",
+    });
     const snapshots = [];
     for (const review of [false, true]) {
+      const session = review ? reviewSession : foregroundSession;
       resetEmbeddedAttemptHarness();
       hoisted.createOpenClawCodingToolsMock.mockReturnValue(codingTools);
       await createContextEngineAttemptRunner({
         contextEngine: createContextEngineBootstrapAndAssemble(),
-        sessionKey: "agent:main:main",
+        sessionKey: session.sessionKey,
         tempPaths,
         attemptOverrides: {
           disableTools: false,
           disableMessageTool: false,
           reasoningLevel: "on",
+          sessionId: session.sessionId,
+          sandboxSessionKey: foregroundSession.sessionKey,
+          promptCacheKey: "foreground-cache-prefix",
           sessionFile: transcriptFile,
           sessionTarget: {
             agentId: "main",
-            sessionId: "embedded-session",
-            sessionKey: "agent:main:main",
+            sessionId: session.sessionId,
+            sessionKey: session.sessionKey,
             storePath: storeFile,
           },
           ...(review
@@ -258,8 +271,8 @@ describe("runEmbeddedAttempt skill policy projections", () => {
       expect(tools.some((tool) => tool.name === "message")).toBe(true);
       snapshots.push(
         beginPromptCacheObservation({
-          sessionId: "embedded-session",
-          sessionKey: "agent:main:main",
+          sessionId: session.sessionId,
+          sessionKey: session.sessionKey,
           provider: "openai",
           modelId: "gpt-test",
           streamStrategy: "test",

--- a/src/skills/workshop/experience-review.apply.test.ts
+++ b/src/skills/workshop/experience-review.apply.test.ts
@@ -239,6 +239,7 @@ describe("experience review auto apply", () => {
           sandboxSessionKey: "agent:main:main",
           trigger: "user",
           promptCacheKey: foregroundPromptCacheKey,
+          messageActionTurnCapability: "closed-foreground-capability",
           reasoningLevel: "on",
         },
       },
@@ -286,6 +287,7 @@ describe("experience review auto apply", () => {
     const reviewSessionKey = runEmbeddedAgent.mock.calls[0]?.[0].sessionKey;
     expect(isIncognitoSessionKey(reviewSessionKey)).toBe(true);
     expect(reviewSessionKey).not.toBe("agent:main:main");
+    expect(runEmbeddedAgent.mock.calls[0]?.[0].messageActionTurnCapability).toBeUndefined();
     expect(runEmbeddedAgent.mock.calls[0]?.[0]).not.toHaveProperty("sessionTarget");
     expect(runEmbeddedAgent.mock.calls[0]?.[0]).not.toHaveProperty("disableMessageTool");
   });

--- a/src/skills/workshop/experience-review.apply.test.ts
+++ b/src/skills/workshop/experience-review.apply.test.ts
@@ -1,16 +1,20 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
+import { resolveSessionLane } from "../../agents/embedded-agent-runner/lanes.js";
 import type { EmbeddedForegroundPromptContext } from "../../agents/embedded-agent-runner/run/params.js";
 import { resolveSessionBoundaryPromptCacheKey } from "../../agents/embedded-agent-runner/run/session-boundary-prompt-cache-key.js";
 import { runWithCanonicalSkillWorkspace } from "../../agents/skill-workshop-workspace-context.js";
 import { createSkillWorkshopTool } from "../../agents/tools/skill-workshop-tool.js";
 import { emitAgentEvent, onAgentRuntimeEvent } from "../../infra/agent-events.js";
 import { getAgentRunContext } from "../../infra/agent-run-registry.js";
+import { enqueueCommandInLane } from "../../process/command-queue.js";
 import {
   isGatewaySubordinateWorkAdmissionClosed,
   tryBeginGatewayRootWorkAdmission,
 } from "../../process/gateway-work-admission.js";
+import { isIncognitoSessionKey } from "../../shared/incognito-session-key.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -72,6 +76,51 @@ afterEach(async () => {
 });
 
 describe("experience review auto apply", () => {
+  it("does not occupy the foreground session lane", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-experience-session-lane-");
+    const foregroundSessionKey = "agent:main:main";
+    const reviewStarted = createDeferred();
+    const releaseReview = createDeferred();
+    runEmbeddedAgent.mockImplementation(async (params) =>
+      enqueueCommandInLane(resolveSessionLane(params.sessionKey ?? params.sessionId), async () => {
+        reviewStarted.resolve();
+        await releaseReview.promise;
+        return {};
+      }),
+    );
+
+    const review = runSkillExperienceReview(
+      {
+        ctx: {
+          sessionId: "foreground-session",
+          sessionKey: foregroundSessionKey,
+          workspaceDir,
+          modelProviderId: "openai",
+          modelId: "gpt-test",
+          foregroundPromptContext: foregroundPromptContext(workspaceDir),
+        },
+        config: { skills: { workshop: { autonomous: { mode: "propose" } } } },
+      },
+      { getCurrentConfig: () => ({}) },
+    );
+    await reviewStarted.promise;
+
+    const foregroundStarted = createDeferred();
+    const foreground = enqueueCommandInLane(resolveSessionLane(foregroundSessionKey), async () => {
+      foregroundStarted.resolve();
+    });
+    try {
+      await withTestTimeout(
+        foregroundStarted.promise,
+        1_000,
+        "foreground work did not start while the review was active",
+      );
+    } finally {
+      releaseReview.resolve();
+      await Promise.all([review, foreground]);
+    }
+  });
+
   it("keeps detached review events out of foreground session presentation", async () => {
     const workspaceDir = await tempDirs.make("openclaw-experience-hidden-events-");
     const observed: Array<
@@ -136,11 +185,14 @@ describe("experience review auto apply", () => {
       unsubscribe();
     }
 
-    expect(observed).toEqual([
+    expect(observed.slice(0, 2)).toEqual([
       ["assistant", false, false, false, undefined],
       ["tool", false, false, false, undefined],
-      ["lifecycle", false, false, false, "agent:main:main"],
     ]);
+    expect(observed[2]?.slice(0, 4)).toEqual(["lifecycle", false, false, false]);
+    expect(observed[2]?.[4]).toMatch(
+      /^agent:main:internal-session-effects:incognito-skill-workshop-review_/u,
+    );
     expect(getAgentRunContext(reviewRunId)).toBeUndefined();
   });
 
@@ -214,14 +266,28 @@ describe("experience review auto apply", () => {
         sessionPersistence: "detached",
         silentExpected: true,
         allowEmptyAssistantReplyAsSilent: true,
+        cleanupBundleMcpOnRunEnd: true,
         terminalReplyExpectation: "optional",
         promptCacheKey: foregroundPromptCacheKey,
+        sandboxSessionKey: "agent:main:main",
+        sessionId: expect.stringMatching(/^internal-session-effects-skill-workshop-review_/u),
+        sessionKey: expect.stringMatching(
+          /^agent:main:internal-session-effects:incognito-skill-workshop-review_/u,
+        ),
+        skillWorkshopOrigin: {
+          agentId: "main",
+          runId: "foreground-run",
+          sessionKey: "agent:main:main",
+        },
         trigger: "user",
         reasoningLevel: "on",
       }),
     );
+    const reviewSessionKey = runEmbeddedAgent.mock.calls[0]?.[0].sessionKey;
+    expect(isIncognitoSessionKey(reviewSessionKey)).toBe(true);
+    expect(reviewSessionKey).not.toBe("agent:main:main");
+    expect(runEmbeddedAgent.mock.calls[0]?.[0]).not.toHaveProperty("sessionTarget");
     expect(runEmbeddedAgent.mock.calls[0]?.[0]).not.toHaveProperty("disableMessageTool");
-    expect(runEmbeddedAgent.mock.calls[0]?.[0]).not.toHaveProperty("cleanupBundleMcpOnRunEnd");
   });
 
   it("records provider input buckets for the detached review run", async () => {

--- a/src/skills/workshop/experience-review.apply.test.ts
+++ b/src/skills/workshop/experience-review.apply.test.ts
@@ -14,7 +14,6 @@ import {
   isGatewaySubordinateWorkAdmissionClosed,
   tryBeginGatewayRootWorkAdmission,
 } from "../../process/gateway-work-admission.js";
-import { isIncognitoSessionKey } from "../../shared/incognito-session-key.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -191,7 +190,7 @@ describe("experience review auto apply", () => {
     ]);
     expect(observed[2]?.slice(0, 4)).toEqual(["lifecycle", false, false, false]);
     expect(observed[2]?.[4]).toMatch(
-      /^agent:main:internal-session-effects:incognito-skill-workshop-review_/u,
+      /^agent:main:internal-session-effects:skill-workshop-review_/u,
     );
     expect(getAgentRunContext(reviewRunId)).toBeUndefined();
   });
@@ -273,7 +272,7 @@ describe("experience review auto apply", () => {
         sandboxSessionKey: "agent:main:main",
         sessionId: expect.stringMatching(/^internal-session-effects-skill-workshop-review_/u),
         sessionKey: expect.stringMatching(
-          /^agent:main:internal-session-effects:incognito-skill-workshop-review_/u,
+          /^agent:main:internal-session-effects:skill-workshop-review_/u,
         ),
         skillWorkshopOrigin: {
           agentId: "main",
@@ -285,7 +284,6 @@ describe("experience review auto apply", () => {
       }),
     );
     const reviewSessionKey = runEmbeddedAgent.mock.calls[0]?.[0].sessionKey;
-    expect(isIncognitoSessionKey(reviewSessionKey)).toBe(true);
     expect(reviewSessionKey).not.toBe("agent:main:main");
     expect(runEmbeddedAgent.mock.calls[0]?.[0].messageActionTurnCapability).toBeUndefined();
     expect(runEmbeddedAgent.mock.calls[0]?.[0]).not.toHaveProperty("sessionTarget");

--- a/src/skills/workshop/experience-review.test.ts
+++ b/src/skills/workshop/experience-review.test.ts
@@ -374,31 +374,33 @@ describe("skill experience review scheduler", () => {
     scheduler.clear();
   });
 
-  it("does not replay running evidence after a shallow foreground turn", async () => {
+  it("does not re-arm evidence during asynchronous review preparation", async () => {
     vi.useFakeTimers();
-    let finishReview: (() => void) | undefined;
-    const runReview = vi
-      .fn()
-      .mockReturnValueOnce(
-        new Promise<void>((resolve) => {
-          finishReview = resolve;
-        }),
-      )
-      .mockResolvedValue(undefined);
+    let finishPreparation: (() => void) | undefined;
+    const prepareReview = vi.fn(async (candidate) => {
+      await new Promise<void>((resolve) => {
+        finishPreparation = resolve;
+      });
+      return candidate;
+    });
+    const runReview = vi.fn().mockResolvedValue(undefined);
     const scheduler = createSkillExperienceReviewScheduler({
       isSystemActive: () => false,
+      prepareReview,
       runReview,
     });
 
     scheduler.schedule(completedRun({ runId: "deep-turn" }));
     await vi.advanceTimersByTimeAsync(30_000);
-    expect(runReview).toHaveBeenCalledOnce();
+    expect(prepareReview).toHaveBeenCalledOnce();
+    expect(runReview).not.toHaveBeenCalled();
 
     scheduler.schedule(completedRun({ runId: "shallow-turn", modelIterations: 1 }));
-    await vi.advanceTimersByTimeAsync(30_000);
-    finishReview?.();
+    finishPreparation?.();
     await flushMicrotasks();
-    await vi.advanceTimersByTimeAsync(30_000);
+    expect(runReview).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(60_000);
 
     expect(runReview).toHaveBeenCalledOnce();
     scheduler.clear();

--- a/src/skills/workshop/experience-review.test.ts
+++ b/src/skills/workshop/experience-review.test.ts
@@ -374,6 +374,36 @@ describe("skill experience review scheduler", () => {
     scheduler.clear();
   });
 
+  it("does not replay running evidence after a shallow foreground turn", async () => {
+    vi.useFakeTimers();
+    let finishReview: (() => void) | undefined;
+    const runReview = vi
+      .fn()
+      .mockReturnValueOnce(
+        new Promise<void>((resolve) => {
+          finishReview = resolve;
+        }),
+      )
+      .mockResolvedValue(undefined);
+    const scheduler = createSkillExperienceReviewScheduler({
+      isSystemActive: () => false,
+      runReview,
+    });
+
+    scheduler.schedule(completedRun({ runId: "deep-turn" }));
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(runReview).toHaveBeenCalledOnce();
+
+    scheduler.schedule(completedRun({ runId: "shallow-turn", modelIterations: 1 }));
+    await vi.advanceTimersByTimeAsync(30_000);
+    finishReview?.();
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(runReview).toHaveBeenCalledOnce();
+    scheduler.clear();
+  });
+
   it("serializes reviews across sessions", async () => {
     vi.useFakeTimers();
     let finishFirst: (() => void) | undefined;

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -461,6 +461,8 @@ async function runSkillExperienceReviewInner(
           preparedRunAdmission,
           sessionId: reviewSession.sessionId,
           sessionKey: reviewSession.sessionKey,
+          // Delivery authority closes with the foreground turn and cannot be reused by this fork.
+          messageActionTurnCapability: undefined,
           sessionManager: detachedSession,
           sessionPersistence: "detached",
           // Never occupy the foreground agent lane after the idle gate opens.

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -10,6 +10,7 @@ import { resolveAgentRunSessionTarget } from "../../agents/run-session-target.js
 import { SessionManager } from "../../agents/sessions/index.js";
 import { getCanonicalSkillWorkspace } from "../../agents/skill-workshop-workspace-context.js";
 import { getRuntimeConfig } from "../../config/config.js";
+import { resolveInternalSessionEffectsIdentity } from "../../config/sessions/internal-session-key.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-run-registry.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -388,15 +389,26 @@ async function runSkillExperienceReviewInner(
 ): Promise<void> {
   const foregroundPromptContext = candidate.ctx.foregroundPromptContext;
   const workspaceDir = getCanonicalSkillWorkspace() ?? candidate.ctx.workspaceDir;
-  const sessionKey = candidate.ctx.sessionKey;
-  const sessionId = candidate.ctx.sessionId;
+  const foregroundSessionKey = candidate.ctx.sessionKey;
+  const foregroundSessionId = candidate.ctx.sessionId;
   const modelProviderId = candidate.ctx.modelProviderId?.trim();
   const modelId = candidate.ctx.modelId?.trim();
-  if (!workspaceDir || !sessionKey || !sessionId || !modelProviderId || !modelId) {
+  if (
+    !workspaceDir ||
+    !foregroundSessionKey ||
+    !foregroundSessionId ||
+    !modelProviderId ||
+    !modelId
+  ) {
     return;
   }
 
   const runId = `skill-workshop-review:${randomUUID()}`;
+  const reviewSession = resolveInternalSessionEffectsIdentity({
+    agentId: foregroundPromptContext.agentId,
+    incognito: true,
+    runId,
+  });
   const origin = foregroundPromptContext.cronCreatorCallerOrigin;
   const capability = origin ? createCronCreatorAuthorityCapability(runId, origin) : undefined;
   const config = candidate.config ?? getRuntimeConfig();
@@ -404,14 +416,14 @@ async function runSkillExperienceReviewInner(
     remaining: 1,
     readSkillHashes: new Map(),
   };
-  const sessionTarget = await resolveAgentRunSessionTarget({
+  const foregroundSessionTarget = await resolveAgentRunSessionTarget({
     agentId: foregroundPromptContext.agentId,
     config,
-    sessionId,
-    sessionKey,
+    sessionId: foregroundSessionId,
+    sessionKey: foregroundSessionKey,
     missingSessionKey: "resolve-existing",
   });
-  const foregroundSession = SessionManager.open(sessionTarget, workspaceDir);
+  const foregroundSession = SessionManager.open(foregroundSessionTarget, workspaceDir);
   const detachedSession = SessionManager.fromEntries(foregroundSession.getEntries(), workspaceDir);
   const { listWritableWorkspaceSkillSummaries } = await import("./workspace-skill-read.js");
   const existingSkills = listWritableWorkspaceSkillSummaries(workspaceDir, {
@@ -429,12 +441,12 @@ async function runSkillExperienceReviewInner(
   let outcome: "applied" | "proposed" | "nothing";
   let proposalId: string | undefined;
   let usage: { inputTokens: number; cachedInputTokens: number; outputTokens: number } | undefined;
-  // The warm review reuses the foreground session identity for prompt caching.
-  // Keep every review event and lifecycle transition out of that user-visible session.
+  // The review owns a private runtime identity while the explicit promptCacheKey
+  // keeps provider cache affinity with the foreground transcript it cloned.
   registerAgentRunContext(runId, {
     agentId: foregroundPromptContext.agentId,
-    sessionId,
-    sessionKey,
+    sessionId: reviewSession.sessionId,
+    sessionKey: reviewSession.sessionKey,
     isControlUiVisible: false,
     projectSessionActive: false,
     projectSessionLifecycle: false,
@@ -447,9 +459,8 @@ async function runSkillExperienceReviewInner(
         runEmbeddedAgent({
           ...foregroundPromptContext,
           preparedRunAdmission,
-          sessionId,
-          sessionKey,
-          sessionTarget,
+          sessionId: reviewSession.sessionId,
+          sessionKey: reviewSession.sessionKey,
           sessionManager: detachedSession,
           sessionPersistence: "detached",
           // Never occupy the foreground agent lane after the idle gate opens.
@@ -472,6 +483,7 @@ async function runSkillExperienceReviewInner(
           allowEmptyAssistantReplyAsSilent: true,
           terminalReplyExpectation: "optional",
           toolExecutionAllow: ["skill_workshop"],
+          cleanupBundleMcpOnRunEnd: true,
           disableTrajectory: true,
           skillWorkshopProposalOnly: true,
           skillWorkshopUpdateProposals: true,
@@ -479,10 +491,9 @@ async function runSkillExperienceReviewInner(
           skillWorkshopProposalMutationBudget: proposalMutationBudget,
           skillWorkshopOrigin: {
             agentId: foregroundPromptContext.agentId,
-            sessionKey,
+            sessionKey: foregroundSessionKey,
             ...(candidate.ctx.runId ? { runId: candidate.ctx.runId } : {}),
           },
-          // The review shares the foreground session, so its MCP runtime stays warm for the next turn.
           verboseLevel: "off",
           suppressToolErrorWarnings: true,
           ...(capability ? { cronCreatorAuthorityCapability: capability } : {}),

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -222,17 +222,13 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
           }
           reviewInFlight = true;
           try {
+            pendingBySession.delete(sessionKey);
             const candidate = deps.prepareReview
               ? await deps.prepareReview(pending.candidate)
               : pending.candidate;
             if (!candidate) {
-              pendingBySession.delete(sessionKey);
               return;
             }
-            if (pendingBySession.get(sessionKey) !== pending || pending.generation !== generation) {
-              return;
-            }
-            pendingBySession.delete(sessionKey);
             await deps.runReview(candidate);
           } finally {
             reviewInFlight = false;

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -404,7 +404,6 @@ async function runSkillExperienceReviewInner(
   const runId = `skill-workshop-review:${randomUUID()}`;
   const reviewSession = resolveInternalSessionEffectsIdentity({
     agentId: foregroundPromptContext.agentId,
-    incognito: true,
     runId,
   });
   const origin = foregroundPromptContext.cronCreatorCallerOrigin;

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -232,10 +232,8 @@ export function createSkillExperienceReviewScheduler(deps: ExperienceReviewSched
             if (pendingBySession.get(sessionKey) !== pending || pending.generation !== generation) {
               return;
             }
+            pendingBySession.delete(sessionKey);
             await deps.runReview(candidate);
-            if (pendingBySession.get(sessionKey) === pending && pending.generation === generation) {
-              pendingBySession.delete(sessionKey);
-            }
           } finally {
             reviewInFlight = false;
           }


### PR DESCRIPTION
Closes #131018

## What Problem This Solves

Fixes an issue where a hidden Skill Workshop experience review could make a new message wait behind the review when the user sent it to the same chat.

The hidden run also shared foreground execution ownership, retained closed foreground delivery authority, and could replay the same review after a shallow message arrived during review startup.

## Why This Change Was Made

Each review now gets a private internal session identity and a detached clone of the foreground transcript. The foreground permission context, proposal origin, rendered prompt/tool prefix, and explicit provider prompt-cache key remain unchanged.

The review drops the completed turn's delivery authority, cleans up its private one-shot Model Context Protocol runtime, and retires queued evidence before asynchronous preparation begins. Review output remains hidden and intentional no-op results remain silent.

Maintainer decision: hidden reviews run beside foreground work on their private session. They do not cancel, preempt, own, or delay the foreground session.

## User Impact

New messages start while a Skill Workshop review is still running. Review prompts, progress, and no-op replies do not become part of the foreground chat, and a later shallow turn does not replay old review evidence.

## Evidence

- Current-main live reproduction: a second dashboard message was accepted during a held review, but its provider request started 60,114 ms later, after the review ended.
- Regression proof: the foreground-lane test failed before the fix because foreground work could not start while the review held the shared session lane.
- Capability regression: the Telegram review failed before the provider request because it retained the completed turn's closed delivery authority; the focused test failed before the authority was removed.
- Scheduler regression: asynchronous preparation is held open while a shallow foreground turn completes; the focused test proves the original evidence proceeds once and no timer replays it.
- Cache regression: the real embedded-attempt test runs the foreground and review on different session identities, then proves their rendered system-prompt and tool digests remain equal while transcript persistence stays disabled.
- Exact head `168ae59bd9ca86f9cb1094b3c14bba1ae8d5b0d1`: 49 focused tests passed across Skill Workshop review behavior, prompt/tool policy, and session classification.
- Runtime-identical Telegram Test Server and Gateway trace from parent `3432118d600c9b89b113ed1b4c1e5604854a358f`: the second user message arrived at 40,086 ms and received `SECOND_DONE` at 41,172 ms while the review response remained held for 60 seconds. Provider request 11 was the review. Request 12 was the independent foreground turn and contained no review-only constraint. The 150-second recording ended with exactly 12 provider requests, so no duplicate review ran. The final commit changes documentation only.
- The runner removed its credential and Gateway scratch state. Its assigned ports are free.
- Exact changed files pass Oxfmt, type-aware Oxlint, and `git diff --check`. Docs MDX and docs formatting checks pass.

- Exact-head local ClawSweeper review: patch correct, zero findings, security cleared, no maintainer decision, and zero rank-up moves.
- Exact-head `openclaw/ci-gate`: green.

AI-assisted: yes. The maintainer reviewed the root cause, implementation, and proof.

