### PR TITLE
perf(gateway): reuse human profiles within session catalogs

### DIFF
--- a/src/gateway/server-methods/session-catalog-entry-snapshot.test.ts
+++ b/src/gateway/server-methods/session-catalog-entry-snapshot.test.ts
@@ -6,6 +6,8 @@ import {
   listSessionCatalogEntries,
   type SessionCatalogProvider,
 } from "../../plugins/session-catalog.js";
+import type { CurrentUserProfileDisplayResolver } from "../current-user-profile-display.js";
+import { createSessionCatalogRequestEntrySnapshot } from "./session-catalog-entry-snapshot.js";
 
 type TestPluginRegistry = Omit<PluginRegistry, "sessionCatalogs"> & {
   sessionCatalogs: Array<{ provider: SessionCatalogProvider }>;
@@ -13,6 +15,7 @@ type TestPluginRegistry = Omit<PluginRegistry, "sessionCatalogs"> & {
 
 const hoisted = vi.hoisted(() => ({
   activeRegistry: {} as TestPluginRegistry,
+  resolveCurrentUserProfileDisplay: vi.fn<CurrentUserProfileDisplayResolver>(),
   listSessionEntriesReadOnly: vi.fn<
     (scope?: { agentId?: string; clone?: boolean; projection?: "full" | "list" }) => Array<{
       sessionKey: string;
@@ -32,6 +35,9 @@ vi.mock("../../config/sessions/session-accessor.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../config/sessions/session-accessor.js")>();
   return { ...actual, listSessionEntriesReadOnly: hoisted.listSessionEntriesReadOnly };
 });
+vi.mock("../current-user-profile-display.js", () => ({
+  resolveCurrentUserProfileDisplay: hoisted.resolveCurrentUserProfileDisplay,
+}));
 
 const { sessionCatalogHandlers } = await import("./session-catalog.js");
 
@@ -75,6 +81,60 @@ describe("session catalog entry snapshots", () => {
   beforeEach(() => {
     hoisted.activeRegistry = createEmptyPluginRegistry() as TestPluginRegistry;
     hoisted.listSessionEntriesReadOnly.mockReset();
+    hoisted.resolveCurrentUserProfileDisplay.mockReset();
+  });
+
+  it("shares resolved and missing human profiles across hosts without retaining them across requests", () => {
+    let label = "Before rename";
+    hoisted.resolveCurrentUserProfileDisplay.mockImplementation((id) =>
+      id === "person"
+        ? { kind: "resolved", profileId: id, label, avatarUrl: "/avatar", hasUploadedAvatar: true }
+        : { kind: "unresolved" },
+    );
+    const hosts = ["alpha", "beta"].map((id) => ({
+      hostId: `gateway:${id}`,
+      label: id,
+      kind: "gateway" as const,
+      connected: true,
+      sessions: ["person", "missing"].map((actorId) => ({
+        threadId: `${id}-${actorId}`,
+        sessionKey: `agent:main:${id}-${actorId}`,
+        status: "stored" as const,
+        archived: false,
+        canContinue: true,
+        canArchive: false,
+      })),
+    }));
+    hoisted.listSessionEntriesReadOnly.mockReturnValue(
+      hosts.flatMap((host) =>
+        host.sessions.map((session, index) => ({
+          sessionKey: session.sessionKey,
+          entry: {
+            createdActor: { type: "human" as const, id: index === 0 ? "person" : "missing" },
+          },
+        })),
+      ),
+    );
+    const project = () => {
+      const snapshot = createSessionCatalogRequestEntrySnapshot({
+        cfg: {},
+        fallbackAgentId: "main",
+      });
+      return hosts.map((host) =>
+        snapshot.projectHostCreatedActors(host).sessions.map((session) => session.createdActor),
+      );
+    };
+    const expectedActors = () => [
+      { type: "human", id: "person", label, avatarUrl: "/avatar" },
+      { type: "human", id: "missing" },
+    ];
+
+    expect(project()).toEqual([expectedActors(), expectedActors()]);
+    expect(hoisted.resolveCurrentUserProfileDisplay).toHaveBeenCalledTimes(2);
+
+    label = "After rename";
+    expect(project()).toEqual([expectedActors(), expectedActors()]);
+    expect(hoisted.resolveCurrentUserProfileDisplay).toHaveBeenCalledTimes(4);
   });
 
   it("shares one flattened entry snapshot across catalogs and creator projection", async () => {

--- a/src/gateway/server-methods/session-catalog-entry-snapshot.ts
+++ b/src/gateway/server-methods/session-catalog-entry-snapshot.ts
@@ -13,6 +13,7 @@ import type { SessionCatalogEntrySnapshot } from "../../plugins/session-catalog.
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { tryResolveSessionCompatibilityOwnerAgentId } from "../session-request-agent.js";
 import { resolveStoredSessionKeyForAgentStore } from "../session-store-key.js";
+import type { SessionActorProfileIdentity } from "../session-utils-contracts.js";
 import { projectSessionActor } from "../session-utils-row.js";
 
 type SessionCatalogRequestEntrySnapshot = {
@@ -27,6 +28,8 @@ export function createSessionCatalogRequestEntrySnapshot(params: {
   const entriesByAgentId = new Map<string, readonly SessionEntrySummary[]>();
   const entryIndexByAgentId = new Map<string, ReadonlyMap<string, SessionEntry>>();
   const actorBySessionKey = new Map<string, SessionCatalogSession["createdActor"]>();
+  // Hosts share human identities within this request; a new snapshot must see profile edits.
+  const userProfileIdentityById = new Map<string, SessionActorProfileIdentity | undefined>();
   let catalogEntries:
     | ReturnType<NonNullable<SessionCatalogEntrySnapshot["entriesForCatalog"]>>
     | undefined;
@@ -92,7 +95,7 @@ export function createSessionCatalogRequestEntrySnapshot(params: {
         freshest = entry;
       }
     }
-    const actor = projectSessionActor(freshest?.createdActor, undefined, params.cfg);
+    const actor = projectSessionActor(freshest?.createdActor, userProfileIdentityById, params.cfg);
     actorBySessionKey.set(actorCacheKey, actor);
     return actor;
   };


### PR DESCRIPTION
Related: #122390 (performance review), #127743 (catalog latency; this does not change freshness policy or close that issue).

## What Problem This Solves

Fixes an issue where listing session catalogs repeats synchronous profile reads for every session created by the same person. Large catalogs pay for the same profile resolution and avatar-row materialization many times during one request.

## Why This Change Was Made

The catalog already shares session entries and caches creators by session key, but passed no identity map to `projectSessionActor`. Distinct sessions therefore repeated the same profile lookup. Share the existing identity map for the lifetime of the request snapshot, matching `sessions.list`; both resolved and missing profiles are reused across hosts. A new request starts a new map and observes profile edits.

No new cache policy, configuration, persistence, schema, authorization rule, or provider protocol is introduced. Production LOC: +4/-1 (net +3), comprising the existing identity type import, request-owned map, and its lifetime comment. Tests: +60/-0. The small growth supplies the missing owner of the existing projection cache rather than adding a second lookup implementation.

## User Impact

Catalogs with repeated human creators do less synchronous database work. Creator labels and avatars remain unchanged, and later requests still see renamed profiles. This is a bounded optimization; it is not claimed to resolve external catalog scan delays or general event-loop stalls.

## Evidence

- Before the fix, the new regression fails: two human identities across two hosts cause four profile reads instead of two. After the fix, it passes and a new snapshot observes the changed profile label. Missing profiles are also reused only within the request.
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server-methods/session-catalog-entry-snapshot.test.ts src/gateway/server-methods/session-catalog.test.ts src/gateway/server-methods/session-catalog-visibility.test.ts`: 49 tests passed.
- Isolated real-SQLite microbenchmark, seven alternating samples of 500 rows for one human creator: median projection wall time without an avatar fell from 18.41 ms to 0.048 ms; with a synthetic 256 KiB avatar, 25.45 ms to 0.069 ms. This measures the projection step, not whole-RPC latency; host scheduling affects wall time. No live user state was modified.
- Exact-head hosted CI passed: https://github.com/openclaw/openclaw/actions/runs/33124994049 (373eeb1a514f84d4393b6366689437c94a4cb9e9), including production and test typechecks. The 49 focused tests also passed again with current dependency pins.
- Local full changed checks initially encountered outdated borrowed root dependencies and then a missing UI-local pako installation. Dependency routing was corrected; the full local `node scripts/check-changed.mjs -- src/gateway/server-methods/session-catalog-entry-snapshot.ts src/gateway/server-methods/session-catalog-entry-snapshot.test.ts` retry passed, including production/test typechecks, lint, dead exports, boundaries and import cycles. No production workaround was added.
- Independent Codex autoreview completed with no reported findings. Public rendering is unchanged; the regression checks the projected labels and avatar URLs.
- Provenance: the per-session projection path originates in #114358, authored and merged by @steipete on July 27, 2026. Subsequent agent-attribution work retained the omitted identity map.

AI-assisted with Codex.
