### PR TITLE
fix: skip Linux-only lease-fence tests on macOS

### DIFF
--- a/test/scripts/run-with-lease-fence.test.ts
+++ b/test/scripts/run-with-lease-fence.test.ts
@@ -8,10 +8,11 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const SCRIPT = "scripts/mantis/run-with-lease-fence.sh";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-const posixIt = process.platform === "win32" ? it.skip : it;
+// Mantis runs on Ubuntu and requires util-linux's setsid for process-group fencing.
+const linuxIt = process.platform === "linux" ? it : it.skip;
 
 describe("run-with-lease-fence", () => {
-  posixIt(
+  linuxIt(
     "stops the active process group after terminal lease loss",
     async () => {
       const root = tempDirs.make("openclaw-lease-fence-");
@@ -63,7 +64,7 @@ describe("run-with-lease-fence", () => {
     20_000,
   );
 
-  posixIt("propagates a clean command exit", () => {
+  linuxIt("propagates a clean command exit", () => {
     const root = tempDirs.make("openclaw-lease-fence-clean-");
     const result = spawnSync(SCRIPT, [path.join(root, "lease.lost"), "--", "/bin/true"], {
       encoding: "utf8",
@@ -73,7 +74,7 @@ describe("run-with-lease-fence", () => {
     expect(result.stderr).toBe("");
   });
 
-  posixIt("passes the caller's stdin through to the fenced command", () => {
+  linuxIt("passes the caller's stdin through to the fenced command", () => {
     // The workflow pipes the agent prompt into the fenced Codex process; a
     // backgrounded child otherwise defaults its stdin to /dev/null, which
     // made the agent fail with an empty prompt.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running the full test suite on macOS get three failures from the Linux-only Mantis lease-fence tests: one command-readiness timeout and two `setsid: command not found` errors.

This is a maintainer-requested QA repair. The test currently treats every non-Windows host as supported, although its only production caller is the Ubuntu Mantis Telegram Desktop Proof workflow.

## Why This Change Was Made

Select Linux explicitly, matching the neighboring Mantis process-group tests. Keep all three behavioral tests and their assertions unchanged on Linux, including failure when the required `setsid` utility is missing. The production fence remains byte-identical: no process-group fallback, utility shim, timeout adjustment, or lease-policy change.

The incorrect platform predicate was present when the test was introduced in [#127804, QA lease keepalive and fencing](https://github.com/openclaw/openclaw/pull/127804), authored and merged by Ayaan Zaidi (@obviyus), in commit `10c774cf38eb8ef0b9456f949fcb2ec782320168` on August 22, 2026. This repair does not alter the later stdin-preservation or prompt-fencing regressions those tests protect.

## User Impact

No product-runtime change. macOS development runs correctly report these three Linux-owned tests as skipped. Linux continues to exercise process-group termination on lease loss, command exit propagation, and stdin preservation.

## Evidence

- Before, on frozen `79dfa81664fd64a3f6192331af4953ff9f9bf1ef`: the macOS full suite failed all three cases; the first timed out waiting for the command PID and the other two exited 127 with `setsid: command not found`.
- After, Node 24.20.0 / pnpm 11.22.0: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/scripts/run-with-lease-fence.test.ts --reporter=verbose` reports **one file skipped, three tests skipped, zero test execution time**. This proves macOS selection, not Linux behavior.
- `node_modules/.bin/oxfmt test/scripts/run-with-lease-fence.test.ts` and `git diff --check`: passed.
- `node scripts/check-changed.mjs -- test/scripts/run-with-lease-fence.test.ts`: passed all classified guards, formatting, root-test typechecking, and script lint.
- Independent Codex review: no findings. AI-assisted with Codex.
- Production/tooling LOC: +0/-0. Tests: +5/-4.
- Exact-head Linux CI at `123dd771eb41540f466117b114e8de6a7e2af817`: [job 98692723362](https://github.com/openclaw/openclaw/actions/runs/33122491527/job/98692723362) passed on Ubuntu 24.04.3 with Node 24.19.0. All three lease-fence tests executed and passed (4.026 seconds total): process-group termination on lease loss, clean exit propagation, and stdin preservation. The surrounding tooling shard passed 61 files / 942 tests.

Linux behavior proof is complete, and [exact-head CI run 33122491527](https://github.com/openclaw/openclaw/actions/runs/33122491527) completed successfully on its first attempt. No retry, rebase, or production change was needed.

Named follow-up, intentionally separate: the first test enters its cleanup `try/finally` after PID/tick readiness. A readiness failure can bypass cleanup. This macOS failure does not establish that a child leaked, and that lifecycle repair needs its own bounded Linux proof.
