### PR TITLE
fix(codex): keep unsupported service-tier warnings out of chat

### DIFF
--- a/extensions/codex/src/app-server/event-projector-events.ts
+++ b/extensions/codex/src/app-server/event-projector-events.ts
@@ -275,7 +275,15 @@ export class CodexEventProjection {
     const summary = readString(params, "summary") ?? readString(params, "message");
     const details = readString(params, "details");
     const message = [summary, details].filter(Boolean).join("\n");
-    if (message) {
+    // Codex's unsupported_service_tier_warning has no structured code. Match its
+    // complete template so this routine diagnostic stays log-only, not other warnings.
+    if (
+      /^Configured service tier `[^`\r\n]+` is not advertised as supported for model `[^`\r\n]+` and will be omitted from requests\.$/.test(
+        message,
+      )
+    ) {
+      embeddedAgentLog.warn(message);
+    } else if (message) {
       this.emitAgentEvent({ stream: "notice", data: { phase: "warning", message } });
     }
   }

--- a/extensions/codex/src/app-server/event-projector.reasoning.test.ts
+++ b/extensions/codex/src/app-server/event-projector.reasoning.test.ts
@@ -1,5 +1,6 @@
 import {
   describe,
+  embeddedAgentLog,
   registerCodexEventProjectorTestLifecycle,
   expect,
   it,
@@ -424,7 +425,29 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
     });
   });
 
-  it("surfaces startup and thread warnings without requiring an upstream turn id", async () => {
+  it.each([
+    { tier: "priority", model: "ultima-alpha" },
+    { tier: "flex", model: "test-no-tier-model" },
+  ])("logs unsupported $tier tiers without projecting a UI notice", async ({ tier, model }) => {
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => {});
+    const onAgentEvent = vi.fn();
+    const projector = await createProjector({ ...(await createParams()), onAgentEvent });
+    const message = `Configured service tier \`${tier}\` is not advertised as supported for model \`${model}\` and will be omitted from requests.`;
+
+    await projector.handleNotification({
+      method: "warning",
+      params: { threadId: THREAD_ID, message },
+    });
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(message);
+  });
+
+  it.each([
+    "Project hooks were disabled.",
+    "Configured service tier `priority` requires account access.",
+    "Configured service tier `priority` is not advertised as supported for model `ultima-alpha` and will be omitted from requests. Additional action required.",
+  ])("surfaces startup and thread warnings: %s", async (message) => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({ ...(await createParams()), onAgentEvent });
 
@@ -437,7 +460,7 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
     });
     await projector.handleNotification({
       method: "warning",
-      params: { threadId: THREAD_ID, message: "Project hooks were disabled." },
+      params: { threadId: THREAD_ID, message },
     });
     await projector.handleNotification({
       method: "warning",
@@ -454,7 +477,7 @@ describe("CodexAppServerEventProjector reasoning and guardian projection", () =>
       },
       {
         stream: "notice",
-        data: { phase: "warning", message: "Project hooks were disabled." },
+        data: { phase: "warning", message },
       },
     ]);
   });


### PR DESCRIPTION
Closes #131189 — unsupported Codex service-tier diagnostics clutter chat.

## What Problem This Solves

Fixes an issue where users starting a Codex chat see a SYSTEM notice that their configured service tier is unsupported, even though Codex already continues by omitting that tier. The maintainer requested that this specific diagnostic stay in logs rather than the UI.

## Why This Change Was Made

Classify the exact upstream unsupported-service-tier message in the Codex plugin's warning projector and send it to the existing warning logger instead of the generic notice stream. Codex supplies no structured warning code, so matching is anchored to its complete template and does not hardcode a model or tier.

The owning boundary is `extensions/codex/src/app-server/event-projector-events.ts::handleWarning`. Filtering there prevents both live notice delivery and reconnect snapshot retention. No vendor-specific policy is added to the gateway or UI. Other warnings, configuration details, Guardian notices, model routing, and the upstream tier-omission behavior are unchanged.

## User Impact

Unsupported-service-tier diagnostics no longer clutter chat; operators can still find them in logs. Other warnings remain visible. No configuration, protocol, SDK, persistence, dependency, or default changes.

## Evidence

- Before fix: `node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.reasoning.test.ts` fails both new cases because the priority and flex warnings emit UI notices (2 failed, 15 passed).
- After fix: the same command passes all 19 tests, including logging, unrelated warnings, similar-but-not-identical service-tier messages, configuration-warning details, thread filtering, and Guardian behavior.
- Final-source `pnpm build` passed, including Control UI build. Inspected the generated runtime bundle and confirmed the log-only branch is present.
- `oxfmt --check` on both changed files and `git diff --check` passed.
- Fresh structured Codex autoreview: clean, no accepted/actionable findings.
- Actual isolated Gateway + Chromium + native Codex flow passed: Codex with `priority` completed a real turn with `LIVE_SERVICE_TIER_OK`. The exact unsupported-tier warning was retained in the gateway log and absent from both terminal and reloaded chat screenshots.
- This live run used the desktop-owned native Codex `0.150.0-alpha.8`, selected by the documented user-home mode, with a private task-only Codex home. No operator gateway or live state was changed. The installed managed binary separately reports 0.150.1.
- `node scripts/check-changed.mjs -- extensions/codex/src/app-server/event-projector-events.ts extensions/codex/src/app-server/event-projector.reasoning.test.ts` passed all selected checks (extension and test types, lint, boundary/contract/legacy-store guards, and import cycles).
- Exact-head CI passed for `347a451b46da948bf8cf4cc79b232acd6ecabac5`: [run 33117510893](https://github.com/openclaw/openclaw/actions/runs/33117510893).
- Proof limitation: an additional malformed-rule live negative-control attempt did not make the native app-server emit a configuration warning, so it is not counted as proof. The actual service-tier live flow passed; unrelated/configuration/Guardian warning preservation is covered by the passing automated controls.

### Live proof

Proof-media links have been removed during privacy cleanup.

Retained gateway diagnostic (model identifier redacted):

```text
2026-08-27T14:19:10.271-07:00 [agent/embedded] Configured service tier `priority` is not advertised as supported for model `Codex` and will be omitted from requests.
```

The isolated native-auth discovery setup intentionally has no model-picker catalog entries; the model was selected in gateway configuration, and the real turn and retained diagnostic establish the `Codex` path. The maintainer-supplied before screenshot showed this same diagnostic as a SYSTEM row.

### Contract and ownership proof

Personally inspected upstream Codex at `5f49aba876922d6f2f55caa153bbb0ed1b46feba`:

- [Warning producer and tier omission](https://github.com/openai/codex/blob/5f49aba876922d6f2f55caa153bbb0ed1b46feba/codex-rs/core/src/session/mod.rs#L945).
- [App-server warning forwarding](https://github.com/openai/codex/blob/5f49aba876922d6f2f55caa153bbb0ed1b46feba/codex-rs/app-server/src/bespoke_event_handling.rs#L255).
- [Warning payload has only threadId/message](https://github.com/openai/codex/blob/5f49aba876922d6f2f55caa153bbb0ed1b46feba/codex-rs/app-server-protocol/src/protocol/v2/notification.rs#L21).
- Managed local binary reports Codex 0.150.1.

Entry: `event-projector.ts:320`; producer: `event-projector-events.ts:274`; reconnect consumer: `src/gateway/server-chat-progress-snapshot.ts:46`; UI consumer: `ui/src/pages/chat/tool-stream.ts:904`. These owner modules are unchanged on current main at `e0680fdd42be52e042e401d019a615762848b1e4` before this patch. General warning projection arrived in #128370 (Codex 0.149.1 integration, authored by @clawsweeper, merged by @steipete); this change narrows presentation only.

Production LOC: +9/-1 (net +8). Tests: +26/-3 (net +23). The production growth is the exact dependency-template classifier and existing log route; no new helper, option, fallback, or consumer path. Removed path: projecting this specific diagnostic as a generic notice. A UI-only filter was rejected because it would leave the producer and reconnect snapshots unchanged.

AI-assisted maintainer repair. Release-note context: keep unsupported Codex service-tier diagnostics in logs without showing chat SYSTEM notices.

_Model identifiers and model-selection arguments have been redacted from this report._
