### PR TITLE
fix(install): preserve Unicode in macOS JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Control UI Gateway labels:** keep the discovered machine name through recovery initialization and refresh open folder-browser labels when name discovery finishes.
-- **Installer JSON output:** preserve accented, CJK, and emoji text in NDJSON paths and errors when using macOS's built-in Bash.
 - **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
 - **Nextcloud Talk diagnostics:** redact reflected credentials before displaying send, reaction, and bot-preflight errors, and suppress incomplete error bodies. (#119976) Thanks @xialonglee.
 - **Control UI config drafts:** preserve external changes and newer Form or Raw edits across reconnects, including saves whose acknowledgments were lost, by keeping the draft's original document and write revision together.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Control UI Gateway labels:** keep the discovered machine name through recovery initialization and refresh open folder-browser labels when name discovery finishes.
+- **Installer JSON output:** preserve accented, CJK, and emoji text in NDJSON paths and errors when using macOS's built-in Bash.
 - **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
 - **Nextcloud Talk diagnostics:** redact reflected credentials before displaying send, reaction, and bot-preflight errors, and suppress incomplete error bodies. (#119976) Thanks @xialonglee.
 - **Control UI config drafts:** preserve external changes and newer Form or Raw edits across reconnects, including saves whose acknowledgments were lost, by keeping the draft's original document and write revision together.

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -201,7 +201,8 @@ quote_json_string() {
       \\) JSON_STRING+="\\\\" ;;
       *)
         printf -v code '%d' "'$char"
-        if ((code < 32)); then
+        # Bash 3.2 reports high UTF-8 bytes as negative integers, not C0 controls.
+        if ((code >= 0 && code < 32)); then
           printf -v escaped '\\u%04x' "$code"
           JSON_STRING+="$escaped"
         else

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -209,7 +209,7 @@ describe("install-cli.sh", () => {
 
   it("round-trips dynamic installer values through independent NDJSON records", () => {
     const root = tempDirs.make("openclaw-install-cli-json-events-");
-    const dynamicValue = `quote"\\lobster🦞${String.fromCharCode(
+    const dynamicValue = `quote"\\café项目lobster🦞${String.fromCharCode(
       ...Array.from({ length: 31 }, (_, index) => index + 1),
     )}end`;
     const repo = join(root, dynamicValue);


### PR DESCRIPTION
Related: #128682

## What Problem This Solves

Fixes an issue where operators using `install-cli.sh --json` on macOS would receive corrupted Unicode paths and error messages when running the built-in Bash 3.2. The output still parses as JSON, but accented, CJK, and emoji text no longer matches the original value.

## Why This Change Was Made

Keep the existing bootstrap-safe serializer and classify C0 controls using their exact nonnegative range. Bash 3.2 can report high UTF-8 bytes as negative integers; the previous upper-bound-only check escaped those bytes as overlong hexadecimal values instead of preserving them.

The repair stays at the single emission owner. It adds no dependency, fallback, runtime requirement, configuration, or alternate encoding path. Existing event names, order, exit status, non-JSON behavior, and the terminal `done.ok: true` boolean remain unchanged.

Provenance: introduced by #128682, authored by xingzhou (@zhangguiping-xydt), merged by @steipete on 2026-08-26 as [ee2f5f2084d4](https://github.com/openclaw/openclaw/commit/ee2f5f2084d4bdf314ba8a258b5457410098b148). This preserves that PR's centralized serializer and fixes its platform-specific byte classification.

## User Impact

The [documented NDJSON interface](https://docs.openclaw.ai/install/installer) preserves Unicode values on macOS without asking operators to install a different shell. Quotes, backslashes, and control characters remain safely escaped into independent records.

## Evidence

On the unchanged base `79dfa81664fd64a3f6192331af4953ff9f9bf1ef`, the complete installer test file reproduced the exact corruption: **69 passed, 1 failed**. After the repair, the same command passed **70/70**, with the existing real-Bash/filesystem regression strengthened to include accented and CJK text alongside emoji and every representable C0 control byte:

```bash
OPENCLAW_TEST_PROJECTS_PARALLEL=4 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test test/scripts/install-cli.test.ts
```

Independent pure-serialization probes ran identical success, error, argument-error, dynamic event/key/value, path, and terminal-boolean cases through `/bin/bash` 3.2.57 and Bash 5.3.15. They extract only the serializer/logger/error/argument-parser functions and do not start installation.

```text
Lobster UTF-8 byte values:
  Bash 3.2: -16, -97, -90, -98
  Bash 5.3: 240, 159, 166, 158
Before: 6 failures / 24 checks, all non-ASCII Bash 3.2 cases
After:  0 failures / 24 checks across both shells
```

Inputs include empty and ASCII strings, quotes, backslashes, accented/CJK/emoji text, C0 bytes 1–31, DEL, U+0085, and U+2028/U+2029. Bash strings cannot represent NUL. Direct inspection of [Apple's Bash `printf` source](https://github.com/apple-oss-distributions/bash/blob/main/bash-3.2/builtins/printf.def) confirms the signed-character conversion in `asciicode`.

- Complete changed-file gate: **13/13 stages passed**, including root test typecheck and full script lint.
- Syntax checks under both Bash versions, ShellCheck with the workflow's `-e SC1091`, and `git diff --check`: passed.
- Read-only retrieval of the currently hosted installer matched the defective base byte-for-byte: SHA-256 `c15d7112f1d80b3b45f83dbd77f7efbee4098c5d5f4e1578060f6a40d70c70d0`.
- Independent Codex review returned no findings in its P0-focused pass.

Production/tooling LOC: **+2/-1**, with the net added line being the dependency comment; executable production LOC is net zero. Tests: **+1/-1**. The final diff contains only the installer and its existing regression test.

Release-note context: installer NDJSON paths and errors now preserve accented, CJK, and emoji text with macOS's built-in Bash. `CHANGELOG.md` is release-owned; this PR carries the behavior, affected surface, and credited introduction above for release generation instead of editing that file.

The necessary changelog-conflict refresh rebased the patch onto `36fdc40c72e251eb54140f65030a2407a35e853c`. Both installer and test blobs are unchanged from the independently reviewed commit. Head `207756dbb6407ee5d1e8aec7fb409f31e2073d51` again passed **70/70** installer tests and **24/24** cross-Bash checks, plus both syntax checks and ShellCheck. Removing only this PR's changelog bullet afterward leaves those runtime and test bytes unchanged; all existing main changelog entries are preserved.

The canonical script is copied into `openclaw.ai` by the existing Website Installer Sync workflow; no manual website edit or deployment is included. The introduction's [sync run](https://github.com/openclaw/openclaw/actions/runs/32957687676) completed its actual website commit/push step.

Named follow-up: add native macOS NDJSON coverage to installer verification. The current macOS installer lane exercises `install.sh`, while the CLI Docker smoke uses an ASCII prefix without `--json`. No CI workflow change is bundled here. These proofs cover the serialization boundary, not a full package download/install or release-validation run.
