### PR TITLE
fix(ci): stop cancelling in-flight docs publish syncs on main pushes

### DIFF
--- a/.github/workflows/docs-sync-publish.yml
+++ b/.github/workflows/docs-sync-publish.yml
@@ -20,8 +20,12 @@ permissions:
   contents: read
 
 concurrency:
+  # cancel-in-progress starved the mirror: every main push cancelled the in-flight
+  # sync and cancelled runs leave no successor, so under sustained merge velocity
+  # openclaw/docs never advanced. Queue instead — GitHub keeps only the newest
+  # pending run per group, and skip_stale_source keeps completed runs idempotent.
   group: docs-sync-publish-${{ github.event_name == 'workflow_dispatch' && format('manual-{0}', github.run_id) || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+  cancel-in-progress: false
 
 jobs:
   sync-publish-repo:


### PR DESCRIPTION
## What Problem This Solves

The docs publish pipeline can silently starve on the source-to-mirror leg. `docs-sync-publish.yml` uses a per-ref concurrency group with `cancel-in-progress: true` for pushes to `main`, so every new docs-touching push cancels the in-flight sync — and cancelled runs leave no successor run behind. Under sustained merge velocity the `openclaw/docs` mirror never advances even though each individual cancelled run looks like routine supersession.

Observed live 2026-08-27 ~18:25–18:39 UTC: four consecutive runs (33103399859, 33104123012, 33104196038, 33104523972) all "completed cancelled" while the mirror sat at source `ce0fafefce` with `main` ~6 commits ahead. Published docs silently stopped updating; `workflow_dispatch` (per-run group) was the only recovery.

This is the second half of the docs publish starvation bug — the mirror-to-R2 half was fixed in openclaw/docs `b4b130bd8` ("stop dropping R2 uploads when docs main moves mid-build").

## Why This Change Was Made

`cancel-in-progress` buys almost nothing here and costs liveness. Switching push runs to `cancel-in-progress: false` makes the in-flight run complete and publish, while GitHub's concurrency-group semantics keep only the newest *pending* run per group — a burst of pushes still collapses to "current run finishes + one queued run at the newest SHA". Self-healing without any new machinery.

Idempotency of back-to-back completions was verified against the existing commit step: the `skip_stale_source` guard skips any run whose `GITHUB_SHA` is an ancestor of the already-mirrored source SHA, and the commit is a no-op when the rsync produces no diff. The `workflow_dispatch` path already used a per-run group with cancellation effectively off, so the literal `false` changes nothing for manual runs.

## User Impact

Docs published at https://docs.openclaw.ai keep advancing during high merge velocity instead of silently freezing until someone notices and manually dispatches the sync. No behavior change for manual dispatch runs.

## Evidence

- Live starvation: runs 33103399859, 33104123012, 33104196038, 33104523972 on `main`, all cancelled by successor pushes, mirror stuck at `ce0fafefce`.
- `git diff --check` clean; `check:changed` tooling lane (format, guards, script lint) green; autoreview (Codex) clean.

Follow-up worth doing separately: a docs-freshness alarm — nothing currently pages anyone when the mirror's `.openclaw-sync/source.json` SHA trails `openclaw/openclaw` `main` by more than ~1h; the openclaw/docs smoke (openclaw/docs#139) only asserts routes after an upload actually happens.
