### PR TITLE
fix: include compaction and branch-summary tokens in run usage

### DIFF
--- a/packages/agent-core/src/harness/compaction/branch-summarization.ts
+++ b/packages/agent-core/src/harness/compaction/branch-summarization.ts
@@ -235,6 +235,8 @@ export async function generateBranchSummary(
   const response = options.streamFn
     ? await consumeAgentCoreStream(options.streamFn(model, context, streamOptions))
     : await resolveAgentCoreCompleteFn(options.runtime)(model, context, streamOptions);
+  // Usage belongs to the completed provider request even when its summary is invalid.
+  options.runtime?.internalUsageSink?.(response.usage);
   if (response.stopReason === "aborted") {
     return err(
       new BranchSummaryError("aborted", response.errorMessage || "Branch summary aborted"),

--- a/packages/agent-core/src/harness/compaction/compaction.test.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.test.ts
@@ -970,21 +970,9 @@ describe("generateSummary thinking options", () => {
 describe("split-turn compaction", () => {
   const operatorFocus = "Preserve API decisions.";
   it.each([
-    {
-      name: "ordinary history",
-      history: true,
-      prefix: false,
-      budgets: [800],
-      focus: operatorFocus,
-    },
-    {
-      name: "history and prefix",
-      history: true,
-      prefix: true,
-      budgets: [800, 500],
-      focus: operatorFocus,
-    },
-    { name: "prefix-only", history: false, prefix: true, budgets: [500], focus: operatorFocus },
+    { name: "ordinary history", history: true, prefix: false, budgets: [800] },
+    { name: "history and prefix", history: true, prefix: true, budgets: [800, 500] },
+    { name: "prefix-only", history: false, prefix: true, budgets: [500] },
     {
       name: "caller-owned instructions",
       history: true,
@@ -994,7 +982,7 @@ describe("split-turn compaction", () => {
     },
   ])(
     "forwards focus and serializes $name summaries",
-    async ({ history, prefix, budgets, focus }) => {
+    async ({ history, prefix, budgets, focus = operatorFocus }) => {
       const model: Model = {
         id: "summary-model",
         name: "Summary Model",
@@ -1009,6 +997,7 @@ describe("split-turn compaction", () => {
       };
       const prompts: string[] = [];
       const outputBudgets: Array<number | undefined> = [];
+      const usageSink = vi.fn();
       let active = 0;
       let maxActive = 0;
       const streamFn = vi.fn<StreamFn>((_model, context, options) => {
@@ -1033,7 +1022,7 @@ describe("split-turn compaction", () => {
             api: model.api,
             provider: model.provider,
             model: model.id,
-            usage: createUsage(0),
+            usage: createUsage(outputBudgets.length * 10 + 1),
             stopReason: "stop",
             timestamp: 1,
           };
@@ -1059,12 +1048,16 @@ describe("split-turn compaction", () => {
         undefined,
         undefined,
         streamFn,
+        { completeSimple: vi.fn(), internalUsageSink: usageSink },
       );
 
       expect(result.ok).toBe(true);
       expect(streamFn).toHaveBeenCalledTimes(budgets.length);
       expect(maxActive).toBe(1);
       expect(outputBudgets).toEqual(budgets);
+      expect(usageSink.mock.calls.map(([usage]) => usage.totalTokens)).toEqual(
+        budgets.map((_, index) => (index + 1) * 10 + 1),
+      );
       for (const prompt of prompts) {
         expect(prompt).toContain(focus);
         expect(prompt.indexOf(focus)).toBeGreaterThan(prompt.lastIndexOf("</conversation>"));

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -632,6 +632,8 @@ async function runSummarizationCompletion(params: {
   const response = params.streamFn
     ? await consumeAgentCoreStream(params.streamFn(params.model, context, options))
     : await resolveAgentCoreCompleteFn(params.runtime)(params.model, context, options);
+  // Usage belongs to the completed provider request even when its summary is invalid.
+  params.runtime?.internalUsageSink?.(response.usage);
   if (response.stopReason === "aborted") {
     return err(
       new CompactionError("aborted", response.errorMessage || `${params.errorLabel} aborted`),

--- a/packages/agent-core/src/runtime-deps.ts
+++ b/packages/agent-core/src/runtime-deps.ts
@@ -1,5 +1,5 @@
 // Agent Core module implements runtime deps behavior.
-import type { CompleteSimpleFn, StreamFn } from "@openclaw/llm-core";
+import type { CompleteSimpleFn, StreamFn, Usage } from "@openclaw/llm-core";
 
 /** Runtime functions injected by host packages so agent-core stays provider-agnostic. */
 export interface AgentCoreRuntimeDeps {
@@ -12,7 +12,10 @@ export interface AgentCoreRuntimeDeps {
 /** Runtime dependency subset required by streaming agent loops. */
 export type AgentCoreStreamRuntimeDeps = Pick<AgentCoreRuntimeDeps, "streamSimple">;
 /** Runtime dependency subset required by summarization helpers. */
-export type AgentCoreCompletionRuntimeDeps = Pick<AgentCoreRuntimeDeps, "completeSimple">;
+export type AgentCoreCompletionRuntimeDeps = Pick<AgentCoreRuntimeDeps, "completeSimple"> & {
+  /** Internal host sink for usage from auxiliary model completions. */
+  internalUsageSink?: (usage: Usage) => void;
+};
 
 function missingRuntimeDep(name: keyof AgentCoreRuntimeDeps): Error {
   return new Error(

--- a/src/agents/agent-hooks/compaction-safeguard.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.ts
@@ -49,7 +49,9 @@ import {
   type SessionTreeEntry as CoreSessionTreeEntry,
 } from "../runtime/index.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
+import type { SessionModelUsageSink } from "../sessions/compaction/runtime.js";
 import type { ExtensionAPI, ExtensionContext } from "../sessions/index.js";
+import { recordSessionModelUsage } from "../sessions/session-model-usage.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
 import {
   MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
@@ -1158,6 +1160,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         messages: messagesToSummarize,
         headers: authResult.headers,
       });
+      const usageSink: SessionModelUsageSink = (usage) =>
+        recordSessionModelUsage(ctx.sessionManager, usage);
       const llmSummaryParams = {
         model,
         apiKey: authResult.apiKey ?? "",
@@ -1168,6 +1172,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         summarizationInstructions,
         thinkingLevel,
         streamFn,
+        usageSink,
       };
       const qualityGuardMaxRetries = resolveQualityGuardMaxRetries(runtime?.qualityGuardMaxRetries);
 

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -24,6 +24,7 @@ import {
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { isTimeoutError } from "./failover-error.js";
 import type { AgentMessage, StreamFn, ThinkingLevel } from "./runtime/index.js";
+import type { SessionModelUsageSink } from "./sessions/compaction/runtime.js";
 import type { ExtensionContext } from "./sessions/index.js";
 import { generateSummary } from "./sessions/index.js";
 
@@ -79,6 +80,7 @@ type CompactionSummaryParams = {
   previousSummary?: string;
   thinkingLevel?: ThinkingLevel;
   streamFn?: StreamFn;
+  usageSink?: SessionModelUsageSink;
 };
 
 function resolveIdentifierPreservationInstructions(
@@ -137,6 +139,7 @@ async function summarizeChunks(params: CompactionSummaryParams): Promise<string>
             summary,
             params.thinkingLevel,
             params.streamFn,
+            params.usageSink,
           ),
         {
           attempts: 3,

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -38,6 +38,8 @@ import { agentSessionAutomaticCompaction } from "../sessions/agent-session-compa
 import { type AgentSession, estimateTokens, SessionManager } from "../sessions/index.js";
 import { getModelRegistryRuntime } from "../sessions/model-registry-runtime.js";
 import { createAgentSessionForEmbeddedRunner } from "../sessions/sdk.js";
+import { setSessionModelUsageSink } from "../sessions/session-model-usage.js";
+import { normalizeUsage, type UsageLike } from "../usage.js";
 import { resolveCompactionFailure } from "./compact-reasons.js";
 import { compactionCheckpointStore, persistCompactionCheckpoint } from "./compaction-checkpoint.js";
 import {
@@ -67,6 +69,7 @@ import type { PreparedCompactionRuntime } from "./prepared-compaction-runtime.js
 import { sanitizeSessionHistory, validateReplayTurns } from "./replay-history.js";
 import { createEmbeddedAgentResourceLoader } from "./resource-loader.js";
 import { wrapStreamFnWithDiagnosticModelCallEvents } from "./run/attempt.model-diagnostic-events.js";
+import { readCompactionUsageRecorder } from "./run/compaction-usage-bridge.js";
 import { estimateLlmBoundaryTokenPressure } from "./run/preemptive-compaction.js";
 import { attemptServerEndpointCompaction } from "./server-endpoint-compaction.js";
 import { applySystemPromptToSession } from "./system-prompt.js";
@@ -148,6 +151,18 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
         sessionTarget,
       });
       compactionSessionManager = sessionManager;
+      const usageRecorder = readCompactionUsageRecorder(params.contextEngineRuntimeContext);
+      const recordUsage = usageRecorder
+        ? (usage: UsageLike) => {
+            const normalized = normalizeUsage(usage);
+            if (normalized) {
+              usageRecorder(normalized);
+            }
+          }
+        : undefined;
+      if (recordUsage) {
+        setSessionModelUsageSink(sessionManager, recordUsage);
+      }
       const settingsManager = createPreparedEmbeddedAgentSettingsManager({
         cwd: effectiveCwd,
         agentDir,
@@ -446,6 +461,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             extraParams: effectiveExtraParams,
             customInstructions: params.customInstructions,
             config: params.config,
+            onUsage: recordUsage,
             requestOptions: {
               apiKey: transportApiKey,
               sessionId: params.sessionId,
@@ -631,6 +647,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
     });
     return fail(failure.reason, failure.error);
   } finally {
+    setSessionModelUsageSink(compactionSessionManager, null);
     if (!checkpointSnapshotRetained) {
       await compactionCheckpointStore.cleanupSnapshot(checkpointSnapshot);
     }

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -6,14 +6,17 @@ import { buildContextEngineRuntimeSettings } from "../../context-engine/runtime-
 import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
 import { createTestAdmittedRunContext } from "../admitted-run-context.test-support.js";
 import type { AgentRuntimeAuthPlan } from "../runtime-plan/types.js";
+import { normalizeUsage } from "../usage.js";
 import {
   compactEmbeddedRunForRecovery,
   createEmbeddedRunCompactionRuntime,
   type EmbeddedRunCompactionRecoveryInput,
 } from "./run/compaction-runtime.js";
+import { readCompactionUsageRecorder } from "./run/compaction-usage-bridge.js";
 import { createEmbeddedRunContextRecoveryState } from "./run/context-recovery-state.js";
 import type { PreparedEmbeddedRunInput } from "./run/execution-context.js";
 import type { EmbeddedRunAttemptResult } from "./run/types.js";
+import { createUsageAccumulator } from "./usage-accumulator.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const completionMocks = vi.hoisted(() => ({
@@ -109,6 +112,7 @@ function makeRecoveryInput(
     }),
     prepareCompactedTranscriptRetry: vi.fn(async () => {}),
     armPostCompactionGuard: vi.fn(),
+    usageAccumulator: createUsageAccumulator(),
     ...overrides,
   };
 }
@@ -242,6 +246,37 @@ describe("compactEmbeddedRunForRecovery", () => {
       ),
     ).rejects.toThrow("not bound to an active session agent");
     expect(completionMocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+  });
+
+  it("accounts recovery model usage even when compaction fails", async () => {
+    const compact = vi.fn(async (params: { runtimeContext?: ContextEngineRuntimeContext }) => {
+      const usage = normalizeUsage({
+        input: 100,
+        output: 50,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 150,
+      });
+      if (!usage) {
+        throw new Error("expected normalized usage");
+      }
+      readCompactionUsageRecorder(params.runtimeContext)?.(usage);
+      return { ok: false as const, compacted: false as const, reason: "invalid summary" };
+    });
+    const usageAccumulator = createUsageAccumulator();
+
+    await compactEmbeddedRunForRecovery(
+      makeRecoveryInput({ contextEngine: makeContextEngine(compact), usageAccumulator }),
+      {
+        tokenBudget: 200_000,
+        trigger: "overflow",
+        diagId: "diag-usage",
+        attempt: 1,
+        maxAttempts: 3,
+      },
+    );
+
+    expect(usageAccumulator).toMatchObject({ input: 100, output: 50, total: 150 });
   });
 });
 

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -309,6 +309,7 @@ export async function recoverEmbeddedRunAttempt(input: {
     }),
     prepareCompactedTranscriptRetry: sessionPromptState.prepareCompactedTranscriptRetry,
     armPostCompactionGuard: input.armPostCompactionGuard,
+    usageAccumulator: input.usageAccumulator,
   };
   if (
     await recoverEmbeddedRunTimeout({

--- a/src/agents/embedded-agent-runner/run/compaction-runtime.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-runtime.ts
@@ -13,6 +13,8 @@ import {
 } from "../compaction-safety-timeout.js";
 import { resolveContextEngineCapabilities } from "../context-engine-capabilities.js";
 import { log } from "../logger.js";
+import { mergeUsageIntoAccumulator, type UsageAccumulator } from "../usage-accumulator.js";
+import { attachCompactionUsageRecorder } from "./compaction-usage-bridge.js";
 import type { EmbeddedRunContextRecoveryState } from "./context-recovery-state.js";
 import type { PreparedEmbeddedRunInput } from "./execution-context.js";
 import type { RunEmbeddedAgentParams } from "./params.js";
@@ -66,6 +68,7 @@ export type EmbeddedRunCompactionRecoveryInput = {
   };
   prepareCompactedTranscriptRetry: () => Promise<void>;
   armPostCompactionGuard: () => void;
+  usageAccumulator: UsageAccumulator;
 };
 
 /** Preserve one prepared owner snapshot for both timeout and overflow recovery. */
@@ -148,6 +151,9 @@ export async function compactEmbeddedRunForRecovery(
     attempt: recovery.attempt,
     maxAttempts: recovery.maxAttempts,
   };
+  attachCompactionUsageRecorder(runtimeContext, (usage) => {
+    mergeUsageIntoAccumulator(input.usageAccumulator, usage);
+  });
   const runtimeSettings = input.buildRuntimeSettings({
     tokenBudget: recovery.tokenBudget,
     ...(recovery.trigger === "overflow" ? { degradedReason: "context_overflow" } : {}),

--- a/src/agents/embedded-agent-runner/run/compaction-usage-bridge.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-usage-bridge.ts
@@ -1,0 +1,20 @@
+import type { ContextEngineRuntimeContext } from "../../../context-engine/types.js";
+import type { NormalizedUsage } from "../../usage.js";
+
+export type CompactionUsageRecorder = (usage: NormalizedUsage) => void;
+
+// The legacy context-engine delegate carries identity, not a public callback.
+const recorderByRuntimeContext = new WeakMap<object, CompactionUsageRecorder>();
+
+export function attachCompactionUsageRecorder(
+  runtimeContext: ContextEngineRuntimeContext,
+  recorder: CompactionUsageRecorder,
+): void {
+  recorderByRuntimeContext.set(runtimeContext, recorder);
+}
+
+export function readCompactionUsageRecorder(
+  runtimeContext: object | undefined,
+): CompactionUsageRecorder | undefined {
+  return runtimeContext ? recorderByRuntimeContext.get(runtimeContext) : undefined;
+}

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
@@ -180,13 +180,21 @@ describe("attemptServerEndpointCompaction", () => {
   it("leaves the durable transcript intact when policy would redact the canonical window", async () => {
     const session = createSession();
     const before = structuredClone(session.sessionManager.getBranch());
+    const onUsage = vi.fn();
     const { result } = attempt({
       sessionManager: session.sessionManager,
       context: { systemPrompt: "system", messages: session.messages },
       config: { logging: { redactPatterns: ["remember copper"] } },
+      onUsage,
     });
 
     await expect(result).resolves.toBeUndefined();
+    expect(onUsage).toHaveBeenCalledOnce();
+    expect(onUsage).toHaveBeenCalledWith({
+      input_tokens: 1_000,
+      output_tokens: 200,
+      dropped_message_count: 1,
+    });
     expect(session.sessionManager.getBranch()).toEqual(before);
   });
 

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.ts
@@ -33,6 +33,7 @@ export async function attemptServerEndpointCompaction(params: {
   requestOptions: Parameters<typeof requestPreparedOpenAIResponsesCompaction>[3];
   customInstructions?: string;
   config?: OpenClawConfig;
+  onUsage?: (usage: ServerEndpointCompactionResult["usage"]) => void;
 }): Promise<ServerEndpointCompactionResult | undefined> {
   if (
     params.trigger === "overflow" ||
@@ -71,6 +72,7 @@ export async function attemptServerEndpointCompaction(params: {
       params.requestOptions.timeoutMs,
       params.requestOptions.signal ? { abortSignal: params.requestOptions.signal } : undefined,
     );
+    params.onUsage?.(compacted.usage);
     const replacement = structuredClone(owner.message);
     captureOpenAIResponsesCompaction(
       replacement,

--- a/src/agents/embedded-agent-subscribe.ts
+++ b/src/agents/embedded-agent-subscribe.ts
@@ -14,6 +14,10 @@ import { hasCommittedMessagingToolDeliveryEvidence } from "./embedded-agent-runn
 import { mergeEmbeddedRunReplayState } from "./embedded-agent-runner/replay-state.js";
 import { consumeEmbeddedToolReceipt } from "./embedded-agent-runner/tool-send-receipts.js";
 import type { EmbeddedRunLivenessState } from "./embedded-agent-runner/types.js";
+import {
+  createUsageAccumulator,
+  mergeUsageIntoAccumulator,
+} from "./embedded-agent-runner/usage-accumulator.js";
 import { runBestEffortCallback } from "./embedded-agent-subscribe.callback.js";
 import { createEmbeddedAgentSessionEventHandler } from "./embedded-agent-subscribe.handlers.js";
 import { readPendingToolMediaReply } from "./embedded-agent-subscribe.handlers.messages.replies.js";
@@ -38,6 +42,7 @@ import { buildToolLifecycleErrorResult } from "./embedded-agent-tool-results.js"
 import { stripDowngradedToolCallText } from "./embedded-agent-utils.js";
 import type { AgentRunTimeoutPhase } from "./run-timeout-attribution.js";
 import type { AgentMessage } from "./runtime/index.js";
+import { setSessionModelUsageSink } from "./sessions/session-model-usage.js";
 import { registerToolEffectReceipt } from "./tool-effect-receipt.js";
 import { consumeTrustedToolNoStartError } from "./tool-result-error.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
@@ -57,14 +62,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   const toolResultFormat = params.toolResultFormat ?? "markdown";
   const useMarkdown = toolResultFormat === "markdown";
   const state: EmbeddedAgentSubscribeState = createEmbeddedAgentSubscribeState(params);
-  const usageTotals = {
-    input: 0,
-    output: 0,
-    cacheRead: 0,
-    cacheWrite: 0,
-    reasoningTokens: 0,
-    total: 0,
-  };
+  const usageTotals = createUsageAccumulator();
   let lastAssistantUsage: ReturnType<typeof normalizeUsage>;
   let compactionCount = 0;
   let currentAttemptAssistant: AssistantMessage | undefined;
@@ -233,15 +231,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       return;
     }
     const usage = state.pendingAssistantUsage;
-    usageTotals.input += usage.input ?? 0;
-    usageTotals.output += usage.output ?? 0;
-    usageTotals.cacheRead += usage.cacheRead ?? 0;
-    usageTotals.cacheWrite += usage.cacheWrite ?? 0;
-    usageTotals.reasoningTokens += usage.reasoningTokens ?? 0;
-    const usageTotal =
-      usage.total ??
-      (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
-    usageTotals.total += usageTotal;
+    mergeUsageIntoAccumulator(usageTotals, usage);
     // A terminal abort may report zeros after several completed model calls.
     // Retain the latest committed nonzero call so context accounting stays exact.
     lastAssistantUsage = { ...usage };
@@ -257,6 +247,14 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
       return;
     }
     state.pendingAssistantUsage = usage;
+  };
+  const recordModelUsage = (usageLike: UsageLike) => {
+    const usage = normalizeUsage(usageLike);
+    if (!hasNonzeroUsage(usage)) {
+      return;
+    }
+    mergeUsageIntoAccumulator(usageTotals, usage);
+    emitRunUsage(usage.output ?? 0);
   };
   const getUsageTotals = () => {
     const hasUsage =
@@ -556,6 +554,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
   };
 
   const sessionUnsubscribe = params.session.subscribe(createEmbeddedAgentSessionEventHandler(ctx));
+  setSessionModelUsageSink(params.session.sessionManager, recordModelUsage);
 
   const unsubscribe = () => {
     if (state.unsubscribed) {
@@ -589,6 +588,7 @@ export function subscribeEmbeddedAgentSession(params: SubscribeEmbeddedAgentSess
         log.warn(`unsubscribe: compaction abort failed runId=${params.runId} err=${String(err)}`);
       }
     }
+    setSessionModelUsageSink(params.session.sessionManager, null);
     sessionUnsubscribe();
   };
 

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -15,13 +15,17 @@ import {
 } from "../agent-hooks/compaction-safeguard-runtime.js";
 import compactionSafeguardExtension from "../agent-hooks/compaction-safeguard.js";
 import { subscribeEmbeddedAgentSession } from "../embedded-agent-subscribe.js";
-import { agentSessionSetContextReplacementHook } from "./agent-session-compaction.js";
+import {
+  agentSessionAutomaticCompaction,
+  agentSessionSetContextReplacementHook,
+} from "./agent-session-compaction.js";
 import {
   createAssistant,
   createAssistantResultStream,
   createAutoCompactionSettings,
   createOverflowAssistant,
   createTestSession,
+  mockInvalidThenTextSummary,
   registerAgentSessionLoopTestLifecycle,
   streamMocks,
   testModel,
@@ -173,6 +177,10 @@ describe("AgentSession compaction", () => {
             retry: { enabled: false },
           }),
         });
+        const subscription = subscribeEmbeddedAgentSession({
+          session,
+          runId: "run-safeguard-summary-usage",
+        });
         const entriesBefore = structuredClone(sessionManager.getEntries());
         const messagesBefore = structuredClone(session.messages);
         const compactionEnds = collectCompactionEnds(session);
@@ -205,6 +213,10 @@ describe("AgentSession compaction", () => {
           outcomes: compactionEnds.map((event) => event.outcome.status),
           appended,
         };
+        expect(subscription.getUsageTotals()?.total ?? 0).toBe(
+          streamMocks.streamSimple.mock.calls.length * 2,
+        );
+        subscription.unsubscribe();
         expect.soft(observation).toMatchObject({
           providerCalls: 1,
           callerAbortedAtProviderEntry: false,
@@ -383,6 +395,62 @@ describe("AgentSession compaction", () => {
     expect(subscription.getCompactionCount()).toBe(1);
     expect(subscription.getLastCompactionTokensAfter()).toEqual(expect.any(Number));
     expect(subscription.getLastCompactionTokensAfter()).toBeGreaterThan(0);
+    subscription.unsubscribe();
+  });
+
+  it("accounts every automatic compaction response before summary validation", async () => {
+    const sessionManager = SessionManager.inMemory();
+    sessionManager.appendMessage({ role: "user", content: "old prompt", timestamp: 1 });
+    sessionManager.appendMessage({
+      ...createAssistant(testModel, [{ type: "text", text: "old answer" }]),
+      timestamp: 2,
+    });
+    sessionManager.appendMessage({ role: "user", content: "latest prompt", timestamp: 3 });
+    const requestCount = mockInvalidThenTextSummary("condensed history");
+    const { session } = await createTestSession({
+      sessionManager,
+      settingsManager: createAutoCompactionSettings(),
+    });
+    const subscription = subscribeEmbeddedAgentSession({
+      session,
+      runId: "run-automatic-summary-usage",
+    });
+
+    await session[agentSessionAutomaticCompaction]();
+
+    expect(requestCount()).toBe(2);
+    expect(subscription.getUsageTotals()).toMatchObject({ input: 2, output: 2, total: 4 });
+    subscription.unsubscribe();
+  });
+
+  it("accounts branch-summary responses through the same run owner", async () => {
+    const sessionManager = SessionManager.inMemory();
+    const rootId = sessionManager.appendMessage({ role: "user", content: "root", timestamp: 1 });
+    const abandonedId = sessionManager.appendMessage({
+      role: "user",
+      content: "abandoned branch",
+      timestamp: 2,
+    });
+    sessionManager.branch(rootId);
+    const targetId = sessionManager.appendMessage({
+      ...createAssistant(testModel, [{ type: "text", text: "target branch" }]),
+      timestamp: 3,
+    });
+    sessionManager.branch(abandonedId);
+    streamMocks.streamSimple.mockImplementation((activeModel: Model) =>
+      createAssistantResultStream(
+        createAssistant(activeModel, [{ type: "text", text: "branch summary" }], "stop", 7),
+      ),
+    );
+    const { session } = await createTestSession({ sessionManager });
+    const subscription = subscribeEmbeddedAgentSession({
+      session,
+      runId: "run-branch-summary-usage",
+    });
+
+    await session.navigateTree(targetId, { summarize: true });
+
+    expect(subscription.getUsageTotals()).toMatchObject({ input: 7, output: 1, total: 8 });
     subscription.unsubscribe();
   });
 

--- a/src/agents/sessions/agent-session-compaction.ts
+++ b/src/agents/sessions/agent-session-compaction.ts
@@ -19,8 +19,10 @@ import { wrapUntrustedPromptDataBlock } from "../sanitize-for-prompt.js";
 import { AgentSessionInspection } from "./agent-session-inspection.js";
 import { unwrapCoreResult } from "./agent-session-utils.js";
 import { formatNoModelSelectedMessage } from "./auth-guidance.js";
+import { createCompactionRuntime } from "./compaction/runtime.js";
 import { preflightManualSessionCompaction } from "./manual-compaction-preflight.js";
 import { getLatestCompactionEntry, type CompactionEntry } from "./session-manager.js";
+import { recordSessionModelUsage } from "./session-model-usage.js";
 import type { SettingsManager } from "./settings-manager.js";
 
 type CompactionReason = "manual" | "threshold" | "overflow";
@@ -238,6 +240,7 @@ export abstract class AgentSessionCompaction extends AgentSessionInspection {
           options.signal,
           this.thinkingLevel,
           this.agent.streamFn,
+          createCompactionRuntime((usage) => recordSessionModelUsage(this.sessionManager, usage)),
         );
       let result = await runCoreCompaction();
       // Automatic core compaction owns one retry for invalid summary output.

--- a/src/agents/sessions/agent-session-tree.ts
+++ b/src/agents/sessions/agent-session-tree.ts
@@ -5,12 +5,14 @@ import {
 } from "../runtime/index.js";
 import { AgentSessionExecution } from "./agent-session-execution.js";
 import { extractTextContent, normalizeBranchSummaryResult } from "./agent-session-utils.js";
+import { createCompactionRuntime } from "./compaction/runtime.js";
 import type {
   ExtensionRunner,
   ReplacedSessionContext,
   TreePreparation,
 } from "./extensions/index.js";
 import type { BranchSummaryEntry } from "./session-manager.js";
+import { recordSessionModelUsage } from "./session-model-usage.js";
 
 export abstract class AgentSessionTree extends AgentSessionExecution {
   // =========================================================================
@@ -136,6 +138,9 @@ export abstract class AgentSessionTree extends AgentSessionExecution {
             replaceInstructions,
             reserveTokens: branchSummarySettings.reserveTokens,
             streamFn: this.agent.streamFn,
+            runtime: createCompactionRuntime((usage) =>
+              recordSessionModelUsage(this.sessionManager, usage),
+            ),
           }),
         );
         if (result.aborted) {

--- a/src/agents/sessions/compaction/branch-summarization.ts
+++ b/src/agents/sessions/compaction/branch-summarization.ts
@@ -7,13 +7,13 @@ import type { Model } from "../../../llm/types.js";
 import {
   collectEntriesForBranchSummaryFromBranches,
   generateBranchSummary as generateBranchSummaryCore,
-  openClawAgentCoreRuntime,
   prepareBranchEntries,
   type BranchPreparation,
   type BranchSummaryDetails,
   type FileOperations,
 } from "../../runtime/index.js";
 import type { SessionEntry, ReadonlySessionManager } from "../session-manager.js";
+import { createCompactionRuntime, type SessionModelUsageSink } from "./runtime.js";
 
 export type { BranchPreparation, BranchSummaryDetails, FileOperations };
 export { prepareBranchEntries };
@@ -39,6 +39,7 @@ export interface GenerateBranchSummaryOptions {
   customInstructions?: string;
   replaceInstructions?: boolean;
   reserveTokens?: number;
+  usageSink?: SessionModelUsageSink;
 }
 
 /** Collects entries that differ between two session branches for summarization. */
@@ -61,9 +62,10 @@ export async function generateBranchSummary(
   entries: SessionEntry[],
   options: GenerateBranchSummaryOptions,
 ): Promise<BranchSummaryResult> {
+  const { usageSink, ...summaryOptions } = options;
   const result = await generateBranchSummaryCore(entries, {
-    runtime: openClawAgentCoreRuntime,
-    ...options,
+    runtime: createCompactionRuntime(usageSink),
+    ...summaryOptions,
   });
   if (result.ok) {
     return result.value;

--- a/src/agents/sessions/compaction/compaction.ts
+++ b/src/agents/sessions/compaction/compaction.ts
@@ -17,7 +17,6 @@ import {
   prepareCompaction as prepareCompactionCore,
   serializeConversation,
   shouldCompact,
-  openClawAgentCoreRuntime,
   type CompactionDetails,
   type CompactionPreparation,
   type CompactionResult,
@@ -29,6 +28,7 @@ import {
   type ThinkingLevel,
 } from "../../runtime/index.js";
 import type { SessionEntry } from "../session-manager.js";
+import { createCompactionRuntime, type SessionModelUsageSink } from "./runtime.js";
 
 export {
   calculateContextTokens,
@@ -75,6 +75,7 @@ export async function generateSummary(
   previousSummary?: string,
   thinkingLevel?: ThinkingLevel,
   streamFn?: StreamFn,
+  usageSink?: SessionModelUsageSink,
 ): Promise<string> {
   return unwrapCompactionResult(
     await generateSummaryCore(
@@ -88,7 +89,7 @@ export async function generateSummary(
       previousSummary,
       thinkingLevel,
       streamFn,
-      openClawAgentCoreRuntime,
+      createCompactionRuntime(usageSink),
     ),
   );
 }
@@ -103,6 +104,7 @@ export async function compact(
   signal?: AbortSignal,
   thinkingLevel?: ThinkingLevel,
   streamFn?: StreamFn,
+  usageSink?: SessionModelUsageSink,
 ): Promise<CompactionResult> {
   return unwrapCompactionResult(
     await compactCore(
@@ -114,7 +116,7 @@ export async function compact(
       signal,
       thinkingLevel,
       streamFn,
-      openClawAgentCoreRuntime,
+      createCompactionRuntime(usageSink),
     ),
   );
 }

--- a/src/agents/sessions/compaction/runtime.ts
+++ b/src/agents/sessions/compaction/runtime.ts
@@ -1,0 +1,11 @@
+import type { Usage } from "../../../llm/types.js";
+import { openClawAgentCoreRuntime } from "../../runtime/index.js";
+
+export type SessionModelUsageSink = (usage: Usage) => void;
+
+/** Adds a private usage sink without changing public summary result shapes. */
+export function createCompactionRuntime(usageSink?: SessionModelUsageSink) {
+  return usageSink
+    ? { ...openClawAgentCoreRuntime, internalUsageSink: usageSink }
+    : openClawAgentCoreRuntime;
+}

--- a/src/agents/sessions/session-model-usage.ts
+++ b/src/agents/sessions/session-model-usage.ts
@@ -1,0 +1,19 @@
+import type { Usage } from "@openclaw/ai";
+import { createSessionManagerRuntimeRegistry } from "../agent-hooks/session-manager-runtime-registry.js";
+
+export type SessionModelUsageSink = (usage: Usage) => void;
+
+const sinkBySessionManager = createSessionManagerRuntimeRegistry<SessionModelUsageSink>();
+
+/** Records one auxiliary model completion at the session that owns the request. */
+export function recordSessionModelUsage(sessionManager: unknown, usage: Usage): void {
+  sinkBySessionManager.get(sessionManager)?.(usage);
+}
+
+/** Sets the active accounting owner for auxiliary model usage. */
+export function setSessionModelUsageSink(
+  sessionManager: unknown,
+  sink: SessionModelUsageSink | null,
+): void {
+  sinkBySessionManager.set(sessionManager, sink);
+}

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -286,15 +286,16 @@ describe("Engine contract tests", () => {
       sessionKey: "agent:main:s2",
       storePath: "/tmp/openclaw-agent.sqlite",
     };
+    const runtimeContext = {
+      workspaceDir: "/tmp/workspace",
+      currentTokenCount: 12345,
+    };
     const result = await delegateCompactionToRuntime({
       sessionId: "s2",
       sessionKey: "agent:main:s2",
       sessionTarget,
       tokenBudget: 4096,
-      runtimeContext: {
-        workspaceDir: "/tmp/workspace",
-        currentTokenCount: 12345,
-      },
+      runtimeContext,
     });
 
     expect(compactRuntimeSpy).toHaveBeenCalledTimes(1);
@@ -306,6 +307,7 @@ describe("Engine contract tests", () => {
     expect(compactRuntimeParams.tokenBudget).toBe(4096);
     expect(compactRuntimeParams.currentTokenCount).toBe(12345);
     expect(compactRuntimeParams.workspaceDir).toBe("/tmp/workspace");
+    expect(compactRuntimeParams.contextEngineRuntimeContext).toBe(runtimeContext);
     expect(result).toEqual({
       ok: true,
       compacted: false,

--- a/src/context-engine/delegate.ts
+++ b/src/context-engine/delegate.ts
@@ -174,6 +174,8 @@ export async function delegateCompactionToRuntime(
 
   const result = await compactEmbeddedAgentSessionOnDemand({
     ...runtimeContextParams,
+    // Preserve identity for the private recovery-accounting bridge.
+    contextEngineRuntimeContext: runtimeContext,
     ...(agentId ? { agentId } : {}),
     sessionId: params.sessionId,
     ...(sessionKey ? { sessionKey } : {}),


### PR DESCRIPTION
Closes #117564

## What Problem This Solves

Compaction, split-turn prefix, and branch-summary model calls returned summary text but discarded their token usage before run accounting. Budget gates, cost views, and idle-timeout cost checks therefore missed paid work.

## Root cause

The shared summarizers materialized full provider responses, then narrowed them to summary-only results. Automatic compaction, the safeguard, branch navigation, and recovery used separate paths, so a result-level fix could not cover every caller.

## Fix

- Record each materialized summarizer response at the completion boundary before summary validation.
- Route usage through one private session owner into the existing run accumulator.
- Use the same recovery adapter for context-engine and Responses endpoint compaction.
- Keep public compaction and branch-summary result shapes unchanged.

## Live proof

- `25cb72398a6fb41e04bac28d888fa3a5ef1d2477`: four real OpenAI summary calls reported nonzero usage; run accounting received zero records.
- `9d4c79695e79b29a0e6f0a7cf3f86184e30344ce`: the same four calls reached run accounting exactly once each.
- The proof varied four marker inputs and produced three distinct summaries, so cached or fixed output could not pass.

### Sanitized after-fix trace

```json
{
  "revision": "9d4c79695e79b29a0e6f0a7cf3f86184e30344ce",
  "summaryCalls": [
    { "providerTokens": 444, "accountedTokens": 444 },
    { "providerTokens": 474, "accountedTokens": 474 },
    { "providerTokens": 282, "accountedTokens": 282 },
    { "providerTokens": 372, "accountedTokens": 372 }
  ],
  "providerTotalTokens": 1572,
  "accountedRunTotalTokens": 1572,
  "publicResultsExposeUsage": false,
  "result": "GREEN"
}
```

## Evidence

- 144 focused tests pass across Agent Core, automatic and safeguard compaction, branch navigation, recovery, endpoint compaction, and the legacy context-engine bridge.
- Format, Oxlint, import-cycle, coercion, max-lines, assertion-safety, database-first, conflict-marker, and diff checks pass.
- Production: +105 net lines. Tests: +106 net lines. The production growth creates the private owner boundary and replaces the prior +279-line multi-bridge design.

AI-assisted; contributor intent and attribution preserved.
