### PR TITLE
fix(github-copilot): normalize malformed usage errors

### DIFF
--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -243,6 +243,23 @@ describe("fetchCopilotUsage", () => {
     expect(canceled).toBe(true);
   });
 
+  it("returns a stable error snapshot for malformed successful JSON responses", async () => {
+    const mockFetch = createProviderUsageFetch(
+      async () =>
+        new Response("{", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    await expect(fetchCopilotUsage("token", 5000, mockFetch)).resolves.toEqual({
+      provider: "github-copilot",
+      displayName: "Copilot",
+      windows: [],
+      error: "Malformed usage response",
+    });
+  });
+
   it("parses premium/chat usage from remaining percentages", async () => {
     const mockFetch = createProviderUsageFetch(async (_url, init) => {
       const headers = (init?.headers as Record<string, string> | undefined) ?? {};

--- a/extensions/github-copilot/usage.ts
+++ b/extensions/github-copilot/usage.ts
@@ -1,7 +1,11 @@
 // Github Copilot plugin module implements usage behavior.
 import { buildCopilotIdeHeaders } from "openclaw/plugin-sdk/provider-auth";
-import { readProviderJsonResponse } from "openclaw/plugin-sdk/provider-http";
 import {
+  ProviderJsonParseError,
+  readProviderJsonResponse,
+} from "openclaw/plugin-sdk/provider-http";
+import {
+  buildUsageErrorSnapshot,
   buildUsageHttpErrorSnapshot,
   fetchJson,
   clampPercent,
@@ -46,7 +50,16 @@ export async function fetchCopilotUsage(
     });
   }
 
-  const payload = await readProviderJsonResponse<unknown>(res, "github-copilot-usage");
+  let payload: unknown;
+  try {
+    payload = await readProviderJsonResponse<unknown>(res, "github-copilot-usage");
+  } catch (error) {
+    // Keep bounded-reader failures visible while normalizing malformed provider JSON.
+    if (error instanceof ProviderJsonParseError) {
+      return buildUsageErrorSnapshot("github-copilot", "Malformed usage response");
+    }
+    throw error;
+  }
   const data = isRecord(payload) ? (payload as CopilotUsageResponse) : {};
   const windows: UsageWindow[] = [];
 

--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -8,6 +8,7 @@ import {
   extractProviderRequestId,
   formatProviderErrorPayload,
   ProviderHttpError,
+  ProviderJsonParseError,
   readProviderBinaryResponse,
   readProviderJsonResponse,
   readProviderTextResponse,
@@ -519,9 +520,12 @@ describe("provider error utils", () => {
       headers: { "content-type": "application/json" },
     });
 
-    await expect(readProviderJsonResponse(response, "Provider catalog failed")).rejects.toThrow(
-      "Provider catalog failed: malformed JSON response",
-    );
+    await expect(
+      readProviderJsonResponse(response, "Provider catalog failed"),
+    ).rejects.toMatchObject({
+      message: "Provider catalog failed: malformed JSON response",
+      name: "ProviderJsonParseError",
+    } satisfies Partial<ProviderJsonParseError>);
   });
 
   it("does not retain reflected credentials in malformed JSON causes", async () => {

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -336,6 +336,24 @@ export class ProviderHttpError extends Error {
   }
 }
 
+/**
+ * Error raised when a bounded provider JSON response cannot be decoded or parsed.
+ *
+ * Public contract: only the decode/parse step of the bounded JSON readers
+ * (`readProviderJsonResponse` and its object/array variants) throws this subtype, so callers can
+ * distinguish malformed JSON from transport failures. Reader-level failures such as size caps,
+ * stalled or truncated bodies, and binary content keep their existing error types and are never
+ * relabeled as this class. The `name` is the stable string "ProviderJsonParseError" and the
+ * message is `<label>: malformed JSON response`; the underlying cause is attached only when the
+ * request had no headers, so header-bearing failures never leak credentials through the cause.
+ */
+export class ProviderJsonParseError extends Error {
+  constructor(label: string, cause: unknown, options?: { omitCause?: boolean }) {
+    super(`${label}: malformed JSON response`, options?.omitCause ? undefined : { cause });
+    this.name = "ProviderJsonParseError";
+  }
+}
+
 /** Builds the human-facing provider HTTP error message from normalized metadata. */
 export function formatProviderHttpErrorMessage(params: {
   label: string;
@@ -416,11 +434,10 @@ export async function readProviderJsonResponse<T>(
   try {
     return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(bytes)) as T;
   } catch (cause) {
-    // oxlint-disable-next-line preserve-caught-error -- Parser causes can quote partial credentials; header-bearing failures must omit them.
-    throw new Error(
-      `${label}: malformed JSON response`,
-      opts?.requestHeaders ? undefined : { cause },
-    );
+    // Parser causes can quote partial credentials; header-bearing failures must omit them.
+    throw new ProviderJsonParseError(label, cause, {
+      omitCause: Boolean(opts?.requestHeaders),
+    });
   }
 }
 

--- a/src/infra/provider-usage.test.ts
+++ b/src/infra/provider-usage.test.ts
@@ -1,5 +1,5 @@
-// Tests provider usage aggregation and formatting.
 import { beforeEach, describe, expect, it } from "vitest";
+// Tests provider usage aggregation and formatting.
 import { createProviderUsageFetch } from "../test-utils/provider-usage-fetch.js";
 import {
   getProviderUsageSnapshotWithPluginMock,

--- a/src/plugin-sdk/provider-http.ts
+++ b/src/plugin-sdk/provider-http.ts
@@ -6,6 +6,9 @@ export {
   type TlsCertificateErrorDetails,
   type TlsCertificateErrorKind,
 } from "@openclaw/ai/internal/shared";
+// ProviderJsonParseError is thrown only by the decode/parse step of the bounded JSON readers so
+// plugin authors can distinguish malformed JSON from transport failures; reader-level failures
+// (size caps, stalled or truncated bodies) keep their existing error types.
 export {
   assertOkOrThrowHttpError,
   assertOkOrThrowProviderError,
@@ -22,6 +25,7 @@ export {
   readProviderTextResponse,
   readResponseTextLimited,
   truncateErrorDetail,
+  ProviderJsonParseError,
 } from "../agents/provider-http-errors.js";
 export {
   readProviderResponseErrorText,


### PR DESCRIPTION
## What Problem This Solves

When GitHub Copilot's usage endpoint returns HTTP 200 with malformed JSON, the usage report should show a stable provider diagnostic instead of leaking the low-level JSON-reader error.

The existing usage loader already contains provider-hook failures and preserves healthy sibling providers. This change targets the diagnostic contract; it does not claim to recover quota from malformed data or change aggregate failure containment.

## Why This Change Was Made

The bounded JSON reader now raises a typed `ProviderJsonParseError`. The Copilot usage entrypoint maps only that decode/parse failure to the canonical `Malformed usage response` snapshot; bounded-reader overflow and stalled-body failures still propagate to the existing loader boundary. This follows the shared `buildUsageErrorSnapshot` contract and the malformed-response hardening in [PR #110795](https://github.com/openclaw/openclaw/pull/110795).

## User Impact

`openclaw status --usage` — the full provider-report surface — shows `Copilot: Malformed usage response` for an HTTP-200 malformed body while healthy provider entries remain visible; malformed data still cannot provide quota windows.

## Evidence

- Real authenticated provider trace at exact head `95fdf9364d28a95c6a9518d6a89e081570dd2a94`: the production `fetchCopilotUsage` entrypoint used native `fetch` against `api.github.com/copilot_internal/user` and returned HTTP 200 JSON with `error=null`, `plan=individual`, and no quota windows.
- Comparable production-module control: validation base `2026a7b47b1b9833dd36efc38feb4f014fd820ef` threw `github-copilot-usage: malformed JSON response`; exact head `95fdf9364d28a95c6a9518d6a89e081570dd2a94` returned `error=Malformed usage response` for the same HTTP 200 malformed body. The fixture is used only at the unavailable malformed-response provider boundary.
- Existing loader and formatter coverage continues to isolate provider-hook failures and keep healthy sibling providers visible; the plugin-local regression covers the Copilot malformed-response mapping.
- Unchanged negative control: the authenticated live response remained a valid usage snapshot on exact head `95fdf9364d28a95c6a9518d6a89e081570dd2a94`.
- Focused regression coverage: `pnpm test extensions/github-copilot/models.test.ts src/infra/provider-usage.load.test.ts src/infra/provider-usage.test.ts --maxWorkers=1 --reporter=verbose` passed, including malformed-response mapping, provider-failure containment, and the oversized-response reader failure.
- Canonical precedent: the shared `buildUsageErrorSnapshot` contract and merged [PR #110795](https://github.com/openclaw/openclaw/pull/110795).

```text
$ GITHUB_TOKEN="$(gh auth token)" pnpm exec tsx proof-live.ts
entrypoint: extensions/github-copilot/usage.ts:fetchCopilotUsage
boundary: native fetch to https://api.github.com/copilot_internal/user
http: status=200 content-type=application/json; charset=utf-8
snapshot: {"error":null,"plan":"individual","windows":[]}

$ pnpm exec tsx proof-malformed.ts
base (2026a7b47b1b9833dd36efc38feb4f014fd820ef): malformed: threw github-copilot-usage: malformed JSON response
head (95fdf9364d28a95c6a9518d6a89e081570dd2a94): malformed: returned {"error":"Malformed usage response"}
```

The authenticated command uses a GitHub CLI token without printing the token or raw response. The live provider returned valid JSON, so the malformed branch is shown separately through the same production entrypoint and the deterministic provider-boundary control.

<details>
<summary>proof-live.ts</summary>

```ts
import { fetchCopilotUsage } from "./extensions/github-copilot/usage.ts";

const token = process.env.GITHUB_TOKEN?.trim();
if (!token) {
  throw new Error("GITHUB_TOKEN is required");
}

let status: number | undefined;
let contentType: string | null = null;
const nativeFetch: typeof fetch = async (input, init) => {
  const response = await fetch(input, init);
  status = response.status;
  contentType = response.headers.get("content-type");
  return response;
};

const snapshot = await fetchCopilotUsage(token, 15_000, nativeFetch);
console.log("entrypoint: extensions/github-copilot/usage.ts:fetchCopilotUsage");
console.log("boundary: native fetch to https://api.github.com/copilot_internal/user");
console.log(`http: status=${status ?? "unknown"} content-type=${contentType ?? "unknown"}`);
console.log(
  `snapshot: ${JSON.stringify({
    error: snapshot.error ?? null,
    plan: snapshot.plan ?? null,
    windows: snapshot.windows,
  })}`,
);
```

</details>

<details>
<summary>proof-malformed.ts</summary>

```ts
import { fetchCopilotUsage } from "./extensions/github-copilot/usage.ts";

const malformedFetch: typeof fetch = async () =>
  new Response("{", {
    status: 200,
    headers: { "content-type": "application/json" },
  });

try {
  const snapshot = await fetchCopilotUsage("redacted", 15_000, malformedFetch);
  console.log(`malformed: returned ${JSON.stringify({ error: snapshot.error ?? null })}`);
} catch (error) {
  console.log(`malformed: threw ${error instanceof Error ? error.message : String(error)}`);
}
```

</details>

Additional exact-head transport proof: `95fdf9364d28a95c6a9518d6a89e081570dd2a94` exercised the production `fetchCopilotUsage` entrypoint through native `fetch` and an isolated loopback HTTP server, rather than an in-memory `Response`. The valid HTTP 200 control returned `{"error":null,"plan":"individual","windows":[{"label":"Premium","usedPercent":20},{"label":"Chat","usedPercent":40}]}`; the malformed HTTP 200 body returned `{"error":"Malformed usage response","windows":[]}`. The wrapper only redirected the production URL to the loopback server, so both cases crossed the real transport, bounded reader, and provider mapping boundary.

Current head delta over the reviewed head `95fdf9364d28a95c6a9518d6a89e081570dd2a94`: a patch-equivalent rebase onto `29464d4ff7d6e7ac37e87a0e29064c930ea19439` plus comment-only contract documentation. The public parse-error contract is now documented at the source class and the SDK re-export: `ProviderJsonParseError` is thrown only by the decode/parse step of the bounded JSON readers, reader-level failures (size caps, stalled or truncated bodies) keep their existing error types, and the stable `name`/message shape is stated for plugin authors. No runtime behavior changed in this delta.

- Conflict-path rebase receipt: the ordered patch series survived the rebase onto `29464d4ff7d6e7ac37e87a0e29064c930ea19439` with one import-list conflict in `src/agents/provider-http-errors.test.ts` resolved by keeping both imported symbols; focused validation passed at the rebased head: `node scripts/run-vitest.mjs src/agents/provider-http-errors.test.ts`, `node scripts/run-vitest.mjs extensions/github-copilot/models.test.ts`, and `node scripts/run-vitest.mjs src/infra/provider-usage.test.ts`.

AI-assisted: built with Codex
