### PR TITLE
fix(ui): keep acknowledged sends pending on current connection

### DIFF
--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -17,7 +17,6 @@ import {
   type ChatCommandResetOptions,
 } from "./chat-commands.ts";
 import { loadChatHistory, type ChatHistoryResult } from "./chat-history.ts";
-import { chatOutboxOwner } from "./chat-outbox-owner.ts";
 import {
   consumeChatOutboxRetry,
   retryableGatewayDelayMs,
@@ -98,8 +97,6 @@ type StoredChatOutboxDrainLane = {
 type StoredChatOutboxClientState = {
   lanes: Map<string, StoredChatOutboxDrainLane>;
 };
-const STORED_OUTBOX_CONFIRMATION_GRACE_MS = 5_000;
-const STORED_OUTBOX_RETRY_DEFAULT_MS = 500;
 export const UNCONFIRMED_CHAT_SEND_ERROR =
   "Reconnected before delivery was confirmed. Check the conversation — retry only if your message didn't arrive.";
 const UNCERTAIN_CLEAR_SUCCESSOR_ERROR =
@@ -152,10 +149,6 @@ function sameQueuedDeliveryVersion(left: ChatQueueItem, right: ChatQueueItem): b
   );
 }
 
-function queuedDeliveryVersion(item: ChatQueueItem): string {
-  return `${item.id}\u0000${item.sendRunId ?? ""}\u0000${item.sendAttempts ?? 0}`;
-}
-
 function sessionRunProvesQueuedDelivery(
   sessionInfo: ChatHistoryResult["sessionInfo"],
   item: ChatQueueItem,
@@ -166,7 +159,6 @@ function sessionRunProvesQueuedDelivery(
       sessionInfo?.lastRunId === item.sendRunId),
   );
 }
-
 async function readCurrentStoredChatHistory(
   host: ChatHost,
   outbox: StoredChatOutbox,
@@ -297,24 +289,19 @@ async function reconcileStoredChatOutboxHead(
       return "blocked";
     }
   }
-  const outboxOwner = chatOutboxOwner(host);
-  const clearConfirmationGrace = () => outboxOwner.clearConfirmationGrace(outbox, item.id);
   const historyArgs = [host, outbox, item, client, connectionEpoch, dependencies] as const;
   const history = await readCurrentStoredChatHistory(...historyArgs);
   // Keyed unknown sends reach history only for exact proof; absence stays blocked.
   if (history === "blocked" || history === "continue" || item.sendState === "unconfirmed") {
-    clearConfirmationGrace();
     return history === "continue" ? "continue" : "blocked";
   }
   if (visibleSessionMatches(host, outbox.sessionKey, outbox.agentId) && isChatBusy(host)) {
-    clearConfirmationGrace();
     return "blocked";
   }
   if ((item.sendAttempts ?? 0) > 0) {
     // History and run metadata are non-atomic; verify idle before parking unknown.
     const verifiedHistory = await readCurrentStoredChatHistory(...historyArgs);
     if (verifiedHistory === "blocked" || verifiedHistory === "continue") {
-      clearConfirmationGrace();
       return verifiedHistory;
     }
     const liveSendCurrent = anyChatOutboxPaneMatches(host, (pane) => {
@@ -325,27 +312,9 @@ async function reconcileStoredChatOutboxHead(
       );
     });
     if (liveSendCurrent) {
-      // Start the bound only after idle is verified; a valid run can outlive the send request.
-      const now = Date.now();
-      const deadlineMs = outboxOwner.confirmationDeadline(
-        outbox,
-        item.id,
-        queuedDeliveryVersion(item),
-        now,
-        STORED_OUTBOX_CONFIRMATION_GRACE_MS,
-      );
-      if (deadlineMs !== null && now < deadlineMs) {
-        scheduleStoredChatOutboxRetry(
-          host,
-          outbox,
-          Math.min(STORED_OUTBOX_RETRY_DEFAULT_MS, deadlineMs - now),
-          dependencies,
-          false,
-        );
-        return "blocked";
-      }
+      // Elapsed time cannot turn a current-connection send into reconnect uncertainty.
+      return "blocked";
     }
-    clearConfirmationGrace();
     const parked = updateQueuedMessageForSession(host, outbox.sessionKey, item.id, (entry) => ({
       ...entry,
       sendError: UNCONFIRMED_CHAT_SEND_ERROR,

--- a/ui/src/pages/chat/chat-outbox-owner.ts
+++ b/ui/src/pages/chat/chat-outbox-owner.ts
@@ -15,11 +15,7 @@ type HostProjection = {
   durableSeen: Set<string>;
   retryable: Set<string>;
 };
-type LiveProjection = {
-  confirmationGrace?: { deadlineMs: number; deliveryVersion: string };
-  item: ChatQueueItem;
-  owner: Host;
-};
+type LiveProjection = { item: ChatQueueItem; owner: Host };
 const LIVE_VERSION_KEYS = ["sendRunId", "sendAttempts", "sendState", "sendError"] as const;
 const routePresentation = new WeakSet<ChatQueueItem>();
 const storageIds = new WeakMap<Storage, number>();
@@ -237,30 +233,6 @@ class ChatOutboxGatewayOwner {
   hasVolatile(host: Host, id: string): boolean {
     return this.hosts.get(host)?.retryable.has(id) ?? false;
   }
-  confirmationDeadline(
-    scope: Scope,
-    itemId: string,
-    deliveryVersion: string,
-    now: number,
-    graceMs: number,
-  ): number | null {
-    const live = this.live.get(storedChatOutboxScopeKey(scope))?.get(itemId);
-    if (!live) {
-      return null;
-    }
-    if (live.confirmationGrace?.deliveryVersion === deliveryVersion) {
-      return live.confirmationGrace.deadlineMs;
-    }
-    const deadlineMs = now + graceMs;
-    live.confirmationGrace = { deadlineMs, deliveryVersion };
-    return deadlineMs;
-  }
-  clearConfirmationGrace(scope: Scope, itemId: string): void {
-    const live = this.live.get(storedChatOutboxScopeKey(scope))?.get(itemId);
-    if (live) {
-      delete live.confirmationGrace;
-    }
-  }
   // Panes share this outbox and its drain while composer state stays per pane, so
   // a pane-local fact that blocks delivery has to be answerable from any of them.
   anyPane(matches: (host: Host) => boolean): boolean {
@@ -285,7 +257,7 @@ class ChatOutboxGatewayOwner {
     const key = storedChatOutboxScopeKey(scope);
     const live = this.live.get(key) ?? new Map<string, LiveProjection>();
     if (item) {
-      live.set(id, { confirmationGrace: live.get(id)?.confirmationGrace, item, owner: host });
+      live.set(id, { item, owner: host });
       this.live.set(key, live);
     } else {
       live.delete(id);

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -83,20 +83,6 @@ function writeChatQueueForScope(
   chatOutboxOwner(host).replace(host, scope, queue);
 }
 
-function setTransientQueuedMessageProjection(
-  host: TestChatHost,
-  sessionKey: string,
-  item: ChatQueueItem,
-): boolean {
-  const owner = chatOutboxOwner(host);
-  const scope = resolveStoredChatOutboxScope(host, sessionKey, item.agentId);
-  if (!owner.durable(host, item.id)) {
-    return false;
-  }
-  owner.projectLive(host, scope, item.id, item);
-  return true;
-}
-
 function requireChatMessageCache(host: ChatHost): ChatMessageCache {
   if (!host.chatMessagesBySession) {
     throw new Error("Expected chat message cache");
@@ -6074,15 +6060,13 @@ describe("handleSendChat", () => {
 
     expect(host.chatQueue[0]?.sendState).toBe("sending");
     expect(host.lastError).toBeNull();
-    await waitForFast(() => expect(listStoredChatOutboxes(host)).toStrictEqual([]), {
-      timeout: 1_000,
-    });
+    await flushChatQueueForEvent(host);
     expect(historyRequests).toBeGreaterThanOrEqual(3);
     expect(host.chatQueue).toStrictEqual([]);
     expect(host.lastError).toBeNull();
   });
 
-  it("marks an acknowledged live send unconfirmed after history stays missing", async () => {
+  it("keeps an acknowledged live send pending while its connection stays current", async () => {
     let now = 1_000;
     vi.spyOn(Date, "now").mockImplementation(() => now);
     const host = makeChatHost({
@@ -6107,48 +6091,8 @@ describe("handleSendChat", () => {
     await flushChatQueueForEvent(host);
 
     expect(host.chatQueue[0]).toMatchObject({
-      sendError: UNCONFIRMED_CHAT_SEND_ERROR,
-      sendState: "unconfirmed",
-      text: "history never catches up",
-    });
-    // The parked bubble's inline footer owns the outcome; no pane banner.
-    expect(host.lastError).toBeNull();
-  });
-
-  it("starts a fresh confirmation grace after the prior outbox scope is removed", async () => {
-    let now = 1_000;
-    vi.spyOn(Date, "now").mockImplementation(() => now);
-    const host = makeChatHost({
-      requestHandlers: {
-        "chat.history": () => idleChatHistory(),
-        "chat.send": (params: unknown) => {
-          const payload = requireRecord(params, "live send payload");
-          const runId = String(payload.idempotencyKey);
-          return Promise.resolve({ runId, status: "started" });
-        },
-      },
-    });
-
-    await handleSendChat(host, "reuse this delivery version");
-    host.chatRunId = null;
-    await flushChatQueueForEvent(host);
-
-    const item = expectDefined(host.chatQueue[0], "queued live send");
-    const sessionKey = expectDefined(item.sessionKey, "queued session key");
-    expect(removeQueuedMessage(host, item.id)).toBe("removed");
-
-    now = 5_500;
-    expect(admitQueuedMessageForSession(host, sessionKey, item)).toBe(true);
-    expect(setTransientQueuedMessageProjection(host, sessionKey, item)).toBe(true);
-    await flushChatQueueForEvent(host);
-
-    now = 6_001;
-    await flushChatQueueForEvent(host);
-
-    expect(host.chatQueue[0]).toMatchObject({
-      id: item.id,
       sendState: "sending",
-      text: "reuse this delivery version",
+      text: "history never catches up",
     });
     expect(host.lastError).toBeNull();
   });


### PR DESCRIPTION
Related: #125425
Related: #125426
Related: #131171

AI-assisted: yes.

## What Problem This Solves

Fixes an issue where users sending a message from the Control UI Home chat could see a delivery-uncertain warning after five seconds when transcript history stayed stale, even though `chat.send` was acknowledged and the Gateway connection never changed.

#125426 reduced the race by adding a confirmation grace period. #131171 added stronger run-ID delivery proof and a calmer inline presentation for genuine reconnect uncertainty. The remaining gap was the timer itself: elapsed time could still turn a current-connection send into reconnect uncertainty without any reconnect evidence.

## Why This Change Was Made

While the exact current connection still owns a matching live `sending` projection, reconciliation now keeps the send pending until authoritative transcript/run proof retires it or a real connection transition removes the live fact. The obsolete five-second confirmation deadline, retry timer, and owner bookkeeping are removed.

Actual reconnect ambiguity keeps the existing conservative `unconfirmed` path and the inline presentation added by #131171. This adds no config, storage, protocol, or API surface.

## User Impact

Acknowledged Home-chat sends no longer become “Delivery unconfirmed” merely because history takes longer than five seconds to catch up. Users still receive the existing review-and-retry outcome when a real reconnect leaves delivery ambiguous.

## Evidence

- Pre-fix regression: the focused test failed after advancing the clock by 5,001 ms because the row changed from `sending` to `unconfirmed`.
- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-send.test.ts` — 283 passed on the current-main rebase.
- `pnpm tsgo:ui` — passed.
- Targeted oxlint and stylelint for all three changed files — passed.
- `git diff --check origin/main...HEAD` — passed.
- Fresh Codex autoreview against `origin/main` — no actionable findings; patch correct, confidence 0.98.
- Production LOC: +4/−63. Tests: +3/−59.

Changed-gate limitation: `node scripts/check-changed.mjs` passed conflict-marker, ratchet, dependency, formatting, dead-export, temp-directory, and UI i18n checks, then stopped in core-test typechecking on pre-existing implicit-`any` errors in `ui/src/test-helpers/control-ui-e2e*.test.ts` and `mock-gateway-page.test.ts`, introduced on current main by #131052. The touched UI typecheck/lint/style lanes pass independently.

Visual proof is not attached yet. The deterministic owner-boundary regression covers the five-second state transition; before landing, the PR should also capture the real Control UI surface or state why isolated visual proof is infeasible.
