### PR TITLE
fix(ui): align settings headers and Learn more links

### DIFF
--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -45,17 +45,18 @@ type SettingsHelpTriggerProps = {
   popoverId: string;
 };
 
+export type SettingsPageHeaderProps = {
+  title: unknown;
+  subtitle?: unknown;
+  actions?: TemplateResult;
+};
+
 export function renderSettingsPage(
   children: unknown,
-  options: { wide?: boolean; intro?: unknown } = {},
+  options: { wide?: boolean } = {},
 ): TemplateResult {
   const className = options.wide ? "settings-page settings-page--wide" : "settings-page";
-  return html`
-    <div class=${className}>
-      ${options.intro ? html`<p class="settings-page__intro">${options.intro}</p>` : nothing}
-      ${children}
-    </div>
-  `;
+  return html`<div class=${className}>${children}</div>`;
 }
 
 export function renderDocsLink(url: string, label: unknown): TemplateResult {
@@ -79,6 +80,28 @@ export function renderSettingsHelpTrigger(props: SettingsHelpTriggerProps): Temp
         <span aria-hidden="true">${helpIcon}</span>
       </button>
     </openclaw-tooltip>
+  `;
+}
+
+export function renderLearnMoreLink(url: string): TemplateResult {
+  return html`<a
+    class="learn-more-link"
+    href=${url}
+    target=${EXTERNAL_LINK_TARGET}
+    rel=${buildExternalLinkRel()}
+    >${t("common.learnMore")}</a
+  >`;
+}
+
+export function renderSettingsPageHeader(props: SettingsPageHeaderProps): TemplateResult {
+  return html`
+    <section class="content-header">
+      <div>
+        <div class="page-title">${props.title}</div>
+        ${props.subtitle ? html`<div class="page-subtitle">${props.subtitle}</div>` : nothing}
+      </div>
+      ${props.actions ? html`<div class="page-header-actions">${props.actions}</div>` : nothing}
+    </section>
   `;
 }
 

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -107,10 +107,13 @@ export function renderSettingsPageHeader(props: SettingsPageHeaderProps): Templa
 
 /** Section = plain text heading + one group surface containing rows. */
 export function renderSettingsSection(props: SettingsSectionProps, rows: unknown): TemplateResult {
-  const heading =
-    props.title || props.actions
+  const description = props.description
+    ? html`<p class="settings-section__desc">${props.description}</p>`
+    : nothing;
+  const copy =
+    props.title || props.description
       ? html`
-          <div class="settings-section__header">
+          <div class="settings-section__copy">
             ${props.title
               ? html`
                   <h2 class="settings-section__heading">
@@ -120,19 +123,25 @@ export function renderSettingsSection(props: SettingsSectionProps, rows: unknown
                   </h2>
                 `
               : nothing}
+            ${description}
+          </div>
+        `
+      : nothing;
+  const header =
+    copy || props.actions
+      ? html`
+          <div class="settings-section__header">
+            ${copy}
             ${props.actions
               ? html`<div class="settings-section__actions">${props.actions}</div>`
               : nothing}
           </div>
         `
       : nothing;
-  const description = props.description
-    ? html`<p class="settings-section__desc">${props.description}</p>`
-    : nothing;
   const groupClass = props.danger ? "settings-group settings-group--danger" : "settings-group";
   return html`
     <section class="settings-section">
-      ${heading}${description}
+      ${header}
       <div class=${groupClass}>${rows}</div>
     </section>
   `;

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -54,6 +54,18 @@ const sectionAlignmentRoutes = [
   "updates",
 ] as const;
 
+const actionSectionCases = [
+  { route: "mcp", heading: "Configured servers" },
+  { route: "model-providers", heading: "Default models" },
+] as const;
+
+const responsiveViewports = [
+  { width: 390, height: 844 },
+  { width: 768, height: 1024 },
+  { width: 1366, height: 768 },
+  { width: 1440, height: 900 },
+] as const;
+
 suite.define(() => {
   it("keeps settings introductions, section headings, and Learn more links on one layout system", async () => {
     const context = await suite.browser.newContext({
@@ -125,6 +137,81 @@ suite.define(() => {
           expect(
             await link.evaluate((element) => getComputedStyle(element).textDecorationLine),
           ).toBe("none");
+        }
+      }
+
+      for (const viewport of responsiveViewports) {
+        await page.setViewportSize(viewport);
+        for (const sectionCase of actionSectionCases) {
+          await page.goto(`${suite.server.baseUrl}settings/${sectionCase.route}`);
+          await waitForControlUiRoute(page, {
+            pathname: `/settings/${sectionCase.route}`,
+            routeId: sectionCase.route,
+          });
+          const heading = page.getByRole("heading", {
+            name: sectionCase.heading,
+            exact: true,
+          });
+          const section = page.locator(".settings-section").filter({ has: heading });
+          const description = section.locator(".settings-section__desc");
+          const actions = section.locator(".settings-section__actions");
+          const group = section.locator(":scope > .settings-group");
+          await Promise.all([
+            heading.waitFor(),
+            description.waitFor(),
+            actions.waitFor(),
+            group.waitFor(),
+          ]);
+          await expect
+            .poll(async () => {
+              const [sectionBox, headingBox, descriptionBox, actionsBox, groupBox] =
+                await Promise.all([
+                  section.boundingBox(),
+                  heading.boundingBox(),
+                  description.boundingBox(),
+                  actions.boundingBox(),
+                  group.boundingBox(),
+                ]);
+              if (!sectionBox || !headingBox || !descriptionBox || !actionsBox || !groupBox) {
+                return null;
+              }
+              return {
+                actionPlacement:
+                  viewport.width <= 640
+                    ? Math.round(actionsBox.y - descriptionBox.y - descriptionBox.height)
+                    : Math.round(actionsBox.y - headingBox.y),
+                actionRightInset: Math.round(
+                  sectionBox.x + sectionBox.width - actionsBox.x - actionsBox.width,
+                ),
+                copyGap: Math.round(descriptionBox.y - headingBox.y - headingBox.height),
+                groupClearance: Math.round(
+                  groupBox.y -
+                    Math.max(
+                      descriptionBox.y + descriptionBox.height,
+                      actionsBox.y + actionsBox.height,
+                    ),
+                ),
+                overlapsAction:
+                  descriptionBox.x < actionsBox.x + actionsBox.width &&
+                  descriptionBox.x + descriptionBox.width > actionsBox.x &&
+                  descriptionBox.y < actionsBox.y + actionsBox.height &&
+                  descriptionBox.y + descriptionBox.height > actionsBox.y,
+              };
+            })
+            .toEqual({
+              actionPlacement: viewport.width <= 640 ? 8 : 0,
+              actionRightInset: 0,
+              copyGap: 4,
+              groupClearance: 12,
+              overlapsAction: false,
+            });
+
+          if (proofEnabled && viewport.width === 1440) {
+            await section.screenshot({
+              animations: "disabled",
+              path: path.join(proofDir, `action-${sectionCase.route}.png`),
+            });
+          }
         }
       }
     } finally {

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -1,0 +1,133 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI settings layout mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
+});
+
+const proofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const proofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "settings-layout-audit",
+  "after",
+);
+
+const introRoutes = [
+  "appearance",
+  "approvals",
+  "cloud-workers",
+  "labs",
+  "mcp",
+  "secrets",
+  "security",
+  "talk",
+  "updates",
+] as const;
+
+const learnMoreRoutes = [
+  "appearance",
+  "approvals",
+  "labs",
+  "mcp",
+  "model-providers",
+  "security",
+  "talk",
+] as const;
+
+const sectionAlignmentRoutes = [
+  "appearance",
+  "cloud-workers",
+  "labs",
+  "mcp",
+  "secrets",
+  "security",
+  "talk",
+  "updates",
+] as const;
+
+suite.define(() => {
+  it("keeps settings introductions, section headings, and Learn more links on one layout system", async () => {
+    const context = await suite.browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page);
+
+    try {
+      if (proofEnabled) {
+        await mkdir(proofDir, { recursive: true });
+      }
+
+      const routes = new Set([...introRoutes, ...learnMoreRoutes, ...sectionAlignmentRoutes]);
+      for (const route of routes) {
+        await page.goto(`${suite.server.baseUrl}settings/${route}`);
+        await waitForControlUiRoute(page, {
+          pathname: `/settings/${route}`,
+          routeId: route,
+        });
+        if ((introRoutes as readonly string[]).includes(route)) {
+          const title = page.locator(".page-title");
+          const subtitle = page.locator(".page-subtitle");
+          await title.waitFor();
+          await subtitle.waitFor();
+          await expect
+            .poll(async () => {
+              const [titleBox, subtitleBox] = await Promise.all([
+                title.boundingBox(),
+                subtitle.boundingBox(),
+              ]);
+              return titleBox && subtitleBox
+                ? Math.round(subtitleBox.y - titleBox.y - titleBox.height)
+                : null;
+            })
+            .toBe(2);
+          expect(await page.locator(".settings-page__intro").count()).toBe(0);
+          if (proofEnabled) {
+            await page.screenshot({
+              animations: "disabled",
+              fullPage: true,
+              path: path.join(proofDir, `${route}.png`),
+            });
+          }
+        }
+
+        if ((sectionAlignmentRoutes as readonly string[]).includes(route)) {
+          const heading = page.locator(".settings-section__heading").first();
+          const group = page.locator(".settings-section .settings-group").first();
+          await heading.waitFor();
+          await group.waitFor();
+          await expect
+            .poll(async () => {
+              const [headingBox, groupBox] = await Promise.all([
+                heading.boundingBox(),
+                group.boundingBox(),
+              ]);
+              return headingBox && groupBox ? Math.round(headingBox.x - groupBox.x) : null;
+            })
+            .toBe(0);
+        }
+
+        if ((learnMoreRoutes as readonly string[]).includes(route)) {
+          const link = page.getByRole("link", { name: "Learn more", exact: true }).first();
+          await link.waitFor();
+          expect(
+            await link.evaluate((element) => getComputedStyle(element).textDecorationLine),
+          ).toBe("none");
+        }
+      }
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -35,6 +35,7 @@ const introRoutes = [
 const learnMoreRoutes = [
   "appearance",
   "approvals",
+  "cloud-workers",
   "labs",
   "mcp",
   "model-providers",

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -35,7 +35,6 @@ const introRoutes = [
 const learnMoreRoutes = [
   "appearance",
   "approvals",
-  "cloud-workers",
   "labs",
   "mcp",
   "model-providers",

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -179,6 +179,10 @@ suite.define(() => {
                   viewport.width <= 640
                     ? Math.round(actionsBox.y - descriptionBox.y - descriptionBox.height)
                     : Math.round(actionsBox.y - headingBox.y),
+                actionGap:
+                  viewport.width <= 640
+                    ? null
+                    : Math.round(actionsBox.x - descriptionBox.x - descriptionBox.width),
                 actionRightInset: Math.round(
                   sectionBox.x + sectionBox.width - actionsBox.x - actionsBox.width,
                 ),
@@ -198,6 +202,7 @@ suite.define(() => {
               };
             })
             .toEqual({
+              actionGap: viewport.width <= 640 ? null : 20,
               actionPlacement: viewport.width <= 640 ? 8 : 0,
               actionRightInset: 0,
               copyGap: 4,

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2609,7 +2609,6 @@ export const en: TranslationMap = {
   },
   cloudWorkersPage: {
     intro: "Run agent sessions on ephemeral cloud machines instead of this gateway.",
-    documentation: "Cloud worker documentation",
     sectionTitle: "Profiles",
     sectionDescription: "Each profile defines how its provider provisions and retires a worker.",
     empty: "No cloud worker profiles are configured.",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2609,6 +2609,7 @@ export const en: TranslationMap = {
   },
   cloudWorkersPage: {
     intro: "Run agent sessions on ephemeral cloud machines instead of this gateway.",
+    documentation: "Cloud worker documentation",
     sectionTitle: "Profiles",
     sectionDescription: "Each profile defines how its provider provisions and retires a worker.",
     empty: "No cloud worker profiles are configured.",

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -14,7 +14,7 @@ import type {
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { resolveControlUiAuthToken } from "../../app/control-ui-auth.ts";
-import { renderDocsLink } from "../../components/settings-ui.ts";
+import { renderLearnMoreLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveAgentSkillsFilter, selectableAgentsList } from "../../lib/agents/display.ts";
@@ -927,7 +927,7 @@ class AgentsPage
         <div>
           <div class="page-title">${titleForRoute("agents")}</div>
           <div class="page-subtitle">
-            ${subtitleForRoute("agents")} ${renderDocsLink(AGENTS_DOCS_URL, t("common.learnMore"))}
+            ${subtitleForRoute("agents")} ${renderLearnMoreLink(AGENTS_DOCS_URL)}
           </div>
         </div>
       </section>

--- a/ui/src/pages/approvals/approvals-page.test.ts
+++ b/ui/src/pages/approvals/approvals-page.test.ts
@@ -109,8 +109,9 @@ describe("ApprovalsPage", () => {
     await settle(page);
 
     expect(request).toHaveBeenNthCalledWith(1, "approval.history", { limit: 50 });
-    const docsLink = page.querySelector<HTMLAnchorElement>(".settings-page__intro a");
+    const docsLink = page.querySelector<HTMLAnchorElement>(".page-subtitle a");
     expect(docsLink?.textContent?.trim()).toBe("Learn more");
+    expect(page.querySelector(".settings-page__intro")).toBeNull();
     expect(docsLink?.href).toBe("https://docs.openclaw.ai/tools/exec-approvals");
     expect(page.querySelectorAll(".approval-history-table tbody tr")).toHaveLength(1);
     expect(page.querySelector(".approval-history-table")?.textContent).toContain("agent:main:test");

--- a/ui/src/pages/approvals/approvals-page.ts
+++ b/ui/src/pages/approvals/approvals-page.ts
@@ -20,7 +20,11 @@ import {
 } from "../../app/context.ts";
 import { parseApprovalResolvedEvent } from "../../app/exec-approval.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
-import { renderDocsLink, renderSettingsPage } from "../../components/settings-ui.ts";
+import {
+  renderLearnMoreLink,
+  renderSettingsPage,
+  renderSettingsPageHeader,
+} from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { i18n, t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
@@ -356,10 +360,6 @@ class ApprovalsPage extends OpenClawLightDomElement {
   override render() {
     const body = renderSettingsPage(
       html`
-        <p class="settings-page__intro">
-          ${t("approvalHistory.description")}
-          ${renderDocsLink(APPROVALS_DOCS_URL, t("common.learnMore"))}
-        </p>
         ${!this.connected
           ? html`<div class="callout warn">${t("approvalHistory.offline")}</div>`
           : nothing}
@@ -385,9 +385,11 @@ class ApprovalsPage extends OpenClawLightDomElement {
       { wide: true },
     );
     return html`
-      <section class="content-header">
-        <div><div class="page-title">${titleForRoute("approvals")}</div></div>
-      </section>
+      ${renderSettingsPageHeader({
+        title: titleForRoute("approvals"),
+        subtitle: html`${t("approvalHistory.description")}
+        ${renderLearnMoreLink(APPROVALS_DOCS_URL)}`,
+      })}
       ${renderSettingsWorkspace(body)}
     `;
   }

--- a/ui/src/pages/channels/channels-page.ts
+++ b/ui/src/pages/channels/channels-page.ts
@@ -11,7 +11,7 @@ import { applicationContext, type ApplicationContext } from "../../app/context.t
 import { resolveControlUiAuthHeader } from "../../app/control-ui-auth.ts";
 import { hasOperatorAdminAccess, hasOperatorPairingAccess } from "../../app/operator-access.ts";
 import { loadSettings, patchSettings } from "../../app/settings.ts";
-import { renderDocsLink } from "../../components/settings-ui.ts";
+import { renderLearnMoreLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { resolveChannelPairingAuthSignature } from "../../lib/channels/index.ts";
@@ -650,8 +650,7 @@ class ChannelsPage extends OpenClawLightDomElement {
         <div>
           <div class="page-title">${titleForRoute("channels")}</div>
           <div class="page-subtitle">
-            ${subtitleForRoute("channels")}
-            ${renderDocsLink(CHANNELS_DOCS_URL, t("common.learnMore"))}
+            ${subtitleForRoute("channels")} ${renderLearnMoreLink(CHANNELS_DOCS_URL)}
           </div>
         </div>
       </section>

--- a/ui/src/pages/chat/components/chat-permission-picker.ts
+++ b/ui/src/pages/chat/components/chat-permission-picker.ts
@@ -133,7 +133,7 @@ export function renderChatPermissionPicker(params: ChatPermissionPickerProps) {
       <div class="chat-controls__popover-title chat-controls__permission-heading">
         <span>${t("chat.permissionControls.label")}</span>
         <a
-          class="chat-controls__permission-learn-more"
+          class="chat-controls__permission-learn-more learn-more-link"
           href=${PERMISSION_MODES_DOCS_URL}
           target=${EXTERNAL_LINK_TARGET}
           rel=${buildExternalLinkRel()}

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -7,6 +7,7 @@ import { applicationContext, type ApplicationContext } from "../../app/context.t
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import {
   renderDocsLink,
+  renderLearnMoreLink,
   renderSettingsEmpty,
   renderSettingsPage,
   renderSettingsPageHeader,
@@ -556,8 +557,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     return html`
       ${renderSettingsPageHeader({
         title: titleForRoute("cloud-workers"),
-        subtitle: html`${t("cloudWorkersPage.intro")}
-        ${renderDocsLink(CLOUD_WORKERS_DOCS_URL, t("cloudWorkersPage.documentation"))}`,
+        subtitle: html`${t("cloudWorkersPage.intro")} ${renderLearnMoreLink(CLOUD_WORKERS_DOCS_URL)}`,
       })}
       ${renderSettingsWorkspace(body)}
     `;

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -9,6 +9,7 @@ import {
   renderDocsLink,
   renderSettingsEmpty,
   renderSettingsPage,
+  renderSettingsPageHeader,
   renderSettingsRow,
   renderSettingsSection,
   renderSettingsStatus,
@@ -524,44 +525,40 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     const rows = profiles.length
       ? profiles.map((profile) => this.renderProfile(profile))
       : renderSettingsEmpty(t("cloudWorkersPage.empty"));
-    const body = renderSettingsPage(
-      html`
-        ${!this.hasManageAccess()
-          ? html`<div class="callout warning" role="note">
-              ${t("cloudWorkersPage.adminRequired")}
-            </div>`
-          : nothing}
-        ${this.catalogError
-          ? html`<div class="callout warning" role="status">
-              ${t("cloudWorkersPage.catalogFailed", { error: this.catalogError })}
-            </div>`
-          : nothing}
-        ${this.formError && !this.editor
-          ? html`<div class="callout warning" role="alert">${this.formError}</div>`
-          : nothing}
-        ${this.notice
-          ? html`<div class="callout warning" role="status">${this.notice}</div>`
-          : nothing}
-        ${renderSettingsSection(
-          {
-            title: t("cloudWorkersPage.sectionTitle"),
-            description: t("cloudWorkersPage.sectionDescription"),
-            actions: addAction,
-            count: profiles.length,
-          },
-          rows,
-        )}
-        ${this.renderEditor()}
-      `,
-      {
-        intro: html`${t("cloudWorkersPage.intro")}
-        ${renderDocsLink(CLOUD_WORKERS_DOCS_URL, t("cloudWorkersPage.documentation"))}`,
-      },
-    );
+    const body = renderSettingsPage(html`
+      ${!this.hasManageAccess()
+        ? html`<div class="callout warning" role="note">
+            ${t("cloudWorkersPage.adminRequired")}
+          </div>`
+        : nothing}
+      ${this.catalogError
+        ? html`<div class="callout warning" role="status">
+            ${t("cloudWorkersPage.catalogFailed", { error: this.catalogError })}
+          </div>`
+        : nothing}
+      ${this.formError && !this.editor
+        ? html`<div class="callout warning" role="alert">${this.formError}</div>`
+        : nothing}
+      ${this.notice
+        ? html`<div class="callout warning" role="status">${this.notice}</div>`
+        : nothing}
+      ${renderSettingsSection(
+        {
+          title: t("cloudWorkersPage.sectionTitle"),
+          description: t("cloudWorkersPage.sectionDescription"),
+          actions: addAction,
+          count: profiles.length,
+        },
+        rows,
+      )}
+      ${this.renderEditor()}
+    `);
     return html`
-      <section class="content-header">
-        <div><div class="page-title">${titleForRoute("cloud-workers")}</div></div>
-      </section>
+      ${renderSettingsPageHeader({
+        title: titleForRoute("cloud-workers"),
+        subtitle: html`${t("cloudWorkersPage.intro")}
+        ${renderDocsLink(CLOUD_WORKERS_DOCS_URL, t("cloudWorkersPage.documentation"))}`,
+      })}
       ${renderSettingsWorkspace(body)}
     `;
   }

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -7,7 +7,6 @@ import { applicationContext, type ApplicationContext } from "../../app/context.t
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import {
   renderDocsLink,
-  renderLearnMoreLink,
   renderSettingsEmpty,
   renderSettingsPage,
   renderSettingsPageHeader,
@@ -557,7 +556,8 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     return html`
       ${renderSettingsPageHeader({
         title: titleForRoute("cloud-workers"),
-        subtitle: html`${t("cloudWorkersPage.intro")} ${renderLearnMoreLink(CLOUD_WORKERS_DOCS_URL)}`,
+        subtitle: html`${t("cloudWorkersPage.intro")}
+        ${renderDocsLink(CLOUD_WORKERS_DOCS_URL, t("cloudWorkersPage.documentation"))}`,
       })}
       ${renderSettingsWorkspace(body)}
     `;

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -44,6 +44,7 @@ import {
   SIDEBAR_HIDDEN_SESSION_CATALOGS_CHANGED_EVENT,
   setStoredSessionCatalogHidden,
 } from "../../components/app-sidebar-session-types.ts";
+import { renderLearnMoreLink, renderSettingsPageHeader } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { i18n, isSupportedLocale, t, type Locale } from "../../i18n/index.ts";
 import { resolveControlUiServerQueueMode } from "../../lib/chat/follow-up-mode.ts";
@@ -181,6 +182,26 @@ export function configSelectionFromSearch(pageId: ConfigPageId, search: string):
 
 function configPageTitle(pageId: ConfigPageId): string {
   return titleForRoute(pageId);
+}
+
+function renderConfigPageSubtitle(pageId: ConfigPageId) {
+  switch (pageId) {
+    case "appearance":
+      return html`${t("configView.appearance.intro")}
+      ${renderLearnMoreLink("https://docs.openclaw.ai/web/control-ui")}`;
+    case "mcp":
+      return html`${t("mcpPage.intro")} ${renderLearnMoreLink("https://docs.openclaw.ai/tools/mcp")}`;
+    case "security":
+      return html`${t("quickSettings.security.intro")}
+      ${renderLearnMoreLink("https://docs.openclaw.ai/gateway/security")}`;
+    case "talk":
+      return html`${t("talkPage.intro")}
+      ${renderLearnMoreLink("https://docs.openclaw.ai/nodes/talk")}`;
+    case "updates":
+      return t("updates.page.intro");
+    default:
+      return undefined;
+  }
 }
 
 export function extractQuickSettingsSecurity(config: unknown): SecurityOverview {
@@ -1497,11 +1518,10 @@ export class ConfigPage extends OpenClawLightDomElement {
       ${this.pageId === "memory"
         ? nothing
         : html`
-            <section class="content-header">
-              <div>
-                <div class="page-title">${configPageTitle(this.pageId)}</div>
-              </div>
-            </section>
+            ${renderSettingsPageHeader({
+              title: configPageTitle(this.pageId),
+              subtitle: renderConfigPageSubtitle(this.pageId),
+            })}
           `}
       ${renderSettingsWorkspace(body)}
     `;

--- a/ui/src/pages/config/mcp.ts
+++ b/ui/src/pages/config/mcp.ts
@@ -1,10 +1,6 @@
 import { html, type TemplateResult } from "lit";
 import "../../components/mcp-servers-card.ts";
-import {
-  renderDocsLink,
-  renderSettingsRow,
-  renderSettingsValue,
-} from "../../components/settings-ui.ts";
+import { renderSettingsRow, renderSettingsValue } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { summarizeMcpServers } from "../../lib/config/mcp-servers.ts";
 
@@ -25,9 +21,6 @@ export function renderMcp(props: McpViewProps) {
   return html`
     <section class="mcp-page">
       <div class="settings-page">
-        <p class="settings-page__intro">
-          ${t("mcpPage.intro")} ${renderDocsLink(MCP_DOCS_URL, t("common.learnMore"))}
-        </p>
         <section class="settings-section mcp-page__summary">
           <div class="settings-section__header">
             <h2 class="settings-section__heading">${t("mcpPage.servers")}</h2>

--- a/ui/src/pages/config/memory-page.ts
+++ b/ui/src/pages/config/memory-page.ts
@@ -11,7 +11,7 @@ import { pathForMemoryTab } from "../../app-route-paths.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
 import type { AgentSelectOption } from "../../components/agent-select.ts";
-import { renderDocsLink } from "../../components/settings-ui.ts";
+import { renderLearnMoreLink } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { listSelectableAgents, normalizeAgentLabel } from "../../lib/agents/display.ts";
 import { currentConfigObject } from "../../lib/config/config-state-model.ts";
@@ -614,7 +614,7 @@ class MemorySettingsPage extends OpenClawLightDomElement {
     return html`
       <p class="settings-page__intro">
         ${t("memoryPage.dreaming.intro", { plugin: pluginId })}
-        ${renderDocsLink(DREAMING_DOCS_URL, t("common.learnMore"))}
+        ${renderLearnMoreLink(DREAMING_DOCS_URL)}
       </p>
       ${this.support === "unsupported"
         ? renderDreamingUnsupported(pluginId)

--- a/ui/src/pages/config/memory.ts
+++ b/ui/src/pages/config/memory.ts
@@ -4,7 +4,7 @@ import "../../components/agent-select-registration.ts";
 import type { AgentSelectOption } from "../../components/agent-select.ts";
 import { renderHubTabs } from "../../components/hub-tabs.ts";
 import {
-  renderDocsLink,
+  renderLearnMoreLink,
   renderSettingsDefaultState,
   renderSettingsRow,
   renderSettingsSection,
@@ -403,7 +403,7 @@ export function renderMemory(props: MemoryViewProps) {
         <div class="hub-page-header__title">
           <div class="page-title">${t("tabs.memory")}</div>
           <div class="page-subtitle">
-            ${t("memoryPage.intro")} ${renderDocsLink(MEMORY_DOCS_URL, t("common.learnMore"))}
+            ${t("memoryPage.intro")} ${renderLearnMoreLink(MEMORY_DOCS_URL)}
           </div>
         </div>
         <div class="hub-page-header__tabs">

--- a/ui/src/pages/config/notifications-section.ts
+++ b/ui/src/pages/config/notifications-section.ts
@@ -5,7 +5,7 @@ import type {
 } from "../../app/native-notifications.ts";
 import { icons } from "../../components/icons.ts";
 import {
-  renderDocsLink,
+  renderLearnMoreLink,
   renderSettingsRow,
   renderSettingsStatus,
   renderSettingsValue,
@@ -17,7 +17,7 @@ import { COMMUNICATION_SETTINGS_TARGET_IDS } from "./settings-targets.ts";
 const NOTIFICATIONS_DOCS_URL = "https://docs.openclaw.ai/web/notifications";
 
 function renderNotificationsHint(copy: string) {
-  return html`${copy} ${renderDocsLink(NOTIFICATIONS_DOCS_URL, t("common.learnMore"))}`;
+  return html`${copy} ${renderLearnMoreLink(NOTIFICATIONS_DOCS_URL)}`;
 }
 
 export type WebPushUiState = {

--- a/ui/src/pages/config/security.ts
+++ b/ui/src/pages/config/security.ts
@@ -4,7 +4,6 @@
 import { html, type TemplateResult } from "lit";
 import { icons } from "../../components/icons.ts";
 import {
-  renderDocsLink,
   renderSettingsDefaultState,
   renderSettingsRow,
   renderSettingsSection,
@@ -15,8 +14,6 @@ import {
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { PROFILE_OPTIONS } from "../../lib/agents/display.ts";
-
-const SECURITY_DOCS_URL = "https://docs.openclaw.ai/gateway/security";
 
 export type SecurityOverview = {
   gatewayAuth: string;
@@ -123,13 +120,7 @@ function renderSecurityOverview(props: SecurityViewProps) {
 export function renderSecurity(props: SecurityViewProps) {
   return html`
     <section class="security-page">
-      <div class="settings-page">
-        <p class="settings-page__intro">
-          ${t("quickSettings.security.intro")}
-          ${renderDocsLink(SECURITY_DOCS_URL, t("common.learnMore"))}
-        </p>
-        ${renderSecurityOverview(props)}
-      </div>
+      <div class="settings-page">${renderSecurityOverview(props)}</div>
       ${props.editor}
     </section>
   `;

--- a/ui/src/pages/config/talk.ts
+++ b/ui/src/pages/config/talk.ts
@@ -5,7 +5,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { renderModelPicker } from "../../components/model-picker.ts";
 import {
-  renderDocsLink,
   renderSettingsRow,
   renderSettingsSection,
   renderSettingsSegmented,
@@ -54,8 +53,6 @@ type TalkViewProps = {
 };
 
 const TALK_PICKER_UNSET = "";
-
-const TALK_DOCS_URL = "https://docs.openclaw.ai/nodes/talk";
 
 /** Config may name a provider by alias; pickers always speak canonical ids. */
 function findProviderOption(
@@ -308,9 +305,6 @@ export function renderTalk(props: TalkViewProps) {
   return html`
     <section class="talk-page">
       <div class="settings-page">
-        <p class="settings-page__intro">
-          ${t("talkPage.intro")} ${renderDocsLink(TALK_DOCS_URL, t("common.learnMore"))}
-        </p>
         ${renderSettingsSection(
           {
             title: t("talkPage.voiceSection.title"),

--- a/ui/src/pages/config/updates.ts
+++ b/ui/src/pages/config/updates.ts
@@ -406,61 +406,58 @@ export function renderUpdates(props: UpdatesViewProps): TemplateResult {
   const updateButtonTitle = !props.canAdmin ? t("updates.adminRequired") : "";
   return html`
     <div id="config-section-update">
-      ${renderSettingsPage(
-        [
-          !props.canAdmin
-            ? html`<div class="callout warning" role="note">${t("updates.adminRequired")}</div>`
-            : nothing,
-          renderBuildFacts(props),
-          renderRecordedAttempt(props),
-          renderSettingsSection({ title: t("updates.page.policyTitle") }, policyRows),
-          renderSettingsSection({ title: t("updates.page.statusTitle") }, [
-            renderSettingsRow({
-              title: t("updates.page.scheduleStatus"),
-              control: html`
-                <div class="updates-status-control">
-                  ${renderScheduleStatus(props)}
-                  ${showHold
-                    ? html`
-                        <button
-                          type="button"
-                          class="btn btn--sm"
-                          ?disabled=${props.updateBusy}
-                          @click=${() => void props.onHoldUpdate()}
-                        >
-                          ${t("updates.holdOneHour")}
-                        </button>
-                      `
-                    : nothing}
-                </div>
-              `,
-            }),
-            renderCommitList(props),
-            renderSettingsRow({
-              title: t("updates.page.updateNow"),
-              description: t("updates.page.updateNowDescription"),
-              control: html`
-                <button
-                  type="button"
-                  class="btn primary"
-                  title=${updateButtonTitle}
-                  ?disabled=${props.updateBusy || !props.canUpdate}
-                  @click=${props.onUpdateNow}
-                >
-                  ${icons.download}
-                  ${props.updateBusy ? t("chat.updating") : t("updates.page.updateNow")}
-                </button>
-              `,
-            }),
-          ]),
-          html`<p class="settings-page__hint">
-            <a href="https://docs.openclaw.ai/install/update-troubleshooting" target="_blank"
-              >${t("updates.page.troubleshoot")}</a
-            >
-          </p>`,
-        ],
-        { intro: t("updates.page.intro") },
-      )}
+      ${renderSettingsPage([
+        !props.canAdmin
+          ? html`<div class="callout warning" role="note">${t("updates.adminRequired")}</div>`
+          : nothing,
+        renderBuildFacts(props),
+        renderRecordedAttempt(props),
+        renderSettingsSection({ title: t("updates.page.policyTitle") }, policyRows),
+        renderSettingsSection({ title: t("updates.page.statusTitle") }, [
+          renderSettingsRow({
+            title: t("updates.page.scheduleStatus"),
+            control: html`
+              <div class="updates-status-control">
+                ${renderScheduleStatus(props)}
+                ${showHold
+                  ? html`
+                      <button
+                        type="button"
+                        class="btn btn--sm"
+                        ?disabled=${props.updateBusy}
+                        @click=${() => void props.onHoldUpdate()}
+                      >
+                        ${t("updates.holdOneHour")}
+                      </button>
+                    `
+                  : nothing}
+              </div>
+            `,
+          }),
+          renderCommitList(props),
+          renderSettingsRow({
+            title: t("updates.page.updateNow"),
+            description: t("updates.page.updateNowDescription"),
+            control: html`
+              <button
+                type="button"
+                class="btn primary"
+                title=${updateButtonTitle}
+                ?disabled=${props.updateBusy || !props.canUpdate}
+                @click=${props.onUpdateNow}
+              >
+                ${icons.download}
+                ${props.updateBusy ? t("chat.updating") : t("updates.page.updateNow")}
+              </button>
+            `,
+          }),
+        ]),
+        html`<p class="settings-page__hint">
+          <a href="https://docs.openclaw.ai/install/update-troubleshooting" target="_blank"
+            >${t("updates.page.troubleshoot")}</a
+          >
+        </p>`,
+      ])}
     </div>
   `;
 }

--- a/ui/src/pages/config/view-appearance.ts
+++ b/ui/src/pages/config/view-appearance.ts
@@ -10,7 +10,6 @@ import type { ThemeTransitionContext } from "../../app/theme-transition.ts";
 import type { ThemeName } from "../../app/theme.ts";
 import { icons } from "../../components/icons.ts";
 import {
-  renderDocsLink,
   renderSettingsDefaultDescription,
   renderSettingsRow,
   renderSettingsSegmented,
@@ -28,8 +27,6 @@ import {
   renderSidebarPreferencesSection,
 } from "./view-appearance-preferences.ts";
 import type { ConfigProps } from "./view-types.ts";
-
-const APPEARANCE_DOCS_URL = "https://docs.openclaw.ai/web/control-ui";
 
 const TEXT_SCALE_LABELS: Record<TextScaleStop, string> = {
   90: "configView.textSizes.small",
@@ -196,10 +193,6 @@ export function renderAppearanceSection(
         });
   return html`
     <div class="settings-page">
-      <p class="settings-page__intro">
-        ${t("configView.appearance.intro")}
-        ${renderDocsLink(APPEARANCE_DOCS_URL, t("common.learnMore"))}
-      </p>
       ${renderLanguageSection(props)}
       <section id=${APPEARANCE_SETTINGS_TARGET_IDS.theme} class="settings-section">
         <div class="settings-section__header">

--- a/ui/src/pages/connection/connection-page.ts
+++ b/ui/src/pages/connection/connection-page.ts
@@ -13,9 +13,8 @@ import {
   type ApplicationGatewaySnapshot,
 } from "../../app/context.ts";
 import { loadGatewaySessionSelection, loadSettings, type UiSettings } from "../../app/settings.ts";
-import { renderDocsLink } from "../../components/settings-ui.ts";
+import { renderLearnMoreLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
-import { t } from "../../i18n/index.ts";
 import { isMissingOperatorReadScopeError } from "../../lib/gateway-errors.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
 import { PollController } from "../../lit/poll-controller.ts";
@@ -278,8 +277,7 @@ export class ConnectionPage extends OpenClawLightDomElement {
         <div>
           <div class="page-title">${titleForRoute("connection")}</div>
           <div class="page-subtitle">
-            ${subtitleForRoute("connection")}
-            ${renderDocsLink(CONNECTION_DOCS_URL, t("common.learnMore"))}
+            ${subtitleForRoute("connection")} ${renderLearnMoreLink(CONNECTION_DOCS_URL)}
           </div>
         </div>
       </section>

--- a/ui/src/pages/devices/devices-page.ts
+++ b/ui/src/pages/devices/devices-page.ts
@@ -14,7 +14,7 @@ import { hasOperatorAdminAccess, hasOperatorPairingAccess } from "../../app/oper
 import { readPresenceEntries } from "../../app/user-profile.ts";
 import { showConfirmDialog, type ConfirmDialogOptions } from "../../components/confirm-dialog.ts";
 import { showSecretRevealDialog } from "../../components/secret-reveal-dialog.ts";
-import { renderDocsLink } from "../../components/settings-ui.ts";
+import { renderLearnMoreLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { currentConfigObject } from "../../lib/config/config-state-model.ts";
@@ -508,8 +508,7 @@ class DevicesPage extends OpenClawLightDomElement {
         <div>
           <div class="page-title">${titleForRoute("devices")}</div>
           <div class="page-subtitle">
-            ${subtitleForRoute("devices")}
-            ${renderDocsLink(DEVICES_DOCS_URL, t("common.learnMore"))}
+            ${subtitleForRoute("devices")} ${renderLearnMoreLink(DEVICES_DOCS_URL)}
           </div>
         </div>
       </section>

--- a/ui/src/pages/labs/labs-page.test.ts
+++ b/ui/src/pages/labs/labs-page.test.ts
@@ -140,8 +140,9 @@ describe("LabsPage", () => {
       tools: { codeMode: { enabled: true }, swarm: { enabled: true } },
     });
 
-    expect(page.querySelector(".settings-page__intro")?.textContent).toContain("experimental");
-    const introLink = page.querySelector<HTMLAnchorElement>(".settings-page__intro a");
+    expect(page.querySelector(".page-subtitle")?.textContent).toContain("experimental");
+    expect(page.querySelector(".settings-page__intro")).toBeNull();
+    const introLink = page.querySelector<HTMLAnchorElement>(".page-subtitle a");
     expect(introLink?.textContent?.trim()).toBe("Learn more");
     expect(introLink?.href).toBe("https://docs.openclaw.ai/concepts/experimental-features");
     expect(page.querySelectorAll(".settings-row")).toHaveLength(LAB_FEATURES.length);

--- a/ui/src/pages/labs/labs-page.ts
+++ b/ui/src/pages/labs/labs-page.ts
@@ -4,8 +4,9 @@ import { state } from "lit/decorators.js";
 import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import {
-  renderDocsLink,
+  renderLearnMoreLink,
   renderSettingsPage,
+  renderSettingsPageHeader,
   renderSettingsRow,
   renderSettingsSection,
   renderSettingsToggleRow,
@@ -171,20 +172,13 @@ class LabsPage extends OpenClawLightDomElement {
         },
         rows,
       ),
-      {
-        intro: html`${t("labsPage.intro")}
-        ${renderDocsLink(
-          "https://docs.openclaw.ai/concepts/experimental-features",
-          t("common.learnMore"),
-        )}`,
-      },
     );
     return html`
-      <section class="content-header">
-        <div>
-          <div class="page-title">${titleForRoute("labs")}</div>
-        </div>
-      </section>
+      ${renderSettingsPageHeader({
+        title: titleForRoute("labs"),
+        subtitle: html`${t("labsPage.intro")}
+        ${renderLearnMoreLink("https://docs.openclaw.ai/concepts/experimental-features")}`,
+      })}
       ${renderSettingsWorkspace(body)}
     `;
   }

--- a/ui/src/pages/memory-import/memory-import-page.ts
+++ b/ui/src/pages/memory-import/memory-import-page.ts
@@ -9,9 +9,8 @@ import type {
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
-import { renderDocsLink } from "../../components/settings-ui.ts";
+import { renderLearnMoreLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
-import { t } from "../../i18n/index.ts";
 import { listSelectableAgents } from "../../lib/agents/display.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
@@ -584,8 +583,7 @@ export class MemoryImportPage extends OpenClawLightDomElement {
         <div>
           <div class="page-title">${titleForRoute("memory-import")}</div>
           <div class="page-subtitle">
-            ${subtitleForRoute("memory-import")}
-            ${renderDocsLink(MEMORY_IMPORT_DOCS_URL, t("common.learnMore"))}
+            ${subtitleForRoute("memory-import")} ${renderLearnMoreLink(MEMORY_IMPORT_DOCS_URL)}
           </div>
         </div>
       </section>

--- a/ui/src/pages/model-providers/model-providers-page.ts
+++ b/ui/src/pages/model-providers/model-providers-page.ts
@@ -9,7 +9,7 @@ import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
 import { renderAgentScopeControl } from "../../components/agent-scope-control.ts";
-import { renderDocsLink } from "../../components/settings-ui.ts";
+import { renderLearnMoreLink, renderSettingsPageHeader } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { normalizeAgentLabel } from "../../lib/agents/display.ts";
@@ -715,15 +715,11 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
       onOpenModelSetup: () => this.context.navigate("model-setup"),
     });
     return html`
-      <section class="content-header">
-        <div>
-          <div class="page-title">${titleForRoute("model-providers")}</div>
-          <div class="page-subtitle">
-            ${t("modelProviders.subtitle")}
-            ${renderDocsLink(MODEL_PROVIDERS_DOCS_URL, t("common.learnMore"))}
-          </div>
-        </div>
-        <div class="page-header-actions">
+      ${renderSettingsPageHeader({
+        title: titleForRoute("model-providers"),
+        subtitle: html`${t("modelProviders.subtitle")}
+        ${renderLearnMoreLink(MODEL_PROVIDERS_DOCS_URL)}`,
+        actions: html`
           ${renderAgentScopeControl({
             agents,
             selection: this.context.agentSelection,
@@ -733,8 +729,8 @@ export class ModelProvidersPage extends OpenClawLightDomElement {
           <button class="btn" @click=${() => this.context.navigate("model-setup")}>
             ${t("tabs.modelSetup")}
           </button>
-        </div>
-      </section>
+        `,
+      })}
       ${renderSettingsWorkspace(body)}
     `;
   }

--- a/ui/src/pages/model-setup/model-setup-page.ts
+++ b/ui/src/pages/model-setup/model-setup-page.ts
@@ -11,7 +11,7 @@ import type {
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { hasOperatorAdminAccess } from "../../app/operator-access.ts";
-import { renderDocsLink } from "../../components/settings-ui.ts";
+import { renderLearnMoreLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
@@ -728,8 +728,7 @@ export class ModelSetupPage extends OpenClawLightDomElement {
         <div>
           <div class="page-title">${titleForRoute("model-setup")}</div>
           <div class="page-subtitle">
-            ${subtitleForRoute("model-setup")}
-            ${renderDocsLink(MODEL_SETUP_DOCS_URL, t("common.learnMore"))}
+            ${subtitleForRoute("model-setup")} ${renderLearnMoreLink(MODEL_SETUP_DOCS_URL)}
           </div>
         </div>
       </section>

--- a/ui/src/pages/plugins/plugins-hub-header.ts
+++ b/ui/src/pages/plugins/plugins-hub-header.ts
@@ -1,7 +1,6 @@
 import { html, type TemplateResult } from "lit";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
-import { renderDocsLink } from "../../components/settings-ui.ts";
-import { t } from "../../i18n/index.ts";
+import { renderLearnMoreLink } from "../../components/settings-ui.ts";
 import { renderPluginsHubTabs, type PluginsHubTab } from "./plugins-hub.ts";
 
 const PLUGINS_DOCS_URL = "https://docs.openclaw.ai/plugins/manage-plugins";
@@ -17,7 +16,7 @@ export function renderPluginsHubHeader(props: PluginsHubHeaderProps): TemplateRe
       <div class="hub-page-header__title">
         <h1 class="page-title">${titleForRoute("plugins")}</h1>
         <div class="page-subtitle">
-          ${subtitleForRoute("plugins")} ${renderDocsLink(PLUGINS_DOCS_URL, t("common.learnMore"))}
+          ${subtitleForRoute("plugins")} ${renderLearnMoreLink(PLUGINS_DOCS_URL)}
         </div>
       </div>
       <div class="hub-page-header__tabs">

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -23,7 +23,7 @@ import type { AuthenticatedUser } from "../../app/user-profile.ts";
 import { resolveCurrentSelfUser } from "../../app/user-profile.ts";
 import { icons } from "../../components/icons.ts";
 import {
-  renderDocsLink,
+  renderLearnMoreLink,
   renderSettingsEmpty,
   renderSettingsGroup,
   renderSettingsNavRow,
@@ -495,8 +495,7 @@ export class ProfilePage extends OpenClawLightDomElement {
         <div>
           <div class="page-title">${titleForRoute("profile")}</div>
           <div class="page-subtitle">
-            ${subtitleForRoute("profile")}
-            ${renderDocsLink(PROFILE_DOCS_URL, t("common.learnMore"))}
+            ${subtitleForRoute("profile")} ${renderLearnMoreLink(PROFILE_DOCS_URL)}
           </div>
         </div>
         ${this.selfUser

--- a/ui/src/pages/secrets/secrets-page.ts
+++ b/ui/src/pages/secrets/secrets-page.ts
@@ -6,6 +6,7 @@ import { isSensitiveEnvName } from "../../../../src/secrets/secret-env-name.js";
 import { titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
+import { renderSettingsPageHeader } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { canCallGatewayMethod, isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
@@ -339,9 +340,10 @@ class SecretsPage extends OpenClawLightDomElement {
       onDelete: (entry) => void this.removeEntry(entry),
     });
     return html`
-      <section class="content-header">
-        <div><div class="page-title">${titleForRoute("secrets")}</div></div>
-      </section>
+      ${renderSettingsPageHeader({
+        title: titleForRoute("secrets"),
+        subtitle: t("secretsStore.hint"),
+      })}
       ${renderSettingsWorkspace(body)}
     `;
   }

--- a/ui/src/pages/secrets/view.ts
+++ b/ui/src/pages/secrets/view.ts
@@ -433,7 +433,7 @@ export function renderSecretsStore(props: SecretsStoreViewProps): TemplateResult
           renderTable(props),
         )}
       `,
-      { wide: true, intro: t("secretsStore.hint") },
+      { wide: true },
     )}
     ${renderEntryDialog(props)} ${renderBulkDialog(props)}
   `;

--- a/ui/src/pages/sessions/sessions-page.ts
+++ b/ui/src/pages/sessions/sessions-page.ts
@@ -25,7 +25,7 @@ import { fetchSessionMenuWork } from "../../components/session-menu-work.ts";
 import type { SessionMenuAction, SessionMenuWork } from "../../components/session-menu.ts";
 import "../../components/session-menu.ts";
 import { renderSessionsHubHeader } from "../../components/sessions-hub-header.ts";
-import { renderDocsLink } from "../../components/settings-ui.ts";
+import { renderLearnMoreLink } from "../../components/settings-ui.ts";
 import { renderSettingsWorkspace } from "../../components/settings-workspace.ts";
 import { t } from "../../i18n/index.ts";
 import { watchAgentScope } from "../../lib/agents/index.ts";
@@ -1525,8 +1525,7 @@ class SessionsPage extends OpenClawLightDomElement {
       ${renderSessionsHubHeader({
         active: "sessions",
         title: titleForRoute("sessions"),
-        subtitle: html`${subtitleForRoute("sessions")}
-        ${renderDocsLink(SESSIONS_DOCS_URL, t("common.learnMore"))}`,
+        subtitle: html`${subtitleForRoute("sessions")} ${renderLearnMoreLink(SESSIONS_DOCS_URL)}`,
         actions: renderAgentScopeControl({
           agents: context.agents.state.agentsList?.agents ?? [],
           selection: context.agentSelection,

--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -13,7 +13,7 @@ import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import { renderSessionsHubHeader } from "../../components/sessions-hub-header.ts";
 import {
-  renderDocsLink,
+  renderLearnMoreLink,
   renderSettingsEmpty,
   renderSettingsPage,
   renderSettingsRow,
@@ -490,8 +490,7 @@ class WorktreesPage extends OpenClawLightDomElement {
       ${renderSessionsHubHeader({
         active: "worktrees",
         title: titleForRoute("sessions"),
-        subtitle: html`${subtitleForRoute("worktrees")}
-        ${renderDocsLink(WORKTREES_DOCS_URL, t("common.learnMore"))}`,
+        subtitle: html`${subtitleForRoute("worktrees")} ${renderLearnMoreLink(WORKTREES_DOCS_URL)}`,
         onSelect: (tab) => {
           if (tab !== "worktrees") {
             this.context?.navigate(tab);

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -837,6 +837,11 @@ a:hover {
   text-decoration-thickness: 2px;
 }
 
+.learn-more-link,
+.learn-more-link:hover {
+  text-decoration: none;
+}
+
 /* Web Awesome defaults checked switches to brand blue. Keep every switch on
    the Control UI accent, matching native check controls and custom switches. */
 wa-switch {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -112,14 +112,14 @@
   min-width: 0;
 }
 
-/* Header and description indent to var(--space-4) so the eyebrow label lines
-   up with the row content inside the group surface below it. */
+/* Section copy aligns to the group surface, while rows own their internal
+   content inset. */
 .settings-section__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-3);
-  padding: 0 var(--space-4);
+  padding: 0;
 }
 
 .settings-section__heading {
@@ -133,7 +133,7 @@
 
 .settings-section__desc {
   margin: calc(-1 * var(--space-2)) 0 0;
-  padding: 0 var(--space-4);
+  padding: 0;
   font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--muted);

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -122,6 +122,20 @@
   padding: 0;
 }
 
+/* Keep heading copy independent from taller header actions. Without this
+   grouping, a button row pushes the description away from its heading. */
+.settings-section__copy {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.settings-section__header:has(.settings-section__copy) {
+  align-items: flex-start;
+}
+
 .settings-section__heading {
   margin: 0;
   font-size: var(--control-ui-text-xs);
@@ -137,6 +151,10 @@
   font-size: var(--control-ui-text-sm);
   line-height: 1.5;
   color: var(--muted);
+}
+
+.settings-section__copy > .settings-section__desc {
+  margin: 0;
 }
 
 /* Control-height header actions overhang the one-line heading; keep the
@@ -760,6 +778,16 @@ textarea.settings-input {
 @media (max-width: 640px) {
   .settings-page {
     padding-inline: var(--space-3);
+  }
+
+  .settings-section__header:has(.settings-section__copy) {
+    align-items: stretch;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .settings-section__header:has(.settings-section__copy) .settings-section__actions {
+    align-self: flex-end;
   }
 
   .settings-row {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -136,6 +136,10 @@
   align-items: flex-start;
 }
 
+.settings-section__header:has(.settings-section__copy):has(.settings-section__actions) {
+  column-gap: var(--space-5);
+}
+
 .settings-section__heading {
   margin: 0;
   font-size: var(--control-ui-text-xs);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes inconsistent settings-page layout where page descriptions could be separated from their titles, section headings could be inset from the cards below them, and "Learn more" links were underlined on some surfaces.

The settings audit found the title/description issue on Appearance, Approvals, Cloud Workers, Labs, MCP, Secrets, Security, Talk, and Updates.

## Why This Change Was Made

Settings headers now use one shared title/subtitle renderer, and section headings use the same horizontal edge as their content groups. A shared semantic "Learn more" link renderer and class remove the underline consistently without changing external-link behavior.

This replaces the page-body intro path with the header-owned subtitle path and keeps section copy grouped independently from taller actions. Production LOC: +254/-221 (net +33). Tests: +225/-3.

## User Impact

Settings pages now present their title and explanatory text as one header, section labels align with the cards they describe, and all "Learn more" links use the same non-underlined treatment.

## Evidence

### Before / after: MCP, Labs, Appearance, Talk, Model Providers

![Before and after comparison for MCP, Labs, Appearance, Talk, and Model Providers](https://github.com/user-attachments/assets/5a3188d1-04aa-4e12-b4a3-274399e20347)

### Before / after: Security, Approvals, Cloud Workers, Secrets, Updates

![Before and after comparison for Security, Approvals, Cloud Workers, Secrets, and Updates](https://github.com/user-attachments/assets/07b34300-f5e2-4b3a-b641-aba953717668)

### Additional proof: action-bearing section headers

#### Default models

| Before | After |
| --- | --- |
| ![Default models heading before](https://github.com/user-attachments/assets/294bc761-e6f7-4966-a539-47eb816827ae) | ![Default models heading after, with close subtitle and aligned actions](https://github.com/user-attachments/assets/294d49eb-ca80-4be8-8d83-be1fcce39b49) |

#### Configured servers

| Before | After |
| --- | --- |
| ![Configured servers heading before](https://github.com/user-attachments/assets/e80b8238-f8ca-4bf1-8b28-649db9954c7a) | ![Configured servers heading after, with close subtitle and aligned Add server action](https://github.com/user-attachments/assets/2f83afe5-5823-45de-82d9-7436bfd9d476) |

Validation:

- Focused UI unit tests: 129 passed
- Settings layout browser regression: 1 passed; pre-fix action headers fail with a 19px heading/subtitle gap
- Responsive layout audit: affected routes and action-bearing Default models/Configured servers sections at 390x844, 768x1024, 1366x768, and 1440x900; no overflow or action overlap, 4px heading/subtitle gap, 12px content clearance, section/card offset 0px, no Learn more underline
- `pnpm lint:ui:styles`
- `pnpm ui:build`
- Diff-scoped autoreview: no actionable findings

Local exact-head UI typecheck/build reruns are blocked by the shared checkout's installed dependency skew: tooling resolves root `pako@1.0.11` instead of the UI workspace's typed `pako@3.0.1`. Clean-install CI remains authoritative for this head.
