### PR TITLE
docs: correct verification and hardened setup claims

### DIFF
--- a/docs/start/why-openclaw.md
+++ b/docs/start/why-openclaw.md
@@ -94,7 +94,7 @@ A remote tool backend also changes what sandboxed code can reach. Hermes can mov
 
 Deterministic enforcement is not unique to OpenClaw — Claude Code, Codex, and Goose all gate approvals in code. Structural tool gating in a multi-channel assistant, rather than a terminal, is rarer: [permission modes](/gateway/permission-modes) shape which tools exist at all. A `read-only` session never has the file-mutation tools registered — `edit`, `write`, and `apply_patch` are not offered to the model — and its exec tool resolves to a deny policy that refuses at the call boundary. `full` requires `operator.admin`, and scopes are derived from request parameters before dispatch ([operator scopes](/gateway/operator-scopes)), so a method with a privileged parameter still needs the privileged scope.
 
-Three controls govern separate decisions ([sandbox vs. tool policy vs. elevated](/gateway/sandbox-vs-tool-policy-vs-elevated)). The sandbox decides where tools run. Tool policy decides which tools exist; deny always wins, and a blocked call's audit entry names the deny rule that fired. `tools.elevated` is an exec-only escape hatch that cannot override a deny.
+Three controls govern separate decisions ([sandbox vs. tool policy vs. elevated](/gateway/sandbox-vs-tool-policy-vs-elevated)). The sandbox decides where tools run. Tool policy decides which tools exist; deny always wins. Routine policy-filter diagnostics name the configured layer and matched deny entries at debug level; the [durable audit ledger](/gateway/audit) records blocked outcomes separately, without the matched rule. `tools.elevated` is an exec-only escape hatch that cannot override a deny.
 
 [Exec approvals](/tools/exec-approvals) bind an approved run to its canonical command, cwd, environment hash, and content-hashed file operands, and deny on any drift after approval. Supported pipelines and command chains can use enforced execution plans. Shell forms or interpreter invocations for which OpenClaw cannot establish the required execution and file bindings are refused. When no approval UI is reachable, the answer is deny by default, and strict cases (inline eval, heredocs) cannot be softened by any fallback setting.
 
@@ -180,7 +180,7 @@ Like other OpenClaw features, harnesses ship as plugins against a core that stay
 
 The public plugin SDK publishes about 150 entrypoints, held under shrink-only surface budgets so growth is a conscious decision. Hermes also has a broad [Python plugin API](https://github.com/NousResearch/hermes-agent/blob/6defe7eb6c462bb784d1f27f5afe7ca4b627fc70/hermes_cli/plugins.py), including tools, platforms, context engines, memory, secret sources, and media providers, plus a [desktop plugin SDK](https://github.com/NousResearch/hermes-agent/blob/6defe7eb6c462bb784d1f27f5afe7ca4b627fc70/website/docs/developer-guide/desktop-plugin-sdk.md). Its seven consent capability IDs describe permission gates, not the size of that API.
 
-[ClawHub](/clawhub) is OpenClaw's registry, with [publishing](/clawhub/publishing), moderation, [security audits](/clawhub/security-audits), and per-release trust verdicts consumed during installation. Hermes also distributes skills through tap repositories and maintains an MCP catalog. ClawHub shows skill scan status from VirusTotal, ClawScan, and static analysis, but a pending or stale scan can allow installation with a warning; installation is not proof that every scan completed. [`openclaw skills verify`](/tools/skills) checks installed content against its trust envelope to detect changes after installation.
+[ClawHub](/clawhub) is OpenClaw's registry, with [publishing](/clawhub/publishing), moderation, [security audits](/clawhub/security-audits), and per-release trust verdicts consumed during installation. Hermes also distributes skills through tap repositories and maintains an MCP catalog. ClawHub shows skill scan status from VirusTotal, ClawScan, and static analysis, but a pending or stale scan can allow installation with a warning; installation is not proof that every scan completed. [`openclaw skills verify`](/cli/skills) retrieves ClawHub's verification envelope for the selected skill, using installed registry and version metadata by default; it does not hash current local files.
 
 ## Open standards
 
@@ -246,12 +246,14 @@ Hermes also has [opt-in session pruning](https://github.com/NousResearch/hermes-
 | Security record      | Public repository advisories and documented trust model; counts are not a safety score                                      | Third-party CVEs and historical user reports; no public repository advisories at the review date                                                                                       |
 | Governance           | OpenClaw Foundation, MIT, public maturity scorecard                                                                         | Nous Research, venture-backed, MIT                                                                                                                                                     |
 
+Since the comparison snapshot, Hermes has added [optional persistent local Python kernels](https://github.com/NousResearch/hermes-agent/blob/dd401e0f15c6d527d5ce01367732746f1da5df3d/tools/code_execution_tool.py#L1464). `code_execution.kernel_mode: session` keeps Python state across local calls; the default remains `per-call`, and kernel state does not survive process restart.
+
 ## The hardened setup
 
 Each enterprise configuration item links to its reference:
 
 - Sandbox on: `agents.defaults.sandbox.mode: "all"` with the [`openshell`](/gateway/openshell) or [`docker`](/gateway/sandboxing) backend; `workspaceAccess: "ro"` unless the agent owns the workspace.
-- Set session defaults to [`guarded` or `workspace`](/gateway/permission-modes); `full` stays admin-only.
+- Select [`guarded` or `workspace`](/gateway/permission-modes) per session; `full` requires `operator.admin`. Managed worktree sessions default to `workspace`; other sessions without a mode use configured tool/exec policy.
 - Front the gateway with [Tailscale](/gateway/tailscale) or an [identity-aware proxy](/gateway/trusted-proxy-auth); define [`gateway.roles`](/gateway/operator-scopes) with a deny-all default; leave DM policy on [pairing](/channels/pairing).
 - Everything behind [SecretRefs](/gateway/secrets); run `openclaw secrets audit --check` against your config in CI.
 - Enable [message auditing](/gateway/audit); export [OpenTelemetry](/gateway/opentelemetry) to your SIEM with operator-owned retention and monitoring for dropped data.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where readers of [Why OpenClaw](https://docs.openclaw.ai/start/why-openclaw) could expect local skill integrity checks, rule-bearing durable audit records, or a configurable session permission default that the current implementation does not provide.

## Why This Change Was Made

The page now distinguishes ClawHub's remote verification envelope from current local file contents, policy diagnostics from durable blocked outcomes, and per-session permission selection from managed-worktree defaults. A separate, immutable Hermes source citation adds its optional persistent local Python kernel without refreshing unrelated comparison claims.

## User Impact

Operators can interpret verification and audit results accurately and follow a supported session setup path. The architecture, policy guarantees, existing comparison, headings, and three diagrams remain intact except for the specific unsupported wording. No runtime behavior, configuration, schema, dependency, or permission changes; production and test LOC are both zero.

## Evidence

Personally checked the claim owners at OpenClaw `6e827231257cf7c9c26ecd54fdc73d8c30afa5d8`:

- `skills-cli.ts` → `resolveClawHubSkillVerificationTarget` → `fetchClawHubSkillVerification` sends identity/version selectors, not current local hashes.
- `tool-policy-audit.ts` emits bounded filtering diagnostics at debug; `agent-event-audit.ts` projects trusted blocks to `blocked` / `tool_blocked` without matched-rule details.
- `sessions-create.ts` uses the selected permission mode, defaulting only managed worktree sessions to `workspace`; session and agent-default config schemas have no permission-mode default.

Hermes [`dd401e0f15`](https://github.com/NousResearch/hermes-agent/tree/dd401e0f15c6d527d5ce01367732746f1da5df3d) was inspected as source only: `config_defaults.py` keeps `per-call` as the default, `code_execution_tool.py` routes remote work before kernel selection, and `code_kernel.py` retains state in a local child. No Hermes code was executed.

Validation passed: docs listing, one-page MDX compilation, formatting, whitespace, and the internal-link audit (6,903 links; zero broken). A preservation check confirms only three existing passages changed and one note was added; all headings and three Mermaid blocks are unchanged. Requested Codex autoreview completed successfully with no actionable P0 findings. Its first attempt failed before producing a result with an older workspace CLI; the same-engine retry used the installed current CLI with isolation unchanged.

This is a bounded documentation repair, not new live-runtime, adversarial, benchmark, or security-certification proof. Historical advisory counts, CVEs, and the older comparison pins were not recertified. Memory artifact cleanup and the other runtime repairs remain separate.
