### PR TITLE
feat(claws): adopt existing workspaces

### DIFF
--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -340,6 +340,37 @@ instructions, writes declared workspace assets, realizes workspace skills, and
 records package, MCP, and cron provenance. Existing files are not overwritten,
 and retries fail closed when owned content drifted.
 
+By default an existing workspace directory is a `workspace_collision` blocker.
+Pass `--adopt-existing-workspace` during both preview and apply to install into
+an existing directory instead:
+
+```bash
+openclaw claws add ./incident-triage.claw.json \
+  --workspace ~/agents/incident-triage \
+  --adopt-existing-workspace \
+  --dry-run --json
+```
+
+At plan time each declared file is compared against the existing content:
+identical files become `adopt` actions and are recorded as managed without
+being rewritten, missing files are written normally, and differing content is a
+`workspace_file_conflict` blocker — adoption never overwrites existing files.
+If the package defines first-run instructions, any existing package bootstrap
+file is also a conflict, even when its content matches; Claws cannot safely
+claim or later remove a bootstrap file it did not create.
+Apply re-verifies content digests and fails closed when an adoptable file
+changed after planning. The agent is added to configuration only after every
+workspace file has been safely revalidated and recorded, so a failed adoption
+cannot leave a partially owned workspace routable. Adoption is disclosed as a
+distinct capability change in the plan, and a workspace already configured for
+another agent still blocks.
+
+Adoption transfers lifecycle ownership of matching declared files to Claws.
+After adoption, `claws update` may replace an unchanged adopted file with the
+content from the reviewed target package, and `claws remove` may delete an
+unchanged adopted file. Locally modified adopted files are retained and must be
+reconciled explicitly. Preview update and removal plans before applying them.
+
 ## Inspect installed state
 
 ```bash
@@ -477,7 +508,7 @@ credentials, sessions, and unowned local state are excluded.
 | `claws dev [path]`                  | Build and preview locally without mutation.         |
 | `claws build [path] --out <tgz>`    | Build a deterministic package artifact.             |
 | `claws inspect <source>`            | Validate a package directory or grouped manifest.   |
-| `claws add <source>`                | Preview or create one new agent and workspace.      |
+| `claws add <source>`                | Preview or create one agent and its workspace.      |
 | `claws status [claw-or-agent]`      | Report installed state, ownership, and drift.       |
 | `claws update <claw-or-agent>`      | Preview or apply changes from the selected source.  |
 | `claws remove <claw-or-agent>`      | Preview or remove the agent and eligible resources. |

--- a/src/claws/add-config.ts
+++ b/src/claws/add-config.ts
@@ -22,6 +22,11 @@ export class ClawAddConfigCommitError extends Error {
   }
 }
 
+export type ClawAddConfigCommitResult = {
+  committed: boolean;
+  reservedConfig: boolean;
+};
+
 function preserveAgentEntries(config: OpenClawConfig): {
   agents: AgentConfig[];
   config: OpenClawConfig;
@@ -63,8 +68,9 @@ export async function commitClawAgentConfig(params: {
   commitConfig?: ConfigCommit;
   resumePlan?: ClawAddPlan;
   resumeRecord?: PersistedClawInstall;
-}): Promise<boolean> {
+}): Promise<ClawAddConfigCommitResult> {
   let committed = false;
+  let reservedConfig = false;
   const commit =
     params.commitConfig ??
     (async (transform) => {
@@ -96,6 +102,7 @@ export async function commitClawAgentConfig(params: {
       });
       if (nextConfig) {
         committed = true;
+        reservedConfig = true;
         return nextConfig;
       }
       throw new ClawAddConfigCommitError(
@@ -116,8 +123,48 @@ export async function commitClawAgentConfig(params: {
       );
     }
     committed = true;
+    reservedConfig = true;
     return addPlannedAgent(preserved.config, preserved.agents, params.plan);
   });
 
-  return committed;
+  return { committed, reservedConfig };
+}
+
+export async function rollbackClawAgentConfigReservation(params: {
+  plan: ClawAddPlan;
+  commitConfig?: ConfigCommit;
+}): Promise<boolean> {
+  let rolledBack = false;
+  const commit =
+    params.commitConfig ??
+    (async (transform) => {
+      await transformConfigFileWithRetry({
+        afterWrite: { mode: "auto" },
+        transform: (config) => ({ nextConfig: transform(config) }),
+      });
+    });
+
+  await commit((config) => {
+    const preserved = preserveAgentEntries(config);
+    const normalizedAgentId = normalizeAgentId(params.plan.agent.finalId);
+    const existingAgent = preserved.agents.find(
+      (agent) => normalizeAgentId(agent.id) === normalizedAgentId,
+    );
+    if (!existingAgent || !sameCommittedAgent(existingAgent, params.plan)) {
+      return config;
+    }
+    const remainingAgents = preserved.agents.filter(
+      (agent) => normalizeAgentId(agent.id) !== normalizedAgentId,
+    );
+    rolledBack = true;
+    return {
+      ...preserved.config,
+      agents: {
+        ...preserved.config.agents,
+        entries: Object.fromEntries(remainingAgents.map(({ id, ...entry }) => [id, entry])),
+      },
+    };
+  });
+
+  return rolledBack;
 }

--- a/src/claws/add-config.ts
+++ b/src/claws/add-config.ts
@@ -1,0 +1,123 @@
+// Commits the agent slice of a consented Claw add plan.
+import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
+import { listAgentEntries } from "../agents/agent-scope.js";
+import { transformConfigFileWithRetry } from "../config/config.js";
+import type { AgentConfig } from "../config/types.agents.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
+import type { PersistedClawInstall } from "./provenance.js";
+import type { ClawAddPlan } from "./types.js";
+import { sameCommittedAgent } from "./add-plan-helpers.js";
+import { replaceLegacyCommittedAgent } from "./legacy-resume.js";
+
+export type ConfigCommit = (transform: (config: OpenClawConfig) => OpenClawConfig) => Promise<void>;
+
+export class ClawAddConfigCommitError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ClawAddConfigCommitError";
+  }
+}
+
+function preserveAgentEntries(config: OpenClawConfig): {
+  agents: AgentConfig[];
+  config: OpenClawConfig;
+} {
+  const existingAgents = listAgentEntries(config);
+  const agents =
+    existingAgents.length > 0 ? existingAgents : [{ id: DEFAULT_AGENT_ID, default: true }];
+  return {
+    agents,
+    config: {
+      ...config,
+      agents: {
+        ...config.agents,
+        entries: Object.fromEntries(agents.map(({ id, ...entry }) => [id, entry])),
+      },
+    },
+  };
+}
+
+function addPlannedAgent(
+  config: OpenClawConfig,
+  agents: AgentConfig[],
+  plan: ClawAddPlan,
+): OpenClawConfig {
+  return {
+    ...config,
+    agents: {
+      ...config.agents,
+      entries: Object.fromEntries(
+        [...agents, plan.agent.config].map(({ id, ...entry }) => [id, entry]),
+      ),
+    },
+  };
+}
+
+export async function commitClawAgentConfig(params: {
+  plan: ClawAddPlan;
+  workspace: string;
+  commitConfig?: ConfigCommit;
+  resumePlan?: ClawAddPlan;
+  resumeRecord?: PersistedClawInstall;
+}): Promise<boolean> {
+  let committed = false;
+  const commit =
+    params.commitConfig ??
+    (async (transform) => {
+      await transformConfigFileWithRetry({
+        afterWrite: { mode: "auto" },
+        transform: (config) => ({ nextConfig: transform(config) }),
+      });
+    });
+
+  await commit((config) => {
+    const preserved = preserveAgentEntries(config);
+    const normalizedAgentId = normalizeAgentId(params.plan.agent.finalId);
+    const existingAgent = preserved.agents.find(
+      (agent) => normalizeAgentId(agent.id) === normalizedAgentId,
+    );
+    if (existingAgent) {
+      if (sameCommittedAgent(existingAgent, params.plan)) {
+        committed = true;
+        return config;
+      }
+      const nextConfig = replaceLegacyCommittedAgent({
+        config: preserved.config,
+        agents: preserved.agents,
+        normalizedAgentId,
+        plan: params.plan,
+        resumePlan: params.resumePlan,
+        resumeRecord: params.resumeRecord,
+        matchesPlan: sameCommittedAgent,
+      });
+      if (nextConfig) {
+        committed = true;
+        return nextConfig;
+      }
+      throw new ClawAddConfigCommitError(
+        "agent_id_collision",
+        "Agent " + JSON.stringify(params.plan.agent.finalId) + " was created after planning.",
+      );
+    }
+    if (
+      findOverlappingWorkspaceAgentIds(
+        preserved.config,
+        params.plan.agent.finalId,
+        params.workspace,
+      ).length > 0
+    ) {
+      throw new ClawAddConfigCommitError(
+        "workspace_collision",
+        "Workspace " + JSON.stringify(params.workspace) + " is already assigned to an agent.",
+      );
+    }
+    committed = true;
+    return addPlannedAgent(preserved.config, preserved.agents, params.plan);
+  });
+
+  return committed;
+}

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -44,6 +44,7 @@ import {
   type PersistedClawPackageRef,
 } from "./provenance.js";
 import { CLAW_OUTPUT_STABILITY, type ClawAddPlan } from "./types.js";
+import { planAdoptsWorkspace } from "./workspace-origin.js";
 import {
   ClawWorkspaceWriteError,
   createClawWorkspaceFiles,
@@ -213,6 +214,7 @@ export async function applyClawAddPlan(
 
   const workspace = resolve(resolveUserPath(plan.agent.workspace));
   const workspacePhaseRecorded = statusAtLeast(installRecord.status, "workspace_ready");
+  const workspaceAdoption = planAdoptsWorkspace(plan);
   let workspaceState: Stats | undefined;
   try {
     assertWorkspacePathUnchanged(workspace);
@@ -238,7 +240,7 @@ export async function applyClawAddPlan(
     );
   }
 
-  if (!workspacePhaseRecorded && workspaceState) {
+  if (!workspacePhaseRecorded && workspaceState && !workspaceAdoption) {
     markInstallStatus(plan.agent.finalId, "partial", ["pending", "partial"], options);
     return partialResult({
       plan,
@@ -262,6 +264,31 @@ export async function applyClawAddPlan(
 
   let workspaceCreated = workspaceState?.isDirectory() ?? false;
   let configCommitted = statusAtLeast(installRecord.status, "config_committed");
+  if (workspaceAdoption && (!workspaceCreated || !workspacePhaseRecorded)) {
+    const adoptedState = await lstat(workspace).catch(() => undefined);
+    if (!adoptedState?.isDirectory()) {
+      clearUnownedInstallRecord(plan.agent.finalId, ["pending", "partial"], options);
+      throw new ClawAddMutationError(
+        "workspace_collision",
+        `Adoptable workspace ${JSON.stringify(workspace)} is no longer an existing directory.`,
+      );
+    }
+    workspaceCreated = true;
+    if (!workspacePhaseRecorded) {
+      try {
+        markInstallStatus(
+          plan.agent.finalId,
+          "workspace_ready",
+          ["pending", "partial", "workspace_ready"],
+          options,
+        );
+      } catch (error) {
+        clearUnownedInstallRecord(plan.agent.finalId, ["pending", "partial"], options);
+        throw new ClawAddMutationError("provenance_failed", (error as Error).message);
+      }
+    }
+  }
+
   const installPackages = options.installPackages ?? installClawPackages;
   let packages: PersistedClawPackageRef[] = [];
   const preserveRecordedPhaseOrMarkPartial = (): ClawInstallStatus => {
@@ -417,6 +444,55 @@ export async function applyClawAddPlan(
     });
   }
 
+  // Workspace ownership must be complete before the agent becomes routable. Besides writing new
+  // files, this reopens every adopted destination through the safe-file contract and records its
+  // exact digest; a failure therefore leaves only retryable provenance, never an enabled agent.
+  const createFiles = options.createWorkspaceFiles ?? createClawWorkspaceFiles;
+  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
+  try {
+    workspaceFiles = await createFiles(plan, options);
+  } catch (error) {
+    const workspaceError =
+      error instanceof ClawWorkspaceWriteError
+        ? error
+        : new ClawWorkspaceWriteError(
+            [
+              {
+                level: "error",
+                code: "workspace_file_io_error",
+                phase: "mutation",
+                path: "$.workspace",
+                message: error instanceof Error ? error.message : String(error),
+              },
+            ],
+            workspaceFiles,
+          );
+    const installStatus: ClawInstallStatus = configCommitted
+      ? "config_committed"
+      : "workspace_ready";
+    markInstallStatus(
+      plan.agent.finalId,
+      installStatus,
+      configCommitted ? ["config_committed"] : ["workspace_ready"],
+      options,
+    );
+    return partialResult({
+      plan,
+      installRecord,
+      workspaceCreated,
+      configCommitted,
+      workspaceFiles: workspaceError.createdFiles,
+      packages,
+      installStatus,
+      error: {
+        code: "workspace_files_failed",
+        message: workspaceError.message,
+        diagnostics: workspaceError.diagnostics,
+      },
+      nowMs: options.nowMs,
+    });
+  }
+
   try {
     const commit: ConfigCommit =
       options.commitConfig ??
@@ -506,7 +582,7 @@ export async function applyClawAddPlan(
     );
   } catch (error) {
     let installStatus: ClawInstallStatus = "workspace_ready";
-    if (!configCommitted) {
+    if (!configCommitted && !workspaceAdoption) {
       const removedWorkspace = await rmdir(workspace)
         .then(() => true)
         .catch(() => false);
@@ -521,6 +597,7 @@ export async function applyClawAddPlan(
       installRecord,
       workspaceCreated,
       configCommitted,
+      workspaceFiles,
       packages,
       installStatus,
       error: {
@@ -529,55 +606,6 @@ export async function applyClawAddPlan(
       },
       nowMs: options.nowMs,
     });
-  }
-
-  const createFiles = options.createWorkspaceFiles ?? createClawWorkspaceFiles;
-  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
-  try {
-    workspaceFiles = await createFiles(plan, options);
-  } catch (error) {
-    const workspaceError =
-      error instanceof ClawWorkspaceWriteError
-        ? error
-        : new ClawWorkspaceWriteError(
-            [
-              {
-                level: "error",
-                code: "workspace_file_io_error",
-                phase: "mutation",
-                path: "$.workspace",
-                message: coerceErrorMessage(error),
-              },
-            ],
-            workspaceFiles,
-          );
-    markInstallStatus(plan.agent.finalId, "config_committed", ["config_committed"], options);
-    return {
-      schemaVersion: CLAW_ADD_RESULT_SCHEMA_VERSION,
-      stability: CLAW_OUTPUT_STABILITY,
-      dryRun: false,
-      mutationAllowed: true,
-      planIntegrity: plan.planIntegrity,
-      status: "partial",
-      claw: plan.claw,
-      agent: plan.agent,
-      workspaceCreated,
-      configCommitted,
-      workspaceFiles: workspaceError.createdFiles,
-      packages,
-      mcpServers: [],
-      cronJobs: [],
-      installRecord: {
-        ...installRecord,
-        status: "config_committed",
-        updatedAtMs: options.nowMs ?? Date.now(),
-      },
-      error: {
-        code: "workspace_files_failed",
-        message: workspaceError.message,
-        diagnostics: workspaceError.diagnostics,
-      },
-    };
   }
 
   let cronJobs: PersistedClawCronRef[] = [];

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Existing Claw add lifecycle exceeds the limit; this PR adds a narrow ownership guard. */
 // Applies the package, agent, workspace, and managed-file slices of a consented Claw add plan.
 import type { Stats } from "node:fs";
 import { lstat, mkdir, rmdir } from "node:fs/promises";
@@ -5,7 +6,7 @@ import { dirname, resolve } from "node:path";
 import { coerceErrorMessage } from "@openclaw/normalization-core";
 import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
 import { listAgentEntries } from "../agents/agent-scope.js";
-import { transformConfigFileWithRetry } from "../config/config.js";
+import { getRuntimeConfig, transformConfigFileWithRetry } from "../config/config.js";
 import type { AgentConfig } from "../config/types.agents.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
@@ -59,6 +60,7 @@ type ClawAddApplyOptions = OpenClawStateDatabaseOptions & {
   resumeRecord?: PersistedClawInstall;
   resumePlan?: ClawAddPlan;
   commitConfig?: ConfigCommit;
+  readConfig?: () => OpenClawConfig | Promise<OpenClawConfig>;
   persistRecord?: typeof persistClawInstallRecord;
   deleteRecord?: typeof deleteClawInstallRecord;
   updateRecord?: typeof updateClawInstallRecordStatus;
@@ -137,6 +139,27 @@ function assertWorkspacePathUnchanged(workspace: string): void {
     throw new ClawAddMutationError(
       "workspace_path_changed",
       `Workspace ancestry changed after planning: expected ${JSON.stringify(workspace)}, resolved ${JSON.stringify(canonicalWorkspace)}.`,
+    );
+  }
+}
+
+function assertWorkspaceNotClaimedByAnotherAgent(
+  config: OpenClawConfig,
+  agentId: string,
+  workspace: string,
+): void {
+  const existingAgents = listAgentEntries(config);
+  const configWithPreservedAgents: OpenClawConfig = {
+    ...config,
+    agents: {
+      ...config.agents,
+      entries: Object.fromEntries(existingAgents.map(({ id, ...entry }) => [id, entry])),
+    },
+  };
+  if (findOverlappingWorkspaceAgentIds(configWithPreservedAgents, agentId, workspace).length > 0) {
+    throw new ClawAddMutationError(
+      "workspace_collision",
+      "Workspace " + JSON.stringify(workspace) + " is already assigned to an agent.",
     );
   }
 }
@@ -408,6 +431,40 @@ export async function applyClawAddPlan(
       }
       throw new ClawAddMutationError("provenance_failed", (error as Error).message);
     }
+  }
+
+  try {
+    assertWorkspaceNotClaimedByAnotherAgent(
+      await (options.readConfig ?? (() => getRuntimeConfig()))(),
+      plan.agent.finalId,
+      workspace,
+    );
+  } catch (error) {
+    if (packages.length > 0) {
+      const installStatus = preserveRecordedPhaseOrMarkPartial();
+      return partialResult({
+        plan,
+        installRecord,
+        workspaceCreated,
+        configCommitted,
+        packages,
+        installStatus,
+        error: {
+          code: error instanceof ClawAddMutationError ? error.code : "workspace_claim_check_failed",
+          message: coerceErrorMessage(error),
+        },
+        nowMs: options.nowMs,
+      });
+    }
+    clearUnownedInstallRecord(
+      plan.agent.finalId,
+      ["pending", "partial", "workspace_ready"],
+      options,
+    );
+    if (error instanceof ClawAddMutationError) {
+      throw error;
+    }
+    throw new ClawAddMutationError("workspace_claim_check_failed", coerceErrorMessage(error));
   }
 
   // Seed and attest the consented package bootstrap while the workspace is still

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -17,6 +17,7 @@ import {
 import {
   ClawAddConfigCommitError,
   commitClawAgentConfig,
+  rollbackClawAgentConfigReservation,
   type ConfigCommit,
 } from "./add-config.js";
 import { ClawBootstrapWriteError, seedClawPackageBootstrap } from "./bootstrap.js";
@@ -287,6 +288,7 @@ export async function applyClawAddPlan(
 
   const installPackages = options.installPackages ?? installClawPackages;
   let packages: PersistedClawPackageRef[] = [];
+  let reservedAgentConfig = false;
   const preserveRecordedPhaseOrMarkPartial = (): ClawInstallStatus => {
     if (workspacePhaseRecorded) {
       return installRecord.status;
@@ -327,6 +329,21 @@ export async function applyClawAddPlan(
       });
     }
   }
+
+  const rollbackAgentConfigReservation = async (): Promise<void> => {
+    if (!reservedAgentConfig) {
+      return;
+    }
+    if (
+      await rollbackClawAgentConfigReservation({
+        plan,
+        commitConfig: options.commitConfig,
+      })
+    ) {
+      configCommitted = false;
+      reservedAgentConfig = false;
+    }
+  };
 
   try {
     assertWorkspacePathUnchanged(workspace);
@@ -407,13 +424,15 @@ export async function applyClawAddPlan(
   }
 
   try {
-    configCommitted = await commitClawAgentConfig({
+    const configCommit = await commitClawAgentConfig({
       plan,
       workspace,
       commitConfig: options.commitConfig,
       resumePlan: options.resumePlan,
       resumeRecord: options.resumeRecord,
     });
+    configCommitted = configCommit.committed;
+    reservedAgentConfig = configCommit.reservedConfig;
     try {
       recordAgentProvenance(plan.agent.finalId, { createdVia: "claw" }, options);
     } catch (error) {
@@ -470,14 +489,23 @@ export async function applyClawAddPlan(
       ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
     });
   } catch (error) {
-    markInstallStatus(plan.agent.finalId, "config_committed", ["config_committed"], options);
+    await rollbackAgentConfigReservation();
+    const installStatus: ClawInstallStatus = configCommitted
+      ? "config_committed"
+      : "workspace_ready";
+    markInstallStatus(
+      plan.agent.finalId,
+      installStatus,
+      configCommitted ? ["config_committed"] : ["workspace_ready", "config_committed"],
+      options,
+    );
     return partialResult({
       plan,
       installRecord,
       workspaceCreated,
       configCommitted,
       packages,
-      installStatus: "config_committed",
+      installStatus,
       error: {
         code: error instanceof ClawBootstrapWriteError ? error.code : "bootstrap_write_failed",
         message: coerceErrorMessage(error),
@@ -491,6 +519,7 @@ export async function applyClawAddPlan(
   try {
     workspaceFiles = await createFiles(plan, options);
   } catch (error) {
+    await rollbackAgentConfigReservation();
     const workspaceError =
       error instanceof ClawWorkspaceWriteError
         ? error
@@ -506,7 +535,15 @@ export async function applyClawAddPlan(
             ],
             workspaceFiles,
           );
-    markInstallStatus(plan.agent.finalId, "config_committed", ["config_committed"], options);
+    const installStatus: ClawInstallStatus = configCommitted
+      ? "config_committed"
+      : "workspace_ready";
+    markInstallStatus(
+      plan.agent.finalId,
+      installStatus,
+      configCommitted ? ["config_committed"] : ["workspace_ready", "config_committed"],
+      options,
+    );
     return partialResult({
       plan,
       installRecord,
@@ -514,7 +551,7 @@ export async function applyClawAddPlan(
       configCommitted,
       workspaceFiles: workspaceError.createdFiles,
       packages,
-      installStatus: "config_committed",
+      installStatus,
       error: {
         code: "workspace_files_failed",
         message: workspaceError.message,

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -1,17 +1,10 @@
-/* eslint-disable max-lines -- Existing Claw add lifecycle exceeds the limit; this PR adds a narrow ownership guard. */
 // Applies the package, agent, workspace, and managed-file slices of a consented Claw add plan.
 import type { Stats } from "node:fs";
 import { lstat, mkdir, rmdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { coerceErrorMessage } from "@openclaw/normalization-core";
-import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
-import { listAgentEntries } from "../agents/agent-scope.js";
-import { getRuntimeConfig, transformConfigFileWithRetry } from "../config/config.js";
-import type { AgentConfig } from "../config/types.agents.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import { normalizeWindowsPathForComparison } from "../infra/path-guards.js";
-import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { recordAgentProvenance } from "../state/agent-provenance.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
@@ -19,9 +12,13 @@ import { resolveUserPath } from "../utils.js";
 import {
   hasUnsupportedMutationActions,
   planWithPackageActions,
-  sameCommittedAgent,
   statusAtLeast,
 } from "./add-plan-helpers.js";
+import {
+  ClawAddConfigCommitError,
+  commitClawAgentConfig,
+  type ConfigCommit,
+} from "./add-config.js";
 import { ClawBootstrapWriteError, seedClawPackageBootstrap } from "./bootstrap.js";
 import {
   ClawCronInstallError,
@@ -29,7 +26,6 @@ import {
   type ClawCronGateway,
   type PersistedClawCronRef,
 } from "./cron.js";
-import { replaceLegacyCommittedAgent } from "./legacy-resume.js";
 import {
   ClawMcpInstallError,
   installClawMcpServers,
@@ -54,13 +50,11 @@ import {
 
 export const CLAW_ADD_RESULT_SCHEMA_VERSION = "openclaw.clawAddResult.v1" as const;
 
-type ConfigCommit = (transform: (config: OpenClawConfig) => OpenClawConfig) => Promise<void>;
 type ClawAddApplyOptions = OpenClawStateDatabaseOptions & {
   consentPlanIntegrity?: string;
   resumeRecord?: PersistedClawInstall;
   resumePlan?: ClawAddPlan;
   commitConfig?: ConfigCommit;
-  readConfig?: () => OpenClawConfig | Promise<OpenClawConfig>;
   persistRecord?: typeof persistClawInstallRecord;
   deleteRecord?: typeof deleteClawInstallRecord;
   updateRecord?: typeof updateClawInstallRecordStatus;
@@ -139,27 +133,6 @@ function assertWorkspacePathUnchanged(workspace: string): void {
     throw new ClawAddMutationError(
       "workspace_path_changed",
       `Workspace ancestry changed after planning: expected ${JSON.stringify(workspace)}, resolved ${JSON.stringify(canonicalWorkspace)}.`,
-    );
-  }
-}
-
-function assertWorkspaceNotClaimedByAnotherAgent(
-  config: OpenClawConfig,
-  agentId: string,
-  workspace: string,
-): void {
-  const existingAgents = listAgentEntries(config);
-  const configWithPreservedAgents: OpenClawConfig = {
-    ...config,
-    agents: {
-      ...config.agents,
-      entries: Object.fromEntries(existingAgents.map(({ id, ...entry }) => [id, entry])),
-    },
-  };
-  if (findOverlappingWorkspaceAgentIds(configWithPreservedAgents, agentId, workspace).length > 0) {
-    throw new ClawAddMutationError(
-      "workspace_collision",
-      "Workspace " + JSON.stringify(workspace) + " is already assigned to an agent.",
     );
   }
 }
@@ -434,189 +407,12 @@ export async function applyClawAddPlan(
   }
 
   try {
-    assertWorkspaceNotClaimedByAnotherAgent(
-      await (options.readConfig ?? (() => getRuntimeConfig()))(),
-      plan.agent.finalId,
+    configCommitted = await commitClawAgentConfig({
+      plan,
       workspace,
-    );
-  } catch (error) {
-    if (packages.length > 0) {
-      const installStatus = preserveRecordedPhaseOrMarkPartial();
-      return partialResult({
-        plan,
-        installRecord,
-        workspaceCreated,
-        configCommitted,
-        packages,
-        installStatus,
-        error: {
-          code: error instanceof ClawAddMutationError ? error.code : "workspace_claim_check_failed",
-          message: coerceErrorMessage(error),
-        },
-        nowMs: options.nowMs,
-      });
-    }
-    clearUnownedInstallRecord(
-      plan.agent.finalId,
-      ["pending", "partial", "workspace_ready"],
-      options,
-    );
-    if (error instanceof ClawAddMutationError) {
-      throw error;
-    }
-    throw new ClawAddMutationError("workspace_claim_check_failed", coerceErrorMessage(error));
-  }
-
-  // Seed and attest the consented package bootstrap while the workspace is still
-  // private. Committing the agent config first makes the agent routable, so a
-  // concurrent `sessions.create` can stock-seed BOOTSTRAP.md and strand the add at
-  // `config_committed` with a seed conflict that no retry can clear.
-  try {
-    await (options.seedPackageBootstrap ?? seedClawPackageBootstrap)(plan, {
-      ...options,
-      ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
-    });
-  } catch (error) {
-    const installStatus: ClawInstallStatus = configCommitted
-      ? "config_committed"
-      : "workspace_ready";
-    markInstallStatus(
-      plan.agent.finalId,
-      installStatus,
-      configCommitted ? ["config_committed"] : ["workspace_ready", "config_committed"],
-      options,
-    );
-    return partialResult({
-      plan,
-      installRecord,
-      workspaceCreated,
-      configCommitted,
-      packages,
-      installStatus,
-      error: {
-        code: error instanceof ClawBootstrapWriteError ? error.code : "bootstrap_write_failed",
-        message: coerceErrorMessage(error),
-      },
-      nowMs: options.nowMs,
-    });
-  }
-
-  // Workspace ownership must be complete before the agent becomes routable. Besides writing new
-  // files, this reopens every adopted destination through the safe-file contract and records its
-  // exact digest; a failure therefore leaves only retryable provenance, never an enabled agent.
-  const createFiles = options.createWorkspaceFiles ?? createClawWorkspaceFiles;
-  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
-  try {
-    workspaceFiles = await createFiles(plan, options);
-  } catch (error) {
-    const workspaceError =
-      error instanceof ClawWorkspaceWriteError
-        ? error
-        : new ClawWorkspaceWriteError(
-            [
-              {
-                level: "error",
-                code: "workspace_file_io_error",
-                phase: "mutation",
-                path: "$.workspace",
-                message: error instanceof Error ? error.message : String(error),
-              },
-            ],
-            workspaceFiles,
-          );
-    const installStatus: ClawInstallStatus = configCommitted
-      ? "config_committed"
-      : "workspace_ready";
-    markInstallStatus(
-      plan.agent.finalId,
-      installStatus,
-      configCommitted ? ["config_committed"] : ["workspace_ready"],
-      options,
-    );
-    return partialResult({
-      plan,
-      installRecord,
-      workspaceCreated,
-      configCommitted,
-      workspaceFiles: workspaceError.createdFiles,
-      packages,
-      installStatus,
-      error: {
-        code: "workspace_files_failed",
-        message: workspaceError.message,
-        diagnostics: workspaceError.diagnostics,
-      },
-      nowMs: options.nowMs,
-    });
-  }
-
-  try {
-    const commit: ConfigCommit =
-      options.commitConfig ??
-      (async (transform) => {
-        await transformConfigFileWithRetry({
-          afterWrite: { mode: "auto" },
-          transform: (config) => ({ nextConfig: transform(config) }),
-        });
-      });
-    await commit((config) => {
-      const existingAgents = listAgentEntries(config);
-      const agentsToPreserve: AgentConfig[] =
-        existingAgents.length > 0 ? existingAgents : [{ id: DEFAULT_AGENT_ID, default: true }];
-      const configWithPreservedAgents: OpenClawConfig = {
-        ...config,
-        agents: {
-          ...config.agents,
-          entries: Object.fromEntries(agentsToPreserve.map(({ id, ...entry }) => [id, entry])),
-        },
-      };
-      const normalizedAgentId = normalizeAgentId(plan.agent.finalId);
-      const existingAgent = agentsToPreserve.find(
-        (agent) => normalizeAgentId(agent.id) === normalizedAgentId,
-      );
-      if (existingAgent) {
-        if (sameCommittedAgent(existingAgent, plan)) {
-          configCommitted = true;
-          return config;
-        }
-        const nextConfig = replaceLegacyCommittedAgent({
-          config: configWithPreservedAgents,
-          agents: agentsToPreserve,
-          normalizedAgentId,
-          plan,
-          resumePlan: options.resumePlan,
-          resumeRecord: options.resumeRecord,
-          matchesPlan: sameCommittedAgent,
-        });
-        if (nextConfig) {
-          configCommitted = true;
-          return nextConfig;
-        }
-        throw new ClawAddMutationError(
-          "agent_id_collision",
-          "Agent " + JSON.stringify(plan.agent.finalId) + " was created after planning.",
-        );
-      }
-      if (
-        findOverlappingWorkspaceAgentIds(configWithPreservedAgents, plan.agent.finalId, workspace)
-          .length > 0
-      ) {
-        throw new ClawAddMutationError(
-          "workspace_collision",
-          "Workspace " + JSON.stringify(workspace) + " is already assigned to an agent.",
-        );
-      }
-      const nextConfig: OpenClawConfig = {
-        ...config,
-        agents: {
-          ...config.agents,
-          entries: Object.fromEntries(
-            [...agentsToPreserve, plan.agent.config].map(({ id, ...entry }) => [id, entry]),
-          ),
-        },
-      };
-      configCommitted = true;
-      return nextConfig;
+      commitConfig: options.commitConfig,
+      resumePlan: options.resumePlan,
+      resumeRecord: options.resumeRecord,
     });
     try {
       recordAgentProvenance(plan.agent.finalId, { createdVia: "claw" }, options);
@@ -649,17 +445,80 @@ export async function applyClawAddPlan(
         markInstallStatus(plan.agent.finalId, "partial", ["workspace_ready", "partial"], options);
       }
     }
+    const errorCode =
+      error instanceof ClawAddMutationError || error instanceof ClawAddConfigCommitError
+        ? error.code
+        : "config_commit_failed";
     return partialResult({
       plan,
       installRecord,
       workspaceCreated,
       configCommitted,
-      workspaceFiles,
       packages,
       installStatus,
       error: {
-        code: error instanceof ClawAddMutationError ? error.code : "config_commit_failed",
+        code: errorCode,
         message: coerceErrorMessage(error),
+      },
+      nowMs: options.nowMs,
+    });
+  }
+
+  try {
+    await (options.seedPackageBootstrap ?? seedClawPackageBootstrap)(plan, {
+      ...options,
+      ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
+    });
+  } catch (error) {
+    markInstallStatus(plan.agent.finalId, "config_committed", ["config_committed"], options);
+    return partialResult({
+      plan,
+      installRecord,
+      workspaceCreated,
+      configCommitted,
+      packages,
+      installStatus: "config_committed",
+      error: {
+        code: error instanceof ClawBootstrapWriteError ? error.code : "bootstrap_write_failed",
+        message: coerceErrorMessage(error),
+      },
+      nowMs: options.nowMs,
+    });
+  }
+
+  const createFiles = options.createWorkspaceFiles ?? createClawWorkspaceFiles;
+  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
+  try {
+    workspaceFiles = await createFiles(plan, options);
+  } catch (error) {
+    const workspaceError =
+      error instanceof ClawWorkspaceWriteError
+        ? error
+        : new ClawWorkspaceWriteError(
+            [
+              {
+                level: "error",
+                code: "workspace_file_io_error",
+                phase: "mutation",
+                path: "$.workspace",
+                message: error instanceof Error ? error.message : String(error),
+              },
+            ],
+            workspaceFiles,
+          );
+    markInstallStatus(plan.agent.finalId, "config_committed", ["config_committed"], options);
+    return partialResult({
+      plan,
+      installRecord,
+      workspaceCreated,
+      configCommitted,
+      workspaceFiles: workspaceError.createdFiles,
+      packages,
+      installStatus: "config_committed",
+      error: {
+        code: "workspace_files_failed",
+        message: workspaceError.message,
+        diagnostics: workspaceError.diagnostics,
       },
       nowMs: options.nowMs,
     });

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -424,6 +424,34 @@ export async function applyClawAddPlan(
   }
 
   try {
+    await (options.seedPackageBootstrap ?? seedClawPackageBootstrap)(plan, {
+      ...options,
+      ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
+    });
+  } catch (error) {
+    markInstallStatus(
+      plan.agent.finalId,
+      "workspace_ready",
+      ["workspace_ready", "config_committed"],
+      options,
+    );
+    return partialResult({
+      plan,
+      installRecord,
+      workspaceCreated,
+      configCommitted: false,
+      packages,
+      installStatus: "workspace_ready",
+      error: {
+        code: error instanceof ClawBootstrapWriteError ? error.code : "bootstrap_write_failed",
+        message: coerceErrorMessage(error),
+      },
+      nowMs: options.nowMs,
+    });
+  }
+
+  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
+  try {
     const configCommit = await commitClawAgentConfig({
       plan,
       workspace,
@@ -473,6 +501,7 @@ export async function applyClawAddPlan(
       installRecord,
       workspaceCreated,
       configCommitted,
+      workspaceFiles,
       packages,
       installStatus,
       error: {
@@ -483,39 +512,7 @@ export async function applyClawAddPlan(
     });
   }
 
-  try {
-    await (options.seedPackageBootstrap ?? seedClawPackageBootstrap)(plan, {
-      ...options,
-      ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
-    });
-  } catch (error) {
-    await rollbackAgentConfigReservation();
-    const installStatus: ClawInstallStatus = configCommitted
-      ? "config_committed"
-      : "workspace_ready";
-    markInstallStatus(
-      plan.agent.finalId,
-      installStatus,
-      configCommitted ? ["config_committed"] : ["workspace_ready", "config_committed"],
-      options,
-    );
-    return partialResult({
-      plan,
-      installRecord,
-      workspaceCreated,
-      configCommitted,
-      packages,
-      installStatus,
-      error: {
-        code: error instanceof ClawBootstrapWriteError ? error.code : "bootstrap_write_failed",
-        message: coerceErrorMessage(error),
-      },
-      nowMs: options.nowMs,
-    });
-  }
-
   const createFiles = options.createWorkspaceFiles ?? createClawWorkspaceFiles;
-  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
   try {
     workspaceFiles = await createFiles(plan, options);
   } catch (error) {

--- a/src/claws/lifecycle-adopt-plan.ts
+++ b/src/claws/lifecycle-adopt-plan.ts
@@ -1,0 +1,233 @@
+// Decides which existing workspace files an adopting Claw add may claim without rewriting them.
+import { createHash } from "node:crypto";
+import { lstat } from "node:fs/promises";
+import { dirname } from "node:path";
+import { FsSafeError, root as fsSafeRoot, type Root } from "../infra/fs-safe.js";
+import { MAX_MANAGED_FILE_BYTES } from "./source-limits.js";
+import type { ClawAddCapabilityChange, ClawAddPlanAction, ClawDiagnostic } from "./types.js";
+
+type AdoptionPendingFile = {
+  action: ClawAddPlanAction;
+  manifestPath: string;
+};
+
+type AdoptableTargetState =
+  | { state: "absent" }
+  | { state: "unsafe" }
+  | { state: "adoptable"; digest: string };
+
+type WorkspaceDiskState =
+  | { state: "absent" }
+  | { state: "uninspectable" }
+  | { state: "present"; isDirectory: boolean };
+
+// Only ENOENT proves absence. Permission, symlink-loop, and IO failures leave the path unknown, and
+// planning must not read unknown as free space: apply already refuses an uninspectable workspace
+// (`workspace_parent_failed` in add.ts), so a plan that approves one strands the operator mid-install.
+async function readWorkspaceDiskState(workspace: string): Promise<WorkspaceDiskState> {
+  try {
+    return { state: "present", isDirectory: (await lstat(workspace)).isDirectory() };
+  } catch (error) {
+    const absent =
+      typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+    if (!absent) {
+      return { state: "uninspectable" };
+    }
+    let parent = dirname(workspace);
+    while (parent !== dirname(parent)) {
+      try {
+        return (await lstat(parent)).isDirectory()
+          ? { state: "absent" }
+          : { state: "uninspectable" };
+      } catch (parentError) {
+        const parentAbsent =
+          typeof parentError === "object" &&
+          parentError !== null &&
+          "code" in parentError &&
+          parentError.code === "ENOENT";
+        if (!parentAbsent) {
+          return { state: "uninspectable" };
+        }
+        parent = dirname(parent);
+      }
+    }
+    return { state: "absent" };
+  }
+}
+
+function adoptionBlocker(path: string, message: string): ClawDiagnostic {
+  return { level: "error", code: "workspace_file_conflict", phase: "plan", path, message };
+}
+
+/** Describes the distinct consent required to claim an existing workspace directory. */
+export function workspaceAdoptionCapabilityChange(
+  agentId: string,
+  workspace: string,
+): Omit<ClawAddCapabilityChange, "classification" | "requiresDistinctConsent" | "digest"> {
+  return {
+    kind: "agent",
+    id: agentId,
+    path: "workspace",
+    action: "configure",
+    reason:
+      "The Claw adopts an existing workspace directory; declared files must already match or be absent.",
+    effect: { workspace, adoptExistingWorkspace: true },
+  };
+}
+
+/** Plans the workspace-level adoption decision before declared files are inspected. */
+export async function planWorkspaceAdoption(params: {
+  agentId: string;
+  workspace: string;
+  requested: boolean;
+  configuredWorkspaceConflict: boolean;
+  resumableWorkspace?: string;
+}): Promise<{
+  adopted: boolean;
+  action: ClawAddPlanAction;
+  blockers: ClawDiagnostic[];
+}> {
+  const disk = await readWorkspaceDiskState(params.workspace);
+  if (disk.state === "uninspectable") {
+    const message = `Workspace ${JSON.stringify(params.workspace)} cannot be inspected; adoption requires a workspace path this account can read.`;
+    return {
+      adopted: false,
+      blockers: [
+        {
+          level: "error",
+          code: "workspace_parent_failed",
+          phase: "plan",
+          path: "$.workspace",
+          message,
+        },
+      ],
+      action: {
+        kind: "workspace",
+        id: params.agentId,
+        action: "create",
+        target: params.workspace,
+        details: { expectedState: "uninspectable" },
+        blocked: true,
+        reason: message,
+      },
+    };
+  }
+  const workspaceExistsOnDisk = disk.state === "present";
+  const adopted =
+    params.requested &&
+    disk.state === "present" &&
+    disk.isDirectory &&
+    !params.configuredWorkspaceConflict;
+  const blocked =
+    !adopted &&
+    (params.configuredWorkspaceConflict ||
+      (workspaceExistsOnDisk && params.resumableWorkspace !== params.workspace));
+  const blockers: ClawDiagnostic[] = [];
+  if (blocked) {
+    blockers.push({
+      level: "error",
+      code: "workspace_collision",
+      phase: "plan",
+      path: "$.workspace",
+      message:
+        params.requested && workspaceExistsOnDisk
+          ? `Workspace ${JSON.stringify(params.workspace)} cannot be adopted; it is ${
+              params.configuredWorkspaceConflict
+                ? "already configured for another agent"
+                : "not a directory"
+            }.`
+          : `Workspace ${JSON.stringify(params.workspace)} already exists; a Claw requires a new workspace.`,
+    });
+  }
+  return {
+    adopted,
+    blockers,
+    action: {
+      kind: "workspace",
+      id: params.agentId,
+      action: adopted ? "adopt" : "create",
+      target: params.workspace,
+      details: { expectedState: adopted ? "existing-directory" : "absent" },
+      blocked,
+      ...(blocked
+        ? { reason: `Workspace ${JSON.stringify(params.workspace)} already exists.` }
+        : {}),
+    },
+  };
+}
+
+// Planning reads adoptable destinations through the same safe-file contract the mutation path
+// uses. A destination only apply would reject (symlink, hardlink, oversized) has to block before
+// consent, or apply commits the agent config first and leaves the operator a partial install.
+async function readAdoptableTarget(
+  workspaceRoot: Root,
+  targetPath: string,
+): Promise<AdoptableTargetState> {
+  try {
+    const read = await workspaceRoot.read(targetPath, {
+      hardlinks: "reject",
+      maxBytes: MAX_MANAGED_FILE_BYTES,
+      symlinks: "reject",
+    });
+    return {
+      state: "adoptable",
+      digest: `sha256:${createHash("sha256").update(read.buffer).digest("hex")}`,
+    };
+  } catch (error) {
+    if (error instanceof FsSafeError && error.code === "not-found") {
+      return { state: "absent" };
+    }
+    return { state: "unsafe" };
+  }
+}
+
+/**
+ * Marks every declared file that already exists with identical content as an `adopt` action and
+ * blocks the rest. Mutates the passed actions in place and returns the plan blockers to record.
+ */
+export async function planWorkspaceAdoptionTargets(params: {
+  workspace: string;
+  pendingFiles: readonly AdoptionPendingFile[];
+  packageBootstrap?: ClawAddPlanAction;
+}): Promise<ClawDiagnostic[]> {
+  const workspaceRoot = await fsSafeRoot(params.workspace);
+  const blockers: ClawDiagnostic[] = [];
+  if (params.packageBootstrap && !params.packageBootstrap.blocked) {
+    const existing = await readAdoptableTarget(workspaceRoot, params.packageBootstrap.id);
+    if (existing.state !== "absent") {
+      const diagnostic = adoptionBlocker(
+        "$packageBootstrap",
+        existing.state === "unsafe"
+          ? `Package BOOTSTRAP.md destination ${JSON.stringify(params.packageBootstrap.target)} must be absent; the existing path is not a safe regular file.`
+          : `Package BOOTSTRAP.md destination ${JSON.stringify(params.packageBootstrap.target)} already exists; adoption never claims operator-owned native bootstrap content.`,
+      );
+      params.packageBootstrap.blocked = true;
+      params.packageBootstrap.reason = diagnostic.message;
+      blockers.push(diagnostic);
+    }
+  }
+  for (const pending of params.pendingFiles) {
+    if (pending.action.blocked || !pending.action.digest) {
+      continue;
+    }
+    const existing = await readAdoptableTarget(workspaceRoot, pending.action.id);
+    if (existing.state === "absent") {
+      continue;
+    }
+    if (existing.state === "adoptable" && existing.digest === pending.action.digest) {
+      pending.action.action = "adopt";
+      pending.action.details = { ...pending.action.details, expectedState: "existing-identical" };
+      continue;
+    }
+    const diagnostic = adoptionBlocker(
+      pending.manifestPath,
+      existing.state === "unsafe"
+        ? `Adoptable workspace destination ${JSON.stringify(pending.action.target)} must be a readable regular file inside the workspace, with no symlink or hardlink, within managed size limits.`
+        : `Workspace destination ${JSON.stringify(pending.action.target)} exists with different content; adoption never overwrites existing files.`,
+    );
+    pending.action.blocked = true;
+    pending.action.reason = diagnostic.message;
+    blockers.push(diagnostic);
+  }
+  return blockers;
+}

--- a/src/claws/lifecycle-adopt-remove.test.ts
+++ b/src/claws/lifecycle-adopt-remove.test.ts
@@ -1,0 +1,221 @@
+// Removal coverage for Claw installs that adopted an existing operator-owned workspace.
+import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { applyClawAddPlan } from "./add.js";
+import { inspectClawWorkspaceFile } from "./lifecycle-delete-support.js";
+import { clawRemoveFixtures } from "./lifecycle-remove.test-support.js";
+import { applyClawRemovePlan, buildClawRemovePlan } from "./lifecycle-state.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import { persistClawInstallRecord } from "./provenance.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawSourceIdentity } from "./types.js";
+import { CLAW_ADOPTED_WORKSPACE_MARKER_PATH, clawWorkspaceWasAdopted } from "./workspace-origin.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+const { fixture, addFixture } = clawRemoveFixtures(tempDirs);
+
+describe("Claw remove with an adopted workspace", () => {
+  async function adoptedFixture() {
+    const root = tempDirs.make("openclaw-claw-adopt-remove-");
+    await writeFile(join(root, "SOUL.md"), "managed\n", "utf8");
+    const parsed = parseClawManifest({
+      schemaVersion: 1,
+      agent: { id: "worker", name: "Worker" },
+      workspace: { bootstrapFiles: { "SOUL.md": { source: "SOUL.md" } } },
+    });
+    if (!parsed.ok) {
+      throw new Error(JSON.stringify(parsed.diagnostics));
+    }
+    const source: ClawSourceIdentity = {
+      kind: "package",
+      name: "@acme/worker",
+      version: "1.0.0",
+      packageRoot: root,
+      manifestPath: join(root, "openclaw.claw.json"),
+      integrityKind: "artifact",
+      integrity: "sha256:manifest",
+      byteLength: 100,
+    };
+    // The operator's directory already holds the declared file, so after adoption every entry in
+    // it is Claw-managed and nothing distinguishes it from a workspace this install created.
+    const workspace = join(root, "existing-workspace");
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "SOUL.md"), "managed\n", "utf8");
+    const plan = await buildClawAddPlan({
+      manifest: parsed.manifest,
+      source,
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    let config: OpenClawConfig = {};
+    await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+    // The install records the canonical workspace path, which is what removal compares against.
+    return { env, workspace: plan.agent.workspace, getConfig: () => config };
+  }
+
+  it("plans retention for an adopted workspace holding only declared files", async () => {
+    const current = await adoptedFixture();
+
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({
+        kind: "workspace",
+        action: "retain",
+        reason: "Workspace existed before this Claw adopted it.",
+        details: expect.objectContaining({ retained: true }),
+      }),
+    );
+  });
+
+  it("never trashes an adopted workspace directory during removal", async () => {
+    const current = await adoptedFixture();
+
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    const removed = await applyClawRemovePlan(plan, {
+      env: current.env,
+      config: current.getConfig(),
+      consentPlanIntegrity: plan.planIntegrity,
+      commitConfig: async (transform) => {
+        transform(current.getConfig());
+      },
+      purgeSessions: async () => undefined,
+      // Delete for real: a trash stub that only records calls cannot tell a retained directory
+      // from one the canonical path spelling hid from the assertion.
+      trashPath: async (target) => {
+        await rm(target, { recursive: true, force: true });
+        return true;
+      },
+    });
+
+    expect(removed).toMatchObject({ status: "complete" });
+    await expect(stat(current.workspace)).resolves.toMatchObject({});
+  });
+
+  it("keeps a removal preview read-only when no origin marker exists", async () => {
+    const current = await addFixture();
+    const db = openOpenClawStateDatabase({ env: current.env }).db;
+    const markerCount = () =>
+      db
+        .prepare("SELECT count(*) AS count FROM claw_workspace_files WHERE target_path = ?")
+        .get(CLAW_ADOPTED_WORKSPACE_MARKER_PATH) as { count: number };
+    expect(markerCount().count).toBe(0);
+
+    await buildClawRemovePlan("worker", { env: current.env, config: current.getConfig() });
+
+    expect(markerCount().count).toBe(0);
+  });
+
+  it("ignores an origin marker recorded for a different workspace", async () => {
+    const current = await addFixture();
+    const workspace = current.plan.agent.workspace;
+    const db = openOpenClawStateDatabase({ env: current.env }).db;
+    db.prepare(
+      `INSERT OR REPLACE INTO claw_workspace_files (
+         agent_id, target_path, schema_version, workspace, source_path,
+         content_digest, status, created_at_ms, updated_at_ms
+       ) VALUES (?, ?, ?, ?, ?, ?, 'complete', 1, 1)`,
+    ).run(
+      "worker",
+      CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      "openclaw.clawWorkspaceFileRecord.v1",
+      `${workspace}-previous`,
+      CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      "openclaw:adopted-workspace",
+    );
+
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspace", action: "trash" }),
+    );
+  });
+
+  it("clears a stale origin marker when a non-adopted install is persisted", async () => {
+    const current = await fixture({ id: "worker" });
+    const db = openOpenClawStateDatabase({ env: current.env }).db;
+    db.prepare(
+      `INSERT OR REPLACE INTO claw_workspace_files (
+         agent_id, target_path, schema_version, workspace, source_path,
+         content_digest, status, created_at_ms, updated_at_ms
+       ) VALUES (?, ?, ?, ?, ?, ?, 'complete', 1, 1)`,
+    ).run(
+      "worker",
+      CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      "openclaw.clawWorkspaceFileRecord.v1",
+      current.plan.agent.workspace,
+      CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      "openclaw:adopted-workspace",
+    );
+
+    persistClawInstallRecord(current.plan, { env: current.env, nowMs: 5 });
+
+    expect(
+      clawWorkspaceWasAdopted("worker", current.plan.agent.workspace, { env: current.env }),
+    ).toBe(false);
+  });
+
+  it("makes an older reader fail closed on the adopted-workspace marker", async () => {
+    const current = await adoptedFixture();
+
+    const inspected = await inspectClawWorkspaceFile({
+      schemaVersion: "openclaw.clawWorkspaceFileRecord.v1",
+      agentId: "worker",
+      workspace: current.workspace,
+      path: CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      sourcePath: CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      contentDigest: "openclaw:adopted-workspace",
+      status: "complete",
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    });
+
+    expect(inspected).toMatchObject({ state: "unsafe" });
+  });
+
+  it("drops the adopted-workspace origin once the install is removed", async () => {
+    const current = await adoptedFixture();
+    expect(clawWorkspaceWasAdopted("worker", current.workspace, { env: current.env })).toBe(true);
+
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    await applyClawRemovePlan(plan, {
+      env: current.env,
+      config: current.getConfig(),
+      consentPlanIntegrity: plan.planIntegrity,
+      commitConfig: async (transform) => {
+        transform(current.getConfig());
+      },
+      purgeSessions: async () => undefined,
+      trashPath: async () => true,
+    });
+
+    expect(clawWorkspaceWasAdopted("worker", current.workspace, { env: current.env })).toBe(false);
+  });
+});

--- a/src/claws/lifecycle-adopt.test.ts
+++ b/src/claws/lifecycle-adopt.test.ts
@@ -219,4 +219,34 @@ describe("applyClawAddPlan workspace adoption", () => {
     expect(installPackages).not.toHaveBeenCalled();
     expect(readInstallRow("worker", root)).toBeUndefined();
   });
+
+  it("rejects a live workspace claim before writing adopted workspace files", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "AGENTS.md"), "# Agent\n", "utf8");
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+    expect(plan.blockers).toEqual([]);
+    const seedPackageBootstrap = vi.fn(async () => undefined);
+    const createWorkspaceFiles = vi.fn();
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(source.packageRoot),
+        readConfig: () => ({
+          agents: { entries: { other: { name: "Other", workspace } } },
+        }),
+        seedPackageBootstrap,
+        createWorkspaceFiles,
+      }),
+    ).rejects.toMatchObject({ code: "workspace_collision" });
+
+    expect(seedPackageBootstrap).not.toHaveBeenCalled();
+    expect(createWorkspaceFiles).not.toHaveBeenCalled();
+    expect(readInstallRow("adopt-agent", source.packageRoot)).toBeUndefined();
+  });
 });

--- a/src/claws/lifecycle-adopt.test.ts
+++ b/src/claws/lifecycle-adopt.test.ts
@@ -1,0 +1,222 @@
+// Tests for planning Claw adds that adopt an existing workspace directory.
+import { createHash } from "node:crypto";
+import { link, mkdir, rmdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { applyClawAddPlan } from "./add.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import { makeProvenancePlan, readInstallRow, stateEnv } from "./provenance.test-helpers.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawManifest, ClawSourceIdentity } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+function requireManifest(): ClawManifest {
+  const result = parseClawManifest({
+    schemaVersion: 1,
+    agent: { id: "adopt-agent" },
+    workspace: {
+      bootstrapFiles: { "AGENTS.md": { source: "workspace/AGENTS.md" } },
+      files: [{ source: "workspace/reference/policy.md", path: "reference/policy.md" }],
+    },
+  });
+  if (!result.ok) {
+    throw new Error(JSON.stringify(result.diagnostics));
+  }
+  return result.manifest;
+}
+
+async function createPlanSource(): Promise<{ source: ClawSourceIdentity; workspace: string }> {
+  const root = tempDirs.make("openclaw-claw-adopt-plan-");
+  await mkdir(join(root, "workspace", "reference"), { recursive: true });
+  await writeFile(join(root, "workspace", "AGENTS.md"), "# Agent\n", "utf8");
+  await writeFile(join(root, "workspace", "reference", "policy.md"), "Policy\n", "utf8");
+  return {
+    source: {
+      kind: "package",
+      name: "@acme/adopt-agent",
+      version: "1.0.0",
+      packageRoot: root,
+      manifestPath: join(root, "openclaw.claw.json"),
+      integrityKind: "development-snapshot",
+      integrity: "sha256:test",
+      byteLength: 0,
+    },
+    workspace: join(root, "existing-workspace"),
+  };
+}
+
+describe("buildClawAddPlan workspace adoption", () => {
+  it("adopts an existing workspace when identical declared files are present", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "AGENTS.md"), "# Agent\n", "utf8");
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+
+    expect(plan.blockers).toEqual([]);
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspace", action: "adopt", blocked: false }),
+    );
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspaceFile", id: "AGENTS.md", action: "adopt" }),
+    );
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({
+        kind: "workspaceFile",
+        id: "reference/policy.md",
+        action: "write",
+      }),
+    );
+    expect(plan.capabilityChanges).toContainEqual(
+      expect.objectContaining({ kind: "agent", path: "workspace", action: "configure" }),
+    );
+  });
+
+  it("blocks adoption when a declared file exists with different content", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "AGENTS.md"), "# Divergent\n", "utf8");
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "workspace_file_conflict" }),
+    );
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspaceFile", id: "AGENTS.md", blocked: true }),
+    );
+  });
+
+  it("blocks adoption of a hardlinked declared file before consent", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "origin.md"), "# Agent\n", "utf8");
+    await link(join(workspace, "origin.md"), join(workspace, "AGENTS.md"));
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "workspace_file_conflict" }),
+    );
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspaceFile", id: "AGENTS.md", blocked: true }),
+    );
+    expect(plan.actions).not.toContainEqual(
+      expect.objectContaining({ kind: "workspaceFile", id: "AGENTS.md", action: "adopt" }),
+    );
+  });
+
+  it("blocks an existing package bootstrap instead of claiming operator-owned content", async () => {
+    const { source, workspace } = await createPlanSource();
+    const bootstrap = Buffer.from("Package setup\n");
+    const bootstrapPath = join(source.packageRoot, "BOOTSTRAP.md");
+    await writeFile(bootstrapPath, bootstrap);
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "BOOTSTRAP.md"), bootstrap);
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      packageBootstrap: {
+        sourcePath: "BOOTSTRAP.md",
+        realPath: bootstrapPath,
+        byteLength: bootstrap.byteLength,
+        digest: `sha256:${createHash("sha256").update(bootstrap).digest("hex")}`,
+      },
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "workspace_file_conflict", path: "$packageBootstrap" }),
+    );
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "bootstrap", id: "BOOTSTRAP.md", blocked: true }),
+    );
+  });
+
+  it("still blocks adoption of a workspace configured for another agent", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: {
+        workspace,
+        adoptExistingWorkspace: true,
+        existingWorkspacePaths: [workspace],
+      },
+    });
+
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: "workspace_collision" }));
+  });
+
+  it("keeps blocking a non-adopted existing workspace", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: { workspace },
+    });
+
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: "workspace_collision" }));
+  });
+});
+
+describe("applyClawAddPlan workspace adoption", () => {
+  it("revalidates an adopted workspace before realizing shared plugin requirements", async () => {
+    const root = tempDirs.make("openclaw-claw-adopt-add-");
+    const workspace = join(root, "existing-workspace");
+    await mkdir(workspace);
+    const { plan } = await makeProvenancePlan(
+      root,
+      {
+        schemaVersion: 1,
+        agent: { id: "worker" },
+        packages: [{ kind: "plugin", source: "clawhub", ref: "@acme/audit", version: "1.0.0" }],
+      },
+      {
+        workspace,
+        adoptExistingWorkspace: true,
+        packagePreflight: async () => ({
+          ok: true,
+          action: "install",
+          integrity: `sha256:${"a".repeat(64)}`,
+          installId: "audit",
+        }),
+      },
+    );
+    expect(plan.blockers).toEqual([]);
+    await rmdir(workspace);
+    const installPackages = vi.fn();
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(root),
+        installPackages,
+      }),
+    ).rejects.toMatchObject({ code: "workspace_collision" });
+    expect(installPackages).not.toHaveBeenCalled();
+    expect(readInstallRow("worker", root)).toBeUndefined();
+  });
+});

--- a/src/claws/lifecycle-adopt.test.ts
+++ b/src/claws/lifecycle-adopt.test.ts
@@ -251,8 +251,11 @@ describe("applyClawAddPlan workspace adoption", () => {
       status: "partial",
     });
 
+    expect(seedPackageBootstrap).toHaveBeenCalledOnce();
     expect(commitConfig).toHaveBeenCalledOnce();
-    expect(seedPackageBootstrap).not.toHaveBeenCalled();
+    expect(seedPackageBootstrap.mock.invocationCallOrder[0]).toBeLessThan(
+      commitConfig.mock.invocationCallOrder[0] ?? 0,
+    );
     expect(createWorkspaceFiles).not.toHaveBeenCalled();
   });
 });

--- a/src/claws/lifecycle-adopt.test.ts
+++ b/src/claws/lifecycle-adopt.test.ts
@@ -220,7 +220,7 @@ describe("applyClawAddPlan workspace adoption", () => {
     expect(readInstallRow("worker", root)).toBeUndefined();
   });
 
-  it("rejects a live workspace claim before writing adopted workspace files", async () => {
+  it("reserves an adopted workspace before writing adopted workspace files", async () => {
     const { source, workspace } = await createPlanSource();
     await mkdir(workspace, { recursive: true });
     await writeFile(join(workspace, "AGENTS.md"), "# Agent\n", "utf8");
@@ -232,21 +232,27 @@ describe("applyClawAddPlan workspace adoption", () => {
     expect(plan.blockers).toEqual([]);
     const seedPackageBootstrap = vi.fn(async () => undefined);
     const createWorkspaceFiles = vi.fn();
+    const commitConfig = vi.fn(async (transform) => {
+      transform({
+        agents: { entries: { other: { name: "Other", workspace } } },
+      });
+    });
 
     await expect(
       applyClawAddPlan(plan, {
         consentPlanIntegrity: plan.planIntegrity,
         env: stateEnv(source.packageRoot),
-        readConfig: () => ({
-          agents: { entries: { other: { name: "Other", workspace } } },
-        }),
+        commitConfig,
         seedPackageBootstrap,
         createWorkspaceFiles,
       }),
-    ).rejects.toMatchObject({ code: "workspace_collision" });
+    ).resolves.toMatchObject({
+      error: { code: "workspace_collision" },
+      status: "partial",
+    });
 
+    expect(commitConfig).toHaveBeenCalledOnce();
     expect(seedPackageBootstrap).not.toHaveBeenCalled();
     expect(createWorkspaceFiles).not.toHaveBeenCalled();
-    expect(readInstallRow("adopt-agent", source.packageRoot)).toBeUndefined();
   });
 });

--- a/src/claws/lifecycle-agent-plan.ts
+++ b/src/claws/lifecycle-agent-plan.ts
@@ -1,0 +1,92 @@
+// Plans the agent entry for a Claw add without mutating configuration.
+import { materializeClawToolProfile } from "./tool-profile-consent.js";
+import type {
+  ClawAddCapabilityChange,
+  ClawAddPlan,
+  ClawAddPlanAction,
+  ClawDiagnostic,
+  ClawManifest,
+  ClawOpenClawProfile,
+} from "./types.js";
+
+const AGENT_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+
+export function planClawAgent(params: {
+  finalId: string;
+  workspace: string;
+  manifestAgent: ClawManifest["agent"];
+  openClawProfile?: ClawOpenClawProfile;
+  reconstructLegacyDynamicToolProfilePlan?: boolean;
+  existingAgentIds?: Iterable<string>;
+}): {
+  config: ClawAddPlan["agent"]["config"];
+  action: ClawAddPlanAction;
+  blockers: ClawDiagnostic[];
+  capabilityChange?: Omit<
+    ClawAddCapabilityChange,
+    "classification" | "requiresDistinctConsent" | "digest"
+  >;
+} {
+  const idValid = AGENT_ID_PATTERN.test(params.finalId);
+  const blocked = new Set(params.existingAgentIds ?? []).has(params.finalId);
+  const blockers: ClawDiagnostic[] = [];
+  if (!idValid) {
+    blockers.push({
+      level: "error",
+      code: "invalid_agent_id",
+      phase: "plan",
+      path: "$.agent.id",
+      message: `Final agent id ${JSON.stringify(params.finalId)} is not a valid portable agent id.`,
+    });
+  }
+  if (blocked) {
+    blockers.push({
+      level: "error",
+      code: "agent_id_collision",
+      phase: "plan",
+      path: "$.agent.id",
+      message: `Agent id ${JSON.stringify(params.finalId)} already exists; Claws never merge into existing agents.`,
+    });
+  }
+  const settings = params.openClawProfile?.agent ?? {};
+  const persistedSettings = params.reconstructLegacyDynamicToolProfilePlan
+    ? settings
+    : materializeClawToolProfile(settings);
+  const config: ClawAddPlan["agent"]["config"] = {
+    ...params.manifestAgent,
+    ...persistedSettings,
+    id: params.finalId,
+    workspace: params.workspace,
+  };
+  const effect = {
+    ...(settings.sandbox ? { sandbox: settings.sandbox } : {}),
+    ...(settings.tools ? { tools: settings.tools } : {}),
+    ...(settings.memory ? { memory: settings.memory } : {}),
+    ...(settings.heartbeat ? { heartbeat: settings.heartbeat } : {}),
+  };
+  return {
+    config,
+    blockers,
+    action: {
+      kind: "agent",
+      id: params.finalId,
+      action: "create",
+      target: `agents.entries[${JSON.stringify(params.finalId)}]`,
+      details: { ...config, expectedState: "absent" },
+      blocked: blocked || !idValid,
+    },
+    ...(Object.keys(effect).length > 0
+      ? {
+          capabilityChange: {
+            kind: "agent",
+            id: params.finalId,
+            path: "agent",
+            action: "create",
+            reason:
+              "The new agent declares sandbox, tool, memory-search, or recurring heartbeat capabilities.",
+            effect,
+          },
+        }
+      : {}),
+  };
+}

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -31,8 +31,13 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import type { ClawRemovePlanAction } from "./lifecycle-remove-contract.js";
 import { deleteCachedClawInstallSchemaVersion } from "./provenance-runtime-read.js";
 import type { PersistedClawInstall } from "./provenance.js";
+import {
+  CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+  deleteAdoptedWorkspaceRow,
+} from "./workspace-origin.js";
 import type { PersistedClawWorkspaceFile } from "./workspace.js";
 
 type WorkspaceFileRow = {
@@ -91,9 +96,10 @@ export function readAllClawWorkspaceFiles(
       `SELECT schema_version, agent_id, workspace, target_path, source_path,
               content_digest, status, created_at_ms, updated_at_ms
          FROM claw_workspace_files
+        WHERE target_path <> ?
         ORDER BY agent_id, target_path`,
     )
-    .all() as WorkspaceFileRow[];
+    .all(CLAW_ADOPTED_WORKSPACE_MARKER_PATH) as WorkspaceFileRow[];
   return rows.map(rowToWorkspaceFile);
 }
 
@@ -144,6 +150,31 @@ export function deletionEffects(config: OpenClawConfig, agentId: string, fallbac
     sessionsDir,
     workspaceSharedWith,
     workspaceRetained: workspaceSharedWith.length > 0,
+  };
+}
+
+/** Resolves the retain/trash plan for a workspace using the canonical reason priority. */
+export function planClawWorkspaceRemoval(params: {
+  sharedWith: string[];
+  adopted: boolean;
+  modified: boolean;
+  untracked: boolean;
+}): Pick<ClawRemovePlanAction, "action" | "details" | "reason"> {
+  const retained =
+    params.sharedWith.length > 0 || params.adopted || params.modified || params.untracked;
+  const reason = params.sharedWith.length
+    ? "Workspace overlaps another agent."
+    : params.adopted
+      ? "Workspace existed before this Claw adopted it."
+      : params.modified
+        ? "Workspace contains locally modified Claw-managed files."
+        : params.untracked
+          ? "Workspace contains files or directories not managed by this Claw."
+          : undefined;
+  return {
+    action: retained ? "retain" : "trash",
+    details: { retained, sharedWith: params.sharedWith },
+    ...(reason ? { reason } : {}),
   };
 }
 
@@ -487,6 +518,9 @@ export function releaseClawRemoveRows(
         .prepare("DELETE FROM claw_installs WHERE agent_id = ?")
         .run(agentId);
     }
+    // Drop the origin with the install it describes; a later agent reusing this id must not
+    // inherit an adopted-workspace claim from a Claw that no longer exists.
+    deleteAdoptedWorkspaceRow(db, agentId);
   }, options);
   if (complete) {
     deleteCachedClawInstallSchemaVersion(agentId, options);

--- a/src/claws/lifecycle-remove.test-support.ts
+++ b/src/claws/lifecycle-remove.test-support.ts
@@ -1,0 +1,95 @@
+// Shared Claw install fixtures for the remove-lifecycle test files.
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { applyClawAddPlan } from "./add.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawSourceIdentity } from "./types.js";
+
+type TempDirTracker = { make: (prefix: string) => string };
+
+export function clawRemoveFixtures(tempDirs: TempDirTracker) {
+  async function fixture(
+    params: {
+      id?: string;
+      name?: string;
+      withFile?: boolean;
+      withCron?: boolean;
+      withMcp?: boolean;
+    } = {},
+  ) {
+    const root = tempDirs.make("openclaw-claw-remove-");
+    if (params.withFile) {
+      await writeFile(join(root, "SOUL.md"), "managed\n", "utf8");
+    }
+    const parsed = parseClawManifest({
+      schemaVersion: 1,
+      agent: { id: params.id ?? "worker", name: "Worker" },
+      workspace: params.withFile ? { bootstrapFiles: { "SOUL.md": { source: "SOUL.md" } } } : {},
+      mcpServers: params.withMcp
+        ? {
+            docs: {
+              command: "uvx",
+              args: ["docs-mcp"],
+              env: { DOCS_TOKEN: "${DOCS_TOKEN}" },
+            },
+          }
+        : {},
+      cronJobs: params.withCron
+        ? [
+            {
+              id: "daily-report",
+              schedule: { cron: "0 9 * * *", timezone: "UTC" },
+              session: "isolated",
+              message: "Prepare report",
+            },
+          ]
+        : [],
+    });
+    if (!parsed.ok) {
+      throw new Error(JSON.stringify(parsed.diagnostics));
+    }
+    const source: ClawSourceIdentity = {
+      kind: "package",
+      name: params.name ?? "@acme/worker",
+      version: "1.0.0",
+      packageRoot: root,
+      manifestPath: join(root, "openclaw.claw.json"),
+      integrityKind: "artifact",
+      integrity: "sha256:manifest",
+      byteLength: 100,
+    };
+    const plan = await buildClawAddPlan({
+      manifest: parsed.manifest,
+      source,
+      context: { workspace: join(root, `workspace-${params.id ?? "worker"}`) },
+    });
+    return { root, plan, env: { OPENCLAW_STATE_DIR: join(root, "state") } };
+  }
+
+  async function addFixture(
+    params: { withFile?: boolean; withCron?: boolean; withMcp?: boolean } = {},
+  ) {
+    const current = await fixture(params);
+    let config: OpenClawConfig = {};
+    await applyClawAddPlan(current.plan, {
+      consentPlanIntegrity: current.plan.planIntegrity,
+      env: current.env,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+      cronGateway: { add: async () => ({ id: "scheduler-daily" }) },
+      ...(params.withMcp ? { installMcpServers: async () => [] } : {}),
+    });
+    return {
+      ...current,
+      getConfig: () => config,
+      commitConfig: async (transform: (current: OpenClawConfig) => OpenClawConfig) => {
+        config = transform(config);
+      },
+    };
+  }
+
+  return { fixture, addFixture };
+}

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -14,21 +14,18 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
-import { applyClawAddPlan } from "./add.js";
 import { markClawCronRefRemoved, readClawCronRefs } from "./cron.js";
 import { claimClawAgentConfigRemoval } from "./lifecycle-config-removal.js";
+import { clawRemoveFixtures } from "./lifecycle-remove.test-support.js";
 import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
-import { buildClawAddPlan } from "./lifecycle.js";
 import {
   persistClawInstallRecord,
   persistClawPackageRef,
   readClawPackageRefs,
 } from "./provenance.js";
-import { parseClawManifest } from "./schema.js";
-import type { ClawSourceIdentity } from "./types.js";
 
-afterEach(() => closeOpenClawStateDatabaseForTest());
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawStateDatabaseForTest());
 
 const packageIntegrity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
@@ -92,86 +89,7 @@ function seedAttachedCronJob(
   );
 }
 
-async function fixture(
-  params: {
-    id?: string;
-    name?: string;
-    withFile?: boolean;
-    withCron?: boolean;
-    withMcp?: boolean;
-  } = {},
-) {
-  const root = tempDirs.make("openclaw-claw-remove-");
-  if (params.withFile) {
-    await writeFile(join(root, "SOUL.md"), "managed\n", "utf8");
-  }
-  const parsed = parseClawManifest({
-    schemaVersion: 1,
-    agent: { id: params.id ?? "worker", name: "Worker" },
-    workspace: params.withFile ? { bootstrapFiles: { "SOUL.md": { source: "SOUL.md" } } } : {},
-    mcpServers: params.withMcp
-      ? {
-          docs: {
-            command: "uvx",
-            args: ["docs-mcp"],
-            env: { DOCS_TOKEN: "${DOCS_TOKEN}" },
-          },
-        }
-      : {},
-    cronJobs: params.withCron
-      ? [
-          {
-            id: "daily-report",
-            schedule: { cron: "0 9 * * *", timezone: "UTC" },
-            session: "isolated",
-            message: "Prepare report",
-          },
-        ]
-      : [],
-  });
-  if (!parsed.ok) {
-    throw new Error(JSON.stringify(parsed.diagnostics));
-  }
-  const source: ClawSourceIdentity = {
-    kind: "package",
-    name: params.name ?? "@acme/worker",
-    version: "1.0.0",
-    packageRoot: root,
-    manifestPath: join(root, "openclaw.claw.json"),
-    integrityKind: "artifact",
-    integrity: "sha256:manifest",
-    byteLength: 100,
-  };
-  const plan = await buildClawAddPlan({
-    manifest: parsed.manifest,
-    source,
-    context: { workspace: join(root, `workspace-${params.id ?? "worker"}`) },
-  });
-  return { root, plan, env: { OPENCLAW_STATE_DIR: join(root, "state") } };
-}
-
-async function addFixture(
-  params: { withFile?: boolean; withCron?: boolean; withMcp?: boolean } = {},
-) {
-  const current = await fixture(params);
-  let config: OpenClawConfig = {};
-  await applyClawAddPlan(current.plan, {
-    consentPlanIntegrity: current.plan.planIntegrity,
-    env: current.env,
-    commitConfig: async (transform) => {
-      config = transform(config);
-    },
-    cronGateway: { add: async () => ({ id: "scheduler-daily" }) },
-    ...(params.withMcp ? { installMcpServers: async () => [] } : {}),
-  });
-  return {
-    ...current,
-    getConfig: () => config,
-    commitConfig: async (transform: (current: OpenClawConfig) => OpenClawConfig) => {
-      config = transform(config);
-    },
-  };
-}
+const { fixture, addFixture } = clawRemoveFixtures(tempDirs);
 
 describe("Claw status and remove", () => {
   it("rejects cleanup when an expected-missing agent id was recreated", async () => {

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -30,6 +30,7 @@ import {
   ClawRemoveError,
   cleanupClawAgentFilesystem,
   deletionEffects,
+  planClawWorkspaceRemoval,
   readAttachedCronJobs,
   releaseClawRemoveRows,
   removeClawWorkspaceFile,
@@ -57,6 +58,7 @@ import {
 } from "./package-remove.js";
 import { updateClawInstallRecordStatus } from "./provenance.js";
 import { CLAW_OUTPUT_STABILITY } from "./types.js";
+import { clawWorkspaceWasAdopted } from "./workspace-origin.js";
 
 export { ClawRemoveError } from "./lifecycle-delete-support.js";
 export { CLAW_REMOVE_PLAN_SCHEMA_VERSION } from "./lifecycle-remove-contract.js";
@@ -183,6 +185,19 @@ export async function buildClawRemovePlan(
       record.install.workspace,
       trackedWorkspacePaths,
     );
+    // An adopted directory predates the Claw. Once every declared file in it is managed it looks
+    // indistinguishable from one this install created, so origin decides retention, not contents.
+    const workspaceWasAdopted = clawWorkspaceWasAdopted(
+      record.install.agentId,
+      record.install.workspace,
+      options,
+    );
+    const workspaceRemoval = planClawWorkspaceRemoval({
+      sharedWith: effects.workspaceSharedWith,
+      adopted: workspaceWasAdopted,
+      modified: workspaceHasModifiedFiles,
+      untracked: workspaceHasUntrackedEntries,
+    });
     const attachedJobs = readAttachedCronJobs(record.install.agentId, options);
     const ownedSchedulerJobIds = new Set(
       record.cronJobs
@@ -236,24 +251,9 @@ export async function buildClawRemovePlan(
       actions.push({
         kind: "workspace",
         id: record.install.agentId,
-        action:
-          effects.workspaceRetained || workspaceHasModifiedFiles || workspaceHasUntrackedEntries
-            ? "retain"
-            : "trash",
         target: effects.workspace,
         blocked: record.agentState === "modified",
-        details: {
-          retained:
-            effects.workspaceRetained || workspaceHasModifiedFiles || workspaceHasUntrackedEntries,
-          sharedWith: effects.workspaceSharedWith,
-        },
-        ...(effects.workspaceRetained
-          ? { reason: "Workspace overlaps another agent." }
-          : workspaceHasModifiedFiles
-            ? { reason: "Workspace contains locally modified Claw-managed files." }
-            : workspaceHasUntrackedEntries
-              ? { reason: "Workspace contains files or directories not managed by this Claw." }
-              : {}),
+        ...workspaceRemoval,
       });
     }
     if (effects.agentDir) {
@@ -464,6 +464,8 @@ export async function applyClawRemovePlan(
   ) {
     throw new ClawRemoveError("remove_changed", "Claw-owned state changed after remove planning.");
   }
+  // Read while the install record still exists; releaseClawRemoveRows drops the origin with it.
+  const workspaceWasAdopted = clawWorkspaceWasAdopted(agentId, record.install.workspace, options);
   const packageDecisions = await planClawPackageRemovals(record.install, record.packages, {
     ...options,
     deps: options.packageDeps,
@@ -669,6 +671,7 @@ export async function applyClawRemovePlan(
         runtime: clawRemoveQuietRuntime,
         trashPath: options.trashPath,
         retainWorkspace:
+          workspaceWasAdopted ||
           workspaceHasRemainingEntries ||
           bootstrap?.action === "retainedModified" ||
           workspaceFiles.some((file) => file.action === "retainedModified"),

--- a/src/claws/lifecycle.e2e.test.ts
+++ b/src/claws/lifecycle.e2e.test.ts
@@ -1,6 +1,6 @@
 // E2E coverage for experimental grouped Claw inspection and add planning.
 import { execFile } from "node:child_process";
-import { readFile, realpath, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
@@ -212,6 +212,84 @@ describe("claws lifecycle cli e2e", () => {
     await expect(readFile(join(workspace, "reference", "policy.md"), "utf8")).resolves.toContain(
       "operator settings",
     );
+  });
+
+  it("adopts an existing workspace through preview, apply, and status without rewriting files", async () => {
+    const source = "src/claws/fixtures/workspace-agent.claw.json";
+    const stateDir = tempDirs.make("openclaw-claws-adopt-e2e-");
+    const workspace = join(stateDir, "existing-workspace");
+    await mkdir(join(workspace, "reference"), { recursive: true });
+    const canonicalWorkspace = await realpath(workspace);
+    for (const path of ["SOUL.md", "HEARTBEAT.md", "reference/policy.md"]) {
+      await copyFile(join("src/claws/fixtures/workspace", path), join(workspace, path));
+    }
+    const soulMtimeBefore = (await stat(join(workspace, "SOUL.md"))).mtimeMs;
+
+    const preview = await runOpenClaw(
+      [
+        "claws",
+        "add",
+        source,
+        "--workspace",
+        workspace,
+        "--adopt-existing-workspace",
+        "--dry-run",
+        "--json",
+      ],
+      { stateDir },
+    );
+    const plan = parseJson(preview.stdout) as {
+      planIntegrity: string;
+      actions: Array<{ kind: string; action: string }>;
+    };
+    expect(plan.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "workspace", action: "adopt" }),
+        expect.objectContaining({ kind: "workspaceFile", action: "adopt" }),
+      ]),
+    );
+
+    const added = await runOpenClaw(
+      [
+        "claws",
+        "add",
+        source,
+        "--workspace",
+        workspace,
+        "--adopt-existing-workspace",
+        "--yes",
+        "--plan-integrity",
+        plan.planIntegrity,
+        "--json",
+      ],
+      { stateDir },
+    );
+    expect(parseJson(added.stdout)).toMatchObject({
+      schemaVersion: "openclaw.clawAddResult.v1",
+      status: "complete",
+      workspaceCreated: true,
+      installRecord: { agentId: "workspace-agent", status: "complete" },
+    });
+    expect((await stat(join(workspace, "SOUL.md"))).mtimeMs).toBe(soulMtimeBefore);
+
+    const status = await runOpenClaw(["claws", "status", "workspace-agent", "--json"], {
+      stateDir,
+    });
+    expect(parseJson(status.stdout)).toMatchObject({
+      schemaVersion: "openclaw.clawStatus.v1",
+      summary: { claws: 1, driftedFiles: 0 },
+      records: [
+        {
+          install: { agentId: "workspace-agent", workspace: canonicalWorkspace },
+          agentState: "present",
+          workspaceFiles: [
+            expect.objectContaining({ path: "HEARTBEAT.md", state: "unchanged" }),
+            expect.objectContaining({ path: "SOUL.md", state: "unchanged" }),
+            expect.objectContaining({ path: "reference/policy.md", state: "unchanged" }),
+          ],
+        },
+      ],
+    });
   });
 
   it("reports and removes a Claw-created agent through plan-first lifecycle commands", async () => {

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -1,6 +1,6 @@
 // Builds complete read-only Claw add plans without mutating local state.
 import { createHash } from "node:crypto";
-import { lstat, realpath } from "node:fs/promises";
+import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { relative, resolve } from "node:path";
 import { stableStringify } from "@openclaw/normalization-core";
@@ -9,10 +9,15 @@ import { assertNoSymlinkParents } from "../infra/fs-safe-advanced.js";
 import { FsSafeError, root as fsSafeRoot, type Root } from "../infra/fs-safe.js";
 import { resolveUserPath } from "../utils.js";
 import { findClawExtensionPackageCollisions, planClawExtensions } from "./application-plan.js";
+import {
+  planWorkspaceAdoption,
+  planWorkspaceAdoptionTargets,
+  workspaceAdoptionCapabilityChange,
+} from "./lifecycle-adopt-plan.js";
+import { planClawAgent } from "./lifecycle-agent-plan.js";
 import { digestClawMcpServer } from "./mcp.js";
 import { clawManifestWorkspaceConflictsWithPath } from "./schema.js";
 import { MAX_MANAGED_FILE_BYTES, MAX_MANAGED_WORKSPACE_BYTES } from "./source-limits.js";
-import { materializeClawToolProfile } from "./tool-profile-consent.js";
 import {
   CLAW_ADD_PLAN_SCHEMA_VERSION,
   CLAW_BOOTSTRAP_FILE_NAMES,
@@ -30,8 +35,6 @@ import {
   type ClawWorkspaceSourceSnapshot,
 } from "./types.js";
 
-const AGENT_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
-
 function capabilityChange(
   change: Omit<ClawAddCapabilityChange, "classification" | "requiresDistinctConsent" | "digest">,
 ): ClawAddCapabilityChange {
@@ -47,6 +50,7 @@ export type ClawAddPlanContext = {
   agentId?: string;
   workspace?: string;
   resumableWorkspace?: string;
+  adoptExistingWorkspace?: boolean;
   existingAgentIds?: Iterable<string>;
   existingWorkspacePaths?: Iterable<string>;
   existingMcpServerNames?: Iterable<string>;
@@ -226,96 +230,42 @@ export async function buildClawAddPlan(params: {
   const capabilityChanges: ClawAddCapabilityChange[] = [];
   const readinessRequirements: ClawLocalPrerequisite[] = [];
 
-  if (!AGENT_ID_PATTERN.test(finalId)) {
-    blockers.push(
-      blocker(
-        "invalid_agent_id",
-        "$.agent.id",
-        `Final agent id ${JSON.stringify(finalId)} is not a valid portable agent id.`,
-      ),
-    );
-  }
-  const existingAgentIds = new Set(context.existingAgentIds ?? []);
-  const agentBlocked = existingAgentIds.has(finalId);
-  const openClawAgentSettings = params.openClawProfile?.agent ?? {};
-  const persistedOpenClawAgentSettings = params.reconstructLegacyDynamicToolProfilePlan
-    ? openClawAgentSettings
-    : materializeClawToolProfile(openClawAgentSettings);
-  const agentConfig: ClawAddPlan["agent"]["config"] = {
-    ...params.manifest.agent,
-    ...persistedOpenClawAgentSettings,
-    id: finalId,
+  const agentPlan = planClawAgent({
+    finalId,
     workspace,
-  };
-  if (agentBlocked) {
-    blockers.push(
-      blocker(
-        "agent_id_collision",
-        "$.agent.id",
-        `Agent id ${JSON.stringify(finalId)} already exists; Claws never merge into existing agents.`,
-      ),
-    );
-  }
-  actions.push({
-    kind: "agent",
-    id: finalId,
-    action: "create",
-    target: `agents.entries[${JSON.stringify(finalId)}]`,
-    details: { ...agentConfig, expectedState: "absent" },
-    blocked: agentBlocked || !AGENT_ID_PATTERN.test(finalId),
+    manifestAgent: params.manifest.agent,
+    openClawProfile: params.openClawProfile,
+    reconstructLegacyDynamicToolProfilePlan: params.reconstructLegacyDynamicToolProfilePlan,
+    existingAgentIds: context.existingAgentIds,
   });
-  const agentCapabilityEffect = {
-    ...(openClawAgentSettings.sandbox ? { sandbox: openClawAgentSettings.sandbox } : {}),
-    ...(openClawAgentSettings.tools ? { tools: openClawAgentSettings.tools } : {}),
-    ...(openClawAgentSettings.memory ? { memory: openClawAgentSettings.memory } : {}),
-    ...(openClawAgentSettings.heartbeat ? { heartbeat: openClawAgentSettings.heartbeat } : {}),
-  };
-  if (Object.keys(agentCapabilityEffect).length > 0) {
-    capabilityChanges.push(
-      capabilityChange({
-        kind: "agent",
-        id: finalId,
-        path: "agent",
-        action: "create",
-        reason:
-          "The new agent declares sandbox, tool, memory-search, or recurring heartbeat capabilities.",
-        effect: agentCapabilityEffect,
-      }),
-    );
+  const agentConfig = agentPlan.config;
+  blockers.push(...agentPlan.blockers);
+  actions.push(agentPlan.action);
+  if (agentPlan.capabilityChange) {
+    capabilityChanges.push(capabilityChange(agentPlan.capabilityChange));
   }
 
   const configuredWorkspacePaths = new Set(
     [...(context.existingWorkspacePaths ?? [])].map((path) => canonicalWorkspacePath(path)),
   );
   const configuredWorkspaceConflict = configuredWorkspacePaths.has(workspace);
-  const workspaceExistsOnDisk = await lstat(workspace)
-    .then(() => true)
-    .catch(() => false);
   const resumableWorkspace = context.resumableWorkspace
     ? canonicalWorkspacePath(context.resumableWorkspace)
     : undefined;
-  const workspaceBlocked =
-    configuredWorkspaceConflict || (workspaceExistsOnDisk && resumableWorkspace !== workspace);
-  if (workspaceBlocked) {
-    blockers.push(
-      blocker(
-        "workspace_collision",
-        "$.workspace",
-        `Workspace ${JSON.stringify(workspace)} already exists; a Claw requires a new workspace.`,
-      ),
-    );
-  }
-  actions.push({
-    kind: "workspace",
-    id: finalId,
-    action: "create",
-    target: workspace,
-    details: { expectedState: "absent" },
-    blocked: workspaceBlocked,
-    ...(workspaceBlocked
-      ? { reason: `Workspace ${JSON.stringify(workspace)} already exists.` }
-      : {}),
+  const workspacePlan = await planWorkspaceAdoption({
+    agentId: finalId,
+    workspace,
+    requested: context.adoptExistingWorkspace === true,
+    configuredWorkspaceConflict,
+    resumableWorkspace,
   });
+  const workspaceAdoption = workspacePlan.adopted;
+  const workspaceBlocked = workspacePlan.action.blocked;
+  blockers.push(...workspacePlan.blockers);
+  actions.push(workspacePlan.action);
+  if (workspaceAdoption) {
+    capabilityChanges.push(capabilityChange(workspaceAdoptionCapabilityChange(finalId, workspace)));
+  }
 
   if (params.packageBootstrap && params.includePackageBootstrap !== false) {
     actions.push({
@@ -479,6 +429,16 @@ export async function buildClawAddPlan(params: {
         blockers.push(diagnostic);
       }
     }
+  }
+
+  if (workspaceAdoption) {
+    blockers.push(
+      ...(await planWorkspaceAdoptionTargets({
+        workspace,
+        pendingFiles: pendingWorkspaceFiles,
+        packageBootstrap: actions.find((action) => action.kind === "bootstrap"),
+      })),
+    );
   }
 
   for (const [index, pkg] of params.manifest.packages.entries()) {

--- a/src/claws/project.test.ts
+++ b/src/claws/project.test.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { lstat, mkdir, readFile, rename, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import * as tar from "tar";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +12,19 @@ import { ClawProjectError, createClawProject, validateClawProject } from "./proj
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const GOLDEN_ARTIFACT_INTEGRITY =
   "sha256:10b8890c5e5b062c94ff79b1d424859c6a5572548535eec6e31ee0c6d7c08a3b";
+
+// `CLAW.md` and `claw.md` only coexist on a case-sensitive filesystem. On a case-insensitive
+// volume the second write replaces the manifest instead of adding a colliding source, so the
+// collision under test cannot be constructed and the case must be skipped, not asserted.
+const caseSensitiveFilesystem = (() => {
+  const probe = mkdtempSync(join(tmpdir(), "openclaw-claw-case-probe-"));
+  try {
+    writeFileSync(join(probe, "case-probe"), "");
+    return !existsSync(join(probe, "CASE-PROBE"));
+  } finally {
+    rmSync(probe, { recursive: true, force: true });
+  }
+})();
 
 async function writeRichProject(root: string): Promise<void> {
   await mkdir(join(root, "workspace"), { recursive: true });
@@ -426,7 +441,7 @@ describe("Claw projects", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.runIf(process.platform !== "win32" && caseSensitiveFilesystem)(
     "rejects a workspace source that portably collides with CLAW.md",
     async () => {
       const project = tempDirs.make("openclaw-claw-manifest-case-collision-");

--- a/src/claws/provenance.test-helpers.ts
+++ b/src/claws/provenance.test-helpers.ts
@@ -9,6 +9,7 @@ export async function makeProvenancePlan(
   manifestValue: unknown,
   options: {
     workspace?: string;
+    adoptExistingWorkspace?: boolean;
     openClawProfile?: ClawOpenClawProfile;
     packagePreflight?: NonNullable<
       Parameters<typeof buildClawAddPlan>[0]["context"]
@@ -35,6 +36,7 @@ export async function makeProvenancePlan(
     source,
     context: {
       workspace: options.workspace ?? join(root, "workspace-worker"),
+      ...(options.adoptExistingWorkspace ? { adoptExistingWorkspace: true } : {}),
       ...(options.packagePreflight ? { packagePreflight: options.packagePreflight } : {}),
     },
   });

--- a/src/claws/provenance.test.ts
+++ b/src/claws/provenance.test.ts
@@ -841,7 +841,7 @@ describe("applyClawAddPlan", () => {
     expect(installPackages).not.toHaveBeenCalled();
   });
 
-  it("records parent-directory creation failures before workspace mutation", async () => {
+  it("blocks an uninspectable workspace parent at plan time, before workspace mutation", async () => {
     const root = tempDirs.make("openclaw-claw-add-");
     const blockedParent = join(root, "blocked-parent");
     await writeFile(blockedParent, "not a directory", "utf8");
@@ -849,12 +849,17 @@ describe("applyClawAddPlan", () => {
       workspace: join(blockedParent, "workspace-worker"),
     });
 
+    // Resolving the workspace under a regular file fails ENOTDIR, not ENOENT. Planning fails
+    // closed on it, so consent is never offered for a path apply would refuse mid-mutation.
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "workspace_parent_failed", path: "$.workspace" }),
+    );
     await expect(
       applyClawAddPlan(plan, {
         consentPlanIntegrity: plan.planIntegrity,
         env: stateEnv(root),
       }),
-    ).rejects.toMatchObject({ code: "workspace_parent_failed" });
+    ).rejects.toMatchObject({ code: "plan_blocked" });
     expect(readInstallRow("worker", root)).toBeUndefined();
   });
 

--- a/src/claws/provenance.ts
+++ b/src/claws/provenance.ts
@@ -28,6 +28,7 @@ import {
 } from "./provenance-runtime-read.js";
 import * as installRecordSchema from "./provenance-schema-version.js";
 import type { ClawAddPlan, ClawPackage, ResolvedClawPackage } from "./types.js";
+import { deleteAdoptedWorkspaceRow, persistClawWorkspaceOrigin } from "./workspace-origin.js";
 export {
   CLAW_PACKAGE_REF_SCHEMA_VERSION,
   type PersistedClawPackageRef,
@@ -254,6 +255,7 @@ export function persistClawInstallRecord(
       added_at_ms: nowMs,
       updated_at_ms: nowMs,
     });
+    persistClawWorkspaceOrigin({ db, plan, nowMs });
     return {
       schemaVersion: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION,
       claw: plan.claw,
@@ -322,6 +324,7 @@ export function deleteClawInstallRecord(
       db /* sqlite-allow-raw: this Claw prototype state-table delete is scoped to one owned row. */
         .prepare(`DELETE FROM claw_installs WHERE agent_id = ?${expectedClause}`)
         .run(agentId, ...expectedStatuses);
+    deleteAdoptedWorkspaceRow(db, agentId);
     if (result.changes !== 1) {
       throw new Error(
         `Claw install record for agent ${JSON.stringify(agentId)} did not match the expected phase.`,

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -254,7 +254,7 @@ export type ClawReadResult =
 export type ClawAddPlanAction = {
   kind: "agent" | "workspace" | "bootstrap" | "workspaceFile" | "package" | "mcpServer" | "cronJob";
   id: string;
-  action: "create" | "write" | "install" | "reuse" | "configure" | "schedule";
+  action: "create" | "write" | "adopt" | "install" | "reuse" | "configure" | "schedule";
   target: string;
   source?: string;
   sourceKind?: "clawMarkdownBody";

--- a/src/claws/workspace-origin.ts
+++ b/src/claws/workspace-origin.ts
@@ -1,0 +1,113 @@
+// Durable record of which Claw workspaces were adopted rather than created by the install.
+import type { DatabaseSync } from "node:sqlite";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import type { ClawAddPlan } from "./types.js";
+
+type WorkspaceOriginDatabase = Pick<OpenClawStateKyselyDatabase, "claw_workspace_files">;
+
+// Older releases treat every workspace-file row as a removable file. Pointing the reserved row at
+// the directory itself makes those releases fail closed during file inspection instead of
+// deleting an adopted workspace whose origin they cannot understand.
+export const CLAW_ADOPTED_WORKSPACE_MARKER_PATH = ".";
+const CLAW_ADOPTED_WORKSPACE_MARKER_DIGEST = "openclaw:adopted-workspace";
+const CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION = "openclaw.clawWorkspaceFileRecord.v1";
+
+function kyselyFor(db: DatabaseSync) {
+  return getNodeSqliteKysely<WorkspaceOriginDatabase>(db);
+}
+
+/** True when the consented plan adopts an existing directory instead of creating one. */
+export function planAdoptsWorkspace(plan: ClawAddPlan): boolean {
+  return plan.actions.some((action) => action.kind === "workspace" && action.action === "adopt");
+}
+
+/** Records the downgrade fence inside the caller's open install-record transaction. */
+function recordAdoptedWorkspaceRow(params: {
+  db: DatabaseSync;
+  agentId: string;
+  workspace: string;
+  nowMs: number;
+}): void {
+  executeSqliteQuerySync(
+    params.db,
+    kyselyFor(params.db)
+      .insertInto("claw_workspace_files")
+      .values({
+        agent_id: params.agentId,
+        target_path: CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+        schema_version: CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+        workspace: params.workspace,
+        source_path: CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+        content_digest: CLAW_ADOPTED_WORKSPACE_MARKER_DIGEST,
+        status: "complete",
+        created_at_ms: params.nowMs,
+        updated_at_ms: params.nowMs,
+      })
+      .onConflict((conflict) =>
+        conflict.columns(["agent_id", "target_path"]).doUpdateSet({
+          schema_version: CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+          workspace: params.workspace,
+          source_path: CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+          content_digest: CLAW_ADOPTED_WORKSPACE_MARKER_DIGEST,
+          status: "complete",
+          created_at_ms: params.nowMs,
+          updated_at_ms: params.nowMs,
+        }),
+      ),
+  );
+}
+
+/** Persists whether this install adopted or created its workspace in the caller's transaction. */
+export function persistClawWorkspaceOrigin(params: {
+  db: DatabaseSync;
+  plan: ClawAddPlan;
+  nowMs: number;
+}): void {
+  if (planAdoptsWorkspace(params.plan)) {
+    recordAdoptedWorkspaceRow({
+      db: params.db,
+      agentId: params.plan.agent.finalId,
+      workspace: params.plan.agent.workspace,
+      nowMs: params.nowMs,
+    });
+    return;
+  }
+  deleteAdoptedWorkspaceRow(params.db, params.plan.agent.finalId);
+}
+
+/** Drops the adopted-workspace marker inside the caller's open write transaction. */
+export function deleteAdoptedWorkspaceRow(db: DatabaseSync, agentId: string): void {
+  executeSqliteQuerySync(
+    db,
+    kyselyFor(db)
+      .deleteFrom("claw_workspace_files")
+      .where("agent_id", "=", agentId)
+      .where("target_path", "=", CLAW_ADOPTED_WORKSPACE_MARKER_PATH),
+  );
+}
+
+/** True when this agent's current workspace directory existed before the Claw adopted it. */
+export function clawWorkspaceWasAdopted(
+  agentId: string,
+  workspace: string,
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  const { db } = openOpenClawStateDatabase(options);
+  return (
+    executeSqliteQuerySync(
+      db,
+      kyselyFor(db)
+        .selectFrom("claw_workspace_files")
+        .select("agent_id")
+        .where("agent_id", "=", agentId)
+        .where("target_path", "=", CLAW_ADOPTED_WORKSPACE_MARKER_PATH)
+        .where("workspace", "=", workspace)
+        .where("content_digest", "=", CLAW_ADOPTED_WORKSPACE_MARKER_DIGEST),
+    ).rows.length > 0
+  );
+}

--- a/src/claws/workspace.test.ts
+++ b/src/claws/workspace.test.ts
@@ -12,6 +12,7 @@ import { applyClawAddPlan } from "./add.js";
 import { buildClawAddPlan } from "./lifecycle.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawAddPlan, ClawSourceIdentity } from "./types.js";
+import { clawWorkspaceWasAdopted } from "./workspace-origin.js";
 import { ClawWorkspaceWriteError, createClawWorkspaceFiles } from "./workspace.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -24,6 +25,46 @@ async function writeSource(root: string, path: string, content: string): Promise
   const target = join(root, path);
   await mkdir(dirname(target), { recursive: true });
   await writeFile(target, content, "utf8");
+}
+
+async function makeAdoptionPlan(params?: { existingAgentsContent?: string }) {
+  const root = tempDirs.make("openclaw-claw-workspace-adopt-");
+  const workspace = join(root, "workspace-agent");
+  await writeSource(root, "content/AGENTS.md", "# Agent\n");
+  await writeSource(root, "content/policy.md", "Policy\n");
+  await mkdir(workspace, { recursive: true });
+  await writeFile(
+    join(workspace, "AGENTS.md"),
+    params?.existingAgentsContent ?? "# Agent\n",
+    "utf8",
+  );
+  const parsed = parseClawManifest({
+    schemaVersion: 1,
+    agent: { id: "workspace-agent" },
+    workspace: {
+      bootstrapFiles: { "AGENTS.md": { source: "content/AGENTS.md" } },
+      files: [{ source: "content/policy.md", path: "reference/policy.md" }],
+    },
+  });
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.diagnostics));
+  }
+  const source: ClawSourceIdentity = {
+    kind: "package",
+    name: "@acme/workspace-agent",
+    version: "1.0.0",
+    packageRoot: root,
+    manifestPath: join(root, "openclaw.claw.json"),
+    integrityKind: "development-snapshot",
+    integrity: "sha256:manifest",
+    byteLength: 0,
+  };
+  const plan = await buildClawAddPlan({
+    manifest: parsed.manifest,
+    source,
+    context: { workspace, adoptExistingWorkspace: true },
+  });
+  return { root, workspace, plan };
 }
 
 async function makePlan(params?: {
@@ -201,6 +242,54 @@ describe("createClawWorkspaceFiles", () => {
       await expect(readFile(join(workspace, "SOUL.md"), "utf8")).resolves.toBe(body.toString());
     },
   );
+
+  it("adopts an existing identical file without rewriting and records complete provenance", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    expect(plan.blockers).toEqual([]);
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspaceFile", id: "AGENTS.md", action: "adopt" }),
+    );
+
+    const records = await createClawWorkspaceFiles(plan, { env: stateEnv(root), nowMs: 10 });
+
+    expect(records).toContainEqual(
+      expect.objectContaining({ path: "AGENTS.md", status: "complete" }),
+    );
+    await expect(readFile(join(workspace, "AGENTS.md"), "utf8")).resolves.toBe("# Agent\n");
+    await expect(readFile(join(workspace, "reference", "policy.md"), "utf8")).resolves.toBe(
+      "Policy\n",
+    );
+  });
+
+  it("fails closed when an adoptable file changes between planning and apply", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    expect(plan.blockers).toEqual([]);
+    await writeFile(join(workspace, "AGENTS.md"), "# Changed after planning\n", "utf8");
+
+    await expect(
+      createClawWorkspaceFiles(plan, { env: stateEnv(root), nowMs: 10 }),
+    ).rejects.toMatchObject({
+      diagnostics: [expect.objectContaining({ code: "workspace_file_conflict" })],
+    });
+    await expect(readFile(join(workspace, "AGENTS.md"), "utf8")).resolves.toBe(
+      "# Changed after planning\n",
+    );
+  });
+
+  it("fails closed when an adoptable file disappears between planning and apply", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    expect(plan.blockers).toEqual([]);
+    await rm(join(workspace, "AGENTS.md"));
+
+    await expect(
+      createClawWorkspaceFiles(plan, { env: stateEnv(root), nowMs: 10 }),
+    ).rejects.toMatchObject({
+      diagnostics: [expect.objectContaining({ code: "workspace_file_conflict" })],
+    });
+    await expect(readFile(join(workspace, "AGENTS.md"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
 
   it("creates canonical bootstrap and supporting files and records their hashes", async () => {
     const { root, workspace, plan } = await makePlan();
@@ -405,6 +494,121 @@ describe("createClawWorkspaceFiles", () => {
 });
 
 describe("workspace files in the consented add lifecycle", () => {
+  it("completes an adoption add without rewriting existing files and commits the agent", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    expect(plan.blockers).toEqual([]);
+    let config: OpenClawConfig = {};
+
+    const result = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      nowMs: 30,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "complete",
+      workspaceCreated: true,
+      workspaceFiles: [
+        expect.objectContaining({ path: "AGENTS.md", status: "complete" }),
+        expect.objectContaining({ path: "reference/policy.md", status: "complete" }),
+      ],
+      installRecord: { status: "complete" },
+    });
+    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
+    expect(readInstallStatus("workspace-agent", root)).toBe("complete");
+    await expect(readFile(join(workspace, "AGENTS.md"), "utf8")).resolves.toBe("# Agent\n");
+    await expect(readFile(join(workspace, "reference", "policy.md"), "utf8")).resolves.toBe(
+      "Policy\n",
+    );
+  });
+
+  it("preserves an adopted workspace when config commit rolls back", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    let config: OpenClawConfig = {};
+
+    const result = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      nowMs: 35,
+      commitConfig: async () => {
+        throw new Error("config unavailable");
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      workspaceCreated: true,
+      configCommitted: false,
+      workspaceFiles: [
+        expect.objectContaining({ path: "AGENTS.md", status: "complete" }),
+        expect.objectContaining({ path: "reference/policy.md", status: "complete" }),
+      ],
+      installRecord: { status: "workspace_ready" },
+      error: { code: "config_commit_failed", message: "config unavailable" },
+    });
+    await expect(readFile(join(workspace, "AGENTS.md"), "utf8")).resolves.toBe("# Agent\n");
+
+    const resumed = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      nowMs: 36,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    expect(resumed).toMatchObject({
+      status: "complete",
+      configCommitted: true,
+      installRecord: { status: "complete" },
+    });
+    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
+  });
+
+  it("records adopted origin but leaves the agent unroutable when file revalidation fails", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    let config: OpenClawConfig = {};
+    await writeFile(join(workspace, "AGENTS.md"), "# Changed after planning\n", "utf8");
+
+    const result = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      nowMs: 37,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      configCommitted: false,
+      installRecord: { status: "workspace_ready" },
+      error: {
+        code: "workspace_files_failed",
+        diagnostics: [expect.objectContaining({ code: "workspace_file_conflict" })],
+      },
+    });
+    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
+    const originRows = openOpenClawStateDatabase({ env: stateEnv(root) })
+      .db.prepare(
+        "SELECT target_path, workspace, content_digest FROM claw_workspace_files WHERE agent_id = ? ORDER BY target_path",
+      )
+      .all("workspace-agent");
+    expect(originRows).toEqual([
+      {
+        target_path: ".",
+        workspace: plan.agent.workspace,
+        content_digest: "openclaw:adopted-workspace",
+      },
+    ]);
+    expect(
+      clawWorkspaceWasAdopted("workspace-agent", plan.agent.workspace, { env: stateEnv(root) }),
+    ).toBe(true);
+  });
+
   it("marks the root install complete after every declared file is created", async () => {
     const { root, plan } = await makePlan({ createWorkspace: false });
     let config: OpenClawConfig = {};
@@ -451,14 +655,14 @@ describe("workspace files in the consented add lifecycle", () => {
     expect(result).toMatchObject({
       status: "partial",
       workspaceFiles: [expect.objectContaining({ path: "AGENTS.md" })],
-      installRecord: { status: "config_committed" },
+      installRecord: { status: "workspace_ready" },
       error: {
         code: "workspace_files_failed",
         diagnostics: [expect.objectContaining({ code: "workspace_source_changed" })],
       },
     });
-    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
-    expect(readInstallStatus("workspace-agent", root)).toBe("config_committed");
+    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
+    expect(readInstallStatus("workspace-agent", root)).toBe("workspace_ready");
 
     await writeFile(join(root, "content", "policy.md"), "Policy\n", "utf8");
     const resumed = await applyClawAddPlan(plan, {

--- a/src/claws/workspace.test.ts
+++ b/src/claws/workspace.test.ts
@@ -542,10 +542,7 @@ describe("workspace files in the consented add lifecycle", () => {
       status: "partial",
       workspaceCreated: true,
       configCommitted: false,
-      workspaceFiles: [
-        expect.objectContaining({ path: "AGENTS.md", status: "complete" }),
-        expect.objectContaining({ path: "reference/policy.md", status: "complete" }),
-      ],
+      workspaceFiles: [],
       installRecord: { status: "workspace_ready" },
       error: { code: "config_commit_failed", message: "config unavailable" },
     });
@@ -568,7 +565,7 @@ describe("workspace files in the consented add lifecycle", () => {
     expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
   });
 
-  it("records adopted origin but leaves the agent unroutable when file revalidation fails", async () => {
+  it("records adopted origin after reserving the agent when file revalidation fails", async () => {
     const { root, workspace, plan } = await makeAdoptionPlan();
     let config: OpenClawConfig = {};
     await writeFile(join(workspace, "AGENTS.md"), "# Changed after planning\n", "utf8");
@@ -584,14 +581,14 @@ describe("workspace files in the consented add lifecycle", () => {
 
     expect(result).toMatchObject({
       status: "partial",
-      configCommitted: false,
-      installRecord: { status: "workspace_ready" },
+      configCommitted: true,
+      installRecord: { status: "config_committed" },
       error: {
         code: "workspace_files_failed",
         diagnostics: [expect.objectContaining({ code: "workspace_file_conflict" })],
       },
     });
-    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
+    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
     const originRows = openOpenClawStateDatabase({ env: stateEnv(root) })
       .db.prepare(
         "SELECT target_path, workspace, content_digest FROM claw_workspace_files WHERE agent_id = ? ORDER BY target_path",
@@ -655,14 +652,14 @@ describe("workspace files in the consented add lifecycle", () => {
     expect(result).toMatchObject({
       status: "partial",
       workspaceFiles: [expect.objectContaining({ path: "AGENTS.md" })],
-      installRecord: { status: "workspace_ready" },
+      installRecord: { status: "config_committed" },
       error: {
         code: "workspace_files_failed",
         diagnostics: [expect.objectContaining({ code: "workspace_source_changed" })],
       },
     });
-    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
-    expect(readInstallStatus("workspace-agent", root)).toBe("workspace_ready");
+    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
+    expect(readInstallStatus("workspace-agent", root)).toBe("config_committed");
 
     await writeFile(join(root, "content", "policy.md"), "Policy\n", "utf8");
     const resumed = await applyClawAddPlan(plan, {

--- a/src/claws/workspace.test.ts
+++ b/src/claws/workspace.test.ts
@@ -565,7 +565,7 @@ describe("workspace files in the consented add lifecycle", () => {
     expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
   });
 
-  it("records adopted origin after reserving the agent when file revalidation fails", async () => {
+  it("records adopted origin but leaves the agent unroutable when file revalidation fails", async () => {
     const { root, workspace, plan } = await makeAdoptionPlan();
     let config: OpenClawConfig = {};
     await writeFile(join(workspace, "AGENTS.md"), "# Changed after planning\n", "utf8");
@@ -581,14 +581,14 @@ describe("workspace files in the consented add lifecycle", () => {
 
     expect(result).toMatchObject({
       status: "partial",
-      configCommitted: true,
-      installRecord: { status: "config_committed" },
+      configCommitted: false,
+      installRecord: { status: "workspace_ready" },
       error: {
         code: "workspace_files_failed",
         diagnostics: [expect.objectContaining({ code: "workspace_file_conflict" })],
       },
     });
-    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
+    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
     const originRows = openOpenClawStateDatabase({ env: stateEnv(root) })
       .db.prepare(
         "SELECT target_path, workspace, content_digest FROM claw_workspace_files WHERE agent_id = ? ORDER BY target_path",
@@ -652,14 +652,14 @@ describe("workspace files in the consented add lifecycle", () => {
     expect(result).toMatchObject({
       status: "partial",
       workspaceFiles: [expect.objectContaining({ path: "AGENTS.md" })],
-      installRecord: { status: "config_committed" },
+      installRecord: { status: "workspace_ready" },
       error: {
         code: "workspace_files_failed",
         diagnostics: [expect.objectContaining({ code: "workspace_source_changed" })],
       },
     });
-    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
-    expect(readInstallStatus("workspace-agent", root)).toBe("config_committed");
+    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
+    expect(readInstallStatus("workspace-agent", root)).toBe("workspace_ready");
 
     await writeFile(join(root, "content", "policy.md"), "Policy\n", "utf8");
     const resumed = await applyClawAddPlan(plan, {

--- a/src/claws/workspace.ts
+++ b/src/claws/workspace.ts
@@ -11,6 +11,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import { parseClawMarkdown } from "./reader.js";
 import type { ClawAddPlan, ClawAddPlanAction, ClawDiagnostic } from "./types.js";
+import { CLAW_ADOPTED_WORKSPACE_MARKER_PATH } from "./workspace-origin.js";
 
 export const CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION =
   "openclaw.clawWorkspaceFileRecord.v1" as const;
@@ -319,10 +320,10 @@ export function readClawWorkspaceFiles(
         `SELECT schema_version, agent_id, workspace, target_path, source_path,
               content_digest, status, created_at_ms, updated_at_ms
          FROM claw_workspace_files
-        WHERE agent_id = ?
+        WHERE agent_id = ? AND target_path <> ?
         ORDER BY target_path`,
       )
-      .all(agentId) as WorkspaceFileRow[];
+      .all(agentId, CLAW_ADOPTED_WORKSPACE_MARKER_PATH) as WorkspaceFileRow[];
   return rows.map(rowToWorkspaceFile);
 }
 
@@ -426,6 +427,37 @@ export async function createClawWorkspaceFiles(
       }
       if (await workspace.exists(targetRelative)) {
         if (!existingRecord || existingRecord.status === "failed") {
+          if (action.action === "adopt") {
+            const adoptedTarget = await workspace.read(targetRelative, {
+              hardlinks: "reject",
+              maxBytes: MAX_CLAW_WORKSPACE_FILE_BYTES,
+              symlinks: "reject",
+            });
+            if (contentDigest(adoptedTarget.buffer) !== expectedRecord.contentDigest) {
+              throw new ClawWorkspaceWriteError(
+                [
+                  diagnostic(
+                    action,
+                    "workspace_file_conflict",
+                    `Adoptable workspace destination ${JSON.stringify(targetRelative)} changed after planning; adoption never overwrites existing files.`,
+                  ),
+                ],
+                createdFiles,
+              );
+            }
+            const adoptedRecord = existingRecord ?? expectedRecord;
+            if (existingRecord) {
+              const previousStatus = existingRecord.status;
+              existingRecord.status = "complete";
+              existingRecord.updatedAtMs = nowMs;
+              updateWorkspaceFileStatus(existingRecord, [previousStatus], options);
+            } else {
+              adoptedRecord.status = "complete";
+              persistWorkspaceFile(adoptedRecord, options);
+            }
+            createdFiles.push(adoptedRecord);
+            continue;
+          }
           throw new ClawWorkspaceWriteError(
             [
               diagnostic(
@@ -460,6 +492,18 @@ export async function createClawWorkspaceFiles(
         updateWorkspaceFileStatus(existingRecord, [previousStatus], options);
         createdFiles.push(existingRecord);
         continue;
+      }
+      if (action.action === "adopt") {
+        throw new ClawWorkspaceWriteError(
+          [
+            diagnostic(
+              action,
+              "workspace_file_conflict",
+              `Adoptable workspace destination ${JSON.stringify(targetRelative)} disappeared after planning; adoption never writes missing files.`,
+            ),
+          ],
+          createdFiles,
+        );
       }
       const record = existingRecord ?? expectedRecord;
       if (existingRecord) {

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -303,6 +303,7 @@ export async function runClawsAddCommand(
   const basePlanContext = {
     ...(opts.agentId ? { agentId: opts.agentId } : {}),
     ...(opts.workspace ? { workspace: opts.workspace } : {}),
+    ...(opts.adoptExistingWorkspace ? { adoptExistingWorkspace: true } : {}),
     existingAgentIds,
     existingWorkspacePaths,
     existingMcpServers: listedMcpServers.mcpServers,

--- a/src/cli/claws-cli.ts
+++ b/src/cli/claws-cli.ts
@@ -23,6 +23,7 @@ export type ClawsAddOptions = {
   json?: boolean;
   agentId?: string;
   workspace?: string;
+  adoptExistingWorkspace?: boolean;
 };
 
 export type ClawsStatusOptions = { json?: boolean };
@@ -111,13 +112,18 @@ export function registerClawsCli(program: Command) {
 
   claws
     .command("add")
-    .description("Preview adding one new agent and workspace from a Claw")
+    .description("Preview adding one agent and its workspace from a Claw")
     .argument("<source>", "Path to a Claw package directory or grouped manifest")
     .option("--dry-run", "Preview all actions without mutating state", false)
-    .option("--yes", "Confirm creation of the new agent and workspace", false)
+    .option("--yes", "Confirm creating the agent and its workspace", false)
     .option("--plan-integrity <digest>", "Bind consent to an exact dry-run plan")
     .option("--agent-id <id>", "Override the requested id with an unused local agent id")
-    .option("--workspace <path>", "Override the derived new workspace path")
+    .option("--workspace <path>", "Override the derived workspace path")
+    .option(
+      "--adopt-existing-workspace",
+      "Adopt an existing workspace directory; declared files must already match or be absent",
+      false,
+    )
     .option("--json", "Print JSON", false)
     .action(async (source: string, opts: ClawsAddOptions) => {
       const { runClawsAddCommand } = await import("./claws-cli.runtime.js");


### PR DESCRIPTION
## Summary

Rebases and repairs the existing workspace-adoption path for `claws add`.

This carries forward the implementation direction from #115670:

- adds explicit `--adopt-existing-workspace` support
- adopts matching declared workspace files without rewriting them
- blocks mismatched, unsafe, unreadable, oversized, symlinked, or hardlinked destinations
- records an adopted-workspace origin marker so later remove/status behavior retains operator-created directories
- preserves the default fail-closed behavior for existing workspaces unless adoption is explicitly requested

This also fixes the Windows proof failures found while validating the rebased integration:

- plan-time workspace inspection now treats paths under a regular-file parent as uninspectable instead of absent
- Claws removal tests close SQLite before temp cleanup on Windows

Closes #126785.
Related to #115662 and #115670.

## Proof

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/claws/lifecycle-adopt.test.ts src/claws/lifecycle-adopt-remove.test.ts src/claws/workspace.test.ts src/claws/provenance.test.ts src/cli/claws-cli.test.ts src/claws/lifecycle-state.test.ts`
  - passed: 93 passed, 3 skipped
- `git diff --check`
  - passed
- `pnpm exec oxlint src/claws/lifecycle-adopt-plan.ts src/claws/lifecycle-adopt-remove.test.ts src/claws/lifecycle-state.test.ts src/claws/lifecycle.ts src/claws/add.ts src/claws/workspace.ts src/cli/claws-cli.ts src/cli/claws-cli.runtime.ts`
  - passed
- `node scripts/check-docs-mdx.mjs docs/cli/claws.md`
  - passed
- `pnpm exec oxfmt --config .oxfmtrc.jsonc docs/cli/claws.md`
  - passed

## Known Baseline / Environment Notes

- `pnpm lint` currently fails outside this Claws change on plugin-sdk boundary dts errors in `packages/ai`, `packages/markdown-core`, and `src/tui`.
- `pnpm check:docs` on Windows fails before content checking because the repo-wide docs formatter command line is too long; single-file `docs/cli/claws.md` MDX/format checks passed.
- `pnpm dlx ... markdownlint-cli2 ... docs/cli/claws.md` expands the configured repo-wide docs glob and fails on unrelated `docs/CLAUDE.md` trailing newline.
