### PR TITLE
docs(start): bridge paragraph for personal readers on Why OpenClaw

### DIFF
--- a/docs/start/why-openclaw.md
+++ b/docs/start/why-openclaw.md
@@ -4,6 +4,7 @@ read_when:
   - You are evaluating agent harnesses for team or enterprise use
   - You need to explain to a security team how OpenClaw differs from single-process harnesses
   - You want the citable version of the trusted-gateway / untrusted-execution argument
+  - You want to know whether OpenClaw's enterprise depth makes it heavyweight for personal use
 title: "Why OpenClaw"
 ---
 
@@ -26,6 +27,8 @@ The recurring comparison is [Hermes Agent](https://github.com/NousResearch/herme
 > The only security boundary against an adversarial LLM is the operating system.
 
 OpenClaw can separate a trusted [Gateway](/gateway) from untrusted, movable execution. Policy is enforced in code, and state is versioned and migrated, so a deployment is replaceable. This page compares configured architectures, not default security certifications: sandboxing is off by default in OpenClaw. The source review was refreshed on August 27, 2026 against [OpenClaw `7b624e9de25`](https://github.com/openclaw/openclaw/tree/7b624e9de25bc66c97166071c8d05f055d82ec54) and [Hermes Agent `6defe7eb6c`](https://github.com/NousResearch/hermes-agent/tree/6defe7eb6c462bb784d1f27f5afe7ca4b627fc70). These are development snapshots; check your installed version and configuration before relying on a capability.
+
+A good harness spans the whole range: the same product runs as a personal assistant on one laptop and as a hardened team deployment, with configuration as the only difference. There is no enterprise edition. If you run OpenClaw for yourself, the defaults are tuned for you and none of this requires action. The properties below are phrased as an enterprise evaluation because that is the harshest audience, but every one of them protects a single operator the same way: credentials the agent never sees, deletion that sticks, upgrades that refuse to break state.
 
 ## What an enterprise harness has to prove
 


### PR DESCRIPTION
## What Problem This Solves

The Why OpenClaw page (`/start/why-openclaw`) sits in Get started, but its body is framed as an enterprise evaluation. A personal reader clicking it on day one can conclude OpenClaw's center of gravity has moved away from them. Nothing on the page says the obvious: it is one product across the whole range.

## Why This Change Was Made

Maintainer-directed. Two additions:

1. A bridge paragraph immediately before "What an enterprise harness has to prove": same product from one laptop to a hardened team deployment, configuration as the only difference, no enterprise edition, defaults tuned for the individual, and the enterprise checklist protecting a single operator for free.
2. A `read_when` bullet naming the hesitant personal reader's actual question: whether OpenClaw's enterprise depth makes it heavyweight for personal use.

## User Impact

Docs-only. Personal evaluators reading the page get an explicit answer that it is for them; no runtime, config, or API change.

## Evidence

- +3 lines, one file; `git diff --check` clean.
- Wording iterated and approved in maintainer chat; consistent with the page's existing claims (no separate enterprise edition; sandboxing off by default with a personal-assistant default posture).
