### PR TITLE
fix(agents): startup warning advises alsoAllow for explicitly-denied tools

### DIFF
--- a/src/agents/agent-tools.policy.test.ts
+++ b/src/agents/agent-tools.policy.test.ts
@@ -752,6 +752,36 @@ describe("resolveEffectiveToolPolicy", () => {
     }
   });
 
+  it("does not advise alsoAllow for a tool the agent explicitly denies (#131102)", async () => {
+    const warnLogs = createWarnLogCapture("openclaw-agent-tools-policy-test");
+    try {
+      const cfg = {
+        agents: {
+          list: [
+            {
+              id: "sage",
+              tools: {
+                profile: "messaging",
+                exec: { mode: "allowlist" },
+                deny: ["exec"],
+              },
+            },
+          ],
+        },
+      } as OpenClawConfig;
+
+      resolveEffectiveToolPolicy({ config: cfg, agentId: "sage" });
+
+      const warning = await warnLogs.findText('tools policy: profile "messaging"');
+      expect(warning).toContain('(agent "sage")');
+      expect(warning).toContain("configured tool sections (tools.exec)");
+      expect(warning).not.toContain('"exec"');
+      expect(warning).toContain('Add alsoAllow: ["process"]');
+    } finally {
+      warnLogs.cleanup();
+    }
+  });
+
   it("explicit alsoAllow with exec still grants exec under messaging profile", () => {
     const cfg = {
       tools: {

--- a/src/agents/agent-tools.policy.ts
+++ b/src/agents/agent-tools.policy.ts
@@ -430,10 +430,13 @@ export function resolveEffectiveToolPolicy(params: {
         explicitProfileAlsoAllow,
       );
       const matchesProfile = createToolPolicyMatcher(profilePolicy);
+      // Denied tools are unreachable via alsoAllow (deny wins), so don't advise them (#131102).
+      const denyPolicy = agentPolicy?.deny?.length ? { deny: agentPolicy.deny } : undefined;
+      const matchesDeny = createToolPolicyMatcher(denyPolicy);
       const uncoveredEntries = implicitGrants.entries
         .map((entry) => ({
           section: entry.section,
-          grants: entry.grants.filter((toolName) => !matchesProfile(toolName)),
+          grants: entry.grants.filter((toolName) => !matchesProfile(toolName) && matchesDeny(toolName)),
         }))
         .filter((entry) => entry.grants.length > 0);
       const uncovered = uncoveredEntries.flatMap((entry) => entry.grants);


### PR DESCRIPTION
Closes #131102

## What Problem This Solves

Fixes an issue where agents that explicitly `deny` a tool would still be advised on every gateway startup to add that same tool to `alsoAllow`. The #47487 implicit-grant migration warning computes its "is this tool already covered?" check from the profile and `alsoAllow` only, so an explicitly-denied tool surfaces as uncovered and the warning tells the operator to `Add alsoAllow: [<denied tool>]`. Following that advice produces self-contradictory config — the tool ends up in both `alsoAllow` and `deny` — and the runtime matcher (`deny` always wins) refuses it anyway, so the operator is told to enable a capability the runtime will block.

## Why This Change Was Made

The warning's coverage check now also consults the agent's `tools.deny`: a tool that is explicitly denied is no longer listed as uncovered, so the `Add alsoAllow` advice skips it. This reuses the codebase's existing deny-check idiom (`isToolAllowedByPolicyName(toolName, { deny })`, the same contract the runtime matcher uses, where deny patterns always win). When no `deny` is configured the new clause is a no-op — `isToolAllowedByPolicyName(name, undefined)` returns `true` — so non-denying agents see no behavior change. The fix is scoped to the agent-level `tools.deny` reported in #131102; a global `tools.deny` producing the same contradiction is a separate, unreported case left for a follow-up.

## User Impact

Operators who deny a tool at the agent level no longer receive a contradictory startup warning instructing them to `alsoAllow` that tool. Non-denied tools that genuinely lost their implicit grant are still surfaced in the warning, so legitimate migration guidance is preserved.

## Evidence

- New test `does not advise alsoAllow for a tool the agent explicitly denies (#131102)` in `src/agents/agent-tools.policy.test.ts`: an agent with `profile: "messaging"`, `tools.exec`, and `deny: ["exec"]` — asserts the warning omits `"exec"` while still listing the non-denied `"process"`.
- Verified red-on-master: with the source change reverted, the new test fails (the warning lists `Add alsoAllow: ["exec", "process"]` despite the deny).
- Verified green-on-branch: 37/37 tests in `src/agents/agent-tools.policy.test.ts` pass with the fix.
- `oxlint` and `oxfmt` clean on both changed files.
