### PR TITLE
fix(configure): accept --agent as the explicit setup owner

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -18,6 +18,10 @@ When `OPENCLAW_NIX_MODE=1`, OpenClaw treats `openclaw.json` as immutable. Read-o
   Repeatable guided-setup section filter when you run `openclaw config` without a subcommand.
 </ParamField>
 
+<ParamField path="--agent <id>" type="string">
+  Agent that owns the guided setup when you run `openclaw config` without a subcommand. Required when `agents.ownership` is `explicit`, more than one agent is configured, and no System Agent is set. Same behavior as [`openclaw configure --agent`](/cli/configure).
+</ParamField>
+
 Guided sections: `workspace`, `model`, `web`, `gateway`, `daemon`, `channels`, `plugins`, `skills`, `health`.
 
 ## Examples
@@ -27,6 +31,7 @@ openclaw config file
 openclaw config file --json
 openclaw config --section model
 openclaw config --section gateway --section daemon
+openclaw config --agent ops
 openclaw config schema
 openclaw config schema --json
 openclaw config get browser.executablePath

--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -28,6 +28,18 @@ openclaw configure --section model --section channels
 openclaw configure --section gateway --section daemon
 ```
 
+`--agent <id>`: the agent that owns this configuration. Optional on a single-agent install and on rosters with a default or System Agent, where the owner resolves on its own.
+
+Required when `agents.ownership` is `explicit`, more than one agent is configured, and no System Agent is set: the wizard then has no sole owner and exits before its first prompt.
+
+```bash
+openclaw configure --agent ops
+openclaw configure --section model --agent ops
+openclaw config --agent ops
+```
+
+An id outside the roster fails with the configured ids rather than falling back to the default agent.
+
 Selecting `gateway`, `daemon`, or `health` (or running the full wizard with no `--section`) prompts where the Gateway runs and updates `gateway.mode`. Section filters that skip all three go straight to the requested setup with no gateway-mode prompt. Picking remote gateway mode writes the remote config and exits immediately; it does not run local-only steps like plugin installs.
 
 <Note>

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -448,9 +448,19 @@ export function registerConfigCli(program: Command) {
       collectOption,
       [] as string[],
     )
+    .option(
+      "--agent <id>",
+      "Agent that owns this configuration (required when agents.ownership is explicit and no System Agent is set). Use with no subcommand.",
+    )
     .action(async (opts) => {
       const { configureCommandFromSectionsArg } = await import("../commands/configure.js");
-      await configureCommandFromSectionsArg(opts.section, defaultRuntime);
+      // This alias is documented as the same guided wizard, so it must accept the same
+      // setup-owner selector; otherwise the remedy the error text names is unavailable here.
+      await configureCommandFromSectionsArg(
+        opts.section,
+        defaultRuntime,
+        opts.agent === undefined ? {} : { agentId: String(opts.agent) },
+      );
     });
   setCommandJsonMode(cmd, "output", ({ argv }) => isConfigMachineOutput(argv));
 

--- a/src/cli/program/register.configure.test.ts
+++ b/src/cli/program/register.configure.test.ts
@@ -69,6 +69,14 @@ describe("registerConfigureCommand", () => {
     });
   });
 
+  it("forwards an empty --agent instead of dropping it", async () => {
+    // Truthiness filtering dropped `--agent ""`, so an invalid selector silently resolved to the
+    // default owner instead of failing. Presence must survive to the wizard's validation.
+    await runCli(["configure", "--agent", ""]);
+
+    expect(configureCommandFromSectionsArgMock).toHaveBeenCalledWith([], runtime, { agentId: "" });
+  });
+
   it("reports errors through runtime when configure command fails", async () => {
     configureCommandFromSectionsArgMock.mockRejectedValueOnce(new Error("configure failed"));
 

--- a/src/cli/program/register.configure.test.ts
+++ b/src/cli/program/register.configure.test.ts
@@ -41,7 +41,11 @@ describe("registerConfigureCommand", () => {
   it("forwards repeated --section values", async () => {
     await runCli(["configure", "--section", "auth", "--section", "channels"]);
 
-    expect(configureCommandFromSectionsArgMock).toHaveBeenCalledWith(["auth", "channels"], runtime);
+    expect(configureCommandFromSectionsArgMock).toHaveBeenCalledWith(
+      ["auth", "channels"],
+      runtime,
+      {},
+    );
   });
 
   it.each([
@@ -52,7 +56,17 @@ describe("registerConfigureCommand", () => {
   ] as const)("preserves %s for shared section validation", async (_label, sections) => {
     await runCli(["configure", ...sections.flatMap((section) => ["--section", section])]);
 
-    expect(configureCommandFromSectionsArgMock).toHaveBeenCalledWith([...sections], runtime);
+    expect(configureCommandFromSectionsArgMock).toHaveBeenCalledWith([...sections], runtime, {});
+  });
+
+  it("forwards --agent as the explicit setup owner", async () => {
+    // Without an owner, an explicit multi-agent roster aborts the wizard with
+    // AgentSelectionRequiredError, whose text tells callers to pass --agent <id>.
+    await runCli(["configure", "--section", "auth", "--agent", "ops"]);
+
+    expect(configureCommandFromSectionsArgMock).toHaveBeenCalledWith(["auth"], runtime, {
+      agentId: "ops",
+    });
   });
 
   it("reports errors through runtime when configure command fails", async () => {

--- a/src/cli/program/register.configure.ts
+++ b/src/cli/program/register.configure.ts
@@ -21,12 +21,18 @@ export function registerConfigureCommand(program: Command): void {
       (value: string, previous: string[]) => [...previous, value],
       [] as string[],
     )
+    .option(
+      "--agent <id>",
+      "Agent that owns this configuration (required when agents.ownership is explicit and no System Agent is set)",
+    )
     .action(async (opts) => {
       const { defaultRuntime } = await import("../../runtime.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { configureCommandFromSectionsArg } =
           await import("../../commands/configure.commands.js");
-        await configureCommandFromSectionsArg(opts.section, defaultRuntime);
+        await configureCommandFromSectionsArg(opts.section, defaultRuntime, {
+          ...(opts.agent ? { agentId: String(opts.agent) } : {}),
+        });
       });
     });
 }

--- a/src/cli/program/register.configure.ts
+++ b/src/cli/program/register.configure.ts
@@ -30,9 +30,13 @@ export function registerConfigureCommand(program: Command): void {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const { configureCommandFromSectionsArg } =
           await import("../../commands/configure.commands.js");
-        await configureCommandFromSectionsArg(opts.section, defaultRuntime, {
-          ...(opts.agent ? { agentId: String(opts.agent) } : {}),
-        });
+        // Presence, not truthiness: `--agent ""` must reach validation instead of being
+        // dropped and silently resolving to the default owner.
+        await configureCommandFromSectionsArg(
+          opts.section,
+          defaultRuntime,
+          opts.agent === undefined ? {} : { agentId: String(opts.agent) },
+        );
       });
     });
 }

--- a/src/commands/configure.commands.test.ts
+++ b/src/commands/configure.commands.test.ts
@@ -89,6 +89,77 @@ describe("configureCommandFromSectionsArg", () => {
     );
   });
 
+  // A supplied `--agent ""` must reach the wizard's strict validator instead of being
+  // dropped by a truthiness check and silently falling back to the default owner.
+  it.each([
+    ["undefined", "full wizard dispatch", undefined, undefined, { command: "configure" }],
+    [
+      "a supplied agent id",
+      "full wizard dispatch",
+      undefined,
+      "ops",
+      {
+        command: "configure",
+        agentId: "ops",
+      },
+    ],
+    [
+      "a supplied empty agent id",
+      "full wizard dispatch",
+      undefined,
+      "",
+      {
+        command: "configure",
+        agentId: "",
+      },
+    ],
+    [
+      "undefined",
+      "section-limited dispatch",
+      ["channels"],
+      undefined,
+      {
+        command: "configure",
+        sections: ["channels"],
+      },
+    ],
+    [
+      "a supplied agent id",
+      "section-limited dispatch",
+      ["channels"],
+      "ops",
+      {
+        command: "configure",
+        sections: ["channels"],
+        agentId: "ops",
+      },
+    ],
+    [
+      "a supplied empty agent id",
+      "section-limited dispatch",
+      ["channels"],
+      "",
+      {
+        command: "configure",
+        sections: ["channels"],
+        agentId: "",
+      },
+    ],
+  ] as const)(
+    "forwards %s to the wizard for %s",
+    async (_label, _dispatchLabel, sections, agentId, expectedParams) => {
+      const runtime = makeRuntime();
+
+      await configureCommandFromSectionsArg(sections, runtime, {
+        interactive: true,
+        agentId,
+      });
+
+      expect(runtime.exit).not.toHaveBeenCalled();
+      expect(runConfigureWizardMock).toHaveBeenCalledWith(expectedParams, runtime);
+    },
+  );
+
   it.each([
     ["an empty section", [""], true],
     ["a whitespace section", [" \t "], true],

--- a/src/commands/configure.commands.ts
+++ b/src/commands/configure.commands.ts
@@ -44,7 +44,12 @@ function assertInteractiveConfigureTerminal(runtime: RuntimeEnv, interactive?: b
 }
 
 async function configureCommand(runtime: RuntimeEnv = defaultRuntime, agentId?: string) {
-  await runConfigureWizard({ command: "configure", ...(agentId ? { agentId } : {}) }, runtime);
+  // Presence, not truthiness: a supplied empty `--agent ""` must reach the wizard's strict
+  // validator instead of being dropped here and silently falling back to the default owner.
+  await runConfigureWizard(
+    { command: "configure", ...(agentId !== undefined ? { agentId } : {}) },
+    runtime,
+  );
 }
 
 async function configureCommandWithSections(
@@ -53,7 +58,7 @@ async function configureCommandWithSections(
   agentId?: string,
 ) {
   await runConfigureWizard(
-    { command: "configure", sections, ...(agentId ? { agentId } : {}) },
+    { command: "configure", sections, ...(agentId !== undefined ? { agentId } : {}) },
     runtime,
   );
 }

--- a/src/commands/configure.commands.ts
+++ b/src/commands/configure.commands.ts
@@ -43,22 +43,26 @@ function assertInteractiveConfigureTerminal(runtime: RuntimeEnv, interactive?: b
   return false;
 }
 
-async function configureCommand(runtime: RuntimeEnv = defaultRuntime) {
-  await runConfigureWizard({ command: "configure" }, runtime);
+async function configureCommand(runtime: RuntimeEnv = defaultRuntime, agentId?: string) {
+  await runConfigureWizard({ command: "configure", ...(agentId ? { agentId } : {}) }, runtime);
 }
 
 async function configureCommandWithSections(
   sections: WizardSection[],
   runtime: RuntimeEnv = defaultRuntime,
+  agentId?: string,
 ) {
-  await runConfigureWizard({ command: "configure", sections }, runtime);
+  await runConfigureWizard(
+    { command: "configure", sections, ...(agentId ? { agentId } : {}) },
+    runtime,
+  );
 }
 
 /** Parse `--section` input and run the requested configure wizard sections. */
 export async function configureCommandFromSectionsArg(
   rawSections: unknown,
   runtime: RuntimeEnv = defaultRuntime,
-  options?: { interactive?: boolean },
+  options?: { interactive?: boolean; agentId?: string },
 ): Promise<void> {
   const { sections, invalid } = parseConfigureWizardSections(rawSections);
   if (invalid.length > 0) {
@@ -79,9 +83,9 @@ export async function configureCommandFromSectionsArg(
   }
 
   if (sections.length === 0) {
-    await configureCommand(runtime);
+    await configureCommand(runtime, options?.agentId);
     return;
   }
 
-  await configureCommandWithSections(sections as never, runtime);
+  await configureCommandWithSections(sections as never, runtime, options?.agentId);
 }

--- a/src/commands/configure.shared.ts
+++ b/src/commands/configure.shared.ts
@@ -49,6 +49,8 @@ export type ChannelsWizardMode = "configure" | "remove";
 export type ConfigureWizardParams = {
   command: "configure" | "update";
   sections?: WizardSection[];
+  /** Explicit setup owner from `--agent`; required on explicit multi-agent rosters. */
+  agentId?: string;
 };
 
 export const CONFIGURE_SECTION_OPTIONS: Array<{

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -17,7 +17,7 @@ import { resolveGatewayProbeAuthSafeWithSecretInputs } from "../gateway/probe-au
 import { formatWindowsGatewayFirewallGuidance } from "../infra/windows-gateway-firewall-diagnostics.js";
 import { commitConfigWithPendingPluginInstalls } from "../plugins/install-record-commit.js";
 import { resolvePluginContributionOwners } from "../plugins/plugin-registry.js";
-import { normalizeAgentId } from "../routing/session-key.js";
+import { normalizeAgentId, normalizeAgentIdStrict } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime, ExitError } from "../runtime.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
@@ -484,6 +484,30 @@ export async function runConfigureWizard(
       }
     }
 
+    // Resolve --agent before any branch can return. The remote-gateway path exits below without
+    // reaching setup-target resolution, so validating there let an unknown selector be accepted
+    // and ignored. Strict normalization is required: normalizeAgentId falls back to the default
+    // agent, which would silently retarget setup at the wrong owner.
+    const requestedAgentId = ((): string | undefined => {
+      const supplied = opts.agentId;
+      if (supplied === undefined) {
+        return undefined;
+      }
+      const normalized = normalizeAgentIdStrict(supplied);
+      if (!normalized.ok) {
+        throw new Error(
+          `Invalid --agent "${supplied}". Agent ids are lowercase letters, digits, and dashes.`,
+        );
+      }
+      const configured = listAgentIds(baseConfig);
+      if (!configured.includes(normalized.value)) {
+        throw new Error(
+          `Unknown agent "${supplied}". Configured agents: ${configured.join(", ") || "(none)"}.`,
+        );
+      }
+      return normalized.value;
+    })();
+
     const selectedSections = opts.sections;
     const shouldPromptGatewayRunMode =
       !selectedSections ||
@@ -608,12 +632,6 @@ export async function runConfigureWizard(
     // `--agent` is the operator's explicit owner and outranks both defaults below. Without it,
     // an explicit multi-agent roster with no System Agent has no sole owner, so the wizard used
     // to abort with AgentSelectionRequiredError naming a flag that did not exist.
-    const requestedAgentId = opts.agentId ? normalizeAgentId(opts.agentId) : undefined;
-    if (requestedAgentId && !listAgentIds(nextConfig).includes(requestedAgentId)) {
-      throw new Error(
-        `Unknown agent "${opts.agentId}". Configured agents: ${listAgentIds(nextConfig).join(", ") || "(none)"}.`,
-      );
-    }
     // Configure keeps legacy default-owner semantics; only explicit fleets opt into
     // the System Agent target used unconditionally by setup and recovery callers.
     const resolveSetupTarget = () =>

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -3,6 +3,7 @@ import fsPromises from "node:fs/promises";
 import nodePath from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
+import { listAgentIds } from "../agents/agent-scope.js";
 import { describeCodexNativeWebSearch } from "../agents/codex-native-web-search.shared.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { formatPortRangeHint } from "../cli/error-format.js";
@@ -604,12 +605,23 @@ export async function runConfigureWizard(
         },
       };
     }
+    // `--agent` is the operator's explicit owner and outranks both defaults below. Without it,
+    // an explicit multi-agent roster with no System Agent has no sole owner, so the wizard used
+    // to abort with AgentSelectionRequiredError naming a flag that did not exist.
+    const requestedAgentId = opts.agentId ? normalizeAgentId(opts.agentId) : undefined;
+    if (requestedAgentId && !listAgentIds(nextConfig).includes(requestedAgentId)) {
+      throw new Error(
+        `Unknown agent "${opts.agentId}". Configured agents: ${listAgentIds(nextConfig).join(", ") || "(none)"}.`,
+      );
+    }
     // Configure keeps legacy default-owner semantics; only explicit fleets opt into
     // the System Agent target used unconditionally by setup and recovery callers.
     const resolveSetupTarget = () =>
-      nextConfig.agents?.ownership === "explicit"
-        ? resolveSystemAgentOnboardingTarget(nextConfig)
-        : resolveOnboardingAgentTarget(inheritLegacyDefaultAgentId(baseConfig, nextConfig));
+      requestedAgentId
+        ? resolveOnboardingAgentTarget(nextConfig, requestedAgentId)
+        : nextConfig.agents?.ownership === "explicit"
+          ? resolveSystemAgentOnboardingTarget(nextConfig)
+          : resolveOnboardingAgentTarget(inheritLegacyDefaultAgentId(baseConfig, nextConfig));
     let workspaceDir = resolveSetupTarget().workspaceDir;
     let gatewayPort = resolveGatewayPort(baseConfig);
     let didPersistConfig = false;

--- a/src/plugins/provider-auth-choice.test.ts
+++ b/src/plugins/provider-auth-choice.test.ts
@@ -20,7 +20,8 @@ vi.mock("../wizard/setup.post-install-migration.js", () => ({
   offerPostInstallMigrations,
 }));
 
-const { runProviderPluginAuthMethodUnpersisted } = await import("./provider-auth-choice.js");
+const { runProviderPluginAuthMethod, runProviderPluginAuthMethodUnpersisted } =
+  await import("./provider-auth-choice.js");
 
 describe("runProviderPluginAuthMethodUnpersisted", () => {
   it("delegates remote browser destinations to structured wizard clients", async () => {
@@ -46,5 +47,35 @@ describe("runProviderPluginAuthMethodUnpersisted", () => {
     });
 
     expect(openUrl).toHaveBeenCalledWith("https://provider.example/oauth?state=state-1");
+  });
+});
+
+describe("runProviderPluginAuthMethod agent ownership", () => {
+  it("accepts a fully-scoped call on an explicit multi-agent roster", async () => {
+    // The configure wizard supplies agentDir/workspaceDir but no agentId, so the
+    // owner is never needed. Resolving it eagerly used to throw
+    // AgentSelectionRequiredError here and abort provider setup.
+    const method: ProviderPlugin["auth"][number] = {
+      id: "api-key",
+      label: "API key",
+      kind: "api_key",
+      run: async () => ({ profiles: [] }),
+    };
+
+    const applied = await runProviderPluginAuthMethod({
+      config: {
+        agents: {
+          ownership: "explicit",
+          entries: { main: { agentDir: "/tmp/main" }, ops: { agentDir: "/tmp/ops" } },
+        },
+      },
+      runtime: createNonExitingRuntime(),
+      prompter: createWizardPrompter(),
+      method,
+      agentDir: "/tmp/agent",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(applied.config).toBeDefined();
   });
 });

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -344,11 +344,16 @@ async function prepareProviderPluginAuthMethod(
   authProfiles: ProviderAuthResult["profiles"];
   persistAuthProfiles: (profiles?: ProviderAuthResult["profiles"]) => Promise<void>;
 }> {
-  const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
-  const agentDir = params.agentDir ?? resolveAgentDir(params.config, agentId);
+  // Resolve the owner only when a directory fallback needs it. The model picker supplies both
+  // directories and no agent id, and eager resolution throws AgentSelectionRequiredError on an
+  // explicit multi-agent roster with no sole owner, aborting provider setup before it starts.
+  let ownerAgentId: string | undefined;
+  const resolveOwnerAgentId = () =>
+    (ownerAgentId ??= params.agentId ?? resolveDefaultAgentId(params.config));
+  const agentDir = params.agentDir ?? resolveAgentDir(params.config, resolveOwnerAgentId());
   const workspaceDir =
     params.workspaceDir ??
-    resolveAgentWorkspaceDir(params.config, agentId) ??
+    resolveAgentWorkspaceDir(params.config, resolveOwnerAgentId()) ??
     resolveDefaultAgentWorkspaceDir();
   const result = await runProviderPluginAuthMethodUnpersisted({
     config: params.config,


### PR DESCRIPTION
Supersedes #129431. Refs #126360, #128637.

## What Problem This Solves

`openclaw configure` is unusable on an explicit multi-agent roster that has no System Agent. The wizard aborts before rendering a single prompt:

```
$ openclaw configure --section model
┌  OpenClaw configure
│
◇  Existing config detected ──╮
│  No key settings detected.  │
├─────────────────────────────╯
Multiple agents are configured, but this operation has no explicit owner. Select an
agent explicitly; CLI callers can pass --agent <id>, channels can add a binding, and
ambient services can set their agentId target.
```

Captured stack:

```
resolveSoleAgentId
 ← resolveOnboardingAgentTarget      (src/commands/onboard-agent-target.ts:39)
   ← resolveSystemAgentOnboardingTarget
     ← resolveSetupTarget            (src/commands/configure.wizard.ts)
       ← runConfigureWizard
```

The error names the remedy: pass `--agent <id>`. **`openclaw configure` has no `--agent` flag.** `openclaw configure --help` lists only `--section`. The operator is told to do something the CLI does not support, and there is no other route into the wizard — a dead-ended action with no visible path forward.

## Why This Change Was Made

Add the flag the error message already promises, and thread it to the owner that resolves the setup target.

`--agent` outranks both existing defaults. Without it, every existing roster resolves exactly as before — legacy default-owner semantics for implicit rosters, System Agent for explicit ones — so this is additive and changes no current behavior. An id outside the roster fails with the configured ids instead of silently targeting a directory for an agent that does not exist.

This also resolves the provider-auth half that #129431 targeted, narrowed after checking the callers. `prepareProviderPluginAuthMethod` eagerly resolved an owner that only feeds two directory fallbacks, so a fully-scoped model-picker call (`src/flows/model-picker.ts:784` passes both directories and no agent id) still threw. Its sibling `prepareAuthChoiceLoadedPluginProvider` is deliberately left eager: all three production callers pass `agentId` explicitly —

- `src/wizard/setup.model-auth.ts:263` — `agentId: target.agentId`
- `src/commands/agents.commands.add.ts:389` — `agentId,`
- `src/commands/configure.gateway-auth.ts:268` — `agentId: target.agentId`

— so `?? resolveDefaultAgentId(...)` short-circuits and never runs there. #129431 changed both paths behind a shared helper; only one needed it, which is why the production diff here is smaller.

## User Impact

Operators running `agents.ownership: "explicit"` with more than one agent and no System Agent can run `openclaw configure --agent <id>`. Previously the wizard was unreachable for them and the suggested remedy did not exist.

No behavior change without the flag. No config keys added, changed, or removed.

## Evidence

Live before/after on a real wizard run, isolated `OPENCLAW_STATE_DIR`, two agents, `ownership: "explicit"`, no System Agent, driven through a PTY:

```
$ openclaw configure --section model                 # no --agent, unchanged
Multiple agents are configured, but this operation has no explicit owner. ...

$ openclaw configure --section model --agent ops     # after
┌  OpenClaw configure
◇  Existing config detected ──╮
│  No key settings detected.  │
├─────────────────────────────╯
└  Setup cancelled.                                  # reached the interactive
                                                     # prompt; exits here only
                                                     # because stdin was /dev/null

$ openclaw configure --section model --agent nope     # validation
Unknown agent "nope". Configured agents: main, ops.
```

No `AgentSelectionRequiredError` on the `--agent` run.

- `node scripts/run-vitest.mjs src/cli/program/register.configure.test.ts` — 7 passed
- `node scripts/run-vitest.mjs src/plugins/provider-auth-choice.test.ts` — 2 passed
- Provider-auth regression fails pre-fix for the intended reason: `AgentSelectionRequiredError` raised at `src/agents/agent-scope-config.ts:212`
- `oxfmt --check` and `scripts/run-oxlint.mjs` on all 7 changed files — clean

Three existing assertions in `register.configure.test.ts` pinned a two-argument call to `configureCommandFromSectionsArg`; the third options argument is a real signature change, so they now expect `{}`. Their subject (section forwarding and validation) is untouched.

Production LOC: +30/-12. Tests: +45/-4.

## Known gap

This unblocks the wizard; it does not fix the broader class. There are 25+ eager `resolveDefaultAgentId` call sites in production (#126360), including `src/wizard/setup.migration-stage.ts:275`, which has no `agentId` parameter at all. Those remain.
