### PR TITLE
fix(ci): keep plugin fixture validation compatible with capability consent

### DIFF
--- a/scripts/e2e/agents-delete-shared-workspace-docker.sh
+++ b/scripts/e2e/agents-delete-shared-workspace-docker.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-agents-delete-shared-workspace-e2e:local" OPENCLAW_AGENTS_DELETE_SHARED_WORKSPACE_E2E_IMAGE)"
@@ -9,7 +10,7 @@ SKIP_BUILD="${OPENCLAW_AGENTS_DELETE_SHARED_WORKSPACE_E2E_SKIP_BUILD:-0}"
 DOCKER_COMMAND_TIMEOUT="${OPENCLAW_AGENTS_DELETE_SHARED_WORKSPACE_DOCKER_COMMAND_TIMEOUT:-300s}"
 OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 agents-delete-shared-workspace empty)"
 
-docker_e2e_build_or_reuse "$IMAGE_NAME" agents-delete-shared-workspace "$ROOT_DIR/Dockerfile" "$ROOT_DIR" "" "$SKIP_BUILD"
+docker_e2e_build_or_reuse "$IMAGE_NAME" agents-delete-shared-workspace "$SOURCE_ROOT/Dockerfile" "$SOURCE_ROOT" "" "$SKIP_BUILD"
 docker_e2e_harness_mount_args
 
 run_logged agents-delete-shared-workspace docker_e2e_docker_cmd run --rm \

--- a/scripts/e2e/cli-installer-distribution-docker.sh
+++ b/scripts/e2e/cli-installer-distribution-docker.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-cli-installer-distribution:local")"
@@ -13,7 +14,7 @@ HOSTED_PROOF_CONTAINER="openclaw-hosted-installer-proof-$$"
 SOURCE_PROOF_CONTAINER="openclaw-source-installer-proof-$$"
 SOURCE_BUNDLE="$(mktemp "${TMPDIR:-/tmp}/openclaw-source.XXXXXX.bundle")"
 SOURCE_PROOF_SCRIPT="$(mktemp "${TMPDIR:-/tmp}/openclaw-source-proof.XXXXXX.sh")"
-SOURCE_SHA="$(git -C "$ROOT_DIR" rev-parse HEAD)"
+SOURCE_SHA="$(git -C "$SOURCE_ROOT" rev-parse HEAD)"
 SOURCE_MEMORY="${OPENCLAW_CLI_INSTALLER_SOURCE_MEMORY:-16g}"
 
 cleanup() {
@@ -25,7 +26,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-git -C "$ROOT_DIR" bundle create "$SOURCE_BUNDLE" HEAD
+git -C "$SOURCE_ROOT" bundle create "$SOURCE_BUNDLE" HEAD
 cat >"$SOURCE_PROOF_SCRIPT" <<'SOURCE_PROOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -86,7 +87,7 @@ docker_e2e_docker_run_cmd run -d \
   -e OPENCLAW_NO_ONBOARD=1 \
   -e OPENCLAW_NO_PROMPT=1 \
   -v "$PACKAGE_TGZ:/tmp/openclaw-current.tgz:ro" \
-  -v "$ROOT_DIR/scripts/install.sh:/tmp/install.sh:ro" \
+  -v "$SOURCE_ROOT/scripts/install.sh:/tmp/install.sh:ro" \
   "$IMAGE_NAME" \
   bash -lc '
     set -euo pipefail

--- a/scripts/e2e/codex-npm-plugin-live-docker.sh
+++ b/scripts/e2e/codex-npm-plugin-live-docker.sh
@@ -259,7 +259,6 @@ POST_UNINSTALL_MODEL_REF="$MODEL_REF"
 SESSION_ID="codex-npm-plugin-live"
 SUCCESS_MARKER="OPENCLAW-CODEX-NPM-PLUGIN-LIVE-OK"
 AGENT_TURN_TIMEOUT_SECONDS="${OPENCLAW_CODEX_NPM_PLUGIN_AGENT_TIMEOUT_SECONDS:-420}"
-PLUGIN_INSTALL_HELP_LOG="/tmp/openclaw-codex-plugin-install-help.log"
 PLUGIN_INSTALL_FLAGS=(--force)
 if [ "${OPENCLAW_CODEX_NPM_PLUGIN_FORCE_UNSAFE_INSTALL:-0}" = "1" ]; then
   PLUGIN_INSTALL_FLAGS+=(--dangerously-force-unsafe-install)
@@ -272,7 +271,6 @@ dump_debug_logs() {
   openclaw_e2e_dump_logs \
     /tmp/openclaw-install.log \
     /tmp/openclaw-codex-plugin-registry.log \
-    "$PLUGIN_INSTALL_HELP_LOG" \
     /tmp/openclaw-codex-plugin-install.log \
     /tmp/openclaw-codex-plugin-enable.log \
     /tmp/openclaw-codex-plugins-list.json \
@@ -313,11 +311,6 @@ chmod 700 "$XDG_CACHE_HOME" "$NPM_CONFIG_CACHE" || true
 openclaw_e2e_install_package /tmp/openclaw-install.log
 command -v openclaw >/dev/null
 openclaw_e2e_enable_openclaw_cli_timeout
-# Capture before probing: grep -q can SIGPIPE the CLI under pipefail and hide supported flags.
-openclaw plugins install --help 2>&1 | head -c 65536 >"$PLUGIN_INSTALL_HELP_LOG" || true
-if grep -q -- "--accept-capabilities" "$PLUGIN_INSTALL_HELP_LOG"; then
-  PLUGIN_INSTALL_FLAGS+=(--accept-capabilities)
-fi
 
 if [ -n "$CODEX_PLUGIN_REGISTRY_TARBALL" ]; then
   registry_port_file=/tmp/openclaw-codex-plugin-registry.port
@@ -350,7 +343,7 @@ if [ -n "$CODEX_PLUGIN_REGISTRY_TARBALL" ]; then
 fi
 
 echo "Installing Codex plugin: $CODEX_PLUGIN_SPEC"
-openclaw plugins install "$CODEX_PLUGIN_SPEC" "${PLUGIN_INSTALL_FLAGS[@]}" >/tmp/openclaw-codex-plugin-install.log 2>&1
+openclaw_e2e_fixture_plugin_command openclaw -- plugins install "$CODEX_PLUGIN_SPEC" "${PLUGIN_INSTALL_FLAGS[@]}" >/tmp/openclaw-codex-plugin-install.log 2>&1
 
 node scripts/e2e/lib/codex-npm-plugin-live/assertions.mjs configure "$MODEL_REF"
 

--- a/scripts/e2e/codex-npm-plugin-live-docker.sh
+++ b/scripts/e2e/codex-npm-plugin-live-docker.sh
@@ -259,6 +259,7 @@ POST_UNINSTALL_MODEL_REF="$MODEL_REF"
 SESSION_ID="codex-npm-plugin-live"
 SUCCESS_MARKER="OPENCLAW-CODEX-NPM-PLUGIN-LIVE-OK"
 AGENT_TURN_TIMEOUT_SECONDS="${OPENCLAW_CODEX_NPM_PLUGIN_AGENT_TIMEOUT_SECONDS:-420}"
+PLUGIN_INSTALL_HELP_LOG="/tmp/openclaw-codex-plugin-install-help.log"
 PLUGIN_INSTALL_FLAGS=(--force)
 if [ "${OPENCLAW_CODEX_NPM_PLUGIN_FORCE_UNSAFE_INSTALL:-0}" = "1" ]; then
   PLUGIN_INSTALL_FLAGS+=(--dangerously-force-unsafe-install)
@@ -271,6 +272,7 @@ dump_debug_logs() {
   openclaw_e2e_dump_logs \
     /tmp/openclaw-install.log \
     /tmp/openclaw-codex-plugin-registry.log \
+    "$PLUGIN_INSTALL_HELP_LOG" \
     /tmp/openclaw-codex-plugin-install.log \
     /tmp/openclaw-codex-plugin-enable.log \
     /tmp/openclaw-codex-plugins-list.json \
@@ -311,6 +313,11 @@ chmod 700 "$XDG_CACHE_HOME" "$NPM_CONFIG_CACHE" || true
 openclaw_e2e_install_package /tmp/openclaw-install.log
 command -v openclaw >/dev/null
 openclaw_e2e_enable_openclaw_cli_timeout
+# Capture before probing: grep -q can SIGPIPE the CLI under pipefail and hide supported flags.
+openclaw plugins install --help 2>&1 | head -c 65536 >"$PLUGIN_INSTALL_HELP_LOG" || true
+if grep -q -- "--accept-capabilities" "$PLUGIN_INSTALL_HELP_LOG"; then
+  PLUGIN_INSTALL_FLAGS+=(--accept-capabilities)
+fi
 
 if [ -n "$CODEX_PLUGIN_REGISTRY_TARBALL" ]; then
   registry_port_file=/tmp/openclaw-codex-plugin-registry.port

--- a/scripts/e2e/compose-setup.sh
+++ b/scripts/e2e/compose-setup.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-docker-e2e-functional:local")"
@@ -17,7 +18,7 @@ COMPOSE=(
   docker compose
   --project-name "$PROJECT_NAME"
   --project-directory "$PROJECT_DIR"
-  -f "$ROOT_DIR/docker-compose.yml"
+  -f "$SOURCE_ROOT/docker-compose.yml"
   -f "$HEALTH_OVERRIDE_PATH"
 )
 
@@ -56,7 +57,7 @@ NODE
 }
 
 assert_dockerfile_healthcheck() {
-  node - "$ROOT_DIR/Dockerfile" <<'NODE'
+  node - "$SOURCE_ROOT/Dockerfile" <<'NODE'
 const fs = require("node:fs");
 const dockerfilePath = process.argv[2];
 const dockerfile = fs.readFileSync(dockerfilePath, "utf8").replace(/\\\r?\n[ \t]*/g, " ");

--- a/scripts/e2e/docker-selected-plugins.sh
+++ b/scripts/e2e/docker-selected-plugins.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}"
 source "$ROOT_DIR/scripts/lib/docker-build.sh"
 source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
 
@@ -35,8 +36,8 @@ else
     env DOCKER_BUILDKIT=1 docker build \
     --target workspace-deps \
     --build-arg OPENCLAW_EXTENSIONS=missing-plugin \
-    -f "$ROOT_DIR/Dockerfile" \
-    "$ROOT_DIR" >"$UNKNOWN_LOG" 2>&1
+    -f "$SOURCE_ROOT/Dockerfile" \
+    "$SOURCE_ROOT" >"$UNKNOWN_LOG" 2>&1
   unknown_status=$?
   set -e
   if [ "$unknown_status" -eq 0 ] || ! grep -Fq \
@@ -51,8 +52,8 @@ else
     --target workspace-deps \
     --build-arg OPENCLAW_EXTENSIONS=whatsapp,kimi \
     -t "$DEPENDENCY_ONLY_IMAGE" \
-    -f "$ROOT_DIR/Dockerfile" \
-    "$ROOT_DIR"
+    -f "$SOURCE_ROOT/Dockerfile" \
+    "$SOURCE_ROOT"
   DEPENDENCY_ONLY_IMAGE_BUILT=1
   docker_e2e_docker_run_cmd run --rm \
     --entrypoint sh \
@@ -65,8 +66,8 @@ else
     --build-arg "OPENCLAW_BUILD_TIMESTAMP=$BUILD_TIMESTAMP" \
     --build-arg "OPENCLAW_EXTENSIONS=$SELECTED_PLUGINS" \
     -t "$IMAGE_NAME" \
-    -f "$ROOT_DIR/Dockerfile" \
-    "$ROOT_DIR"
+    -f "$SOURCE_ROOT/Dockerfile" \
+    "$SOURCE_ROOT"
 fi
 
 echo "Inspecting selected plugins from the final runtime image..."

--- a/scripts/e2e/kitchen-sink-rpc-walk.mts
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mts
@@ -2754,12 +2754,17 @@ async function main() {
   let sampleTimer: ReturnType<typeof setInterval> | undefined;
   try {
     console.log(`Kitchen Sink RPC walk using ${PLUGIN_SPEC} via ${runner.label}`);
-    await runOpenClaw(runner, ["plugins", "install", PLUGIN_SPEC, "--force"], env, {
-      ...commandResourceOptions,
-      requireResourceSample: true,
-      resourceLabel: "plugins install",
-      timeoutMs: config.installTimeoutMs,
-    });
+    await runOpenClaw(
+      runner,
+      ["plugins", "install", PLUGIN_SPEC, "--force", "--accept-capabilities"],
+      env,
+      {
+        ...commandResourceOptions,
+        requireResourceSample: true,
+        resourceLabel: "plugins install",
+        timeoutMs: config.installTimeoutMs,
+      },
+    );
     runner = resolveOpenClawRunner();
     console.log(`Kitchen Sink RPC runtime runner: ${runner.label}`);
     configureKitchenSink(env, port);

--- a/scripts/e2e/kitchen-sink-rpc-walk.mts
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mts
@@ -24,6 +24,7 @@ import {
   resolveWindowsSystem32Path,
   resolveWindowsTaskkillPath,
 } from "../lib/windows-taskkill.mjs";
+import { fixtureCapabilityConsentArgs } from "./lib/package-compat.mjs";
 import { readTextFileTail } from "./lib/text-file-utils.mjs";
 
 type JsonRecord = Record<string, unknown>;
@@ -2754,9 +2755,19 @@ async function main() {
   let sampleTimer: ReturnType<typeof setInterval> | undefined;
   try {
     console.log(`Kitchen Sink RPC walk using ${PLUGIN_SPEC} via ${runner.label}`);
+    const installHelp = await runOpenClaw(runner, ["plugins", "install", "--help"], env);
+    if (installHelp.stdoutTruncatedChars > 0) {
+      throw new Error("Plugin fixture help probe output was truncated");
+    }
     await runOpenClaw(
       runner,
-      ["plugins", "install", PLUGIN_SPEC, "--force", "--accept-capabilities"],
+      [
+        "plugins",
+        "install",
+        PLUGIN_SPEC,
+        "--force",
+        ...fixtureCapabilityConsentArgs(installHelp.stdout),
+      ],
       env,
       {
         ...commandResourceOptions,

--- a/scripts/e2e/lib/codex-media-path/scenario.sh
+++ b/scripts/e2e/lib/codex-media-path/scenario.sh
@@ -41,7 +41,7 @@ rm -f "$OPENCLAW_CODEX_MEDIA_PATH_APP_SERVER_LOG"
 openclaw_e2e_enable_openclaw_cli_timeout
 
 echo "Installing Codex plugin: $PLUGIN_SPEC"
-openclaw plugins install "$PLUGIN_SPEC" --force >"$PLUGIN_INSTALL_LOG" 2>&1
+openclaw plugins install "$PLUGIN_SPEC" --force --accept-capabilities >"$PLUGIN_INSTALL_LOG" 2>&1
 openclaw plugins inspect codex --runtime --json >"$PLUGIN_INSPECT_LOG"
 
 node scripts/e2e/lib/codex-media-path/write-config.mjs

--- a/scripts/e2e/lib/codex-media-path/scenario.sh
+++ b/scripts/e2e/lib/codex-media-path/scenario.sh
@@ -41,7 +41,7 @@ rm -f "$OPENCLAW_CODEX_MEDIA_PATH_APP_SERVER_LOG"
 openclaw_e2e_enable_openclaw_cli_timeout
 
 echo "Installing Codex plugin: $PLUGIN_SPEC"
-openclaw plugins install "$PLUGIN_SPEC" --force --accept-capabilities >"$PLUGIN_INSTALL_LOG" 2>&1
+openclaw_e2e_fixture_plugin_command openclaw -- plugins install "$PLUGIN_SPEC" --force >"$PLUGIN_INSTALL_LOG" 2>&1
 openclaw plugins inspect codex --runtime --json >"$PLUGIN_INSPECT_LOG"
 
 node scripts/e2e/lib/codex-media-path/write-config.mjs

--- a/scripts/e2e/lib/kitchen-sink-plugin/sweep.sh
+++ b/scripts/e2e/lib/kitchen-sink-plugin/sweep.sh
@@ -155,11 +155,11 @@ run_success_scenario() {
   echo "Testing ${KITCHEN_SINK_LABEL} install from ${KITCHEN_SINK_SPEC}..."
   local install_args=("$KITCHEN_SINK_SPEC")
   if [ -n "${KITCHEN_SINK_PREINSTALL_SPEC:-}" ]; then
-    run_kitchen_sink_openclaw_logged "kitchen-sink-preinstall-${KITCHEN_SINK_LABEL}" plugins install "$KITCHEN_SINK_PREINSTALL_SPEC" --force
+    run_kitchen_sink_openclaw_logged "kitchen-sink-preinstall-${KITCHEN_SINK_LABEL}" plugins install "$KITCHEN_SINK_PREINSTALL_SPEC" --force --accept-capabilities
     assert_kitchen_sink_cutover_preinstalled
     install_args+=("--force")
   fi
-  run_kitchen_sink_openclaw_logged "kitchen-sink-install-${KITCHEN_SINK_LABEL}" plugins install "${install_args[@]}" --force
+  run_kitchen_sink_openclaw_logged "kitchen-sink-install-${KITCHEN_SINK_LABEL}" plugins install "${install_args[@]}" --force --accept-capabilities
   configure_kitchen_sink_runtime
   run_kitchen_sink_openclaw_logged "kitchen-sink-enable-${KITCHEN_SINK_LABEL}" plugins enable "$KITCHEN_SINK_ID"
   run_kitchen_sink_openclaw_capture "${KITCHEN_SINK_TMP_DIR}/kitchen-sink-${KITCHEN_SINK_LABEL}-plugins.json" plugins list --json

--- a/scripts/e2e/lib/kitchen-sink-plugin/sweep.sh
+++ b/scripts/e2e/lib/kitchen-sink-plugin/sweep.sh
@@ -63,11 +63,25 @@ openclaw_e2e_read_positive_int_env OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES 65536 >/d
 run_kitchen_sink_openclaw_logged() {
   local label="$1"
   shift
+  run_kitchen_sink_command_logged "$label" openclaw_e2e_maybe_timeout "$KITCHEN_SINK_CLI_TIMEOUT" node "$OPENCLAW_ENTRY" "$@"
+}
+
+run_kitchen_sink_fixture_logged() {
+  local label="$1"
+  shift
+  run_kitchen_sink_command_logged "$label" openclaw_e2e_fixture_plugin_command openclaw_e2e_maybe_timeout "$KITCHEN_SINK_CLI_TIMEOUT" node "$OPENCLAW_ENTRY" -- "$@"
+}
+
+run_kitchen_sink_command_logged() {
+  local label="$1"
+  shift
   local safe_label="${label//[^[:alnum:]._-]/_}"
   local log_file="${KITCHEN_SINK_TMP_DIR}/${safe_label}.log"
-  if ! openclaw_e2e_maybe_timeout "$KITCHEN_SINK_CLI_TIMEOUT" node "$OPENCLAW_ENTRY" "$@" >"$log_file" 2>&1; then
+  local command_status=0
+  "$@" >"$log_file" 2>&1 || command_status=$?
+  if [[ "$command_status" -ne 0 ]]; then
     print_kitchen_sink_log "$log_file"
-    return 1
+    return "$command_status"
   fi
   print_kitchen_sink_log "$log_file"
 }
@@ -155,11 +169,11 @@ run_success_scenario() {
   echo "Testing ${KITCHEN_SINK_LABEL} install from ${KITCHEN_SINK_SPEC}..."
   local install_args=("$KITCHEN_SINK_SPEC")
   if [ -n "${KITCHEN_SINK_PREINSTALL_SPEC:-}" ]; then
-    run_kitchen_sink_openclaw_logged "kitchen-sink-preinstall-${KITCHEN_SINK_LABEL}" plugins install "$KITCHEN_SINK_PREINSTALL_SPEC" --force --accept-capabilities
+    run_kitchen_sink_fixture_logged "kitchen-sink-preinstall-${KITCHEN_SINK_LABEL}" plugins install "$KITCHEN_SINK_PREINSTALL_SPEC" --force
     assert_kitchen_sink_cutover_preinstalled
     install_args+=("--force")
   fi
-  run_kitchen_sink_openclaw_logged "kitchen-sink-install-${KITCHEN_SINK_LABEL}" plugins install "${install_args[@]}" --force --accept-capabilities
+  run_kitchen_sink_fixture_logged "kitchen-sink-install-${KITCHEN_SINK_LABEL}" plugins install "${install_args[@]}" --force
   configure_kitchen_sink_runtime
   run_kitchen_sink_openclaw_logged "kitchen-sink-enable-${KITCHEN_SINK_LABEL}" plugins enable "$KITCHEN_SINK_ID"
   run_kitchen_sink_openclaw_capture "${KITCHEN_SINK_TMP_DIR}/kitchen-sink-${KITCHEN_SINK_LABEL}-plugins.json" plugins list --json

--- a/scripts/e2e/lib/package-compat.mjs
+++ b/scripts/e2e/lib/package-compat.mjs
@@ -1,4 +1,6 @@
-// Package-version compatibility helpers for E2E acceptance scripts.
+// Candidate-package compatibility helpers for E2E acceptance scripts.
+import { readFileSync } from "node:fs";
+import { stripVTControlCharacters } from "node:util";
 import { isDirectRunUrl } from "../../lib/direct-run.mjs";
 
 export function legacyPackageAcceptanceCompat(version) {
@@ -9,6 +11,20 @@ export function legacyPackageAcceptanceCompat(version) {
   );
 }
 
+// Candidates on either side of consent enforcement can share a package version.
+// Only successful command help establishes support; callers own probe failures.
+export function fixtureCapabilityConsentArgs(help) {
+  return /^[\t ]*--accept-capabilities(?:[\t ]|$)/m.test(stripVTControlCharacters(help))
+    ? ["--accept-capabilities"]
+    : [];
+}
+
 if (isDirectRunUrl(process.argv[1], import.meta.url)) {
-  console.log(legacyPackageAcceptanceCompat(process.argv[2]) ? "1" : "0");
+  console.log(
+    process.argv[2] === "fixture-consent"
+      ? fixtureCapabilityConsentArgs(readFileSync(0, "utf8")).join("\n")
+      : legacyPackageAcceptanceCompat(process.argv[2])
+        ? "1"
+        : "0",
+  );
 }

--- a/scripts/e2e/lib/plugins/clawhub.sh
+++ b/scripts/e2e/lib/plugins/clawhub.sh
@@ -56,7 +56,7 @@ run_plugins_clawhub_scenario() {
 
     node scripts/e2e/lib/plugins/assertions.mjs clawhub-preflight
 
-    run_plugins_openclaw_logged install-clawhub plugins install "$CLAWHUB_PLUGIN_SPEC"
+    run_plugins_fixture_install_logged install-clawhub plugins install "$CLAWHUB_PLUGIN_SPEC"
     run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-clawhub-installed.json" plugins list --json
     run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-clawhub-inspect.json" plugins inspect "$CLAWHUB_PLUGIN_ID" --json
 

--- a/scripts/e2e/lib/plugins/clawhub.sh
+++ b/scripts/e2e/lib/plugins/clawhub.sh
@@ -56,7 +56,7 @@ run_plugins_clawhub_scenario() {
 
     node scripts/e2e/lib/plugins/assertions.mjs clawhub-preflight
 
-    run_plugins_fixture_install_logged install-clawhub plugins install "$CLAWHUB_PLUGIN_SPEC"
+    run_plugins_fixture_logged install-clawhub plugins install "$CLAWHUB_PLUGIN_SPEC"
     run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-clawhub-installed.json" plugins list --json
     run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-clawhub-inspect.json" plugins inspect "$CLAWHUB_PLUGIN_ID" --json
 

--- a/scripts/e2e/lib/plugins/marketplace.sh
+++ b/scripts/e2e/lib/plugins/marketplace.sh
@@ -20,8 +20,8 @@ run_plugins_marketplace_scenario() {
 
   node scripts/e2e/lib/plugins/assertions.mjs marketplace-list
 
-  run_plugins_openclaw_logged install-marketplace-shortcut plugins install marketplace-shortcut@claude-fixtures --force
-  run_plugins_openclaw_logged install-marketplace-direct plugins install marketplace-direct --marketplace claude-fixtures --force
+  run_plugins_fixture_install_logged install-marketplace-shortcut plugins install marketplace-shortcut@claude-fixtures --force
+  run_plugins_fixture_install_logged install-marketplace-direct plugins install marketplace-direct --marketplace claude-fixtures --force
   run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-marketplace.json" plugins list --json
   run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-marketplace-shortcut-inspect.json" plugins inspect marketplace-shortcut --runtime --json
   run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-marketplace-direct-inspect.json" plugins inspect marketplace-direct --runtime --json
@@ -37,7 +37,7 @@ run_plugins_marketplace_scenario() {
     "demo.marketplace.shortcut.v2" \
     "Marketplace Shortcut"
   run_plugins_openclaw_logged update-marketplace-shortcut-dry-run plugins update marketplace-shortcut --dry-run
-  run_plugins_openclaw_logged update-marketplace-shortcut plugins update marketplace-shortcut
+  run_plugins_openclaw_logged update-marketplace-shortcut plugins update marketplace-shortcut --accept-capabilities
   run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-marketplace-updated.json" plugins list --json
   run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-marketplace-updated-inspect.json" plugins inspect marketplace-shortcut --runtime --json
 

--- a/scripts/e2e/lib/plugins/marketplace.sh
+++ b/scripts/e2e/lib/plugins/marketplace.sh
@@ -20,8 +20,8 @@ run_plugins_marketplace_scenario() {
 
   node scripts/e2e/lib/plugins/assertions.mjs marketplace-list
 
-  run_plugins_fixture_install_logged install-marketplace-shortcut plugins install marketplace-shortcut@claude-fixtures --force
-  run_plugins_fixture_install_logged install-marketplace-direct plugins install marketplace-direct --marketplace claude-fixtures --force
+  run_plugins_fixture_logged install-marketplace-shortcut plugins install marketplace-shortcut@claude-fixtures --force
+  run_plugins_fixture_logged install-marketplace-direct plugins install marketplace-direct --marketplace claude-fixtures --force
   run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-marketplace.json" plugins list --json
   run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-marketplace-shortcut-inspect.json" plugins inspect marketplace-shortcut --runtime --json
   run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-marketplace-direct-inspect.json" plugins inspect marketplace-direct --runtime --json
@@ -37,7 +37,7 @@ run_plugins_marketplace_scenario() {
     "demo.marketplace.shortcut.v2" \
     "Marketplace Shortcut"
   run_plugins_openclaw_logged update-marketplace-shortcut-dry-run plugins update marketplace-shortcut --dry-run
-  run_plugins_openclaw_logged update-marketplace-shortcut plugins update marketplace-shortcut --accept-capabilities
+  run_plugins_fixture_logged update-marketplace-shortcut plugins update marketplace-shortcut
   run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-marketplace-updated.json" plugins list --json
   run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-marketplace-updated-inspect.json" plugins inspect marketplace-shortcut --runtime --json
 

--- a/scripts/e2e/lib/plugins/sweep.sh
+++ b/scripts/e2e/lib/plugins/sweep.sh
@@ -48,6 +48,18 @@ print_plugins_stderr_log() {
 run_plugins_openclaw_logged() {
   local label="$1"
   shift
+  run_plugins_command_logged "$label" openclaw_e2e_maybe_timeout "$OPENCLAW_PLUGINS_CLI_TIMEOUT" node "$OPENCLAW_ENTRY" "$@"
+}
+
+run_plugins_fixture_logged() {
+  local label="$1"
+  shift
+  run_plugins_command_logged "$label" openclaw_e2e_fixture_plugin_command openclaw_e2e_maybe_timeout "$OPENCLAW_PLUGINS_CLI_TIMEOUT" node "$OPENCLAW_ENTRY" -- "$@"
+}
+
+run_plugins_command_logged() {
+  local label="$1"
+  shift
   local output_file
   output_file="$(mktemp "$OPENCLAW_PLUGINS_TMP_DIR/openclaw-plugin-stdout.XXXXXX")" || return $?
   local error_file
@@ -57,7 +69,7 @@ run_plugins_openclaw_logged() {
     return "$create_status"
   }
   local status=0
-  if openclaw_e2e_maybe_timeout "$OPENCLAW_PLUGINS_CLI_TIMEOUT" node "$OPENCLAW_ENTRY" "$@" >"$output_file" 2>"$error_file"; then
+  if "$@" >"$output_file" 2>"$error_file"; then
     if plugins_lifecycle_trace_enabled; then
       print_plugins_stderr_log "$error_file" || status=$?
     fi
@@ -76,12 +88,6 @@ run_plugins_openclaw_logged() {
   fi
   rm -f "$error_file" "$output_file"
   return "$status"
-}
-
-run_plugins_fixture_install_logged() {
-  local label="$1"
-  shift
-  run_plugins_openclaw_logged "$label" "$@" --accept-capabilities
 }
 
 run_plugins_openclaw_capture() {
@@ -154,7 +160,7 @@ echo "Testing tgz install flow..."
 pack_dir="$(mktemp -d "$OPENCLAW_PLUGINS_TMP_DIR/openclaw-plugin-pack.XXXXXX")"
 pack_fixture_plugin "$pack_dir" "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-tgz.tgz" demo-plugin-tgz 0.0.1 demo.tgz "Demo Plugin TGZ"
 
-run_plugins_fixture_install_logged install-tgz plugins install "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-tgz.tgz" --force
+run_plugins_fixture_logged install-tgz plugins install "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-tgz.tgz" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins2.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins2-inspect.json" plugins inspect demo-plugin-tgz --runtime --json
 
@@ -168,7 +174,7 @@ echo "Testing install from local folder (plugins.load.paths)..."
 dir_plugin="$(mktemp -d "$OPENCLAW_PLUGINS_TMP_DIR/openclaw-plugin-dir.XXXXXX")"
 write_fixture_plugin "$dir_plugin" demo-plugin-dir 0.0.1 demo.dir "Demo Plugin DIR"
 
-run_plugins_fixture_install_logged install-dir plugins install "$dir_plugin" --force
+run_plugins_fixture_logged install-dir plugins install "$dir_plugin" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins3.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins3-inspect.json" plugins inspect demo-plugin-dir --runtime --json
 
@@ -185,7 +191,7 @@ echo "Testing install from local folder with preinstalled dependencies..."
 dir_deps_plugin="$(mktemp -d "$OPENCLAW_PLUGINS_TMP_DIR/openclaw-plugin-dir-deps.XXXXXX")"
 write_fixture_plugin_with_vendored_dependency "$dir_deps_plugin" demo-plugin-dir-deps 0.0.1 demo.dir.deps "Demo Plugin DIR Deps"
 
-run_plugins_fixture_install_logged install-dir-deps plugins install "$dir_deps_plugin" --force
+run_plugins_fixture_logged install-dir-deps plugins install "$dir_deps_plugin" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-dir-deps.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-dir-deps-inspect.json" plugins inspect demo-plugin-dir-deps --runtime --json
 
@@ -199,7 +205,7 @@ echo "Testing install from npm spec (file:)..."
 file_pack_dir="$(mktemp -d "$OPENCLAW_PLUGINS_TMP_DIR/openclaw-plugin-filepack.XXXXXX")"
 write_fixture_plugin "$file_pack_dir/package" demo-plugin-file 0.0.1 demo.file "Demo Plugin FILE"
 
-run_plugins_fixture_install_logged install-file plugins install "file:$file_pack_dir/package" --force
+run_plugins_fixture_logged install-file plugins install "file:$file_pack_dir/package" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins4.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins4-inspect.json" plugins inspect demo-plugin-file --runtime --json
 
@@ -219,7 +225,7 @@ pack_fake_is_number_package "$npm_dep_pack_dir" "$OPENCLAW_PLUGINS_TMP_DIR/is-nu
 pack_fixture_plugin_with_invalid_extension_entry "$invalid_npm_pack_dir" "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-invalid-metadata.tgz" demo-plugin-invalid-metadata 0.0.1 demo.invalid.metadata "Demo Plugin Invalid Metadata"
 start_npm_fixture_registry "@openclaw/demo-plugin-npm" "0.0.1" "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-npm.tgz" "$npm_registry_dir" "is-number" "7.0.0" "$OPENCLAW_PLUGINS_TMP_DIR/is-number-7.0.0.tgz" "@openclaw/demo-plugin-invalid-metadata" "0.0.1" "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-invalid-metadata.tgz"
 
-run_plugins_fixture_install_logged install-npm plugins install "npm:@openclaw/demo-plugin-npm@0.0.1" --force
+run_plugins_fixture_logged install-npm plugins install "npm:@openclaw/demo-plugin-npm@0.0.1" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-inspect.json" plugins inspect demo-plugin-npm --runtime --json
 run_plugins_shell_logged exec-npm-plugin-cli 'node "$OPENCLAW_ENTRY" demo-npm ping >"$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-cli.txt"'
@@ -233,7 +239,7 @@ run_plugins_openclaw_logged uninstall-npm-retained plugins uninstall demo-plugin
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-retained.json" plugins list --json
 node scripts/e2e/lib/plugins/assertions.mjs plugin-npm-retained
 
-run_plugins_fixture_install_logged reinstall-npm plugins install "npm:@openclaw/demo-plugin-npm@0.0.1" --force
+run_plugins_fixture_logged reinstall-npm plugins install "npm:@openclaw/demo-plugin-npm@0.0.1" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-inspect.json" plugins inspect demo-plugin-npm --runtime --json
 run_plugins_shell_logged exec-reinstalled-npm-plugin-cli 'node "$OPENCLAW_ENTRY" demo-npm ping >"$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-cli.txt"'
@@ -264,7 +270,7 @@ git -C "$git_repo" add -A
 git -C "$git_repo" commit -qm "test fixture"
 git_ref="$(git -C "$git_repo" rev-parse HEAD)"
 
-run_plugins_fixture_install_logged install-git plugins install "git:$git_repo_url@$git_ref" --force
+run_plugins_fixture_logged install-git plugins install "git:$git_repo_url@$git_ref" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-git.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-git-inspect.json" plugins inspect demo-plugin-git --runtime --json
 run_plugins_shell_logged exec-git-plugin-cli 'node "$OPENCLAW_ENTRY" demo-git ping >"$OPENCLAW_PLUGINS_TMP_DIR/plugins-git-cli.txt"'
@@ -288,7 +294,7 @@ git -C "$git_update_repo" add -A
 git -C "$git_update_repo" commit -qm "test fixture v1"
 git_update_ref_v1="$(git -C "$git_update_repo" rev-parse HEAD)"
 
-run_plugins_fixture_install_logged install-git-update plugins install "git:$git_update_repo_url@main" --force
+run_plugins_fixture_logged install-git-update plugins install "git:$git_update_repo_url@main" --force
 write_fixture_plugin_with_cli "$git_update_repo" demo-plugin-git-update 0.0.2 demo.git.update.v2 "Demo Plugin Git Update" demo-git-update "demo-plugin-git-update:pong-v2"
 git -C "$git_update_repo" add -A
 git -C "$git_update_repo" commit -qm "test fixture v2"
@@ -309,7 +315,7 @@ record_fixture_plugin_trust "$bundle_plugin_id" "$bundle_root" 0
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-bundle-disabled.json" plugins list --json
 node scripts/e2e/lib/plugins/assertions.mjs bundle-disabled
 
-run_plugins_openclaw_logged enable-claude-bundle plugins enable claude-bundle-e2e --accept-capabilities
+run_plugins_fixture_logged enable-claude-bundle plugins enable claude-bundle-e2e
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-bundle-inspect.json" plugins inspect claude-bundle-e2e --json
 node scripts/e2e/lib/plugins/assertions.mjs bundle-inspect
 
@@ -317,7 +323,7 @@ echo "Testing plugin install visible after explicit restart..."
 slash_install_dir="$(mktemp -d "$OPENCLAW_PLUGINS_TMP_DIR/openclaw-plugin-slash-install.XXXXXX")"
 write_fixture_plugin "$slash_install_dir" slash-install-plugin 0.0.1 demo.slash.install "Slash Install Plugin"
 
-run_plugins_fixture_install_logged install-slash-plugin plugins install "$slash_install_dir" --force
+run_plugins_fixture_logged install-slash-plugin plugins install "$slash_install_dir" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugin-command-install-show.json" plugins inspect slash-install-plugin --runtime --json
 node scripts/e2e/lib/plugins/assertions.mjs slash-install
 

--- a/scripts/e2e/lib/plugins/sweep.sh
+++ b/scripts/e2e/lib/plugins/sweep.sh
@@ -78,6 +78,12 @@ run_plugins_openclaw_logged() {
   return "$status"
 }
 
+run_plugins_fixture_install_logged() {
+  local label="$1"
+  shift
+  run_plugins_openclaw_logged "$label" "$@" --accept-capabilities
+}
+
 run_plugins_openclaw_capture() {
   local output_file="$1"
   shift
@@ -148,7 +154,7 @@ echo "Testing tgz install flow..."
 pack_dir="$(mktemp -d "$OPENCLAW_PLUGINS_TMP_DIR/openclaw-plugin-pack.XXXXXX")"
 pack_fixture_plugin "$pack_dir" "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-tgz.tgz" demo-plugin-tgz 0.0.1 demo.tgz "Demo Plugin TGZ"
 
-run_plugins_openclaw_logged install-tgz plugins install "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-tgz.tgz" --force
+run_plugins_fixture_install_logged install-tgz plugins install "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-tgz.tgz" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins2.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins2-inspect.json" plugins inspect demo-plugin-tgz --runtime --json
 
@@ -162,7 +168,7 @@ echo "Testing install from local folder (plugins.load.paths)..."
 dir_plugin="$(mktemp -d "$OPENCLAW_PLUGINS_TMP_DIR/openclaw-plugin-dir.XXXXXX")"
 write_fixture_plugin "$dir_plugin" demo-plugin-dir 0.0.1 demo.dir "Demo Plugin DIR"
 
-run_plugins_openclaw_logged install-dir plugins install "$dir_plugin" --force
+run_plugins_fixture_install_logged install-dir plugins install "$dir_plugin" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins3.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins3-inspect.json" plugins inspect demo-plugin-dir --runtime --json
 
@@ -179,7 +185,7 @@ echo "Testing install from local folder with preinstalled dependencies..."
 dir_deps_plugin="$(mktemp -d "$OPENCLAW_PLUGINS_TMP_DIR/openclaw-plugin-dir-deps.XXXXXX")"
 write_fixture_plugin_with_vendored_dependency "$dir_deps_plugin" demo-plugin-dir-deps 0.0.1 demo.dir.deps "Demo Plugin DIR Deps"
 
-run_plugins_openclaw_logged install-dir-deps plugins install "$dir_deps_plugin" --force
+run_plugins_fixture_install_logged install-dir-deps plugins install "$dir_deps_plugin" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-dir-deps.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-dir-deps-inspect.json" plugins inspect demo-plugin-dir-deps --runtime --json
 
@@ -193,7 +199,7 @@ echo "Testing install from npm spec (file:)..."
 file_pack_dir="$(mktemp -d "$OPENCLAW_PLUGINS_TMP_DIR/openclaw-plugin-filepack.XXXXXX")"
 write_fixture_plugin "$file_pack_dir/package" demo-plugin-file 0.0.1 demo.file "Demo Plugin FILE"
 
-run_plugins_openclaw_logged install-file plugins install "file:$file_pack_dir/package" --force
+run_plugins_fixture_install_logged install-file plugins install "file:$file_pack_dir/package" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins4.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins4-inspect.json" plugins inspect demo-plugin-file --runtime --json
 
@@ -213,7 +219,7 @@ pack_fake_is_number_package "$npm_dep_pack_dir" "$OPENCLAW_PLUGINS_TMP_DIR/is-nu
 pack_fixture_plugin_with_invalid_extension_entry "$invalid_npm_pack_dir" "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-invalid-metadata.tgz" demo-plugin-invalid-metadata 0.0.1 demo.invalid.metadata "Demo Plugin Invalid Metadata"
 start_npm_fixture_registry "@openclaw/demo-plugin-npm" "0.0.1" "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-npm.tgz" "$npm_registry_dir" "is-number" "7.0.0" "$OPENCLAW_PLUGINS_TMP_DIR/is-number-7.0.0.tgz" "@openclaw/demo-plugin-invalid-metadata" "0.0.1" "$OPENCLAW_PLUGINS_TMP_DIR/demo-plugin-invalid-metadata.tgz"
 
-run_plugins_openclaw_logged install-npm plugins install "npm:@openclaw/demo-plugin-npm@0.0.1" --force
+run_plugins_fixture_install_logged install-npm plugins install "npm:@openclaw/demo-plugin-npm@0.0.1" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-inspect.json" plugins inspect demo-plugin-npm --runtime --json
 run_plugins_shell_logged exec-npm-plugin-cli 'node "$OPENCLAW_ENTRY" demo-npm ping >"$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-cli.txt"'
@@ -227,7 +233,7 @@ run_plugins_openclaw_logged uninstall-npm-retained plugins uninstall demo-plugin
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-retained.json" plugins list --json
 node scripts/e2e/lib/plugins/assertions.mjs plugin-npm-retained
 
-run_plugins_openclaw_logged reinstall-npm plugins install "npm:@openclaw/demo-plugin-npm@0.0.1" --force
+run_plugins_fixture_install_logged reinstall-npm plugins install "npm:@openclaw/demo-plugin-npm@0.0.1" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-inspect.json" plugins inspect demo-plugin-npm --runtime --json
 run_plugins_shell_logged exec-reinstalled-npm-plugin-cli 'node "$OPENCLAW_ENTRY" demo-npm ping >"$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-cli.txt"'
@@ -258,7 +264,7 @@ git -C "$git_repo" add -A
 git -C "$git_repo" commit -qm "test fixture"
 git_ref="$(git -C "$git_repo" rev-parse HEAD)"
 
-run_plugins_openclaw_logged install-git plugins install "git:$git_repo_url@$git_ref" --force
+run_plugins_fixture_install_logged install-git plugins install "git:$git_repo_url@$git_ref" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-git.json" plugins list --json
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-git-inspect.json" plugins inspect demo-plugin-git --runtime --json
 run_plugins_shell_logged exec-git-plugin-cli 'node "$OPENCLAW_ENTRY" demo-git ping >"$OPENCLAW_PLUGINS_TMP_DIR/plugins-git-cli.txt"'
@@ -282,7 +288,7 @@ git -C "$git_update_repo" add -A
 git -C "$git_update_repo" commit -qm "test fixture v1"
 git_update_ref_v1="$(git -C "$git_update_repo" rev-parse HEAD)"
 
-run_plugins_openclaw_logged install-git-update plugins install "git:$git_update_repo_url@main" --force
+run_plugins_fixture_install_logged install-git-update plugins install "git:$git_update_repo_url@main" --force
 write_fixture_plugin_with_cli "$git_update_repo" demo-plugin-git-update 0.0.2 demo.git.update.v2 "Demo Plugin Git Update" demo-git-update "demo-plugin-git-update:pong-v2"
 git -C "$git_update_repo" add -A
 git -C "$git_update_repo" commit -qm "test fixture v2"
@@ -303,7 +309,7 @@ record_fixture_plugin_trust "$bundle_plugin_id" "$bundle_root" 0
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-bundle-disabled.json" plugins list --json
 node scripts/e2e/lib/plugins/assertions.mjs bundle-disabled
 
-run_plugins_openclaw_logged enable-claude-bundle plugins enable claude-bundle-e2e
+run_plugins_openclaw_logged enable-claude-bundle plugins enable claude-bundle-e2e --accept-capabilities
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-bundle-inspect.json" plugins inspect claude-bundle-e2e --json
 node scripts/e2e/lib/plugins/assertions.mjs bundle-inspect
 
@@ -311,7 +317,7 @@ echo "Testing plugin install visible after explicit restart..."
 slash_install_dir="$(mktemp -d "$OPENCLAW_PLUGINS_TMP_DIR/openclaw-plugin-slash-install.XXXXXX")"
 write_fixture_plugin "$slash_install_dir" slash-install-plugin 0.0.1 demo.slash.install "Slash Install Plugin"
 
-run_plugins_openclaw_logged install-slash-plugin plugins install "$slash_install_dir" --force
+run_plugins_fixture_install_logged install-slash-plugin plugins install "$slash_install_dir" --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugin-command-install-show.json" plugins inspect slash-install-plugin --runtime --json
 node scripts/e2e/lib/plugins/assertions.mjs slash-install
 

--- a/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
+++ b/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
@@ -78,7 +78,7 @@ node scripts/e2e/lib/release-scenarios/write-marketplace.mjs \
 openclaw plugins marketplace list release-fixtures --json >/tmp/openclaw-release-plugin-marketplace-list.json
 node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains /tmp/openclaw-release-plugin-marketplace-list.json release-marketplace-plugin
 
-openclaw plugins install release-marketplace-plugin@release-fixtures --force >/tmp/openclaw-release-plugin-marketplace-install-plugin.log 2>&1
+openclaw plugins install release-marketplace-plugin@release-fixtures --force --accept-capabilities >/tmp/openclaw-release-plugin-marketplace-install-plugin.log 2>&1
 node "$marketplace_assertions" \
   assert-marketplace-state \
   release-marketplace-plugin \
@@ -111,7 +111,7 @@ node "$marketplace_assertions" \
   "$install_path_file"
 openclaw release-market ping >/tmp/openclaw-release-plugin-marketplace-cli-after-dry-run.log 2>&1
 node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains /tmp/openclaw-release-plugin-marketplace-cli-after-dry-run.log "release-marketplace-plugin:v1"
-openclaw plugins update release-marketplace-plugin >/tmp/openclaw-release-plugin-marketplace-update.log 2>&1
+openclaw plugins update release-marketplace-plugin --accept-capabilities >/tmp/openclaw-release-plugin-marketplace-update.log 2>&1
 node "$marketplace_assertions" \
   assert-update-log \
   /tmp/openclaw-release-plugin-marketplace-update.log \

--- a/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
+++ b/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
@@ -78,7 +78,7 @@ node scripts/e2e/lib/release-scenarios/write-marketplace.mjs \
 openclaw plugins marketplace list release-fixtures --json >/tmp/openclaw-release-plugin-marketplace-list.json
 node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains /tmp/openclaw-release-plugin-marketplace-list.json release-marketplace-plugin
 
-openclaw plugins install release-marketplace-plugin@release-fixtures --force --accept-capabilities >/tmp/openclaw-release-plugin-marketplace-install-plugin.log 2>&1
+openclaw_e2e_fixture_plugin_command openclaw -- plugins install release-marketplace-plugin@release-fixtures --force >/tmp/openclaw-release-plugin-marketplace-install-plugin.log 2>&1
 node "$marketplace_assertions" \
   assert-marketplace-state \
   release-marketplace-plugin \
@@ -111,7 +111,7 @@ node "$marketplace_assertions" \
   "$install_path_file"
 openclaw release-market ping >/tmp/openclaw-release-plugin-marketplace-cli-after-dry-run.log 2>&1
 node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains /tmp/openclaw-release-plugin-marketplace-cli-after-dry-run.log "release-marketplace-plugin:v1"
-openclaw plugins update release-marketplace-plugin --accept-capabilities >/tmp/openclaw-release-plugin-marketplace-update.log 2>&1
+openclaw_e2e_fixture_plugin_command openclaw -- plugins update release-marketplace-plugin >/tmp/openclaw-release-plugin-marketplace-update.log 2>&1
 node "$marketplace_assertions" \
   assert-update-log \
   /tmp/openclaw-release-plugin-marketplace-update.log \

--- a/scripts/e2e/lib/release-upgrade-user-journey/scenario.sh
+++ b/scripts/e2e/lib/release-upgrade-user-journey/scenario.sh
@@ -146,7 +146,7 @@ node scripts/e2e/lib/release-scenarios/write-cli-plugin.mjs \
   "Release Upgrade Plugin" \
   release-upgrade \
   "release-upgrade-plugin:pong"
-openclaw plugins install "$plugin_dir" --force >"$PLUGIN_INSTALL_LOG" 2>&1
+openclaw_e2e_fixture_plugin_command openclaw -- plugins install "$plugin_dir" --force >"$PLUGIN_INSTALL_LOG" 2>&1
 openclaw release-upgrade ping >"$PLUGIN_CLI_BEFORE_LOG" 2>&1
 node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains "$PLUGIN_CLI_BEFORE_LOG" "release-upgrade-plugin:pong"
 node scripts/e2e/lib/release-user-journey/assertions.mjs configure-clickclack "http://127.0.0.1:$CLICKCLACK_PORT"
@@ -170,7 +170,7 @@ node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains "$PLU
 
 clickclack_plugin_dir="$(mktemp -d "$scenario_tmp/clickclack-plugin.XXXXXX")"
 node scripts/e2e/lib/release-user-journey/write-clickclack-plugin.mjs "$clickclack_plugin_dir"
-openclaw plugins install "$clickclack_plugin_dir" --force --accept-capabilities >"$CLICKCLACK_PLUGIN_INSTALL_LOG" 2>&1
+openclaw_e2e_fixture_plugin_command openclaw -- plugins install "$clickclack_plugin_dir" --force >"$CLICKCLACK_PLUGIN_INSTALL_LOG" 2>&1
 
 openclaw channels status --json >"$STATUS_JSON" 2>"$STATUS_ERR"
 node scripts/e2e/lib/release-user-journey/assertions.mjs assert-channel-configured clickclack "$STATUS_JSON"

--- a/scripts/e2e/lib/release-upgrade-user-journey/scenario.sh
+++ b/scripts/e2e/lib/release-upgrade-user-journey/scenario.sh
@@ -170,7 +170,7 @@ node scripts/e2e/lib/release-scenarios/assertions.mjs assert-file-contains "$PLU
 
 clickclack_plugin_dir="$(mktemp -d "$scenario_tmp/clickclack-plugin.XXXXXX")"
 node scripts/e2e/lib/release-user-journey/write-clickclack-plugin.mjs "$clickclack_plugin_dir"
-openclaw plugins install "$clickclack_plugin_dir" --force >"$CLICKCLACK_PLUGIN_INSTALL_LOG" 2>&1
+openclaw plugins install "$clickclack_plugin_dir" --force --accept-capabilities >"$CLICKCLACK_PLUGIN_INSTALL_LOG" 2>&1
 
 openclaw channels status --json >"$STATUS_JSON" 2>"$STATUS_ERR"
 node scripts/e2e/lib/release-user-journey/assertions.mjs assert-channel-configured clickclack "$STATUS_JSON"

--- a/scripts/e2e/lib/release-user-journey/scenario.sh
+++ b/scripts/e2e/lib/release-user-journey/scenario.sh
@@ -192,7 +192,7 @@ plugin_a_dir="$(mktemp -d "$scenario_tmp/plugin-a.XXXXXX")"
 plugin_a_install_path_file="$PLUGIN_A_INSTALL_PATH_FILE"
 plugin_a_source_path_file="$PLUGIN_A_SOURCE_PATH_FILE"
 write_journey_plugin "$plugin_a_dir" journey-plugin-a 0.0.1 journey.a "Journey Plugin A" journey-a "journey-plugin-a:pong"
-openclaw plugins install "$plugin_a_dir" --force >"$PLUGIN_A_INSTALL_LOG" 2>&1
+openclaw plugins install "$plugin_a_dir" --force --accept-capabilities >"$PLUGIN_A_INSTALL_LOG" 2>&1
 node scripts/e2e/lib/release-user-journey/assertions.mjs \
   remember-plugin-install-path \
   journey-plugin-a \
@@ -213,14 +213,14 @@ node scripts/e2e/lib/release-user-journey/assertions.mjs \
 echo "Installing replacement external plugin..."
 plugin_b_dir="$(mktemp -d "$scenario_tmp/plugin-b.XXXXXX")"
 write_journey_plugin "$plugin_b_dir" journey-plugin-b 0.0.1 journey.b "Journey Plugin B" journey-b "journey-plugin-b:pong"
-openclaw plugins install "$plugin_b_dir" --force >"$PLUGIN_B_INSTALL_LOG" 2>&1
+openclaw plugins install "$plugin_b_dir" --force --accept-capabilities >"$PLUGIN_B_INSTALL_LOG" 2>&1
 openclaw journey-b ping >"$PLUGIN_B_CLI_LOG" 2>&1
 node scripts/e2e/lib/release-user-journey/assertions.mjs assert-file-contains "$PLUGIN_B_CLI_LOG" "journey-plugin-b:pong"
 
 echo "Installing ClickClack fixture plugin..."
 clickclack_plugin_dir="$(mktemp -d "$scenario_tmp/clickclack-plugin.XXXXXX")"
 node scripts/e2e/lib/release-user-journey/write-clickclack-plugin.mjs "$clickclack_plugin_dir"
-openclaw plugins install "$clickclack_plugin_dir" --force >"$CLICKCLACK_PLUGIN_INSTALL_LOG" 2>&1
+openclaw plugins install "$clickclack_plugin_dir" --force --accept-capabilities >"$CLICKCLACK_PLUGIN_INSTALL_LOG" 2>&1
 
 echo "Configuring ClickClack..."
 node scripts/e2e/lib/release-user-journey/assertions.mjs configure-clickclack "http://127.0.0.1:$CLICKCLACK_PORT"

--- a/scripts/e2e/lib/release-user-journey/scenario.sh
+++ b/scripts/e2e/lib/release-user-journey/scenario.sh
@@ -192,7 +192,7 @@ plugin_a_dir="$(mktemp -d "$scenario_tmp/plugin-a.XXXXXX")"
 plugin_a_install_path_file="$PLUGIN_A_INSTALL_PATH_FILE"
 plugin_a_source_path_file="$PLUGIN_A_SOURCE_PATH_FILE"
 write_journey_plugin "$plugin_a_dir" journey-plugin-a 0.0.1 journey.a "Journey Plugin A" journey-a "journey-plugin-a:pong"
-openclaw plugins install "$plugin_a_dir" --force --accept-capabilities >"$PLUGIN_A_INSTALL_LOG" 2>&1
+openclaw_e2e_fixture_plugin_command openclaw -- plugins install "$plugin_a_dir" --force >"$PLUGIN_A_INSTALL_LOG" 2>&1
 node scripts/e2e/lib/release-user-journey/assertions.mjs \
   remember-plugin-install-path \
   journey-plugin-a \
@@ -213,14 +213,14 @@ node scripts/e2e/lib/release-user-journey/assertions.mjs \
 echo "Installing replacement external plugin..."
 plugin_b_dir="$(mktemp -d "$scenario_tmp/plugin-b.XXXXXX")"
 write_journey_plugin "$plugin_b_dir" journey-plugin-b 0.0.1 journey.b "Journey Plugin B" journey-b "journey-plugin-b:pong"
-openclaw plugins install "$plugin_b_dir" --force --accept-capabilities >"$PLUGIN_B_INSTALL_LOG" 2>&1
+openclaw_e2e_fixture_plugin_command openclaw -- plugins install "$plugin_b_dir" --force >"$PLUGIN_B_INSTALL_LOG" 2>&1
 openclaw journey-b ping >"$PLUGIN_B_CLI_LOG" 2>&1
 node scripts/e2e/lib/release-user-journey/assertions.mjs assert-file-contains "$PLUGIN_B_CLI_LOG" "journey-plugin-b:pong"
 
 echo "Installing ClickClack fixture plugin..."
 clickclack_plugin_dir="$(mktemp -d "$scenario_tmp/clickclack-plugin.XXXXXX")"
 node scripts/e2e/lib/release-user-journey/write-clickclack-plugin.mjs "$clickclack_plugin_dir"
-openclaw plugins install "$clickclack_plugin_dir" --force --accept-capabilities >"$CLICKCLACK_PLUGIN_INSTALL_LOG" 2>&1
+openclaw_e2e_fixture_plugin_command openclaw -- plugins install "$clickclack_plugin_dir" --force >"$CLICKCLACK_PLUGIN_INSTALL_LOG" 2>&1
 
 echo "Configuring ClickClack..."
 node scripts/e2e/lib/release-user-journey/assertions.mjs configure-clickclack "http://127.0.0.1:$CLICKCLACK_PORT"

--- a/scripts/e2e/live-plugin-tool-docker.sh
+++ b/scripts/e2e/live-plugin-tool-docker.sh
@@ -165,7 +165,7 @@ fi
 plugin_tgz="${plugin_tgzs[0]}"
 
 echo "Installing fixture plugin from npm-pack: $plugin_tgz"
-openclaw plugins install "npm-pack:$plugin_tgz" --force >/tmp/openclaw-plugin-install.log 2>&1
+openclaw plugins install "npm-pack:$plugin_tgz" --force --accept-capabilities >/tmp/openclaw-plugin-install.log 2>&1
 node --disable-warning=ExperimentalWarning scripts/e2e/lib/live-plugin-tool/assertions.mjs configure
 openclaw plugins enable "$PLUGIN_ID" >/tmp/openclaw-plugin-enable.log 2>&1
 openclaw plugins list --json >/tmp/openclaw-plugins-list.json

--- a/scripts/e2e/live-plugin-tool-docker.sh
+++ b/scripts/e2e/live-plugin-tool-docker.sh
@@ -165,7 +165,7 @@ fi
 plugin_tgz="${plugin_tgzs[0]}"
 
 echo "Installing fixture plugin from npm-pack: $plugin_tgz"
-openclaw plugins install "npm-pack:$plugin_tgz" --force --accept-capabilities >/tmp/openclaw-plugin-install.log 2>&1
+openclaw_e2e_fixture_plugin_command openclaw -- plugins install "npm-pack:$plugin_tgz" --force >/tmp/openclaw-plugin-install.log 2>&1
 node --disable-warning=ExperimentalWarning scripts/e2e/lib/live-plugin-tool/assertions.mjs configure
 openclaw plugins enable "$PLUGIN_ID" >/tmp/openclaw-plugin-enable.log 2>&1
 openclaw plugins list --json >/tmp/openclaw-plugins-list.json

--- a/scripts/e2e/plugin-binding-command-escape-docker.sh
+++ b/scripts/e2e/plugin-binding-command-escape-docker.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 
 IMAGE_NAME="${OPENCLAW_PLUGIN_BINDING_COMMAND_ESCAPE_E2E_IMAGE:-openclaw-plugin-binding-command-escape-e2e}"
@@ -23,7 +24,7 @@ docker_e2e_build_or_reuse \
   "$IMAGE_NAME" \
   plugin-binding-command-escape \
   "$ROOT_DIR/scripts/e2e/plugin-binding-command-escape.Dockerfile" \
-  "$ROOT_DIR"
+  "$SOURCE_ROOT"
 
 echo "Running plugin binding command escape Docker E2E..."
 set +e

--- a/scripts/e2e/qr-import-docker.sh
+++ b/scripts/e2e/qr-import-docker.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}"
 source "$ROOT_DIR/scripts/lib/docker-build.sh"
 source "$ROOT_DIR/scripts/lib/docker-e2e-container.sh"
 IMAGE_NAME="${OPENCLAW_QR_SMOKE_IMAGE:-openclaw-qr-smoke}"
@@ -16,11 +17,12 @@ if [[ "${OPENCLAW_QR_SMOKE_FORCE_INSTALL:-0}" == "1" ]]; then
 fi
 
 echo "Building Docker image..."
+# Bash 3 treats an empty array as unset under nounset.
 docker_build_run qr-import-build \
-  "${DOCKER_BUILD_ARGS[@]}" \
+  ${DOCKER_BUILD_ARGS[@]+"${DOCKER_BUILD_ARGS[@]}"} \
   -t "$IMAGE_NAME" \
   -f "$ROOT_DIR/scripts/e2e/Dockerfile.qr-import" \
-  "$ROOT_DIR"
+  "$SOURCE_ROOT"
 
 echo "Running qrcode import smoke..."
 run_logged qr-import-run docker_e2e_docker_run_cmd run --rm -t "$IMAGE_NAME" node -e "import('qrcode').then(async (m)=>{const q=m.default??m;process.stdout.write(await q.toString('qr-smoke',{small:true,type:'terminal'}))})"

--- a/scripts/e2e/sandbox-browser-sidecar-docker.sh
+++ b/scripts/e2e/sandbox-browser-sidecar-docker.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOURCE_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 
 FUNCTIONAL_IMAGE="$(docker_e2e_resolve_image \
@@ -68,13 +69,13 @@ docker_e2e_build_or_reuse \
 
 docker_build_run sandbox-browser-sidecar-sandbox-build \
   -t "$SANDBOX_IMAGE" \
-  -f "$ROOT_DIR/scripts/docker/sandbox/Dockerfile" \
-  "$ROOT_DIR"
+  -f "$SOURCE_ROOT/scripts/docker/sandbox/Dockerfile" \
+  "$SOURCE_ROOT"
 
 docker_build_run sandbox-browser-sidecar-browser-build \
   -t "$BROWSER_IMAGE" \
-  -f "$ROOT_DIR/scripts/docker/sandbox/Dockerfile.browser" \
-  "$ROOT_DIR"
+  -f "$SOURCE_ROOT/scripts/docker/sandbox/Dockerfile.browser" \
+  "$SOURCE_ROOT"
 
 cat >"$BUILD_DIR/Dockerfile" <<'EOF'
 ARG BASE_IMAGE

--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -177,8 +177,10 @@ docker_e2e_prepare_package_tgz() {
   local pack_dir
   pack_dir="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-docker-e2e-pack.XXXXXX")"
   local pack_status=0
+  # ROOT_DIR can be a frozen candidate; resolve tooling beside this helper.
   package_tgz="$(
-    node "$ROOT_DIR/scripts/package-openclaw-for-docker.mjs" \
+    node "$DOCKER_E2E_PACKAGE_LIB_DIR/../package-openclaw-for-docker.mjs" \
+      --source-dir "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" \
       --allow-unreleased-changelog \
       --output-dir "$pack_dir" \
       --output-name openclaw-current.tgz

--- a/scripts/lib/docker-e2e-plan.mts
+++ b/scripts/lib/docker-e2e-plan.mts
@@ -51,7 +51,6 @@ type PublishedReleaseVersion = { year: number; month: number; patch: number };
 type UpgradeSurvivorExpansion = { lanes: DockerE2eLane[]; omittedLaneNames: string[] };
 type DockerE2ePlanOptions = {
   allowFrozenTargetScenarioOmissions?: boolean;
-  candidatePackageRoot?: string;
   includeOpenWebUI: boolean;
   liveMode: LiveMode;
   liveRetries: number;
@@ -566,69 +565,6 @@ function applyLiveRetries(poolLanes: DockerE2eLane[], retries: number): DockerE2
   return poolLanes.map((poolLane) => (poolLane.live ? { ...poolLane, retries } : poolLane));
 }
 
-const PNPM_NON_SCRIPT_COMMANDS = new Set([
-  "add",
-  "audit",
-  "config",
-  "dlx",
-  "exec",
-  "fetch",
-  "install",
-  "pack",
-  "publish",
-  "rebuild",
-  "remove",
-]);
-
-function candidatePackageScripts(
-  candidatePackageRoot: string | undefined,
-): Set<string> | undefined {
-  if (!candidatePackageRoot) {
-    return undefined;
-  }
-  const packageJson = JSON.parse(
-    readFileSync(resolve(candidatePackageRoot, "package.json"), "utf8"),
-  );
-  if (!packageJson || typeof packageJson !== "object" || Array.isArray(packageJson)) {
-    throw new Error("Candidate package manifest must be an object");
-  }
-  if (
-    packageJson.scripts !== undefined &&
-    (!packageJson.scripts ||
-      typeof packageJson.scripts !== "object" ||
-      Array.isArray(packageJson.scripts))
-  ) {
-    throw new Error("Candidate package manifest has an invalid scripts field");
-  }
-  return new Set(
-    Object.entries(packageJson.scripts ?? {})
-      .filter(([, command]) => typeof command === "string")
-      .map(([name]) => name),
-  );
-}
-
-function requiredPackageScripts(poolLane: DockerE2eLane): string[] {
-  return [...poolLane.command.matchAll(/\bpnpm\s+(?:run\s+)?([a-z][a-z0-9:-]*)/giu)]
-    .map(([, script]) => script)
-    .filter((script): script is string => script !== undefined)
-    .filter((script) => !PNPM_NON_SCRIPT_COMMANDS.has(script));
-}
-
-function filterUnavailableCandidateScriptLanes(
-  poolLanes: DockerE2eLane[],
-  candidatePackageRoot: string | undefined,
-): DockerE2eLane[] {
-  const scripts = candidatePackageScripts(candidatePackageRoot);
-  if (!scripts) {
-    return poolLanes;
-  }
-  // The trusted catalog can add lanes before a frozen candidate has their scripts.
-  // Only schedule package-script commands the selected candidate can execute.
-  return poolLanes.filter((poolLane) =>
-    requiredPackageScripts(poolLane).every((script) => scripts.has(script)),
-  );
-}
-
 export function laneWeight(poolLane: DockerE2eLane): number {
   return Math.max(1, poolLane.weight ?? 1);
 }
@@ -946,16 +882,8 @@ export function resolveDockerE2ePlan(options: DockerE2ePlanOptions) {
       : options.liveMode === "only"
         ? []
         : applyLiveMode(retriedTailLanes, options.liveMode);
-  const availableLanes = filterUnavailableCandidateScriptLanes(
-    configuredLanes,
-    options.candidatePackageRoot,
-  );
-  const availableTailLanes = filterUnavailableCandidateScriptLanes(
-    configuredTailLanes,
-    options.candidatePackageRoot,
-  );
-  const orderedLanes = options.orderLanes(availableLanes, options.timingStore);
-  const orderedTailLanes = options.orderLanes(availableTailLanes, options.timingStore);
+  const orderedLanes = options.orderLanes(configuredLanes, options.timingStore);
+  const orderedTailLanes = options.orderLanes(configuredTailLanes, options.timingStore);
   return {
     omittedUnsupportedLaneNames: [...omittedUnsupportedLaneNames],
     orderedLanes,

--- a/scripts/lib/docker-e2e-scenarios.mts
+++ b/scripts/lib/docker-e2e-scenarios.mts
@@ -80,7 +80,7 @@ const LIVE_RETRY_PATTERNS = [
   /ECONNRESET|ETIMEDOUT|ENOTFOUND/i,
 ];
 
-function liveDockerScriptCommand(
+export function liveDockerScriptCommand(
   script: string,
   envPrefix = "",
   options: { shellPrelude?: string; skipBuild?: boolean } = {},
@@ -538,11 +538,10 @@ export const mainLanes: DockerE2eLane[] = [
       weight: 3,
     },
   ),
-  serviceLane(
-    "gateway-concurrency",
-    "OPENCLAW_SKIP_DOCKER_BUILD=1 bash scripts/e2e/gateway-concurrency-docker.sh",
-    { timeoutMs: 10 * 60 * 1000, weight: 3 },
-  ),
+  serviceLane("gateway-concurrency", liveDockerScriptCommand("e2e/gateway-concurrency-docker.sh"), {
+    timeoutMs: 10 * 60 * 1000,
+    weight: 3,
+  }),
   serviceLane("gateway-network", "OPENCLAW_SKIP_DOCKER_BUILD=1 pnpm test:docker:gateway-network"),
   serviceLane("browser-cdp-snapshot", "pnpm test:docker:browser-cdp-snapshot", {
     stateScenario: "empty",

--- a/scripts/lib/openclaw-e2e-instance.sh
+++ b/scripts/lib/openclaw-e2e-instance.sh
@@ -526,6 +526,26 @@ openclaw_e2e_run_command() {
   local timeout_value="${OPENCLAW_E2E_COMMAND_TIMEOUT:-300s}"
   openclaw_e2e_maybe_timeout "$timeout_value" "$@"
 }
+openclaw_e2e_fixture_plugin_command() {
+  local runner=()
+  while [[ "${1:-}" != "--" && "$#" -gt 0 ]]; do
+    runner+=("$1")
+    shift
+  done
+  shift
+  local help consent
+  # Use the caller's bounded runner for both calls; never cache across package replacement.
+  help="$("${runner[@]}" "$1" "$2" --help)" || {
+    local probe_status=$?
+    printf '%s\nPlugin fixture help probe failed with status %s: %s %s\n' "$help" "$probe_status" "$1" "$2" >&2
+    return "$probe_status"
+  }
+  consent="$(printf '%s' "$help" | node scripts/e2e/lib/package-compat.mjs fixture-consent)" || return $?
+  if [[ -n "$consent" ]]; then
+    set -- "$@" "$consent"
+  fi
+  "${runner[@]}" "$@"
+}
 openclaw_e2e_enable_openclaw_cli_timeout() {
   OPENCLAW_E2E_CLI_BIN="$(type -P openclaw)"
   if [ -z "$OPENCLAW_E2E_CLI_BIN" ]; then

--- a/scripts/test-docker-all.mts
+++ b/scripts/test-docker-all.mts
@@ -30,7 +30,7 @@ import {
   parseProfile,
   resolveDockerE2ePlan,
 } from "./lib/docker-e2e-plan.mts";
-import type { DockerE2eLane } from "./lib/docker-e2e-scenarios.mts";
+import { liveDockerScriptCommand, type DockerE2eLane } from "./lib/docker-e2e-scenarios.mts";
 import {
   inspectManagedProcessGroup,
   terminateManagedChild,
@@ -45,10 +45,10 @@ import {
 
 const SCRIPT_ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ROOT_DIR = path.resolve(process.env.OPENCLAW_DOCKER_E2E_REPO_ROOT || SCRIPT_ROOT_DIR);
-const LIVE_DOCKER_DEFAULT_HARNESS_DIR =
-  path.basename(SCRIPT_ROOT_DIR) === ".release-harness" && ROOT_DIR !== SCRIPT_ROOT_DIR
-    ? ".release-harness"
-    : ".";
+const HARNESS_ROOT_DIR = path.resolve(
+  ROOT_DIR,
+  process.env.OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR || SCRIPT_ROOT_DIR,
+);
 const DEFAULT_FAILURE_TAIL_LINES = 80;
 const DEFAULT_LANE_TIMEOUT_MS = 120 * 60 * 1000;
 const DEFAULT_LANE_START_STAGGER_MS = 2_000;
@@ -554,6 +554,8 @@ export function buildLaneRerunCommand(name: string, baseEnv: NodeJS.ProcessEnv) 
     ["OPENCLAW_DOCKER_E2E_IMAGE", image || DEFAULT_E2E_FUNCTIONAL_IMAGE],
     ["OPENCLAW_DOCKER_E2E_BARE_IMAGE", baseEnv.OPENCLAW_DOCKER_E2E_BARE_IMAGE],
     ["OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE", baseEnv.OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE],
+    ["OPENCLAW_DOCKER_E2E_REPO_ROOT", baseEnv.OPENCLAW_DOCKER_E2E_REPO_ROOT],
+    ["OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR", baseEnv.OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR],
     ...CANDIDATE_ENV_KEYS.map((key) => [key, baseEnv[key]] as const),
     ...REGISTRY_ENV_KEYS.map((key) => [key, baseEnv[key]] as const),
     ["OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC", baseEnv.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC],
@@ -568,11 +570,19 @@ export function buildLaneRerunCommand(name: string, baseEnv: NodeJS.ProcessEnv) 
       (entry): entry is readonly [string, string] => entry[1] !== undefined && entry[1] !== "",
     )
     .map(([key, value]) => `${key}=${shellQuote(value)}`)
-    .join(" ")} pnpm test:docker:all`;
+    .join(" ")} ${prepareHarnessCommand("pnpm test:docker:all", baseEnv)}`;
 }
 
-function liveDockerHarnessScriptCommand(script: string) {
-  return `bash -c 'harness="\${OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR:-${LIVE_DOCKER_DEFAULT_HARNESS_DIR}}"; OPENCLAW_LIVE_DOCKER_REPO_ROOT="\${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$PWD}" bash "$harness/scripts/${script}"'`;
+function prepareHarnessCommand(command: string, env: NodeJS.ProcessEnv) {
+  const pinnedPnpm = env.OPENCLAW_DOCKER_ALL_PNPM_COMMAND?.trim();
+  const pnpm = pinnedPnpm ? shellQuote(pinnedPnpm) : "pnpm";
+  // Keep shell CWD on the candidate for relative inputs, but resolve test scripts
+  // from the trusted harness, including scripts absent from historical packages.
+  const directory = HARNESS_ROOT_DIR === ROOT_DIR ? "" : ` --dir ${shellQuote(HARNESS_ROOT_DIR)}`;
+  return command.replace(
+    /(^|\s)pnpm(?=\s)/g,
+    (_, prefix: string) => `${prefix}${pnpm}${directory}`,
+  );
 }
 
 async function loadTimingStore(file: string, enabled: boolean) {
@@ -1061,7 +1071,7 @@ export async function runCleanupSmokePhase(
   logDir: string,
   phases: Array<Record<string, unknown>>,
 ) {
-  const command = "pnpm test:docker:cleanup";
+  const command = prepareHarnessCommand("pnpm test:docker:cleanup", baseEnv);
   const logFile = path.join(logDir, `${CLEANUP_SMOKE_NAME}.log`);
   const startedAtMs = Date.now();
   let failure: LaneResult | undefined;
@@ -1212,7 +1222,7 @@ async function prepareOpenClawPackage(baseEnv: NodeJS.ProcessEnv, logDir: string
   const packageTgz = path.join(packDir, "openclaw-current.tgz");
   await runForeground(
     "Prepare OpenClaw package once",
-    `node ${shellQuote(path.join(ROOT_DIR, "scripts/package-openclaw-for-docker.mjs"))} --source-dir ${shellQuote(ROOT_DIR)} --allow-unreleased-changelog --output-dir ${shellQuote(packDir)} --output-name openclaw-current.tgz`,
+    `node ${shellQuote(path.join(HARNESS_ROOT_DIR, "scripts/package-openclaw-for-docker.mjs"))} --source-dir ${shellQuote(ROOT_DIR)} --allow-unreleased-changelog --output-dir ${shellQuote(packDir)} --output-name openclaw-current.tgz`,
     baseEnv,
   );
   await fs.promises.access(packageTgz);
@@ -1334,10 +1344,7 @@ async function runLane(
   const noOutputTimeoutMs = lane.noOutputTimeoutMs;
   const logFile = path.join(logDir, `${name}.log`);
   const env = laneEnv(lane, baseEnv, logDir, lane.cacheKey);
-  const pnpmCommand = env.OPENCLAW_DOCKER_ALL_PNPM_COMMAND?.trim();
-  const command = pnpmCommand
-    ? lane.command.replace(/(^|\s)pnpm(?=\s)/g, `$1${shellQuote(pnpmCommand)}`)
-    : lane.command;
+  const command = prepareHarnessCommand(lane.command, env);
   await mkdir(env.OPENCLAW_DOCKER_CLI_TOOLS_DIR, { recursive: true });
   await mkdir(env.OPENCLAW_DOCKER_CACHE_HOME_DIR, { recursive: true });
   await fs.promises.writeFile(
@@ -1350,6 +1357,8 @@ async function runLane(
       `==> [${name}] retries: ${lane.retries ?? 0}`,
       `==> [${name}] e2e image kind: ${lane.e2eImageKind ?? "none"}`,
       `==> [${name}] e2e image: ${env.OPENCLAW_DOCKER_E2E_IMAGE ?? ""}`,
+      `==> [${name}] trusted harness: ${HARNESS_ROOT_DIR}`,
+      `==> [${name}] candidate source: ${ROOT_DIR}`,
       "",
     ].join("\n"),
   );
@@ -1776,6 +1785,9 @@ async function main() {
   );
 
   const baseEnv = commandEnv({
+    OPENCLAW_DOCKER_E2E_REPO_ROOT: ROOT_DIR,
+    OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR: HARNESS_ROOT_DIR,
+    OPENCLAW_LIVE_DOCKER_REPO_ROOT: ROOT_DIR,
     OPENCLAW_DOCKER_E2E_BARE_IMAGE:
       process.env.OPENCLAW_DOCKER_E2E_BARE_IMAGE ||
       process.env.OPENCLAW_DOCKER_E2E_IMAGE ||
@@ -1809,7 +1821,6 @@ async function main() {
       upgradeSurvivorScenarios: process.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS,
       upgradeSurvivorTargetRoot: process.env.OPENCLAW_UPGRADE_SURVIVOR_TARGET_ROOT,
       allowFrozenTargetScenarioOmissions,
-      candidatePackageRoot: ROOT_DIR,
     });
   if (omittedUnsupportedLaneNames.length > 0 && !allowFrozenTargetScenarioOmissions) {
     throw new Error(
@@ -1962,7 +1973,7 @@ async function main() {
     const buildEntries: ForegroundEntry[] = [];
     if (scheduledLanes.some((poolLane) => poolLane.needsLiveImage)) {
       buildEntries.push({
-        command: liveDockerHarnessScriptCommand("test-live-build-docker.sh"),
+        command: liveDockerScriptCommand("test-live-build-docker.sh", "", { skipBuild: false }),
         label: "shared live-test image once",
         phaseDetails: { imageKind: "live" },
         phases,
@@ -1970,7 +1981,7 @@ async function main() {
     }
     if (lanesNeedE2eImageKind(scheduledLanes, "bare")) {
       buildEntries.push({
-        command: "pnpm test:docker:e2e-build",
+        command: prepareHarnessCommand("pnpm test:docker:e2e-build", baseEnv),
         env: {
           OPENCLAW_DOCKER_E2E_IMAGE: baseEnv.OPENCLAW_DOCKER_E2E_BARE_IMAGE,
           OPENCLAW_DOCKER_E2E_TARGET: "bare",
@@ -1982,7 +1993,7 @@ async function main() {
     }
     if (lanesNeedE2eImageKind(scheduledLanes, "functional")) {
       buildEntries.push({
-        command: "pnpm test:docker:e2e-build",
+        command: prepareHarnessCommand("pnpm test:docker:e2e-build", baseEnv),
         env: {
           OPENCLAW_DOCKER_E2E_IMAGE: baseEnv.OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE,
           OPENCLAW_DOCKER_E2E_TARGET: "functional",

--- a/scripts/test-docker-all.mts
+++ b/scripts/test-docker-all.mts
@@ -565,24 +565,33 @@ export function buildLaneRerunCommand(name: string, baseEnv: NodeJS.ProcessEnv) 
   if (baseEnv.OPENCLAW_DOCKER_ALL_PNPM_COMMAND) {
     env.push(["OPENCLAW_DOCKER_ALL_PNPM_COMMAND", baseEnv.OPENCLAW_DOCKER_ALL_PNPM_COMMAND]);
   }
-  return `${env
+  const envPrefix = env
     .filter(
       (entry): entry is readonly [string, string] => entry[1] !== undefined && entry[1] !== "",
     )
     .map(([key, value]) => `${key}=${shellQuote(value)}`)
-    .join(" ")} ${prepareHarnessCommand("pnpm test:docker:all", baseEnv)}`;
+    .join(" ");
+  return prepareHarnessCommand("pnpm test:docker:all", baseEnv, envPrefix);
 }
 
-function prepareHarnessCommand(command: string, env: NodeJS.ProcessEnv) {
+function prepareHarnessCommand(command: string, env: NodeJS.ProcessEnv, envPrefix = "") {
+  if (!/(^|\s)pnpm(?=\s)/.test(command)) {
+    return command;
+  }
   const pinnedPnpm = env.OPENCLAW_DOCKER_ALL_PNPM_COMMAND?.trim();
-  const pnpm = pinnedPnpm ? shellQuote(pinnedPnpm) : "pnpm";
-  // Keep shell CWD on the candidate for relative inputs, but resolve test scripts
-  // from the trusted harness, including scripts absent from historical packages.
-  const directory = HARNESS_ROOT_DIR === ROOT_DIR ? "" : ` --dir ${shellQuote(HARNESS_ROOT_DIR)}`;
-  return command.replace(
+  const executable = pinnedPnpm?.includes("/") ? path.resolve(ROOT_DIR, pinnedPnpm) : pinnedPnpm;
+  const invocation = command.replace(
     /(^|\s)pnpm(?=\s)/g,
-    (_, prefix: string) => `${prefix}${pnpm}${directory}`,
+    (_, prefix: string) => `${prefix}${executable ? shellQuote(executable) : "pnpm"}`,
   );
+  // Quoted environment values may themselves contain " pnpm ". Substitute only
+  // the catalog invocation, then add the already-quoted rerun assignments.
+  const prepared = envPrefix ? `${envPrefix} ${invocation}` : invocation;
+  // Corepack selects the package-manager pin before pnpm parses --dir. Enter
+  // the harness first; candidate paths have already been prepared as absolute.
+  return HARNESS_ROOT_DIR === ROOT_DIR
+    ? prepared
+    : `(cd ${shellQuote(HARNESS_ROOT_DIR)} && ${prepared})`;
 }
 
 async function loadTimingStore(file: string, enabled: boolean) {
@@ -1317,10 +1326,12 @@ function laneEnv(
   const cacheName = cacheKey || name;
   const env: DockerLaneEnv = {
     ...baseEnv,
-    OPENCLAW_DOCKER_CACHE_HOME_DIR:
+    OPENCLAW_DOCKER_CACHE_HOME_DIR: path.resolve(
       process.env.OPENCLAW_DOCKER_CACHE_HOME_DIR ?? path.join(logDir, `${cacheName}-cache`),
-    OPENCLAW_DOCKER_CLI_TOOLS_DIR:
+    ),
+    OPENCLAW_DOCKER_CLI_TOOLS_DIR: path.resolve(
       process.env.OPENCLAW_DOCKER_CLI_TOOLS_DIR ?? path.join(logDir, `${cacheName}-cli-tools`),
+    ),
   };
   env.OPENCLAW_DOCKER_ALL_LANE_NAME = name;
   const image = e2eImageForLane(poolLane, baseEnv);

--- a/test/scripts/docker-all-harness.test-support.ts
+++ b/test/scripts/docker-all-harness.test-support.ts
@@ -1,0 +1,42 @@
+import { copyFileSync, cpSync, mkdirSync } from "node:fs";
+import path from "node:path";
+
+export function copyDockerSchedulerHarness(root: string) {
+  const scriptsDir = path.join(root, "scripts");
+  const libDir = path.join(scriptsDir, "lib");
+  const upgradeSurvivorDir = path.join(scriptsDir, "e2e/lib/upgrade-survivor");
+  mkdirSync(libDir, { recursive: true });
+  mkdirSync(upgradeSurvivorDir, { recursive: true });
+  copyFileSync("package.json", path.join(root, "package.json"));
+  copyFileSync("scripts/test-docker-all.mjs", path.join(scriptsDir, "test-docker-all.mjs"));
+  copyFileSync("scripts/test-docker-all.mts", path.join(scriptsDir, "test-docker-all.mts"));
+  copyFileSync("scripts/lib/tsx-cli-shim.mjs", path.join(libDir, "tsx-cli-shim.mjs"));
+  copyFileSync("scripts/tsx.mjs", path.join(scriptsDir, "tsx.mjs"));
+  copyFileSync(
+    "scripts/prepublish-plugin-registry-artifact.mjs",
+    path.join(scriptsDir, "prepublish-plugin-registry-artifact.mjs"),
+  );
+  copyFileSync("scripts/windows-cmd-helpers.mjs", path.join(scriptsDir, "windows-cmd-helpers.mjs"));
+  for (const fileName of [
+    "docker-e2e-plan.mts",
+    "docker-e2e-scenarios.mts",
+    "local-check-runtime.mts",
+    "managed-child-process.mts",
+    "official-external-channel-catalog.json",
+    "release-version.mjs",
+    "sleep.mjs",
+    "windows-taskkill.mjs",
+  ]) {
+    copyFileSync(path.join("scripts/lib", fileName), path.join(libDir, fileName));
+  }
+  copyFileSync(
+    "scripts/e2e/lib/upgrade-survivor/config-recipe.mts",
+    path.join(upgradeSurvivorDir, "config-recipe.mts"),
+  );
+  cpSync(
+    "scripts/e2e/lib/upgrade-survivor/config-recipe",
+    path.join(upgradeSurvivorDir, "config-recipe"),
+    { recursive: true },
+  );
+  return scriptsDir;
+}

--- a/test/scripts/docker-all-harness.test.ts
+++ b/test/scripts/docker-all-harness.test.ts
@@ -23,18 +23,24 @@ function writeJson(file: string, value: unknown) {
   writeFileSync(file, JSON.stringify(value));
 }
 
-function setupFixture(mode: "split" | "override" | "local", missingTargetScript = false) {
+function setupFixture(
+  mode: "split" | "override" | "local",
+  missingTargetScript = false,
+  corepack = false,
+) {
   const artifactRoot = path.resolve(".artifacts");
   mkdirSync(artifactRoot, { recursive: true });
   const root = realpathSync(tempDirs.make("docker-harness-", artifactRoot));
-  const target = path.join(root, "frozen target");
+  const target = path.join(root, "frozen pnpm target");
   mkdirSync(target);
   const harness = mode === "local" ? target : path.join(target, ".release-harness");
-  const selectedHarness = mode === "override" ? path.join(root, "operator's $& harness") : harness;
+  const selectedHarness =
+    mode === "override" ? path.join(root, "operator's $& pnpm harness") : harness;
   copyDockerSchedulerHarness(harness);
   if (selectedHarness !== harness) mkdirSync(selectedHarness, { recursive: true });
   const marker = path.join(root, "calls.jsonl");
   const poison = path.join(root, "target-ran");
+  const toolchainMarker = path.join(root, "toolchains.jsonl");
   const version = "2026.8.1";
   const packageDir = path.join(root, "packed", "package");
   writeJson(path.join(packageDir, "package.json"), { name: "openclaw", version });
@@ -56,6 +62,8 @@ fs.appendFileSync(${JSON.stringify(marker)}, JSON.stringify({
   package: process.env.OPENCLAW_CURRENT_PACKAGE_TGZ,
   sha256: process.env.OPENCLAW_CURRENT_PACKAGE_SHA256,
   selectedSha: process.env.OPENCLAW_DOCKER_E2E_SELECTED_SHA,
+  cache: process.env.OPENCLAW_DOCKER_CACHE_HOME_DIR,
+  tools: process.env.OPENCLAW_DOCKER_CLI_TOOLS_DIR,
 }) + '\\n');
 `;
   const poisonedScript = `require('node:fs').writeFileSync(${JSON.stringify(poison)}, 'old harness'); process.exit(47);`;
@@ -79,6 +87,9 @@ fs.appendFileSync(${JSON.stringify(marker)}, JSON.stringify({
     writeJson(path.join(dir, "package.json"), {
       name: "openclaw",
       version,
+      ...(corepack && {
+        packageManager: dir === selectedHarness ? "pnpm@11.22.0" : "pnpm@12.0.0",
+      }),
       scripts:
         dir === target && missingTargetScript
           ? {}
@@ -86,6 +97,7 @@ fs.appendFileSync(${JSON.stringify(marker)}, JSON.stringify({
               "test:docker:gateway-network": "node marker.cjs",
               "test:docker:e2e-build": "node marker.cjs package-image",
               "test:docker:cleanup": "node marker.cjs cleanup",
+              "test:docker:all": `node ${quote(path.join(harness, "scripts/test-docker-all.mjs"))}`,
             },
     });
     // Keep pnpm in this miniature workspace, away from the host repo's toolchain pin.
@@ -124,8 +136,32 @@ fs.appendFileSync(${JSON.stringify(marker)}, JSON.stringify({
   });
   const registrySha256 = createHash("sha256").update(readFileSync(registryManifest)).digest("hex");
   const pnpm = execFileSync("bash", ["-c", "command -v pnpm"], { encoding: "utf8" }).trim();
-  const pinnedPnpm = path.join(root, "pinned '$& pnpm");
-  writeFileSync(pinnedPnpm, `#!/usr/bin/env bash\nexec ${quote(pnpm)} "$@"\n`);
+  const pinnedPnpm = path.join(root, "pinned '$& pnpm wrapper");
+  // Corepack Engine.executePackageManagerRequest resolves findProjectSpec(cwd)
+  // before runVersion forwards argv. pnpm then checks its effective project's pin.
+  // Model only that offline boundary; package scripts still execute as real children.
+  writeFileSync(
+    pinnedPnpm,
+    corepack
+      ? `#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+const manifest = (cwd) => JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf8'));
+const selected = manifest(process.cwd()).packageManager;
+const args = process.argv.slice(2);
+const cwd = args[0] === '--dir' ? args.splice(0, 2)[1] : process.cwd();
+const project = manifest(cwd);
+fs.appendFileSync(${JSON.stringify(toolchainMarker)}, JSON.stringify({ cwd: process.cwd(), selected, required: project.packageManager }) + '\\n');
+if (selected !== project.packageManager) {
+  console.error('ERR_PNPM_BAD_PM_VERSION: Corepack selected ' + selected + ' before --dir; project requires ' + project.packageManager);
+  process.exit(1);
+}
+const result = spawnSync(project.scripts[args[0]], { cwd, shell: true, stdio: 'inherit' });
+process.exit(result.status ?? 1);
+`
+      : `#!/usr/bin/env bash\nexec ${quote(pnpm)} "$@"\n`,
+  );
   chmodSync(pinnedPnpm, 0o755);
   return {
     root,
@@ -140,6 +176,7 @@ fs.appendFileSync(${JSON.stringify(marker)}, JSON.stringify({
     pinnedPnpm,
     registry,
     registrySha256,
+    toolchainMarker,
   };
 }
 
@@ -188,8 +225,14 @@ describe("Docker scheduler trusted harness execution", () => {
   posixIt.each(["split", "override", "local"] as const)(
     "executes current scripts with the frozen candidate in %s mode",
     (mode) => {
-      const fixture = setupFixture(mode);
-      const { result, logDir } = runFixture(fixture, mode);
+      const fixture = setupFixture(mode, false, true);
+      const { result, logDir } = runFixture(fixture, mode, laneNames, {
+        env: {
+          OPENCLAW_DOCKER_ALL_PNPM_COMMAND: path.relative(fixture.target, fixture.pinnedPnpm),
+          OPENCLAW_DOCKER_CACHE_HOME_DIR: "relative cache",
+          OPENCLAW_DOCKER_CLI_TOOLS_DIR: "relative tools",
+        },
+      });
       expect(result.status, result.stdout + result.stderr).toBe(0);
       expect(existsSync(fixture.poison)).toBe(false);
       const calls = readFileSync(fixture.marker, "utf8")
@@ -208,15 +251,57 @@ describe("Docker scheduler trusted harness execution", () => {
           registry: fixture.registry,
           registryVersion: "2026.8.1",
           registrySha256: fixture.registrySha256,
+          cache: path.join(fixture.target, "relative cache"),
+          tools: path.join(fixture.target, "relative tools"),
         });
       }
       expect(calls.find((call) => call.lane === "gateway-network").cwd).toBe(
         fixture.selectedHarness,
       );
       expect(calls.find((call) => call.lane === "live-models").cwd).toBe(fixture.target);
+      expect(calls.find((call) => call.lane === "gateway-concurrency").cwd).toBe(fixture.target);
       const summary = JSON.parse(readFileSync(path.join(logDir, "summary.json"), "utf8"));
       expect(summary.status).toBe("passed");
       expect(summary.lanes).toHaveLength(3);
+      expect(JSON.parse(readFileSync(fixture.toolchainMarker, "utf8").trim())).toEqual({
+        cwd: fixture.selectedHarness,
+        selected: "pnpm@11.22.0",
+        required: "pnpm@11.22.0",
+      });
+      if (mode === "override") {
+        const rerun = spawnSync(
+          "bash",
+          [
+            "-c",
+            summary.lanes.find((lane: { name: string }) => lane.name === "gateway-network")
+              .rerunCommand,
+          ],
+          {
+            cwd: fixture.target,
+            encoding: "utf8",
+            timeout: 30_000,
+            env: {
+              ...process.env,
+              OPENCLAW_DOCKER_ALL_LOG_DIR: path.join(fixture.root, "rerun logs"),
+              OPENCLAW_DOCKER_ALL_TIMINGS: "0",
+            },
+          },
+        );
+        expect(rerun.status, rerun.stdout + rerun.stderr).toBe(0);
+        const rerunCall = JSON.parse(
+          readFileSync(fixture.marker, "utf8").trim().split("\n").at(-1)!,
+        );
+        expect(rerunCall).toMatchObject({
+          lane: "gateway-network",
+          cwd: fixture.selectedHarness,
+          target: fixture.target,
+          package: fixture.tarball,
+          sha256: fixture.sha256,
+          selectedSha: fixture.selectedSha,
+          registry: fixture.registry,
+          registrySha256: fixture.registrySha256,
+        });
+      }
     },
   );
 

--- a/test/scripts/docker-all-harness.test.ts
+++ b/test/scripts/docker-all-harness.test.ts
@@ -1,0 +1,320 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { copyDockerSchedulerHarness } from "./docker-all-harness.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const posixIt = process.platform === "win32" ? it.skip : it;
+const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+const laneNames = ["gateway-network", "gateway-concurrency", "live-models"];
+
+function writeJson(file: string, value: unknown) {
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, JSON.stringify(value));
+}
+
+function setupFixture(mode: "split" | "override" | "local", missingTargetScript = false) {
+  const artifactRoot = path.resolve(".artifacts");
+  mkdirSync(artifactRoot, { recursive: true });
+  const root = realpathSync(tempDirs.make("docker-harness-", artifactRoot));
+  const target = path.join(root, "frozen target");
+  mkdirSync(target);
+  const harness = mode === "local" ? target : path.join(target, ".release-harness");
+  const selectedHarness = mode === "override" ? path.join(root, "operator's $& harness") : harness;
+  copyDockerSchedulerHarness(harness);
+  if (selectedHarness !== harness) mkdirSync(selectedHarness, { recursive: true });
+  const marker = path.join(root, "calls.jsonl");
+  const poison = path.join(root, "target-ran");
+  const version = "2026.8.1";
+  const packageDir = path.join(root, "packed", "package");
+  writeJson(path.join(packageDir, "package.json"), { name: "openclaw", version });
+  const tarball = path.join(root, "frozen candidate.tgz");
+  execFileSync("tar", ["-czf", tarball, "-C", path.dirname(packageDir), "package"]);
+  const sha256 = createHash("sha256").update(readFileSync(tarball)).digest("hex");
+  const trustedScript = `
+const fs = require('node:fs');
+fs.appendFileSync(${JSON.stringify(marker)}, JSON.stringify({
+  lane: process.env.OPENCLAW_DOCKER_ALL_LANE_NAME,
+  cwd: process.cwd(),
+  phase: process.argv[2],
+  registry: process.env.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR,
+  registryVersion: process.env.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION,
+  registrySha256: process.env.OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256,
+  target: process.env.OPENCLAW_DOCKER_E2E_REPO_ROOT,
+  harness: process.env.OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR,
+  liveTarget: process.env.OPENCLAW_LIVE_DOCKER_REPO_ROOT,
+  package: process.env.OPENCLAW_CURRENT_PACKAGE_TGZ,
+  sha256: process.env.OPENCLAW_CURRENT_PACKAGE_SHA256,
+  selectedSha: process.env.OPENCLAW_DOCKER_E2E_SELECTED_SHA,
+}) + '\\n');
+`;
+  const poisonedScript = `require('node:fs').writeFileSync(${JSON.stringify(poison)}, 'old harness'); process.exit(47);`;
+  for (const [dir, script] of [
+    [target, poisonedScript],
+    [selectedHarness, trustedScript],
+  ] as const) {
+    const scriptsDir = path.join(dir, "scripts");
+    mkdirSync(path.join(scriptsDir, "e2e"), { recursive: true });
+    writeFileSync(path.join(dir, "marker.cjs"), script);
+    for (const leaf of [
+      "e2e/gateway-concurrency-docker.sh",
+      "test-live-models-docker.sh",
+      "test-live-build-docker.sh",
+    ]) {
+      writeFileSync(
+        path.join(scriptsDir, leaf),
+        `#!/usr/bin/env bash\nexec node ${quote(path.join(dir, "marker.cjs"))} ${leaf === "test-live-build-docker.sh" ? "live-build" : ""}\n`,
+      );
+    }
+    writeJson(path.join(dir, "package.json"), {
+      name: "openclaw",
+      version,
+      scripts:
+        dir === target && missingTargetScript
+          ? {}
+          : {
+              "test:docker:gateway-network": "node marker.cjs",
+              "test:docker:e2e-build": "node marker.cjs package-image",
+              "test:docker:cleanup": "node marker.cjs cleanup",
+            },
+    });
+    // Keep pnpm in this miniature workspace, away from the host repo's toolchain pin.
+    writeFileSync(path.join(dir, "pnpm-workspace.yaml"), "packages: []\n");
+  }
+  execFileSync("git", ["init", "-q"], { cwd: target });
+  execFileSync("git", ["add", "package.json"], { cwd: target });
+  execFileSync(
+    "git",
+    ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "candidate"],
+    { cwd: target },
+  );
+  const selectedSha = execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: target,
+    encoding: "utf8",
+  }).trim();
+  const registry = path.join(root, "frozen registry");
+  mkdirSync(registry);
+  writeJson(path.join(packageDir, "package.json"), { name: "@openclaw/codex", version });
+  const pluginTarball = path.join(registry, "codex.tgz");
+  execFileSync("tar", ["-czf", pluginTarball, "-C", path.dirname(packageDir), "package"]);
+  const registryManifest = path.join(registry, "prepublish-plugin-registry.json");
+  writeJson(registryManifest, {
+    schema: "openclaw.prepublish-plugin-registry/v1",
+    schemaVersion: 1,
+    sourceSha: selectedSha,
+    candidateVersion: version,
+    packages: [
+      {
+        name: "@openclaw/codex",
+        version,
+        tarball: "codex.tgz",
+        sha256: createHash("sha256").update(readFileSync(pluginTarball)).digest("hex"),
+      },
+    ],
+  });
+  const registrySha256 = createHash("sha256").update(readFileSync(registryManifest)).digest("hex");
+  const pnpm = execFileSync("bash", ["-c", "command -v pnpm"], { encoding: "utf8" }).trim();
+  const pinnedPnpm = path.join(root, "pinned '$& pnpm");
+  writeFileSync(pinnedPnpm, `#!/usr/bin/env bash\nexec ${quote(pnpm)} "$@"\n`);
+  chmodSync(pinnedPnpm, 0o755);
+  return {
+    root,
+    target,
+    harness,
+    selectedHarness,
+    marker,
+    poison,
+    tarball,
+    sha256,
+    selectedSha,
+    pinnedPnpm,
+    registry,
+    registrySha256,
+  };
+}
+
+function runFixture(
+  fixture: ReturnType<typeof setupFixture>,
+  mode: string,
+  lanes = laneNames,
+  options: { args?: string[]; env?: NodeJS.ProcessEnv } = {},
+) {
+  const logDir = path.join(fixture.root, "logs");
+  const result = spawnSync(
+    process.execPath,
+    [path.join(fixture.harness, "scripts/test-docker-all.mjs"), ...(options.args ?? [])],
+    {
+      cwd: fixture.target,
+      encoding: "utf8",
+      timeout: 30_000,
+      env: {
+        ...process.env,
+        OPENCLAW_DOCKER_ALL_BUILD: "0",
+        OPENCLAW_DOCKER_ALL_PREFLIGHT: "0",
+        OPENCLAW_DOCKER_ALL_TIMINGS: "0",
+        OPENCLAW_DOCKER_ALL_START_STAGGER_MS: "0",
+        OPENCLAW_DOCKER_ALL_LIVE_RETRIES: "0",
+        OPENCLAW_DOCKER_ALL_LANES: lanes.join(","),
+        OPENCLAW_DOCKER_ALL_LOG_DIR: logDir,
+        OPENCLAW_DOCKER_ALL_PNPM_COMMAND: fixture.pinnedPnpm,
+        OPENCLAW_DOCKER_E2E_REPO_ROOT: mode === "local" ? "" : fixture.target,
+        OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR:
+          mode === "override" ? path.relative(fixture.target, fixture.selectedHarness) : "",
+        OPENCLAW_DOCKER_E2E_SELECTED_SHA: fixture.selectedSha,
+        OPENCLAW_CURRENT_PACKAGE_TGZ: fixture.tarball,
+        OPENCLAW_CURRENT_PACKAGE_VERSION: "2026.8.1",
+        OPENCLAW_CURRENT_PACKAGE_SHA256: fixture.sha256,
+        OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: fixture.registry,
+        OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_CANDIDATE_VERSION: "2026.8.1",
+        OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_MANIFEST_SHA256: fixture.registrySha256,
+        ...options.env,
+      },
+    },
+  );
+  return { result, logDir };
+}
+
+describe("Docker scheduler trusted harness execution", () => {
+  posixIt.each(["split", "override", "local"] as const)(
+    "executes current scripts with the frozen candidate in %s mode",
+    (mode) => {
+      const fixture = setupFixture(mode);
+      const { result, logDir } = runFixture(fixture, mode);
+      expect(result.status, result.stdout + result.stderr).toBe(0);
+      expect(existsSync(fixture.poison)).toBe(false);
+      const calls = readFileSync(fixture.marker, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(calls.map((call) => call.lane).sort()).toEqual([...laneNames].sort());
+      for (const call of calls) {
+        expect(call).toMatchObject({
+          target: fixture.target,
+          harness: fixture.selectedHarness,
+          liveTarget: fixture.target,
+          package: fixture.tarball,
+          sha256: fixture.sha256,
+          selectedSha: fixture.selectedSha,
+          registry: fixture.registry,
+          registryVersion: "2026.8.1",
+          registrySha256: fixture.registrySha256,
+        });
+      }
+      expect(calls.find((call) => call.lane === "gateway-network").cwd).toBe(
+        fixture.selectedHarness,
+      );
+      expect(calls.find((call) => call.lane === "live-models").cwd).toBe(fixture.target);
+      const summary = JSON.parse(readFileSync(path.join(logDir, "summary.json"), "utf8"));
+      expect(summary.status).toBe("passed");
+      expect(summary.lanes).toHaveLength(3);
+    },
+  );
+
+  posixIt("runs a trusted package script absent from the frozen target", () => {
+    const fixture = setupFixture("split", true);
+    const { result } = runFixture(fixture, "split", ["gateway-network"]);
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(existsSync(fixture.poison)).toBe(false);
+    expect(JSON.parse(readFileSync(fixture.marker, "utf8").trim()).lane).toBe("gateway-network");
+  });
+  posixIt("keeps preflight on the target while shared builds use trusted scripts", () => {
+    const fixture = setupFixture("split");
+    const bin = path.join(fixture.root, "bin");
+    mkdirSync(bin);
+    const dockerLog = path.join(fixture.root, "docker.jsonl");
+    const docker = path.join(bin, "docker");
+    writeFileSync(
+      docker,
+      `#!/usr/bin/env node
+import fs from 'node:fs';
+fs.appendFileSync(${JSON.stringify(dockerLog)}, JSON.stringify({ cwd: process.cwd(), args: process.argv.slice(2) }) + '\\n');
+console.log('fixture-docker');
+`,
+    );
+    chmodSync(docker, 0o755);
+    const { result } = runFixture(fixture, "split", laneNames, {
+      env: {
+        OPENCLAW_DOCKER_ALL_BUILD: "1",
+        OPENCLAW_DOCKER_ALL_PREFLIGHT: "1",
+        OPENCLAW_DOCKER_ALL_PREFLIGHT_CLEANUP: "0",
+        PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+      },
+    });
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    const dockerCalls = readFileSync(dockerLog, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(dockerCalls.map((call) => call.args[0])).toEqual(["version", "run"]);
+    expect(dockerCalls.every((call) => call.cwd === fixture.target)).toBe(true);
+    const builds = readFileSync(fixture.marker, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line))
+      .filter((call) => call.phase);
+    expect(builds).toEqual([
+      expect.objectContaining({
+        phase: "live-build",
+        cwd: fixture.target,
+        liveTarget: fixture.target,
+      }),
+      expect.objectContaining({
+        phase: "package-image",
+        cwd: fixture.selectedHarness,
+        target: fixture.target,
+        package: fixture.tarball,
+      }),
+    ]);
+  });
+
+  posixIt("prepares target bytes through the trusted packer before any Docker work", () => {
+    const fixture = setupFixture("split");
+    const packedMarker = path.join(fixture.root, "packed-source");
+    const targetPacker = path.join(fixture.target, "scripts/package-openclaw-for-docker.mjs");
+    writeFileSync(targetPacker, "process.exit(47);\n");
+    writeFileSync(
+      path.join(fixture.harness, "scripts/package-openclaw-for-docker.mjs"),
+      `
+import fs from 'node:fs'; import path from 'node:path';
+const value = (name) => process.argv[process.argv.indexOf(name) + 1];
+fs.writeFileSync(${JSON.stringify(packedMarker)}, value('--source-dir'));
+fs.mkdirSync(value('--output-dir'), { recursive: true });
+fs.copyFileSync(${JSON.stringify(fixture.tarball)}, path.join(value('--output-dir'), value('--output-name')));
+`,
+    );
+    execFileSync("git", ["add", "."], { cwd: fixture.target });
+    execFileSync(
+      "git",
+      [
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-qm",
+        "fixture packers",
+      ],
+      { cwd: fixture.target },
+    );
+    const manifestPath = path.join(fixture.root, "candidate.json");
+    const { result } = runFixture(fixture, "split", ["gateway-network"], {
+      args: [`--prepare-only=${manifestPath}`],
+    });
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(readFileSync(packedMarker, "utf8")).toBe(fixture.target);
+    expect(JSON.parse(readFileSync(manifestPath, "utf8"))).toMatchObject({
+      candidate: { package: { sha256: fixture.sha256, version: "2026.8.1" } },
+    });
+    expect(existsSync(fixture.marker)).toBe(false);
+  });
+});

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -4,7 +4,6 @@ import { createHash } from "node:crypto";
 import {
   chmodSync,
   copyFileSync,
-  cpSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -43,6 +42,7 @@ import {
   writeRunSummary,
 } from "../../scripts/test-docker-all.mts";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { copyDockerSchedulerHarness } from "./docker-all-harness.test-support.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createPrepublishPluginRegistryArtifact } = vi.hoisted(() => ({
@@ -228,6 +228,7 @@ function runCandidatePrep(fixture: ReturnType<typeof candidateFixture>) {
         OPENCLAW_DOCKER_ALL_LOG_DIR: path.join(fixture.root, "logs"),
         OPENCLAW_DOCKER_ALL_TIMINGS: "0",
         OPENCLAW_DOCKER_E2E_REPO_ROOT: fixture.root,
+        OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR: fixture.root,
       },
     },
   );
@@ -295,6 +296,45 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<voi
     await delay(5);
   }
   throw new Error("condition was not met before timeout");
+}
+
+async function runReadyTimedCommand<T>(
+  start: () => Promise<T>,
+  ready: () => boolean,
+  timeoutMs: number,
+): Promise<T> {
+  const scheduleTimeout = globalThis.setTimeout;
+  let fireDeadline = () => {};
+  let deadlineMs: number | undefined;
+  // Hold only the command deadline until real child handlers are ready. Kill
+  // grace and process-group cleanup continue to use real timers and signals.
+  const timerSpy = vi
+    .spyOn(globalThis, "setTimeout")
+    .mockImplementationOnce((callback, ms, ...args) => {
+      const timer = scheduleTimeout(callback, ms, ...args);
+      clearTimeout(timer);
+      deadlineMs = ms;
+      fireDeadline = () => {
+        fireDeadline = () => {};
+        callback(...args);
+      };
+      return timer;
+    });
+  let command: Promise<T>;
+  try {
+    command = start();
+  } finally {
+    timerSpy.mockRestore();
+  }
+  try {
+    expect(deadlineMs).toBe(timeoutMs);
+    await waitFor(ready);
+    fireDeadline();
+    return await command;
+  } finally {
+    fireDeadline();
+    await command;
+  }
 }
 
 async function waitForChildClose(child: ReturnType<typeof spawn>, timeoutMs = 5_000) {
@@ -607,45 +647,7 @@ describe("scripts/test-docker-all scheduler", () => {
     const artifactRoot = path.resolve(".artifacts");
     mkdirSync(artifactRoot, { recursive: true });
     const root = tempDirs.make("openclaw-docker-plan-isolated-harness-", artifactRoot);
-    const scriptsDir = path.join(root, "scripts");
-    const libDir = path.join(scriptsDir, "lib");
-    const upgradeSurvivorDir = path.join(scriptsDir, "e2e/lib/upgrade-survivor");
-    mkdirSync(libDir, { recursive: true });
-    mkdirSync(upgradeSurvivorDir, { recursive: true });
-    copyFileSync("package.json", path.join(root, "package.json"));
-    copyFileSync("scripts/test-docker-all.mjs", path.join(scriptsDir, "test-docker-all.mjs"));
-    copyFileSync("scripts/test-docker-all.mts", path.join(scriptsDir, "test-docker-all.mts"));
-    copyFileSync("scripts/lib/tsx-cli-shim.mjs", path.join(libDir, "tsx-cli-shim.mjs"));
-    copyFileSync("scripts/tsx.mjs", path.join(scriptsDir, "tsx.mjs"));
-    copyFileSync(
-      "scripts/prepublish-plugin-registry-artifact.mjs",
-      path.join(scriptsDir, "prepublish-plugin-registry-artifact.mjs"),
-    );
-    copyFileSync(
-      "scripts/windows-cmd-helpers.mjs",
-      path.join(scriptsDir, "windows-cmd-helpers.mjs"),
-    );
-    for (const fileName of [
-      "docker-e2e-plan.mts",
-      "docker-e2e-scenarios.mts",
-      "local-check-runtime.mts",
-      "managed-child-process.mts",
-      "official-external-channel-catalog.json",
-      "release-version.mjs",
-      "sleep.mjs",
-      "windows-taskkill.mjs",
-    ]) {
-      copyFileSync(path.join("scripts/lib", fileName), path.join(libDir, fileName));
-    }
-    copyFileSync(
-      "scripts/e2e/lib/upgrade-survivor/config-recipe.mts",
-      path.join(upgradeSurvivorDir, "config-recipe.mts"),
-    );
-    cpSync(
-      "scripts/e2e/lib/upgrade-survivor/config-recipe",
-      path.join(upgradeSurvivorDir, "config-recipe"),
-      { recursive: true },
-    );
+    const scriptsDir = copyDockerSchedulerHarness(root);
 
     const result = spawnSync(
       process.execPath,
@@ -1321,10 +1323,17 @@ postgres Created
   });
 
   posixIt("kills timed-out shell command groups when the leader exits first", async () => {
-    const root = mkdtempSync(path.join(tmpdir(), "openclaw-docker-all-timeout-"));
+    const root = createTempDir("openclaw-docker-all-timeout-");
     const scriptPath = path.join(root, "leader-exits.mjs");
     const grandchildPidPath = path.join(root, "grandchild.pid");
+    const readyPath = path.join(root, "ready");
     let grandchildPid = 0;
+    const childScript = [
+      "const fs = require('node:fs');",
+      "process.on('SIGTERM', () => {});",
+      `fs.writeFileSync(${JSON.stringify(readyPath)}, 'ready');`,
+      "setInterval(() => {}, 1000);",
+    ].join("\n");
 
     writeFileSync(
       scriptPath,
@@ -1332,93 +1341,71 @@ postgres Created
 import { spawn } from "node:child_process";
 import fs from "node:fs";
 
-const grandchild = spawn(process.execPath, [
-  "-e",
-  "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
-], { stdio: "ignore" });
-fs.writeFileSync(process.argv[2], String(grandchild.pid));
+const grandchild = spawn(process.execPath, ["-e", ${JSON.stringify(childScript)}], { stdio: "ignore" });
 process.on("SIGTERM", () => process.exit(0));
+fs.writeFileSync(process.argv[2], String(grandchild.pid));
 setInterval(() => {}, 1000);
 `,
       "utf8",
     );
 
     try {
-      const runPromise = runShellCommand({
-        command: `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(
-          scriptPath,
-        )} ${JSON.stringify(grandchildPidPath)}`,
-        env: process.env,
-        label: "timeout-leader-exits",
-        timeoutKillGraceMs: 25,
-        timeoutMs: 250,
-      });
+      const result = await runReadyTimedCommand(
+        () =>
+          runShellCommand({
+            command: `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)} ${JSON.stringify(grandchildPidPath)}`,
+            env: process.env,
+            label: "timeout-leader-exits",
+            timeoutKillGraceMs: 25,
+            timeoutMs: 250,
+          }),
+        () => {
+          grandchildPid = readCompletePidFile(grandchildPidPath) ?? 0;
+          if (!grandchildPid || !existsSync(readyPath)) {
+            return false;
+          }
+          expect(isProcessAlive(grandchildPid)).toBe(true);
+          return true;
+        },
+        250,
+      );
 
-      await waitFor(() => {
-        grandchildPid = readCompletePidFile(grandchildPidPath) ?? 0;
-        return grandchildPid > 0;
-      });
-      expect(isProcessAlive(grandchildPid)).toBe(true);
-
-      await expect(runPromise).resolves.toMatchObject({ timedOut: true });
+      expect(result).toMatchObject({ timedOut: true });
       await waitFor(() => !isProcessAlive(grandchildPid));
     } finally {
       if (grandchildPid && isProcessAlive(grandchildPid)) {
         process.kill(grandchildPid, "SIGKILL");
       }
-      rmSync(root, { force: true, recursive: true });
     }
   });
 
-  posixIt("clamps oversized shell command kill grace before scheduling", async () => {
-    const root = createTempDir("openclaw-docker-all-oversized-grace-");
-    const scriptPath = path.join(root, "leader-exits.mjs");
-    const donePath = path.join(root, "done");
-    const readyPath = path.join(root, "ready");
-    const childScript = [
-      "const fs = require('node:fs');",
-      `fs.writeFileSync(${JSON.stringify(readyPath)}, 'ready');`,
-      "process.on('SIGTERM', () => {",
-      `  setTimeout(() => { fs.writeFileSync(${JSON.stringify(donePath)}, 'done'); process.exit(0); }, 75);`,
-      "});",
-      "setInterval(() => {}, 1000);",
-    ].join("\n");
-
-    writeFileSync(
-      scriptPath,
-      `
-import { spawn } from "node:child_process";
-
-spawn(process.execPath, ["-e", ${JSON.stringify(childScript)}], { stdio: "ignore" });
-process.on("SIGTERM", () => process.exit(0));
-setInterval(() => {}, 1000);
-`,
-      "utf8",
-    );
-
-    const result = await runShellCommand({
-      command: `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)}`,
-      env: process.env,
-      label: "oversized-timeout-grace",
-      timeoutKillGraceMs: Number.MAX_SAFE_INTEGER,
-      timeoutMs: 500,
-    });
-
-    expect(result).toMatchObject({ timedOut: true });
-    expect(readFileSync(donePath, "utf8")).toBe("done");
-  });
-
-  posixIt("lets timed-out shell command descendants exit during kill grace", async () => {
+  posixIt.each([
+    {
+      title: "clamps oversized shell command kill grace before scheduling",
+      run: runShellCommand,
+      grace: Number.MAX_SAFE_INTEGER,
+    },
+    {
+      title: "lets timed-out shell command descendants exit during kill grace",
+      run: runShellCommand,
+      grace: 500,
+    },
+    {
+      title: "lets timed-out shell capture descendants exit during kill grace",
+      run: runShellCaptureCommand,
+      grace: 500,
+    },
+  ])("$title", async ({ run, grace }) => {
     const root = createTempDir("openclaw-docker-all-grace-");
     const scriptPath = path.join(root, "leader-exits.mjs");
     const donePath = path.join(root, "done");
     const readyPath = path.join(root, "ready");
     const childScript = [
       "const fs = require('node:fs');",
-      `fs.writeFileSync(${JSON.stringify(readyPath)}, 'ready');`,
       "process.on('SIGTERM', () => {",
       `  setTimeout(() => { fs.writeFileSync(${JSON.stringify(donePath)}, 'done'); process.exit(0); }, 75);`,
       "});",
+      `fs.writeFileSync(${JSON.stringify(readyPath)}, 'ready');`,
       "setInterval(() => {}, 1000);",
     ].join("\n");
 
@@ -1434,56 +1421,18 @@ setInterval(() => {}, 1000);
       "utf8",
     );
 
-    const runPromise = runShellCommand({
-      command: `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)}`,
-      env: process.env,
-      label: "timeout-grace",
-      timeoutKillGraceMs: 500,
-      timeoutMs: 500,
-    });
-
-    await waitFor(() => existsSync(readyPath));
-    const result = await runPromise;
-    expect(result).toMatchObject({ timedOut: true });
-    expect(readFileSync(donePath, "utf8")).toBe("done");
-  });
-
-  posixIt("lets timed-out shell capture descendants exit during kill grace", async () => {
-    const root = createTempDir("openclaw-docker-all-capture-grace-");
-    const scriptPath = path.join(root, "leader-exits.mjs");
-    const donePath = path.join(root, "done");
-    const readyPath = path.join(root, "ready");
-    const childScript = [
-      "const fs = require('node:fs');",
-      `fs.writeFileSync(${JSON.stringify(readyPath)}, 'ready');`,
-      "process.on('SIGTERM', () => {",
-      `  setTimeout(() => { fs.writeFileSync(${JSON.stringify(donePath)}, 'done'); process.exit(0); }, 75);`,
-      "});",
-      "setInterval(() => {}, 1000);",
-    ].join("\n");
-
-    writeFileSync(
-      scriptPath,
-      `
-import { spawn } from "node:child_process";
-
-spawn(process.execPath, ["-e", ${JSON.stringify(childScript)}], { stdio: "ignore" });
-process.on("SIGTERM", () => process.exit(0));
-setInterval(() => {}, 1000);
-`,
-      "utf8",
+    const result = await runReadyTimedCommand(
+      async () =>
+        run({
+          command: `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)}`,
+          env: process.env,
+          label: "timeout-grace",
+          timeoutKillGraceMs: grace,
+          timeoutMs: 500,
+        }),
+      () => existsSync(readyPath),
+      500,
     );
-
-    const runPromise = runShellCaptureCommand({
-      command: `exec ${JSON.stringify(process.execPath)} ${JSON.stringify(scriptPath)}`,
-      env: process.env,
-      label: "capture-timeout-grace",
-      timeoutKillGraceMs: 500,
-      timeoutMs: 500,
-    });
-
-    await waitFor(() => existsSync(readyPath));
-    const result = await runPromise;
     expect(result).toMatchObject({ timedOut: true });
     expect(readFileSync(donePath, "utf8")).toBe("done");
   });

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -94,15 +94,11 @@ const UPDATE_CHANNEL_SWITCH_ASSERTIONS_PATH =
   "scripts/e2e/lib/update-channel-switch/assertions.mjs";
 const RELEASE_UPGRADE_USER_JOURNEY_SCENARIO_PATH =
   "scripts/e2e/lib/release-upgrade-user-journey/scenario.sh";
-const RELEASE_PLUGIN_MARKETPLACE_SCENARIO_PATH =
-  "scripts/e2e/lib/release-plugin-marketplace/scenario.sh";
 const RELEASE_TYPED_ONBOARDING_SCENARIO_PATH =
   "scripts/e2e/lib/release-typed-onboarding/scenario.sh";
 const RELEASE_USER_JOURNEY_DOCKER_E2E_PATH = "scripts/e2e/release-user-journey-docker.sh";
 const RELEASE_USER_JOURNEY_SCENARIO_PATH = "scripts/e2e/lib/release-user-journey/scenario.sh";
 const UPGRADE_SURVIVOR_RUN_SCRIPT = "scripts/e2e/lib/upgrade-survivor/run.sh";
-const UPGRADE_SURVIVOR_PACKAGE_SELF_UPGRADE_PATH =
-  "scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh";
 const UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH =
   "scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh";
 const UPGRADE_SURVIVOR_CONFIG_PARKING_PATH = "scripts/e2e/lib/upgrade-survivor/config-parking.mjs";
@@ -2750,7 +2746,7 @@ docker_e2e_docker_run_cmd run demo
       UPDATE_CHANNEL_SWITCH_DOCKER_E2E_PATH,
       RELEASE_UPGRADE_USER_JOURNEY_SCENARIO_PATH,
       "scripts/e2e/lib/release-media-memory/scenario.sh",
-      RELEASE_PLUGIN_MARKETPLACE_SCENARIO_PATH,
+      "scripts/e2e/lib/release-plugin-marketplace/scenario.sh",
       "scripts/e2e/lib/release-typed-onboarding/scenario.sh",
       "scripts/e2e/lib/release-user-journey/scenario.sh",
     ];
@@ -2762,90 +2758,6 @@ docker_e2e_docker_run_cmd run demo
     }
     expect(readFileSync(RELEASE_UPGRADE_USER_JOURNEY_SCENARIO_PATH, "utf8")).toContain(
       'openclaw_e2e_run_command node "$baseline_entry" onboard',
-    );
-  });
-
-  it("accepts capabilities for trusted fixture installs without breaking old CLIs", () => {
-    const currentCliInstalls = [
-      [
-        CODEX_MEDIA_PATH_SCENARIO_PATH,
-        'openclaw plugins install "$PLUGIN_SPEC" --force --accept-capabilities',
-      ],
-      [
-        "scripts/e2e/kitchen-sink-rpc-walk.mts",
-        '["plugins", "install", PLUGIN_SPEC, "--force", "--accept-capabilities"]',
-      ],
-      [
-        RELEASE_PLUGIN_MARKETPLACE_SCENARIO_PATH,
-        "openclaw plugins install release-marketplace-plugin@release-fixtures --force --accept-capabilities",
-      ],
-      [
-        RELEASE_PLUGIN_MARKETPLACE_SCENARIO_PATH,
-        "openclaw plugins update release-marketplace-plugin --accept-capabilities",
-      ],
-      [
-        RELEASE_USER_JOURNEY_SCENARIO_PATH,
-        'openclaw plugins install "$plugin_a_dir" --force --accept-capabilities',
-      ],
-      [
-        RELEASE_USER_JOURNEY_SCENARIO_PATH,
-        'openclaw plugins install "$plugin_b_dir" --force --accept-capabilities',
-      ],
-      [
-        RELEASE_USER_JOURNEY_SCENARIO_PATH,
-        'openclaw plugins install "$clickclack_plugin_dir" --force --accept-capabilities',
-      ],
-      [
-        RELEASE_UPGRADE_USER_JOURNEY_SCENARIO_PATH,
-        'openclaw plugins install "$clickclack_plugin_dir" --force --accept-capabilities',
-      ],
-      [
-        LIVE_PLUGIN_TOOL_DOCKER_E2E_PATH,
-        'openclaw plugins install "npm-pack:$plugin_tgz" --force --accept-capabilities',
-      ],
-    ] as const;
-
-    for (const [path, command] of currentCliInstalls) {
-      expect(readFileSync(path, "utf8"), path).toContain(command);
-    }
-
-    const releaseMarketplace = readFileSync(RELEASE_PLUGIN_MARKETPLACE_SCENARIO_PATH, "utf8");
-    expect(releaseMarketplace).toContain(
-      "openclaw plugins update release-marketplace-plugin --dry-run",
-    );
-    expect(releaseMarketplace).not.toContain(
-      "openclaw plugins update release-marketplace-plugin --dry-run --accept-capabilities",
-    );
-
-    const codexNpmPlugin = readFileSync(CODEX_NPM_PLUGIN_LIVE_DOCKER_E2E_PATH, "utf8");
-    expectTextToIncludeAll(codexNpmPlugin, [
-      'PLUGIN_INSTALL_HELP_LOG="/tmp/openclaw-codex-plugin-install-help.log"',
-      'openclaw plugins install --help 2>&1 | head -c 65536 >"$PLUGIN_INSTALL_HELP_LOG" || true',
-      'grep -q -- "--accept-capabilities" "$PLUGIN_INSTALL_HELP_LOG"',
-      "PLUGIN_INSTALL_FLAGS+=(--accept-capabilities)",
-      "PLUGIN_INSTALL_FLAGS+=(--dangerously-force-unsafe-install)",
-    ]);
-    expect(codexNpmPlugin).not.toContain("install --help 2>&1 | grep -q");
-
-    const releaseUpgrade = readFileSync(RELEASE_UPGRADE_USER_JOURNEY_SCENARIO_PATH, "utf8");
-    expect(releaseUpgrade).toContain(
-      'openclaw plugins install "$plugin_dir" --force >"$PLUGIN_INSTALL_LOG" 2>&1',
-    );
-    expect(releaseUpgrade).not.toContain(
-      'openclaw plugins install "$plugin_dir" --force --accept-capabilities',
-    );
-    const corruptUpdate = readFileSync(PLUGIN_UPDATE_CORRUPT_SCENARIO_PATH, "utf8");
-    expect(corruptUpdate).toContain(
-      'plugins install "npm:@openclaw/demo-corrupt-plugin@0.0.1" --force',
-    );
-    expect(corruptUpdate).not.toContain(
-      'plugins install "npm:@openclaw/demo-corrupt-plugin@0.0.1" --force --accept-capabilities',
-    );
-
-    const packageSelfUpgrade = readFileSync(UPGRADE_SURVIVOR_PACKAGE_SELF_UPGRADE_PATH, "utf8");
-    expect(packageSelfUpgrade).toContain('openclaw plugins install "$qa_plugin_source" --link');
-    expect(packageSelfUpgrade).not.toContain(
-      'openclaw plugins install "$qa_plugin_source" --link --accept-capabilities',
     );
   });
 
@@ -4827,7 +4739,6 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
       'KITCHEN_SINK_CLI_TIMEOUT="${KITCHEN_SINK_CLI_TIMEOUT:-180s}"',
       "run_kitchen_sink_openclaw_logged()",
       "run_kitchen_sink_openclaw_capture()",
-      'openclaw_e2e_maybe_timeout "$KITCHEN_SINK_CLI_TIMEOUT" node "$OPENCLAW_ENTRY" "$@" >"$log_file" 2>&1',
       'local log_file="${KITCHEN_SINK_TMP_DIR}/${safe_label}.log"',
     ]);
 
@@ -5951,7 +5862,6 @@ done
       'openclaw_e2e_maybe_timeout "$OPENCLAW_PLUGINS_CLI_TIMEOUT" node "$OPENCLAW_ENTRY" "$@" >"$output_file"',
       "plugins_lifecycle_trace_enabled()",
       "print_plugins_stderr_log()",
-      'openclaw_e2e_maybe_timeout "$OPENCLAW_PLUGINS_CLI_TIMEOUT" node "$OPENCLAW_ENTRY" "$@" >"$output_file" 2>"$error_file"',
       "Plugin sweep command timed out after %s: %s",
       "Plugin sweep command failed with status %s: %s",
       "Plugin sweep capture timed out after %s: %s",
@@ -6001,7 +5911,6 @@ done
     expectTextToIncludeAll(clawhub, [
       'plugins install "$CLAWHUB_PLUGIN_SPEC"',
       'plugins update "$CLAWHUB_PLUGIN_ID"',
-      "run_plugins_fixture_install_logged install-clawhub",
       'openclaw_e2e_maybe_timeout "$OPENCLAW_PLUGINS_CLI_TIMEOUT"',
       "clawhub:@openclaw/kitchen-sink",
     ]);

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5031,10 +5031,6 @@ done
     expect(scheduler).toContain("path.dirname(process.execPath)");
     expect(scheduler).toContain("env.PATH = [...new Set(pathEntries)].join(path.delimiter)");
     expect(scheduler).toContain(
-      "const pnpmCommand = env.OPENCLAW_DOCKER_ALL_PNPM_COMMAND?.trim();",
-    );
-    expect(scheduler).toContain("lane.command.replace(/(^|\\s)pnpm(?=\\s)/g");
-    expect(scheduler).toContain(
       'env.push(["OPENCLAW_DOCKER_ALL_PNPM_COMMAND", baseEnv.OPENCLAW_DOCKER_ALL_PNPM_COMMAND]);',
     );
   });

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1409,7 +1409,7 @@ stderr="$(<"$TMPDIR/stderr")"
 node() {
   local script="$1"
   shift
-  if [[ "$script" != "$ROOT_DIR/scripts/package-openclaw-for-docker.mjs" ]]; then
+  if [[ "$script" != "$DOCKER_E2E_PACKAGE_LIB_DIR/../package-openclaw-for-docker.mjs" ]]; then
     command node "$script" "$@"
     return
   fi
@@ -1552,7 +1552,7 @@ export PATH="$TMPDIR/bin:$PATH"
 node() {
   local script="$1"
   shift
-  if [[ "$script" != "$ROOT_DIR/scripts/package-openclaw-for-docker.mjs" ]]; then
+  if [[ "$script" != "$DOCKER_E2E_PACKAGE_LIB_DIR/../package-openclaw-for-docker.mjs" ]]; then
     command node "$script" "$@"
     return
   fi

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -94,11 +94,15 @@ const UPDATE_CHANNEL_SWITCH_ASSERTIONS_PATH =
   "scripts/e2e/lib/update-channel-switch/assertions.mjs";
 const RELEASE_UPGRADE_USER_JOURNEY_SCENARIO_PATH =
   "scripts/e2e/lib/release-upgrade-user-journey/scenario.sh";
+const RELEASE_PLUGIN_MARKETPLACE_SCENARIO_PATH =
+  "scripts/e2e/lib/release-plugin-marketplace/scenario.sh";
 const RELEASE_TYPED_ONBOARDING_SCENARIO_PATH =
   "scripts/e2e/lib/release-typed-onboarding/scenario.sh";
 const RELEASE_USER_JOURNEY_DOCKER_E2E_PATH = "scripts/e2e/release-user-journey-docker.sh";
 const RELEASE_USER_JOURNEY_SCENARIO_PATH = "scripts/e2e/lib/release-user-journey/scenario.sh";
 const UPGRADE_SURVIVOR_RUN_SCRIPT = "scripts/e2e/lib/upgrade-survivor/run.sh";
+const UPGRADE_SURVIVOR_PACKAGE_SELF_UPGRADE_PATH =
+  "scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh";
 const UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH =
   "scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh";
 const UPGRADE_SURVIVOR_CONFIG_PARKING_PATH = "scripts/e2e/lib/upgrade-survivor/config-parking.mjs";
@@ -2746,7 +2750,7 @@ docker_e2e_docker_run_cmd run demo
       UPDATE_CHANNEL_SWITCH_DOCKER_E2E_PATH,
       RELEASE_UPGRADE_USER_JOURNEY_SCENARIO_PATH,
       "scripts/e2e/lib/release-media-memory/scenario.sh",
-      "scripts/e2e/lib/release-plugin-marketplace/scenario.sh",
+      RELEASE_PLUGIN_MARKETPLACE_SCENARIO_PATH,
       "scripts/e2e/lib/release-typed-onboarding/scenario.sh",
       "scripts/e2e/lib/release-user-journey/scenario.sh",
     ];
@@ -2758,6 +2762,90 @@ docker_e2e_docker_run_cmd run demo
     }
     expect(readFileSync(RELEASE_UPGRADE_USER_JOURNEY_SCENARIO_PATH, "utf8")).toContain(
       'openclaw_e2e_run_command node "$baseline_entry" onboard',
+    );
+  });
+
+  it("accepts capabilities for trusted fixture installs without breaking old CLIs", () => {
+    const currentCliInstalls = [
+      [
+        CODEX_MEDIA_PATH_SCENARIO_PATH,
+        'openclaw plugins install "$PLUGIN_SPEC" --force --accept-capabilities',
+      ],
+      [
+        "scripts/e2e/kitchen-sink-rpc-walk.mts",
+        '["plugins", "install", PLUGIN_SPEC, "--force", "--accept-capabilities"]',
+      ],
+      [
+        RELEASE_PLUGIN_MARKETPLACE_SCENARIO_PATH,
+        "openclaw plugins install release-marketplace-plugin@release-fixtures --force --accept-capabilities",
+      ],
+      [
+        RELEASE_PLUGIN_MARKETPLACE_SCENARIO_PATH,
+        "openclaw plugins update release-marketplace-plugin --accept-capabilities",
+      ],
+      [
+        RELEASE_USER_JOURNEY_SCENARIO_PATH,
+        'openclaw plugins install "$plugin_a_dir" --force --accept-capabilities',
+      ],
+      [
+        RELEASE_USER_JOURNEY_SCENARIO_PATH,
+        'openclaw plugins install "$plugin_b_dir" --force --accept-capabilities',
+      ],
+      [
+        RELEASE_USER_JOURNEY_SCENARIO_PATH,
+        'openclaw plugins install "$clickclack_plugin_dir" --force --accept-capabilities',
+      ],
+      [
+        RELEASE_UPGRADE_USER_JOURNEY_SCENARIO_PATH,
+        'openclaw plugins install "$clickclack_plugin_dir" --force --accept-capabilities',
+      ],
+      [
+        LIVE_PLUGIN_TOOL_DOCKER_E2E_PATH,
+        'openclaw plugins install "npm-pack:$plugin_tgz" --force --accept-capabilities',
+      ],
+    ] as const;
+
+    for (const [path, command] of currentCliInstalls) {
+      expect(readFileSync(path, "utf8"), path).toContain(command);
+    }
+
+    const releaseMarketplace = readFileSync(RELEASE_PLUGIN_MARKETPLACE_SCENARIO_PATH, "utf8");
+    expect(releaseMarketplace).toContain(
+      "openclaw plugins update release-marketplace-plugin --dry-run",
+    );
+    expect(releaseMarketplace).not.toContain(
+      "openclaw plugins update release-marketplace-plugin --dry-run --accept-capabilities",
+    );
+
+    const codexNpmPlugin = readFileSync(CODEX_NPM_PLUGIN_LIVE_DOCKER_E2E_PATH, "utf8");
+    expectTextToIncludeAll(codexNpmPlugin, [
+      'PLUGIN_INSTALL_HELP_LOG="/tmp/openclaw-codex-plugin-install-help.log"',
+      'openclaw plugins install --help 2>&1 | head -c 65536 >"$PLUGIN_INSTALL_HELP_LOG" || true',
+      'grep -q -- "--accept-capabilities" "$PLUGIN_INSTALL_HELP_LOG"',
+      "PLUGIN_INSTALL_FLAGS+=(--accept-capabilities)",
+      "PLUGIN_INSTALL_FLAGS+=(--dangerously-force-unsafe-install)",
+    ]);
+    expect(codexNpmPlugin).not.toContain("install --help 2>&1 | grep -q");
+
+    const releaseUpgrade = readFileSync(RELEASE_UPGRADE_USER_JOURNEY_SCENARIO_PATH, "utf8");
+    expect(releaseUpgrade).toContain(
+      'openclaw plugins install "$plugin_dir" --force >"$PLUGIN_INSTALL_LOG" 2>&1',
+    );
+    expect(releaseUpgrade).not.toContain(
+      'openclaw plugins install "$plugin_dir" --force --accept-capabilities',
+    );
+    const corruptUpdate = readFileSync(PLUGIN_UPDATE_CORRUPT_SCENARIO_PATH, "utf8");
+    expect(corruptUpdate).toContain(
+      'plugins install "npm:@openclaw/demo-corrupt-plugin@0.0.1" --force',
+    );
+    expect(corruptUpdate).not.toContain(
+      'plugins install "npm:@openclaw/demo-corrupt-plugin@0.0.1" --force --accept-capabilities',
+    );
+
+    const packageSelfUpgrade = readFileSync(UPGRADE_SURVIVOR_PACKAGE_SELF_UPGRADE_PATH, "utf8");
+    expect(packageSelfUpgrade).toContain('openclaw plugins install "$qa_plugin_source" --link');
+    expect(packageSelfUpgrade).not.toContain(
+      'openclaw plugins install "$qa_plugin_source" --link --accept-capabilities',
     );
   });
 
@@ -5913,7 +6001,7 @@ done
     expectTextToIncludeAll(clawhub, [
       'plugins install "$CLAWHUB_PLUGIN_SPEC"',
       'plugins update "$CLAWHUB_PLUGIN_ID"',
-      "run_plugins_openclaw_logged install-clawhub",
+      "run_plugins_fixture_install_logged install-clawhub",
       'openclaw_e2e_maybe_timeout "$OPENCLAW_PLUGINS_CLI_TIMEOUT"',
       "clawhub:@openclaw/kitchen-sink",
     ]);

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -56,12 +56,6 @@ function planFor(
   }).plan;
 }
 
-function writeCandidatePackage(scripts: Record<string, string>): string {
-  const root = tempDirs.make("openclaw-docker-plan-candidate-");
-  writeFileSync(join(root, "package.json"), JSON.stringify({ scripts }));
-  return root;
-}
-
 function requireFirstLane(plan: ReturnType<typeof planFor>) {
   const [lane] = plan.lanes;
   if (!lane) {
@@ -158,67 +152,6 @@ describe("scripts/lib/docker-e2e-plan", () => {
     expect(requiredPrepublishPluginPackagesForLanes(lanes.flatMap((lane) => lane ?? []))).toEqual([
       "@openclaw/codex",
     ]);
-  });
-
-  it("omits a package-script lane unavailable from the candidate", () => {
-    const plan = planFor({
-      candidatePackageRoot: writeCandidatePackage({}),
-      selectedLaneNames: ["update-run-package-self-upgrade"],
-    });
-
-    expect(plan.lanes).toEqual([]);
-  });
-
-  it("keeps a package-script lane available from the candidate", () => {
-    const plan = planFor({
-      candidatePackageRoot: writeCandidatePackage({
-        "test:docker:update-run-package-self-upgrade": "node test.mjs",
-      }),
-      selectedLaneNames: ["update-run-package-self-upgrade"],
-    });
-
-    expect(plan.lanes.map((lane) => lane.name)).toEqual(["update-run-package-self-upgrade"]);
-  });
-
-  it("keeps trusted upgrade harness lanes without candidate package scripts", () => {
-    const plan = planFor({
-      candidatePackageRoot: writeCandidatePackage({}),
-      selectedLaneNames: [
-        "upgrade-survivor",
-        "published-upgrade-survivor",
-        "root-managed-vps-upgrade",
-        "update-migration",
-        "update-run-package-self-upgrade",
-      ],
-    });
-
-    expect(plan.lanes.map((lane) => lane.name)).toEqual([
-      "upgrade-survivor",
-      "published-upgrade-survivor",
-      "root-managed-vps-upgrade",
-      "update-migration",
-    ]);
-  });
-
-  it("fails when the selected candidate package manifest is missing", () => {
-    expect(() =>
-      planFor({
-        candidatePackageRoot: tempDirs.make("openclaw-docker-plan-missing-package-"),
-        selectedLaneNames: ["update-run-package-self-upgrade"],
-      }),
-    ).toThrow(/package\.json/);
-  });
-
-  it("fails when the selected candidate package manifest is malformed", () => {
-    const root = tempDirs.make("openclaw-docker-plan-malformed-package-");
-    writeFileSync(join(root, "package.json"), "{");
-
-    expect(() =>
-      planFor({
-        candidatePackageRoot: root,
-        selectedLaneNames: ["update-run-package-self-upgrade"],
-      }),
-    ).toThrow(SyntaxError);
   });
 
   it("finds a named lane through the expanded catalog", () => {
@@ -469,7 +402,8 @@ describe("scripts/lib/docker-e2e-plan", () => {
 
     expect(targeted.lanes.map(summarizeLane)).toEqual([
       {
-        command: "OPENCLAW_SKIP_DOCKER_BUILD=1 bash scripts/e2e/gateway-concurrency-docker.sh",
+        command:
+          'OPENCLAW_SKIP_DOCKER_BUILD=1 bash -c \'harness="${OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR:-.}"; OPENCLAW_LIVE_DOCKER_REPO_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$PWD}" bash "$harness/scripts/e2e/gateway-concurrency-docker.sh"\'',
         imageKind: "functional",
         live: false,
         name: "gateway-concurrency",

--- a/test/scripts/docker-e2e-source-roots.test.ts
+++ b/test/scripts/docker-e2e-source-roots.test.ts
@@ -12,32 +12,38 @@ const posixIt = process.platform === "win32" ? it.skip : it;
 describe("Docker E2E source and harness inputs", () => {
   posixIt.each<{
     script: string;
-    dockerfile?: string;
+    dockerfiles?: string[];
     harnessDockerfile?: boolean;
     reuse?: boolean;
   }>([
-    { script: "docker-selected-plugins.sh", dockerfile: "Dockerfile" },
+    {
+      script: "docker-selected-plugins.sh",
+      dockerfiles: ["Dockerfile", "Dockerfile", "Dockerfile"],
+    },
     {
       script: "plugin-binding-command-escape-docker.sh",
-      dockerfile: "scripts/e2e/plugin-binding-command-escape.Dockerfile",
+      dockerfiles: ["scripts/e2e/plugin-binding-command-escape.Dockerfile"],
       harnessDockerfile: true,
     },
     {
       script: "qr-import-docker.sh",
-      dockerfile: "scripts/e2e/Dockerfile.qr-import",
+      dockerfiles: ["scripts/e2e/Dockerfile.qr-import"],
       harnessDockerfile: true,
     },
-    { script: "agents-delete-shared-workspace-docker.sh", dockerfile: "Dockerfile" },
+    { script: "agents-delete-shared-workspace-docker.sh", dockerfiles: ["Dockerfile"] },
     {
       script: "sandbox-browser-sidecar-docker.sh",
-      dockerfile: "scripts/docker/sandbox/Dockerfile",
+      dockerfiles: [
+        "scripts/docker/sandbox/Dockerfile",
+        "scripts/docker/sandbox/Dockerfile.browser",
+      ],
       reuse: true,
     },
     { script: "compose-setup.sh", reuse: true },
     { script: "cli-installer-distribution-docker.sh", reuse: true },
   ])(
     "keeps candidate product inputs for $script",
-    async ({ script, dockerfile, harnessDockerfile, reuse }) => {
+    async ({ script, dockerfiles, harnessDockerfile, reuse }) => {
       const root = tempDirs.make("e2e-src-");
       const target = path.join(root, "candidate source");
       const bin = path.join(root, "bin");
@@ -60,7 +66,15 @@ const args = process.argv.slice(2);
 fs.appendFileSync(${JSON.stringify(log)}, JSON.stringify({ command: ${JSON.stringify(command)}, args }) + '\\n');
 if (${JSON.stringify(command)} === 'git') {
   if (args.includes('rev-parse')) console.log('a'.repeat(40));
-} else if (args[0] === 'build' || args[0] === 'buildx' || args[0] === 'compose' || (args[0] === 'run' && args.includes('-d'))) {
+} else if (args[0] === 'build' || args[0] === 'buildx') {
+  if (args.some((arg) => arg.includes('OPENCLAW_EXTENSIONS=missing-plugin'))) {
+    console.error('unknown OPENCLAW_EXTENSIONS plugin id: missing-plugin');
+    process.exit(49);
+  }
+} else if (
+  args[0] === 'compose' ||
+  (args[0] === 'run' && !args.some((arg) => arg.endsWith('-dependency-only')))
+) {
   console.error('fixture-stop at product input boundary');
   process.exit(49);
 }
@@ -95,14 +109,17 @@ if (${JSON.stringify(command)} === 'git') {
           .trim()
           .split("\n")
           .map((line) => JSON.parse(line) as { command: string; args: string[] });
-        if (dockerfile) {
-          const build = calls.find(
-            (call) => call.command === "docker" && call.args.includes("build"),
+        if (dockerfiles) {
+          const builds = calls.filter(
+            (call) =>
+              call.command === "docker" &&
+              (call.args[0] === "build" || call.args[0] === "buildx") &&
+              call.args.at(-1) === target,
           );
-          expect(build).toBeDefined();
-          expect(build?.args.at(-1)).toBe(target);
-          expect(build?.args[build.args.indexOf("-f") + 1]).toBe(
-            path.join(harnessDockerfile ? harness : target, dockerfile),
+          expect(builds.map((build) => build.args[build.args.indexOf("-f") + 1])).toEqual(
+            dockerfiles.map((dockerfile) =>
+              path.join(harnessDockerfile ? harness : target, dockerfile),
+            ),
           );
         } else if (script === "compose-setup.sh") {
           expect(calls.find((call) => call.args[0] === "compose")?.args).toContain(

--- a/test/scripts/docker-e2e-source-roots.test.ts
+++ b/test/scripts/docker-e2e-source-roots.test.ts
@@ -1,0 +1,183 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const harness = process.cwd();
+const posixIt = process.platform === "win32" ? it.skip : it;
+
+describe("Docker E2E source and harness inputs", () => {
+  posixIt.each<{
+    script: string;
+    dockerfile?: string;
+    harnessDockerfile?: boolean;
+    reuse?: boolean;
+  }>([
+    { script: "docker-selected-plugins.sh", dockerfile: "Dockerfile" },
+    {
+      script: "plugin-binding-command-escape-docker.sh",
+      dockerfile: "scripts/e2e/plugin-binding-command-escape.Dockerfile",
+      harnessDockerfile: true,
+    },
+    {
+      script: "qr-import-docker.sh",
+      dockerfile: "scripts/e2e/Dockerfile.qr-import",
+      harnessDockerfile: true,
+    },
+    { script: "agents-delete-shared-workspace-docker.sh", dockerfile: "Dockerfile" },
+    {
+      script: "sandbox-browser-sidecar-docker.sh",
+      dockerfile: "scripts/docker/sandbox/Dockerfile",
+      reuse: true,
+    },
+    { script: "compose-setup.sh", reuse: true },
+    { script: "cli-installer-distribution-docker.sh", reuse: true },
+  ])(
+    "keeps candidate product inputs for $script",
+    async ({ script, dockerfile, harnessDockerfile, reuse }) => {
+      const root = tempDirs.make("e2e-src-");
+      const target = path.join(root, "candidate source");
+      const bin = path.join(root, "bin");
+      const log = path.join(root, "commands.jsonl");
+      mkdirSync(target);
+      mkdirSync(bin);
+      writeFileSync(
+        path.join(target, "Dockerfile"),
+        'HEALTHCHECK CMD ["node", "dist/docker-healthcheck.js"]\n',
+      );
+      const packageTgz = path.join(root, "candidate.tgz");
+      writeFileSync(packageTgz, "fixture package bytes");
+      for (const command of ["docker", "git"]) {
+        const file = path.join(bin, command);
+        writeFileSync(
+          file,
+          `#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+fs.appendFileSync(${JSON.stringify(log)}, JSON.stringify({ command: ${JSON.stringify(command)}, args }) + '\\n');
+if (${JSON.stringify(command)} === 'git') {
+  if (args.includes('rev-parse')) console.log('a'.repeat(40));
+} else if (args[0] === 'build' || args[0] === 'buildx' || args[0] === 'compose' || (args[0] === 'run' && args.includes('-d'))) {
+  console.error('fixture-stop at product input boundary');
+  process.exit(49);
+}
+`,
+        );
+        chmodSync(file, 0o755);
+      }
+      const socketPath = path.join(root, "docker.sock");
+      const socket = createServer();
+      await new Promise<void>((resolve, reject) => {
+        socket.once("error", reject);
+        socket.listen(socketPath, resolve);
+      });
+      try {
+        const result = spawnSync("bash", [path.join(harness, "scripts/e2e", script)], {
+          cwd: target,
+          encoding: "utf8",
+          timeout: 30_000,
+          env: {
+            ...process.env,
+            PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+            TMPDIR: root,
+            OPENCLAW_DOCKER_E2E_REPO_ROOT: target,
+            OPENCLAW_CURRENT_PACKAGE_TGZ: packageTgz,
+            OPENCLAW_SKIP_DOCKER_BUILD: reuse ? "1" : "0",
+            OPENCLAW_DOCKER_SOCKET: socketPath,
+          },
+        });
+        expect(result.status).not.toBe(0);
+        expect(result.stdout + result.stderr).toContain("fixture-stop at product input boundary");
+        const calls = readFileSync(log, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line) as { command: string; args: string[] });
+        if (dockerfile) {
+          const build = calls.find(
+            (call) => call.command === "docker" && call.args.includes("build"),
+          );
+          expect(build).toBeDefined();
+          expect(build?.args.at(-1)).toBe(target);
+          expect(build?.args[build.args.indexOf("-f") + 1]).toBe(
+            path.join(harnessDockerfile ? harness : target, dockerfile),
+          );
+        } else if (script === "compose-setup.sh") {
+          expect(calls.find((call) => call.args[0] === "compose")?.args).toContain(
+            path.join(target, "docker-compose.yml"),
+          );
+        } else {
+          const gitCalls = calls.filter((call) => call.command === "git");
+          expect(gitCalls.map((call) => call.args.slice(0, 2))).toEqual([
+            ["-C", target],
+            ["-C", target],
+          ]);
+          expect(
+            calls.find((call) => call.args[0] === "run" && call.args.includes("-d"))?.args,
+          ).toContain(`${target}/scripts/install.sh:/tmp/install.sh:ro`);
+        }
+      } finally {
+        await new Promise<void>((resolve, reject) =>
+          socket.close((error) => (error ? reject(error) : resolve())),
+        );
+      }
+    },
+  );
+  posixIt("packs candidate source through the sourced trusted package helper", () => {
+    const root = tempDirs.make("e2e-pack-");
+    const trusted = path.join(root, "trusted harness");
+    const target = path.join(root, "candidate source");
+    const lib = path.join(trusted, "scripts/lib");
+    mkdirSync(lib, { recursive: true });
+    mkdirSync(path.join(target, "scripts"), { recursive: true });
+    copyFileSync("scripts/lib/docker-e2e-package.sh", path.join(lib, "docker-e2e-package.sh"));
+    writeFileSync(
+      path.join(target, "scripts/package-openclaw-for-docker.mjs"),
+      "process.exit(47);\n",
+    );
+    const marker = path.join(root, "packer-source");
+    writeFileSync(
+      path.join(trusted, "scripts/package-openclaw-for-docker.mjs"),
+      `
+import fs from 'node:fs'; import path from 'node:path';
+const value = (name) => process.argv[process.argv.indexOf(name) + 1];
+fs.writeFileSync(${JSON.stringify(marker)}, value('--source-dir'));
+const output = path.join(value('--output-dir'), value('--output-name'));
+fs.writeFileSync(output, 'candidate bytes');
+console.log(output);
+`,
+    );
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `
+set -euo pipefail
+run_logged() { :; }
+docker_e2e_docker_cmd() { :; }
+docker_e2e_docker_run_cmd() { :; }
+source "$TRUSTED/scripts/lib/docker-e2e-package.sh"
+package="$(docker_e2e_prepare_package_tgz fixture)"
+[[ "$(cat "$package")" == 'candidate bytes' ]]
+docker_e2e_cleanup_package_tgz "$package"
+`,
+      ],
+      {
+        encoding: "utf8",
+        timeout: 30_000,
+        env: {
+          ...process.env,
+          ROOT_DIR: target,
+          TRUSTED: trusted,
+          TMPDIR: root,
+          OPENCLAW_DOCKER_E2E_REPO_ROOT: target,
+          OPENCLAW_CURRENT_PACKAGE_TGZ: "",
+        },
+      },
+    );
+    expect(result.status, result.stdout + result.stderr).toBe(0);
+    expect(readFileSync(marker, "utf8")).toBe(target);
+  });
+});

--- a/test/scripts/kitchen-sink-plugin-assertions.test.ts
+++ b/test/scripts/kitchen-sink-plugin-assertions.test.ts
@@ -11,11 +11,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const ASSERTIONS_SCRIPT = "scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs";
 const BASH_BIN = process.platform === "win32" ? "bash" : "/bin/bash";
 const SWEEP_SCRIPT = "scripts/e2e/lib/kitchen-sink-plugin/sweep.sh";
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 // The shim waits for an explicit log-ready marker; this only bounds a broken fixture process.
 const FIXTURE_READY_WAIT_ATTEMPTS = process.env.CI ? 2_000 : 1_000;
 const REQUIRED_FULL_DIAGNOSTIC_CANARIES = [
@@ -679,6 +681,71 @@ grep -q "cli transcript: plugins install demo" "$SCRATCH_ROOT/install_log.log"
     } finally {
       rmSync(parent, { force: true, recursive: true });
     }
+  });
+
+  it("accepts capabilities only for successful kitchen-sink installs", () => {
+    const parent = tempDirs.make("openclaw-kitchen-sink-install-consent-");
+    const scratchRoot = path.join(parent, "scratch");
+    const result = runSweepShell(
+      `
+set -euo pipefail
+export KITCHEN_SINK_SWEEP_SOURCE_ONLY=1
+export KITCHEN_SINK_TMP_DIR="$SCRATCH_ROOT"
+export OPENCLAW_ENTRY=fixture-entry
+export KITCHEN_SINK_LABEL=fixture
+export KITCHEN_SINK_SPEC=fixture-spec
+export KITCHEN_SINK_PREINSTALL_SPEC=preinstall-spec
+export KITCHEN_SINK_ID=fixture-id
+export KITCHEN_SINK_SOURCE=npm
+source scripts/e2e/lib/kitchen-sink-plugin/sweep.sh
+run_kitchen_sink_openclaw_logged() {
+  printf 'success'
+  printf ' <%s>' "$@"
+  printf '\\n'
+}
+run_kitchen_sink_openclaw_capture() {
+  :
+}
+assert_kitchen_sink_cutover_preinstalled() {
+  :
+}
+configure_kitchen_sink_runtime() {
+  :
+}
+assert_kitchen_sink_installed() {
+  :
+}
+assert_kitchen_sink_removed() {
+  :
+}
+remove_kitchen_sink_channel_config() {
+  :
+}
+run_expect_failure() {
+  printf 'failure'
+  printf ' <%s>' "$@"
+  printf '\\n'
+}
+run_success_scenario
+run_failure_scenario
+`,
+      { SCRATCH_ROOT: scratchRoot },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    const successInstalls = result.stdout
+      .split("\n")
+      .filter((line) => line.startsWith("success") && line.includes(" <plugins> <install> "));
+    expect(successInstalls).toHaveLength(2);
+    for (const install of successInstalls) {
+      expect(install).toContain(" <--accept-capabilities>");
+    }
+    const failureInstall = result.stdout
+      .split("\n")
+      .find((line) => line.startsWith("failure") && line.includes(" <plugins> <install> "));
+    expect(failureInstall).toBeDefined();
+    expect(failureInstall).not.toContain(" <--accept-capabilities>");
   });
 
   it("bounds printed kitchen-sink CLI command logs without truncating saved logs", () => {

--- a/test/scripts/kitchen-sink-plugin-assertions.test.ts
+++ b/test/scripts/kitchen-sink-plugin-assertions.test.ts
@@ -11,13 +11,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { describe, expect, it } from "vitest";
 
 const ASSERTIONS_SCRIPT = "scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs";
 const BASH_BIN = process.platform === "win32" ? "bash" : "/bin/bash";
 const SWEEP_SCRIPT = "scripts/e2e/lib/kitchen-sink-plugin/sweep.sh";
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 // The shim waits for an explicit log-ready marker; this only bounds a broken fixture process.
 const FIXTURE_READY_WAIT_ATTEMPTS = process.env.CI ? 2_000 : 1_000;
 const REQUIRED_FULL_DIAGNOSTIC_CANARIES = [
@@ -681,71 +679,6 @@ grep -q "cli transcript: plugins install demo" "$SCRATCH_ROOT/install_log.log"
     } finally {
       rmSync(parent, { force: true, recursive: true });
     }
-  });
-
-  it("accepts capabilities only for successful kitchen-sink installs", () => {
-    const parent = tempDirs.make("openclaw-kitchen-sink-install-consent-");
-    const scratchRoot = path.join(parent, "scratch");
-    const result = runSweepShell(
-      `
-set -euo pipefail
-export KITCHEN_SINK_SWEEP_SOURCE_ONLY=1
-export KITCHEN_SINK_TMP_DIR="$SCRATCH_ROOT"
-export OPENCLAW_ENTRY=fixture-entry
-export KITCHEN_SINK_LABEL=fixture
-export KITCHEN_SINK_SPEC=fixture-spec
-export KITCHEN_SINK_PREINSTALL_SPEC=preinstall-spec
-export KITCHEN_SINK_ID=fixture-id
-export KITCHEN_SINK_SOURCE=npm
-source scripts/e2e/lib/kitchen-sink-plugin/sweep.sh
-run_kitchen_sink_openclaw_logged() {
-  printf 'success'
-  printf ' <%s>' "$@"
-  printf '\\n'
-}
-run_kitchen_sink_openclaw_capture() {
-  :
-}
-assert_kitchen_sink_cutover_preinstalled() {
-  :
-}
-configure_kitchen_sink_runtime() {
-  :
-}
-assert_kitchen_sink_installed() {
-  :
-}
-assert_kitchen_sink_removed() {
-  :
-}
-remove_kitchen_sink_channel_config() {
-  :
-}
-run_expect_failure() {
-  printf 'failure'
-  printf ' <%s>' "$@"
-  printf '\\n'
-}
-run_success_scenario
-run_failure_scenario
-`,
-      { SCRATCH_ROOT: scratchRoot },
-    );
-
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe("");
-    const successInstalls = result.stdout
-      .split("\n")
-      .filter((line) => line.startsWith("success") && line.includes(" <plugins> <install> "));
-    expect(successInstalls).toHaveLength(2);
-    for (const install of successInstalls) {
-      expect(install).toContain(" <--accept-capabilities>");
-    }
-    const failureInstall = result.stdout
-      .split("\n")
-      .find((line) => line.startsWith("failure") && line.includes(" <plugins> <install> "));
-    expect(failureInstall).toBeDefined();
-    expect(failureInstall).not.toContain(" <--accept-capabilities>");
   });
 
   it("bounds printed kitchen-sink CLI command logs without truncating saved logs", () => {

--- a/test/scripts/kitchen-sink-rpc-walk.test.ts
+++ b/test/scripts/kitchen-sink-rpc-walk.test.ts
@@ -72,6 +72,8 @@ import { formatGatewayClientRequestErrorJson } from "../../src/gateway/call.js";
 import { cleanupTempDirs, makeTempDir } from "../helpers/temp-dir.js";
 
 const posixIt = process.platform === "win32" ? it.skip : it;
+const realDelay = delay;
+const realNow = Date.now;
 
 type RunTaskkill = NonNullable<
   NonNullable<Parameters<typeof signalProcessGroup>[2]>["runTaskkill"]
@@ -968,6 +970,7 @@ describe("kitchen-sink RPC caller loading", () => {
     const scriptPath = path.join(root, "term-zero-grandchild.mjs");
     const grandchildPidPath = path.join(root, "grandchild.pid");
     const grandchildReadyPath = path.join(root, "grandchild.ready");
+    const parentPidPath = path.join(root, "parent.pid");
     let grandchildPid = 0;
     const grandchildScript = [
       "const fs = require('node:fs');",
@@ -986,45 +989,69 @@ const grandchild = spawn(process.execPath, [
   "-e",
   ${JSON.stringify(grandchildScript)},
 ], { env: { ...process.env, GRANDCHILD_READY_PATH: process.argv[3] }, stdio: "ignore" });
-fs.writeFileSync(process.argv[2], String(grandchild.pid));
 process.on("SIGTERM", () => process.exit(0));
+fs.writeFileSync(process.argv[4], String(process.pid));
+fs.writeFileSync(process.argv[2], String(grandchild.pid));
 setInterval(() => {}, 1000);
 `,
       "utf8",
     );
 
+    // Readiness polling uses real time; command deadlines advance only after
+    // the real processes have installed their signal handlers.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
     const runPromise = runCommand(
       process.execPath,
-      [scriptPath, grandchildPidPath, grandchildReadyPath],
+      [scriptPath, grandchildPidPath, grandchildReadyPath, parentPidPath],
       {
         timeoutKillGraceMs: 100,
         timeoutMs: 100,
       },
     );
+    let settled = false;
     const runErrorPromise = runPromise.then(
       () => {
-        throw new Error("expected timed command to reject");
+        settled = true;
       },
-      (error: unknown) => error,
+      (error: unknown) => {
+        settled = true;
+        return error;
+      },
     );
+    const finishCommand = () =>
+      waitFor(async () => {
+        await vi.runOnlyPendingTimersAsync();
+        return settled;
+      });
 
     try {
       await waitFor(() => existsSync(grandchildPidPath));
-      await waitFor(() => existsSync(grandchildReadyPath));
       grandchildPid = Number.parseInt(readText(grandchildPidPath), 10);
+      const parentPid = Number.parseInt(readText(parentPidPath), 10);
+      await waitFor(() => existsSync(grandchildReadyPath));
       expect(Number.isInteger(grandchildPid)).toBe(true);
       expect(isProcessAlive(grandchildPid)).toBe(true);
 
+      await vi.advanceTimersByTimeAsync(100);
+      await waitFor(() => !isProcessAlive(parentPid));
+      await finishCommand();
       const runError = await runErrorPromise;
       expect(runError).toBeInstanceOf(Error);
       expect((runError as Error).message).toContain("timed out after 100ms");
+      expect(runError).toMatchObject({ status: 0, signal: null });
       await waitFor(() => !isProcessAlive(grandchildPid), 5_000);
     } finally {
-      await runPromise.catch(() => {});
-      if (grandchildPid && isProcessAlive(grandchildPid)) {
-        process.kill(grandchildPid, "SIGKILL");
+      try {
+        // A readiness/assertion failure must still fire the deadline and kill grace.
+        await finishCommand();
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+        if (grandchildPid && isProcessAlive(grandchildPid)) {
+          process.kill(grandchildPid, "SIGKILL");
+        }
+        cleanupTempDirs(tempDirs);
       }
-      cleanupTempDirs(tempDirs);
     }
   });
 
@@ -2225,13 +2252,13 @@ function readText(file: string) {
   return readFileSync(file, "utf8");
 }
 
-async function waitFor(condition: () => boolean, timeoutMs = 3_000) {
-  const startedAt = Date.now();
-  while (!condition()) {
-    if (Date.now() - startedAt > timeoutMs) {
+async function waitFor(condition: () => boolean | Promise<boolean>, timeoutMs = 3_000) {
+  const startedAt = realNow();
+  while (!(await condition())) {
+    if (realNow() - startedAt > timeoutMs) {
       throw new Error("timed out waiting for condition");
     }
-    await delay(25);
+    await realDelay(25);
   }
 }
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4002,7 +4002,6 @@ describe("package artifact reuse", () => {
     const workflow = readFileSync(LIVE_E2E_WORKFLOW, "utf8");
     const providerSuites = workflowJob(LIVE_E2E_WORKFLOW, "validate_live_docker_provider_suites");
     const scenarios = readFileSync("scripts/lib/docker-e2e-scenarios.mts", "utf8");
-    const scheduler = readFileSync("scripts/test-docker-all.mts", "utf8");
     const harness = readFileSync("scripts/test-live-codex-harness-docker.sh", "utf8");
     const codexLiveTest = readFileSync("src/gateway/gateway-codex-harness.live.test.ts", "utf8");
     const liveDockerAuth = readFileSync("scripts/lib/live-docker-auth.sh", "utf8");
@@ -4110,15 +4109,6 @@ describe("package artifact reuse", () => {
     expect(scenarios).toMatch(
       /liveDockerScriptCommand\(\s*"test-live-subagent-announce-docker\.sh"/u,
     );
-    expect(scheduler).toContain("function liveDockerHarnessScriptCommand");
-    expect(scheduler).toContain("const LIVE_DOCKER_DEFAULT_HARNESS_DIR");
-    expect(scheduler).toContain('path.basename(SCRIPT_ROOT_DIR) === ".release-harness"');
-    expect(scheduler).toContain("ROOT_DIR !== SCRIPT_ROOT_DIR");
-    expect(scheduler).toContain(
-      'harness="\\${OPENCLAW_DOCKER_E2E_TRUSTED_HARNESS_DIR:-${LIVE_DOCKER_DEFAULT_HARNESS_DIR}}"',
-    );
-    expect(scheduler).not.toContain("harness=.release-harness");
-    expect(scheduler).toContain('liveDockerHarnessScriptCommand("test-live-build-docker.sh")');
     expect(liveDockerAuth).toContain("codex-cli | openai)");
     expect(liveDockerAuth).toContain("openclaw_live_init_docker_run_args()");
     expect(liveDockerAuth).toContain("openclaw_live_stage_profile_into_home()");

--- a/test/scripts/package-compat.test.ts
+++ b/test/scripts/package-compat.test.ts
@@ -1,0 +1,327 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const consent = "--accept-capabilities";
+const BASH_BIN = process.platform === "win32" ? "bash" : "/bin/bash";
+
+function writeCandidate(
+  root: string,
+  options: { commands?: string[]; helpStatus?: number; hang?: boolean; exitCode?: number } = {},
+  name = "candidate.cjs",
+) {
+  const entry = path.join(root, name);
+  writeFileSync(
+    entry,
+    `
+const fs = require('node:fs');
+const options = ${JSON.stringify(options)};
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.ARGV_LOG, JSON.stringify(args) + '\\n');
+const supported = (options.commands ?? ['install', 'enable', 'update']).includes(args[1]);
+if (args.includes('--help')) {
+  console.log('OpenClaw 2026.8.1\\nOptions:');
+  console.log(supported ? '  --accept-capabilities  Accept capabilities' : '  --force  Confirm source');
+  if (options.hang) setInterval(() => {}, 1000);
+  else process.exit(options.helpStatus ?? 0);
+} else {
+  const accepted = args.includes('--accept-capabilities');
+  if (accepted && !supported) {
+    console.error('unknown option --accept-capabilities');
+    process.exit(2);
+  }
+  if (args[2]?.includes('invalid-metadata') || args[2] === 'missing-version') process.exit(41);
+  const needsConsent = args[0] === 'plugins' && (args[1] === 'install' ||
+    (args[1] === 'enable' && args[2] === 'claude-bundle-e2e') ||
+    (args[1] === 'update' && args[2] === 'marketplace-shortcut' && !args.includes('--dry-run')));
+  if (supported && needsConsent && !accepted) {
+    console.error('requires capability consent');
+    process.exit(42);
+  }
+  console.log('{}');
+  process.exit(options.exitCode ?? 0);
+}
+`,
+  );
+  return entry;
+}
+
+function runShell(root: string, entry: string, script: string) {
+  const result = spawnSync(BASH_BIN, ["-c", `set -euo pipefail\n${script}`], {
+    encoding: "utf8",
+    timeout: 30_000,
+    env: {
+      ...process.env,
+      HOME: root,
+      OPENCLAW_ENTRY: entry,
+      OPENCLAW_PLUGINS_TMP_DIR: root,
+      KITCHEN_SINK_TMP_DIR: root,
+      ARGV_LOG: path.join(root, "argv.jsonl"),
+      OPENCLAW_PLUGINS_E2E_CLAWHUB: "0",
+      OPENCLAW_PLUGINS_CLI_TIMEOUT: "5s",
+      OPENCLAW_TEST_STATE_SCRIPT_B64: Buffer.from(":").toString("base64"),
+    },
+  });
+  const log = path.join(root, "argv.jsonl");
+  const calls: string[][] = existsSync(log)
+    ? readFileSync(log, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line))
+    : [];
+  return { ...result, calls };
+}
+
+const fixtureCommand = `
+source scripts/lib/openclaw-e2e-instance.sh
+openclaw_e2e_fixture_plugin_command openclaw_e2e_maybe_timeout 5s node "$OPENCLAW_ENTRY" --
+`.trim();
+
+// Replace artifact construction and inventory assertions, not the CLI runner or scenario order.
+const sweepFixtureLoader = `
+source() {
+  if [[ "$1" == scripts/e2e/lib/plugins/fixtures.sh ]]; then
+    write_fixture_plugin() { mkdir -p "$1"; }
+    write_demo_fixture_plugin() { write_fixture_plugin "$@"; }
+    write_fixture_plugin_with_cli() { write_fixture_plugin "$@"; }
+    write_fixture_plugin_with_vendored_dependency() { write_fixture_plugin "$@"; }
+    write_claude_bundle_fixture() { write_fixture_plugin "$@"; }
+    pack_fixture_plugin() { :; }
+    pack_fixture_plugin_with_cli_registry_dependency() { :; }
+    pack_fake_is_number_package() { :; }
+    pack_fixture_plugin_with_invalid_extension_entry() { :; }
+    start_npm_fixture_registry() { :; }
+    record_fixture_plugin_trust() { :; }
+    openclaw_plugins_cleanup_fixture_servers() { :; }
+  else
+    builtin source "$@"
+  fi
+}
+node() {
+  case "$1" in
+    scripts/e2e/lib/plugins/assertions.mjs|scripts/e2e/lib/fixture.mjs) return 0 ;;
+    *) command node "$@" ;;
+  esac
+}
+git() { printf 'fixture-commit\\n'; }
+source scripts/e2e/lib/plugins/sweep.sh
+`;
+
+const kitchenFixtureLoader = `
+export KITCHEN_SINK_SWEEP_SOURCE_ONLY=1
+source scripts/e2e/lib/kitchen-sink-plugin/sweep.sh
+assert_kitchen_sink_cutover_preinstalled() { :; }
+configure_kitchen_sink_runtime() { :; }
+assert_kitchen_sink_installed() { :; }
+assert_kitchen_sink_removed() { :; }
+remove_kitchen_sink_channel_config() { :; }
+node() {
+  case "$1" in
+    scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs) return 0 ;;
+    *) command node "$@" ;;
+  esac
+}
+KITCHEN_SINK_LABEL=fixture
+KITCHEN_SINK_ID=fixture-id
+KITCHEN_SINK_SPEC=fixture-spec
+KITCHEN_SINK_PREINSTALL_SPEC=preinstall-spec
+KITCHEN_SINK_SOURCE=npm
+run_success_scenario
+KITCHEN_SINK_SPEC=missing-version
+run_failure_scenario
+`;
+
+describe("package fixture consent compatibility", () => {
+  it.each([true, false])(
+    "runs the plugin sweep with selective consent (supported=%s)",
+    (supported) => {
+      const root = tempDirs.make("openclaw-consent-sweep-");
+      const entry = writeCandidate(root, { commands: supported ? undefined : [] });
+      const result = runShell(root, entry, sweepFixtureLoader);
+      expect(result.status, result.stderr).toBe(0);
+      const mutations = result.calls.filter(
+        (args) => args[0] === "plugins" && !args.includes("--help"),
+      );
+      const installs = mutations.filter((args) => args[1] === "install");
+      expect(installs).toHaveLength(12);
+      for (const args of mutations) {
+        const positive =
+          (args[1] === "install" && !args.some((arg) => arg.includes("invalid-metadata"))) ||
+          args[1] === "enable" ||
+          (args[1] === "update" &&
+            args[2] === "marketplace-shortcut" &&
+            !args.includes("--dry-run"));
+        expect(args.includes(consent), args.join(" ")).toBe(supported && positive);
+      }
+      expect(mutations.filter((args) => args[1] === "update")).toHaveLength(5);
+      expect(mutations.find((args) => args[1] === "enable")).toContain("claude-bundle-e2e");
+    },
+  );
+
+  it.each([true, false])(
+    "runs kitchen-sink success and registry failure (supported=%s)",
+    (supported) => {
+      const root = tempDirs.make("openclaw-consent-kitchen-");
+      const result = runShell(
+        root,
+        writeCandidate(root, { commands: supported ? undefined : [] }),
+        kitchenFixtureLoader,
+      );
+      expect(result.status, result.stderr).toBe(0);
+      const installs = result.calls.filter(
+        (args) => args[1] === "install" && !args.includes("--help"),
+      );
+      expect(installs.map((args) => args[2])).toEqual([
+        "preinstall-spec",
+        "fixture-spec",
+        "missing-version",
+      ]);
+      expect(installs.map((args) => args.includes(consent))).toEqual([supported, supported, false]);
+      expect(result.calls.find((args) => args[1] === "enable")).not.toContain(consent);
+    },
+  );
+
+  it("probes each command and preserves literal argv", () => {
+    const root = tempDirs.make("openclaw-consent-argv-");
+    const entry = writeCandidate(root, { commands: ["install", "update"] });
+    const result = runShell(
+      root,
+      entry,
+      `${fixtureCommand} plugins install 'file:a b/$(literal)' --force ''
+${fixtureCommand} plugins enable fixture
+${fixtureCommand} plugins update fixture`,
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.calls).toEqual([
+      ["plugins", "install", "--help"],
+      ["plugins", "install", "file:a b/$(literal)", "--force", "", consent],
+      ["plugins", "enable", "--help"],
+      ["plugins", "enable", "fixture"],
+      ["plugins", "update", "--help"],
+      ["plugins", "update", "fixture", consent],
+    ]);
+  });
+
+  it.each([true, false])(
+    "consents to ClawHub install but not unchanged update (supported=%s)",
+    (supported) => {
+      const root = tempDirs.make("openclaw-consent-clawhub-");
+      const result = runShell(
+        root,
+        writeCandidate(root, { commands: supported ? undefined : [] }),
+        `
+export OPENCLAW_PLUGINS_SWEEP_SOURCE_ONLY=1
+export OPENCLAW_PLUGINS_E2E_CLAWHUB=1
+export OPENCLAW_PLUGINS_E2E_LIVE_CLAWHUB=1
+source scripts/e2e/lib/plugins/sweep.sh
+node() {
+  case "$1" in
+    scripts/e2e/lib/plugins/assertions.mjs) return 0 ;;
+    *) command node "$@" ;;
+  esac
+}
+run_plugins_clawhub_scenario
+`,
+      );
+      expect(result.status, result.stderr).toBe(0);
+      expect(
+        result.calls
+          .find((args) => args[1] === "install" && !args.includes("--help"))
+          ?.includes(consent),
+      ).toBe(supported);
+      expect(result.calls.find((args) => args[1] === "update")).not.toContain(consent);
+    },
+  );
+
+  it.each([
+    ["  --accept-capabilities  Accept\n", consent],
+    ["  \u001b[32m--accept-capabilities\u001b[0m  Accept\n", consent],
+    ["  --accept-capabilities-extra  Other\n", ""],
+    ["See --accept-capabilities in newer releases\n", ""],
+    ["  --force  Confirm\n", ""],
+  ])("reads only an advertised option from help %j", (help, expected) => {
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/e2e/lib/package-compat.mjs", "fixture-consent"],
+      { encoding: "utf8", input: help },
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(expected);
+  });
+
+  it.each([
+    ["plugins", "error"],
+    ["plugins", "timeout"],
+    ["kitchen-sink", "error"],
+    ["kitchen-sink", "timeout"],
+  ])("%s logger fails before mutation on help %s", (suite, failure) => {
+    const root = tempDirs.make("openclaw-consent-failure-");
+    const entry = writeCandidate(root, failure === "error" ? { helpStatus: 47 } : { hang: true });
+    const result = runShell(
+      root,
+      entry,
+      suite === "plugins"
+        ? `
+export OPENCLAW_PLUGINS_SWEEP_SOURCE_ONLY=1
+export OPENCLAW_PLUGINS_CLI_TIMEOUT=1s
+source scripts/e2e/lib/plugins/sweep.sh
+run_plugins_fixture_logged failure plugins install fixture --force
+`
+        : `
+export KITCHEN_SINK_SWEEP_SOURCE_ONLY=1
+export KITCHEN_SINK_CLI_TIMEOUT=1s
+source scripts/e2e/lib/kitchen-sink-plugin/sweep.sh
+run_kitchen_sink_fixture_logged failure plugins install fixture --force
+`,
+    );
+    expect(result.status, result.stderr).toBe(failure === "error" ? 47 : 124);
+    expect(result.stdout + result.stderr).toContain("help probe failed");
+    expect(result.calls).toEqual([["plugins", "install", "--help"]]);
+  });
+
+  it("returns the mutation exit status", () => {
+    const root = tempDirs.make("openclaw-consent-exit-");
+    const result = runShell(
+      root,
+      writeCandidate(root, { exitCode: 49 }),
+      `${fixtureCommand} plugins install fixture`,
+    );
+    expect(result.status).toBe(49);
+    expect(result.calls.at(-1)).toEqual(["plugins", "install", "fixture", consent]);
+  });
+
+  it("reprobes a replacement at the same executable path and version", () => {
+    const root = tempDirs.make("openclaw-consent-replacement-");
+    const entry = writeCandidate(root, { commands: [] });
+    writeCandidate(root, {}, "replacement.cjs");
+    const result = runShell(
+      root,
+      entry,
+      `${fixtureCommand} plugins install fixture
+cp "$HOME/replacement.cjs" "$OPENCLAW_ENTRY"
+${fixtureCommand} plugins install fixture`,
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.calls).toEqual([
+      ["plugins", "install", "--help"],
+      ["plugins", "install", "fixture"],
+      ["plugins", "install", "--help"],
+      ["plugins", "install", "fixture", consent],
+    ]);
+  });
+
+  it.each([
+    ["2026.4.25", "1"],
+    ["2026.4.26", "0"],
+    ["2026.8.1", "0"],
+  ])("preserves legacy version CLI %s", (version, output) => {
+    const result = spawnSync(process.execPath, ["scripts/e2e/lib/package-compat.mjs", version], {
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe(output);
+  });
+});

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -242,6 +242,61 @@ describe("plugins Docker assertions", () => {
     }
   });
 
+  it("accepts capabilities for successful plugin fixture installs", () => {
+    const root = autoCleanupTempDirs.make("openclaw-plugin-fixture-install-");
+    const result = runPluginsSweepShell(
+      `
+set -euo pipefail
+export OPENCLAW_PLUGINS_SWEEP_SOURCE_ONLY=1
+export OPENCLAW_PLUGINS_TMP_DIR="$SCRATCH_ROOT"
+source scripts/e2e/lib/plugins/sweep.sh
+run_plugins_openclaw_logged() {
+  printf '<%s>\\n' "$@"
+}
+if ! declare -F run_plugins_fixture_install_logged >/dev/null; then
+  run_plugins_fixture_install_logged() {
+    run_plugins_openclaw_logged "$@"
+  }
+fi
+run_plugins_fixture_install_logged install-fixture plugins install fixture-spec --force
+`,
+      { SCRATCH_ROOT: root },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout.trim().split("\n")).toEqual([
+      "<install-fixture>",
+      "<plugins>",
+      "<install>",
+      "<fixture-spec>",
+      "<--force>",
+      "<--accept-capabilities>",
+    ]);
+  });
+
+  it("accepts capabilities when enabling the unconsented Claude bundle fixture", () => {
+    const script = readFileSync("scripts/e2e/lib/plugins/sweep.sh", "utf8");
+
+    expect(script).toContain(
+      "run_plugins_openclaw_logged enable-claude-bundle plugins enable claude-bundle-e2e --accept-capabilities",
+    );
+  });
+
+  it("accepts capabilities only for the real widening marketplace update", () => {
+    const script = readFileSync("scripts/e2e/lib/plugins/marketplace.sh", "utf8");
+
+    expect(script).toContain(
+      "run_plugins_openclaw_logged update-marketplace-shortcut plugins update marketplace-shortcut --accept-capabilities",
+    );
+    expect(script).toContain(
+      "run_plugins_openclaw_logged update-marketplace-shortcut-dry-run plugins update marketplace-shortcut --dry-run",
+    );
+    expect(script).not.toContain(
+      "update-marketplace-shortcut-dry-run plugins update marketplace-shortcut --dry-run --accept-capabilities",
+    );
+  });
+
   it("cleans the default plugin sweep scratch root", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugin-sweep-cleanup-"));
     const marker = path.join(root, "scratch-path.txt");

--- a/test/scripts/plugins-assertions.test.ts
+++ b/test/scripts/plugins-assertions.test.ts
@@ -242,61 +242,6 @@ describe("plugins Docker assertions", () => {
     }
   });
 
-  it("accepts capabilities for successful plugin fixture installs", () => {
-    const root = autoCleanupTempDirs.make("openclaw-plugin-fixture-install-");
-    const result = runPluginsSweepShell(
-      `
-set -euo pipefail
-export OPENCLAW_PLUGINS_SWEEP_SOURCE_ONLY=1
-export OPENCLAW_PLUGINS_TMP_DIR="$SCRATCH_ROOT"
-source scripts/e2e/lib/plugins/sweep.sh
-run_plugins_openclaw_logged() {
-  printf '<%s>\\n' "$@"
-}
-if ! declare -F run_plugins_fixture_install_logged >/dev/null; then
-  run_plugins_fixture_install_logged() {
-    run_plugins_openclaw_logged "$@"
-  }
-fi
-run_plugins_fixture_install_logged install-fixture plugins install fixture-spec --force
-`,
-      { SCRATCH_ROOT: root },
-    );
-
-    expect(result.status).toBe(0);
-    expect(result.stderr).toBe("");
-    expect(result.stdout.trim().split("\n")).toEqual([
-      "<install-fixture>",
-      "<plugins>",
-      "<install>",
-      "<fixture-spec>",
-      "<--force>",
-      "<--accept-capabilities>",
-    ]);
-  });
-
-  it("accepts capabilities when enabling the unconsented Claude bundle fixture", () => {
-    const script = readFileSync("scripts/e2e/lib/plugins/sweep.sh", "utf8");
-
-    expect(script).toContain(
-      "run_plugins_openclaw_logged enable-claude-bundle plugins enable claude-bundle-e2e --accept-capabilities",
-    );
-  });
-
-  it("accepts capabilities only for the real widening marketplace update", () => {
-    const script = readFileSync("scripts/e2e/lib/plugins/marketplace.sh", "utf8");
-
-    expect(script).toContain(
-      "run_plugins_openclaw_logged update-marketplace-shortcut plugins update marketplace-shortcut --accept-capabilities",
-    );
-    expect(script).toContain(
-      "run_plugins_openclaw_logged update-marketplace-shortcut-dry-run plugins update marketplace-shortcut --dry-run",
-    );
-    expect(script).not.toContain(
-      "update-marketplace-shortcut-dry-run plugins update marketplace-shortcut --dry-run --accept-capabilities",
-    );
-  });
-
   it("cleans the default plugin sweep scratch root", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-plugin-sweep-cleanup-"));
     const marker = path.join(root, "scratch-path.txt");


### PR DESCRIPTION
Closes #131206

## What Problem This Solves

Fixes an issue where Full Release Validation plugin lanes failed when trusted non-interactive fixtures installed, enabled, or updated plugins after capability consent enforcement.

## Why This Change Was Made

Candidate versions can span both sides of capability-consent enforcement, so version checks are unsafe. Trusted positive fixtures now probe command-specific help through the bounded runner and pass `--accept-capabilities` only when advertised. Negative, dry-run, integrity-failure, and unsupported historical paths remain unapproved.

FRV also runs current validation lanes against frozen package candidates. Package scripts and packaging tools now resolve from the trusted current harness while candidate source, artifacts, registry identity, and preflight remain pinned to the candidate.

## User Impact

No runtime behavior changes. Release validation can exercise plugin install, enable, update, marketplace, ClawHub, kitchen-sink, and live-plugin flows without weakening production capability consent.

## Evidence

- Before: FRV `33109771278` failed plugin prerelease/release checks with missing capability-consent errors.
- Focused exact-head Vitest:
  - fixture, scheduler, harness, source-root, and workflow tests: 637 passed.
  - final multi-build source-root regression: 8 passed.
  - Corepack toolchain-selection follow-up: 109 passed.
- Blacksmith Testbox:
  - `pnpm test:docker:plugins`: passed, including marketplace update and ClawHub.
  - `pnpm test:docker:kitchen-sink-plugin`: 7 scenarios passed.
  - `pnpm test:docker:kitchen-sink-rpc`: passed.
- Exact-head GitHub CI: 121 successful checks; no failures or pending jobs.
- Frozen-candidate Package Acceptance:
  - source-ref attempt `33141064899` was rejected before Docker because `76feb368` had been force-pushed out of every branch/tag.
  - immutable original-artifact retry `33141832151` uses package SHA-256 `e1e2b2be...`, current harness `60d50eba`, and the original 12-lane selection.
- `bash -n` for changed shell scripts: passed.
- `git diff --check`: passed.
- Independent high-reasoning audits: no correctness regressions; the only test-gap finding was fixed in `2684b8a2410`, and the Corepack follow-up was clean.

Production LOC delta: 0. Changes are limited to E2E/test support.

AI-assisted: yes.
