### PR TITLE
perf(ui): keep settings search responsive

### DIFF
--- a/ui/src/lib/config-form-utils.node.test.ts
+++ b/ui/src/lib/config-form-utils.node.test.ts
@@ -2,11 +2,36 @@
 import { describe, expect, it } from "vitest";
 import {
   cloneConfigObject,
+  hintForPath,
   removePathValue,
   sanitizeRedactedFormForSubmit,
   serializeConfigForm,
   setPathValue,
 } from "./config-form-utils.ts";
+
+describe("hintForPath", () => {
+  it("does not rescan wildcard hints for each path lookup", () => {
+    let catalogScans = 0;
+    const hints = new Proxy(
+      {
+        "plugins.entries.*.enabled": { label: "Plugin Enabled" },
+      },
+      {
+        ownKeys(target) {
+          catalogScans += 1;
+          return Reflect.ownKeys(target);
+        },
+      },
+    );
+
+    expect(hintForPath(["plugins", "entries", "voice-call", "enabled"], hints)?.label).toBe(
+      "Plugin Enabled",
+    );
+    expect(hintForPath(["plugins", "missing"], hints)).toBeUndefined();
+    expect(hintForPath(["channels", "missing"], hints)).toBeUndefined();
+    expect(catalogScans).toBeLessThanOrEqual(1);
+  });
+});
 
 function makeConfigWithProvider(): Record<string, unknown> {
   return {

--- a/ui/src/lib/config-form-utils.ts
+++ b/ui/src/lib/config-form-utils.ts
@@ -1,6 +1,6 @@
 // Control UI controller manages form utils gateway state.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { ConfigUiHints } from "../api/types.ts";
+import type { ConfigUiHint, ConfigUiHints } from "../api/types.ts";
 
 export type JsonSchema = {
   type?: string | string[];
@@ -69,17 +69,24 @@ export function pathKey(path: Array<string | number>): string {
   return path.filter((segment) => typeof segment === "string").join(".");
 }
 
+const wildcardHintCache = new WeakMap<ConfigUiHints, Array<[string[], ConfigUiHint]>>();
+
 export function hintForPath(path: Array<string | number>, hints: ConfigUiHints) {
   const direct = hints[pathKey(path)];
   if (direct) {
     return direct;
   }
   const segments = path.map(String);
-  for (const [hintKey, hint] of Object.entries(hints)) {
-    if (!hintKey.includes("*")) {
-      continue;
-    }
-    const hintSegments = hintKey.split(".");
+  let wildcardHints = wildcardHintCache.get(hints);
+  if (!wildcardHints) {
+    // Schema reloads replace the hints object, so identity safely owns this index.
+    // Reuse it across recursive form and search lookups instead of rescanning the catalog.
+    wildcardHints = Object.entries(hints).flatMap(([hintKey, hint]) =>
+      hintKey.includes("*") ? [[hintKey.split("."), hint]] : [],
+    );
+    wildcardHintCache.set(hints, wildcardHints);
+  }
+  for (const [hintSegments, hint] of wildcardHints) {
     if (
       hintSegments.length === segments.length &&
       hintSegments.every((segment, index) => segment === "*" || segment === segments[index])


### PR DESCRIPTION
Closes #131262

## What Problem This Solves

Control UI settings search recursively resolves UI hints across the full runtime configuration schema on every input update. Wildcard resolution enumerated the entire hint catalog for every path, making typing visibly lag on large schemas.

## Why This Change Was Made

`hintForPath` now builds the parsed wildcard-hint list once per `ConfigUiHints` object and reuses it across recursive form and search lookups. Schema reloads replace that object, so `WeakMap` identity provides the correct lifecycle without explicit invalidation or retained stale state.

The existing exact-key fast path and wildcard insertion-order precedence are unchanged. The fix stays at the shared hint-resolution owner, so settings search and sibling config-form callers use one canonical path.

## User Impact

Settings search remains responsive while typing and navigating results. A recovered pre-fix worst-case run took about 182 ms; the fixed flow's slowest sampled query had a 13.8 ms median and 19.52 ms maximum over 50 runs.

## Evidence

- Regression test first failed on pre-fix code because three lookups enumerated the hint catalog three times; it passes with one enumeration after the fix.
- Focused owner/sibling suite: 7 files, 146 tests passed.
- Control UI E2E: 7 settings/sidebar scenarios passed; the 12.08-second recording and every generated screenshot were visually inspected.
- Changed format, typecheck, lint, architecture, and repository guards passed.
- Fresh autoreview against the rebased commit: no accepted/actionable findings, correctness 0.99.
- Production delta: +13/-6 (net +7); regression test delta: +25/-0.

### Validation commands

```text
node scripts/run-vitest.mjs ui/src/lib/config-form-utils.node.test.ts ui/src/components/config-form.search.node.test.ts ui/src/components/config-form.tiers.test.ts ui/src/pages/config/settings-search.test.ts ui/src/components/settings-sidebar.test.ts ui/src/components/config-form.browser.test.ts ui/src/pages/config/view.browser.test.ts
node scripts/check-changed.mjs -- ui/src/lib/config-form-utils.ts ui/src/lib/config-form-utils.node.test.ts
PLAYWRIGHT_BROWSERS_PATH="$PWD/.artifacts/playwright-browsers" OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/sidebar-customization.e2e.test.ts
.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --stream-engine-output
```

AI-assisted: implementation, tests, validation, and PR preparation were performed with Codex under maintainer supervision.
