### PR TITLE
fix(ui): make composer text sizing consistent

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3372,10 +3372,37 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         expect(rectsOverlap(model, send)).toBe(false);
         const contextModelGap = model.x - (context.x + context.width);
         expect(contextModelGap).toBeGreaterThanOrEqual(-1);
-        const composerFontSize = await page
-          .locator(".agent-chat__composer-combobox > textarea")
-          .evaluate((textareaNode) => Number.parseFloat(getComputedStyle(textareaNode).fontSize));
-        expect(composerFontSize).toBe(16);
+        const composerFontSizes = await page.evaluate(() => {
+          const textareaNode = document.querySelector<HTMLTextAreaElement>(
+            ".agent-chat__composer-combobox > textarea",
+          );
+          const selectors = [
+            ".chat-controls__permission-trigger .chat-controls__inline-select-label",
+            ".chat-controls__model-trigger .chat-controls__inline-select-label",
+            ".chat-controls__effort-trigger .chat-controls__inline-select-label",
+          ];
+          if (!textareaNode) {
+            throw new Error("Missing composer textarea");
+          }
+          const fontSize = (node: Element, pseudo?: string) =>
+            Number.parseFloat(getComputedStyle(node, pseudo).fontSize);
+          return {
+            labels: selectors.map((selector) => {
+              const label = document.querySelector(selector);
+              if (!label) {
+                throw new Error(`Missing composer label: ${selector}`);
+              }
+              return fontSize(label);
+            }),
+            placeholder: fontSize(textareaNode, "::placeholder"),
+            textarea: fontSize(textareaNode),
+          };
+        });
+        expect(composerFontSizes).toEqual({
+          labels: [12, 12, 12],
+          placeholder: 12,
+          textarea: 12,
+        });
         if (width <= 480) {
           const modelSettings = expectControlRect(
             controls.modelSettings,
@@ -3412,9 +3439,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           }
           expect(footer.height).toBeLessThanOrEqual(53);
         } else {
-          // The editor reads at input size, while the controls around it stay
-          // chrome-sized — that difference is what marks the text as the
-          // subject of the surface.
           expect(send.width).toBeCloseTo(32, 2);
           expect(send.height).toBeCloseTo(32, 2);
         }

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3399,9 +3399,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           };
         });
         expect(composerFontSizes).toEqual({
-          labels: [12, 12, 12],
-          placeholder: 12,
-          textarea: 12,
+          labels: [14, 14, 14],
+          placeholder: 14,
+          textarea: 14,
         });
         if (width <= 480) {
           const modelSettings = expectControlRect(

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3123,7 +3123,7 @@ button.chat-pr__diff {
   --chat-composer-chip-height: 30px;
   --chat-composer-chip-gap: 6px;
   --chat-composer-chip-padding-inline: 8px;
-  --chat-composer-chip-text: 13px;
+  --chat-composer-chip-text: var(--control-ui-text-sm);
   --chat-composer-chip-icon: 16px;
   /* Menu-row family: every option row inside a composer popover (model, effort,
      permission, plus menu, attach, microphone) shares one box, icon size, and
@@ -3143,12 +3143,9 @@ button.chat-pr__diff {
      the surface's own floor is taller than the editor plus these insets. */
   --chat-composer-editor-inset-inline: 14px;
   --chat-composer-editor-inset-block: 6px;
-  /* The editor is a reading and writing surface, not a compact form field, so it
-     owns a 16px base instead of the shared control token, whose 14px base only
-     reaches 16px through an iOS zoom floor — text that size by accident does not
-     follow the operator's text scale until the scale passes 1.15, and it drops
-     the moment that floor moves. The max() keeps 16px as a hard floor. */
-  --chat-composer-editor-size: max(16px, calc(16px * var(--control-ui-text-scale)));
+  /* Draft text and its surrounding labels share one semantic UI size. The
+     coarse-pointer floor in base.css still prevents iOS focus zoom. */
+  --chat-composer-editor-size: var(--control-ui-text-sm);
   /* One editor line. The single-line box centres a line of exactly this height,
      and the multiline editor never gets shorter than one of them. Derived, so a
      scaled-up editor keeps its leading instead of crowding its own descenders. */
@@ -7297,7 +7294,6 @@ button.chat-pr__diff {
     --chat-composer-chip-height: var(--chat-mobile-row-target-size);
     --chat-composer-chip-gap: var(--chat-mobile-row-chip-gap);
     --chat-composer-chip-padding-inline: var(--chat-mobile-row-chip-padding-inline);
-    --chat-composer-chip-text: 12px;
     --chat-composer-footer-icon-size: var(--chat-mobile-row-icon-size);
     --chat-composer-menu-icon: var(--chat-mobile-row-icon-size);
     --chat-composer-send-size: var(--chat-mobile-row-plus-target-size);

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3123,7 +3123,7 @@ button.chat-pr__diff {
   --chat-composer-chip-height: 30px;
   --chat-composer-chip-gap: 6px;
   --chat-composer-chip-padding-inline: 8px;
-  --chat-composer-chip-text: var(--control-ui-text-sm);
+  --chat-composer-chip-text: var(--control-ui-text-md);
   --chat-composer-chip-icon: 16px;
   /* Menu-row family: every option row inside a composer popover (model, effort,
      permission, plus menu, attach, microphone) shares one box, icon size, and
@@ -3145,7 +3145,7 @@ button.chat-pr__diff {
   --chat-composer-editor-inset-block: 6px;
   /* Draft text and its surrounding labels share one semantic UI size. The
      coarse-pointer floor in base.css still prevents iOS focus zoom. */
-  --chat-composer-editor-size: var(--control-ui-text-sm);
+  --chat-composer-editor-size: var(--control-ui-text-md);
   /* One editor line. The single-line box centres a line of exactly this height,
      and the multiline editor never gets shorter than one of them. Derived, so a
      scaled-up editor keeps its leading instead of crowding its own descenders. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI chat composer mixed a 16px draft/placeholder size with 13px Workspace, model, and effort labels instead of using the shared semantic small-text size.

## Why This Change Was Made

The composer draft, placeholder, Workspace label, model label, and effort label now share `--control-ui-text-md`. The existing coarse-pointer input floor remains responsible for preventing iOS focus zoom.

## User Impact

Composer text and its three surrounding labels now have one consistent semantic size and continue to follow Control UI text scaling.

## Evidence

Default desktop computed sizes:

| Surface | Before | After |
| --- | ---: | ---: |
| Draft and placeholder | 16px | 14px |
| Workspace, model, effort | 13px | 14px |

| State | Before | After |
| --- | --- | --- |
| Placeholder | ![Composer placeholder before](https://github.com/user-attachments/assets/a4d78a19-7344-4652-901c-b411432e2a5f) | ![Composer placeholder after](https://github.com/user-attachments/assets/c47e0f6f-5b8c-472f-9e9d-b6c22fa66e21) |
| Typed text | ![Composer typed text before](https://github.com/user-attachments/assets/84fe4edd-569a-42d4-bea4-0136180d14ac) | ![Composer typed text after](https://github.com/user-attachments/assets/ee3a86b7-00a0-4fce-a85d-54fe016be01a) |

Validation:

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-responsive.browser.test.ts` — 103 passed
- `node scripts/check-changed.mjs -- ui/src/styles/chat/layout.css ui/src/pages/chat/chat-responsive.browser.test.ts` — passed
- Autoreview — clean, no actionable findings
- Production delta: +4/−8 CSS lines (net −4); test delta: +31/−7 lines
