### PR TITLE
test(codex): await shared-client transport writes

### DIFF
--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -149,14 +149,14 @@ async function sendInitializeResult(
   harness: ReturnType<typeof createClientHarness>,
   userAgent: string,
 ): Promise<void> {
-  await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(1));
-  const initialize = JSON.parse(harness.writes[0] ?? "{}") as { id?: number };
+  const initialize = JSON.parse(await harness.waitForWrite(0)) as { id: number; method: string };
+  expect(initialize.method).toBe("initialize");
   harness.send({ id: initialize.id, result: { userAgent } });
 }
 
 async function sendEmptyModelList(harness: ReturnType<typeof createClientHarness>): Promise<void> {
-  await vi.waitFor(() => expect(harness.writes.length).toBeGreaterThanOrEqual(3));
-  const modelList = JSON.parse(harness.writes[2] ?? "{}") as { id?: number };
+  const modelList = JSON.parse(await harness.waitForWrite(2)) as { id: number; method: string };
+  expect(modelList.method).toBe("model/list");
   harness.send({ id: modelList.id, result: { data: [] } });
 }
 
@@ -411,8 +411,8 @@ describe("shared Codex app-server client", () => {
         secretFreeCacheKey: "replacement-account",
       });
       const nextAcquire = getLeasedSharedCodexAppServerClient(options);
-      await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2));
       await sendInitializeResult(replacement, "openclaw/0.149.0 (Linux; test)");
+      expect(startSpy).toHaveBeenCalledTimes(2);
       await expect(nextAcquire).resolves.toBe(replacement.client);
       releaseLeasedSharedCodexAppServerClient(replacement.client);
       expect(mocks.applyCodexAppServerAuthProfile).toHaveBeenLastCalledWith(
@@ -1374,25 +1374,33 @@ describe("shared Codex app-server client", () => {
           chatgptPlanType: null,
         });
       }
+      const responseIndex = first.writes.length;
       first.send({
         id: "failed-refresh",
         method: "account/chatgptAuthTokens/refresh",
         params: { reason: "unauthorized", previousAccountId: "original-account" },
       });
-      await vi.waitFor(() =>
-        expect(first.writes.map((line) => JSON.parse(line))).toContainEqual(
-          expect.objectContaining({ id: "failed-refresh", error: expect.any(Object) }),
-        ),
-      );
+      expect(JSON.parse(await first.waitForWrite(responseIndex))).toEqual({
+        id: "failed-refresh",
+        error: {
+          code: -32603,
+          message:
+            failure === "failure"
+              ? "refresh failed"
+              : "ChatGPT workspace changed during Codex token refresh. Retry to start a client for the selected workspace.",
+        },
+      });
       expect(first.stdinDestroyed).toBe(false);
       const nextAcquire = getLeasedSharedCodexAppServerClient(options);
-      await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2));
       await sendInitializeResult(replacement, "openclaw/0.149.0 (Linux; test)");
+      expect(startSpy).toHaveBeenCalledTimes(2);
       await expect(nextAcquire).resolves.toBe(replacement.client);
       expect(releaseLeasedSharedCodexAppServerClient(first.client)).toBe(true);
       expect(first.stdinDestroyed).toBe(true);
       expect(replacement.stdinDestroyed).toBe(false);
-      releaseLeasedSharedCodexAppServerClient(replacement.client);
+      expect(releaseLeasedSharedCodexAppServerClient(replacement.client)).toBe(true);
+      expect(clearSharedCodexAppServerClientIfCurrent(replacement.client)).toBe(true);
+      expect(replacement.stdinDestroyed).toBe(true);
     },
   );
 
@@ -1543,8 +1551,8 @@ describe("shared Codex app-server client", () => {
             }
           : { authProfileId: "openai:scoped", authProfileStore: secondStore }),
       });
-      await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2));
       await sendInitializeResult(secondHarness, "openclaw/0.149.0 (macOS; test)");
+      expect(startSpy).toHaveBeenCalledTimes(2);
       await expect(secondPromise).resolves.toBe(secondHarness.client);
 
       expect(resolvedCacheKeys).toEqual(["account:sha256:first", "account:sha256:second"]);
@@ -1693,8 +1701,8 @@ describe("shared Codex app-server client", () => {
       timeoutMs: 1000,
       preparedAuth: { kind: "api-key", apiKey: "second-platform-key" },
     });
-    await vi.waitFor(() => expect(startSpy).toHaveBeenCalledTimes(2));
     await sendInitializeResult(secondHarness, "openclaw/0.149.0 (macOS; test)");
+    expect(startSpy).toHaveBeenCalledTimes(2);
     await expect(secondPromise).resolves.toBe(secondHarness.client);
 
     expect(cacheKeys).toEqual(["api_key:sha256:first", "api_key:sha256:second"]);

--- a/extensions/codex/src/app-server/test-support.ts
+++ b/extensions/codex/src/app-server/test-support.ts
@@ -93,6 +93,7 @@ export function createCodexTestModel(provider = "openai", input = ["text"]): Mod
 export function createClientHarness(options: { autoEmitExit?: boolean } = {}) {
   const stdout = new PassThrough();
   const writes: string[] = [];
+  const writeEvents = new EventEmitter();
   let stdinDestroyed = false;
   let exitEmitted = false;
   let emitProcessExit: () => void = () => undefined;
@@ -113,6 +114,7 @@ export function createClientHarness(options: { autoEmitExit?: boolean } = {}) {
     write(chunk, _encoding, callback) {
       writes.push(chunk.toString());
       callback();
+      writeEvents.emit("write");
     },
   });
   const destroyStdin = stdin.destroy.bind(stdin);
@@ -143,6 +145,28 @@ export function createClientHarness(options: { autoEmitExit?: boolean } = {}) {
     client,
     process,
     writes,
+    async waitForWrite(index: number): Promise<string> {
+      if (writes[index] !== undefined) {
+        return writes[index];
+      }
+      return await new Promise<string>((resolve, reject) => {
+        const cleanup = () => {
+          clearTimeout(timer);
+          writeEvents.off("write", onWrite);
+        };
+        const onWrite = () => {
+          if (writes[index] !== undefined) {
+            cleanup();
+            resolve(writes[index]);
+          }
+        };
+        const timer = setTimeout(() => {
+          cleanup();
+          reject(new Error(`Timed out waiting for app-server harness write ${index}`));
+        }, 1_000);
+        writeEvents.on("write", onWrite);
+      });
+    },
     get stdinDestroyed() {
       return stdinDestroyed;
     },


### PR DESCRIPTION
## What Problem This Solves

Codex shared-client lifecycle tests spend several seconds waiting for the next 50 ms polling tick after their in-memory transport has already written a request or response. This slows focused development and CI without adding lifecycle coverage.

## Why This Change Was Made

Observe recorded transport writes directly in the existing test harness, with the same one-second readiness deadline and explicit timer/listener cleanup. Initialization and model-list helpers await their actual outgoing frame. Replacement-start assertions remain, but no longer need a separate poll before the initialize frame. Refresh-failure tests wait for the real JSON-RPC error response and now check its exact code and distinct failure/workspace-change message, then verify both old-lease drainage and replacement cleanup.

The production shared-client owner, JSON-RPC client, transport lifecycle, timeouts, fake-timer tests, and real WebSocket/process tests are unchanged. Lower polling intervals, fake time, awaited refresh mocks, or mocked initialization would not preserve the same boundary as clearly.

## User Impact

No runtime behavior change. The project-routed shared-client file is about six seconds faster on the measured Linux host, with all 90 tests retained and stronger refresh-response/cleanup assertions. This is a maintainer-requested, AI-assisted test-performance change.

Production LOC: +0/-0. Tests: +22/-14. Test support: +24/-0. No dependency, configuration, protocol, persistence, package, or public API change.

## Evidence

Benchmark base: `1d097044e9d109fdd83f1b997fde0291da87af98`. One [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33127416658), Linux x86_64, Node 24.19.0, pnpm 11.22.0. Baseline and candidate warmups excluded; eight order-balanced pairs, one worker, a distinct empty Vitest filesystem module cache per run, import diagnostics and `/usr/bin/time -v`. The measured scope is the whole changed file, because its initialization helper is shared across cases.

```sh
/usr/bin/time -v env   OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=<unique-path-per-run>   OPENCLAW_VITEST_IMPORT_DURATIONS=1   OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1   OPENCLAW_VITEST_MAX_WORKERS=1   pnpm test extensions/codex/src/app-server/shared-client.test.ts   --maxWorkers=1 --reporter=verbose
```

A task-local reporter additionally recorded Vitest module diagnostics; it did not alter tests.

| Median | Before | After |
|---|---:|---:|
| Scoped wall | 20.100 s | 14.205 s |
| Vitest | 16.275 s | 10.590 s |
| Test bodies/hooks | 7.631 s | 1.888 s |
| Import | 7.942 s | 8.085 s |
| Max RSS | 1,099,378 KiB | 1,092,136 KiB |
| CPU user/system | 14.185 / 1.600 s | 13.840 / 1.610 s |
| CPU utilization | 77.5% | 107% |
| Passing tests | 90 | 90 |

Median wall reduction: **5.895 s**; median paired improvement: **31.02%**. **8/8** pairs clear both 0.5 s and 3%; the minimum is 4.65 s / 23.79%. Imports and RSS remain effectively unchanged.

| Pair | Order | Before s | After s | Improvement |
|---|---|---:|---:|---:|
| 1 | before/after | 19.62 | 13.11 | 33.18% |
| 2 | after/before | 20.26 | 13.99 | 30.95% |
| 3 | before/after | 20.61 | 14.42 | 30.03% |
| 4 | after/before | 19.55 | 14.90 | 23.79% |
| 5 | before/after | 22.28 | 15.21 | 31.73% |
| 6 | after/before | 21.35 | 15.70 | 26.46% |
| 7 | before/after | 19.94 | 13.34 | 33.10% |
| 8 | after/before | 19.49 | 13.43 | 31.09% |

Separate reversible count probes, excluded from timing, matched before/after: 2,726 Vite module-graph entries, 110 in-memory client objects, 109 in-memory initialize writes, and two real WebSocket connections. The shared-client file intentionally owns no real stdio child processes. Its sibling process-lifecycle tests remain real and passed. Vitest's printed top-ten import list is not misreported as a total module count.

Three reversible mutations against the actual production owners each made **both** optimized refresh cases fail:

- Remove `shared-client.ts`'s refresh-failure retirement callback: no replacement initialize frame arrives.
- Keep the shared entry's active-lease count at one on release: old-client destruction assertion fails.
- Serialize error code `-32602` instead of `-32603` in `client.ts`: exact response assertions fail.

Each owner file was restored byte-for-byte and SHA-256 verified; the restored focused run passed both cases. No mutation is included in this PR.

Validation: 341 tests across nine focused/sibling files passed (`shared-client`, `client-runtime`, `client`, `auth-bridge`, `auth-binding`, `models`, `request`, `session-retirement`, `transport.process`). Shuffled full-file runs passed all 90 tests with seeds `131187` and `8272026`. Formatting and `git diff --check` passed. Deslop required no changes; fresh isolated Codex autoreview was clean (default P0 scope). The complete `pnpm check:changed` gate passed in Testbox (exit 0, 8m1s), including both extension type-check lanes, lint, formatting, all three dead-export scans and runtime guards. Its shallow remote checkout skipped only the env-budget base comparison; that exact comparison separately passed locally against the frozen benchmark base (`OPENCLAW_* count 501/501`). Build/API/package checks are not needed for this test-only surface.

Test-audit: the retained test specifically connects failed token refresh to retirement, fresh acquisition and old-lease drainage; generic retirement tests do not cover that producer. Missing retirement, leaked/early destruction, wrong replacement and wrong/missing wire response are credible failures. No new test-only production seam was added.

Upstream contract was personally checked in the actual sibling Codex repository, including freshly fetched commit `2d929eb7c39a612b84e0987f2af4a4c2282249e2`:

- [common.rs:1721-1724](https://github.com/openai/codex/blob/2d929eb7c39a612b84e0987f2af4a4c2282249e2/codex-rs/app-server-protocol/src/protocol/common.rs#L1721-L1724) maps the refresh request and response; its serialization test covers `unauthorized` and `previousAccountId`.
- [v2/account.rs:271-307](https://github.com/openai/codex/blob/2d929eb7c39a612b84e0987f2af4a4c2282249e2/codex-rs/app-server-protocol/src/protocol/v2/account.rs#L271-L307) defines the workspace hint and returned auth fields.
- [external_auth.rs:33-83](https://github.com/openai/codex/blob/2d929eb7c39a612b84e0987f2af4a4c2282249e2/codex-rs/app-server/src/external_auth.rs#L33-L83) waits on the response with a ten-second deadline and updates auth only after valid success.
- [outgoing_message.rs:281-357](https://github.com/openai/codex/blob/2d929eb7c39a612b84e0987f2af4a4c2282249e2/codex-rs/app-server/src/outgoing_message.rs#L281-L357) and [response/error handling](https://github.com/openai/codex/blob/2d929eb7c39a612b84e0987f2af4a4c2282249e2/codex-rs/app-server/src/outgoing_message.rs#L385-L464) preserve request-id correlation and cancellation.
- [message_processor.rs:837-889](https://github.com/openai/codex/blob/2d929eb7c39a612b84e0987f2af4a4c2282249e2/codex-rs/app-server/src/message_processor.rs#L837-L889) enforces initialization before normal request dispatch.

This proves the in-memory OpenClaw protocol/lifecycle boundary, not authenticated live-provider behavior. Production behavior is unchanged.

Landing continuation: the earlier worktree blocker was a mistaken interpretation. The restriction applies to a separate implementation worktree; the temporary repository-native `scripts/pr` review/prepare worktree is explicitly authorized. Native review, prepare and merge completed on the unchanged head, landing as [4e33639bef29cc9fa45e8db8377d9eb7dba90283](https://github.com/openclaw/openclaw/commit/4e33639bef29cc9fa45e8db8377d9eb7dba90283). The native worktree/refs/lock and source branch are cleaned up; the visible checkout is clean main. The acting maintainer independently matched all benchmark baseline/candidate files to Git blobs, recomputed the eight raw timing pairs, checked actual-owner fault and sibling logs, and obtained a fresh clean isolated Codex autoreview (default P0 scope). The current upstream refresh and lifecycle contracts were personally rechecked at Codex commit `91c66024c7784f8de2d8c8355bcccad40ab3c44d`, including `common.rs:1721-1724,2850-2871`, `v2/account.rs:271-307`, complete `external_auth.rs:1-98`, `outgoing_message.rs:281-360,383-463`, and `message_processor.rs:795-889` under the same paths linked above. Exact-head CI remains green. Supplemental local proof: the same nine-file command passed 340 tests, including all eight non-process files and all 90 shared-client cases. One unchanged process-containment assertion failed (`transport.process.test.ts:423`, sentinel survival). Running that process file alone on current main `e1a2f775733e28f362b1372e4e49ab9af0b04883` reproduces the identical failure (1 passed / 1 failed). Its test and transport/containment owners are byte-identical between main and this PR; it does not import the changed test harness. Host load exceeded 340 and containment has a two-second inspection budget; load sensitivity is a hypothesis, not a proven root cause. Named follow-up: investigate the macOS process-containment fixture under heavy scheduling pressure without weakening identity checks or deadlines. This unrelated current-main failure is not counted as a pass; the archived Linux 341-test run and exact-head CI remain passing. No source edits or rebase were needed.
