### PR TITLE
test(parallels): prevent timeout fixture PID races and leaks

### DIFF
--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -2123,14 +2123,17 @@ if (commandArgs[0] === "list") {
 
   it.runIf(process.platform !== "win32")(
     "settles timed host commands when an escaped descendant retains child pipes",
-    () => {
+    async () => {
       const tempDir = makeTempDir(tempDirs, "openclaw-parallels-host-command-pipes-");
       const grandchildPidPath = join(tempDir, "grandchild.pid");
       let grandchildPid = 0;
       const grandchildScript = [
-        "const { writeFileSync } = require('node:fs');",
-        "writeFileSync(process.env.GRANDCHILD_PID_PATH, String(process.pid));",
-        "setInterval(() => {}, 1000);",
+        "const { renameSync, writeFileSync } = require('node:fs');",
+        // Outlive the assertion bound, but self-clean if PID setup fails.
+        "setTimeout(() => process.exit(0), 3_000);",
+        "const pidPath = process.env.GRANDCHILD_PID_PATH;",
+        "writeFileSync(pidPath + '.tmp', String(process.pid));",
+        "renameSync(pidPath + '.tmp', pidPath);",
       ].join("\n");
       const parentScript = [
         "const { spawn } = require('node:child_process');",
@@ -2155,12 +2158,17 @@ if (commandArgs[0] === "list") {
           timeoutMs: 100,
         });
 
-        expect(result.status).toBe(124);
-        expect(Date.now() - startedAt).toBeLessThan(2_000);
-        grandchildPid = Number.parseInt(readFileSync(grandchildPidPath, "utf8"), 10);
+        const durationMs = Date.now() - startedAt;
+        // The renamed path publishes a complete PID even if timeout settles first.
+        await waitFor(() => existsSync(grandchildPidPath));
+        grandchildPid = Number(readFileSync(grandchildPidPath, "utf8"));
+
         expect(Number.isInteger(grandchildPid)).toBe(true);
+        expect(grandchildPid).toBeGreaterThan(1);
+        expect(result.status).toBe(124);
+        expect(durationMs).toBeLessThan(2_000);
       } finally {
-        if (grandchildPid && isProcessAlive(grandchildPid)) {
+        if (Number.isInteger(grandchildPid) && grandchildPid > 1 && isProcessAlive(grandchildPid)) {
           process.kill(-grandchildPid, "SIGKILL");
         }
       }


### PR DESCRIPTION
Related: #118479

## What Problem This Solves

Resolves a problem where the Parallels timeout regression test could fail on a busy host and leave its detached fixture running. The timed command had already returned the expected timeout status within the allowed duration, but the test read the descendant's PID file between creation and completion of its write.

## Why This Change Was Made

The fixture now writes its PID to a temporary sibling and renames it into place only after the write completes. The test waits for that publication before taking cleanup ownership, while measuring command completion before the wait. A three-second fixture lifetime also prevents indefinite leftovers when setup fails.

The production timeout code is unchanged. The original 100 ms command timeout and two-second completion bound remain intact. The affected fixture originated in #118479, authored and merged by @vincentkoc on August 3, 2026.

## User Impact

No runtime or configuration changes. Maintainers get reliable timeout regression coverage without leaking detached test processes.

## Evidence

The unchanged grouped run failed at the PID assertion after the timeout status and duration checks passed. A standalone reproduction with delayed PID publication reproduced the incomplete read. With atomic publication and readiness synchronization, the fixture completed successfully; recreating the historical timeout-owner regression still took more than three seconds and failed the unchanged two-second bound.

Focused timeout and phase tests passed: 3 files, 120 tests. The original grouped Parallels and updater run then passed: 25 files, 561 tests across four shards. The scoped changed gate passed formatting, root test typechecking, script lint, and guards. A fresh independent Codex review covering P0–P3 findings returned no actionable findings.

Production LOC: +0/-0. Tests: +16/-8. AI-assisted maintainer repair discovered during the requested cross-platform install and update sweep.
