### PR TITLE
fix(agents): preserve generated video output order

### DIFF
--- a/qa/scenarios/media/video-generation-invocation.yaml
+++ b/qa/scenarios/media/video-generation-invocation.yaml
@@ -25,8 +25,8 @@ scenario:
     - src/video-generation/runtime.ts
     - src/video-generation/capability-overlays.ts
     - src/media/store.ts
-    - test/e2e/qa-lab/media/video-generation-invocation.e2e.test.ts
+    - src/agents/tools/video-generate-tool.storage.test.ts
   execution:
     kind: vitest
-    path: test/e2e/qa-lab/media/video-generation-invocation.e2e.test.ts
+    path: src/agents/tools/video-generate-tool.storage.test.ts
     summary: Run video_generate through deterministic prepared providers, capability fallback, provider option validation, and real media persistence.

--- a/src/agents/tools/video-generate-tool.storage.test.ts
+++ b/src/agents/tools/video-generate-tool.storage.test.ts
@@ -1,17 +1,17 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import type { PreparedModelRuntimeSnapshot } from "../../../../src/agents/prepared-model-runtime.js";
-import { createVideoGenerateTool } from "../../../../src/agents/tools/video-generate-tool.js";
-import type { OpenClawConfig } from "../../../../src/config/types.js";
-import { withEnvAsync } from "../../../../src/test-utils/env.js";
-import { resolveVideoGenerationModeCapabilities } from "../../../../src/video-generation/capabilities.js";
+import { createSolidPngBuffer } from "../../../test/helpers/image-fixtures.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../../config/types.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { resolveVideoGenerationModeCapabilities } from "../../video-generation/capabilities.js";
 import type {
   VideoGenerationProvider,
   VideoGenerationRequest,
-} from "../../../../src/video-generation/types.js";
-import { createSolidPngBuffer } from "../../../helpers/image-fixtures.js";
-import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
+} from "../../video-generation/types.js";
+import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
+import { createVideoGenerateTool } from "./video-generate-tool.js";
 
 function createMp4Fixture(): Buffer {
   return Buffer.from([
@@ -188,6 +188,71 @@ describe("video generation invocation QA", () => {
           mimeType: "video/mp4",
           sizeBytes: generatedVideo.byteLength,
         }),
+      ]);
+    });
+  });
+
+  it("preserves provider order through managed storage and URL fallback", async () => {
+    const root = tempDirs.make("openclaw-qa-video-output-order-");
+    const savedVideo = createMp4Fixture();
+    const oversizedVideo = Buffer.concat([savedVideo, Buffer.from([0x00])]);
+    const provider: VideoGenerationProvider = {
+      id: "qa-ordered-video",
+      defaultModel: "ordered-v1",
+      models: ["ordered-v1"],
+      isConfigured: () => true,
+      capabilities: {},
+      generateVideo: async () => ({
+        videos: [
+          {
+            url: "https://media.example/first.mp4",
+            mimeType: "video/mp4",
+            fileName: "first.mp4",
+          },
+          {
+            buffer: savedVideo,
+            mimeType: "video/mp4",
+            fileName: "middle.mp4",
+          },
+          {
+            buffer: oversizedVideo,
+            url: "https://media.example/last.mp4",
+            mimeType: "video/mp4",
+            fileName: "last.mp4",
+          },
+        ],
+      }),
+    };
+    const config = createConfig("qa-ordered-video/ordered-v1", []);
+    config.agents!.defaults!.mediaMaxMb = savedVideo.byteLength / (1024 * 1024);
+
+    await withEnvAsync({ OPENCLAW_STATE_DIR: path.join(root, "state") }, async () => {
+      const tool = requireVideoTool(
+        createVideoGenerateTool({
+          config,
+          agentDir: path.join(root, "agent"),
+          workspaceDir: root,
+          preparedModelRuntime: createPreparedRuntime([provider]),
+        }),
+      );
+      const result = await tool.execute("qa-video-output-order", {
+        prompt: "Generate three ordered QA clips.",
+      });
+      const details = requireDetails(result);
+      const paths = details.paths as string[];
+
+      expect(paths).toHaveLength(3);
+      expect(paths[0]).toBe("https://media.example/first.mp4");
+      expect(paths[2]).toBe("https://media.example/last.mp4");
+      const savedPath = paths[1];
+      if (!savedPath) {
+        throw new Error("expected managed middle video path");
+      }
+      await expect(fs.readFile(savedPath)).resolves.toEqual(savedVideo);
+      expect(details.attachments).toMatchObject([
+        { url: paths[0], name: "first.mp4" },
+        { path: savedPath },
+        { url: paths[2], name: "last.mp4" },
       ]);
     });
   });

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -897,6 +897,64 @@ describe("createVideoGenerateTool", () => {
     expect(details.metadata).toEqual({ taskId: "task-1" });
   });
 
+  it("preserves provider order across URL and saved video outputs", async () => {
+    vi.spyOn(videoGenerationRuntime, "generateVideo").mockResolvedValue({
+      provider: "vydra",
+      model: "veo3",
+      attempts: [],
+      ignoredOverrides: [],
+      videos: [
+        {
+          url: "https://example.com/first.mp4",
+          mimeType: "video/mp4",
+          fileName: "first.mp4",
+        },
+        {
+          buffer: Buffer.from("middle-video"),
+          mimeType: "video/mp4",
+          fileName: "middle.mp4",
+        },
+        {
+          url: "https://example.com/last.mp4",
+          mimeType: "video/mp4",
+          fileName: "last.mp4",
+        },
+      ],
+    });
+    vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValueOnce({
+      path: "/tmp/middle.mp4",
+      id: "middle.mp4",
+      size: 12,
+      contentType: "video/mp4",
+    });
+    const tool = expectVideoGenerateTool(
+      createVideoGenerateTool({
+        config: asConfig({
+          agents: { defaults: { videoGenerationModel: { primary: "vydra/veo3" } } },
+        }),
+      }),
+    );
+
+    const result = await tool.execute("call-mixed-outputs", { prompt: "three videos" });
+    const text = (result.content?.[0] as { text: string } | undefined)?.text ?? "";
+    const details = resultDetails(result);
+    const expectedPaths = [
+      "https://example.com/first.mp4",
+      "/tmp/middle.mp4",
+      "https://example.com/last.mp4",
+    ];
+
+    expect(details.paths).toEqual(expectedPaths);
+    expect((details.media as { mediaUrls: string[] }).mediaUrls).toEqual(expectedPaths);
+    expect(details.attachments).toMatchObject([
+      { url: expectedPaths[0], name: "first.mp4" },
+      { path: expectedPaths[1], name: "middle.mp4" },
+      { url: expectedPaths[2], name: "last.mp4" },
+    ]);
+    expect(text.indexOf('name="first.mp4"')).toBeLessThan(text.indexOf('name="middle.mp4"'));
+    expect(text.indexOf('name="middle.mp4"')).toBeLessThan(text.indexOf('name="last.mp4"'));
+  });
+
   it("keeps signed video URLs exact while disarming provider-controlled attachment presentation", async () => {
     const signedUrl =
       "https://example.com/generated.mp4?signature=abc%2Fdef%3D&voice=[[audio_as_voice]]&reply=[[reply_to:attacker]]&image=![hidden](https://example.com/hidden.png)&tail=signed";
@@ -1021,15 +1079,25 @@ describe("createVideoGenerateTool", () => {
       videos: [
         {
           buffer: Buffer.from("large-video-bytes"),
-          url: "https://fal.run/files/generated-lobster.mp4",
+          url: "https://fal.run/files/first.mp4",
           mimeType: "video/mp4",
-          fileName: "lobster.mp4",
+          fileName: "first.mp4",
+        },
+        {
+          buffer: Buffer.from("second-video-bytes"),
+          mimeType: "video/mp4",
+          fileName: "second.mp4",
         },
       ],
     });
-    vi.spyOn(mediaStore, "saveMediaBuffer").mockRejectedValueOnce(
-      new Error("Media exceeds 16MB limit"),
-    );
+    vi.spyOn(mediaStore, "saveMediaBuffer")
+      .mockRejectedValueOnce(new Error("Media exceeds 16MB limit"))
+      .mockResolvedValueOnce({
+        path: "/tmp/second.mp4",
+        id: "second.mp4",
+        size: 18,
+        contentType: "video/mp4",
+      });
 
     const tool = createVideoGenerateTool({
       config: asConfig({
@@ -1049,17 +1117,18 @@ describe("createVideoGenerateTool", () => {
     });
     const text = (result.content?.[0] as { text: string } | undefined)?.text ?? "";
 
-    expect(text).toContain("Generated 1 video with fal/fal-ai/minimax/video-01-live.");
-    expect(text).toContain('mediaUrl="https://fal.run/files/generated-lobster.mp4"');
+    expect(text).toContain("Generated 2 videos with fal/fal-ai/minimax/video-01-live.");
+    expect(text).toContain('mediaUrl="https://fal.run/files/first.mp4"');
     expect(text).not.toContain("MEDIA:");
     const details = resultDetails(result);
     expect(details.provider).toBe("fal");
     expect(details.model).toBe("fal-ai/minimax/video-01-live");
-    expect(details.count).toBe(1);
+    expect(details.count).toBe(2);
     expect((details.media as { mediaUrls?: string[] }).mediaUrls).toEqual([
-      "https://fal.run/files/generated-lobster.mp4",
+      "https://fal.run/files/first.mp4",
+      "/tmp/second.mp4",
     ]);
-    expect(details.paths).toEqual(["https://fal.run/files/generated-lobster.mp4"]);
+    expect(details.paths).toEqual(["https://fal.run/files/first.mp4", "/tmp/second.mp4"]);
   });
 
   it("starts background generation and wakes the session with url-only MEDIA lines", async () => {

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -548,21 +548,22 @@ async function executeVideoGenerationJob(params: {
     });
   }
 
-  const urlOnlyVideos: Array<{ url: string; mimeType: string; fileName?: string }> = [];
+  type UrlVideo = { url: string; mimeType: string; fileName?: string };
   type PersistedVideo =
     | { kind: "saved"; media: Awaited<ReturnType<typeof saveMediaBuffer>> }
-    | { kind: "url"; media: (typeof urlOnlyVideos)[number] };
+    | { kind: "url"; media: UrlVideo };
+  const videoOrder: Array<PersistedVideo | number> = [];
   const bufferVideos: Array<(typeof result.videos)[number] & { buffer: Buffer }> = [];
   for (const video of result.videos) {
     if (video.buffer) {
+      videoOrder.push(bufferVideos.length);
       bufferVideos.push(video as (typeof result.videos)[number] & { buffer: Buffer });
       continue;
     }
     if (video.url) {
-      urlOnlyVideos.push({
-        url: video.url,
-        mimeType: video.mimeType,
-        fileName: video.fileName,
+      videoOrder.push({
+        kind: "url",
+        media: { url: video.url, mimeType: video.mimeType, fileName: video.fileName },
       });
       continue;
     }
@@ -605,15 +606,10 @@ async function executeVideoGenerationJob(params: {
       }
     }),
   });
-  const savedVideos: Array<Awaited<ReturnType<typeof saveMediaBuffer>>> = [];
-  for (const persisted of persistedVideos) {
-    if (persisted.kind === "saved") {
-      savedVideos.push(persisted.media);
-    } else {
-      urlOnlyVideos.push(persisted.media);
-    }
-  }
-  const totalCount = savedVideos.length + urlOnlyVideos.length;
+  // Preserve provider ordinals while replacing only buffer-backed slots with persistence results.
+  const deliveredVideos = videoOrder.map((video) =>
+    typeof video === "number" ? persistedVideos[video]! : video,
+  );
   const requestedDurationSeconds =
     result.normalization?.durationSeconds?.requested ??
     (typeof result.metadata?.requestedDurationSeconds === "number" &&
@@ -664,46 +660,48 @@ async function executeVideoGenerationJob(params: {
       typeof result.metadata?.requestedSize === "string" &&
       result.metadata.requestedSize === params.size &&
       Boolean(normalizedAspectRatio));
-  const allMediaUrls = [
-    ...savedVideos.map((video) => video.path),
-    ...urlOnlyVideos.map((video) => video.url),
-  ];
+  const allMediaUrls = deliveredVideos.map((video) =>
+    video.kind === "saved" ? video.media.path : video.media.url,
+  );
   const savedVideoMetadata = await probeMediaFilesWithinBudget(
-    savedVideos.map((video) => ({ filePath: video.path, kind: "video" })),
+    deliveredVideos.flatMap((video) =>
+      video.kind === "saved" ? [{ filePath: video.media.path, kind: "video" as const }] : [],
+    ),
     {
       budgetMs: GENERATED_VIDEO_PROBE_BUDGET_MS,
       concurrency: GENERATED_VIDEO_PROBE_CONCURRENCY,
       maxProbes: MAX_GENERATED_VIDEO_PROBES,
     },
   );
-  const attachments: AgentGeneratedAttachment[] = [
-    ...savedVideos.map((video, index) =>
-      Object.assign(
-        {
-          type: "video" as const,
-          path: video.path,
-          mimeType: video.contentType,
-          name: video.id,
-          sizeBytes: video.size,
-          ...(typeof normalizedDurationSeconds === "number"
-            ? { durationMs: normalizedDurationSeconds * 1000 }
-            : {}),
-        },
-        savedVideoMetadata[index] ?? {},
-      ),
-    ),
-    ...urlOnlyVideos.map((video) => ({
-      type: "video" as const,
-      url: video.url,
-      mimeType: video.mimeType,
-      name: video.fileName,
-      ...(typeof normalizedDurationSeconds === "number"
-        ? { durationMs: normalizedDurationSeconds * 1000 }
-        : {}),
-    })),
-  ];
+  let savedMetadataIndex = 0;
+  const attachments: AgentGeneratedAttachment[] = deliveredVideos.map((video) => {
+    if (video.kind === "url") {
+      return {
+        type: "video" as const,
+        url: video.media.url,
+        mimeType: video.media.mimeType,
+        name: video.media.fileName,
+        ...(typeof normalizedDurationSeconds === "number"
+          ? { durationMs: normalizedDurationSeconds * 1000 }
+          : {}),
+      };
+    }
+    return Object.assign(
+      {
+        type: "video" as const,
+        path: video.media.path,
+        mimeType: video.media.contentType,
+        name: video.media.id,
+        sizeBytes: video.media.size,
+        ...(typeof normalizedDurationSeconds === "number"
+          ? { durationMs: normalizedDurationSeconds * 1000 }
+          : {}),
+      },
+      savedVideoMetadata[savedMetadataIndex++] ?? {},
+    );
+  });
   const lines = [
-    `Generated ${totalCount} video${totalCount === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
+    `Generated ${deliveredVideos.length} video${deliveredVideos.length === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
     ...(warning ? [`Warning: ${warning}`] : []),
     typeof requestedDurationSeconds === "number" &&
     typeof normalizedDurationSeconds === "number" &&
@@ -716,8 +714,10 @@ async function executeVideoGenerationJob(params: {
   return {
     provider: result.provider,
     model: result.model,
-    urlOnlyUrls: urlOnlyVideos.map((video) => video.url),
-    count: totalCount,
+    urlOnlyUrls: deliveredVideos.flatMap((video) =>
+      video.kind === "url" ? [video.media.url] : [],
+    ),
+    count: deliveredVideos.length,
     mediaUrls: allMediaUrls,
     attachments,
     contentText: lines.join("\n"),
@@ -725,7 +725,7 @@ async function executeVideoGenerationJob(params: {
     details: {
       provider: result.provider,
       model: result.model,
-      count: totalCount,
+      count: deliveredVideos.length,
       media: {
         mediaUrls: allMediaUrls,
         attachments,


### PR DESCRIPTION
Closes #127575

## What Problem This Solves

`video_generate` grouped saved buffer outputs before URL-only outputs. A provider result such as `[URL A, buffer B, URL C]` was published as `[saved B, URL A, URL C]`.

This changed visible ordinals across tool text, paths, attachments, and detached delivery.

## Root cause

The production handler split provider output into buffer and URL lists. It persisted the buffer list, then concatenated saved buffers before URLs.

## Fix

The handler now keeps one provider-ordered output plan. Buffer persistence results, including size-limit URL fallbacks, replace their original slots.

Paths, attachments, tool text, and detached completion delivery all consume the same ordered collection. The existing all-or-nothing rollback owner remains unchanged.

## Evidence

- Exact main `8b1e44c107982d240c70fb8b5a5dd5d7bfec6a3a` returned `[saved B, URL A, URL C]` from the production handler. Current main retained the same handler bytes after the proof run.
- Proven head `de419053098952a6ed0fab749a7f0000440b5709` returned `[URL A, saved B, URL C]` from the same handler and input. Current head `09a96224372a36daeb487f68dd68fcc45adf8f3e` is the patch-identical history refresh on current main.
- The provider ran once in each run. Saved B was read back from managed storage as 24 bytes with matching SHA-256 `9f76e24fc8542b7fd66f70148f1d785be47486fb0a7ca3f5d2fb16f05e408d88`.
- Focused owner coverage passed: 2 tests passed and 48 tests were skipped.
- Production delta is `+50/-50` (net 0). Test and scenario coverage is `+154/-20` (net +134).

## AI assistance

AI-assisted: yes. Codex assisted with implementation, regression tests, verification, and review.
