### PR TITLE
test(channels): consolidate command fixtures

### DIFF
--- a/src/commands/channels.resolve.test.ts
+++ b/src/commands/channels.resolve.test.ts
@@ -1,6 +1,6 @@
 // Channels resolve tests cover channel/account selection and command output for message routing.
-import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelResolverAdapter } from "../channels/plugins/types.adapters.js";
 import { channelsResolveCommand } from "./channels/resolve.js";
 
 const mocks = vi.hoisted(() => ({
@@ -50,19 +50,6 @@ vi.mock("./channel-setup/channel-plugin-resolution.js", () => ({
   resolveInstallableChannelPlugin: mocks.resolveInstallableChannelPlugin,
 }));
 
-const requireRecord = createRequireRecord("record", "expected-label");
-
-function requireFirstMockArg(
-  mock: { mock: { calls: unknown[][] } },
-  label: string,
-): Record<string, unknown> {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return requireRecord(call[0], `${label} request`);
-}
-
 describe("channelsResolveCommand", () => {
   const runtime = {
     log: vi.fn(),
@@ -94,7 +81,7 @@ describe("channelsResolveCommand", () => {
       agents: { list: [{ id: "main" }, { id: "ops" }] },
       channels: {},
     });
-    const resolveTargets = vi.fn().mockResolvedValue([
+    const resolveTargets = vi.fn<ChannelResolverAdapter["resolveTargets"]>().mockResolvedValue([
       {
         input: "friends",
         resolved: true,
@@ -123,25 +110,20 @@ describe("channelsResolveCommand", () => {
     );
 
     expect(mocks.resolveInstallableChannelPlugin).toHaveBeenCalledTimes(1);
-    const pluginResolutionRequest = requireFirstMockArg(
-      mocks.resolveInstallableChannelPlugin,
-      "installable channel resolution",
+    expect(mocks.resolveInstallableChannelPlugin).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ agentId: "ops", rawChannel: "whatsapp", allowInstall: false }),
     );
-    const commandSecretRequest = requireFirstMockArg(
-      mocks.resolveCommandSecretRefsViaGateway,
-      "command secret resolution",
+    expect(mocks.resolveCommandSecretRefsViaGateway).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ agentId: "ops" }),
     );
-    expect(commandSecretRequest.agentId).toBe("ops");
-    expect(pluginResolutionRequest.agentId).toBe("ops");
-    expect(pluginResolutionRequest.rawChannel).toBe("whatsapp");
-    expect(pluginResolutionRequest.allowInstall).toBe(false);
     expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
     expect(mocks.refreshPluginRegistryAfterConfigMutation).not.toHaveBeenCalled();
     expect(resolveTargets).toHaveBeenCalledTimes(1);
-    const resolveRequest = requireFirstMockArg(resolveTargets, "target resolution");
-    expect(resolveRequest.cfg).toStrictEqual({ channels: {} });
-    expect(resolveRequest.inputs).toStrictEqual(["friends"]);
-    expect(resolveRequest.kind).toBe("group");
+    expect(resolveTargets.mock.calls[0]?.[0].cfg).toStrictEqual({ channels: {} });
+    expect(resolveTargets.mock.calls[0]?.[0].inputs).toStrictEqual(["friends"]);
+    expect(resolveTargets).toHaveBeenNthCalledWith(1, expect.objectContaining({ kind: "group" }));
     expect(runtime.log).toHaveBeenCalledWith("friends -> 120363000000@g.us (Friends)");
   });
 
@@ -196,7 +178,7 @@ describe("channelsResolveCommand", () => {
       channels: { whatsapp: {} },
       plugins: { allow: ["whatsapp"] },
     };
-    const resolveTargets = vi.fn().mockResolvedValue([
+    const resolveTargets = vi.fn<ChannelResolverAdapter["resolveTargets"]>().mockResolvedValue([
       {
         input: "friends",
         resolved: true,
@@ -235,9 +217,8 @@ describe("channelsResolveCommand", () => {
       channel: null,
     });
     expect(resolveTargets).toHaveBeenCalledTimes(1);
-    const resolveRequest = requireFirstMockArg(resolveTargets, "target resolution");
-    expect(resolveRequest.cfg).toBe(autoEnabledConfig);
-    expect(resolveRequest.inputs).toStrictEqual(["friends"]);
-    expect(resolveRequest.kind).toBe("group");
+    expect(resolveTargets.mock.calls[0]?.[0].cfg).toBe(autoEnabledConfig);
+    expect(resolveTargets.mock.calls[0]?.[0].inputs).toStrictEqual(["friends"]);
+    expect(resolveTargets).toHaveBeenNthCalledWith(1, expect.objectContaining({ kind: "group" }));
   });
 });

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -1,9 +1,8 @@
 // Channels capabilities tests cover capability reporting, account selection, probes, and installable plugins.
-import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getChannelPlugin, listChannelPlugins } from "../../channels/plugins/index.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import { ExpectedCliError } from "../../cli/failure-output.js";
+import type { replaceConfigFile } from "../../config/config.js";
 import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
 import { channelsCapabilitiesCommand } from "./capabilities.js";
 
@@ -12,7 +11,7 @@ const errors: string[] = [];
 const resolveDefaultAccountId = () => DEFAULT_ACCOUNT_ID;
 const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
-  replaceConfigFile: vi.fn(),
+  replaceConfigFile: vi.fn<(params: Parameters<typeof replaceConfigFile>[0]) => Promise<void>>(),
   refreshPluginRegistryAfterConfigMutation: vi.fn(async () => undefined),
   resolveInstallableChannelPlugin: vi.fn(),
   listReadOnlyChannelPluginsForConfig: vi.fn(),
@@ -28,11 +27,6 @@ vi.mock("./shared.js", async () => {
     ),
   };
 });
-
-vi.mock("../../channels/plugins/index.js", () => ({
-  listChannelPlugins: vi.fn(),
-  getChannelPlugin: vi.fn(),
-}));
 
 vi.mock("../../channels/plugins/read-only.js", () => ({
   listReadOnlyChannelPluginsForConfig: mocks.listReadOnlyChannelPluginsForConfig,
@@ -73,27 +67,12 @@ function resetOutput() {
   errors.length = 0;
 }
 
-const requireRecord = createRequireRecord("record", "expected-label");
-
-function requireFirstMockArg(
-  mock: { mock: { calls: unknown[][] } },
-  label: string,
-): Record<string, unknown> {
-  const [call] = mock.mock.calls;
-  if (!call) {
-    throw new Error(`expected ${label} call`);
-  }
-  return requireRecord(call[0], `${label} request`);
-}
-
 function buildPlugin(params: {
   id: string;
   capabilities?: ChannelPlugin["capabilities"];
   account?: Record<string, unknown>;
   probe?: unknown;
 }): ChannelPlugin {
-  const capabilities =
-    params.capabilities ?? ({ chatTypes: ["direct"] } as ChannelPlugin["capabilities"]);
   return {
     id: params.id,
     meta: {
@@ -103,7 +82,7 @@ function buildPlugin(params: {
       docsPath: "/channels/test",
       blurb: "test",
     },
-    capabilities,
+    capabilities: params.capabilities ?? { chatTypes: ["direct"] },
     config: {
       listAccountIds: () => ["default"],
       resolveAccount: () => params.account ?? { accountId: "default" },
@@ -161,8 +140,6 @@ describe("channelsCapabilitiesCommand", () => {
         },
       }),
     };
-    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
-    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
     mocks.resolveInstallableChannelPlugin.mockResolvedValue({
       cfg: { channels: {} },
       channelId: "slack",
@@ -274,8 +251,6 @@ describe("channelsCapabilitiesCommand", () => {
       probe: { ok: true },
     });
     plugin.status = { ...plugin.status, probeAccount };
-    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
-    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
     mocks.resolveInstallableChannelPlugin.mockResolvedValue({
       cfg: { channels: {} },
       channelId: "slack",
@@ -302,8 +277,6 @@ describe("channelsCapabilitiesCommand", () => {
       },
     });
     plugin.status = { probeAccount, buildCapabilitiesDiagnostics };
-    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
-    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
     mocks.resolveInstallableChannelPlugin.mockResolvedValue({
       cfg: { channels: {} },
       channelId: "slack",
@@ -334,8 +307,6 @@ describe("channelsCapabilitiesCommand", () => {
       },
     });
     plugin.status = { probeAccount };
-    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
-    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
     mocks.resolveInstallableChannelPlugin.mockResolvedValue({
       cfg: { channels: {} },
       channelId: "slack",
@@ -370,8 +341,6 @@ describe("channelsCapabilitiesCommand", () => {
       },
     });
     plugin.status = { probeAccount, formatCapabilitiesProbe: () => [] };
-    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
-    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
     mocks.resolveInstallableChannelPlugin.mockResolvedValue({
       cfg: { channels: {} },
       channelId: "telegram",
@@ -400,8 +369,6 @@ describe("channelsCapabilitiesCommand", () => {
       probe: { ok: true },
     });
     plugin.status = { ...plugin.status, buildCapabilitiesDiagnostics };
-    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
-    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
     mocks.resolveInstallableChannelPlugin.mockResolvedValue({
       cfg: { channels: {} },
       channelId: "slack",
@@ -446,8 +413,6 @@ describe("channelsCapabilitiesCommand", () => {
         },
       ],
     };
-    vi.mocked(listChannelPlugins).mockReturnValue([plugin]);
-    vi.mocked(getChannelPlugin).mockReturnValue(plugin);
     mocks.resolveInstallableChannelPlugin.mockResolvedValue({
       cfg: { channels: {} },
       channelId: "msteams",
@@ -487,28 +452,26 @@ describe("channelsCapabilitiesCommand", () => {
       configChanged: true,
       pluginInstalled: true,
     });
-    vi.mocked(listChannelPlugins).mockReturnValue([]);
-    vi.mocked(getChannelPlugin).mockReturnValue(undefined);
 
     await channelsCapabilitiesCommand({ channel: "whatsapp" }, runtime);
 
-    const resolveParams = requireFirstMockArg(
-      mocks.resolveInstallableChannelPlugin,
-      "installable channel resolution",
+    expect(mocks.resolveInstallableChannelPlugin).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ rawChannel: "whatsapp", allowInstall: true }),
     );
-    expect(resolveParams.rawChannel).toBe("whatsapp");
-    expect(resolveParams.allowInstall).toBe(true);
 
-    const replaceParams = requireFirstMockArg(mocks.replaceConfigFile, "config replace");
-    expect(requireRecord(replaceParams.nextConfig, "replace next config").plugins).toStrictEqual({
+    expect(mocks.replaceConfigFile).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ baseHash: "config-1" }),
+    );
+    expect(mocks.replaceConfigFile.mock.calls[0]?.[0].nextConfig.plugins).toStrictEqual({
       entries: { whatsapp: { enabled: true } },
     });
-    expect(replaceParams.baseHash).toBe("config-1");
 
-    const refreshCalls = mocks.refreshPluginRegistryAfterConfigMutation.mock
-      .calls as unknown as Array<[{ reason?: string }]>;
-    const refreshParams = refreshCalls[0]?.[0];
-    expect(refreshParams?.reason).toBe("source-changed");
+    expect(mocks.refreshPluginRegistryAfterConfigMutation).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ reason: "source-changed" }),
+    );
     expect(logs).toStrictEqual([
       [
         "whatsapp:default",


### PR DESCRIPTION
## What Problem This Solves

The channel capability and target-resolution suites carried duplicated record-coercion helpers, unused registry mocks, and untyped callback fixtures around the same command boundaries. That scaffolding obscured the actual request and config assertions without adding behavioral coverage.

## Why This Change Was Made

The tests now use the command owners' existing callback types and Vitest's typed call assertions directly. Redundant registry mocks and local request-unwrapping helpers are removed while every capability, account, install, probe, config-write, and target-resolution case remains.

## User Impact

No production or user-visible behavior changes. The owner tests are smaller and more directly coupled to public command inputs and outputs rather than copied test-only plumbing.

## Evidence

- Unchanged-production baseline: 26/26 owner tests passed.
- Final focused owner and sibling proof: 113/113 passed across 6 files.
- Complete changed-file gate: exit 0; all routed core/core-test types, lint, format, dead-code scans, and guards passed.
- Isolated P0 autoreview: no findings, 0.99 confidence.
- Production LOC: +0/-0. Tests: +30/-86 (net -56); no test cases deleted.
- Local proof used dependency-compatible main ancestor `19d61d9ada04b5b9af24efc444f7bd05c53b82c0`; both touched files are byte-identical on the publication-era main. Exact-head CI and native preparation own current-main integration before landing.

