### PR TITLE
fix(openshell): preserve nested host symlinks during mirror sync

### DIFF
--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -409,6 +409,12 @@ Workspace synchronization excludes `.git`, `hooks`, and `git-hooks` in both
 directions. Repository credentials, history, and trusted hook code remain on
 the OpenClaw Gateway host instead of being copied into an untrusted sandbox.
 
+Mirror synchronization never copies symlinks into either workspace. Existing
+host symlinks remain intact at every depth, along with their parent directories,
+even if the sandbox deletes those directories or replaces them with files.
+Remote replacements that conflict with these preserved host paths are ignored;
+ordinary files and directories still receive remote changes and deletions.
+
 ## Custom image contract
 
 The OpenShell source image owns the remote operating system and package set.

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -539,6 +539,20 @@ describe("openshell sandbox backend e2e", () => {
           await fs.mkdir(protectedPath, { recursive: true });
           await fs.writeFile(path.join(protectedPath, "host-only.txt"), "private\n", "utf8");
         }
+        const hostLinkTarget = path.join(rootDir, "host-link-target.txt");
+        await fs.writeFile(hostLinkTarget, "host-only-link-target\n");
+        const hostLinks = [
+          "host-link",
+          "links/nested/link",
+          "links/removed/link",
+          "links/conflict/link",
+        ];
+        for (const relativePath of hostLinks) {
+          const linkPath = path.join(mirrorWorkspaceDir, relativePath);
+          await fs.mkdir(path.dirname(linkPath), { recursive: true });
+          await fs.symlink(hostLinkTarget, linkPath);
+        }
+        await fs.link(hostLinkTarget, path.join(mirrorWorkspaceDir, "links", "hardlinked.txt"));
         await fs.writeFile(dockerfilePath, CUSTOM_IMAGE_DOCKERFILE, "utf8");
         await fs.writeFile(
           denyPolicyPath,
@@ -652,6 +666,31 @@ describe("openshell sandbox backend e2e", () => {
         });
         expect(mirrorExecResult.stdout).toContain("/sandbox/project");
         expect(mirrorExecResult.stdout).toContain("mirror-from-local");
+        for (const relativePath of hostLinks) {
+          await expect(fs.readlink(path.join(mirrorWorkspaceDir, relativePath))).resolves.toBe(
+            hostLinkTarget,
+          );
+        }
+        await runBackendExec({
+          backend: mirrorBackend,
+          command:
+            "test ! -e host-link && test ! -L host-link && test ! -e links/nested/link && test ! -L links/nested/link && rm -rf links/removed links/conflict && printf remote-file > links/conflict && printf remote-write > links/hardlinked.txt && ln -s /etc/passwd links/remote-link",
+          timeoutMs: 60_000,
+        });
+        for (const relativePath of hostLinks) {
+          await expect(fs.readlink(path.join(mirrorWorkspaceDir, relativePath))).resolves.toBe(
+            hostLinkTarget,
+          );
+        }
+        await expect(fs.readFile(hostLinkTarget, "utf8")).resolves.toBe("host-only-link-target\n");
+        await expect(
+          fs.readFile(path.join(mirrorWorkspaceDir, "links", "hardlinked.txt"), "utf8"),
+        ).resolves.toBe("remote-write");
+        await expect(
+          fs.lstat(path.join(mirrorWorkspaceDir, "links", "remote-link")),
+        ).rejects.toMatchObject({
+          code: "ENOENT",
+        });
         for (const protectedDirectory of [".git", "hooks", "git-hooks"]) {
           await expect(
             fs.readFile(path.join(mirrorWorkspaceDir, protectedDirectory, "host-only.txt"), "utf8"),

--- a/extensions/openshell/src/mirror.test.ts
+++ b/extensions/openshell/src/mirror.test.ts
@@ -2,7 +2,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS,
   replaceDirectoryContents,
@@ -20,7 +21,7 @@ async function makeTmpDir(): Promise<string> {
 async function expectPathMissing(targetPath: string): Promise<void> {
   let error: unknown;
   try {
-    await fs.access(targetPath);
+    await fs.lstat(targetPath);
   } catch (caught) {
     error = caught;
   }
@@ -37,13 +38,86 @@ describe("replaceDirectoryContents", () => {
   it("copies source entries to target", async () => {
     const source = await makeTmpDir();
     const target = await makeTmpDir();
+    const outside = await makeTmpDir();
+    await fs.writeFile(path.join(outside, "original.txt"), "host-only");
+    await fs.link(path.join(outside, "original.txt"), path.join(target, "a.txt"));
     await fs.writeFile(path.join(source, "a.txt"), "hello");
     await fs.writeFile(path.join(target, "old.txt"), "stale");
 
     await replaceDirectoryContents({ sourceDir: source, targetDir: target });
 
     expect(await fs.readFile(path.join(target, "a.txt"), "utf8")).toBe("hello");
+    expect(await fs.readFile(path.join(outside, "original.txt"), "utf8")).toBe("host-only");
     await expectPathMissing(path.join(target, "old.txt"));
+  });
+
+  it("applies remote deletions and file-directory replacements without protected links", async () => {
+    const source = await makeTmpDir();
+    const target = await makeTmpDir();
+    await fs.mkdir(path.join(target, "deleted", "nested"), { recursive: true });
+    await fs.writeFile(path.join(target, "deleted", "nested", "old.txt"), "stale");
+    await fs.mkdir(path.join(target, "now-file"));
+    await fs.writeFile(path.join(target, "now-file", "old.txt"), "stale");
+    await fs.writeFile(path.join(source, "now-file"), "file");
+    await fs.writeFile(path.join(target, "now-directory"), "stale");
+    await fs.mkdir(path.join(source, "now-directory"));
+    await fs.writeFile(path.join(source, "now-directory", "new.txt"), "directory");
+    await fs.mkdir(path.join(source, "empty-directory"));
+
+    await replaceDirectoryContents({ sourceDir: source, targetDir: target });
+
+    await expectPathMissing(path.join(target, "deleted"));
+    expect(await fs.readFile(path.join(target, "now-file"), "utf8")).toBe("file");
+    expect(await fs.readFile(path.join(target, "now-directory", "new.txt"), "utf8")).toBe(
+      "directory",
+    );
+    expect(await fs.readdir(path.join(target, "empty-directory"))).toEqual([]);
+  });
+
+  it("waits for in-flight copies before reporting a mirror failure", async () => {
+    const source = await makeTmpDir();
+    const target = await makeTmpDir();
+    await fs.mkdir(path.join(source, "nested"));
+    await fs.writeFile(path.join(source, "nested", "failed.txt"), "failed");
+    await fs.writeFile(path.join(source, "nested", "delayed.txt"), "finished");
+    const failure = new Error("copy failed");
+    const failedCopyStarted = createDeferred<void>();
+    const delayedCopyStarted = createDeferred<void>();
+    const releaseCopy = createDeferred<void>();
+    const originalCopyFile = fs.copyFile;
+    const copyFile = vi.spyOn(fs, "copyFile").mockImplementation(async (from, to, mode) => {
+      if (from === path.join(source, "nested", "failed.txt")) {
+        failedCopyStarted.resolve();
+        throw failure;
+      }
+      delayedCopyStarted.resolve();
+      await releaseCopy.promise;
+      await originalCopyFile(from, to, mode);
+    });
+    let settled = false;
+    const replacement = replaceDirectoryContents({ sourceDir: source, targetDir: target }).then(
+      () => {
+        settled = true;
+      },
+      (error: unknown) => {
+        settled = true;
+        return error;
+      },
+    );
+    try {
+      await Promise.all([failedCopyStarted.promise, delayedCopyStarted.promise]);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(settled).toBe(false);
+      releaseCopy.resolve();
+      expect(await replacement).toBe(failure);
+      expect(await fs.readFile(path.join(target, "nested", "delayed.txt"), "utf8")).toBe(
+        "finished",
+      );
+    } finally {
+      releaseCopy.resolve();
+      await replacement;
+      copyFile.mockRestore();
+    }
   });
 
   // Mirrored OpenShell sandbox content must never overwrite trusted workspace
@@ -158,20 +232,57 @@ describe("replaceDirectoryContents", () => {
     await expectPathMissing(path.join(target, "nested", "escaped-dir"));
   });
 
-  it("preserves existing trusted host symlinks", async () => {
-    const source = await makeTmpDir();
-    const target = await makeTmpDir();
+  it.each(["directory", "absent", "file", "symlink"] as const)(
+    "preserves trusted host symlinks when their remote ancestor is %s",
+    async (remoteAncestor) => {
+      const source = await makeTmpDir();
+      const target = await makeTmpDir();
+      const outside = await makeTmpDir();
+      await fs.writeFile(path.join(outside, "canary.txt"), "host-only");
+      const linkTargets = {
+        "file-link": path.join(outside, "canary.txt"),
+        "directory-link": outside,
+        "dangling-link": "missing-relative-target",
+      };
+      const nested = path.join(target, "nested", "deeper");
+      await fs.mkdir(nested, { recursive: true });
+      for (const [name, destination] of Object.entries(linkTargets)) {
+        await fs.symlink(destination, path.join(nested, name));
+      }
+      await fs.writeFile(path.join(nested, "deleted.txt"), "stale");
+      await fs.symlink(outside, path.join(target, "linked-entry"));
+      await stageDirectoryContents({ sourceDir: target, targetDir: source });
 
-    await fs.writeFile(path.join(source, "safe.txt"), "ok");
-    await fs.writeFile(path.join(source, "linked-entry"), "remote-plain-file");
-    const trustedTarget = path.resolve("/tmp/trusted-host-target");
-    await fs.symlink(trustedTarget, path.join(target, "linked-entry"));
+      await fs.writeFile(path.join(source, "safe.txt"), "ok");
+      await fs.writeFile(path.join(source, "linked-entry"), "remote-plain-file");
+      await fs.rm(path.join(source, "nested"), { recursive: true });
+      if (remoteAncestor === "directory") {
+        await fs.mkdir(path.join(source, "nested", "deeper"), { recursive: true });
+        await fs.writeFile(path.join(source, "nested", "deeper", "file-link"), "remote");
+        await fs.mkdir(path.join(source, "nested", "deeper", "directory-link"));
+        await fs.writeFile(
+          path.join(source, "nested", "deeper", "directory-link", "new.txt"),
+          "remote",
+        );
+        await fs.symlink(outside, path.join(source, "nested", "deeper", "dangling-link"));
+      } else if (remoteAncestor === "file") {
+        await fs.writeFile(path.join(source, "nested"), "remote replacement");
+      } else if (remoteAncestor === "symlink") {
+        await fs.symlink(outside, path.join(source, "nested"));
+      }
 
-    await replaceDirectoryContents({ sourceDir: source, targetDir: target });
+      await replaceDirectoryContents({ sourceDir: source, targetDir: target });
 
-    expect(await fs.readFile(path.join(target, "safe.txt"), "utf8")).toBe("ok");
-    expect(await fs.readlink(path.join(target, "linked-entry"))).toBe(trustedTarget);
-  });
+      expect(await fs.readFile(path.join(target, "safe.txt"), "utf8")).toBe("ok");
+      expect(await fs.readlink(path.join(target, "linked-entry"))).toBe(outside);
+      for (const [name, destination] of Object.entries(linkTargets)) {
+        expect(await fs.readlink(path.join(nested, name))).toBe(destination);
+      }
+      await expectPathMissing(path.join(nested, "deleted.txt"));
+      expect(await fs.readFile(path.join(outside, "canary.txt"), "utf8")).toBe("host-only");
+      expect(await fs.readdir(outside)).toEqual(["canary.txt"]);
+    },
+  );
 });
 
 describe("stageDirectoryContents", () => {

--- a/extensions/openshell/src/mirror.test.ts
+++ b/extensions/openshell/src/mirror.test.ts
@@ -106,7 +106,9 @@ describe("replaceDirectoryContents", () => {
     );
     try {
       await Promise.all([failedCopyStarted.promise, delayedCopyStarted.promise]);
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
       expect(settled).toBe(false);
       releaseCopy.resolve();
       expect(await replacement).toBe(failure);

--- a/extensions/openshell/src/mirror.ts
+++ b/extensions/openshell/src/mirror.ts
@@ -1,7 +1,7 @@
 // Openshell plugin module implements mirror behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { movePathWithCopyFallback } from "openclaw/plugin-sdk/security-runtime";
+import { extractErrorCode, movePathWithCopyFallback } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import pLimit from "p-limit";
 
@@ -16,8 +16,8 @@ function createExcludeMatcher(excludeDirs?: readonly string[]) {
 const runLimitedFs = pLimit(COPY_TREE_FS_CONCURRENCY);
 
 async function lstatIfExists(targetPath: string) {
-  return await runLimitedFs(fs.lstat, targetPath).catch((error: NodeJS.ErrnoException) => {
-    if (error.code === "ENOENT") {
+  return await runLimitedFs(fs.lstat, targetPath).catch((error: unknown) => {
+    if (extractErrorCode(error) === "ENOENT") {
       return null;
     }
     throw error;

--- a/extensions/openshell/src/mirror.ts
+++ b/extensions/openshell/src/mirror.ts
@@ -16,42 +16,92 @@ function createExcludeMatcher(excludeDirs?: readonly string[]) {
 const runLimitedFs = pLimit(COPY_TREE_FS_CONCURRENCY);
 
 async function lstatIfExists(targetPath: string) {
-  return await runLimitedFs(async () => await fs.lstat(targetPath)).catch(() => null);
+  return await runLimitedFs(fs.lstat, targetPath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") {
+      return null;
+    }
+    throw error;
+  });
 }
 
-async function copyTreeWithoutSymlinks(params: {
-  sourcePath: string;
+async function reconcileMirrorPath(params: {
+  sourcePath?: string;
   targetPath: string;
-  preserveTargetSymlinks?: boolean;
-}): Promise<void> {
-  const stats = await runLimitedFs(async () => await fs.lstat(params.sourcePath));
-  // Mirror sync only carries regular files and directories across the
-  // host/sandbox boundary. Symlinks and special files are dropped.
-  if (stats.isSymbolicLink()) {
-    return;
-  }
+  replace: boolean;
+}): Promise<boolean> {
   const targetStats = await lstatIfExists(params.targetPath);
-  if (params.preserveTargetSymlinks && targetStats?.isSymbolicLink()) {
-    return;
+  if (targetStats?.isSymbolicLink()) {
+    return true;
   }
-  if (stats.isDirectory()) {
-    await runLimitedFs(fs.mkdir, params.targetPath, { recursive: true });
-    const entries = await runLimitedFs(async () => await fs.readdir(params.sourcePath));
-    await Promise.all(
-      entries.map(async (entry) => {
-        await copyTreeWithoutSymlinks({
-          sourcePath: path.join(params.sourcePath, entry),
-          targetPath: path.join(params.targetPath, entry),
-          preserveTargetSymlinks: params.preserveTargetSymlinks,
-        });
-      }),
-    );
-    return;
+  const sourceStats = params.sourcePath ? await runLimitedFs(fs.lstat, params.sourcePath) : null;
+  // Source symlinks and special files never cross the sandbox boundary.
+  const sourceDir = sourceStats?.isDirectory() ? params.sourcePath : undefined;
+  const sourceFile = sourceStats?.isFile() ? params.sourcePath : undefined;
+  if (!params.replace && !sourceDir && !sourceFile) {
+    return false;
   }
-  if (stats.isFile()) {
-    await runLimitedFs(fs.mkdir, path.dirname(params.targetPath), { recursive: true });
-    await runLimitedFs(async () => await fs.copyFile(params.sourcePath, params.targetPath));
+  if (sourceDir || targetStats?.isDirectory()) {
+    if (targetStats && !targetStats.isDirectory()) {
+      await runLimitedFs(fs.rm, params.targetPath, { force: true });
+    }
+    const preservedLinks = await reconcileMirrorDirectory({
+      sourceDir,
+      targetDir: params.targetPath,
+      replace: params.replace,
+    });
+    // Host links also protect their ancestor directories. A conflicting remote
+    // file cannot replace those directories, just as it cannot replace a link.
+    if (sourceDir || preservedLinks) {
+      return preservedLinks;
+    }
+    await runLimitedFs(fs.rmdir, params.targetPath);
+  } else if (targetStats) {
+    // Unlink before copying so a host hardlink cannot redirect the new content
+    // into an inode outside the workspace.
+    await runLimitedFs(fs.rm, params.targetPath, { force: true });
   }
+  if (sourceFile) {
+    await runLimitedFs(fs.copyFile, sourceFile, params.targetPath);
+  }
+  return false;
+}
+
+async function reconcileMirrorDirectory(params: {
+  sourceDir?: string;
+  targetDir: string;
+  replace: boolean;
+  excludeDirs?: readonly string[];
+}): Promise<boolean> {
+  const { sourceDir } = params;
+  const isExcluded = createExcludeMatcher(params.excludeDirs);
+  await runLimitedFs(fs.mkdir, params.targetDir, { recursive: true });
+  const sourceEntries = new Set(
+    sourceDir ? await runLimitedFs(async () => await fs.readdir(sourceDir)) : [],
+  );
+  const targetEntries = params.replace
+    ? await runLimitedFs(async () => await fs.readdir(params.targetDir))
+    : [];
+  // Finish every mutation before returning an error and releasing the workspace lease.
+  const results = await Promise.allSettled(
+    [...new Set([...sourceEntries, ...targetEntries])]
+      .filter((entry) => !isExcluded(entry))
+      .map((entry) =>
+        reconcileMirrorPath({
+          sourcePath:
+            sourceDir && sourceEntries.has(entry) ? path.join(sourceDir, entry) : undefined,
+          targetPath: path.join(params.targetDir, entry),
+          replace: params.replace,
+        }),
+      ),
+  );
+  let preservedLinks = false;
+  for (const result of results) {
+    if (result.status === "rejected") {
+      throw result.reason;
+    }
+    preservedLinks ||= result.value;
+  }
+  return preservedLinks;
 }
 
 export async function replaceDirectoryContents(params: {
@@ -60,32 +110,7 @@ export async function replaceDirectoryContents(params: {
   /** Top-level directory names to exclude from sync (preserved in target, skipped from source). */
   excludeDirs?: readonly string[];
 }): Promise<void> {
-  const isExcluded = createExcludeMatcher(params.excludeDirs);
-  await fs.mkdir(params.targetDir, { recursive: true });
-  const existing = await fs.readdir(params.targetDir);
-  await Promise.all(
-    existing
-      .filter((entry) => !isExcluded(entry))
-      .map(async (entry) => {
-        const targetPath = path.join(params.targetDir, entry);
-        const stats = await lstatIfExists(targetPath);
-        if (stats?.isSymbolicLink()) {
-          return;
-        }
-        await runLimitedFs(fs.rm, targetPath, { recursive: true, force: true });
-      }),
-  );
-  const sourceEntries = await fs.readdir(params.sourceDir);
-  for (const entry of sourceEntries) {
-    if (isExcluded(entry)) {
-      continue;
-    }
-    await copyTreeWithoutSymlinks({
-      sourcePath: path.join(params.sourceDir, entry),
-      targetPath: path.join(params.targetDir, entry),
-      preserveTargetSymlinks: true,
-    });
-  }
+  await reconcileMirrorDirectory({ ...params, replace: true });
 }
 
 export async function stageDirectoryContents(params: {
@@ -94,18 +119,7 @@ export async function stageDirectoryContents(params: {
   /** Top-level directory names to exclude from the staged upload. */
   excludeDirs?: readonly string[];
 }): Promise<void> {
-  const isExcluded = createExcludeMatcher(params.excludeDirs);
-  await fs.mkdir(params.targetDir, { recursive: true });
-  const sourceEntries = await fs.readdir(params.sourceDir);
-  for (const entry of sourceEntries) {
-    if (isExcluded(entry)) {
-      continue;
-    }
-    await copyTreeWithoutSymlinks({
-      sourcePath: path.join(params.sourceDir, entry),
-      targetPath: path.join(params.targetDir, entry),
-    });
-  }
+  await reconcileMirrorDirectory({ ...params, replace: false });
 }
 
 export { movePathWithCopyFallback };


### PR DESCRIPTION
Closes #131111

## What Problem This Solves

Fixes an issue where OpenShell mirror users lose existing host symlinks inside subdirectories after an ordinary sandbox command, even when that command changes nothing. The previous download replacement preserved immediate symlink children but recursively deleted their parent directories.

## Why This Change Was Made

Upload staging and download publication now share one recursive reconciliation flow. Existing host symlinks and the directories needed to retain them take precedence over conflicting remote entries; ordinary remote edits, deletions, and file/directory changes still apply. Sandbox symlinks and special files remain excluded. Regular destinations are unlinked before copying, preserving the existing protection against writing through a host hardlink into an outside inode.

The traversal also drains all started filesystem operations before reporting an error, so the workspace lease cannot be released while a sibling copy is still mutating the host. No new dependency, configuration, storage, or protocol surface is introduced. The old whole-directory deletion and duplicate copy loops are removed.

Production LOC: +81/-67 (net +14). This growth implements recursive preservation of host links and their ancestors, plus error settlement at the same owner boundary. Tests: +168/-16; docs: +6/-0.

## User Impact

Host symlinks survive mirror round-trips at any depth, including dangling links and links whose remote parent was deleted or replaced. A remote replacement that conflicts with such a preserved host path is ignored, matching the existing rule that host links win. The OpenShell guide documents this boundary.

## Evidence

- Before the production change, the focused regression suite had 4 failures and 7 passes. Every new ancestor case failed because a nested host link was deleted or replaced (`ENOENT`, `EINVAL`, or `ENOTDIR`).
- After the repair, `node scripts/run-vitest.mjs extensions/openshell` passed 101 tests across 6 files. Coverage includes nested and dangling links, remote ancestor conflicts, normal deletions/type changes, outside hardlink canaries, and draining delayed copies after a sibling failure.
- `pnpm docs:list`, targeted formatting, and `git diff --check` passed.
- Structured Codex review: no accepted/actionable findings.
- The changed-file gate passed production and test typechecks, lint, database-first and media guards, runtime sidecar validation, and runtime import-cycle checks.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33105876794) passed on b2e35d40d09983b0b4f9e4cb5a05862406fb2be7.
- Real OpenShell E2E passed **5/5 tests in 96.82s**, including mirror and remote stress. Environment: isolated Ubuntu24.04 arm64 container, Node24.19.0, pnpm11.22.0, OpenShell0.0.109, nested Linux Docker29.1.3 with vfs storage, authenticated mTLS. Protected whoami and sandbox list passed before running `pnpm test:e2e:openshell`. Source hashes matched the PR head. The existing fixture host-IP override used the actual task-owned Docker bridge gateway. The suite verified host links after real upload/SSH/download, ancestor conflicts, remote-link exclusion, outside hardlink canaries and ordinary writes.
- The [hosted live attempt](https://github.com/openclaw/openclaw/actions/runs/33106165717) stopped before tests because of the independent bootstrap defect recorded in #131134. An initial isolated-container attempt lacked the SSH client; installing the required executable allowed the unchanged full E2E suite to pass. No authentication, assertions, timeouts, or CI thresholds were weakened.
- The first CI attempt found two callback lint violations, corrected in the current head. Its artifact job also exceeded the existing plugins-list startup RSS limit; the current run passed that unchanged gate. The first live run was canceled before tests to replace it with proof of the corrected head.

The affected deletion logic is already present in stable v2026.7.1. The retained local history carries it through e357203be57; that shallow-history boundary does not establish who originally introduced the defect. Upstream OpenShell v0.0.109 upload/download behavior was checked directly in `crates/openshell-cli/src/run.rs` and `ssh.rs` at pinned commit 8d67250a5d17348eb96c4fa46226b06d8041f2ba.

AI-assisted; the implementation, boundary behavior, and regression evidence were reviewed.
