### PR TITLE
fix(ui): reconnect-uncertain sends stay inline and prove delivery by run id

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -609,6 +609,12 @@ automatically when the Gateway returns. Live controls and slash commands remain 
 offline, except that **Stop** can queue an exact local run ID for replay. A session-only stop
 is not replayed because newer work may start in that session before the connection returns.
 
+If the connection drops before a send is acknowledged, reconnect checks the transcript and
+the session's active or last run ID for delivery proof. A matching run confirms receipt even
+before its transcript row appears. Without proof, an attempted message stays in the conversation
+with an amber **Delivery unconfirmed** footer and **Retry**. Check the conversation and retry only
+if the message did not arrive. Unconfirmed local commands keep their retry/discard queue controls.
+
 First opens and reloads show a small animated OpenClaw mark while the Gateway resolves the initial
 connection, including when authentication comes from a trusted proxy or Tailscale instead of a
 browser-stored credential. The login gate appears only after the initial connection fails or the

--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -592,22 +592,24 @@ suite.define(() => {
 
       await gateway.closeLatest(1006, "lost ack");
 
-      const queue = page.locator(".chat-queue");
-      await queue.getByText("Delivery uncertain").waitFor({ timeout: 10_000 });
+      const deliveryStatus = page.locator('.chat-send-status[data-send-state="unconfirmed"]');
+      await deliveryStatus.getByText("Delivery unconfirmed").waitFor({ timeout: 10_000 });
+      expect(await page.locator(".chat-queue").count()).toBe(0);
+      await page.locator(".chat-group.user").getByText(prompt, { exact: true }).waitFor();
       expect(await gateway.getRequests("chat.send")).toHaveLength(1);
-      await queue.locator(".chat-queue__retry").click();
+      await deliveryStatus.getByRole("button", { name: "Retry queued message" }).click();
 
       const sends = await waitForRequests(gateway, "chat.send", 2);
       const secondParams = requireRecord(sends[1]?.params);
       expect(secondParams.idempotencyKey).toBe(runId);
       expect(secondParams.message).toBe(prompt);
-      await queue.waitFor({ state: "detached", timeout: 10_000 });
+      await deliveryStatus.waitFor({ state: "detached", timeout: 10_000 });
     } finally {
       await suite.closeBrowserContext(context);
     }
   });
 
-  it("dismisses an ACK-lost banner after exact authoritative history proof", async () => {
+  it("clears inline delivery uncertainty after exact authoritative history proof", async () => {
     const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     const context = await suite.newBrowserContext({
       locale: "en-US",
@@ -644,8 +646,11 @@ suite.define(() => {
       );
       await gateway.closeLatest(1006, "lost ack");
 
-      const queue = page.locator(".chat-queue");
-      await queue.getByText("Delivery uncertain").waitFor({ timeout: 10_000 });
+      const deliveryStatus = page.locator('.chat-send-status[data-send-state="unconfirmed"]');
+      await deliveryStatus.getByText("Delivery unconfirmed").waitFor({ timeout: 10_000 });
+      expect(await page.locator(".chat-queue").count()).toBe(0);
+      const userBubble = page.locator(".chat-group.user").getByText(prompt, { exact: true });
+      await userBubble.waitFor();
       if (artifactDir) {
         await page.screenshot({ path: `${artifactDir}/01-delivery-uncertain.png`, fullPage: true });
       }
@@ -665,7 +670,7 @@ suite.define(() => {
         sessionKey: "main",
         status: "done",
       });
-      await queue.getByText("Delivery uncertain").waitFor({ timeout: 10_000 });
+      await deliveryStatus.getByText("Delivery unconfirmed").waitFor({ timeout: 10_000 });
       expect(await gateway.getRequests("chat.send")).toHaveLength(1);
       if (artifactDir) {
         await page.screenshot({
@@ -691,8 +696,9 @@ suite.define(() => {
         status: "running",
       });
 
-      await queue.waitFor({ state: "detached", timeout: 10_000 });
-      await page.locator(".chat-group.user").getByText(prompt).waitFor({ timeout: 10_000 });
+      await deliveryStatus.waitFor({ state: "detached", timeout: 10_000 });
+      await userBubble.waitFor({ timeout: 10_000 });
+      expect(await userBubble.count()).toBe(1);
       expect(await gateway.getRequests("chat.send")).toHaveLength(1);
       if (artifactDir) {
         await page.screenshot({ path: `${artifactDir}/03-delivery-proven.png`, fullPage: true });

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5721,6 +5721,7 @@ export const en: TranslationMap = {
     },
     queue: {
       notSent: "Not sent",
+      deliveryUnconfirmed: "Delivery unconfirmed",
       retry: "Retry",
       retryQueuedMessage: "Retry queued message",
       steer: "Steer",

--- a/ui/src/pages/chat/chat-composer-queue.test.ts
+++ b/ui/src/pages/chat/chat-composer-queue.test.ts
@@ -13,6 +13,44 @@ afterEach(async () => {
 });
 
 describe("chat composer steering queue", () => {
+  it("keeps attempted unconfirmed messages inline while local commands retain retry and discard", () => {
+    const onQueueRetry = vi.fn();
+    const onQueueRemove = vi.fn();
+    const container = renderQueue({
+      queue: [
+        {
+          id: "message",
+          text: "Already attempted",
+          createdAt: 1,
+          sendState: "unconfirmed",
+          sendAttempts: 1,
+        },
+        {
+          id: "reset",
+          text: "/reset",
+          localCommandName: "reset",
+          createdAt: 2,
+          sendState: "unconfirmed",
+          sendError: "Check the conversation before retrying the command.",
+          sendAttempts: 1,
+        },
+      ],
+      onQueueRetry,
+      onQueueRemove,
+    });
+
+    const rows = container.querySelectorAll(".chat-queue__item");
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.getAttribute("data-chat-queue-item")).toBe("reset");
+    expect(rows[0]?.querySelector(".chat-queue__badge")?.textContent?.trim()).toBe(
+      t("chat.queue.states.needsReview"),
+    );
+    rows[0]?.querySelector<HTMLButtonElement>(".chat-queue__retry")?.click();
+    rows[0]?.querySelector<HTMLButtonElement>(".chat-queue__remove")?.click();
+    expect(onQueueRetry).toHaveBeenCalledWith("reset");
+    expect(onQueueRemove).toHaveBeenCalledWith("reset");
+  });
+
   it("renders the durable steer mode without a run-bound state", () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -101,7 +101,7 @@ type StoredChatOutboxClientState = {
 const STORED_OUTBOX_CONFIRMATION_GRACE_MS = 5_000;
 const STORED_OUTBOX_RETRY_DEFAULT_MS = 500;
 export const UNCONFIRMED_CHAT_SEND_ERROR =
-  "Delivery could not be confirmed after reconnect. Check the conversation before retrying.";
+  "Reconnected before delivery was confirmed. Check the conversation — retry only if your message didn't arrive.";
 const UNCERTAIN_CLEAR_SUCCESSOR_ERROR =
   "A preceding /clear may have completed. Review the current conversation before retrying.";
 
@@ -154,6 +154,17 @@ function sameQueuedDeliveryVersion(left: ChatQueueItem, right: ChatQueueItem): b
 
 function queuedDeliveryVersion(item: ChatQueueItem): string {
   return `${item.id}\u0000${item.sendRunId ?? ""}\u0000${item.sendAttempts ?? 0}`;
+}
+
+function sessionRunProvesQueuedDelivery(
+  sessionInfo: ChatHistoryResult["sessionInfo"],
+  item: ChatQueueItem,
+): boolean {
+  return Boolean(
+    item.sendRunId &&
+    (sessionInfo?.activeRunIds?.includes(item.sendRunId) ||
+      sessionInfo?.lastRunId === item.sendRunId),
+  );
 }
 
 async function readCurrentStoredChatHistory(
@@ -209,6 +220,10 @@ async function readCurrentStoredChatHistory(
       outbox.sessionKey,
       outbox.agentId,
       parked ? error : OFFLINE_QUEUE_STORAGE_ERROR,
+      // A parked attempted message owns its inline bubble footer; the pane
+      // banner would duplicate it. Never-attempted failures, command chips,
+      // and storage failures keep the banner — they render no bubble.
+      { inline: Boolean(parked && attempted && !item.localCommandName) },
     );
     return parked && !attempted ? "continue" : "blocked";
   }
@@ -221,7 +236,12 @@ async function readCurrentStoredChatHistory(
     return "continue";
   }
   syncVisibleChatQueueProjection(host);
-  if (chatMessagesContainQueuedSend(history.messages, item)) {
+  // Gateway chat run IDs equal client idempotency keys; terminal-event retirement
+  // uses the same delivery proof, even before the transcript marker is persisted.
+  if (
+    chatMessagesContainQueuedSend(history.messages, item) ||
+    sessionRunProvesQueuedDelivery(history.sessionInfo, item)
+  ) {
     // Materialize server history locally before removing the queue bubble.
     preserveQueuedUserTurn(host, item);
     const removed = removeQueuedMessageWithoutReleasing(host, item.id, outbox.sessionKey);
@@ -260,7 +280,7 @@ async function reconcileStoredChatOutboxHead(
   // recorded into the session row. Skipping the 1000-message chat.history here
   // stops one full-history RPC per transcript event while a run streams.
   // Attempted items keep the fetch: delivered-detection must retire their
-  // bubbles even mid-run, and a missing row falls through conservatively.
+  // bubbles even mid-run; missing transcript and run proof falls through conservatively.
   const neverAttempted =
     (item.sendAttempts ?? 0) === 0 && item.sendRequestStartedAtMs === undefined;
   if (neverAttempted && item.queueMode) {
@@ -337,6 +357,9 @@ async function reconcileStoredChatOutboxHead(
         outbox.sessionKey,
         outbox.agentId,
         UNCONFIRMED_CHAT_SEND_ERROR,
+        // The parked bubble's inline footer is the visible outcome; hidden
+        // panes still get the named toast. Command chips never park here.
+        { inline: !item.localCommandName },
       );
     }
     return "blocked";

--- a/ui/src/pages/chat/chat-progress.ts
+++ b/ui/src/pages/chat/chat-progress.ts
@@ -167,7 +167,9 @@ export function isQueuedSendInlineState(item: ChatQueueItem): boolean {
   return (
     queuedSendStarted(item) &&
     !item.localCommandName &&
-    (item.sendState === "failed" || (item.sendState === "waiting-idle" && Boolean(item.sendError)))
+    (item.sendState === "failed" ||
+      item.sendState === "unconfirmed" ||
+      (item.sendState === "waiting-idle" && Boolean(item.sendError)))
   );
 }
 

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3818,6 +3818,60 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it.for(["dark", "light"])(
+    "keeps unconfirmed footers and Retry amber while failed sends stay red in %s mode",
+    async (theme, context) => {
+      const page = await openBrowserPage(390, 844);
+      try {
+        await page.setContent(`<!doctype html><html data-theme-mode="${theme}"><head><style>${readUiCss()}</style></head><body>
+        <span id="warning-color-probe" style="color: var(--warn)">Warning</span>
+        <span id="danger-color-probe" style="color: var(--danger)">Failure</span>
+        ${[
+          { state: "unconfirmed", label: "Delivery unconfirmed" },
+          { state: "failed", label: "Not sent" },
+        ]
+          .map(
+            ({ state, label }) => `<div class="chat-group user chat-group--with-footer">
+          <div class="chat-group-messages"><div class="chat-bubble">Attempted message</div></div>
+          <div class="chat-group-footer chat-group-footer--send-failure">
+            <div class="chat-group-footer__meta"><span class="chat-sender-name">You</span>
+              <span class="chat-send-status" data-send-state="${state}">
+                <span>·</span><span>${label}</span><span>·</span>
+                <button class="chat-send-status__retry" type="button">Retry</button>
+              </span>
+            </div>
+          </div>
+        </div>`,
+          )
+          .join("")}
+      </body></html>`);
+
+        for (const [state, probe] of [
+          ["unconfirmed", "warning"],
+          ["failed", "danger"],
+        ]) {
+          const status = page.locator(`.chat-send-status[data-send-state="${state}"]`);
+          const expectedColor = await page
+            .locator(`#${probe}-color-probe`)
+            .evaluate((element) => getComputedStyle(element).color);
+          expect(await status.evaluate((element) => getComputedStyle(element).color)).toBe(
+            expectedColor,
+          );
+          const retry = status.locator("button");
+          expect(await retry.evaluate((element) => getComputedStyle(element).color)).toBe(
+            expectedColor,
+          );
+          await retry.hover();
+          await context.expect
+            .poll(() => retry.evaluate((element) => getComputedStyle(element).color))
+            .toBe(expectedColor);
+        }
+      } finally {
+        await closeBrowserPage(page);
+      }
+    },
+  );
+
   it("covers every reachable queue presentation cell without repeating global state", async () => {
     const page = await openBrowserPage(1520, 2400);
     const reachableCells = QUEUE_MATRIX_MODES.flatMap((mode) =>
@@ -3856,11 +3910,11 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           '<span class="chat-queue__error"><span class="chat-queue__badge">Failed</span><span class="chat-queue__error-text">Request rejected</span></span>',
         ),
         queueExceptionCellHtml(
-          "unconfirmed",
+          "unconfirmed-local-command",
           "",
           "chat-queue__item--failed",
           "",
-          '<span class="chat-queue__error"><span class="chat-queue__badge">Delivery uncertain</span><span class="chat-queue__error-text">Review before retrying</span></span>',
+          '<span class="chat-queue__error"><span class="chat-queue__badge">Delivery uncertain</span><span class="chat-queue__error-text">Reconnected before delivery was confirmed. Check the conversation — retry only if your message didn\'t arrive.</span></span>',
         ),
         queueExceptionCellHtml(
           "applying-settings",
@@ -3932,7 +3986,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           "item-reconnect",
           "running-command",
           "failed",
-          "unconfirmed",
+          "unconfirmed-local-command",
           "applying-settings",
         ]) {
           await page.locator(`[data-queue-exception="${key}"]`).screenshot({

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -5008,7 +5008,7 @@ describe("handleSendChat", () => {
     const item = {
       ...createQueuedLocalCommand("unconfirmed-reset-retry", "/reset"),
       sendAttempts: 1,
-      sendError: "Delivery could not be confirmed after reconnect.",
+      sendError: UNCONFIRMED_CHAT_SEND_ERROR,
       sendRequestStartedAtMs: 10,
       sendRunId: runId,
       sendState: "unconfirmed" as const,
@@ -6111,7 +6111,8 @@ describe("handleSendChat", () => {
       sendState: "unconfirmed",
       text: "history never catches up",
     });
-    expect(host.lastError).toBe(UNCONFIRMED_CHAT_SEND_ERROR);
+    // The parked bubble's inline footer owns the outcome; no pane banner.
+    expect(host.lastError).toBeNull();
   });
 
   it("starts a fresh confirmation grace after the prior outbox scope is removed", async () => {
@@ -7513,6 +7514,56 @@ describe("handleSendChat", () => {
     },
   );
 
+  it.each([
+    {
+      proof: "active run",
+      sessionInfo: row("agent:main", {
+        hasActiveRun: true,
+        activeRunIds: ["admitted-run"],
+        status: "running",
+      }),
+    },
+    {
+      proof: "completed run",
+      sessionInfo: row("agent:main", {
+        hasActiveRun: false,
+        lastRunId: "admitted-run",
+        status: "done",
+      }),
+    },
+  ])(
+    "retires a reconnect send proved by its $proof before transcript persistence",
+    async ({ sessionInfo }) => {
+      const host = makeChatHost({
+        requestHandlers: {
+          "chat.history": () => ({ messages: [], sessionInfo }),
+        },
+        chatQueue: [
+          {
+            id: "admitted-send",
+            text: "keep my admitted message visible",
+            createdAt: 1,
+            sendAttempts: 1,
+            sendRunId: "admitted-run",
+            sendState: "sending",
+            sessionKey: "agent:main",
+          },
+        ],
+      });
+      admitHostQueueItems(host);
+      markQueuedChatSendsWaitingForReconnect(host);
+
+      await retryReconnectableQueuedChatSends(host);
+
+      expect(listStoredChatOutboxes(host)).toStrictEqual([]);
+      expect(host.chatQueue).toStrictEqual([]);
+      expect(host.chatMessages.map(extractText)).toContain("keep my admitted message visible");
+      expect(host.lastError).toBeNull();
+      expect(host.chatError).toBeNull();
+      expect(host.request).not.toHaveBeenCalledWith("chat.send", expect.anything());
+    },
+  );
+
   it("rechecks an idle history snapshot before parking a delivered send", async () => {
     let historyRequests = 0;
 
@@ -7603,13 +7654,17 @@ describe("handleSendChat", () => {
     expect(listStoredChatOutboxes(host)[0]?.queue[0]?.id).toBe(item.id);
   });
 
-  it("parks an ambiguous reconnect send when idle history cannot prove delivery", async () => {
+  it("parks an ambiguous reconnect send when idle history only proves another run", async () => {
     const host = makeChatHost({
       requestHandlers: {
         "chat.history": () =>
           Promise.resolve({
             messages: [],
-            sessionInfo: row("agent:main", { hasActiveRun: false, status: "done" }),
+            sessionInfo: row("agent:main", {
+              hasActiveRun: false,
+              lastRunId: "other-run",
+              status: "done",
+            }),
           }),
       },
       chatQueue: [
@@ -7639,42 +7694,53 @@ describe("handleSendChat", () => {
     expect(host.chatQueue[0]).toMatchObject({
       id: "ambiguous-unconfirmed",
       sendState: "unconfirmed",
+      sendError: UNCONFIRMED_CHAT_SEND_ERROR,
     });
     expect(host.chatQueue.map((item) => item.id)).toEqual([
       "ambiguous-unconfirmed",
       "blocked-tail",
     ]);
-    expect(host.lastError).toContain("Delivery could not be confirmed");
+    // The parked bubble's inline footer owns the outcome; no pane banner.
+    expect(host.lastError).toBeNull();
   });
 
-  it("does not replay while fresh history reports an active run", async () => {
-    const host = makeChatHost({
-      requestHandlers: {
-        "chat.history": () =>
-          Promise.resolve({
-            messages: [],
-            sessionInfo: row("agent:main", { hasActiveRun: true, status: "done" }),
-          }),
-      },
-      chatQueue: [
-        {
-          id: "wait-for-idle",
-          text: "send after the active run",
-          createdAt: 1,
-          sendAttempts: 0,
-          sendRunId: "wait-for-idle-run",
-          sendState: "waiting-reconnect",
-          sessionKey: "agent:main",
+  it.each([0, 1])(
+    "does not replay or retire a send with %i attempts while another run is active",
+    async (sendAttempts) => {
+      const host = makeChatHost({
+        requestHandlers: {
+          "chat.history": () =>
+            Promise.resolve({
+              messages: [],
+              sessionInfo: row("agent:main", {
+                hasActiveRun: true,
+                activeRunIds: ["other-run"],
+                status: "running",
+              }),
+            }),
         },
-      ],
-    });
-    admitHostQueueItems(host);
+        chatQueue: [
+          {
+            id: "wait-for-idle",
+            text: "send after the active run",
+            createdAt: 1,
+            sendAttempts,
+            sendRunId: "wait-for-idle-run",
+            sendState: "waiting-reconnect",
+            sessionKey: "agent:main",
+          },
+        ],
+      });
+      admitHostQueueItems(host);
 
-    await retryReconnectableQueuedChatSends(host);
+      await retryReconnectableQueuedChatSends(host);
 
-    expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
-    expect(host.chatQueue[0]?.sendState).toBe("waiting-reconnect");
-  });
+      expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
+      expect(host.chatQueue[0]?.sendState).toBe("waiting-reconnect");
+      expect(host.lastError).toBeNull();
+      expect(listStoredChatOutboxes(host)[0]?.queue[0]?.sendRunId).toBe("wait-for-idle-run");
+    },
+  );
 
   it("skips a manually failed head when replaying a later reconnect send", async () => {
     const host = makeChatHost({
@@ -8809,13 +8875,14 @@ describe("handleSendChat", () => {
     await retryReconnectableQueuedChatSends(host);
 
     // An attempted head may already be a server-side turn; it must park for
-    // review rather than fail-and-release, and the outcome must be visible.
-    expect(host.lastError).toBe(
-      "Delivery could not be confirmed after reconnect. Check the conversation before retrying.",
-    );
+    // review rather than fail-and-release. The parked bubble's inline footer
+    // owns the visible outcome, so the pane banner stays clear.
+    expect(host.lastError).toBeNull();
     const stored = listStoredChatOutboxes(host).flatMap((outbox) => outbox.queue);
     expect(stored.find((entry) => entry.id === "attempted-head")).toMatchObject({
       sendState: "unconfirmed",
+      sendError:
+        "Reconnected before delivery was confirmed. Check the conversation — retry only if your message didn't arrive.",
     });
     expect(host.request.mock.calls.filter(([method]) => method === "chat.send")).toHaveLength(0);
   });

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -301,15 +301,21 @@ export function isPendingSendMessage(message: unknown): boolean {
 export function readPendingSendFailure(message: unknown): {
   error?: string;
   id: string;
+  state: "failed" | "unconfirmed";
 } | null {
   const metadata = asRecord(asRecord(message)?.["__openclaw"]);
   const state = metadata?.state;
   const id = metadata?.id;
-  if (metadata?.kind !== "pending-send" || state !== "failed" || typeof id !== "string") {
+  if (
+    metadata?.kind !== "pending-send" ||
+    (state !== "failed" && state !== "unconfirmed") ||
+    typeof id !== "string"
+  ) {
     return null;
   }
   return {
     id,
+    state,
     ...(typeof metadata.error === "string" ? { error: metadata.error } : {}),
   };
 }

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -17,6 +17,7 @@ import {
   getExpandedToolCards,
   getExpandedUserMessages,
   persistedMessageEntryId,
+  readPendingSendFailure,
   resetChatThreadState,
   setExpansionState,
   syncToolCardExpansionState,
@@ -3510,50 +3511,68 @@ describe("buildCachedChatItems", () => {
     expect(messageAt(groupAt(groups, 0), 1).duplicateCount).toBeUndefined();
   });
 
-  it("hides a pending send after history accepts its idempotency key", () => {
-    const groups = messageGroups({
-      messages: [
-        userMessage("accepted prompt", 1, {
-          __openclaw: { idempotencyKey: "accepted-run:user", seq: 1 },
-        }),
-      ],
-      queue: [
-        queuedSend("pending-send-1", "accepted prompt", 2, "sending", {
+  it.each(["sending", "failed", "unconfirmed"] as const)(
+    "hands a %s bubble to matching history without changing its key",
+    (sendState) => {
+      const queue = [
+        queuedSend("pending-send-1", "accepted prompt", 2, sendState, {
           sendRunId: "accepted-run",
-          sendSubmittedAtMs: 10,
+          sendAttempts: 1,
         }),
-      ],
-    });
+      ];
+      const pending = messageGroups({ queue });
+      expect(pending).toHaveLength(1);
+      const groups = messageGroups({
+        messages: [
+          userMessage("accepted prompt", 1, {
+            __openclaw: { idempotencyKey: "accepted-run:user", seq: 1 },
+          }),
+        ],
+        queue,
+      });
 
-    expect(groups).toHaveLength(1);
-    expect(groupAt(groups, 0).messages).toHaveLength(1);
-    expect(messageRecord(groupAt(groups, 0))["__openclaw"]).toMatchObject({
-      idempotencyKey: "accepted-run:user",
-      seq: 1,
-    });
-  });
+      expect(groups).toHaveLength(1);
+      expect(groupAt(groups, 0).messages).toHaveLength(1);
+      expect(messageAt(groupAt(groups, 0), 0).key).toBe(messageAt(groupAt(pending, 0), 0).key);
+      expect(messageRecord(groupAt(groups, 0))["__openclaw"]).toMatchObject({
+        idempotencyKey: "accepted-run:user",
+        seq: 1,
+      });
+    },
+  );
 
-  it("keeps failed submitted sends in the thread for inline retry", () => {
-    const groups = messageGroups({
-      queue: [
-        queuedSend("failed-send-1", "retry me from the transcript", 1, "failed", {
-          sendError: "send failed",
-          sendSubmittedAtMs: 10,
-        }),
-      ],
-    });
+  it.each(["failed", "unconfirmed"] as const)(
+    "keeps a %s attempted send after the preceding reply for inline retry",
+    (sendState) => {
+      const groups = messageGroups({
+        messages: [assistantMessage("Previous reply", 2)],
+        queue: [
+          queuedSend("attempted-send-1", "retry me from the transcript", 1, sendState, {
+            sendError: "Delivery diagnostic",
+            sendAttempts: 1,
+          }),
+        ],
+      });
 
-    expect(groups).toHaveLength(1);
-    expect(messageRecord(groupAt(groups, 0))).toMatchObject({
-      content: [{ type: "text", text: "retry me from the transcript" }],
-      __openclaw: {
-        id: "failed-send-1",
-        kind: "pending-send",
-        state: "failed",
-        error: "send failed",
-      },
-    });
-  });
+      expect(groups.map((group) => group.role)).toEqual(["assistant", "user"]);
+      const message = messageRecord(groupAt(groups, 1));
+      expect(message).toMatchObject({
+        timestamp: 1,
+        content: [{ type: "text", text: "retry me from the transcript" }],
+        __openclaw: {
+          id: "attempted-send-1",
+          kind: "pending-send",
+          state: sendState,
+          error: "Delivery diagnostic",
+        },
+      });
+      expect(readPendingSendFailure(message)).toEqual({
+        id: "attempted-send-1",
+        state: sendState,
+        error: "Delivery diagnostic",
+      });
+    },
+  );
 
   it("filters submitted queued sends while chat search is active", () => {
     const groups = messageGroups({

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -619,10 +619,16 @@ export function renderMessageGroup(group: MessageGroup, opts: RenderMessageGroup
                 ? html`<span
                     class="chat-send-status"
                     title=${sendFailure.error ?? nothing}
-                    data-send-state="failed"
+                    data-send-state=${sendFailure.state}
                   >
                     <span aria-hidden="true">·</span>
-                    <span>${t("chat.queue.notSent")}</span>
+                    <span
+                      >${t(
+                        sendFailure.state === "unconfirmed"
+                          ? "chat.queue.deliveryUnconfirmed"
+                          : "chat.queue.notSent",
+                      )}</span
+                    >
                     ${opts.onRetryQueuedMessage
                       ? html`
                           <span aria-hidden="true">·</span>

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -867,6 +867,34 @@ describe("grouped chat rendering", () => {
     expect(order).toEqual(["Reply to message", "Rewind", "name", "time"]);
   });
 
+  it.each([
+    { state: "failed", label: "Not sent" },
+    { state: "unconfirmed", label: "Delivery unconfirmed" },
+  ] as const)("shows a $state footer with its diagnostic and retry action", ({ state, label }) => {
+    const container = document.createElement("div");
+    const onRetryQueuedMessage = vi.fn();
+    renderGroupedMessage(
+      container,
+      createUserMessage("Attempted message", {
+        __openclaw: {
+          id: "attempted-send",
+          kind: "pending-send",
+          state,
+          error: "Delivery diagnostic",
+        },
+      }),
+      "user",
+      { onRetryQueuedMessage },
+    );
+
+    const status = expectElement(container, ".chat-group.user .chat-send-status", HTMLElement);
+    expect(status.dataset.sendState).toBe(state);
+    expect(status.title).toBe("Delivery diagnostic");
+    expect(status.textContent?.replace(/\s+/g, " ").trim()).toBe(`· ${label} · Retry`);
+    status.querySelector<HTMLButtonElement>(".chat-send-status__retry")?.click();
+    expect(onRetryQueuedMessage).toHaveBeenCalledWith("attempted-send");
+  });
+
   it("orders peer footer actions after the sender name and timestamp", () => {
     const container = document.createElement("div");
     const message = createUserMessage("Peer footer order.");

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -411,20 +411,24 @@
   stroke-linejoin: round;
 }
 
+.chat-send-status[data-send-state="unconfirmed"] {
+  color: var(--warn);
+}
+
 .chat-group-footer .chat-send-status__retry {
   width: auto;
   min-width: 0;
   min-height: 0;
   padding: 0;
   border-radius: 0;
-  color: var(--danger);
+  color: inherit;
   font: inherit;
   opacity: 1 !important;
   pointer-events: auto;
 }
 
 .chat-group-footer .chat-send-status__retry:hover {
-  color: var(--danger);
+  color: inherit;
   text-decoration: underline;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Control UI operator whose WebSocket reconnected while a `chat.send` was in flight would see a red "Delivery uncertain" error chip in the composer — and keep seeing it for the entire run — even though the message was delivered and the agent was visibly replying. The message also vanished from the conversation into the composer chip area, plus a duplicate red top-bar banner.

## Why This Change Was Made

Two root causes:

1. **Delivery-proof blind spot.** After a reconnect loses the ack, the outbox reconcile's only delivery proof was the transcript idempotency marker — which doesn't exist until the run *commits*. The fact that was available the whole time (the session row reporting the send's own run id in `sessionInfo.activeRunIds`, or as `lastRunId` after completion) was never consulted, even though live terminal-event retirement (`removeDeliveredQueuedChatSendForRun`) already trusts exactly that identity (gateway chat runs use the client idempotency key as run id, `src/gateway/server-methods/chat-send-session.ts:41`). So a send admitted during the reconnect race parked as "unconfirmed" and stayed red until the run ended.
2. **Wrong failure surface.** Attempted sends already have a messenger-style inline presentation: `failed` sends render as a normal conversation bubble with a quiet "· Not sent · Retry" footer. `unconfirmed` was the one attempted state excluded from that path, falling back to a red composer chip styled like a hard failure.

The reconcile now retires a queued send when the session row proves its run (active or last), and `unconfirmed` joins the inline bubble path: the message stays in the conversation as an ordinary bubble, and only genuine, concluded uncertainty gets an amber "Delivery unconfirmed · Retry" footer (tooltip carries the calmer diagnostic). The duplicate pane banner is suppressed for parked attempted messages since the bubble owns the outcome; hidden sessions still get the named toast, and local-command chips, never-attempted failures, and storage errors keep their existing surfaces.

## User Impact

- A send that raced a reconnect but was delivered never shows an error: the bubble stays in the conversation and silently hands off to the authoritative history row (same Lit key, no flicker) — including runs that completed while the client was disconnected.
- Real uncertainty reads as a calm review request next to the speech bubble, not a failure: amber "Delivery unconfirmed · Retry" instead of a red chip + red banner. Red stays reserved for actual failures.
- Copy softened: "Reconnected before delivery was confirmed. Check the conversation — retry only if your message didn't arrive."

## Evidence

- **Pre-fix failure proof:** `pnpm test ui/src/pages/chat/chat-send.test.ts -t 'retires a reconnect send proved by'` fails 2/2 on pre-fix code (active-run case stays `waiting-reconnect`, completed-run case stays `unconfirmed`); both pass post-fix.
- `pnpm test ui/src/pages/chat/chat-send.test.ts` — 284 passed (new regressions: active-run proof, last-run proof, unrelated-run still parks, banner suppressed for parked bubbles).
- `pnpm test ui/src/e2e/chat-flow.history-recovery.e2e.test.ts` — 7 passed (real UI + mock-gateway WebSocket reconnect: ACK-lost park, same-key Retry, uncertainty surviving unrelated history, single authoritative bubble after proof).
- Touched-file suites (`chat-thread`, `chat-composer-queue`, `chat-message`, `chat-responsive.browser` incl. Chromium layout/theme color assertions) — 516 passed; full `pnpm test ui/src/pages/chat` — 11,174 passed.
- `pnpm check:changed` green (typecheck, lint, styles, i18n catalog); `pnpm ui:i18n:baseline` byte-identical.
- Fresh isolated Codex autoreview on the final diff: clean, no actionable findings.
- Production LOC: +51/−9 across 6 files (delivery-proof predicate, second visual state in the existing footer renderer, banner suppression); no new storage, config, or API surface. Tests +291/−82, docs +6.
- Before/after screenshots (mock-gateway e2e harness, sanitized) in the comment below.
