### PR TITLE
refactor(cli): reuse function-shaped lazy loaders

### DIFF
--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -66,7 +66,7 @@ import {
   detectPluginVersionDrift,
   type PluginVersionDriftReport,
 } from "../../plugins/plugin-version-drift.js";
-import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { createLazyPromise } from "../../shared/lazy-promise.js";
 import { VERSION } from "../../version.js";
 import { resolveGatewayLocalPortOverride } from "../gateway-port-option.js";
 import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
@@ -133,45 +133,13 @@ type CliStatusSummary = {
 
 type GatewayConnectFailureKind = ReturnType<typeof classifyGatewayConnectFailure>["kind"];
 
-const gatewayProbeAuthModuleLoader = createLazyImportLoader(
-  () => import("../../gateway/probe-auth.js"),
-);
-const daemonInspectModuleLoader = createLazyImportLoader(() => import("../../daemon/inspect.js"));
-const launchdModuleLoader = createLazyImportLoader(() => import("../../daemon/launchd.js"));
-const serviceAuditModuleLoader = createLazyImportLoader(
-  () => import("../../daemon/service-audit.js"),
-);
-const gatewayTlsModuleLoader = createLazyImportLoader(() => import("../../infra/tls/gateway.js"));
-const daemonProbeModuleLoader = createLazyImportLoader(() => import("./probe.js"));
-const restartHealthModuleLoader = createLazyImportLoader(() => import("./restart-health.js"));
-
-function loadGatewayProbeAuthModule() {
-  return gatewayProbeAuthModuleLoader.load();
-}
-
-function loadDaemonInspectModule() {
-  return daemonInspectModuleLoader.load();
-}
-
-function loadLaunchdModule() {
-  return launchdModuleLoader.load();
-}
-
-function loadServiceAuditModule() {
-  return serviceAuditModuleLoader.load();
-}
-
-function loadGatewayTlsModule() {
-  return gatewayTlsModuleLoader.load();
-}
-
-function loadDaemonProbeModule() {
-  return daemonProbeModuleLoader.load();
-}
-
-function loadRestartHealthModule() {
-  return restartHealthModuleLoader.load();
-}
+const loadGatewayProbeAuthModule = createLazyPromise(() => import("../../gateway/probe-auth.js"));
+const loadDaemonInspectModule = createLazyPromise(() => import("../../daemon/inspect.js"));
+const loadLaunchdModule = createLazyPromise(() => import("../../daemon/launchd.js"));
+const loadServiceAuditModule = createLazyPromise(() => import("../../daemon/service-audit.js"));
+const loadGatewayTlsModule = createLazyPromise(() => import("../../infra/tls/gateway.js"));
+const loadDaemonProbeModule = createLazyPromise(() => import("./probe.js"));
+const loadRestartHealthModule = createLazyPromise(() => import("./restart-health.js"));
 
 function resolveSnapshotRuntimeConfig(snapshot: ConfigFileSnapshot | null): OpenClawConfig | null {
   if (!snapshot?.valid || !snapshot.runtimeConfig) {

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -17,7 +17,7 @@ import type {
 } from "../../logging/diagnostic-stability.js";
 import type { WriteDiagnosticSupportExportResult } from "../../logging/diagnostic-support-export.js";
 import { defaultRuntime } from "../../runtime.js";
-import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { createLazyPromise } from "../../shared/lazy-promise.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayServiceCommands } from "../daemon-cli/register-service-commands.js";
 import { formatCliJsonFailure, rethrowExpectedCliError } from "../failure-output.js";
@@ -38,28 +38,26 @@ import { runGatewayResume, runGatewaySuspend } from "./suspend-cli.js";
 
 type GatewayRpcOpts = Parameters<typeof callGatewayFromCliWithTransport>[1];
 
-const configModuleLoader = createLazyImportLoader(
+const loadConfigModule = createLazyPromise(
   () => import("../../config/read-best-effort-config.runtime.js"),
 );
-const gatewayStatusModuleLoader = createLazyImportLoader(
-  () => import("../../commands/gateway-status.js"),
-);
-const gatewayHealthModuleLoader = createLazyImportLoader(() => import("../../commands/health.js"));
-const bonjourDiscoveryModuleLoader = createLazyImportLoader(
+const loadGatewayStatusModule = createLazyPromise(() => import("../../commands/gateway-status.js"));
+const loadGatewayHealthModule = createLazyPromise(() => import("../../commands/health.js"));
+const loadBonjourDiscoveryModule = createLazyPromise(
   () => import("../../infra/bonjour-discovery.js"),
 );
-const wideAreaDnsModuleLoader = createLazyImportLoader(() => import("../../infra/widearea-dns.js"));
-const healthStyleModuleLoader = createLazyImportLoader(
+const loadWideAreaDnsModule = createLazyPromise(() => import("../../infra/widearea-dns.js"));
+const loadHealthStyleModule = createLazyPromise(
   () => import("../../../packages/terminal-core/src/health-style.js"),
 );
-const usageFormatModuleLoader = createLazyImportLoader(() => import("../../utils/usage-format.js"));
-const stabilityBundleModuleLoader = createLazyImportLoader(
+const loadUsageFormatModule = createLazyPromise(() => import("../../utils/usage-format.js"));
+const loadStabilityBundleModule = createLazyPromise(
   () => import("../../logging/diagnostic-stability-bundle.js"),
 );
-const supportExportModuleLoader = createLazyImportLoader(
+const loadSupportExportModule = createLazyPromise(
   () => import("../../logging/diagnostic-support-export.js"),
 );
-const daemonStatusGatherModuleLoader = createLazyImportLoader(
+const loadDaemonStatusGatherModule = createLazyPromise(
   () => import("../daemon-cli/status.gather.js"),
 );
 
@@ -69,46 +67,6 @@ type GatewayCliDependencies = {
   loadGatewayHealthModule?: typeof loadGatewayHealthModule;
   loadHealthStyleModule?: typeof loadHealthStyleModule;
 };
-
-function loadConfigModule() {
-  return configModuleLoader.load();
-}
-
-function loadGatewayStatusModule() {
-  return gatewayStatusModuleLoader.load();
-}
-
-function loadGatewayHealthModule() {
-  return gatewayHealthModuleLoader.load();
-}
-
-function loadBonjourDiscoveryModule() {
-  return bonjourDiscoveryModuleLoader.load();
-}
-
-function loadWideAreaDnsModule() {
-  return wideAreaDnsModuleLoader.load();
-}
-
-function loadHealthStyleModule() {
-  return healthStyleModuleLoader.load();
-}
-
-function loadUsageFormatModule() {
-  return usageFormatModuleLoader.load();
-}
-
-function loadStabilityBundleModule() {
-  return stabilityBundleModuleLoader.load();
-}
-
-function loadSupportExportModule() {
-  return supportExportModuleLoader.load();
-}
-
-function loadDaemonStatusGatherModule() {
-  return daemonStatusGatherModuleLoader.load();
-}
 
 function gatewayCallOpts(cmd: Command, defaultTimeoutMs = DEFAULT_GATEWAY_RPC_TIMEOUT_MS): Command {
   return addGatewayClientOptions(cmd, { timeoutMs: defaultTimeoutMs }).option(

--- a/src/cli/program/routed-command-definitions.ts
+++ b/src/cli/program/routed-command-definitions.ts
@@ -1,6 +1,6 @@
 // Lazy command implementations for routes that can bypass full Commander registration.
 import { defaultRuntime } from "../../runtime.js";
-import { createLazyImportLoader } from "../../shared/lazy-promise.js";
+import { createLazyPromise } from "../../shared/lazy-promise.js";
 import {
   parseAgentsListRouteArgs,
   parseChannelsListRouteArgs,
@@ -22,11 +22,6 @@ import {
 type RouteArgParser<TArgs> = (argv: string[]) => TArgs | null;
 
 type ParsedRouteArgs<TParse extends RouteArgParser<unknown>> = Exclude<ReturnType<TParse>, null>;
-type AgentsListCommandModule = typeof import("../../commands/agents.commands.list.js");
-type ConfigCliModule = typeof import("../config-cli.js");
-type ModelsListCommandModule = typeof import("../../commands/models/list.list-command.js");
-type ModelsStatusCommandModule = typeof import("../../commands/models/list.status-command.js");
-type TasksJsonCommandModule = typeof import("../../commands/tasks-json.js");
 
 /** Typed parsed route definition that binds one parser to its runner. */
 type RoutedCommandDefinition<TParse extends RouteArgParser<unknown>> = {
@@ -46,39 +41,17 @@ function defineRoutedCommand<TParse extends RouteArgParser<unknown>>(
   return definition;
 }
 
-const configCliLoader = createLazyImportLoader<ConfigCliModule>(() => import("../config-cli.js"));
-const agentsListCommandLoader = createLazyImportLoader<AgentsListCommandModule>(
+const loadConfigCli = createLazyPromise(() => import("../config-cli.js"));
+const loadAgentsListCommand = createLazyPromise(
   () => import("../../commands/agents.commands.list.js"),
 );
-const modelsListCommandLoader = createLazyImportLoader<ModelsListCommandModule>(
+const loadModelsListCommand = createLazyPromise(
   () => import("../../commands/models/list.list-command.js"),
 );
-const modelsStatusCommandLoader = createLazyImportLoader<ModelsStatusCommandModule>(
+const loadModelsStatusCommand = createLazyPromise(
   () => import("../../commands/models/list.status-command.js"),
 );
-const tasksJsonCommandLoader = createLazyImportLoader<TasksJsonCommandModule>(
-  () => import("../../commands/tasks-json.js"),
-);
-
-function loadConfigCli(): Promise<ConfigCliModule> {
-  return configCliLoader.load();
-}
-
-function loadAgentsListCommand(): Promise<AgentsListCommandModule> {
-  return agentsListCommandLoader.load();
-}
-
-function loadModelsListCommand(): Promise<ModelsListCommandModule> {
-  return modelsListCommandLoader.load();
-}
-
-function loadModelsStatusCommand(): Promise<ModelsStatusCommandModule> {
-  return modelsStatusCommandLoader.load();
-}
-
-function loadTasksJsonCommand(): Promise<TasksJsonCommandModule> {
-  return tasksJsonCommandLoader.load();
-}
+const loadTasksJsonCommand = createLazyPromise(() => import("../../commands/tasks-json.js"));
 
 /** Route id to lazy parser/runner definition. */
 export const routedCommandDefinitions = {


### PR DESCRIPTION
## What Problem This Solves

The gateway, daemon-status, and routed CLI paths repeat private forwarding functions around lazy import loaders even though the shared lazy-promise owner already exposes the same function-shaped API. This maintainer-requested cleanup removes that unnecessary indirection.

## Why This Change Was Made

Use the existing `createLazyPromise` for all 22 forwarding-only loaders across these three owners. Deferred imports, cached promise identity, concurrent-load deduplication, and rejection eviction still use the unchanged canonical implementation. Remove five private type aliases used only by those wrappers.

The refresh preserves the local-port selection and authentication behavior from #130847 (gateway status leaf-port handling); daemon service registration is untouched. Production LOC: +25/-126, net -101. Tests: +0/-0. No new helper, compatibility path, flag, configuration, or dependency.

## User Impact

No user-visible behavior change. Commands, options, output, startup laziness, and retry behavior remain the same. This is an AI-assisted internal refactor requested by the maintainer.

## Evidence

- Fresh independent P0-P3 precommit review: no findings. Complete owner/caller/callee/sibling/history review and AST equivalence checks preserve all 122 other top-level statements and each lazy import expression.
- Pinned Linux baseline and candidate: the same eight existing test files passed, 214 tests plus one Darwin-only skip on each version. Coverage includes lazy-promise retries, real Commander parsing, gateway/daemon status, probe, inherited/leaf port precedence, and routing.
- Full candidate changed gate passed: core/coreTests type checks, lint, format, all three Knip scans, and repository guards. Baseline CLI-startup build and full candidate production build passed, including the CLI bootstrap and plugin export checks; no ineffective-dynamic-import warnings.
- 34 real built CLI processes passed using disposable state and source fallback disabled: help, health JSON/text, config lookup, tasks list/audit, status aliases, and 16 explicit-local-port cases. Six stable outputs matched literally. Remote-mode config and a distinct decoy endpoint verify leaf/inherited port selection, leaf-over-parent precedence, local auth, and no-probe behavior; zero decoy connections. The gateway transport was an owned deterministic fixture, not a live-provider or installed-service test.
- Five complete inventories of 34,349 tracked files verified that baseline remained unchanged and candidate differed only by this three-file patch. The proof's temporary dependency build output was restored; artifacts were collected and verified before the owned environment was stopped.
- Supplemental candidate macOS run: all 215 tests passed, including the Darwin case. Existing local Vitest/tsx versions were older than the declared pins, so pinned proof comes from Linux.

Linux provider: `blacksmith-testbox`; lease `tbx_01m128grx6q7501h6jyj093r0b`; [proof workflow](https://github.com/openclaw/openclaw/actions/runs/33104856492). The managed command completed with exit code 0 before explicit lease cleanup; the linked workflow can show cancellation after the lease is stopped. Exact proof base: `19d61d9ada04b5b9af24efc444f7bd05c53b82c0`. Candidate patch SHA-256: `87223049862215602503de4b02eac8a99128794c17a0708db15ccfb471d3a7e7`. Collected evidence archive SHA-256: `f7f0e6f0089e6d51364222effe619df86728f23e826664331e05f4b2e469c6ac`.

Focused command on both Linux versions:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/shared/lazy-promise.test.ts \
  src/cli/gateway-cli/register.option-collisions.test.ts \
  src/cli/daemon-cli/register-service-commands.test.ts \
  src/cli/daemon-cli/status.gather.test.ts \
  src/cli/daemon-cli/probe.test.ts \
  src/cli/gateway-port-option.test.ts \
  src/cli/program/routes.test.ts \
  src/cli/route.test.ts
```

Candidate gate/build commands in the isolated Linux worktree:

```sh
OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs \
  --base 19d61d9ada04b5b9af24efc444f7bd05c53b82c0 --staged
node --import ./scripts/tsx.mjs scripts/build-all.mts
```

The changed-gate environment flag is the wrapper's delegation-loop guard, not a skipped check. Built-CLI proof covers read-only commands only; it does not claim installation or service lifecycle validation.
