### PR TITLE
fix(copilot): prevent static GPT-5.4 mini thinking failures

### DIFF
--- a/extensions/github-copilot/openclaw.plugin.json
+++ b/extensions/github-copilot/openclaw.plugin.json
@@ -239,6 +239,8 @@
             "status": "deprecated",
             "replacedBy": "gpt-5.6-luna",
             "reasoning": true,
+            "thinkingLevelMap": { "minimal": "low", "xhigh": "xhigh", "max": null },
+            "compat": { "supportedReasoningEfforts": ["none", "low", "medium", "high", "xhigh"] },
             "input": ["text", "image"],
             "contextWindow": 400000,
             "contextTokens": 272000,

--- a/src/plugin-sdk/test-helpers/provider-runtime-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-runtime-contract.ts
@@ -1,5 +1,6 @@
 // Provider runtime contract helpers define reusable runtime tests for provider plugins.
 import { normalizeModelCatalog } from "@openclaw/model-catalog-core/model-catalog-normalize";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPluginMetadataSnapshot } from "../../config/plugin-auto-enable.test-helpers.js";
 import type { ProviderRuntimeModel } from "../plugin-entry.js";
@@ -285,6 +286,56 @@ export function describeGithubCopilotProviderRuntimeContract(
       ]);
       const createManifestModel = createManifestModelFactory("github-copilot", manifestCatalog);
 
+      async function resolveStaticModel(modelId: string, discoveryEnabled = false) {
+        const { createBundledStaticCatalogModelResolver } =
+          await import("../../agents/embedded-agent-runner/model.static-catalog.js");
+        const config = {
+          models: { catalogRefresh: { enabled: false } },
+          plugins: {
+            entries: {
+              "github-copilot": { config: { discovery: { enabled: discoveryEnabled } } },
+            },
+          },
+        };
+        const metadataSnapshot = createPluginMetadataSnapshot({
+          config,
+          manifestRegistry: {
+            diagnostics: [],
+            plugins: [
+              {
+                id: "github-copilot",
+                origin: "bundled",
+                providers: ["github-copilot"],
+                channels: [],
+                cliBackends: [],
+                skills: [],
+                hooks: [],
+                rootDir: "/fixtures/github-copilot",
+                source: "/fixtures/github-copilot/index.js",
+                manifestPath: "/fixtures/github-copilot/openclaw.plugin.json",
+                modelCatalog: normalizeModelCatalog(
+                  {
+                    providers: { "github-copilot": manifestCatalog },
+                    discovery: { "github-copilot": "runtime" },
+                  },
+                  { ownedProviders: new Set(["github-copilot"]) },
+                ),
+              },
+            ],
+          },
+        });
+        const resolveModel = createBundledStaticCatalogModelResolver({
+          cfg: config,
+          env: {},
+          metadataSnapshot,
+          includeRuntimeDiscovery: true,
+        });
+        return {
+          config,
+          model: expectDefined(resolveModel({ provider: "github-copilot", modelId }), modelId),
+        };
+      }
+
       it.each([
         ["gemini-3.6-flash", "openai-completions", false],
         ["gemini-3.1-pro-preview", "openai-completions", false],
@@ -296,53 +347,10 @@ export function describeGithubCopilotProviderRuntimeContract(
       ] as const)(
         "routes static %s through %s with discovery enabled=%s",
         async (modelId, api, discoveryEnabled) => {
-          const { createBundledStaticCatalogModelResolver } =
-            await import("../../agents/embedded-agent-runner/model.static-catalog.js");
-          const config = {
-            models: { catalogRefresh: { enabled: false } },
-            plugins: {
-              entries: {
-                "github-copilot": { config: { discovery: { enabled: discoveryEnabled } } },
-              },
-            },
-          };
-          const metadataSnapshot = createPluginMetadataSnapshot({
-            config,
-            manifestRegistry: {
-              diagnostics: [],
-              plugins: [
-                {
-                  id: "github-copilot",
-                  origin: "bundled",
-                  providers: ["github-copilot"],
-                  channels: [],
-                  cliBackends: [],
-                  skills: [],
-                  hooks: [],
-                  rootDir: "/fixtures/github-copilot",
-                  source: "/fixtures/github-copilot/index.js",
-                  manifestPath: "/fixtures/github-copilot/openclaw.plugin.json",
-                  modelCatalog: normalizeModelCatalog(
-                    {
-                      providers: { "github-copilot": manifestCatalog },
-                      discovery: { "github-copilot": "runtime" },
-                    },
-                    { ownedProviders: new Set(["github-copilot"]) },
-                  ),
-                },
-              ],
-            },
-          });
-          const resolveModel = createBundledStaticCatalogModelResolver({
-            cfg: config,
-            env: {},
-            metadataSnapshot,
-            includeRuntimeDiscovery: true,
-          });
-          const model = resolveModel({ provider: "github-copilot", modelId });
-          expect(model?.api).toBe(api);
+          const { config, model } = await resolveStaticModel(modelId, discoveryEnabled);
+          expect(model.api).toBe(api);
           if (api === "openai-completions") {
-            expect(model?.compat).toMatchObject({
+            expect(model.compat).toMatchObject({
               supportsStore: false,
               supportsDeveloperRole: false,
               supportsUsageInStreaming: false,
@@ -365,14 +373,78 @@ export function describeGithubCopilotProviderRuntimeContract(
               modelId,
               modelRegistry: {
                 find: () => model,
-                getAll: () => (model ? [model] : []),
-                getAvailable: () => (model ? [model] : []),
+                getAll: () => [model],
+                getAvailable: () => [],
                 hasConfiguredAuth: () => false,
               },
             }),
           ).toBeUndefined();
         },
       );
+
+      it.each([
+        ["minimal", "low"],
+        ["xhigh", "xhigh"],
+      ] as const)("sends static GPT-5.4 mini %s thinking as %s", async (level, effort) => {
+        const { createApiRegistry, createLlmRuntime } = await import("@openclaw/ai");
+        const { streamOpenAIResponses, streamSimpleOpenAIResponses } =
+          await import("@openclaw/ai/internal/openai");
+        const { config, model } = await resolveStaticModel("gpt-5.4-mini");
+        const provider = requireProviderContractProvider("github-copilot");
+        const profile = provider.resolveThinkingProfile?.({
+          provider: model.provider,
+          modelId: model.id,
+          api: model.api,
+          compat: model.compat,
+        });
+        const registry = createApiRegistry();
+        registry.registerApiProvider({
+          api: "openai-responses",
+          stream: streamOpenAIResponses,
+          streamSimple: streamSimpleOpenAIResponses,
+        });
+        const stream = expectDefined(
+          provider.wrapStreamFn?.({
+            config,
+            provider: model.provider,
+            modelId: model.id,
+            model,
+            streamFn: createLlmRuntime(registry).streamSimple,
+          }),
+          "Copilot stream wrapper",
+        );
+        const network = vi
+          .spyOn(globalThis, "fetch")
+          .mockRejectedValue(new Error("Unexpected network"));
+        const payloads: unknown[] = [];
+        try {
+          const response = await stream(
+            model,
+            {
+              messages: [{ role: "user", content: "Say hello", timestamp: 0 }],
+            },
+            {
+              apiKey: "test-token",
+              reasoning: level,
+              maxTokens: 1024,
+              maxRetries: 0,
+              onPayload: (payload) => {
+                payloads.push(payload);
+                throw new Error("Captured payload before network");
+              },
+            },
+          );
+          await response.result();
+          expect(network).not.toHaveBeenCalled();
+          expect.soft(profile?.levels.map(({ id }) => id)).toContain(level);
+          expect(profile?.levels.map(({ id }) => id)).not.toContain("max");
+          expect(payloads).toEqual([
+            expect.objectContaining({ reasoning: expect.objectContaining({ effort }) }),
+          ]);
+        } finally {
+          network.mockRestore();
+        }
+      });
 
       it("owns Copilot-specific forward-compat fallbacks", () => {
         const provider = requireProviderContractProvider("github-copilot");


### PR DESCRIPTION
Closes #131159

## What Problem This Solves

Fixes an issue where Copilot GPT-5.4 mini requests with `minimal` thinking fail with HTTP400 when OpenClaw uses the bundled static catalog. The same missing metadata hides `xhigh` from the provider policy and reduces it to `high` at the request-builder boundary.

## Why This Change Was Made

Add the model's observed supported-effort list and thinking-level map to the owning manifest. The existing mapper then sends `minimal` as `low`, preserves `xhigh`, and keeps `max` unavailable. Live catalog limits and explicit opt-outs still take precedence.

Production is **two declarative lines**, with no TypeScript runtime change, new option, dependency, export, or core provider-specific branch. The tests reuse one unexported actual static-resolver fixture for the existing Gemini coverage and the new mini policy/request cases: test support **+120/-48**, including moved fixture setup. No context, pricing, availability or transport changes.

The omission is present at the reproduced source commit `8f1df760385a2359ec2f3abb71e6a035cac38897`. The earlier sibling repair in #107834 did not cover this static mini entry; its original introduction is not established from the available history.

## User Impact

The existing GPT-5.4 mini entry behaves consistently with its supported Copilot effort range even when live discovery is disabled or unavailable. No manual effort override is required. This does not add native support for `max` or change other GPT/Claude models.

## Evidence

- Before: actual static resolver → registered thinking policy/provider wrapper → actual API registry/SDK sent `minimal` unchanged. Copilot returned HTTP400 `invalid_request_body`, explicitly rejecting that value. A low-only control on the same model/API returned HTTP200 and the exact nonce.
- Regression tests failed before the metadata edit: minimal→minimal instead of low; xhigh missing from policy and reduced to high. After the repair: **84 tests passed across four focused files**, including static Gemini siblings, dynamic discovery, provider policy and existing live opt-outs. Network-free payload captures use the actual registered provider and SDK builder, not a reimplementation.
- Final candidate live proof: requested `minimal` naturally reached `/responses` as `low`, and requested `xhigh` remained `xhigh`; both returned HTTP200 with separate exact fresh nonces. Neither request overrode the selected model/API/compatibility metadata or outgoing effort. Registered policy and SDK supported levels excluded `max`. All31 source hashes and OpenAI SDK7.5.0 hashes stayed unchanged during the proof.
- Targeted type-aware/type-check and syntax lint for the changed test helper, formatting, max-lines ratchet and whitespace checks passed. Fresh managed Codex P0–P2 review and a separate standalone Codex CLI review reported no actionable findings. Independent manual review also verified the source and live-artifact binding. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33112104261) completed successfully: 126 successful jobs, 21 conditional skips, zero failures.

Latest ClawSweeper status at landing preflight is a started-review placeholder, without a verdict or Rank-up moves. Independent source and live reviews are complete; the queued publisher is not being treated as a blocking review requirement. Post-merge catalog projection will be verified separately.

Live proof covers the registered source-provider flow on a personal GitHub account, not a full Gateway/slash-command session or enterprise tenant. After the Gemini parent landed, this change was rebased onto its merge commit. The two changed files are byte-identical to the live-tested candidate; of the 31 proof-bound paths, only an unrelated, already-landed usage-reporting hook changed. The integrated head `0a446ffe9d90ec390954e6977b50914bb84fae56` passed all 84 focused tests and the targeted type check again. Catalog publication and a software release are not claimed before verification.
