### PR TITLE
fix(ui): utility model info is compact and shows a tooltip

### DIFF
--- a/ui/src/components/config-form.browser.test.ts
+++ b/ui/src/components/config-form.browser.test.ts
@@ -858,10 +858,14 @@ describe("config form renderer", () => {
       "section help button",
     );
     expect(button.getAttribute("aria-label")).toBe("Help for Gateway");
+    const tooltip = expectElement(button.closest("openclaw-tooltip"), "section help tooltip");
+    expect((tooltip as HTMLElement & { content: string }).content).toBe("Help for Gateway");
     const link = expectElement(
       container.querySelector<HTMLAnchorElement>(".settings-section__help-popover a"),
       "section guide link",
     );
+    const popover = expectElement(link.closest("wa-popover"), "section help popover");
+    expect(button.getAttribute("aria-controls")).toBe(popover.id);
     expect(link.getAttribute("href")).toBe("https://docs.openclaw.ai/gateway/configuration");
     expect(link.getAttribute("target")).toBe("_blank");
     expect(link.getAttribute("rel")).toBe("noopener noreferrer");

--- a/ui/src/components/config-form.browser.test.ts
+++ b/ui/src/components/config-form.browser.test.ts
@@ -858,6 +858,7 @@ describe("config form renderer", () => {
       "section help button",
     );
     expect(button.getAttribute("aria-label")).toBe("Help for Gateway");
+    expect(button.querySelector("svg")).not.toBeNull();
     const tooltip = expectElement(button.closest("openclaw-tooltip"), "section help tooltip");
     expect((tooltip as HTMLElement & { content: string }).content).toBe("Help for Gateway");
     const link = expectElement(

--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -265,7 +265,7 @@ export function renderConfigForm(props: ConfigFormProps) {
                           id: docsTriggerId,
                           label: t("configForm.sectionHelp", { section: params.label }),
                           tooltip: t("configForm.sectionHelp", { section: params.label }),
-                          glyph: "?",
+                          icon: "question",
                           popoverId: `settings-section-help-popover-${params.id}`,
                         })}
                         <wa-popover

--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -9,7 +9,11 @@ import { renderNode } from "./config-form.node.ts";
 import { matchesConfigSectionSearch, parseConfigSearchQuery } from "./config-form.search.ts";
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 import { splitConfigSchemaByTier } from "./config-form.tiers.ts";
-import { renderSettingsEmpty, renderSettingsPage } from "./settings-ui.ts";
+import {
+  renderSettingsEmpty,
+  renderSettingsHelpTrigger,
+  renderSettingsPage,
+} from "./settings-ui.ts";
 
 type ConfigFormProps = {
   schema: JsonSchema | null;
@@ -257,16 +261,15 @@ export function renderConfigForm(props: ConfigFormProps) {
                 ${docsUrl
                   ? html`
                       <span class="settings-section__docs">
-                        <button
-                          id=${docsTriggerId}
-                          type="button"
-                          class="settings-section__help-button"
-                          aria-label=${t("configForm.sectionHelp", { section: params.label })}
-                          aria-haspopup="dialog"
-                        >
-                          <span aria-hidden="true">?</span>
-                        </button>
+                        ${renderSettingsHelpTrigger({
+                          id: docsTriggerId,
+                          label: t("configForm.sectionHelp", { section: params.label }),
+                          tooltip: t("configForm.sectionHelp", { section: params.label }),
+                          glyph: "?",
+                          popoverId: `settings-section-help-popover-${params.id}`,
+                        })}
                         <wa-popover
+                          id=${`settings-section-help-popover-${params.id}`}
                           class="settings-section__help-popover"
                           for=${docsTriggerId}
                           placement="bottom-end"

--- a/ui/src/components/ip-location.test.ts
+++ b/ui/src/components/ip-location.test.ts
@@ -47,6 +47,8 @@ describe("openclaw-ip-location", () => {
     await settleUntil(element, () => (element.textContent ?? "").includes("Vienna, Vienna"));
 
     expect(element.querySelector("a")?.getAttribute("href")).toBe("https://db-ip.com");
+    expect(element.querySelector("a")?.getAttribute("aria-label")).toBe("IP Geolocation by DB-IP");
+    expect(element.querySelector("a svg")).not.toBeNull();
   });
 
   it("renders nothing when the address cannot be placed", async () => {

--- a/ui/src/components/ip-location.ts
+++ b/ui/src/components/ip-location.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { lookupClientGeolocation, type ClientGeolocation } from "../lib/geolocation-lookup.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
+import { icons } from "./icons.ts";
 
 // The first lookup on a fresh Gateway waits on a database download that can take
 // a minute, so an unavailable answer is retried on a widening delay instead of
@@ -87,8 +88,9 @@ class OpenClawIpLocation extends OpenClawLightDomContentsElement {
             href=${attribution.url}
             target="_blank"
             rel="noreferrer noopener"
+            aria-label=${attribution.text}
             title=${attribution.text}
-            >ⓘ</a
+            >${icons.info}</a
           >`
         : nothing}</span
     >`;

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -41,7 +41,7 @@ type SettingsHelpTriggerProps = {
   id: string;
   label: string;
   tooltip: string;
-  glyph: "?" | "i";
+  icon: "question" | "info";
   popoverId: string;
 };
 
@@ -65,6 +65,7 @@ export function renderDocsLink(url: string, label: unknown): TemplateResult {
 }
 
 export function renderSettingsHelpTrigger(props: SettingsHelpTriggerProps): TemplateResult {
+  const helpIcon = props.icon === "info" ? icons.info : icons.circleQuestionMark;
   return html`
     <openclaw-tooltip .content=${props.tooltip}>
       <button
@@ -75,7 +76,7 @@ export function renderSettingsHelpTrigger(props: SettingsHelpTriggerProps): Temp
         aria-controls=${props.popoverId}
         aria-haspopup="dialog"
       >
-        <span aria-hidden="true">${props.glyph}</span>
+        <span aria-hidden="true">${helpIcon}</span>
       </button>
     </openclaw-tooltip>
   `;

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -37,6 +37,14 @@ export type SettingsSectionProps = {
   danger?: boolean;
 };
 
+type SettingsHelpTriggerProps = {
+  id: string;
+  label: string;
+  tooltip: string;
+  glyph: "?" | "i";
+  popoverId: string;
+};
+
 export function renderSettingsPage(
   children: unknown,
   options: { wide?: boolean; intro?: unknown } = {},
@@ -54,6 +62,23 @@ export function renderDocsLink(url: string, label: unknown): TemplateResult {
   return html`<a href=${url} target=${EXTERNAL_LINK_TARGET} rel=${buildExternalLinkRel()}
     >${label}</a
   >`;
+}
+
+export function renderSettingsHelpTrigger(props: SettingsHelpTriggerProps): TemplateResult {
+  return html`
+    <openclaw-tooltip .content=${props.tooltip}>
+      <button
+        id=${props.id}
+        type="button"
+        class="settings-section__help-button"
+        aria-label=${props.label}
+        aria-controls=${props.popoverId}
+        aria-haspopup="dialog"
+      >
+        <span aria-hidden="true">${props.glyph}</span>
+      </button>
+    </openclaw-tooltip>
+  `;
 }
 
 /** Section = plain text heading + one group surface containing rows. */

--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -25,6 +25,17 @@ suite.define(() => {
         viewport: { height: 900, width: 1280 },
       },
       async ({ page }) => {
+        await page.route("**/plugins/geolocation/lookup?ip=203.0.113.20", async (route) => {
+          await route.fulfill({
+            contentType: "application/json",
+            json: {
+              found: true,
+              city: "Vienna",
+              region: "Vienna",
+              attribution: { text: "IP Geolocation by DB-IP", url: "https://db-ip.com" },
+            },
+          });
+        });
         const current = new Date();
         // Keep the automation fixtures on one local calendar day in every timezone.
         const now = new Date(
@@ -51,6 +62,7 @@ suite.define(() => {
               host: "Alice's MacBook Pro",
               platform: "macOS 26.5",
               deviceFamily: "Mac",
+              ip: "203.0.113.20",
               lastInputSeconds: 32,
               watchedSessions: [releaseKey, designKey],
             },
@@ -312,6 +324,9 @@ suite.define(() => {
         await expect
           .poll(() => activityPage.locator('[data-activity-identity="profile-alice"]').isVisible())
           .toBe(true);
+        const attributionIcon = activityPage.locator(".activity-feed__device-attribution");
+        await expect.poll(() => attributionIcon.locator("svg").count()).toBe(1);
+        await expect.poll(async () => (await attributionIcon.boundingBox())?.width).toBe(16);
         await expect
           .poll(() =>
             activityPage.locator(".activity-feed__viewing-list .activity-feed__session").count(),

--- a/ui/src/e2e/chat-only-model.e2e.test.ts
+++ b/ui/src/e2e/chat-only-model.e2e.test.ts
@@ -105,6 +105,9 @@ suite.define(() => {
         .poll(() => localOption.locator(".chat-controls__model-option-meta").textContent())
         .toBe("32.8k");
       await expect.poll(() => localOption.getAttribute("aria-label")).toContain("cannot use tools");
+      const infoIcon = localOption.locator(".chat-controls__model-chat-only-info");
+      await expect.poll(() => infoIcon.locator("svg").count()).toBe(1);
+      await expect.poll(async () => (await infoIcon.boundingBox())?.width).toBe(16);
       await expect
         .poll(async () => (await openAiOption.textContent())?.includes("Chat only"))
         .toBe(false);

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -411,6 +411,23 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
         await expect
           .poll(() => helpButton.evaluate((node) => getComputedStyle(node).color))
           .not.toBe(defaultColor);
+        const hoverTooltip = utilityLabel.locator("openclaw-tooltip wa-tooltip");
+        expect(await hoverTooltip.count()).toBe(1);
+        await expect
+          .poll(() => hoverTooltip.evaluate((node) => node.hasAttribute("open")))
+          .toBe(true);
+        await expect.poll(() => hoverTooltip.textContent()).toContain("short background tasks");
+        const helpButtonBox = await helpButton.boundingBox();
+        expect(helpButtonBox).not.toBeNull();
+        expect(helpButtonBox?.width).toBeLessThanOrEqual(18);
+        expect(helpButtonBox?.height).toBeLessThanOrEqual(18);
+        if (recordVisuals) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(utilityHelpArtifactDir, `${colorScheme}-hover-tooltip-full.png`),
+          });
+        }
 
         await helpButton.click();
         const popover = page.locator("wa-popover.model-providers__utility-help-popover");

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -386,6 +386,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
         const utilityField = defaults.locator(".field").nth(1);
         const utilityLabel = utilityField.locator(".model-providers__utility-label");
         await utilityField.waitFor();
+        expect(await utilityLabel.evaluate((node) => getComputedStyle(node).columnGap)).toBe("8px");
         await expect
           .poll(() => modelPickerValue(utilityField.locator("wa-select")))
           .toBe("__openclaw_automatic_utility__");

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -404,6 +404,7 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
 
         const helpButton = defaults.getByRole("button", { name: "About the utility model" });
         await expect.poll(() => helpButton.count()).toBe(1);
+        await expect.poll(() => helpButton.locator("svg").count()).toBe(1);
         expect(await helpButton.getAttribute("aria-haspopup")).toBe("dialog");
 
         const defaultColor = await helpButton.evaluate((node) => getComputedStyle(node).color);

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -419,8 +419,8 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
         await expect.poll(() => hoverTooltip.textContent()).toContain("short background tasks");
         const helpButtonBox = await helpButton.boundingBox();
         expect(helpButtonBox).not.toBeNull();
-        expect(helpButtonBox?.width).toBeLessThanOrEqual(18);
-        expect(helpButtonBox?.height).toBeLessThanOrEqual(18);
+        expect(helpButtonBox?.width).toBeLessThanOrEqual(16);
+        expect(helpButtonBox?.height).toBeLessThanOrEqual(16);
         if (recordVisuals) {
           await page.screenshot({
             animations: "disabled",

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -353,13 +353,6 @@
     },
     {
       "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/chat/components/chat-model-picker-options.ts",
-      "text": "i"
-    },
-    {
-      "count": 1,
       "kind": "object-property",
       "name": "title",
       "path": "ui/src/pages/chat/components/chat-pane-header.test-support.ts",

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -464,13 +464,6 @@
       "text": "exec host=gateway/node"
     },
     {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/pages/model-providers/default-models-view.ts",
-      "text": "i"
-    },
-    {
       "count": 4,
       "kind": "html-text",
       "name": "text",

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -7182,9 +7182,9 @@ describe("chat model controls", () => {
     ).toBe("32.8k");
     expect(
       container.querySelector(
-        '[data-chat-model-option="lmstudio/qwen3-8b"] .chat-controls__model-chat-only-info',
-      )?.textContent,
-    ).toBe("i");
+        '[data-chat-model-option="lmstudio/qwen3-8b"] .chat-controls__model-chat-only-info svg',
+      ),
+    ).not.toBeNull();
     expect(
       container.querySelector('[data-chat-model-option="openai/gpt-5.5"]')?.textContent,
     ).not.toContain("Chat only");

--- a/ui/src/pages/chat/components/chat-model-picker-options.ts
+++ b/ui/src/pages/chat/components/chat-model-picker-options.ts
@@ -154,7 +154,9 @@ export function renderChatModelPickerOption(params: {
           ? html`<span class="chat-controls__model-option-meta">${modelMeta}</span>`
           : nothing}
         ${params.entry.supportsTools === false
-          ? html`<span class="chat-controls__model-chat-only-info" aria-hidden="true">i</span>`
+          ? html`<span class="chat-controls__model-chat-only-info" aria-hidden="true"
+              >${icons.info}</span
+            >`
           : nothing}
       </span>
     </span>

--- a/ui/src/pages/model-providers/default-models-view.ts
+++ b/ui/src/pages/model-providers/default-models-view.ts
@@ -95,7 +95,7 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
                 id: UTILITY_MODEL_HELP_ID,
                 label: t("modelProviders.defaults.utilityHelpLabel"),
                 tooltip: t("modelProviders.defaults.utilityHelpPurpose"),
-                glyph: "i",
+                icon: "info",
                 popoverId: UTILITY_MODEL_HELP_POPOVER_ID,
               })}
               <wa-popover

--- a/ui/src/pages/model-providers/default-models-view.ts
+++ b/ui/src/pages/model-providers/default-models-view.ts
@@ -1,6 +1,6 @@
 import { html, nothing } from "lit";
 import { renderModelPicker, type ModelPickerOption } from "../../components/model-picker.ts";
-import { renderSettingsSection } from "../../components/settings-ui.ts";
+import { renderSettingsHelpTrigger, renderSettingsSection } from "../../components/settings-ui.ts";
 import "../../components/web-awesome-popover.ts";
 import { t } from "../../i18n/index.ts";
 import { modelCatalogRef, type DefaultModelSelection, type ModelPickerEntry } from "./data.ts";
@@ -91,16 +91,13 @@ export function renderDefaultModels(props: DefaultModelsViewProps) {
           <span class="model-providers__utility-label">
             <label for=${UTILITY_MODEL_PICKER_ID}>${t("modelProviders.defaults.utility")}</label>
             <span class="settings-section__docs">
-              <button
-                id=${UTILITY_MODEL_HELP_ID}
-                type="button"
-                class="settings-section__help-button"
-                aria-label=${t("modelProviders.defaults.utilityHelpLabel")}
-                aria-controls=${UTILITY_MODEL_HELP_POPOVER_ID}
-                aria-haspopup="dialog"
-              >
-                <span aria-hidden="true">i</span>
-              </button>
+              ${renderSettingsHelpTrigger({
+                id: UTILITY_MODEL_HELP_ID,
+                label: t("modelProviders.defaults.utilityHelpLabel"),
+                tooltip: t("modelProviders.defaults.utilityHelpPurpose"),
+                glyph: "i",
+                popoverId: UTILITY_MODEL_HELP_POPOVER_ID,
+              })}
               <wa-popover
                 id=${UTILITY_MODEL_HELP_POPOVER_ID}
                 class="settings-section__help-popover model-providers__utility-help-popover"

--- a/ui/src/styles/activity.css
+++ b/ui/src/styles/activity.css
@@ -565,9 +565,18 @@ openclaw-activity-page {
 /* The credit is a license term for the default database, so it stays visible
    next to the value it describes rather than living in a settings page. */
 .activity-feed__device-attribution {
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
   color: var(--muted);
   text-decoration: none;
-  font-size: var(--control-ui-text-xs);
+}
+
+.activity-feed__device-attribution svg {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .activity-feed__device-attribution:hover,

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -6580,18 +6580,17 @@ button.chat-pr__diff {
 }
 
 .chat-controls__model-chat-only-info {
-  display: inline-grid;
-  width: 15px;
-  height: 15px;
+  display: inline-flex;
+  width: 16px;
+  height: 16px;
   margin-inline-start: 6px;
-  border: 1px solid color-mix(in srgb, var(--warn) 54%, transparent);
-  border-radius: var(--radius-full);
   color: color-mix(in srgb, var(--warn) 80%, var(--text));
-  font-family: var(--mono);
-  font-size: 9px;
-  font-weight: 700;
-  line-height: 1;
-  place-items: center;
+}
+
+.chat-controls__model-chat-only-info svg {
+  display: block;
+  width: 100%;
+  height: 100%;
 }
 
 .chat-controls__reasoning-panel {

--- a/ui/src/styles/model-providers.css
+++ b/ui/src/styles/model-providers.css
@@ -168,7 +168,7 @@
 .model-providers__utility-label {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-1);
+  gap: var(--space-2);
   width: fit-content;
 }
 

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -163,24 +163,27 @@
   height: 16px;
   padding: 0;
   place-items: center;
-  border: 1px solid color-mix(in srgb, var(--muted) 35%, transparent);
-  border-radius: 50%;
+  border: 0;
   background: transparent;
   color: var(--muted);
-  font: 600 var(--control-ui-text-xs) / 1 var(--font-body);
   cursor: var(--cursor-action);
 }
 
 .settings-section__help-button > span {
-  /* SF's ascent+descent exceed 1em, so a centered line box parks the glyph
-     below the circle's midline; trim to cap bounds for true centering. */
   display: block;
-  text-box: trim-both cap alphabetic;
+  width: 100%;
+  height: 100%;
+}
+
+.settings-section__help-button svg {
+  display: block;
+  width: 100%;
+  height: 100%;
+  stroke-width: 1.75;
 }
 
 .settings-section__help-button:hover,
 .settings-section__help-button:focus-visible {
-  border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
   color: var(--accent);
 }
 

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -159,8 +159,8 @@
 
 .settings-section__help-button {
   display: inline-grid;
-  width: 22px;
-  height: 22px;
+  width: 18px;
+  height: 18px;
   padding: 0;
   place-items: center;
   border: 1px solid color-mix(in srgb, var(--muted) 35%, transparent);

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -159,8 +159,8 @@
 
 .settings-section__help-button {
   display: inline-grid;
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   padding: 0;
   place-items: center;
   border: 1px solid color-mix(in srgb, var(--muted) 35%, transparent);

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -332,6 +332,7 @@ export type ControlUiMockGatewayScenario = {
     avatarUrl?: string;
     deviceFamily?: string;
     host?: string;
+    ip?: string;
     instanceId?: string;
     lastInputSeconds?: number;
     onlineSince?: number;
@@ -1380,6 +1381,7 @@ function installControlUiMockGateway(
         reason: "connect",
         ts: user.ts ?? Date.now(),
         ...(user.host ? { host: user.host } : {}),
+        ...(user.ip ? { ip: user.ip } : {}),
         ...(user.platform ? { platform: user.platform } : {}),
         ...(user.deviceFamily ? { deviceFamily: user.deviceFamily } : {}),
         ...(user.lastInputSeconds === undefined ? {} : { lastInputSeconds: user.lastInputSeconds }),


### PR DESCRIPTION
## What Problem This Solves

Fixes the oversized Utility model info icon and missing hover explanation, then removes the remaining Control UI text glyphs being styled as info icons.

## Why This Change Was Made

The Utility model control now uses the shared settings help trigger backed by `openclaw-tooltip`, while preserving the richer click popover for keyboard and pointer users. The trigger renders the existing Lucide-style `icons.info` and `icons.circleQuestionMark` SVGs through the repo's shared `strokeIcon()` shell, so the complete icon scales consistently at 16px instead of combining a CSS circle with a text glyph. The label-to-icon gap is now 8px.

A repository-wide source audit checked literal `i`/`ⓘ` text nodes, CSS `content: "i"`, and `glyph: "i"` props. It found two sibling surfaces: the chat-only model marker and IP-location attribution. Both now use the existing shared Lucide info icon; no new icon dependency or custom SVG was added.

Production LOC: +85/-44 (net +41) | Tests/test support: +49/-3 | Generated raw-copy baseline: +0/-14. The production growth establishes one shared settings help-trigger boundary and replaces three custom glyph presentations with accessible shared SVG icons.

## User Impact

The Utility model info icon is 16px, has a little more breathing room, and immediately explains the setting on hover or focus. Clicking it still opens the detailed explanation. Chat-only model and IP-attribution info marks now scale as complete 16px Lucide icons instead of tiny text glyphs.

## Evidence

### Utility model — before / after

| Before: oversized custom glyph | After: 16px Lucide icon, 8px gap |
| --- | --- |
| ![Before: oversized Utility model info icon](https://github.com/user-attachments/assets/870607ab-4890-4a1d-b88d-b8d8ef07d27a) | ![After: compact 16px Lucide Utility model info icon with more spacing](https://github.com/user-attachments/assets/9d5421f4-2c90-4d58-bd3e-6a269a010884) |

#### Hover tooltip

![Utility model tooltip visible on hover](https://github.com/user-attachments/assets/93ca467d-d712-4547-b687-9e4511c51a05)

### Chat-only model marker — before / after

| Before: CSS circle + literal `i` | After: shared 16px Lucide info icon |
| --- | --- |
| ![Before: literal i in the chat model picker](https://github.com/user-attachments/assets/18ef799f-89df-4fd2-842e-6dd8c7fe2033) | ![After: Lucide info icon in the chat model picker](https://github.com/user-attachments/assets/83cdc10b-995c-4ce4-b0db-87dfc2985e09) |

### IP-location attribution — before / after

| Before: literal Unicode `ⓘ` | After: shared 16px Lucide info icon |
| --- | --- |
| ![Before: literal Unicode info glyph beside a location](https://github.com/user-attachments/assets/61864bf9-573a-4350-8dd5-25be2b3d7289) | ![After: Lucide info icon beside a location](https://github.com/user-attachments/assets/23e9057f-90b7-4eab-afdc-0d376d1d09c9) |

## Validation

- Source audit: no remaining literal `i`/`ⓘ` info text nodes, CSS `content: "i"`, or `glyph: "i"` props.
- Utility model Playwright: 1 passed, 5 skipped; asserts 8px label gap, 16px icon, hover/focus tooltip, click popover, keyboard behavior, and narrow layout.
- Chat-only model Playwright: 1 passed; asserts a shared SVG at 16px and records the picker proof.
- Activity feed Playwright: 1 passed; asserts the attribution SVG at 16px and records the activity proof.
- Focused UI units: settings form 18 passed; IP location 3 passed; chat model marker 1 passed.
- Changed-file checks: dead-export scan passed on the full diff; formatting, i18n, typecheck, lint, and style checks passed after the generated raw-copy baseline refresh.
- `git diff --check` — passed.
- Autoreview — clean, no accepted/actionable findings (0.99 confidence).
