### PR TITLE
fix(feishu): split oversized Markdown cards without losing content or receipts

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -319,6 +319,11 @@ The official `lark-cli` VC agent skill currently marks meeting-bot actions as a 
 - `streaming.chunkMode` - `"length"` (default) splits at the limit; `"newline"` prefers newline boundaries
 - `mediaMaxMb` - media upload/download limit (default: `30` MB)
 
+Ordinary Markdown cards and rich-text posts are also split to fit Feishu's 30 KB
+serialized message limit. Headers, notes, mentions, JSON escaping, and UTF-8 text
+count toward that limit, so chunks may be shorter than `textChunkLimit`. Long
+media captions are sent as text/card chunks before the attachment.
+
 ### Streaming
 
 Feishu/Lark supports streaming replies via interactive cards (Card Kit streaming API). When enabled, the bot updates the card in real time as it generates text.
@@ -336,7 +341,7 @@ Feishu/Lark supports streaming replies via interactive cards (Card Kit streaming
 }
 ```
 
-Set `streaming.mode: "off"` to send the complete reply in one message; `renderMode: "raw"` (plain text instead of cards) also disables streaming cards. `streaming.block.enabled` is off by default; enable it only when you want completed assistant blocks flushed before the final reply. Legacy boolean `streaming` and the flat `blockStreaming` / `blockStreamingCoalesce` / `chunkMode` keys migrate to this nested shape via `openclaw doctor --fix`.
+Set `streaming.mode: "off"` to send the completed reply without streaming updates; long replies still split at the message limits above. `renderMode: "raw"` (plain text instead of cards) also disables streaming cards. `streaming.block.enabled` is off by default; enable it only when you want completed assistant blocks flushed before the final reply. Legacy boolean `streaming` and the flat `blockStreaming` / `blockStreamingCoalesce` / `chunkMode` keys migrate to this nested shape via `openclaw doctor --fix`.
 
 ### Quota optimization
 

--- a/extensions/feishu/src/dm-delivery-loopback.test.ts
+++ b/extensions/feishu/src/dm-delivery-loopback.test.ts
@@ -2,9 +2,11 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import * as Lark from "@larksuiteoapi/node-sdk";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { describe, expect, it } from "vitest";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { sendMediaFeishu } from "./media.js";
+import { feishuOutbound } from "./outbound.js";
 import { sendCardFeishu, sendMessageFeishu } from "./send.js";
 
 type RecordedFeishuRequest = {
@@ -16,10 +18,12 @@ type RecordedFeishuRequest = {
   appId?: string;
   authorization?: string;
   replyInThread?: boolean;
+  content?: string;
+  platformMessageId?: string;
 };
 
 describe("Feishu DM delivery over the real Lark SDK", () => {
-  it("authenticates conversation replies and preserves account, group, thread, and error boundaries", async () => {
+  it("preserves routing, card byte envelopes and physical-send receipts", async () => {
     const requests: RecordedFeishuRequest[] = [];
     const server = createServer((request, response) => {
       void (async () => {
@@ -46,6 +50,7 @@ describe("Feishu DM delivery over the real Lark SDK", () => {
             ? { authorization: request.headers.authorization }
             : {}),
           ...(body.reply_in_thread === true ? { replyInThread: true } : {}),
+          ...(typeof body.content === "string" ? { content: body.content } : {}),
         };
         requests.push(record);
 
@@ -81,11 +86,17 @@ describe("Feishu DM delivery over the real Lark SDK", () => {
           return;
         }
 
-        if (path === "/open-apis/im/v1/messages/om_dm_thread_root/reply") {
+        if (
+          path === "/open-apis/im/v1/messages/om_dm_thread_root/reply" ||
+          path === "/open-apis/im/v1/messages/om_card_split_root/reply"
+        ) {
+          record.platformMessageId = path.includes("om_dm_thread_root")
+            ? "om_dm_thread_reply"
+            : `om_dm_loopback_${requests.length}`;
           sendJson(200, {
             code: 0,
             msg: "success",
-            data: { message_id: "om_dm_thread_reply" },
+            data: { message_id: record.platformMessageId },
           });
           return;
         }
@@ -108,10 +119,19 @@ describe("Feishu DM delivery over the real Lark SDK", () => {
           return;
         }
 
+        if (
+          body.receive_id === "oc_card_partial" &&
+          requests.filter((entry) => entry.receiveId === body.receive_id).length === 3
+        ) {
+          sendJson(400, { code: 230027, msg: "Lack of necessary permissions." });
+          return;
+        }
+
+        record.platformMessageId = `om_dm_loopback_${requests.length}`;
         sendJson(200, {
           code: 0,
           msg: "success",
-          data: { message_id: `om_dm_loopback_${requests.length}` },
+          data: { message_id: record.platformMessageId },
         });
       })().catch((error: unknown) => {
         response.writeHead(500, { "content-type": "application/json" });
@@ -288,6 +308,138 @@ describe("Feishu DM delivery over the real Lark SDK", () => {
           }),
         ]),
       );
+
+      const sendText = feishuOutbound.sendText!;
+      for (const fixture of [
+        { name: "default limit", body: "漢".repeat(11_000), limit: 4_000, header: "Header" },
+        { name: "UTF-8 bytes", body: "漢".repeat(11_000), limit: 25_000, header: "Header" },
+        { name: "JSON escapes", body: '"\\'.repeat(8_000), limit: 25_000, header: "Header" },
+        {
+          name: "header and fence overhead",
+          body: "x".repeat(24_576),
+          limit: 25_000,
+          header: "界".repeat(2_000),
+        },
+      ]) {
+        for (const thread of [false, true]) {
+          const before = requests.length;
+          const deliveries: string[] = [];
+          const result = await sendText({
+            cfg: {
+              ...cfg,
+              channels: { feishu: { ...cfg.channels!.feishu, textChunkLimit: fixture.limit } },
+            },
+            to: "chat:oc_dm_conversation",
+            text: `\`\`\`text\n${fixture.body}\n\`\`\``,
+            identity: { name: fixture.header },
+            ...(thread ? { threadId: "om_card_split_root" } : {}),
+            onDeliveryResult: (delivery) => {
+              deliveries.push(delivery.messageId);
+            },
+          });
+          const sent = requests.slice(before).filter((request) => request.messageType);
+          expect
+            .soft(sent.length, `${fixture.name}: split direct card, thread=${thread}`)
+            .toBeGreaterThan(1);
+          const bodies: string[] = [];
+          for (const request of sent) {
+            expect(request.messageType).toBe("interactive");
+            expect(request.path).toBe(
+              thread
+                ? "/open-apis/im/v1/messages/om_card_split_root/reply"
+                : "/open-apis/im/v1/messages",
+            );
+            expect(request.replyInThread).toBe(thread ? true : undefined);
+            expect
+              .soft(Buffer.byteLength(request.content!, "utf8"), fixture.name)
+              .toBeLessThanOrEqual(30 * 1024);
+            const card = JSON.parse(request.content!) as {
+              header: { title: { content: string } };
+              body: { elements: Array<{ tag: string; content: string }> };
+            };
+            expect(card.header.title.content).toBe(fixture.header);
+            const markdown = card.body.elements[0]?.content;
+            if (markdown === undefined) {
+              throw new Error("Expected a Markdown card body");
+            }
+            expect(markdown.startsWith("```text\n")).toBe(true);
+            expect(markdown.endsWith("\n```")).toBe(true);
+            bodies.push(markdown.slice(8, -4));
+          }
+          expect(bodies.join("")).toBe(fixture.body);
+          expect(deliveries).toEqual(sent.map((request) => request.platformMessageId));
+          expect.soft(result.receipt?.platformMessageIds, fixture.name).toEqual(deliveries);
+          expect(result.messageId).toBe(deliveries.at(-1));
+          expect(result.receipt?.primaryPlatformMessageId).toBe(result.messageId);
+        }
+      }
+
+      const postStart = requests.length;
+      const post = await sendText({
+        cfg,
+        to: "chat:oc_dm_conversation",
+        text: "漢".repeat(11_000),
+      });
+      const postIds = requests
+        .slice(postStart)
+        .flatMap((request) => request.platformMessageId ?? []);
+      expect(postIds.length).toBeGreaterThan(1);
+      expect
+        .soft(post.receipt?.platformMessageIds, "logical post receipt contains every physical send")
+        .toEqual(postIds);
+
+      const partialStart = requests.length;
+      let partialError: unknown;
+      try {
+        await sendText({
+          cfg: { ...cfg, channels: { feishu: { ...cfg.channels!.feishu, textChunkLimit: 10 } } },
+          to: "chat:oc_card_partial",
+          text: "abcdefghij".repeat(3),
+        });
+      } catch (error) {
+        partialError = error;
+      }
+      const acceptedIds = requests
+        .slice(partialStart)
+        .flatMap((request) => request.platformMessageId ?? []);
+      expect(acceptedIds).toHaveLength(2);
+      expect
+        .soft(
+          isChannelPartialDeliveryError(partialError),
+          "later rejection preserves accepted chunks",
+        )
+        .toBe(true);
+      if (isChannelPartialDeliveryError(partialError)) {
+        expect(partialError.deliveryResult.visibleReplySent).toBe(true);
+        expect(partialError.deliveryResult.messageIds).toEqual(acceptedIds);
+      }
+
+      const callbackStart = requests.length;
+      let callbackError: unknown;
+      let callbacks = 0;
+      try {
+        await sendText({
+          cfg,
+          to: "chat:oc_dm_conversation",
+          text: "漢".repeat(11_000),
+          onDeliveryResult: () => {
+            if (++callbacks === 2) {
+              throw new Error("recording failed");
+            }
+          },
+        });
+      } catch (error) {
+        callbackError = error;
+      }
+      const callbackIds = requests
+        .slice(callbackStart)
+        .flatMap((request) => request.platformMessageId ?? []);
+      expect(callbacks).toBe(2);
+      expect(callbackIds).toHaveLength(2);
+      expect(isChannelPartialDeliveryError(callbackError)).toBe(true);
+      if (isChannelPartialDeliveryError(callbackError)) {
+        expect(callbackError.deliveryResult.messageIds).toEqual(callbackIds);
+      }
     } finally {
       Lark.defaultHttpInstance.interceptors.request.eject(loopbackInterceptor);
       await new Promise<void>((resolve, reject) => {

--- a/extensions/feishu/src/markdown.ts
+++ b/extensions/feishu/src/markdown.ts
@@ -163,15 +163,33 @@ function postContentBytes(messageText: string, mentions?: MentionTarget[]): numb
  * Honor both configured character chunking and Feishu's serialized post envelope.
  * Markdown wrappers and first-chunk mentions count toward the byte budget.
  */
-export function chunkFeishuPostMarkdown(params: {
+export type FeishuMarkdownChunkOptions = {
   text: string;
   limit: number;
   mode?: ChunkMode;
   firstChunkMentions?: MentionTarget[];
   chunkMentions?: MentionTarget[];
   initialChunks?: string[];
-}): string[] {
-  const { text, firstChunkMentions, chunkMentions } = params;
+};
+
+export function chunkFeishuPostMarkdown(params: FeishuMarkdownChunkOptions): string[] {
+  return chunkFeishuMarkdownByEnvelope({
+    ...params,
+    contentBytes: (text, isFirst) =>
+      postContentBytes(text, [
+        ...(params.chunkMentions ?? []),
+        ...(isFirst ? (params.firstChunkMentions ?? []) : []),
+      ]),
+  });
+}
+
+/** Measure the actual transport envelope, including UTF-8, JSON escapes and fence wrappers. */
+export function chunkFeishuMarkdownByEnvelope(
+  params: FeishuMarkdownChunkOptions & {
+    contentBytes: (text: string, isFirst: boolean) => number;
+  },
+): string[] {
+  const { text } = params;
   if (!text) {
     return [];
   }
@@ -182,14 +200,8 @@ export function chunkFeishuPostMarkdown(params: {
     params.initialChunks ??
     chunkFeishuMarkdownWithMode(text, requestedLimit, params.mode ?? "length");
   const output: string[] = [];
-  const resolveMentions = (isFirst: boolean): MentionTarget[] | undefined => {
-    const mentions = [...(chunkMentions ?? []), ...(isFirst ? (firstChunkMentions ?? []) : [])];
-    return mentions.length > 0 ? mentions : undefined;
-  };
-
   for (const initialChunk of initialChunks) {
-    const mentions = resolveMentions(output.length === 0);
-    if (postContentBytes(initialChunk, mentions) <= FEISHU_POST_MAX_BYTES) {
+    if (params.contentBytes(initialChunk, output.length === 0) <= FEISHU_POST_MAX_BYTES) {
       output.push(initialChunk);
       continue;
     }
@@ -204,15 +216,12 @@ export function chunkFeishuPostMarkdown(params: {
       );
       let largestContentBytes = 0;
       let oversizedChunk: string | undefined;
-      let oversizedMentions: MentionTarget[] | undefined;
 
       for (const [index, chunk] of chunks.entries()) {
-        const mentionsForChunk = resolveMentions(output.length === 0 && index === 0);
-        const contentBytes = postContentBytes(chunk, mentionsForChunk);
+        const contentBytes = params.contentBytes(chunk, output.length === 0 && index === 0);
         largestContentBytes = Math.max(largestContentBytes, contentBytes);
         if (contentBytes > FEISHU_POST_MAX_BYTES && oversizedChunk === undefined) {
           oversizedChunk = chunk;
-          oversizedMentions = mentionsForChunk;
         }
       }
 
@@ -221,14 +230,7 @@ export function chunkFeishuPostMarkdown(params: {
         break;
       }
       if (adaptiveLimit === 1) {
-        assertFeishuPostWithinEnvelope(
-          buildFeishuPostMessageContent({
-            messageText: oversizedChunk,
-            mentions: oversizedMentions,
-          }),
-          "Feishu post chunk",
-        );
-        return [...output, ...chunks];
+        throw new Error("Feishu Markdown chunk exceeds the 30 KB API limit");
       }
 
       // Scale by the observed serialized size, then force progress for envelope

--- a/extensions/feishu/src/outbound-delivery.test.ts
+++ b/extensions/feishu/src/outbound-delivery.test.ts
@@ -23,11 +23,11 @@ vi.mock("./media.js", () => ({
   shouldSuppressFeishuTextForVoiceMedia: () => false,
 }));
 
-vi.mock("./send.js", () => ({
+vi.mock("./send.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./send.js")>()),
   editMessageFeishu: vi.fn(),
   getMessageFeishu: vi.fn(),
   sendCardFeishu: sendCardFeishuMock,
-  sendMarkdownCardFeishu: vi.fn(),
   sendMessageFeishu: sendMessageFeishuMock,
   sendStructuredCardFeishu: vi.fn(),
 }));

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -26,7 +26,6 @@ import type { FeishuClientCredentials } from "./client.js";
 const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
 const sendCardFeishuMock = vi.hoisted(() => vi.fn());
-const sendMarkdownCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendStructuredCardFeishuMock = vi.hoisted(() => vi.fn());
 const createFeishuClientMock = vi.hoisted(() =>
   vi.fn((_account: FeishuClientCredentials) => ({ request: vi.fn() })),
@@ -71,12 +70,12 @@ vi.mock("./media.js", () => ({
   shouldSuppressFeishuTextForVoiceMedia: shouldSuppressFeishuTextForVoiceMediaMock,
 }));
 
-vi.mock("./send.js", () => ({
+vi.mock("./send.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./send.js")>()),
   editMessageFeishu: vi.fn(),
   getMessageFeishu: vi.fn(),
   sendCardFeishu: sendCardFeishuMock,
   sendMessageFeishu: sendMessageFeishuMock,
-  sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
   sendStructuredCardFeishu: sendStructuredCardFeishuMock,
   resolveFeishuCardTemplate: (template?: string) =>
     new Set([
@@ -236,7 +235,6 @@ function resetOutboundMocks() {
   vi.clearAllMocks();
   sendMessageFeishuMock.mockResolvedValue({ messageId: "text_msg" });
   sendCardFeishuMock.mockResolvedValue({ messageId: "native_card_msg" });
-  sendMarkdownCardFeishuMock.mockResolvedValue({ messageId: "card_msg" });
   sendStructuredCardFeishuMock.mockResolvedValue({ messageId: "card_msg" });
   sendMediaFeishuMock.mockResolvedValue({ messageId: "media_msg" });
   deliverCommentThreadTextMock.mockResolvedValue({
@@ -263,11 +261,6 @@ function sendCardCall(index = 0): Record<string, any> | undefined {
 
 function sendStructuredCardCall(index = 0): Record<string, any> | undefined {
   const calls = sendStructuredCardFeishuMock.mock.calls as unknown as Array<[Record<string, any>]>;
-  return calls[index]?.[0];
-}
-
-function sendMarkdownCardCall(index = 0): Record<string, any> | undefined {
-  const calls = sendMarkdownCardFeishuMock.mock.calls as unknown as Array<[Record<string, any>]>;
   return calls[index]?.[0];
 }
 
@@ -2545,7 +2538,6 @@ describe("feishuOutbound comment-thread routing", () => {
     expect(commentThreadParams()?.comment_id).toBe("7623358762119646411");
     expect(commentThreadParams()?.content).toBe("```ts\nconst x = 1\n```");
     expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
     expectFeishuResult(result, "reply_msg");
   });
 
@@ -2562,7 +2554,6 @@ describe("feishuOutbound comment-thread routing", () => {
     expect(commentThreadParams()?.comment_id).toBe("7623358762119646411");
     expect(commentThreadParams()?.content).toBe("handled in thread");
     expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
     expectFeishuResult(result, "reply_msg");
   });
 
@@ -3244,7 +3235,7 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
     }));
     const onDeliveryResult = vi.fn();
 
-    await feishuOutbound.sendMedia?.({
+    const result = await feishuOutbound.sendMedia?.({
       cfg: emptyConfig,
       to: "chat_1",
       text: Array.from({ length: 2_200 }, () => "a").join("\n"),
@@ -3254,10 +3245,15 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
     });
 
     expect(sendMessageFeishuMock.mock.calls.length).toBeGreaterThan(1);
-    expect(onDeliveryResult.mock.calls.map(([result]) => result.messageId)).toEqual([
+    expect(onDeliveryResult.mock.calls.map(([delivery]) => delivery.messageId)).toEqual([
       ...sendMessageFeishuMock.mock.calls.map((_call, index) => `caption_${index + 1}`),
       "media_msg",
     ]);
+    expect(result?.receipt?.parts.map((part) => part.platformMessageId)).toEqual(
+      onDeliveryResult.mock.calls.map(([delivery]) => delivery.messageId),
+    );
+    expect(result?.messageId).toBe("media_msg");
+    expect(result?.receipt?.primaryPlatformMessageId).toBe("media_msg");
   });
 
   it("preserves accepted caption chunks when a later chunk fails before media", async () => {
@@ -3444,35 +3440,42 @@ describe("feishuOutbound.sendMedia replyToId forwarding", () => {
   // duplicates the already-visible caption. Pre-fix the catch block threw a plain
   // Error with no receipt; post-fix it throws a ChannelPartialDeliveryError
   // carrying the caption's messageId.
-  it("preserves a delivered caption as partial delivery when media upload fails", async () => {
-    sendMessageFeishuMock.mockResolvedValueOnce({
-      messageId: "caption_msg",
-      chatId: "chat_1",
-    });
-    sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
+  it.each(["see attachment", "x".repeat(8_500), `\`\`\`text\n${"x".repeat(8_500)}\n\`\`\``])(
+    "preserves all delivered caption chunks when media upload fails (%#)",
+    async (text) => {
+      const sender = text.startsWith("```") ? sendStructuredCardFeishuMock : sendMessageFeishuMock;
+      sender.mockImplementation(async () => ({
+        messageId: `caption_${sender.mock.calls.length}`,
+        chatId: "chat_1",
+      }));
+      sendMediaFeishuMock.mockRejectedValueOnce(new Error("upload failed"));
 
-    let caught: unknown;
-    try {
-      await feishuOutbound.sendMedia?.({
-        cfg: emptyConfig,
-        to: "chat_1",
-        text: "see attachment",
-        mediaUrl: "https://example.com/file.png",
-        accountId: "main",
-        propagateMediaUploadFailure: true,
-      } as never);
-    } catch (err) {
-      caught = err;
-    }
+      let caught: unknown;
+      try {
+        await feishuOutbound.sendMedia?.({
+          cfg: emptyConfig,
+          to: "chat_1",
+          text,
+          mediaUrl: "https://example.com/file.png",
+          accountId: "main",
+          propagateMediaUploadFailure: true,
+        } as never);
+      } catch (err) {
+        caught = err;
+      }
 
-    expect(isChannelPartialDeliveryError(caught)).toBe(true);
-    const partial = caught as ReturnType<typeof createChannelPartialDeliveryError>;
-    expect(partial.deliveryResult.visibleReplySent).toBe(true);
-    expect(partial.deliveryResult.messageIds).toEqual(["caption_msg"]);
-    // The caption was delivered exactly once; no retry/duplicate send occurred.
-    expect(sendMessageFeishuMock).toHaveBeenCalledOnce();
-    expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
-  });
+      expect(isChannelPartialDeliveryError(caught)).toBe(true);
+      const partial = caught as ReturnType<typeof createChannelPartialDeliveryError>;
+      expect(partial.deliveryResult.visibleReplySent).toBe(true);
+      const ids = sender.mock.calls.map((_call, index) => `caption_${index + 1}`);
+      expect(ids.length).toBe(text.length > 4_000 ? 3 : 1);
+      expect(new Set(partial.deliveryResult.messageIds)).toEqual(new Set(ids));
+      expect(partial.deliveryResult.receipt?.parts.map((part) => part.platformMessageId)).toEqual(
+        ids,
+      );
+      expect(sendMediaFeishuMock).toHaveBeenCalledOnce();
+    },
+  );
 
   // Regression for #112244 (seventeenth-review P1, scope guard): a media-upload
   // failure with NO delivered caption is a wholly failed send, so the propagated
@@ -3649,9 +3652,9 @@ describe("feishuOutbound.sendMedia renderMode", () => {
       accountId: "main",
     });
 
-    expect(sendMarkdownCardCall()?.to).toBe("chat_1");
-    expect(sendMarkdownCardCall()?.text).toBe("| a | b |\n| - | - |");
-    expect(sendMarkdownCardCall()?.accountId).toBe("main");
+    expect(sendStructuredCardCall()?.to).toBe("chat_1");
+    expect(sendStructuredCardCall()?.text).toBe("| a | b |\n| - | - |");
+    expect(sendStructuredCardCall()?.accountId).toBe("main");
     expect(sendMediaCall()?.to).toBe("chat_1");
     expect(sendMediaCall()?.mediaUrl).toBe("https://example.com/image.png");
     expect(sendMediaCall()?.accountId).toBe("main");

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -1,10 +1,10 @@
 // Feishu plugin module implements outbound behavior.
 import path from "node:path";
+import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import {
-  isChannelPartialDeliveryError,
-  createChannelPartialDeliveryError,
-} from "openclaw/plugin-sdk/channel-inbound";
-import { createReplyToFanout } from "openclaw/plugin-sdk/channel-outbound";
+  createMessageReceiptFromOutboundResults,
+  createReplyToFanout,
+} from "openclaw/plugin-sdk/channel-outbound";
 import {
   attachChannelToResult,
   createAttachedChannelResultAdapter,
@@ -57,10 +57,16 @@ import {
   resolveFeishuRichReply,
 } from "./presentation-card.js";
 import {
+  createFeishuPartialReplyDeliveryError,
+  createFeishuReplyDeliveryResult,
+  type FeishuReplyDeliverySource,
+} from "./reply-delivery-result.js";
+import {
+  chunkFeishuCardMarkdown,
   sendCardFeishu,
-  sendMarkdownCardFeishu,
   sendMessageFeishu,
   sendStructuredCardFeishu,
+  type CardHeaderConfig,
 } from "./send.js";
 
 const RENDERED_FEISHU_CARD = Symbol("openclaw.renderedFeishuCard");
@@ -188,6 +194,34 @@ async function reportFeishuOutboundDelivery<T extends { messageId: string; chatI
 ): Promise<T> {
   await onDeliveryResult?.(attachChannelToResult("feishu", toFeishuOutboundResult(result)));
   return result;
+}
+
+function aggregateFeishuSendResult<T extends FeishuReplyDeliverySource>(
+  result: T,
+  results: readonly FeishuReplyDeliverySource[],
+) {
+  return {
+    ...result,
+    receipt: {
+      ...createMessageReceiptFromOutboundResults({ results }),
+      // Keep the established edit/reply target while retaining every physical send.
+      primaryPlatformMessageId: result.messageId,
+    },
+  };
+}
+
+function partialFeishuSendError(error: unknown, results: readonly FeishuReplyDeliverySource[]) {
+  if (results.length === 0 && error instanceof Error) {
+    return error;
+  }
+  const accepted = isChannelPartialDeliveryError(error) ? error.deliveryResult : undefined;
+  return createFeishuPartialReplyDeliveryError(error, {
+    ...accepted,
+    ...createFeishuReplyDeliveryResult({
+      results: [...results, accepted],
+      visibleReplySent: results.length > 0 || accepted !== undefined,
+    }),
+  });
 }
 
 function consumeFeishuPresentationFallbackMarker(payload: FeishuOutboundPayload): {
@@ -434,6 +468,7 @@ async function sendOutboundText(params: {
   replyToIdSource?: FeishuSendTextContext["replyToIdSource"];
   replyToMode?: FeishuSendTextContext["replyToMode"];
   onDeliveryResult?: FeishuSendTextContext["onDeliveryResult"];
+  header?: CardHeaderConfig;
 }) {
   const { cfg, to, text, accountId, replyToMessageId, replyInThread, onDeliveryResult } = params;
   const commentResult = await sendCommentThreadReply({
@@ -453,37 +488,29 @@ async function sendOutboundText(params: {
   // Decide card routing on the original text so card content is never
   // modified by post-md newline normalization. Only the post path below
   // materializes CommonMark soft breaks for Feishu rendering.
-  if (renderMode === "card" || (renderMode === "auto" && shouldUseCard(text))) {
-    return await reportFeishuOutboundDelivery(
-      await sendMarkdownCardFeishu({
-        cfg,
-        to,
-        text,
-        accountId,
-        replyToMessageId,
-        replyInThread,
-      }),
-      onDeliveryResult,
-    );
-  }
+  const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
   // Tables need contiguous source rows, so convert them before the parser
   // materializes prose soft breaks for Feishu post rendering.
   const tableMode = resolveMarkdownTableMode({ cfg, channel: "feishu" });
-  const tableConvertedText = convertMarkdownTables(text, tableMode);
-  const normalizedText = materializeFeishuPostMarkdownSoftBreaks(tableConvertedText);
+  const normalizedText = useCard
+    ? text
+    : materializeFeishuPostMarkdownSoftBreaks(convertMarkdownTables(text, tableMode));
 
   // Core chunks raw text before channel rendering. Re-chunk after expansion
   // and keep each fenced-code chunk independently valid Markdown.
   const postLimit = resolveTextChunkLimit(cfg, "feishu", accountId, {
     fallbackLimit: FEISHU_TEXT_CHUNK_LIMIT,
   });
-  const subChunks = chunkFeishuPostMarkdown({
+  const chunkOptions = {
     text: normalizedText,
     limit: postLimit,
     mode: resolveChunkMode(cfg, "feishu", accountId),
-  });
-  let lastResult: Awaited<ReturnType<typeof sendMessageFeishu>> | undefined;
+  };
+  const subChunks = useCard
+    ? chunkFeishuCardMarkdown({ ...chunkOptions, header: params.header })
+    : chunkFeishuPostMarkdown(chunkOptions);
+  const results: Awaited<ReturnType<typeof sendMessageFeishu>>[] = [];
   const preserveThread = replyInThread === true;
   const nextReplyToMessageId = createReplyToFanout({
     replyToId: replyToMessageId,
@@ -492,20 +519,26 @@ async function sendOutboundText(params: {
   });
   for (const [i, chunk] of (subChunks.length ? subChunks : [normalizedText]).entries()) {
     // Explicit replies and native topic roots stay sticky; implicit first replies do not.
-    lastResult = await reportFeishuOutboundDelivery(
-      await sendMessageFeishu({
+    try {
+      const sendParams = {
         cfg,
         to,
         text: chunk,
-        preparedPostText: true,
         accountId,
         replyToMessageId: preserveThread ? replyToMessageId : nextReplyToMessageId(),
         replyInThread: preserveThread ? true : i === 0 ? replyInThread : undefined,
-      }),
-      onDeliveryResult,
-    );
+      };
+      const result = useCard
+        ? await sendStructuredCardFeishu({ ...sendParams, header: params.header })
+        : await sendMessageFeishu({ ...sendParams, preparedPostText: true });
+      // Record acceptance before a callback or later chunk can fail.
+      results.push(result);
+      await reportFeishuOutboundDelivery(result, onDeliveryResult);
+    } catch (error) {
+      throw partialFeishuSendError(error, results);
+    }
   }
-  return lastResult!;
+  return aggregateFeishuSendResult(results.at(-1)!, results);
 }
 
 async function sendFeishuFallbackPayload(params: {
@@ -938,31 +971,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         );
       }
 
-      const account = resolveFeishuAccount({ cfg, accountId: accountId ?? undefined });
-      const renderMode = account.config?.renderMode ?? "auto";
-      const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
-      if (useCard) {
-        const header = identity
-          ? {
-              title: resolveFeishuIdentityHeaderTitle(identity),
-              template: "blue" as const,
-            }
-          : undefined;
-        return toFeishuOutboundResult(
-          await reportFeishuOutboundDelivery(
-            await sendStructuredCardFeishu({
-              cfg,
-              to,
-              text,
-              replyToMessageId,
-              replyInThread,
-              accountId: accountId ?? undefined,
-              header: header?.title ? header : undefined,
-            }),
-            onDeliveryResult,
-          ),
-        );
-      }
+      const title = identity ? resolveFeishuIdentityHeaderTitle(identity) : undefined;
       return toFeishuOutboundResult(
         await sendOutboundText({
           cfg,
@@ -971,6 +980,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           accountId: accountId ?? undefined,
           replyToMessageId,
           replyInThread,
+          header: title ? { title, template: "blue" } : undefined,
           ...deliveryOptions,
         }),
       );
@@ -1065,8 +1075,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         mediaUrl,
         audioAsVoice,
       });
-      let textSent = false;
-      let captionResult: { messageId: string; chatId: string } | undefined;
+      let captionResult: Awaited<ReturnType<typeof sendOutboundText>> | undefined;
 
       // Send text first if provided, except for Feishu native voice bubbles.
       if (text?.trim() && !suppressTextForVoiceMedia) {
@@ -1078,9 +1087,9 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           ...nextReplyMode(),
           ...deliveryOptions,
         });
-        textSent = true;
       }
 
+      const results: FeishuReplyDeliverySource[] = captionResult ? [captionResult] : [];
       let mediaResult: Awaited<ReturnType<typeof sendMediaFeishu>>;
       const mediaReplyMode = nextReplyMode();
       try {
@@ -1098,7 +1107,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
       } catch (err) {
         if (isChannelPartialDeliveryError(err)) {
           // Accepted media is not an upload failure and must never trigger a second send.
-          throw err;
+          throw partialFeishuSendError(err, results);
         }
         if (propagateMediaUploadFailure) {
           // The direct `send` action requested a controlled failure when the
@@ -1109,11 +1118,8 @@ export const feishuOutbound: ChannelOutboundAdapter = {
           // knows the text is visible and does not retry it (which would
           // duplicate the caption); only a send with no delivered caption is a
           // wholly failed send.
-          if (textSent && captionResult) {
-            throw createChannelPartialDeliveryError(err, {
-              messageIds: [captionResult.messageId],
-              visibleReplySent: true,
-            });
+          if (captionResult) {
+            throw partialFeishuSendError(err, results);
           }
           throw new Error(
             `Feishu send could not deliver the requested media attachment: ${
@@ -1124,35 +1130,47 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         }
         console.error(`[feishu] sendMediaFeishu failed:`, err);
         const fallbackText = await buildFeishuMediaFallbackText({
-          text: textSent ? undefined : text,
+          text: captionResult ? undefined : text,
           mediaUrl,
         });
-        return toFeishuOutboundResult(
-          await sendOutboundText({
+        try {
+          const fallbackResult = await sendOutboundText({
             cfg,
             to,
             text: fallbackText,
             accountId: accountId ?? undefined,
             // A rejected upload never delivered its attempted reply target.
-            ...(textSent ? nextReplyMode() : mediaReplyMode),
+            ...(captionResult ? nextReplyMode() : mediaReplyMode),
             ...deliveryOptions,
-          }),
-        );
+          });
+          return toFeishuOutboundResult(
+            aggregateFeishuSendResult(fallbackResult, [...results, fallbackResult]),
+          );
+        } catch (error) {
+          throw partialFeishuSendError(error, results);
+        }
       }
 
       // Persist the accepted attachment before any later fallible text action.
-      await reportFeishuOutboundDelivery(mediaResult, onDeliveryResult);
-      if (mediaResult.voiceIntentDegradedToFile && text?.trim()) {
-        await sendOutboundText({
-          cfg,
-          to,
-          text,
-          accountId: accountId ?? undefined,
-          ...nextReplyMode(),
-          ...deliveryOptions,
-        });
+      results.push(mediaResult);
+      try {
+        await reportFeishuOutboundDelivery(mediaResult, onDeliveryResult);
+        if (mediaResult.voiceIntentDegradedToFile && text?.trim()) {
+          results.push(
+            await sendOutboundText({
+              cfg,
+              to,
+              text,
+              accountId: accountId ?? undefined,
+              ...nextReplyMode(),
+              ...deliveryOptions,
+            }),
+          );
+        }
+      } catch (error) {
+        throw partialFeishuSendError(error, results);
       }
-      return toFeishuOutboundResult(mediaResult);
+      return toFeishuOutboundResult(aggregateFeishuSendResult(mediaResult, results));
     },
   }),
 };

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -24,7 +24,6 @@ const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());
 const getFeishuRuntimeMock = vi.hoisted(() => vi.fn());
 const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
 const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
-const sendMarkdownCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendStructuredCardFeishuMock = vi.hoisted(() => vi.fn());
 const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
@@ -92,9 +91,9 @@ vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   return { ...actual, getGlobalHookRunner: getGlobalHookRunnerMock };
 });
-vi.mock("./send.js", () => ({
+vi.mock("./send.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./send.js")>()),
   sendMessageFeishu: sendMessageFeishuMock,
-  sendMarkdownCardFeishu: sendMarkdownCardFeishuMock,
   sendStructuredCardFeishu: sendStructuredCardFeishuMock,
 }));
 vi.mock("./media.js", () => ({
@@ -109,7 +108,10 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
   };
 });
 vi.mock("./client.js", () => ({ createFeishuClient: createFeishuClientMock }));
-vi.mock("./targets.js", () => ({ resolveReceiveIdType: resolveReceiveIdTypeMock }));
+vi.mock("./targets.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./targets.js")>()),
+  resolveReceiveIdType: resolveReceiveIdTypeMock,
+}));
 vi.mock("./typing.js", () => ({
   addTypingIndicator: addTypingIndicatorMock,
   removeTypingIndicator: removeTypingIndicatorMock,
@@ -587,7 +589,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       note: "Agent: agent",
     });
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
   it("keeps oversized auto mode plain final text on the chunked message path", async () => {
@@ -659,6 +660,65 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
   });
 
+  it.each(["static", "streaming fallback"])(
+    "budgets full metadata on every %s card chunk",
+    async (deliveryMode) => {
+      const account = resolveFeishuAccountMock();
+      resolveFeishuAccountMock.mockReturnValue({
+        ...account,
+        configured: true,
+        config: {
+          ...account.config,
+          renderMode: "card",
+          streaming: { mode: deliveryMode === "static" ? "off" : "partial" },
+        },
+      });
+      getFeishuRuntimeMock().channel.text.resolveTextChunkLimit.mockReturnValue(40_000);
+      const create = vi.fn(async (_request: { data: { content: string } }) => ({
+        code: 0,
+        data: { message_id: `om_envelope_${create.mock.calls.length}` },
+      }));
+      createFeishuClientMock.mockReturnValue({ im: { message: { create } } });
+      const actualSend = await vi.importActual<typeof import("./send.js")>("./send.js");
+      sendStructuredCardFeishuMock.mockImplementation(actualSend.sendStructuredCardFeishu);
+      const name = "界".repeat(1_100);
+      const body = "x".repeat(24_576);
+      const { options } = createDispatcherHarness({
+        identity: { name },
+        // Required peer-bot mentions intentionally disable CardKit streaming.
+        ...(deliveryMode === "static"
+          ? { requiredMentionTargets: [{ openId: "ou_peer_bot", name: "Peer Bot", key: "" }] }
+          : {}),
+      });
+      const delivery = await options.deliver(
+        { text: `\`\`\`text\n${body}\n\`\`\`` },
+        { kind: "final" },
+      );
+      if (deliveryMode !== "static") {
+        requireStreamingInstance(0).closeWithResult.mockResolvedValueOnce({
+          visibleReplySent: false,
+        });
+      }
+      await options.onIdle?.();
+      await delivery?.finalization;
+      expect(create.mock.calls.length).toBeGreaterThan(1);
+      const bodies: string[] = [];
+      for (const [request] of create.mock.calls) {
+        const content = request.data.content;
+        expect(Buffer.byteLength(content, "utf8")).toBeLessThanOrEqual(30 * 1024);
+        const card = JSON.parse(content);
+        expect(card.header.title.content).toBe(name);
+        expect(card.body.elements[2].content).toBe(`<font color='grey'>Agent: ${name}</font>`);
+        const markdown = card.body.elements[0].content as string;
+        const prefix = `${deliveryMode === "static" ? "<at id=ou_peer_bot></at> " : ""}\`\`\`text\n`;
+        expect(markdown.startsWith(prefix)).toBe(true);
+        expect(markdown.endsWith("\n```")).toBe(true);
+        bodies.push(markdown.slice(prefix.length, -4));
+      }
+      expect(bodies.join("")).toBe(body);
+    },
+  );
+
   it("discards partial streaming preview before oversized final text fallback", async () => {
     const runtime = getFeishuRuntimeMock();
     runtime.channel.text.resolveTextChunkLimit.mockReturnValue(10);
@@ -695,7 +755,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expectMockArgFields(sendMessageFeishuMock, "message send params", {
       text: "tool summary",
     });
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
   it("keeps active auto mode streaming sessions from swallowing tool text", async () => {
@@ -718,7 +777,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(requireStreamingInstance(0).close).toHaveBeenCalledWith("plain final answer", {
       note: "Agent: agent",
     });
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
   it("keeps auto mode plain text on the message path when streaming is disabled", async () => {
@@ -727,7 +785,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(streamingInstances).toHaveLength(0);
     expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
   it("passes mention-forward targets to non-streaming plain text replies without rewriting body text", async () => {
@@ -815,7 +872,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(streamingInstances).toHaveLength(0);
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
   });
 
@@ -964,7 +1020,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
     expect(requireStreamingInstance(0).close).toHaveBeenCalledTimes(1);
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
   it("strips prose from identity emoji in streaming and static card headers", async () => {
@@ -1036,7 +1091,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     );
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
   it("retains each logical payload content when finals coalesce onto one card", async () => {
@@ -1145,7 +1199,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       note: "Agent: agent",
     });
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
   it("skips final text already closed by idle streaming", async () => {
@@ -1178,7 +1231,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       },
     );
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
     expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
   });
 
@@ -1211,7 +1263,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
 
     expect(streamingInstances).toHaveLength(0);
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
     expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
   });
 
@@ -1264,7 +1315,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       note: "Agent: agent",
     });
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
     expect(sendStructuredCardFeishuMock).not.toHaveBeenCalled();
     expect(sendMediaFeishuMock).toHaveBeenCalledTimes(1);
     expectMockArgFields(sendMediaFeishuMock, "media send params", {
@@ -1462,7 +1512,6 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       mediaUrl: "https://example.com/a.png",
     });
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
   it("passes audioAsVoice to media attachments", async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -41,7 +41,12 @@ import {
 } from "./reply-delivery-result.js";
 import { streamingStartBackoffUntilByAccount } from "./reply-dispatcher-state.js";
 import { getFeishuRuntime } from "./runtime.js";
-import { sendMessageFeishu, sendStructuredCardFeishu, type CardHeaderConfig } from "./send.js";
+import {
+  chunkFeishuCardMarkdown,
+  sendMessageFeishu,
+  sendStructuredCardFeishu,
+  type CardHeaderConfig,
+} from "./send.js";
 import {
   FeishuStreamingFinalizationError,
   FeishuStreamingSession,
@@ -711,6 +716,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     infoKind?: string;
     firstChunkMentions?: MentionTarget[];
     chunkMentions?: MentionTarget[];
+    header?: CardHeaderConfig;
+    note?: string;
     sendChunk: (params: {
       chunk: string;
       isFirst: boolean;
@@ -727,18 +734,23 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       textChunkLimit,
       chunkMode,
     );
+    const chunkOptions = {
+      text: chunkSource,
+      limit: textChunkLimit,
+      mode: chunkMode,
+      firstChunkMentions: paramsLocal.firstChunkMentions,
+      chunkMentions: paramsLocal.chunkMentions,
+      initialChunks,
+    };
     const chunks = resolveTextChunksWithFallback(
       chunkSource,
       paramsLocal.useCard
-        ? initialChunks
-        : chunkFeishuPostMarkdown({
-            text: chunkSource,
-            limit: textChunkLimit,
-            mode: chunkMode,
-            firstChunkMentions: paramsLocal.firstChunkMentions,
-            chunkMentions: paramsLocal.chunkMentions,
-            initialChunks,
-          }),
+        ? chunkFeishuCardMarkdown({
+            ...chunkOptions,
+            header: paramsLocal.header,
+            note: paramsLocal.note,
+          })
+        : chunkFeishuPostMarkdown(chunkOptions),
     );
     const results: FeishuReplyDeliverySource[] = [];
     const acceptedChunks: string[] = [];
@@ -957,6 +969,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       text: content,
       useCard: true,
       infoKind,
+      header: cardHeader,
+      note: cardNote,
       chunkMentions: requiredMentionTargets,
       sendChunk: async ({ chunk, mentions }) =>
         await sendStructuredCardFeishu({
@@ -1445,6 +1459,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               text,
               useCard: true,
               infoKind: info?.kind,
+              header: cardHeader,
+              note: cardNote,
               chunkMentions: requiredMentionTargets,
               sendChunk: async ({ chunk, mentions }) =>
                 await sendStructuredCardFeishu({

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -73,7 +73,6 @@ let editMessageFeishu: typeof import("./send.js").editMessageFeishu;
 let getMessageFeishu: typeof import("./send.js").getMessageFeishu;
 let listFeishuThreadMessages: typeof import("./send.js").listFeishuThreadMessages;
 let resolveFeishuCardTemplate: typeof import("./send.js").resolveFeishuCardTemplate;
-let sendMarkdownCardFeishu: typeof import("./send.js").sendMarkdownCardFeishu;
 let sendMessageFeishu: typeof import("./send.js").sendMessageFeishu;
 let sendStructuredCardFeishu: typeof import("./send.js").sendStructuredCardFeishu;
 
@@ -117,7 +116,6 @@ describe("getMessageFeishu", () => {
       getMessageFeishu,
       listFeishuThreadMessages,
       resolveFeishuCardTemplate,
-      sendMarkdownCardFeishu,
       sendMessageFeishu,
       sendStructuredCardFeishu,
     } = await import("./send.js"));
@@ -295,9 +293,9 @@ describe("getMessageFeishu", () => {
       },
     },
     {
-      name: "markdown",
+      name: "without header",
       send: () =>
-        sendMarkdownCardFeishu({ cfg: {} as ClawdbotConfig, to: "oc_card", text: "hello" }),
+        sendStructuredCardFeishu({ cfg: {} as ClawdbotConfig, to: "oc_card", text: "hello" }),
       expectedHeader: undefined,
     },
   ])("sends $name cards with schema-2.0 width config", async ({ send, expectedHeader }) => {
@@ -1070,14 +1068,11 @@ describe("Feishu card-mode newline preservation", () => {
   }
 
   it.each([
-    ["single", "markdown", "line one\nline two\nline three"],
-    ["single", "structured", "first\nsecond\nthird"],
-    ["double", "markdown", "para a\n\npara b"],
-    ["double", "structured", "section 1\n\nsection 2"],
-  ] as const)("preserves %s newlines in %s cards", async (_newline, format, text) => {
+    ["single", "line one\nline two\nline three"],
+    ["double", "para a\n\npara b"],
+  ] as const)("preserves %s newlines in cards", async (_newline, text) => {
     const create = createCardClient();
-    const send = format === "markdown" ? sendMarkdownCardFeishu : sendStructuredCardFeishu;
-    await send({
+    await sendStructuredCardFeishu({
       cfg: {} as ClawdbotConfig,
       to: "oc_card",
       text,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -12,7 +12,9 @@ import { parseInteractiveCardContent } from "./interactive-message-content.js";
 import {
   assertFeishuPostWithinEnvelope,
   buildFeishuPostMessageContent,
+  chunkFeishuMarkdownByEnvelope,
   materializeFeishuPostMarkdownSoftBreaks,
+  type FeishuMarkdownChunkOptions,
 } from "./markdown.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent } from "./mention.js";
@@ -581,28 +583,6 @@ export async function editMessageFeishu(params: {
   return { messageId, contentType: "post" };
 }
 
-/**
- * Build a Feishu interactive card with markdown content.
- * Cards render markdown properly (code blocks, tables, links, etc.)
- * Uses schema 2.0 format for proper markdown rendering.
- */
-function buildMarkdownCard(text: string): Record<string, unknown> {
-  return {
-    schema: "2.0",
-    config: {
-      width_mode: "fill",
-    },
-    body: {
-      elements: [
-        {
-          tag: "markdown",
-          content: text,
-        },
-      ],
-    },
-  };
-}
-
 /** Header configuration for structured Feishu cards. */
 export type CardHeaderConfig = {
   /** Header title text, e.g. "💻 Coder" */
@@ -613,16 +593,19 @@ export type CardHeaderConfig = {
 
 /**
  * Build a Feishu interactive card with optional header and note footer.
- * When header/note are omitted, behaves identically to buildMarkdownCard.
  */
 function buildStructuredCard(
   text: string,
   options?: {
     header?: CardHeaderConfig;
     note?: string;
+    mentions?: MentionTarget[];
   },
 ): Record<string, unknown> {
-  const elements: Record<string, unknown>[] = [{ tag: "markdown", content: text }];
+  const content = options?.mentions?.length
+    ? buildMentionedCardContent(options.mentions, text)
+    : text;
+  const elements: Record<string, unknown>[] = [{ tag: "markdown", content }];
   if (options?.note) {
     elements.push({ tag: "hr" });
     elements.push({ tag: "markdown", content: `<font color='grey'>${options.note}</font>` });
@@ -639,6 +622,31 @@ function buildStructuredCard(
     };
   }
   return card;
+}
+
+export function chunkFeishuCardMarkdown(
+  params: FeishuMarkdownChunkOptions & {
+    header?: CardHeaderConfig;
+    note?: string;
+  },
+): string[] {
+  return chunkFeishuMarkdownByEnvelope({
+    ...params,
+    contentBytes: (text, isFirst) =>
+      Buffer.byteLength(
+        JSON.stringify(
+          buildStructuredCard(text, {
+            header: params.header,
+            note: params.note,
+            mentions: [
+              ...(params.chunkMentions ?? []),
+              ...(isFirst ? (params.firstChunkMentions ?? []) : []),
+            ],
+          }),
+        ),
+        "utf8",
+      ),
+  });
 }
 
 /**
@@ -669,53 +677,7 @@ export async function sendStructuredCardFeishu(params: {
     header,
     note,
   } = params;
-  let cardText = text;
-  if (mentions && mentions.length > 0) {
-    cardText = buildMentionedCardContent(mentions, text);
-  }
-  const card = buildStructuredCard(cardText, { header, note });
-  return sendCardFeishu({
-    cfg,
-    to,
-    card,
-    replyToMessageId,
-    replyInThread,
-    allowTopLevelReplyFallback,
-    accountId,
-  });
-}
-
-/**
- * Send a message as a markdown card (interactive message).
- * This renders markdown properly in Feishu (code blocks, tables, bold/italic, etc.)
- */
-export async function sendMarkdownCardFeishu(params: {
-  cfg: ClawdbotConfig;
-  to: string;
-  text: string;
-  replyToMessageId?: string;
-  /** When true, reply creates a Feishu topic thread instead of an inline reply */
-  replyInThread?: boolean;
-  allowTopLevelReplyFallback?: boolean;
-  /** Mention target users */
-  mentions?: MentionTarget[];
-  accountId?: string;
-}): Promise<FeishuSendResult> {
-  const {
-    cfg,
-    to,
-    text,
-    replyToMessageId,
-    replyInThread,
-    allowTopLevelReplyFallback,
-    mentions,
-    accountId,
-  } = params;
-  let cardText = text;
-  if (mentions && mentions.length > 0) {
-    cardText = buildMentionedCardContent(mentions, text);
-  }
-  const card = buildMarkdownCard(cardText);
+  const card = buildStructuredCard(text, { header, note, mentions });
   return sendCardFeishu({
     cfg,
     to,

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -407,6 +407,36 @@ describe("resolveTextChunkLimit", () => {
 });
 
 describe("chunkMarkdownText", () => {
+  it.each(["length", "newline"] as const)(
+    "preserves indentation at fenced line boundaries in %s mode",
+    (mode) => {
+      for (const indent of ["    ", "\t", " \t "]) {
+        const body = `${indent}value = 1\n`.repeat(10);
+        const chunks = chunkMarkdownTextWithMode(`\`\`\`txt\n${body}\`\`\``, 34, mode);
+        expect(chunks.length).toBeGreaterThan(1);
+        expectFencesBalanced(chunks);
+        // Every split is at an existing line ending; retain it while removing fences.
+        expect
+          .soft(chunks.map((chunk) => chunk.slice(7, -3)).join(""), JSON.stringify(indent))
+          .toBe(body);
+        expect(chunks.every((chunk) => chunk.length <= 34)).toBe(true);
+      }
+    },
+  );
+
+  it.each(["length", "newline"] as const)(
+    "preserves spaces at hard fenced boundaries in %s mode",
+    (mode) => {
+      const body = "abc def ghi jkl mno";
+      const chunks = chunkMarkdownTextWithMode(`\`\`\`txt\n${body}\n\`\`\``, 14, mode);
+      expect(chunks.length).toBeGreaterThan(1);
+      expectFencesBalanced(chunks);
+      // Single-line chunks gain a newline only to close their transport fence.
+      expect(chunks.map((chunk) => chunk.slice(7, -4)).join("")).toBe(body);
+      expect(chunks.every((chunk) => chunk.length <= 14)).toBe(true);
+    },
+  );
+
   it.each([
     {
       name: "keeps fenced blocks intact when a safe break exists",

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -474,14 +474,16 @@ export function chunkMarkdownText(text: string, limit: number): string[] {
     }
 
     let rawChunk = `${reopenPrefix}${rawContent}`;
-    const brokeOnSeparator = breakIdx < text.length && /\s/.test(text.charAt(breakIdx));
-    let nextStart = Math.min(text.length, breakIdx + (brokeOnSeparator ? 1 : 0));
+    let nextStart = breakIdx;
 
     if (fenceToSplit) {
       const closeLine = `${fenceToSplit.indent}${fenceToSplit.marker}`;
       rawChunk = rawChunk.endsWith("\n") ? `${rawChunk}${closeLine}` : `${rawChunk}\n${closeLine}`;
       reopenFence = fenceToSplit;
     } else {
+      // Only prose separators are disposable; fenced whitespace can be code indentation.
+      const brokeOnSeparator = breakIdx < text.length && /\s/.test(text.charAt(breakIdx));
+      nextStart = Math.min(text.length, breakIdx + (brokeOnSeparator ? 1 : 0));
       nextStart = skipLeadingNewlines(text, nextStart);
       reopenFence = undefined;
     }


### PR DESCRIPTION
Closes #131092

AI-assisted implementation and review; maintainer-owned source and behavior verification.

## What Problem This Solves

Fixes an issue where users sending long ordinary Feishu Markdown messages, topic replies, or image captions would exceed the channel's documented card-content limit instead of getting a complete, ordered split message. Existing rich-post fanout also omitted earlier accepted message IDs from the logical receipt.

## Why This Change Was Made

Ordinary cards and rich posts now share the existing adaptive envelope-aware chunking flow. Card sizing uses the same structured-card builder as the physical send, including UTF-8, JSON escaping, fences, identity headers, notes, and mentions. The duplicate Markdown card builder/sender and direct whole-card bypass are removed. Both static reply-dispatcher paths use this owner, including streaming's completed-reply fallback.

The common outbound fanout records accepted sends before callbacks and aggregates existing receipt parts for direct text and media captions. A later send, callback, or upload failure retains the accepted IDs; attachments remain last and are never retried blindly. The existing last-text/attachment primary ID stays the follow-up target; receipt parts, rather than the primary-first platform-ID list, define physical order.

Initial independent review found that the shared Markdown chunker discarded one whitespace character at a fenced boundary. A real Gateway replay confirmed 42,000 Python body characters becoming 41,999. The canonical core repair now consumes separators only in prose, matching the sibling streaming chunker's fence behavior. No Feishu-only compensation was added.

Production LOC: +186/-186 (net 0); tests: +306/-77 (net +229); docs: +6/-1. No new dependency, public SDK/config/protocol surface, or persisted state.

Provenance: the whole-card path is present in stable `v2026.7.1-2`, with no known-good regression claim. The structured-card feature came through #29938 (code/PR author @nszhsl, merger @Takhoffman, 2026-03-15, `df3a247db2a90da2a2593f85bdd5ef07f6b39a91`). The shared fence separator behavior dates to `67bda21811b3923fd428e7434c2f4754a25abfb2` (author/committer @steipete, 2026-01-06), carried forward by later chunker refactors.

## User Impact

Long ordinary Markdown messages and captions fit the existing 30 KB serialized content budget without losing code indentation or other fenced whitespace. Topic chunks stay in their thread, captions finish before the attachment, and receipts describe all accepted physical messages even when a later operation fails. Existing post normalization and configured character limits remain intact.

Native structured presentation cards, TTS/control behavior, and typing/comment lifecycle are outside this repair. Named follow-up: the outer presentation/TTS fallback loops still return their final result across outer fanout; that separate receipt hypothesis has not been reproduced through the native public path and is not claimed fixed here.

## Evidence

- Authentic pre-fix built Gateway → registered Feishu plugin → Lark SDK 1.73.0 → local HTTP observation: three long-card cases emitted 33,127-byte content strings; short direct/thread and plain-post controls passed. Four actual rich posts produced only the last receipt ID.
- Pre-fix SDK/owner regression replay captured 22 failing assertions covering byte limits, metadata, caption receipts, partial delivery, and callback failures. Core fence reconstruction added four failing tests/eight assertions for space, tab, mixed indentation, and hard spaces in both chunking modes.
- Final focused and sibling suite: **558/558 passed across 14 files**, including Feishu (369), shared chunking (76), planner (7), Discord (40), Telegram (20), and Slack (46).
- Final built Gateway: **16/16 scenarios passed** across default and 25,000-character configurations. Maximum observed serialized content was 30,717 bytes. Direct/thread/caption/post receipts include every accepted ID; Python and hard-space bodies reconstruct exactly.
- Final controlled failures: **5/5 passed**. Later card/post rejection retained two accepted IDs, first-send rejection reported no delivery, upload rejection retained all caption IDs, and a fresh changed-target send succeeded afterward.
- Real Lark SDK loopback tests additionally cover header pressure, serialized wire bytes, and callback failure. Dispatcher tests exercise the real card serializer with a mocked SDK client for header/note/required-mention pressure and static streaming fallback. These metadata/callback inputs are not exposed by the public Gateway fixture and are not claimed as source-blind coverage.
- Independent source-blind validation: **14 fresh public actions, 41 HTTP requests, 34 accepted messages; no observed failure**. Five contract clauses passed. Clause 4 passed high-limit byte pressure but its metadata subcase remained blocked because the public interface cannot supply it. Separate source-aware serializer-boundary tests cover that metadata gap. Independent space/tab/LF reconstruction, direct/thread routes, caption ordering, five injected failure paths, and recovery all passed; maximum card content was 30,709 bytes while the separately measured outer HTTP body reached 44,758 bytes.
- Whole-patch authenticated Codex review was clean after repairing the shared fence defect. The full changed gate then found two test callback-local shadowing names; these were renamed without changing production, and the affected **156/156 tests passed**. The final fresh whole-patch review and full changed-file gate both passed. Native and blind proof use identical production bytes.

This is actual built Gateway/SDK wire and receipt proof against a mocked channel API, not SaaS acceptance or Feishu desktop rendering proof. The fixture observes complete serialized content separately from outer HTTP-body bytes and uses a documented permission-error response only for controlled failure tests; it does not invent a size-rejection response.

Compact verdict extracted from the completed native and blind reports; the committed production bytes are identical to the built proof:

```json
{
  "candidate": "fa2a055c2747bdbeceb7ef5c3b3b883b0c0c70c8",
  "productionIdenticalToBuiltProof": true,
  "native": [{"textLimit":4000,"verdict":"pass"},{"textLimit":25000,"verdict":"pass"}],
  "cases": [
    {"case":"short Markdown send control","default":"pass","high":"pass"},
    {"case":"long ordinary Markdown send","default":"pass","high":"pass"},
    {"case":"short Markdown thread control","default":"pass","high":"pass"},
    {"case":"long ordinary Markdown thread reply","default":"pass","high":"pass"},
    {"case":"long plain post control","default":"pass","high":"pass"},
    {"case":"long Markdown caption and one image","default":"pass","high":"pass"},
    {"case":"indented Python reconstruction","default":"pass","high":"pass"},
    {"case":"hard-space fenced reconstruction","default":"pass","high":"pass"}
  ],
  "faults": [
    {"name":"later card rejection prevents image","verdict":"pass","accepted":2,"requests":3},
    {"name":"later post rejection","verdict":"pass","accepted":2,"requests":3},
    {"name":"first card rejection","verdict":"pass","accepted":0,"requests":1},
    {"name":"upload rejection retains all captions","verdict":"pass","accepted":2,"requests":3},
    {"name":"fresh target after failure","verdict":"pass","accepted":1,"requests":1}
  ],
  "sourceBlind": {
    "clauses":{"pass":5,"fail":0,"blocked":1},
    "metadata":"blocked: public fixture does not expose metadata",
    "probes":14,"httpRequests":41,"accepted":34
  }
}
```
