### PR TITLE
fix(imap): stop reporting strength before mail authentication

### DIFF
--- a/docs/automation/imap.md
+++ b/docs/automation/imap.md
@@ -91,13 +91,14 @@ The plugin checks the parsed `From` address against `allowedSenders` before any 
 | A configured, trusted Authentication-Results server reports `dmarc=pass` | `asserted`        | No; requires `acceptTrustedAuthservId: true` and `min: "asserted"` |
 | SPF alone passes or an untrusted server asserts a result                 | `unverified`      | No; requires `min: "unverified"`                                   |
 | Unproven ownership, including no evidence or a DMARC `temperror` result  | `unverified`      | No; requires `min: "unverified"` or lower                          |
-| A matching sender-specific plus-address token                            | `mutable`         | Yes, only for the named allowlisted sender                         |
 
 The shared identifier-authentication ladder is `verified > asserted > unverified > mutable`.
 `mutable` denotes a changeable or shared alias and is never produced by the IMAP
-authentication mapper. The gate still records it for the separate token path and
-early rejections before authentication. `min: "mutable"` remains valid and accepts
-any classified strength; it does not bypass the sender allowlist or freshness checks.
+authentication mapper. A matching sender-bound token admits mail before authentication
+and records `gate=token`, without a strength. Rejections before authentication record
+`gate=invalid-from`, `gate=sender-not-allowed`, or `gate=message-too-old`, also without
+a strength. `min: "mutable"` remains valid and accepts any classified strength; lowering
+the minimum does not bypass the sender allowlist or freshness checks.
 
 The default minimum remains `verified`; `asserted` and `verified` admission are
 unchanged. An explicit `min: "unverified"` now admits no-evidence mail and DMARC
@@ -117,7 +118,7 @@ Configure a sender-bound token only when an allowlisted sender cannot produce us
 }
 ```
 
-Send that source to `reader+<long-random-token>@example.com`. The token never expands the account allowlist and never grants additional agent tools or workspace access. Lower authentication thresholds and trusted-header overrides are operator-owned security relaxations.
+Send that source to `reader+<long-random-token>@example.com`. After validating `From` and checking the account allowlist, the plugin checks sender-bound tokens before freshness or mail authentication. A matching token bypasses both the 48-hour freshness check and mail authentication; without one, messages whose IMAP internal date is more than 48 hours old are rejected before authentication. The token never expands the account allowlist and never grants additional agent tools or workspace access. Lower authentication thresholds and trusted-header overrides are operator-owned security relaxations.
 
 ## Verify the security boundary
 

--- a/extensions/imap/src/sender-gate.test.ts
+++ b/extensions/imap/src/sender-gate.test.ts
@@ -34,17 +34,22 @@ describe("IMAP sender admission", () => {
     ["trusted@evil.example", ["trusted@example.com"], false],
     ["Trusted@example.com", ["trusted@example.com"], false],
   ])("matches sender %s against the actual addr-spec", async (sender, entries, accepted) => {
-    const mail = await message([`From: ${sender}`, "To: reader@example.com"]);
+    const mail = await message([`From: ${sender}`, "To: reader+secret-token@example.com"]);
     const authenticator = vi.fn(async () => createImapAuthResult("pass"));
     const verdict = await evaluateImapSender({
       ...mail,
-      account: account({ allowedSenders: entries }),
+      account: account({
+        allowedSenders: entries,
+        addressTokens: [{ token: "secret-token", senders: [sender] }],
+      }),
       authenticator,
     });
     expect(verdict.accepted).toBe(accepted);
     if (!accepted) {
       expect(verdict.reason).toBe("sender-not-allowed");
     }
+    expect(authenticator).not.toHaveBeenCalled();
+    expect(verdict).not.toHaveProperty("strength");
   });
 
   it("rejects a spoofed display name and ignores Reply-To", async () => {
@@ -68,9 +73,31 @@ describe("IMAP sender admission", () => {
     ["From: attacker@evil.example", "From: trusted@example.com"],
   ])("rejects multi-From messages before authentication", async (...headers) => {
     const mail = await message(headers);
-    await expect(evaluateImapSender({ ...mail, account: account() })).resolves.toMatchObject({
+    const authenticator = vi.fn(async () => createImapAuthResult("pass"));
+    const verdict = await evaluateImapSender({ ...mail, account: account(), authenticator });
+    expect(authenticator).not.toHaveBeenCalled();
+    expect(verdict).toStrictEqual({
       accepted: false,
       reason: "invalid-from",
+      transient: false,
+    });
+  });
+
+  it("rejects stale mail before authentication even at the weakest floor", async () => {
+    const mail = await message(["From: trusted@example.com"]);
+    const authenticator = vi.fn(async () => createImapAuthResult("pass"));
+    const verdict = await evaluateImapSender({
+      ...mail,
+      internalDate: new Date(Date.now() - 72 * 60 * 60 * 1_000),
+      account: account({ senderAuth: { min: "mutable" } }),
+      authenticator,
+    });
+    expect(authenticator).not.toHaveBeenCalled();
+    expect(verdict).toStrictEqual({
+      accepted: false,
+      sender: "trusted@example.com",
+      reason: "message-too-old",
+      transient: false,
     });
   });
 
@@ -189,7 +216,7 @@ describe("IMAP sender admission", () => {
     });
   });
 
-  it("binds plus-address tokens to an already-allowed sender", async () => {
+  it("admits stale mail with a sender-bound token without evaluating authentication", async () => {
     const configured = account({
       addressTokens: [{ token: "secret-token", senders: ["trusted@example.com"] }],
     });
@@ -197,19 +224,38 @@ describe("IMAP sender admission", () => {
       "From: trusted@example.com",
       "To: reader+secret-token@example.com",
     ]);
-    await expect(evaluateImapSender({ ...accepted, account: configured })).resolves.toMatchObject({
+    const authenticator = vi.fn(async () => createImapAuthResult("none"));
+    const verdict = await evaluateImapSender({
+      ...accepted,
+      internalDate: new Date(Date.now() - 72 * 60 * 60 * 1_000),
+      account: configured,
+      authenticator,
+    });
+    expect(authenticator).not.toHaveBeenCalled();
+    expect(verdict).toStrictEqual({
       accepted: true,
-      strength: "mutable",
+      sender: "trusted@example.com",
       reason: "token",
     });
     const rejected = await message([
       "From: attacker@evil.example",
       "To: reader+secret-token@example.com",
     ]);
-    await expect(evaluateImapSender({ ...rejected, account: configured })).resolves.toMatchObject({
+    await expect(
+      evaluateImapSender({
+        ...rejected,
+        account: account({
+          allowedSenders: ["@evil.example"],
+          addressTokens: configured.addressTokens,
+        }),
+        authenticator,
+      }),
+    ).resolves.toMatchObject({
       accepted: false,
-      reason: "sender-not-allowed",
+      strength: "unverified",
+      reason: "dmarc-none",
     });
+    expect(authenticator).toHaveBeenCalledTimes(1);
   });
 
   it("uses only an explicitly trusted Authentication-Results header when DNS verification fails", async () => {

--- a/extensions/imap/src/sender-gate.ts
+++ b/extensions/imap/src/sender-gate.ts
@@ -11,15 +11,28 @@ import type { ImapAccountConfig } from "./config.js";
 const AUTH_FRESHNESS_MS = 48 * 60 * 60 * 1_000;
 const DNS_TIMEOUT_MS = 5_000;
 
-export type SenderGateVerdict =
-  | { accepted: true; sender: string; strength: IdentifierAuthentication; reason: string }
+type ImapAuthEvidence = {
+  strength: IdentifierAuthentication;
+  reason:
+    | `dmarc-${Exclude<AuthenticateResult["dmarc"], false>["status"]["result"]}`
+    | "dkim-unsigned-body"
+    | "trusted-authserv-dmarc-pass"
+    | "unverified-authentication"
+    | "authentication-temperror";
+};
+
+type SenderGateVerdict =
+  | { accepted: true; sender: string; reason: "token" }
   | {
       accepted: false;
       sender?: string;
-      strength: IdentifierAuthentication;
-      reason: string;
-      transient: boolean;
-    };
+      reason: "invalid-from" | "sender-not-allowed" | "message-too-old";
+      transient: false;
+    }
+  | (ImapAuthEvidence & { sender: string } & (
+        | { accepted: true }
+        | { accepted: false; transient: boolean }
+      ));
 
 export type MailAuthenticator = typeof authenticate;
 
@@ -119,7 +132,7 @@ function mapImapAuthStrength(
   result: AuthenticateResult | undefined,
   headers: readonly AuthenticationHeader[],
   account: ImapAccountConfig,
-): { strength: IdentifierAuthentication; reason: string; transient: boolean } {
+): ImapAuthEvidence & { transient: boolean } {
   const dmarc = result?.dmarc && result.dmarc.status.result;
   // mailauth omits alignment when no DMARC policy exists or its DNS lookup fails.
   if (result?.dmarc && result.dmarc.alignment?.dkim.underSized) {
@@ -163,29 +176,17 @@ export async function evaluateImapSender(params: {
   const fromValues = params.mail.from?.value ?? [];
   const fromHeaders = params.mail.headerLines.filter(({ key }) => key.toLowerCase() === "from");
   if (fromHeaders.length !== 1 || fromValues.length !== 1 || !fromValues[0]?.address) {
-    return { accepted: false, strength: "mutable", reason: "invalid-from", transient: false };
+    return { accepted: false, reason: "invalid-from", transient: false };
   }
   const sender = fromValues[0].address;
   if (!matchesImapSender(sender, params.account.allowedSenders)) {
-    return {
-      accepted: false,
-      sender,
-      strength: "mutable",
-      reason: "sender-not-allowed",
-      transient: false,
-    };
+    return { accepted: false, sender, reason: "sender-not-allowed", transient: false };
   }
   if (matchingSenderToken(params.mail, sender, params.account)) {
-    return { accepted: true, sender, strength: "mutable", reason: "token" };
+    return { accepted: true, sender, reason: "token" };
   }
   if (Date.now() - params.internalDate.getTime() > AUTH_FRESHNESS_MS) {
-    return {
-      accepted: false,
-      sender,
-      strength: "mutable",
-      reason: "message-too-old",
-      transient: false,
-    };
+    return { accepted: false, sender, reason: "message-too-old", transient: false };
   }
   let result: AuthenticateResult | undefined;
   try {

--- a/extensions/imap/src/watcher.test.ts
+++ b/extensions/imap/src/watcher.test.ts
@@ -190,28 +190,75 @@ async function startWatcher(
 }
 
 describe("IMAP watcher protocol boundary", () => {
-  it("dispatches no-evidence mail at an explicit unverified floor", async () => {
-    const { server, state, context, authenticator, dispatchHookAgentTurn } = await startWatcher({
-      account: {
-        senderAuth: { min: "unverified", trustedAuthservIds: [], acceptTrustedAuthservId: false },
-      },
-    });
-    await vi.waitFor(async () =>
-      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
-    );
-    authenticator.mockResolvedValue(createImapAuthResult("none"));
-    server.append(
-      "From: trusted@example.com\r\nSubject: Unproven\r\n\r\nNo authentication evidence",
-    );
-    await vi.waitFor(async () =>
-      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 2 }),
-    );
-    expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(1);
-    expect(context.logger.info).toHaveBeenCalledWith(
-      expect.stringContaining("strength=unverified run=mail-run"),
-    );
-    expect(await state.skips.lookup("inbox:dmarc-none")).toBeUndefined();
-  });
+  it.each([
+    ["unverified", "none", "", "strength=unverified"],
+    ["verified", "pass", "", "strength=verified"],
+    [
+      "asserted",
+      "none",
+      "Authentication-Results: mx.example.com; dmarc=pass\r\n",
+      "strength=asserted",
+    ],
+    ["token", "none", "To: reader+secret-token@example.com\r\n", "gate=token"],
+  ] as const)(
+    "dispatches %s mail with the actual admission evidence",
+    async (gate, dmarc, headers, log) => {
+      const { server, state, context, authenticator, dispatchHookAgentTurn } = await startWatcher({
+        account: {
+          senderAuth: {
+            min: gate === "token" ? "verified" : gate,
+            trustedAuthservIds: ["mx.example.com"],
+            acceptTrustedAuthservId: gate === "asserted",
+          },
+          addressTokens: [{ token: "secret-token", senders: ["trusted@example.com"] }],
+        },
+      });
+      await vi.waitFor(async () =>
+        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
+      );
+      authenticator.mockResolvedValue(createImapAuthResult(dmarc));
+      server.append(
+        `From: trusted@example.com\r\n${headers}Subject: Admission\r\n\r\nEmail content`,
+      );
+      await vi.waitFor(async () =>
+        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 2 }),
+      );
+      expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(1);
+      expect(authenticator).toHaveBeenCalledTimes(gate === "token" ? 0 : 1);
+      expect(context.logger.info).toHaveBeenCalledWith(
+        `imap: account=inbox uid=2 domain=example.com ${log} run=mail-run`,
+      );
+      expect(await state.skips.lookup("inbox:dmarc-none")).toBeUndefined();
+    },
+  );
+
+  it.each([
+    ["From: trusted@example.com, attacker@evil.example", "invalid-from", "unknown"],
+    ["From: attacker@evil.example", "sender-not-allowed", "evil.example"],
+  ])(
+    "records pre-auth rejection for %s without claiming strength",
+    async (from, reason, domain) => {
+      const { server, state, context, authenticator, dispatchHookAgentTurn } = await startWatcher({
+        account: {
+          addressTokens: [{ token: "secret-token", senders: ["@evil.example"] }],
+        },
+      });
+      await vi.waitFor(async () =>
+        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 }),
+      );
+      server.append(`${from}\r\nTo: reader+secret-token@example.com\r\n\r\nRejected mail`);
+      await vi.waitFor(async () =>
+        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 2 }),
+      );
+      expect(authenticator).not.toHaveBeenCalled();
+      expect(dispatchHookAgentTurn).not.toHaveBeenCalled();
+      expect(context.logger.warn).toHaveBeenCalledWith(
+        `imap: account=inbox uid=2 domain=${domain} gate=${reason}`,
+      );
+      expect(await state.skips.lookup(`inbox:${reason}`)).toEqual({ count: 1 });
+      expect(await state.claims.lookup("attempt:inbox:17:2")).toBeUndefined();
+    },
+  );
 
   it.each(["rejected admission", "throwing admission", "transient authentication"] as const)(
     "retries %s without waiting for another email",

--- a/extensions/imap/src/watcher.ts
+++ b/extensions/imap/src/watcher.ts
@@ -362,8 +362,9 @@ export class ImapAccountWatcher {
       if (mail.messageId) {
         await rememberImapMessage(state, accountId, mail.messageId);
       }
+      const gate = verdict.reason === "token" ? "gate=token" : `strength=${verdict.strength}`;
       this.options.context.logger.info(
-        `imap: account=${accountId} uid=${message.uid} domain=${senderDomain(verdict.sender)} strength=${verdict.strength} run=${result.runId}`,
+        `imap: account=${accountId} uid=${message.uid} domain=${senderDomain(verdict.sender)} ${gate} run=${result.runId}`,
       );
       return true;
     }


### PR DESCRIPTION
Related: #131178 (IMAP adoption of the core identifier-authentication scale), #130230 (IMAP email trigger), and [accepted RFC 0028](https://github.com/openclaw/rfcs/blob/main/rfcs/0028-channel-agnostic-sender-authentication-strength.md).

## What Problem This Solves

Fixes an issue where IMAP operators would see `strength=mutable` for sender-bound token admissions even though mail authentication was never evaluated. The same fabricated strength was attached to early `invalid-from`, `sender-not-allowed`, and `message-too-old` verdicts. `mutable` means a changeable/shared alias, not “not applicable.” This completes the precise pre-auth result-shape follow-up named in #131178.

## Why This Change Was Made

The plugin-owned verdict required strength on every path. Replace that requirement with closed pre-auth reason variants, and reserve strength for evaluated mail-authentication evidence. The watcher narrows the actual verdict: token admissions log `gate=token`; authenticated admissions retain `strength=...`. Authentication reasons are also closed codes derived from the mailauth contract, and the unused verdict type export is removed.

This is the owner-boundary fix, not a logging-only workaround or an optional-strength field. It reuses the core scale and comparator; no new dependency, SDK surface, config, persistence, or compatibility shim. IMAP is not in the stable release line. Production LOC: **+26/-24 (net +2)**, paying for the closed result contract while deleting all four fabricated-strength return paths. Tests: **+123/-30 (net +93)**; docs: **+6/-5**.

## User Impact

Diagnostics now describe what was evaluated. No admission, retry, trusted-header, allowlist, or freshness-policy change. A sender-bound token still requires a valid allowlisted From address and still precedes the 48-hour freshness check. The [IMAP guide](https://docs.openclaw.ai/automation/imap) removes the token from the strength ladder and documents this existing ordering explicitly. Lowering the strength minimum still cannot bypass allowlisting or freshness.

## Evidence

- **Pre-fix reproduction:** `node scripts/run-vitest.mjs extensions/imap` failed 9 assertions against unchanged production (36 passed): token and all early rejection shapes contained `mutable`, and the real watcher emitted `strength=mutable` for a token admission.
- **After repair:** the same command passes **45/45 tests**. Regressions check actual strength-property absence, no authenticator call on pre-auth outcomes, sender-bound token enforcement, allowlisting, stale-mail rejection even at the weakest floor, and token-before-freshness ordering.
- **Operator-log boundary:** a loopback TCP IMAP server drives real ImapFlow, MIME parsing, the sender gate, watcher, and log generation. Token admission logs `gate=token`; verified/asserted/unverified admissions retain their strengths; invalid/disallowed senders are skipped with their exact reasons and no auth call or retry claim. The authenticator, Gateway dispatch, and state store are controlled test doubles. This is protocol-boundary proof, not a live mailbox or model run; no external API behavior changes.
- `node scripts/check-changed.mjs .` passes the broad all-lanes gate: formatting, all production/test typechecks, lint, guards, and zero runtime import cycles. The exact scoped `node scripts/check-changed.mjs` also completed with **exit 0**, including all selected guards and zero runtime import cycles.
- Independent structured Codex autoreview: clean, no accepted/actionable findings. Lead review also checked the full producer/caller flow, existing tests, sibling authenticated outcomes, config/state boundaries, RFC semantics, and installed mailauth `lib/mailauth.js`, `lib/dmarc/verify.js`, and `index.d.ts` contracts.
- Provenance: the required-strength pre-auth returns originated in #130230, commit `87b56458a1dd621c6a2463e74a8ca91da9295e3c` (2026-08-26), authored and merged by @steipete; #131178 deliberately left this follow-up. No stable tag contains the introducing commit in the checked release history.

- **Exact-head CI:** [CI run 33129299194](https://github.com/openclaw/openclaw/actions/runs/33129299194) completed successfully at `ea012b594de0408b47203d98312352969084a304`, including `openclaw/ci-gate`; no failing or pending jobs. Native hosted-gate verification also confirmed [Workflow Sanity 33129282228](https://github.com/openclaw/openclaw/actions/runs/33129282228).
- **ClawSweeper follow-through:** [latest review](https://github.com/openclaw/openclaw/pull/131304#issuecomment-5446959179) has no code/security findings. Its rank-up move and stale CI concern are satisfied by the completed exact-head run. Its missing dependency-inspection evidence is supplied by direct inspection of installed `mailauth` 5.0.2: `lib/mailauth.js` returns a DMARC result or `false`; `lib/dmarc/verify.js:57` returns `none`/`temperror` without alignment; `index.d.ts:148` defines the closed status union used through `AuthenticateResult` at line 541. The maintainer approved this exact patch for landing.
- **Bot proof limit:** ClawSweeper's `expect_output` stopped waiting for `Test Files` after 30 seconds, before any test verdict. That attempt is not claimed as passing. The completed local run of the same command passed all 45 tests in 42.91 seconds; exact-head hosted CI is also green. No timeout or test assertion was weakened.
- **Native preparation:** `scripts/pr review-init 131304`, main/PR checkout review, artifact initialization and validation, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 131304` succeeded. The head stayed unchanged; preparation reused hosted evidence and skipped pushing because the remote already matched. No source changes, branch rewrite, new Testbox allocation, or gate bypass.

AI-assisted; reviewed and validated against the actual owner boundary.
