### PR TITLE
fix(ui): shrink oversized Plugins trash icons

### DIFF
--- a/ui/src/components/form-controls.browser.test.ts
+++ b/ui/src/components/form-controls.browser.test.ts
@@ -33,6 +33,7 @@ function readUiCss(): string {
     "ui/src/styles/chat/layout.css",
     "ui/src/styles/sidebar-markdown.css",
     "ui/src/styles/chat/sidebar.css",
+    "ui/src/styles/plugins.css",
   ];
   return files.map((file) => readStyleSheet(file)).join("\n");
 }
@@ -165,6 +166,43 @@ describeBrowserLayout("sensitive input visibility", () => {
         display: getComputedStyle(mask).display,
       }));
       expect(state).toEqual({ hidden: true, display: "none" });
+    } finally {
+      await page.close().catch(() => {});
+    }
+  });
+});
+
+describeBrowserLayout("settings icon buttons", () => {
+  it("keeps plugin and MCP remove glyphs proportionate to settings buttons", async () => {
+    const page = await desktopContext.newPage();
+    try {
+      await page.setContent(`
+        <!doctype html>
+        <html data-theme-mode="light">
+          <head><style>${readUiCss()}</style></head>
+          <body>
+            <div class="settings-row__control">
+              <button class="btn btn--sm btn--icon plugins-remove" type="button">
+                <svg viewBox="0 0 24 24"><path d="M3 6h18" /></svg>
+              </button>
+            </div>
+          </body>
+        </html>
+      `);
+
+      const metrics = await page.locator(".plugins-remove").evaluate((button) => {
+        const glyph = button.querySelector("svg");
+        if (!(glyph instanceof SVGElement)) {
+          throw new Error("Missing remove button glyph");
+        }
+        const buttonRect = button.getBoundingClientRect();
+        const glyphRect = glyph.getBoundingClientRect();
+        return {
+          button: [buttonRect.width, buttonRect.height],
+          glyph: [glyphRect.width, glyphRect.height],
+        };
+      });
+      expect(metrics).toEqual({ button: [32, 32], glyph: [18, 18] });
     } finally {
       await page.close().catch(() => {});
     }

--- a/ui/src/styles/plugins.css
+++ b/ui/src/styles/plugins.css
@@ -390,21 +390,7 @@ h3.plugins-subheader {
 }
 
 .plugins-remove {
-  width: 30px;
-  height: 30px;
-  min-width: 30px;
-  padding: 7px;
   color: var(--muted);
-}
-
-.plugins-remove svg {
-  width: 100%;
-  height: 100%;
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 1.7px;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 
 .plugins-remove:hover:not(:disabled) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing removable plugins or MCP servers in Settings → Plugins saw trash glyphs nearly fill their icon buttons, making the destructive actions visually oversized.

## Why This Change Was Made

The Plugins stylesheet carried an older local button geometry while the shared Settings row contract now owns the 32px button size and zero padding. Their cascade stretched the local `width: 100%` SVG to 30×30px. This removes the stale local geometry so the existing shared icon-button contract renders an 18×18px glyph inside the unchanged 32×32px hit target.

The audit covered all 45 Control UI `btn--icon` call sites and all 14 `icons.trash` render sites. Other delete/icon-only controls already render in the established 14–18px range; this shared Plugins helper was the only full-button outlier. The helper serves both installed-plugin and MCP-server rows.

## User Impact

Trash actions in Plugins and MCP rows now match the visual weight of neighboring controls while keeping the same accessible labels and click targets.

## Evidence

| Before — 30×30 glyphs | After — 18×18 glyphs |
| --- | --- |
| ![Before: oversized plugin and MCP trash icons](https://github.com/user-attachments/assets/d5a9ad20-0a90-4b22-abb5-b0dc517e278c) | ![After: proportionate plugin and MCP trash icons](https://github.com/user-attachments/assets/fd17de36-e08d-4810-8bb6-f7a726582637) |

Captured from the real mocked Control UI route at 393×852. The screenshot includes both affected consumers of the shared helper: Calendar Plus (installed plugin) and github (MCP server).

Validation:

- Red/green browser regression: old CSS measured both buttons at 32×32px with 30×30px glyphs; repaired CSS measures 32×32px with 18×18px glyphs.
- `node scripts/run-vitest.mjs ui/src/components/form-controls.browser.test.ts` — 10 passed.
- Plugins mocked-Gateway E2E — 6 passed across desktop and mobile layouts.
- `pnpm check:changed` — passed.
- `pnpm ui:build` — passed.
- Autoreview — clean, no actionable findings.

Production LOC: +0/-14 (net -14) | Tests: +38/-0
