### PR TITLE
fix(config): reject agents.entries keys that collide after id normalization

### DIFF
--- a/src/config/zod-schema.agents.test.ts
+++ b/src/config/zod-schema.agents.test.ts
@@ -38,6 +38,26 @@ describe("agent roster ownership", () => {
     ).toBe(false);
   });
 
+  it("rejects entry keys that resolve to the same agent id", () => {
+    const result = AgentsSchema.safeParse({
+      ownership: "explicit",
+      entries: { Ops: {}, ops: {} },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]).toMatchObject({
+        path: ["entries", "ops"],
+        message:
+          'agents.entries keys "Ops" and "ops" resolve to the same agent id "ops"; rename one key so each agent has a unique id',
+      });
+    }
+  });
+
+  it("accepts one mixed-case entry key", () => {
+    expect(AgentsSchema.safeParse({ entries: { Ops: {} } }).success).toBe(true);
+  });
+
   it("rejects a legacy marker with explicit ownership", () => {
     expect(
       AgentsSchema.safeParse({

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -1,4 +1,5 @@
 // Defines agent-related Zod schema fragments for config parsing.
+import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { z } from "zod";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
@@ -44,6 +45,20 @@ export const AgentsSchema = z
         code: z.ZodIssueCode.custom,
         path: ["entries"],
         message: "agents.entries must contain at least one configured agent",
+      });
+    }
+    const firstKeyByAgentId = new Map<string, string>();
+    for (const [key] of entries) {
+      const agentId = normalizeAgentId(key);
+      const firstKey = firstKeyByAgentId.get(agentId);
+      if (!firstKey) {
+        firstKeyByAgentId.set(agentId, key);
+        continue;
+      }
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["entries", key],
+        message: `agents.entries keys "${firstKey}" and "${key}" resolve to the same agent id "${agentId}"; rename one key so each agent has a unique id`,
       });
     }
     const marked = entries.filter(([, entry]) => entry.default === true);


### PR DESCRIPTION
## What Problem This Solves

A hand-written `openclaw.json` could define `agents.entries` keys such as `Ops` and `ops`. Validation accepted both keys. Runtime normalization then lowercased both keys to `ops`, exposed one agent, and gave both entries the same state and session identity.

## Root cause

- `src/config/zod-schema.agents.ts` accepts mixed-case roster keys.
- `packages/normalization-core/src/agent-id.ts` defines the canonical agent ID and lowercases it.
- `src/agents/agent-scope-config.ts` deduplicates normalized IDs and returns the first matching entry.
- State, session, gateway, and config-write consumers all use that normalized ID.

The config boundary did not enforce the invariant that each roster key must own one unique canonical agent ID.

## Fix

`AgentsSchema` now records the first key for each canonical ID and rejects later keys that resolve to the same ID. The error names both keys, points to the later key, and tells the operator to rename one key.

A single mixed-case key remains valid. This limits the change to the ambiguous producer state.

## Upgrade behavior

The latest stable roster schema in `v2026.7.1-2` uses `agents.list`. Keyed `agents.entries` rosters have shipped only in beta releases, so they do not require a stable upgrade migration.

Doctor also cannot safely choose which colliding entry owns existing shared state. Rejecting the ambiguous keyed roster before runtime is the deterministic repair.

## Evidence

**Real behavior proof:** On exact current main `009cd5b800a1c4d1d30c104f7214f5fe45189f8e`, `config validate --json` accepted `Ops` plus `ops`, and `agents list --json` exposed one `ops` agent using the first workspace. On exact repaired head `a84367a5612d3d77b4100a2bad749cea028a7da3`, the same config failed at `agents.entries.ops` with:

```text
agents.entries keys "Ops" and "ops" resolve to the same agent id "ops"; rename one key so each agent has a unique id
```

The one-key `Ops` control remained valid on both revisions.

- Regression test: failed on current main for the intended reason, then passed on repaired head.
- `src/config/zod-schema.agents.test.ts`: 19 passed.
- Sibling config tests: 50 passed.
- Targeted formatting, lint, repository ratchets, `git diff --check`, and permitted changed-scope checks passed.
- Hosted CI owns type checking and repository-wide validation.

Production delta: +15 lines. Test delta: +20 lines.
