### PR TITLE
feat(ci): alarm and self-heal when the docs mirror goes stale

### DIFF
--- a/.github/workflows/docs-mirror-freshness.yml
+++ b/.github/workflows/docs-mirror-freshness.yml
@@ -1,0 +1,36 @@
+name: Docs Mirror Freshness
+
+# Freshness alarm for the docs publish pipeline: docs-sync-publish.yml mirrors
+# docs into openclaw/docs, but a broken sync leaves the mirror silently stale.
+# This check fails (notifying the workflow actor) when the mirror trails a
+# docs-touching main commit by more than the grace window, after dispatching
+# one recovery sync.
+
+on:
+  schedule:
+    - cron: "17,47 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Needed to dispatch a docs-sync-publish.yml recovery run when stale.
+  actions: write
+
+jobs:
+  check-mirror-freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24.x"
+
+      - name: Check docs mirror freshness
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/docs-mirror-freshness.mjs

--- a/scripts/docs-mirror-freshness.mjs
+++ b/scripts/docs-mirror-freshness.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+// Alerts when the openclaw/docs mirror is stale relative to docs-touching
+// commits on main. Reads the watched paths from docs-sync-publish.yml itself so
+// the staleness definition can never drift from the sync trigger's path filters.
+// On staleness it dispatches one recovery sync, then exits nonzero so the
+// scheduled run fails and notifies. Runner: .github/workflows/docs-mirror-freshness.yml.
+
+import fs from "node:fs";
+import process from "node:process";
+
+const TOOL = "docs-mirror-freshness";
+const SOURCE_REPO = process.env.GITHUB_REPOSITORY || "openclaw/openclaw";
+// Publish-repo contract: docs mirror to openclaw/docs (root AGENTS.md, Docs section).
+const MIRROR_REPO = "openclaw/docs";
+const SYNC_WORKFLOW = "docs-sync-publish.yml";
+const SYNC_WORKFLOW_FILE = `.github/workflows/${SYNC_WORKFLOW}`;
+const STALE_MINUTES = Number(process.env.DOCS_MIRROR_STALE_MINUTES ?? "60");
+
+function fail(message) {
+  console.error(message);
+  console.error(`[${TOOL}] FAILED (exit 1)`);
+  process.exit(1);
+}
+
+async function githubJson(apiPath, init = {}) {
+  const headers = {
+    accept: "application/vnd.github+json",
+    "user-agent": TOOL,
+    ...init.headers,
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  const response = await fetch(`https://api.github.com${apiPath}`, { ...init, headers });
+  if (!response.ok) {
+    throw new Error(`GitHub ${init.method ?? "GET"} ${apiPath} responded ${response.status}`);
+  }
+  return response.status === 204 ? null : await response.json();
+}
+
+function readSyncWatchPaths(workflowText) {
+  const paths = [];
+  let inPush = false;
+  let inPaths = false;
+  for (const line of workflowText.split("\n")) {
+    if (/^ {2}push:\s*$/.test(line)) {
+      inPush = true;
+      continue;
+    }
+    if (inPush && /^ {0,2}\S/.test(line)) {
+      inPush = false;
+      inPaths = false;
+    }
+    if (inPush && /^ {4}paths:\s*$/.test(line)) {
+      inPaths = true;
+      continue;
+    }
+    if (inPaths) {
+      const item = line.match(/^\s+-\s+(\S+)\s*$/);
+      if (item) {
+        paths.push(item[1]);
+        continue;
+      }
+      inPaths = false;
+    }
+  }
+  if (paths.length === 0) {
+    throw new Error(
+      `no push path filters parsed from ${SYNC_WORKFLOW_FILE}; parser needs updating`,
+    );
+  }
+  return paths;
+}
+
+// The commits API takes plain file/directory paths, so only the trailing-glob
+// directory form used by the sync trigger is translatable; any other glob means
+// the filter shape changed and this check must be updated, not silently skipped.
+function toCommitApiPath(pattern) {
+  const bare = pattern.endsWith("/**") ? pattern.slice(0, -3) : pattern;
+  if (/[*?[\]]/.test(bare)) {
+    throw new Error(`unsupported glob in sync path filter: ${pattern}`);
+  }
+  return bare;
+}
+
+async function newestWatchedCommit(watchPaths) {
+  let newest = null;
+  for (const watchPath of watchPaths) {
+    const commits = await githubJson(
+      `/repos/${SOURCE_REPO}/commits?sha=main&path=${encodeURIComponent(watchPath)}&per_page=1`,
+    );
+    const head = commits[0];
+    if (!head) {
+      continue;
+    }
+    const committedAt = Date.parse(head.commit.committer.date);
+    if (!newest || committedAt > newest.committedAt) {
+      newest = { sha: head.sha, committedAt, path: watchPath };
+    }
+  }
+  if (!newest) {
+    throw new Error("no commits found for any watched docs path on main");
+  }
+  return newest;
+}
+
+async function readMirroredSourceSha() {
+  const contents = await githubJson(
+    `/repos/${MIRROR_REPO}/contents/.openclaw-sync/source.json?ref=main`,
+  );
+  const source = JSON.parse(Buffer.from(contents.content, "base64").toString("utf8"));
+  if (typeof source.sha !== "string" || !/^[0-9a-f]{40}$/.test(source.sha)) {
+    throw new Error(`mirror source.json has no valid source sha: ${JSON.stringify(source.sha)}`);
+  }
+  return source.sha;
+}
+
+async function mirrorCoversCommit(commitSha, mirroredSha) {
+  if (commitSha === mirroredSha) {
+    return true;
+  }
+  const comparison = await githubJson(
+    `/repos/${SOURCE_REPO}/compare/${commitSha}...${mirroredSha}`,
+  );
+  // "ahead"/"identical": the mirrored sha contains the commit. "behind" or
+  // "diverged" (mirror off main history) both count as not covered.
+  return comparison.status === "identical" || comparison.status === "ahead";
+}
+
+async function countActiveSyncRuns() {
+  let active = 0;
+  for (const status of ["queued", "in_progress"]) {
+    const runs = await githubJson(
+      `/repos/${SOURCE_REPO}/actions/workflows/${SYNC_WORKFLOW}/runs?status=${status}&per_page=1`,
+    );
+    active += runs.total_count;
+  }
+  return active;
+}
+
+async function dispatchRecoverySync() {
+  await githubJson(`/repos/${SOURCE_REPO}/actions/workflows/${SYNC_WORKFLOW}/dispatches`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ ref: "main" }),
+  });
+}
+
+async function main() {
+  const watchPaths = readSyncWatchPaths(fs.readFileSync(SYNC_WORKFLOW_FILE, "utf8")).map(
+    toCommitApiPath,
+  );
+  const [newest, mirroredSha] = await Promise.all([
+    newestWatchedCommit(watchPaths),
+    readMirroredSourceSha(),
+  ]);
+  const ageMinutes = Math.round((Date.now() - newest.committedAt) / 60_000);
+  const summary = `newest docs-touching main commit ${newest.sha} (${newest.path}, ${ageMinutes}m ago); mirror at ${mirroredSha}`;
+
+  if (await mirrorCoversCommit(newest.sha, mirroredSha)) {
+    console.log(`docs mirror fresh: ${summary}`);
+    return;
+  }
+  if (ageMinutes < STALE_MINUTES) {
+    console.log(
+      `docs mirror trailing within ${STALE_MINUTES}m grace (sync in flight?): ${summary}`,
+    );
+    return;
+  }
+
+  const activeSyncRuns = await countActiveSyncRuns();
+  if (activeSyncRuns === 0) {
+    await dispatchRecoverySync();
+    console.error(`dispatched ${SYNC_WORKFLOW} recovery run on main`);
+  } else {
+    console.error(
+      `${activeSyncRuns} ${SYNC_WORKFLOW} run(s) already queued/in progress; not dispatching another`,
+    );
+  }
+  fail(`docs mirror stale for ${ageMinutes}m (threshold ${STALE_MINUTES}m): ${summary}`);
+}
+
+try {
+  await main();
+} catch (error) {
+  fail(`${TOOL} error: ${error instanceof Error ? error.message : String(error)}`);
+}


### PR DESCRIPTION
## What Problem This Solves

Nothing pages anyone when the openclaw/docs mirror silently stops tracking `main`. Both halves of the docs publish starvation bug — the R2 head-drift guard (openclaw/docs `b4b130bd8`) and the cancel-in-progress starvation fix (#131155) — were discovered by someone noticing stale published docs, not by any alert. The remaining failure modes (dead `OPENCLAW_DOCS_SYNC_TOKEN`, MDX check failure, disabled workflow, GitHub incident) would again produce an indefinitely stale mirror with zero signal. The openclaw/docs smoke (openclaw/docs#139) asserts routes only after an upload happens, so a sync that never completes never trips it.

## Why This Change Was Made

Adds a scheduled **Docs Mirror Freshness** workflow (every 30 minutes, ~10 GitHub API calls per run, seconds of ubuntu-latest time) backed by `scripts/docs-mirror-freshness.mjs`:

1. Parses the watched paths from `docs-sync-publish.yml`'s own `on.push.paths` block, so the staleness definition can never drift from the sync trigger's filters (this is also why the check lives in this repo rather than openclaw/docs — a copy of the filter list over there would rot). Zero parsed paths or an untranslatable glob fails loudly instead of silently narrowing coverage.
2. Finds the newest docs-touching `main` commit (commits API per watched path) and reads the mirror's `.openclaw-sync/source.json` SHA — which every completed sync rewrites (`syncedAt` + source SHA), so it is a reliable recorded fact.
3. Fresh when the mirror SHA contains that commit (compare API; a diverged/off-main mirror SHA counts as stale, fail-closed). Trailing commits younger than 60 minutes are grace (sync in flight).
4. When stale past the threshold: dispatches one `docs-sync-publish.yml` recovery run via same-repo `workflow_dispatch` with the default `GITHUB_TOKEN` (`actions: write`; no cross-repo PAT needed, and `workflow_dispatch` is exempt from the GITHUB_TOKEN no-recursion rule) — skipped when a sync run is already queued or in progress — then exits nonzero so the scheduled run fails and notifies the workflow actor.

Documented heuristic choices: committer date (= squash-merge time on this repo) is the staleness clock; clawhub-side staleness is out of scope (the top-level `source.json` `sha` is the openclaw/openclaw source SHA).

## User Impact

Docs pipeline breakage becomes a paged, self-healing event instead of a silent freeze: transient causes are healed by the dispatched recovery sync within ~1–1.5h, and persistent causes produce a failing scheduled run every 30 minutes until fixed.

## Evidence

- Fresh path, live against real repos: `docs mirror fresh: newest docs-touching main commit 7c65d89e60 (.github/workflows/docs-sync-publish.yml, 7m ago); mirror at 7c65d89e60` — correctly identified the just-landed #131155 commit as newest-watched and the mirror as caught up.
- Stale path, live with a simulated stale mirror SHA (`f636bf237`, the real pre-#131155 mirror state) and threshold 0: detected staleness, found a real sync run in flight, correctly suppressed the duplicate dispatch, exited 1 with the `[docs-mirror-freshness] FAILED (exit 1)` wrapper line.
- Recovery dispatch endpoint, live: one real manual sync dispatched via the same endpoint/payload → run 33113089552 (`workflow_dispatch`, completed).
- `check:changed` tooling lane green (format, guards, script lint); Codex autoreview clean.
- Not locally provable: `GITHUB_TOKEN` + `actions: write` dispatch inside Actions (personal-token proof above covers endpoint/payload); post-merge the workflow can be exercised manually via its own `workflow_dispatch` trigger.
