### PR TITLE
refactor(imap): consume the core identifier-authentication scale

### DIFF
--- a/docs/automation/imap.md
+++ b/docs/automation/imap.md
@@ -87,11 +87,22 @@ The plugin checks the parsed `From` address against `allowedSenders` before any 
 
 | Evidence                                                                 | Recorded strength | Accepted by default                                                |
 | ------------------------------------------------------------------------ | ----------------- | ------------------------------------------------------------------ |
-| Client-side DKIM/DMARC verification returns `dmarc=pass`                 | `verified`        | Yes                                                                |
+| Local `mailauth` verification returns aligned `dmarc=pass`               | `verified`        | Yes                                                                |
 | A configured, trusted Authentication-Results server reports `dmarc=pass` | `asserted`        | No; requires `acceptTrustedAuthservId: true` and `min: "asserted"` |
 | SPF alone passes or an untrusted server asserts a result                 | `unverified`      | No; requires `min: "unverified"`                                   |
-| No usable authentication evidence                                        | `mutable`         | No; requires `min: "mutable"`                                      |
+| Unproven ownership, including no evidence or a DMARC `temperror` result  | `unverified`      | No; requires `min: "unverified"` or lower                          |
 | A matching sender-specific plus-address token                            | `mutable`         | Yes, only for the named allowlisted sender                         |
+
+The shared identifier-authentication ladder is `verified > asserted > unverified > mutable`.
+`mutable` denotes a changeable or shared alias and is never produced by the IMAP
+authentication mapper. The gate still records it for the separate token path and
+early rejections before authentication. `min: "mutable"` remains valid and accepts
+any classified strength; it does not bypass the sender allowlist or freshness checks.
+
+The default minimum remains `verified`; `asserted` and `verified` admission are
+unchanged. An explicit `min: "unverified"` now admits no-evidence mail and DMARC
+`temperror` results, which previously required `min: "mutable"`. Authenticator
+exceptions still cause retries unless an explicitly trusted header satisfies the floor.
 
 Configure a sender-bound token only when an allowlisted sender cannot produce useful DKIM or DMARC authentication:
 

--- a/docs/plugins/sdk-channel-ingress.md
+++ b/docs/plugins/sdk-channel-ingress.md
@@ -135,6 +135,10 @@ execution-identity assurance strength. In particular, an identifier claim of
 `verified` never becomes execution assurance `boundary-verified` or
 `cryptographic`.
 
+Import the type and `meetsIdentifierAuthentication(actual, minimum)` from
+`openclaw/plugin-sdk/channel-ingress-runtime`. Downstream authentication mappers
+should use this boolean comparator instead of maintaining their own rank tables.
+
 The meanings are normative:
 
 - `verified`: the owning trusted transport or session boundary bound this exact

--- a/docs/security/THREAT-MODEL-ATLAS.md
+++ b/docs/security/THREAT-MODEL-ATLAS.md
@@ -155,15 +155,15 @@ Out-of-scope reports and false-positive patterns (public internet exposure, prom
 
 #### T-ACCESS-002: AllowFrom spoofing
 
-| Attribute               | Value                                                                          |
-| ----------------------- | ------------------------------------------------------------------------------ |
-| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access                                      |
-| **Description**         | Attacker spoofs an allowed sender identity on a channel                        |
-| **Attack vector**       | Channel-dependent - phone number spoofing, username impersonation              |
-| **Affected components** | Per-channel AllowFrom validation                                               |
-| **Current mitigations** | Channel-specific identity verification                                         |
-| **Residual risk**       | Medium - some channels remain vulnerable to spoofing                           |
-| **Recommendations**     | Document channel-specific risks, add cryptographic verification where possible |
+| Attribute               | Value                                                                                                                                                                                                                                                                                                                                       |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **ATLAS ID**            | AML.T0040 - AI Model Inference API Access                                                                                                                                                                                                                                                                                                   |
+| **Description**         | Attacker spoofs an allowed sender identity on a channel                                                                                                                                                                                                                                                                                     |
+| **Attack vector**       | Channel-dependent - phone number spoofing, username impersonation                                                                                                                                                                                                                                                                           |
+| **Affected components** | Per-channel AllowFrom validation                                                                                                                                                                                                                                                                                                            |
+| **Current mitigations** | Channel-specific identity verification; graded identifier-authentication gate uses `min(entry, subject)` over `verified > asserted > unverified > mutable` with exact match provenance and default minimum `asserted` (#123782/#123793). Channels declare per-identifier strength; security audit warns on inert mutable entries (#131129). |
+| **Residual risk**       | Medium - some channels remain vulnerable to spoofing                                                                                                                                                                                                                                                                                        |
+| **Recommendations**     | Continue per-channel `verified` adoption and downstream strength mappers; document channel-specific risks                                                                                                                                                                                                                                   |
 
 #### T-ACCESS-003: Token theft
 
@@ -502,11 +502,11 @@ T-EXEC-002 → T-EXFIL-001 → External exfiltration
 
 ### 6.3 Medium-term (P2)
 
-| ID    | Recommendation                                        | Addresses     |
-| ----- | ----------------------------------------------------- | ------------- |
-| R-008 | Add cryptographic channel verification where possible | T-ACCESS-002  |
-| R-009 | Implement config integrity verification               | T-PERSIST-003 |
-| R-010 | Add update signing and version pinning                | T-PERSIST-002 |
+| ID    | Recommendation                                                                                                                                                        | Addresses     |
+| ----- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| R-008 | Implemented in core: graded identifier-authentication primitive and audit findings; remaining work is per-channel `verified` adoption and downstream strength mappers | T-ACCESS-002  |
+| R-009 | Implement config integrity verification                                                                                                                               | T-PERSIST-003 |
+| R-010 | Add update signing and version pinning                                                                                                                                | T-PERSIST-002 |
 
 ---
 

--- a/extensions/imap/src/config.test.ts
+++ b/extensions/imap/src/config.test.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import type { IdentifierAuthentication } from "openclaw/plugin-sdk/channel-ingress-runtime";
+import { validateJsonSchemaValue } from "openclaw/plugin-sdk/json-schema-runtime";
+import { expect, it } from "vitest";
+import { resolveImapConfig } from "./config.js";
+
+it("accepts all SDK authentication strengths and rejects an unknown config minimum", () => {
+  const manifest = JSON.parse(
+    fs.readFileSync(new URL("../openclaw.plugin.json", import.meta.url), "utf8"),
+  ) as { configSchema: Record<string, unknown> };
+  const strengths = [
+    "mutable",
+    "unverified",
+    "asserted",
+    "verified",
+  ] satisfies IdentifierAuthentication[];
+  for (const min of [...strengths, "unknown"]) {
+    const value = {
+      accounts: {
+        inbox: {
+          host: "imap.example.com",
+          user: "reader@example.com",
+          password: "fixture-password",
+          agentId: "mail_reader",
+          senderAuth: { min },
+        },
+      },
+    };
+    expect(
+      validateJsonSchemaValue({
+        schema: manifest.configSchema,
+        cacheKey: "imap.manifest.config-schema",
+        value,
+      }).ok,
+    ).toBe(min !== "unknown");
+    if (min !== "unknown") {
+      expect(resolveImapConfig(value).accounts.inbox?.senderAuth.min).toBe(min);
+    }
+  }
+});

--- a/extensions/imap/src/config.ts
+++ b/extensions/imap/src/config.ts
@@ -1,8 +1,13 @@
+import type { IdentifierAuthentication } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { asNonArrayRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
-export const SENDER_STRENGTHS = ["mutable", "unverified", "asserted", "verified"] as const;
-export type SenderStrength = (typeof SENDER_STRENGTHS)[number];
+const SENDER_STRENGTHS = [
+  "mutable",
+  "unverified",
+  "asserted",
+  "verified",
+] as const satisfies readonly IdentifierAuthentication[];
 type HookDispatch = OpenClawPluginApi["runtime"]["hooks"]["dispatchHookAgentTurn"];
 
 export type ImapAccountConfig = {
@@ -15,7 +20,7 @@ export type ImapAccountConfig = {
   watch: { mode: "auto" | "idle" | "interval"; pollSeconds: number };
   allowedSenders: string[];
   senderAuth: {
-    min: SenderStrength;
+    min: IdentifierAuthentication;
     trustedAuthservIds: string[];
     acceptTrustedAuthservId: boolean;
   };
@@ -95,7 +100,11 @@ export function resolveImapConfig(
       },
       allowedSenders: stringList(account.allowedSenders),
       senderAuth: {
-        min: SENDER_STRENGTHS.find((strength) => strength === min) ?? "verified",
+        // The predicate requires every SDK strength to remain in the local config values.
+        min:
+          SENDER_STRENGTHS.find(
+            (strength): strength is IdentifierAuthentication => strength === min,
+          ) ?? "verified",
         trustedAuthservIds: stringList(senderAuth?.trustedAuthservIds),
         acceptTrustedAuthservId: senderAuth?.acceptTrustedAuthservId === true,
       },

--- a/extensions/imap/src/sender-gate.test.ts
+++ b/extensions/imap/src/sender-gate.test.ts
@@ -1,5 +1,6 @@
 import { authenticate } from "mailauth";
 import { simpleParser } from "mailparser";
+import type { IdentifierAuthentication } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { resolveImapConfig } from "./config.js";
 import { createImapAuthResult } from "./imap-test-support.js";
@@ -106,7 +107,12 @@ describe("IMAP sender admission", () => {
           account: configured,
           authenticator: async () => authentication,
         }),
-      ).resolves.toMatchObject({ accepted: false, transient: result === "temperror" });
+      ).resolves.toMatchObject({
+        accepted: false,
+        strength: "unverified",
+        reason: result === "temperror" ? "authentication-temperror" : `dmarc-${result}`,
+        transient: result === "temperror",
+      });
     },
   );
 
@@ -125,6 +131,31 @@ describe("IMAP sender admission", () => {
     },
   );
 
+  it.each([
+    ["mutable", true],
+    ["unverified", true],
+    ["asserted", false],
+    ["verified", false],
+  ] satisfies [IdentifierAuthentication, boolean][])(
+    "admits verified mail and applies the %s floor to unproven mail",
+    async (min, acceptsUnproven) => {
+      const mail = await message(["From: trusted@example.com"]);
+      const configured = account({ senderAuth: { min } });
+      for (const result of ["pass", "none", "temperror"] as const) {
+        await expect(
+          evaluateImapSender({
+            ...mail,
+            account: configured,
+            authenticator: async () => createImapAuthResult(result),
+          }),
+        ).resolves.toMatchObject({
+          accepted: result === "pass" || acceptsUnproven,
+          strength: result === "pass" ? "verified" : "unverified",
+        });
+      }
+    },
+  );
+
   it("accepts only configured Authentication-Results authorities", async () => {
     const configured = account({
       senderAuth: {
@@ -140,7 +171,11 @@ describe("IMAP sender admission", () => {
     ]);
     await expect(
       evaluateImapSender({ ...untrusted, account: configured, authenticator }),
-    ).resolves.toMatchObject({ accepted: false, reason: "unverified-authentication" });
+    ).resolves.toMatchObject({
+      accepted: false,
+      strength: "unverified",
+      reason: "unverified-authentication",
+    });
     const trusted = await message([
       "From: trusted@example.com",
       "Authentication-Results: mx.example.com; dmarc=pass header.from=example.com",
@@ -207,5 +242,23 @@ describe("IMAP sender admission", () => {
     const prompt = renderImapPrompt(parsed.mail, { includeBody: true, maxBytes: 256 });
     expect(Buffer.byteLength(prompt)).toBeLessThanOrEqual(256);
     expect(prompt).toContain("[truncated:");
+  });
+
+  it("keeps authenticator exceptions retryable without claiming a mutable identifier", async () => {
+    const mail = await message(["From: trusted@example.com"]);
+    await expect(
+      evaluateImapSender({
+        ...mail,
+        account: account({ senderAuth: { min: "unverified" } }),
+        authenticator: async () => {
+          throw new Error("DNS timeout");
+        },
+      }),
+    ).resolves.toMatchObject({
+      accepted: false,
+      strength: "unverified",
+      reason: "authentication-temperror",
+      transient: true,
+    });
   });
 });

--- a/extensions/imap/src/sender-gate.ts
+++ b/extensions/imap/src/sender-gate.ts
@@ -2,17 +2,21 @@ import { timingSafeEqual } from "node:crypto";
 import { Resolver } from "node:dns/promises";
 import { authenticate, type AuthenticateResult } from "mailauth";
 import type { AddressObject, ParsedMail } from "mailparser";
-import { SENDER_STRENGTHS, type ImapAccountConfig, type SenderStrength } from "./config.js";
+import {
+  meetsIdentifierAuthentication,
+  type IdentifierAuthentication,
+} from "openclaw/plugin-sdk/channel-ingress-runtime";
+import type { ImapAccountConfig } from "./config.js";
 
 const AUTH_FRESHNESS_MS = 48 * 60 * 60 * 1_000;
 const DNS_TIMEOUT_MS = 5_000;
 
 export type SenderGateVerdict =
-  | { accepted: true; sender: string; strength: SenderStrength; reason: string }
+  | { accepted: true; sender: string; strength: IdentifierAuthentication; reason: string }
   | {
       accepted: false;
       sender?: string;
-      strength: SenderStrength;
+      strength: IdentifierAuthentication;
       reason: string;
       transient: boolean;
     };
@@ -115,7 +119,7 @@ function mapImapAuthStrength(
   result: AuthenticateResult | undefined,
   headers: readonly AuthenticationHeader[],
   account: ImapAccountConfig,
-): { strength: SenderStrength; reason: string; transient: boolean } {
+): { strength: IdentifierAuthentication; reason: string; transient: boolean } {
   const dmarc = result?.dmarc && result.dmarc.status.result;
   // mailauth omits alignment when no DMARC policy exists or its DNS lookup fails.
   if (result?.dmarc && result.dmarc.alignment?.dkim.underSized) {
@@ -143,7 +147,7 @@ function mapImapAuthStrength(
     };
   }
   return {
-    strength: "mutable",
+    strength: "unverified",
     reason: dmarc === "temperror" ? "authentication-temperror" : `dmarc-${dmarc || "none"}`,
     transient: dmarc === "temperror",
   };
@@ -200,24 +204,20 @@ export async function evaluateImapSender(params: {
     );
     if (
       fallback.strength === "asserted" &&
-      SENDER_STRENGTHS.indexOf(fallback.strength) >=
-        SENDER_STRENGTHS.indexOf(params.account.senderAuth.min)
+      meetsIdentifierAuthentication(fallback.strength, params.account.senderAuth.min)
     ) {
       return { accepted: true, sender, strength: fallback.strength, reason: fallback.reason };
     }
     return {
       accepted: false,
       sender,
-      strength: "mutable",
+      strength: "unverified",
       reason: "authentication-temperror",
       transient: true,
     };
   }
   const evidence = mapImapAuthStrength(result, authenticationHeaders(params.mail), params.account);
-  if (
-    SENDER_STRENGTHS.indexOf(evidence.strength) <
-    SENDER_STRENGTHS.indexOf(params.account.senderAuth.min)
-  ) {
+  if (!meetsIdentifierAuthentication(evidence.strength, params.account.senderAuth.min)) {
     return { accepted: false, sender, ...evidence };
   }
   return { accepted: true, sender, strength: evidence.strength, reason: evidence.reason };

--- a/extensions/imap/src/watcher.test.ts
+++ b/extensions/imap/src/watcher.test.ts
@@ -190,6 +190,29 @@ async function startWatcher(
 }
 
 describe("IMAP watcher protocol boundary", () => {
+  it("dispatches no-evidence mail at an explicit unverified floor", async () => {
+    const { server, state, context, authenticator, dispatchHookAgentTurn } = await startWatcher({
+      account: {
+        senderAuth: { min: "unverified", trustedAuthservIds: [], acceptTrustedAuthservId: false },
+      },
+    });
+    await vi.waitFor(async () =>
+      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
+    );
+    authenticator.mockResolvedValue(createImapAuthResult("none"));
+    server.append(
+      "From: trusted@example.com\r\nSubject: Unproven\r\n\r\nNo authentication evidence",
+    );
+    await vi.waitFor(async () =>
+      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 2 }),
+    );
+    expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(1);
+    expect(context.logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("strength=unverified run=mail-run"),
+    );
+    expect(await state.skips.lookup("inbox:dmarc-none")).toBeUndefined();
+  });
+
   it.each(["rejected admission", "throwing admission", "transient authentication"] as const)(
     "retries %s without waiting for another email",
     async (failure) => {

--- a/scripts/check-plugin-sdk-exports.mts
+++ b/scripts/check-plugin-sdk-exports.mts
@@ -69,7 +69,7 @@ let missing = 0;
       join(consumerRoot, "index.ts"),
       `import { buildChannelConfigSchema, DmPolicySchema } from "openclaw/plugin-sdk/channel-config-schema";
 import { defineChannelPluginEntry } from "openclaw/plugin-sdk/core";
-import { identityEntryAuthenticationClassifier } from "openclaw/plugin-sdk/channel-ingress-runtime";
+import { identityEntryAuthenticationClassifier, meetsIdentifierAuthentication } from "openclaw/plugin-sdk/channel-ingress-runtime";
 import type {
   ChannelIngressIdentitySubjectInput,
   IdentifierAuthentication,
@@ -84,6 +84,8 @@ import { createPluginRuntimeStore, type PluginRuntime } from "openclaw/plugin-sd
 import { z } from "zod";
 
 const identifierAuthentication: IdentifierAuthentication = "verified";
+const meetsMinimum: boolean = meetsIdentifierAuthentication(identifierAuthentication, "asserted");
+void meetsMinimum;
 const subject: ChannelIngressIdentitySubjectInput = {
   stableId: "provider-user-id",
   authentication: { "provider-user-id": identifierAuthentication },

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -322,7 +322,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +1: identifier authentication input type for external channel plugins.
       // +1: shared channel-account logout config cleanup.
       // +1: descriptor-based allowFrom authentication classifier for channel security audits.
-      4348,
+      // +1: downstream strength mappers need canonical ordering instead of duplicate rank tables.
+      4349,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -421,7 +422,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: canonical session-model selection and auxiliary runtime-auth preparation.
       // +1: shared channel-account logout config cleanup.
       // +1: descriptor-based allowFrom authentication classifier for channel security audits.
-      2584,
+      // +1: downstream strength mappers need canonical ordering instead of duplicate rank tables.
+      2585,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/channel-ingress-runtime.test.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   fanInChannelIngressLifecycles,
+  meetsIdentifierAuthentication,
   resolveChannelMessageIngress,
   type ChannelIngressIdentityDescriptor,
   type IdentifierAuthentication,
@@ -27,14 +28,15 @@ async function resolve(input: Partial<ResolveChannelMessageIngressParams> = {}) 
 }
 
 describe("plugin-sdk/channel-ingress-runtime", () => {
-  it("exports only the generic identifier-authentication inputs", () => {
-    const strengths: IdentifierAuthentication[] = ["verified", "asserted", "unverified", "mutable"];
-    const subject: NonNullable<ResolveChannelMessageIngressParams["subject"]["authentication"]> = {
+  it("compares typed identifier claims through the public SDK", () => {
+    const minimum: IdentifierAuthentication = "asserted";
+    const subject = {
       email: "verified",
       displayName: "mutable",
-    };
+    } satisfies NonNullable<ResolveChannelMessageIngressParams["subject"]["authentication"]>;
 
-    expect(strengths).toContain(subject.email);
+    expect(meetsIdentifierAuthentication(subject.email, minimum)).toBe(true);
+    expect(meetsIdentifierAuthentication(subject.displayName, minimum)).toBe(false);
   });
 
   it("fans one logical turn lifecycle across every durable claim", async () => {

--- a/src/plugin-sdk/channel-ingress-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-runtime.ts
@@ -20,7 +20,10 @@ export {
   resolveChannelMessageIngress,
   resolveStableChannelMessageIngress,
 } from "../channels/message-access/runtime.js";
-export type { IdentifierAuthentication } from "../channels/message-access/identifier-authentication.js";
+export {
+  meetsIdentifierAuthentication,
+  type IdentifierAuthentication,
+} from "../channels/message-access/identifier-authentication.js";
 export {
   defineStableChannelIngressIdentity,
   identityEntryAuthenticationClassifier,


### PR DESCRIPTION
Completes the sender-authentication-strength campaign's perimeter (RFC 0028, merged as [openclaw/rfcs#51](https://github.com/openclaw/rfcs/pull/51) → 967d9aac747; kernel #123782, SDK contract #123793, audit findings #131129): the bundled IMAP trigger stops carrying a private clone of the trust scale, and the threat-model atlas stops presenting the closed gap as open (RFC stage 1).

## What Problem This Solves

`extensions/imap` (landed via #130230, before the SDK export existed) defined its own `SENDER_STRENGTHS`/`SenderStrength` vocabulary and rank comparisons — a parallel copy of the exact scale the RFC exists to canonicalize, with one real semantic drift: mail with **no authentication evidence** was classified `mutable`, but per the accepted RFC an exact From address whose ownership is unproven is `unverified` — `mutable` means a changeable/shared alias, and collapsing them makes the diagnostic lie. Separately, `docs/security/THREAT-MODEL-ATLAS.md` still described T-ACCESS-002/R-008 as an open gap whose recommended mitigation now ships in core.

## Why This Change Was Made

- **One scale, one owner.** The private type and values array are deleted; IMAP imports `IdentifierAuthentication` from `openclaw/plugin-sdk/channel-ingress-runtime` and compares with the core `meetsIdentifierAuthentication` — newly exported (+1 export/+1 callable, justified in-line: every downstream strength mapper needs the canonical ordering, and re-implementing the rank table is precisely the duplication bug class). The config's schema enum stays local but is statically bound (`as const satisfies readonly IdentifierAuthentication[]` + exhaustiveness guard), so scale drift fails the build. Config keys and defaults unchanged.
- **Semantic drift fixed (deliberate behavior change).** No-evidence / DMARC none / neutral / fail / temperror outcomes now record `unverified` instead of `mutable`; reasons and transient flags unchanged. Default `senderAuth.min` is `verified` and the `asserted`/`verified` floors are unaffected — only an explicitly configured `min: "unverified"` floor now admits such mail (previously only `min: "mutable"` did). The plugin exists only in the beta line (verified: none of 97 stable tags contains #130230's commit), so no compatibility contract applies. `mutable` remains accepted in config and still occurs on pre-authentication gate paths (token admission, invalid-from), which are unchanged; whether those deserve a more precise result shape is a named follow-up.
- **RFC stage 1 delivered.** T-ACCESS-002's mitigations row records the graded `min(entry, subject)` gate with exact match provenance and the audit's inert-entry warnings; R-008 is marked implemented-in-core with the remaining scope (per-channel `verified` adoption, downstream mappers). Residual risk deliberately stays Medium.

## User Impact

Operators of the IMAP trigger see honest strength labels: unauthenticated mail reports `unverified` in verdicts and logs instead of masquerading as an alias-class rejection. Docs (`docs/automation/imap.md`, channel-ingress SDK page) describe the unified ladder. No default-path admission change anywhere.

## Evidence

- Pre-fix reproduction: 3 of 16 sender-gate tests fail on the old code (DMARC neutral/temperror/none returned `mutable`); pass after.
- Boundary proof: real TCP IMAP + ImapFlow + MIME parsing + sender gate + watcher dispatch with a controlled authenticator — explicit-`unverified` no-evidence mail dispatches once and logs `unverified`.
- Exhaustiveness guard proven by isolated tsgo probes: adding an SDK strength or omitting a local one fails compilation (TS2677).
- `extensions/imap` suite 39/39; `pnpm plugin-sdk:surface:check` 4349 exports / 2585 callables (exactly +1 each); kernel + SDK-runtime suites green; `pnpm build` green with packaged-consumer import and a built-package runtime check of all 16 comparator pairs. `check:changed` on the rebased head passes every lane except "typecheck core tests", which fails on 14 pre-existing TS7006s in untouched `ui/src/test-helpers` files — reproduced identically on clean `origin/main` in the same environment while main's hosted CI is green on that exact head, i.e. a local worktree type-resolution quirk, not this diff; exact-head hosted CI on this PR is the authoritative gate.
- mailauth dependency contract verified against installed sources (`lib/dmarc/verify.js`, `lib/mailauth.js`) for alignment and DNS-error shapes; the regression table drives real mailauth with controlled DNS.
- Structured Codex autoreview: no accepted/actionable findings (two passes).
- Production LOC +29/−17 (net +12: SDK import/export threading and the contract guard; the duplicate rank logic is deleted) | tests +120 | docs +15.
