### PR TITLE
fix(test): stabilize stale-owner followup ordering checks

### DIFF
--- a/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
+++ b/src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts
@@ -65,50 +65,56 @@ describe("force-clear terminal state persistence", () => {
   });
 
   it("delays stale-owner followups until the old reply owner settles", async () => {
-    const sessionKey = "agent:main:reply-stuck-followup";
-    const sessionId = "session-reply-stuck-followup";
-    const operation = createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
-    const handle = createRunHandle();
-    operation.attachBackend({
-      kind: "embedded",
-      cancel: handle.abort,
-      isStreaming: handle.isStreaming,
-    });
-    operation.setPhase("running");
-    setActiveEmbeddedRun(sessionId, handle, sessionKey);
+    // Owner ordering must not depend on the host finishing within the drain deadline.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      const sessionKey = "agent:main:reply-stuck-followup";
+      const sessionId = "session-reply-stuck-followup";
+      const operation = createReplyOperation({ sessionKey, sessionId, resetTriggered: false });
+      const handle = createRunHandle();
+      operation.attachBackend({
+        kind: "embedded",
+        cancel: handle.abort,
+        isStreaming: handle.isStreaming,
+      });
+      operation.setPhase("running");
+      setActiveEmbeddedRun(sessionId, handle, sessionKey);
 
-    const followupObservedActiveHandle: boolean[] = [];
-    runAfterReplyOperationClear(operation, () => {
-      followupObservedActiveHandle.push(isEmbeddedAgentRunHandleActive(sessionId));
-    });
+      const followupObservedActiveHandle: boolean[] = [];
+      runAfterReplyOperationClear(operation, () => {
+        followupObservedActiveHandle.push(isEmbeddedAgentRunHandleActive(sessionId));
+      });
 
-    const recovery = abortAndDrainEmbeddedAgentRun({
-      sessionId,
-      sessionKey,
-      reason: "stuck_recovery",
-      forceClear: true,
-      settleMs: 100,
-    });
-    expect(isReplyRunActiveForSessionId(sessionId)).toBe(true);
-    expect(followupObservedActiveHandle).toEqual([]);
+      const recovery = abortAndDrainEmbeddedAgentRun({
+        sessionId,
+        sessionKey,
+        reason: "stuck_recovery",
+        forceClear: true,
+        settleMs: 100,
+      });
+      expect(isReplyRunActiveForSessionId(sessionId)).toBe(true);
+      expect(followupObservedActiveHandle).toEqual([]);
 
-    clearActiveEmbeddedRun(sessionId, handle, sessionKey);
-    let recoverySettled = false;
-    void recovery.then(() => {
-      recoverySettled = true;
-    });
-    await Promise.resolve();
-    expect(recoverySettled).toBe(false);
-    expect(followupObservedActiveHandle).toEqual([]);
+      clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+      let recoverySettled = false;
+      void recovery.then(() => {
+        recoverySettled = true;
+      });
+      await Promise.resolve();
+      expect(recoverySettled).toBe(false);
+      expect(followupObservedActiveHandle).toEqual([]);
 
-    operation.complete();
-    await expect(recovery).resolves.toEqual({
-      aborted: true,
-      drained: true,
-      forceCleared: false,
-    });
-    await Promise.resolve();
-    expect(followupObservedActiveHandle).toEqual([false]);
+      operation.complete();
+      await expect(recovery).resolves.toEqual({
+        aborted: true,
+        drained: true,
+        forceCleared: false,
+      });
+      await Promise.resolve();
+      expect(followupObservedActiveHandle).toEqual([false]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("force-clears exact owners before releasing followups after cancel throws", async () => {


### PR DESCRIPTION
Related: #131059

## What Problem This Solves

Resolves a problem where CI could reject unrelated changes when the stale-owner followup ordering test was paused for more than 100 ms. [The observed job](https://github.com/openclaw/openclaw/actions/runs/33101410438/job/98620214721) returned `drained: false` instead of the test's expected `true`.

## Why This Change Was Made

The test checks ownership ordering, but its real wall clock also races the production drain deadline. Once the embedded handle clears, the waiter checks the remaining budget while the reply owner is still active. A host scheduling pause can legitimately exhaust that budget. This change freezes only `Date` in that test and restores it in `finally`. Real timer APIs, the 100 ms deadline, all ordering assertions, and the sibling timeout tests stay unchanged. There is no runtime change.

Provenance: the test and its real-clock deadline came from commit `5cc2fa6249257829ca2ec2856281cb4e2fc7244c` in #119851, authored and merged by Josh Avant (@joshavant) on August 7, 2026. The current CI run exposed that pre-existing race.

## User Impact

No product behavior changes. CI continues to verify that recovered followups wait for the old reply owner and observe the embedded handle already cleared, without treating host scheduling speed as part of that contract.

## Evidence

A temporary 150 ms synchronous pause immediately after handle clearance reproduces the exact failure on the original test. The same pause passes after controlling `Date`; the pause is not part of the committed test. Production code, assertions, and deadlines are unchanged.

Final no-pause proof: `node scripts/run-vitest.mjs src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts src/agents/embedded-agent-runner/runs.lifecycle.test.ts src/agents/embedded-agent-runner/runs.test.ts src/auto-reply/reply/reply-run-registry.test.ts --no-isolate --maxWorkers=1` passed 135 tests across four files in 62.83 seconds. The original ordering test is retained; no redundant regression test or production seam was added.

Formatting and `git diff --check` passed. Isolated Codex autoreview completed with no actionable findings at its P0 threshold. Production LOC: +0/-0. Test LOC: +50/-44, net +6; existing statements are reindented under `try/finally`.

Targeted typed lint passed. `node scripts/check-changed.mjs -- src/agents/embedded-agent-runner/runs.force-clear-terminal.test.ts` passed 17 guards/format/report steps, then stopped in core-test typechecking because the reused local install predates current pinned dependencies: Google GenAI 2.13.0 versus 2.18.0, markdown-it 14.3.0 versus 15.0.0, and pi-tui 0.82.1 versus 0.84.2. The shared install was not modified. The [full exact-head hosted CI run](https://github.com/openclaw/openclaw/actions/runs/33103443933) with pinned dependencies subsequently passed on its first attempt, including typechecking, build, lint, and all selected test shards.

No live product run is needed for this test-only change. The separate scheduling repair in #131059 has actual SMTP/IMAP, Gateway, and live-provider proof.
