### PR TITLE
perf(startup): measure default resolve path and gate debug-capture imports

### DIFF
--- a/scripts/check-cli-startup-memory.mjs
+++ b/scripts/check-cli-startup-memory.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Measures CLI startup memory with an isolated home and RSS hook.
+// Measures CLI startup memory with an isolated home and an in-process bench entry.
 import { spawnSync as defaultSpawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
@@ -17,7 +17,7 @@ const COMMAND_TIMEOUT_MS = readPositiveIntEnv(
   DEFAULT_COMMAND_TIMEOUT_MS,
 );
 let tmpHome = null;
-let rssHookPath = null;
+let benchEntryPath = null;
 const PASS = "pass";
 const FAIL = "fail";
 function readPositiveIntEnv(name, fallback, env = process.env) {
@@ -226,8 +226,8 @@ function buildBenchEnv(homeDir = tmpHome) {
   return env;
 }
 function runCaseSample(testCase, sampleIndex, params = {}) {
-  if (!rssHookPath) {
-    throw new Error("RSS hook path is not initialized");
+  if (!benchEntryPath) {
+    throw new Error("bench entry path is not initialized");
   }
   if (!tmpHome) {
     throw new Error("temporary home is not initialized");
@@ -237,18 +237,14 @@ function runCaseSample(testCase, sampleIndex, params = {}) {
   const env = buildBenchEnv(sampleHome);
   const spawn = params.spawnSync ?? defaultSpawnSync;
   const timeoutMs = params.timeoutMs ?? COMMAND_TIMEOUT_MS;
-  const result = spawn(
-    process.execPath,
-    ["--import", nodeImportSpecifierForPath(rssHookPath), ...testCase.args],
-    {
-      cwd: repoRoot,
-      env,
-      encoding: "utf8",
-      maxBuffer: 20 * 1024 * 1024,
-      timeout: timeoutMs,
-      killSignal: "SIGKILL",
-    },
-  );
+  const result = spawn(process.execPath, [benchEntryPath, ...testCase.args.slice(1)], {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: timeoutMs,
+    killSignal: "SIGKILL",
+  });
   const stderr = String(result.stderr ?? "");
   const stdout = String(result.stdout ?? "");
   const maxRssMb = parseMaxRssMb(stderr);
@@ -372,14 +368,24 @@ function runStartupMemoryCheck(argv = process.argv.slice(2), params = {}) {
   }
   const options = parseArgs(argv);
   tmpHome = mkdtempSync(path.join(os.tmpdir(), "openclaw-startup-memory-"));
-  rssHookPath = path.join(tmpHome, "measure-rss.mjs");
+  benchEntryPath = path.join(tmpHome, "bench-entry.mjs");
+  // Run the real launcher in-process so peak RSS is self-reported at exit
+  // without --import/--require flags: the entry declines its dist ESM resolve
+  // fast path when preload hooks may be registered, so an injected hook would
+  // measure a slower non-default resolution configuration instead of what a
+  // plain `node openclaw.mjs ...` invocation pays.
+  const launcherPath = path.join(repoRoot, "openclaw.mjs");
   writeFileSync(
-    rssHookPath,
+    benchEntryPath,
     [
       "process.on('exit', () => {",
       "  const usage = typeof process.resourceUsage === 'function' ? process.resourceUsage() : null;",
       `  if (usage && typeof usage.maxRSS === 'number') console.error('${MAX_RSS_MARKER}' + String(usage.maxRSS));`,
       "});",
+      `const launcherPath = ${JSON.stringify(launcherPath)};`,
+      "// The launcher and entry expect argv[1] to be the launcher path itself.",
+      "process.argv[1] = launcherPath;",
+      `await import(${JSON.stringify(nodeImportSpecifierForPath(launcherPath))});`,
       "",
     ].join("\n"),
     "utf8",
@@ -394,7 +400,7 @@ function runStartupMemoryCheck(argv = process.argv.slice(2), params = {}) {
     if (tmpHome) {
       rmSync(tmpHome, { recursive: true, force: true });
       tmpHome = null;
-      rssHookPath = null;
+      benchEntryPath = null;
     }
   }
   const failure = results.find((result) => result.status !== "pass");

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -3504,13 +3504,15 @@ describe("runCli exit behavior", () => {
     const processOnceSpy = vi.spyOn(process, "once");
     try {
       const runPromise = runCli(["node", "openclaw", "plugins", "marketplace", "list"]);
+      // Only the managed-proxy kill hook registers here: the debug-capture
+      // finalize hook stays unloaded unless the capture env requests it.
       await vi.waitFor(() => {
         expect(
           processOnceSpy.mock.calls.reduce(
             (count, [event]) => count + (event === "exit" ? 1 : 0),
             0,
           ),
-        ).toBe(2);
+        ).toBe(1);
       });
 
       const exitHandler = processOnceSpy.mock.calls.find(([event]) => event === "exit")?.[1];

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -851,11 +851,15 @@ async function ensureCliEnvProxyDispatcher(): Promise<void> {
   }
 }
 
-function shouldBootstrapCliProxyBeforeFastPath(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (
+function isDebugProxyCaptureEnvEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return (
     isTruthyEnvValue(env.OPENCLAW_DEBUG_PROXY_ENABLED) ||
     isTruthyEnvValue(env.OPENCLAW_DEBUG_PROXY_REQUIRE)
-  ) {
+  );
+}
+
+function shouldBootstrapCliProxyBeforeFastPath(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (isDebugProxyCaptureEnvEnabled(env)) {
     return true;
   }
   return CLI_PROXY_ENV_KEYS.some((key) => {
@@ -1032,20 +1036,25 @@ async function bootstrapCliProxyCaptureAndDispatcher(
   startupTrace: ReturnType<typeof createGatewayDispatchStartupTrace>,
   options: { ensureDispatcher?: boolean } = {},
 ): Promise<void> {
-  const [
-    { initializeDebugProxyCapture, finalizeDebugProxyCapture },
-    { maybeWarnAboutDebugProxyCoverage },
-  ] = await startupTrace.measure("proxy-imports", () =>
-    Promise.all([import("../proxy-capture/runtime.js"), import("../proxy-capture/coverage.js")]),
-  );
-  initializeDebugProxyCapture("cli");
-  process.once("exit", () => {
-    finalizeDebugProxyCapture();
-  });
+  // Capture init, exit finalize, and coverage warnings all no-op unless the
+  // debug-proxy env requests capture; importing their sqlite-store graph anyway
+  // costs ~100 MB RSS on metadata-only commands such as `plugins list --json`.
+  if (isDebugProxyCaptureEnvEnabled()) {
+    const [
+      { initializeDebugProxyCapture, finalizeDebugProxyCapture },
+      { maybeWarnAboutDebugProxyCoverage },
+    ] = await startupTrace.measure("proxy-imports", () =>
+      Promise.all([import("../proxy-capture/runtime.js"), import("../proxy-capture/coverage.js")]),
+    );
+    initializeDebugProxyCapture("cli");
+    process.once("exit", () => {
+      finalizeDebugProxyCapture();
+    });
+    maybeWarnAboutDebugProxyCoverage(undefined, (message) => console.warn(message));
+  }
   if (options.ensureDispatcher !== false) {
     await startupTrace.measure("proxy-dispatcher", () => ensureCliEnvProxyDispatcher());
   }
-  maybeWarnAboutDebugProxyCoverage(undefined, (message) => console.warn(message));
 }
 
 export async function runCli(

--- a/src/config/io.context.ts
+++ b/src/config/io.context.ts
@@ -10,7 +10,10 @@ import {
   shouldDeferShellEnvFallback,
   shouldEnableShellEnvFallback,
 } from "../infra/shell-env.js";
-import { createConfigValidationMetadataPluginIdScope } from "../plugins/gateway-startup-plugin-ids.js";
+// Import the metadata module directly: the gateway-startup-plugin-ids facade
+// also re-exports the startup loader and embedding providers, which config
+// reads must not drag into every CLI invocation.
+import { createConfigValidationMetadataPluginIdScope } from "../plugins/gateway-startup-plugin-metadata.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import {
   rebasePluginMetadataSnapshotManifestRegistry,

--- a/test/scripts/check-cli-startup-memory.test.ts
+++ b/test/scripts/check-cli-startup-memory.test.ts
@@ -335,8 +335,12 @@ describe("check-cli-startup-memory", () => {
     expect(seenArgs).toHaveLength(testing.cases.length * testing.sampleCount);
     expect(new Set(seenHomes).size).toBe(seenArgs.length);
     for (const args of seenArgs) {
-      expect(args[0]).toBe("--import");
-      expect(args[1]).toMatch(/^file:/u);
+      // The bench entry runs the launcher in-process instead of preloading an
+      // --import hook, which would disable the dist ESM resolve fast path and
+      // measure a non-default resolution configuration.
+      expect(args[0]).toMatch(/bench-entry\.mjs$/u);
+      expect(args[0]).not.toBe("--import");
+      expect(args[1]).not.toBe("openclaw.mjs");
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The `build-artifacts` startup-memory gate for `plugins list --json` failed on Blacksmith at 401.0 MB against the 400 MB budget (run 33101641632, samples 318.4/403.3/401.0 MB) on a UI-only PR, and has been running at 399–401 MB — zero headroom — since 2026-08-27 ~10:58 UTC.

Bisecting real Blacksmith `main` runs pins the step to a single commit: 88c684c13ef (#128663, "preserve preloaded resolver hooks") moved the gate from 246.7 MB to 400.6 MB in one commit. #128663 correctly declines the dist ESM resolve fast path from #128541 whenever `--import`/`--require`/`--loader` may register resolver hooks (a later `registerHooks` short-circuit would bypass them) — but the startup-memory gate itself injected its RSS hook via `--import`. Since then the gate has been measuring a slow-resolution configuration that no plain `node openclaw.mjs …` invocation uses. The default path still costs ~243 MB; the gate just stopped measuring it.

The huge sample spread (318 vs 403 MB) is page-cache warmth: cold first samples load dist slowly enough that V8 keeps up; warm samples allocate fast enough that resolver-churn garbage peaks the heap. With the fast path measured, samples tighten to ±3 MB.

## Why This Change Was Made

Three changes, one invariant each:

1. **Measure the default resolution path** (`scripts/check-cli-startup-memory.mjs`): the bench now writes a tiny wrapper that registers the exit-time RSS reporter, rewrites `argv[1]` to the launcher path, and imports `openclaw.mjs` in-process — clean `execArgv`, so the fast path installs exactly as it does for users. Same self-measurement semantics (`process.resourceUsage().maxRSS` at exit) as before, so the series stays comparable with the Aug 24–27 ~243 MB readings.
2. **Gate the debug-proxy capture import graph** (`src/cli/run-main.ts`): every non-help CLI invocation imported `proxy-capture/runtime.js` + `coverage.js` before route dispatch, although capture init, exit finalize, and coverage warnings all no-op unless `OPENCLAW_DEBUG_PROXY_ENABLED`/`REQUIRE` is truthy. That import graph statically drags the sqlite capture store, proxyline, and the full undici stack (~235 modules / 1.2 MB bundled source on the `plugins list --json` path). The imports now happen only when the capture env is set; the `HTTP(S)_PROXY` dispatcher half is unchanged.
3. **Stop config reads importing the gateway-startup facade** (`src/config/io.context.ts`): it needs one function from `gateway-startup-plugin-metadata.js`; the `gateway-startup-plugin-ids.js` facade also re-exports the startup loader, which config reads must not pull into every CLI invocation.

Pre-#128663 there was also genuine slow drift in the declined-fast-path reading (~310 MB on Jul 20 → ~396 MB on Aug 23, ~1 MB/day, global runtime growth: `status --json` moved in lockstep while `--help` stayed flat at 49 MB). Change 2 attacks the largest single removable edge of that shared graph.

## User Impact

- The Blacksmith gate returns to ~243 MB against the 400 MB budget instead of failing at 401.0; the measured configuration matches what users actually run.
- `plugins list --json` and sibling metadata commands stop loading the debug-capture sqlite store, proxyline, and undici when capture is off (−235 modules; −25 MB max RSS in the slow-resolution configuration, smaller in the default one). Capture behavior with `OPENCLAW_DEBUG_PROXY_ENABLED=1` is unchanged (verified live: capture session persisted to `openclaw.sqlite`, JSON output intact).
- No budget changes: after this fix the 400/425 MB budgets have real headroom again. Whether to *tighten* them (the gate would now let a +150 MB regression pass) is a maintainer policy decision — flagged as follow-up, per CI-limits policy.

## Evidence

- CI drift timeline (sampled Blacksmith `main` runs, `plugins list --json` median MB): Jul 20: 310.3 → Aug 23: 396.1 → **Aug 24 (after #128541): 243.0** → Aug 27 10:56 (`bbce340`): 246.7 → **Aug 27 10:58 (`88c684c`, #128663): 400.6** → since: 399–401.
- Local before/after on the same machine (darwin, Node 24.20, built dist):

| case | before (hook-injected, pre-fix code) | after (in-process bench, this PR) |
|---|---:|---:|
| `--help` | 46.4 MB | 46.5 MB |
| `plugins list --json` | 332.8 MB (samples 318.9–354.5) | **240.8 MB** (samples 237.7–244.0) |
| `status --json` | 434.1 MB | **302.8 MB** |
| `gateway status` | 418.7 MB | **243.9 MB** |

- Module census (`module.registerHooks` load recorder) on `plugins list --json`: 1797 → 1562 modules in the declined-fast-path configuration; `undici`, `proxy-capture/*`, and the gateway-startup loader no longer load; capture-enabled run still loads them and records its session.
- Tests: `pnpm test test/scripts/check-cli-startup-memory.test.ts src/cli/run-main.test.ts src/cli/run-main.exit.test.ts src/cli/run-main.import-boundary.test.ts src/config/io.snapshot.test.ts src/config/io.context.plugin-metadata.test.ts src/proxy-capture/runtime.test.ts src/entry.esm-resolve-fast-path.test.ts` green; `pnpm check:changed` green; Codex autoreview clean.
- The two spawn-shape assertions in the script's tests were updated to the new bench-entry contract; the `run-main.exit` test that counted two `process.once("exit")` registrations now expects one (the capture finalize hook is intentionally absent when capture is off).

Follow-ups (named, not in this PR):
- `installed-plugin-index-store.ts` statically imports `runOpenClawStateWriteTransaction` (full Kysely store) into the read path; a read/write module split would remove sqlite+kysely from metadata-only commands entirely (persistence-adjacent, needs its own review).
- `gateway-startup-plugin-metadata` → `…-config` → `…-providers` still pulls embedding providers and `fetch-guard` into config reads.
- Runtime config reads bundle the doctor legacy-config-migrations suite (`applyLegacyDoctorMigrations` in `io.context.ts`) — the database-first/doctor-owns-migrations doctrine suggests moving this behind the doctor boundary.
- Maintainer decision: tighten the Blacksmith/hosted startup-memory budgets now that the measured baseline is ~243 MB.
