### PR TITLE
fix: admin access recovery works before read scope arrives

### DIFF
--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -271,6 +271,11 @@ function authorizeGatewayMethod(
   if (role === "node") {
     return null;
   }
+  if (method === "device.scopes.requestUpgrade" || method === "device.scopes.waitUpgrade") {
+    // Scope recovery must remain reachable from a paired operator whose grant is empty;
+    // the handlers bind both calls to the connection's exact device identity.
+    return null;
+  }
   if (scopes.includes(ADMIN_SCOPE)) {
     return null;
   }

--- a/src/gateway/server.device-scope-upgrade.test.ts
+++ b/src/gateway/server.device-scope-upgrade.test.ts
@@ -75,6 +75,23 @@ describe("live device scope upgrade", () => {
     return { ...paired, ws, hello };
   }
 
+  async function openScopeLessDevice(name: string) {
+    const paired = await issueOperatorToken({
+      name,
+      approvedScopes: [],
+      clientId: GATEWAY_CLIENT_IDS.TEST,
+      clientMode: GATEWAY_CLIENT_MODES.TEST,
+    });
+    const ws = await openTrackedWs(started.port);
+    const hello = await connectOk(ws, {
+      skipDefaultAuth: true,
+      deviceToken: paired.token,
+      deviceIdentityPath: paired.identityPath,
+      scopes: [],
+    });
+    return { ...paired, ws, hello };
+  }
+
   async function openLimitedBrowserDevice(name: string) {
     const { identityPath, identity } = loadDeviceIdentity(name);
     const ws = await openTrackedWs(started.port, { origin: BROWSER_ORIGIN });
@@ -96,6 +113,21 @@ describe("live device scope upgrade", () => {
       deviceToken: auth?.deviceToken ?? "",
     };
   }
+
+  test("lets a paired scope-less operator request access recovery", async () => {
+    const limited = await openScopeLessDevice("live-scope-upgrade-scope-less");
+    try {
+      const registration = await rpcReq<{ requestId: string }>(
+        limited.ws,
+        "device.scopes.requestUpgrade",
+        { scopes: FULL_SCOPES },
+      );
+      expect(registration.ok, JSON.stringify(registration.error)).toBe(true);
+      expect(registration.payload?.requestId).toBeTypeOf("string");
+    } finally {
+      limited.ws.close();
+    }
+  });
 
   test("returns the rotated token after approval and reconnects with admin scopes", async () => {
     const limited = await openLimitedDevice("live-scope-upgrade-approved");


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where a paired Control UI browser could connect with an empty or stale scope grant, then be unable to request administrator access because the recovery RPC itself required `operator.read`.

## Why This Change Was Made

The two scope-recovery RPCs remain operator-only but are allowed to reach their existing handlers without a current scope grant. Those handlers still require the exact paired device identity, validate the requested operator scopes and role ceiling, and bind waiting to the same device.

## User Impact

Users who briefly connect before their readable grant is available can request access immediately instead of waiting for a later refresh to pick up the token.

## Evidence

- Pre-fix live Gateway regression: `device.scopes.requestUpgrade` returned `FORBIDDEN: missing scope: operator.read` for a connected, paired scope-less operator.
- Post-fix: `node scripts/run-vitest.mjs src/gateway/server.device-scope-upgrade.test.ts` — 11 passed.
- Structured autoreview: clean, no accepted/actionable findings.

