### PR TITLE
fix: inspect exact hook names before matching key aliases

### DIFF
--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -93,9 +93,11 @@ advisory: they do not by themselves make a hook unloadable.
 openclaw hooks info <name> [--agent <id>] [--json]
 ```
 
-Accepts a hook name or its metadata `hookKey`. Shows source, descriptor and
-handler paths, homepage, events, unknown-event warnings, blocked reason, and
-per-requirement status. A missing hook exits with code 1.
+Accepts a hook name or its metadata `hookKey`. Exact hook names take precedence
+over matching keys; a key must identify a single hook. Shows source, descriptor
+and handler paths, homepage, events, unknown-event warnings, blocked reason, and
+per-requirement status. A missing or ambiguous hook exits with code 1; an
+ambiguous selector lists candidates so you can choose a unique name or key.
 
 JSON includes the list fields plus `filePath`, `baseDir`, `handlerPath`,
 `hookKey`, `always`, `requirements`, `configChecks`, and normalized `install`

--- a/src/cli/hooks-cli.format.ts
+++ b/src/cli/hooks-cli.format.ts
@@ -174,12 +174,10 @@ export function formatHooksList(report: HookStatusReport, opts: HooksListOptions
  * Format detailed info for a single hook
  */
 export function formatHookInfo(
-  report: HookStatusReport,
+  hook: HookStatusEntry | undefined,
   hookName: string,
   opts: HookInfoOptions,
 ): string {
-  const hook = report.hooks.find((h) => h.name === hookName || h.hookKey === hookName);
-
   if (!hook) {
     if (opts.json) {
       const failure = formatCliJsonFailure(`Hook "${hookName}" not found.`);

--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -164,7 +164,7 @@ describe("hooks cli formatting", () => {
   );
 
   it("shows eventless hooks as blocked by their event declaration in info output", () => {
-    const output = formatHookInfo(createEventlessHookReport(), "session-memory", {});
+    const output = formatHookInfo(createEventlessHookReport().hooks[0], "session-memory", {});
 
     expect(output).toContain("No events defined");
     expect(output).toContain("Blocked reason: no events defined");
@@ -172,18 +172,14 @@ describe("hooks cli formatting", () => {
   });
 
   it("keeps missing requirement hooks labeled as missing requirements in info output", () => {
-    const output = formatHookInfo(createMissingRequirementHookReport(), "session-memory", {});
+    const output = formatHookInfo(
+      createMissingRequirementHookReport().hooks[0],
+      "session-memory",
+      {},
+    );
 
     expect(output).toContain("Missing requirements");
     expect(output).toContain("DEMO_HOOK_TOKEN");
-  });
-
-  it("keeps the missing hook identifier beside the canonical JSON failure", () => {
-    expect(JSON.parse(formatHookInfo(report, "missing-hook", { json: true }))).toEqual({
-      ok: false,
-      error: { type: "cli_error", message: 'Hook "missing-hook" not found.' },
-      hook: "missing-hook",
-    });
   });
 
   it("labels hooks status output", () => {
@@ -239,14 +235,14 @@ describe("hooks cli formatting", () => {
       ],
     };
 
-    const output = formatHookInfo(typoReport, "typo-hook", {});
+    const output = formatHookInfo(typoReport.hooks[0], "typo-hook", {});
     expect(output).toContain("Event not emitted by core (likely typo): command:nwe");
   });
 
   it("shows plugin-managed details in hook info", () => {
     const pluginReport = createPluginManagedHookReport();
 
-    const output = formatHookInfo(pluginReport, "plugin-hook", {});
+    const output = formatHookInfo(pluginReport.hooks[0], "plugin-hook", {});
     expect(output).toContain("voice-call");
     expect(output).toContain("Managed by plugin");
   });

--- a/src/cli/hooks-cli.toggle.test.ts
+++ b/src/cli/hooks-cli.toggle.test.ts
@@ -119,7 +119,7 @@ const hook: HookStatusEntry = {
   baseDir: "/tmp/openclaw-hook-workspace",
   handlerPath: "/tmp/openclaw-hook-workspace/handler.js",
   hookKey: "metadata-key",
-  events: [],
+  events: ["command:new"],
   unknownEvents: [],
   always: false,
   enabledByConfig: true,
@@ -379,18 +379,142 @@ describe("hooks CLI metadata config keys", () => {
     expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
   });
 
-  it("preserves machine-readable missing-hook output and requests a failing exit", async () => {
-    await createHooksProgram().parseAsync(["hooks", "info", "missing-hook", "--json"], {
-      from: "user",
+  describe.each(["human", "leaf JSON", "parent JSON"])("info selection (%s)", (output) => {
+    const json = output !== "human";
+    const argv = (identifier: string) => [
+      "hooks",
+      ...(output === "parent JSON" ? ["--json"] : []),
+      "info",
+      identifier,
+      ...(output === "leaf JSON" ? ["--json"] : []),
+    ];
+    const exactNameHook = { ...hook, name: "shared" };
+    const collidingKeyHook = { ...hook, name: "another-hook", hookKey: "shared" };
+
+    it.each([
+      {
+        label: "key before name",
+        hooks: [collidingKeyHook, exactNameHook],
+        identifier: "shared",
+        selected: exactNameHook,
+      },
+      {
+        label: "name before key",
+        hooks: [exactNameHook, collidingKeyHook],
+        identifier: "shared",
+        selected: exactNameHook,
+      },
+      { label: "unique key alias", hooks: [hook], identifier: "metadata-key", selected: hook },
+      {
+        label: "plugin-managed hook",
+        hooks: [
+          { ...hook, source: "openclaw-plugin", managedByPlugin: true, pluginId: "demo-plugin" },
+        ],
+        identifier: "metadata-key",
+        selected: hook,
+      },
+      {
+        label: "ineligible hook",
+        hooks: [{ ...hook, requirementsSatisfied: false, loadable: false }],
+        identifier: "metadata-key",
+        selected: hook,
+      },
+    ])("inspects $label without mutation", async ({ hooks, identifier, selected }) => {
+      mocks.callGateway.mockResolvedValue({ ...report, hooks });
+
+      await createHooksProgram().parseAsync(argv(identifier), { from: "user" });
+
+      expect(capture.runtimeLogs).toHaveLength(1);
+      if (json) {
+        expect(JSON.parse(capture.runtimeLogs[0] ?? "")).toMatchObject({
+          name: selected.name,
+          hookKey: selected.hookKey,
+        });
+        expect(capture.defaultRuntime.writeStdout).toHaveBeenCalledOnce();
+      } else {
+        expect(capture.runtimeLogs[0]).toContain(`${selected.name} `);
+        expect(capture.runtimeLogs[0]).not.toContain("another-hook");
+        expect(capture.defaultRuntime.writeStdout).not.toHaveBeenCalled();
+      }
+      expect(mocks.requestExitAfterOneShotOutput).toHaveBeenCalledWith(capture.defaultRuntime, 0);
+      expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+      expect(capture.runtimeErrors).toEqual([]);
     });
 
-    expect(JSON.parse(capture.runtimeLogs.at(-1) ?? "{}")).toEqual({
-      ok: false,
-      error: { type: "cli_error", message: 'Hook "missing-hook" not found.' },
-      hook: "missing-hook",
+    it("rejects an ambiguous key instead of reporting a successful inspection", async () => {
+      mocks.callGateway.mockResolvedValue({
+        ...report,
+        hooks: [
+          { ...hook, name: "first-hook", hookKey: "shared-key" },
+          { ...hook, name: "second-hook", hookKey: "shared-key" },
+        ],
+      });
+
+      await expect(
+        createHooksProgram().parseAsync(argv("shared-key"), { from: "user" }),
+      ).rejects.toMatchObject({
+        name: "ExpectedCliError",
+        message:
+          'Hook "shared-key" is ambiguous; matches: first-hook (shared-key), second-hook (shared-key). Use a unique hook name or hook key.',
+      });
+      expect(capture.runtimeLogs).toEqual([]);
+      expect(mocks.requestExitAfterOneShotOutput).not.toHaveBeenCalled();
+      expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
     });
-    expect(mocks.requestExitAfterOneShotOutput).toHaveBeenCalledWith(capture.defaultRuntime, 1);
+
+    it("preserves missing-hook output and requests a failing exit", async () => {
+      await createHooksProgram().parseAsync(argv("missing-hook"), { from: "user" });
+
+      expect(capture.runtimeLogs).toHaveLength(1);
+      if (json) {
+        expect(JSON.parse(capture.runtimeLogs[0] ?? "")).toEqual({
+          ok: false,
+          error: { type: "cli_error", message: 'Hook "missing-hook" not found.' },
+          hook: "missing-hook",
+        });
+        expect(capture.defaultRuntime.writeStdout).toHaveBeenCalledOnce();
+      } else {
+        expect(capture.runtimeLogs[0]).toBe(
+          'Hook "missing-hook" not found. Run `openclaw hooks list` to see available hooks.',
+        );
+        expect(capture.defaultRuntime.writeStdout).not.toHaveBeenCalled();
+      }
+      expect(mocks.requestExitAfterOneShotOutput).toHaveBeenCalledWith(capture.defaultRuntime, 1);
+      expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each(["enable", "disable"])("still rejects %s for plugin-managed hooks", async (action) => {
+    mocks.buildWorkspaceHookStatus.mockReturnValue({
+      ...report,
+      hooks: [
+        { ...hook, source: "openclaw-plugin", managedByPlugin: true, pluginId: "demo-plugin" },
+      ],
+    });
+    await expect(
+      createHooksProgram().parseAsync(["hooks", action, "metadata-key"], { from: "user" }),
+    ).rejects.toThrow("__exit__:1");
+    expect(capture.runtimeErrors.at(-1)).toContain('managed by plugin "demo-plugin"');
     expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("allows disabling a hook with missing requirements", async () => {
+    mocks.buildWorkspaceHookStatus.mockReturnValue({
+      ...report,
+      hooks: [{ ...hook, requirementsSatisfied: false, loadable: false }],
+    });
+    await createHooksProgram().parseAsync(["hooks", "disable", "metadata-key"], { from: "user" });
+    expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
+      nextConfig: {
+        hooks: {
+          internal: {
+            enabled: true,
+            entries: { "metadata-key": { env: { HOOK_ENV: "preserved" }, enabled: false } },
+          },
+        },
+      },
+      baseHash: "config-hash",
+    });
   });
 
   it.each([

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -141,11 +141,11 @@ function resolveHooksAgentOption(command: Command | undefined): string | undefin
   return resolveOptionFromCommand<string>(command, "agent");
 }
 
-function resolveHookForToggle(
+function resolveHookSelection(
   report: HookStatusReport,
   hookName: string,
-  opts?: { requireEligible?: boolean },
-): HookStatusEntry {
+): HookStatusEntry | undefined {
+  // A metadata key may alias another hook's name; exact names always win.
   const nameMatches = report.hooks.filter((hook) => hook.name === hookName);
   const matches =
     nameMatches.length > 0 ? nameMatches : report.hooks.filter((hook) => hook.hookKey === hookName);
@@ -158,30 +158,7 @@ function resolveHookForToggle(
       `Hook "${hookName}" is ambiguous; matches: ${candidates}. Use a unique hook name or hook key.`,
     );
   }
-  const hook = matches[0];
-  if (!hook) {
-    throw new Error(
-      `Hook "${hookName}" not found. Run \`${formatCliCommand("openclaw hooks list")}\` to see available hooks.`,
-    );
-  }
-  if (hook.managedByPlugin) {
-    throw new Error(
-      `Hook "${hookName}" is managed by plugin "${hook.pluginId ?? "unknown"}" and cannot be enabled/disabled.`,
-    );
-  }
-  if (opts?.requireEligible && !hook.requirementsSatisfied) {
-    const missing = formatHookMissingSummary(hook, 3);
-    const installHint = hook.install.length
-      ? ` Install options: ${summarizeStringEntries({
-          entries: hook.install.map((option) => option.label),
-          limit: 3,
-        })}.`
-      : "";
-    throw new Error(
-      `Hook "${hookName}" is not eligible; missing ${missing}.${installHint} Run \`${formatCliCommand(`openclaw hooks info ${hookName}`)}\` for details.`,
-    );
-  }
-  return hook;
+  return matches[0];
 }
 
 function writeHooksOutput(value: string, json: boolean | undefined): void {
@@ -215,11 +192,32 @@ async function runOneShotHooksCliAction(
 async function setHookEnabled(hookName: string, enabled: boolean, agentId?: string): Promise<void> {
   const snapshot = await readConfigFileSnapshot();
   const config = (snapshot.sourceConfig ?? snapshot.config) as OpenClawConfig;
-  const hook = resolveHookForToggle(
+  const hook = resolveHookSelection(
     buildHooksReport(config, resolveHooksReportTarget(config, agentId)),
     hookName,
-    { requireEligible: enabled },
   );
+  if (!hook) {
+    throw new Error(
+      `Hook "${hookName}" not found. Run \`${formatCliCommand("openclaw hooks list")}\` to see available hooks.`,
+    );
+  }
+  if (hook.managedByPlugin) {
+    throw new Error(
+      `Hook "${hookName}" is managed by plugin "${hook.pluginId ?? "unknown"}" and cannot be enabled/disabled.`,
+    );
+  }
+  if (enabled && !hook.requirementsSatisfied) {
+    const missing = formatHookMissingSummary(hook, 3);
+    const installHint = hook.install.length
+      ? ` Install options: ${summarizeStringEntries({
+          entries: hook.install.map((option) => option.label),
+          limit: 3,
+        })}.`
+      : "";
+    throw new Error(
+      `Hook "${hookName}" is not eligible; missing ${missing}.${installHint} Run \`${formatCliCommand(`openclaw hooks info ${hookName}`)}\` for details.`,
+    );
+  }
   const entries = { ...config.hooks?.internal?.entries };
   entries[hook.hookKey] = { ...entries[hook.hookKey], enabled };
   const nextConfig: OpenClawConfig = {
@@ -300,8 +298,9 @@ export function registerHooksCli(program: Command): void {
       runOneShotHooksCliAction(async () => {
         const report = await loadHooksReport(resolveHooksAgentOption(command));
         const json = hasJsonOutput(opts);
-        writeHooksOutput(formatHookInfo(report, name, { ...opts, json }), json);
-        return report.hooks.some((hook) => hook.name === name || hook.hookKey === name) ? 0 : 1;
+        const hook = resolveHookSelection(report, name);
+        writeHooksOutput(formatHookInfo(hook, name, { ...opts, json }), json);
+        return hook ? 0 : 1;
       }, "root"),
     );
 


### PR DESCRIPTION
Closes #131075

## What Problem This Solves

Fixes an issue where `openclaw hooks info` reported the wrong hook when a metadata key appeared before an exact name match. Ambiguous keys also produced a successful report instead of explaining which hook to choose, so inspection could disagree with enable/disable.

## Why This Change Was Made

Inspection and toggles now share the existing name-first, ambiguity-aware selector. Inspection resolves once and carries the selected hook to both rendering and exit status; the formatter's separate lookup and the command's separate existence check are removed. Plugin-management and eligibility checks remain with the mutation owner, so inspection remains available for disabled, ineligible, and plugin-managed hooks.

## User Impact

Exact hook names win over key aliases regardless of inventory order. Unique keys still work; ambiguous keys fail with bounded candidates and recovery guidance. The existing missing-hook human output and JSON envelope, including its requested `hook` field, are preserved. Agent/Gateway selection and config-write behavior are unchanged. Ambiguous-key inspection intentionally changes from arbitrary success to an explicit error; callers can use a unique name or key.

## Evidence

Before production edits, **six assertions failed and 130 passed** in the real CLI parser/report fixture: wrong selection and ambiguous success in human, leaf-JSON, and parent-JSON modes. After repair, all136 passed. The final owner/sibling run passed **252 tests across nine files**:

```bash
node scripts/run-vitest.mjs src/cli/hooks-cli.toggle.test.ts src/cli/hooks-cli.test.ts src/hooks/hooks-status.test.ts src/hooks/policy.test.ts src/hooks/workspace.test.ts src/hooks/frontmatter.test.ts src/hooks/config.test.ts src/cli/one-shot-exit.test.ts src/cli/failure-output.test.ts
```

The coordinator also passed **12 public built-CLI cases** with actual `HOOK.md` discovery, temporary HOME/config/state, and a task-owned offline endpoint. Exact-name and unique-key requests succeeded; ambiguous and missing requests exited1 in all three output forms. Handlers were not executed and config bytes remained unchanged. This is real local CLI/discovery proof, not a live remote Gateway claim.

```bash
pnpm check:changed -- src/cli/hooks-cli.ts src/cli/hooks-cli.format.ts src/cli/hooks-cli.test.ts src/cli/hooks-cli.toggle.test.ts docs/cli/hooks.md
```

```bash
OPENCLAW_BUILD_ALL_NO_PNPM=1 node --import tsx scripts/build-all.mts
```

```bash
git diff --check
```

All passed. Full build completed in5m51s with no ineffective-dynamic-import warning. Worker sandbox restrictions initially blocked signature retrieval and socket access; the coordinator closed both gaps through normal local tooling without disabling verification. Independent P1 autoreview found no actionable findings (correct, confidence0.95).

Production **+31/-34, net-3**; tests **+141/-21**; docs **+5/-3**. Existing fixtures were extended and one redundant formatter-only missing-hook test was removed; no new test-only production seam or compatibility wrapper. Latest-main comparison found no drift in the affected owner, hook producers, terminal helpers, or docs before commit.

Provenance: first-match lookup appears in [3a6ee5ee0017](https://github.com/openclaw/openclaw/commit/3a6ee5ee00176c88aee32bb8bfd543780014c079), Git author/committer Peter Steinberger, January17,2026. It was carried forward, not introduced, by [PR127370 — hook failure guidance](https://github.com/openclaw/openclaw/pull/127370), authored/merged by @steipete on August21,2026. Inspected stable-tag source contains the old pattern; no old-tag runtime claim is made.

No schema, protocol, dependency, or configuration option change. Documentation: https://docs.openclaw.ai/cli/hooks. AI-assisted repair; the behavior above is the release-note context.

### Final landing proof

Exact-head [CI33101280796](https://github.com/openclaw/openclaw/actions/runs/33101280796) completed **success** at `0bf3d473cfcf75906b9c235ce94097d9fdb0605e`; the bounded native watcher reported GREEN. The skipped draft run is not evidence. One documented close/reopen recovered CI attachment without changing the head. Native review artifacts are validated, and current-main comparison still shows no affected-owner drift.

Latest ClawSweeper feedback is a review-started placeholder, with no published verdict or Rank-up moves yet. Independent autoreview is clean; no ClawSweeper approval is claimed. The real local CLI proof above does not claim live remote Gateway coverage.
