### PR TITLE
chore: speed up update restart tests

### DIFF
--- a/src/cli/update-cli/update-command-service.test.ts
+++ b/src/cli/update-cli/update-command-service.test.ts
@@ -1,11 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
 
 const mocks = vi.hoisted(() => ({
   createUpdateConfigSnapshot: vi.fn(async () => undefined),
+  doctorCommand: vi.fn<typeof import("../../commands/doctor.js").doctorCommand>(),
+  runDaemonInstall: vi.fn<typeof import("../daemon-cli.js").runDaemonInstall>(),
+  runDaemonRestart: vi.fn<typeof import("../daemon-cli.js").runDaemonRestart>(),
   runRestartScript: vi.fn(async () => undefined),
   waitForGatewayHealthyRestart: vi.fn(),
+}));
+
+vi.mock("../../commands/doctor.js", () => ({ doctorCommand: mocks.doctorCommand }));
+vi.mock("../daemon-cli.js", () => ({
+  runDaemonInstall: mocks.runDaemonInstall,
+  runDaemonRestart: mocks.runDaemonRestart,
 }));
 
 vi.mock("../../infra/gateway-supervision.js", async (importOriginal) => ({
@@ -31,6 +40,12 @@ vi.mock("./update-command-config.js", async (importOriginal) => ({
 import { maybeRestartService } from "./update-command-service.js";
 
 describe("maybeRestartService", () => {
+  afterEach(() => {
+    expect(mocks.doctorCommand).not.toHaveBeenCalled();
+    expect(mocks.runDaemonInstall).not.toHaveBeenCalled();
+    expect(mocks.runDaemonRestart).not.toHaveBeenCalled();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.waitForGatewayHealthyRestart.mockResolvedValue({


### PR DESCRIPTION
Related: #130957 (Git update build identity), #131223 (previous test-performance audit).

## What Problem This Solves

Resolves unnecessary cold-import work in the four restart/build-identity cases added by #130957. The suite loads doctor and daemon command graphs even though these scenarios never invoke those commands.

## Why This Change Was Made

Mock the existing doctor and daemon command exports with typed spies, and assert after every case that none was called. Keep all four existing partial-real owner mocks, real restart diagnostics, ownership/abort error classes, and every build-ID/service-ownership assertion unchanged. No production seam or runtime behavior changes.

This is the best measured boundary: replacing three partial-real factories saved only 0.175s (1.94%) and was fully restored. Existing command exports remove substantially more unused work without replacing the owners whose behavior these cases exercise.

## User Impact

No operator-visible change. Developers and CI run the same four tests with 181 fewer transformed modules and stronger checks against unintended doctor/install/restart command execution. Production LOC: 0. Test LOC: +16/-1. No changelog or dependency changes.

## Evidence

Linux x86_64, Node 24.19.0, pnpm 11.22.0, Vitest 4.1.11, pinned baseline `9de405337a7cec59a09373804192d93f30cab544`. One task-owned Blacksmith Testbox; [hydration run](https://github.com/openclaw/openclaw/actions/runs/33123291976). Lease stopped after proof.

One worker, fresh distinct `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH` for every sample, `OPENCLAW_VITEST_IMPORT_DURATIONS=1`, `OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1`, `/usr/bin/time -v`, excluded A/B warmups, eight order-balanced pairs (`AB BA AB BA AB BA AB BA`). Four tests passed in every sample.

| Median | Original | Candidate |
| --- | ---: | ---: |
| Wall | 9.995s | 8.845s |
| Vitest | 6.110s | 5.100s |
| Import | 5.225s | 4.375s |
| Test body | 19.5ms | 15.5ms |
| CPU user / system | 10.920 / 1.125s | 9.665 / 0.960s |
| Max RSS | 900,932 KiB | 834,994 KiB |
| Transformed modules | 1,503 | 1,322 |

Wall improvement: **1.150s / 11.51%**, all eight pairs faster. Original wall samples: `9.03, 9.87, 10.12, 9.46, 10.43, 12.11, 12.16, 9.69`; candidate: `8.12, 8.27, 8.85, 8.84, 10.23, 9.25, 10.74, 8.56`. The import report displays only its top ten entries; module counts come from transformed cache records, excluding metadata. An initial comparison accidentally used the remote snapshot HEAD for both variants; those samples were discarded and are not included above.

Reproduction command, with the selected original/candidate test bytes installed and a new cache directory each time:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 \
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/update-build-id-unique-sample \
OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
/usr/bin/time -v node scripts/run-vitest.mjs \
  src/cli/update-cli/update-command-service.test.ts \
  --maxWorkers=1 --reporter=verbose
```

Reversible production fault proof ran in the isolated Linux checkout. Changing forwarded build identity to `wrong-build` failed exactly the build-ID case with the expected `expectedBuildId` mismatch (1 failed, 3 passed). Inserting `await runDaemonRestart()` in the ownership-skip branch failed exactly the ownership case through the new no-call assertion (1 failed, 3 passed). Neither failed through a missing mock export. Restoring the production file returned 4/4 passing; production diff was empty.

Focused sibling proof: **247 tests / 12 files passed**, covering update service/orchestration/lifecycle/post-update, restart health/probe/wait/external management, gateway supervision, update runner, Gateway hello update scope, and UI build info.

Test-audit answers: the protected contracts are correct build-ID forwarding, honoring restart ownership/skip decisions, and avoiding command side effects in these scenarios. Wrong build identity and an unauthorized restart are credible regressions demonstrated by mutations. Existing positive assertions do not reliably catch incidental command calls when errors are caught; shared no-call assertions strengthen the existing cases without adding duplicate cases. No test-only production seam is added.

Source audit retained restart-health's cached dynamic imports and mock/clock isolation, and UI build-info's structural cold imports for module-evaluation globals. Refreshed-main discovery inspected the Linux lease-fence eligibility fix, dashboard styling, memory purge/retry/consolidation tests, and generated locale refresh; none supplied another safe qualifying shortcut.

The final fetched-main discovery also inspected `36fdc40c72e251eb54140f65030a2407a35e853c` (utility-model tooltip). It adds assertions to existing browser cases; real hover-delay, focus, theme and layout checks remain necessary. No update-service import path changed.

Fresh Codex autoreview completed with no actionable findings at its configured default threshold; manual owner/caller/sibling and installed Vitest contract review completed. AI-assisted implementation and verification: Codex. No transcript included.

Refreshed-base check at `0706f629c3b550f285d70767f9b869fa7ae5bb4c`: eight more order-balanced pairs on macOS arm64 / Node 26.5.0 with fresh caches and `/usr/bin/time -l`. All four tests passed in every sample; transformed modules remained 1,503 -> 1,322. Median wall 18.250 -> 17.640s, Vitest 11.130 -> 10.080s, imports 9.635 -> 8.550s, body 94 -> 83.5ms, CPU user/system 16.235/3.760 -> 15.645/3.465s, RSS 695,240 -> 640,576 KiB. Host-load variation was large (original wall 14.03–35.94s; candidate 15.08–32.53s, three pairs slower), so these local timings are **not** the claimed performance result; the isolated Linux comparison above is.

Refreshed-base proof also replayed both reversible production faults, passed the focused suite shuffled with seeds 271 and 827, and passed all 247 sibling tests with seed 130957. Production was restored byte-for-byte.

Complete `check:changed` coreTests gate passed with no skipped checks, including core test typechecking and type-aware lint. Targeted formatting, `git diff --check`, production/test LOC inspection, and deslop passed. No operator Gateway or external service mutation was used for proof.
