### PR TITLE
refactor(gateway): reuse completed conversation delivery projection

### DIFF
--- a/src/gateway/conversation-delivery.test-support.ts
+++ b/src/gateway/conversation-delivery.test-support.ts
@@ -1,0 +1,51 @@
+import path from "node:path";
+import { onTestFinished, vi } from "vitest";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  beginConversationDeliveryOperation,
+  getConversationDeliveryOperation,
+  markConversationDeliveryQueued,
+  markConversationDeliverySent,
+  markConversationDeliverySuppressed,
+} from "../config/sessions/conversation-delivery-store.js";
+import { registerConversationAddresses } from "../config/sessions/conversation-registry.js";
+import { buildConversationRef } from "../routing/conversation-ref.js";
+import { closeOpenClawAgentDatabaseByPath } from "../state/openclaw-agent-db.js";
+
+const address = {
+  channel: "reef",
+  accountId: "default",
+  kind: "direct" as const,
+  peerId: "molty",
+};
+
+export const conversation = {
+  ...address,
+  conversationRef: buildConversationRef(address),
+  target: "reef:molty",
+  sessionId: "reef-session",
+  sessionKey: "agent:main:reef:direct:molty",
+  role: "participant" as const,
+  firstSeenAt: 100,
+  lastSeenAt: 200,
+};
+
+export function createConversationDeliveryTestStore(agentId = "main") {
+  const dirs = createTempDirTracker();
+  const agentDir = path.join(dirs.make("openclaw-gateway-conversation-"), "agents", agentId);
+  const scope = { agentId, storePath: path.join(agentDir, "sessions", "sessions.json") };
+  onTestFinished(() => {
+    closeOpenClawAgentDatabaseByPath(path.join(agentDir, "agent", "openclaw-agent.sqlite"));
+    dirs.cleanup();
+  });
+  registerConversationAddresses(scope, [{ ...conversation, deliveryTarget: conversation.target }]);
+  return {
+    scope,
+    config: { session: { store: scope.storePath } },
+    beginOperation: vi.fn(beginConversationDeliveryOperation),
+    getOperation: vi.fn(getConversationDeliveryOperation),
+    markQueued: vi.fn(markConversationDeliveryQueued),
+    markSent: vi.fn(markConversationDeliverySent),
+    markSuppressed: vi.fn(markConversationDeliverySuppressed),
+  };
+}

--- a/src/gateway/conversation-send.test.ts
+++ b/src/gateway/conversation-send.test.ts
@@ -1,28 +1,25 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  ConversationDeliveryInputError,
+  beginConversationDeliveryOperation,
+  markConversationDeliveryQueued,
+  markConversationDeliveryRejected,
+  markConversationDeliveryReplied,
+  markConversationDeliverySent,
+  markConversationDeliverySuppressed,
+  markConversationDeliveryUnknown,
   type ConversationDeliveryRecord,
 } from "../config/sessions/conversation-delivery-store.js";
+import { registerConversationAddresses } from "../config/sessions/conversation-registry.js";
 import type { MessageActionResult } from "../infra/outbound/message-action-contracts.js";
+import {
+  conversation,
+  createConversationDeliveryTestStore,
+} from "./conversation-delivery.test-support.js";
 import {
   ConversationInputError,
   ConversationOperationConflictError,
 } from "./conversation-errors.js";
 import { runGatewayConversationSend } from "./conversation-send.js";
-
-const conversation = {
-  conversationRef: "conv_0123456789abcdef0123456789abcdef",
-  channel: "reef",
-  accountId: "default",
-  kind: "direct" as const,
-  peerId: "molty",
-  target: "reef:molty",
-  sessionId: "reef-session",
-  sessionKey: "agent:main:reef:direct:molty",
-  role: "participant" as const,
-  firstSeenAt: 100,
-  lastSeenAt: 200,
-};
 
 function sentResult(): Extract<MessageActionResult, { kind: "send" }> {
   return {
@@ -44,20 +41,7 @@ function sentResult(): Extract<MessageActionResult, { kind: "send" }> {
   };
 }
 
-function createDeps() {
-  const operations = new Map<string, ConversationDeliveryRecord>();
-  const update = (
-    operationId: string,
-    patch: Partial<ConversationDeliveryRecord>,
-  ): ConversationDeliveryRecord => {
-    const current = operations.get(operationId);
-    if (!current) {
-      throw new Error(`missing operation: ${operationId}`);
-    }
-    const next = { ...current, ...patch, updatedAt: current.updatedAt + 1 };
-    operations.set(operationId, next);
-    return next;
-  };
+function createDeps(agentId = "main") {
   const runMessageActionMock = vi.fn(async (input: Record<string, unknown>) => {
     const onDeliveryIntent = input.onDeliveryIntent as (intent: {
       id: string;
@@ -74,72 +58,162 @@ function createDeps() {
     return sentResult();
   });
   return {
-    beginOperation: vi.fn(
-      (
-        _scope: unknown,
-        params: {
-          operationId: string;
-          operationKind: "send" | "turn";
-          conversationRef: string;
-          sourceSessionKey?: string;
-          message: string;
-        },
-      ) => {
-        const existing = operations.get(params.operationId);
-        if (existing) {
-          if (
-            existing.operationKind !== params.operationKind ||
-            existing.conversationRef !== params.conversationRef ||
-            existing.sourceSessionKey !== params.sourceSessionKey ||
-            existing.messageHash !== params.message
-          ) {
-            throw new ConversationDeliveryInputError(
-              `Conversation delivery operation was reused with different input: ${params.operationId}`,
-            );
-          }
-          return { created: false, record: existing };
-        }
-        const record: ConversationDeliveryRecord = {
-          operationId: params.operationId,
-          operationKind: params.operationKind,
-          conversationRef: params.conversationRef,
-          channel: conversation.channel,
-          ...(params.sourceSessionKey ? { sourceSessionKey: params.sourceSessionKey } : {}),
-          messageHash: params.message,
-          status: "created",
-          createdAt: 100,
-          updatedAt: 100,
-        };
-        operations.set(params.operationId, record);
-        return { created: true, record };
-      },
-    ),
-    getOperation: vi.fn((_scope: unknown, operationId: string) => operations.get(operationId)),
-    markQueued: vi.fn((_scope: unknown, operationId: string, queueId: string) =>
-      update(operationId, { status: "queued", queueId }),
-    ),
-    markSent: vi.fn((_scope: unknown, operationId: string, platformMessageId?: string) =>
-      update(operationId, {
-        status: "sent",
-        ...(platformMessageId ? { platformMessageId } : {}),
-      }),
-    ),
-    markSuppressed: vi.fn((_scope: unknown, operationId: string) =>
-      update(operationId, { status: "suppressed" }),
-    ),
+    ...createConversationDeliveryTestStore(agentId),
     resolveConversation: vi.fn((): typeof conversation | undefined => conversation),
     runMessageAction: runMessageActionMock as never,
     runMessageActionMock,
-    operations,
   };
 }
 
 describe("runGatewayConversationSend", () => {
+  it.each([
+    {
+      status: "sent",
+      preparedMessageId: "prepared",
+      platformMessageId: "platform",
+      messageId: "platform",
+    },
+    { status: "sent", preparedMessageId: "prepared", messageId: "prepared" },
+    { status: "sent" },
+    {
+      status: "replied",
+      preparedMessageId: "prepared",
+      platformMessageId: "platform",
+      messageId: "platform",
+    },
+    { status: "queued", preparedMessageId: "prepared", messageId: "prepared" },
+    { status: "queued" },
+    { status: "suppressed", preparedMessageId: "prepared" },
+    { status: "unknown", preparedMessageId: "prepared" },
+    { status: "rejected" },
+  ] satisfies Array<{
+    status: ConversationDeliveryRecord["status"];
+    preparedMessageId?: string;
+    platformMessageId?: string;
+    messageId?: string;
+  }>)(
+    "replays $status with persisted metadata and no current store access ($messageId)",
+    async ({ status, preparedMessageId, platformMessageId, messageId }) => {
+      const deps = createDeps();
+      const operationId = "send-completed";
+      beginConversationDeliveryOperation(deps.scope, {
+        operationId,
+        operationKind: "send",
+        conversationRef: conversation.conversationRef,
+        message: "hello",
+        preparedMessageId,
+      });
+      markConversationDeliveryQueued(deps.scope, operationId, "queue-existing");
+      switch (status) {
+        case "queued":
+          break;
+        case "sent":
+        case "replied":
+          markConversationDeliverySent(deps.scope, operationId, platformMessageId);
+          if (status === "replied") {
+            markConversationDeliveryReplied(deps.scope, {
+              operationId,
+              reply: { messageId: "reply-existing", text: "ack", timestamp: 300 },
+            });
+          }
+          break;
+        case "suppressed":
+          markConversationDeliverySuppressed(deps.scope, operationId);
+          break;
+        case "unknown":
+          markConversationDeliveryUnknown(deps.scope, operationId);
+          break;
+        case "rejected":
+          markConversationDeliveryRejected(deps.scope, operationId, "permanent rejection");
+          break;
+      }
+      deps.resolveConversation.mockReturnValue({
+        ...conversation,
+        channel: "reef-current",
+        conversationRef: "conv_ffffffffffffffffffffffffffffffff",
+      });
+      const result = runGatewayConversationSend(
+        {
+          config: deps.config,
+          readCurrentConfig: () => ({
+            session: {
+              get store(): string {
+                throw new Error("current store must not be opened");
+              },
+            },
+          }),
+          agentId: "main",
+          senderIsOwner: true,
+          operationId,
+          conversationRef: conversation.conversationRef,
+          message: "hello",
+        },
+        deps,
+      );
+      if (status === "rejected") {
+        await expect(result).rejects.toMatchObject({
+          name: "ConversationInputError",
+          message: "permanent rejection",
+        });
+      } else {
+        await expect(result).resolves.toEqual({
+          status: status === "replied" ? "sent" : status,
+          conversationRef: conversation.conversationRef,
+          channel: conversation.channel,
+          queueId: "queue-existing",
+          ...(messageId ? { messageId } : {}),
+        });
+      }
+      expect(deps.resolveConversation).toHaveBeenCalled();
+      expect(deps.runMessageAction).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([false, true])(
+    "projects current conversation metadata for an unfinished send (existing=%s)",
+    async (existing) => {
+      const deps = createDeps();
+      if (existing) {
+        beginConversationDeliveryOperation(deps.scope, {
+          operationId: "send-unfinished",
+          operationKind: "send",
+          conversationRef: conversation.conversationRef,
+          message: "hello",
+        });
+      }
+      const current = {
+        ...conversation,
+        channel: "reef-current",
+        conversationRef: "conv_ffffffffffffffffffffffffffffffff",
+      };
+      registerConversationAddresses(deps.scope, [{ ...current, deliveryTarget: current.target }]);
+      deps.resolveConversation.mockReturnValue(current);
+      await expect(
+        runGatewayConversationSend(
+          {
+            config: deps.config,
+            agentId: "main",
+            senderIsOwner: true,
+            operationId: "send-unfinished",
+            conversationRef: conversation.conversationRef,
+            message: "hello",
+          },
+          deps,
+        ),
+      ).resolves.toMatchObject({
+        status: "sent",
+        channel: current.channel,
+        conversationRef: current.conversationRef,
+      });
+      expect(deps.runMessageAction).toHaveBeenCalledOnce();
+    },
+  );
+
   it("owns durable delivery in the Gateway and binds the source session", async () => {
     const deps = createDeps();
     const result = await runGatewayConversationSend(
       {
-        config: {},
+        config: deps.config,
         agentId: "main",
         senderIsOwner: true,
         sourceSessionKey: "agent:main:telegram:direct:operator",
@@ -177,55 +251,21 @@ describe("runGatewayConversationSend", () => {
     });
   });
 
-  it("returns durable completed state without recipient-visible I/O", async () => {
-    const deps = createDeps();
-    deps.operations.set("send-replayed", {
-      operationId: "send-replayed",
-      operationKind: "send",
-      conversationRef: conversation.conversationRef,
-      channel: conversation.channel,
-      messageHash: "hello",
-      status: "sent",
-      platformMessageId: "reef-existing",
-      queueId: "queue-existing",
-      createdAt: 100,
-      updatedAt: 200,
-    });
-    await expect(
-      runGatewayConversationSend(
-        {
-          config: {},
-          agentId: "main",
-          senderIsOwner: true,
-          operationId: "send-replayed",
-          conversationRef: conversation.conversationRef,
-          message: "hello",
-        },
-        deps,
-      ),
-    ).resolves.toMatchObject({ status: "sent", messageId: "reef-existing" });
-    expect(deps.resolveConversation).toHaveBeenCalled();
-    expect(deps.runMessageAction).not.toHaveBeenCalled();
-  });
-
   it("does not reveal completed send state after the route owner changes", async () => {
     const deps = createDeps();
-    deps.operations.set("send-reassigned", {
+    beginConversationDeliveryOperation(deps.scope, {
       operationId: "send-reassigned",
       operationKind: "send",
       conversationRef: conversation.conversationRef,
-      channel: conversation.channel,
-      messageHash: "hello",
-      status: "sent",
-      platformMessageId: "reef-private-message",
-      createdAt: 100,
-      updatedAt: 200,
+      message: "hello",
     });
+    markConversationDeliverySent(deps.scope, "send-reassigned", "reef-private-message");
 
     await expect(
       runGatewayConversationSend(
         {
           config: {
+            ...deps.config,
             agents: { entries: { main: {}, finance: {} } },
             bindings: [
               {
@@ -253,6 +293,7 @@ describe("runGatewayConversationSend", () => {
       runGatewayConversationSend(
         {
           config: {
+            ...deps.config,
             agents: { entries: { main: {}, finance: {} } },
             bindings: [
               {
@@ -295,8 +336,9 @@ describe("runGatewayConversationSend", () => {
     }) as never;
     const readCurrentConfig = vi
       .fn()
-      .mockReturnValueOnce({})
+      .mockReturnValueOnce(deps.config)
       .mockReturnValue({
+        ...deps.config,
         agents: { entries: { main: {}, finance: {} } },
         bindings: [
           {
@@ -310,7 +352,7 @@ describe("runGatewayConversationSend", () => {
     await expect(
       runGatewayConversationSend(
         {
-          config: {},
+          config: deps.config,
           readCurrentConfig,
           agentId: "main",
           senderIsOwner: true,
@@ -328,11 +370,11 @@ describe("runGatewayConversationSend", () => {
 
   it("namespaces stable queue intents across agents", async () => {
     const mainDeps = createDeps();
-    const workerDeps = createDeps();
+    const workerDeps = createDeps("worker");
 
     await runGatewayConversationSend(
       {
-        config: {},
+        config: mainDeps.config,
         agentId: "main",
         senderIsOwner: true,
         operationId: "shared-operation",
@@ -344,6 +386,7 @@ describe("runGatewayConversationSend", () => {
     await runGatewayConversationSend(
       {
         config: {
+          ...workerDeps.config,
           agents: { entries: { worker: { default: true } } },
         },
         agentId: "worker",
@@ -369,7 +412,7 @@ describe("runGatewayConversationSend", () => {
     await expect(
       runGatewayConversationSend(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           operationId: "send-missing",
@@ -385,22 +428,19 @@ describe("runGatewayConversationSend", () => {
 
   it("preserves durable operation conflicts for Gateway identity recovery", async () => {
     const deps = createDeps();
-    deps.operations.set("send-reused", {
+    beginConversationDeliveryOperation(deps.scope, {
       operationId: "send-reused",
       operationKind: "send",
       conversationRef: conversation.conversationRef,
-      channel: conversation.channel,
-      messageHash: "original",
-      status: "sent",
-      createdAt: 100,
-      updatedAt: 200,
+      message: "original",
     });
+    markConversationDeliverySent(deps.scope, "send-reused");
     deps.resolveConversation.mockReturnValue(undefined);
 
     await expect(
       runGatewayConversationSend(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           operationId: "send-reused",

--- a/src/gateway/conversation-send.ts
+++ b/src/gateway/conversation-send.ts
@@ -12,6 +12,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   ConversationDeliveryRejectedError,
   defaultConversationDeliveryDeps,
+  resultFromExistingOperation,
   sendGatewayConversationMessage,
   type ConversationDeliveryDeps,
 } from "../infra/outbound/conversation-delivery.js";
@@ -32,44 +33,6 @@ const defaultDeps: ConversationSendDeps = {
   ...defaultConversationDeliveryDeps,
   resolveConversation,
 };
-
-function resultForCompletedOperation(
-  operation: ConversationDeliveryRecord,
-): ConversationSendResult | undefined {
-  const base = {
-    conversationRef: operation.conversationRef,
-    channel: operation.channel,
-    ...(operation.queueId ? { queueId: operation.queueId } : {}),
-  };
-  switch (operation.status) {
-    case "sent":
-    case "replied":
-      return {
-        ...base,
-        status: "sent",
-        ...(operation.platformMessageId || operation.preparedMessageId
-          ? { messageId: operation.platformMessageId ?? operation.preparedMessageId }
-          : {}),
-      };
-    case "queued":
-      return {
-        ...base,
-        status: "queued",
-        ...(operation.preparedMessageId ? { messageId: operation.preparedMessageId } : {}),
-      };
-    case "suppressed":
-      return { ...base, status: "suppressed" };
-    case "rejected":
-      throw new ConversationDeliveryRejectedError(
-        operation.rejectionError ?? "Conversation delivery was permanently rejected",
-      );
-    case "unknown":
-      return { ...base, status: "unknown" };
-    case "created":
-      return undefined;
-  }
-  return operation.status satisfies never;
-}
 
 /** Performs one durable conversation send inside the Gateway channel owner. */
 export async function runGatewayConversationSend(
@@ -113,42 +76,41 @@ export async function runGatewayConversationSend(
       conversation,
     });
     const routeFingerprint = resolveConversationRouteFingerprint(conversation);
-    if (operation) {
-      const completed = resultForCompletedOperation(operation);
-      if (completed) {
-        return completed;
-      }
-    }
-    const sent = await sendGatewayConversationMessage({
-      deps,
-      context: {
-        agentId: params.agentId,
-        ...(params.sourceSessionKey ? { sourceSessionKey: params.sourceSessionKey } : {}),
-        config: currentConfig,
-        senderIsOwner: params.senderIsOwner,
-      },
-      conversation,
-      message: params.message,
-      operationId: params.operationId,
-      operationKind: "send",
-      routeFingerprint,
-      onDeliveryAttempt: async () => {
-        assertConversationDeliveryAttemptAuthorized({
-          config: params.readCurrentConfig?.() ?? currentConfig,
+    // Completed retries retain persisted metadata and bypass current delivery-store resolution.
+    const completed = operation ? resultFromExistingOperation(operation) : undefined;
+    const sent =
+      completed ??
+      (await sendGatewayConversationMessage({
+        deps,
+        context: {
           agentId: params.agentId,
-          conversationRef: conversation.conversationRef,
-          expectedRouteFingerprint: routeFingerprint,
-          scope,
-          resolveConversation: deps.resolveConversation,
-        });
-      },
-      ...(operation ? { operation } : {}),
-      ...(params.signal ? { signal: params.signal } : {}),
-    });
+          ...(params.sourceSessionKey ? { sourceSessionKey: params.sourceSessionKey } : {}),
+          config: currentConfig,
+          senderIsOwner: params.senderIsOwner,
+        },
+        conversation,
+        message: params.message,
+        operationId: params.operationId,
+        operationKind: "send",
+        routeFingerprint,
+        onDeliveryAttempt: async () => {
+          assertConversationDeliveryAttemptAuthorized({
+            config: params.readCurrentConfig?.() ?? currentConfig,
+            agentId: params.agentId,
+            conversationRef: conversation.conversationRef,
+            expectedRouteFingerprint: routeFingerprint,
+            scope,
+            resolveConversation: deps.resolveConversation,
+          });
+        },
+        ...(operation ? { operation } : {}),
+        ...(params.signal ? { signal: params.signal } : {}),
+      }));
+    const resultConversation = completed ? completed.operation : conversation;
     return {
       status: sent.deliveryStatus,
-      conversationRef: conversation.conversationRef,
-      channel: conversation.channel,
+      conversationRef: resultConversation.conversationRef,
+      channel: resultConversation.channel,
       ...(sent.messageId ? { messageId: sent.messageId } : {}),
       ...(sent.operation.queueId ? { queueId: sent.operation.queueId } : {}),
     };

--- a/src/gateway/conversation-turn.test.ts
+++ b/src/gateway/conversation-turn.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  ConversationDeliveryInputError,
-  type ConversationDeliveryRecord,
+  beginConversationDeliveryOperation,
+  markConversationDeliveryQueued,
+  markConversationDeliveryRejected,
+  markConversationDeliveryReplied,
+  markConversationDeliverySent,
 } from "../config/sessions/conversation-delivery-store.js";
 import type { ConversationRecord } from "../config/sessions/conversation-registry.js";
 import { PlatformMessageNotDispatchedError } from "../infra/outbound/deliver-types.js";
@@ -10,22 +13,12 @@ import {
   claimPendingConversationTurnReply,
   registerPendingConversationTurn,
 } from "../sessions/conversation-turns.js";
+import {
+  conversation,
+  createConversationDeliveryTestStore,
+} from "./conversation-delivery.test-support.js";
 import { ConversationInputError } from "./conversation-errors.js";
 import { runGatewayConversationTurn } from "./conversation-turn.js";
-
-const conversation = {
-  conversationRef: "conv_0123456789abcdef0123456789abcdef",
-  channel: "reef",
-  accountId: "default",
-  kind: "direct" as const,
-  peerId: "molty",
-  target: "reef:molty",
-  sessionId: "reef-session",
-  sessionKey: "agent:main:reef:direct:molty",
-  role: "participant" as const,
-  firstSeenAt: 100,
-  lastSeenAt: 200,
-};
 
 function sentResult(messageId = "reef-outbound-1"): Extract<MessageActionResult, { kind: "send" }> {
   return {
@@ -49,78 +42,8 @@ function sentResult(messageId = "reef-outbound-1"): Extract<MessageActionResult,
 }
 
 function createDeps() {
-  const operations = new Map<string, ConversationDeliveryRecord>();
-  const update = (
-    operationId: string,
-    patch: Partial<ConversationDeliveryRecord>,
-  ): ConversationDeliveryRecord => {
-    const current = operations.get(operationId);
-    if (!current) {
-      throw new Error(`missing operation: ${operationId}`);
-    }
-    const next = { ...current, ...patch, updatedAt: current.updatedAt + 1 };
-    operations.set(operationId, next);
-    return next;
-  };
   return {
-    beginOperation: vi.fn(
-      (
-        _scope: unknown,
-        params: {
-          operationId: string;
-          operationKind: "send" | "turn";
-          conversationRef: string;
-          sourceSessionKey?: string;
-          message: string;
-          preparedMessageId?: string;
-        },
-      ) => {
-        const existing = operations.get(params.operationId);
-        if (existing) {
-          if (
-            existing.operationKind !== params.operationKind ||
-            existing.conversationRef !== params.conversationRef ||
-            existing.sourceSessionKey !== params.sourceSessionKey ||
-            existing.messageHash !== params.message
-          ) {
-            throw new ConversationDeliveryInputError(
-              `Conversation delivery operation was reused with different input: ${params.operationId}`,
-            );
-          }
-          return { created: false, record: existing };
-        }
-        const record: ConversationDeliveryRecord = {
-          operationId: params.operationId,
-          operationKind: params.operationKind,
-          conversationRef: params.conversationRef,
-          channel: conversation.channel,
-          ...(params.sourceSessionKey ? { sourceSessionKey: params.sourceSessionKey } : {}),
-          messageHash: params.message,
-          status: "created",
-          ...(params.preparedMessageId ? { preparedMessageId: params.preparedMessageId } : {}),
-          createdAt: 100,
-          updatedAt: 100,
-        };
-        operations.set(params.operationId, record);
-        return { created: true, record };
-      },
-    ),
-    getOperation: vi.fn((_scope: unknown, operationId: string) => operations.get(operationId)),
-    markQueued: vi.fn((_scope: unknown, operationId: string, queueId: string) =>
-      update(operationId, { status: "queued", queueId }),
-    ),
-    markSent: vi.fn((_scope: unknown, operationId: string, platformMessageId?: string) =>
-      update(operationId, {
-        status: "sent",
-        ...(platformMessageId ? { platformMessageId } : {}),
-      }),
-    ),
-    markSuppressed: vi.fn((_scope: unknown, operationId: string) =>
-      update(operationId, { status: "suppressed" }),
-    ),
-    markUnknown: vi.fn((_scope: unknown, operationId: string) =>
-      update(operationId, { status: "unknown" }),
-    ),
+    ...createConversationDeliveryTestStore(),
     registerPendingConversationTurn: vi.fn(registerPendingConversationTurn),
     resolveConversation: vi.fn((): ConversationRecord | undefined => conversation),
     resolveOutboundChannelPlugin: vi.fn(
@@ -141,8 +64,6 @@ function createDeps() {
       async (_params: { assertCommitAllowed?: () => void }) => undefined,
     ),
     runMessageAction: vi.fn(async () => sentResult()) as never,
-    operations,
-    update,
   };
 }
 
@@ -169,6 +90,7 @@ describe("runGatewayConversationTurn", () => {
       runGatewayConversationTurn(
         {
           config: {
+            ...deps.config,
             agents: { entries: { main: {}, finance: {} } },
             bindings: [
               {
@@ -215,7 +137,7 @@ describe("runGatewayConversationTurn", () => {
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-directory-peer",
@@ -252,8 +174,9 @@ describe("runGatewayConversationTurn", () => {
     );
     const readCurrentConfig = vi
       .fn()
-      .mockReturnValueOnce({})
+      .mockReturnValueOnce(deps.config)
       .mockReturnValue({
+        ...deps.config,
         agents: { entries: { main: {}, finance: {} } },
         bindings: [
           {
@@ -267,7 +190,7 @@ describe("runGatewayConversationTurn", () => {
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           readCurrentConfig,
           agentId: "main",
           senderIsOwner: true,
@@ -310,7 +233,7 @@ describe("runGatewayConversationTurn", () => {
 
     const result = await runGatewayConversationTurn(
       {
-        config: {},
+        config: deps.config,
         agentId: "main",
         senderIsOwner: true,
         sourceSessionKey: "agent:main:telegram:direct:operator",
@@ -340,16 +263,12 @@ describe("runGatewayConversationTurn", () => {
     deps.resolveOutboundChannelPlugin.mockReturnValueOnce({
       outbound: {
         prepareConversationTurnMessageId: () => {
-          deps.operations.set("turn-raced", {
+          beginConversationDeliveryOperation(deps.scope, {
             operationId: "turn-raced",
             operationKind: "turn",
             conversationRef: conversation.conversationRef,
-            channel: conversation.channel,
-            messageHash: "hello molty",
-            status: "created",
+            message: "hello molty",
             preparedMessageId: "reef-authoritative-a",
-            createdAt: 100,
-            updatedAt: 100,
           });
           return "reef-candidate-b";
         },
@@ -372,7 +291,7 @@ describe("runGatewayConversationTurn", () => {
 
     const result = await runGatewayConversationTurn(
       {
-        config: {},
+        config: deps.config,
         agentId: "main",
         senderIsOwner: true,
         turnId: "turn-raced",
@@ -393,23 +312,22 @@ describe("runGatewayConversationTurn", () => {
 
   it("returns a prior durable reply without sending again", async () => {
     const deps = createDeps();
-    deps.operations.set("turn-replied", {
+    beginConversationDeliveryOperation(deps.scope, {
       operationId: "turn-replied",
       operationKind: "turn",
       conversationRef: conversation.conversationRef,
-      channel: conversation.channel,
-      messageHash: "hello",
-      status: "replied",
+      message: "hello",
       preparedMessageId: "reef-outbound-1",
-      platformMessageId: "reef-outbound-1",
+    });
+    markConversationDeliverySent(deps.scope, "turn-replied", "reef-outbound-1");
+    markConversationDeliveryReplied(deps.scope, {
+      operationId: "turn-replied",
       reply: { messageId: "reply-1", replyToId: "reef-outbound-1", text: "ack", timestamp: 300 },
-      createdAt: 100,
-      updatedAt: 300,
     });
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-replied",
@@ -427,29 +345,29 @@ describe("runGatewayConversationTurn", () => {
 
   it("does not reveal a completed reply after the route owner changes", async () => {
     const deps = createDeps();
-    deps.operations.set("turn-reassigned", {
+    beginConversationDeliveryOperation(deps.scope, {
       operationId: "turn-reassigned",
       operationKind: "turn",
       conversationRef: conversation.conversationRef,
-      channel: conversation.channel,
-      messageHash: "hello",
-      status: "replied",
+      message: "hello",
       preparedMessageId: "reef-outbound-1",
-      platformMessageId: "reef-outbound-1",
+    });
+    markConversationDeliverySent(deps.scope, "turn-reassigned", "reef-outbound-1");
+    markConversationDeliveryReplied(deps.scope, {
+      operationId: "turn-reassigned",
       reply: {
         messageId: "reply-private",
         replyToId: "reef-outbound-1",
         text: "private finance reply",
         timestamp: 300,
       },
-      createdAt: 100,
-      updatedAt: 300,
     });
 
     await expect(
       runGatewayConversationTurn(
         {
           config: {
+            ...deps.config,
             agents: { entries: { main: {}, finance: {} } },
             bindings: [
               {
@@ -473,23 +391,19 @@ describe("runGatewayConversationTurn", () => {
 
   it("returns queued state without retrying recipient-visible I/O", async () => {
     const deps = createDeps();
-    deps.operations.set("turn-queued", {
+    beginConversationDeliveryOperation(deps.scope, {
       operationId: "turn-queued",
       operationKind: "turn",
       conversationRef: conversation.conversationRef,
-      channel: conversation.channel,
-      messageHash: "hello",
-      status: "queued",
+      message: "hello",
       preparedMessageId: "reef-outbound-1",
-      queueId: "queue-existing",
-      createdAt: 100,
-      updatedAt: 200,
     });
+    markConversationDeliveryQueued(deps.scope, "turn-queued", "queue-existing");
 
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-queued",
@@ -505,24 +419,20 @@ describe("runGatewayConversationTurn", () => {
 
   it("returns a durable permanent rejection as invalid input after restart", async () => {
     const deps = createDeps();
-    deps.operations.set("turn-rejected", {
+    beginConversationDeliveryOperation(deps.scope, {
       operationId: "turn-rejected",
       operationKind: "turn",
       conversationRef: conversation.conversationRef,
-      channel: conversation.channel,
-      messageHash: "hello",
-      status: "rejected",
+      message: "hello",
       preparedMessageId: "reef-outbound-1",
-      queueId: "queue-rejected",
-      rejectionError: "atomic message limit",
-      createdAt: 100,
-      updatedAt: 200,
     });
+    markConversationDeliveryQueued(deps.scope, "turn-rejected", "queue-rejected");
+    markConversationDeliveryRejected(deps.scope, "turn-rejected", "atomic message limit");
 
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-rejected",
@@ -542,23 +452,20 @@ describe("runGatewayConversationTurn", () => {
 
   it("classifies durable operation-id input reuse as invalid input", async () => {
     const deps = createDeps();
-    deps.operations.set("turn-reused", {
+    beginConversationDeliveryOperation(deps.scope, {
       operationId: "turn-reused",
       operationKind: "turn",
       conversationRef: conversation.conversationRef,
-      channel: conversation.channel,
-      messageHash: "original",
-      status: "sent",
+      message: "original",
       preparedMessageId: "reef-outbound-reused",
-      createdAt: 100,
-      updatedAt: 200,
     });
+    markConversationDeliverySent(deps.scope, "turn-reused");
     deps.resolveConversation.mockReturnValue(undefined);
 
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-reused",
@@ -579,23 +486,19 @@ describe("runGatewayConversationTurn", () => {
 
   it("requires a live binding before resuming an unfinished durable turn", async () => {
     const deps = createDeps();
-    deps.operations.set("turn-created", {
+    beginConversationDeliveryOperation(deps.scope, {
       operationId: "turn-created",
       operationKind: "turn",
       conversationRef: conversation.conversationRef,
-      channel: conversation.channel,
-      messageHash: "hello",
-      status: "created",
+      message: "hello",
       preparedMessageId: "reef-outbound-created",
-      createdAt: 100,
-      updatedAt: 100,
     });
     deps.resolveConversation.mockReturnValue(undefined);
 
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-created",
@@ -614,10 +517,11 @@ describe("runGatewayConversationTurn", () => {
   it("classifies a final rendered provider rejection as invalid input", async () => {
     const deps = createDeps();
     deps.runMessageAction = vi.fn(async () => {
-      deps.update("turn-rendered-rejected", {
-        status: "rejected",
-        rejectionError: "atomic message limit",
-      });
+      markConversationDeliveryRejected(
+        deps.scope,
+        "turn-rendered-rejected",
+        "atomic message limit",
+      );
       throw new PlatformMessageNotDispatchedError("atomic message limit", {
         cause: new Error("rendered text is too large"),
         retryable: false,
@@ -627,7 +531,7 @@ describe("runGatewayConversationTurn", () => {
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-rendered-rejected",
@@ -657,10 +561,11 @@ describe("runGatewayConversationTurn", () => {
       try {
         await (input.onDeliveryAttempt as () => Promise<void>)();
       } catch (error) {
-        deps.update("turn-replaced-session", {
-          status: "rejected",
-          rejectionError: error instanceof Error ? error.message : String(error),
-        });
+        markConversationDeliveryRejected(
+          deps.scope,
+          "turn-replaced-session",
+          error instanceof Error ? error.message : String(error),
+        );
         throw error;
       }
       return sentResult();
@@ -669,7 +574,7 @@ describe("runGatewayConversationTurn", () => {
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-replaced-session",
@@ -697,7 +602,7 @@ describe("runGatewayConversationTurn", () => {
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-unsupported",
@@ -728,7 +633,7 @@ describe("runGatewayConversationTurn", () => {
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-preflight-rejected",
@@ -757,7 +662,7 @@ describe("runGatewayConversationTurn", () => {
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-wrong-id",
@@ -798,7 +703,7 @@ describe("runGatewayConversationTurn", () => {
     await expect(
       runGatewayConversationTurn(
         {
-          config: {},
+          config: deps.config,
           agentId: "main",
           senderIsOwner: true,
           turnId: "turn-suppressed",

--- a/src/infra/outbound/conversation-delivery.ts
+++ b/src/infra/outbound/conversation-delivery.ts
@@ -101,7 +101,7 @@ function readMessageIdFromActionResult(result: MessageActionResult): string | un
   return undefined;
 }
 
-function resultFromExistingOperation(
+export function resultFromExistingOperation(
   operation: ConversationDeliveryRecord,
 ): ConversationMessageDeliveryResult | undefined {
   switch (operation.status) {


### PR DESCRIPTION
## What Problem This Solves

Completed conversation-send retries duplicated the canonical delivery-result projection, while their tests used copied in-memory stores instead of the real conversation storage owner. That left two internal interpretations of the same durable operation and made the tests less representative of production persistence.

## Why This Change Was Made

The Gateway send path now reuses `resultFromExistingOperation`, the canonical completed-delivery projection. Completed retries still validate current route eligibility before replay, retain persisted operation metadata, and bypass fresh delivery-store resolution and transport; fresh sends keep their existing current-conversation projection and delivery behavior. Test setup now uses the canonical SQLite-backed store through one shared helper.

## User Impact

No user-visible behavior, schema, protocol, configuration, or public API changes. This is an internal behavior-preserving consolidation of completed delivery replay and its tests.

## Evidence

- Strengthened owner baseline on unchanged production: 35/35 passed.
- Final owner suite: 35/35 passed; sibling conversation contracts: 85 passed.
- Complete changed-file gate: exit 0 after the explicit status case was corrected; all routed types, lint, format, dead-code scans, and guards passed.
- Exact-head CI passed on attempt 2. Attempt 1's only independent failure was two unchanged browser-server harness cases that received `ECONNREFUSED` during startup before their route assertions; the unchanged failed-only retry passed. The startup cause was not reproduced or proven. Named follow-up: improve deterministic browser test-server startup diagnostics and lifecycle proof without extending its existing retry window.
- Isolated P0 autoreview: no findings, 0.95 confidence.
- Production LOC: +34/-72 (net -38). Tests/support: +290/-294 (net -4). Total: net -42.
- Both completed retries and fresh sends resolve and authorize the current route; completed retries preserve persisted metadata while bypassing fresh delivery-store resolution and transport.
