### PR TITLE
fix(copilot): keep Gemini working without live discovery

### DIFF
--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -289,8 +289,9 @@ configured default model is never replaced.
   <Accordion title="Transport selection">
     Claude model IDs use the Anthropic Messages transport automatically.
     Gemini models use the OpenAI Chat Completions transport; GPT and o-series
-    models keep the OpenAI Responses transport. OpenClaw selects the correct
-    transport based on the model ref.
+    models keep the OpenAI Responses transport. The bundled static catalog
+    includes these transports and request compatibility settings, so Gemini
+    keeps using Chat Completions when live discovery is disabled or unavailable.
   </Accordion>
 
   <Accordion title="Thinking levels">

--- a/extensions/github-copilot/model-metadata.ts
+++ b/extensions/github-copilot/model-metadata.ts
@@ -26,10 +26,6 @@ const manifestModels = buildManifestModelProviderConfig({
   providerId: "github-copilot",
   catalog: manifestCatalog,
 }).models;
-for (const model of manifestModels) {
-  model.api = resolveCopilotTransportApi(model.id);
-  model.compat = { ...resolveCopilotModelCompat(model.id), ...model.compat };
-}
 
 const STATIC_MODEL_OVERRIDES = new Map<string, Partial<ModelDefinitionConfig>>([
   ...manifestModels.map((model) => [model.id, model] as const),

--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -97,6 +97,13 @@
           {
             "id": "gemini-3.6-flash",
             "name": "Gemini 3.6 Flash",
+            "api": "openai-completions",
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsUsageInStreaming": false,
+              "maxTokensField": "max_tokens"
+            },
             "input": ["text", "image"],
             "contextWindow": 1048576,
             "maxTokens": 65536,
@@ -105,6 +112,13 @@
           {
             "id": "gemini-3.1-pro-preview",
             "name": "Gemini 3.1 Pro Preview",
+            "api": "openai-completions",
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsUsageInStreaming": false,
+              "maxTokensField": "max_tokens"
+            },
             "input": ["text", "image"],
             "contextWindow": 1048576,
             "maxTokens": 65536,
@@ -113,6 +127,13 @@
           {
             "id": "gemini-3.5-flash",
             "name": "Gemini 3.5 Flash",
+            "api": "openai-completions",
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsUsageInStreaming": false,
+              "maxTokensField": "max_tokens"
+            },
             "status": "deprecated",
             "replacedBy": "gemini-3.6-flash",
             "input": ["text", "image"],
@@ -123,6 +144,13 @@
           {
             "id": "gemini-2.5-pro",
             "name": "Gemini 2.5 Pro",
+            "api": "openai-completions",
+            "compat": {
+              "supportsStore": false,
+              "supportsDeveloperRole": false,
+              "supportsUsageInStreaming": false,
+              "maxTokensField": "max_tokens"
+            },
             "status": "deprecated",
             "replacedBy": "gemini-3.1-pro-preview",
             "input": ["text", "image"],

--- a/src/plugin-sdk/test-helpers/provider-runtime-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-runtime-contract.ts
@@ -1,5 +1,7 @@
 // Provider runtime contract helpers define reusable runtime tests for provider plugins.
+import { normalizeModelCatalog } from "@openclaw/model-catalog-core/model-catalog-normalize";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginMetadataSnapshot } from "../../config/plugin-auto-enable.test-helpers.js";
 import type { ProviderRuntimeModel } from "../plugin-entry.js";
 import { registerProviderPlugin, requireRegisteredProvider } from "../plugin-test-runtime.js";
 import { buildManifestModelProviderConfig } from "../provider-catalog-shared.js";
@@ -282,6 +284,95 @@ export function describeGithubCopilotProviderRuntimeContract(
         },
       ]);
       const createManifestModel = createManifestModelFactory("github-copilot", manifestCatalog);
+
+      it.each([
+        ["gemini-3.6-flash", "openai-completions", false],
+        ["gemini-3.1-pro-preview", "openai-completions", false],
+        ["gemini-3.5-flash", "openai-completions", false],
+        ["gemini-2.5-pro", "openai-completions", false],
+        ["gpt-5.6-sol", "openai-responses", false],
+        ["claude-sonnet-5", "anthropic-messages", false],
+        ["gemini-3.6-flash", "openai-completions", true],
+      ] as const)(
+        "routes static %s through %s with discovery enabled=%s",
+        async (modelId, api, discoveryEnabled) => {
+          const { createBundledStaticCatalogModelResolver } =
+            await import("../../agents/embedded-agent-runner/model.static-catalog.js");
+          const config = {
+            models: { catalogRefresh: { enabled: false } },
+            plugins: {
+              entries: {
+                "github-copilot": { config: { discovery: { enabled: discoveryEnabled } } },
+              },
+            },
+          };
+          const metadataSnapshot = createPluginMetadataSnapshot({
+            config,
+            manifestRegistry: {
+              diagnostics: [],
+              plugins: [
+                {
+                  id: "github-copilot",
+                  origin: "bundled",
+                  providers: ["github-copilot"],
+                  channels: [],
+                  cliBackends: [],
+                  skills: [],
+                  hooks: [],
+                  rootDir: "/fixtures/github-copilot",
+                  source: "/fixtures/github-copilot/index.js",
+                  manifestPath: "/fixtures/github-copilot/openclaw.plugin.json",
+                  modelCatalog: normalizeModelCatalog(
+                    {
+                      providers: { "github-copilot": manifestCatalog },
+                      discovery: { "github-copilot": "runtime" },
+                    },
+                    { ownedProviders: new Set(["github-copilot"]) },
+                  ),
+                },
+              ],
+            },
+          });
+          const resolveModel = createBundledStaticCatalogModelResolver({
+            cfg: config,
+            env: {},
+            metadataSnapshot,
+            includeRuntimeDiscovery: true,
+          });
+          const model = resolveModel({ provider: "github-copilot", modelId });
+          expect(model?.api).toBe(api);
+          if (api === "openai-completions") {
+            expect(model?.compat).toMatchObject({
+              supportsStore: false,
+              supportsDeveloperRole: false,
+              supportsUsageInStreaming: false,
+              maxTokensField: "max_tokens",
+            });
+          }
+          const provider = requireProviderContractProvider("github-copilot");
+          expect(
+            provider.preferRuntimeResolvedModel?.({
+              config,
+              provider: "github-copilot",
+              modelId,
+            }),
+          ).toBe(discoveryEnabled);
+          // A missing prepared live row also occurs when enabled discovery is unavailable.
+          expect(
+            provider.resolveDynamicModel?.({
+              config,
+              provider: "github-copilot",
+              modelId,
+              modelRegistry: {
+                find: () => model,
+                getAll: () => (model ? [model] : []),
+                getAvailable: () => (model ? [model] : []),
+                hasConfiguredAuth: () => false,
+              },
+            }),
+          ).toBeUndefined();
+        },
+      );
 
       it("owns Copilot-specific forward-compat fallbacks", () => {
         const provider = requireProviderContractProvider("github-copilot");


### PR DESCRIPTION
Closes #131142.

## What Problem This Solves

Fixes an issue where users selecting a Copilot Gemini model receive HTTP400 when live model discovery is disabled or unavailable and OpenClaw uses its bundled catalog. The static selection incorrectly sends Gemini to the Responses API.

## Why This Change Was Made

Declare the existing Gemini Chat Completions transport and request compatibility fields in the owning plugin manifest, so every catalog consumer receives the same metadata. Remove the private metadata-rewrite loop that only repaired forward-compatible synthesis and could not repair a model already present in the registry.

The change does not expand model availability, reasoning support, context limits, or account permissions. GPT and Claude routes stay unchanged. The existing Haiku forward-compatible compatibility fallback is preserved; a live Haiku baseline/control pair both succeeded, so this PR makes no Haiku failure claim.

Production TypeScript: **+0/-4**. Declarative manifest: **+28/-0**, required to expose the existing API and four compatibility fields on the four Gemini rows. Test support: **+91/-0**. Docs: **+3/-2**. No new production export, configuration setting, dependency or core provider-specific branch.

## User Impact

Copilot Gemini models keep using Chat Completions even when a live catalog is unavailable. No manual API override is required. The bundled catalog and its published catalog projection carry the same transport metadata.

## Evidence

- Live before/control proof through the actual static resolver → provider wrapper → API registry → SDK: unchanged Gemini3.6Flash selection sent `/responses` and received HTTP400 `unsupported_api_for_model`; an explicitly labeled API/compatibility control sent `/chat/completions` and received HTTP200 with the exact fresh nonce. This was a source-level provider flow, not a full Gateway session.
- Final candidate live proof used the actual updated static resolver, registered Copilot auth/stream hooks, API registry and OpenAI SDK, with no selected-model overrides. Both Gemini3.6Flash tool-round-trip requests returned HTTP200. The first request did not contain the nonce; one harmless local tool callback supplied it only in the tool result, and the final response returned the exact nonce. Both wire payloads used `max_tokens` and a system role, without `store`, `stream_options`, developer role or `max_completion_tokens`. Source and SDK hashes were unchanged throughout. This proves the registered source-provider flow, not full Gateway or enterprise-tenant behavior.
- Regression before the repair: five Gemini cases failed on Responses versus Chat Completions, with three controls passing. After the repair: **66 tests passed across three focused files**, including all four static Gemini entries, discovery-enabled missing-live-row fallback, GPT/Claude routes, existing forward-compatible Haiku behavior, and provider discovery contracts.
- Targeted syntax lint, changed test-helper type-aware/type-check, formatting, docs MDX, max-lines ratchet and whitespace checks passed. Full extension typing/build remains a hosted CI gate: this linked worktree lacks built plugin-SDK declaration artifacts, including on the baseline.
- Fresh Codex P0–P2 review and a separate independent source review reported no actionable findings. The independent verifier also checked the live artifact against the exact source and SDK hashes.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33108866593) completed successfully for `501541c0e3c93c23a28d35a496483155c21788f6`: 127 successful jobs,20 conditional skips,zero failures. The [complete ClawSweeper review](https://github.com/openclaw/openclaw/pull/131143#issuecomment-5444489404) has no correctness findings. Its Rank-up moves are CI completion (done) and catalog projection verification (scheduled after merge).

The missing Gemini metadata was carried forward by #113681; this is not evidence that it first introduced the bug. No shipped-release completion or catalog publication is claimed before verification.
