### PR TITLE
refactor(gateway): reuse user request validation

### DIFF
--- a/src/gateway/server-methods/users.test.ts
+++ b/src/gateway/server-methods/users.test.ts
@@ -86,6 +86,65 @@ describe("users gateway methods", () => {
     });
   });
 
+  it.each([
+    { method: "users.list", params: {} },
+    { method: "users.self", params: {} },
+    { method: "users.prefs.get", params: { keys: ["ui.theme"] } },
+    { method: "users.prefs.set", params: { entries: { "ui.theme": "claw" } } },
+    {
+      method: "users.linkEmail",
+      params: { email: "ada@example.test", targetProfileId: "profile-1" },
+    },
+    {
+      method: "users.setDisplayName",
+      params: { profileId: "profile-1", displayName: "Ada" },
+    },
+    { method: "users.setRole", params: { profileId: "profile-1", role: null } },
+    {
+      method: "users.setAvatar",
+      params: { profileId: "profile-1", mime: "image/png", avatarBase64: "AQ==" },
+    },
+  ])("rejects malformed $method before reaching user state", async ({ method, params }) => {
+    const invalid = { ...params, unexpected: true };
+    const original = structuredClone(invalid);
+    const unreadableState = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("invalid users request reached owner state");
+        },
+      },
+    );
+
+    const respond = await runUsersHandler(method, invalid, unreadableState, unreadableState);
+
+    expect(respond.mock.calls).toEqual([
+      [
+        false,
+        undefined,
+        {
+          code: "INVALID_REQUEST",
+          message: `invalid ${method} params: at root: unexpected property 'unexpected'`,
+        },
+      ],
+    ]);
+    expect(invalid).toEqual(original);
+    for (const effect of [
+      ensureProfileForEmail,
+      getUserProfileDisplay,
+      getUserProfileListItem,
+      resolveUserProfileId,
+      linkEmail,
+      listProfiles,
+      setAvatar,
+      setDisplayName,
+      setUserProfileRole,
+      invalidateOperatorRolePolicy,
+    ]) {
+      expect(effect).not.toHaveBeenCalled();
+    }
+  });
+
   it("lists profiles through the read method", async () => {
     listProfiles.mockReturnValue([{ id: "profile-1" }]);
 

--- a/src/gateway/server-methods/users.ts
+++ b/src/gateway/server-methods/users.ts
@@ -3,7 +3,6 @@ import {
   ErrorCodes,
   GatewayErrorDetailCodes,
   errorShape,
-  formatValidationErrors,
   validateUsersLinkEmailParams,
   validateUsersListParams,
   validateUsersPrefsGetParams,
@@ -34,6 +33,7 @@ import {
   isGatewayClientProfilePending,
 } from "./gateway-client-identity.js";
 import type { GatewayRequestHandlerOptions, GatewayRequestHandlers } from "./types.js";
+import { assertValidParams } from "./validation.js";
 
 function refreshConnectedProfile(
   context: GatewayRequestHandlerOptions["context"],
@@ -57,13 +57,6 @@ function decodeBase64(value: string): Uint8Array | undefined {
     return undefined;
   }
   return Buffer.from(trimmed, "base64");
-}
-
-function invalidParams(name: string, errors: Parameters<typeof formatValidationErrors>[0]) {
-  return errorShape(
-    ErrorCodes.INVALID_REQUEST,
-    `invalid ${name} params: ${formatValidationErrors(errors)}`,
-  );
 }
 
 function profileError(error: unknown) {
@@ -128,15 +121,13 @@ function requireProfileMutationAccess(
 
 export const usersHandlers: GatewayRequestHandlers = {
   "users.list": ({ params, respond }) => {
-    if (!validateUsersListParams(params)) {
-      respond(false, undefined, invalidParams("users.list", validateUsersListParams.errors));
+    if (!assertValidParams(params, validateUsersListParams, "users.list", respond)) {
       return;
     }
     respond(true, { profiles: listProfiles() });
   },
   "users.self": async ({ client, params, respond }) => {
-    if (!validateUsersSelfParams(params)) {
-      respond(false, undefined, invalidParams("users.self", validateUsersSelfParams.errors));
+    if (!assertValidParams(params, validateUsersSelfParams, "users.self", respond)) {
       return;
     }
     if (!client?.authenticatedUserId) {
@@ -166,12 +157,7 @@ export const usersHandlers: GatewayRequestHandlers = {
     }
   },
   "users.prefs.get": ({ client, params, respond }) => {
-    if (!validateUsersPrefsGetParams(params)) {
-      respond(
-        false,
-        undefined,
-        invalidParams("users.prefs.get", validateUsersPrefsGetParams.errors),
-      );
+    if (!assertValidParams(params, validateUsersPrefsGetParams, "users.prefs.get", respond)) {
       return;
     }
     const profileId = client?.authenticatedUserProfile?.profileId ?? "";
@@ -199,12 +185,7 @@ export const usersHandlers: GatewayRequestHandlers = {
     }
   },
   "users.prefs.set": ({ client, context, params, respond }) => {
-    if (!validateUsersPrefsSetParams(params)) {
-      respond(
-        false,
-        undefined,
-        invalidParams("users.prefs.set", validateUsersPrefsSetParams.errors),
-      );
+    if (!assertValidParams(params, validateUsersPrefsSetParams, "users.prefs.set", respond)) {
       return;
     }
     const profileId = client?.authenticatedUserProfile?.profileId ?? "";
@@ -278,12 +259,7 @@ export const usersHandlers: GatewayRequestHandlers = {
     }
   },
   "users.linkEmail": ({ context, params, respond }) => {
-    if (!validateUsersLinkEmailParams(params)) {
-      respond(
-        false,
-        undefined,
-        invalidParams("users.linkEmail", validateUsersLinkEmailParams.errors),
-      );
+    if (!assertValidParams(params, validateUsersLinkEmailParams, "users.linkEmail", respond)) {
       return;
     }
     const email = params.email.trim();
@@ -300,12 +276,9 @@ export const usersHandlers: GatewayRequestHandlers = {
     }
   },
   "users.setDisplayName": ({ client, context, params, respond }) => {
-    if (!validateUsersSetDisplayNameParams(params)) {
-      respond(
-        false,
-        undefined,
-        invalidParams("users.setDisplayName", validateUsersSetDisplayNameParams.errors),
-      );
+    if (
+      !assertValidParams(params, validateUsersSetDisplayNameParams, "users.setDisplayName", respond)
+    ) {
       return;
     }
     try {
@@ -320,8 +293,7 @@ export const usersHandlers: GatewayRequestHandlers = {
     }
   },
   "users.setRole": ({ context, params, respond }) => {
-    if (!validateUsersSetRoleParams(params)) {
-      respond(false, undefined, invalidParams("users.setRole", validateUsersSetRoleParams.errors));
+    if (!assertValidParams(params, validateUsersSetRoleParams, "users.setRole", respond)) {
       return;
     }
     const roleDefinitions = context.getRuntimeConfig().gateway?.roles?.definitions;
@@ -349,12 +321,7 @@ export const usersHandlers: GatewayRequestHandlers = {
     }
   },
   "users.setAvatar": ({ client, context, params, respond }) => {
-    if (!validateUsersSetAvatarParams(params)) {
-      respond(
-        false,
-        undefined,
-        invalidParams("users.setAvatar", validateUsersSetAvatarParams.errors),
-      );
+    if (!assertValidParams(params, validateUsersSetAvatarParams, "users.setAvatar", respond)) {
       return;
     }
     const bytes = decodeBase64(params.avatarBase64);


### PR DESCRIPTION
## What Problem This Solves

The user-profile RPC owner duplicates the gateway's standard request-validation and error-response path across eight methods. Keeping that extra copy makes an otherwise shared protocol contract harder to maintain.

Production LOC: +11/-44 (net -33). Tests: +59/-0.

## Why This Change Was Made

Use the existing `assertValidParams` helper and remove the private error formatter. Keep the same validators, original params object, method-specific error text, synchronous rejection, and three-argument error response. All handler bodies after validation remain unchanged, including identity resolution, profile permissions, role invalidation, avatar handling, preference quotas, merging, and broadcasts.

The new table in the existing users suite exercises malformed requests for all eight methods and verifies exact errors, unchanged params, and no owner-state access. No new production abstraction, configuration, schema, SDK surface, or compatibility path is introduced.

## User Impact

No user-visible behavior change. This is a behavior-preserving internal cleanup. Preference synchronization work in #130587 remains separate; this patch preserves the current preference implementation and tests.

## Evidence

- Clean Linux proof with Node 24.19.0, pnpm 11.22.0, Vitest 4.1.11, TypeBox 1.3.16, and the other lockfile-pinned dependencies.
- The same four suites passed on the unchanged production owner with the new tests, then on the candidate: **44 tests each** (`users.test.ts`, `users-preferences.test.ts`, `validation.test.ts`, and `schema/users-prefs.test.ts`).
- Both versions passed real in-process router and SQLite checks: all eight malformed errors, scope-before-schema and pending-identity-before-schema ordering, self-scoped preferences and broadcasts, cross-profile edit denial, and merged preferences surviving database reopen.
- Both versions passed real production Gateway listener/client requests over loopback WebSockets, including the eight malformed methods, scope denial, profile listing, missing-identity outcomes, and a durable admin edit. This used disposable state, loopback `auth: none`, and the supported deferred-sidecar startup option—not mocked handlers, an external provider, or a production account.
- Full canonical changed gate passed, including core and all core-test typechecks, changed-file typed lint, dead-export scans, and architecture/storage guards: `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --base dd005e53866fc557c91ae1eebcc0e0888d79670b --staged`.
- Full inventories of 34,274 tracked files matched before and after each phase. Independent precommit review found no actionable findings. The remote worktree was removed and the test machine stopped.

Source identity came from an exact Git base plus a hash-sealed patch and full tracked inventories. The caller requested `--no-sync`; the delegated wrapper reported a targeted sync, so the proof does not rely on a wrapper-sync claim. Hydrated dependency reuse was rejected and a fresh frozen install ran in the owned remote worktree. A 4 GiB heap cap applied only to the standalone flow processes, not the full changed gate.

Proof archive SHA-256: `fc8e758af2d3bf5c01acf7f2e34ea7e719b59958014e41cfadf22cda7ab1425d`. Hosted exact-head CI and the native landing checks are separate publication gates.
