### PR TITLE
fix: honor scenario drivers in generated QA commands

### DIFF
--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -1324,7 +1324,10 @@ for machine-readable output). When choosing focused proof for a touched
 behavior or file path, run `pnpm openclaw qa coverage --match <query>`. The
 match report searches scenario metadata, docs refs, code refs, coverage IDs,
 plugins, and provider requirements, then prints matching `qa suite
---scenario ...` targets.
+--scenario ...` targets. Generated commands preserve declared channel-driver
+requirements and separate scenarios with different driver requirements. Without
+a driver requirement, non-QA channels use `live` and `qa-channel` keeps its
+default driver.
 
 Every `qa suite` run writes top-level `qa-evidence.json`,
 `qa-suite-summary.json`, and `qa-suite-report.md` artifacts for the selected

--- a/extensions/qa-lab/src/coverage-report.commands.test.ts
+++ b/extensions/qa-lab/src/coverage-report.commands.test.ts
@@ -1,0 +1,132 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { Command } from "commander";
+import { describe, expect, it, vi } from "vitest";
+import { hasTopLevelShellControlOperator, splitShellArgs } from "../../../src/utils/shell-argv.js";
+import { registerQaLabCli } from "./cli.js";
+import { findQaScenarioMatches, renderQaScenarioMatchesMarkdownReport } from "./coverage-report.js";
+import { defaultQaModelForMode, type QaProviderMode } from "./model-selection.js";
+import { DEFAULT_QA_LIVE_PROVIDER_MODE } from "./providers/index.js";
+import { readQaScenarioById, type QaSeedScenarioWithSource } from "./scenario-catalog.js";
+import type { QaScorecardChannelDriver } from "./scorecard-taxonomy.js";
+import { selectQaFlowSuiteScenarios } from "./suite-planning.js";
+import { makeQaSuiteTestScenario } from "./suite-test-helpers.js";
+
+vi.mock("openclaw/plugin-sdk/qa-runner-runtime", () => ({
+  listQaRunnerCliContributions: () => [],
+}));
+
+function selectReportedCommands(scenarios: QaSeedScenarioWithSource[]) {
+  const matches = scenarios.flatMap((scenario) => findQaScenarioMatches([scenario], scenario.id));
+  const report = renderQaScenarioMatchesMarkdownReport({ query: "selected scenarios", matches });
+  const commands = [...report.matchAll(/`(pnpm openclaw qa suite[^`]+)`/gu)];
+  expect(commands.length).toBeGreaterThan(0);
+  return commands.map(([, command]) => {
+    const argv = expectDefined(splitShellArgs(command!), "generated shell arguments");
+    expect(argv.slice(0, 4)).toEqual(["pnpm", "openclaw", "qa", "suite"]);
+    const program = new Command();
+    registerQaLabCli(program);
+    const qa = expectDefined(
+      program.commands.find((entry) => entry.name() === "qa"),
+      "qa",
+    );
+    const suite = expectDefined(
+      qa.commands.find((entry) => entry.name() === "suite"),
+      "suite",
+    );
+    // Parse the real options without running the suite action or starting a provider.
+    expect(suite.parseOptions(argv.slice(4))).toEqual({ operands: [], unknown: [] });
+    const opts = suite.opts<{
+      scenario: string[];
+      channelDriver?: QaScorecardChannelDriver;
+      channel?: string;
+      providerMode?: QaProviderMode;
+    }>();
+    expect(opts.scenario.length).toBeGreaterThan(0);
+    const providerMode = opts.providerMode ?? DEFAULT_QA_LIVE_PROVIDER_MODE;
+    const selected = selectQaFlowSuiteScenarios({
+      scenarios,
+      scenarioIds: opts.scenario,
+      channelDriver: opts.channelDriver,
+      channel: opts.channel,
+      providerMode,
+      primaryModel: defaultQaModelForMode(providerMode),
+    });
+    expect(
+      selected.map(({ id }) => id),
+      command,
+    ).toEqual(opts.scenario);
+    return {
+      driver: opts.channelDriver ?? "qa-channel",
+      ids: selected.map(({ id }) => id),
+    };
+  });
+}
+
+describe("QA coverage command selection", () => {
+  it.each([
+    ["telegram-assistant-transcript-role-boundary", "crabline"],
+    ["native-command-session-target", "crabline"],
+    ["matrix-room-generated-image-delivery", "live"],
+    ["remember-across-conversations", "qa-channel"],
+    ["whatsapp-access-control-group-disabled", "live"],
+    ["instruction-followthrough-repo-contract", "qa-channel"],
+    ["agent-startup-instruction-first-action", "qa-channel"],
+    ["channel-canary", "qa-channel"],
+  ])("selects exactly %s from its generated command", (id, driver) => {
+    expect(selectReportedCommands([readQaScenarioById(id)])).toEqual([{ driver, ids: [id] }]);
+  });
+
+  it("separates conflicting drivers on the same channel and groups compatible scenarios", () => {
+    const scenarios = [
+      ...["crabline", "live"].flatMap((requiredChannelDriver) =>
+        ["first", "second"].map((suffix) =>
+          makeQaSuiteTestScenario(`${requiredChannelDriver}-${suffix}`, {
+            channel: "telegram",
+            config: { requiredChannelDriver, requiredProviderMode: "mock-openai" },
+          }),
+        ),
+      ),
+      makeQaSuiteTestScenario("unconstrained", { channel: "telegram" }),
+    ];
+
+    expect(selectReportedCommands(scenarios)).toEqual([
+      { driver: "crabline", ids: ["crabline-first", "crabline-second"] },
+      { driver: "live", ids: ["live-first", "live-second"] },
+      { driver: "live", ids: ["unconstrained"] },
+    ]);
+  });
+
+  it("preserves a driver requirement without a pinned channel", () => {
+    const scenario = makeQaSuiteTestScenario("driver-only", {
+      config: { requiredChannelDriver: "crabline" },
+    });
+
+    expect(selectReportedCommands([scenario])).toEqual([
+      { driver: "crabline", ids: [scenario.id] },
+    ]);
+  });
+
+  it("keeps a declared driver as one shell argument", () => {
+    const requiredChannelDriver = "crabline' ; printf unexpected #";
+    const scenario = makeQaSuiteTestScenario("quoted-driver", {
+      config: { requiredChannelDriver },
+    });
+    const report = renderQaScenarioMatchesMarkdownReport({
+      query: scenario.id,
+      matches: findQaScenarioMatches([scenario], scenario.id),
+    });
+    const command = expectDefined(report.match(/`(pnpm openclaw qa suite[^`]+)`/u)?.[1], "command");
+
+    expect(hasTopLevelShellControlOperator(command)).toBe(false);
+    expect(splitShellArgs(command)).toEqual([
+      "pnpm",
+      "openclaw",
+      "qa",
+      "suite",
+      "--channel-driver",
+      requiredChannelDriver,
+      "--scenario",
+      scenario.id,
+    ]);
+  });
+});

--- a/extensions/qa-lab/src/coverage-report.commands.test.ts
+++ b/extensions/qa-lab/src/coverage-report.commands.test.ts
@@ -1,7 +1,7 @@
+import { execFileSync } from "node:child_process";
 import { expectDefined } from "@openclaw/normalization-core";
 import { Command } from "commander";
 import { describe, expect, it, vi } from "vitest";
-import { hasTopLevelShellControlOperator, splitShellArgs } from "../../../src/utils/shell-argv.js";
 import { registerQaLabCli } from "./cli.js";
 import { findQaScenarioMatches, renderQaScenarioMatchesMarkdownReport } from "./coverage-report.js";
 import { defaultQaModelForMode, type QaProviderMode } from "./model-selection.js";
@@ -15,13 +15,24 @@ vi.mock("openclaw/plugin-sdk/qa-runner-runtime", () => ({
   listQaRunnerCliContributions: () => [],
 }));
 
+function captureReportedArgv(command: string): string[] {
+  // Previews use POSIX quoting; Windows test hosts need Git Bash's sh on PATH.
+  // Capture the shell-expanded arguments without starting pnpm or a QA provider.
+  const argv = execFileSync("sh", ["-c", `pnpm() { printf '%s\\0' pnpm "$@"; }\n${command}`], {
+    encoding: "utf8",
+    timeout: 5_000,
+  }).split("\0");
+  expect(argv.pop()).toBe("");
+  return argv;
+}
+
 function selectReportedCommands(scenarios: QaSeedScenarioWithSource[]) {
   const matches = scenarios.flatMap((scenario) => findQaScenarioMatches([scenario], scenario.id));
   const report = renderQaScenarioMatchesMarkdownReport({ query: "selected scenarios", matches });
   const commands = [...report.matchAll(/`(pnpm openclaw qa suite[^`]+)`/gu)];
   expect(commands.length).toBeGreaterThan(0);
   return commands.map(([, command]) => {
-    const argv = expectDefined(splitShellArgs(command!), "generated shell arguments");
+    const argv = captureReportedArgv(command!);
     expect(argv.slice(0, 4)).toEqual(["pnpm", "openclaw", "qa", "suite"]);
     const program = new Command();
     registerQaLabCli(program);
@@ -117,8 +128,7 @@ describe("QA coverage command selection", () => {
     });
     const command = expectDefined(report.match(/`(pnpm openclaw qa suite[^`]+)`/u)?.[1], "command");
 
-    expect(hasTopLevelShellControlOperator(command)).toBe(false);
-    expect(splitShellArgs(command)).toEqual([
+    expect(captureReportedArgv(command)).toEqual([
       "pnpm",
       "openclaw",
       "qa",

--- a/extensions/qa-lab/src/coverage-report.ts
+++ b/extensions/qa-lab/src/coverage-report.ts
@@ -13,6 +13,7 @@ import {
   readQaScorecardTaxonomyReport,
   type QaScorecardTaxonomyReport,
 } from "./scorecard-taxonomy.js";
+import { shellQuote } from "./shell-quote.js";
 
 type QaCoverageScenarioSummary = {
   id: string;
@@ -31,6 +32,7 @@ type QaScenarioSearchMatch = QaCoverageScenarioSummary & {
   executionKind: QaSeedScenarioWithSource["execution"]["kind"];
   executionPath?: string;
   runtimePairLane?: string;
+  requiredChannelDriver?: string;
   requiredProviderMode?: string;
   requiredProvider?: string;
   requiredModel?: string;
@@ -145,6 +147,7 @@ function summarizeScenarioSearchMatch(
       channels[0],
     ...(scenario.execution.kind !== "flow" ? { executionPath: scenario.execution.path } : {}),
     runtimePairLane: scenario.runtimePairLane,
+    requiredChannelDriver: stringifyConfigValue(config.requiredChannelDriver),
     requiredProviderMode: resolveQaScenarioRequiredProviderMode(scenario),
     requiredProvider: stringifyConfigValue(config.requiredProvider),
     requiredModel: stringifyConfigValue(config.requiredModel),
@@ -393,14 +396,18 @@ function formatOptionalScenarioMetadata(match: QaScenarioSearchMatch) {
 
 function formatSuiteCommand(matches: readonly QaScenarioSearchMatch[]) {
   const scenarioArgs = matches.map((match) => `--scenario ${match.id}`).join(" ");
-  const { channel, requiredProviderMode } = matches[0]!;
-  const channelArg =
-    channel && channel !== "qa-channel" ? ` --channel-driver live --channel ${channel}` : "";
+  const { channel, requiredChannelDriver, requiredProviderMode } = matches[0]!;
+  const channelArg = channel && channel !== "qa-channel" ? ` --channel ${channel}` : "";
+  const driverArg = requiredChannelDriver
+    ? ` --channel-driver ${shellQuote(requiredChannelDriver)}`
+    : channelArg
+      ? " --channel-driver live"
+      : "";
   const providerModeArg =
     requiredProviderMode && requiredProviderMode !== DEFAULT_QA_LIVE_PROVIDER_MODE
       ? ` --provider-mode ${requiredProviderMode}`
       : "";
-  return `pnpm openclaw qa suite${channelArg}${providerModeArg} ${scenarioArgs}`;
+  return `pnpm openclaw qa suite${driverArg}${channelArg}${providerModeArg} ${scenarioArgs}`;
 }
 
 function scenarioMatchCommandGroups(matches: readonly QaScenarioSearchMatch[]) {
@@ -409,6 +416,7 @@ function scenarioMatchCommandGroups(matches: readonly QaScenarioSearchMatch[]) {
     const key = JSON.stringify([
       match.executionKind,
       match.channel,
+      match.requiredChannelDriver,
       match.requiredProviderMode ?? DEFAULT_QA_LIVE_PROVIDER_MODE,
     ]);
     const group = groups.get(key) ?? [];


### PR DESCRIPTION
Closes #131088

## What Problem This Solves

Fixes an issue where `qa coverage --match` suggested suite commands that contradicted a scenario's required channel driver. Two current Crabline-only scenarios received `--channel-driver live` and were rejected by the same canonical selector used during suite startup.

## Why This Change Was Made

The existing search projection now retains `requiredChannelDriver`; command grouping includes it, and rendering uses the declared value with the existing shell-quoting helper. Unconstrained defaults stay unchanged. The fix carries the prepared fact instead of rediscovering catalog data while rendering or weakening lane validation.

## User Impact

Generated commands preserve explicit driver requirements and separate incompatible driver groups. Source-checkout QA users no longer need to repair a flag chosen by coverage output. JSON search results also retain the requirement. No scenario, authentication, provider, or execution policy changes.

## Evidence

Both real catalog commands failed canonical selection before production edits with `channelDriver=crabline`: `telegram-assistant-transcript-role-boundary` and `native-command-session-target`. The completed regression table produced **5 failures and 6 passes** against baseline production, then **11 passes** against the candidate.

**402 tests passed across eight files**, covering coverage reports, generated commands, scenario catalog, lane selection, suite planning, module-flow planning, and CLI/runtime registration. The new tests parse generated commands with real CLI options and feed them to canonical selection, requiring a nonzero exact scenario set. They also protect defaults, conflicting-driver grouping, unpinned channels, and shell argument safety.

The coordinator independently ran the private built CLI for both catalog scenarios in Markdown and JSON modes with isolated HOME/config/state and the existing private-QA CLI opt-in. Each generated command selected exactly its intended scenario, count 1. **Generated suite commands were not executed:** this is command-generation and selection proof, not a provider/channel or scenario-run success claim.

```bash
pnpm check:changed -- extensions/qa-lab/src/coverage-report.ts extensions/qa-lab/src/coverage-report.commands.test.ts docs/concepts/qa-e2e-automation.md
```

```bash
OPENCLAW_BUILD_PRIVATE_QA=1 OPENCLAW_BUILD_ALL_NO_PNPM=1 node --import tsx scripts/build-all.mts qaRuntime
```

```bash
git diff --check
```

All passed. The full changed gate includes extension/test types, prepared declaration lint, formatting, architecture guards, and five additional doctor-contract checks. Worker attempts at package-manager startup/declaration preparation were sandbox-blocked; the coordinator completed the gate through normal local tooling without disabling verification. The targeted private QA runtime build passed; ordinary packaged/full-suite validation is not claimed, and QA Lab remains source-only.

Fresh independent P1 autoreview of the integrated repair and final test correction found no actionable findings (correct, confidence 0.93; original pass 0.96). Production **+12/-4, net +8**; tests **+142**; docs **+4/-1**. The eight production lines retain one previously discarded requirement across projection/grouping and quote it safely; no wrapper, duplicate validator, dependency, or new configuration option is introduced.

Provenance: the gap became visible after [PR118542 — Telegram release validation](https://github.com/openclaw/openclaw/pull/118542), authored and merged by @vincentkoc on August 3, 2026, added the driver requirements. It remained after [PR129340 — runnable coverage commands](https://github.com/openclaw/openclaw/pull/129340), authored and merged by @steipete on August 25, 2026. Local containing tags are beta-only; no stable-release regression is claimed.

### CI follow-through

Initial [CI33101964481](https://github.com/openclaw/openclaw/actions/runs/33101964481) failed the plugin test boundary because the new test imported core-private shell parsing. The corrected test instead captures real POSIX-shell arguments, then uses the actual CLI options and canonical scenario selector. It starts no QA suite/provider/channel. All 11 cases, the exact import guard, and the complete changed gate passed again; independent integrated review is clean. Windows developers need Git Bash's `sh` on PATH; native Windows execution is not claimed.

The same initial run also measured `plugins list --json` at 401.8 MB against the 401 MB effective ceiling (samples 401.9/328.8/401.8). This matches [shared incident130977 — Blacksmith startup-memory variance](https://github.com/openclaw/openclaw/issues/130977). Normal builds exclude QA Lab, and the changed report has no ordinary packaged-CLI import path. Fresh incident metadata says automation skipped implementation pending a maintainer decision on runner calibration/headroom; no active repair PR is claimed. Memory thresholds, sample policy, and verifier scheduling are unchanged. The corrected head passed [exact-head CI33104409357](https://github.com/openclaw/openclaw/actions/runs/33104409357) at `3c30df2c3e2e296726ef3805e8bb0a819a3c9c65`; the native watcher reported GREEN. All 402 local owner/sibling tests also passed again on that published head, with a clean checkout. The failed initial run remains recorded, and a green run does not mean the shared memory incident is repaired. Latest ClawSweeper feedback is only a corrected-head review-started placeholder, not a published verdict or Rank-up moves; no bot approval is claimed.

Documentation: https://docs.openclaw.ai/concepts/qa-e2e-automation. AI-assisted repair; the behavior above is the release-note context.
