### PR TITLE
fix(plugins): keep Gateway available while upgrades await consent

### DIFF
--- a/scripts/e2e/parallels/linux-smoke.ts
+++ b/scripts/e2e/parallels/linux-smoke.ts
@@ -40,7 +40,9 @@ import {
   buildCommonSmokeSummary,
   expectedPackageBuildCommit,
   expectedPackageTargetVersion,
+  ensureSmokeGuestRuntime,
   extractLastOpenClawVersion,
+  installSmokeRuntimeCompanions,
   npmRegistryEnv,
   packAndServeSmokeArtifact,
   printSmokeTargetSummary,
@@ -260,12 +262,26 @@ class LinuxSmoke extends SmokeRunController<LinuxOptions> {
     );
     await this.phase("fresh.reset-state", 180, () => this.resetState());
     await this.phase("fresh.preflight", 90, () => this.logGuestPreflight());
-    await this.phase("fresh.install-latest-bootstrap", 420, () => this.installLatestRelease());
+    await this.phase("fresh.ensure-runtime", 420, () =>
+      ensureSmokeGuestRuntime({
+        runShell: (script) => this.guestBash(script),
+        bootstrap: () => this.installLatestRelease(),
+      }),
+    );
     await this.phase("fresh.install-main", 420, () =>
       this.installMainTgz("openclaw-main-fresh.tgz"),
     );
     this.status.freshVersion = await this.extractLastVersion("fresh.install-main");
     await this.phase("fresh.verify-main-version", 90, () => this.verifyTargetVersion());
+    await this.phase("fresh.install-companions", 600, () =>
+      installSmokeRuntimeCompanions({
+        provider: this.options.provider,
+        readCli: (args) => this.guestExec(["openclaw", ...args]),
+        installCli: (args) => {
+          this.guestExec(["openclaw", ...args]);
+        },
+      }),
+    );
     await this.phase("fresh.onboard-ref", 420, () => this.runRefOnboard());
     await this.phase("fresh.inject-bad-plugin", 90, () =>
       this.maybeInjectBadPluginFixture("fresh"),

--- a/scripts/e2e/parallels/macos-smoke.ts
+++ b/scripts/e2e/parallels/macos-smoke.ts
@@ -46,6 +46,7 @@ import { MacosDiscordSmoke } from "./macos-discord.ts";
 import { resolveMacosVmName, waitForVmStatus } from "./parallels-vm.ts";
 import { PhaseRunner } from "./phase-runner.ts";
 import {
+  installSmokeRuntimeCompanions,
   npmRegistryEnv,
   packAndServeSmokeArtifact,
   parseSmokeCliArgs,
@@ -420,6 +421,15 @@ class MacosSmoke {
     this.status.freshVersion = await this.extractLastVersion("fresh.install-main");
     await this.phase("fresh.verify-main-version", 60, () => this.verifyTargetVersion());
     await this.phase("fresh.verify-bundle-permissions", 180, () => this.verifyBundlePermissions());
+    await this.phase("fresh.install-companions", 600, () =>
+      installSmokeRuntimeCompanions({
+        provider: this.options.provider,
+        readCli: (args) => this.guestExec([guestOpenClaw, ...args]),
+        installCli: (args) => {
+          this.guestExec([guestOpenClaw, ...args]);
+        },
+      }),
+    );
     await this.phase("fresh.onboard-ref", 420, () => this.runRefOnboard());
     await this.phase("fresh.gateway-start", 180, () => this.startManualGatewayIfNeeded());
     await this.phase("fresh.gateway-status", 180, () => this.verifyGateway());

--- a/scripts/e2e/parallels/smoke-common.ts
+++ b/scripts/e2e/parallels/smoke-common.ts
@@ -1,11 +1,12 @@
 // Smoke Common helper supports OpenClaw script workflows.
 import { readFile, rm } from "node:fs/promises";
 import path from "node:path";
+import { PROCESS_NODE_VERSION_CHECK } from "../../../node-version.mjs";
 import { stripLeadingPackageManagerSeparator } from "../../lib/arg-utils.mts";
 import { resolveProviderConfig } from "../../lib/cross-os-release-checks/config.ts";
 import { parseTcpPort } from "./env-limits.ts";
 import { extractLastOpenClawVersionFromLog } from "./filesystem.ts";
-import { run, say, die } from "./host-command.ts";
+import { run, say, die, shellQuote } from "./host-command.ts";
 import {
   resolveHostIp,
   resolveHostPort,
@@ -353,6 +354,63 @@ export async function packAndServeSmokeArtifact(
     port: hostPort,
   });
   return [artifact, server, server.port];
+}
+
+export function ensureSmokeGuestRuntime(input: {
+  runShell: (script: string) => string;
+  bootstrap: () => void;
+}): void {
+  const nodeCheck = shellQuote(`process.exit(${PROCESS_NODE_VERSION_CHECK} ? 0 : 1)`);
+  const ready = input.runShell(`if node -e ${nodeCheck} >/dev/null 2>&1 &&
+  npm --version >/dev/null 2>&1 && git --version >/dev/null 2>&1; then
+  printf 'ready\\n'
+fi`);
+  if (ready.trim() === "ready") {
+    say("Reuse supported guest Node, npm, and Git; install candidate directly");
+    return;
+  }
+  // Older pristine snapshots have no Node/npm; retain their installer bootstrap.
+  say("Bootstrap missing or unsupported guest runtime prerequisites");
+  input.bootstrap();
+}
+
+export async function installSmokeRuntimeCompanions(input: {
+  provider: Provider;
+  readCli: (args: string[]) => string;
+  installCli: (args: string[]) => Promise<void> | void;
+}): Promise<void> {
+  const providerConfig = resolveProviderConfig(input.provider);
+  if (!providerConfig) {
+    throw new Error(`missing release smoke configuration for provider: ${input.provider}`);
+  }
+  if (providerConfig.requiredCompanionPackages.length === 0) {
+    return;
+  }
+  const help = input.readCli(["plugins", "install", "--help"]);
+  // Stable 2026.7.1-2 predates capability consent and provisions its own
+  // companion version during onboarding; it must not receive the newer flag.
+  if (!/^\s+--accept-capabilities(?:\s|$)/mu.test(help)) {
+    say("Installed CLI predates capability consent; using its onboarding contract");
+    return;
+  }
+  const version = input
+    .readCli(["--version"])
+    .match(/^OpenClaw\s+(\d{4}\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?)(?:\s|$)/mu)?.[1];
+  if (!version) {
+    throw new Error("could not resolve installed OpenClaw version for runtime companions");
+  }
+  // Candidate registries bind reviewed companion artifacts to the core version.
+  // Only the selected provider's required packages receive explicit consent.
+  for (const packageName of providerConfig.requiredCompanionPackages) {
+    say(`Install reviewed runtime companion: ${packageName}@${version}`);
+    await input.installCli([
+      "plugins",
+      "install",
+      `npm:${packageName}@${version}`,
+      "--pin",
+      "--accept-capabilities",
+    ]);
+  }
 }
 
 async function runRequestedSmokeLanes(input: {

--- a/scripts/e2e/parallels/windows-smoke.ts
+++ b/scripts/e2e/parallels/windows-smoke.ts
@@ -46,6 +46,7 @@ import {
   expectedPackageBuildCommit,
   expectedPackageTargetVersion,
   extractLastOpenClawVersion,
+  installSmokeRuntimeCompanions,
   npmRegistryEnv,
   packAndServeSmokeArtifact,
   parseSmokeCliArgs,
@@ -296,6 +297,19 @@ class WindowsSmoke extends SmokeRunController<WindowsOptions> {
     );
     this.status.freshVersion = await this.extractLastVersion("fresh.install-main");
     await this.phase("fresh.verify-main-version", 120, () => this.verifyTargetVersion());
+    await this.phase("fresh.install-companions", 600, () =>
+      installSmokeRuntimeCompanions({
+        provider: this.options.provider,
+        readCli: (args) =>
+          this.guestPowerShell(`Invoke-OpenClaw ${args.map(psSingleQuote).join(" ")}`),
+        installCli: (args) =>
+          this.guestPowerShellBackground(
+            "install-companion",
+            `Invoke-OpenClaw ${args.map(psSingleQuote).join(" ")}\nif ($LASTEXITCODE -ne 0) { throw "runtime companion install failed with exit code $LASTEXITCODE" }`,
+            600_000,
+          ),
+      }),
+    );
     await this.phase("fresh.onboard-ref", 720, () => this.runRefOnboard());
     await this.phase("fresh.gateway-restart", 420, () => this.gatewayAction("restart"));
     await this.phase("fresh.gateway-status", 420, () => this.verifyGatewayReachable());

--- a/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.install.ts
@@ -1,6 +1,7 @@
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import { stripAnsi } from "../../../../packages/terminal-core/src/ansi.js";
 import { sanitizeTerminalText } from "../../../../packages/terminal-core/src/safe-text.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
@@ -97,6 +98,7 @@ export async function installCandidate(params: {
   notices: string[];
   warnings: string[];
   failedPluginId?: string;
+  code?: string;
 }> {
   const consent = capturePluginCapabilityConsentHandlerErrors(params.onCapabilityConsent);
   try {
@@ -117,6 +119,7 @@ export async function installCandidate(params: {
       notices: [],
       warnings: [sanitizeTerminalText(error.message)],
       failedPluginId: params.candidate.pluginId,
+      ...(error.capabilityConsent ? { code: PLUGIN_CAPABILITY_CONSENT_REQUIRED } : {}),
     };
   }
 }

--- a/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.repair.ts
@@ -1,8 +1,13 @@
 import { rm } from "node:fs/promises";
+import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import { stripAnsi } from "../../../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../../config/types.plugins.js";
 import type { PluginCapabilityConsentHandler } from "../../../plugins/capability-consent.js";
+import {
+  normalizePluginsConfig,
+  resolveEffectiveEnableState,
+} from "../../../plugins/config-state.js";
 import { writePersistedInstalledPluginIndexInstallRecords } from "../../../plugins/installed-plugin-index-records.js";
 import { withPluginLifecycleLease } from "../../../plugins/plugin-lifecycle-lease.js";
 import { updateNpmInstalledPlugins } from "../../../plugins/update.js";
@@ -166,6 +171,31 @@ async function repairMissingPluginInstallsWithLease(
   const deferredPluginIds = new Set<string>();
   const preferNpmInstalls = isLegacyPackageUpdateDoctorPass(env);
   let nextRecords = records;
+  const normalizedPluginConfig = normalizePluginsConfig(params.cfg.plugins);
+  const recordFailure = (pluginId: string, messages: string[], code?: string) => {
+    const retainedEnabledInstall =
+      code === PLUGIN_CAPABILITY_CONSENT_REQUIRED &&
+      knownIds.has(pluginId) &&
+      !isInstalledRecordMissingOnDisk(records[pluginId], env) &&
+      !installedPluginIdsWithRepairablePackageDiagnostics.has(pluginId) &&
+      !configuredPluginIdsWithStaleDescriptors.has(pluginId) &&
+      resolveEffectiveEnableState({
+        id: pluginId,
+        origin: "global",
+        config: normalizedPluginConfig,
+        rootConfig: params.cfg,
+      }).enabled;
+    // Consent refusal rolls back the replacement; a retained enabled artifact is
+    // still subject to the caller's payload smoke check, not a failed activation.
+    if (retainedEnabledInstall) {
+      notices.push(
+        `Kept installed plugin "${pluginId}"; replacement deferred. ${messages.join(" ")}`,
+      );
+    } else {
+      warnings.push(...messages);
+    }
+    failedPluginIds.add(pluginId);
+  };
 
   for (const [pluginId, record] of Object.entries(records)) {
     const bundled = bundledPluginsById.get(pluginId);
@@ -200,8 +230,8 @@ async function repairMissingPluginInstallsWithLease(
     }
   }
 
-  const missingRecordedPluginIds = Object.keys(records).filter(
-    (pluginId) =>
+  const missingRecordedPlugins = Object.entries(records).filter(
+    ([pluginId]) =>
       !deferredPluginIds.has(pluginId) &&
       !officialReplacementPluginIds.has(pluginId) &&
       Object.hasOwn(nextRecords, pluginId) &&
@@ -211,27 +241,20 @@ async function repairMissingPluginInstallsWithLease(
         configuredPluginIdsWithStaleDescriptors.has(pluginId) ||
         installedPluginIdsWithRepairablePackages.has(pluginId)),
   );
+  const missingRecordedPluginIds = missingRecordedPlugins.map(([pluginId]) => pluginId);
 
   if (missingRecordedPluginIds.length > 0) {
-    for (const pluginId of missingRecordedPluginIds) {
-      const record = nextRecords[pluginId];
-      if (!record) {
-        continue;
-      }
-      const forced = forceNpmInstallRecordRepair(record);
-      if (forced !== record) {
-        if (nextRecords === records) {
-          nextRecords = { ...records };
-        }
-        nextRecords[pluginId] = forced;
-      }
+    // Dropping resolved fields forces an installer attempt, not a record mutation.
+    const repairRecords = { ...nextRecords };
+    for (const [pluginId, record] of missingRecordedPlugins) {
+      repairRecords[pluginId] = forceNpmInstallRecordRepair(record);
     }
     const updateResult = await updateNpmInstalledPlugins({
       config: {
         ...params.cfg,
         plugins: {
           ...params.cfg.plugins,
-          installs: nextRecords,
+          installs: repairRecords,
         },
       },
       pluginIds: missingRecordedPluginIds,
@@ -261,15 +284,18 @@ async function repairMissingPluginInstallsWithLease(
               ? `Repaired broken installed plugin "${outcome.pluginId}".`
               : `Repaired missing configured plugin "${outcome.pluginId}".`,
         );
-      } else if (outcome.status === "error") {
-        warnings.push(outcome.message);
-        failedPluginIds.add(outcome.pluginId);
-      } else if (isActionableClawHubSkippedOutcome(outcome)) {
-        warnings.push(outcome.message);
-        failedPluginIds.add(outcome.pluginId);
+      } else if (outcome.status === "error" || isActionableClawHubSkippedOutcome(outcome)) {
+        recordFailure(outcome.pluginId, [outcome.message], outcome.code);
       }
     }
-    nextRecords = updateResult.config.plugins?.installs ?? nextRecords;
+    if (repairedPluginIds.size > 0) {
+      nextRecords = { ...(updateResult.config.plugins?.installs ?? nextRecords) };
+      for (const [pluginId, record] of missingRecordedPlugins) {
+        if (!repairedPluginIds.has(pluginId)) {
+          nextRecords[pluginId] = record;
+        }
+      }
+    }
   }
 
   const missingPluginIds = new Set(
@@ -365,12 +391,13 @@ async function repairMissingPluginInstallsWithLease(
     nextRecords = installed.records;
     changes.push(...installed.changes);
     notices.push(...installed.notices);
-    warnings.push(...installed.warnings);
     if (!installed.failedPluginId && installed.records[candidate.pluginId]) {
       repairedPluginIds.add(candidate.pluginId);
     }
     if (installed.failedPluginId) {
-      failedPluginIds.add(installed.failedPluginId);
+      recordFailure(installed.failedPluginId, installed.warnings, installed.code);
+    } else {
+      warnings.push(...installed.warnings);
     }
   }
 

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -3,10 +3,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import { useAutoCleanupTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import type { OpenClawConfig, PluginsConfig } from "../../../config/types.js";
 import { resolveRegistryUpdateChannel } from "../../../infra/update-channels.js";
 import type { PluginCapabilityConsentHandler } from "../../../plugins/capability-consent.js";
+import { computeDeclaredSurfaceHash } from "../../../plugins/capability-summary.js";
 import {
   resolveClawHubInstallSpecsForUpdateChannel,
   resolveNpmInstallSpecsForUpdateChannel,
@@ -338,6 +340,196 @@ vi.mock("../../../plugins/update.js", async (importOriginal) => {
 });
 
 describe("repairMissingConfiguredPluginInstalls", () => {
+  it.each(["legacy", "accepted", "missing", "damaged", "stale-descriptor", "disabled"] as const)(
+    "preserves a %s installed artifact when replacement capability consent is pending",
+    async (previousState) => {
+      const actual = await vi.importActual<typeof import("../../../plugins/capability-consent.js")>(
+        "../../../plugins/capability-consent.js",
+      );
+      prepareManagedPluginArtifactConsentHandler.mockImplementation(
+        actual.prepareManagedPluginArtifactConsentHandler,
+      );
+      const installDir = tempDirs.make("openclaw-doctor-retained-consent-");
+      const stageDir = tempDirs.make("openclaw-doctor-staged-consent-");
+      const stateDir = tempDirs.make("openclaw-doctor-consent-state-");
+      for (const [rootDir, widened] of [
+        [installDir, false],
+        [stageDir, true],
+      ] as const) {
+        createColdPluginFixture({
+          rootDir,
+          pluginId: "codex",
+          packageName: "@openclaw/codex",
+          packageVersion: "2026.5.6",
+          manifest: {
+            contracts: { tools: widened ? ["fixture.read", "fixture.write"] : ["fixture.read"] },
+          },
+        });
+      }
+      const originalManifest = fs.readFileSync(
+        path.join(installDir, "openclaw.plugin.json"),
+        "utf8",
+      );
+      const records = installedRecords("codex", {
+        spec: "@openclaw/codex",
+        resolvedSpec: "@openclaw/codex@2026.5.6",
+        resolvedVersion: "2026.5.6",
+        integrity: "sha512-previous",
+        installPath: installDir,
+        ...(previousState === "accepted"
+          ? {
+              acceptedSurface: actual.resolvePluginArtifactDeclaredSurface(installDir),
+              acceptedSurfaceHash: computeDeclaredSurfaceHash(
+                actual.resolvePluginArtifactDeclaredSurface(installDir),
+              ),
+              acceptedSurfaceAt: "2026-01-01T00:00:00.000Z",
+              acceptedSurfaceIntegrity: "sha512-previous",
+            }
+          : {}),
+      });
+      if (previousState === "missing") {
+        fs.rmSync(path.join(installDir, "package.json"));
+      } else if (previousState === "damaged") {
+        fs.rmSync(path.join(installDir, "index.cjs"));
+      }
+      const originalRecords = structuredClone(records);
+      const originalFiles = fs.readdirSync(installDir).map((file) => ({
+        file,
+        bytes: fs.readFileSync(path.join(installDir, file)),
+      }));
+      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+      mocks.loadPluginMetadataSnapshot.mockReturnValue({
+        index: { plugins: [] },
+        plugins: [{ id: "codex", packageVersion: "2026.5.6", channels: ["codex"] }],
+        diagnostics:
+          previousState === "damaged"
+            ? brokenPluginSnapshot("codex").diagnostics
+            : previousState === "stale-descriptor"
+              ? [{ level: "error", pluginId: "codex", message: "without channelConfigs metadata" }]
+              : [],
+      });
+      mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+        officialPluginEntry({ id: "codex", npmSpec: "@openclaw/codex" }),
+      ]);
+      let committed = false;
+      mocks.installPluginFromNpmSpec.mockImplementation(
+        async (params: { onBeforePluginArtifactCommit: PluginInstallArtifactConsentHandler }) => {
+          await params.onBeforePluginArtifactCommit({
+            pluginId: "codex",
+            stagedArtifactDir: stageDir,
+            mode: "update",
+          });
+          committed = true;
+          return successfulInstall({
+            pluginId: "codex",
+            npmSpec: "@openclaw/codex",
+            targetDir: stageDir,
+          });
+        },
+      );
+      const cfg: OpenClawConfig = {
+        plugins: { entries: { codex: { enabled: previousState !== "disabled" } } },
+      };
+      const { repairMissingPluginInstallsForIds } =
+        await import("./missing-configured-plugin-install.js");
+      const result = await repairMissingPluginInstallsForIds({
+        cfg,
+        pluginIds: ["codex"],
+        env: { OPENCLAW_STATE_DIR: stateDir },
+      });
+
+      expect(committed).toBe(false);
+      expect(fs.readFileSync(path.join(installDir, "openclaw.plugin.json"), "utf8")).toBe(
+        originalManifest,
+      );
+      expect(result.records).toBe(records);
+      expect(result.records).toEqual(originalRecords);
+      for (const { file, bytes } of originalFiles) {
+        expect(fs.readFileSync(path.join(installDir, file))).toEqual(bytes);
+      }
+      expect(result.failedPluginIds).toEqual(["codex"]);
+      expect(result.repairedPluginIds).toBeUndefined();
+      expect(result.pluginInventoryChanged).toBeUndefined();
+      expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+      expect(cfg.plugins?.entries?.codex?.enabled).toBe(previousState !== "disabled");
+      if (previousState === "legacy" || previousState === "accepted") {
+        expect(result.warnings).toEqual([]);
+        expect(result.notices).toEqual([expect.stringContaining("--accept-capabilities")]);
+      } else {
+        expect(result.warnings).toEqual([expect.stringContaining("--accept-capabilities")]);
+        expect(result.notices).toBeUndefined();
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "preserves refused repair records with a successful sibling=%s",
+    async (siblingSucceeded) => {
+      const records = installedRecords("demo", {
+        spec: "@example/demo",
+        resolvedSpec: "@example/demo@1.0.0",
+        resolvedVersion: "1.0.0",
+        installPath: path.join(tempDirs.make("openclaw-doctor-missing-consent-"), "missing"),
+        integrity: "sha512-previous",
+      });
+      const updatedSibling = {
+        source: "npm",
+        spec: "@example/sibling",
+        version: "2.0.0",
+        installPath: tempDirs.make("openclaw-doctor-sibling-"),
+      };
+      if (siblingSucceeded) {
+        records.sibling = { ...updatedSibling, version: "1.0.0" };
+      }
+      mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+      mocks.updateNpmInstalledPlugins.mockImplementation(
+        async ({ config }: { config: OpenClawConfig }) => ({
+          config: siblingSucceeded
+            ? {
+                ...config,
+                plugins: {
+                  ...config.plugins,
+                  installs: { ...config.plugins?.installs, sibling: updatedSibling },
+                },
+              }
+            : config,
+          changed: siblingSucceeded,
+          outcomes: [
+            ...(siblingSucceeded
+              ? [{ pluginId: "sibling", status: "updated", message: "Updated sibling." }]
+              : []),
+            {
+              pluginId: "demo",
+              status: "error",
+              code: PLUGIN_CAPABILITY_CONSENT_REQUIRED,
+              message: "Review replacement capabilities.",
+            },
+          ],
+        }),
+      );
+
+      const result = await repairConfiguredPlugins({
+        plugins: { entries: { demo: { enabled: true }, sibling: { enabled: true } } },
+      });
+
+      expect(result.records.demo).toBe(records.demo);
+      expect(result.records).toEqual(
+        siblingSucceeded ? { ...records, sibling: updatedSibling } : records,
+      );
+      expect(result.warnings).toEqual(["Review replacement capabilities."]);
+      expect(result.notices).toBeUndefined();
+      if (siblingSucceeded) {
+        expect(mocks.writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith(
+          result.records,
+          expect.any(Object),
+        );
+      } else {
+        expect(result.records).toBe(records);
+        expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+      }
+    },
+  );
+
   it.each(
     (["npm", "npm-retry", "clawhub", "adopt"] as const).flatMap((source) =>
       [false, true].map((accepted) => ({ source, accepted })),

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -1,3 +1,4 @@
+import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveNpmSpecMetadata } from "../infra/install-source-utils.js";
 import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
@@ -510,7 +511,12 @@ export async function updateNpmInstalledPlugins(params: {
     if (attempt.kind === "exception") {
       if (attempt.error instanceof ManagedPluginLifecycleError && attempt.error.capabilityConsent) {
         // Staging was rolled back; pending consent must not disable the previous installation.
-        outcomes.push({ pluginId, status: "error", message: attempt.error.message });
+        outcomes.push({
+          pluginId,
+          status: "error",
+          code: PLUGIN_CAPABILITY_CONSENT_REQUIRED,
+          message: attempt.error.message,
+        });
         continue;
       }
       recordFailure(pluginId, attempt.message);

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -1128,6 +1128,7 @@ describe("updateNpmInstalledPlugins", () => {
             pluginId,
             status: "error",
             message: expect.stringContaining("--accept-capabilities"),
+            code: "PLUGIN_CAPABILITY_CONSENT_REQUIRED",
           }),
         ]);
         if (previousPayload === "missing") {

--- a/test/scripts/parallels-runtime-setup.test.ts
+++ b/test/scripts/parallels-runtime-setup.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import { shellQuote } from "../../scripts/e2e/parallels/host-command.ts";
+import {
+  ensureSmokeGuestRuntime,
+  installSmokeRuntimeCompanions,
+} from "../../scripts/e2e/parallels/smoke-common.ts";
+
+describe("Parallels runtime companion setup", () => {
+  it.each(["anthropic", "minimax"] as const)(
+    "does not install unrelated companions for %s",
+    async (provider) => {
+      const readCli = vi.fn();
+      const installCli = vi.fn();
+      await installSmokeRuntimeCompanions({ provider, readCli, installCli });
+      expect(readCli).not.toHaveBeenCalled();
+      expect(installCli).not.toHaveBeenCalled();
+    },
+  );
+
+  it("leaves the shipped pre-consent CLI to provision its own companion version", async () => {
+    const readCli = vi.fn((args: string[]) => {
+      expect(args).toEqual(["plugins", "install", "--help"]);
+      return "Usage: openclaw plugins install [options] <spec>\n  --pin  Pin resolved version\n";
+    });
+    const installCli = vi.fn();
+    await installSmokeRuntimeCompanions({ provider: "openai", readCli, installCli });
+    expect(readCli).toHaveBeenCalledTimes(1);
+    expect(installCli).not.toHaveBeenCalled();
+  });
+
+  it.each(["2026.8.1", "2026.8.1-beta.2"])(
+    "pins only the reviewed runtime companion to installed candidate %s",
+    async (version) => {
+      const readCli = vi.fn((args: string[]) =>
+        args[0] === "--version"
+          ? `OpenClaw ${version} (abcdef0)\n`
+          : "Options:\n  --accept-capabilities  Accept declared capabilities\n",
+      );
+      const installCli = vi.fn().mockResolvedValue(undefined);
+      await installSmokeRuntimeCompanions({ provider: "openai", readCli, installCli });
+      expect(installCli).toHaveBeenCalledExactlyOnceWith([
+        "plugins",
+        "install",
+        `npm:@openclaw/codex@${version}`,
+        "--pin",
+        "--accept-capabilities",
+      ]);
+    },
+  );
+
+  it("propagates companion installation failures before onboarding can continue", async () => {
+    const error = new Error("existing plugin install must not be overwritten");
+    const readCli = (args: string[]) =>
+      args[0] === "--version" ? "OpenClaw 2026.8.1" : "  --accept-capabilities  Accept\n";
+    const installCli = vi.fn().mockRejectedValue(error);
+    await expect(
+      installSmokeRuntimeCompanions({ provider: "openai", readCli, installCli }),
+    ).rejects.toBe(error);
+  });
+
+  it("refuses an unidentifiable core version instead of installing a moving tag", async () => {
+    const readCli = (args: string[]) =>
+      args[0] === "--version" ? "unknown" : "  --accept-capabilities  Accept\n";
+    const installCli = vi.fn();
+    await expect(
+      installSmokeRuntimeCompanions({ provider: "openai", readCli, installCli }),
+    ).rejects.toThrow("could not resolve installed OpenClaw version");
+    expect(installCli).not.toHaveBeenCalled();
+  });
+});
+
+describe("Parallels Linux runtime prerequisites", () => {
+  it.each([
+    { nodeVersion: "24.18.0", npmExit: 0, gitExit: 0, bootstrap: false },
+    { nodeVersion: "26.0.0", npmExit: 0, gitExit: 0, bootstrap: false },
+    { nodeVersion: "24.14.1", npmExit: 0, gitExit: 0, bootstrap: true },
+    { nodeVersion: "23.11.0", npmExit: 0, gitExit: 0, bootstrap: true },
+    { nodeVersion: "", npmExit: 0, gitExit: 0, bootstrap: true },
+    { nodeVersion: "24.18.0", npmExit: 127, gitExit: 0, bootstrap: true },
+    { nodeVersion: "24.18.0", npmExit: 0, gitExit: 127, bootstrap: true },
+  ])("checks usable Node/npm/Git before bootstrap: %j", (scenario) => {
+    const bootstrap = vi.fn();
+    ensureSmokeGuestRuntime({
+      runShell: (script) => {
+        const nodeRunner = shellQuote(process.execPath);
+        const nodeCheckRunner = shellQuote(
+          'Object.defineProperty(process.versions, "node", { value: process.env.OPENCLAW_TEST_NODE_RELEASE }); eval(process.argv[1]);',
+        );
+        return execFileSync(
+          "bash",
+          [
+            "-c",
+            `node() { ${nodeRunner} -e ${nodeCheckRunner} "$2"; }
+npm() { return ${scenario.npmExit}; }
+git() { return ${scenario.gitExit}; }
+${script}`,
+          ],
+          {
+            encoding: "utf8",
+            env: { ...process.env, OPENCLAW_TEST_NODE_RELEASE: scenario.nodeVersion },
+            timeout: 10_000,
+          },
+        );
+      },
+      bootstrap,
+    });
+    expect(bootstrap).toHaveBeenCalledTimes(scenario.bootstrap ? 1 : 0);
+  });
+});

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -598,7 +598,7 @@ ensure_vm_running`,
       const restoreIndex = linux.indexOf(`this.phase("${lane}.restore-snapshot"`);
       const resetIndex = linux.indexOf(`this.phase("${lane}.reset-state"`);
       const installIndex = linux.indexOf(
-        `this.phase("${lane}.${lane === "fresh" ? "install-latest-bootstrap" : "install-latest"}"`,
+        `this.phase("${lane}.${lane === "fresh" ? "install-main" : "install-latest"}"`,
       );
       expect(restoreIndex).toBeGreaterThanOrEqual(0);
       expect(resetIndex).toBeGreaterThan(restoreIndex);


### PR DESCRIPTION
Related: #130168

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Fixes an issue where users upgrading from stable would lose Gateway availability when a required plugin replacement needed capability review, even though the updater had correctly preserved the prior enabled plugin. Packaged upgrades from `2026.7.1-2` to main `dd2add04682d49b0ea7ba36e0ea483c1a19248b5` reproduced this on macOS, native Windows, and Linux.

Fresh automated setup also stopped at the new consent gate because the Parallels harness and onboarding examples omitted the explicit runtime-plugin review step.

## Why This Change Was Made

The install owners retain the typed capability-consent outcome. Doctor classifies it as a deferred-replacement notice only when the previous enabled installation is present and has no known package or descriptor damage. Startup's independent payload verification and quarantine remain unchanged; no new capabilities are approved. Forced npm repair fields are now temporary request inputs, so a rejected replacement cannot overwrite the prior version-resolution or acceptance record, including when another plugin update succeeds.

Parallels fresh setup explicitly installs only the selected provider's required, version-pinned companion through the managed plugin installer. The stable CLI predating capability consent retains its shipped onboarding path. Prepared Linux guests with supported Node, npm, and Git now install the candidate directly without first installing stable. Windows retains native daemon installation, restart, and RPC checks. Current main already contains the fuller consent instructions from #131298, so this PR preserves those docs without duplicating them.

Product code changes are +61/-25 (net +36): the typed owner classification and preservation of authoritative install records. Harness tooling is +100/-2 and tests are +304/-1; there is no remaining docs or changelog diff. No configuration options, database schemas, dependencies, automatic grants, or downstream startup exceptions are added.

## User Impact

A working plugin can remain available while its replacement awaits review, and the operator sees what was deferred and how to approve it. Missing, damaged, disabled, and otherwise failed installations retain their warnings. Automated fresh setup has an explicit supported consent step.

## Evidence

### Rebased candidate `7715da924886d031740161da6a754acf1f9bb12a`

Rebased onto `0e1afb2e8c16a816722435349f55a98ad9aa124e` only to resolve real conflicts. Main's changelog and the fuller onboarding documentation from #131298 are preserved unchanged. The product, Parallels harness, and test files are byte-identical to the prior reviewed head; the release-owned changelog entry and duplicate docs changes are gone.

Fresh local verification passed: 528 unique focused/sibling tests across 14 files; the complete changed-file gate, including formatting, lint, boundary guards, and core/test/scripts typechecks; and independent restricted Codex P0–P3 autoreview with no findings. Regression proof against the base owner modules reproduced four Doctor warning/provenance failures and five updater typed-code failures; restoring this candidate passed all 260 owner tests. No tests, retries, or timeouts were relaxed.

[Exact-head CI run 33159495444](https://github.com/openclaw/openclaw/actions/runs/33159495444) completed successfully, including the required `openclaw/ci-gate`, on `7715da924886d031740161da6a754acf1f9bb12a`. No CI rerun or bypass was used.

### Current exact-head packaged proof

The final maintainer source review and packaged matrix are complete at [`7715da924886d031740161da6a754acf1f9bb12a`](https://github.com/openclaw/openclaw/commit/7715da924886d031740161da6a754acf1f9bb12a). All nine lanes passed, exercising published stable `2026.7.1-2`, the installed `openclaw update` path, and a cold candidate install. `2026.8.1` identifies a locally built candidate, not a publication.

| Platform | Stable baseline | Installed update | Cold candidate | Total |
|---|---|---|---|---|
| macOS | Pass | Pass | Pass | 558s |
| Native Windows | Pass | Pass | Pass | 1809s |
| Linux | Pass | Pass | Pass | 453s |

Each update log identifies `OpenClaw 2026.8.1 (7715da9)`, reaches `Read probe: ok`, and returns `finalAssistantVisibleText: OK`. Consent refusal leaves the retained plugin available and prints `Kept installed plugin "codex"; replacement deferred...`; it does not approve the replacement. Cold candidates explicitly install the pinned, reviewed companion with capability acceptance before onboarding. These matrix model turns use the embedded runtime and are not native Codex proof.

Source tree: `aa46cd3a5d1eae519201274f647fe4d900cdd850`. Artifact metadata binds both packages to the full source SHA, and both package digests were independently recomputed:

- Core `openclaw-main-7715da92488.tgz` SHA-256: `de70061cc77e61c01012091d79d66e7d5440c47cd84e445ab5722fcea811baed`.
- Companion `openclaw-codex-2026.8.1.tgz` SHA-256: `13c5586a73f8a5882adc9a787aef2f282c53d7128495d2543ad5d89c686e514a`.

Actual invocation shape below, run once per platform with `PLATFORM=macos`, `windows`, or `linux`; `CAP=75m` for macOS/Linux and `90m` for Windows. Private VM and snapshot selector values are explicitly redacted; candidate paths are repository-relative.

```sh
gtimeout --foreground "$CAP" bash scripts/e2e/parallels-npm-update-smoke.sh \
  --platform "$PLATFORM" --package-spec openclaw@2026.7.1-2 \
  --target-tarball .artifacts/parallels/candidate-7715da92488/openclaw-main-7715da92488.tgz \
  --registry-package-tarball .artifacts/parallels/candidate-7715da92488/plugins/openclaw-codex-2026.8.1.tgz \
  --macos-vm '<redacted>' --macos-snapshot-hint '<redacted>' \
  --windows-vm '<redacted>' \
  --provider openai --model openai/gpt-5.6-luna --json
```

Linux's first cold-candidate attempt encountered Parallels snapshot-restore error 255. The existing bounded fresh-lane retry restored the snapshot and passed; no product step required a retry. Normal Gateway readiness polling is included in the logs. The Windows lanes cover native service install/restart/RPC. The macOS snapshot lacks a launchd-user session, and Linux lacks systemd-user, so those service paths are not claimed. No operator-host Gateway was touched.

A separate current-head Linux native Codex probe exited 0 with `agentHarnessId=codex` and exact `finalAssistantVisibleText=OK`. Its first probe used the embedded runtime because a harness-authored provider timeout remained; after removing that test-only timeout and model transport overrides, the explicit native route passed. Raw first output was retained, and production code was unchanged. Current-head native macOS/Windows execution is not claimed; their native results below belong only to historical head `9f3663f`.

Exact focused/sibling verification commands (528 unique tests, all passing):

```sh
node scripts/run-vitest.mjs src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/plugins/update.test.ts src/commands/doctor-config-preflight.test.ts src/cli/update-cli/post-core-plugin-convergence.test.ts src/cli/update-cli/post-core-plugin-convergence.retirement.test.ts test/scripts/parallels-runtime-setup.test.ts test/scripts/parallels-smoke-model.test.ts
node scripts/run-vitest.mjs src/commands/doctor-config-preflight-plugin-verification.test.ts src/commands/doctor/shared/startup-plugin-convergence-plan.test.ts test/scripts/parallels-npm-update-smoke.test.ts test/scripts/parallels-phase-runner.test.ts test/scripts/parallels-update-job-timeout.test.ts
node scripts/run-vitest.mjs src/commands/doctor-config-preflight-plugin-index.test.ts src/plugins/capability-consent.test.ts
node scripts/check-changed.mjs --staged
git diff --check 0e1afb2e8c16a816722435349f55a98ad9aa124e HEAD
```

The changed-file check ran on the complete staged candidate before commit; reviewed source bytes did not change afterward. The base-owner regression runs fail on four Doctor and five updater assertions, then pass after restoring the candidate. Independent restricted Codex autoreview has no findings. [Exact-head CI 33159495444](https://github.com/openclaw/openclaw/actions/runs/33159495444), including `openclaw/ci-gate`, is green without rerun or bypass.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/131290#issuecomment-5446857667), refreshed August 28 at 09:50 UTC, has no code/security findings and requests the exact-head three-platform packaged proof. That request and the earlier exact-head-CI Rank-up are satisfied above; final maintainer inspection accepts the install/Doctor repair. Production +61/-25 (net +36) is needed to carry the typed deferral and keep temporary repair inputs separate from authoritative install records. The shared failure classifier removes the duplicate warning branch; neither downstream startup suppression nor automatic consent grants is acceptable. No schema or new configuration surface changes.

The landing reviewer personally inspected pinned upstream Codex source: [initialize state/response, rust-v0.144.3](https://github.com/openai/codex/blob/rust-v0.144.3/codex-rs/app-server/src/request_processors/initialize_processor.rs#L44-L159), [initialize types, rust-v0.144.3](https://github.com/openai/codex/blob/rust-v0.144.3/codex-rs/app-server-protocol/src/protocol/v1.rs#L27-L82), [API-key stdin login, rust-v0.150.1](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/cli/src/login.rs#L204-L310), and [login dispatch, rust-v0.150.1](https://github.com/openai/codex/blob/rust-v0.150.1/codex-rs/cli/src/main.rs#L1540-L1586). OpenClaw artifact consent remains separate from Codex initialize capabilities; neither upstream protocol nor login semantics changes here.

### Historical proof at `9f3663f7172120abddd9d7e4b3a8a05cb2f251a1`

- Before the patch, all three stable baseline installs passed Gateway RPC and a real OpenAI model turn. All three installed-updater runs installed the exact candidate core successfully, then Gateway startup refused on pending Codex capability consent. A read-only macOS capture confirmed that the original Codex `2026.7.1-1` payload and install/provenance record, including the absence of capability-acceptance fields, remained unchanged. Windows did not use stale-module recovery.
- Untouched fresh candidate onboarding failed on all three OSes with the consent error. On macOS, explicit managed plugin install with `--accept-capabilities` followed by the documented noninteractive command succeeded. An additional native Codex turn returned `OK` with `meta.agentMeta.agentHarnessId=codex`.
- Regression tests failed before the repair for the blocking warning, erased resolution fields, and missing typed updater outcome. Afterward: 260 doctor/updater tests, 172 Parallels tests, and 88 startup/post-core sibling tests passed. Coverage includes legacy and previously accepted installations, missing/damaged/disabled controls, unchanged prior files/records, and mixed success/refusal.
- Independent Codex P0–P3 autoreview found no actionable findings. Docs MDX, internal links, glossary, and formatting checks passed.
- Full changed checks passed. [CI run 33128472786](https://github.com/openclaw/openclaw/actions/runs/33128472786) passed on exact head `9f3663f7172120abddd9d7e4b3a8a05cb2f251a1`, including `openclaw/ci-gate`.

### Prior-head repaired packaged matrix

All nine lanes passed on source commit [`9f3663f7172120abddd9d7e4b3a8a05cb2f251a1`](https://github.com/openclaw/openclaw/commit/9f3663f7172120abddd9d7e4b3a8a05cb2f251a1); the aggregate command exited 0 after 40m 56s.

| OS | Clean stable `2026.7.1-2` baseline | Installed update to candidate `2026.8.1` | Clean candidate `2026.8.1` install |
|---|---|---|---|
| macOS | Pass | Pass | Pass |
| Native Windows | Pass | Pass | Pass |
| Linux | Pass | Pass | Pass |

The candidate core and required companion were built locally from that exact commit and served through the prepared test registry. `2026.8.1` here identifies the tested candidate, not an npm publication or a newly released stable version. The baseline used published stable `2026.7.1-2`.

Each lane passed Gateway RPC checks and a real model turn. The standard matrix uses provider isolation and the embedded runtime; those turns are not claimed as native Codex execution. All three upgrades kept Codex `2026.7.1-1`. Read-only macOS and Linux captures confirmed the retained install/provenance records and the absence of all capability-acceptance fields. The replacement stayed deferred with a visible consent notice, while Gateway became available. Fresh candidate installs explicitly pinned and accepted the reviewed Codex `2026.8.1` companion before non-interactive onboarding.

Separate fresh-candidate native Codex checks passed on macOS, native Windows, and Linux with exact final text `OK`, `meta.agentMeta.agentHarnessId=codex`, and `fallbackUsed=false`; the Windows CLI exited 0 without rerouting. The extra probes required clearing an inherited test transport override and separating an informational Windows PowerShell stderr block from the captured JSON; the raw output was preserved, with no second Windows model call or product change.

Windows baseline and fresh-candidate checks exercised native Scheduled Task installation, restart, and Gateway RPC; its installed-update lane also passed Gateway RPC. The macOS snapshot lacks a usable GUI-user service session, and the Linux snapshot lacks a systemd-user service session, so their results do not claim launchd-user or systemd-user service coverage.

The installed Linux candidate also printed `plugins install --help` with both `--accept-capabilities` and `--pin`, then successfully installed the pinned companion. The prior-head ClawSweeper review also completed its source-checkout help probe successfully and confirmed `--accept-capabilities`; an earlier probe had timed out.

The prior-head ClawSweeper review found the runtime repair correct and requested removal of the release-owned changelog entry. That finding and Rank-up move are addressed by removing this PR’s added line and preserving main’s changelog. Release-note context remains in this PR body. The current-head matrix and final maintainer inspection are recorded separately above; this historical matrix is not evidence for the rebased SHA.

The consent feature came from #130168, authored and merged by @steipete. The repair preserves that feature's explicit-review boundary. Published prior-plugin integrity and compatibility floors were inspected, along with its pinned Codex `0.144.3` initialize contract and the candidate's `0.150.1` API-key/login contract; no exact OpenClaw version loader restriction was found.

Known follow-up: native Windows can add a PowerShell CLIXML/plaintext stderr parsing diagnostic before the actual onboarding error. The structured consent failure and nonzero exit were preserved; this change does not alter that transport behavior. These VM snapshots do not provide macOS launchd-user or Linux systemd-user service coverage; Windows uses its native service path.
