### PR TITLE
fix(update): skip stopped Gateway probe during external finalization

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1291,6 +1291,59 @@ describe("doctor health contributions", () => {
     expect(mocks.probeGatewayMemoryStatus).not.toHaveBeenCalled();
   });
 
+  it("skips Gateway health probes during update-owned Doctor finalization", async () => {
+    const contribution = requireDoctorContribution(DOCTOR_GATEWAY_HEALTH_ID);
+    const ctx = {
+      cfg: { gateway: { mode: "local" } },
+      configResult: { cfg: { gateway: { mode: "local" } } },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: { nonInteractive: true },
+      cfgForPersistence: { gateway: { mode: "local" } },
+      configPath: "/tmp/fake-openclaw.json",
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
+        OPENCLAW_SERVICE_REPAIR_POLICY: "external",
+      },
+    } as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(mocks.checkGatewayHealth).not.toHaveBeenCalled();
+    expect(mocks.probeGatewayMemoryStatus).not.toHaveBeenCalled();
+    expect(ctx.gatewayHealthSkipped).toBe(true);
+    expect(ctx.gatewayMemoryProbe).toEqual({ checked: false, ready: false, skipped: true });
+  });
+
+  it("keeps Gateway health probes for internally managed update Doctor runs", async () => {
+    mocks.checkGatewayHealth.mockResolvedValue({
+      authenticated: false,
+      healthOk: true,
+      status: { ok: true },
+    });
+    const contribution = requireDoctorContribution(DOCTOR_GATEWAY_HEALTH_ID);
+    const cfg = { gateway: { mode: "local" as const } };
+    const ctx = {
+      cfg,
+      configResult: { cfg },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(false),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: { nonInteractive: true },
+      cfgForPersistence: cfg,
+      configPath: "/tmp/fake-openclaw.json",
+      env: { OPENCLAW_UPDATE_IN_PROGRESS: "1" },
+    } as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(mocks.checkGatewayHealth).toHaveBeenCalledOnce();
+    expect(ctx.healthOk).toBe(true);
+    expect(ctx.gatewayHealthSkipped).toBe(false);
+  });
+
   it("skips remote gateway health probes for local fallback exec SecretRefs", async () => {
     mocks.checkGatewayHealth.mockResolvedValue({
       authenticated: false,

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -2,7 +2,10 @@
 // exposing the same checks to structured lint and repair commands.
 import fs from "node:fs";
 import { isDeepStrictEqual } from "node:util";
-import { shouldManageGatewayService } from "../commands/doctor-service-repair-policy.js";
+import {
+  resolveServiceRepairPolicy,
+  shouldManageGatewayService,
+} from "../commands/doctor-service-repair-policy.js";
 import { scrubDoctorErrorMessage } from "./doctor-error-message.js";
 import { hasActiveGatewayExecCredential } from "./doctor-gateway-exec-credential.js";
 import {
@@ -14,6 +17,7 @@ import type {
   DoctorHealthFlowContext,
 } from "./doctor-health-contribution-types.js";
 import {
+  isUpdateDoctorRun,
   resolveDoctorMode,
   resolveDoctorWorkspaceDir,
 } from "./doctor-health-contribution-utils.js";
@@ -393,6 +397,12 @@ async function runShellCompletionHealth(ctx: DoctorHealthFlowContext): Promise<v
 
 async function runGatewayHealthChecks(ctx: DoctorHealthFlowContext): Promise<void> {
   const { note } = await loadNoteModule();
+  const env = ctx.env ?? process.env;
+  if (isUpdateDoctorRun(env) && resolveServiceRepairPolicy(env) === "external") {
+    ctx.gatewayHealthSkipped = true;
+    ctx.gatewayMemoryProbe = { checked: false, ready: false, skipped: true };
+    return;
+  }
   if ((await hasActiveGatewayExecCredential(ctx)) && ctx.options.allowExec !== true) {
     note(
       "Gateway health probes skipped because gateway credentials use an exec SecretRef. Run `openclaw doctor --allow-exec` to verify Gateway health with exec SecretRefs.",


### PR DESCRIPTION
Closes #131074

## What Problem This Solves

Fixes an issue where externally managed update finalization probes a Gateway that the external supervisor intentionally stopped.

The probe is nonfatal on current main, but it reports an unhealthy Gateway during a valid stopped-state migration and obscures the actual finalization result. The external controller owns the later service start and post-start health verification.

## Why This Change Was Made

Doctor now skips Gateway health and memory probes only when both conditions are true:

- Doctor is running inside update finalization; and
- the existing service-repair policy is `external`.

Ordinary Doctor runs and internally managed updates retain their current Gateway health checks.

## User Impact

External upgrade controllers can finalize stopped environments without a misleading expected connection failure. Gateway health is still verified after the external controller starts the updated service.

## Evidence

- Positive regression: external update finalization skips Gateway health and memory probes.
- Negative regression: internally managed update Doctor still performs Gateway health checks.
- Validation on current upstream:
  - 222 Doctor health and service tests passed;
  - core TypeScript checking passed;
  - formatting passed;
  - targeted type-aware lint passed.
- Live Personal clone proof:
  - current main already includes the plugin-lease ordering fix from #131062;
  - current main plus this patch completed stopped-state finalization and switched the clone successfully.
- A later OCM fleet-isolation event during canary inspection invalidated broader canary acceptance, so this PR does not claim end-to-end agent/browser acceptance from that run. Production Personal was not upgraded.

## Worked on by

_No credited co-authors for this turn._
