### PR TITLE
test(commands): reuse config snapshot fixtures

### DIFF
--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -35,7 +35,11 @@ import {
   registerOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db-registry.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
-import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+import {
+  baseConfigSnapshot,
+  createTestConfigSnapshot,
+  createTestRuntime,
+} from "./test-runtime-config-helpers.js";
 
 const configMocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
@@ -178,13 +182,7 @@ async function arrangeAgentsDeleteTest(params: {
     recursive: true,
   });
 
-  configMocks.readConfigFileSnapshot.mockResolvedValue({
-    ...baseConfigSnapshot,
-    config: cfg,
-    runtimeConfig: cfg,
-    sourceConfig: cfg,
-    resolved: cfg,
-  });
+  configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(cfg));
 
   return storePath;
 }
@@ -434,13 +432,7 @@ describe("agents delete command", () => {
       },
       "ops",
     );
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: cfg,
-      runtimeConfig: cfg,
-      sourceConfig: cfg,
-      resolved: cfg,
-    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(cfg));
 
     await agentsDeleteCommand({ id: "ops", force: true }, runtime);
 

--- a/src/commands/agents.delete.workspace.test.ts
+++ b/src/commands/agents.delete.workspace.test.ts
@@ -19,7 +19,7 @@ import { GatewayTransportError } from "../gateway/transport-error.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
-import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+import { createTestConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const configMocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
@@ -156,13 +156,7 @@ async function arrangeAgentsDeleteTest(params: {
     recursive: true,
   });
 
-  configMocks.readConfigFileSnapshot.mockResolvedValue({
-    ...baseConfigSnapshot,
-    config: cfg,
-    runtimeConfig: cfg,
-    sourceConfig: cfg,
-    resolved: cfg,
-  });
+  configMocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(cfg));
 
   return storePath;
 }

--- a/src/commands/agents.identity.test.ts
+++ b/src/commands/agents.identity.test.ts
@@ -5,8 +5,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ExpectedCliError } from "../cli/failure-output.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import {
-  baseConfigSnapshot,
   createCapturingTestRuntime,
+  createTestConfigSnapshot,
   createTestRuntime,
 } from "./test-runtime-config-helpers.js";
 
@@ -60,10 +60,9 @@ function getWrittenMainIdentity() {
 }
 
 async function runIdentityCommandFromWorkspace(workspace: string, fromIdentity = true) {
-  configMocks.readConfigFileSnapshot.mockResolvedValue({
-    ...baseConfigSnapshot,
-    config: { agents: { entries: { main: { workspace } } } },
-  });
+  configMocks.readConfigFileSnapshot.mockResolvedValue(
+    createTestConfigSnapshot({ agents: { entries: { main: { workspace } } } }),
+  );
   await agentsSetIdentityCommand({ workspace, fromIdentity }, runtime);
 }
 
@@ -102,17 +101,16 @@ describe("agents set-identity command", () => {
       "",
     ]);
 
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         agents: {
           entries: {
             main: { workspace },
             ops: { workspace: path.join(root, "ops") },
           },
         },
-      },
-    });
+      }),
+    );
 
     await agentsSetIdentityCommand({ workspace }, runtime);
 
@@ -129,10 +127,9 @@ describe("agents set-identity command", () => {
     const { root, workspace } = await createIdentityWorkspace();
     await writeIdentityFile(workspace, ["- Name: Workspace Agent"]);
 
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { main: { workspace } } } },
-    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({ agents: { entries: { main: { workspace } } } }),
+    );
     const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(root);
 
     try {
@@ -149,14 +146,13 @@ describe("agents set-identity command", () => {
     const identityPath = await writeIdentityFile(workspace, ["- Name: Echo"]);
     const originalIdentity = await fs.readFile(identityPath, "utf8");
 
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         agents: {
           entries: { main: { workspace }, ops: { workspace } },
         },
-      },
-    });
+      }),
+    );
 
     await expectIdentityCommandFailure(
       { workspace },
@@ -169,10 +165,9 @@ describe("agents set-identity command", () => {
     const { workspace } = await createIdentityWorkspace("unmatched");
     const identityPath = await writeIdentityFile(workspace, ["- Name: Untouched"]);
     const originalIdentity = await fs.readFile(identityPath, "utf8");
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { main: {} } } },
-    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({ agents: { entries: { main: {} } } }),
+    );
 
     await expectIdentityCommandFailure(
       { workspace, name: "Override", json: true },
@@ -192,10 +187,9 @@ describe("agents set-identity command", () => {
       "",
     ]);
 
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { main: { workspace } } } },
-    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({ agents: { entries: { main: { workspace } } } }),
+    );
 
     await agentsSetIdentityCommand(
       {
@@ -218,10 +212,9 @@ describe("agents set-identity command", () => {
 
   it("sanitizes identity echoes while preserving stored and JSON values", async () => {
     const name = "Operator\u001B]0;identity-injection\u0007🦞\r\nforged-row\tbadge";
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { main: {} } } },
-    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({ agents: { entries: { main: {} } } }),
+    );
 
     await agentsSetIdentityCommand({ agent: "main", name }, runtime);
 
@@ -251,10 +244,9 @@ describe("agents set-identity command", () => {
       "",
     ]);
 
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { main: {} } } },
-    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({ agents: { entries: { main: {} } } }),
+    );
 
     await agentsSetIdentityCommand({ agent: "main", identityFile: identityPath }, runtime);
 
@@ -278,10 +270,9 @@ describe("agents set-identity command", () => {
   });
 
   it("accepts avatar-only updates via flags", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { main: {} } } },
-    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({ agents: { entries: { main: {} } } }),
+    );
 
     await agentsSetIdentityCommand(
       { agent: "main", avatar: "https://example.com/avatar.png" },
@@ -296,10 +287,9 @@ describe("agents set-identity command", () => {
   it.each(["ghostzzz", "агент✨", "   "])(
     "errors without changing config when --agent names %j",
     async (agent) => {
-      configMocks.readConfigFileSnapshot.mockResolvedValue({
-        ...baseConfigSnapshot,
-        config: { agents: { entries: { main: {} } } },
-      });
+      configMocks.readConfigFileSnapshot.mockResolvedValue(
+        createTestConfigSnapshot({ agents: { entries: { main: {} } } }),
+      );
 
       await expectIdentityCommandFailure(
         { agent, name: "Ghost", json: true },
@@ -311,10 +301,9 @@ describe("agents set-identity command", () => {
   it.each(["main", "openclaw", "crestodian"])(
     "does not create absent reserved agent %s",
     async (agentId) => {
-      configMocks.readConfigFileSnapshot.mockResolvedValue({
-        ...baseConfigSnapshot,
-        config: { agents: { entries: { ops: {} } } },
-      });
+      configMocks.readConfigFileSnapshot.mockResolvedValue(
+        createTestConfigSnapshot({ agents: { entries: { ops: {} } } }),
+      );
 
       await expectIdentityCommandFailure(
         { agent: agentId, name: "Hijack" },
@@ -325,10 +314,9 @@ describe("agents set-identity command", () => {
 
   it("rejects an unknown agent before attempting to read its explicit identity file", async () => {
     const { workspace } = await createIdentityWorkspace();
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { main: { workspace } } } },
-    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({ agents: { entries: { main: { workspace } } } }),
+    );
 
     await expectIdentityCommandFailure(
       { agent: "ghost", identityFile: path.join(workspace, "missing.md"), json: true },
@@ -337,14 +325,13 @@ describe("agents set-identity command", () => {
   });
 
   it("still updates a real existing agent", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         agents: {
           entries: { ops: { identity: { emoji: "🛠️" } } },
         },
-      },
-    });
+      }),
+    );
 
     await agentsSetIdentityCommand({ agent: "ops", name: "Operator" }, runtime);
 
@@ -359,15 +346,14 @@ describe("agents set-identity command", () => {
 
   it("still resolves and updates the implicit default agent by workspace", async () => {
     const { workspace } = await createIdentityWorkspace("implicit-main");
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         agents: {
           defaults: { workspace },
           entries: {},
         },
-      },
-    });
+      }),
+    );
 
     await agentsSetIdentityCommand({ workspace, name: "Default Agent" }, runtime);
 
@@ -387,10 +373,9 @@ describe("agents set-identity command", () => {
       "x".repeat(TEST_MAX_IDENTITY_FILE_BYTES + 1),
     ]);
 
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { main: {} } } },
-    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({ agents: { entries: { main: {} } } }),
+    );
 
     const originalIdentity = await fs.readFile(identityPath, "utf8");
     const error = await agentsSetIdentityCommand(
@@ -415,10 +400,9 @@ describe("agents set-identity command", () => {
 
   it("errors when identity data is missing", async () => {
     const { workspace } = await createIdentityWorkspace();
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { main: { workspace } } } },
-    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({ agents: { entries: { main: { workspace } } } }),
+    );
 
     await expectIdentityCommandFailure(
       { workspace, fromIdentity: true, json: true },
@@ -430,10 +414,9 @@ describe("agents set-identity command", () => {
   });
 
   it("leaves unexpected configuration write failures with the shared root owner", async () => {
-    configMocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { main: {} } } },
-    });
+    configMocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({ agents: { entries: { main: {} } } }),
+    );
     const writeFailure = new Error("configuration storage is unavailable");
     configMocks.replaceConfigFile.mockRejectedValueOnce(writeFailure);
 

--- a/src/commands/channels.list.test.ts
+++ b/src/commands/channels.list.test.ts
@@ -4,7 +4,7 @@ import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import type { ChannelPluginCatalogEntry } from "../channels/plugins/catalog.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { resolvePluginControlPlaneWorkspace } from "../plugins/control-plane-workspace.js";
-import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
+import { createTestConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   metadataSnapshot: {
@@ -104,9 +104,7 @@ function createMockChannelPlugin(overrides: {
 function createCatalogEntry(id: string, label: string): ChannelPluginCatalogEntry {
   return {
     id,
-    label,
     pluginId: `@openclaw/${id}`,
-    origin: "official",
     meta: {
       id,
       label,
@@ -115,7 +113,7 @@ function createCatalogEntry(id: string, label: string): ChannelPluginCatalogEntr
       blurb: label,
     },
     install: { npmSpec: `@openclaw/${id}` },
-  } as unknown as ChannelPluginCatalogEntry;
+  };
 }
 
 function loggedText(runtime: ReturnType<typeof createTestRuntime>): string {
@@ -151,10 +149,7 @@ describe("channels list", () => {
 
   it("does not include auth providers in JSON output (auth section was removed)", async () => {
     const runtime = createTestRuntime();
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {},
-    });
+    mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot({}));
 
     await channelsListCommand({ json: true }, runtime);
 
@@ -178,10 +173,7 @@ describe("channels list", () => {
         },
       },
     };
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config,
-    });
+    mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(config));
 
     await channelsListCommand({ json: true }, runtime);
 
@@ -219,7 +211,7 @@ describe("channels list", () => {
       createCatalogEntry("qqbot", "QQ Bot"),
     ]);
     mocks.listManifestInstalledChannelIds.mockReturnValue(new Set(["qqbot"]));
-    mocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot, config });
+    mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(config));
 
     await channelsListCommand({ all: true, json: true }, runtime);
 
@@ -259,7 +251,7 @@ describe("channels list", () => {
       workspaceDir: "/tmp/research-workspace",
       workspaceScope: "selected",
     });
-    mocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot, config });
+    mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(config));
 
     await channelsListCommand({ all: true, json: true }, runtime);
 
@@ -283,10 +275,7 @@ describe("channels list", () => {
 
   it("keeps JSON output valid when only channels are provided (no usage field)", async () => {
     const runtime = createTestRuntime();
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {},
-    });
+    mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot({}));
 
     await channelsListCommand({ json: true }, runtime);
 
@@ -317,10 +306,7 @@ describe("channels list", () => {
         },
       },
     };
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config,
-    });
+    mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(config));
 
     await channelsListCommand({}, runtime);
 
@@ -352,7 +338,7 @@ describe("channels list", () => {
       enabled: true,
     });
     const config = { channels: { telegram: { accounts: { [accountId]: {} } } } };
-    mocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot, config });
+    mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot(config));
 
     const textRuntime = createTestRuntime();
     await channelsListCommand({}, textRuntime);
@@ -397,14 +383,13 @@ describe("channels list", () => {
         ],
       },
     });
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    mocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           discord: { enabled: true },
         },
-      },
-    });
+      }),
+    );
 
     await channelsListCommand({ all: true }, runtime);
 
@@ -433,14 +418,13 @@ describe("channels list", () => {
       enabled: true,
     });
     mocks.callGateway.mockRejectedValue(new Error("gateway unavailable"));
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    mocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           discord: { enabled: true },
         },
-      },
-    });
+      }),
+    );
 
     await channelsListCommand({ all: true }, runtime);
 
@@ -462,14 +446,13 @@ describe("channels list", () => {
       tokenStatus: "configured_unavailable",
       enabled: true,
     });
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    mocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           discord: { enabled: true },
         },
-      },
-    });
+      }),
+    );
 
     await channelsListCommand({ all: true }, runtime);
 
@@ -485,10 +468,7 @@ describe("channels list", () => {
       createCatalogEntry("qqbot", "QQ Bot"),
     ]);
     mocks.listManifestInstalledChannelIds.mockReturnValue(new Set());
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {},
-    });
+    mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot({}));
 
     await channelsListCommand({}, runtime);
 
@@ -516,14 +496,13 @@ describe("channels list", () => {
       repairHint:
         "Install the official external plugin with: openclaw plugins install @openclaw/discord, or run: openclaw doctor --fix.",
     });
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    mocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           discord: { enabled: true, token: "secret" },
         },
-      },
-    });
+      }),
+    );
 
     await channelsListCommand({}, runtime);
 
@@ -566,14 +545,13 @@ describe("channels list", () => {
       repairHint:
         "Install the official external plugin with: openclaw plugins install @openclaw/discord, or run: openclaw doctor --fix.",
     });
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    mocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           discord: { enabled: true, token: "secret" },
         },
-      },
-    });
+      }),
+    );
 
     await channelsListCommand({ json: true }, runtime);
 
@@ -594,10 +572,7 @@ describe("channels list", () => {
       createCatalogEntry("qqbot", "QQ Bot"),
     ]);
     mocks.listManifestInstalledChannelIds.mockReturnValue(new Set());
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {},
-    });
+    mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot({}));
 
     await channelsListCommand({ all: true }, runtime);
 
@@ -617,10 +592,7 @@ describe("channels list", () => {
       configured: false,
       enabled: false,
     });
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {},
-    });
+    mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot({}));
 
     // Without --all: discord should not appear.
     await channelsListCommand({}, runtime);
@@ -653,14 +625,13 @@ describe("channels list", () => {
       createCatalogEntry("qqbot", "QQ Bot"),
     ]);
     mocks.listManifestInstalledChannelIds.mockReturnValue(new Set());
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {
+    mocks.readConfigFileSnapshot.mockResolvedValue(
+      createTestConfigSnapshot({
         channels: {
           telegram: { accounts: { default: { botToken: "x:y" } } },
         },
-      },
-    });
+      }),
+    );
 
     await channelsListCommand({ json: true, all: true }, runtime);
 
@@ -682,10 +653,7 @@ describe("channels list", () => {
       createCatalogEntry("qqbot", "QQ Bot"),
     ]);
     mocks.listManifestInstalledChannelIds.mockReturnValue(new Set(["wecom"]));
-    mocks.readConfigFileSnapshot.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: {},
-    });
+    mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot({}));
 
     await channelsListCommand({ all: true, json: true }, runtime);
 
@@ -722,10 +690,7 @@ describe("channels list", () => {
         createCatalogEntry("wecom", "WeCom"),
       ]);
       mocks.listManifestInstalledChannelIds.mockReturnValue(new Set(["wecom"]));
-      mocks.readConfigFileSnapshot.mockResolvedValue({
-        ...baseConfigSnapshot,
-        config: {},
-      });
+      mocks.readConfigFileSnapshot.mockResolvedValue(createTestConfigSnapshot({}));
 
       await channelsListCommand({ all: true }, runtime);
 


### PR DESCRIPTION
## What Problem This Solves

Four command test suites manually assembled configuration snapshots in slightly different ways. Several mocks overrode only `config`, leaving the snapshot's authored, runtime, resolved, and compatibility views inconsistent; deletion suites repeated the complete envelope by hand. The channels-list catalog fixture also duplicated fields already owned by canonical catalog metadata and needed an `unknown` cast.

## Why This Change Was Made

The tests now use the existing `createTestConfigSnapshot` owner helper so every mocked snapshot carries the same complete, internally consistent configuration views. The channels-list catalog fixture supplies the canonical metadata shape directly and no longer launders it through `unknown`.

This is a test-only cleanup. It does not change command behavior, runtime configuration, catalog policy, public API, or production code.

## Evidence

- Pre-cleanup baseline: 73/73 focused owner tests passed.
- Frozen four-file candidate: 73/73 focused owner tests passed.
- Assertion preservation: all 222 changed-suite expectation sites remain present; the broader matcher-expression inventory remains intact.
- Complete changed-file gate: exit 0.
- Fresh isolated P0 autoreview: no findings, 0.99 confidence.
- Production LOC: +0/-0. Tests: +103/-169 (net -66).
