### PR TITLE
test(whatsapp): fix order-dependent pairing-prompt flake with event-driven inbound drain

### DIFF
--- a/extensions/whatsapp/src/inbound.media.test.ts
+++ b/extensions/whatsapp/src/inbound.media.test.ts
@@ -263,9 +263,11 @@ const QUOTED_SYNTHETIC_API_KEY = "synthetic-quoted-api-key-never-real";
 const DEPLOYMENT_REDACTION_SENTINEL = "deployment-secret-never-real";
 
 async function waitForMessage(onMessage: ReturnType<typeof vi.fn>) {
+  // Saturated no-isolate suite runs can stall the worker (sync module fetches
+  // against the shared transform queue) well past a 2s delivery budget.
   await vi.waitFor(() => expect(onMessage).toHaveBeenCalledTimes(1), {
     interval: 1,
-    timeout: 2_000,
+    timeout: 5_000,
   });
   return onMessage.mock.calls[0]?.[0];
 }

--- a/extensions/whatsapp/src/monitor-inbox.access-and-echo.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.access-and-echo.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it, vi } from "vitest";
 import { isRecentOutboundMessage } from "./inbound/dedupe.js";
 import {
   buildNotifyMessageUpsert,
-  expectPairingPromptSent,
   getRecordChannelActivityMock,
   installWebMonitorInboxUnitTestHooks,
   mockLoadConfig,
@@ -12,6 +11,7 @@ import {
   startInboxMonitor,
   upsertPairingRequestMock,
   waitForMessageCalls,
+  waitForPairingPromptSent,
 } from "./monitor-inbox.test-harness.js";
 
 const nowSeconds = (offsetMs = 0) => Math.floor((Date.now() + offsetMs) / 1000);
@@ -227,14 +227,8 @@ describe("web monitor inbox", () => {
     });
 
     sock.ev.emit("messages.upsert", upsertBlocked);
-    await vi.waitFor(
-      () => {
-        expect(sock.sendMessage).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 5_000, interval: 5 },
-    );
+    await waitForPairingPromptSent(sock, "999@s.whatsapp.net", "+999");
     expect(onMessage).not.toHaveBeenCalled();
-    expectPairingPromptSent(sock, "999@s.whatsapp.net", "+999");
 
     const upsertBlockedAgain = buildNotifyMessageUpsert({
       id: "no-config-1b",
@@ -293,15 +287,9 @@ describe("web monitor inbox", () => {
     });
 
     sock.ev.emit("messages.upsert", upsertBlocked);
-    await vi.waitFor(
-      () => {
-        expect(sock.sendMessage).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 5_000, interval: 5 },
-    );
+    await waitForPairingPromptSent(sock, "999@s.whatsapp.net", "+999");
 
     expect(onMessage).not.toHaveBeenCalled();
-    expectPairingPromptSent(sock, "999@s.whatsapp.net", "+999");
 
     await listener.close();
   });

--- a/extensions/whatsapp/src/monitor-inbox.media-and-session.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.media-and-session.test.ts
@@ -1,14 +1,12 @@
 // WhatsApp monitor inbox media and session behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  DEFAULT_ACCOUNT_ID,
-  getAuthDir,
-  getMonitorWebInbox,
   getSock,
   installWebMonitorInboxUnitTestHooks,
   mockLoadConfig,
+  startInboxMonitor,
+  waitForInboundWorkDrained,
 } from "./monitor-inbox.test-harness.js";
-let monitorWebInbox: typeof import("./inbound.js").monitorWebInbox;
 const inboundLoggerInfoMock = vi.hoisted(() => vi.fn());
 
 vi.mock("openclaw/plugin-sdk/logging-core", async () => {
@@ -31,48 +29,19 @@ describe("web monitor inbox", () => {
 
   beforeEach(() => {
     inboundLoggerInfoMock.mockReset();
-    monitorWebInbox = getMonitorWebInbox();
   });
 
-  async function openMonitor(
-    onMessage = vi.fn(),
-    extraOptions: Partial<Parameters<typeof monitorWebInbox>[0]> = {},
-  ) {
-    return await monitorWebInbox({
-      cfg: mockLoadConfig() as never,
-      verbose: false,
-      accountId: DEFAULT_ACCOUNT_ID,
-      authDir: getAuthDir(),
-      onMessage,
-      ...extraOptions,
-    });
+  async function openMonitor(onMessage = vi.fn()) {
+    const { listener } = await startInboxMonitor(onMessage);
+    return listener;
   }
 
   async function runSingleUpsertAndCapture(upsert: unknown) {
     const onMessage = vi.fn();
-    let armed = false;
-    let observedPendingWork = false;
-    let resolvePendingWorkDrained!: () => void;
-    const pendingWorkDrained = new Promise<void>((resolve) => {
-      resolvePendingWorkDrained = resolve;
-    });
-    const listener = await openMonitor(onMessage, {
-      onPendingWorkChanged: (pendingWorkCount) => {
-        if (!armed) {
-          return;
-        }
-        if (pendingWorkCount > 0) {
-          observedPendingWork = true;
-        } else if (observedPendingWork) {
-          resolvePendingWorkDrained();
-        }
-      },
-    });
-    const sock = getSock();
-    // The monitor owns async media and delivery work; wait for its drain signal instead of polling.
-    armed = true;
+    const { listener, sock } = await startInboxMonitor(onMessage);
     sock.ev.emit("messages.upsert", upsert);
-    await pendingWorkDrained;
+    // The monitor owns async media and delivery work; wait for its drain instead of polling.
+    await waitForInboundWorkDrained();
     return { onMessage, listener, sock };
   }
 

--- a/extensions/whatsapp/src/monitor-inbox.policy.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.policy.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { WebInboundMessage } from "./inbound/types.js";
 import {
   DEFAULT_ACCOUNT_ID,
-  expectPairingPromptSent,
   getAuthDir,
   getMonitorWebInbox,
   getSock,
@@ -11,6 +10,7 @@ import {
   mockLoadConfig,
   settleInboundWork,
   waitForMessageCalls,
+  waitForPairingPromptSent,
 } from "./monitor-inbox.test-harness.js";
 
 const nowSeconds = (offsetMs = 0) => Math.floor((Date.now() + offsetMs) / 1000);
@@ -122,7 +122,7 @@ describe("web monitor inbox", () => {
         }),
       ),
     );
-    await vi.waitFor(() => expectPairingPromptSent(sock, "999@s.whatsapp.net", "+999"));
+    await waitForPairingPromptSent(sock, "999@s.whatsapp.net", "+999");
 
     // Should NOT call onMessage for unauthorized senders
     expect(onMessage).not.toHaveBeenCalled();

--- a/extensions/whatsapp/src/monitor-inbox.policy.test.ts
+++ b/extensions/whatsapp/src/monitor-inbox.policy.test.ts
@@ -2,13 +2,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { WebInboundMessage } from "./inbound/types.js";
 import {
-  DEFAULT_ACCOUNT_ID,
-  getAuthDir,
-  getMonitorWebInbox,
-  getSock,
   installWebMonitorInboxUnitTestHooks,
   mockLoadConfig,
-  settleInboundWork,
+  startInboxMonitor,
+  waitForInboundWorkDrained,
   waitForMessageCalls,
   waitForPairingPromptSent,
 } from "./monitor-inbox.test-harness.js";
@@ -59,28 +56,16 @@ async function startWebInboxMonitor(params: {
   loadConfig?: () => Record<string, unknown>;
   sendReadReceipts?: boolean;
 }) {
-  const monitorWebInbox = getMonitorWebInbox();
   if (params.config) {
     mockLoadConfig.mockReturnValue(params.config);
   }
   const onMessage = vi.fn();
-  const base = {
+  const { listener, sock } = await startInboxMonitor(onMessage, {
     cfg: (params.config ?? mockLoadConfig()) as never,
     ...(params.loadConfig ? { loadConfig: params.loadConfig as never } : {}),
-    verbose: false,
-    accountId: DEFAULT_ACCOUNT_ID,
-    authDir: getAuthDir(),
-    onMessage,
-  };
-  const listener = await monitorWebInbox(
-    params.sendReadReceipts === undefined
-      ? base
-      : {
-          ...base,
-          sendReadReceipts: params.sendReadReceipts,
-        },
-  );
-  return { onMessage, listener, sock: getSock() };
+    ...(params.sendReadReceipts === undefined ? {} : { sendReadReceipts: params.sendReadReceipts }),
+  });
+  return { onMessage, listener, sock };
 }
 
 function firstInboundPayload(onMessage: ReturnType<typeof vi.fn>) {
@@ -169,7 +154,7 @@ describe("web monitor inbox", () => {
         }),
       ),
     );
-    await settleInboundWork();
+    await waitForInboundWorkDrained();
 
     expect(onMessage).not.toHaveBeenCalled();
     expect(sock.sendMessage).not.toHaveBeenCalled();
@@ -367,7 +352,7 @@ describe("web monitor inbox", () => {
           }),
         ),
       );
-      await settleInboundWork();
+      await waitForInboundWorkDrained();
 
       expect(onMessage).toHaveBeenCalledTimes(expectedCalls);
       if (expectedCalls === 1) {

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -353,7 +353,7 @@ export function buildNotifyMessageUpsert(params: {
   };
 }
 
-export function expectPairingPromptSent(sock: MockSock, jid: string, senderE164: string) {
+function expectPairingPromptSent(sock: MockSock, jid: string, senderE164: string) {
   expect(sock.sendMessage).toHaveBeenCalledTimes(1);
   const sendCall = sock.sendMessage.mock.calls.at(0);
   expect(sendCall?.[0]).toBe(jid);
@@ -362,6 +362,15 @@ export function expectPairingPromptSent(sock: MockSock, jid: string, senderE164:
     idLine: `Your WhatsApp phone number: ${senderE164}`,
     code: "PAIRCODE",
   });
+}
+
+export async function waitForPairingPromptSent(sock: MockSock, jid: string, senderE164: string) {
+  await vi.waitFor(
+    () => expectPairingPromptSent(sock, jid, senderE164),
+    // Saturated no-isolate suite runs can stall the worker (sync module fetches
+    // against the shared transform queue) past vi.waitFor's 1s default budget.
+    { timeout: 5_000, interval: 5 },
+  );
 }
 
 let authDir: string | undefined;

--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -276,17 +276,64 @@ function expectInboxPairingReplyText(
   return resolvedCode;
 }
 
-export function getMonitorWebInbox(): MonitorWebInbox {
-  if (!monitorWebInbox) {
-    throw new Error("monitorWebInbox not initialized");
-  }
-  return monitorWebInbox;
-}
-
+// Yields two macrotask ticks so already-scheduled inbound continuations run.
+// This deliberately does NOT wait for pending inbound work to finish — tests
+// observing intermediate states (held handlers, parked debounce batches) rely
+// on that. For final-state assertions use waitForInboundWorkDrained().
 export async function settleInboundWork() {
   await new Promise((resolve) => {
     setImmediate(resolve);
   });
+  await new Promise((resolve) => {
+    setImmediate(resolve);
+  });
+}
+
+type InboundWorkTracker = { pending: number };
+const inboundWorkTrackers = new Set<InboundWorkTracker>();
+let inboundDrainWaiters: Array<() => void> = [];
+
+function releaseInboundDrainWaitersIfIdle() {
+  if (inboundDrainWaiters.length === 0) {
+    return;
+  }
+  for (const tracker of inboundWorkTrackers) {
+    if (tracker.pending > 0) {
+      return;
+    }
+  }
+  const waiters = inboundDrainWaiters;
+  inboundDrainWaiters = [];
+  for (const release of waiters) {
+    release();
+  }
+}
+
+function hasPendingInboundWork(): boolean {
+  for (const tracker of inboundWorkTrackers) {
+    if (tracker.pending > 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Event-driven drain: resolves when every harness-started listener reports zero
+// pending inbound work. Unlike a vi.waitFor deadline, this cannot fail spuriously
+// when a saturated no-isolate worker stalls mid-flow (sync module fetches against
+// the shared transform queue starve waitFor's interval timers). Do not call it
+// while a handler or debounced batch is intentionally held open — it would wait
+// for that work too; use settleInboundWork/waitForMessageCalls there.
+export async function waitForInboundWorkDrained() {
+  if (inboundWorkTrackers.size === 0) {
+    throw new Error("waitForInboundWorkDrained requires a listener started via startInboxMonitor");
+  }
+  if (hasPendingInboundWork()) {
+    await new Promise<void>((resolve) => {
+      inboundDrainWaiters.push(resolve);
+    });
+  }
+  // One extra tick lets drained-callback continuations (delivery bookkeeping) run.
   await new Promise((resolve) => {
     setImmediate(resolve);
   });
@@ -316,13 +363,24 @@ export async function startInboxMonitor(
   if (!monitorWebInbox) {
     ({ monitorWebInbox } = await import("./inbound.js"));
   }
-  const listener = await monitorWebInbox({
+  const merged = {
     cfg: mockLoadConfig() as never,
     verbose: false,
     onMessage,
     accountId: DEFAULT_ACCOUNT_ID,
     authDir: getAuthDir(),
     ...extraOptions,
+  };
+  const tracker: InboundWorkTracker = { pending: 0 };
+  inboundWorkTrackers.add(tracker);
+  const callerOnPendingWorkChanged = merged.onPendingWorkChanged;
+  const listener = await monitorWebInbox({
+    ...merged,
+    onPendingWorkChanged: (pendingWorkCount: number, at?: number) => {
+      tracker.pending = pendingWorkCount;
+      releaseInboundDrainWaitersIfIdle();
+      callerOnPendingWorkChanged?.(pendingWorkCount, at);
+    },
   });
   return { listener, sock: getSock() };
 }
@@ -364,13 +422,12 @@ function expectPairingPromptSent(sock: MockSock, jid: string, senderE164: string
   });
 }
 
+// The pairing reply is sent before the inbound handler completes, so a full
+// drain guarantees the prompt is observable — and makes the callers' negative
+// assertions (onMessage/readMessages never called) non-vacuous.
 export async function waitForPairingPromptSent(sock: MockSock, jid: string, senderE164: string) {
-  await vi.waitFor(
-    () => expectPairingPromptSent(sock, jid, senderE164),
-    // Saturated no-isolate suite runs can stall the worker (sync module fetches
-    // against the shared transform queue) past vi.waitFor's 1s default budget.
-    { timeout: 5_000, interval: 5 },
-  );
+  await waitForInboundWorkDrained();
+  expectPairingPromptSent(sock, jid, senderE164);
 }
 
 let authDir: string | undefined;
@@ -388,6 +445,8 @@ export function installWebMonitorInboxUnitTestHooks(opts?: { authDir?: boolean }
   beforeEach(async () => {
     vi.useRealTimers();
     vi.clearAllMocks();
+    inboundWorkTrackers.clear();
+    inboundDrainWaiters = [];
     channelActivityMocks.recordChannelActivity.mockClear();
     pluginRuntimeMocks.reset();
     setWhatsAppRuntime({


### PR DESCRIPTION
## What Problem This Solves

Fixes an order-dependent flake where `extensions/whatsapp/src/monitor-inbox.policy.test.ts > delivery coordinator blocks unauthorized senders outside allowFrom` fails in full `extension-whatsapp` project runs (`node scripts/run-vitest.mjs extensions/whatsapp`) but passes solo — `sock.sendMessage` shows 0 calls at the pairing-prompt assertion. Reproduced on clean `origin/main` at roughly a 50% failure rate (4 of 7 runs).

## Why This Change Was Made

Instrumented probes along the pairing path disproved the suspected isolate:false shared-worker mock-defeat class: in every captured failure the mocks all fired correctly (`upsertChannelPairingRequest` returned `created=true code=PAIRCODE`) and the reply landed on the correct mock sock — just after the deadline. The timestamped trace shows `vi.waitFor` (1s default budget) polling exactly once, then a ~1.5s synchronous worker stall mid-flow (module fetches blocking on the saturated shared transform queue under 16-way file parallelism) starving the interval timers; the prompt arrived milliseconds after the timeout. Sibling pairing tests already used the suite's saturation budget (`{ timeout: 5_000, interval: 5 }`); this test was the one pairing wait left on defaults.

Rather than only widening the deadline, the wait is redesigned to be deadline-free: the harness tracks each listener's `onPendingWorkChanged` signal (already a first-class `monitorWebInbox` option, used the same way by the auto-reply monitor) and `waitForInboundWorkDrained()` resolves when pending inbound work returns to zero. No stall can outlast it, and the callers' negative assertions (`onMessage`/`readMessages` never called) become non-vacuous because they now run against the final state. `settleInboundWork` keeps its yield-ticks semantics for tests that deliberately observe intermediate states (held handlers, parked 60s debounce batches), and `waitForMessageCalls` stays a polling observer for intermediate call counts.

Consolidations in the same change: `monitor-inbox.media-and-session.test.ts`'s bespoke pending-work-drained machinery collapses into the shared helper, the policy and media-and-session monitor helpers route through the harness `startInboxMonitor` (so their listeners are drain-tracked), the duplicated inline pairing waits in `monitor-inbox.access-and-echo.test.ts` become `waitForPairingPromptSent`, the now-unused `getMonitorWebInbox` export is removed, and `inbound.media.test.ts`'s 2s delivery wait (observed failing once with the identical signature) is aligned to the 5s saturation budget.

## User Impact

None at runtime — test-only change (production LOC delta: 0). Maintainers and CI stop hitting the spurious `extension-whatsapp` shard failure in full-project runs.

## Evidence

- Pre-fix repro: 4 of 7 full `extensions/whatsapp` runs failed on clean origin/main (identical `expected ... 1 times, but got 0 times` at `monitor-inbox.test-harness.ts` `expectPairingPromptSent`); file passes solo and passes in strict single-worker order (`OPENCLAW_VITEST_MAX_WORKERS=1`), ruling out cross-file module-state leaks.
- Failing-run probe trace (temporary stderr probes, since reverted): waitFor polled once at `17:01:57.215` (`calls=0`); admit `57.218`; normalize `57.223`; then a 1.48s stall; mocked upsert `58.707` (`created=true code=PAIRCODE`); reply sent to the correct base sock `58.708` (`mock-accepted-1`).
- Post-fix: policy file solo green; 7 consecutive full `extensions/whatsapp` runs green (98 files / 1366 tests each), including 3 rounds of two concurrent full-suite runs (doubled transform-queue contention, harsher than the failing conditions).
- `node scripts/check-changed.mjs` green (format, lint, tsgo lanes, guards, import cycles).
- Codex autoreview clean on both commits ("patch is correct", no accepted findings).
