### PR TITLE
test(config): consolidate runtime snapshot fixtures

### DIFF
--- a/src/config/io.runtime-snapshot-write.test.ts
+++ b/src/config/io.runtime-snapshot-write.test.ts
@@ -6,35 +6,8 @@ import {
   setRuntimeConfigSnapshotRefreshHandler,
   setRuntimeConfigSnapshot,
 } from "./io.js";
+import { createProviderConfigFixture } from "./runtime-snapshot.test-fixtures.js";
 import type { OpenClawConfig } from "./types.js";
-
-function createSourceConfig(): OpenClawConfig {
-  return {
-    models: {
-      providers: {
-        openai: {
-          baseUrl: "https://api.openai.com/v1",
-          apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-          models: [],
-        },
-      },
-    },
-  };
-}
-
-function createRuntimeConfig(): OpenClawConfig {
-  return {
-    models: {
-      providers: {
-        openai: {
-          baseUrl: "https://api.openai.com/v1",
-          apiKey: "sk-runtime-resolved", // pragma: allowlist secret
-          models: [],
-        },
-      },
-    },
-  };
-}
 
 function resetRuntimeConfigState(): void {
   setRuntimeConfigSnapshotRefreshHandler(null);
@@ -52,7 +25,7 @@ describe("runtime config snapshot writes", () => {
 
   it("skips source projection for non-runtime-derived configs", () => {
     const sourceConfig: OpenClawConfig = {
-      ...createSourceConfig(),
+      ...createProviderConfigFixture(),
       gateway: {
         auth: {
           mode: "token",
@@ -60,24 +33,14 @@ describe("runtime config snapshot writes", () => {
       },
     };
     const runtimeConfig: OpenClawConfig = {
-      ...createRuntimeConfig(),
+      ...createProviderConfigFixture("sk-runtime-resolved"), // pragma: allowlist secret
       gateway: {
         auth: {
           mode: "token",
         },
       },
     };
-    const independentConfig: OpenClawConfig = {
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            apiKey: "sk-independent-config", // pragma: allowlist secret
-            models: [],
-          },
-        },
-      },
-    };
+    const independentConfig = createProviderConfigFixture("sk-independent-config"); // pragma: allowlist secret
 
     setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
     const projected = projectConfigOntoRuntimeSourceSnapshot(independentConfig);

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -31,6 +31,7 @@ import {
   writeConfigFile,
 } from "./io.js";
 import { ConfigMutationConflictError } from "./mutation-conflict.js";
+import { createProviderConfigFixture } from "./runtime-snapshot.test-fixtures.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "./types.openclaw.js";
 
 const CONFIG_CLOBBER_SNAPSHOT_LIMIT = 32;
@@ -195,6 +196,25 @@ describe("config io write", () => {
     path.join(home, ".openclaw", fileName);
 
   const formatConfig = (config: unknown) => `${JSON.stringify(config, null, 2)}\n`;
+
+  const createExistingConfigSnapshot = (
+    configPath: string,
+    config: OpenClawConfig,
+    raw: string | null,
+  ): ConfigFileSnapshot => ({
+    path: configPath,
+    exists: true,
+    raw,
+    parsed: config,
+    sourceConfig: config,
+    resolved: config,
+    valid: true,
+    runtimeConfig: config,
+    config,
+    issues: [],
+    warnings: [],
+    legacyIssues: [],
+  });
 
   const readPersistedConfig = async (configPath: string): Promise<OpenClawConfig> =>
     JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;
@@ -626,20 +646,7 @@ describe("config io write", () => {
       env: { VITEST: "true" } as NodeJS.ProcessEnv,
       logger: { warn, error: vi.fn() },
     });
-    const baseSnapshot = {
-      path: configPath,
-      exists: true,
-      raw: originalRaw,
-      parsed: original,
-      sourceConfig: original,
-      resolved: original,
-      valid: true,
-      runtimeConfig: original,
-      config: original,
-      issues: [],
-      warnings: [],
-      legacyIssues: [],
-    } satisfies ConfigFileSnapshot;
+    const baseSnapshot = createExistingConfigSnapshot(configPath, original, originalRaw);
 
     await expectConfigWriteRejected(
       io.writeConfigFile(
@@ -679,20 +686,7 @@ describe("config io write", () => {
         configPath,
         env: { VITEST: "true" } as NodeJS.ProcessEnv,
       });
-      const baseSnapshot = {
-        path: configPath,
-        exists: true,
-        raw: originalRaw,
-        parsed: original,
-        sourceConfig: original,
-        resolved: original,
-        valid: true,
-        runtimeConfig: original,
-        config: original,
-        issues: [],
-        warnings: [],
-        legacyIssues: [],
-      } satisfies ConfigFileSnapshot;
+      const baseSnapshot = createExistingConfigSnapshot(configPath, original, originalRaw);
       let preflightCalls = 0;
 
       await expectConfigWriteRejected(
@@ -835,20 +829,7 @@ describe("config io write", () => {
       const io = createHomeConfigIO(home, {
         env: { VITEST: "true" } as NodeJS.ProcessEnv,
       });
-      const baseSnapshot = {
-        path: configPath,
-        exists: true,
-        raw: originalRaw,
-        parsed: original,
-        sourceConfig: original,
-        resolved: original,
-        valid: true,
-        runtimeConfig: original,
-        config: original,
-        issues: [],
-        warnings: [],
-        legacyIssues: [],
-      } satisfies ConfigFileSnapshot;
+      const baseSnapshot = createExistingConfigSnapshot(configPath, original, originalRaw);
 
       const acceptedWrite = await io.writeConfigFile(
         { meta: original.meta, gateway: { mode: "local" } },
@@ -1851,56 +1832,24 @@ describe("config io write", () => {
   itWithHome("writes runtime-derived edits back to source SecretRef markers", async (home) => {
     const { configPath } = await writeConfigFixture(home, {
       gateway: { mode: "local" },
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-            models: [],
-          },
-        },
-      },
+      ...createProviderConfigFixture(),
     });
 
     await withEnvAsync({ OPENCLAW_CONFIG_PATH: configPath }, async () => {
       setRuntimeConfigSnapshot(
         {
           gateway: { mode: "local" },
-          models: {
-            providers: {
-              openai: {
-                baseUrl: "https://api.openai.com/v1",
-                apiKey: "sk-runtime-resolved",
-                models: [],
-              },
-            },
-          },
+          ...createProviderConfigFixture("sk-runtime-resolved"),
         },
         {
           gateway: { mode: "local" },
-          models: {
-            providers: {
-              openai: {
-                baseUrl: "https://api.openai.com/v1",
-                apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-                models: [],
-              },
-            },
-          },
+          ...createProviderConfigFixture(),
         },
       );
 
       await writeConfigFile({
         gateway: { mode: "local", port: 18789 },
-        models: {
-          providers: {
-            openai: {
-              baseUrl: "https://api.openai.com/v1",
-              apiKey: "sk-runtime-resolved",
-              models: [],
-            },
-          },
-        },
+        ...createProviderConfigFixture("sk-runtime-resolved"),
       });
 
       const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
@@ -2361,20 +2310,7 @@ describe("config io write", () => {
       await fs.mkdir(path.dirname(configPath), { recursive: true });
       const initialConfig = { gateway: { mode: "local", port: 18789 } } satisfies OpenClawConfig;
       await writeConfigJson(configPath, initialConfig);
-      const baseSnapshot = {
-        path: configPath,
-        exists: true,
-        raw: null,
-        parsed: initialConfig,
-        sourceConfig: initialConfig,
-        resolved: initialConfig,
-        valid: true,
-        runtimeConfig: initialConfig,
-        config: initialConfig,
-        issues: [],
-        warnings: [],
-        legacyIssues: [],
-      } satisfies ConfigFileSnapshot;
+      const baseSnapshot = createExistingConfigSnapshot(configPath, initialConfig, null);
 
       try {
         await withEnvAsync({ OPENCLAW_CONFIG_PATH: configPath }, async () => {

--- a/src/config/runtime-snapshot.test-fixtures.ts
+++ b/src/config/runtime-snapshot.test-fixtures.ts
@@ -1,0 +1,18 @@
+import type { OpenClawConfig } from "./types.js";
+import type { SecretInput } from "./types.secrets.js";
+
+export function createProviderConfigFixture(
+  apiKey: SecretInput = { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+): OpenClawConfig {
+  return {
+    models: {
+      providers: {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          apiKey,
+          models: [],
+        },
+      },
+    },
+  };
+}

--- a/src/config/runtime-snapshot.test.ts
+++ b/src/config/runtime-snapshot.test.ts
@@ -27,6 +27,7 @@ import {
   setRuntimeConfigSourceSnapshotIfCurrent,
   setRuntimeConfigSnapshotRefreshHandler,
 } from "./runtime-snapshot.js";
+import { createProviderConfigFixture } from "./runtime-snapshot.test-fixtures.js";
 import type { OpenClawConfig } from "./types.js";
 
 function resetRuntimeConfigState(): void {
@@ -60,28 +61,8 @@ describe("runtime snapshot state", () => {
   });
 
   it("returns the source snapshot when runtime snapshot is active", () => {
-    const sourceConfig: OpenClawConfig = {
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-            models: [],
-          },
-        },
-      },
-    };
-    const runtimeConfig: OpenClawConfig = {
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            apiKey: "sk-runtime-resolved",
-            models: [],
-          },
-        },
-      },
-    };
+    const sourceConfig = createProviderConfigFixture();
+    const runtimeConfig = createProviderConfigFixture("sk-runtime-resolved");
 
     setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
     expect(getRuntimeConfigSourceSnapshot()).toEqual(sourceConfig);
@@ -159,28 +140,8 @@ describe("runtime snapshot state", () => {
   });
 
   it("selects runtime config only when input still matches the runtime source", () => {
-    const sourceConfig: OpenClawConfig = {
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-            models: [],
-          },
-        },
-      },
-    };
-    const runtimeConfig: OpenClawConfig = {
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            apiKey: "sk-runtime-resolved",
-            models: [],
-          },
-        },
-      },
-    };
+    const sourceConfig = createProviderConfigFixture();
+    const runtimeConfig = createProviderConfigFixture("sk-runtime-resolved");
     const scopedResolvedConfig: OpenClawConfig = {
       ...runtimeConfig,
       tools: {
@@ -219,31 +180,10 @@ describe("runtime snapshot state", () => {
     }));
     const nextSourceConfig: OpenClawConfig = {
       gateway: { auth: { mode: "token" } },
-      models: {
-        providers: {
-          openai: {
-            baseUrl: "https://api.openai.com/v1",
-            apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-            models: [],
-          },
-        },
-      },
+      ...createProviderConfigFixture(),
     };
 
-    setRuntimeConfigSnapshot(
-      {
-        models: {
-          providers: {
-            openai: {
-              baseUrl: "https://api.openai.com/v1",
-              apiKey: "sk-runtime-resolved",
-              models: [],
-            },
-          },
-        },
-      },
-      nextSourceConfig,
-    );
+    setRuntimeConfigSnapshot(createProviderConfigFixture("sk-runtime-resolved"), nextSourceConfig);
 
     await finalizeRuntimeSnapshotWrite({
       nextSourceConfig,
@@ -294,28 +234,8 @@ describe("runtime snapshot state", () => {
     });
 
     setRuntimeConfigSnapshot(
-      {
-        models: {
-          providers: {
-            openai: {
-              baseUrl: "https://api.openai.com/v1",
-              apiKey: "sk-runtime-resolved",
-              models: [],
-            },
-          },
-        },
-      },
-      {
-        models: {
-          providers: {
-            openai: {
-              baseUrl: "https://api.openai.com/v1",
-              apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-              models: [],
-            },
-          },
-        },
-      },
+      createProviderConfigFixture("sk-runtime-resolved"),
+      createProviderConfigFixture(),
     );
     setRuntimeConfigSnapshotRefreshHandler({
       refresh: async ({ sourceConfig }) => {
@@ -328,15 +248,7 @@ describe("runtime snapshot state", () => {
     const writePromise = finalizeRuntimeSnapshotWrite({
       nextSourceConfig: {
         gateway: { auth: { mode: "token" } },
-        models: {
-          providers: {
-            openai: {
-              baseUrl: "https://api.openai.com/v1",
-              apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
-              models: [],
-            },
-          },
-        },
+        ...createProviderConfigFixture(),
       },
       hadRuntimeSnapshot: true,
       hadBothSnapshots: true,


### PR DESCRIPTION
## What Problem This Solves

The runtime-snapshot and config-write suites repeated the same nested provider configuration and complete snapshot records in several places. That test-only scaffolding made the source/runtime projection contract harder to read and easier to update inconsistently.

## Why This Change Was Made

The suites now share one small typed provider-config fixture and one local complete-snapshot builder. Independent input and expected objects remain independent, and each assertion continues to exercise the same config I/O and runtime-snapshot owner rather than a new production seam.

## User Impact

No production or user-visible behavior changes. The config owner tests are smaller while preserving all source-marker, runtime-projection, write-conflict, and snapshot-refresh coverage.

## Evidence

- Unchanged-production baseline: 97/97 tests passed.
- Final focused proof: 97/97 tests passed across the three owner suites; all 283 expectations and all test cases remain.
- The new pure fixture received a focused import/smoke check.
- Complete changed-file gate: exit 0; all routed core/core-test types, lint, format, dead-code scans, storage guards, and import-cycle checks passed.
- Isolated P0 autoreview: no findings, 0.99 confidence.
- Production LOC: +0/-0. Tests/support: +60/-231 (net -171).
- No performance claim: observed warm-cache timing was not used as evidence.

