### PR TITLE
fix(openai): restore automatic Code Mode for preferred models

### DIFF
--- a/extensions/openai/openai-dynamic-model.test.ts
+++ b/extensions/openai/openai-dynamic-model.test.ts
@@ -2,9 +2,7 @@ import type {
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
-import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { applyConfiguredProviderOverrides } from "../../src/agents/embedded-agent-runner/model.configured-overrides.js";
 import { buildOpenAIProvider } from "./openai-provider.js";
 
 function modelRegistry(
@@ -179,69 +177,5 @@ describe("OpenAI dynamic model capabilities", () => {
       modelRegistry: modelRegistry([exact]),
     });
     expect(model?.compat).toEqual(exact.compat);
-  });
-
-  it.each(["provider", "model"])("preserves authored %s transport and model overrides", (scope) => {
-    const provider = buildOpenAIProvider();
-    const modelId = "gpt-5.6-luna";
-    const route = { api: "openai-completions", baseUrl: "https://proxy.example/v1" } as const;
-    const providerConfig: ModelProviderConfig = {
-      baseUrl: "https://api.openai.com/v1",
-      ...(scope === "provider" ? route : {}),
-      headers: { "X-Provider-Route": "authored" },
-      models: [
-        {
-          id: modelId,
-          name: "Authored Luna",
-          ...(scope === "model" ? route : {}),
-          headers: { "X-Model-Route": "authored" },
-          compat: { codeMode: "capable", supportsTemperature: true },
-          reasoning: false,
-          input: ["text"],
-          contextWindow: 64_000,
-          maxTokens: 4_000,
-          cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
-        },
-      ],
-    };
-    const config = { models: { providers: { openai: providerConfig } } };
-    const discoveredModel = provider.resolveDynamicModel?.({
-      provider: "openai",
-      modelId,
-      providerConfig,
-      config,
-      modelRegistry: modelRegistry(),
-    });
-    if (!discoveredModel) {
-      throw new Error("expected the OpenAI dynamic model");
-    }
-    const model = applyConfiguredProviderOverrides({
-      provider: "openai",
-      modelId,
-      discoveredModel,
-      providerConfig,
-      cfg: config,
-      manifestAlias: { provider: "openai" },
-      runtimeHooks: {
-        buildProviderUnknownModelHintWithPlugin: ({ context }) =>
-          provider.buildUnknownModelHint?.(context) ?? undefined,
-        prepareProviderDynamicModel: async () => undefined,
-        runProviderDynamicModel: ({ context }) => provider.resolveDynamicModel?.(context),
-        normalizeProviderResolvedModelWithPlugin: ({ context }) =>
-          provider.normalizeResolvedModel?.(context),
-        normalizeProviderTransportWithPlugin: ({ context }) =>
-          provider.normalizeTransport?.(context) ?? undefined,
-      },
-    });
-    expect(model).toMatchObject({
-      ...route,
-      headers: { "X-Provider-Route": "authored", "X-Model-Route": "authored" },
-      compat: { codeMode: "capable", supportsTemperature: true },
-      reasoning: false,
-      input: ["text"],
-      contextWindow: 64_000,
-      maxTokens: 4_000,
-      cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
-    });
   });
 });

--- a/extensions/openai/openai-dynamic-model.test.ts
+++ b/extensions/openai/openai-dynamic-model.test.ts
@@ -1,0 +1,247 @@
+import type {
+  ProviderResolveDynamicModelContext,
+  ProviderRuntimeModel,
+} from "openclaw/plugin-sdk/plugin-entry";
+import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { applyConfiguredProviderOverrides } from "../../src/agents/embedded-agent-runner/model.configured-overrides.js";
+import { buildOpenAIProvider } from "./openai-provider.js";
+
+function modelRegistry(
+  models: ProviderRuntimeModel[] = [],
+): ProviderResolveDynamicModelContext["modelRegistry"] {
+  return {
+    find: (provider, id) => models.find((model) => model.provider === provider && model.id === id),
+    getAll: () => models,
+    getAvailable: () => models,
+    hasConfiguredAuth: () => false,
+  };
+}
+
+const preferredModels = [
+  { id: "gpt-5.6", cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 } },
+  { id: "gpt-5.6-sol", cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 } },
+  { id: "gpt-5.6-terra", cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 3.125 } },
+  { id: "gpt-5.6-luna", cost: { input: 1, output: 6, cacheRead: 0.1, cacheWrite: 1.25 } },
+  { id: "gpt-5.5", cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 } },
+  { id: "gpt-5.5-pro", cost: { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 } },
+];
+
+describe("OpenAI dynamic model capabilities", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it.each(preferredModels)(
+    "retains preferred capabilities for $id without discovery",
+    ({ id, cost }) => {
+      const model = buildOpenAIProvider().resolveDynamicModel?.({
+        provider: "openai",
+        modelId: id,
+        agentRuntimeId: "openclaw",
+        modelRegistry: modelRegistry(),
+      });
+
+      expect(model).toMatchObject({
+        id,
+        provider: "openai",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 1_050_000,
+        contextTokens: 272_000,
+        maxTokens: 128_000,
+        cost,
+        compat: { codeMode: "preferred" },
+      });
+      if (id.startsWith("gpt-5.6")) {
+        expect(model?.thinkingLevelMap).toEqual({ off: "none", xhigh: "xhigh", max: "max" });
+        expect(model?.compat).toMatchObject({
+          supportsReasoningEffort: true,
+          supportsTemperature: false,
+          supportedReasoningEfforts: ["none", "low", "medium", "high", "xhigh", "max"],
+        });
+      } else {
+        expect(model?.mediaInput).toEqual({
+          image: { maxSidePx: 6000, preferredSidePx: 2048, tokenMode: "detail" },
+        });
+      }
+    },
+  );
+
+  it.each([
+    {
+      id: "gpt-5.6-sol",
+      cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+      codeMode: "capable",
+    },
+    {
+      id: "gpt-5.6-terra",
+      cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 3.125 },
+      codeMode: "preferred",
+    },
+    {
+      id: "gpt-5.6-luna",
+      cost: { input: 1, output: 6, cacheRead: 0.1, cacheWrite: 1.25 },
+      codeMode: undefined,
+    },
+  ] as const)("preserves exact registry metadata for $id", ({ id, cost, codeMode }) => {
+    const provider = buildOpenAIProvider();
+    const exactModel: ProviderRuntimeModel = {
+      id,
+      name: id,
+      provider: "openai",
+      api: "openai-completions",
+      baseUrl: "https://proxy.example/v1",
+      headers: { "X-Model-Route": "authored" },
+      reasoning: true,
+      input: ["text", "image"],
+      cost,
+      contextWindow: 1_050_000,
+      contextTokens: 272_000,
+      maxTokens: 128_000,
+      compat: { supportedReasoningEfforts: ["registry-exact"], codeMode },
+    };
+
+    const model = provider.resolveDynamicModel?.({
+      provider: "openai",
+      modelId: id,
+      modelRegistry: modelRegistry([exactModel]),
+    });
+
+    expect(model).toBe(exactModel);
+  });
+
+  it.each(["chat-latest", "gpt-5.4", "gpt-5.4-pro", "gpt-5.4-mini", "gpt-5.4-nano"])(
+    "does not promote unpreferred %s without discovery",
+    (modelId) => {
+      const model = buildOpenAIProvider().resolveDynamicModel?.({
+        provider: "openai",
+        modelId,
+        modelRegistry: modelRegistry(),
+      });
+      expect(model?.id).toBe(modelId);
+      expect(model?.compat?.codeMode).toBeUndefined();
+    },
+  );
+
+  it("does not inherit a different model's Code Mode opt-out", () => {
+    const template: ProviderRuntimeModel = {
+      id: "gpt-5.4",
+      name: "GPT-5.4",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 1_050_000,
+      maxTokens: 128_000,
+      cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+      compat: { codeMode: "capable" },
+    };
+    const model = buildOpenAIProvider().resolveDynamicModel?.({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      modelRegistry: modelRegistry([template]),
+    });
+    expect(model?.compat?.codeMode).toBe("preferred");
+  });
+
+  it("retains the environment-selected endpoint with preferred metadata", () => {
+    vi.stubEnv("OPENAI_BASE_URL", "https://proxy.example/v1");
+    const model = buildOpenAIProvider().resolveDynamicModel?.({
+      provider: "openai",
+      modelId: "gpt-5.6-luna",
+      modelRegistry: modelRegistry(),
+    });
+    expect(model).toMatchObject({
+      baseUrl: "https://proxy.example/v1",
+      compat: { codeMode: "preferred" },
+    });
+  });
+
+  it.each(["capable", undefined] as const)("preserves exact GPT-5.5 compat (%s)", (codeMode) => {
+    const exact: ProviderRuntimeModel = {
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 1_050_000,
+      maxTokens: 128_000,
+      cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+      compat: { supportsTemperature: true, codeMode },
+    };
+    const model = buildOpenAIProvider().resolveDynamicModel?.({
+      provider: "openai",
+      modelId: ` ${exact.id} `,
+      modelRegistry: modelRegistry([exact]),
+    });
+    expect(model?.compat).toEqual(exact.compat);
+  });
+
+  it.each(["provider", "model"])("preserves authored %s transport and model overrides", (scope) => {
+    const provider = buildOpenAIProvider();
+    const modelId = "gpt-5.6-luna";
+    const route = { api: "openai-completions", baseUrl: "https://proxy.example/v1" } as const;
+    const providerConfig: ModelProviderConfig = {
+      baseUrl: "https://api.openai.com/v1",
+      ...(scope === "provider" ? route : {}),
+      headers: { "X-Provider-Route": "authored" },
+      models: [
+        {
+          id: modelId,
+          name: "Authored Luna",
+          ...(scope === "model" ? route : {}),
+          headers: { "X-Model-Route": "authored" },
+          compat: { codeMode: "capable", supportsTemperature: true },
+          reasoning: false,
+          input: ["text"],
+          contextWindow: 64_000,
+          maxTokens: 4_000,
+          cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
+        },
+      ],
+    };
+    const config = { models: { providers: { openai: providerConfig } } };
+    const discoveredModel = provider.resolveDynamicModel?.({
+      provider: "openai",
+      modelId,
+      providerConfig,
+      config,
+      modelRegistry: modelRegistry(),
+    });
+    if (!discoveredModel) {
+      throw new Error("expected the OpenAI dynamic model");
+    }
+    const model = applyConfiguredProviderOverrides({
+      provider: "openai",
+      modelId,
+      discoveredModel,
+      providerConfig,
+      cfg: config,
+      manifestAlias: { provider: "openai" },
+      runtimeHooks: {
+        buildProviderUnknownModelHintWithPlugin: ({ context }) =>
+          provider.buildUnknownModelHint?.(context) ?? undefined,
+        prepareProviderDynamicModel: async () => undefined,
+        runProviderDynamicModel: ({ context }) => provider.resolveDynamicModel?.(context),
+        normalizeProviderResolvedModelWithPlugin: ({ context }) =>
+          provider.normalizeResolvedModel?.(context),
+        normalizeProviderTransportWithPlugin: ({ context }) =>
+          provider.normalizeTransport?.(context) ?? undefined,
+      },
+    });
+    expect(model).toMatchObject({
+      ...route,
+      headers: { "X-Provider-Route": "authored", "X-Model-Route": "authored" },
+      compat: { codeMode: "capable", supportsTemperature: true },
+      reasoning: false,
+      input: ["text"],
+      contextWindow: 64_000,
+      maxTokens: 4_000,
+      cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
+    });
+  });
+});

--- a/extensions/openai/openai-provider.test.ts
+++ b/extensions/openai/openai-provider.test.ts
@@ -2071,47 +2071,6 @@ describe("buildOpenAIProvider", () => {
     });
   });
 
-  it.each([
-    {
-      id: "gpt-5.6-sol",
-      cost: { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
-    },
-    {
-      id: "gpt-5.6-terra",
-      cost: { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 3.125 },
-    },
-    {
-      id: "gpt-5.6-luna",
-      cost: { input: 1, output: 6, cacheRead: 0.1, cacheWrite: 1.25 },
-    },
-  ])("preserves exact registry metadata for $id", ({ id, cost }) => {
-    const provider = buildOpenAIProvider();
-    const exactModel = {
-      id,
-      name: id,
-      provider: "openai",
-      api: "openai-responses",
-      baseUrl: "https://api.openai.com/v1",
-      reasoning: true,
-      input: ["text", "image"],
-      cost,
-      contextWindow: 1_050_000,
-      contextTokens: 272_000,
-      maxTokens: 128_000,
-      compat: { supportedReasoningEfforts: ["registry-exact"] },
-    };
-
-    const model = provider.resolveDynamicModel?.({
-      provider: "openai",
-      modelId: id,
-      modelRegistry: {
-        find: (_provider: string, templateId: string) => (templateId === id ? exactModel : null),
-      } as never,
-    } as never);
-
-    expect(model).toBe(exactModel);
-  });
-
   it("resolves gpt-5.5-pro locally", () => {
     const provider = buildOpenAIProvider();
 

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -95,9 +95,7 @@ const OPENAI_CODEX_CLIENT_VERSION = "0.150.1";
 const OPENAI_CODEX_MODELS_ENDPOINT = `${OPENAI_CODEX_RESPONSES_BASE_URL}/models?client_version=${OPENAI_CODEX_CLIENT_VERSION}`;
 const OPENAI_MODELS_CACHE_TTL_MS = 60_000;
 const OPENAI_CODEX_MODELS_CACHE_TTL_MS = 60_000;
-const OPENAI_GPT_56_DIRECT_CONTEXT_WINDOW = 1_050_000;
 const OPENAI_CODEX_GPT_56_CONTEXT_WINDOW = 372_000;
-const OPENAI_GPT_55_CONTEXT_WINDOW = 1_050_000;
 const OPENAI_GPT_55_PRO_CONTEXT_WINDOW = 1_050_000;
 const OPENAI_GPT_54_CONTEXT_TOKENS = 1_050_000;
 const OPENAI_GPT_54_PRO_CONTEXT_TOKENS = 1_050_000;
@@ -105,26 +103,6 @@ const OPENAI_GPT_54_MINI_CONTEXT_TOKENS = 400_000;
 const OPENAI_GPT_54_NANO_CONTEXT_TOKENS = 400_000;
 const OPENAI_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_CHAT_LATEST_COST = { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 } as const;
-const OPENAI_GPT_56_SOL_COST = {
-  input: 5,
-  output: 30,
-  cacheRead: 0.5,
-  cacheWrite: 6.25,
-} as const;
-const OPENAI_GPT_56_TERRA_COST = {
-  input: 2.5,
-  output: 15,
-  cacheRead: 0.25,
-  cacheWrite: 3.125,
-} as const;
-const OPENAI_GPT_56_LUNA_COST = {
-  input: 1,
-  output: 6,
-  cacheRead: 0.1,
-  cacheWrite: 1.25,
-} as const;
-const OPENAI_GPT_55_COST = { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 } as const;
-const OPENAI_GPT_55_PRO_COST = { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 } as const;
 const OPENAI_GPT_54_COST = { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 } as const;
 const OPENAI_GPT_54_PRO_COST = { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 } as const;
 const OPENAI_GPT_54_MINI_COST = {
@@ -143,9 +121,6 @@ const OPENAI_GPT_55_PRO_TEMPLATE_MODEL_IDS = [
   OPENAI_GPT_54_PRO_MODEL_ID,
   OPENAI_GPT_54_MODEL_ID,
 ] as const;
-const OPENAI_GPT_55_MEDIA_INPUT = {
-  image: { maxSidePx: 6000, preferredSidePx: 2048, tokenMode: "detail" },
-} as const satisfies ProviderRuntimeModel["mediaInput"];
 // Repair an already-authorized model before borrowing an older family template;
 // remote discovery must not be needed to restore its native image capability.
 const OPENAI_GPT_54_TEMPLATE_MODEL_IDS = [OPENAI_GPT_54_MODEL_ID, OPENAI_GPT_55_MODEL_ID] as const;
@@ -164,11 +139,6 @@ const OPENAI_CHAT_LATEST_TEMPLATE_MODEL_IDS = [
   OPENAI_GPT_54_MODEL_ID,
 ] as const;
 const OPENAI_GPT_56_TEMPLATE_MODEL_IDS = [OPENAI_GPT_55_MODEL_ID] as const;
-const OPENAI_GPT_56_THINKING_LEVEL_MAP = {
-  off: "none",
-  xhigh: "xhigh",
-  max: "max",
-} as const;
 const OPENAI_UNKNOWN_MODEL_COST = {
   input: 0,
   output: 0,
@@ -820,83 +790,70 @@ const OPENAI_GPT_FORWARD_COMPAT_CASES = [
       OPENAI_GPT_56_LUNA_MODEL_ID,
     ],
     templateIds: OPENAI_GPT_56_TEMPLATE_MODEL_IDS,
-    patch: ({ normalizedModelId: id }) =>
-      ({
-        cost:
-          id === OPENAI_GPT_56_MODEL_ID || id === OPENAI_GPT_56_SOL_MODEL_ID
-            ? OPENAI_GPT_56_SOL_COST
-            : id === OPENAI_GPT_56_TERRA_MODEL_ID
-              ? OPENAI_GPT_56_TERRA_COST
-              : OPENAI_GPT_56_LUNA_COST,
-        contextWindow: OPENAI_GPT_56_DIRECT_CONTEXT_WINDOW,
-        contextTokens: OPENAI_DEFAULT_RUNTIME_CONTEXT_TOKENS,
-        thinkingLevelMap: OPENAI_GPT_56_THINKING_LEVEL_MAP,
-      }) satisfies Partial<ProviderRuntimeModel>,
   },
   {
     match: [OPENAI_GPT_55_MODEL_ID],
     templateIds: [OPENAI_GPT_55_MODEL_ID, OPENAI_GPT_54_MODEL_ID],
-    patch: {
-      mediaInput: OPENAI_GPT_55_MEDIA_INPUT,
-      cost: OPENAI_GPT_55_COST,
-      contextWindow: OPENAI_GPT_55_CONTEXT_WINDOW,
-      contextTokens: OPENAI_DEFAULT_RUNTIME_CONTEXT_TOKENS,
-    },
   },
   {
     match: [OPENAI_GPT_55_PRO_MODEL_ID],
     templateIds: OPENAI_GPT_55_PRO_TEMPLATE_MODEL_IDS,
-    patch: {
-      cost: OPENAI_GPT_55_PRO_COST,
-      contextWindow: OPENAI_GPT_55_PRO_CONTEXT_WINDOW,
-      contextTokens: OPENAI_DEFAULT_RUNTIME_CONTEXT_TOKENS,
-    },
   },
   {
     match: [OPENAI_GPT_54_MODEL_ID],
     templateIds: OPENAI_GPT_54_TEMPLATE_MODEL_IDS,
-    patch: { cost: OPENAI_GPT_54_COST, contextWindow: OPENAI_GPT_54_CONTEXT_TOKENS },
   },
   {
     match: [OPENAI_GPT_54_PRO_MODEL_ID],
     templateIds: OPENAI_GPT_54_PRO_TEMPLATE_MODEL_IDS,
-    patch: { cost: OPENAI_GPT_54_PRO_COST, contextWindow: OPENAI_GPT_54_PRO_CONTEXT_TOKENS },
   },
   {
     match: [OPENAI_GPT_54_MINI_MODEL_ID],
     templateIds: OPENAI_GPT_54_MINI_TEMPLATE_MODEL_IDS,
-    patch: { cost: OPENAI_GPT_54_MINI_COST, contextWindow: OPENAI_GPT_54_MINI_CONTEXT_TOKENS },
   },
   {
     match: [OPENAI_GPT_54_NANO_MODEL_ID],
     templateIds: OPENAI_GPT_54_NANO_TEMPLATE_MODEL_IDS,
-    patch: { cost: OPENAI_GPT_54_NANO_COST, contextWindow: OPENAI_GPT_54_NANO_CONTEXT_TOKENS },
   },
 ] satisfies Parameters<typeof resolveFamilyForwardCompatModel>[0]["cases"];
 
 function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelContext) {
-  const modelId = normalizeLowercaseStringOrEmpty(ctx.modelId);
+  const trimmedModelId = ctx.modelId.trim();
+  const modelId = normalizeLowercaseStringOrEmpty(trimmedModelId);
+  const exactModel = ctx.modelRegistry.find(PROVIDER_ID, trimmedModelId);
   if (
     modelId === OPENAI_GPT_56_SOL_MODEL_ID ||
     modelId === OPENAI_GPT_56_TERRA_MODEL_ID ||
     modelId === OPENAI_GPT_56_LUNA_MODEL_ID
   ) {
-    const exactModel = ctx.modelRegistry.find(PROVIDER_ID, ctx.modelId);
     if (exactModel) {
       return exactModel;
     }
   }
+  // Known rows own capability metadata even before discovery. Only an exact registry row
+  // may override compat; an older family template cannot choose this model's Code Mode tier.
+  const catalogModel = OPENAI_MANIFEST_PROVIDER.models.find(
+    ({ id }) => id === (modelId === OPENAI_GPT_56_MODEL_ID ? OPENAI_GPT_56_SOL_MODEL_ID : modelId),
+  );
   return resolveFamilyForwardCompatModel({
     providerId: PROVIDER_ID,
     ctx,
     cases: OPENAI_GPT_FORWARD_COMPAT_CASES,
     patch: {
+      reasoning: true,
+      maxTokens: OPENAI_GPT_54_MAX_TOKENS,
+      ...catalogModel,
+      id: trimmedModelId,
+      name: trimmedModelId,
       api: "openai-responses",
       provider: PROVIDER_ID,
       baseUrl: resolveOpenAIDefaultBaseUrl(),
-      reasoning: true,
-      input: ["text", "image"],
-      maxTokens: OPENAI_GPT_54_MAX_TOKENS,
+      input: catalogModel
+        ? catalogModel.input.filter(
+            (item): item is "text" | "image" => item === "text" || item === "image",
+          )
+        : ["text", "image"],
+      compat: exactModel ? exactModel.compat : catalogModel?.compat,
     },
     synthesize: true,
   });

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildOpenAIProvider } from "../../../extensions/openai/api.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { discoverAuthStorage, discoverModels } from "../agent-model-discovery.js";
 import {
@@ -259,6 +260,7 @@ import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/ty
 import type { Model } from "../../llm/types.js";
 import { getModelProviderLocalService } from "../provider-local-service.js";
 import { getModelProviderRequestTransport } from "../provider-request-config.js";
+import { applyConfiguredProviderOverrides } from "./model.configured-overrides.js";
 import { buildForwardCompatTemplate } from "./model.forward-compat.test-support.js";
 import { buildInlineProviderModels } from "./model.inline-provider.js";
 import { resolveModelAsync, resolveModelWithRegistry } from "./model.js";
@@ -4477,6 +4479,77 @@ describe("resolveModel", () => {
     expect(result.error).toBe(
       "Unknown model: openai/gpt-5.3-codex-spark. gpt-5.3-codex-spark is available only through ChatGPT/Codex OAuth. Run `openclaw models auth login --provider openai` and use openai/gpt-5.3-codex-spark with that OAuth profile; OpenAI API-key auth cannot use this model.",
     );
+  });
+
+  it.each(["provider", "model"])("preserves authored %s transport and model overrides", (scope) => {
+    const provider = buildOpenAIProvider();
+    const modelId = "gpt-5.6-luna";
+    const route = { api: "openai-completions", baseUrl: "https://proxy.example/v1" } as const;
+    const providerConfig: ModelProviderConfig = {
+      baseUrl: "https://api.openai.com/v1",
+      ...(scope === "provider" ? route : {}),
+      headers: { "X-Provider-Route": "authored" },
+      models: [
+        {
+          id: modelId,
+          name: "Authored Luna",
+          ...(scope === "model" ? route : {}),
+          headers: { "X-Model-Route": "authored" },
+          compat: { codeMode: "capable", supportsTemperature: true },
+          reasoning: false,
+          input: ["text"],
+          contextWindow: 64_000,
+          maxTokens: 4_000,
+          cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
+        },
+      ],
+    };
+    const config = { models: { providers: { openai: providerConfig } } };
+    const discoveredModel = provider.resolveDynamicModel?.({
+      provider: "openai",
+      modelId,
+      providerConfig,
+      config,
+      modelRegistry: {
+        find: () => undefined,
+        getAll: () => [],
+        getAvailable: () => [],
+        hasConfiguredAuth: () => false,
+      },
+    });
+    if (!discoveredModel) {
+      throw new Error("expected the OpenAI dynamic model");
+    }
+    expect(discoveredModel.compat?.codeMode).toBe("preferred");
+
+    const model = applyConfiguredProviderOverrides({
+      provider: "openai",
+      modelId,
+      discoveredModel,
+      providerConfig,
+      cfg: config,
+      manifestAlias: { provider: "openai" },
+      runtimeHooks: {
+        buildProviderUnknownModelHintWithPlugin: ({ context }) =>
+          provider.buildUnknownModelHint?.(context) ?? undefined,
+        prepareProviderDynamicModel: async () => undefined,
+        runProviderDynamicModel: ({ context }) => provider.resolveDynamicModel?.(context),
+        normalizeProviderResolvedModelWithPlugin: ({ context }) =>
+          provider.normalizeResolvedModel?.(context),
+        normalizeProviderTransportWithPlugin: ({ context }) =>
+          provider.normalizeTransport?.(context) ?? undefined,
+      },
+    });
+    expect(model).toMatchObject({
+      ...route,
+      headers: { "X-Provider-Route": "authored", "X-Model-Route": "authored" },
+      compat: { codeMode: "capable", supportsTemperature: true },
+      reasoning: false,
+      input: ["text"],
+      contextWindow: 64_000,
+      maxTokens: 4_000,
+      cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
+    });
   });
 
   it("applies provider overrides to openai gpt-5.4 forward-compat models", async () => {

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -4,7 +4,8 @@ import os from "node:os";
 import path from "node:path";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { buildOpenAIProvider } from "../../../extensions/openai/api.js";
+import { loadBundledPluginPublicSurface } from "../../plugin-sdk/test-helpers/public-surface-loader.js";
+import type { ProviderPlugin } from "../../plugins/types.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { discoverAuthStorage, discoverModels } from "../agent-model-discovery.js";
 import {
@@ -4481,76 +4482,82 @@ describe("resolveModel", () => {
     );
   });
 
-  it.each(["provider", "model"])("preserves authored %s transport and model overrides", (scope) => {
-    const provider = buildOpenAIProvider();
-    const modelId = "gpt-5.6-luna";
-    const route = { api: "openai-completions", baseUrl: "https://proxy.example/v1" } as const;
-    const providerConfig: ModelProviderConfig = {
-      baseUrl: "https://api.openai.com/v1",
-      ...(scope === "provider" ? route : {}),
-      headers: { "X-Provider-Route": "authored" },
-      models: [
-        {
-          id: modelId,
-          name: "Authored Luna",
-          ...(scope === "model" ? route : {}),
-          headers: { "X-Model-Route": "authored" },
-          compat: { codeMode: "capable", supportsTemperature: true },
-          reasoning: false,
-          input: ["text"],
-          contextWindow: 64_000,
-          maxTokens: 4_000,
-          cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
+  it.each(["provider", "model"])(
+    "preserves authored %s transport and model overrides",
+    async (scope) => {
+      const { buildOpenAIProvider } = await loadBundledPluginPublicSurface<{
+        buildOpenAIProvider: () => ProviderPlugin;
+      }>({ pluginId: "openai", artifactBasename: "api.js" });
+      const provider = buildOpenAIProvider();
+      const modelId = "gpt-5.6-luna";
+      const route = { api: "openai-completions", baseUrl: "https://proxy.example/v1" } as const;
+      const providerConfig: ModelProviderConfig = {
+        baseUrl: "https://api.openai.com/v1",
+        ...(scope === "provider" ? route : {}),
+        headers: { "X-Provider-Route": "authored" },
+        models: [
+          {
+            id: modelId,
+            name: "Authored Luna",
+            ...(scope === "model" ? route : {}),
+            headers: { "X-Model-Route": "authored" },
+            compat: { codeMode: "capable", supportsTemperature: true },
+            reasoning: false,
+            input: ["text"],
+            contextWindow: 64_000,
+            maxTokens: 4_000,
+            cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
+          },
+        ],
+      };
+      const config = { models: { providers: { openai: providerConfig } } };
+      const discoveredModel = provider.resolveDynamicModel?.({
+        provider: "openai",
+        modelId,
+        providerConfig,
+        config,
+        modelRegistry: {
+          find: () => undefined,
+          getAll: () => [],
+          getAvailable: () => [],
+          hasConfiguredAuth: () => false,
         },
-      ],
-    };
-    const config = { models: { providers: { openai: providerConfig } } };
-    const discoveredModel = provider.resolveDynamicModel?.({
-      provider: "openai",
-      modelId,
-      providerConfig,
-      config,
-      modelRegistry: {
-        find: () => undefined,
-        getAll: () => [],
-        getAvailable: () => [],
-        hasConfiguredAuth: () => false,
-      },
-    });
-    if (!discoveredModel) {
-      throw new Error("expected the OpenAI dynamic model");
-    }
-    expect(discoveredModel.compat?.codeMode).toBe("preferred");
+      });
+      if (!discoveredModel) {
+        throw new Error("expected the OpenAI dynamic model");
+      }
+      expect(discoveredModel.compat?.codeMode).toBe("preferred");
 
-    const model = applyConfiguredProviderOverrides({
-      provider: "openai",
-      modelId,
-      discoveredModel,
-      providerConfig,
-      cfg: config,
-      manifestAlias: { provider: "openai" },
-      runtimeHooks: {
-        buildProviderUnknownModelHintWithPlugin: ({ context }) =>
-          provider.buildUnknownModelHint?.(context) ?? undefined,
-        prepareProviderDynamicModel: async () => undefined,
-        runProviderDynamicModel: ({ context }) => provider.resolveDynamicModel?.(context),
-        normalizeProviderResolvedModelWithPlugin: ({ context }) =>
-          provider.normalizeResolvedModel?.(context),
-        normalizeProviderTransportWithPlugin: ({ context }) =>
-          provider.normalizeTransport?.(context) ?? undefined,
-      },
-    });
-    expect(model).toMatchObject({
-      ...route,
-      headers: { "X-Provider-Route": "authored", "X-Model-Route": "authored" },
-      compat: { codeMode: "capable", supportsTemperature: true },
-      reasoning: false,
-      input: ["text"],
-      contextWindow: 64_000,
-      maxTokens: 4_000,
-      cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
-    });
-  });
+      const model = applyConfiguredProviderOverrides({
+        provider: "openai",
+        modelId,
+        discoveredModel,
+        providerConfig,
+        cfg: config,
+        manifestAlias: { provider: "openai" },
+        runtimeHooks: {
+          buildProviderUnknownModelHintWithPlugin: ({ context }) =>
+            provider.buildUnknownModelHint?.(context) ?? undefined,
+          prepareProviderDynamicModel: async () => undefined,
+          runProviderDynamicModel: ({ context }) => provider.resolveDynamicModel?.(context),
+          normalizeProviderResolvedModelWithPlugin: ({ context }) =>
+            provider.normalizeResolvedModel?.(context),
+          normalizeProviderTransportWithPlugin: ({ context }) =>
+            provider.normalizeTransport?.(context) ?? undefined,
+        },
+      });
+      expect(model).toMatchObject({
+        ...route,
+        headers: { "X-Provider-Route": "authored", "X-Model-Route": "authored" },
+        compat: { codeMode: "capable", supportsTemperature: true },
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 64_000,
+        maxTokens: 4_000,
+        cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
+      });
+    },
+  );
 
   it("applies provider overrides to openai gpt-5.4 forward-compat models", async () => {
     mockDiscoveredModel(discoverModels, {


### PR DESCRIPTION
Closes #131073 — automatic Code Mode loses preferred OpenAI model capabilities.

<details>
<summary>Additional instructions</summary>

Maintainers can edit this branch in the OpenClaw repository.

</details>

## What Problem This Solves

Fixes an issue where users running preferred OpenAI models through the OpenClaw runtime would silently receive the larger direct-tool surface when Code Mode was left at its automatic default. File tasks could still succeed, so task success alone did not reveal the missing automatic engagement.

## Why This Change Was Made

Initial tiered model resolution uses an empty registry; the OpenAI plugin's successful dynamic synthesis omitted the manifest's authored compatibility metadata and returned before static fallback could supply it. Reusing the existing normalized manifest rows for eligible known models repairs the metadata at its producer and removes duplicated cost, context, and thinking patches, while retaining family eligibility, the GPT-5.6 alias, exact registry compatibility precedence, and configured transport/model overrides.

## User Impact

Preferred OpenAI models can engage OpenClaw Code Mode automatically without adding configuration. Explicit direct and forced modes, unpreferred models, route eligibility, and operator overrides keep their existing contracts. No activation gate, default, configuration, manifest, dependency, or schema changes are included; native Codex Code Mode is separate and untouched.

Release-note context: restore automatic OpenClaw Code Mode for preferred OpenAI models resolved before discovery (#131073, reported by @steipete). The existing [Code Mode documentation](https://docs.openclaw.ai/tools/code-mode#automatic-per-model-activation) already describes the intended behavior; no new setting or documentation workaround is needed.

## Evidence

Production LOC: +19/-62 (net -43). Tests: +261/-41 (net +220); the existing exact-registry case was moved and strengthened. The OpenAI producer, its two test files, and the core model-resolution test suite change. The CI repair itself is test-only (+80/-66); production remains byte-identical to the original live-tested head.

The pre-fix regression run failed eight intended cases: six preferred known models/alias, the environment-selected endpoint, and borrowed-template capability precedence. The original repaired patch passed 131 focused and sibling tests, covering exact registry authority, configured API/base URL/headers/compat/pricing/context/input overrides, trimmed identifiers, unpreferred controls, ChatGPT routing, model eligibility, thinking behavior, and the existing Anthropic producer precedent.

Validation commands:

```sh
node scripts/run-vitest.mjs extensions/openai/openai-dynamic-model.test.ts extensions/openai/openai-provider.test.ts
node scripts/run-vitest.mjs extensions/openai/openai-dynamic-model.test.ts extensions/openai/openai-provider.test.ts extensions/openai/openai-chatgpt-provider.test.ts extensions/openai/provider-runtime.contract.test.ts extensions/openai/model-route-contract.test.ts extensions/openai/thinking-policy.test.ts extensions/anthropic/forward-compat-generation.test.ts
node scripts/check-changed.mjs -- extensions/openai/openai-provider.ts extensions/openai/openai-provider.test.ts extensions/openai/openai-dynamic-model.test.ts
OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
git diff --check
```

The changed-file gate passed, including production/test type checks, lint, selected guards, and doctor-contract tests. Its first run caught two nullable-return errors in the test adapter; those were repaired before the final frozen patch. The full private-QA build passed after a patch-identical refresh. Fresh independent autoreview of that same patch returned no findings.

CI repair: [run 33108093984, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33108093984/job/98643619743) failed `lint:plugins:no-extension-test-core-imports` because the new plugin test imported the core configured-override owner. The same guard failed locally on the published head before editing. The repair moves both provider/model override cases into `src/agents/embedded-agent-runner/model.test.ts`, using the existing public `extensions/openai/api.ts` seam. Existing core OpenAI cases use simulated producers; retaining these two real-producer composition cases protects the new preferred metadata together with custom-route overrides. Every override assertion remains, and the cases additionally verify that the discovered model starts as preferred. Preferred, unpreferred, exact-registry, trimmed-ID, endpoint, and borrowed-template regression cases remain in the plugin suite. No SDK export, assertion weakening, ignored check, dependency/config/schema change, or production edit was added.

A second [CI run 33110786473, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33110786473/job/98653169221) caught the remaining compile-graph boundary: directly importing the public OpenAI API still pulled plugin implementation files into the core TypeScript project. This also failed locally before correction. The core cases now load that same real public API with the existing `loadBundledPluginPublicSurface` test helper, already used by core and provider contracts. This keeps plugin compilation owned by the plugin graph without adding a new export or an ad hoc dynamic-import workaround. The exact `lint:tmp:tsgo-core-boundary` guard passes; the 154 core and 18 producer tests were rerun, and a fresh isolated Codex review of the loader correction returned no findings.

Focused and sibling evidence covers 328 passing tests (172 rerun after the loader correction, with the other 156 unchanged): 154 core model tests (including both relocated cases), 45 core sibling tests, and 129 OpenAI/Anthropic plugin tests. Both exact boundary guards and the full changed-file gates passed; the follow-up loader edit also passed its core-test changed-file check. The initial dependency-less worktree had incomplete dependency resolution: first `ws`, then stale versions in the canonical install, then missing UI/`jsdom` types in a borrowed install. A task-local `pnpm install --frozen-lockfile --ignore-scripts` supplied the unchanged pinned dependencies without lifecycle hooks, builds, or edits to either shared checkout. Fresh structured Codex autoreview of the final test edits returned no findings at its default P0 scope. The initial review launcher selected an older CLI and failed; the successful pass used the current trusted CLI with the managed empty-workspace permission profile, without weakening reviewer isolation.

```sh
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=.local/vitest-cache-ci-repair node scripts/run-vitest.mjs src/agents/embedded-agent-runner/model.test.ts src/agents/embedded-agent-runner/model.inline-provider.test.ts src/agents/model-compat-catalog.test.ts src/agents/code-mode.config.test.ts src/agents/tool-surface-plan.test.ts extensions/openai/openai-dynamic-model.test.ts extensions/openai/openai-provider.test.ts extensions/openai/openai-chatgpt-provider.test.ts extensions/openai/provider-runtime.contract.test.ts extensions/openai/model-route-contract.test.ts extensions/openai/thinking-policy.test.ts extensions/anthropic/forward-compat-generation.test.ts --reporter=verbose
node --import ./scripts/tsx.mjs scripts/check-no-extension-test-core-imports.ts
node --import ./scripts/tsx.mjs scripts/check-tsgo-core-boundary.mts
node scripts/check-changed.mjs -- extensions/openai/openai-provider.ts extensions/openai/openai-provider.test.ts extensions/openai/openai-dynamic-model.test.ts src/agents/embedded-agent-runner/model.test.ts
```

The completed production build and authenticated live proof below are reused only because `extensions/openai/openai-provider.ts` retains SHA-256 `ed4fa02887b59a984937fdd8c12f40b7dca4f70d06adb20ce903e2f0d6366f02`; no new build or live run was performed for the test-only CI repair.

Authenticated acceptance matrix using `openai/gpt-5.6-luna` through the OpenClaw runtime:

| Mode | Tasks pass before / after | Engagement before / after | Bridge calls before / after (read; dependent read/write) |
| --- | --- | --- | --- |
| Automatic | 2/2; 2/2 | false; true | 0, 0; 1, 3 |
| Forced code | 2/2; 2/2 | true; true | 1, 3; 1, 3 |
| Direct | 2/2; 2/2 | false; false | 0, 0; 0, 0 |

The generic matrix PASS did not prove preferred-model activation: both baseline automatic cells passed their task oracles with Code Mode disengaged. The candidate's actual engagement facts and bridge calls satisfy the stricter known-preferred expectation as well.

```sh
node --import tsx scripts/code-mode-model-matrix.ts --model openai/gpt-5.6-luna --repetitions 1 --thinking low --keep-state --output-dir .artifacts/qa-e2e/code-mode-443e40-auto-after
```

A separate normal isolated Gateway turn, with no `tools.codeMode` configuration, also changed from `codeModeEngaged=false` to `true` using the OpenClaw runtime and `openai/gpt-5.6-luna`. The actual file read succeeded through one bridge call. Its client tool surface shrank from 54 tools to `exec`, `wait`, `computer`, `sessions_yield`, and `view_image`; provider-hosted web search remained available separately. These are five client tools, not five total tools.

```sh
node dist/entry.js agent --agent qa --message 'Read facts.txt using the file tool. Reply with only its verification_code value.' --thinking low --timeout 180 --json
```

Both Control UI file write/read tasks succeeded. The first recorder watched `chat.send`, but New Session uses `sessions.create` and its returned `runId`; the corrected recorder passed using that exact receipt. No runtime workaround, product timeout increase, or assertion relaxation was needed. Before-state activation evidence comes from the actual CLI matrix and Gateway result; the after-state also has inspected live Control UI media with synthetic fixture data:

![Control UI after the repair: completed file write and read verification](https://github.com/user-attachments/assets/b46224c9-e2a6-40df-9ee4-f9c3a355e2b7)

https://github.com/user-attachments/assets/d856b230-8084-43c4-996d-7f9a749ddbe0

Separate follow-up: automatic session titles misleadingly claimed files/tools were unavailable despite successful tasks. That symptom is tracked separately; this patch neither repairs it nor claims to establish its cause.

Source ownership: `extensions/openai/openai-provider.ts:821` uses the existing manifest normalizer (`src/plugin-sdk/provider-catalog-shared.ts:221`) and family resolver (`src/plugins/provider-model-helpers.ts:54`). The caller is `src/agents/embedded-agent-runner/model-resolution.ts:45`; empty-registry construction and dynamic-before-static resolution are in `src/agents/embedded-agent-runner/model.ts:120` and `:353`. The unchanged consumer gate is `src/agents/code-mode-runtime.ts:199`. The Anthropic producer already preserves equivalent manifest capability metadata. A Code Mode-only append would retain metadata duplication; changing core precedence or forcing activation would put provider policy in the wrong owner.

Limits: credentialed live proof covers the OpenClaw runtime with the OpenAI API-key Responses route, not native Codex or subscription-route live behavior. Direct inspection of Codex source at `92cbfb4d2431bdc53dc03507aea2dc5b8e932e40`, `codex-rs/core/src/tools/code_mode/execute_spec.rs:8` and `codex-rs/core/src/tools/spec_plan.rs:323`, confirms the native freeform tool and ToolMode gate are a separate surface. No cancellation work or broader generic metadata redesign is included. Hosted [CI run 33111619695](https://github.com/openclaw/openclaw/actions/runs/33111619695), attempt 1, completed successfully at final head `6c59509425bf6baa4f941327508d446d475d72ad`.

AI-assisted implementation and validation.

Latest ClawSweeper comment remains a started placeholder at https://github.com/openclaw/openclaw/pull/131139#issuecomment-5444646473; no completed review or Rank-up moves were available at the final check. Fresh isolated review and required CI are complete; publication is not treated as an approval gate.
