### PR TITLE
test(gateway): event-driven dispatch fixture replaces polling waits in dispatcher tests

### DIFF
--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.abort.test.ts
@@ -6,11 +6,14 @@ import {
   GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
 } from "../../../../packages/gateway-protocol/src/client-info.js";
+import { createDeferredCore } from "../../../shared/deferred.js";
 import { NodeRegistry } from "../../node-registry.js";
 import type { GatewayRequestOptions } from "../../server-methods/types.js";
 import type { GatewayWsClient } from "../ws-types.js";
-import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
-import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
+import {
+  createDispatchTestHarness,
+  createOperatorWsClient,
+} from "./authenticated-request-dispatch.test-support.js";
 
 const handleGatewayRequest = vi.hoisted(() => vi.fn());
 
@@ -30,6 +33,12 @@ afterEach(() => {
 
 function createPairedNode() {
   const frames: string[] = [];
+  let frameArrived = createDeferredCore();
+  const waitForFrameCount = async (count: number) => {
+    while (frames.length < count) {
+      await frameArrived.promise;
+    }
+  };
   const registry = new NodeRegistry();
   activeRegistries.add(registry);
   registry.register(
@@ -41,6 +50,8 @@ function createPairedNode() {
         send(frame: unknown) {
           if (typeof frame === "string") {
             frames.push(frame);
+            frameArrived.resolve();
+            frameArrived = createDeferredCore();
           }
         },
       },
@@ -66,49 +77,31 @@ function createPairedNode() {
     } as GatewayWsClient,
     { pairingIdentity: "paired-node-identity" },
   );
-  return { registry, frames };
+  return { registry, frames, waitForFrameCount };
 }
 
 function createDispatcher(
   socket: EventEmitter,
-  clientIdentity: Pick<GatewayWsClient["connect"]["client"], "id" | "mode"> = {
+  clientInfo: Pick<GatewayWsClient["connect"]["client"], "id" | "mode"> = {
     id: GATEWAY_CLIENT_IDS.CLI,
     mode: GATEWAY_CLIENT_MODES.CLI,
   },
 ) {
-  const client = {
-    socket: socket as unknown as WebSocket,
+  const client = createOperatorWsClient({
     connId: "operator-connection",
-    usesSharedGatewayAuth: false,
-    connect: {
-      minProtocol: 1,
-      maxProtocol: 1,
-      client: { ...clientIdentity, version: "1.0.0", platform: "linux" },
-      role: "operator",
-      scopes: ["operator.write"],
-    },
-  } as GatewayWsClient;
-  const dispatcher = createGatewayAuthenticatedRequestDispatcher({
-    handler: {
-      connId: client.connId,
-      extraHandlers: {},
-      buildRequestContext: () => ({}) as never,
-      send: vi.fn((_frame: unknown) => ({ kind: "sent" }) as const),
-      close: vi.fn(),
-      isClosed: () => false,
-      setCloseCause: vi.fn(),
-      logGateway: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    } as unknown as GatewayWsMessageHandlerParams,
-    isWebchatConnect: () => false,
+    socket,
+    clientInfo,
+    scopes: ["operator.write"],
   });
-  return { client, dispatcher };
+  const harness = createDispatchTestHarness({ connId: client.connId });
+  return { client, ...harness };
 }
 
 describe("authenticated WebSocket request cancellation", () => {
   it("forwards CLI socket closure to the actual first-party node cancel event", async () => {
     const socket = new EventEmitter();
-    const { registry, frames } = createPairedNode();
-    const { client, dispatcher } = createDispatcher(socket);
+    const { registry, frames, waitForFrameCount } = createPairedNode();
+    const { awaitResponseFrame, client, dispatcher } = createDispatcher(socket);
     handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
       const result = await registry.invoke({
         nodeId: "paired-node",
@@ -141,17 +134,19 @@ describe("authenticated WebSocket request cancellation", () => {
       },
       client,
     );
-    await vi.waitFor(() => expect(frames).toHaveLength(1));
+    await waitForFrameCount(1);
     expect(socket.listenerCount("close")).toBe(1);
 
     socket.emit("close", 1000, Buffer.alloc(0));
 
-    await vi.waitFor(() => expect(frames).toHaveLength(2));
+    await waitForFrameCount(2);
     const request = JSON.parse(frames[0] ?? "{}") as { payload?: { id?: string } };
     expect(JSON.parse(frames[1] ?? "{}")).toMatchObject({
       event: "node.invoke.cancel",
       payload: { invokeId: request.payload?.id, nodeId: "paired-node" },
     });
+    await awaitResponseFrame("paired-node-cli-inference");
+    // Listener removal is the dispatch finally block, a microtask after the response.
     await vi.waitFor(() => expect(socket.listenerCount("close")).toBe(0));
   });
 
@@ -159,14 +154,13 @@ describe("authenticated WebSocket request cancellation", () => {
     "keeps authenticated %s work alive after its socket disconnects",
     async (method) => {
       const socket = new EventEmitter();
-      const { client, dispatcher } = createDispatcher(socket);
-      let finish!: () => void;
-      const completion = new Promise<void>((resolve) => {
-        finish = resolve;
-      });
+      const { awaitResponseFrame, client, dispatcher } = createDispatcher(socket);
+      const invoked = createDeferredCore();
+      const completion = createDeferredCore();
       let completed = false;
       handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
-        await completion;
+        invoked.resolve();
+        await completion.promise;
         completed = true;
         options.respond(true, { ok: true });
       });
@@ -175,15 +169,17 @@ describe("authenticated WebSocket request cancellation", () => {
         { type: "req", id: "ordinary-request", method, params: {} },
         client,
       );
-      await vi.waitFor(() => expect(handleGatewayRequest).toHaveBeenCalledOnce());
+      await invoked.promise;
+      expect(handleGatewayRequest).toHaveBeenCalledOnce();
 
       expect(handleGatewayRequest.mock.calls[0]?.[0]).not.toHaveProperty("signal");
       expect(socket.listenerCount("close")).toBe(0);
       socket.emit("close", 1006, Buffer.alloc(0));
       expect(completed).toBe(false);
 
-      finish();
-      await vi.waitFor(() => expect(completed).toBe(true));
+      completion.resolve();
+      await awaitResponseFrame("ordinary-request");
+      expect(completed).toBe(true);
     },
   );
 
@@ -193,15 +189,17 @@ describe("authenticated WebSocket request cancellation", () => {
       id: GATEWAY_CLIENT_IDS.CONTROL_UI,
       mode: GATEWAY_CLIENT_MODES.UI,
     });
+    const invoked = createDeferredCore();
+    const abortObserved = createDeferredCore();
     let observedSignal: AbortSignal | undefined;
     handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
       observedSignal = options.signal;
-      await new Promise<void>((resolve) => {
-        options.signal?.addEventListener("abort", () => resolve(), { once: true });
-      });
+      options.signal?.addEventListener("abort", () => abortObserved.resolve(), { once: true });
+      invoked.resolve();
+      await abortObserved.promise;
     });
 
-    const request = dispatcher.dispatch(
+    await dispatcher.dispatch(
       {
         type: "req",
         id: "session-companion",
@@ -210,13 +208,16 @@ describe("authenticated WebSocket request cancellation", () => {
       },
       client,
     );
-    await vi.waitFor(() => expect(socket.listenerCount("close")).toBe(1));
+    // Emitting close before the handler registers its abort listener would leave
+    // the already-aborted signal unobserved; wait for the handler first.
+    await invoked.promise;
+    expect(socket.listenerCount("close")).toBe(1);
 
     socket.emit("close", 1000, Buffer.alloc(0));
 
-    await request;
+    await abortObserved.promise;
     expect(observedSignal?.aborted).toBe(true);
-    expect(socket.listenerCount("close")).toBe(0);
+    await vi.waitFor(() => expect(socket.listenerCount("close")).toBe(0));
   });
 
   it.each([
@@ -239,7 +240,7 @@ describe("authenticated WebSocket request cancellation", () => {
     "does not cancel an authenticated $label node invocation on socket close",
     async (identity) => {
       const socket = new EventEmitter();
-      const { registry, frames } = createPairedNode();
+      const { registry, frames, waitForFrameCount } = createPairedNode();
       const { client, dispatcher } = createDispatcher(socket, identity);
       handleGatewayRequest.mockImplementation(async (options: GatewayRequestOptions) => {
         const result = await registry.invoke({
@@ -264,7 +265,7 @@ describe("authenticated WebSocket request cancellation", () => {
         },
         client,
       );
-      await vi.waitFor(() => expect(frames).toHaveLength(1));
+      await waitForFrameCount(1);
       expect(handleGatewayRequest.mock.calls[0]?.[0]).not.toHaveProperty("signal");
       expect(socket.listenerCount("close")).toBe(0);
 

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.connection-liveness.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { WebSocket } from "ws";
+import { createDeferredCore } from "../../../shared/deferred.js";
 import { createGatewayConnectionState } from "../../server-connection-state.js";
 import type { GatewayRequestOptions } from "../../server-methods/types.js";
-import type { GatewayWsClient } from "../ws-types.js";
-import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
-import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
+import {
+  createDispatchTestHarness,
+  createOperatorWsClient,
+} from "./authenticated-request-dispatch.test-support.js";
 
 const runtime = vi.hoisted(() => ({ beforeHandler: vi.fn<() => Promise<void>>() }));
 
@@ -26,21 +27,6 @@ vi.mock("./authenticated-request-dispatch.server-methods.runtime.js", async () =
   };
 });
 
-function createClient(): GatewayWsClient {
-  return {
-    socket: {} as WebSocket,
-    connId: "late-subscription-connection",
-    usesSharedGatewayAuth: false,
-    connect: {
-      minProtocol: 1,
-      maxProtocol: 1,
-      client: { id: "gateway-client", version: "dev", platform: "test", mode: "backend" },
-      role: "operator",
-      scopes: ["operator.read"],
-    },
-  };
-}
-
 describe.sequential("authenticated request connection liveness", () => {
   beforeEach(() => {
     runtime.beforeHandler.mockReset();
@@ -60,66 +46,41 @@ describe.sequential("authenticated request connection liveness", () => {
         expect(state.sessionMessageSubscribers.get("agent:main:main")).toEqual(new Set()),
     },
   ])("rejects a late $method mutation after disconnect cleanup", async (testCase) => {
-    let releaseHandler!: () => void;
-    const held = new Promise<void>((resolve) => {
-      releaseHandler = resolve;
-    });
-    // dispatch() is fire-and-forget behind a lazy server-methods import, so the
-    // handler start and the response are awaited as events; a polling deadline
-    // here loses to a slow first module load and leaks the call into the
-    // sibling case.
-    let handlerStarted!: () => void;
-    const started = new Promise<void>((resolve) => {
-      handlerStarted = resolve;
-    });
+    const held = createDeferredCore();
+    const started = createDeferredCore();
     runtime.beforeHandler.mockImplementation(() => {
-      handlerStarted();
-      return held;
+      started.resolve();
+      return held.promise;
     });
     const state = createGatewayConnectionState({ cfg: {} });
-    const client = createClient();
+    const client = createOperatorWsClient({
+      connId: "late-subscription-connection",
+      scopes: ["operator.read"],
+    });
     state.clients.add(client);
-    let respondedWith!: (frame: unknown) => void;
-    const responded = new Promise<unknown>((resolve) => {
-      respondedWith = resolve;
-    });
-    const send = vi.fn((frame: unknown) => {
-      respondedWith(frame);
-      return { kind: "sent" } as const;
-    });
-    const context = {
-      getRuntimeConfig: () => ({}),
-      logGateway: { error: vi.fn() },
-      subscribeSessionEvents: state.sessionEventSubscribers.subscribe,
-      subscribeSessionMessageEvents: state.sessionMessageSubscribers.subscribe,
-    };
-    const dispatcher = createGatewayAuthenticatedRequestDispatcher({
-      handler: {
-        connId: client.connId,
-        extraHandlers: {},
-        buildRequestContext: () => context as never,
-        send,
-        close: vi.fn(),
-        isClosed: () => false,
-        setCloseCause: vi.fn(),
-        logGateway: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      } as unknown as GatewayWsMessageHandlerParams,
-      isWebchatConnect: () => false,
+    const harness = createDispatchTestHarness({
+      connId: client.connId,
+      buildRequestContext: () => ({
+        getRuntimeConfig: () => ({}),
+        logGateway: { error: vi.fn() },
+        subscribeSessionEvents: state.sessionEventSubscribers.subscribe,
+        subscribeSessionMessageEvents: state.sessionMessageSubscribers.subscribe,
+      }),
     });
 
-    await dispatcher.dispatch(
+    await harness.dispatcher.dispatch(
       { type: "req", id: testCase.method, method: testCase.method, params: testCase.params },
       client,
     );
-    await started;
+    await started.promise;
     expect(runtime.beforeHandler).toHaveBeenCalledOnce();
 
     state.clients.delete(client);
     state.sessionEventSubscribers.unsubscribe(client.connId);
     state.sessionMessageSubscribers.unsubscribeAll(client.connId);
-    releaseHandler();
+    held.resolve();
 
-    expect(await responded).toEqual(expect.objectContaining({ id: testCase.method, ok: true }));
+    expect(await harness.awaitResponseFrame(testCase.method)).toMatchObject({ ok: true });
     testCase.assertEmpty(state);
   });
 });

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.load-failure.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.load-failure.test.ts
@@ -1,8 +1,6 @@
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { GatewayWsClient } from "../ws-types.js";
-import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
 
 function moduleNotFoundError(filePath: string): Error {
   return Object.assign(new Error(`Cannot find module '${filePath}'`), {
@@ -31,56 +29,30 @@ describe("authenticated request dispatcher load failures", () => {
         throw error;
       },
     }));
-    const { createGatewayAuthenticatedRequestDispatcher } =
-      await import("./authenticated-request-dispatch.js");
-    const send = vi.fn((_frame: unknown) => ({ kind: "sent" }) as const);
-    const dispatcher = createGatewayAuthenticatedRequestDispatcher({
-      handler: {
-        connId: "stale-install-dispatch",
-        extraHandlers: {},
-        buildRequestContext: () => ({}) as never,
-        send,
-        close: vi.fn(),
-        isClosed: () => false,
-        setCloseCause: vi.fn(),
-        logGateway: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-      } as unknown as GatewayWsMessageHandlerParams,
-      isWebchatConnect: () => false,
-    });
-    const client = {
-      socket: {},
-      connId: "stale-install-dispatch",
-      usesSharedGatewayAuth: false,
-      connect: {
-        minProtocol: 1,
-        maxProtocol: 1,
-        client: { id: "gateway-client", version: "dev", platform: "test", mode: "backend" },
-        role: "operator",
-        scopes: ["operator.admin"],
-      },
-    } as GatewayWsClient;
+    // Imported after doMock so the harness binds a dispatcher whose lazy runtime
+    // load hits the mocked failing module.
+    const { createDispatchTestHarness, createOperatorWsClient } =
+      await import("./authenticated-request-dispatch.test-support.js");
+    const harness = createDispatchTestHarness({ connId: "stale-install-dispatch" });
+    const client = createOperatorWsClient({ connId: "stale-install-dispatch" });
 
-    await dispatcher.dispatch(
+    await harness.dispatcher.dispatch(
       { type: "req", id: "stale-install", method: "status", params: {} },
       client,
     );
 
-    await vi.waitFor(() => {
-      expect(send).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: "stale-install",
-          ok: false,
-          error: expect.objectContaining({
-            code: "UNAVAILABLE",
-            retryable: false,
-            message: expect.stringContaining("openclaw --profile r13 gateway restart"),
-            details: {
-              code: "STALE_INSTALL",
-              restartCommand: "openclaw --profile r13 gateway restart",
-            },
-          }),
-        }),
-      );
+    expect(await harness.awaitResponseFrame("stale-install")).toMatchObject({
+      id: "stale-install",
+      ok: false,
+      error: {
+        code: "UNAVAILABLE",
+        retryable: false,
+        message: expect.stringContaining("openclaw --profile r13 gateway restart"),
+        details: {
+          code: "STALE_INSTALL",
+          restartCommand: "openclaw --profile r13 gateway restart",
+        },
+      },
     });
   });
 });

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.server.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.server.test.ts
@@ -8,6 +8,7 @@ import {
   type DiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
 import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
+import { createDeferredCore, type Deferred } from "../../../shared/deferred.js";
 import type { AgentRuntimeIdentity } from "../../agent-runtime-identity-token.js";
 import {
   connectOk,
@@ -22,7 +23,10 @@ import {
   setTestPluginRegistry,
 } from "../../test-helpers.plugin-registry.js";
 import type { GatewayWsClient } from "../ws-types.js";
-import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
+import {
+  createDispatchTestHarness,
+  createOperatorWsClient,
+} from "./authenticated-request-dispatch.test-support.js";
 import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
 
 const TRACEPARENTS = {
@@ -33,23 +37,7 @@ const TRACEPARENTS = {
 installGatewayTestHooks({ scope: "suite" });
 
 function createClient(): GatewayWsClient {
-  return {
-    socket: {} as WebSocket,
-    connect: {
-      minProtocol: 1,
-      maxProtocol: 1,
-      client: {
-        id: "gateway-client",
-        version: "dev",
-        platform: "test",
-        mode: "backend",
-      },
-      role: "operator",
-      scopes: ["operator.admin"],
-    },
-    connId: "conn-trace-test",
-    usesSharedGatewayAuth: false,
-  };
+  return createOperatorWsClient({ connId: "conn-trace-test" });
 }
 
 function createTestAgentRuntimeIdentity(runId: string): AgentRuntimeIdentity {
@@ -72,29 +60,11 @@ function createDispatcher(
   handler: NonNullable<GatewayWsMessageHandlerParams["extraHandlers"][string]>,
   context: Record<string, unknown> = {},
 ) {
-  const send = vi.fn((_frame: unknown) => ({ kind: "sent" }) as const);
-  const close = vi.fn();
-  const setCloseCause = vi.fn();
-  const logGateway = {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  };
-  const dispatcher = createGatewayAuthenticatedRequestDispatcher({
-    handler: {
-      connId: "conn-trace-test",
-      extraHandlers: { "test.trace": handler },
-      buildRequestContext: () => context as never,
-      send,
-      close,
-      isClosed: () => false,
-      setCloseCause,
-      logGateway,
-    } as unknown as GatewayWsMessageHandlerParams,
-    isWebchatConnect: () => false,
+  return createDispatchTestHarness({
+    connId: "conn-trace-test",
+    extraHandlers: { "test.trace": handler },
+    buildRequestContext: () => context,
   });
-  return { close, dispatcher, logGateway, send, setCloseCause };
 }
 
 async function dispatchInFreshMessageScope(
@@ -176,14 +146,14 @@ describe("authenticated WebSocket request trace dispatch", () => {
 
   it("continues a valid upstream trace as a child context", async () => {
     let observed: DiagnosticTraceContext | undefined;
+    const handled = createDeferredCore();
     const { dispatcher } = createDispatcher(() => {
       observed = getActiveDiagnosticTraceContext();
+      handled.resolve();
     });
 
     await dispatchInFreshMessageScope(dispatcher, createClient(), "first", TRACEPARENTS.first);
-    await vi.waitFor(() => {
-      expect(observed).toBeDefined();
-    });
+    await handled.promise;
 
     expect(observed).toMatchObject({
       traceId: "11111111111111111111111111111111",
@@ -222,16 +192,15 @@ describe("authenticated WebSocket request trace dispatch", () => {
 
   it("revalidates delegated authority before returning a post-await result", async () => {
     let authorityActive = true;
-    let releaseHandler: (() => void) | undefined;
-    const held = new Promise<void>((resolve) => {
-      releaseHandler = resolve;
-    });
+    const invoked = createDeferredCore();
+    const held = createDeferredCore();
     const handler = vi.fn(async ({ respond }) => {
-      await held;
+      invoked.resolve();
+      await held.promise;
       respond(true, { exposed: true }, undefined);
     });
     const validateAgentRuntimeApprovalAuthority = vi.fn(() => authorityActive);
-    const { close, dispatcher, send } = createDispatcher(handler, {
+    const { awaitResponseFrame, close, dispatcher, send } = createDispatcher(handler, {
       validateAgentRuntimeApprovalAuthority,
     });
     const client = createClient();
@@ -240,20 +209,16 @@ describe("authenticated WebSocket request trace dispatch", () => {
     };
 
     await dispatchInFreshMessageScope(dispatcher, client, "closed-before-result");
-    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+    await invoked.promise;
+    expect(handler).toHaveBeenCalledOnce();
     authorityActive = false;
-    releaseHandler?.();
+    held.resolve();
 
-    await vi.waitFor(() => {
-      expect(send).toHaveBeenCalledWith(
-        expect.objectContaining({
-          id: "closed-before-result",
-          ok: false,
-          error: expect.objectContaining({
-            message: "agent runtime authority is no longer active",
-          }),
-        }),
-      );
+    expect(await awaitResponseFrame("closed-before-result")).toMatchObject({
+      ok: false,
+      error: expect.objectContaining({
+        message: "agent runtime authority is no longer active",
+      }),
     });
     expect(send).not.toHaveBeenCalledWith(
       expect.objectContaining({ id: "closed-before-result", ok: true }),
@@ -264,7 +229,7 @@ describe("authenticated WebSocket request trace dispatch", () => {
   it("keeps handler failure logging and responses inside the request trace", async () => {
     let loggedContext: DiagnosticTraceContext | undefined;
     let responseContext: DiagnosticTraceContext | undefined;
-    const { dispatcher, logGateway, send } = createDispatcher(async () => {
+    const { awaitResponseFrame, dispatcher, logGateway, send } = createDispatcher(async () => {
       throw new Error("expected trace failure");
     });
     logGateway.error.mockImplementation(() => {
@@ -276,10 +241,8 @@ describe("authenticated WebSocket request trace dispatch", () => {
     });
 
     await dispatchInFreshMessageScope(dispatcher, createClient(), "failure", TRACEPARENTS.first);
-    await vi.waitFor(() => {
-      expect(logGateway.error).toHaveBeenCalled();
-      expect(send).toHaveBeenCalled();
-    });
+    await awaitResponseFrame("failure");
+    expect(logGateway.error).toHaveBeenCalled();
 
     expect(loggedContext).toMatchObject({
       traceId: "11111111111111111111111111111111",
@@ -291,24 +254,23 @@ describe("authenticated WebSocket request trace dispatch", () => {
 
   it("retains fresh roots for missing and malformed traceparent values", async () => {
     const observed = new Map<string, DiagnosticTraceContext | undefined>();
+    let handled = createDeferredCore();
     const { dispatcher } = createDispatcher(({ req }) => {
       observed.set(req.id, getActiveDiagnosticTraceContext());
+      handled.resolve();
     });
     const client = createClient();
 
     await dispatchInFreshMessageScope(dispatcher, client, "missing");
-    await vi.waitFor(() => {
-      expect(observed.has("missing")).toBe(true);
-    });
+    await handled.promise;
+    handled = createDeferredCore();
     await dispatchInFreshMessageScope(
       dispatcher,
       client,
       "malformed",
       "00-11111111111111111111111111111111-1111111111111111-zz",
     );
-    await vi.waitFor(() => {
-      expect(observed.has("malformed")).toBe(true);
-    });
+    await handled.promise;
 
     const missing = observed.get("missing");
     const malformed = observed.get("malformed");
@@ -320,10 +282,9 @@ describe("authenticated WebSocket request trace dispatch", () => {
   });
 
   it("isolates concurrent request contexts on one connection", async () => {
-    let releaseRequests: (() => void) | undefined;
-    const requestBarrier = new Promise<void>((resolve) => {
-      releaseRequests = resolve;
-    });
+    const requestBarrier = createDeferredCore();
+    const bothObserved = createDeferredCore();
+    const bothCompleted = createDeferredCore();
     const observed = new Map<
       string,
       { before: DiagnosticTraceContext | undefined; after?: DiagnosticTraceContext }
@@ -334,8 +295,14 @@ describe("authenticated WebSocket request trace dispatch", () => {
         after?: DiagnosticTraceContext;
       } = { before: getActiveDiagnosticTraceContext() };
       observed.set(req.id, observation);
-      await requestBarrier;
+      if (observed.size === 2) {
+        bothObserved.resolve();
+      }
+      await requestBarrier.promise;
       observation.after = getActiveDiagnosticTraceContext();
+      if ([...observed.values()].every((entry) => entry.after)) {
+        bothCompleted.resolve();
+      }
     });
     const client = createClient();
 
@@ -343,13 +310,9 @@ describe("authenticated WebSocket request trace dispatch", () => {
       dispatchInFreshMessageScope(dispatcher, client, "first", TRACEPARENTS.first),
       dispatchInFreshMessageScope(dispatcher, client, "second", TRACEPARENTS.second),
     ]);
-    await vi.waitFor(() => {
-      expect(observed.size).toBe(2);
-    });
-    releaseRequests?.();
-    await vi.waitFor(() => {
-      expect([...observed.values()].every((entry) => entry.after)).toBe(true);
-    });
+    await bothObserved.promise;
+    requestBarrier.resolve();
+    await bothCompleted.promise;
 
     expect(observed.get("first")?.before?.traceId).toBe("11111111111111111111111111111111");
     expect(observed.get("second")?.before?.traceId).toBe("22222222222222222222222222222222");
@@ -362,8 +325,8 @@ describe("authenticated WebSocket request trace dispatch", () => {
       string,
       { before: DiagnosticTraceContext | undefined; after?: DiagnosticTraceContext }
     >();
-    let requestBarrier: Promise<void> | undefined;
-    let releaseRequests: (() => void) | undefined;
+    const bothConcurrentObserved = createDeferredCore();
+    let requestBarrier: Deferred | undefined;
     const registry = createEmptyPluginRegistry();
     registry.gatewayHandlers["test.trace"] = async ({ req, respond }) => {
       const observation: {
@@ -371,7 +334,10 @@ describe("authenticated WebSocket request trace dispatch", () => {
         after?: DiagnosticTraceContext;
       } = { before: getActiveDiagnosticTraceContext() };
       observed.set(req.id, observation);
-      await requestBarrier;
+      if (observed.has("concurrent-first") && observed.has("concurrent-second")) {
+        bothConcurrentObserved.resolve();
+      }
+      await requestBarrier?.promise;
       observation.after = getActiveDiagnosticTraceContext();
       respond(true, { traced: true });
     };
@@ -410,16 +376,11 @@ describe("authenticated WebSocket request trace dispatch", () => {
       expect(malformed?.traceId).not.toBe("11111111111111111111111111111111");
       expect(malformed?.traceId).not.toBe(afterConnect?.traceId);
 
-      requestBarrier = new Promise<void>((resolve) => {
-        releaseRequests = resolve;
-      });
+      requestBarrier = createDeferredCore();
       const first = sendTraceRequest(ws, "concurrent-first", TRACEPARENTS.first);
       const second = sendTraceRequest(ws, "concurrent-second", TRACEPARENTS.second);
-      await vi.waitFor(() => {
-        expect(observed.has("concurrent-first")).toBe(true);
-        expect(observed.has("concurrent-second")).toBe(true);
-      });
-      releaseRequests?.();
+      await bothConcurrentObserved.promise;
+      requestBarrier.resolve();
       await expect(Promise.all([first, second])).resolves.toMatchObject([
         { ok: true },
         { ok: true },

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.test-support.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.test-support.ts
@@ -1,0 +1,99 @@
+// Shared fixture for tests driving createGatewayAuthenticatedRequestDispatcher.
+import { vi } from "vitest";
+import type { WebSocket } from "ws";
+import { createDeferredCore, type Deferred } from "../../../shared/deferred.js";
+import type { GatewayWsClient } from "../ws-types.js";
+import { createGatewayAuthenticatedRequestDispatcher } from "./authenticated-request-dispatch.js";
+import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
+
+export type GatewayTestResponseFrame = {
+  type: "res";
+  id: string;
+  ok: boolean;
+  payload?: unknown;
+  error?: { code?: string; message?: string } & Record<string, unknown>;
+};
+
+export function createOperatorWsClient(
+  overrides: {
+    connId?: string;
+    socket?: unknown;
+    clientInfo?: { id: string; mode: string };
+    scopes?: string[];
+  } = {},
+): GatewayWsClient {
+  return {
+    socket: (overrides.socket ?? {}) as WebSocket,
+    connId: overrides.connId ?? "dispatch-test-connection",
+    usesSharedGatewayAuth: false,
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: {
+        id: overrides.clientInfo?.id ?? "gateway-client",
+        version: "dev",
+        platform: "test",
+        mode: overrides.clientInfo?.mode ?? "backend",
+      },
+      role: "operator",
+      scopes: overrides.scopes ?? ["operator.admin"],
+    },
+  } as GatewayWsClient;
+}
+
+export function createDispatchTestHarness(
+  options: {
+    connId?: string;
+    extraHandlers?: GatewayWsMessageHandlerParams["extraHandlers"];
+    buildRequestContext?: () => unknown;
+  } = {},
+) {
+  const sentResponses: GatewayTestResponseFrame[] = [];
+  const responseWaiters: { id: string; deferred: Deferred<GatewayTestResponseFrame> }[] = [];
+  const send = vi.fn((_frame: unknown) => ({ kind: "sent" }) as const);
+  // Recording lives outside the spy so tests may replace send's implementation
+  // (to observe call context) without silently breaking awaitResponseFrame.
+  const sendForDispatcher = (frame: unknown) => {
+    const response = frame as GatewayTestResponseFrame;
+    if (response?.type === "res") {
+      sentResponses.push(response);
+      for (let index = responseWaiters.length - 1; index >= 0; index -= 1) {
+        const waiter = responseWaiters[index];
+        if (waiter && waiter.id === response.id) {
+          responseWaiters.splice(index, 1);
+          waiter.deferred.resolve(response);
+        }
+      }
+    }
+    return send(frame) ?? ({ kind: "sent" } as const);
+  };
+  const close = vi.fn();
+  const setCloseCause = vi.fn();
+  const logGateway = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  const dispatcher = createGatewayAuthenticatedRequestDispatcher({
+    handler: {
+      connId: options.connId ?? "dispatch-test-connection",
+      extraHandlers: options.extraHandlers ?? {},
+      buildRequestContext: () => (options.buildRequestContext?.() ?? {}) as never,
+      send: sendForDispatcher,
+      close,
+      isClosed: () => false,
+      setCloseCause,
+      logGateway,
+    } as unknown as GatewayWsMessageHandlerParams,
+    isWebchatConnect: () => false,
+  });
+  // dispatch() is fire-and-forget behind a lazy server-methods import, so waiting
+  // on the response event keeps tests off polling deadlines that lose to a slow
+  // first module load and leak in-flight dispatches into sibling cases.
+  const awaitResponseFrame = (id: string): Promise<GatewayTestResponseFrame> => {
+    const already = sentResponses.find((frame) => frame.id === id);
+    if (already) {
+      return Promise.resolve(already);
+    }
+    const deferred = createDeferredCore<GatewayTestResponseFrame>();
+    responseWaiters.push({ id, deferred });
+    return deferred.promise;
+  };
+  return { awaitResponseFrame, close, dispatcher, logGateway, send, setCloseCause };
+}


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #131076. That PR fixed one CI shard flake in the gateway connection-liveness test, but every test driving `createGatewayAuthenticatedRequestDispatcher` had the same latent race: the dispatcher fires requests without awaiting them behind the lazy `loadGatewayServerMethods()` dynamic import, while the tests bounded that unbounded first module load with `vi.waitFor`'s 1s polling deadline. The worst exposure was `authenticated-request-dispatch.server.test.ts`, which loads the real server-methods module graph (the heaviest first-load of all four files). The abort suite additionally had a latent hang: emitting socket close before the handler registered its abort listener would leave an already-aborted signal unobserved.

## Why This Change Was Made

Rather than patching each file's synchronization separately, fixture ownership moves to a shared colocated harness, `authenticated-request-dispatch.test-support.ts`: it owns the dispatcher/handler-params/client scaffold that all four files duplicated, and exposes `awaitResponseFrame(id)` — an event promise resolved when the dispatcher actually sends the response — so no test polls a deadline against the fire-and-forget boundary. Response recording lives outside the `send` spy, so tests that replace `send`'s implementation (the trace-context test) keep `awaitResponseFrame` working. Handler starts synchronize on `createDeferred` signals resolved inside the handler mocks; the node-registry fake socket resolves frame-arrival events. The two remaining `vi.waitFor` calls (in the abort suite) wait only for post-response microtask settling (the dispatch `finally` removing the close listener), which is bounded work, not the unbounded-load race.

## User Impact

None at runtime; test-only. Removes the remaining false-negative flake class from the gateway shard and deduplicates four copies of dispatcher test scaffolding.

## Evidence

- All four files pass: 19/19 tests, including after rebase onto current main.
- Shard-load condition proof: injecting a 1.5s delay into the mocked lazy server-methods load (the condition that produced the 0-then-2 failure signature in run 33061841674 pre-#131076) — the refactored liveness and abort suites pass 10/10 under the same delay.
- Live proof on a real gateway process: built dist, started `openclaw gateway run` on an isolated `OPENCLAW_STATE_DIR` (port 19477, token auth), drove the real `GatewayClient` over WS: `sessions.subscribe` → `{subscribed:true}` and `sessions.messages.subscribe` → `{subscribed:true, key:"agent:main:main"}` on a first connection, abrupt disconnect, then a fresh connection resubscribed successfully and `health` returned ok — the real handlers and disconnect-cleanup path the unit mocks stand in for. Gateway log shows clean startup, no errors during the probe window, clean shutdown.
- `check-changed` plan green (knip dead-export scans, core-test typecheck shards, lint); oxfmt clean; Codex autoreview on the diff: no findings.

Production LOC: +0/-0 | Tests: +251/-257 (net -6; new 99-line shared fixture absorbed by deleted per-file scaffolding)
