### PR TITLE
feat(claws): adopt configured agents

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2331,7 +2331,6 @@ src/channels/turn/history-window.ts	1
 src/channels/turn/lifecycle.ts	3
 src/channels/turn/route-dm-scope.ts	1
 src/channels/turn/run-channel-turn.ts	6
-src/claws/add.ts	7
 src/claws/cron.ts	15
 src/claws/doctor.ts	2
 src/claws/export.ts	8
@@ -2343,7 +2342,7 @@ src/claws/packages.ts	1
 src/claws/project-build.ts	4
 src/claws/project.ts	4
 src/claws/provenance-runtime-read.ts	1
-src/claws/provenance.ts	6
+src/claws/provenance.ts	5
 src/claws/reader.ts	8
 src/claws/schema.ts	3
 src/claws/update-capability-changes.ts	11
@@ -2362,7 +2361,7 @@ src/cli/channel-auth.ts	4
 src/cli/channel-options.ts	1
 src/cli/channels-cli.ts	7
 src/cli/claws-cli.gateway-readiness.ts	1
-src/cli/claws-cli.runtime.ts	2
+src/cli/claws-cli.runtime.ts	1
 src/cli/command-config-resolution.ts	2
 src/cli/command-format.ts	1
 src/cli/command-options.ts	1

--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -340,6 +340,37 @@ instructions, writes declared workspace assets, realizes workspace skills, and
 records package, MCP, and cron provenance. Existing files are not overwritten,
 and retries fail closed when owned content drifted.
 
+By default an existing workspace directory is a `workspace_collision` blocker.
+Pass `--adopt-existing-workspace` during both preview and apply to install into
+an existing directory instead:
+
+```bash
+openclaw claws add ./incident-triage.claw.json \
+  --workspace ~/agents/incident-triage \
+  --adopt-existing-workspace \
+  --dry-run --json
+```
+
+At plan time each declared file is compared against the existing content:
+identical files become `adopt` actions and are recorded as managed without
+being rewritten, missing files are written normally, and differing content is a
+`workspace_file_conflict` blocker — adoption never overwrites existing files.
+If the package defines first-run instructions, any existing package bootstrap
+file is also a conflict, even when its content matches; Claws cannot safely
+claim or later remove a bootstrap file it did not create.
+Apply re-verifies content digests and fails closed when an adoptable file
+changed after planning. The agent is added to configuration only after every
+workspace file has been safely revalidated and recorded, so a failed adoption
+cannot leave a partially owned workspace routable. Adoption is disclosed as a
+distinct capability change in the plan, and a workspace already configured for
+another agent still blocks.
+
+Adoption transfers lifecycle ownership of matching declared files to Claws.
+After adoption, `claws update` may replace an unchanged adopted file with the
+content from the reviewed target package, and `claws remove` may delete an
+unchanged adopted file. Locally modified adopted files are retained and must be
+reconciled explicitly. Preview update and removal plans before applying them.
+
 ## Inspect installed state
 
 ```bash
@@ -477,7 +508,7 @@ credentials, sessions, and unowned local state are excluded.
 | `claws dev [path]`                  | Build and preview locally without mutation.         |
 | `claws build [path] --out <tgz>`    | Build a deterministic package artifact.             |
 | `claws inspect <source>`            | Validate a package directory or grouped manifest.   |
-| `claws add <source>`                | Preview or create one new agent and workspace.      |
+| `claws add <source>`                | Preview or create one agent and its workspace.      |
 | `claws status [claw-or-agent]`      | Report installed state, ownership, and drift.       |
 | `claws update <claw-or-agent>`      | Preview or apply changes from the selected source.  |
 | `claws remove <claw-or-agent>`      | Preview or remove the agent and eligible resources. |

--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -9,10 +9,11 @@ title: "Claws"
 
 # `openclaw claws`
 
-A Claw is a versioned setup for one new OpenClaw agent. It can describe the
+A Claw is a versioned setup for one OpenClaw agent. It can describe the
 agent's portable identity, workspace files, skills, plugins, MCP servers, and
 cron jobs. Harness-specific agent settings may be carried in a conventional
-package profile. A Claw does not replace or modify an existing agent.
+package profile. By default, add creates a new agent; explicit adoption can
+transfer lifecycle ownership of an exact existing configuration.
 
 Claws are experimental. Their schema, command output, and lifecycle may change.
 Enable the command surface explicitly:
@@ -371,6 +372,52 @@ content from the reviewed target package, and `claws remove` may delete an
 unchanged adopted file. Locally modified adopted files are retained and must be
 reconciled explicitly. Preview update and removal plans before applying them.
 
+### Adopt a configured agent
+
+Use configured-agent adoption to bring an agent that predates Claws under the
+same package lifecycle. Pass the same agent id, workspace, and explicit flag in
+both preview and apply:
+
+```bash
+openclaw claws add ./incident-triage.claw.json \
+  --agent-id incident-triage \
+  --workspace ~/agents/incident-triage \
+  --adopt-existing-agent \
+  --dry-run --json
+
+openclaw claws add ./incident-triage.claw.json \
+  --agent-id incident-triage \
+  --workspace ~/agents/incident-triage \
+  --adopt-existing-agent \
+  --yes \
+  --plan-integrity <SHA256_FROM_DRY_RUN>
+```
+
+`--adopt-existing-agent` also opts into adoption of that agent's configured
+workspace. The agent must exist without another Claw install record, its
+canonical workspace must equal the requested workspace, and no other agent may
+use an overlapping workspace. After preserving the existing `default` marker,
+the complete package-derived agent configuration must match exactly. Adoption
+never rewrites a differing agent entry; the plan reports only the differing
+field paths and blocks.
+
+Successful adoption transfers ownership of the matching agent configuration,
+declared workspace files, and other managed package resources. Status exposes
+`agentOrigin: "adopted"`. Update retains the adopted agent's recorded
+`default` marker and still treats any later full-configuration change as drift.
+
+Removal deletes the managed agent configuration, derived bindings and allow
+references, unchanged managed workspace files, and eligible package, MCP, and
+cron resources. It never deletes an adopted agent's pre-existing agent
+directory or database, session index, session transcripts, workspace
+directory, or undeclared workspace files. Those historical artifacts remain
+on disk after the Claw install record is removed.
+
+Adopted-agent ownership uses a newer install-record format as a downgrade
+fence. Builds that predate configured-agent adoption reject that record before
+status, update, or removal can mutate it. Complete the lifecycle with a build
+that supports configured-agent adoption before downgrading.
+
 ## Inspect installed state
 
 ```bash
@@ -379,7 +426,8 @@ openclaw claws status incident-triage --json
 openclaw doctor
 ```
 
-`status` compares the installed agent and its recorded workspace, package, MCP,
+`status` reports whether the agent was created or adopted, then compares the
+installed agent and its recorded workspace, package, MCP,
 and cron provenance with current state. It also reports whether native
 first-run bootstrap remains pending. It reports incomplete installs, missing
 resources, and drift without changing local state. `openclaw doctor` adds

--- a/docs/cli/claws.md
+++ b/docs/cli/claws.md
@@ -360,11 +360,13 @@ If the package defines first-run instructions, any existing package bootstrap
 file is also a conflict, even when its content matches; Claws cannot safely
 claim or later remove a bootstrap file it did not create.
 Apply re-verifies content digests and fails closed when an adoptable file
-changed after planning. The agent is added to configuration only after every
-workspace file has been safely revalidated and recorded, so a failed adoption
-cannot leave a partially owned workspace routable. Adoption is disclosed as a
-distinct capability change in the plan, and a workspace already configured for
-another agent still blocks.
+changed after planning. Claws seeds any package bootstrap before publishing the
+agent, then reserves the agent configuration before recording workspace files so
+the workspace claim is checked in the authoritative config write. If file
+revalidation fails, Claws rolls back that reservation when the live config still
+matches the reviewed plan, so a failed adoption cannot leave a partially owned
+workspace routable. Adoption is disclosed as a distinct capability change in
+the plan, and a workspace already configured for another agent still blocks.
 
 Adoption transfers lifecycle ownership of matching declared files to Claws.
 After adoption, `claws update` may replace an unchanged adopted file with the
@@ -406,12 +408,20 @@ declared workspace files, and other managed package resources. Status exposes
 `agentOrigin: "adopted"`. Update retains the adopted agent's recorded
 `default` marker and still treats any later full-configuration change as drift.
 
+Adoption owns nothing until the final configuration write lands. If that write
+loses to a concurrent config change, `claws add` rolls back the files it wrote
+during the attempt and releases the ownership record, leaving the agent and its
+workspace as the operator left them; rerun `claws add --dry-run` to preview
+again. Managed state that cannot be rolled back keeps the record so
+`claws remove` can release it, and the error names what remains.
+
 Removal deletes the managed agent configuration, derived bindings and allow
 references, unchanged managed workspace files, and eligible package, MCP, and
 cron resources. It never deletes an adopted agent's pre-existing agent
-directory or database, session index, session transcripts, workspace
-directory, or undeclared workspace files. Those historical artifacts remain
-on disk after the Claw install record is removed.
+directory or database, its durable database registration, session index,
+session transcripts, workspace directory, or undeclared workspace files. Those
+historical artifacts remain on disk, and discoverable, after the Claw install
+record is removed.
 
 Adopted-agent ownership uses a newer install-record format as a downgrade
 fence. Builds that predate configured-agent adoption reject that record before

--- a/src/agents/agent-delete-safety.ts
+++ b/src/agents/agent-delete-safety.ts
@@ -35,7 +35,7 @@ export function isInheritedAuthStoreOwner(cfg: OpenClawConfig, agentId: string):
   }
   return agentId === normalizeAgentId(resolveLegacyInheritedAuthAgentId(cfg));
 }
-function workspacePathsOverlap(left: string, right: string): boolean {
+export function workspacePathsOverlap(left: string, right: string): boolean {
   const normalizedLeft = resolveCanonicalWorkspacePath(left.replaceAll("\0", ""));
   const normalizedRight = resolveCanonicalWorkspacePath(right.replaceAll("\0", ""));
   return (

--- a/src/agents/workspace-bootstrap-seed-marker.ts
+++ b/src/agents/workspace-bootstrap-seed-marker.ts
@@ -1,0 +1,30 @@
+// The seed marker and the BOOTSTRAP.md it describes are one fact. An attempt that rolls back the
+// file it seeded must drop the marker with it, or the next seed reads "already seeded, file gone"
+// as consumed and silently writes nothing.
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  runOpenClawStateWriteTransaction,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import { resolveWorkspaceStateIdentity } from "./workspace-state-identity.js";
+
+type WorkspaceSetupStateDatabase = Pick<OpenClawStateKyselyDatabase, "workspace_setup_state">;
+
+export function clearWorkspaceBootstrapSeedMarker(
+  workspaceDir: string,
+  nowMs = Date.now(),
+  options: OpenClawStateDatabaseOptions = {},
+): void {
+  const identity = resolveWorkspaceStateIdentity(workspaceDir);
+  runOpenClawStateWriteTransaction((database) => {
+    const kysely = getNodeSqliteKysely<WorkspaceSetupStateDatabase>(database.db);
+    executeSqliteQuerySync(
+      database.db,
+      kysely
+        .updateTable("workspace_setup_state")
+        .set({ bootstrap_seeded_at: null, updated_at: nowMs })
+        .where("workspace_key", "=", identity.workspaceKey),
+    );
+  }, options);
+}

--- a/src/claws/add-adoption-release.test.ts
+++ b/src/claws/add-adoption-release.test.ts
@@ -1,0 +1,132 @@
+// Rollback boundary for an adoption whose config commit never landed.
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  mergeWorkspaceSetupState,
+  readWorkspaceStateSnapshot,
+} from "../agents/workspace-state-store.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { releaseUnclaimedClawAdoption } from "./add-adoption-release.js";
+import type { PersistedClawInstall } from "./provenance.js";
+import type { ClawAddPlan } from "./types.js";
+import {
+  CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+  type PersistedClawWorkspaceFile,
+} from "./workspace.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+function digest(content: string): string {
+  return `sha256:${createHash("sha256").update(content).digest("hex")}`;
+}
+
+function ownedFile(workspace: string, path: string, content: string): PersistedClawWorkspaceFile {
+  return {
+    schemaVersion: CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+    agentId: "worker",
+    workspace,
+    path,
+    sourcePath: path,
+    contentDigest: digest(content),
+    status: "complete",
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  };
+}
+
+function installRecord(workspace: string, bootstrapContent?: string): PersistedClawInstall {
+  return {
+    schemaVersion: "openclaw.clawInstallRecord.v3",
+    claw: {
+      kind: "package",
+      name: "@acme/worker",
+      version: "1.0.0",
+      packageRoot: workspace,
+      manifestPath: join(workspace, "openclaw.claw.json"),
+      integrityKind: "artifact",
+      integrity: "sha256:manifest",
+      byteLength: 1,
+    },
+    manifestSchemaVersion: 1,
+    planIntegrity: "sha256:plan",
+    agentId: "worker",
+    workspace,
+    agentConfigDigest: "sha256:agent",
+    agentOwnedPaths: [],
+    agentOrigin: "adopted",
+    status: "workspace_ready",
+    addedAtMs: 1,
+    updatedAtMs: 1,
+    ...(bootstrapContent
+      ? { bootstrap: { sourcePath: "BOOTSTRAP.md", contentDigest: digest(bootstrapContent) } }
+      : {}),
+  } as PersistedClawInstall;
+}
+
+function planWith(workspace: string, actions: ClawAddPlan["actions"]): ClawAddPlan {
+  return { agent: { finalId: "worker", workspace }, actions } as unknown as ClawAddPlan;
+}
+
+describe("releaseUnclaimedClawAdoption", () => {
+  it("keeps a declared file the attempt adopted instead of writing", async () => {
+    const root = tempDirs.make("openclaw-claw-release-adopted-");
+    const workspace = join(root, "workspace");
+    await mkdir(workspace);
+    const adopted = join(workspace, "SKILL.md");
+    await writeFile(adopted, "operator content");
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+
+    const result = await releaseUnclaimedClawAdoption({
+      plan: planWith(workspace, [
+        {
+          kind: "workspaceFile",
+          id: "SKILL.md",
+          action: "adopt",
+          target: adopted,
+          blocked: false,
+        },
+      ] as ClawAddPlan["actions"]),
+      install: installRecord(workspace),
+      workspaceFiles: [ownedFile(workspace, "SKILL.md", "operator content")],
+      packages: [],
+      bootstrapSeeded: false,
+      options: { env },
+    });
+
+    expect(result).toEqual({ released: true, retained: [] });
+    // The attempt claimed this file, it never wrote it; releasing the claim must not delete it.
+    expect(existsSync(adopted)).toBe(true);
+  });
+
+  it("clears the seed marker with the bootstrap it rolls back", async () => {
+    const root = tempDirs.make("openclaw-claw-release-bootstrap-");
+    const workspace = join(root, "workspace");
+    await mkdir(workspace);
+    const bootstrap = join(workspace, "BOOTSTRAP.md");
+    await writeFile(bootstrap, "seeded bootstrap");
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    mergeWorkspaceSetupState(workspace, { bootstrapSeededAt: new Date(1).toISOString() }, 1, {
+      env,
+    });
+
+    const result = await releaseUnclaimedClawAdoption({
+      plan: planWith(workspace, [] as ClawAddPlan["actions"]),
+      install: installRecord(workspace, "seeded bootstrap"),
+      workspaceFiles: [],
+      packages: [],
+      bootstrapSeeded: true,
+      options: { env, nowMs: 2 },
+    });
+
+    expect(result).toEqual({ released: true, retained: [] });
+    expect(existsSync(bootstrap)).toBe(false);
+    // A marker left behind makes the next seed read "already seeded, file gone" as consumed and
+    // silently skip the retry's bootstrap.
+    expect(readWorkspaceStateSnapshot(workspace, { env }).setup.bootstrapSeededAt).toBeUndefined();
+  });
+});

--- a/src/claws/add-adoption-release.ts
+++ b/src/claws/add-adoption-release.ts
@@ -1,0 +1,100 @@
+import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
+// Adoption owns an operator-configured agent only once the final config compare-and-swap wins.
+// A record kept after that swap loses claims an agent Claw never took: resume rejects the changed
+// digest, remove refuses a modified agent, and a remove that did run would delete operator config
+// Claw never adopted. Roll back exactly what this attempt wrote, then drop the claim.
+import { clearWorkspaceBootstrapSeedMarker } from "../agents/workspace-bootstrap-seed-marker.js";
+import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
+import type { ClawAddApplyOptions } from "./add-contract.js";
+import {
+  releaseClawRemoveRows,
+  removeClawWorkspaceFile,
+  type RemovedWorkspaceFile,
+} from "./lifecycle-delete-support.js";
+import { applyClawPackageRemovals, planClawPackageRemovals } from "./package-remove.js";
+import type { PersistedClawInstall, PersistedClawPackageRef } from "./provenance.js";
+import type { ClawAddPlan } from "./types.js";
+import type { PersistedClawWorkspaceFile } from "./workspace.js";
+
+/**
+ * Releases an adoption record whose config commit never landed. Returns the paths that survived
+ * rollback; while any remain, Claw still owns real state and keeps the record to clean it later.
+ */
+export async function releaseUnclaimedClawAdoption(params: {
+  plan: ClawAddPlan;
+  install: PersistedClawInstall;
+  workspaceFiles: PersistedClawWorkspaceFile[];
+  packages: PersistedClawPackageRef[];
+  bootstrapSeeded: boolean;
+  options: ClawAddApplyOptions;
+}): Promise<{ released: boolean; retained: string[] }> {
+  // A declared file that already existed with identical content was adopted, not written, so the
+  // attempt owns its row but never owned its bytes. Dropping the row is the whole rollback.
+  const adoptedPaths = new Set(
+    params.plan.actions
+      .filter((action) => action.kind === "workspaceFile" && action.action === "adopt")
+      .map((action) => action.id),
+  );
+  const removals: RemovedWorkspaceFile[] = [];
+  for (const file of params.workspaceFiles) {
+    removals.push(
+      adoptedPaths.has(file.path)
+        ? { path: file.path, action: "missing" }
+        : await removeClawWorkspaceFile({ ...file, state: "unchanged" }),
+    );
+  }
+  let bootstrapRemoval: RemovedWorkspaceFile | undefined;
+  if (params.install.bootstrap) {
+    bootstrapRemoval = await removeClawWorkspaceFile(
+      {
+        workspace: params.install.workspace,
+        path: DEFAULT_BOOTSTRAP_FILENAME,
+        contentDigest: params.install.bootstrap.contentDigest,
+        state: "unchanged",
+      },
+      MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+    );
+    removals.push(bootstrapRemoval);
+  }
+  // The seed marker and the file are one fact. Deleting the file while the marker stands makes the
+  // next seed read "already seeded, file gone" as consumed and write nothing at all.
+  if (params.bootstrapSeeded && bootstrapRemoval?.action === "deleted") {
+    clearWorkspaceBootstrapSeedMarker(
+      params.install.workspace,
+      params.options.nowMs ?? Date.now(),
+      params.options,
+    );
+  }
+  const retained = removals
+    .filter((removal) => removal.action === "retainedModified" || removal.action === "error")
+    .map((removal) => removal.path);
+  // Stop before the packages when a file survived: half-uninstalling what the retained record
+  // still claims would leave ownership describing state that is already gone.
+  if (retained.length > 0) {
+    releaseClawRemoveRows(params.install.agentId, removals, false, params.options, true);
+    return { released: false, retained };
+  }
+  if (params.packages.length > 0) {
+    const decisions = await planClawPackageRemovals(
+      params.install,
+      params.packages,
+      params.options,
+    );
+    const results = await applyClawPackageRemovals(decisions, params.options);
+    // A referenced package another Claw still owns stays installed; only a failed uninstall
+    // leaves state this attempt cannot account for.
+    retained.push(
+      ...results
+        .filter((result) => result.action === "error")
+        .map((result) => `${result.kind}:${result.ref}`),
+    );
+  }
+  if (retained.length > 0) {
+    releaseClawRemoveRows(params.install.agentId, removals, false, params.options, true);
+    return { released: false, retained };
+  }
+  // Adopted state was never Claw-created, so its durable agent-database registration is not this
+  // attempt's to unregister.
+  releaseClawRemoveRows(params.install.agentId, removals, true, params.options, true);
+  return { released: true, retained: [] };
+}

--- a/src/claws/add-agent-adoption.test.ts
+++ b/src/claws/add-agent-adoption.test.ts
@@ -1,0 +1,205 @@
+// Apply-time compare-and-swap coverage for adopting a configured agent.
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { applyClawAddPlan } from "./add.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import { persistClawInstallRecord, readClawInstallRecord } from "./provenance.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawAddPlan, ClawSourceIdentity } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+async function fixture(): Promise<{
+  root: string;
+  plan: ClawAddPlan;
+  config: OpenClawConfig;
+}> {
+  const root = tempDirs.make("openclaw-claw-agent-adopt-apply-");
+  const workspace = join(root, "workspace");
+  await mkdir(workspace);
+  const parsed = parseClawManifest({
+    schemaVersion: 1,
+    agent: { id: "worker", name: "Worker" },
+  });
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.diagnostics));
+  }
+  const source: ClawSourceIdentity = {
+    kind: "package",
+    name: "@acme/worker",
+    version: "1.0.0",
+    packageRoot: root,
+    manifestPath: join(root, "openclaw.claw.json"),
+    integrityKind: "artifact",
+    integrity: "sha256:manifest",
+    byteLength: 1,
+  };
+  const existing = { id: "worker", name: "Worker", workspace, default: true };
+  const plan = await buildClawAddPlan({
+    manifest: parsed.manifest,
+    source,
+    context: { workspace, adoptExistingAgent: true, existingAgents: [existing] },
+  });
+  return {
+    root,
+    plan,
+    config: { agents: { entries: { worker: { name: "Worker", workspace, default: true } } } },
+  };
+}
+
+describe("applyClawAddPlan agent adoption", () => {
+  it("asserts exact config without rewriting the adopted entry", async () => {
+    const { root, plan, config } = await fixture();
+    const commitConfig = vi.fn(async (transform) => {
+      expect(transform(config)).toBe(config);
+    });
+
+    const result = await applyClawAddPlan(plan, {
+      env: { OPENCLAW_STATE_DIR: join(root, "state") },
+      consentPlanIntegrity: plan.planIntegrity,
+      readConfig: () => config,
+      commitConfig,
+    });
+
+    expect(result).toMatchObject({ status: "complete", configCommitted: true });
+    expect(commitConfig).toHaveBeenCalledOnce();
+  });
+
+  it("accepts a canonical plan for a non-canonical configured roster key", async () => {
+    const { root, plan, config } = await fixture();
+    const worker = config.agents?.entries?.worker;
+    if (!worker) {
+      throw new Error("fixture agent missing");
+    }
+    const nonCanonicalConfig: OpenClawConfig = {
+      agents: { entries: { WORKER: worker } },
+    };
+    const commitConfig = vi.fn(async (transform) => {
+      expect(transform(nonCanonicalConfig)).toBe(nonCanonicalConfig);
+    });
+
+    const result = await applyClawAddPlan(plan, {
+      env: { OPENCLAW_STATE_DIR: join(root, "state") },
+      consentPlanIntegrity: plan.planIntegrity,
+      readConfig: () => nonCanonicalConfig,
+      commitConfig,
+    });
+
+    expect(result).toMatchObject({ status: "complete", configCommitted: true });
+    expect(commitConfig).toHaveBeenCalledOnce();
+  });
+
+  it("clears a new pending record when the pre-mutation digest changed", async () => {
+    const { root, plan, config } = await fixture();
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const installPackages = vi.fn();
+    const createWorkspaceFiles = vi.fn();
+    const commitConfig = vi.fn();
+
+    await expect(
+      applyClawAddPlan(plan, {
+        env,
+        consentPlanIntegrity: plan.planIntegrity,
+        readConfig: () => ({
+          ...config,
+          agents: { entries: { worker: { ...config.agents?.entries?.worker, name: "Changed" } } },
+        }),
+        installPackages,
+        createWorkspaceFiles,
+        commitConfig,
+      }),
+    ).rejects.toMatchObject({ code: "agent_config_conflict" });
+
+    expect(installPackages).not.toHaveBeenCalled();
+    expect(createWorkspaceFiles).not.toHaveBeenCalled();
+    expect(commitConfig).not.toHaveBeenCalled();
+    expect(readClawInstallRecord("worker", { env })).toBeUndefined();
+  });
+
+  it("keeps durable v3 provenance when the final compare-and-swap loses a race", async () => {
+    const { root, plan, config } = await fixture();
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+
+    const result = await applyClawAddPlan(plan, {
+      env,
+      consentPlanIntegrity: plan.planIntegrity,
+      readConfig: () => config,
+      commitConfig: async (transform) => {
+        transform({
+          ...config,
+          agents: { entries: { worker: { ...config.agents?.entries?.worker, name: "Raced" } } },
+        });
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      error: { code: "agent_config_conflict" },
+      installRecord: { agentOrigin: "adopted" },
+    });
+    expect(readClawInstallRecord("worker", { env })).toMatchObject({
+      schemaVersion: "openclaw.clawInstallRecord.v3",
+      agentOrigin: "adopted",
+    });
+  });
+
+  it("rejects a concurrently configured overlapping workspace in the final CAS", async () => {
+    const { root, plan, config } = await fixture();
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    let committedConfig: OpenClawConfig | undefined;
+
+    const result = await applyClawAddPlan(plan, {
+      env,
+      consentPlanIntegrity: plan.planIntegrity,
+      readConfig: () => config,
+      commitConfig: async (transform) => {
+        const racedConfig: OpenClawConfig = {
+          ...config,
+          agents: {
+            entries: {
+              ...config.agents?.entries,
+              other: { workspace: join(plan.agent.workspace, "nested") },
+            },
+          },
+        };
+        committedConfig = transform(racedConfig);
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      configCommitted: false,
+      error: { code: "agent_workspace_conflict" },
+      installRecord: { agentOrigin: "adopted" },
+    });
+    expect(committedConfig).toBeUndefined();
+  });
+
+  it("preserves an existing v3 resume record when the early digest check loses a race", async () => {
+    const { root, plan, config } = await fixture();
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const resumeRecord = persistClawInstallRecord(plan, { env, status: "partial", nowMs: 1 });
+    const installPackages = vi.fn();
+
+    await expect(
+      applyClawAddPlan(plan, {
+        env,
+        resumeRecord,
+        consentPlanIntegrity: plan.planIntegrity,
+        readConfig: () => ({
+          ...config,
+          agents: { entries: { worker: { ...config.agents?.entries?.worker, name: "Raced" } } },
+        }),
+        installPackages,
+      }),
+    ).rejects.toMatchObject({ code: "agent_config_conflict" });
+
+    expect(installPackages).not.toHaveBeenCalled();
+    expect(readClawInstallRecord("worker", { env })).toEqual(resumeRecord);
+  });
+});

--- a/src/claws/add-agent-adoption.test.ts
+++ b/src/claws/add-agent-adoption.test.ts
@@ -1,5 +1,7 @@
 // Apply-time compare-and-swap coverage for adopting a configured agent.
-import { mkdir } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -10,6 +12,24 @@ import { buildClawAddPlan } from "./lifecycle.js";
 import { persistClawInstallRecord, readClawInstallRecord } from "./provenance.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawAddPlan, ClawSourceIdentity } from "./types.js";
+import {
+  CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+  type PersistedClawWorkspaceFile,
+} from "./workspace.js";
+
+function managedWorkspaceFile(plan: ClawAddPlan, content: string): PersistedClawWorkspaceFile {
+  return {
+    schemaVersion: CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+    agentId: plan.agent.finalId,
+    workspace: plan.agent.workspace,
+    path: "SKILL.md",
+    sourcePath: "SKILL.md",
+    contentDigest: `sha256:${createHash("sha256").update(content).digest("hex")}`,
+    status: "complete",
+    createdAtMs: 1,
+    updatedAtMs: 1,
+  };
+}
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => closeOpenClawStateDatabaseForTest());
@@ -121,7 +141,7 @@ describe("applyClawAddPlan agent adoption", () => {
     expect(readClawInstallRecord("worker", { env })).toBeUndefined();
   });
 
-  it("keeps durable v3 provenance when the final compare-and-swap loses a race", async () => {
+  it("releases the unclaimed adoption when the final compare-and-swap loses a race", async () => {
     const { root, plan, config } = await fixture();
     const env = { OPENCLAW_STATE_DIR: join(root, "state") };
 
@@ -137,15 +157,89 @@ describe("applyClawAddPlan agent adoption", () => {
       },
     });
 
-    expect(result).toMatchObject({
-      status: "partial",
-      error: { code: "agent_config_conflict" },
-      installRecord: { agentOrigin: "adopted" },
+    expect(result).toMatchObject({ status: "partial", error: { code: "agent_config_conflict" } });
+    expect(result.error?.message).toContain("released its unclaimed adoption");
+    // The result must not report ownership the state database no longer holds.
+    expect(result.installRecord).toBeUndefined();
+    // The claim never landed, so no record may survive to block resume or authorize a remove
+    // that would delete the operator's own agent.
+    expect(readClawInstallRecord("worker", { env })).toBeUndefined();
+  });
+
+  it("releases when the write retries and the second transform loses", async () => {
+    const { root, plan, config } = await fixture();
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const raced = {
+      ...config,
+      agents: { entries: { worker: { ...config.agents?.entries?.worker, name: "Raced" } } },
+    };
+
+    const result = await applyClawAddPlan(plan, {
+      env,
+      consentPlanIntegrity: plan.planIntegrity,
+      readConfig: () => config,
+      // A config write that hash-conflicts re-runs the transform against the newer file, so a
+      // first transform that would have committed proves nothing about what landed.
+      commitConfig: async (transform) => {
+        transform(config);
+        transform(raced);
+      },
     });
-    expect(readClawInstallRecord("worker", { env })).toMatchObject({
-      schemaVersion: "openclaw.clawInstallRecord.v3",
-      agentOrigin: "adopted",
+
+    expect(result).toMatchObject({ status: "partial", error: { code: "agent_config_conflict" } });
+    expect(result.installRecord).toBeUndefined();
+    expect(readClawInstallRecord("worker", { env })).toBeUndefined();
+  });
+
+  it("does not write managed files before an adoption reservation loses", async () => {
+    const { root, plan, config } = await fixture();
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const managedPath = join(plan.agent.workspace, "SKILL.md");
+    const createWorkspaceFiles = vi.fn(async () => [managedWorkspaceFile(plan, "managed")]);
+
+    const result = await applyClawAddPlan(plan, {
+      env,
+      consentPlanIntegrity: plan.planIntegrity,
+      readConfig: () => config,
+      createWorkspaceFiles,
+      commitConfig: async (transform) => {
+        transform({
+          ...config,
+          agents: { entries: { worker: { ...config.agents?.entries?.worker, name: "Raced" } } },
+        });
+      },
     });
+
+    expect(result).toMatchObject({ status: "partial", workspaceFiles: [] });
+    expect(createWorkspaceFiles).not.toHaveBeenCalled();
+    expect(existsSync(managedPath)).toBe(false);
+    expect(readClawInstallRecord("worker", { env })).toBeUndefined();
+  });
+
+  it("preserves an operator file when an adoption reservation loses before file writes", async () => {
+    const { root, plan, config } = await fixture();
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const managedPath = join(plan.agent.workspace, "SKILL.md");
+    await writeFile(managedPath, "edited by the operator");
+    const createWorkspaceFiles = vi.fn(async () => [managedWorkspaceFile(plan, "managed")]);
+
+    const result = await applyClawAddPlan(plan, {
+      env,
+      consentPlanIntegrity: plan.planIntegrity,
+      readConfig: () => config,
+      createWorkspaceFiles,
+      commitConfig: async (transform) => {
+        transform({
+          ...config,
+          agents: { entries: { worker: { ...config.agents?.entries?.worker, name: "Raced" } } },
+        });
+      },
+    });
+
+    expect(result.error?.message).toContain("released its unclaimed adoption");
+    expect(createWorkspaceFiles).not.toHaveBeenCalled();
+    expect(existsSync(managedPath)).toBe(true);
+    expect(readClawInstallRecord("worker", { env })).toBeUndefined();
   });
 
   it("rejects a concurrently configured overlapping workspace in the final CAS", async () => {
@@ -175,8 +269,9 @@ describe("applyClawAddPlan agent adoption", () => {
       status: "partial",
       configCommitted: false,
       error: { code: "agent_workspace_conflict" },
-      installRecord: { agentOrigin: "adopted" },
     });
+    // A workspace conflict loses the same claim as a digest conflict, so it releases the same way.
+    expect(result.installRecord).toBeUndefined();
     expect(committedConfig).toBeUndefined();
   });
 

--- a/src/claws/add-config.ts
+++ b/src/claws/add-config.ts
@@ -22,6 +22,11 @@ export class ClawAddConfigCommitError extends Error {
   }
 }
 
+export type ClawAddConfigCommitResult = {
+  committed: boolean;
+  reservedConfig: boolean;
+};
+
 function preserveAgentEntries(config: OpenClawConfig): {
   agents: AgentConfig[];
   config: OpenClawConfig;
@@ -63,8 +68,9 @@ export async function commitClawAgentConfig(params: {
   commitConfig?: ConfigCommit;
   resumePlan?: ClawAddPlan;
   resumeRecord?: PersistedClawInstall;
-}): Promise<boolean> {
+}): Promise<ClawAddConfigCommitResult> {
   let committed = false;
+  let reservedConfig = false;
   const commit =
     params.commitConfig ??
     (async (transform) => {
@@ -96,6 +102,7 @@ export async function commitClawAgentConfig(params: {
       });
       if (nextConfig) {
         committed = true;
+        reservedConfig = true;
         return nextConfig;
       }
       throw new ClawAddConfigCommitError(
@@ -116,8 +123,48 @@ export async function commitClawAgentConfig(params: {
       );
     }
     committed = true;
+    reservedConfig = true;
     return addPlannedAgent(preserved.config, preserved.agents, params.plan);
   });
 
-  return committed;
+  return { committed, reservedConfig };
+}
+
+export async function rollbackClawAgentConfigReservation(params: {
+  plan: ClawAddPlan;
+  commitConfig?: ConfigCommit;
+}): Promise<boolean> {
+  let rolledBack = false;
+  const commit =
+    params.commitConfig ??
+    (async (transform) => {
+      await transformConfigFileWithRetry({
+        afterWrite: { mode: "auto" },
+        transform: (config) => ({ nextConfig: transform(config) }),
+      });
+    });
+
+  await commit((config) => {
+    const preserved = preserveAgentEntries(config);
+    const normalizedAgentId = normalizeAgentId(params.plan.agent.finalId);
+    const existingAgent = preserved.agents.find(
+      (agent) => normalizeAgentId(agent.id) === normalizedAgentId,
+    );
+    if (!existingAgent || !sameCommittedAgent(existingAgent, params.plan)) {
+      return config;
+    }
+    const remainingAgents = preserved.agents.filter(
+      (agent) => normalizeAgentId(agent.id) !== normalizedAgentId,
+    );
+    rolledBack = true;
+    return {
+      ...preserved.config,
+      agents: {
+        ...preserved.config.agents,
+        entries: Object.fromEntries(remainingAgents.map(({ id, ...entry }) => [id, entry])),
+      },
+    };
+  });
+
+  return rolledBack;
 }

--- a/src/claws/add-config.ts
+++ b/src/claws/add-config.ts
@@ -1,0 +1,123 @@
+// Commits the agent slice of a consented Claw add plan.
+import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
+import { listAgentEntries } from "../agents/agent-scope.js";
+import { transformConfigFileWithRetry } from "../config/config.js";
+import type { AgentConfig } from "../config/types.agents.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
+import type { PersistedClawInstall } from "./provenance.js";
+import type { ClawAddPlan } from "./types.js";
+import { sameCommittedAgent } from "./add-plan-helpers.js";
+import { replaceLegacyCommittedAgent } from "./legacy-resume.js";
+
+export type ConfigCommit = (transform: (config: OpenClawConfig) => OpenClawConfig) => Promise<void>;
+
+export class ClawAddConfigCommitError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "ClawAddConfigCommitError";
+  }
+}
+
+function preserveAgentEntries(config: OpenClawConfig): {
+  agents: AgentConfig[];
+  config: OpenClawConfig;
+} {
+  const existingAgents = listAgentEntries(config);
+  const agents =
+    existingAgents.length > 0 ? existingAgents : [{ id: DEFAULT_AGENT_ID, default: true }];
+  return {
+    agents,
+    config: {
+      ...config,
+      agents: {
+        ...config.agents,
+        entries: Object.fromEntries(agents.map(({ id, ...entry }) => [id, entry])),
+      },
+    },
+  };
+}
+
+function addPlannedAgent(
+  config: OpenClawConfig,
+  agents: AgentConfig[],
+  plan: ClawAddPlan,
+): OpenClawConfig {
+  return {
+    ...config,
+    agents: {
+      ...config.agents,
+      entries: Object.fromEntries(
+        [...agents, plan.agent.config].map(({ id, ...entry }) => [id, entry]),
+      ),
+    },
+  };
+}
+
+export async function commitClawAgentConfig(params: {
+  plan: ClawAddPlan;
+  workspace: string;
+  commitConfig?: ConfigCommit;
+  resumePlan?: ClawAddPlan;
+  resumeRecord?: PersistedClawInstall;
+}): Promise<boolean> {
+  let committed = false;
+  const commit =
+    params.commitConfig ??
+    (async (transform) => {
+      await transformConfigFileWithRetry({
+        afterWrite: { mode: "auto" },
+        transform: (config) => ({ nextConfig: transform(config) }),
+      });
+    });
+
+  await commit((config) => {
+    const preserved = preserveAgentEntries(config);
+    const normalizedAgentId = normalizeAgentId(params.plan.agent.finalId);
+    const existingAgent = preserved.agents.find(
+      (agent) => normalizeAgentId(agent.id) === normalizedAgentId,
+    );
+    if (existingAgent) {
+      if (sameCommittedAgent(existingAgent, params.plan)) {
+        committed = true;
+        return config;
+      }
+      const nextConfig = replaceLegacyCommittedAgent({
+        config: preserved.config,
+        agents: preserved.agents,
+        normalizedAgentId,
+        plan: params.plan,
+        resumePlan: params.resumePlan,
+        resumeRecord: params.resumeRecord,
+        matchesPlan: sameCommittedAgent,
+      });
+      if (nextConfig) {
+        committed = true;
+        return nextConfig;
+      }
+      throw new ClawAddConfigCommitError(
+        "agent_id_collision",
+        "Agent " + JSON.stringify(params.plan.agent.finalId) + " was created after planning.",
+      );
+    }
+    if (
+      findOverlappingWorkspaceAgentIds(
+        preserved.config,
+        params.plan.agent.finalId,
+        params.workspace,
+      ).length > 0
+    ) {
+      throw new ClawAddConfigCommitError(
+        "workspace_collision",
+        "Workspace " + JSON.stringify(params.workspace) + " is already assigned to an agent.",
+      );
+    }
+    committed = true;
+    return addPlannedAgent(preserved.config, preserved.agents, params.plan);
+  });
+
+  return committed;
+}

--- a/src/claws/add-config.ts
+++ b/src/claws/add-config.ts
@@ -8,6 +8,7 @@ import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import type { PersistedClawInstall } from "./provenance.js";
 import type { ClawAddPlan } from "./types.js";
 import { sameCommittedAgent } from "./add-plan-helpers.js";
+import { exactExistingAgentIsAuthorized } from "./agent-adoption-apply.js";
 import { replaceLegacyCommittedAgent } from "./legacy-resume.js";
 
 export type ConfigCommit = (transform: (config: OpenClawConfig) => OpenClawConfig) => Promise<void>;
@@ -68,6 +69,8 @@ export async function commitClawAgentConfig(params: {
   commitConfig?: ConfigCommit;
   resumePlan?: ClawAddPlan;
   resumeRecord?: PersistedClawInstall;
+  agentAdoption?: boolean;
+  persistedStatus: PersistedClawInstall["status"];
 }): Promise<ClawAddConfigCommitResult> {
   let committed = false;
   let reservedConfig = false;
@@ -87,7 +90,26 @@ export async function commitClawAgentConfig(params: {
       (agent) => normalizeAgentId(agent.id) === normalizedAgentId,
     );
     if (existingAgent) {
-      if (sameCommittedAgent(existingAgent, params.plan)) {
+      if (
+        sameCommittedAgent(existingAgent, params.plan) &&
+        exactExistingAgentIsAuthorized({
+          adoption: params.agentAdoption ?? false,
+          resume: params.resumeRecord !== undefined,
+          persistedStatus: params.persistedStatus,
+        })
+      ) {
+        if (
+          findOverlappingWorkspaceAgentIds(
+            preserved.config,
+            params.plan.agent.finalId,
+            params.workspace,
+          ).length > 0
+        ) {
+          throw new ClawAddConfigCommitError(
+            "agent_workspace_conflict",
+            "Workspace " + JSON.stringify(params.workspace) + " is assigned to another agent.",
+          );
+        }
         committed = true;
         return config;
       }
@@ -106,8 +128,16 @@ export async function commitClawAgentConfig(params: {
         return nextConfig;
       }
       throw new ClawAddConfigCommitError(
-        "agent_id_collision",
-        "Agent " + JSON.stringify(params.plan.agent.finalId) + " was created after planning.",
+        params.agentAdoption ? "agent_config_conflict" : "agent_id_collision",
+        params.agentAdoption
+          ? `Agent ${JSON.stringify(params.plan.agent.finalId)} changed after adoption planning.`
+          : "Agent " + JSON.stringify(params.plan.agent.finalId) + " was created after planning.",
+      );
+    }
+    if (params.agentAdoption) {
+      throw new ClawAddConfigCommitError(
+        "agent_config_conflict",
+        `Agent ${JSON.stringify(params.plan.agent.finalId)} disappeared after adoption planning.`,
       );
     }
     if (

--- a/src/claws/add-contract.ts
+++ b/src/claws/add-contract.ts
@@ -1,0 +1,66 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import type { seedClawPackageBootstrap } from "./bootstrap.js";
+import type { ClawCronGateway, installClawCronJobs, PersistedClawCronRef } from "./cron.js";
+import type { installClawMcpServers, PersistedClawMcpServerRef } from "./mcp.js";
+import type { installClawPackages } from "./packages.js";
+import type {
+  deleteClawInstallRecord,
+  PersistedClawInstall,
+  PersistedClawPackageRef,
+  persistClawInstallRecord,
+  updateClawInstallRecordStatus,
+} from "./provenance.js";
+import type { ClawAddPlan } from "./types.js";
+import type {
+  createClawWorkspaceFiles,
+  PersistedClawWorkspaceFile,
+  ClawWorkspaceWriteError,
+} from "./workspace.js";
+
+export const CLAW_ADD_RESULT_SCHEMA_VERSION = "openclaw.clawAddResult.v1" as const;
+
+type ConfigCommit = (transform: (config: OpenClawConfig) => OpenClawConfig) => Promise<void>;
+
+export type ClawAddApplyOptions = OpenClawStateDatabaseOptions & {
+  consentPlanIntegrity?: string;
+  resumeRecord?: PersistedClawInstall;
+  resumePlan?: ClawAddPlan;
+  commitConfig?: ConfigCommit;
+  readConfig?: () => OpenClawConfig | Promise<OpenClawConfig>;
+  persistRecord?: typeof persistClawInstallRecord;
+  deleteRecord?: typeof deleteClawInstallRecord;
+  updateRecord?: typeof updateClawInstallRecordStatus;
+  createWorkspaceFiles?: typeof createClawWorkspaceFiles;
+  runtime?: RuntimeEnv;
+  installPackages?: typeof installClawPackages;
+  installMcpServers?: typeof installClawMcpServers;
+  installCronJobs?: typeof installClawCronJobs;
+  seedPackageBootstrap?: typeof seedClawPackageBootstrap;
+  cronGateway?: Pick<ClawCronGateway, "add" | "list" | "waitUntilAgentAvailable">;
+  nowMs?: number;
+};
+
+export type ClawAddResult = {
+  schemaVersion: typeof CLAW_ADD_RESULT_SCHEMA_VERSION;
+  stability: "experimental";
+  dryRun: false;
+  mutationAllowed: true;
+  planIntegrity: string;
+  status: "complete" | "partial";
+  claw: ClawAddPlan["claw"];
+  agent: ClawAddPlan["agent"];
+  workspaceCreated: boolean;
+  configCommitted: boolean;
+  workspaceFiles: PersistedClawWorkspaceFile[];
+  packages: PersistedClawPackageRef[];
+  mcpServers: PersistedClawMcpServerRef[];
+  cronJobs: PersistedClawCronRef[];
+  installRecord?: PersistedClawInstall;
+  error?: {
+    code: string;
+    message: string;
+    diagnostics?: ClawWorkspaceWriteError["diagnostics"];
+  };
+};

--- a/src/claws/add-contract.ts
+++ b/src/claws/add-contract.ts
@@ -7,12 +7,13 @@ import type { installClawMcpServers, PersistedClawMcpServerRef } from "./mcp.js"
 import type { installClawPackages } from "./packages.js";
 import type {
   deleteClawInstallRecord,
+  ClawInstallStatus,
   PersistedClawInstall,
   PersistedClawPackageRef,
   persistClawInstallRecord,
   updateClawInstallRecordStatus,
 } from "./provenance.js";
-import type { ClawAddPlan } from "./types.js";
+import { CLAW_OUTPUT_STABILITY, type ClawAddPlan } from "./types.js";
 import type {
   createClawWorkspaceFiles,
   PersistedClawWorkspaceFile,
@@ -64,3 +65,47 @@ export type ClawAddResult = {
     diagnostics?: ClawWorkspaceWriteError["diagnostics"];
   };
 };
+// Shapes every aborted apply into the same result, so callers read one contract whether the
+// failure happened before the workspace, after the config commit, or anywhere between.
+export function partialResult(params: {
+  plan: ClawAddPlan;
+  // Absent once an attempt has released its record: the result must not report ownership
+  // that no longer exists in the state database.
+  installRecord: PersistedClawInstall | undefined;
+  workspaceCreated: boolean;
+  configCommitted: boolean;
+  workspaceFiles?: PersistedClawWorkspaceFile[];
+  packages?: PersistedClawPackageRef[];
+  installStatus?: ClawInstallStatus;
+  mcpServers?: PersistedClawMcpServerRef[];
+  cronJobs?: PersistedClawCronRef[];
+  error: ClawAddResult["error"];
+  nowMs?: number;
+}): ClawAddResult {
+  return {
+    schemaVersion: CLAW_ADD_RESULT_SCHEMA_VERSION,
+    stability: CLAW_OUTPUT_STABILITY,
+    dryRun: false,
+    mutationAllowed: true,
+    planIntegrity: params.plan.planIntegrity,
+    status: "partial",
+    claw: params.plan.claw,
+    agent: params.plan.agent,
+    workspaceCreated: params.workspaceCreated,
+    configCommitted: params.configCommitted,
+    workspaceFiles: params.workspaceFiles ?? [],
+    packages: params.packages ?? [],
+    mcpServers: params.mcpServers ?? [],
+    cronJobs: params.cronJobs ?? [],
+    ...(params.installRecord
+      ? {
+          installRecord: {
+            ...params.installRecord,
+            status: params.installStatus ?? "partial",
+            updatedAtMs: params.nowMs ?? Date.now(),
+          },
+        }
+      : {}),
+    error: params.error,
+  };
+}

--- a/src/claws/add-plan-helpers.ts
+++ b/src/claws/add-plan-helpers.ts
@@ -1,5 +1,6 @@
 import { stableStringify } from "@openclaw/normalization-core";
 import type { AgentConfig } from "../config/types.agents.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import type { ClawInstallStatus } from "./provenance.js";
 import type { ClawAddPlan } from "./types.js";
 
@@ -40,5 +41,8 @@ export function statusAtLeast(status: ClawInstallStatus, phase: ClawInstallStatu
 }
 
 export function sameCommittedAgent(existingAgent: AgentConfig, plan: ClawAddPlan): boolean {
-  return stableStringify(existingAgent) === stableStringify(plan.agent.config);
+  return (
+    stableStringify({ ...existingAgent, id: normalizeAgentId(existingAgent.id) }) ===
+    stableStringify(plan.agent.config)
+  );
 }

--- a/src/claws/add-plan-integrity.ts
+++ b/src/claws/add-plan-integrity.ts
@@ -1,0 +1,31 @@
+import { createHash } from "node:crypto";
+import { stableStringify } from "@openclaw/normalization-core";
+import type { ClawAddPlan } from "./types.js";
+
+type ClawAddPlanIntegrityInput = Pick<
+  ClawAddPlan,
+  | "manifestSchemaVersion"
+  | "claw"
+  | "agent"
+  | "actions"
+  | "capabilityChanges"
+  | "blockers"
+  | "extensions"
+>;
+
+export function digestClawAddPlanIntegrity(plan: ClawAddPlanIntegrityInput): string {
+  return `sha256:${createHash("sha256")
+    .update(
+      stableStringify({
+        manifestSchemaVersion: plan.manifestSchemaVersion,
+        clawIntegrity: plan.claw.integrity,
+        finalId: plan.agent.finalId,
+        workspace: plan.agent.workspace,
+        actions: plan.actions,
+        capabilityChanges: plan.capabilityChanges,
+        blockers: plan.blockers,
+        extensions: plan.extensions,
+      }),
+    )
+    .digest("hex")}`;
+}

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -5,10 +5,13 @@ import { dirname, resolve } from "node:path";
 import { coerceErrorMessage } from "@openclaw/normalization-core";
 import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import { normalizeWindowsPathForComparison } from "../infra/path-guards.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { recordAgentProvenance } from "../state/agent-provenance.js";
-import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import { resolveUserPath } from "../utils.js";
+import {
+  CLAW_ADD_RESULT_SCHEMA_VERSION,
+  type ClawAddApplyOptions,
+  type ClawAddResult,
+} from "./add-contract.js";
 import {
   hasUnsupportedMutationActions,
   planWithPackageActions,
@@ -18,15 +21,17 @@ import {
   ClawAddConfigCommitError,
   commitClawAgentConfig,
   rollbackClawAgentConfigReservation,
-  type ConfigCommit,
 } from "./add-config.js";
 import { ClawBootstrapWriteError, seedClawPackageBootstrap } from "./bootstrap.js";
 import {
   ClawCronInstallError,
   installClawCronJobs,
-  type ClawCronGateway,
   type PersistedClawCronRef,
 } from "./cron.js";
+import {
+  assertAgentAdoptionDigest,
+  planAdoptsAgent,
+} from "./agent-adoption-apply.js";
 import {
   ClawMcpInstallError,
   installClawMcpServers,
@@ -49,25 +54,8 @@ import {
   type PersistedClawWorkspaceFile,
 } from "./workspace.js";
 
-export const CLAW_ADD_RESULT_SCHEMA_VERSION = "openclaw.clawAddResult.v1" as const;
+export { CLAW_ADD_RESULT_SCHEMA_VERSION } from "./add-contract.js";
 
-type ClawAddApplyOptions = OpenClawStateDatabaseOptions & {
-  consentPlanIntegrity?: string;
-  resumeRecord?: PersistedClawInstall;
-  resumePlan?: ClawAddPlan;
-  commitConfig?: ConfigCommit;
-  persistRecord?: typeof persistClawInstallRecord;
-  deleteRecord?: typeof deleteClawInstallRecord;
-  updateRecord?: typeof updateClawInstallRecordStatus;
-  createWorkspaceFiles?: typeof createClawWorkspaceFiles;
-  runtime?: RuntimeEnv;
-  installPackages?: typeof installClawPackages;
-  installMcpServers?: typeof installClawMcpServers;
-  installCronJobs?: typeof installClawCronJobs;
-  seedPackageBootstrap?: typeof seedClawPackageBootstrap;
-  cronGateway?: Pick<ClawCronGateway, "add" | "list" | "waitUntilAgentAvailable">;
-  nowMs?: number;
-};
 export class ClawAddMutationError extends Error {
   constructor(
     readonly code: string,
@@ -77,29 +65,6 @@ export class ClawAddMutationError extends Error {
     this.name = "ClawAddMutationError";
   }
 }
-
-type ClawAddResult = {
-  schemaVersion: typeof CLAW_ADD_RESULT_SCHEMA_VERSION;
-  stability: typeof CLAW_OUTPUT_STABILITY;
-  dryRun: false;
-  mutationAllowed: true;
-  planIntegrity: string;
-  status: "complete" | "partial";
-  claw: ClawAddPlan["claw"];
-  agent: ClawAddPlan["agent"];
-  workspaceCreated: boolean;
-  configCommitted: boolean;
-  workspaceFiles: PersistedClawWorkspaceFile[];
-  packages: PersistedClawPackageRef[];
-  mcpServers: PersistedClawMcpServerRef[];
-  cronJobs: PersistedClawCronRef[];
-  installRecord?: PersistedClawInstall;
-  error?: {
-    code: string;
-    message: string;
-    diagnostics?: ClawWorkspaceWriteError["diagnostics"];
-  };
-};
 
 function markInstallStatus(
   agentId: string,
@@ -207,6 +172,25 @@ export async function applyClawAddPlan(
     });
   } catch (error) {
     throw new ClawAddMutationError("provenance_failed", (error as Error).message);
+  }
+
+  const agentAdoption = planAdoptsAgent(plan);
+  if (agentAdoption) {
+    try {
+      await assertAgentAdoptionDigest({
+        plan,
+        install: installRecord,
+        readConfig: options.readConfig,
+      });
+    } catch (error) {
+      if (!options.resumeRecord) {
+        clearUnownedInstallRecord(plan.agent.finalId, ["pending"], options);
+      }
+      throw new ClawAddMutationError(
+        "agent_config_conflict",
+        `Could not verify agent ${JSON.stringify(plan.agent.finalId)} before adoption: ${coerceErrorMessage(error)}`,
+      );
+    }
   }
 
   const workspace = resolve(resolveUserPath(plan.agent.workspace));
@@ -458,13 +442,17 @@ export async function applyClawAddPlan(
       commitConfig: options.commitConfig,
       resumePlan: options.resumePlan,
       resumeRecord: options.resumeRecord,
+      agentAdoption,
+      persistedStatus: installRecord.status,
     });
     configCommitted = configCommit.committed;
     reservedAgentConfig = configCommit.reservedConfig;
-    try {
-      recordAgentProvenance(plan.agent.finalId, { createdVia: "claw" }, options);
-    } catch (error) {
-      throw new ClawAddMutationError("provenance_failed", coerceErrorMessage(error));
+    if (!agentAdoption) {
+      try {
+        recordAgentProvenance(plan.agent.finalId, { createdVia: "claw" }, options);
+      } catch (error) {
+        throw new ClawAddMutationError("provenance_failed", coerceErrorMessage(error));
+      }
     }
     if (options.resumePlan && installRecord.schemaVersion === "openclaw.clawInstallRecord.v1") {
       installRecord = persistRecord(plan, {

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -44,6 +44,7 @@ import {
   type PersistedClawPackageRef,
 } from "./provenance.js";
 import { CLAW_OUTPUT_STABILITY, type ClawAddPlan } from "./types.js";
+import { planAdoptsWorkspace } from "./workspace-origin.js";
 import {
   ClawWorkspaceWriteError,
   createClawWorkspaceFiles,
@@ -213,6 +214,7 @@ export async function applyClawAddPlan(
 
   const workspace = resolve(resolveUserPath(plan.agent.workspace));
   const workspacePhaseRecorded = statusAtLeast(installRecord.status, "workspace_ready");
+  const workspaceAdoption = planAdoptsWorkspace(plan);
   let workspaceState: Stats | undefined;
   try {
     assertWorkspacePathUnchanged(workspace);
@@ -238,7 +240,7 @@ export async function applyClawAddPlan(
     );
   }
 
-  if (!workspacePhaseRecorded && workspaceState) {
+  if (!workspacePhaseRecorded && workspaceState && !workspaceAdoption) {
     markInstallStatus(plan.agent.finalId, "partial", ["pending", "partial"], options);
     return partialResult({
       plan,
@@ -262,6 +264,31 @@ export async function applyClawAddPlan(
 
   let workspaceCreated = workspaceState?.isDirectory() ?? false;
   let configCommitted = statusAtLeast(installRecord.status, "config_committed");
+  if (workspaceAdoption && (!workspaceCreated || !workspacePhaseRecorded)) {
+    const adoptedState = await lstat(workspace).catch(() => undefined);
+    if (!adoptedState?.isDirectory()) {
+      clearUnownedInstallRecord(plan.agent.finalId, ["pending", "partial"], options);
+      throw new ClawAddMutationError(
+        "workspace_collision",
+        `Adoptable workspace ${JSON.stringify(workspace)} is no longer an existing directory.`,
+      );
+    }
+    workspaceCreated = true;
+    if (!workspacePhaseRecorded) {
+      try {
+        markInstallStatus(
+          plan.agent.finalId,
+          "workspace_ready",
+          ["pending", "partial", "workspace_ready"],
+          options,
+        );
+      } catch (error) {
+        clearUnownedInstallRecord(plan.agent.finalId, ["pending", "partial"], options);
+        throw new ClawAddMutationError("provenance_failed", (error as Error).message);
+      }
+    }
+  }
+
   const installPackages = options.installPackages ?? installClawPackages;
   let packages: PersistedClawPackageRef[] = [];
   const preserveRecordedPhaseOrMarkPartial = (): ClawInstallStatus => {
@@ -417,6 +444,55 @@ export async function applyClawAddPlan(
     });
   }
 
+  // Workspace ownership must be complete before the agent becomes routable. Besides writing new
+  // files, this reopens every adopted destination through the safe-file contract and records its
+  // exact digest; a failure therefore leaves only retryable provenance, never an enabled agent.
+  const createFiles = options.createWorkspaceFiles ?? createClawWorkspaceFiles;
+  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
+  try {
+    workspaceFiles = await createFiles(plan, options);
+  } catch (error) {
+    const workspaceError =
+      error instanceof ClawWorkspaceWriteError
+        ? error
+        : new ClawWorkspaceWriteError(
+            [
+              {
+                level: "error",
+                code: "workspace_file_io_error",
+                phase: "mutation",
+                path: "$.workspace",
+                message: error instanceof Error ? error.message : String(error),
+              },
+            ],
+            workspaceFiles,
+          );
+    const installStatus: ClawInstallStatus = configCommitted
+      ? "config_committed"
+      : "workspace_ready";
+    markInstallStatus(
+      plan.agent.finalId,
+      installStatus,
+      configCommitted ? ["config_committed"] : ["workspace_ready"],
+      options,
+    );
+    return partialResult({
+      plan,
+      installRecord,
+      workspaceCreated,
+      configCommitted,
+      workspaceFiles: workspaceError.createdFiles,
+      packages,
+      installStatus,
+      error: {
+        code: "workspace_files_failed",
+        message: workspaceError.message,
+        diagnostics: workspaceError.diagnostics,
+      },
+      nowMs: options.nowMs,
+    });
+  }
+
   try {
     const commit: ConfigCommit =
       options.commitConfig ??
@@ -506,7 +582,7 @@ export async function applyClawAddPlan(
     );
   } catch (error) {
     let installStatus: ClawInstallStatus = "workspace_ready";
-    if (!configCommitted) {
+    if (!configCommitted && !workspaceAdoption) {
       const removedWorkspace = await rmdir(workspace)
         .then(() => true)
         .catch(() => false);
@@ -521,6 +597,7 @@ export async function applyClawAddPlan(
       installRecord,
       workspaceCreated,
       configCommitted,
+      workspaceFiles,
       packages,
       installStatus,
       error: {
@@ -529,55 +606,6 @@ export async function applyClawAddPlan(
       },
       nowMs: options.nowMs,
     });
-  }
-
-  const createFiles = options.createWorkspaceFiles ?? createClawWorkspaceFiles;
-  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
-  try {
-    workspaceFiles = await createFiles(plan, options);
-  } catch (error) {
-    const workspaceError =
-      error instanceof ClawWorkspaceWriteError
-        ? error
-        : new ClawWorkspaceWriteError(
-            [
-              {
-                level: "error",
-                code: "workspace_file_io_error",
-                phase: "mutation",
-                path: "$.workspace",
-                message: coerceErrorMessage(error),
-              },
-            ],
-            workspaceFiles,
-          );
-    markInstallStatus(plan.agent.finalId, "config_committed", ["config_committed"], options);
-    return {
-      schemaVersion: CLAW_ADD_RESULT_SCHEMA_VERSION,
-      stability: CLAW_OUTPUT_STABILITY,
-      dryRun: false,
-      mutationAllowed: true,
-      planIntegrity: plan.planIntegrity,
-      status: "partial",
-      claw: plan.claw,
-      agent: plan.agent,
-      workspaceCreated,
-      configCommitted,
-      workspaceFiles: workspaceError.createdFiles,
-      packages,
-      mcpServers: [],
-      cronJobs: [],
-      installRecord: {
-        ...installRecord,
-        status: "config_committed",
-        updatedAtMs: options.nowMs ?? Date.now(),
-      },
-      error: {
-        code: "workspace_files_failed",
-        message: workspaceError.message,
-        diagnostics: workspaceError.diagnostics,
-      },
-    };
   }
 
   let cronJobs: PersistedClawCronRef[] = [];

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Existing Claw add lifecycle exceeds the limit; this PR adds a narrow ownership guard. */
 // Applies the package, agent, workspace, and managed-file slices of a consented Claw add plan.
 import type { Stats } from "node:fs";
 import { lstat, mkdir, rmdir } from "node:fs/promises";
@@ -5,7 +6,7 @@ import { dirname, resolve } from "node:path";
 import { coerceErrorMessage } from "@openclaw/normalization-core";
 import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
 import { listAgentEntries } from "../agents/agent-scope.js";
-import { transformConfigFileWithRetry } from "../config/config.js";
+import { getRuntimeConfig, transformConfigFileWithRetry } from "../config/config.js";
 import type { AgentConfig } from "../config/types.agents.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
@@ -59,6 +60,7 @@ type ClawAddApplyOptions = OpenClawStateDatabaseOptions & {
   resumeRecord?: PersistedClawInstall;
   resumePlan?: ClawAddPlan;
   commitConfig?: ConfigCommit;
+  readConfig?: () => OpenClawConfig | Promise<OpenClawConfig>;
   persistRecord?: typeof persistClawInstallRecord;
   deleteRecord?: typeof deleteClawInstallRecord;
   updateRecord?: typeof updateClawInstallRecordStatus;
@@ -137,6 +139,27 @@ function assertWorkspacePathUnchanged(workspace: string): void {
     throw new ClawAddMutationError(
       "workspace_path_changed",
       `Workspace ancestry changed after planning: expected ${JSON.stringify(workspace)}, resolved ${JSON.stringify(canonicalWorkspace)}.`,
+    );
+  }
+}
+
+function assertWorkspaceNotClaimedByAnotherAgent(
+  config: OpenClawConfig,
+  agentId: string,
+  workspace: string,
+): void {
+  const existingAgents = listAgentEntries(config);
+  const configWithPreservedAgents: OpenClawConfig = {
+    ...config,
+    agents: {
+      ...config.agents,
+      entries: Object.fromEntries(existingAgents.map(({ id, ...entry }) => [id, entry])),
+    },
+  };
+  if (findOverlappingWorkspaceAgentIds(configWithPreservedAgents, agentId, workspace).length > 0) {
+    throw new ClawAddMutationError(
+      "workspace_collision",
+      "Workspace " + JSON.stringify(workspace) + " is already assigned to an agent.",
     );
   }
 }
@@ -408,6 +431,40 @@ export async function applyClawAddPlan(
       }
       throw new ClawAddMutationError("provenance_failed", (error as Error).message);
     }
+  }
+
+  try {
+    assertWorkspaceNotClaimedByAnotherAgent(
+      await (options.readConfig ?? (() => getRuntimeConfig()))(),
+      plan.agent.finalId,
+      workspace,
+    );
+  } catch (error) {
+    if (packages.length > 0) {
+      const installStatus = preserveRecordedPhaseOrMarkPartial();
+      return partialResult({
+        plan,
+        installRecord,
+        workspaceCreated,
+        configCommitted,
+        packages,
+        installStatus,
+        error: {
+          code: error instanceof ClawAddMutationError ? error.code : "workspace_claim_check_failed",
+          message: coerceErrorMessage(error),
+        },
+        nowMs: options.nowMs,
+      });
+    }
+    clearUnownedInstallRecord(
+      plan.agent.finalId,
+      ["pending", "partial", "workspace_ready"],
+      options,
+    );
+    if (error instanceof ClawAddMutationError) {
+      throw error;
+    }
+    throw new ClawAddMutationError("workspace_claim_check_failed", coerceErrorMessage(error));
   }
 
   // Seed and attest the consented package bootstrap while the workspace is still

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -17,6 +17,7 @@ import {
 import {
   ClawAddConfigCommitError,
   commitClawAgentConfig,
+  rollbackClawAgentConfigReservation,
   type ConfigCommit,
 } from "./add-config.js";
 import { ClawBootstrapWriteError, seedClawPackageBootstrap } from "./bootstrap.js";
@@ -287,6 +288,7 @@ export async function applyClawAddPlan(
 
   const installPackages = options.installPackages ?? installClawPackages;
   let packages: PersistedClawPackageRef[] = [];
+  let reservedAgentConfig = false;
   const preserveRecordedPhaseOrMarkPartial = (): ClawInstallStatus => {
     if (workspacePhaseRecorded) {
       return installRecord.status;
@@ -327,6 +329,21 @@ export async function applyClawAddPlan(
       });
     }
   }
+
+  const rollbackAgentConfigReservation = async (): Promise<void> => {
+    if (!reservedAgentConfig) {
+      return;
+    }
+    if (
+      await rollbackClawAgentConfigReservation({
+        plan,
+        commitConfig: options.commitConfig,
+      })
+    ) {
+      configCommitted = false;
+      reservedAgentConfig = false;
+    }
+  };
 
   try {
     assertWorkspacePathUnchanged(workspace);
@@ -407,13 +424,15 @@ export async function applyClawAddPlan(
   }
 
   try {
-    configCommitted = await commitClawAgentConfig({
+    const configCommit = await commitClawAgentConfig({
       plan,
       workspace,
       commitConfig: options.commitConfig,
       resumePlan: options.resumePlan,
       resumeRecord: options.resumeRecord,
     });
+    configCommitted = configCommit.committed;
+    reservedAgentConfig = configCommit.reservedConfig;
     try {
       recordAgentProvenance(plan.agent.finalId, { createdVia: "claw" }, options);
     } catch (error) {
@@ -470,14 +489,23 @@ export async function applyClawAddPlan(
       ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
     });
   } catch (error) {
-    markInstallStatus(plan.agent.finalId, "config_committed", ["config_committed"], options);
+    await rollbackAgentConfigReservation();
+    const installStatus: ClawInstallStatus = configCommitted
+      ? "config_committed"
+      : "workspace_ready";
+    markInstallStatus(
+      plan.agent.finalId,
+      installStatus,
+      configCommitted ? ["config_committed"] : ["workspace_ready", "config_committed"],
+      options,
+    );
     return partialResult({
       plan,
       installRecord,
       workspaceCreated,
       configCommitted,
       packages,
-      installStatus: "config_committed",
+      installStatus,
       error: {
         code: error instanceof ClawBootstrapWriteError ? error.code : "bootstrap_write_failed",
         message: coerceErrorMessage(error),
@@ -491,6 +519,7 @@ export async function applyClawAddPlan(
   try {
     workspaceFiles = await createFiles(plan, options);
   } catch (error) {
+    await rollbackAgentConfigReservation();
     const workspaceError =
       error instanceof ClawWorkspaceWriteError
         ? error
@@ -506,7 +535,15 @@ export async function applyClawAddPlan(
             ],
             workspaceFiles,
           );
-    markInstallStatus(plan.agent.finalId, "config_committed", ["config_committed"], options);
+    const installStatus: ClawInstallStatus = configCommitted
+      ? "config_committed"
+      : "workspace_ready";
+    markInstallStatus(
+      plan.agent.finalId,
+      installStatus,
+      configCommitted ? ["config_committed"] : ["workspace_ready", "config_committed"],
+      options,
+    );
     return partialResult({
       plan,
       installRecord,
@@ -514,7 +551,7 @@ export async function applyClawAddPlan(
       configCommitted,
       workspaceFiles: workspaceError.createdFiles,
       packages,
-      installStatus: "config_committed",
+      installStatus,
       error: {
         code: "workspace_files_failed",
         message: workspaceError.message,

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -1,17 +1,10 @@
-/* eslint-disable max-lines -- Existing Claw add lifecycle exceeds the limit; this PR adds a narrow ownership guard. */
 // Applies the package, agent, workspace, and managed-file slices of a consented Claw add plan.
 import type { Stats } from "node:fs";
 import { lstat, mkdir, rmdir } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { coerceErrorMessage } from "@openclaw/normalization-core";
-import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
-import { listAgentEntries } from "../agents/agent-scope.js";
-import { getRuntimeConfig, transformConfigFileWithRetry } from "../config/config.js";
-import type { AgentConfig } from "../config/types.agents.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import { normalizeWindowsPathForComparison } from "../infra/path-guards.js";
-import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { recordAgentProvenance } from "../state/agent-provenance.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
@@ -19,9 +12,13 @@ import { resolveUserPath } from "../utils.js";
 import {
   hasUnsupportedMutationActions,
   planWithPackageActions,
-  sameCommittedAgent,
   statusAtLeast,
 } from "./add-plan-helpers.js";
+import {
+  ClawAddConfigCommitError,
+  commitClawAgentConfig,
+  type ConfigCommit,
+} from "./add-config.js";
 import { ClawBootstrapWriteError, seedClawPackageBootstrap } from "./bootstrap.js";
 import {
   ClawCronInstallError,
@@ -29,7 +26,6 @@ import {
   type ClawCronGateway,
   type PersistedClawCronRef,
 } from "./cron.js";
-import { replaceLegacyCommittedAgent } from "./legacy-resume.js";
 import {
   ClawMcpInstallError,
   installClawMcpServers,
@@ -54,13 +50,11 @@ import {
 
 export const CLAW_ADD_RESULT_SCHEMA_VERSION = "openclaw.clawAddResult.v1" as const;
 
-type ConfigCommit = (transform: (config: OpenClawConfig) => OpenClawConfig) => Promise<void>;
 type ClawAddApplyOptions = OpenClawStateDatabaseOptions & {
   consentPlanIntegrity?: string;
   resumeRecord?: PersistedClawInstall;
   resumePlan?: ClawAddPlan;
   commitConfig?: ConfigCommit;
-  readConfig?: () => OpenClawConfig | Promise<OpenClawConfig>;
   persistRecord?: typeof persistClawInstallRecord;
   deleteRecord?: typeof deleteClawInstallRecord;
   updateRecord?: typeof updateClawInstallRecordStatus;
@@ -139,27 +133,6 @@ function assertWorkspacePathUnchanged(workspace: string): void {
     throw new ClawAddMutationError(
       "workspace_path_changed",
       `Workspace ancestry changed after planning: expected ${JSON.stringify(workspace)}, resolved ${JSON.stringify(canonicalWorkspace)}.`,
-    );
-  }
-}
-
-function assertWorkspaceNotClaimedByAnotherAgent(
-  config: OpenClawConfig,
-  agentId: string,
-  workspace: string,
-): void {
-  const existingAgents = listAgentEntries(config);
-  const configWithPreservedAgents: OpenClawConfig = {
-    ...config,
-    agents: {
-      ...config.agents,
-      entries: Object.fromEntries(existingAgents.map(({ id, ...entry }) => [id, entry])),
-    },
-  };
-  if (findOverlappingWorkspaceAgentIds(configWithPreservedAgents, agentId, workspace).length > 0) {
-    throw new ClawAddMutationError(
-      "workspace_collision",
-      "Workspace " + JSON.stringify(workspace) + " is already assigned to an agent.",
     );
   }
 }
@@ -434,189 +407,12 @@ export async function applyClawAddPlan(
   }
 
   try {
-    assertWorkspaceNotClaimedByAnotherAgent(
-      await (options.readConfig ?? (() => getRuntimeConfig()))(),
-      plan.agent.finalId,
+    configCommitted = await commitClawAgentConfig({
+      plan,
       workspace,
-    );
-  } catch (error) {
-    if (packages.length > 0) {
-      const installStatus = preserveRecordedPhaseOrMarkPartial();
-      return partialResult({
-        plan,
-        installRecord,
-        workspaceCreated,
-        configCommitted,
-        packages,
-        installStatus,
-        error: {
-          code: error instanceof ClawAddMutationError ? error.code : "workspace_claim_check_failed",
-          message: coerceErrorMessage(error),
-        },
-        nowMs: options.nowMs,
-      });
-    }
-    clearUnownedInstallRecord(
-      plan.agent.finalId,
-      ["pending", "partial", "workspace_ready"],
-      options,
-    );
-    if (error instanceof ClawAddMutationError) {
-      throw error;
-    }
-    throw new ClawAddMutationError("workspace_claim_check_failed", coerceErrorMessage(error));
-  }
-
-  // Seed and attest the consented package bootstrap while the workspace is still
-  // private. Committing the agent config first makes the agent routable, so a
-  // concurrent `sessions.create` can stock-seed BOOTSTRAP.md and strand the add at
-  // `config_committed` with a seed conflict that no retry can clear.
-  try {
-    await (options.seedPackageBootstrap ?? seedClawPackageBootstrap)(plan, {
-      ...options,
-      ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
-    });
-  } catch (error) {
-    const installStatus: ClawInstallStatus = configCommitted
-      ? "config_committed"
-      : "workspace_ready";
-    markInstallStatus(
-      plan.agent.finalId,
-      installStatus,
-      configCommitted ? ["config_committed"] : ["workspace_ready", "config_committed"],
-      options,
-    );
-    return partialResult({
-      plan,
-      installRecord,
-      workspaceCreated,
-      configCommitted,
-      packages,
-      installStatus,
-      error: {
-        code: error instanceof ClawBootstrapWriteError ? error.code : "bootstrap_write_failed",
-        message: coerceErrorMessage(error),
-      },
-      nowMs: options.nowMs,
-    });
-  }
-
-  // Workspace ownership must be complete before the agent becomes routable. Besides writing new
-  // files, this reopens every adopted destination through the safe-file contract and records its
-  // exact digest; a failure therefore leaves only retryable provenance, never an enabled agent.
-  const createFiles = options.createWorkspaceFiles ?? createClawWorkspaceFiles;
-  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
-  try {
-    workspaceFiles = await createFiles(plan, options);
-  } catch (error) {
-    const workspaceError =
-      error instanceof ClawWorkspaceWriteError
-        ? error
-        : new ClawWorkspaceWriteError(
-            [
-              {
-                level: "error",
-                code: "workspace_file_io_error",
-                phase: "mutation",
-                path: "$.workspace",
-                message: error instanceof Error ? error.message : String(error),
-              },
-            ],
-            workspaceFiles,
-          );
-    const installStatus: ClawInstallStatus = configCommitted
-      ? "config_committed"
-      : "workspace_ready";
-    markInstallStatus(
-      plan.agent.finalId,
-      installStatus,
-      configCommitted ? ["config_committed"] : ["workspace_ready"],
-      options,
-    );
-    return partialResult({
-      plan,
-      installRecord,
-      workspaceCreated,
-      configCommitted,
-      workspaceFiles: workspaceError.createdFiles,
-      packages,
-      installStatus,
-      error: {
-        code: "workspace_files_failed",
-        message: workspaceError.message,
-        diagnostics: workspaceError.diagnostics,
-      },
-      nowMs: options.nowMs,
-    });
-  }
-
-  try {
-    const commit: ConfigCommit =
-      options.commitConfig ??
-      (async (transform) => {
-        await transformConfigFileWithRetry({
-          afterWrite: { mode: "auto" },
-          transform: (config) => ({ nextConfig: transform(config) }),
-        });
-      });
-    await commit((config) => {
-      const existingAgents = listAgentEntries(config);
-      const agentsToPreserve: AgentConfig[] =
-        existingAgents.length > 0 ? existingAgents : [{ id: DEFAULT_AGENT_ID, default: true }];
-      const configWithPreservedAgents: OpenClawConfig = {
-        ...config,
-        agents: {
-          ...config.agents,
-          entries: Object.fromEntries(agentsToPreserve.map(({ id, ...entry }) => [id, entry])),
-        },
-      };
-      const normalizedAgentId = normalizeAgentId(plan.agent.finalId);
-      const existingAgent = agentsToPreserve.find(
-        (agent) => normalizeAgentId(agent.id) === normalizedAgentId,
-      );
-      if (existingAgent) {
-        if (sameCommittedAgent(existingAgent, plan)) {
-          configCommitted = true;
-          return config;
-        }
-        const nextConfig = replaceLegacyCommittedAgent({
-          config: configWithPreservedAgents,
-          agents: agentsToPreserve,
-          normalizedAgentId,
-          plan,
-          resumePlan: options.resumePlan,
-          resumeRecord: options.resumeRecord,
-          matchesPlan: sameCommittedAgent,
-        });
-        if (nextConfig) {
-          configCommitted = true;
-          return nextConfig;
-        }
-        throw new ClawAddMutationError(
-          "agent_id_collision",
-          "Agent " + JSON.stringify(plan.agent.finalId) + " was created after planning.",
-        );
-      }
-      if (
-        findOverlappingWorkspaceAgentIds(configWithPreservedAgents, plan.agent.finalId, workspace)
-          .length > 0
-      ) {
-        throw new ClawAddMutationError(
-          "workspace_collision",
-          "Workspace " + JSON.stringify(workspace) + " is already assigned to an agent.",
-        );
-      }
-      const nextConfig: OpenClawConfig = {
-        ...config,
-        agents: {
-          ...config.agents,
-          entries: Object.fromEntries(
-            [...agentsToPreserve, plan.agent.config].map(({ id, ...entry }) => [id, entry]),
-          ),
-        },
-      };
-      configCommitted = true;
-      return nextConfig;
+      commitConfig: options.commitConfig,
+      resumePlan: options.resumePlan,
+      resumeRecord: options.resumeRecord,
     });
     try {
       recordAgentProvenance(plan.agent.finalId, { createdVia: "claw" }, options);
@@ -649,17 +445,80 @@ export async function applyClawAddPlan(
         markInstallStatus(plan.agent.finalId, "partial", ["workspace_ready", "partial"], options);
       }
     }
+    const errorCode =
+      error instanceof ClawAddMutationError || error instanceof ClawAddConfigCommitError
+        ? error.code
+        : "config_commit_failed";
     return partialResult({
       plan,
       installRecord,
       workspaceCreated,
       configCommitted,
-      workspaceFiles,
       packages,
       installStatus,
       error: {
-        code: error instanceof ClawAddMutationError ? error.code : "config_commit_failed",
+        code: errorCode,
         message: coerceErrorMessage(error),
+      },
+      nowMs: options.nowMs,
+    });
+  }
+
+  try {
+    await (options.seedPackageBootstrap ?? seedClawPackageBootstrap)(plan, {
+      ...options,
+      ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
+    });
+  } catch (error) {
+    markInstallStatus(plan.agent.finalId, "config_committed", ["config_committed"], options);
+    return partialResult({
+      plan,
+      installRecord,
+      workspaceCreated,
+      configCommitted,
+      packages,
+      installStatus: "config_committed",
+      error: {
+        code: error instanceof ClawBootstrapWriteError ? error.code : "bootstrap_write_failed",
+        message: coerceErrorMessage(error),
+      },
+      nowMs: options.nowMs,
+    });
+  }
+
+  const createFiles = options.createWorkspaceFiles ?? createClawWorkspaceFiles;
+  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
+  try {
+    workspaceFiles = await createFiles(plan, options);
+  } catch (error) {
+    const workspaceError =
+      error instanceof ClawWorkspaceWriteError
+        ? error
+        : new ClawWorkspaceWriteError(
+            [
+              {
+                level: "error",
+                code: "workspace_file_io_error",
+                phase: "mutation",
+                path: "$.workspace",
+                message: error instanceof Error ? error.message : String(error),
+              },
+            ],
+            workspaceFiles,
+          );
+    markInstallStatus(plan.agent.finalId, "config_committed", ["config_committed"], options);
+    return partialResult({
+      plan,
+      installRecord,
+      workspaceCreated,
+      configCommitted,
+      workspaceFiles: workspaceError.createdFiles,
+      packages,
+      installStatus: "config_committed",
+      error: {
+        code: "workspace_files_failed",
+        message: workspaceError.message,
+        diagnostics: workspaceError.diagnostics,
       },
       nowMs: options.nowMs,
     });

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -7,10 +7,12 @@ import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import { normalizeWindowsPathForComparison } from "../infra/path-guards.js";
 import { recordAgentProvenance } from "../state/agent-provenance.js";
 import { resolveUserPath } from "../utils.js";
+import { releaseUnclaimedClawAdoption } from "./add-adoption-release.js";
 import {
   CLAW_ADD_RESULT_SCHEMA_VERSION,
   type ClawAddApplyOptions,
   type ClawAddResult,
+  partialResult,
 } from "./add-contract.js";
 import {
   hasUnsupportedMutationActions,
@@ -103,43 +105,6 @@ function assertWorkspacePathUnchanged(workspace: string): void {
   }
 }
 
-function partialResult(params: {
-  plan: ClawAddPlan;
-  installRecord: PersistedClawInstall;
-  workspaceCreated: boolean;
-  configCommitted: boolean;
-  workspaceFiles?: PersistedClawWorkspaceFile[];
-  packages?: PersistedClawPackageRef[];
-  installStatus?: ClawInstallStatus;
-  mcpServers?: PersistedClawMcpServerRef[];
-  cronJobs?: PersistedClawCronRef[];
-  error: ClawAddResult["error"];
-  nowMs?: number;
-}): ClawAddResult {
-  return {
-    schemaVersion: CLAW_ADD_RESULT_SCHEMA_VERSION,
-    stability: CLAW_OUTPUT_STABILITY,
-    dryRun: false,
-    mutationAllowed: true,
-    planIntegrity: params.plan.planIntegrity,
-    status: "partial",
-    claw: params.plan.claw,
-    agent: params.plan.agent,
-    workspaceCreated: params.workspaceCreated,
-    configCommitted: params.configCommitted,
-    workspaceFiles: params.workspaceFiles ?? [],
-    packages: params.packages ?? [],
-    mcpServers: params.mcpServers ?? [],
-    cronJobs: params.cronJobs ?? [],
-    installRecord: {
-      ...params.installRecord,
-      status: params.installStatus ?? "partial",
-      updatedAtMs: params.nowMs ?? Date.now(),
-    },
-    error: params.error,
-  };
-}
-
 export async function applyClawAddPlan(
   plan: ClawAddPlan,
   options: ClawAddApplyOptions = {},
@@ -171,7 +136,7 @@ export async function applyClawAddPlan(
       deferLegacyPlanUpgrade: options.resumePlan !== undefined,
     });
   } catch (error) {
-    throw new ClawAddMutationError("provenance_failed", (error as Error).message);
+    throw new ClawAddMutationError("provenance_failed", coerceErrorMessage(error));
   }
 
   const agentAdoption = planAdoptsAgent(plan);
@@ -217,7 +182,7 @@ export async function applyClawAddPlan(
     }
     throw new ClawAddMutationError(
       "workspace_parent_failed",
-      `Could not inspect workspace ${JSON.stringify(workspace)}: ${(error as Error).message}`,
+      `Could not inspect workspace ${JSON.stringify(workspace)}: ${coerceErrorMessage(error)}`,
     );
   }
 
@@ -265,7 +230,7 @@ export async function applyClawAddPlan(
         );
       } catch (error) {
         clearUnownedInstallRecord(plan.agent.finalId, ["pending", "partial"], options);
-        throw new ClawAddMutationError("provenance_failed", (error as Error).message);
+        throw new ClawAddMutationError("provenance_failed", coerceErrorMessage(error));
       }
     }
   }
@@ -348,7 +313,7 @@ export async function applyClawAddPlan(
           message:
             error instanceof ClawAddMutationError
               ? error.message
-              : `Could not create parent directory for workspace ${JSON.stringify(workspace)}: ${(error as Error).message}`,
+              : `Could not create parent directory for workspace ${JSON.stringify(workspace)}: ${coerceErrorMessage(error)}`,
         },
         nowMs: options.nowMs,
       });
@@ -359,7 +324,7 @@ export async function applyClawAddPlan(
     }
     throw new ClawAddMutationError(
       "workspace_parent_failed",
-      `Could not create parent directory for workspace ${JSON.stringify(workspace)}: ${(error as Error).message}`,
+      `Could not create parent directory for workspace ${JSON.stringify(workspace)}: ${coerceErrorMessage(error)}`,
     );
   }
 
@@ -377,7 +342,7 @@ export async function applyClawAddPlan(
         packages,
         error: {
           code: "workspace_collision",
-          message: `Could not create new workspace ${JSON.stringify(workspace)}: ${(error as Error).message}`,
+          message: `Could not create new workspace ${JSON.stringify(workspace)}: ${coerceErrorMessage(error)}`,
         },
         nowMs: options.nowMs,
       });
@@ -403,15 +368,18 @@ export async function applyClawAddPlan(
           // Preserve the phase-write failure if the unowned attempt cannot be reconciled.
         }
       }
-      throw new ClawAddMutationError("provenance_failed", (error as Error).message);
+      throw new ClawAddMutationError("provenance_failed", coerceErrorMessage(error));
     }
   }
 
+  let bootstrapSeeded: boolean;
+  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
   try {
-    await (options.seedPackageBootstrap ?? seedClawPackageBootstrap)(plan, {
-      ...options,
-      ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
-    });
+    bootstrapSeeded =
+      (await (options.seedPackageBootstrap ?? seedClawPackageBootstrap)(plan, {
+        ...options,
+        ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
+      })) === "seeded";
   } catch (error) {
     markInstallStatus(
       plan.agent.finalId,
@@ -434,7 +402,6 @@ export async function applyClawAddPlan(
     });
   }
 
-  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
   try {
     const configCommit = await commitClawAgentConfig({
       plan,
@@ -447,6 +414,11 @@ export async function applyClawAddPlan(
     });
     configCommitted = configCommit.committed;
     reservedAgentConfig = configCommit.reservedConfig;
+    // The transform runs again on every write retry, so only a returned commit proves the write
+    // landed; setting this inside the transform kept a stale claim after a losing retry.
+    // Creation provenance belongs to whoever created the agent. Adoption claims an agent the
+    // operator already made, so recording "claw" here would rewrite that origin and make a later
+    // remove treat pre-existing config as Claw-created.
     if (!agentAdoption) {
       try {
         recordAgentProvenance(plan.agent.finalId, { createdVia: "claw" }, options);
@@ -484,9 +456,33 @@ export async function applyClawAddPlan(
       error instanceof ClawAddMutationError || error instanceof ClawAddConfigCommitError
         ? error.code
         : "config_commit_failed";
+    let releaseNote = "";
+    let releasedRecord = false;
+    if (!configCommitted && agentAdoption) {
+      const release = await releaseUnclaimedClawAdoption({
+        plan,
+        install: installRecord,
+        workspaceFiles,
+        packages,
+        bootstrapSeeded,
+        options,
+      });
+      if (release.released) {
+        installStatus = "partial";
+        workspaceFiles = [];
+        packages = [];
+        releasedRecord = true;
+        releaseNote = ` Claw released its unclaimed adoption of agent ${JSON.stringify(plan.agent.finalId)}; the agent and its workspace were left as they are.`;
+      } else {
+        markInstallStatus(plan.agent.finalId, "partial", ["workspace_ready", "partial"], options);
+        installStatus = "partial";
+        workspaceFiles = workspaceFiles.filter((file) => release.retained.includes(file.path));
+        releaseNote = ` Claw still owns ${release.retained.join(", ")}; restore agent ${JSON.stringify(plan.agent.finalId)} to its recorded configuration, then preview again to retry or remove.`;
+      }
+    }
     return partialResult({
       plan,
-      installRecord,
+      installRecord: releasedRecord ? undefined : installRecord,
       workspaceCreated,
       configCommitted,
       workspaceFiles,
@@ -494,7 +490,7 @@ export async function applyClawAddPlan(
       installStatus,
       error: {
         code: errorCode,
-        message: coerceErrorMessage(error),
+        message: `${coerceErrorMessage(error)}${releaseNote}`,
       },
       nowMs: options.nowMs,
     });
@@ -660,7 +656,7 @@ export async function applyClawAddPlan(
       packages,
       mcpServers,
       cronJobs,
-      error: { code: "provenance_failed", message: (error as Error).message },
+      error: { code: "provenance_failed", message: coerceErrorMessage(error) },
     });
   }
 }

--- a/src/claws/add.ts
+++ b/src/claws/add.ts
@@ -424,6 +424,34 @@ export async function applyClawAddPlan(
   }
 
   try {
+    await (options.seedPackageBootstrap ?? seedClawPackageBootstrap)(plan, {
+      ...options,
+      ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
+    });
+  } catch (error) {
+    markInstallStatus(
+      plan.agent.finalId,
+      "workspace_ready",
+      ["workspace_ready", "config_committed"],
+      options,
+    );
+    return partialResult({
+      plan,
+      installRecord,
+      workspaceCreated,
+      configCommitted: false,
+      packages,
+      installStatus: "workspace_ready",
+      error: {
+        code: error instanceof ClawBootstrapWriteError ? error.code : "bootstrap_write_failed",
+        message: coerceErrorMessage(error),
+      },
+      nowMs: options.nowMs,
+    });
+  }
+
+  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
+  try {
     const configCommit = await commitClawAgentConfig({
       plan,
       workspace,
@@ -473,6 +501,7 @@ export async function applyClawAddPlan(
       installRecord,
       workspaceCreated,
       configCommitted,
+      workspaceFiles,
       packages,
       installStatus,
       error: {
@@ -483,39 +512,7 @@ export async function applyClawAddPlan(
     });
   }
 
-  try {
-    await (options.seedPackageBootstrap ?? seedClawPackageBootstrap)(plan, {
-      ...options,
-      ...(options.nowMs !== undefined ? { nowMs: options.nowMs } : {}),
-    });
-  } catch (error) {
-    await rollbackAgentConfigReservation();
-    const installStatus: ClawInstallStatus = configCommitted
-      ? "config_committed"
-      : "workspace_ready";
-    markInstallStatus(
-      plan.agent.finalId,
-      installStatus,
-      configCommitted ? ["config_committed"] : ["workspace_ready", "config_committed"],
-      options,
-    );
-    return partialResult({
-      plan,
-      installRecord,
-      workspaceCreated,
-      configCommitted,
-      packages,
-      installStatus,
-      error: {
-        code: error instanceof ClawBootstrapWriteError ? error.code : "bootstrap_write_failed",
-        message: coerceErrorMessage(error),
-      },
-      nowMs: options.nowMs,
-    });
-  }
-
   const createFiles = options.createWorkspaceFiles ?? createClawWorkspaceFiles;
-  let workspaceFiles: PersistedClawWorkspaceFile[] = [];
   try {
     workspaceFiles = await createFiles(plan, options);
   } catch (error) {

--- a/src/claws/adopted-agent-update.ts
+++ b/src/claws/adopted-agent-update.ts
@@ -1,0 +1,39 @@
+import type { AgentConfig } from "../config/types.agents.js";
+import { digestClawAddPlanIntegrity } from "./add-plan-integrity.js";
+import { canonicalizeClawAgent } from "./agent-adoption-apply.js";
+import { digestClawAgentConfig } from "./agent-config-digest.js";
+import type { PersistedClawInstall } from "./provenance.js";
+import type { ClawAddPlan } from "./types.js";
+
+export function preserveAdoptedAgentDefault(params: {
+  plan: ClawAddPlan;
+  install: PersistedClawInstall;
+  liveAgent: AgentConfig | undefined;
+}): ClawAddPlan | undefined {
+  if (params.install.agentOrigin !== "adopted") {
+    return params.plan;
+  }
+  const liveAgent = params.liveAgent
+    ? canonicalizeClawAgent(params.liveAgent, params.install.agentId)
+    : undefined;
+  if (!liveAgent || digestClawAgentConfig(liveAgent) !== params.install.agentConfigDigest) {
+    return undefined;
+  }
+  const config: ClawAddPlan["agent"]["config"] = { ...params.plan.agent.config };
+  if (Object.hasOwn(liveAgent, "default")) {
+    config.default = liveAgent.default;
+  } else {
+    delete config.default;
+  }
+  const actions = params.plan.actions.map((action) =>
+    action.kind === "agent" && action.id === params.install.agentId
+      ? { ...action, details: { ...action.details, ...config } }
+      : action,
+  );
+  const plan = {
+    ...params.plan,
+    agent: { ...params.plan.agent, config },
+    actions,
+  };
+  return { ...plan, planIntegrity: digestClawAddPlanIntegrity(plan) };
+}

--- a/src/claws/agent-adoption-apply.ts
+++ b/src/claws/agent-adoption-apply.ts
@@ -36,7 +36,7 @@ export function resolveClawAgentRosterKey(
   return resolveAgentEntry(config, agentId)?.id;
 }
 
-export function resolveClawPlanningAgentRoster(
+function resolveClawPlanningAgentRoster(
   config: OpenClawConfig,
   sourceConfig: OpenClawConfig = config,
 ) {

--- a/src/claws/agent-adoption-apply.ts
+++ b/src/claws/agent-adoption-apply.ts
@@ -1,0 +1,131 @@
+import { stableStringify } from "@openclaw/normalization-core";
+import {
+  listAgentEntries,
+  listAgentIds,
+  resolveAgentEntry,
+  resolveAgentWorkspaceDir,
+} from "../agents/agent-scope-config.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import type { AgentConfig } from "../config/types.agents.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { digestClawAgentConfig } from "./agent-config-digest.js";
+import type { PersistedClawInstall } from "./provenance.js";
+import type { ClawAddPlan } from "./types.js";
+
+export function planAdoptsAgent(plan: ClawAddPlan): boolean {
+  return plan.actions.some((action) => action.kind === "agent" && action.action === "adopt");
+}
+
+export function canonicalizeClawAgent(agent: AgentConfig, agentId = agent.id): AgentConfig {
+  return { ...agent, id: normalizeAgentId(agentId) };
+}
+
+export function resolveCanonicalClawAgent(
+  config: OpenClawConfig,
+  agentId: string,
+): AgentConfig | undefined {
+  const agent = resolveAgentEntry(config, agentId);
+  return agent ? canonicalizeClawAgent(agent, agentId) : undefined;
+}
+
+export function resolveClawAgentRosterKey(
+  config: OpenClawConfig,
+  agentId: string,
+): string | undefined {
+  return resolveAgentEntry(config, agentId)?.id;
+}
+
+export function resolveClawPlanningAgentRoster(
+  config: OpenClawConfig,
+  sourceConfig: OpenClawConfig = config,
+) {
+  const configuredAgents = listAgentEntries(sourceConfig).map((agent) =>
+    Object.assign({}, agent, { id: normalizeAgentId(agent.id) }),
+  );
+  const configuredAgentsById = new Map(configuredAgents.map((agent) => [agent.id, agent]));
+  // listAgentIds preserves the implicit main agent while canonicalizing explicit roster ids.
+  const existingAgents = listAgentIds(config).map((agentId) =>
+    Object.assign({}, configuredAgentsById.get(agentId) ?? { id: agentId }, {
+      resolvedWorkspace: resolveAgentWorkspaceDir(config, agentId),
+    }),
+  );
+  return { configuredAgents, existingAgents };
+}
+
+export async function readClawPlanningAgentRoster(config: OpenClawConfig) {
+  const snapshot = await readConfigFileSnapshot({ observe: false });
+  return resolveClawPlanningAgentRoster(config, snapshot.sourceConfig);
+}
+
+export function exactCommittedClawAgentExists(params: {
+  config: OpenClawConfig;
+  agentId: string;
+  expected: AgentConfig[];
+}): boolean {
+  const agent = resolveCanonicalClawAgent(params.config, params.agentId);
+  return Boolean(
+    agent &&
+    params.expected.some((expected) => stableStringify(agent) === stableStringify(expected)),
+  );
+}
+
+export async function assertAgentAdoptionDigest(params: {
+  plan: ClawAddPlan;
+  install: PersistedClawInstall;
+  readConfig?: () => OpenClawConfig | Promise<OpenClawConfig>;
+}): Promise<void> {
+  // The runtime snapshot may predate package preflight. Re-read disk here so mutations cannot
+  // begin after an adoption target has changed behind the pinned CLI view.
+  const config = await (
+    params.readConfig ??
+    (async () => (await readConfigFileSnapshot({ observe: false })).sourceConfig)
+  )();
+  const normalizedAgentId = normalizeAgentId(params.plan.agent.finalId);
+  const canonicalAgent = resolveCanonicalClawAgent(config, normalizedAgentId);
+  if (
+    !canonicalAgent ||
+    digestClawAgentConfig(canonicalAgent) !== params.install.agentConfigDigest
+  ) {
+    throw new Error(`Agent ${JSON.stringify(params.plan.agent.finalId)} changed after planning.`);
+  }
+}
+
+export function exactExistingAgentIsAuthorized(params: {
+  adoption: boolean;
+  resume: boolean;
+  persistedStatus: PersistedClawInstall["status"];
+}): boolean {
+  return params.adoption || params.resume || params.persistedStatus !== "pending";
+}
+
+export function createdAgentMayBeAbsentDuringResume(
+  record: Pick<PersistedClawInstall, "agentOrigin" | "status">,
+  committedAgentExists: boolean,
+): boolean {
+  // Adopted entries must remain visible so resume planning can reassert exact ownership.
+  return (
+    record.agentOrigin === "created" &&
+    (record.status === "config_committed" ||
+      (record.status === "workspace_ready" && committedAgentExists))
+  );
+}
+
+export function isExactAdoptedAgentResumeCandidate(params: {
+  requested: boolean;
+  record: PersistedClawInstall | undefined;
+  liveAgent: AgentConfig | undefined;
+}): boolean {
+  const canonicalAgent =
+    params.liveAgent && params.record
+      ? canonicalizeClawAgent(params.liveAgent, params.record.agentId)
+      : undefined;
+  return (
+    params.requested &&
+    params.record?.agentOrigin === "adopted" &&
+    params.record.status !== "complete" &&
+    canonicalAgent !== undefined &&
+    params.record.workspace === canonicalAgent.workspace &&
+    params.record.agentConfigDigest === digestClawAgentConfig(canonicalAgent)
+  );
+}

--- a/src/claws/lifecycle-adopt-plan.ts
+++ b/src/claws/lifecycle-adopt-plan.ts
@@ -1,0 +1,233 @@
+// Decides which existing workspace files an adopting Claw add may claim without rewriting them.
+import { createHash } from "node:crypto";
+import { lstat } from "node:fs/promises";
+import { dirname } from "node:path";
+import { FsSafeError, root as fsSafeRoot, type Root } from "../infra/fs-safe.js";
+import { MAX_MANAGED_FILE_BYTES } from "./source-limits.js";
+import type { ClawAddCapabilityChange, ClawAddPlanAction, ClawDiagnostic } from "./types.js";
+
+type AdoptionPendingFile = {
+  action: ClawAddPlanAction;
+  manifestPath: string;
+};
+
+type AdoptableTargetState =
+  | { state: "absent" }
+  | { state: "unsafe" }
+  | { state: "adoptable"; digest: string };
+
+type WorkspaceDiskState =
+  | { state: "absent" }
+  | { state: "uninspectable" }
+  | { state: "present"; isDirectory: boolean };
+
+// Only ENOENT proves absence. Permission, symlink-loop, and IO failures leave the path unknown, and
+// planning must not read unknown as free space: apply already refuses an uninspectable workspace
+// (`workspace_parent_failed` in add.ts), so a plan that approves one strands the operator mid-install.
+async function readWorkspaceDiskState(workspace: string): Promise<WorkspaceDiskState> {
+  try {
+    return { state: "present", isDirectory: (await lstat(workspace)).isDirectory() };
+  } catch (error) {
+    const absent =
+      typeof error === "object" && error !== null && "code" in error && error.code === "ENOENT";
+    if (!absent) {
+      return { state: "uninspectable" };
+    }
+    let parent = dirname(workspace);
+    while (parent !== dirname(parent)) {
+      try {
+        return (await lstat(parent)).isDirectory()
+          ? { state: "absent" }
+          : { state: "uninspectable" };
+      } catch (parentError) {
+        const parentAbsent =
+          typeof parentError === "object" &&
+          parentError !== null &&
+          "code" in parentError &&
+          parentError.code === "ENOENT";
+        if (!parentAbsent) {
+          return { state: "uninspectable" };
+        }
+        parent = dirname(parent);
+      }
+    }
+    return { state: "absent" };
+  }
+}
+
+function adoptionBlocker(path: string, message: string): ClawDiagnostic {
+  return { level: "error", code: "workspace_file_conflict", phase: "plan", path, message };
+}
+
+/** Describes the distinct consent required to claim an existing workspace directory. */
+export function workspaceAdoptionCapabilityChange(
+  agentId: string,
+  workspace: string,
+): Omit<ClawAddCapabilityChange, "classification" | "requiresDistinctConsent" | "digest"> {
+  return {
+    kind: "agent",
+    id: agentId,
+    path: "workspace",
+    action: "configure",
+    reason:
+      "The Claw adopts an existing workspace directory; declared files must already match or be absent.",
+    effect: { workspace, adoptExistingWorkspace: true },
+  };
+}
+
+/** Plans the workspace-level adoption decision before declared files are inspected. */
+export async function planWorkspaceAdoption(params: {
+  agentId: string;
+  workspace: string;
+  requested: boolean;
+  configuredWorkspaceConflict: boolean;
+  resumableWorkspace?: string;
+}): Promise<{
+  adopted: boolean;
+  action: ClawAddPlanAction;
+  blockers: ClawDiagnostic[];
+}> {
+  const disk = await readWorkspaceDiskState(params.workspace);
+  if (disk.state === "uninspectable") {
+    const message = `Workspace ${JSON.stringify(params.workspace)} cannot be inspected; adoption requires a workspace path this account can read.`;
+    return {
+      adopted: false,
+      blockers: [
+        {
+          level: "error",
+          code: "workspace_parent_failed",
+          phase: "plan",
+          path: "$.workspace",
+          message,
+        },
+      ],
+      action: {
+        kind: "workspace",
+        id: params.agentId,
+        action: "create",
+        target: params.workspace,
+        details: { expectedState: "uninspectable" },
+        blocked: true,
+        reason: message,
+      },
+    };
+  }
+  const workspaceExistsOnDisk = disk.state === "present";
+  const adopted =
+    params.requested &&
+    disk.state === "present" &&
+    disk.isDirectory &&
+    !params.configuredWorkspaceConflict;
+  const blocked =
+    !adopted &&
+    (params.configuredWorkspaceConflict ||
+      (workspaceExistsOnDisk && params.resumableWorkspace !== params.workspace));
+  const blockers: ClawDiagnostic[] = [];
+  if (blocked) {
+    blockers.push({
+      level: "error",
+      code: "workspace_collision",
+      phase: "plan",
+      path: "$.workspace",
+      message:
+        params.requested && workspaceExistsOnDisk
+          ? `Workspace ${JSON.stringify(params.workspace)} cannot be adopted; it is ${
+              params.configuredWorkspaceConflict
+                ? "already configured for another agent"
+                : "not a directory"
+            }.`
+          : `Workspace ${JSON.stringify(params.workspace)} already exists; a Claw requires a new workspace.`,
+    });
+  }
+  return {
+    adopted,
+    blockers,
+    action: {
+      kind: "workspace",
+      id: params.agentId,
+      action: adopted ? "adopt" : "create",
+      target: params.workspace,
+      details: { expectedState: adopted ? "existing-directory" : "absent" },
+      blocked,
+      ...(blocked
+        ? { reason: `Workspace ${JSON.stringify(params.workspace)} already exists.` }
+        : {}),
+    },
+  };
+}
+
+// Planning reads adoptable destinations through the same safe-file contract the mutation path
+// uses. A destination only apply would reject (symlink, hardlink, oversized) has to block before
+// consent, or apply commits the agent config first and leaves the operator a partial install.
+async function readAdoptableTarget(
+  workspaceRoot: Root,
+  targetPath: string,
+): Promise<AdoptableTargetState> {
+  try {
+    const read = await workspaceRoot.read(targetPath, {
+      hardlinks: "reject",
+      maxBytes: MAX_MANAGED_FILE_BYTES,
+      symlinks: "reject",
+    });
+    return {
+      state: "adoptable",
+      digest: `sha256:${createHash("sha256").update(read.buffer).digest("hex")}`,
+    };
+  } catch (error) {
+    if (error instanceof FsSafeError && error.code === "not-found") {
+      return { state: "absent" };
+    }
+    return { state: "unsafe" };
+  }
+}
+
+/**
+ * Marks every declared file that already exists with identical content as an `adopt` action and
+ * blocks the rest. Mutates the passed actions in place and returns the plan blockers to record.
+ */
+export async function planWorkspaceAdoptionTargets(params: {
+  workspace: string;
+  pendingFiles: readonly AdoptionPendingFile[];
+  packageBootstrap?: ClawAddPlanAction;
+}): Promise<ClawDiagnostic[]> {
+  const workspaceRoot = await fsSafeRoot(params.workspace);
+  const blockers: ClawDiagnostic[] = [];
+  if (params.packageBootstrap && !params.packageBootstrap.blocked) {
+    const existing = await readAdoptableTarget(workspaceRoot, params.packageBootstrap.id);
+    if (existing.state !== "absent") {
+      const diagnostic = adoptionBlocker(
+        "$packageBootstrap",
+        existing.state === "unsafe"
+          ? `Package BOOTSTRAP.md destination ${JSON.stringify(params.packageBootstrap.target)} must be absent; the existing path is not a safe regular file.`
+          : `Package BOOTSTRAP.md destination ${JSON.stringify(params.packageBootstrap.target)} already exists; adoption never claims operator-owned native bootstrap content.`,
+      );
+      params.packageBootstrap.blocked = true;
+      params.packageBootstrap.reason = diagnostic.message;
+      blockers.push(diagnostic);
+    }
+  }
+  for (const pending of params.pendingFiles) {
+    if (pending.action.blocked || !pending.action.digest) {
+      continue;
+    }
+    const existing = await readAdoptableTarget(workspaceRoot, pending.action.id);
+    if (existing.state === "absent") {
+      continue;
+    }
+    if (existing.state === "adoptable" && existing.digest === pending.action.digest) {
+      pending.action.action = "adopt";
+      pending.action.details = { ...pending.action.details, expectedState: "existing-identical" };
+      continue;
+    }
+    const diagnostic = adoptionBlocker(
+      pending.manifestPath,
+      existing.state === "unsafe"
+        ? `Adoptable workspace destination ${JSON.stringify(pending.action.target)} must be a readable regular file inside the workspace, with no symlink or hardlink, within managed size limits.`
+        : `Workspace destination ${JSON.stringify(pending.action.target)} exists with different content; adoption never overwrites existing files.`,
+    );
+    pending.action.blocked = true;
+    pending.action.reason = diagnostic.message;
+    blockers.push(diagnostic);
+  }
+  return blockers;
+}

--- a/src/claws/lifecycle-adopt-plan.ts
+++ b/src/claws/lifecycle-adopt-plan.ts
@@ -81,6 +81,7 @@ export async function planWorkspaceAdoption(params: {
   workspace: string;
   requested: boolean;
   configuredWorkspaceConflict: boolean;
+  configuredWorkspaceConflictCode?: "workspace_collision" | "agent_workspace_conflict";
   resumableWorkspace?: string;
 }): Promise<{
   adopted: boolean;
@@ -126,7 +127,7 @@ export async function planWorkspaceAdoption(params: {
   if (blocked) {
     blockers.push({
       level: "error",
-      code: "workspace_collision",
+      code: params.configuredWorkspaceConflictCode ?? "workspace_collision",
       phase: "plan",
       path: "$.workspace",
       message:

--- a/src/claws/lifecycle-adopt-remove.test.ts
+++ b/src/claws/lifecycle-adopt-remove.test.ts
@@ -1,7 +1,7 @@
 // Removal coverage for Claw installs that adopted an existing operator-owned workspace.
 import { mkdir, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -111,6 +111,36 @@ describe("Claw remove with an adopted workspace", () => {
 
     expect(removed).toMatchObject({ status: "complete" });
     await expect(stat(current.workspace)).resolves.toMatchObject({});
+  });
+
+  it("still purges created-agent history when only its workspace was adopted", async () => {
+    const current = await adoptedFixture();
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    const purgeSessions = vi.fn(async () => undefined);
+    const trashed: string[] = [];
+
+    await applyClawRemovePlan(plan, {
+      env: current.env,
+      config: current.getConfig(),
+      consentPlanIntegrity: plan.planIntegrity,
+      commitConfig: async (transform) => {
+        transform(current.getConfig());
+      },
+      purgeSessions,
+      trashPath: async (target) => {
+        trashed.push(target);
+        return true;
+      },
+    });
+
+    const agentState = plan.actions.find((action) => action.kind === "agentState")?.target;
+    const transcripts = plan.actions.find((action) => action.kind === "sessionTranscripts")?.target;
+    expect(purgeSessions).toHaveBeenCalledOnce();
+    expect(trashed).toEqual(expect.arrayContaining([agentState, transcripts]));
+    expect(trashed).not.toContain(current.workspace);
   });
 
   it("keeps a removal preview read-only when no origin marker exists", async () => {

--- a/src/claws/lifecycle-adopt-remove.test.ts
+++ b/src/claws/lifecycle-adopt-remove.test.ts
@@ -1,0 +1,221 @@
+// Removal coverage for Claw installs that adopted an existing operator-owned workspace.
+import { mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { applyClawAddPlan } from "./add.js";
+import { inspectClawWorkspaceFile } from "./lifecycle-delete-support.js";
+import { clawRemoveFixtures } from "./lifecycle-remove.test-support.js";
+import { applyClawRemovePlan, buildClawRemovePlan } from "./lifecycle-state.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import { persistClawInstallRecord } from "./provenance.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawSourceIdentity } from "./types.js";
+import { CLAW_ADOPTED_WORKSPACE_MARKER_PATH, clawWorkspaceWasAdopted } from "./workspace-origin.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+const { fixture, addFixture } = clawRemoveFixtures(tempDirs);
+
+describe("Claw remove with an adopted workspace", () => {
+  async function adoptedFixture() {
+    const root = tempDirs.make("openclaw-claw-adopt-remove-");
+    await writeFile(join(root, "SOUL.md"), "managed\n", "utf8");
+    const parsed = parseClawManifest({
+      schemaVersion: 1,
+      agent: { id: "worker", name: "Worker" },
+      workspace: { bootstrapFiles: { "SOUL.md": { source: "SOUL.md" } } },
+    });
+    if (!parsed.ok) {
+      throw new Error(JSON.stringify(parsed.diagnostics));
+    }
+    const source: ClawSourceIdentity = {
+      kind: "package",
+      name: "@acme/worker",
+      version: "1.0.0",
+      packageRoot: root,
+      manifestPath: join(root, "openclaw.claw.json"),
+      integrityKind: "artifact",
+      integrity: "sha256:manifest",
+      byteLength: 100,
+    };
+    // The operator's directory already holds the declared file, so after adoption every entry in
+    // it is Claw-managed and nothing distinguishes it from a workspace this install created.
+    const workspace = join(root, "existing-workspace");
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "SOUL.md"), "managed\n", "utf8");
+    const plan = await buildClawAddPlan({
+      manifest: parsed.manifest,
+      source,
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    let config: OpenClawConfig = {};
+    await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+    // The install records the canonical workspace path, which is what removal compares against.
+    return { env, workspace: plan.agent.workspace, getConfig: () => config };
+  }
+
+  it("plans retention for an adopted workspace holding only declared files", async () => {
+    const current = await adoptedFixture();
+
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({
+        kind: "workspace",
+        action: "retain",
+        reason: "Workspace existed before this Claw adopted it.",
+        details: expect.objectContaining({ retained: true }),
+      }),
+    );
+  });
+
+  it("never trashes an adopted workspace directory during removal", async () => {
+    const current = await adoptedFixture();
+
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    const removed = await applyClawRemovePlan(plan, {
+      env: current.env,
+      config: current.getConfig(),
+      consentPlanIntegrity: plan.planIntegrity,
+      commitConfig: async (transform) => {
+        transform(current.getConfig());
+      },
+      purgeSessions: async () => undefined,
+      // Delete for real: a trash stub that only records calls cannot tell a retained directory
+      // from one the canonical path spelling hid from the assertion.
+      trashPath: async (target) => {
+        await rm(target, { recursive: true, force: true });
+        return true;
+      },
+    });
+
+    expect(removed).toMatchObject({ status: "complete" });
+    await expect(stat(current.workspace)).resolves.toMatchObject({});
+  });
+
+  it("keeps a removal preview read-only when no origin marker exists", async () => {
+    const current = await addFixture();
+    const db = openOpenClawStateDatabase({ env: current.env }).db;
+    const markerCount = () =>
+      db
+        .prepare("SELECT count(*) AS count FROM claw_workspace_files WHERE target_path = ?")
+        .get(CLAW_ADOPTED_WORKSPACE_MARKER_PATH) as { count: number };
+    expect(markerCount().count).toBe(0);
+
+    await buildClawRemovePlan("worker", { env: current.env, config: current.getConfig() });
+
+    expect(markerCount().count).toBe(0);
+  });
+
+  it("ignores an origin marker recorded for a different workspace", async () => {
+    const current = await addFixture();
+    const workspace = current.plan.agent.workspace;
+    const db = openOpenClawStateDatabase({ env: current.env }).db;
+    db.prepare(
+      `INSERT OR REPLACE INTO claw_workspace_files (
+         agent_id, target_path, schema_version, workspace, source_path,
+         content_digest, status, created_at_ms, updated_at_ms
+       ) VALUES (?, ?, ?, ?, ?, ?, 'complete', 1, 1)`,
+    ).run(
+      "worker",
+      CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      "openclaw.clawWorkspaceFileRecord.v1",
+      `${workspace}-previous`,
+      CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      "openclaw:adopted-workspace",
+    );
+
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspace", action: "trash" }),
+    );
+  });
+
+  it("clears a stale origin marker when a non-adopted install is persisted", async () => {
+    const current = await fixture({ id: "worker" });
+    const db = openOpenClawStateDatabase({ env: current.env }).db;
+    db.prepare(
+      `INSERT OR REPLACE INTO claw_workspace_files (
+         agent_id, target_path, schema_version, workspace, source_path,
+         content_digest, status, created_at_ms, updated_at_ms
+       ) VALUES (?, ?, ?, ?, ?, ?, 'complete', 1, 1)`,
+    ).run(
+      "worker",
+      CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      "openclaw.clawWorkspaceFileRecord.v1",
+      current.plan.agent.workspace,
+      CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      "openclaw:adopted-workspace",
+    );
+
+    persistClawInstallRecord(current.plan, { env: current.env, nowMs: 5 });
+
+    expect(
+      clawWorkspaceWasAdopted("worker", current.plan.agent.workspace, { env: current.env }),
+    ).toBe(false);
+  });
+
+  it("makes an older reader fail closed on the adopted-workspace marker", async () => {
+    const current = await adoptedFixture();
+
+    const inspected = await inspectClawWorkspaceFile({
+      schemaVersion: "openclaw.clawWorkspaceFileRecord.v1",
+      agentId: "worker",
+      workspace: current.workspace,
+      path: CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      sourcePath: CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+      contentDigest: "openclaw:adopted-workspace",
+      status: "complete",
+      createdAtMs: 1,
+      updatedAtMs: 1,
+    });
+
+    expect(inspected).toMatchObject({ state: "unsafe" });
+  });
+
+  it("drops the adopted-workspace origin once the install is removed", async () => {
+    const current = await adoptedFixture();
+    expect(clawWorkspaceWasAdopted("worker", current.workspace, { env: current.env })).toBe(true);
+
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    await applyClawRemovePlan(plan, {
+      env: current.env,
+      config: current.getConfig(),
+      consentPlanIntegrity: plan.planIntegrity,
+      commitConfig: async (transform) => {
+        transform(current.getConfig());
+      },
+      purgeSessions: async () => undefined,
+      trashPath: async () => true,
+    });
+
+    expect(clawWorkspaceWasAdopted("worker", current.workspace, { env: current.env })).toBe(false);
+  });
+});

--- a/src/claws/lifecycle-adopt.test.ts
+++ b/src/claws/lifecycle-adopt.test.ts
@@ -219,4 +219,34 @@ describe("applyClawAddPlan workspace adoption", () => {
     expect(installPackages).not.toHaveBeenCalled();
     expect(readInstallRow("worker", root)).toBeUndefined();
   });
+
+  it("rejects a live workspace claim before writing adopted workspace files", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "AGENTS.md"), "# Agent\n", "utf8");
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+    expect(plan.blockers).toEqual([]);
+    const seedPackageBootstrap = vi.fn(async () => undefined);
+    const createWorkspaceFiles = vi.fn();
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(source.packageRoot),
+        readConfig: () => ({
+          agents: { entries: { other: { name: "Other", workspace } } },
+        }),
+        seedPackageBootstrap,
+        createWorkspaceFiles,
+      }),
+    ).rejects.toMatchObject({ code: "workspace_collision" });
+
+    expect(seedPackageBootstrap).not.toHaveBeenCalled();
+    expect(createWorkspaceFiles).not.toHaveBeenCalled();
+    expect(readInstallRow("adopt-agent", source.packageRoot)).toBeUndefined();
+  });
 });

--- a/src/claws/lifecycle-adopt.test.ts
+++ b/src/claws/lifecycle-adopt.test.ts
@@ -1,0 +1,222 @@
+// Tests for planning Claw adds that adopt an existing workspace directory.
+import { createHash } from "node:crypto";
+import { link, mkdir, rmdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { applyClawAddPlan } from "./add.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import { makeProvenancePlan, readInstallRow, stateEnv } from "./provenance.test-helpers.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawManifest, ClawSourceIdentity } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+function requireManifest(): ClawManifest {
+  const result = parseClawManifest({
+    schemaVersion: 1,
+    agent: { id: "adopt-agent" },
+    workspace: {
+      bootstrapFiles: { "AGENTS.md": { source: "workspace/AGENTS.md" } },
+      files: [{ source: "workspace/reference/policy.md", path: "reference/policy.md" }],
+    },
+  });
+  if (!result.ok) {
+    throw new Error(JSON.stringify(result.diagnostics));
+  }
+  return result.manifest;
+}
+
+async function createPlanSource(): Promise<{ source: ClawSourceIdentity; workspace: string }> {
+  const root = tempDirs.make("openclaw-claw-adopt-plan-");
+  await mkdir(join(root, "workspace", "reference"), { recursive: true });
+  await writeFile(join(root, "workspace", "AGENTS.md"), "# Agent\n", "utf8");
+  await writeFile(join(root, "workspace", "reference", "policy.md"), "Policy\n", "utf8");
+  return {
+    source: {
+      kind: "package",
+      name: "@acme/adopt-agent",
+      version: "1.0.0",
+      packageRoot: root,
+      manifestPath: join(root, "openclaw.claw.json"),
+      integrityKind: "development-snapshot",
+      integrity: "sha256:test",
+      byteLength: 0,
+    },
+    workspace: join(root, "existing-workspace"),
+  };
+}
+
+describe("buildClawAddPlan workspace adoption", () => {
+  it("adopts an existing workspace when identical declared files are present", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "AGENTS.md"), "# Agent\n", "utf8");
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+
+    expect(plan.blockers).toEqual([]);
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspace", action: "adopt", blocked: false }),
+    );
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspaceFile", id: "AGENTS.md", action: "adopt" }),
+    );
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({
+        kind: "workspaceFile",
+        id: "reference/policy.md",
+        action: "write",
+      }),
+    );
+    expect(plan.capabilityChanges).toContainEqual(
+      expect.objectContaining({ kind: "agent", path: "workspace", action: "configure" }),
+    );
+  });
+
+  it("blocks adoption when a declared file exists with different content", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "AGENTS.md"), "# Divergent\n", "utf8");
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "workspace_file_conflict" }),
+    );
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspaceFile", id: "AGENTS.md", blocked: true }),
+    );
+  });
+
+  it("blocks adoption of a hardlinked declared file before consent", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "origin.md"), "# Agent\n", "utf8");
+    await link(join(workspace, "origin.md"), join(workspace, "AGENTS.md"));
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "workspace_file_conflict" }),
+    );
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspaceFile", id: "AGENTS.md", blocked: true }),
+    );
+    expect(plan.actions).not.toContainEqual(
+      expect.objectContaining({ kind: "workspaceFile", id: "AGENTS.md", action: "adopt" }),
+    );
+  });
+
+  it("blocks an existing package bootstrap instead of claiming operator-owned content", async () => {
+    const { source, workspace } = await createPlanSource();
+    const bootstrap = Buffer.from("Package setup\n");
+    const bootstrapPath = join(source.packageRoot, "BOOTSTRAP.md");
+    await writeFile(bootstrapPath, bootstrap);
+    await mkdir(workspace, { recursive: true });
+    await writeFile(join(workspace, "BOOTSTRAP.md"), bootstrap);
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      packageBootstrap: {
+        sourcePath: "BOOTSTRAP.md",
+        realPath: bootstrapPath,
+        byteLength: bootstrap.byteLength,
+        digest: `sha256:${createHash("sha256").update(bootstrap).digest("hex")}`,
+      },
+      context: { workspace, adoptExistingWorkspace: true },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "workspace_file_conflict", path: "$packageBootstrap" }),
+    );
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "bootstrap", id: "BOOTSTRAP.md", blocked: true }),
+    );
+  });
+
+  it("still blocks adoption of a workspace configured for another agent", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: {
+        workspace,
+        adoptExistingWorkspace: true,
+        existingWorkspacePaths: [workspace],
+      },
+    });
+
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: "workspace_collision" }));
+  });
+
+  it("keeps blocking a non-adopted existing workspace", async () => {
+    const { source, workspace } = await createPlanSource();
+    await mkdir(workspace, { recursive: true });
+
+    const plan = await buildClawAddPlan({
+      manifest: requireManifest(),
+      source,
+      context: { workspace },
+    });
+
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: "workspace_collision" }));
+  });
+});
+
+describe("applyClawAddPlan workspace adoption", () => {
+  it("revalidates an adopted workspace before realizing shared plugin requirements", async () => {
+    const root = tempDirs.make("openclaw-claw-adopt-add-");
+    const workspace = join(root, "existing-workspace");
+    await mkdir(workspace);
+    const { plan } = await makeProvenancePlan(
+      root,
+      {
+        schemaVersion: 1,
+        agent: { id: "worker" },
+        packages: [{ kind: "plugin", source: "clawhub", ref: "@acme/audit", version: "1.0.0" }],
+      },
+      {
+        workspace,
+        adoptExistingWorkspace: true,
+        packagePreflight: async () => ({
+          ok: true,
+          action: "install",
+          integrity: `sha256:${"a".repeat(64)}`,
+          installId: "audit",
+        }),
+      },
+    );
+    expect(plan.blockers).toEqual([]);
+    await rmdir(workspace);
+    const installPackages = vi.fn();
+
+    await expect(
+      applyClawAddPlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: stateEnv(root),
+        installPackages,
+      }),
+    ).rejects.toMatchObject({ code: "workspace_collision" });
+    expect(installPackages).not.toHaveBeenCalled();
+    expect(readInstallRow("worker", root)).toBeUndefined();
+  });
+});

--- a/src/claws/lifecycle-adopt.test.ts
+++ b/src/claws/lifecycle-adopt.test.ts
@@ -251,8 +251,11 @@ describe("applyClawAddPlan workspace adoption", () => {
       status: "partial",
     });
 
+    expect(seedPackageBootstrap).toHaveBeenCalledOnce();
     expect(commitConfig).toHaveBeenCalledOnce();
-    expect(seedPackageBootstrap).not.toHaveBeenCalled();
+    expect(seedPackageBootstrap.mock.invocationCallOrder[0]).toBeLessThan(
+      commitConfig.mock.invocationCallOrder[0] ?? 0,
+    );
     expect(createWorkspaceFiles).not.toHaveBeenCalled();
   });
 });

--- a/src/claws/lifecycle-adopt.test.ts
+++ b/src/claws/lifecycle-adopt.test.ts
@@ -220,7 +220,7 @@ describe("applyClawAddPlan workspace adoption", () => {
     expect(readInstallRow("worker", root)).toBeUndefined();
   });
 
-  it("rejects a live workspace claim before writing adopted workspace files", async () => {
+  it("reserves an adopted workspace before writing adopted workspace files", async () => {
     const { source, workspace } = await createPlanSource();
     await mkdir(workspace, { recursive: true });
     await writeFile(join(workspace, "AGENTS.md"), "# Agent\n", "utf8");
@@ -232,21 +232,27 @@ describe("applyClawAddPlan workspace adoption", () => {
     expect(plan.blockers).toEqual([]);
     const seedPackageBootstrap = vi.fn(async () => undefined);
     const createWorkspaceFiles = vi.fn();
+    const commitConfig = vi.fn(async (transform) => {
+      transform({
+        agents: { entries: { other: { name: "Other", workspace } } },
+      });
+    });
 
     await expect(
       applyClawAddPlan(plan, {
         consentPlanIntegrity: plan.planIntegrity,
         env: stateEnv(source.packageRoot),
-        readConfig: () => ({
-          agents: { entries: { other: { name: "Other", workspace } } },
-        }),
+        commitConfig,
         seedPackageBootstrap,
         createWorkspaceFiles,
       }),
-    ).rejects.toMatchObject({ code: "workspace_collision" });
+    ).resolves.toMatchObject({
+      error: { code: "workspace_collision" },
+      status: "partial",
+    });
 
+    expect(commitConfig).toHaveBeenCalledOnce();
     expect(seedPackageBootstrap).not.toHaveBeenCalled();
     expect(createWorkspaceFiles).not.toHaveBeenCalled();
-    expect(readInstallRow("adopt-agent", source.packageRoot)).toBeUndefined();
   });
 });

--- a/src/claws/lifecycle-agent-adopt-remove.test.ts
+++ b/src/claws/lifecycle-agent-adopt-remove.test.ts
@@ -1,0 +1,129 @@
+// Removal coverage for historical state retained after configured-agent adoption.
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { applyClawAddPlan } from "./add.js";
+import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawSourceIdentity } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+async function adoptedAgentFixture() {
+  const root = tempDirs.make("openclaw-claw-agent-adopt-remove-");
+  const workspace = join(root, "workspace");
+  await mkdir(workspace);
+  const parsed = parseClawManifest({
+    schemaVersion: 1,
+    agent: { id: "worker", name: "Worker" },
+  });
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.diagnostics));
+  }
+  const source: ClawSourceIdentity = {
+    kind: "package",
+    name: "@acme/worker",
+    version: "1.0.0",
+    packageRoot: root,
+    manifestPath: join(root, "openclaw.claw.json"),
+    integrityKind: "artifact",
+    integrity: "sha256:manifest",
+    byteLength: 1,
+  };
+  let config: OpenClawConfig = {
+    agents: { entries: { worker: { name: "Worker", workspace, default: true } } },
+  };
+  const plan = await buildClawAddPlan({
+    manifest: parsed.manifest,
+    source,
+    context: {
+      workspace,
+      adoptExistingAgent: true,
+      existingAgents: [{ id: "worker", name: "Worker", workspace, default: true }],
+    },
+  });
+  const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+  await applyClawAddPlan(plan, {
+    env,
+    consentPlanIntegrity: plan.planIntegrity,
+    readConfig: () => config,
+    commitConfig: async (transform) => {
+      config = transform(config);
+    },
+  });
+  return {
+    env,
+    workspace,
+    getConfig: () => config,
+    setConfig: (next: OpenClawConfig) => (config = next),
+  };
+}
+
+describe("Claw remove after configured-agent adoption", () => {
+  it("reports adopted agent origin in status", async () => {
+    const current = await adoptedAgentFixture();
+    const agent = current.getConfig().agents?.entries?.worker;
+    if (!agent) {
+      throw new Error("fixture agent missing");
+    }
+    current.setConfig({ agents: { entries: { WORKER: agent } } });
+
+    await expect(
+      readClawStatus("worker", { env: current.env, config: current.getConfig() }),
+    ).resolves.toMatchObject({ records: [{ agentOrigin: "adopted", agentState: "present" }] });
+  });
+
+  it("plans retention for the pre-existing agent and session state", async () => {
+    const current = await adoptedAgentFixture();
+
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+
+    expect(plan.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "agentState", action: "retain", blocked: false }),
+        expect.objectContaining({ kind: "sessionIndex", action: "retain", blocked: false }),
+        expect.objectContaining({ kind: "sessionTranscripts", action: "retain", blocked: false }),
+        expect.objectContaining({ kind: "workspace", action: "retain", blocked: false }),
+      ]),
+    );
+  });
+
+  it("removes managed config without purging or trashing historical state", async () => {
+    const current = await adoptedAgentFixture();
+    const agent = current.getConfig().agents?.entries?.worker;
+    if (!agent) {
+      throw new Error("fixture agent missing");
+    }
+    current.setConfig({ agents: { entries: { WORKER: agent } } });
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+    const purgeSessions = vi.fn();
+    const trashPath = vi.fn(async () => true);
+
+    const result = await applyClawRemovePlan(plan, {
+      env: current.env,
+      config: current.getConfig(),
+      consentPlanIntegrity: plan.planIntegrity,
+      commitConfig: async (transform) => {
+        current.setConfig(transform(current.getConfig()));
+      },
+      purgeSessions,
+      trashPath,
+    });
+
+    expect(result.status).toBe("complete");
+    expect(Object.keys(current.getConfig().agents?.entries ?? {})).toEqual([]);
+    expect(purgeSessions).not.toHaveBeenCalled();
+    expect(trashPath).not.toHaveBeenCalled();
+  });
+});

--- a/src/claws/lifecycle-agent-adopt-remove.test.ts
+++ b/src/claws/lifecycle-agent-adopt-remove.test.ts
@@ -4,6 +4,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  listOpenClawRegisteredAgentDatabases,
+  registerOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db-registry.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { applyClawAddPlan } from "./add.js";
 import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
@@ -94,6 +98,45 @@ describe("Claw remove after configured-agent adoption", () => {
         expect.objectContaining({ kind: "workspace", action: "retain", blocked: false }),
       ]),
     );
+  });
+
+  it("keeps durable database discovery for the retained adopted agent", async () => {
+    const current = await adoptedAgentFixture();
+    const agent = current.getConfig().agents?.entries?.worker;
+    if (!agent) {
+      throw new Error("fixture agent missing");
+    }
+    current.setConfig({ agents: { entries: { WORKER: agent } } });
+    const databasePath = join(
+      current.env.OPENCLAW_STATE_DIR,
+      "agents",
+      "worker",
+      "agent",
+      "openclaw-agent.sqlite",
+    );
+    registerOpenClawAgentDatabase({ agentId: "worker", path: databasePath, env: current.env });
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config: current.getConfig(),
+    });
+
+    const result = await applyClawRemovePlan(plan, {
+      env: current.env,
+      config: current.getConfig(),
+      consentPlanIntegrity: plan.planIntegrity,
+      commitConfig: async (transform) => {
+        current.setConfig(transform(current.getConfig()));
+      },
+      purgeSessions: vi.fn(),
+      trashPath: vi.fn(async () => true),
+    });
+
+    expect(result.status).toBe("complete");
+    // Removal retains the adopted agent's database and sessions, so the registration that finds
+    // them must survive; unregistering here would orphan state the operator still owns.
+    expect(
+      listOpenClawRegisteredAgentDatabases({ env: current.env }).map((entry) => entry.agentId),
+    ).toEqual(["worker"]);
   });
 
   it("removes managed config without purging or trashing historical state", async () => {

--- a/src/claws/lifecycle-agent-adoption.e2e.test.ts
+++ b/src/claws/lifecycle-agent-adoption.e2e.test.ts
@@ -1,0 +1,257 @@
+import { execFile } from "node:child_process";
+import { access, copyFile, mkdir, readFile, realpath, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  appendTranscriptEvent,
+  loadSessionEntry,
+  loadTranscriptEvents,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  resolveOpenClawAgentSqlitePath,
+} from "../state/openclaw-agent-db.js";
+
+const execFileAsync = promisify(execFile);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function runBuiltOpenClaw(args: string[], stateDir: string) {
+  const result = await execFileAsync(process.execPath, ["openclaw.mjs", ...args], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      HOME: stateDir,
+      USERPROFILE: stateDir,
+      OPENCLAW_CONFIG_PATH: join(stateDir, "openclaw.json"),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_EXPERIMENTAL_CLAWS: "1",
+      OPENCLAW_HOME: stateDir,
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TEST_FAST: "1",
+      VITEST: "",
+    },
+    maxBuffer: 1024 * 1024,
+  });
+  return JSON.parse(result.stdout.trim()) as Record<string, unknown>;
+}
+
+describe("configured agent adoption built CLI e2e", () => {
+  it("manages declared state while retaining the pre-Claws history on remove", async () => {
+    const stateDir = tempDirs.make("openclaw-claws-agent-adopt-e2e-");
+    const workspace = join(stateDir, "existing-workspace");
+    await mkdir(join(workspace, "reference"), { recursive: true });
+    for (const path of ["SOUL.md", "HEARTBEAT.md", "reference/policy.md"]) {
+      await copyFile(join("src/claws/fixtures/workspace", path), join(workspace, path));
+    }
+    const canonicalWorkspace = await realpath(workspace);
+    const agentDir = join(stateDir, "agents", "workspace-agent");
+    const agentDatabase = resolveOpenClawAgentSqlitePath({
+      agentId: "workspace-agent",
+      env: { OPENCLAW_STATE_DIR: stateDir },
+    });
+    const sessionStorePath = join(agentDir, "sessions", "sessions.json");
+    const sessionKey = "agent:workspace-agent:pre-claws";
+    const sessionId = "pre-claws-session";
+    const stateSentinel = join(agentDir, "pre-claws-state.txt");
+    const transcriptSentinel = join(agentDir, "sessions", "pre-claws-transcript.jsonl");
+    const undeclared = join(workspace, "operator-notes.md");
+    await mkdir(join(agentDir, "sessions"), { recursive: true });
+    await upsertSessionEntryCore(
+      { agentId: "workspace-agent", sessionKey, storePath: sessionStorePath },
+      { sessionId, updatedAt: 1 },
+    );
+    const transcriptEvent = {
+      id: "pre-claws-event",
+      marker: "pre-claws-history",
+      timestamp: "1970-01-01T00:00:00.001Z",
+      type: "metadata",
+    };
+    await appendTranscriptEvent(
+      { agentId: "workspace-agent", sessionId, sessionKey, storePath: sessionStorePath },
+      transcriptEvent,
+    );
+    await writeFile(stateSentinel, "pre-claws-agent-state\n", "utf8");
+    await writeFile(transcriptSentinel, "pre-claws-transcript-sentinel\n", "utf8");
+    await writeFile(undeclared, "operator-owned\n", "utf8");
+    await writeFile(
+      join(stateDir, "openclaw.json"),
+      `${JSON.stringify(
+        {
+          agents: {
+            entries: {
+              main: {},
+              "workspace-agent": {
+                default: true,
+                name: "Workspace Agent",
+                identity: { name: "Workspace" },
+                workspace: canonicalWorkspace,
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+    expect(
+      loadSessionEntry({ agentId: "workspace-agent", sessionKey, storePath: sessionStorePath }),
+    ).toMatchObject({ sessionId });
+    await expect(
+      loadTranscriptEvents({
+        agentId: "workspace-agent",
+        sessionId,
+        sessionKey,
+        storePath: sessionStorePath,
+      }),
+    ).resolves.toContainEqual(transcriptEvent);
+    closeOpenClawAgentDatabasesForTest();
+
+    const source = "src/claws/fixtures/workspace-agent.claw.json";
+    const preview = await runBuiltOpenClaw(
+      [
+        "claws",
+        "add",
+        source,
+        "--workspace",
+        workspace,
+        "--adopt-existing-agent",
+        "--dry-run",
+        "--json",
+      ],
+      stateDir,
+    );
+    expect(preview).toMatchObject({
+      blockers: [],
+      actions: expect.arrayContaining([
+        expect.objectContaining({ kind: "agent", action: "adopt" }),
+        expect.objectContaining({ kind: "workspace", action: "adopt" }),
+      ]),
+    });
+    const added = await runBuiltOpenClaw(
+      [
+        "claws",
+        "add",
+        source,
+        "--workspace",
+        workspace,
+        "--adopt-existing-agent",
+        "--yes",
+        "--plan-integrity",
+        String(preview.planIntegrity),
+        "--json",
+      ],
+      stateDir,
+    );
+    expect(added).toMatchObject({
+      status: "complete",
+      agent: { finalId: "workspace-agent" },
+      installRecord: {
+        agentOrigin: "adopted",
+        schemaVersion: "openclaw.clawInstallRecord.v3",
+      },
+    });
+    const adoptedConfig = {
+      default: true,
+      name: "Workspace Agent",
+      identity: { name: "Workspace" },
+      workspace: canonicalWorkspace,
+    };
+    expect(
+      JSON.parse(await readFile(join(stateDir, "openclaw.json"), "utf8")).agents.entries[
+        "workspace-agent"
+      ],
+    ).toEqual(adoptedConfig);
+
+    const status = await runBuiltOpenClaw(
+      ["claws", "status", "workspace-agent", "--json"],
+      stateDir,
+    );
+    expect(status).toMatchObject({
+      records: [
+        {
+          agentOrigin: "adopted",
+          agentState: "present",
+          install: { agentId: "workspace-agent", agentOrigin: "adopted" },
+        },
+      ],
+    });
+
+    const updatePlan = await runBuiltOpenClaw(
+      ["claws", "update", "workspace-agent", "--dry-run", "--json"],
+      stateDir,
+    );
+    const updated = await runBuiltOpenClaw(
+      [
+        "claws",
+        "update",
+        "workspace-agent",
+        "--yes",
+        "--plan-integrity",
+        String(updatePlan.planIntegrity),
+        "--json",
+      ],
+      stateDir,
+    );
+    expect(updated).toMatchObject({
+      status: "complete",
+      installRecord: { agentOrigin: "adopted" },
+    });
+    expect(
+      JSON.parse(await readFile(join(stateDir, "openclaw.json"), "utf8")).agents.entries[
+        "workspace-agent"
+      ],
+    ).toEqual(adoptedConfig);
+
+    const removePlan = await runBuiltOpenClaw(
+      ["claws", "remove", "workspace-agent", "--dry-run", "--json"],
+      stateDir,
+    );
+    expect(removePlan).toMatchObject({
+      blockers: [],
+      actions: expect.arrayContaining([
+        expect.objectContaining({ kind: "agentState", action: "retain" }),
+        expect.objectContaining({ kind: "sessionIndex", action: "retain" }),
+        expect.objectContaining({ kind: "sessionTranscripts", action: "retain" }),
+      ]),
+    });
+    const removed = await runBuiltOpenClaw(
+      [
+        "claws",
+        "remove",
+        "workspace-agent",
+        "--yes",
+        "--plan-integrity",
+        String(removePlan.planIntegrity),
+        "--json",
+      ],
+      stateDir,
+    );
+    expect(removed).toMatchObject({ status: "complete", agentRemoved: true });
+
+    const config = JSON.parse(await readFile(join(stateDir, "openclaw.json"), "utf8"));
+    expect(config.agents.entries["workspace-agent"]).toBeUndefined();
+    await expect(access(join(workspace, "SOUL.md"))).rejects.toThrow();
+    await expect(access(agentDatabase)).resolves.toBeUndefined();
+    expect(
+      loadSessionEntry({ agentId: "workspace-agent", sessionKey, storePath: sessionStorePath }),
+    ).toMatchObject({ sessionId });
+    await expect(
+      loadTranscriptEvents({
+        agentId: "workspace-agent",
+        sessionId,
+        sessionKey,
+        storePath: sessionStorePath,
+      }),
+    ).resolves.toContainEqual(transcriptEvent);
+    await expect(readFile(stateSentinel, "utf8")).resolves.toBe("pre-claws-agent-state\n");
+    await expect(readFile(transcriptSentinel, "utf8")).resolves.toBe(
+      "pre-claws-transcript-sentinel\n",
+    );
+    await expect(readFile(undeclared, "utf8")).resolves.toBe("operator-owned\n");
+    closeOpenClawAgentDatabasesForTest();
+  });
+});

--- a/src/claws/lifecycle-agent-adoption.test.ts
+++ b/src/claws/lifecycle-agent-adoption.test.ts
@@ -1,0 +1,267 @@
+// Planning coverage for explicitly adopting a configured pre-Claws agent.
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { inspectAgentWorkspaceOwnership } from "./lifecycle-agent-workspace.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawManifest, ClawSourceIdentity } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function manifest(): ClawManifest {
+  const parsed = parseClawManifest({
+    schemaVersion: 1,
+    agent: { id: "worker", name: "Worker" },
+    workspace: { bootstrapFiles: { "SOUL.md": { source: "SOUL.md" } } },
+  });
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.diagnostics));
+  }
+  return parsed.manifest;
+}
+
+async function fixture() {
+  const root = tempDirs.make("openclaw-claw-agent-adopt-plan-");
+  const workspace = join(root, "workspace");
+  await mkdir(workspace);
+  await writeFile(join(root, "SOUL.md"), "managed\n", "utf8");
+  await writeFile(join(workspace, "SOUL.md"), "managed\n", "utf8");
+  const source: ClawSourceIdentity = {
+    kind: "package",
+    name: "@acme/worker",
+    version: "1.0.0",
+    packageRoot: root,
+    manifestPath: join(root, "openclaw.claw.json"),
+    integrityKind: "artifact",
+    integrity: "sha256:manifest",
+    byteLength: 1,
+  };
+  return { source, workspace };
+}
+
+describe("buildClawAddPlan configured-agent adoption", () => {
+  it("canonicalizes pre-resolved workspace candidates before overlap checks", () => {
+    const ownership = inspectAgentWorkspaceOwnership({
+      existingAgents: [{ id: "other", resolvedWorkspace: "/workspace-alias" }],
+      finalId: "worker",
+      workspace: "/workspace",
+      adopting: true,
+      canonicalize: (path) => (path === "/workspace-alias" ? "/workspace" : path),
+    });
+
+    expect(ownership.configuredWorkspaceConflict).toBe(true);
+  });
+
+  it("preserves agent_id_collision without explicit adoption", async () => {
+    const { source, workspace } = await fixture();
+    const plan = await buildClawAddPlan({
+      manifest: manifest(),
+      source,
+      context: {
+        workspace,
+        existingAgents: [{ id: "worker", name: "Worker", workspace }],
+        existingWorkspacePaths: [workspace],
+      },
+    });
+
+    expect(plan.blockers).toContainEqual(expect.objectContaining({ code: "agent_id_collision" }));
+  });
+
+  it("adopts an exact configured agent and preserves its default marker", async () => {
+    const { source, workspace } = await fixture();
+    const plan = await buildClawAddPlan({
+      manifest: manifest(),
+      source,
+      context: {
+        workspace,
+        adoptExistingAgent: true,
+        existingAgents: [{ id: "worker", name: "Worker", workspace, default: true }],
+        existingWorkspacePaths: [workspace],
+      },
+    });
+
+    expect(plan.blockers).toEqual([]);
+    expect(plan.agent.config).toMatchObject({
+      id: "worker",
+      name: "Worker",
+      workspace,
+      default: true,
+    });
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "agent", id: "worker", action: "adopt", blocked: false }),
+    );
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspace", action: "adopt", blocked: false }),
+    );
+    expect(plan.capabilityChanges).toContainEqual(
+      expect.objectContaining({ kind: "agent", path: "agent", action: "configure" }),
+    );
+  });
+
+  it("blocks explicit adoption when the configured agent is missing", async () => {
+    const { source, workspace } = await fixture();
+    const plan = await buildClawAddPlan({
+      manifest: manifest(),
+      source,
+      context: { workspace, adoptExistingAgent: true, existingAgents: [] },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "agent_adoption_missing", path: "$.agent.id" }),
+    );
+  });
+
+  it("blocks explicit adoption of an already-managed agent", async () => {
+    const { source, workspace } = await fixture();
+    const plan = await buildClawAddPlan({
+      manifest: manifest(),
+      source,
+      context: {
+        workspace,
+        adoptExistingAgent: true,
+        existingAgents: [{ id: "worker", name: "Worker", workspace }],
+        existingWorkspacePaths: [workspace],
+        managedAgentIds: ["worker"],
+      },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "agent_already_managed", path: "$.agent.id" }),
+    );
+  });
+
+  it("reports durable ownership before a missing configured entry", async () => {
+    const { source, workspace } = await fixture();
+    const plan = await buildClawAddPlan({
+      manifest: manifest(),
+      source,
+      context: {
+        workspace,
+        adoptExistingAgent: true,
+        existingAgents: [],
+        managedAgentIds: ["worker"],
+      },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "agent_already_managed", path: "$.agent.id" }),
+    );
+    expect(plan.blockers).not.toContainEqual(
+      expect.objectContaining({ code: "agent_adoption_missing" }),
+    );
+  });
+
+  it("reports bounded differing field paths without either value", async () => {
+    const { source, workspace } = await fixture();
+    const plan = await buildClawAddPlan({
+      manifest: manifest(),
+      source,
+      openClawProfile: { schemaVersion: 1, agent: { tools: { deny: ["exec"] } } },
+      context: {
+        workspace,
+        adoptExistingAgent: true,
+        existingAgents: [{ id: "worker", name: "Worker", workspace, tools: { deny: ["browser"] } }],
+        existingWorkspacePaths: [workspace],
+      },
+    });
+
+    const conflict = plan.blockers.find((candidate) => candidate.code === "agent_config_conflict");
+    expect(conflict?.message).toContain("tools.deny[0]");
+    expect(conflict?.message).not.toContain("exec");
+    expect(conflict?.message).not.toContain("browser");
+  });
+
+  it("compares the full config when workspace spellings resolve identically", async () => {
+    const { source, workspace } = await fixture();
+    const plan = await buildClawAddPlan({
+      manifest: manifest(),
+      source,
+      context: {
+        workspace,
+        adoptExistingAgent: true,
+        existingAgents: [
+          {
+            id: "worker",
+            name: "Different Name",
+            workspace: join(source.packageRoot, "workspace-alias"),
+            resolvedWorkspace: workspace,
+          },
+        ],
+        existingWorkspacePaths: [workspace],
+      },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "agent_config_conflict", path: "$.agent" }),
+    );
+    expect(plan.blockers).not.toContainEqual(
+      expect.objectContaining({ code: "agent_workspace_conflict" }),
+    );
+  });
+
+  it("blocks a requested workspace remap", async () => {
+    const { source, workspace } = await fixture();
+    const plan = await buildClawAddPlan({
+      manifest: manifest(),
+      source,
+      context: {
+        workspace,
+        adoptExistingAgent: true,
+        existingAgents: [
+          { id: "worker", name: "Worker", workspace: join(source.packageRoot, "other") },
+        ],
+      },
+    });
+
+    expect(
+      plan.blockers.filter((diagnostic) => diagnostic.code === "agent_workspace_conflict"),
+    ).toHaveLength(1);
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspace", action: "create", blocked: true }),
+    );
+    expect(plan.capabilityChanges).not.toContainEqual(
+      expect.objectContaining({ path: "workspace" }),
+    );
+  });
+
+  it("blocks overlap with another configured agent workspace", async () => {
+    const { source, workspace } = await fixture();
+    const plan = await buildClawAddPlan({
+      manifest: manifest(),
+      source,
+      context: {
+        workspace,
+        adoptExistingAgent: true,
+        existingAgents: [
+          { id: "worker", name: "Worker", workspace },
+          { id: "other", workspace: join(workspace, "nested") },
+        ],
+        existingWorkspacePaths: [workspace, join(workspace, "nested")],
+      },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "agent_workspace_conflict", path: "$.workspace" }),
+    );
+  });
+
+  it("blocks overlap supplied only through supplemental workspace ownership", async () => {
+    const { source, workspace } = await fixture();
+    const plan = await buildClawAddPlan({
+      manifest: manifest(),
+      source,
+      context: {
+        workspace,
+        adoptExistingAgent: true,
+        existingAgents: [{ id: "worker", name: "Worker", workspace }],
+        existingWorkspacePaths: [workspace, join(workspace, "nested")],
+      },
+    });
+
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "agent_workspace_conflict", path: "$.workspace" }),
+    );
+  });
+});

--- a/src/claws/lifecycle-agent-plan.ts
+++ b/src/claws/lifecycle-agent-plan.ts
@@ -1,4 +1,7 @@
 // Plans the agent entry for a Claw add without mutating configuration.
+import { stableStringify } from "@openclaw/normalization-core";
+import { collectChangedPaths } from "../config/config-change-paths.js";
+import type { AgentConfig } from "../config/types.agents.js";
 import { materializeClawToolProfile } from "./tool-profile-consent.js";
 import type {
   ClawAddCapabilityChange,
@@ -10,6 +13,23 @@ import type {
 } from "./types.js";
 
 const AGENT_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+const MAX_CONFLICT_PATHS = 16;
+
+export type ExistingClawAgent = AgentConfig & { id: string; resolvedWorkspace?: string };
+
+function configuredAgent(existing: ExistingClawAgent): AgentConfig & { id: string } {
+  const { resolvedWorkspace: _resolvedWorkspace, ...config } = existing;
+  return config;
+}
+
+function configConflictMessage(existing: AgentConfig, target: AgentConfig): string {
+  const paths = new Set<string>();
+  collectChangedPaths(existing, target, "", paths);
+  const sorted = [...paths].toSorted();
+  const shown = sorted.slice(0, MAX_CONFLICT_PATHS);
+  const remainder = sorted.length - shown.length;
+  return `Existing agent configuration differs at ${shown.join(", ")}${remainder > 0 ? `, and ${remainder} more path${remainder === 1 ? "" : "s"}` : ""}; adoption never reports or overwrites either value.`;
+}
 
 export function planClawAgent(params: {
   finalId: string;
@@ -17,7 +37,10 @@ export function planClawAgent(params: {
   manifestAgent: ClawManifest["agent"];
   openClawProfile?: ClawOpenClawProfile;
   reconstructLegacyDynamicToolProfilePlan?: boolean;
+  existingAgents?: Iterable<ExistingClawAgent>;
   existingAgentIds?: Iterable<string>;
+  managedAgentIds?: Iterable<string>;
+  adoptExistingAgent?: boolean;
 }): {
   config: ClawAddPlan["agent"]["config"];
   action: ClawAddPlanAction;
@@ -28,7 +51,12 @@ export function planClawAgent(params: {
   >;
 } {
   const idValid = AGENT_ID_PATTERN.test(params.finalId);
-  const blocked = new Set(params.existingAgentIds ?? []).has(params.finalId);
+  const existing = [...(params.existingAgents ?? [])].find((agent) => agent.id === params.finalId);
+  const existingId =
+    existing !== undefined || new Set(params.existingAgentIds ?? []).has(params.finalId);
+  const adoptionRequested = params.adoptExistingAgent === true;
+  const alreadyManaged = new Set(params.managedAgentIds ?? []).has(params.finalId);
+  const existingConfig = existing ? configuredAgent(existing) : undefined;
   const blockers: ClawDiagnostic[] = [];
   if (!idValid) {
     blockers.push({
@@ -39,7 +67,7 @@ export function planClawAgent(params: {
       message: `Final agent id ${JSON.stringify(params.finalId)} is not a valid portable agent id.`,
     });
   }
-  if (blocked) {
+  if (existingId && !adoptionRequested) {
     blockers.push({
       level: "error",
       code: "agent_id_collision",
@@ -58,6 +86,38 @@ export function planClawAgent(params: {
     id: params.finalId,
     workspace: params.workspace,
   };
+  if (existingConfig && Object.hasOwn(existingConfig, "default")) {
+    config.default = existingConfig.default;
+  }
+  if (adoptionRequested && alreadyManaged) {
+    blockers.push({
+      level: "error",
+      code: "agent_already_managed",
+      phase: "plan",
+      path: "$.agent.id",
+      message: `Agent id ${JSON.stringify(params.finalId)} already has a Claw install record.`,
+    });
+  } else if (adoptionRequested && !existingConfig) {
+    blockers.push({
+      level: "error",
+      code: "agent_adoption_missing",
+      phase: "plan",
+      path: "$.agent.id",
+      message: `Agent id ${JSON.stringify(params.finalId)} does not exist; adoption requires an existing unmanaged agent.`,
+    });
+  } else if (
+    adoptionRequested &&
+    existingConfig &&
+    stableStringify(existingConfig) !== stableStringify(config)
+  ) {
+    blockers.push({
+      level: "error",
+      code: "agent_config_conflict",
+      phase: "plan",
+      path: "$.agent",
+      message: configConflictMessage(existingConfig, config),
+    });
+  }
   const effect = {
     ...(settings.sandbox ? { sandbox: settings.sandbox } : {}),
     ...(settings.tools ? { tools: settings.tools } : {}),
@@ -70,23 +130,35 @@ export function planClawAgent(params: {
     action: {
       kind: "agent",
       id: params.finalId,
-      action: "create",
+      action: adoptionRequested ? "adopt" : "create",
       target: `agents.entries[${JSON.stringify(params.finalId)}]`,
-      details: { ...config, expectedState: "absent" },
-      blocked: blocked || !idValid,
+      details: { ...config, expectedState: adoptionRequested ? "present-exact" : "absent" },
+      blocked: blockers.length > 0,
     },
-    ...(Object.keys(effect).length > 0
+    ...(adoptionRequested
       ? {
           capabilityChange: {
             kind: "agent",
             id: params.finalId,
             path: "agent",
-            action: "create",
+            action: "configure",
             reason:
-              "The new agent declares sandbox, tool, memory-search, or recurring heartbeat capabilities.",
-            effect,
+              "The Claw adopts ownership of an exact existing agent configuration without rewriting it.",
+            effect: { ...effect, adoptExistingAgent: true },
           },
         }
-      : {}),
+      : Object.keys(effect).length > 0
+        ? {
+            capabilityChange: {
+              kind: "agent",
+              id: params.finalId,
+              path: "agent",
+              action: "create",
+              reason:
+                "The new agent declares sandbox, tool, memory-search, or recurring heartbeat capabilities.",
+              effect,
+            },
+          }
+        : {}),
   };
 }

--- a/src/claws/lifecycle-agent-plan.ts
+++ b/src/claws/lifecycle-agent-plan.ts
@@ -1,0 +1,92 @@
+// Plans the agent entry for a Claw add without mutating configuration.
+import { materializeClawToolProfile } from "./tool-profile-consent.js";
+import type {
+  ClawAddCapabilityChange,
+  ClawAddPlan,
+  ClawAddPlanAction,
+  ClawDiagnostic,
+  ClawManifest,
+  ClawOpenClawProfile,
+} from "./types.js";
+
+const AGENT_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+
+export function planClawAgent(params: {
+  finalId: string;
+  workspace: string;
+  manifestAgent: ClawManifest["agent"];
+  openClawProfile?: ClawOpenClawProfile;
+  reconstructLegacyDynamicToolProfilePlan?: boolean;
+  existingAgentIds?: Iterable<string>;
+}): {
+  config: ClawAddPlan["agent"]["config"];
+  action: ClawAddPlanAction;
+  blockers: ClawDiagnostic[];
+  capabilityChange?: Omit<
+    ClawAddCapabilityChange,
+    "classification" | "requiresDistinctConsent" | "digest"
+  >;
+} {
+  const idValid = AGENT_ID_PATTERN.test(params.finalId);
+  const blocked = new Set(params.existingAgentIds ?? []).has(params.finalId);
+  const blockers: ClawDiagnostic[] = [];
+  if (!idValid) {
+    blockers.push({
+      level: "error",
+      code: "invalid_agent_id",
+      phase: "plan",
+      path: "$.agent.id",
+      message: `Final agent id ${JSON.stringify(params.finalId)} is not a valid portable agent id.`,
+    });
+  }
+  if (blocked) {
+    blockers.push({
+      level: "error",
+      code: "agent_id_collision",
+      phase: "plan",
+      path: "$.agent.id",
+      message: `Agent id ${JSON.stringify(params.finalId)} already exists; Claws never merge into existing agents.`,
+    });
+  }
+  const settings = params.openClawProfile?.agent ?? {};
+  const persistedSettings = params.reconstructLegacyDynamicToolProfilePlan
+    ? settings
+    : materializeClawToolProfile(settings);
+  const config: ClawAddPlan["agent"]["config"] = {
+    ...params.manifestAgent,
+    ...persistedSettings,
+    id: params.finalId,
+    workspace: params.workspace,
+  };
+  const effect = {
+    ...(settings.sandbox ? { sandbox: settings.sandbox } : {}),
+    ...(settings.tools ? { tools: settings.tools } : {}),
+    ...(settings.memory ? { memory: settings.memory } : {}),
+    ...(settings.heartbeat ? { heartbeat: settings.heartbeat } : {}),
+  };
+  return {
+    config,
+    blockers,
+    action: {
+      kind: "agent",
+      id: params.finalId,
+      action: "create",
+      target: `agents.entries[${JSON.stringify(params.finalId)}]`,
+      details: { ...config, expectedState: "absent" },
+      blocked: blocked || !idValid,
+    },
+    ...(Object.keys(effect).length > 0
+      ? {
+          capabilityChange: {
+            kind: "agent",
+            id: params.finalId,
+            path: "agent",
+            action: "create",
+            reason:
+              "The new agent declares sandbox, tool, memory-search, or recurring heartbeat capabilities.",
+            effect,
+          },
+        }
+      : {}),
+  };
+}

--- a/src/claws/lifecycle-agent-workspace.ts
+++ b/src/claws/lifecycle-agent-workspace.ts
@@ -1,0 +1,45 @@
+import { workspacePathsOverlap } from "../agents/agent-delete-safety.js";
+import type { ExistingClawAgent } from "./lifecycle-agent-plan.js";
+
+export function inspectAgentWorkspaceOwnership(params: {
+  existingAgents?: Iterable<ExistingClawAgent>;
+  existingWorkspacePaths?: Iterable<string>;
+  finalId: string;
+  workspace: string;
+  adopting: boolean;
+  canonicalize: (path: string) => string;
+}) {
+  const existingAgents = [...(params.existingAgents ?? [])];
+  const adoptedAgent = existingAgents.find((agent) => agent.id === params.finalId);
+  const workspaceOf = (agent: ExistingClawAgent) => {
+    const workspace = agent.resolvedWorkspace ?? agent.workspace;
+    return workspace ? params.canonicalize(workspace) : undefined;
+  };
+  const agentCandidates = existingAgents.flatMap((agent) => {
+    const path = workspaceOf(agent);
+    return path ? [{ agentId: agent.id, path }] : [];
+  });
+  const identifiedPaths = new Set(agentCandidates.map((candidate) => candidate.path));
+  // Some callers have agent identity for only part of the roster. Keep supplemental path-only
+  // ownership while letting the identified candidate represent duplicate paths.
+  const pathCandidates = [...(params.existingWorkspacePaths ?? [])]
+    .map((path) => params.canonicalize(path))
+    .filter((path) => !identifiedPaths.has(path))
+    .map((path) => ({ agentId: undefined, path }));
+  const candidates = [...agentCandidates, ...pathCandidates];
+  const configuredWorkspaceConflict = candidates.some(
+    (candidate) =>
+      (candidate.path === params.workspace &&
+        !(params.adopting && candidate.agentId === params.finalId)) ||
+      (params.adopting &&
+        candidate.agentId === params.finalId &&
+        candidate.path !== params.workspace) ||
+      (params.adopting &&
+        !(candidate.agentId === params.finalId && candidate.path === params.workspace) &&
+        workspacePathsOverlap(params.workspace, candidate.path)),
+  );
+  return {
+    configuredWorkspaceConflict,
+    adoptedAgentWorkspace: adoptedAgent ? workspaceOf(adoptedAgent) : undefined,
+  };
+}

--- a/src/claws/lifecycle-config-removal.ts
+++ b/src/claws/lifecycle-config-removal.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
 import { stableStringify } from "@openclaw/normalization-core";
 import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
-import { listAgentEntries } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -11,6 +10,7 @@ import {
 import { withAgentExecApprovalsRemoved } from "../infra/exec-approvals.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
+import { canonicalizeClawAgent, resolveCanonicalClawAgent } from "./agent-adoption-apply.js";
 import { digestClawAgentConfig } from "./agent-config-digest.js";
 import {
   deletionEffects,
@@ -61,7 +61,7 @@ async function commitClawAgentConfigRemoval(
     let result: ClawAgentConfigRemovalResult | undefined;
     await params.commitConfig((config) => {
       const effects = deletionEffects(config, params.agentId, params.fallbackWorkspace);
-      const agent = listAgentEntries(config).find((candidate) => candidate.id === params.agentId);
+      const agent = resolveCanonicalClawAgent(config, params.agentId);
       if (
         (agent && digestClawAgentConfig(agent) !== params.expectedDigest) ||
         digestClawAgentRemovalSurface(config, params.agentId) !==
@@ -110,7 +110,10 @@ async function commitClawAgentConfigRemoval(
         if (params.expectedState === "missing") {
           throw params.onModified();
         }
-        if (digestClawAgentConfig(agent) !== params.expectedDigest) {
+        if (
+          digestClawAgentConfig(canonicalizeClawAgent(agent, params.agentId)) !==
+          params.expectedDigest
+        ) {
           throw params.onModified();
         }
       },
@@ -135,7 +138,7 @@ async function commitClawAgentConfigRemoval(
       throw error;
     }
     const latestConfig = getRuntimeConfig();
-    if (listAgentEntries(latestConfig).some((agent) => agent.id === params.agentId)) {
+    if (resolveCanonicalClawAgent(latestConfig, params.agentId)) {
       throw params.onModified();
     }
     const effects = deletionEffects(latestConfig, params.agentId, params.fallbackWorkspace);

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -544,8 +544,11 @@ export function releaseClawRemoveRows(
   files: RemovedWorkspaceFile[],
   complete: boolean,
   options: OpenClawStateDatabaseOptions,
+  retainHistoricalAgentState = false,
 ): void {
-  if (complete) {
+  // Adopted removal keeps the agent database and its sessions, so the durable discovery
+  // registration that finds them must survive too; only Claw-created agents lose it here.
+  if (complete && !retainHistoricalAgentState) {
     // Keep the install record as the retry owner until database discovery is released.
     unregisterOpenClawAgentDatabases({ agentId, env: options.env });
   }

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -31,8 +31,13 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import type { ClawRemovePlanAction } from "./lifecycle-remove-contract.js";
 import { deleteCachedClawInstallSchemaVersion } from "./provenance-runtime-read.js";
 import type { PersistedClawInstall } from "./provenance.js";
+import {
+  CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+  deleteAdoptedWorkspaceRow,
+} from "./workspace-origin.js";
 import type { PersistedClawWorkspaceFile } from "./workspace.js";
 
 type WorkspaceFileRow = {
@@ -91,9 +96,10 @@ export function readAllClawWorkspaceFiles(
       `SELECT schema_version, agent_id, workspace, target_path, source_path,
               content_digest, status, created_at_ms, updated_at_ms
          FROM claw_workspace_files
+        WHERE target_path <> ?
         ORDER BY agent_id, target_path`,
     )
-    .all() as WorkspaceFileRow[];
+    .all(CLAW_ADOPTED_WORKSPACE_MARKER_PATH) as WorkspaceFileRow[];
   return rows.map(rowToWorkspaceFile);
 }
 
@@ -144,6 +150,31 @@ export function deletionEffects(config: OpenClawConfig, agentId: string, fallbac
     sessionsDir,
     workspaceSharedWith,
     workspaceRetained: workspaceSharedWith.length > 0,
+  };
+}
+
+/** Resolves the retain/trash plan for a workspace using the canonical reason priority. */
+export function planClawWorkspaceRemoval(params: {
+  sharedWith: string[];
+  adopted: boolean;
+  modified: boolean;
+  untracked: boolean;
+}): Pick<ClawRemovePlanAction, "action" | "details" | "reason"> {
+  const retained =
+    params.sharedWith.length > 0 || params.adopted || params.modified || params.untracked;
+  const reason = params.sharedWith.length
+    ? "Workspace overlaps another agent."
+    : params.adopted
+      ? "Workspace existed before this Claw adopted it."
+      : params.modified
+        ? "Workspace contains locally modified Claw-managed files."
+        : params.untracked
+          ? "Workspace contains files or directories not managed by this Claw."
+          : undefined;
+  return {
+    action: retained ? "retain" : "trash",
+    details: { retained, sharedWith: params.sharedWith },
+    ...(reason ? { reason } : {}),
   };
 }
 
@@ -487,6 +518,9 @@ export function releaseClawRemoveRows(
         .prepare("DELETE FROM claw_installs WHERE agent_id = ?")
         .run(agentId);
     }
+    // Drop the origin with the install it describes; a later agent reusing this id must not
+    // inherit an adopted-workspace claim from a Claw that no longer exists.
+    deleteAdoptedWorkspaceRow(db, agentId);
   }, options);
   if (complete) {
     deleteCachedClawInstallSchemaVersion(agentId, options);

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -4,7 +4,8 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import { findOverlappingWorkspaceAgentIds } from "../agents/agent-delete-safety.js";
-import { listAgentEntries, resolveAgentDir } from "../agents/agent-scope.js";
+import { resolveAgentEntry } from "../agents/agent-scope-config.js";
+import { resolveAgentDir } from "../agents/agent-scope.js";
 import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
 import {
   prepareLegacyWorkspaceStateReset,
@@ -127,6 +128,7 @@ export function synthesizeOrphanInstall(params: {
     agentId: params.agentId,
     workspace: params.workspace ?? "",
     agentConfigDigest: "sha256:missing",
+    agentOrigin: "created",
     agentOwnedPaths: [],
     status: "partial",
     addedAtMs: updatedAtMs,
@@ -135,7 +137,7 @@ export function synthesizeOrphanInstall(params: {
 }
 
 export function deletionEffects(config: OpenClawConfig, agentId: string, fallbackWorkspace = "") {
-  const agent = listAgentEntries(config).find((candidate) => candidate.id === agentId);
+  const agent = resolveAgentEntry(config, agentId);
   const pruned = pruneAgentConfig(config, agentId);
   const workspace = agent?.workspace ?? fallbackWorkspace;
   const agentDir = resolveAgentDir(config, agentId);
@@ -151,6 +153,53 @@ export function deletionEffects(config: OpenClawConfig, agentId: string, fallbac
     workspaceSharedWith,
     workspaceRetained: workspaceSharedWith.length > 0,
   };
+}
+
+export function planClawHistoricalAgentState(params: {
+  agentId: string;
+  agentDir?: string;
+  sessionsDir: string;
+  retain: boolean;
+  modified: boolean;
+}): ClawRemovePlanAction[] {
+  const blocked = params.retain ? false : params.modified;
+  const actions: ClawRemovePlanAction[] = params.agentDir
+    ? [
+        {
+          kind: "agentState",
+          id: params.agentId,
+          action: params.retain ? "retain" : "trash",
+          target: params.agentDir,
+          blocked,
+          ...(params.retain
+            ? { reason: "Agent state existed before this Claw adopted the agent." }
+            : {}),
+        },
+      ]
+    : [];
+  actions.push(
+    {
+      kind: "sessionIndex",
+      id: params.agentId,
+      action: params.retain ? "retain" : "delete",
+      target: `session store entries for agent:${params.agentId}`,
+      blocked,
+      ...(params.retain
+        ? { reason: "Session history existed before this Claw adopted the agent." }
+        : {}),
+    },
+    {
+      kind: "sessionTranscripts",
+      id: params.agentId,
+      action: params.retain ? "retain" : "trash",
+      target: params.sessionsDir,
+      blocked,
+      ...(params.retain
+        ? { reason: "Session transcripts existed before this Claw adopted the agent." }
+        : {}),
+    },
+  );
+  return actions;
 }
 
 /** Resolves the retain/trash plan for a workspace using the canonical reason priority. */
@@ -280,6 +329,7 @@ export async function cleanupClawAgentFilesystem(params: {
   runtime: RuntimeEnv;
   trashPath?: ClawTrashPath;
   retainWorkspace?: boolean;
+  retainHistoricalAgentState?: boolean;
 }): Promise<string[]> {
   const errors: string[] = [];
   const trashPath = params.trashPath ?? moveToTrash;
@@ -308,11 +358,13 @@ export async function cleanupClawAgentFilesystem(params: {
       errors.push(`Could not trash workspace ${params.targets.workspaceDir}.`);
     }
   }
-  if (!(await trashPath(params.targets.agentDir, params.runtime))) {
-    errors.push(`Could not trash agent state ${params.targets.agentDir}.`);
-  }
-  if (!(await trashPath(params.targets.sessionsDir, params.runtime))) {
-    errors.push(`Could not trash session transcripts ${params.targets.sessionsDir}.`);
+  if (!params.retainHistoricalAgentState) {
+    if (!(await trashPath(params.targets.agentDir, params.runtime))) {
+      errors.push(`Could not trash agent state ${params.targets.agentDir}.`);
+    }
+    if (!(await trashPath(params.targets.sessionsDir, params.runtime))) {
+      errors.push(`Could not trash session transcripts ${params.targets.sessionsDir}.`);
+    }
   }
   return errors;
 }

--- a/src/claws/lifecycle-remove.test-support.ts
+++ b/src/claws/lifecycle-remove.test-support.ts
@@ -1,0 +1,95 @@
+// Shared Claw install fixtures for the remove-lifecycle test files.
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { applyClawAddPlan } from "./add.js";
+import { buildClawAddPlan } from "./lifecycle.js";
+import { parseClawManifest } from "./schema.js";
+import type { ClawSourceIdentity } from "./types.js";
+
+type TempDirTracker = { make: (prefix: string) => string };
+
+export function clawRemoveFixtures(tempDirs: TempDirTracker) {
+  async function fixture(
+    params: {
+      id?: string;
+      name?: string;
+      withFile?: boolean;
+      withCron?: boolean;
+      withMcp?: boolean;
+    } = {},
+  ) {
+    const root = tempDirs.make("openclaw-claw-remove-");
+    if (params.withFile) {
+      await writeFile(join(root, "SOUL.md"), "managed\n", "utf8");
+    }
+    const parsed = parseClawManifest({
+      schemaVersion: 1,
+      agent: { id: params.id ?? "worker", name: "Worker" },
+      workspace: params.withFile ? { bootstrapFiles: { "SOUL.md": { source: "SOUL.md" } } } : {},
+      mcpServers: params.withMcp
+        ? {
+            docs: {
+              command: "uvx",
+              args: ["docs-mcp"],
+              env: { DOCS_TOKEN: "${DOCS_TOKEN}" },
+            },
+          }
+        : {},
+      cronJobs: params.withCron
+        ? [
+            {
+              id: "daily-report",
+              schedule: { cron: "0 9 * * *", timezone: "UTC" },
+              session: "isolated",
+              message: "Prepare report",
+            },
+          ]
+        : [],
+    });
+    if (!parsed.ok) {
+      throw new Error(JSON.stringify(parsed.diagnostics));
+    }
+    const source: ClawSourceIdentity = {
+      kind: "package",
+      name: params.name ?? "@acme/worker",
+      version: "1.0.0",
+      packageRoot: root,
+      manifestPath: join(root, "openclaw.claw.json"),
+      integrityKind: "artifact",
+      integrity: "sha256:manifest",
+      byteLength: 100,
+    };
+    const plan = await buildClawAddPlan({
+      manifest: parsed.manifest,
+      source,
+      context: { workspace: join(root, `workspace-${params.id ?? "worker"}`) },
+    });
+    return { root, plan, env: { OPENCLAW_STATE_DIR: join(root, "state") } };
+  }
+
+  async function addFixture(
+    params: { withFile?: boolean; withCron?: boolean; withMcp?: boolean } = {},
+  ) {
+    const current = await fixture(params);
+    let config: OpenClawConfig = {};
+    await applyClawAddPlan(current.plan, {
+      consentPlanIntegrity: current.plan.planIntegrity,
+      env: current.env,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+      cronGateway: { add: async () => ({ id: "scheduler-daily" }) },
+      ...(params.withMcp ? { installMcpServers: async () => [] } : {}),
+    });
+    return {
+      ...current,
+      getConfig: () => config,
+      commitConfig: async (transform: (current: OpenClawConfig) => OpenClawConfig) => {
+        config = transform(config);
+      },
+    };
+  }
+
+  return { fixture, addFixture };
+}

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -14,21 +14,18 @@ import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
-import { applyClawAddPlan } from "./add.js";
 import { markClawCronRefRemoved, readClawCronRefs } from "./cron.js";
 import { claimClawAgentConfigRemoval } from "./lifecycle-config-removal.js";
+import { clawRemoveFixtures } from "./lifecycle-remove.test-support.js";
 import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
-import { buildClawAddPlan } from "./lifecycle.js";
 import {
   persistClawInstallRecord,
   persistClawPackageRef,
   readClawPackageRefs,
 } from "./provenance.js";
-import { parseClawManifest } from "./schema.js";
-import type { ClawSourceIdentity } from "./types.js";
 
-afterEach(() => closeOpenClawStateDatabaseForTest());
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawStateDatabaseForTest());
 
 const packageIntegrity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
@@ -92,86 +89,7 @@ function seedAttachedCronJob(
   );
 }
 
-async function fixture(
-  params: {
-    id?: string;
-    name?: string;
-    withFile?: boolean;
-    withCron?: boolean;
-    withMcp?: boolean;
-  } = {},
-) {
-  const root = tempDirs.make("openclaw-claw-remove-");
-  if (params.withFile) {
-    await writeFile(join(root, "SOUL.md"), "managed\n", "utf8");
-  }
-  const parsed = parseClawManifest({
-    schemaVersion: 1,
-    agent: { id: params.id ?? "worker", name: "Worker" },
-    workspace: params.withFile ? { bootstrapFiles: { "SOUL.md": { source: "SOUL.md" } } } : {},
-    mcpServers: params.withMcp
-      ? {
-          docs: {
-            command: "uvx",
-            args: ["docs-mcp"],
-            env: { DOCS_TOKEN: "${DOCS_TOKEN}" },
-          },
-        }
-      : {},
-    cronJobs: params.withCron
-      ? [
-          {
-            id: "daily-report",
-            schedule: { cron: "0 9 * * *", timezone: "UTC" },
-            session: "isolated",
-            message: "Prepare report",
-          },
-        ]
-      : [],
-  });
-  if (!parsed.ok) {
-    throw new Error(JSON.stringify(parsed.diagnostics));
-  }
-  const source: ClawSourceIdentity = {
-    kind: "package",
-    name: params.name ?? "@acme/worker",
-    version: "1.0.0",
-    packageRoot: root,
-    manifestPath: join(root, "openclaw.claw.json"),
-    integrityKind: "artifact",
-    integrity: "sha256:manifest",
-    byteLength: 100,
-  };
-  const plan = await buildClawAddPlan({
-    manifest: parsed.manifest,
-    source,
-    context: { workspace: join(root, `workspace-${params.id ?? "worker"}`) },
-  });
-  return { root, plan, env: { OPENCLAW_STATE_DIR: join(root, "state") } };
-}
-
-async function addFixture(
-  params: { withFile?: boolean; withCron?: boolean; withMcp?: boolean } = {},
-) {
-  const current = await fixture(params);
-  let config: OpenClawConfig = {};
-  await applyClawAddPlan(current.plan, {
-    consentPlanIntegrity: current.plan.planIntegrity,
-    env: current.env,
-    commitConfig: async (transform) => {
-      config = transform(config);
-    },
-    cronGateway: { add: async () => ({ id: "scheduler-daily" }) },
-    ...(params.withMcp ? { installMcpServers: async () => [] } : {}),
-  });
-  return {
-    ...current,
-    getConfig: () => config,
-    commitConfig: async (transform: (current: OpenClawConfig) => OpenClawConfig) => {
-      config = transform(config);
-    },
-  };
-}
+const { fixture, addFixture } = clawRemoveFixtures(tempDirs);
 
 describe("Claw status and remove", () => {
   it("rejects cleanup when an expected-missing agent id was recreated", async () => {

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -675,7 +675,13 @@ export async function applyClawRemovePlan(
   if (!complete) {
     updateClawInstallRecordStatus(agentId, "partial", options);
   }
-  releaseClawRemoveRows(plan.agentId, workspaceFiles, complete, options);
+  releaseClawRemoveRows(
+    plan.agentId,
+    workspaceFiles,
+    complete,
+    options,
+    retainHistoricalAgentState,
+  );
   return {
     schemaVersion: CLAW_REMOVE_RESULT_SCHEMA_VERSION,
     stability: CLAW_OUTPUT_STABILITY,

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -30,6 +30,7 @@ import {
   ClawRemoveError,
   cleanupClawAgentFilesystem,
   deletionEffects,
+  planClawWorkspaceRemoval,
   readAttachedCronJobs,
   releaseClawRemoveRows,
   removeClawWorkspaceFile,
@@ -57,6 +58,7 @@ import {
 } from "./package-remove.js";
 import { updateClawInstallRecordStatus } from "./provenance.js";
 import { CLAW_OUTPUT_STABILITY } from "./types.js";
+import { clawWorkspaceWasAdopted } from "./workspace-origin.js";
 
 export { ClawRemoveError } from "./lifecycle-delete-support.js";
 export { CLAW_REMOVE_PLAN_SCHEMA_VERSION } from "./lifecycle-remove-contract.js";
@@ -183,6 +185,19 @@ export async function buildClawRemovePlan(
       record.install.workspace,
       trackedWorkspacePaths,
     );
+    // An adopted directory predates the Claw. Once every declared file in it is managed it looks
+    // indistinguishable from one this install created, so origin decides retention, not contents.
+    const workspaceWasAdopted = clawWorkspaceWasAdopted(
+      record.install.agentId,
+      record.install.workspace,
+      options,
+    );
+    const workspaceRemoval = planClawWorkspaceRemoval({
+      sharedWith: effects.workspaceSharedWith,
+      adopted: workspaceWasAdopted,
+      modified: workspaceHasModifiedFiles,
+      untracked: workspaceHasUntrackedEntries,
+    });
     const attachedJobs = readAttachedCronJobs(record.install.agentId, options);
     const ownedSchedulerJobIds = new Set(
       record.cronJobs
@@ -236,24 +251,9 @@ export async function buildClawRemovePlan(
       actions.push({
         kind: "workspace",
         id: record.install.agentId,
-        action:
-          effects.workspaceRetained || workspaceHasModifiedFiles || workspaceHasUntrackedEntries
-            ? "retain"
-            : "trash",
         target: effects.workspace,
         blocked: record.agentState === "modified",
-        details: {
-          retained:
-            effects.workspaceRetained || workspaceHasModifiedFiles || workspaceHasUntrackedEntries,
-          sharedWith: effects.workspaceSharedWith,
-        },
-        ...(effects.workspaceRetained
-          ? { reason: "Workspace overlaps another agent." }
-          : workspaceHasModifiedFiles
-            ? { reason: "Workspace contains locally modified Claw-managed files." }
-            : workspaceHasUntrackedEntries
-              ? { reason: "Workspace contains files or directories not managed by this Claw." }
-              : {}),
+        ...workspaceRemoval,
       });
     }
     if (effects.agentDir) {
@@ -464,6 +464,8 @@ export async function applyClawRemovePlan(
   ) {
     throw new ClawRemoveError("remove_changed", "Claw-owned state changed after remove planning.");
   }
+  // Read while the install record still exists; releaseClawRemoveRows drops the origin with it.
+  const workspaceWasAdopted = clawWorkspaceWasAdopted(agentId, record.install.workspace, options);
   const packageDecisions = await planClawPackageRemovals(record.install, record.packages, {
     ...options,
     deps: options.packageDeps,
@@ -669,6 +671,7 @@ export async function applyClawRemovePlan(
         runtime: clawRemoveQuietRuntime,
         trashPath: options.trashPath,
         retainWorkspace:
+          workspaceWasAdopted ||
           workspaceHasRemainingEntries ||
           bootstrap?.action === "retainedModified" ||
           workspaceFiles.some((file) => file.action === "retainedModified"),

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -31,6 +31,7 @@ import {
   cleanupClawAgentFilesystem,
   deletionEffects,
   planClawWorkspaceRemoval,
+  planClawHistoricalAgentState,
   readAttachedCronJobs,
   releaseClawRemoveRows,
   removeClawWorkspaceFile,
@@ -143,6 +144,7 @@ export async function buildClawRemovePlan(
   }
   const actions: ClawRemovePlanAction[] = [];
   if (record) {
+    const retainHistoricalAgentState = record.install.agentOrigin === "adopted";
     const selectedResources = options.referencedCleanup?.selected ?? [];
     const packageCleanup = options.referencedCleanup
       ? {
@@ -256,29 +258,15 @@ export async function buildClawRemovePlan(
         ...workspaceRemoval,
       });
     }
-    if (effects.agentDir) {
-      actions.push({
-        kind: "agentState",
-        id: record.install.agentId,
-        action: "trash",
-        target: effects.agentDir,
-        blocked: record.agentState === "modified",
-      });
-    }
-    actions.push({
-      kind: "sessionIndex",
-      id: record.install.agentId,
-      action: "delete",
-      target: `session store entries for agent:${record.install.agentId}`,
-      blocked: record.agentState === "modified",
-    });
-    actions.push({
-      kind: "sessionTranscripts",
-      id: record.install.agentId,
-      action: "trash",
-      target: effects.sessionsDir,
-      blocked: record.agentState === "modified",
-    });
+    actions.push(
+      ...planClawHistoricalAgentState({
+        agentId: record.install.agentId,
+        agentDir: effects.agentDir,
+        sessionsDir: effects.sessionsDir,
+        retain: retainHistoricalAgentState,
+        modified: record.agentState === "modified",
+      }),
+    );
     for (const job of attachedJobs) {
       actions.push({
         kind: "scheduledJob",
@@ -466,6 +454,7 @@ export async function applyClawRemovePlan(
   }
   // Read while the install record still exists; releaseClawRemoveRows drops the origin with it.
   const workspaceWasAdopted = clawWorkspaceWasAdopted(agentId, record.install.workspace, options);
+  const retainHistoricalAgentState = record.install.agentOrigin === "adopted";
   const packageDecisions = await planClawPackageRemovals(record.install, record.packages, {
     ...options,
     deps: options.packageDeps,
@@ -608,13 +597,16 @@ export async function applyClawRemovePlan(
     configBeforeDelete,
     nextConfig: committedNextConfig,
   } = configRemoval;
-  if (!options.commitConfig || options.purgeSessions) {
+  // Agent adoption owns managed config and resources, never history that predates adoption.
+  if (!retainHistoricalAgentState && (!options.commitConfig || options.purgeSessions)) {
     const purgeSessions =
       options.purgeSessions ??
       (await import("../config/sessions/cleanup-service.js")).purgeAgentSessionStoreEntries;
     await purgeSessions(configBeforeDelete, agentId);
   }
-  closeOpenClawAgentDatabaseByPath(resolveOpenClawAgentSqlitePath({ agentId, env: options.env }));
+  if (!retainHistoricalAgentState) {
+    closeOpenClawAgentDatabaseByPath(resolveOpenClawAgentSqlitePath({ agentId, env: options.env }));
+  }
   const packages = await applyClawPackageRemovals(
     packageDecisions.toSorted(
       (left, right) =>
@@ -675,6 +667,7 @@ export async function applyClawRemovePlan(
           workspaceHasRemainingEntries ||
           bootstrap?.action === "retainedModified" ||
           workspaceFiles.some((file) => file.action === "retainedModified"),
+        retainHistoricalAgentState,
       })),
     );
   }

--- a/src/claws/lifecycle-status.ts
+++ b/src/claws/lifecycle-status.ts
@@ -1,5 +1,4 @@
 import { stableStringify } from "@openclaw/normalization-core";
-import { listAgentEntries } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { normalizeConfiguredMcpServers } from "../config/mcp-config-normalize.js";
 import { listConfiguredMcpServers } from "../config/mcp-config.js";
@@ -10,6 +9,7 @@ import {
   PLUGIN_ARTIFACT_ADAPTER_IDENTITY,
 } from "../plugins/install-artifact-inspection.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import { resolveCanonicalClawAgent } from "./agent-adoption-apply.js";
 import { readClawCronRefs, type PersistedClawCronRef } from "./cron.js";
 import { digestClawAgentConfig } from "./lifecycle-config-removal.js";
 import {
@@ -132,6 +132,7 @@ async function inspectClawPackageCompatibility(params: {
 
 export type ClawStatusRecord = {
   install: PersistedClawInstall;
+  agentOrigin: PersistedClawInstall["agentOrigin"];
   orphaned?: boolean;
   agentState: "present" | "modified" | "missing";
   bootstrapState: ClawBootstrapStatus["state"];
@@ -239,7 +240,7 @@ export async function readClawStatus(
   const records: ClawStatusRecord[] = [];
   const packagePreflight = options.packagePreflight;
   for (const install of installs) {
-    const agent = listAgentEntries(config).find((candidate) => candidate.id === install.agentId);
+    const agent = resolveCanonicalClawAgent(config, install.agentId);
     const packageRefs = allPackageRefs.filter(
       (packageRef) => packageRef.agentId === install.agentId,
     );
@@ -255,6 +256,7 @@ export async function readClawStatus(
         };
     records.push({
       install,
+      agentOrigin: install.agentOrigin,
       ...(installAgentIds.has(install.agentId) ? {} : { orphaned: true }),
       agentState: !agent
         ? "missing"

--- a/src/claws/lifecycle.e2e.test.ts
+++ b/src/claws/lifecycle.e2e.test.ts
@@ -1,6 +1,6 @@
 // E2E coverage for experimental grouped Claw inspection and add planning.
 import { execFile } from "node:child_process";
-import { readFile, realpath, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
@@ -212,6 +212,84 @@ describe("claws lifecycle cli e2e", () => {
     await expect(readFile(join(workspace, "reference", "policy.md"), "utf8")).resolves.toContain(
       "operator settings",
     );
+  });
+
+  it("adopts an existing workspace through preview, apply, and status without rewriting files", async () => {
+    const source = "src/claws/fixtures/workspace-agent.claw.json";
+    const stateDir = tempDirs.make("openclaw-claws-adopt-e2e-");
+    const workspace = join(stateDir, "existing-workspace");
+    await mkdir(join(workspace, "reference"), { recursive: true });
+    const canonicalWorkspace = await realpath(workspace);
+    for (const path of ["SOUL.md", "HEARTBEAT.md", "reference/policy.md"]) {
+      await copyFile(join("src/claws/fixtures/workspace", path), join(workspace, path));
+    }
+    const soulMtimeBefore = (await stat(join(workspace, "SOUL.md"))).mtimeMs;
+
+    const preview = await runOpenClaw(
+      [
+        "claws",
+        "add",
+        source,
+        "--workspace",
+        workspace,
+        "--adopt-existing-workspace",
+        "--dry-run",
+        "--json",
+      ],
+      { stateDir },
+    );
+    const plan = parseJson(preview.stdout) as {
+      planIntegrity: string;
+      actions: Array<{ kind: string; action: string }>;
+    };
+    expect(plan.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "workspace", action: "adopt" }),
+        expect.objectContaining({ kind: "workspaceFile", action: "adopt" }),
+      ]),
+    );
+
+    const added = await runOpenClaw(
+      [
+        "claws",
+        "add",
+        source,
+        "--workspace",
+        workspace,
+        "--adopt-existing-workspace",
+        "--yes",
+        "--plan-integrity",
+        plan.planIntegrity,
+        "--json",
+      ],
+      { stateDir },
+    );
+    expect(parseJson(added.stdout)).toMatchObject({
+      schemaVersion: "openclaw.clawAddResult.v1",
+      status: "complete",
+      workspaceCreated: true,
+      installRecord: { agentId: "workspace-agent", status: "complete" },
+    });
+    expect((await stat(join(workspace, "SOUL.md"))).mtimeMs).toBe(soulMtimeBefore);
+
+    const status = await runOpenClaw(["claws", "status", "workspace-agent", "--json"], {
+      stateDir,
+    });
+    expect(parseJson(status.stdout)).toMatchObject({
+      schemaVersion: "openclaw.clawStatus.v1",
+      summary: { claws: 1, driftedFiles: 0 },
+      records: [
+        {
+          install: { agentId: "workspace-agent", workspace: canonicalWorkspace },
+          agentState: "present",
+          workspaceFiles: [
+            expect.objectContaining({ path: "HEARTBEAT.md", state: "unchanged" }),
+            expect.objectContaining({ path: "SOUL.md", state: "unchanged" }),
+            expect.objectContaining({ path: "reference/policy.md", state: "unchanged" }),
+          ],
+        },
+      ],
+    });
   });
 
   it("reports and removes a Claw-created agent through plan-first lifecycle commands", async () => {

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -1,6 +1,6 @@
 // Builds complete read-only Claw add plans without mutating local state.
 import { createHash } from "node:crypto";
-import { lstat, realpath } from "node:fs/promises";
+import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import { relative, resolve } from "node:path";
 import { stableStringify } from "@openclaw/normalization-core";
@@ -9,10 +9,15 @@ import { assertNoSymlinkParents } from "../infra/fs-safe-advanced.js";
 import { FsSafeError, root as fsSafeRoot, type Root } from "../infra/fs-safe.js";
 import { resolveUserPath } from "../utils.js";
 import { findClawExtensionPackageCollisions, planClawExtensions } from "./application-plan.js";
+import {
+  planWorkspaceAdoption,
+  planWorkspaceAdoptionTargets,
+  workspaceAdoptionCapabilityChange,
+} from "./lifecycle-adopt-plan.js";
+import { planClawAgent } from "./lifecycle-agent-plan.js";
 import { digestClawMcpServer } from "./mcp.js";
 import { clawManifestWorkspaceConflictsWithPath } from "./schema.js";
 import { MAX_MANAGED_FILE_BYTES, MAX_MANAGED_WORKSPACE_BYTES } from "./source-limits.js";
-import { materializeClawToolProfile } from "./tool-profile-consent.js";
 import {
   CLAW_ADD_PLAN_SCHEMA_VERSION,
   CLAW_BOOTSTRAP_FILE_NAMES,
@@ -30,8 +35,6 @@ import {
   type ClawWorkspaceSourceSnapshot,
 } from "./types.js";
 
-const AGENT_ID_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
-
 function capabilityChange(
   change: Omit<ClawAddCapabilityChange, "classification" | "requiresDistinctConsent" | "digest">,
 ): ClawAddCapabilityChange {
@@ -47,6 +50,7 @@ export type ClawAddPlanContext = {
   agentId?: string;
   workspace?: string;
   resumableWorkspace?: string;
+  adoptExistingWorkspace?: boolean;
   existingAgentIds?: Iterable<string>;
   existingWorkspacePaths?: Iterable<string>;
   existingMcpServerNames?: Iterable<string>;
@@ -226,96 +230,42 @@ export async function buildClawAddPlan(params: {
   const capabilityChanges: ClawAddCapabilityChange[] = [];
   const readinessRequirements: ClawLocalPrerequisite[] = [];
 
-  if (!AGENT_ID_PATTERN.test(finalId)) {
-    blockers.push(
-      blocker(
-        "invalid_agent_id",
-        "$.agent.id",
-        `Final agent id ${JSON.stringify(finalId)} is not a valid portable agent id.`,
-      ),
-    );
-  }
-  const existingAgentIds = new Set(context.existingAgentIds ?? []);
-  const agentBlocked = existingAgentIds.has(finalId);
-  const openClawAgentSettings = params.openClawProfile?.agent ?? {};
-  const persistedOpenClawAgentSettings = params.reconstructLegacyDynamicToolProfilePlan
-    ? openClawAgentSettings
-    : materializeClawToolProfile(openClawAgentSettings);
-  const agentConfig: ClawAddPlan["agent"]["config"] = {
-    ...params.manifest.agent,
-    ...persistedOpenClawAgentSettings,
-    id: finalId,
+  const agentPlan = planClawAgent({
+    finalId,
     workspace,
-  };
-  if (agentBlocked) {
-    blockers.push(
-      blocker(
-        "agent_id_collision",
-        "$.agent.id",
-        `Agent id ${JSON.stringify(finalId)} already exists; Claws never merge into existing agents.`,
-      ),
-    );
-  }
-  actions.push({
-    kind: "agent",
-    id: finalId,
-    action: "create",
-    target: `agents.entries[${JSON.stringify(finalId)}]`,
-    details: { ...agentConfig, expectedState: "absent" },
-    blocked: agentBlocked || !AGENT_ID_PATTERN.test(finalId),
+    manifestAgent: params.manifest.agent,
+    openClawProfile: params.openClawProfile,
+    reconstructLegacyDynamicToolProfilePlan: params.reconstructLegacyDynamicToolProfilePlan,
+    existingAgentIds: context.existingAgentIds,
   });
-  const agentCapabilityEffect = {
-    ...(openClawAgentSettings.sandbox ? { sandbox: openClawAgentSettings.sandbox } : {}),
-    ...(openClawAgentSettings.tools ? { tools: openClawAgentSettings.tools } : {}),
-    ...(openClawAgentSettings.memory ? { memory: openClawAgentSettings.memory } : {}),
-    ...(openClawAgentSettings.heartbeat ? { heartbeat: openClawAgentSettings.heartbeat } : {}),
-  };
-  if (Object.keys(agentCapabilityEffect).length > 0) {
-    capabilityChanges.push(
-      capabilityChange({
-        kind: "agent",
-        id: finalId,
-        path: "agent",
-        action: "create",
-        reason:
-          "The new agent declares sandbox, tool, memory-search, or recurring heartbeat capabilities.",
-        effect: agentCapabilityEffect,
-      }),
-    );
+  const agentConfig = agentPlan.config;
+  blockers.push(...agentPlan.blockers);
+  actions.push(agentPlan.action);
+  if (agentPlan.capabilityChange) {
+    capabilityChanges.push(capabilityChange(agentPlan.capabilityChange));
   }
 
   const configuredWorkspacePaths = new Set(
     [...(context.existingWorkspacePaths ?? [])].map((path) => canonicalWorkspacePath(path)),
   );
   const configuredWorkspaceConflict = configuredWorkspacePaths.has(workspace);
-  const workspaceExistsOnDisk = await lstat(workspace)
-    .then(() => true)
-    .catch(() => false);
   const resumableWorkspace = context.resumableWorkspace
     ? canonicalWorkspacePath(context.resumableWorkspace)
     : undefined;
-  const workspaceBlocked =
-    configuredWorkspaceConflict || (workspaceExistsOnDisk && resumableWorkspace !== workspace);
-  if (workspaceBlocked) {
-    blockers.push(
-      blocker(
-        "workspace_collision",
-        "$.workspace",
-        `Workspace ${JSON.stringify(workspace)} already exists; a Claw requires a new workspace.`,
-      ),
-    );
-  }
-  actions.push({
-    kind: "workspace",
-    id: finalId,
-    action: "create",
-    target: workspace,
-    details: { expectedState: "absent" },
-    blocked: workspaceBlocked,
-    ...(workspaceBlocked
-      ? { reason: `Workspace ${JSON.stringify(workspace)} already exists.` }
-      : {}),
+  const workspacePlan = await planWorkspaceAdoption({
+    agentId: finalId,
+    workspace,
+    requested: context.adoptExistingWorkspace === true,
+    configuredWorkspaceConflict,
+    resumableWorkspace,
   });
+  const workspaceAdoption = workspacePlan.adopted;
+  const workspaceBlocked = workspacePlan.action.blocked;
+  blockers.push(...workspacePlan.blockers);
+  actions.push(workspacePlan.action);
+  if (workspaceAdoption) {
+    capabilityChanges.push(capabilityChange(workspaceAdoptionCapabilityChange(finalId, workspace)));
+  }
 
   if (params.packageBootstrap && params.includePackageBootstrap !== false) {
     actions.push({
@@ -479,6 +429,16 @@ export async function buildClawAddPlan(params: {
         blockers.push(diagnostic);
       }
     }
+  }
+
+  if (workspaceAdoption) {
+    blockers.push(
+      ...(await planWorkspaceAdoptionTargets({
+        workspace,
+        pendingFiles: pendingWorkspaceFiles,
+        packageBootstrap: actions.find((action) => action.kind === "bootstrap"),
+      })),
+    );
   }
 
   for (const [index, pkg] of params.manifest.packages.entries()) {

--- a/src/claws/lifecycle.ts
+++ b/src/claws/lifecycle.ts
@@ -8,13 +8,15 @@ import { resolvePathViaExistingAncestorSync } from "../infra/boundary-path.js";
 import { assertNoSymlinkParents } from "../infra/fs-safe-advanced.js";
 import { FsSafeError, root as fsSafeRoot, type Root } from "../infra/fs-safe.js";
 import { resolveUserPath } from "../utils.js";
+import { digestClawAddPlanIntegrity } from "./add-plan-integrity.js";
 import { findClawExtensionPackageCollisions, planClawExtensions } from "./application-plan.js";
 import {
   planWorkspaceAdoption,
   planWorkspaceAdoptionTargets,
   workspaceAdoptionCapabilityChange,
 } from "./lifecycle-adopt-plan.js";
-import { planClawAgent } from "./lifecycle-agent-plan.js";
+import { planClawAgent, type ExistingClawAgent } from "./lifecycle-agent-plan.js";
+import { inspectAgentWorkspaceOwnership } from "./lifecycle-agent-workspace.js";
 import { digestClawMcpServer } from "./mcp.js";
 import { clawManifestWorkspaceConflictsWithPath } from "./schema.js";
 import { MAX_MANAGED_FILE_BYTES, MAX_MANAGED_WORKSPACE_BYTES } from "./source-limits.js";
@@ -51,7 +53,10 @@ export type ClawAddPlanContext = {
   workspace?: string;
   resumableWorkspace?: string;
   adoptExistingWorkspace?: boolean;
+  adoptExistingAgent?: boolean;
+  existingAgents?: Iterable<ExistingClawAgent>;
   existingAgentIds?: Iterable<string>;
+  managedAgentIds?: Iterable<string>;
   existingWorkspacePaths?: Iterable<string>;
   existingMcpServerNames?: Iterable<string>;
   existingMcpServers?: Record<string, Record<string, unknown>>;
@@ -236,7 +241,10 @@ export async function buildClawAddPlan(params: {
     manifestAgent: params.manifest.agent,
     openClawProfile: params.openClawProfile,
     reconstructLegacyDynamicToolProfilePlan: params.reconstructLegacyDynamicToolProfilePlan,
+    existingAgents: context.existingAgents,
     existingAgentIds: context.existingAgentIds,
+    managedAgentIds: context.managedAgentIds,
+    adoptExistingAgent: context.adoptExistingAgent,
   });
   const agentConfig = agentPlan.config;
   blockers.push(...agentPlan.blockers);
@@ -245,18 +253,24 @@ export async function buildClawAddPlan(params: {
     capabilityChanges.push(capabilityChange(agentPlan.capabilityChange));
   }
 
-  const configuredWorkspacePaths = new Set(
-    [...(context.existingWorkspacePaths ?? [])].map((path) => canonicalWorkspacePath(path)),
-  );
-  const configuredWorkspaceConflict = configuredWorkspacePaths.has(workspace);
+  const { configuredWorkspaceConflict } = inspectAgentWorkspaceOwnership({
+    existingAgents: context.existingAgents,
+    existingWorkspacePaths: context.existingWorkspacePaths,
+    finalId,
+    workspace,
+    adopting: context.adoptExistingAgent === true,
+    canonicalize: canonicalWorkspacePath,
+  });
   const resumableWorkspace = context.resumableWorkspace
     ? canonicalWorkspacePath(context.resumableWorkspace)
     : undefined;
   const workspacePlan = await planWorkspaceAdoption({
     agentId: finalId,
     workspace,
-    requested: context.adoptExistingWorkspace === true,
+    requested: context.adoptExistingWorkspace === true || context.adoptExistingAgent === true,
     configuredWorkspaceConflict,
+    configuredWorkspaceConflictCode:
+      context.adoptExistingAgent === true ? "agent_workspace_conflict" : undefined,
     resumableWorkspace,
   });
   const workspaceAdoption = workspacePlan.adopted;
@@ -627,20 +641,20 @@ export async function buildClawAddPlan(params: {
     `${left.kind}:${left.id}:${left.path}`.localeCompare(`${right.kind}:${right.id}:${right.path}`),
   );
 
-  const planIntegrity = `sha256:${createHash("sha256")
-    .update(
-      stableStringify({
-        manifestSchemaVersion: params.manifest.schemaVersion,
-        clawIntegrity: source.integrity,
-        finalId,
-        workspace,
-        actions,
-        capabilityChanges,
-        blockers,
-        extensions,
-      }),
-    )
-    .digest("hex")}`;
+  const planIntegrity = digestClawAddPlanIntegrity({
+    manifestSchemaVersion: params.manifest.schemaVersion,
+    claw: planSource,
+    agent: {
+      requestedId: params.manifest.agent.id,
+      finalId,
+      workspace,
+      config: agentConfig,
+    },
+    actions,
+    capabilityChanges,
+    blockers,
+    extensions,
+  });
 
   return {
     schemaVersion: CLAW_ADD_PLAN_SCHEMA_VERSION,

--- a/src/claws/project.test.ts
+++ b/src/claws/project.test.ts
@@ -1,5 +1,7 @@
 import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { lstat, mkdir, readFile, rename, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import * as tar from "tar";
 import { afterEach, describe, expect, it } from "vitest";
@@ -10,6 +12,19 @@ import { ClawProjectError, createClawProject, validateClawProject } from "./proj
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const GOLDEN_ARTIFACT_INTEGRITY =
   "sha256:10b8890c5e5b062c94ff79b1d424859c6a5572548535eec6e31ee0c6d7c08a3b";
+
+// `CLAW.md` and `claw.md` only coexist on a case-sensitive filesystem. On a case-insensitive
+// volume the second write replaces the manifest instead of adding a colliding source, so the
+// collision under test cannot be constructed and the case must be skipped, not asserted.
+const caseSensitiveFilesystem = (() => {
+  const probe = mkdtempSync(join(tmpdir(), "openclaw-claw-case-probe-"));
+  try {
+    writeFileSync(join(probe, "case-probe"), "");
+    return !existsSync(join(probe, "CASE-PROBE"));
+  } finally {
+    rmSync(probe, { recursive: true, force: true });
+  }
+})();
 
 async function writeRichProject(root: string): Promise<void> {
   await mkdir(join(root, "workspace"), { recursive: true });
@@ -426,7 +441,7 @@ describe("Claw projects", () => {
     });
   });
 
-  it.runIf(process.platform !== "win32")(
+  it.runIf(process.platform !== "win32" && caseSensitiveFilesystem)(
     "rejects a workspace source that portably collides with CLAW.md",
     async () => {
       const project = tempDirs.make("openclaw-claw-manifest-case-collision-");

--- a/src/claws/provenance-agent-origin.test.ts
+++ b/src/claws/provenance-agent-origin.test.ts
@@ -1,0 +1,168 @@
+// Provenance compatibility coverage for created and adopted agent ownership.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import {
+  clawInstallRecordMatchesPlan,
+  persistClawInstallRecord,
+  readClawInstallRecord,
+  updateClawInstallRecord,
+} from "./provenance.js";
+import { makeProvenancePlan, stateEnv } from "./provenance.test-helpers.js";
+import type { ClawAddPlan } from "./types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawStateDatabaseForTest());
+
+function adoptedPlan(plan: ClawAddPlan): ClawAddPlan {
+  return {
+    ...plan,
+    actions: plan.actions.map((action) =>
+      action.kind === "agent" ? { ...action, action: "adopt" as const } : action,
+    ),
+  };
+}
+
+function rawOriginPayload(root: string): {
+  schema_version: string;
+  agent_owned_paths_json: string;
+} {
+  return openOpenClawStateDatabase({ env: stateEnv(root) })
+    .db.prepare(
+      "SELECT schema_version, agent_owned_paths_json FROM claw_installs WHERE agent_id = ?",
+    )
+    .get("worker") as { schema_version: string; agent_owned_paths_json: string };
+}
+
+describe("Claw agent-origin provenance", () => {
+  it("keeps newly created agents on v2 array records", async () => {
+    const root = tempDirs.make("openclaw-claw-origin-created-");
+    const { plan } = await makeProvenancePlan(root, {
+      schemaVersion: 1,
+      agent: { id: "worker" },
+    });
+
+    const record = persistClawInstallRecord(plan, { env: stateEnv(root), nowMs: 1 });
+
+    expect(record).toMatchObject({
+      schemaVersion: "openclaw.clawInstallRecord.v2",
+      agentOrigin: "created",
+    });
+    expect(JSON.parse(rawOriginPayload(root).agent_owned_paths_json)).toEqual(
+      record.agentOwnedPaths,
+    );
+  });
+
+  it("round-trips adopted agents through the v3 origin envelope", async () => {
+    const root = tempDirs.make("openclaw-claw-origin-adopted-");
+    const { plan } = await makeProvenancePlan(root, {
+      schemaVersion: 1,
+      agent: { id: "worker" },
+    });
+
+    persistClawInstallRecord(adoptedPlan(plan), { env: stateEnv(root), nowMs: 1 });
+    const row = rawOriginPayload(root);
+
+    expect(row.schema_version).toBe("openclaw.clawInstallRecord.v3");
+    expect(JSON.parse(row.agent_owned_paths_json)).toEqual({
+      origin: "adopted",
+      paths: ['agents.entries["worker"]'],
+    });
+    expect(readClawInstallRecord("worker", { env: stateEnv(root) })).toMatchObject({
+      schemaVersion: "openclaw.clawInstallRecord.v3",
+      agentOrigin: "adopted",
+      agentOwnedPaths: ['agents.entries["worker"]'],
+    });
+  });
+
+  it("preserves adopted v3 origin through update", async () => {
+    const root = tempDirs.make("openclaw-claw-origin-update-");
+    const { plan } = await makeProvenancePlan(root, {
+      schemaVersion: 1,
+      agent: { id: "worker" },
+    });
+    const adopted = adoptedPlan(plan);
+    persistClawInstallRecord(adopted, { env: stateEnv(root), nowMs: 1 });
+
+    const record = updateClawInstallRecord(adopted, { env: stateEnv(root), nowMs: 2 });
+
+    expect(record).toMatchObject({
+      schemaVersion: "openclaw.clawInstallRecord.v3",
+      agentOrigin: "adopted",
+    });
+    expect(JSON.parse(rawOriginPayload(root).agent_owned_paths_json)).toEqual({
+      origin: "adopted",
+      paths: record.agentOwnedPaths,
+    });
+  });
+
+  it("binds adopted resume to origin, agent digest, workspace, package identity, and plan", async () => {
+    const root = tempDirs.make("openclaw-claw-origin-resume-");
+    const { plan } = await makeProvenancePlan(root, {
+      schemaVersion: 1,
+      agent: { id: "worker" },
+    });
+    const adopted = adoptedPlan(plan);
+    const record = persistClawInstallRecord(adopted, {
+      env: stateEnv(root),
+      status: "partial",
+      nowMs: 1,
+    });
+
+    expect(clawInstallRecordMatchesPlan(record, adopted)).toBe(true);
+    const mismatches: ClawAddPlan[] = [
+      plan,
+      { ...adopted, planIntegrity: "sha256:different" },
+      { ...adopted, claw: { ...adopted.claw, version: "9.9.9" } },
+      {
+        ...adopted,
+        agent: { ...adopted.agent, workspace: `${adopted.agent.workspace}-other` },
+      },
+      {
+        ...adopted,
+        agent: {
+          ...adopted.agent,
+          config: { ...adopted.agent.config, default: true },
+        },
+      },
+    ];
+    for (const mismatch of mismatches) {
+      expect(clawInstallRecordMatchesPlan(record, mismatch)).toBe(false);
+    }
+  });
+
+  it("makes a pre-v3 reader reject adopted provenance before lifecycle mutation", async () => {
+    const root = tempDirs.make("openclaw-claw-origin-downgrade-");
+    const { plan } = await makeProvenancePlan(root, {
+      schemaVersion: 1,
+      agent: { id: "worker" },
+    });
+    persistClawInstallRecord(adoptedPlan(plan), { env: stateEnv(root), nowMs: 1 });
+    const row = rawOriginPayload(root);
+    const mutateStatusUpdateOrRemove = vi.fn();
+
+    const readWithPreV3Contract = () => {
+      if (
+        row.schema_version !== "openclaw.clawInstallRecord.v1" &&
+        row.schema_version !== "openclaw.clawInstallRecord.v2"
+      ) {
+        throw new Error(
+          `Unsupported Claw install record schema ${JSON.stringify(row.schema_version)}.`,
+        );
+      }
+      const paths = JSON.parse(row.agent_owned_paths_json);
+      if (!Array.isArray(paths)) {
+        throw new Error("Unsupported Claw agent-owned paths payload.");
+      }
+      mutateStatusUpdateOrRemove();
+    };
+
+    expect(readWithPreV3Contract).toThrow(
+      'Unsupported Claw install record schema "openclaw.clawInstallRecord.v3".',
+    );
+    expect(mutateStatusUpdateOrRemove).not.toHaveBeenCalled();
+  });
+});

--- a/src/claws/provenance-agent-origin.ts
+++ b/src/claws/provenance-agent-origin.ts
@@ -1,0 +1,47 @@
+import * as installRecordSchema from "./provenance-schema-version.js";
+import type { PersistedClawInstall } from "./provenance.js";
+import type { ClawAddPlan } from "./types.js";
+
+export function decodeClawAgentOwnership(schemaValue: string, payloadJson: string) {
+  const schemaVersion = installRecordSchema.parseClawInstallRecordSchemaVersion(schemaValue);
+  const payload = JSON.parse(payloadJson) as unknown;
+  const adopted = schemaVersion === installRecordSchema.CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION;
+  const valid = adopted
+    ? typeof payload === "object" &&
+      payload !== null &&
+      !Array.isArray(payload) &&
+      "origin" in payload &&
+      payload.origin === "adopted" &&
+      "paths" in payload &&
+      Array.isArray(payload.paths) &&
+      payload.paths.every((path) => typeof path === "string")
+    : Array.isArray(payload) && payload.every((path) => typeof path === "string");
+  if (!valid) {
+    throw new Error(
+      `Invalid Claw agent ownership payload for schema ${JSON.stringify(schemaVersion)}.`,
+    );
+  }
+  return {
+    schemaVersion,
+    origin: adopted ? ("adopted" as const) : ("created" as const),
+    paths: adopted ? (payload as { paths: string[] }).paths : (payload as string[]),
+  };
+}
+
+export function clawAgentOrigin(plan: ClawAddPlan): PersistedClawInstall["agentOrigin"] {
+  return plan.actions.some((action) => action.kind === "agent" && action.action === "adopt")
+    ? "adopted"
+    : "created";
+}
+
+export function encodeClawAgentOwnership(
+  origin: PersistedClawInstall["agentOrigin"],
+  paths: string[],
+) {
+  return origin === "adopted"
+    ? {
+        schemaVersion: installRecordSchema.CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION,
+        payload: { origin, paths },
+      }
+    : { schemaVersion: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION, payload: paths };
+}

--- a/src/claws/provenance-agent-origin.ts
+++ b/src/claws/provenance-agent-origin.ts
@@ -1,43 +1,41 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import * as installRecordSchema from "./provenance-schema-version.js";
-import type { PersistedClawInstall } from "./provenance.js";
+import type { ClawAgentOrigin } from "./provenance-schema-version.js";
 import type { ClawAddPlan } from "./types.js";
+
+function ownedPathList(payload: unknown): string[] | undefined {
+  return Array.isArray(payload) && payload.every((path) => typeof path === "string")
+    ? payload
+    : undefined;
+}
+
+function adoptedOwnedPathList(payload: unknown): string[] | undefined {
+  if (!isRecord(payload) || Array.isArray(payload)) {
+    return undefined;
+  }
+  return payload.origin === "adopted" ? ownedPathList(payload.paths) : undefined;
+}
 
 export function decodeClawAgentOwnership(schemaValue: string, payloadJson: string) {
   const schemaVersion = installRecordSchema.parseClawInstallRecordSchemaVersion(schemaValue);
   const payload = JSON.parse(payloadJson) as unknown;
   const adopted = schemaVersion === installRecordSchema.CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION;
-  const valid = adopted
-    ? typeof payload === "object" &&
-      payload !== null &&
-      !Array.isArray(payload) &&
-      "origin" in payload &&
-      payload.origin === "adopted" &&
-      "paths" in payload &&
-      Array.isArray(payload.paths) &&
-      payload.paths.every((path) => typeof path === "string")
-    : Array.isArray(payload) && payload.every((path) => typeof path === "string");
-  if (!valid) {
+  const paths = adopted ? adoptedOwnedPathList(payload) : ownedPathList(payload);
+  if (!paths) {
     throw new Error(
       `Invalid Claw agent ownership payload for schema ${JSON.stringify(schemaVersion)}.`,
     );
   }
-  return {
-    schemaVersion,
-    origin: adopted ? ("adopted" as const) : ("created" as const),
-    paths: adopted ? (payload as { paths: string[] }).paths : (payload as string[]),
-  };
+  return { schemaVersion, origin: adopted ? ("adopted" as const) : ("created" as const), paths };
 }
 
-export function clawAgentOrigin(plan: ClawAddPlan): PersistedClawInstall["agentOrigin"] {
+export function clawAgentOrigin(plan: ClawAddPlan): ClawAgentOrigin {
   return plan.actions.some((action) => action.kind === "agent" && action.action === "adopt")
     ? "adopted"
     : "created";
 }
 
-export function encodeClawAgentOwnership(
-  origin: PersistedClawInstall["agentOrigin"],
-  paths: string[],
-) {
+export function encodeClawAgentOwnership(origin: ClawAgentOrigin, paths: string[]) {
   return origin === "adopted"
     ? {
         schemaVersion: installRecordSchema.CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION,

--- a/src/claws/provenance-schema-version.ts
+++ b/src/claws/provenance-schema-version.ts
@@ -4,6 +4,9 @@ import { stableStringify } from "@openclaw/normalization-core";
 const LEGACY_CLAW_INSTALL_RECORD_SCHEMA_VERSION = "openclaw.clawInstallRecord.v1" as const;
 export const CLAW_INSTALL_RECORD_SCHEMA_VERSION = "openclaw.clawInstallRecord.v2" as const;
 export const CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION = "openclaw.clawInstallRecord.v3" as const;
+
+/** Whether Claw created the agent it owns or adopted one the operator already configured. */
+export type ClawAgentOrigin = "created" | "adopted";
 type ClawInstallRecordSchemaVersion =
   | typeof LEGACY_CLAW_INSTALL_RECORD_SCHEMA_VERSION
   | typeof CLAW_INSTALL_RECORD_SCHEMA_VERSION

--- a/src/claws/provenance-schema-version.ts
+++ b/src/claws/provenance-schema-version.ts
@@ -3,18 +3,27 @@ import { stableStringify } from "@openclaw/normalization-core";
 
 const LEGACY_CLAW_INSTALL_RECORD_SCHEMA_VERSION = "openclaw.clawInstallRecord.v1" as const;
 export const CLAW_INSTALL_RECORD_SCHEMA_VERSION = "openclaw.clawInstallRecord.v2" as const;
+export const CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION = "openclaw.clawInstallRecord.v3" as const;
 type ClawInstallRecordSchemaVersion =
   | typeof LEGACY_CLAW_INSTALL_RECORD_SCHEMA_VERSION
-  | typeof CLAW_INSTALL_RECORD_SCHEMA_VERSION;
+  | typeof CLAW_INSTALL_RECORD_SCHEMA_VERSION
+  | typeof CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION;
 
 export function parseClawInstallRecordSchemaVersion(value: string): ClawInstallRecordSchemaVersion {
   if (
     value === LEGACY_CLAW_INSTALL_RECORD_SCHEMA_VERSION ||
-    value === CLAW_INSTALL_RECORD_SCHEMA_VERSION
+    value === CLAW_INSTALL_RECORD_SCHEMA_VERSION ||
+    value === CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION
   ) {
     return value;
   }
   throw new Error(`Unsupported Claw install record schema ${JSON.stringify(value)}.`);
+}
+
+export function isLegacyClawInstallRecordSchemaVersion(
+  value: ClawInstallRecordSchemaVersion,
+): value is typeof LEGACY_CLAW_INSTALL_RECORD_SCHEMA_VERSION {
+  return value === LEGACY_CLAW_INSTALL_RECORD_SCHEMA_VERSION;
 }
 
 export function upgradeClawInstallSchema<
@@ -30,6 +39,11 @@ export function upgradeClawInstallSchema<
   expectedRecord: TRecord | undefined,
   replacement?: Pick<TRecord, "planIntegrity" | "agentConfigDigest">,
 ): Omit<TRecord, "schemaVersion"> & { schemaVersion: typeof CLAW_INSTALL_RECORD_SCHEMA_VERSION } {
+  if (record.schemaVersion !== LEGACY_CLAW_INSTALL_RECORD_SCHEMA_VERSION) {
+    throw new Error(
+      `Claw install record for agent ${JSON.stringify(agentId)} is not a legacy v1 record.`,
+    );
+  }
   if (!expectedRecord || stableStringify(record) !== stableStringify(expectedRecord)) {
     throw new Error(
       `Legacy Claw install record for agent ${JSON.stringify(agentId)} is not an exact resumable attempt.`,

--- a/src/claws/provenance.test-helpers.ts
+++ b/src/claws/provenance.test-helpers.ts
@@ -10,6 +10,10 @@ export async function makeProvenancePlan(
   options: {
     workspace?: string;
     adoptExistingWorkspace?: boolean;
+    adoptExistingAgent?: boolean;
+    existingAgents?: NonNullable<
+      Parameters<typeof buildClawAddPlan>[0]["context"]
+    >["existingAgents"];
     openClawProfile?: ClawOpenClawProfile;
     packagePreflight?: NonNullable<
       Parameters<typeof buildClawAddPlan>[0]["context"]
@@ -37,6 +41,8 @@ export async function makeProvenancePlan(
     context: {
       workspace: options.workspace ?? join(root, "workspace-worker"),
       ...(options.adoptExistingWorkspace ? { adoptExistingWorkspace: true } : {}),
+      ...(options.adoptExistingAgent ? { adoptExistingAgent: true } : {}),
+      ...(options.existingAgents ? { existingAgents: options.existingAgents } : {}),
       ...(options.packagePreflight ? { packagePreflight: options.packagePreflight } : {}),
     },
   });

--- a/src/claws/provenance.test-helpers.ts
+++ b/src/claws/provenance.test-helpers.ts
@@ -9,6 +9,7 @@ export async function makeProvenancePlan(
   manifestValue: unknown,
   options: {
     workspace?: string;
+    adoptExistingWorkspace?: boolean;
     openClawProfile?: ClawOpenClawProfile;
     packagePreflight?: NonNullable<
       Parameters<typeof buildClawAddPlan>[0]["context"]
@@ -35,6 +36,7 @@ export async function makeProvenancePlan(
     source,
     context: {
       workspace: options.workspace ?? join(root, "workspace-worker"),
+      ...(options.adoptExistingWorkspace ? { adoptExistingWorkspace: true } : {}),
       ...(options.packagePreflight ? { packagePreflight: options.packagePreflight } : {}),
     },
   });

--- a/src/claws/provenance.test.ts
+++ b/src/claws/provenance.test.ts
@@ -841,7 +841,7 @@ describe("applyClawAddPlan", () => {
     expect(installPackages).not.toHaveBeenCalled();
   });
 
-  it("records parent-directory creation failures before workspace mutation", async () => {
+  it("blocks an uninspectable workspace parent at plan time, before workspace mutation", async () => {
     const root = tempDirs.make("openclaw-claw-add-");
     const blockedParent = join(root, "blocked-parent");
     await writeFile(blockedParent, "not a directory", "utf8");
@@ -849,12 +849,17 @@ describe("applyClawAddPlan", () => {
       workspace: join(blockedParent, "workspace-worker"),
     });
 
+    // Resolving the workspace under a regular file fails ENOTDIR, not ENOENT. Planning fails
+    // closed on it, so consent is never offered for a path apply would refuse mid-mutation.
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "workspace_parent_failed", path: "$.workspace" }),
+    );
     await expect(
       applyClawAddPlan(plan, {
         consentPlanIntegrity: plan.planIntegrity,
         env: stateEnv(root),
       }),
-    ).rejects.toMatchObject({ code: "workspace_parent_failed" });
+    ).rejects.toMatchObject({ code: "plan_blocked" });
     expect(readInstallRow("worker", root)).toBeUndefined();
   });
 

--- a/src/claws/provenance.ts
+++ b/src/claws/provenance.ts
@@ -54,7 +54,7 @@ export type PersistedClawInstall = {
   agentId: string;
   workspace: string;
   agentConfigDigest: string;
-  agentOrigin: "created" | "adopted";
+  agentOrigin: installRecordSchema.ClawAgentOrigin;
   agentOwnedPaths: string[];
   bootstrap?: { sourcePath: string; contentDigest: string };
   status: ClawInstallStatus;

--- a/src/claws/provenance.ts
+++ b/src/claws/provenance.ts
@@ -18,6 +18,11 @@ import {
   type PersistedClawPackageRef,
 } from "./package-extension-provenance.js";
 import {
+  clawAgentOrigin,
+  decodeClawAgentOwnership,
+  encodeClawAgentOwnership,
+} from "./provenance-agent-origin.js";
+import {
   clawBootstrapProvenanceFromRow,
   selectClawBootstrapProvenanceColumns,
 } from "./provenance-bootstrap.js";
@@ -49,6 +54,7 @@ export type PersistedClawInstall = {
   agentId: string;
   workspace: string;
   agentConfigDigest: string;
+  agentOrigin: "created" | "adopted";
   agentOwnedPaths: string[];
   bootstrap?: { sourcePath: string; contentDigest: string };
   status: ClawInstallStatus;
@@ -80,8 +86,9 @@ type ClawInstallRow = {
 };
 
 function rowToRecord(row: ClawInstallRow): PersistedClawInstall {
+  const ownership = decodeClawAgentOwnership(row.schema_version, row.agent_owned_paths_json);
   return {
-    schemaVersion: installRecordSchema.parseClawInstallRecordSchemaVersion(row.schema_version),
+    schemaVersion: ownership.schemaVersion,
     claw: {
       kind: row.source_kind,
       name: row.claw_name,
@@ -99,7 +106,8 @@ function rowToRecord(row: ClawInstallRow): PersistedClawInstall {
     agentId: row.agent_id,
     workspace: row.workspace,
     agentConfigDigest: row.agent_config_digest,
-    agentOwnedPaths: JSON.parse(row.agent_owned_paths_json) as string[],
+    agentOrigin: ownership.origin,
+    agentOwnedPaths: ownership.paths,
     ...clawBootstrapProvenanceFromRow(row),
     status: row.status,
     addedAtMs: Number(row.added_at_ms),
@@ -137,6 +145,7 @@ export function clawInstallRecordMatchesPlan(
     record.planIntegrity === plan.planIntegrity &&
     record.workspace === plan.agent.workspace &&
     record.agentConfigDigest === digestClawAgentConfig(plan.agent.config) &&
+    record.agentOrigin === clawAgentOrigin(plan) &&
     stableStringify(record.agentOwnedPaths) === stableStringify(agentOwnedPaths(plan)) &&
     record.bootstrap?.sourcePath === bootstrap?.sourcePath &&
     record.bootstrap?.contentDigest === bootstrap?.contentDigest
@@ -188,6 +197,7 @@ export function persistClawInstallRecord(
   const status = options.status ?? "complete";
   const agentConfigDigest = digestClawAgentConfig(plan.agent.config);
   const ownedPaths = agentOwnedPaths(plan);
+  const encoding = encodeClawAgentOwnership(clawAgentOrigin(plan), ownedPaths);
   const bootstrap = bootstrapProvenance(plan);
   const persistedRecord = runOpenClawStateWriteTransaction(({ db }) => {
     const existing = selectClawInstallRow(db, plan.agent.finalId);
@@ -195,7 +205,7 @@ export function persistClawInstallRecord(
       const record = rowToRecord(existing);
       const expectedPlan = options.expectedExistingPlan ?? plan;
       if (existing.status !== "complete" && clawInstallRecordMatchesPlan(record, expectedPlan)) {
-        if (record.schemaVersion !== installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION) {
+        if (installRecordSchema.isLegacyClawInstallRecordSchemaVersion(record.schemaVersion)) {
           if (options.deferLegacyPlanUpgrade) {
             return record;
           }
@@ -235,7 +245,7 @@ export function persistClawInstallRecord(
        )`,
     ).run({
       agent_id: plan.agent.finalId,
-      schema_version: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION,
+      schema_version: encoding.schemaVersion,
       source_kind: plan.claw.kind,
       claw_name: plan.claw.name,
       claw_version: plan.claw.version,
@@ -248,7 +258,7 @@ export function persistClawInstallRecord(
       plan_integrity: plan.planIntegrity,
       workspace: plan.agent.workspace,
       agent_config_digest: agentConfigDigest,
-      agent_owned_paths_json: JSON.stringify(ownedPaths),
+      agent_owned_paths_json: JSON.stringify(encoding.payload),
       bootstrap_source_path: bootstrap?.sourcePath ?? null,
       bootstrap_content_digest: bootstrap?.contentDigest ?? null,
       status,
@@ -257,13 +267,14 @@ export function persistClawInstallRecord(
     });
     persistClawWorkspaceOrigin({ db, plan, nowMs });
     return {
-      schemaVersion: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION,
+      schemaVersion: encoding.schemaVersion,
       claw: plan.claw,
       manifestSchemaVersion: plan.manifestSchemaVersion,
       planIntegrity: plan.planIntegrity,
       agentId: plan.agent.finalId,
       workspace: plan.agent.workspace,
       agentConfigDigest,
+      agentOrigin: clawAgentOrigin(plan),
       agentOwnedPaths: ownedPaths,
       ...(bootstrap ? { bootstrap } : {}),
       status,
@@ -376,6 +387,7 @@ export function updateClawInstallRecord(
     .filter((action) => action.kind === "agent")
     .map((action) => action.target);
   const bootstrap = bootstrapProvenance(plan) ?? current.bootstrap;
+  const encoding = encodeClawAgentOwnership(current.agentOrigin, ownedAgentPaths);
   runOpenClawStateWriteTransaction(({ db }) => {
     const result = db /* sqlite-allow-raw: Claw install provenance compare-and-swap write. */
       .prepare(
@@ -400,11 +412,13 @@ export function updateClawInstallRecord(
                 updated_at_ms = @updated_at_ms
           WHERE agent_id = @agent_id
             AND claw_version = @expected_claw_version
-            AND integrity = @expected_integrity`,
+            AND integrity = @expected_integrity
+            AND schema_version = @expected_schema_version
+            AND agent_owned_paths_json = @expected_agent_owned_paths_json`,
       )
       .run({
         agent_id: plan.agent.finalId,
-        schema_version: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION,
+        schema_version: encoding.schemaVersion,
         source_kind: plan.claw.kind,
         claw_name: plan.claw.name,
         claw_version: plan.claw.version,
@@ -417,13 +431,17 @@ export function updateClawInstallRecord(
         plan_integrity: plan.planIntegrity,
         workspace: plan.agent.workspace,
         agent_config_digest: agentConfigDigest,
-        agent_owned_paths_json: JSON.stringify(ownedAgentPaths),
+        agent_owned_paths_json: JSON.stringify(encoding.payload),
         bootstrap_source_path: bootstrap?.sourcePath ?? null,
         bootstrap_content_digest: bootstrap?.contentDigest ?? null,
         status,
         updated_at_ms: updatedAtMs,
         expected_claw_version: options.expectedClaw?.version ?? current.claw.version,
         expected_integrity: options.expectedClaw?.integrity ?? current.claw.integrity,
+        expected_schema_version: current.schemaVersion,
+        expected_agent_owned_paths_json: JSON.stringify(
+          encodeClawAgentOwnership(current.agentOrigin, current.agentOwnedPaths).payload,
+        ),
       });
     if (Number(result.changes) !== 1) {
       throw new Error(
@@ -432,13 +450,14 @@ export function updateClawInstallRecord(
     }
   }, options);
   const record = {
-    schemaVersion: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION,
+    schemaVersion: encoding.schemaVersion,
     claw: plan.claw,
     manifestSchemaVersion: plan.manifestSchemaVersion,
     planIntegrity: plan.planIntegrity,
     agentId: plan.agent.finalId,
     workspace: plan.agent.workspace,
     agentConfigDigest,
+    agentOrigin: current.agentOrigin,
     agentOwnedPaths: ownedAgentPaths,
     ...(bootstrap ? { bootstrap } : {}),
     status,

--- a/src/claws/provenance.ts
+++ b/src/claws/provenance.ts
@@ -28,6 +28,7 @@ import {
 } from "./provenance-runtime-read.js";
 import * as installRecordSchema from "./provenance-schema-version.js";
 import type { ClawAddPlan, ClawPackage, ResolvedClawPackage } from "./types.js";
+import { deleteAdoptedWorkspaceRow, persistClawWorkspaceOrigin } from "./workspace-origin.js";
 export {
   CLAW_PACKAGE_REF_SCHEMA_VERSION,
   type PersistedClawPackageRef,
@@ -254,6 +255,7 @@ export function persistClawInstallRecord(
       added_at_ms: nowMs,
       updated_at_ms: nowMs,
     });
+    persistClawWorkspaceOrigin({ db, plan, nowMs });
     return {
       schemaVersion: installRecordSchema.CLAW_INSTALL_RECORD_SCHEMA_VERSION,
       claw: plan.claw,
@@ -322,6 +324,7 @@ export function deleteClawInstallRecord(
       db /* sqlite-allow-raw: this Claw prototype state-table delete is scoped to one owned row. */
         .prepare(`DELETE FROM claw_installs WHERE agent_id = ?${expectedClause}`)
         .run(agentId, ...expectedStatuses);
+    deleteAdoptedWorkspaceRow(db, agentId);
     if (result.changes !== 1) {
       throw new Error(
         `Claw install record for agent ${JSON.stringify(agentId)} did not match the expected phase.`,

--- a/src/claws/tool-policy-runtime.integration.test.ts
+++ b/src/claws/tool-policy-runtime.integration.test.ts
@@ -187,6 +187,69 @@ describe("Claw tool policy consent provenance", () => {
     ).toThrow("Cannot verify the installed tool authority");
   });
 
+  it("honors adopted v3 tool profile consent after verifying the agent config digest", async () => {
+    const root = tempDirs.make("openclaw-adopted-claw-tool-consent-");
+    const env = stateEnv(root);
+    const workspace = join(root, "workspace-worker");
+    mkdirSync(workspace);
+    vi.stubEnv("OPENCLAW_STATE_DIR", env.OPENCLAW_STATE_DIR);
+    const adoptedAgent = {
+      id: "worker",
+      workspace,
+      tools: { profile: "full" as const, allow: ["read"] },
+    };
+    const { plan } = await makeProvenancePlan(
+      root,
+      { schemaVersion: 1, agent: { id: "worker" } },
+      {
+        workspace,
+        adoptExistingAgent: true,
+        existingAgents: [adoptedAgent],
+        openClawProfile: {
+          schemaVersion: 1,
+          agent: { tools: { profile: "full", allow: ["read"] } },
+        },
+      },
+    );
+    const record = persistClawInstallRecord(plan, { env });
+    const config = { agents: { list: [plan.agent.config] } };
+    setRuntimeConfigSnapshot(config);
+
+    const capabilityProfile = resolveConversationCapabilityProfile({
+      agentId: "worker",
+      config,
+    });
+    const policies = resolveConversationToolPolicies({ capabilityProfile });
+    const filtered = applyToolPolicyPipeline({
+      tools: [{ name: "read" }, { name: "exec" }],
+      toolMeta: () => undefined,
+      warn: () => {},
+      steps: buildConversationToolPolicyPipelineSteps({
+        capabilityProfile,
+        policies,
+        includeRuntimeToolPolicy: true,
+      }),
+    });
+
+    expect(record.schemaVersion).toBe("openclaw.clawInstallRecord.v3");
+    expect(filtered.map((tool) => tool.name)).toEqual(["read"]);
+
+    const driftedConfig = {
+      agents: {
+        list: [
+          {
+            ...plan.agent.config,
+            tools: { profile: "full" as const, allow: ["read", "exec"] },
+          },
+        ],
+      },
+    };
+    setRuntimeConfigSnapshot(driftedConfig);
+    expect(() =>
+      resolveConversationCapabilityProfile({ agentId: "worker", config: driftedConfig }),
+    ).toThrow("Cannot verify the installed tool authority");
+  });
+
   it("fails closed after a host upgrade leaves legacy profile provenance", async () => {
     const root = tempDirs.make("openclaw-claw-tool-consent-");
     const env = stateEnv(root);

--- a/src/claws/tool-policy-runtime.ts
+++ b/src/claws/tool-policy-runtime.ts
@@ -8,7 +8,10 @@ import {
   readCachedClawInstallSchemaVersions,
   registerClawInstallSchemaVersionSnapshotListener,
 } from "./provenance-runtime-read.js";
-import { CLAW_INSTALL_RECORD_SCHEMA_VERSION } from "./provenance-schema-version.js";
+import {
+  CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION,
+  CLAW_INSTALL_RECORD_SCHEMA_VERSION,
+} from "./provenance-schema-version.js";
 
 const frozenToolAllowPolicies = new WeakSet<object>();
 type PreparedClawToolPolicy =
@@ -67,10 +70,10 @@ function applyPreparedClawToolPolicyConsent(): void {
       });
       continue;
     }
-    if (
-      schemaVersionRead.schemaVersion === CLAW_INSTALL_RECORD_SCHEMA_VERSION &&
-      schemaVersionRead.agentConfigDigest !== candidate.agentConfigDigest
-    ) {
+    const currentSchema =
+      schemaVersionRead.schemaVersion === CLAW_INSTALL_RECORD_SCHEMA_VERSION ||
+      schemaVersionRead.schemaVersion === CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION;
+    if (currentSchema && schemaVersionRead.agentConfigDigest !== candidate.agentConfigDigest) {
       preparedClawToolPolicies.set(candidate.tools, {
         kind: "state-error",
         error: new Error("Claw agent configuration does not match its consent provenance."),
@@ -78,10 +81,7 @@ function applyPreparedClawToolPolicyConsent(): void {
       continue;
     }
     preparedClawToolPolicies.set(candidate.tools, {
-      kind:
-        schemaVersionRead.schemaVersion === CLAW_INSTALL_RECORD_SCHEMA_VERSION
-          ? "current"
-          : "legacy",
+      kind: currentSchema ? "current" : "legacy",
     });
   }
 }

--- a/src/claws/types.ts
+++ b/src/claws/types.ts
@@ -254,7 +254,7 @@ export type ClawReadResult =
 export type ClawAddPlanAction = {
   kind: "agent" | "workspace" | "bootstrap" | "workspaceFile" | "package" | "mcpServer" | "cronJob";
   id: string;
-  action: "create" | "write" | "install" | "reuse" | "configure" | "schedule";
+  action: "create" | "write" | "adopt" | "install" | "reuse" | "configure" | "schedule";
   target: string;
   source?: string;
   sourceKind?: "clawMarkdownBody";

--- a/src/claws/update-apply.test.ts
+++ b/src/claws/update-apply.test.ts
@@ -46,6 +46,7 @@ const install: PersistedClawInstall = {
   agentId: "worker",
   workspace: "/tmp/workspace-worker",
   agentConfigDigest: "sha256:current-agent",
+  agentOrigin: "created",
   agentOwnedPaths: ['agents.entries["worker"]'],
   status: "complete",
   addedAtMs: 1,
@@ -81,6 +82,11 @@ const addPlan: ClawAddPlan = {
   diagnostics: [],
   readiness: { ready: true, requirements: [] },
 };
+function agentDigest(config: ClawAddPlan["agent"]["config"]): string {
+  return `sha256:${createHash("sha256").update(stableStringify(config)).digest("hex")}`;
+}
+const targetAgentDigest = agentDigest(addPlan.agent.config);
+const adoptedTargetAgentDigest = agentDigest({ ...addPlan.agent.config, default: true });
 
 function plan(actions: ClawUpdatePlan["actions"]): ClawUpdatePlan {
   return {
@@ -206,6 +212,36 @@ describe("applyClawUpdatePlan", () => {
     ).rejects.toMatchObject({ code: "update_changed" });
   });
 
+  it("rejects a materialized agent config that differs from the consented target", async () => {
+    const updatePlan = plan([
+      {
+        kind: "agent",
+        id: "worker",
+        action: "change",
+        target: 'agents.entries["worker"]',
+        blocked: false,
+        reason: "target changed",
+        desiredDigest: targetAgentDigest,
+      },
+    ]);
+    const changedAddPlan = structuredClone(addPlan);
+    changedAddPlan.agent.config.name = "Changed after consent";
+
+    await expect(
+      applyClawUpdatePlan(
+        updatePlan,
+        { targetManifest: manifest, targetSource: source },
+        {
+          config: {},
+          ...consent(updatePlan),
+          rebuildPlan: vi.fn(async () => updatePlan),
+          buildAddPlan: vi.fn(async () => changedAddPlan),
+          readInstall: vi.fn(() => install),
+        },
+      ),
+    ).rejects.toMatchObject({ code: "update_changed" });
+  });
+
   it("compare-writes the owned agent and advances root provenance", async () => {
     const currentAgent = { id: "worker", name: "Worker" };
     const currentDigest = `sha256:${createHash("sha256").update(stableStringify(currentAgent)).digest("hex")}`;
@@ -218,7 +254,7 @@ describe("applyClawUpdatePlan", () => {
         blocked: false,
         reason: "target changed",
         currentDigest,
-        desiredDigest: "sha256:target-agent",
+        desiredDigest: targetAgentDigest,
       },
     ]);
     let config: OpenClawConfig = { agents: { entries: { worker: { name: "Worker" } } } };
@@ -263,6 +299,7 @@ describe("applyClawUpdatePlan", () => {
         target: 'agents.entries["worker"]',
         blocked: false,
         reason: "restore agent",
+        desiredDigest: targetAgentDigest,
       },
     ]);
     const order: string[] = [];
@@ -415,6 +452,7 @@ describe("applyClawUpdatePlan", () => {
         target: 'agents.entries["worker"]',
         blocked: false,
         reason: "restore agent",
+        desiredDigest: targetAgentDigest,
       },
       {
         kind: "cronJob",
@@ -829,6 +867,7 @@ describe("applyClawUpdatePlan", () => {
         blocked: false,
         reason: "target changed",
         currentDigest,
+        desiredDigest: targetAgentDigest,
       },
     ]);
     let config: OpenClawConfig = { agents: { entries: { worker: { name: "Worker" } } } };
@@ -858,6 +897,75 @@ describe("applyClawUpdatePlan", () => {
     expect(commits).toBe(2);
   });
 
+  it("preserves an adopted agent default marker in config and provenance", async () => {
+    const liveAgent = {
+      id: "worker",
+      name: "Worker",
+      workspace: "/tmp/workspace-worker",
+      default: true,
+    };
+    const currentDigest = `sha256:${createHash("sha256")
+      .update(stableStringify(liveAgent))
+      .digest("hex")}`;
+    const adoptedInstall: PersistedClawInstall = {
+      ...install,
+      schemaVersion: "openclaw.clawInstallRecord.v3",
+      agentOrigin: "adopted",
+      agentConfigDigest: currentDigest,
+    };
+    const updatePlan = plan([
+      {
+        kind: "agent",
+        id: "worker",
+        action: "change",
+        target: 'agents.entries["worker"]',
+        blocked: false,
+        reason: "target changed",
+        currentDigest,
+        desiredDigest: adoptedTargetAgentDigest,
+      },
+    ]);
+    let config: OpenClawConfig = {
+      agents: {
+        entries: {
+          WORKER: { name: liveAgent.name, workspace: liveAgent.workspace, default: true },
+        },
+      },
+    };
+    const persistInstall = vi.fn((targetPlan: ClawAddPlan) => {
+      expect(targetPlan.agent.config.default).toBe(true);
+      return adoptedInstall;
+    });
+
+    await applyClawUpdatePlan(
+      updatePlan,
+      { targetManifest: manifest, targetSource: source },
+      {
+        config,
+        ...consent(updatePlan),
+        rebuildPlan: vi.fn(async () => updatePlan),
+        buildAddPlan: vi.fn(async () => addPlan),
+        readInstall: vi.fn(() => adoptedInstall),
+        persistInstall,
+        commitConfig: async (transform) => {
+          config = transform(config);
+        },
+        applyWorkspace: vi.fn(async () => ({ appliedPaths: [], rollback: async () => undefined })),
+        applyMcp: vi.fn(async () => ({ appliedNames: [], rollback: async () => undefined })),
+        applyCron: vi.fn(async () => ({ appliedIds: [], rollback: async () => undefined })),
+        applyPackage: vi.fn(async () => ({ appliedIds: [], rollback: async () => undefined })),
+      },
+    );
+
+    expect(config.agents?.entries?.worker).toEqual({
+      name: "Worker v2",
+      workspace: "/tmp/workspace-worker",
+      default: true,
+    });
+    expect(config.agents?.entries?.WORKER).toBeUndefined();
+    expect(persistInstall).toHaveBeenCalledOnce();
+  });
+
   it("does not recreate an agent removed after planning", async () => {
     const currentAgent = { id: "worker", name: "Worker" };
     const currentDigest = `sha256:${createHash("sha256").update(stableStringify(currentAgent)).digest("hex")}`;
@@ -870,6 +978,7 @@ describe("applyClawUpdatePlan", () => {
         blocked: false,
         reason: "target changed",
         currentDigest,
+        desiredDigest: targetAgentDigest,
       },
     ]);
     let config: OpenClawConfig = { agents: { entries: {} } };

--- a/src/claws/update-apply.test.ts
+++ b/src/claws/update-apply.test.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { ClawCronUpdateError } from "./cron-update.js";
 import type { buildClawAddPlan } from "./lifecycle.js";
 import {
@@ -19,6 +20,7 @@ import { applyClawUpdatePlan } from "./update-apply.js";
 import type { ClawUpdatePlan } from "./update-plan.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => closeOpenClawStateDatabaseForTest());
 
 const source: ClawSourceIdentity = {
   kind: "package",
@@ -1039,5 +1041,6 @@ describe("applyClawUpdatePlan", () => {
     ).rejects.toMatchObject({ code: "update_blocked" });
   });
 });
+/* eslint-disable max-lines -- Existing update coverage is at the limit; this PR adds Windows DB cleanup. */
 import { createHash } from "node:crypto";
 import { stableStringify } from "@openclaw/normalization-core";

--- a/src/claws/update-apply.ts
+++ b/src/claws/update-apply.ts
@@ -1,11 +1,12 @@
 import { createHash } from "node:crypto";
 import { coerceErrorMessage, stableStringify } from "@openclaw/normalization-core";
-import { listAgentEntries } from "../agents/agent-scope.js";
 import { transformConfigFileWithRetry } from "../config/config.js";
 import type { AgentConfig } from "../config/types.agents.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import { preserveAdoptedAgentDefault } from "./adopted-agent-update.js";
+import { resolveCanonicalClawAgent, resolveClawAgentRosterKey } from "./agent-adoption-apply.js";
 import { clawTargetPackages } from "./application-provenance.js";
 import {
   applyClawCronUpdate,
@@ -196,7 +197,7 @@ export async function applyClawUpdatePlan(
     }
     return new ClawUpdateMutationError("update_partial", message);
   };
-  const targetAddPlan = await buildAddPlan({
+  const rawTargetAddPlan = await buildAddPlan({
     manifest: params.targetManifest,
     clawMarkdownBody: params.targetClawMarkdownBody,
     includePackageBootstrap: false,
@@ -237,6 +238,18 @@ export async function applyClawUpdatePlan(
     },
   });
   const unchangedPaths = unchangedPackagePaths(fresh, params.targetManifest);
+  const liveAgent = resolveCanonicalClawAgent(options.config, fresh.agentId);
+  const targetAddPlan = preserveAdoptedAgentDefault({
+    plan: rawTargetAddPlan,
+    install: currentInstall,
+    liveAgent,
+  });
+  if (!targetAddPlan) {
+    throw new ClawUpdateMutationError(
+      "agent_changed",
+      "The adopted agent changed before update materialization.",
+    );
+  }
   if (
     targetAddPlan.blockers.some(
       (blocker) =>
@@ -262,6 +275,13 @@ export async function applyClawUpdatePlan(
         `Package ${JSON.stringify(action.id)} is no longer present; build a new dry-run plan.`,
       );
     }
+  }
+  const agentAction = fresh.actions.find((action) => action.kind === "agent");
+  if (agentAction && agentAction.desiredDigest !== digest(targetAddPlan.agent.config)) {
+    throw new ClawUpdateMutationError(
+      "update_changed",
+      "The materialized agent configuration changed after update planning.",
+    );
   }
   const targetPackages = clawTargetPackages(params.targetManifest, params.targetOpenClawProfile);
   for (const action of fresh.actions.filter(
@@ -399,7 +419,6 @@ export async function applyClawUpdatePlan(
     throw new ClawUpdateMutationError("package_update_failed", coerceErrorMessage(error));
   }
 
-  const agentAction = fresh.actions.find((action) => action.kind === "agent");
   const commit: ConfigCommit =
     options.commitConfig ??
     (async (transform) => {
@@ -409,13 +428,14 @@ export async function applyClawUpdatePlan(
       });
     });
   let previousAgent: AgentConfig | undefined;
+  let previousAgentKey: string | undefined;
   let agentChanged = false;
   const rollbackAgent = async (): Promise<void> => {
     if (!agentChanged) {
       return;
     }
     await commit((config) => {
-      const current = listAgentEntries(config).find((agent) => agent.id === fresh.agentId);
+      const current = resolveCanonicalClawAgent(config, fresh.agentId);
       const targetDigest = `sha256:${createHash("sha256").update(stableStringify(targetAddPlan.agent.config)).digest("hex")}`;
       const liveDigest = current
         ? `sha256:${createHash("sha256").update(stableStringify(current)).digest("hex")}`
@@ -424,11 +444,13 @@ export async function applyClawUpdatePlan(
         throw new Error("The agent changed before rollback.");
       }
       const nextEntries = { ...config.agents?.entries };
+      const currentKey = resolveClawAgentRosterKey(config, fresh.agentId);
+      if (currentKey) {
+        delete nextEntries[currentKey];
+      }
       if (previousAgent) {
         const { id: _id, ...previousEntry } = previousAgent;
-        nextEntries[fresh.agentId] = previousEntry;
-      } else {
-        delete nextEntries[fresh.agentId];
+        nextEntries[previousAgentKey ?? fresh.agentId] = previousEntry;
       }
       return { ...config, agents: { ...config.agents, entries: nextEntries } };
     });
@@ -437,8 +459,9 @@ export async function applyClawUpdatePlan(
   if (agentAction?.action === "change") {
     try {
       await commit((config) => {
-        const current = listAgentEntries(config).find((agent) => agent.id === fresh.agentId);
+        const current = resolveCanonicalClawAgent(config, fresh.agentId);
         previousAgent = current;
+        previousAgentKey = resolveClawAgentRosterKey(config, fresh.agentId);
         if (agentAction.currentDigest !== undefined) {
           if (!current) {
             throw new ClawUpdateMutationError(
@@ -455,6 +478,9 @@ export async function applyClawUpdatePlan(
           }
         }
         const nextEntries = { ...config.agents?.entries };
+        if (previousAgentKey) {
+          delete nextEntries[previousAgentKey];
+        }
         const { id: _id, ...targetEntry } = targetAddPlan.agent.config;
         nextEntries[fresh.agentId] = targetEntry;
         agentChanged = true;

--- a/src/claws/update-plan.test.ts
+++ b/src/claws/update-plan.test.ts
@@ -10,6 +10,7 @@ import {
   openOpenClawStateDatabase,
 } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION } from "./provenance-schema-version.js";
 import { persistClawPackageRef } from "./provenance.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawPackage } from "./types.js";
@@ -215,6 +216,76 @@ describe("buildClawUpdatePlan", () => {
     );
     expect(agentAction).toMatchObject({ action: "change", blocked: false });
     expect(agentAction).not.toHaveProperty("currentDigest");
+  });
+
+  it("preserves an adopted agent default marker when planning an update", async () => {
+    const current = await fixture();
+    const entry = current.config.agents?.entries?.worker;
+    if (!entry) {
+      throw new Error("fixture agent missing");
+    }
+    entry.default = true;
+    const recordedAgent = { id: "worker", ...entry };
+    const recordedDigest = `sha256:${createHash("sha256")
+      .update(stableStringify(recordedAgent))
+      .digest("hex")}`;
+    openOpenClawStateDatabase({ env: current.env })
+      .db.prepare(
+        `UPDATE claw_installs
+            SET schema_version = ?, agent_config_digest = ?, agent_owned_paths_json = ?
+          WHERE agent_id = ?`,
+      )
+      .run(
+        CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION,
+        recordedDigest,
+        JSON.stringify({ origin: "adopted", paths: ['agents.entries["worker"]'] }),
+        "worker",
+      );
+    current.config.agents = {
+      ...current.config.agents,
+      entries: { WORKER: entry },
+    };
+
+    const plan = await buildClawUpdatePlan({
+      agentId: "worker",
+      targetManifest: current.manifest,
+      targetSource: current.source,
+      config: current.config,
+      sourceMcpServers: current.config.mcp?.servers ?? {},
+      stateOptions: { env: current.env },
+      packagePreflight,
+    });
+
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "agent", id: "worker", action: "unchanged" }),
+    );
+  });
+
+  it("never restores a missing adopted agent without its captured default marker", async () => {
+    const current = await fixture();
+    const db = openOpenClawStateDatabase({ env: current.env }).db;
+    db.prepare(
+      `UPDATE claw_installs SET schema_version = ?, agent_owned_paths_json = ? WHERE agent_id = ?`,
+    ).run(
+      CLAW_ADOPTED_INSTALL_RECORD_SCHEMA_VERSION,
+      JSON.stringify({ origin: "adopted", paths: ['agents.entries["worker"]'] }),
+      "worker",
+    );
+    current.config.agents = { ...current.config.agents, entries: {} };
+
+    const plan = await buildClawUpdatePlan({
+      agentId: "worker",
+      targetManifest: current.manifest,
+      targetSource: current.source,
+      config: current.config,
+      sourceMcpServers: current.config.mcp?.servers ?? {},
+      stateOptions: { env: current.env },
+      packagePreflight,
+    });
+
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "agent", id: "worker", action: "manual", blocked: true }),
+    );
   });
 
   it("plans workspace restoration when the owned workspace directory is missing", async () => {

--- a/src/claws/update-plan.ts
+++ b/src/claws/update-plan.ts
@@ -9,6 +9,8 @@ import {
   openExistingOpenClawStateDatabaseReadOnly,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import { preserveAdoptedAgentDefault } from "./adopted-agent-update.js";
+import { resolveCanonicalClawAgent } from "./agent-adoption-apply.js";
 import {
   clawExtensionProvenanceChanged,
   clawPackageActionsById,
@@ -192,7 +194,7 @@ export async function buildClawUpdatePlan(params: {
     const currentPackages = new Map(
       record.packages.map((pkg) => [clawPackageKey(pkg), pkg] as const),
     );
-    const targetPlan = await buildClawAddPlan({
+    const rawTargetPlan = await buildClawAddPlan({
       manifest: params.targetManifest,
       clawMarkdownBody: params.targetClawMarkdownBody,
       includePackageBootstrap: false,
@@ -210,13 +212,22 @@ export async function buildClawUpdatePlan(params: {
         ),
       },
     });
+    const liveAgent = resolveCanonicalClawAgent(params.config, agentId);
+    const targetPlan =
+      preserveAdoptedAgentDefault({
+        plan: rawTargetPlan,
+        install: record.install,
+        liveAgent,
+      }) ?? rawTargetPlan;
     const blockers = targetPlan.blockers.filter(isApplicationUpdateBlocker);
     const actions: ClawUpdateAction[] = [];
     const capabilityChanges: ClawUpdateCapabilityChange[] = [];
 
     const desiredAgentDigest = digest(targetPlan.agent.config);
+    const adoptedAgentUnavailable =
+      record.install.agentOrigin === "adopted" && record.agentState !== "present";
     const agentAction =
-      record.agentState === "modified"
+      record.agentState === "modified" || adoptedAgentUnavailable
         ? "manual"
         : record.agentState === "missing"
           ? "change"
@@ -231,7 +242,9 @@ export async function buildClawUpdatePlan(params: {
       blocked: agentAction === "manual",
       reason:
         agentAction === "manual"
-          ? "Live agent config changed after installation and must be reconciled manually."
+          ? adoptedAgentUnavailable && record.agentState === "missing"
+            ? "The adopted agent is missing; its pre-adoption default marker cannot be reconstructed safely."
+            : "Live agent config changed after installation and must be reconciled manually."
           : record.agentState === "missing"
             ? "Owned agent config is missing and would be restored from the target manifest."
             : agentAction === "unchanged"

--- a/src/claws/workspace-origin.ts
+++ b/src/claws/workspace-origin.ts
@@ -1,0 +1,113 @@
+// Durable record of which Claw workspaces were adopted rather than created by the install.
+import type { DatabaseSync } from "node:sqlite";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  openOpenClawStateDatabase,
+  type OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db.js";
+import type { ClawAddPlan } from "./types.js";
+
+type WorkspaceOriginDatabase = Pick<OpenClawStateKyselyDatabase, "claw_workspace_files">;
+
+// Older releases treat every workspace-file row as a removable file. Pointing the reserved row at
+// the directory itself makes those releases fail closed during file inspection instead of
+// deleting an adopted workspace whose origin they cannot understand.
+export const CLAW_ADOPTED_WORKSPACE_MARKER_PATH = ".";
+const CLAW_ADOPTED_WORKSPACE_MARKER_DIGEST = "openclaw:adopted-workspace";
+const CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION = "openclaw.clawWorkspaceFileRecord.v1";
+
+function kyselyFor(db: DatabaseSync) {
+  return getNodeSqliteKysely<WorkspaceOriginDatabase>(db);
+}
+
+/** True when the consented plan adopts an existing directory instead of creating one. */
+export function planAdoptsWorkspace(plan: ClawAddPlan): boolean {
+  return plan.actions.some((action) => action.kind === "workspace" && action.action === "adopt");
+}
+
+/** Records the downgrade fence inside the caller's open install-record transaction. */
+function recordAdoptedWorkspaceRow(params: {
+  db: DatabaseSync;
+  agentId: string;
+  workspace: string;
+  nowMs: number;
+}): void {
+  executeSqliteQuerySync(
+    params.db,
+    kyselyFor(params.db)
+      .insertInto("claw_workspace_files")
+      .values({
+        agent_id: params.agentId,
+        target_path: CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+        schema_version: CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+        workspace: params.workspace,
+        source_path: CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+        content_digest: CLAW_ADOPTED_WORKSPACE_MARKER_DIGEST,
+        status: "complete",
+        created_at_ms: params.nowMs,
+        updated_at_ms: params.nowMs,
+      })
+      .onConflict((conflict) =>
+        conflict.columns(["agent_id", "target_path"]).doUpdateSet({
+          schema_version: CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION,
+          workspace: params.workspace,
+          source_path: CLAW_ADOPTED_WORKSPACE_MARKER_PATH,
+          content_digest: CLAW_ADOPTED_WORKSPACE_MARKER_DIGEST,
+          status: "complete",
+          created_at_ms: params.nowMs,
+          updated_at_ms: params.nowMs,
+        }),
+      ),
+  );
+}
+
+/** Persists whether this install adopted or created its workspace in the caller's transaction. */
+export function persistClawWorkspaceOrigin(params: {
+  db: DatabaseSync;
+  plan: ClawAddPlan;
+  nowMs: number;
+}): void {
+  if (planAdoptsWorkspace(params.plan)) {
+    recordAdoptedWorkspaceRow({
+      db: params.db,
+      agentId: params.plan.agent.finalId,
+      workspace: params.plan.agent.workspace,
+      nowMs: params.nowMs,
+    });
+    return;
+  }
+  deleteAdoptedWorkspaceRow(params.db, params.plan.agent.finalId);
+}
+
+/** Drops the adopted-workspace marker inside the caller's open write transaction. */
+export function deleteAdoptedWorkspaceRow(db: DatabaseSync, agentId: string): void {
+  executeSqliteQuerySync(
+    db,
+    kyselyFor(db)
+      .deleteFrom("claw_workspace_files")
+      .where("agent_id", "=", agentId)
+      .where("target_path", "=", CLAW_ADOPTED_WORKSPACE_MARKER_PATH),
+  );
+}
+
+/** True when this agent's current workspace directory existed before the Claw adopted it. */
+export function clawWorkspaceWasAdopted(
+  agentId: string,
+  workspace: string,
+  options: OpenClawStateDatabaseOptions = {},
+): boolean {
+  const { db } = openOpenClawStateDatabase(options);
+  return (
+    executeSqliteQuerySync(
+      db,
+      kyselyFor(db)
+        .selectFrom("claw_workspace_files")
+        .select("agent_id")
+        .where("agent_id", "=", agentId)
+        .where("target_path", "=", CLAW_ADOPTED_WORKSPACE_MARKER_PATH)
+        .where("workspace", "=", workspace)
+        .where("content_digest", "=", CLAW_ADOPTED_WORKSPACE_MARKER_DIGEST),
+    ).rows.length > 0
+  );
+}

--- a/src/claws/workspace.test.ts
+++ b/src/claws/workspace.test.ts
@@ -12,6 +12,7 @@ import { applyClawAddPlan } from "./add.js";
 import { buildClawAddPlan } from "./lifecycle.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawAddPlan, ClawSourceIdentity } from "./types.js";
+import { clawWorkspaceWasAdopted } from "./workspace-origin.js";
 import { ClawWorkspaceWriteError, createClawWorkspaceFiles } from "./workspace.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -24,6 +25,46 @@ async function writeSource(root: string, path: string, content: string): Promise
   const target = join(root, path);
   await mkdir(dirname(target), { recursive: true });
   await writeFile(target, content, "utf8");
+}
+
+async function makeAdoptionPlan(params?: { existingAgentsContent?: string }) {
+  const root = tempDirs.make("openclaw-claw-workspace-adopt-");
+  const workspace = join(root, "workspace-agent");
+  await writeSource(root, "content/AGENTS.md", "# Agent\n");
+  await writeSource(root, "content/policy.md", "Policy\n");
+  await mkdir(workspace, { recursive: true });
+  await writeFile(
+    join(workspace, "AGENTS.md"),
+    params?.existingAgentsContent ?? "# Agent\n",
+    "utf8",
+  );
+  const parsed = parseClawManifest({
+    schemaVersion: 1,
+    agent: { id: "workspace-agent" },
+    workspace: {
+      bootstrapFiles: { "AGENTS.md": { source: "content/AGENTS.md" } },
+      files: [{ source: "content/policy.md", path: "reference/policy.md" }],
+    },
+  });
+  if (!parsed.ok) {
+    throw new Error(JSON.stringify(parsed.diagnostics));
+  }
+  const source: ClawSourceIdentity = {
+    kind: "package",
+    name: "@acme/workspace-agent",
+    version: "1.0.0",
+    packageRoot: root,
+    manifestPath: join(root, "openclaw.claw.json"),
+    integrityKind: "development-snapshot",
+    integrity: "sha256:manifest",
+    byteLength: 0,
+  };
+  const plan = await buildClawAddPlan({
+    manifest: parsed.manifest,
+    source,
+    context: { workspace, adoptExistingWorkspace: true },
+  });
+  return { root, workspace, plan };
 }
 
 async function makePlan(params?: {
@@ -201,6 +242,54 @@ describe("createClawWorkspaceFiles", () => {
       await expect(readFile(join(workspace, "SOUL.md"), "utf8")).resolves.toBe(body.toString());
     },
   );
+
+  it("adopts an existing identical file without rewriting and records complete provenance", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    expect(plan.blockers).toEqual([]);
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "workspaceFile", id: "AGENTS.md", action: "adopt" }),
+    );
+
+    const records = await createClawWorkspaceFiles(plan, { env: stateEnv(root), nowMs: 10 });
+
+    expect(records).toContainEqual(
+      expect.objectContaining({ path: "AGENTS.md", status: "complete" }),
+    );
+    await expect(readFile(join(workspace, "AGENTS.md"), "utf8")).resolves.toBe("# Agent\n");
+    await expect(readFile(join(workspace, "reference", "policy.md"), "utf8")).resolves.toBe(
+      "Policy\n",
+    );
+  });
+
+  it("fails closed when an adoptable file changes between planning and apply", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    expect(plan.blockers).toEqual([]);
+    await writeFile(join(workspace, "AGENTS.md"), "# Changed after planning\n", "utf8");
+
+    await expect(
+      createClawWorkspaceFiles(plan, { env: stateEnv(root), nowMs: 10 }),
+    ).rejects.toMatchObject({
+      diagnostics: [expect.objectContaining({ code: "workspace_file_conflict" })],
+    });
+    await expect(readFile(join(workspace, "AGENTS.md"), "utf8")).resolves.toBe(
+      "# Changed after planning\n",
+    );
+  });
+
+  it("fails closed when an adoptable file disappears between planning and apply", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    expect(plan.blockers).toEqual([]);
+    await rm(join(workspace, "AGENTS.md"));
+
+    await expect(
+      createClawWorkspaceFiles(plan, { env: stateEnv(root), nowMs: 10 }),
+    ).rejects.toMatchObject({
+      diagnostics: [expect.objectContaining({ code: "workspace_file_conflict" })],
+    });
+    await expect(readFile(join(workspace, "AGENTS.md"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
 
   it("creates canonical bootstrap and supporting files and records their hashes", async () => {
     const { root, workspace, plan } = await makePlan();
@@ -405,6 +494,121 @@ describe("createClawWorkspaceFiles", () => {
 });
 
 describe("workspace files in the consented add lifecycle", () => {
+  it("completes an adoption add without rewriting existing files and commits the agent", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    expect(plan.blockers).toEqual([]);
+    let config: OpenClawConfig = {};
+
+    const result = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      nowMs: 30,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "complete",
+      workspaceCreated: true,
+      workspaceFiles: [
+        expect.objectContaining({ path: "AGENTS.md", status: "complete" }),
+        expect.objectContaining({ path: "reference/policy.md", status: "complete" }),
+      ],
+      installRecord: { status: "complete" },
+    });
+    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
+    expect(readInstallStatus("workspace-agent", root)).toBe("complete");
+    await expect(readFile(join(workspace, "AGENTS.md"), "utf8")).resolves.toBe("# Agent\n");
+    await expect(readFile(join(workspace, "reference", "policy.md"), "utf8")).resolves.toBe(
+      "Policy\n",
+    );
+  });
+
+  it("preserves an adopted workspace when config commit rolls back", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    let config: OpenClawConfig = {};
+
+    const result = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      nowMs: 35,
+      commitConfig: async () => {
+        throw new Error("config unavailable");
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      workspaceCreated: true,
+      configCommitted: false,
+      workspaceFiles: [
+        expect.objectContaining({ path: "AGENTS.md", status: "complete" }),
+        expect.objectContaining({ path: "reference/policy.md", status: "complete" }),
+      ],
+      installRecord: { status: "workspace_ready" },
+      error: { code: "config_commit_failed", message: "config unavailable" },
+    });
+    await expect(readFile(join(workspace, "AGENTS.md"), "utf8")).resolves.toBe("# Agent\n");
+
+    const resumed = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      nowMs: 36,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    expect(resumed).toMatchObject({
+      status: "complete",
+      configCommitted: true,
+      installRecord: { status: "complete" },
+    });
+    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
+  });
+
+  it("records adopted origin but leaves the agent unroutable when file revalidation fails", async () => {
+    const { root, workspace, plan } = await makeAdoptionPlan();
+    let config: OpenClawConfig = {};
+    await writeFile(join(workspace, "AGENTS.md"), "# Changed after planning\n", "utf8");
+
+    const result = await applyClawAddPlan(plan, {
+      consentPlanIntegrity: plan.planIntegrity,
+      env: stateEnv(root),
+      nowMs: 37,
+      commitConfig: async (transform) => {
+        config = transform(config);
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "partial",
+      configCommitted: false,
+      installRecord: { status: "workspace_ready" },
+      error: {
+        code: "workspace_files_failed",
+        diagnostics: [expect.objectContaining({ code: "workspace_file_conflict" })],
+      },
+    });
+    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
+    const originRows = openOpenClawStateDatabase({ env: stateEnv(root) })
+      .db.prepare(
+        "SELECT target_path, workspace, content_digest FROM claw_workspace_files WHERE agent_id = ? ORDER BY target_path",
+      )
+      .all("workspace-agent");
+    expect(originRows).toEqual([
+      {
+        target_path: ".",
+        workspace: plan.agent.workspace,
+        content_digest: "openclaw:adopted-workspace",
+      },
+    ]);
+    expect(
+      clawWorkspaceWasAdopted("workspace-agent", plan.agent.workspace, { env: stateEnv(root) }),
+    ).toBe(true);
+  });
+
   it("marks the root install complete after every declared file is created", async () => {
     const { root, plan } = await makePlan({ createWorkspace: false });
     let config: OpenClawConfig = {};
@@ -451,14 +655,14 @@ describe("workspace files in the consented add lifecycle", () => {
     expect(result).toMatchObject({
       status: "partial",
       workspaceFiles: [expect.objectContaining({ path: "AGENTS.md" })],
-      installRecord: { status: "config_committed" },
+      installRecord: { status: "workspace_ready" },
       error: {
         code: "workspace_files_failed",
         diagnostics: [expect.objectContaining({ code: "workspace_source_changed" })],
       },
     });
-    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
-    expect(readInstallStatus("workspace-agent", root)).toBe("config_committed");
+    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
+    expect(readInstallStatus("workspace-agent", root)).toBe("workspace_ready");
 
     await writeFile(join(root, "content", "policy.md"), "Policy\n", "utf8");
     const resumed = await applyClawAddPlan(plan, {

--- a/src/claws/workspace.test.ts
+++ b/src/claws/workspace.test.ts
@@ -542,10 +542,7 @@ describe("workspace files in the consented add lifecycle", () => {
       status: "partial",
       workspaceCreated: true,
       configCommitted: false,
-      workspaceFiles: [
-        expect.objectContaining({ path: "AGENTS.md", status: "complete" }),
-        expect.objectContaining({ path: "reference/policy.md", status: "complete" }),
-      ],
+      workspaceFiles: [],
       installRecord: { status: "workspace_ready" },
       error: { code: "config_commit_failed", message: "config unavailable" },
     });
@@ -568,7 +565,7 @@ describe("workspace files in the consented add lifecycle", () => {
     expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
   });
 
-  it("records adopted origin but leaves the agent unroutable when file revalidation fails", async () => {
+  it("records adopted origin after reserving the agent when file revalidation fails", async () => {
     const { root, workspace, plan } = await makeAdoptionPlan();
     let config: OpenClawConfig = {};
     await writeFile(join(workspace, "AGENTS.md"), "# Changed after planning\n", "utf8");
@@ -584,14 +581,14 @@ describe("workspace files in the consented add lifecycle", () => {
 
     expect(result).toMatchObject({
       status: "partial",
-      configCommitted: false,
-      installRecord: { status: "workspace_ready" },
+      configCommitted: true,
+      installRecord: { status: "config_committed" },
       error: {
         code: "workspace_files_failed",
         diagnostics: [expect.objectContaining({ code: "workspace_file_conflict" })],
       },
     });
-    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
+    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
     const originRows = openOpenClawStateDatabase({ env: stateEnv(root) })
       .db.prepare(
         "SELECT target_path, workspace, content_digest FROM claw_workspace_files WHERE agent_id = ? ORDER BY target_path",
@@ -655,14 +652,14 @@ describe("workspace files in the consented add lifecycle", () => {
     expect(result).toMatchObject({
       status: "partial",
       workspaceFiles: [expect.objectContaining({ path: "AGENTS.md" })],
-      installRecord: { status: "workspace_ready" },
+      installRecord: { status: "config_committed" },
       error: {
         code: "workspace_files_failed",
         diagnostics: [expect.objectContaining({ code: "workspace_source_changed" })],
       },
     });
-    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
-    expect(readInstallStatus("workspace-agent", root)).toBe("workspace_ready");
+    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
+    expect(readInstallStatus("workspace-agent", root)).toBe("config_committed");
 
     await writeFile(join(root, "content", "policy.md"), "Policy\n", "utf8");
     const resumed = await applyClawAddPlan(plan, {

--- a/src/claws/workspace.test.ts
+++ b/src/claws/workspace.test.ts
@@ -565,7 +565,7 @@ describe("workspace files in the consented add lifecycle", () => {
     expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
   });
 
-  it("records adopted origin after reserving the agent when file revalidation fails", async () => {
+  it("records adopted origin but leaves the agent unroutable when file revalidation fails", async () => {
     const { root, workspace, plan } = await makeAdoptionPlan();
     let config: OpenClawConfig = {};
     await writeFile(join(workspace, "AGENTS.md"), "# Changed after planning\n", "utf8");
@@ -581,14 +581,14 @@ describe("workspace files in the consented add lifecycle", () => {
 
     expect(result).toMatchObject({
       status: "partial",
-      configCommitted: true,
-      installRecord: { status: "config_committed" },
+      configCommitted: false,
+      installRecord: { status: "workspace_ready" },
       error: {
         code: "workspace_files_failed",
         diagnostics: [expect.objectContaining({ code: "workspace_file_conflict" })],
       },
     });
-    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
+    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
     const originRows = openOpenClawStateDatabase({ env: stateEnv(root) })
       .db.prepare(
         "SELECT target_path, workspace, content_digest FROM claw_workspace_files WHERE agent_id = ? ORDER BY target_path",
@@ -652,14 +652,14 @@ describe("workspace files in the consented add lifecycle", () => {
     expect(result).toMatchObject({
       status: "partial",
       workspaceFiles: [expect.objectContaining({ path: "AGENTS.md" })],
-      installRecord: { status: "config_committed" },
+      installRecord: { status: "workspace_ready" },
       error: {
         code: "workspace_files_failed",
         diagnostics: [expect.objectContaining({ code: "workspace_source_changed" })],
       },
     });
-    expect(config.agents?.entries?.["workspace-agent"]).toBeDefined();
-    expect(readInstallStatus("workspace-agent", root)).toBe("config_committed");
+    expect(config.agents?.entries?.["workspace-agent"]).toBeUndefined();
+    expect(readInstallStatus("workspace-agent", root)).toBe("workspace_ready");
 
     await writeFile(join(root, "content", "policy.md"), "Policy\n", "utf8");
     const resumed = await applyClawAddPlan(plan, {

--- a/src/claws/workspace.ts
+++ b/src/claws/workspace.ts
@@ -11,6 +11,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import { parseClawMarkdown } from "./reader.js";
 import type { ClawAddPlan, ClawAddPlanAction, ClawDiagnostic } from "./types.js";
+import { CLAW_ADOPTED_WORKSPACE_MARKER_PATH } from "./workspace-origin.js";
 
 export const CLAW_WORKSPACE_FILE_RECORD_SCHEMA_VERSION =
   "openclaw.clawWorkspaceFileRecord.v1" as const;
@@ -319,10 +320,10 @@ export function readClawWorkspaceFiles(
         `SELECT schema_version, agent_id, workspace, target_path, source_path,
               content_digest, status, created_at_ms, updated_at_ms
          FROM claw_workspace_files
-        WHERE agent_id = ?
+        WHERE agent_id = ? AND target_path <> ?
         ORDER BY target_path`,
       )
-      .all(agentId) as WorkspaceFileRow[];
+      .all(agentId, CLAW_ADOPTED_WORKSPACE_MARKER_PATH) as WorkspaceFileRow[];
   return rows.map(rowToWorkspaceFile);
 }
 
@@ -426,6 +427,37 @@ export async function createClawWorkspaceFiles(
       }
       if (await workspace.exists(targetRelative)) {
         if (!existingRecord || existingRecord.status === "failed") {
+          if (action.action === "adopt") {
+            const adoptedTarget = await workspace.read(targetRelative, {
+              hardlinks: "reject",
+              maxBytes: MAX_CLAW_WORKSPACE_FILE_BYTES,
+              symlinks: "reject",
+            });
+            if (contentDigest(adoptedTarget.buffer) !== expectedRecord.contentDigest) {
+              throw new ClawWorkspaceWriteError(
+                [
+                  diagnostic(
+                    action,
+                    "workspace_file_conflict",
+                    `Adoptable workspace destination ${JSON.stringify(targetRelative)} changed after planning; adoption never overwrites existing files.`,
+                  ),
+                ],
+                createdFiles,
+              );
+            }
+            const adoptedRecord = existingRecord ?? expectedRecord;
+            if (existingRecord) {
+              const previousStatus = existingRecord.status;
+              existingRecord.status = "complete";
+              existingRecord.updatedAtMs = nowMs;
+              updateWorkspaceFileStatus(existingRecord, [previousStatus], options);
+            } else {
+              adoptedRecord.status = "complete";
+              persistWorkspaceFile(adoptedRecord, options);
+            }
+            createdFiles.push(adoptedRecord);
+            continue;
+          }
           throw new ClawWorkspaceWriteError(
             [
               diagnostic(
@@ -460,6 +492,18 @@ export async function createClawWorkspaceFiles(
         updateWorkspaceFileStatus(existingRecord, [previousStatus], options);
         createdFiles.push(existingRecord);
         continue;
+      }
+      if (action.action === "adopt") {
+        throw new ClawWorkspaceWriteError(
+          [
+            diagnostic(
+              action,
+              "workspace_file_conflict",
+              `Adoptable workspace destination ${JSON.stringify(targetRelative)} disappeared after planning; adoption never writes missing files.`,
+            ),
+          ],
+          createdFiles,
+        );
       }
       const record = existingRecord ?? expectedRecord;
       if (existingRecord) {

--- a/src/cli/claws-cli-agent-adoption.test.ts
+++ b/src/cli/claws-cli-agent-adoption.test.ts
@@ -1,0 +1,412 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { persistClawInstallRecord, persistClawPackageRef } from "../claws/provenance.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import * as cliTestHelpers from "./claws-cli.test-helpers.js";
+
+const mocks = vi.hoisted(() => {
+  const logs: string[] = [];
+  const runtime = {
+    log: vi.fn((value: unknown) => logs.push(String(value))),
+    error: vi.fn(),
+    writeJson: vi.fn((value: unknown, space = 2) =>
+      logs.push(JSON.stringify(value, null, space > 0 ? space : undefined)),
+    ),
+    writeStdout: vi.fn(),
+    exit: vi.fn((code: number) => {
+      throw new Error(`__exit__:${code}`);
+    }),
+  };
+  return {
+    logs,
+    runtime,
+    loadConfig: vi.fn<() => Record<string, unknown>>(() => ({})),
+    readConfigFileSnapshot: vi.fn(),
+    listConfiguredMcpServers: vi.fn(),
+    readClawStatus: vi.fn(),
+    openExistingOpenClawStateDatabaseReadOnly: vi.fn(),
+    applyClawAddPlan: vi.fn(),
+    preflightClawPackage: vi.fn(),
+  };
+});
+
+vi.mock("../runtime.js", async () => ({
+  ...(await vi.importActual<typeof import("../runtime.js")>("../runtime.js")),
+  defaultRuntime: mocks.runtime,
+  writeRuntimeJson: (runtime: typeof mocks.runtime, value: unknown, space = 2) =>
+    runtime.writeJson(value, space),
+}));
+vi.mock("../config/config.js", async () => ({
+  ...(await vi.importActual<typeof import("../config/config.js")>("../config/config.js")),
+  getRuntimeConfig: mocks.loadConfig,
+  loadConfig: mocks.loadConfig,
+  readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+}));
+vi.mock("../claws/lifecycle-state.js", async () => ({
+  ...(await vi.importActual<typeof import("../claws/lifecycle-state.js")>(
+    "../claws/lifecycle-state.js",
+  )),
+  readClawStatus: mocks.readClawStatus,
+}));
+vi.mock("../config/mcp-config.js", async () => ({
+  ...(await vi.importActual<typeof import("../config/mcp-config.js")>("../config/mcp-config.js")),
+  listConfiguredMcpServers: mocks.listConfiguredMcpServers,
+}));
+vi.mock("../claws/packages.js", async () => ({
+  ...(await vi.importActual<typeof import("../claws/packages.js")>("../claws/packages.js")),
+  preflightClawPackage: mocks.preflightClawPackage,
+}));
+vi.mock("../state/openclaw-state-db.js", async () => ({
+  ...(await vi.importActual<typeof import("../state/openclaw-state-db.js")>(
+    "../state/openclaw-state-db.js",
+  )),
+  openExistingOpenClawStateDatabaseReadOnly: mocks.openExistingOpenClawStateDatabaseReadOnly,
+}));
+vi.mock("../claws/add.js", async () => ({
+  ...(await vi.importActual<typeof import("../claws/add.js")>("../claws/add.js")),
+  applyClawAddPlan: mocks.applyClawAddPlan,
+}));
+
+const { registerClawsCli } = await import("./claws-cli.js");
+const { runClawsAddCommand, runClawsStatusCommand } = await import("./claws-cli.runtime.js");
+const { openExistingOpenClawStateDatabaseReadOnly } = await vi.importActual<
+  typeof import("../state/openclaw-state-db.js")
+>("../state/openclaw-state-db.js");
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function runAdd(source: string, options: Parameters<typeof runClawsAddCommand>[1]) {
+  try {
+    await runClawsAddCommand(source, options, mocks.runtime);
+  } catch (error) {
+    if (!(error instanceof Error && error.message.startsWith("__exit__:"))) {
+      throw error;
+    }
+  }
+}
+
+async function prepareAdoptionResume() {
+  const { root, workspace } = await cliTestHelpers.writePackageFixture(tempDirs);
+  await mkdir(workspace);
+  await writeFile(join(workspace, "AGENTS.md"), "# Demo\n", "utf8");
+  vi.stubEnv("OPENCLAW_STATE_DIR", join(tempDirs.make("openclaw-claws-adopt-resume-"), "state"));
+  mocks.loadConfig.mockReturnValue({
+    agents: { entries: { "demo-agent": { name: "Demo Agent", workspace, default: true } } },
+  });
+  await runAdd(root, { dryRun: true, workspace, adoptExistingAgent: true, json: true });
+  const plan = JSON.parse(mocks.logs[0] ?? "{}");
+  const record = persistClawInstallRecord(plan, { status: "workspace_ready", nowMs: 1 });
+  mocks.logs.length = 0;
+  mocks.runtime.exit.mockClear();
+  mocks.applyClawAddPlan.mockClear();
+  return { root, workspace, plan, record };
+}
+
+describe("claws configured-agent adoption CLI", () => {
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_EXPERIMENTAL_CLAWS", "1");
+    mocks.logs.length = 0;
+    mocks.runtime.exit.mockClear();
+    mocks.loadConfig.mockReset();
+    mocks.readConfigFileSnapshot.mockReset();
+    mocks.readConfigFileSnapshot.mockImplementation(async () => ({
+      sourceConfig: mocks.loadConfig(),
+    }));
+    mocks.listConfiguredMcpServers.mockResolvedValue({ ok: true, mcpServers: {} });
+    mocks.readClawStatus.mockReset();
+    mocks.openExistingOpenClawStateDatabaseReadOnly.mockReturnValue(undefined);
+    mocks.preflightClawPackage.mockResolvedValue({
+      ok: true,
+      action: "reuse",
+      integrity: `sha256:${"a".repeat(64)}`,
+    });
+    mocks.applyClawAddPlan.mockReset();
+    mocks.applyClawAddPlan.mockImplementation(async (plan) => ({
+      schemaVersion: "openclaw.clawAddResult.v1",
+      stability: "experimental",
+      status: "complete",
+      planIntegrity: plan.planIntegrity,
+      agent: plan.agent,
+    }));
+  });
+
+  it("registers the explicit adoption flag", () => {
+    const program = new Command();
+    registerClawsCli(program);
+    const add = program.commands
+      .find((command) => command.name() === "claws")
+      ?.commands.find((command) => command.name() === "add");
+    expect(add?.options.some((option) => option.long === "--adopt-existing-agent")).toBe(true);
+  });
+
+  it("passes the exact configured entry into adoption planning", async () => {
+    const { root, workspace, plan } = await prepareAdoptionResume();
+    expect(plan.agent.config).toMatchObject({ default: true, workspace });
+    expect(plan.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "agent", action: "adopt", blocked: false }),
+        expect.objectContaining({ kind: "workspace", action: "adopt", blocked: false }),
+      ]),
+    );
+    expect(root).toBeTruthy();
+  });
+
+  it("normalizes configured roster ids before exact adoption matching", async () => {
+    const { root, workspace } = await cliTestHelpers.writePackageFixture(tempDirs);
+    await mkdir(workspace);
+    await writeFile(join(workspace, "AGENTS.md"), "# Demo\n", "utf8");
+    mocks.loadConfig.mockReturnValue({
+      agents: { entries: { "DEMO-AGENT": { name: "Demo Agent", workspace } } },
+    });
+
+    await runAdd(root, { dryRun: true, workspace, adoptExistingAgent: true, json: true });
+
+    const plan = JSON.parse(mocks.logs[0] ?? "{}");
+    expect(plan.blockers).toEqual([]);
+    expect(plan.actions).toContainEqual(
+      expect.objectContaining({ kind: "agent", id: "demo-agent", action: "adopt" }),
+    );
+  });
+
+  it("retains the implicit main workspace in collision planning", async () => {
+    const { root } = await cliTestHelpers.writePackageFixture(tempDirs);
+    const workspace = tempDirs.make("openclaw-claws-implicit-main-");
+    mocks.loadConfig.mockReturnValue({ agents: { defaults: { workspace } } });
+
+    await runAdd(root, { dryRun: true, workspace, json: true });
+
+    const plan = JSON.parse(mocks.logs[0] ?? "{}");
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "workspace_collision", path: "$.workspace" }),
+    );
+  });
+
+  it("blocks a raw workspace spelling that only canonicalizes to the requested path", async () => {
+    const { root } = await cliTestHelpers.writePackageFixture(tempDirs);
+    const home = tempDirs.make("openclaw-claws-agent-raw-workspace-");
+    const workspace = join(home, "existing");
+    await mkdir(workspace);
+    await writeFile(join(workspace, "AGENTS.md"), "# Demo\n", "utf8");
+    vi.stubEnv("HOME", home);
+    mocks.loadConfig.mockReturnValue({
+      agents: { entries: { "demo-agent": { name: "Demo Agent", workspace } } },
+    });
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      sourceConfig: {
+        agents: { entries: { "demo-agent": { name: "Demo Agent", workspace: "~/existing" } } },
+      },
+    });
+
+    await runAdd(root, {
+      dryRun: true,
+      workspace,
+      adoptExistingAgent: true,
+      json: true,
+    });
+    const plan = JSON.parse(mocks.logs[0] ?? "{}");
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "agent_config_conflict", path: "$.agent" }),
+    );
+
+    mocks.logs.length = 0;
+    await runAdd(root, {
+      yes: true,
+      workspace,
+      adoptExistingAgent: true,
+      planIntegrity: plan.planIntegrity,
+      json: true,
+    });
+    expect(mocks.applyClawAddPlan).not.toHaveBeenCalled();
+  });
+
+  it("renders adopted ownership in text status", async () => {
+    mocks.readClawStatus.mockResolvedValue({
+      summary: { claws: 1 },
+      records: [
+        {
+          install: {
+            agentId: "demo-agent",
+            claw: { name: "@acme/demo", version: "1.0.0" },
+            status: "complete",
+          },
+          agentOrigin: "adopted",
+          agentState: "present",
+          bootstrapState: "complete",
+          workspaceFiles: [],
+          packages: [],
+        },
+      ],
+    });
+
+    await runClawsStatusCommand(undefined, {}, mocks.runtime);
+
+    expect(mocks.logs).toContain("demo-agent: @acme/demo@1.0.0 (complete; agent adopted)");
+  });
+
+  it("resumes exact v3 adoption only with the flag and recorded plan", async () => {
+    const { root, workspace, plan, record } = await prepareAdoptionResume();
+    expect(record).toMatchObject({
+      agentOrigin: "adopted",
+      schemaVersion: "openclaw.clawInstallRecord.v3",
+    });
+    await runAdd(root, {
+      yes: true,
+      workspace,
+      adoptExistingAgent: true,
+      planIntegrity: plan.planIntegrity,
+      json: true,
+    });
+    expect(mocks.applyClawAddPlan).toHaveBeenCalledWith(
+      expect.objectContaining({ planIntegrity: plan.planIntegrity, blockers: [] }),
+      expect.objectContaining({
+        resumeRecord: expect.objectContaining({ agentOrigin: "adopted" }),
+      }),
+    );
+  });
+
+  it("reconstructs a consented plugin install when an adopted add resumes after installation", async () => {
+    const { root, workspace } = await cliTestHelpers.writePackageFixture(tempDirs);
+    const manifestPath = join(root, "openclaw.claw.json");
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        ...manifest,
+        packages: [
+          {
+            kind: "plugin",
+            source: "clawhub",
+            ref: "@acme/demo-plugin",
+            version: "1.0.0",
+          },
+        ],
+      }),
+      "utf8",
+    );
+    await mkdir(workspace);
+    await writeFile(join(workspace, "AGENTS.md"), "# Demo\n", "utf8");
+    vi.stubEnv("OPENCLAW_STATE_DIR", join(tempDirs.make("openclaw-claws-plugin-resume-"), "state"));
+    mocks.loadConfig.mockReturnValue({
+      agents: { entries: { "demo-agent": { name: "Demo Agent", workspace, default: true } } },
+    });
+    const integrity = `sha256:${"b".repeat(64)}`;
+    mocks.preflightClawPackage.mockResolvedValue({ ok: true, action: "install", integrity });
+    await runAdd(root, { dryRun: true, workspace, adoptExistingAgent: true, json: true });
+    const originalPlan = JSON.parse(mocks.logs[0] ?? "{}");
+    persistClawInstallRecord(originalPlan, { status: "workspace_ready", nowMs: 1 });
+    persistClawPackageRef(
+      originalPlan,
+      {
+        kind: "plugin",
+        source: "clawhub",
+        ref: "@acme/demo-plugin",
+        version: "1.0.0",
+        integrity,
+      },
+      { nowMs: 1, origin: "claw-introduced" },
+    );
+    mocks.logs.length = 0;
+    mocks.runtime.exit.mockClear();
+    mocks.applyClawAddPlan.mockClear();
+    mocks.preflightClawPackage.mockResolvedValue({
+      ok: true,
+      action: "reuse",
+      integrity,
+      installedIntegrity: integrity,
+      installedAt: new Date(1).toISOString(),
+    });
+
+    await runAdd(root, {
+      yes: true,
+      workspace,
+      adoptExistingAgent: true,
+      planIntegrity: originalPlan.planIntegrity,
+      json: true,
+    });
+
+    expect(mocks.applyClawAddPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        planIntegrity: originalPlan.planIntegrity,
+        actions: expect.arrayContaining([
+          expect.objectContaining({
+            kind: "package",
+            action: "install",
+            details: expect.objectContaining({ ref: "@acme/demo-plugin" }),
+          }),
+        ]),
+      }),
+      expect.objectContaining({
+        resumeRecord: expect.objectContaining({ agentOrigin: "adopted" }),
+      }),
+    );
+  });
+
+  it("blocks resume without the flag or after full-config drift", async () => {
+    const first = await prepareAdoptionResume();
+    await runAdd(first.root, {
+      yes: true,
+      workspace: first.workspace,
+      planIntegrity: first.plan.planIntegrity,
+      json: true,
+    });
+    expect(mocks.applyClawAddPlan).not.toHaveBeenCalled();
+
+    closeOpenClawStateDatabaseForTest();
+    const second = await prepareAdoptionResume();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        entries: {
+          "demo-agent": { name: "Locally changed", workspace: second.workspace, default: true },
+        },
+      },
+    });
+    await runAdd(second.root, {
+      yes: true,
+      workspace: second.workspace,
+      adoptExistingAgent: true,
+      planIntegrity: second.plan.planIntegrity,
+      json: true,
+    });
+    expect(mocks.applyClawAddPlan).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "package version",
+      mutate: async (root: string) => {
+        const packagePath = join(root, "package.json");
+        const pkg = JSON.parse(await readFile(packagePath, "utf8"));
+        await writeFile(packagePath, JSON.stringify({ ...pkg, version: "1.2.4" }), "utf8");
+      },
+    },
+    {
+      name: "package integrity",
+      mutate: async (root: string) => {
+        const manifestPath = join(root, "openclaw.claw.json");
+        await writeFile(manifestPath, `${await readFile(manifestPath, "utf8")}\n`, "utf8");
+      },
+    },
+  ])("blocks a partial adopted resume after changed $name", async ({ mutate }) => {
+    const { root, workspace } = await prepareAdoptionResume();
+    closeOpenClawStateDatabaseForTest();
+    mocks.openExistingOpenClawStateDatabaseReadOnly.mockImplementation(
+      openExistingOpenClawStateDatabaseReadOnly,
+    );
+    await mutate(root);
+    mocks.logs.length = 0;
+
+    await runAdd(root, {
+      dryRun: true,
+      workspace,
+      adoptExistingAgent: true,
+      json: true,
+    });
+    const plan = JSON.parse(mocks.logs[0] ?? "{}");
+    expect(plan.blockers).toContainEqual(
+      expect.objectContaining({ code: "claw_resume_plan_mismatch" }),
+    );
+    expect(mocks.applyClawAddPlan).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/claws-cli-agent-adoption.test.ts
+++ b/src/cli/claws-cli-agent-adoption.test.ts
@@ -141,6 +141,25 @@ describe("claws configured-agent adoption CLI", () => {
     expect(add?.options.some((option) => option.long === "--adopt-existing-agent")).toBe(true);
   });
 
+  it("uses mode-neutral consent text for adoption adds", async () => {
+    const { root, workspace } = await cliTestHelpers.writePackageFixture(tempDirs);
+    await mkdir(workspace);
+    await writeFile(join(workspace, "AGENTS.md"), "# Demo\n", "utf8");
+    mocks.loadConfig.mockReturnValue({
+      agents: { entries: { "demo-agent": { name: "Demo Agent", workspace } } },
+    });
+
+    await runAdd(root, { workspace, adoptExistingAgent: true, json: true });
+
+    expect(JSON.parse(mocks.logs[0] ?? "{}")).toMatchObject({
+      ok: false,
+      error: {
+        code: "consent_required",
+        message: expect.stringContaining("apply the reviewed Claw add plan"),
+      },
+    });
+  });
+
   it("passes the exact configured entry into adoption planning", async () => {
     const { root, workspace, plan } = await prepareAdoptionResume();
     expect(plan.agent.config).toMatchObject({ default: true, workspace });

--- a/src/cli/claws-cli.plan-console.ts
+++ b/src/cli/claws-cli.plan-console.ts
@@ -1,0 +1,68 @@
+// Console rendering for experimental Claws command output: diagnostics, the experimental banner,
+// and the add-plan summary an operator consents to.
+import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ClawAddPlan } from "../claws/types.js";
+import { redactSensitiveArgv } from "../config/redact-argv.js";
+import { redactSensitiveText } from "../logging/redact.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+type DiagnosticLike = { level: string; code: string; path: string; message: string };
+
+export function formatDiagnostics(diagnostics: DiagnosticLike[]): string {
+  return diagnostics
+    .map(
+      (diagnostic) =>
+        `${diagnostic.level.toUpperCase()} ${diagnostic.code} ${diagnostic.path}: ${diagnostic.message}`,
+    )
+    .join("\n");
+}
+
+export function logExperimentalWarning(runtime: RuntimeEnv): void {
+  runtime.log("Experimental: Claws contracts may change while RFC 0016 is under review.");
+}
+
+export function logClawAddPlanSummary(plan: ClawAddPlan, runtime: RuntimeEnv): void {
+  runtime.log(`Agent: ${plan.agent.finalId}`);
+  runtime.log(`Workspace: ${plan.agent.workspace}`);
+  runtime.log(`Actions: ${plan.summary.totalActions}`);
+  runtime.log(`Packages: ${plan.summary.packageActions}`);
+  for (const action of plan.actions.filter((candidate) => candidate.kind === "package")) {
+    const requirementState =
+      typeof action.details?.requirementState === "string"
+        ? action.details.requirementState
+        : "unresolved";
+    runtime.log(
+      `  Requirement ${action.target}: ${requirementState}${action.action === "install" ? " (installation requires this exact plan consent)" : ""}`,
+    );
+  }
+  runtime.log(`MCP servers: ${plan.summary.mcpServerActions}`);
+  for (const action of plan.actions.filter((candidate) => candidate.kind === "mcpServer")) {
+    const server = asOptionalRecord(action.details);
+    const target =
+      typeof server?.url === "string"
+        ? redactSensitiveUrlLikeString(server.url)
+        : typeof server?.command === "string"
+          ? redactSensitiveArgv([
+              server.command,
+              ...(Array.isArray(server.args)
+                ? server.args.filter((arg): arg is string => typeof arg === "string")
+                : []),
+            ]).join(" ")
+          : "invalid declaration";
+    runtime.log(`  MCP ${action.id}: ${target}`);
+  }
+  runtime.log(`Cron jobs: ${plan.summary.cronJobActions}`);
+  if (plan.capabilityChanges.length > 0) {
+    runtime.log(`Capability escalations (${plan.capabilityChanges.length}):`);
+    for (const change of plan.capabilityChanges) {
+      runtime.log(
+        redactSensitiveText(`  ! ${change.kind}:${change.id} ${JSON.stringify(change.effect)}`),
+      );
+    }
+    runtime.log("The plan integrity binds every capability line above.");
+  }
+  if (plan.summary.blockedActions > 0) {
+    runtime.log(`Blocked actions: ${plan.summary.blockedActions}`);
+  }
+}

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -303,6 +303,7 @@ export async function runClawsAddCommand(
   const basePlanContext = {
     ...(opts.agentId ? { agentId: opts.agentId } : {}),
     ...(opts.workspace ? { workspace: opts.workspace } : {}),
+    ...(opts.adoptExistingWorkspace ? { adoptExistingWorkspace: true } : {}),
     existingAgentIds,
     existingWorkspacePaths,
     existingMcpServers: listedMcpServers.mcpServers,

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -1,15 +1,11 @@
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { stableStringify } from "@openclaw/normalization-core";
 import {
-  listAgentEntries,
-  listAgentIds,
-  resolveAgentWorkspaceDir,
-} from "../agents/agent-scope-config.js";
-import {
   applyClawAddPlan,
   CLAW_ADD_RESULT_SCHEMA_VERSION,
   ClawAddMutationError,
 } from "../claws/add.js";
+import * as agentAdoptionApply from "../claws/agent-adoption-apply.js";
 import {
   findClawExtensionPackageCollisions,
   planClawExtensions,
@@ -115,7 +111,11 @@ function logClawAddPlanSummary(plan: ClawAddPlan, runtime: RuntimeEnv): void {
   }
 }
 
-async function matchingResumeState(plan: ClawAddPlan, opts: ClawsAddOptions) {
+async function matchingResumeState(
+  plan: ClawAddPlan,
+  opts: ClawsAddOptions,
+  exactAdoptResumeCandidate: boolean,
+) {
   const readOnlyState = opts.dryRun
     ? await readClawResumeStateReadOnly(plan.agent.finalId)
     : undefined;
@@ -127,7 +127,8 @@ async function matchingResumeState(plan: ClawAddPlan, opts: ClawsAddOptions) {
     record.claw.kind !== plan.claw.kind ||
     record.claw.name !== plan.claw.name ||
     record.claw.version !== plan.claw.version ||
-    record.claw.integrity !== plan.claw.integrity
+    record.claw.integrity !== plan.claw.integrity ||
+    (record.agentOrigin === "adopted" && (!opts.adoptExistingAgent || !exactAdoptResumeCandidate))
   ) {
     return undefined;
   }
@@ -287,7 +288,6 @@ export async function runClawsAddCommand(
     runtime.exit(1);
     return;
   }
-
   const config = getRuntimeConfig();
   const listedMcpServers = await listConfiguredMcpServers();
   if (!listedMcpServers.ok) {
@@ -295,17 +295,26 @@ export async function runClawsAddCommand(
     runtime.exit(1);
     return;
   }
-  const existingAgentIds = listAgentIds(config);
-  const existingWorkspacePaths = existingAgentIds.map((agentId) =>
-    resolveAgentWorkspaceDir(config, agentId),
-  );
+  const { configuredAgents, existingAgents } =
+    await agentAdoptionApply.readClawPlanningAgentRoster(config);
+  const finalAgentId = opts.agentId ?? result.manifest.agent.id;
+  const targetInstallRecord = opts.dryRun
+    ? (await readClawResumeStateReadOnly(finalAgentId))?.record
+    : readClawInstallRecord(finalAgentId);
+  const exactAdoptResumeCandidate = agentAdoptionApply.isExactAdoptedAgentResumeCandidate({
+    requested: opts.adoptExistingAgent === true,
+    record: targetInstallRecord,
+    liveAgent: configuredAgents.find((agent) => agent.id === finalAgentId),
+  });
   const cronStore = await loadCronJobsStoreWithConfigJobsReadOnly(resolveCronJobsStorePath());
   const basePlanContext = {
     ...(opts.agentId ? { agentId: opts.agentId } : {}),
     ...(opts.workspace ? { workspace: opts.workspace } : {}),
     ...(opts.adoptExistingWorkspace ? { adoptExistingWorkspace: true } : {}),
-    existingAgentIds,
-    existingWorkspacePaths,
+    ...(opts.adoptExistingAgent ? { adoptExistingAgent: true } : {}),
+    existingAgents,
+    managedAgentIds:
+      targetInstallRecord && !exactAdoptResumeCandidate ? [targetInstallRecord.agentId] : [],
     existingMcpServers: listedMcpServers.mcpServers,
     existingCronJobIds: cronStore.store.jobs.map((job) => job.id),
     packagePreflight: preflightClawPackage,
@@ -332,8 +341,12 @@ export async function runClawsAddCommand(
       })
     : undefined;
   let resumableInstallRecord: PersistedClawInstall | undefined;
-  const resumeState = await matchingResumeState(legacyResumePlan ?? plan, opts);
-  if (result.legacyOpenClawProfile && !resumeState) {
+  const resumeState = await matchingResumeState(
+    legacyResumePlan ?? plan,
+    opts,
+    exactAdoptResumeCandidate,
+  );
+  if ((result.legacyOpenClawProfile || exactAdoptResumeCandidate) && !resumeState) {
     plan = {
       ...plan,
       blockers: [
@@ -371,27 +384,21 @@ export async function runClawsAddCommand(
     const expectedCommittedAgentConfigs = legacyResumePlan
       ? [legacyResumePlan.agent.config, plan.agent.config]
       : [plan.agent.config];
-    const committedAgent = listAgentEntries(config).find(
-      (agent) =>
-        agent.id === resumeRecord.agentId &&
-        expectedCommittedAgentConfigs.some(
-          (expected) => stableStringify(agent) === stableStringify(expected),
-        ),
+    const canResumeAgent = agentAdoptionApply.createdAgentMayBeAbsentDuringResume(
+      resumeRecord,
+      agentAdoptionApply.exactCommittedClawAgentExists({
+        config,
+        agentId: resumeRecord.agentId,
+        expected: expectedCommittedAgentConfigs,
+      }),
     );
-    const canResumeAgent =
-      resumeRecord.status === "config_committed" ||
-      (resumeRecord.status === "workspace_ready" && committedAgent !== undefined);
     const resumePlanContext = {
       ...basePlanContext,
       packagePreflight,
-      existingAgentIds: canResumeAgent
-        ? existingAgentIds.filter((agentId) => agentId !== resumeRecord.agentId)
-        : existingAgentIds,
-      existingWorkspacePaths: canResumeWorkspace
-        ? existingAgentIds
-            .filter((agentId) => agentId !== resumeRecord.agentId)
-            .map((agentId) => resolveAgentWorkspaceDir(config, agentId))
-        : existingWorkspacePaths,
+      existingAgents: canResumeAgent
+        ? existingAgents.filter((agent) => agent.id !== resumeRecord.agentId)
+        : existingAgents,
+      managedAgentIds: [],
       ...(canResumeWorkspace ? { resumableWorkspace: resumeRecord.workspace } : {}),
     };
     plan = await buildClawAddPlan({
@@ -544,7 +551,7 @@ export async function runClawsStatusCommand(
     runtime.log(`Installed Claws: ${status.summary.claws}`);
     for (const record of status.records) {
       runtime.log(
-        `${record.install.agentId}: ${record.install.claw.name}@${record.install.claw.version} (${record.install.status})`,
+        `${record.install.agentId}: ${record.install.claw.name}@${record.install.claw.version} (${record.install.status}; agent ${record.agentOrigin})`,
       );
       runtime.log(
         `  Agent: ${record.agentState}; bootstrap: ${record.bootstrapState}; files: ${record.workspaceFiles.length}; packages: ${record.packages.length}`,

--- a/src/cli/claws-cli.runtime.ts
+++ b/src/cli/claws-cli.runtime.ts
@@ -1,4 +1,3 @@
-import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { stableStringify } from "@openclaw/normalization-core";
 import {
   applyClawAddPlan,
@@ -46,12 +45,10 @@ import {
 // Runtime handlers for experimental local Claws commands.
 import { getRuntimeConfig } from "../config/config.js";
 import { listConfiguredMcpServers } from "../config/mcp-config.js";
-import { redactSensitiveArgv } from "../config/redact-argv.js";
 import {
   loadCronJobsStoreWithConfigJobsReadOnly,
   resolveCronJobsStorePath,
 } from "../cron/store.js";
-import { redactSensitiveText } from "../logging/redact.js";
 import { defaultRuntime, writeRuntimeJson, type RuntimeEnv } from "../runtime.js";
 import { authorizeLegacyV1Resume } from "./claws-cli-legacy-resume.js";
 import { formatClawDiagnostics, logClawExperimentalWarning } from "./claws-cli-output.js";
@@ -63,53 +60,9 @@ import type {
   ClawsRemoveOptions,
   ClawsStatusOptions,
 } from "./claws-cli.js";
+import { logClawAddPlanSummary } from "./claws-cli.plan-console.js";
 import { listCronJobsFromGateway } from "./cron-cli/list-jobs.js";
 import { callGatewayFromCli } from "./gateway-rpc.js";
-
-function logClawAddPlanSummary(plan: ClawAddPlan, runtime: RuntimeEnv): void {
-  runtime.log(`Agent: ${plan.agent.finalId}`);
-  runtime.log(`Workspace: ${plan.agent.workspace}`);
-  runtime.log(`Actions: ${plan.summary.totalActions}`);
-  runtime.log(`Packages: ${plan.summary.packageActions}`);
-  for (const action of plan.actions.filter((candidate) => candidate.kind === "package")) {
-    const requirementState =
-      typeof action.details?.requirementState === "string"
-        ? action.details.requirementState
-        : "unresolved";
-    runtime.log(
-      `  Requirement ${action.target}: ${requirementState}${action.action === "install" ? " (installation requires this exact plan consent)" : ""}`,
-    );
-  }
-  runtime.log(`MCP servers: ${plan.summary.mcpServerActions}`);
-  for (const action of plan.actions.filter((candidate) => candidate.kind === "mcpServer")) {
-    const server = action.details as Record<string, unknown> | undefined;
-    const target =
-      typeof server?.url === "string"
-        ? redactSensitiveUrlLikeString(server.url)
-        : typeof server?.command === "string"
-          ? redactSensitiveArgv([
-              server.command,
-              ...(Array.isArray(server.args)
-                ? server.args.filter((arg): arg is string => typeof arg === "string")
-                : []),
-            ]).join(" ")
-          : "invalid declaration";
-    runtime.log(`  MCP ${action.id}: ${target}`);
-  }
-  runtime.log(`Cron jobs: ${plan.summary.cronJobActions}`);
-  if (plan.capabilityChanges.length > 0) {
-    runtime.log(`Capability escalations (${plan.capabilityChanges.length}):`);
-    for (const change of plan.capabilityChanges) {
-      runtime.log(
-        redactSensitiveText(`  ! ${change.kind}:${change.id} ${JSON.stringify(change.effect)}`),
-      );
-    }
-    runtime.log("The plan integrity binds every capability line above.");
-  }
-  if (plan.summary.blockedActions > 0) {
-    runtime.log(`Blocked actions: ${plan.summary.blockedActions}`);
-  }
-}
 
 async function matchingResumeState(
   plan: ClawAddPlan,
@@ -149,7 +102,7 @@ function failNonDryRun(opts: ClawsAddOptions, runtime: RuntimeEnv): boolean {
   const code = opts.yes ? "plan_integrity_required" : "consent_required";
   const message = opts.yes
     ? "Claw add consent must include --plan-integrity from the exact dry-run plan."
-    : "Claw add requires explicit consent; pass --dry-run to preview or --yes with --plan-integrity to create the new agent and workspace.";
+    : "Claw add requires explicit consent; pass --dry-run to preview or --yes with --plan-integrity to apply the reviewed Claw add plan.";
   if (opts.json) {
     writeRuntimeJson(runtime, {
       schemaVersion: CLAW_ADD_PLAN_SCHEMA_VERSION,

--- a/src/cli/claws-cli.ts
+++ b/src/cli/claws-cli.ts
@@ -23,6 +23,7 @@ export type ClawsAddOptions = {
   json?: boolean;
   agentId?: string;
   workspace?: string;
+  adoptExistingWorkspace?: boolean;
 };
 
 export type ClawsStatusOptions = { json?: boolean };
@@ -111,13 +112,18 @@ export function registerClawsCli(program: Command) {
 
   claws
     .command("add")
-    .description("Preview adding one new agent and workspace from a Claw")
+    .description("Preview adding one agent and its workspace from a Claw")
     .argument("<source>", "Path to a Claw package directory or grouped manifest")
     .option("--dry-run", "Preview all actions without mutating state", false)
-    .option("--yes", "Confirm creation of the new agent and workspace", false)
+    .option("--yes", "Confirm creating the agent and its workspace", false)
     .option("--plan-integrity <digest>", "Bind consent to an exact dry-run plan")
     .option("--agent-id <id>", "Override the requested id with an unused local agent id")
-    .option("--workspace <path>", "Override the derived new workspace path")
+    .option("--workspace <path>", "Override the derived workspace path")
+    .option(
+      "--adopt-existing-workspace",
+      "Adopt an existing workspace directory; declared files must already match or be absent",
+      false,
+    )
     .option("--json", "Print JSON", false)
     .action(async (source: string, opts: ClawsAddOptions) => {
       const { runClawsAddCommand } = await import("./claws-cli.runtime.js");

--- a/src/cli/claws-cli.ts
+++ b/src/cli/claws-cli.ts
@@ -24,6 +24,7 @@ export type ClawsAddOptions = {
   agentId?: string;
   workspace?: string;
   adoptExistingWorkspace?: boolean;
+  adoptExistingAgent?: boolean;
 };
 
 export type ClawsStatusOptions = { json?: boolean };
@@ -122,6 +123,11 @@ export function registerClawsCli(program: Command) {
     .option(
       "--adopt-existing-workspace",
       "Adopt an existing workspace directory; declared files must already match or be absent",
+      false,
+    )
+    .option(
+      "--adopt-existing-agent",
+      "Adopt an exact existing unmanaged agent and its configured workspace",
       false,
     )
     .option("--json", "Print JSON", false)

--- a/src/cli/claws-cli.ts
+++ b/src/cli/claws-cli.ts
@@ -116,7 +116,7 @@ export function registerClawsCli(program: Command) {
     .description("Preview adding one agent and its workspace from a Claw")
     .argument("<source>", "Path to a Claw package directory or grouped manifest")
     .option("--dry-run", "Preview all actions without mutating state", false)
-    .option("--yes", "Confirm creating the agent and its workspace", false)
+    .option("--yes", "Confirm applying the reviewed Claw add plan", false)
     .option("--plan-integrity <digest>", "Bind consent to an exact dry-run plan")
     .option("--agent-id <id>", "Override the requested id with an unused local agent id")
     .option("--workspace <path>", "Override the derived workspace path")

--- a/src/gateway/server-methods/agents-config-mutations.test.ts
+++ b/src/gateway/server-methods/agents-config-mutations.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+const mocks = vi.hoisted(() => ({ config: {} as OpenClawConfig }));
+
+vi.mock("../../config/config.js", async () => ({
+  ...(await vi.importActual<typeof import("../../config/config.js")>("../../config/config.js")),
+  mutateConfigFileWithRetry: async <T>(params: {
+    mutate: (draft: OpenClawConfig) => T | Promise<T>;
+  }) => {
+    const draft = structuredClone(mocks.config);
+    const result = await params.mutate(draft);
+    mocks.config = draft;
+    return { nextConfig: draft, result };
+  },
+}));
+
+const { deleteAgentConfigEntry } = await import("./agents-config-mutations.js");
+
+describe("deleteAgentConfigEntry", () => {
+  it("validates and reports the normalized roster match that it removes", async () => {
+    mocks.config = {
+      agents: {
+        entries: {
+          WORKER: { name: "Worker", workspace: "/tmp/worker" },
+        },
+      },
+    };
+    const validate = vi.fn();
+
+    const committed = await deleteAgentConfigEntry({ agentId: "worker", validate });
+
+    expect(validate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "WORKER", name: "Worker", workspace: "/tmp/worker" }),
+    );
+    expect(committed.result).toMatchObject({ workspaceDir: "/tmp/worker" });
+    expect(committed.nextConfig.agents?.entries).toBeUndefined();
+  });
+});

--- a/src/gateway/server-methods/agents-config-mutations.ts
+++ b/src/gateway/server-methods/agents-config-mutations.ts
@@ -78,7 +78,9 @@ export async function deleteAgentConfigEntry(params: {
       if (!configured && !params.allowMissing) {
         throw new AgentConfigPreconditionError(`agent "${params.agentId}" not found`);
       }
-      const agent = listAgentEntries(draft).find((candidate) => candidate.id === params.agentId);
+      const entries = listAgentEntries(draft);
+      const agentIndex = findAgentEntryIndex(entries, params.agentId);
+      const agent = agentIndex >= 0 ? entries[agentIndex] : undefined;
       if (agent) {
         params.validate?.(agent);
       }


### PR DESCRIPTION
## Summary
- stack on #131163 to let `claws add --adopt-existing-agent` claim an already configured matching agent without rewriting its config
- persist configured-agent adoption provenance, canonical roster ownership, update/remove behavior, and release rollback for unclaimed adoption attempts
- document the adoption/export boundary in the Claws CLI docs

## Stack
- Depends on #131163 (`feat(claws): adopt existing workspaces`). Review this after #131163 lands or compare from `giodl/claws-adopt-existing-workspace-rebase`.

## Validation
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/claws/add-agent-adoption.test.ts src/claws/add-adoption-release.test.ts src/claws/lifecycle-agent-adoption.test.ts src/claws/lifecycle-agent-adopt-remove.test.ts src/claws/provenance-agent-origin.test.ts src/claws/update-apply.test.ts src/claws/update-plan.test.ts src/cli/claws-cli-agent-adoption.test.ts src/gateway/server-methods/agents-config-mutations.test.ts`
- `pnpm exec oxlint src/agents/agent-delete-safety.ts src/agents/workspace-bootstrap-seed-marker.ts src/claws/add-adoption-release.test.ts src/claws/add-adoption-release.ts src/claws/add-agent-adoption.test.ts src/claws/add-contract.ts src/claws/add-plan-helpers.ts src/claws/add-plan-integrity.ts src/claws/add.ts src/claws/adopted-agent-update.ts src/claws/agent-adoption-apply.ts src/claws/lifecycle-agent-adopt-remove.test.ts src/claws/lifecycle-agent-adoption.e2e.test.ts src/claws/lifecycle-agent-adoption.test.ts src/claws/lifecycle-agent-plan.ts src/claws/lifecycle-agent-workspace.ts src/claws/lifecycle-config-removal.ts src/claws/lifecycle-delete-support.ts src/claws/lifecycle-state.ts src/claws/lifecycle-status.ts src/claws/lifecycle.ts src/claws/provenance-agent-origin.test.ts src/claws/provenance-agent-origin.ts src/claws/provenance-schema-version.ts src/claws/provenance.test-helpers.ts src/claws/provenance.ts src/claws/tool-policy-runtime.integration.test.ts src/claws/tool-policy-runtime.ts src/claws/update-apply.test.ts src/claws/update-apply.ts src/claws/update-plan.test.ts src/claws/update-plan.ts src/cli/claws-cli-agent-adoption.test.ts src/cli/claws-cli.plan-console.ts src/cli/claws-cli.runtime.ts src/cli/claws-cli.ts src/gateway/server-methods/agents-config-mutations.test.ts src/gateway/server-methods/agents-config-mutations.ts`
- `git diff --check`
- `node scripts/check-docs-mdx.mjs docs/cli/claws.md`
