### PR TITLE
fix(github-copilot): restore usage for domain-aware OAuth profiles

### DIFF
--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -333,6 +333,11 @@ configured default model is never replaced.
     resolves the account-specific API endpoint, and uses the stored GitHub token
     for Copilot requests. You do not need to manage runtime authentication
     manually.
+
+    Usage checks also use the selected profile's GitHub token. For OAuth profiles
+    that carry a tenant domain, usage follows that domain before the provider's
+    configured domain. `COPILOT_GITHUB_DOMAIN` still takes precedence.
+
   </Accordion>
 </AccordionGroup>
 

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -725,12 +725,17 @@ export default definePluginEntry({
       },
       resolveUsageAuth: async (ctx) => await ctx.resolveOAuthToken(),
       fetchUsageSnapshot: async (ctx) => {
+        const source = parseGithubCopilotApiKey(ctx.token);
         const { fetchCopilotUsage } = await loadGithubCopilotRuntime();
         return await fetchCopilotUsage(
-          ctx.token,
+          source.githubToken,
           ctx.timeoutMs,
           ctx.fetchFn,
-          resolveGithubCopilotDomain({ env: ctx.env, config: ctx.config }),
+          resolveGithubCopilotDomain({
+            env: ctx.env,
+            explicit: source.githubDomain,
+            config: ctx.config,
+          }),
         );
       },
     });

--- a/extensions/github-copilot/usage.test.ts
+++ b/extensions/github-copilot/usage.test.ts
@@ -1,0 +1,129 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import type { OpenClawConfig, OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
+import { describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+
+function registerProvider() {
+  const registerProviderMock = vi.fn<OpenClawPluginApi["registerProvider"]>();
+  plugin.register(createTestPluginApi({ registerProvider: registerProviderMock }));
+  return expectDefined(registerProviderMock.mock.calls[0]?.[0], "Copilot provider registration");
+}
+
+describe("GitHub Copilot usage credential routing", () => {
+  it.each([
+    { label: "plain public token", expectedDomain: "github.com" },
+    {
+      label: "plain token with configured tenant",
+      configuredDomain: "config.ghe.com",
+      expectedDomain: "config.ghe.com",
+    },
+    {
+      label: "public OAuth metadata",
+      credentialDomain: "github.com",
+      expectedDomain: "github.com",
+    },
+    {
+      label: "OAuth tenant without provider config",
+      credentialDomain: "account.ghe.com",
+      expectedDomain: "account.ghe.com",
+    },
+    {
+      label: "OAuth tenant before provider config",
+      credentialDomain: "account.ghe.com",
+      configuredDomain: "config.ghe.com",
+      expectedDomain: "account.ghe.com",
+    },
+    {
+      label: "public OAuth before provider config",
+      credentialDomain: "github.com",
+      configuredDomain: "config.ghe.com",
+      expectedDomain: "github.com",
+    },
+    {
+      label: "environment override before OAuth and config",
+      credentialDomain: "account.ghe.com",
+      configuredDomain: "config.ghe.com",
+      envDomain: "override.ghe.com",
+      expectedDomain: "override.ghe.com",
+    },
+  ])("uses the raw token and correct host for $label", async (testCase) => {
+    const provider = registerProvider();
+    const token = testCase.credentialDomain
+      ? expectDefined(
+          provider.formatApiKey,
+          "Copilot OAuth formatter",
+        )({
+          type: "oauth",
+          provider: "github-copilot",
+          refresh: "durable-token",
+          access: "old-access",
+          expires: 0,
+          enterpriseUrl: testCase.credentialDomain,
+        })
+      : "durable-token";
+    const config: OpenClawConfig = testCase.configuredDomain
+      ? {
+          models: {
+            providers: {
+              "github-copilot": {
+                baseUrl: "https://api.githubcopilot.com",
+                models: [],
+                params: { githubDomain: testCase.configuredDomain },
+              },
+            },
+          },
+        }
+      : {};
+    const fetchFn = vi.fn<typeof fetch>(async (input, init) => {
+      const request = new Request(input, init);
+      expect(request.url).toBe(`https://api.${testCase.expectedDomain}/copilot_internal/user`);
+      expect(request.headers.get("authorization")).toBe("token durable-token");
+      return Response.json({
+        copilot_plan: "business",
+        quota_snapshots: { premium_interactions: { percent_remaining: 75 } },
+      });
+    });
+
+    const result = await expectDefined(
+      provider.fetchUsageSnapshot,
+      "Copilot usage hook",
+    )({
+      config,
+      env: testCase.envDomain ? { COPILOT_GITHUB_DOMAIN: testCase.envDomain } : {},
+      provider: "github-copilot",
+      token,
+      timeoutMs: 5000,
+      fetchFn,
+    });
+
+    expect(fetchFn).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({
+      provider: "github-copilot",
+      plan: "business",
+      windows: [{ label: "Premium", usedPercent: 25 }],
+    });
+  });
+
+  it.each([
+    "openclaw-github-copilot-oauth:v1:invalid-json",
+    'openclaw-github-copilot-oauth:v1:{"token":"durable-token","githubDomain":"attacker.example"}',
+  ])("rejects invalid credential metadata before sending a request", async (token) => {
+    const provider = registerProvider();
+    const fetchFn = vi.fn<typeof fetch>();
+    await expect(
+      expectDefined(
+        provider.fetchUsageSnapshot,
+        "Copilot usage hook",
+      )({
+        config: {},
+        env: {},
+        provider: "github-copilot",
+        token,
+        timeoutMs: 5000,
+        fetchFn,
+      }),
+    ).rejects.toThrow("Invalid GitHub Copilot legacy OAuth credential metadata");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #131135

## What Problem This Solves

Fixes an issue where users checking Copilot usage would receive HTTP 401 when their OAuth profile carried domain metadata. Usage could also target the wrong tenant, even though inference already handled the same profile correctly.

## Why This Change Was Made

The Copilot plugin now decodes its existing credential envelope before usage HTTP requests and resolves the host through its existing domain policy: environment override, credential domain, configured domain, then public GitHub. Generic auth storage and usage orchestration remain provider-agnostic; no new configuration, transport wrapper, auth format, or persistence path is introduced.

Production TypeScript: +7/-2 (net +5). The added decode and domain argument repair the missing provider boundary directly; extracting another helper would add an abstraction for these two short hook consumers without removing a policy owner. Tests: +129 lines. Documentation: +5 lines.

## User Impact

Existing OAuth profiles can report Copilot quota using their actual GitHub credential and account domain. Plain-token profiles retain their public/configured-domain routing, and `COPILOT_GITHUB_DOMAIN` retains precedence. Invalid credential envelopes fail before an HTTP request is sent.

This is a current-main regression introduced by #118063, not a claim about a stable release. It is separate from #127287's affected-enterprise inference/policy report, which remains open.

## Evidence

- Before: the real `loadProviderUsageSummary` flow on current main, using one existing public GitHub Copilot account and an isolated in-memory auth store, returned HTTP 200 and two usage windows for a plain token profile, but HTTP 401 and no windows for the same token in an OAuth profile with `enterpriseUrl: "github.com"`. Outbound inspection confirmed the latter sent the metadata envelope as its credential.
- After: the same real usage-summary flow returns HTTP 200 and both usage windows for the OAuth profile and the plain-token control. Outbound inspection confirms that both send exactly the raw GitHub credential. Source hashes were checked before and after both runs; no operator auth/config state was changed.
- Regression: nine registered-provider fetch-boundary cases; seven fail before the fix and two raw-token controls pass. They cover raw and encoded profiles, credential/config/environment domain precedence, malformed metadata, and rejected domains. Tenant cases use deterministic fake fetch; no live enterprise-tenant result is claimed.
- Focused auth, OAuth, domain, model, usage, and plugin tests: 151 passed. Extension production/test typechecks, scoped typed lint, formatting, max-lines/assertion guards, and diff checks pass. Fresh structured P2 review and a separate independent Codex review found no actionable findings. Local checks caught and corrected missing test-helper diagnostic arguments and a shadowed test variable before publication; production behavior was unchanged after live validation.

Dependency contract: GitHub's [REST authentication documentation](https://docs.github.com/en/rest/authentication/authenticating-to-the-rest-api) requires the actual authentication token in `Authorization`; an OpenClaw metadata envelope is not that token. The live before/after check covers the actual Copilot usage endpoint rather than treating general REST documentation as endpoint-specific proof.
