### PR TITLE
fix(code-mode): continue tasks after discovery-only errors

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -189,9 +189,13 @@ to occur before execution become failed `exec` results that the model can read
 and correct across successive turns. A failed tool call does not automatically
 end the agent run when OpenClaw can prove that no nested action started.
 
+Catalog search, handle `describe()`, `skills.list()`, and `skills.read()` are
+read-only discovery. A guest error after only these operations still allows
+ordinary recovery from a failed `exec`; discovery does not count as a mutation.
+
 OpenClaw does not automatically replay a failed program. If earlier calls
-already ran or a failed call may have partially applied, OpenClaw first limits
-recovery to an authorized read-only inspection of the current state. It does
+may have changed state or a failed call may have partially applied, OpenClaw
+first limits recovery to an authorized read-only inspection of the current state. It does
 not expose writes, sends, shell commands, or other mutations during that
 reconciliation. Cancellation, explicitly terminal tool outcomes, sandbox
 restrictions, approval requirements, and tool-policy denials retain their
@@ -981,9 +985,10 @@ code-mode tool call and the nested tool id.
 
 Nested tool failures cross into the guest as catchable JavaScript errors. If
 guest code does not catch an error, `exec` or `wait` returns a failed tool
-result. Proven no-start failures and guest-only errors allow ordinary model
-recovery; possible nested side effects require authorized read-only
-reconciliation before any further action. Network-controlled tool output and
+result. In `exec`, proven no-start failures and guest-only errors, including
+errors after read-only discovery, allow ordinary model recovery. A failed `wait`
+still ends ordinary continuation. Possible nested side effects require authorized
+read-only reconciliation before any further action. Network-controlled tool output and
 errors retain their existing untrusted-content wrapping and sanitization;
 recovering from a failure does not grant new permissions or replay completed
 side effects.

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -363,10 +363,10 @@ export function createPendingBridgeStates(params: {
     const target = params.catalogProjection.byCallableName.get(String(request.args[0]));
     const yieldRunSignal = target?.name === "sessions_yield" ? params.ctx.abortSignal : undefined;
     const tracksDispatch = request.method !== "sleep";
-    // Exact catalog binding rejects shadowed or untrusted tools before replay-safety applies.
+    // Discovery is read-only; replay-safe actions such as agentSpawn may still mutate.
     const recoverySafe =
-      (request.method === "nodes" && (request.args[0] === "list" || request.args[0] === "get")) ||
-      (request.method === "callValue" &&
+      ["search", "describe", "skillsList", "skillsRead"].includes(request.method) ||
+      (["nodes", "callValue"].includes(request.method) &&
         isPendingBridgeRequestReplaySafe(request, params.runtime, params.catalogProjection));
     if (tracksDispatch) {
       params.bridgeDispatch.started = true;

--- a/src/agents/code-mode.agent-loop.test.ts
+++ b/src/agents/code-mode.agent-loop.test.ts
@@ -6,6 +6,7 @@ import {
 } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setPluginToolMeta } from "../plugins/tools.js";
+import type { CodeModeSkill } from "./code-mode-skills.js";
 import { applyCodeModeCatalog } from "./code-mode.js";
 import {
   createCodeModeHarness,
@@ -51,8 +52,14 @@ function createAssistant(content: AssistantMessage["content"]): AssistantMessage
   };
 }
 
-async function runCodeModeAgent(params: { programs: string[]; hiddenTools: AnyAgentTool[] }) {
-  const { config, catalogRef, tools } = createCodeModeHarness();
+async function runCodeModeAgent(params: {
+  programs: string[];
+  hiddenTools: AnyAgentTool[];
+  codeModeSkills?: CodeModeSkill[];
+}) {
+  const { config, catalogRef, tools } = createCodeModeHarness({
+    codeModeSkills: params.codeModeSkills,
+  });
   applyCodeModeCatalog({
     tools: [...tools, ...params.hiddenTools],
     config,
@@ -60,6 +67,7 @@ async function runCodeModeAgent(params: { programs: string[]; hiddenTools: AnyAg
     sessionKey: "agent:main:main",
     runId: "run-code-mode",
     catalogRef,
+    codeModeSkills: params.codeModeSkills,
   });
   const providerContexts: Context[] = [];
   let reconciliationCandidates = 0;
@@ -102,6 +110,64 @@ async function runCodeModeAgent(params: { programs: string[]; hiddenTools: AnyAg
 
 describe("Code Mode agent-loop error recovery", () => {
   afterEach(() => resetCodeModeTestState());
+
+  it.each([
+    {
+      name: "catalog.search",
+      discovery: '(await catalog.search("complete_task")).map((tool) => tool.toolName)',
+      value: ["complete_task"],
+    },
+    {
+      name: "handle.describe",
+      discovery: "(await complete_task.describe()).name",
+      value: "complete_task",
+    },
+    {
+      name: "skills.list",
+      discovery: "(await skills.list()).map((skill) => skill.name)",
+      value: ["demo"],
+    },
+    { name: "skills.read", discovery: 'await skills.read("demo")', value: "Demo instructions" },
+  ])(
+    "continues ordinary recovery after $name metadata and a guest error",
+    async ({ discovery, value }) => {
+      const complete = pluginToolWithExecute("complete_task", "Complete the task", async () =>
+        jsonResult({ completed: true }),
+      );
+      const { agent, providerContexts, reconciliationCandidates } = await runCodeModeAgent({
+        hiddenTools: [complete],
+        codeModeSkills: [
+          {
+            name: "demo",
+            description: "Demo skill",
+            location: "/skills/demo/SKILL.md",
+            source: { filePath: "/skills/demo/SKILL.md", readContent: "Demo instructions" },
+          },
+        ],
+        programs: [`json(${discovery}); return missingFn();`, "return await complete_task({});"],
+      });
+
+      const failure = expect.objectContaining({
+        role: "toolResult",
+        toolName: "exec",
+        isError: true,
+        details: expect.objectContaining({
+          status: "failed",
+          error: expect.stringContaining("ReferenceError: missingFn is not defined"),
+          output: [{ type: "json", value }],
+          telemetry: expect.objectContaining({ callCount: 0 }),
+        }),
+      });
+      expect(agent.state.messages).toContainEqual(failure);
+      expect(providerContexts).toHaveLength(3);
+      expect(complete.execute).toHaveBeenCalledOnce();
+      expect(reconciliationCandidates).toBe(0);
+      expect(agent.state.messages.at(-1)).toMatchObject({
+        role: "assistant",
+        content: [{ type: "text", text: "recovered" }],
+      });
+    },
+  );
 
   it("returns a trusted no-start tool failure to the model for ordinary recovery", async () => {
     const terminal = pluginToolWithExecute("terminal", "Open a terminal", async () =>


### PR DESCRIPTION
Closes #131050

## What Problem This Solves

Fixes an issue where users would receive an unfinished read-only reconciliation report after a correctable Code Mode error, even when the cell had only searched the tool catalog or read skill metadata and no nested action had run.

The live reproduction starts with `await catalog.search("read"); return missingFn();`, then asks the agent to read an input file, write its verification code, and read the output back. Before this fix, the model executes the diagnostic exactly but OpenClaw removes write tools; the requested output file is never created.

## Why This Change Was Made

The host bridge owner now classifies catalog search, handle description, skill listing, and skill reading as read-only discovery. The existing host-minted, exact-object recovery provenance can therefore permit ordinary continuation after these operations. Node and exact catalog-call checks reuse the existing audited predicate; no model-specific exception, retry, alternate executor, or blanket replay-safe exemption was added.

Actual or uncertain side effects remain restricted. In particular, replay-safe Swarm spawning is not treated as mutation-free. Failed `wait` behavior is unchanged and explicitly documented.

Production LOC: **+3/-3 (net 0)**. Tests: **+68/-2**. Docs: **+10/-5**. No configuration, dependency, schema, protocol, or persistence changes.

Provenance: the broad bridge-dispatch tracking was introduced by Shakker in commit `c3ec166cbcdd405d7baef29a235f6a5f06a133cd` (2026-08-23). The omission was carried forward in [read-only node recovery](https://github.com/openclaw/openclaw/pull/129427) and the subsequent [invalid nested-call recovery repair](https://github.com/openclaw/openclaw/pull/130478), whose relevant classification lines were authored by Vito Cappello (@VACInc); the latter was merged by @VACInc on 2026-08-27. This patch repairs the metadata branch rather than weakening those mutation controls.

## User Impact

After a Code Mode cell fails following only discovery, the agent can correct its code and finish the original authorized task. It does not repeat the failed program or replay any previous mutation. The same behavior applies to catalog and skill discovery, while mutation, terminal-outcome, and abort restrictions remain intact.

## Evidence

**Before/after live authenticated proof:** OpenAI `gpt-5.6-luna` through the **OpenClaw** runtime, using task-owned config/state/workspaces and a separate loopback Gateway. The operator Gateway and state were not touched.

- Before: exact diagnostic recorded once; `search=1`, `call=0`; read-only reconciliation; output absent.
- After: exact diagnostic recorded once; ordinary continuation; read -> write -> read; output bytes and final answer both equal the verification code. CLI result has `codeModeEngaged=true`, `bridgeCalls={search:1,describe:0,call:3}`, and one intentional diagnostic failure.
- The same scenario was driven through the real Control UI. Before and after captures were opened and inspected; they contain only synthetic test data.

### Before

![Before: reconciliation reports that the output file was not created](https://github.com/user-attachments/assets/550f8614-997d-41bd-9d9f-d83b69a02908)

https://github.com/user-attachments/assets/abeb2ed6-d995-4414-a9b1-ae292e012192

### After

![After: the agent completes read-write-read and returns the verified code](https://github.com/user-attachments/assets/f29323b5-050c-44b7-a00d-e2e1883fb767)

https://github.com/user-attachments/assets/a912e785-5561-40ac-afd8-540e0db7bf22

### Regression and sibling proof

The four new metadata cases failed on pre-fix production, then passed after the repair. **61 focused and sibling tests passed**, including side-effecting plugin and Swarm controls, node lookup, replay safety, and exact result provenance.

```bash
node scripts/run-vitest.mjs src/agents/code-mode.agent-loop.test.ts
```

```bash
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts src/agents/tool-result-error.test.ts src/agents/code-mode-nodes.test.ts src/agents/code-mode.replay.test.ts src/agents/code-mode.preflight-repair.test.ts --maxWorkers=1 --no-file-parallelism
```

```bash
node scripts/run-vitest.mjs src/agents/code-mode-swarm.test.ts --maxWorkers=1 --no-file-parallelism -t 'keeps a guest error after agents.run restricted'
```

```bash
node scripts/check-changed.mjs -- src/agents/code-mode-state.ts src/agents/code-mode.agent-loop.test.ts docs/tools/code-mode.md
```

```bash
OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
```

The changed gate, full build, formatting/MDX validation, and `git diff --check` passed. The runtime patch was byte-compared before and after the build. Fresh independent Codex autoreview reported no actionable P0/P1 findings.

Dependency/owner inspection covered the complete Code Mode state/execution/bridge/worker and outcome modules, catalog and skill readers, relevant tests, and installed QuickJS-WASI 3.4.0 snapshot/restore/callback source. Codex-native execution is a separate surface and was not used as substitute proof.

AI-assisted implementation and verification. Release-note context is the recovery behavior above; no changelog edit.
