### PR TITLE
fix(ui): align plugin hub header and tabs with content

### DIFF
--- a/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
+++ b/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
@@ -220,16 +220,26 @@ suite.define(() => {
         const installed = await hubGeometry(page);
         expect(installed.title).toBe("Plugins");
         expect(installed.titleVisible).toBe(true);
+        const layout = await page.evaluate(() => {
+          const title = document.querySelector<HTMLElement>(".hub-page-header__title");
+          const tabs = document.querySelector<HTMLElement>(".plugins-hub-tabs");
+          const content = document.querySelector<HTMLElement>("#plugins-global-search");
+          if (!title || !tabs || !content) {
+            throw new Error("Plugins hub layout did not render");
+          }
+          return {
+            aboveTabs: tabs.getBoundingClientRect().top - title.getBoundingClientRect().bottom,
+            belowTabs: content.getBoundingClientRect().top - tabs.getBoundingClientRect().bottom,
+            contentLeft: content.getBoundingClientRect().left,
+            tabsLeft: tabs.getBoundingClientRect().left,
+            titleLeft: title.getBoundingClientRect().left,
+          };
+        });
+        expect(Math.abs(layout.tabsLeft - layout.titleLeft)).toBeLessThanOrEqual(1);
+        expect(layout.aboveTabs).toBeGreaterThan(0);
+        expect(Math.abs(layout.aboveTabs - layout.belowTabs)).toBeLessThanOrEqual(1);
         if (label === "desktop") {
-          const [headerLeft, contentLeft] = await Promise.all([
-            page
-              .locator(".hub-page-header__title")
-              .evaluate((element) => element.getBoundingClientRect().left),
-            page
-              .getByRole("searchbox", { name: "Search plugins" })
-              .evaluate((element) => element.getBoundingClientRect().left),
-          ]);
-          expect(Math.abs(headerLeft - contentLeft)).toBeLessThanOrEqual(1);
+          expect(Math.abs(layout.tabsLeft - layout.contentLeft)).toBeLessThanOrEqual(1);
         }
         await captureScreenshot(page, `${label}-01-installed.png`);
 

--- a/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
+++ b/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
@@ -220,6 +220,17 @@ suite.define(() => {
         const installed = await hubGeometry(page);
         expect(installed.title).toBe("Plugins");
         expect(installed.titleVisible).toBe(true);
+        if (label === "desktop") {
+          const [headerLeft, contentLeft] = await Promise.all([
+            page
+              .locator(".hub-page-header__title")
+              .evaluate((element) => element.getBoundingClientRect().left),
+            page
+              .getByRole("searchbox", { name: "Search plugins" })
+              .evaluate((element) => element.getBoundingClientRect().left),
+          ]);
+          expect(Math.abs(headerLeft - contentLeft)).toBeLessThanOrEqual(1);
+        }
         await captureScreenshot(page, `${label}-01-installed.png`);
 
         await selectHubTab(page, "Discover", {

--- a/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
+++ b/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
@@ -237,7 +237,8 @@ suite.define(() => {
         });
         expect(Math.abs(layout.tabsLeft - layout.titleLeft)).toBeLessThanOrEqual(1);
         expect(layout.aboveTabs).toBeGreaterThan(0);
-        expect(Math.abs(layout.aboveTabs - layout.belowTabs)).toBeLessThanOrEqual(1);
+        expect(layout.belowTabs - layout.aboveTabs).toBeGreaterThanOrEqual(7);
+        expect(layout.belowTabs - layout.aboveTabs).toBeLessThanOrEqual(9);
         if (label === "desktop") {
           expect(Math.abs(layout.tabsLeft - layout.contentLeft)).toBeLessThanOrEqual(1);
         }

--- a/ui/src/pages/plugins/plugins-hub-header.ts
+++ b/ui/src/pages/plugins/plugins-hub-header.ts
@@ -23,7 +23,6 @@ export function renderPluginsHubHeader(props: PluginsHubHeaderProps): TemplateRe
       <div class="hub-page-header__tabs">
         ${renderPluginsHubTabs({ active: props.active, onSelect: props.onSelect })}
       </div>
-      <div class="hub-page-header__actions"></div>
     </section>
   `;
 }

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -6,6 +6,28 @@
   margin: 0;
 }
 
+.content-header.hub-page-header.plugins-hub-header {
+  width: 100%;
+  max-width: 1120px;
+  margin-inline: auto;
+  padding-inline: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-5);
+  max-height: none;
+}
+
+.plugins-hub-header + .settings-workspace {
+  margin-top: 0;
+}
+
+@media (max-width: 400px) {
+  .content-header.hub-page-header.plugins-hub-header {
+    gap: var(--space-4);
+  }
+}
+
 /* ---------- toolbar ---------- */
 
 .plugins-toolbar {

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -19,7 +19,7 @@
 }
 
 .plugins-hub-header + .settings-workspace {
-  margin-top: 0;
+  margin-top: var(--space-2);
 }
 
 @media (max-width: 400px) {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -45,16 +45,15 @@
   flex-direction: column;
 }
 
-/* The page headline adopts the column of the page below it; without this
-   top-level hubs and the settings shell can leave the title floating left of
-   the content. */
-.content:has(.settings-page) .content-header {
+/* The page headline adopts the column of the page below it; without this the
+   shell caps headers at 1120px while narrow pages use a 760px column, leaving
+   the title floating left of the content. */
+.shell--settings .content:has(.settings-page) .content-header {
   max-width: 760px;
-  margin-inline: auto;
   padding-inline: var(--space-4);
 }
 
-.content:has(.settings-page--wide) .content-header {
+.shell--settings .content:has(.settings-page--wide) .content-header {
   max-width: 1120px;
 }
 

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -45,15 +45,16 @@
   flex-direction: column;
 }
 
-/* The page headline adopts the column of the page below it; without this the
-   shell caps headers at 1120px while narrow pages use a 760px column, leaving
-   the title floating left of the content. */
-.shell--settings .content:has(.settings-page) .content-header {
+/* The page headline adopts the column of the page below it; without this
+   top-level hubs and the settings shell can leave the title floating left of
+   the content. */
+.content:has(.settings-page) .content-header {
   max-width: 760px;
+  margin-inline: auto;
   padding-inline: var(--space-4);
 }
 
-.shell--settings .content:has(.settings-page--wide) .content-header {
+.content:has(.settings-page--wide) .content-header {
   max-width: 1120px;
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Plugins hub header was visibly wider than its 1120px content column on latest `main`. At a 1440px viewport, the title began 19px left of the plugin search and the tabs floated in the header's middle column.

## Why This Change Was Made

The Plugins hub now owns its stable 1120px header column across Installed, Discover, Skills, and Workshop. Its tabs are stacked below the title instead of relying on the shared three-column hub layout, and the empty actions slot is removed. This keeps the header geometry independent of whichever hub panel is mounted.

## User Impact

The Plugins title, tabs, search, filters, and plugin list now share one left edge. The tabs have an additional 8px of breathing room before the search controls below.

## Evidence

- Reproduced on untouched `main` at `dd2add04682d49b0ea7ba36e0ea483c1a19248b5`: Playwright measured header `x=286` and content `x=305`.
- Added route-level Playwright coverage for stacked placement, the larger gap below the tabs, content alignment, and stable geometry through all four hub transitions.
- Responsive Playwright checks: 390×844, 768×1024, 1366×768, and 1440×900; no horizontal overflow. The space below the tabs is 8px larger than the space above across all four sizes.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/plugins-hub-navigation.e2e.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/pages/plugins/plugins.e2e.test.ts`
- `pnpm check:changed`
- `node --import tsx scripts/run-stylelint.mts ui/src/styles/plugins.css`
- `pnpm ui:build`

[Before/after Playwright screenshots](https://github.com/openclaw/openclaw/pull/131239#issuecomment-5446135077) are attached in the PR discussion.
