### PR TITLE
fix(active-memory): restore interactive recall and preserve completed results

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { toErrorObject as toLintErrorObject } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
@@ -17,6 +18,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { applyCliRuntimeRecallTimeoutDefault } from "./config.js";
 import plugin, { testing } from "./index.js";
 import { resolveActiveRecallForRun } from "./recall-state.js";
+import * as transcriptWatch from "./transcript-watch.js";
 
 // Match only lone surrogates so valid supplementary-plane characters remain allowed.
 const UNPAIRED_SURROGATE_RE =
@@ -4602,53 +4604,130 @@ describe("active-memory plugin", () => {
     expectLinesToContain(lines, `Active Memory Debug: ${warning} ${action}`);
   });
 
-  it("uses configured memory evidence from a rotated embedded transcript", async () => {
-    testing.setMinimumTimeoutMsForTests(1);
-    testing.setSetupGraceTimeoutMsForTests(0);
-    registerPluginConfig({
-      timeoutMs: 1_000,
-      toolsAllow: ["memory_get", "memory_search"],
-      logging: true,
-    });
-    const sessionKey = "agent:main:rotated-memory-evidence";
-    seedSession(sessionKey, "s-rotated-memory-evidence", 0);
-    runEmbeddedAgent.mockImplementationOnce(async (params: { sessionFile: string }) => {
-      await writeTranscriptJsonl(params.sessionFile, [
-        {
+  it.each([false, true])(
+    "uses configured memory evidence from a rotated embedded transcript (stale poll: %s)",
+    async (stalePoll) => {
+      testing.setMinimumTimeoutMsForTests(1);
+      testing.setSetupGraceTimeoutMsForTests(0);
+      registerPluginConfig({
+        timeoutMs: 1_000,
+        toolsAllow: ["memory_get", "memory_search"],
+        logging: true,
+      });
+      const sessionKey = "agent:main:rotated-memory-evidence";
+      seedSession(sessionKey, "s-rotated-memory-evidence", 0);
+      const cleanupStarted = createDeferred<void>();
+      const releaseCleanup = createDeferred<void>();
+      const watcherStopped = createDeferred<void>();
+      const staleReadStarted = createDeferred<void>();
+      const releaseStaleRead = createDeferred<void>();
+      if (stalePoll) {
+        const transcriptRuntime = await import("openclaw/plugin-sdk/session-transcript-runtime");
+        const readDelta = transcriptRuntime.readSessionTranscriptRawDelta;
+        let heldRead = false;
+        vi.spyOn(transcriptRuntime, "readSessionTranscriptRawDelta").mockImplementation(
+          async (params) => {
+            const page = await readDelta(params);
+            if (!heldRead && page.kind === "page" && page.events.length > 0) {
+              heldRead = true;
+              staleReadStarted.resolve();
+              await releaseStaleRead.promise;
+            }
+            return page;
+          },
+        );
+      }
+      const cleanup = expectDefined(
+        hoisted.cleanupSessionLifecycleArtifacts.getMockImplementation(),
+        "recall cleanup fixture",
+      );
+      hoisted.cleanupSessionLifecycleArtifacts.mockImplementationOnce(async (params) => {
+        cleanupStarted.resolve();
+        await releaseCleanup.promise;
+        return await cleanup(params);
+      });
+      const watchTerminalMemorySearchResult = transcriptWatch.watchTerminalMemorySearchResult;
+      vi.spyOn(transcriptWatch, "watchTerminalMemorySearchResult").mockImplementation((params) => {
+        const watch = watchTerminalMemorySearchResult(params);
+        return {
+          ...watch,
+          stop() {
+            watch.stop();
+            watcherStopped.resolve();
+          },
+        };
+      });
+      runEmbeddedAgent.mockImplementationOnce(async (params: { sessionFile: string }) => {
+        if (stalePoll) {
+          await writeTranscriptJsonl(params.sessionFile, [
+            {
+              message: {
+                role: "toolResult",
+                toolName: "memory_search",
+                details: { disabled: true, error: "embedding request failed" },
+              },
+            },
+          ]);
+          await staleReadStarted.promise;
+        }
+        const memoryResult = {
           message: {
             role: "toolResult",
             toolName: "memory_get",
             details: { path: "memory/food.md", text: "User usually orders ramen." },
           },
-        },
-      ]);
-      const activeSessionFile = path.join(path.dirname(params.sessionFile), "rotated.jsonl");
-      await writeTranscriptJsonl(activeSessionFile, [
-        {
-          message: {
-            role: "toolResult",
-            toolName: "memory_search",
-            details: {
-              disabled: true,
-              error: "embedding request failed",
+        };
+        if (stalePoll) {
+          await fs.appendFile(params.sessionFile, `${JSON.stringify(memoryResult)}\n`, "utf8");
+        } else {
+          await writeTranscriptJsonl(params.sessionFile, [memoryResult]);
+        }
+        const activeSessionFile = path.join(path.dirname(params.sessionFile), "rotated.jsonl");
+        await writeTranscriptJsonl(activeSessionFile, [
+          {
+            message: {
+              role: "toolResult",
+              toolName: "memory_search",
+              details: {
+                disabled: true,
+                error: "embedding request failed",
+              },
             },
           },
-        },
-      ]);
-      return {
-        payloads: [{ text: "User usually orders ramen." }],
-        meta: { agentMeta: { sessionFile: activeSessionFile } },
-      };
-    });
+        ]);
+        return {
+          payloads: [{ text: "User usually orders ramen." }],
+          meta: { agentMeta: { sessionFile: activeSessionFile } },
+        };
+      });
 
-    const result = await runPromptBuild(
-      { prompt: "what food do i usually order? rotated transcript" },
-      { sessionKey },
-    );
+      const resultPromise = runPromptBuild(
+        { prompt: "what food do i usually order? rotated transcript" },
+        { sessionKey },
+      );
+      try {
+        await cleanupStarted.promise;
+        releaseStaleRead.resolve();
+        // Drain continuations of the old read after execution has completed;
+        // a stopped watcher must not publish that stale unavailable snapshot.
+        await new Promise<void>((resolve) => {
+          setImmediate(resolve);
+        });
+        // The completed run already has evidence; pending cleanup must not
+        // let a later transcript replace that grounded result.
+        await watcherStopped.promise;
+      } finally {
+        releaseStaleRead.resolve();
+        releaseCleanup.resolve();
+      }
+      const result = await resultPromise;
 
-    expectPrependContextContains(result, "User usually orders ramen.");
-    expectLinesToContain(getActiveMemoryLines(sessionKey), "status=ok");
-  });
+      expect(result, JSON.stringify(api.logger.info.mock.calls)).toMatchObject({
+        prependContext: expect.stringContaining("User usually orders ramen."),
+      });
+      expectLinesToContain(getActiveMemoryLines(sessionKey), "status=ok");
+    },
+  );
 
   it("rejects completed output when only a rotated transcript reports unavailable memory", async () => {
     testing.setMinimumTimeoutMsForTests(1);

--- a/extensions/active-memory/recall-run.ts
+++ b/extensions/active-memory/recall-run.ts
@@ -158,6 +158,7 @@ async function runRecallSubagent(params: {
   fastMode?: ActiveMemoryFastMode;
   abortSignal?: AbortSignal;
   onTranscriptSources?: (sources: readonly ActiveMemoryTranscriptSource[]) => void;
+  onEmbeddedRunSettled?: () => void;
 }): Promise<RecallSubagentResult> {
   const workspaceDir = resolveAgentWorkspaceDir(params.runtimeConfig, params.agentId);
   const agentDir = resolveAgentDir(params.runtimeConfig, params.agentId);
@@ -262,56 +263,58 @@ async function runRecallSubagent(params: {
       channelId: params.channelId,
     });
     const embeddedTimeoutMs = params.config.timeoutMs + params.config.setupGraceTimeoutMs;
-    const result = await params.api.runtime.agent.runEmbeddedAgent({
-      sessionId: subagentSessionId,
-      sessionKey: subagentSessionKey,
-      agentId: params.agentId,
-      sessionTarget: {
-        agentId: params.agentId,
+    const result = await params.api.runtime.agent
+      .runEmbeddedAgent({
         sessionId: subagentSessionId,
         sessionKey: subagentSessionKey,
-        storePath,
-      },
-      messageChannel,
-      messageProvider,
-      sessionFile: runtimeSessionFile,
-      workspaceDir,
-      agentDir,
-      config: params.runtimeConfig,
-      prompt,
-      provider: modelRef.provider,
-      model: modelRef.model,
-      lane: ACTIVE_MEMORY_RECALL_LANE,
-      timeoutMs: embeddedTimeoutMs,
-      runId: subagentSessionId,
-      trigger: "manual",
-      conversationRecall: params.conversationRecall,
-      toolsAllow: [...params.config.toolsAllow],
-      disableMessageTool: true,
-      allowGatewaySubagentBinding: true,
-      bootstrapContextMode: "lightweight",
-      verboseLevel: "off",
-      thinkLevel: params.config.thinking,
-      fastMode: params.fastMode,
-      reasoningLevel: "off",
-      silentExpected: true,
-      authProfileFailurePolicy: "local",
-      // On subscription-only claude-cli setups, direct provider API calls
-      // either fail with a billing rejection or silently draw metered extra
-      // usage; route recall through the CLI backend so it runs on plan
-      // limits like the session's main turns.
-      cliBackendDispatch: "subscription-auth",
-      cleanupBundleMcpOnRunEnd: true,
-      abortSignal: params.abortSignal,
-      onAgentToolResult: (event) => {
-        const evidence = readMemoryToolResultEvidence({
-          ...event,
-          toolsAllow: params.config.toolsAllow,
-        });
-        harnessHasUsableMemoryResult ||= evidence.hasUsableMemoryResult;
-        harnessHasUnavailableMemorySearchResult ||= evidence.hasUnavailableMemorySearchResult;
-      },
-    });
+        agentId: params.agentId,
+        sessionTarget: {
+          agentId: params.agentId,
+          sessionId: subagentSessionId,
+          sessionKey: subagentSessionKey,
+          storePath,
+        },
+        messageChannel,
+        messageProvider,
+        sessionFile: runtimeSessionFile,
+        workspaceDir,
+        agentDir,
+        config: params.runtimeConfig,
+        prompt,
+        provider: modelRef.provider,
+        model: modelRef.model,
+        lane: ACTIVE_MEMORY_RECALL_LANE,
+        timeoutMs: embeddedTimeoutMs,
+        runId: subagentSessionId,
+        trigger: "manual",
+        conversationRecall: params.conversationRecall,
+        toolsAllow: [...params.config.toolsAllow],
+        disableMessageTool: true,
+        allowGatewaySubagentBinding: true,
+        bootstrapContextMode: "lightweight",
+        verboseLevel: "off",
+        thinkLevel: params.config.thinking,
+        fastMode: params.fastMode,
+        reasoningLevel: "off",
+        silentExpected: true,
+        authProfileFailurePolicy: "local",
+        // On subscription-only claude-cli setups, direct provider API calls
+        // either fail with a billing rejection or silently draw metered extra
+        // usage; route recall through the CLI backend so it runs on plan
+        // limits like the session's main turns.
+        cliBackendDispatch: "subscription-auth",
+        cleanupBundleMcpOnRunEnd: true,
+        abortSignal: params.abortSignal,
+        onAgentToolResult: (event) => {
+          const evidence = readMemoryToolResultEvidence({
+            ...event,
+            toolsAllow: params.config.toolsAllow,
+          });
+          harnessHasUsableMemoryResult ||= evidence.hasUsableMemoryResult;
+          harnessHasUnavailableMemorySearchResult ||= evidence.hasUnavailableMemorySearchResult;
+        },
+      })
+      .finally(params.onEmbeddedRunSettled);
     const activeSessionFile =
       readActiveMemorySessionFileFromRunResult(result) ?? runtimeSessionFile;
     transcriptSources = collectActiveMemoryTranscriptSources({

--- a/extensions/active-memory/recall.ts
+++ b/extensions/active-memory/recall.ts
@@ -279,6 +279,9 @@ async function resolveActiveRecall(
       onTranscriptSources: (sources) => {
         transcriptSources = sources;
       },
+      // Completed execution owns the result; transcript recovery and cleanup
+      // must not let a later poll replace it with terminal unavailability.
+      onEmbeddedRunSettled: () => terminalMemorySearchWatch?.stop(),
     });
     terminalMemorySearchWatch = watchTerminalMemorySearchResult({
       getTranscriptSources: () => transcriptSources,

--- a/extensions/active-memory/transcript-watch.ts
+++ b/extensions/active-memory/transcript-watch.ts
@@ -195,6 +195,10 @@ function watchTerminalMemorySearchResult(params: {
         undefined,
         params.toolsAllow,
       );
+      // Execution can settle while this transcript read is still in flight.
+      if (stopped || params.abortSignal.aborted) {
+        return;
+      }
       if (result) {
         finish(result);
         return;

--- a/extensions/qa-lab/src/suite-runtime-agent-process.ts
+++ b/extensions/qa-lab/src/suite-runtime-agent-process.ts
@@ -391,6 +391,7 @@ async function runAgentPrompt(
     threadId?: string;
     provider?: string;
     model?: string;
+    taskTracking?: boolean;
     timeoutMs?: number;
     transcriptToolName?: string;
     requireSuccessfulTranscriptToolResult?: boolean;

--- a/qa/scenarios/memory/active-memory-cold-first-turn-trigger-recall.yaml
+++ b/qa/scenarios/memory/active-memory-cold-first-turn-trigger-recall.yaml
@@ -13,11 +13,6 @@ scenario:
   gatewayConfigPatch:
     session:
       dmScope: per-channel-peer
-    tools:
-      toolsBySender:
-        "id:qa-active-memory-cold-user":
-          deny:
-            - group:memory
     plugins:
       entries:
         active-memory:

--- a/qa/scenarios/memory/active-memory-preprompt-recall.yaml
+++ b/qa/scenarios/memory/active-memory-preprompt-recall.yaml
@@ -10,7 +10,7 @@ scenario:
       - session-memory.active-memory-memory-recall
     secondary:
       - session-memory.memory-recall
-  objective: Verify one ordered Active Memory search/get chain injects a memory-only preference into the agent-runtime turn and records the resulting reply in agent history, while the same turn stays unresolved when the plugin is off.
+  objective: Verify one ordered Active Memory search/get chain injects a memory-only preference into a persistent chat turn and records the resulting reply in chat history, while the same turn stays unresolved when the plugin is off.
   plugins:
     - active-memory
   gatewayConfigPatch:
@@ -33,10 +33,10 @@ scenario:
             timeoutMs: 15000
             setupGraceTimeoutMs: 30000
   successCriteria:
-    - With Active Memory off after doctor migrates the legacy session toggle, agent history excludes the recalled fact and the exact one-request trace has no helper, injected context, or planned tool.
+    - With Active Memory off after doctor migrates the legacy session toggle, chat history excludes the recalled fact and the exact one-request trace has no helper, injected context, or planned tool.
     - With Active Memory on, the exact four-request trace links memory_search and memory_get call IDs to the expected memory path and text before one main request.
     - The main request follows the helper chain, contains the user marker, Active Memory envelope, and recalled fact, and plans no tool.
-    - Agent history records the recalled preference, Active Memory debug evidence, and no transient helper session remains.
+    - Chat history records the recalled preference, Active Memory debug evidence, and no transient helper session remains.
   docsRefs:
     - docs/concepts/active-memory.md
     - docs/concepts/memory-search.md
@@ -47,7 +47,7 @@ scenario:
     - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
-    summary: Verify agent-runtime history and an exact mock request trace distinguish a disabled Active Memory turn from one complete memory_search and memory_get recall chain.
+    summary: Verify persistent-chat history and an exact mock request trace distinguish a disabled Active Memory turn from one complete memory_search and memory_get recall chain.
     channel: qa-channel
     providerMode: mock-openai
     suiteIsolation: isolated
@@ -153,6 +153,7 @@ flow:
             - ref: env
             - sessionKey:
                 ref: baselineSessionKey
+              taskTracking: false
               to:
                 expr: "`dm:${config.baselineConversationId}`"
               message:
@@ -204,6 +205,7 @@ flow:
             - ref: env
             - sessionKey:
                 ref: activeSessionKey
+              taskTracking: false
               to:
                 expr: "`dm:${config.activeConversationId}`"
               message:
@@ -226,7 +228,7 @@ flow:
         - assert:
             expr: "activeLower.includes(normalizeLowercaseStringOrEmpty(config.expectedFact))"
             message:
-              expr: "`active agent history missed the hidden preference: ${activeReply.text}`"
+              expr: "`active chat history missed the hidden preference: ${activeReply.text}`"
         - call: waitForCondition
           saveAs: activeSessionEntry
           args:

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.loop.test.ts
@@ -181,6 +181,20 @@ describe("embedded run retry dispatch", () => {
     },
   );
 
+  it.each([undefined, "current-turn-tool-policy"])(
+    "preserves the supplied turn tool authority at dispatch (%s)",
+    async (toolAuthorityFingerprint) => {
+      const input = makeDispatchInput({}, createEmbeddedRunReplayState());
+      input.params.toolAuthorityFingerprint = toolAuthorityFingerprint;
+
+      await dispatchEmbeddedRunAttempt(input);
+
+      expect(mocks.runAttempt.mock.calls[0]?.[0].toolAuthorityFingerprint).toBe(
+        toolAuthorityFingerprint,
+      );
+    },
+  );
+
   it.each([true, false])(
     "settles accepted spawns before a late post-compaction abort (yielded: %s)",
     async (yieldDetected) => {

--- a/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
+++ b/src/agents/embedded-agent-runner/run/run-attempt-dispatch.ts
@@ -488,6 +488,8 @@ export async function dispatchEmbeddedRunAttempt(input: {
     scheduledRuntimeAuthorityRecoveryRequired: params.scheduledRuntimeAuthorityRecoveryRequired,
     toolsAllow: params.toolsAllow,
     toolExecutionAllow: params.toolExecutionAllow,
+    // Authorized prompt enrichment needs the exact prepared turn policy identity.
+    toolAuthorityFingerprint: params.toolAuthorityFingerprint,
     sessionPersistence: params.sessionPersistence,
     ...(params.systemAgentTool ? { systemAgentTool: params.systemAgentTool } : {}),
     cleanupBundleMcpOnRunEnd: params.cleanupBundleMcpOnRunEnd,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users with Active Memory enabled would receive replies without recalled context on supported interactive turns. Also fixes completed, grounded recall being discarded when transcript rotation or an in-flight transcript poll overlaps result cleanup.

Both defects were found while retesting current source: a deterministic transcript-lifecycle regression reproduced the cleanup race, and real Gateway scenarios exposed the missing interactive recall path.

## Why This Change Was Made

Keep each invariant at its owner. Attempt dispatch now preserves the exact tool-authority fingerprint already prepared for the turn; authorized prompt enrichment still requires the existing finalized tool surface and active host. The recall owner stops its transcript watcher as soon as embedded execution settles, before final scans and cleanup. A poll that was already awaiting a read rechecks closure before publishing its result.

The QA scenarios also needed two corrections to match existing documented behavior: persistent-chat recall now uses the established interactive `chat.send` path instead of generic agent RPC, and the cold-turn fixture no longer denies the memory tools whose authority it expects recall to use. All fact, envelope, request-count, call-ID causality, outbound, and cleanup assertions remain intact. Denied-tool and closed-host coverage remains in the owner/sibling tests.

No new configuration, public API, schema, persistence/retention policy, deadline, fallback, or authorization rule. Production changes are net +12 lines, including the two ownership comments; tests and QA support are net +91. The promise-chain formatting accounts for most replaced production lines; there is no parallel execution or cleanup path.

Provenance: the watcher lifetime and missing post-read closure check trace to [#76183](https://github.com/openclaw/openclaw/pull/76183), commit [`ae82a39150f9`](https://github.com/openclaw/openclaw/commit/ae82a39150f9e02668ea34ca5955ccfc9bd67b70), merged May 2, 2026. That PR was authored and merged by ClawSweeper; [@Takhoffman triggered automerge](https://github.com/openclaw/openclaw/pull/76183#issuecomment-4364800419). Subsequent transcript changes carried that lifecycle forward. The missing dispatch field became behaviorally significant when [#126482](https://github.com/openclaw/openclaw/pull/126482), authored and merged by @joshavant on August 20, 2026 UTC, correctly required prepared authority for automatic recall but did not forward that existing field through the attempt projection. This PR preserves that authority requirement.

## User Impact

Enabled, authorized interactive turns receive recalled context again. A completed recall keeps its grounded summary even when transcript rotation and cleanup overlap a poll. Disabled recall, denied tools, closed turns, raw probes, and settled-turn finalization keep their existing boundaries.

## Evidence

- Lifecycle regression: both controlled completion/cleanup interleavings fail before the repair and pass afterward. A stop-only negative control still fails the stale in-flight read case, demonstrating why the post-read closure check is necessary.
- Actual dispatch regression: the supplied fingerprint is lost before the repair and preserved afterward; absent input remains absent. Final dispatch file: 9/9 passed.
- Final owner/sibling validation on `eb880e0ea0c0eb80ff7ae9c6248f87d890bc81f3` (base `392018c285556a006198d2f89d70219f9bf9b5f3`): **462/462 tests across 13 files**, including all 400 Active Memory tests plus dispatcher, finalized tool-policy, raw/settled-turn, shared-harness, and closed-authority coverage. QA scenario/catalog/helper coverage on the pre-rebase patch: **134/134 tests across four files**; all nine patched files remained byte-identical through the rebase.
- Full changed-file gate on that same commit passed all selected lanes: core/UI/plugin/test/script type checks, repository guards, dead-export scans, lint, and zero runtime value import cycles. Private-QA build and the final source rebuild passed. Independent Codex static review reported no findings; subsequent changes only removed the changelog bullet to follow release-only policy and mechanically rebased the nine unchanged source/test/QA files.
- Real isolated Gateway with local mock OpenAI and QA-channel: **2 passed, 0 failed, 0 skipped**. No live provider credentials or operator state were used. The persistent-chat scenario proved one disabled-baseline request versus the enabled `memory_search` → matching result → `memory_get` → matching result → main-request chain, grounded context, status `ok`, and transient-session cleanup. The cold first turn proved exactly one visible reply and one main request containing the fact/envelope, with no helper request. Both replies included the expected remembered preference. All owned listener ports closed afterward.

```sh
OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build
pnpm openclaw qa suite --provider-mode mock-openai \
  --scenario active-memory-preprompt-recall \
  --scenario active-memory-cold-first-turn-trigger-recall \
  --concurrency 1 \
  --output-dir .artifacts/qa-e2e/active-memory-retest-rebased-20260827
```

Recorded Gateway verdict:

```json
{"providerMode":"mock-openai","channel":"qa-channel","counts":{"total":2,"passed":2,"failed":0,"skipped":0}}
```

Validation caveat and named follow-up: an earlier same-order run passed all 62 sibling tests but failed six existing Active Memory timeout/reset cases (394/400). An earlier owned-dependency run also hit one fixture-reset `ENOTEMPTY`. Those cases combine real filesystem/SQLite work with 1–100 ms test deadlines or can race late cleanup against the next fixture reset; several exact failure statuses were not retained by their mocked loggers, so they are not classified as fixed. After source-level diagnosis and the final gate, **one unchanged replay of the same complete command and order passed all 462 tests**. The fresh post-rebase run also passed all 462 on its first attempt. No timeouts, assertions, clocks, retries, or production behavior were changed to obtain those results. Follow-up: **Active Memory timeout fixtures—real-I/O deadline sensitivity and late finalization versus shared-state reset**.

Runtime scope: native evidence records Node 24.20.0, and the gate's live executable was verified as Node 24.20.0. The completed owner/sibling run used the normal shell path without a separate per-run version receipt; no retrospective version guarantee is claimed for it.

Native provider/channel integrations beyond the local mock Gateway lane were not exercised. Exact PR-head CI remains a separate pre-merge gate.
