### PR TITLE
fix(plugins): keep SecretRef configurations loadable

### DIFF
--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -855,6 +855,8 @@ Each `dangerousFlags` entry supports:
 | `bundledDefaultEnabled` | No       | `boolean`  | Override bundled-plugin default enablement when deciding whether this SecretRef surface is active. Use this when the plugin is bundled but the surface should stay inactive until explicitly enabled in config.                                                                                                                                            |
 | `paths`                 | Yes      | `object[]` | Secret-shaped config paths, each with `path` (dot-separated, relative to `plugins.entries.<id>.config`, supports `*` wildcards), optional `expected` (currently only `"string"`), and optional `ownerKind` (currently only `"route"`). A declared owner isolates only that exact matched path when resolution fails; its owner id is the full config path. |
 
+For plugins declaring `secretInputs`, `configSchema` validates the pre-resolution source config paired with the runtime config. A valid SecretRef is not rejected because its resolved credential is a string with a different shape. Invalid plaintext source values still fail validation. Runtime loading, CLI registration, and root command discovery use the same rule; plugins receive resolved values with defaults selected from the source config, without changing either input.
+
 Concrete paths preserve literal record keys and array indices: `headers["X.Trace"]` remains distinct from `headers.X.Trace`, and record key `["0"]` remains distinct from array index `[0]`. Plugin IDs containing dots are quoted the same way, such as `plugins.entries["example.plugin"].config.headers["X.Trace"]`.
 
 ## mediaUnderstandingProviderMetadata reference

--- a/src/plugins/cli-root-descriptors.ts
+++ b/src/plugins/cli-root-descriptors.ts
@@ -37,6 +37,7 @@ export async function getPluginCliCommandDescriptors(
     let selectedMemoryPluginId: string | null = null;
     const memorySlot = context.config.plugins?.slots?.memory;
     const normalizedConfig = normalizePluginsConfig(context.config.plugins);
+    const sourceConfig = normalizePluginsConfig(context.activationSourceConfig.plugins);
 
     for (const plugin of snapshot.plugins) {
       if (seenPluginIds.has(plugin.id)) {
@@ -52,6 +53,9 @@ export async function getPluginCliCommandDescriptors(
           schema: plugin.configSchema,
           cacheKey: plugin.schemaCacheKey,
           value: pluginConfig,
+          sourceValue: plugin.configContracts?.secretInputs
+            ? sourceConfig.entries[normalizePluginPolicyId(plugin.id)]?.config
+            : undefined,
         }).ok
       ) {
         continue;

--- a/src/plugins/loader-cli-registry.ts
+++ b/src/plugins/loader-cli-registry.ts
@@ -184,6 +184,9 @@ export async function loadOpenClawPluginCliRegistry(
       schema: manifestRecord.configSchema,
       cacheKey: manifestRecord.schemaCacheKey,
       value: entry?.config,
+      sourceValue: manifestRecord.configContracts?.secretInputs
+        ? context.activationSource.plugins.entries[policyId]?.config
+        : undefined,
     });
     if (!validatedConfig.ok) {
       logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.error.join(", ")}`);

--- a/src/plugins/loader-load-context.ts
+++ b/src/plugins/loader-load-context.ts
@@ -147,8 +147,10 @@ function buildActivationMetadataHash(params: {
     })
     .map(([channelId]) => channelId)
     .toSorted((left, right) => left.localeCompare(right));
-  const pluginEntryStates = Object.entries(params.activationSource.plugins.entries)
-    .map(([pluginId, entry]) => [pluginId, entry?.enabled ?? null] as const)
+  // Source config selects validation and defaults even when resolved values match.
+  // Object fields keep an absent config distinct from an explicit null source.
+  const pluginEntryInputs = Object.entries(params.activationSource.plugins.entries)
+    .map(([pluginId, { enabled, config }]) => [pluginId, { enabled, config }] as const)
     .toSorted(([left], [right]) => left.localeCompare(right));
   const autoEnableReasonEntries = Object.entries(params.autoEnabledReasons)
     .map(([pluginId, reasons]) => [pluginId, [...reasons]] as const)
@@ -161,7 +163,7 @@ function buildActivationMetadataHash(params: {
         allow: params.activationSource.plugins.allow,
         deny: params.activationSource.plugins.deny,
         memorySlot: params.activationSource.plugins.slots.memory,
-        entries: pluginEntryStates,
+        entries: pluginEntryInputs,
         enabledChannels: enabledSourceChannels,
         autoEnabledReasons: autoEnableReasonEntries,
       }),

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -337,6 +337,9 @@ export function loadRuntimePluginCandidate(params: {
     schema: manifestRecord.configSchema,
     cacheKey: manifestRecord.schemaCacheKey,
     value: entry?.config,
+    sourceValue: manifestRecord.configContracts?.secretInputs
+      ? context.activationSource.plugins.entries[policyId]?.config
+      : undefined,
   });
   if (!validatedConfig.ok) {
     params.logger.error(

--- a/src/plugins/loader-shared.test.ts
+++ b/src/plugins/loader-shared.test.ts
@@ -1,11 +1,21 @@
-import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import { afterAll, describe, expect, it } from "vitest";
+import { setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { resolvePluginCandidateInstallOwner } from "./candidate-install-owner.js";
+import { getPluginCliCommandDescriptors } from "./cli-root-descriptors.js";
 import type { PluginCandidate } from "./discovery.js";
 import {
   createManifestPluginRecord,
   createPluginCandidatesFromManifestRegistry,
   validatePluginConfig,
 } from "./loader-shared.js";
+import { loadOpenClawPluginCliRegistry, loadOpenClawPlugins } from "./loader.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  resetPluginLoaderTestStateForTest,
+} from "./loader.test-fixtures.js";
 import { recordPluginManifestInstallOwner } from "./manifest-install-owner.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 
@@ -82,6 +92,58 @@ describe("createPluginCandidatesFromManifestRegistry", () => {
   });
 });
 
+describe("validatePluginConfig source values", () => {
+  it("does not accept a null source through the empty-schema fast path", () => {
+    expect(
+      validatePluginConfig({ schema: emptyObjectSchema, sourceValue: null, value: {} }).ok,
+    ).toBe(false);
+  });
+  it("keeps the resolved runtime value when source validation needs no defaults", () => {
+    const schema = {
+      type: "object",
+      properties: { credential: { type: "object", required: ["id"] } },
+      required: ["credential"],
+    };
+    const value = { credential: "resolved-fixture-key" };
+    const result = validatePluginConfig({
+      schema,
+      sourceValue: { credential: { id: "KEY" } },
+      value,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toBe(value);
+    }
+  });
+
+  it("validates secret input source refs while preserving resolved values and defaults", () => {
+    const schema = {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        credential: {
+          type: "object",
+          required: ["source", "provider", "id"],
+          properties: {
+            source: { const: "store" },
+            provider: { type: "string" },
+            id: { type: "string" },
+          },
+        },
+        retries: { type: "integer", default: 2 },
+      },
+    };
+    const sourceValue = { credential: { source: "store", provider: "default", id: "KEY" } };
+    const value = { credential: "resolved-fixture-key" };
+    expect(validatePluginConfig({ schema, sourceValue, value })).toEqual({
+      ok: true,
+      value: { ...value, retries: 2 },
+    });
+    expect(validatePluginConfig({ schema, value })).toMatchObject({ ok: false });
+    expect(value).toEqual({ credential: "resolved-fixture-key" });
+  });
+});
+
 describe("validatePluginConfig empty schema classification", () => {
   it("validates pattern properties instead of requiring empty config", () => {
     const schema = {
@@ -147,3 +209,198 @@ describe("validatePluginConfig empty schema classification", () => {
     ).toEqual({ ok: false, error: ["<root>: config must be empty"] });
   });
 });
+
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe.each(["runtime", "cli", "descriptors"] as const)(
+  "%s source-config boundary",
+  (surface) => {
+    it.each(["paired", "mixed-case", "candidate", "undeclared", "invalid-source"] as const)(
+      "validates the exact source only for declared secretInputs (%s)",
+      async (scenario) => {
+        await withOpenClawTestState(
+          { label: "plugin-source-validation", env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" } },
+          async (state) => {
+            const id = "source-fixture";
+            const configId = scenario === "mixed-case" ? "Source-Fixture" : id;
+            const descriptor = {
+              name: "source-fixture",
+              description: "Fixture command",
+              hasSubcommands: false,
+            };
+            const configSchema = {
+              type: "object",
+              properties: {
+                credential: {
+                  type: "object",
+                  properties: {
+                    source: { const: "store" },
+                    provider: { type: "string" },
+                    id: { type: "string" },
+                  },
+                  required: ["source", "provider", "id"],
+                },
+                retries: { type: "integer", default: 2 },
+                description: { type: "string" },
+              },
+              if: { properties: { credential: { properties: { id: { const: "KEY" } } } } },
+              // oxlint-disable-next-line unicorn/no-thenable -- JSON Schema branch data, not a promise method.
+              then: { properties: { description: { default: "Fixture command" } } },
+              else: { properties: { description: { default: "Alternate command" } } },
+              required: ["credential"],
+              additionalProperties: false,
+            };
+            const marker = state.statePath("fixture/imported");
+            const entry = await state.writeText(
+              "fixture/index.cjs",
+              `
+require("node:fs").writeFileSync(${JSON.stringify(marker)}, "imported");
+module.exports = { id: "source-fixture", register(api) {
+  if (api.pluginConfig.credential !== "resolved-fixture-key" || api.pluginConfig.retries !== 2) {
+    throw new Error("paired runtime config was not hydrated");
+  }
+  api.registerCli(() => {}, { descriptors: [{ ...${JSON.stringify(descriptor)}, description: api.pluginConfig.description }] });
+} };`,
+            );
+            await state.writeJson("fixture/openclaw.plugin.json", {
+              id,
+              configSchema,
+              cliCommands: [descriptor],
+              ...(scenario === "undeclared"
+                ? {}
+                : {
+                    configContracts: {
+                      secretInputs: { paths: [{ path: "credential", expected: "string" }] },
+                    },
+                  }),
+            });
+            const runtime: OpenClawConfig = {
+              plugins: {
+                allow: [id],
+                load: { paths: [entry] },
+                entries: {
+                  [configId]: { enabled: true, config: { credential: "resolved-fixture-key" } },
+                },
+              },
+            };
+            const source: OpenClawConfig = {
+              ...runtime,
+              plugins: {
+                ...runtime.plugins,
+                entries: {
+                  [configId]: {
+                    enabled: true,
+                    config: {
+                      credential:
+                        scenario === "invalid-source"
+                          ? "invalid-plaintext-fixture"
+                          : { source: "store", provider: "default", id: "KEY" },
+                    },
+                  },
+                },
+              },
+            };
+            const before = structuredClone({ runtime, source });
+            setRuntimeConfigSnapshot(runtime, source);
+            const config = scenario === "candidate" ? structuredClone(runtime) : runtime;
+            const accepted = scenario === "paired" || scenario === "mixed-case";
+            try {
+              if (surface === "descriptors") {
+                expect(await getPluginCliCommandDescriptors(config, state.env)).toEqual(
+                  accepted ? [descriptor] : [],
+                );
+                expect(fs.existsSync(marker)).toBe(false);
+              } else {
+                const messages: string[] = [];
+                const options = {
+                  config,
+                  env: state.env,
+                  activate: false,
+                  logger: {
+                    info() {},
+                    warn() {},
+                    error(message: string) {
+                      messages.push(message);
+                    },
+                  },
+                };
+                const registry =
+                  surface === "runtime"
+                    ? loadOpenClawPlugins(options)
+                    : await loadOpenClawPluginCliRegistry(options);
+                expect(registry.plugins.find((plugin) => plugin.id === id)?.status).toBe(
+                  accepted ? "loaded" : "error",
+                );
+                expect(
+                  registry.cliRegistrars.flatMap((registrar) => registrar.descriptors),
+                ).toEqual(accepted ? [descriptor] : []);
+                expect(fs.existsSync(marker)).toBe(accepted);
+                if (surface === "runtime" && scenario === "paired") {
+                  const candidate = structuredClone(runtime);
+                  const unpaired = loadOpenClawPlugins({ ...options, config: candidate });
+                  expect
+                    .soft(unpaired.plugins.find((plugin) => plugin.id === id)?.status)
+                    .toBe("error");
+                  // Identity failures must not expand the registries' lazy runtime properties.
+                  expect.soft(unpaired === registry).toBe(false);
+                  expect(
+                    loadOpenClawPlugins({
+                      ...options,
+                      config: candidate,
+                      activationSourceConfig: structuredClone(source),
+                    }) === registry,
+                  ).toBe(true);
+
+                  const alternateSource: OpenClawConfig = {
+                    ...source,
+                    plugins: {
+                      ...source.plugins,
+                      entries: {
+                        [id]: {
+                          enabled: true,
+                          config: {
+                            credential: { source: "store", provider: "default", id: "OTHER" },
+                          },
+                        },
+                      },
+                    },
+                  };
+                  const alternateOptions = {
+                    ...options,
+                    config: candidate,
+                    activationSourceConfig: alternateSource,
+                  };
+                  const alternate = loadOpenClawPlugins(alternateOptions);
+                  expect.soft(alternate === registry).toBe(false);
+                  expect
+                    .soft(alternate.cliRegistrars.flatMap((registrar) => registrar.descriptors))
+                    .toEqual([{ ...descriptor, description: "Alternate command" }]);
+                  expect(
+                    loadOpenClawPlugins({
+                      ...alternateOptions,
+                      activationSourceConfig: structuredClone(alternateSource),
+                    }) === alternate,
+                  ).toBe(true);
+
+                  setRuntimeConfigSnapshot(candidate, structuredClone(source));
+                  expect(loadOpenClawPlugins({ ...options, config: candidate }) === registry).toBe(
+                    true,
+                  );
+                }
+                expect(
+                  JSON.stringify({ messages, diagnostics: registry.diagnostics }),
+                ).not.toContain("resolved-fixture-key");
+                expect(
+                  JSON.stringify({ messages, diagnostics: registry.diagnostics }),
+                ).not.toContain("invalid-plaintext-fixture");
+              }
+              expect({ runtime, source }).toEqual(before);
+            } finally {
+              resetPluginLoaderTestStateForTest();
+            }
+          },
+        );
+      },
+    );
+  },
+);

--- a/src/plugins/loader-shared.ts
+++ b/src/plugins/loader-shared.ts
@@ -202,12 +202,13 @@ export function validatePluginConfig(params: {
   schema?: Record<string, unknown>;
   cacheKey?: string;
   value?: unknown;
+  sourceValue?: unknown;
 }): Result<Record<string, unknown> | undefined, string[]> {
   const { schema, value } = params;
   if (!schema) {
     return ok(value as Record<string, unknown> | undefined);
   }
-  if (isEmptyPluginConfigJsonSchema(schema)) {
+  if (params.sourceValue === undefined && isEmptyPluginConfigJsonSchema(schema)) {
     if (
       value === undefined ||
       (value &&
@@ -226,6 +227,7 @@ export function validatePluginConfig(params: {
     schema,
     cacheKey: params.cacheKey ?? JSON.stringify(schema),
     value: value ?? {},
+    sourceValue: params.sourceValue,
     applyDefaults: true,
   });
   return result.ok

--- a/src/plugins/schema-validator.source-value.test.ts
+++ b/src/plugins/schema-validator.source-value.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import { validateJsonSchemaValue } from "./schema-validator.js";
+
+describe.each([true, false])("source-aware schema validation (cache=%s)", (cache) => {
+  const schema = {
+    type: "object",
+    properties: {
+      credential: {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      },
+      retries: { type: "integer", default: 2 },
+    },
+    required: ["credential"],
+  };
+
+  it("validates persisted references and defaults the paired runtime without mutating either", () => {
+    const sourceValue = { credential: { id: "KEY" } };
+    const value = { credential: "resolved-fixture-key" };
+    const params = {
+      schema,
+      cacheKey: "source-ref",
+      value,
+      sourceValue,
+      applyDefaults: true,
+      cache,
+    };
+    // Exercise a reused validator as well as its initial compilation.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      expect(validateJsonSchemaValue(params)).toEqual({
+        ok: true,
+        value: { ...value, retries: 2 },
+      });
+      expect(
+        validateJsonSchemaValue({ ...params, sourceValue: { credential: "plaintext" } }).ok,
+      ).toBe(false);
+      expect(validateJsonSchemaValue({ ...params, sourceValue: null }).ok).toBe(false);
+    }
+    expect(sourceValue).toEqual({ credential: { id: "KEY" } });
+    expect(value).toEqual({ credential: "resolved-fixture-key" });
+  });
+
+  it.each([true, false])(
+    "preserves the runtime identity without applicable defaults (%s)",
+    (applyDefaults) => {
+      const value = { credential: "resolved-fixture-key" };
+      const result = validateJsonSchemaValue({
+        schema: { ...schema, properties: { credential: schema.properties.credential } },
+        cacheKey: "source-no-defaults",
+        sourceValue: { credential: { id: "KEY" } },
+        value,
+        applyDefaults,
+        cache,
+      });
+      expect(result).toEqual({ ok: true, value });
+      if (result.ok) {
+        expect(result.value).toBe(value);
+      }
+    },
+  );
+
+  it("keeps the conditional-default exception tied to the source input", () => {
+    const conditional = {
+      ...schema,
+      properties: { ...schema.properties, enabled: { type: "boolean", default: true } },
+      if: { properties: { enabled: { const: true } }, required: ["enabled"] },
+      // oxlint-disable-next-line unicorn/no-thenable -- JSON Schema branch data, not a promise method.
+      then: { required: ["confirmation"] },
+    };
+    const params = {
+      schema: conditional,
+      cacheKey: "source-conditional",
+      value: { credential: "resolved-fixture-key" },
+      sourceValue: { credential: { id: "KEY" } },
+      applyDefaults: true,
+      cache,
+    };
+    expect(validateJsonSchemaValue(params)).toEqual({
+      ok: true,
+      value: { credential: "resolved-fixture-key", retries: 2, enabled: true },
+    });
+    expect(
+      validateJsonSchemaValue({
+        ...params,
+        sourceValue: { ...params.sourceValue, enabled: true },
+      }).ok,
+    ).toBe(false);
+  });
+
+  it.each([null, { credential: "invalid-plaintext-fixture" }])(
+    "rejects invalid source even when the runtime itself matches the schema (%s)",
+    (sourceValue) => {
+      const result = validateJsonSchemaValue({
+        schema,
+        cacheKey: "source-invalid",
+        sourceValue,
+        value: { credential: { id: "VALID" } },
+        applyDefaults: true,
+        cache,
+      });
+      expect(result.ok).toBe(false);
+      expect(JSON.stringify(result)).not.toContain("invalid-plaintext-fixture");
+    },
+  );
+
+  it("uses source-selected conditional defaults in nested runtime objects and arrays", () => {
+    const settingsSchema = {
+      ...schema,
+      properties: { ...schema.properties, endpoint: { type: "string" } },
+      if: { properties: { credential: { type: "object" } }, required: ["credential"] },
+      // oxlint-disable-next-line unicorn/no-thenable -- JSON Schema branch data, not a promise method.
+      then: { properties: { endpoint: { default: "https://reference.example" } } },
+      else: { properties: { endpoint: { default: "https://plaintext.example" } } },
+    };
+    const sourceValue = { accounts: [{ credential: { id: "KEY" } }] };
+    const value = { accounts: [{ credential: "resolved-fixture-key" }] };
+    expect(
+      validateJsonSchemaValue({
+        schema: {
+          type: "object",
+          properties: { accounts: { type: "array", items: settingsSchema } },
+        },
+        cacheKey: "source-conditional-branch",
+        value,
+        sourceValue,
+        applyDefaults: true,
+        cache,
+      }),
+    ).toEqual({
+      ok: true,
+      value: {
+        accounts: [
+          { credential: "resolved-fixture-key", retries: 2, endpoint: "https://reference.example" },
+        ],
+      },
+    });
+    expect(sourceValue).toEqual({ accounts: [{ credential: { id: "KEY" } }] });
+    expect(value).toEqual({ accounts: [{ credential: "resolved-fixture-key" }] });
+  });
+
+  it("preserves runtime overrides and removed references while transferring source defaults", () => {
+    const sourceValue = { credential: { id: "KEY" }, accounts: [{ credential: { id: "OTHER" } }] };
+    const value = { retries: 9, accounts: [{ credential: "resolved-fixture-key" }] };
+    const before = structuredClone({ sourceValue, value });
+    expect(
+      validateJsonSchemaValue({
+        schema: {
+          ...schema,
+          properties: { ...schema.properties, accounts: { type: "array", items: schema } },
+        },
+        cacheKey: "source-preserve-runtime",
+        value,
+        sourceValue,
+        applyDefaults: true,
+        cache,
+      }),
+    ).toEqual({
+      ok: true,
+      value: { retries: 9, accounts: [{ credential: "resolved-fixture-key", retries: 2 }] },
+    });
+    expect({ sourceValue, value }).toEqual(before);
+  });
+});

--- a/src/plugins/schema-validator.ts
+++ b/src/plugins/schema-validator.ts
@@ -1,9 +1,11 @@
 import { normalizeJsonSchemaForTypeBox } from "@openclaw/normalization-core/json-schema";
+import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 // Compiles plugin manifest schemas for validation without runtime loading.
 import { Compile, type Validator as TypeBoxValidator } from "typebox/compile";
 import { Format } from "typebox/format";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { appendAllowedValuesHint, summarizeAllowedValues } from "../config/allowed-values.js";
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import {
   applyJsonSchemaDefaults,
   findJsonSchemaShapeError,
@@ -74,11 +76,30 @@ function schemaHasDefaults(schema: unknown): boolean {
   return Object.values(record).some((value) => schemaHasDefaults(value));
 }
 
-function cloneValidationValue<T>(value: T): T {
-  if (value === undefined || value === null) {
-    return value;
+// Transfer only defaults selected by the source; re-evaluating branches on resolved
+// strings changes their meaning. Never restore a reference removed by runtime isolation.
+function applyValidatedSourceDefaults(
+  value: unknown,
+  source: unknown,
+  defaulted: unknown,
+): unknown {
+  if (source === undefined) {
+    return value === undefined ? defaulted : value;
   }
-  return structuredClone(value);
+  const target = asOptionalObjectRecord(value);
+  const original = asOptionalObjectRecord(source);
+  const hydrated = asOptionalObjectRecord(defaulted);
+  if (target && original && hydrated) {
+    for (const [key, entry] of Object.entries(hydrated)) {
+      if (
+        !isBlockedObjectKey(key) &&
+        (Object.hasOwn(target, key) || !Object.hasOwn(original, key))
+      ) {
+        target[key] = applyValidatedSourceDefaults(target[key], original[key], entry);
+      }
+    }
+  }
+  return value;
 }
 
 function compileSchema(schema: JsonSchemaValue): TypeBoxValidator {
@@ -139,27 +160,6 @@ function checkSchemaWithCurrentFormats(
   return [...validate.Errors(value)] as TypeBoxValidationError[];
 }
 
-function checkSchema(validate: TypeBoxValidator, value: unknown): TypeBoxValidationError[] | null {
-  return withPluginFormatSemantics(() => checkSchemaWithCurrentFormats(validate, value));
-}
-
-function applyDefaultsAndCheckSchema(params: {
-  schema: JsonSchemaValue;
-  validate: TypeBoxValidator;
-  value: unknown;
-  applyDefaults: boolean;
-  hasDefaults: boolean;
-}): { value: unknown; errors: TypeBoxValidationError[] | null } {
-  if (!params.applyDefaults || !params.hasDefaults) {
-    return { value: params.value, errors: checkSchema(params.validate, params.value) };
-  }
-  const clonedValue = cloneValidationValue(params.value);
-  return withPluginFormatSemantics(() => {
-    const value = applyJsonSchemaDefaults(params.schema, clonedValue);
-    return { value, errors: checkSchemaWithCurrentFormats(params.validate, value) };
-  });
-}
-
 function isDefaultActivatedConditionalFailure(params: {
   schema: JsonSchemaValue;
   originalValue: unknown;
@@ -168,11 +168,11 @@ function isDefaultActivatedConditionalFailure(params: {
   const relaxedConditionalValidator = compileSchema(
     relaxConditionalRequiredKeywords(params.schema),
   );
-  if (checkSchema(relaxedConditionalValidator, params.defaultedValue)) {
+  if (checkSchemaWithCurrentFormats(relaxedConditionalValidator, params.defaultedValue)) {
     return false;
   }
   const originalValidator = compileSchema(params.schema);
-  return checkSchema(originalValidator, params.originalValue) === null;
+  return checkSchemaWithCurrentFormats(originalValidator, params.originalValue) === null;
 }
 
 /**
@@ -352,6 +352,8 @@ export function validateJsonSchemaValue(params: {
   schema: JsonSchemaValue;
   cacheKey: string;
   value: unknown;
+  /** Persisted input paired with this runtime value, before secret resolution. */
+  sourceValue?: unknown;
   applyDefaults?: boolean;
   cache?: boolean;
 }): { ok: true; value: unknown } | { ok: false; errors: JsonSchemaValidationError[] } {
@@ -360,37 +362,8 @@ export function validateJsonSchemaValue(params: {
     throw new Error(sanitizeTerminalText(`invalid schema: ${schemaError}`));
   }
 
-  const useCache = params.cache !== false;
-  if (!useCache) {
-    const validate = compileSchema(params.schema);
-    const { value, errors } = applyDefaultsAndCheckSchema({
-      schema: params.schema,
-      validate,
-      value: params.value,
-      applyDefaults: params.applyDefaults === true,
-      hasDefaults: params.applyDefaults === true && schemaHasDefaults(params.schema),
-    });
-    if (!errors) {
-      return { ok: true, value };
-    }
-    if (
-      params.applyDefaults &&
-      value !== params.value &&
-      isDefaultActivatedConditionalFailure({
-        schema: params.schema,
-        originalValue: params.value,
-        defaultedValue: value,
-      })
-    ) {
-      // Defaults can select a conditional branch that requires the defaulted property;
-      // keep the hydrated value when the original input was valid before hydration.
-      return { ok: true, value };
-    }
-    return { ok: false, errors: formatValidationErrors(errors) };
-  }
-
   const cacheKey = params.applyDefaults ? `${params.cacheKey}::defaults` : params.cacheKey;
-  let cached = schemaCache.get(cacheKey);
+  let cached = params.cache === false ? undefined : schemaCache.get(cacheKey);
   const schemaFingerprint =
     !cached || cached.schema !== params.schema ? fingerprintSchema(params.schema) : undefined;
   if (
@@ -404,32 +377,44 @@ export function validateJsonSchemaValue(params: {
       schema: params.schema,
       schemaFingerprint: schemaFingerprint ?? fingerprintSchema(params.schema),
     };
-    schemaCache.set(cacheKey, cached);
+    if (params.cache !== false) {
+      schemaCache.set(cacheKey, cached);
+    }
   } else if (cached.schema !== params.schema) {
     cached.schema = params.schema;
   }
 
-  const { value, errors } = applyDefaultsAndCheckSchema({
-    schema: params.schema,
-    validate: cached.validate,
-    value: params.value,
-    applyDefaults: params.applyDefaults === true,
-    hasDefaults: cached.hasDefaults,
+  return withPluginFormatSemantics(() => {
+    const originalValue = params.sourceValue === undefined ? params.value : params.sourceValue;
+    const value =
+      params.applyDefaults && cached.hasDefaults
+        ? applyJsonSchemaDefaults(params.schema, structuredClone(originalValue))
+        : originalValue;
+    const errors = checkSchemaWithCurrentFormats(cached.validate, value);
+    // Defaults may activate a required-only conditional failure in otherwise valid source.
+    if (
+      errors &&
+      !(
+        params.applyDefaults &&
+        value !== originalValue &&
+        isDefaultActivatedConditionalFailure({
+          schema: params.schema,
+          originalValue,
+          defaultedValue: value,
+        })
+      )
+    ) {
+      return { ok: false, errors: formatValidationErrors(errors) };
+    }
+    if (originalValue === params.value) {
+      return { ok: true, value };
+    }
+    return {
+      ok: true,
+      value:
+        value === originalValue
+          ? params.value
+          : applyValidatedSourceDefaults(structuredClone(params.value), originalValue, value),
+    };
   });
-  if (!errors) {
-    return { ok: true, value };
-  }
-  if (
-    params.applyDefaults &&
-    value !== params.value &&
-    isDefaultActivatedConditionalFailure({
-      schema: params.schema,
-      originalValue: params.value,
-      defaultedValue: value,
-    })
-  ) {
-    // Same conditional-default exception as the uncached path; cache only changes validator reuse.
-    return { ok: true, value };
-  }
-  return { ok: false, errors: formatValidationErrors(errors) };
 }


### PR DESCRIPTION
Related: #130713 (guided cloud-session setup with protected provider credentials).

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer-editable branch. AI-assisted with Codex; the source, dependency contracts, and reproduced behavior were inspected by the maintainer agent.

</details>

## What Problem This Solves

Fixes an issue where a plugin configured with a valid SecretRef can fail to load—or lose its CLI commands—after OpenClaw resolves that reference to a credential string, when the plugin's manifest schema requires the saved reference shape.

The saved configuration and runtime configuration intentionally have different shapes. This also matters for schema defaults: choosing a conditional branch again after credential resolution can silently select the wrong default.

## Why This Change Was Made

The existing schema validator now validates the exact pre-resolution source paired with the runtime value for plugins declaring `secretInputs`. Defaults are selected once from that source and transferred without overwriting runtime values or restoring credential paths removed by isolation. Runtime loading, CLI registration, and manifest-first command discovery use the same normalized, captured source.

The existing registry-cache identity includes the source configuration that determines validation and defaults. A real ordered reproduction showed why this is necessary: a previously successful paired load could otherwise be reused for an unpaired config copy. Equivalent valid inputs still reuse their registry. Cached and uncached schema validation now share one implementation instead of maintaining duplicate paths.

This is an independent prerequisite, not the cloud-settings UI or a cloud-test lifecycle. It adds an optional `sourceValue` parameter to the existing `json-schema-runtime` validator, without new SDK export names, configuration options, environment variables, dependencies, or persistent storage.

## User Impact

Plugins can keep strict persisted-reference schemas while receiving their resolved credentials. Invalid source is rejected even when an equivalent resolved value is already cached. Existing callers that validate only one value retain their behavior; plaintext remains allowed where the owning schema permits it.

Production LOC: **+83/-84 (net -1)**. Tests: **+422/-1 (net +421)**, including the new source-value test file. Docs: **+2/-0**. The production reduction comes from removing duplicate validation/default paths, not hiding exports or changing budgets.

## Evidence

On Node 24.20.0/macOS, the new owner and actual-plugin-loader regressions failed before the repair. The initial main reproduction produced 13 intended failures; expanded source/default cases also reproduced the old checkpoint's conditional-default, normalized-source, and null-source defects before their fixes.

The warm-cache regression was separately reproduced through actual `loadOpenClawPlugins` with a generated CJS plugin and manifest, isolated state, literal fake credentials, and default caching. Before the cache-owner repair: paired load `loaded`, unpaired copy `loaded`, same registry. Afterward: paired load `loaded`, unpaired copy `error`, different registry. The committed ordered test also verifies equivalent explicit/snapshot pairs reuse correctly and a different source-selected default gets its own reusable registry.

Final worker proof, reported as separate runs rather than an inflated campaign total:

- 15 plugin/loader/config test files: **236 passed**.
- Ordinary schema, defaults, and cache tests: **51 passed**; external-channel secret-schema sibling: **4 passed**.
- Focused loader lifecycle cases: **16 passed**; source/scope cases: **20 passed**. Unselected cases were explicitly filtered, not disabled in source.
- Complete nine-path changed gate passed: core/core-test `tsgo`, lint/format, dead-export checks, architecture/security guards, and zero runtime import cycles.
- `pnpm build` passed after the final cache repair, including SDK declarations/exports, CLI bootstrap, plugin artifacts, and Control UI. No ineffective dynamic-import warnings or tracked generated/baseline changes.

Key reproducible commands:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.plugins.config.ts src/plugins/loader-shared.test.ts src/plugins/schema-validator.source-value.test.ts --reporter=verbose
```

```bash
node scripts/run-vitest.mjs src/plugins/schema-validator.test.ts src/plugins/loader-cache-state.test.ts src/shared/json-schema-defaults.test.ts src/config/official-external-channel-secret-schema.test.ts --reporter=verbose
```

```bash
node scripts/check-changed.mjs -- src/plugins/schema-validator.ts src/plugins/schema-validator.source-value.test.ts src/plugins/loader-shared.ts src/plugins/loader-shared.test.ts src/plugins/loader-load-context.ts src/plugins/loader-cli-registry.ts src/plugins/loader-runtime-candidate.ts src/plugins/cli-root-descriptors.ts docs/plugins/manifest.md
```

```bash
pnpm build
```

After the final assertion-reporting and documentation wording refinements, the parent reran the complete two-file source/loader regression suite: **43 passed, no failures or skips**. The changed-file gate for those final two paths also passed, including all selected core-test type shards, lint/format, and dead-export checks. Production code was unchanged from the complete nine-path gate and final build above.

Fresh isolated Codex autoreview completed with no accepted/actionable findings at its P0 threshold. The parent also inspected the owner, caller, cache, defaults, and installed TypeBox contracts directly. This is not an all-priority or hosted-provider certification.

Latest ClawSweeper review reconciled: exact-head CI [33129626548](https://github.com/openclaw/openclaw/actions/runs/33129626548) passed on attempt 1, satisfying its remaining check/rank-up request. Direct dependency inspection used installed **TypeBox 1.3.16**: `build/compile/compile.mjs:5–11` constructs the validator; `build/compile/validator.mjs:44–60` checks/errors against the supplied value, with defaulting separate; `build/format/_registry.mjs:25–67` owns the global format map and snapshot/test operations. The patch preserves those contracts and the ordinary schema/format/default regression suite passes.

There is no persistent data-model change: these functions validate or clone in-memory values, and the new source-aware callers are loaders/discovery, not storage writers. No database schema, serialization format, or migration changes; inputs remain immutable. The bot's live-verification trace ran only `loader-shared.test.ts` (27 passed), not the added source-value file, and then failed its expected-output observer. That is incomplete proof, not a failing product test. The parent ran both files and observed all 43 tests pass. Separate follow-up: investigate added-test selection/output observation in ClawSweeper's partial-checkout live-proof path.

Proof limits: the loader tests use real generated plugin modules/manifests and the actual registry/discovery boundaries, not a mocked validator. They do not perform provider requests or hosted-worker acceptance. There is no changed visual control in this PR. Earlier diagnostic attempts included one zero-selected filter and two stalls while a failing identity assertion traversed a lazy registry; those attempts are not counted as proof. Identity assertions now compare booleans without weakening the identity check or increasing timeouts. Hosted cloud-setup proof remains a separate gate for the broader feature.
