### PR TITLE
improve(ui): add permission docs link to picker

### DIFF
--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -154,6 +154,26 @@ describe("chat pane composer controls", () => {
     expect(activeIcons.size).toBe(5);
   });
 
+  it("links the permission picker to the permission modes guide", () => {
+    const container = document.createElement("div");
+    render(
+      renderChatPermissionPicker({
+        canSelectFull: true,
+        mode: "workspace",
+        onSelect: () => undefined,
+      }),
+      container,
+    );
+
+    const docsLink = container.querySelector<HTMLAnchorElement>(
+      ".chat-controls__permission-learn-more",
+    );
+    expect(docsLink?.textContent?.trim()).toBe("Learn more");
+    expect(docsLink?.href).toBe("https://docs.openclaw.ai/tools/permission-modes");
+    expect(docsLink?.target).toBe("_blank");
+    expect(docsLink?.rel.split(/\s+/).toSorted()).toEqual(["noopener", "noreferrer"]);
+  });
+
   it("patches a rootless session, clears to default, and locks full access", async () => {
     const container = document.createElement("div");
     const patch = vi.fn(async () => ({}));

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -169,7 +169,7 @@ describe("chat pane composer controls", () => {
       ".chat-controls__permission-learn-more",
     );
     expect(docsLink?.textContent?.trim()).toBe("Learn more");
-    expect(docsLink?.href).toBe("https://docs.openclaw.ai/tools/permission-modes");
+    expect(docsLink?.href).toBe("https://docs.openclaw.ai/gateway/permission-modes");
     expect(docsLink?.target).toBe("_blank");
     expect(docsLink?.rel.split(/\s+/).toSorted()).toEqual(["noopener", "noreferrer"]);
   });

--- a/ui/src/pages/chat/components/chat-permission-picker.ts
+++ b/ui/src/pages/chat/components/chat-permission-picker.ts
@@ -2,8 +2,10 @@ import { html, nothing } from "lit";
 import type { SessionPermissionMode } from "../../../../../packages/gateway-protocol/src/index.js";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
+import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../../../lib/external-link.ts";
 import { restorePointerOpenedChatComposerTrigger } from "./chat-picker-overlay.ts";
 
+const PERMISSION_MODES_DOCS_URL = "https://docs.openclaw.ai/tools/permission-modes";
 const PERMISSION_MODES = ["read-only", "guarded", "workspace", "full"] as const;
 const DEFAULT_PERMISSION_VALUE = "default";
 const PERMISSION_OPTIONS = [null, ...PERMISSION_MODES] as const;
@@ -128,7 +130,16 @@ export function renderChatPermissionPicker(params: ChatPermissionPickerProps) {
           ${modeLabel(params.mode)}
         </span>
       </button>
-      <div class="chat-controls__popover-title">${t("chat.permissionControls.label")}</div>
+      <div class="chat-controls__popover-title chat-controls__permission-heading">
+        <span>${t("chat.permissionControls.label")}</span>
+        <a
+          class="chat-controls__permission-learn-more"
+          href=${PERMISSION_MODES_DOCS_URL}
+          target=${EXTERNAL_LINK_TARGET}
+          rel=${buildExternalLinkRel()}
+          >${t("common.learnMore")}</a
+        >
+      </div>
       ${PERMISSION_OPTIONS.map((mode, index) => {
         const value = mode ?? DEFAULT_PERMISSION_VALUE;
         const selected = (params.mode ?? null) === mode;

--- a/ui/src/pages/chat/components/chat-permission-picker.ts
+++ b/ui/src/pages/chat/components/chat-permission-picker.ts
@@ -5,7 +5,7 @@ import { t } from "../../../i18n/index.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../../../lib/external-link.ts";
 import { restorePointerOpenedChatComposerTrigger } from "./chat-picker-overlay.ts";
 
-const PERMISSION_MODES_DOCS_URL = "https://docs.openclaw.ai/tools/permission-modes";
+const PERMISSION_MODES_DOCS_URL = "https://docs.openclaw.ai/gateway/permission-modes";
 const PERMISSION_MODES = ["read-only", "guarded", "workspace", "full"] as const;
 const DEFAULT_PERMISSION_VALUE = "default";
 const PERMISSION_OPTIONS = [null, ...PERMISSION_MODES] as const;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -6189,6 +6189,7 @@ button.chat-pr__diff {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  padding-bottom: 9px;
 }
 
 .chat-controls__permission-learn-more {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -6184,6 +6184,24 @@ button.chat-pr__diff {
   overflow: hidden;
 }
 
+.chat-controls__permission-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.chat-controls__permission-learn-more {
+  color: var(--muted);
+  font-weight: 500;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.chat-controls__permission-learn-more:hover {
+  color: var(--text-strong);
+}
+
 .chat-controls__permission-option {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What Problem This Solves

The permission picker explains each access mode, but it does not link users to the full permissions guide when they need more detail.

## Why This Change Was Made

Adds a localized “Learn more” link in the permission-picker heading. The link opens the canonical permission modes guide in a new tab using the Control UI’s shared external-link safety attributes.

The separate missing-icon report is already fixed on current `main`; this change preserves the per-mode trigger and menu icons.

## User Impact

Users can open the complete permission-mode documentation directly from the picker without leaving their chat.

## Evidence

![Permission picker showing Learn more and permission mode icons](https://github.com/user-attachments/assets/302e3d4f-fe8f-4a6e-8ab3-82a527d0f24c)

_PR head `1251890a9a`: the picker exposes the session-permissions guide, all five menu icons, the left-side trigger icon, and added space below the heading row._

- DOM regression proof covers the rendered link label, canonical URL, new-tab target, and external-link safety attributes.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-session-controls.test.ts` — 22 tests passed.
- `pnpm test:changed` — 10,886 tests passed across both shards.
- `pnpm ui:build` — production build and performance budgets passed.
- `pnpm check:changed` — formatting, type checks, lint, i18n, and repository guards passed.
- ClawSweeper finding resolved on `1251890a9a`: the link now targets `/gateway/permission-modes`; the focused test and live proof were rerun.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript</summary>

```text
[user]
OpenClaw has a permissions picker. Do we have a permissions documentation page, and can we add a “Learn more” link like the supplied design reference?

[assistant]
Confirmed that current `main` already contains explicit per-mode icons. PR review then caught that this session picker must target `docs/gateway/permission-modes.md`, not the separate host-execution permissions guide; the URL and regression test were corrected.

[assistant]
Added a regression test for the observable contract: the picker exposes a safe external “Learn more” link to the canonical permission-mode guide. The test failed before implementation and passed afterward.

[assistant]
Implemented the localized link using the Control UI’s shared external-link target and rel helpers. Kept unrelated shared-checkout edits out of the commit.

[assistant]
Validation completed: focused UI tests, changed-scope tests, production UI build, changed-code checks, and structured review all passed. The deterministic mock preview remains running for Codex Browser visual proof.

[user]
Continue, and include the redacted transcript in the PR.
```

</details>
<!-- agent-transcript:end -->