### PR TITLE
fix(codex): repair auth ownership across private turns, custom commands, and shared clients

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -233,7 +233,7 @@ extensions/codex/src/app-server/scheduled-app-authority.ts	5
 extensions/codex/src/app-server/session-binding.ts	4
 extensions/codex/src/app-server/session-history.ts	6
 extensions/codex/src/app-server/settled-turn-context.ts	3
-extensions/codex/src/app-server/shared-client.ts	5
+extensions/codex/src/app-server/shared-client.ts	4
 extensions/codex/src/app-server/shell-dynamic-tools.ts	2
 extensions/codex/src/app-server/side-question.ts	8
 extensions/codex/src/app-server/startup-binding.ts	2

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -562,7 +562,9 @@ read, fork, rename, archive, and unarchive those threads. Fork a thread before
 continuing it in OpenClaw; independent Codex processes do not coordinate
 concurrent writers for the same thread.
 
-That `homeScope` opt-in applies to ordinary harness sessions. A Chat created
+That `homeScope` opt-in applies to ordinary harness sessions. Hosted web search
+and settled-turn finalization use private temporary homes and OpenClaw auth
+even when ordinary sessions share the user home. A Chat created
 through Codex Sessions uses its private supervision connection instead, which
 preserves the native connection's auth and provider configuration for the
 canonical branch and future resumes.

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -509,14 +509,16 @@ and [Run Codex on a cloud worker](/plugins/codex-harness#run-codex-on-a-cloud-wo
 
 ## Auth and environment isolation
 
-In the default per-agent home, managed stdio launches use Codex's ephemeral
-credential store. OpenClaw supplies auth in this order:
+In the default per-agent home, stdio launches use Codex's ephemeral credential
+store, including custom commands selected by `appServer.command` or
+`OPENCLAW_CODEX_APP_SERVER_BIN`. Command wrappers must forward Codex's `-c`
+configuration arguments. OpenClaw supplies auth in this order:
 
 1. An explicit or ordered OpenClaw auth profile for the agent.
 2. For an API-key route only, a prepared key or local stdio fallback from
    `CODEX_API_KEY`, then `OPENAI_API_KEY`.
 
-The managed app-server does not read an existing `codex-home/auth.json` in
+The app-server does not read an existing `codex-home/auth.json` in
 this mode. Import that file explicitly as described below. Set
 `appServer.homeScope: "user"` only when the app-server should instead own and
 use the operator's native Codex account.

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -535,7 +535,12 @@ an `account/chatgptAuthTokens/refresh` request back to OpenClaw over the same
 connection. OpenClaw refreshes against its own auth profile store and returns a
 fresh access token, so the refresh token stays in SQLite. A refresh that does
 not answer within the app-server's timeout fails that turn rather than falling
-back to another credential.
+back to another credential. A failed refresh retires the shared client from
+reuse; existing leases drain, and the next request starts a fresh client. If the
+workspace changed, retry the request. If credentials cannot refresh, sign in
+again with `openclaw models auth login --provider openai` and select that profile.
+Shared clients recheck the selected profile before reuse so changing accounts
+under the same profile ID also selects a new client.
 
 When OpenClaw sees a ChatGPT subscription-style Codex auth profile (OAuth or
 token credential type), it removes `CODEX_API_KEY` and `OPENAI_API_KEY` from

--- a/extensions/codex/src/app-server/attempt-startup.test-support.ts
+++ b/extensions/codex/src/app-server/attempt-startup.test-support.ts
@@ -1,6 +1,7 @@
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { expect, vi } from "vitest";
 import type { startCodexAttemptThread } from "./attempt-startup.js";
+import { withEphemeralCodexAuthStore } from "./auth-start-options.js";
 import { resolveCodexAppServerRuntimeOptions } from "./config.js";
 import { resolveCodexAppServerSpawnIdentity } from "./shared-client.js";
 import { createClientHarness } from "./test-support.js";
@@ -69,14 +70,15 @@ export async function captureExpectedRuntimeArtifact(
 ) {
   const { captureCodexAppServerRuntimeArtifactBeforeStart, finalizeCodexAppServerRuntimeArtifact } =
     await import("./runtime-artifact.js");
-  const spawnIdentity = resolveCodexAppServerSpawnIdentity(appServer.start);
+  const startOptions = withEphemeralCodexAuthStore({ startOptions: appServer.start });
+  const spawnIdentity = resolveCodexAppServerSpawnIdentity(startOptions);
   const before = await captureCodexAppServerRuntimeArtifactBeforeStart({
-    startOptions: appServer.start,
+    startOptions,
     spawnIdentity,
   });
   return finalizeCodexAppServerRuntimeArtifact({
     before,
-    startOptions: appServer.start,
+    startOptions,
     spawnIdentity,
     runtimeIdentity: { serverVersion: "0.149.0", userAgent: "openclaw/0.149.0 (macOS; test)" },
   });

--- a/extensions/codex/src/app-server/auth-binding.test.ts
+++ b/extensions/codex/src/app-server/auth-binding.test.ts
@@ -15,6 +15,61 @@ describe("Codex app-server auth binding", () => {
     vi.unstubAllEnvs();
   });
 
+  it.each([true, false])(
+    "binds OAuth workspace identity with stored account ID=%s without token-refresh churn",
+    async (storedAccountId) => {
+      const profileId = "openai:work";
+      const credential = (accountId: string, rotation: string) => ({
+        type: "oauth" as const,
+        provider: "openai",
+        email: "user@example.com",
+        ...(storedAccountId ? { accountId } : {}),
+        access: `e30.${Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } })).toString("base64url")}.${rotation}`,
+        refresh: `fake-refresh-${rotation}`,
+        expires: Date.now() + 60_000,
+      });
+      const store: AuthProfileStore = {
+        version: 1,
+        profiles: { [profileId]: credential("workspace-a", "first") },
+      };
+      const params = {
+        authProfileId: profileId,
+        authProfileStore: store,
+        agentDir: "/tmp/codex-binding",
+        config: {},
+      };
+      const prepared = await prepareCodexAppServerAuthBinding(params);
+      const first = prepared?.fingerprint;
+      expect(first).toEqual(expect.any(String));
+      store.profiles[profileId] = credential("workspace-a", "rotated");
+      expect(await fingerprintCodexAppServerAuthBinding(params)).toBe(first);
+      store.profiles[profileId] = credential("workspace-b", "replacement");
+      expect(await fingerprintCodexAppServerAuthBinding(params)).not.toBe(first);
+      expect(
+        await fingerprintCodexAppServerAuthBinding({
+          ...params,
+          authProfileStore: prepared!.authProfileStore,
+        }),
+      ).toBe(first);
+    },
+  );
+
+  it("names a repair when a selected profile cannot resolve credentials", async () => {
+    await expect(
+      prepareCodexAppServerAuthBinding({
+        authProfileId: "openai:missing-key",
+        authProfileStore: {
+          version: 1,
+          profiles: {
+            "openai:missing-key": { type: "api_key", provider: "openai" },
+          },
+        },
+        agentDir: "/tmp/codex-binding",
+        config: {},
+      }),
+    ).rejects.toThrow(/could not resolve.*[Rr]epair/);
+  });
+
   it("uses the materialized runtime SecretRef snapshot and fingerprints the executed store", async () => {
     const profileId = "openai:work";
     const store: AuthProfileStore = {

--- a/extensions/codex/src/app-server/auth-binding.ts
+++ b/extensions/codex/src/app-server/auth-binding.ts
@@ -7,6 +7,7 @@ import {
   type AuthProfileCredential,
   type AuthProfileStore,
 } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveOpenAICodexAuthIdentity } from "openclaw/plugin-sdk/provider-auth";
 
 type CodexAppServerPreparedAuthBinding = {
   authProfileStore: AuthProfileStore;
@@ -35,8 +36,23 @@ export async function prepareCodexAppServerAuthBinding(
   params: AgentHarnessAuthBindingFingerprintParams,
 ): Promise<CodexAppServerPreparedAuthBinding | undefined> {
   const credential = params.authProfileStore.profiles[params.authProfileId];
-  if (!credential || credential.type === "oauth") {
+  if (!credential) {
     return undefined;
+  }
+  if (credential.type === "oauth") {
+    // The ChatGPT workspace can change under the same profile/email. Rotating
+    // tokens for that same workspace must not invalidate a live process binding.
+    const fingerprint = fingerprintResolvedAuthProfileCredential({
+      profileId: params.authProfileId,
+      credential: {
+        ...credential,
+        accountId: resolveOpenAICodexAuthIdentity(credential).accountId,
+      },
+      resolvedAuth: undefined,
+    });
+    return fingerprint
+      ? { fingerprint, authProfileStore: structuredClone(params.authProfileStore) }
+      : undefined;
   }
   const resolved = await resolveApiKeyForProfile({
     cfg: params.config,
@@ -45,7 +61,9 @@ export async function prepareCodexAppServerAuthBinding(
     agentDir: params.agentDir,
   });
   if (!resolved?.apiKey) {
-    throw new Error(`Codex could not resolve auth profile "${params.authProfileId}".`);
+    throw new Error(
+      `Codex could not resolve auth profile "${params.authProfileId}". Repair or replace its credential or SecretRef, then retry.`,
+    );
   }
   const fingerprint = fingerprintResolvedAuthProfileCredential({
     profileId: params.authProfileId,
@@ -58,7 +76,9 @@ export async function prepareCodexAppServerAuthBinding(
     },
   });
   if (!fingerprint) {
-    throw new Error(`Codex could not attest auth profile "${params.authProfileId}".`);
+    throw new Error(
+      `Codex could not attest auth profile "${params.authProfileId}". Re-select the OpenAI profile and retry.`,
+    );
   }
   return {
     fingerprint,

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -340,9 +340,16 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it.each(["subscription", "api-key"] as const)(
-    "rejects an unimported agent-scoped Codex auth file for a %s route without fallback",
-    async (authRequirement) => {
+  it.each(
+    (["subscription", "api-key"] as const).flatMap((authRequirement) =>
+      (["managed", "config", "env"] as const).map((commandSource) => ({
+        authRequirement,
+        commandSource,
+      })),
+    ),
+  )(
+    "rejects an unimported agent-scoped Codex auth file for $commandSource/$authRequirement without fallback",
+    async ({ authRequirement, commandSource }) => {
       await withTempDir("openclaw-codex-unimported-auth-", async (agentDir) => {
         const codexHome = resolveCodexAppServerHomeDir(agentDir);
         await writeCodexCliAuthFile(codexHome);
@@ -353,7 +360,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
 
         await expect(
           bridgeCodexAppServerStartOptions({
-            startOptions: createStartOptions({ headers: {} }),
+            startOptions: createStartOptions({ headers: {}, commandSource }),
             agentDir,
             agentId: "research",
             authRequirement,
@@ -3231,7 +3238,7 @@ describe("bridgeCodexAppServerStartOptions", () => {
             authProfileId: "openai:work",
             previousAccountId: "workspace-original",
           }),
-        ).rejects.toThrow("ChatGPT workspace changed");
+        ).rejects.toThrow(/ChatGPT workspace changed.*[Rr]etry/);
         expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
       } finally {
         await fs.rm(agentDir, { recursive: true, force: true });

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -795,20 +795,35 @@ describe("bridgeCodexAppServerStartOptions", () => {
     });
   });
 
-  it("preserves custom stdio backend arguments", async () => {
-    await withTempDir("openclaw-codex-custom-backend-", async (agentDir) => {
-      const startOptions = createStartOptions({
-        command: "custom-codex-compatible-server",
-        commandSource: "config",
-        args: [],
+  it.each([
+    { commandSource: "config", authProfileId: "openai:test", ephemeral: true },
+    { commandSource: "env", authProfileId: "openai:test", ephemeral: true },
+    { commandSource: "config", authProfileId: null, ephemeral: false },
+    { commandSource: "env", authProfileId: null, ephemeral: false },
+  ] as const)(
+    "uses ephemeral=$ephemeral auth for a $commandSource command with profile $authProfileId",
+    async ({ commandSource, authProfileId, ephemeral }) => {
+      await withTempDir("openclaw-codex-custom-backend-", async (agentDir) => {
+        const startOptions = createStartOptions({
+          command: "/custom/codex",
+          commandSource,
+        });
+
+        const bridged = await bridgeCodexAppServerStartOptions({
+          startOptions,
+          agentDir,
+          authProfileId,
+          authProfileStore: {
+            version: 1,
+            profiles: { "openai:test": { type: "api_key", provider: "openai", key: "fake-key" } },
+          },
+        });
+
+        expect(bridged.args).toEqual(ephemeral ? EPHEMERAL_AUTH_ARGS : ["app-server"]);
+        expect(startOptions.args).toEqual(["app-server"]);
       });
-      await writeCodexCliAuthFile(resolveCodexAppServerHomeDir(agentDir));
-
-      const bridged = await bridgeCodexAppServerStartOptions({ startOptions, agentDir });
-
-      expect(bridged.args).toEqual([]);
-    });
-  });
+    },
+  );
 
   it("preserves inherited HOME when clearEnv asks to clear app-server isolation vars", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -1849,119 +1849,142 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
-  it("routes a same-identity stale persisted clone through canonical persisted auth", async () => {
-    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
-    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
-    try {
-      upsertAuthProfile({
-        agentDir,
-        profileId: "openai:work",
-        credential: {
-          type: "oauth",
-          provider: "openai",
-          access: "stale-access",
-          refresh: "stale-refresh",
-          expires: Date.now() - 60_000,
-          accountId: "persisted-account",
-        },
-      });
-      const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
-      expect(authProfileStore.runtimePersistedProfileIds).toContain("openai:work");
-      upsertAuthProfile({
-        agentDir,
-        profileId: "openai:work",
-        credential: {
-          type: "oauth",
-          provider: "openai",
-          access: "current-access",
-          refresh: "current-refresh",
-          expires: Date.now() + 24 * 60 * 60_000,
-          accountId: "persisted-account",
-        },
-      });
+  it.each([true, false])(
+    "routes a same-identity stale persisted clone through canonical auth with stored ID=%s",
+    async (storedAccountId) => {
+      const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+      const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+      const currentAccess = storedAccountId
+        ? "current-access"
+        : chatgptAccessToken("persisted-account", "current");
+      try {
+        upsertAuthProfile({
+          agentDir,
+          profileId: "openai:work",
+          credential: {
+            type: "oauth",
+            provider: "openai",
+            access: storedAccountId
+              ? "stale-access"
+              : chatgptAccessToken("persisted-account", "stale"),
+            refresh: "stale-refresh",
+            expires: Date.now() - 60_000,
+            ...(storedAccountId ? { accountId: "persisted-account" } : {}),
+            email: "codex@example.test",
+          },
+        });
+        const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+        expect(authProfileStore.runtimePersistedProfileIds).toContain("openai:work");
+        upsertAuthProfile({
+          agentDir,
+          profileId: "openai:work",
+          credential: {
+            type: "oauth",
+            provider: "openai",
+            access: currentAccess,
+            refresh: "current-refresh",
+            expires: Date.now() + 24 * 60 * 60_000,
+            ...(storedAccountId ? { accountId: "persisted-account" } : {}),
+            email: "codex@example.test",
+          },
+        });
 
-      await applyCodexAppServerAuthProfile({
-        client: { request } as never,
-        agentDir,
-        authProfileId: "openai:work",
-        authProfileStore,
-      });
+        await applyCodexAppServerAuthProfile({
+          client: { request } as never,
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+        });
 
-      expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
-      expect(request).toHaveBeenCalledWith("account/login/start", {
-        type: "chatgptAuthTokens",
-        accessToken: "current-access",
-        chatgptAccountId: "persisted-account",
-        chatgptPlanType: null,
-      });
-    } finally {
-      await fs.rm(agentDir, { recursive: true, force: true });
-    }
-  });
+        expect(oauthMocks.refreshOpenAICodexToken).not.toHaveBeenCalled();
+        expect(request).toHaveBeenCalledWith("account/login/start", {
+          type: "chatgptAuthTokens",
+          accessToken: currentAccess,
+          chatgptAccountId: "persisted-account",
+          chatgptPlanType: null,
+        });
+      } finally {
+        await fs.rm(agentDir, { recursive: true, force: true });
+      }
+    },
+  );
 
-  it("keeps a changed-identity persisted clone scoped", async () => {
-    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
-    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
-    oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
-      access: "account-a-refreshed-access",
-      refresh: "account-a-refreshed-refresh",
-      expires: Date.now() + 60_000,
-      accountId: "account-a",
-    });
-    try {
-      upsertAuthProfile({
-        agentDir,
-        profileId: "openai:work",
-        credential: {
-          type: "oauth",
-          provider: "openai",
-          access: "account-a-expired-access",
-          refresh: "account-a-refresh",
-          expires: Date.now() - 60_000,
-          accountId: "account-a",
-        },
+  it.each([true, false])(
+    "keeps a changed-identity persisted clone scoped with stored ID=%s",
+    async (storedAccountId) => {
+      const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+      const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+      const refreshedAccess = storedAccountId
+        ? "account-a-refreshed-access"
+        : chatgptAccessToken("account-a", "refreshed");
+      const replacementAccess = storedAccountId
+        ? "account-b-access"
+        : chatgptAccessToken("account-b");
+      oauthMocks.refreshOpenAICodexToken.mockResolvedValueOnce({
+        access: refreshedAccess,
+        refresh: "account-a-refreshed-refresh",
+        expires: Date.now() + 60_000,
+        accountId: "account-a",
       });
-      const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
-      expect(authProfileStore.runtimePersistedProfileIds).toContain("openai:work");
-      upsertAuthProfile({
-        agentDir,
-        profileId: "openai:work",
-        credential: {
-          type: "oauth",
-          provider: "openai",
-          access: "account-b-access",
+      try {
+        upsertAuthProfile({
+          agentDir,
+          profileId: "openai:work",
+          credential: {
+            type: "oauth",
+            provider: "openai",
+            access: storedAccountId
+              ? "account-a-expired-access"
+              : chatgptAccessToken("account-a", "expired"),
+            refresh: "account-a-refresh",
+            expires: Date.now() - 60_000,
+            ...(storedAccountId ? { accountId: "account-a" } : {}),
+            email: "codex@example.test",
+          },
+        });
+        const authProfileStore = loadAuthProfileStoreForSecretsRuntime(agentDir);
+        expect(authProfileStore.runtimePersistedProfileIds).toContain("openai:work");
+        upsertAuthProfile({
+          agentDir,
+          profileId: "openai:work",
+          credential: {
+            type: "oauth",
+            provider: "openai",
+            access: replacementAccess,
+            refresh: "account-b-refresh",
+            expires: Date.now() + 24 * 60 * 60_000,
+            ...(storedAccountId ? { accountId: "account-b" } : {}),
+            email: "codex@example.test",
+          },
+        });
+        replaceRuntimeAuthProfileStoreSnapshots([{ agentDir, store: authProfileStore }]);
+
+        await applyCodexAppServerAuthProfile({
+          client: { request } as never,
+          agentDir,
+          authProfileId: "openai:work",
+          authProfileStore,
+        });
+
+        expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("account-a-refresh");
+        expect(request).toHaveBeenCalledWith("account/login/start", {
+          type: "chatgptAuthTokens",
+          accessToken: refreshedAccess,
+          chatgptAccountId: "account-a",
+          chatgptPlanType: null,
+        });
+        expect(
+          loadAuthProfileStoreForSecretsRuntime(agentDir).profiles["openai:work"],
+        ).toMatchObject({
+          access: replacementAccess,
           refresh: "account-b-refresh",
-          expires: Date.now() + 24 * 60 * 60_000,
-          accountId: "account-b",
-        },
-      });
-      replaceRuntimeAuthProfileStoreSnapshots([{ agentDir, store: authProfileStore }]);
-
-      await applyCodexAppServerAuthProfile({
-        client: { request } as never,
-        agentDir,
-        authProfileId: "openai:work",
-        authProfileStore,
-      });
-
-      expect(oauthMocks.refreshOpenAICodexToken).toHaveBeenCalledWith("account-a-refresh");
-      expect(request).toHaveBeenCalledWith("account/login/start", {
-        type: "chatgptAuthTokens",
-        accessToken: "account-a-refreshed-access",
-        chatgptAccountId: "account-a",
-        chatgptPlanType: null,
-      });
-      expect(loadAuthProfileStoreForSecretsRuntime(agentDir).profiles["openai:work"]).toMatchObject(
-        {
-          access: "account-b-access",
-          refresh: "account-b-refresh",
-          accountId: "account-b",
-        },
-      );
-    } finally {
-      await fs.rm(agentDir, { recursive: true, force: true });
-    }
-  });
+          ...(storedAccountId ? { accountId: "account-b" } : {}),
+        });
+      } finally {
+        await fs.rm(agentDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("serializes concurrent refreshes of the same scoped OAuth profile", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -148,7 +148,7 @@ function assertNoUnimportedAgentCodexAuthFile(params: {
   agentDir: string;
   authRequirement?: CodexAppServerAuthRequirement;
 }): void {
-  // Ephemeral managed starts cannot load this stale file, and the shared-client key
+  // Ephemeral stdio starts cannot load this stale file, and the shared-client key
   // separates auth requirements plus fallback identities. Preserve the supported
   // stdio API-key login instead of turning a leftover file into a hard failure.
   if (
@@ -168,19 +168,12 @@ function resolveUnimportedAgentCodexAuthMessage(params: {
   agentId?: string;
   agentDir: string;
 }): string | undefined {
-  const managedCodexCli =
-    params.startOptions.commandSource === "managed" ||
-    params.startOptions.commandSource === "resolved-managed";
-  if (
-    params.startOptions.transport !== "stdio" ||
-    !managedCodexCli ||
-    params.startOptions.homeScope === "user"
-  ) {
+  if (params.startOptions.transport !== "stdio" || params.startOptions.homeScope === "user") {
     return undefined;
   }
   const codexHome = resolveCodexAppServerHomeDir(params.agentDir);
   const authPath = path.join(codexHome, CODEX_AUTH_JSON_FILENAME);
-  // Managed starts force ephemeral Codex auth, so this file would otherwise be
+  // OpenClaw-owned starts force ephemeral Codex auth, so this file would otherwise be
   // ignored and the operator would receive only the downstream authentication error.
   if (!fsSync.existsSync(authPath)) {
     return undefined;
@@ -803,36 +796,30 @@ export async function applyCodexAppServerAuthProfile(params: {
   startOptions?: CodexAppServerStartOptions;
   config?: AuthProfileOrderConfig;
 }): Promise<void> {
-  if (params.preparedAuth?.kind === "profile") {
-    await params.client.request("account/login/start", params.preparedAuth.snapshot.loginParams);
-    return;
-  }
-  if (params.preparedAuth?.kind === "api-key") {
-    await params.client.request("account/login/start", {
-      type: "apiKey",
-      apiKey: params.preparedAuth.apiKey,
-    });
-    return;
-  }
-  if (params.authProfileId === null) {
+  if (!params.preparedAuth && params.authProfileId === null) {
     await assertNativeCodexAccountMatchesRoute(params.client, params.authRequirement);
     return;
   }
   let loginParams: CodexLoginAccountParams | undefined;
   try {
-    loginParams = await resolveCodexAppServerAuthProfileLoginParams({
-      agentDir: params.agentDir,
-      authProfileId: params.authProfileId,
-      authProfileStore: params.authProfileStore,
-      config: params.config,
-    });
+    loginParams =
+      params.preparedAuth?.kind === "profile"
+        ? params.preparedAuth.snapshot.loginParams
+        : params.preparedAuth?.kind === "api-key"
+          ? { type: "apiKey", apiKey: params.preparedAuth.apiKey }
+          : await resolveCodexAppServerAuthProfileLoginParams({
+              agentDir: params.agentDir,
+              authProfileId: params.authProfileId ?? undefined,
+              authProfileStore: params.authProfileStore,
+              config: params.config,
+            });
   } catch (error) {
     if (
       params.authRequirement === "subscription" &&
       error instanceof CodexAppServerAuthProfileUnavailableError
     ) {
       throw createCodexAppServerAuthError(
-        "Codex subscription auth profile could not produce login credentials.",
+        "Codex subscription auth profile could not produce login credentials. Sign in with `openclaw models auth login --provider openai`, select that profile, then retry.",
         error,
       );
     }
@@ -840,17 +827,10 @@ export async function applyCodexAppServerAuthProfile(params: {
   }
   if (params.authRequirement === "subscription" && loginParams?.type !== "chatgptAuthTokens") {
     throw createCodexAppServerAuthError(
-      "Codex subscription auth profile could not produce login credentials.",
+      "Codex subscription auth profile could not produce login credentials. Sign in with `openclaw models auth login --provider openai`, select that profile, then retry.",
     );
   }
   if (!loginParams) {
-    // Observe native state only for explicit API-key routes. A subscription
-    // route must fail here so profile rotation can run before billing changes.
-    if (params.authRequirement === "subscription") {
-      throw createCodexAppServerAuthError(
-        "Codex subscription auth profile could not produce login credentials.",
-      );
-    }
     if (params.authRequirement !== "api-key" || params.startOptions?.transport !== "stdio") {
       return;
     }
@@ -889,7 +869,7 @@ async function assertNativeCodexAccountMatchesRoute(
   if (authRequirement === "subscription") {
     if (accountType !== "chatgpt") {
       throw createCodexAppServerAuthError(
-        "Codex subscription auth profile could not produce login credentials.",
+        'Codex subscription route requires ChatGPT auth in the native Codex home. Run `codex login` for that home, or use appServer.homeScope="agent" with an OpenClaw OAuth profile, then retry.',
       );
     }
     return;
@@ -906,7 +886,9 @@ function createCodexAppServerAuthError(message: string, cause?: unknown): Error 
   return Object.assign(error, { status: 401 as const });
 }
 
-class CodexAppServerAuthProfileUnavailableError extends Error {}
+class CodexAppServerAuthProfileUnavailableError extends Error {
+  readonly status = 401;
+}
 
 async function resolveCodexAppServerAuthProfileLoginParams(params: {
   agentDir: string;
@@ -923,7 +905,7 @@ async function resolveCodexAppServerAuthProfileLoginParams(params: {
   const profile = profileId ? store.profiles[profileId] : undefined;
   if (profileId && !profile) {
     throw new CodexAppServerAuthProfileUnavailableError(
-      `Codex app-server auth profile "${profileId}" was not found.`,
+      `Codex app-server auth profile "${profileId}" was not found. Select an existing OpenAI profile or sign in again with OpenClaw, then retry.`,
     );
   }
   if (profileId && profile && !isCodexAppServerAuthProfileCredential(profile)) {
@@ -960,7 +942,9 @@ export async function refreshCodexAppServerAuthTokens(params: {
           : undefined))
       : undefined;
     if (selectedAccountId && selectedAccountId !== previousAccountId) {
-      throw new Error("ChatGPT workspace changed before Codex token refresh.");
+      throw new Error(
+        "ChatGPT workspace changed before Codex token refresh. Retry to start a client for the selected workspace.",
+      );
     }
   }
   const loginParams = await resolveCodexAppServerAuthProfileLoginParamsInternal({
@@ -968,10 +952,14 @@ export async function refreshCodexAppServerAuthTokens(params: {
     forceOAuthRefresh: true,
   });
   if (!loginParams || loginParams.type !== "chatgptAuthTokens") {
-    throw new Error("Codex app-server ChatGPT token refresh requires an OAuth auth profile.");
+    throw new Error(
+      "Codex app-server ChatGPT token refresh requires an OAuth auth profile. Sign in with `openclaw models auth login --provider openai`, select that profile, then retry.",
+    );
   }
   if (previousAccountId && loginParams.chatgptAccountId !== previousAccountId) {
-    throw new Error("ChatGPT workspace changed during Codex token refresh.");
+    throw new Error(
+      "ChatGPT workspace changed during Codex token refresh. Retry to start a client for the selected workspace.",
+    );
   }
   return {
     accessToken: loginParams.accessToken,
@@ -1003,7 +991,9 @@ async function resolveCodexAppServerAuthProfileLoginParamsInternal(params: {
   }
   const credential = store.profiles[profileId];
   if (!credential) {
-    throw new Error(`Codex app-server auth profile "${profileId}" was not found.`);
+    throw new Error(
+      `Codex app-server auth profile "${profileId}" was not found. Select an existing OpenAI profile or sign in again with OpenClaw, then retry.`,
+    );
   }
   if (!isCodexAppServerAuthProfileCredential(credential)) {
     throw new Error(
@@ -1019,7 +1009,7 @@ async function resolveCodexAppServerAuthProfileLoginParamsInternal(params: {
   });
   if (!loginParams) {
     throw new CodexAppServerAuthProfileUnavailableError(
-      `Codex app-server auth profile "${profileId}" does not contain usable credentials.`,
+      `Codex app-server auth profile "${profileId}" does not contain usable credentials. Repair or replace the selected OpenAI credential, then retry.`,
     );
   }
   return loginParams;
@@ -1210,7 +1200,9 @@ async function resolveOAuthCredentialForCodexAppServer(
       credential: overlaidOAuthCredential,
     });
     if (!refreshedRuntimeCredential?.access?.trim()) {
-      throw new Error(`Codex app-server auth profile "${profileId}" could not refresh.`);
+      throw new Error(
+        `Codex app-server auth profile "${profileId}" could not refresh. Sign in again with OpenClaw, then retry.`,
+      );
     }
     store.profiles[profileId] = refreshedRuntimeCredential;
     return refreshedRuntimeCredential;
@@ -1303,11 +1295,13 @@ async function resolveScopedOAuthCredential(params: {
     }
     const refreshed = await refreshOAuthCredentialForRuntime({ credential });
     if (!refreshed?.access?.trim()) {
-      throw new Error(`Codex app-server auth profile "${params.profileId}" could not refresh.`);
+      throw new Error(
+        `Codex app-server auth profile "${params.profileId}" could not refresh. Sign in again with OpenClaw, then retry.`,
+      );
     }
     if (!isDeepStrictEqual(params.store.profiles[params.profileId], credential)) {
       throw new Error(
-        `Codex app-server auth profile "${params.profileId}" changed while refreshing.`,
+        `Codex app-server auth profile "${params.profileId}" changed while refreshing. Retry with the newly selected OpenAI profile.`,
       );
     }
     params.store.profiles[params.profileId] = refreshed;

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -1261,8 +1261,10 @@ function shouldUseScopedOAuthCredential(params: {
 }
 
 function hasMatchingOAuthIdentity(persisted: OAuthCredential, supplied: OAuthCredential): boolean {
-  const persistedAccountId = persisted.accountId?.trim();
-  const suppliedAccountId = supplied.accountId?.trim();
+  // Claim-only workspaces must stay distinct even when their emails match,
+  // or a scoped refresh can overwrite a replacement persisted account.
+  const persistedAccountId = resolveOpenAICodexAuthIdentity(persisted).accountId?.trim();
+  const suppliedAccountId = resolveOpenAICodexAuthIdentity(supplied).accountId?.trim();
   if (persistedAccountId && suppliedAccountId) {
     return persistedAccountId === suppliedAccountId;
   }

--- a/extensions/codex/src/app-server/auth-start-options.ts
+++ b/extensions/codex/src/app-server/auth-start-options.ts
@@ -31,9 +31,7 @@ export function withEphemeralCodexAuthStore(params: {
   authProfileId?: string | null;
 }): CodexAppServerStartOptions {
   const { startOptions } = params;
-  const managedCodexCli =
-    startOptions.commandSource === "managed" || startOptions.commandSource === "resolved-managed";
-  if (!managedCodexCli || (!params.preparedAuth && params.authProfileId === null)) {
+  if (!params.preparedAuth && params.authProfileId === null) {
     return startOptions;
   }
   if (

--- a/extensions/codex/src/app-server/bounded-turn.test.ts
+++ b/extensions/codex/src/app-server/bounded-turn.test.ts
@@ -463,36 +463,53 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
     ).rejects.toThrow("turn ended with status interrupted");
   });
 
-  it("forwards one prepared authorization selection to the isolated client", async () => {
-    const fake = createClientFactory();
-    const preparedAuth = { kind: "api-key" as const, apiKey: "test-key" };
+  it.each(["prepared", "profile", "implicit"] as const)(
+    "bridges %s auth into the private home when the configured home is native",
+    async (authSelection) => {
+      const fake = createClientFactory();
+      const preparedAuth = { kind: "api-key" as const, apiKey: "test-key" };
+      const profile = "openai:bounded";
 
-    await runBoundedCodexAppServerTurn({
-      model: { mode: "required", id: "gpt-5.4" },
-      preparedAuth,
-      authRequirement: "api-key",
-      timeoutMs: 5_000,
-      options: {
-        clientFactory: fake.factory,
-        pluginConfig: { appServer: { homeScope: "user" } },
-      },
-      taskLabel: "isolated completion",
-      developerInstructions: "Answer only.",
-      input: [{ type: "text", text: "Name this conversation.", text_elements: [] }],
-      requiredModalities: ["text"],
-      isolation: "private-stdio",
-      requireNoExternalCapabilities: true,
-    });
-
-    expect(fake.factory).toHaveBeenCalledWith(
-      expect.objectContaining({
-        preparedAuth,
+      await runBoundedCodexAppServerTurn({
+        model: { mode: "required", id: "gpt-5.4" },
+        ...(authSelection === "prepared"
+          ? { preparedAuth }
+          : authSelection === "profile"
+            ? { profile }
+            : {}),
         authRequirement: "api-key",
-        startOptions: expect.objectContaining({ homeScope: "agent" }),
-      }),
-    );
-    expect(vi.mocked(fake.factory).mock.calls[0]?.[0]).not.toHaveProperty("authProfileId");
-  });
+        timeoutMs: 5_000,
+        options: {
+          clientFactory: fake.factory,
+          pluginConfig: { appServer: { homeScope: "user" } },
+        },
+        taskLabel: "isolated completion",
+        developerInstructions: "Answer only.",
+        input: [{ type: "text", text: "Name this conversation.", text_elements: [] }],
+        requiredModalities: ["text"],
+        isolation: "private-stdio",
+        requireNoExternalCapabilities: true,
+      });
+
+      expect(fake.factory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...(authSelection === "prepared"
+            ? { preparedAuth }
+            : { authProfileId: authSelection === "profile" ? profile : undefined }),
+          authRequirement: "api-key",
+          startOptions: expect.objectContaining({
+            homeScope: "agent",
+            env: expect.objectContaining({
+              CODEX_HOME: expect.stringContaining("codex-bounded-turn-"),
+            }),
+          }),
+        }),
+      );
+      expect(vi.mocked(fake.factory).mock.calls[0]?.[0]).not.toHaveProperty(
+        authSelection === "prepared" ? "authProfileId" : "preparedAuth",
+      );
+    },
+  );
 
   it("preserves the configured native model provider when no override is supplied", async () => {
     const fake = createClientFactory();
@@ -500,7 +517,10 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
     await runBoundedCodexAppServerTurn({
       model: { mode: "required", id: "gpt-5.4" },
       timeoutMs: 5_000,
-      options: { clientFactory: fake.factory },
+      options: {
+        clientFactory: fake.factory,
+        pluginConfig: { appServer: { homeScope: "user" } },
+      },
       taskLabel: "isolated completion",
       developerInstructions: "Answer only.",
       input: [{ type: "text", text: "Name this conversation.", text_elements: [] }],
@@ -511,6 +531,9 @@ describe("runBoundedCodexAppServerTurn settled finalization isolation", () => {
 
     const startParams = fake.request.mock.calls.find(([method]) => method === "thread/start")?.[1];
     expect(startParams).not.toHaveProperty("modelProvider");
+    expect(fake.factory).toHaveBeenCalledWith(
+      expect.objectContaining({ startOptions: expect.objectContaining({ homeScope: "user" }) }),
+    );
   });
 
   it("uses the execution model for required logical model ids", async () => {

--- a/extensions/codex/src/app-server/bounded-turn.ts
+++ b/extensions/codex/src/app-server/bounded-turn.ts
@@ -170,15 +170,9 @@ async function runBoundedCodexAppServerTurnInWorkspace(
   // Hosted search needs a private Codex home and cwd so inherited native tools
   // cannot escape the bounded turn. Media calls retain configured transport
   // compatibility while still using an isolated ephemeral thread.
-  const isolatedStartOptions = workspace.codexHome
+  const startOptions = workspace.codexHome
     ? buildPrivateCodexAppServerStartOptions(appServer.start, workspace.codexHome)
     : appServer.start;
-  // A prepared credential is scoped to the fresh private home even when the
-  // operator's configured app-server normally points at their user home.
-  const startOptions =
-    workspace.codexHome && params.preparedAuth
-      ? { ...isolatedStartOptions, homeScope: "agent" as const }
-      : isolatedStartOptions;
   const ownsClient = !params.options.clientFactory;
   const authSelection = params.preparedAuth
     ? { preparedAuth: params.preparedAuth }
@@ -431,6 +425,9 @@ function buildPrivateCodexAppServerStartOptions(
   });
   return {
     ...start,
+    // A fresh private home has no native account; bridge OpenClaw auth even
+    // when the operator's ordinary harness uses their native Codex home.
+    homeScope: "agent",
     args: ["app-server", ...providerArgs, "--listen", "stdio://"],
     env: {
       ...privateEnv,

--- a/extensions/codex/src/app-server/client-runtime.ts
+++ b/extensions/codex/src/app-server/client-runtime.ts
@@ -10,6 +10,7 @@ import { withTimeout } from "./timeout.js";
 type ClientRuntimeContext = Omit<CodexAppServerAuthProfileLookup, "agentDir"> & {
   agentDir: string;
   authMode?: "prepared-api-key" | "profile";
+  onAuthRefreshFailure?: () => void;
 };
 
 type ClientRuntime = {
@@ -111,23 +112,32 @@ export function ensureCodexAppServerClientRuntime(
       isJsonObject(request.params) && typeof request.params.previousAccountId === "string"
         ? request.params.previousAccountId.trim() || undefined
         : undefined;
-    const tokens = await withTimeout(
-      refreshCodexAppServerAuthTokens({
-        agentDir: runtime.context.agentDir,
-        authProfileId: runtime.context.authProfileId,
-        ...(previousAccountId ? { previousAccountId } : {}),
-        ...(runtime.context.authProfileStore
-          ? { authProfileStore: runtime.context.authProfileStore }
-          : {}),
-        config: runtime.context.config,
-      }),
-      CODEX_EXTERNAL_AUTH_REFRESH_TIMEOUT_MS,
-      "Codex app-server ChatGPT token refresh timed out before its external-auth deadline",
-    );
-    if (previousAccountId && tokens.chatgptAccountId !== previousAccountId) {
-      throw new Error("ChatGPT workspace changed during Codex token refresh.");
+    try {
+      const tokens = await withTimeout(
+        refreshCodexAppServerAuthTokens({
+          agentDir: runtime.context.agentDir,
+          authProfileId: runtime.context.authProfileId,
+          ...(previousAccountId ? { previousAccountId } : {}),
+          ...(runtime.context.authProfileStore
+            ? { authProfileStore: runtime.context.authProfileStore }
+            : {}),
+          config: runtime.context.config,
+        }),
+        CODEX_EXTERNAL_AUTH_REFRESH_TIMEOUT_MS,
+        "Codex app-server ChatGPT token refresh timed out before its external-auth deadline. Retry the request; if it persists, sign in again with OpenClaw.",
+      );
+      if (previousAccountId && tokens.chatgptAccountId !== previousAccountId) {
+        throw new Error(
+          "ChatGPT workspace changed during Codex token refresh. Retry to start a client for the selected workspace.",
+        );
+      }
+      return { ...tokens };
+    } catch (error) {
+      // Failed refresh leaves Codex holding its old account. Detach the cached
+      // process before another acquisition; existing leases can finish safely.
+      runtime.context.onAuthRefreshFailure?.();
+      throw error;
     }
-    return { ...tokens };
   });
   client.addNotificationHandler((notification) => {
     if (notification.method === "account/rateLimits/updated") {

--- a/extensions/codex/src/app-server/models.test.ts
+++ b/extensions/codex/src/app-server/models.test.ts
@@ -27,6 +27,7 @@ vi.mock("./auth-bridge.js", () => ({
   reconcileCodexComputerUseStartArtifacts: mocks.authBridge.reconcileComputerUseArtifacts,
   resolveCodexAppServerFallbackApiKeyCacheKey: mocks.authBridge.fallbackApiKeyCacheKey,
   resolveCodexAppServerAuthProfileIdForAgent: mocks.authBridge.authProfileId,
+  resolveCodexAppServerAuthProfileStore: () => ({ version: 1, profiles: {} }),
   resolveCodexAppServerHomeDir: (agentDir: string) => `${agentDir}/codex-home`,
 }));
 

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -371,54 +371,64 @@ describe("shared Codex app-server client", () => {
     expect(startSpy).not.toHaveBeenCalled();
   });
 
-  it("skips auth-store resolution only while the same config-owned client stays warm", async () => {
-    const first = createClientHarness();
-    const replacement = createClientHarness();
-    const startSpy = vi
-      .spyOn(CodexAppServerClient, "start")
-      .mockReturnValueOnce(first.client)
-      .mockReturnValueOnce(replacement.client);
-    mocks.resolveCodexAppServerAuthProfileIdForAgent.mockImplementation(() => {
-      mocks.resolveCodexAppServerAuthProfileStore();
-      return "openai:work";
-    });
-    const startOptions: CodexAppServerStartOptions = {
-      transport: "stdio",
-      homeScope: "agent",
-      command: "codex",
-      args: ["app-server"],
-      headers: {},
-    };
-    const config = { auth: { order: { openai: ["openai:work"] } } };
-    const options = { config, startOptions, timeoutMs: 1_000 };
-
-    const firstAcquire = getLeasedSharedCodexAppServerClient(options);
-    await sendInitializeResult(first, "openclaw/0.149.0 (Linux; test)");
-    await expect(firstAcquire).resolves.toBe(first.client);
-    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
-    expect(mocks.resolveCodexAppServerAuthProfileStore).toHaveBeenCalledOnce();
-
-    await expect(getLeasedSharedCodexAppServerClient(options)).resolves.toBe(first.client);
-    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
-    expect(mocks.resolveCodexAppServerAuthProfileStore).toHaveBeenCalledOnce();
-
-    await expect(
-      getLeasedSharedCodexAppServerClient({
-        ...options,
+  it.each(["implicit", "explicit"] as const)(
+    "revalidates %s auth before reusing a warm client after account replacement",
+    async (selector) => {
+      const first = createClientHarness();
+      const replacement = createClientHarness();
+      const startSpy = vi
+        .spyOn(CodexAppServerClient, "start")
+        .mockReturnValueOnce(first.client)
+        .mockReturnValueOnce(replacement.client);
+      mocks.resolveCodexAppServerAuthProfileIdForAgent.mockReturnValue("openai:work");
+      mocks.resolveCodexAppServerAuthProfileStore.mockReturnValue({ version: 1, profiles: {} });
+      const options = {
         config: { auth: { order: { openai: ["openai:work"] } } },
-      }),
-    ).resolves.toBe(first.client);
-    expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
-    expect(mocks.resolveCodexAppServerAuthProfileStore).toHaveBeenCalledTimes(2);
+        startOptions: {
+          transport: "stdio",
+          homeScope: "agent",
+          command: "codex",
+          args: ["app-server"],
+          headers: {},
+        } satisfies CodexAppServerStartOptions,
+        authProfileId: selector === "explicit" ? "openai:work" : undefined,
+        timeoutMs: 1_000,
+      };
+      const firstAcquire = getLeasedSharedCodexAppServerClient(options);
+      await sendInitializeResult(first, "openclaw/0.149.0 (Linux; test)");
+      await expect(firstAcquire).resolves.toBe(first.client);
+      releaseLeasedSharedCodexAppServerClient(first.client);
+      await expect(getLeasedSharedCodexAppServerClient(options)).resolves.toBe(first.client);
+      releaseLeasedSharedCodexAppServerClient(first.client);
 
-    expect(clearSharedCodexAppServerClientIfCurrent(first.client)).toBe(true);
-    const replacementAcquire = getLeasedSharedCodexAppServerClient(options);
-    await sendInitializeResult(replacement, "openclaw/0.149.0 (Linux; test)");
-    await expect(replacementAcquire).resolves.toBe(replacement.client);
-    expect(releaseLeasedSharedCodexAppServerClient(replacement.client)).toBe(true);
-    expect(mocks.resolveCodexAppServerAuthProfileStore).toHaveBeenCalledTimes(3);
-    expect(startSpy).toHaveBeenCalledTimes(2);
-  });
+      mocks.resolveCodexAppServerPreparedAuthProfileSnapshot.mockResolvedValue({
+        loginParams: {
+          type: "chatgptAuthTokens",
+          accessToken: "replacement-token",
+          chatgptAccountId: "replacement-account",
+          chatgptPlanType: null,
+        },
+        secretFreeCacheKey: "replacement-account",
+      });
+      const nextAcquire = getLeasedSharedCodexAppServerClient(options);
+      await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2));
+      await sendInitializeResult(replacement, "openclaw/0.149.0 (Linux; test)");
+      await expect(nextAcquire).resolves.toBe(replacement.client);
+      releaseLeasedSharedCodexAppServerClient(replacement.client);
+      expect(mocks.applyCodexAppServerAuthProfile).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          preparedAuth: expect.objectContaining({
+            snapshot: expect.objectContaining({
+              loginParams: expect.objectContaining({
+                accessToken: "replacement-token",
+                chatgptAccountId: "replacement-account",
+              }),
+            }),
+          }),
+        }),
+      );
+    },
+  );
 
   it("does not spawn after startup context exceeds its total deadline", async () => {
     vi.useFakeTimers();
@@ -1342,6 +1352,50 @@ describe("shared Codex app-server client", () => {
     });
   });
 
+  it.each(["failure", "workspace-change"] as const)(
+    "retires a shared client after token refresh %s while existing leases drain",
+    async (failure) => {
+      const first = createClientHarness();
+      const replacement = createClientHarness();
+      const startSpy = vi
+        .spyOn(CodexAppServerClient, "start")
+        .mockReturnValueOnce(first.client)
+        .mockReturnValueOnce(replacement.client);
+      const options = { timeoutMs: 1_000, authProfileId: "openai:work" };
+      const acquired = getLeasedSharedCodexAppServerClient(options);
+      await sendInitializeResult(first, "openclaw/0.149.0 (Linux; test)");
+      await acquired;
+      if (failure === "failure") {
+        mocks.refreshCodexAppServerAuthTokens.mockRejectedValueOnce(new Error("refresh failed"));
+      } else {
+        mocks.refreshCodexAppServerAuthTokens.mockResolvedValueOnce({
+          accessToken: "other-token",
+          chatgptAccountId: "other-account",
+          chatgptPlanType: null,
+        });
+      }
+      first.send({
+        id: "failed-refresh",
+        method: "account/chatgptAuthTokens/refresh",
+        params: { reason: "unauthorized", previousAccountId: "original-account" },
+      });
+      await vi.waitFor(() =>
+        expect(first.writes.map((line) => JSON.parse(line))).toContainEqual(
+          expect.objectContaining({ id: "failed-refresh", error: expect.any(Object) }),
+        ),
+      );
+      expect(first.stdinDestroyed).toBe(false);
+      const nextAcquire = getLeasedSharedCodexAppServerClient(options);
+      await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2));
+      await sendInitializeResult(replacement, "openclaw/0.149.0 (Linux; test)");
+      await expect(nextAcquire).resolves.toBe(replacement.client);
+      expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
+      expect(first.stdinDestroyed).toBe(true);
+      expect(replacement.stdinDestroyed).toBe(false);
+      releaseLeasedSharedCodexAppServerClient(replacement.client);
+    },
+  );
+
   it("keeps a shared prepared auth store authoritative through startup and refresh", async () => {
     const harness = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
@@ -1410,95 +1464,114 @@ describe("shared Codex app-server client", () => {
     });
   });
 
-  it("separates prepared profile clients by secret-free account identity", async () => {
-    const firstHarness = createClientHarness();
-    const secondHarness = createClientHarness();
-    const startSpy = vi
-      .spyOn(CodexAppServerClient, "start")
-      .mockReturnValueOnce(firstHarness.client)
-      .mockReturnValueOnce(secondHarness.client);
-    const resolvedCacheKeys: string[] = [];
-    mocks.resolveCodexAppServerPreparedAuthProfileSnapshot.mockImplementation(
-      async (params?: {
-        authProfileStore?: {
-          profiles?: Record<string, { token?: string }>;
-        };
-      }) => {
-        const token = params?.authProfileStore?.profiles?.["openai:scoped"]?.token;
-        const key =
-          token === "first-secret-token" ? "account:sha256:first" : "account:sha256:second";
-        resolvedCacheKeys.push(key);
-        return {
-          loginParams: {
-            type: "chatgptAuthTokens" as const,
-            accessToken: token ?? "",
-            chatgptAccountId: "prepared-account",
-            chatgptPlanType: null,
+  it.each(["prepared", "selected"] as const)(
+    "separates %s profile clients by secret-free account identity",
+    async (selection) => {
+      const firstHarness = createClientHarness();
+      const secondHarness = createClientHarness();
+      const startSpy = vi
+        .spyOn(CodexAppServerClient, "start")
+        .mockReturnValueOnce(firstHarness.client)
+        .mockReturnValueOnce(secondHarness.client);
+      const resolvedCacheKeys: string[] = [];
+      mocks.resolveCodexAppServerPreparedAuthProfileSnapshot.mockImplementation(
+        async (params?: {
+          authProfileStore?: {
+            profiles?: Record<string, { token?: string }>;
+          };
+        }) => {
+          const token = params?.authProfileStore?.profiles?.["openai:scoped"]?.token;
+          const key =
+            token === "first-secret-token" ? "account:sha256:first" : "account:sha256:second";
+          resolvedCacheKeys.push(key);
+          return {
+            loginParams: {
+              type: "chatgptAuthTokens" as const,
+              accessToken: token ?? "",
+              chatgptAccountId: "prepared-account",
+              chatgptPlanType: null,
+            },
+            secretFreeCacheKey: key,
+          };
+        },
+      );
+      const firstStore = {
+        version: 1 as const,
+        profiles: {
+          "openai:scoped": {
+            type: "token" as const,
+            provider: "openai",
+            token: "first-secret-token",
           },
-          secretFreeCacheKey: key,
-        };
-      },
-    );
-    const firstStore = {
-      version: 1 as const,
-      profiles: {
-        "openai:scoped": {
-          type: "token" as const,
-          provider: "openai",
-          token: "first-secret-token",
         },
-      },
-    };
-    const secondStore = {
-      version: 1 as const,
-      profiles: {
-        "openai:scoped": {
-          type: "token" as const,
-          provider: "openai",
-          token: "second-secret-token",
+      };
+      const secondStore = {
+        version: 1 as const,
+        profiles: {
+          "openai:scoped": {
+            type: "token" as const,
+            provider: "openai",
+            token: "second-secret-token",
+          },
         },
-      },
-    };
+      };
 
-    const firstPromise = getSharedCodexAppServerClient({
-      timeoutMs: 1000,
-      preparedAuth: { kind: "profile", profileId: "openai:scoped", store: firstStore },
-    });
-    await sendInitializeResult(firstHarness, "openclaw/0.149.0 (macOS; test)");
-    await expect(firstPromise).resolves.toBe(firstHarness.client);
+      const firstPromise = getSharedCodexAppServerClient({
+        timeoutMs: 1000,
+        ...(selection === "prepared"
+          ? {
+              preparedAuth: {
+                kind: "profile" as const,
+                profileId: "openai:scoped",
+                store: firstStore,
+              },
+            }
+          : { authProfileId: "openai:scoped", authProfileStore: firstStore }),
+      });
+      await sendInitializeResult(firstHarness, "openclaw/0.149.0 (macOS; test)");
+      await expect(firstPromise).resolves.toBe(firstHarness.client);
 
-    const secondPromise = getSharedCodexAppServerClient({
-      timeoutMs: 1000,
-      preparedAuth: { kind: "profile", profileId: "openai:scoped", store: secondStore },
-    });
-    await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2));
-    await sendInitializeResult(secondHarness, "openclaw/0.149.0 (macOS; test)");
-    await expect(secondPromise).resolves.toBe(secondHarness.client);
+      const secondPromise = getSharedCodexAppServerClient({
+        timeoutMs: 1000,
+        ...(selection === "prepared"
+          ? {
+              preparedAuth: {
+                kind: "profile" as const,
+                profileId: "openai:scoped",
+                store: secondStore,
+              },
+            }
+          : { authProfileId: "openai:scoped", authProfileStore: secondStore }),
+      });
+      await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2));
+      await sendInitializeResult(secondHarness, "openclaw/0.149.0 (macOS; test)");
+      await expect(secondPromise).resolves.toBe(secondHarness.client);
 
-    expect(resolvedCacheKeys).toEqual(["account:sha256:first", "account:sha256:second"]);
-    expect(mocks.applyCodexAppServerAuthProfile).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({
-        preparedAuth: expect.objectContaining({
-          snapshot: expect.objectContaining({
-            loginParams: expect.objectContaining({ accessToken: "first-secret-token" }),
+      expect(resolvedCacheKeys).toEqual(["account:sha256:first", "account:sha256:second"]);
+      expect(mocks.applyCodexAppServerAuthProfile).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          preparedAuth: expect.objectContaining({
+            snapshot: expect.objectContaining({
+              loginParams: expect.objectContaining({ accessToken: "first-secret-token" }),
+            }),
           }),
         }),
-      }),
-    );
-    expect(mocks.applyCodexAppServerAuthProfile).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        preparedAuth: expect.objectContaining({
-          snapshot: expect.objectContaining({
-            loginParams: expect.objectContaining({ accessToken: "second-secret-token" }),
+      );
+      expect(mocks.applyCodexAppServerAuthProfile).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          preparedAuth: expect.objectContaining({
+            snapshot: expect.objectContaining({
+              loginParams: expect.objectContaining({ accessToken: "second-secret-token" }),
+            }),
           }),
         }),
-      }),
-    );
-    expect(resolvedCacheKeys.join("\n")).not.toContain("first-secret-token");
-    expect(resolvedCacheKeys.join("\n")).not.toContain("second-secret-token");
-  });
+      );
+      expect(resolvedCacheKeys.join("\n")).not.toContain("first-secret-token");
+      expect(resolvedCacheKeys.join("\n")).not.toContain("second-secret-token");
+    },
+  );
 
   it("starts a prepared API-key client without profile or ambient-store resolution", async () => {
     const harness = createClientHarness();

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -77,22 +77,6 @@ type SharedCodexAppServerClientState = {
   entriesByClient: WeakMap<CodexAppServerClient, SharedCodexAppServerClientEntry>;
   leasedReleases: WeakMap<CodexAppServerClient, Array<() => void>>;
   desktopGenerationDrainChecks: Set<() => void>;
-  warmClientsByConfig?: WeakMap<
-    object,
-    WeakMap<CodexAppServerStartOptions, Map<string, WarmSharedCodexAppServerClient>>
-  >;
-};
-
-type WarmSharedCodexAppServerClient = {
-  key: string;
-  entry: SharedCodexAppServerClientEntry;
-  client: CodexAppServerClient;
-};
-
-type WarmSharedCodexAppServerClientIdentity = {
-  config: object;
-  startOptions: CodexAppServerStartOptions;
-  selectorKey: string;
 };
 
 type CodexAppServerClientStartMetadata = {
@@ -381,7 +365,9 @@ async function resolveCodexAppServerClientStartContext(
     throw new Error("Prepared Codex auth cannot also select a legacy auth profile.");
   }
   if (preparedAuth?.kind === "profile" && !preparedAuth.store.profiles[preparedAuth.profileId]) {
-    throw new Error(`Prepared Codex auth profile "${preparedAuth.profileId}" was not found.`);
+    throw new Error(
+      `Prepared Codex auth profile "${preparedAuth.profileId}" was not found. Select an existing OpenAI profile or sign in again with OpenClaw, then retry.`,
+    );
   }
   if (preparedAuth?.kind === "api-key" && !preparedApiKey) {
     throw new Error("Prepared Codex API-key auth is missing its resolved key.");
@@ -411,12 +397,12 @@ async function resolveCodexAppServerClientStartContext(
   const authProfileStore =
     preparedAuth?.kind === "profile"
       ? preparedAuth.store
-      : !usesNativeAuth && options?.authProfileStore
+      : !usesNativeAuth && preparedAuth?.kind !== "api-key"
         ? resolveCodexAppServerAuthProfileStore({
             agentDir,
             authProfileId: requestedAuthProfileId,
-            authProfileStore: options.authProfileStore,
-            config: options.config,
+            authProfileStore: options?.authProfileStore,
+            config: options?.config,
           })
         : options?.authProfileStore;
   const authProfileId =
@@ -430,9 +416,11 @@ async function resolveCodexAppServerClientStartContext(
             config: options?.config,
             ...(authProfileStore ? { authProfileStore } : {}),
           });
+  // Resolve the selected profile once: the keyed process must log in with the
+  // same account material, including ordinary catalog callers without prepared auth.
   const preparedAuthProfileSnapshot =
-    preparedAuth?.kind === "profile"
-      ? (preparedAuth.snapshot ??
+    !usesNativeAuth && authProfileId
+      ? ((preparedAuth?.kind === "profile" ? preparedAuth.snapshot : undefined) ??
         (await resolveCodexAppServerPreparedAuthProfileSnapshot({
           authProfileId,
           authProfileStore,
@@ -441,17 +429,19 @@ async function resolveCodexAppServerClientStartContext(
         })))
       : undefined;
   if (preparedAuth?.kind === "profile" && !preparedAuthProfileSnapshot) {
-    throw new Error(`Prepared Codex auth profile "${preparedAuth.profileId}" is unusable.`);
+    throw new Error(
+      `Prepared Codex auth profile "${preparedAuth.profileId}" is unusable. Repair or replace the selected OpenAI profile, then retry.`,
+    );
   }
   const resolvedPreparedAuth: CodexAppServerResolvedPreparedAuth | undefined =
     preparedAuth?.kind === "api-key"
       ? { kind: "api-key", apiKey: preparedApiKey as string }
-      : preparedAuth?.kind === "profile"
+      : preparedAuthProfileSnapshot && authProfileId && authProfileStore
         ? {
-            ...preparedAuth,
-            snapshot: preparedAuthProfileSnapshot as NonNullable<
-              typeof preparedAuthProfileSnapshot
-            >,
+            kind: "profile",
+            profileId: authProfileId,
+            store: authProfileStore,
+            snapshot: preparedAuthProfileSnapshot,
           }
         : undefined;
   const agentStartOptions = resolveCodexAppServerStartOptionsForAgent({
@@ -459,12 +449,14 @@ async function resolveCodexAppServerClientStartContext(
     agentDir,
   });
   const managedStartOptions = await resolveManagedCodexAppServerStartOptions(agentStartOptions);
+  // Preserve ordinary profile environment policy; only explicitly prepared
+  // handoffs clear all inherited auth variables before spawning.
   const startOptions = await bridgeCodexAppServerStartOptions({
     startOptions: managedStartOptions,
     agentId: options?.agentId,
     agentDir,
     authProfileId: usesNativeAuth || preparedAuth?.kind === "api-key" ? null : authProfileId,
-    ...(resolvedPreparedAuth ? { preparedAuth: resolvedPreparedAuth } : {}),
+    ...(preparedAuth && resolvedPreparedAuth ? { preparedAuth: resolvedPreparedAuth } : {}),
     authRequirement,
     config: options?.config,
     pluginConfig: options?.pluginConfig,
@@ -503,82 +495,6 @@ function shouldTrackDesktopGeneration(
     startOptions.commandSource === "managed" &&
     (startOptions.managedCommandOrder ?? "package-first") === "desktop-first"
   );
-}
-
-function resolveWarmSharedCodexAppServerClientIdentity(
-  options?: CodexAppServerClientOptions,
-): WarmSharedCodexAppServerClientIdentity | undefined {
-  if (
-    !options?.config ||
-    typeof options.config !== "object" ||
-    !options.startOptions ||
-    options.pluginConfig !== undefined ||
-    options.authProfileStore !== undefined ||
-    options.preparedAuth !== undefined ||
-    options.runtimeArtifactMode !== undefined ||
-    options.expectedRuntimeArtifact !== undefined
-  ) {
-    return undefined;
-  }
-  const authProfileSelector =
-    options.authProfileId === null
-      ? ["native"]
-      : options.authProfileId === undefined
-        ? ["implicit"]
-        : ["profile", options.authProfileId];
-  return {
-    config: options.config,
-    startOptions: options.startOptions,
-    selectorKey: JSON.stringify([
-      options.agentDir ?? resolveDefaultAgentDir(options.config),
-      authProfileSelector,
-      options.authBindingFingerprint ?? null,
-      options.authRequirement ?? null,
-    ]),
-  };
-}
-
-function readWarmSharedCodexAppServerClient(
-  state: SharedCodexAppServerClientState,
-  identity: WarmSharedCodexAppServerClientIdentity,
-): WarmSharedCodexAppServerClient | undefined {
-  const aliases = state.warmClientsByConfig?.get(identity.config)?.get(identity.startOptions);
-  const warm = aliases?.get(identity.selectorKey);
-  if (!warm) {
-    return undefined;
-  }
-  // Config/start options are immutable runtime snapshots. The alias is valid only while the
-  // canonical keyed entry still owns this physical client; close, retirement, and auth-profile
-  // invalidation remove that entry, forcing the next acquire through full start-context resolution.
-  if (
-    state.clients.get(warm.key) !== warm.entry ||
-    warm.entry.client !== warm.client ||
-    warm.entry.closeWhenIdle ||
-    warm.entry.closeError
-  ) {
-    aliases?.delete(identity.selectorKey);
-    return undefined;
-  }
-  return warm;
-}
-
-function rememberWarmSharedCodexAppServerClient(
-  state: SharedCodexAppServerClientState,
-  identity: WarmSharedCodexAppServerClientIdentity,
-  warm: WarmSharedCodexAppServerClient,
-): void {
-  state.warmClientsByConfig ??= new WeakMap();
-  let byStartOptions = state.warmClientsByConfig.get(identity.config);
-  if (!byStartOptions) {
-    byStartOptions = new WeakMap();
-    state.warmClientsByConfig.set(identity.config, byStartOptions);
-  }
-  let aliases = byStartOptions.get(identity.startOptions);
-  if (!aliases) {
-    aliases = new Map();
-    byStartOptions.set(identity.startOptions, aliases);
-  }
-  aliases.set(identity.selectorKey, warm);
 }
 
 /** Gets or starts a shared Codex app-server client without retaining a lease. */
@@ -730,30 +646,6 @@ async function acquireSharedCodexAppServerClient(
   const acquireStartedAt = Date.now();
   const timeoutMs = options?.timeoutMs ?? 0;
   const state = getSharedCodexAppServerClientState();
-  const warmIdentity = resolveWarmSharedCodexAppServerClientIdentity(options);
-  let warmClient = warmIdentity
-    ? readWarmSharedCodexAppServerClient(state, warmIdentity)
-    : undefined;
-  const warmGeneration = warmClient
-    ? getCodexAppServerClientStartMetadata().get(warmClient.client)?.desktopGeneration
-    : undefined;
-  if (warmClient && warmGeneration && !isCodexDesktopGenerationCurrent(warmGeneration)) {
-    await withCodexAppServerAcquireDeadline(
-      resolveRemainingAcquireTimeout(timeoutMs, acquireStartedAt),
-      waitForCodexDesktopGeneration(),
-      options?.abandonSignal,
-    );
-    if (!isCodexDesktopGenerationCurrent(warmGeneration)) {
-      retireSharedCodexAppServerClientIfCurrent(warmClient.client);
-      warmClient = undefined;
-    }
-  }
-  if (warmClient) {
-    warmClient.entry.leaseGeneration += 1;
-    options?.onStartedClient?.(warmClient.client);
-    const release = leaseOptions?.leased ? retainSharedClientEntry(warmClient.entry) : undefined;
-    return release ? { client: warmClient.client, release } : { client: warmClient.client };
-  }
   const context = await withCodexAppServerAcquireDeadline(
     timeoutMs,
     resolveCodexAppServerClientStartContext(options),
@@ -893,9 +785,6 @@ async function acquireSharedCodexAppServerClient(
       config: options?.config,
     });
     const release = leaseOptions?.leased ? retainSharedClientEntry(entry) : undefined;
-    if (warmIdentity) {
-      rememberWarmSharedCodexAppServerClient(state, warmIdentity, { key, entry, client });
-    }
     return release ? { client, release } : { client };
   } catch (error) {
     // This deadline belongs to one waiter, not the shared physical client.
@@ -1283,6 +1172,7 @@ async function startInitializedCodexAppServerClient(params: {
       authMode: params.preparedAuth?.kind === "api-key" ? "prepared-api-key" : "profile",
       ...(params.authProfileStore ? { authProfileStore: params.authProfileStore } : {}),
       config: params.config,
+      onAuthRefreshFailure: () => retireSharedCodexAppServerClientIfCurrent(client),
     });
 
     try {
@@ -1380,7 +1270,6 @@ export function resetSharedCodexAppServerClientForTests(): void {
   state.isolatedClients.clear();
   state.entriesByClient = new WeakMap();
   state.leasedReleases = new WeakMap();
-  state.warmClientsByConfig = new WeakMap();
   for (const client of clients) {
     client.close();
   }
@@ -1395,7 +1284,6 @@ export function clearSharedCodexAppServerClient(): void {
   const state = getSharedCodexAppServerClientState();
   const clients = collectSharedClients(state);
   state.clients.clear();
-  state.warmClientsByConfig = new WeakMap();
   for (const client of clients) {
     client.close();
   }
@@ -1660,7 +1548,6 @@ export async function clearSharedCodexAppServerClientAndWait(options?: {
   const state = getSharedCodexAppServerClientState();
   const clients = collectSharedClients(state);
   state.clients.clear();
-  state.warmClientsByConfig = new WeakMap();
   await Promise.all(clients.map((client) => client.closeAndWait(options)));
 }
 

--- a/extensions/codex/src/command-rpc.test.ts
+++ b/extensions/codex/src/command-rpc.test.ts
@@ -204,9 +204,7 @@ describe("Codex command RPC helpers", () => {
         },
       });
       expect(acquiredOptions().authProfileId).toBeUndefined();
-      expect(acquiredOptions().authBindingFingerprint).toEqual(
-        type === "token" ? expect.stringMatching(/^[a-f0-9]{64}$/) : undefined,
-      );
+      expect(acquiredOptions().authBindingFingerprint).toMatch(/^[a-f0-9]{64}$/);
       expect(onResponse).toHaveBeenCalledWith(expect.anything(), harness.client, {
         authProfileId: "openai:ready",
         assertCurrent: expect.any(Function),


### PR DESCRIPTION
> [!IMPORTANT]
> **review-required: codex auth surface.** Prepared under the auto-QA campaign; auth/credential semantics are review-required, so this stays a draft for maintainer review and is not counted or merged autonomously.

## What Problem This Solves

Four related auth-ownership defects in the Codex plugin (R4-R7 of the campaign audit):

1. **Private bounded turns lose credentials** (R4): with operator `homeScope: "user"`, private-stdio bounded turns started Codex on an empty temp `CODEX_HOME` with no credentials — hosted web-search and settled-turn finalization failed hard under documented config. The `homeScope: "agent"` correction was gated on `preparedAuth`, so the profile branch kept `"user"` and discarded the profile.
2. **Custom commands persist API keys in plaintext** (R5): custom/env `appServer.command` skipped the ephemeral auth store (managed-only gate in `auth-start-options.ts`), so `account/login/start` wrote the OpenAI API key to `CODEX_HOME/auth.json` in plaintext, contradicting `docs/plugins/codex-harness-reference.md`.
3. **Failed refreshes never retire the cached client** (R6): workspace-changed refresh failures left the shared client cached, producing a permanent failure loop with dead-end error text naming no remedy.
4. **Shared/warm client identity gaps** (R7): OAuth re-login under the same profile id was invisible to the cache key, and the warm alias keyed as literal `"implicit"` was never invalidated by auth-store mutation despite a comment claiming it was.

A deep-context Codex review pass on the finished branch found and fixed a fifth defect the worker missed: `hasMatchingOAuthIdentity` compared only **stored** account IDs plus email, so two different workspaces sharing an email (account IDs carried only in token claims) aliased — a retained stale snapshot for workspace A could take the persisted path on refresh and **overwrite workspace B's credentials**.

## Why This Change Was Made

Fixes land at owners: private-home scope at its start-options producer (`bounded-turn.ts`), credential-store policy at owned stdio startup (`auth-start-options.ts` — the managed-only gate was unnecessary since `-c` overrides are clap-global upstream), physical-client retirement at the shared-client lifecycle, and workspace identity resolved via the existing canonical `resolveOpenAICodexAuthIdentity` (stored IDs keep precedence; claim-only IDs now participate). The warm `"implicit"` alias is removed rather than patched — its key lacked the required auth-store invalidation contract; the normal keyed process cache still reuses unchanged identities.

Upstream contracts personally inspected in sibling `openai/codex` at `be6e8eac029` (home-dir selection, credential-store modes, ephemeral process-local map, clap-global `-c`, external-auth refresh boundary in `external_auth.rs`, refresh identity in `auth/manager.rs`). A real-binary probe against the plugin-pinned Codex 0.150.1 (fake key, temp homes) verified: default login writes `auth.json`, ephemeral login does not, final ephemeral override wins.

## User Impact

- Private bounded turns (web search, settled-turn finalization) work under `homeScope: "user"` config instead of failing on an empty home.
- Custom `appServer.command` setups no longer persist API keys to disk.
- A failed credential refresh recovers on the next acquisition instead of looping forever; error text names the remedy.
- Multi-workspace OAuth setups can no longer cross-contaminate persisted credentials.

## Evidence

- Production **+122/−214 (net −92)**; tests/support net +197; docs net +9. Assertion ratchet +1/−1 (shrink).
- Failing-first regressions per finding (worker logs `/tmp/codex-auth-*`; review follow-up: 3 passed / 1 failed pre-fix, workspace-aliasing case).
- Post-rebase onto `e0680fdd42b`: 6 focused app-server suites, **282 passed / 0 failed**.
- Full changed-file gate across all 15 cluster paths: **PASS exit 0** (types, lint, format, ratchets, unused-export scans, doctor/plugin/storage/media/loader guards, import cycles).
- Two independent Codex autoreviews clean (worker + deep-review follow-up).
- Residual: real OAuth re-login and credentialed hosted search remain unverified live; deterministic suites cover the owner boundaries and the real-binary probe covers credential-store behavior.
