### PR TITLE
fix: admin access errors appear once in Inbox

### DIFF
--- a/ui/src/components/sidebar-issue-item.ts
+++ b/ui/src/components/sidebar-issue-item.ts
@@ -173,9 +173,7 @@ function scopeUpgradeText(state: Exclude<ScopeUpgradeState, { phase: "hidden" }>
 }
 
 function scopeUpgradeSummaryText(state: Exclude<ScopeUpgradeState, { phase: "hidden" }>): string {
-  return state.phase === "guidance" || state.phase === "available"
-    ? t("connection.scopeUpgrade.inboxState")
-    : scopeUpgradeText(state);
+  return t("connection.scopeUpgrade.inboxState");
 }
 
 export function renderSidebarScopeUpgradeItem(params: {

--- a/ui/src/components/sidebar-issue-item.ts
+++ b/ui/src/components/sidebar-issue-item.ts
@@ -172,10 +172,6 @@ function scopeUpgradeText(state: Exclude<ScopeUpgradeState, { phase: "hidden" }>
   return state satisfies never;
 }
 
-function scopeUpgradeSummaryText(state: Exclude<ScopeUpgradeState, { phase: "hidden" }>): string {
-  return t("connection.scopeUpgrade.inboxState");
-}
-
 export function renderSidebarScopeUpgradeItem(params: {
   state: ScopeUpgradeState;
   onCancel: () => void;
@@ -187,7 +183,7 @@ export function renderSidebarScopeUpgradeItem(params: {
     return nothing;
   }
   const text = scopeUpgradeText(params.state);
-  const summary = scopeUpgradeSummaryText(params.state);
+  const summary = t("connection.scopeUpgrade.inboxState");
   const retryable =
     params.state.phase === "error"
       ? params.state.retryable

--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -292,6 +292,28 @@ describeControlUiE2e("Control UI live device scope upgrade", () => {
     await expect.poll(() => page.locator(".sidebar-issues-button__count").count()).toBe(0);
   });
 
+  it("shows an administrator access request error once", async () => {
+    const context = await createContext();
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      operatorScopes: LIMITED_SCOPES,
+      methodResponses: {
+        "device.scopes.requestUpgrade": {
+          __mockError: { code: "INVALID_REQUEST", message: "missing scope: operator.read" },
+        },
+      },
+    });
+    await page.goto(`${server.baseUrl}activity`);
+
+    const item = await openLimitedAccessItem(await openInbox(page));
+    await item.getByRole("button", { name: "Request admin" }).click();
+    const message = "Administrator access request failed: missing scope: operator.read";
+    await item.locator(".sidebar-issues-panel__body").getByText(message, { exact: true }).waitFor();
+
+    expect(await item.getByText(message, { exact: true }).count()).toBe(1);
+    await captureProof(page, "desktop-inbox-upgrade-error.png");
+  });
+
   it.each(SCOPE_UPGRADE_METHODS)(
     "keeps role denials non-retryable at %s while transient errors can retry",
     async (method) => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where an expanded administrator-access failure in the Control UI Inbox displayed the same error in both the collapsed summary row and the details body.

## Why This Change Was Made

The Inbox summary now keeps the stable “Administrator access required” state while the expanded body remains the single owner of phase-specific guidance and error details.

## User Impact

Administrator-access failures are shown once and remain actionable with Retry and Cancel.

## Evidence

- Pre-fix browser regression: the exact formatted error occurred twice in one Inbox item.
- Post-fix: `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/device-scope-upgrade.e2e.test.ts` — 9 passed.
- Visual proof captured locally at `.artifacts/control-ui-e2e/admin-access-recovery/desktop-inbox-upgrade-error.png` (not committed).
- Structured autoreview: clean, no accepted/actionable findings.

