### PR TITLE
improve(ui): reduce gateway name test polling

### DIFF
--- a/ui/src/pages/new-session/draft-place-browser.test.ts
+++ b/ui/src/pages/new-session/draft-place-browser.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { DraftGatewayState } from "./draft-gateway-state.ts";
 import { DraftPlaceBrowser } from "./draft-place-browser.ts";
 import type { NewSessionRouteData } from "./location.ts";
@@ -155,7 +156,7 @@ describe("DraftGatewayState", () => {
     fixture.hello.features.methods.push("system.info");
     fixture.client.recoveryScopeReady = false;
     fixture.update();
-    await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe("Gateway A"));
+    await waitForFast(() => expect(fixture.gateway.gatewayName).toBe("Gateway A"));
 
     fixture.client.recoveryScope = "resolved-principal";
     fixture.client.recoveryScopeReady = true;
@@ -169,7 +170,7 @@ describe("DraftGatewayState", () => {
     const fixture = createBrowser(request);
     fixture.hello.features.methods.push("system.info");
     fixture.update();
-    await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe("Gateway A"));
+    await waitForFast(() => expect(fixture.gateway.gatewayName).toBe("Gateway A"));
 
     fixture.context.gateway.snapshot.phase = "reconnecting";
     fixture.update();
@@ -179,7 +180,7 @@ describe("DraftGatewayState", () => {
     fixture.update();
     expect(fixture.gateway.gatewayName).toBe("");
     pending.resolve({ machineName: "Gateway B" });
-    await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe("Gateway B"));
+    await waitForFast(() => expect(fixture.gateway.gatewayName).toBe("Gateway B"));
   });
 
   it("ignores a late name from the replaced client", async () => {
@@ -197,7 +198,7 @@ describe("DraftGatewayState", () => {
     });
     expect(fixture.gateway.gatewayName).toBe("");
     newName.resolve({ machineName: "Active Gateway" });
-    await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe("Active Gateway"));
+    await waitForFast(() => expect(fixture.gateway.gatewayName).toBe("Active Gateway"));
   });
 
   it.each([
@@ -217,7 +218,7 @@ describe("DraftGatewayState", () => {
       const fixture = createBrowser(request);
       fixture.hello.features.methods.push("system.info");
       fixture.update();
-      await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe("Current Gateway"));
+      await waitForFast(() => expect(fixture.gateway.gatewayName).toBe("Current Gateway"));
       current = response;
       fixture.context.gateway.snapshot.phase = "reconnecting";
       fixture.update();
@@ -227,7 +228,7 @@ describe("DraftGatewayState", () => {
       await new Promise<void>((resolve) => {
         setTimeout(resolve, 0);
       });
-      await vi.waitFor(() => expect(fixture.gateway.gatewayName).toBe(name));
+      await waitForFast(() => expect(fixture.gateway.gatewayName).toBe(name));
       expect(request.mock.calls.filter(([method]) => method === "system.info")).toHaveLength(
         advertised ? 2 : 1,
       );


### PR DESCRIPTION
## What Problem This Solves

Gateway place-label tests spend time waiting for Vitest's default polling interval after their promise-driven state has already changed. This adds avoidable latency to the focused UI test lane.

## Why This Change Was Made

Use the existing UI `waitForFast` helper for six Gateway-name assertion sites instead of default `vi.waitFor`. The helper polls at 1ms with the same timeout. Both explicit `setTimeout(0)` completion barriers, all assertions, request counts, fixtures, and pending/replaced-client boundaries remain unchanged. No global timer defaults, fake timers, private Task access, or production seams are introduced.

The owner is `DraftGatewayState` and its Lit name-discovery task. The observable getter is the appropriate synchronization point: Lit's `taskComplete` follows a replacement run and cannot by itself prove that an obsolete request has completed. Existing completion barriers continue to cover that distinction.

## User Impact

No runtime or visual behavior changes. Developers get a faster focused UI test lane with the same ten cases. Production LOC: **0**. Test LOC: **+7/-6 (net +1)**. No changelog, dependency, snapshot, or baseline changes.

## Evidence

Measured on one dedicated Linux Blacksmith Testbox, Node 24.19.0 / pnpm 11.22.0, against main `7c5a880cca8a3aeec1420ff9da4d422f24b311f4`. Excluded warmups; eight samples per variant; alternating AB/BA pairs; one worker; a distinct filesystem module cache per sample; import timing/breakdown enabled; GNU `/usr/bin/time -v`. All ten cases passed in every sample.

| Median metric | Before | After |
| --- | ---: | ---: |
| Scoped wall | 2.870s | 2.560s |
| Vitest duration | 2.165s | 1.820s |
| Test body | 374.5ms | 25ms |
| Imports | 1.135s | 1.155s |
| Peak RSS | 718,812 KiB | 711,136 KiB |
| User / system CPU | 3.030 / 0.425s | 3.070 / 0.440s |
| CPU utilization | 120.5% | 134.5% |

**Wall improvement: 0.310s / 10.8%; seven of eight paired wins.** The slow final after sample is retained. Before/after wall samples (seconds): `2.91/2.44, 2.61/2.38, 2.77/2.51, 2.83/2.60, 2.79/2.52, 3.00/2.71, 3.28/3.13, 2.91/3.17`. This is a scoped test measurement, not a whole-suite speed claim.

Reproduction command, using a new cache path for each sample:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 \
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/ui-polling-sample-A1 \
OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
/usr/bin/time -v node scripts/run-vitest.mjs \
  ui/src/pages/new-session/draft-place-browser.test.ts --maxWorkers=1
```

Reversible owner mutations were each run against both before and after tests, then restored byte-for-byte. All six runs failed for the intended reason:

- Remove the completed-task getter gate: the pending/disconnected test sees `Gateway A` instead of an empty name.
- Suppress task argument changes with `argsEqual: () => true`: the replaced-client test sees `Retired Gateway` instead of an empty name.
- Add recovery scope to the name-task arguments: the scope-arrival test loses `Gateway A`.

Test audit: the retained cases protect recovery-scope independence, hiding pending/stale names, rejecting late retired-client results, method advertisement, hostname fallback, failure behavior, and exact request counts. These mutations demonstrate credible failures; existing cases are retained instead of adding redundant tests, and no production seam is needed. The two zero-delay completion barriers remain because they prove ordering rather than merely poll a positive state.

Owner/sibling proof: 77/77 cases across `draft-place-browser`, `draft-place-state`, `draft-submission-flow`, `where-chip`, `project-chip`, and `place-labels`, on both macOS and Linux. Shuffled runs passed with seeds `27194` (Linux) and `130297` (macOS). The complete changed gate passed, including all fourteen core test type graphs, dead-export scans, UI localization, formatting, and file-scoped lint. `git diff --check` and a diff-scoped deslop pass are clean. Fresh independent Codex autoreview reports no findings.

The primary XAI candidate was rejected and fully restored: eight samples per variant gave median wall 39.745s versus 41.325s with four wins/four losses. It is not included in this PR. Its four cache/pending/lifecycle mutations were detected before and after, but the timing evidence did not meet the acceptance bar.

Testbox workflow: https://github.com/openclaw/openclaw/actions/runs/33119489036 . The task-owned Testbox is stopped. This is test-only work; there is no changed visual or live-provider behavior requiring screenshots or authenticated provider calls.

AI-assisted implementation and review: Codex.
