### PR TITLE
feat(codex): support filesystem rules in network proxy profiles

### DIFF
--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -297,6 +297,11 @@ export default {
             sandbox: "workspace-write",
             networkProxy: {
               enabled: true,
+              filesystem: {
+                ":root": "read",
+                ":tmpdir": "write",
+                "~/.ssh": "deny",
+              },
               domains: {
                 "api.openai.com": "allow",
                 "blocked.example.com": "deny",
@@ -316,6 +321,11 @@ If the normal app-server runtime would be `danger-full-access`, enabling
 `networkProxy` uses workspace-style filesystem access for the generated
 permission profile instead. Codex-managed network enforcement is sandboxed
 networking, so a full-access profile would not protect outbound traffic.
+Additional filesystem entries use `read`, `write`, or `deny`. OpenClaw
+preserves the generated `:minimal` entry and the `baseProfile` project-root
+access; filesystem entries cannot replace those two base rules. Use explicit
+deny entries for credential directories whenever a broader read entry is
+configured.
 
 The plugin manages stable Codex app-server `0.150.1`. Explicit custom
 executables, remote app-servers, and macOS desktop binaries must report a

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -1292,6 +1292,11 @@ is required.
             sandbox: "workspace-write",
             networkProxy: {
               enabled: true,
+              filesystem: {
+                ":root": "read",
+                ":tmpdir": "write",
+                "~/.ssh": "deny",
+              },
               domains: {
                 "api.openai.com": "allow",
                 "blocked.example.com": "deny",
@@ -1316,7 +1321,11 @@ If the normal app-server runtime would be `danger-full-access`, enabling
 permission profile: Codex managed network enforcement is sandboxed
 networking, so a full-access profile would not protect outbound traffic.
 Domain entries use `allow` or `deny`; Unix socket entries use Codex's
-`allow` or `none` values.
+`allow` or `none` values. Additional filesystem entries use `read`, `write`,
+or `deny`. OpenClaw preserves the generated `:minimal` entry and the
+`baseProfile` project-root access; filesystem entries cannot replace those two
+base rules. Use explicit deny entries for credential directories whenever a
+broader read entry is configured.
 
 ### Image loader ownership
 

--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -372,6 +372,13 @@
                 "type": "string",
                 "enum": ["read-only", "workspace"]
               },
+              "filesystem": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string",
+                  "enum": ["read", "write", "deny"]
+                }
+              },
               "mode": {
                 "type": "string",
                 "enum": ["limited", "full"]
@@ -716,6 +723,11 @@
     "appServer.networkProxy.baseProfile": {
       "label": "Network Proxy Base",
       "help": "Filesystem access used by the generated profile. Defaults to read-only for read-only sandboxes and workspace otherwise.",
+      "advanced": true
+    },
+    "appServer.networkProxy.filesystem": {
+      "label": "Additional Filesystem Permissions",
+      "help": "Additional Codex filesystem permission-profile entries. The generated minimal and project-root entries remain authoritative.",
       "advanced": true
     },
     "appServer.networkProxy.domains": {

--- a/extensions/codex/src/app-server/config-contracts.ts
+++ b/extensions/codex/src/app-server/config-contracts.ts
@@ -130,6 +130,7 @@ type CodexAppServerExperimentalConfig = {
 };
 
 type CodexAppServerNetworkProxyDomainPermission = "allow" | "deny";
+type CodexAppServerNetworkProxyFilesystemPermission = "read" | "write" | "deny";
 type CodexAppServerNetworkProxyUnixSocketPermission = "allow" | "none";
 type CodexAppServerNetworkProxyBaseProfile = "read-only" | "workspace";
 type CodexAppServerNetworkProxyMode = "limited" | "full";
@@ -138,6 +139,7 @@ export type CodexAppServerNetworkProxyConfig = {
   enabled?: boolean;
   profileName?: string;
   baseProfile?: CodexAppServerNetworkProxyBaseProfile;
+  filesystem?: Record<string, CodexAppServerNetworkProxyFilesystemPermission>;
   mode?: CodexAppServerNetworkProxyMode;
   domains?: Record<string, CodexAppServerNetworkProxyDomainPermission>;
   unixSockets?: Record<string, CodexAppServerNetworkProxyUnixSocketPermission>;

--- a/extensions/codex/src/app-server/config-parsing.ts
+++ b/extensions/codex/src/app-server/config-parsing.ts
@@ -62,12 +62,16 @@ const codexAppServerExperimentalSchema = z
   .strict();
 const codexAppServerRemoteWorkspaceRootSchema = z.string().trim().min(1);
 const codexAppServerNetworkProxyDomainPermissionSchema = z.enum(["allow", "deny"]);
+const codexAppServerNetworkProxyFilesystemPermissionSchema = z.enum(["read", "write", "deny"]);
 const codexAppServerNetworkProxyUnixSocketPermissionSchema = z.enum(["allow", "none"]);
 const codexAppServerNetworkProxySchema = z
   .object({
     enabled: z.boolean().optional(),
     profileName: z.string().trim().min(1).optional(),
     baseProfile: z.enum(["read-only", "workspace"]).optional(),
+    filesystem: z
+      .record(z.string(), codexAppServerNetworkProxyFilesystemPermissionSchema)
+      .optional(),
     mode: z.enum(["limited", "full"]).optional(),
     domains: z.record(z.string(), codexAppServerNetworkProxyDomainPermissionSchema).optional(),
     unixSockets: z

--- a/extensions/codex/src/app-server/config-security.ts
+++ b/extensions/codex/src/app-server/config-security.ts
@@ -62,8 +62,13 @@ export function resolveCodexAppServerNetworkProxy(
     dangerously_allow_non_loopback_proxy: config.dangerouslyAllowNonLoopbackProxy,
     dangerously_allow_all_unix_sockets: config.dangerouslyAllowAllUnixSockets,
   });
+  const additionalFilesystem = normalizeNetworkProxyPermissionMap(config.filesystem) ?? {};
+  delete additionalFilesystem[":minimal"];
+  delete additionalFilesystem[":project_roots"];
+  delete additionalFilesystem[":workspace_roots"];
   const profile = {
     filesystem: {
+      ...additionalFilesystem,
       ":minimal": "read",
       ":project_roots": {
         ".": fileSystemMode,

--- a/extensions/codex/src/app-server/config-security.ts
+++ b/extensions/codex/src/app-server/config-security.ts
@@ -70,7 +70,7 @@ export function resolveCodexAppServerNetworkProxy(
     filesystem: {
       ...additionalFilesystem,
       ":minimal": "read",
-      ":project_roots": {
+      ":workspace_roots": {
         ".": fileSystemMode,
       },
     },

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -208,7 +208,7 @@ describe("Codex app-server config", () => {
           "mock-proxy": {
             filesystem: {
               ":minimal": "read",
-              ":project_roots": {
+              ":workspace_roots": {
                 ".": "write",
               },
             },
@@ -251,12 +251,12 @@ describe("Codex app-server config", () => {
     const profileName = runtime.networkProxy?.profileName;
     const permissions = runtime.networkProxy?.configPatch.permissions as Record<
       string,
-      { filesystem: { ":project_roots": { ".": string } } }
+      { filesystem: { ":workspace_roots": { ".": string } } }
     >;
 
     expect(profileName).toMatch(/^openclaw-network-[a-f0-9]{16}$/u);
     expect(runtime.networkProxy?.configPatch.default_permissions).toBe(profileName);
-    expect(permissions[profileName ?? ""]?.filesystem[":project_roots"]["."]).toBe("read");
+    expect(permissions[profileName ?? ""]?.filesystem[":workspace_roots"]["."]).toBe("read");
   });
 
   it("adds declared filesystem rules to network proxy profiles", () => {
@@ -284,7 +284,7 @@ describe("Codex app-server config", () => {
 
     expect(permissions[profileName ?? ""]?.filesystem).toEqual({
       ":minimal": "read",
-      ":project_roots": { ".": "write" },
+      ":workspace_roots": { ".": "write" },
       ":root": "read",
       ":tmpdir": "write",
       "~/.ssh": "deny",

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -259,6 +259,38 @@ describe("Codex app-server config", () => {
     expect(permissions[profileName ?? ""]?.filesystem[":project_roots"]["."]).toBe("read");
   });
 
+  it("adds declared filesystem rules to network proxy profiles", () => {
+    const runtime = resolveRuntimeForTest({
+      pluginConfig: {
+        appServer: {
+          sandbox: "workspace-write",
+          networkProxy: {
+            enabled: true,
+            filesystem: {
+              " :root ": "read",
+              ":tmpdir": "write",
+              ":workspace_roots": "deny",
+              "~/.ssh": "deny",
+            },
+          },
+        },
+      },
+    });
+    const profileName = runtime.networkProxy?.profileName;
+    const permissions = runtime.networkProxy?.configPatch.permissions as Record<
+      string,
+      { filesystem: Record<string, unknown> }
+    >;
+
+    expect(permissions[profileName ?? ""]?.filesystem).toEqual({
+      ":minimal": "read",
+      ":project_roots": { ".": "write" },
+      ":root": "read",
+      ":tmpdir": "write",
+      "~/.ssh": "deny",
+    });
+  });
+
   it("clamps oversized app-server timer config", () => {
     const runtime = resolveRuntimeForTest({
       pluginConfig: {

--- a/extensions/codex/src/app-server/side-question.test.ts
+++ b/extensions/codex/src/app-server/side-question.test.ts
@@ -2033,7 +2033,7 @@ describe("runCodexAppServerSideQuestion", () => {
         "side-proxy": {
           filesystem: {
             ":minimal": "read",
-            ":project_roots": { ".": "write" },
+            ":workspace_roots": { ".": "write" },
           },
           network: {
             enabled: true,

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -95,7 +95,7 @@ function createNetworkProxyThreadLifecycleAppServerOptions() {
       "openclaw-network": {
         filesystem: {
           ":minimal": "read",
-          ":project_roots": {
+          ":workspace_roots": {
             ".": "write",
           },
         },

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -719,7 +719,7 @@ function createNetworkProxyAppServerOptions() {
       "mock-proxy": {
         filesystem: {
           ":minimal": "read",
-          ":project_roots": {
+          ":workspace_roots": {
             ".": "write",
           },
         },


### PR DESCRIPTION
Related: #118684

## What Problem This Solves

Resolves a problem where operators enabling the Codex app-server network proxy could not grant bounded read or temporary-directory access outside the generated workspace profile. Routine inspection tools that depend on user-level configuration or system temporary directories could therefore fail even when network access was safely limited.

## Why This Change Was Made

The Codex plugin now accepts additional filesystem entries using Codex's native `read`, `write`, and `deny` permission values, while preserving the generated `:minimal` and project-root rules as authoritative. The configuration remains opt-in and supports explicit credential-directory denies alongside broader read access.

This PR is AI-assisted. I reviewed the implementation, tests, generated profile shape, and upstream Codex permission contract directly.

## User Impact

Operators can combine a limited domain allowlist with the filesystem access required by ordinary read-only diagnostics, without switching the app-server to unrestricted network or filesystem access. Reserved generated rules cannot be overridden through the additional map.

## Evidence

- Before the fix, the strict plugin parser rejected `appServer.networkProxy.filesystem`; the added regression test failed at config parsing.
- `pnpm test extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/approval-bridge.test.ts extensions/codex/src/manifest.test.ts` — 276 tests passed.
- `pnpm test:extension codex` — all 189 Codex extension test files passed across 16 chunks.
- `pnpm check:changed` — passed after rebasing onto current `origin/main`.
- `pnpm docs:check-config-examples` — 786 documents and 1,208 config examples validated.
- `pnpm build` — passed.
- Direct source verification used OpenClaw's pinned Codex `0.150.1` / `rust-v0.150.1`. `codex-rs/core/src/config/permissions.rs` confirms that `:project_roots` is a legacy input alias while `:workspace_roots` is canonical; `codex-rs/protocol/src/permissions.rs` confirms `read`, `write`, and `deny` (`none` remains a legacy deny alias). The generated base entry now emits `:workspace_roots`, and both spellings remain protected from operator override.
- Real app-server proof on macOS used a built beta3 descendant carrying this exact two-commit patch and the managed Codex app-server. With a limited GitHub/Jira domain allowlist, read-only base, `:root = read`, temporary-directory writes, and explicit credential-path denies, one delivery-disabled owner session completed eight commands without approval: Jira list/view routes, filesystem search, Git status, GitHub API GET, system status, log tail, and bounded HTTP GET.
- The same live profile denied a workspace file-creation canary and left the target absent. Separate destructive-sentinel and credential-read canaries also failed closed without exposing content or mutating external state.

## Redacted Exact-Head Runtime Trace

Source head: de4282202acfbdcda4094469ba0c69eaef168e7e

The immutable macOS app-server release used for this trace carries the same two production patches as this PR. Stable patch-id for the canonical workspace-root fix is 3739d5f858adb44385b3891a02bd611a19bcaa76 in both the release and PR histories; range-diff shows only adjacent upstream documentation-version context drift in the filesystem-map commit.

```text
PROFILE_GENERATED base=read-only mode=limited domains=3
FILESYSTEM :minimal=read :workspace_roots=read broader-root=read temporary-roots=write credential-roots=deny
READ_ROUTES jira-list-help=PASS jira-view-help=PASS filesystem-search=PASS git-status=PASS github-get=PASS system-status=PASS log-tail=PASS http-get=PASS
APPROVAL_RECORDS_FOR_READ_RUN=0
WRITE_CANARY result=DENIED target=ABSENT
DELETE_CANARY result=DENIED sentinel=PRESERVED_DURING_CHECK
CREDENTIAL_CANARY result=DENIED output=SUPPRESSED
EXTERNAL_WRITE_CANARY result=DENIED mutation=NONE
```

No credential value, approval identifier, issue body, private message content, or private filesystem path is included. The focused exact-head suite passes 642/642, including generated profile shape, reserved-key protection, app-server lifecycle binding, and the approval bridge; pnpm check:changed also exits 0.