### PR TITLE
docs: correct Copilot Proxy default enablement

### DIFF
--- a/extensions/copilot-proxy/README.md
+++ b/extensions/copilot-proxy/README.md
@@ -4,7 +4,7 @@ Provider plugin for the **Copilot Proxy** VS Code extension.
 
 ## Enable
 
-Bundled plugins are disabled by default. Enable this one:
+This bundled plugin is enabled by default. If you previously disabled it, re-enable it:
 
 ```bash
 openclaw plugins enable copilot-proxy


### PR DESCRIPTION
## What Problem This Solves

Fixes contradictory setup guidance in the Copilot Proxy plugin README, which said bundled plugins were disabled by default even though this plugin is enabled by default.

## Why This Change Was Made

Align the README with the plugin manifest and the [GitHub Copilot provider guide](https://docs.openclaw.ai/providers/github-copilot). Keep the existing enable command for users who previously disabled the plugin.

## User Impact

Users can proceed to configuration without an unnecessary enable step. The VS Code proxy requirement, authentication command, and restart guidance remain unchanged. This is a documentation-only correction; no runtime or configuration defaults change.

## Evidence

- Verified `enabledByDefault: true` in `extensions/copilot-proxy/openclaw.plugin.json` and the shared activation policy, including explicit disable and allow/deny precedence.
- `pnpm docs:list` passed; the canonical provider guide already documents this plugin as enabled by default.
- Targeted oxfmt check passed for the README; `git diff --check` passed.
- Fresh Codex P0–P2 review and independent manual source review found no actionable findings.
- Scope: one README line replaced; no production or test changes. No provider calls or runtime builds are needed for this documentation-only correction.

AI-assisted with Codex.
