### PR TITLE
fix(ui): keep Gateway place labels current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Control UI Gateway labels:** keep the discovered machine name through recovery initialization and refresh open folder-browser labels when name discovery finishes.
 - **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
 - **Nextcloud Talk diagnostics:** redact reflected credentials before displaying send, reaction, and bot-preflight errors, and suppress incomplete error bodies. (#119976) Thanks @xialonglee.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.

--- a/ui/src/components/session-group-defaults-dialog.ts
+++ b/ui/src/components/session-group-defaults-dialog.ts
@@ -8,7 +8,6 @@ import type {
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
 import { renderSessionMenuItem } from "../pages/new-session/cloud-target.ts";
-import type { BrowserTarget } from "../pages/new-session/discovery.ts";
 import { folderDisplayName, isAbsolutePath } from "../pages/new-session/path.ts";
 import { renderPlaceBrowser } from "../pages/new-session/place-browser.ts";
 import "../styles/new-session.css";
@@ -49,7 +48,6 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
     let browserListing: FsListDirResult | null = null;
     let browserPathDraft = "";
     let browserRequestToken = 0;
-    const browserTarget: BrowserTarget = { nodeId: "", label: t("newSession.gateway") };
 
     const finish = () => {
       browserRequestToken += 1;
@@ -299,7 +297,7 @@ export function showSessionGroupDefaultsDialog(options: Options): Promise<void> 
                     ${browserVisible
                       ? renderPlaceBrowser({
                           listing: browserListing,
-                          target: browserTarget,
+                          label: t("newSession.gateway"),
                           loading: browserLoading,
                           error: browserError,
                           pathDraft: browserPathDraft,

--- a/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
@@ -2,11 +2,13 @@ import { expect, it } from "vitest";
 import {
   SESSION_LIST_DEFAULTS,
   WORKSPACE,
+  captureUiProofEnabled,
   captureProjectUiProof,
   createNewSessionPageE2eSuite,
   installMockGateway,
   pollLocatorText,
   prepareProjectUiProof,
+  projectProofArtifactDir,
   replaceGatewayClient,
 } from "./new-session-page.test-support.ts";
 
@@ -145,54 +147,94 @@ suite.define(() => {
     }
   });
 
-  it("uses advertised system info for Gateway place labels", async () => {
-    const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
-    const page = await context.newPage();
-    const gateway = await installMockGateway(page, {
-      workspace: WORKSPACE,
-      workspaceGit: true,
-      featureMethods: ["chat.metadata", "chat.startup", "sessions.create", "system.info"],
-      methodResponses: {
-        "system.info": {
-          machineName: "Peters-Mac-Studio",
-          hostname: "peters-mac-studio.local",
-          platform: "darwin",
+  it.each(["recovery scope", "system info"] as const)(
+    "updates Gateway place labels after late %s",
+    async (late) => {
+      await prepareProjectUiProof();
+      const context = await suite.browser.newContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        ...(captureUiProofEnabled ? { recordVideo: { dir: projectProofArtifactDir } } : {}),
+      });
+      const page = await context.newPage();
+      if (late === "recovery scope") {
+        // Resolve auth recovery after name discovery to exercise their independent lifetimes.
+        await page.addInitScript(() => {
+          const originalDigest = crypto.subtle.digest.bind(crypto.subtle);
+          const delayed = new Promise<void>((resolve) => {
+            window.addEventListener("test-release-recovery-scope", () => resolve(), { once: true });
+          });
+          crypto.subtle.digest = async (algorithm, data) => {
+            if (new TextDecoder().decode(data) === "e2e-device-token") {
+              await delayed;
+            }
+            return originalDigest(algorithm, data);
+          };
+        });
+      }
+      const systemInfo = {
+        machineName: "QA-Gateway",
+        hostname: "qa-gateway.local",
+        platform: "darwin",
+      };
+      const gateway = await installMockGateway(page, {
+        workspace: WORKSPACE,
+        workspaceGit: true,
+        featureMethods: ["chat.metadata", "chat.startup", "sessions.create", "system.info"],
+        heldMethods: late === "system info" ? ["system.info"] : [],
+        methodResponses: {
+          "system.info": systemInfo,
+          "environments.list": {
+            environments: [gatewayEnvironment],
+            profiles: [],
+          },
         },
-        "environments.list": {
-          environments: [gatewayEnvironment],
-          profiles: [],
-        },
-      },
-    });
+      });
 
-    try {
-      await page.goto(`${suite.server.baseUrl}new`);
-      await gateway.waitForRequest("system.info");
-      const trigger = page.locator("#new-session-where-trigger");
-      await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("Local");
-      await trigger.click();
-      const place = page.locator("wa-popover.new-session-page__where-popover");
-      await place.getByRole("button", { name: /Local/u }).waitFor();
-      await page.keyboard.press("Escape");
-      await page.locator("#new-session-project-trigger").click();
-      await page
-        .locator("wa-popover.new-session-page__project-popover")
-        .getByRole("button", { name: "Browse folders" })
-        .click();
-      await expect
-        .poll(() =>
-          page.locator("input.new-session-page__browser-path").getAttribute("placeholder"),
-        )
-        .toBe("Gateway · Peters-Mac-Studio");
+      try {
+        await page.goto(`${suite.server.baseUrl}new`);
+        await gateway.waitForRequest("system.info");
+        const trigger = page.locator("#new-session-where-trigger");
+        await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("Local");
+        const place = page.locator("wa-popover.new-session-page__where-popover");
+        const local = place.locator('[data-value="gateway"]');
+        if (late === "recovery scope") {
+          await trigger.click();
+          await expect.poll(() => local.getAttribute("title")).toBe("Gateway · QA-Gateway");
+          const catalogRequests = (await gateway.getRequests("environments.list")).length;
+          await page.evaluate(() => window.dispatchEvent(new Event("test-release-recovery-scope")));
+          await gateway.waitForRequest("environments.list", { after: catalogRequests });
+          await page.keyboard.press("Escape");
+        }
+        await page.locator("#new-session-project-trigger").click();
+        await page
+          .locator("wa-popover.new-session-page__project-popover")
+          .getByRole("button", { name: "Browse folders" })
+          .click();
+        const pathInput = page.locator("input.new-session-page__browser-path");
+        await pathInput.fill("");
+        if (late === "system info") {
+          await expect.poll(() => pathInput.getAttribute("placeholder")).toBe("Gateway · local");
+          await gateway.resolveDeferred("system.info", systemInfo);
+          await expect.poll(() => local.getAttribute("title")).toBe("Gateway · QA-Gateway");
+        }
+        await expect.poll(() => pathInput.getAttribute("placeholder")).toBe("Gateway · QA-Gateway");
+        await captureProjectUiProof(page, `gateway-name-${late.replaceAll(" ", "-")}.png`);
 
-      await replaceGatewayClient(page);
-      await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("Local");
-      await trigger.click();
-      await place.getByRole("button", { name: /Local/u }).waitFor();
-    } finally {
-      await context.close();
-    }
-  });
+        await page.keyboard.press("Escape");
+        await replaceGatewayClient(page);
+        await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("Local");
+        await trigger.click();
+        await expect.poll(() => local.getAttribute("title")).toBe("Gateway · QA-Gateway");
+      } finally {
+        try {
+          await captureProjectUiProof(page, `gateway-name-${late.replaceAll(" ", "-")}-final.png`);
+        } finally {
+          await context.close();
+        }
+      }
+    },
+  );
 
   it("keeps and disambiguates recent locations with the same basename", async () => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });

--- a/ui/src/pages/new-session/discovery.ts
+++ b/ui/src/pages/new-session/discovery.ts
@@ -62,8 +62,6 @@ export type DraftEnvironment = {
   issues?: RuntimeTargetIssue[];
 };
 
-export type BrowserTarget = { nodeId: string; label: string };
-
 function normalizeTimestamp(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value >= 0
     ? Math.trunc(value)

--- a/ui/src/pages/new-session/draft-gateway-state.ts
+++ b/ui/src/pages/new-session/draft-gateway-state.ts
@@ -65,7 +65,6 @@ type DraftGatewayCallbacks = {
 };
 
 export class DraftGatewayState {
-  private gatewayNameValue = "";
   private cloudProfilesValue: DraftCloudProfile[] = [];
   private environmentsValue: DraftEnvironment[] | null = null;
   private cloudProfilesReadyValue = false;
@@ -110,10 +109,6 @@ export class DraftGatewayState {
         ] as const,
       task: ([client, advertised, _connectionEpoch], { signal }) =>
         discoverGatewayName(client, advertised, signal),
-      onComplete: (name) => {
-        this.gatewayNameValue = name;
-        this.callbacks.requestUpdate();
-      },
     });
     this.cloudProfileTask = new Task(host, {
       args: () =>
@@ -142,7 +137,10 @@ export class DraftGatewayState {
   }
 
   get gatewayName(): string {
-    return this.gatewayNameValue;
+    // Recovery-scope discovery does not retire this connection's machine identity.
+    return this.gatewayNameTask.status === TaskStatus.COMPLETE
+      ? (this.gatewayNameTask.value ?? "")
+      : "";
   }
 
   get cloudProfiles(): readonly DraftCloudProfile[] {
@@ -296,7 +294,6 @@ export class DraftGatewayState {
   }
 
   invalidateDiscovery(resetHostSelection: boolean, submissionOutcome: SubmissionOutcomeReason) {
-    this.gatewayNameValue = "";
     this.cloudProfilesValue = [];
     this.cloudProfilesReadyValue = false;
     if (resetHostSelection) {

--- a/ui/src/pages/new-session/draft-place-browser.test.ts
+++ b/ui/src/pages/new-session/draft-place-browser.test.ts
@@ -1,5 +1,8 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ReactiveController } from "lit";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import { DraftGatewayState } from "./draft-gateway-state.ts";
 import { DraftPlaceBrowser } from "./draft-place-browser.ts";
 import type { NewSessionRouteData } from "./location.ts";
@@ -12,17 +15,20 @@ afterEach(() => {
 
 function createBrowser(request: (method: string) => Promise<unknown>, data?: NewSessionRouteData) {
   const host = new TestReactiveControllerHost();
+  const controllers: ReactiveController[] = [];
+  vi.spyOn(host, "addController").mockImplementation((controller) => controllers.push(controller));
   const client = { request, recoveryScope: "principal-a", recoveryScopeReady: true };
+  const hello = {
+    auth: { role: "operator", scopes: ["operator.read"] },
+    features: { methods: ["projects.list"] },
+  };
   const context = {
     gateway: {
       connection: { gatewayUrl: "ws://gateway.example" },
       snapshot: {
         phase: "connected",
         client,
-        hello: {
-          auth: { role: "operator", scopes: ["operator.read"] },
-          features: { methods: ["projects.list"] },
-        },
+        hello,
       },
     },
     sessions: {
@@ -76,7 +82,23 @@ function createBrowser(request: (method: string) => Promise<unknown>, data?: New
       body: () => null,
     },
   );
-  return { browser, gateway };
+  onTestFinished(() => {
+    gateway.disconnect();
+    browser.disconnect();
+  });
+  return {
+    browser,
+    gateway,
+    client,
+    context,
+    hello,
+    update() {
+      gateway.synchronize(context.gateway);
+      for (const controller of controllers) {
+        controller.hostUpdate?.();
+      }
+    },
+  };
 }
 
 describe("DraftPlaceBrowser", () => {
@@ -128,6 +150,90 @@ describe("DraftPlaceBrowser", () => {
 });
 
 describe("DraftGatewayState", () => {
+  it("retains a discovered name when the same connection's recovery scope arrives", async () => {
+    const fixture = createBrowser(async () => ({ machineName: "Gateway A" }));
+    fixture.hello.features.methods.push("system.info");
+    fixture.client.recoveryScopeReady = false;
+    fixture.update();
+    await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe("Gateway A"));
+
+    fixture.client.recoveryScope = "resolved-principal";
+    fixture.client.recoveryScopeReady = true;
+    fixture.update();
+    expect(fixture.gateway.gatewayName).toBe("Gateway A");
+  });
+
+  it("hides a disconnected name until the same client's new discovery completes", async () => {
+    const pending = createDeferred<{ machineName: string }>();
+    const request = vi.fn(async () => ({ machineName: "Gateway A" }));
+    const fixture = createBrowser(request);
+    fixture.hello.features.methods.push("system.info");
+    fixture.update();
+    await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe("Gateway A"));
+
+    fixture.context.gateway.snapshot.phase = "reconnecting";
+    fixture.update();
+    expect(fixture.gateway.gatewayName).toBe("");
+    request.mockImplementation(() => pending.promise);
+    fixture.context.gateway.snapshot.phase = "connected";
+    fixture.update();
+    expect(fixture.gateway.gatewayName).toBe("");
+    pending.resolve({ machineName: "Gateway B" });
+    await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe("Gateway B"));
+  });
+
+  it("ignores a late name from the replaced client", async () => {
+    const oldName = createDeferred<{ machineName: string }>();
+    const newName = createDeferred<{ machineName: string }>();
+    const fixture = createBrowser(() => oldName.promise);
+    fixture.hello.features.methods.push("system.info");
+    fixture.update();
+    fixture.context.gateway.snapshot.client = createTestGatewayClient(() => newName.promise);
+    fixture.update();
+    oldName.resolve({ machineName: "Retired Gateway" });
+    // Flush the retired request's promise continuations before checking the active owner.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0);
+    });
+    expect(fixture.gateway.gatewayName).toBe("");
+    newName.resolve({ machineName: "Active Gateway" });
+    await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe("Active Gateway"));
+  });
+
+  it.each([
+    { advertised: false, response: { machineName: "Hidden Gateway" }, name: "" },
+    { advertised: true, response: { hostname: "host.example" }, name: "host" },
+    { advertised: true, response: null, name: "" },
+  ])(
+    "settles name discovery with advertisement $advertised and response $response",
+    async ({ advertised, response, name }) => {
+      let current: typeof response | { machineName: string } = { machineName: "Current Gateway" };
+      const request = vi.fn(async (_method: string) => {
+        if (!current) {
+          throw new Error("System info unavailable");
+        }
+        return current;
+      });
+      const fixture = createBrowser(request);
+      fixture.hello.features.methods.push("system.info");
+      fixture.update();
+      await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe("Current Gateway"));
+      current = response;
+      fixture.context.gateway.snapshot.phase = "reconnecting";
+      fixture.update();
+      fixture.hello.features.methods = advertised ? ["system.info"] : [];
+      fixture.context.gateway.snapshot.phase = "connected";
+      fixture.update();
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe(name));
+      expect(request.mock.calls.filter(([method]) => method === "system.info")).toHaveLength(
+        advertised ? 2 : 1,
+      );
+    },
+  );
+
   it("keeps group route defaults isolated from ordinary New Session preferences", () => {
     patchNewSessionPreference("ws://gateway.example", "main", {
       folder: "/workspace/ordinary",

--- a/ui/src/pages/new-session/draft-place-browser.ts
+++ b/ui/src/pages/new-session/draft-place-browser.ts
@@ -14,7 +14,6 @@ import type { ApplicationContext } from "../../app/context.ts";
 import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { canCallGatewayMethod, isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
-import type { BrowserTarget } from "./discovery.ts";
 import type { DraftGatewayState } from "./draft-gateway-state.ts";
 import { folderDisplayName, isAbsolutePath, isKnownWorkspacePath } from "./path.ts";
 import { projectCloneInput, type DraftRemoteProject } from "./project-chip.ts";
@@ -52,7 +51,7 @@ export class DraftPlaceBrowser {
   private browserLoadingValue = false;
   private browserErrorValue: string | null = null;
   private browserListingValue: FsListDirResult | null = null;
-  private browserTargetValue: BrowserTarget | null = null;
+  private browserOpenValue = false;
   private browserProjectPathValue: string | null = null;
   private browserRegisteringValue = false;
   private openPopoverValue: DraftPickerKind | null = null;
@@ -198,8 +197,8 @@ export class DraftPlaceBrowser {
     return this.browserListingValue;
   }
 
-  get browserTarget(): BrowserTarget | null {
-    return this.browserTargetValue;
+  get browserOpen(): boolean {
+    return this.browserOpenValue;
   }
 
   get browserProjectPath(): string | null {
@@ -367,8 +366,8 @@ export class DraftPlaceBrowser {
     return isAbsolutePath(draft) ? draft : null;
   }
 
-  selectGatewayBrowser(label: string, path?: string) {
-    this.browserTargetValue = { nodeId: "", label };
+  selectGatewayBrowser(path?: string) {
+    this.browserOpenValue = true;
     this.loadBrowser(path && isAbsolutePath(path) ? path : undefined);
   }
 
@@ -376,8 +375,7 @@ export class DraftPlaceBrowser {
     const snapshot = this.read();
     const gatewaySnapshot = snapshot.context?.gateway.snapshot;
     const client = gatewaySnapshot?.client;
-    const target = this.browserTargetValue;
-    if (gatewaySnapshot?.phase !== "connected" || !client || !target) {
+    if (gatewaySnapshot?.phase !== "connected" || !client || !this.browserOpenValue) {
       return;
     }
     const requestId = ++this.browserRequestToken;
@@ -537,7 +535,7 @@ export class DraftPlaceBrowser {
     this.browserLoadingValue = false;
     this.browserErrorValue = null;
     this.browserListingValue = null;
-    this.browserTargetValue = null;
+    this.browserOpenValue = false;
     this.browserProjectPathValue = null;
     this.browserRegisteringValue = false;
     this.browserPathDraftValue = "";

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -481,7 +481,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
       submitting,
       pendingPlacement,
       ...this.browser.popoverCallbacks("project"),
-      browserTarget: this.browser.browserTarget,
+      browserOpen: this.browser.browserOpen,
       browserListing: this.browser.browserListing,
       browserLoading: this.browser.browserLoading,
       browserError: this.browser.browserError,
@@ -496,11 +496,8 @@ export class NewSessionPage extends OpenClawLightDomElement {
         this.place.applyFolder(folder, this.browser.browserListing?.path === folder),
       onBaseRefInput: (baseRef) => this.place.setBaseRef(baseRef),
       onWorktreeNameInput: (worktreeName) => this.place.setWorktreeName(worktreeName),
-      onBrowse: (target) =>
-        this.browser.selectGatewayBrowser(
-          target.label,
-          this.place.folder.trim() || this.place.workspacePath(),
-        ),
+      onBrowse: () =>
+        this.browser.selectGatewayBrowser(this.place.folder.trim() || this.place.workspacePath()),
       onBrowserPathDraftChange: (value) => {
         this.browser.browserPathDraft = value;
       },

--- a/ui/src/pages/new-session/place-browser.ts
+++ b/ui/src/pages/new-session/place-browser.ts
@@ -2,11 +2,10 @@ import { html, nothing } from "lit";
 import type { FsListDirResult } from "../../../../packages/gateway-protocol/src/index.js";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
-import type { BrowserTarget } from "./discovery.ts";
 
 export function renderPlaceBrowser(params: {
   listing: FsListDirResult | null;
-  target: BrowserTarget;
+  label: string;
   loading: boolean;
   error: string | null;
   pathDraft: string;
@@ -54,7 +53,7 @@ export function renderPlaceBrowser(params: {
           class="new-session-page__browser-path"
           type="text"
           aria-label=${t("newSession.folder")}
-          placeholder=${params.target.label}
+          placeholder=${params.label}
           .value=${params.pathDraft}
           @input=${(event: Event) => {
             params.onPathDraftChange((event.target as HTMLInputElement).value);

--- a/ui/src/pages/new-session/project-chip.ts
+++ b/ui/src/pages/new-session/project-chip.ts
@@ -9,7 +9,7 @@ import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { renderSessionMenuItem } from "./cloud-target.ts";
 import { renderWorktreeFields } from "./detail-chip.ts";
-import type { BrowserTarget, DraftBranches } from "./discovery.ts";
+import type { DraftBranches } from "./discovery.ts";
 import { folderDisplayName, parentFolderDisplayName } from "./path.ts";
 import { renderPlaceBrowser } from "./place-browser.ts";
 import { disambiguate } from "./place-labels.ts";
@@ -106,7 +106,7 @@ export function renderProjectChip(params: {
   pendingPlacement: boolean;
   popoverOpen: boolean;
   popoverHiding: boolean;
-  browserTarget: BrowserTarget | null;
+  browserOpen: boolean;
   browserListing: FsListDirResult | null;
   browserLoading: boolean;
   browserError: string | null;
@@ -124,7 +124,7 @@ export function renderProjectChip(params: {
   onApplyFolder: (folder: string) => void;
   onBaseRefInput: (baseRef: string) => void;
   onWorktreeNameInput: (name: string) => void;
-  onBrowse: (target: BrowserTarget) => void;
+  onBrowse: () => void;
   onBrowserPathDraftChange: (value: string) => void;
   onBrowserNavigate: (path: string | undefined) => void;
   onBrowserBack: () => void;
@@ -134,7 +134,6 @@ export function renderProjectChip(params: {
   const folder = params.folder.trim();
   const cloneInput = projectCloneInput(params.projectQuery);
   const query = params.projectQuery.trim();
-  const browseTarget: BrowserTarget = { nodeId: "", label: params.gatewayLabel };
   const browseNeedsAdmin = !params.browseAvailable && !params.isAdmin;
   const recentItems = params.state.recents;
   const recentSuffixes = disambiguate(recentItems, (recent) => recent.displayName, [
@@ -154,7 +153,7 @@ export function renderProjectChip(params: {
       (!params.browseAvailable && !browseNeedsAdmin)}
       @click=${() => {
         if (params.browseAvailable && !params.submitting && !params.pendingPlacement) {
-          params.onBrowse(browseTarget);
+          params.onBrowse();
         }
       }}
     >
@@ -205,10 +204,10 @@ export function renderProjectChip(params: {
       @wa-hide=${params.onPopoverHide}
       @wa-after-hide=${params.onPopoverAfterHide}
     >
-      ${params.browserTarget
+      ${params.browserOpen
         ? renderPlaceBrowser({
             listing: params.browserListing,
-            target: params.browserTarget,
+            label: params.gatewayLabel,
             loading: params.browserLoading,
             error: params.browserError,
             pathDraft: params.browserPathDraft,


### PR DESCRIPTION
## What Problem This Solves

Fixes two New Session races that leave the Gateway displayed as `Gateway · local` even after its machine name was discovered: late recovery initialization can erase the name, and an already-open folder browser can retain an old label. The first symptom surfaced in an unrelated test-only PR's hosted browser job; controlled Chromium tests reproduce both ordering failures on current main.

## Why This Change Was Made

The discovery Task now owns the machine name directly. Its completed value survives unrelated recovery-scope initialization, while pending discovery hides an old connection's value and Task cancellation/call ordering rejects retired responses. This removes the separately mutable name field and completion callback.

The folder browser now stores only its open state. Its label comes from the current render rather than a captured `BrowserTarget` object. The unused node ID and target type are removed; the group-defaults dialog, the only other browser-renderer caller, keeps its existing generic Gateway label. Directory browsing, selection, request retirement, permissions, and session placement are unchanged.

Production: **+23/-37 (net -14)**. Tests: **+199/-51**. Changelog: +1. No dependency, configuration, protocol, persistence, or compatibility surface is added.

Alternatives rejected: adding recovery scope to name-discovery arguments would refetch to compensate for duplicated state, and updating captured labels on every metadata event would create another synchronization path. Reading the existing owner and deriving presentation at render time removes both failure modes.

Provenance: the name mirror was carried forward by draft-owner extraction #122413 (`6b0be0215fb8f54bf55b0a36b85678b16d7b096b`, August 12 UTC). The captured browser label is blamed to #126187 (`80934e5639d424b1a9ffda6e88726218d2ac5276`, August 19 UTC). The original machine-identity feature was #112162 (`dd6e366d94bce56c986a4e88ae42dcec2129be7a`, July 21 UTC). All three PRs were authored and merged by @steipete; this identifies the exact current patterns, not necessarily the first appearance of each race. The affected paths are unchanged between the earlier fixture baseline and this PR's main baseline `5890806fbe5688cebf4b713e0580e98e7a6b1958`.

## User Impact

New Session keeps the advertised Gateway machine name when recovery setup completes. Browse folders updates its label if discovery completes while it is open. Reconnects and replacement clients still hide retired names until their own discovery finishes. The generic local label remains when discovery is unadvertised or unavailable.

The changelog follows the maintainer's explicit instruction to include release notes for user-visible fixes, a scoped exception to the release-owned changelog workflow.

## Evidence

- Authentic current-main Chromium RED: both controlled orderings fail with `Gateway · local` instead of `Gateway · QA-Gateway`. One delays the actual recovery-scope digest until discovery completes; the other holds the actual `system.info` response until Browse is open.
- Authentic owner RED: the discovered-name retention test fails before the production repair, with nine other cases passing.
- GREEN: 26 focused owner/rendering tests across three files and 26 Chromium scenarios across three files pass. Coverage includes project browsing/registration, group defaults, client replacement, same-client reconnect, late retired responses, advertisement removal, hostname fallback, and failed discovery.
- The two controlled browser scenarios pass again after independent review's context-teardown feedback. Browser capture failure now still closes the context. Unit fixtures explicitly retire their owners.
- Direct source proof includes both browser callers and the installed Lit Task lifecycle: host-update argument comparison, pending status, request call IDs, abort handling, completion publication, and disconnect retirement. Independent review found no production issue.
- The final nine-UI-file changed gate passes, including core-test/UI types, type-aware lint, formatting, i18n, dead exports, and ownership/baseline ratchets. Its first run caught two missing braces in test code; corrected, then the owner file passed all 10 tests again. Final structured Codex review is clean at its configured blocking threshold.
- The earlier changelog-triggered gate exposed a pre-existing config-documentation baseline mismatch. This is now resolved on main by #131128 (`cad34e612f0d23db922191f1f4be5c7248de97e9`), incorporated by the mechanical rebase onto `79dfa81664fd64a3f6192331af4953ff9f9bf1ef`. The canonical config-documentation check passed on that baseline. This PR changes neither baseline nor budget; its refreshed complete changed-file gate passes.

Resolved integration follow-up: #121554 added the Daytona manifest without refreshing the plugin documentation baseline. Main #131128 refreshed the canonical artifacts; no workaround is included here.

Before: an empty folder path still shows the generic local label after successful name discovery.

![Before: open browser retains the generic Gateway label](https://github.com/user-attachments/assets/0705b916-0a60-4285-93de-b34ee7816b1b)

After: the same open browser uses the discovered name.

![After: open browser reflects the current Gateway name](https://github.com/user-attachments/assets/dbfbf9db-20c5-46f9-a37b-4709a24aa146)

Captures contain synthetic QA data only. This is deterministic Chromium/mock-Gateway evidence, not authenticated live-profile proof.

## Final landing verification

The earlier Chrome connection blocker is cleared through the supported Chrome connection; no browser access policy was changed. On exact head `d177cff9a33af89b0ecbe1c261a96ed522da2202`, real Chrome passed both controlled timing sequences against the explicitly synthetic Gateway: releasing `system.info` while Browse was already open changed its placeholder from `Gateway · local` to `Gateway · QA-Gateway`; releasing recovery scope after discovery retained that name without a second `system.info` call. Disconnect/reconnect advanced discovery from one to two requests and restored the correct name. These are real-profile UI interactions with controlled mock transport, not a claim that the mock is a real Gateway.

![Real Chrome: discovered name survives delayed recovery publication](https://github.com/user-attachments/assets/aa83e692-cd86-47c8-9434-b4ee6f25ee65)

Exact-head [CI run 33114840863](https://github.com/openclaw/openclaw/actions/runs/33114840863) completed successfully, including all UI browser shards. Refreshed owner tests passed 26/26; complete changed-file gate passed. Structured Codex review has no actionable findings at its configured P0 threshold, and independent owner review found no correctness issue. Rebase is patch-identical by range-diff.

Latest ClawSweeper review on this exact head has no findings. Its dependency-source gap is resolved by direct inspection of installed `@lit/task` 1.0.3 `development/task.js`: argument comparison/host update (151–192), run call-ID and completion publication (205–278), and abort semantics (282–306), together with the OpenClaw owner's disconnect retirement. Its CI gap is now green. The stored-data warning is not applicable: the group-defaults diff removes only a transient closure-local `BrowserTarget`; serialized defaults are unchanged. No migration is needed. A supplementary real-Gateway connection succeeded, but its New Session navigation hit a browser-control timeout; it is not counted as ordering proof. The completed controlled real-Chrome cases and exact-head browser CI above are the ordering proof.

Named follow-up: the supplemental combined source-Gateway/Vite harness later became CPU-busy and did not complete graceful shutdown. Its exact cause is unproven and is not attributed to this label change. Only that isolated task process was force-stopped; its child, test-state directory and loopback listeners were verified removed. The operator's managed Gateway was untouched. Preserve this harness/lifecycle observation for a separate reproduction; do not count that attempt as passing backend proof.

Related: #131052 repairs serialized unit-fixture lifetime, not these product races. Its original browser assertion passed three focused repeats, but the controlled orderings above reproduce the baseline defects deterministically. This PR does not weaken that assertion or raise its timeout.
