### PR TITLE
refactor(plugins): separate consent mutation from inventory

### DIFF
--- a/src/cli/plugins-cli.policy.test.ts
+++ b/src/cli/plugins-cli.policy.test.ts
@@ -163,8 +163,9 @@ describe("plugins cli policy mutations", () => {
 
       await runPluginsCommand(["plugins", "enable", "alpha", "--accept-capabilities"]);
 
-      const { computeDeclaredSurfaceHash, resolvePluginArtifactDeclaredSurface } =
+      const { resolvePluginArtifactDeclaredSurface } =
         await import("../plugins/capability-consent.js");
+      const { computeDeclaredSurfaceHash } = await import("../plugins/capability-summary.js");
       const acceptedRecord =
         writePersistedInstalledPluginIndexInstallRecordsWithLeaseMock.mock.calls[0]?.[0]?.alpha;
       expect(acceptedRecord?.acceptedSurfaceHash).toBe(

--- a/src/cli/plugins-list-command.test.ts
+++ b/src/cli/plugins-list-command.test.ts
@@ -90,8 +90,6 @@ describe("runPluginsListCommand", () => {
     vi.doUnmock("../plugins/status.js");
     vi.doUnmock("../plugins/status-snapshot.js");
     vi.doUnmock("../plugins/source-display.js");
-    vi.doUnmock("../terminal/table.js");
-    vi.doUnmock("../terminal/theme.js");
     vi.doUnmock("../../packages/terminal-core/src/table.js");
     vi.doUnmock("../../packages/terminal-core/src/theme.js");
     vi.doUnmock("./command-format.js");
@@ -129,45 +127,7 @@ describe("runPluginsListCommand", () => {
         diagnostics: [],
       }),
     }));
-    vi.doMock("../plugins/source-display.js", () => {
-      importedHumanModules.push("source-display");
-      return {
-        formatPluginSourceForTable: vi.fn(),
-        resolvePluginSourceRoots: vi.fn(),
-      };
-    });
-    vi.doMock("../terminal/table.js", () => {
-      importedHumanModules.push("table");
-      return {
-        getTerminalTableWidth: vi.fn(),
-        renderTable: vi.fn(),
-      };
-    });
-    vi.doMock("../terminal/theme.js", () => {
-      importedHumanModules.push("theme");
-      return {
-        theme: {
-          muted: (value: string) => value,
-          heading: (value: string) => value,
-          command: (value: string) => value,
-          error: (value: string) => value,
-          success: (value: string) => value,
-          warn: (value: string) => value,
-        },
-      };
-    });
-    vi.doMock("./command-format.js", () => {
-      importedHumanModules.push("command-format");
-      return {
-        formatCliCommand: (value: string) => value,
-      };
-    });
-    vi.doMock("./plugins-list-format.js", () => {
-      importedHumanModules.push("plugins-list-format");
-      return {
-        formatPluginLine: vi.fn(),
-      };
-    });
+    mockHumanListModules(importedHumanModules);
 
     const { runPluginsListCommand } = await import("./plugins-list-command.js");
     const writes: unknown[] = [];

--- a/src/cli/plugins-list-route-cold-imports.test.ts
+++ b/src/cli/plugins-list-route-cold-imports.test.ts
@@ -48,6 +48,10 @@ vi.mock("../plugins/loader-module-runtime.js", () => {
   return {};
 });
 
+vi.mock("../plugins/capability-consent.js", () => {
+  throw new Error("metadata inventory must not load the capability consent mutation owner");
+});
+
 import { tryRouteCli } from "./route.js";
 
 const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugins-list-route-"));

--- a/src/plugins/capability-consent.test.ts
+++ b/src/plugins/capability-consent.test.ts
@@ -7,14 +7,17 @@ import type {
 } from "../config/types.plugins.js";
 import {
   buildPluginCapabilityConsentReview,
-  computeDeclaredSurfaceHash,
   createManagedPluginArtifactConsentHandler,
   diffDeclaredSurfaceWidening,
-  resolveAcceptedSurfaceCurrent,
   resolvePluginArtifactDeclaredSurface,
-  resolvePluginInstallRecordIntegrity,
 } from "./capability-consent.js";
-import { buildPluginCapabilitySummary, mergePluginDeclaredSurfaces } from "./capability-summary.js";
+import {
+  buildPluginCapabilitySummary,
+  computeDeclaredSurfaceHash,
+  mergePluginDeclaredSurfaces,
+  resolveAcceptedSurfaceCurrent,
+  resolvePluginInstallRecordIntegrity,
+} from "./capability-summary.js";
 import { resolveInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
 import { loadInstalledPluginIndexWithDiscovery } from "./installed-plugin-index.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";

--- a/src/plugins/capability-consent.ts
+++ b/src/plugins/capability-consent.ts
@@ -1,10 +1,8 @@
-import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { PLUGIN_DECLARED_SURFACE_GROUPS } from "../../packages/gateway-protocol/src/schema/plugin-declared-surface-groups.js";
 import type {
-  PluginInspectSource,
   PluginInstallTrust,
   PluginsInspectResult,
 } from "../../packages/gateway-protocol/src/schema/plugins.js";
@@ -24,7 +22,10 @@ import { isPathInside } from "../infra/path-guards.js";
 import { resolveUserPath } from "../utils.js";
 import {
   buildPluginCapabilitySummary,
+  computeDeclaredSurfaceHash,
   mergePluginDeclaredSurfaces,
+  resolveAcceptedSurfaceCurrent,
+  resolvePluginInstallRecordIntegrity,
   resolvePluginPackageDeclaredSurface,
 } from "./capability-summary.js";
 import { resolvePluginControlPlaneWorkspace } from "./control-plane-workspace.js";
@@ -174,13 +175,6 @@ export function resolvePluginArtifactDeclaredSurface(
   );
 }
 
-export function computeDeclaredSurfaceHash(declared: PluginAcceptedDeclaredSurface): string {
-  const canonical = Object.fromEntries(
-    PLUGIN_DECLARED_SURFACE_GROUPS.map((group) => [group, declared[group].toSorted()]),
-  );
-  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
-}
-
 export function diffDeclaredSurfaceWidening(
   previous: PluginAcceptedDeclaredSurface,
   next: PluginAcceptedDeclaredSurface,
@@ -194,36 +188,6 @@ export function diffDeclaredSurfaceWidening(
     }
   }
   return { widened, hasWidening: Object.keys(widened).length > 0 };
-}
-
-export function resolvePluginInstallRecordIntegrity(
-  record: Pick<PluginInstallRecord, "integrity" | "npmIntegrity" | "clawpackSha256" | "gitCommit">,
-):
-  | { integrity: string; integrityKind: NonNullable<PluginInspectSource["integrityKind"]> }
-  | undefined {
-  const npmIntegrity = record.integrity ?? record.npmIntegrity;
-  if (npmIntegrity) {
-    return { integrity: npmIntegrity, integrityKind: "ssri" };
-  }
-  if (record.clawpackSha256) {
-    return { integrity: record.clawpackSha256, integrityKind: "sha256" };
-  }
-  return record.gitCommit
-    ? { integrity: record.gitCommit, integrityKind: "git-commit" }
-    : undefined;
-}
-
-export function resolveAcceptedSurfaceCurrent(
-  record: PluginInstallRecord,
-  declared: PluginAcceptedDeclaredSurface,
-): boolean {
-  return (
-    record.acceptedSurface !== undefined &&
-    record.acceptedSurfaceHash !== undefined &&
-    record.acceptedSurfaceHash === computeDeclaredSurfaceHash(record.acceptedSurface) &&
-    record.acceptedSurfaceHash === computeDeclaredSurfaceHash(declared) &&
-    record.acceptedSurfaceIntegrity === resolvePluginInstallRecordIntegrity(record)?.integrity
-  );
 }
 
 export type PluginCapabilityConsentAcknowledgment = { reviewToken: string };
@@ -675,8 +639,4 @@ export async function prepareManagedPluginArtifactConsentHandler(
     previousRecords,
     previousPluginOwners,
   });
-}
-
-export function formatPluginCapabilityConsentRequired(pluginId: string): string {
-  return `Plugin "${pluginId}" requires capability consent; disable and re-enable it or run \`openclaw plugins enable ${pluginId} --accept-capabilities\`.`;
 }

--- a/src/plugins/capability-summary.ts
+++ b/src/plugins/capability-summary.ts
@@ -1,10 +1,17 @@
+// Inventory needs capability facts without artifact inspection or lifecycle writes.
+import { createHash } from "node:crypto";
 import { PLUGIN_DECLARED_SURFACE_GROUPS } from "../../packages/gateway-protocol/src/schema/plugin-declared-surface-groups.js";
 import type {
   PluginDeclaredSurface,
   PluginHookGrant,
+  PluginInspectSource,
   PluginOperatorGrants,
 } from "../../packages/gateway-protocol/src/schema/plugins.js";
-import type { PluginEntryConfig } from "../config/types.plugins.js";
+import type {
+  PluginAcceptedDeclaredSurface,
+  PluginEntryConfig,
+  PluginInstallRecord,
+} from "../config/types.plugins.js";
 import {
   resolveConversationAccessAllowed,
   resolvePromptInjectionAllowed,
@@ -102,6 +109,47 @@ export function resolvePluginPackageDeclaredSurface(
     surfaces.push(buildPluginCapabilitySummary({ manifest, origin: manifest.origin }).declared);
   }
   return mergePluginDeclaredSurfaces(surfaces);
+}
+
+export function computeDeclaredSurfaceHash(declared: PluginAcceptedDeclaredSurface): string {
+  const canonical = Object.fromEntries(
+    PLUGIN_DECLARED_SURFACE_GROUPS.map((group) => [group, declared[group].toSorted()]),
+  );
+  return createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+export function resolvePluginInstallRecordIntegrity(
+  record: Pick<PluginInstallRecord, "integrity" | "npmIntegrity" | "clawpackSha256" | "gitCommit">,
+):
+  | { integrity: string; integrityKind: NonNullable<PluginInspectSource["integrityKind"]> }
+  | undefined {
+  const npmIntegrity = record.integrity ?? record.npmIntegrity;
+  if (npmIntegrity) {
+    return { integrity: npmIntegrity, integrityKind: "ssri" };
+  }
+  if (record.clawpackSha256) {
+    return { integrity: record.clawpackSha256, integrityKind: "sha256" };
+  }
+  return record.gitCommit
+    ? { integrity: record.gitCommit, integrityKind: "git-commit" }
+    : undefined;
+}
+
+export function resolveAcceptedSurfaceCurrent(
+  record: PluginInstallRecord,
+  declared: PluginAcceptedDeclaredSurface,
+): boolean {
+  return (
+    record.acceptedSurface !== undefined &&
+    record.acceptedSurfaceHash !== undefined &&
+    record.acceptedSurfaceHash === computeDeclaredSurfaceHash(record.acceptedSurface) &&
+    record.acceptedSurfaceHash === computeDeclaredSurfaceHash(declared) &&
+    record.acceptedSurfaceIntegrity === resolvePluginInstallRecordIntegrity(record)?.integrity
+  );
+}
+
+export function formatPluginCapabilityConsentRequired(pluginId: string): string {
+  return `Plugin "${pluginId}" requires capability consent; disable and re-enable it or run \`openclaw plugins enable ${pluginId} --accept-capabilities\`.`;
 }
 
 function buildHookGrant(effective: boolean, configured: boolean | undefined): PluginHookGrant {

--- a/src/plugins/install-record-commit.sqlite.test.ts
+++ b/src/plugins/install-record-commit.sqlite.test.ts
@@ -9,10 +9,10 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { withEnvAsync } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
-  computeDeclaredSurfaceHash,
   resolvePluginArtifactDeclaredSurface,
   resolvePluginCapabilityConsent,
 } from "./capability-consent.js";
+import { computeDeclaredSurfaceHash } from "./capability-summary.js";
 import { enablePluginWithCapabilityConsent } from "./enable.js";
 import { commitConfigWriteWithPendingPluginInstalls } from "./install-record-commit.js";
 import { writePersistedInstalledPluginIndexInstallRecordsWithLease } from "./installed-plugin-index-records.js";

--- a/src/plugins/management-service.capability-consent.test.ts
+++ b/src/plugins/management-service.capability-consent.test.ts
@@ -3,13 +3,12 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import {
-  computeDeclaredSurfaceHash,
   createManagedPluginArtifactConsentHandler,
   resolvePluginArtifactDeclaredSurface,
   resolvePluginCapabilityConsent,
   type PluginCapabilityConsentHandler,
 } from "./capability-consent.js";
-import { buildPluginCapabilitySummary } from "./capability-summary.js";
+import { buildPluginCapabilitySummary, computeDeclaredSurfaceHash } from "./capability-summary.js";
 import { recordInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
 import { loadInstalledPluginIndexWithDiscovery } from "./installed-plugin-index.js";
 import {

--- a/src/plugins/management-service.inspect.test.ts
+++ b/src/plugins/management-service.inspect.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { computeDeclaredSurfaceHash } from "./capability-consent.js";
+import { computeDeclaredSurfaceHash } from "./capability-summary.js";
 import {
   emptyMetadataSnapshot,
   hostedFeedDiffsEntry,

--- a/src/plugins/management-service.install.test.ts
+++ b/src/plugins/management-service.install.test.ts
@@ -1,7 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { computeDeclaredSurfaceHash } from "./capability-consent.js";
-import { buildPluginCapabilitySummary } from "./capability-summary.js";
+import { buildPluginCapabilitySummary, computeDeclaredSurfaceHash } from "./capability-summary.js";
 import {
   configSnapshot,
   hostedFeedDiffsEntry,

--- a/src/plugins/management-service.registry-refresh.test.ts
+++ b/src/plugins/management-service.registry-refresh.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { computeDeclaredSurfaceHash } from "./capability-consent.js";
-import { buildPluginCapabilitySummary } from "./capability-summary.js";
+import { buildPluginCapabilitySummary, computeDeclaredSurfaceHash } from "./capability-summary.js";
 import { recordInstalledPluginIndexInstallOwner } from "./installed-plugin-index-install-owner.js";
 import { recordPluginManifestInstallOwner } from "./manifest-install-owner.js";
 import { createColdPluginFixture } from "./test-helpers/cold-plugin-fixtures.js";

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -28,19 +28,19 @@ import { VERSION } from "../version.js";
 import { installBundledPluginSource } from "./bundled-install.js";
 import type { BundledPluginSource } from "./bundled-sources.js";
 import {
-  computeDeclaredSurfaceHash,
   prepareManagedPluginArtifactConsentHandler,
-  formatPluginCapabilityConsentRequired,
-  resolveAcceptedSurfaceCurrent,
   resolvePendingPluginCapabilityReview,
   resolvePluginCapabilityConsent,
-  resolvePluginInstallRecordIntegrity,
   resolvePluginInstallRecordTrust,
   type PluginCapabilityConsentAcknowledgment,
   type PluginCapabilityConsentHandler,
 } from "./capability-consent.js";
 import {
   buildPluginCapabilitySummary,
+  computeDeclaredSurfaceHash,
+  formatPluginCapabilityConsentRequired,
+  resolveAcceptedSurfaceCurrent,
+  resolvePluginInstallRecordIntegrity,
   resolvePluginPackageDeclaredSurface,
 } from "./capability-summary.js";
 import { CLAWHUB_INSTALL_ERROR_CODE, isUnavailableClawHubTarget } from "./clawhub-error-codes.js";

--- a/src/plugins/status-snapshot.ts
+++ b/src/plugins/status-snapshot.ts
@@ -3,10 +3,11 @@ import { uniqueStrings } from "@openclaw/normalization-core/string-normalization
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  buildPluginCapabilitySummary,
   formatPluginCapabilityConsentRequired,
+  mergePluginDeclaredSurfaces,
   resolveAcceptedSurfaceCurrent,
-} from "./capability-consent.js";
-import { buildPluginCapabilitySummary, mergePluginDeclaredSurfaces } from "./capability-summary.js";
+} from "./capability-summary.js";
 import {
   appendPluginControlPlaneWorkspaceDiagnostic,
   resolvePluginControlPlaneWorkspace,

--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -4,8 +4,7 @@ import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it } from "vitest";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
-import { computeDeclaredSurfaceHash } from "./capability-consent.js";
-import { buildPluginCapabilitySummary } from "./capability-summary.js";
+import { buildPluginCapabilitySummary, computeDeclaredSurfaceHash } from "./capability-summary.js";
 import {
   readPersistedInstalledPluginIndex,
   writePersistedInstalledPluginIndexSync,

--- a/src/plugins/update-capability-consent.ts
+++ b/src/plugins/update-capability-consent.ts
@@ -6,13 +6,15 @@ import type {
 import { readInstalledPackageManifest } from "../infra/package-update-utils.js";
 import {
   buildPluginCapabilityConsentReview,
-  computeDeclaredSurfaceHash,
   diffDeclaredSurfaceWidening,
-  resolveAcceptedSurfaceCurrent,
   resolvePluginArtifactDeclaredSurface,
-  resolvePluginInstallRecordIntegrity,
   type PluginCapabilityConsentHandler,
 } from "./capability-consent.js";
+import {
+  computeDeclaredSurfaceHash,
+  resolveAcceptedSurfaceCurrent,
+  resolvePluginInstallRecordIntegrity,
+} from "./capability-summary.js";
 import { normalizePluginsConfig, resolveEffectiveEnableState } from "./config-state.js";
 import type { PluginInstallArtifactConsentHandler } from "./install-types.js";
 import { ManagedPluginLifecycleError } from "./management-lifecycle-error.js";

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -7,10 +7,8 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { OpenClawConfig } from "../config/config.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import {
-  computeDeclaredSurfaceHash,
-  resolvePluginArtifactDeclaredSurface,
-} from "./capability-consent.js";
+import { resolvePluginArtifactDeclaredSurface } from "./capability-consent.js";
+import { computeDeclaredSurfaceHash } from "./capability-summary.js";
 import { makeTrackedTempDir } from "./test-helpers/fs-fixtures.js";
 
 const APP_ROOT = "/app";


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

`openclaw plugins list --json` was loading artifact-inspection, installation, and lifecycle-write dependencies just to report capability-consent facts. Metadata-only inventory paid this startup cost even though it never performed those operations.

## Why This Change Was Made

Move the four unchanged pure capability hash, integrity, acceptance, and diagnostic helpers into the existing capability-summary owner. Inventory now reads those facts without importing the consent mutation owner; installation, update, and enablement continue to use the same helpers and retain their artifact-review and lifecycle-lease behavior. All internal consumers move directly, with no aliases, new layer, public SDK change, or capability-policy change.

The existing cold-route regression now rejects mutation-owner imports. The JSON-renderer test also reuses its existing canonical mock helper, removing stale terminal-module mocks and duplicated setup.

Production: +64/-53 (net +11, import/type declarations and the cold-owner invariant comment; helper bodies are byte-identical). Tests: +22/-60 (net -38). Overall: -27 lines across 16 files.

## User Impact

Plugin inventory loads fewer modules while preserving its complete output. In the paired Linux sample, median startup time fell from 937.6 ms to 673.2 ms. Consent requirements, accepted-surface binding, install/update behavior, configuration, and storage are unchanged.

This is **not a claim that the intermittent startup-memory CI failure is fixed**. The unchanged guard passed, but candidate runs still reached approximately 400 MB RSS; reliable memory headroom remains a separate investigation.

## Evidence

- The extended real CLI-route regression failed on the original production source at the consent mutation import, then passed after the owner move.
- 284 focused tests passed across 12 files, covering inventory, capability facts, consent and artifact binding, installation, registry refresh, updates, SQLite commit behavior, and CLI policy.
- The actual 16-file changed gate passed, including core and test types, lint, dead exports, import cycles, and storage/auth guards. Diff-scoped cleanup and fresh isolated review found no actionable issues.
- Both canonical `pnpm build:ci-artifacts` and normal full `pnpm build` passed on Linux x64, Node 24.19.0, pnpm 11.22.0. The full build included canonical declarations and verified all 147 public SDK subpaths. Source hashes were checked before and after; all three build stamps matched the base commit.
- Same-host, isolated-HOME startup measurements used the unchanged guard and three unprofiled benchmark runs. Timing baseline: `19d61d9ada04b5b9af24efc444f7bd05c53b82c0`; candidate: that base plus the frozen patch, full-index diff SHA-256 `5728f3cd793d465681c4c81db81396d4f73a92a9dda23fb3b5c250b37b169130`. These are pre-commit snapshot measurements, not a claim about future committed-head CI.
- A separate native ESM trace recorded 1,678 → 1,521 translated modules, 1,158 → 1,016 external modules, and 109 → 0 `execa` modules. Instrumented tracing was not used as RSS evidence.
- Complete captured inventory output from the original CI merge `1d29795f5cedfbdce3b6c81943cf02a7960148fc` and the candidate matched for all 151 plugins after normalizing only the exact checkout prefixes in `source`/`rootDir` and the temporary-HOME prefix in `workspaceDir`. No fields or ordering were discarded.
