### PR TITLE
test(whatsapp): drop dead monitor-inbox harness generality

### DIFF
--- a/extensions/whatsapp/src/monitor-inbox.test-harness.ts
+++ b/extensions/whatsapp/src/monitor-inbox.test-harness.ts
@@ -65,7 +65,6 @@ const channelActivityMocks = vi.hoisted(() => ({
 const pluginRuntimeMocks = vi.hoisted(() => {
   type StoreEntry = { key: string; value: unknown; createdAt: number };
   const stores = new Map<string, Map<string, StoreEntry>>();
-  let nextRegisterIfAbsentError: Error | undefined;
   let stateDir = `/tmp/openclaw-whatsapp-ingress-${Date.now()}-${Math.random()}`;
 
   const openKeyedStore = vi.fn((options: { namespace: string }) => {
@@ -79,11 +78,6 @@ const pluginRuntimeMocks = vi.hoisted(() => {
         store.set(key, { key, value, createdAt: Date.now() });
       },
       registerIfAbsent: async (key: string, value: unknown) => {
-        if (nextRegisterIfAbsentError) {
-          const error = nextRegisterIfAbsentError;
-          nextRegisterIfAbsentError = undefined;
-          throw error;
-        }
         if (store.has(key)) {
           return false;
         }
@@ -107,12 +101,8 @@ const pluginRuntimeMocks = vi.hoisted(() => {
   return {
     openKeyedStore,
     stateDir: () => stateDir,
-    failNextRegisterIfAbsent: (error: Error) => {
-      nextRegisterIfAbsentError = error;
-    },
     reset: () => {
       stores.clear();
-      nextRegisterIfAbsentError = undefined;
       openKeyedStore.mockClear();
       stateDir = `/tmp/openclaw-whatsapp-ingress-${Date.now()}-${Math.random()}`;
     },
@@ -388,26 +378,21 @@ export function buildNotifyMessageUpsert(params: {
   };
 }
 
-// The mocked pairing upsert always issues PAIRCODE, so the reply text can be
-// asserted directly instead of re-extracting the code from the message.
-function expectPairingPromptSent(sock: MockSock, jid: string, senderE164: string) {
+// The pairing reply is sent before the inbound handler completes, so a full
+// drain guarantees the prompt is observable — and makes the callers' negative
+// assertions (onMessage/readMessages never called) non-vacuous.
+export async function waitForPairingPromptSent(sock: MockSock, jid: string, senderE164: string) {
+  await waitForInboundWorkDrained();
   expect(sock.sendMessage).toHaveBeenCalledTimes(1);
   const sendCall = sock.sendMessage.mock.calls.at(0);
   expect(sendCall?.[0]).toBe(jid);
+  // The mocked pairing upsert always issues PAIRCODE.
   const text = (sendCall?.[1] as { text?: string } | undefined)?.text ?? "";
   expect(text).toContain("OpenClaw: access not configured.");
   expect(text).toContain(`Your WhatsApp phone number: ${senderE164}`);
   expect(text).toContain("Pairing code:");
   expect(text).toContain("\n```\nPAIRCODE\n```\n");
   expect(text).toContain("pairing approve whatsapp PAIRCODE");
-}
-
-// The pairing reply is sent before the inbound handler completes, so a full
-// drain guarantees the prompt is observable — and makes the callers' negative
-// assertions (onMessage/readMessages never called) non-vacuous.
-export async function waitForPairingPromptSent(sock: MockSock, jid: string, senderE164: string) {
-  await waitForInboundWorkDrained();
-  expectPairingPromptSent(sock, jid, senderE164);
 }
 
 let authDir: string | undefined;
@@ -419,9 +404,7 @@ export function getAuthDir(): string {
   return authDir;
 }
 
-export function installWebMonitorInboxUnitTestHooks(opts?: { authDir?: boolean }) {
-  const createAuthDir = opts?.authDir ?? true;
-
+export function installWebMonitorInboxUnitTestHooks() {
   beforeEach(async () => {
     vi.useRealTimers();
     vi.clearAllMocks();
@@ -447,11 +430,7 @@ export function installWebMonitorInboxUnitTestHooks(opts?: { authDir?: boolean }
       resetWebInboundDedupe = inboundModule.resetWebInboundDedupe;
     }
     resetWebInboundDedupe();
-    if (createAuthDir) {
-      authDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
-    } else {
-      authDir = undefined;
-    }
+    authDir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-"));
   });
 
   afterEach(() => {


### PR DESCRIPTION
Related: #131109, #131158

## What Problem This Solves

Third and final cleanup pass on the WhatsApp monitor-inbox test harness: three pieces of dead generality remained after the drain redesign (#131109) and internals simplification (#131158).

## Why This Change Was Made

A Codex simplification pass was asked whether anything further could be cut; it found three candidates, each verified against all consumers before landing:

- The `registerIfAbsent` fault-injection path (`failNextRegisterIfAbsent` / `nextRegisterIfAbsentError`) has zero callers anywhere — `pluginRuntimeMocks` never surfaced it to any test, so the setter, the state, and the throw branch were unreachable.
- `installWebMonitorInboxUnitTestHooks`' `{ authDir: false }` variant has no users; all five call sites are no-arg, so the hook now always creates the temp auth dir and the option plumbing is gone.
- `expectPairingPromptSent` folds into `waitForPairingPromptSent`, its only caller, preserving every assertion and the drain-before-assert ordering.

The three wait primitives (`settleInboundWork` / `waitForMessageCalls` / `waitForInboundWorkDrained`) and all their call sites are untouched.

## User Impact

None at runtime — test-support only (production LOC delta: 0; net −21 test-support lines, harness 466 → 445).

## Evidence

- `node scripts/run-vitest.mjs extensions/whatsapp/src/monitor-inbox` green (121 tests, run by the implementing worker and reverified).
- Full `node scripts/run-vitest.mjs extensions/whatsapp` green (98 files / 1366 tests), plus one round of two concurrent full-suite runs (the #131109 saturation stress) — all green.
- `node scripts/check-changed.mjs` green.
- Consumer verification: `rg` shows zero references to the removed fault-injection surface, all `installWebMonitorInboxUnitTestHooks(` call sites no-arg, zero remaining `expectPairingPromptSent` references.
- Codex autoreview clean ("patch is correct 0.99").
