### PR TITLE
perf(copilot): avoid duplicating BYOK request bodies

### DIFF
--- a/extensions/copilot/src/byok-proxy.test.ts
+++ b/extensions/copilot/src/byok-proxy.test.ts
@@ -15,6 +15,7 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
 describe("createCopilotByokProxy", () => {
   afterEach(() => {
     ssrfRuntimeMock.fetchWithSsrFGuard.mockReset();
+    vi.restoreAllMocks();
   });
 
   it("presents a loopback SDK endpoint and forwards through guarded fetch", async () => {
@@ -81,6 +82,77 @@ describe("createCopilotByokProxy", () => {
       await proxy?.close();
     }
   });
+
+  it.each([307, 308])("preserves binary request bytes across a %i redirect", async (status) => {
+    const { fetchWithSsrFGuard } = await vi.importActual<
+      typeof import("openclaw/plugin-sdk/ssrf-runtime")
+    >("openclaw/plugin-sdk/ssrf-runtime");
+    ssrfRuntimeMock.fetchWithSsrFGuard.mockImplementation(fetchWithSsrFGuard);
+    const clientFetch = globalThis.fetch;
+    const received: Buffer[] = [];
+    const upstreamFetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (url, init) => {
+      const request = new Request(url, init);
+      expect(request.method).toBe("POST");
+      received.push(Buffer.from(await request.arrayBuffer()));
+      return received.length === 1
+        ? new Response(null, { status, headers: { location: "/v1/replayed" } })
+        : new Response("ok");
+    });
+    const proxy = await createCopilotByokProxy(
+      resolveCopilotProvider({
+        model: {
+          provider: "custom-proxy",
+          api: "openai-responses",
+          id: "proxy-model",
+          baseUrl: "https://proxy.example/v1",
+        },
+      }),
+    );
+    // Keep invalid UTF-8 and a nonzero offset: forwarding the backing pool would leak other bytes.
+    const body = Buffer.from([42, 0, 255, 128, 192, 10, 42]).subarray(1, -1);
+    try {
+      const response = await clientFetch(`${proxy?.provider.provider?.baseUrl}/responses`, {
+        method: "POST",
+        body,
+      });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe("ok");
+      expect(upstreamFetch).toHaveBeenCalledTimes(2);
+      expect(received).toEqual([body, body]);
+    } finally {
+      await proxy?.close();
+    }
+  });
+
+  it.each(["GET", "HEAD", "POST"])(
+    "forwards an empty %s request without a body",
+    async (method) => {
+      ssrfRuntimeMock.fetchWithSsrFGuard.mockResolvedValue({
+        response: new Response(null, { status: 204 }),
+        release: vi.fn(async () => undefined),
+      });
+      const proxy = await createCopilotByokProxy(
+        resolveCopilotProvider({
+          model: {
+            provider: "custom-proxy",
+            api: "openai-responses",
+            id: "proxy-model",
+            baseUrl: "https://proxy.example/v1",
+          },
+        }),
+      );
+      try {
+        const response = await fetch(`${proxy?.provider.provider?.baseUrl}/responses`, { method });
+        expect(response.status).toBe(204);
+        expect(ssrfRuntimeMock.fetchWithSsrFGuard).toHaveBeenCalledWith(
+          expect.objectContaining({ init: expect.objectContaining({ method }) }),
+        );
+        expect(ssrfRuntimeMock.fetchWithSsrFGuard.mock.calls[0]?.[0].init.body).toBeUndefined();
+      } finally {
+        await proxy?.close();
+      }
+    },
+  );
 
   it("injects resolved bearer auth when the SDK request omits Authorization", async () => {
     ssrfRuntimeMock.fetchWithSsrFGuard.mockResolvedValue({

--- a/extensions/copilot/src/byok-proxy.ts
+++ b/extensions/copilot/src/byok-proxy.ts
@@ -126,7 +126,7 @@ async function handleProxyRequest(
             : undefined,
         }),
         signal: upstreamAbort.signal,
-        ...(body ? { body: toFetchBody(body) } : {}),
+        ...(body ? { body } : {}),
       },
       auditContext: "copilot-byok-provider",
       requireHttps: true,
@@ -210,18 +210,12 @@ function isNonceProtectedProxyRequest(req: IncomingMessage, proxyPathPrefix: str
   );
 }
 
-async function readBody(req: IncomingMessage): Promise<Buffer | undefined> {
+async function readBody(req: IncomingMessage): Promise<Buffer<ArrayBuffer> | undefined> {
   const chunks: Buffer[] = [];
   for await (const chunk of req) {
     chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
   }
   return chunks.length > 0 ? Buffer.concat(chunks) : undefined;
-}
-
-function toFetchBody(body: Buffer): Uint8Array<ArrayBuffer> {
-  const copy = new Uint8Array(body.byteLength);
-  copy.set(body);
-  return copy;
 }
 
 function normalizeProxyRequestHeaders(headers: IncomingMessage["headers"]): Record<string, string> {


### PR DESCRIPTION
Related: #99064. This is a separate performance improvement, not a replacement or resolution of the request-body limit proposal. Thanks @sunlit-deng for the report that prompted this investigation.

## What Problem This Solves

Copilot agent-runtime users with BYOK providers incur an unnecessary full-size memory allocation and copy for every outgoing request. Large prompts, images, and histories amplify this overhead. In an instrumented real-loopback proxy run, a 32 MiB request caused an extra 32 MiB allocation inside the proxy before the HTTP transport handled it.

## Why This Change Was Made

Keep the accurately typed `Buffer<ArrayBuffer>` returned by `Buffer.concat` and pass that Buffer view directly to guarded fetch. Delete the redundant `toFetchBody` allocator. Undici already consumes BufferSource views using their exact byte offset and length; passing the backing `.buffer` alone would be incorrect.

Retain buffered same-origin 307/308 replay. A real shared-guard/Undici loopback experiment showed that a streaming replacement succeeds without redirects but fails when asked to replay a consumed body after a 307. No size limit, intake timeout, SDK surface, configuration, auth policy, or persistent-store change is introduced.

## User Impact

BYOK requests avoid one whole-body allocation and copy, with unchanged request bytes, authentication, redirect behavior, and shutdown handling. This is not a zero-allocation transport: body collection and Undici's own copy remain. The unbounded collector discussed in #99064 remains open and is not fixed by this PR.

## Evidence

- Before/after actual proxy allocation instrumentation: the same 32 MiB chunked request produced 33,554,432 versus 0 redundant proxy-specific Uint8Array bytes. Both runs returned HTTP 200 after a 307; both upstream bodies had the same length and SHA256. Upstream responses were mocked for this allocation measurement, not represented as vendor proof.
- Actual Copilot SDK **1.0.11** / CLI **1.0.80** → changed loopback proxy → OpenAI Responses API: one POST, HTTP **200**, exact unique nonce returned by `gpt-5.6-luna`. Source hashes bound the run to the candidate. Empty-mode SDK session, tools disabled, deny-all permission handler, zero permission requests, empty isolated workspace unchanged, client cleanup returned no errors, and temporary runtime state was removed. This is source-runtime proof, not installed OpenClaw package proof.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/copilot/src/byok-proxy.test.ts extensions/copilot/src/provider-bridge.test.ts`: **24 passed**. New behavior-preservation cases exercise real HTTP ingress and the actual shared guard's 307/308 handling with byte-exact binary payloads, including invalid UTF-8/nonzero Buffer offsets, plus empty GET/HEAD/POST requests. These controls also passed before the performance change; the before/after allocation probe measures the regression being removed.
- Existing bearer-auth, Azure routing, and in-flight shutdown checks remain green. A separate real-loopback diagnostic preserves ordinary delayed uploads, a completed 17 MiB chunked upload, and close-during-incomplete-body behavior.
- Targeted formatting, type-aware lint, and `git diff --check` passed. Fresh P0–P2 autoreview and a separate direct independent Codex review found no actionable findings. [Exact-head CI run 33109006153](https://github.com/openclaw/openclaw/actions/runs/33109006153) completed successfully for `814f35b5da7599facf02f292ab33832b4a84e676`: 30 successful jobs, 21 intentionally skipped, and no failed or cancelled jobs.

Production: **+2/-8 (net -6)**. Tests: **+72/-0**. AI-assisted maintainer change; no contributor code was reused.

Named follow-up outside this topic: `copilot-proxy`'s README says disabled by default although its manifest and public provider documentation say enabled by default.
