### PR TITLE
fix(ui): menu shortcut modifier glyphs render correctly

### DIFF
--- a/ui/src/e2e/sidebar-account-footer.e2e.test.ts
+++ b/ui/src/e2e/sidebar-account-footer.e2e.test.ts
@@ -99,6 +99,10 @@ async function runAccountFooterProof(page: Page, sidebar: Locator, branch: "feat
     ]);
 
     const settings = menu.locator('wa-dropdown-item[value="command:settings"]');
+    const settingsShortcut = settings.locator(".session-menu__shortcut");
+    expect(
+      await settingsShortcut.evaluate((element) => getComputedStyle(element).fontFamily),
+    ).toMatch(/^system-ui,/u);
     const settingsRestBackground = await settings.evaluate(
       (element) => getComputedStyle(element).backgroundColor,
     );

--- a/ui/src/e2e/theme-typography.e2e.test.ts
+++ b/ui/src/e2e/theme-typography.e2e.test.ts
@@ -1,6 +1,10 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import {
+  formatKeyboardShortcutCombo,
+  KEYBOARD_SHORTCUT_COMBOS,
+} from "../lib/keyboard-shortcut-contract.ts";
 import { controlUiBundledGatewayUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { requireRecord, requireString } from "./chat-flow.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -177,6 +181,69 @@ suite.define(() => {
     if (captureUiProof) {
       await page.screenshot({ path: path.join(proofDirectory, `${spec.theme}-chat-dark.png`) });
     }
+  });
+
+  it("keeps Phosphor menu modifier glyphs on the system UI stack", async () => {
+    const { page } = await openThemedChat("phosphor", "dark");
+    await page.goto(`${suite.server.baseUrl}chat`);
+    const identity = page.locator(".sidebar-identity-card");
+    await identity.focus();
+    await page.keyboard.press("Enter");
+    const menu = page.locator("wa-dropdown.sidebar-identity-menu");
+    await menu.waitFor();
+    const shortcut = menu
+      .locator('wa-dropdown-item[value="command:settings"]')
+      .locator(".session-menu__shortcut");
+
+    const report = await shortcut.evaluate((element) => ({
+      body: getComputedStyle(document.body).fontFamily,
+      shortcut: getComputedStyle(element).fontFamily,
+      text: element.textContent,
+    }));
+    expect(report.body).toMatch(/^"?JetBrains Mono/u);
+    expect(report.shortcut).toMatch(/^system-ui,/u);
+    const applePlatform = await page.evaluate(() =>
+      /Mac|iPhone|iPad|iPod/u.test(navigator.platform),
+    );
+    expect(report.text).toBe(
+      formatKeyboardShortcutCombo(KEYBOARD_SHORTCUT_COMBOS.appearanceSettings, applePlatform),
+    );
+
+    if (captureUiProof) {
+      await mkdir(proofDirectory, { recursive: true });
+      await page.screenshot({ path: path.join(proofDirectory, "phosphor-settings-shortcut.png") });
+    }
+
+    const modelShortcutFont = await page.evaluate(() => {
+      const action = document.createElement("span");
+      action.className = "chat-controls__model-option-action";
+      const keycap = document.createElement("kbd");
+      action.append(keycap);
+      document.body.append(action);
+      const fontFamily = getComputedStyle(keycap).fontFamily;
+      action.remove();
+      return fontFamily;
+    });
+    expect(modelShortcutFont).toBe(
+      await page.evaluate(() =>
+        getComputedStyle(document.documentElement).getPropertyValue("--mono").trim(),
+      ),
+    );
+
+    const genericMenuShortcutFont = await page.evaluate(() => {
+      const genericShortcut = document.createElement("span");
+      genericShortcut.className = "session-menu__shortcut";
+      genericShortcut.textContent = "C";
+      document.body.append(genericShortcut);
+      const fontFamily = getComputedStyle(genericShortcut).fontFamily;
+      genericShortcut.remove();
+      return fontFamily;
+    });
+    expect(genericMenuShortcutFont).toBe(
+      await page.evaluate(() =>
+        getComputedStyle(document.documentElement).getPropertyValue("--mono").trim(),
+      ),
+    );
   });
 
   it.each([

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2659,9 +2659,9 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   white-space: nowrap;
 }
 
-/* Keycap hint, not content: the app's quiet mono shortcut idiom (see
-   .chat-question-panel__option kbd), fixed-width so letters and digits share
-   one rail beside the labels. */
+/* Keycap hint, not content: the app's quiet mono shortcut idiom, fixed-width so
+   letters and digits share one rail. Identity-menu chords use the system UI face
+   below because theme body fonts are not guaranteed to cover modifier glyphs. */
 .session-menu__shortcut,
 .chat-controls__model-option-action kbd {
   flex: 0 0 auto;
@@ -2671,6 +2671,15 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
   font-size: var(--control-ui-text-xs);
   line-height: 1;
   text-align: center;
+}
+
+.sidebar-identity-menu .session-menu__shortcut {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI Symbol",
+    sans-serif;
 }
 
 .session-menu__info {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Control UI account menu would see the Settings shortcut's Shift modifier render as a malformed, detached mark.

## Why This Change Was Made

Identity-menu chords now use a glyph-safe system UI font stack instead of the shared code-font stack. The shortcut formatter and Unicode glyphs remain unchanged. Generic single-letter context-menu hints and model-picker numeric keycaps keep their intentional monospace face. Browser assertions protect the default and Phosphor theme paths plus both sibling monospace rules.

## User Impact

macOS modifier symbols in Control UI identity-menu shortcuts render consistently across supported themes and remain legible at the compact menu size. Other shortcut hints retain their existing appearance.

## Evidence

### Before

![Settings shortcut before: malformed Shift modifier](https://github.com/user-attachments/assets/12405ec2-b518-46c8-ac3e-1fb386863b3b)

### After

![Settings shortcut after: complete Shift modifier](https://github.com/user-attachments/assets/240db000-99cb-427b-a27b-22df0fd79bfe)

### After — Phosphor theme

![Settings shortcut in the Phosphor theme](https://github.com/user-attachments/assets/b41f0638-618c-4a57-b3ab-584c292ebff5)

Focused browser proof:

- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-account-footer.e2e.test.ts ui/src/e2e/theme-typography.e2e.test.ts`
- Result: 19 tests passed, covering the repaired menu chord, Phosphor's mono body theme, preserved monospace generic menu hints, and preserved monospace model-picker keycaps.
- Focused `oxlint`, `oxfmt`, and `git diff --check`: passed.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33125429295) passed for `4d004722c435187944e8115ccc49fc57f8d3b988`.
