### PR TITLE
fix(code-mode): canceled timers stall automation and closed cells exhaust slots

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -562,6 +562,10 @@ QuickJS-WASI snapshot/restore is the resume mechanism:
 Snapshots are runtime state, not user artifacts: they live only in an
 in-process map (no database or disk write), are size-limited, expire, and are
 scoped to the run and session that created them.
+Canceling the owning run or tool call, or closing its tool catalog at attempt
+teardown, immediately releases parked snapshots and cancels their pending host
+work, even if no `wait` call follows. Catalog description refreshes and client
+tool additions do not close the owner.
 
 `wait` fails (as a `failed` result) when:
 
@@ -590,6 +594,8 @@ declare function yield_control(reason?: string): Promise<void>;
 ```
 
 Guest timers are bridged through the host, so they survive QuickJS snapshot/resume and remain bounded by the Code Mode execution and snapshot limits.
+`clearTimeout` also cancels a timer created before an earlier suspension; this
+applies to interactive Code Mode and headless automation scripts.
 
 Every effective non-MCP tool is also installed as an async global function.
 The model-visible `exec` description includes a bounded, deterministic subset

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -35,6 +35,7 @@ import {
   activeRuns,
   cancelPendingBridgeStates,
   cancelPendingBridgeStatesById,
+  codeModeAbortedResult,
   codeModeWaitingReason,
   createCodeModeBridgeDispatchState,
   createPendingBridgeStates,
@@ -295,16 +296,7 @@ async function settleCodeModeResult(params: {
   // rounds; maxPendingToolCalls stays a per-batch concurrency cap enforced in
   // the worker.
   const settleDeadline = () => params.deadlineMs + params.approvalWait.pausedMs;
-  const abortedResult = () => ({
-    status: "failed" as const,
-    error: "code mode execution aborted",
-    code: "aborted" as const,
-    failurePhase: params.bridgeDispatch.started ? ("bridge" as const) : ("host" as const),
-    bridgeDispatchStarted: params.bridgeDispatch.started,
-    output: output.slice(deliveredOutputCount),
-    replaySafe: params.replaySafe,
-    telemetry: telemetry(params.runtime),
-  });
+  const abortedResult = () => codeModeAbortedResult({ ...params, output, deliveredOutputCount });
   // Bridge tool calls (search/describe/call/namespace) run through the same
   // policy-checked executor whether the model awaits them one at a time or in a
   // batch, so resolve them inline within the exec deadline and resume the VM
@@ -408,6 +400,7 @@ async function settleCodeModeResult(params: {
           output,
           deliveredOutputCount,
           bridgeDispatch: params.bridgeDispatch,
+          signal: params.signal,
         });
       }
       // Deliver the settled frontier only. Unresolved sibling promises remain
@@ -524,6 +517,7 @@ async function settleCodeModeResult(params: {
           output,
           deliveredOutputCount,
           bridgeDispatch: params.bridgeDispatch,
+          signal: params.signal,
         });
       } catch (error) {
         cancelPendingBridgeStates(pending);
@@ -612,6 +606,11 @@ export async function runWait(params: {
   // pending calls, the resume worker, and the inline settle phase.
   const deadlineMs = Date.now() + state.config.timeoutMs;
   const approvalWait = observeAgentRunApprovalWait(state.ctx);
+  // Snapshot closure wakes an observing wait even if its guest budget just expired.
+  // Transfer releases this signal; worker execution keeps its normal per-call signal.
+  const parkedSignal = params.signal
+    ? AbortSignal.any([params.signal, state.ownerSignal])
+    : state.ownerSignal;
   let releaseActiveRunSlot: (() => void) | undefined;
   try {
     const ready = await waitForPending(
@@ -619,7 +618,7 @@ export async function runWait(params: {
       state.settlementMode,
       Math.max(1, deadlineMs - Date.now()),
       approvalWait,
-      params.signal,
+      parkedSignal,
     );
     const resumeBudgetMs = ready
       ? usableResumeBudgetMs(deadlineMs + approvalWait.pausedMs, state.config)
@@ -627,7 +626,7 @@ export async function runWait(params: {
     if (!ready || resumeBudgetMs === undefined) {
       // An aborted wait drops the suspended run: nothing will resume it, and
       // parking it would pin a process-global active-run slot until TTL expiry.
-      if (params.signal?.aborted) {
+      if (parkedSignal.aborted) {
         disposeCodeModeRun(state.runId);
         return {
           status: "failed" as const,

--- a/src/agents/code-mode-headless.cancellation.test.ts
+++ b/src/agents/code-mode-headless.cancellation.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { runCodeModeScriptHeadless } from "./code-mode.js";
+import {
+  createHeadlessCodeModeHarness,
+  resetCodeModeTestState,
+  testing,
+} from "./code-mode.test-support.js";
+
+describe("headless Code Mode cancellation", () => {
+  afterEach(() => {
+    try {
+      expect(testing.activeRuns.size).toBe(0);
+    } finally {
+      resetCodeModeTestState();
+    }
+  });
+
+  it("completes after canceling a guest timer across two resumes", async () => {
+    const result = await runCodeModeScriptHeadless({
+      ctx: createHeadlessCodeModeHarness(),
+      code: `
+        const timer = setTimeout(() => {}, 60_000);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        clearTimeout(timer);
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        return "done";
+      `,
+      wallClockMs: 5_000,
+    });
+
+    expect(result).toEqual({
+      status: "completed",
+      value: "done",
+      output: [],
+      toolCallCount: 0,
+    });
+  });
+
+  it("terminates an in-flight worker leg when aborted", async () => {
+    const ctx = createHeadlessCodeModeHarness();
+    const config = testing.resolveCodeModeHeadlessConfig(ctx);
+    const controller = new AbortController();
+    const resultPromise = testing.runCodeModeWorker(
+      {
+        kind: "exec",
+        source: "while (true) {}",
+        config,
+        catalog: [],
+        apiFiles: [],
+        namespaces: [],
+      },
+      5000,
+      undefined,
+      controller.signal,
+    );
+    setTimeout(() => controller.abort(), 100);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: "failed",
+      code: "aborted",
+      error: "code mode execution aborted",
+    });
+  });
+
+  it("classifies caller aborts before the worker leg as aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await runCodeModeScriptHeadless({
+      ctx: createHeadlessCodeModeHarness(),
+      code: "return true;",
+      signal: controller.signal,
+    });
+
+    expect(result).toMatchObject({
+      status: "failed",
+      code: "aborted",
+      error: "code mode execution aborted",
+    });
+  });
+});

--- a/src/agents/code-mode-headless.test.ts
+++ b/src/agents/code-mode-headless.test.ts
@@ -11,12 +11,7 @@ import { createDeferred } from "../../test/helpers/promise.js";
 import type { CodeModeNamespaceDescriptor } from "./code-mode-namespaces.js";
 import { prepareSource } from "./code-mode-runtime.js";
 import { runCodeModeScriptHeadless, type CodeModeHeadlessResult } from "./code-mode.js";
-import { testing } from "./code-mode.test-support.js";
-import {
-  createToolSearchCatalogRef,
-  registerHeadlessToolSearchCatalog,
-  type ToolSearchToolContext,
-} from "./tool-search.js";
+import { createHeadlessCodeModeHarness, testing } from "./code-mode.test-support.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
 
 function fakeTool(name: string, execute: AnyAgentTool["execute"]): AnyAgentTool {
@@ -26,26 +21,6 @@ function fakeTool(name: string, execute: AnyAgentTool["execute"]): AnyAgentTool 
     description: `Test tool ${name}`,
     parameters: { type: "object", properties: {} },
     execute: vi.fn(execute) as AnyAgentTool["execute"],
-  };
-}
-
-function createHeadlessHarness(
-  tools: AnyAgentTool[] = [],
-  options: { swarmEnabled?: boolean } = {},
-): ToolSearchToolContext {
-  const config = {
-    tools: {
-      codeMode: { enabled: false, timeoutMs: 60_000 },
-      ...(options.swarmEnabled ? { swarm: true } : {}),
-    },
-  } as never;
-  const catalogRef = createToolSearchCatalogRef();
-  registerHeadlessToolSearchCatalog({ catalogRef, tools });
-  return {
-    config,
-    runtimeConfig: config,
-    agentId: "main",
-    catalogRef,
   };
 }
 
@@ -87,7 +62,7 @@ describe("headless Code Mode", () => {
       expect(testing.activeRuns.size).toBe(0);
       return jsonResult({ input });
     });
-    const ctx = createHeadlessHarness([first, second]);
+    const ctx = createHeadlessCodeModeHarness([first, second]);
 
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
@@ -143,7 +118,7 @@ describe("headless Code Mode", () => {
 
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([first, second, release]),
+        ctx: createHeadlessCodeModeHarness([first, second, release]),
         code: `const value = await Promise.race([
             headless_first_race({}),
             headless_second_race({}),
@@ -197,7 +172,7 @@ describe("headless Code Mode", () => {
 
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([never, fast, release]),
+        ctx: createHeadlessCodeModeHarness([never, fast, release]),
         code: `const value = await Promise.race([
             Promise.all([headless_nested_race_never({})]),
             headless_nested_race_fast({}),
@@ -280,7 +255,7 @@ describe("headless Code Mode", () => {
 
       const result = expectCompleted(
         await runCodeModeScriptHeadless({
-          ctx: createHeadlessHarness([audit, fast, release]),
+          ctx: createHeadlessCodeModeHarness([audit, fast, release]),
           code: `${auditCode}
           const value = await headless_awaited_fast({});
           void headless_early_audit_release({});
@@ -341,7 +316,7 @@ describe("headless Code Mode", () => {
 
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([winner, loser, audit, release]),
+        ctx: createHeadlessCodeModeHarness([winner, loser, audit, release]),
         code: `const value = await Promise.race([
             headless_race_winner({}),
             headless_race_loser({}),
@@ -375,7 +350,7 @@ describe("headless Code Mode", () => {
 
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([first, second]),
+        ctx: createHeadlessCodeModeHarness([first, second]),
         code: `void headless_detached_first({});
           void headless_detached_second({});
           return "done";`,
@@ -427,7 +402,7 @@ describe("headless Code Mode", () => {
 
       const result = expectCompleted(
         await runCodeModeScriptHeadless({
-          ctx: createHeadlessHarness([fast, slow, release]),
+          ctx: createHeadlessCodeModeHarness([fast, slow, release]),
           code: `const value = await Promise.${combinator}([
               headless_slow({}),
               headless_fast({}),
@@ -486,7 +461,7 @@ describe("headless Code Mode", () => {
 
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([failed, slow, release]),
+        ctx: createHeadlessCodeModeHarness([failed, slow, release]),
         code: `try {
           await Promise.all([
             headless_failed({}),
@@ -520,7 +495,7 @@ describe("headless Code Mode", () => {
   it("does not expose collector globals without resumable snapshot state", async () => {
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([], { swarmEnabled: true }),
+        ctx: createHeadlessCodeModeHarness([], { swarmEnabled: true }),
         code: "return [typeof agents, typeof phase, typeof log];",
       }),
     );
@@ -571,14 +546,14 @@ describe("headless Code Mode", () => {
     "preserves harmless $name in headless source validation",
     async ({ code, value, realHeadless }) => {
       if (!realHeadless) {
-        const ctx = createHeadlessHarness();
+        const ctx = createHeadlessCodeModeHarness();
         const config = testing.resolveCodeModeHeadlessConfig(ctx);
         await expect(prepareSource({ code, config })).resolves.toBe(code);
         return;
       }
       const result = expectCompleted(
         await runCodeModeScriptHeadless({
-          ctx: createHeadlessHarness(),
+          ctx: createHeadlessCodeModeHarness(),
           code,
         }),
       );
@@ -591,7 +566,7 @@ describe("headless Code Mode", () => {
   it("executes module-shaped regular expressions in a TypeScript headless guest", async () => {
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness(),
+        ctx: createHeadlessCodeModeHarness(),
         language: "typescript",
         code: 'const value: number = 1; return /import.meta/.test("import.meta");',
       }),
@@ -627,7 +602,7 @@ describe("headless Code Mode", () => {
   ])("rejects executable module access in a headless guest: %s", async (code) => {
     const result = expectFailed(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness(),
+        ctx: createHeadlessCodeModeHarness(),
         code,
       }),
     );
@@ -642,7 +617,7 @@ describe("headless Code Mode", () => {
     async (moduleAccess) => {
       const result = expectFailed(
         await runCodeModeScriptHeadless({
-          ctx: createHeadlessHarness(),
+          ctx: createHeadlessCodeModeHarness(),
           language: "typescript",
           code: `const padding: string = "${"😀".repeat(96)}"; return ${moduleAccess};`,
         }),
@@ -657,7 +632,7 @@ describe("headless Code Mode", () => {
   it("injects deeply frozen trigger state and emits replacement state through json", async () => {
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness(),
+        ctx: createHeadlessCodeModeHarness(),
         code: `
           json({
             fire: true,
@@ -700,7 +675,7 @@ describe("headless Code Mode", () => {
 
   it("keeps an injected namespace while calling a colliding tool by its advertised global", async () => {
     const tool = fakeTool("trigger", async () => jsonResult({ owner: "tool" }));
-    const ctx = createHeadlessHarness([tool]);
+    const ctx = createHeadlessCodeModeHarness([tool]);
     const extraNamespaces: CodeModeNamespaceDescriptor[] = [
       {
         id: "cron:trigger",
@@ -744,7 +719,7 @@ describe("headless Code Mode", () => {
   it("rejects colliding injected namespace globals", async () => {
     const result = expectFailed(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness(),
+        ctx: createHeadlessCodeModeHarness(),
         code: "return true;",
         extraNamespaces: [
           {
@@ -769,7 +744,7 @@ describe("headless Code Mode", () => {
     const tool = fakeTool("budgeted", async () => jsonResult({ ok: true }));
     const result = expectFailed(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([tool]),
+        ctx: createHeadlessCodeModeHarness([tool]),
         code: `
           await budgeted({});
           await budgeted({});
@@ -790,7 +765,7 @@ describe("headless Code Mode", () => {
 
     const result = expectFailed(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([nodesTool]),
+        ctx: createHeadlessCodeModeHarness([nodesTool]),
         code: `
           await nodes.list();
           await nodes.list();
@@ -809,7 +784,7 @@ describe("headless Code Mode", () => {
   it("fails an awaiting promise without bridge work before resuming a worker", async () => {
     const result = expectFailed(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness(),
+        ctx: createHeadlessCodeModeHarness(),
         code: "await new Promise(() => {}); return true;",
         wallClockMs: 5_000,
       }),
@@ -825,7 +800,7 @@ describe("headless Code Mode", () => {
 
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([tool]),
+        ctx: createHeadlessCodeModeHarness([tool]),
         code: `
           text("x".repeat(700));
           await output_boundary({});
@@ -847,7 +822,7 @@ describe("headless Code Mode", () => {
     const tool = fakeTool("budgeted", async () => jsonResult({ ok: true }));
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness([tool]),
+        ctx: createHeadlessCodeModeHarness([tool]),
         code: `
           const calls = Array.from({ length: 129 }, () => () =>
             budgeted({}),
@@ -887,7 +862,7 @@ describe("headless Code Mode", () => {
       return jsonResult({ ok: true });
     });
     const resultPromise = runCodeModeScriptHeadless({
-      ctx: createHeadlessHarness([slow]),
+      ctx: createHeadlessCodeModeHarness([slow]),
       code: `
         await slow_leg({});
         return true;
@@ -915,7 +890,7 @@ describe("headless Code Mode", () => {
       return jsonResult({ ok: true });
     });
     const resultPromise = runCodeModeScriptHeadless({
-      ctx: createHeadlessHarness([slow]),
+      ctx: createHeadlessCodeModeHarness([slow]),
       code: `
         await slow_leg({});
         return true;
@@ -940,7 +915,7 @@ describe("headless Code Mode", () => {
   it("settles yield_control inline and resumes to completion", async () => {
     const result = expectCompleted(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness(),
+        ctx: createHeadlessCodeModeHarness(),
         code: `
           const yielded = await yield_control("pause");
           return { yielded, resumed: true };
@@ -955,56 +930,12 @@ describe("headless Code Mode", () => {
     expect(result.toolCallCount).toBe(0);
   });
 
-  it("terminates an in-flight worker leg when aborted", async () => {
-    const ctx = createHeadlessHarness();
-    const config = testing.resolveCodeModeHeadlessConfig(ctx);
-    const controller = new AbortController();
-    const resultPromise = testing.runCodeModeWorker(
-      {
-        kind: "exec",
-        source: "while (true) {}",
-        config,
-        catalog: [],
-        apiFiles: [],
-        namespaces: [],
-      },
-      5000,
-      undefined,
-      controller.signal,
-    );
-    setTimeout(() => controller.abort(), 100);
-
-    await expect(resultPromise).resolves.toMatchObject({
-      status: "failed",
-      code: "aborted",
-      error: "code mode execution aborted",
-    });
-  });
-
-  it("classifies caller aborts before the worker leg as aborted", async () => {
-    const controller = new AbortController();
-    controller.abort();
-
-    const result = expectFailed(
-      await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness(),
-        code: "return true;",
-        signal: controller.signal,
-      }),
-    );
-
-    expect(result).toMatchObject({
-      code: "aborted",
-      error: "code mode execution aborted",
-    });
-  });
-
   it("times out an unfinished headless TypeScript runtime load", async () => {
     loadCodeModeTypeScriptRuntime.mockReturnValue(new Promise(() => {}));
 
     const result = expectFailed(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness(),
+        ctx: createHeadlessCodeModeHarness(),
         language: "typescript",
         code: "return 42;",
         wallClockMs: 25,
@@ -1023,7 +954,7 @@ describe("headless Code Mode", () => {
     loadCodeModeTypeScriptRuntime.mockReturnValue(new Promise(() => {}));
     const controller = new AbortController();
     const resultPromise = runCodeModeScriptHeadless({
-      ctx: createHeadlessHarness(),
+      ctx: createHeadlessCodeModeHarness(),
       language: "typescript",
       code: "return 42;",
       signal: controller.signal,
@@ -1040,7 +971,7 @@ describe("headless Code Mode", () => {
   });
 
   it("keeps worker-leg wall-clock expiry classified as timeout", async () => {
-    const ctx = createHeadlessHarness();
+    const ctx = createHeadlessCodeModeHarness();
     expectCompleted(await runCodeModeScriptHeadless({ ctx, code: "return true;" }));
 
     const result = expectFailed(
@@ -1058,7 +989,7 @@ describe("headless Code Mode", () => {
   it("classifies syntax errors", async () => {
     const result = expectFailed(
       await runCodeModeScriptHeadless({
-        ctx: createHeadlessHarness(),
+        ctx: createHeadlessCodeModeHarness(),
         code: "return (;",
       }),
     );
@@ -1067,7 +998,7 @@ describe("headless Code Mode", () => {
   });
 
   it("clamps headless limit overrides to worker-safe bounds", () => {
-    const config = testing.resolveCodeModeHeadlessConfig(createHeadlessHarness(), {
+    const config = testing.resolveCodeModeHeadlessConfig(createHeadlessCodeModeHarness(), {
       timeoutMs: 1,
       memoryLimitBytes: 1,
       maxOutputBytes: 1,

--- a/src/agents/code-mode-headless.ts
+++ b/src/agents/code-mode-headless.ts
@@ -30,6 +30,7 @@ import {
 } from "./code-mode-runtime.js";
 import {
   cancelPendingBridgeStates,
+  cancelPendingBridgeStatesById,
   createCodeModeBridgeDispatchState,
   createPendingBridgeStates,
   pendingBridgeStatesForSettlement,
@@ -283,6 +284,7 @@ export async function runCodeModeScriptHeadless(params: {
       }
 
       enforceSnapshotPayloadLimits({ snapshotBytes: result.snapshotBytes, config });
+      cancelPendingBridgeStatesById(pending, result.canceledRequestIds);
       const pendingIds = new Set(pending.map((entry) => entry.id));
       const newRequests = result.pendingRequests.filter((request) => !pendingIds.has(request.id));
       // Node discovery invokes the generic nodes tool for live status too;

--- a/src/agents/code-mode-state.ts
+++ b/src/agents/code-mode-state.ts
@@ -52,6 +52,8 @@ type CodeModeRunState = {
   catalogProjection: CodeModeCatalogProjection;
   namespaceRuntime: CodeModeNamespaceRuntime;
   bridgeDispatch: CodeModeBridgeDispatchState;
+  ownerSignal: AbortSignal;
+  releaseOwner: () => void;
 };
 
 const MAX_ACTIVE_CODE_MODE_RUNS = 64;
@@ -120,15 +122,19 @@ export function removeExpiredRuns(now = Date.now()): void {
 
 export function disposeCodeModeRun(runId: string): void {
   const state = activeRuns.get(runId);
-  cancelPendingBridgeStates(state?.pending ?? []);
   activeRuns.delete(runId);
+  state?.releaseOwner();
+  cancelPendingBridgeStates(state?.pending ?? []);
   resumingRunIds.delete(runId);
   scheduleActiveRunExpiry();
 }
 
 /** Cancel suspended bridge work before its Gateway-owned runtimes disappear. */
 export function disposeAllCodeModeRuns(): void {
-  activeRuns.forEach((state) => cancelPendingBridgeStates(state.pending));
+  activeRuns.forEach((state) => {
+    state.releaseOwner();
+    cancelPendingBridgeStates(state.pending);
+  });
   activeRuns.clear();
   resumingRunIds.clear();
   scheduleActiveRunExpiry();
@@ -221,8 +227,13 @@ function enforceActiveRunLimit(): void {
 export function reserveActiveRunSlot(ownedRunId?: string): () => void {
   if (ownedRunId === undefined) {
     enforceActiveRunLimit();
-  } else if (!activeRuns.delete(ownedRunId)) {
-    throw new ToolInputError("code mode run is unavailable or expired.");
+  } else {
+    const state = activeRuns.get(ownedRunId);
+    if (!state) {
+      throw new ToolInputError("code mode run is unavailable or expired.");
+    }
+    activeRuns.delete(ownedRunId);
+    state.releaseOwner();
   }
   // Resume transfers an existing slot without exposing a free capacity window
   // to concurrent exec calls or rejecting its own run at the global limit.
@@ -443,7 +454,19 @@ export function storeSnapshotState(params: {
   output: unknown[];
   deliveredOutputCount?: number;
   bridgeDispatch: CodeModeBridgeDispatchState;
+  signal?: AbortSignal;
 }) {
+  const catalogRef = params.ctx.catalogRef;
+  const closed = new AbortController();
+  const ownerSignal = AbortSignal.any(
+    [params.signal, params.ctx.abortSignal, closed.signal].filter(
+      (signal): signal is AbortSignal => signal !== undefined,
+    ),
+  );
+  if (!catalogRef?.current || ownerSignal.aborted) {
+    cancelPendingBridgeStates(params.pending);
+    return codeModeAbortedResult(params);
+  }
   const now = Date.now();
   const expiresAt = resolveCodeModeSnapshotExpiresAt(now, params.config.snapshotTtlSeconds);
   if (expiresAt === undefined) {
@@ -458,7 +481,15 @@ export function storeSnapshotState(params: {
         params.config.snapshotTtlSeconds * MAX_AGENT_WAIT_SNAPSHOT_TTL_WINDOWS,
       )
     : undefined;
-  activeRuns.set(params.runId, {
+  const disposers = (catalogRef.onDispose ??= new Set());
+  const onClose = () => {
+    // A transferred snapshot may reuse this cell id; stale observers own only
+    // the exact parked state they subscribed for, never its replacement.
+    if (activeRuns.get(params.runId) === state) {
+      disposeCodeModeRun(params.runId);
+    }
+  };
+  const state: CodeModeRunState = {
     runId: params.runId,
     replayId: params.replayId,
     parentToolCallId: params.parentToolCallId,
@@ -476,7 +507,16 @@ export function storeSnapshotState(params: {
     catalogProjection: params.catalogProjection,
     namespaceRuntime: params.namespaceRuntime,
     bridgeDispatch: params.bridgeDispatch,
-  });
+    ownerSignal,
+    releaseOwner: () => {
+      disposers.delete(onClose);
+      ownerSignal.removeEventListener("abort", onClose);
+      closed.abort();
+    },
+  };
+  activeRuns.set(params.runId, state);
+  disposers.add(onClose);
+  ownerSignal.addEventListener("abort", onClose, { once: true });
   scheduleActiveRunExpiry();
   return {
     status: "waiting" as const,
@@ -485,6 +525,25 @@ export function storeSnapshotState(params: {
     pendingToolCalls: pendingToolCalls(params.pending),
     replaySafe: params.replaySafe,
     output: params.output.slice(params.deliveredOutputCount ?? 0),
+    telemetry: telemetry(params.runtime),
+  };
+}
+
+export function codeModeAbortedResult(params: {
+  bridgeDispatch: CodeModeBridgeDispatchState;
+  output: unknown[];
+  deliveredOutputCount?: number;
+  replaySafe: boolean;
+  runtime: ToolSearchRuntime;
+}) {
+  return {
+    status: "failed" as const,
+    error: "code mode execution aborted",
+    code: "aborted" as const,
+    failurePhase: params.bridgeDispatch.started ? ("bridge" as const) : ("host" as const),
+    bridgeDispatchStarted: params.bridgeDispatch.started,
+    output: params.output.slice(params.deliveredOutputCount ?? 0),
+    replaySafe: params.replaySafe,
     telemetry: telemetry(params.runtime),
   };
 }

--- a/src/agents/code-mode-swarm.test.ts
+++ b/src/agents/code-mode-swarm.test.ts
@@ -494,6 +494,7 @@ describe("Code Mode swarm host bridge", () => {
   it("renews expired snapshots while agentWait remains pending", () => {
     const now = 10_000;
     testing.activeRuns.set("cm-pending-agent", {
+      releaseOwner: () => undefined,
       config: { ...config, snapshotTtlSeconds: 60 },
       expiresAt: now - 1,
       agentWaitRetainUntil: now + 120_000,
@@ -516,6 +517,7 @@ describe("Code Mode swarm host bridge", () => {
     const now = 10_000;
     const cancel = vi.fn();
     testing.activeRuns.set("cm-expired-agent", {
+      releaseOwner: () => undefined,
       config: { ...config, snapshotTtlSeconds: 60 },
       expiresAt: now - 1,
       agentWaitRetainUntil: now - 1,

--- a/src/agents/code-mode.bridge.lifecycle.test.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test.ts
@@ -1,12 +1,18 @@
 /** Subscribed embedded tool lifecycles, including real QuickJS bridge coverage. */
+import { getEventListeners } from "node:events";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { createDiagnosticEmbeddedRunOwner } from "../logging/diagnostic-run-activity.js";
 import { buildExecApprovalPendingToolResult } from "./bash-tools.exec-host-shared.js";
 import { disposeAllCodeModeRuns } from "./code-mode-state.js";
-import { applyCodeModeCatalog, createCodeModeTools } from "./code-mode.js";
 import {
+  addClientToolsToCodeModeCatalog,
+  applyCodeModeCatalog,
+  createCodeModeTools,
+} from "./code-mode.js";
+import {
+  fakeTool,
   pluginToolWithExecute,
   resetCodeModeTestState,
   resultDetails,
@@ -21,7 +27,7 @@ import {
   emitAssistantTextDeltaAndEnd,
 } from "./embedded-agent-subscribe.e2e-harness.js";
 import { countActiveToolExecutions } from "./embedded-agent-subscribe.handlers.tools.js";
-import { createToolSearchCatalogRef } from "./tool-search.js";
+import { clearToolSearchCatalog, createToolSearchCatalogRef } from "./tool-search.js";
 import { jsonResult } from "./tools/common.js";
 
 function createSubscribedCodeModeHarness(params: {
@@ -330,6 +336,228 @@ describe("Code Mode subscribed bridge lifecycle", () => {
       expect(testing.activeRuns.size).toBe(0);
     } finally {
       harness.dispose();
+    }
+  });
+
+  it.each(["context", "tool", "catalog"] as const)(
+    "releases only the parked owner after %s abort without wait",
+    async (signalSource) => {
+      const owner = createSubscribedCodeModeHarness({ name: `parked-${signalSource}` });
+      const survivor = createSubscribedCodeModeHarness({ name: `survivor-${signalSource}` });
+      const toolAbortController = new AbortController();
+      const controller =
+        signalSource === "context" ? owner.runAbortController : toolAbortController;
+      const code = 'setTimeout(() => {}, 60_000); await yield_control("pause"); return "done";';
+      applyCodeModeCatalog(owner);
+      applyCodeModeCatalog(survivor);
+
+      try {
+        const parked = resultDetails(
+          await expectDefined(owner.tools[0], "owner exec").execute(
+            "code-call-parked",
+            { code },
+            signalSource === "tool" ? toolAbortController.signal : undefined,
+          ),
+        );
+        const other = resultDetails(
+          await expectDefined(survivor.tools[0], "survivor exec").execute("code-call-survivor", {
+            code,
+          }),
+        );
+        for (const result of [parked, other]) {
+          expect(result).toMatchObject({ status: "waiting", runId: expect.any(String) });
+        }
+        const ownerId = parked.runId as string;
+        const survivorId = other.runId as string;
+        const ownerState = expectDefined(testing.activeRuns.get(ownerId), "parked owner snapshot");
+        const survivorState = expectDefined(
+          testing.activeRuns.get(survivorId),
+          "survivor snapshot",
+        );
+        const pending = expectDefined(
+          ownerState.pending.find((entry) => entry.method === "sleep"),
+          "owner timer",
+        );
+        const otherPending = expectDefined(
+          survivorState.pending.find((entry) => entry.method === "sleep"),
+          "survivor timer",
+        );
+        expect(pending.settled).toBeUndefined();
+        expect(otherPending.settled).toBeUndefined();
+        expect(ownerState.snapshotBytes.byteLength).toBeGreaterThan(0);
+        expect(testing.resumingRunIds.size).toBe(0);
+
+        // Both exec calls have returned; no wait is in flight to perform owner cleanup.
+        if (signalSource === "catalog") {
+          clearToolSearchCatalog(owner);
+        } else {
+          controller.abort(new Error("parked owner closed"));
+        }
+        expect([...testing.activeRuns.keys()]).toEqual([survivorId]);
+        await expect(pending.promise).resolves.toMatchObject({ id: pending.id, ok: false });
+        expect(testing.activeRuns.get(survivorId)).toBe(survivorState);
+        expect(otherPending.settled).toBeUndefined();
+      } finally {
+        owner.dispose();
+        survivor.dispose();
+      }
+    },
+  );
+
+  it.each(["complete", "context", "tool", "catalog"] as const)(
+    "transfers parked ownership across refresh and repeated resumes before %s",
+    async (close) => {
+      const owner = createSubscribedCodeModeHarness({ name: `transfer-${close}` });
+      applyCodeModeCatalog(owner);
+      const exec = expectDefined(owner.tools[0], "owner exec");
+      const wait = expectDefined(owner.tools[1], "owner wait");
+      let controller = new AbortController();
+      try {
+        let result = resultDetails(
+          await exec.execute(
+            "transfer-exec",
+            {
+              code: `const timer = setTimeout(() => {}, 60_000);
+                await yield_control("first");
+                await yield_control("second");
+                await yield_control("third");
+                clearTimeout(timer);
+                return "done";`,
+            },
+            controller.signal,
+          ),
+        );
+        expect(result.status).toBe("waiting");
+        const runId = result.runId as string;
+        const initial = expectDefined(testing.activeRuns.get(runId), "initial snapshot");
+        expect(applyCodeModeCatalog(owner).catalogReused).toBe(true);
+        addClientToolsToCodeModeCatalog({
+          ...owner,
+          tools: [fakeTool("client_probe", "Client probe")],
+        });
+        expect(testing.activeRuns.get(runId)).toBe(initial);
+        expect(exec.description).toContain("client_probe");
+
+        for (let index = 0; index < 2; index += 1) {
+          const previous = expectDefined(testing.activeRuns.get(runId), "previous snapshot");
+          const staleClose = expectDefined(
+            owner.catalogRef.onDispose?.values().next().value,
+            "parked owner subscription",
+          );
+          controller = new AbortController();
+          result = resultDetails(
+            await wait.execute(`transfer-wait-${index}`, { runId }, controller.signal),
+          );
+          expect(result).toMatchObject({ status: "waiting", runId });
+          const replacement = expectDefined(testing.activeRuns.get(runId), "replacement snapshot");
+          expect(replacement).not.toBe(previous);
+          staleClose();
+          expect(testing.activeRuns.get(runId)).toBe(replacement);
+          expect(getEventListeners(previous.ownerSignal, "abort")).toHaveLength(0);
+          expect(previous.ownerSignal.aborted).toBe(true);
+          expect(getEventListeners(replacement.ownerSignal, "abort")).toHaveLength(1);
+          expect(owner.catalogRef.onDispose?.size).toBe(1);
+        }
+
+        const finalState = expectDefined(testing.activeRuns.get(runId), "final snapshot");
+        const pending = finalState.pending;
+        if (close === "complete") {
+          expect(resultDetails(await wait.execute("transfer-complete", { runId }))).toMatchObject({
+            status: "completed",
+            value: "done",
+          });
+        } else if (close === "catalog") {
+          clearToolSearchCatalog(owner);
+        } else {
+          (close === "context" ? owner.runAbortController : controller).abort();
+        }
+        expect(testing.activeRuns.size).toBe(0);
+        expect(testing.resumingRunIds.size).toBe(0);
+        await Promise.all(pending.map((entry) => entry.promise));
+        expect(getEventListeners(finalState.ownerSignal, "abort")).toHaveLength(0);
+        expect(finalState.ownerSignal.aborted).toBe(true);
+        expect(owner.catalogRef.onDispose?.size ?? 0).toBe(0);
+      } finally {
+        clearToolSearchCatalog(owner);
+        owner.dispose();
+      }
+    },
+  );
+
+  it.each(["exec", "wait"] as const)(
+    "does not publish a snapshot after its catalog closes during %s",
+    async (phase) => {
+      const owner = createSubscribedCodeModeHarness({ name: `close-during-${phase}` });
+      const closeOwner = pluginToolWithExecute("close_owner", "Close the run catalog", async () => {
+        clearToolSearchCatalog(owner);
+        return jsonResult({ closed: true });
+      });
+      applyCodeModeCatalog({ ...owner, tools: [...owner.tools, closeOwner] });
+      try {
+        const execute = () =>
+          expectDefined(owner.tools[0], "owner exec").execute("close-during-exec", {
+            code: `${phase === "wait" ? 'await yield_control("initial");' : ""}
+            await close_owner({});
+            await yield_control("closed");
+            return "unreachable";`,
+          });
+        let completion;
+        if (phase === "wait") {
+          const parked = resultDetails(await execute());
+          expect(parked.status).toBe("waiting");
+          completion = expectDefined(owner.tools[1], "owner wait").execute("close-during-wait", {
+            runId: parked.runId,
+          });
+        } else {
+          completion = execute();
+        }
+        await expect(completion).rejects.toThrow(
+          "Tool Search catalog is unavailable for this run.",
+        );
+        expect(closeOwner.execute).toHaveBeenCalledOnce();
+        expect(testing.activeRuns.size).toBe(0);
+        expect(testing.resumingRunIds.size).toBe(0);
+        expect(countActiveToolExecutions(owner.runId)).toBe(0);
+      } finally {
+        clearToolSearchCatalog(owner);
+        owner.dispose();
+      }
+    },
+  );
+
+  it("does not return a closed snapshot when owner abort races the wait deadline", async () => {
+    vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
+    const owner = createSubscribedCodeModeHarness({
+      name: "abort-wait-deadline",
+      timeoutMs: 1_500,
+    });
+    const started = createDeferred();
+    const stalled = pluginToolWithExecute("stalled", "Await cancellation", async () => {
+      started.resolve();
+      return await new Promise<never>(() => {});
+    });
+    applyCodeModeCatalog({ ...owner, tools: [...owner.tools, stalled] });
+    try {
+      const execution = expectDefined(owner.tools[0], "owner exec").execute("deadline-exec", {
+        code: "return await stalled({});",
+      });
+      await started.promise;
+      await vi.advanceTimersByTimeAsync(1_500);
+      const parked = resultDetails(await execution);
+      expect(parked.status).toBe("waiting");
+      const waiting = expectDefined(owner.tools[1], "owner wait").execute("deadline-wait", {
+        runId: parked.runId,
+      });
+      vi.advanceTimersByTime(1_499);
+      owner.runAbortController.abort();
+      expect(resultDetails(await waiting)).toMatchObject({ status: "failed", code: "aborted" });
+      expect(testing.activeRuns.size).toBe(0);
+      expect(testing.resumingRunIds.size).toBe(0);
+      expect(countActiveToolExecutions(owner.runId)).toBe(0);
+    } finally {
+      clearToolSearchCatalog(owner);
+      owner.dispose();
+      vi.useRealTimers();
     }
   });
 

--- a/src/agents/code-mode.test-support.ts
+++ b/src/agents/code-mode.test-support.ts
@@ -11,7 +11,12 @@ import {
 } from "./code-mode-state.js";
 import { normalizeCodeModeWorkerResult, runCodeModeWorker } from "./code-mode-worker.js";
 import { createCodeModeTools } from "./code-mode.js";
-import { createToolSearchCatalogRef, type ToolSearchCatalogRef } from "./tool-search.js";
+import {
+  createToolSearchCatalogRef,
+  registerHeadlessToolSearchCatalog,
+  type ToolSearchCatalogRef,
+  type ToolSearchToolContext,
+} from "./tool-search.js";
 import { jsonResult, type AnyAgentTool } from "./tools/common.js";
 
 export const testing = {
@@ -113,6 +118,26 @@ export function resultDetails(result: { details?: unknown }): Record<string, unk
   expect(result.details).toBeDefined();
   expect(typeof result.details).toBe("object");
   return result.details as Record<string, unknown>;
+}
+
+export function createHeadlessCodeModeHarness(
+  tools: AnyAgentTool[] = [],
+  options: { swarmEnabled?: boolean } = {},
+): ToolSearchToolContext {
+  const config = {
+    tools: {
+      codeMode: { enabled: false, timeoutMs: 60_000 },
+      ...(options.swarmEnabled ? { swarm: true } : {}),
+    },
+  } as never;
+  const catalogRef = createToolSearchCatalogRef();
+  registerHeadlessToolSearchCatalog({ catalogRef, tools });
+  return {
+    config,
+    runtimeConfig: config,
+    agentId: "main",
+    catalogRef,
+  };
 }
 
 export function createCodeModeHarness(

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -324,9 +324,10 @@ export function applyCodeModeCatalog(params: {
   const catalogRef = params.catalogRef;
   const execTool = compacted.tools.find((tool) => tool.name === CODE_MODE_EXEC_TOOL_NAME);
   if (catalogRef?.current && execTool) {
-    catalogRef.onDispose?.();
+    // Refreshing descriptions replaces their observer, not the catalog's parked consumers.
+    catalogRef.disposeObserver?.();
     const descriptionUpdater = createCodeModeExecDescriptionUpdater(execTool);
-    catalogRef.onDispose = descriptionUpdater.dispose;
+    catalogRef.disposeObserver = descriptionUpdater.dispose;
     catalogRef.onChange = () => {
       descriptionUpdater.update(
         createCodeModeExecDescription(

--- a/src/agents/code-mode.wait.test.ts
+++ b/src/agents/code-mode.wait.test.ts
@@ -538,6 +538,7 @@ describe("Code Mode wait, scope, and suspended runs", () => {
     const { tools: codeModeTools } = createCodeModeHarness();
     testing.activeRuns.set("invalid-expiry-run", {
       expiresAt: 8_640_000_000_000_001,
+      releaseOwner: () => undefined,
     } as never);
 
     await expect(

--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -334,9 +334,11 @@ export function clearToolSearchCatalog(params: {
   catalogRef?: ToolSearchCatalogRef;
 }): void {
   if (params.catalogRef) {
-    params.catalogRef.onDispose?.();
     params.catalogRef.current = undefined;
+    params.catalogRef.disposeObserver?.();
+    params.catalogRef.onDispose?.forEach((dispose) => dispose());
     delete params.catalogRef.onChange;
+    delete params.catalogRef.disposeObserver;
     delete params.catalogRef.onDispose;
   }
   if (!params.runId?.trim()) {

--- a/src/agents/tool-search-types.ts
+++ b/src/agents/tool-search-types.ts
@@ -132,7 +132,8 @@ export type ToolSearchCatalogSession = {
 export type ToolSearchCatalogRef = {
   current?: ToolSearchCatalogSession;
   onChange?: () => void;
-  onDispose?: () => void;
+  disposeObserver?: () => void;
+  onDispose?: Set<() => void>;
 };
 
 export type CodeModeBridgeMethod = "search" | "describe" | "call";


### PR DESCRIPTION
Closes #131112
Closes #131124

AI-assisted implementation and validation. Maintainers can edit this same-repository branch.

## What Problem This Solves

Fixes an issue where users running Code Mode automation scripts would hit their deadline after canceling a timer across awaits, even though the guest program had completed. Also fixes canceled agent runs retaining parked Code Mode cells until expiry: after enough abandoned cells, unrelated runs could fail with `too many suspended code mode runs.`

The second failure depends on order: `exec` returns `waiting`, the owning chat is aborted, and no `wait` is called. Canceling host work alone did not release the parked execution slot.

## Why This Change Was Made

Headless execution now consumes the worker's canceled request IDs using the same reconciliation helper as interactive execution. Parked VM snapshots now belong to their exact context/tool/catalog owner, with subscriptions released on transfer and disposal. Catalog description-observer replacement is separated from real catalog teardown, so refresh and client-tool append do not kill valid cells.

This repairs ownership at snapshot publication rather than increasing capacity, shortening TTL, retrying, or compensating in a downstream consumer. A stale snapshot callback cannot delete a replacement with the same cell ID. Parked waits observe owner closure at their deadline, while worker execution retains the existing initiating `sessions_yield` handoff semantics. Existing reservation accounting, unrelated owners, metadata-only recovery/mutation controls, and destroyed-catalog exception presentation remain intact.

Production LOC: **+86/-22 (net +64)**. Tests/support: **+371/-103 (net +268, including moved existing tests and a shared fixture)**. Docs: **+6**. Growth supplies the missing transferable snapshot-owner binding and distinguishes actual catalog close from description refresh; existing cancellation, expiry, reservation and disposal primitives are reused, and duplicate aborted-result construction is removed. No configuration, schema, protocol, dependency, timeout, or capacity change.

## User Impact

Canceled guest timers no longer keep headless automation draining stale work. Aborted or normally closed owners release their parked cells promptly, allowing subsequent runs to allocate and resume without waiting for the default 900-second TTL. Valid refreshes and repeated resumes remain usable.

This concerns OpenClaw's QuickJS-WASI Code Mode, not native Codex's separate V8 runtime. Stable-release reachability has not been established; this PR does not claim a particular stable release is affected. Release-note context is contained here; no changelog edit is included.

## Evidence

### Failing before, passing after

On unchanged pre-fix production, the saved real-QuickJS timer regression failed at the original five-second limit with zero tool calls, and both no-wait context/tool-abort regressions retained the canceled owner's snapshot. Additional catalog-close and publication/deadline cases also failed before the repair. The same cases now pass, including unrelated-owner preservation, two resumes, stale callback rejection, subscription cleanup, normal catalog teardown, and initiating `sessions_yield` completion.

**370 tests in 15 files passed through normal routing**: 15 tests/two files in unit-fast-isolated, 350/11 in agents-core, and 5/two in embedded-agent-run; 136.83 seconds. The new cancellation file was included, not an empty shard. The complete changed-file gate and frozen build passed. Independent structured P0/P1 autoreview reported no accepted/actionable findings; the reviewer did not run tests and reviewed the supplied bundle, so runtime proof comes from the separate runs below. All 13 source hashes stayed unchanged across review, tests, build and real-flow proof.

An initial validation attempt lacked the already-declared jsdom types. Restoring the frozen-lockfile dependencies and forcing the unchanged UI typecheck cleared stale incremental results; the complete changed gate then passed without UI, manifest, or lockfile edits. The installer printed Done but remained alive after other-platform fetch warnings and was stopped after the restored tree was verified; a clean installer exit is not claimed.

Exact local test/check/build commands:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/agents/code-mode-headless.test.ts \
  src/agents/code-mode-headless.cancellation.test.ts \
  src/agents/code-mode-headless.validation.test.ts \
  src/agents/code-mode.bridge.test.ts \
  src/agents/code-mode.bridge.lifecycle.test.ts \
  src/agents/code-mode-worker-lifecycle.test.ts \
  src/agents/code-mode.wait.test.ts \
  src/agents/code-mode.limits.test.ts \
  src/agents/code-mode.agent-loop.test.ts \
  src/agents/code-mode-swarm.test.ts \
  src/agents/agent-tools.runtime.test.ts \
  src/agents/embedded-agent-runner/run/attempt-client-tools.test.ts \
  src/agents/embedded-agent-runner/run/attempt-session-settle.test.ts \
  src/agents/embedded-agent-runner/run/attempt.tool-search-catalog-abort.test.ts \
  src/agents/tool-search.test.ts \
  --maxWorkers=1 --no-file-parallelism

node scripts/check-changed.mjs -- \
  docs/tools/code-mode.md \
  src/agents/code-mode-execution.ts \
  src/agents/code-mode-headless.cancellation.test.ts \
  src/agents/code-mode-headless.test.ts \
  src/agents/code-mode-headless.ts \
  src/agents/code-mode-state.ts \
  src/agents/code-mode-swarm.test.ts \
  src/agents/code-mode.bridge.lifecycle.test.ts \
  src/agents/code-mode.test-support.ts \
  src/agents/code-mode.ts \
  src/agents/code-mode.wait.test.ts \
  src/agents/tool-search-catalog.ts \
  src/agents/tool-search-types.ts

OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
```

### Real Gateway capacity proof

The same isolated scenario ran on Node 26.7.0 through a **real Gateway/OpenClaw/QuickJS runtime with AIMock at the model protocol boundary**. This is neither a live-model test nor a mocked Control UI/Gateway test. For each of 64 chats: send a yielding exec, observe its actual waiting result, abort that exact chat run, verify its exact abort acknowledgment and terminal settlement, and independently inspect history for one exec/one parked result/zero waits. Only then admit chat 65, execute another yielding cell, and resume it through one actual wait.

Before: the 65th actual exec failed with too many suspended runs, 13,514ms after the first parked result. After: the 65th actual exec returned waiting, then **one actual wait completed with `RESUMED_OK`**, within a 16,671ms window. All 64 abort acknowledgments and terminal settlements were verified; 131 mock protocol requests. No cap/TTL override or Gateway restart; default snapshot TTL remained 900 seconds. Source, scenario, and dist hashes stayed unchanged. All owned helpers/services/temporary roots were cleaned up.

```json
{"runtime":"real Gateway/OpenClaw/QuickJS","provider":"AIMock","abandonedAdmissions":64,"exactAbortAcknowledgments":64,"terminalSettlements":64,"abandonedWaitCalls":0,"admission65":{"exec":"waiting","waitCalls":1,"result":"completed","value":"RESUMED_OK"},"beforeWindowMs":13514,"afterWindowMs":16671,"snapshotTtlMs":900000,"gatewayRestarts":0,"capOrTtlOverrides":false}
```

Before:

![65th execution blocked before owner cleanup](https://github.com/user-attachments/assets/4cdf6f73-9f63-4c92-b36e-295b116cd8ce)

After:

![65th execution resumes successfully after 64 aborted owners](https://github.com/user-attachments/assets/1cb39509-66fc-4ba1-9e16-2d035bf7a30c)

https://github.com/user-attachments/assets/d74b7f32-2a03-4029-aebd-34c12ffdffd3

The UI activity summary displays `Wait ×3`; authoritative history and the model sequence show one actual wait. **Control UI activity-count semantics** is a separate named follow-up, not execution-count evidence and not fixed here. An initial recorder attempt lacked ffmpeg in its isolated environment; owned resources were cleaned, the existing recorder cache selected, and the unchanged runtime/scenario rerun. Final captures and video frames/contact sheets were inspected; all media contains approved synthetic fixtures only.

### Real scheduler timer proof, with matched setup and cold caveat

The original disabled, no-delivery scheduler job retained the exact script, `toolsAllow: ["*"]`, tool budget 1, and timeout 5 seconds:

```js
const timer = setTimeout(() => {}, 60000);
await new Promise((resolve) => setTimeout(resolve, 1));
clearTimeout(timer);
await new Promise((resolve) => setTimeout(resolve, 1));
return { notify: "CM-TIMER-DONE" };
```

Before: failed at **5167ms**. Final after: **succeeded at 4023ms with `CM-TIMER-DONE`**, following the same ordinary OpenClaw agent file-read task before the automation run as the original before case. Actual agent/bridge/read effects and unchanged job payload were verified. A fully cached same-job diagnostic completed in 125ms; that is distinct from the matched-setup proof. No deadline enlargement and no delivery requested.

**Cold preparation remains a separate limitation.** The first uninstrumented cold after run exceeded the nondefault five-second ceiling at 8688ms. A separate fresh-process V8-coverage diagnostic timed out at 5862ms and recorded preparation, runner, and catalog registration entry, but **zero headless entry calls**. That failure occurs before guest execution and is not the canceled-timer defect; it is not claimed fixed. The normal script budget remains 300 seconds. **Cold script preparation performance** is a separate named follow-up. The successful matched and cached runs do not erase these failures.

Before:

![Scheduler timer script times out before cancellation repair](https://github.com/user-attachments/assets/758ee95e-54e5-4df4-8330-54aea6ecb1a4)

Matched after:

![Unchanged scheduler job completes with CM-TIMER-DONE](https://github.com/user-attachments/assets/da3a951a-59ab-443c-a708-cdfa5980ebda)

https://github.com/user-attachments/assets/4349f48a-7b9f-480e-a682-ebb79894914d

### Source and contract evidence

The canonical owner is `src/agents/code-mode-state.ts` (publication, transfer and disposal), called from `code-mode-execution.ts`; headless reconciliation belongs in `code-mode-headless.ts`. Attempt teardown reaches `clearToolSearchCatalog` from `embedded-agent-runner/run/attempt-session-settle.ts`. Client-tool/description-replacement siblings and the existing abort-wrapper handoff were read and tested. Docs: https://docs.openclaw.ai/tools/code-mode.

Installed quickjs-wasi 3.4.0 was inspected directly: `dist/index.js:310` restore copies memory into a fresh VM, `:1276` promise states, `:1751` snapshot copy, `:1770` named callbacks/disposal; declarations at `dist/index.d.ts:795` and `:873`. Host timer and snapshot lifetime remains OpenClaw's responsibility. Native Codex source was also inspected at `92cbfb4d2431bdc53dc03507aea2dc5b8e932e40`, `codex-rs/code-mode-runtime/src/v8_init.rs:42` and `session_runtime/mod.rs:135-209`; its separate V8 implementation is unchanged.

History: timer cancellation propagation in #124879 (`6bddfed5302`) covered interactive execution but omitted headless reconciliation. Snapshot module/expiry work in #113669 and #114945 did not bind parked state to owner closure. Larger limits, shorter TTL, a wait-only guard, or disposal on every description refresh would leave the invariant broken or kill valid cells; none is used.

Remaining scope limits: no full heap/GC proof, no claim of stable-release impact, no change to destroyed-catalog exception presentation, and no change to the separately deferred read-only failed-wait recovery policy. Exact-head CI and native landing evidence will be recorded before merge.
