### PR TITLE
feat(configure): surface the trusted-proxy loopback opt-in with its warning

### DIFF
--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -34,6 +34,12 @@ Selecting `gateway`, `daemon`, or `health` (or running the full wizard with no `
 `openclaw configure` requires an interactive terminal (both stdin and stdout must be TTYs). Without one it prints the equivalent non-interactive `openclaw config get|set|patch|validate` commands and exits with an error instead of partially running.
 </Note>
 
+## Gateway section
+
+For **Trusted Proxy** auth, entering a loopback proxy address shows a security warning and asks for explicit consent before setting `gateway.auth.trustedProxy.allowLoopback`. Declining leaves it unset and warns that loopback proxy requests will be rejected at runtime. See [Trusted proxy auth](/gateway/trusted-proxy-auth#configure-with-the-wizard) for the trust requirements.
+
+Reconfiguring trusted-proxy mode defaults the loopback prompt to the existing opt-in and preserves `deviceAutoApprove` unchanged. An explicit refusal revokes loopback consent; without a loopback address, the existing setting is retained.
+
 ## Model section
 
 <Note>

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -37,7 +37,7 @@ read_when:
     Proxy adds a header with the authenticated user identity (e.g., `x-forwarded-user: nick@example.com`).
   </Step>
   <Step title="Gateway verifies trusted source">
-    OpenClaw checks that the request came from a **trusted proxy IP** (`gateway.trustedProxies`) and is not the Gateway's own loopback or local interface address.
+    OpenClaw checks that the request came from a **trusted proxy IP** (`gateway.trustedProxies`). Loopback sources require explicit `allowLoopback` consent; other Gateway-local interface addresses are rejected.
   </Step>
   <Step title="Gateway extracts identity">
     OpenClaw reads the required headers, then the user identity from the configured header.
@@ -135,8 +135,14 @@ Internal Gateway clients that do not travel through the reverse proxy should use
 </ParamField>
 
 <Warning>
-Only enable `allowLoopback` when the local reverse proxy is the intended trust boundary. Any local process that can connect to the Gateway can try to send proxy identity headers, so keep direct Gateway access private to the host and require proxy-owned headers such as `x-forwarded-proto`, or a signed assertion header where your proxy supports one.
+Any local process that can connect to the Gateway can impersonate a loopback reverse proxy by sending identity headers. Only enable `allowLoopback` when the reverse proxy is the sole local listener for incoming user traffic, direct Gateway access is locked down, and you trust local processes. The proxy must authenticate users and strip or overwrite client-supplied identity headers; required headers alone do not distinguish the proxy from another local process.
 </Warning>
+
+### Configure with the wizard
+
+Run `openclaw configure --section gateway` and select **Trusted Proxy**. Entering a loopback proxy address (including a CIDR with a loopback base address) shows the security warning above and asks whether to allow loopback authentication. The default is **No** for a new configuration. **Yes** saves `gateway.auth.trustedProxy.allowLoopback: true`; **No** leaves it unset and warns that loopback proxy requests will fail with `trusted_proxy_loopback_source`, with a link back to this page.
+
+When reconfiguring an existing trusted-proxy setup, the prompt defaults to the existing `allowLoopback` opt-in. Choosing **No** revokes it. If no entered proxy address is loopback, the wizard leaves the existing value unchanged. Same-mode reconfiguration also preserves `deviceAutoApprove` verbatim; device enrollment policy is not changed by this prompt. Switching from another auth mode does not restore dormant trusted-proxy opt-ins.
 
 ## Per-identity scope grants
 

--- a/src/commands/configure.gateway-auth.ts
+++ b/src/commands/configure.gateway-auth.ts
@@ -171,11 +171,7 @@ export function buildGatewayAuthConfig(params: {
   mode: GatewayAuthChoice;
   token?: SecretInput;
   password?: string;
-  trustedProxy?: {
-    userHeader: string;
-    requiredHeaders?: string[];
-    allowUsers?: string[];
-  };
+  trustedProxy?: GatewayAuthConfig["trustedProxy"];
 }): GatewayAuthConfig | undefined {
   const base: GatewayAuthConfig = { ...params.existing };
   delete base.token;

--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -91,7 +91,6 @@ async function runTrustedProxyPrompt(params: {
   return runGatewayPrompt({
     ...params,
     selectQueue: ["loopback", "trusted-proxy", params.tailscaleMode ?? "off"],
-    textQueue: params.textQueue,
   });
 }
 
@@ -437,29 +436,20 @@ describe("promptGatewayConfig", () => {
   });
 
   it("stores gateway token as SecretRef when token source is ref", async () => {
-    const previous = process.env.OPENCLAW_GATEWAY_TOKEN;
-    process.env.OPENCLAW_GATEWAY_TOKEN = "env-gateway-token";
-    try {
-      const result = await runGatewayPrompt({
-        selectQueue: ["loopback", "token", "off", "ref"],
-        textQueue: ["18789", "OPENCLAW_GATEWAY_TOKEN"],
-      });
+    vi.stubEnv("OPENCLAW_GATEWAY_TOKEN", "env-gateway-token");
+    const result = await runGatewayPrompt({
+      selectQueue: ["loopback", "token", "off", "ref"],
+      textQueue: ["18789", "OPENCLAW_GATEWAY_TOKEN"],
+    });
 
-      expect(result.config.gateway?.auth).toEqual({
-        mode: "token",
-        token: {
-          source: "env",
-          provider: "default",
-          id: "OPENCLAW_GATEWAY_TOKEN",
-        },
-      });
-      expect(result.token).toBeUndefined();
-    } finally {
-      if (previous === undefined) {
-        delete process.env.OPENCLAW_GATEWAY_TOKEN;
-      } else {
-        process.env.OPENCLAW_GATEWAY_TOKEN = previous;
-      }
-    }
+    expect(result.config.gateway?.auth).toEqual({
+      mode: "token",
+      token: {
+        source: "env",
+        provider: "default",
+        id: "OPENCLAW_GATEWAY_TOKEN",
+      },
+    });
+    expect(result.token).toBeUndefined();
   });
 });

--- a/src/commands/configure.gateway.test.ts
+++ b/src/commands/configure.gateway.test.ts
@@ -1,6 +1,9 @@
 // Configure gateway tests cover interactive gateway auth, port, bind, and remote settings.
-import { describe, expect, it, vi } from "vitest";
+import { IncomingMessage } from "node:http";
+import { Socket } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { authorizeHttpGatewayConnect, resolveGatewayAuth } from "../gateway/auth.js";
 import type { RuntimeEnv } from "../runtime.js";
 
 const mocks = vi.hoisted(() => ({
@@ -75,18 +78,43 @@ async function runGatewayPrompt(params: {
   mocks.text.mockImplementation(async () => params.textQueue.shift());
   mocks.password.mockImplementation(async () => params.textQueue.shift());
   mocks.randomToken.mockReturnValue(params.randomToken ?? "generated-token");
-  mocks.confirm.mockResolvedValue(params.confirmResult ?? true);
+  mocks.confirm.mockImplementation(async (input) => params.confirmResult ?? input.initialValue);
   return promptGatewayConfig(params.baseConfig ?? {}, makeRuntime());
 }
 
 async function runTrustedProxyPrompt(params: {
   textQueue: Array<string | undefined>;
   tailscaleMode?: "off" | "serve";
+  baseConfig?: OpenClawConfig;
+  confirmResult?: boolean;
 }) {
   return runGatewayPrompt({
+    ...params,
     selectQueue: ["loopback", "trusted-proxy", params.tailscaleMode ?? "off"],
     textQueue: params.textQueue,
   });
+}
+
+afterEach(() => vi.unstubAllEnvs());
+
+async function authorizeConfiguredProxy(config: OpenClawConfig, remoteAddress = "127.0.0.1") {
+  const req = new IncomingMessage(new Socket());
+  Object.defineProperty(req.socket, "remoteAddress", { value: remoteAddress });
+  req.headers = {
+    host: "localhost",
+    "x-forwarded-for": "203.0.113.10",
+    "x-forwarded-user": "operator@example.test",
+    "x-forwarded-proto": "https",
+  };
+  try {
+    return await authorizeHttpGatewayConnect({
+      auth: resolveGatewayAuth({ authConfig: config.gateway?.auth, env: {} }),
+      trustedProxies: config.gateway?.trustedProxies,
+      req,
+    });
+  } finally {
+    req.destroy();
+  }
 }
 
 describe("promptGatewayConfig", () => {
@@ -181,6 +209,152 @@ describe("promptGatewayConfig", () => {
     });
     expect(result.config.gateway?.bind).toBe("loopback");
     expect(result.config.gateway?.trustedProxies).toEqual(["10.0.0.1"]);
+    expect(mocks.confirm).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["127.0.0.1", "127.0.0.1"],
+    ["127.0.0.2", "127.0.0.2"],
+    ["::1", "::1"],
+    ["::ffff:127.0.0.1", "::ffff:127.0.0.1"],
+    ["10.0.0.1, 127.0.0.1", "127.0.0.1"],
+    ["127.0.0.0/8", "127.0.0.1"],
+    ["::1/128", "::1"],
+  ])("accepts runtime auth after consent for loopback proxy %s", async (proxies, remoteAddress) => {
+    vi.stubEnv("OPENCLAW_LOCALE", "en");
+    const result = await runTrustedProxyPrompt({
+      textQueue: ["18789", "x-forwarded-user", "x-forwarded-proto", "", proxies],
+      confirmResult: true,
+    });
+    expect(result.config.gateway?.auth?.trustedProxy?.allowLoopback).toBe(true);
+    expect(mocks.confirm).toHaveBeenCalledWith(expect.objectContaining({ initialValue: false }));
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("Any local process"),
+      expect.any(String),
+    );
+    expect(await authorizeConfiguredProxy(result.config, remoteAddress)).toEqual({
+      ok: true,
+      method: "trusted-proxy",
+      user: "operator@example.test",
+    });
+  });
+
+  it.each([
+    ["en", "Any local process", "Allow loopback", "will be rejected"],
+    ["zh-CN", "任何本地进程", "允许回环", "将被拒绝"],
+    ["zh-TW", "任何本機程序", "允許回環", "將被拒絕"],
+  ])(
+    "warns before and after refusing loopback consent in %s",
+    async (locale, warning, prompt, refusal) => {
+      vi.stubEnv("OPENCLAW_LOCALE", locale);
+      const result = await runTrustedProxyPrompt({
+        textQueue: ["18789", "x-forwarded-user", "", "", "127.0.0.1"],
+        confirmResult: false,
+      });
+      expect(result.config.gateway?.auth?.trustedProxy?.allowLoopback).toBeUndefined();
+      expect(mocks.note).toHaveBeenCalledWith(expect.stringContaining(warning), expect.any(String));
+      expect(mocks.confirm).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining(prompt), initialValue: false }),
+      );
+      const refusalMessage = mocks.note.mock.calls.at(-1)?.[0];
+      expect(refusalMessage).toContain(refusal);
+      expect(refusalMessage).toContain("trusted_proxy_loopback_source");
+      expect(refusalMessage).toContain("https://docs.openclaw.ai/gateway/trusted-proxy-auth");
+      expect(await authorizeConfiguredProxy(result.config)).toMatchObject({
+        ok: false,
+        reason: "trusted_proxy_loopback_source",
+      });
+    },
+  );
+
+  it.each([
+    { proxies: "127.0.0.1", answer: undefined, expected: true },
+    { proxies: "127.0.0.1", answer: false, expected: undefined },
+    { proxies: "10.0.0.1", answer: undefined, expected: true },
+  ])(
+    "preserves or explicitly revokes loopback consent on rerun: $proxies/$answer",
+    async ({ proxies, answer, expected }) => {
+      const baseConfig: OpenClawConfig = {
+        gateway: {
+          auth: {
+            mode: "trusted-proxy",
+            trustedProxy: {
+              userHeader: "x-old-user",
+              allowLoopback: true,
+              deviceAutoApprove: { enabled: true, scopes: ["operator.read"] },
+            },
+          },
+        },
+      };
+      const original = structuredClone(baseConfig);
+      const result = await runTrustedProxyPrompt({
+        baseConfig,
+        textQueue: ["18789", "x-forwarded-user", "", "", proxies],
+        confirmResult: answer,
+      });
+      expect(result.config.gateway?.auth?.trustedProxy).toEqual({
+        userHeader: "x-forwarded-user",
+        allowLoopback: expected,
+        deviceAutoApprove: { enabled: true, scopes: ["operator.read"] },
+      });
+      expect(baseConfig).toEqual(original);
+      if (proxies === "127.0.0.1") {
+        expect(mocks.confirm).toHaveBeenCalledWith(expect.objectContaining({ initialValue: true }));
+      } else {
+        expect(mocks.confirm).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it.each([{ enabled: false, scopes: [] }, { enabled: true }, {}])(
+    "preserves unprompted device enrollment policy %j",
+    async (deviceAutoApprove) => {
+      const result = await runTrustedProxyPrompt({
+        baseConfig: {
+          gateway: {
+            auth: {
+              mode: "trusted-proxy",
+              trustedProxy: {
+                userHeader: "x-forwarded-user",
+                allowLoopback: false,
+                deviceAutoApprove,
+              },
+            },
+          },
+        },
+        textQueue: ["18789", "x-forwarded-user", "", "", "10.0.0.1"],
+      });
+      expect(result.config.gateway?.auth?.trustedProxy).toEqual({
+        userHeader: "x-forwarded-user",
+        allowLoopback: false,
+        deviceAutoApprove,
+      });
+      expect(mocks.confirm).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not revive dormant trusted-proxy consent when switching modes", async () => {
+    const result = await runTrustedProxyPrompt({
+      baseConfig: {
+        gateway: {
+          auth: {
+            mode: "password",
+            password: "old-password",
+            trustedProxy: {
+              userHeader: "x-old-user",
+              allowLoopback: true,
+              deviceAutoApprove: { enabled: true },
+            },
+          },
+        },
+      },
+      textQueue: ["18789", "x-forwarded-user", "", "", "127.0.0.1"],
+    });
+    expect(mocks.confirm).toHaveBeenCalledWith(expect.objectContaining({ initialValue: false }));
+    expect(result.config.gateway?.auth).toEqual({
+      mode: "trusted-proxy",
+      trustedProxy: { userHeader: "x-forwarded-user" },
+    });
   });
 
   it("forces tailscale off when trusted-proxy is selected", async () => {

--- a/src/commands/configure.gateway.ts
+++ b/src/commands/configure.gateway.ts
@@ -9,6 +9,7 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { formatPortRangeHint } from "../cli/error-format.js";
 import { parsePort } from "../cli/shared/parse-port.js";
 import { resolveGatewayPort } from "../config/config.js";
+import type { GatewayTrustedProxyConfig } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isValidEnvSecretRefId, type SecretInput } from "../config/types.secrets.js";
 import {
@@ -17,11 +18,13 @@ import {
   TAILSCALE_EXPOSURE_OPTIONS,
   TAILSCALE_MISSING_BIN_NOTE_LINES,
 } from "../gateway/gateway-config-prompts.shared.js";
+import { isLoopbackAddress } from "../gateway/net.js";
 import { findTailscaleBinary } from "../infra/tailscale.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveDefaultSecretProviderAlias } from "../secrets/ref-contract.js";
+import { t } from "../wizard/i18n/index.js";
 import { buildGatewayAuthConfig } from "./configure.gateway-auth.js";
-import { password, select, text } from "./configure.shared.js";
+import { confirm, password, select, text } from "./configure.shared.js";
 import {
   guardCancel,
   normalizeGatewayTokenInput,
@@ -160,7 +163,7 @@ export async function promptGatewayConfig(
   }
 
   // trusted-proxy + loopback is valid when the reverse proxy runs on the same
-  // host (e.g. cloudflared, nginx, Caddy). trustedProxies must include 127.0.0.1.
+  // host, with the loopback source in trustedProxies and allowLoopback consent.
   if (authMode === "trusted-proxy" && tailscaleMode !== "off") {
     note(
       "Trusted proxy auth is incompatible with Tailscale serve/funnel. Disabling Tailscale.",
@@ -172,9 +175,7 @@ export async function promptGatewayConfig(
   let gatewayToken: SecretInput | undefined;
   let gatewayTokenForCalls: string | undefined;
   let gatewayPassword: string | undefined;
-  let trustedProxyConfig:
-    | { userHeader: string; requiredHeaders?: string[]; allowUsers?: string[] }
-    | undefined;
+  let trustedProxyConfig: GatewayTrustedProxyConfig | undefined;
   let trustedProxies: string[] | undefined;
   let next = cfg;
 
@@ -316,10 +317,34 @@ export async function promptGatewayConfig(
     );
     trustedProxies = normalizeStringEntries(trustedProxiesRaw.split(","));
 
+    const existingProxy =
+      cfg.gateway?.auth?.mode === "trusted-proxy" ? cfg.gateway.auth.trustedProxy : undefined;
+    let allowLoopback = existingProxy?.allowLoopback;
+    // Classify CIDR base addresses with the same loopback rules as runtime auth.
+    if (trustedProxies.some((address) => isLoopbackAddress(address.split("/")[0]))) {
+      const title = t("wizard.gateway.trustedProxyLoopbackTitle");
+      note(t("wizard.gateway.trustedProxyLoopbackWarning"), title);
+      allowLoopback =
+        guardCancel(
+          await confirm({
+            message: t("wizard.gateway.trustedProxyAllowLoopback"),
+            initialValue: allowLoopback === true,
+          }),
+          runtime,
+          1,
+        ) || undefined;
+      if (!allowLoopback) {
+        note(t("wizard.gateway.trustedProxyLoopbackRefused"), title);
+      }
+    }
+
     trustedProxyConfig = {
+      // Retain unprompted policy, including device enrollment, on same-mode reruns.
+      ...existingProxy,
       userHeader: normalizeOptionalString(userHeader) ?? "",
       requiredHeaders: requiredHeaders.length > 0 ? requiredHeaders : undefined,
       allowUsers: allowUsers.length > 0 ? allowUsers : undefined,
+      allowLoopback,
     };
   }
 

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -97,6 +97,12 @@ export const en = {
       tokenPromptGenerate: "Gateway token (blank to generate)",
       tokenStoreProvisioned:
         "Generated a gateway token and stored it in the OpenClaw secret store as {name}. Config keeps only a reference; inspect it with `openclaw secrets store list`.",
+      trustedProxyAllowLoopback: "Allow loopback trusted-proxy authentication?",
+      trustedProxyLoopbackTitle: "Loopback proxy security warning",
+      trustedProxyLoopbackWarning:
+        "Any local process can impersonate a loopback reverse proxy by sending identity headers to the Gateway.\nOnly enable this when the reverse proxy is the sole local listener for incoming user traffic, direct Gateway access is locked down, and you trust local processes.\nThe proxy must authenticate users and strip or overwrite client-supplied identity headers.",
+      trustedProxyLoopbackRefused:
+        "Loopback proxy requests will be rejected at runtime (trusted_proxy_loopback_source).\nUse a non-loopback proxy address, or rerun gateway configuration and explicitly allow loopback after reviewing the security warning.\nDocs: https://docs.openclaw.ai/gateway/trusted-proxy-auth",
       websocketUrl: "Gateway WebSocket URL",
     },
     gatewayTailscale: {

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -96,6 +96,12 @@ export const zh_CN = {
       tokenPromptGenerate: "Gateway 令牌（留空则生成）",
       tokenStoreProvisioned:
         "已生成 Gateway 令牌并以 {name} 存入 OpenClaw 密钥存储。配置中只保留引用；可用 `openclaw secrets store list` 查看。",
+      trustedProxyAllowLoopback: "允许回环可信代理身份验证？",
+      trustedProxyLoopbackTitle: "回环代理安全警告",
+      trustedProxyLoopbackWarning:
+        "任何本地进程都可以向 Gateway 发送身份标头，冒充回环反向代理。\n仅当反向代理是接收用户流量的唯一本地监听服务、Gateway 的直接访问已受限且你信任本地进程时，才启用此选项。\n代理必须验证用户身份，并移除或覆盖客户端提供的身份标头。",
+      trustedProxyLoopbackRefused:
+        "回环代理请求在运行时将被拒绝（trusted_proxy_loopback_source）。\n请使用非回环代理地址，或重新运行 Gateway 配置，在阅读安全警告后明确允许回环。\n文档：https://docs.openclaw.ai/gateway/trusted-proxy-auth",
       websocketUrl: "Gateway WebSocket URL",
     },
     gatewayTailscale: {

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -96,6 +96,12 @@ export const zh_TW = {
       tokenPromptGenerate: "Gateway 權杖（留空則產生）",
       tokenStoreProvisioned:
         "已產生 Gateway 權杖並以 {name} 存入 OpenClaw 祕密儲存。設定中只保留參照；可用 `openclaw secrets store list` 檢視。",
+      trustedProxyAllowLoopback: "允許回環可信代理驗證？",
+      trustedProxyLoopbackTitle: "回環代理安全警告",
+      trustedProxyLoopbackWarning:
+        "任何本機程序都可以向 Gateway 傳送身分標頭，冒充回環反向代理。\n僅當反向代理是接收使用者流量的唯一本機監聽服務、Gateway 的直接存取已受限且你信任本機程序時，才啟用此選項。\n代理必須驗證使用者身分，並移除或覆寫用戶端提供的身分標頭。",
+      trustedProxyLoopbackRefused:
+        "回環代理請求在執行時將被拒絕（trusted_proxy_loopback_source）。\n請使用非回環代理位址，或重新執行 Gateway 設定，在閱讀安全警告後明確允許回環。\n文件：https://docs.openclaw.ai/gateway/trusted-proxy-auth",
       websocketUrl: "Gateway WebSocket URL",
     },
     gatewayTailscale: {


### PR DESCRIPTION
## What Problem This Solves

The gateway wizard accepted `127.0.0.1` as a trusted-proxy address but never surfaced the required `allowLoopback` opt-in, so the saved configuration was rejected at runtime with `trusted_proxy_loopback_source` (`src/gateway/auth.ts`) — a silent dead-end the docs (`docs/gateway/trusted-proxy-auth.md:95`) only resolve via a manual config edit. Reruns of *working* same-host proxy configs also broke, because the wizard rebuilt the nested block and silently dropped an existing `allowLoopback: true`. Verified in stable v2026.7.1. (Audit finding F-O4; the fix shape — prompt with warning — is the maintainer's explicit product decision.)

## Why This Change Was Made

When the operator enters a loopback trusted-proxy address (classified by the same `isLoopbackAddress` helper runtime auth uses — no new IP parser; loopback literals, mapped IPv6, and loopback-base CIDRs), the wizard shows the security warning (any local process can forge identity headers; enable only when the proxy is the sole local listener) and asks for explicit consent. Consent sets `trustedProxy.allowLoopback: true`; refusal leaves it unset and states the exact runtime rejection with the docs URL. Same-mode reruns default to the existing opt-in (preserved, or revocable with an explicit No); entering trusted-proxy from another mode never revives dormant consent. `deviceAutoApprove` — pairing policy where omitted and empty scopes differ — is preserved verbatim, never reconstructed. Copy localized in en/zh-CN/zh-TW.

Two independent passes preceded landing: a deep-context review confirmed the owner and shape ("best owner and shape"; runtime keeps sole authorization ownership — no bypass for HTTP or WebSocket), and the branch was rebased onto #131035's real-builder test harness with a fresh branch-mode autoreview, keeping main's three-mode preservation matrix byte-for-byte plus all 17 consent cases.

## User Impact

Same-host reverse-proxy setups configured through the wizard now work at runtime with explicit, informed consent — no more silent rejection loop — and reconfiguring never silently drops or revives the loopback opt-in.

## Evidence

- Consent matrix: 17 cases — seven loopback/address forms, three translated refusal flows, three preserve/revoke reruns, three device-enrollment policy shapes, dormant-consent rejection — through the real `promptGatewayConfig` → `buildGatewayAuthConfig` path with live-config write/read proof for revocation.
- Suites green post-rebase (31 gateway tests on head d158c97534d; 68 in the rebase validation); `check-changed` full gates exit 0; Codex autoreview clean three times (implementation, deep review, rebased branch).
- LOC vs main: production +49/−10 (+39, the consent interaction + three locales), tests +164, docs +12.
- Named follow-ups (source-grounded, untouched): trusted-proxy address prompt accepts malformed nonempty IP/CIDR strings; device-autoapproval docs/help drift (`operator.questions` missing from stated defaults; "manual upgrade" claim stale).
