### PR TITLE
docs: align gateway approval, web-tool limit, and search-provider docs with shipped behavior

### DIFF
--- a/docs/gateway/config-tools.md
+++ b/docs/gateway/config-tools.md
@@ -309,7 +309,7 @@ Tool-loop safety checks are **disabled by default**. Set `enabled: true` to acti
     web: {
       search: {
         enabled: true,
-        apiKey: "brave_api_key", // or BRAVE_API_KEY env (Brave provider)
+        provider: "brave", // optional; omit for auto-detect
         maxResults: 5,
         timeoutSeconds: 30,
         cacheTtlMinutes: 15,
@@ -328,10 +328,19 @@ Tool-loop safety checks are **disabled by default**. Set `enabled: true` to acti
       },
     },
   },
+  plugins: {
+    entries: {
+      brave: {
+        config: {
+          webSearch: { apiKey: "brave_api_key" }, // or BRAVE_API_KEY env
+        },
+      },
+    },
+  },
 }
 ```
 
-Values shown are defaults except `provider` and `userAgent`. `maxResponseBytes` clamps to 32000–10000000; `maxChars` clamps to `maxCharsCap` (raise `maxCharsCap` to allow larger responses).
+Web-search provider credentials belong under `plugins.entries.<plugin>.config.webSearch`, as shown for Brave; see [Web search](/tools/web#storing-api-keys). The `tools.web` values shown are defaults except `provider` and `userAgent`. `maxResponseBytes` clamps to 32000–10000000; `maxChars` clamps to `maxCharsCap` (raise `maxCharsCap` to allow larger responses).
 
 ### `tools.media`
 

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -49,6 +49,10 @@ read_when:
 
 ## Configuration
 
+<Note>
+The `deviceAutoApprove` examples below target beta/current-main builds. Stable `v2026.7.1` does not support this option.
+</Note>
+
 ```json5
 {
   gateway: {
@@ -128,7 +132,7 @@ Internal Gateway clients that do not travel through the reverse proxy should use
   Opt-in support for same-host loopback reverse proxies.
 </ParamField>
 <ParamField path="gateway.auth.trustedProxy.deviceAutoApprove.enabled" type="boolean" default="false">
-  Automatically approve new Control UI and WebChat browser devices and same-key scope upgrades after trusted-proxy authentication.
+  Automatically approve new browser operator devices and same-key scope upgrades after trusted-proxy authentication.
 </ParamField>
 <ParamField path="gateway.auth.trustedProxy.deviceAutoApprove.scopes" type="string[]" default='["operator.read", "operator.write", "operator.approvals", "operator.questions"]'>
   Maximum scopes granted to an auto-approved browser device. Explicitly listing `operator.admin` lets every proxy-authenticated user request an automatic full-admin device grant, makes scope-less requests receive full admin automatically, and triggers the CRITICAL `gateway.trusted_proxy_device_auto_approve_admin` security audit finding plus a Gateway startup warning.
@@ -200,8 +204,8 @@ Trusted-proxy auth can optionally use the proxy identity as the approval boundar
 The default is `enabled: false`. When enabled, all of these rules apply:
 
 1. The WebSocket must have authenticated through the `trusted-proxy` method with a non-empty user identity that passed `allowUsers` when an allowlist is configured. Token, password, Tailscale, and unauthenticated connections never use this policy.
-2. New Control UI or WebChat browser devices and scope upgrades from an existing device with the same paired public key resolve automatically. If the existing grant already covers the automatically approvable scopes, the session narrows to that grant without a pairing request or audit entry; otherwise, `deviceAutoApprove.scopes` can automatically approve the widened intersection. Role, metadata, and public-key changes are not eligible for this auto-approval policy. A connection claiming an existing device ID with a different public key is rejected before a pairing request is created.
-3. The device is approved with role `operator`. With an explicit `deviceAutoApprove.scopes` list, requested scopes are intersected with that list; a request that omits scopes receives the list. When the list is unset, it defaults to `operator.read`, `operator.write`, `operator.approvals`, and `operator.questions`. OpenClaw also adds `operator.questions` to older browser clients' requested scopes in this default case, so tabs left open across upgrades retain interactive question access. An explicit scope list is never widened. The resulting grant is then additionally capped by the connection's [`x-openclaw-scopes`](#control-ui-pairing-behavior) proxy header when present, so a proxy that narrows a user's scopes also limits the **persistent** device grant, not just the session — a present-but-empty header yields no scopes. This cap applies even when the client omits its own scope list.
+2. New browser operator devices (including Control UI and WebChat) and scope upgrades from an existing device with the same paired public key resolve automatically. If the existing grant already covers the automatically approvable scopes, the session narrows to that grant without a pairing request or audit entry; otherwise, `deviceAutoApprove.scopes` can automatically approve the widened intersection. Role upgrades and changes to pinned platform or device-family metadata are not eligible for this auto-approval policy. A connection claiming an existing device ID with a different public key is rejected before a pairing request is created.
+3. The device is approved with role `operator`. With an explicit `deviceAutoApprove.scopes` list, requested scopes are intersected with that list; a request that omits scopes receives the list. When the list is unset, it defaults to `operator.read`, `operator.write`, `operator.approvals`, and `operator.questions`. During auto-approval with this default list, OpenClaw also adds `operator.questions` even if an older browser client does not request it. An explicit scope list is never widened. The resulting grant is then additionally capped by the connection's [`x-openclaw-scopes`](#control-ui-pairing-behavior) proxy header when present, so a proxy that narrows a user's scopes also limits the **persistent** device grant, not just the session — a present-but-empty header yields no scopes. This cap applies even when the client omits its own scope list.
 4. `operator.admin` is allowed only through explicit listing in `deviceAutoApprove.scopes`. When listed, every proxy-authenticated user can request and automatically receive full admin on a new browser device; requests without scopes receive full admin automatically. `openclaw security audit` reports the CRITICAL `gateway.trusted_proxy_device_auto_approve_admin` finding, and the Gateway logs a warning once at startup. Prefer a targeted [`identityScopes`](#per-identity-scope-grants) admin grant when selected verified users need session admin without a persistent admin device grant.
 
 <Warning>

--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -76,10 +76,10 @@ read_when:
         // Optional: allow a same-host loopback proxy after explicit opt-in
         allowLoopback: false,
 
-        // Optional: let authenticated proxy users enroll new browser devices
+        // Optional: let authenticated proxy users enroll browsers and upgrade scopes
         deviceAutoApprove: {
           enabled: false,
-          scopes: ["operator.read", "operator.write", "operator.approvals"],
+          scopes: ["operator.read", "operator.write", "operator.approvals", "operator.questions"],
         },
       },
     },
@@ -128,9 +128,9 @@ Internal Gateway clients that do not travel through the reverse proxy should use
   Opt-in support for same-host loopback reverse proxies.
 </ParamField>
 <ParamField path="gateway.auth.trustedProxy.deviceAutoApprove.enabled" type="boolean" default="false">
-  Automatically approve new Control UI and WebChat device identities after trusted-proxy authentication.
+  Automatically approve new Control UI and WebChat browser devices and same-key scope upgrades after trusted-proxy authentication.
 </ParamField>
-<ParamField path="gateway.auth.trustedProxy.deviceAutoApprove.scopes" type="string[]" default='["operator.read", "operator.write", "operator.approvals"]'>
+<ParamField path="gateway.auth.trustedProxy.deviceAutoApprove.scopes" type="string[]" default='["operator.read", "operator.write", "operator.approvals", "operator.questions"]'>
   Maximum scopes granted to an auto-approved browser device. Explicitly listing `operator.admin` lets every proxy-authenticated user request an automatic full-admin device grant, makes scope-less requests receive full admin automatically, and triggers the CRITICAL `gateway.trusted_proxy_device_auto_approve_admin` security audit finding plus a Gateway startup warning.
 </ParamField>
 
@@ -177,7 +177,7 @@ no-auth connections do not carry a verified identity and never receive a grant.
 
 ## Automatic device approval
 
-Trusted-proxy auth can optionally use the proxy identity as the approval boundary for new browser devices:
+Trusted-proxy auth can optionally use the proxy identity as the approval boundary for new browser devices and same-key scope upgrades:
 
 ```json5
 {
@@ -189,7 +189,7 @@ Trusted-proxy auth can optionally use the proxy identity as the approval boundar
         allowUsers: ["operator@example.com"],
         deviceAutoApprove: {
           enabled: true,
-          scopes: ["operator.read", "operator.write", "operator.approvals"],
+          scopes: ["operator.read", "operator.write", "operator.approvals", "operator.questions"],
         },
       },
     },
@@ -200,8 +200,8 @@ Trusted-proxy auth can optionally use the proxy identity as the approval boundar
 The default is `enabled: false`. When enabled, all of these rules apply:
 
 1. The WebSocket must have authenticated through the `trusted-proxy` method with a non-empty user identity that passed `allowUsers` when an allowlist is configured. Token, password, Tailscale, and unauthenticated connections never use this policy.
-2. New Control UI or WebChat browser devices and scope upgrades from an existing device with the same paired public key resolve automatically. If the existing grant already covers the automatically approvable scopes, the session narrows to that grant without a pairing request or audit entry; otherwise, `deviceAutoApprove.scopes` can automatically approve the widened intersection. A public-key mismatch remains pending for manual approval with `openclaw devices approve <requestId>`.
-3. The device is approved with role `operator`. If the connect request includes scopes, the grant is the exact intersection of the requested scopes and `deviceAutoApprove.scopes`. If the request omits scopes, the configured list is granted; when that list is omitted, it defaults to `operator.read`, `operator.write`, and `operator.approvals`. The resulting grant is then additionally capped by the connection's [`x-openclaw-scopes`](#control-ui-pairing-behavior) proxy header when present, so a proxy that narrows a user's scopes also limits the **persistent** device grant, not just the session — a present-but-empty header yields no scopes. This cap applies even when the client omits its own scope list.
+2. New Control UI or WebChat browser devices and scope upgrades from an existing device with the same paired public key resolve automatically. If the existing grant already covers the automatically approvable scopes, the session narrows to that grant without a pairing request or audit entry; otherwise, `deviceAutoApprove.scopes` can automatically approve the widened intersection. Role, metadata, and public-key changes are not eligible for this auto-approval policy. A connection claiming an existing device ID with a different public key is rejected before a pairing request is created.
+3. The device is approved with role `operator`. With an explicit `deviceAutoApprove.scopes` list, requested scopes are intersected with that list; a request that omits scopes receives the list. When the list is unset, it defaults to `operator.read`, `operator.write`, `operator.approvals`, and `operator.questions`. OpenClaw also adds `operator.questions` to older browser clients' requested scopes in this default case, so tabs left open across upgrades retain interactive question access. An explicit scope list is never widened. The resulting grant is then additionally capped by the connection's [`x-openclaw-scopes`](#control-ui-pairing-behavior) proxy header when present, so a proxy that narrows a user's scopes also limits the **persistent** device grant, not just the session — a present-but-empty header yields no scopes. This cap applies even when the client omits its own scope list.
 4. `operator.admin` is allowed only through explicit listing in `deviceAutoApprove.scopes`. When listed, every proxy-authenticated user can request and automatically receive full admin on a new browser device; requests without scopes receive full admin automatically. `openclaw security audit` reports the CRITICAL `gateway.trusted_proxy_device_auto_approve_admin` finding, and the Gateway logs a warning once at startup. Prefer a targeted [`identityScopes`](#per-identity-scope-grants) admin grant when selected verified users need session admin without a persistent admin device grant.
 
 <Warning>

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -130,11 +130,11 @@ export const CORE_FIELD_HELP: Record<string, string> = {
   "gateway.auth.trustedProxy":
     "Trusted-proxy auth header mapping for upstream identity providers that inject user claims. Use only with known proxy CIDRs and strict header allowlists to prevent spoofed identity headers.",
   "gateway.auth.trustedProxy.deviceAutoApprove":
-    "Optional policy for automatically approving new Control UI and WebChat device identities after trusted-proxy authentication. Existing-device scope upgrades always remain manual.",
+    "Optional policy for automatically approving new Control UI and WebChat browser devices and same-key scope upgrades after trusted-proxy authentication. Grants are capped by deviceAutoApprove.scopes and the proxy's x-openclaw-scopes header when present.",
   "gateway.auth.trustedProxy.deviceAutoApprove.enabled":
-    "Automatically approves new browser device identities after the reverse proxy authenticates an allowed user. Default: false. Enable only when the proxy identity boundary is strong enough to replace manual device pairing.",
+    "Automatically approves new browser devices and same-key scope upgrades after the reverse proxy authenticates an allowed user. Default: false. Enable only when the proxy identity boundary is strong enough to replace manual device pairing.",
   "gateway.auth.trustedProxy.deviceAutoApprove.scopes":
-    "Maximum scopes granted to auto-approved browser devices. Requested scopes are capped to this list; requests without scopes receive this list. Explicitly listing operator.admin lets every proxy-authenticated user auto-approve full admin and makes scope-less requests receive full admin automatically; it also triggers a critical security audit finding and Gateway startup warning.",
+    "Maximum scopes granted to auto-approved browser devices. Defaults to operator.read, operator.write, operator.approvals, and operator.questions. Requested scopes are capped to this list; requests without scopes receive this list. When unset, operator.questions is also added for older browser clients; an explicit list is never widened. Explicitly listing operator.admin lets every proxy-authenticated user auto-approve full admin and makes scope-less requests receive full admin automatically; it also triggers a critical security audit finding and Gateway startup warning.",
   "gateway.roles":
     "Optional profile-bound operator roles for team Gateways. Each named role controls access to other people's sessions, sandbox isolation, session and run agents, and granted operator scopes; omitting this section preserves existing operator behavior.",
   "gateway.roles.default":

--- a/src/config/schema.help.core.ts
+++ b/src/config/schema.help.core.ts
@@ -130,11 +130,11 @@ export const CORE_FIELD_HELP: Record<string, string> = {
   "gateway.auth.trustedProxy":
     "Trusted-proxy auth header mapping for upstream identity providers that inject user claims. Use only with known proxy CIDRs and strict header allowlists to prevent spoofed identity headers.",
   "gateway.auth.trustedProxy.deviceAutoApprove":
-    "Optional policy for automatically approving new Control UI and WebChat browser devices and same-key scope upgrades after trusted-proxy authentication. Grants are capped by deviceAutoApprove.scopes and the proxy's x-openclaw-scopes header when present.",
+    "Optional policy for automatically approving new browser operator devices and same-key scope upgrades after trusted-proxy authentication. Grants are capped by deviceAutoApprove.scopes and the proxy's x-openclaw-scopes header when present.",
   "gateway.auth.trustedProxy.deviceAutoApprove.enabled":
-    "Automatically approves new browser devices and same-key scope upgrades after the reverse proxy authenticates an allowed user. Default: false. Enable only when the proxy identity boundary is strong enough to replace manual device pairing.",
+    "Automatically approves new browser operator devices and same-key scope upgrades after the reverse proxy authenticates an allowed user. Default: false. Enable only when the proxy identity boundary is strong enough to replace manual device pairing.",
   "gateway.auth.trustedProxy.deviceAutoApprove.scopes":
-    "Maximum scopes granted to auto-approved browser devices. Defaults to operator.read, operator.write, operator.approvals, and operator.questions. Requested scopes are capped to this list; requests without scopes receive this list. When unset, operator.questions is also added for older browser clients; an explicit list is never widened. Explicitly listing operator.admin lets every proxy-authenticated user auto-approve full admin and makes scope-less requests receive full admin automatically; it also triggers a critical security audit finding and Gateway startup warning.",
+    "Maximum scopes granted to auto-approved browser devices. Defaults to operator.read, operator.write, operator.approvals, and operator.questions. Requested scopes are capped to this list; requests without scopes receive this list. When unset, auto-approval also adds operator.questions for older browser clients; an explicit list is never widened. Explicitly listing operator.admin lets every proxy-authenticated user auto-approve full admin and makes scope-less requests receive full admin automatically; it also triggers a critical security audit finding and Gateway startup warning.",
   "gateway.roles":
     "Optional profile-bound operator roles for team Gateways. Each named role controls access to other people's sessions, sandbox isolation, session and run agents, and granted operator scopes; omitting this section preserves existing operator behavior.",
   "gateway.roles.default":

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -207,18 +207,18 @@ export type GatewayTrustedProxyConfig = {
    */
   allowLoopback?: boolean;
   /**
-   * Automatically approve new browser device identities after trusted-proxy
-   * authentication. Disabled by default; existing-device upgrades stay manual.
+   * Automatically approve new browser devices and same-key scope upgrades after
+   * trusted-proxy authentication. Disabled by default; configured scopes cap grants.
    */
   deviceAutoApprove?: {
-    /** Enable automatic approval for new browser devices. @default false */
+    /** Enable automatic browser enrollment and same-key scope upgrades. @default false */
     enabled?: boolean;
     /**
      * Maximum operator scopes granted by automatic approval. Listing
      * operator.admin explicitly lets every proxy-authenticated user request
      * automatic full-admin device grants. Requests without scopes receive the
      * configured maximum. @default operator.read, operator.write,
-     * operator.approvals
+     * operator.approvals, operator.questions
      */
     scopes?: string[];
   };

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -468,9 +468,9 @@ export type ToolsConfig = {
       provider?: string;
       /** Max characters to return from fetched content. */
       maxChars?: number;
-      /** Hard cap for maxChars (tool or config), defaults to 50000. */
+      /** Hard cap for maxChars (tool or config), defaults to 20000. */
       maxCharsCap?: number;
-      /** Max download size before truncation, defaults to 2000000. */
+      /** Max download size before truncation, defaults to 750000 bytes. */
       maxResponseBytes?: number;
       /** Timeout in seconds for fetch requests. */
       timeoutSeconds?: number;


### PR DESCRIPTION
## What Problem This Solves

Operator-facing config help, type docs, and gateway docs contradicted shipped behavior in five places — doctrine-class drift ("a competent person following the docs must end with a working bot"):

1. `src/config/schema.help.core.ts` / `src/config/types.gateway.ts` claimed existing-device auto-approval upgrades stay **manual**; the gateway performs same-key scope upgrades for authenticated browser operator clients (59bc78a5b27) and augments default question scope for older clients (bec7d8a1449).
2. `docs/gateway/trusted-proxy-auth.md` omitted `operator.questions` from the default auto-approval scopes and claimed a foreign public key under an existing device ID creates a pending manual request — the gateway rejects the identity mismatch before pairing (`connect-device-proof.ts`), proven by the existing integration test.
3. `src/config/types.tools.ts` documented web-fetch limits as 50,000 chars / 2 MB; shipped defaults have been 20,000 / 750,000 bytes since 4f00b769251 (verified by a real loopback HTTP probe through the actual tool).
4. `docs/gateway/config-tools.md` demonstrated the retired `tools.web.search.apiKey` — a config the schema **rejects** (`zod-schema.agent-runtime.ts` legacy-provider rejection); replaced with the canonical `plugins.entries.brave.config.webSearch.apiKey` shape, validated against both raw and plugin-aware validators (old example fails, new passes).
5. Overbroad prose tightened to the real boundaries: reconnect metadata refresh vs approval planning, question augmentation limited to default-scope auto-approval, generic browser-operator wording matching the shared eligibility path.

A version note scopes the `deviceAutoApprove` examples to beta/current-main: no local stable tag contains the feature (stable `v2026.7.1` schema has no such option), and the published docs page has no release selector.

## Why This Change Was Made

Docs and help text are projections of the owning source (`connect-pairing-approval-plan.ts`, web-fetch constants, the web-search schema); every corrected sentence was verified against that owner, its tests, and its history rather than the audit notes — the audit's original premise (a missing wizard question) was refuted: 9be3cefabdc deliberately asks only loopback consent.

## User Impact

Operators reading the trusted-proxy and web-tool docs now see what the product actually does; the one copy-pasteable web-search example now validates instead of being rejected at load.

## Evidence

- Net **0 executable lines** — the two edited type modules emit byte-identical JavaScript; source changes are comments/help strings (+9/−9), docs +23/−10.
- Validator reproduction: old Brave example `ok:false` (legacy web_search rejection), new example `ok:true`; canonical `auditDocsConfigExamples` on the edited pages: 35 examples, zero findings.
- Real HTTP/tool probe: 800,000-byte response → 20,000 returned chars, 750,000 retained bytes, explicit truncation.
- Focused suites 123 tests green (configure wizard, schema help quality, gateway auth zod, real-WebSocket trusted-proxy auto-approve, web-fetch); full changed-file gate **PASS exit 0**; docs MDX check green post-rebase.
- Two independent Codex autoreview passes clean (worker + deep-review follow-up).
- Named follow-ups (not in this PR): docs-config audit filters miss custom legacy-key rejections (`docs-config-examples.ts:99`); `web-tools.fetch.test.ts` passes retired `fetch.firecrawl` overrides through its loose fixture.
