### PR TITLE
fix(test): honor native filesystem casing in doctor checks

### DIFF
--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -473,64 +473,19 @@ describe("doctor state integrity oauth dir checks", () => {
     expect(doctorChangesText()).toContain("Cleared aborted restart-recovery flags");
   });
 
-  it("warns when a case-mismatched agent dir does not resolve to the configured agent path", async () => {
+  it("checks case-mismatched agent dirs using native filesystem reachability", async () => {
     createAgentDir("Research");
-
-    const realpathNative = fs.realpathSync.native.bind(fs.realpathSync);
-    const realpathSpy = vi
-      .spyOn(fs.realpathSync, "native")
-      .mockImplementation((target, options) => {
-        const targetPath = String(target);
-        if (targetPath.endsWith(`${path.sep}agents${path.sep}research${path.sep}agent`)) {
-          const error = new Error("ENOENT");
-          (error as NodeJS.ErrnoException).code = "ENOENT";
-          throw error;
-        }
-        return realpathNative(target, options);
-      });
-
-    try {
-      const text = await runStateIntegrityText({
-        agents: {
-          list: [{ id: "main", default: true }, { id: "research" }],
-        },
-      });
-
-      expect(text).toContain("without a matching agents.list entry");
-      expect(text).toContain("Examples: Research (id research)");
-    } finally {
-      realpathSpy.mockRestore();
-    }
-  });
-
-  it("does not warn when a case-mismatched dir resolves to the configured agent path", async () => {
-    createAgentDir("Research");
-
-    const realpathNative = fs.realpathSync.native.bind(fs.realpathSync);
-    const resolvedResearchAgentDir = realpathNative(
-      path.join(process.env.OPENCLAW_STATE_DIR ?? "", "agents", "Research", "agent"),
+    const configuredAgentDirExists = fs.existsSync(
+      path.join(process.env.OPENCLAW_STATE_DIR ?? "", "agents", "research", "agent"),
     );
-    const realpathSpy = vi
-      .spyOn(fs.realpathSync, "native")
-      .mockImplementation((target, options) => {
-        const targetPath = String(target);
-        if (targetPath.endsWith(`${path.sep}agents${path.sep}research${path.sep}agent`)) {
-          return resolvedResearchAgentDir;
-        }
-        return realpathNative(target, options);
-      });
 
-    try {
-      const text = await runStateIntegrityText({
-        agents: {
-          list: [{ id: "main", default: true }, { id: "research" }],
-        },
-      });
+    const text = await runStateIntegrityText({
+      agents: {
+        list: [{ id: "main", default: true }, { id: "research" }],
+      },
+    });
 
-      expect(text).not.toContain("without a matching agents.list entry");
-      expect(text).not.toContain("Examples:");
-    } finally {
-      realpathSpy.mockRestore();
-    }
+    expect(text.includes("without a matching agents.list entry")).toBe(!configuredAgentDirExists);
+    expect(text.includes("Examples: Research (id research)")).toBe(!configuredAgentDirExists);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The broad macOS test run fails in Doctor's case-mismatched agent-directory test after #130895 added scanning of every configured agent's session store. The test reports `research/agent` missing through a mocked `realpath`, while the real case-insensitive filesystem still reports that directory present through `lstat`. Canonical database-path resolution correctly rejects those inconsistent observations.

## Why This Change Was Made

Replace the two synthetic casing fixtures with one native-filesystem boundary test. It creates `Research/agent`, independently observes whether the configured lowercase spelling exists, invokes the complete Doctor integrity check, and requires the orphan warning and directory label exactly when that spelling is unreachable. Ordinary configured, orphaned, and incomplete-directory coverage remains.

The fixture owns the inconsistency. Adding a database resolver fallback or mocking more filesystem operations would repair the wrong layer. Production code, SQLite schemas, persistence behavior, and configuration are unchanged. Production LOC: +0/-0. Tests: +10/-55, net -45.

## User Impact

No runtime behavior changes. This restores meaningful macOS test coverage while retaining the case-sensitive filesystem contract. This is a maintainer-requested CI/test repair.

## Evidence

- Unchanged complete Doctor file: 1 failed, 19 passed, reproducing the exact `ENOENT` from canonical ancestor resolution.
- Repaired complete Doctor file: 19 passed on the native case-insensitive macOS volume.
- Six complete owner/sibling files: 158 passed, 4 existing platform skips. These cover Doctor integrity/transcript/order behavior, session-target selection/deduplication, and agent-database path identity.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/doctor-state-integrity.test.ts`.
- `OPENCLAW_TEST_PROJECTS_PARALLEL=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/state/openclaw-agent-db.test.ts src/config/sessions/targets-dedupe.test.ts src/config/sessions/targets.selection.test.ts src/commands/doctor-state-integrity.test.ts src/commands/doctor-state-integrity.transcripts.test.ts src/commands/doctor-state-integrity.order.test.ts`.
- Full changed gate passed: `node scripts/check-changed.mjs -- src/commands/doctor-state-integrity.test.ts`; formatting and `git diff --check` also passed.
- Independent Codex static P0 review completed without findings. The maintainer audit inspected the complete test, support, Doctor owner, database-path registry, and collision caller.

Exact-head [CI run 33119738021](https://github.com/openclaw/openclaw/actions/runs/33119738021) passed at `d818e341eaf7bd3fbc899fc16346ab740c51bb90`. The [Ubuntu 24.04 changed-test job](https://github.com/openclaw/openclaw/actions/runs/33119738021/job/98683529794) explicitly selected `src/commands/doctor-state-integrity.test.ts` and passed all 19 tests, covering the native Linux filesystem path alongside the local macOS run.

The unrelated full-suite commands-worker heap exhaustion is not fixed by this patch; its omitted five-test sessions file passes independently, which recovers only that file's coverage.
