### PR TITLE
fix(sessions): preserve required creation stamps in storage

### DIFF
--- a/src/commands/doctor-session-canonical-keys.owner-repair.test.ts
+++ b/src/commands/doctor-session-canonical-keys.owner-repair.test.ts
@@ -45,6 +45,79 @@ function insertEmptyAlias(params: {
 
 describe("doctor transcript owner repair", () => {
   it.each([
+    { sourceAgentId: "main", requiredAlias: true, requiredCanonical: false },
+    { sourceAgentId: "ops", requiredAlias: true, requiredCanonical: false },
+    { sourceAgentId: "main", requiredAlias: true, requiredCanonical: true },
+    { sourceAgentId: "main", requiredAlias: false, requiredCanonical: false },
+  ])("preserves required creation provenance during canonical repair: %o", async (fixture) => {
+    await withStateDirEnv("openclaw-doctor-canonical-creation-stamp-", async ({ stateDir }) => {
+      const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+      const storeTemplate = path.join(stateDir, "agents", "{agentId}", "sessions.json");
+      const destinationStore = resolveSessionStorePathCore(storeTemplate, { agentId: "main", env });
+      const sourceStore = resolveSessionStorePathCore(storeTemplate, {
+        agentId: fixture.sourceAgentId,
+        env,
+      });
+      const canonicalKey = "agent:main:work";
+      const cfg: OpenClawConfig = {
+        agents: { list: [{ id: "main", default: true }, { id: "ops" }] },
+        session: { mainKey: "work", store: storeTemplate },
+      };
+      const canonicalStamp = {
+        createdVia: "operator" as const,
+        createdActor: { type: "human" as const, id: "profile-canonical" },
+        createdAt: 10,
+        ...(fixture.requiredCanonical ? { sandbox: "required" as const } : {}),
+      };
+      const aliasStamp = {
+        createdVia: "channel" as const,
+        createdActor: { type: "human" as const, id: "profile-alias" },
+        createdAt: 20,
+        ...(fixture.requiredAlias ? { sandbox: "required" as const } : {}),
+      };
+      insertLegacySession({
+        agentId: "main",
+        entry: {
+          ...canonicalStamp,
+          sessionId: "canonical-session",
+          updatedAt: fixture.requiredCanonical ? 10 : 30,
+        },
+        env,
+        sessionKey: canonicalKey,
+        storePath: destinationStore,
+      });
+      insertLegacySession({
+        agentId: fixture.sourceAgentId,
+        entry: { ...aliasStamp, sessionId: "alias-session", updatedAt: 20 },
+        env,
+        sessionKey: "agent:main:main",
+        storePath: sourceStore,
+      });
+
+      expect(await repairCanonicalSessionKeys({ apply: true, cfg, env })).toMatchObject({
+        foundGroups: 1,
+        repairedGroups: 1,
+      });
+      const repaired = loadExactSessionEntryReadOnly({
+        agentId: "main",
+        env,
+        sessionKey: canonicalKey,
+        storePath: destinationStore,
+      })?.entry;
+      const expectedStamp =
+        fixture.requiredAlias && !fixture.requiredCanonical ? aliasStamp : canonicalStamp;
+      expect(repaired).toMatchObject({
+        ...expectedStamp,
+        sessionId: fixture.requiredCanonical ? "alias-session" : "canonical-session",
+        updatedAt: fixture.requiredCanonical ? 20 : 30,
+      });
+      if (!fixture.requiredAlias && !fixture.requiredCanonical) {
+        expect(repaired).not.toHaveProperty("sandbox");
+      }
+    });
+  });
+
+  it.each([
     { label: "replaces a stale same-store owner", sourceAgentId: "main", winnerOwned: true },
     { label: "clears a stale same-store owner", sourceAgentId: "main", winnerOwned: false },
     { label: "lazily restores cross-store owner columns", sourceAgentId: "ops", winnerOwned: true },

--- a/src/commands/doctor-session-canonical-keys.ts
+++ b/src/commands/doctor-session-canonical-keys.ts
@@ -18,6 +18,7 @@ import { replaceSessionOwnerInTransaction } from "../config/sessions/session-acc
 import { collectSessionStateIdsForEntry } from "../config/sessions/session-accessor.sqlite-references.js";
 import { resolveSqliteTranscriptArchiveDirectory } from "../config/sessions/session-accessor.sqlite-scope.js";
 import { setCanonicalSqliteSessionMainKey } from "../config/sessions/session-canonical-key.js";
+import { preserveCreationStamp } from "../config/sessions/session-entry-provenance.js";
 import { serializeJsonlLines } from "../config/sessions/transcript-jsonl.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -179,24 +180,38 @@ function selectCanonicalSessionCandidate(
     env: params.env,
     sourceAgentId: first.agentId,
   });
-  const metadataCandidates = candidates.filter((candidate) => !candidate.ownerEvidenceOnly);
+  const rankedCandidates = candidates
+    .toSorted((left, right) =>
+      Buffer.compare(
+        Buffer.from(`${left.sqlitePath}\0${left.sessionKey}`, "utf8"),
+        Buffer.from(`${right.sqlitePath}\0${right.sessionKey}`, "utf8"),
+      ),
+    )
+    .map((candidate) => ({
+      entry: candidate.entry,
+      preferred:
+        candidate.sqlitePath === destination.sqlitePath &&
+        candidate.sessionKey === candidate.canonicalKey,
+      value: candidate,
+    }));
+  const metadataCandidates = rankedCandidates.filter(({ value }) => !value.ownerEvidenceOnly);
   const selected = mergeCanonicalSessionEntryCandidates(
-    (metadataCandidates.length > 0 ? metadataCandidates : candidates)
-      .toSorted((left, right) =>
-        Buffer.compare(
-          Buffer.from(`${left.sqlitePath}\0${left.sessionKey}`, "utf8"),
-          Buffer.from(`${right.sqlitePath}\0${right.sessionKey}`, "utf8"),
-        ),
-      )
-      .map((candidate) => ({
-        entry: candidate.entry,
-        preferred:
-          candidate.sqlitePath === destination.sqlitePath &&
-          candidate.sessionKey === candidate.canonicalKey,
-        value: candidate,
-      })),
+    metadataCandidates.length > 0 ? metadataCandidates : rankedCandidates,
   );
-  return selected ? { ...selected, destination } : undefined;
+  if (!selected) {
+    return undefined;
+  }
+  // Metadata follows recency, but an existing canonical isolation identity wins
+  // even over a newer required alias. Otherwise retain the newest required alias.
+  const requiredCandidates = rankedCandidates.filter(({ entry }) => entry.sandbox === "required");
+  const authoritativeStamp =
+    requiredCandidates.find(({ preferred }) => preferred)?.entry ??
+    mergeCanonicalSessionEntryCandidates(requiredCandidates)?.entry;
+  return {
+    ...selected,
+    entry: preserveCreationStamp(selected.entry, authoritativeStamp),
+    destination,
+  };
 }
 
 type SingleDatabaseCanonicalRepairGroup = {

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -727,6 +727,51 @@ describe("runDoctorSessionSqlite", () => {
     });
   });
 
+  it.each([true, false])(
+    "preserves required=%s creation provenance when importing an older legacy row",
+    async (required) => {
+      const legacyStamp = {
+        createdActor: { id: "profile-legacy", type: "human" as const },
+        createdAt: 1000,
+        createdVia: "channel" as const,
+      };
+      const authoritativeStamp = {
+        createdActor: { id: "profile-protected", type: "human" as const },
+        createdAt: 1500,
+        createdVia: "operator" as const,
+        ...(required ? { sandbox: "required" as const } : {}),
+      };
+      const store = createLegacyStore({ entryOverrides: legacyStamp });
+      const scope = {
+        agentId: "main",
+        env: store.env,
+        sessionKey: "agent:main:main",
+        storePath: store.storePath,
+      };
+      await upsertSessionEntryCore(scope, {
+        ...authoritativeStamp,
+        sessionId: "session-1",
+        updatedAt: 3000,
+      });
+
+      const report = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+
+      expect(report.totals).toMatchObject({ importedEntries: 1, issues: 0 });
+      const imported = loadExactSessionEntry(scope)?.entry;
+      expect(imported).toMatchObject({
+        ...(required ? authoritativeStamp : legacyStamp),
+        sessionId: "session-1",
+      });
+      if (!required) {
+        expect(imported).not.toHaveProperty("sandbox");
+      }
+    },
+  );
+
   it("imports and validates legacy sessions idempotently", async () => {
     const store = createLegacyStore();
 

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -1,9 +1,11 @@
+import { isDeepStrictEqual } from "node:util";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { Selectable } from "kysely";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
 } from "../../infra/kysely-sync.js";
+import { getChildLogger } from "../../logging/logger.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type { ConversationRouteContext } from "./conversation-route-context.js";
@@ -57,6 +59,7 @@ import {
   canonicalSessionKeyMigrationRequiredError,
 } from "./session-canonical-key.js";
 import { parseSqliteSessionEntryRecord } from "./session-entry-json.js";
+import { preserveCreationStamp } from "./session-entry-provenance.js";
 import { projectCanonicalSessionEntryShape } from "./store-entry-shape.js";
 import {
   collectSessionEntryLookupKeys,
@@ -561,7 +564,7 @@ export function writeSessionEntry(
     previousEntry?: SessionEntry | null;
     routeContext?: ConversationRouteContext | null;
   } = {},
-): void {
+): SessionEntry {
   const db = getSessionKysely(database.db);
   if (!options.allowStoredAliases) {
     assertCanonicalSessionKeyWriteMatchesDatabase(database, sessionKey);
@@ -572,22 +575,31 @@ export function writeSessionEntry(
       );
     }
   }
-  const normalizedEntry = normalizeSessionEntryTimestamp(entry);
+  let normalizedEntry = normalizeSessionEntryTimestamp(entry);
   if (!hasValidSessionEntryIdentity(normalizedEntry)) {
     throw new Error("Refusing invalid SQLite session entry identity");
   }
   const updatedAt = normalizedEntry.updatedAt;
   // Doctor validated the raw rejected row before entering the transaction and passes its
   // hydrated snapshot explicitly; re-reading it through the runtime parser must stay fail-closed.
-  const canonicalPreviousRow =
-    options.allowStoredAliases && options.previousEntry !== undefined
-      ? undefined
-      : readExactSessionEntryRow(database, sessionKey);
   const canonicalPreviousEntry =
-    canonicalPreviousRow?.entry ??
-    (options.allowStoredAliases && options.previousEntry !== undefined
+    options.allowStoredAliases && options.previousEntry !== undefined
       ? (options.previousEntry ?? undefined)
-      : undefined);
+      : readExactSessionEntryRow(database, sessionKey)?.entry;
+  if (canonicalPreviousEntry?.sandbox === "required") {
+    if (
+      normalizedEntry.sandbox !== "required" ||
+      normalizedEntry.createdVia !== canonicalPreviousEntry.createdVia ||
+      normalizedEntry.createdAt !== canonicalPreviousEntry.createdAt ||
+      !isDeepStrictEqual(normalizedEntry.createdActor, canonicalPreviousEntry.createdActor)
+    ) {
+      getChildLogger({ subsystem: "session-sqlite" }).warn(
+        "blocked role-required session creation provenance downgrade",
+        { agentId: database.agentId, sessionKey },
+      );
+    }
+    normalizedEntry = preserveCreationStamp(normalizedEntry, canonicalPreviousEntry);
+  }
   const previousEntry =
     options.previousEntry === undefined
       ? canonicalPreviousEntry
@@ -717,6 +729,7 @@ export function writeSessionEntry(
     });
   }
   publishSessionEntryCacheInvalidation(database, sessionNode, writeGeneration);
+  return normalizedEntry;
 }
 
 /** Resolves the parent fork decision using SQLite transcript rows when totals are stale. */

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -582,13 +582,17 @@ async function patchSqliteSessionEntrySnapshot<TSnapshot>(
     const patch = await params.update(cloneSessionEntry(writeBase), {
       existingEntry: existing ? cloneSessionEntry(existing) : undefined,
     });
-    const merged = !patch
+    // A fallback supplies identity, not an existing node's immutable creation policy.
+    const creatingRequiredSession = !existing && patch?.sandbox === "required";
+    const mergeBase = creatingRequiredSession ? undefined : writeBase;
+    const creationPatch = creatingRequiredSession ? { ...writeBase, ...patch } : patch;
+    const merged = !creationPatch
       ? undefined
       : options.replaceEntry
         ? cloneSessionEntry(patch as SessionEntry)
         : options.preserveActivity
-          ? mergeSessionEntryPreserveActivity(writeBase, patch)
-          : mergeSessionEntry(writeBase, patch);
+          ? mergeSessionEntryPreserveActivity(mergeBase, creationPatch)
+          : mergeSessionEntry(mergeBase, creationPatch);
     const next = !merged
       ? undefined
       : options.replaceEntry
@@ -625,7 +629,7 @@ async function patchSqliteSessionEntrySnapshot<TSnapshot>(
           ];
           previousIdentity = createSessionIdentitySnapshot(snapshotRows);
           const selectedPreviousEntry = params.existingEntry(fresh) ?? writeBase;
-          writeSessionEntry(writeDatabase, sessionKey, next, {
+          const persisted = writeSessionEntry(writeDatabase, sessionKey, next, {
             previousEntry: selectedPreviousEntry,
           });
           if (params.rehomeWindows) {
@@ -644,7 +648,7 @@ async function patchSqliteSessionEntrySnapshot<TSnapshot>(
             }),
           );
           currentIdentity = readSessionIdentitySnapshot(writeDatabase, identityKeys);
-          result = cloneSessionEntry(next);
+          result = cloneSessionEntry(persisted.sandbox === "required" ? persisted : next);
         }, toDatabaseOptions(resolved));
         emitCommittedSessionIdentityDiff(previousIdentity, currentIdentity);
         return { maintenancePlans, result };

--- a/src/config/sessions/session-accessor.sqlite-session-row.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-session-row.test.ts
@@ -7,7 +7,12 @@ import {
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { loadSessionEntry, upsertSessionEntryCore } from "./session-accessor.js";
+import {
+  loadSessionEntry,
+  patchSessionEntryCore,
+  upsertSessionEntryCore,
+} from "./session-accessor.js";
+import { replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
 import {
   projectPublicSessionEntry,
   projectPublicSessionEntryPatch,
@@ -23,6 +28,103 @@ afterEach(() => {
 });
 
 describe("SQLite session row persistence", () => {
+  it.each(["async", "sync"] as const)(
+    "protects required provenance during %s replacement",
+    async (mode) => {
+      const env = {
+        ...process.env,
+        OPENCLAW_STATE_DIR: fs.realpathSync(tempDirs.make("session-stamp-")),
+      };
+      const scope = { agentId: "main", env, sessionKey: "agent:main:stamp" };
+      const stamp = {
+        createdVia: "operator" as const,
+        createdActor: { type: "human" as const, id: "profile-creator" },
+        createdAt: 10,
+        sandbox: "required" as const,
+      };
+      await upsertSessionEntryCore(scope, { sessionId: "original", updatedAt: 10, ...stamp });
+      const replacement: InternalSessionEntry = {
+        sessionId: "replacement",
+        updatedAt: 20,
+        createdVia: "plugin",
+        createdActor: { type: "agent", id: "replacement-agent" },
+        createdAt: 20,
+      };
+      if (mode === "async") {
+        expect(
+          await patchSessionEntryCore(scope, () => replacement, { replaceEntry: true }),
+        ).toMatchObject(stamp);
+      } else {
+        replaceSessionEntrySync(scope, replacement);
+      }
+      expect(loadSessionEntry(scope)).toMatchObject({ sessionId: "replacement", ...stamp });
+      const row = openOpenClawAgentDatabase({ agentId: "main", env })
+        .db.prepare(
+          "SELECT created_actor_type, created_actor_id, created_via, created_at, entry_json FROM session_nodes WHERE session_key = ?",
+        )
+        .get(scope.sessionKey) as {
+        created_actor_type: string;
+        created_actor_id: string;
+        created_via: string;
+        created_at: number;
+        entry_json: string;
+      };
+      expect(row).toMatchObject({
+        created_actor_type: "human",
+        created_actor_id: "profile-creator",
+        created_via: "operator",
+        created_at: 10,
+      });
+      expect(JSON.parse(row.entry_json)).toMatchObject(stamp);
+    },
+  );
+
+  it.each([false, true])(
+    "keeps new required provenance with fallback (preserveActivity=%s)",
+    async (preserveActivity) => {
+      const env = {
+        ...process.env,
+        OPENCLAW_STATE_DIR: fs.realpathSync(tempDirs.make("session-stamp-fallback-")),
+      };
+      const scope = { agentId: "main", env, sessionKey: "agent:main:fallback" };
+      const stamp = {
+        createdVia: "operator" as const,
+        createdActor: { type: "human" as const, id: "profile-creator" },
+        createdAt: 20,
+        sandbox: "required" as const,
+      };
+      const result = await patchSessionEntryCore(scope, () => stamp, {
+        fallbackEntry: { sessionId: "fallback", updatedAt: 10 },
+        preserveActivity,
+      });
+      expect(result).toMatchObject({ sessionId: "fallback", ...stamp });
+      expect(loadSessionEntry(scope)).toMatchObject({ sessionId: "fallback", ...stamp });
+    },
+  );
+
+  it("keeps unstamped replacement semantics unchanged", async () => {
+    const env = {
+      ...process.env,
+      OPENCLAW_STATE_DIR: fs.realpathSync(tempDirs.make("session-unstamped-")),
+    };
+    const scope = { agentId: "main", env, sessionKey: "agent:main:unstamped" };
+    await upsertSessionEntryCore(scope, {
+      sessionId: "original",
+      updatedAt: 10,
+      createdVia: "operator",
+      label: "removed",
+    });
+    await patchSessionEntryCore(
+      scope,
+      () => ({ sessionId: "replacement", updatedAt: 20, createdVia: "plugin" }),
+      { replaceEntry: true },
+    );
+    const persisted = loadSessionEntry(scope);
+    expect(persisted).toMatchObject({ sessionId: "replacement", createdVia: "plugin" });
+    expect(persisted).not.toHaveProperty("sandbox");
+    expect(persisted).not.toHaveProperty("label");
+  });
+
   it("persists pending remote projects but excludes runtime-only resolved skills from SQLite JSON", async () => {
     const stateDir = fs.realpathSync(tempDirs.make("openclaw-sqlite-session-skills-"));
     const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

--- a/src/config/sessions/session-entry-provenance.ts
+++ b/src/config/sessions/session-entry-provenance.ts
@@ -82,6 +82,21 @@ export function buildSessionCreationStamp(params: {
   };
 }
 
+/** A required node keeps its original isolation identity across every write and rollover. */
+export function preserveCreationStamp<
+  T extends Partial<ReturnType<typeof buildSessionCreationStamp>>,
+>(entry: T, authoritative: Partial<ReturnType<typeof buildSessionCreationStamp>> | undefined): T {
+  return authoritative?.sandbox === "required"
+    ? {
+        ...entry,
+        createdVia: authoritative.createdVia,
+        createdActor: authoritative.createdActor,
+        createdAt: authoritative.createdAt,
+        sandbox: authoritative.sandbox,
+      }
+    : entry;
+}
+
 export type SessionEntryProvenance = {
   /** Plugin id that owns this session through a trusted runtime creation seam. */
   pluginOwnerId?: string;


### PR DESCRIPTION
## What Problem This Solves

`gateway.roles` can mark a person's sessions `sandbox: "required"`. That requirement is recorded as write-once creation provenance on the session row (`createdVia`, `createdActor`, `createdAt`, `sandbox`). The requirement is only as strong as the weakest write that touches the row.

Session entries are rewritten by many callers — doctor canonical-key repair, checkpoint/rewind writes, plugin `replaceEntry`, and ordinary merges. Any caller that rebuilt an entry without carrying the four provenance fields silently produced a row whose `sandbox` was no longer `"required"`. The next run of that session resolved as unsandboxed, with no error and no log: a guest-created session could quietly lose its isolation.

The store also trusted `options.previousEntry` supplied by the caller. A caller passing a stale or reconstructed previous entry could therefore define what the "existing" provenance was, which is exactly the value being protected.

## Why This Change Was Made

The SQLite entry store is the single chokepoint every session write passes through, so it is the correct owner for this invariant — not each of the ~20 callers. Enforcing it here means a caller that forgets provenance gets repaired rather than believed.

Two changes carry that:

- The store now reads the authoritative row itself (`readExactSessionEntryRow`) instead of trusting the caller-supplied `previousEntry`, and reconciles the incoming entry against it via a new `preserveCreationStamp` helper. A downgrade attempt is repaired and logged with `blocked role-required session creation provenance downgrade`, so the event is visible instead of silent.
- `session-accessor.sqlite-entry.ts` distinguishes creating a genuinely new required session from merging into an existing one. A fallback base supplies identity, never an existing node's immutable creation policy, so a new required row cannot inherit a weaker stamp from a merge base.

`doctor-session-canonical-keys.ts` reuses the same helper, so the repair path preserves the authoritative stamp when it collapses duplicate keys rather than picking whichever entry it selected.

This is the storage half of the invariant. The stacked follow-up makes each creation path stamp the creator in the first place, so the store has an authoritative value to protect.

## User Impact

No behavior change for sessions that were already stamped correctly. Sessions whose provenance would previously have been dropped by a rewriting caller now keep their required sandbox, and the repair is logged. No config, schema, or protocol change; no migration.

## Evidence

- New regression coverage in `session-accessor.sqlite-session-row.test.ts`, `doctor-session-sqlite.test.ts`, and `doctor-session-canonical-keys.owner-repair.test.ts`; the downgrade tests fail on pre-fix code for the intended reason.
- Full `CI=true pnpm check:changed` green on the rebased branch.
- `pnpm build` exit 0.
- Production LOC delta for this commit: +77/-30.

Note for reviewers: a cold `.artifacts/tsgo-cache` is required after pulling this range — a stale incremental cache from before `@types/jsdom` was added in #131052 replays 14 phantom `TS7006` errors in `ui/src/test-helpers/`.
