### PR TITLE
fix(backup): restore verified archive-relative hardlinks

### DIFF
--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -14,6 +14,7 @@ import {
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { backupRestoreCommand } from "./backup-restore.js";
 import { buildBackupArchivePath } from "./backup-shared.js";
+import { verifyBackupArchive } from "./backup-verify.js";
 
 function createRuntime(): RuntimeEnv {
   return {
@@ -114,6 +115,54 @@ async function writeArchive(params: {
 }
 
 describe("backupRestoreCommand", () => {
+  it.each([
+    { targetForm: "qualified", suffix: "" },
+    { targetForm: "root-relative", suffix: "" },
+    { targetForm: "qualified", suffix: " " },
+    { targetForm: "root-relative", suffix: " " },
+  ])(
+    "restores verified $targetForm hardlinks with suffix '$suffix'",
+    async ({ targetForm, suffix }, ctx) => {
+      if (suffix && process.platform === "win32") {
+        ctx.skip(); // Windows cannot preserve a trailing space in a filename.
+      }
+      await withOpenClawTestState(
+        { layout: "state-only", prefix: "openclaw-backup-restore-hardlink-", scenario: "minimal" },
+        async (state) => {
+          const archivePath = state.path("backup.tar.gz");
+          const targetPath = state.path("restored");
+          const archiveRoot = "2026-08-12T00-00-00.000Z-openclaw-backup";
+          const payloadPath = `${buildBackupArchivePath(archiveRoot, "/tmp/openclaw.json")}${suffix}`;
+          const hardlinkPath = `${archiveRoot}/payload/config-link${suffix}`;
+          await writeArchive({
+            archivePath,
+            archiveRoot,
+            payloadPath,
+            extraEntries: [
+              encodeTarEntry({
+                path: hardlinkPath,
+                type: "Link",
+                linkpath:
+                  targetForm === "qualified"
+                    ? payloadPath
+                    : path.posix.relative(archiveRoot, payloadPath),
+              }),
+            ],
+          });
+
+          await expect(verifyBackupArchive(archivePath)).resolves.toMatchObject({ ok: true });
+          await expect(
+            backupRestoreCommand(createRuntime(), { archive: archivePath, target: targetPath }),
+          ).resolves.toMatchObject({ ok: true, entryCount: 3 });
+          const original = path.join(targetPath, payloadPath);
+          const linked = path.join(targetPath, hardlinkPath);
+          await expect(fs.readFile(linked, "utf8")).resolves.toBe("{}\n");
+          expect((await fs.stat(linked)).ino).toBe((await fs.stat(original)).ino);
+        },
+      );
+    },
+  );
+
   it("round-trips a backup into a fresh target with matching inventory and readable databases", async () => {
     await withOpenClawTestState(
       {

--- a/src/commands/backup-restore.test.ts
+++ b/src/commands/backup-restore.test.ts
@@ -115,7 +115,7 @@ async function writeArchive(params: {
 }
 
 describe("backupRestoreCommand", () => {
-  it.each([
+  it.for([
     { targetForm: "qualified", suffix: "" },
     { targetForm: "root-relative", suffix: "" },
     { targetForm: "qualified", suffix: " " },

--- a/src/commands/backup-restore.ts
+++ b/src/commands/backup-restore.ts
@@ -12,7 +12,7 @@ import {
   resolveBackupAgentRoots,
   resolveRequiredBackupPath,
 } from "./backup-shared.js";
-import { verifyBackupArchive } from "./backup-verify.js";
+import { prepareBackupArchive } from "./backup-verify.js";
 import { isPathWithin } from "./cleanup-utils.js";
 import { resolveUpgradeConfigSnapshot } from "./doctor/shared/automatic-upgrade-config-repair.js";
 
@@ -98,7 +98,11 @@ async function cleanupFailedRestore(targetPath: string, created: boolean): Promi
   }
 }
 
-async function extractBackupArchive(archivePath: string, targetPath: string): Promise<void> {
+async function extractBackupArchive(
+  archivePath: string,
+  targetPath: string,
+  hardlinkTargets: ReadonlyMap<string, string>,
+): Promise<void> {
   let extractionError: Error | undefined;
   await tar.x({
     file: archivePath,
@@ -109,6 +113,13 @@ async function extractBackupArchive(archivePath: string, targetPath: string): Pr
     // Verification catches fatal archive errors; rethrow recoverable warnings after close.
     strict: false,
     preserveOwner: false,
+    // node-tar calls this before its path checks and filesystem reservations.
+    onReadEntry: (entry) => {
+      const target = hardlinkTargets.get(entry.path);
+      if (target !== undefined) {
+        entry.linkpath = target;
+      }
+    },
     onwarn: (code, message, data) => {
       extractionError ??=
         data instanceof Error ? data : Object.assign(new Error(`${code}: ${message}`), data);
@@ -140,28 +151,17 @@ export async function backupRestoreCommand(
 ): Promise<BackupRestoreResult> {
   const targetPath = resolveRequiredBackupPath(options.target, "--target");
   await assertTargetOutsideLiveState(targetPath);
-  const verified = await verifyBackupArchive(options.archive);
+  const { result: verified, hardlinkTargets } = await prepareBackupArchive(options.archive);
   const target = await prepareRestoreTarget(targetPath);
 
-  let extractionError: unknown;
-  let extractionFailed = false;
   try {
-    await extractBackupArchive(verified.archivePath, targetPath);
-  } catch (caughtExtractionError) {
-    extractionError = caughtExtractionError;
-    extractionFailed = true;
-  }
-  if (extractionFailed) {
-    let cleanupError: unknown;
-    let cleanupFailed = false;
+    await extractBackupArchive(verified.archivePath, targetPath, hardlinkTargets);
+  } catch (extractionError) {
     try {
       await cleanupFailedRestore(targetPath, target.created);
-    } catch (caughtCleanupError) {
-      cleanupError = caughtCleanupError;
-      cleanupFailed = true;
-    }
-    if (cleanupFailed) {
-      // Extraction stays the primary cause; cleanup rides along as the second AggregateError entry.
+    } catch (cleanupError) {
+      // Both errors are retained; extraction remains the primary cause, not cleanup.
+      // oxlint-disable-next-line preserve-caught-error -- AggregateError.errors preserves the cleanup error.
       throw new AggregateError(
         [extractionError, cleanupError],
         `Backup restore failed and the incomplete target could not be cleaned: ${targetPath}. Cleanup error: ${formatErrorMessage(cleanupError)}`,

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -49,6 +49,11 @@ type BackupVerifyResult = {
   symlinkCount: number;
 };
 
+type PreparedBackupArchive = {
+  result: BackupVerifyResult;
+  hardlinkTargets: ReadonlyMap<string, string>;
+};
+
 type ArchiveEntry = {
   path: string;
   linkpath?: string;
@@ -121,32 +126,6 @@ async function extractManifest(params: {
     throw content;
   }
   return content.toString("utf8");
-}
-
-function verifyHardlinkTargetsAgainstArchiveRoot(
-  hardlinkTargets: Array<{ entryPath: string; normalized: string }>,
-  archiveRoot: string,
-  entries: Set<string>,
-): void {
-  const normalizedRoot = normalizeArchiveRoot(archiveRoot);
-  for (const target of hardlinkTargets) {
-    // Older backup archives may store hardlink linkpath values relative to the
-    // archive root instead of including the root segment. Accept that form only
-    // when it resolves to a real entry inside this archive.
-    const normalizedTarget = isArchivePathWithin(target.normalized, normalizedRoot)
-      ? target.normalized
-      : path.posix.join(normalizedRoot, target.normalized);
-    if (!isArchivePathWithin(normalizedTarget, normalizedRoot)) {
-      throw new Error(
-        `Archive hardlink target is outside the declared archive root: ${target.entryPath} -> ${normalizedTarget}`,
-      );
-    }
-    if (!entries.has(normalizedTarget)) {
-      throw new Error(
-        `Archive hardlink target is missing from archive entries: ${target.entryPath} -> ${normalizedTarget}`,
-      );
-    }
-  }
 }
 
 function formatResult(result: BackupVerifyResult): string {
@@ -573,7 +552,7 @@ async function verifySqliteSnapshots(params: {
   }
 }
 
-async function verifyResolvedBackupArchive(archivePath: string): Promise<BackupVerifyResult> {
+async function verifyResolvedBackupArchive(archivePath: string): Promise<PreparedBackupArchive> {
   let archiveStat;
   try {
     archiveStat = await fs.stat(archivePath);
@@ -613,19 +592,11 @@ async function verifyResolvedBackupArchive(archivePath: string): Promise<BackupV
     ...(entry.size !== undefined ? { size: entry.size } : {}),
     ...(entry.type ? { type: entry.type } : {}),
   }));
-  const hardlinkTargets = rawEntries
-    .filter((entry) => entry.type === "Link" && entry.linkpath)
-    .map((entry) => ({
-      entryPath: entry.path,
-      normalized: normalizeArchivePath(
-        entry.linkpath ?? "",
-        `Archive hardlink target for ${entry.path}`,
-      ),
-    }));
   const symbolicLinks = rawEntries
     .filter((entry) => entry.type === "SymbolicLink")
     .map((entry) => ({ entryPath: entry.path, linkpath: entry.linkpath }));
-  const normalizedEntrySet = new Set(entries.map((entry) => entry.normalized));
+  const rawEntryPaths = new Map(entries.map((entry) => [entry.normalized, entry.raw]));
+  const normalizedEntrySet = new Set(rawEntryPaths.keys());
 
   const manifestMatches = entries.filter((entry) => isRootBackupManifestEntry(entry.normalized));
   if (manifestMatches.length !== 1) {
@@ -649,11 +620,28 @@ async function verifyResolvedBackupArchive(archivePath: string): Promise<BackupV
   const manifestRaw = await extractManifest({ archivePath, manifestEntryPath });
   const manifest = parseBackupManifest(manifestRaw);
   verifyBackupManifestEntries(manifest, normalizedEntrySet);
-  verifyHardlinkTargetsAgainstArchiveRoot(
-    hardlinkTargets,
-    manifest.archiveRoot,
-    normalizedEntrySet,
-  );
+  const archiveRoot = normalizeArchiveRoot(manifest.archiveRoot);
+  const hardlinkTargets = new Map<string, string>();
+  for (const entry of rawEntries) {
+    if (entry.type === "Link") {
+      const target = normalizeArchivePath(
+        entry.linkpath ?? "",
+        `Archive hardlink target for ${entry.path}`,
+      );
+      // Older backups omit the archive root. Resolve once, retaining the actual
+      // entry spelling: normalization is a lookup key, not a filename rewrite.
+      const resolved = isArchivePathWithin(target, archiveRoot)
+        ? target
+        : path.posix.join(archiveRoot, target);
+      const rawTarget = rawEntryPaths.get(resolved);
+      if (!rawTarget) {
+        throw new Error(
+          `Archive hardlink target is missing from archive entries: ${entry.path} -> ${resolved}`,
+        );
+      }
+      hardlinkTargets.set(entry.path, rawTarget);
+    }
+  }
   for (const link of symbolicLinks) {
     assertArchiveSymbolicLinkTarget({
       ...link,
@@ -674,16 +662,21 @@ async function verifyResolvedBackupArchive(archivePath: string): Promise<BackupV
     symlinkCount: symbolicLinks.length,
   };
 
-  return result;
+  return { result, hardlinkTargets };
 }
 
-/** Verify a backup archive and return its normalized, integrity-checked inventory. */
-export async function verifyBackupArchive(archive: string): Promise<BackupVerifyResult> {
+/** Verify an archive and prepare the exact hardlink targets needed by extraction. */
+export async function prepareBackupArchive(archive: string): Promise<PreparedBackupArchive> {
   const archivePath = resolveUserPath(archive);
   return await verifyResolvedBackupArchive(archivePath).catch((error: unknown) => {
     const detail = error instanceof Error ? error.message : formatErrorMessage(error);
     throw new Error(`Backup archive verification failed: ${archivePath}. ${detail}`);
   });
+}
+
+/** Verify a backup archive without exposing extraction metadata in CLI output. */
+export async function verifyBackupArchive(archive: string): Promise<BackupVerifyResult> {
+  return (await prepareBackupArchive(archive)).result;
 }
 
 /** Verify a backup archive, including snapshot shape and canonical SQLite integrity checks. */

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -210,6 +210,8 @@ describe("production lint suppressions", () => {
         "src/cli/plugins-cli-test-helpers.ts|typescript/no-unnecessary-type-parameters|1",
         "src/cli/program/openclaw-command.ts|eslint/no-underscore-dangle|1",
         "src/cli/test-runtime-capture.ts|typescript/no-unnecessary-type-parameters|1",
+        // Cleanup is retained in AggregateError.errors; extraction remains the primary cause.
+        "src/commands/backup-restore.ts|preserve-caught-error|1",
         "src/gateway/test-helpers.server.ts|typescript/no-unnecessary-type-parameters|1",
         "src/hooks/module-loader.ts|typescript/no-unnecessary-type-parameters|1",
         "src/infra/device-pairing-store.ts|typescript/no-unnecessary-type-parameters|1",


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where operators restoring an older backup with archive-root-relative hardlinks would receive an extraction error even though `openclaw backup verify` accepted the archive.

## Why This Change Was Made

Verification resolved the target against the archive root, checked it, then discarded that result. Extraction interpreted the original header relative to the destination directory. The verifier now prepares the exact validated target entry spelling once, and extraction consumes it before node-tar's path checks and filesystem reservations. Normalized paths remain lookup keys, not rewritten filenames: qualified and legacy targets ending in spaces retain their original spelling.

This removes the projected target array and separate verification helper. Nested catch scopes replace four extraction/cleanup bookkeeping variables while retaining both failures and keeping extraction as the primary cause. Public verify/restore JSON, target isolation, symlink handling, and drain-before-cleanup behavior remain unchanged. No new config, schema, dependency, or alternate extraction implementation.

## User Impact

Ordered legacy hardlinks now restore the same bytes and filesystem identity as qualified hardlinks, including valid filenames with trailing spaces. Unsafe or missing targets still reject, and failed extraction still cleans its incomplete target.

Production: **+57/−64, net −7 lines**. Tests: **+51**. [Existing backup documentation](https://docs.openclaw.ai/cli/backup) describes the restored behavior; no new operator action is needed.

## Evidence

The legacy restore regression failed before the repair with ENOENT. An independent real node-tar probe also caught a would-be regression from assigning normalized filenames: that approach broke existing qualified targets ending in spaces. The final implementation passes all four normal/space and qualified/legacy restore cases, asserting bytes and inode identity where supported.

The four focused backup suites pass **154 tests**, with one pre-existing skipped test. They cover create/verify/restore, Windows creation contracts, path rejection, integrity checks, symlinks, and extraction cleanup, including an existing empty destination. Formatting, targeted typed lint, and diff checks pass. The cleanup AggregateError keeps extraction as its cause and both errors in its errors array; a documented lint exception preserves that existing contract.

A broad local changed-file gate passed its initial checks but could not complete typechecking because the prepared shared dependency tree has stale Google SDK, markdown-it, and pi-tui types. Dependencies were not reconciled in the worktree. This failure is disclosed, not counted as passing.

Independent isolated Codex autoreview of the final diff found no actionable findings at its P0-only scope. AI-assisted implementation. Exact candidate commit: `23cc65f05a56a681f9f38bd1096ebc7b8b990b9a`; baseline: `6e827231257cf7c9c26ecd54fdc73d8c30afa5d8`.

**Real built CLI proof passed all 16 before/after scenarios (30 verify/restore invocations).** Each exact Git revision received its own frozen dependency install on Linux, Node24.19.0/pnpm11.22.0. Both legacy archives verified but failed restoration before the fix; afterward all four qualified/legacy and plain/trailing-space archives restored equal bytes and the same inode. Unsafe/missing targets rejected before creating a destination. Real directory-hardlink extraction failures cleaned new destinations and preserved existing empty destinations on both revisions. Public JSON omitted the private prepared map. Source HEAD, tree, and touched blobs stayed unchanged before/after.

[The hosting Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33118973692) used tooling head `ef858c0f1bb8e34fc15d5dbaddaef30b2ea4ced1`, distinct from the tested revisions. A sealed Git bundle supplied the candidate; binary patch SHA256 `6003fb1f9d4c3bf3cd851ed39b2669c7d6244fc709a5cea3d9df24ee4c5dd974`. Commands began with `node scripts/run-node.mjs backup verify <archive> --json` and `backup restore <archive> --json --target <isolated-target>`, then used the built `openclaw.mjs` for the rest of the matrix. The initial queued runner request was stopped without product execution; the bounded retry exited0 and its lease was verified completed. Temporary source/state was removed. No provider credentials, model calls, mocks, operator backups, npm package installation, or Windows live restore were used. The workflow link identifies the hosting job, not an automatically uploaded foreground artifact bundle.

Known follow-up: a hardlink appearing before its target, or pointing to a directory, can still verify but fail extraction. This repair restores the already-supported legacy target spelling; it does not claim that every accepted link graph is extractable. Existing directory-link cleanup coverage remains intact. Supporting arbitrary forward link graphs needs a separate archive/extraction design, not retries or a second ad hoc extractor.


CI follow-up: the initial run found two test-infrastructure issues in this patch. The table test now uses Vitest `it.for`, whose callback supplies the typed test context needed for the Windows filename skip; all17 restore cases pass. The exact documented AggregateError lint exception is registered in the intentional-suppression allowlist; all4 suppression tests pass. The [pinned Oxlint rule](https://github.com/oxc-project/oxc/blob/oxlint_v1.78.0/crates/oxc_linter/src/rules/eslint/preserve_caught_error.rs#L64-L68) checks the second constructor argument and does not recognize cleanup retained in AggregateError.errors; extraction must remain the primary cause. No production bytes changed after the live CLI proof. The follow-up local diff also passed isolated P0 autoreview. Full test-type checking remains blocked locally by the previously disclosed stale dependencies; the specific backup type error is gone.
