### PR TITLE
fix(channels): preserve authored config during setup

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2490,7 +2490,6 @@ src/commands/channels/add-wizard.ts	2
 src/commands/channels/add.ts	3
 src/commands/channels/capabilities.ts	4
 src/commands/channels/list.ts	1
-src/commands/channels/remove.ts	1
 src/commands/channels/status.runtime.ts	9
 src/commands/cleanup-utils.ts	1
 src/commands/configure.channels.ts	1

--- a/docs/cli/directory.md
+++ b/docs/cli/directory.md
@@ -26,6 +26,7 @@ JSON mode.
 ## Notes
 
 - For many channels, results are config-backed (allowlists / configured groups) rather than a live provider directory.
+- Before a live lookup, OpenClaw resolves configured SecretRefs only for the selected channel and account. Resolved credentials remain runtime-only; plugin installation and auto-enable writes preserve the authored references without persisting runtime defaults.
 - WhatsApp group listing is live. Gateway lookups reuse its owned connection; a standalone command opens the linked session only when no other process owns that account and otherwise reports that live groups are unavailable.
 - An already-installed channel plugin can lack directory support. In that case the command reports the unsupported operation; it does not try to reinstall or upgrade the plugin to add support.
 

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -281,6 +281,7 @@ describe("registerDirectoryCli", () => {
     expect(mocks.resolveMessageChannelSelection).toHaveBeenCalledWith({
       cfg: autoEnabledConfig,
       channel: null,
+      accountResolution: "read_only",
     });
     expect(self).toHaveBeenCalledTimes(1);
     expect(firstRecordArg(self).cfg).toBe(autoEnabledConfig);
@@ -288,6 +289,84 @@ describe("registerDirectoryCli", () => {
       nextConfig: autoEnabledConfig,
       baseHash: "config-1",
     });
+  });
+
+  it("inspects an implicit channel before resolving only that account's secrets", async () => {
+    const tokenRef = {
+      source: "env",
+      provider: "default",
+      id: "DIRECTORY_TEST_SLACK_TOKEN",
+    } as const;
+    const sourceConfig = { channels: { slack: { botToken: tokenRef } } };
+    const runtimeConfig = {
+      ...sourceConfig,
+      messages: { responsePrefix: "runtime-default" },
+    };
+    const calls: string[] = [];
+    const self = vi.fn().mockImplementation(async () => {
+      calls.push("directory");
+      return { id: "U123", name: "Slack Bot" };
+    });
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      ...createTestConfigSnapshot(sourceConfig, runtimeConfig),
+      hash: "config-1",
+    });
+    mocks.loadConfig.mockReturnValue(runtimeConfig);
+    mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
+    mocks.resolveMessageChannelSelection.mockImplementation(
+      async ({ accountResolution }: { accountResolution?: string }) => {
+        calls.push("selection");
+        if (accountResolution !== "read_only") {
+          throw new Error("unresolved SecretRef");
+        }
+        return {
+          channel: "slack",
+          plugin: { id: "slack", directory: { self } },
+          configured: ["slack"],
+          source: "single-configured",
+        };
+      },
+    );
+    mocks.getScopedChannelsCommandSecretTargets.mockImplementationOnce(() => {
+      calls.push("scope");
+      return {
+        targetIds: new Set(["channels.slack.botToken"]),
+        allowedPaths: new Set(["channels.slack.botToken"]),
+      };
+    });
+    mocks.resolveCommandSecretRefsViaGateway.mockImplementation(async ({ config }) => {
+      calls.push("secrets");
+      return {
+        resolvedConfig: {
+          ...config,
+          channels: { slack: { botToken: "resolved-directory-token" } },
+        },
+        diagnostics: [],
+      };
+    });
+
+    const program = new Command().name("openclaw");
+    registerDirectoryCli(program);
+
+    await program.parseAsync(["directory", "self", "--json"], { from: "user" });
+
+    expect(mocks.resolveMessageChannelSelection).toHaveBeenCalledWith({
+      cfg: runtimeConfig,
+      channel: null,
+      accountResolution: "read_only",
+    });
+    expect(mocks.getScopedChannelsCommandSecretTargets).toHaveBeenCalledWith({
+      config: runtimeConfig,
+      channel: "slack",
+      accountId: "default",
+    });
+    expect(firstRecordArg(self).cfg).toEqual({
+      ...runtimeConfig,
+      channels: { slack: { botToken: "resolved-directory-token" } },
+    });
+    expect(calls).toEqual(["selection", "scope", "secrets", "directory"]);
+    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { nullChannelDirectorySelf } from "../channels/plugins/directory-adapters.js";
+import { createTestConfigSnapshot } from "../commands/test-runtime-config-helpers.js";
 import { registerDirectoryCli } from "./directory-cli.js";
 
 const runtimeState = await vi.hoisted(async () => {
@@ -12,11 +13,24 @@ const runtimeState = await vi.hoisted(async () => {
 const mocks = vi.hoisted(() => ({
   loadConfig: vi.fn(),
   readConfigFileSnapshot: vi.fn(),
+  resolveCommandSecretRefsViaGateway: vi.fn(),
+  getScopedChannelsCommandSecretTargets: vi.fn(() => ({
+    targetIds: new Set(["channels.slack.botToken"]),
+    allowedPaths: new Set(["channels.slack.botToken"]),
+  })),
   applyPluginAutoEnable: vi.fn(),
   replaceConfigFile: vi.fn(),
   resolveInstallableChannelPlugin: vi.fn(),
   resolveMessageChannelSelection: vi.fn(),
   resolveChannelDefaultAccountId: vi.fn(),
+}));
+
+vi.mock("./command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway: mocks.resolveCommandSecretRefsViaGateway,
+}));
+
+vi.mock("./command-secret-targets.js", () => ({
+  getScopedChannelsCommandSecretTargets: mocks.getScopedChannelsCommandSecretTargets,
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -77,7 +91,14 @@ describe("registerDirectoryCli", () => {
     runtimeState.runtimeLogs.length = 0;
     runtimeState.runtimeErrors.length = 0;
     mocks.loadConfig.mockReturnValue({ channels: {} });
-    mocks.readConfigFileSnapshot.mockResolvedValue({ hash: "config-1" });
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      ...createTestConfigSnapshot({ channels: {} }),
+      hash: "config-1",
+    });
+    mocks.resolveCommandSecretRefsViaGateway.mockImplementation(async ({ config }) => ({
+      resolvedConfig: config,
+      diagnostics: [],
+    }));
     mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
     mocks.replaceConfigFile.mockResolvedValue(undefined);
     mocks.resolveChannelDefaultAccountId.mockReturnValue("default");
@@ -98,45 +119,134 @@ describe("registerDirectoryCli", () => {
   });
 
   it("installs an explicit optional directory channel on demand", async () => {
+    const tokenRef = {
+      source: "env",
+      provider: "default",
+      id: "DIRECTORY_TEST_SLACK_TOKEN",
+    } as const;
+    const sourceConfig = { channels: { slack: { botToken: tokenRef } } };
+    let runtimeConfig = {
+      ...sourceConfig,
+      messages: { responsePrefix: "runtime-default" },
+    };
+    let postWriteRuntimeConfig = runtimeConfig;
+    mocks.loadConfig.mockImplementation(() => runtimeConfig);
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      ...createTestConfigSnapshot(sourceConfig, runtimeConfig),
+      hash: "config-1",
+    });
+    mocks.resolveCommandSecretRefsViaGateway.mockImplementation(async ({ config }) => ({
+      resolvedConfig: {
+        ...config,
+        channels: { slack: { botToken: "resolved-directory-token" } },
+      },
+      diagnostics: [],
+    }));
     const self = vi.fn().mockResolvedValue({ id: "self-1", name: "Family Phone" });
-    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
+    mocks.resolveInstallableChannelPlugin.mockImplementation(async ({ cfg }) => ({
       cfg: {
-        channels: {},
-        plugins: { entries: { "demo-directory": { enabled: true } } },
+        ...cfg,
+        plugins: { entries: { slack: { enabled: true } } },
       },
-      channelId: "demo-directory",
-      plugin: {
-        id: "demo-directory",
-        directory: { self },
-      },
+      channelId: "slack",
+      plugin: { id: "slack", directory: { self } },
       configChanged: true,
+      pluginInstalled: true,
+    }));
+    mocks.replaceConfigFile.mockImplementation(async ({ nextConfig }) => {
+      postWriteRuntimeConfig = {
+        ...nextConfig,
+        messages: { responsePrefix: "runtime-default" },
+      };
+      runtimeConfig = postWriteRuntimeConfig;
     });
 
     const program = new Command().name("openclaw");
     registerDirectoryCli(program);
 
-    await program.parseAsync(["directory", "self", "--channel", "demo-directory", "--json"], {
+    await program.parseAsync(["directory", "self", "--channel", "slack", "--json"], {
       from: "user",
     });
 
     expect(mocks.resolveInstallableChannelPlugin).toHaveBeenCalledTimes(1);
     const installArgs = firstRecordArg(mocks.resolveInstallableChannelPlugin);
-    expect(installArgs.rawChannel).toBe("demo-directory");
+    expect(installArgs.rawChannel).toBe("slack");
     expect(installArgs.allowInstall).toBe(true);
     expect(installArgs.preferRegisteredPlugin).toBe(true);
+    expect(installArgs.cfg).toEqual(sourceConfig);
     expect(mocks.replaceConfigFile).toHaveBeenCalledTimes(1);
     const replaceArgs = firstRecordArg(mocks.replaceConfigFile);
     expect(replaceArgs.nextConfig).toEqual({
-      channels: {},
-      plugins: { entries: { "demo-directory": { enabled: true } } },
+      channels: { slack: { botToken: tokenRef } },
+      plugins: { entries: { slack: { enabled: true } } },
     });
+    expect(replaceArgs.nextConfig).not.toHaveProperty("messages");
     expect(replaceArgs.baseHash).toBe("config-1");
+    expect(mocks.resolveCommandSecretRefsViaGateway).toHaveBeenCalledOnce();
+    expect(firstRecordArg(mocks.resolveCommandSecretRefsViaGateway)).toMatchObject({
+      config: postWriteRuntimeConfig,
+      commandName: "directory",
+      targetIds: new Set(["channels.slack.botToken"]),
+      allowedPaths: new Set(["channels.slack.botToken"]),
+      mode: "read_only_operational",
+    });
     expect(self).toHaveBeenCalledTimes(1);
     expect(firstRecordArg(self).accountId).toBe("default");
+    expect(firstRecordArg(self).cfg).toEqual({
+      ...postWriteRuntimeConfig,
+      channels: { slack: { botToken: "resolved-directory-token" } },
+    });
     expect(runtimeState.defaultRuntime.log).toHaveBeenCalledWith(
       JSON.stringify({ id: "self-1", name: "Family Phone" }, null, 2),
     );
     expect(runtimeState.defaultRuntime.error).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["self", ["directory", "self", "--channel", "slack", "--json"]],
+    ["peers", ["directory", "peers", "list", "--channel", "slack", "--json"]],
+    ["groups", ["directory", "groups", "list", "--channel", "slack", "--json"]],
+    [
+      "group members",
+      ["directory", "groups", "members", "--channel", "slack", "--group-id", "group-1", "--json"],
+    ],
+  ])("stops %s when canonical config validation exits", async (_label, args) => {
+    const directory = {
+      self: vi.fn().mockResolvedValue({ id: "self-1" }),
+      listPeersLive: vi.fn().mockResolvedValue([]),
+      listGroupsLive: vi.fn().mockResolvedValue([]),
+      listGroupMembers: vi.fn().mockResolvedValue([]),
+    };
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      path: "/tmp/invalid-openclaw.json",
+      exists: true,
+      valid: false,
+      sourceConfig: {},
+      runtimeConfig: {},
+      config: {},
+      issues: [{ path: "channels.slack", message: "invalid Slack config" }],
+      warnings: [],
+      legacyIssues: [],
+    });
+    mocks.resolveMessageChannelSelection.mockResolvedValue({
+      channel: "slack",
+      plugin: { id: "slack", directory },
+      configured: ["slack"],
+      source: "explicit",
+    });
+    runtimeState.defaultRuntime.exit.mockImplementation(() => undefined);
+
+    const program = new Command().name("openclaw");
+    registerDirectoryCli(program);
+    await program.parseAsync(args, { from: "user" });
+
+    expect(Object.values(directory).every((fn) => fn.mock.calls.length === 0)).toBe(true);
+    expect(mocks.resolveInstallableChannelPlugin).not.toHaveBeenCalled();
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(runtimeState.defaultRuntime.writeJson).not.toHaveBeenCalled();
+    expect(runtimeState.defaultRuntime.log).not.toHaveBeenCalled();
+    expect(runtimeErrors()[0]).toContain("OpenClaw config is invalid");
+    expect(runtimeState.defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
 
   it("uses the auto-enabled config snapshot for omitted channel selection", async () => {
@@ -145,6 +255,9 @@ describe("registerDirectoryCli", () => {
     mocks.applyPluginAutoEnable.mockReturnValue({
       config: autoEnabledConfig,
       changes: ["whatsapp"],
+    });
+    mocks.replaceConfigFile.mockImplementationOnce(async () => {
+      mocks.loadConfig.mockReturnValue(autoEnabledConfig);
     });
     mocks.resolveMessageChannelSelection.mockResolvedValue({
       channel: "whatsapp",

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -155,6 +155,7 @@ export function registerDirectoryCli(program: Command) {
       : await resolveMessageChannelSelection({
           cfg: runtimeConfig,
           channel: opts.channel ?? null,
+          accountResolution: "read_only",
         });
     const selectedChannelId = selection.channel;
     const plugin = selection.plugin;

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -15,13 +15,16 @@ import { theme } from "../../packages/terminal-core/src/theme.js";
 import { nullChannelDirectorySelf } from "../channels/plugins/directory-adapters.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import { resolveInstallableChannelPlugin } from "../commands/channel-setup/channel-plugin-resolution.js";
-import { getRuntimeConfig, readConfigFileSnapshot, replaceConfigFile } from "../config/config.js";
+import { requireValidConfigFileSnapshot } from "../commands/config-validation.js";
+import { getRuntimeConfig, replaceConfigFile } from "../config/config.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { danger } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveMessageChannelSelection } from "../infra/outbound/channel-selection.js";
 import { commitConfigWithPendingPluginInstalls } from "../plugins/install-record-commit.js";
 import { defaultRuntime } from "../runtime.js";
+import { resolveCommandConfigWithSecrets } from "./command-config-resolution.js";
+import { getScopedChannelsCommandSecretTargets } from "./command-secret-targets.js";
 import { formatHelpExamples } from "./help-format.js";
 
 function parseLimit(value: unknown): number | null {
@@ -107,16 +110,19 @@ export function registerDirectoryCli(program: Command) {
       .option("--json", "Output JSON", false);
 
   const resolve = async (opts: { channel?: string; account?: string }) => {
-    const sourceSnapshotPromise = readConfigFileSnapshot().catch(() => null);
+    const sourceSnapshot = await requireValidConfigFileSnapshot(defaultRuntime);
+    if (!sourceSnapshot) {
+      return null;
+    }
     const autoEnabled = applyPluginAutoEnable({
-      config: getRuntimeConfig(),
+      config: sourceSnapshot.sourceConfig,
       env: process.env,
     });
-    let cfg = autoEnabled.config;
+    const sourceConfig = autoEnabled.config;
     const explicitChannel = opts.channel?.trim();
     const resolvedExplicit = explicitChannel
       ? await resolveInstallableChannelPlugin({
-          cfg,
+          cfg: sourceConfig,
           runtime: defaultRuntime,
           rawChannel: explicitChannel,
           allowInstall: true,
@@ -125,28 +131,29 @@ export function registerDirectoryCli(program: Command) {
         })
       : null;
     if (resolvedExplicit?.configChanged) {
-      cfg = resolvedExplicit.cfg;
       // Installing an explicit channel can update plugin records; commit before directory calls
       // so subsequent registry reads see the channel the user just selected.
-      const committed = await commitConfigWithPendingPluginInstalls({
-        nextConfig: cfg,
-        baseHash: (await sourceSnapshotPromise)?.hash,
+      await commitConfigWithPendingPluginInstalls({
+        nextConfig: resolvedExplicit.cfg,
+        baseHash: sourceSnapshot.hash,
       });
-      cfg = committed.config;
     } else if (autoEnabled.changes.length > 0) {
       // Auto-enable changes are config-only and must be persisted before later CLI invocations.
       await replaceConfigFile({
-        nextConfig: cfg,
-        baseHash: (await sourceSnapshotPromise)?.hash,
+        nextConfig: sourceConfig,
+        baseHash: sourceSnapshot.hash,
       });
     }
+    // Config writes refresh the active runtime snapshot. Directory execution must use that
+    // prepared view, never the authored config that was just persisted.
+    const runtimeConfig = getRuntimeConfig();
     const selection = explicitChannel
       ? {
           channel: resolvedExplicit?.channelId,
           plugin: resolvedExplicit?.plugin,
         }
       : await resolveMessageChannelSelection({
-          cfg,
+          cfg: runtimeConfig,
           channel: opts.channel ?? null,
         });
     const selectedChannelId = selection.channel;
@@ -156,8 +163,22 @@ export function registerDirectoryCli(program: Command) {
     }
     const channelId = selectedChannelId ?? plugin.id;
     const accountId =
-      normalizeOptionalString(opts.account) || resolveChannelDefaultAccountId({ plugin, cfg });
-    return { cfg, channelId, accountId, plugin };
+      normalizeOptionalString(opts.account) ||
+      resolveChannelDefaultAccountId({ plugin, cfg: runtimeConfig });
+    const secretTargets = getScopedChannelsCommandSecretTargets({
+      config: runtimeConfig,
+      channel: channelId,
+      accountId,
+    });
+    const { effectiveConfig } = await resolveCommandConfigWithSecrets({
+      config: runtimeConfig,
+      commandName: "directory",
+      targetIds: secretTargets.targetIds,
+      ...(secretTargets.allowedPaths ? { allowedPaths: secretTargets.allowedPaths } : {}),
+      mode: "read_only_operational",
+      runtime: defaultRuntime,
+    });
+    return { cfg: effectiveConfig, channelId, accountId, plugin };
   };
 
   const runDirectoryList = async (params: {
@@ -174,10 +195,14 @@ export function registerDirectoryCli(program: Command) {
     emptyMessage: string;
   }) => {
     const limit = parseLimit(params.opts.limit);
-    const { cfg, channelId, accountId, plugin } = await resolve({
+    const resolved = await resolve({
       channel: params.opts.channel as string | undefined,
       account: params.opts.account as string | undefined,
     });
+    if (!resolved) {
+      return;
+    }
+    const { cfg, channelId, accountId, plugin } = resolved;
     const fn =
       params.action === "listPeers"
         ? (plugin.directory?.listPeersLive ?? plugin.directory?.listPeers)
@@ -218,10 +243,14 @@ export function registerDirectoryCli(program: Command) {
   withChannel(directory.command("self").description("Show the current account user")).action(
     (opts) =>
       runDirectoryAction(opts, async () => {
-        const { cfg, channelId, accountId, plugin } = await resolve({
+        const resolved = await resolve({
           channel: opts.channel as string | undefined,
           account: opts.account as string | undefined,
         });
+        if (!resolved) {
+          return;
+        }
+        const { cfg, channelId, accountId, plugin } = resolved;
         const fn = plugin.directory?.self;
         if (!fn) {
           throw new Error(`Channel ${channelId} does not support directory self`);
@@ -310,10 +339,14 @@ export function registerDirectoryCli(program: Command) {
     .action((opts) =>
       runDirectoryAction(opts, async () => {
         const limit = parseLimit(opts.limit);
-        const { cfg, channelId, accountId, plugin } = await resolve({
+        const resolved = await resolve({
           channel: opts.channel as string | undefined,
           account: opts.account as string | undefined,
         });
+        if (!resolved) {
+          return;
+        }
+        const { cfg, channelId, accountId, plugin } = resolved;
         const fn = plugin.directory?.listGroupMembers;
         if (!fn) {
           throw new Error(`Channel ${channelId} does not support group members listing`);

--- a/src/cli/test-runtime-mock.ts
+++ b/src/cli/test-runtime-mock.ts
@@ -26,7 +26,7 @@ export function createCliRuntimeMock(
     writeJson: viInstance.fn((value: unknown, space = 2) => {
       defaultRuntime.log(JSON.stringify(value, null, space > 0 ? space : undefined));
     }),
-    exit: viInstance.fn((code: number) => {
+    exit: viInstance.fn((code: number): void => {
       throw new Error(`${options.exitPrefix ?? "__exit__"}:${code}`);
     }),
   };

--- a/src/commands/channels.adds-non-default-telegram-account.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.test.ts
@@ -11,7 +11,11 @@ import { configMocks, offsetMocks, secretMocks } from "./channels.mock-harness.j
 import { channelsAddCommand } from "./channels/add.js";
 import { channelsRemoveCommand } from "./channels/remove.js";
 import { formatGatewayChannelsStatusLines } from "./channels/status.runtime.js";
-import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+import {
+  baseConfigSnapshot,
+  createTestConfigSnapshot,
+  createTestRuntime,
+} from "./test-runtime-config-helpers.js";
 
 const runtime = createTestRuntime();
 let minimalChannelsCommandRegistry: ReturnType<typeof createTestRegistry>;
@@ -491,9 +495,8 @@ describe("channels command", () => {
   });
 
   it("deletes a non-default discord account", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           discord: {
             accounts: {
@@ -502,8 +505,8 @@ describe("channels command", () => {
             },
           },
         },
-      },
-    });
+      }),
+    );
 
     await channelsRemoveCommand({ channel: "discord", account: "work", delete: true }, runtime, {
       hasFlags: true,
@@ -572,12 +575,11 @@ describe("channels command", () => {
   });
 
   it("disables a default provider account when remove has no delete flag", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: { discord: { token: "d0", enabled: true } },
-      },
-    });
+      }),
+    );
 
     await runRemoveWithConfirm({ channel: "discord", account: "default" });
 
@@ -832,14 +834,13 @@ describe("channels command", () => {
   });
 
   it("cleans up telegram update offset when deleting a telegram account", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           telegram: { botToken: "123:abc", enabled: true },
         },
-      },
-    });
+      }),
+    );
 
     await channelsRemoveCommand(
       { channel: "telegram", account: "default", delete: true },
@@ -853,9 +854,8 @@ describe("channels command", () => {
   });
 
   it("does not clean up offset when deleting a non-telegram channel", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           discord: {
             accounts: {
@@ -863,8 +863,8 @@ describe("channels command", () => {
             },
           },
         },
-      },
-    });
+      }),
+    );
 
     await channelsRemoveCommand({ channel: "discord", account: "default", delete: true }, runtime, {
       hasFlags: true,
@@ -874,14 +874,13 @@ describe("channels command", () => {
   });
 
   it("does not clean up offset when disabling (not deleting) a telegram account", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           telegram: { botToken: "123:abc", enabled: true },
         },
-      },
-    });
+      }),
+    );
 
     await runRemoveWithConfirm({ channel: "telegram", account: "default" });
 

--- a/src/commands/channels.remove.test.ts
+++ b/src/commands/channels.remove.test.ts
@@ -13,7 +13,7 @@ import {
   createExternalChatCatalogEntry,
   createExternalChatDeletePlugin,
 } from "./channels.plugin-install.test-helpers.js";
-import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+import { createTestConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
 let channelsRemoveCommand: typeof import("./channels.js").channelsRemoveCommand;
 
@@ -108,17 +108,16 @@ describe("channelsRemoveCommand", () => {
   });
 
   it("asks users to add an external channel plugin before removing its account", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           "external-chat": {
             enabled: true,
             token: "token-1",
           },
         },
-      },
-    });
+      }),
+    );
     const catalogEntry: ChannelPluginCatalogEntry = createExternalChatCatalogEntry();
     catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
 
@@ -142,17 +141,16 @@ describe("channelsRemoveCommand", () => {
   });
 
   it("removes an external channel account when its plugin is already installed", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           "external-chat": {
             enabled: true,
             token: "token-1",
           },
         },
-      },
-    });
+      }),
+    );
     const catalogEntry: ChannelPluginCatalogEntry = createExternalChatCatalogEntry();
     catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
     const scopedPlugin = createExternalChatDeletePlugin();
@@ -185,17 +183,16 @@ describe("channelsRemoveCommand", () => {
   });
 
   it("keeps omitted removal on literal default when the plugin selects another default", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           "external-chat": {
             enabled: true,
             token: "token-1",
           },
         },
-      },
-    });
+      }),
+    );
     catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([
       createExternalChatCatalogEntry(),
     ]);
@@ -244,17 +241,16 @@ describe("channelsRemoveCommand", () => {
 
   it("stops an active gateway channel runtime before deleting a runtime-backed account", async () => {
     const callOrder: string[] = [];
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           "external-chat": {
             enabled: true,
             token: "token-1",
           },
         },
-      },
-    });
+      }),
+    );
     const catalogEntry: ChannelPluginCatalogEntry = createExternalChatCatalogEntry();
     catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
     const deletePlugin = createExternalChatDeletePlugin();
@@ -331,17 +327,16 @@ describe("channelsRemoveCommand", () => {
 
   it("stops a runtime-backed account before reporting an unsupported delete", async () => {
     const callOrder: string[] = [];
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           "external-chat": {
             enabled: true,
             token: "token-1",
           },
         },
-      },
-    });
+      }),
+    );
     catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([
       createExternalChatCatalogEntry(),
     ]);

--- a/src/commands/channels/capabilities.test.ts
+++ b/src/commands/channels/capabilities.test.ts
@@ -2,26 +2,32 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import { ExpectedCliError } from "../../cli/failure-output.js";
-import type { replaceConfigFile } from "../../config/config.js";
+import type { OpenClawConfig, replaceConfigFile } from "../../config/config.js";
 import { DEFAULT_ACCOUNT_ID } from "../../routing/session-key.js";
+import { createTestConfigSnapshot } from "../test-runtime-config-helpers.js";
 import { channelsCapabilitiesCommand } from "./capabilities.js";
 
 const logs: string[] = [];
 const errors: string[] = [];
 const resolveDefaultAccountId = () => DEFAULT_ACCOUNT_ID;
 const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(),
   readConfigFileSnapshot: vi.fn(),
+  resolveCommandSecretRefsViaGateway: vi.fn(),
   replaceConfigFile: vi.fn<(params: Parameters<typeof replaceConfigFile>[0]) => Promise<void>>(),
   refreshPluginRegistryAfterConfigMutation: vi.fn(async () => undefined),
   resolveInstallableChannelPlugin: vi.fn(),
   listReadOnlyChannelPluginsForConfig: vi.fn(),
 }));
 
+vi.mock("../../cli/command-secret-gateway.js", () => ({
+  resolveCommandSecretRefsViaGateway: mocks.resolveCommandSecretRefsViaGateway,
+}));
+
 vi.mock("./shared.js", async () => {
   const actual = await vi.importActual<typeof import("./shared.js")>("./shared.js");
   return {
     ...actual,
-    requireValidChannelConfig: vi.fn(async () => ({ channels: {} })),
     formatChannelAccountLabel: vi.fn(
       ({ channel, accountId }: { channel: string; accountId: string }) => `${channel}:${accountId}`,
     ),
@@ -37,6 +43,7 @@ vi.mock("../../config/config.js", async () => {
     await vi.importActual<typeof import("../../config/config.js")>("../../config/config.js");
   return {
     ...actual,
+    getRuntimeConfig: mocks.loadConfig,
     readConfigFileSnapshot: mocks.readConfigFileSnapshot,
     replaceConfigFile: mocks.replaceConfigFile,
   };
@@ -106,7 +113,16 @@ describe("channelsCapabilitiesCommand", () => {
     vi.stubEnv("NO_COLOR", "1");
     resetOutput();
     vi.clearAllMocks();
-    mocks.readConfigFileSnapshot.mockResolvedValue({ hash: "config-1" });
+    const baseConfig = { channels: {} };
+    mocks.loadConfig.mockReturnValue(baseConfig);
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      ...createTestConfigSnapshot(baseConfig),
+      hash: "config-1",
+    });
+    mocks.resolveCommandSecretRefsViaGateway.mockImplementation(async ({ config }) => ({
+      resolvedConfig: config,
+      diagnostics: [],
+    }));
     mocks.replaceConfigFile.mockResolvedValue(undefined);
     mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([]);
     mocks.resolveInstallableChannelPlugin.mockResolvedValue({
@@ -434,39 +450,95 @@ describe("channelsCapabilitiesCommand", () => {
   });
 
   it("installs an explicit optional channel before rendering capabilities", async () => {
+    const tokenRef = {
+      source: "env",
+      provider: "default",
+      id: "CAPABILITIES_TEST_SLACK_TOKEN",
+    } as const;
+    const sourceConfig = { channels: { slack: { botToken: tokenRef } } };
+    let runtimeConfig: OpenClawConfig = {
+      ...sourceConfig,
+      messages: { responsePrefix: "runtime-default" },
+    };
+    mocks.loadConfig.mockImplementation(() => runtimeConfig);
+    mocks.readConfigFileSnapshot.mockImplementation(async () => ({
+      ...createTestConfigSnapshot(sourceConfig, runtimeConfig),
+      hash: "config-1",
+    }));
+    mocks.resolveCommandSecretRefsViaGateway.mockImplementation(async ({ config }) => ({
+      resolvedConfig: {
+        ...config,
+        channels: { slack: { botToken: "resolved-capabilities-token" } },
+      },
+      diagnostics: [],
+    }));
     const plugin = buildPlugin({
-      id: "whatsapp",
+      id: "slack",
       probe: { ok: true },
     });
+    const resolveAccount = vi.fn((cfg) => ({
+      accountId: "default",
+      botToken: cfg.channels?.slack?.botToken,
+    }));
+    const probeAccount = vi.fn(async ({ cfg }) => ({
+      ok: true,
+      botToken: cfg.channels?.slack?.botToken,
+    }));
+    plugin.config.resolveAccount = resolveAccount;
     plugin.status = {
       ...plugin.status,
+      probeAccount,
       formatCapabilitiesProbe: () => [{ text: "Probe: linked" }],
     };
-    mocks.resolveInstallableChannelPlugin.mockResolvedValue({
-      cfg: {
-        channels: {},
-        plugins: { entries: { whatsapp: { enabled: true } } },
-      },
-      channelId: "whatsapp",
+    mocks.resolveInstallableChannelPlugin.mockImplementation(async ({ cfg }) => ({
+      cfg: { ...cfg, plugins: { entries: { slack: { enabled: true } } } },
+      channelId: "slack",
       plugin,
       configChanged: true,
       pluginInstalled: true,
+    }));
+    mocks.replaceConfigFile.mockImplementation(async ({ nextConfig }) => {
+      runtimeConfig = {
+        ...nextConfig,
+        messages: { responsePrefix: "runtime-default" },
+      };
     });
 
-    await channelsCapabilitiesCommand({ channel: "whatsapp" }, runtime);
+    await channelsCapabilitiesCommand({ channel: "slack" }, runtime);
 
     expect(mocks.resolveInstallableChannelPlugin).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ rawChannel: "whatsapp", allowInstall: true }),
+      expect.objectContaining({ rawChannel: "slack", allowInstall: true }),
     );
+    expect(mocks.resolveInstallableChannelPlugin.mock.calls[0]?.[0].cfg).toEqual(sourceConfig);
 
     expect(mocks.replaceConfigFile).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ baseHash: "config-1" }),
     );
-    expect(mocks.replaceConfigFile.mock.calls[0]?.[0].nextConfig.plugins).toStrictEqual({
-      entries: { whatsapp: { enabled: true } },
+    expect(mocks.replaceConfigFile.mock.calls[0]?.[0].nextConfig).toStrictEqual({
+      channels: { slack: { botToken: tokenRef } },
+      plugins: { entries: { slack: { enabled: true } } },
     });
+    expect(mocks.replaceConfigFile.mock.calls[0]?.[0].nextConfig).not.toHaveProperty("messages");
+    expect(mocks.resolveCommandSecretRefsViaGateway).toHaveBeenCalledTimes(2);
+    expect(mocks.resolveCommandSecretRefsViaGateway.mock.calls[0]?.[0].commandName).toBe(
+      "channels",
+    );
+    expect(mocks.resolveCommandSecretRefsViaGateway.mock.calls[1]?.[0].commandName).toBe(
+      "channels",
+    );
+    expect(mocks.resolveCommandSecretRefsViaGateway.mock.calls[1]?.[0].config).toEqual(
+      runtimeConfig,
+    );
+    expect(resolveAccount.mock.calls[0]?.[0].channels?.slack?.botToken).toBe(
+      "resolved-capabilities-token",
+    );
+    expect(resolveAccount.mock.calls[0]?.[0].messages?.responsePrefix).toBe("runtime-default");
+    expect(probeAccount.mock.calls[0]?.[0].cfg.channels?.slack?.botToken).toBe(
+      "resolved-capabilities-token",
+    );
+    expect(probeAccount.mock.calls[0]?.[0].cfg.messages?.responsePrefix).toBe("runtime-default");
 
     expect(mocks.refreshPluginRegistryAfterConfigMutation).toHaveBeenNthCalledWith(
       1,
@@ -474,7 +546,7 @@ describe("channelsCapabilitiesCommand", () => {
     );
     expect(logs).toStrictEqual([
       [
-        "whatsapp:default",
+        "slack:default",
         "Support: chatTypes=direct",
         "Actions: send, broadcast, poll",
         "Probe: linked",

--- a/src/commands/channels/capabilities.ts
+++ b/src/commands/channels/capabilities.ts
@@ -16,18 +16,20 @@ import type {
   ChannelCapabilitiesDisplayLine,
   ChannelPlugin,
 } from "../../channels/plugins/types.public.js";
+import { resolveCommandConfigWithSecrets } from "../../cli/command-config-resolution.js";
 import { formatCliCommand } from "../../cli/command-format.js";
+import { getChannelsCommandSecretTargetIds } from "../../cli/command-secret-targets.js";
 import { formatUnknownChannelMessage } from "../../cli/error-format.js";
 import { ExpectedCliError } from "../../cli/failure-output.js";
 import { parseTimeoutMsWithFallback } from "../../cli/parse-timeout.js";
-import { readConfigFileSnapshot } from "../../config/config.js";
-import type { OpenClawConfig } from "../../config/config.js";
+import { getRuntimeConfig, type OpenClawConfig } from "../../config/config.js";
 import { danger } from "../../globals.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { resolveInstallableChannelPlugin } from "../channel-setup/channel-plugin-resolution.js";
-import { persistResolvedChannelPluginConfig } from "./plugin-config-persistence.js";
-import { formatChannelAccountLabel, requireValidChannelConfig } from "./shared.js";
+import { requireValidConfigFileSnapshot } from "../config-validation.js";
+import { persistChannelPluginConfig } from "./plugin-config-persistence.js";
+import { formatChannelAccountLabel } from "./shared.js";
 
 export type ChannelsCapabilitiesOptions = {
   channel?: string;
@@ -298,17 +300,27 @@ async function resolveChannelReports(params: {
   return reports;
 }
 
+async function resolveCapabilitiesRuntimeConfig(config: OpenClawConfig, runtime: RuntimeEnv) {
+  return (
+    await resolveCommandConfigWithSecrets({
+      config,
+      commandName: "channels",
+      targetIds: getChannelsCommandSecretTargetIds(),
+      runtime,
+    })
+  ).effectiveConfig;
+}
+
 /** Print or serialize configured channel capabilities, actions, and optional health probe details. */
 export async function channelsCapabilitiesCommand(
   opts: ChannelsCapabilitiesOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
-  const sourceSnapshotPromise = readConfigFileSnapshot().catch(() => null);
-  const loadedCfg = await requireValidChannelConfig(runtime);
-  if (!loadedCfg) {
+  const configSnapshot = await requireValidConfigFileSnapshot(runtime);
+  if (!configSnapshot) {
     return;
   }
-  let cfg = loadedCfg;
+  let cfg = await resolveCapabilitiesRuntimeConfig(configSnapshot.config, runtime);
   const timeoutMs = resolveChannelCapabilitiesTimeoutMs(
     parseTimeoutMsWithFallback(opts.timeout, 10_000),
   );
@@ -329,17 +341,21 @@ export async function channelsCapabilitiesCommand(
       ? plugins
       : await (async () => {
           const resolved = await resolveInstallableChannelPlugin({
-            cfg,
+            cfg: configSnapshot.sourceConfig,
             runtime,
             rawChannel,
             allowInstall: true,
           });
           if (resolved.configChanged) {
-            cfg = await persistResolvedChannelPluginConfig({
-              resolved,
-              baseHash: (await sourceSnapshotPromise)?.hash,
+            await persistChannelPluginConfig({
+              cfg: resolved.cfg,
+              pluginInstalled: resolved.pluginInstalled,
+              baseHash: configSnapshot.hash,
               runtime,
             });
+            // The writer refreshes the active runtime snapshot; probes must use that prepared
+            // view rather than the authored config that installation persisted.
+            cfg = await resolveCapabilitiesRuntimeConfig(getRuntimeConfig(), runtime);
           }
           return resolved.plugin ? [resolved.plugin] : null;
         })();

--- a/src/commands/channels/plugin-config-persistence.ts
+++ b/src/commands/channels/plugin-config-persistence.ts
@@ -4,24 +4,14 @@ import { commitConfigWithPendingPluginInstalls } from "../../plugins/install-rec
 import { refreshPluginRegistryAfterConfigMutation } from "../../plugins/registry-refresh.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
-export async function persistResolvedChannelPluginConfig(params: {
-  resolved: {
-    cfg: OpenClawConfig;
-    configChanged: boolean;
-    pluginInstalled: boolean;
-  };
+export async function persistChannelPluginConfig(params: {
+  cfg: OpenClawConfig;
+  pluginInstalled: boolean;
   baseHash?: string;
   runtime: RuntimeEnv;
-}): Promise<OpenClawConfig> {
-  if (!params.resolved.configChanged) {
-    return params.resolved.cfg;
-  }
-
-  const cfg = params.resolved.cfg;
-  const shouldMovePluginInstalls = Boolean(
-    cfg.plugins?.installs && Object.keys(cfg.plugins.installs).length > 0,
-  );
-  if (shouldMovePluginInstalls) {
+}): Promise<void> {
+  const cfg = params.cfg;
+  if (cfg.plugins?.installs && Object.keys(cfg.plugins.installs).length > 0) {
     const committed = await commitConfigWithPendingPluginInstalls({
       nextConfig: cfg,
       baseHash: params.baseHash,
@@ -32,19 +22,18 @@ export async function persistResolvedChannelPluginConfig(params: {
       installRecords: committed.installRecords,
       logger: { warn: (message) => params.runtime.log(message) },
     });
-    return committed.config;
+    return;
   }
 
   await replaceConfigFile({
     nextConfig: cfg,
     baseHash: params.baseHash,
   });
-  if (params.resolved.pluginInstalled) {
+  if (params.pluginInstalled) {
     await refreshPluginRegistryAfterConfigMutation({
       config: cfg,
       reason: "source-changed",
       logger: { warn: (message) => params.runtime.log(message) },
     });
   }
-  return cfg;
 }

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -12,15 +12,14 @@ import {
   formatUnknownChannelMessage,
   formatUnsupportedChannelActionMessage,
 } from "../../cli/error-format.js";
-import { replaceConfigFile, type OpenClawConfig } from "../../config/config.js";
+import type { OpenClawConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { commitConfigWithPendingPluginInstalls } from "../../plugins/install-record-commit.js";
-import { refreshPluginRegistryAfterConfigMutation } from "../../plugins/registry-refresh.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { createClackPrompter } from "../../wizard/clack-prompter.js";
+import { persistChannelPluginConfig } from "./plugin-config-persistence.js";
 import { channelLabel } from "./runtime-label.js";
 import { type ChatChannel, requireValidConfigFileSnapshot, shouldUseWizard } from "./shared.js";
 
@@ -83,7 +82,7 @@ export async function channelsRemoveCommand(
     return;
   }
   const baseHash = configSnapshot.hash;
-  let cfg = (configSnapshot.sourceConfig ?? configSnapshot.config) as OpenClawConfig;
+  const cfg: OpenClawConfig = configSnapshot.sourceConfig;
 
   const useWizard = shouldUseWizard(params);
   const prompter = useWizard ? createClackPrompter() : null;
@@ -164,9 +163,6 @@ export async function channelsRemoveCommand(
         });
       })()
     : null;
-  if (resolvedPluginState?.configChanged) {
-    cfg = resolvedPluginState.cfg;
-  }
   const resolvedChannel = resolvedPluginState?.channelId ?? channel;
   if (!resolvedChannel) {
     runtime.error(formatUnknownChannelMessage({ channel: rawChannel }));
@@ -216,36 +212,12 @@ export async function channelsRemoveCommand(
     runtime.exit(1);
     return;
   }
-  let next = removal.value.nextConfig;
-
-  const shouldMovePluginInstalls = Boolean(
-    next.plugins?.installs && Object.keys(next.plugins.installs).length > 0,
-  );
-  if (shouldMovePluginInstalls) {
-    const committed = await commitConfigWithPendingPluginInstalls({
-      nextConfig: next,
-      ...(baseHash !== undefined ? { baseHash } : {}),
-    });
-    next = committed.config;
-    await refreshPluginRegistryAfterConfigMutation({
-      config: next,
-      reason: "source-changed",
-      installRecords: committed.installRecords,
-      logger: { warn: (message) => runtime.log(message) },
-    });
-  } else {
-    await replaceConfigFile({
-      nextConfig: next,
-      ...(baseHash !== undefined ? { baseHash } : {}),
-    });
-    if (resolvedPluginState?.pluginInstalled) {
-      await refreshPluginRegistryAfterConfigMutation({
-        config: next,
-        reason: "source-changed",
-        logger: { warn: (message) => runtime.log(message) },
-      });
-    }
-  }
+  await persistChannelPluginConfig({
+    cfg: removal.value.nextConfig,
+    pluginInstalled: false,
+    ...(baseHash !== undefined ? { baseHash } : {}),
+    runtime,
+  });
   if (useWizard && prompter) {
     await prompter.outro(
       deleteConfig

--- a/src/commands/channels/resolve.ts
+++ b/src/commands/channels/resolve.ts
@@ -13,12 +13,11 @@ import { resolveCommandConfigWithSecrets } from "../../cli/command-config-resolu
 import { formatCliCommand } from "../../cli/command-format.js";
 import { getChannelsCommandSecretTargetIds } from "../../cli/command-secret-targets.js";
 import { formatUnsupportedChannelActionMessage } from "../../cli/error-format.js";
-import { getRuntimeConfig, readConfigFileSnapshot } from "../../config/config.js";
+import { getRuntimeConfig } from "../../config/config.js";
 import { danger } from "../../globals.js";
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { resolveInstallableChannelPlugin } from "../channel-setup/channel-plugin-resolution.js";
-import { persistResolvedChannelPluginConfig } from "./plugin-config-persistence.js";
 
 export type ChannelsResolveOptions = {
   agent?: string;
@@ -132,8 +131,7 @@ export async function channelsResolveCommand(opts: ChannelsResolveOptions, runti
     throw new Error("--agent must not be blank");
   }
   const agentId = requestedAgent ? resolveConfiguredAgentId(loadedRaw, requestedAgent) : undefined;
-  const sourceSnapshotPromise = readConfigFileSnapshot().catch(() => null);
-  let { effectiveConfig: cfg } = await resolveCommandConfigWithSecrets({
+  const { effectiveConfig: cfg } = await resolveCommandConfigWithSecrets({
     config: loadedRaw,
     commandName: "channels resolve",
     targetIds: getChannelsCommandSecretTargetIds(),
@@ -159,14 +157,6 @@ export async function channelsResolveCommand(opts: ChannelsResolveOptions, runti
       `Channel plugin "${resolvedExplicit.catalogEntry.id}" is not installed. Run ${formatCliCommand(`openclaw channels add --channel ${resolvedExplicit.catalogEntry.id}`)} first.`,
     );
   }
-  if (resolvedExplicit?.configChanged) {
-    cfg = await persistResolvedChannelPluginConfig({
-      resolved: resolvedExplicit,
-      baseHash: (await sourceSnapshotPromise)?.hash,
-      runtime,
-    });
-  }
-
   const selection = explicitChannel
     ? {
         channel: resolvedExplicit?.channelId,

--- a/src/commands/test-runtime-config-helpers.ts
+++ b/src/commands/test-runtime-config-helpers.ts
@@ -2,6 +2,7 @@
 // Kept under commands because many command tests need the same mock runtime shapes.
 
 import { vi } from "vitest";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { MockFn } from "../test-utils/vitest-mock-fn.js";
 
@@ -15,6 +16,31 @@ export const baseConfigSnapshot = {
   issues: [],
   legacyIssues: [],
 };
+
+/** Builds a complete config snapshot while preserving distinct authored and runtime fixtures. */
+export function createTestConfigSnapshot(
+  sourceConfig: OpenClawConfig,
+  runtimeConfig: OpenClawConfig = sourceConfig,
+): ConfigFileSnapshot {
+  // SAFETY: Snapshot source branding preserves the exact caller-owned authored config object.
+  const resolvedSourceConfig = sourceConfig as ConfigFileSnapshot["sourceConfig"];
+  // SAFETY: Snapshot runtime branding preserves the distinct caller-owned runtime config object.
+  const resolvedRuntimeConfig = runtimeConfig as ConfigFileSnapshot["runtimeConfig"];
+  return {
+    path: "/tmp/openclaw.json",
+    exists: true,
+    raw: "{}",
+    parsed: {},
+    sourceConfig: resolvedSourceConfig,
+    resolved: resolvedSourceConfig,
+    valid: true,
+    runtimeConfig: resolvedRuntimeConfig,
+    config: resolvedRuntimeConfig,
+    issues: [],
+    warnings: [],
+    legacyIssues: [],
+  };
+}
 
 type TestRuntime = {
   log: MockFn<RuntimeEnv["log"]>;

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -95,6 +95,7 @@ function makePlugin(params: {
   id: string;
   accountIds?: string[];
   resolveAccount?: (accountId: string) => unknown;
+  inspectAccount?: (accountId: string) => unknown;
   isEnabled?: (account: unknown) => boolean;
   isConfigured?: (account: unknown) => boolean | Promise<boolean>;
 }) {
@@ -104,6 +105,12 @@ function makePlugin(params: {
       listAccountIds: () => params.accountIds ?? ["default"],
       resolveAccount: (_cfg: unknown, accountId: string) =>
         params.resolveAccount ? params.resolveAccount(accountId) : {},
+      ...(params.inspectAccount
+        ? {
+            inspectAccount: (_cfg: unknown, accountId: string) =>
+              params.inspectAccount?.(accountId),
+          }
+        : {}),
       ...(params.isEnabled ? { isEnabled: params.isEnabled } : {}),
       ...(params.isConfigured ? { isConfigured: params.isConfigured } : {}),
     },
@@ -321,6 +328,128 @@ describe("resolveMessageChannelSelection", () => {
     const selection = await expectResolvedSelection({ cfg: {} as never });
 
     expect(selection.plugin).toBe(plugin);
+  });
+
+  it.each([
+    {
+      name: "trusts inspected configured state without materializing credentials",
+      accountResolution: "read_only" as const,
+      accountIds: ["default"],
+      inspect: async () => ({ enabled: true, configured: true }),
+      resolve: () => {
+        throw new Error("unresolved SecretRef");
+      },
+      configured: () => false,
+      expected: true,
+      inspectCalls: ["default"],
+      resolveCalls: 0,
+    },
+    {
+      name: "keeps strict selection on runtime account callbacks",
+      accountResolution: undefined,
+      accountIds: ["default"],
+      inspect: () => ({ enabled: true, configured: true }),
+      resolve: () => ({ enabled: true }),
+      configured: () => false,
+      expected: false,
+      inspectCalls: [],
+      resolveCalls: 1,
+    },
+    {
+      name: "excludes inspected disabled and unconfigured accounts",
+      accountResolution: "read_only" as const,
+      accountIds: ["disabled", "missing"],
+      inspect: (accountId: string) =>
+        accountId === "disabled"
+          ? { enabled: false, configured: true }
+          : { enabled: true, configured: false },
+      resolve: () => {
+        throw new Error("strict resolution must not run");
+      },
+      configured: () => {
+        throw new Error("strict configured check must not run");
+      },
+      expected: false,
+      inspectCalls: ["disabled", "missing"],
+      resolveCalls: 0,
+    },
+    {
+      name: "finds an inspected secondary account after a disabled default",
+      accountResolution: "read_only" as const,
+      accountIds: ["default", "secondary"],
+      inspect: (accountId: string) => ({
+        enabled: accountId === "secondary",
+        configured: true,
+      }),
+      resolve: () => {
+        throw new Error("strict resolution must not run");
+      },
+      configured: () => {
+        throw new Error("strict configured check must not run");
+      },
+      expected: true,
+      inspectCalls: ["default", "secondary"],
+      resolveCalls: 0,
+    },
+    {
+      name: "contains read-only inspector failures to their account",
+      accountResolution: "read_only" as const,
+      accountIds: ["default"],
+      inspect: () => {
+        throw new Error("inspection failed");
+      },
+      resolve: () => {
+        throw new Error("strict resolution must not run");
+      },
+      configured: () => true,
+      expected: false,
+      inspectCalls: ["default"],
+      resolveCalls: 0,
+    },
+    {
+      name: "retains strict callback fallback for plugins without an inspector",
+      accountResolution: "read_only" as const,
+      accountIds: ["default"],
+      inspect: undefined,
+      resolve: () => ({ enabled: true, configured: false }),
+      configured: () => true,
+      expected: true,
+      inspectCalls: [],
+      resolveCalls: 1,
+    },
+  ])("$name", async (scenario) => {
+    const inspectAccount = scenario.inspect ? vi.fn(scenario.inspect) : undefined;
+    const resolveAccount = vi.fn(scenario.resolve);
+    const isConfigured = vi.fn(scenario.configured);
+    const plugin = makePlugin({
+      id: "delta",
+      accountIds: scenario.accountIds,
+      inspectAccount,
+      resolveAccount,
+      isEnabled: (account) => (account as { enabled?: boolean }).enabled !== false,
+      isConfigured,
+    });
+    mocks.listChannelPlugins.mockReturnValue([plugin]);
+    const params = {
+      cfg: {} as never,
+      ...(scenario.accountResolution ? { accountResolution: scenario.accountResolution } : {}),
+    };
+
+    if (scenario.expected) {
+      await expect(expectResolvedSelection(params)).resolves.toMatchObject({
+        channel: "delta",
+        configured: ["delta"],
+        source: "single-configured",
+      });
+    } else {
+      await expect(expectResolvedSelection(params)).rejects.toThrow(
+        "Channel is required (no configured channels detected).",
+      );
+    }
+    expect(inspectAccount?.mock.calls.map(([accountId]) => accountId) ?? []).toEqual(
+      scenario.inspectCalls,
+    );
+    expect(resolveAccount).toHaveBeenCalledTimes(scenario.resolveCalls);
   });
 
   it("allows bootstrap while checking explicit and fallback channels", async () => {

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -1,4 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 // Channel selection chooses a deliverable message channel from explicit input,
 // tool context fallback, or configured plugin accounts.
 import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
@@ -11,6 +12,7 @@ import {
 } from "../../plugins/official-external-plugin-repair-hints.js";
 import { defaultRuntime } from "../../runtime.js";
 import { isAccountEnabled } from "../../shared/account-enabled.js";
+import { asBoolean } from "../../utils/boolean.js";
 import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
@@ -119,7 +121,7 @@ const loggedChannelSelectionErrors = createDedupeCache({
 function logChannelSelectionError(params: {
   pluginId: string;
   accountId: string;
-  operation: "resolveAccount" | "isConfigured";
+  operation: "inspectAccount" | "resolveAccount" | "isConfigured";
   error: unknown;
 }) {
   const message = formatErrorMessage(params.error);
@@ -132,37 +134,49 @@ function logChannelSelectionError(params: {
   );
 }
 
-async function isPluginConfigured(plugin: ChannelPlugin, cfg: OpenClawConfig): Promise<boolean> {
-  const accountIds = plugin.config.listAccountIds(cfg);
-  if (accountIds.length === 0) {
-    return false;
-  }
+type AccountResolutionMode = "strict" | "read_only";
 
+async function isPluginConfigured(
+  plugin: ChannelPlugin,
+  cfg: OpenClawConfig,
+  accountResolution: AccountResolutionMode,
+): Promise<boolean> {
+  const accountIds = plugin.config.listAccountIds(cfg);
   for (const accountId of accountIds) {
+    let operation: "inspectAccount" | "resolveAccount" = "inspectAccount";
+    let inspection: Record<string, unknown> | undefined;
     let account: unknown;
     try {
-      account = plugin.config.resolveAccount(cfg, accountId);
+      inspection = asOptionalRecord(
+        accountResolution === "read_only"
+          ? await plugin.config.inspectAccount?.(cfg, accountId)
+          : undefined,
+      );
+      operation = "resolveAccount";
+      account = inspection ?? plugin.config.resolveAccount(cfg, accountId);
     } catch (error) {
       logChannelSelectionError({
         pluginId: plugin.id,
         accountId,
-        operation: "resolveAccount",
+        operation,
         error,
       });
       continue;
     }
-    const enabled = plugin.config.isEnabled
-      ? plugin.config.isEnabled(account, cfg)
-      : isAccountEnabled(account);
+    const enabled =
+      asBoolean(inspection?.enabled) ??
+      (plugin.config.isEnabled ? plugin.config.isEnabled(account, cfg) : isAccountEnabled(account));
     if (!enabled) {
       continue;
     }
-    if (!plugin.config.isConfigured) {
-      return true;
-    }
-    let configured;
     try {
-      configured = await plugin.config.isConfigured(account, cfg);
+      const configured =
+        asBoolean(inspection?.configured) ??
+        (await plugin.config.isConfigured?.(account, cfg)) ??
+        true;
+      if (configured) {
+        return true;
+      }
     } catch (error) {
       logChannelSelectionError({
         pluginId: plugin.id,
@@ -170,23 +184,22 @@ async function isPluginConfigured(plugin: ChannelPlugin, cfg: OpenClawConfig): P
         operation: "isConfigured",
         error,
       });
-      continue;
-    }
-    if (configured) {
-      return true;
     }
   }
 
   return false;
 }
 
-async function listConfiguredMessageChannelPlugins(cfg: OpenClawConfig): Promise<ChannelPlugin[]> {
+async function listConfiguredMessageChannelPlugins(
+  cfg: OpenClawConfig,
+  accountResolution: AccountResolutionMode = "strict",
+): Promise<ChannelPlugin[]> {
   const plugins: ChannelPlugin[] = [];
   for (const plugin of listRuntimeVisibleChannelPlugins()) {
     if (!isDeliverableMessageChannel(plugin.id)) {
       continue;
     }
-    if (await isPluginConfigured(plugin, cfg)) {
+    if (await isPluginConfigured(plugin, cfg, accountResolution)) {
       plugins.push(plugin);
     }
   }
@@ -204,6 +217,9 @@ export async function resolveMessageChannelSelection(params: {
   channel?: string | null;
   fallbackChannel?: string | null;
   agentId?: string;
+  // Strict callers select usable runtime accounts. Directory inspection opts in before it knows
+  // which account-scoped SecretRefs to redeem.
+  accountResolution?: AccountResolutionMode;
 }): Promise<{
   channel: string;
   plugin: ChannelPlugin;
@@ -267,7 +283,10 @@ export async function resolveMessageChannelSelection(params: {
     };
   }
 
-  const configuredPlugins = await listConfiguredMessageChannelPlugins(params.cfg);
+  const configuredPlugins = await listConfiguredMessageChannelPlugins(
+    params.cfg,
+    params.accountResolution,
+  );
   const configured = configuredPlugins.map((plugin) => plugin.id);
   if (configuredPlugins.length === 1) {
     const plugin = expectDefined(configuredPlugins[0], "configured plugin at 0");


### PR DESCRIPTION
## What Problem This Solves

Fixes channel directory and capability commands that could pass a runtime-expanded config into plugin installation/setup and then persist materialized defaults or resolved credential values. Related remove/resolve paths also carried config-write branches into operations that do not install plugins.

## Why This Change Was Made

Install and auto-enable decisions now start from the validated authored source snapshot, while execution uses the writer-prepared runtime snapshot. Directory resolves secrets only for the selected channel/account; capabilities preserves the existing broad channels-command secret-target policy. Intentional writes keep the snapshot hash as their commit lease. The shared persistence owner handles both pending install records and ordinary config writes; remove uses that owner, and resolve no longer writes config for its non-installing lookup.

The directory path still commits an explicitly installed plugin before invoking its directory adapter, preserving the existing lease/order guarantee. The writer refreshes runtime state, and the command reads that prepared snapshot for execution instead of persisting the runtime-expanded view.

## User Impact

`openclaw directory` and `openclaw channels capabilities` preserve authored SecretRefs and avoid persisting runtime defaults while still using resolved credentials for execution. Directory scopes resolution to the selected channel/account; capabilities retains its broader channels-command target policy. Channel remove/resolve avoid false install-persistence paths. Invalid config continues to stop the command before plugin work.

## Evidence

- Genuine pre-production RED: directory install resolution received a materialized `messages.responsePrefix`; capabilities resolution received a resolved token and runtime default instead of the authored SecretRef source.
- Initial built behavior proof passed 7/8 cases and exposed a second real boundary: implicit directory selection tried strict account resolution before the selected account's SecretRefs could be redeemed. The repair adds an opt-in read-only account inspection mode for directory selection; every existing caller keeps strict runtime-account resolution.
- Original 13-file commit focused owners: directory 26/26 and capabilities 15/15 passed.
- Owner RED→GREEN coverage also exercises the intentional plugin enable/install write branches and their source-snapshot commit lease.
- Original 13-file owner/sibling matrix: 155/155 passed across 11 files, covering config validation, install resolution, directory/capability execution, remove/resolve behavior, scoped secret targets, and install-record persistence.
- H4 repair proof passed selection 31/31, directory 27/27, and 90 sibling tests: 148 distinct tests in the delta scope.
- Two targeted core-test type graphs and the complete 13-path changed-file gate passed, including production/test types, lint, dead-code scans, schema/storage/auth/media/import-cycle/webhook/pairing guards, and the assertion-safety ratchet shrink.
- The combined 15-file changed-gate invocation passed its core source/test phases, then failed at the independent built-artifact scripts-lint lane before reaching later guards because `.mts` files lacked canonical project membership. Eight later guard commands were run separately through one verified `&&` chain and passed. A separate tooling repair is in progress; this PR does not hide or call the full gate green.
- Original 13-file review: no findings, 0.96 confidence. H4 repair-delta review: no findings, 0.98 confidence. Root integration review covers the combined 15-file source.
- Full builds on original exact13 commit `b0c830fd` and combined H4-repair commit `3d2feb77` passed with exact stamps and build info.
- Source-blind built directory CLI behavior proof against an owned Slack-shaped HTTP endpoint: all seven repaired checks H1/H2/H3/H4/H4R/H5/H6 passed on `3d2feb77`; H7/H8 remain evidenced only on `b0c830fd`. Observed identities matched the expected A/A/B/A/A/C sequence, H6 exercised both exit-1 and exit-0 request outcomes, every config delta was empty, and full-snapshot continuity held across H1→H2, H4→H4R, and H4R→H5. Raw record SHA-256: `e4afba529cfb897f8a4a9acfe336f1c5c20d60c70918fef66769712d79dc119b`. This is not real Slack authentication, provider networking, or live plugin installation proof.
- First exact-head CI run `33123677480` failed only in unchanged Mattermost `client.fetch-timeout.test.ts:71` (1 failure, 827 passes; job `98696682667`). No elapsed/timer-delay diagnostic was captured, so starvation is not proven and the CI trigger remains unproven. The test starts the request, awaits unbounded server arrival, and attaches its rejection/750 ms race later; named follow-up: bound server-arrival and observe early request rejection without weakening the request timeout. One unchanged-head failed-only retry was authorized; no guard, assertion, or timeout changed.
- Combined LOC: production +141/-121 (net +20). Tests/support: +494/-81 (net +413). Docs: +1/-0. Assertion metadata: +0/-1. Total: +636/-203 (net +433).
- No public API, schema, protocol, or default-policy change.

Intentional setup writes preserve canonical version and migration stamps; this change does not claim universal byte identity for those writes. The pending strict no-write cases cover already-enabled fixtures.

## Provenance

This was a carried-forward ownership gap rather than one isolated regression. Peter Steinberger authored the directory optional-plugin installation in [`ba1bb8505fc2`](https://github.com/openclaw/openclaw/commit/ba1bb8505fc2c12cbb8f5d8f69271d49443723e5) (2026-03-19), source-snapshot write leasing in [`a27ccee5d9d5`](https://github.com/openclaw/openclaw/commit/a27ccee5d9d5d27f2c368056ee4ad96ae7e46ae6) (2026-03-30), and runtime plugin config access in [`7f3f108521f4`](https://github.com/openclaw/openclaw/commit/7f3f108521f45ba14b65b2ffe507b5ee88979671) (2026-04-27). Vincent Koc authored the shared capabilities/resolve persistence in [`f77a74dec780`](https://github.com/openclaw/openclaw/commit/f77a74dec7807862effc8bb9aac254220a055094) (2026-06-22). Their combination blurred authored config, runtime execution, and install-persistence ownership.

The implicit-selection H4 failure traces to strict `resolveAccount` usage carried through Peter Steinberger's mechanical provider-to-channel rename in [`90342a4f3a5b`](https://github.com/openclaw/openclaw/commit/90342a4f3a5b46f3c44b5c7b98109a5792a2d184) (2026-01-13). Josh Avant's later scoped-SecretRef logging hardening in [`da34f81ce237`](https://github.com/openclaw/openclaw/commit/da34f81ce23744c2a69e37ab585e2cc95b6adf9b) (2026-03-17) carried that strict behavior forward; it did not introduce the defect.

## Follow-ups

- Audit the core command secret-target inventory when arbitrary new custom channel target IDs appear across same-process plugin install or reload before making any new cache contract claim.
- Continue migrating partial `ConfigFileSnapshot` test fixtures to the canonical complete authored/runtime snapshot helper when their owners are touched.
- Avoid synthesizing an empty `agents` parent on unrelated config writes while preserving intentional canonical version/migration stamps; prior source-blind auth proof observed this residue on successful writes.
- Add owner proof for implicit inference and local logout on auth-capable channels with SecretRef-backed accounts. Slack is excluded because its plugin supports neither login nor logout.
