### PR TITLE
fix(agents): keep transcript redaction out of live tool arguments

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -310,10 +310,13 @@ exec output, and patch summaries):
 - Sensitive-value redaction is always enabled.
 - `logging.redactPatterns`: list of regex strings that replaces the default set for log/transcript output. For Control UI tool payloads, custom patterns apply on top of the built-in defaults, so adding a pattern never weakens redaction of values already caught by the defaults.
 
-File logs and session transcripts stay JSONL, but matching secret values are
-masked before the line or message is written to disk. Redaction is best-effort:
+File logs use JSONL; active session transcripts live in the
+[per-agent SQLite database](/reference/database-schemas#database-layout). Matching
+secret values are masked before the line or message is persisted. Redaction is best-effort:
 it applies to text-bearing message content and log strings, not every
 identifier or binary payload field.
+
+Transcript redaction does not replace the live arguments used to execute tools.
 
 Model-visible tool-result text uses narrower assignment matching so source code
 remains intact. Registered secrets and explicit credential forms, including

--- a/src/agents/sessions/agent-session-base.ts
+++ b/src/agents/sessions/agent-session-base.ts
@@ -1,4 +1,5 @@
 import { cleanupSessionResources } from "@openclaw/ai/internal/runtime";
+import { applyAssistantDeliveryDirectives } from "../../config/sessions/transcript-assistant-delivery.js";
 import { getStreamLlmRuntime } from "../../llm/model-runtime-binding.js";
 import type { AssistantMessage, Model } from "../../llm/types.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -410,6 +411,9 @@ export abstract class AgentSessionBase {
           this.extensionModifiedToolResultIds.delete(event.message.toolCallId);
         let entryId: string;
         try {
+          // Normalize live delivery facts before persistence makes its redacted copy.
+          // Stored arguments must never replace the values used for tool execution.
+          applyAssistantDeliveryDirectives(event.message);
           entryId = this.sessionManager.appendMessage(event.message, {
             invalidateSerializedPrefixCache:
               messageChangedByExtension || toolResultChangedByExtension,
@@ -421,10 +425,6 @@ export abstract class AgentSessionBase {
           throw error;
         }
         if (event.message.role === "assistant") {
-          const persisted = this.sessionManager.getEntry(entryId);
-          if (persisted?.type === "message" && persisted.message.role === "assistant") {
-            replaceAgentMessageInPlace(event.message, persisted.message);
-          }
           this.lastAssistantEntryId = entryId;
         } else if (event.message.role === "user") {
           // A queued user message_end normally follows a committed append before listeners consume it.

--- a/src/agents/sessions/agent-session-runtime-projection.test.ts
+++ b/src/agents/sessions/agent-session-runtime-projection.test.ts
@@ -1,0 +1,138 @@
+import path from "node:path";
+import type { Model } from "openclaw/plugin-sdk/llm";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import { toClientToolDefinitions } from "../agent-tool-definition-adapter.js";
+import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
+import {
+  createAssistant,
+  createAssistantResultStream,
+  createTestSession,
+  registerAgentSessionLoopTestLifecycle,
+  streamMocks,
+} from "./agent-session-loop-correctness.test-support.js";
+import { createResourceLoader } from "./agent-session-loop-resource-loader.test-support.js";
+import type { MessageEndEvent } from "./extensions/types.js";
+import { SessionManager } from "./session-manager.js";
+
+registerAgentSessionLoopTestLifecycle();
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+describe("AgentSession runtime and transcript projections", () => {
+  it.each(["key", "apiKey", "account"])(
+    "executes original %s arguments while preserving redacted storage and delivery facts",
+    async (field) => {
+      const dir = tempDirs.make("openclaw-runtime-projection-");
+      const scope = {
+        agentId: "main",
+        sessionId: "runtime-projection",
+        sessionKey: "agent:main:runtime-projection",
+        storePath: path.join(dir, "sessions.json"),
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      const sessionManager = SessionManager.open(scope, dir);
+      guardSessionManager(sessionManager, { config: {}, allowedToolNames: ["lookup"] });
+      const calls = vi.fn();
+      const values = ["alpha", "beta"];
+      const customTools = toClientToolDefinitions(
+        [
+          {
+            type: "function",
+            function: {
+              name: "lookup",
+              parameters: {
+                type: "object",
+                properties: { [field]: { type: "string", enum: values } },
+                required: [field],
+                additionalProperties: false,
+              },
+            },
+          },
+        ],
+        calls,
+      );
+      streamMocks.streamSimple
+        .mockImplementationOnce((model: Model) =>
+          createAssistantResultStream(
+            createAssistant(
+              model,
+              [
+                { type: "text", text: "Looking up both records." },
+                ...values.map((value, index) => ({
+                  type: "toolCall" as const,
+                  id: `call_${index}`,
+                  name: "lookup",
+                  arguments: { [field]: value },
+                })),
+              ],
+              "toolUse",
+            ),
+          ),
+        )
+        .mockImplementation((model: Model) =>
+          createAssistantResultStream(
+            createAssistant(model, [{ type: "text", text: "Stopped after tool errors." }]),
+          ),
+        );
+      const resourceLoader = createResourceLoader(
+        new Map([
+          [
+            "message_end",
+            [
+              async (event: unknown) => {
+                const { message } = event as MessageEndEvent;
+                if (message.role !== "assistant") {
+                  return undefined;
+                }
+                return {
+                  message: {
+                    ...message,
+                    content: message.content.map((block) =>
+                      block.type === "text"
+                        ? {
+                            type: block.type,
+                            text: `[[reply_to_current]] Extension: ${block.text}`,
+                          }
+                        : block,
+                    ),
+                  },
+                };
+              },
+            ],
+          ],
+        ]),
+      );
+      const { session } = await createTestSession({ sessionManager, customTools, resourceLoader });
+
+      await session.prompt("Look up alpha and beta.");
+
+      expect(calls.mock.calls).toEqual(values.map((value) => ["lookup", { [field]: value }]));
+      expect(streamMocks.streamSimple).toHaveBeenCalledOnce();
+      const live = session.state.messages.find((message) => message.role === "assistant");
+      expect(live).toMatchObject({
+        content: [
+          { type: "text", text: "Extension: Looking up both records." },
+          ...values.map((value) => ({ type: "toolCall", arguments: { [field]: value } })),
+        ],
+        openclawDelivery: { replyToCurrent: true },
+      });
+      const reopened = SessionManager.open(scope, dir);
+      const stored = reopened.getBranch().find((entry) => {
+        return entry.type === "message" && entry.message.role === "assistant";
+      });
+      expect(stored).toMatchObject({
+        message: {
+          content: [
+            { type: "text", text: "Extension: Looking up both records." },
+            ...values.map((value) => ({
+              type: "toolCall",
+              arguments: { [field]: field === "account" ? value : "***" },
+            })),
+          ],
+          openclawDelivery: { replyToCurrent: true },
+        },
+      });
+    },
+  );
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Tool arguments could be redacted before execution. The session listener persisted a finalized assistant message and then copied the stored message back over the live message. The transcript guard correctly masked fields such as `key` and `apiKey`, but that stored projection then reached tool validation: valid enum arguments failed, and unconstrained string arguments could execute with the masked value.

## Why This Change Was Made

Normalize delivery directives on the live message with the existing shared applier before the transcript guard creates its redacted copy. Remove the stored-message readback. Extension `message_end` replacements still precede normalization; standalone session-manager writes retain their existing normalization path. Transcript redaction and persistence hooks remain unchanged. Production delta is +4/-4 (net zero); the regression adds 138 test lines and the docs are +5/-2 (including the adjacent correction from JSONL to canonical SQLite transcript storage).

## User Impact

Client tools receive the original validated arguments while stored transcript values remain redacted. Delivery directives and extension message replacements keep their intended behavior. No new setup is required.

## Evidence

The original regression failed for `key` and `apiKey` and passed its ordinary-field control before the fix. All three pass after the fix. The final test composes a real AgentSession loop, actual client-tool adapter, guarded SQLite persistence, an extension replacement, and a fake provider. It verifies two tool calls retain their original values, stored secret-named fields are masked, and normalized commentary/reply facts survive both live execution and opening a second SessionManager against the same SQLite store.

Nine focused suites passed (212 tests), covering loop ordering, extension callbacks, guarded writes/hooks, transcript redaction, and standalone persistence. The final test was rerun after lint cleanup (3 passed). Targeted type-aware lint, MDX compilation, max-lines and assertion-safety ratchets passed. Both isolated Codex autoreviews, including the final formatting/docs diff, reported no actionable findings. Hosted exact-head CI remains the full typecheck/check gate.

A real built Gateway and OpenAI model passed on Blacksmith Testbox [run 33120120602](https://github.com/openclaw/openclaw/actions/runs/33120120602). JSON with `key` and SSE with `apiKey` each returned two pending client calls carrying `alpha` and `beta` under unchanged strict enum schemas. The fixture's SQLite transcript stored `***` for the same arguments, retained `replyToCurrent`, and removed the raw directive tags. This used the exact baseline plus this runtime patch, its own frozen install and build, isolated HOME/state, and no separate Responses replay patch. The lease was stopped and verified completed. Final changes after that proof are test formatting and documentation only; production bytes are identical.

## Risk and scope

This restores the execution/storage ownership boundary without changing configuration, SQLite schema, protocol, or stored-output contracts. It does not weaken transcript or UI redaction. The inherited `invalidateSerializedPrefixCache` option is retained untouched; its current SQLite implementation does not consume it, so this change makes no cache-performance claim. Removing that obsolete option is a separate follow-up.

Persistence proof clarification: the local test opens a second SessionManager against the existing SQLite store; it does not claim a cold database close/reopen. The live fixture independently opens a read-only SQLite connection and verifies the stored assistant record.


AI-assisted implementation and verification. The final production SHA256 is `64fc9ea28d3bfcffe2a31cb97b5f4f8b9173ecea13ee5fbf4f094fb760a90336`, identical to live proof. Baseline `6e827231257cf7c9c26ecd54fdc73d8c30afa5d8`; final patch SHA256 `ac1678dcef7c4a0dcfcd65b631780dd7f5f0be4e9d5af10cb415a2631cb43835`. Live verification covered pending client-call admission and independent reading of the fixture SQLite rows, not an external lookup server or a second-turn Responses replay.

Both independent review passes were scoped to P0; they are not exhaustive reviews at every priority.
