### PR TITLE
fix(wizard): require literal true for confirmation

### DIFF
--- a/src/gateway/gateway-wizard.e2e.test.ts
+++ b/src/gateway/gateway-wizard.e2e.test.ts
@@ -22,6 +22,51 @@ describe("gateway wizard e2e", () => {
   beforeEach(resetGatewayTestState);
   afterEach(resetGatewayTestState);
 
+  it(
+    "requires boolean consent through wizard.next",
+    { timeout: GATEWAY_E2E_TIMEOUT_MS },
+    async () => {
+      const { envSnapshot, tempHome } = await setupGatewayTempHome({
+        prefix: "openclaw-wizard-consent-home-",
+        minimalGateway: true,
+      });
+      const token = nextGatewayId("wizard-consent");
+      const port = await getGatewayE2ePortBlock();
+      const confirmations: boolean[] = [];
+      const server = await startGatewayServer(port, {
+        bind: "loopback",
+        auth: { mode: "token", token },
+        controlUiEnabled: false,
+        wizardRunner: async (_opts, _runtime, prompter) => {
+          confirmations.push(await prompter.confirm({ message: "Continue?", initialValue: false }));
+        },
+      });
+      const client = await connectGatewayClient({ url: `ws://127.0.0.1:${port}`, token });
+
+      try {
+        for (const { value, expected } of [
+          { value: "false", expected: false },
+          { value: false, expected: false },
+          { value: true, expected: true },
+        ]) {
+          const start = await client.request<WizardStartResult>("wizard.start", { mode: "local" });
+          expect(start.step).toMatchObject({ type: "confirm", initialValue: false });
+          const result = await client.request<WizardNextResult>("wizard.next", {
+            sessionId: start.sessionId,
+            answer: { stepId: start.step?.id, value },
+          });
+          expect(result).toMatchObject({ done: true, status: "done" });
+          expect(confirmations.at(-1)).toBe(expected);
+        }
+      } finally {
+        await disconnectGatewayClient(client);
+        await server.close({ reason: "wizard consent E2E complete" });
+        await removeGatewayTempHome(tempHome);
+        envSnapshot.restore();
+      }
+    },
+  );
+
   it("contains hosted wizard exits", { timeout: GATEWAY_E2E_TIMEOUT_MS }, async () => {
     const { envSnapshot, tempHome } = await setupGatewayTempHome({
       prefix: "openclaw-wizard-contained-exit-home-",

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -13,6 +13,23 @@ function noteRunner() {
 }
 
 describe("WizardSession", () => {
+  test.each([true, false, "true", "false", 1, {}, null, undefined])(
+    "only literal true confirms a wire answer (%j)",
+    async (answer) => {
+      let confirmed: boolean | undefined;
+      const session = new WizardSession(async (prompter) => {
+        confirmed = await prompter.confirm({ message: "Continue?", initialValue: false });
+      });
+      const step = (await session.next()).step;
+      if (!step) {
+        throw new Error("expected confirmation step");
+      }
+      await session.answer(step.id, answer);
+      await session.whenSettled();
+      expect(confirmed).toBe(answer === true);
+    },
+  );
+
   test.each([
     ["select", undefined, true],
     ["multiselect", undefined, true],

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -217,7 +217,8 @@ class WizardSessionPrompter implements WizardPrompter {
       initialValue: params.initialValue,
       executor: "client",
     });
-    return Boolean(res);
+    // Answers cross the wire as unknown values; truthy strings are not consent.
+    return res === true;
   }
 
   progress(label: string): WizardProgress {


### PR DESCRIPTION
Closes #131225 — wizard confirmation treats a string `"false"` as affirmative.
Related: #130713 — guided cloud-session setup; this is an independent generic repair extracted from that work.

<details>
<summary>Additional instructions</summary>

AI-assisted maintainer repair. This same-repository branch remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where a client answering a wizard confirmation with the string `"false"` would select the affirmative branch. JavaScript truthiness also accepted `"true"`, `1`, and `{}` instead of requiring a boolean confirmation.

## Why This Change Was Made

Normalize the answer once at `WizardSessionPrompter.confirm`: only literal `true` is affirmative. The generic wizard answer schema must remain capable of carrying values for other step types; adding per-caller guards or tightening every wizard answer to boolean would be the wrong boundary.

## User Impact

Malformed or incorrectly typed confirmation answers are no longer treated as consent. Normal Control UI buttons already emit boolean `false`/`true`, and the local CLI confirmation contract is boolean-valued, so their normal behavior is unchanged. Authentication, authorization, setup ownership, cancellation, and persistence are untouched.

## Evidence

On unmodified main production at `cbdb7768cedf39976d05abe24aa1a1b578474641`, the focused session test failed for exactly four truthy non-boolean values (`"true"`, `"false"`, `1`, `{}`); the other 28 cases passed. The new token-authenticated loopback-Gateway E2E case separately failed for `wizard.next` carrying `"false"`, proving the value reaches the real session owner through the wire path.

After the repair, **84 tests across seven files passed** in three serial shards: 21 Gateway owner/tracker tests, 59 wizard/CLI tests, and four actual loopback-Gateway E2E tests. The new E2E case checks string `"false"`, boolean `false`, and boolean `true`, including ordinary terminal settlement. Existing setup/channel routing, hosted exits, cancellation, and replacement ownership remain covered. The E2E harness rebuilt stale TypeScript/bundled runtime output from the changed source; it did not reuse the pre-fix binary.

```bash
node scripts/run-vitest.mjs src/wizard/session.test.ts src/wizard/clack-prompter.test.ts src/wizard/clack-prompter.process.test.ts src/gateway/server-methods/wizard.test.ts src/gateway/server-wizard-sessions.test.ts src/gateway/gateway-wizard.e2e.test.ts src/gateway/gateway-wizard-cancel.e2e.test.ts
```

```bash
node scripts/check-changed.mjs -- src/wizard/session.ts src/wizard/session.test.ts src/gateway/gateway-wizard.e2e.test.ts
```

The complete three-file changed gate passed, including canonical core types, all 14 core-test typecheck shards, targeted lint/format, and the selected architecture/ownership guards. No guard, budget, timeout, or assertion was weakened.

Fresh isolated Codex review completed at the required P0-only threshold with no actionable findings. No external provider, model inference, cloud allocation, or operator Gateway/state was used. This is actual Gateway protocol proof with a fixture wizard runner, not a claim of hosted-provider acceptance. There is no visual change: the ordinary UI cannot emit the malformed values being fixed, so protocol red/green evidence—not an unrelated screenshot—covers the changed path.

**Production LOC:** +2/-1 (net +1, including the invariant comment). **Tests:** +62/-0. No dependency, configuration, schema, SDK, or generated-file change.

Provenance: present on the tested main snapshot; the local repository is shallow and blame terminates at a history boundary, so the exact introducing PR is unknown. This is reported as a behavior bug, not an attributed regression.
