### PR TITLE
fix(release): restore Telegram package validation after plugin consent

### DIFF
--- a/scripts/e2e/npm-telegram-live-docker.sh
+++ b/scripts/e2e/npm-telegram-live-docker.sh
@@ -484,6 +484,7 @@ dump_hotpath_logs() {
   echo "installed-package onboarding recovery hot path failed with exit code $status" >&2
   for file in \
     /tmp/openclaw-npm-telegram-onboard.json \
+    /tmp/openclaw-npm-telegram-codex-install.log \
     /tmp/openclaw-npm-telegram-channel-add.log \
     /tmp/openclaw-npm-telegram-doctor-fix.log \
     /tmp/openclaw-npm-telegram-doctor-check.log \
@@ -564,6 +565,10 @@ if [ "${OPENCLAW_NPM_TELEGRAM_SKIP_HOTPATH:-0}" != "1" ]; then
     hotpath_model_value="$OPENAI_API_KEY"
   fi
   hotpath_channel_value="$(printf '%s:%s' 123456 "$hotpath_placeholder")"
+  # Non-interactive onboarding cannot approve plugin capabilities. This release
+  # harness explicitly accepts the staged Codex artifact before testing setup.
+  openclaw_e2e_run_command "$sut_command" plugins install @openclaw/codex \
+    --accept-capabilities >/tmp/openclaw-npm-telegram-codex-install.log 2>&1 </dev/null
   OPENAI_API_KEY="$hotpath_model_value" openclaw_e2e_run_command "$sut_command" onboard \
     --non-interactive --accept-risk \
     --mode local \

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -106,6 +106,10 @@ describe("package Telegram live Docker E2E", () => {
     expect(runtimeRun).toContain("source scripts/lib/openclaw-e2e-instance.sh");
     expect(runtimeRun).toContain('sut_command="/npm-global/bin/openclaw"');
     expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" --version');
+    expect(runtimeRun).toContain(
+      'openclaw_e2e_run_command "$sut_command" plugins install @openclaw/codex',
+    );
+    expect(runtimeRun).toContain("--accept-capabilities");
     expect(runtimeRun).toContain('openclaw_e2e_run_command "$sut_command" onboard');
     expect(runtimeRun).toContain(
       'OPENAI_API_KEY="$hotpath_model_value" openclaw_e2e_run_command "$sut_command" onboard',
@@ -120,6 +124,9 @@ describe("package Telegram live Docker E2E", () => {
     expect(runtimeRun).toContain('openclaw_e2e_print_log "$file"');
     expect(runtimeRun).not.toContain("sed -n '1,220p'");
     expect(runtimeRun).not.toMatch(/^\s*openclaw (onboard|channels add|doctor )/mu);
+    expect(
+      runtimeRun.indexOf('openclaw_e2e_run_command "$sut_command" plugins install @openclaw/codex'),
+    ).toBeLessThan(runtimeRun.indexOf('openclaw_e2e_run_command "$sut_command" onboard'));
   });
 
   it("isolates onboarding hot-path config from the live suite", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where full release validation stopped before Telegram package acceptance after plugin capability consent became mandatory. The installed-package onboarding recovery probe attempted to acquire the Codex runtime noninteractively, which cannot approve the staged artifact.

## Why This Change Was Made

The release harness now explicitly installs and accepts the staged official Codex plugin before invoking noninteractive OpenAI onboarding. Product runtime behavior remains fail-closed: ordinary noninteractive onboarding still cannot approve plugin capabilities implicitly.

## User Impact

No shipped runtime behavior changes. Full release validation can reach its real Telegram scenarios while continuing to exercise the explicit plugin-consent contract.

## Evidence

Before: full release run 33111246953, job 98655826825 stopped with `Plugin "codex" requires capability consent` before Telegram credential acquisition or scenarios.

- `node scripts/run-vitest.mjs test/scripts/npm-telegram-live.test.ts` — 52 passed
- `bash -n scripts/e2e/npm-telegram-live-docker.sh` — passed
- focused formatting and `git diff --check` — passed

The live package Telegram workflow on this PR is the final external-flow proof.
