### PR TITLE
fix(scripts): include mts files in typed lint project

### DIFF
--- a/scripts/dependency-ownership-surface-report.mts
+++ b/scripts/dependency-ownership-surface-report.mts
@@ -166,7 +166,16 @@ function ownershipFor(dependencyOwnership: JsonObject, name: string) {
     ? dependencyOwnership.dependencies
     : {};
   const ownership = dependencies[name];
-  return isRecord(ownership) ? ownership : undefined;
+  if (!isRecord(ownership)) {
+    return undefined;
+  }
+  return {
+    owner: typeof ownership.owner === "string" ? ownership.owner : undefined,
+    class: typeof ownership.class === "string" ? ownership.class : undefined,
+    risk: Array.isArray(ownership.risk)
+      ? ownership.risk.filter((value): value is string => typeof value === "string")
+      : [],
+  };
 }
 
 function gitValue(repoRoot: string, args: string[]) {
@@ -405,7 +414,7 @@ export function renderDependencyOwnershipSurfaceMarkdownReport(
     for (const warning of typedReport.ownershipWarnings) {
       lines.push(
         `- ${markdownCode(warning.name)}: ${warning.message}; source sections: ` +
-          `${warning.sourceSections.join(", ")}`,
+          warning.sourceSections.join(", "),
       );
     }
   }

--- a/scripts/docker-e2e.mts
+++ b/scripts/docker-e2e.mts
@@ -91,18 +91,18 @@ function summaryMarkdown(value: unknown, title: string) {
     "| --- | ---: | ---: | --- | --- |",
   ];
   for (const lane of lanes) {
-    const status = lane.status === 0 ? "pass" : `fail ${lane.status}`;
+    const status = lane.status === 0 ? "pass" : `fail ${markdownCell(lane.status)}`;
     lines.push(
-      `| ${inlineCode(lane.name)} | ${markdownCell(status)} | ${markdownCell(lane.elapsedSeconds)} | ${lane.timedOut ? "yes" : "no"} | ${inlineCode(lane.rerunCommand)} |`,
+      `| ${inlineCode(lane.name)} | ${status} | ${markdownCell(lane.elapsedSeconds)} | ${lane.timedOut ? "yes" : "no"} | ${inlineCode(lane.rerunCommand)} |`,
     );
   }
 
   if (slowest.length > 0) {
     lines.push("", "| Slowest lane | Duration | Status |", "| --- | ---: | --- |");
     for (const lane of slowest) {
-      const status = lane.status === 0 ? "pass" : `fail ${lane.status}`;
+      const status = lane.status === 0 ? "pass" : `fail ${markdownCell(lane.status)}`;
       lines.push(
-        `| ${inlineCode(lane.name)} | ${markdownCell(formatSeconds(lane.elapsedSeconds))} | ${markdownCell(status)} |`,
+        `| ${inlineCode(lane.name)} | ${markdownCell(formatSeconds(lane.elapsedSeconds))} | ${status} |`,
       );
     }
   }
@@ -130,7 +130,9 @@ function failedRerunCommands(value: unknown) {
   const summary = recordOrEmpty(value);
   const lanes = recordArray(summary.lanes);
   return lanes.flatMap((lane) =>
-    lane.status !== 0 && lane.rerunCommand ? [String(lane.rerunCommand)] : [],
+    lane.status !== 0 && typeof lane.rerunCommand === "string" && lane.rerunCommand
+      ? [lane.rerunCommand]
+      : [],
   );
 }
 

--- a/scripts/e2e-sandbox-bind-conflict.mts
+++ b/scripts/e2e-sandbox-bind-conflict.mts
@@ -13,6 +13,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { formatErrorMessage } from "./lib/error-format.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 
 type WorkspaceMountModule = Pick<
@@ -224,7 +225,12 @@ try {
   }
 } catch (err) {
   const engineError = isRecord(err) ? err : {};
-  const msg = engineError.stderr ? String(engineError.stderr) : String(engineError.message ?? err);
+  const msg =
+    typeof engineError.stderr === "string" && engineError.stderr
+      ? engineError.stderr
+      : typeof engineError.message === "string"
+        ? engineError.message
+        : formatErrorMessage(err);
   if (msg.includes("Duplicate mount point") || msg.includes("duplicate mount")) {
     fail(`Duplicate mount point rejected by ${engine}`);
     console.log(msg.slice(0, 500));

--- a/scripts/e2e/kitchen-sink-rpc-walk.mts
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mts
@@ -1217,7 +1217,7 @@ function isRetryableTransientNetworkError(error: unknown, seen = new Set<unknown
   const message =
     candidate instanceof Error ? candidate.message : typeof candidate === "string" ? candidate : "";
   const code = asRecord(candidate).code;
-  const text = `${String(code ?? "")} ${message}`;
+  const text = `${typeof code === "string" ? code : ""} ${message}`;
   if (
     /\b(?:ECONNRESET|ECONNREFUSED|ETIMEDOUT|EPIPE|EHOSTUNREACH|ENETUNREACH)\b/iu.test(text) ||
     /\b(?:fetch failed|socket hang up|connection reset)\b/iu.test(text)
@@ -1980,7 +1980,7 @@ export async function assertOperatorRpcDenied(
   } catch (error) {
     const candidate = asRecord(error);
     const gatewayCode = candidate.gatewayCode;
-    const message = String(candidate.message ?? "");
+    const message = typeof candidate.message === "string" ? candidate.message : "";
     if (gatewayCode === "INVALID_REQUEST" && message.includes("unauthorized role: operator")) {
       return;
     }

--- a/scripts/generate-kysely-types.mts
+++ b/scripts/generate-kysely-types.mts
@@ -98,7 +98,7 @@ function generateTypes(db: DatabaseSync): string {
       .toSorted((left, right) => String(left.name).localeCompare(String(right.name)));
     const primaryKeyColumnCount = columns.filter((column) => Number(column.pk) > 0).length;
     for (const column of columns) {
-      lines.push(`  ${column.name}: ${columnType(column, primaryKeyColumnCount)};`);
+      lines.push(`  ${String(column.name)}: ${columnType(column, primaryKeyColumnCount)};`);
     }
     lines.push("}", "");
   }

--- a/scripts/release-candidate-checklist.mts
+++ b/scripts/release-candidate-checklist.mts
@@ -421,7 +421,7 @@ export function validateParallelsRegistryPackageArtifact(
     packedPackage.version !== packageVersion
   ) {
     throw new Error(
-      `plugin npm preflight tarball identity mismatch: manifest=${packageName}@${packageVersion} packed=${isRecord(packedPackage) ? (packedPackage.name ?? "<missing>") : "<missing>"}@${isRecord(packedPackage) ? (packedPackage.version ?? "<missing>") : "<missing>"}`,
+      `plugin npm preflight tarball identity mismatch: manifest=${packageName}@${packageVersion} packed=${formatJsonValue(isRecord(packedPackage) ? (packedPackage.name ?? "<missing>") : "<missing>")}@${formatJsonValue(isRecord(packedPackage) ? (packedPackage.version ?? "<missing>") : "<missing>")}`,
     );
   }
   return {
@@ -605,7 +605,7 @@ export async function validateWindowsSourceRelease(tag: string, options: GithubA
   }
   if (release.tag_name !== tag) {
     throw new Error(
-      `Windows source release tag mismatch: expected ${tag}, got ${release.tag_name}`,
+      `Windows source release tag mismatch: expected ${tag}, got ${formatJsonValue(release.tag_name)}`,
     );
   }
   if (release.draft) {
@@ -1217,7 +1217,7 @@ export function fullReleaseTrustedWorkflowFields({
 }) {
   const workflow: unknown = parseYaml(workflowSource);
   const env = isRecord(workflow) && isRecord(workflow.env) ? workflow.env : undefined;
-  const contract = String(env?.RELEASE_ISOLATION_TOOLING_CONTRACT ?? "");
+  const contract = formatJsonValue(env?.RELEASE_ISOLATION_TOOLING_CONTRACT ?? "");
   if (contract === "1") {
     return {};
   }
@@ -1315,8 +1315,8 @@ function summarizePendingDeployments(repo: string, runId: string, deployments: u
       const deployment = isRecord(deploymentValue) ? deploymentValue : {};
       const environment = isRecord(deployment.environment) ? deployment.environment : {};
       return [
-        `- pending approval: env=${environment.name ?? "<unknown>"} canApprove=${String(deployment.current_user_can_approve ?? "<unknown>")}`,
-        `  approve: gh api -X POST repos/${repo}/actions/runs/${runId}/pending_deployments -F 'environment_ids[]=${environment.id ?? "<id>"}' -f state=approved -f comment='Approve release gate'`,
+        `- pending approval: env=${formatJsonValue(environment.name ?? "<unknown>")} canApprove=${formatJsonValue(deployment.current_user_can_approve ?? "<unknown>")}`,
+        `  approve: gh api -X POST repos/${repo}/actions/runs/${runId}/pending_deployments -F 'environment_ids[]=${formatJsonValue(environment.id ?? "<id>")}' -f state=approved -f comment='Approve release gate'`,
       ].join("\n");
     })
     .join("\n");
@@ -1328,7 +1328,10 @@ function summarizeFailedRun(info: RunInfo) {
   );
   return [
     `${info.workflowName} ${info.databaseId} ended ${info.status}/${info.conclusion}: ${info.url}`,
-    ...failedJobs.map((job) => `- ${job.name}: ${job.conclusion} ${job.url ?? ""}`),
+    ...failedJobs.map(
+      (job) =>
+        `- ${formatJsonValue(job.name)}: ${formatJsonValue(job.conclusion)} ${formatJsonValue(job.url ?? "")}`,
+    ),
   ].join("\n");
 }
 
@@ -1998,7 +2001,7 @@ async function main() {
   const actualTarballSha = sha256(tarballPath);
   if (actualTarballSha !== npmManifest.tarballSha256) {
     throw new Error(
-      `prepared tarball digest mismatch: expected ${npmManifest.tarballSha256}, got ${actualTarballSha}`,
+      `prepared tarball digest mismatch: expected ${formatJsonValue(npmManifest.tarballSha256)}, got ${actualTarballSha}`,
     );
   }
   const corePackageTarballPaths = new Map(
@@ -2112,7 +2115,7 @@ async function main() {
       `- npm preflight: ${options.npmPreflightRunId} ${npmRun.url}`,
       ...(windowsNodeSourceRelease
         ? [
-            `- Windows Node source release: ${windowsNodeSourceRelease.tag} ${windowsNodeSourceRelease.url}`,
+            `- Windows Node source release: ${windowsNodeSourceRelease.tag} ${formatJsonValue(windowsNodeSourceRelease.url)}`,
             ...windowsNodeSourceRelease.assets.map(
               (asset) => `- Windows Node source asset: ${asset.name} ${asset.digest}`,
             ),

--- a/scripts/root-dependency-ownership-audit.mts
+++ b/scripts/root-dependency-ownership-audit.mts
@@ -427,13 +427,17 @@ function printTextReport(records: AuditRecord[]) {
     console.log(`\n## ${category}`);
     for (const record of grouped.get(category) ?? []) {
       const details = [`sections=${record.sections.join(",") || "-"}`, `files=${record.fileCount}`];
+      const spec =
+        typeof record.spec === "string"
+          ? record.spec
+          : (JSON.stringify(record.spec) ?? "<undefined>");
       if (record.declaredInExtensions.length > 0) {
         details.push(`extensions=${record.declaredInExtensions.join(",")}`);
       }
       if (record.internalizedBundledRuntimeOwners.length > 0) {
         details.push(`internalized=${record.internalizedBundledRuntimeOwners.join(",")}`);
       }
-      console.log(`- ${record.depName}@${record.spec} :: ${details.join(" | ")}`);
+      console.log(`- ${record.depName}@${spec} :: ${details.join(" | ")}`);
       console.log(`  ${record.recommendation}`);
     }
   }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
+    "allowJs": true,
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["**/*.ts"],
+  "include": ["**/*.ts", "**/*.mts"],
   "exclude": ["pre-commit/**"]
 }

--- a/scripts/validate-qa-runtime-pair-summary.mts
+++ b/scripts/validate-qa-runtime-pair-summary.mts
@@ -118,6 +118,13 @@ function projectedReportCellStatus(cell: Record<string, unknown>) {
   return cell.runtimeErrorClass || cell.transportErrorClass ? "fail" : "pass";
 }
 
+function formatRuntimePairReportValue(value: unknown) {
+  if (typeof value === "string") {
+    return value;
+  }
+  return value === undefined ? "undefined" : (JSON.stringify(value) ?? "<undefined>");
+}
+
 function hasPassingRuntimeCellStatus(cell: Record<string, unknown>) {
   // Early frozen candidates did not serialize the derived cell status. Accept
   // only that absent legacy field when the same runtime evidence projects pass.
@@ -360,7 +367,7 @@ export function validateQaRuntimePairReport(
     .filter((scenario) => scenario.status === "skip")
     .map(
       (scenario) =>
-        `${scenario.name} drift=${scenario.runtimeParity.drift} (${scenario.runtimeParity.driftDetails}).`,
+        `${formatRuntimePairReportValue(scenario.name)} drift=${formatRuntimePairReportValue(scenario.runtimeParity.drift)} (${formatRuntimePairReportValue(scenario.runtimeParity.driftDetails)}).`,
     );
   const reportFailures = reportSummary.failures;
   if (
@@ -374,7 +381,7 @@ export function validateQaRuntimePairReport(
     !reportMarkdown.startsWith("# OpenClaw Runtime Parity Report") ||
     !reportMarkdown.includes(`- Verdict: ${counts.skipped === 0 ? "pass" : "fail"}`) ||
     scenarios.some((scenario) => {
-      const heading = `\n### ${scenario.name}\n`;
+      const heading = `\n### ${formatRuntimePairReportValue(scenario.name)}\n`;
       const start = reportMarkdown.indexOf(heading);
       if (start < 0) {
         return true;
@@ -386,7 +393,9 @@ export function validateQaRuntimePairReport(
       const expectedStatus = scenario.status === "skip" ? "fail" : "pass";
       return (
         !sectionLines.has(`- status: ${expectedStatus}`) ||
-        !sectionLines.has(`- drift: ${scenario.runtimeParity.drift}`) ||
+        !sectionLines.has(
+          `- drift: ${formatRuntimePairReportValue(scenario.runtimeParity.drift)}`,
+        ) ||
         ![...sectionLines].some((line) =>
           line.startsWith(
             `- openclaw: ${projectedReportCellStatus(scenario.runtimeParity.cells.openclaw)} `,

--- a/scripts/verify-plugin-npm-published-runtime.mts
+++ b/scripts/verify-plugin-npm-published-runtime.mts
@@ -420,8 +420,7 @@ async function verifyPublishedPluginRuntime(spec: string) {
       readme = packedPackage.readme;
     }
     return {
-      packageName: packedPackage.packageJson.name,
-      version: packedPackage.packageJson.version,
+      packageLabel: formatPackageLabel(packedPackage.packageJson, spec),
       fileCount: packedPackage.files.length,
       readmeLength: readme.length,
     };
@@ -438,7 +437,7 @@ async function main(argv: string[]) {
   }
   const result = await verifyPublishedPluginRuntime(args.spec);
   console.log(
-    `plugin-npm-published-runtime-check: ${result.packageName}@${result.version} OK (${result.fileCount} files, ${result.readmeLength} readme chars)`,
+    `plugin-npm-published-runtime-check: ${result.packageLabel} OK (${result.fileCount} files, ${result.readmeLength} readme chars)`,
   );
 }
 

--- a/scripts/verify-pr-hosted-gates.mts
+++ b/scripts/verify-pr-hosted-gates.mts
@@ -281,8 +281,7 @@ function matchingAuthoritativeRuns(
 function latestRun(runs: WorkflowRun[]) {
   // GitHub run_number is creation order; updated_at moves as jobs finish.
   return runs.toSorted(
-    (left, right) =>
-      Number(right.run_number ?? right.id ?? 0) - Number(left.run_number ?? left.id ?? 0),
+    (left, right) => (right.run_number ?? right.id ?? 0) - (left.run_number ?? left.id ?? 0),
   )[0];
 }
 
@@ -819,9 +818,7 @@ export function collectHostedGateEvidence({
             ) &&
             isRecentRun(run, nowMs),
         )
-        .toSorted((left, right) =>
-          String(right.updated_at ?? "").localeCompare(String(left.updated_at ?? "")),
-        )
+        .toSorted((left, right) => (right.updated_at ?? "").localeCompare(left.updated_at ?? ""))
         .map((run) => run.head_sha),
     ].filter((value): value is string => typeof value === "string" && value.length > 0);
     let fallbackError;

--- a/test/scripts/oxlint-config.test.ts
+++ b/test/scripts/oxlint-config.test.ts
@@ -15,6 +15,9 @@ type OxlintConfig = {
 };
 
 type OxlintTsconfig = {
+  compilerOptions?: {
+    allowJs?: boolean;
+  };
   include?: string[];
   exclude?: string[];
 };
@@ -141,8 +144,11 @@ describe("oxlint config", () => {
   it("has a discoverable scripts tsconfig for type-aware linting", () => {
     const tsconfig = readJson("scripts/tsconfig.json") as OxlintTsconfig;
 
+    expect(tsconfig.compilerOptions?.allowJs).toBe(true);
     expect(tsconfig.include).toContain("**/*.ts");
+    expect(tsconfig.include).toContain("**/*.mts");
     expect(tsconfig.exclude ?? []).not.toContain("**/*.ts");
+    expect(tsconfig.exclude ?? []).not.toContain("**/*.mts");
   });
 
   it("has a discoverable test tsconfig for type-aware linting", () => {


### PR DESCRIPTION
## What Problem This Solves

The scripts type-aware lint project included `*.ts` but not the repository's `*.mts` scripts. A clean source tree could therefore lint successfully, while the post-build check for #131235 failed with 29 diagnostics across 6 files. Adding `.mts` membership alone exposed 60 diagnostics across 13 files; enabling the existing JSDoc JavaScript closure removed 19 false project-context artifacts and left 41 genuine diagnostics across 10 script owners.

## Why This Change Was Made

The canonical scripts TypeScript project, introduced in `59925c1a7405` by Peter Steinberger on April 10, now includes `*.mts` and enables JavaScript inputs needed by existing typed JSDoc `.mjs` helpers. The affected script owners use their existing record/string coercion contracts before interpolation or comparison. The net +30 tooling lines are the owner-level type repairs needed for the 41 genuine diagnostics; the change does not suppress rules, delete build artifacts, or special-case the changed-file gate.

The existing Oxlint config test now asserts `.mts` membership, so source and post-build lint use the same project closure.

## User Impact

No runtime product behavior, public API, release policy, or database behavior changes. Maintainer script lint becomes deterministic before and after a build, while valid existing QA and release output formats remain unchanged.

## Evidence

- Genuine reproduction: full scripts type-aware lint passed with no `dist`, then the post-build run exposed the project-membership mismatch and typed diagnostics.
- Baseline build: exit 0 after only the project-membership config/test edits. It established `dist`, which remained intact through final lint and gate proof; this is not a frozen-candidate build claim.
- Final scripts type-aware lint: exit 0 on the frozen 12-file patch.
- Owner proof: 374/374 tests passed across 9 files, covering Oxlint config, Docker helpers, kitchen-sink RPC walking, release checklist behavior, QA pair summaries, npm runtime verification, dependency ownership reports, and hosted-gate verification.
- Kysely, exact formatting, and diff checks passed.
- Complete changed-file gate: exit 0.
- Fresh isolated P0 autoreview: no findings, 0.99 confidence.
- Source-blind comparison: all 10 captured script outputs, stderr, exit codes, and original fixture bytes/mtimes matched the baseline. Raw records SHA-256: `9a8c8a5aa3a1eeee1d80efe07f2531d159c1f853d0214994c89ebaecfee68ffd`.
- Runtime production LOC: +0/-0. Tooling/config: +62/-32 (net +30). Tests: +6/-0. Total: +68/-32 (net +36).
