### PR TITLE
fix: picker sections run together

### DIFF
--- a/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
@@ -17,6 +17,54 @@ const deviceTargets = [
 ];
 
 suite.define(() => {
+  it("spaces destination section headings consistently", async () => {
+    const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      operatorScopes: ["operator.admin", "operator.read", "operator.write"],
+      workspace: WORKSPACE,
+      workspaceGit: true,
+      methodResponses: {
+        "environments.list": {
+          environments: [
+            {
+              id: "node:paired-runner",
+              type: "node",
+              label: "Paired runner",
+              status: "available",
+              sessionHost: true,
+              workerSlots: { total: 2, available: 1 },
+            },
+          ],
+          profiles: [{ id: "aws", providerId: "aws" }],
+        },
+      },
+    });
+
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      await gateway.waitForRequest("environments.list");
+      await page.locator("#new-session-where-trigger").click();
+
+      const headings = page.locator(
+        ".new-session-page__where-popover .new-session-page__menu-title",
+      );
+      await expect
+        .poll(() => headings.allTextContents())
+        .toEqual(["Environments", "Your devices", "Cloud"]);
+      const spacing = await page.evaluate(() =>
+        getComputedStyle(document.documentElement).getPropertyValue("--space-2").trim(),
+      );
+      expect(
+        await headings.evaluateAll((elements) =>
+          elements.map((element) => getComputedStyle(element).marginTop),
+        ),
+      ).toEqual(["0px", spacing, spacing]);
+    } finally {
+      await context.close();
+    }
+  });
+
   it.each(deviceTargets)("dispatches the $name device", async ({ value, target }) => {
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -622,6 +622,12 @@ wa-popover.new-session-page__select::part(body) {
   text-transform: uppercase;
 }
 
+wa-popover.new-session-page__picker-popover
+  .new-session-page__picker-root
+  > .new-session-page__menu-title:not(:first-child) {
+  margin-top: var(--space-2);
+}
+
 .new-session-page__project-search {
   display: block;
   padding: 4px 8px 6px;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where adjacent groups in new-session dropdowns had no vertical separation, making “Environments,” “Your devices,” and “Cloud” read as one dense list. The same issue affected repeated sections such as “Projects” and “Recent.”

Supersedes the closed tooltip experiment in #131243; this PR intentionally contains no info icon or tooltip.

## Why This Change Was Made

Standardizes spacing at the existing new-session dropdown seam: every direct section heading after the first receives `var(--space-2)`. This covers all new-session picker popovers without per-section modifier classes, and intentionally excludes unrelated dropdown implementations and the move-session dialog.

A broader shared dropdown abstraction was not warranted: these pickers already share one root/title structure, while Web Awesome dropdowns and other menus use different markup and spacing contracts.

## User Impact

Location and project picker groups are easier to scan, with consistent 8px token-based separation between sections.

## Evidence

### Location picker

| Before | After |
| --- | --- |
| ![Location picker before](https://github.com/user-attachments/assets/a57c1c4f-ddba-4bcb-a288-0304e3fb3205) | ![Location picker after](https://github.com/user-attachments/assets/74cf0155-4c74-42e8-bc77-d6dec55d2d77) |

Computed heading margins changed from `0 / 0 / 0px` to `0 / 8 / 8px` for Environments / Your devices / Cloud.

### Project picker

| Before | After |
| --- | --- |
| ![Project picker before](https://github.com/user-attachments/assets/7215b79d-cb0b-4c5a-97e8-77a7eb69a4ab) | ![Project picker after](https://github.com/user-attachments/assets/a6a9c388-ce76-4b98-99ca-3721c9138ae4) |

Computed heading margins changed from `0 / 0px` to `0 / 8px` for Projects / Recent.

### Validation

- Regression proof on parent: focused E2E failed with `0 / 0 / 0px`, expected `0 / 8 / 8px`.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts` — 12 passed.
- `node scripts/run-vitest.mjs ui/src/pages/new-session/where-chip.test.ts` — 9 passed.
- `pnpm exec oxfmt --write ui/src/styles/new-session.css ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts` — passed.
- `git diff --check` — passed.

Production LOC: +6/-0 | Tests: +48/-0.
