### PR TITLE
perf(tests): reuse model manifest selection imports

### DIFF
--- a/src/agents/model-selection-manifest-workspace.test.ts
+++ b/src/agents/model-selection-manifest-workspace.test.ts
@@ -1,6 +1,12 @@
 // Verifies configured model selection uses manifest policy only in scoped contexts.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  buildAllowedModelSet,
+  buildConfiguredModelCatalog,
+  buildModelAliasIndex,
+  resolveConfiguredModelRef,
+} from "./model-selection-shared.js";
 
 const loadManifestMetadataSnapshotMock = vi.hoisted(() => vi.fn());
 const getCurrentPluginMetadataSnapshotMock = vi.hoisted(() => vi.fn());
@@ -26,7 +32,6 @@ vi.mock("./provider-model-normalization.runtime.js", () => ({
 
 describe("configured model manifest workspace scope", () => {
   beforeEach(() => {
-    vi.resetModules();
     loadManifestMetadataSnapshotMock.mockReset();
     getCurrentPluginMetadataSnapshotMock.mockReset();
     getActivePluginRegistryWorkspaceDirFromStateMock.mockReset();
@@ -47,10 +52,9 @@ describe("configured model manifest workspace scope", () => {
     });
   });
 
-  it("does not reuse workspace manifest policies without a workspace context", async () => {
+  it("does not reuse workspace manifest policies without a workspace context", () => {
     // Workspace plugin normalization must not leak into unscoped callers; they
     // can only use the current global metadata snapshot.
-    const { buildConfiguredModelCatalog } = await import("./model-selection-shared.js");
     const cfg = {
       models: {
         providers: {
@@ -74,8 +78,7 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
-  it("uses manifest policies when the workspace context is explicit", async () => {
-    const { buildConfiguredModelCatalog } = await import("./model-selection-shared.js");
+  it("uses manifest policies when the workspace context is explicit", () => {
     const cfg = {
       models: {
         providers: {
@@ -100,7 +103,7 @@ describe("configured model manifest workspace scope", () => {
     expect(getCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
-  it("uses an unscoped current snapshot without falling back to a metadata scan", async () => {
+  it("uses an unscoped current snapshot without falling back to a metadata scan", () => {
     getCurrentPluginMetadataSnapshotMock.mockReturnValue({
       plugins: [
         {
@@ -114,7 +117,6 @@ describe("configured model manifest workspace scope", () => {
         },
       ],
     });
-    const { buildConfiguredModelCatalog } = await import("./model-selection-shared.js");
     const cfg = {
       models: {
         providers: {
@@ -134,9 +136,8 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
-  it("builds configured catalog facts once when resolving allowed models", async () => {
+  it("builds configured catalog facts once when resolving allowed models", () => {
     getCurrentPluginMetadataSnapshotMock.mockReturnValue({ plugins: [] });
-    const { buildAllowedModelSet } = await import("./model-selection-shared.js");
     const cfg = {
       models: {
         providers: {
@@ -156,10 +157,9 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
-  it("does not load manifest metadata for empty configured model aliases", async () => {
+  it("does not load manifest metadata for empty configured model aliases", () => {
     // Alias indexing is a hot config path. Empty inputs should avoid manifest
     // scans entirely.
-    const { buildModelAliasIndex } = await import("./model-selection-shared.js");
     const cfg = {} as unknown as OpenClawConfig;
 
     const aliases = buildModelAliasIndex({ cfg, defaultProvider: "anthropic" });
@@ -170,8 +170,7 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
-  it("does not load manifest metadata for wildcard-only configured model aliases", async () => {
-    const { buildModelAliasIndex } = await import("./model-selection-shared.js");
+  it("does not load manifest metadata for wildcard-only configured model aliases", () => {
     const cfg = {
       agents: {
         defaults: {
@@ -190,8 +189,7 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
-  it("does not load manifest metadata for configured model entries without aliases", async () => {
-    const { buildModelAliasIndex } = await import("./model-selection-shared.js");
+  it("does not load manifest metadata for configured model entries without aliases", () => {
     const cfg = {
       agents: {
         defaults: {
@@ -210,8 +208,7 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
-  it("indexes selected-agent default-provider aliases without cold manifest discovery", async () => {
-    const { buildModelAliasIndex } = await import("./model-selection-shared.js");
+  it("indexes selected-agent default-provider aliases without cold manifest discovery", () => {
     const cfg = {
       agents: {
         ownership: "explicit",
@@ -237,8 +234,7 @@ describe("configured model manifest workspace scope", () => {
     expect(normalizeProviderModelIdWithRuntimeMock.mock.calls.length).toBe(0);
   });
 
-  it("resolves selected-agent default-provider aliases without cold manifest discovery", async () => {
-    const { resolveConfiguredModelRef } = await import("./model-selection-shared.js");
+  it("resolves selected-agent default-provider aliases without cold manifest discovery", () => {
     const cfg = {
       agents: {
         ownership: "explicit",
@@ -266,7 +262,7 @@ describe("configured model manifest workspace scope", () => {
 
   it.each(["current", "supplied"] as const)(
     "preserves %s prepared manifest policy for default-provider aliases",
-    async (source) => {
+    (source) => {
       const manifestPlugins = [
         {
           modelIdNormalization: {
@@ -279,7 +275,6 @@ describe("configured model manifest workspace scope", () => {
       if (source === "current") {
         getCurrentPluginMetadataSnapshotMock.mockReturnValue({ plugins: manifestPlugins });
       }
-      const { buildModelAliasIndex } = await import("./model-selection-shared.js");
       const cfg = {
         agents: { defaults: { models: { "openai/legacy": { alias: "Legacy" } } } },
       } as unknown as OpenClawConfig;
@@ -299,14 +294,13 @@ describe("configured model manifest workspace scope", () => {
     },
   );
 
-  it("preserves workspace manifest policy for default-provider aliases", async () => {
+  it("preserves workspace manifest policy for default-provider aliases", () => {
     getActivePluginRegistryWorkspaceDirFromStateMock.mockReturnValue("/workspace/a");
     loadManifestMetadataSnapshotMock.mockReturnValue({
       plugins: [
         { modelIdNormalization: { providers: { openai: { aliases: { ops: "workspace-ops" } } } } },
       ],
     });
-    const { buildModelAliasIndex } = await import("./model-selection-shared.js");
     const cfg = {
       agents: { defaults: { models: { "openai/ops": { alias: "Operations" } } } },
     } as unknown as OpenClawConfig;
@@ -318,8 +312,7 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock.mock.calls[0]?.[0]?.workspaceDir).toBe("/workspace/a");
   });
 
-  it("preserves provider-owned manifest discovery for non-default aliases", async () => {
-    const { buildModelAliasIndex } = await import("./model-selection-shared.js");
+  it("preserves provider-owned manifest discovery for non-default aliases", () => {
     const cfg = {
       agents: { defaults: { models: { "custom/ops": { alias: "Operations" } } } },
     } as unknown as OpenClawConfig;
@@ -346,7 +339,7 @@ describe("configured model manifest workspace scope", () => {
         ["openai/legacy", { alias: "Legacy" }],
       ],
     },
-  ])("normalizes mixed aliases consistently with $name", async ({ models }) => {
+  ])("normalizes mixed aliases consistently with $name", ({ models }) => {
     loadManifestMetadataSnapshotMock.mockReturnValue({
       plugins: [
         {
@@ -359,7 +352,6 @@ describe("configured model manifest workspace scope", () => {
         },
       ],
     });
-    const { buildModelAliasIndex } = await import("./model-selection-shared.js");
     const cfg = {
       agents: { defaults: { models: Object.fromEntries(models) } },
     } as unknown as OpenClawConfig;
@@ -377,8 +369,7 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock).toHaveBeenCalledTimes(1);
   });
 
-  it("preserves manifest discovery for default-provider configured API-owner mappings", async () => {
-    const { buildModelAliasIndex } = await import("./model-selection-shared.js");
+  it("preserves manifest discovery for default-provider configured API-owner mappings", () => {
     const cfg = {
       agents: { defaults: { models: { "openai/ops": { alias: "Operations" } } } },
       models: { providers: { openai: { api: "custom-owner", models: [] } } },
@@ -390,8 +381,7 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock.mock.calls.length).toBe(1);
   });
 
-  it("does not load manifest metadata for statically resolved primary models", async () => {
-    const { resolveConfiguredModelRef } = await import("./model-selection-shared.js");
+  it("does not load manifest metadata for statically resolved primary models", () => {
     const cases: Array<{ cfg: OpenClawConfig; expected: { provider: string; model: string } }> = [
       {
         cfg: {
@@ -423,8 +413,7 @@ describe("configured model manifest workspace scope", () => {
     }
   });
 
-  it("does not load manifest metadata for non-alias primary models with configured aliases", async () => {
-    const { resolveConfiguredModelRef } = await import("./model-selection-shared.js");
+  it("does not load manifest metadata for non-alias primary models with configured aliases", () => {
     const cfg = {
       agents: {
         defaults: {
@@ -447,7 +436,7 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
-  it("uses manifest-normalized configured refs to infer providers for bare defaults", async () => {
+  it("uses manifest-normalized configured refs to infer providers for bare defaults", () => {
     loadManifestMetadataSnapshotMock.mockReturnValue({
       plugins: [
         {
@@ -463,7 +452,6 @@ describe("configured model manifest workspace scope", () => {
         },
       ],
     });
-    const { resolveConfiguredModelRef } = await import("./model-selection-shared.js");
     const cfg = {
       agents: {
         defaults: {
@@ -485,7 +473,7 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock).toHaveBeenCalledTimes(1);
   });
 
-  it("reuses resolved manifest plugins while resolving configured model aliases", async () => {
+  it("reuses resolved manifest plugins while resolving configured model aliases", () => {
     loadManifestMetadataSnapshotMock.mockReturnValue({
       plugins: [
         {
@@ -504,7 +492,6 @@ describe("configured model manifest workspace scope", () => {
         },
       ],
     });
-    const { resolveConfiguredModelRef } = await import("./model-selection-shared.js");
     const cfg = {
       agents: {
         defaults: {
@@ -527,7 +514,7 @@ describe("configured model manifest workspace scope", () => {
     expect(loadManifestMetadataSnapshotMock).toHaveBeenCalledTimes(1);
   });
 
-  it("reuses resolved manifest plugins while resolving direct primary models", async () => {
+  it("reuses resolved manifest plugins while resolving direct primary models", () => {
     loadManifestMetadataSnapshotMock.mockReturnValue({
       plugins: [
         {
@@ -546,7 +533,6 @@ describe("configured model manifest workspace scope", () => {
         },
       ],
     });
-    const { resolveConfiguredModelRef } = await import("./model-selection-shared.js");
     const cfg = {
       agents: {
         defaults: {


### PR DESCRIPTION
## What Problem This Solves

Maintainers running the configured-model workspace tests pay for reloading the same module graph before each of 21 cases, although those cases vary config and mock results rather than module-owned state.

## Why This Change Was Made

Import the existing model-selection owner once and continue resetting the four mutable mocks before every case. Keep every case, assertion, partial-real mock factory, and the runner's per-file cleanup unchanged. Manifest resolution state already belongs to each model-selection invocation, so no production cache or new test seam is needed.

## User Impact

No user-facing behavior changes. The scoped suite is 6.55% faster in an eight-pair benchmark and uses 18.6% less peak memory, while retaining workspace isolation, prepared policy reuse, mixed-provider alias normalization, and no-unnecessary-discovery checks.

## Evidence

One task-owned Blacksmith Testbox, Linux/Node 24, one Vitest worker, excluded warmup for each variant, eight order-balanced AB/BA pairs, distinct filesystem-module-cache paths, import diagnostics, and `/usr/bin/time -v`:

| Median metric | Before | After |
| --- | ---: | ---: |
| Scoped wall | 6.490s | 6.065s |
| Vitest duration | 2.530s | 2.090s |
| Test body | 1.705s | 0.162s |
| Collection import | 0.021s | 1.075s |
| Max RSS | 817,842 KiB | 665,958 KiB |
| User / system CPU | 7.225s / 0.580s | 6.490s / 0.540s |
| Passing tests | 21 | 21 |
| Cached module artifacts | 423 | 423 |
| Sampled process tree size, including time/runner helpers | 6 | 6 |

Wall improvement is 0.425s / 6.55%, with seven of eight paired wins (median paired improvement 0.350s). Static imports move work from test bodies to collection; neither the body-only reduction nor the overlapping top-ten import breakdown is used as the acceptance metric. No process, browser, storage, provider, or lifecycle boundary was removed.

The baseline and optimized suites both reject a reversible production mutation that ignores the explicit workspace: the same case fails because `fast-model` replaces `workspace-custom/fast-model`. Restoring the owner returns all 21 cases to green. The mutation is not part of this PR.

Focused owner/sibling proof passed locally and on the same Testbox: 177 tests across `model-selection-manifest-workspace`, `model-selection`, `model-selection.plugin-runtime`, and `embedded-agent-runner/model-resolution-consistency`, using their three native routed shards.

Benchmark and Linux fault/sibling environment: https://github.com/openclaw/openclaw/actions/runs/33116267630. Commands executed through the task's Testbox lease; the Actions run tracks provisioning and cleanup, not the SSH command verdicts. The lease is stopped after evidence collection.

Production LOC: +0/-0. Tests: +25/-39 (net -14). Deslop complete; fresh Codex autoreview reports no actionable findings. Complete `env -u OPENCLAW_TESTBOX pnpm check:changed` passed, including all 17 core-test typecheck shards and all three dead-export scans. A shuffled 155-test owner/workspace run also passed (seed 20260827). Exact-head hosted CI evidence will be posted before landing.
