### PR TITLE
fix: preserve systemd units when interrupted status cannot authorize cleanup

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -499,6 +499,8 @@ That stages grounded durable candidates into the short-term dreaming store while
   <Accordion title="8. Gateway service migrations and cleanup hints">
     Doctor detects legacy gateway services (launchd/systemd/schtasks) and offers to remove them and install the OpenClaw service using the current gateway port. It can also scan for extra gateway-like services and print cleanup hints. Profile-named OpenClaw gateway services are considered first-class and are not flagged as "extra."
 
+    Linux user-service cleanup preserves the unit file if stopping or disabling the service fails. An interrupted status probe does not permit file-only removal; that fallback is reported only when `systemctl` is unavailable.
+
     On Linux, if the user-level gateway service is missing but a system-level OpenClaw gateway service exists, doctor does not install a second user-level service automatically. Inspect with `openclaw gateway status --deep` or `openclaw doctor --deep`, then remove the duplicate or set `OPENCLAW_SERVICE_REPAIR_POLICY=external` when a system supervisor owns the gateway lifecycle.
 
   </Accordion>

--- a/src/daemon/systemd-exec.ts
+++ b/src/daemon/systemd-exec.ts
@@ -368,5 +368,7 @@ export async function assertSystemdAvailable(
 
 export async function isSystemctlAvailable(env: GatewayServiceEnv): Promise<boolean> {
   const res = await execSystemctlUser(env, ["status"]);
-  return res.termination === "exit" && (res.code === 0 || !isSystemctlMissing(res));
+  // Cleanup uses false to permit file-only removal. An interrupted status probe
+  // must still attempt disable before removing a potentially loaded unit.
+  return res.code === 0 || !isSystemctlMissing(res);
 }

--- a/src/daemon/systemd-unavailable.test.ts
+++ b/src/daemon/systemd-unavailable.test.ts
@@ -1,6 +1,7 @@
 // Systemd unavailable tests cover fallback behavior when systemd is not present.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
 import { withTempDir } from "../test-utils/temp-dir.js";
 import { execFileUtf8 } from "./exec-file.js";
@@ -10,6 +11,10 @@ import {
   isSystemctlAvailable,
   isSystemdUserServiceAvailable,
 } from "./systemd-exec.js";
+import {
+  uninstallLegacySystemdUnits,
+  uninstallUserSystemdGatewayUnit,
+} from "./systemd-lifecycle.js";
 import {
   classifySystemdUnavailableDetail,
   isSystemctlMissingDetail,
@@ -57,6 +62,7 @@ describe("classifySystemdUnavailableDetail", () => {
 describe.skipIf(process.platform === "win32")("systemd process availability", () => {
   function systemctlEnv(dir: string) {
     return {
+      HOME: dir,
       PATH: dir,
       XDG_RUNTIME_DIR: dir,
       DBUS_SESSION_BUS_ADDRESS: `unix:path=${path.join(dir, "bus")}`,
@@ -131,9 +137,77 @@ describe.skipIf(process.platform === "win32")("systemd process availability", ()
       );
       expect(isLaunchctlNotLoaded(result)).toBe(false);
       if (termination === "signal") {
-        await expect(isSystemctlAvailable(env)).resolves.toBe(false);
+        await expect(isSystemctlAvailable(env)).resolves.toBe(true);
         await expect(isSystemdUserServiceAvailable(env)).resolves.toBe(false);
       }
     });
+  });
+
+  describe.each([
+    { unitName: "clawdbot-gateway.service", uninstall: uninstallLegacySystemdUnits },
+    { unitName: "openclaw-gateway.service", uninstall: uninstallUserSystemdGatewayUnit },
+  ])("$unitName cleanup", ({ unitName, uninstall }) => {
+    it.each([
+      { availability: "signal", disableFails: true },
+      { availability: "signal", disableFails: false },
+      { availability: "missing", disableFails: false },
+    ])(
+      "handles $availability status with disable failure $disableFails",
+      async ({ availability, disableFails }) => {
+        await withTempDir("openclaw-systemctl-cleanup-", async (dir) => {
+          const env = systemctlEnv(dir);
+          const unitPath = path.join(dir, ".config/systemd/user", unitName);
+          const definition = "[Unit]\nDescription=Gateway cleanup fixture\n";
+          await fs.mkdir(path.dirname(unitPath), { recursive: true });
+          await fs.writeFile(unitPath, definition);
+          if (availability !== "missing") {
+            await fs.writeFile(
+              path.join(dir, "systemctl"),
+              [
+                "#!/bin/sh",
+                'printf "%s\\n" "$*" >> "$HOME/systemctl.calls"',
+                'case " $* " in',
+                '*" status "*) kill -TERM $$ ;;',
+                '*" is-enabled "*) printf "enabled\\n" ;;',
+                '*" disable "*)',
+                `  test -f "$HOME/.config/systemd/user/${unitName}" || exit 98`,
+                disableFails ? "  kill -TERM $$ ;;" : "  exit 0 ;;",
+                "esac",
+              ].join("\n"),
+              { mode: 0o700 },
+            );
+          }
+          let output = "";
+          const stdout = new Writable({
+            write(chunk, _encoding, callback) {
+              output += chunk.toString();
+              callback();
+            },
+          });
+          if (disableFails) {
+            await expect(uninstall({ env, stdout })).rejects.toThrow("systemctl disable failed:");
+            await expect(fs.readFile(unitPath, "utf8")).resolves.toBe(definition);
+            expect(output).not.toContain("Removed");
+          } else {
+            await uninstall({ env, stdout });
+            await expect(fs.access(unitPath)).rejects.toMatchObject({ code: "ENOENT" });
+            expect(output).toContain("Removed");
+          }
+          if (availability === "missing") {
+            await expect(fs.access(path.join(dir, "systemctl.calls"))).rejects.toMatchObject({
+              code: "ENOENT",
+            });
+            expect(output).toContain("systemctl unavailable");
+          } else {
+            const calls = (await fs.readFile(path.join(dir, "systemctl.calls"), "utf8"))
+              .trim()
+              .split("\n");
+            expect(calls).toContain(`--user disable --now ${unitName}`);
+            expect(calls.includes("--user daemon-reload")).toBe(!disableFails);
+            expect(output).not.toContain("systemctl unavailable");
+          }
+        });
+      },
+    );
   });
 });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -3377,37 +3377,48 @@ describe("uninstallLegacySystemdUnits", () => {
     execFileMock.mockReset();
   });
 
-  it("preserves a legacy unit file when systemctl cannot disable it", async () => {
-    const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-unit-"));
-    const env = { HOME: path.join(tempHomeRoot, "home") };
-    const unitPath = path.join(env.HOME, ".config", "systemd", "user", "clawdbot-gateway.service");
-    try {
-      await fs.mkdir(path.dirname(unitPath), { recursive: true });
-      await fs.writeFile(unitPath, "[Unit]\nDescription=Clawdbot Gateway\n", "utf8");
-      execFileMock
-        .mockImplementationOnce(systemctlUserSuccess("status"))
-        .mockImplementationOnce(
-          systemctlUserResult([null, "enabled\n", ""], "is-enabled", "clawdbot-gateway.service"),
-        )
-        .mockImplementationOnce(systemctlUserSuccess("status"))
-        .mockImplementationOnce(
-          systemctlUserResult(
-            [createExecFileError("permission denied", { code: 1 }), "", "Permission denied"],
-            "disable",
-            "--now",
-            "clawdbot-gateway.service",
-          ),
-        );
-
-      const { stdout } = createWritableStreamMock();
-      await expect(uninstallLegacySystemdUnits({ env, stdout })).rejects.toThrow(
-        "systemctl disable failed: Permission denied",
+  it.each(["exit", "signal"] as const)(
+    "preserves a legacy unit file when disable fails after status %s",
+    async (termination) => {
+      const tempHomeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-unit-"));
+      const env = { HOME: path.join(tempHomeRoot, "home") };
+      const unitPath = path.join(
+        env.HOME,
+        ".config",
+        "systemd",
+        "user",
+        "clawdbot-gateway.service",
       );
-      await expect(fs.access(unitPath)).resolves.toBeUndefined();
-    } finally {
-      await fs.rm(tempHomeRoot, { recursive: true, force: true });
-    }
-  });
+      try {
+        await fs.mkdir(path.dirname(unitPath), { recursive: true });
+        await fs.writeFile(unitPath, "[Unit]\nDescription=Clawdbot Gateway\n", "utf8");
+        execFileMock.mockImplementation((_command, args, _options, callback) => {
+          if (args[1] === "status") {
+            callback(
+              termination === "signal"
+                ? createExecFileError("status interrupted", { termination })
+                : null,
+              "",
+              "",
+            );
+          } else if (args[1] === "is-enabled") {
+            callback(null, "enabled\n", "");
+          } else {
+            assertUserSystemctlArgs(args, "disable", "--now", "clawdbot-gateway.service");
+            callback(createExecFileError("permission denied"), "", "Permission denied");
+          }
+        });
+
+        const { stdout } = createWritableStreamMock();
+        await expect(uninstallLegacySystemdUnits({ env, stdout })).rejects.toThrow(
+          "systemctl disable failed: Permission denied",
+        );
+        await expect(fs.access(unitPath)).resolves.toBeUndefined();
+      } finally {
+        await fs.rm(tempHomeRoot, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 describe("uninstallUserSystemdGatewayUnit", () => {
@@ -3485,28 +3496,42 @@ describe("uninstallUserSystemdGatewayUnit", () => {
     });
   });
 
-  it("preserves the unit file when systemctl cannot disable the service", async () => {
-    await withUserUnitFixture(async ({ env, unitPath }) => {
-      await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Gateway\n", "utf8");
-      execFileMock
-        .mockImplementationOnce(systemctlUserSuccess("status"))
-        .mockImplementationOnce(
-          systemctlUserResult(
-            [createExecFileError("permission denied", { code: 1 }), "", "Permission denied"],
-            "disable",
-            "--now",
-            GATEWAY_SERVICE,
-          ),
-        );
+  it.each(["exit", "signal"] as const)(
+    "preserves the unit file when disable fails after status %s",
+    async (termination) => {
+      await withUserUnitFixture(async ({ env, unitPath }) => {
+        await fs.writeFile(unitPath, "[Unit]\nDescription=OpenClaw Gateway\n", "utf8");
+        execFileMock
+          .mockImplementationOnce(
+            systemctlUserResult(
+              [
+                termination === "signal"
+                  ? createExecFileError("status interrupted", { termination })
+                  : null,
+                "",
+                "",
+              ],
+              "status",
+            ),
+          )
+          .mockImplementationOnce(
+            systemctlUserResult(
+              [createExecFileError("permission denied", { code: 1 }), "", "Permission denied"],
+              "disable",
+              "--now",
+              GATEWAY_SERVICE,
+            ),
+          );
 
-      const { stdout } = createWritableStreamMock();
-      await expect(uninstallUserSystemdGatewayUnit({ env, stdout })).rejects.toThrow(
-        "systemctl disable failed: Permission denied",
-      );
-      await expect(fs.access(unitPath)).resolves.toBeUndefined();
-      expect(execFileMock).toHaveBeenCalledTimes(2);
-    });
-  });
+        const { stdout } = createWritableStreamMock();
+        await expect(uninstallUserSystemdGatewayUnit({ env, stdout })).rejects.toThrow(
+          "systemctl disable failed: Permission denied",
+        );
+        await expect(fs.access(unitPath)).resolves.toBeUndefined();
+        expect(execFileMock).toHaveBeenCalledTimes(2);
+      });
+    },
+  );
 
   it("surfaces daemon-reload failure after removing the disabled unit", async () => {
     await withUserUnitFixture(async ({ env, unitPath }) => {


### PR DESCRIPTION
Fixes #131069

## What Problem This Solves

Fixes an issue where users running Linux gateway-service cleanup could have a unit file deleted without attempting to stop or disable its service when the initial `systemctl status` query was interrupted.

## Why This Change Was Made

The shared executable-availability predicate no longer mistakes an interrupted query for an unavailable executable. Both legacy and current user-unit cleanup therefore retain the existing disable-before-delete path; manager readiness and activity still reject interrupted results. The established missing/inaccessible-executable file-only cleanup behavior is unchanged.

This repairs the producer of the destructive decision instead of duplicating guards in both cleanup callers. Production changes are +3/-1 lines (net +2, entirely the explanatory invariant comment; runtime logic is net zero), tests +151/-52 (net +99), and docs +2/-0. No new API, configuration, dependency, storage, or fallback path is added.

## User Impact

An interrupted status probe no longer silently permits file-only removal. Cleanup attempts to disable the unit first; if that operation fails, the unit file stays intact and the failure is reported. A successful disable still permits removal and manager reload, while genuine `systemctl` unavailability retains its explicit file-only diagnostic.

Release-note context: preserve Linux gateway unit files when service cleanup cannot safely disable them after an interrupted status query.

## Evidence

- Before the production change, the regression suite failed in seven intended cases: four real-child cleanup cases across both unit owners, two extended existing cleanup regressions, and executable-availability classification. The other 213 tests passed.
- After the fix, all **220 tests in three files** passed: `src/daemon/systemd.test.ts`, `src/daemon/systemd-unavailable.test.ts`, and `src/daemon/systemd-system.test.ts`.
- Real POSIX child-process fixtures terminate status with SIGTERM and exercise production cleanup. Failed disable preserves the exact unit bytes, reports failure, and does not reload or claim removal. Successful disable observes the file still present before deleting it, then reloads. A missing executable retains file-only cleanup. Both legacy and canonical user units use the same table.
- This initial proof ran on macOS with Node 24.20, installed Vitest 4.1.10 and Execa 10.0.0, through the canonical daemon configuration with a dependency adapter. It is not exact-lockfile or native Linux proof. Native PR-worktree frozen-install tests and actual Linux CI execution are required before landing; no real systemd manager has been exercised or is claimed.
- Follow-up on committed head `cc54e8f751dc3f306e25c40e5939ada8636d1eba`: an isolated native PR worktree with `pnpm install --frozen-lockfile` passed the normal `scripts/run-vitest.mjs` invocation, **220/220 tests in three files**, zero skips (187 systemd, 17 process/unavailability, 16 system-scope). Installed Vitest 4.1.11 and Execa 10.0.1 match the lockfile. This closes the local dependency-adapter gap; Linux CI proof is tracked separately. Another **106 Doctor caller tests in two files** passed on the same source commit using the earlier local dependency setup.
- **Linux proof completed:** [daemon-owning CI job](https://github.com/openclaw/openclaw/actions/runs/33100211990/job/98616203239) passed on Ubuntu 24.04 / Node 24.19.0 with frozen dependencies and Vitest 4.1.11. Its actual daemon-config output reports 836 passing tests in 21 files, plus 25 platform-specific launchd skips. The three relevant files passed **187 + 17 + 16 tests with no skips**, including all six new real-process cleanup cases. The tested merge snapshot binds this exact source head to base `715859aacb1b876c0aa9a08da17ba116f5d5cf1c`. This is native Linux process/file proof, not interaction with a real systemd manager.
- Initial CI attempt had two failures outside this daemon change: the SDK-report job exhausted five bounded history fetches before running SDK analysis; build compilation and smoke checks passed, but `plugins list` startup-memory median was **401.7 MB** against the effective **401 MB** limit. A single unchanged-head failed-job retry then passed. Its [build log](https://github.com/openclaw/openclaw/actions/runs/33100211990/job/98622454944) measured **318.1 MB** median (samples 318.1, 402.3, 317.9) against the unchanged 401 MB ceiling. The [SDK job](https://github.com/openclaw/openclaw/actions/runs/33100211990/job/98622457005) fetched the exact base successfully; API reporting retained its normal PR skip. No memory limit, timeout, assertion, or source change was made. This records observed variance, not a claimed root-cause memory fix.
- [Exact-head CI attempt 2](https://github.com/openclaw/openclaw/actions/runs/33100211990/attempts/2) completed successfully for `cc54e8f751dc3f306e25c40e5939ada8636d1eba` on August 27 at 18:15:10 UTC. The Linux daemon proof above is retained from the successful first-attempt job, not counted as a rerun.
- Independent P0–P3 review found no actionable findings. Configured Codex autoreview reported no P0 findings; it intentionally excluded lower severities. The changed-file gate passed ten guards before stopping because the sparse checkout lacked `oxfmt`; separate formatting of all four files and diff checks passed. Exact-head hosted checks remain mandatory.

Provenance: the extra normal-termination requirement was introduced by #130634, commit `b4262689db5dbb4b88660119f67ae6fc4372cd97`, merged August 27, 2026. Code/PR author and PR merger: @steipete; merge committer: GitHub. This fixes a current-main regression; no stable-release regression or real-host frequency is claimed.

AI-assisted implementation and review with Codex. The responsible maintainer workflow inspected the diff, real-process evidence, cleanup owners, and dependency result contracts.
