### PR TITLE
fix(ui): show active reasoning level in effort picker

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2976,6 +2976,56 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
+  it("shows the current effort beside its heading in the accent color", async () => {
+    const page = await openBrowserPage(393, 852);
+    try {
+      await page.setContent(`
+        <!doctype html>
+        <html>
+          <head><style>${readUiCss()}</style></head>
+          <body>
+            <div class="chat-controls__reasoning-panel">
+              <div class="chat-controls__reasoning-head">
+                <span class="chat-controls__effort-heading">Effort</span>
+                <span class="chat-controls__effort-value">Extra high</span>
+              </div>
+            </div>
+            <span data-accent-probe style="color: var(--accent)"></span>
+          </body>
+        </html>
+      `);
+
+      const layout = await page.evaluate(() => {
+        const heading = document
+          .querySelector<HTMLElement>(".chat-controls__effort-heading")!
+          .getBoundingClientRect();
+        const valueNode = document.querySelector<HTMLElement>(".chat-controls__effort-value")!;
+        const value = valueNode.getBoundingClientRect();
+        return {
+          accentColor: getComputedStyle(document.querySelector<HTMLElement>("[data-accent-probe]")!)
+            .color,
+          heading: { right: heading.right, y: heading.y, height: heading.height },
+          value: {
+            color: getComputedStyle(valueNode).color,
+            x: value.x,
+            y: value.y,
+            height: value.height,
+          },
+        };
+      });
+
+      expect(layout.value.x).toBeGreaterThanOrEqual(layout.heading.right);
+      expect(
+        Math.abs(
+          layout.value.y + layout.value.height / 2 - (layout.heading.y + layout.heading.height / 2),
+        ),
+      ).toBeLessThanOrEqual(1);
+      expect(layout.value.color).toBe(layout.accentColor);
+    } finally {
+      await closeBrowserPage(page);
+    }
+  });
+
   it("aligns the reasoning default action with the reasoning heading", async () => {
     const page = await openBrowserPage(520, 600);
     try {

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -7405,6 +7405,10 @@ describe("chat model controls", () => {
     expect(getThinkingSliderValues(container)).toEqual(["adaptive", "low", "medium", "high"]);
     expect(slider?.value).toBe("3");
     expect(slider?.getAttribute("aria-valuetext")).toBe("Default (High)");
+    const effortValue = container.querySelector<HTMLElement>(".chat-controls__effort-value");
+    expect(effortValue).toBeInstanceOf(HTMLElement);
+    expect(effortValue?.classList.contains("sr-only")).toBe(false);
+    expect(getThinkingReasoningValueLabel(container)).toBe("High");
     expect(container.querySelector(".chat-controls__fast-mode-title")?.textContent?.trim()).toBe(
       "Fast mode",
     );

--- a/ui/src/pages/chat/components/chat-effort-picker.ts
+++ b/ui/src/pages/chat/components/chat-effort-picker.ts
@@ -211,7 +211,7 @@ export function renderChatEffortPicker(params: ChatEffortPickerParams) {
                     <span class="chat-controls__effort-heading">
                       ${t("chat.modelControls.effort")}
                     </span>
-                    <span class="sr-only">
+                    <span class="chat-controls__effort-value" aria-hidden="true">
                       <span data-chat-thinking-preview-committed>${reasoningValueText}</span>
                       ${sliderStops.map(
                         (stop, index) => html`<span data-chat-thinking-preview-index=${index} hidden

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -6715,6 +6715,15 @@ button.chat-pr__diff {
   font-weight: 650;
 }
 
+.chat-controls__effort-value {
+  min-width: 0;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 650;
+  text-align: end;
+  white-space: nowrap;
+}
+
 .chat-controls__effort-scale {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Effort control—especially in the mobile Control UI—could see the reasoning slider but not a textual indication of the active reasoning level.

## Why This Change Was Made

The existing committed/preview value is now shown beside **Effort** and styled with the active accent color. It reuses the existing slider preview/reset state, so dragging previews the candidate level without adding new state, persistence, or control behavior.

## User Impact

Users can immediately confirm the active reasoning level (for example, **Extra high**) instead of inferring it from the slider position. The slider, Faster/Smarter scale, and Fast mode row keep the same layout.

## Evidence

### Before

![Before: Effort control without a visible reasoning-level label](https://raw.githubusercontent.com/fuller-stack-dev/openclaw/9c17a599fe430219462b15bf37fcad6f0529c25a/before.png)

### After

![After: active reasoning level shown beside Effort in the accent color](https://raw.githubusercontent.com/fuller-stack-dev/openclaw/9c17a599fe430219462b15bf37fcad6f0529c25a/after.png)

Captured from the real running Control UI at a 393 × 852 mobile viewport with a synthetic session. Both images are sanitized and identically framed.

- Source-blind visual validation: 5/5 clauses passed; all changed pixels were confined to the new label region.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts ui/src/pages/chat/chat-view.test.ts` — 299 passed.
- `pnpm --dir ui exec vitest run --config vitest.config.ts src/pages/chat/chat-responsive.browser.test.ts` — changed responsive assertion passed; three unrelated browser setup timeouts passed on immediate focused rerun.
- `pnpm ui:build` — passed, including Control UI startup budgets.
- Targeted Oxfmt and Stylelint — passed.
- Autoreview — clean; no accepted/actionable findings.

AI-assisted: Yes. I reviewed the implementation and validation evidence.
