### PR TITLE
improve: skip re-hashing unchanged worker workspaces after every turn

### DIFF
--- a/src/gateway/worker-environments/node-worker-tunnel.test.ts
+++ b/src/gateway/worker-environments/node-worker-tunnel.test.ts
@@ -21,9 +21,12 @@ import {
   workspaceTransfer,
 } from "./node-worker-tunnel.test-support.js";
 import type { NodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
+import { verifyReconciledWorkspaceFinal } from "./workspace-finalize.js";
 import { serializeWorkerWorkspaceManifest } from "./workspace-manifest.js";
+import { readActualWorkspaceManifest } from "./workspace-reconcile.js";
 
 const workspaceInfo = vi.hoisted(() => vi.fn());
+const workspaceDebug = vi.hoisted(() => vi.fn());
 const tunnelWarn = vi.hoisted(() => vi.fn());
 vi.mock("../../logging/subsystem.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
@@ -32,7 +35,7 @@ vi.mock("../../logging/subsystem.js", async (importOriginal) => {
     createSubsystemLogger: (subsystem: string) => {
       const logger = actual.createSubsystemLogger(subsystem);
       if (subsystem === "gateway/worker-workspace") {
-        return { ...logger, info: workspaceInfo };
+        return { ...logger, debug: workspaceDebug, info: workspaceInfo };
       }
       return subsystem === "gateway/worker-tunnel" ? { ...logger, warn: tunnelWarn } : logger;
     },
@@ -725,6 +728,74 @@ describe("node worker tunnel manager", () => {
         journal: { load: () => undefined, begin: vi.fn(), commit: vi.fn(), abort: vi.fn() },
       }),
     ).rejects.toThrow(error);
+  });
+
+  it("reuses the placement hash memo across node reconciliations", async () => {
+    const record = environment();
+    const localPath = tempDirs.make("node-worker-memo-persist-");
+    const remoteWorkspaceDir = tempDirs.make("node-worker-memo-persist-remote-");
+    const stagingRoot = tempDirs.make("node-worker-memo-persist-staging-");
+    await fs.writeFile(path.join(localPath, "artifact.txt"), "cross turn\n");
+    const actual = await readActualWorkspaceManifest({ root: localPath, baseCommit: null });
+    const raw = serializeWorkerWorkspaceManifest(actual.manifest);
+    const manifestRef = actual.manifestRef;
+    const nodeTransport = transport();
+    nodeTransport.invoke = vi.fn(async () => ({
+      ok: true,
+      payloadJSON: workspaceCommandPayload(remoteWorkspaceDir, { stdout: `${manifestRef}\n` }),
+    }));
+    const transfer = {
+      prepareSync: vi.fn(async () => ({
+        snapshot: { manifest: actual.manifest, manifestRef, rawManifest: raw, root: localPath },
+        token: "download-token",
+      })),
+      prepareUpload: vi.fn(() => "upload-token"),
+      takeUpload: vi.fn(() => ({
+        base: actual.manifest,
+        baseManifestRef: manifestRef,
+        baseRaw: raw,
+        current: actual.manifest,
+        currentManifestRef: manifestRef,
+        currentRaw: raw,
+        stagingRoot,
+      })),
+      close: vi.fn(async () => {}),
+      revoke: vi.fn(),
+    } as unknown as NodeWorkspaceTransferService;
+    const manager = createNodeWorkerTunnelManager({
+      gatewayDeviceId: "gateway-device-1",
+      getEnvironment: () => record,
+      listEnvironments: () => [record],
+      getTransport: () => nodeTransport,
+      launchNodeWorker: vi.fn(),
+      validateWorkerTurn: () => true,
+      workspaceTransfer: transfer,
+    });
+    const handle = await manager.start(startRequest());
+    await handle.syncWorkspace({ localPath, sessionId: "session-1", generation: 1 });
+    const quiescence = { assertActive: async () => {}, resume: async () => {} };
+    const journal = { load: () => undefined, begin: vi.fn(), commit: vi.fn(), abort: vi.fn() };
+    workspaceDebug.mockClear();
+
+    for (let turn = 0; turn < 2; turn += 1) {
+      const reconciliation = await handle.reconcileWorkspace({
+        localPath,
+        remoteWorkspaceDir,
+        baseManifestRef: manifestRef,
+        journal,
+      });
+      await verifyReconciledWorkspaceFinal(reconciliation, quiescence);
+    }
+
+    const reports = workspaceDebug.mock.calls
+      .filter(([message]) => message === "worker workspace reconcile completed")
+      .map(([, data]) => data as { gateway: { contentHashCount: number; memoHitCount: number } });
+    expect(reports).toHaveLength(2);
+    // Turn one hashes the managed worktree; turn two must reuse the
+    // placement-owned memo instead of re-hashing every file.
+    expect(reports[0]!.gateway.contentHashCount).toBeGreaterThan(0);
+    expect(reports[1]!.gateway.contentHashCount).toBe(0);
+    expect(reports[1]!.gateway.memoHitCount).toBeGreaterThan(0);
   });
 
   it("does not republish an accepted manifest already current on the node", async () => {

--- a/src/gateway/worker-environments/node-worker-workspace-actions.ts
+++ b/src/gateway/worker-environments/node-worker-workspace-actions.ts
@@ -6,6 +6,14 @@ import {
 } from "./node-worker-workspace-fallback.js";
 import type { NodeWorkspaceTransferService } from "./node-workspace-transfer-service.js";
 import type { WorkerWorkspaceCommand, WorkerWorkspaceTunnelHandle } from "./tunnel-contract.js";
+import { runInstrumentedWorkspaceReconcile } from "./workspace-finalize.js";
+import {
+  measureLocalWorkspaceReconciliation,
+  pruneWorkspaceHashMemo,
+  withWorkspaceHashMemo,
+  type WorkspaceHashMemo,
+  type WorkspaceReconcileMetrics,
+} from "./workspace-hash-memo.js";
 import { serializeWorkerWorkspaceManifest } from "./workspace-manifest.js";
 import { createWorkerWorkspaceQuiescence } from "./workspace-quiescence.js";
 import {
@@ -86,9 +94,22 @@ export function createNodeWorkerWorkspaceActions(params: {
       await quiescence.resume();
     }
   };
-  const reconcileWorkspace = async (
+  // Same placement-lifetime memo contract as the SSH tunnel owner: stat-identity
+  // keys self-invalidate on change, and without this owner every turn re-hashes
+  // the full managed worktree during prepare/apply/verify.
+  const placementHashMemo: WorkspaceHashMemo = new Map();
+  const reconcileWorkspace = (
     request: Parameters<WorkerWorkspaceTunnelHandle["reconcileWorkspace"]>[0],
+  ) => runInstrumentedWorkspaceReconcile((metrics) => reconcileWorkspaceRun(request, metrics));
+  const reconcileWorkspaceRun = async (
+    request: Parameters<WorkerWorkspaceTunnelHandle["reconcileWorkspace"]>[0],
+    metrics: WorkspaceReconcileMetrics,
   ) => {
+    pruneWorkspaceHashMemo(placementHashMemo);
+    const runLocalReconciliation = <T>(operation: () => Promise<T>): Promise<T> =>
+      measureLocalWorkspaceReconciliation(metrics, () =>
+        withWorkspaceHashMemo(placementHashMemo, operation, metrics.gateway),
+      );
     const pending = request.journal.load();
     if (pending) {
       await recoverWorkerWorkspaceReconciliation({ root: request.localPath, journal: pending });
@@ -173,27 +194,33 @@ export function createNodeWorkerWorkspaceActions(params: {
         }
       };
       const preparedStagedResult = request.stagedResult
-        ? await workerWorkspaceResultStaging.prepareRequestedWorkerWorkspaceResult({
-            request,
-            stagingRoot: uploaded.stagingRoot,
-            currentManifestRef: uploaded.currentManifestRef,
-            baseManifestRaw: uploaded.baseRaw,
-            currentManifestRaw: uploaded.currentRaw,
-            publishAcceptedManifest,
-          })
+        ? await runLocalReconciliation(
+            async () =>
+              await workerWorkspaceResultStaging.prepareRequestedWorkerWorkspaceResult({
+                request,
+                stagingRoot: uploaded.stagingRoot,
+                currentManifestRef: uploaded.currentManifestRef,
+                baseManifestRaw: uploaded.baseRaw,
+                currentManifestRaw: uploaded.currentRaw,
+                publishAcceptedManifest,
+              }),
+          )
         : undefined;
       let appliedWorkspaceResult: WorkerWorkspaceApplyResult | undefined;
       if (!preparedStagedResult) {
-        appliedWorkspaceResult = await applyStagedWorkerWorkspace({
-          root: request.localPath,
-          stagingRoot: uploaded.stagingRoot,
-          baseManifestRef: request.baseManifestRef,
-          currentManifestRef: uploaded.currentManifestRef,
-          base: uploaded.base,
-          current: uploaded.current,
-          journal: request.journal,
-          publishAcceptedManifest,
-        });
+        appliedWorkspaceResult = await runLocalReconciliation(
+          async () =>
+            await applyStagedWorkerWorkspace({
+              root: request.localPath,
+              stagingRoot: uploaded.stagingRoot,
+              baseManifestRef: request.baseManifestRef,
+              currentManifestRef: uploaded.currentManifestRef,
+              base: uploaded.base,
+              current: uploaded.current,
+              journal: request.journal,
+              publishAcceptedManifest,
+            }),
+        );
       }
       return {
         get manifestRef() {
@@ -202,18 +229,23 @@ export function createNodeWorkerWorkspaceActions(params: {
         changed,
         verifyStable,
         verifyLocalStable: async () =>
-          await (appliedWorkspaceResult?.verifyLocalStable() ??
-            assertWorkspaceResultStable({
-              root: request.localPath,
-              base: uploaded.base,
-              current: uploaded.current,
-            })),
+          await runLocalReconciliation(
+            async () =>
+              await (appliedWorkspaceResult?.verifyLocalStable() ??
+                assertWorkspaceResultStable({
+                  root: request.localPath,
+                  base: uploaded.base,
+                  current: uploaded.current,
+                })),
+          ),
         getAppliedWorkspaceResult: () => appliedWorkspaceResult,
         ...(preparedStagedResult
           ? {
               ...preparedStagedResult,
               applyPreparedStagedResult: async () => {
-                await preparedStagedResult.applyPreparedStagedResult();
+                await runLocalReconciliation(
+                  async () => await preparedStagedResult.applyPreparedStagedResult(),
+                );
                 appliedWorkspaceResult = preparedStagedResult.getAppliedWorkspaceResult();
               },
             }

--- a/src/gateway/worker-environments/workspace-finalize.test.ts
+++ b/src/gateway/worker-environments/workspace-finalize.test.ts
@@ -1,13 +1,28 @@
 import { describe, expect, it, vi } from "vitest";
 import {
-  registerWorkspaceReconcileReporter,
+  runInstrumentedWorkspaceReconcile,
   verifyReconciledWorkspaceFinal,
 } from "./workspace-finalize.js";
+
+const workspaceDebug = vi.hoisted(() => vi.fn());
+vi.mock("../../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "gateway/worker-workspace"
+        ? { ...logger, debug: workspaceDebug }
+        : logger;
+    },
+  };
+});
 
 describe("final worker workspace fences", () => {
   it("rechecks remote and local stability after the final quiescence renewal", async () => {
     const log: string[] = [];
-    const reconciliation = {
+    workspaceDebug.mockClear();
+    const reconciliation = await runInstrumentedWorkspaceReconcile(async () => ({
       manifestRef: "sha256:" + "a".repeat(64),
       changed: true,
       verifyStable: async () => {
@@ -16,9 +31,8 @@ describe("final worker workspace fences", () => {
       verifyLocalStable: async () => {
         log.push("local");
       },
-    };
-    const outcomes: string[] = [];
-    registerWorkspaceReconcileReporter(reconciliation, (outcome) => outcomes.push(outcome));
+    }));
+    expect(workspaceDebug).not.toHaveBeenCalled();
     await verifyReconciledWorkspaceFinal(reconciliation, {
       assertActive: async () => {
         log.push("quiescence");
@@ -27,7 +41,10 @@ describe("final worker workspace fences", () => {
     });
 
     expect(log).toEqual(["remote", "local", "quiescence", "remote", "local"]);
-    expect(outcomes).toEqual(["succeeded"]);
+    expect(workspaceDebug).toHaveBeenCalledExactlyOnceWith(
+      "worker workspace reconcile completed",
+      expect.objectContaining({ outcome: "succeeded" }),
+    );
   });
 
   it("rejects a remote write observed after the final quiescence renewal", async () => {

--- a/src/gateway/worker-environments/workspace-finalize.ts
+++ b/src/gateway/worker-environments/workspace-finalize.ts
@@ -1,8 +1,15 @@
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type {
   WorkerWorkspaceQuiescence,
   WorkerWorkspaceReconcileResult,
 } from "./tunnel-contract.js";
+import {
+  createWorkspaceReconcileMetrics,
+  type WorkspaceReconcileMetrics,
+} from "./workspace-hash-memo.js";
 import type { WorkerWorkspaceApplyResult } from "./workspace-reconcile.js";
+
+const workspaceReconcileLog = createSubsystemLogger("gateway/worker-workspace");
 
 export class WorkerWorkspaceFinalFenceError extends Error {
   readonly reclaimDisposition: "retry" | "preserve-result";
@@ -38,11 +45,27 @@ const workspaceReconcileReporters = new WeakMap<
   (outcome: WorkspaceReconcileOutcome) => void
 >();
 
-export function registerWorkspaceReconcileReporter(
-  reconciliation: WorkerWorkspaceReconcileResult,
-  reporter: (outcome: WorkspaceReconcileOutcome) => void,
-): void {
-  workspaceReconcileReporters.set(reconciliation, reporter);
+/** Runs one reconciliation with shared metrics and logs them once the final fence settles. */
+export async function runInstrumentedWorkspaceReconcile(
+  run: (metrics: WorkspaceReconcileMetrics) => Promise<WorkerWorkspaceReconcileResult>,
+): Promise<WorkerWorkspaceReconcileResult> {
+  const metrics = createWorkspaceReconcileMetrics();
+  const startedAt = performance.now();
+  const report = (outcome: WorkspaceReconcileOutcome) => {
+    workspaceReconcileLog.debug("worker workspace reconcile completed", {
+      outcome,
+      durationMs: performance.now() - startedAt,
+      ...metrics,
+    });
+  };
+  try {
+    const reconciliation = await run(metrics);
+    workspaceReconcileReporters.set(reconciliation, report);
+    return reconciliation;
+  } catch (error) {
+    report("failed");
+    throw error;
+  }
 }
 
 function reportWorkspaceReconcile(

--- a/src/gateway/worker-environments/workspace-hash-memo.test.ts
+++ b/src/gateway/worker-environments/workspace-hash-memo.test.ts
@@ -7,9 +7,11 @@ import { runCommandWithTimeout } from "../../process/exec.js";
 import {
   createWorkspaceReconcileMetrics,
   MAX_WORKSPACE_HASH_MEMO_BYTES,
+  pruneWorkspaceHashMemo,
   recordRemoteWorkspaceHashMetrics,
   serializeRemoteWorkspaceHashMemo,
   withWorkspaceHashMemo,
+  type WorkspaceHashMemo,
 } from "./workspace-hash-memo.js";
 import { MAX_RECONCILIATION_ENTRIES, type WorkerWorkspaceManifest } from "./workspace-manifest.js";
 import { preflightWorkspaceApply, readActualWorkspaceManifest } from "./workspace-reconcile.js";
@@ -289,5 +291,27 @@ describe("workspace hash memo", () => {
       memoHitCount: 2,
       memoTruncatedCount: 1,
     });
+  });
+});
+
+describe("placement hash memo pruning", () => {
+  it("keeps a memo under the byte cap and clears one that exceeds it", () => {
+    const retained: WorkspaceHashMemo = new Map([
+      ["worker:1:2:3:4:5", "a".repeat(64)],
+      ["gateway:1:2:3:4:5", "b".repeat(64)],
+    ]);
+    pruneWorkspaceHashMemo(retained);
+    expect(retained.size).toBe(2);
+
+    const digest = "c".repeat(64);
+    const oversized: WorkspaceHashMemo = new Map();
+    let bytes = 0;
+    for (let index = 0; bytes <= MAX_WORKSPACE_HASH_MEMO_BYTES; index += 1) {
+      const identity = `gateway:${index}:0:0:0:0`;
+      oversized.set(identity, digest);
+      bytes += identity.length + digest.length;
+    }
+    pruneWorkspaceHashMemo(oversized);
+    expect(oversized.size).toBe(0);
   });
 });

--- a/src/gateway/worker-environments/workspace-hash-memo.ts
+++ b/src/gateway/worker-environments/workspace-hash-memo.ts
@@ -1,4 +1,6 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { z } from "zod";
+import { MAX_RECONCILIATION_ENTRIES } from "./workspace-manifest.js";
 
 type WorkspaceHashMetrics = {
   contentHashCount: number;
@@ -26,6 +28,54 @@ type RemoteWorkspaceHashMetrics = WorkspaceHashMetrics & {
 };
 
 export const MAX_WORKSPACE_HASH_MEMO_BYTES = 8 * 1024 * 1024;
+
+const MANIFEST_REF_PATTERN = /^sha256:[a-f0-9]{64}$/u;
+const WORKER_HASH_IDENTITY_PATTERN = /^worker:\d+:\d+:\d+:\d+:\d+$/u;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
+const remoteWorkspaceManifestEnvelopeSchema = z
+  .object({
+    version: z.literal(1),
+    manifestRef: z.string().regex(MANIFEST_REF_PATTERN),
+    memo: z
+      .array(
+        z.tuple([z.string().regex(WORKER_HASH_IDENTITY_PATTERN), z.string().regex(SHA256_PATTERN)]),
+      )
+      .max(MAX_RECONCILIATION_ENTRIES),
+    metrics: z
+      .object({
+        contentHashCount: z.number().finite().nonnegative(),
+        contentHashDurationMs: z.number().finite().nonnegative(),
+        memoHitCount: z.number().finite().nonnegative(),
+        memoTruncatedCount: z.number().finite().nonnegative(),
+        totalDurationMs: z.number().finite().nonnegative(),
+      })
+      .strict(),
+  })
+  .strict();
+
+export type RemoteWorkspaceManifestEnvelope = z.infer<typeof remoteWorkspaceManifestEnvelopeSchema>;
+
+/** Parses and validates a memo-v1 capture response from the remote manifest script. */
+export function parseRemoteWorkspaceManifestEnvelope(
+  stdout: string,
+): RemoteWorkspaceManifestEnvelope {
+  return remoteWorkspaceManifestEnvelopeSchema.parse(JSON.parse(stdout));
+}
+
+/** Replaces the memo's worker-owned entries with the latest capture's entries wholesale. */
+export function replaceWorkerWorkspaceHashMemoEntries(
+  memo: WorkspaceHashMemo,
+  entries: RemoteWorkspaceManifestEnvelope["memo"],
+): void {
+  for (const identity of memo.keys()) {
+    if (identity.startsWith("worker:")) {
+      memo.delete(identity);
+    }
+  }
+  for (const [identity, sha256] of entries) {
+    memo.set(identity, sha256);
+  }
+}
 
 type WorkspaceHashContext = {
   memo: WorkspaceHashMemo;
@@ -90,6 +140,17 @@ export function pruneWorkspaceHashMemo(memo: WorkspaceHashMemo): void {
   }
 }
 
+/** Returns the placement-owned memo for a key, pruning it before each reuse. */
+export function takeWorkspaceHashMemo(
+  store: Map<string, WorkspaceHashMemo>,
+  key: string,
+): WorkspaceHashMemo {
+  const memo = store.get(key) ?? new Map();
+  pruneWorkspaceHashMemo(memo);
+  store.set(key, memo);
+  return memo;
+}
+
 export function serializeRemoteWorkspaceHashMemo(memo: WorkspaceHashMemo): string {
   const serialized = JSON.stringify(
     [...memo]
@@ -127,7 +188,13 @@ export async function measureLocalWorkspaceReconciliation<T>(
 
 export function workspaceStatIdentity(
   owner: "gateway" | "worker",
-  stats: { dev: bigint; ino: bigint; size: bigint; mtimeNs: bigint; ctimeNs: bigint },
+  stats: {
+    dev: bigint;
+    ino: bigint;
+    size: bigint;
+    mtimeNs: bigint;
+    ctimeNs: bigint;
+  },
 ): string {
   return `${owner}:${stats.dev}:${stats.ino}:${stats.size}:${stats.mtimeNs}:${stats.ctimeNs}`;
 }

--- a/src/gateway/worker-environments/workspace-hash-memo.ts
+++ b/src/gateway/worker-environments/workspace-hash-memo.ts
@@ -74,6 +74,22 @@ export async function withWorkspaceHashContext<T>(operation: () => Promise<T>): 
   return await withWorkspaceHashMemo(active?.memo ?? new Map(), operation, active?.metrics);
 }
 
+// A placement-lifetime memo self-bounds its worker entries (each remote capture
+// replaces them wholesale) but gateway entries accumulate as stat identities
+// change across turns. Reset the whole memo once its estimated footprint
+// crosses the shared byte cap so one placement cannot hold unbounded hash state.
+export function pruneWorkspaceHashMemo(memo: WorkspaceHashMemo): void {
+  let bytes = 0;
+  for (const [identity, sha256] of memo) {
+    // Identities and digests are ASCII, so string length equals byte length.
+    bytes += identity.length + sha256.length;
+    if (bytes > MAX_WORKSPACE_HASH_MEMO_BYTES) {
+      memo.clear();
+      return;
+    }
+  }
+}
+
 export function serializeRemoteWorkspaceHashMemo(memo: WorkspaceHashMemo): string {
   const serialized = JSON.stringify(
     [...memo]

--- a/src/gateway/worker-environments/workspace-sync-helpers.ts
+++ b/src/gateway/worker-environments/workspace-sync-helpers.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { z } from "zod";
 import { redactSensitiveText } from "../../logging/redact.js";
 import type { CommandOptions, SpawnResult } from "../../process/exec.js";
 import { WORKER_BUNDLE_RSYNC_RECEIVER_PATH } from "../../shared/worker-bundle-hash.js";
@@ -15,37 +14,16 @@ import {
 } from "./ssh.js";
 import type { WorkerWorkspaceCommand, WorkerWorkspaceSyncRequest } from "./tunnel-contract.js";
 import {
+  parseRemoteWorkspaceManifestEnvelope,
   recordRemoteWorkspaceHashMetrics,
+  replaceWorkerWorkspaceHashMemoEntries,
   serializeRemoteWorkspaceHashMemo,
   type WorkspaceHashMemo,
   type WorkspaceReconcileMetrics,
 } from "./workspace-hash-memo.js";
-import { MAX_RECONCILIATION_ENTRIES } from "./workspace-manifest.js";
 import { REMOTE_WORKSPACE_MANIFEST_JS } from "./workspace-sync-scripts.js";
 
 const MANIFEST_REF_PATTERN = /^sha256:[a-f0-9]{64}$/u;
-const WORKER_HASH_IDENTITY_PATTERN = /^worker:\d+:\d+:\d+:\d+:\d+$/u;
-const SHA256_PATTERN = /^[a-f0-9]{64}$/u;
-const remoteWorkspaceManifestEnvelopeSchema = z
-  .object({
-    version: z.literal(1),
-    manifestRef: z.string().regex(MANIFEST_REF_PATTERN),
-    memo: z
-      .array(
-        z.tuple([z.string().regex(WORKER_HASH_IDENTITY_PATTERN), z.string().regex(SHA256_PATTERN)]),
-      )
-      .max(MAX_RECONCILIATION_ENTRIES),
-    metrics: z
-      .object({
-        contentHashCount: z.number().finite().nonnegative(),
-        contentHashDurationMs: z.number().finite().nonnegative(),
-        memoHitCount: z.number().finite().nonnegative(),
-        memoTruncatedCount: z.number().finite().nonnegative(),
-        totalDurationMs: z.number().finite().nonnegative(),
-      })
-      .strict(),
-  })
-  .strict();
 const INBOUND_QUOTA_INITIAL_POLL_MS = 25;
 const INBOUND_QUOTA_MAX_POLL_MS = 250;
 export const WORKER_WORKSPACE_RSYNC_DESTINATION = "openclaw-rsync-destination";
@@ -55,7 +33,9 @@ export type WorkerWorkspaceActionsOptions = {
   sharedHost?: boolean;
   ownerSignal: AbortSignal;
   waitForPrepared: () => Promise<PreparedWorkerSsh>;
-  runner: { run(argv: string[], options: CommandOptions): Promise<SpawnResult> };
+  runner: {
+    run(argv: string[], options: CommandOptions): Promise<SpawnResult>;
+  };
   tasks: Set<Promise<unknown>>;
   bundleHash: string;
 };
@@ -85,7 +65,9 @@ export function workerWorkspaceCommandSucceeded(result: SpawnResult): boolean {
 }
 
 export function workspaceSyncError(result: SpawnResult): Error {
-  const detail = redactSensitiveText(result.stderr || result.stdout, { mode: "tools" })
+  const detail = redactSensitiveText(result.stderr || result.stdout, {
+    mode: "tools",
+  })
     .replace(/\s+/gu, " ")
     .trim();
   return new Error(
@@ -265,20 +247,13 @@ export async function captureRemoteWorkspaceManifest(params: {
   }
   let response;
   try {
-    response = remoteWorkspaceManifestEnvelopeSchema.parse(JSON.parse(captured.stdout));
+    response = parseRemoteWorkspaceManifestEnvelope(captured.stdout);
   } catch (error) {
     throw new Error("Worker workspace manifest returned an invalid memo response", {
       cause: error,
     });
   }
-  for (const identity of params.hashMemo.keys()) {
-    if (identity.startsWith("worker:")) {
-      params.hashMemo.delete(identity);
-    }
-  }
-  for (const [identity, sha256] of response.memo) {
-    params.hashMemo.set(identity, sha256);
-  }
+  replaceWorkerWorkspaceHashMemoEntries(params.hashMemo, response.memo);
   recordRemoteWorkspaceHashMetrics(params.metrics, response.metrics);
   return response.manifestRef;
 }
@@ -333,7 +308,10 @@ export async function resolveWorkerWorkspaceGitAuthor(
     return workerWorkspaceCommandSucceeded(result) ? result.stdout.trim() : "";
   };
   const [name, email] = await Promise.all([read("name"), read("email")]);
-  return { name: request.gitAuthor?.name ?? name, email: request.gitAuthor?.email ?? email };
+  return {
+    name: request.gitAuthor?.name ?? name,
+    email: request.gitAuthor?.email ?? email,
+  };
 }
 
 export function stableWorkerPathComponent(value: string, length: number): string {

--- a/src/gateway/worker-environments/workspace-sync-tunnel.memo.test.ts
+++ b/src/gateway/worker-environments/workspace-sync-tunnel.memo.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  localWorkspaceRunner,
+  memoryWorkspaceJournal,
+  startConnectedTunnel,
+} from "./tunnel.test-support.js";
+
+describe("worker tunnel manager hash memo", () => {
+  it("persists the workspace hash memo across reconciliations for one placement", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worker-memo-persist-"));
+    const localPath = path.join(root, "local");
+    const remoteHome = path.join(root, "remote-home");
+    await Promise.all([
+      fs.mkdir(localPath, { recursive: true }),
+      fs.mkdir(remoteHome, { recursive: true }),
+    ]);
+    await fs.writeFile(path.join(localPath, "artifact.txt"), "cross-turn content\n");
+    // Manifest captures end with the literal memo-v1 argument; the resolve and
+    // setup commands only carry it inside the embedded script source.
+    const isMemoCapture = (argv: readonly string[]) =>
+      argv[0] === "ssh" && (argv.at(-1)?.endsWith("'memo-v1'") ?? false);
+    const captureEnvelopes: Array<{
+      metrics: { contentHashCount: number; memoHitCount: number };
+    }> = [];
+    const fake = localWorkspaceRunner(remoteHome, undefined, (argv, result) => {
+      if (isMemoCapture(argv)) {
+        captureEnvelopes.push(JSON.parse(result.stdout));
+      }
+    });
+    const { handle } = await startConnectedTunnel(fake, "worker:memo-persist", 3);
+
+    try {
+      const synced = await handle.syncWorkspace({
+        localPath,
+        sessionId: "session:memo-persist",
+        generation: 1,
+      });
+      expect(synced.mode).toBe("plain");
+      let acceptedManifestRef = synced.manifestRef;
+      const journal = memoryWorkspaceJournal((manifestRef) => {
+        acceptedManifestRef = manifestRef;
+      });
+      const memoInputs = () =>
+        fake.runs
+          .filter((entry) => isMemoCapture(entry.argv))
+          .map((entry) => JSON.parse(entry.options.input as string) as [string, string][]);
+
+      const first = await handle.reconcileWorkspace({
+        localPath,
+        remoteWorkspaceDir: synced.remoteWorkspaceDir,
+        baseManifestRef: synced.manifestRef,
+        journal,
+      });
+      expect(first.changed).toBe(false);
+      const firstTurnCaptures = memoInputs().length;
+      // The placement's first reconciliation necessarily starts empty.
+      expect(memoInputs()[0]).toEqual([]);
+
+      const second = await handle.reconcileWorkspace({
+        localPath,
+        remoteWorkspaceDir: synced.remoteWorkspaceDir,
+        baseManifestRef: acceptedManifestRef,
+        journal,
+      });
+      expect(second.changed).toBe(false);
+      // The second turn's first capture must reuse the prior turn's worker
+      // entries; a per-call memo would send an empty payload again.
+      const secondTurnFirstInput = memoInputs()[firstTurnCaptures]!;
+      expect(secondTurnFirstInput.length).toBeGreaterThan(0);
+      expect(secondTurnFirstInput.every(([identity]) => identity.startsWith("worker:"))).toBe(true);
+      const secondTurnFirstEnvelope = captureEnvelopes[firstTurnCaptures]!;
+      expect(secondTurnFirstEnvelope.metrics.contentHashCount).toBe(0);
+      expect(secondTurnFirstEnvelope.metrics.memoHitCount).toBeGreaterThan(0);
+    } finally {
+      await handle.stop();
+      await fs.rm(root, { recursive: true });
+    }
+  }, 60_000);
+});

--- a/src/gateway/worker-environments/workspace-sync.ts
+++ b/src/gateway/worker-environments/workspace-sync.ts
@@ -3,7 +3,6 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { withTimeout } from "../../infra/fs-safe.js";
-import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { CommandOptions, SpawnResult } from "../../process/exec.js";
 import { type PreparedWorkerSsh, runWorkerSshCandidates, workerSshCommandOptions } from "./ssh.js";
 import type {
@@ -18,12 +17,13 @@ import {
   createAcceptedWorkspacePublisherFactory,
   recoverAcceptedWorkspacePublication,
 } from "./workspace-accepted-sync.js";
-import { registerWorkspaceReconcileReporter } from "./workspace-finalize.js";
+import { runInstrumentedWorkspaceReconcile } from "./workspace-finalize.js";
 import {
-  createWorkspaceReconcileMetrics,
   MAX_WORKSPACE_HASH_MEMO_BYTES,
   measureLocalWorkspaceReconciliation,
+  pruneWorkspaceHashMemo,
   withWorkspaceHashMemo,
+  type WorkspaceHashMemo,
   type WorkspaceReconcileMetrics,
 } from "./workspace-hash-memo.js";
 import { MAX_WORKSPACE_MANIFEST_BYTES } from "./workspace-inventory-limits.js";
@@ -84,7 +84,6 @@ const REMOTE_WORKSPACE_ROOT = ".openclaw-worker/workspaces";
 const REMOTE_GIT_PACK_NAME = ".openclaw-base.pack";
 const GIT_COMMIT_PATTERN = /^[a-f0-9]{40}(?:[a-f0-9]{24})?$/u;
 const INBOUND_RSYNC_BW_LIMIT_KIB = 65_536;
-const workspaceSyncLog = createSubsystemLogger("gateway/worker-workspace");
 
 /** Binds workspace commands and synchronization to one connected tunnel owner. */
 export function createWorkerWorkspaceActions(
@@ -188,6 +187,13 @@ export function createWorkerWorkspaceActions(
         ),
     );
   };
+
+  // Stat-identity keys self-invalidate when files change, so this memo safely
+  // outlives one reconciliation. Owning it here scopes it to the connected
+  // tunnel owner: one placement epoch, dropped with the tunnel entry. Remote
+  // (`worker:`) entries round-trip through each memo-v1 capture; without this
+  // owner every turn re-hashes the full tree on both sides.
+  const placementHashMemo: WorkspaceHashMemo = new Map();
 
   const quiesceWorkspace = createWorkerWorkspaceQuiescence({
     ownerSignal: options.ownerSignal,
@@ -442,7 +448,8 @@ export function createWorkerWorkspaceActions(
       await recoverWorkerWorkspaceReconciliation({ root: request.localPath, journal: pending });
       request.journal.abort();
     }
-    const hashMemo = new Map<string, string>();
+    pruneWorkspaceHashMemo(placementHashMemo);
+    const hashMemo = placementHashMemo;
     const runLocalReconciliation = <T>(operation: () => Promise<T>): Promise<T> =>
       measureLocalWorkspaceReconciliation(metrics, () =>
         withWorkspaceHashMemo(hashMemo, operation, metrics.gateway),
@@ -668,27 +675,10 @@ export function createWorkerWorkspaceActions(
     }
   };
 
-  const reconcileWorkspaceImpl = async (
+  const reconcileWorkspaceImpl = (
     request: WorkerWorkspaceReconcileRequest,
-  ): Promise<WorkerWorkspaceReconcileResult> => {
-    const metrics = createWorkspaceReconcileMetrics();
-    const startedAt = performance.now();
-    const report = (outcome: "failed" | "succeeded") => {
-      workspaceSyncLog.debug("worker workspace reconcile completed", {
-        outcome,
-        durationMs: performance.now() - startedAt,
-        ...metrics,
-      });
-    };
-    try {
-      const reconciliation = await reconcileWorkspaceRun(request, metrics);
-      registerWorkspaceReconcileReporter(reconciliation, report);
-      return reconciliation;
-    } catch (error) {
-      report("failed");
-      throw error;
-    }
-  };
+  ): Promise<WorkerWorkspaceReconcileResult> =>
+    runInstrumentedWorkspaceReconcile((metrics) => reconcileWorkspaceRun(request, metrics));
 
   return {
     quiesceWorkspace,

--- a/src/node-host/node-worker-transfer-client.memo.test.ts
+++ b/src/node-host/node-worker-transfer-client.memo.test.ts
@@ -1,0 +1,111 @@
+import { createHash } from "node:crypto";
+import { createServer as createHttpServer, type Server as HttpServer } from "node:http";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { serializeWorkerWorkspaceManifest } from "../gateway/worker-environments/workspace-manifest.js";
+import { runNodeWorkerWorkspaceTransfer } from "./node-worker-transfer-client.js";
+
+const workspaceDebug = vi.hoisted(() => vi.fn());
+vi.mock("../logging/subsystem.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../logging/subsystem.js")>();
+  return {
+    ...actual,
+    createSubsystemLogger: (subsystem: string) => {
+      const logger = actual.createSubsystemLogger(subsystem);
+      return subsystem === "node-host/worker-workspace"
+        ? { ...logger, debug: workspaceDebug }
+        : logger;
+    },
+  };
+});
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+async function listen(server: HttpServer): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("test transfer server did not bind");
+  }
+  return `ws://127.0.0.1:${address.port}`;
+}
+
+describe("node worker transfer client hash memo", () => {
+  it("reuses the placement hash memo across download and upload captures", async () => {
+    workspaceDebug.mockClear();
+    const root = tempDirs.make("node-worker-transfer-memo-");
+    const workspaceDir = path.join(root, "workspace");
+    const body = Buffer.from("memoized content\n");
+    const sha256 = createHash("sha256").update(body).digest("hex");
+    const rawManifest = serializeWorkerWorkspaceManifest({
+      version: 1,
+      baseCommit: null,
+      entries: [{ path: "artifact.txt", type: "file", mode: 0o644, size: body.byteLength, sha256 }],
+    });
+    const manifestRef = `sha256:${createHash("sha256").update(rawManifest).digest("hex")}`;
+    const server = createHttpServer((req, res) => {
+      void (async () => {
+        if (req.url?.endsWith("/manifest")) {
+          res.writeHead(200).end(rawManifest);
+          return;
+        }
+        if (req.url?.endsWith(`/blobs/${sha256}`)) {
+          res.writeHead(200).end(body);
+          return;
+        }
+        if (req.method === "POST" && req.url?.includes("/reconciliations/")) {
+          for await (const chunk of req) {
+            void chunk;
+          }
+          res.writeHead(200).end(JSON.stringify({ manifestRef }));
+          return;
+        }
+        res.writeHead(404).end();
+      })().catch((error: unknown) => {
+        res.destroy(error instanceof Error ? error : new Error(String(error)));
+      });
+    });
+    const gatewayUrl = await listen(server);
+    const hashMemo = new Map<string, string>();
+    try {
+      await expect(
+        runNodeWorkerWorkspaceTransfer({
+          gatewayUrl,
+          environmentId: "environment-memo",
+          workspaceDir,
+          manifestHome: root,
+          transfer: { direction: "download", token: "download-token", manifestRef },
+          hashMemo,
+        }),
+      ).resolves.toBe(manifestRef);
+      await expect(
+        runNodeWorkerWorkspaceTransfer({
+          gatewayUrl,
+          environmentId: "environment-memo",
+          workspaceDir,
+          manifestHome: root,
+          transfer: { direction: "upload", token: "upload-token", baseManifestRef: manifestRef },
+          hashMemo,
+        }),
+      ).resolves.toBe(manifestRef);
+      const captures = workspaceDebug.mock.calls
+        .filter(([message]) => message === "node worker manifest capture completed")
+        .map(([, data]) => data as { contentHashCount: number; memoHitCount: number });
+      expect(captures).toHaveLength(2);
+      // Download verifies fresh staging files by hashing; the unchanged upload
+      // capture must reuse the memo seeded through the workspace rename.
+      expect(captures[0]!.contentHashCount).toBe(1);
+      expect(captures[1]!.contentHashCount).toBe(0);
+      expect(captures[1]!.memoHitCount).toBe(1);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+});

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -5,6 +5,7 @@ import fsp from "node:fs/promises";
 import type { ClientRequest, IncomingMessage } from "node:http";
 import path from "node:path";
 import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
+import type { WorkspaceHashMemo } from "../gateway/worker-environments/workspace-hash-memo.js";
 import {
   MAX_WORKSPACE_MANIFEST_BYTES,
   MAX_WORKSPACE_INVENTORY_TOTAL_BYTES,
@@ -19,7 +20,7 @@ import { REMOTE_WORKSPACE_MANIFEST_JS } from "../gateway/worker-environments/wor
 import { isPathInside } from "../infra/path-guards.js";
 import { tempWorkspace } from "../infra/private-temp-workspace.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { runCommandWithTimeout, runExec } from "../process/exec.js";
+import { runExec } from "../process/exec.js";
 import {
   nodeWorkspaceTransferBlobPath,
   NodeWorkerWorkspaceTransferError,
@@ -33,8 +34,13 @@ import {
   openNodeWorkerTransferHttpRequest,
   type NodeWorkerTransferHttpRequest,
 } from "./node-worker-transfer-http.js";
+import {
+  captureManifest,
+  runWorkspaceCommand,
+  TRANSFER_TIMEOUT_MS,
+  workspaceCommandEnv,
+} from "./node-worker-workspace-commands.js";
 
-const TRANSFER_TIMEOUT_MS = 10 * 60_000;
 const TRANSFER_RESULT_MAX_BYTES = 64 * 1024;
 const transferLog = createSubsystemLogger("node-host/worker-workspace");
 
@@ -88,7 +94,10 @@ async function downloadFile(params: {
 }): Promise<void> {
   const response = await openNodeWorkerTransferHttpRequest(params.request);
   await requireOk(response);
-  const output = fs.createWriteStream(params.destination, { flags: "wx", mode: 0o600 });
+  const output = fs.createWriteStream(params.destination, {
+    flags: "wx",
+    mode: 0o600,
+  });
   const hash = createHash("sha256");
   let bytes = 0;
   try {
@@ -129,75 +138,6 @@ function workspacePath(root: string, relative: string): string {
     throw new Error("workspace transfer manifest escaped its workspace");
   }
   return candidate;
-}
-
-function workspaceCommandEnv(homeDir: string): NodeJS.ProcessEnv {
-  return {
-    ...process.env,
-    HOME: homeDir,
-    ...(process.platform === "win32" ? { USERPROFILE: homeDir } : {}),
-    GCM_INTERACTIVE: "Never",
-    GIT_ASKPASS: "",
-    GIT_CONFIG_GLOBAL: process.platform === "win32" ? "NUL" : "/dev/null",
-    GIT_CONFIG_NOSYSTEM: "1",
-    GIT_TERMINAL_PROMPT: "0",
-    SSH_ASKPASS: "",
-  };
-}
-
-async function runWorkspaceCommand(params: {
-  workspaceDir: string;
-  homeDir: string;
-  argv: string[];
-  input?: string | Uint8Array;
-  signal?: AbortSignal;
-  maxOutputBytes?: number;
-}): Promise<string> {
-  const maxOutputBytes = params.maxOutputBytes ?? 128 * 1024;
-  const result = await runCommandWithTimeout(params.argv, {
-    cwd: params.workspaceDir,
-    baseEnv: workspaceCommandEnv(params.homeDir),
-    ...(params.input === undefined ? {} : { input: params.input }),
-    timeoutMs: TRANSFER_TIMEOUT_MS,
-    signal: params.signal,
-    maxOutputBytes,
-    maxCombinedOutputBytes: maxOutputBytes + 128 * 1024,
-  });
-  if (result.termination !== "exit" || result.code !== 0) {
-    throw new Error(`workspace transfer apply failed: ${(result.stderr || result.stdout).trim()}`);
-  }
-  return result.stdout;
-}
-
-async function captureManifest(params: {
-  workspaceDir: string;
-  manifestHome: string;
-  baseCommit: string | null;
-  referenceManifestRef: string;
-  signal?: AbortSignal;
-}): Promise<string> {
-  return (
-    await runWorkspaceCommand({
-      workspaceDir: params.workspaceDir,
-      homeDir: params.manifestHome,
-      argv: [
-        "node",
-        "-e",
-        REMOTE_WORKSPACE_MANIFEST_JS,
-        params.workspaceDir,
-        params.baseCommit ?? "",
-        ...(process.platform === "win32"
-          ? [
-              params.baseCommit ? "eligible" : "all",
-              params.referenceManifestRef.slice("sha256:".length),
-            ]
-          : params.baseCommit
-            ? ["eligible"]
-            : []),
-      ],
-      signal: params.signal,
-    })
-  ).trim();
 }
 
 async function initializeGitWorkspace(params: {
@@ -379,7 +319,9 @@ async function replaceWorkspace(workspaceDir: string, staging: string): Promise<
         const recoveryError = new Error(`workspace transfer rollback failed; recover ${backup}`, {
           cause: error,
         });
-        Object.defineProperty(recoveryError, "rollbackError", { value: rollbackError });
+        Object.defineProperty(recoveryError, "rollbackError", {
+          value: rollbackError,
+        });
         throw recoveryError;
       }
     }
@@ -399,6 +341,7 @@ async function downloadWorkspace(params: {
   workspaceDir: string;
   manifestHome: string;
   transfer: Extract<NodeWorkerWorkspaceTransferInput, { direction: "download" }>;
+  hashMemo?: WorkspaceHashMemo;
   signal?: AbortSignal;
 }): Promise<string> {
   const startedAt = performance.now();
@@ -475,7 +418,10 @@ async function downloadWorkspace(params: {
     }
     const blobApplyStartedAt = performance.now();
     for (const directory of manifest.directories ?? []) {
-      await fsp.mkdir(workspacePath(staging, directory), { recursive: true, mode: 0o700 });
+      await fsp.mkdir(workspacePath(staging, directory), {
+        recursive: true,
+        mode: 0o700,
+      });
     }
     for (const entry of manifest.entries) {
       const destination = workspacePath(staging, entry.path);
@@ -486,7 +432,10 @@ async function downloadWorkspace(params: {
       if (manifest.baseCommit && (await absoluteEntryMatches(destination, materializedEntry))) {
         continue;
       }
-      await fsp.mkdir(path.dirname(destination), { recursive: true, mode: 0o700 });
+      await fsp.mkdir(path.dirname(destination), {
+        recursive: true,
+        mode: 0o700,
+      });
       await fsp.rm(destination, { recursive: true, force: true });
       if (entry.type === "symlink") {
         await fsp.symlink(entry.target, destination);
@@ -509,11 +458,14 @@ async function downloadWorkspace(params: {
       await fsp.chmod(destination, entry.mode);
     }
     const blobApplyMs = performance.now() - blobApplyStartedAt;
+    // Staging identities are fresh, so this capture re-hashes; its memo output
+    // survives the rename into workspaceDir and seeds the next upload capture.
     const observed = await captureManifest({
       workspaceDir: staging,
       manifestHome: params.manifestHome,
       baseCommit: manifest.baseCommit,
       referenceManifestRef: params.transfer.manifestRef,
+      ...(params.hashMemo === undefined ? {} : { hashMemo: params.hashMemo }),
       signal: params.signal,
     });
     if (observed !== params.transfer.manifestRef) {
@@ -557,6 +509,7 @@ async function uploadWorkspace(params: {
   workspaceDir: string;
   manifestHome: string;
   transfer: Extract<NodeWorkerWorkspaceTransferInput, { direction: "upload" }>;
+  hashMemo?: WorkspaceHashMemo;
   signal?: AbortSignal;
 }): Promise<string> {
   const baseRaw = await fsp.readFile(
@@ -574,6 +527,7 @@ async function uploadWorkspace(params: {
     manifestHome: params.manifestHome,
     baseCommit: base.baseCommit,
     referenceManifestRef: params.transfer.baseManifestRef,
+    ...(params.hashMemo === undefined ? {} : { hashMemo: params.hashMemo }),
     signal: params.signal,
   });
   const currentRaw = await fsp.readFile(
@@ -646,6 +600,7 @@ export async function runNodeWorkerWorkspaceTransfer(params: {
   workspaceDir: string;
   manifestHome: string;
   transfer: NodeWorkerWorkspaceTransferInput;
+  hashMemo?: WorkspaceHashMemo;
   signal?: AbortSignal;
 }): Promise<string> {
   try {

--- a/src/node-host/node-worker-workspace-commands.ts
+++ b/src/node-host/node-worker-workspace-commands.ts
@@ -1,0 +1,108 @@
+import {
+  MAX_WORKSPACE_HASH_MEMO_BYTES,
+  parseRemoteWorkspaceManifestEnvelope,
+  replaceWorkerWorkspaceHashMemoEntries,
+  serializeRemoteWorkspaceHashMemo,
+  type WorkspaceHashMemo,
+} from "../gateway/worker-environments/workspace-hash-memo.js";
+import { REMOTE_WORKSPACE_MANIFEST_JS } from "../gateway/worker-environments/workspace-sync-scripts.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { runCommandWithTimeout } from "../process/exec.js";
+
+export const TRANSFER_TIMEOUT_MS = 10 * 60_000;
+const commandLog = createSubsystemLogger("node-host/worker-workspace");
+
+/** Environment for node-owned workspace commands: pinned HOME, no credential prompts. */
+export function workspaceCommandEnv(homeDir: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HOME: homeDir,
+    ...(process.platform === "win32" ? { USERPROFILE: homeDir } : {}),
+    GCM_INTERACTIVE: "Never",
+    GIT_ASKPASS: "",
+    GIT_CONFIG_GLOBAL: process.platform === "win32" ? "NUL" : "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_TERMINAL_PROMPT: "0",
+    SSH_ASKPASS: "",
+  };
+}
+
+/** Runs one workspace-scoped command and returns stdout, failing on nonzero exit. */
+export async function runWorkspaceCommand(params: {
+  workspaceDir: string;
+  homeDir: string;
+  argv: string[];
+  input?: string | Uint8Array;
+  signal?: AbortSignal;
+  maxOutputBytes?: number;
+}): Promise<string> {
+  const maxOutputBytes = params.maxOutputBytes ?? 128 * 1024;
+  const result = await runCommandWithTimeout(params.argv, {
+    cwd: params.workspaceDir,
+    baseEnv: workspaceCommandEnv(params.homeDir),
+    ...(params.input === undefined ? {} : { input: params.input }),
+    timeoutMs: TRANSFER_TIMEOUT_MS,
+    signal: params.signal,
+    maxOutputBytes,
+    maxCombinedOutputBytes: maxOutputBytes + 128 * 1024,
+  });
+  if (result.termination !== "exit" || result.code !== 0) {
+    throw new Error(`workspace transfer apply failed: ${(result.stderr || result.stdout).trim()}`);
+  }
+  return result.stdout;
+}
+
+/**
+ * Captures the workspace manifest with the shared remote script. With a hash
+ * memo the capture round-trips memo-v1 so unchanged files reuse prior hashes.
+ */
+export async function captureManifest(params: {
+  workspaceDir: string;
+  manifestHome: string;
+  baseCommit: string | null;
+  referenceManifestRef: string;
+  hashMemo?: WorkspaceHashMemo;
+  signal?: AbortSignal;
+}): Promise<string> {
+  const memoMode = params.hashMemo !== undefined;
+  const stdout = (
+    await runWorkspaceCommand({
+      workspaceDir: params.workspaceDir,
+      homeDir: params.manifestHome,
+      argv: [
+        "node",
+        "-e",
+        REMOTE_WORKSPACE_MANIFEST_JS,
+        params.workspaceDir,
+        params.baseCommit ?? "",
+        ...(process.platform === "win32"
+          ? [
+              params.baseCommit ? "eligible" : "all",
+              params.referenceManifestRef.slice("sha256:".length),
+            ]
+          : params.baseCommit
+            ? ["eligible"]
+            : []),
+        ...(memoMode ? ["memo-v1"] : []),
+      ],
+      ...(params.hashMemo === undefined
+        ? {}
+        : {
+            input: serializeRemoteWorkspaceHashMemo(params.hashMemo),
+            // The memo round-trip returns up to the memo byte cap on stdout.
+            maxOutputBytes: MAX_WORKSPACE_HASH_MEMO_BYTES + 128 * 1024,
+          }),
+      signal: params.signal,
+    })
+  ).trim();
+  if (params.hashMemo === undefined) {
+    return stdout;
+  }
+  const envelope = parseRemoteWorkspaceManifestEnvelope(stdout);
+  replaceWorkerWorkspaceHashMemoEntries(params.hashMemo, envelope.memo);
+  commandLog.debug("node worker manifest capture completed", {
+    workspaceDir: params.workspaceDir,
+    ...envelope.metrics,
+  });
+  return envelope.manifestRef;
+}

--- a/src/node-host/node-worker-workspace.ts
+++ b/src/node-host/node-worker-workspace.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
+import { takeWorkspaceHashMemo } from "../gateway/worker-environments/workspace-hash-memo.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { KeyedAsyncQueue } from "../plugin-sdk/keyed-async-queue.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -281,6 +282,8 @@ export class NodeWorkerWorkspaceRuntime {
   private readonly acceptedSnapshots = new Map<string, AcceptedRetainSnapshot>();
   private readonly activeWorkspaceOperations = new Map<string, number>();
   private readonly latestTransferredManifest = new Map<string, string>();
+  // Per-generation capture hash memo; lets upload captures skip re-hashing unchanged trees.
+  private readonly workspaceHashMemos = new Map<string, Map<string, string>>();
   private readonly deletingWorkspaceGenerations = new Set<string>();
   private readonly activeRetainProtections = new Map<string, Set<Set<string>>>();
 
@@ -533,6 +536,7 @@ export class NodeWorkerWorkspaceRuntime {
             deleted += 1;
             if (parseGenerationName(path.basename(candidate.path)) !== undefined) {
               this.latestTransferredManifest.delete(candidate.generationKey);
+              this.workspaceHashMemos.delete(candidate.generationKey);
             }
           }
         }
@@ -673,6 +677,7 @@ export class NodeWorkerWorkspaceRuntime {
           if (!gateway?.url) {
             throw new Error("INVALID_REQUEST: workspace transfer gateway is unavailable");
           }
+          const hashMemo = takeWorkspaceHashMemo(this.workspaceHashMemos, generationKey);
           const stdout = await runNodeWorkerWorkspaceTransfer({
             gatewayUrl: gateway.url,
             gatewayTlsFingerprint: gateway.tlsFingerprint,
@@ -681,6 +686,7 @@ export class NodeWorkerWorkspaceRuntime {
             workspaceDir: workspacePath,
             manifestHome: sessionRoot,
             transfer: input.transfer,
+            hashMemo,
             signal,
           });
           // A snapshot sent before this transfer knows only the old base. Keep the latest


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where every completed turn on a cloud/device worker re-hashed the entire workspace on both the gateway and the worker, even when nothing changed. On large trees (an openclaw-sized checkout, ~25k files) this added a ~60s+ tail to every turn: the stat-identity hash memo was created fresh per reconcile call, so no hash ever survived to the next turn, and the node-worker path had no hash context at all.

## Why This Change Was Made

The memo is now owned for the lifetime of a placement instead of one reconcile call: the SSH and node-worker tunnel owners keep it in their owner closure on the gateway, and `NodeWorkerWorkspaceRuntime` keeps a per-generation memo on the node device, with the node-side capture round-tripping the existing memo-v1 protocol. Stat-identity keys self-invalidate when a file changes, and the memo is pruned against the shared 8 MB cap on every use and dropped with its workspace generation. Gitignore-aware eligibility was deliberately left as a design note rather than shipped here.

## User Impact

Turns on remote workers with large workspaces complete substantially faster: after the first capture, reconciling an unchanged tree performs zero content hashing on either side. No behavior changes for unchanged files' correctness — a modified file's stat identity changes, so it is always re-hashed.

## Evidence

- New regression tests assert memo reuse via capture metrics on all three paths: `workspace-sync-tunnel.memo.test.ts` (SSH), `node-worker-tunnel.test.ts` (node path, gateway side: turn two reports `contentHashCount: 0`, `memoHitCount > 0`), and `node-worker-transfer-client.memo.test.ts` (node device: an unchanged upload capture after a download hashes zero files because the memo survives the staging rename).
- Focused suites: 125 passed / 2 skipped across the transfer client, workspace retention, tunnel, hash memo, sync memo, and finalize suites.
- Synthetic 25k-file benchmark harness (`OPENCLAW_RECONCILE_BENCH=1`, local-only test): 6/6 per-phase timing assertions pass.
- `node scripts/check-changed.mjs --base origin/main`: exit 0 (format, lint, typecheck core + tests, dead-export scan).
- Branch autoreview: no findings.
