### PR TITLE
fix(gateway): preserve stateless Responses history replay

### DIFF
--- a/docs/gateway/openresponses-http-api.md
+++ b/docs/gateway/openresponses-http-api.md
@@ -87,6 +87,8 @@ Provide tools with `tools: [{ type: "function", name, description?, parameters? 
 
 If the agent calls a tool, the response returns a `function_call` output item. Send a follow-up request with `function_call_output` to continue the turn.
 
+Clients that manage their own history can append `response.output` to `input`, then append new user messages or `function_call_output` items. Keep returned assistant metadata and function-call IDs, names, and arguments unchanged. Alternatively, supply `previous_response_id` and only the new input items.
+
 For `tool_choice: "required"` and function-pinned `tool_choice`, the endpoint narrows the exposed client function-tool set, instructs the runtime to call a client tool before responding, and rejects the turn if it does not include a matching structured client-tool call, matching the `/v1/chat/completions` contract. Non-streaming requests return `502` with an `api_error`; streaming requests emit a `response.failed` event.
 
 ## Images (`input_image`)

--- a/src/gateway/agent-prompt.ts
+++ b/src/gateway/agent-prompt.ts
@@ -10,6 +10,12 @@ export type ConversationEntry = {
   internalStreamError?: boolean;
 };
 
+export type ConversationToolCall = { id?: string; name: string; arguments: string };
+
+export function renderConversationToolCall(call: ConversationToolCall): string {
+  return `tool_call id=${call.id ?? ""} name=${call.name} arguments=${call.arguments}`;
+}
+
 // Placeholder user text for an image-only turn. The agent command requires a
 // non-empty message even when the real payload is the attached image, so both
 // the /v1/chat/completions and /v1/responses prompt builders substitute this

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -91,23 +91,21 @@ export type ContentPart = z.infer<typeof ContentPartSchema>;
 const MessageItemRoleSchema = z.enum(["system", "developer", "user", "assistant"]);
 
 const AssistantPhaseSchema = z.enum(["commentary", "final_answer"]);
+const ItemStatusSchema = z.enum(["in_progress", "completed", "incomplete"]);
 
 const MessageItemSchema = z
   .object({
     type: z.literal("message"),
+    id: z.string().optional(),
     role: MessageItemRoleSchema,
     content: z.union([z.string(), z.array(ContentPartSchema)]),
     phase: AssistantPhaseSchema.optional(),
+    status: ItemStatusSchema.optional(),
   })
   .strict()
-  .superRefine((value, ctx) => {
-    if (value.phase !== undefined && value.role !== "assistant") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["phase"],
-        message: "`phase` is only valid on assistant messages.",
-      });
-    }
+  .refine((value) => value.phase === undefined || value.role === "assistant", {
+    path: ["phase"],
+    message: "`phase` is only valid on assistant messages.",
   });
 
 const FunctionCallItemSchema = z
@@ -117,6 +115,7 @@ const FunctionCallItemSchema = z
     call_id: z.string().optional(),
     name: z.string(),
     arguments: z.string(),
+    status: ItemStatusSchema.optional(),
   })
   .strict();
 
@@ -245,26 +244,19 @@ const ResponseStatusSchema = z.enum([
 ]);
 
 const OutputItemSchema = z.discriminatedUnion("type", [
-  z
-    .object({
-      type: z.literal("message"),
-      id: z.string(),
-      role: z.literal("assistant"),
-      content: z.array(OutputTextContentPartSchema),
-      phase: AssistantPhaseSchema.optional(),
-      status: z.enum(["in_progress", "completed"]).optional(),
-    })
-    .strict(),
-  z
-    .object({
-      type: z.literal("function_call"),
-      id: z.string(),
-      call_id: z.string(),
-      name: z.string(),
-      arguments: z.string(),
-      status: z.enum(["in_progress", "completed"]).optional(),
-    })
-    .strict(),
+  // Output items are replayable input; narrow required output fields without
+  // duplicating the supported item shape or dropping assistant phase validation.
+  MessageItemSchema.safeExtend({
+    id: z.string(),
+    role: z.literal("assistant"),
+    content: z.array(OutputTextContentPartSchema),
+    status: z.enum(["in_progress", "completed"]).optional(),
+  }),
+  FunctionCallItemSchema.extend({
+    id: z.string(),
+    call_id: z.string(),
+    status: z.enum(["in_progress", "completed"]).optional(),
+  }),
   z
     .object({
       type: z.literal("reasoning"),

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -44,7 +44,9 @@ import {
 import {
   buildAgentMessageFromConversationEntries,
   type ConversationEntry,
+  type ConversationToolCall,
   IMAGE_ONLY_USER_MESSAGE,
+  renderConversationToolCall,
 } from "./agent-prompt.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
@@ -448,12 +450,6 @@ function extractTextContent(content: unknown): string {
   return "";
 }
 
-type AssistantToolCall = {
-  id: string;
-  name: string;
-  arguments: string;
-};
-
 function stringifyToolCallArguments(value: unknown): string {
   if (typeof value === "string") {
     return value;
@@ -469,11 +465,11 @@ function stringifyToolCallArguments(value: unknown): string {
   }
 }
 
-function extractAssistantToolCalls(value: unknown): AssistantToolCall[] {
+function extractAssistantToolCalls(value: unknown): ConversationToolCall[] {
   if (!Array.isArray(value)) {
     return [];
   }
-  const calls: AssistantToolCall[] = [];
+  const calls: ConversationToolCall[] = [];
   for (const rawCall of value) {
     if (!rawCall || typeof rawCall !== "object" || Array.isArray(rawCall)) {
       continue;
@@ -493,12 +489,6 @@ function extractAssistantToolCalls(value: unknown): AssistantToolCall[] {
     calls.push({ id, name, arguments: argumentsValue });
   }
   return calls;
-}
-
-function renderAssistantToolCalls(calls: AssistantToolCall[]): string {
-  return calls
-    .map((call) => `tool_call id=${call.id} name=${call.name} arguments=${call.arguments}`)
-    .join("\n");
 }
 
 function resolveImageUrlPart(part: unknown): string | undefined {
@@ -681,8 +671,7 @@ function buildAgentPrompt(
     }
     const assistantToolCalls =
       normalizedRole === "assistant" ? extractAssistantToolCalls(msg.tool_calls) : [];
-    const assistantToolCallsSummary =
-      assistantToolCalls.length > 0 ? renderAssistantToolCalls(assistantToolCalls) : "";
+    const assistantToolCallsSummary = assistantToolCalls.map(renderConversationToolCall).join("\n");
 
     // Keep the image-only placeholder scoped to the active user turn so we don't
     // mention historical image-only turns whose bytes are intentionally not replayed.

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -31,6 +31,7 @@ import {
 import { ensureProfileForEmail } from "../state/user-profiles.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { IMAGE_ONLY_USER_MESSAGE } from "./agent-prompt.js";
+import type { ResponseResource } from "./open-responses.schema.js";
 import { buildAssistantDeltaResult } from "./test-helpers.agent-results.js";
 import {
   agentCommandMock,
@@ -3142,6 +3143,69 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(response?.output?.slice(1)).toEqual(doneFunctionCalls.map(({ item }) => item));
     expect(events.map((event) => event.data)).toContain("[DONE]");
   });
+
+  it.each([
+    { stream: false, tools: false },
+    { stream: true, tools: false },
+    { stream: false, tools: true },
+    { stream: true, tools: true },
+  ])(
+    "replays returned items into a stateless turn (stream=$stream, tools=$tools)",
+    async ({ stream, tools }) => {
+      agentCommandMock.mockClear();
+      const calls = [
+        { id: "call_1", name: "get_weather", arguments: '{"city":"Taipei"}' },
+        { id: "call_2", name: "get_weather", arguments: '{"city":"Paris"}' },
+      ];
+      agentCommandMock.mockResolvedValueOnce({
+        payloads: [{ text: "Checking both cities." }],
+        ...(tools ? { meta: { stopReason: "tool_calls", pendingToolCalls: calls } } : {}),
+      } as never);
+      const user = { type: "message", role: "user", content: "Compare the weather." };
+      const firstResponse = await postResponses(enabledPort, {
+        model: "openclaw",
+        input: [user],
+        stream,
+        tools: WEATHER_TOOL,
+      });
+      expect(firstResponse.status).toBe(200);
+      const first = stream
+        ? (
+            parseSseData(
+              findSseEvent(parseSseEvents(await firstResponse.text()), "response.completed"),
+            ) as { response: ResponseResource }
+          ).response
+        : ((await firstResponse.json()) as ResponseResource);
+      const results = tools
+        ? calls.map((call, index) => ({
+            type: "function_call_output",
+            call_id: call.id,
+            output: String(20 + index),
+          }))
+        : [{ ...user, content: "Explain that answer." }];
+      agentCommandMock.mockResolvedValueOnce({ payloads: [{ text: "Compared." }] } as never);
+      const secondResponse = await postResponses(enabledPort, {
+        model: "openclaw",
+        input: [user, ...first.output, ...results],
+        tools: WEATHER_TOOL,
+      });
+      expect(secondResponse.status).toBe(200);
+      expect(firstAgentOpts(1).sessionKey).not.toBe(firstAgentOpts().sessionKey);
+      const prompt = firstAgentOpts(1).message;
+      expect(prompt).toContain("Checking both cities.");
+      if (tools) {
+        for (const call of calls) {
+          expect(prompt).toContain(
+            `tool_call id=${call.id} name=${call.name} arguments=${call.arguments}`,
+          );
+          expect(prompt).toContain(`Tool:${call.id}:`);
+        }
+      } else {
+        expect(prompt).toContain("Explain that answer.");
+      }
+      await ensureResponseConsumed(secondResponse);
+    },
+  );
 
   it("reuses the prior session when previous_response_id is provided", async () => {
     const port = enabledPort;

--- a/src/gateway/openresponses-parity.test.ts
+++ b/src/gateway/openresponses-parity.test.ts
@@ -3,6 +3,7 @@ import { IMAGE_ONLY_USER_MESSAGE } from "./agent-prompt.js";
 import { CreateResponseBodySchema } from "./open-responses.schema.js";
 import { wrapUntrustedFileContent } from "./openresponses-file-content.js";
 import { buildAgentPrompt } from "./openresponses-prompt.js";
+import { createAssistantOutputItem, createFunctionCallOutputItem } from "./openresponses-shape.js";
 
 describe("OpenResponses aggregate behavior", () => {
   it("validates image, file, and tool request inputs", () => {
@@ -34,6 +35,56 @@ describe("OpenResponses aggregate behavior", () => {
         input: [{ type: "function_call_output", call_id: "call-1", output: '{"ok":true}' }],
       }).success,
     ).toBe(true);
+  });
+
+  it.each([
+    createAssistantOutputItem({
+      id: "msg_1",
+      text: "Checking.",
+      phase: "commentary",
+      status: "completed",
+    }),
+    createFunctionCallOutputItem({
+      id: "fc_1",
+      callId: "call_1",
+      name: "lookup",
+      arguments: "{}",
+      status: "completed",
+    }),
+  ])("accepts supported output metadata on replay: $type", (item) => {
+    const body = { model: "openclaw", input: [item] };
+    expect(CreateResponseBodySchema.safeParse(body).success).toBe(true);
+    for (const extra of [{ unexpected: true }, { status: "invented" }]) {
+      expect(
+        CreateResponseBodySchema.safeParse({ ...body, input: [{ ...item, ...extra }] }).success,
+      ).toBe(false);
+    }
+  });
+
+  it("preserves function identities and arguments alongside multiple returned results", () => {
+    const result = buildAgentPrompt([
+      { type: "message", role: "user", content: "Compare the accounts." },
+      {
+        type: "function_call",
+        call_id: "call_1",
+        name: "lookup",
+        arguments: '{"account":"alpha"}',
+      },
+      { type: "function_call", call_id: "call_2", name: "lookup", arguments: '{"account":"beta"}' },
+      { type: "function_call_output", call_id: "call_2", output: "42" },
+      { type: "function_call_output", call_id: "call_1", output: "17" },
+    ]);
+    expect(result.message).toContain(
+      'tool_call id=call_1 name=lookup arguments={"account":"alpha"}',
+    );
+    expect(result.message).toContain(
+      'tool_call id=call_2 name=lookup arguments={"account":"beta"}',
+    );
+    expect(result.message).toContain("Tool:call_2: 42");
+    expect(result.message).toContain("Tool:call_1: 17");
+    expect(result.message.indexOf("tool_call id=call_2")).toBeLessThan(
+      result.message.indexOf("Tool:call_2"),
+    );
   });
 
   it("rejects invalid image media types through the aggregate request schema", () => {

--- a/src/gateway/openresponses-prompt.ts
+++ b/src/gateway/openresponses-prompt.ts
@@ -3,6 +3,7 @@ import {
   buildAgentMessageFromConversationEntries,
   type ConversationEntry,
   IMAGE_ONLY_USER_MESSAGE,
+  renderConversationToolCall,
 } from "./agent-prompt.js";
 import type { ContentPart, ItemParam } from "./open-responses.schema.js";
 
@@ -98,6 +99,14 @@ export function buildAgentPrompt(input: string | ItemParam[]): {
       conversationEntries.push({
         role: normalizedRole,
         entry: { sender, body },
+      });
+    } else if (item.type === "function_call") {
+      conversationEntries.push({
+        role: "assistant",
+        entry: {
+          sender: "Assistant",
+          body: renderConversationToolCall({ ...item, id: item.call_id ?? item.id }),
+        },
       });
     } else if (item.type === "function_call_output") {
       conversationEntries.push({


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Clients following the documented Responses history pattern could not send the Gateway's own `response.output` back as input: its strict input schemas rejected emitted message IDs/status and streamed function-call status. Stripping that metadata still lost function names and arguments from the next prompt, so multiple tool results no longer carried the context needed to associate them with their requests.

## Why This Change Was Made

This change derives supported output message/function shapes from their input schemas and uses one conversation tool-call renderer for Responses and Chat Completions. Returned metadata can be replayed unchanged; function IDs, names, arguments, and results remain in the next prompt. Strict extra-field rejection, output requirements, and assistant-only `phase` semantics stay intact. The two duplicate output declarations and private Chat-only renderer/type are removed; production code shrinks by four lines.

## User Impact

Clients can append returned output to their history without stripping metadata, and retain the function-call context needed to interpret multiple results. The alternative `previous_response_id` flow remains unchanged. [The API documentation](https://docs.openclaw.ai/gateway/openresponses-http-api#client-tool-loop-function-tools) now describes both paths.

Production delta: **+40/−44, net −4 lines**. Tests: **+115**; documentation: **+2**. No new configuration or storage changes.

## Evidence

Seven new regression cases failed before the repair and pass afterward. The five adjacent suites pass all 168 tests, covering ordinary/tool replay from JSON and SSE, multiple calls, phase handling, strict request validation, and existing Chat Completions behavior. Scoped lint, formatting, max-lines/assertion guards, docs MDX, and 6902 internal links pass. Fresh isolated Codex Autoreview found no actionable P0 issue.

An isolated Blacksmith Testbox built the exact base plus reviewed patch, verified every tracked source file, and used its own frozen dependency install. The real Gateway completed six OpenAI model requests in six distinct sessions: ordinary replay plus JSON and SSE continuations with two function calls each. Returned output was sent unchanged, results arrived in reverse order, and the model matched each result to the correct arguments. Unsupported metadata and non-assistant phase still returned HTTP400. Gateway and lease cleanup are verified.

The live fixture used the explicit OpenClaw runtime and direct client function tools, with codeMode/toolSearch disabled only in isolated test config. This proves the supported replay path, not full upstream Responses conformance or Codex-runtime coverage. A `key`-named fixture parameter encountered enum validation failures with redacted arguments before replay; its root cause remains a separate recorded follow-up. The final non-sensitive `account` fixture passed with the same strict validation.


The regression suites were `openresponses-parity`, `openresponses-phase`, `openresponses-http`, `openai-http`, and `agent-prompt` as recorded in the local test receipt. Live source was baseline `6e827231257cf7c9c26ecd54fdc73d8c30afa5d8` plus patch SHA256 `628b5263ed33210f47dde68acdad325302ce92f7a30b0aa07601bcc47ea23b13`; tracked-source fingerprint `36ba85d30dc358df82f847da905be4289bbeb7e8b97a561bdc5a655b6ff8e0ba`. The remote recipe ran `pnpm install --frozen-lockfile`, `node scripts/run-node.mjs --version`, then a Python HTTP client against the built Gateway. This was not an npm package install.

AI-assisted implementation. The independent review scope was P0 only, not an exhaustive review at every priority. No production changes followed review or live proof.
