### PR TITLE
fix: worktree option missing when starting a session on a new GitHub repo

### DIFF
--- a/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
@@ -13,8 +13,100 @@ import {
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
+const remoteSearchResult = {
+  credential: "missing",
+  projects: [
+    {
+      name: "openclaw",
+      fullName: "openclaw/openclaw",
+      description: "Personal AI assistant",
+      cloneUrl: "https://github.com/openclaw/openclaw.git",
+      webUrl: "https://github.com/openclaw/openclaw",
+      private: false,
+    },
+  ],
+};
 
 suite.define(() => {
+  it("offers a worktree for a GitHub result and materializes its project before session creation", async () => {
+    await prepareProjectUiProof();
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        ...(captureUiProofEnabled
+          ? {
+              recordVideo: { dir: projectProofArtifactDir, size: { height: 900, width: 1280 } },
+              viewport: { height: 900, width: 1280 },
+            }
+          : {}),
+      },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          workspace: WORKSPACE,
+          workspaceGit: false,
+          featureMethods: [
+            "chat.metadata",
+            "chat.startup",
+            "projects.add",
+            "projects.list",
+            "projects.searchRemote",
+            "sessions.create",
+          ],
+          methodResponses: {
+            "projects.list": { projects: [] },
+            "projects.searchRemote": remoteSearchResult,
+            "projects.add": { id: "cloned-worktree-project" },
+            "sessions.create": { key: "agent:main:github-worktree-e2e" },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}new`);
+        await gateway.waitForRequest("projects.list");
+        await page.locator("#new-session-project-trigger").click();
+        const projects = page.locator("wa-popover.new-session-page__project-popover");
+        await projects
+          .getByRole("searchbox", { name: "Search projects or paste a Git URL" })
+          .fill("openclaw");
+        await projects.getByRole("button", { name: /openclaw\/openclaw/u }).click();
+
+        await captureProjectUiProof(page, "github-worktree-direct.png");
+        const detail = page.locator("#new-session-detail-trigger");
+        await expect.poll(() => detail.isVisible()).toBe(true);
+        await pollLocatorText(detail).toContain("Runs directly");
+        await detail.click();
+        const branches = page.locator("wa-popover.new-session-page__detail-popover");
+        await branches.getByRole("button", { name: "Worktree", exact: true }).click();
+        await expect.poll(() => detail.getAttribute("data-worktree")).toBe("true");
+        const baseRef = branches.getByLabel("Base branch");
+        expect(await baseRef.getAttribute("placeholder")).toBe("Base branch");
+        expect(await baseRef.inputValue()).toBe("");
+        expect(await branches.locator("datalist option").count()).toBe(0);
+        await captureProjectUiProof(page, "github-worktree-selected.png");
+        await page.locator(".new-session-page__message").fill("inspect the worktree");
+        await page.getByRole("button", { name: "Start session" }).click();
+
+        const create = await gateway.waitForRequest("sessions.create");
+        expect(create.params).toMatchObject({
+          projectId: "cloned-worktree-project",
+          worktree: true,
+          message: "inspect the worktree",
+        });
+        expect(create.params).not.toHaveProperty("projectGitUrl");
+        expect(create.params).not.toHaveProperty("worktreeBaseRef");
+        const materialization = (await gateway.getRequests()).filter(
+          (request) => request.method === "projects.add" || request.method === "sessions.create",
+        );
+        expect(materialization.map((request) => request.method)).toEqual([
+          "projects.add",
+          "sessions.create",
+        ]);
+        expect(materialization[0]?.params).toEqual({
+          gitUrl: "https://github.com/openclaw/openclaw.git",
+        });
+      },
+    );
+  });
+
   it.each([
     { name: "shows workspace preparation in the admitted session", failure: null },
     {
@@ -98,19 +190,7 @@ suite.define(() => {
       ],
       methodResponses: {
         "projects.list": { projects: [] },
-        "projects.searchRemote": {
-          credential: "missing",
-          projects: [
-            {
-              name: "openclaw",
-              fullName: "openclaw/openclaw",
-              description: "Personal AI assistant",
-              cloneUrl: "https://github.com/openclaw/openclaw.git",
-              webUrl: "https://github.com/openclaw/openclaw",
-              private: false,
-            },
-          ],
-        },
+        "projects.searchRemote": remoteSearchResult,
         "worktrees.branches": {
           branches: [{ kind: "local", name: "main" }],
           defaultBranch: "main",

--- a/ui/src/pages/new-session/discovery.ts
+++ b/ui/src/pages/new-session/discovery.ts
@@ -20,6 +20,9 @@ export type DraftBranches = {
 
 export type DraftRepositoryState =
   | { kind: "idle" }
+  // Selected GitHub project is git by construction; projects.add materializes
+  // its checkout before sessions.create runs.
+  | { kind: "pending-clone"; cloneUrl: string }
   | { kind: "checking"; repoRoot: string }
   | ({ kind: "git" } & DraftBranches)
   | { kind: "direct"; repoRoot: string }

--- a/ui/src/pages/new-session/draft-place-state.test.ts
+++ b/ui/src/pages/new-session/draft-place-state.test.ts
@@ -1,8 +1,147 @@
 import { describe, expect, it, vi } from "vitest";
+import type { ApplicationContext } from "../../app/context.ts";
 import type { DraftCloudProfile } from "./discovery.ts";
 import type { DraftGatewayState } from "./draft-gateway-state.ts";
-import type { DraftPlaceBrowser } from "./draft-place-browser.ts";
+import { DraftPlaceBrowser } from "./draft-place-browser.ts";
 import { DraftPlaceState } from "./draft-place-state.ts";
+import { TestReactiveControllerHost } from "./reactive-controller-host.test-support.ts";
+
+const REMOTE_PROJECT = {
+  identity: "openclaw/openclaw",
+  cloneUrl: "https://github.com/openclaw/openclaw.git",
+};
+
+function createRepositoryFixture() {
+  const requestUpdate = vi.fn();
+  const persistPreference = vi.fn();
+  const readPreference = vi.fn(() => ({ worktree: true }));
+  const request = vi.fn(async (method: string) =>
+    method === "fs.listDir"
+      ? { path: "/plain", entries: [] }
+      : { repositoryStatus: "not_git", branches: [] },
+  );
+  const context = {
+    gateway: {
+      snapshot: {
+        phase: "connected",
+        client: { request },
+        hello: { auth: { role: "operator", scopes: ["operator.admin"] } },
+      },
+    },
+    agents: {
+      state: {
+        agentsList: {
+          defaultId: "main",
+          agents: [{ id: "main", workspace: "/workspace", workspaceGit: false }],
+        },
+      },
+    },
+    sessions: { state: { result: null } },
+  } as unknown as ApplicationContext;
+  const gateway = {
+    cloudProfiles: [{ id: "aws", providerId: "crabbox" }],
+    environments: [
+      {
+        id: "node:desktop",
+        type: "node",
+        status: "available",
+        sessionHost: true,
+        workerSlots: { total: 1, available: 1 },
+      },
+    ],
+    persistPreference,
+    readPreference,
+  } as unknown as DraftGatewayState;
+  const browser = new DraftPlaceBrowser(
+    new TestReactiveControllerHost(),
+    gateway,
+    () => ({ context, isAdmin: true }),
+    {
+      requestUpdate,
+      onProjectMissing: vi.fn(),
+      onSelectProject: vi.fn(),
+      onApprovedListing: vi.fn(),
+      querySelector: () => null,
+      activeElement: () => null,
+      body: () => null,
+    },
+  );
+  const state = new DraftPlaceState(
+    gateway,
+    browser,
+    () => ({ context, data: undefined, submitting: false, pendingPlacementSessionKey: "" }),
+    { requestUpdate, onError: vi.fn(), onClearError: vi.fn() },
+  );
+  return { state, browser, persistPreference, requestUpdate };
+}
+
+describe("DraftPlaceState repository selection", () => {
+  it("offers remote-project worktrees locally without resetting the typed base branch on toggle", () => {
+    const { state } = createRepositoryFixture();
+    state.selectRemoteProject(REMOTE_PROJECT);
+
+    expect(state.repository).toEqual({ kind: "pending-clone", cloneUrl: REMOTE_PROJECT.cloneUrl });
+    expect(state.worktreeAvailable()).toBe(true);
+    expect(state.worktree).toBe(false);
+    state.toggleWorktree();
+    expect(state.worktree).toBe(true);
+    state.setBaseRef("release");
+    state.toggleWorktree();
+    state.toggleWorktree();
+    expect(state.worktree).toBe(true);
+    expect(state.baseRef).toBe("release");
+  });
+
+  it.each(["device", "cloud"] as const)(
+    "preserves a remote project and enables worktree when switching to %s placement",
+    (placement) => {
+      const { state, browser } = createRepositoryFixture();
+      state.selectRemoteProject(REMOTE_PROJECT);
+      state.setBaseRef("release");
+      if (placement === "device") {
+        state.selectDevice("desktop");
+        expect(state.deviceId).toBe("desktop");
+      } else {
+        state.selectCloudProfile("aws");
+        expect(state.cloudProfileId).toBe("aws");
+      }
+      expect(browser.remoteProject).toEqual(REMOTE_PROJECT);
+      expect(state.worktree).toBe(true);
+      expect(state.baseRef).toBe("release");
+    },
+  );
+
+  it.each(["/workspace", "/plain"])(
+    "rejects and persists worktree off for a non-git folder %s",
+    async (folder) => {
+      const { state, persistPreference, requestUpdate } = createRepositoryFixture();
+      state.adoptAgentDefaults();
+      state.applyFolder(folder);
+      await vi.waitFor(() => expect(state.repository.kind).toBe("direct"));
+      persistPreference.mockClear();
+      requestUpdate.mockClear();
+
+      state.toggleWorktree();
+
+      await vi.waitFor(() => expect(state.worktree).toBe(false));
+      expect(state.worktreeAvailable()).toBe(false);
+      expect(persistPreference).toHaveBeenLastCalledWith("main", "/workspace", {
+        worktree: false,
+      });
+      expect(requestUpdate).toHaveBeenCalled();
+    },
+  );
+
+  it("restores a preferred worktree when a remote project awaits cloning", () => {
+    const { state, browser } = createRepositoryFixture();
+    browser.selectProject({ kind: "remote", project: REMOTE_PROJECT });
+
+    state.adoptAgentDefaults();
+
+    expect(state.worktree).toBe(true);
+    expect(state.placementPreferenceReady).toBe(true);
+  });
+});
 
 describe("DraftPlaceState cloud machine selection", () => {
   it("uses each profile default and retains only non-default overrides per destination", () => {

--- a/ui/src/pages/new-session/draft-place-state.ts
+++ b/ui/src/pages/new-session/draft-place-state.ts
@@ -68,7 +68,7 @@ export class DraftPlaceState {
       () => ({
         remotePlacement: this.remotePlacement,
         selectedProject: this.browser.selectedProject(),
-        remoteProjectSelected: Boolean(this.browser.remoteProject),
+        remoteProject: this.browser.remoteProject,
         folder: this.folderValue,
         workspace: this.workspacePath(),
         workspaceGit: this.selectedAgent()?.workspaceGit === true,

--- a/ui/src/pages/new-session/draft-repository-state.ts
+++ b/ui/src/pages/new-session/draft-repository-state.ts
@@ -5,11 +5,12 @@ import type {
 import type { ApplicationContext } from "../../app/context.ts";
 import type { DraftRepositoryState } from "./discovery.ts";
 import type { NewSessionPreference } from "./preferences.ts";
+import type { DraftRemoteProject } from "./project-chip.ts";
 
 type DraftRepositorySnapshot = Readonly<{
   remotePlacement: boolean;
   selectedProject: ProjectRecord | undefined;
-  remoteProjectSelected: boolean;
+  remoteProject: DraftRemoteProject | null;
   folder: string;
   workspace: string;
   workspaceGit: boolean;
@@ -20,6 +21,31 @@ type DraftRepositoryCallbacks = {
   requestUpdate: () => void;
   persistPreference: (patch: NewSessionPreference) => void;
 };
+
+type RepositoryRestore = { worktree: boolean; baseRef: string; baseRefEditGeneration: number };
+type ResolvedRepository = Exclude<DraftRepositoryState, { kind: "checking" }>;
+
+function planRepositoryDiscovery(
+  snapshot: DraftRepositorySnapshot,
+):
+  | { plan: "none" }
+  | { plan: "resolved"; state: ResolvedRepository }
+  | { plan: "check"; repoRoot: string } {
+  if (snapshot.remoteProject) {
+    return {
+      plan: "resolved",
+      state: { kind: "pending-clone", cloneUrl: snapshot.remoteProject.cloneUrl },
+    };
+  }
+  const repoRoot =
+    snapshot.selectedProject?.repoRoot ?? (snapshot.folder.trim() || snapshot.workspace);
+  if (!repoRoot || (snapshot.selectedProject && !snapshot.selectedProject.repoRoot)) {
+    return { plan: "none" };
+  }
+  return !snapshot.selectedProject && repoRoot === snapshot.workspace && !snapshot.workspaceGit
+    ? { plan: "resolved", state: { kind: "direct", repoRoot } }
+    : { plan: "check", repoRoot };
+}
 
 export class DraftRepositoryController {
   private worktreeValue = false;
@@ -118,7 +144,11 @@ export class DraftRepositoryController {
       folder: this.read().folder.trim() || this.read().workspace,
       worktree: this.worktreeValue,
     });
-    if (this.worktreeValue && this.repositoryValue.kind !== "git") {
+    if (
+      this.worktreeValue &&
+      this.repositoryValue.kind !== "git" &&
+      this.repositoryValue.kind !== "pending-clone"
+    ) {
       this.load();
     }
     this.callbacks.requestUpdate();
@@ -151,65 +181,49 @@ export class DraftRepositoryController {
     if (snapshot.selectedProject?.repoRoot) {
       return true;
     }
-    if (this.repositoryValue.kind === "git") {
-      return true;
-    }
+    const state = this.repositoryValue;
     return (
-      this.repositoryValue.kind === "unavailable" &&
-      this.repositoryValue.repoRoot === snapshot.workspace &&
-      snapshot.workspaceGit
+      state.kind === "git" ||
+      state.kind === "pending-clone" ||
+      (state.kind === "unavailable" &&
+        state.repoRoot === snapshot.workspace &&
+        snapshot.workspaceGit)
     );
   }
 
   matchesCurrentRepo(): boolean {
-    if (this.repositoryValue.kind === "idle") {
+    const snapshot = this.read();
+    const state = this.repositoryValue;
+    if (state.kind === "pending-clone") {
+      return snapshot.remoteProject?.cloneUrl === state.cloneUrl;
+    }
+    if (state.kind === "idle" || snapshot.remoteProject) {
       return false;
     }
-    const snapshot = this.read();
     const repoRoot =
       snapshot.selectedProject?.repoRoot ?? (snapshot.folder.trim() || snapshot.workspace);
-    return this.repositoryValue.repoRoot === repoRoot;
+    return state.repoRoot === repoRoot;
   }
 
   load() {
     const requestId = ++this.requestToken;
-    const restoreWorktree = this.preferredWorktreeRestore && !this.worktreeSelectedByUser;
-    const restoreBaseRef = this.preferredBaseRefRestore;
-    const baseRefEditGeneration = this.baseRefEditGeneration;
+    const restore = {
+      worktree: this.preferredWorktreeRestore && !this.worktreeSelectedByUser,
+      baseRef: this.preferredBaseRefRestore,
+      baseRefEditGeneration: this.baseRefEditGeneration,
+    };
     const snapshot = this.read();
     this.repositoryValue = { kind: "idle" };
     this.baseRefValue = "";
-    if (
-      snapshot.remoteProjectSelected ||
-      (snapshot.selectedProject && !snapshot.selectedProject.repoRoot)
-    ) {
-      this.preferredWorktreeRestore = false;
-      return;
-    }
-    const repoRoot =
-      snapshot.selectedProject?.repoRoot ?? (snapshot.folder.trim() || snapshot.workspace);
-    const usesWorkspace = !snapshot.selectedProject && repoRoot === snapshot.workspace;
-    if (!repoRoot) {
-      this.preferredWorktreeRestore = false;
-      return;
-    }
-    if (usesWorkspace && !snapshot.workspaceGit) {
-      this.repositoryValue = { kind: "direct", repoRoot };
-      const rejectedWorktree = !snapshot.remotePlacement && (this.worktreeValue || restoreWorktree);
-      if (!snapshot.remotePlacement) {
-        this.worktreeValue = false;
-      }
-      this.preferredWorktreeRestore = false;
-      if (rejectedWorktree) {
-        this.callbacks.persistPreference({ worktree: false });
-      }
-      return;
+    const discovery = planRepositoryDiscovery(snapshot);
+    if (discovery.plan === "resolved") {
+      return this.adoptResolvedRepository(discovery.state, restore);
     }
     const client = snapshot.gateway?.client;
-    if (snapshot.gateway?.phase !== "connected" || !client) {
-      this.preferredWorktreeRestore = false;
-      return;
+    if (discovery.plan === "none" || snapshot.gateway?.phase !== "connected" || !client) {
+      return this.adoptResolvedRepository({ kind: "idle" }, restore);
     }
+    const { repoRoot } = discovery;
     this.repositoryValue = { kind: "checking", repoRoot };
     void client
       .request<WorktreesBranchesResult>("worktrees.branches", {
@@ -220,56 +234,54 @@ export class DraftRepositoryController {
         if (requestId !== this.requestToken) {
           return;
         }
-        if (result?.repositoryStatus !== "git") {
-          this.repositoryValue = {
-            kind: result?.repositoryStatus === "not_git" ? "direct" : "unavailable",
-            repoRoot,
-          };
-          if (result?.repositoryStatus === "not_git") {
-            const rejectedWorktree =
-              !this.read().remotePlacement && (this.worktreeValue || restoreWorktree);
-            if (!this.read().remotePlacement) {
-              this.worktreeValue = false;
-            }
-            if (rejectedWorktree) {
-              this.callbacks.persistPreference({ worktree: false });
-            }
-          } else if (restoreWorktree && !this.worktreeSelectedByUser && this.available()) {
-            this.worktreeValue = true;
-          }
-          this.preferredWorktreeRestore = false;
-          this.callbacks.requestUpdate();
-          return;
-        }
-        this.repositoryValue = {
-          kind: "git",
-          repoRoot,
-          branches: result.branches,
-          ...(result.defaultBranch ? { defaultBranch: result.defaultBranch } : {}),
-          ...(result.headBranch ? { headBranch: result.headBranch } : {}),
-        };
-        if (restoreWorktree && !this.worktreeSelectedByUser) {
-          this.worktreeValue = true;
-        }
-        this.preferredWorktreeRestore = false;
-        if (baseRefEditGeneration === this.baseRefEditGeneration) {
-          this.baseRefValue = restoreBaseRef || result.defaultBranch || result.headBranch || "";
-          if (restoreBaseRef) {
-            this.preferredBaseRefRestore = "";
-          }
-        }
-        this.callbacks.requestUpdate();
+        this.adoptResolvedRepository(
+          result?.repositoryStatus === "git"
+            ? {
+                kind: "git",
+                repoRoot,
+                branches: result.branches,
+                ...(result.defaultBranch ? { defaultBranch: result.defaultBranch } : {}),
+                ...(result.headBranch ? { headBranch: result.headBranch } : {}),
+              }
+            : { kind: result?.repositoryStatus === "not_git" ? "direct" : "unavailable", repoRoot },
+          restore,
+        );
       })
       .catch(() => {
         if (requestId !== this.requestToken) {
           return;
         }
-        this.repositoryValue = { kind: "unavailable", repoRoot };
-        if (restoreWorktree && !this.worktreeSelectedByUser && this.available()) {
-          this.worktreeValue = true;
-        }
-        this.preferredWorktreeRestore = false;
-        this.callbacks.requestUpdate();
+        this.adoptResolvedRepository({ kind: "unavailable", repoRoot }, restore);
       });
+  }
+
+  private adoptResolvedRepository(state: ResolvedRepository, restore: RepositoryRestore) {
+    // Discovery owns restore/rejection for both immediate and RPC results;
+    // placement and user edits may have changed while an RPC was pending.
+    this.repositoryValue = state;
+    if (state.kind === "direct") {
+      if (!this.read().remotePlacement) {
+        const rejectedWorktree = this.worktreeValue || restore.worktree;
+        this.worktreeValue = false;
+        if (rejectedWorktree) {
+          this.callbacks.persistPreference({ worktree: false });
+        }
+      }
+    } else if (
+      state.kind !== "idle" &&
+      restore.worktree &&
+      !this.worktreeSelectedByUser &&
+      this.available()
+    ) {
+      this.worktreeValue = true;
+    }
+    this.preferredWorktreeRestore = false;
+    if (state.kind === "git" && restore.baseRefEditGeneration === this.baseRefEditGeneration) {
+      this.baseRefValue = restore.baseRef || state.defaultBranch || state.headBranch || "";
+      if (restore.baseRef) {
+        this.preferredBaseRefRestore = "";
+      }
+    }
+    this.callbacks.requestUpdate();
   }
 }

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -720,7 +720,6 @@ describe("DraftSubmissionFlow", () => {
     });
     if (worktree) {
       place.toggleWorktree();
-      vi.spyOn(place, "worktreeAvailable").mockReturnValue(true);
     }
     flow.setMessage(message);
     if (worktree && !message) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting a new GitHub repository in the new-session picker (from GitHub search results or a pasted clone URL) would lose the branch/worktree chip entirely on Local placement — there was no way to start that first session in a worktree, and cloud placement was blocked for the same selection. Switching to a device placement even silently dropped the selected repository.

The submit machinery has supported this since #130192: it materializes the remote project via `projects.add` and then creates the session with `projectId` + `worktree: true`. Only the UI availability gate never opened — the unit test for that path had to mock `worktreeAvailable` to `true` to be reachable.

## Why This Change Was Made

The draft repository model classified a selected remote GitHub repository as unknown (`kind: "idle"`) when it is git by construction. This adds a `pending-clone` repository state so every consumer of worktree availability (detail chip, cloud-profile gating, device-placement retention) sees the selection as worktree-capable. Repository discovery is restructured into a pure `planRepositoryDiscovery` classifier plus one `adoptResolvedRepository` reconciliation that owns preference restore and non-git rejection for both immediate and RPC results — previously duplicated with drift across four branches. No server or protocol changes.

## User Impact

Picking a not-yet-cloned GitHub repository now offers the same Runs directly / Worktree choice as a registered project: the repo is cloned first, then the session runs in a managed worktree of that clone. Cloud placement works with such a selection, and switching to a device placement keeps it. Stored worktree preferences now also apply to these selections.

## Evidence

Unit + e2e lanes green (`pnpm test ui/src/pages/new-session`, `ui/src/e2e/new-session-page.github-projects.e2e.test.ts`), `pnpm check:changed` green, fresh autoreview clean. The new e2e fails on pre-fix code at the chip-visibility assertion (`#new-session-detail-trigger` absent). Production LOC +103/−88 (net +15), tests +233/−15.

**Before** — GitHub repo selected, branches chip missing:

![before: no worktree chip](https://github.com/user-attachments/assets/4a57afdf-3fdd-453f-8f4c-0bd3ad23e06f)

**After** — chip present with "Runs directly", and Worktree selectable with base branch + name:

![after: runs directly chip](https://github.com/user-attachments/assets/19caf135-a1ae-4646-ac0c-b59cc49a0571)

![after: worktree selected](https://github.com/user-attachments/assets/11a8d74c-b34e-4062-8cf4-7507a76dfce8)

**Live proof** (isolated dev gateway, built dist, real clone of `octocat/Hello-World`): pasted the clone URL, toggled Worktree, started the session. The gateway cloned the project and provisioned a managed worktree; the agent answered from inside it ("Just one file at the root: README", claude-sonnet-4-6, 12s):

![live: worktree toggled on pasted URL](https://github.com/user-attachments/assets/5f456fa6-ea1b-4d3f-ad8a-f9a6a9f7535e)

![live: session ran in the worktree](https://github.com/user-attachments/assets/9080129b-0f68-47a3-a942-c23cf8854db3)

```
$ git -C <state>/projects/1d7ed7bd7bc9f544/hello-world worktree list
.../projects/1d7ed7bd7bc9f544/hello-world            7fd1a60 [master]
.../worktrees/d3f16419821e02fd/repository-root-files 7fd1a60 [openclaw/repository-root-files]
```

Video of the full live flow is attached below.

https://github.com/user-attachments/assets/543de033-f106-41d3-a1d7-82e6068d00d2