### PR TITLE
fix(skills): record explicit selections for foreground repair

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { consumeRunSkillUsage, hasRunWorkspaceSkillUsage } from "../../skills/runtime/run-usage.js";
+import { createCanonicalFixtureSkill } from "../../skills/test-support/test-helpers.js";
 import { createTestAdmittedRunContext } from "../admitted-run-context.test-support.js";
 import {
   createEmbeddedRunReplayState,
@@ -123,9 +125,73 @@ function makeDispatchInput(
 
 describe("embedded run retry dispatch", () => {
   beforeEach(() => {
+    consumeRunSkillUsage("run-1");
     mocks.runAttempt.mockReset().mockResolvedValue({ terminal: { kind: "ok" } });
     mocks.settleRequesterAfterSessionSpawns.mockReset();
   });
+
+  it.each(["openclaw", "codex", "third-party"])(
+    "records only snapshot-matched explicit skill selections for the admitted %s run",
+    async (agentHarnessId) => {
+      const skillFile = "/tmp/workspace/skills/release/SKILL.md";
+      const bundledSkillFile = "/tmp/bundled/skills/lint/SKILL.md";
+      const input = makeDispatchInput({}, createEmbeddedRunReplayState());
+      input.runtime.agentHarnessId = agentHarnessId;
+      input.params.explicitSkillSelections = [
+        { name: "release_alias", path: skillFile },
+        { name: "spoofed_workspace", path: bundledSkillFile },
+        { name: "unmatched", path: "/tmp/workspace/skills/unmatched/SKILL.md" },
+      ];
+      input.params.skillsSnapshot = {
+        prompt: "",
+        skills: [],
+        resolvedSkills: [
+          createCanonicalFixtureSkill({
+            name: "release",
+            description: "Release safely",
+            filePath: skillFile,
+            baseDir: "/tmp/workspace/skills/release",
+            source: "workspace",
+          }),
+          createCanonicalFixtureSkill({
+            name: "lint",
+            description: "Lint safely",
+            filePath: bundledSkillFile,
+            baseDir: "/tmp/bundled/skills/lint",
+            source: "bundled",
+          }),
+        ],
+      };
+
+      await dispatchEmbeddedRunAttempt(input);
+      await dispatchEmbeddedRunAttempt(input);
+
+      expect(hasRunWorkspaceSkillUsage({ runId: "run-1", name: "release", skillFile })).toBe(true);
+      expect(
+        hasRunWorkspaceSkillUsage({
+          runId: "run-1",
+          name: "lint",
+          skillFile: bundledSkillFile,
+        }),
+      ).toBe(false);
+      expect(
+        hasRunWorkspaceSkillUsage({
+          runId: "run-1",
+          name: "unmatched",
+          skillFile: "/tmp/workspace/skills/unmatched/SKILL.md",
+        }),
+      ).toBe(false);
+      expect(consumeRunSkillUsage("run-1")).toEqual([
+        { name: "release", source: "workspace", activation: "command", skillFile },
+        {
+          name: "lint",
+          source: "bundled",
+          activation: "command",
+          skillFile: bundledSkillFile,
+        },
+      ]);
+    },
+  );
 
   it("preserves caller-owned turn facts and unsafe replay state on the next attempt", async () => {
     const sessionManager = { owner: "caller" };

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -1,4 +1,5 @@
 import { getGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
+import { recordExplicitSkillSelectionsForRun } from "../../../skills/runtime/run-usage.js";
 import { createAgentHarnessTaskRuntimeScope } from "../../../tasks/agent-harness-task-runtime-scope.js";
 import type { ToolOutcomeObserver } from "../../agent-tools.before-tool-call.js";
 import type { AuthProfileStore } from "../../auth-profiles.js";
@@ -533,9 +534,14 @@ export async function dispatchEmbeddedRunAttempt(input: {
     turnSourceAccountId: params.agentAccountId,
     turnSourceThreadId: params.currentThreadTs,
   });
-  const rawAttempt = await withGatewayToolCallerIdentity(callerIdentity, () =>
-    runEmbeddedAttemptWithBackend(attemptParams),
-  )
+  const rawAttempt = await withGatewayToolCallerIdentity(callerIdentity, () => {
+    recordExplicitSkillSelectionsForRun({
+      runId: attemptParams.runId,
+      selections: attemptParams.explicitSkillSelections,
+      skillsSnapshot: attemptParams.skillsSnapshot,
+    });
+    return runEmbeddedAttemptWithBackend(attemptParams);
+  })
     .catch((err: unknown): never => {
       throw control.getPostCompactionAbortError() ?? err;
     })

--- a/src/skills/runtime/run-usage.test.ts
+++ b/src/skills/runtime/run-usage.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempDir } from "../../test-utils/temp-dir.js";
+import { buildWorkspaceSkillCommandSpecs } from "../discovery/command-specs.js";
+import { loadWorkspaceSkills } from "../loading/workspace-skill-loader.js";
+import { buildSkillSnapshot } from "../loading/workspace-skill-prompt.js";
+import { writeSkill } from "../test-support/e2e-test-helpers.js";
+import {
+  consumeRunSkillUsage,
+  hasRunWorkspaceSkillUsage,
+  recordExplicitSkillSelectionsForRun,
+} from "./run-usage.js";
+
+describe("explicit run skill usage", () => {
+  it.runIf(process.platform !== "win32")(
+    "matches a canonical selection to an allowed workspace symlink snapshot",
+    async () => {
+      await withTempDir("openclaw-run-skill-usage-", async (rootDir) => {
+        const workspacePath = path.join(rootDir, "workspace");
+        await fs.mkdir(workspacePath, { recursive: true });
+        const workspaceDir = await fs.realpath(workspacePath);
+        const targetRoot = path.join(rootDir, "allowed-targets");
+        const targetSkillDir = path.join(targetRoot, "release");
+        const unrelatedTargetSkillDir = path.join(targetRoot, "unrelated");
+        const linkedSkillDir = path.join(workspaceDir, "skills", "release");
+        const unrelatedLinkedSkillDir = path.join(workspaceDir, "skills", "unrelated");
+        await writeSkill({
+          dir: targetSkillDir,
+          name: "release",
+          description: "Release safely",
+        });
+        await writeSkill({
+          dir: unrelatedTargetSkillDir,
+          name: "unrelated",
+          description: "Unrelated skill",
+        });
+        await fs.mkdir(path.dirname(linkedSkillDir), { recursive: true });
+        await fs.symlink(targetSkillDir, linkedSkillDir, "dir");
+        await fs.symlink(unrelatedTargetSkillDir, unrelatedLinkedSkillDir, "dir");
+        const config = { skills: { load: { allowSymlinkTargets: [targetRoot] } } };
+        const entries = loadWorkspaceSkills(workspaceDir, {
+          config,
+          managedSkillsDir: path.join(rootDir, "managed"),
+          bundledSkillsDir: "",
+          pluginSkillsDir: path.join(rootDir, "plugins"),
+        });
+        const snapshot = buildSkillSnapshot(workspaceDir, { config, entries });
+        const selection = buildWorkspaceSkillCommandSpecs(workspaceDir, {
+          config,
+          entries,
+        }).find((command) => command.skillName === "release");
+        const snapshotSkillFile = path.join(linkedSkillDir, "SKILL.md");
+        const unrelatedSkillFile = path.join(unrelatedLinkedSkillDir, "SKILL.md");
+        const snapshotSkill = snapshot.resolvedSkills?.find((skill) => skill.name === "release");
+        const runId = "allowed-symlink-run";
+
+        expect(selection?.skillFile).toBe(await fs.realpath(snapshotSkillFile));
+        expect(snapshotSkill?.filePath).toBe(snapshotSkillFile);
+
+        recordExplicitSkillSelectionsForRun({
+          runId,
+          selections: selection?.skillFile
+            ? [{ name: selection.name, path: selection.skillFile }]
+            : [],
+          skillsSnapshot: snapshot,
+        });
+
+        expect(
+          hasRunWorkspaceSkillUsage({ runId, name: "release", skillFile: snapshotSkillFile }),
+        ).toBe(true);
+        expect(
+          hasRunWorkspaceSkillUsage({
+            runId,
+            name: "unrelated",
+            skillFile: unrelatedSkillFile,
+          }),
+        ).toBe(false);
+        consumeRunSkillUsage(runId);
+      });
+    },
+  );
+});

--- a/src/skills/runtime/run-usage.ts
+++ b/src/skills/runtime/run-usage.ts
@@ -1,5 +1,8 @@
+import path from "node:path";
+import { canonicalizePath } from "../../agents/utils/paths.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
-import type { SkillTelemetrySource } from "../types.js";
+import { resolveSkillTelemetrySource } from "../loading/source.js";
+import type { ExplicitSkillSelection, SkillSnapshot, SkillTelemetrySource } from "../types.js";
 
 const MAX_TRACKED_SKILL_USAGE_RUNS = 1024;
 
@@ -11,6 +14,15 @@ export type RunSkillUsage = Readonly<{
 }>;
 
 const skillUsageByRun = new Map<string, Map<string, RunSkillUsage>>();
+
+function comparableSkillPath(value: string): string | undefined {
+  const trimmed = value.trim();
+  if (!path.isAbsolute(trimmed)) {
+    return undefined;
+  }
+  const resolved = canonicalizePath(path.resolve(trimmed));
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
 
 /** Records the skills the foreground run demonstrably invoked or read. */
 export function recordRunSkillUsage(params: RunSkillUsage & { runId?: string }): void {
@@ -28,6 +40,37 @@ export function recordRunSkillUsage(params: RunSkillUsage & { runId?: string }):
   usage.set(`${record.source}\u0000${record.name}\u0000${record.activation}`, record);
   skillUsageByRun.set(runId, usage);
   pruneMapToMaxSize(skillUsageByRun, MAX_TRACKED_SKILL_USAGE_RUNS);
+}
+
+/** Records core-resolved explicit skill commands against the admitted run. */
+export function recordExplicitSkillSelectionsForRun(params: {
+  runId?: string;
+  selections?: readonly ExplicitSkillSelection[];
+  skillsSnapshot?: SkillSnapshot;
+}): void {
+  if (!params.runId || !params.selections?.length) {
+    return;
+  }
+  const skillsByPath = new Map(
+    (params.skillsSnapshot?.resolvedSkills ?? []).flatMap((skill) => {
+      const skillFile = comparableSkillPath(skill.filePath);
+      return skillFile ? [[skillFile, skill] as const] : [];
+    }),
+  );
+  for (const selection of params.selections) {
+    const selectedPath = comparableSkillPath(selection.path);
+    const skill = selectedPath ? skillsByPath.get(selectedPath) : undefined;
+    if (!skill) {
+      continue;
+    }
+    recordRunSkillUsage({
+      runId: params.runId,
+      name: skill.name,
+      source: resolveSkillTelemetrySource(skill),
+      activation: "command",
+      skillFile: skill.filePath,
+    });
+  }
 }
 
 /** Checks whether this run demonstrably used one writable workspace skill. */


### PR DESCRIPTION
Fixes #131162

## What Problem This Solves

OpenClaw resolves an explicit `/skill` or `$skill` reference and carries that exact selection into the admitted run, but it does not record the selection in the run-scoped usage ledger. Native Codex can therefore load and follow the selected workspace skill, then have a same-run foreground repair rejected as `skill was not used`.

## Why This Change Was Made

The shared admitted-run dispatch now records core-resolved explicit selections immediately before backend dispatch. A selection must match an absolute path in the frozen skill snapshot; core derives the canonical name and source from that snapshot.

The implementation preserves these boundaries:

- no public or plugin-harness receipt capability is added;
- plugins cannot mint repair authorization;
- unmatched and relative paths record nothing;
- bundled and other non-workspace skills remain ineligible for the workspace guard;
- caller-supplied names cannot override snapshot identity;
- retries are idempotent in the existing bounded per-run ledger;
- `skill_workshop read` remains non-authorizing;
- Workshop ownership and apply rules are unchanged.

The matcher uses the same realpath-aware `canonicalizePath` contract as the explicit-command producer. This matters for a supported workspace skill reached through a configured symlink: the producer emits the real path while the admitted snapshot retains the workspace's lexical symlink path.

## User Impact

Users can explicitly invoke a writable workspace skill and repair that exact skill in the same foreground run, including through native Codex. Attempting to repair an unselected skill remains blocked. The behavior is harness-independent because the trusted fact is OpenClaw's resolved explicit selection, not a plugin assertion.

## Evidence

Corrected head: `0f7557acd09eafcc33a38dc0b36c199573292f1d`, rebased onto upstream `b70945a58e69d5c48d27835239cc4cb02f1db2d7`.

### Regression provenance

The original core regression fails on clean `main`: the admitted explicit selection produces no usage receipt.

ClawSweeper's review identified a second supported-route regression in the first rewritten head. The command producer canonicalizes symlinks, but that head compared lexical paths only:

```text
Reviewed head a841f4085c71:
expected hasRunWorkspaceSkillUsage(...) to be true
received false
```

The corrected regression creates two real workspace directory symlinks whose targets are explicitly allowlisted outside the workspace root. It proves:

- the command producer emits the canonical target path;
- the frozen snapshot retains the lexical workspace symlink path;
- the selected symlinked skill receives a command receipt;
- the unrelated symlinked skill remains unauthorized.

The existing dispatch regression additionally proves snapshot-derived identity/source, unmatched denial, bundled-skill ineligibility, retry idempotence, and identical behavior for OpenClaw, Codex, and third-party harness identifiers.

### Inspectable native-Codex behavior proof

This was run on the corrected exact tree with a temporary OpenClaw config, state directory, SQLite store, workspace, and loopback Gateway. Both targets were created and applied through Skill Workshop. Only the existing Codex OAuth login was copied into the temporary agent auth store; no live OpenClaw config, workspace, session, transcript, database, or Gateway was used.

Positive real `chat.send`:

```text
message: $receipt-proof Follow the selected skill exactly.
runId: 131176-positive-20260828

native Codex tool: bash
command: sed -n '1,240p' <isolated>/workspace/skills/receipt-proof/SKILL.md
result: ... replace `PROOF_OLD` with `PROOF_NEW` through Skill Workshop ...

tool: skill_workshop
arguments: { action: prepare_patch, skill_name: receipt-proof,
             old_string: PROOF_OLD, new_string: PROOF_NEW }
result: Prepared patch context ... authorized old_string ... PROOF_OLD

tool: skill_workshop
arguments: { action: patch, skill_name: receipt-proof,
             old_string: PROOF_OLD, new_string: PROOF_NEW }
result: Repaired used skill receipt-proof through proposal receipt-proof-20260828-746e1c547e.

assistant: REPAIR_APPLIED
agent.wait: { status: ok }
filesystem: receipt-proof/SKILL.md contains PROOF_NEW
```

Negative real `chat.send`:

```text
selected: $receipt-proof
target: unused-proof
runId: 131176-negative-20260828

tool: skill_workshop
arguments: { action: read, skill_name: unused-proof }
result: ... Keep the marker `UNUSED_OLD` unchanged unless this skill is explicitly invoked.

tool: skill_workshop
arguments: { action: patch, skill_name: unused-proof,
             old_string: UNUSED_OLD, new_string: UNUSED_NEW }
result: skill "unused-proof" was not used in this run and cannot be repaired autonomously

assistant: skill "unused-proof" was not used in this run and cannot be repaired autonomously
agent.wait: { status: ok }
filesystem: unused-proof/SKILL.md still contains UNUSED_OLD
```

### Native Codex source contract

The required sibling Codex checkout was inspected directly at exact tag `rust-v0.150.1`:

- `codex-rs/skills/src/selection.rs` matches structured `{name,path}` selections against enabled skills by canonical identity or logical discovery path;
- `codex-rs/core/src/session/turn.rs` collects selected skills and injects their prompts into the turn;
- `codex-rs/app-server-protocol/src/protocol/v2/turn.rs` defines the structured skill input;
- OpenClaw's Codex adapter path-matches the enabled catalog before sending that structured selection.

### Scoped checks

```text
Test Files  7 passed (7)
Tests       91 passed (91)

Core production typecheck: passed
Touched-file type-aware oxlint: passed
Touched-file formatting: passed
git diff --check: passed
```

The focused suite covers the new symlink regression, admitted-run dispatch and retries, the Workshop foreground guard, skill path containment, and the native Codex explicit-selection adapter.

## AI assistance

AI-assisted. The author reviewed the final invariant, source ownership, diff, Codex source contract, failing/passing regressions, and isolated positive/negative runtime transcript.
