### PR TITLE
fix(gateway): pin runtime generation at admission

### DIFF
--- a/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
+++ b/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
@@ -32,7 +32,10 @@ import type { GetReplyOptions, ReplyPayload } from "../../auto-reply/types.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import type { FailoverReason } from "../failover/signal.js";
 import { registerAgentHarness } from "../harness/registry.js";
-import { withPreparedModelRuntimePluginGenerationScope } from "../prepared-model-runtime-generation-scope.js";
+import {
+  getPreparedModelRuntimeBorrowedSnapshot,
+  withPreparedModelRuntimePluginGenerationScope,
+} from "../prepared-model-runtime-generation-scope.js";
 import type { PreparedModelRuntimePluginGeneration } from "../prepared-model-runtime.types.js";
 import { makeAttemptResult } from "./run.overflow-compaction.fixture.js";
 import {
@@ -534,7 +537,7 @@ describe("prepared harness source delivery", () => {
     );
   });
 
-  it("completes an admitted turn on its generation after a plugin-runtime replacement", async () => {
+  it("completes an admitted turn on A after plugin-runtime generation B publishes", async () => {
     const { runEmbeddedAgent } = await loadRunOverflowCompactionHarness();
     const config = {};
     const workspaceDir = "/tmp/workspace";
@@ -560,28 +563,37 @@ describe("prepared harness source delivery", () => {
       policyHash: "replacement",
       workspaceDir,
     };
+    const admittedSnapshot = {
+      ...baseLease.snapshot,
+      config,
+      workspaceDir,
+      pluginRegistry,
+      metadataSnapshot: admittedMetadataSnapshot,
+    } as NonNullable<ReturnType<typeof getPreparedModelRuntimeBorrowedSnapshot>>;
+    let publishedMetadataSnapshot = admittedMetadataSnapshot;
     const release = vi.fn();
     let servedMetadataSnapshot: unknown;
+    let publishedMetadataAtAcquire: unknown;
     mockedAcquireAgentRunPreparedModelRuntime.mockClear();
     mockedAcquireAgentRunPreparedModelRuntime.mockImplementationOnce(
       async (
         _input,
         options?: {
-          pluginGeneration?: { pluginMetadataSnapshot: typeof admittedMetadataSnapshot };
+          pluginGeneration?: PreparedModelRuntimePluginGeneration;
         },
       ) => {
-        const metadataSnapshot =
-          options?.pluginGeneration?.pluginMetadataSnapshot ?? replacementMetadataSnapshot;
-        servedMetadataSnapshot = metadataSnapshot;
+        const generation = options?.pluginGeneration;
+        const borrowed = generation
+          ? getPreparedModelRuntimeBorrowedSnapshot(generation)
+          : undefined;
+        if (!borrowed) {
+          throw new Error("prepared model runtime plugin generation was superseded");
+        }
+        publishedMetadataAtAcquire = publishedMetadataSnapshot;
+        servedMetadataSnapshot = borrowed.metadataSnapshot;
         return {
           ...baseLease,
-          snapshot: {
-            ...baseLease.snapshot,
-            config,
-            workspaceDir,
-            pluginRegistry,
-            metadataSnapshot,
-          },
+          snapshot: borrowed as typeof baseLease.snapshot,
           release,
         };
       },
@@ -589,6 +601,7 @@ describe("prepared harness source delivery", () => {
     mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "ok" }]);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ assistantTexts: ["ok"] }));
     useOpenAIPlatformAuthFixture();
+    publishedMetadataSnapshot = replacementMetadataSnapshot;
 
     const result = await withPreparedModelRuntimePluginGenerationScope(
       admittedGeneration,
@@ -601,12 +614,14 @@ describe("prepared harness source delivery", () => {
           runId: "admitted-generation-replacement",
           sessionKey: undefined,
         }),
+      () => admittedSnapshot,
     );
 
     expect(mockedAcquireAgentRunPreparedModelRuntime).toHaveBeenCalledWith(
       expect.objectContaining({ config, workspaceDir }),
       expect.objectContaining({ pluginGeneration: admittedGeneration }),
     );
+    expect(publishedMetadataAtAcquire).toBe(replacementMetadataSnapshot);
     expect(servedMetadataSnapshot).toBe(admittedGeneration.pluginMetadataSnapshot);
     expect(result.payloads).toEqual([{ text: "ok" }]);
     expect(release).toHaveBeenCalledOnce();

--- a/src/gateway/agent-turn/agent-run-admission-phase.ts
+++ b/src/gateway/agent-turn/agent-run-admission-phase.ts
@@ -14,7 +14,14 @@ import {
   type MainSessionRecoveryPendingTarget,
 } from "../../agents/main-session-recovery/main-session-recovery-store.js";
 import { resolvePersistedOverrideModelRef } from "../../agents/model-selection.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  loadPublishedGatewayReplyDispatchRuntime,
+  type PreparedModelRuntimeLease,
+  type PreparedReplyDispatchRuntime,
+} from "../../agents/prepared-model-runtime.js";
 import { resolveProviderIdForAuth } from "../../agents/provider-auth-aliases.js";
+import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawned-context.js";
 import {
   resolveExactSubagentCompletionEvent,
   type TrustedSubagentCompletionHandoff,
@@ -46,6 +53,7 @@ import { formatForLog } from "../ws-log.js";
 import {
   isPreRegistrationAbortedAgentDedupeEntryForSession,
   readGatewayDedupeEntry,
+  setAbortedAgentDedupeEntries,
   setGatewayDedupeEntries,
 } from "./agent-dedupe.js";
 import type { AgentDeliveryPhaseResult } from "./agent-delivery-phase.js";
@@ -71,8 +79,11 @@ export type PreparedAgentRunDispatch = {
   lifecycleStorePath: string;
   resolvedThreadId?: string | number;
   dispatchTaskTrackingMode: Exclude<GatewayAgentTaskTrackingMode, "plugin_subagent">;
+  preparedModelRuntimeLease: PreparedModelRuntimeLease;
+  replyDispatchRuntime: PreparedReplyDispatchRuntime;
   unpersistedOffloadedRefs: OffloadedRef[];
   userTurn: PreparedAgentRunUserTurn;
+  workspaceOverride?: string;
   restoreAdmittedRestartRecoveryInterrupted?: () => Promise<
     MainSessionRecoveryPendingTarget | undefined
   >;
@@ -320,6 +331,84 @@ export async function prepareAgentRunDispatch(params: {
     }
   }
 
+  const workspaceOverride = resolveIngressWorkspaceOverrideForSessionRun({
+    spawnedBy: params.sessionEntry?.spawnedBy,
+    workspaceDir: params.sessionEntry?.spawnedWorkspaceDir,
+    cwd: params.sessionEntry?.spawnedCwd,
+  });
+  let preparedModelRuntimeLease: PreparedModelRuntimeLease | undefined;
+  const cleanupPreaccept = (admissionReleased = false) => {
+    preparedModelRuntimeLease?.release();
+    preparedModelRuntimeLease = undefined;
+    activeRunAbort.cleanup({ force: true });
+    if (!admissionReleased) {
+      activeGatewayWorkAdmission.release();
+    }
+  };
+  const rejectPreaccept = (error: ReturnType<typeof errorShape>) => {
+    cleanupPreaccept();
+    params.io.emitAcceptance([false, undefined, error]);
+    return undefined;
+  };
+  const revalidateAdmission = () => {
+    if (activeRunAbort.controller.signal.aborted) {
+      setAbortedAgentDedupeEntries({
+        dedupe: params.context.dedupe,
+        keys: params.agentDedupeKeys,
+        agentId: params.admissionAgentId(),
+        runId: params.runId,
+        stopReason: activeRunAbort.entry?.abortStopReason ?? "rpc",
+      });
+    }
+    try {
+      params.assertGatewayWorkAdmissionAllowed();
+    } catch (err) {
+      rejectPreaccept(errorShapeFromError(ErrorCodes.INVALID_REQUEST, err));
+      return false;
+    }
+    if (!params.respondToGatewayAdmissionOutcome()) {
+      return true;
+    }
+    cleanupPreaccept(true);
+    return false;
+  };
+  let replyDispatchRuntime: PreparedReplyDispatchRuntime;
+  try {
+    const publishedRuntime = await loadPublishedGatewayReplyDispatchRuntime({
+      agentId: params.activeSessionAgentId,
+      abortSignal: activeRunAbort.controller.signal,
+    });
+    if (!revalidateAdmission()) {
+      return undefined;
+    }
+    if (!publishedRuntime) {
+      throw new Error(`published reply runtime missing for ${params.activeSessionAgentId}`);
+    }
+    replyDispatchRuntime = publishedRuntime;
+    preparedModelRuntimeLease = await acquireAgentRunPreparedModelRuntime(
+      {
+        config: replyDispatchRuntime.config,
+        agentId: replyDispatchRuntime.agentId,
+        agentDir: replyDispatchRuntime.agentDir,
+        allowGatewaySubagentBinding: true,
+        workspaceDir: workspaceOverride ?? replyDispatchRuntime.workspaceDir,
+      },
+      {
+        catalogMode: "static",
+        pluginGeneration: replyDispatchRuntime.pluginGeneration,
+        abortSignal: activeRunAbort.controller.signal,
+      },
+    );
+    if (!revalidateAdmission()) {
+      return undefined;
+    }
+  } catch (err) {
+    if (!revalidateAdmission()) {
+      return undefined;
+    }
+    return rejectPreaccept(errorShapeFromError(ErrorCodes.UNAVAILABLE, err));
+  }
+
   const resolvedThreadId =
     params.delivery.explicitThreadId ?? params.delivery.deliveryPlan.resolvedThreadId;
   const completionEvent = resolveExactSubagentCompletionEvent({
@@ -367,23 +456,21 @@ export async function prepareAgentRunDispatch(params: {
         pluginId: normalizeOptionalString(params.client?.internal?.pluginRuntimeOwnerId),
         gatewayContextResolver: params.context.resolveGatewayContext,
       });
+      if (!revalidateAdmission()) {
+        return undefined;
+      }
     } catch (err) {
       params.context.logGateway.warn(
         `failed to register plugin subagent run ${params.runId}; rejecting untracked dispatch: ${formatForLog(err)}`,
       );
-      activeRunAbort.cleanup({ force: true });
-      activeGatewayWorkAdmission.release();
-      params.io.emitAcceptance([
-        false,
-        undefined,
+      return rejectPreaccept(
         errorShapeFromError(
           ErrorCodes.UNAVAILABLE,
           new Error("plugin subagent registry persistence failed; run was not started", {
             cause: err,
           }),
         ),
-      ]);
-      return undefined;
+      );
     }
   }
   let restoreAdmittedRestartRecoveryInterrupted:
@@ -392,14 +479,9 @@ export async function prepareAgentRunDispatch(params: {
   if (params.isRestartRecoveryResumeRun) {
     const recoverySessionKey = params.resolvedSessionKey;
     if (!recoverySessionKey) {
-      activeRunAbort.cleanup({ force: true });
-      activeGatewayWorkAdmission.release();
-      params.io.emitAcceptance([
-        false,
-        undefined,
+      return rejectPreaccept(
         errorShape(ErrorCodes.UNAVAILABLE, "restart recovery session target is unavailable"),
-      ]);
-      return undefined;
+      );
     }
     try {
       const recoveryAdmission = await commitMainSessionRecovery({
@@ -413,6 +495,9 @@ export async function prepareAgentRunDispatch(params: {
         requireWriteSuccess: true,
         target: { sessionKey: recoverySessionKey, storePath: lifecycleStorePath },
       });
+      if (!revalidateAdmission()) {
+        return undefined;
+      }
       if (recoveryAdmission.transition.kind !== "admitted_recovery") {
         throw new Error(
           `Session "${recoverySessionKey}" restart recovery reservation is stale; recovery was skipped.`,
@@ -449,14 +534,7 @@ export async function prepareAgentRunDispatch(params: {
           : undefined;
       };
     } catch (err) {
-      activeRunAbort.cleanup({ force: true });
-      activeGatewayWorkAdmission.release();
-      params.io.emitAcceptance([
-        false,
-        undefined,
-        errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)),
-      ]);
-      return undefined;
+      return rejectPreaccept(errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
     }
   }
   let userTurn: PreparedAgentRunUserTurn;
@@ -491,29 +569,10 @@ export async function prepareAgentRunDispatch(params: {
       params.onUserTurnMediaPersisted();
     }
   } catch (err) {
-    activeRunAbort.cleanup({ force: true });
-    activeGatewayWorkAdmission.release();
-    params.io.emitAcceptance([false, undefined, errorShapeFromError(ErrorCodes.UNAVAILABLE, err)]);
-    return undefined;
+    return rejectPreaccept(errorShapeFromError(ErrorCodes.UNAVAILABLE, err));
   }
-  try {
-    // Transcript persistence can yield. Revalidate the exact live admission
-    // before its durable turn is allowed to cross the acceptance boundary.
-    params.assertGatewayWorkAdmissionAllowed();
-  } catch (err) {
+  if (!revalidateAdmission()) {
     releasePreparedAgentRunUserTurn(userTurn);
-    activeRunAbort.cleanup({ force: true });
-    activeGatewayWorkAdmission.release();
-    params.io.emitAcceptance([
-      false,
-      undefined,
-      errorShapeFromError(ErrorCodes.INVALID_REQUEST, err),
-    ]);
-    return undefined;
-  }
-  if (params.respondToGatewayAdmissionOutcome()) {
-    releasePreparedAgentRunUserTurn(userTurn);
-    activeRunAbort.cleanup({ force: true });
     return undefined;
   }
   const accepted = {
@@ -566,8 +625,11 @@ export async function prepareAgentRunDispatch(params: {
     lifecycleStorePath,
     resolvedThreadId,
     dispatchTaskTrackingMode,
+    preparedModelRuntimeLease,
+    replyDispatchRuntime,
     unpersistedOffloadedRefs: userTurn.recorder ? [] : params.offloadedRefs,
     userTurn,
+    workspaceOverride,
     restoreAdmittedRestartRecoveryInterrupted,
   };
 }

--- a/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts
@@ -1,47 +1,55 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getPreparedModelRuntimeBorrowedSnapshot,
+  getPreparedModelRuntimePluginGeneration,
+} from "../../agents/prepared-model-runtime-generation-scope.js";
 import { startAgentRunExecution } from "./agent-run-execution-phase.js";
 
 const dispatchAgentRunFromGateway = vi.hoisted(() => vi.fn());
-
-vi.mock("../../agents/prepared-model-runtime.js", () => ({
-  loadPublishedGatewayReplyDispatchRuntime: async () => ({
-    config: {},
-    pluginGeneration: "test",
-  }),
-}));
 
 vi.mock("./agent-run-dispatch.js", () => ({
   dispatchAgentRunFromGateway,
   resolveAbortedAgentStopReason: () => "rpc",
 }));
 
-describe("startAgentRunExecution Gateway ownership", () => {
-  it("rejects a retired owner after preparation and before final dispatch", async () => {
-    const cleanup = vi.fn();
-    const release = vi.fn();
-    let resolveFinal!: () => void;
-    const final = new Promise<void>((resolve) => {
-      resolveFinal = resolve;
-    });
-
-    startAgentRunExecution({
-      assertContextCurrent: () => {
-        throw new Error("Gateway owner retired");
-      },
+function createExecution(options: { aborted?: boolean; assertContextCurrent?: () => void } = {}) {
+  const abortCleanup = vi.fn();
+  const gatewayRelease = vi.fn();
+  let resolveRuntimeReleased!: () => void;
+  const runtimeReleased = new Promise<void>((resolve) => {
+    resolveRuntimeReleased = resolve;
+  });
+  const runtimeRelease = vi.fn(resolveRuntimeReleased);
+  const controller = new AbortController();
+  if (options.aborted) {
+    controller.abort();
+  }
+  return {
+    abortCleanup,
+    gatewayRelease,
+    runtimeRelease,
+    runtimeReleased,
+    params: {
+      assertContextCurrent: options.assertContextCurrent,
       prepared: {
         activeGatewayWorkAdmission: {
-          release,
+          release: gatewayRelease,
           run: async (run: () => Promise<void>) => await run(),
         },
         activeRunAbort: {
-          cleanup,
-          controller: new AbortController(),
+          cleanup: abortCleanup,
+          controller,
           registered: false,
         },
         dispatchTaskTrackingMode: "none",
         effectiveAllowModelOverride: false,
         lifecycleStorePath: "",
         operationalRunInstance: {},
+        preparedModelRuntimeLease: { release: runtimeRelease, snapshot: {} },
+        replyDispatchRuntime: {
+          config: { runtime: "A" },
+          pluginGeneration: "generation-A",
+        },
         unpersistedOffloadedRefs: [],
         userTurn: {
           execApprovalFollowupHandoffClaimId: "claim",
@@ -49,6 +57,7 @@ describe("startAgentRunExecution Gateway ownership", () => {
           senderIsOwner: false,
           suppressPromptPersistence: false,
         },
+        workspaceOverride: "/workspace/A",
       },
       request: {},
       cfg: {},
@@ -62,7 +71,7 @@ describe("startAgentRunExecution Gateway ownership", () => {
       images: [],
       imageOrder: [],
       media: [],
-      runId: "owner-retired",
+      runId: "owner-test",
       agentDedupeKeys: [],
       bestEffortDeliver: false,
       lifecycleGeneration: "test",
@@ -77,14 +86,87 @@ describe("startAgentRunExecution Gateway ownership", () => {
       },
       io: {
         emitAcceptance: vi.fn(),
-        emitFinal: () => resolveFinal(),
+        emitFinal: vi.fn(),
       },
       releaseCronContinuationClaimWithRecovery: async () => true,
-    } as never);
+    } as unknown as Parameters<typeof startAgentRunExecution>[0],
+  };
+}
 
-    await final;
-    await vi.waitFor(() => expect(cleanup).toHaveBeenCalledOnce());
+describe("startAgentRunExecution Gateway ownership", () => {
+  beforeEach(() => dispatchAgentRunFromGateway.mockReset());
+
+  it("dispatches with the runtime generation frozen at admission", async () => {
+    const execution = createExecution();
+    let resolveDispatched!: () => void;
+    const dispatched = new Promise<void>((resolve) => {
+      resolveDispatched = resolve;
+    });
+    let resolveCleanupObserved!: () => void;
+    const cleanupObserved = new Promise<void>((resolve) => {
+      resolveCleanupObserved = resolve;
+    });
+    let borrowedAfterCleanup: Promise<unknown> | undefined;
+    let dispatchedGeneration: unknown;
+    let dispatchedSnapshot: unknown;
+    dispatchAgentRunFromGateway.mockImplementationOnce(() => {
+      const generation = execution.params.prepared.replyDispatchRuntime.pluginGeneration;
+      dispatchedGeneration = getPreparedModelRuntimePluginGeneration();
+      dispatchedSnapshot = getPreparedModelRuntimeBorrowedSnapshot(generation);
+      borrowedAfterCleanup = (async () => {
+        await cleanupObserved;
+        return getPreparedModelRuntimeBorrowedSnapshot(generation);
+      })();
+      resolveDispatched();
+    });
+
+    startAgentRunExecution(execution.params);
+
+    await dispatched;
+    expect(dispatchedGeneration).toBe(
+      execution.params.prepared.replyDispatchRuntime.pluginGeneration,
+    );
+    expect(dispatchedSnapshot).toBe(execution.params.prepared.preparedModelRuntimeLease.snapshot);
+    const dispatch = dispatchAgentRunFromGateway.mock.calls[0]?.[0];
+    expect(dispatch?.commandRuntimeContext).toEqual({
+      config: { runtime: "A" },
+      pluginGeneration: "generation-A",
+    });
+    expect(dispatch?.ingressOpts.workspaceDir).toBe("/workspace/A");
+    expect(execution.runtimeRelease).not.toHaveBeenCalled();
+
+    dispatch?.cleanupAbortController();
+    dispatch?.cleanupAbortController();
+    resolveCleanupObserved();
+    await expect(borrowedAfterCleanup).resolves.toBeUndefined();
+    expect(execution.runtimeRelease).toHaveBeenCalledOnce();
+  });
+
+  it("releases the admitted runtime once when aborted before dispatch", async () => {
+    const execution = createExecution({ aborted: true });
+
+    startAgentRunExecution(execution.params);
+
+    await execution.runtimeReleased;
     expect(dispatchAgentRunFromGateway).not.toHaveBeenCalled();
-    expect(release).toHaveBeenCalledOnce();
+    expect(execution.abortCleanup).toHaveBeenCalledOnce();
+    expect(execution.gatewayRelease).toHaveBeenCalledOnce();
+    expect(execution.runtimeRelease).toHaveBeenCalledOnce();
+  });
+
+  it("releases the admitted runtime once when its owner retires before dispatch", async () => {
+    const execution = createExecution({
+      assertContextCurrent: () => {
+        throw new Error("Gateway owner retired");
+      },
+    });
+
+    startAgentRunExecution(execution.params);
+
+    await execution.runtimeReleased;
+    expect(dispatchAgentRunFromGateway).not.toHaveBeenCalled();
+    expect(execution.abortCleanup).toHaveBeenCalledOnce();
+    expect(execution.gatewayRelease).toHaveBeenCalledOnce();
+    expect(execution.runtimeRelease).toHaveBeenCalledOnce();
   });
 });

--- a/src/gateway/agent-turn/agent-run-execution-phase.ts
+++ b/src/gateway/agent-turn/agent-run-execution-phase.ts
@@ -13,9 +13,8 @@ import {
   type MainSessionRecoveryPendingTarget,
   type MainSessionRecoveryOwnerLease,
 } from "../../agents/main-session-recovery/main-session-recovery-store.js";
-import { loadPublishedGatewayReplyDispatchRuntime } from "../../agents/prepared-model-runtime.js";
+import { withPreparedModelRuntimePluginGenerationScope } from "../../agents/prepared-model-runtime-generation-scope.js";
 import { resolveScheduledToolPolicyContext } from "../../agents/scheduled-tool-policy.js";
-import { resolveIngressWorkspaceOverrideForSessionRun } from "../../agents/spawned-context.js";
 import { isExecutionIdentityCollectionEnabled } from "../../audit/audit-config.js";
 import {
   setChannelSourceTurnId,
@@ -112,16 +111,27 @@ export function startAgentRunExecution(params: {
 }): void {
   const { prepared } = params;
   let unpersistedOffloadedRefs = prepared.unpersistedOffloadedRefs;
+  let preparedModelRuntimeLease: typeof prepared.preparedModelRuntimeLease | undefined =
+    prepared.preparedModelRuntimeLease;
   let releaseGatewayRootContinuation = retainGatewayRootWorkAdmissionContinuation() ?? undefined;
   const cleanupAdmittedRun: typeof prepared.activeRunAbort.cleanup = (options) => {
     const refsToDiscard = unpersistedOffloadedRefs;
     unpersistedOffloadedRefs = [];
     prepared.activeRunAbort.cleanup(options);
     prepared.activeGatewayWorkAdmission.release();
+    const runtimeLease = preparedModelRuntimeLease;
+    preparedModelRuntimeLease = undefined;
+    runtimeLease?.release();
     releaseGatewayRootContinuation?.();
     releaseGatewayRootContinuation = undefined;
     void discardPreparedInboundMedia(refsToDiscard, params.context.logGateway);
   };
+  const dispatchAdmittedAgentRun = (dispatch: Parameters<typeof dispatchAgentRunFromGateway>[0]) =>
+    withPreparedModelRuntimePluginGenerationScope(
+      prepared.replyDispatchRuntime.pluginGeneration,
+      () => dispatchAgentRunFromGateway(dispatch),
+      () => preparedModelRuntimeLease?.snapshot,
+    );
   void prepared.activeGatewayWorkAdmission.run(async () => {
     await yieldAfterAgentAcceptedAck();
     let dispatched = false;
@@ -212,15 +222,6 @@ export function startAgentRunExecution(params: {
       const ingressAgentId = params.resolvedSessionKey
         ? params.activeSessionAgentId
         : params.agentId;
-      const replyDispatchRuntime = await loadPublishedGatewayReplyDispatchRuntime({
-        agentId: params.activeSessionAgentId,
-        abortSignal: prepared.activeRunAbort.controller.signal,
-      });
-      if (!replyDispatchRuntime?.pluginGeneration) {
-        throw new Error(
-          `prepared reply dispatch runtime was not published for ${params.activeSessionAgentId}`,
-        );
-      }
       // Plugin-owned additive grants stay internal to the authenticated in-process run.
       // Public agent params cannot supply them, and normal tool policy still filters them.
       const runtimePluginToolGrant =
@@ -280,16 +281,15 @@ export function startAgentRunExecution(params: {
       } else if (localUserIngress) {
         attachAgentCommandAdmissionFacts(runContext, localUserIngress.facts);
       }
-      // Routing and runtime publication await after admission. Retired owners
-      // must fail before the prepared user turn becomes an agent run.
+      // Awaited routing can retire this owner before final dispatch.
       params.assertContextCurrent?.();
       finalizePreparedAgentRunUserTurn(prepared.userTurn);
-      dispatchAgentRunFromGateway(
+      dispatchAdmittedAgentRun(
         withAgentRunDispatchExecutionIdentity(
           {
             commandRuntimeContext: {
-              config: replyDispatchRuntime.config,
-              pluginGeneration: replyDispatchRuntime.pluginGeneration,
+              config: prepared.replyDispatchRuntime.config,
+              pluginGeneration: prepared.replyDispatchRuntime.pluginGeneration,
             },
             cronCreatorAuthority: prepared.cronCreatorAuthority,
             ingressOpts: {
@@ -425,11 +425,7 @@ export function startAgentRunExecution(params: {
                   prepared.activeRunAbort.entry.sessionId = sessionId;
                 }
               },
-              workspaceDir: resolveIngressWorkspaceOverrideForSessionRun({
-                spawnedBy: params.spawnedBy,
-                workspaceDir: params.sessionEntry?.spawnedWorkspaceDir,
-                cwd: params.sessionEntry?.spawnedCwd,
-              }),
+              workspaceDir: prepared.workspaceOverride,
               cwd: resolveSessionRuntimeCwd({
                 requestedCwd: params.request.cwd,
                 sessionEntry: params.sessionEntry,

--- a/src/gateway/server-methods/agent.create-event.test.ts
+++ b/src/gateway/server-methods/agent.create-event.test.ts
@@ -41,6 +41,20 @@ vi.mock("../../commands/agent.js", () => ({
   agentCommandFromIngress: agentIngressMocks.agentCommandFromIngress,
 }));
 
+vi.mock("../../agents/prepared-model-runtime.js", () => ({
+  acquireAgentRunPreparedModelRuntime: vi.fn(async () => ({
+    release: vi.fn(),
+    snapshot: {},
+  })),
+  loadPublishedGatewayReplyDispatchRuntime: vi.fn(async ({ agentId }: { agentId: string }) => ({
+    agentId,
+    agentDir: configMocks.workspaceDir,
+    config: configMocks.getRuntimeConfig(),
+    pluginGeneration: { pluginMetadataSnapshot: {} },
+    workspaceDir: configMocks.workspaceDir,
+  })),
+}));
+
 vi.mock("../../runtime.js", () => ({
   defaultRuntime: {},
 }));

--- a/src/gateway/server-methods/agent.test-harness.ts
+++ b/src/gateway/server-methods/agent.test-harness.ts
@@ -193,10 +193,16 @@ vi.mock("../../commands/agent.js", () => {
 vi.mock("../../agents/prepared-model-runtime.js", () => ({
   // Direct handler tests bypass Gateway startup, so provide the lifecycle fact
   // that production publishes before admitting agent RPCs.
+  acquireAgentRunPreparedModelRuntime: vi.fn(async () => ({
+    release: vi.fn(),
+    snapshot: {},
+  })),
   loadPublishedGatewayReplyDispatchRuntime: async ({ agentId }: { agentId: string }) => ({
     agentId,
+    agentDir: "/tmp/agent",
     config: resolveAgentTestConfig(),
     pluginGeneration: { pluginMetadataSnapshot: {} },
+    workspaceDir: "/tmp/workspace",
   }),
 }));
 

--- a/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
+++ b/src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts
@@ -70,6 +70,31 @@ function sendAgentRpc(socket: WebSocket, params: { agentId: string; runId: strin
   return { accepted, final };
 }
 
+function sendPreacceptAgentRpc(socket: WebSocket, params: { agentId: string; runId: string }) {
+  const response = onceMessage<AgentRpcFrame>(
+    socket,
+    (frame) => frame.type === "res" && frame.id === params.runId,
+  );
+  const final = onceMessage<AgentRpcFrame>(
+    socket,
+    (frame) =>
+      frame.type === "res" && frame.id === params.runId && frame.payload?.status !== "accepted",
+  );
+  socket.send(
+    JSON.stringify({
+      type: "req",
+      id: params.runId,
+      method: "agent",
+      params: {
+        agentId: params.agentId,
+        message: `dispatch ${params.runId}`,
+        idempotencyKey: params.runId,
+      },
+    }),
+  );
+  return { response, final };
+}
+
 function agentCommandCallsFor(runId: string) {
   return vi
     .mocked(agentCommandMock)
@@ -101,6 +126,71 @@ describe("gateway agent auth refresh dispatch", () => {
 
   afterEach(() => {
     testState.agentsConfig = undefined;
+  });
+
+  test("keeps an accepted run on its admitted runtime generation", async () => {
+    const affectedAgentId = "auth-pinned";
+    const admittedRunId = "idem-agent-auth-admitted";
+    const subsequentRunId = "idem-agent-auth-next";
+    const before = await prepareAuthDispatchAgents(affectedAgentId);
+    const published = createDeferred();
+    const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+      if (event.phase === "published") {
+        published.resolve();
+      }
+    });
+    try {
+      const admitted = sendAgentRpc(gatewaySuite.ws, {
+        agentId: affectedAgentId,
+        runId: admittedRunId,
+      });
+      await admitted.accepted;
+      expect(agentCommandCallsFor(admittedRunId)).toHaveLength(0);
+
+      setRuntimeAuthProfileStoreSnapshot(
+        {
+          version: 1,
+          profiles: {
+            "anthropic:default": {
+              type: "api_key",
+              provider: "anthropic",
+              key: "next-generation-key",
+            },
+          },
+        },
+        before.agentDir,
+      );
+      await published.promise;
+      const after = await loadPublishedGatewayReplyDispatchRuntime({
+        agentId: affectedAgentId,
+      });
+      expect(after).not.toBe(before.runtime);
+
+      await expect(admitted.final).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "ok" },
+      });
+      expect(agentCommandCallsFor(admittedRunId)[0]?.[4]).toMatchObject({
+        config: before.runtime?.config,
+        pluginGeneration: before.runtime?.pluginGeneration,
+      });
+
+      const subsequent = sendAgentRpc(gatewaySuite.ws, {
+        agentId: affectedAgentId,
+        runId: subsequentRunId,
+      });
+      await subsequent.accepted;
+      await expect(subsequent.final).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "ok" },
+      });
+      expect(agentCommandCallsFor(subsequentRunId)[0]?.[4]).toMatchObject({
+        config: after?.config,
+        pluginGeneration: after?.pluginGeneration,
+      });
+    } finally {
+      unregister();
+    }
   });
 
   test("aborts one affected waiter without cancelling shared auth publication", async () => {
@@ -142,15 +232,14 @@ describe("gateway agent auth refresh dispatch", () => {
         before.agentDir,
       );
 
-      const aborted = sendAgentRpc(gatewaySuite.ws, {
+      const aborted = sendPreacceptAgentRpc(gatewaySuite.ws, {
         agentId: affectedAgentId,
         runId: abortedRunId,
       });
-      const waiting = sendAgentRpc(gatewaySuite.ws, {
+      const waiting = sendPreacceptAgentRpc(gatewaySuite.ws, {
         agentId: affectedAgentId,
         runId: waitingRunId,
       });
-      await Promise.all([aborted.accepted, waiting.accepted]);
       const sibling = sendAgentRpc(gatewaySuite.ws, { agentId: "main", runId: siblingRunId });
       await sibling.accepted;
       await expect(sibling.final).resolves.toMatchObject({ ok: true, payload: { status: "ok" } });
@@ -168,7 +257,7 @@ describe("gateway agent auth refresh dispatch", () => {
         payload: { aborted: true, runIds: [abortedRunId] },
       });
       await vi.waitFor(() => expect(getActiveGatewayRootWorkCount()).toBe(activeWorkBefore + 1));
-      await expect(aborted.final).resolves.toMatchObject({
+      await expect(aborted.response).resolves.toMatchObject({
         ok: true,
         payload: {
           status: "timeout",
@@ -178,13 +267,17 @@ describe("gateway agent auth refresh dispatch", () => {
         },
       });
       await expect(
-        Promise.race([waiting.final.then(() => "settled"), Promise.resolve("pending")]),
+        Promise.race([waiting.response.then(() => "settled"), Promise.resolve("pending")]),
       ).resolves.toBe("pending");
 
       publicationGate.resolve({ agentDir: before.agentDir, wrote: false });
       await published.promise;
       const after = await loadPublishedGatewayReplyDispatchRuntime({ agentId: affectedAgentId });
       expect(after).not.toBe(before.runtime);
+      await expect(waiting.response).resolves.toMatchObject({
+        ok: true,
+        payload: { status: "accepted" },
+      });
       await expect(waiting.final).resolves.toMatchObject({
         ok: true,
         payload: { status: "ok" },
@@ -253,14 +346,12 @@ describe("gateway agent auth refresh dispatch", () => {
         `prepared reply dispatch runtime owner was not published for ${affectedAgentId}`,
       );
 
-      const dispatched = sendAgentRpc(gatewaySuite.ws, { agentId: affectedAgentId, runId });
-      await expect(dispatched.accepted).resolves.toMatchObject({
-        ok: true,
-        payload: { status: "accepted" },
+      const rejected = sendPreacceptAgentRpc(gatewaySuite.ws, {
+        agentId: affectedAgentId,
+        runId,
       });
-      await expect(dispatched.final).resolves.toMatchObject({
+      await expect(rejected.response).resolves.toMatchObject({
         ok: false,
-        payload: { status: "error" },
         error: {
           code: "UNAVAILABLE",
           message: expect.stringContaining(


### PR DESCRIPTION
## What Problem This Solves

Gateway agent turns accepted on prepared runtime generation A could perform a later execution-time lookup after config, plugin, or auth publication advanced to generation B. The accepted response therefore did not identify the runtime generation that would actually execute.

## Root Cause And Fix

The direct Gateway admission/execution boundary owned the invariant but selected runtime and workspace facts in execution. Admission now resolves the workspace override, loads the published reply runtime, and acquires an exact-generation prepared-model-runtime lease before acceptance. It revalidates admission after every await and releases the lease on every preaccept failure or cancellation.

Execution carries those admitted facts forward and removes the late runtime/workspace lookups. The canonical Gateway dispatch runs inside the admitted prepared-generation scope with a borrower tied to the still-live lease. Cleanup detaches the lease before release, so retained async work cannot borrow after queued abort, undispatched error, owner retirement, dispatched success, error, or cancellation.

There is no retry, fallback, configuration, persistence, protocol, or production test seam. `CHANGELOG.md` is not part of the PR.

## User Impact

- An accepted run stays on generation A after generation B publishes.
- The next admitted run uses generation B.
- Cancelling one publication waiter does not cancel another waiter or a sibling agent.
- Publication failure rejects before acceptance and never dispatches.

## Scope And Size

- Production: +122/-64, net +58.
- Tests: +262/-54, net +208.
- The production remainder is the admission-owned lease/runtime/workspace transfer and post-await lifecycle revalidation; execution is net -4 after deleting late lookups.
- One adjacent existing runner test was added to the reviewed write set: `src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts`. It was necessary to exercise the real embedded runner rather than only the mocked `agentCommand` boundary.
- Exact-head CI exposed one stale direct-handler fixture, so the reviewed scope added 14 lines to `src/gateway/server-methods/agent.create-event.test.ts` to supply the now-required published runtime and lease.
- Exact-head CI then exposed the same stale contract in the isolated full agent-handler harness. The reviewed expansion added six lines to its existing prepared-runtime mock: a fresh no-op lease plus `agentDir` and `workspaceDir`.
- `src/gateway/agent-turn/agent-run-execution-phase.ts` is +17/-21 against current main. Its existing dispatch object remains byte-stable; a single-argument local wrapper supplies the generation scope.

## Evidence

Pre-fix reproduction on reviewed head `9bd05225c562f19f4d01d0f8d56ecb2e9532b1aa`:

```text
pnpm test src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts \
  -t "dispatches with the runtime generation frozen at admission"

AssertionError: expected undefined to be 'generation-A'
```

Existing mock-Gateway verdict from behavior head `caca48cc432e924fdc7c75a4cfe1915f72525eab`:

```json
{
  "scenario": "gateway-runtime-generation-admission",
  "headSha": "caca48cc432e924fdc7c75a4cfe1915f72525eab",
  "result": "pass",
  "acceptedGeneration": "A",
  "publishedGeneration": "B",
  "executedGeneration": "A",
  "nextRunGeneration": "B"
}
```

Current amended-head focused proof on `23734d386fa86667a1dea7477f36c46a28bc93f4`:

- Previously failing isolated cron-creator case: 1 passed, 283 skipped.
- Full isolated `agent.test.ts`: 284 passed.
- Full isolated config (`agent.test.ts` + `board.runtime-boundaries.test.ts`): 295 passed.
- Four-file W4 Gateway/prepared-runtime suite: 39 passed.
- Create-event direct handler + Gateway execution owner: 4 passed.
- Gateway auth-refresh: 3 passed.
- Real embedded-runner A-admitted/B-published case: 1 passed.
- Harness-scoped lint and format: passed.
- Diff check: passed; both production files are byte-identical to `caca48cc432e924fdc7c75a4cfe1915f72525eab`.

Earlier focused proof, unchanged by the test-only amendment:

- Prepared owner-selection/inbound-registry: 33 passed.
- Exact-head mock-Gateway case: 1 passed, 2 skipped.
- Owning core-test typecheck shards (`agents-other`, `gateway-other`, `gateway-root`): passed.
- `pnpm check:changed`: all guards through production typecheck passed. The changed-file test typing errors were corrected; the full composite test-typecheck then stopped only on existing current-main `ui/src/test-helpers/*` implicit-any and missing `jsdom` declaration errors outside this PR.

Exact-head CI classification for run https://github.com/openclaw/openclaw/actions/runs/33110811851 on `caca48cc432e924fdc7c75a4cfe1915f72525eab`:

- `check-lint`: branch-owned. Four lint violations in the new execution-owner test were corrected by block Promise executors and an explicit abort `if`; current-head file-scoped lint passes.
- `checks-node-compact-large-2`: branch-owned stale fixture. `agent.create-event.test.ts` passed at parent `9be3cefabdc75de1e5d8c9d05e5a5792cac181df`, failed at `caca48cc`, and passes at the amended head after mocking the admission-owned runtime and lease.
- `checks-node-compact-small-19`: unrelated baseline watchdog failure in untouched `test/scripts/run-tsgo.test.ts`; the compiler process remained alive past that test's 2-second reap bound. No W4 patch or retry was made.

Exact-head CI classification for run https://github.com/openclaw/openclaw/actions/runs/33112010906 on `b72619b886e6e265905898f34f230d8f32d9850f`:

- `checks-node-compact-large-2`: branch-owned stale full agent-handler fixture. The normal Gateway-methods config passed 202 files/3577 tests. The isolated config then passed `board.runtime-boundaries.test.ts` but its compact reporter remained silent while `agent.test.ts` accumulated missing-dispatch failures because the harness mocked publication without the newly required lease acquisition. The focused verbose reproduction showed repeated `agentCommand`-not-called failures; after the six-line mock completion, full `agent.test.ts` passes 284/284 and the full two-file isolated config passes 295/295.
- `openclaw/ci-gate`: downstream aggregate fallout from that single failed shard, not an independent failure.
- No CI retry or Testbox rerun was performed for this test-only fixture repair.

Focused exact-head Linux Node 24 Testbox:

- Provider: `blacksmith-testbox`
- ID: `tbx_01m12c743qx56pvwvkagpns4hm`
- Slug: `amber-barnacle-2805`
- Run: https://github.com/openclaw/openclaw/actions/runs/33110160915
- Result: wrapper succeeded with exit 0 and all 40 focused tests passed. The backing Actions job concluded `cancelled` only when the delegated one-shot lifecycle closed `Run Testbox` after completion; no test failed.

```sh
node scripts/crabbox-wrapper.mjs run \
  --provider blacksmith-testbox \
  --blacksmith-ref fix/gateway-admission-runtime-lease \
  --timing-json -- \
  CI=1 NODE_OPTIONS=--max-old-space-size=4096 \
  OPENCLAW_TEST_PROJECTS_PARALLEL=3 \
  OPENCLAW_VITEST_MAX_WORKERS=1 \
  OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 \
  bash -lc 'set -euo pipefail; test "$(uname -s)" = Linux; test "$(node -p "process.versions.node.split(\".\")[0]")" = 24; test "$(git rev-parse HEAD)" = caca48cc432e924fdc7c75a4cfe1915f72525eab; pnpm test src/gateway/agent-turn/agent-run-execution-phase.owner.test.ts src/gateway/server.agent.gateway-server-agent-auth-refresh.test.ts src/agents/prepared-model-runtime.owner-selection.test.ts src/agents/prepared-model-runtime.inbound-registry.test.ts; pnpm test src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts -t "completes an admitted turn on A after plugin-runtime generation B publishes"'
```

The unchanged broad exact-head graph was not duplicated. Existing evidence remains:

- Provider: `blacksmith-testbox`
- ID: `tbx_01m128mzxvdge1hrt8e5r6yxk4`
- Slug: `golden-crayfish`
- Run: https://github.com/openclaw/openclaw/actions/runs/33105053382
- Head: `9bd05225c562f19f4d01d0f8d56ecb2e9532b1aa`
- Result: GitHub Actions succeeded. The wrapper later exited 137 during internal watchdog cleanup; no gate failed.

## Collision Watch

- https://github.com/openclaw/openclaw/pull/130986 remains open; its admission participant-recording semantics are preserved.
- https://github.com/openclaw/openclaw/pull/130579 remains open; its execution `execTarget` semantics are preserved.
