### PR TITLE
fix(auto-reply): bound fence reopen headers so chunks respect the limit

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -523,7 +523,7 @@ describe("chunkMarkdownText", () => {
         for (const chunk of chunks) {
           expect(chunk.length).toBeLessThanOrEqual(4000);
         }
-        expect(chunks.join("").replaceAll("\`", "").replaceAll("\n", "")).toBe(payload);
+        expect(chunks.join("").replaceAll("`", "").replaceAll("\n", "")).toBe(payload);
         expectFencesBalanced(chunks);
       },
     },
@@ -532,7 +532,7 @@ describe("chunkMarkdownText", () => {
       run: () => {
         const chunks = chunkMarkdownText(`\`\`\`${"A".repeat(4200)}\n\`\`\``, 2000);
         expect(chunks.length).toBeLessThanOrEqual(4);
-        expect(requireChunk(chunks, 1).startsWith("\`\`\`\n")).toBe(true);
+        expect(requireChunk(chunks, 1).startsWith("```\n")).toBe(true);
         for (const chunk of chunks) {
           expect(chunk.length).toBeLessThanOrEqual(2000);
         }
@@ -542,12 +542,31 @@ describe("chunkMarkdownText", () => {
     {
       name: "keeps the full opening line when it fits the reopen budget",
       run: () => {
-        const chunks = chunkMarkdownText(`\`\`\`js\n${"const a = 1;\n".repeat(80)}\`\`\``, 200);
+        const openLine = `\`\`\`language-${"A".repeat(1_488)}`;
+        const chunks = chunkMarkdownText(`${openLine}\n${"x".repeat(1_200)}\n\`\`\``, 2_000);
         expect(chunks.length).toBeGreaterThan(1);
         for (const chunk of chunks.slice(1)) {
-          expect(chunk.startsWith("\`\`\`js\n")).toBe(true);
+          expect(chunk.startsWith(`${openLine}\n`)).toBe(true);
         }
+        expect(chunks.every((chunk) => chunk.length <= 2_000)).toBe(true);
         expectFencesBalanced(chunks);
+      },
+    },
+    {
+      name: "keeps the hard limit when synthetic fence balancing cannot fit",
+      run: () => {
+        const text = `\`\`\`\n${"x".repeat(20)}\n\`\`\``;
+        for (const limit of [5, 6, 8]) {
+          const chunks = chunkMarkdownText(text, limit);
+          expect(
+            chunks.every((chunk) => chunk.length <= limit),
+            `limit ${limit}`,
+          ).toBe(true);
+          expect(chunks.length, `limit ${limit}`).toBeLessThanOrEqual(
+            Math.ceil(text.length / limit),
+          );
+          expect(chunks.join(""), `limit ${limit}`).toBe(text);
+        }
       },
     },
   ] as const)("$name", ({ run }) => {

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -524,7 +524,7 @@ describe("chunkMarkdownText", () => {
           expect(chunk.length).toBeLessThanOrEqual(4000);
         }
         expect(chunks.join("").replaceAll("`", "").replaceAll("\n", "")).toBe(payload);
-        expectFencesBalanced(chunks);
+        expectFencesBalanced(chunks.slice(1));
       },
     },
     {
@@ -536,7 +536,7 @@ describe("chunkMarkdownText", () => {
         for (const chunk of chunks) {
           expect(chunk.length).toBeLessThanOrEqual(2000);
         }
-        expectFencesBalanced(chunks);
+        expectFencesBalanced(chunks.slice(1));
       },
     },
     {
@@ -567,6 +567,18 @@ describe("chunkMarkdownText", () => {
           );
           expect(chunks.join(""), `limit ${limit}`).toBe(text);
         }
+      },
+    },
+    {
+      name: "does not emit a header-only fence at the reopen budget boundary",
+      run: () => {
+        const limit = 20;
+        const openLine = `\`\`\`${"x".repeat(limit - 8)}`;
+        const text = `${openLine}\nbody-content-long\n\`\`\``;
+        const chunks = chunkMarkdownText(text, limit);
+
+        expect(chunks.every((chunk) => chunk.length <= limit)).toBe(true);
+        expectNoEmptyFencedChunks(text, limit);
       },
     },
   ] as const)("$name", ({ run }) => {

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -514,6 +514,42 @@ describe("chunkMarkdownText", () => {
         expectFenceParseOccursOnce(`\`\`\`txt\n${"line\n".repeat(600)}\`\`\``, 80);
       },
     },
+    {
+      name: "keeps chunks within the limit when a fence opening line exceeds it",
+      run: () => {
+        const payload = `token.${"A".repeat(4200)}`;
+        const chunks = chunkMarkdownText(`\`\`\`${payload}\n\`\`\``, 4000);
+        expect(chunks.length).toBeLessThanOrEqual(3);
+        for (const chunk of chunks) {
+          expect(chunk.length).toBeLessThanOrEqual(4000);
+        }
+        expect(chunks.join("").replaceAll("\`", "").replaceAll("\n", "")).toBe(payload);
+        expectFencesBalanced(chunks);
+      },
+    },
+    {
+      name: "reopens an oversized fence opening line with the bare marker",
+      run: () => {
+        const chunks = chunkMarkdownText(`\`\`\`${"A".repeat(4200)}\n\`\`\``, 2000);
+        expect(chunks.length).toBeLessThanOrEqual(4);
+        expect(requireChunk(chunks, 1).startsWith("\`\`\`\n")).toBe(true);
+        for (const chunk of chunks) {
+          expect(chunk.length).toBeLessThanOrEqual(2000);
+        }
+        expectFencesBalanced(chunks);
+      },
+    },
+    {
+      name: "keeps the full opening line when it fits the reopen budget",
+      run: () => {
+        const chunks = chunkMarkdownText(`\`\`\`js\n${"const a = 1;\n".repeat(80)}\`\`\``, 200);
+        expect(chunks.length).toBeGreaterThan(1);
+        for (const chunk of chunks.slice(1)) {
+          expect(chunk.startsWith("\`\`\`js\n")).toBe(true);
+        }
+        expectFencesBalanced(chunks);
+      },
+    },
   ] as const)("$name", ({ run }) => {
     expectChunkSpecialCase(run);
   });

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -411,6 +411,8 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
       break;
     }
 
+    // A reopen applies to one continuation; the split below records the next one.
+    reopenFence = undefined;
     const windowEnd = Math.min(text.length, start + contentLimit);
     const softBreak = pickSafeBreakIndex(text, start, windowEnd, spans);
     let breakIdx = softBreak > start ? softBreak : windowEnd;
@@ -427,9 +429,12 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
         fenceToSplit = undefined;
       } else {
         const maxIdxIfNeedNewline = start + (contentLimit - (closeLine.length + 1));
+        // A synthetic reopen makes any remaining physical opener bytes continuation body.
         const minProgressIdx = Math.min(
           text.length,
-          Math.max(start + 1, initialFence.start + initialFence.openLine.length + 2),
+          reopenPrefix
+            ? start + 1
+            : Math.max(start + 1, initialFence.start + initialFence.openLine.length + 2),
         );
         const maxIdxIfAlreadyNewline = start + (contentLimit - closeLine.length);
 
@@ -449,17 +454,18 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
           lastNewline = text.lastIndexOf("\n", lastNewline - 1);
         }
 
-        if (!pickedNewline) {
-          if (minProgressIdx >= maxIdxIfAlreadyNewline) {
-            breakIdx = maxIdxIfNeedNewline;
-          } else {
+        if (!pickedNewline && minProgressIdx >= maxIdxIfAlreadyNewline) {
+          breakIdx = windowEnd;
+          fenceToSplit = undefined;
+          reopenFence = initialFence;
+        } else {
+          if (!pickedNewline) {
             breakIdx = Math.max(minProgressIdx, maxIdxIfNeedNewline);
           }
+          const fenceAtBreak = findFenceSpanAt(spans, breakIdx);
+          fenceToSplit =
+            fenceAtBreak && fenceAtBreak.start === initialFence.start ? fenceAtBreak : undefined;
         }
-
-        const fenceAtBreak = findFenceSpanAt(spans, breakIdx);
-        fenceToSplit =
-          fenceAtBreak && fenceAtBreak.start === initialFence.start ? fenceAtBreak : undefined;
       }
     }
 
@@ -485,14 +491,11 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
       const closeLine = `${fenceToSplit.indent}${fenceToSplit.marker}`;
       rawChunk = rawChunk.endsWith("\n") ? `${rawChunk}${closeLine}` : `${rawChunk}\n${closeLine}`;
       reopenFence = fenceToSplit;
-    } else {
+    } else if (!initialFence) {
       // Only prose separators are disposable; fenced whitespace can be code indentation.
-      if (!initialFence) {
-        const brokeOnSeparator = breakIdx < text.length && /\s/.test(text.charAt(breakIdx));
-        nextStart = Math.min(text.length, breakIdx + (brokeOnSeparator ? 1 : 0));
-        nextStart = skipLeadingNewlines(text, nextStart);
-      }
-      reopenFence = undefined;
+      const brokeOnSeparator = breakIdx < text.length && /\s/.test(text.charAt(breakIdx));
+      nextStart = Math.min(text.length, breakIdx + (brokeOnSeparator ? 1 : 0));
+      nextStart = skipLeadingNewlines(text, nextStart);
     }
 
     chunks.push(rawChunk);

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -422,12 +422,11 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
     let fenceToSplit = initialFence;
     if (initialFence) {
       const closeLine = `${initialFence.indent}${initialFence.marker}`;
-      const maxIdxIfNeedNewline = start + (contentLimit - (closeLine.length + 1));
-
-      if (maxIdxIfNeedNewline <= start) {
+      if (!resolveFenceReopenLine(initialFence, normalizedLimit)) {
         breakIdx = windowEnd;
         fenceToSplit = undefined;
       } else {
+        const maxIdxIfNeedNewline = start + (contentLimit - (closeLine.length + 1));
         const minProgressIdx = Math.min(
           text.length,
           Math.max(start + 1, initialFence.start + initialFence.openLine.length + 2),
@@ -451,7 +450,7 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
         }
 
         if (!pickedNewline) {
-          if (minProgressIdx > maxIdxIfAlreadyNewline) {
+          if (minProgressIdx >= maxIdxIfAlreadyNewline) {
             breakIdx = maxIdxIfNeedNewline;
           } else {
             breakIdx = Math.max(minProgressIdx, maxIdxIfNeedNewline);
@@ -488,9 +487,11 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
       reopenFence = fenceToSplit;
     } else {
       // Only prose separators are disposable; fenced whitespace can be code indentation.
-      const brokeOnSeparator = breakIdx < text.length && /\s/.test(text.charAt(breakIdx));
-      nextStart = Math.min(text.length, breakIdx + (brokeOnSeparator ? 1 : 0));
-      nextStart = skipLeadingNewlines(text, nextStart);
+      if (!initialFence) {
+        const brokeOnSeparator = breakIdx < text.length && /\s/.test(text.charAt(breakIdx));
+        nextStart = Math.min(text.length, breakIdx + (brokeOnSeparator ? 1 : 0));
+        nextStart = skipLeadingNewlines(text, nextStart);
+      }
       reopenFence = undefined;
     }
 
@@ -504,12 +505,12 @@ function resolveFenceReopenLine(
   fence: NonNullable<ReturnType<typeof findFenceSpanAt>>,
   limit: number,
 ): string {
-  const budget = Math.floor(limit / 2);
-  if (fence.openLine.length + 1 <= budget) {
+  const markerLine = `${fence.indent}${fence.marker}`;
+  // Reserve the closing marker, two newlines, and one body character.
+  if (fence.openLine.length + markerLine.length + 3 <= limit) {
     return fence.openLine;
   }
-  const markerLine = `${fence.indent}${fence.marker}`;
-  return markerLine.length + 1 <= budget ? markerLine : "";
+  return markerLine.length * 2 + 3 <= limit ? markerLine : "";
 }
 
 function skipLeadingNewlines(value: string, start = 0): number {

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -400,7 +400,8 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
   let reopenFence: ReturnType<typeof findFenceSpanAt> | undefined;
 
   while (start < text.length) {
-    const reopenPrefix = reopenFence ? `${reopenFence.openLine}\n` : "";
+    const reopenLine = reopenFence ? resolveFenceReopenLine(reopenFence, normalizedLimit) : "";
+    const reopenPrefix = reopenLine ? `${reopenLine}\n` : "";
     const contentLimit = Math.max(1, normalizedLimit - reopenPrefix.length);
     if (text.length - start <= contentLimit) {
       const finalChunk = `${reopenPrefix}${text.slice(start)}`;
@@ -425,6 +426,7 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
 
       if (maxIdxIfNeedNewline <= start) {
         breakIdx = windowEnd;
+        fenceToSplit = undefined;
       } else {
         const minProgressIdx = Math.min(
           text.length,
@@ -450,16 +452,16 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
 
         if (!pickedNewline) {
           if (minProgressIdx > maxIdxIfAlreadyNewline) {
-            breakIdx = windowEnd;
+            breakIdx = maxIdxIfNeedNewline;
           } else {
             breakIdx = Math.max(minProgressIdx, maxIdxIfNeedNewline);
           }
         }
-      }
 
-      const fenceAtBreak = findFenceSpanAt(spans, breakIdx);
-      fenceToSplit =
-        fenceAtBreak && fenceAtBreak.start === initialFence.start ? fenceAtBreak : undefined;
+        const fenceAtBreak = findFenceSpanAt(spans, breakIdx);
+        fenceToSplit =
+          fenceAtBreak && fenceAtBreak.start === initialFence.start ? fenceAtBreak : undefined;
+      }
     }
 
     const safeBreakIdx = avoidTrailingHighSurrogateBreak(text, start, breakIdx);
@@ -496,6 +498,18 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
     start = nextStart;
   }
   return chunks;
+}
+
+function resolveFenceReopenLine(
+  fence: NonNullable<ReturnType<typeof findFenceSpanAt>>,
+  limit: number,
+): string {
+  const budget = Math.floor(limit / 2);
+  if (fence.openLine.length + 1 <= budget) {
+    return fence.openLine;
+  }
+  const markerLine = `${fence.indent}${fence.marker}`;
+  return markerLine.length + 1 <= budget ? markerLine : "";
 }
 
 function skipLeadingNewlines(value: string, start = 0): number {


### PR DESCRIPTION
## What Problem This Solves

A fenced Markdown reply can exceed the channel chunk limit when its opening line is very long. The old planner repeats that unbounded line on every continuation, advances by one source character, and sends oversized messages that transports can reject.

## Why This Change Was Made

`chunkMarkdownText` is the shared owner used by Telegram, Feishu, Zalo, and other channel paths. It now budgets the reopen line against the real closing marker, two newline delimiters, and one body character.

- Keep the full opening line when it fits safely.
- Use the bare fence marker when the full line does not fit.
- Emit raw bounded slices when synthetic fence balancing cannot fit at all.
- Keep fenced whitespace and make useful source progress in every case.

This follows the existing Discord fence-budget rule without adding channel-specific policy to core.

When a configured limit cannot fit an opener, body character, and closer, raw bounded slices intentionally preserve source bytes and the transport limit. Independently balanced rendering is impossible at that limit, and a rejected message is worse than degraded formatting.

## User Impact

Long fenced replies no longer expand into hundreds of oversized sends. Valid continuation fences keep their language header when the complete balanced chunk fits.

## Evidence

Live Telegram Test Server proof used the same 4,200-character fence header at a 4,000-character chunk limit.

- Current main `c203fc3fb33dc36627212dcdaa27d2b1d57fcc8f`: planned 243 chunks; Telegram accepted a 4,004-character first message, rejected the 4,215-character continuation with HTTP 400, and never delivered the unique tail marker.
- Proven head `a005e4da7394acef9603297c0dbd4736a8bc7916`: planned two chunks of 4,000 and 246 characters; Telegram accepted both with HTTP 200, and the second message contained the unique tail marker.
- At the 20-character equality boundary, the repaired head planned three chunks of 20, 20, and 12 characters; Telegram accepted all three, the first contained body text, and the second contained the unique marker.
- Current head `6cd116d0d5f6f9e6542598924d8c1e6d14ae1ff5` is a base-only rebase with the same stable patch ID `d6e726b6a4f6bdbe94915aaa005b7c98db0860ef`.

Focused validation:

- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/chunk.test.ts` — 91 passed
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/telegram/src/telegram-outbound.test.ts` — 20 passed
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/discord/src/chunk.test.ts` — 40 passed
- Oxfmt, Oxlint, max-lines ratchet, assertion-safety ratchet, conflict-marker check, and `git diff --check` passed
- Deterministic sweep: 720 fence-marker, header, and limit combinations; zero oversized chunks

Production delta is +18 lines. The growth adds one shared owner-level budget rule, preserves source bytes when balanced fences cannot fit, and avoids header-only chunks at the equality boundary. Tests add 67 lines.
