### PR TITLE
fix(plugins): refuse git installs onto an existing managed checkout

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -227,6 +227,8 @@ third-party packages, and non-npm sources are not rewritten.
 
     Git installs clone into a temporary directory, check out the requested ref when present, then use the normal plugin directory installer, so manifest validation, operator install policy, package-manager install work, and install records behave like npm installs. Recorded git installs include the source URL/ref plus the resolved commit so `openclaw plugins update` can re-resolve the source later.
 
+    Reinstalling the same Git source and ref without `--force` refuses an existing managed checkout, even if the repository now declares a different plugin id. Use `openclaw plugins update <id>` for a tracked upgrade, or `openclaw plugins install git:<repo>@<ref> --force` to explicitly replace the checkout.
+
     After installing from git, use `openclaw plugins inspect <id> --runtime --json` to verify runtime registrations such as gateway methods and CLI commands. If the plugin registered a CLI root with `api.registerCli`, run that command directly through the OpenClaw root CLI, for example `openclaw demo-plugin ping`.
 
   </Accordion>

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -227,7 +227,7 @@ third-party packages, and non-npm sources are not rewritten.
 
     Git installs clone into a temporary directory, check out the requested ref when present, then use the normal plugin directory installer, so manifest validation, operator install policy, package-manager install work, and install records behave like npm installs. Recorded git installs include the source URL/ref plus the resolved commit so `openclaw plugins update` can re-resolve the source later.
 
-    Reinstalling the same Git source and ref without `--force` refuses an existing managed checkout, even if the repository now declares a different plugin id. Use `openclaw plugins update <id>` for a tracked upgrade, or `openclaw plugins install git:<repo>@<ref> --force` to explicitly replace the checkout.
+    Reinstalling the same Git source and ref without `--force` refuses an existing managed checkout, even if the repository now declares a different plugin id. Use `openclaw plugins update <id>` for a tracked upgrade, or `openclaw plugins install git:<repo>@<ref> --force` to intentionally reinstall the same plugin id. `--force` does not migrate an existing install record to a different plugin id.
 
     After installing from git, use `openclaw plugins inspect <id> --runtime --json` to verify runtime registrations such as gateway methods and CLI commands. If the plugin registered a CLI root with `api.registerCli`, run that command directly through the OpenClaw root CLI, for example `openclaw demo-plugin ping`.
 

--- a/src/plugins/git-install-target.test.ts
+++ b/src/plugins/git-install-target.test.ts
@@ -1,0 +1,146 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolvePluginInstallPreflight } from "../cli/plugins-install-preflight.js";
+import { runCommandWithTimeout } from "../process/exec.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { installPluginFromGitSpec } from "./git-install.js";
+import {
+  requestDeferredPluginInstall,
+  resolvePluginInstallTransaction,
+} from "./install-transaction.js";
+
+describe("git install target ownership", () => {
+  let state: OpenClawTestState;
+  let sourceDir: string;
+  let spec: string;
+
+  async function git(cwd: string, ...args: string[]) {
+    const result = await runCommandWithTimeout(["git", ...args], { cwd, timeoutMs: 10_000 });
+    expect(result.code, result.stderr).toBe(0);
+    return result.stdout.trim();
+  }
+
+  async function commitPlugin(pluginId: string, version: string) {
+    await fs.writeFile(
+      path.join(sourceDir, "package.json"),
+      JSON.stringify({ name: "git-fixture", version, openclaw: { extensions: ["index.js"] } }),
+    );
+    await fs.writeFile(
+      path.join(sourceDir, "openclaw.plugin.json"),
+      JSON.stringify({ id: pluginId, configSchema: { type: "object", properties: {} } }),
+    );
+    await fs.writeFile(
+      path.join(sourceDir, "index.js"),
+      `export default ${JSON.stringify(version)};\n`,
+    );
+    await git(sourceDir, "add", ".");
+    await git(sourceDir, "-c", "commit.gpgsign=false", "commit", "-m", version);
+    return await git(sourceDir, "rev-parse", "HEAD");
+  }
+
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "git-install-target" });
+    const globalConfig = await state.writeText("global-npmrc", "");
+    vi.stubEnv("NPM_CONFIG_GLOBALCONFIG", globalConfig);
+    sourceDir = state.path("source");
+    await fs.mkdir(sourceDir);
+    await git(sourceDir, "init", "--initial-branch=main");
+    await git(sourceDir, "config", "user.name", "OpenClaw Test");
+    await git(sourceDir, "config", "user.email", "test@openclaw.invalid");
+    await commitPlugin("demo", "1.0.0");
+    spec = `git:${pathToFileURL(sourceDir).href}`;
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await state.cleanup();
+  });
+
+  it.each([
+    { pluginId: "demo", deferred: false },
+    { pluginId: "renamed-demo", deferred: false },
+    { pluginId: "demo", deferred: true },
+    { pluginId: "renamed-demo", deferred: true },
+  ])(
+    "refuses a reinstall with id=$pluginId and deferred=$deferred",
+    async ({ pluginId, deferred }) => {
+      const installed = await installPluginFromGitSpec({ spec });
+      if (!installed.ok) {
+        throw new Error(installed.error);
+      }
+      const markerPath = path.join(installed.targetDir, "operator-note.txt");
+      await fs.writeFile(markerPath, "keep this checkout");
+      await commitPlugin(pluginId, "2.0.0");
+
+      const options = { spec, mode: "install" as const };
+      const result = await installPluginFromGitSpec(
+        deferred ? requestDeferredPluginInstall(options) : options,
+      );
+      // Settle any pre-fix transaction so the failing reproduction leaves no backup behind.
+      await resolvePluginInstallTransaction(result)?.commit();
+      expect.soft(result).toEqual({
+        ok: false,
+        error: `plugin already exists: ${installed.targetDir} (delete it first)`,
+      });
+      expect.soft(await git(installed.targetDir, "rev-parse", "HEAD")).toBe(installed.git.commit);
+      await expect.soft(fs.readFile(markerPath, "utf8")).resolves.toBe("keep this checkout");
+      await expect
+        .soft(fs.readFile(path.join(installed.targetDir, "openclaw.plugin.json"), "utf8"))
+        .resolves.toContain('"id":"demo"');
+    },
+  );
+
+  it("refuses default and dry-run reinstalls but allows an explicit force replacement", async () => {
+    const installed = await installPluginFromGitSpec({ spec });
+    if (!installed.ok) {
+      throw new Error(installed.error);
+    }
+    const nextCommit = await commitPlugin("demo", "2.0.0");
+    const refusal = {
+      ok: false,
+      error: `plugin already exists: ${installed.targetDir} (delete it first)`,
+    };
+    expect(await installPluginFromGitSpec({ spec })).toEqual(refusal);
+    expect(await installPluginFromGitSpec({ spec, dryRun: true })).toEqual(refusal);
+
+    const preflight = await resolvePluginInstallPreflight({
+      raw: spec,
+      opts: { force: true },
+      allowInstallPolicyWarningPrompt: false,
+    });
+    if (!preflight.ok) {
+      throw new Error(preflight.error);
+    }
+    expect(preflight.installMode).toBe("update");
+    const updated = await installPluginFromGitSpec({ spec, mode: preflight.installMode });
+    expect(updated).toMatchObject({ ok: true, targetDir: installed.targetDir, version: "2.0.0" });
+    expect(await git(installed.targetDir, "rev-parse", "HEAD")).toBe(nextCommit);
+  });
+
+  it("installs a missing update target and preserves it when a tracked update changes plugin id", async () => {
+    const installed = await installPluginFromGitSpec({
+      spec,
+      mode: "update",
+      expectedPluginId: "demo",
+    });
+    if (!installed.ok) {
+      throw new Error(installed.error);
+    }
+    await commitPlugin("renamed-demo", "2.0.0");
+    const updated = await installPluginFromGitSpec({
+      spec,
+      mode: "update",
+      expectedPluginId: "demo",
+    });
+    expect(updated).toMatchObject({
+      ok: false,
+      error: "plugin id mismatch: expected demo, got renamed-demo",
+    });
+    expect(await git(installed.targetDir, "rev-parse", "HEAD")).toBe(installed.git.commit);
+  });
+});

--- a/src/plugins/git-install.test.ts
+++ b/src/plugins/git-install.test.ts
@@ -10,6 +10,10 @@ import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { DiagnosticSecurityEvent } from "../infra/diagnostic-events.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import {
   requestDeferredPluginInstall,
   resolvePluginInstallTransaction,
 } from "./install-transaction.js";
@@ -157,7 +161,7 @@ describe("isImmutableGitCommitRef", () => {
 });
 
 describe("installPluginFromGitSpec", () => {
-  const tempDirs: string[] = [];
+  let state: OpenClawTestState;
   const trackedTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
   beforeEach(async () => {
@@ -165,20 +169,14 @@ describe("installPluginFromGitSpec", () => {
     installPluginFromInstalledPackageDirMock.mockReset();
     preflightPluginGitInstallPolicyMock.mockReset();
     preflightPluginGitInstallPolicyMock.mockResolvedValue(null);
-    const globalConfigRoot = await fs.mkdtemp(
-      path.join(os.tmpdir(), "openclaw-git-install-npmrc-"),
-    );
-    tempDirs.push(globalConfigRoot);
-    const globalConfig = path.join(globalConfigRoot, "global-npmrc");
-    await fs.writeFile(globalConfig, "", "utf8");
+    state = await createOpenClawTestState({ label: "git-install" });
+    const globalConfig = await state.writeText("global-npmrc", "");
     vi.stubEnv("NPM_CONFIG_GLOBALCONFIG", globalConfig);
   });
 
   afterEach(async () => {
     vi.unstubAllEnvs();
-    await Promise.all(
-      tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
-    );
+    await state.cleanup();
   });
 
   it("rejects option-leading clone sources before invoking git", async () => {

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -27,6 +27,7 @@ import {
   type InstallSafetyOverrides,
   type InstallSecurityScanResult,
 } from "./install-security-scan.js";
+import { ensureInstallTargetAvailableForMode, loadPluginInstallRuntime } from "./install-shared.js";
 import {
   attachPluginInstallTransaction,
   isPluginInstallCommitDeferred,
@@ -421,6 +422,14 @@ export async function installPluginFromGitSpec(
   const persistentRepoDir = resolveGitInstallRepoDir({ gitDir: params.gitDir, source: parsed });
   const effectiveMode =
     params.mode === "update" && (await pathExists(persistentRepoDir)) ? "update" : "install";
+  const availability = await ensureInstallTargetAvailableForMode({
+    runtime: await loadPluginInstallRuntime(),
+    targetPath: persistentRepoDir,
+    mode: effectiveMode,
+  });
+  if (!availability.ok) {
+    return availability;
+  }
   const stagingRepoDir = params.dryRun ? undefined : persistentRepoDir;
   return await withGitStagingDir(stagingRepoDir, async (tmpDir) => {
     const repoDir = path.join(tmpDir, "repo");


### PR DESCRIPTION
> **REVIEW REQUIRED — fail-closed install-path change (a previously accepted reinstall becomes an explicit error; the old behavior is stable-shipped). Prepared by the auto-QA campaign; draft pending maintainer review.**

## What Problem This Solves

`openclaw plugins install` from a Git source silently **overwrote an existing managed checkout** — deleting local files in it — because the Git install owner never checked target availability: the managed path is keyed by normalized source/ref (`src/plugins/git-install.ts:251`), immediate publication atomically replaced the old checkout, and deferred publication independently flipped to update mode whenever the target existed. The npm and directory/archive install owners both refuse this exact situation via `ensureInstallTargetAvailableForMode` (`install-managed-npm.ts:136`, `install-shared.ts:408`); Git was the divergent sibling. (Audit finding R16. The audit's second claim — durable install-record corruption on manifest-id change — was **refuted** at this base: discovery marks multi-owner paths ambiguous and persistence rejects them pre-commit, verified against the compensation suite.)

## Why This Change Was Made

The existing canonical guard is invoked at the Git owner immediately after target/mode resolution — before staging, cloning, npm work, policy/consent callbacks, and publication — producing the same `plugin already exists: <target> (delete it first)` error as the siblings. **+9 production lines** (import, invocation, failure propagation); no new policy, fallback, or persistence path; update/force/missing-target/expected-id/deferred-rollback semantics unchanged. A 13-row behavior matrix (fresh, reinstall same id, changed manifest id, omitted mode, dry-runs, updates, `--force` both ways, non-interactive, different source/ref) is in the worker report, each row backed by a real-Git regression or source audit. Deep-context review confirmed owner and shape ("the installed-package validator cannot own this refusal"; no net-neutral rewrite exists that doesn't hide the missing precondition) and added a docs clarification on `--force` identity limits.

**Compat impact for the reviewer:** interactive users and direct installer callers who previously "reinstalled" over an existing checkout must now choose a tracked update, explicit force, or removal — `docs/cli/plugins.md` documents the routes. Non-interactive `--force` flows are unchanged (CLI preflight already selects update mode).

## User Impact

A Git plugin install can no longer silently destroy an existing checkout (including local modifications); the refusal names the recovery paths.

## Evidence

- Failing-first real-Git regressions (146-line new test file): immediate and deferred publication both overwrote at base (original commit, manifest, and a local marker file destroyed); post-fix both refuse early with the canonical message and preserve everything.
- Focused suites: 69 tests / 5 files (git-install, git-install-target, install-shared, management-service compensation, CLI preflight); `pnpm docs:list`, oxfmt, `git diff --check` pass; standalone lint + all eight tail guards pass.
- Full `check-changed` blocked **environmentally** (shared worktree node_modules lacks `@types/jsdom` for an unrelated UI shard; Testbox sync timed out) — exact-head CI on ready is the authoritative gate; no classifier was suppressed.
- Codex autoreview clean; deep-context review verdict "correct for the existing managed-install lifecycle, keep it."
