### PR TITLE
fix(tui): avoid stalls for non-auth error messages

### DIFF
--- a/src/infra/vitest-e2e-config.test.ts
+++ b/src/infra/vitest-e2e-config.test.ts
@@ -40,6 +40,7 @@ describe("e2e vitest config", () => {
       "src/tui/tui-session-identity-pty.e2e.test.ts",
       "src/tui/tui-reset-transition-pty.e2e.test.ts",
       "src/tui/tui-task-suggestions-pty.e2e.test.ts",
+      "src/tui/tui-error-pty.e2e.test.ts",
       "src/tui/tui-pty-local.e2e.test.ts",
     ];
 

--- a/src/tui/tui-error-pty.e2e.test.ts
+++ b/src/tui/tui-error-pty.e2e.test.ts
@@ -1,0 +1,23 @@
+import { expect, it } from "vitest";
+import {
+  startTuiFixture,
+  waitForSynchronizedFrameRows,
+} from "./tui-pty-harness-fixture-test-support.js";
+
+it("keeps the terminal responsive after a cold non-auth provider failure", async () => {
+  const fixture = await startTuiFixture();
+  try {
+    await fixture.run.waitForOutput("local ready", 20_000);
+    await fixture.run.write("provider failure proof\r", { delay: false });
+    const rows = await waitForSynchronizedFrameRows(
+      fixture.run,
+      (frame) => frame.some((row) => row.includes("run error: fixture provider failed")),
+      2_000,
+    );
+    expect(rows.join("\n")).not.toContain("/auth");
+    await fixture.run.write("/session recovered\r", { delay: false });
+    await fixture.run.waitForOutput("session agent:main:recovered");
+  } finally {
+    await fixture.cleanup();
+  }
+}, 25_000);

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1,5 +1,6 @@
 // Covers TUI event handler routing for keyboard and backend events.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as failoverClassifier from "../agents/failover/classify.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
 import {
@@ -2721,6 +2722,25 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     await vi.waitFor(() => expect(chatLog.addSystem).toHaveBeenCalledTimes(2));
     expect(loadHistory).toHaveBeenCalledTimes(1);
     expect(chatLog.addSystem).toHaveBeenLastCalledWith("run error: provider exploded");
+  });
+
+  it("renders non-auth failures without invoking provider classification", () => {
+    const classify = vi
+      .spyOn(failoverClassifier, "classifyFailoverReason")
+      .mockImplementation(() => {
+        throw new Error("provider classification must not block non-auth error rendering");
+      });
+    try {
+      const { chatLog, handleChatEvent } = createHandlersHarness({ localMode: true });
+      handleChatEvent({
+        runId: "run-provider-error",
+        state: "error",
+        errorMessage: "fixture provider failed",
+      });
+      expect(chatLog.addSystem).toHaveBeenCalledWith("run error: fixture provider failed");
+    } finally {
+      classify.mockRestore();
+    }
   });
 
   it("shows a concise /auth hint for local auth failures", () => {

--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -387,7 +387,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
           }
           const isSourceReplyProof = opts.message === "message tool only source reply proof";
           setTimeout(() => {
-            if (opts.message === "xai limit proof") {
+            if (opts.message === "xai limit proof" || opts.message === "provider failure proof") {
               this.onEvent?.({
                 event: "chat",
                 payload: {
@@ -395,7 +395,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
                   sessionKey: opts.sessionKey,
                   seq: 0,
                   state: "error",
-                  errorMessage: xaiLimitError,
+                  errorMessage: opts.message === "xai limit proof" ? xaiLimitError : "fixture provider failed",
                 },
               });
               return;

--- a/src/tui/tui-run-lifecycle.ts
+++ b/src/tui/tui-run-lifecycle.ts
@@ -162,15 +162,13 @@ export function createTuiRunLifecycle(context: TuiRunLifecycleContext) {
   };
 
   const resolveAuthErrorHint = (errorMessage: string): string | undefined => {
-    if (!localMode) {
+    // Cold provider classification must not block errors that cannot receive an auth hint.
+    if (!localMode || !isAuthErrorMessage(errorMessage)) {
       return undefined;
     }
     const provider = state.sessionInfo.modelProvider?.trim();
     const failoverReason = classifyFailoverReason(errorMessage, { provider });
     if (failoverReason === "billing" || failoverReason === "rate_limit") {
-      return undefined;
-    }
-    if (!isAuthErrorMessage(errorMessage)) {
       return undefined;
     }
     return provider

--- a/test/vitest/vitest.test-shards.mjs
+++ b/test/vitest/vitest.test-shards.mjs
@@ -18,6 +18,7 @@ export const tuiPtyTestFiles = [
   "src/tui/tui-session-identity-pty.e2e.test.ts",
   "src/tui/tui-reset-transition-pty.e2e.test.ts",
   "src/tui/tui-task-suggestions-pty.e2e.test.ts",
+  "src/tui/tui-error-pty.e2e.test.ts",
   "src/tui/tui-pty-local.e2e.test.ts",
 ];
 


### PR DESCRIPTION
Closes #131264

## What Problem This Solves

Fixes an issue where users running a cold source TUI could see an already-received non-authentication failure remain at `sending` for seconds before the error appeared.

## Why This Change Was Made

The run lifecycle's optional auth-hint formatter invoked execution/provider failover classification before checking whether the message was auth-shaped. For every non-auth message, it then returned no hint regardless of the classification result. Moving the existing pure predicate first removes that unnecessary work at the display owner, without changing message text or provider-owned auth, billing, or rate-limit interpretation.

Production: **+2/-4 (net -2)**. Tests and test support: **+47/-2**. No new production abstractions, options, dependencies, or protocol fields. The old late predicate is removed.

## User Impact

Non-auth failures render promptly without cold-loading execution classification on the terminal event path. Subsequent input remains usable. Gateway-backed rendering and auth-shaped local errors retain their existing behavior.

## Evidence

- The new handler regression failed before the fix at `resolveAuthErrorHint` when provider classification was made unavailable; after the fix, the same error renders without invoking it.
- `node scripts/run-vitest.mjs src/tui/tui-event-handlers.test.ts src/infra/vitest-e2e-config.test.ts`: **193 tests passed**, including existing local auth/billing and lifecycle/reconnect coverage.
- Real macOS Terminal, isolated temporary state, real `runTui()` loop with the checked-in fake backend: the same non-auth error rendered in **8,144 ms before / 195 ms after**. A separate cold CPU-profiled PTY run measured **12,093 ms before / 1,237 ms after**, with classifier stack frames present only before. These are observed source-run measurements on a heavily loaded host, not a general benchmark or packaged/provider claim.
- Added a fresh-process PTY regression for the error frame plus subsequent session navigation; wired into the canonical PTY shard and routing test. It **passed on clean Linux** using Blacksmith Testbox `tbx_01m12t3p72gqnwszymgzqq31vq`, [workflow 33127689992](https://github.com/openclaw/openclaw/actions/runs/33127689992). The test took 5.04 seconds including startup and cleanup, and passed the unchanged two-second error-response assertion. Wrapper result: `exitCode: 0`, `runStatus: succeeded`; the one-shot lease stopped successfully. This proves the real source TUI with a synthetic backend, not authenticated-provider behavior.
- [Exact-head CI 33126833116](https://github.com/openclaw/openclaw/actions/runs/33126833116) **passed** on `e0cb8a28b9b55fcbf531f098cce82b8ae527d040`, including the TUI handler suite and all hosted core test-type shards. The compact PR selection ran only two built-CLI PTY canaries, not the full PTY inventory; the separate Linux run above explicitly exercised the new case.
- Formatting and `git diff --check` passed. Local `check-changed` passed structural guards, dead-export scans and core production types, then failed core test types because the shared dependency install lacks the pinned `@types/jsdom` package. The same hosted typecheck shards passed; no shared dependency install was changed. Local PTY attempts hit the existing 20-second startup ceiling before the error assertion on the heavily loaded Mac, on Node 26 and Node 24; no timeout was increased.
- Independent Codex autoreview: no accepted/actionable findings. AI-assisted.

Before: terminal remains at `sending` while the classifier imports.

![Before: non-auth failure not yet displayed](https://github.com/user-attachments/assets/0f32e316-ecc7-4c46-8c5e-cba4b317a984)

After: the same failure appears immediately; the capture includes the measured 195 ms result.

![After: error displayed promptly](https://github.com/user-attachments/assets/db5adc25-32dc-48cf-801f-0f57a8abd3e2)

### Scope and follow-up

This does **not** claim to fix the separate cold auth-shaped/403 delay. Replacing provider classification with generic billing predicates would lose provider-owned subscription/budget meanings; removing broad alias lookup would also need runtime-only alias compatibility proof. Carrying a producer-recorded failure category to display is the follow-up to investigate. No provider policy or alias behavior is changed here.

The fixture proves terminal event handling/rendering, not Gateway transport, authenticated providers, or persistence. The original guard ordering predates this checkout's shallow history boundary; that boundary is not reliable attribution for the original bug.

Linux proof command (run from the reviewed task checkout, synchronized by the wrapper):

```sh
node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --timing-json -- \
  CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 \
  node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts \
  src/tui/tui-error-pty.e2e.test.ts
```
