### PR TITLE
fix(ui): use accent activity and muted dashboard badges

### DIFF
--- a/ui/public/themes/beacon.css
+++ b/ui/public/themes/beacon.css
@@ -88,7 +88,6 @@
   --danger-subtle: rgba(255, 255, 255, 0.1);
   --info: #8ecdff;
   --info-subtle: rgba(255, 255, 255, 0.1);
-  --run: #5ee88a;
 
   /* Diff ink is a status pair too: it sits on the same neutral tints. */
   --hljs-deletion: #ffaba3;
@@ -184,7 +183,6 @@
   --danger-subtle: rgba(0, 0, 0, 0.07);
   --info: #09428d;
   --info-subtle: rgba(0, 0, 0, 0.07);
-  --run: #0c5024;
 
   /* Diff ink is a status pair too: it sits on the same neutral tints. */
   --hljs-deletion: #8b0c20;

--- a/ui/src/components/app-sidebar-render.ts
+++ b/ui/src/components/app-sidebar-render.ts
@@ -225,7 +225,7 @@ export function renderAppSidebarHomeRow(host: AppSidebarRenderHost) {
       ${sessionHasBoard(mainKey)
         ? html`<openclaw-tooltip .content=${t("sessionsView.dashboardAvailable")}>
             <span
-              class="sidebar-board-glyph"
+              class="session-row-badge"
               role="img"
               aria-label=${t("sessionsView.dashboardAvailable")}
               >${icons.layoutDashboard}</span

--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -362,7 +362,7 @@ export function renderRecentSession(params: {
             <span class="sidebar-recent-session__details-endcap">
               ${!session.isChild && sessionHasBoard(session.key)
                 ? html`<span
-                    class="sidebar-board-glyph"
+                    class="session-row-badge"
                     role="img"
                     aria-label=${t("sessionsView.dashboardAvailable")}
                     title=${t("sessionsView.dashboardAvailable")}

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -404,11 +404,54 @@ suite.define(() => {
       const plainRow = page.locator(`.sidebar-recent-session[data-session-key="${plainKey}"]`);
       await busyRow.locator(".session-row-badges").waitFor();
       const sidebar = page.locator("openclaw-app-sidebar");
-      const homeBoard = sidebar.locator(".nav-item--home .sidebar-board-glyph svg");
-      const sessionBoard = busyRow.locator(".sidebar-board-glyph svg");
+      const homeBoard = sidebar
+        .locator(".nav-item--home")
+        .getByRole("img", { name: "Dashboard available" })
+        .locator("svg");
+      const sessionBoard = busyRow.getByRole("img", { name: "Dashboard available" }).locator("svg");
       const ordinaryBadge = busyRow.locator(".session-row-badge--incognito svg");
       await homeBoard.waitFor({ state: "visible" });
       await sessionBoard.waitFor({ state: "visible" });
+      const automationBadge = busyRow
+        .getByRole("img", { name: "Automation attached" })
+        .locator("svg");
+      for (const colorScheme of ["dark", "light"] as const) {
+        await page.emulateMedia({ colorScheme });
+        await expect.poll(() => page.locator("html").getAttribute("data-theme")).toBe(colorScheme);
+        const automationStyle = await automationBadge.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return { color: style.color, strokeWidth: style.strokeWidth };
+        });
+        for (const board of [homeBoard, sessionBoard]) {
+          expect
+            .soft(
+              await board.evaluate((element) => {
+                const style = getComputedStyle(element);
+                return { color: style.color, strokeWidth: style.strokeWidth };
+              }),
+            )
+            .toEqual(automationStyle);
+        }
+        for (const reducedMotion of ["no-preference", "reduce"] as const) {
+          await page.emulateMedia({ reducedMotion });
+          const spinnerColors = await busyRow
+            .locator(".session-run-spinner")
+            .evaluate((element) => {
+              const style = getComputedStyle(element);
+              const accent = document.createElement("span").style;
+              accent.color = style.getPropertyValue("--accent").trim();
+              return { actual: style.borderTopColor, expected: accent.color };
+            });
+          expect.soft(spinnerColors.actual).toBe(spinnerColors.expected);
+        }
+        await page.emulateMedia({ reducedMotion: "no-preference" });
+        if (captureUiProofEnabled) {
+          await page.locator(".shell-nav").screenshot({
+            animations: "disabled",
+            path: path.join(sessionSecondRowProofDir, `indicators-${colorScheme}.png`),
+          });
+        }
+      }
       const shellNav = page.locator(".shell-nav");
       const sidebarResizer = page.getByRole("separator", { name: "Resize sidebar" });
       const badgeSizes = [];

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -195,11 +195,6 @@
   --warn-strong: #d97706;
   --danger-solid-hover: #dc2626;
   --pr-merged: #a78bfa;
-  /* Run state needs its own token: --accent is red in every shipped theme and
-     sits on top of --danger, so a spinning ring reads as a failed session.
-     Graphical indicator, judged against WCAG 1.4.11 (3:1), not the label audit
-     above: #14b8a6 is 7.7:1 on --bg. */
-  --run: #14b8a6;
 
   /* Focus */
   --focus: rgba(255, 92, 92, 0.2);
@@ -612,9 +607,6 @@
   --info: #1d4ed8;
   --info-subtle: rgba(29, 78, 216, 0.08);
   --pr-merged: #7c3aed;
-  /* See the dark-theme note: run state stays off --accent. #0d9488 is 3.6:1 on
-     --bg, above the 3:1 WCAG 1.4.11 bar for a non-text indicator. */
-  --run: #0d9488;
 
   --focus: rgba(189, 69, 49, 0.15);
   --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 70%, transparent);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -164,8 +164,8 @@ openclaw-session-owner-chip {
   position: absolute;
   inset: -2px;
   box-sizing: border-box;
-  border: 1.5px solid color-mix(in srgb, var(--run) 28%, transparent);
-  border-top-color: var(--run);
+  border: 1.5px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  border-top-color: var(--accent);
   border-radius: var(--radius-full);
   pointer-events: none;
 }
@@ -5797,8 +5797,8 @@ td.data-table-key-col {
   width: 12px;
   height: 12px;
   flex: 0 0 auto;
-  border: 1.5px solid color-mix(in srgb, var(--run) 28%, transparent);
-  border-top-color: var(--run);
+  border: 1.5px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  border-top-color: var(--accent);
   border-radius: var(--radius-full);
 }
 
@@ -5817,7 +5817,7 @@ td.data-table-key-col {
   .session-run-spinner,
   .session-glyph__ring {
     animation: none;
-    border-color: var(--run);
+    border-color: var(--accent);
   }
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1878,7 +1878,7 @@ openclaw-settings-save-indicator:empty {
 }
 
 .sidebar-child-session-toggle--running {
-  color: var(--run);
+  color: var(--accent);
 }
 
 .sidebar-child-session-toggle--failed {
@@ -1906,22 +1906,6 @@ openclaw-settings-save-indicator:empty {
 
 .sidebar-recent-session__link:hover {
   text-decoration: none;
-}
-
-.sidebar-board-glyph {
-  display: inline-flex;
-  flex: 0 0 auto;
-  color: color-mix(in srgb, var(--accent) 76%, var(--muted));
-}
-
-.sidebar-board-glyph svg {
-  width: 12px;
-  height: 12px;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 1.7px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 
 .viewer-facepile {

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -307,7 +307,7 @@ describe("AppSidebar agent chip", () => {
       sidebar.requestUpdate();
       await sidebar.updateComplete;
 
-      const glyph = sidebar.querySelector(".nav-item--home .sidebar-board-glyph");
+      const glyph = sidebar.querySelector('.nav-item--home [aria-label="Dashboard available"]');
       expect(glyph?.getAttribute("aria-label")).toBe("Dashboard available");
       expect(glyph?.hasAttribute("title")).toBe(false);
       expect(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where running-session indicators use a separate teal color and dashboard availability icons are more prominent than automation metadata in the Control UI sidebar.

Maintainer-requested visual simplification: use the theme accent for running work and make dashboard icons as understated as automation icons.

## Why This Change Was Made

Use `--accent` directly for run spinners, glyph rings, reduced-motion rings, and running-child toggles. Remove the unused `--run` token and its Beacon theme overrides. Home and session dashboard icons reuse the existing muted automation badge style (12px, 1.6px stroke), removing the dedicated accent-tinted dashboard styling.

No state, routing, tooltip, accessibility-label, or configuration behavior changes. Production LOC: **+8/-34 (net -26)**; tests/test-support: **+46/-3**.

## User Impact

Running work follows the selected theme accent. Dashboard availability stays visible without competing with activity or attention indicators.

## Evidence

- Extended the existing real-Chromium sidebar browser regression with dark/light dashboard-to-automation color/stroke parity and accent-color assertions under normal and reduced motion.
- The regression failed on the original styles for both reported differences; the fixed test passes.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts` — **5 passed**.
- Sidebar and base-theme unit suites — **322 passed** across three files.
- `node scripts/ui.js build` and full `pnpm build` — **passed**, including finalized asset sidecars and UI performance budget checks.
- Targeted oxfmt and `git diff --check` — **passed**.
- Fresh Autoreview (Codex Sol) — **clean**, no accepted/actionable findings.
- `node scripts/check-changed.mjs` — **passed**, including UI/core-test typechecks, lint, stylelint, formatting, i18n, and dead-export guards.

### Before / after — dark

| Before | After |
| --- | --- |
| ![Dark sidebar before](https://github.com/user-attachments/assets/9ac41626-6e6d-4df5-b0c1-8fc583764d5c) | ![Dark sidebar after](https://github.com/user-attachments/assets/2024172d-63af-408a-b6f4-b3545caf2777) |

### Before / after — light

| Before | After |
| --- | --- |
| ![Light sidebar before](https://github.com/user-attachments/assets/f4c5d456-4bb8-4f98-a8ea-51daeeb9d44b) | ![Light sidebar after](https://github.com/user-attachments/assets/10e69fa9-4c25-4084-8cd9-ebaba4b52614) |

All four captures were inspected. These are real Chromium screenshots with deterministic mocked Gateway responses, not live-provider screenshots. The exact-head built UI also connected successfully to an isolated loopback Gateway with separate temporary state. A live-provider sidebar run remains unproven: guided model setup stayed on an in-progress activation notice, so no live-run screenshot is claimed. The isolated Gateway was stopped cleanly; the operator Gateway and state were untouched. The deterministic browser proof above covers the changed styles and narrow-sidebar layout directly.

AI-assisted implementation.
