### PR TITLE
fix(code-mode): continue tasks after proven-safe wait failures

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -186,8 +186,9 @@ try {
 
 JavaScript syntax errors, TypeScript transform errors, and tool failures proven
 to occur before execution become failed `exec` results that the model can read
-and correct across successive turns. A failed tool call does not automatically
-end the agent run when OpenClaw can prove that no nested action started.
+and correct across successive turns. A failed `exec` or `wait` does not automatically
+end the agent run when OpenClaw's host execution record proves that no potentially
+mutating nested action started, including before a suspended run resumed.
 
 Catalog search, handle `describe()`, `skills.list()`, and `skills.read()` are
 read-only discovery. A guest error after only these operations still allows
@@ -991,13 +992,15 @@ code-mode tool call and the nested tool id.
 
 Nested tool failures cross into the guest as catchable JavaScript errors. If
 guest code does not catch an error, `exec` or `wait` returns a failed tool
-result. In `exec`, proven no-start failures and guest-only errors, including
-errors after read-only discovery, allow ordinary model recovery. A failed `wait`
-still ends ordinary continuation. Possible nested side effects require authorized
-read-only reconciliation before any further action. Network-controlled tool output and
-errors retain their existing untrusted-content wrapping and sanitization;
-recovering from a failure does not grant new permissions or replay completed
-side effects.
+result. Proven no-start failures and errors after only audited read-only work
+allow ordinary model recovery, including when `wait` resumes a suspended cell.
+This proof covers the cell's entire execution, not just the latest resume.
+Failed waits without that host proof remain terminal; serialized result fields
+cannot grant recovery. Possible nested side effects in a failed `exec` require
+authorized read-only reconciliation before any further action. Network-controlled
+tool output and errors retain their existing untrusted-content wrapping and
+sanitization; recovering from a failure does not grant new permissions or replay
+completed side effects.
 
 Parallel nested calls are allowed up to `maxPendingToolCalls`.
 

--- a/src/agents/code-mode-swarm.test.ts
+++ b/src/agents/code-mode-swarm.test.ts
@@ -1,12 +1,15 @@
 import { createHash } from "node:crypto";
 import { stableStringify } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { createCodeModeNamespaceRuntime } from "./code-mode-namespaces.js";
 import { consumeRepairableCodeModeFailure } from "./code-mode-repair-provenance.js";
 import { applyCodeModeCatalog, resolveCodeModeConfig } from "./code-mode.js";
 import {
   createCodeModeHarness,
   fakeTool,
+  resetCodeModeTestState,
+  resultDetails,
   runUntilCompleted,
   testing,
 } from "./code-mode.test-support.js";
@@ -168,7 +171,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  testing.activeRuns.clear();
+  resetCodeModeTestState();
+  vi.useRealTimers();
 });
 
 describe("Code Mode swarm guest", () => {
@@ -286,18 +290,51 @@ describe("Code Mode swarm guest", () => {
     }
   });
 
-  it("keeps a guest error after agents.run restricted", async () => {
-    const details = await runSwarmCode(
-      createSwarmHarness(),
-      `await agents.run("Research"); return missingAfterCollector();`,
-    );
-
-    expect(details).toMatchObject({
-      status: "failed",
-      failurePhase: "bridge",
-      bridgeDispatchStarted: true,
+  it("keeps a guest error after a parked agents.run restricted without replaying the collector", async () => {
+    const collectorStarted = createDeferred();
+    const collectorRelease = createDeferred();
+    swarmMocks.waitForCollectorCompletion.mockImplementation(async () => {
+      collectorStarted.resolve();
+      await collectorRelease.promise;
+      return { runId: "collector-1", status: "done", result: "collected" };
     });
-    expect(consumeRepairableCodeModeFailure(details)).toBe(false);
+    const harness = createSwarmHarness();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+    const executing = harness.tools[0]!.execute("parked-collector", {
+      code: `await agents.run("Research"); return missingAfterCollector();`,
+    });
+    try {
+      await collectorStarted.promise;
+      await vi.advanceTimersByTimeAsync(10_000);
+      const parked = resultDetails(await executing);
+      expect(parked).toMatchObject({
+        status: "waiting",
+        reason: "pending_tools",
+        pendingToolCalls: [expect.objectContaining({ method: "agentWait" })],
+      });
+      vi.useRealTimers();
+      collectorRelease.resolve();
+      const details = resultDetails(
+        await harness.tools[1]!.execute("collector-wait", {
+          runId: parked.runId,
+        }),
+      );
+
+      expect(details).toMatchObject({
+        status: "failed",
+        failurePhase: "bridge",
+        bridgeDispatchStarted: true,
+        error: expect.stringContaining("ReferenceError: missingAfterCollector is not defined"),
+      });
+      expect(consumeRepairableCodeModeFailure(details)).toBe(false);
+      expect(harness.spawnTool.execute).toHaveBeenCalledOnce();
+      expect(swarmMocks.waitForCollectorCompletion).toHaveBeenCalledOnce();
+      expect(testing.activeRuns.size).toBe(0);
+    } finally {
+      collectorRelease.resolve();
+      vi.useRealTimers();
+      await executing;
+    }
   });
 
   it.each([

--- a/src/agents/code-mode.agent-loop.test.ts
+++ b/src/agents/code-mode.agent-loop.test.ts
@@ -1,3 +1,6 @@
+import { access, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   createAssistantMessageEventStream,
   type AssistantMessage,
@@ -5,7 +8,9 @@ import {
   type Model,
 } from "openclaw/plugin-sdk/llm";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
+import { consumeRepairableCodeModeFailure } from "./code-mode-repair-provenance.js";
 import type { CodeModeSkill } from "./code-mode-skills.js";
 import { applyCodeModeCatalog } from "./code-mode.js";
 import {
@@ -13,10 +18,13 @@ import {
   fakeTool,
   pluginToolWithExecute,
   resetCodeModeTestState,
+  resultDetails,
+  testing,
 } from "./code-mode.test-support.js";
 import { installCodeModeOutcomeHook } from "./embedded-agent-runner/run/code-mode-outcome.js";
 import { Agent } from "./runtime/index.js";
-import { isToolResultError } from "./tool-result-error.js";
+import { createReadTool } from "./sessions/tools/read.js";
+import { isToolResultError, readToolResultDetails } from "./tool-result-error.js";
 import { jsonResult, ToolInputError, type AnyAgentTool } from "./tools/common.js";
 
 const model: Model = {
@@ -53,9 +61,10 @@ function createAssistant(content: AssistantMessage["content"]): AssistantMessage
 }
 
 async function runCodeModeAgent(params: {
-  programs: string[];
+  programs: Array<string | { wait: true }>;
   hiddenTools: AnyAgentTool[];
   codeModeSkills?: CodeModeSkill[];
+  configureAgent?: (agent: Agent) => void;
 }) {
   const { config, catalogRef, tools } = createCodeModeHarness({
     codeModeSkills: params.codeModeSkills,
@@ -80,10 +89,20 @@ async function runCodeModeAgent(params: {
       providerContexts.push(context);
       const index = providerContexts.length - 1;
       const code = params.programs[index];
+      const waiting = code !== undefined && typeof code !== "string";
       const message = createAssistant(
         code === undefined
           ? [{ type: "text", text: "recovered" }]
-          : [{ type: "toolCall", id: `code-call-${index}`, name: "exec", arguments: { code } }],
+          : [
+              {
+                type: "toolCall",
+                id: `code-call-${index}`,
+                name: waiting ? "wait" : "exec",
+                arguments: waiting
+                  ? { runId: readToolResultDetails(context.messages.at(-1))?.runId }
+                  : { code },
+              },
+            ],
       );
       const stream = createAssistantMessageEventStream();
       queueMicrotask(() => {
@@ -97,6 +116,7 @@ async function runCodeModeAgent(params: {
       return stream;
     },
   });
+  params.configureAgent?.(agent);
   installCodeModeOutcomeHook({
     agent,
     onReconciliationCandidate: () => {
@@ -108,8 +128,168 @@ async function runCodeModeAgent(params: {
   return { agent, providerContexts, reconciliationCandidates };
 }
 
+type ParkedFailure =
+  | "read-only"
+  | "earlier mutation"
+  | "terminal read"
+  | "copied details"
+  | "cancel wait"
+  | "abort outcome";
+
+async function runParkedReadFailure(scenario: ParkedFailure) {
+  const workspace = await realpath(await mkdtemp(join(tmpdir(), "code-mode-wait-")));
+  const input = join(workspace, "input.txt");
+  await writeFile(input, "audited input\n");
+  const readStarted = createDeferred();
+  const readRelease = createDeferred();
+  const readFinished = createDeferred();
+  const parked = createDeferred<Record<string, unknown>>();
+  const beginWait = createDeferred();
+  const outcomeEntered = createDeferred();
+  const outcomeRelease = createDeferred();
+  const effects: string[] = [];
+  const read = createReadTool(workspace, {
+    operations: {
+      access,
+      readFile: async (file) => {
+        readStarted.resolve();
+        await readRelease.promise;
+        try {
+          return await readFile(file);
+        } finally {
+          readFinished.resolve();
+        }
+      },
+    },
+  });
+  const executeRead = read.execute.bind(read);
+  read.execute = vi.fn(async (...args: Parameters<typeof executeRead>) => ({
+    ...(await executeRead(...args)),
+    ...(scenario === "terminal read" ? { terminate: true } : {}),
+  }));
+  const complete = pluginToolWithExecute("complete_task", "Complete the task", async () => {
+    effects.push("completed");
+    return jsonResult({ completed: true });
+  });
+  let activeAgent: Agent | undefined;
+  let waitDetails: Record<string, unknown> | undefined;
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "Date"] });
+  const running = runCodeModeAgent({
+    hiddenTools: [read, complete],
+    programs: [
+      `${scenario === "earlier mutation" ? "await complete_task({});" : ""}
+       json(await read({ path: ${JSON.stringify(input)} })); return missingAfterWait();`,
+      { wait: true },
+      "return await complete_task({});",
+    ],
+    configureAgent: (agent) => {
+      activeAgent = agent;
+      agent.afterToolCall = async ({ toolCall, result, isError }) => {
+        if (toolCall.name === "wait") {
+          waitDetails = resultDetails(result);
+          if (scenario === "copied details") {
+            return { details: structuredClone(waitDetails), isError: true };
+          }
+        }
+        return { isError: isError || isToolResultError(result) };
+      };
+      agent.afterToolOutcome = async ({ toolCall, result }) => {
+        if (toolCall.name === "exec" && readToolResultDetails(result)?.status === "waiting") {
+          vi.useRealTimers();
+          parked.resolve(resultDetails(result));
+          await beginWait.promise;
+        }
+        if (toolCall.name === "wait" && scenario === "abort outcome") {
+          outcomeEntered.resolve();
+          await outcomeRelease.promise;
+        }
+      };
+    },
+  });
+  try {
+    await readStarted.promise;
+    // Only the host deadline moves; the real worker has already dispatched the audited read.
+    await vi.advanceTimersByTimeAsync(10_000);
+    const suspended = await parked.promise;
+    expect(suspended).toMatchObject({
+      status: "waiting",
+      reason: "pending_tools",
+      replaySafe: false,
+    });
+    expect(read.execute).toHaveBeenCalledOnce();
+    expect(effects).toEqual(scenario === "earlier mutation" ? ["completed"] : []);
+    beginWait.resolve();
+    if (scenario === "cancel wait") {
+      await vi.waitFor(() => expect(testing.resumingRunIds.size).toBe(1));
+      activeAgent?.abort();
+    } else {
+      readRelease.resolve();
+    }
+    if (scenario === "abort outcome") {
+      await outcomeEntered.promise;
+      activeAgent?.abort();
+      outcomeRelease.resolve();
+    }
+    const result = await running;
+    expect(read.execute).toHaveBeenCalledOnce();
+    expect(testing.activeRuns.size).toBe(0);
+    expect(testing.resumingRunIds.size).toBe(0);
+    expect(result.reconciliationCandidates).toBe(0);
+    expect(waitDetails).toMatchObject(
+      scenario === "cancel wait"
+        ? { status: "failed", code: "aborted" }
+        : {
+            status: "failed",
+            bridgeDispatchStarted: true,
+            error: expect.stringContaining("ReferenceError: missingAfterWait is not defined"),
+            output: [expect.objectContaining({ type: "json" })],
+          },
+    );
+    return { ...result, complete, effects, waitDetails };
+  } finally {
+    vi.useRealTimers();
+    activeAgent?.abort();
+    beginWait.resolve();
+    readRelease.resolve();
+    outcomeRelease.resolve();
+    await running;
+    await readFinished.promise;
+    await rm(workspace, { recursive: true, force: true });
+  }
+}
+
 describe("Code Mode agent-loop error recovery", () => {
-  afterEach(() => resetCodeModeTestState());
+  afterEach(() => {
+    resetCodeModeTestState();
+    vi.useRealTimers();
+  });
+
+  it("recovers from a real parked read failure and completes the requested mutation once", async () => {
+    const { agent, providerContexts, complete, effects } = await runParkedReadFailure("read-only");
+    expect(providerContexts).toHaveLength(4);
+    expect(complete.execute).toHaveBeenCalledOnce();
+    expect(effects).toEqual(["completed"]);
+    expect(agent.state.messages.at(-1)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "recovered" }],
+    });
+  });
+
+  it.each([
+    "earlier mutation",
+    "terminal read",
+    "copied details",
+    "cancel wait",
+    "abort outcome",
+  ] as const)("prevents another provider turn after a parked failure with %s", async (scenario) => {
+    const { providerContexts, complete, effects, waitDetails } =
+      await runParkedReadFailure(scenario);
+    expect(providerContexts).toHaveLength(2);
+    expect(complete.execute).toHaveBeenCalledTimes(scenario === "earlier mutation" ? 1 : 0);
+    expect(effects).toEqual(scenario === "earlier mutation" ? ["completed"] : []);
+    // Replacing details before the outcome boundary must leave the original proof unused.
+    expect(consumeRepairableCodeModeFailure(waitDetails)).toBe(scenario === "copied details");
+  });
 
   it.each([
     {

--- a/src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { registerRepairableCodeModeFailure } from "../../code-mode-repair-provenance.js";
 import type { Agent } from "../../runtime/index.js";
+import { readToolResultDetails } from "../../tool-result-error.js";
 import { installCodeModeOutcomeHook } from "./code-mode-outcome.js";
 
 type AfterToolOutcomeContext = Parameters<NonNullable<Agent["afterToolOutcome"]>>[0];
@@ -8,7 +9,7 @@ type AfterToolOutcomeContext = Parameters<NonNullable<Agent["afterToolOutcome"]>
 function createOutcome(
   options: {
     bridgeStarted?: boolean;
-    noToolStarted?: boolean;
+    repairableFailure?: boolean;
     toolName?: "exec" | "wait";
     terminal?: boolean;
   } = {},
@@ -18,7 +19,7 @@ function createOutcome(
     error: "execution failed",
     bridgeDispatchStarted: options.bridgeStarted ?? false,
   };
-  if (options.noToolStarted) {
+  if (options.repairableFailure) {
     registerRepairableCodeModeFailure(details);
   }
   const toolCall = {
@@ -61,17 +62,38 @@ describe("Code Mode outcome safety", () => {
     expect(onReconciliationCandidate).not.toHaveBeenCalled();
   });
 
-  it("continues only when host provenance proves a bridge target never started", async () => {
-    const { agent, onReconciliationCandidate } = createAgent();
+  it.each(["exec", "wait"] as const)(
+    "accepts exact host proof once for %s, never copied or serialized proof",
+    async (toolName) => {
+      const outcome = createOutcome({ toolName, bridgeStarted: true, repairableFailure: true });
+      const details = readToolResultDetails(outcome.result);
+      for (const copied of [
+        { ...details },
+        structuredClone(details),
+        // oxlint-disable-next-line unicorn/prefer-structured-clone -- Exercise serialized tool results separately from in-memory clones.
+        JSON.parse(JSON.stringify(details)),
+      ]) {
+        const { agent } = createAgent();
+        await expect(
+          agent.afterToolOutcome?.({
+            ...outcome,
+            result: { ...outcome.result, details: copied },
+          }),
+        ).resolves.toMatchObject({ isError: true, terminate: true });
+      }
 
-    const result = await agent.afterToolOutcome?.(
-      createOutcome({ bridgeStarted: true, noToolStarted: true }),
-    );
-
-    expect(result).toMatchObject({ isError: true });
-    expect(result).not.toHaveProperty("terminate");
-    expect(onReconciliationCandidate).not.toHaveBeenCalled();
-  });
+      const { agent, onReconciliationCandidate } = createAgent();
+      const result = await agent.afterToolOutcome?.(outcome);
+      expect(result).toMatchObject({ isError: true });
+      expect.soft(result).not.toHaveProperty("terminate");
+      expect(onReconciliationCandidate).not.toHaveBeenCalled();
+      // The real consumer used the proof above; never mint it again for the replay.
+      await expect(createAgent().agent.afterToolOutcome?.(outcome)).resolves.toMatchObject({
+        isError: true,
+        terminate: true,
+      });
+    },
+  );
 
   it("sends uncertain bridge side effects to read-only reconciliation", async () => {
     const { agent, onReconciliationCandidate } = createAgent();
@@ -82,12 +104,23 @@ describe("Code Mode outcome safety", () => {
     expect(onReconciliationCandidate).toHaveBeenCalledOnce();
   });
 
-  it("cannot grant reconciliation from a wait failure", async () => {
+  it.each([
+    { bridgeStarted: true, executionStarted: true },
+    { bridgeStarted: false, executionStarted: false },
+    { bridgeStarted: undefined, executionStarted: false },
+  ])("keeps unproven wait failures closed: %j", async ({ bridgeStarted, executionStarted }) => {
     const { agent, onReconciliationCandidate } = createAgent();
+    const outcome = createOutcome({ toolName: "wait" });
+    outcome.result.details = {
+      status: "failed",
+      ...(bridgeStarted === undefined ? {} : { bridgeDispatchStarted: bridgeStarted }),
+    };
+    outcome.executionStarted = executionStarted;
 
-    await expect(
-      agent.afterToolOutcome?.(createOutcome({ toolName: "wait", bridgeStarted: true })),
-    ).resolves.toMatchObject({ isError: true, terminate: true });
+    await expect(agent.afterToolOutcome?.(outcome)).resolves.toMatchObject({
+      isError: true,
+      terminate: true,
+    });
     expect(onReconciliationCandidate).not.toHaveBeenCalled();
   });
 
@@ -112,7 +145,14 @@ describe("Code Mode outcome safety", () => {
   it("keeps explicit terminal outcomes and hook failures closed", async () => {
     const terminalAgent = createAgent(async () => ({ terminate: false }));
     await expect(
-      terminalAgent.agent.afterToolOutcome?.(createOutcome({ terminal: true })),
+      terminalAgent.agent.afterToolOutcome?.(
+        createOutcome({
+          toolName: "wait",
+          terminal: true,
+          bridgeStarted: true,
+          repairableFailure: true,
+        }),
+      ),
     ).resolves.toMatchObject({ terminate: true });
 
     const brokenHook = createAgent(async () => {

--- a/src/agents/embedded-agent-runner/run/code-mode-outcome.ts
+++ b/src/agents/embedded-agent-runner/run/code-mode-outcome.ts
@@ -21,8 +21,8 @@ export function installCodeModeOutcomeHook(params: {
     }
 
     const details = readToolResultDetails(context.result);
-    // Capability is host-minted on this exact result object; guest-supplied fields cannot grant it.
-    const noToolStarted = consumeRepairableCodeModeFailure(details);
+    // Exact host proof covers the full cell history, including work before wait; copies cannot grant it.
+    const repairableFailure = consumeRepairableCodeModeFailure(details);
     let prior: AfterToolCallResult | undefined;
     try {
       prior = await previousAfterToolOutcome?.(context, signal);
@@ -58,7 +58,7 @@ export function installCodeModeOutcomeHook(params: {
     const dispatchUnknown =
       context.executionStarted && typeof details?.bridgeDispatchStarted !== "boolean";
     const unsafeToContinue =
-      isCodeModeWait || ((bridgeStarted || dispatchUnknown) && !noToolStarted);
+      (isCodeModeWait || bridgeStarted || dispatchUnknown) && !repairableFailure;
     if (
       unsafeToContinue &&
       isCodeModeExec &&


### PR DESCRIPTION
Closes #131279 — proven-safe failed waits prematurely end Code Mode tasks.

Related: #131079 — discovery-only recovery; that merged repair explicitly left failed waits unchanged. Wrong-shell-session-ID issue #128859 and host-policy-denial issue #130274 are separate defects and are not closed by this PR.

<details>
<summary>Additional instructions</summary>

This branch is in the upstream repository and remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users asking an OpenClaw Code Mode agent to finish a task would get text-only finalization after a slow, read-only cell resumed and raised a correctable guest error. The agent could print attempted tool calls or a completion marker without creating the requested output artifact, even though the host knew that no potentially mutating action had started.

## Why This Change Was Made

The execution owner already carries cumulative dispatch accounting across snapshots and mints one-use proof on the exact finalized result object. The outcome hook consumed that proof but independently vetoed every failed `wait`; this repair applies the same proof to the whole unsafe-continuation condition and removes that unconditional veto. No second recovery path or automatic replay is added.

The safety boundary stays with the host execution owner. Unproven waits remain terminal even when dispatch fields are false or absent. Copies, serialized/reused proof, earlier mutations, replay-safe but side-effecting Swarm work, explicit terminal outcomes, cancellation, expiry, and wrong scopes stay closed. Reconciliation eligibility remains exec-only. This is **OpenClaw QuickJS-WASI Code Mode**, not native Codex Code Mode.

Production LOC: **+3/-3 (net 0)**. Tests: **+292/-35 (net +257)**. Docs: **+12/-9 (net +3)**. No new configuration, schema, SQLite/persistence, dependency, protocol, exported API, admission authority, or mutation classification.

Provenance: the conservative wait restriction was introduced by code author and PR merger @vincentkoc in #115729 (`892907bf25c3`, 2026-07-29), before host-private repair proof existed. Current blame is the ordinary-continuation repair #128088 (`977bbe266772`, 2026-08-23), authored and merged by @steipete, which carried the rule forward. Current PR author: @steipete. The inspected local stable tags do not contain the original rule; beta tags do. This is bounded tag evidence, not an exhaustive remote-tag claim.

## User Impact

After a failed resumed cell with exact host proof of no potentially mutating work, the model can correct its code and complete the original authorized task. It does not rerun the failed cell or repeat prior effects. Existing unsafe-wait restrictions, policy and approval checks, and terminal/cancellation behavior are preserved. The [Code Mode documentation](https://docs.openclaw.ai/tools/code-mode) now describes that boundary.

## Evidence

**Authenticated before/after product proof:** real OpenAI `gpt-5.6-luna`, OpenClaw runtime, a task-owned Gateway and synthetic workspace. The operator Gateway/state were untouched. A task-only audited read takes 12 seconds, causing a real parked QuickJS snapshot. The diagnostic executes exactly once:

```javascript
const row = await wait_probe_read({}); json(row); return missingAfterWait();
```

| Observed result | Baseline | Candidate and fresh capture session |
| --- | --- | --- |
| Exact diagnostic / resumed guest error | Once / observed | Once / observed |
| Ordinary continuation | Stops; text-only finalizer | New exec writes and reads the requested output |
| Requested output artifact | Absent | Exact bytes and final marker verified |
| Inner bridge calls / all calls / intentional errors | 1 / 3 / 1 | 3 / 6 / 1 |

The capture session uses a new session and a different artifact, not replay of an earlier cell. Real QuickJS controls also verified earlier actual mutation retained across parking, exact versus copied/reused proof, terminal reads, wrong scopes, expiry and cancellation. The standalone safe case executed one canonical read and zero mutations.

### Before

![Before: text-only attempted calls without the requested file](https://github.com/user-attachments/assets/3a8ecba1-e394-49e4-aa32-794616c552d5)

### After

![After: task completes with verified output](https://github.com/user-attachments/assets/ff4153be-3071-4723-913f-27fba1276b18)

https://github.com/user-attachments/assets/ee74c69c-a557-43bc-9fca-1ba045c4b371

The 44.96-second recording preserves intervals between 24 timestamped real Chrome viewport captures. The CLI initiated the real Gateway task and the Control UI observed it; this is screenshot-sampled video, **not Playwright recording or UI-submission proof**. All media contains synthetic task data and was visually inspected. The UI can duplicate activity counts; exact counts above come from authoritative transcript/CLI assertions, not UI labels.

### Regression and integration proof

The two intended regressions failed before the production edit: real parked-read continuation and exact-proof wait acceptance (42 other tests passed). The candidate passed **137 tests across 11 files**. After an exact tuple type correction in the test wrapper, its **18 tests passed again** and the final changed gate passed. No production seam was added for tests. Coverage includes earlier mutations, copied/reused/serialized proof, terminal reads, result replacement, pending cancellation, abort during the awaited outcome hook, unproven waits, and a genuinely parked Swarm collector.

```bash
node scripts/run-vitest.mjs src/agents/code-mode.agent-loop.test.ts src/agents/code-mode-swarm.test.ts src/agents/code-mode.wait.test.ts src/agents/code-mode.bridge.lifecycle.test.ts src/agents/code-mode.replay.test.ts src/agents/code-mode.preflight-repair.test.ts src/agents/code-mode-nodes.test.ts src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts src/agents/embedded-agent-runner/run/code-mode-reconciliation.test.ts src/agents/embedded-agent-runner/run/attempt.code-mode-reconciliation.test.ts src/agents/tool-result-error.test.ts --maxWorkers=1 --no-file-parallelism
node scripts/check-changed.mjs -- src/agents/embedded-agent-runner/run/code-mode-outcome.ts src/agents/code-mode.agent-loop.test.ts src/agents/code-mode-swarm.test.ts src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts docs/tools/code-mode.md
pnpm build
pnpm docs:check-mdx
git diff --check
```

Baseline and candidate full builds passed; docs MDX passed (792 files). The final changed gate includes core/test typecheck, lint, formatting, dead exports, owner-boundary and import-cycle guards. Five final file hashes were frozen across proof and rechecked for publication. Fresh isolated Codex autoreview: clean at default P0 threshold, no accepted/actionable findings; owner/caller/dependency datasets included, all supplied proof already completed.

Post-rebase proof: all **44 tests across the three changed files** passed on `e0cd1e7206224d64fdea6c069383a639b66be9d2` after a clean rebase onto `456dd3e64e8f1a5ca73ad8f335a286d28b3c6e6d`. The five source hashes remained identical. Command:

```bash
node scripts/run-vitest.mjs src/agents/code-mode.agent-loop.test.ts src/agents/code-mode-swarm.test.ts src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts --maxWorkers=1 --no-file-parallelism
```

### Owner and dependency evidence

The reviewed path is public exec/wait controls (`src/agents/code-mode.ts`) -> execution/settlement (`code-mode-execution.ts`) -> cumulative snapshot owner (`code-mode-state.ts`) -> exact-object proof (`code-mode-repair-provenance.ts`) -> outcome hook (`embedded-agent-runner/run/code-mode-outcome.ts`). Caller installation is `attempt-session-prepare.ts`; Agent core independently checks abort before continuation. Exact catalog safety and terminal projection remain in `tool-search-runtime.ts`; the bridge preserves the original cell's accounting.

Installed QuickJS-WASI 3.4.0 `dist/index.js:310-347,1751-1772` restores VM memory and requires callback re-registration. `src/agents/code-mode.worker.ts:438-473` settles original pending requests instead of reevaluating source. The landing reviewer personally inspected [Codex native wait at 92cbfb4](https://github.com/openai/codex/blob/92cbfb4d2431bdc53dc03507aea2dc5b8e932e40/codex-rs/core/src/tools/code_mode/wait_handler.rs#L94), its hook policy at line 170, and [dynamic dispatch](https://github.com/openai/codex/blob/92cbfb4d2431bdc53dc03507aea2dc5b8e932e40/codex-rs/core/src/tools/handlers/dynamic.rs#L113). These are separate unchanged surfaces, not substitutes for QuickJS proof. Headless Code Mode and legacy Tool Search do not install this outcome hook.

Best-fix judgment: honor the existing proof at its intended consumer. Blanket-enabling failed waits would admit unproven failures; changing the already-correct producer or adding replay machinery would create unnecessary policy and authority surface.

Limitations/follow-ups: catalog closure still masks cancellation telemetry with catalog-unavailable text; this remains fail-closed and is tracked separately. Duplicate Control UI activity counts are separate ongoing work. Neither is changed or claimed fixed here. A fresh post-merge live test is reserved for the lead after native landing; it is not claimed complete by this PR.

AI-assisted implementation and verification. Release-note context is the user-facing recovery behavior above; no changelog edit.


### Landing gate update

Exact-head [CI run 33127484502, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33127484502) completed successfully, including the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33127484502/job/98713836720), on `e0cd1e7206224d64fdea6c069383a639b66be9d2`. No CI retry or source change was needed. The draft run was skipped normally; the ready-for-review run supplies the green evidence.

The [fresh ClawSweeper review](https://github.com/openclaw/openclaw/pull/131282#issuecomment-5446742848) found no actionable correctness/security issue. Its sole remaining acceptance item and Rank-up move—complete required checks on this exact head—is fulfilled by the run above. No move was skipped and no new review request is needed for the unchanged head. Native review artifacts validated, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 131282` passed hosted gates without changing or pushing the already-matching head.
