### PR TITLE
fix(configure): preserve the primary model across provider auth overrides

### DIFF
--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -1,8 +1,9 @@
 import { createServer } from "node:http";
 // Configure gateway auth prompt tests cover interactive auth selection and model-aware auth config.
 import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAgentEffectiveModelPrimary } from "../agents/agent-scope.js";
+import { testing as cliBackendsTesting } from "../agents/cli-backends.test-support.js";
 import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderAuthMethod, ProviderPlugin } from "../plugins/types.js";
@@ -15,139 +16,6 @@ const mocks = vi.hoisted(() => ({
   applyAuthChoice: vi.fn(),
   promptModelAllowlist: vi.fn(),
   promptDefaultModel: vi.fn(),
-  applyPrimaryModel: vi.fn((cfg: OpenClawConfig, model: string) => ({
-    ...cfg,
-    agents: {
-      ...cfg.agents,
-      defaults: {
-        ...cfg.agents?.defaults,
-        model: { primary: model },
-      },
-    },
-  })),
-  applyModelAllowlist: vi.fn(
-    (cfg: OpenClawConfig, models: string[], opts: { scopeKeys?: string[] } = {}) => {
-      const defaults = cfg.agents?.defaults;
-      const normalized = normalizeTestModelKeys(models);
-      const scopeKeys = opts.scopeKeys ? normalizeTestModelKeys(opts.scopeKeys) : [];
-      const scopeKeySet = scopeKeys.length > 0 ? new Set(scopeKeys) : null;
-      if (normalized.length === 0) {
-        if (!defaults?.models && !defaults?.modelPolicy?.allow) {
-          return cfg;
-        }
-        if (scopeKeySet) {
-          const nextModels = { ...defaults.models };
-          for (const key of scopeKeySet) {
-            delete nextModels[key];
-          }
-          const { models: _ignored, ...restDefaults } = defaults;
-          const allow = Object.keys(nextModels);
-          return {
-            ...cfg,
-            agents: {
-              ...cfg.agents,
-              defaults:
-                allow.length > 0
-                  ? {
-                      ...defaults,
-                      models: nextModels,
-                      modelPolicy: { ...defaults.modelPolicy, allow },
-                    }
-                  : (({ modelPolicy: _modelPolicy, ...rest }) => rest)(restDefaults),
-            },
-          };
-        }
-        const { models: _ignored, modelPolicy: _modelPolicy, ...restDefaults } = defaults;
-        return { ...cfg, agents: { ...cfg.agents, defaults: restDefaults } };
-      }
-      const existingModels = defaults?.models ?? {};
-      const nextModels = scopeKeySet ? { ...existingModels } : {};
-      if (scopeKeySet) {
-        for (const key of scopeKeySet) {
-          delete nextModels[key];
-        }
-      }
-      for (const key of normalized) {
-        nextModels[key] = existingModels[key] ?? {};
-      }
-      return {
-        ...cfg,
-        agents: {
-          ...cfg.agents,
-          defaults: {
-            ...defaults,
-            models: nextModels,
-            modelPolicy: { ...defaults?.modelPolicy, allow: Object.keys(nextModels) },
-          },
-        },
-      };
-    },
-  ),
-  applyModelFallbacksFromSelection: vi.fn(
-    (cfg: OpenClawConfig, selection: string[], opts: { scopeKeys?: string[] } = {}) => {
-      const defaults = cfg.agents?.defaults;
-      const existingModel = defaults?.model;
-      const primary =
-        typeof existingModel === "string"
-          ? existingModel
-          : existingModel && typeof existingModel === "object"
-            ? existingModel.primary
-            : undefined;
-      const normalized = normalizeTestModelKeys(selection);
-      const scopeKeys = opts.scopeKeys ? normalizeTestModelKeys(opts.scopeKeys) : [];
-      const scopeKeySet = scopeKeys.length > 0 ? new Set(scopeKeys) : null;
-      if (!primary || (normalized.length === 0 && !scopeKeySet)) {
-        return cfg;
-      }
-      const aliasIndex = new Map<string, string>();
-      for (const [key, value] of Object.entries(defaults?.models ?? {})) {
-        const alias = (value as { alias?: unknown }).alias;
-        if (typeof alias === "string" && alias.trim()) {
-          aliasIndex.set(alias.trim(), key);
-        }
-      }
-      const existingFallbacks =
-        existingModel && typeof existingModel === "object" && Array.isArray(existingModel.fallbacks)
-          ? normalizeTestModelKeys(
-              existingModel.fallbacks.map((fallback) => aliasIndex.get(fallback) ?? fallback),
-            )
-          : [];
-      const selectedFallbacks = normalized.filter((key) => key !== primary);
-      const selected = new Set(
-        scopeKeySet && !normalized.includes(primary)
-          ? selectedFallbacks.filter((key) => existingFallbacks.includes(key))
-          : selectedFallbacks,
-      );
-      const fallbacks: string[] = [];
-      for (const fallback of existingFallbacks) {
-        if (scopeKeySet && !scopeKeySet.has(fallback)) {
-          fallbacks.push(fallback);
-        } else if (selected.delete(fallback)) {
-          fallbacks.push(fallback);
-        }
-      }
-      for (const fallback of selectedFallbacks) {
-        if (selected.has(fallback)) {
-          fallbacks.push(fallback);
-        }
-      }
-      return {
-        ...cfg,
-        agents: {
-          ...cfg.agents,
-          defaults: {
-            ...defaults,
-            model: {
-              ...(existingModel && typeof existingModel === "object"
-                ? (({ fallbacks: _oldFallbacks, ...rest }) => rest)(existingModel)
-                : { primary }),
-              ...(fallbacks.length > 0 ? { fallbacks } : {}),
-            },
-          },
-        },
-      };
-    },
-  ),
   resolvePluginProvidersCore: vi.fn(() => []),
   resolveProviderPluginChoiceCore: vi.fn<() => unknown>(() => null),
   loadStaticManifestCatalogRowsForList: vi.fn<() => readonly NormalizedModelCatalogRow[]>(() => []),
@@ -155,20 +23,6 @@ const mocks = vi.hoisted(() => ({
     async () => undefined,
   ),
 }));
-
-function normalizeTestModelKeys(values: string[]): string[] {
-  const seen = new Set<string>();
-  const next: string[] = [];
-  for (const raw of values) {
-    const value = raw.trim();
-    if (!value || seen.has(value)) {
-      continue;
-    }
-    seen.add(value);
-    next.push(value);
-  }
-  return next;
-}
 
 vi.mock("../agents/auth-profiles.js", () => ({
   persistAuthProfileBatch: vi.fn(async () => {}),
@@ -187,13 +41,16 @@ vi.mock("./auth-choice.js", () => ({
   resolvePreferredProviderForAuthChoice: mocks.resolvePreferredProviderForAuthChoice,
 }));
 
-vi.mock("./model-picker.js", () => ({
-  applyModelAllowlist: mocks.applyModelAllowlist,
-  applyModelFallbacksFromSelection: mocks.applyModelFallbacksFromSelection,
-  applyPrimaryModel: mocks.applyPrimaryModel,
-  promptModelAllowlist: mocks.promptModelAllowlist,
-  promptDefaultModel: mocks.promptDefaultModel,
-}));
+vi.mock("./model-picker.js", async () => {
+  const { applyModelAllowlist, applyModelFallbacksFromSelection } =
+    await import("../flows/model-picker.js");
+  return {
+    applyModelAllowlist,
+    applyModelFallbacksFromSelection,
+    promptModelAllowlist: mocks.promptModelAllowlist,
+    promptDefaultModel: mocks.promptDefaultModel,
+  };
+});
 
 vi.mock("../plugins/providers.runtime.js", () => ({
   resolvePluginProvidersCore: mocks.resolvePluginProvidersCore,
@@ -210,7 +67,22 @@ vi.mock("./models/list.manifest-catalog.js", () => ({
 import { promptAuthConfig } from "./configure.gateway-auth.js";
 
 beforeEach(() => {
+  // These provider fixtures expose no CLI backends; policy checks need no plugin discovery.
+  cliBackendsTesting.setDepsForTest({
+    resolveRuntimeCliBackends: () => [],
+    resolvePluginSetupRegistry: () => ({
+      providers: [],
+      cliBackends: [],
+      configMigrations: [],
+      autoEnableProbes: [],
+      diagnostics: [],
+    }),
+  });
   mocks.loadStaticManifestCatalogRowsForList.mockReturnValue([]);
+});
+
+afterEach(() => {
+  cliBackendsTesting.resetDepsForTest();
 });
 
 function makeRuntime(): RuntimeEnv {
@@ -404,6 +276,7 @@ describe("promptAuthConfig", () => {
 
     expect(result.agents?.defaults?.models).toEqual({
       "openai/gpt-5.5": { alias: "GPT" },
+      "anthropic/claude-opus-4-6": { alias: "Opus" },
       "anthropic/claude-sonnet-4-6": {},
     });
     expect(result.agents?.defaults?.modelPolicy?.allow).toEqual([
@@ -460,6 +333,7 @@ describe("promptAuthConfig", () => {
     });
     expect(result.agents?.defaults?.models).toEqual({
       "openai/gpt-5.5": { alias: "GPT" },
+      "openai/gpt-5.4-mini": { alias: "mini" },
       "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
     });
   });
@@ -819,17 +693,73 @@ describe("promptAuthConfig", () => {
     });
   });
 
-  it.each(
-    [false, true].flatMap((sharedPrimary) =>
+  it.each<{
+    name: string;
+    defaultModel?: AgentModelConfig;
+    agentModel?: AgentModelConfig;
+    existingPrimary?: string;
+    explicit: boolean;
+    override: boolean;
+  }>([
+    ...[false, true].flatMap((sharedPrimary) =>
       [false, true].flatMap((agentPrimary) =>
         [false, true].flatMap((explicit) =>
-          [false, true].map((override) => ({ sharedPrimary, agentPrimary, explicit, override })),
+          [false, true].map((override) => ({
+            name: `shared=${sharedPrimary}, agent=${agentPrimary}`,
+            defaultModel: sharedPrimary
+              ? { primary: "openai/gpt-5.6-luna", fallbacks: ["shared/fallback"] }
+              : undefined,
+            agentModel: agentPrimary
+              ? { primary: "anthropic/sonnet-4.6", fallbacks: ["agent/fallback"] }
+              : undefined,
+            existingPrimary: agentPrimary
+              ? "anthropic/sonnet-4.6"
+              : sharedPrimary
+                ? "openai/gpt-5.6-luna"
+                : undefined,
+            explicit,
+            override,
+          })),
         ),
       ),
     ),
-  )(
-    "provider auth preserves primary (shared=$sharedPrimary, agent=$agentPrimary, explicit=$explicit, override=$override)",
-    async ({ sharedPrimary, agentPrimary, explicit, override }) => {
+    {
+      name: "inherited string primary",
+      defaultModel: "openai/gpt-5.6-luna",
+      existingPrimary: "openai/gpt-5.6-luna",
+      explicit: true,
+      override: true,
+    },
+    {
+      name: "agent string primary",
+      agentModel: "anthropic/sonnet-4.6",
+      existingPrimary: "anthropic/sonnet-4.6",
+      explicit: true,
+      override: true,
+    },
+    {
+      name: "agent-only fallbacks inherit shared primary",
+      defaultModel: { primary: "openai/gpt-5.6-luna" },
+      agentModel: { fallbacks: ["agent/fallback"] },
+      existingPrimary: "openai/gpt-5.6-luna",
+      explicit: true,
+      override: true,
+    },
+    {
+      name: "agent-only fallbacks initialize the legacy target",
+      agentModel: { fallbacks: ["agent/fallback"] },
+      explicit: false,
+      override: true,
+    },
+    {
+      name: "shared-only fallbacks initialize shared primary",
+      defaultModel: { fallbacks: ["shared/fallback"] },
+      explicit: false,
+      override: true,
+    },
+  ])(
+    "provider auth preserves primary through model policy ($name, explicit=$explicit, override=$override)",
+    async ({ defaultModel, agentModel, existingPrimary, explicit, override }) => {
       vi.clearAllMocks();
       const recommended = "configure-provider/recommended";
       const method: ProviderAuthMethod = {
@@ -866,14 +796,10 @@ describe("promptAuthConfig", () => {
       mocks.promptAuthChoiceGrouped.mockResolvedValue("provider-plugin:configure-provider:api-key");
       mocks.applyAuthChoice.mockImplementationOnce(applyProviderAuthChoice);
       mocks.resolveProviderPluginChoiceCore.mockReturnValue({ provider, method });
-      mocks.promptModelAllowlist.mockResolvedValue({ models: undefined });
-
-      const defaultModel = sharedPrimary
-        ? { primary: "openai/gpt-5.6-luna", fallbacks: ["shared/fallback"] }
-        : undefined;
-      const agentModel = agentPrimary
-        ? { primary: "anthropic/sonnet-4.6", fallbacks: ["agent/fallback"] }
-        : undefined;
+      mocks.promptModelAllowlist.mockResolvedValue({
+        models: [recommended],
+        scopeKeys: [recommended],
+      });
       const config: OpenClawConfig = {
         agents: {
           ...(explicit ? { ownership: "explicit" } : {}),
@@ -881,6 +807,7 @@ describe("promptAuthConfig", () => {
             systemAgent: { agentId: "ops" },
             model: defaultModel,
             models: { "shared/available": { alias: "Existing" } },
+            modelPolicy: { allow: ["shared/available"] },
           },
           entries: { main: {}, OPS: { model: agentModel } },
         },
@@ -891,17 +818,26 @@ describe("promptAuthConfig", () => {
         workspaceDir: "/tmp/ops-workspace",
       });
 
-      const existingPrimary = agentModel?.primary ?? defaultModel?.primary;
       const initializesPrimary = !existingPrimary && override;
+      const initializesAgent = initializesPrimary && (explicit || agentModel !== undefined);
+      const expectedAgentModel =
+        typeof agentModel === "string" ? { primary: agentModel } : agentModel;
       expect(resolveAgentEffectiveModelPrimary(result, "ops")).toBe(
         existingPrimary ?? (override ? recommended : undefined),
       );
       expect(result.agents?.entries?.OPS?.model).toEqual(
-        initializesPrimary && explicit ? { primary: recommended } : agentModel,
+        initializesAgent ? { ...expectedAgentModel, primary: recommended } : expectedAgentModel,
       );
       expect(result.agents?.defaults?.model).toEqual(
-        initializesPrimary && !explicit ? { primary: recommended } : defaultModel,
+        initializesPrimary && !initializesAgent
+          ? { ...(typeof defaultModel === "object" ? defaultModel : {}), primary: recommended }
+          : defaultModel,
       );
+      expect(result.agents?.entries?.OPS?.modelPolicy?.allow).toEqual([
+        "shared/available",
+        recommended,
+      ]);
+      expect(result.agents?.defaults?.modelPolicy).toEqual(config.agents?.defaults?.modelPolicy);
       expect(result.agents?.defaults?.models).toMatchObject({
         "shared/available": { alias: "Existing" },
         [recommended]: { alias: "Recommended" },

--- a/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
+++ b/src/commands/configure.gateway-auth.prompt-auth-config.test.ts
@@ -2,10 +2,13 @@ import { createServer } from "node:http";
 // Configure gateway auth prompt tests cover interactive auth selection and model-aware auth config.
 import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveAgentEffectiveModelPrimary } from "../agents/agent-scope.js";
 import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderAuthMethod, ProviderPlugin } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
+import { applyAuthChoice as applyProviderAuthChoice } from "./auth-choice.apply.js";
 
 const mocks = vi.hoisted(() => ({
   promptAuthChoiceGrouped: vi.fn(),
@@ -168,6 +171,7 @@ function normalizeTestModelKeys(values: string[]): string[] {
 }
 
 vi.mock("../agents/auth-profiles.js", () => ({
+  persistAuthProfileBatch: vi.fn(async () => {}),
   ensureAuthProfileStore: vi.fn(() => ({
     version: 1,
     profiles: {},
@@ -815,44 +819,99 @@ describe("promptAuthConfig", () => {
     });
   });
 
-  it("projects provider-auth model defaults onto the explicit target", async () => {
-    vi.clearAllMocks();
-    mocks.promptAuthChoiceGrouped.mockResolvedValue("provider-auth");
-    mocks.applyAuthChoice.mockResolvedValue({
-      config: {
+  it.each(
+    [false, true].flatMap((sharedPrimary) =>
+      [false, true].flatMap((agentPrimary) =>
+        [false, true].flatMap((explicit) =>
+          [false, true].map((override) => ({ sharedPrimary, agentPrimary, explicit, override })),
+        ),
+      ),
+    ),
+  )(
+    "provider auth preserves primary (shared=$sharedPrimary, agent=$agentPrimary, explicit=$explicit, override=$override)",
+    async ({ sharedPrimary, agentPrimary, explicit, override }) => {
+      vi.clearAllMocks();
+      const recommended = "configure-provider/recommended";
+      const method: ProviderAuthMethod = {
+        id: "api-key",
+        label: "Configure provider",
+        kind: "api_key",
+        run: async () => ({
+          profiles: [],
+          ...(override ? { defaultModel: recommended } : {}),
+          configPatch: {
+            agents: {
+              defaults: {
+                ...(override ? { model: { primary: recommended } } : {}),
+                models: { [recommended]: { alias: "Recommended" } },
+              },
+            },
+            models: {
+              providers: {
+                "configure-provider": {
+                  baseUrl: "https://configure-provider.example/v1",
+                  api: "openai-completions",
+                  models: [createTestModel("recommended")],
+                },
+              },
+            },
+          },
+        }),
+      };
+      const provider: ProviderPlugin = {
+        id: "configure-provider",
+        label: "Configure provider",
+        auth: [method],
+      };
+      mocks.promptAuthChoiceGrouped.mockResolvedValue("provider-plugin:configure-provider:api-key");
+      mocks.applyAuthChoice.mockImplementationOnce(applyProviderAuthChoice);
+      mocks.resolveProviderPluginChoiceCore.mockReturnValue({ provider, method });
+      mocks.promptModelAllowlist.mockResolvedValue({ models: undefined });
+
+      const defaultModel = sharedPrimary
+        ? { primary: "openai/gpt-5.6-luna", fallbacks: ["shared/fallback"] }
+        : undefined;
+      const agentModel = agentPrimary
+        ? { primary: "anthropic/sonnet-4.6", fallbacks: ["agent/fallback"] }
+        : undefined;
+      const config: OpenClawConfig = {
         agents: {
-          ownership: "explicit" as const,
-          defaults: { model: { primary: "provider/global" } },
-          entries: { main: {}, OPS: {} },
+          ...(explicit ? { ownership: "explicit" } : {}),
+          defaults: {
+            systemAgent: { agentId: "ops" },
+            model: defaultModel,
+            models: { "shared/available": { alias: "Existing" } },
+          },
+          entries: { main: {}, OPS: { model: agentModel } },
         },
-      },
-      agentModelOverride: "provider/selected",
-    });
-    mocks.promptModelAllowlist.mockResolvedValue({ models: undefined });
+      };
+      const result = await promptAuthConfig(config, makeRuntime(), noopPrompter, {
+        agentId: "ops",
+        agentDir: "/tmp/ops-agent",
+        workspaceDir: "/tmp/ops-workspace",
+      });
 
-    const config = {
-      agents: {
-        ownership: "explicit" as const,
-        defaults: {
-          systemAgent: { agentId: "ops" },
-          model: { primary: "provider/original" },
-        },
-        entries: { main: {}, OPS: {} },
-      },
-    };
-    const result = await promptAuthConfig(config, makeRuntime(), noopPrompter, {
-      agentId: "ops",
-      agentDir: "/tmp/ops-agent",
-      workspaceDir: "/tmp/ops-workspace",
-    });
-
-    expect(mocks.applyAuthChoice).toHaveBeenCalledWith(
-      expect.objectContaining({ setDefaultModel: false }),
-    );
-    expect(result.agents?.entries?.OPS?.model).toEqual({ primary: "provider/selected" });
-    expect(result.agents?.defaults?.model).toEqual({ primary: "provider/original" });
-    expect(result.agents?.entries?.ops).toBeUndefined();
-  });
+      const existingPrimary = agentModel?.primary ?? defaultModel?.primary;
+      const initializesPrimary = !existingPrimary && override;
+      expect(resolveAgentEffectiveModelPrimary(result, "ops")).toBe(
+        existingPrimary ?? (override ? recommended : undefined),
+      );
+      expect(result.agents?.entries?.OPS?.model).toEqual(
+        initializesPrimary && explicit ? { primary: recommended } : agentModel,
+      );
+      expect(result.agents?.defaults?.model).toEqual(
+        initializesPrimary && !explicit ? { primary: recommended } : defaultModel,
+      );
+      expect(result.agents?.defaults?.models).toMatchObject({
+        "shared/available": { alias: "Existing" },
+        [recommended]: { alias: "Recommended" },
+      });
+      expect(result.models?.providers?.[provider.id]?.models).toEqual([
+        createTestModel("recommended"),
+      ]);
+      expect(result.agents?.entries?.ops).toBeUndefined();
+    },
+  );
 
   it.each<{
     name: string;

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -283,17 +283,13 @@ export async function promptAuthConfig(
       preserveExistingDefaultModel: true,
     });
     next = applied.config;
-    if (applied.agentModelOverride) {
-      const targeted = applyOnboardingPrimaryModel(next, target, applied.agentModelOverride);
-      next = {
-        ...targeted,
-        agents: {
-          ...targeted.agents,
-          ...(beforeAuthConfig.agents?.defaults === undefined
-            ? { defaults: undefined }
-            : { defaults: beforeAuthConfig.agents.defaults }),
-        },
-      };
+    // Auth recommendations initialize an unset primary; reauth must not replace
+    // the target's explicit or inherited model.
+    if (
+      applied.agentModelOverride &&
+      !resolveAgentEffectiveModelPrimary(beforeAuthConfig, target.agentId)
+    ) {
+      next = applyOnboardingPrimaryModel(next, target, applied.agentModelOverride);
     }
     preferredProvider = resolveConfiguredProviderFromAuthChange({
       before: beforeAuthConfig,


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #131034, now with a full boundary proof: ordinary provider auth in `openclaw configure` could still replace or shadow the operator's primary model. A 16-cell state matrix ({shared primary} × {agent primary} × {target} × {provider override}) through the real `promptAuthConfig` → `applyAuthChoice` → target-projection flow found **five cells violating the docs contract** (`docs/cli/configure.md:42`): whenever a provider returned a model recommendation (`agentModelOverride`), configure applied it over an existing agent primary, or created an agent primary shadowing the shared one. One more cell lost legitimate first-primary bootstrap, and **all eight override cells destroyed returned shared model metadata** because configure restored the entire pre-auth defaults object as a rollback hack.

## Why This Change Was Made

The rollback hack is deleted — the auth producer already restores the original shared model (`provider-auth-choice.ts:601`) — and override consumption is gated on the pre-auth effective primary: recommendations initialize an unset primary, reauth never replaces the target's explicit or inherited model. Same shape as #131034's custom branch. Provider inventory confirmed recommendations are setup conveniences, not override instructions (Google, OpenAI OAuth/device-code, Copilot starter model), and `agents add`'s deferred-override purpose is untouched. Net **−4** production lines.

Deep-context review (second independent pass) confirmed production and replaced copied test transforms with the real model-picker policy implementations (follow-up commit, net −64 test lines).

## User Impact

Reauthenticating or adding any provider through configure keeps the operator's primary model exactly, keeps returned model metadata (previously silently discarded), and still bootstraps a first primary on fresh setups.

## Evidence

- Failing-first 16-cell matrix through the real flow: 5 primary violations + 1 lost bootstrap + 8 metadata losses at base; all 16 conform post-fix. Re-run green on rebased head b9ac3c2b4ba (45 tests).
- Suites: auth-choice apply/plugin-provider, provider-auth helpers/choices, onboard-agent-target — all pass; `check-changed` full run exit 0; Codex autoreview clean on both the fix and the review follow-up.
- Named follow-up (pre-existing, not this PR): `setDefaultModel:false` skips required-runtime provisioning hooks for deferred selections — needs an isolated fresh-install probe before touching that lifecycle owner.
