### PR TITLE
fix(line): /card splits an action, list item, or receipt entry at a comma inside its data

### DIFF
--- a/extensions/line/src/card-command.escapes.test.ts
+++ b/extensions/line/src/card-command.escapes.test.ts
@@ -69,6 +69,11 @@ describe("line card option separators", () => {
       actions: String.raw`Path|C:\temp`,
       expected: [{ type: "message", label: "Path", text: String.raw`C:\temp` }],
     },
+    {
+      kind: "a backslash before a colon, which actions do not split on",
+      actions: String.raw`Path|C\:\temp`,
+      expected: [{ type: "message", label: "Path", text: String.raw`C\:\temp` }],
+    },
   ])("resolves $kind into the authored card actions", async ({ actions, expected }) => {
     expect(
       cardActions(await runCardCommand(`action "Menu" "Body" --actions "${actions}"`)),
@@ -104,6 +109,18 @@ describe("line card option separators", () => {
       String.raw`receipt "Receipt" "Coffee\, large:$10,Time: 10:30:$5" --total "$15"`,
     );
     expect(cardAltText(line)).toBe("Receipt: Coffee, large $10, Time: 10:30 $5");
+  });
+
+  it("keeps a backslashed pipe literal in a receipt name, which receipts do not split on", async () => {
+    const line = await runCardCommand(String.raw`receipt "Receipt" "A\|B:$10" --total "$10"`);
+    expect(cardAltText(line)).toBe(String.raw`Receipt: A\|B $10`);
+  });
+
+  it("keeps a backslashed comma literal in a confirm label, which confirm does not split on", async () => {
+    const line = await runCardCommand(
+      String.raw`confirm "Ship it?" --yes "Yes\,now|go" --no "No|stop"`,
+    );
+    expect(line.templateMessage).toMatchObject({ confirmLabel: String.raw`Yes\,now` });
   });
 
   it("keeps an escaped pipe inside a confirm button label", async () => {

--- a/extensions/line/src/card-command.escapes.test.ts
+++ b/extensions/line/src/card-command.escapes.test.ts
@@ -1,0 +1,123 @@
+// Line tests cover escaped separators inside card option values.
+import type { messagingApi } from "@line/bot-sdk";
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it } from "vitest";
+import { registerLineCardCommand } from "./card-command.js";
+import { buildTemplateMessageFromPayload } from "./template-messages.js";
+import type { LineChannelData } from "./types.js";
+
+async function runCardCommand(args: string): Promise<LineChannelData> {
+  let result: unknown;
+  registerLineCardCommand({
+    registerCommand(command: unknown) {
+      const { handler } = command as {
+        handler: (ctx: { args: string; channel: string }) => Promise<unknown>;
+      };
+      result = handler({ channel: "line", args });
+    },
+  } as never);
+  const payload = (await result) as { channelData: { line: LineChannelData } };
+  return payload.channelData.line;
+}
+
+function cardActions(line: LineChannelData): messagingApi.Action[] {
+  const flex = expectDefined(line.flexMessage, "LINE flex-message payload");
+  const contents = flex.contents as messagingApi.FlexContainer;
+  if (contents.type !== "bubble") {
+    throw new Error("Expected the card to render a bubble");
+  }
+  const footer = expectDefined(contents.footer, "LINE flex-message footer");
+  return footer.contents.map((component) => {
+    if (component.type !== "button") {
+      throw new Error("Expected the card footer to contain buttons");
+    }
+    return component.action;
+  });
+}
+
+function cardAltText(line: LineChannelData): string {
+  return expectDefined(line.flexMessage, "LINE flex-message payload").altText;
+}
+
+describe("line card option separators", () => {
+  it.each([
+    {
+      kind: "an escaped comma inside a link",
+      actions: String.raw`Open|https://example.test/a\,b`,
+      expected: [{ type: "uri", label: "Open", uri: "https://example.test/a,b" }],
+    },
+    {
+      kind: "an escaped comma inside callback data",
+      actions: String.raw`Save|k=a\,b`,
+      expected: [{ type: "postback", label: "Save", data: "k=a,b", displayText: "Save" }],
+    },
+    {
+      kind: "an escaped pipe inside a label",
+      actions: String.raw`A\|B|/status`,
+      expected: [{ type: "message", label: "A|B", text: "/status" }],
+    },
+    {
+      kind: "an unescaped comma between two actions",
+      actions: "One|/a,Two|/b",
+      expected: [
+        { type: "message", label: "One", text: "/a" },
+        { type: "message", label: "Two", text: "/b" },
+      ],
+    },
+    {
+      kind: "a backslash that protects nothing",
+      actions: String.raw`Path|C:\temp`,
+      expected: [{ type: "message", label: "Path", text: String.raw`C:\temp` }],
+    },
+  ])("resolves $kind into the authored card actions", async ({ actions, expected }) => {
+    expect(
+      cardActions(await runCardCommand(`action "Menu" "Body" --actions "${actions}"`)),
+    ).toEqual(expected);
+  });
+
+  it("keeps an escaped comma inside a buttons template action", async () => {
+    const line = await runCardCommand(
+      String.raw`buttons "Menu" "Body" --actions "Open|https://example.test/a\,b"`,
+    );
+    const message = expectDefined(
+      buildTemplateMessageFromPayload(
+        expectDefined(line.templateMessage, "LINE template-message payload"),
+      ),
+      "LINE buttons template message",
+    );
+    if (message.template.type !== "buttons") {
+      throw new Error("Expected a LINE buttons template");
+    }
+
+    expect(message.template.actions).toEqual([
+      { type: "uri", label: "Open", uri: "https://example.test/a,b" },
+    ]);
+  });
+
+  it("keeps an escaped comma inside a list item title", async () => {
+    const line = await runCardCommand(String.raw`list "List" "Coffee\, large|Hot,Tea|Iced"`);
+    expect(cardAltText(line)).toBe("List: Coffee, large, Tea");
+  });
+
+  it("keeps an escaped comma in a receipt name and still splits at the last colon", async () => {
+    const line = await runCardCommand(
+      String.raw`receipt "Receipt" "Coffee\, large:$10,Time: 10:30:$5" --total "$15"`,
+    );
+    expect(cardAltText(line)).toBe("Receipt: Coffee, large $10, Time: 10:30 $5");
+  });
+
+  it("keeps an escaped pipe inside a confirm button label", async () => {
+    const line = await runCardCommand(
+      String.raw`confirm "Ship it?" --yes "Yes\|now|go" --no "No|stop"`,
+    );
+    expect(line.templateMessage).toEqual({
+      type: "confirm",
+      text: "Ship it?",
+      altText: "Ship it?",
+      confirmLabel: "Yes|now",
+      confirmData: "go",
+      cancelLabel: "No",
+      cancelData: "stop",
+    });
+  });
+});

--- a/extensions/line/src/card-command.escapes.test.ts
+++ b/extensions/line/src/card-command.escapes.test.ts
@@ -130,4 +130,26 @@ describe("line card option separators", () => {
     const line = await runCardCommand(String.raw`receipt "Receipt" "A\|B:$10" --total "$10"`);
     expect(cardAltText(line)).toBe(String.raw`Receipt: A\|B $10`);
   });
+
+  it("keeps a backslashed comma literal in a confirm label, which confirm does not split on", async () => {
+    const line = await runCardCommand(
+      String.raw`confirm "Ship it?" --yes "Yes\,now|go" --no "No|stop"`,
+    );
+    expect(line.templateMessage).toMatchObject({ confirmLabel: String.raw`Yes\,now` });
+  });
+
+  it("keeps an escaped pipe inside a confirm button label", async () => {
+    const line = await runCardCommand(
+      String.raw`confirm "Ship it?" --yes "Yes\|now|go" --no "No|stop"`,
+    );
+    expect(line.templateMessage).toEqual({
+      type: "confirm",
+      text: "Ship it?",
+      altText: "Ship it?",
+      confirmLabel: "Yes|now",
+      confirmData: "go",
+      cancelLabel: "No",
+      cancelData: "stop",
+    });
+  });
 });

--- a/extensions/line/src/card-command.escapes.test.ts
+++ b/extensions/line/src/card-command.escapes.test.ts
@@ -57,6 +57,11 @@ describe("line card option separators", () => {
       expected: [{ type: "message", label: "A|B", text: "/status" }],
     },
     {
+      kind: "an escaped pipe inside action data",
+      actions: String.raw`Open|left\|right`,
+      expected: [{ type: "message", label: "Open", text: "left|right" }],
+    },
+    {
       kind: "an unescaped comma between two actions",
       actions: "One|/a,Two|/b",
       expected: [
@@ -73,6 +78,11 @@ describe("line card option separators", () => {
       kind: "a literal backslash pair, which no option splits on",
       actions: String.raw`Path|\\server\share`,
       expected: [{ type: "message", label: "Path", text: String.raw`\\server\share` }],
+    },
+    {
+      kind: "a literal backslash before an escaped comma",
+      actions: String.raw`Path|\\,tail`,
+      expected: [{ type: "message", label: "Path", text: String.raw`\,tail` }],
     },
     {
       kind: "a backslash before a colon, which actions do not split on",
@@ -111,35 +121,13 @@ describe("line card option separators", () => {
 
   it("keeps an escaped comma in a receipt name and still splits at the last colon", async () => {
     const line = await runCardCommand(
-      String.raw`receipt "Receipt" "Coffee\, large:$10,Time: 10:30:$5" --total "$15"`,
+      String.raw`receipt "Receipt" "Coffee\, large:$10,Time: 10:30:$5,Window:10\:30" --total "$15"`,
     );
-    expect(cardAltText(line)).toBe("Receipt: Coffee, large $10, Time: 10:30 $5");
+    expect(cardAltText(line)).toBe("Receipt: Coffee, large $10, Time: 10:30 $5, Window 10:30");
   });
 
   it("keeps a backslashed pipe literal in a receipt name, which receipts do not split on", async () => {
     const line = await runCardCommand(String.raw`receipt "Receipt" "A\|B:$10" --total "$10"`);
     expect(cardAltText(line)).toBe(String.raw`Receipt: A\|B $10`);
-  });
-
-  it("keeps a backslashed comma literal in a confirm label, which confirm does not split on", async () => {
-    const line = await runCardCommand(
-      String.raw`confirm "Ship it?" --yes "Yes\,now|go" --no "No|stop"`,
-    );
-    expect(line.templateMessage).toMatchObject({ confirmLabel: String.raw`Yes\,now` });
-  });
-
-  it("keeps an escaped pipe inside a confirm button label", async () => {
-    const line = await runCardCommand(
-      String.raw`confirm "Ship it?" --yes "Yes\|now|go" --no "No|stop"`,
-    );
-    expect(line.templateMessage).toEqual({
-      type: "confirm",
-      text: "Ship it?",
-      altText: "Ship it?",
-      confirmLabel: "Yes|now",
-      confirmData: "go",
-      cancelLabel: "No",
-      cancelData: "stop",
-    });
   });
 });

--- a/extensions/line/src/card-command.escapes.test.ts
+++ b/extensions/line/src/card-command.escapes.test.ts
@@ -70,6 +70,11 @@ describe("line card option separators", () => {
       expected: [{ type: "message", label: "Path", text: String.raw`C:\temp` }],
     },
     {
+      kind: "a literal backslash pair, which no option splits on",
+      actions: String.raw`Path|\\server\share`,
+      expected: [{ type: "message", label: "Path", text: String.raw`\\server\share` }],
+    },
+    {
       kind: "a backslash before a colon, which actions do not split on",
       actions: String.raw`Path|C\:\temp`,
       expected: [{ type: "message", label: "Path", text: String.raw`C\:\temp` }],

--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -25,7 +25,7 @@ Types:
   confirm "Question?" --yes "Yes|data" --no "No|data"
   buttons "Title" "Text" --actions "Btn1|url1,Btn2|data2"
 
-Escape a separator that the option splits on with a backslash, as in \\, or \\|
+Escape a separator that belongs to the data with a backslash: \\, \\|, or \\:
 
 Examples:
   /card info "Welcome" "Thanks for joining!"
@@ -51,40 +51,20 @@ function buildLineFlexReply(
   });
 }
 
-/** Separators of each card option grammar; a backslash protects only these. */
-const CARD_PAIR_LIST_SEPARATORS: ReadonlySet<string> = new Set([",", "|"]);
-const CARD_RECEIPT_SEPARATORS: ReadonlySet<string> = new Set([",", ":"]);
-const CARD_PAIR_SEPARATORS: ReadonlySet<string> = new Set(["|"]);
-
 /**
  * Split a card option value on its unescaped separators.
  *
- * A backslash is meaningful only before a separator this option splits on.
- * Every other backslash, including one before another backslash, is literal
- * data, so `C:\temp`, `C\:\temp` and `\\server\share` all survive
- * unchanged. Escapes stay inside the returned parts so a later split on a
- * different separator still sees them; `unescapeCardValue` removes them at
- * the leaf.
+ * Each pass consumes escapes for its own separator and preserves every other
+ * backslash. This lets nested comma, pipe, and colon passes stay independent.
  */
-function splitCardValue(
-  value: string,
-  separator: string,
-  separators: ReadonlySet<string>,
-): string[] {
+function splitCardValue(value: string, separator: string): string[] {
   const parts: string[] = [];
   let current = "";
-  let pendingEscape = false;
-  for (const char of value) {
-    if (pendingEscape) {
-      pendingEscape = false;
-      if (separators.has(char)) {
-        current += `\\${char}`;
-        continue;
-      }
-      current += "\\";
-    }
-    if (char === "\\") {
-      pendingEscape = true;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === "\\" && value[index + 1] === separator) {
+      current += separator;
+      index += 1;
       continue;
     }
     if (char === separator) {
@@ -94,40 +74,13 @@ function splitCardValue(
     }
     current += char;
   }
-  if (pendingEscape) {
-    current += "\\";
-  }
   parts.push(current);
   return parts;
 }
 
-/** Drop the backslashes that protected separators inside a card option value. */
-function unescapeCardValue(value: string, separators: ReadonlySet<string>): string {
-  let result = "";
-  let pendingEscape = false;
-  for (const char of value) {
-    if (pendingEscape) {
-      pendingEscape = false;
-      result += separators.has(char) ? char : `\\${char}`;
-      continue;
-    }
-    if (char === "\\") {
-      pendingEscape = true;
-      continue;
-    }
-    result += char;
-  }
-  return pendingEscape ? `${result}\\` : result;
-}
-
 /** Split a "Label|data" pair, keeping escaped separators inside either side. */
-function splitCardPair(
-  part: string,
-  separators: ReadonlySet<string>,
-): [string, string | undefined] {
-  const [label = "", data] = splitCardValue(part, "|", separators).map((piece) =>
-    unescapeCardValue(piece.trim(), separators),
-  );
+function splitCardPair(part: string): [string, string | undefined] {
+  const [label = "", data] = splitCardValue(part, "|").map((piece) => piece.trim());
   return [label, data];
 }
 
@@ -142,8 +95,8 @@ function parseActions(actionsStr: string | undefined): CardAction[] {
 
   const results: CardAction[] = [];
 
-  for (const part of splitCardValue(actionsStr, ",", CARD_PAIR_LIST_SEPARATORS)) {
-    const [label, data] = splitCardPair(part, CARD_PAIR_LIST_SEPARATORS);
+  for (const part of splitCardValue(actionsStr, ",")) {
+    const [label, data] = splitCardPair(part);
     if (!label) {
       continue;
     }
@@ -166,9 +119,9 @@ function parseActions(actionsStr: string | undefined): CardAction[] {
  * Parse list items format: "Item1|Subtitle1,Item2|Subtitle2"
  */
 function parseListItems(itemsStr: string): ListItem[] {
-  return splitCardValue(itemsStr, ",", CARD_PAIR_LIST_SEPARATORS)
+  return splitCardValue(itemsStr, ",")
     .map((part) => {
-      const [title, subtitle] = splitCardPair(part, CARD_PAIR_LIST_SEPARATORS);
+      const [title, subtitle] = splitCardPair(part);
       return { title, subtitle };
     })
     .filter((item) => item.title);
@@ -178,15 +131,15 @@ function parseListItems(itemsStr: string): ListItem[] {
  * Parse receipt items format: "Item1:$10,Item2:$20"
  */
 function parseReceiptItems(itemsStr: string): Array<{ name: string; value: string }> {
-  return splitCardValue(itemsStr, ",", CARD_RECEIPT_SEPARATORS)
+  return splitCardValue(itemsStr, ",")
     .map((part) => {
       // The last unescaped colon separates the entry value, so a name may still
       // contain colons of its own.
-      const segments = splitCardValue(part, ":", CARD_RECEIPT_SEPARATORS);
+      const segments = splitCardValue(part, ":");
       const value = segments.length > 1 ? segments.pop() : undefined;
       return {
-        name: unescapeCardValue(segments.join(":").trim(), CARD_RECEIPT_SEPARATORS),
-        value: value === undefined ? "" : unescapeCardValue(value.trim(), CARD_RECEIPT_SEPARATORS),
+        name: segments.join(":").trim(),
+        value: value?.trim() ?? "",
       };
     })
     .filter((item) => item.name);
@@ -326,8 +279,8 @@ export function registerLineCardCommand(api: OpenClawPluginApi): void {
             const yesStr = flags.yes || "Yes|yes";
             const noStr = flags.no || "No|no";
 
-            const [yesLabel, yesData] = splitCardPair(yesStr, CARD_PAIR_SEPARATORS);
-            const [noLabel, noData] = splitCardPair(noStr, CARD_PAIR_SEPARATORS);
+            const [yesLabel, yesData] = yesStr.split("|").map((s) => s.trim());
+            const [noLabel, noData] = noStr.split("|").map((s) => s.trim());
 
             return buildLineReply({
               templateMessage: {

--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -57,19 +57,14 @@ const CARD_RECEIPT_SEPARATORS: ReadonlySet<string> = new Set([",", ":"]);
 const CARD_PAIR_SEPARATORS: ReadonlySet<string> = new Set(["|"]);
 
 /**
- * A backslash is meaningful only before a separator the current grammar splits
- * on, or before another backslash. Anything else keeps its backslash as data,
- * so a value like `C:\temp` survives every option that does not split on `:`.
- */
-function isCardValueEscapable(char: string, separators: ReadonlySet<string>): boolean {
-  return char === "\\" || separators.has(char);
-}
-
-/**
  * Split a card option value on its unescaped separators.
  *
- * Escapes stay inside the returned parts so a later split on a different
- * separator still sees them; `unescapeCardValue` removes them at the leaf.
+ * A backslash is meaningful only before a separator this option splits on.
+ * Every other backslash, including one before another backslash, is literal
+ * data, so `C:\temp`, `C\:\temp` and `\\server\share` all survive
+ * unchanged. Escapes stay inside the returned parts so a later split on a
+ * different separator still sees them; `unescapeCardValue` removes them at
+ * the leaf.
  */
 function splitCardValue(
   value: string,
@@ -82,7 +77,7 @@ function splitCardValue(
   for (const char of value) {
     if (pendingEscape) {
       pendingEscape = false;
-      if (isCardValueEscapable(char, separators)) {
+      if (separators.has(char)) {
         current += `\\${char}`;
         continue;
       }
@@ -113,7 +108,7 @@ function unescapeCardValue(value: string, separators: ReadonlySet<string>): stri
   for (const char of value) {
     if (pendingEscape) {
       pendingEscape = false;
-      result += isCardValueEscapable(char, separators) ? char : `\\${char}`;
+      result += separators.has(char) ? char : `\\${char}`;
       continue;
     }
     if (char === "\\") {

--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -25,7 +25,7 @@ Types:
   confirm "Question?" --yes "Yes|data" --no "No|data"
   buttons "Title" "Text" --actions "Btn1|url1,Btn2|data2"
 
-Escape a separator that belongs to the data with a backslash: \\, \\| \\:
+Escape a separator that the option splits on with a backslash, as in \\, or \\|
 
 Examples:
   /card info "Welcome" "Thanks for joining!"
@@ -51,24 +51,38 @@ function buildLineFlexReply(
   });
 }
 
-/** Separator characters a card option value may protect with a backslash. */
-const CARD_VALUE_ESCAPABLE = new Set(["\\", ",", "|", ":"]);
+/** Separators of each card option grammar; a backslash protects only these. */
+const CARD_PAIR_LIST_SEPARATORS: ReadonlySet<string> = new Set([",", "|"]);
+const CARD_RECEIPT_SEPARATORS: ReadonlySet<string> = new Set([",", ":"]);
+const CARD_PAIR_SEPARATORS: ReadonlySet<string> = new Set(["|"]);
+
+/**
+ * A backslash is meaningful only before a separator the current grammar splits
+ * on, or before another backslash. Anything else keeps its backslash as data,
+ * so a value like `C:\temp` survives every option that does not split on `:`.
+ */
+function isCardValueEscapable(char: string, separators: ReadonlySet<string>): boolean {
+  return char === "\\" || separators.has(char);
+}
 
 /**
  * Split a card option value on its unescaped separators.
  *
  * Escapes stay inside the returned parts so a later split on a different
  * separator still sees them; `unescapeCardValue` removes them at the leaf.
- * A backslash that protects nothing is literal data and is preserved.
  */
-function splitCardValue(value: string, separator: string): string[] {
+function splitCardValue(
+  value: string,
+  separator: string,
+  separators: ReadonlySet<string>,
+): string[] {
   const parts: string[] = [];
   let current = "";
   let pendingEscape = false;
   for (const char of value) {
     if (pendingEscape) {
       pendingEscape = false;
-      if (CARD_VALUE_ESCAPABLE.has(char)) {
+      if (isCardValueEscapable(char, separators)) {
         current += `\\${char}`;
         continue;
       }
@@ -93,13 +107,13 @@ function splitCardValue(value: string, separator: string): string[] {
 }
 
 /** Drop the backslashes that protected separators inside a card option value. */
-function unescapeCardValue(value: string): string {
+function unescapeCardValue(value: string, separators: ReadonlySet<string>): string {
   let result = "";
   let pendingEscape = false;
   for (const char of value) {
     if (pendingEscape) {
       pendingEscape = false;
-      result += CARD_VALUE_ESCAPABLE.has(char) ? char : `\\${char}`;
+      result += isCardValueEscapable(char, separators) ? char : `\\${char}`;
       continue;
     }
     if (char === "\\") {
@@ -112,9 +126,12 @@ function unescapeCardValue(value: string): string {
 }
 
 /** Split a "Label|data" pair, keeping escaped separators inside either side. */
-function splitCardPair(part: string): [string, string | undefined] {
-  const [label = "", data] = splitCardValue(part, "|").map((piece) =>
-    unescapeCardValue(piece.trim()),
+function splitCardPair(
+  part: string,
+  separators: ReadonlySet<string>,
+): [string, string | undefined] {
+  const [label = "", data] = splitCardValue(part, "|", separators).map((piece) =>
+    unescapeCardValue(piece.trim(), separators),
   );
   return [label, data];
 }
@@ -130,8 +147,8 @@ function parseActions(actionsStr: string | undefined): CardAction[] {
 
   const results: CardAction[] = [];
 
-  for (const part of splitCardValue(actionsStr, ",")) {
-    const [label, data] = splitCardPair(part);
+  for (const part of splitCardValue(actionsStr, ",", CARD_PAIR_LIST_SEPARATORS)) {
+    const [label, data] = splitCardPair(part, CARD_PAIR_LIST_SEPARATORS);
     if (!label) {
       continue;
     }
@@ -154,9 +171,9 @@ function parseActions(actionsStr: string | undefined): CardAction[] {
  * Parse list items format: "Item1|Subtitle1,Item2|Subtitle2"
  */
 function parseListItems(itemsStr: string): ListItem[] {
-  return splitCardValue(itemsStr, ",")
+  return splitCardValue(itemsStr, ",", CARD_PAIR_LIST_SEPARATORS)
     .map((part) => {
-      const [title, subtitle] = splitCardPair(part);
+      const [title, subtitle] = splitCardPair(part, CARD_PAIR_LIST_SEPARATORS);
       return { title, subtitle };
     })
     .filter((item) => item.title);
@@ -166,15 +183,15 @@ function parseListItems(itemsStr: string): ListItem[] {
  * Parse receipt items format: "Item1:$10,Item2:$20"
  */
 function parseReceiptItems(itemsStr: string): Array<{ name: string; value: string }> {
-  return splitCardValue(itemsStr, ",")
+  return splitCardValue(itemsStr, ",", CARD_RECEIPT_SEPARATORS)
     .map((part) => {
       // The last unescaped colon separates the entry value, so a name may still
       // contain colons of its own.
-      const segments = splitCardValue(part, ":");
+      const segments = splitCardValue(part, ":", CARD_RECEIPT_SEPARATORS);
       const value = segments.length > 1 ? segments.pop() : undefined;
       return {
-        name: unescapeCardValue(segments.join(":").trim()),
-        value: value === undefined ? "" : unescapeCardValue(value.trim()),
+        name: unescapeCardValue(segments.join(":").trim(), CARD_RECEIPT_SEPARATORS),
+        value: value === undefined ? "" : unescapeCardValue(value.trim(), CARD_RECEIPT_SEPARATORS),
       };
     })
     .filter((item) => item.name);
@@ -314,8 +331,8 @@ export function registerLineCardCommand(api: OpenClawPluginApi): void {
             const yesStr = flags.yes || "Yes|yes";
             const noStr = flags.no || "No|no";
 
-            const [yesLabel, yesData] = splitCardPair(yesStr);
-            const [noLabel, noData] = splitCardPair(noStr);
+            const [yesLabel, yesData] = splitCardPair(yesStr, CARD_PAIR_SEPARATORS);
+            const [noLabel, noData] = splitCardPair(noStr, CARD_PAIR_SEPARATORS);
 
             return buildLineReply({
               templateMessage: {

--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -25,10 +25,13 @@ Types:
   confirm "Question?" --yes "Yes|data" --no "No|data"
   buttons "Title" "Text" --actions "Btn1|url1,Btn2|data2"
 
+Escape a separator that belongs to the data with a backslash: \\, \\| \\:
+
 Examples:
   /card info "Welcome" "Thanks for joining!"
   /card image "Product" "Check it out" --url https://example.com/img.jpg
-  /card action "Menu" "Choose an option" --actions "Order|/order,Help|/help"`;
+  /card action "Menu" "Choose an option" --actions "Order|/order,Help|/help"
+  /card action "Links" "Pick one" --actions "Open|https://example.com/a\\,b"`;
 
 function buildLineReply(lineData: LineChannelData): ReplyPayload {
   return {
@@ -48,6 +51,74 @@ function buildLineFlexReply(
   });
 }
 
+/** Separator characters a card option value may protect with a backslash. */
+const CARD_VALUE_ESCAPABLE = new Set(["\\", ",", "|", ":"]);
+
+/**
+ * Split a card option value on its unescaped separators.
+ *
+ * Escapes stay inside the returned parts so a later split on a different
+ * separator still sees them; `unescapeCardValue` removes them at the leaf.
+ * A backslash that protects nothing is literal data and is preserved.
+ */
+function splitCardValue(value: string, separator: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let pendingEscape = false;
+  for (const char of value) {
+    if (pendingEscape) {
+      pendingEscape = false;
+      if (CARD_VALUE_ESCAPABLE.has(char)) {
+        current += `\\${char}`;
+        continue;
+      }
+      current += "\\";
+    }
+    if (char === "\\") {
+      pendingEscape = true;
+      continue;
+    }
+    if (char === separator) {
+      parts.push(current);
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+  if (pendingEscape) {
+    current += "\\";
+  }
+  parts.push(current);
+  return parts;
+}
+
+/** Drop the backslashes that protected separators inside a card option value. */
+function unescapeCardValue(value: string): string {
+  let result = "";
+  let pendingEscape = false;
+  for (const char of value) {
+    if (pendingEscape) {
+      pendingEscape = false;
+      result += CARD_VALUE_ESCAPABLE.has(char) ? char : `\\${char}`;
+      continue;
+    }
+    if (char === "\\") {
+      pendingEscape = true;
+      continue;
+    }
+    result += char;
+  }
+  return pendingEscape ? `${result}\\` : result;
+}
+
+/** Split a "Label|data" pair, keeping escaped separators inside either side. */
+function splitCardPair(part: string): [string, string | undefined] {
+  const [label = "", data] = splitCardValue(part, "|").map((piece) =>
+    unescapeCardValue(piece.trim()),
+  );
+  return [label, data];
+}
+
 /**
  * Parse action string format: "Label|data,Label2|data2"
  * Data can be a URL (uri action) or plain text (message action) or key=value (postback)
@@ -59,11 +130,8 @@ function parseActions(actionsStr: string | undefined): CardAction[] {
 
   const results: CardAction[] = [];
 
-  for (const part of actionsStr.split(",")) {
-    const [label, data] = part
-      .trim()
-      .split("|")
-      .map((s) => s.trim());
+  for (const part of splitCardValue(actionsStr, ",")) {
+    const [label, data] = splitCardPair(part);
     if (!label) {
       continue;
     }
@@ -86,14 +154,10 @@ function parseActions(actionsStr: string | undefined): CardAction[] {
  * Parse list items format: "Item1|Subtitle1,Item2|Subtitle2"
  */
 function parseListItems(itemsStr: string): ListItem[] {
-  return itemsStr
-    .split(",")
+  return splitCardValue(itemsStr, ",")
     .map((part) => {
-      const [title, subtitle] = part
-        .trim()
-        .split("|")
-        .map((s) => s.trim());
-      return { title: title || "", subtitle };
+      const [title, subtitle] = splitCardPair(part);
+      return { title, subtitle };
     })
     .filter((item) => item.title);
 }
@@ -102,16 +166,15 @@ function parseListItems(itemsStr: string): ListItem[] {
  * Parse receipt items format: "Item1:$10,Item2:$20"
  */
 function parseReceiptItems(itemsStr: string): Array<{ name: string; value: string }> {
-  return itemsStr
-    .split(",")
+  return splitCardValue(itemsStr, ",")
     .map((part) => {
-      const colonIndex = part.lastIndexOf(":");
-      if (colonIndex === -1) {
-        return { name: part.trim(), value: "" };
-      }
+      // The last unescaped colon separates the entry value, so a name may still
+      // contain colons of its own.
+      const segments = splitCardValue(part, ":");
+      const value = segments.length > 1 ? segments.pop() : undefined;
       return {
-        name: part.slice(0, colonIndex).trim(),
-        value: part.slice(colonIndex + 1).trim(),
+        name: unescapeCardValue(segments.join(":").trim()),
+        value: value === undefined ? "" : unescapeCardValue(value.trim()),
       };
     })
     .filter((item) => item.name);
@@ -251,8 +314,8 @@ export function registerLineCardCommand(api: OpenClawPluginApi): void {
             const yesStr = flags.yes || "Yes|yes";
             const noStr = flags.no || "No|no";
 
-            const [yesLabel, yesData] = yesStr.split("|").map((s) => s.trim());
-            const [noLabel, noData] = noStr.split("|").map((s) => s.trim());
+            const [yesLabel, yesData] = splitCardPair(yesStr);
+            const [noLabel, noData] = splitCardPair(noStr);
 
             return buildLineReply({
               templateMessage: {

--- a/extensions/line/src/card-command.ts
+++ b/extensions/line/src/card-command.ts
@@ -279,8 +279,8 @@ export function registerLineCardCommand(api: OpenClawPluginApi): void {
             const yesStr = flags.yes || "Yes|yes";
             const noStr = flags.no || "No|no";
 
-            const [yesLabel, yesData] = yesStr.split("|").map((s) => s.trim());
-            const [noLabel, noData] = noStr.split("|").map((s) => s.trim());
+            const [yesLabel, yesData] = splitCardPair(yesStr);
+            const [noLabel, noData] = splitCardPair(noStr);
 
             return buildLineReply({
               templateMessage: {


### PR DESCRIPTION
Closes #129349

## What Problem This Solves

LINE `/card` values used commas, pipes, and colons as separators with no way to keep those characters inside data. A URL such as `https://example.test/a,b` was shortened at the comma and produced an unintended extra button. The same parser rule affected action data, list fields, receipt fields, button templates, and confirm values.

## Why This Change Was Made

The card parser now has one local escape-aware splitter. A backslash protects only the separator used by the current parsing pass. Other backslashes stay literal, including adjacent backslashes and backslashes before separators that are inactive for that option.

Maintainer decision: adopt backslash before an active separator as the permanent `/card` escape grammar. This deliberately changes only values that use `\,`, `\|`, or `\:`. Existing unescaped input keeps its current behavior.

The shared parser is the correct owner because it covers actions, buttons, lists, receipts, and confirms without URL-specific inference or a parallel parser path. The existing normalization helpers only support plain comma-separated lists and cannot preserve escaped separators.

## User Impact

Operators can keep commas, pipes, and colons inside card data by escaping them. For example, `/card action "Links" "Pick" --actions "Open|https://example.test/a\,b"` now creates one URI button for the full URL.

## Evidence

The registered `/card` handler ran with identical action, list, and receipt scenarios on current-main revision `4c1c4a4ae8c69d75313db20f94eea2af904efabc` and repaired revision `2cdfa1028c9a6b0ceb395dc3453d4c814d471d13`.

- Main shortened the URI to a trailing backslash, created extra actions, and misplaced escape markers in list and receipt fields.
- The repaired head produced `https://example.test/a,b`, callback data `key=a|b`, list fields `Coffee, large` and `Hot|fresh`, and receipt value `10:30`.
- Unescaped action, list, and receipt control payloads were byte-identical between revisions.
- Focused parser tests pass: 15 tests.
- Existing LINE card tests pass: 67 tests.
- Formatting, lint, extension production and test type checks, repository ratchets, dead-code checks, plugin boundaries, and import-cycle checks pass.
- Production delta: +51/-23, net +28. Tests: +155/-0.

Earlier contributor proof delivered the escaped URI payload through the real LINE Messaging API successfully. Exact-head external delivery was not repeated because no approved disposable LINE QA channel credential was available. No personal or unrelated account was used.

Not tested: tapping the delivered button in a LINE client. The outer quoted-argument tokenizer is unchanged.

PR #129360 overlaps only on URL commas and does not repair the shared card grammar.
