### PR TITLE
fix: channel config updates no longer wait on themselves

### DIFF
--- a/src/config/runtime-write-application.ts
+++ b/src/config/runtime-write-application.ts
@@ -10,6 +10,9 @@ export type RuntimeConfigWriteApplicationStatus =
 
 export type RuntimeConfigWriteApplicationClaim = {
   settle: (status: RuntimeConfigWriteApplicationStatus) => void;
+  // Re-enter only the originating request root so channel drain excludes the RPC awaiting
+  // this receipt; unrelated watcher reloads retain their independent transaction root.
+  runTransaction?: <T>(run: () => Promise<T>) => Promise<T>;
 };
 
 type RuntimeConfigWriteApplication = {
@@ -21,7 +24,9 @@ type RuntimeConfigWriteApplication = {
 const runtimeConfigWriteApplications = new WeakMap<object, RuntimeConfigWriteApplication>();
 
 /** Creates a single-owner receipt for one persisted config write. */
-export function createRuntimeConfigWriteApplication(): RuntimeConfigWriteApplication {
+export function createRuntimeConfigWriteApplication(
+  runTransaction?: <T>(run: () => Promise<T>) => Promise<T>,
+): RuntimeConfigWriteApplication {
   let claimed = false;
   const result = createDeferredCore<RuntimeConfigWriteApplicationStatus>();
   return {
@@ -34,7 +39,7 @@ export function createRuntimeConfigWriteApplication(): RuntimeConfigWriteApplica
         return null;
       }
       claimed = true;
-      return { settle: result.resolve };
+      return { settle: result.resolve, ...(runTransaction ? { runTransaction } : {}) };
     },
   };
 }

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -34,6 +34,7 @@ import {
   getActiveGatewayRootWorkCount,
   resetGatewayWorkAdmission,
   runWithGatewayIndependentRootWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
 } from "../process/gateway-work-admission.js";
 import {
   getSkillsSnapshotVersion,
@@ -1677,7 +1678,7 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
-  it("carries an RPC write receipt through real option and listener copies until commit", async () => {
+  it("applies an RPC write receipt inside its originating gateway root", async () => {
     const root = tempDirs.make("openclaw-config-receipt-");
     const configPath = nodePath.join(root, "openclaw.json");
     const initialConfig = {
@@ -1707,10 +1708,11 @@ describe("startGatewayConfigReloader", () => {
         runtimeConfig: OpenClawConfig,
         ownership: GatewayConfigReloadTransactionOwnership,
       ) => {
+        const competingRootCount = getActiveGatewayRootWorkCount({ excludeCurrent: true });
         markHotReloadStarted();
         await hotReloadGate;
         ownership.markRuntimeCommitted(runtimeConfig, plan);
-        return "applied" as const;
+        return { status: "applied" as const, competingRootCount };
       },
     );
     const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
@@ -1745,34 +1747,49 @@ describe("startGatewayConfigReloader", () => {
           onNoopConfigCommit: async (plan, runtimeConfig, ownership) => {
             ownership.markRuntimeCommitted(runtimeConfig, plan);
           },
-          onHotReload,
+          onHotReload: async (plan, runtimeConfig, ownership) =>
+            (await onHotReload(plan, runtimeConfig, ownership)).status,
           onRestart: async () => {
             throw new Error("unexpected restart");
           },
+          runTransaction: runWithGatewayIndependentRootWorkAdmission,
           log,
           watchPath: configPath,
         });
 
         try {
-          const prepared = await readConfigFileSnapshotForWrite();
-          const writeResult = await commitGatewayConfigWrite({
-            snapshot: prepared.snapshot,
-            writeOptions: prepared.writeOptions,
-            nextConfig,
-            awaitRuntimeApplication: true,
+          const request = tryBeginGatewayRootWorkAdmission();
+          if (!request) {
+            throw new Error("expected gateway request admission");
+          }
+          const writeResult = await request.run(async () => {
+            const prepared = await readConfigFileSnapshotForWrite();
+            return await commitGatewayConfigWrite({
+              snapshot: prepared.snapshot,
+              writeOptions: prepared.writeOptions,
+              nextConfig,
+              awaitRuntimeApplication: true,
+            });
           });
-          let settled = false;
-          void writeResult.application?.then(() => {
-            settled = true;
-          });
+          try {
+            let settled = false;
+            void writeResult.application?.then(() => {
+              settled = true;
+            });
 
-          await vi.advanceTimersByTimeAsync(0);
-          await hotReloadStarted;
-          expect(onHotReload).toHaveBeenCalledOnce();
-          expect(settled).toBe(false);
+            await vi.advanceTimersByTimeAsync(0);
+            await hotReloadStarted;
+            expect(onHotReload).toHaveBeenCalledOnce();
+            expect(settled).toBe(false);
 
-          releaseHotReload();
-          await expect(writeResult.application).resolves.toBe("applied");
+            releaseHotReload();
+            await expect(writeResult.application).resolves.toBe("applied");
+            await expect(onHotReload.mock.results[0]?.value).resolves.toMatchObject({
+              competingRootCount: 0,
+            });
+          } finally {
+            request.release();
+          }
         } finally {
           await reloader.stop();
         }

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -806,12 +806,12 @@ export function startGatewayConfigReloader(opts: {
     }
   };
 
-  const runAcceptedTransaction = async (run: () => Promise<void>) => {
-    if (opts.runTransaction) {
-      await opts.runTransaction(run);
-      return;
-    }
-    await run();
+  const runAcceptedTransaction = async (
+    run: () => Promise<void>,
+    application?: RuntimeConfigWriteApplicationClaim,
+  ) => {
+    const runTransaction = application?.runTransaction ?? opts.runTransaction;
+    await (runTransaction ? runTransaction(run) : run());
   };
 
   const acceptCurrentRuntimeEcho = async (
@@ -899,7 +899,7 @@ export function startGatewayConfigReloader(opts: {
               activeInProcessConfig = null;
             }
             await promoteAcceptedInProcessWrite(pendingWrite.persistedHash);
-          });
+          }, pendingWrite.application);
         } catch (err) {
           if (lastAppliedWriteHash === pendingWrite.persistedHash) {
             lastAppliedWriteHash = null;
@@ -980,7 +980,7 @@ export function startGatewayConfigReloader(opts: {
               watcherIntentCameFromPendingWrite = false;
             }
             await promoteAcceptedSnapshot(snapshot, "in-process-write");
-          });
+          }, intentCandidate.application);
         } catch (err) {
           if (lastAppliedWriteHash === intentCandidate.persistedHash) {
             lastAppliedWriteHash = null;

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -20,6 +20,7 @@ import {
   writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
+import { captureGatewayRootWorkAdmissionContinuationScope } from "../../process/gateway-work-admission.js";
 import { getActiveSecretsRuntimeSnapshotState } from "../../secrets/runtime-state.js";
 import { isRecord } from "../../utils.js";
 import { resolveEffectiveSharedGatewayAuth, resolveGatewayAuth } from "../auth.js";
@@ -306,7 +307,7 @@ export async function commitGatewayConfigWrite(params: {
   queueFollowUp: () => void;
 }> {
   const application = params.awaitRuntimeApplication
-    ? createRuntimeConfigWriteApplication()
+    ? createRuntimeConfigWriteApplication(captureGatewayRootWorkAdmissionContinuationScope()?.run)
     : undefined;
   const result = await replaceConfigFile({
     nextConfig: params.nextConfig,


### PR DESCRIPTION
Closes #131138

AI-assisted: Codex was used for investigation, implementation, and test review. I reviewed the resulting code and understand the ownership change.

## What Problem This Solves

Fixes an issue where operators applying a configuration change that reloads channels could wait until the forced-reload timeout. The `config.patch` request waited for runtime application while the channel reload counted that same request as competing active work, creating a self-wait.

## Why This Change Was Made

The accepted write receipt now privately carries the originating Gateway root continuation. Only the reload claimed by that receipt re-enters the request root, so channel draining excludes the RPC waiting for its own application. Watcher-driven and otherwise unrelated reloads continue to use the independent reload transaction and still wait for genuinely competing requests.

## User Impact

Channel-affecting `config.patch` calls can acknowledge promptly after the requested runtime application instead of timing out and forcing a reload several minutes later. Receipt-gated acknowledgement semantics remain intact.

## Evidence

- Real pre-fix Gateway observation: the write was accepted, the client timed out after 120 seconds, the channel reload forced after about 300 seconds, and the stale RPC response arrived after about 376 seconds.
- Real after-fix Gateway proof on exact head `e55a7483c16f98bc500a471df4217d4611b5e694` (`2026.8.1-e55a7483c16f-2026-08-27T23-05-32.755Z`): an isolated loopback Gateway with a real QA channel received `channels.qa-channel.pollTimeoutMs` `250 -> 300` over one persistent RPC client. The channel restart and `config hot reload applied` were both logged before `config.patch` returned in 282.678 ms. The same connection restored `300 -> 250` in 239.722 ms. Across both reloads: 2 channel restarts, 2 applied reloads, 0 deferred-reload messages, 0 forced-timeout messages, stable Gateway PID, settled application receipt/hash, channel ready/connected, HTTP `/health` 200/live, and `/readyz` 200/ready. The disposable isolated config was restored semantically and removed; the managed Mac Gateway was not touched.
- The focused regression uses real config I/O, write-listener/receipt copies, real Gateway root admission, and the production independent reload transaction. It fails on `main` with one competing root and passes with zero after the fix.
- `pnpm test src/gateway/config-reload.test.ts` — 205/205 passed.
- On final base `d56e2c42c93`, the exact receipt/root regression passed 1/1 after a clean rebase with no patch change.
- `node scripts/check-changed.mjs -- src/config/runtime-write-application.ts src/gateway/server-methods/config-write-flow.ts src/gateway/config-reload.ts src/gateway/config-reload.test.ts` — passed the core/core-test type, lint, format, dead-code, import-cycle, and policy gates.
- `pnpm test src/gateway/server-reload-handlers.test.ts` — 227/230 passed; the three unrelated skill-review reconciliation cases each hit their existing 120-second timeout because the fixture lacked process-start identity (`cron run cannot acquire a durable fence`). No config receipt/root test failed.
