### PR TITLE
fix(crabbox): avoid resending the full checkout for changed gates

### DIFF
--- a/scripts/crabbox-wrapper.mts
+++ b/scripts/crabbox-wrapper.mts
@@ -3557,8 +3557,8 @@ function prepareFullCheckoutForSync(options: { changedGateBase?: string } = {}) 
         if (changedGateTree === baseTree.stdout) {
           writeFileSync(bundleTempPath, "", "utf8");
         } else {
-          // A parentless carrier makes the bundle self-contained while sending
-          // only the final tree. The remote attaches the fetched base as parent.
+          // The receiver fetches a shallow base. Restrict exclusions to its tree,
+          // not older objects reachable only through the producer's full history.
           const transportCommit = gitOutput([
             "-C",
             dir,
@@ -3568,6 +3568,8 @@ function prepareFullCheckoutForSync(options: { changedGateBase?: string } = {}) 
             "user.email=ci@openclaw.local",
             "commit-tree",
             changedGateTree,
+            "-p",
+            base.stdout,
             "-m",
             "remote-changed-gate-tree",
           ]);
@@ -3578,7 +3580,12 @@ function prepareFullCheckoutForSync(options: { changedGateBase?: string } = {}) 
           if (updateHead.status !== 0) {
             throw new Error(updateHead.text || "git update-ref HEAD failed");
           }
-          const bundle = gitOutput(["-C", dir, "bundle", "create", bundleTempPath, "HEAD"]);
+          const range = `${base.stdout}..HEAD`;
+          const shallowPath = resolve(bundleTempDir, "shallow");
+          writeFileSync(shallowPath, `${base.stdout}\n`, "utf8");
+          const bundle = gitOutput(["-C", dir, "bundle", "create", bundleTempPath, range], {
+            GIT_SHALLOW_FILE: shallowPath,
+          });
           if (bundle.status !== 0) {
             throw new Error(bundle.text || `git bundle exited with status ${bundle.status}`);
           }

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -1,13 +1,16 @@
 // Crabbox Wrapper tests cover crabbox wrapper script behavior.
 import { spawn, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
   realpathSync,
+  renameSync,
   rmSync,
   statSync,
   symlinkSync,
@@ -167,6 +170,7 @@ async function main() {
     setInterval(() => {}, 1000); return;
   }
   const bundlePath = ".openclaw-crabbox-changed-gate.bundle";
+  if (process.env.OPENCLAW_FAKE_CRABBOX_COPY_CHANGED_GATE_BUNDLE_TO) fs.copyFileSync(bundlePath, process.env.OPENCLAW_FAKE_CRABBOX_COPY_CHANGED_GATE_BUNDLE_TO);
   if (Object.hasOwn(process.env, "OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE")) {
     const bundle = fs.existsSync(bundlePath) ? fs.readFileSync(bundlePath, "utf8") : null;
     if (bundle !== process.env.OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE) { process.stderr.write("changed-gate bundle mismatch\n"); process.exit(67); }
@@ -201,7 +205,7 @@ main().catch((error) => { process.stderr.write(String(error?.stack || error) + "
         '  case "$arg" in --artifact-glob|-artifact-glob|--script|-script) fast_run=0 ;; esac',
         "done",
         'if { [ "$1" = "run" ] || [ "$1" = "warmup" ]; } && [ "$fast_run" -eq 1 ] &&',
-        '  [ -z "${OPENCLAW_FAKE_CRABBOX_CLAIM_PATH:-}${OPENCLAW_FAKE_CRABBOX_EXTRA_CLAIM_PATH:-}${OPENCLAW_FAKE_CRABBOX_TIMING_LEASE_ID:-}${OPENCLAW_FAKE_CRABBOX_RUN_STATUS:-}${OPENCLAW_FAKE_CRABBOX_DELETE_CWD_AND_EXIT:-}${OPENCLAW_FAKE_CRABBOX_DELETE_CWD_ONCE:-}${OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH:-}${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE+x}${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE_BYTES:-}${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_FORCE_ADD:-}" ]; then',
+        '  [ -z "${OPENCLAW_FAKE_CRABBOX_CLAIM_PATH:-}${OPENCLAW_FAKE_CRABBOX_EXTRA_CLAIM_PATH:-}${OPENCLAW_FAKE_CRABBOX_TIMING_LEASE_ID:-}${OPENCLAW_FAKE_CRABBOX_RUN_STATUS:-}${OPENCLAW_FAKE_CRABBOX_DELETE_CWD_AND_EXIT:-}${OPENCLAW_FAKE_CRABBOX_DELETE_CWD_ONCE:-}${OPENCLAW_FAKE_CRABBOX_DESCENDANT_PID_PATH:-}${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE+x}${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_BUNDLE_BYTES:-}${OPENCLAW_FAKE_CRABBOX_EXPECT_CHANGED_GATE_FORCE_ADD:-}${OPENCLAW_FAKE_CRABBOX_COPY_CHANGED_GATE_BUNDLE_TO:-}" ]; then',
         `  printf '${fakeCrabboxProtocol}\\000%s\\000' "$#"`,
         "  printf '%s\\000' \"$@\"",
         "  printf '%s\\000\\000' \"$PWD\"",
@@ -343,15 +347,13 @@ if (args[0] === "-C" && args[2] === "rev-parse") {
   process.stdout.write(value + "\n"); process.exit(0);
 }
 if (args[0] === "-C" && args[2] === "-c" && args[6] === "commit-tree") {
-  if (process.env.OPENCLAW_FAKE_GIT_ROOT_COMMIT_MARKER && args.includes("-p")) process.exit(68);
   if (process.env.OPENCLAW_FAKE_GIT_EXPECT_COMMIT_TREE && args[7] !== process.env.OPENCLAW_FAKE_GIT_EXPECT_COMMIT_TREE) process.exit(69);
-  touch("OPENCLAW_FAKE_GIT_ROOT_COMMIT_MARKER"); touch("OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_MARKER");
+  touch("OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_MARKER");
   process.stdout.write((process.env.OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_SHA || "synthetic789") + "\n"); process.exit(0);
 }
 if (args[0] === "-C" && args[2] === "update-ref" && args[3] === "HEAD") { touch("OPENCLAW_FAKE_GIT_SYNTHETIC_HEAD_MARKER"); process.exit(0); }
 if (args[0] === "-C" && args[2] === "bundle" && args[3] === "create") {
-  if (process.env.OPENCLAW_FAKE_GIT_SELF_CONTAINED_BUNDLE_MARKER && (args.length !== 6 || args[5] !== "HEAD")) process.exit(68);
-  touch("OPENCLAW_FAKE_GIT_SELF_CONTAINED_BUNDLE_MARKER"); const bytes = Number(process.env.OPENCLAW_FAKE_GIT_BUNDLE_BYTES || 0);
+  const bytes = Number(process.env.OPENCLAW_FAKE_GIT_BUNDLE_BYTES || 0);
   fs.writeFileSync(args[4], bytes ? "x".repeat(bytes) : process.env.OPENCLAW_FAKE_GIT_BUNDLE || "fake-bundle"); process.exit(0);
 }
 if (args[0] === "-C" && args[2] === "add" && args[3] === "-f") { touch("OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER"); process.exit(0); }
@@ -3466,8 +3468,6 @@ describe("scripts/crabbox-wrapper", () => {
     const forceAddMarker = path.join(markerDir, "force-added");
     const syntheticCommitMarker = path.join(markerDir, "synthetic-commit");
     const syntheticHeadMarker = path.join(markerDir, "synthetic-head");
-    const rootCommitMarker = path.join(markerDir, "root-commit");
-    const selfContainedBundleMarker = path.join(markerDir, "self-contained-bundle");
     const result = runDefaultWrapper(
       ["run", "--provider", "aws", "--", "corepack", "pnpm", "check:changed"],
       {
@@ -3478,8 +3478,6 @@ describe("scripts/crabbox-wrapper", () => {
           OPENCLAW_FAKE_GIT_FORCE_ADD_MARKER: forceAddMarker,
           OPENCLAW_FAKE_GIT_SYNTHETIC_COMMIT_MARKER: syntheticCommitMarker,
           OPENCLAW_FAKE_GIT_SYNTHETIC_HEAD_MARKER: syntheticHeadMarker,
-          OPENCLAW_FAKE_GIT_ROOT_COMMIT_MARKER: rootCommitMarker,
-          OPENCLAW_FAKE_GIT_SELF_CONTAINED_BUNDLE_MARKER: selfContainedBundleMarker,
         },
         gitResponses: {
           [GIT_CONFIG_SPARSE_KEY]: { stdout: "true\n" },
@@ -3494,9 +3492,220 @@ describe("scripts/crabbox-wrapper", () => {
     expect(existsSync(forceAddMarker)).toBe(true);
     expect(existsSync(syntheticCommitMarker)).toBe(true);
     expect(existsSync(syntheticHeadMarker)).toBe(true);
-    expect(existsSync(rootCommitMarker)).toBe(true);
-    expect(existsSync(selfContainedBundleMarker)).toBe(true);
   });
+
+  it.skipIf(process.platform === "win32").each([true, false])(
+    "reuses the fetched base while transporting the exact dirty tree (shallow=%s)",
+    (shallow) => {
+      const root = makeTempDir(tempDirs, "openclaw-changed-gate-real-git-");
+      const origin = path.join(root, "origin");
+      const producer = path.join(root, "producer");
+      const capturedBundle = path.join(root, "captured.bundle");
+      const fakeBin = makeFakeCrabbox(defaultProviderHelp);
+      const env = {
+        ...testHomeEnv(path.join(root, "home")),
+        PATH: [fakeBin, path.dirname(process.execPath), process.env.PATH ?? ""].join(
+          path.delimiter,
+        ),
+        GIT_CONFIG_GLOBAL: "/dev/null",
+        GIT_CONFIG_NOSYSTEM: "1",
+        GIT_OPTIONAL_LOCKS: "0",
+        GIT_AUTHOR_NAME: "Transport fixture",
+        GIT_AUTHOR_EMAIL: "transport@example.invalid",
+        GIT_COMMITTER_NAME: "Transport fixture",
+        GIT_COMMITTER_EMAIL: "transport@example.invalid",
+        OPENCLAW_CRABBOX_WRAPPER_IGNORE_REPO_BINARY: "1",
+        OPENCLAW_CRABBOX_SYNC_TMPDIR: path.join(root, "sync"),
+        OPENCLAW_CRABBOX_SYNC_MIN_FREE_BYTES: "0",
+        OPENCLAW_FAKE_CRABBOX_COPY_CHANGED_GATE_BUNDLE_TO: capturedBundle,
+      };
+      const git = (cwd: string, args: string[]) => {
+        const result = spawnSync("git", args, { cwd, env, encoding: "utf8", timeout: 10_000 });
+        expect(result.status, `${args.join(" ")}\n${result.stderr}`).toBe(0);
+        return result.stdout.trim();
+      };
+      mkdirSync(path.join(origin, "scripts"), { recursive: true });
+      git(origin, ["init", "-q", "-b", "main"]);
+      writeFileSync(path.join(origin, ".gitignore"), ".tmp/\n");
+      const restored = "old content beyond the receiver's shallow history\n";
+      mkdirSync(path.join(origin, "restored"));
+      writeFileSync(path.join(origin, "restored", "old.txt"), restored);
+      git(origin, ["add", "-A"]);
+      git(origin, ["commit", "-qm", "old content"]);
+      rmSync(path.join(origin, "restored"), { recursive: true });
+      git(origin, ["add", "-A"]);
+      git(origin, ["commit", "-qm", "remove old content"]);
+      git(origin, ["commit", "--allow-empty", "-qm", "advance history"]);
+      const unchanged = Buffer.concat(
+        Array.from({ length: 8192 }, (_, index) =>
+          createHash("sha256").update(`unchanged-${index}`).digest(),
+        ),
+      );
+      writeFileSync(path.join(origin, "unchanged.bin"), unchanged);
+      for (const file of ["owner.txt", "deleted.txt", "rename-before.txt", "mode.sh"]) {
+        writeFileSync(path.join(origin, file), "base\n");
+      }
+      symlinkSync("owner.txt", path.join(origin, "alias"));
+      // The leaf is deliberately inert: this test proves transport, not check lanes.
+      writeFileSync(
+        path.join(origin, "scripts/check-changed.mjs"),
+        'process.stdout.write("transport fixture reached\\n");\n',
+      );
+      git(origin, ["add", "-A"]);
+      git(origin, ["commit", "-qm", "base"]);
+      const base = git(origin, ["rev-parse", "HEAD"]);
+      git(root, ["clone", "-q", ...(shallow ? ["--depth=1"] : []), `file://${origin}`, producer]);
+      expect(git(producer, ["rev-parse", "--is-shallow-repository"])).toBe(String(shallow));
+      if (!shallow) {
+        git(producer, ["repack", "-adb"]);
+        expect(
+          readdirSync(path.join(producer, ".git", "objects", "pack")).some((file) =>
+            file.endsWith(".bitmap"),
+          ),
+        ).toBe(true);
+      }
+      const fixtureWrapper = path.join(producer, ".tmp", "crabbox-wrapper.mjs");
+      mkdirSync(path.dirname(fixtureWrapper), { recursive: true });
+      copyFileSync(bundledWrapperPath, fixtureWrapper);
+      const runSender = () => {
+        const result = spawnSync(
+          process.execPath,
+          [fixtureWrapper, "run", "--provider", "aws", "--", "node", "scripts/check-changed.mjs"],
+          { cwd: producer, env, encoding: "utf8", timeout: 10_000 },
+        );
+        const run = expectSuccessfulWrapperRun(result);
+        expect(existsSync(run.output.cwd)).toBe(false);
+        expect(readdirSync(path.join(root, "sync"))).toEqual([]);
+        return { remoteCommand: run.remoteCommand, bundle: readFileSync(capturedBundle) };
+      };
+      const receive = (name: string, remoteCommand: string, bundle?: Buffer, source = origin) => {
+        const receiver = path.join(root, name);
+        mkdirSync(receiver);
+        if (bundle) {
+          writeFileSync(path.join(receiver, ".openclaw-crabbox-changed-gate.bundle"), bundle);
+        }
+        const result = spawnSync("bash", ["-c", remoteCommand], {
+          cwd: receiver,
+          encoding: "utf8",
+          timeout: 10_000,
+          env: {
+            ...env,
+            GIT_CONFIG_COUNT: "2",
+            GIT_CONFIG_KEY_0: `url.file://${source}.insteadOf`,
+            GIT_CONFIG_VALUE_0: "https://github.com/openclaw/openclaw.git",
+            GIT_CONFIG_KEY_1: "protocol.file.allow",
+            GIT_CONFIG_VALUE_1: "always",
+          },
+        });
+        return { receiver, result };
+      };
+      const empty = runSender();
+      expect(empty.bundle.length).toBe(0);
+      const unchangedRun = receive("unchanged", empty.remoteCommand, empty.bundle);
+      expect(unchangedRun.result.status, unchangedRun.result.stderr).toBe(0);
+      expect(git(unchangedRun.receiver, ["rev-parse", "HEAD"])).toBe(base);
+
+      writeFileSync(path.join(producer, "owner.txt"), "committed\n");
+      git(producer, ["add", "owner.txt"]);
+      git(producer, ["commit", "-qm", "committed change"]);
+      writeFileSync(path.join(producer, "owner.txt"), "unstaged\n");
+      writeFileSync(path.join(producer, "untracked.txt"), "untracked\n");
+      mkdirSync(path.join(producer, "restored"));
+      writeFileSync(path.join(producer, "restored", "old.txt"), restored);
+      rmSync(path.join(producer, "deleted.txt"));
+      renameSync(path.join(producer, "rename-before.txt"), path.join(producer, "renamed.txt"));
+      chmodSync(path.join(producer, "mode.sh"), 0o755);
+      git(producer, ["add", "mode.sh", "rename-before.txt", "renamed.txt"]);
+      const headBefore = git(producer, ["rev-parse", "HEAD"]);
+      const indexBefore = readFileSync(path.join(producer, ".git", "index"));
+      const statusBefore = git(producer, ["status", "--porcelain=v1"]);
+      const shallowBefore = shallow
+        ? readFileSync(path.join(producer, ".git", "shallow"))
+        : undefined;
+      const candidate = runSender();
+      // A change must not resend the unchanged, incompressible base blob.
+      expect(candidate.bundle.length).toBeLessThan(unchanged.length);
+      expect(git(producer, ["rev-parse", "HEAD"])).toBe(headBefore);
+      expect(readFileSync(path.join(producer, ".git", "index"))).toEqual(indexBefore);
+      expect(git(producer, ["status", "--porcelain=v1"])).toBe(statusBefore);
+      expect(
+        shallow
+          ? readFileSync(path.join(producer, ".git", "shallow"))
+          : existsSync(path.join(producer, ".git", "shallow")),
+      ).toEqual(shallowBefore ?? false);
+
+      const imported = receive("candidate", candidate.remoteCommand, candidate.bundle);
+      expect(imported.result.status, imported.result.stderr).toBe(0);
+      expect(imported.result.stdout).toBe("transport fixture reached\n");
+      expect(git(imported.receiver, ["rev-parse", "HEAD^"])).toBe(base);
+      expect(git(imported.receiver, ["status", "--porcelain=v1"])).toBe("");
+      expect(readFileSync(path.join(imported.receiver, "unchanged.bin"))).toEqual(unchanged);
+      expect(readFileSync(path.join(imported.receiver, "owner.txt"), "utf8")).toBe("unstaged\n");
+      expect(readFileSync(path.join(imported.receiver, "untracked.txt"), "utf8")).toBe(
+        "untracked\n",
+      );
+      expect(existsSync(path.join(imported.receiver, "deleted.txt"))).toBe(false);
+      expect(existsSync(path.join(imported.receiver, "rename-before.txt"))).toBe(false);
+      expect(readFileSync(path.join(imported.receiver, "renamed.txt"), "utf8")).toBe("base\n");
+      expect(readFileSync(path.join(imported.receiver, "restored", "old.txt"), "utf8")).toBe(
+        restored,
+      );
+      expect(git(imported.receiver, ["ls-tree", "HEAD", "alias"])).toMatch(/^120000 blob /u);
+      expect(git(imported.receiver, ["ls-tree", "HEAD", "mode.sh"])).toMatch(/^100755 blob /u);
+      expect(git(imported.receiver, ["diff", "--no-renames", "--name-status", base, "HEAD"])).toBe(
+        [
+          "D\tdeleted.txt",
+          "M\tmode.sh",
+          "M\towner.txt",
+          "D\trename-before.txt",
+          "A\trenamed.txt",
+          "A\trestored/old.txt",
+          "A\tuntracked.txt",
+        ].join("\n"),
+      );
+
+      const corrupt = Buffer.from(candidate.bundle);
+      const lastIndex = corrupt.length - 1;
+      corrupt.writeUInt8(corrupt.readUInt8(lastIndex) ^ 1, lastIndex);
+      const wrongBase = git(imported.receiver, [
+        "commit-tree",
+        `${base}^{tree}`,
+        "-m",
+        "other base",
+      ]);
+      const wrongCarrier = git(imported.receiver, [
+        "commit-tree",
+        "HEAD^{tree}",
+        "-p",
+        wrongBase,
+        "-m",
+        "other prerequisite",
+      ]);
+      git(imported.receiver, ["update-ref", "HEAD", wrongCarrier]);
+      const wrongBundle = path.join(root, "wrong-base.bundle");
+      git(imported.receiver, ["bundle", "create", wrongBundle, "HEAD", `^${wrongBase}`]);
+      for (const [name, bundle] of [
+        ["missing-bundle", undefined],
+        ["wrong-base-bundle", readFileSync(wrongBundle)],
+        ["corrupt-bundle", corrupt],
+      ] as const) {
+        const rejected = receive(name, candidate.remoteCommand, bundle);
+        expect(rejected.result.status).toBe(2);
+        expect(rejected.result.stdout).not.toContain("transport fixture reached");
+      }
+      const emptyOrigin = path.join(root, "empty-origin");
+      mkdirSync(emptyOrigin);
+      git(emptyOrigin, ["init", "-q", "--bare"]);
+      const missingBase = receive(
+        "missing-base",
+        candidate.remoteCommand,
+        candidate.bundle,
+        emptyOrigin,
+      );
+      expect(missingBase.result.status).toBe(2);
+      expect(missingBase.result.stdout).not.toContain("transport fixture reached");
+    },
+  );
 
   it("transports changed-gate bundles larger than the child-process buffer", () => {
     const bundleBytes = 2 * 1024 * 1024;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where developers running remote changed-file checks could spend the synchronization budget retransmitting the entire checkout, even for a two-file change. The remote already fetches the exact base, but the parentless source carrier packaged that unchanged tree again.

## Why This Change Was Made

The carrier now sends the candidate tree relative to the fetched base, with a subprocess-local shallow boundary that excludes only objects available from that base. That boundary matters for full-history, bitmap-backed producers: without it, Git can omit old objects restored by the candidate even though the shallow receiver does not have them.

The existing temporary bundle directory owns the boundary file and its cleanup. Receiver reconstruction, providers, synchronization timeouts, full changed-check policy, dependencies, and public options are unchanged.

## User Impact

No end-user behavior changes. Maintainer checks transfer the changed source while preserving the exact candidate tree, including restored historical files, instead of sending an unnecessary full-tree carrier.

## Evidence

- Test-first real-Git reproduction: the original carrier included a 256 KiB unchanged fixture blob in a 262,937-byte bundle. The new regression requires reuse of the fetched base and verifies the exact reconstructed tree.
- A second test-first reproduction caught the full-history/bitmap case: a delta without the private shallow boundary passed bundle verification but failed receiver import with missing objects. Both shallow and full-history variants pass with the correction.
- Coverage includes committed, unstaged and untracked changes; deletion, rename, executable and symlink entries; restored old subtrees; an empty carrier; unchanged source HEAD/index/shallow state; and fail-closed missing, corrupt or wrong-prerequisite bundles.
- An actual [Blacksmith run](https://github.com/openclaw/openclaw/actions/runs/33121017983) used the modified canonical wrapper: a 4,204-byte carrier, one-file targeted synchronization in 32.060 seconds, all 251 owner/sibling tests passing, and all 17 canonical changed gates passing, including both complete semantic type checks. Before/after attestations verified the exact two-file patch, base, source hashes, metadata and 12 installed dependency pins. These transfer measurements describe this patch, not a benchmark against the earlier, different native cleanup patch.
- Corrected precommit review found no actionable P0–P3 findings. The full affected suite also passed locally. Local linked dependencies were stale and produced unrelated type errors; the pinned Linux type gates above passed without changing local dependencies.

The temp-directory guard emits a warning for the real-Git fixture's existing `makeTempDir(tempDirs, ...)` pattern. The file's existing `afterAll` owns and drains that tracker; the test does not introduce a separate cleanup owner. An earlier intermittent repeated-parent-signal test failure remains a named follow-up; later local and pinned Linux full-suite passes do not establish its cause.

Production/tooling LOC: +10/-3 (net +7). Tests: +220/-11 (net +209). The small production increase enforces the exact receiver-object-availability invariant; no checks, timeouts or assertions were weakened. The original parentless implementation predates the available shallow history boundary, so its introducing PR/author is not attributed here.
