### PR TITLE
refactor(agents): derive list entry type from output schema

### DIFF
--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -3,7 +3,7 @@
  *
  * Lists configured or allowed agent ids plus model/runtime metadata for subagent spawn decisions.
  */
-import { Type } from "typebox";
+import { Type, type Static } from "typebox";
 import { getRuntimeConfig } from "../../config/config.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { resolveModelAgentRuntimeMetadata } from "../agent-runtime-metadata.js";
@@ -55,24 +55,7 @@ const AgentsListOutputSchema = Type.Object(
   { additionalProperties: false },
 );
 
-type AgentListEntry = {
-  id: string;
-  name?: string;
-  configured: boolean;
-  model?: string;
-  agentRuntime?: {
-    id: string;
-    source:
-      | "env"
-      | "agent"
-      | "defaults"
-      | "model"
-      | "provider"
-      | "implicit"
-      | "session"
-      | "session-key";
-  };
-};
+type AgentListEntry = Static<typeof AgentsListOutputSchema>["agents"][number];
 
 export function createAgentsListTool(opts?: {
   agentSessionKey?: string;


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup: maintaining the `agents_list` result shape currently requires keeping a private TypeScript declaration synchronized with the tool's existing output schema. The two declarations describe the same contract and can drift independently.

## Why This Change Was Made

Derive the private `AgentListEntry` type directly from the same-file `AgentsListOutputSchema` using TypeBox `Static`. This removes the duplicate declaration without exporting a new type or changing the schema or execution path.

Production LOC: **+2/-19 (net -17)**. Tests: **+0/-0**. AI-assisted; independent Codex precommit review reported no findings.

## User Impact

No user-visible behavior change. Agent visibility, ordering, model/runtime metadata, tool descriptions, defaults, and emitted schemas remain unchanged. No public SDK surface is edited.

## Evidence

Clean-machine Linux proof on Node 24.19.0 with a fresh frozen pnpm 11.22.0 install, TypeBox 1.3.16, TypeScript 6.0.3, and Vitest 4.1.11. The [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33076858891) executed the candidate based on `1cbcf141ed1e77516ad30eee16a1cbe8cbeafe11`; the command completed with exit 0. This proof is not a claim about subsequent PR-head CI.

- The same 20 existing tests passed before and after the change, covering the tool, its assembled registration, and the shared subagent target policy:

  ```sh
  node scripts/run-vitest.mjs src/agents/tools/agents-list-tool.test.ts src/agents/openclaw-tools.agents.test.ts src/agents/subagents/spawn/subagent-target-policy.test.ts
  ```

- All 27 canonical changed checks passed, including core/core-test typechecks, lint, dead-export scans, and architecture guards:

  ```sh
  node scripts/check-changed.mjs --base 1cbcf141ed1e77516ad30eee16a1cbe8cbeafe11 --staged --timed
  ```

- A strict TypeScript probe verified exact type identity, bidirectional assignment, and 92 fixtures across both `exactOptionalPropertyTypes` settings against the actual pinned TypeBox package. Emitted JavaScript and the factory's isolated raw declaration output were byte-identical. The declaration check was not a full SDK declaration build.
- Real factory/`execute` calls with the real configuration owner and synthetic in-process configuration produced identical schema hashes and payloads for default requester, filtered allowlist, wildcard ordering, and explicit requester override. This was not a gateway or authenticated provider/channel test.

The first Linux install attempt stopped before baseline tests because the package manager changed only the CLI entrypoint's permission mode from 0775 to 0755; its contents were identical. Retrying in a fresh private clone with standard umask 022 preserved the strict source checks and passed. An earlier local full-gate attempt used stale shared dependency types; the successful Linux run used the pinned dependencies above.

The successful run checked all 34,274 tracked files before/after the relevant phases. Its complete terminal reports were retained, and independently reconstructing the expected Linux inventory from the pinned Git blobs plus the sole candidate file reproduced the recorded inventory digest exactly. The lease was already shut down when artifact collection resumed: raw remote artifact files were not downloaded, and individual clone/store/harness directory deletions were not observed. Provider shutdown was verified; no active lease remains.
