### PR TITLE
fix: Claude session discovery stalls on stale Desktop metadata

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayProcessManager.swift
@@ -1152,6 +1152,7 @@ extension GatewayProcessManager {
         let connection = self.connection
         // Startup owns recovery and its wall-clock deadline. A normal request can recursively
         // start the Gateway and spend several 30-second connect retries before its RPC timer begins.
+        // Disable the inner RPC timer so it cannot race the owner's typed probe timeout.
         return try await AsyncTimeout.withTimeout(
             seconds: max(0.001, timeoutMs / 1000),
             onTimeout: { GatewayHealthProbeTimeout(timeoutMs: timeoutMs) },
@@ -1159,7 +1160,7 @@ extension GatewayProcessManager {
                 try await connection.request(
                     method: GatewayConnection.Method.health.rawValue,
                     params: nil,
-                    timeoutMs: timeoutMs,
+                    timeoutMs: 0,
                     retryTransportFailures: false)
             })
     }

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeClaudeSessionCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeClaudeSessionCatalog.swift
@@ -604,6 +604,7 @@ extension MacNodeClaudeSessionCatalog {
     private static func discoverCLIRecords(
         projectsURL: URL,
         resolvedProjectsURL: URL,
+        projectFiles: [[URL]],
         records: inout [String: SessionRecord],
         sidechainIds: inout Set<String>) throws
     {
@@ -615,12 +616,8 @@ extension MacNodeClaudeSessionCatalog {
             projectsURL: projectsURL,
             resolvedProjectsURL: resolvedProjectsURL,
             rootPath: projectsURL.path)
-        scan: for projectURL in self.childDirectories(projectsURL) {
+        scan: for files in projectFiles {
             try Task.checkCancellation()
-            let files = (try? FileManager.default.contentsOfDirectory(
-                at: projectURL,
-                includingPropertiesForKeys: [.contentModificationDateKey],
-                options: [.skipsHiddenFiles])) ?? []
             for candidate in files where candidate.pathExtension == "jsonl" {
                 try Task.checkCancellation()
                 guard discoveredFiles < self.maxCatalogDiscoveryFiles else {
@@ -688,6 +685,7 @@ extension MacNodeClaudeSessionCatalog {
             return scannedBytes >= self.maxCatalogMetadataScanBytes
         }
         guard let handle = try? FileHandle(forReadingFrom: fileURL) else { return false }
+        defer { try? handle.close() }
         let updatedAt = identity.map {
             Int64($0.modificationDate.timeIntervalSince1970 * 1000)
         } ?? (try? fileURL.resourceValues(
@@ -699,7 +697,6 @@ extension MacNodeClaudeSessionCatalog {
             sessionId: sessionId,
             updatedAt: updatedAt,
             byteLimit: self.maxCatalogMetadataScanBytes - scannedBytes)
-        try? handle.close()
         scannedBytes += scan.fileBytes
         if scan.sidechain {
             sidechainIds.insert(sessionId)
@@ -841,9 +838,16 @@ extension MacNodeClaudeSessionCatalog {
         let resolvedProjectsURL = projectsURL.resolvingSymlinksInPath()
         var records: [String: SessionRecord] = [:]
         var sidechainIds = Set<String>()
+        var projectFiles: [[URL]] = []
         for projectURL in self.childDirectories(projectsURL) {
             try Task.checkCancellation()
-            guard let index = readJSON(projectURL.appending(path: "sessions-index.json")) as? [String: Any],
+            let files = (try? FileManager.default.contentsOfDirectory(
+                at: projectURL,
+                includingPropertiesForKeys: nil,
+                options: [.skipsHiddenFiles])) ?? []
+            projectFiles.append(files)
+            guard let indexURL = files.first(where: { $0.lastPathComponent == "sessions-index.json" }),
+                  let index = readJSON(indexURL) as? [String: Any],
                   let entries = index["entries"] as? [[String: Any]]
             else { continue }
             for entry in entries {
@@ -879,9 +883,15 @@ extension MacNodeClaudeSessionCatalog {
         try self.discoverCLIRecords(
             projectsURL: projectsURL,
             resolvedProjectsURL: resolvedProjectsURL,
+            projectFiles: projectFiles,
             records: &records,
             sidechainIds: &sidechainIds)
 
+        // Reuse this refresh's inventory: stale Desktop metadata must not trigger
+        // a filesystem walk for every missing transcript. Candidates still pass path validation.
+        let sessionFiles = Dictionary(
+            grouping: projectFiles.joined().filter { $0.pathExtension == "jsonl" },
+            by: \.lastPathComponent)
         let desktop = try self.desktopMetadata(homeURL: homeURL)
         for sessionId in desktop.archived {
             try Task.checkCancellation()
@@ -894,7 +904,13 @@ extension MacNodeClaudeSessionCatalog {
             }
             var record = records[sessionId]
             if record == nil,
-               let fileURL = try locateSessionFile(homeURL: homeURL, sessionId: sessionId)
+               let fileURL = (sessionFiles["\(sessionId).jsonl"] ?? []).lazy.compactMap({ candidate in
+                   self.safeSessionFile(
+                       root: projectsURL,
+                       resolvedRoot: resolvedProjectsURL,
+                       candidate: candidate,
+                       sessionId: sessionId)
+               }).first
             {
                 record = SessionRecord(
                     threadId: sessionId,
@@ -919,24 +935,6 @@ extension MacNodeClaudeSessionCatalog {
             let rightTime = right.updatedAt ?? 0
             return leftTime == rightTime ? left.threadId < right.threadId : leftTime > rightTime
         }
-    }
-
-    private static func locateSessionFile(homeURL: URL, sessionId: String) throws -> URL? {
-        let root = self.projectsURL(homeURL: homeURL)
-        let resolvedRoot = root.resolvingSymlinksInPath()
-        for projectURL in self.childDirectories(root) {
-            try Task.checkCancellation()
-            let candidate = projectURL.appending(path: "\(sessionId).jsonl")
-            if let fileURL = safeSessionFile(
-                root: root,
-                resolvedRoot: resolvedRoot,
-                candidate: candidate,
-                sessionId: sessionId)
-            {
-                return fileURL
-            }
-        }
-        return nil
     }
 }
 

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayProcessManagerTests.swift
@@ -7,6 +7,10 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct GatewayProcessManagerTests {
+    /// Recovery integration suites exercise the app singleton concurrently. Each
+    /// unit test owns its manager so readiness state cannot leak into their requests.
+    private let manager = GatewayProcessManager()
+
     @Test func `colliding profile ports cannot attach another profile gateway`() {
         let first = AppProfile(environment: ["OPENCLAW_PROFILE": "p1402"])
         let second = AppProfile(environment: ["OPENCLAW_PROFILE": "p2380"])
@@ -107,9 +111,9 @@ struct GatewayProcessManagerTests {
                 GatewayLaunchAgentManager.setTestingDaemonStatusPayload(nil)
                 GatewayLaunchAgentManager.setTestingDaemonCommandDelayNanoseconds(0)
                 GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
-                GatewayProcessManager.shared.setTestingDesiredActive(false)
-                GatewayProcessManager.shared._testClearLaunchAgentReadinessFailure()
-                GatewayProcessManager.shared._testClearLaunchAgentInstallEvidence()
+                self.manager.setTestingDesiredActive(false)
+                self.manager._testClearLaunchAgentReadinessFailure()
+                self.manager._testClearLaunchAgentInstallEvidence()
             }
             return try await body()
         }
@@ -124,7 +128,7 @@ struct GatewayProcessManagerTests {
         let connection = GatewayConnection(
             configProvider: { (url: url, token: nil, password: nil) },
             sessionBox: WebSocketSessionBox(session: session))
-        let manager = GatewayProcessManager.shared
+        let manager = self.manager
         manager._testResetGatewayStartTask()
         manager.setTestingConnection(connection)
         return (session, connection, manager)
@@ -194,7 +198,7 @@ struct GatewayProcessManagerTests {
         try await self.withLaunchAgentEnvironment(
             statusPayload: #"{"ok":true,"service":{"loaded":false}}"#)
         {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             async let first: String? = manager._testEnableLaunchAgentIfNeeded(
                 bundlePath: "/Applications/OpenClaw.app",
                 port: port)
@@ -216,7 +220,7 @@ struct GatewayProcessManagerTests {
             statusPayload: #"{"ok":true,"service":{"loaded":false}}"#,
             commandDelayNanoseconds: 100_000_000)
         {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             let first = Task { @MainActor in
                 await manager._testEnableLaunchAgentIfNeeded(
                     bundlePath: "/Applications/OpenClaw.app",
@@ -300,7 +304,7 @@ struct GatewayProcessManagerTests {
             ],
             commandDelayNanoseconds: 100_000_000)
         {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             let first = Task { @MainActor in
                 await manager._testEnableLaunchAgentIfNeededInstalled(
                     bundlePath: "/Applications/OpenClaw.app",
@@ -333,7 +337,7 @@ struct GatewayProcessManagerTests {
             statusPayload: #"{"ok":true,"service":{"loaded":false}}"#,
             commandDelayNanoseconds: 100_000_000)
         {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             manager.setTestingDesiredActive(true)
             let first = Task { @MainActor in
                 await manager._testEnableLaunchAgentIfNeeded(
@@ -380,7 +384,7 @@ struct GatewayProcessManagerTests {
             statusPayload: #"{"ok":true,"service":{"loaded":false}}"#,
             commandDelayNanoseconds: 100_000_000)
         {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             manager.setTestingDesiredActive(true)
             manager.stop()
             await self.waitForCondition {
@@ -451,7 +455,7 @@ struct GatewayProcessManagerTests {
 
     @Test func `remote mode still removes the local launch agent`() async throws {
         try await self.withLaunchAgentEnvironment(mode: "remote") {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             manager.setTestingDesiredActive(true)
             manager.stop()
             await self.waitForCondition {
@@ -467,7 +471,7 @@ struct GatewayProcessManagerTests {
 
     @Test func `inactive lifecycle skips persistence ensure`() async throws {
         try await self.withLaunchAgentEnvironment {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             manager.setTestingDesiredActive(false)
             _ = await manager.ensureLaunchAgentEnabledIfNeeded()
 
@@ -477,7 +481,7 @@ struct GatewayProcessManagerTests {
 
     @Test func `newer inactive lifecycle retains the pending disable`() async throws {
         try await self.withLaunchAgentEnvironment(commandDelayNanoseconds: 100_000_000) {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             manager.setTestingDesiredActive(true)
             manager.stop()
             manager.stop()
@@ -505,7 +509,7 @@ struct GatewayProcessManagerTests {
                     self.loadedGatewayStatus(port: port, configAudit: configAudit))
                 GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
 
-                _ = await GatewayProcessManager.shared._testEnableLaunchAgentIfNeeded(
+                _ = await self.manager._testEnableLaunchAgentIfNeeded(
                     bundlePath: "/Applications/OpenClaw.app",
                     port: port)
 
@@ -519,7 +523,7 @@ struct GatewayProcessManagerTests {
     @Test func `repairs only a stable launch agent PID after readiness fails`() async throws {
         let port = 19085
         try await self.withLaunchAgentEnvironment(statusPayload: self.loadedGatewayStatus(port: port)) {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             _ = await manager._testEnableLaunchAgentIfNeeded(
                 bundlePath: "/Applications/OpenClaw.app",
                 port: port)
@@ -546,7 +550,7 @@ struct GatewayProcessManagerTests {
         try await self.withLaunchAgentEnvironment(
             statusPayload: self.loadedGatewayStatus(port: port, pid: 4243))
         {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             await manager._testRecordLaunchAgentReadinessFailure(port: port, startingPID: 4242)
             GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
 
@@ -566,7 +570,7 @@ struct GatewayProcessManagerTests {
             statusPayload: self.loadedGatewayStatus(port: port),
             commandDelayNanoseconds: 100_000_000)
         {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             manager.setTestingDesiredActive(true)
             let finish = Task { @MainActor in
                 await manager._testFinishLaunchAgentReadinessFailure(
@@ -595,7 +599,7 @@ struct GatewayProcessManagerTests {
             statusPayload: self.loadedGatewayStatus(port: port),
             commandDelayNanoseconds: 200_000_000)
         {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             manager.setTestingDesiredActive(true)
             let staleFinish = Task { @MainActor in
                 await manager._testFinishLaunchAgentReadinessFailure(
@@ -627,7 +631,7 @@ struct GatewayProcessManagerTests {
     @Test func `repairs a stable launch agent PID with a wedged listener`() async throws {
         let port = 19087
         try await self.withLaunchAgentEnvironment(statusPayload: self.loadedGatewayStatus(port: port)) {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             let listener = self.gatewayDescriptor(pid: 4242)
             await PortGuardian.shared.setTestingDescriptor(listener, forPort: port)
             await manager._testRecordLaunchAgentReadinessFailure(port: port, startingPID: 4242)
@@ -647,7 +651,7 @@ struct GatewayProcessManagerTests {
     @Test func `protects a foreign listener after launch agent readiness fails`() async throws {
         let port = 19088
         try await self.withLaunchAgentEnvironment(statusPayload: self.loadedGatewayStatus(port: port)) {
-            let manager = GatewayProcessManager.shared
+            let manager = self.manager
             await manager._testRecordLaunchAgentReadinessFailure(port: port, startingPID: 4242)
             let listener = self.gatewayDescriptor(
                 pid: 4243,
@@ -678,7 +682,7 @@ struct GatewayProcessManagerTests {
                 executablePath: "/tmp/manual-gateway")
             await PortGuardian.shared.setTestingDescriptor(listener, forPort: port)
 
-            _ = await GatewayProcessManager.shared._testEnableLaunchAgentIfNeeded(
+            _ = await self.manager._testEnableLaunchAgentIfNeeded(
                 bundlePath: "/Applications/OpenClaw.app",
                 port: port)
 
@@ -699,7 +703,7 @@ struct GatewayProcessManagerTests {
             let listener = self.gatewayDescriptor(pid: 4242)
             await PortGuardian.shared.setTestingDescriptor(listener, forPort: port)
 
-            _ = await GatewayProcessManager.shared._testEnableLaunchAgentIfNeeded(
+            _ = await self.manager._testEnableLaunchAgentIfNeeded(
                 bundlePath: "/Applications/OpenClaw.app",
                 port: port)
 
@@ -744,7 +748,7 @@ struct GatewayProcessManagerTests {
                 GatewayLaunchAgentManager.setTestingDaemonStatusPayload(status)
                 GatewayLaunchAgentManager.clearTestingDaemonCommandCalls()
 
-                _ = await GatewayProcessManager.shared._testEnableLaunchAgentIfNeeded(
+                _ = await self.manager._testEnableLaunchAgentIfNeeded(
                     bundlePath: "/Applications/OpenClaw.app",
                     port: port)
 
@@ -1205,9 +1209,12 @@ struct GatewayProcessManagerTests {
         let port = 19118
         let url = try #require(URL(string: "ws://example.invalid"))
         let (session, connection, manager) = self.makeGatewayReadinessFixture(url: url) {
-            self.gatewayTask(
-                healthSucceedsAfter: 0,
-                stallsFirstHealthResponse: true)
+            GatewayTestWebSocketTask(sendHook: { task, message, sendIndex in
+                guard sendIndex == 1,
+                      let id = GatewayWebSocketTestSupport.requestID(from: message)
+                else { return }
+                task.emitReceiveSuccess(.data(GatewayWebSocketTestSupport.okResponseData(id: id)))
+            })
         }
         defer { manager.setTestingConnection(nil) }
 
@@ -1225,6 +1232,9 @@ struct GatewayProcessManagerTests {
                 manager._testClearLaunchAgentReadinessFailure()
             }
 
+            // Establish the socket before the short probe budget. This test owns
+            // delayed launchd authorization, not cold-handshake scheduling.
+            _ = try await connection.request(method: "status", params: nil, retryTransportFailures: false)
             manager._testStartLaunchdGatewayReadiness(
                 port: port,
                 pid: 4242,
@@ -1235,7 +1245,7 @@ struct GatewayProcessManagerTests {
             #expect(manager.status == .failed("Gateway did not start in time"))
             #expect(manager.lastFailureReason == "launchd start timeout")
             #expect(manager._testHasLaunchAgentReadinessFailure())
-            #expect(session.latestTask()?.snapshotSendCount() == 2)
+            #expect(session.latestTask()?.snapshotSendCount() == 3)
             #expect(GatewayLaunchAgentManager.testingDaemonCommandCallsSnapshot()
                 .filter { $0.first == "status" }.count == 2)
 
@@ -1364,7 +1374,7 @@ struct GatewayProcessManagerTests {
     }
 
     @Test func `only endpoint reachability failures arm launchd repair`() {
-        let manager = GatewayProcessManager.shared
+        let manager = self.manager
         #expect(manager._testProbeFailureMayNeedLaunchAgentRepair(.timedOut))
         #expect(manager._testProbeFailureMayNeedLaunchAgentRepair(.cannotConnectToHost))
         #expect(manager._testProbeFailureMayNeedLaunchAgentRepair(.networkConnectionLost))

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeClaudeSessionCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeClaudeSessionCatalogTests.swift
@@ -152,13 +152,14 @@ struct MacNodeClaudeSessionCatalogTests {
         }
     }
 
-    @Test func `merges Desktop metadata over CLI indexes and filters archived sessions`() throws {
+    @Test(arguments: [true, false])
+    func `merges Desktop metadata with indexed or Desktop-only transcripts`(indexedDesktop: Bool) throws {
         let fixture = try Fixture()
         let desktopId = "desktop-session"
         let cliId = "cli-session"
         let archivedId = "archived-session"
         let project = try fixture.project()
-        try fixture.writeIndex([
+        var indexEntries = [
             fixture.indexEntry(
                 cliId,
                 in: project,
@@ -175,7 +176,11 @@ struct MacNodeClaudeSessionCatalogTests {
                 in: project,
                 summary: "Archived",
                 modified: "2026-07-03T00:00:00.000Z"),
-        ], in: project)
+        ]
+        if !indexedDesktop {
+            indexEntries.removeAll { $0["sessionId"] as? String == desktopId }
+        }
+        try fixture.writeIndex(indexEntries, in: project)
         for sessionId in [desktopId, cliId, archivedId] {
             try fixture.writeTranscript(
                 [fixture.message(sessionId, sessionId)],
@@ -198,6 +203,9 @@ struct MacNodeClaudeSessionCatalogTests {
                 "isArchived": true,
             ],
             to: fixture.desktopMetadata("local_archived"))
+        try fixture.writeJSON(
+            ["cliSessionId": "missing-session", "title": "Stale Desktop metadata", "isArchived": false],
+            to: fixture.desktopMetadata("local_missing"))
 
         let first = try #require(try fixture.list(paramsJSON: #"{"limit":1}"#))
         let firstSessions = try #require(first["sessions"] as? [[String: Any]])
@@ -276,6 +284,7 @@ struct MacNodeClaudeSessionCatalogTests {
             ("local_sidechain", sidechainId, "Desktop sidechain"),
             ("local_cli_sidechain", cliSidechainId, "Interactive Desktop sidechain"),
             ("local_discovered_sidechain", discoveredSidechainId, "Headless Desktop sidechain"),
+            ("local_escaped", escapedId, "Escaped Desktop session"),
         ] {
             try fixture.writeJSON(
                 ["cliSessionId": sessionId, "title": title, "isArchived": false],

--- a/extensions/anthropic/session-catalog-listing.ts
+++ b/extensions/anthropic/session-catalog-listing.ts
@@ -50,7 +50,7 @@ const MAX_TRANSCRIPT_PAGE_BYTES = 20 * 1024 * 1024;
 const NODE_INVOKE_TIMEOUT_MS = 30_000;
 // Catalog refresh is fail-soft: one unhealthy machine must not hold the whole sidebar.
 // The node invoke keeps running so cold native discovery can warm the next poll.
-const NODE_CATALOG_LIST_RESPONSE_TIMEOUT_MS = 8_000;
+const NODE_CATALOG_LIST_RESPONSE_TIMEOUT_MS = 20_000;
 const CLAUDE_HISTORY_IMPORT_MAX_ITEMS = 200;
 const CLAUDE_HISTORY_IMPORT_MAX_BYTES = 512 * 1024;
 

--- a/extensions/anthropic/session-catalog.test.ts
+++ b/extensions/anthropic/session-catalog.test.ts
@@ -2800,7 +2800,7 @@ describe("Claude session catalog", () => {
       } as unknown as PluginRuntime);
       const pending = provider.list({ hostIds: ["node:slow-node"] });
 
-      await vi.advanceTimersByTimeAsync(8_000);
+      await vi.advanceTimersByTimeAsync(20_000);
 
       await expect(pending).resolves.toEqual([
         expect.objectContaining({
@@ -2816,7 +2816,18 @@ describe("Claude session catalog", () => {
     }
   });
 
-  it("publishes a paired-node page that finishes after the fail-soft response", async () => {
+  it.each([
+    {
+      name: "returns cold paired-node discovery before the fail-soft response",
+      delayMs: 10_000,
+      timedOut: false,
+    },
+    {
+      name: "publishes a paired-node page that finishes after the fail-soft response",
+      delayMs: 20_000,
+      timedOut: true,
+    },
+  ])("$name", async ({ delayMs, timedOut }) => {
     vi.useFakeTimers();
     try {
       let resolveInvoke!: (value: unknown) => void;
@@ -2842,10 +2853,14 @@ describe("Claude session catalog", () => {
       const onHost = vi.fn();
       const pending = provider.list({ hostIds: ["node:slow-node"], onHost });
 
-      await vi.advanceTimersByTimeAsync(8_000);
-      await expect(pending).resolves.toEqual([
-        expect.objectContaining({ error: expect.objectContaining({ code: "NODE_INVOKE_FAILED" }) }),
-      ]);
+      await vi.advanceTimersByTimeAsync(delayMs);
+      if (timedOut) {
+        await expect(pending).resolves.toEqual([
+          expect.objectContaining({
+            error: expect.objectContaining({ code: "NODE_INVOKE_FAILED" }),
+          }),
+        ]);
+      }
       expect(onHost).not.toHaveBeenCalled();
 
       resolveInvoke({
@@ -2863,6 +2878,14 @@ describe("Claude session catalog", () => {
       });
       await vi.advanceTimersByTimeAsync(0);
 
+      if (!timedOut) {
+        await expect(pending).resolves.toEqual([
+          expect.objectContaining({
+            hostId: "node:slow-node",
+            sessions: [expect.objectContaining({ threadId: "late-thread" })],
+          }),
+        ]);
+      }
       expect(onHost).toHaveBeenCalledWith(
         expect.objectContaining({
           hostId: "node:slow-node",


### PR DESCRIPTION
Closes #131236 (paired-Mac Claude discovery repeatedly scans missing Desktop transcripts and misses the sidebar deadline).

<details>
<summary>Additional instructions</summary>

Maintainers can edit this repository-owned branch.

</details>

## What Problem This Solves

Fixes an issue where users browsing Claude Code sessions on a paired Mac would see a failed discovery warning when cold scans or stale Claude Desktop metadata pushed the listing beyond the sidebar's 8-second response deadline. Observed successful native listings took 10.1s and 7.5s; this is session discovery, not a Claude model failure.

## Why This Change Was Made

Reuse one per-refresh project-directory inventory for index loading, CLI discovery, and Desktop transcript matching. This removes the repeated filesystem walk for every missing Desktop transcript, while keeping path validation, archive/sidechain filtering, metadata budgets, and the existing cache. Metadata file handles now also close when scanning throws or is cancelled.

Extend the Anthropic paired-node list response deadline from 8s to 20s; the underlying node invocation remains bounded at 30s. No new configuration, protocol, dependency, or persistent-store surface.

## User Impact

Claude catalogs load faster on Macs, especially when Desktop metadata outlives its transcript. Healthy cold listings get more time to finish. Hung hosts still produce a bounded failure, and healthy hosts can publish progress independently.

This does not deploy or restart any running app/Gateway. The macOS app and Gateway must receive the updated code through their normal update path.

## Evidence

AI-assisted; implementation and evidence personally reviewed.

- Regression: existing provider fixture extended with a 10s successful node response. It fails against the original 8s production deadline; passes with 20s. Hung-node and post-deadline provider-callback cases remain covered.
- `node scripts/run-vitest.mjs extensions/anthropic/session-catalog.test.ts`: **58/58 passed**, refreshed before publication.
- `swift test --package-path apps/macos --build-system native --filter MacNodeClaudeSessionCatalogTests`: **9 tests / 10 cases passed**, refreshed before publication. Covers indexed and Desktop-only records, stale metadata, archives, sidechains, symlink escapes, permission revocation, replacement, and transcript pagination.
- Exact-source paired release benchmark, real local catalog: **1.144s cold / 0.404s, 0.289s warm before**, **0.327s cold / 0.123s, 0.097s warm after**; all response hashes identical, 11 sessions.
- Stale-Desktop fixture: 300 projects, 200 missing targets, one valid Desktop-only transcript. Paired benchmark **8.208s, 9.883s, 5.188s before** versus **0.038s, 0.019s, 0.016s after**, identical full-response hashes. Publication refresh: baseline **9.399s, 6.973s, 6.935s**, candidate **0.127s, 0.033s, 0.024s**; same response hash. Timing varies with host load. Candidate benchmark source matches repository source byte-for-byte.
- Fresh mandatory autoreview: clean at the helper's default P0 threshold. Manual owner/caller/sibling review additionally verified retained filtering and path checks. Sibling TypeScript discovery already consumes a shared project snapshot.
- Prior changed-surface formatting, plugin typechecks/lint, pinned SwiftLint 0.65.0, native-schema and repository architecture guards passed. No formatting/type/lint suppression was added. `git diff --check` passes. The publication rebase did not change any of the four reviewed file contents.
- Production **+27/-28 (net -1)**; tests **+78/-36 (net +42)**. Removed the per-Desktop-record `locateSessionFile` path. No new test-only production seam.

### Proof limitations and follow-ups

- No paired-node candidate deployment or before/after sidebar recording: the target Mac's remote shell required node approval, and replacing/restarting the operator's live app/Gateway was not authorized. Integrated app tests and the exact production scanner against real local data are the completed proof; they are not claimed as a deployed end-to-end UI run.
- Broader `pnpm test:macos:ci` previously passed 256 tooling/packaging cases; its full result was 406 passed / 83 failed. All failures were in unchanged `src/daemon/launchd.test.ts`, whose fixtures inherit the parent Gateway's LaunchAgent identity. The production safety guard correctly refuses simulated in-band service mutations. Named follow-up: fix fixture environment ownership without disabling that guard. This PR does not claim an all-green local full suite; hosted exact-head CI remains a landing gate.
- Late catalog progress subscription lifetime: the provider's post-deadline callback is tested, but `src/gateway/server-methods/session-catalog.ts` clears subscribers when the final RPC settles. End-to-end automatic refresh after 20s remains separate work.
- Misleading discovery configuration advice remains unchanged in the sidebar renderer.
- Related: #127743 (expired Gateway catalog cache blocks foreground refresh) and #126604 (bound Anthropic catalog JSON reads); neither is closed or claimed fixed here.

### Provenance

Repeated native Desktop lookup introduced by #104528 (Claude session fleet), commit c3b426f280a92bfe9db0701b61cf75461755bab7, July 11, 2026. The 8s deadline came from #110106 (bound slow-node sidebar delay), commit 67a5ffab778a65cae14d92fb09848bd7cb77e32e, July 17, 2026. Both authored and merged by @steipete. Current main still contains both paths. Local containing tags were beta-only; this is not asserted to be a stable-release regression.


### Landing CI repairs

The first exact-head CI run, [33123947689](https://github.com/openclaw/openclaw/actions/runs/33123947689), passed all lanes except one of 1,837 macOS tests: Cron recovery observed `.starting` instead of `.stopped` on the shared Gateway manager. Direct manager unit tests were mutating the app singleton outside the isolation lock used by recovery integration tests. `GatewayProcessManagerTests` now owns a manager per test; integration fixtures keep the real shared recovery route, and launch-agent/config globals keep their existing isolation. No assertion was weakened. [Swift Testing's suite-instance contract](https://developer.apple.com/documentation/testing/organizingtests) gives each test method a distinct suite instance.

That isolation exposed a real competing-deadline bug: the delayed-startup readiness test failed four existing assertions when the inner RPC timer returned generic `Gateway` error 5 before the wall-clock owner could produce `GatewayHealthProbeTimeout`. `probeGatewayHealth` now uses the existing `timeoutMs: 0` RPC contract, leaving its unchanged bounded outer deadline as the only timer. Cancellation still removes the pending request through `GatewayChannelActor`'s cancellation handler. No larger readiness deadline, new error matching, or retry was added. The competing timers originated in #108764 (fresh local startup hardening), commit 167a8ef20a2a60594cd3fae1e96e3e95ffad9e4c, authored and merged by @steipete on July 17.

Validation after both repairs:

- `swift test --package-path apps/macos --build-system native --filter 'CronJobsStoreTests|GatewayProcessManagerTests|GatewayConnectionControlTests|MacNodeClaudeSessionCatalogTests|AsyncTimeoutTests'`: **98 tests / 6 suites passed**. The delayed-startup case failed before the deadline-owner repair and passes afterward. Its socket is explicitly established with one status request before the short readiness budget, so the assertion counts exactly one health request (three total sends including handshake and warmup) without depending on cold-handshake scheduling.
- Pinned repository `scripts/lint-swift.sh macos`, scoped SwiftFormat using `config/swiftformat`, and `git diff --check`: passed.
- Fresh autoreview of both additional repairs: clean at default P0 threshold. The final delayed-authorization case also passed five bounded repeat runs (about 0.24–0.27s each).
- Local unfiltered baseline also exposed unrelated `GatewayEnvironmentTests` ambient-port and `MacNodeCodexThreadCatalogTests` fixture-timing failures, which were not present in the hosted CI run. They are recorded as follow-ups, not treated as a green full-local-suite result.

The live-deployment/video limitation above also applies to the readiness correction: no operator app or Gateway was replaced or restarted. Existing native boundary tests exercise the startup, cancellation, and repair outcomes; exact-head hosted CI is required again for the updated patch.


Final full-local-sweep note: `swift test --package-path apps/macos --build-system native --skip-build` after the repair passed the original superseded-history assertion and `GatewayProcessManagerTests`, but the overall local sweep remained red on ambient-port and unrelated fixture-scheduling failures (GatewayEnvironment, onboarding method-order, CUA restart, Codex process fixture deadlines, and a Cron fixture request-arrival wait). These are not claimed fixed or used as green proof. The targeted 98-test set and five exact-case repeats pass; fresh hosted CI owns the full native landing gate.


### Final hosted verification

[Exact-head CI run 33125194925](https://github.com/openclaw/openclaw/actions/runs/33125194925) completed **successfully** for `a8896cbc91ad078a528dae4f7ca7abf7f4247340`; required `openclaw/ci-gate` is green. The macOS lane passed release build, Swift lint, **1,470 OpenClawKit tests**, and **1,837 app tests**, including the original Cron shared-manager assertion and all readiness tests. Local full-sweep limitations above remain recorded accurately; hosted clean-machine proof is green.
