### PR TITLE
fix(memory): forgotten facts survive in consolidation history

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -156,7 +156,7 @@ and remain selected.
 | `untargetableEntryKeys`            | Promotion markers found without origin rows in this agent's store. This does not enumerate unmarked prose.                                           |
 | `curatedWrites`                    | Files to review, with `relativePath` and `observedAt` (Unix milliseconds). Includes supported recorded write attempts, which may not have succeeded. |
 | `artifacts`                        | Counts of matching files, entries, lines, and store rows described below.                                                                            |
-| `refusals`                         | Reserved report list; currently empty. An empty list does not establish complete deletion coverage.                                                  |
+| `refusals`                         | Historical consolidation highlights needing manual review. An empty list does not establish complete deletion coverage.                              |
 
 Preview and apply use the same matching logic, but each reads current state;
 a preview is not an immutable plan or a lock on subsequent writes. Apply
@@ -188,7 +188,10 @@ backups, rather than deleting every backup.
 
 Consolidation preserves origins for replaced promotion markers while retained
 rewrite preimages reference them. Those origins are pruned only after live
-entries, retained preimages, and indexed snapshots stop referencing the keys.
+entries, retained preimages, diary excerpts, and indexed snapshots stop referencing the keys.
+New consolidation-history excerpts carry the replacement entry's lineage and
+are removed with it. Their origins remain while the excerpts remain, even
+after backup rotation; diary history has no automatic expiry.
 In a shared workspace, a later purge for another agent also checks its indexed
 snapshots, even when the first purge already removed the shared file content.
 

--- a/docs/concepts/memory-provenance.md
+++ b/docs/concepts/memory-provenance.md
@@ -87,7 +87,12 @@ share a workspace; the model does not own the origin rows.
 
 Origins for replaced entries remain while retained rewrite preimages still
 reference their promotion markers. Backup rotation prunes those origins only
-when live entries, retained preimages, and indexed snapshots no longer reference them.
+when live entries, retained preimages, diary excerpts, and indexed snapshots no longer reference them.
+
+New consolidation-history excerpts retain the replacement entry's lineage,
+including its merged or superseded parents. Their origin rows remain while
+those excerpts remain, even after backup rotation. Diary history has no
+automatic expiry; long revision histories can retain growing origin sets.
 
 When backfill coalesces the same claim from several sessions, it retains every
 source origin without counting the repeated claim as extra evidence.
@@ -200,7 +205,11 @@ reason `forgotten`.
 The memory plugin coordinates purges with its staging and file mutations.
 A pending dream narrative is skipped if its tracked source entries or prior
 diary context were removed before publication. This does not retroactively
-identify untracked paraphrases in older diary entries.
+identify untracked paraphrases in older diary entries. Historical consolidation
+highlights with quoted markers also lack reliable deletion boundaries. The
+report warns in `refusals` when it recognizes remaining highlights in that
+format; review them manually. The warning is not an inventory of all untracked
+history, and missing historical lineage is not reconstructed.
 
 Indexing checks again before publishing chunks or cached embeddings, so a
 result prepared before the purge cannot restore forgotten session data or a

--- a/extensions/memory-core/src/dreaming-consolidation-artifacts.ts
+++ b/extensions/memory-core/src/dreaming-consolidation-artifacts.ts
@@ -59,7 +59,8 @@ export async function storeMemoryPreimage(params: {
   const retainedKeys = new Set(entries.flatMap(({ value }) => extractPromotionKeys(value.content)));
   // Rotation releases only expired backup references. The current preimage and
   // staged keys still protect live content if the following MEMORY write fails.
-  pruneMemoryEntryOrigins({
+  await pruneMemoryEntryOrigins({
+    workspaceDir: params.workspaceDir,
     agentIds: params.agentIds,
     entryKeys: current.flatMap(({ value }) => extractPromotionKeys(value.content)),
     retainedEntryKeys: new Set([...retainedKeys, ...params.retainedEntryKeys]),
@@ -79,12 +80,7 @@ export async function appendConsolidationSummary(params: {
     `- Added: ${params.result.added}`,
     `- Merged: ${params.result.merged}`,
     `- Superseded: ${params.result.superseded}`,
-    ...(params.result.highlights.length > 0
-      ? [
-          "- Highlights:",
-          ...params.result.highlights.map((line) => `  - \`${line.replaceAll("`", "'")}\``),
-        ]
-      : []),
+    ...params.result.highlights,
     "",
   ];
   await updateDreamsFile({

--- a/extensions/memory-core/src/dreaming-consolidation.test.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.test.ts
@@ -79,6 +79,32 @@ function createSubagent(output: string, status = "ok", onWait?: () => Promise<vo
   };
 }
 
+async function recordConsolidationRecall(workspaceDir: string) {
+  await recordShortTermRecalls({
+    workspaceDir,
+    query: "tea preference",
+    results: [
+      {
+        path: "memory/2026-07-01.md",
+        startLine: 1,
+        endLine: 1,
+        score: 0.9,
+        snippet: "User prefers green tea.",
+        source: "memory",
+        provenance: candidate("agent").provenance,
+      },
+    ],
+    nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
+  });
+  return rankShortTermPromotionCandidates({
+    workspaceDir,
+    minScore: 0,
+    minRecallCount: 0,
+    minUniqueQueries: 0,
+    nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
+  });
+}
+
 const logger = { info: vi.fn(), warn: vi.fn() };
 
 describe("memory consolidation", () => {
@@ -606,29 +632,7 @@ describe("memory consolidation", () => {
     const notePath = path.join(workspaceDir, "memory", "2026-07-01.md");
     await fs.mkdir(path.dirname(notePath), { recursive: true });
     await fs.writeFile(notePath, "User prefers green tea.\n", "utf8");
-    await recordShortTermRecalls({
-      workspaceDir,
-      query: "tea preference",
-      results: [
-        {
-          path: "memory/2026-07-01.md",
-          startLine: 1,
-          endLine: 1,
-          score: 0.9,
-          snippet: "User prefers green tea.",
-          source: "memory",
-          provenance: candidate("agent").provenance,
-        },
-      ],
-      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
-    });
-    const candidates = await rankShortTermPromotionCandidates({
-      workspaceDir,
-      minScore: 0,
-      minRecallCount: 0,
-      minUniqueQueries: 0,
-      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
-    });
+    const candidates = await recordConsolidationRecall(workspaceDir);
     const subagent = createSubagent("", "error");
     const applied = await applyShortTermPromotions({
       workspaceDir,
@@ -653,29 +657,7 @@ describe("memory consolidation", () => {
     await fs.mkdir(path.dirname(notePath), { recursive: true });
     await fs.writeFile(notePath, "User prefers green tea.\n", "utf8");
     await fs.writeFile(memoryPath, "# Memory\n\n- Original fact.\n", "utf8");
-    await recordShortTermRecalls({
-      workspaceDir,
-      query: "tea preference",
-      results: [
-        {
-          path: "memory/2026-07-01.md",
-          startLine: 1,
-          endLine: 1,
-          score: 0.9,
-          snippet: "User prefers green tea.",
-          source: "memory",
-          provenance: candidate("agent").provenance,
-        },
-      ],
-      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
-    });
-    const candidates = await rankShortTermPromotionCandidates({
-      workspaceDir,
-      minScore: 0,
-      minRecallCount: 0,
-      minUniqueQueries: 0,
-      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
-    });
+    const candidates = await recordConsolidationRecall(workspaceDir);
     const promoted = candidates[0];
     if (!promoted) {
       throw new Error("expected ranked candidate");
@@ -722,29 +704,7 @@ describe("memory consolidation", () => {
     await fs.mkdir(path.dirname(notePath), { recursive: true });
     await fs.writeFile(notePath, "User prefers green tea.\n", "utf8");
     await fs.writeFile(memoryPath, "# Memory\n\n- Original fact.\n", "utf8");
-    await recordShortTermRecalls({
-      workspaceDir,
-      query: "tea preference",
-      results: [
-        {
-          path: "memory/2026-07-01.md",
-          startLine: 1,
-          endLine: 1,
-          score: 0.9,
-          snippet: "User prefers green tea.",
-          source: "memory",
-          provenance: candidate("agent").provenance,
-        },
-      ],
-      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
-    });
-    const candidates = await rankShortTermPromotionCandidates({
-      workspaceDir,
-      minScore: 0,
-      minRecallCount: 0,
-      minUniqueQueries: 0,
-      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
-    });
+    const candidates = await recordConsolidationRecall(workspaceDir);
     const promoted = candidates[0];
     if (!promoted) {
       throw new Error("expected ranked candidate");
@@ -789,29 +749,7 @@ describe("memory consolidation", () => {
     await fs.mkdir(path.dirname(notePath), { recursive: true });
     await fs.writeFile(notePath, "User prefers green tea.\n", "utf8");
     await fs.writeFile(memoryPath, "# Memory\n\n- Original fact.\n", "utf8");
-    await recordShortTermRecalls({
-      workspaceDir,
-      query: "tea preference",
-      results: [
-        {
-          path: "memory/2026-07-01.md",
-          startLine: 1,
-          endLine: 1,
-          score: 0.9,
-          snippet: "User prefers green tea.",
-          source: "memory",
-          provenance: candidate("agent").provenance,
-        },
-      ],
-      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
-    });
-    const candidates = await rankShortTermPromotionCandidates({
-      workspaceDir,
-      minScore: 0,
-      minRecallCount: 0,
-      minUniqueQueries: 0,
-      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
-    });
+    const candidates = await recordConsolidationRecall(workspaceDir);
     const promoted = candidates[0];
     if (!promoted) {
       throw new Error("expected ranked candidate");
@@ -878,29 +816,7 @@ describe("memory consolidation", () => {
     const memoryPath = path.join(workspaceDir, "MEMORY.md");
     await fs.mkdir(path.dirname(notePath), { recursive: true });
     await fs.writeFile(notePath, "User prefers green tea.\n", "utf8");
-    await recordShortTermRecalls({
-      workspaceDir,
-      query: "tea preference",
-      results: [
-        {
-          path: "memory/2026-07-01.md",
-          startLine: 1,
-          endLine: 1,
-          score: 0.9,
-          snippet: "User prefers green tea.",
-          source: "memory",
-          provenance: candidate("agent").provenance,
-        },
-      ],
-      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
-    });
-    const candidates = await rankShortTermPromotionCandidates({
-      workspaceDir,
-      minScore: 0,
-      minRecallCount: 0,
-      minUniqueQueries: 0,
-      nowMs: Date.parse("2026-07-02T10:00:00.000Z"),
-    });
+    const candidates = await recordConsolidationRecall(workspaceDir);
     const promoted = candidates[0];
     if (!promoted) {
       throw new Error("expected ranked candidate");

--- a/extensions/memory-core/src/dreaming-consolidation.test.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.test.ts
@@ -164,6 +164,30 @@ describe("memory consolidation", () => {
     expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps consolidation history bounded and attached to each operation's lineage", () => {
+    const operations = Array.from({ length: 5 }, (_, index) => ({
+      candidateKey: `revision-${index}`,
+      action: "merged" as const,
+      resultEntry: `- Result ${index} ${"🦞".repeat(110)}`,
+      priorEntries: [`- Prior ${index} ${"🦞".repeat(110)}`],
+    }));
+    const existingMemory = operations.flatMap((operation) => operation.priorEntries).join("\n");
+    const result = applyMemoryConsolidationPlan({
+      existingMemory,
+      plan: { memory: "", operations },
+      nowMs: 1_000,
+      maxPriorEntryLossFraction: 1,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.highlights).toHaveLength(8);
+    for (const [index, highlight] of result!.highlights.entries()) {
+      const [marker, entry] = highlight.split("\n");
+      expect(marker).toBe(`<!-- openclaw-memory-promotion:revision-${Math.floor(index / 2)} -->`);
+      expect(entry!.length).toBeLessThanOrEqual(184); // 180 excerpt characters plus the Markdown bullet/quotes.
+      expect(entry).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/u);
+    }
+  });
+
   it("rejects a rewrite that loses too many prior entries", async () => {
     const workspaceDir = await createTempWorkspace("memory-consolidation-reject-");
     const promoted = candidate("owner");

--- a/extensions/memory-core/src/dreaming-consolidation.ts
+++ b/extensions/memory-core/src/dreaming-consolidation.ts
@@ -369,30 +369,6 @@ function validateConsolidatedMemory(params: {
   return null;
 }
 
-function diffHighlights(previous: string, next: string): string[] {
-  const previousLines = new Set(
-    previous
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean),
-  );
-  const nextLines = new Set(
-    next
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean),
-  );
-  const highlights = [
-    ...[...nextLines]
-      .filter((line) => !previousLines.has(line))
-      .map((line) => `+ ${truncateUtf16Safe(line, 180)}`),
-    ...[...previousLines]
-      .filter((line) => !nextLines.has(line))
-      .map((line) => `- ${truncateUtf16Safe(line, 180)}`),
-  ];
-  return highlights.slice(0, 8);
-}
-
 export function applyMemoryConsolidationPlan(params: {
   existingMemory: string;
   plan: MemoryConsolidationPlan;
@@ -492,7 +468,15 @@ export function applyMemoryConsolidationPlan(params: {
     merged: params.plan.operations.filter((operation) => operation.action === "merged").length,
     superseded: params.plan.operations.filter((operation) => operation.action === "superseded")
       .length,
-    highlights: diffHighlights(params.existingMemory, content),
+    // Each excerpt uses its replacement's unioned origins so the ordinary scrubber can erase it.
+    highlights: params.plan.operations
+      .flatMap(({ candidateKey, resultEntry, priorEntries }) =>
+        [`+ ${resultEntry}`, ...priorEntries.map((entry) => `- ${entry}`)].map(
+          (line) =>
+            `${buildPromotionMarker(candidateKey)}\n- \`${truncateUtf16Safe(line, 180).replaceAll("`", "'")}\``,
+        ),
+      )
+      .slice(0, 8),
   };
 }
 

--- a/extensions/memory-core/src/dreaming-dreams-file.ts
+++ b/extensions/memory-core/src/dreaming-dreams-file.ts
@@ -6,7 +6,7 @@ import { replaceManagedMarkdownBlock } from "openclaw/plugin-sdk/memory-host-mar
 import { readRegularFile, replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import { withMemoryWorkspaceLock } from "./memory-workspace-lock.js";
 
-const DREAMS_FILENAMES = ["DREAMS.md", "dreams.md"] as const;
+export const DREAMS_FILENAMES = ["DREAMS.md", "dreams.md"] as const;
 const DEEP_START_MARKER = "<!-- openclaw:dreaming:deep:start -->";
 const DEEP_END_MARKER = "<!-- openclaw:dreaming:deep:end -->";
 

--- a/extensions/memory-core/src/memory-entry-origins.test.ts
+++ b/extensions/memory-core/src/memory-entry-origins.test.ts
@@ -125,7 +125,7 @@ describe("memory entry origins", () => {
     expect(db.prepare("PRAGMA user_version").get()).toEqual(version);
   });
 
-  it("unions every parent session onto a merged entry and removes its retired parent key", () => {
+  it("unions every parent session onto a merged entry and removes its retired parent key", async () => {
     recordMemoryEntryOrigins({
       agentId: "main",
       origins: [origin("prior", "session-1"), origin("candidate", "session-2")],
@@ -145,7 +145,8 @@ describe("memory entry origins", () => {
         },
       ],
     });
-    pruneMemoryEntryOrigins({
+    await pruneMemoryEntryOrigins({
+      workspaceDir: stateDir,
       agentIds: ["main"],
       entryKeys: extractPromotionKeys(previousMemory),
       retainedEntryKeys: new Set(extractPromotionKeys(currentMemory)),
@@ -158,7 +159,7 @@ describe("memory entry origins", () => {
     expect(listMemoryEntryOrigins({ agentId: "main", entryKeys: ["prior"] })).toEqual([]);
   });
 
-  it("re-keys superseded session lineage while preserving unrelated live memory", () => {
+  it("re-keys superseded session lineage while preserving unrelated live memory", async () => {
     recordMemoryEntryOrigins({
       agentId: "main",
       origins: [origin("stale", "session-1"), origin("surviving", "session-3")],
@@ -178,7 +179,8 @@ describe("memory entry origins", () => {
         },
       ],
     });
-    pruneMemoryEntryOrigins({
+    await pruneMemoryEntryOrigins({
+      workspaceDir: stateDir,
       agentIds: ["main"],
       entryKeys: extractPromotionKeys(previousMemory),
       retainedEntryKeys: new Set(extractPromotionKeys(currentMemory)),
@@ -208,52 +210,73 @@ describe("memory entry origins", () => {
     expect(listMemoryEntryOrigins({ agentId: "main" })).toEqual(original);
   });
 
-  it("releases expired backup lineage only after its last retained reference disappears", async () => {
-    const workspaceDir = path.join(stateDir, "workspace");
-    const retainedEntryKeys = new Set(["current", "staged"]);
-    const save = (keys: string[], nowMs: number) =>
-      storeMemoryPreimage({
+  it.each(["DREAMS.md", "dreams.md"])(
+    "retains diary-only lineage in %s after backup rotation",
+    async (diaryName) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      await fs.mkdir(workspaceDir);
+      const diaryPath = path.join(workspaceDir, diaryName);
+      await fs.writeFile(
+        diaryPath,
+        `${buildPromotionMarker("diary")}\n- Retained diary excerpt.\n`,
+      );
+      const retainedEntryKeys = new Set(["current", "staged"]);
+      const save = (keys: string[], nowMs: number) =>
+        storeMemoryPreimage({
+          workspaceDir,
+          agentIds: ["main"],
+          content: keys.map((key) => `${buildPromotionMarker(key)}\n- ${key}`).join("\n"),
+          retainedEntryKeys,
+          nowMs,
+        });
+      recordMemoryEntryOrigins({
+        agentId: "main",
+        origins: ["current", "diary", "expired", "indexed", "shared", "staged"].map((key) =>
+          origin(key, key),
+        ),
+      });
+      const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
+      db.prepare(
+        "INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, 'memory', 1, 2, ?, 'fts-only', ?, '[]', 1000)",
+      ).run(
+        "older-memory",
+        "MEMORY.md",
+        "older-memory-hash",
+        `# Memory\n${buildPromotionMarker("indexed")}`,
+      );
+      await save(["diary", "expired", "indexed", "shared", "staged"], 1_000);
+      await save(["shared"], 2_000);
+      for (let index = 3; index <= 9; index += 1) {
+        await save(["current"], index * 1_000);
+      }
+      expect(await readMemoryPreimages(workspaceDir)).toHaveLength(8);
+      expect(listMemoryEntryOrigins({ agentId: "main" }).map((entry) => entry.entryKey)).toEqual([
+        "current",
+        "diary",
+        "indexed",
+        "shared",
+        "staged",
+      ]);
+
+      await save(["current"], 10_000);
+
+      expect(await readMemoryPreimages(workspaceDir)).toHaveLength(8);
+      expect(listMemoryEntryOrigins({ agentId: "main" }).map((entry) => entry.entryKey)).toEqual([
+        "current",
+        "diary",
+        "indexed",
+        "staged",
+      ]);
+      await fs.unlink(diaryPath);
+      await pruneMemoryEntryOrigins({
         workspaceDir,
         agentIds: ["main"],
-        content: keys.map((key) => `${buildPromotionMarker(key)}\n- ${key}`).join("\n"),
+        entryKeys: ["diary"],
         retainedEntryKeys,
-        nowMs,
       });
-    recordMemoryEntryOrigins({
-      agentId: "main",
-      origins: ["current", "expired", "indexed", "shared", "staged"].map((key) => origin(key, key)),
-    });
-    const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
-    db.prepare(
-      "INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at) VALUES (?, ?, 'memory', 1, 2, ?, 'fts-only', ?, '[]', 1000)",
-    ).run(
-      "older-memory",
-      "MEMORY.md",
-      "older-memory-hash",
-      `# Memory\n${buildPromotionMarker("indexed")}`,
-    );
-    await save(["expired", "indexed", "shared", "staged"], 1_000);
-    await save(["shared"], 2_000);
-    for (let index = 3; index <= 9; index += 1) {
-      await save(["current"], index * 1_000);
-    }
-    expect(await readMemoryPreimages(workspaceDir)).toHaveLength(8);
-    expect(listMemoryEntryOrigins({ agentId: "main" }).map((entry) => entry.entryKey)).toEqual([
-      "current",
-      "indexed",
-      "shared",
-      "staged",
-    ]);
-
-    await save(["current"], 10_000);
-
-    expect(await readMemoryPreimages(workspaceDir)).toHaveLength(8);
-    expect(listMemoryEntryOrigins({ agentId: "main" }).map((entry) => entry.entryKey)).toEqual([
-      "current",
-      "indexed",
-      "staged",
-    ]);
-  });
+      expect(listMemoryEntryOrigins({ agentId: "main", entryKeys: ["diary"] })).toEqual([]);
+    },
+  );
 
   it("records exact session identity when a transcript recall candidate is first produced", async () => {
     const workspaceDir = path.join(stateDir, "workspace");

--- a/extensions/memory-core/src/memory-entry-origins.ts
+++ b/extensions/memory-core/src/memory-entry-origins.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import {
   executeSqliteQuerySync,
@@ -7,6 +8,7 @@ import {
   tableExists,
   withOpenClawAgentDatabaseReadOnly,
 } from "openclaw/plugin-sdk/sqlite-runtime";
+import { DREAMS_FILENAMES, readDreamsFile } from "./dreaming-dreams-file.js";
 import { extractPromotionKeys } from "./short-term-promotion-memory-write.js";
 
 type MemoryOriginClass = "owner" | "agent" | "untrusted" | "system";
@@ -330,17 +332,23 @@ export function reserveMemoryEntryOrigins(params: {
   return rollback;
 }
 
-export function pruneMemoryEntryOrigins(params: {
+export async function pruneMemoryEntryOrigins(params: {
+  workspaceDir: string;
   agentIds: readonly string[];
   entryKeys: Iterable<string>;
   retainedEntryKeys: ReadonlySet<string>;
-}): void {
+}): Promise<void> {
   const entryKeys = [...new Set(params.entryKeys)].filter(
     (key) => !params.retainedEntryKeys.has(key),
   );
   if (entryKeys.length === 0) {
     return;
   }
+  // Keep diary origins through backup rotation; callers hold the workspace lock.
+  const diaries = await Promise.all(
+    DREAMS_FILENAMES.map((name) => readDreamsFile(path.join(params.workspaceDir, name))),
+  );
+  const diaryKeys = new Set(diaries.flatMap(extractPromotionKeys));
   for (const agentId of new Set(params.agentIds)) {
     // A sibling may still index an older shared MEMORY snapshot. Retain its
     // lineage until that agent can identify and purge those derived records.
@@ -360,7 +368,9 @@ export function pruneMemoryEntryOrigins(params: {
     );
     deleteMemoryEntryOrigins({
       agentId,
-      entryKeys: entryKeys.filter((key) => !(indexed.found && indexed.value.has(key))),
+      entryKeys: entryKeys.filter(
+        (key) => !diaryKeys.has(key) && !(indexed.found && indexed.value.has(key)),
+      ),
     });
   }
 }

--- a/extensions/memory-core/src/memory-forget-consolidation.test.ts
+++ b/extensions/memory-core/src/memory-forget-consolidation.test.ts
@@ -85,6 +85,8 @@ describe("memory forget", () => {
       const snippet =
         action === "merged" ? "The launch code is violet." : "The launch code is cobalt.";
       const memoryPath = path.join(workspaceDir, "MEMORY.md");
+      const diaryPath = path.join(workspaceDir, "DREAMS.md");
+      await fs.writeFile(diaryPath, "# Dream Diary\nKeep this unrelated diary entry.\n");
       const previousMemory = [
         "# Long-Term Memory",
         ...(action === "superseded" ? ["<!-- openclaw-memory-lineage:launch-code -->"] : []),
@@ -208,6 +210,10 @@ describe("memory forget", () => {
           .get(),
       ).toBeUndefined();
 
+      expect(await fs.readFile(diaryPath, "utf8")).toContain(snippet);
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      resetPluginStateStoreForTests();
       const report = await forgetMemoryEntries({
         cfg,
         agentId: "gamma",
@@ -215,15 +221,113 @@ describe("memory forget", () => {
       });
       expect(report).toMatchObject({
         entryKeys: expect.arrayContaining([promoted!.key]),
-        artifacts: { memoryEntries: 1, backups: 1 },
+        artifacts: { memoryEntries: 3, backups: 1 },
       });
       expect(await fs.readFile(memoryPath, "utf8")).not.toContain(snippet);
       expect((await readBackups()).every(({ value }) => !value.content.includes(priorEntry))).toBe(
         true,
       );
       expect(listMemoryEntryOrigins({ agentId: "gamma" })).toEqual([]);
+      const diary = await fs.readFile(diaryPath, "utf8");
+      expect.soft(diary).not.toContain(priorEntry);
+      expect.soft(diary).not.toContain(snippet);
+      expect(diary).toContain("Keep this unrelated diary entry.");
+      expect(report.refusals).toEqual([]);
+      const repeated = await forgetMemoryEntries({
+        cfg,
+        agentId: "gamma",
+        sessionIds: ["private-session"],
+      });
+      expect(Object.values(repeated.artifacts).every((count) => count === 0)).toBe(true);
     },
   );
+
+  it.each(["DREAMS.md", "dreams.md"])(
+    "warns and preserves historical untraceable highlights in %s",
+    async (diaryName) => {
+      await seedSession("target");
+      recordMemoryEntryOrigins({
+        agentId: "main",
+        origins: [
+          {
+            entryKey: "historical",
+            agentId: "main",
+            sessionId: "target",
+            sessionKey: "agent:main:target",
+            originClass: "owner",
+            observedAt: 1_000,
+          },
+        ],
+      });
+      const diaryPath = path.join(workspaceDir, diaryName);
+      const historical =
+        "# Dream Diary\n## Memory Consolidation History\n- Highlights:\n  - `+ <!-- openclaw-memory-promotion:historical -->`\n  - `+ Untraceable historical fact.`\n";
+      await fs.writeFile(diaryPath, historical);
+      const preview = await forgetMemoryEntries({
+        cfg,
+        agentId: "main",
+        sessionIds: ["target"],
+        dryRun: true,
+      });
+      expect(preview.refusals).toEqual([expect.stringContaining("review them manually")]);
+      expect(preview.artifacts.memoryFiles).toBe(0);
+      const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
+      expect(report.refusals).toEqual(preview.refusals);
+      expect(await fs.readFile(diaryPath, "utf8")).toBe(historical);
+      const repeated = await forgetMemoryEntries({
+        cfg,
+        agentId: "main",
+        sessionIds: ["target"],
+        dryRun: true,
+      });
+      expect(repeated.refusals).toEqual(preview.refusals);
+    },
+  );
+
+  it("removes only the selected historical session highlight, not its following sibling", async () => {
+    await seedSession("target");
+    const diaryPath = path.join(workspaceDir, "DREAMS.md");
+    const selected =
+      "  - `+ Session ID: target; Selected private fact.`\n    Selected continuation.";
+    const survivor =
+      "  - `+ Keep this unrelated historical fact.`\n<!-- openclaw-memory-promotion:unrelated -->\n- Unrelated adjacent marked entry.";
+    const heading = "## Memory Consolidation History\n";
+    await fs.writeFile(diaryPath, `${heading}${selected}\n${survivor}\n`);
+    const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
+    expect(await fs.readFile(diaryPath, "utf8")).toBe(`${heading}${survivor}\n`);
+    expect(report.refusals).toEqual([expect.stringContaining("review them manually")]);
+  });
+
+  it.each(["## Session ID: target", "Session: saved; Session ID: target;"])(
+    "preserves section cleanup for the multiline header %s",
+    async (header) => {
+      await seedSession("target");
+      const diaryPath = path.join(workspaceDir, "DREAMS.md");
+      const survivor = "## Other session\n- Keep this separate section.\n";
+      await fs.writeFile(
+        diaryPath,
+        `${header}\n- Selected first line.\n  Selected continuation.\n- Selected second line.\n${survivor}`,
+      );
+      await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
+      expect(await fs.readFile(diaryPath, "utf8")).toBe(survivor);
+    },
+  );
+
+  it("does not warn after removing every traceable historical highlight", async () => {
+    await seedSession("target");
+    const quote = "User: This exact historical quotation is attributable.";
+    const corpusDir = path.join(workspaceDir, "memory", ".dreams", "session-corpus");
+    await fs.mkdir(corpusDir, { recursive: true });
+    await fs.writeFile(
+      path.join(corpusDir, "day.txt"),
+      `[main/sessions/main/target#L1] ${quote}\n`,
+    );
+    const diaryPath = path.join(workspaceDir, "DREAMS.md");
+    await fs.writeFile(diaryPath, `## Memory Consolidation History\n  - ` + "`+ " + quote + "`\n");
+    const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
+    expect(report.refusals).toEqual([]);
+    expect(await fs.readFile(diaryPath, "utf8")).not.toContain(quote);
+  });
 
   it("removes a marker-addressable plain-append promotion after budget compaction", async () => {
     await seedSession("target");

--- a/extensions/memory-core/src/memory-forget-consolidation.test.ts
+++ b/extensions/memory-core/src/memory-forget-consolidation.test.ts
@@ -323,7 +323,7 @@ describe("memory forget", () => {
       `[main/sessions/main/target#L1] ${quote}\n`,
     );
     const diaryPath = path.join(workspaceDir, "DREAMS.md");
-    await fs.writeFile(diaryPath, `## Memory Consolidation History\n  - ` + "`+ " + quote + "`\n");
+    await fs.writeFile(diaryPath, `## Memory Consolidation History\n  - \`+ ${quote}\`\n`);
     const report = await forgetMemoryEntries({ cfg, agentId: "main", sessionIds: ["target"] });
     expect(report.refusals).toEqual([]);
     expect(await fs.readFile(diaryPath, "utf8")).not.toContain(quote);

--- a/extensions/memory-core/src/memory-forget.ts
+++ b/extensions/memory-core/src/memory-forget.ts
@@ -28,6 +28,7 @@ import {
   withOpenClawAgentDatabaseReadOnly,
 } from "openclaw/plugin-sdk/sqlite-runtime";
 import { readMemoryPreimages } from "./dreaming-consolidation-artifacts.js";
+import { DREAMS_FILENAMES } from "./dreaming-dreams-file.js";
 import {
   DREAMING_MEMORY_BACKUP_NAMESPACE,
   SHORT_TERM_RECALL_NAMESPACE,
@@ -184,6 +185,7 @@ function scrubMemoryContent(params: {
       continue;
     }
     const heading = /^(#{1,6})\s/u.exec(lines[index] ?? "");
+    const rowIndent = /^(\s*)[-*+]\s/u.exec(lines[index] ?? "")?.[1]?.length;
     if (!heading && !/\bSession ID:/iu.test(lines[index] ?? "")) {
       continue;
     }
@@ -191,6 +193,7 @@ function scrubMemoryContent(params: {
     while (end < lines.length) {
       const nextHeading = /^(#{1,6})\s/u.exec(lines[end] ?? "");
       if (
+        (rowIndent !== undefined && (lines[end] ?? "").search(/\S/u) <= rowIndent) ||
         (nextHeading && (!heading || nextHeading[1]!.length <= heading[1]!.length)) ||
         /\bSession ID:/iu.test(lines[end] ?? "")
       ) {
@@ -388,6 +391,7 @@ async function forgetWorkspaceMemory(
       .map((origin) => origin.entryKey),
   );
   const untargetableEntryKeys = new Set<string>();
+  const refusals: string[] = [];
   const corpusDir = path.join(workspaceDir, SESSION_CORPUS_RELATIVE_DIR);
   const corpusFiles = await fs
     .readdir(corpusDir, { withFileTypes: true })
@@ -436,10 +440,10 @@ async function forgetWorkspaceMemory(
     scrubMemoryContent({ content, entryKeys, sessionIds, corpusSnippets, agentId: params.agentId });
   let removedMemoryEntries = 0;
   let removedMemoryLines = 0;
-  const memoryFiles = await listMemoryFiles(workspaceDir, [
-    path.join(workspaceDir, "DREAMS.md"),
-    path.join(workspaceDir, "dreams.md"),
-  ]);
+  const memoryFiles = await listMemoryFiles(
+    workspaceDir,
+    DREAMS_FILENAMES.map((name) => path.join(workspaceDir, name)),
+  );
   for (const absolutePath of memoryFiles) {
     // Corpus evidence must survive until every dependent artifact is clean.
     if (path.dirname(absolutePath) === corpusDir) {
@@ -453,6 +457,11 @@ async function forgetWorkspaceMemory(
       }
     }
     const scrubbed = scrub(content);
+    if (/^## Memory Consolidation History\r?$[\s\S]*^  - `[+-] /mu.test(scrubbed.content)) {
+      refusals.push(
+        `Cannot trace historical consolidation highlights in ${path.relative(workspaceDir, absolutePath)}; review them manually.`,
+      );
+    }
     if (scrubbed.content !== content) {
       memoryRewrites.push({
         absolutePath,
@@ -604,7 +613,7 @@ async function forgetWorkspaceMemory(
       backups: rewrittenBackups,
       originRows: allOrigins.filter((origin) => entryKeys.has(origin.entryKey)).length,
     },
-    refusals: [],
+    refusals,
   };
   if (params.dryRun || sessionIds.size === 0) {
     return report;

--- a/extensions/memory-core/src/memory-forget.ts
+++ b/extensions/memory-core/src/memory-forget.ts
@@ -457,7 +457,7 @@ async function forgetWorkspaceMemory(
       }
     }
     const scrubbed = scrub(content);
-    if (/^## Memory Consolidation History\r?$[\s\S]*^  - `[+-] /mu.test(scrubbed.content)) {
+    if (/^## Memory Consolidation History\r?$[\s\S]*^ {2}- `[+-] /mu.test(scrubbed.content)) {
       refusals.push(
         `Cannot trace historical consolidation highlights in ${path.relative(workspaceDir, absolutePath)}; review them manually.`,
       );
@@ -504,9 +504,11 @@ async function forgetWorkspaceMemory(
       !entryKeys.has(value.key) &&
       !referencesSession(`${value.path}\n${value.snippet}`, params.agentId, sessionIds),
   );
-  const removedSeenScopes = Object.keys(ingestionState.seenMessages).filter((scope) =>
-    referencesSession(scope, params.agentId, sessionIds),
+  const retainedSeenMessages = Object.entries(ingestionState.seenMessages).filter(
+    ([scope]) => !referencesSession(scope, params.agentId, sessionIds),
   );
+  const removedSeenScopes =
+    Object.keys(ingestionState.seenMessages).length - retainedSeenMessages.length;
   const retainedFileStates = Object.fromEntries(
     Object.entries(ingestionState.files).filter(
       ([key]) => !referencesSession(key, params.agentId, sessionIds),
@@ -609,7 +611,7 @@ async function forgetWorkspaceMemory(
       vectorRows: indexPlan.vectorRows,
       embeddingCacheRows: indexPlan.embeddingCacheRows,
       shortTermEntries: shortTermEntries.length - retainedShortTerm.length,
-      seenHashScopes: removedSeenScopes.length,
+      seenHashScopes: removedSeenScopes,
       backups: rewrittenBackups,
       originRows: allOrigins.filter((origin) => entryKeys.has(origin.entryKey)).length,
     },
@@ -702,17 +704,13 @@ async function forgetWorkspaceMemory(
       });
     }
     if (
-      removedSeenScopes.length > 0 ||
+      removedSeenScopes > 0 ||
       Object.keys(retainedFileStates).length !== Object.keys(ingestionState.files).length
     ) {
       await writeSessionIngestionState(workspaceDir, {
         ...ingestionState,
         files: retainedFileStates,
-        seenMessages: Object.fromEntries(
-          Object.entries(ingestionState.seenMessages).filter(
-            ([scope]) => !referencesSession(scope, params.agentId, sessionIds),
-          ),
-        ),
+        seenMessages: Object.fromEntries(retainedSeenMessages),
       });
     }
     if (rewrittenBackups > 0) {

--- a/extensions/memory-core/src/short-term-promotion-apply.ts
+++ b/extensions/memory-core/src/short-term-promotion-apply.ts
@@ -631,7 +631,8 @@ export async function applyShortTermPromotions(
             extractPromotionKeys(value.content),
           ),
         );
-        pruneMemoryEntryOrigins({
+        await pruneMemoryEntryOrigins({
+          workspaceDir,
           agentIds: originAgentIds,
           entryKeys: extractPromotionKeys(existingMemory),
           retainedEntryKeys: new Set([


### PR DESCRIPTION
Related: #131179

## What Problem This Solves

Fixes an issue where users forgetting a source session could still find its old and replacement facts in generated dream-diary consolidation history. Rotating the retained memory backups could also discard the provenance needed to identify diary-only copies. Historical quoted session references could cause the scrubber to remove an unrelated following diary row.

## Why This Change Was Made

Consolidation now derives its bounded history excerpts directly from the validated operations and attaches the replacement entry's existing unioned lineage. The ordinary memory scrubber can then remove those excerpts without reconstructing attribution from a textual diff. The existing provenance collector retains keys referenced by either supported diary filename, as it already does for live entries, backups, and indexed snapshots.

Historical excerpts without reliable attribution remain untouched and are reported through the existing `refusals` field for manual review. Exact source quotations and explicit session references remain eligible for deletion; list-row boundaries prevent a selected reference from consuming its unrelated peer. This builds on the already merged #131179 without duplicating its backup/index work. There is no new SQLite schema or configuration surface.

## User Impact

Forgetting a session removes newly generated consolidation excerpts, including superseded facts, while preserving unrelated diary content. Preview and apply report recognizable untraceable historical highlights instead of claiming complete deletion. Diary provenance remains for as long as the corresponding excerpts remain; long histories can therefore retain growing origin sets.

## Evidence

The pre-fix regressions reproduce retained merged/superseded diary facts and deletion of an unrelated following historical row. The final owner/sibling matrix passes 104 tests across five files. A fresh isolated Codex autoreview reports no findings at its P0-only threshold; independent owner review found no remaining actionable issue.

Production LOC: +49/−51, net −2. Tests: +229/−162, net +67. Docs: +16/−4. The generic textual-diff highlight path is removed in favor of the validated consolidation operations.

The patch was ported onto main `0706f629c3b550f285d70767f9b869fa7ae5bb4c`; all 34,391 tracked blobs and modes match the frozen candidate manifest at head `3952df5499f48ec84b130ca03b30597ef33bdc24`.

The first exact-source Linux proof passed: [run 33124783681](https://github.com/openclaw/openclaw/actions/runs/33124783681) reproduced the defect through two actual CLI calls on baseline `0706f629` and passed seven CLI calls at `9c30a622`, including both diary filename cases, backup rotation, cold repeat, and the human warning. No live model or channel is claimed; canonical owners seed isolated synthetic state using a fixed valid consolidation response. The lease is stopped.

CI then caught two file-size limits, a regex spelling issue, and redundant test-string concatenation. The follow-up reuses one retained-ingestion calculation for both counts and persistence, removes duplicated test setup without dropping any cases or assertions, and fixes the spelling issues. All 104 tests and fresh P0 autoreview passed again. Final exact-commit CLI proof also passed at `3952df5499f48ec84b130ca03b30597ef33bdc24`: [run 33125682225](https://github.com/openclaw/openclaw/actions/runs/33125682225), Blacksmith Testbox `tbx_01m12r59yqxvx6kg12sxm1ssbx`. Its own frozen install/build and all seven CLI calls passed. All 34,391 source blobs/modes matched before and after; the lease is stopped/completed. Workflow dispatch used main `7838302658d5b2a79660fb36d7e86b54bbfc26e6`, distinct from the synchronized and tested candidate commit. [Exact-head CI 33125643610](https://github.com/openclaw/openclaw/actions/runs/33125643610) and `openclaw/ci-gate` passed, with no pending or failed checks. Local typed lint encountered pre-existing stale shared dependency declarations before linting this patch; no worktree dependency reconciliation was attempted.
