### PR TITLE
fix(ui): dismiss navigation and Inbox reliably during lazy loading

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3914,7 +3914,6 @@ ui/src/app-navigation.ts	2
 ui/src/app-route-paths.ts	1
 ui/src/app-routes.ts	1
 ui/src/app/app-host-route-state.ts	1
-ui/src/app/app-host.ts	1
 ui/src/app/app-shell-chrome.ts	2
 ui/src/app/app-shell-gateway.ts	1
 ui/src/app/assistant-identity.ts	2

--- a/ui/src/app/app-host.test.ts
+++ b/ui/src/app/app-host.test.ts
@@ -797,7 +797,8 @@ describe("OpenClaw shell keyboard shortcuts", () => {
     trigger.remove();
   });
 
-  it("closes an open navigation drawer before moving its sidebar into desktop layout", () => {
+  it("closes an open navigation drawer before moving its sidebar into desktop layout", async () => {
+    await import("../components/app-sidebar.ts");
     vi.stubGlobal("matchMedia", () => ({ matches: false }));
     const shell = document.createElement("openclaw-app-shell") as ShellNavDrawerCloseState;
     const updateNavigation = vi.fn();
@@ -809,9 +810,10 @@ describe("OpenClaw shell keyboard shortcuts", () => {
         },
       } as unknown as ApplicationContext,
     };
-    const sidebar = document.createElement("openclaw-app-sidebar");
-    const dismissTransientMenus = vi.fn(() => true);
-    Object.defineProperty(sidebar, "dismissTransientMenus", { value: dismissTransientMenus });
+    const sidebar = document.createElement("openclaw-app-sidebar") as HTMLElement & {
+      dismissTransientMenus: () => boolean;
+    };
+    const dismissTransientMenus = vi.spyOn(sidebar, "dismissTransientMenus").mockReturnValue(true);
     shell.append(sidebar);
     const trigger = document.body.appendChild(document.createElement("button"));
     const restoreTriggerFocus = vi.spyOn(trigger, "focus");

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -82,10 +82,6 @@ import {
 import { setSettingsChangeListener } from "./settings.ts";
 import { isStaleChunkImportError, scheduleStaleChunkReload } from "./stale-chunk-reload.ts";
 
-type AppSidebarElement = HTMLElement & {
-  dismissTransientMenus: () => boolean;
-};
-
 const APP_SIDEBAR_TAG = "openclaw-app-sidebar";
 // Stable references so the sidebar's enabledRouteIds property does not churn
 // on every shell render.
@@ -166,7 +162,7 @@ class OpenClawShell
   // Desktop and modal navigation are two slots for the same live sidebar.
   // Moving its element preserves session controllers and the resident pet
   // instead of resetting their lifecycle at every responsive breakpoint.
-  readonly navigationSidebar = document.createElement(APP_SIDEBAR_TAG) as AppSidebarElement;
+  readonly navigationSidebar = document.createElement(APP_SIDEBAR_TAG);
   // Where "Back to app" / Escape leaves the settings takeover; falls back to
   // chat (the app default route) when settings was the entry point.
   lastWorkspaceLocation: ShellNavigationHost["lastWorkspaceLocation"] = null;

--- a/ui/src/app/navigation-surface.ts
+++ b/ui/src/app/navigation-surface.ts
@@ -16,13 +16,14 @@ type AppSidebarElement = HTMLElement & { dismissTransientMenus(): boolean };
 type SidebarAttentionElement = HTMLElement & { dismissPanel(): boolean };
 
 export function dismissNavigationTransientSurfaces(host: HTMLElement): boolean {
+  // Unupgraded elements cannot own transient UI; navigation must not wait for their imports.
   const dismissedPanel = [
-    ...host.querySelectorAll<SidebarAttentionElement>("openclaw-sidebar-attention"),
+    ...host.querySelectorAll<SidebarAttentionElement>("openclaw-sidebar-attention:defined"),
   ]
     .map((attention) => attention.dismissPanel())
     .some((dismissed) => dismissed);
   const dismissedMenu = host
-    .querySelector<AppSidebarElement>("openclaw-app-sidebar")
+    .querySelector<AppSidebarElement>("openclaw-app-sidebar:defined")
     ?.dismissTransientMenus();
   return dismissedMenu === true || dismissedPanel;
 }

--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -5,6 +5,8 @@ import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { CronJob, CronJobsListResult, ModelAuthStatusResult } from "../api/types.ts";
 import type { ApplicationContext, ApplicationGateway } from "../app/context.ts";
 import type { ScopeUpgradeState } from "../app/device-scope-upgrade-availability.ts";
+import { client as mockClient, createGatewayHarness } from "../app/overlays-access.test-support.ts";
+import { createApplicationOverlays } from "../app/overlays.ts";
 import {
   createApplicationContextProvider,
   hiddenScopeUpgradeCapability,
@@ -68,6 +70,7 @@ function cronListResponse(jobs: CronJob[]): CronJobsListResult {
 type SidebarAttentionElement = HTMLElement & {
   context: ApplicationContext;
   updateComplete: Promise<boolean>;
+  dismissPanel: () => boolean;
   cronJobs: CronJob[];
   modelAuthStatus: ModelAuthStatusResult | null;
   loadedAtMs: number;
@@ -236,7 +239,9 @@ describe("sidebar attention refresh ownership", () => {
     vi.unstubAllGlobals();
   });
 
-  it("keeps the plain attention panel inside its top-layer menu surface", async () => {
+  async function mountAttention(
+    overrides: Partial<Pick<ApplicationContext, "gateway" | "overlays">> = {},
+  ) {
     const provider = createApplicationContextProvider({
       gateway: {
         snapshot: { phase: "connected", client: null, hello: null },
@@ -253,6 +258,7 @@ describe("sidebar attention refresh ownership", () => {
         subscribe: () => () => undefined,
       },
       scopeUpgrade: hiddenScopeUpgradeCapability,
+      ...overrides,
     } as unknown as ApplicationContext);
     const element = document.createElement("openclaw-sidebar-attention") as SidebarAttentionElement;
     provider.append(element);
@@ -261,13 +267,157 @@ describe("sidebar attention refresh ownership", () => {
     await waitForFast(() =>
       expect(element.querySelector<HTMLButtonElement>(".sidebar-issues-button")).not.toBeNull(),
     );
-    element.querySelector<HTMLButtonElement>(".sidebar-issues-button")!.click();
+    const trigger = element.querySelector<HTMLButtonElement>(".sidebar-issues-button")!;
+    return { element, provider, trigger };
+  }
+
+  it("keeps the plain attention panel inside its top-layer menu surface", async () => {
+    const { element, trigger } = await mountAttention();
+    trigger.click();
 
     await import("./sidebar-attention-panel.runtime.ts");
     await element.updateComplete;
     const panel = element.querySelector(".sidebar-issues-panel");
     expect(panel).not.toBeNull();
     expect(panel?.closest("openclaw-menu-surface")).not.toBeNull();
+    panel!.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await element.updateComplete;
+    expect(element.querySelector(".sidebar-issues-panel")).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it("keeps a reconnected attention panel closed until a new open", async () => {
+    const { element, provider, trigger } = await mountAttention();
+    trigger.click();
+    await waitForFast(() => expect(element.querySelector(".sidebar-issues-panel")).not.toBeNull());
+
+    element.remove();
+    provider.append(element);
+    await element.updateComplete;
+
+    expect(element.querySelector(".sidebar-issues-panel")).toBeNull();
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    trigger.click();
+    await waitForFast(() => expect(element.querySelector(".sidebar-issues-panel")).not.toBeNull());
+  });
+
+  it("does not let an obsolete open render steal focus from a later interaction", async () => {
+    const { element, trigger } = await mountAttention();
+    const rendered = deferred<boolean>();
+    const updateComplete = vi
+      .spyOn(element, "updateComplete", "get")
+      .mockReturnValueOnce(rendered.promise);
+    trigger.click();
+    await waitForFast(() => expect(element.querySelector(".sidebar-issues-panel")).not.toBeNull());
+    expect(updateComplete).toHaveBeenCalledOnce();
+    updateComplete.mockRestore();
+
+    element.dismissPanel();
+    await element.updateComplete;
+    trigger.click();
+    await waitForFast(() =>
+      expect(document.activeElement).toBe(element.querySelector(".sidebar-issues-panel__list")),
+    );
+    const nextControl = document.body.appendChild(document.createElement("button"));
+    nextControl.focus();
+    rendered.resolve(true);
+    await rendered.promise;
+
+    expect(document.activeElement).toBe(nextControl);
+  });
+
+  it("does not restore an obsolete close's focus after another open and close", async () => {
+    const { element, trigger } = await mountAttention();
+    trigger.click();
+    await waitForFast(() => expect(element.querySelector(".sidebar-issues-panel")).not.toBeNull());
+    const rendered = deferred<boolean>();
+    const updateComplete = vi
+      .spyOn(element, "updateComplete", "get")
+      .mockReturnValueOnce(rendered.promise);
+    element
+      .querySelector(".sidebar-issues-panel")!
+      .dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(updateComplete).toHaveBeenCalledOnce();
+    updateComplete.mockRestore();
+    await element.updateComplete;
+    trigger.click();
+    await waitForFast(() =>
+      expect(document.activeElement).toBe(element.querySelector(".sidebar-issues-panel__list")),
+    );
+    element.dismissPanel();
+    await element.updateComplete;
+    const nextControl = document.body.appendChild(document.createElement("button"));
+    nextControl.focus();
+    rendered.resolve(true);
+    await rendered.promise;
+
+    expect(document.activeElement).toBe(nextControl);
+  });
+
+  it.each([
+    { name: "same panel", reopen: false },
+    { name: "reopened panel", reopen: true },
+  ])("restores approval focus only within the initiating panel ($name)", async ({ reopen }) => {
+    const resolution = deferred<unknown>();
+    const request = vi.fn((method: string) => {
+      if (method === "exec.approval.resolve") {
+        return resolution.promise;
+      }
+      if (method === "cron.list") {
+        return Promise.resolve(cronListResponse([]));
+      }
+      if (
+        method === "exec.approval.list" ||
+        method === "plugin.approval.list" ||
+        method === "openclaw.approval.list"
+      ) {
+        return Promise.resolve([]);
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const harness = createGatewayHarness(mockClient(request));
+    const overlays = createApplicationOverlays(harness.gateway);
+    const decideApproval = vi.spyOn(overlays, "decideApproval");
+    try {
+      const { element, trigger } = await mountAttention({ gateway: harness.gateway, overlays });
+      harness.emitApproval("remaining", 1);
+      harness.emitApproval("selected", 2);
+      trigger.click();
+      const decisionSelector =
+        '[data-approval-id="selected"] .sidebar-approval-row__action--allow-once';
+      await waitForFast(() => expect(element.querySelector(decisionSelector)).not.toBeNull());
+      element.querySelector<HTMLButtonElement>(decisionSelector)!.click();
+      expect(decideApproval).toHaveBeenCalledExactlyOnceWith("allow-once", "selected");
+      expect(request).toHaveBeenCalledWith("exec.approval.resolve", {
+        id: "selected",
+        decision: "allow-once",
+      });
+      if (reopen) {
+        element.dismissPanel();
+        await element.updateComplete;
+        trigger.click();
+        await waitForFast(() =>
+          expect(document.activeElement).toBe(element.querySelector(".sidebar-issues-panel__list")),
+        );
+      }
+      const tab = element.querySelector<HTMLElement>("#sidebar-issues-tab-all")!;
+      if (reopen) {
+        tab.focus();
+      }
+      resolution.resolve({ ok: true });
+      await decideApproval.mock.results[0]!.value;
+      await element.updateComplete;
+
+      expect(overlays.snapshot.approvalQueue.map((approval) => approval.id)).toEqual(["remaining"]);
+      expect(document.activeElement).toBe(
+        reopen
+          ? tab
+          : element.querySelector('[data-approval-id="remaining"] [data-issue-row-focus]'),
+      );
+    } finally {
+      resolution.resolve({ ok: true });
+      overlays.dispose();
+    }
   });
 
   it("keeps the latest refresh when an older load on the same client finishes last", async () => {
@@ -832,26 +982,12 @@ describe("sidebar Inbox projection", () => {
 });
 
 describe("dismissSidebarAttention", () => {
-  function createStorageMock(): Storage {
-    const map = new Map<string, string>();
-    return {
-      get length() {
-        return map.size;
-      },
-      clear: () => map.clear(),
-      getItem: (key: string) => map.get(key) ?? null,
-      key: (index: number) => [...map.keys()][index] ?? null,
-      removeItem: (key: string) => void map.delete(key),
-      setItem: (key: string, value: string) => void map.set(key, value),
-    };
-  }
-
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
   it("merges with the persisted map so another tab's dismissal survives", () => {
-    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("localStorage", createTestStorageMock());
     const key = dismissalStoreKey("ws://gateway.test");
     // Another tab dismissed a cron chip after this tab last loaded.
     localStorage.setItem(key, JSON.stringify({ cronFailed: ["alpha"] }));
@@ -867,7 +1003,7 @@ describe("dismissSidebarAttention", () => {
   });
 
   it("preserves released single-signature dismissals during upgrade", () => {
-    vi.stubGlobal("localStorage", createStorageMock());
+    vi.stubGlobal("localStorage", createTestStorageMock());
     const gatewayUrl = "ws://gateway.test";
     localStorage.setItem(
       dismissalStoreKey(gatewayUrl),

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -96,6 +96,7 @@ class SidebarAttention extends OpenClawLightDomElement {
   private panelTrigger: HTMLElement | null = null;
   private panelRenderer: SidebarAttentionPanelRenderer | null = null;
   private panelLoad: Promise<SidebarAttentionPanelRuntime> | null = null;
+  private panelGeneration = 0;
   private nativeUpdateDeclined = false;
 
   private readonly loadTask = new Task(this, {
@@ -229,6 +230,9 @@ class SidebarAttention extends OpenClawLightDomElement {
   override connectedCallback() {
     super.connectedCallback();
     this.nativeUpdateDeclined = false;
+    // Dismissal belongs to the connected Inbox, including while its panel imports.
+    document.addEventListener("pointerdown", this.handleOutsideInteraction, true);
+    document.addEventListener("keydown", this.handleOutsideInteraction, true);
     document.addEventListener("visibilitychange", this.refreshIfStale);
     globalThis.addEventListener("storage", this.syncDismissalsFromStorage);
     window.addEventListener(
@@ -240,6 +244,8 @@ class SidebarAttention extends OpenClawLightDomElement {
   }
 
   override disconnectedCallback() {
+    document.removeEventListener("pointerdown", this.handleOutsideInteraction, true);
+    document.removeEventListener("keydown", this.handleOutsideInteraction, true);
     document.removeEventListener("visibilitychange", this.refreshIfStale);
     globalThis.removeEventListener("storage", this.syncDismissalsFromStorage);
     window.removeEventListener(
@@ -247,7 +253,7 @@ class SidebarAttention extends OpenClawLightDomElement {
       this.handleNativeUpdateAvailabilityChanged,
     );
     window.removeEventListener(NATIVE_UPDATE_DECLINED_EVENT, this.handleNativeUpdateDeclined);
-    document.removeEventListener("pointerdown", this.closeOnOutsidePointer, true);
+    this.closePanel(false);
     if (this.idleRefreshTimer !== null) {
       globalThis.clearInterval(this.idleRefreshTimer);
       this.idleRefreshTimer = null;
@@ -455,17 +461,21 @@ class SidebarAttention extends OpenClawLightDomElement {
     );
   }
 
-  private readonly closeOnOutsidePointer = (event: PointerEvent) => {
-    if (!this.panelOpen || event.composedPath().includes(this)) {
-      return;
+  private readonly handleOutsideInteraction = (event: PointerEvent | KeyboardEvent) => {
+    const dismiss =
+      event instanceof KeyboardEvent
+        ? event.key === "Escape" && !this.panelOpen && !event.defaultPrevented
+        : !event.composedPath().includes(this);
+    if (dismiss) {
+      this.closePanel(false);
     }
-    this.closePanel(false);
   };
 
   private async openPanel(trigger: HTMLElement) {
+    const generation = ++this.panelGeneration;
     this.panelLoad ??= import("./sidebar-attention-panel.runtime.ts");
     const panelRuntime = await this.panelLoad;
-    if (!this.isConnected) {
+    if (!this.isConnected || generation !== this.panelGeneration) {
       return;
     }
     this.context?.scopeUpgrade.activate(panelRuntime.ScopeUpgradeController);
@@ -481,13 +491,15 @@ class SidebarAttention extends OpenClawLightDomElement {
         : { left, anchor: "bottom", bottom: Math.max(8, globalThis.innerHeight - rect.top + 8) };
     this.selectedTab = "all";
     this.panelOpen = true;
-    document.addEventListener("pointerdown", this.closeOnOutsidePointer, true);
-    void this.updateComplete.then(() => {
+    await this.updateComplete;
+    if (generation === this.panelGeneration) {
       this.querySelector<HTMLElement>(".sidebar-issues-panel__list")?.focus();
-    });
+    }
   }
 
   private closePanel(restoreFocus: boolean) {
+    // Closing also cancels an open that is still waiting for its runtime or render.
+    const generation = ++this.panelGeneration;
     if (!this.panelOpen) {
       return;
     }
@@ -496,9 +508,12 @@ class SidebarAttention extends OpenClawLightDomElement {
     this.overflowAbove = false;
     this.overflowBelow = false;
     this.panelTrigger = null;
-    document.removeEventListener("pointerdown", this.closeOnOutsidePointer, true);
     if (restoreFocus) {
-      void this.updateComplete.then(() => trigger?.focus());
+      void this.updateComplete.then(() => {
+        if (generation === this.panelGeneration) {
+          trigger?.focus();
+        }
+      });
     }
   }
 
@@ -603,9 +618,10 @@ class SidebarAttention extends OpenClawLightDomElement {
     const row = target.closest<HTMLElement>("[data-approval-id]");
     const rowFocus = row?.querySelector<HTMLElement>("[data-issue-row-focus]") ?? null;
     const rowIndex = rowFocus ? focusOrder.indexOf(rowFocus) : 0;
+    const generation = this.panelGeneration;
     await context.overlays.decideApproval(decision, approvalId);
     await this.updateComplete;
-    if (!this.panelOpen || target.isConnected) {
+    if (generation !== this.panelGeneration || target.isConnected) {
       return;
     }
     const remaining = Array.from(this.querySelectorAll<HTMLElement>("[data-issue-row-focus]"));

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -467,12 +467,18 @@ class SidebarAttention extends OpenClawLightDomElement {
         ? event.key === "Escape" && !this.panelOpen && !event.defaultPrevented
         : !event.composedPath().includes(this);
     if (dismiss) {
+      if (event instanceof KeyboardEvent && this.panelTrigger) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
       this.closePanel(false);
     }
   };
 
   private async openPanel(trigger: HTMLElement) {
     const generation = ++this.panelGeneration;
+    // The pending open owns Escape before its lazy panel can handle keyboard events.
+    this.panelTrigger = trigger;
     this.panelLoad ??= import("./sidebar-attention-panel.runtime.ts");
     const panelRuntime = await this.panelLoad;
     if (!this.isConnected || generation !== this.panelGeneration) {
@@ -483,7 +489,6 @@ class SidebarAttention extends OpenClawLightDomElement {
     const width = Math.min(390, globalThis.innerWidth - 16);
     const preferredLeft = rect.left + rect.width / 2 - width / 2;
     const left = Math.max(8, Math.min(preferredLeft, globalThis.innerWidth - width - 8));
-    this.panelTrigger = trigger;
     this.panelRenderer = panelRuntime.renderSidebarAttentionPanel;
     this.panelPosition =
       rect.top < globalThis.innerHeight / 2
@@ -500,18 +505,15 @@ class SidebarAttention extends OpenClawLightDomElement {
   private closePanel(restoreFocus: boolean) {
     // Closing also cancels an open that is still waiting for its runtime or render.
     const generation = ++this.panelGeneration;
-    if (!this.panelOpen) {
-      return;
-    }
-    const trigger = this.panelTrigger;
+    const trigger = restoreFocus && this.panelOpen ? this.panelTrigger : null;
     this.panelOpen = false;
     this.overflowAbove = false;
     this.overflowBelow = false;
     this.panelTrigger = null;
-    if (restoreFocus) {
+    if (trigger) {
       void this.updateComplete.then(() => {
         if (generation === this.panelGeneration) {
-          trigger?.focus();
+          trigger.focus();
         }
       });
     }

--- a/ui/src/e2e/control-ui-e2e-suite.test-support.ts
+++ b/ui/src/e2e/control-ui-e2e-suite.test-support.ts
@@ -1,5 +1,5 @@
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect } from "vitest";
 import {
   canRunPlaywrightChromium,
   controlUiE2eWaitTimeoutMs,
@@ -33,6 +33,27 @@ type ControlUiE2eSuite = {
     run: (fixture: ControlUiE2ePage) => Promise<T>,
   ) => Promise<T>;
 };
+
+export async function holdModuleResponse(page: Page, module: RegExp) {
+  let release!: () => void;
+  let requested!: (url: string) => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const request = new Promise<string>((resolve) => {
+    requested = resolve;
+  });
+  let requests = 0;
+  await page.route(module, async (route) => {
+    requests += 1;
+    const response = await route.fetch();
+    expect(response.status()).toBe(200);
+    requested(route.request().url());
+    await gate;
+    await route.fulfill({ response });
+  });
+  return { request, release, requests: () => requests };
+}
 
 export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): ControlUiE2eSuite {
   const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -3,7 +3,7 @@
 // Plain browsers keep their normal in-page controls.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import type { BrowserContext } from "playwright";
+import type { BrowserContext, Page } from "playwright";
 import { afterEach, expect, it } from "vitest";
 import {
   installMockGateway,
@@ -65,6 +65,27 @@ const TOAST_SCENARIO: ControlUiMockGatewayScenario = {
 
 let context: BrowserContext | undefined;
 
+async function holdModuleResponse(page: Page, module: RegExp) {
+  let release!: () => void;
+  let requested!: (url: string) => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const request = new Promise<string>((resolve) => {
+    requested = resolve;
+  });
+  let requests = 0;
+  await page.route(module, async (route) => {
+    requests += 1;
+    const response = await route.fetch();
+    expect(response.status()).toBe(200);
+    requested(route.request().url());
+    await gate;
+    await route.fulfill({ response });
+  });
+  return { request, release, requests: () => requests };
+}
+
 suite.define(() => {
   afterEach(async () => {
     await context?.close();
@@ -72,11 +93,14 @@ suite.define(() => {
   });
 
   async function openPage(options: {
+    beforeNavigate?: (page: Page) => Promise<void>;
     colorScheme?: "dark" | "light";
     deviceLess?: boolean;
     hasTouch?: boolean;
     height?: number;
     nativeNav?: boolean;
+    pathname?: string;
+    readySelector?: string;
     scenario?: ControlUiMockGatewayScenario;
     webChrome?: boolean;
     width?: number;
@@ -151,11 +175,14 @@ suite.define(() => {
       featureMethods: ["chat.metadata", "chat.startup", "sessions.create"],
       ...options.scenario,
     });
-    const response = await page.goto(suite.server.baseUrl);
+    await options.beforeNavigate?.(page);
+    const response = await page.goto(`${suite.server.baseUrl}${options.pathname ?? ""}`, {
+      waitUntil: options.beforeNavigate ? "domcontentloaded" : "load",
+    });
     expect(response?.status()).toBe(200);
     // The brand row only becomes visible on desktop widths; drawer widths keep
     // the sidebar hidden, so wait for DOM attachment instead of visibility.
-    await page.locator(".sidebar-brand").waitFor({ state: "attached" });
+    await page.locator(options.readySelector ?? ".sidebar-brand").waitFor({ state: "attached" });
     if (options.scenario) {
       await gateway.waitForRequest("sessions.list");
     }
@@ -186,6 +213,135 @@ suite.define(() => {
     await expect.poll(() => desktopInbox.getAttribute("aria-modal")).toBeNull();
     await page.keyboard.press("Escape");
   });
+
+  it.each([
+    {
+      name: "sidebar",
+      module: /\/assets\/app-sidebar-[A-Za-z0-9_-]{8}\.js(?:\?.*)?$/u,
+      pathname: "new",
+      readySelector: ".new-session-page__message",
+      tag: "openclaw-app-sidebar",
+    },
+    {
+      name: "floating attention",
+      module: /\/assets\/sidebar-attention-[A-Za-z0-9_-]{8}\.js(?:\?.*)?$/u,
+      pathname: "settings/appearance",
+      readySelector: ".shell--settings",
+      tag: "openclaw-sidebar-attention",
+    },
+  ])("closes navigation while the $name element is still unregistered", async (testCase) => {
+    let held!: Awaited<ReturnType<typeof holdModuleResponse>>;
+    const errors: string[] = [];
+    try {
+      const page = await openPage({
+        ...testCase,
+        width: 900,
+        beforeNavigate: async (targetPage) => {
+          targetPage.on("pageerror", (error) => errors.push(error.message));
+          held = await holdModuleResponse(targetPage, testCase.module);
+        },
+      });
+      await held.request;
+      const element = page.locator(testCase.tag).first();
+      expect(await element.evaluate((node) => node.matches(":defined"))).toBe(false);
+      const toggle = page.locator(".topbar-nav-toggle");
+      const navigation = page.getByRole("dialog", { name: "Navigation" });
+      await toggle.click();
+      await expect.poll(() => navigation.isVisible()).toBe(true);
+      await page.keyboard.press("Escape");
+      await expect.poll(() => navigation.isVisible()).toBe(false);
+      expect(await page.locator("#control-ui-main").getAttribute("inert")).toBeNull();
+
+      await toggle.click();
+      await expect.poll(() => navigation.isVisible()).toBe(true);
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await expect.poll(() => navigation.isVisible()).toBe(false);
+      await expect
+        .poll(() => page.locator(".shell").getAttribute("class"))
+        .not.toContain("shell--mobile-nav");
+      expect(errors).toEqual([]);
+
+      held.release();
+      await expect.poll(() => element.evaluate((node) => node.matches(":defined"))).toBe(true);
+      await page.setViewportSize({ width: 900, height: 900 });
+      await toggle.click();
+      await expect.poll(() => navigation.isVisible()).toBe(true);
+      await page.keyboard.press("Escape");
+      await expect.poll(() => navigation.isVisible()).toBe(false);
+      expect(errors).toEqual([]);
+      expect(held.requests()).toBe(1);
+    } finally {
+      held?.release();
+    }
+  });
+
+  it.each(["navigation", "replacement open", "reconnection", "outside pointer", "Escape"] as const)(
+    "keeps pending Inbox intent current across %s",
+    async (action) => {
+      const page = await openPage({ pathname: "new" });
+      const held = await holdModuleResponse(
+        page,
+        /\/assets\/sidebar-attention-panel\.runtime-[^/?]+\.js(?:\?.*)?$/u,
+      );
+      const attention = await page
+        .locator("openclaw-app-sidebar openclaw-sidebar-attention")
+        .elementHandle();
+      expect(attention).not.toBeNull();
+      const inbox = page.locator("openclaw-app-sidebar .sidebar-issues-button");
+      const dialog = page.getByRole("dialog", { name: "Inbox" });
+      try {
+        await inbox.click();
+        const moduleUrl = await held.request;
+        expect(await dialog.count()).toBe(0);
+        if (action === "reconnection") {
+          await attention!.evaluate((element) => {
+            const parent = element.parentNode!;
+            const next = element.nextSibling;
+            element.remove();
+            parent.insertBefore(element, next);
+          });
+        } else if (action === "outside pointer") {
+          await page.locator(".new-session-page__message").click();
+        } else if (action === "Escape") {
+          await page.keyboard.press("Escape");
+        } else {
+          const toggle = page.locator(".shell-chrome-controls__nav-toggle");
+          await toggle.click();
+          await expect.poll(() => toggle.getAttribute("aria-label")).toBe("Expand sidebar");
+          // The native event does not generate an outside pointer that could
+          // accidentally dismiss an Inbox resurrected by the old import.
+          await page.evaluate(() => {
+            window.dispatchEvent(new CustomEvent("openclaw:native-toggle-sidebar"));
+          });
+          await expect.poll(() => toggle.getAttribute("aria-label")).toBe("Collapse sidebar");
+          if (action === "replacement open") {
+            await inbox.click();
+          }
+        }
+        held.release();
+        // Keep the import native: Vitest rewrites imports inside serialized callbacks.
+        await page.evaluate(`import(${JSON.stringify(moduleUrl)}).then(() => undefined)`);
+        await attention!.evaluate(
+          (element) =>
+            (element as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete,
+        );
+        if (action !== "replacement open") {
+          expect(await dialog.count()).toBe(0);
+          expect(await inbox.getAttribute("aria-expanded")).toBe("false");
+          await inbox.click();
+        }
+        await dialog.waitFor({ state: "visible" });
+        await expect
+          .poll(() => dialog.evaluate((element) => element.contains(document.activeElement)))
+          .toBe(true);
+        expect(held.requests()).toBe(1);
+        await page.keyboard.press("Escape");
+        await expect.poll(() => dialog.count()).toBe(0);
+      } finally {
+        held.release();
+      }
+    },
+  );
 
   it("keeps pointer-triggered sidebar focus from opening its tooltip", async () => {
     const page = await openPage({ hasTouch: true, nativeNav: false });

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -14,7 +14,10 @@ import {
   failNextDeviceIdentityMint,
   openChatSidePanelType,
 } from "./chat-side-panel.test-support.ts";
-import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import {
+  createControlUiE2eSuite,
+  holdModuleResponse,
+} from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({
   name: "Control UI native-nav sidebar toggle E2E",
@@ -64,27 +67,6 @@ const TOAST_SCENARIO: ControlUiMockGatewayScenario = {
 };
 
 let context: BrowserContext | undefined;
-
-async function holdModuleResponse(page: Page, module: RegExp) {
-  let release!: () => void;
-  let requested!: (url: string) => void;
-  const gate = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  const request = new Promise<string>((resolve) => {
-    requested = resolve;
-  });
-  let requests = 0;
-  await page.route(module, async (route) => {
-    requests += 1;
-    const response = await route.fetch();
-    expect(response.status()).toBe(200);
-    requested(route.request().url());
-    await gate;
-    await route.fulfill({ response });
-  });
-  return { request, release, requests: () => requests };
-}
 
 suite.define(() => {
   afterEach(async () => {

--- a/ui/src/e2e/sidebar-settings.e2e.test.ts
+++ b/ui/src/e2e/sidebar-settings.e2e.test.ts
@@ -3,6 +3,7 @@ import {
   installMockGateway,
   waitForControlUiSettingsTakeover,
 } from "../test-helpers/control-ui-e2e.ts";
+import { holdModuleResponse } from "./control-ui-e2e-suite.test-support.ts";
 import {
   captureSettingsSidebarUiProof,
   createSidebarCustomizationSuite,
@@ -11,6 +12,80 @@ import {
 const suite = createSidebarCustomizationSuite("Control UI sidebar settings mocked Gateway E2E");
 
 suite.define(() => {
+  it.each([
+    { state: "ready", pending: false, focusSearch: false },
+    { state: "pending with trigger focus", pending: true, focusSearch: false },
+    { state: "pending with search focus", pending: true, focusSearch: true },
+  ])(
+    "dismisses $state Inbox before exiting Settings with Escape",
+    async ({ pending, focusSearch }) => {
+      const context = await suite.newBrowserContext({
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+      });
+      const page = await context.newPage();
+      const held = await holdModuleResponse(
+        page,
+        /\/assets\/sidebar-attention-panel\.runtime-[^/?]+\.js(?:\?.*)?$/u,
+      );
+      await installMockGateway(page);
+
+      try {
+        await page.goto(`${suite.server.baseUrl}new`);
+        await page.locator(".new-session-page__message").waitFor({ state: "visible" });
+        await page.keyboard.press("Control+Shift+,");
+        const { search, sidebar } = await waitForControlUiSettingsTakeover(page);
+        const attention = await page.locator(".sidebar-attention--floating").elementHandle();
+        expect(attention).not.toBeNull();
+        const inbox = page.locator(".sidebar-attention--floating .sidebar-issues-button");
+        const dialog = page.getByRole("dialog", { name: "Inbox" });
+        if (!pending) {
+          held.release();
+        }
+        await inbox.click();
+        const moduleUrl = await held.request;
+        if (pending) {
+          expect(await dialog.count()).toBe(0);
+          if (focusSearch) {
+            expect(await search.inputValue()).toBe("");
+            // Move focus without an outside pointer that would cancel the pending open.
+            await search.focus();
+          }
+        } else {
+          await dialog.waitFor({ state: "visible" });
+          await expect
+            .poll(() => dialog.evaluate((element) => element.contains(document.activeElement)))
+            .toBe(true);
+        }
+
+        await page.keyboard.press("Escape");
+        held.release();
+        // Keep the import native: Vitest rewrites imports inside serialized callbacks.
+        await page.evaluate(`import(${JSON.stringify(moduleUrl)}).then(() => undefined)`);
+        await attention!.evaluate(
+          (element) =>
+            (element as HTMLElement & { updateComplete: Promise<boolean> }).updateComplete,
+        );
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/settings/appearance");
+        expect(await sidebar.isVisible()).toBe(true);
+        expect(await dialog.count()).toBe(0);
+        const focusTarget = focusSearch ? search : inbox;
+        await expect
+          .poll(() => focusTarget.evaluate((element) => element === document.activeElement))
+          .toBe(true);
+
+        await page.keyboard.press("Escape");
+        await expect.poll(() => new URL(page.url()).pathname).toBe("/new");
+        await page.locator(".new-session-page__message").waitFor({ state: "visible" });
+        expect(held.requests()).toBe(1);
+      } finally {
+        held.release();
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
+
   it("keeps Gateway access fields editable by their visible labels", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",


### PR DESCRIPTION
Closes #131022
Closes #131025

## What Problem This Solves

Fixes an issue where users closing mobile navigation with Escape or resizing the window could leave navigation stuck while sidebar components were still loading. It also fixes a dismissed Inbox appearing later when its delayed import finishes, and old render or approval callbacks moving focus into a newer Inbox.

## Why This Change Was Made

Navigation now calls component methods only after custom-element registration, without waiting for an import to dismiss the shell. The connected Inbox owns outside-click and pending-Escape dismissal. A single generation identifies its current open/close lifecycle, so an obsolete import, render or approval callback cannot reopen the panel or steal focus. Disconnect uses the same close path. A pending Inbox now records its trigger immediately and consumes Escape before Settings sees it; closing clears both pending and open ownership.

This removes the false ready-element cast and per-open listener management. Existing sidebar overrides, dismissal of all Inbox instances, ready-panel keyboard handling and actual approval decisions remain intact. No configuration, dependency, persistence or public API changes are introduced.

Production LOC: +40/-25 (net +15). Tests and test support: +399/-27. Validation metadata: one obsolete assertion allowance removed. The production growth supplies the missing asynchronous lifecycle identity and pending keyboard ownership; booleans cannot distinguish closing, reopening and closing again. It avoids a new controller or parallel state machine.

## User Impact

Navigation remains dismissible during slow loading. Closing or replacing an Inbox request takes effect immediately, and a later import or approval result cannot undo that decision. Ready Inbox opening, Escape and focus restoration continue to work. In Settings, the first Escape cancels a loading Inbox without leaving the page, and a second Escape exits Settings normally, including when its empty search field has focus.

## Evidence

Corrected head: [8ddd91d0457b](https://github.com/openclaw/openclaw/commit/8ddd91d0457b75a0afd335d88ea79e341a0dfa28). The local proof ran on these exact reviewed source bytes before commit; the served build still identifies its pre-commit `1b510696` base. Commit hooks preserved all four corrected file hashes.

- Before the fix, real Chromium reproduced both registration failures and four delayed-import failures; the replacement-open control passed. Three component lifecycle regressions and the delayed approval-focus regression also failed at their intended assertions.
- The corrected files pass all 446 focused tests across seven owner and sibling files, including the actual approval overlay owner, Settings keyboard handling and same-panel controls.
- The review follow-up reproduced the Settings failure in real Chromium: both pending Inbox cases left Settings on the first Escape, while the ready-panel control passed. The permanent three-case regression table reproduces those same two failures on the published pre-correction bundle.
- All 29 corrected production-bundle browser cases pass without skips: the 23 navigation cases plus all six Settings cases, including ready, pending-trigger-focus and pending-search-focus Inbox dismissal.
- The original three-case visual replay also passes: closed Inbox Escape exits Settings, while ready and pending Inbox Escape first dismiss the Inbox and retain Settings. A second Escape then exits normally. The original failing and corrected screenshots were inspected directly.
- Before the follow-up correction, all 23 production-bundle navigation browser scenarios passed without skips: seven new lazy lifecycle cases plus existing keyboard, modal focus, breakpoint, native window-event, titlebar and toast controls. The harness delays the original HTTP module response and releases its unchanged bytes. Those results belong to the original published head; the corrected 29-case suite reruns them with all six Settings cases.
- One canonical UI build passes the unchanged startup budget: 342,789 gzip bytes across eight requests, below 344,620. This is a budget pass, not a before/after compression claim.
- Independent full-severity source review found no actionable findings; restricted Codex autoreview returned no P0 findings on the original seven-file patch and again on the four-file Settings correction. The correction also passed independent full-severity review.

The first complete local changed-file gate passed its type stages, then found six shadowed identifiers in the new tests. Those names and a later whitespace finding were corrected; final targeted typed lint, formatting and all 446 owner tests pass. The first corrected browser attempt stopped at the runner’s 120-second no-output watchdog without a test verdict. Direct inspection showed that Vitest’s automatic agent reporter suppresses passing results; that explains the missing progress output but does not establish why the earlier attempt failed to finish. Its logs and verified process/server cleanup are retained. The diagnostic repeat passed all 29 cases using the same tests, bundle and timeouts with the documented verbose reporter; no deadline was increased. Both attempts remain recorded honestly.

The 20-command changed-check plan was mapped to its actual CI owners: 16 commands are covered by automatic PR CI, including every selected core lint/type stripe, UI types, formatting, stylelint, i18n, dead-code and ratchet checks. The remaining four canonical local guards all passed: changelog attribution, both wildcard-export guards and dependency pins. This does not claim a final complete local changed-gate run. The original published head passed [CI33111583267](https://github.com/openclaw/openclaw/actions/runs/33111583267). Corrected head `8ddd91d0457b` now passes complete [CI33126854882](https://github.com/openclaw/openclaw/actions/runs/33126854882): 110 successful jobs and 14 intentionally skipped jobs. The final pre-merge check inventory was green with no failed or pending checks. Native preparation and merge both completed successfully on the unchanged reviewed head, landing [13f3e2621e7c](https://github.com/openclaw/openclaw/commit/13f3e2621e7cc7df919d32e68f43e159f6042769). The entire landed tree matches the expected merge of that reviewed head with its actual main parent. Both linked issues closed as completed; main ancestry and native worktree, lock, temporary-ref and remote-branch cleanup were verified. The latest exact-head ClawSweeper review (August 27, 23:45 UTC) found no remaining correctness defect and recommended this owner-boundary fix after green gates. Its separate live attempt stopped at a 30-second output expectation before any test result; that attempt is not a passing run. The completed 29-case Chromium proof above is retained separately.

History: the unguarded navigation calls came from #130319 (August 27); the Inbox open/close lifecycle came from #125070 (August 23) and retained the missing cancellation check through later renderer splits. Both original PRs were authored and merged by Vyctor H. Brzezowski (@vyctorbrzezowski). This repair preserves their lazy-loading and responsive-navigation design.

The browser proof uses the real built UI and Chromium with the canonical synthetic Gateway. It does not claim a live provider or personal account session. Source and served-bundle hashes remained stable, and all owned browsers and preview servers were closed.

The existing global stale-module reload and cached-import failure recovery policy is unchanged; permanent stale assets with unavailable recovery remain a separate follow-up under #127733. A separate source-audit follow-up, **Cancel floating Inbox presentation on route changes**, found that the floating renderer does not pass the existing route identity to the Inbox owner. Browser-history and Settings-shortcut proof are still pending; this PR does not claim to fix that separate route-binding gap.

| Scenario | Before | After |
|---|---|---|
| Escape while the main sidebar loads | ![Before: Escape while the main sidebar loads](https://github.com/user-attachments/assets/3182204a-21ae-4c71-9140-b81cabaff3d5) | ![After: Escape while the main sidebar loads](https://github.com/user-attachments/assets/f599632a-1ad1-4f2e-b269-a0beec179a9d) |
| Escape while the Settings Inbox custom element registers | ![Before: Escape while the Settings Inbox custom element registers](https://github.com/user-attachments/assets/380f13ab-89a5-47f2-9b15-160f11c0e337) | ![After: Escape while the Settings Inbox custom element registers](https://github.com/user-attachments/assets/08128544-e3cf-4a4c-9a8c-a01bc275cb7a) |
| Reopen navigation after dismissing a loading Inbox | ![Before: Reopen navigation after dismissing a loading Inbox](https://github.com/user-attachments/assets/0cfbd841-6cfd-43a8-ba82-622c061272de) | ![After: Reopen navigation after dismissing a loading Inbox](https://github.com/user-attachments/assets/157a89c3-52fa-4799-ac6a-a562d53a7602) |
| First Escape while the Inbox panel loads in Settings | ![Before: Escape unexpectedly exits Settings](https://github.com/user-attachments/assets/5dc77dc7-949f-4940-85f4-af32f0c267cb) | ![After: Inbox closes and Settings remains open](https://github.com/user-attachments/assets/3fc3dbc3-7c40-4301-b269-75b1ef29dad7) |
