### PR TITLE
fix(ci): prevent updater tests leaking pending handoffs

### DIFF
--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -35,7 +35,6 @@ const { forceKillChildProcessTreeMock, spawnMock } = vi.hoisted(() => ({
   forceKillChildProcessTreeMock: vi.fn(),
   spawnMock: vi.fn(),
 }));
-const FAST_WAIT_OPTS = { interval: 1 } as const;
 const MOCK_INSTALL_ROOT = path.join(os.tmpdir(), `openclaw-handoff-lifecycle-${process.pid}`);
 
 function createSpawnMock(params?: { pid?: number }) {
@@ -400,7 +399,13 @@ describe("managed service update handoff", () => {
 
   it("rejects failed helper spawns and removes the sensitive handoff directory", async () => {
     const child = createSpawnMock();
-    spawnMock.mockReturnValueOnce(child);
+    // Fire after spawn installs readiness listeners; preparation has no one-second deadline.
+    spawnMock.mockImplementationOnce(() => {
+      process.nextTick(() => {
+        child.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
+      });
+      return child;
+    });
     const { startManagedServiceUpdateHandoff } =
       await import("./update-managed-service-handoff.js");
 
@@ -412,14 +417,12 @@ describe("managed service update handoff", () => {
       argv1: "/opt/openclaw/openclaw.mjs",
       meta: { sessionKey: "agent:test:webchat:dm:user-123" },
     });
-    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1), FAST_WAIT_OPTS);
+    await expect(resultPromise).rejects.toMatchObject({ code: "ENOENT" });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
     const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
     const handoffDir = path.dirname(args[0] ?? "");
     tempDirs.add(handoffDir);
 
-    child.emit("error", Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }));
-
-    await expect(resultPromise).rejects.toMatchObject({ code: "ENOENT" });
     expect(child.unref).not.toHaveBeenCalled();
     await expect(pathExists(handoffDir)).resolves.toBe(false);
     expect(child.listenerCount("exit")).toBe(0);
@@ -429,7 +432,10 @@ describe("managed service update handoff", () => {
 
   it("rejects a systemd-run launcher that exits before the helper is ready", async () => {
     const child = createSpawnMock();
-    spawnMock.mockReturnValueOnce(child);
+    spawnMock.mockImplementationOnce(() => {
+      process.nextTick(() => child.emit("exit", 1, null));
+      return child;
+    });
     const binDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-systemd-run-bin-"));
     tempDirs.add(binDir);
     await fs.writeFile(path.join(binDir, "systemd-run"), "#!/bin/sh\nexit 0\n", { mode: 0o755 });
@@ -446,16 +452,14 @@ describe("managed service update handoff", () => {
       env: { PATH: binDir, OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" },
       meta: {},
     });
-    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1), FAST_WAIT_OPTS);
+    await expect(resultPromise).rejects.toThrow(
+      "managed update handoff exited before signaling readiness (code=1, signal=null)",
+    );
+    expect(spawnMock).toHaveBeenCalledTimes(1);
     const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
     const handoffDir = path.dirname(args.at(-2) ?? "");
     tempDirs.add(handoffDir);
 
-    child.emit("exit", 1, null);
-
-    await expect(resultPromise).rejects.toThrow(
-      "managed update handoff exited before signaling readiness (code=1, signal=null)",
-    );
     expect(child.unref).not.toHaveBeenCalled();
     await expect(pathExists(handoffDir)).resolves.toBe(false);
     expect(child.listenerCount("exit")).toBe(0);
@@ -466,7 +470,11 @@ describe("managed service update handoff", () => {
   it("terminates a detached helper that misses the readiness deadline", async () => {
     vi.useFakeTimers();
     const child = createSpawnMock();
-    spawnMock.mockReturnValueOnce(child);
+    spawnMock.mockImplementationOnce(() => {
+      // The readiness timer is armed after spawn returns, not during filesystem preparation.
+      process.nextTick(() => vi.advanceTimersByTime(30_000));
+      return child;
+    });
     const { startManagedServiceUpdateHandoff } =
       await import("./update-managed-service-handoff.js");
 
@@ -478,17 +486,14 @@ describe("managed service update handoff", () => {
       argv1: "/opt/openclaw/openclaw.mjs",
       meta: {},
     });
-    const rejection = resultPromise.catch((err: unknown) => err);
-    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1), FAST_WAIT_OPTS);
+    await expect(resultPromise).rejects.toMatchObject({
+      message: "managed update handoff did not signal readiness within 30 seconds",
+    });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
     const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
     const handoffDir = path.dirname(args[0] ?? "");
     tempDirs.add(handoffDir);
 
-    await vi.advanceTimersByTimeAsync(30_000);
-
-    await expect(rejection).resolves.toMatchObject({
-      message: "managed update handoff did not signal readiness within 30 seconds",
-    });
     expect(forceKillChildProcessTreeMock).toHaveBeenCalledExactlyOnceWith(child);
     expect(child.unref).not.toHaveBeenCalled();
     await expect(pathExists(handoffDir)).resolves.toBe(false);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where managed-update lifecycle tests fail on busy Linux CI runners and leave an unfinished handoff operation running during the next test. The full-main validation run [33114810409](https://github.com/openclaw/openclaw/actions/runs/33114810409/job/98667024752) reproduced the failure: the launcher-exit test expected a spawn within one second, then a late helper-lease rejection escaped into a later case.

## Why This Change Was Made

Handoff preparation performs asynchronous filesystem and systemd discovery before spawning the helper. The three failure tests now schedule their fault from the mocked spawn callback and immediately await the actual terminal handoff promise, then assert call counts and cleanup. This removes the independent one-second polling deadline and the abandoned-promise race. The existing readiness deadline remains 30 seconds; no production code, discovery, lease validation, or safety policy changes.

## User Impact

No runtime or configuration change. Maintainer-requested, AI-assisted CI reliability repair: failure tests wait for the behavior they exercise and finish before their fixtures are removed. Production LOC: +0/-0. Test LOC: +26/-21.

## Evidence

- Frozen baseline: `79dfa81664fd64a3f6192331af4953ff9f9bf1ef`.
- Before: the unchanged original 32-case lifecycle order, with a diagnostic preload delaying one real systemd-discovery filesystem access by 1.5 seconds, produced **1 failed / 31 passed and one unhandled rejection**. The spawn-zero assertion failed after 1.022 seconds. The late macOS error concerned the deleted systemd-run fixture; Linux CI instead reached its native fallback and failed lease validation. These are distinct downstream symptoms of the abandoned operation.
- After: the same delayed original order passed **32/32**, with no unhandled rejection. Final bytes also passed all three changed cases with that same delay.
- Normal owner/sibling proof: `node scripts/run-vitest.mjs src/infra/update-managed-service-handoff-lifecycle.test.ts src/infra/update-managed-service-handoff-command.test.ts src/infra/update-managed-service-handoff-ownership.test.ts src/infra/update-managed-service-handoff-cross-process.test.ts src/infra/update-managed-service-handoff-single-flight.test.ts` — **79 passed, 2 existing Windows-only skips, five files passed**.
- Independent Codex static review completed with no P0 findings. Manual review covered the complete handoff owner, test lifecycle, discovery path, sibling fixtures, and installed Vitest polling behavior.
- Formatting, `git diff --check`, and the complete changed gate passed, including core test types, type-aware lint, guards, and three dead-export scans. The first gate attempt exposed a missing UI dependency link in the isolated worktree; correcting that link to the same pinned install resolved it without source changes. Exact-head CI is tracked below as it completes.

The delay preload is diagnostic evidence, not shipped code or part of normal tests. This is test-lifecycle proof; it does not claim a live systemd/launchd service update or a repaired production lease defect.
