### PR TITLE
fix(cron): surface command prompt capability failures

### DIFF
--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -1680,6 +1680,28 @@ describe("createCopilotToolBridge", () => {
       expect(options?.toolConstructionPlan?.includeOpenClawTools).toBe(true);
     });
 
+    it("constructs shell tools through the shared glob-aware plan", async () => {
+      const createOpenClawCodingTools = vi.fn(async () => [
+        makeTool({ name: "exec" }),
+        makeTool({ name: "read" }),
+      ]);
+      const result = await createCopilotToolBridge({
+        attemptParams: { toolsAllow: ["exec*"] } as never,
+        createOpenClawCodingTools,
+      });
+      expect(result.sourceTools.map((tool) => tool.name)).toEqual(["exec"]);
+      const options = (createOpenClawCodingTools.mock.calls[0] as unknown[] | undefined)?.[0] as {
+        toolConstructionPlan?: {
+          includeBaseCodingTools?: boolean;
+          includeShellTools?: boolean;
+        };
+      };
+      expect(options?.toolConstructionPlan).toMatchObject({
+        includeBaseCodingTools: false,
+        includeShellTools: true,
+      });
+    });
+
     it("does not keep apply_patch for a write-only allowlist", async () => {
       const createOpenClawCodingTools = vi.fn(async () => [
         makeTool({ name: "write" }),

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -184,21 +184,7 @@ export async function createCopilotToolBridge(
     isRawModelRun: isRawCopilotModelRun(attemptParams),
     toolsAllow: attemptParams.toolsAllow,
   });
-  const effectiveToolPlan = hasNonWildcardGlobAllowlist(toolPlan.runtimeToolAllowlist)
-    ? {
-        ...toolPlan,
-        codingToolConstructionPlan: {
-          includeBaseCodingTools: true,
-          includeChannelTools: true,
-          includeOpenClawTools: true,
-          includePluginTools: true,
-          includeShellTools: true,
-        },
-        constructTools: true,
-        includeCoreTools: true,
-      }
-    : toolPlan;
-  if (!effectiveToolPlan.constructTools) {
+  if (!toolPlan.constructTools) {
     return { codeModeEngaged: false, promptToolPolicy: EMPTY_PROMPT_TOOL_POLICY, sourceTools: [] };
   }
 
@@ -221,7 +207,7 @@ export async function createCopilotToolBridge(
     modelToolsEnabled: true,
     prompt: attemptParams.prompt,
     runId: attemptParams.runId,
-    runtimeToolAllowlist: effectiveToolPlan.runtimeToolAllowlist,
+    runtimeToolAllowlist: toolPlan.runtimeToolAllowlist,
     sessionId: input.sessionId,
     sessionKey: attemptParams.sandboxSessionKey ?? attemptParams.sessionKey ?? input.sessionKey,
     scheduledToolPolicy: attemptParams.scheduledToolPolicy,
@@ -231,7 +217,7 @@ export async function createCopilotToolBridge(
   const toolOptions = buildOpenClawCodingToolsOptions(
     input,
     {
-      ...effectiveToolPlan,
+      ...toolPlan,
       runtimeToolAllowlist: toolSurfaceRuntime.runtimeToolAllowlist,
     },
     toolSurfaceRuntime,
@@ -269,7 +255,7 @@ export async function createCopilotToolBridge(
   );
   const plannedSourceTools = filterCopilotToolsForConstructionPlan(
     allowedSourceTools,
-    effectiveToolPlan.codingToolConstructionPlan,
+    toolPlan.codingToolConstructionPlan,
     { preserveToolNames: toolSurfaceRuntime.runtimeToolAllowlist },
   );
   const compactedTools = toolSurfaceRuntime.compactTools(plannedSourceTools, {
@@ -869,13 +855,6 @@ function filterCopilotToolsForConstructionPlan<T extends { name: string }>(
       return false;
     }
     return true;
-  });
-}
-
-function hasNonWildcardGlobAllowlist(toolsAllow: string[] | undefined): boolean {
-  return (toolsAllow ?? []).some((entry) => {
-    const trimmed = entry.trim();
-    return trimmed !== "*" && trimmed.includes("*");
   });
 }
 

--- a/src/agents/core-tool-factory-descriptors.ts
+++ b/src/agents/core-tool-factory-descriptors.ts
@@ -7,8 +7,8 @@ import { AUTOMATIONS_TOOL_NAME } from "./tools/automations-tool-name.js";
 export type CoreToolFactoryFamily = "base-coding" | "shell" | "openclaw";
 
 type CoreToolFactoryDescriptor = {
-  name: string;
-  family: CoreToolFactoryFamily;
+  readonly name: string;
+  readonly family: CoreToolFactoryFamily;
 };
 
 const CORE_TOOL_FACTORY_DESCRIPTORS = [
@@ -83,6 +83,10 @@ export type OpenClawCodingToolConstructionPlan = {
 
 export function resolveCoreToolFactoryFamily(name: string): CoreToolFactoryFamily | undefined {
   return CORE_TOOL_FACTORY_FAMILY_BY_NAME.get(name);
+}
+
+export function listCoreToolFactoryDescriptors(): readonly CoreToolFactoryDescriptor[] {
+  return CORE_TOOL_FACTORY_DESCRIPTORS;
 }
 
 /**

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
@@ -122,9 +122,20 @@ describe("applyEmbeddedAttemptToolsAllow", () => {
       "read",
       "message",
     ]);
+    expect(applyEmbeddedAttemptToolsAllow(tools, ["exec*"]).map((tool) => tool.name)).toEqual([
+      "exec",
+    ]);
     expect(applyEmbeddedAttemptToolsAllow(tools, ["group:fs"]).map((tool) => tool.name)).toEqual([
       "read",
     ]);
+  });
+
+  it("keeps write and apply_patch distinct in per-run caps", () => {
+    const tools = [{ name: "write" }, { name: "apply_patch" }, { name: "exec" }];
+
+    expect(
+      applyEmbeddedAttemptToolsAllow(tools, ["write", "exec"]).map((tool) => tool.name),
+    ).toEqual(["write", "exec"]);
   });
 
   it("keeps plugin-only allowlists on the shared tool policy path", () => {
@@ -397,6 +408,119 @@ describe("resolveEmbeddedAttemptToolConstructionPlan", () => {
         },
       );
     }
+  });
+
+  it("materializes the shell family for matching wildcard allowlists", () => {
+    expectConstructionPlan(resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: ["exec*"] }), {
+      constructTools: true,
+      includeCoreTools: true,
+      runtimeToolAllowlist: ["exec*"],
+      coding: {
+        includeBaseCodingTools: false,
+        includeShellTools: true,
+        includeOpenClawTools: false,
+        includePluginTools: true,
+      },
+    });
+
+    expectConstructionPlan(
+      resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: ["plugin_*"] }),
+      {
+        includeCoreTools: false,
+        coding: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      },
+    );
+
+    const incompatibleIntersection = attachToolAllowlistIntersection(
+      ["exec*"],
+      [["exec*"], ["read"]],
+    );
+    expectConstructionPlan(
+      resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: incompatibleIntersection }),
+      {
+        includeCoreTools: false,
+        coding: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      },
+    );
+  });
+
+  it.each([
+    {
+      toolsAllow: ["read*"],
+      coding: { includeBaseCodingTools: true, includeShellTools: false },
+    },
+    {
+      toolsAllow: ["web_*"],
+      coding: { includeOpenClawTools: true, includeShellTools: false },
+    },
+    {
+      toolsAllow: ["group:fs"],
+      coding: { includeBaseCodingTools: true, includeShellTools: true },
+    },
+    {
+      toolsAllow: ["apply-patch"],
+      coding: { includeBaseCodingTools: false, includeShellTools: true },
+    },
+    {
+      toolsAllow: ["apply_*"],
+      coding: { includeBaseCodingTools: false, includeShellTools: true },
+    },
+    {
+      toolsAllow: ["group:runtime"],
+      coding: { includePluginTools: true, includeShellTools: true },
+    },
+  ])("materializes core families for $toolsAllow", ({ toolsAllow, coding }) => {
+    expectConstructionPlan(resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow }), {
+      includeCoreTools: true,
+      coding,
+    });
+  });
+
+  it("honors runtime-cap intersections when selecting core families", () => {
+    expectConstructionPlan(resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: ["write"] }), {
+      includeCoreTools: true,
+      coding: {
+        includeBaseCodingTools: true,
+        includeShellTools: false,
+        includeOpenClawTools: false,
+      },
+    });
+
+    const narrowedWildcard = attachToolAllowlistIntersection(["*", "write"], [["*"], ["write"]]);
+    expectConstructionPlan(
+      resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: narrowedWildcard }),
+      {
+        includeCoreTools: true,
+        coding: {
+          includeBaseCodingTools: true,
+          includeShellTools: false,
+          includeOpenClawTools: false,
+        },
+      },
+    );
+
+    const overlappingGlobs = attachToolAllowlistIntersection([], [["exec*"], ["*xec"]]);
+    expectConstructionPlan(
+      resolveEmbeddedAttemptToolConstructionPlan({ toolsAllow: overlappingGlobs }),
+      {
+        includeCoreTools: true,
+        coding: {
+          includeBaseCodingTools: false,
+          includeShellTools: true,
+          includeOpenClawTools: false,
+        },
+      },
+    );
   });
 
   it("materializes computer for an exact core-tool allowlist", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts
@@ -130,12 +130,13 @@ describe("applyEmbeddedAttemptToolsAllow", () => {
     ]);
   });
 
-  it("keeps write and apply_patch distinct in per-run caps", () => {
+  it("preserves runtime write compatibility in the final filter", () => {
     const tools = [{ name: "write" }, { name: "apply_patch" }, { name: "exec" }];
 
-    expect(
-      applyEmbeddedAttemptToolsAllow(tools, ["write", "exec"]).map((tool) => tool.name),
-    ).toEqual(["write", "exec"]);
+    expect(applyEmbeddedAttemptToolsAllow(tools, ["write"]).map((tool) => tool.name)).toEqual([
+      "write",
+      "apply_patch",
+    ]);
   });
 
   it("keeps plugin-only allowlists on the shared tool policy path", () => {

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
@@ -9,7 +9,10 @@ import {
   resolveCoreToolFactoryFamily,
 } from "../../core-tool-factory-descriptors.js";
 import { mayMatchGlobWithPrefix } from "../../glob-pattern.js";
-import { isRuntimeToolAllowed } from "../../tool-policy-match.js";
+import {
+  isRuntimeToolAllowed,
+  isRuntimeToolAllowedForConstruction,
+} from "../../tool-policy-match.js";
 import {
   attachToolAllowlistIntersection,
   buildPluginToolGroups,
@@ -134,12 +137,22 @@ function resolveCodingToolConstructionPlanForAllowlist(
   const constructionEntries = restrictions?.flat() ?? toolsAllow;
   const expanded = expandToolGroups(expandShippedCoreToolPolicyNames(constructionEntries));
   const normalized = normalizeToolList(expanded);
+  const constructionRestrictions = restrictions ?? [toolsAllow];
   // Construct every family containing a tool that the final runtime policy can retain.
   // Otherwise a valid glob can survive filtering after its factory was never run.
   const coreFamilies = new Set<CoreToolFactoryFamily>(
-    applyEmbeddedAttemptToolsAllow([...listCoreToolFactoryDescriptors()], toolsAllow).map(
-      ({ family }) => family,
-    ),
+    listCoreToolFactoryDescriptors()
+      .filter(({ name }) =>
+        constructionRestrictions.every(
+          (restriction) =>
+            restriction.length > 0 &&
+            isRuntimeToolAllowedForConstruction(
+              name,
+              expandShippedCoreToolPolicyNames(restriction),
+            ),
+        ),
+      )
+      .map(({ family }) => family),
   );
   let includePluginTools = false;
   for (const name of normalized) {

--- a/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.ts
@@ -5,10 +5,11 @@ import { TOOL_NAME_SEPARATOR } from "../../agent-bundle-mcp-names.js";
 import {
   type CoreToolFactoryFamily,
   type OpenClawCodingToolConstructionPlan,
+  listCoreToolFactoryDescriptors,
   resolveCoreToolFactoryFamily,
 } from "../../core-tool-factory-descriptors.js";
 import { mayMatchGlobWithPrefix } from "../../glob-pattern.js";
-import { isToolAllowedByPolicyName } from "../../tool-policy-match.js";
+import { isRuntimeToolAllowed } from "../../tool-policy-match.js";
 import {
   attachToolAllowlistIntersection,
   buildPluginToolGroups,
@@ -80,7 +81,7 @@ export function applyEmbeddedAttemptToolsAllow<T extends { name: string }>(
     const policy = pluginGroups
       ? expandPolicyWithPluginGroups({ allow: restriction }, pluginGroups)
       : { allow: expandShippedCoreToolPolicyNames(restriction) };
-    return currentTools.filter((tool) => isToolAllowedByPolicyName(tool.name, policy));
+    return currentTools.filter((tool) => isRuntimeToolAllowed(tool.name, policy?.allow));
   }, tools);
 }
 
@@ -123,20 +124,27 @@ function resolveCodingToolConstructionPlanForAllowlist(
   if (!toolsAllow) {
     return cloneCodingToolConstructionPlan(ALL_CODING_TOOL_CONSTRUCTION_PLAN);
   }
-  if (toolsAllow.length === 0) {
+  const restrictions = readToolAllowlistIntersection(toolsAllow);
+  if (!restrictions && toolsAllow.length === 0) {
     return cloneCodingToolConstructionPlan(NO_CODING_TOOL_CONSTRUCTION_PLAN);
   }
-  if (hasWildcardToolAllowlist(toolsAllow)) {
+  if (!restrictions && hasWildcardToolAllowlist(toolsAllow)) {
     return cloneCodingToolConstructionPlan(ALL_CODING_TOOL_CONSTRUCTION_PLAN);
   }
-  const expanded = expandToolGroups(expandShippedCoreToolPolicyNames(toolsAllow));
+  const constructionEntries = restrictions?.flat() ?? toolsAllow;
+  const expanded = expandToolGroups(expandShippedCoreToolPolicyNames(constructionEntries));
   const normalized = normalizeToolList(expanded);
-  const coreFamilies = new Set<CoreToolFactoryFamily>();
+  // Construct every family containing a tool that the final runtime policy can retain.
+  // Otherwise a valid glob can survive filtering after its factory was never run.
+  const coreFamilies = new Set<CoreToolFactoryFamily>(
+    applyEmbeddedAttemptToolsAllow([...listCoreToolFactoryDescriptors()], toolsAllow).map(
+      ({ family }) => family,
+    ),
+  );
   let includePluginTools = false;
   for (const name of normalized) {
     const family = resolveCoreToolFactoryFamily(name);
     if (family) {
-      coreFamilies.add(family);
       continue;
     }
     // Plugin ids/tool names are not known to the local factory catalog.

--- a/src/agents/tool-policy-match.ts
+++ b/src/agents/tool-policy-match.ts
@@ -7,10 +7,7 @@ import type { SandboxToolPolicy } from "./sandbox/types.js";
 import { readToolAllowlistIntersection } from "./tool-policy-shared.js";
 import { expandToolGroups, normalizeToolPolicyName } from "./tool-policy.js";
 
-function makeToolPolicyMatcher(
-  policy: SandboxToolPolicy,
-  options: { writeAllowsApplyPatch: boolean },
-) {
+function makeToolPolicyMatcher(policy: SandboxToolPolicy, writeAllowsApplyPatch = true) {
   const deny = compileGlobPatterns({
     raw: expandToolGroups(policy.deny ?? []),
     normalize: normalizeToolPolicyName,
@@ -30,10 +27,10 @@ function makeToolPolicyMatcher(
     if (matchesAnyGlobPattern(normalized, allow)) {
       return true;
     }
-    // Sandbox config historically treats `write` as covering `apply_patch`.
-    // Per-run caps disable that compatibility so explicit tool grants stay exact.
+    // Runtime policy historically treats `write` as covering `apply_patch`.
+    // Construction planning can disable that compatibility to avoid selecting a shell factory.
     if (
-      options.writeAllowsApplyPatch &&
+      writeAllowsApplyPatch &&
       normalized === "apply_patch" &&
       matchesAnyGlobPattern("write", allow)
     ) {
@@ -48,7 +45,7 @@ export function isToolAllowedByPolicyName(name: string, policy?: SandboxToolPoli
   if (!policy) {
     return true;
   }
-  return makeToolPolicyMatcher(policy, { writeAllowsApplyPatch: true })(name);
+  return makeToolPolicyMatcher(policy)(name);
 }
 
 /** Runtime caps deny empty lists and preserve every independently merged restriction. */
@@ -56,9 +53,17 @@ export function isRuntimeToolAllowed(name: string, toolsAllow?: string[]): boole
   return (
     toolsAllow === undefined ||
     (readToolAllowlistIntersection(toolsAllow) ?? [toolsAllow]).every(
-      (allow) =>
-        allow.length > 0 &&
-        makeToolPolicyMatcher({ allow }, { writeAllowsApplyPatch: false })(name),
+      (allow) => allow.length > 0 && isToolAllowedByPolicyName(name, { allow }),
+    )
+  );
+}
+
+/** Avoid selecting the shell factory solely through the `write` compatibility alias. */
+export function isRuntimeToolAllowedForConstruction(name: string, toolsAllow?: string[]): boolean {
+  return (
+    toolsAllow === undefined ||
+    (readToolAllowlistIntersection(toolsAllow) ?? [toolsAllow]).every(
+      (allow) => allow.length > 0 && makeToolPolicyMatcher({ allow }, false)(name),
     )
   );
 }

--- a/src/agents/tool-policy-match.ts
+++ b/src/agents/tool-policy-match.ts
@@ -7,7 +7,10 @@ import type { SandboxToolPolicy } from "./sandbox/types.js";
 import { readToolAllowlistIntersection } from "./tool-policy-shared.js";
 import { expandToolGroups, normalizeToolPolicyName } from "./tool-policy.js";
 
-function makeToolPolicyMatcher(policy: SandboxToolPolicy) {
+function makeToolPolicyMatcher(
+  policy: SandboxToolPolicy,
+  options: { writeAllowsApplyPatch: boolean },
+) {
   const deny = compileGlobPatterns({
     raw: expandToolGroups(policy.deny ?? []),
     normalize: normalizeToolPolicyName,
@@ -27,9 +30,13 @@ function makeToolPolicyMatcher(policy: SandboxToolPolicy) {
     if (matchesAnyGlobPattern(normalized, allow)) {
       return true;
     }
-    // `apply_patch` is the concrete write tool, so a broad write allowlist entry
-    // should cover it even though its tool name is more specific.
-    if (normalized === "apply_patch" && matchesAnyGlobPattern("write", allow)) {
+    // Sandbox config historically treats `write` as covering `apply_patch`.
+    // Per-run caps disable that compatibility so explicit tool grants stay exact.
+    if (
+      options.writeAllowsApplyPatch &&
+      normalized === "apply_patch" &&
+      matchesAnyGlobPattern("write", allow)
+    ) {
       return true;
     }
     return false;
@@ -41,7 +48,7 @@ export function isToolAllowedByPolicyName(name: string, policy?: SandboxToolPoli
   if (!policy) {
     return true;
   }
-  return makeToolPolicyMatcher(policy)(name);
+  return makeToolPolicyMatcher(policy, { writeAllowsApplyPatch: true })(name);
 }
 
 /** Runtime caps deny empty lists and preserve every independently merged restriction. */
@@ -49,7 +56,9 @@ export function isRuntimeToolAllowed(name: string, toolsAllow?: string[]): boole
   return (
     toolsAllow === undefined ||
     (readToolAllowlistIntersection(toolsAllow) ?? [toolsAllow]).every(
-      (allow) => allow.length > 0 && isToolAllowedByPolicyName(name, { allow }),
+      (allow) =>
+        allow.length > 0 &&
+        makeToolPolicyMatcher({ allow }, { writeAllowsApplyPatch: false })(name),
     )
   );
 }

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -7,7 +7,11 @@ import type { OpenClawConfig } from "../config/config.js";
 import { pickSandboxToolPolicy } from "./sandbox-tool-policy.js";
 import { isToolAllowed, resolveSandboxToolPolicyForAgent } from "./sandbox/tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
-import { isRuntimeToolAllowed, isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import {
+  isRuntimeToolAllowed,
+  isRuntimeToolAllowedForConstruction,
+  isToolAllowedByPolicyName,
+} from "./tool-policy-match.js";
 import {
   collectExplicitAllowlist,
   DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
@@ -212,8 +216,9 @@ describe("isToolAllowedByPolicyName — apply_patch / write deny decoupling (#76
     );
   });
 
-  it("keeps per-run write caps distinct from explicit apply_patch access", () => {
-    expect(isRuntimeToolAllowed("apply_patch", ["write"])).toBe(false);
+  it("keeps runtime write compatibility out of construction planning", () => {
+    expect(isRuntimeToolAllowed("apply_patch", ["write"])).toBe(true);
+    expect(isRuntimeToolAllowedForConstruction("apply_patch", ["write"])).toBe(false);
     expect(isRuntimeToolAllowed("apply_patch", ["apply-patch"])).toBe(true);
     expect(isRuntimeToolAllowed("apply_patch", ["apply_*"])).toBe(true);
     expect(isRuntimeToolAllowed("apply_patch", ["group:fs"])).toBe(true);

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -7,7 +7,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { pickSandboxToolPolicy } from "./sandbox-tool-policy.js";
 import { isToolAllowed, resolveSandboxToolPolicyForAgent } from "./sandbox/tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
-import { isToolAllowedByPolicyName } from "./tool-policy-match.js";
+import { isRuntimeToolAllowed, isToolAllowedByPolicyName } from "./tool-policy-match.js";
 import {
   collectExplicitAllowlist,
   DEFAULT_PLUGIN_TOOLS_ALLOWLIST_ENTRY,
@@ -210,5 +210,12 @@ describe("isToolAllowedByPolicyName — apply_patch / write deny decoupling (#76
     expect(isToolAllowedByPolicyName("apply_patch", { deny: ["write", "apply_patch"] })).toBe(
       false,
     );
+  });
+
+  it("keeps per-run write caps distinct from explicit apply_patch access", () => {
+    expect(isRuntimeToolAllowed("apply_patch", ["write"])).toBe(false);
+    expect(isRuntimeToolAllowed("apply_patch", ["apply-patch"])).toBe(true);
+    expect(isRuntimeToolAllowed("apply_patch", ["apply_*"])).toBe(true);
+    expect(isRuntimeToolAllowed("apply_patch", ["group:fs"])).toBe(true);
   });
 });

--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -1825,7 +1825,7 @@ describe("maybeRepairLegacyCronStore", () => {
         payload: {
           kind: "agentTurn",
           message: "Execute ./scripts/check_mail.sh and report changed mailbox counts.",
-          toolsAllow: ["shell"],
+          toolsAllow: ["process"],
         },
         delivery: { mode: "announce" },
       }),

--- a/src/commands/doctor/cron/payload-migration.ts
+++ b/src/commands/doctor/cron/payload-migration.ts
@@ -4,6 +4,12 @@ import {
   normalizeOptionalString,
   readStringValue as readString,
 } from "../../../../packages/normalization-core/src/string-coerce.js";
+import {
+  classifyCronAgentTurnShellPrompt,
+  hasCronShellToolAccess,
+  parseCronAgentTurnCommandPrompt,
+  type CronAgentTurnShellPromptKind,
+} from "../../../cron/agent-turn-command-prompt.js";
 import { toCanonicalOpenAIModelRef } from "../shared/codex-route-model-ref.js";
 import {
   IMAGE_INSPECTION_TOOL_NAME_MIGRATION,
@@ -13,19 +19,6 @@ import {
 
 type UnknownRecord = Record<string, unknown>;
 
-type LegacyAgentTurnCommandPayload = {
-  command: string;
-  cwd?: string;
-  timeoutSeconds?: number;
-};
-
-type UnresolvedAgentTurnShellToolPromptKind = "commandPromptWithoutShellAccess" | "shellToolPrompt";
-
-const LEGACY_AGENT_TURN_COMMAND_MARKER_RE = /\bCommand to run\s*:/iu;
-const LEGACY_AGENT_TURN_COMMAND_FIELD_RE = /^\s*-\s*(command|workdir|timeout)\s*:\s*(.*?)\s*$/iu;
-const SHELL_TOOL_NAMES = new Set(["bash", "command", "exec", "process", "shell", "sh"]);
-const SHELL_COMMAND_MESSAGE_RE =
-  /\b(?:bash|command|execute|exec|process|run|shell)\b[\s\S]{0,240}\b(?:python3?|node|bun|pnpm|npm|npx|yarn|sh|bash|sudo|cd|\.\/|\/[A-Za-z0-9._/-]+)\b/iu;
 const LEGACY_DELIVERY_HINT_FIELDS = [
   "deliver",
   "bestEffortDeliver",
@@ -190,19 +183,6 @@ export function stripLegacyTopLevelFields(raw: UnknownRecord) {
   }
 }
 
-function hasShellToolAccess(toolsAllow: unknown): boolean {
-  if (toolsAllow === undefined) {
-    return true;
-  }
-  if (!Array.isArray(toolsAllow)) {
-    return false;
-  }
-  return toolsAllow.some((tool) => {
-    const normalized = normalizeOptionalLowercaseString(tool);
-    return normalized === "*" || (normalized ? SHELL_TOOL_NAMES.has(normalized) : false);
-  });
-}
-
 type LegacyOpenAICodexCronModelRoute = {
   legacyModelRef: string;
   canonicalModelRef: string;
@@ -249,55 +229,10 @@ function normalizeChannel(value: string): string {
   return normalizeOptionalLowercaseString(value) ?? "";
 }
 
-function parsePositiveInteger(value: string): number | undefined {
-  const trimmed = value.trim();
-  if (!/^\d+$/u.test(trimmed)) {
-    return undefined;
-  }
-  const parsed = Number.parseInt(trimmed, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
-}
-
 function readPositiveInteger(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.floor(value)
     : undefined;
-}
-
-function parseLegacyAgentTurnCommandMessage(message: string): LegacyAgentTurnCommandPayload | null {
-  if (!LEGACY_AGENT_TURN_COMMAND_MARKER_RE.test(message)) {
-    return null;
-  }
-
-  let command = "";
-  let cwd: string | undefined;
-  let timeoutSeconds: number | undefined;
-
-  for (const line of message.split(/\r?\n/u)) {
-    const match = LEGACY_AGENT_TURN_COMMAND_FIELD_RE.exec(line);
-    if (!match) {
-      continue;
-    }
-    const key = match[1]?.toLowerCase();
-    const value = match[2]?.trim() ?? "";
-    if (key === "command" && value && !command) {
-      command = value;
-    } else if (key === "workdir" && value && !cwd) {
-      cwd = value;
-    } else if (key === "timeout" && value && timeoutSeconds === undefined) {
-      timeoutSeconds = parsePositiveInteger(value);
-    }
-  }
-
-  if (!command) {
-    return null;
-  }
-
-  return {
-    command,
-    ...(cwd ? { cwd } : {}),
-    ...(timeoutSeconds ? { timeoutSeconds } : {}),
-  };
 }
 
 /** Return true when a cron payload contains legacy Codex-route model refs. */
@@ -396,11 +331,11 @@ export function migrateLegacyAgentTurnCommandPayload(payload: UnknownRecord): bo
   if (typeof message !== "string") {
     return false;
   }
-  const parsed = parseLegacyAgentTurnCommandMessage(message);
+  const parsed = parseCronAgentTurnCommandPrompt(message);
   if (!parsed) {
     return false;
   }
-  if (!hasShellToolAccess(payload.toolsAllow)) {
+  if (!hasCronShellToolAccess(payload.toolsAllow)) {
     return false;
   }
 
@@ -430,21 +365,6 @@ export function migrateLegacyAgentTurnCommandPayload(payload: UnknownRecord): bo
 
 export function classifyUnresolvedAgentTurnShellToolPrompt(
   payload: UnknownRecord,
-): UnresolvedAgentTurnShellToolPromptKind | null {
-  if (payload.kind !== "agentTurn") {
-    return null;
-  }
-  const message = readString(payload.message);
-  if (typeof message !== "string") {
-    return null;
-  }
-  const parsed = parseLegacyAgentTurnCommandMessage(message);
-  const shellToolAccess = hasShellToolAccess(payload.toolsAllow);
-  if (parsed && !shellToolAccess) {
-    return "commandPromptWithoutShellAccess";
-  }
-  if (shellToolAccess && SHELL_COMMAND_MESSAGE_RE.test(message)) {
-    return "shellToolPrompt";
-  }
-  return null;
+): CronAgentTurnShellPromptKind | null {
+  return classifyCronAgentTurnShellPrompt(payload);
 }

--- a/src/commands/doctor/cron/store-migration.test.ts
+++ b/src/commands/doctor/cron/store-migration.test.ts
@@ -596,7 +596,7 @@ describe("normalizeStoredCronJobs", () => {
             "- If the command prints exactly NO_REPLY, respond exactly NO_REPLY.",
             "- Otherwise return the concise command output.",
           ].join("\n"),
-          toolsAllow: ["bash", "process"],
+          toolsAllow: ["group:runtime"],
           lightContext: true,
           timeoutSeconds: 900,
           model: "openai/gpt-5.5",

--- a/src/cron/agent-turn-command-prompt.ts
+++ b/src/cron/agent-turn-command-prompt.ts
@@ -1,0 +1,95 @@
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
+
+type UnknownRecord = Record<string, unknown>;
+
+export type CronAgentTurnCommandPrompt = {
+  command: string;
+  cwd?: string;
+  timeoutSeconds?: number;
+};
+
+export type CronAgentTurnShellPromptKind = "commandPromptWithoutShellAccess" | "shellToolPrompt";
+
+const COMMAND_MARKER_RE = /\bCommand to run\s*:/iu;
+const COMMAND_FIELD_RE = /^\s*-\s*(command|workdir|timeout)\s*:\s*(.*?)\s*$/iu;
+const SHELL_TOOL_NAMES = new Set(["bash", "command", "exec", "process", "shell", "sh"]);
+const SHELL_COMMAND_MESSAGE_RE =
+  /\b(?:bash|command|execute|exec|process|run|shell)\b[\s\S]{0,240}\b(?:python3?|node|bun|pnpm|npm|npx|yarn|sh|bash|sudo|cd|\.\/|\/[A-Za-z0-9._/-]+)\b/iu;
+
+function parsePositiveInteger(value: string): number | undefined {
+  const trimmed = value.trim();
+  if (!/^\d+$/u.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/** Parses the legacy structured command block used by isolated agent prompts. */
+export function parseCronAgentTurnCommandPrompt(value: unknown): CronAgentTurnCommandPrompt | null {
+  const message = normalizeOptionalString(value);
+  if (!message || !COMMAND_MARKER_RE.test(message)) {
+    return null;
+  }
+
+  let command = "";
+  let cwd: string | undefined;
+  let timeoutSeconds: number | undefined;
+  for (const line of message.split(/\r?\n/u)) {
+    const match = COMMAND_FIELD_RE.exec(line);
+    if (!match) {
+      continue;
+    }
+    const key = match[1]?.toLowerCase();
+    const fieldValue = match[2]?.trim() ?? "";
+    if (key === "command" && fieldValue && !command) {
+      command = fieldValue;
+    } else if (key === "workdir" && fieldValue && !cwd) {
+      cwd = fieldValue;
+    } else if (key === "timeout" && fieldValue && timeoutSeconds === undefined) {
+      timeoutSeconds = parsePositiveInteger(fieldValue);
+    }
+  }
+  return command
+    ? { command, ...(cwd ? { cwd } : {}), ...(timeoutSeconds ? { timeoutSeconds } : {}) }
+    : null;
+}
+
+/** Returns whether an agent-turn cap explicitly permits a shell/process tool. */
+export function hasCronShellToolAccess(toolsAllow: unknown): boolean {
+  if (toolsAllow === undefined) {
+    return true;
+  }
+  if (!Array.isArray(toolsAllow)) {
+    return false;
+  }
+  return toolsAllow.some((tool) => {
+    const normalized = normalizeOptionalLowercaseString(tool);
+    return normalized === "*" || (normalized ? SHELL_TOOL_NAMES.has(normalized) : false);
+  });
+}
+
+/** Classifies only command-like agent turns that need cron operator attention. */
+export function classifyCronAgentTurnShellPrompt(
+  payload: UnknownRecord,
+): CronAgentTurnShellPromptKind | null {
+  if (payload.kind !== "agentTurn") {
+    return null;
+  }
+  const message = normalizeOptionalString(payload.message);
+  if (!message) {
+    return null;
+  }
+  const parsed = parseCronAgentTurnCommandPrompt(message);
+  const shellToolAccess = hasCronShellToolAccess(payload.toolsAllow);
+  if (parsed && !shellToolAccess) {
+    return "commandPromptWithoutShellAccess";
+  }
+  if (shellToolAccess && SHELL_COMMAND_MESSAGE_RE.test(message)) {
+    return "shellToolPrompt";
+  }
+  return null;
+}

--- a/src/cron/agent-turn-command-prompt.ts
+++ b/src/cron/agent-turn-command-prompt.ts
@@ -1,7 +1,5 @@
-import {
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { isRuntimeToolAllowed } from "../agents/tool-policy-match.js";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -15,7 +13,6 @@ export type CronAgentTurnShellPromptKind = "commandPromptWithoutShellAccess" | "
 
 const COMMAND_MARKER_RE = /\bCommand to run\s*:/iu;
 const COMMAND_FIELD_RE = /^\s*-\s*(command|workdir|timeout)\s*:\s*(.*?)\s*$/iu;
-const SHELL_TOOL_NAMES = new Set(["bash", "command", "exec", "process", "shell", "sh"]);
 const SHELL_COMMAND_MESSAGE_RE =
   /\b(?:bash|command|execute|exec|process|run|shell)\b[\s\S]{0,240}\b(?:python3?|node|bun|pnpm|npm|npx|yarn|sh|bash|sudo|cd|\.\/|\/[A-Za-z0-9._/-]+)\b/iu;
 
@@ -66,10 +63,13 @@ export function hasCronShellToolAccess(toolsAllow: unknown): boolean {
   if (!Array.isArray(toolsAllow)) {
     return false;
   }
-  return toolsAllow.some((tool) => {
-    const normalized = normalizeOptionalLowercaseString(tool);
-    return normalized === "*" || (normalized ? SHELL_TOOL_NAMES.has(normalized) : false);
-  });
+  if (!toolsAllow.every((tool): tool is string => typeof tool === "string")) {
+    return false;
+  }
+  if (toolsAllow.some((tool) => tool.trim().length === 0)) {
+    return false;
+  }
+  return isRuntimeToolAllowed("exec", toolsAllow) || isRuntimeToolAllowed("process", toolsAllow);
 }
 
 /** Classifies only command-like agent turns that need cron operator attention. */

--- a/src/cron/isolated-agent/run-command-preflight.ts
+++ b/src/cron/isolated-agent/run-command-preflight.ts
@@ -1,0 +1,28 @@
+import { classifyCronAgentTurnShellPrompt } from "../agent-turn-command-prompt.js";
+import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
+import type { CronStoredJob } from "../types.js";
+import type { RunCronAgentTurnResult } from "./run.types.js";
+
+/** Rejects deterministic command prompts whose stored cap cannot execute them. */
+export function resolveCronCommandPromptPreflight(
+  job: CronStoredJob,
+): RunCronAgentTurnResult | undefined {
+  if (
+    job.payload.kind !== "agentTurn" ||
+    classifyCronAgentTurnShellPrompt(job.payload) !== "commandPromptWithoutShellAccess"
+  ) {
+    return undefined;
+  }
+  const error =
+    `Automation ${job.id} cannot run its requested command because the agent prompt contains ` +
+    'a "Command to run:" block but toolsAllow does not grant shell/process access. ' +
+    `No command was executed. Recreate it as a command automation with ` +
+    '`openclaw automations add ... --command "<shell>"`, or explicitly reauthorize this job ' +
+    `from a trusted operator shell with ` +
+    `\`openclaw automations edit ${job.id} --tools exec,process\`.`;
+  return {
+    status: "error",
+    error,
+    diagnostics: createCronRunDiagnosticsFromError("cron-preflight", error),
+  };
+}

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -34,6 +34,7 @@ import {
   resolveCronModelSelectionOwner,
   resolveCronThinkingSelection,
 } from "./model-selection.js";
+import { resolveCronCommandPromptPreflight } from "./run-command-preflight.js";
 import { resolveCronActiveRuntimeConfig, resolveCronAgentConfig } from "./run-config.js";
 import { buildCurrentConversationContextBlock } from "./run-current-context.js";
 import {
@@ -143,6 +144,10 @@ export async function prepareCronRunContext(params: {
   onLifecycleInterrupt: () => void;
 }): Promise<CronPreparationResult> {
   const { input } = params;
+  const commandPromptPreflight = resolveCronCommandPromptPreflight(input.job);
+  if (commandPromptPreflight) {
+    return { ok: false, result: commandPromptPreflight };
+  }
   const requestedRuntimeCfg = resolveCronActiveRuntimeConfig(input.cfg);
   const requestedAgentId = input.agentId?.trim() || input.job.agentId?.trim();
   const normalizedRequested = requestedAgentId ? normalizeAgentId(requestedAgentId) : undefined;

--- a/src/cron/isolated-agent/run.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run.tools-allow.test.ts
@@ -364,6 +364,24 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
   );
 
   it(
+    "keeps a structured command prompt with wildcard shell access runnable",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      const params = makeParamsWithToolsAllow(["exec*"]);
+      (params.job as { payload: { message: string } }).payload.message = [
+        "Command to run:",
+        "- command: python3 scripts/check_mail.py",
+      ].join("\n");
+
+      const result = await runCronIsolatedAgentTurn(params);
+
+      expect(result.status).toBe("ok");
+      expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+      expect(requireEmbeddedAgentCall().toolsAllow).toEqual(["exec*"]);
+    },
+  );
+
+  it(
     "does not reject an explanatory prompt that only mentions a command",
     { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
     async () => {

--- a/src/cron/isolated-agent/run.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run.tools-allow.test.ts
@@ -286,6 +286,27 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
     },
   );
 
+  it.each([
+    ["a blank tool allowlist entry", [" "]],
+    ["a noncanonical shell pseudo-tool", ["shell"]],
+    ["the patch-only tool", ["apply_patch"]],
+  ])(
+    "does not treat %s as shell access",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async (_label, toolsAllow) => {
+      const params = makeParamsWithToolsAllow(toolsAllow);
+      (params.job as { payload: { message: string } }).payload.message = [
+        "Command to run:",
+        "- command: python3 scripts/check_mail.py",
+      ].join("\n");
+
+      const result = await runCronIsolatedAgentTurn(params);
+
+      expect(result.status).toBe("error");
+      expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+    },
+  );
+
   it(
     "keeps a structured command prompt with explicit shell access runnable",
     { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
@@ -302,6 +323,43 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
       expect(result.status).toBe("ok");
       expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
       expect(requireEmbeddedAgentCall().toolsAllow).toEqual(["exec", "read"]);
+    },
+  );
+
+  it(
+    "keeps a structured command prompt with process access runnable",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      const params = makeParamsWithToolsAllow(["process"]);
+      (params.job as { payload: { message: string } }).payload.message = [
+        "Command to run:",
+        "- command: python3 scripts/check_mail.py",
+      ].join("\n");
+
+      const result = await runCronIsolatedAgentTurn(params);
+
+      expect(result.status).toBe("ok");
+      expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+      expect(requireEmbeddedAgentCall().toolsAllow).toEqual(["process"]);
+    },
+  );
+
+  it(
+    "keeps a structured command prompt with grouped shell access runnable",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      const params = makeParamsWithToolsAllow(["group:runtime"]);
+      (params.job as { payload: { message: string } }).payload.message = [
+        "Command to run:",
+        "- command: python3 scripts/check_mail.py",
+        "- workdir: /srv/openclaw",
+      ].join("\n");
+
+      const result = await runCronIsolatedAgentTurn(params);
+
+      expect(result.status).toBe("ok");
+      expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+      expect(requireEmbeddedAgentCall().toolsAllow).toEqual(["group:runtime"]);
     },
   );
 

--- a/src/cron/isolated-agent/run.tools-allow.test.ts
+++ b/src/cron/isolated-agent/run.tools-allow.test.ts
@@ -258,6 +258,69 @@ describe("runCronIsolatedAgentTurn toolsAllow passthrough", () => {
   );
 
   it(
+    "fails a structured command prompt without shell access before model execution",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      const params = makeParamsWithToolsAllow(["terminal", "node_exec", "node_process"]);
+      (params.job as { payload: { message: string } }).payload.message = [
+        "Command to run:",
+        "- command: python3 scripts/check_mail.py",
+        "- workdir: /srv/openclaw",
+      ].join("\n");
+
+      const result = await runCronIsolatedAgentTurn(params);
+
+      expect(result).toMatchObject({
+        status: "error",
+        admissionDisposition: "rejected",
+        error: expect.stringContaining(
+          "openclaw automations edit tools-allow --tools exec,process",
+        ),
+        diagnostics: {
+          summary: expect.stringContaining("No command was executed"),
+          entries: [expect.objectContaining({ source: "cron-preflight", severity: "error" })],
+        },
+      });
+      expect(runEmbeddedAgentMock).not.toHaveBeenCalled();
+      expect(resolveConfiguredModelRefMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it(
+    "keeps a structured command prompt with explicit shell access runnable",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      const params = makeParamsWithToolsAllow(["exec", "read"]);
+      (params.job as { payload: { message: string } }).payload.message = [
+        "Command to run:",
+        "- command: python3 scripts/check_mail.py",
+        "- workdir: /srv/openclaw",
+      ].join("\n");
+
+      const result = await runCronIsolatedAgentTurn(params);
+
+      expect(result.status).toBe("ok");
+      expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+      expect(requireEmbeddedAgentCall().toolsAllow).toEqual(["exec", "read"]);
+    },
+  );
+
+  it(
+    "does not reject an explanatory prompt that only mentions a command",
+    { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
+    async () => {
+      const params = makeParamsWithToolsAllow(["read", "message"]);
+      (params.job as { payload: { message: string } }).payload.message =
+        "Explain whether the operator should run python3 scripts/check_mail.py.";
+
+      const result = await runCronIsolatedAgentTurn(params);
+
+      expect(result.status).toBe("ok");
+      expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it(
     "adds cron diagnostics when web_search is allowed without a selected provider",
     { timeout: RUN_TOOLS_ALLOW_TIMEOUT_MS },
     async () => {


### PR DESCRIPTION
## Summary

- fail a retained `agentTurn` automation before model execution when its structured `Command to run:` block cannot use any shell/process tool
- persist a structured `cron-preflight` error that names the job, confirms no command ran, and gives exact reauthorization and command-automation repair paths
- move the existing Doctor classifier into the cron owner so Doctor and runtime use one contract
- align construction planning with runtime tool caps so aliases, groups, globs, and attached intersections construct the tool families they can retain without changing existing runtime authority semantics

## Root cause

Doctor already recognized this persisted mismatch, but normal cron execution did not. The model therefore received a command it could not execute and could only narrate the failure. Because cron status deliberately trusts structured terminal evidence rather than assistant prose, the run remained `ok`; failure counters, alerts, CLI, and dashboard all reflected that incorrect status.

The first preflight implementation also interpreted tool names separately from the embedded runner. That rejected valid grouped policies such as `group:runtime`. Reusing the canonical runtime matcher exposed a second existing mismatch: wildcard caps such as `exec*` survived final filtering but construction planning only selected literal factory descriptors, so no shell tool was constructed.

## Why this fix

The preflight is limited to the existing deterministic command-block shape. It does not parse words such as `FAILED`, reinterpret arbitrary assistant output, or change the structured-status invariant. It also does not silently grant shell access or convert a restricted job into a command job, because either action crosses the stored authority boundary. Instead, it fails before spending a model turn and tells the operator how to make that explicit choice.

Shell access and final filtering use the canonical runtime-cap contract. Construction planning applies the same aliases, groups, globs, and independently attached intersections to the canonical descriptor catalog, with one deliberate construction-only distinction: the established `write` → `apply_patch` compatibility does not by itself select the shell factory. This preserves MCP loopback and worker runtime authority while keeping the existing embedded/Copilot write-only surface. The Copilot build-everything glob workaround is removed because the shared planner now owns wildcard construction.

Explicit `exec` or `process` access remains runnable; blank entries, noncanonical pseudo-tools, and patch-only access do not bypass the preflight. Explanatory prompts that merely mention a command remain unchanged.

## Evidence

- red proof on unmodified main: Doctor classified the fixture as `commandPromptWithoutShellAccess`, while normal run preflight returned no diagnostic
- review red proof: `toolsAllow: ["group:runtime"]` was rejected before the canonical matcher was used; the owner-boundary regression now passes
- construction red proof: `toolsAllow: ["exec*"]` survived final filtering but omitted the shell factory; shared construction planning now retains the family
- exact-head CI falsifier: globally removing `write` → `apply_patch` compatibility broke three MCP loopback/worker authority assertions; the corrected split restores that runtime contract and limits compatibility-free matching to factory selection
- malformed-input red proof: a blank allowlist entry failed open before explicit validation; it now fails closed
- `node scripts/run-vitest.mjs src/agents/tool-policy.test.ts src/agents/embedded-agent-runner/run/attempt-tool-construction-plan.test.ts extensions/copilot/src/tool-bridge.test.ts src/cron/isolated-agent/run.tools-allow.test.ts src/commands/doctor/cron/store-migration.test.ts src/commands/doctor/cron/index.test.ts src/gateway/mcp-http.runtime.test.ts src/gateway/worker-environments/worker-tool-authority.test.ts` — 317 tests passed across six shards
- targeted formatting, core Oxlint, and `git diff --check` — passed
- fresh autoreview on the final diff — no accepted or actionable findings
- source-blind CLI/Gateway validation — 5/5 clauses passed; the broken fixture failed in 11 ms without provider/model/session metadata, history retained the structured error, and both negative controls reached the normal provider boundary

The branch is based on canonical main `cad34e612f0`; intervening movement only touched unrelated channel fixtures, gateway/update code, canvas migration, agent transport recovery, security warning paths, OpenShell mirror sync, Copilot BYOK/OAuth code, the agents-list schema type, and channel join introductions. Exact-head hosted checks and ClawSweeper re-review are required before merge.

## Scope

Production delta: +66 lines net. Test delta: +298 lines net. The production growth is the shared classifier owner, isolated-run preflight boundary, and explicit construction-only compatibility seam. No config, protocol, schema, or bundle-boundary change is included.

Related but intentionally separate:

- the agent-tool `toolsAllow: null` behavior tracked by #101349 / #103745; this PR handles retained jobs at execution time and does not change creator-cap semantics
- a follow-up audit of bundle MCP and LSP tool-construction planning for attached intersections and suffix-style globs; those sibling construction surfaces are outside this cron execution path and are not changed here

