### PR TITLE
fix(feishu): include thread_id in inbound debounce key when root_id is absent

### DIFF
--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -281,8 +281,8 @@ export function createFeishuMessageReceiveHandler({
         if (!chatId || !senderId) {
           return null;
         }
-        const rootId = event.message.root_id?.trim();
-        const threadKey = rootId ? `thread:${rootId}` : "chat";
+        const threadId = event.message.root_id?.trim() || event.message.thread_id?.trim();
+        const threadKey = threadId ? `thread:${threadId}` : "chat";
         return `feishu:${accountId}:${chatId}:${threadKey}:${senderId}`;
       },
       shouldDebounce: ({ event }) => {

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -154,6 +154,7 @@ function createTextEvent(params: {
   text: string;
   senderId?: string;
   mentions?: FeishuMention[];
+  threadId?: string;
 }): FeishuMessageEvent {
   const senderId = params.senderId ?? "ou_sender";
   return {
@@ -168,6 +169,7 @@ function createTextEvent(params: {
       message_type: "text",
       content: JSON.stringify({ text: params.text }),
       mentions: params.mentions,
+      ...(params.threadId ? { thread_id: params.threadId } : {}),
     },
   };
 }
@@ -599,6 +601,43 @@ describe("Feishu inbound debounce regressions", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("keeps root-less topic threads in separate debounce buckets", async () => {
+    setDedupPassThroughMocks();
+    const onMessage = await setupDebounceMonitor();
+
+    await enqueueDebouncedMessage(
+      onMessage,
+      createTextEvent({
+        messageId: "om_topic_a",
+        text: "topic alpha",
+        threadId: "omt_topic_a",
+      }),
+    );
+    await enqueueDebouncedMessage(
+      onMessage,
+      createTextEvent({
+        messageId: "om_topic_b",
+        text: "topic beta",
+        threadId: "omt_topic_b",
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(25);
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(2);
+    const dispatched = handleFeishuMessageMock.mock.calls.map(
+      ([params]) => params.event as FeishuMessageEvent,
+    );
+    expect(
+      dispatched.map((event) => ({
+        threadId: event.message.thread_id,
+        text: JSON.parse(event.message.content).text,
+      })),
+    ).toEqual([
+      { threadId: "omt_topic_a", text: "topic alpha" },
+      { threadId: "omt_topic_b", text: "topic beta" },
+    ]);
   });
 
   it("releases pending text before a bare abort trigger instead of debouncing it", async () => {


### PR DESCRIPTION
## What Problem This Solves

Feishu can send topic messages with `thread_id` but no `root_id`. The inbound debounce key then used chat scope, so rapid messages from different topics could become one agent turn.

Fixes #130028.

## Why This Change Was Made

The Feishu receive handler owns the debounce partition. It now uses the trimmed root ID first, then the native thread ID, and only then chat scope.

This keeps the production change net zero and preserves root precedence. The monitor-level regression protects the same boundary that registers `im.message.receive_v1` and uses the shared production debouncer.

Thanks to @emberb170d for this repair and @KhanCold for the independent earlier report and fix in #130090.

## User Impact

Rapid messages from different root-less Feishu topics stay in their own agent turns. Messages in the same topic still debounce together.

## Evidence

- Live red on current main `1dba34be9be1249c0e35badcb5ec887ce5d71c72`: two valid signed webhook events with different `thread_id` values returned HTTP 200 but produced one merged dispatch.
- Live green on head `689dd68574dfa21d2b7fc83c564d155470035f83`: the same flow produced two dispatches, each with its own thread ID and text.
- Boundary controls passed: invalid signatures returned HTTP 401, same-topic messages still merged, distinct roots stayed separate, and chat fallback still merged.
- `node scripts/run-vitest.mjs extensions/feishu/src/monitor.reaction.test.ts --reporter=dot` — 31 passed.
- `node scripts/run-vitest.mjs extensions/feishu/src/monitor.message-handler.ingress.test.ts --reporter=dot` — 10 passed.
- `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts --reporter=dot` — 102 passed.
- `node scripts/check-changed.mjs -- extensions/feishu/src/monitor.message-handler.ts extensions/feishu/src/monitor.reaction.test.ts` — passed.
- Production: `+2/-2`; tests: `+39/-0`.
