### PR TITLE
fix(ui): remove underlines from Settings Learn more links

### DIFF
--- a/ui/src/components/config-form.browser.test.ts
+++ b/ui/src/components/config-form.browser.test.ts
@@ -866,6 +866,7 @@ describe("config form renderer", () => {
       "section guide link",
     );
     expect(link.textContent?.trim()).toBe("Learn more");
+    expect(link.classList.contains("learn-more-link")).toBe(true);
     const popover = expectElement(link.closest("wa-popover"), "section help popover");
     expect(button.getAttribute("aria-controls")).toBe(popover.id);
     expect(link.getAttribute("href")).toBe("https://docs.openclaw.ai/gateway/configuration");

--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -2,7 +2,6 @@
 import { html, nothing, type TemplateResult } from "lit";
 import type { ConfigUiHints } from "../api/types.ts";
 import { t } from "../i18n/index.ts";
-import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
 import "./web-awesome-popover.ts";
 import { SECTION_META } from "./config-form.meta.ts";
 import { renderNode } from "./config-form.node.ts";
@@ -10,6 +9,7 @@ import { matchesConfigSectionSearch, parseConfigSearchQuery } from "./config-for
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 import { splitConfigSchemaByTier } from "./config-form.tiers.ts";
 import {
+  renderLearnMoreLink,
   renderSettingsEmpty,
   renderSettingsHelpTrigger,
   renderSettingsPage,
@@ -276,12 +276,7 @@ export function renderConfigForm(props: ConfigFormProps) {
                         >
                           <div class="settings-section__help-panel">
                             ${params.description ? html`<p>${params.description}</p>` : nothing}
-                            <a
-                              href=${docsUrl}
-                              target=${EXTERNAL_LINK_TARGET}
-                              rel=${buildExternalLinkRel()}
-                              >${t("common.learnMore")}</a
-                            >
+                            ${renderLearnMoreLink(docsUrl)}
                           </div>
                         </wa-popover>
                       </span>

--- a/ui/src/components/mcp-servers-card.test.ts
+++ b/ui/src/components/mcp-servers-card.test.ts
@@ -226,6 +226,7 @@ describe("openclaw-mcp-servers-card", () => {
 
     const sectionLink = card.querySelector<HTMLAnchorElement>(".settings-section__desc a");
     expect(sectionLink?.textContent?.trim()).toBe("Learn more");
+    expect(sectionLink?.classList.contains("learn-more-link")).toBe(true);
     expect(sectionLink?.getAttribute("href")).toBe("/settings/plugins");
     expect(card.querySelector(".settings-empty")?.textContent).toContain(
       "No MCP servers configured.",

--- a/ui/src/components/mcp-servers-card.ts
+++ b/ui/src/components/mcp-servers-card.ts
@@ -23,6 +23,7 @@ import { icons } from "./icons.ts";
 import { renderMcpServerForm, type McpServerForm } from "./mcp-server-form.ts";
 import {
   renderDocsLink,
+  renderLearnMoreLink,
   renderSettingsEmpty,
   renderSettingsSection,
   renderSettingsStatus,
@@ -237,8 +238,7 @@ class McpServersCard extends OpenClawLightDomElement {
           {
             title: t("mcpPage.configuredServers"),
             description: html`
-              ${t("mcpPage.runtimeHint")}
-              <a href=${this.pluginsHref}>${t("common.learnMore")}</a>
+              ${t("mcpPage.runtimeHint")} ${renderLearnMoreLink(this.pluginsHref)}
             `,
             actions: html`
               <button

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -42,6 +42,15 @@ const learnMoreRoutes = [
   "talk",
 ] as const;
 
+const settingsGuidanceLinks: ReadonlyArray<{
+  route: string;
+  container: string;
+  section?: string;
+}> = [
+  { route: "cloud-workers", container: ".page-subtitle" },
+  { route: "mcp", section: "Configured servers", container: ".settings-section__desc" },
+];
+
 const sectionAlignmentRoutes = [
   "appearance",
   "cloud-workers",
@@ -137,6 +146,26 @@ suite.define(() => {
             await link.evaluate((element) => getComputedStyle(element).textDecorationLine),
           ).toBe("none");
         }
+      }
+
+      for (const guidanceLink of settingsGuidanceLinks) {
+        await page.goto(`${suite.server.baseUrl}settings/${guidanceLink.route}`);
+        await waitForControlUiRoute(page, {
+          pathname: `/settings/${guidanceLink.route}`,
+          routeId: guidanceLink.route,
+        });
+        const root = guidanceLink.section
+          ? page.locator(".settings-section").filter({
+              has: page.getByRole("heading", { name: guidanceLink.section, exact: true }),
+            })
+          : page;
+        const link = (guidanceLink.container ? root.locator(guidanceLink.container) : root)
+          .getByRole("link", { name: "Learn more", exact: true })
+          .first();
+        await link.waitFor();
+        expect(await link.evaluate((element) => getComputedStyle(element).textDecorationLine)).toBe(
+          "none",
+        );
       }
 
       for (const viewport of responsiveViewports) {

--- a/ui/src/pages/cloud-workers/cloud-workers-page.ts
+++ b/ui/src/pages/cloud-workers/cloud-workers-page.ts
@@ -7,6 +7,7 @@ import { applicationContext, type ApplicationContext } from "../../app/context.t
 import { showConfirmDialog } from "../../components/confirm-dialog.ts";
 import {
   renderDocsLink,
+  renderLearnMoreLink,
   renderSettingsEmpty,
   renderSettingsPage,
   renderSettingsPageHeader,
@@ -556,8 +557,7 @@ class CloudWorkersPage extends OpenClawLightDomElement {
     return html`
       ${renderSettingsPageHeader({
         title: titleForRoute("cloud-workers"),
-        subtitle: html`${t("cloudWorkersPage.intro")}
-        ${renderDocsLink(CLOUD_WORKERS_DOCS_URL, t("common.learnMore"))}`,
+        subtitle: html`${t("cloudWorkersPage.intro")} ${renderLearnMoreLink(CLOUD_WORKERS_DOCS_URL)}`,
       })}
       ${renderSettingsWorkspace(body)}
     `;


### PR DESCRIPTION
Related: #131222

## What Problem This Solves

Fixes an issue where Settings guidance links labeled “Learn more” were underlined after the wording was standardized, unlike the established Settings link presentation.

## Why This Change Was Made

Routes the three remaining Settings guidance link owners through the existing `renderLearnMoreLink()` primitive. This keeps the established no-underline style in one shared owner while preserving destinations, external-link safety, and non-guidance link styling.

## User Impact

Every “Learn more” link attached to a Settings page title, section description, or section help popover now uses the same accent-only presentation without an underline.

## Evidence

Playwright checked the nine audited Settings guidance surfaces against both builds and verified all nine changed from `text-decoration-line: underline` to `none`.

It also repeated the fixed-state checks at 390, 768, 1366, and 1440 px (36 assertions total), verifying the expected destinations, visible links, and zero horizontal overflow.

### Before

![Before: all nine Settings Learn more links are underlined](https://github.com/user-attachments/assets/2e964714-e88f-41a5-8a83-81d3602e70df)

### After

![After: all nine Settings Learn more links have no underline](https://github.com/user-attachments/assets/d4c4579b-6a23-46a5-a46a-0d59bff79621)

Validation:

- `node scripts/run-vitest.mjs ui/src/components/config-form.browser.test.ts ui/src/components/mcp-servers-card.test.ts` — 38 passed
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/settings-layout.e2e.test.ts` — 1 passed
- `pnpm test:ui` — 797 files passed; 11,630 passed, 1 skipped
- `pnpm ui:build` — passed
