### PR TITLE
fix(ui): restore 16px composer editor text

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3400,8 +3400,8 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         });
         expect(composerFontSizes).toEqual({
           labels: [14, 14, 14],
-          placeholder: 14,
-          textarea: 14,
+          placeholder: 16,
+          textarea: 16,
         });
         if (width <= 480) {
           const modelSettings = expectControlRect(
@@ -3439,6 +3439,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
           }
           expect(footer.height).toBeLessThanOrEqual(53);
         } else {
+          // The editor reads at input size, while the controls around it stay
+          // chrome-sized — that difference is what marks the text as the
+          // subject of the surface.
           expect(send.width).toBeCloseTo(32, 2);
           expect(send.height).toBeCloseTo(32, 2);
         }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -3143,9 +3143,12 @@ button.chat-pr__diff {
      the surface's own floor is taller than the editor plus these insets. */
   --chat-composer-editor-inset-inline: 14px;
   --chat-composer-editor-inset-block: 6px;
-  /* Draft text and its surrounding labels share one semantic UI size. The
-     coarse-pointer floor in base.css still prevents iOS focus zoom. */
-  --chat-composer-editor-size: var(--control-ui-text-md);
+  /* The editor is a reading and writing surface, not a compact form field, so it
+     owns a 16px base instead of the shared control token, whose 14px base only
+     reaches 16px through an iOS zoom floor — text that size by accident does not
+     follow the operator's text scale until the scale passes 1.15, and it drops
+     the moment that floor moves. The max() keeps 16px as a hard floor. */
+  --chat-composer-editor-size: max(16px, calc(16px * var(--control-ui-text-scale)));
   /* One editor line. The single-line box centres a line of exactly this height,
      and the multiline editor never gets shorter than one of them. Derived, so a
      scaled-up editor keeps its leading instead of crowding its own descenders. */


### PR DESCRIPTION
Related: #131154

## What Problem This Solves

Fixes an issue where the Control UI chat composer flattened the visual hierarchy between the text being written and its secondary controls after #131154 reduced the editor text to 14px.

## Why This Change Was Made

The composer editor and placeholder return to a 16px minimum, preserving the writing surface as the primary content. Workspace, model, and effort controls remain at the 14px size introduced by #131154, so the hierarchy is restored without widening the previous gap.

## User Impact

Typed text and placeholder copy are easier to read and visually distinct from the secondary controls around them. The controls remain at 14px.

## Evidence

| Before | After |
| --- | --- |
| Editor and controls both render at 14px. | Editor renders at 16px while controls remain at 14px. |
| ![Composer editor before](https://github.com/user-attachments/assets/2db7760a-5852-470b-a666-093751f0620d) | ![Composer editor after](https://github.com/user-attachments/assets/93e94f63-b851-48e3-b0ef-be337b4ef3cf) |

- Focused composer browser test (105 passed)
- `pnpm check:changed`
