### PR TITLE
feat(models): refresh provider models and live discovery

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1106,7 +1106,7 @@ extensions/qa-lab/web/src/ui-render-capture-controls.ts	1
 extensions/qa-lab/web/src/ui-render-utils.ts	1
 extensions/qianfan/onboard.ts	2
 extensions/qwen/models.ts	1
-extensions/qwen/stream.ts	4
+extensions/qwen/stream.ts	3
 extensions/raft/src/accounts.ts	1
 extensions/raft/src/gateway.ts	2
 extensions/raft/src/inbound.ts	1

--- a/docs/providers/deepseek.md
+++ b/docs/providers/deepseek.md
@@ -76,10 +76,11 @@ available to that process (for example, in `~/.openclaw/.env` or via
 
 ## Built-in catalog
 
-| Model ref                    | Name              | Input | Context   | Max output | Notes                            |
-| ---------------------------- | ----------------- | ----- | --------- | ---------- | -------------------------------- |
-| `deepseek/deepseek-v4-flash` | DeepSeek V4 Flash | text  | 1,000,000 | 384,000    | Fast V4 thinking-capable surface |
-| `deepseek/deepseek-v4-pro`   | DeepSeek V4 Pro   | text  | 1,000,000 | 384,000    | Default; strongest V4 model      |
+| Model ref                               | Name                                    | Input       | Context   | Max output | Notes                            |
+| --------------------------------------- | --------------------------------------- | ----------- | --------- | ---------- | -------------------------------- |
+| `deepseek/deepseek-v4-flash`            | DeepSeek V4 Flash                       | text        | 1,000,000 | 384,000    | Fast V4 thinking-capable surface |
+| `deepseek/deepseek-v4-pro`              | DeepSeek V4 Pro                         | text        | 1,000,000 | 384,000    | Default; strongest V4 model      |
+| `deepseek/deepseek-v4-flash-vision-exp` | DeepSeek V4 Flash Vision (Experimental) | text, image | 1,000,000 | 384,000    | Experimental image understanding |
 
 <Warning>
 DeepSeek retired `deepseek-chat` and `deepseek-reasoner` on July 24, 2026 at
@@ -87,10 +88,16 @@ DeepSeek retired `deepseek-chat` and `deepseek-reasoner` on July 24, 2026 at
 to `deepseek/deepseek-v4-flash` or `deepseek/deepseek-v4-pro`.
 </Warning>
 
-OpenClaw's local cost estimates follow DeepSeek's published cache-hit,
-cache-miss, and output rates. DeepSeek can change those rates; its
+OpenClaw's local costs are estimates. The vision model's bundled estimate uses
+DeepSeek's peak rates; its published off-peak rates are half those amounts.
+DeepSeek can change rates; its
 [Models & Pricing](https://api-docs.deepseek.com/quick_start/pricing/) page is
 authoritative for billing.
+
+For image inputs, select `deepseek/deepseek-v4-flash-vision-exp`. The regular
+Flash and Pro models are text-only. DeepSeek's experimental vision model accepts
+PNG, JPEG, GIF, and WebP images through the same API and API key. See
+[DeepSeek vision](https://api-docs.deepseek.com/guides/vision) for image limits.
 
 <Tip>
 V4 models support DeepSeek's `thinking` control. OpenClaw also replays
@@ -105,8 +112,8 @@ maximum `reasoning_effort`; both map to `"max"`.
 DeepSeek V4 thinking sessions require replayed assistant messages from a
 thinking-enabled turn to include `reasoning_content` on follow-up requests.
 OpenClaw's DeepSeek plugin backfills that field automatically, so normal
-multi-turn tool use works on `deepseek/deepseek-v4-flash` and
-`deepseek/deepseek-v4-pro` even when history came from another
+multi-turn tool use works on `deepseek/deepseek-v4-flash`,
+`deepseek/deepseek-v4-flash-vision-exp`, and `deepseek/deepseek-v4-pro` even when history came from another
 OpenAI-compatible provider (no native `reasoning_content`) or from a plain
 assistant message. No `/new` required after switching providers mid-session.
 
@@ -130,6 +137,16 @@ pnpm test:live src/agents/models.profiles.live.test.ts
 
 Verifies both V4 models complete and that thinking/tool follow-up turns
 preserve the replay payload DeepSeek requires.
+
+To check the experimental vision model with the same `DEEPSEEK_API_KEY`:
+
+```bash
+OPENCLAW_LIVE_DEEPSEEK_MODEL=deepseek-v4-flash-vision-exp \
+pnpm test:live extensions/deepseek/deepseek.live.test.ts
+```
+
+This runs text, generated-image recognition, and thinking replay checks against
+the selected model.
 
 ## Config example
 

--- a/docs/providers/nvidia.md
+++ b/docs/providers/nvidia.md
@@ -64,21 +64,44 @@ openclaw onboard --auth-choice nvidia-api-key --nvidia-api-key "nvapi-..."
 }
 ```
 
-## Featured catalog
+## Live model catalog
 
-When an NVIDIA API key is configured, setup and model-selection paths fetch
-NVIDIA's public featured-model catalog from
-`https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json` and
-cache the result for 24 hours (first 32 entries, imported as free text-input
-rows). New or republished featured models from build.nvidia.com therefore appear
-in setup and model-selection surfaces after the cache refreshes, without waiting
-for an OpenClaw release. A fresh NVIDIA catalog overrides bundled retirement
-metadata. When the live feed is available, its first model is preselected during
-NVIDIA setup.
+When an NVIDIA API key is configured, setup and model-selection paths check
+`https://integrate.api.nvidia.com/v1/models` for available model IDs, cached for
+30 seconds. NVIDIA's public
+`https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json` feed
+provides ranking and token limits, cached for 24 hours. Featured models appear
+first only while the inference inventory still lists them; other available
+bundled chat models follow. A fresh inventory can restore a previously hidden
+model that NVIDIA has republished.
 
-The fetch uses a fixed HTTPS host policy for `assets.ngc.nvidia.com`. If no
-NVIDIA API key is configured, or if the feed is unavailable or malformed,
-OpenClaw falls back to the bundled catalog and bundled default below.
+The inventory also contains embeddings and other non-chat endpoints, without
+capability metadata. OpenClaw therefore offers only exact models with bundled
+chat metadata or valid featured-model metadata; it does not guess capabilities
+from model names. Unknown IDs can still be configured explicitly; listing alone
+does not prove chat compatibility. This is not a complete automatic catalog of
+every NVIDIA model.
+
+Both public fetches use fixed HTTPS hosts and send no credentials. If the
+featured feed fails, available bundled chat models still appear. If the
+inventory is unavailable or malformed, browse and setup retain the bundled
+fallback, while the fresh-live catalog stays empty. A successful empty inventory
+does not restore stale bundled entries. Without NVIDIA auth, browsing uses the
+bundled catalog without fetching.
+
+## Nemotron 3.5 Lightning
+
+[`nvidia/nemotron-3.5-lightning-30b-a3b`](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b/build)
+is NVIDIA's smaller 30B total / 3B active reasoning model for agentic work. The
+bundled row records its 1M context and a 16,384-token output budget matching
+NVIDIA's hosted example. Select it with:
+
+```bash
+openclaw models set nvidia/nvidia/nemotron-3.5-lightning-30b-a3b
+```
+
+Lightning is selectable when the live inventory lists it even if it is absent
+from the featured feed. Nemotron 3 Ultra remains the default.
 
 ## Nemotron 3 Ultra
 
@@ -97,24 +120,25 @@ hosted in NVIDIA's catalog when their context, latency, or behavior fits better.
 
 ## Bundled fallback catalog
 
-The selectable bundled rows snapshot NVIDIA's featured-model catalog. Deprecated
+The bundled rows provide known chat metadata and an offline fallback. Deprecated
 compatibility rows keep existing exact model references recognizable but stay
 out of model pickers.
 
-| Model ref                                  | Name                  | Context   | Max output |
-| ------------------------------------------ | --------------------- | --------- | ---------- |
-| `nvidia/nvidia/nemotron-3-ultra-550b-a55b` | Nemotron 3 Ultra 550B | 1,048,576 | 8,192      |
-| `nvidia/nvidia/nemotron-3-super-120b-a12b` | Nemotron 3 Super 120B | 1,000,000 | 8,192      |
-| `nvidia/z-ai/glm-5.2`                      | GLM 5.2               | 202,752   | 8,192      |
-| `nvidia/moonshotai/kimi-k2.6`              | Kimi K2.6             | 262,144   | 65,536     |
-| `nvidia/minimaxai/minimax-m3`              | Minimax M3            | 196,608   | 8,192      |
-| `nvidia/deepseek-ai/deepseek-v4-pro`       | DeepSeek V4 Pro       | 262,144   | 16,384     |
+| Model ref                                      | Name                       | Context   | Max output |
+| ---------------------------------------------- | -------------------------- | --------- | ---------- |
+| `nvidia/nvidia/nemotron-3-ultra-550b-a55b`     | Nemotron 3 Ultra 550B      | 1,048,576 | 8,192      |
+| `nvidia/nvidia/nemotron-3.5-lightning-30b-a3b` | Nemotron 3.5 Lightning 30B | 1,048,576 | 16,384     |
+| `nvidia/nvidia/nemotron-3-super-120b-a12b`     | Nemotron 3 Super 120B      | 1,000,000 | 8,192      |
+| `nvidia/z-ai/glm-5.2`                          | GLM 5.2                    | 202,752   | 8,192      |
+| `nvidia/moonshotai/kimi-k2.6`                  | Kimi K2.6                  | 262,144   | 65,536     |
+| `nvidia/minimaxai/minimax-m3`                  | Minimax M3                 | 196,608   | 8,192      |
+| `nvidia/deepseek-ai/deepseek-v4-pro`           | DeepSeek V4 Pro            | 262,144   | 16,384     |
 
 The full compatibility catalog also retains these shipped refs for existing
 configurations and migration: `nvidia/qwen/qwen3.5-397b-a17b`,
 `nvidia/moonshotai/kimi-k2.5`, `nvidia/z-ai/glm-5.1`, `nvidia/z-ai/glm5`, and
 `nvidia/minimaxai/minimax-m2.7`. These references stay hidden from bundled and
-offline model pickers unless NVIDIA republishes them in its featured catalog.
+offline model pickers unless NVIDIA republishes them in its inference inventory.
 NVIDIA has retired the Qwen endpoint, so requests using its model reference no
 longer work. Migrate existing Qwen configurations to an active model.
 
@@ -128,11 +152,11 @@ longer work. Migrate existing Qwen configurations to an active model.
   </Accordion>
 
   <Accordion title="Catalog and pricing">
-    OpenClaw prefers NVIDIA's public featured-model catalog when NVIDIA auth is
-    configured and caches it for 24 hours. The bundled selectable fallback is a
-    static snapshot of NVIDIA's featured-model catalog; deprecated exact-reference
-    compatibility rows stay hidden from that fallback. Fresh featured rows can
-    restore models that NVIDIA has republished. Costs default to `0` in source
+    OpenClaw uses NVIDIA's inference inventory for availability and its featured
+    feed for ranking. Exact bundled metadata preserves reasoning and image
+    capabilities omitted by the featured feed. Deprecated exact-reference
+    compatibility rows stay hidden from the offline fallback; fresh inventory
+    can restore models that NVIDIA has republished. Costs default to `0` in source
     since NVIDIA currently offers free API access for the listed models.
   </Accordion>
 

--- a/docs/providers/qwen.md
+++ b/docs/providers/qwen.md
@@ -19,7 +19,9 @@ Qwen Cloud is an official external OpenClaw provider plugin with canonical id `q
 
 <Tip>
 `qwen3.7-plus` and `qwen3.6-plus` work with Coding Plan and Standard endpoints.
-For `qwen3.7-max` or `qwen3.6-flash`, use a **Standard (pay-as-you-go)** endpoint.
+For `qwen3.8-max` or `qwen3.8-flash`, use **Standard (pay-as-you-go)** or **Token Plan**.
+The older Coding Plan does not include these models. `qwen3.7-max` and
+`qwen3.6-flash` also require Standard or Token Plan.
 </Tip>
 
 ## Install plugin
@@ -86,7 +88,7 @@ Choose your plan type and follow the setup steps.
   </Tab>
 
   <Tab title="Standard (pay-as-you-go)">
-    **Best for:** pay-as-you-go access through the Standard Model Studio endpoint, including `qwen3.7-max` and `qwen3.6-flash`, which are not available on the Coding Plan.
+    **Best for:** pay-as-you-go access through the Standard Model Studio endpoint, including `qwen3.8-max` and `qwen3.8-flash`, which are not available on the older Coding Plan.
 
     <Steps>
       <Step title="Get your API key">
@@ -202,8 +204,11 @@ Override with a custom `baseUrl` in config.
 
 ## Built-in catalog
 
-OpenClaw ships this Qwen static catalog. The catalog is endpoint-aware: Coding
-Plan configs omit models that only work on the Standard endpoint.
+OpenClaw discovers models from the configured endpoint's authenticated `/models`
+API. The plugin keeps the following seed metadata for offline discovery and for
+endpoints that return only model IDs. Coding Plan configs omit models that are
+not included in that plan; a Standard model listing does not establish Token
+Plan or Coding Plan access.
 
 | Model ref                   | Input       | Context   | Notes                   |
 | --------------------------- | ----------- | --------- | ----------------------- |
@@ -212,6 +217,8 @@ Plan configs omit models that only work on the Standard endpoint.
 | `qwen/qwen3.6-plus`         | text, image | 1,000,000 | Coding Plan + Standard  |
 | `qwen/qwen3.7-max`          | text        | 1,000,000 | Standard endpoints only |
 | `qwen/qwen3.7-plus`         | text, image | 1,000,000 | Coding Plan + Standard  |
+| `qwen/qwen3.8-max`          | text, image | 1,000,000 | Standard endpoints only |
+| `qwen/qwen3.8-flash`        | text, image | 1,000,000 | Standard endpoints only |
 | `qwen/qwen3-max-2026-01-23` | text        | 262,144   | Qwen Max line           |
 | `qwen/qwen3-coder-next`     | text        | 262,144   | Coding                  |
 | `qwen/qwen3-coder-plus`     | text        | 1,000,000 | Coding                  |
@@ -222,7 +229,9 @@ Plan configs omit models that only work on the Standard endpoint.
 
 <Note>
 Availability can still vary by endpoint and billing plan even when a model is
-present in the static catalog.
+present in the seed catalog. Additional chat models returned by the endpoint can
+appear without a plugin update. For locally hosted models, use the
+[Ollama](/providers/ollama) or [LM Studio](/providers/lmstudio) discovery flow.
 </Note>
 
 ### Token Plan catalog
@@ -236,6 +245,8 @@ included here because they use different APIs.
 | Model ref                          | Input       | Context   | Picker status |
 | ---------------------------------- | ----------- | --------- | ------------- |
 | `qwen-token-plan/qwen3.7-plus`     | text, image | 1,000,000 | visible       |
+| `qwen-token-plan/qwen3.8-max`      | text, image | 1,000,000 | visible       |
+| `qwen-token-plan/qwen3.8-flash`    | text, image | 1,000,000 | visible       |
 | `qwen-token-plan/qwen3.6-plus`     | text, image | 1,000,000 | visible       |
 | `qwen-token-plan/qwen3-coder-next` | text        | 262,144   | hidden        |
 | `qwen-token-plan/kimi-k2.5`        | text, image | 262,144   | visible       |
@@ -243,6 +254,17 @@ included here because they use different APIs.
 | `qwen-token-plan/MiniMax-M2.5`     | text        | 196,608   | visible       |
 
 ## Thinking controls
+
+`qwen3.8-max` and `qwen3.8-flash` support `off`, `low`, `medium`, and `xhigh`
+thinking, with `xhigh` as the default. `minimal` maps to `low`; `high` and `max`
+map to `xhigh`. This applies to Standard and Token Plan. Both models support
+131,072 output tokens. OpenClaw preserves returned reasoning in its separate
+`reasoning_content` replay field during tool use, rather than placing it in
+visible answer text.
+
+An explicit `thinking_budget` in request parameters takes precedence over the
+mapped `reasoning_effort`: Qwen rejects requests containing both. See the
+[Qwen thinking reference](https://docs.qwencloud.com/developer-guides/text-generation/thinking).
 
 `qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-flash`, and `qwen3.6-plus` are
 reasoning-enabled in the built-in catalog. For reasoning models on the `qwen`
@@ -309,15 +331,15 @@ See [Video generation](/tools/video-generation) for shared tool parameters, prov
 ## Advanced configuration
 
 <AccordionGroup>
-  <Accordion title="Qwen 3.6 and 3.7 availability">
-    `qwen3.7-plus` and `qwen3.6-plus` are available on Coding Plan and Standard endpoints. `qwen3.7-max` and `qwen3.6-flash` are Standard-only. The Standard (pay-as-you-go) endpoints are:
+  <Accordion title="Qwen model availability">
+    `qwen3.7-plus` and `qwen3.6-plus` are available on Coding Plan and Standard endpoints. For `qwen3.8-max`, `qwen3.8-flash`, `qwen3.7-max`, or `qwen3.6-flash`, use Standard or Token Plan. The Standard (pay-as-you-go) endpoints are:
 
     - China: `dashscope.aliyuncs.com/compatible-mode/v1`
     - Global: `dashscope-intl.aliyuncs.com/compatible-mode/v1`
 
-    OpenClaw omits `qwen3.7-max` and `qwen3.6-flash` from Coding Plan catalogs.
-    If a Coding Plan endpoint returns an "unsupported model" error for either,
-    switch to the matching Standard endpoint and key.
+    OpenClaw omits these models from Coding Plan catalogs. If a Coding Plan
+    endpoint returns an "unsupported model" error, switch to the matching
+    Standard or Token Plan endpoint and its dedicated key.
 
   </Accordion>
 

--- a/docs/providers/synthetic.md
+++ b/docs/providers/synthetic.md
@@ -84,25 +84,26 @@ changes its base URL, override `models.providers.synthetic.baseUrl`.
 }
 ```
 
-## Built-in catalog
+## Model discovery
 
-All Synthetic models use cost `0` (input/output/cache). See Synthetic's
-[current model list](https://dev.synthetic.new/docs/api/models) for service availability.
+With a Synthetic credential, OpenClaw discovers current text models from
+Synthetic's [`/openai/v1/models` API](https://dev.synthetic.new/docs/openai/models).
+Inference still uses the Anthropic Messages API. Newly advertised models, including
+small models and `syn:` aliases, do not need an OpenClaw catalog update.
 
-| Model ID                                            | Context window | Max tokens | Reasoning | Input        |
-| --------------------------------------------------- | -------------- | ---------- | --------- | ------------ |
-| `hf:MiniMaxAI/MiniMax-M3`                           | 262,144        | 65,536     | yes       | text + image |
-| `hf:moonshotai/Kimi-K2.7-Code`                      | 262,144        | 8,192      | yes       | text + image |
-| `hf:nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` | 262,144        | 8,192      | yes       | text         |
-| `hf:openai/gpt-oss-120b`                            | 131,072        | 8,192      | yes       | text         |
-| `hf:Qwen/Qwen3.6-27B`                               | 262,144        | 81,920     | yes       | text + image |
-| `hf:zai-org/GLM-4.7-Flash`                          | 196,608        | 131,072    | yes       | text         |
-| `hf:zai-org/GLM-5.2`                                | 524,288        | 131,072    | yes       | text         |
+The live catalog supplies context and output limits, image input, reasoning,
+tool support, and usage-based token prices. Those prices are estimates, not a
+subscription bill. See Synthetic's [current model list](https://dev.synthetic.new/docs/api/models)
+for availability and its recommended aliases.
+
+Offline catalog generation and unavailable or unusable discovery responses use
+the bundled seed models. Your selected model is not changed automatically.
+When you override the inference base URL, OpenClaw skips Synthetic's fixed
+discovery URL so a proxy credential is not sent to Synthetic.
 
 <Tip>
 Model refs use the form `synthetic/<modelId>`. Use
-`openclaw models list --provider synthetic` to see all models available on your
-account.
+`openclaw models list --provider synthetic` to inspect your configured models.
 </Tip>
 
 <AccordionGroup>

--- a/extensions/deepseek/deepseek.live.test.ts
+++ b/extensions/deepseek/deepseek.live.test.ts
@@ -1,11 +1,11 @@
 // Deepseek tests cover deepseek plugin behavior.
 import {
-  completeSimple,
   streamSimple,
   type AssistantMessage,
   type Context,
   type Model,
 } from "openclaw/plugin-sdk/llm";
+import { createSolidPngBuffer } from "openclaw/plugin-sdk/test-fixtures";
 import {
   createSingleUserPromptMessage,
   extractNonEmptyAssistantText,
@@ -37,15 +37,6 @@ const ZERO_USAGE: AssistantMessage["usage"] = {
   },
 };
 
-function forceDeepSeekNonThinkingPath(payload: unknown): void {
-  if (!payload || typeof payload !== "object") {
-    return;
-  }
-  const request = payload as Record<string, unknown>;
-  request.thinking = { type: "disabled" };
-  delete request.reasoning_effort;
-}
-
 function resolveDeepSeekLiveModel(): Model<"openai-completions"> {
   const provider = buildDeepSeekProvider();
   const model = provider.models?.find((entry) => entry.id === DEEPSEEK_LIVE_MODEL);
@@ -60,27 +51,17 @@ function resolveDeepSeekLiveModel(): Model<"openai-completions"> {
   } as Model<"openai-completions">;
 }
 
-function resolveDeepSeekV4LiveModel(): Model<"openai-completions"> {
-  const provider = buildDeepSeekProvider();
-  const requestedModel =
-    DEEPSEEK_LIVE_MODEL === "deepseek-v4-flash" || DEEPSEEK_LIVE_MODEL === "deepseek-v4-pro"
-      ? DEEPSEEK_LIVE_MODEL
-      : "deepseek-v4-flash";
-  const model = provider.models?.find((entry) => entry.id === requestedModel);
-  if (!model) {
-    throw new Error(`DeepSeek bundled catalog does not include ${requestedModel}`);
+function createDeepSeekLiveStream(thinkingLevel: "off" | "high") {
+  const streamFn = createDeepSeekV4ThinkingWrapper(streamSimple, thinkingLevel);
+  if (!streamFn) {
+    throw new Error("expected DeepSeek V4 thinking stream wrapper");
   }
-  return {
-    provider: "deepseek",
-    baseUrl: provider.baseUrl,
-    ...model,
-    api: "openai-completions",
-  } as Model<"openai-completions">;
+  return streamFn;
 }
 
 describeLive("deepseek plugin live", () => {
   it("returns assistant text from the bundled V4 model catalog", async () => {
-    const res = await completeSimple(
+    const stream = await createDeepSeekLiveStream("off")(
       resolveDeepSeekLiveModel(),
       {
         messages: createSingleUserPromptMessage(),
@@ -88,9 +69,9 @@ describeLive("deepseek plugin live", () => {
       {
         apiKey: DEEPSEEK_KEY,
         maxTokens: 64,
-        onPayload: forceDeepSeekNonThinkingPath,
       },
     );
+    const res = await stream.result();
 
     if (res.stopReason === "error") {
       throw new Error(res.errorMessage || "DeepSeek returned error with no message");
@@ -99,6 +80,43 @@ describeLive("deepseek plugin live", () => {
     const text = extractNonEmptyAssistantText(res.content);
     expect(text.length).toBeGreaterThan(0);
   }, 60_000);
+
+  it.runIf(DEEPSEEK_LIVE_MODEL === "deepseek-v4-flash-vision-exp")(
+    "recognizes image content through the selected vision model",
+    async () => {
+      const model = resolveDeepSeekLiveModel();
+      expect(model.input).toContain("image");
+      const stream = await createDeepSeekLiveStream("off")(
+        model,
+        {
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: "What single color fills this image? Reply with exactly RED, BLUE, or GREEN.",
+                },
+                {
+                  type: "image",
+                  data: createSolidPngBuffer(64, 64, { r: 0, g: 255, b: 0 }).toString("base64"),
+                  mimeType: "image/png",
+                },
+              ],
+              timestamp: Date.now(),
+            },
+          ],
+        },
+        { apiKey: DEEPSEEK_KEY, maxTokens: 64 },
+      );
+      const result = await stream.result();
+      if (result.stopReason === "error") {
+        throw new Error(result.errorMessage || "DeepSeek vision returned error with no message");
+      }
+      expect(extractNonEmptyAssistantText(result.content).trim()).toMatch(/^green[.!]?$/i);
+    },
+    60_000,
+  );
 
   it("accepts V4 thinking replay after a prior provider tool call", async () => {
     const toolCallId = "call_deepseek_live_replay_1";
@@ -142,12 +160,7 @@ describeLive("deepseek plugin live", () => {
       ],
     };
     let capturedPayload: Record<string, unknown> | undefined;
-    const streamFn = createDeepSeekV4ThinkingWrapper(streamSimple, "high");
-    if (!streamFn) {
-      throw new Error("expected DeepSeek V4 thinking stream wrapper");
-    }
-
-    const stream = streamFn(resolveDeepSeekV4LiveModel(), context, {
+    const stream = createDeepSeekLiveStream("high")(resolveDeepSeekLiveModel(), context, {
       apiKey: DEEPSEEK_KEY,
       maxTokens: 64,
       onPayload: (payload) => {
@@ -202,12 +215,7 @@ describeLive("deepseek plugin live", () => {
       ],
     };
     let capturedPayload: Record<string, unknown> | undefined;
-    const streamFn = createDeepSeekV4ThinkingWrapper(streamSimple, "high");
-    if (!streamFn) {
-      throw new Error("expected DeepSeek V4 thinking stream wrapper");
-    }
-
-    const stream = streamFn(resolveDeepSeekV4LiveModel(), context, {
+    const stream = createDeepSeekLiveStream("high")(resolveDeepSeekLiveModel(), context, {
       apiKey: DEEPSEEK_KEY,
       maxTokens: 64,
       onPayload: (payload) => {

--- a/extensions/deepseek/index.test.ts
+++ b/extensions/deepseek/index.test.ts
@@ -10,6 +10,7 @@ import { createProviderUsageFetch, makeResponse } from "openclaw/plugin-sdk/test
 import { describe, expect, it } from "vitest";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
 import deepseekPlugin from "./index.js";
+import { buildDeepSeekProvider } from "./provider-catalog.js";
 import { createDeepSeekV4ThinkingWrapper } from "./stream.js";
 
 type OpenAICompletionsModel = Model<"openai-completions">;
@@ -66,23 +67,17 @@ const readTool = {
   parameters: { type: "object", properties: {}, required: [], additionalProperties: false },
 };
 
-function deepSeekV4Model(id: "deepseek-v4-flash" | "deepseek-v4-pro"): OpenAICompletionsModel {
+function deepSeekV4Model(id: string): OpenAICompletionsModel {
+  const provider = buildDeepSeekProvider();
+  const model = provider.models.find((entry) => entry.id === id);
+  if (!model) {
+    throw new Error(`DeepSeek bundled catalog does not include ${id}`);
+  }
   return {
+    ...model,
     provider: "deepseek",
-    id,
-    name: id === "deepseek-v4-flash" ? "DeepSeek V4 Flash" : "DeepSeek V4 Pro",
     api: "openai-completions",
-    baseUrl: "https://api.deepseek.com",
-    reasoning: true,
-    input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 1_000_000,
-    maxTokens: 384_000,
-    compat: {
-      supportsUsageInStreaming: true,
-      supportsReasoningEffort: true,
-      maxTokensField: "max_tokens",
-    },
+    baseUrl: provider.baseUrl,
   } as OpenAICompletionsModel;
 }
 
@@ -111,11 +106,11 @@ function readToolReplayContext(assistantMessage: ReturnType<typeof replayAssista
   } as Context;
 }
 
-function deepSeekReasoningToolReplayContext() {
+function deepSeekReasoningToolReplayContext(modelId = "deepseek-v4-flash") {
   return readToolReplayContext(
     replayAssistantMessage({
       provider: "deepseek",
-      model: "deepseek-v4-flash",
+      model: modelId,
       content: [
         {
           type: "thinking",
@@ -200,6 +195,7 @@ describe("deepseek provider plugin", () => {
     expect(catalogProvider.models?.map((model) => model.id)).toEqual([
       "deepseek-v4-flash",
       "deepseek-v4-pro",
+      "deepseek-v4-flash-vision-exp",
     ]);
     const flashModel = catalogProvider.models?.find((model) => model.id === "deepseek-v4-flash");
     expect(flashModel?.reasoning).toBe(true);
@@ -228,6 +224,11 @@ describe("deepseek provider plugin", () => {
         contextWindow: 1_000_000,
         maxTokens: 384_000,
         cost: { input: 0.435, output: 0.87, cacheRead: 0.003625, cacheWrite: 0 },
+      },
+      "deepseek-v4-flash-vision-exp": {
+        contextWindow: 1_000_000,
+        maxTokens: 384_000,
+        cost: { input: 0.44, output: 1.32, cacheRead: 0.014, cacheWrite: 0 },
       },
     });
   });
@@ -329,24 +330,15 @@ describe("deepseek provider plugin", () => {
     const resolveThinkingProfile = requireThinkingProfileResolver(provider);
     const expectedV4Levels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"];
 
-    expect(
-      resolveThinkingProfile({
-        provider: "deepseek",
-        modelId: "deepseek-v4-pro",
-      } as never)?.levels.map((level) => level.id),
-    ).toEqual(expectedV4Levels);
-    expect(
-      resolveThinkingProfile({
-        provider: "deepseek",
-        modelId: "deepseek-v4-flash",
-      } as never)?.defaultLevel,
-    ).toBe("high");
-    expect(
-      resolveThinkingProfile({
-        provider: "deepseek",
-        modelId: "deepseek-v4-flash",
-      } as never)?.levels.map((level) => level.id),
-    ).toEqual(expectedV4Levels);
+    for (const modelId of [
+      "deepseek-v4-flash",
+      "deepseek-v4-pro",
+      "deepseek-v4-flash-vision-exp",
+    ]) {
+      const profile = resolveThinkingProfile({ provider: "deepseek", modelId } as never);
+      expect(profile?.defaultLevel).toBe("high");
+      expect(profile?.levels.map((level) => level.id)).toEqual(expectedV4Levels);
+    }
     expect(
       resolveThinkingProfile({ provider: "deepseek", modelId: "deepseek-chat" } as never),
     ).toBe(undefined);
@@ -355,80 +347,121 @@ describe("deepseek provider plugin", () => {
     ).toBe(undefined);
   });
 
-  it("maps thinking levels to DeepSeek V4 payload controls", async () => {
-    let capturedPayload: Record<string, unknown> | undefined;
-    const baseStreamFn = (
-      _model: Model<"openai-completions">,
-      _context: Context,
-      options?: { onPayload?: (payload: unknown) => unknown },
-    ) => {
-      capturedPayload = {
-        model: "deepseek-v4-pro",
-        reasoning_effort: "high",
+  it.each(["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-v4-flash-vision-exp"])(
+    "maps thinking levels to %s payload controls",
+    async (modelId) => {
+      let capturedPayload: Record<string, unknown> | undefined;
+      const baseStreamFn = (
+        _model: Model<"openai-completions">,
+        _context: Context,
+        options?: { onPayload?: (payload: unknown) => unknown },
+      ) => {
+        capturedPayload = {
+          model: "deepseek-v4-pro",
+          reasoning_effort: "high",
+        };
+        options?.onPayload?.(capturedPayload);
+        const stream = createAssistantMessageEventStream();
+        queueMicrotask(() => stream.end());
+        return stream;
       };
-      options?.onPayload?.(capturedPayload);
-      const stream = createAssistantMessageEventStream();
-      queueMicrotask(() => stream.end());
-      return stream;
-    };
 
-    const wrapThinkingOff = requireThinkingWrapper(
-      createDeepSeekV4ThinkingWrapper(baseStreamFn as never, "off"),
-      "off",
-    );
-    await wrapThinkingOff(
+      const wrapThinkingOff = requireThinkingWrapper(
+        createDeepSeekV4ThinkingWrapper(baseStreamFn as never, "off"),
+        "off",
+      );
+      await wrapThinkingOff(
+        {
+          provider: "deepseek",
+          id: modelId,
+          api: "openai-completions",
+        } as never,
+        { messages: [] } as never,
+        {},
+      );
+
+      expect(readThinking(capturedPayload)?.type).toBe("disabled");
+      expect(capturedPayload).not.toHaveProperty("reasoning_effort");
+
+      const wrapThinkingXhigh = requireThinkingWrapper(
+        createDeepSeekV4ThinkingWrapper(baseStreamFn as never, "xhigh"),
+        "xhigh",
+      );
+      await wrapThinkingXhigh(
+        {
+          provider: "deepseek",
+          id: modelId,
+          api: "openai-completions",
+        } as never,
+        { messages: [] } as never,
+        {},
+      );
+
+      expect(readThinking(capturedPayload)?.type).toBe("enabled");
+      expect(capturedPayload?.reasoning_effort).toBe("max");
+    },
+  );
+
+  it.each(["deepseek-v4-flash", "deepseek-v4-flash-vision-exp"])(
+    "preserves replayed reasoning_content for %s",
+    async (modelId) => {
+      const capture: PayloadCapture = {};
+      const model = deepSeekV4Model(modelId);
+      const context = deepSeekReasoningToolReplayContext(modelId);
+      const baseStreamFn = createPayloadCapturingStream(capture);
+
+      const wrapThinkingHigh = requireThinkingWrapper(
+        createDeepSeekV4ThinkingWrapper(baseStreamFn as never, "high"),
+        "high",
+      );
+      await wrapThinkingHigh(model, context, {});
+
+      expect(readThinking(capture.payload)?.type).toBe("enabled");
+      expect(capture.payload?.reasoning_effort).toBe("high");
+      const assistantMessage = readPayloadMessage(capture, 1);
+      expect(assistantMessage?.role).toBe("assistant");
+      expect(assistantMessage?.reasoning_content).toBe("call reasoning");
+      const toolCall = readFirstToolCall(assistantMessage);
+      expect(toolCall?.id).toBe("call_1");
+      expect(toolCall?.type).toBe("function");
+      expect(toolCall?.function?.name).toBe("read");
+      expect(toolCall?.function?.arguments).toBe("{}");
+    },
+  );
+
+  it("keeps image input in requests for the bundled vision model", () => {
+    const provider = buildDeepSeekProvider();
+    const entry = provider.models?.find((model) => model.id === "deepseek-v4-flash-vision-exp");
+    expect(entry).toMatchObject({ reasoning: true, input: ["text", "image"] });
+    const model = {
+      ...entry,
+      provider: "deepseek",
+      baseUrl: provider.baseUrl,
+      api: "openai-completions",
+    } as OpenAICompletionsModel;
+    const payload = buildOpenAICompletionsParams(
+      model,
       {
-        provider: "deepseek",
-        id: "deepseek-v4-pro",
-        api: "openai-completions",
-      } as never,
-      { messages: [] } as never,
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Describe this image." },
+              { type: "image", data: "fixture-image", mimeType: "image/png" },
+            ],
+            timestamp: 1,
+          },
+        ],
+      },
       {},
     );
-
-    expect(readThinking(capturedPayload)?.type).toBe("disabled");
-    expect(capturedPayload).not.toHaveProperty("reasoning_effort");
-
-    const wrapThinkingXhigh = requireThinkingWrapper(
-      createDeepSeekV4ThinkingWrapper(baseStreamFn as never, "xhigh"),
-      "xhigh",
-    );
-    await wrapThinkingXhigh(
-      {
-        provider: "deepseek",
-        id: "deepseek-v4-pro",
-        api: "openai-completions",
-      } as never,
-      { messages: [] } as never,
-      {},
-    );
-
-    expect(readThinking(capturedPayload)?.type).toBe("enabled");
-    expect(capturedPayload?.reasoning_effort).toBe("max");
-  });
-
-  it("preserves replayed reasoning_content when DeepSeek V4 thinking is enabled", async () => {
-    const capture: PayloadCapture = {};
-    const model = deepSeekV4Model("deepseek-v4-flash");
-    const context = deepSeekReasoningToolReplayContext();
-    const baseStreamFn = createPayloadCapturingStream(capture);
-
-    const wrapThinkingHigh = requireThinkingWrapper(
-      createDeepSeekV4ThinkingWrapper(baseStreamFn as never, "high"),
-      "high",
-    );
-    await wrapThinkingHigh(model, context, {});
-
-    expect(readThinking(capture.payload)?.type).toBe("enabled");
-    expect(capture.payload?.reasoning_effort).toBe("high");
-    const assistantMessage = readPayloadMessage(capture, 1);
-    expect(assistantMessage?.role).toBe("assistant");
-    expect(assistantMessage?.reasoning_content).toBe("call reasoning");
-    const toolCall = readFirstToolCall(assistantMessage);
-    expect(toolCall?.id).toBe("call_1");
-    expect(toolCall?.type).toBe("function");
-    expect(toolCall?.function?.name).toBe("read");
-    expect(toolCall?.function?.arguments).toBe("{}");
+    expect(payload.messages).toContainEqual({
+      role: "user",
+      content: [
+        { type: "text", text: "Describe this image." },
+        { type: "image_url", image_url: { url: "data:image/png;base64,fixture-image" } },
+      ],
+    });
   });
 
   it("adds blank reasoning_content for replayed tool calls from non-DeepSeek turns", async () => {

--- a/extensions/deepseek/models.ts
+++ b/extensions/deepseek/models.ts
@@ -11,7 +11,9 @@ export const DEEPSEEK_MODEL_CATALOG: ModelDefinitionConfig[] = buildManifestMode
   catalog: DEEPSEEK_MANIFEST_CATALOG,
 }).models.map((model) => Object.assign(model, { api: "openai-completions" }));
 
-const DEEPSEEK_V4_MODEL_IDS = new Set(["deepseek-v4-flash", "deepseek-v4-pro"]);
+const DEEPSEEK_V4_MODEL_IDS = new Set(
+  DEEPSEEK_MODEL_CATALOG.map((model) => model.id).filter((id) => id.startsWith("deepseek-v4-")),
+);
 
 export function isDeepSeekV4ModelId(modelId: string): boolean {
   return DEEPSEEK_V4_MODEL_IDS.has(modelId.toLowerCase());

--- a/extensions/deepseek/openclaw.plugin.json
+++ b/extensions/deepseek/openclaw.plugin.json
@@ -69,6 +69,26 @@
               "maxTokensField": "max_tokens",
               "codeMode": "preferred"
             }
+          },
+          {
+            "id": "deepseek-v4-flash-vision-exp",
+            "name": "DeepSeek V4 Flash Vision (Experimental)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 384000,
+            "cost": {
+              "input": 0.44,
+              "output": 1.32,
+              "cacheRead": 0.014,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "supportsUsageInStreaming": true,
+              "supportsReasoningEffort": true,
+              "maxTokensField": "max_tokens",
+              "codeMode": "preferred"
+            }
           }
         ]
       }

--- a/extensions/nvidia/index.test.ts
+++ b/extensions/nvidia/index.test.ts
@@ -45,11 +45,22 @@ afterEach(() => {
 });
 
 function mockFeaturedCatalogResponse(payload: unknown, status = 200) {
-  ssrfRuntimeMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
-    response: Response.json(payload, { status }),
-    finalUrl: NVIDIA_FEATURED_MODELS_URL,
+  const featured =
+    (payload as { "featured-models"?: Array<{ model: string }> })["featured-models"] ?? [];
+  ssrfRuntimeMocks.fetchWithSsrFGuard.mockImplementation(async ({ url }: { url: string }) => ({
+    response: Response.json(
+      url === NVIDIA_FEATURED_MODELS_URL
+        ? payload
+        : {
+            data: featured.map(({ model }) => ({
+              id: model.includes("/") ? model : `nvidia/${model}`,
+            })),
+          },
+      { status },
+    ),
+    finalUrl: url,
     release: vi.fn(),
-  });
+  }));
 }
 
 function registerNvidiaPluginApi() {
@@ -208,6 +219,7 @@ describe("nvidia provider hooks", () => {
 
     expect(entries?.map((entry) => entry.id)).toEqual([
       "nvidia/nemotron-3-ultra-550b-a55b",
+      "nvidia/nemotron-3.5-lightning-30b-a3b",
       "nvidia/nemotron-3-super-120b-a12b",
       "z-ai/glm-5.2",
       "moonshotai/kimi-k2.6",
@@ -218,7 +230,7 @@ describe("nvidia provider hooks", () => {
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
   });
 
-  it("surfaces the bundled NVIDIA models when authenticated featured catalog fetch fails", async () => {
+  it("surfaces the bundled NVIDIA models when authenticated live discovery fails", async () => {
     mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
     const provider = await registerNvidiaProvider();
 
@@ -226,6 +238,7 @@ describe("nvidia provider hooks", () => {
 
     expect(entries?.map((entry) => entry.id)).toEqual([
       "nvidia/nemotron-3-ultra-550b-a55b",
+      "nvidia/nemotron-3.5-lightning-30b-a3b",
       "nvidia/nemotron-3-super-120b-a12b",
       "z-ai/glm-5.2",
       "moonshotai/kimi-k2.6",
@@ -233,7 +246,7 @@ describe("nvidia provider hooks", () => {
       "deepseek-ai/deepseek-v4-pro",
     ]);
     expect(entries?.every((entry) => entry.provider === "nvidia")).toBe(true);
-    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(1);
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(2);
   });
 
   it("surfaces republished NVIDIA featured models via augmentModelCatalog", async () => {
@@ -309,6 +322,7 @@ describe("nvidia provider hooks", () => {
     const staticRows = await catalogProvider?.staticCatalog?.(buildCatalogContext());
     expect(staticRows?.map((entry) => `${entry.source}:${entry.provider}/${entry.model}`)).toEqual([
       "static:nvidia/nvidia/nemotron-3-ultra-550b-a55b",
+      "static:nvidia/nvidia/nemotron-3.5-lightning-30b-a3b",
       "static:nvidia/nvidia/nemotron-3-super-120b-a12b",
       "static:nvidia/z-ai/glm-5.2",
       "static:nvidia/moonshotai/kimi-k2.6",
@@ -325,7 +339,7 @@ describe("nvidia provider hooks", () => {
     ]);
   });
 
-  it("keeps static rows out of the live catalog when the featured catalog is unavailable", async () => {
+  it("keeps static rows out of the live catalog when discovery is unavailable", async () => {
     mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
     const { registeredModelCatalogProviders } = registerNvidiaPluginApi();
     const catalogProvider = registeredModelCatalogProviders[0];

--- a/extensions/nvidia/nvidia.live.test.ts
+++ b/extensions/nvidia/nvidia.live.test.ts
@@ -1,0 +1,19 @@
+import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
+import { describe, expect, it } from "vitest";
+import { buildSelectableLiveNvidiaProvider } from "./provider-catalog.js";
+
+const describeLive = isLiveTestEnabled() ? describe : describe.skip;
+
+describeLive("NVIDIA public catalog live", () => {
+  it("finds Lightning outside the featured feed without offering non-chat inventory", async () => {
+    const provider = await buildSelectableLiveNvidiaProvider();
+    expect(
+      provider.models.find((model) => model.id === "nvidia/nemotron-3.5-lightning-30b-a3b"),
+    ).toMatchObject({
+      reasoning: true,
+      input: ["text"],
+      contextWindow: 1_048_576,
+    });
+    expect(provider.models.some((model) => model.id.includes("embed"))).toBe(false);
+  }, 30_000);
+});

--- a/extensions/nvidia/onboard.test.ts
+++ b/extensions/nvidia/onboard.test.ts
@@ -17,6 +17,7 @@ describe("nvidia onboard", () => {
     expect(provider.api).toBe("openai-completions");
     expect(provider.models.map((model) => model.id)).toEqual([
       "nvidia/nemotron-3-ultra-550b-a55b",
+      "nvidia/nemotron-3.5-lightning-30b-a3b",
       "nvidia/nemotron-3-super-120b-a12b",
       "z-ai/glm-5.2",
       "moonshotai/kimi-k2.6",
@@ -44,6 +45,7 @@ describe("nvidia onboard", () => {
     expect(provider?.models.map((model) => model.id)).toEqual([
       "nvidia/custom-model",
       "nvidia/nemotron-3-ultra-550b-a55b",
+      "nvidia/nemotron-3.5-lightning-30b-a3b",
       "nvidia/nemotron-3-super-120b-a12b",
       "z-ai/glm-5.2",
       "moonshotai/kimi-k2.6",
@@ -69,6 +71,7 @@ describe("nvidia onboard", () => {
     expect(provider?.models.map((model) => model.id)).toEqual([
       id,
       "nvidia/nemotron-3-ultra-550b-a55b",
+      "nvidia/nemotron-3.5-lightning-30b-a3b",
       "nvidia/nemotron-3-super-120b-a12b",
       "z-ai/glm-5.2",
       "moonshotai/kimi-k2.6",

--- a/extensions/nvidia/openclaw.plugin.json
+++ b/extensions/nvidia/openclaw.plugin.json
@@ -44,6 +44,23 @@
             }
           },
           {
+            "id": "nvidia/nemotron-3.5-lightning-30b-a3b",
+            "name": "Nemotron 3.5 Lightning 30B",
+            "input": ["text"],
+            "reasoning": true,
+            "contextWindow": 1048576,
+            "maxTokens": 16384,
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "compat": {
+              "requiresStringContent": true
+            }
+          },
+          {
             "id": "nvidia/nemotron-3-super-120b-a12b",
             "name": "Nemotron 3 Super 120B",
             "input": ["text"],

--- a/extensions/nvidia/provider-catalog.test.ts
+++ b/extensions/nvidia/provider-catalog.test.ts
@@ -11,13 +11,20 @@ import {
 
 const NVIDIA_FEATURED_MODELS_URL =
   "https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json";
+const NVIDIA_MODELS_URL = "https://integrate.api.nvidia.com/v1/models";
 
-const EXPECTED_FEATURED_MODELS = [
+const EXPECTED_SELECTABLE_MODELS = [
   {
     id: "nvidia/nemotron-3-ultra-550b-a55b",
     name: "Nemotron 3 Ultra 550B",
     contextWindow: 1_048_576,
     maxTokens: 8_192,
+  },
+  {
+    id: "nvidia/nemotron-3.5-lightning-30b-a3b",
+    name: "Nemotron 3.5 Lightning 30B",
+    contextWindow: 1_048_576,
+    maxTokens: 16_384,
   },
   {
     id: "nvidia/nemotron-3-super-120b-a12b",
@@ -75,7 +82,7 @@ const EXPECTED_DEPRECATED_MODELS = [
 ] as const;
 
 const EXPECTED_BUNDLED_MODELS = [
-  ...EXPECTED_FEATURED_MODELS,
+  ...EXPECTED_SELECTABLE_MODELS,
   ...EXPECTED_DEPRECATED_MODELS,
 ] as const;
 
@@ -88,24 +95,177 @@ const ssrfRuntimeMocks = vi.hoisted(() => ({
 
 vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ssrfRuntimeMocks);
 
+const catalogResponses = new Map<
+  string,
+  Array<{ response: Response; finalUrl: string; release: ReturnType<typeof vi.fn> }>
+>();
+
 afterEach(() => {
   vi.useRealTimers();
   clearLiveCatalogCacheForTests();
   ssrfRuntimeMocks.fetchWithSsrFGuard.mockReset();
   ssrfRuntimeMocks.ssrfPolicyFromHttpBaseUrlAllowedHostname.mockClear();
+  catalogResponses.clear();
 });
 
-function mockFeaturedCatalogResponse(payload: unknown, status = 200) {
+function mockFeaturedCatalogResponse(payload: unknown, status = 200, inventoryIds?: string[]) {
   const release = vi.fn();
-  ssrfRuntimeMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
-    response: Response.json(payload, { status }),
-    finalUrl: NVIDIA_FEATURED_MODELS_URL,
-    release,
+  const featured =
+    (payload as { "featured-models"?: Array<{ model: string }> })["featured-models"] ?? [];
+  const ids =
+    inventoryIds ??
+    featured.map((row) => row.model).filter((id) => typeof id === "string" && !/\s/.test(id));
+  for (const [url, body] of [
+    [
+      NVIDIA_MODELS_URL,
+      { data: ids.map((id) => ({ id: id.includes("/") ? id : `nvidia/${id}` })) },
+    ],
+    [NVIDIA_FEATURED_MODELS_URL, payload],
+  ] as const) {
+    const responses = catalogResponses.get(url) ?? [];
+    responses.push({
+      response: Response.json(body, { status }),
+      finalUrl: url,
+      release: url === NVIDIA_FEATURED_MODELS_URL ? release : vi.fn(),
+    });
+    catalogResponses.set(url, responses);
+  }
+  ssrfRuntimeMocks.fetchWithSsrFGuard.mockImplementation(async ({ url }: { url: string }) => {
+    const response = catalogResponses.get(url)?.shift();
+    if (!response) {
+      throw new Error(`Unexpected catalog request: ${url}`);
+    }
+    return response;
   });
   return release;
 }
 
+function mockInventoryAndFeatured(params: {
+  ids: string[];
+  featured: unknown[];
+  inventoryStatus?: number;
+  featuredStatus?: number;
+}) {
+  ssrfRuntimeMocks.fetchWithSsrFGuard.mockImplementation(async ({ url }: { url: string }) => ({
+    response:
+      url === NVIDIA_MODELS_URL
+        ? Response.json(
+            { data: params.ids.map((id) => ({ id, object: "model" })) },
+            { status: params.inventoryStatus ?? 200 },
+          )
+        : Response.json(
+            { "featured-models": params.featured },
+            { status: params.featuredStatus ?? 200 },
+          ),
+    finalUrl: url,
+    release: vi.fn(),
+  }));
+}
+
 describe("nvidia provider catalog", () => {
+  it("uses the model inventory for availability while retaining featured ordering", async () => {
+    mockInventoryAndFeatured({
+      ids: [
+        "nvidia/nemotron-3-ultra-550b-a55b",
+        "nvidia/nemotron-3-super-120b-a12b",
+        "nvidia/nemotron-3.5-lightning-30b-a3b",
+        "nvidia/unclassified-new-model",
+        "nvidia/nemotron-4-340b-reward",
+      ],
+      featured: [
+        {
+          model: "z-ai/glm-5.2",
+          "model-name": "Stale featured model",
+          context: 202752,
+          "max-output": 8192,
+        },
+        {
+          model: "nemotron-3-super-120b-a12b",
+          "model-name": "Nemotron 3 Super",
+          context: 1000000,
+          "max-output": 8192,
+        },
+      ],
+    });
+
+    const provider = await buildLiveNvidiaProvider();
+
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "nvidia/nemotron-3-super-120b-a12b",
+      "nvidia/nemotron-3-ultra-550b-a55b",
+      "nvidia/nemotron-3.5-lightning-30b-a3b",
+    ]);
+  });
+
+  it("preserves known capabilities when a featured row only supplies limits", async () => {
+    mockInventoryAndFeatured({
+      ids: ["moonshotai/kimi-k2.6"],
+      featured: [
+        {
+          model: "moonshotai/kimi-k2.6",
+          "model-name": "Kimi K2.6",
+          context: 262144,
+          "max-output": 65536,
+        },
+      ],
+    });
+
+    expect((await buildLiveNvidiaProvider()).models).toMatchObject([
+      { id: "moonshotai/kimi-k2.6", reasoning: true, input: ["text", "image"] },
+    ]);
+  });
+
+  it("uses known live models when the featured feed fails", async () => {
+    mockInventoryAndFeatured({
+      ids: ["nvidia/nemotron-3-ultra-550b-a55b"],
+      featured: [],
+      featuredStatus: 503,
+    });
+
+    const provider = await buildSelectableLiveNvidiaProvider();
+
+    expect(provider.models).toMatchObject([
+      {
+        id: "nvidia/nemotron-3-ultra-550b-a55b",
+        reasoning: true,
+        params: { chat_template_kwargs: { enable_thinking: false, force_nonempty_content: true } },
+      },
+    ]);
+    expect(provider.models).toHaveLength(1);
+  });
+
+  it("does not turn an empty authoritative inventory into a bundled fallback", async () => {
+    mockInventoryAndFeatured({
+      ids: [],
+      featured: [
+        {
+          model: "z-ai/glm-5.2",
+          "model-name": "Stale featured model",
+          context: 202752,
+          "max-output": 8192,
+        },
+      ],
+    });
+
+    expect((await buildLiveNvidiaProvider()).models).toEqual([]);
+    expect((await buildSelectableLiveNvidiaProvider()).models).toEqual([]);
+  });
+
+  it("does not treat featured rows as fresh inventory when model discovery fails", async () => {
+    mockInventoryAndFeatured({
+      ids: [],
+      inventoryStatus: 503,
+      featured: [
+        { model: "z-ai/glm-5.2", "model-name": "GLM 5.2", context: 202752, "max-output": 8192 },
+      ],
+    });
+
+    expect((await buildLiveNvidiaProvider()).models.map((model) => model.id)).toEqual(
+      EXPECTED_SELECTABLE_MODELS.map((model) => model.id),
+    );
+    expect((await buildSelectableLiveNvidiaProvider()).models).toEqual([]);
+  });
+
   it("builds the bundled NVIDIA provider defaults", () => {
     const provider = buildNvidiaProvider();
 
@@ -124,14 +284,21 @@ describe("nvidia provider catalog", () => {
       [],
     );
     expect(
-      provider.models.slice(0, EXPECTED_FEATURED_MODELS.length).map(({ id, input, reasoning }) => ({
-        id,
-        input,
-        reasoning,
-      })),
+      provider.models
+        .slice(0, EXPECTED_SELECTABLE_MODELS.length)
+        .map(({ id, input, reasoning }) => ({
+          id,
+          input,
+          reasoning,
+        })),
     ).toEqual([
       {
         id: "nvidia/nemotron-3-ultra-550b-a55b",
+        input: ["text"],
+        reasoning: true,
+      },
+      {
+        id: "nvidia/nemotron-3.5-lightning-30b-a3b",
         input: ["text"],
         reasoning: true,
       },
@@ -163,7 +330,7 @@ describe("nvidia provider catalog", () => {
         },
       },
     });
-    expect(provider.models[1]).toMatchObject({
+    expect(provider.models[2]).toMatchObject({
       id: "nvidia/nemotron-3-super-120b-a12b",
       contextWindow: 1_000_000,
     });
@@ -198,7 +365,7 @@ describe("nvidia provider catalog", () => {
     const provider = buildSelectableNvidiaProvider();
 
     expect(provider.models.map((model) => model.id)).toEqual(
-      EXPECTED_FEATURED_MODELS.map((model) => model.id),
+      EXPECTED_SELECTABLE_MODELS.map((model) => model.id),
     );
   });
 
@@ -244,19 +411,21 @@ describe("nvidia provider catalog", () => {
     });
     // getCachedLiveProviderModelRows forwards the budget remaining after elapsed
     // time, so only the bound is stable; pinning 10_000 fails once a millisecond passes.
-    const guardedRequest = ssrfRuntimeMocks.fetchWithSsrFGuard.mock.calls[0]?.[0];
+    const guardedRequest = ssrfRuntimeMocks.fetchWithSsrFGuard.mock.calls.find(
+      ([request]) => request.url === NVIDIA_FEATURED_MODELS_URL,
+    )?.[0];
     expect(guardedRequest?.timeoutMs).toBeGreaterThan(0);
     expect(guardedRequest?.timeoutMs).toBeLessThanOrEqual(10_000);
     expect(release).toHaveBeenCalledOnce();
   });
 
-  it("falls back to the bundled catalog when the featured catalog is unavailable", async () => {
+  it("falls back to the bundled catalog when live discovery is unavailable", async () => {
     mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
 
     const provider = await buildLiveNvidiaProvider();
 
     expect(provider.models.map((model) => model.id)).toEqual(
-      EXPECTED_FEATURED_MODELS.map((model) => model.id),
+      EXPECTED_SELECTABLE_MODELS.map((model) => model.id),
     );
   });
 
@@ -354,7 +523,7 @@ describe("nvidia provider catalog", () => {
     ]);
   });
 
-  it("returns no selectable live rows when the featured catalog is unavailable", async () => {
+  it("returns no selectable live rows when live discovery is unavailable", async () => {
     mockFeaturedCatalogResponse({ error: "unavailable" }, 503);
 
     const provider = await buildSelectableLiveNvidiaProvider();
@@ -406,7 +575,7 @@ describe("nvidia provider catalog", () => {
     await buildLiveNvidiaProvider();
     await buildLiveNvidiaProvider();
 
-    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledOnce();
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(2);
   });
 
   it("skips featured catalog cache when ttl expiry overflows", async () => {
@@ -437,26 +606,30 @@ describe("nvidia provider catalog", () => {
 
     expect(first.models.map((model) => model.id)).toEqual(["minimaxai/minimax-m3"]);
     expect(second.models.map((model) => model.id)).toEqual(["z-ai/glm-5.2"]);
-    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(2);
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(4);
   });
 
   it("does not cache successful featured catalog responses with no usable rows", async () => {
-    mockFeaturedCatalogResponse({
-      "featured-models": [
-        {
-          model: "bad model id",
-          "model-name": "Bad",
-          context: 1000,
-          "max-output": 1000,
-        },
-      ],
-    });
+    mockFeaturedCatalogResponse(
+      {
+        "featured-models": [
+          {
+            model: "bad model id",
+            "model-name": "Bad",
+            context: 1000,
+            "max-output": 1000,
+          },
+        ],
+      },
+      200,
+      ["z-ai/glm-5.2"],
+    );
     mockFeaturedCatalogResponse({
       "featured-models": [
         {
           model: "z-ai/glm-5.2",
-          "model-name": "GLM 5.2",
-          context: 202752,
+          "model-name": "Updated GLM 5.2",
+          context: 262144,
           "max-output": 8192,
         },
       ],
@@ -465,11 +638,13 @@ describe("nvidia provider catalog", () => {
     const first = await buildLiveNvidiaProvider();
     const second = await buildLiveNvidiaProvider();
 
-    expect(first.models.map((model) => model.id)).toEqual(
-      EXPECTED_FEATURED_MODELS.map((model) => model.id),
-    );
-    expect(second.models.map((model) => model.id)).toEqual(["z-ai/glm-5.2"]);
-    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(2);
+    expect(first.models).toMatchObject([
+      { id: "z-ai/glm-5.2", name: "GLM 5.2", contextWindow: 202752 },
+    ]);
+    expect(second.models).toMatchObject([
+      { id: "z-ai/glm-5.2", name: "Updated GLM 5.2", contextWindow: 262144 },
+    ]);
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(3);
   });
 
   it("applies bundled Ultra defaults when featured catalog returns Ultra", async () => {

--- a/extensions/nvidia/provider-catalog.ts
+++ b/extensions/nvidia/provider-catalog.ts
@@ -1,6 +1,9 @@
 // Nvidia provider module implements model/runtime integration.
 import { lookup as dnsLookup } from "node:dns/promises";
-import { getCachedLiveProviderModelRows } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import {
+  getCachedLiveProviderModelRows,
+  readLiveModelCatalogStringField,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type {
   ModelDefinitionConfig,
@@ -14,6 +17,7 @@ import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 export const NVIDIA_DEFAULT_MODEL_ID = "nvidia/nemotron-3-ultra-550b-a55b";
+const NVIDIA_MODELS_URL = "https://integrate.api.nvidia.com/v1/models";
 const NVIDIA_FEATURED_MODELS_URL =
   "https://assets.ngc.nvidia.com/products/api-catalog/featured-models.json";
 
@@ -90,30 +94,75 @@ export function buildSelectableNvidiaProvider(): ModelProviderConfig {
 }
 
 export async function buildLiveNvidiaProvider(): Promise<ModelProviderConfig> {
-  const provider = buildSelectableNvidiaProvider();
-  const featuredModels = await loadNvidiaFeaturedModels();
-  if (!featuredModels || featuredModels.length === 0) {
-    return provider;
-  }
+  const provider = buildNvidiaProvider();
   return {
     ...provider,
-    models: applyNvidiaModelDefaults(featuredModels),
+    models:
+      (await loadNvidiaLiveModels(provider.models)) ??
+      filterSelectableNvidiaModels(provider.models),
   };
 }
 
 export async function buildSelectableLiveNvidiaProvider(): Promise<ModelProviderConfig> {
-  const provider = buildSelectableNvidiaProvider();
-  const featuredModels = await loadNvidiaFeaturedModels();
-  if (!featuredModels || featuredModels.length === 0) {
-    return {
-      ...provider,
-      models: [],
-    };
-  }
+  const provider = buildNvidiaProvider();
   return {
     ...provider,
-    models: applyNvidiaModelDefaults(featuredModels),
+    models: (await loadNvidiaLiveModels(provider.models)) ?? [],
   };
+}
+
+async function loadNvidiaLiveModels(
+  bundledModels: ModelDefinitionConfig[],
+): Promise<ModelDefinitionConfig[] | null> {
+  try {
+    const [rows, featured] = await Promise.all([
+      getCachedLiveProviderModelRows({
+        providerId: "nvidia",
+        endpoint: NVIDIA_MODELS_URL,
+        requireHttps: true,
+        readRows: (payload) => {
+          if (!isRecord(payload) || !Array.isArray(payload.data)) {
+            throw new Error("NVIDIA model inventory must contain data[]");
+          }
+          if (payload.data.some((row) => !readLiveModelCatalogStringField(row, "id"))) {
+            throw new Error("NVIDIA model inventory contains a row without an id");
+          }
+          return payload.data;
+        },
+      }),
+      loadNvidiaFeaturedModels(),
+    ]);
+    const available = new Set(rows.map((row) => readLiveModelCatalogStringField(row, "id")));
+    const known = new Map(bundledModels.map((model) => [model.id, model]));
+    // /models includes embeddings and other non-chat endpoints without capabilities.
+    // Only exact known chat metadata or the vendor's featured chat rows are selectable.
+    const ranked = new Map(
+      (featured ?? []).map((model) => {
+        const bundled = known.get(model.id);
+        return [
+          model.id,
+          bundled
+            ? {
+                ...bundled,
+                name: model.name,
+                contextWindow: model.contextWindow,
+                maxTokens: model.maxTokens,
+              }
+            : model,
+        ];
+      }),
+    );
+    for (const [id, model] of known) {
+      if (!ranked.has(id)) {
+        ranked.set(id, model);
+      }
+    }
+    // A fresh inventory can restore a republished legacy id, but a stale featured
+    // recommendation cannot restore an id the inference endpoint no longer lists.
+    return [...ranked.values()].filter((model) => available.has(model.id));
+  } catch {
+    return null;
+  }
 }
 
 async function loadNvidiaFeaturedModels(): Promise<ModelDefinitionConfig[] | null> {

--- a/extensions/qwen/index.test.ts
+++ b/extensions/qwen/index.test.ts
@@ -53,6 +53,8 @@ describe("qwen provider plugin", () => {
           { id: QWEN_36_PLUS_MODEL_ID },
           { id: QWEN_37_MAX_MODEL_ID },
           { id: QWEN_37_PLUS_MODEL_ID },
+          { id: "qwen3.8-max" },
+          { id: "qwen3.8-flash" },
         ],
       },
     } as never);
@@ -115,7 +117,9 @@ describe("qwen provider plugin", () => {
     } as never);
     const catalogProvider = requireCatalogProvider(result);
     expect(catalogProvider.baseUrl).toBe(QWEN_TOKEN_PLAN_GLOBAL_BASE_URL);
-    expect(catalogProvider.models).toHaveLength(6);
+    expect(catalogProvider.models.map((model) => model.id)).toEqual(
+      expect.arrayContaining(["qwen3.7-plus", "qwen3.8-max", "qwen3.8-flash"]),
+    );
 
     const legacy = requireRegisteredProvider(providers, QWEN_TOKEN_PLAN_LEGACY_PROVIDER_ID);
     expect(legacy.auth).toEqual([]);
@@ -196,7 +200,9 @@ describe("qwen provider plugin", () => {
       apiKey: "canonical-key",
       baseUrl: QWEN_TOKEN_PLAN_CN_BASE_URL,
     });
-    expect(catalogProvider.models).toHaveLength(6);
+    expect(catalogProvider.models.map((model) => model.id)).toEqual(
+      expect.arrayContaining(["qwen3.8-max", "qwen3.8-flash"]),
+    );
     expect(catalogProvider.models?.map((model) => model.id)).not.toContain("legacy-only");
     expect(resolveProviderApiKey).toHaveBeenCalledTimes(1);
     expect(resolveProviderApiKey).toHaveBeenCalledWith(QWEN_TOKEN_PLAN_PROVIDER_ID);
@@ -209,6 +215,15 @@ describe("qwen provider plugin", () => {
       name: "Qwen Provider",
     });
     const provider = requireRegisteredProvider(providers, QWEN_TOKEN_PLAN_PROVIDER_ID);
+    for (const ownerId of ["qwen", QWEN_TOKEN_PLAN_PROVIDER_ID]) {
+      const owner = requireRegisteredProvider(providers, ownerId);
+      for (const modelId of ["qwen3.8-max", "qwen3.8-flash"]) {
+        expect(owner.resolveThinkingProfile?.({ modelId } as never)).toEqual({
+          levels: ["off", "low", "medium", "xhigh"].map((id) => ({ id })),
+          defaultLevel: "xhigh",
+        });
+      }
+    }
     const expected = {
       levels: [{ id: "low", label: "on" }],
       defaultLevel: "low",

--- a/extensions/qwen/index.ts
+++ b/extensions/qwen/index.ts
@@ -5,6 +5,7 @@ import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-en
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { buildQwenMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import {
+  isQwen38ModelId,
   isQwenCodingPlanBaseUrl,
   isQwenStandardOnlyModelId,
   isQwenTokenPlanDeepSeekV4ModelId,
@@ -112,6 +113,10 @@ function createQwenTokenPlanAuthMethod(region: "global" | "cn") {
 }
 
 function resolveQwenTokenPlanThinkingProfile(modelId: string) {
+  const qwenProfile = resolveQwenThinkingProfile(modelId);
+  if (qwenProfile) {
+    return qwenProfile;
+  }
   // Uncataloged exact refs remain selectable, so family predicates preserve their request controls.
   if (isQwenTokenPlanThinkingOnlyModelId(modelId)) {
     return {
@@ -138,6 +143,15 @@ function resolveQwenTokenPlanThinkingProfile(modelId: string) {
   return undefined;
 }
 
+function resolveQwenThinkingProfile(modelId: string) {
+  return isQwen38ModelId(modelId)
+    ? {
+        levels: (["off", "low", "medium", "xhigh"] as const).map((id) => ({ id })),
+        defaultLevel: "xhigh" as const,
+      }
+    : undefined;
+}
+
 export default defineSingleProviderPluginEntry({
   id: PROVIDER_ID,
   name: "Qwen Provider",
@@ -161,7 +175,7 @@ export default defineSingleProviderPluginEntry({
           "Manage API keys: https://home.qwencloud.com/api-keys",
           "Docs: https://docs.qwencloud.com/",
           "Endpoint: dashscope.aliyuncs.com/compatible-mode/v1",
-          "Models: qwen3.7-max, qwen3.7-plus, qwen3.6-plus, qwen3.6-flash, qwen3.5-plus, etc.",
+          "Models: qwen3.8-max, qwen3.8-flash, qwen3.7-plus, and other discovered models.",
         ].join("\n"),
         noteTitle: "Qwen Cloud Standard (China)",
         wizard: {
@@ -184,7 +198,7 @@ export default defineSingleProviderPluginEntry({
           "Manage API keys: https://home.qwencloud.com/api-keys",
           "Docs: https://docs.qwencloud.com/",
           "Endpoint: dashscope-intl.aliyuncs.com/compatible-mode/v1",
-          "Models: qwen3.7-max, qwen3.7-plus, qwen3.6-plus, qwen3.6-flash, qwen3.5-plus, etc.",
+          "Models: qwen3.8-max, qwen3.8-flash, qwen3.7-plus, and other discovered models.",
         ].join("\n"),
         noteTitle: "Qwen Cloud Standard (Global/Intl)",
         wizard: {
@@ -259,6 +273,7 @@ export default defineSingleProviderPluginEntry({
       staticRun: async () => ({ provider: buildQwenProvider() }),
     },
     wrapStreamFn: wrapQwenProviderStream,
+    resolveThinkingProfile: ({ modelId }) => resolveQwenThinkingProfile(modelId),
     normalizeConfig: ({ providerConfig }) => {
       if (!isQwenCodingPlanBaseUrl(providerConfig.baseUrl)) {
         return undefined;

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -85,7 +85,8 @@ export const QWEN_TOKEN_PLAN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig>
 export const QWEN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> =
   buildManifestModelProviderConfig({
     providerId: "qwen",
-    catalog: manifest.modelCatalog.providers.qwen,
+    // Shared seeds span plans; only runtime config selects the Coding Plan default.
+    catalog: { ...manifest.modelCatalog.providers.qwen, baseUrl: QWEN_BASE_URL },
   }).models;
 
 export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {

--- a/extensions/qwen/models.ts
+++ b/extensions/qwen/models.ts
@@ -1,12 +1,14 @@
 // Qwen plugin module implements models behavior.
 import {
   applyProviderNativeStreamingUsageCompat,
+  buildManifestModelProviderConfig,
   supportsNativeStreamingUsageCompat,
 } from "openclaw/plugin-sdk/provider-catalog-shared";
 import type {
   ModelDefinitionConfig,
   ModelProviderConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 export const QWEN_BASE_URL = "https://coding-intl.dashscope.aliyuncs.com/v1";
 export const QWEN_GLOBAL_BASE_URL = QWEN_BASE_URL;
@@ -26,6 +28,11 @@ export const QWEN_36_FLASH_MODEL_ID = "qwen3.6-flash";
 export const QWEN_36_PLUS_MODEL_ID = "qwen3.6-plus";
 export const QWEN_37_MAX_MODEL_ID = "qwen3.7-max";
 export const QWEN_37_PLUS_MODEL_ID = "qwen3.7-plus";
+const QWEN_38_MODEL_IDS = new Set(["qwen3.8-max", "qwen3.8-flash"]);
+
+export function isQwen38ModelId(modelId: string): boolean {
+  return QWEN_38_MODEL_IDS.has(modelId.trim().toLowerCase());
+}
 export const QWEN_DEFAULT_COST = {
   input: 0,
   output: 0,
@@ -68,52 +75,18 @@ export function resolveQwenTokenPlanBaseUrl(region: QwenTokenPlanRegion): string
   return QWEN_TOKEN_PLAN_BASE_URLS[region];
 }
 
-type QwenCatalogModelRow = readonly [
-  id: string,
-  reasoning: boolean,
-  input: ModelDefinitionConfig["input"],
-  contextWindow: number,
-  maxTokens: number,
-];
-
-function buildQwenCatalogModels(rows: readonly QwenCatalogModelRow[]): ModelDefinitionConfig[] {
-  return rows.map(([id, reasoning, input, contextWindow, maxTokens]) => ({
-    id,
-    name: id,
-    reasoning,
-    input,
-    cost: QWEN_DEFAULT_COST,
-    contextWindow,
-    maxTokens,
-  }));
-}
-
 // Token Plan is credit-based, so per-token prices do not map to its billing model.
-// This curated picker catalog keeps current recommendations plus one selectable compatibility row.
 export const QWEN_TOKEN_PLAN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> =
-  buildQwenCatalogModels([
-    [QWEN_37_PLUS_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
-    [QWEN_36_PLUS_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
-    ["qwen3-coder-next", true, ["text"], 262_144, 65_536],
-    ["kimi-k2.5", true, ["text", "image"], 262_144, 98_304],
-    ["glm-5", true, ["text"], 202_752, 16_384],
-    ["MiniMax-M2.5", true, ["text"], 196_608, 32_768],
-  ]);
+  buildManifestModelProviderConfig({
+    providerId: QWEN_TOKEN_PLAN_PROVIDER_ID,
+    catalog: manifest.modelCatalog.providers[QWEN_TOKEN_PLAN_PROVIDER_ID],
+  }).models;
 
-export const QWEN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> = buildQwenCatalogModels([
-  [QWEN_DEFAULT_MODEL_ID, false, ["text", "image"], 1_000_000, 65_536],
-  [QWEN_36_FLASH_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
-  [QWEN_36_PLUS_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
-  [QWEN_37_MAX_MODEL_ID, true, ["text"], 1_000_000, 65_536],
-  [QWEN_37_PLUS_MODEL_ID, true, ["text", "image"], 1_000_000, 65_536],
-  ["qwen3-max-2026-01-23", false, ["text"], 262_144, 65_536],
-  ["qwen3-coder-next", false, ["text"], 262_144, 65_536],
-  ["qwen3-coder-plus", false, ["text"], 1_000_000, 65_536],
-  ["MiniMax-M2.5", true, ["text"], 1_000_000, 65_536],
-  ["glm-5", false, ["text"], 202_752, 16_384],
-  ["glm-4.7", false, ["text"], 202_752, 16_384],
-  ["kimi-k2.5", false, ["text", "image"], 262_144, 32_768],
-]);
+export const QWEN_MODEL_CATALOG: ReadonlyArray<ModelDefinitionConfig> =
+  buildManifestModelProviderConfig({
+    providerId: "qwen",
+    catalog: manifest.modelCatalog.providers.qwen,
+  }).models;
 
 export function isQwenCodingPlanBaseUrl(baseUrl: string | undefined): boolean {
   const trimmed = baseUrl?.trim();
@@ -138,6 +111,7 @@ export function isQwen36PlusSupportedBaseUrl(_baseUrl: string | undefined): bool
 const QWEN_STANDARD_ONLY_MODEL_IDS = new Set<string>([
   QWEN_36_FLASH_MODEL_ID,
   QWEN_37_MAX_MODEL_ID,
+  ...QWEN_38_MODEL_IDS,
 ]);
 
 export function isQwenStandardOnlyModelId(modelId: string): boolean {

--- a/extensions/qwen/openclaw.plugin.json
+++ b/extensions/qwen/openclaw.plugin.json
@@ -52,6 +52,66 @@
     "suppressions": [
       {
         "provider": "qwen",
+        "model": "qwen3.8-max",
+        "reason": "qwen3.8-max is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go or Token Plan endpoint.",
+        "when": {
+          "baseUrlHosts": [
+            "coding.dashscope.aliyuncs.com",
+            "coding-intl.dashscope.aliyuncs.com"
+          ],
+          "providerConfigApiIn": [
+            "qwen",
+            "modelstudio"
+          ]
+        }
+      },
+      {
+        "provider": "qwen",
+        "model": "qwen3.8-flash",
+        "reason": "qwen3.8-flash is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go or Token Plan endpoint.",
+        "when": {
+          "baseUrlHosts": [
+            "coding.dashscope.aliyuncs.com",
+            "coding-intl.dashscope.aliyuncs.com"
+          ],
+          "providerConfigApiIn": [
+            "qwen",
+            "modelstudio"
+          ]
+        }
+      },
+      {
+        "provider": "modelstudio",
+        "model": "qwen3.8-max",
+        "reason": "qwen3.8-max is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go or Token Plan endpoint.",
+        "when": {
+          "baseUrlHosts": [
+            "coding.dashscope.aliyuncs.com",
+            "coding-intl.dashscope.aliyuncs.com"
+          ],
+          "providerConfigApiIn": [
+            "qwen",
+            "modelstudio"
+          ]
+        }
+      },
+      {
+        "provider": "modelstudio",
+        "model": "qwen3.8-flash",
+        "reason": "qwen3.8-flash is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go or Token Plan endpoint.",
+        "when": {
+          "baseUrlHosts": [
+            "coding.dashscope.aliyuncs.com",
+            "coding-intl.dashscope.aliyuncs.com"
+          ],
+          "providerConfigApiIn": [
+            "qwen",
+            "modelstudio"
+          ]
+        }
+      },
+      {
+        "provider": "qwen",
         "model": "qwen3.6-flash",
         "reason": "qwen3.6-flash is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint.",
         "when": {
@@ -88,6 +148,146 @@
       }
     ],
     "providers": {
+      "qwen": {
+        "baseUrl": "https://coding-intl.dashscope.aliyuncs.com/v1",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "qwen3.5-plus",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536
+          },
+          {
+            "id": "qwen3.6-flash",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536
+          },
+          {
+            "id": "qwen3.6-plus",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536
+          },
+          {
+            "id": "qwen3.7-max",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536
+          },
+          {
+            "id": "qwen3.7-plus",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536
+          },
+          {
+            "id": "qwen3.8-max",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "thinkingLevelMap": {
+              "minimal": "low",
+              "high": "xhigh",
+              "max": "xhigh"
+            },
+            "compat": {
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": [
+                "low",
+                "medium",
+                "xhigh"
+              ],
+              "reasoningEffortMap": {
+                "minimal": "low",
+                "high": "xhigh",
+                "max": "xhigh"
+              }
+            }
+          },
+          {
+            "id": "qwen3.8-flash",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "thinkingLevelMap": {
+              "minimal": "low",
+              "high": "xhigh",
+              "max": "xhigh"
+            },
+            "compat": {
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": [
+                "low",
+                "medium",
+                "xhigh"
+              ],
+              "reasoningEffortMap": {
+                "minimal": "low",
+                "high": "xhigh",
+                "max": "xhigh"
+              }
+            }
+          },
+          {
+            "id": "qwen3-max-2026-01-23",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 65536
+          },
+          {
+            "id": "qwen3-coder-next",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 262144,
+            "maxTokens": 65536
+          },
+          {
+            "id": "qwen3-coder-plus",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536
+          },
+          {
+            "id": "MiniMax-M2.5",
+            "reasoning": true,
+            "input": ["text"],
+            "contextWindow": 1000000,
+            "maxTokens": 65536
+          },
+          {
+            "id": "glm-5",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 202752,
+            "maxTokens": 16384
+          },
+          {
+            "id": "glm-4.7",
+            "reasoning": false,
+            "input": ["text"],
+            "contextWindow": 202752,
+            "maxTokens": 16384
+          },
+          {
+            "id": "kimi-k2.5",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "contextWindow": 262144,
+            "maxTokens": 32768
+          }
+        ]
+      },
       "qwen-token-plan": {
         "baseUrl": "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
         "api": "openai-completions",
@@ -100,6 +300,76 @@
             "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
             "contextWindow": 1000000,
             "maxTokens": 65536
+          },
+          {
+            "id": "qwen3.8-max",
+            "name": "qwen3.8-max",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "thinkingLevelMap": {
+              "minimal": "low",
+              "high": "xhigh",
+              "max": "xhigh"
+            },
+            "compat": {
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": [
+                "low",
+                "medium",
+                "xhigh"
+              ],
+              "reasoningEffortMap": {
+                "minimal": "low",
+                "high": "xhigh",
+                "max": "xhigh"
+              }
+            }
+          },
+          {
+            "id": "qwen3.8-flash",
+            "name": "qwen3.8-flash",
+            "reasoning": true,
+            "input": [
+              "text",
+              "image"
+            ],
+            "cost": {
+              "input": 0,
+              "output": 0,
+              "cacheRead": 0,
+              "cacheWrite": 0
+            },
+            "contextWindow": 1000000,
+            "maxTokens": 131072,
+            "thinkingLevelMap": {
+              "minimal": "low",
+              "high": "xhigh",
+              "max": "xhigh"
+            },
+            "compat": {
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": [
+                "low",
+                "medium",
+                "xhigh"
+              ],
+              "reasoningEffortMap": {
+                "minimal": "low",
+                "high": "xhigh",
+                "max": "xhigh"
+              }
+            }
           },
           {
             "id": "qwen3.6-plus",

--- a/extensions/qwen/openclaw.plugin.json
+++ b/extensions/qwen/openclaw.plugin.json
@@ -58,10 +58,6 @@
           "baseUrlHosts": [
             "coding.dashscope.aliyuncs.com",
             "coding-intl.dashscope.aliyuncs.com"
-          ],
-          "providerConfigApiIn": [
-            "qwen",
-            "modelstudio"
           ]
         }
       },
@@ -73,10 +69,6 @@
           "baseUrlHosts": [
             "coding.dashscope.aliyuncs.com",
             "coding-intl.dashscope.aliyuncs.com"
-          ],
-          "providerConfigApiIn": [
-            "qwen",
-            "modelstudio"
           ]
         }
       },
@@ -88,10 +80,6 @@
           "baseUrlHosts": [
             "coding.dashscope.aliyuncs.com",
             "coding-intl.dashscope.aliyuncs.com"
-          ],
-          "providerConfigApiIn": [
-            "qwen",
-            "modelstudio"
           ]
         }
       },
@@ -103,10 +91,6 @@
           "baseUrlHosts": [
             "coding.dashscope.aliyuncs.com",
             "coding-intl.dashscope.aliyuncs.com"
-          ],
-          "providerConfigApiIn": [
-            "qwen",
-            "modelstudio"
           ]
         }
       },
@@ -115,8 +99,7 @@
         "model": "qwen3.6-flash",
         "reason": "qwen3.6-flash is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint.",
         "when": {
-          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
-          "providerConfigApiIn": ["qwen", "modelstudio"]
+          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"]
         }
       },
       {
@@ -124,8 +107,7 @@
         "model": "qwen3.7-max",
         "reason": "qwen3.7-max is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint.",
         "when": {
-          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
-          "providerConfigApiIn": ["qwen", "modelstudio"]
+          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"]
         }
       },
       {
@@ -133,8 +115,7 @@
         "model": "qwen3.6-flash",
         "reason": "qwen3.6-flash is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint.",
         "when": {
-          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
-          "providerConfigApiIn": ["qwen", "modelstudio"]
+          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"]
         }
       },
       {
@@ -142,14 +123,12 @@
         "model": "qwen3.7-max",
         "reason": "qwen3.7-max is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint.",
         "when": {
-          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"],
-          "providerConfigApiIn": ["qwen", "modelstudio"]
+          "baseUrlHosts": ["coding.dashscope.aliyuncs.com", "coding-intl.dashscope.aliyuncs.com"]
         }
       }
     ],
     "providers": {
       "qwen": {
-        "baseUrl": "https://coding-intl.dashscope.aliyuncs.com/v1",
         "api": "openai-completions",
         "models": [
           {
@@ -199,6 +178,7 @@
               "max": "xhigh"
             },
             "compat": {
+              "codeMode": "capable",
               "supportsReasoningEffort": true,
               "supportedReasoningEfforts": [
                 "low",
@@ -323,6 +303,7 @@
               "max": "xhigh"
             },
             "compat": {
+              "codeMode": "capable",
               "supportsReasoningEffort": true,
               "supportedReasoningEfforts": [
                 "low",

--- a/extensions/qwen/provider-catalog.test.ts
+++ b/extensions/qwen/provider-catalog.test.ts
@@ -1,3 +1,4 @@
+import { buildOpenAICompatibleLiveModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 // Qwen tests cover provider catalog plugin behavior.
 import { describe, expect, it } from "vitest";
 import {
@@ -72,6 +73,16 @@ describe("qwen provider catalog", () => {
       contextWindow: 1_000_000,
       maxTokens: 65_536,
     });
+    for (const id of ["qwen3.8-max", "qwen3.8-flash"]) {
+      expect(getQwenModelIds(coding)).not.toContain(id);
+      expect(getQwenModelIds(codingTrailingDot)).not.toContain(id);
+      expect(standard.models.find((model) => model.id === id)).toMatchObject({
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 1_000_000,
+        maxTokens: 131_072,
+      });
+    }
   });
 
   it("opts native Qwen baseUrls into streaming usage only inside the extension", () => {
@@ -99,7 +110,7 @@ describe("qwen provider catalog", () => {
 });
 
 describe("qwen token plan provider catalog", () => {
-  it("ships the curated six-row Global catalog through manifest and runtime", () => {
+  it("advertises current plan models while retaining the deprecated compatibility row", () => {
     const provider = buildQwenTokenPlanProvider();
     const models = provider.models;
     const modelIds = models.map((model) => model.id);
@@ -108,6 +119,8 @@ describe("qwen token plan provider catalog", () => {
     expect(provider.api).toBe("openai-completions");
     expect(modelIds).toEqual([
       QWEN_TOKEN_PLAN_DEFAULT_MODEL_ID,
+      "qwen3.8-max",
+      "qwen3.8-flash",
       "qwen3.6-plus",
       "qwen3-coder-next",
       "kimi-k2.5",
@@ -158,10 +171,60 @@ describe("qwen token plan provider catalog", () => {
     "opts Token Plan endpoint %s into native streaming usage",
     (baseUrl) => {
       const provider = applyQwenNativeStreamingUsageCompat(buildQwenTokenPlanProvider({ baseUrl }));
-      expect(provider.models).toHaveLength(6);
+      expect(provider.models.map((model) => model.id)).toEqual(
+        expect.arrayContaining(["qwen3.8-max", "qwen3.8-flash"]),
+      );
       expect(
         provider.models.every((model) => model.compat?.supportsUsageInStreaming === true),
       ).toBe(true);
     },
   );
 });
+
+it.each(["qwen", "qwen-token-plan"])(
+  "keeps %s flagship metadata while discovering uncurated models",
+  async (providerId) => {
+    const providerConfig =
+      providerId === "qwen"
+        ? buildQwenProvider({ baseUrl: QWEN_STANDARD_GLOBAL_BASE_URL })
+        : buildQwenTokenPlanProvider();
+    const provider = await buildOpenAICompatibleLiveModelProviderConfig({
+      providerId,
+      providerConfig,
+      apiKey: `discovery-${providerId}`,
+      fetchGuard: async ({ url }) => ({
+        response: new Response(
+          JSON.stringify({
+            data: [
+              { id: "qwen3.8-max" },
+              { id: "qwen3.8-flash" },
+              {
+                id: "qwen3.8-27b",
+                reasoning: true,
+                input: ["text", "image"],
+                context_window: 1_000_000,
+                max_output_tokens: 131_072,
+              },
+            ],
+          }),
+        ),
+        finalUrl: url,
+        release: async () => {},
+      }),
+    });
+    expect(provider.models.map((model) => model.id)).toEqual([
+      "qwen3.8-27b",
+      "qwen3.8-flash",
+      "qwen3.8-max",
+    ]);
+    for (const model of provider.models) {
+      expect(model).toMatchObject({
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 1_000_000,
+        maxTokens: 131_072,
+      });
+    }
+    expect(providerConfig.models.some((model) => model.id === "qwen3.8-27b")).toBe(false);
+  },
+);

--- a/extensions/qwen/qwen.live.test.ts
+++ b/extensions/qwen/qwen.live.test.ts
@@ -1,0 +1,121 @@
+import { streamSimple, type Context, type Model } from "openclaw/plugin-sdk/llm";
+import { buildOpenAICompatibleLiveModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { createSolidPngBuffer } from "openclaw/plugin-sdk/test-fixtures";
+import { extractNonEmptyAssistantText, isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
+import { Type } from "typebox";
+import { beforeAll, describe, expect, it } from "vitest";
+import { QWEN_STANDARD_GLOBAL_BASE_URL } from "./models.js";
+import { buildQwenProvider } from "./provider-catalog.js";
+import { wrapQwenProviderStream } from "./stream.js";
+
+const apiKey = process.env.QWEN_API_KEY ?? "";
+const describeLive = isLiveTestEnabled() && apiKey ? describe : describe.skip;
+
+describeLive.each(["qwen3.8-max", "qwen3.8-flash"])("Qwen Standard live: %s", (id) => {
+  let model: Model<"openai-completions">;
+  beforeAll(async () => {
+    const provider = await buildOpenAICompatibleLiveModelProviderConfig({
+      providerId: "qwen",
+      providerConfig: buildQwenProvider({ baseUrl: QWEN_STANDARD_GLOBAL_BASE_URL }),
+      apiKey,
+    });
+    const discovered = provider.models.find((entry) => entry.id === id);
+    if (!discovered) {
+      throw new Error(`Qwen discovery did not return ${id}`);
+    }
+    expect(discovered).toMatchObject({ reasoning: true, input: ["text", "image"] });
+    model = {
+      ...discovered,
+      input: discovered.input.filter((modality) => modality === "text" || modality === "image"),
+      provider: "qwen",
+      baseUrl: provider.baseUrl,
+      api: "openai-completions",
+    };
+  });
+
+  async function complete(context: Context, thinkingLevel: "off" | "low" | "high") {
+    const stream = wrapQwenProviderStream({
+      provider: "qwen",
+      modelId: id,
+      model,
+      thinkingLevel,
+      streamFn: streamSimple,
+    });
+    if (!stream) {
+      throw new Error("Qwen provider did not wrap the model stream");
+    }
+    const result = await (
+      await stream(model, context, {
+        apiKey,
+        maxTokens: 2048,
+        signal: AbortSignal.timeout(60_000),
+      })
+    ).result();
+    if (result.stopReason === "error" || result.stopReason === "aborted") {
+      throw new Error(result.errorMessage || `Qwen stopped: ${result.stopReason}`);
+    }
+    return result;
+  }
+
+  it("recognizes image input with thinking disabled", async () => {
+    const result = await complete(
+      {
+        messages: [
+          {
+            role: "user",
+            timestamp: Date.now(),
+            content: [
+              {
+                type: "text",
+                text: "Name the dominant color in this image. Reply with one color word.",
+              },
+              {
+                type: "image",
+                mimeType: "image/png",
+                data: createSolidPngBuffer(64, 64, { r: 255, g: 0, b: 0 }).toString("base64"),
+              },
+            ],
+          },
+        ],
+      },
+      "off",
+    );
+    expect(extractNonEmptyAssistantText(result.content).toLowerCase()).toContain("red");
+  }, 70_000);
+
+  it("round-trips a tool call with low and mapped xhigh reasoning", async () => {
+    const context: Context = {
+      messages: [
+        {
+          role: "user",
+          content:
+            "Call lookup_secret once, then reply with only its returned word. Do not guess the word.",
+          timestamp: Date.now(),
+        },
+      ],
+      tools: [
+        {
+          name: "lookup_secret",
+          description: "Retrieve a fixture word.",
+          parameters: Type.Object({}, { additionalProperties: false }),
+        },
+      ],
+    };
+    const first = await complete(context, "low");
+    const call = first.content.find((block) => block.type === "toolCall");
+    expect(call?.name).toBe("lookup_secret");
+    if (!call) {
+      throw new Error("Qwen did not call the requested tool");
+    }
+    context.messages.push(first, {
+      role: "toolResult",
+      toolCallId: call.id,
+      toolName: call.name,
+      content: [{ type: "text", text: "marigold" }],
+      isError: false,
+      timestamp: Date.now(),
+    });
+    const second = await complete(context, "high");
+    expect(extractNonEmptyAssistantText(second.content).toLowerCase()).toContain("marigold");
+  }, 130_000);
+});

--- a/extensions/qwen/stream.test.ts
+++ b/extensions/qwen/stream.test.ts
@@ -100,6 +100,93 @@ describe("createQwenThinkingWrapper", () => {
 });
 
 describe("wrapQwenProviderStream", () => {
+  it.each(
+    ["qwen", "qwen-token-plan"].flatMap((provider) =>
+      ["qwen3.8-max", "qwen3.8-flash"].flatMap((id) =>
+        (
+          [
+            ["off", undefined],
+            ["low", "low"],
+            ["medium", "medium"],
+            ["high", "xhigh"],
+            ["xhigh", "xhigh"],
+            ["max", "xhigh"],
+          ] as const
+        ).map(([level, effort]) => ({ provider, id, level, effort })),
+      ),
+    ),
+  )(
+    "maps $provider/$id $level without changing reasoning replay",
+    ({ provider, id, level, effort }) => {
+      let captured: Record<string, unknown> = {};
+      const messages = [
+        { role: "assistant", content: "done", reasoning_content: "original reasoning" },
+      ];
+      const model = {
+        api: "openai-completions",
+        provider,
+        id,
+        reasoning: true,
+      } as Model<"openai-completions">;
+      const streamFn: StreamFn = (_model, _context, options) => {
+        const payload = { messages, thinking: { type: "enabled" } };
+        options?.onPayload?.(payload, _model);
+        captured = payload;
+        return {} as ReturnType<StreamFn>;
+      };
+      const wrapped = wrapQwenProviderStream({
+        provider,
+        modelId: id,
+        model,
+        streamFn,
+        thinkingLevel: level,
+      } as never);
+      void wrapped?.(model, { messages: [] } as Context, {});
+      expect(captured).toEqual({
+        messages,
+        enable_thinking: level !== "off",
+        ...(effort ? { reasoning_effort: effort } : {}),
+      });
+      expect(messages[0]?.reasoning_content).toBe("original reasoning");
+    },
+  );
+
+  it.each(["qwen", "qwen-token-plan"])(
+    "honors %s caller budgets and reasoning overrides after async payload replacement",
+    async (provider) => {
+      const model = {
+        api: "openai-completions",
+        provider,
+        id: "qwen3.8-max",
+        reasoning: true,
+      } as Model<"openai-completions">;
+      let captured: Record<string, unknown> = {};
+      const streamFn: StreamFn = async (_model, _context, options) => {
+        const payload = { messages: [] };
+        const replacement = await options?.onPayload?.(payload, _model);
+        captured = (replacement ?? payload) as Record<string, unknown>;
+        return {} as Awaited<ReturnType<StreamFn>>;
+      };
+      const wrapped = wrapQwenProviderStream({
+        provider,
+        modelId: model.id,
+        model,
+        streamFn,
+        thinkingLevel: "high",
+      } as never);
+      for (const [replacement, expected] of [
+        [{ thinking_budget: 512 }, { thinking_budget: 512, enable_thinking: true }],
+        [{ reasoning_effort: "low" }, { reasoning_effort: "low", enable_thinking: true }],
+        [{ reasoning_effort: "none" }, { enable_thinking: false }],
+      ]) {
+        await wrapped?.(model, { messages: [] } as Context, {
+          onPayload: async () => ({ ...replacement }),
+        });
+        expect(captured).toEqual(expected);
+      }
+    },
+  );
+
   it("only registers for Qwen-family OpenAI-compatible providers", () => {
     const streamFn = wrapQwenProviderStream({
       provider: "qwencloud",

--- a/extensions/qwen/stream.ts
+++ b/extensions/qwen/stream.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { asOptionalRecord as asPayloadRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  isQwen38ModelId,
   isQwenTokenPlanDeepSeekV4ModelId,
   isQwenTokenPlanGlmModelId,
   isQwenTokenPlanKimiModelId,
@@ -22,7 +23,8 @@ import {
 
 type QwenThinkingLevel = ProviderWrapStreamFnContext["thinkingLevel"];
 type QwenThinkingFormat = string | undefined;
-type QwenTokenPlanThinkingContract =
+type QwenThinkingContract =
+  | { family: "qwen-3.8" }
   | { family: "deepseek-v4" }
   | { family: "kimi" }
   | { family: "glm"; supportsMax: boolean };
@@ -33,8 +35,12 @@ function resolveQwenThinkingLevel(
 ): QwenThinkingLevel {
   const runtimeOptions = (options ?? {}) as { reasoningEffort?: unknown; reasoning?: unknown };
   const raw = runtimeOptions.reasoningEffort ?? runtimeOptions.reasoning ?? thinkingLevel;
+  return normalizeQwenThinkingLevel(raw, thinkingLevel);
+}
+
+function normalizeQwenThinkingLevel(raw: unknown, fallback?: QwenThinkingLevel): QwenThinkingLevel {
   if (typeof raw !== "string") {
-    return thinkingLevel;
+    return fallback;
   }
   const normalized = raw.trim().toLowerCase();
   if (normalized === "none") {
@@ -50,7 +56,7 @@ function resolveQwenThinkingLevel(
     case "max":
       return normalized;
     default:
-      return thinkingLevel;
+      return fallback;
   }
 }
 
@@ -73,10 +79,13 @@ function isQwenTokenPlanProviderId(providerId: string): boolean {
   );
 }
 
-function resolveQwenTokenPlanThinkingContract(
+function resolveQwenThinkingContract(
   providerId: string,
   modelId: string,
-): QwenTokenPlanThinkingContract | undefined {
+): QwenThinkingContract | undefined {
+  if (isQwen38ModelId(modelId)) {
+    return { family: "qwen-3.8" };
+  }
   if (!isQwenTokenPlanProviderId(providerId)) {
     return undefined;
   }
@@ -90,6 +99,26 @@ function resolveQwenTokenPlanThinkingContract(
     return { family: "glm", supportsMax: supportsQwenTokenPlanGlmMaxThinking(modelId) };
   }
   return undefined;
+}
+
+function patchQwen38Payload(
+  payload: Record<string, unknown>,
+  thinkingLevel: QwenThinkingLevel,
+  enableThinking: boolean,
+): void {
+  delete payload.thinking;
+  // An explicit token budget owns reasoning depth; Qwen rejects it together
+  // with reasoning_effort. Preserve caller budgets instead of overriding them.
+  if (!enableThinking || payload.thinking_budget !== undefined) {
+    delete payload.reasoning_effort;
+    return;
+  }
+  payload.reasoning_effort =
+    thinkingLevel === "minimal" || thinkingLevel === "low"
+      ? "low"
+      : thinkingLevel === "medium"
+        ? "medium"
+        : "xhigh";
 }
 
 function patchTokenPlanDeepSeekV4Payload(
@@ -149,9 +178,9 @@ function normalizeTokenPlanThinkingToolChoice(
   return true;
 }
 
-function enforceQwenTokenPlanPayloadAfterCaller(
+function enforceQwenPayloadAfterCaller(
   payload: Record<string, unknown>,
-  tokenPlanContract: QwenTokenPlanThinkingContract | undefined,
+  tokenPlanContract: QwenThinkingContract | undefined,
   forceThinking: boolean,
   requestedEnableThinking: boolean,
   requestedThinkingLevel: QwenThinkingLevel,
@@ -166,12 +195,18 @@ function enforceQwenTokenPlanPayloadAfterCaller(
       : hasPayloadThinking
         ? undefined
         : requestedThinkingLevel;
-  if (!forceThinking && rawThinkingLevel === "off") {
+  if (
+    !forceThinking &&
+    (rawThinkingLevel === "off" ||
+      (tokenPlanContract?.family === "qwen-3.8" && rawThinkingLevel === "none"))
+  ) {
     enableThinking = false;
   }
   payload.enable_thinking = enableThinking;
   enableThinking = normalizeTokenPlanThinkingToolChoice(payload, enableThinking, forceThinking);
-  if (tokenPlanContract?.family === "deepseek-v4") {
+  if (tokenPlanContract?.family === "qwen-3.8") {
+    patchQwen38Payload(payload, normalizeQwenThinkingLevel(rawThinkingLevel), enableThinking);
+  } else if (tokenPlanContract?.family === "deepseek-v4") {
     const thinkingLevel =
       rawThinkingLevel === "xhigh" || rawThinkingLevel === "max" ? "max" : "high";
     patchTokenPlanDeepSeekV4Payload(payload, thinkingLevel, enableThinking);
@@ -184,10 +219,7 @@ function enforceQwenTokenPlanPayloadAfterCaller(
     if (rawThinkingLevel === "none" && enableThinking) {
       delete payload.thinking;
     } else {
-      const thinkingLevel =
-        typeof rawThinkingLevel === "string"
-          ? resolveQwenThinkingLevel(rawThinkingLevel as QwenThinkingLevel, undefined)
-          : undefined;
+      const thinkingLevel = normalizeQwenThinkingLevel(rawThinkingLevel);
       patchTokenPlanGlmPayload(
         payload,
         thinkingLevel,
@@ -203,17 +235,17 @@ function enforceQwenTokenPlanPayloadAfterCaller(
   delete payload.reasoning;
 }
 
-function finalizeQwenTokenPlanPayloadAfterCaller(
+function finalizeQwenPayloadAfterCaller(
   value: unknown,
   fallbackPayload: Record<string, unknown> | undefined,
-  tokenPlanContract: QwenTokenPlanThinkingContract | undefined,
+  tokenPlanContract: QwenThinkingContract | undefined,
   forceThinking: boolean,
   requestedEnableThinking: boolean,
   requestedThinkingLevel: QwenThinkingLevel,
 ): unknown {
   const finalPayload = asPayloadRecord(value) ?? fallbackPayload;
   if (finalPayload) {
-    enforceQwenTokenPlanPayloadAfterCaller(
+    enforceQwenPayloadAfterCaller(
       finalPayload,
       tokenPlanContract,
       forceThinking,
@@ -224,9 +256,9 @@ function finalizeQwenTokenPlanPayloadAfterCaller(
   return value;
 }
 
-function createQwenTokenPlanConstraintWrapper(
+function createQwenConstraintWrapper(
   baseStreamFn: StreamFn | undefined,
-  tokenPlanContract: QwenTokenPlanThinkingContract | undefined,
+  tokenPlanContract: QwenThinkingContract | undefined,
   forceThinking: boolean,
   thinkingLevel: QwenThinkingLevel,
 ): StreamFn {
@@ -246,7 +278,7 @@ function createQwenTokenPlanConstraintWrapper(
         const result = originalOnPayload?.(payload, payloadModel);
         if (result && typeof (result as Promise<unknown>).then === "function") {
           return Promise.resolve(result).then((resolved) =>
-            finalizeQwenTokenPlanPayloadAfterCaller(
+            finalizeQwenPayloadAfterCaller(
               resolved,
               payloadObj,
               tokenPlanContract,
@@ -256,7 +288,7 @@ function createQwenTokenPlanConstraintWrapper(
             ),
           );
         }
-        return finalizeQwenTokenPlanPayloadAfterCaller(
+        return finalizeQwenPayloadAfterCaller(
           result,
           payloadObj,
           tokenPlanContract,
@@ -312,7 +344,7 @@ export function createQwenThinkingWrapper(
   thinkingLevel: QwenThinkingLevel,
   thinkingFormat?: QwenThinkingFormat,
   forceThinking = false,
-  tokenPlanContract?: QwenTokenPlanThinkingContract,
+  tokenPlanContract?: QwenThinkingContract,
 ): StreamFn {
   return createPayloadPatchStreamWrapper(
     baseStreamFn,
@@ -328,7 +360,9 @@ export function createQwenThinkingWrapper(
       } else {
         payloadObj.enable_thinking = enableThinking;
       }
-      if (tokenPlanContract?.family === "deepseek-v4") {
+      if (isQwen38ModelId(model.id) && effectiveThinkingFormat === undefined) {
+        patchQwen38Payload(payloadObj, effectiveThinkingLevel, enableThinking);
+      } else if (tokenPlanContract?.family === "deepseek-v4") {
         // DashScope's OpenAI endpoint uses enable_thinking, while DeepSeek V4
         // also requires replay reasoning_content and high/max effort mapping.
         patchTokenPlanDeepSeekV4Payload(payloadObj, effectiveThinkingLevel, enableThinking);
@@ -370,13 +404,15 @@ export function wrapQwenProviderStream(ctx: ProviderWrapStreamFnContext): Stream
   }
   const tokenPlanContract = explicitLegacyThinkingFormat
     ? undefined
-    : resolveQwenTokenPlanThinkingContract(ctx.provider, ctx.modelId);
+    : resolveQwenThinkingContract(ctx.provider, ctx.modelId);
   const tokenPlanProvider = isQwenTokenPlanProviderId(ctx.provider);
   // The picker catalog is intentionally curated; direct Token Plan refs still
   // need provider constraints unless an explicit transport format owns them.
-  const useTokenPlanConstraints =
-    tokenPlanProvider && !explicitLegacyThinkingFormat && thinkingFormat === undefined;
-  const forceThinking = useTokenPlanConstraints && isQwenTokenPlanThinkingOnlyModelId(ctx.modelId);
+  const useWireConstraints =
+    (tokenPlanProvider || tokenPlanContract?.family === "qwen-3.8") &&
+    !explicitLegacyThinkingFormat &&
+    thinkingFormat === undefined;
+  const forceThinking = useWireConstraints && isQwenTokenPlanThinkingOnlyModelId(ctx.modelId);
   let streamFn = createQwenThinkingWrapper(
     ctx.streamFn,
     ctx.thinkingLevel,
@@ -384,10 +420,10 @@ export function wrapQwenProviderStream(ctx: ProviderWrapStreamFnContext): Stream
     forceThinking,
     tokenPlanContract,
   );
-  if (useTokenPlanConstraints) {
+  if (useWireConstraints) {
     // Config and request extra_body hooks run outside plugin wrappers. Reapply
     // model wire constraints after those hooks so invalid fields cannot escape.
-    streamFn = createQwenTokenPlanConstraintWrapper(
+    streamFn = createQwenConstraintWrapper(
       streamFn,
       tokenPlanContract,
       forceThinking,

--- a/extensions/synthetic/index.ts
+++ b/extensions/synthetic/index.ts
@@ -2,7 +2,7 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applySyntheticConfig, SYNTHETIC_DEFAULT_MODEL_REF } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
-import { buildSyntheticProvider } from "./provider-catalog.js";
+import { buildSyntheticProvider, SYNTHETIC_MODEL_DISCOVERY } from "./provider-catalog.js";
 
 const PROVIDER_ID = "synthetic";
 
@@ -20,6 +20,9 @@ export default defineSingleProviderPluginEntry({
     },
     catalog: {
       buildProvider: buildSyntheticProvider,
+      buildStaticProvider: buildSyntheticProvider,
+      allowExplicitBaseUrl: true,
+      liveModelDiscovery: SYNTHETIC_MODEL_DISCOVERY,
     },
   },
 });

--- a/extensions/synthetic/openclaw.plugin.json
+++ b/extensions/synthetic/openclaw.plugin.json
@@ -5,6 +5,11 @@
   },
   "enabledByDefault": true,
   "providers": ["synthetic"],
+  "modelCatalog": {
+    "discovery": {
+      "synthetic": "refreshable"
+    }
+  },
   "setup": {
     "providers": [
       {

--- a/extensions/synthetic/provider-catalog.test.ts
+++ b/extensions/synthetic/provider-catalog.test.ts
@@ -1,0 +1,162 @@
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import plugin from "./index.js";
+import { SYNTHETIC_BASE_URL } from "./models.js";
+import { buildSyntheticProvider } from "./provider-catalog.js";
+
+const fetchGuard = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  fetchWithSsrFGuard: fetchGuard,
+  ssrfPolicyFromHttpBaseUrlAllowedHostname: (baseUrl: string) => ({
+    allowedHostnames: [new URL(baseUrl).hostname],
+  }),
+}));
+
+const endpoint = "https://api.synthetic.new/openai/v1/models";
+const liveModel = {
+  id: "hf:Qwen/Qwen3.8-27B",
+  name: "Qwen/Qwen3.8-27B",
+  input_modalities: ["text", "image"],
+  output_modalities: ["text"],
+  context_length: 262144,
+  max_output_length: 65536,
+  supported_features: ["tools", "reasoning"],
+  reasoning_parameters: { efforts: ["low", "medium", "xhigh"] },
+  pricing: {
+    prompt: "$0.00000045",
+    completion: "$0.0000022",
+    input_cache_reads: "$0.00000009",
+    input_cache_writes: "0",
+  },
+};
+
+function context(config: ProviderCatalogContext["config"] = {}): ProviderCatalogContext {
+  return {
+    config,
+    env: {},
+    resolveProviderApiKey: () => ({
+      apiKey: "SYNTHETIC_API_KEY",
+      discoveryApiKey: "fixture-discovery-key",
+    }),
+    resolveProviderAuth: () => ({
+      apiKey: "SYNTHETIC_API_KEY",
+      discoveryApiKey: "fixture-discovery-key",
+      mode: "api_key",
+      source: "profile",
+    }),
+  };
+}
+
+function respond(data: unknown[]) {
+  fetchGuard.mockResolvedValueOnce({
+    response: Response.json({ data }),
+    finalUrl: endpoint,
+    release: vi.fn(),
+  });
+}
+
+afterEach(() => {
+  fetchGuard.mockReset();
+  clearLiveCatalogCacheForTests();
+});
+
+describe("Synthetic live catalog", () => {
+  it("discovers new models and refreshes known metadata without changing the inference transport", async () => {
+    respond([
+      liveModel,
+      { ...liveModel, id: "hf:moonshotai/Kimi-K3", context_length: 524288 },
+      { ...liveModel, id: "hf:zai-org/GLM-5.2", input_modalities: ["text"] },
+      {
+        ...liveModel,
+        id: "syn:small:vision",
+        max_output_length: undefined,
+        supported_features: undefined,
+        reasoning_parameters: { efforts: ["none"] },
+      },
+      liveModel,
+      { ...liveModel, id: "embedding-model", output_modalities: ["embedding"] },
+      { ...liveModel, id: "invalid-limits", context_length: -1 },
+      { ...liveModel, id: "retired-model", deprecated: true },
+    ]);
+    const provider = await registerSingleProviderPlugin(plugin);
+    const result = await provider.catalog?.run(context());
+    if (!result || !("provider" in result)) {
+      throw new Error("expected Synthetic catalog");
+    }
+    expect(result.provider).toMatchObject({
+      api: "anthropic-messages",
+      baseUrl: SYNTHETIC_BASE_URL,
+      apiKey: "SYNTHETIC_API_KEY",
+    });
+    expect(result.provider.models.map((model) => model.id).toSorted()).toEqual(
+      [liveModel.id, "hf:moonshotai/Kimi-K3", "hf:zai-org/GLM-5.2", "syn:small:vision"].toSorted(),
+    );
+    expect(result.provider.models.find((model) => model.id === liveModel.id)).toMatchObject({
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 262144,
+      maxTokens: 65536,
+      cost: { input: 0.45, output: 2.2, cacheRead: 0.09, cacheWrite: 0 },
+      compat: { supportsTools: true },
+    });
+    expect(result.provider.models.find((model) => model.id === "hf:zai-org/GLM-5.2")).toMatchObject(
+      {
+        input: ["text"],
+        contextWindow: 262144,
+        maxTokens: 65536,
+      },
+    );
+    expect(result.provider.models.find((model) => model.id === "syn:small:vision")).toMatchObject({
+      reasoning: false,
+      input: ["text", "image"],
+      maxTokens: 8192,
+    });
+    const request = fetchGuard.mock.calls[0]?.[0];
+    expect(request.url).toBe(endpoint);
+    expect(new Headers(request.init.headers).get("authorization")).toBe(
+      "Bearer fixture-discovery-key",
+    );
+  });
+
+  it.each(["failure", "empty", "unusable"])("keeps offline seeds on %s discovery", async (mode) => {
+    if (mode === "failure") {
+      fetchGuard.mockRejectedValueOnce(new Error("fixture unavailable"));
+    } else {
+      respond(mode === "empty" ? [] : [{ id: "missing-metadata" }]);
+    }
+    const provider = await registerSingleProviderPlugin(plugin);
+    await expect(provider.catalog?.run(context())).resolves.toEqual({
+      provider: { ...buildSyntheticProvider(), apiKey: "SYNTHETIC_API_KEY" },
+    });
+  });
+
+  it("does not send a custom proxy credential to Synthetic's fixed model endpoint", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const result = await provider.catalog?.run(
+      context({
+        models: {
+          providers: {
+            synthetic: { baseUrl: "https://proxy.example/anthropic", models: [] },
+          },
+        },
+      }),
+    );
+    expect(result).toMatchObject({
+      provider: { baseUrl: "https://proxy.example/anthropic", api: "anthropic-messages" },
+    });
+    expect(fetchGuard).not.toHaveBeenCalled();
+  });
+
+  it("keeps static discovery network-free and live discovery credential-gated", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    await expect(provider.staticCatalog?.run(context())).resolves.toEqual({
+      provider: buildSyntheticProvider(),
+    });
+    await expect(
+      provider.catalog?.run({ ...context(), resolveProviderApiKey: () => ({ apiKey: undefined }) }),
+    ).resolves.toBeNull();
+    expect(fetchGuard).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/synthetic/provider-catalog.ts
+++ b/extensions/synthetic/provider-catalog.ts
@@ -1,5 +1,15 @@
 // Synthetic provider module implements model/runtime integration.
-import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import type { OpenAICompatibleModelDiscoveryOptions } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  asOptionalRecord,
+  asPositiveSafeInteger,
+  filterStringEntries,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   buildSyntheticModelDefinition,
   SYNTHETIC_BASE_URL,
@@ -13,3 +23,74 @@ export function buildSyntheticProvider(): ModelProviderConfig {
     models: SYNTHETIC_MODEL_CATALOG.map(buildSyntheticModelDefinition),
   };
 }
+
+function readTokenPrice(value: unknown): number | undefined {
+  const raw = normalizeOptionalString(value)?.replace(/^\$/, "");
+  const price = raw ? Number(raw) * 1_000_000 : Number.NaN;
+  return Number.isFinite(price) && price >= 0 ? Number(price.toFixed(9)) : undefined;
+}
+
+function projectSyntheticModels(
+  rows: readonly unknown[],
+  fallback: ModelProviderConfig,
+): ModelDefinitionConfig[] {
+  const seeds = new Map(fallback.models.map((model) => [model.id, model]));
+  const models = new Map<string, ModelDefinitionConfig>();
+  for (const row of rows) {
+    const record = asOptionalRecord(row);
+    const id = normalizeOptionalString(record?.id);
+    const contextWindow = asPositiveSafeInteger(record?.context_length);
+    const input = filterStringEntries(record?.input_modalities);
+    if (
+      !record ||
+      !id ||
+      id.length > 512 ||
+      /[\s\p{Cc}]/u.test(id) ||
+      !contextWindow ||
+      !input.includes("text") ||
+      !filterStringEntries(record.output_modalities).includes("text") ||
+      record.deprecated === true ||
+      record.active === false
+    ) {
+      continue;
+    }
+    const seed = seeds.get(id);
+    const features = filterStringEntries(record.supported_features);
+    const efforts = filterStringEntries(asOptionalRecord(record.reasoning_parameters)?.efforts);
+    const pricing = asOptionalRecord(record.pricing);
+    // The live feed owns current limits and capabilities even for seeded IDs.
+    // ProxiedModelDetails may omit output limits and supported_features.
+    models.set(id, {
+      ...seed,
+      id,
+      name: normalizeOptionalString(record.name) ?? id,
+      reasoning: features.includes("reasoning") || efforts.some((effort) => effort !== "none"),
+      input: input.includes("image") ? ["text", "image"] : ["text"],
+      contextWindow,
+      maxTokens: Math.min(
+        asPositiveSafeInteger(record.max_output_length) ?? seed?.maxTokens ?? 8192,
+        contextWindow,
+      ),
+      cost: {
+        input: readTokenPrice(pricing?.prompt) ?? seed?.cost.input ?? 0,
+        output: readTokenPrice(pricing?.completion) ?? seed?.cost.output ?? 0,
+        cacheRead: readTokenPrice(pricing?.input_cache_reads) ?? seed?.cost.cacheRead ?? 0,
+        cacheWrite: readTokenPrice(pricing?.input_cache_writes) ?? seed?.cost.cacheWrite ?? 0,
+      },
+      ...(Array.isArray(record.supported_features)
+        ? { compat: { ...seed?.compat, supportsTools: features.includes("tools") } }
+        : {}),
+    });
+  }
+  return [...models.values()].toSorted((a, b) => a.id.localeCompare(b.id));
+}
+
+export const SYNTHETIC_MODEL_DISCOVERY: OpenAICompatibleModelDiscoveryOptions = {
+  // Discovery is OpenAI-compatible; inference stays on the Anthropic endpoint.
+  // A custom proxy's credential must never be forwarded to this vendor URL.
+  endpointUrl: {
+    url: "https://api.synthetic.new/openai/v1/models",
+    requireBaseUrl: SYNTHETIC_BASE_URL,
+  },
+  projectRows: projectSyntheticModels,
+};

--- a/extensions/synthetic/synthetic.live.test.ts
+++ b/extensions/synthetic/synthetic.live.test.ts
@@ -1,0 +1,26 @@
+import { buildOpenAICompatibleLiveModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-live";
+import { describe, expect, it } from "vitest";
+import { buildSyntheticProvider, SYNTHETIC_MODEL_DISCOVERY } from "./provider-catalog.js";
+
+const describeLive = isLiveTestEnabled() ? describe : describe.skip;
+
+describeLive("Synthetic public catalog live", () => {
+  it("discovers current small models with native capabilities and pricing", async () => {
+    const provider = await buildOpenAICompatibleLiveModelProviderConfig({
+      providerId: "synthetic",
+      providerConfig: buildSyntheticProvider(),
+      modelDiscovery: SYNTHETIC_MODEL_DISCOVERY,
+    });
+    expect(provider.api).toBe("anthropic-messages");
+    expect(provider.models.find((model) => model.id === "hf:Qwen/Qwen3.8-27B")).toMatchObject({
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 262_144,
+      maxTokens: 65_536,
+      compat: { supportsTools: true },
+      cost: { input: 0.45, output: 2.2, cacheRead: 0.09 },
+    });
+    expect(provider.models.some((model) => model.id.startsWith("syn:"))).toBe(true);
+  });
+});

--- a/src/flows/doctor-core-checks.runtime.bundled.test.ts
+++ b/src/flows/doctor-core-checks.runtime.bundled.test.ts
@@ -1,7 +1,9 @@
-// Doctor bundled provider tests ensure every shipped manifest catalog projects into runtime rows.
+// Validate authored catalog rows and complete static provider configurations.
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { normalizeModelCatalog } from "@openclaw/model-catalog-core/model-catalog-normalize";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { describe, expect, it } from "vitest";
 import { buildManifestModelProviderConfig } from "../plugin-sdk/provider-catalog-shared.js";
 
@@ -9,7 +11,7 @@ const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
 const extensionsDir = path.join(repoRoot, "extensions");
 
 describe("doctor bundled provider catalog validation", () => {
-  it("accepts every bundled manifest provider catalog", () => {
+  it("normalizes every catalog without dropping rows and validates static providers", () => {
     const errors: string[] = [];
 
     for (const extension of fs.readdirSync(extensionsDir, { withFileTypes: true })) {
@@ -25,12 +27,25 @@ describe("doctor bundled provider catalog validation", () => {
         providers?: string[];
         modelCatalog?: { providers?: Record<string, unknown> };
       };
+      const normalized = normalizeModelCatalog(manifest.modelCatalog, {
+        ownedProviders: new Set(manifest.providers),
+      });
       for (const [providerId, catalog] of Object.entries(manifest.modelCatalog?.providers ?? {})) {
         if (!manifest.providers?.includes(providerId)) {
           continue;
         }
         try {
-          buildManifestModelProviderConfig({ providerId, catalog });
+          const rawModels = asOptionalRecord(catalog)?.models;
+          const models = normalized?.providers?.[providerId]?.models;
+          if (!Array.isArray(rawModels) || models?.length !== rawModels.length) {
+            throw new Error("Manifest catalog normalization dropped a provider or model row");
+          }
+          // Runtime catalogs supply their own endpoints; only static catalogs
+          // are converted directly into provider configurations by discovery.
+          const discovery = normalized?.discovery?.[providerId];
+          if (discovery !== "runtime" && discovery !== "refreshable") {
+            buildManifestModelProviderConfig({ providerId, catalog });
+          }
         } catch (error) {
           errors.push(`${manifest.id ?? extension.name}/${providerId}: ${String(error)}`);
         }

--- a/src/plugins/manifest-model-suppression.test.ts
+++ b/src/plugins/manifest-model-suppression.test.ts
@@ -1,10 +1,10 @@
 // Verifies manifest-driven model suppression behavior.
+import fs from "node:fs";
 import {
   normalizeModelCatalog,
   normalizeModelCatalogProviderRows,
 } from "@openclaw/model-catalog-core/model-catalog-normalize";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import qwenManifest from "../../extensions/qwen/openclaw.plugin.json" with { type: "json" };
 
 const mocks = vi.hoisted(() => ({
   loadPluginMetadataSnapshot: vi.fn(),
@@ -288,8 +288,17 @@ describe("manifest model suppression", () => {
         ["https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1", false],
         ["https://proxy.example/v1", false],
       ] as const)("matches the plan at %s", (baseUrl, suppressed) => {
+        // Public metadata is fixture data; core's type graph must not compile plugin files.
+        const qwenManifest: Record<string, unknown> = JSON.parse(
+          fs.readFileSync(
+            new URL("../../extensions/qwen/openclaw.plugin.json", import.meta.url),
+            "utf8",
+          ),
+        );
         mocks.loadPluginMetadataSnapshot.mockReturnValue(createMetadataSnapshot([qwenManifest]));
-        const providerCatalog = normalizeModelCatalog(qwenManifest.modelCatalog)?.providers?.qwen;
+        const providerCatalog = normalizeModelCatalog(qwenManifest.modelCatalog, {
+          ownedProviders: new Set(["qwen"]),
+        })?.providers?.qwen;
         if (!providerCatalog) {
           throw new Error("Qwen manifest catalog is missing");
         }

--- a/src/plugins/manifest-model-suppression.test.ts
+++ b/src/plugins/manifest-model-suppression.test.ts
@@ -1,5 +1,10 @@
 // Verifies manifest-driven model suppression behavior.
+import {
+  normalizeModelCatalog,
+  normalizeModelCatalogProviderRows,
+} from "@openclaw/model-catalog-core/model-catalog-normalize";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import qwenManifest from "../../extensions/qwen/openclaw.plugin.json" with { type: "json" };
 
 const mocks = vi.hoisted(() => ({
   loadPluginMetadataSnapshot: vi.fn(),
@@ -270,5 +275,47 @@ describe("manifest model suppression", () => {
         id: "qwen3.6-plus",
       }),
     ).toBeUndefined();
+  });
+
+  describe.each(["qwen", "modelstudio"])("%s plan availability", (provider) => {
+    describe.each(["openai-completions", undefined] as const)("api=%s", (api) => {
+      it.each([
+        ["https://coding.dashscope.aliyuncs.com/v1", true],
+        ["https://coding-intl.dashscope.aliyuncs.com/v1", true],
+        ["https://dashscope.aliyuncs.com/compatible-mode/v1", false],
+        ["https://dashscope-intl.aliyuncs.com/compatible-mode/v1", false],
+        ["https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1", false],
+        ["https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1", false],
+        ["https://proxy.example/v1", false],
+      ] as const)("matches the plan at %s", (baseUrl, suppressed) => {
+        mocks.loadPluginMetadataSnapshot.mockReturnValue(createMetadataSnapshot([qwenManifest]));
+        const providerCatalog = normalizeModelCatalog(qwenManifest.modelCatalog)?.providers?.qwen;
+        if (!providerCatalog) {
+          throw new Error("Qwen manifest catalog is missing");
+        }
+        const rows = normalizeModelCatalogProviderRows({
+          provider,
+          providerCatalog,
+          source: "manifest",
+        });
+        const resolver = buildManifestBuiltInModelSuppressionResolver({
+          config: {
+            models: {
+              providers: { [provider]: { baseUrl, ...(api ? { api } : {}), models: [] } },
+            },
+          },
+          env: process.env,
+        });
+
+        for (const id of ["qwen3.6-flash", "qwen3.7-max", "qwen3.8-max", "qwen3.8-flash"]) {
+          const row = rows.find((entry) => entry.id === id);
+          expect(row, id).toBeDefined();
+          expect(Boolean(resolver({ provider, id, baseUrl: row?.baseUrl })?.suppress), id).toBe(
+            suppressed,
+          );
+        }
+        expect(resolver({ provider, id: "qwen3.7-plus" })).toBeUndefined();
+      });
+    });
   });
 });

--- a/test/scripts/publish-model-catalog.test.ts
+++ b/test/scripts/publish-model-catalog.test.ts
@@ -123,7 +123,7 @@ describe("publish model catalog", () => {
       { cwd: root, encoding: "utf8" },
     );
     expect(result.status, result.stderr).toBe(0);
-    const stats = /dry-run schemaVersion=1 providers=40 models=(\d+)/u.exec(result.stdout);
+    const stats = /dry-run schemaVersion=1 providers=[1-9]\d* models=(\d+)/u.exec(result.stdout);
     expect(stats).not.toBeNull();
     expect(Number(stats?.[1])).toBeGreaterThanOrEqual(MODEL_CATALOG_MIN_MODELS);
     expect(fs.existsSync(out)).toBe(false);

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -85,70 +85,61 @@ describe("scripts/test-live-shard", () => {
     );
   });
 
-  it("keeps slow gateway backend and media-capable extension files in their own shards", () => {
-    expect(selectLiveShardFiles("native-live-src-agents", allFiles)).toContain(
-      "src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts",
+  it("routes fixture files across alphabet boundaries and dedicated slow shards", () => {
+    const expectedByShard = {
+      "native-live-src-agents": [
+        "src/agents/zai.live.test.ts",
+        "src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.live.test.ts",
+        "src/skills/workshop/experience-review.live.test.ts",
+      ],
+      "native-live-src-agents-zai-coding": ["src/agents/zai.live.test.ts"],
+      "native-live-src-gateway-backends": [
+        "src/gateway/gateway-acp-bind.live.test.ts",
+        "src/gateway/gateway-cli-backend.live.test.ts",
+        "src/gateway/gateway-codex-bind.live.test.ts",
+        "src/gateway/gateway-codex-harness.live.test.ts",
+      ],
+      "native-live-src-gateway-profiles": [
+        "src/gateway/gateway-models.profiles.live.test.ts",
+        "src/gateway/gateway-openai-long-context.live.test.ts",
+      ],
+      "native-live-src-gateway-core": [
+        "src/gateway/fixture.live.test.ts",
+        "src/system-agent/fixture.live.test.ts",
+      ],
+      "native-live-src-infra": ["src/infra/fixture.live.test.ts"],
+      "native-live-test": ["test/fixture.live.test.ts"],
+      "native-live-extensions-a-k": [
+        "extensions/a-provider/model.live.test.ts",
+        "extensions/k-provider/model.live.test.ts",
+      ],
+      "native-live-extensions-l-n": [
+        "extensions/l-provider/model.live.test.ts",
+        "extensions/n-provider/model.live.test.ts",
+      ],
+      "native-live-extensions-moonshot": ["extensions/moonshot/moonshot.live.test.ts"],
+      "native-live-extensions-openai": ["extensions/openai/openai.live.test.ts"],
+      "native-live-extensions-o-z-other": [
+        "extensions/o-provider/model.live.test.ts",
+        "extensions/z-provider/model.live.test.ts",
+      ],
+      "native-live-extensions-xai": ["extensions/xai/xai.live.test.ts"],
+      "native-live-extensions-media": [
+        "extensions/minimax/minimax.live.test.ts",
+        "extensions/music-generation-providers.live.test.ts",
+        "extensions/openai/openai-tts.live.test.ts",
+        "extensions/video-generation-providers.live.test.ts",
+        "extensions/volcengine/tts.live.test.ts",
+        "extensions/vydra/vydra.live.test.ts",
+      ],
+    };
+    const files = [...new Set(Object.values(expectedByShard).flat())].toSorted((a, b) =>
+      a.localeCompare(b),
     );
-    expect(selectLiveShardFiles("native-live-src-agents", allFiles)).toContain(
-      "src/skills/workshop/experience-review.live.test.ts",
-    );
-    expect(selectLiveShardFiles("native-live-src-agents", allFiles)).toContain(
-      "src/agents/zai.live.test.ts",
-    );
-    expect(selectLiveShardFiles("native-live-src-agents-zai-coding", allFiles)).toEqual([
-      "src/agents/zai.live.test.ts",
-    ]);
-    expect(selectLiveShardFiles("native-live-src-gateway-backends", allFiles)).toEqual([
-      "src/gateway/gateway-acp-bind.live.test.ts",
-      "src/gateway/gateway-cli-backend.live.test.ts",
-      "src/gateway/gateway-codex-bind.live.test.ts",
-      "src/gateway/gateway-codex-harness.live.test.ts",
-    ]);
-    expect(selectLiveShardFiles("native-live-src-gateway-profiles", allFiles)).toEqual([
-      "src/gateway/gateway-models.profiles.live.test.ts",
-      "src/gateway/gateway-openai-long-context.live.test.ts",
-    ]);
-    expect(selectLiveShardFiles("native-live-src-gateway-core", allFiles)).toEqual([
-      "src/gateway/android-node.capabilities.live.test.ts",
-      "src/gateway/gateway-acp-spawn-defaults.live.test.ts",
-      "src/gateway/gateway-trajectory-export.live.test.ts",
-      "src/system-agent/rescue-channel.live.test.ts",
-      "src/system-agent/setup-app-recommendations.live.test.ts",
-    ]);
-    expect(selectLiveShardFiles("native-live-src-infra", allFiles)).toEqual([
-      "src/infra/push-apns-http2.live.test.ts",
-    ]);
-    expect(selectLiveShardFiles("native-live-test", allFiles)).toEqual([
-      "test/e2e/qa-lab/runtime/gateway-node-mcp.live.test.ts",
-      "test/image-generation.infer-cli.live.test.ts",
-      "test/image-generation.runtime.live.test.ts",
-      "test/openai-onboarding.live.test.ts",
-    ]);
-    expect(selectLiveShardFiles("native-live-extensions-media", allFiles)).toEqual([
-      "extensions/minimax/minimax.live.test.ts",
-      "extensions/music-generation-providers.live.test.ts",
-      "extensions/openai/openai-tts.live.test.ts",
-      "extensions/video-generation-providers.live.test.ts",
-      "extensions/volcengine/tts.live.test.ts",
-      "extensions/vydra/vydra.live.test.ts",
-    ]);
-    expect(selectLiveShardFiles("native-live-extensions-openai", allFiles)).toEqual([
-      "extensions/openai/openai-provider.live.test.ts",
-      "extensions/openai/openai.live.test.ts",
-      "extensions/openai/realtime-quicksilver-gateway-bridge.live.test.ts",
-      "extensions/openai/realtime-quicksilver.live.test.ts",
-      "extensions/openai/realtime-voice-provider.live.test.ts",
-    ]);
-    expect(selectLiveShardFiles("native-live-extensions-l-n", allFiles)).toEqual([
-      "extensions/llama-cpp/src/external-server/llama-server.live.test.ts",
-      "extensions/memory-lancedb/memory-lancedb.live.test.ts",
-      "extensions/meta/meta.live.test.ts",
-      "extensions/microsoft/microsoft.live.test.ts",
-      "extensions/mistral/mistral.live.test.ts",
-    ]);
-    expect(selectLiveShardFiles("native-live-extensions-moonshot", allFiles)).toEqual([
-      "extensions/moonshot/moonshot.live.test.ts",
-    ]);
+
+    for (const [shard, expectedFiles] of Object.entries(expectedByShard)) {
+      expect(selectLiveShardFiles(shard, files), shard).toEqual(expectedFiles);
+    }
   });
 
   it("keeps the Codex CLI backend live smoke on a minimal tool profile", () => {


### PR DESCRIPTION
Related: #113577 and #113578 (Qwen Token Plan catalog freshness; this change does not close their remaining video-input and older-model limit work).

Thanks to @oliver-mee for the earlier Qwen 3.8 Max Token Plan work in #113578. This maintainer refresh carries that model-support outcome forward using the current Qwen contract, alongside the other requested providers.

## What Problem This Solves

Users selecting newly available models can miss Qwen 3.8 Max/Flash, DeepSeek V4 Flash Vision, and NVIDIA Nemotron 3.5 Lightning. Static provider lists also age independently of the actual endpoints: NVIDIA's featured feed still advertises IDs absent from its inference inventory, while Synthetic's richer live catalog already describes newer small models and aliases.

## Why This Change Was Made

Keep model ownership in the provider plugins and reuse the existing live-discovery SDK. Add the public model IDs and their verified metadata, make Qwen's manifest the canonical seed catalog, and extend its existing thinking/replay wrapper for the Qwen 3.8 contract. DeepSeek's existing V4 behavior now includes its experimental vision model.

Synthetic now projects its native model metadata from the OpenAI-compatible discovery endpoint while retaining Anthropic inference. NVIDIA intersects known chat metadata and featured ranking with the actual inference inventory; unknown mixed-task IDs are not guessed to be chat models. Existing defaults and custom inference endpoints are unchanged. No new config options, dependencies, core provider branches, or persistence changes.

## User Impact

- Qwen Standard and Token Plan expose 3.8 Max/Flash; older Coding Plan excludes them. Thinking supports off/low/medium/xhigh, preserves explicit token budgets, and retains reasoning during tool replay.
- DeepSeek exposes `deepseek-v4-flash-vision-exp` with image input and the existing V4 thinking/replay behavior.
- NVIDIA exposes Lightning even when it is not featured, and stale featured entries no longer imply availability.
- Synthetic discovers new text-capable models, image/reasoning/tool support, token limits, aliases, and current usage-based price metadata without adding a hardcoded row for each small model.
- Qwen's existing discovery already finds 3.8 27B and 2.4T. Ollama and LM Studio remain dynamic; no small-model inventory is added to them.

## Evidence

AI-assisted implementation and independent Codex review. Provider-native documentation and live responses were checked on 2026-08-27:

- [Qwen current models](https://docs.qwencloud.com/developer-guides/getting-started/latest-model) and [thinking contract](https://docs.qwencloud.com/developer-guides/text-generation/thinking).
- [DeepSeek vision](https://api-docs.deepseek.com/guides/vision) and [pricing](https://api-docs.deepseek.com/quick_start/pricing/).
- [NVIDIA Lightning hosted model](https://build.nvidia.com/nvidia/nemotron-3.5-lightning-30b-a3b/build).
- [Synthetic discovery API](https://dev.synthetic.new/docs/openai/models).

Validation completed against the task diff:

```text
node scripts/run-vitest.mjs extensions/deepseek extensions/qwen extensions/nvidia extensions/synthetic
218 tests passed across 14 files.

Qwen and shared provider-catalog sibling coverage: 172 tests passed.
Final DeepSeek/Qwen payload regression rerun: 105 tests passed.

OPENCLAW_LIVE_TEST=1 node scripts/run-vitest.mjs --config test/vitest/vitest.live.config.ts extensions/qwen/qwen.live.test.ts extensions/deepseek/deepseek.live.test.ts extensions/nvidia/nvidia.live.test.ts extensions/synthetic/synthetic.live.test.ts
10 live tests passed twice with isolated HOME/config/state.

node --import ./scripts/tsx.mjs scripts/build-all.mts
Full build passed.

node scripts/check-changed.mjs
Passed: formatting, production/test types, lint, boundary/dead-export guards, and runtime import-cycle checks.
```

Live inference proof is Qwen Standard Max/Flash (generated-image recognition and tool round-trips with reasoning) and DeepSeek Vision (text, image, and thinking replay). NVIDIA and Synthetic tests exercise their real public catalog APIs, not inference. Before-fix regressions failed for Synthetic metadata projection, NVIDIA authoritative inventory, and DeepSeek vision routing, then passed after repair.

Built CLI proof in clean isolated state lists DeepSeek Vision and NVIDIA Lightning. With the Standard Qwen credential and locally loaded external plugin, `models list --all --provider qwen --json` returns 144 models including Max, Flash, 27B, and 2.4T. The credential-free Qwen probe correctly has no authenticated runtime catalog; it is not a plugin activation failure.

### Known proof limitations and follow-ups

- NVIDIA native inference could not be verified: available credentials returned authorization/authentication errors (403/401). No credential, access-control, or retry workaround was added. Public inventory discovery succeeded.
- Synthetic native inference could not be verified because no approved credential was available. Public catalog discovery succeeded. Its selected default remains unchanged; the current public feed omits two older seeded IDs, so an authenticated entitlement/default audit remains follow-up work.
- Token Plan subscription inference was not run with a dedicated subscription key. Standard inference does not establish Token Plan entitlement; the separate plan rows follow the vendor's published plan catalog.
- Lightning's 16,384-token output budget follows NVIDIA's hosted example, not a claim that this is the provider's absolute maximum.
- Cerebras intentionally remains static: #117584 restored that behavior because its inventory omitted a documented model. Kimi Coding's authenticated `/models` metadata is a future dynamic-discovery candidate. Existing DeepSeek Flash/Pro price estimates and the remaining #113577 catalog corrections are separate follow-ups.

### CI integration follow-up

The first hosted run exposed three integration omissions, repaired in this PR: Qwen Max now explicitly declares the existing `capable` code-mode tier shared with OpenCode; the catalog CLI smoke no longer hardcodes today's provider count; and the live-shard routing test uses controlled fixtures instead of duplicating today's full file inventory. The real-repository completeness and intentional-fanout checks remain unchanged. The test cleanup removes nine net lines.

The focused follow-up rerun passed 268 tests across Qwen, shared-model contracts, code-mode defaults, catalog publishing, and live-shard routing. A fresh independent Codex review found no actionable P0 findings. The code-mode declaration preserves the existing implicit default and does not change provider payloads or enable code mode automatically.

The final default-list audit caught a manifest-only Coding Plan regression before landing: plain `models list --json` intentionally avoids provider runtime discovery, and the old suppression condition accepted provider names instead of the canonical `openai-completions` transport (or omitted API). Removing that condition leaves plan availability owned by the Qwen endpoint hosts. The shared seed catalog also must not attach a Coding endpoint to Standard models: its endpoint now remains unspecified until runtime configuration selects the actual plan. The CLI reproduced fourteen available Coding rows before repair, including four unsupported entries; afterward, Coding exposes ten supported rows while Standard/custom endpoints retain fourteen, including Max/Flash. China Coding with omitted API was also verified. This is isolated CLI proof using a non-secret auth fixture, not inference. Eight original suppression cases and twenty normalized-row endpoint cases failed before their respective repairs; all 35 cases now pass. No core production logic changed.

The next CI run caught test-boundary issues, now repaired: the regression reads public manifest metadata as data instead of pulling plugin JSON into the core TypeScript graph, and supplies the normalizer's required ownership argument. The all-bundled catalog smoke now validates that every owned catalog and model row survives normalization, then constructs physical provider configurations only for static/default discovery, matching the actual discovery implementation. The strict SDK converter and its missing-endpoint/malformed-row tests are unchanged. No placeholder URL, provider exception, or weakened CI guard was added.

Final follow-up proof: 70 Qwen/manifest/boundary tests and 67 catalog/SDK/boundary regression tests passed; the two affected core test typecheck projects, type-graph boundary guard, and targeted lint passed. Fresh independent Codex review of the final test-only patch is clean at P0. Full local build passed again. Hosted CI remains the exact-head landing gate.

Production LOC: +555/-101 (net +454), comprising +161 executable TypeScript and +293 manifest data; tests +1044/-256 (net +788); docs net +64. Growth adds the requested models and two provider-owned discovery projections. Duplicate Qwen TypeScript seed tables, obsolete suppression predicates, and the featured-only NVIDIA availability path are removed; no provider policy moved into core.

Co-authored-by: Oliver Mee <102673257+oliver-mee@users.noreply.github.com>
