### PR TITLE
fix(telegram): preserve forum admission identity in audit

### DIFF
--- a/extensions/telegram/src/bot-handlers.inbound-authorization.test.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-authorization.test.ts
@@ -1,0 +1,124 @@
+import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
+import { describe, expect, it, vi } from "vitest";
+import { createHostChannelInboundEventContextBuilder } from "../../../src/channels/inbound-event/host-context-builder.js";
+import {
+  configureChannelAdmissionEvidenceCollection,
+  consumeChannelAdmissionEvidence,
+  readChannelContextAdmissionEvidence,
+  registerChannelAdmissionEvidenceOwner,
+} from "../../../src/channels/message-access/admission-evidence.js";
+import { defaultTelegramBotDeps } from "./bot-deps.js";
+import { createTelegramHandlerAuthorization } from "./bot-handlers.inbound-authorization.js";
+import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
+
+describe("Telegram inbound admission authorization", () => {
+  it("binds a forum admission to the finalized parent and topic scope", async () => {
+    const chatId = -1001234567890;
+    const topicId = 99;
+    const participantId = "42";
+    const cfg = {
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: [participantId],
+          groups: {
+            [String(chatId)]: { allowFrom: [participantId], groupPolicy: "allowlist" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = {
+      accountId: "default",
+      ownerAgentId: "main",
+      bot: {} as RegisterTelegramHandlerParams["bot"],
+      cfg,
+      mediaMaxBytes: 1,
+      opts: { token: "test-token" },
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+      telegramCfg: cfg.channels?.telegram ?? {},
+      telegramDeps: {
+        ...defaultTelegramBotDeps,
+        getRuntimeConfig: () => cfg,
+        readChannelAllowFromStore: async () => [],
+      },
+      logger: getChildLogger({ module: "telegram/admission-test" }),
+      resolveGroupPolicy: () => ({ allowlistEnabled: true, allowed: true }),
+      resolveGroupActivation: () => undefined,
+      resolveGroupRequireMention: () => false,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { allowFrom: [participantId], groupPolicy: "allowlist" as const },
+        topicConfig: undefined,
+      }),
+      shouldSkipUpdate: () => false,
+      processMessage: async () => ({ kind: "completed" as const }),
+    } satisfies RegisterTelegramHandlerParams;
+    const gate = await createTelegramHandlerAuthorization(params).authorizeInboundMessage({
+      msg: {
+        message_id: 7,
+        date: 1_700_000_000,
+        chat: { id: chatId, type: "supergroup", title: "Forum", is_forum: true },
+        from: { id: Number(participantId), is_bot: false, first_name: "Pat" },
+        message_thread_id: topicId,
+        text: "hello",
+      },
+      chatId,
+      isGroup: true,
+      isForum: true,
+      senderId: participantId,
+      senderUsername: "",
+      requireConfiguredGroup: false,
+      dmAccess: "silent",
+    });
+    expect(gate.allowed).toBe(true);
+    if (!gate.allowed) {
+      throw new Error("expected forum admission");
+    }
+
+    const clearCollection = configureChannelAdmissionEvidenceCollection(true);
+    const owner = { channelId: "telegram", record: {}, epoch: {}, isLive: () => true };
+    const clearOwner = registerChannelAdmissionEvidenceOwner(owner);
+    try {
+      const sessionKey = "agent:main:telegram:group:forum:topic:99";
+      const ingress = await gate.resolveChannelIngress({
+        agentId: "main",
+        sessionKey,
+        messageId: "7",
+        inboundEventKind: "user_request",
+      });
+      const buildContext = createHostChannelInboundEventContextBuilder(
+        buildChannelInboundEventContext,
+        owner,
+      );
+      const context = buildContext({
+        channel: "telegram",
+        accountId: "default",
+        messageId: "7",
+        from: `telegram:group:${String(chatId)}:topic:${String(topicId)}`,
+        sender: { id: participantId },
+        conversation: {
+          kind: "group",
+          id: String(chatId),
+          parentId: String(chatId),
+          threadId: String(topicId),
+        },
+        route: { agentId: "main", routeSessionKey: sessionKey },
+        reply: { to: `telegram:${String(chatId)}`, messageThreadId: topicId },
+        message: { rawBody: "hello", inboundEventKind: "user_request" },
+        channelIngress: ingress,
+      });
+
+      expect(
+        consumeChannelAdmissionEvidence(readChannelContextAdmissionEvidence(context)),
+      ).toMatchObject({
+        ingressState: "present",
+        invoker: { state: "present", kind: "person" },
+        decisionCoverage: "enforced",
+      });
+    } finally {
+      clearOwner();
+      clearCollection();
+    }
+  });
+});

--- a/extensions/telegram/src/bot-handlers.inbound-authorization.test.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-authorization.test.ts
@@ -1,14 +1,14 @@
 import { buildChannelInboundEventContext } from "openclaw/plugin-sdk/channel-inbound";
-import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
-import { describe, expect, it, vi } from "vitest";
-import { createHostChannelInboundEventContextBuilder } from "../../../src/channels/inbound-event/host-context-builder.js";
 import {
   configureChannelAdmissionEvidenceCollection,
   consumeChannelAdmissionEvidence,
+  createHostChannelInboundEventContextBuilder,
   readChannelContextAdmissionEvidence,
   registerChannelAdmissionEvidenceOwner,
-} from "../../../src/channels/message-access/admission-evidence.js";
+} from "openclaw/plugin-sdk/channel-ingress-test-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
+import { describe, expect, it, vi } from "vitest";
 import { defaultTelegramBotDeps } from "./bot-deps.js";
 import { createTelegramHandlerAuthorization } from "./bot-handlers.inbound-authorization.js";
 import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";

--- a/extensions/telegram/src/bot-handlers.inbound-authorization.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-authorization.ts
@@ -458,6 +458,9 @@ export function createTelegramHandlerAuthorization({
         conversation: {
           kind: params.isGroup ? "group" : "direct",
           id: String(params.chatId),
+          ...(params.isGroup && resolvedThreadId != null
+            ? { parentId: String(params.chatId) }
+            : {}),
           ...(resolvedThreadId != null ? { threadId: String(resolvedThreadId) } : {}),
         },
         contextBinding,

--- a/scripts/e2e/telegram-mantis-sut.ts
+++ b/scripts/e2e/telegram-mantis-sut.ts
@@ -198,6 +198,7 @@ export function writeSutConfig(params: {
   mockPort: number;
   outputDir: string;
   repoRoot?: string;
+  telegramApiRoot?: string;
   testerId: string;
 }) {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-tg-crabbox-sut-"));
@@ -237,7 +238,7 @@ export function writeSutConfig(params: {
     channels: {
       telegram: {
         allowFrom: [params.testerId],
-        apiRoot: "http://telegram-api-proxy:8080",
+        ...(params.telegramApiRoot ? { apiRoot: params.telegramApiRoot } : {}),
         botToken: { id: "TELEGRAM_BOT_TOKEN", provider: "default", source: "env" },
         commands: { native: true, nativeSkills: false },
         dmPolicy: "allowlist",
@@ -718,7 +719,11 @@ export async function startMantisSut(params: {
   onRuntimeDisposed?: () => void;
 }): Promise<MantisSutRuntime> {
   const drained = await drainSutUpdates(params.sutToken);
-  const config = writeSutConfig({ ...params, mockHost: "mock-openai" });
+  const config = writeSutConfig({
+    ...params,
+    mockHost: "mock-openai",
+    telegramApiRoot: "http://telegram-api-proxy:8080",
+  });
   // The root wrapper relocates tempRoot into its bounded filesystem, then restores this
   // exact path as a symlink before Docker starts. Keep controller and claim paths anchored
   // here so live log reads, mock updates, stop, and destroy all share one runtime identity.

--- a/scripts/e2e/telegram-user-crabbox-proof.ts
+++ b/scripts/e2e/telegram-user-crabbox-proof.ts
@@ -1479,8 +1479,8 @@ download_file() {
 }
 mkdir -p "$root"
 tar -xzf "$root/state.tgz" -C "$root"
-run_setup_step "apt-get update" "$apt_timeout" sudo apt-get update -y
-run_setup_step "apt-get install" "$apt_timeout" sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y curl git cmake g++ make zlib1g-dev libssl-dev python3 ffmpeg scrot xz-utils tar wmctrl xdotool x11-utils zbar-tools libopengl0 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 libxkbcommon-x11-0 >/tmp/openclaw-telegram-apt.log
+run_setup_step "apt-get update" "$apt_timeout" sudo apt-get -o DPkg::Lock::Timeout=900 update -y
+run_setup_step "apt-get install" "$apt_timeout" sudo env DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=900 install -y curl git cmake g++ make zlib1g-dev libssl-dev python3 ffmpeg scrot xz-utils tar wmctrl xdotool x11-utils zbar-tools libopengl0 libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-shape0 libxcb-xfixes0 libxcb-xinerama0 libxkbcommon-x11-0 >/tmp/openclaw-telegram-apt.log
 if ! command -v python3 >/dev/null 2>&1; then
   echo "python3 is required" >&2
   exit 127
@@ -2310,6 +2310,31 @@ function inspectIdentityContext(result: JsonObject): JsonObject | undefined {
     : undefined;
 }
 
+export function hasBoundaryVerifiedChannelAdmissionAssurance(context: unknown): boolean {
+  if (!context || typeof context !== "object" || Array.isArray(context)) {
+    return false;
+  }
+  const ingress = (context as JsonObject).ingress;
+  const assurance = (context as JsonObject).assurance;
+  return (
+    ingress !== null &&
+    typeof ingress === "object" &&
+    !Array.isArray(ingress) &&
+    (ingress as JsonObject).kind === "channel" &&
+    Array.isArray(assurance) &&
+    assurance.some((item) => {
+      if (!item || typeof item !== "object" || Array.isArray(item)) {
+        return false;
+      }
+      return (
+        (item as JsonObject).kind === "channel-admission" &&
+        (item as JsonObject).strength === "boundary-verified" &&
+        typeof (item as JsonObject).evidenceRef === "string"
+      );
+    })
+  );
+}
+
 async function inspectSessionIdentity(root: string, opts: Options, outputDir: string) {
   const { session } = readSession(root, opts, outputDir);
   const listed = parseCommandJson(
@@ -2395,20 +2420,7 @@ async function inspectSessionIdentity(root: string, opts: Options, outputDir: st
       principal && typeof principal === "object" && !Array.isArray(principal)
         ? (principal as JsonObject).principalRef
         : undefined;
-    const decisions = Array.isArray(inspection.json.decisions) ? inspection.json.decisions : [];
-    const hasChannelDecision = decisions.some((decision) => {
-      if (!decision || typeof decision !== "object" || Array.isArray(decision)) {
-        return false;
-      }
-      const action = (decision as JsonObject).action;
-      return (
-        action &&
-        typeof action === "object" &&
-        !Array.isArray(action) &&
-        (action as JsonObject).family === "channel" &&
-        (action as JsonObject).operation === "admission"
-      );
-    });
+    const hasChannelAdmission = hasBoundaryVerifiedChannelAdmissionAssurance(context);
     if (
       !invoker ||
       typeof invoker !== "object" ||
@@ -2419,8 +2431,9 @@ async function inspectSessionIdentity(root: string, opts: Options, outputDir: st
       Array.isArray(principal) ||
       (principal as JsonObject).kind !== "person" ||
       typeof principalRef !== "string" ||
-      !hasChannelDecision ||
+      !hasChannelAdmission ||
       !inspection.human.includes("Invoker [present]") ||
+      !inspection.human.includes("channel-admission") ||
       !inspection.human.includes("Decisions")
     ) {
       throw new Error(`Telegram run ${inspection.runId} omitted participant CLI evidence.`);

--- a/scripts/e2e/telegram-user-driver.py
+++ b/scripts/e2e/telegram-user-driver.py
@@ -477,8 +477,8 @@ class UserDriver:
         sut = resolve_sut(self.config, self.bot_config)
         expect = args.expect or []
         from_bot = (args.from_bot or sut["username"] or "").lstrip("@")
-        from_bot_id = int(from_bot) if from_bot.isdigit() else sut["id"]
-        from_bot_username = "" if from_bot.isdigit() else from_bot
+        from_bot_id = int(from_bot) if from_bot.isdigit() else (sut["id"] if not from_bot else None)
+        from_bot_username = "" if from_bot_id else from_bot
         deadline = time.time() + args.timeout_ms / 1000
         observed = []
         while time.time() < deadline:
@@ -1418,8 +1418,7 @@ def main():
     probe.add_argument("--from-bot", default="")
     probe.add_argument("--reply-to")
     probe.add_argument("--thread-id", type=int, default=0)
-    probe.add_argument("--require-reply", action="store_true", default=True)
-    probe.add_argument("--any-sut-reply", dest="require_reply", action="store_false")
+    probe.add_argument("--require-reply", action="store_true")
     probe.set_defaults(func=command_probe)
 
     transcript = sub.add_parser("transcript")

--- a/src/plugin-sdk/channel-ingress-test-runtime.ts
+++ b/src/plugin-sdk/channel-ingress-test-runtime.ts
@@ -1,3 +1,10 @@
 /** Test-only durable channel ingress state helpers. */
+export { createHostChannelInboundEventContextBuilder } from "../channels/inbound-event/host-context-builder.js";
+export {
+  configureChannelAdmissionEvidenceCollection,
+  consumeChannelAdmissionEvidence,
+  readChannelContextAdmissionEvidence,
+  registerChannelAdmissionEvidenceOwner,
+} from "../channels/message-access/admission-evidence.js";
 export { createChannelIngressQueue as createChannelIngressQueueForTests } from "../channels/message/ingress-queue.js";
 export { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";

--- a/test/scripts/telegram-mantis-sut.test.ts
+++ b/test/scripts/telegram-mantis-sut.test.ts
@@ -279,4 +279,29 @@ exit "\${GATEWAY_EXIT_CODE:-0}"
     expect(config.models.providers.openai.baseUrl).toBe("http://mock-openai:19882/v1");
     expect(config.session.sendPolicy).toEqual({ default: "deny" });
   });
+
+  it("routes Telegram through the proxy only for the container SUT", () => {
+    const shared = {
+      gatewayPort: 19_879,
+      groupId: "-100123456789",
+      mockPort: 19_882,
+      testerId: "12345",
+    };
+    const local = writeSutConfig({
+      ...shared,
+      mockHost: "127.0.0.1",
+      outputDir: tempDirs.make("telegram-local-sut-config-"),
+    });
+    const container = writeSutConfig({
+      ...shared,
+      mockHost: "mock-openai",
+      outputDir: tempDirs.make("telegram-container-sut-config-"),
+      telegramApiRoot: "http://telegram-api-proxy:8080",
+    });
+
+    const localConfig = JSON.parse(fs.readFileSync(local.configPath, "utf8"));
+    const containerConfig = JSON.parse(fs.readFileSync(container.configPath, "utf8"));
+    expect(localConfig.channels.telegram).not.toHaveProperty("apiRoot");
+    expect(containerConfig.channels.telegram.apiRoot).toBe("http://telegram-api-proxy:8080");
+  });
 });

--- a/test/scripts/telegram-user-crabbox-proof.test.ts
+++ b/test/scripts/telegram-user-crabbox-proof.test.ts
@@ -19,6 +19,7 @@ import {
   COMMAND_TIMEOUT_MS,
   createCrabboxWarmupArgs,
   createOpenClawCliSpawnSpec,
+  hasBoundaryVerifiedChannelAdmissionAssurance,
   parseArgs,
   processTargetExists,
   readLogAfterOffset,
@@ -161,6 +162,33 @@ describe("telegram user Crabbox proof log polling", () => {
     expect(spec.command).toBe("/opt/mantis-toolchain/pnpm");
     expect(spec.args).toEqual(["openclaw", "audit", "--run", "run-1", "--explain", "--json"]);
     expect(spec.options.env?.OPENCLAW_CONFIG_PATH).toBe("/tmp/openclaw.json");
+  });
+
+  it("requires the persisted boundary-verified channel admission assurance", () => {
+    const context = {
+      ingress: { kind: "channel", state: "present" },
+      assurance: [
+        {
+          kind: "channel-admission",
+          strength: "boundary-verified",
+          evidenceRef: "hmac-sha256:v1:test",
+        },
+      ],
+    };
+
+    expect(hasBoundaryVerifiedChannelAdmissionAssurance(context)).toBe(true);
+    expect(
+      hasBoundaryVerifiedChannelAdmissionAssurance({
+        ...context,
+        assurance: [{ ...context.assurance[0], strength: "self-asserted" }],
+      }),
+    ).toBe(false);
+    expect(
+      hasBoundaryVerifiedChannelAdmissionAssurance({
+        ...context,
+        ingress: { kind: "local-cli", state: "present" },
+      }),
+    ).toBe(false);
   });
 
   it("routes fork SUT startup through the root-owned validating wrapper", () => {
@@ -958,6 +986,19 @@ setInterval(() => {}, 1000);
       `tdlib_url='${payload}'`,
     );
     expect(renderSelectDesktopChat({ chatTitle: payload })).toContain(`chat_title='${payload}'`);
+  });
+
+  it("bounds native apt lock waits without disturbing the lock holder", () => {
+    const script = renderRemoteSetup({});
+
+    expect(script).toContain(
+      'run_setup_step "apt-get update" "$apt_timeout" sudo apt-get -o DPkg::Lock::Timeout=900 update -y',
+    );
+    expect(script).toContain(
+      'run_setup_step "apt-get install" "$apt_timeout" sudo env DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=900 install -y',
+    );
+    expect(script).not.toMatch(/\b(?:kill|pkill|fuser)\b[^\n]*(?:apt|dpkg)/u);
+    expect(script).not.toMatch(/\brm\b[^\n]*(?:\/var\/lib\/(?:apt|dpkg)|lock-frontend)/u);
   });
 
   it("stages full publish artifacts without session control files", () => {

--- a/test/scripts/telegram-user-driver.test.ts
+++ b/test/scripts/telegram-user-driver.test.ts
@@ -1,0 +1,97 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+describe("Telegram user driver reply matching", () => {
+  it("matches an explicitly named SUT by username when its cached numeric id is stale", () => {
+    const program = String.raw`
+import argparse
+import importlib.util
+from pathlib import Path
+
+path = Path("scripts/e2e/telegram-user-driver.py")
+spec = importlib.util.spec_from_file_location("telegram_user_driver", path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+driver = module.UserDriver.__new__(module.UserDriver)
+driver.config = {"sutUsername": "foremanclawbot", "sutId": "7"}
+driver.bot_config = {}
+message = {
+    "@type": "updateNewMessage",
+    "message": {
+        "id": 20,
+        "chat_id": 10,
+        "sender_id": {"@type": "messageSenderUser", "user_id": 42},
+        "content": {
+            "@type": "messageText",
+            "text": {"@type": "formattedText", "text": "OPENCLAW_E2E_OK", "entities": []},
+        },
+    },
+}
+class Client:
+    users = {42: {"username": "foremanclawbot"}}
+    def __init__(self):
+        self.updates = [message]
+    def next_update(self, _timeout):
+        return self.updates.pop(0) if self.updates else None
+driver.client = Client()
+args = argparse.Namespace(
+    expect=["OPENCLAW_E2E_OK"],
+    from_bot="@foremanclawbot",
+    reply_to=None,
+    thread_id=0,
+    timeout_ms=10,
+)
+matched, _observed = driver.wait_for_message(10, args, 0)
+raise SystemExit(0 if matched else 1)
+`;
+    const result = spawnSync("python3", ["-c", program], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+  });
+
+  it("accepts the exact later SUT response without native reply metadata by default", () => {
+    const program = String.raw`
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+path = Path("scripts/e2e/telegram-user-driver.py")
+spec = importlib.util.spec_from_file_location("telegram_user_driver", path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+module.load_config = lambda: ({"sutUsername": "foremanclawbot", "sutId": "7"}, {})
+class Driver:
+    def __init__(self, _config, _bot_config):
+        pass
+    def authorize(self, _args):
+        pass
+    def resolve_chat(self, _chat):
+        return 10
+    def send_text(self, _chat_id, _text, _reply_to):
+        return {"id": 10, "chat_id": 10, "content": {"@type": "messageText"}}
+    def wait_for_message(self, _chat_id, args, _after_message_id):
+        if args.reply_to is not None:
+            return None, []
+        return {
+            "messageId": 20,
+            "senderUsername": "foremanclawbot",
+            "text": "OPENCLAW_E2E_OK",
+        }, []
+module.UserDriver = Driver
+sys.argv = [str(path), "probe", "--text", "test", "--expect", "OPENCLAW_E2E_OK"]
+module.main()
+`;
+    const result = spawnSync("python3", ["-c", program], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where admitted Telegram forum turns could appear with unknown participant provenance in execution-identity audit output. It also repairs three owner-path defects exposed while proving that flow: ordinary local Telegram proof targeted a container-only proxy, apt setup did not wait for the native dpkg lock, and the TDLib matcher could miss a valid later response from the configured bot.

## Why This Change Was Made

Telegram now supplies the forum parent at the channel ingress owner boundary. The proof harness keeps `apiRoot` container-only, uses apt's bounded native lock timeout, validates owner-native channel-admission assurance, and matches configured bot usernames without requiring native reply metadata unless explicitly requested. No generic audit receipt is promoted to verified display trust; no SQLite schema or version changes.

Root causes / owners:

- Telegram forum conversation scope omitted its parent before the strict ingress handoff (`extensions/telegram`).
- `writeSutConfig` installed the Docker proxy in ordinary local SUT config (`scripts/e2e`).
- remote setup's 900-second outer bound did not make apt wait for the dpkg frontend lock (`scripts/e2e`).
- TDLib matching subordinated an explicit username to a stale cached ID and required native reply metadata by default (`scripts/e2e`).

Best-fix verdict: owner-boundary repair. Downstream audit promotion, transport fallback, proxy compensation, retries, lock deletion, and holder termination were rejected.

## User Impact

Operators inspecting admitted Telegram forum runs now retain the correct redacted participant and channel-admission evidence. Maintainers can run the real-user Telegram proof locally or in its container lane without misrouting ordinary polling, spuriously failing on apt lock contention, or losing valid later replies.

## Evidence

- Pre-fix: apt owner regression failed 1/60; local/container config regression failed 1/7; forum provenance, stale-ID, and native-reply-default regressions each failed for the intended owner defect.
- Focused: 143 owner/sibling tests passed with 2 skips; final matcher suite 63/63; both Telegram harness suites 65/65.
- Repository-selected changed gates over all 9 paths passed, including formatting, typechecks, lint, repository guards, and import cycles; the extension/core-import boundary check and `git diff --check` passed.
- Review: ordinary Codex Autoreview clean; bundled pre-send and final-branch-diff TruffleHog scans passed. Exact-head ClawSweeper artifact found the patch correct with no review/security findings; its only rank-up move (finish exact-head checks) is complete. The workflow's later live-proof planner failed non-attributably on a missing/invalid plan, so it was not rerun.
- Testbox: `tbx_01m124jc3yj0mbjrkqkc6t20zx` / run `33099060357` failed infrastructure-only (Vitest worker EPIPE/unexpected exit followed by box stop). Per campaign policy it was not rerun; unintended retry `tbx_01m12a5akwnpkhdv1zt9qcb0jh` was stopped and not recreated.
- Direct AWS: `cbx_ab35be227704` proved the patched apt bootstrap. `cbx_cffebe7f4f64` proved DM delivery and unmentioned-group suppression while exposing the audit/matcher defects. Later AWS allocation failures occurred before held-session creation and were classified infrastructure-only.
- Final real Telegram proof: Mainframe-local isolated SUT, exact Node 24.18.0, no normal Telegram profile access. Config omitted `apiRoot`; default polling was healthy. HITL nonces `HITL-20260827-A` and `HITL-20260827-B` each produced exactly one correlated model/mock request and successful outbound send, before and after the owner RPC restart.
- Audit/CLI/privacy: three channel runs inspected; all had present person invokers, boundary-verified `channel-admission` assurance, stable pseudonymous principal, durable byte-stable pre-restart contexts, and no raw participant or room identifiers.
- Redacted evidence: `../E2E-results/E2E-53380e5-20260827/` in the campaign workspace. Raw credential-adjacent artifacts are intentionally not published.

LOC: product `+3/-0`; tooling `+40/-23`; tests/test-support `+294/-0`.

Named follow-up: held Crabbox `finish` should preserve injected Convex and selected-Node context through credential release. The terminal local path cleaned up successfully; this PR does not broaden into that separate lifecycle repair.
