### PR TITLE
fix(ui): keep sidebar membership filters on displayed sessions

### DIFF
--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -143,6 +143,10 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
 
   private readonly sessionOwnerFilter = new SessionOwnerFilterController(this, () => this.context);
 
+  sidebarSessionOwnerFilter() {
+    return this.sessionOwnerFilter;
+  }
+
   get sessionOwnerFilterId(): string | null {
     return this.sessionOwnerFilter.ownerId;
   }

--- a/ui/src/components/session-data-controller-catalog.ts
+++ b/ui/src/components/session-data-controller-catalog.ts
@@ -19,7 +19,10 @@ import {
   sessionCatalogRequestError,
 } from "./app-sidebar-session-catalog-state.ts";
 import { sessionCatalogHostKey } from "./app-sidebar-session-types.ts";
-import type { SidebarSessionStatusFilter } from "./app-sidebar-session-types.ts";
+import type {
+  SidebarSessionOwnerFilter,
+  SidebarSessionStatusFilter,
+} from "./app-sidebar-session-types.ts";
 import {
   completePanelRefresh,
   failPanelRefresh,
@@ -35,6 +38,7 @@ export interface SessionDataControllerHost extends ReactiveControllerHost {
   promoteCreatedSession(sessionKey: string): void;
   selectedAgentIdForSessions(): string;
   sidebarSessionStatusFilter(): SidebarSessionStatusFilter;
+  sidebarSessionOwnerFilter(): SidebarSessionOwnerFilter;
   querySelector(selectors: string): Element | null;
 }
 

--- a/ui/src/components/session-data-controller-events.test.ts
+++ b/ui/src/components/session-data-controller-events.test.ts
@@ -12,6 +12,7 @@ describe("publishSidebarSessionList", () => {
     sessionsLoading: false,
     sessionMutationError: null,
     expandedAgentId: () => "main",
+    sessionListQuery: (agentId: string) => ({ agentId }),
     requestSessionDataUpdate: () => undefined,
   });
 

--- a/ui/src/components/session-data-controller-events.ts
+++ b/ui/src/components/session-data-controller-events.ts
@@ -2,11 +2,16 @@ import type { RouteId } from "../app-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { readPresenceEntries, type PresencePayload } from "../app/user-profile.ts";
 import type { AgentCapability } from "../lib/agents/index.ts";
-import type { SessionCapability, SessionListSnapshot } from "../lib/sessions/index.ts";
+import type {
+  SessionCapability,
+  SessionListOptions,
+  SessionListSnapshot,
+} from "../lib/sessions/index.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import {
   SIDEBAR_AGENT_SESSION_LIST_LIMIT,
   type SidebarSessionStatusFilter,
+  type SidebarSessionOwnerFilter,
 } from "./app-sidebar-session-types.ts";
 
 type SidebarSessionListOwner = {
@@ -17,6 +22,7 @@ type SidebarSessionListOwner = {
   sessionsLoading: boolean;
   sessionMutationError: string | null;
   expandedAgentId(): string;
+  sessionListQuery(agentId: string): SessionListOptions;
   requestSessionDataUpdate(): void;
 };
 
@@ -76,10 +82,23 @@ export function subscribeSidebarAgentSessionCaches(
   });
 }
 
-function filteredSidebarSessionQuery(agentId: string, archivedFilter: SidebarSessionStatusFilter) {
+type SidebarSessionQueryOwner = {
+  sidebarSessionOwnerFilter(): SidebarSessionOwnerFilter;
+  sidebarSessionStatusFilter(): SidebarSessionStatusFilter;
+};
+
+export function hasSidebarListFilter(owner: SidebarSessionQueryOwner): boolean {
+  const { ownerId, involvingMe } = owner.sidebarSessionOwnerFilter();
+  return owner.sidebarSessionStatusFilter() !== "active" || Boolean(ownerId || involvingMe);
+}
+
+export function sidebarSessionListQuery(owner: SidebarSessionQueryOwner, agentId: string) {
+  const { ownerId, involvingMe } = owner.sidebarSessionOwnerFilter();
   return {
+    ownerId: involvingMe ? undefined : ownerId || undefined,
+    involvingMe: involvingMe || undefined,
     agentId,
-    archivedFilter,
+    archivedFilter: owner.sidebarSessionStatusFilter(),
     limit: SIDEBAR_AGENT_SESSION_LIST_LIMIT,
     includeDerivedTitles: true,
     includeLastMessage: true,
@@ -100,11 +119,9 @@ export function publishSidebarSessionList(
 export function subscribeFilteredSidebarSessions(
   owner: SidebarSessionListOwner,
   sessions: SessionCapability,
-  agentId: string,
-  archivedFilter: Exclude<SidebarSessionStatusFilter, "active">,
+  scope: SessionListOptions,
   isCurrent: () => boolean,
 ): () => void {
-  const scope = filteredSidebarSessionQuery(agentId, archivedFilter);
   const apply = (snapshot: SessionListSnapshot) => {
     if (!isCurrent()) {
       return;
@@ -129,7 +146,6 @@ export function subscribeFilteredSidebarSessions(
 export function refreshSidebarSessionList(
   owner: SidebarSessionListOwner,
   agentId: string | null,
-  archivedFilter: SidebarSessionStatusFilter,
   append = false,
 ): Promise<void> {
   const result = owner.sessionsResult;
@@ -147,7 +163,7 @@ export function refreshSidebarSessionList(
     return Promise.resolve();
   }
   return owner.context.sessions.refreshList({
-    ...filteredSidebarSessionQuery(agentId, archivedFilter),
+    ...owner.sessionListQuery(agentId),
     ...(append && typeof offset === "number" ? { offset, append: true } : {}),
     force: true,
   });

--- a/ui/src/components/session-data-controller.event-refresh.test.ts
+++ b/ui/src/components/session-data-controller.event-refresh.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../api/gateway.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { createSessionCapability, type SessionCapability } from "../lib/sessions/index.ts";
+import type { SessionGateway } from "../lib/sessions/session-capability.ts";
 import type { SessionDataControllerHost } from "./session-data-controller-catalog.ts";
 import { SessionDataController } from "./session-data-controller.ts";
 
@@ -11,7 +12,11 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function createFilteredSessionController(statusFilter: "archived" | "all", rowCount = 1) {
+function createFilteredSessionController(
+  statusFilter: "active" | "archived" | "all",
+  rowCount = 1,
+  includeActiveRows = false,
+) {
   vi.stubGlobal("document", {
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
@@ -35,14 +40,16 @@ function createFilteredSessionController(statusFilter: "archived" | "all", rowCo
   const list = vi.fn(async (options?: Parameters<SessionCapability["list"]>[0]) => {
     const offset = options?.offset ?? 0;
     const limit = options?.limit ?? 60;
-    const sessions = rows.slice(offset, offset + limit);
+    const matchingRows =
+      options?.involvingMe || options?.ownerId ? rows.filter((_, index) => index % 2 === 0) : rows;
+    const sessions = matchingRows.slice(offset, offset + limit);
     const nextOffset = offset + sessions.length;
-    const hasMore = nextOffset < rows.length;
+    const hasMore = nextOffset < matchingRows.length;
     return {
       ts: 1,
       path: "",
       count: sessions.length,
-      totalCount: rows.length,
+      totalCount: matchingRows.length,
       nextOffset: hasMore ? nextOffset : null,
       hasMore,
       defaults: { modelProvider: null, model: null, contextTokens: null },
@@ -61,7 +68,7 @@ function createFilteredSessionController(statusFilter: "archived" | "all", rowCo
       const { archived, ...options } = (params ?? {}) as NonNullable<
         Parameters<SessionCapability["list"]>[0]
       > & { archived?: true | "all" };
-      if (!archived && !options.spawnedBy) {
+      if (!includeActiveRows && !archived && !options.spawnedBy) {
         return Promise.resolve({
           ts: 1,
           path: "",
@@ -76,15 +83,20 @@ function createFilteredSessionController(statusFilter: "archived" | "all", rowCo
       }) as Promise<T>;
     },
   } as GatewayBrowserClient;
+  const snapshot: SessionGateway["snapshot"] = {
+    phase: "connected",
+    client,
+    hello: null,
+    assistantAgentId: "main",
+    sessionKey: "agent:main:main",
+  };
+  const gatewayListeners = new Set<(next: SessionGateway["snapshot"]) => void>();
   const gateway = {
-    snapshot: {
-      phase: "connected",
-      client,
-      hello: null,
-      assistantAgentId: "main",
-      sessionKey: "agent:main:main",
+    snapshot,
+    subscribe(listener: (next: SessionGateway["snapshot"]) => void) {
+      gatewayListeners.add(listener);
+      return () => gatewayListeners.delete(listener);
     },
-    subscribe: () => () => undefined,
     subscribeEvents(listener: (event: GatewayEventFrame) => void) {
       eventListeners.add(listener);
       return () => eventListeners.delete(listener);
@@ -93,6 +105,7 @@ function createFilteredSessionController(statusFilter: "archived" | "all", rowCo
   const sessions = createSessionCapability(gateway);
   let selectedAgentId = "main";
   let selectedStatusFilter = statusFilter;
+  let membership = { ownerId: null as string | null, involvingMe: false };
   const agentsState = {
     connected: true,
     client,
@@ -132,6 +145,7 @@ function createFilteredSessionController(statusFilter: "archived" | "all", rowCo
     promoteCreatedSession: () => undefined,
     selectedAgentIdForSessions: () => selectedAgentId,
     sidebarSessionStatusFilter: () => selectedStatusFilter,
+    sidebarSessionOwnerFilter: () => membership,
     querySelector: () => null,
   } satisfies SessionDataControllerHost;
   const controller = new SessionDataController(host);
@@ -140,13 +154,23 @@ function createFilteredSessionController(statusFilter: "archived" | "all", rowCo
     controller,
     list,
     resultForKeys,
+    reconnect: () => {
+      for (const phase of ["reconnecting", "connected"] as const) {
+        snapshot.phase = phase;
+        gatewayListeners.forEach((listener) => listener(snapshot));
+      }
+    },
+    selectMembership: async (filter: typeof membership) => {
+      membership = filter;
+      await controller.refreshSidebarSessions();
+    },
     selectAgent: (agentId: string) => {
       selectedAgentId = agentId;
       controller.synchronizeSessionScope();
     },
-    selectStatusFilter: (nextStatusFilter: "archived" | "all") => {
+    selectStatusFilter: (nextStatusFilter: "active" | "archived" | "all") => {
       selectedStatusFilter = nextStatusFilter;
-      controller.resetForStatusFilter(nextStatusFilter);
+      controller.resetSessionList();
     },
     publishSessionChanged: (payload: Record<string, unknown> = {}) => {
       const event = {
@@ -180,6 +204,73 @@ function createFilteredSessionController(statusFilter: "archived" | "all", rowCo
 }
 
 describe("filtered sidebar session event refresh", () => {
+  it.each(["active", "archived", "all"] as const)(
+    "keeps membership in the displayed %s query across refresh, pagination, and agent changes",
+    async (statusFilter) => {
+      vi.useFakeTimers();
+      const {
+        controller,
+        list,
+        selectMembership,
+        selectAgent,
+        selectStatusFilter,
+        reconnect,
+        publishSessionChanged,
+      } = createFilteredSessionController(statusFilter, 140, true);
+      controller.hostConnected();
+      try {
+        await selectMembership({ ownerId: null, involvingMe: true });
+        expect(controller.sessionsResult?.sessions).toHaveLength(60);
+        expect(list).toHaveBeenLastCalledWith(expect.objectContaining({ involvingMe: true }));
+        expect(controller.sessionsResult?.sessions.every((row) => row.updatedAt! % 2 === 1)).toBe(
+          true,
+        );
+
+        await controller.loadMoreSidebarSessions();
+        expect(controller.sessionsResult?.sessions).toHaveLength(70);
+        expect(list).toHaveBeenLastCalledWith(
+          expect.objectContaining({ involvingMe: true, offset: 60 }),
+        );
+        await controller.refreshSidebarSessions();
+        expect(controller.sessionsResult?.sessions).toHaveLength(70);
+
+        list.mockClear();
+        publishSessionChanged();
+        await vi.advanceTimersByTimeAsync(200);
+        expect(list.mock.calls.some(([query]) => query?.involvingMe === true)).toBe(true);
+        expect(controller.sessionsResult?.sessions).toHaveLength(70);
+
+        list.mockClear();
+        reconnect();
+        await controller.refreshSidebarSessions();
+        expect(list.mock.calls.some(([query]) => query?.involvingMe === true)).toBe(true);
+        expect(controller.sessionsResult?.sessions).toHaveLength(70);
+
+        selectStatusFilter(statusFilter === "all" ? "archived" : "all");
+        await controller.refreshSidebarSessions();
+        expect(list).toHaveBeenLastCalledWith(expect.objectContaining({ involvingMe: true }));
+        expect(controller.sessionsResult?.sessions).toHaveLength(60);
+
+        selectAgent("research");
+        await controller.refreshSidebarSessions();
+        expect(list).toHaveBeenLastCalledWith(
+          expect.objectContaining({ agentId: "research", involvingMe: true }),
+        );
+        expect(controller.sessionsResult?.sessions).toHaveLength(60);
+
+        await selectMembership({ ownerId: "profile-ada", involvingMe: false });
+        expect(list).toHaveBeenLastCalledWith(expect.objectContaining({ ownerId: "profile-ada" }));
+        expect(list.mock.lastCall?.[0]?.involvingMe).toBeUndefined();
+        expect(controller.sessionsResult?.sessions).toHaveLength(60);
+
+        await selectMembership({ ownerId: null, involvingMe: false });
+        expect(list.mock.lastCall?.[0]?.ownerId).toBeUndefined();
+        expect(list.mock.lastCall?.[0]?.involvingMe).toBeUndefined();
+      } finally {
+        controller.hostDisconnected();
+      }
+    },
+  );
   it.each(["archived", "all"] as const)(
     "clears a recovered %s list failure without erasing a same-text action failure",
     async (statusFilter) => {

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -30,7 +30,6 @@ import { SessionCatalogLiveState } from "./app-sidebar-session-catalog-live.ts";
 import { bindAdoptedCatalogSession } from "./app-sidebar-session-catalogs.ts";
 import type {
   SidebarSessionMutationScope,
-  SidebarSessionStatusFilter,
   SidebarSessionsScrollState,
 } from "./app-sidebar-session-types.ts";
 import { createPanelRefreshStatus, type PanelRefreshStatus } from "./panel-refresh-status.ts";
@@ -46,9 +45,11 @@ import {
   updateSessionCatalogData as updateSessionCatalogDataForHost,
 } from "./session-data-controller-catalog.ts";
 import {
+  hasSidebarListFilter,
   publishSidebarSessionError,
   publishSidebarSessionList,
   refreshSidebarSessionList,
+  sidebarSessionListQuery,
   subscribeSidebarAgentSessionCaches,
   subscribeFilteredSidebarSessions,
   subscribeSessionDataGatewayEvents,
@@ -176,6 +177,8 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     this.host.requestUpdate();
   }
 
+  sessionListQuery = (agentId: string) => sidebarSessionListQuery(this.host, agentId);
+
   private readonly notify = () => this.requestSessionDataUpdate();
 
   hostConnected(): void {
@@ -279,7 +282,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       previousCatalogAgentId !== null && previousCatalogAgentId !== nextCatalogAgentId;
     const currentCanonicalAgentId = this.sessionsAgentId;
     const ownsCurrentCanonicalList =
-      this.host.sidebarSessionStatusFilter() === "active" &&
+      !hasSidebarListFilter(this.host) &&
       nextAgentId !== null &&
       currentCanonicalAgentId !== null &&
       normalizeAgentId(currentCanonicalAgentId) === nextAgentId &&
@@ -307,7 +310,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     if (
       agentChanged &&
       context?.gateway.snapshot.phase === "connected" &&
-      this.host.sidebarSessionStatusFilter() !== "active"
+      hasSidebarListFilter(this.host)
     ) {
       void this.refreshSidebarSessions();
     }
@@ -420,7 +423,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       this.notify();
     }
     const snapshot = sessions.state;
-    if (this.host.sidebarSessionStatusFilter() !== "active") {
+    if (hasSidebarListFilter(this.host)) {
       return;
     }
     const gateway = this.context?.gateway;
@@ -457,7 +460,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     if (this.context?.gateway.snapshot.phase === "connected") {
       // Group catalog hydration is idempotent per connection.
       void sessions.groupsLoad();
-      if (sourceChanged && this.host.sidebarSessionStatusFilter() !== "active") {
+      if (sourceChanged && hasSidebarListFilter(this.host)) {
         void this.refreshSidebarSessions();
       }
     }
@@ -493,7 +496,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     this.notify();
     if (!sourceOrClientChanged) {
       this.retireSessionCatalogData(!connected);
-      if (connected && this.sessionsSource && this.host.sidebarSessionStatusFilter() !== "active") {
+      if (connected && this.sessionsSource && hasSidebarListFilter(this.host)) {
         void this.refreshSidebarSessions();
       }
       return;
@@ -503,7 +506,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       this.clearSessionCache();
     }
     this.resetSessionCatalogConnection();
-    if (connected && this.sessionsSource && this.host.sidebarSessionStatusFilter() !== "active") {
+    if (connected && this.sessionsSource && hasSidebarListFilter(this.host)) {
       void this.refreshSidebarSessions();
     }
   }
@@ -527,13 +530,13 @@ export class SessionDataController implements ReactiveController, SessionCatalog
 
   private bindFilteredSessions(agentId: string): void {
     const sessions = this.context?.sessions;
-    const archivedFilter = this.host.sidebarSessionStatusFilter();
-    if (!sessions || archivedFilter === "active") {
+    if (!sessions || !hasSidebarListFilter(this.host)) {
       this.retireFilteredSessions();
       return;
     }
     const normalizedAgentId = normalizeAgentId(agentId);
-    const scopeKey = `${normalizedAgentId}:${archivedFilter}`;
+    const query = this.sessionListQuery(normalizedAgentId);
+    const scopeKey = JSON.stringify(query);
     if (this.filteredSessionScope === scopeKey) {
       return;
     }
@@ -542,24 +545,22 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     this.unsubscribeFilteredSessions = subscribeFilteredSidebarSessions(
       this,
       sessions,
-      normalizedAgentId,
-      archivedFilter,
+      query,
       () =>
         this.filteredSessionScope === scopeKey &&
         this.context?.sessions === sessions &&
-        this.host.sidebarSessionStatusFilter() === archivedFilter &&
+        this.host.sidebarSessionStatusFilter() === query.archivedFilter &&
         normalizeAgentId(this.host.expandedAgentId()) === normalizedAgentId,
     );
   }
 
   refreshSidebarSessions(agentId = this.host.expandedAgentId()): Promise<void> {
     this.bindFilteredSessions(agentId);
-    return refreshSidebarSessionList(this, agentId, this.host.sidebarSessionStatusFilter());
+    return refreshSidebarSessionList(this, agentId);
   }
 
   loadMoreSidebarSessions(): Promise<void> {
-    const statusFilter = this.host.sidebarSessionStatusFilter();
-    return refreshSidebarSessionList(this, this.sessionsAgentId, statusFilter, true);
+    return refreshSidebarSessionList(this, this.sessionsAgentId, true);
   }
 
   async loadChildSessions(parentKey: string): Promise<void> {
@@ -691,7 +692,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     this.notify();
   }
 
-  resetForStatusFilter(statusFilter: SidebarSessionStatusFilter): void {
+  resetSessionList(): void {
     this.retireFilteredSessions();
     this.sessionsLoading = false;
     this.visibleSessionLimits.clear();
@@ -699,7 +700,7 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     // pending request from the retired view can repopulate its cleared rows.
     this.resetChildSessionState();
     this.sessionResultsByAgent = {};
-    if (statusFilter === "active" && this.context) {
+    if (!hasSidebarListFilter(this.host) && this.context) {
       this.sessionsResult = this.context.sessions.state.result;
       this.sessionsAgentId = this.context.sessions.state.agentId;
     } else if (this.context) {

--- a/ui/src/components/session-organizer-controller-types.ts
+++ b/ui/src/components/session-organizer-controller-types.ts
@@ -17,7 +17,7 @@ export interface SessionOrganizerControllerHost extends ReactiveControllerHost {
     | "isSessionMutationScopeCurrent"
     | "publishSessionMutationError"
     | "refreshSidebarSessions"
-    | "resetForStatusFilter"
+    | "resetSessionList"
     | "sessionMutationError"
   >;
   readonly onUpdateSidebarEntries?: (entries: string[]) => void;

--- a/ui/src/components/session-organizer-controller.ts
+++ b/ui/src/components/session-organizer-controller.ts
@@ -766,7 +766,7 @@ export class SessionOrganizerController {
     }
     this.host.sessionsStatusFilter = statusFilter;
     this.host.clearSessionSelection();
-    this.host.sessionData.resetForStatusFilter(statusFilter);
+    this.host.sessionData.resetSessionList();
     try {
       storeSidebarSessionStatusFilter(statusFilter);
     } catch {

--- a/ui/src/components/session-owner-filter-controller.test.ts
+++ b/ui/src/components/session-owner-filter-controller.test.ts
@@ -1,6 +1,6 @@
 /* @vitest-environment jsdom */
 
-import type { ReactiveController, ReactiveControllerHost } from "lit";
+import type { ReactiveController } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   loadStoredSidebarSessionOwnerFilter,
@@ -41,21 +41,23 @@ describe("SessionOwnerFilterController", () => {
       removeController: vi.fn(),
       requestUpdate: vi.fn(),
       updateComplete: Promise.resolve(true),
-    } satisfies ReactiveControllerHost;
+      sessionData: {
+        resetSessionList: vi.fn(),
+        refreshSidebarSessions: () => refresh(),
+      },
+    };
     let selfUserId = "profile-ada";
-    let canonicalListRevision = 1;
-    const setOwnerFilter = vi.fn(() => Promise.resolve());
+    let finishRefresh!: () => void;
+    const refresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRefresh = resolve;
+        }),
+    );
     const ownerFilter = new SessionOwnerFilterController(host, () => ({
       gateway: {
         connection: { gatewayUrl: "wss://one.example/ws" },
         snapshot: { selfUser: { id: selfUserId } },
-      },
-      sessions: {
-        get canonicalListRevision() {
-          return canonicalListRevision;
-        },
-        setInvolvingMeFilter: vi.fn(() => Promise.resolve()),
-        setOwnerFilter,
       },
     }));
     expect(controller).toBe(ownerFilter);
@@ -73,19 +75,19 @@ describe("SessionOwnerFilterController", () => {
     ownerFilter.hostUpdated();
 
     expect(ownerFilter.ownerId).toBe("owner-bob");
-    expect(setOwnerFilter).toHaveBeenCalledWith("owner-bob");
-    expect(setOwnerFilter).not.toHaveBeenCalledWith(null);
+    expect(refresh).toHaveBeenCalledOnce();
     expect(loadStoredSidebarSessionOwnerFilter("wss://one.example/ws", "profile-bob")).toEqual({
       ownerId: "owner-bob",
       involvingMe: false,
     });
 
-    canonicalListRevision += 1;
+    finishRefresh();
+    await Promise.resolve();
     ownerFilter.hostUpdated();
     ownerFilter.observeOwnerFacet(true, [{ id: "owner-bob" }]);
     ownerFilter.hostUpdated();
     expect(ownerFilter.ownerId).toBe("owner-bob");
-    expect(setOwnerFilter).not.toHaveBeenCalledWith(null);
+    expect(refresh).toHaveBeenCalledOnce();
     expect(loadStoredSidebarSessionOwnerFilter("wss://one.example/ws", "profile-bob")).toEqual({
       ownerId: "owner-bob",
       involvingMe: false,

--- a/ui/src/components/session-owner-filter-controller.ts
+++ b/ui/src/components/session-owner-filter-controller.ts
@@ -1,5 +1,4 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
-import type { SessionCapability } from "../lib/sessions/index.ts";
 import {
   loadStoredSidebarSessionOwnerFilter,
   storeSidebarSessionOwnerFilter,
@@ -10,16 +9,6 @@ type SessionOwnerFilterContext = {
     connection: { gatewayUrl: string };
     snapshot: { selfUser?: { id: string } | null };
   };
-  sessions: Pick<
-    SessionCapability,
-    "canonicalListRevision" | "setInvolvingMeFilter" | "setOwnerFilter"
-  >;
-};
-
-type PendingFacetRefresh = {
-  revision: number;
-  scope: string;
-  settled: boolean;
 };
 
 export class SessionOwnerFilterController implements ReactiveController {
@@ -28,10 +17,12 @@ export class SessionOwnerFilterController implements ReactiveController {
   private scope: string | null = null;
   private ownerFacetResolved = false;
   private ownerOptions: readonly { id: string }[] = [];
-  private pendingFacetRefresh: PendingFacetRefresh | null = null;
+  private pendingFacetRefresh: Promise<void> | null = null;
 
   constructor(
-    private readonly host: ReactiveControllerHost,
+    private readonly host: ReactiveControllerHost & {
+      sessionData: { resetSessionList(): void; refreshSidebarSessions(): Promise<void> };
+    },
     private readonly getContext: () => SessionOwnerFilterContext | undefined,
   ) {
     host.addController(this);
@@ -39,19 +30,7 @@ export class SessionOwnerFilterController implements ReactiveController {
 
   hostUpdated(): void {
     this.restore();
-    const pending = this.pendingFacetRefresh;
-    const context = this.getContext();
-    if (
-      pending?.settled &&
-      pending.scope === this.scope &&
-      context &&
-      context.sessions.canonicalListRevision > pending.revision
-    ) {
-      this.pendingFacetRefresh = null;
-      this.host.requestUpdate();
-      return;
-    }
-    if (pending) {
+    if (this.pendingFacetRefresh) {
       return;
     }
     if (
@@ -85,7 +64,7 @@ export class SessionOwnerFilterController implements ReactiveController {
       );
     }
     this.host.requestUpdate();
-    void this.applyRequest();
+    void this.refresh();
   }
 
   private restore(): void {
@@ -110,34 +89,25 @@ export class SessionOwnerFilterController implements ReactiveController {
     }
     this.host.requestUpdate();
     if (previousScope !== null || this.ownerId || this.involvingMe) {
-      const pending = {
-        revision: context.sessions.canonicalListRevision,
-        scope: nextScope,
-        settled: false,
-      };
-      this.pendingFacetRefresh = pending;
       this.ownerFacetResolved = false;
       this.ownerOptions = [];
-      void this.applyRequest().finally(() => {
+      const pending = this.refresh();
+      this.pendingFacetRefresh = pending;
+      void pending.finally(() => {
         if (this.pendingFacetRefresh === pending) {
-          pending.settled = true;
+          this.pendingFacetRefresh = null;
           this.host.requestUpdate();
         }
       });
     }
   }
 
-  private currentFilter() {
-    return { ownerId: this.ownerId, involvingMe: this.involvingMe };
+  private refresh(): Promise<void> {
+    this.host.sessionData.resetSessionList();
+    return this.host.sessionData.refreshSidebarSessions();
   }
 
-  private applyRequest(): Promise<void> {
-    const sessions = this.getContext()?.sessions;
-    if (!sessions) {
-      return Promise.resolve();
-    }
-    return this.involvingMe
-      ? sessions.setInvolvingMeFilter(true)
-      : sessions.setOwnerFilter(this.ownerId);
+  private currentFilter() {
+    return { ownerId: this.ownerId, involvingMe: this.involvingMe };
   }
 }

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -352,37 +352,42 @@ suite.define(() => {
       "true",
     );
     await captureUiProof(currentPage, "01-people-sort-selected.png");
+    const expectOwnerFilter = async (after: number) => {
+      // The chat title survives a sidebar refresh; wait for the filtered row itself.
+      await expectBrowser(
+        currentPage.locator('[data-session-section="category:Research"]'),
+      ).toContainText("Ada research");
+      await expectBrowser(currentPage.locator('[data-session-key="agent:main:ada"]')).toBeVisible();
+      await expectBrowser(currentPage.locator('[data-session-key="agent:main:bob"]')).toHaveCount(
+        0,
+      );
+      await expectBrowser(
+        currentPage.locator('[data-session-section="category:Operations"]'),
+      ).toHaveCount(0);
+      // The shared roster may also refresh, so the filtered request need not be last.
+      await expect
+        .poll(async () => (await gateway.getRequests("sessions.list")).slice(after))
+        .toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              params: expect.objectContaining({ ownerId: "profile-ada" }),
+            }),
+          ]),
+        );
+    };
+    const beforeSelection = (await gateway.getRequests("sessions.list")).length;
     await peopleMenu.locator('[value="owner:profile-ada"]').waitFor();
     await selectMenuValue(peopleMenu, "owner:profile-ada");
-    await currentPage.getByText("Ada research", { exact: true }).first().waitFor();
-    await expect
-      .poll(() => currentPage.locator('[data-session-key="agent:main:bob"]').count())
-      .toBe(0);
+    await expectOwnerFilter(beforeSelection);
     await captureSessionOwnerProof(currentPage, "04-owner-filter-selected.png");
-    expect(await currentPage.locator('[data-session-section="category:Research"]').count()).toBe(1);
-    expect(await currentPage.locator('[data-session-section="category:Operations"]').count()).toBe(
-      0,
-    );
-    await expect
-      .poll(async () =>
-        (await gateway.getRequests("sessions.list")).some(
-          (request) =>
-            (request.params as { ownerId?: unknown } | undefined)?.ownerId === "profile-ada",
-        ),
-      )
-      .toBe(true);
 
     const initialConnections = (await gateway.getRequests("connect")).length;
+    const beforeReconnect = (await gateway.getRequests("sessions.list")).length;
     await gateway.closeLatest(1012, "owner filter reconnect proof");
     await expect
       .poll(async () => (await gateway.getRequests("connect")).length)
       .toBeGreaterThan(initialConnections);
-    await expect
-      .poll(async () => (await gateway.getRequests("sessions.list")).at(-1)?.params)
-      .toMatchObject({ ownerId: "profile-ada" });
-    await expect
-      .poll(() => currentPage.locator('[data-session-key="agent:main:bob"]').count())
-      .toBe(0);
+    await expectOwnerFilter(beforeReconnect);
     const reconnectedMenu = await openSidebarSortMenu(currentPage);
     await expectBrowser(reconnectedMenu.locator('[value="owner:profile-ada"]')).toHaveAttribute(
       "aria-checked",
@@ -390,17 +395,8 @@ suite.define(() => {
     );
 
     await currentPage.reload();
-    // installMockGateway creates a new in-page request log for the reloaded
-    // document, so this wait and last-request assertion cannot reuse traffic
-    // from the pre-reload owner selection.
-    await gateway.waitForRequest("sessions.list");
-    await currentPage.getByText("Ada research", { exact: true }).first().waitFor();
-    await expect
-      .poll(async () => (await gateway.getRequests("sessions.list")).at(-1)?.params)
-      .toMatchObject({ ownerId: "profile-ada" });
-    await expect
-      .poll(() => currentPage.locator('[data-session-key="agent:main:bob"]').count())
-      .toBe(0);
+    // Reload starts a new in-page request log, so no earlier traffic can satisfy this.
+    await expectOwnerFilter(0);
     const reloadedMenu = await openSidebarSortMenu(currentPage);
     await expectBrowser(reloadedMenu.locator('[value="owner:profile-ada"]')).toHaveAttribute(
       "aria-checked",

--- a/ui/src/lib/sessions/index.event-refresh.test.ts
+++ b/ui/src/lib/sessions/index.event-refresh.test.ts
@@ -471,12 +471,14 @@ describe("event-driven session list refresh", () => {
     {
       filter: "ownerId",
       query: { ownerId: "profile-ada" },
-      applyFilter: (sessions: SessionCapability) => sessions.setOwnerFilter("profile-ada"),
+      applyFilter: (sessions: SessionCapability) =>
+        sessions.refresh({ agentId: "main", ownerId: "profile-ada", force: true }),
     },
     {
       filter: "involvingMe",
       query: { involvingMe: true },
-      applyFilter: (sessions: SessionCapability) => sessions.setInvolvingMeFilter(true),
+      applyFilter: (sessions: SessionCapability) =>
+        sessions.refresh({ agentId: "main", involvingMe: true, force: true }),
     },
     {
       filter: "search",

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -596,8 +596,6 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       return () => listeners.delete(notify);
     },
     refreshList: (options) => roster.refreshList(options),
-    setOwnerFilter: (ownerId) => roster.setOwnerFilter(ownerId),
-    setInvolvingMeFilter: (enabled) => roster.setInvolvingMeFilter(enabled),
     reconcile,
     reconcileChanged,
     reconcileRunTerminal,

--- a/ui/src/lib/sessions/session-capability.ts
+++ b/ui/src/lib/sessions/session-capability.ts
@@ -162,8 +162,6 @@ export type SessionCapability = {
     listener: (snapshot: SessionListSnapshot) => void,
   ) => () => void;
   refreshList: (options?: SessionRefreshOptions) => Promise<void>;
-  setOwnerFilter: (ownerId: string | null) => Promise<void>;
-  setInvolvingMeFilter: (enabled: boolean) => Promise<void>;
   reconcile: (
     row: GatewaySessionRow | undefined,
     defaults?: SessionsListResult["defaults"],

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -626,24 +626,6 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         }
       }
     },
-    setOwnerFilter(ownerId: string | null) {
-      const options = {
-        ...lastListOptions,
-        ownerId: ownerId?.trim() || undefined,
-        involvingMe: undefined,
-      };
-      delete options.offset;
-      return refresh({ ...options, force: true });
-    },
-    setInvolvingMeFilter(enabled: boolean) {
-      const options = {
-        ...lastListOptions,
-        ownerId: undefined,
-        involvingMe: enabled || undefined,
-      };
-      delete options.offset;
-      return refresh({ ...options, force: true });
-    },
     lastOptions: () => lastListOptions,
     // Gateway-owned membership filters require an authoritative list refresh.
     canApplyPrimarySnapshot: () => isPrimarySessionListQuery(lastListOptions),

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership-filtering.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership-filtering.ts
@@ -27,6 +27,8 @@ async function selectOwner(sidebar: SidebarLifecycleState, ownerId: string) {
     }),
   );
   await sidebar.updateComplete;
+  await waitForFast(() => expect(sidebar.sessionData.sessionsLoading).toBe(false));
+  await sidebar.updateComplete;
 }
 
 describe("AppSidebar session ownership filtering", () => {
@@ -232,6 +234,7 @@ describe("AppSidebar session ownership filtering", () => {
       result: { ...result, count: 1, sessions: [ada] },
       agentId: "main",
     });
+    await sidebar.sessionData.refreshSidebarSessions();
     await sidebar.updateComplete;
     expect(sidebar.querySelector(`[data-session-key="${backingSessionKey}"]`)).toBeNull();
     expect(sidebar.textContent).not.toContain("External unowned session");

--- a/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-ownership.ts
@@ -242,20 +242,18 @@ describe("AppSidebar session ownership", () => {
       }),
     );
     await sidebar.updateComplete;
-    expect(harness.setOwnerFilter).toHaveBeenCalledWith("profile-bob");
+    expect(harness.list).toHaveBeenCalledWith(expect.objectContaining({ ownerId: "profile-bob" }));
 
     result.owners = [{ type: "human", id: "profile-bob", label: "Bob" }];
     harness.publishList({ result, agentId: "main" });
     await sidebar.updateComplete;
     expect(sidebar.sessionOwnerFilterId).toBe("profile-bob");
-    expect(harness.setOwnerFilter).not.toHaveBeenCalledWith(null);
 
     result.owners = undefined;
     harness.publishList({ result, agentId: "main" });
     await sidebar.updateComplete;
     expect(sidebar.sessionOwnerFilterId).toBe("profile-bob");
     expect(sidebar.querySelector('[data-session-key="agent:main:ada"]')).toBeNull();
-    expect(harness.setOwnerFilter).not.toHaveBeenCalledWith(null);
     const unresolvedMenu = await openOwnerMenu(sidebar);
     expect(unresolvedMenu.querySelector('[value="owner:"]')).not.toBeNull();
 
@@ -264,7 +262,6 @@ describe("AppSidebar session ownership", () => {
     await sidebar.updateComplete;
     await sidebar.updateComplete;
     expect(sidebar.sessionOwnerFilterId).toBeNull();
-    expect(harness.setOwnerFilter).toHaveBeenLastCalledWith(null);
   });
 
   it("shows the authenticated user first in the owner filter", async () => {
@@ -334,7 +331,7 @@ describe("AppSidebar session ownership", () => {
       }),
     );
     await sidebar.updateComplete;
-    expect(harness.setInvolvingMeFilter).toHaveBeenCalledWith(true);
+    expect(harness.list).toHaveBeenCalledWith(expect.objectContaining({ involvingMe: true }));
   });
 
   it("renders no ownership chrome when the listed sessions have fewer than two owners", async () => {

--- a/ui/src/test-helpers/app-sidebar-cases/session-pagination.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/session-pagination.ts
@@ -27,7 +27,7 @@ describe("AppSidebar gateway session pagination", () => {
       const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
       (sidebar as unknown as { sessionsStatusFilter: "archived" | "all" }).sessionsStatusFilter =
         statusFilter;
-      sidebar.sessionData.resetForStatusFilter(statusFilter);
+      sidebar.sessionData.resetSessionList();
       await sidebar.sessionData.refreshSidebarSessions("main");
       harness.list.mockClear();
       harness.list.mockResolvedValue(changedResult);
@@ -78,7 +78,7 @@ describe("AppSidebar gateway session pagination", () => {
       const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
       (sidebar as unknown as { sessionsStatusFilter: "archived" | "all" }).sessionsStatusFilter =
         statusFilter;
-      sidebar.sessionData.resetForStatusFilter(statusFilter);
+      sidebar.sessionData.resetSessionList();
       await sidebar.sessionData.refreshSidebarSessions("main");
       await sidebar.sessionData.loadMoreSidebarSessions();
       expect(sidebar.sessionData.sessionsResult?.sessions).toHaveLength(120);
@@ -114,7 +114,7 @@ describe("AppSidebar gateway session pagination", () => {
       const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
       (sidebar as unknown as { sessionsStatusFilter: "archived" | "all" }).sessionsStatusFilter =
         statusFilter;
-      sidebar.sessionData.resetForStatusFilter(statusFilter);
+      sidebar.sessionData.resetSessionList();
 
       const pendingRefresh = sidebar.sessionData.refreshSidebarSessions("main");
       const generation = sidebar.sessionData.sessionScopeGeneration;
@@ -157,7 +157,7 @@ describe("AppSidebar gateway session pagination", () => {
       );
       (sidebar as unknown as { sessionsStatusFilter: "archived" | "all" }).sessionsStatusFilter =
         statusFilter;
-      sidebar.sessionData.resetForStatusFilter(statusFilter);
+      sidebar.sessionData.resetSessionList();
 
       const staleRefresh = sidebar.sessionData.refreshSidebarSessions("main");
       context.agentSelection.state.selectedId = "research";
@@ -197,7 +197,7 @@ describe("AppSidebar gateway session pagination", () => {
       const { sidebar } = await mountSidebar(gateway.gateway, harness.sessions);
       (sidebar as unknown as { sessionsStatusFilter: "archived" | "all" }).sessionsStatusFilter =
         statusFilter;
-      sidebar.sessionData.resetForStatusFilter(statusFilter);
+      sidebar.sessionData.resetSessionList();
 
       const staleRefresh = sidebar.sessionData.refreshSidebarSessions("main");
       gateway.publish({ phase: "reconnecting" });
@@ -244,7 +244,7 @@ describe("AppSidebar gateway session pagination", () => {
       );
       (sidebar as unknown as { sessionsStatusFilter: "archived" | "all" }).sessionsStatusFilter =
         statusFilter;
-      sidebar.sessionData.resetForStatusFilter(statusFilter);
+      sidebar.sessionData.resetSessionList();
       await sidebar.sessionData.refreshSidebarSessions("main");
       harness.list.mockClear();
 
@@ -431,7 +431,7 @@ describe("AppSidebar gateway session pagination", () => {
       );
       (sidebar as unknown as { sessionsStatusFilter: "archived" | "all" }).sessionsStatusFilter =
         statusFilter;
-      sidebar.sessionData.resetForStatusFilter(statusFilter);
+      sidebar.sessionData.resetSessionList();
       await sidebar.sessionData.refreshSidebarSessions("main");
       harness.list.mockClear();
 
@@ -487,7 +487,7 @@ describe("AppSidebar gateway session pagination", () => {
           sessionsStatusFilter: "archived" | "all";
         }
       ).sessionsStatusFilter = statusFilter;
-      sidebar.sessionData.resetForStatusFilter(statusFilter);
+      sidebar.sessionData.resetSessionList();
       await sidebar.sessionData.refreshSidebarSessions("main");
       await sidebar.updateComplete;
 

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -284,8 +284,6 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
       })),
     }),
   );
-  const setOwnerFilter = vi.fn(() => Promise.resolve());
-  const setInvolvingMeFilter = vi.fn(() => Promise.resolve());
   const subscribeMessages = vi.fn((key: string, options?: { agentId?: string | null }) =>
     Promise.resolve({ key, agentId: options?.agentId ?? null }),
   );
@@ -380,7 +378,11 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
     deleteMany,
     list,
     listSnapshot(scope: Parameters<SessionCapability["listSnapshot"]>[0]) {
-      if (!scope.archivedFilter || scope.archivedFilter === "active") {
+      if (
+        (!scope.archivedFilter || scope.archivedFilter === "active") &&
+        !scope.ownerId &&
+        !scope.involvingMe
+      ) {
         return {
           result: state.result,
           agentId: state.agentId,
@@ -397,14 +399,16 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
       return scopedSessions!.subscribeList(scope, listener);
     },
     refreshList(options: Parameters<SessionCapability["refreshList"]>[0]) {
-      if (!options?.archivedFilter || options.archivedFilter === "active") {
+      if (
+        (!options?.archivedFilter || options.archivedFilter === "active") &&
+        !options?.ownerId &&
+        !options?.involvingMe
+      ) {
         return refresh(options);
       }
       return scopedSessions!.refreshList(options);
     },
     reconcile,
-    setOwnerFilter,
-    setInvolvingMeFilter,
     refresh,
     refreshReplacement,
     subscribeMessages,
@@ -441,12 +445,12 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
           const { archived, ...options } = (params ?? {}) as SessionListOptions & {
             archived?: true | "all";
           };
-          if (!archived) {
+          if (!archived && !options.ownerId && !options.involvingMe) {
             return state.result as T;
           }
           return (await list({
             ...options,
-            archivedFilter: archived === true ? "archived" : "all",
+            ...(archived ? { archivedFilter: archived === true ? "archived" : "all" } : {}),
           })) as T;
         },
       } as GatewayBrowserClient;
@@ -483,8 +487,6 @@ export function createSessionsHarness(agentId: string, keys: string[]) {
     deleteMany,
     list,
     reconcile,
-    setOwnerFilter,
-    setInvolvingMeFilter,
     refresh,
     refreshReplacement,
     subscribeMessages,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users selecting **Involving me** in the Control UI sidebar would still see unrelated sessions in **All** or **Archived**, or after a sidebar refresh, even though the filter remained selected.

## Why This Change Was Made

The sidebar filter changed the shared Active roster, while status-filtered views and later refreshes used a separate query without the membership predicate. One sidebar query now composes membership, agent, status, and pagination for the displayed subscription and every refresh path. Filter changes reset and refresh that displayed list through its existing data controller.

The primary-only owner-filter setters are removed. The shared unfiltered Active roster remains available to its other consumers; the Gateway remains the authority for full participant membership. Persisted preferences, authorization, protocol, and storage schemas are unchanged. Production delta: **69 additions / 96 deletions (net −27)**; tests and test support: **181 additions / 87 deletions (net +94)**. AI-assisted implementation and verification.

## User Impact

The selected owner or Involving me filter stays applied when refreshing, loading more sessions, reconnecting, changing agents, or switching between Active, All, and Archived. Clearing the filter restores the corresponding unfiltered view.

## Evidence

The new controller/capability regression failed in all three status modes before the production change. The final focused suite passes **377 tests in six files**, including pagination, event refresh, reconnect, agent/status changes, owner-filter changes and clearing, identity-scoped preferences, and existing sidebar/catalog behavior. Changed-file type-aware lint and whitespace checks pass. A fresh isolated Codex autoreview found no actionable P0 findings; that review was explicitly limited to P0.

The broader UI typecheck and local build were blocked by the prepared checkout's older dependencies, including markdown-it, pako, pi-tui, and missing panzoom. They are not reported as passing.

Real Gateway and built Control UI verification also passed on an isolated Linux Testbox. Separate exact-baseline and candidate copies each received a frozen dependency install; the unchanged source fingerprint was verified before and after execution. Synthetic Ada/Bob profiles authenticated through the supported trusted-proxy flow, and real Gateway RPCs created and archived their fixture sessions. Playwright then used the visible filter controls. No Gateway RPC was mocked.

With **Involving me** checked, **All** showed four Ada/Bob sessions before and only Ada's two afterward; **Archived** showed both users' archived sessions before and only Ada's archived session afterward. Four before/after screenshots were personally inspected. The shared Home Recent chats list still includes other accessible sessions, as intended: this change scopes the sidebar filter, not authorization or the shared roster.

The Gateway runtime build and both UI production builds passed. The browser command exited 0. Browser coverage is specifically the All and Archived menu flows; Active refresh, pagination, reconnect, identity change, and agent switching have focused controller/capability coverage, not additional live-browser claims. No external identity provider, channel, or model call was tested; the isolated fixture intentionally has no provider plugins enabled.



Before: All with Involving me selected still displays Bob's unrelated sessions.

![Before: membership filter ignored](https://github.com/user-attachments/assets/62642d3a-3744-44d8-baf8-8e71e7280d19)

After: the same filter and status show only Ada's sessions. Home Recent Chats remains an independent unfiltered view.

![After: membership filter applied](https://github.com/user-attachments/assets/976b38d4-c070-4cf8-b60f-a584adfbf177)


CI follow-up: the existing owner-filter E2E test treated the open chat title and absence of Bob during sidebar loading as proof that filtering had finished. It also assumed the last session-list request must be filtered, although the sidebar and shared roster now refresh independently. The test now waits for the actual Research/Ada sidebar result and checks fresh filtered requests after selection, reconnect, and reload. No production code, timeouts, fixture behavior, or dependency versions changed; test LOC is +29/-33.

Reproduced the exact original CI failure on the PR head in a clean isolated browser environment, then passed all 13 ownership E2E cases after the test-only correction. A separate visual run passed, and all five screenshots plus representative video frames were inspected. This follow-up uses the built Control UI with mocked Gateway RPC; the production fix's real Gateway before/after evidence remains unchanged. Scoped lint, formatting, diff checks, and fresh isolated Codex P0-only review passed.
