### PR TITLE
fix(gateway): keep accepted runs stable during runtime refresh

### DIFF
--- a/src/gateway/agent-turn/agent-run-admission-phase.ts
+++ b/src/gateway/agent-turn/agent-run-admission-phase.ts
@@ -14,7 +14,14 @@ import {
   type MainSessionRecoveryPendingTarget,
 } from "../../agents/main-session-recovery/main-session-recovery-store.js";
 import { resolvePersistedOverrideModelRef } from "../../agents/model-selection.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  loadPublishedGatewayReplyDispatchRuntime,
+  type PreparedModelRuntimeLease,
+  type PreparedReplyDispatchRuntime,
+} from "../../agents/prepared-model-runtime.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
+import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawned-context.js";
 import {
   resolveExactSubagentCompletionEvent,
   type TrustedSubagentCompletionHandoff,
@@ -46,10 +53,12 @@ import { formatForLog } from "../ws-log.js";
 import {
   isPreRegistrationAbortedAgentDedupeEntryForSession,
   readGatewayDedupeEntry,
+  setAbortedAgentDedupeEntries,
   setGatewayDedupeEntries,
 } from "./agent-dedupe.js";
 import type { AgentDeliveryPhaseResult } from "./agent-delivery-phase.js";
 import type { RestoredCronContinuation } from "./agent-handler-helpers.js";
+import { resolveAbortedAgentStopReason } from "./agent-run-dispatch.js";
 import {
   prepareAgentRunUserTurn,
   releasePreparedAgentRunUserTurn,
@@ -73,6 +82,9 @@ export type PreparedAgentRunDispatch = {
   dispatchTaskTrackingMode: Exclude<GatewayAgentTaskTrackingMode, "plugin_subagent">;
   unpersistedOffloadedRefs: OffloadedRef[];
   userTurn: PreparedAgentRunUserTurn;
+  replyDispatchRuntime: PreparedReplyDispatchRuntime;
+  preparedModelRuntimeLease: PreparedModelRuntimeLease;
+  workspaceDir?: string;
   restoreAdmittedRestartRecoveryInterrupted?: () => Promise<
     MainSessionRecoveryPendingTarget | undefined
   >;
@@ -496,24 +508,83 @@ export async function prepareAgentRunDispatch(params: {
     params.io.emitAcceptance([false, undefined, errorShapeFromError(ErrorCodes.UNAVAILABLE, err)]);
     return undefined;
   }
-  try {
-    // Transcript persistence can yield. Revalidate the exact live admission
-    // before its durable turn is allowed to cross the acceptance boundary.
-    params.assertGatewayWorkAdmissionAllowed();
-  } catch (err) {
+  const workspaceDir = resolveIngressWorkspaceOverrideForSessionRun({
+    spawnedBy: params.sessionEntry?.spawnedBy,
+    workspaceDir: params.sessionEntry?.spawnedWorkspaceDir,
+    cwd: params.sessionEntry?.spawnedCwd,
+  });
+  let replyDispatchRuntime: PreparedReplyDispatchRuntime;
+  let preparedModelRuntimeLease: PreparedModelRuntimeLease | undefined;
+  const releasePreacceptResources = () => {
+    preparedModelRuntimeLease?.release();
     releasePreparedAgentRunUserTurn(userTurn);
     activeRunAbort.cleanup({ force: true });
+  };
+  let admissionErrorCode: (typeof ErrorCodes)[keyof typeof ErrorCodes] = ErrorCodes.INVALID_REQUEST;
+  try {
+    // Every awaited preparation step must revalidate the exact live admission
+    // before its durable turn is allowed to cross the acceptance boundary.
+    params.assertGatewayWorkAdmissionAllowed();
+    if (params.respondToGatewayAdmissionOutcome()) {
+      releasePreacceptResources();
+      return undefined;
+    }
+    admissionErrorCode = ErrorCodes.UNAVAILABLE;
+    const loadedRuntime = await loadPublishedGatewayReplyDispatchRuntime({
+      agentId: params.activeSessionAgentId,
+      abortSignal: activeRunAbort.controller.signal,
+    });
+    admissionErrorCode = ErrorCodes.INVALID_REQUEST;
+    params.assertGatewayWorkAdmissionAllowed();
+    if (params.respondToGatewayAdmissionOutcome()) {
+      releasePreacceptResources();
+      return undefined;
+    }
+    admissionErrorCode = ErrorCodes.UNAVAILABLE;
+    if (!loadedRuntime?.pluginGeneration) {
+      throw new Error(
+        `prepared reply dispatch runtime was not published for ${params.activeSessionAgentId}`,
+      );
+    }
+    replyDispatchRuntime = loadedRuntime;
+    preparedModelRuntimeLease = await acquireAgentRunPreparedModelRuntime(
+      {
+        config: replyDispatchRuntime.config,
+        agentId: replyDispatchRuntime.agentId,
+        agentDir: replyDispatchRuntime.agentDir,
+        workspaceDir: workspaceDir ?? replyDispatchRuntime.workspaceDir,
+        allowGatewaySubagentBinding: true,
+      },
+      {
+        catalogMode: "static",
+        pluginGeneration: replyDispatchRuntime.pluginGeneration,
+        abortSignal: activeRunAbort.controller.signal,
+      },
+    );
+    admissionErrorCode = ErrorCodes.INVALID_REQUEST;
+    params.assertGatewayWorkAdmissionAllowed();
+  } catch (err) {
+    releasePreacceptResources();
     activeGatewayWorkAdmission.release();
-    params.io.emitAcceptance([
-      false,
-      undefined,
-      errorShapeFromError(ErrorCodes.INVALID_REQUEST, err),
-    ]);
+    if (activeRunAbort.controller.signal.aborted) {
+      setAbortedAgentDedupeEntries({
+        dedupe: params.context.dedupe,
+        keys: params.agentDedupeKeys,
+        agentId: params.activeSessionAgentId,
+        sessionKey: params.resolvedSessionKey,
+        runId: params.runId,
+        stopReason: resolveAbortedAgentStopReason(activeRunAbort.entry),
+      });
+      params.assertGatewayWorkAdmissionAllowed();
+    }
+    if (params.respondToGatewayAdmissionOutcome()) {
+      return undefined;
+    }
+    params.io.emitAcceptance([false, undefined, errorShapeFromError(admissionErrorCode, err)]);
     return undefined;
   }
   if (params.respondToGatewayAdmissionOutcome()) {
-    releasePreparedAgentRunUserTurn(userTurn);
-    activeRunAbort.cleanup({ force: true });
+    releasePreacceptResources();
     return undefined;
   }
   const accepted = {
@@ -568,6 +639,9 @@ export async function prepareAgentRunDispatch(params: {
     dispatchTaskTrackingMode,
     unpersistedOffloadedRefs: userTurn.recorder ? [] : params.offloadedRefs,
     userTurn,
+    replyDispatchRuntime,
+    preparedModelRuntimeLease,
+    workspaceDir,
     restoreAdmittedRestartRecoveryInterrupted,
   };
 }

--- a/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
@@ -1,13 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { startAgentRunExecution } from "./agent-run-execution-phase.js";
 
 const dispatchAgentRunFromGateway = vi.hoisted(() => vi.fn());
+const loadPublishedGatewayReplyDispatchRuntime = vi.hoisted(() =>
+  vi.fn(async () => ({
+    config: { runtime: "late" },
+    pluginGeneration: "late",
+  })),
+);
 
 vi.mock("../../agents/prepared-model-runtime.js", () => ({
-  loadPublishedGatewayReplyDispatchRuntime: async () => ({
-    config: {},
-    pluginGeneration: "test",
-  }),
+  loadPublishedGatewayReplyDispatchRuntime,
 }));
 
 vi.mock("./agent-run-dispatch.js", () => ({
@@ -16,75 +19,140 @@ vi.mock("./agent-run-dispatch.js", () => ({
 }));
 
 describe("startAgentRunExecution Gateway ownership", () => {
-  it("rejects a retired owner after preparation and before final dispatch", async () => {
+  beforeEach(() => {
+    dispatchAgentRunFromGateway.mockReset();
+    loadPublishedGatewayReplyDispatchRuntime.mockReset();
+    loadPublishedGatewayReplyDispatchRuntime.mockResolvedValue({
+      config: { runtime: "late" },
+      pluginGeneration: "late",
+    });
+  });
+
+  function createExecutionParams(
+    options: {
+      assertContextCurrent?: () => void;
+      controller?: AbortController;
+    } = {},
+  ) {
     const cleanup = vi.fn();
-    const release = vi.fn();
-    let resolveFinal!: () => void;
-    const final = new Promise<void>((resolve) => {
-      resolveFinal = resolve;
+    const gatewayRelease = vi.fn();
+    const runtimeRelease = vi.fn();
+    const emitFinal = vi.fn();
+    return {
+      cleanup,
+      gatewayRelease,
+      runtimeRelease,
+      emitFinal,
+      params: {
+        assertContextCurrent: options.assertContextCurrent,
+        prepared: {
+          activeGatewayWorkAdmission: {
+            release: gatewayRelease,
+            run: async (run: () => Promise<void>) => await run(),
+          },
+          activeRunAbort: {
+            cleanup,
+            controller: options.controller ?? new AbortController(),
+            registered: false,
+          },
+          dispatchTaskTrackingMode: "none",
+          effectiveAllowModelOverride: false,
+          lifecycleStorePath: "",
+          operationalRunInstance: {},
+          preparedModelRuntimeLease: { release: runtimeRelease },
+          replyDispatchRuntime: {
+            config: { runtime: "admitted" },
+            pluginGeneration: "admitted",
+          },
+          unpersistedOffloadedRefs: [],
+          userTurn: {
+            execApprovalFollowupHandoffClaimId: "claim",
+            message: "continue",
+            senderIsOwner: false,
+            suppressPromptPersistence: false,
+          },
+          workspaceDir: "/workspace/admitted",
+        },
+        request: {},
+        cfg: {},
+        activeSessionAgentId: "main",
+        delivery: {},
+        isNewSession: false,
+        isRawModelRun: true,
+        isOneShotModelRun: true,
+        isRestartRecoveryResumeRun: false,
+        suppressVisibleSessionEffects: true,
+        images: [],
+        imageOrder: [],
+        media: [],
+        runId: "owner-test",
+        agentDedupeKeys: [],
+        bestEffortDeliver: false,
+        lifecycleGeneration: "test",
+        preserveUserFacingSessionModelState: false,
+        skipAgentInitialSessionTouch: true,
+        canUseInternalRuntimeHandoff: false,
+        client: null,
+        context: {
+          dedupe: new Map(),
+          deps: {},
+          logGateway: { error: vi.fn(), warn: vi.fn() },
+        },
+        io: {
+          emitAcceptance: vi.fn(),
+          emitFinal,
+        },
+        releaseCronContinuationClaimWithRecovery: async () => true,
+      },
+    };
+  }
+
+  it("dispatches with the admitted runtime and releases its lease on completion", async () => {
+    const fixture = createExecutionParams();
+    dispatchAgentRunFromGateway.mockImplementationOnce((params) => {
+      params.cleanupAbortController({ force: true });
     });
 
-    startAgentRunExecution({
+    startAgentRunExecution(fixture.params as never);
+
+    await vi.waitFor(() => expect(dispatchAgentRunFromGateway).toHaveBeenCalledOnce());
+    const dispatched = dispatchAgentRunFromGateway.mock.calls[0]?.[0];
+    expect(dispatched).toMatchObject({
+      commandRuntimeContext: {
+        config: { runtime: "admitted" },
+        pluginGeneration: "admitted",
+      },
+      ingressOpts: { workspaceDir: "/workspace/admitted" },
+    });
+    expect(loadPublishedGatewayReplyDispatchRuntime).not.toHaveBeenCalled();
+    expect(fixture.runtimeRelease).toHaveBeenCalledOnce();
+  });
+
+  it("releases the admitted runtime lease when aborted before dispatch", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const fixture = createExecutionParams({ controller });
+
+    startAgentRunExecution(fixture.params as never);
+
+    await vi.waitFor(() => expect(fixture.emitFinal).toHaveBeenCalledOnce());
+    expect(dispatchAgentRunFromGateway).not.toHaveBeenCalled();
+    expect(fixture.runtimeRelease).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a retired owner after preparation and before final dispatch", async () => {
+    const fixture = createExecutionParams({
       assertContextCurrent: () => {
         throw new Error("Gateway owner retired");
       },
-      prepared: {
-        activeGatewayWorkAdmission: {
-          release,
-          run: async (run: () => Promise<void>) => await run(),
-        },
-        activeRunAbort: {
-          cleanup,
-          controller: new AbortController(),
-          registered: false,
-        },
-        dispatchTaskTrackingMode: "none",
-        effectiveAllowModelOverride: false,
-        lifecycleStorePath: "",
-        operationalRunInstance: {},
-        unpersistedOffloadedRefs: [],
-        userTurn: {
-          execApprovalFollowupHandoffClaimId: "claim",
-          message: "continue",
-          senderIsOwner: false,
-          suppressPromptPersistence: false,
-        },
-      },
-      request: {},
-      cfg: {},
-      activeSessionAgentId: "main",
-      delivery: {},
-      isNewSession: false,
-      isRawModelRun: true,
-      isOneShotModelRun: true,
-      isRestartRecoveryResumeRun: false,
-      suppressVisibleSessionEffects: true,
-      images: [],
-      imageOrder: [],
-      media: [],
-      runId: "owner-retired",
-      agentDedupeKeys: [],
-      bestEffortDeliver: false,
-      lifecycleGeneration: "test",
-      preserveUserFacingSessionModelState: false,
-      skipAgentInitialSessionTouch: true,
-      canUseInternalRuntimeHandoff: false,
-      client: null,
-      context: {
-        dedupe: new Map(),
-        deps: {},
-        logGateway: { error: vi.fn(), warn: vi.fn() },
-      },
-      io: {
-        emitAcceptance: vi.fn(),
-        emitFinal: () => resolveFinal(),
-      },
-      releaseCronContinuationClaimWithRecovery: async () => true,
-    } as never);
+    });
 
-    await final;
-    await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce());
+    startAgentRunExecution(fixture.params as never);
+
+    await vi.waitFor(() => expect(fixture.emitFinal).toHaveBeenCalledOnce());
+    expect(fixture.cleanup).toHaveBeenCalledOnce();
     expect(dispatchAgentRunFromGateway).not.toHaveBeenCalled();
-    expect(release).toHaveBeenCalledOnce();
+    expect(fixture.gatewayRelease).toHaveBeenCalledOnce();
+    expect(fixture.runtimeRelease).toHaveBeenCalledOnce();
   });
 });

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -13,9 +13,7 @@ import {
   type MainSessionRecoveryPendingTarget,
   type MainSessionRecoveryOwnerLease,
 } from "../../agents/main-session-recovery/main-session-recovery-store.js";
-import { loadPublishedGatewayReplyDispatchRuntime } from "../../agents/prepared-model-runtime.js";
 import { resolveScheduledToolPolicyContext } from "../../agents/scheduled-tool-policy.js";
-import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawned-context.js";
 import { isExecutionIdentityCollectionEnabled } from "../../audit/audit-config.js";
 import {
   setChannelSourceTurnId,
@@ -113,10 +111,16 @@ export function startAgentRunExecution(params: {
   const { prepared } = params;
   let unpersistedOffloadedRefs = prepared.unpersistedOffloadedRefs;
   let releaseGatewayRootContinuation = retainGatewayRootWorkAdmissionContinuation() ?? undefined;
+  let releasePreparedModelRuntime: (() => void) | undefined =
+    prepared.preparedModelRuntimeLease.release;
   const cleanupAdmittedRun: typeof prepared.activeRunAbort.cleanup = (options) => {
     const refsToDiscard = unpersistedOffloadedRefs;
     unpersistedOffloadedRefs = [];
     prepared.activeRunAbort.cleanup(options);
+    // Admission transfers this exact generation to execution; every terminal
+    // path converges here so retirement cannot release it twice.
+    releasePreparedModelRuntime?.();
+    releasePreparedModelRuntime = undefined;
     prepared.activeGatewayWorkAdmission.release();
     releaseGatewayRootContinuation?.();
     releaseGatewayRootContinuation = undefined;
@@ -212,15 +216,7 @@ export function startAgentRunExecution(params: {
       const ingressAgentId = params.resolvedSessionKey
         ? params.activeSessionAgentId
         : params.agentId;
-      const replyDispatchRuntime = await loadPublishedGatewayReplyDispatchRuntime({
-        agentId: params.activeSessionAgentId,
-        abortSignal: prepared.activeRunAbort.controller.signal,
-      });
-      if (!replyDispatchRuntime?.pluginGeneration) {
-        throw new Error(
-          `prepared reply dispatch runtime was not published for ${params.activeSessionAgentId}`,
-        );
-      }
+      const replyDispatchRuntime = prepared.replyDispatchRuntime;
       // Plugin-owned additive grants stay internal to the authenticated in-process run.
       // Public agent params cannot supply them, and normal tool policy still filters them.
       const runtimePluginToolGrant =
@@ -425,11 +421,7 @@ export function startAgentRunExecution(params: {
                   prepared.activeRunAbort.entry.sessionId = sessionId;
                 }
               },
-              workspaceDir: resolveIngressWorkspaceOverrideForSessionRun({
-                spawnedBy: params.spawnedBy,
-                workspaceDir: params.sessionEntry?.spawnedWorkspaceDir,
-                cwd: params.sessionEntry?.spawnedCwd,
-              }),
+              workspaceDir: prepared.workspaceDir,
               cwd: resolveSessionRuntimeCwd({
                 requestedCwd: params.request.cwd,
                 sessionEntry: params.sessionEntry,

--- a/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
@@ -3,11 +3,9 @@ import type { WebSocket } from "ws";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import { setRuntimeAuthProfileStoreSnapshot } from "../agents/auth-profiles/runtime-snapshots.js";
-import {
-  loadPublishedGatewayReplyDispatchRuntime,
-  registerPreparedModelRuntimePublicationListener,
-} from "../agents/prepared-model-runtime.js";
+import * as preparedModelRuntime from "../agents/prepared-model-runtime.js";
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
+import * as agentHandlerHelpers from "./agent-turn/agent-handler-helpers.js";
 import { installConnectedSessionStoreGatewaySuite } from "./test-helpers.connected-session-store.js";
 import {
   agentCommandMock,
@@ -90,7 +88,9 @@ async function prepareAuthDispatchAgents(affectedAgentId: string) {
   const config = getRuntimeConfig();
   return {
     agentDir: resolveAgentDir(config, affectedAgentId),
-    runtime: await loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId }),
+    runtime: await preparedModelRuntime.loadPublishedGatewayReplyDispatchRuntime({
+      agentId: affectedAgentId,
+    }),
   };
 }
 
@@ -101,6 +101,94 @@ describe("gateway agent auth refresh dispatch", () => {
 
   afterEach(() => {
     testState.agentsConfig = undefined;
+  });
+
+  test("keeps an accepted run on its runtime while the next run uses the replacement", async () => {
+    const affectedAgentId = "auth-pinned";
+    const admittedRunId = "idem-agent-auth-pinned";
+    const subsequentRunId = "idem-agent-auth-next";
+    const before = await prepareAuthDispatchAgents(affectedAgentId);
+    const acquireRuntimeLease =
+      preparedModelRuntime.acquireAgentRunPreparedModelRuntime.bind(preparedModelRuntime);
+    const acquireSpy = vi
+      .spyOn(preparedModelRuntime, "acquireAgentRunPreparedModelRuntime")
+      .mockImplementation(async (...args) => await acquireRuntimeLease(...args));
+    const executionGate = createDeferred();
+    const executionSpy = vi
+      .spyOn(agentHandlerHelpers, "yieldAfterAgentAcceptedAck")
+      .mockImplementation(async () => await executionGate.promise);
+    const published = createDeferred();
+    const unregister = preparedModelRuntime.registerPreparedModelRuntimePublicationListener(
+      (event) => {
+        if (event.phase === "published") {
+          published.resolve();
+        }
+      },
+    );
+    try {
+      const admitted = sendAgentRpc(gatewaySuite.ws, {
+        agentId: affectedAgentId,
+        runId: admittedRunId,
+      });
+      await admitted.accepted;
+      expect(acquireSpy).toHaveBeenCalledOnce();
+      expect(acquireSpy.mock.calls[0]?.[0]).toMatchObject({
+        config: before.runtime?.config,
+        agentId: before.runtime?.agentId,
+        agentDir: before.runtime?.agentDir,
+      });
+      expect(acquireSpy.mock.calls[0]?.[1]?.pluginGeneration).toBe(
+        before.runtime?.pluginGeneration,
+      );
+
+      setRuntimeAuthProfileStoreSnapshot(
+        {
+          version: 1,
+          profiles: {
+            "anthropic:default": {
+              type: "api_key",
+              provider: "anthropic",
+              key: "replacement-generation-key",
+            },
+          },
+        },
+        before.agentDir,
+      );
+      await published.promise;
+      const after = await preparedModelRuntime.loadPublishedGatewayReplyDispatchRuntime({
+        agentId: affectedAgentId,
+      });
+      expect(after).not.toBe(before.runtime);
+
+      executionGate.resolve();
+      await expect(admitted.final).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "ok" },
+      });
+      expect(acquireSpy).toHaveBeenCalledOnce();
+
+      const subsequent = sendAgentRpc(gatewaySuite.ws, {
+        agentId: affectedAgentId,
+        runId: subsequentRunId,
+      });
+      await subsequent.accepted;
+      await expect(subsequent.final).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "ok" },
+      });
+      expect(acquireSpy).toHaveBeenCalledTimes(2);
+      expect(acquireSpy.mock.calls[1]?.[0]).toMatchObject({
+        config: after?.config,
+        agentId: after?.agentId,
+        agentDir: after?.agentDir,
+      });
+      expect(acquireSpy.mock.calls[1]?.[1]?.pluginGeneration).toBe(after?.pluginGeneration);
+    } finally {
+      executionGate.resolve();
+      unregister();
+      acquireSpy.mockRestore();
+      executionSpy.mockRestore();
+    }
   });
 
   test("aborts one affected waiter without cancelling shared auth publication", async () => {
@@ -122,11 +210,13 @@ describe("gateway agent auth refresh dispatch", () => {
           : await ensureOpenClawModelsJson(config, agentDir, options),
       );
     const published = createDeferred();
-    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
-      if (event.phase === "published") {
-        published.resolve();
-      }
-    });
+    const unregister = preparedModelRuntime.registerPreparedModelRuntimePublicationListener(
+      (event) => {
+        if (event.phase === "published") {
+          published.resolve();
+        }
+      },
+    );
     try {
       setRuntimeAuthProfileStoreSnapshot(
         {
@@ -150,7 +240,17 @@ describe("gateway agent auth refresh dispatch", () => {
         agentId: affectedAgentId,
         runId: waitingRunId,
       });
-      await Promise.all([aborted.accepted, waiting.accepted]);
+      let abortedAccepted = false;
+      let waitingAccepted = false;
+      void aborted.accepted.then(
+        () => {
+          abortedAccepted = true;
+        },
+        () => undefined,
+      );
+      void waiting.accepted.then(() => {
+        waitingAccepted = true;
+      });
       const sibling = sendAgentRpc(gatewaySuite.ws, { agentId: "main", runId: siblingRunId });
       await sibling.accepted;
       await expect(sibling.final).resolves.toMatchObject({ ok: true, payload: { status: "ok" } });
@@ -158,6 +258,9 @@ describe("gateway agent auth refresh dispatch", () => {
       expect(agentCommandCallsFor(abortedRunId)).toHaveLength(0);
       expect(agentCommandCallsFor(waitingRunId)).toHaveLength(0);
       await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(activeWorkBefore + 2));
+      await Promise.resolve();
+      expect(abortedAccepted).toBe(false);
+      expect(waitingAccepted).toBe(false);
 
       const abort = await rpcReq(gatewaySuite.ws, "chat.abort", {
         sessionKey: `agent:${affectedAgentId}:main`,
@@ -183,8 +286,11 @@ describe("gateway agent auth refresh dispatch", () => {
 
       publicationGate.resolve({ agentDir: before.agentDir, wrote: false });
       await published.promise;
-      const after = await loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId });
+      const after = await preparedModelRuntime.loadPublishedGatewayReplyDispatchRuntime({
+        agentId: affectedAgentId,
+      });
       expect(after).not.toBe(before.runtime);
+      await waiting.accepted;
       await expect(waiting.final).resolves.toMatchObject({
         ok: true,
         payload: { status: "ok" },
@@ -205,6 +311,7 @@ describe("gateway agent auth refresh dispatch", () => {
         payload: { status: "ok" },
       });
       expect(agentCommandCallsFor(subsequentRunId)).toHaveLength(1);
+      expect(getActiveGatewayRootWorkCount()).toBe(activeWorkBefore);
     } finally {
       publicationGate.resolve({ agentDir: before.agentDir, wrote: false });
       unregister();
@@ -227,11 +334,13 @@ describe("gateway agent auth refresh dispatch", () => {
         return await ensureOpenClawModelsJson(config, agentDir, options);
       });
     const failed = createDeferred();
-    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
-      if (event.phase === "failed") {
-        failed.resolve();
-      }
-    });
+    const unregister = preparedModelRuntime.registerPreparedModelRuntimePublicationListener(
+      (event) => {
+        if (event.phase === "failed") {
+          failed.resolve();
+        }
+      },
+    );
     try {
       setRuntimeAuthProfileStoreSnapshot(
         {
@@ -248,19 +357,21 @@ describe("gateway agent auth refresh dispatch", () => {
       );
       await failed.promise;
       await expect(
-        loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId }),
+        preparedModelRuntime.loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId }),
       ).rejects.toThrow(
         `prepared reply dispatch runtime owner was not published for ${affectedAgentId}`,
       );
 
       const dispatched = sendAgentRpc(gatewaySuite.ws, { agentId: affectedAgentId, runId });
-      await expect(dispatched.accepted).resolves.toMatchObject({
-        ok: true,
-        payload: { status: "accepted" },
-      });
+      let accepted = false;
+      void dispatched.accepted.then(
+        () => {
+          accepted = true;
+        },
+        () => undefined,
+      );
       await expect(dispatched.final).resolves.toMatchObject({
         ok: false,
-        payload: { status: "error" },
         error: {
           code: "UNAVAILABLE",
           message: expect.stringContaining(
@@ -268,6 +379,8 @@ describe("gateway agent auth refresh dispatch", () => {
           ),
         },
       });
+      await Promise.resolve();
+      expect(accepted).toBe(false);
       expect(agentCommandCallsFor(runId)).toHaveLength(0);
     } finally {
       unregister();


### PR DESCRIPTION
Related: #127850

## What Problem This Solves

Fixes an issue where an agent run accepted immediately before an auth/runtime refresh could execute with the replacement runtime generation instead of the generation that admitted the run.

## Why This Change Was Made

Gateway admission now resolves the persisted workspace override, loads the published reply runtime, acquires an exact-generation prepared-model-runtime lease, and revalidates admission after each await before acknowledging acceptance. Execution consumes those prepared facts directly, with no late runtime/workspace lookup, retry, or fallback; the existing execution cleanup owner releases the transferred lease exactly once.

Preaccept cancellation keeps the landed queue-timeout response contract from #127850. The open collision branches were checked: #130986 still records participants after acceptance, and #130579's `execTarget` work is unrelated.

## User Impact

Runs accepted during credential or runtime publication changes remain internally consistent: the accepted run finishes on its admitted generation, the next run uses the replacement, cancelled waiters do not cancel shared publication, and unaffected agents continue dispatching normally.

## Evidence

- Pre-fix exact-order reproduction on `608e365ce485`: `accepted=A rotation=B executionLookup=B admittedRuntimePreserved=false`.
- Exact PR-head W4 harness on `8b49703684b0`: 1/1 passed with `accepted=A rotation=B execution=A next=B admittedRuntimePreserved=true`.
- Focused exact-head Gateway/owner proof on `715859aacb1`: 6/6 tests passed.
- Prepared-runtime lifecycle, auth-reload, inbound-registry, and owner-selection proof: 87/87 tests passed; execution ownership proof: 3/3.
- Production typecheck and touched-file lint passed.
- `check:changed` passed every emitted gate through production typecheck, then hit the known baseline missing `pako` declaration in `ui/vite.config.ts`.
- Remaining emitted guards passed directly: native schema, database-first storage, media helpers, runtime sidecars, import cycles, webhook auth ordering, and pairing auth/account scope.
- `test:changed` passed 6,959 fast tests, 1,261 isolated tests, and 148 fake-timer tests before one unrelated rollback-journal race assertion and a later Vitest worker exit. The exact failed state suite passed 23/23 on both this branch and exact main, so neither outcome is a W4 regression.
- Removed execution-time paths: published-runtime reload and persisted-workspace re-resolution.
- LOC: production `+93/-26` (net `+67`); tests `+268/-88` (net `+180`). Production growth is the admission-owned runtime/lease transfer and preaccept cancellation preservation; it remains below the approved `+100` hard cap.
