### PR TITLE
fix(test): prevent shared build races across parallel projects

### DIFF
--- a/extensions/qa-lab/src/suite-process-lifecycle.test-support.ts
+++ b/extensions/qa-lab/src/suite-process-lifecycle.test-support.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { resolveQaGatewayChildCommand } from "./gateway-child-command.js";
 import { runQaSuite } from "./suite-launch.runtime.js";
 
 const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
@@ -13,17 +12,12 @@ if (!outputDir || scenarioIds.length === 0) {
 }
 
 try {
-  const sutOpenClawCommand = {
-    ...resolveQaGatewayChildCommand(repoRoot),
-    usePackagedPlugins: false,
-  };
   const result = await runQaSuite({
     repoRoot,
     outputDir: path.relative(repoRoot, outputDir),
     providerMode: "mock-openai",
     scenarioIds,
     concurrency: 4,
-    sutOpenClawCommand,
   });
   const failed = result.result.scenarios.filter((scenario) => scenario.status !== "pass");
   if (failed.length > 0) {

--- a/extensions/qa-lab/src/suite-process-lifecycle.test.ts
+++ b/extensions/qa-lab/src/suite-process-lifecycle.test.ts
@@ -1,5 +1,4 @@
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
-import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import net from "node:net";
 import path from "node:path";
@@ -33,13 +32,8 @@ function buildSuiteProcessEnv(outputDir: string) {
     OPENCLAW_HOME: home,
     OPENCLAW_STATE_DIR: path.join(home, ".openclaw"),
     OPENCLAW_CONFIG_PATH: path.join(home, ".openclaw", "openclaw.json"),
-    OPENCLAW_BUILD_PRIVATE_QA: "1",
     OPENCLAW_QA_SUITE_PROGRESS: "1",
-    OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "1",
   };
-  if (!existsSync(path.join(repoRoot, "dist", "index.js"))) {
-    env.OPENCLAW_FORCE_BUILD = "1";
-  }
   delete env.VITEST;
   delete env.VITEST_POOL_ID;
   delete env.VITEST_WORKER_ID;

--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -22,13 +22,17 @@ import {
   splitExtensionTestJobTargets,
 } from "./extension-test-plan.mts";
 import { buildPluginSdkEntrySources, publicPluginSdkEntrypoints } from "./plugin-sdk-entries.mts";
+import {
+  resolveVitestPretestBuildMode,
+  type VitestPretestBuildMode,
+} from "./vitest-build-prerequisites.mts";
 
 type ChangedNodeTestShard = {
   checkName: string;
   configs: string[];
   includePatterns?: string[];
   planConcurrency?: number;
-  pretestBuildMode?: "private-qa" | "runtime";
+  pretestBuildMode?: VitestPretestBuildMode;
   requiresDist: boolean;
   runner: string;
   shardName: string;
@@ -45,12 +49,6 @@ const CHANGED_NODE_TEST_TARGETS_PER_JOB = 12;
 // processes starve each other on 4-vCPU runners and push otherwise healthy
 // integration tests past the global timeout.
 const SERIAL_CHANGED_TARGET_RE = /^extensions\/memory-core\//u;
-const PRETEST_RUNTIME_BUILD_TARGETS = new Set([
-  "test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts",
-]);
-const PRETEST_PRIVATE_QA_BUILD_TARGETS = new Set([
-  "extensions/qa-lab/src/suite-process-lifecycle.test.ts",
-]);
 const BOUNDARY_NODE_TEST_CONFIG = "test/vitest/vitest.boundary.config.ts";
 const DOCKER_SEED_LANE_ORDER = [
   "mcp-channels",
@@ -326,10 +324,9 @@ function createChangedTargetShards(
       shardName: `${names.shardName}${suffix}`,
       targets: chunk,
     };
-    if (chunk.some((target) => PRETEST_PRIVATE_QA_BUILD_TARGETS.has(target))) {
-      shard.pretestBuildMode = "private-qa";
-    } else if (chunk.some((target) => PRETEST_RUNTIME_BUILD_TARGETS.has(target))) {
-      shard.pretestBuildMode = "runtime";
+    const pretestBuildMode = resolveVitestPretestBuildMode([{ includePatterns: chunk }]);
+    if (pretestBuildMode) {
+      shard.pretestBuildMode = pretestBuildMode;
     }
     if (chunk.some((target) => SERIAL_CHANGED_TARGET_RE.test(target))) {
       shard.planConcurrency = 1;
@@ -375,8 +372,11 @@ function createChangedExtensionConfigShards(extensionRoots: string[]) {
       runner: DEFAULT_NODE_TEST_RUNNER,
       shardName: `changed-extensions-config${suffix}`,
     };
-    if (roots.includes("extensions/qa-lab")) {
-      shard.pretestBuildMode = "private-qa";
+    const pretestBuildMode = resolveVitestPretestBuildMode([
+      { configs: [config], includePatterns },
+    ]);
+    if (pretestBuildMode) {
+      shard.pretestBuildMode = pretestBuildMode;
     }
     if (includePatterns) {
       shard.includePatterns = includePatterns;

--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -22,6 +22,10 @@ import {
 } from "../../test/vitest/vitest.unit-fast-paths.mjs";
 import { boundaryTestFiles, isUnitConfigTestFile } from "../../test/vitest/vitest.unit-paths.mjs";
 import { listTrackedTestFiles } from "./list-test-files.mts";
+import {
+  resolveVitestPretestBuildMode,
+  type VitestPretestBuildMode as NodeTestPretestBuildMode,
+} from "./vitest-build-prerequisites.mts";
 
 type NodeTestShardGroup = {
   shard_name: string;
@@ -58,15 +62,6 @@ type NodeTestPlanOptions = {
 };
 
 type CompactNodeTestPlanMode = "pull-request" | "push";
-type NodeTestPretestBuildMode = "private-qa" | "runtime";
-
-const PRETEST_RUNTIME_BUILD_FILES = new Set([
-  "test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts",
-]);
-
-function resolvePretestBuildMode(paths: readonly string[]): NodeTestPretestBuildMode | undefined {
-  return paths.some((file) => PRETEST_RUNTIME_BUILD_FILES.has(file)) ? "runtime" : undefined;
-}
 
 type PolicyTestWatch = {
   ownerGlobs?: readonly string[];
@@ -137,7 +132,7 @@ type CompactNodeTestShard = Omit<NodeTestShard, "configs" | "groups"> & {
   groups: NodeTestShardGroup[];
 };
 
-type NodeTestSplitShard = Omit<NodeTestShard, "checkName" | "runner"> & {
+type NodeTestSplitShard = Omit<NodeTestShard, "checkName" | "runner" | "pretestBuildMode"> & {
   includeExternalConfigs?: boolean;
   runner?: string;
 };
@@ -1588,19 +1583,12 @@ function createToolingSplitShards(): NodeTestSplitShard[] {
       listCompactToolingTestFiles(),
       COMPACT_TOOLING_NODE_TEST_GROUPS,
       stripeFileWeight,
-    ).map((includePatterns, index) => {
-      const pretestBuildMode = resolvePretestBuildMode(includePatterns);
-      const shard: NodeTestSplitShard = {
-        shardName: `core-tooling-${index + 1}`,
-        configs: [TOOLING_CONFIG],
-        includePatterns,
-        requiresDist: false,
-      };
-      if (pretestBuildMode) {
-        shard.pretestBuildMode = pretestBuildMode;
-      }
-      return shard;
-    }),
+    ).map((includePatterns, index) => ({
+      shardName: `core-tooling-${index + 1}`,
+      configs: [TOOLING_CONFIG],
+      includePatterns,
+      requiresDist: false,
+    })),
     {
       shardName: "core-tooling-isolated",
       configs: ["test/vitest/vitest.tooling-docker.config.ts", TOOLING_ISOLATED_CONFIG],
@@ -1908,6 +1896,10 @@ export function createNodeTestShards(options: NodeTestPlanOptions = {}): NodeTes
           return [];
         }
 
+        const pretestBuildMode = resolveVitestPretestBuildMode([
+          { configs: splitConfigs, includePatterns: splitShard.includePatterns },
+        ]);
+
         return [
           {
             checkName: formatNodeTestShardCheckName(splitShard.shardName),
@@ -1915,9 +1907,7 @@ export function createNodeTestShards(options: NodeTestPlanOptions = {}): NodeTes
             configs: splitConfigs,
             ...(splitShard.env ? { env: splitShard.env } : {}),
             ...(splitShard.includePatterns ? { includePatterns: splitShard.includePatterns } : {}),
-            ...(splitShard.pretestBuildMode
-              ? { pretestBuildMode: splitShard.pretestBuildMode }
-              : {}),
+            ...(pretestBuildMode ? { pretestBuildMode } : {}),
             runner: splitShard.runner ?? DEFAULT_NODE_TEST_RUNNER,
             requiresDist: splitShard.requiresDist,
           },
@@ -1925,11 +1915,13 @@ export function createNodeTestShards(options: NodeTestPlanOptions = {}): NodeTes
       });
     }
 
+    const pretestBuildMode = resolveVitestPretestBuildMode([{ configs }]);
     return [
       {
         checkName: formatNodeTestShardCheckName(shard.name),
         shardName: shard.name,
         configs,
+        ...(pretestBuildMode ? { pretestBuildMode } : {}),
         runner: DEFAULT_NODE_TEST_RUNNER,
         requiresDist: DIST_DEPENDENT_NODE_SHARD_NAMES.has(shard.name),
       },

--- a/scripts/lib/vitest-build-prerequisites.mts
+++ b/scripts/lib/vitest-build-prerequisites.mts
@@ -1,0 +1,105 @@
+import { spawn } from "node:child_process";
+import { matchesGlob } from "node:path";
+import { fullSuiteVitestShards } from "../../test/vitest/vitest.test-shards.mjs";
+
+export type VitestPretestBuildMode = "private-qa" | "runtime";
+type SetupCommandRunner = (args: string[], env: NodeJS.ProcessEnv) => Promise<number>;
+
+type TestSelection = {
+  configs?: readonly string[];
+  includePatterns?: readonly string[] | null;
+};
+
+// These process tests consume built runtime artifacts. Prepare their strongest
+// prerequisite before admitting any workers: a child build invalidates dist
+// while unrelated workers may still be importing its public plugin facades.
+// Strongest first: a private-QA build also satisfies ordinary runtime readers.
+const runtimeConsumers = [
+  {
+    file: "extensions/qa-lab/src/suite-process-lifecycle.test.ts",
+    config: "test/vitest/vitest.extension-qa.config.ts",
+    mode: "private-qa",
+  },
+  {
+    file: "test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts",
+    config: "test/vitest/vitest.tooling.config.ts",
+    mode: "runtime",
+  },
+] as const;
+
+export function resolveVitestPretestBuildMode(
+  selections: readonly TestSelection[],
+): VitestPretestBuildMode | undefined {
+  return runtimeConsumers.find(({ file, config }) =>
+    selections.some(({ configs, includePatterns }) =>
+      includePatterns
+        ? includePatterns.some((pattern) => matchesGlob(file, pattern))
+        : configs?.some(
+            (selected) =>
+              selected === config ||
+              selected === "vitest.config.ts" ||
+              selected === "test/vitest/vitest.config.ts" ||
+              fullSuiteVitestShards.some(
+                (shard) => shard.config === selected && shard.projects.includes(config),
+              ),
+          ),
+    ),
+  )?.mode;
+}
+
+export function isE2eBuildSkipped(env: NodeJS.ProcessEnv) {
+  return env.OPENCLAW_E2E_SKIP_BUILD === "1" || env.OPENCLAW_E2E_USE_PREBUILT_DIST === "1";
+}
+
+function runE2eSetupCommand(args: string[], env: NodeJS.ProcessEnv): Promise<number> {
+  const child = spawn(process.execPath, args, {
+    cwd: process.cwd(),
+    detached: false,
+    env,
+    stdio: ["inherit", "pipe", "pipe"],
+  });
+  child.stdout.pipe(process.stdout, { end: false });
+  child.stderr.pipe(process.stderr, { end: false });
+
+  return new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (status, signal) => {
+      if (signal) {
+        reject(new Error(`E2E setup command terminated by ${signal}: ${args.join(" ")}`));
+        return;
+      }
+      resolve(status ?? 1);
+    });
+  });
+}
+
+export async function runE2eGlobalSetup(
+  runCommand: SetupCommandRunner = runE2eSetupCommand,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  // Focused suites may own their fixtures; prebuilt consumers already have the
+  // complete surface. Neither may start another shared artifact writer.
+  if (isE2eBuildSkipped(env)) {
+    return;
+  }
+  const commands = [
+    {
+      args: ["scripts/run-node.mjs", "--version"],
+      env: {
+        ...env,
+        OPENCLAW_BUILD_PRIVATE_QA: "1",
+        OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
+      },
+    },
+    {
+      args: ["--import", "tsx", "scripts/tsdown-build.mts", "--config", "tsdown.ai.config.ts"],
+      env,
+    },
+  ];
+  for (const { args, env: commandEnv } of commands) {
+    const status = await runCommand(args, commandEnv);
+    if (status !== 0) {
+      throw new Error(`E2E setup command failed with exit code ${status}: ${args.join(" ")}`);
+    }
+  }
+}

--- a/scripts/test-projects.mts
+++ b/scripts/test-projects.mts
@@ -5,6 +5,12 @@ import fs from "node:fs";
 import { performance } from "node:perf_hooks";
 import pMap from "p-map";
 import { formatMs } from "./lib/check-timing-summary.mts";
+import { runManagedCommand } from "./lib/managed-child-process.mts";
+import {
+  isE2eBuildSkipped,
+  resolveVitestPretestBuildMode,
+  runE2eGlobalSetup,
+} from "./lib/vitest-build-prerequisites.mts";
 import {
   isCiLikeEnv,
   resolveLocalFullSuiteProfile,
@@ -302,6 +308,35 @@ async function main() {
     printNoChangedTestTargets(args, process.cwd(), baseEnv);
     printTestSummary("skipped", 0, performance.now() - suiteStartedAt);
     return;
+  }
+
+  const pretestBuildMode = resolveVitestPretestBuildMode(
+    runSpecs.map((spec) => ({ configs: [spec.config], includePatterns: spec.includePatterns })),
+  );
+  const runBuildCommand = (commandArgs: string[], env: NodeJS.ProcessEnv) =>
+    runManagedCommand({ bin: process.execPath, args: commandArgs, cwd: process.cwd(), env });
+  const e2eSpecs = runSpecs.filter((spec) => spec.config === "test/vitest/vitest.e2e.config.ts");
+  if (e2eSpecs.length > 0) {
+    if (!isE2eBuildSkipped(baseEnv)) {
+      console.error("[test] preparing E2E runtime before Vitest workers");
+      await runE2eGlobalSetup(runBuildCommand, baseEnv);
+      // E2E preparation also covers runtime/private-QA readers. Only a completed
+      // owner may tell config-level setup to reuse that shared generation.
+      for (const spec of e2eSpecs) {
+        spec.env = { ...spec.env, OPENCLAW_E2E_USE_PREBUILT_DIST: "1" };
+      }
+    }
+  } else if (pretestBuildMode) {
+    console.error(`[test] preparing ${pretestBuildMode} runtime before Vitest workers`);
+    const code = await runBuildCommand(["scripts/run-node.mjs", "--version"], {
+      ...baseEnv,
+      ...(pretestBuildMode === "private-qa" ? { OPENCLAW_BUILD_PRIVATE_QA: "1" } : {}),
+    });
+    if (code !== 0) {
+      printTestSummary("failed", 0, performance.now() - suiteStartedAt);
+      process.exitCode = code;
+      return;
+    }
   }
 
   const isFullSuiteRun =

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -543,6 +543,17 @@ describe("CI changed Node test plan", () => {
     ]);
   });
 
+  it("routes lifecycle edits to the prepared QA config without losing boundary coverage", () => {
+    const target = "extensions/qa-lab/src/suite-process-lifecycle.test.ts";
+    expect(createChangedNodeTestShards([target])).toEqual([
+      expect.objectContaining({
+        configs: ["test/vitest/vitest.extension-qa.config.ts"],
+        pretestBuildMode: "private-qa",
+      }),
+      expect.objectContaining({ configs: ["test/vitest/vitest.boundary.config.ts"] }),
+    ]);
+  });
+
   it("fails safe when a targeted config needs special shard setup", () => {
     expect(createChangedNodeTestShards(["scripts/docs-i18n/main.go"])).toBeNull();
     expect(createChangedNodeTestShards(["src/tui/tui-pty-harness.e2e.test.ts"])).toBeNull();

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -857,6 +857,28 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
     expect(requiresDistShardNames).toEqual(["core-support-boundary", "core-runtime-tui-pty"]);
   });
 
+  it("preserves runtime preparation and core-only ownership in full and compact plans", () => {
+    const qaConfig = "test/vitest/vitest.extension-qa.config.ts";
+    const runtimeTarget = "test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts";
+    for (const shards of [
+      createNodeTestShards(),
+      createNodeTestShardBundles({ compact: true, compactMode: "pull-request" }),
+    ]) {
+      expect(
+        shards.flatMap((shard) =>
+          "configs" in shard ? shard.configs : shard.groups.flatMap((group) => group.configs),
+        ),
+      ).not.toContain(qaConfig);
+      expect(
+        shards.find((shard) =>
+          ("configs" in shard ? [shard] : shard.groups).some((group) =>
+            group.includePatterns?.includes(runtimeTarget),
+          ),
+        )?.pretestBuildMode,
+      ).toBe("runtime");
+    }
+  });
+
   it("splits tooling checks independently from built artifacts", () => {
     const toolingShards = createNodeTestShards().filter((shard) =>
       shard.shardName.startsWith("core-tooling"),

--- a/test/scripts/test-projects-build-admission.test.ts
+++ b/test/scripts/test-projects-build-admission.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../helpers/promise.js";
+
+const commands = vi.hoisted(() => ({ prepare: vi.fn(), prepareE2e: vi.fn(), reader: vi.fn() }));
+vi.mock("../../scripts/lib/managed-child-process.mts", () => ({
+  runManagedCommand: commands.prepare,
+}));
+vi.mock("../../scripts/lib/vitest-build-prerequisites.mts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../scripts/lib/vitest-build-prerequisites.mts")>()),
+  runE2eGlobalSetup: commands.prepareE2e,
+}));
+vi.mock("../../scripts/run-vitest.mts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../scripts/run-vitest.mts")>()),
+  spawnWatchedVitestProcess: commands.reader,
+}));
+vi.mock("../../scripts/lib/vitest-shard-timings.mts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../scripts/lib/vitest-shard-timings.mts")>()),
+  readShardTimings: () => new Map(),
+  writeShardTimings: () => {},
+}));
+
+const modelTarget = "src/agents/embedded-agent-runner/model-resolution-consistency.test.ts";
+const targets = [modelTarget, "extensions/qa-lab/src/suite-process-lifecycle.test.ts"];
+const e2eTarget = "test/openclaw-launcher-version.e2e.test.ts";
+const e2eConfig = "test/vitest/vitest.e2e.config.ts";
+let originalArgv: string[];
+let originalExitCode: typeof process.exitCode;
+let terminal: ReturnType<typeof createDeferred<unknown>>;
+
+beforeEach(() => {
+  vi.resetModules();
+  commands.prepare.mockReset();
+  commands.prepareE2e.mockReset();
+  commands.reader.mockReset().mockImplementation(() => ({
+    completion: Promise.resolve({ code: 0, signal: null }),
+    getForwardedSignal: () => undefined,
+  }));
+  originalArgv = process.argv;
+  originalExitCode = process.exitCode;
+  process.exitCode = undefined;
+  vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "");
+  vi.stubEnv("OPENCLAW_BUILD_PRIVATE_QA", "");
+  vi.stubEnv("OPENCLAW_E2E_SKIP_BUILD", "");
+  vi.stubEnv("OPENCLAW_E2E_USE_PREBUILT_DIST", "");
+  terminal = createDeferred<unknown>();
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation((value: unknown) => {
+    if (value instanceof Error || /^\[test\] (passed|failed|skipped) /u.test(String(value))) {
+      terminal.resolve(value);
+    }
+  });
+});
+
+afterEach(() => {
+  process.argv = originalArgv;
+  process.exitCode = originalExitCode;
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+async function start(args: string[]) {
+  process.argv = [process.execPath, "scripts/test-projects.mts", ...args];
+  await import("../../scripts/test-projects.mts");
+}
+
+describe("test-projects build admission", () => {
+  it.each([false, true])(
+    "holds every reader until preparation completes (parallel=%s)",
+    async (parallel) => {
+      vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", parallel ? "2" : "");
+      const preparation = createDeferred<number>();
+      const readers = createDeferred<{ code: number; signal: null }>();
+      commands.prepare.mockReturnValue(preparation.promise);
+      commands.reader.mockImplementation(() => ({
+        completion: readers.promise,
+        getForwardedSignal: () => undefined,
+      }));
+      await start(targets);
+      try {
+        expect(commands.reader).not.toHaveBeenCalled();
+        expect(commands.prepare).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            args: ["scripts/run-node.mjs", "--version"],
+            env: expect.objectContaining({ OPENCLAW_BUILD_PRIVATE_QA: "1" }),
+          }),
+        );
+        preparation.resolve(0);
+        await vi.waitFor(() => expect(commands.reader).toHaveBeenCalledTimes(parallel ? 2 : 1));
+      } finally {
+        preparation.resolve(0);
+        readers.resolve({ code: 0, signal: null });
+        await terminal.promise;
+      }
+      expect(await terminal.promise).toMatch(/^\[test\] passed 2 Vitest shards/u);
+      expect(commands.reader).toHaveBeenCalledTimes(2);
+      expect(process.exitCode).toBeUndefined();
+    },
+  );
+
+  it.each(["exit", "throw"])("admits no readers when preparation fails by %s", async (failure) => {
+    commands.prepare.mockImplementation(async () => {
+      if (failure === "throw") {
+        throw new Error("build failed");
+      }
+      return 7;
+    });
+    await start(targets);
+    await terminal.promise;
+    expect(commands.reader).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(failure === "throw" ? 1 : 7);
+  });
+
+  it("starts unrelated tests without runtime preparation", async () => {
+    await start([modelTarget]);
+    expect(await terminal.promise).toMatch(/^\[test\] passed 1 Vitest shard/u);
+    expect(commands.prepare).not.toHaveBeenCalled();
+    expect(commands.reader).toHaveBeenCalledOnce();
+  });
+
+  it("coalesces mixed E2E and private QA preparation before marking only E2E prebuilt", async () => {
+    vi.stubEnv("OPENCLAW_TEST_PROJECTS_PARALLEL", "2");
+    const preparation = createDeferred();
+    commands.prepareE2e.mockReturnValue(preparation.promise);
+    await start([...targets, e2eTarget]);
+    try {
+      expect(commands.prepareE2e).toHaveBeenCalledOnce();
+      expect(commands.prepare).not.toHaveBeenCalled();
+      expect(commands.reader).not.toHaveBeenCalled();
+    } finally {
+      preparation.resolve();
+      await terminal.promise;
+    }
+    expect(await terminal.promise).toMatch(/^\[test\] passed 3 Vitest shards/u);
+    expect(commands.prepare).not.toHaveBeenCalled();
+    expect(commands.reader).toHaveBeenCalledTimes(3);
+    for (const [options] of commands.reader.mock.calls) {
+      expect(options.env.OPENCLAW_E2E_USE_PREBUILT_DIST).toBe(
+        options.pnpmArgs.includes(e2eConfig) ? "1" : "",
+      );
+    }
+  });
+
+  it("admits no mixed readers when E2E preparation fails", async () => {
+    commands.prepareE2e.mockRejectedValue(new Error("E2E build failed"));
+    await start([...targets, e2eTarget]);
+    await terminal.promise;
+    expect(commands.prepare).not.toHaveBeenCalled();
+    expect(commands.reader).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it.each(["OPENCLAW_E2E_SKIP_BUILD", "OPENCLAW_E2E_USE_PREBUILT_DIST"] as const)(
+    "preserves the explicit %s contract",
+    async (key) => {
+      vi.stubEnv(key, "1");
+      await start([...targets, e2eTarget]);
+      await terminal.promise;
+      expect(commands.prepareE2e).not.toHaveBeenCalled();
+      expect(commands.prepare).not.toHaveBeenCalled();
+      expect(commands.reader).toHaveBeenCalledTimes(3);
+      for (const [options] of commands.reader.mock.calls) {
+        expect(options.env[key]).toBe("1");
+      }
+    },
+  );
+});

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { listExtensionTestFilesForRoots } from "../../scripts/lib/extension-test-plan.mts";
+import { resolveVitestPretestBuildMode } from "../../scripts/lib/vitest-build-prerequisites.mts";
 import {
   CHANNEL_CONTRACT_CONFIG_PATTERNS,
   DEFAULT_TEST_PROJECTS_VITEST_NO_OUTPUT_HEARTBEAT_MS,
@@ -42,6 +43,51 @@ const normalizeRepoPath = toRepoPath;
 const CODEX_TEST_PROCESS_FILE_LIMIT = 12;
 const MATRIX_TEST_PROCESS_FILE_LIMIT = 40;
 const TELEGRAM_TEST_PROCESS_FILE_LIMIT = 1;
+
+describe("test runtime prerequisites", () => {
+  it.each([
+    ["lifecycle file", ["extensions/qa-lab/src/suite-process-lifecycle.test.ts"], "private-qa"],
+    ["QA directory", ["extensions/qa-lab"], "private-qa"],
+    ["QA config", ["test/vitest/vitest.extension-qa.config.ts"], "private-qa"],
+    ["all plugins", ["extensions"], "private-qa"],
+    ["full local suite", [], "private-qa"],
+    ["root config", ["vitest.config.ts"], "private-qa"],
+    [
+      "runtime reader",
+      ["test/e2e/qa-lab/runtime/gateway-support-export-runtime.test.ts"],
+      "runtime",
+    ],
+    ["ordinary QA unit test", ["extensions/qa-lab/src/gateway-child-command.test.ts"], undefined],
+    [
+      "model reader",
+      ["src/agents/embedded-agent-runner/model-resolution-consistency.test.ts"],
+      undefined,
+    ],
+  ] as const)("prepares only the prerequisite selected by %s", (_name, args, expected) => {
+    const plans = args.length ? buildVitestRunPlans([...args]) : buildFullSuiteVitestRunPlans([]);
+    expect(
+      resolveVitestPretestBuildMode(
+        plans.map((plan) => ({
+          configs: [plan.config],
+          includePatterns: plan.includePatterns,
+        })),
+      ),
+    ).toBe(expected);
+  });
+
+  it("combines private QA and runtime readers into one private build", () => {
+    expect(
+      resolveVitestPretestBuildMode([
+        { includePatterns: ["test/e2e/qa-lab/runtime/**/*.test.ts"] },
+        { includePatterns: ["extensions/qa-lab/**/*.test.ts"] },
+      ]),
+    ).toBe("private-qa");
+    expect(resolveVitestPretestBuildMode([])).toBeUndefined();
+    expect(resolveVitestPretestBuildMode([{ configs: ["test/vitest/vitest.config.ts"] }])).toBe(
+      "private-qa",
+    );
+  });
+});
 
 function expectedCodexTestProcessCount() {
   const testFileCount = listExtensionTestFilesForRoots(["extensions/codex"]).length;
@@ -1581,6 +1627,7 @@ describe("scripts/test-projects changed-target routing", () => {
           "test/scripts/check-plugin-sdk-wildcard-reexports.test.ts",
           "test/scripts/control-ui-i18n.test.ts",
           "test/scripts/openclaw-e2e-instance.test.ts",
+          "test/scripts/test-projects-build-admission.test.ts",
         ],
         watchMode: false,
       },
@@ -1768,6 +1815,7 @@ describe("scripts/test-projects changed-target routing", () => {
           "test/scripts/check-plugin-sdk-wildcard-reexports.test.ts",
           "test/scripts/control-ui-i18n.test.ts",
           "test/scripts/openclaw-e2e-instance.test.ts",
+          "test/scripts/test-projects-build-admission.test.ts",
         ],
         watchMode: false,
       },

--- a/test/scripts/vitest-e2e-global-setup.test.ts
+++ b/test/scripts/vitest-e2e-global-setup.test.ts
@@ -3,12 +3,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { runE2eGlobalSetup } from "../../scripts/lib/vitest-build-prerequisites.mts";
 import {
   forceKillVitestProcessGroup,
   forwardSignalToVitestProcessGroup,
 } from "../../scripts/vitest-process-group.mts";
 import { waitForChildClose, waitForDead, waitForPidFile } from "../helpers/process-wait.js";
-import { runE2eGlobalSetup } from "../vitest/vitest.e2e.global-setup.js";
 
 type SetupCommandRunner = NonNullable<Parameters<typeof runE2eGlobalSetup>[0]>;
 
@@ -69,8 +69,9 @@ describe("vitest E2E global setup", () => {
 
   posixIt("forwards output and SIGTERM through the runner process group", async () => {
     const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-e2e-setup-group-"));
-    const fixturePath = path.join(fixtureDir, "build-fixture.mjs");
+    const fixturePath = path.join(fixtureDir, "scripts", "run-node.mjs");
     const pidPaths = ["child.pid", "descendant.pid"].map((name) => path.join(fixtureDir, name));
+    fs.mkdirSync(path.dirname(fixturePath), { recursive: true });
     fs.writeFileSync(
       fixturePath,
       `import { spawn } from "node:child_process";
@@ -86,9 +87,11 @@ process.stdin.once("data", () => {
 process.stdin.resume();
 `,
     );
-    const setupUrl = new URL("../vitest/vitest.e2e.global-setup.ts", import.meta.url).href;
-    const runnerScript = `import { runE2eSetupCommand } from ${JSON.stringify(setupUrl)};
-await runE2eSetupCommand([${JSON.stringify(fixturePath)}], process.env);`;
+    const setupUrl = new URL("../../scripts/lib/vitest-build-prerequisites.mts", import.meta.url)
+      .href;
+    const runnerScript = `import { runE2eGlobalSetup } from ${JSON.stringify(setupUrl)};
+process.chdir(${JSON.stringify(fixtureDir)});
+await runE2eGlobalSetup(undefined, process.env);`;
     const runner = spawn(
       process.execPath,
       ["--import", "tsx", "--input-type=module", "--eval", runnerScript],

--- a/test/vitest/vitest.e2e.global-setup.ts
+++ b/test/vitest/vitest.e2e.global-setup.ts
@@ -1,62 +1,6 @@
-// Builds the shared CLI/package artifacts once before parallel E2E workers
-// start long-lived Gateway processes that import those artifacts lazily.
-import { spawn } from "node:child_process";
-
-type SetupCommandRunner = (args: string[], env: NodeJS.ProcessEnv) => Promise<number>;
-
-export function runE2eSetupCommand(args: string[], env: NodeJS.ProcessEnv): Promise<number> {
-  const child = spawn(process.execPath, args, {
-    cwd: process.cwd(),
-    detached: false,
-    env,
-    stdio: ["inherit", "pipe", "pipe"],
-  });
-  child.stdout.pipe(process.stdout, { end: false });
-  child.stderr.pipe(process.stderr, { end: false });
-
-  return new Promise((resolve, reject) => {
-    child.once("error", reject);
-    child.once("close", (status, signal) => {
-      if (signal) {
-        reject(new Error(`E2E setup command terminated by ${signal}: ${args.join(" ")}`));
-        return;
-      }
-      resolve(status ?? 1);
-    });
-  });
-}
-
-export async function runE2eGlobalSetup(
-  runCommand: SetupCommandRunner = runE2eSetupCommand,
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<void> {
-  // Some focused suites bring their own fixtures, while exact-run artifact consumers already
-  // have the complete built surface. In both cases rebuilding here would duplicate slow work.
-  if (env.OPENCLAW_E2E_SKIP_BUILD === "1" || env.OPENCLAW_E2E_USE_PREBUILT_DIST === "1") {
-    return;
-  }
-  const commands = [
-    {
-      args: ["scripts/run-node.mjs", "--version"],
-      env: {
-        ...env,
-        OPENCLAW_BUILD_PRIVATE_QA: "1",
-        OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
-      },
-    },
-    {
-      args: ["--import", "tsx", "scripts/tsdown-build.mts", "--config", "tsdown.ai.config.ts"],
-      env,
-    },
-  ];
-  for (const { args, env: commandEnv } of commands) {
-    const status = await runCommand(args, commandEnv);
-    if (status !== 0) {
-      throw new Error(`E2E setup command failed with exit code ${status}: ${args.join(" ")}`);
-    }
-  }
-}
-
+// Raw Vitest entrypoint; the project scheduler prepares these same artifacts
+// before any selected shard and passes the existing prebuilt contract onward.
+import { runE2eGlobalSetup } from "../../scripts/lib/vitest-build-prerequisites.mts";
 export default async function setup() {
   await runE2eGlobalSetup();
 }

--- a/test/vitest/vitest.tooling-isolated-paths.mjs
+++ b/test/vitest/vitest.tooling-isolated-paths.mjs
@@ -7,6 +7,7 @@ export const toolingIsolatedTestFiles = [
   "test/scripts/check-plugin-sdk-wildcard-reexports.test.ts",
   "test/scripts/control-ui-i18n.test.ts",
   "test/scripts/openclaw-e2e-instance.test.ts",
+  "test/scripts/test-projects-build-admission.test.ts",
 ];
 
 const toolingIsolatedTestFileSet = new Set(toolingIsolatedTestFiles);


### PR DESCRIPTION
Related: #120624 (the earlier parallel-E2E artifact race) and #125924 (QA lifecycle regression coverage).

## What Problem This Solves

Resolves a problem where developers running QA lifecycle tests alongside other test projects could see unrelated model-resolution tests fail with missing generated modules, even after a successful build. A full-suite retest reproduced five failures among the nine existing model-resolution cases while the QA fixture rebuilt the shared output tree.

## Why This Change Was Made

The selected test run now owns preparation before admitting any workers: one shared classifier supplies local and CI prerequisite modes, private QA satisfies ordinary runtime requirements, and the lifecycle fixture consumes the existing built Gateway instead of launching a development rebuild. Explicit mixed E2E selections reuse the same E2E preparation owner before all readers, while standalone E2E setup, existing prebuilt/skip contracts, cleanup, progress and deadlines remain intact.

This removes the fixture's custom development command and build-forcing fields, duplicate prerequisite metadata, and a test-only export. It does not change model/provider behavior, add configuration, alter hosted CI capacity, or attempt to coordinate arbitrary independent commands sharing a checkout. Product runtime LOC is unchanged; tooling is net +76 lines to supply the missing combined admission boundary, and tests/test-support are net +239.

## User Impact

No end-user behavior changes. Maintainers can run selected QA, model and E2E projects together without those projects deleting artifacts beneath already-running readers. A failed preparation admits no test workers, and selections without runtime prerequisites do not build.

## Evidence

AI-assisted with Codex; independently reviewed. All proof used an isolated exact-dependency checkout based on `79dfa81664fd64a3f6192331af4953ff9f9bf1ef` and task-owned state/ports.

Runtime attestation: test controllers and observed Vitest readers used Node 24.20.0. Build/lint commands that launched bare `node` through the host PATH were not uniformly version-attested and may have used supported Node 26; this is not a claim that every subprocess used Node 24.

Publication refresh: rebased once onto `2d2c8a9fb53e5720f69a58af4fa806852cad0a13`, producing `c9c1c33226c702d2eba9a7675ef963fee535195e`; all 13 patch files remained byte-identical. The refreshed managed-command owner installs signal handlers before spawn, so its current 31 tests were added to the focused run: all 428 tests passed. The real rebuilt mixed run also passed 22/22 again, with overlapping readers, immutable exact-head artifacts, normal QA exit and no survivors. The full changed gate against the refreshed base passed all 23 checks (exit 0).

- **Before:** the original lifecycle fixture caused the exact missing Anthropic facade target, with 5 failed/4 passed existing model tests. The writer removed the target for about 13 seconds. The fixture itself passed, demonstrating that its success did not protect sibling readers.
- **After, same execution order:** collected the actual model module, started the repaired real QA fixture, waited for real Gateway readiness, then ran the unchanged assertions: 9/9 model tests and 1/1 QA scenario passed. Artifact stamps remained byte-identical, all child processes exited, and the Gateway listener closed. One earlier instrumented attempt hit the unchanged no-output watchdog under host contention before model assertions; the isolated retry used the same deadlines and no synthetic heartbeat.
- **Native serial and parallel runs:** the existing model 9 + lifecycle 1 passed in both modes. Parallelism 2 admitted overlapping workers; the generated artifact generation stayed unchanged throughout their lifetimes.
- **Mixed E2E coverage:** model 9 + lifecycle 1 + launcher E2E 12 passed after combined preparation. The same 22 passed with explicitly supplied prebuilt artifacts, preserving the generation from experiment start and performing no replacement build.
- **Regression coverage:** the new admission test failed 6/9 cases against the original scheduler. The fixed focused selection passed 397 tests across five files. Final test-only cleanup reruns passed all 9 admission cases and all 5 raw E2E owner cases, including stdout/stderr and SIGTERM descendant cleanup. Repeated runs are not additional unique tests.
- **CI routing:** original and candidate full/compact plan JSON matched exactly: 126 full jobs, 34 PR compact jobs, 25 push compact jobs. Existing QA coverage remains selected.
- **Changed gate:** the complete final 13-file gate passed (exit 0), including formatting, all guards, all three dead-export scans with zero entries, extension/script/root-test type checks, and full plugin/script lint. Earlier attempts caught an unnecessary script export, test-library typing issues, and a shadowed callback parameter; targeted lint also caught missing test braces. These were corrected without suppressions, compiler-setting changes, or weakened assertions. Full script lint, focused admission lint, and the nine admission cases also passed.

Named follow-ups from extra targeted lint: pre-existing cleanup throws inside `finally` in `test/scripts/vitest-e2e-global-setup.test.ts`, and a pre-existing comparator-free sort in `test/scripts/ci-node-test-plan.test.ts`. Both are unchanged from the base and outside the required changed-gate lint lanes; this repair does not suppress them or broaden into unrelated cleanup.

Reproducible native commands (Node 24):

```sh
node scripts/run-vitest.mjs test/scripts/test-projects-build-admission.test.ts test/scripts/test-projects.test.ts test/scripts/ci-node-test-plan.test.ts test/scripts/ci-changed-node-test-plan.test.ts test/scripts/vitest-e2e-global-setup.test.ts
OPENCLAW_TEST_PROJECTS_PARALLEL=2 OPENCLAW_VITEST_MAX_WORKERS=1 node --import ./scripts/tsx.mjs scripts/test-projects.mts src/agents/embedded-agent-runner/model-resolution-consistency.test.ts extensions/qa-lab/src/suite-process-lifecycle.test.ts -- --reporter=verbose
OPENCLAW_TEST_PROJECTS_PARALLEL=2 OPENCLAW_VITEST_MAX_WORKERS=1 node --import ./scripts/tsx.mjs scripts/test-projects.mts src/agents/embedded-agent-runner/model-resolution-consistency.test.ts extensions/qa-lab/src/suite-process-lifecycle.test.ts test/openclaw-launcher-version.e2e.test.ts -- --reporter=verbose
node scripts/check-changed.mjs --base 79dfa81664fd64a3f6192331af4953ff9f9bf1ef --timed
```

Provenance: the lifecycle development-command/build-forcing path was introduced in #125924 (`88edcd165480`, 2026-08-19; code author, PR author and merger @steipete). The related E2E ownership fix #120628 (`40385bb5c153`, 2026-08-08; code author, PR author and merger @steipete) prepared only its own config; this closes the mixed-project boundary. Its stream/signal repair #120653 (`a9012617543c`, 2026-08-08; code author, PR author and merger @vincentkoc) is preserved.
