### PR TITLE
fix(code-mode): preserve cancellation diagnostics after catalog teardown

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -1108,11 +1108,17 @@ objects, prototypes, and host functions do not cross into QuickJS.
 
 Each result's `telemetry` field reports: hidden catalog size and a source
 breakdown (`openclaw`/`mcp`/`client` counts), cumulative search/describe/call
-counts for the run's catalog, and the model-visible tool names (`exec`,
-`wait`, and retained direct-only tools).
+counts for the run's catalog, and the code-mode control tool names (`exec` and
+`wait`).
 The `counterScope` identifies one counter lifetime, changing when a catalog is
 replaced or restored but remaining stable when tools are appended or prompt
 policy narrows that catalog.
+
+Catalog teardown retains only these final aggregate diagnostics, not executable
+tools or VM state. If teardown closes a suspended run while `wait` is observing
+pending work, that wait returns `failed` with `code: "aborted"` and the final
+telemetry; pending calls are canceled and the snapshot is dropped. Retained
+diagnostics grant no authority to resume or repair the closed run.
 
 The run metadata (`meta.agentMeta` in `openclaw agent --json`, mirrored on the
 `agent exec --json` envelope) adds per-run stats:

--- a/src/agents/code-mode.bridge.lifecycle.test.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test.ts
@@ -487,6 +487,8 @@ describe("Code Mode subscribed bridge lifecycle", () => {
   it.each(["exec", "wait"] as const)(
     "does not publish a snapshot after its catalog closes during %s",
     async (phase) => {
+      // Worker startup must not consume the host budget before close_owner dispatches.
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
       const owner = createSubscribedCodeModeHarness({ name: `close-during-${phase}` });
       const closeOwner = pluginToolWithExecute("close_owner", "Close the run catalog", async () => {
         clearToolSearchCatalog(owner);
@@ -511,9 +513,12 @@ describe("Code Mode subscribed bridge lifecycle", () => {
         } else {
           completion = execute();
         }
-        await expect(completion).rejects.toThrow(
-          "Tool Search catalog is unavailable for this run.",
-        );
+        expect(resultDetails(await completion)).toMatchObject({
+          status: "failed",
+          code: "aborted",
+          telemetry: { catalogSize: 1, callCount: 1 },
+        });
+        expect(owner.catalogRef.current).toBeUndefined();
         expect(closeOwner.execute).toHaveBeenCalledOnce();
         expect(testing.activeRuns.size).toBe(0);
         expect(testing.resumingRunIds.size).toBe(0);
@@ -521,6 +526,7 @@ describe("Code Mode subscribed bridge lifecycle", () => {
       } finally {
         clearToolSearchCatalog(owner);
         owner.dispose();
+        vi.useRealTimers();
       }
     },
   );
@@ -566,33 +572,43 @@ describe("Code Mode subscribed bridge lifecycle", () => {
     { kind: "run-owner loss", close: "abort" },
     { kind: "snapshot expiry", close: "expire" },
     { kind: "gateway shutdown", close: "shutdown" },
+    { kind: "catalog closure during wait", close: "catalog" },
   ] as const)(
     "settles an abort-ignoring subscribed tool exactly once after $kind",
     async ({ close }) => {
+      vi.useFakeTimers({ toFake: ["Date", "setTimeout", "clearTimeout"] });
       const downstream = createDeferred();
+      const started = createDeferred();
       const harness = createSubscribedCodeModeHarness({
         name: `closure-${close}`,
         timeoutMs: 2_000,
       });
       const target = pluginToolWithExecute("stalled_target", "Ignore cancellation", async () => {
+        started.resolve();
         await downstream.promise;
         return jsonResult({ late: true });
       });
-      applyCodeModeCatalog({ ...harness, tools: [...harness.tools, target] });
+      const continuation = pluginToolWithExecute(
+        "continue_after_target",
+        "Continue the guest",
+        async () => jsonResult({ continued: true }),
+      );
+      applyCodeModeCatalog({ ...harness, tools: [...harness.tools, target, continuation] });
 
       try {
-        const suspended = resultDetails(
-          await expectDefined(harness.tools[0], "Code Mode exec test invariant").execute(
-            `code-call-${close}`,
-            {
-              code: `const target = stalled_target({});
-                await yield_control("pause");
-                try { return await target; } catch (error) { return error.message; }`,
-            },
-          ),
+        const execution = expectDefined(harness.tools[0], "Code Mode exec test invariant").execute(
+          `code-call-${close}`,
+          {
+            code: `const target = stalled_target({});
+                try { await target; } catch (error) { return error.message; }
+                return await continue_after_target({});`,
+          },
         );
+        await started.promise;
+        await vi.advanceTimersByTimeAsync(2_000);
+        const suspended = resultDetails(await execution);
         expect(suspended.status).toBe("waiting");
-        await vi.waitFor(() => expect(target.execute).toHaveBeenCalledOnce());
+        expect(target.execute).toHaveBeenCalledOnce();
         expect(countActiveToolExecutions(harness.runId)).toBe(1);
 
         const parked = testing.activeRuns.get(suspended.runId as string);
@@ -603,6 +619,7 @@ describe("Code Mode subscribed bridge lifecycle", () => {
         }
         const settlements = vi.fn();
         void pending.promise.then(settlements);
+        const cancel = vi.spyOn(pending, "cancel");
         const waiting = expectDefined(harness.tools[1], "Code Mode wait test invariant").execute(
           `code-wait-${close}`,
           { runId: suspended.runId },
@@ -615,6 +632,8 @@ describe("Code Mode subscribed bridge lifecycle", () => {
         } else if (close === "expire") {
           parked.expiresAt = Date.now() - 1;
           testing.removeExpiredRuns();
+        } else if (close === "catalog") {
+          clearToolSearchCatalog(harness);
         } else {
           disposeAllCodeModeRuns();
         }
@@ -622,19 +641,34 @@ describe("Code Mode subscribed bridge lifecycle", () => {
         const settlement = await pending.promise;
         expect(settlement).toMatchObject({ id: pending.id, ok: false });
         expect(settlement.ok ? "" : settlement.error).toMatch(/cancel|abort|expir|owner|shut/i);
-        expect(resultDetails(await waiting).status).not.toBe("waiting");
+        const result = resultDetails(await waiting);
+        expect(result.status).not.toBe("waiting");
+        if (close === "catalog") {
+          expect(result).toMatchObject({
+            status: "failed",
+            code: "aborted",
+            telemetry: suspended.telemetry,
+          });
+          expect(harness.catalogRef.current).toBeUndefined();
+        }
         await vi.waitFor(() => expect(countActiveToolExecutions(harness.runId)).toBe(0));
         expect(settlements).toHaveBeenCalledOnce();
+        expect(cancel).toHaveBeenCalledOnce();
         expect(harness.subscription.getItemLifecycle().activeCount).toBe(0);
         expect(testing.activeRuns.size).toBe(0);
+        expect(testing.resumingRunIds.size).toBe(0);
 
         downstream.resolve();
         await Promise.resolve();
         expect(target.execute).toHaveBeenCalledOnce();
+        expect(continuation.execute).not.toHaveBeenCalled();
         expect(settlements).toHaveBeenCalledOnce();
+        expect(cancel).toHaveBeenCalledOnce();
       } finally {
         downstream.resolve();
+        clearToolSearchCatalog(harness);
         harness.dispose();
+        vi.useRealTimers();
       }
     },
   );

--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -20,6 +20,7 @@ import {
   type ToolSearchCatalogEntry,
   type ToolSearchCatalogRef,
   type ToolSearchCatalogSession,
+  type ToolSearchCatalogTelemetry,
   type ToolSearchToolContext,
 } from "./tool-search-types.js";
 import { ToolInputError, type AnyAgentTool } from "./tools/common.js";
@@ -139,6 +140,7 @@ function restoreToolSearchCatalog(params: {
     callCount: 0,
   };
   params.catalogRef.current = next;
+  delete params.catalogRef.closedTelemetry;
   catalogFingerprints.set(next, params.fingerprint);
   params.catalogRef.onChange?.();
 }
@@ -322,6 +324,7 @@ function registerToolSearchCatalog(params: {
       : catalogEntriesFingerprint(next.entries);
   catalogFingerprints.set(next, fingerprint);
   params.catalogRef.current = next;
+  delete params.catalogRef.closedTelemetry;
   params.catalogRef.onChange?.();
   return next;
 }
@@ -334,6 +337,11 @@ export function clearToolSearchCatalog(params: {
   catalogRef?: ToolSearchCatalogRef;
 }): void {
   if (params.catalogRef) {
+    // Capture only aggregate facts before releasing executable state. Disposal
+    // can wake an in-flight wait that still needs its final diagnostics.
+    if (params.catalogRef.current) {
+      params.catalogRef.closedTelemetry = getTelemetry(params.catalogRef.current);
+    }
     params.catalogRef.current = undefined;
     params.catalogRef.disposeObserver?.();
     params.catalogRef.onDispose?.forEach((dispose) => dispose());
@@ -380,6 +388,31 @@ export function resolveCatalog(ctx: ToolSearchToolContext): ToolSearchCatalogSes
     throw new ToolInputError("Tool Search catalog is unavailable for this run.");
   }
   return catalog;
+}
+
+function getTelemetry(catalog: ToolSearchCatalogSession): ToolSearchCatalogTelemetry {
+  const sources: Record<CatalogSource, number> = { openclaw: 0, mcp: 0, client: 0 };
+  for (const entry of catalog.entries) {
+    sources[entry.source] += 1;
+  }
+  return {
+    catalogSize: catalog.entries.length,
+    sources,
+    counterScope: catalog.counterScope,
+    searchCount: catalog.searchCount,
+    describeCount: catalog.describeCount,
+    callCount: catalog.callCount,
+  };
+}
+
+export function readToolSearchCatalogTelemetry(
+  ctx: ToolSearchToolContext,
+): ToolSearchCatalogTelemetry {
+  const closed = ctx.catalogRef?.closedTelemetry;
+  if (!ctx.catalogRef?.current && closed) {
+    return { ...closed, sources: { ...closed.sources } };
+  }
+  return getTelemetry(resolveCatalog(ctx));
 }
 
 export function visibleCatalogEntries(

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -24,6 +24,7 @@ import {
 import {
   compactToolSearchCatalogEntry,
   prepareToolSearchCatalogExecutionTool,
+  readToolSearchCatalogTelemetry,
   resolveCatalog,
   visibleCatalogEntries,
 } from "./tool-search-catalog.js";
@@ -37,7 +38,6 @@ import {
 import { readToolSearchLimit } from "./tool-search-request.js";
 import { snapshotToolSearchTargetTranscriptResult } from "./tool-search-transcript.js";
 import type {
-  CatalogSource,
   CatalogVisibilityOptions,
   ToolSearchCallOptions,
   ToolSearchCatalogEntry,
@@ -265,21 +265,6 @@ export function prepareToolSearchDispatcherArguments(args: unknown): unknown {
   }
   const { args: _wrappedArgs, input: _wrappedInput, ...outerRest } = args;
   return { ...outerRest, ...nestedInput, id: selectorValue };
-}
-
-function getTelemetry(catalog: ToolSearchCatalogSession) {
-  const sources: Record<CatalogSource, number> = { openclaw: 0, mcp: 0, client: 0 };
-  for (const entry of catalog.entries) {
-    sources[entry.source] += 1;
-  }
-  return {
-    catalogSize: catalog.entries.length,
-    sources,
-    counterScope: catalog.counterScope,
-    searchCount: catalog.searchCount,
-    describeCount: catalog.describeCount,
-    callCount: catalog.callCount,
-  };
 }
 
 type CatalogSchemaName = "inputSchema" | "outputSchema";
@@ -711,7 +696,7 @@ export class ToolSearchRuntime {
   };
 
   telemetry() {
-    return getTelemetry(resolveCatalog(this.ctx));
+    return readToolSearchCatalogTelemetry(this.ctx);
   }
 }
 

--- a/src/agents/tool-search-types.ts
+++ b/src/agents/tool-search-types.ts
@@ -129,8 +129,14 @@ export type ToolSearchCatalogSession = {
   callCount: number;
 };
 
+export type ToolSearchCatalogTelemetry = Omit<ToolSearchCatalogSession, "entries"> & {
+  catalogSize: number;
+  sources: Record<CatalogSource, number>;
+};
+
 export type ToolSearchCatalogRef = {
   current?: ToolSearchCatalogSession;
+  closedTelemetry?: ToolSearchCatalogTelemetry;
   onChange?: () => void;
   disposeObserver?: () => void;
   onDispose?: Set<() => void>;

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -37,6 +37,7 @@ import {
   createToolSearchTools as createRunToolSearchTools,
   projectToolSearchTargetTranscriptMessages,
   registerHeadlessToolSearchCatalog,
+  restrictToolSearchCatalog,
   resolveToolSearchConfig,
   resolveToolSearchCatalogTool as resolveRunToolSearchCatalogTool,
   TOOL_CALL_RAW_TOOL_NAME,
@@ -2100,28 +2101,125 @@ describe("Tool Search", () => {
     });
   });
 
-  it("changes the telemetry counter scope when a catalog is replaced", async () => {
-    const config = { tools: { toolSearch: true } } as never;
-    const catalogRef = createToolSearchCatalogRef();
-    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
-    applyToolSearchCatalog({
-      tools: [codeTool, pluginTool("fake_first", "First capability")],
-      config,
-      catalogRef,
-    });
-    const firstScope = expectDefined(catalogRef.current, "first catalog").counterScope;
-    const runtime = new ToolSearchRuntime({ catalogRef }, resolveToolSearchConfig(config));
-    await runtime.search("fake_first");
-    expect(runtime.telemetry()).toMatchObject({ counterScope: firstScope, searchCount: 1 });
+  it.each([false, true])(
+    "changes the telemetry counter scope on replacement after clear=%s",
+    async (clear) => {
+      const config = { tools: { toolSearch: true } } as never;
+      const catalogRef = createToolSearchCatalogRef();
+      const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+      applyToolSearchCatalog({
+        tools: [codeTool, pluginTool("fake_first", "First capability")],
+        config,
+        catalogRef,
+      });
+      const firstScope = expectDefined(catalogRef.current, "first catalog").counterScope;
+      const runtime = new ToolSearchRuntime({ catalogRef }, resolveToolSearchConfig(config));
+      await runtime.search("fake_first");
+      expect(runtime.telemetry()).toMatchObject({ counterScope: firstScope, searchCount: 1 });
+      if (clear) {
+        clearToolSearchCatalog({ catalogRef });
+        expect(runtime.telemetry()).toMatchObject({ counterScope: firstScope, searchCount: 1 });
+      }
 
-    applyToolSearchCatalog({
-      tools: [codeTool, pluginTool("fake_second", "Second capability")],
-      config,
-      catalogRef,
+      applyToolSearchCatalog({
+        tools: [codeTool, pluginTool("fake_second", "Second capability")],
+        config,
+        catalogRef,
+      });
+      const replacementScope = expectDefined(catalogRef.current, "second catalog").counterScope;
+      expect(replacementScope).not.toBe(firstScope);
+      expect(runtime.telemetry()).toMatchObject({ counterScope: replacementScope, searchCount: 0 });
+      clearToolSearchCatalog({ catalogRef });
+      expect(runtime.telemetry()).toMatchObject({ counterScope: replacementScope, searchCount: 0 });
+    },
+  );
+
+  it.each([false, true])(
+    "retains final shared catalog diagnostics after an earlier telemetry read=%s",
+    async (readBeforeClear) => {
+      const catalogRef = createToolSearchCatalogRef();
+      const ctx = { catalogRef };
+      const config = { tools: { toolSearch: true } } as never;
+      const target = pluginTool("diagnostic_target", "Diagnostic target");
+      registerHeadlessToolSearchCatalog({
+        catalogRef,
+        tools: [target, mcpPluginTool("remote_target", "Remote target")],
+      });
+      const runtime = new ToolSearchRuntime(ctx, resolveToolSearchConfig(config));
+      const sibling = new ToolSearchRuntime(ctx, resolveToolSearchConfig(config));
+      const counterScope = expectDefined(catalogRef.current, "catalog").counterScope;
+      if (readBeforeClear) {
+        expect(runtime.telemetry()).toEqual({
+          catalogSize: 2,
+          sources: { openclaw: 1, mcp: 1, client: 0 },
+          counterScope,
+          searchCount: 0,
+          describeCount: 0,
+          callCount: 0,
+        });
+      }
+      await sibling.search(target.name);
+      await sibling.describe(target.name);
+      await sibling.call(target.name);
+      addClientToolsToToolSearchCatalog({
+        ...ctx,
+        config,
+        tools: [fakeTool("client_target", "Client target")],
+      });
+      restrictToolSearchCatalog({
+        ...ctx,
+        allowedToolNames: new Set([target.name, "client_target"]),
+      });
+      const expected = {
+        catalogSize: 2,
+        sources: { openclaw: 1, mcp: 0, client: 1 },
+        counterScope,
+        searchCount: 1,
+        describeCount: 1,
+        callCount: 1,
+      };
+      clearToolSearchCatalog(ctx);
+      expect(catalogRef.current).toBeUndefined();
+      expect(runtime.telemetry()).toEqual(expected);
+      expect(sibling.telemetry()).toEqual(expected);
+      const snapshot = runtime.telemetry();
+      snapshot.sources.client = 99;
+      snapshot.callCount = 99;
+      clearToolSearchCatalog(ctx);
+      expect(runtime.telemetry()).toEqual(expected);
+
+      const unavailable = "Tool Search catalog is unavailable for this run.";
+      expect(() => runtime.all()).toThrow(unavailable);
+      expect(() => runtime.namespaceEntries()).toThrow(unavailable);
+      await expect(runtime.search(target.name)).rejects.toThrow(unavailable);
+      await expect(runtime.describe(target.name)).rejects.toThrow(unavailable);
+      await expect(runtime.call(target.name)).rejects.toThrow(unavailable);
+      await expect(runtime.callExactId("openclaw:fake-catalog:diagnostic_target")).rejects.toThrow(
+        unavailable,
+      );
+      await expect(runtime.callValue(target.name)).rejects.toThrow(unavailable);
+      expect(runtime.isReplaySafeExactId("openclaw:fake-catalog:diagnostic_target")).toBe(false);
+      expect(target.execute).toHaveBeenCalledOnce();
+      expect(runtime.telemetry()).toEqual(expected);
+    },
+  );
+
+  it("distinguishes a closed empty catalog from a never-registered catalog", () => {
+    const catalogRef = createToolSearchCatalogRef();
+    const ctx = { catalogRef };
+    const runtime = new ToolSearchRuntime(ctx, resolveToolSearchConfig());
+    clearToolSearchCatalog(ctx);
+    expect(() => runtime.telemetry()).toThrow("Tool Search catalog is unavailable for this run.");
+    registerHeadlessToolSearchCatalog({ catalogRef, tools: [] });
+    clearToolSearchCatalog(ctx);
+    expect(runtime.telemetry()).toEqual({
+      catalogSize: 0,
+      sources: { openclaw: 0, mcp: 0, client: 0 },
+      counterScope: expect.any(String),
+      searchCount: 0,
+      describeCount: 0,
+      callCount: 0,
     });
-    const replacementScope = expectDefined(catalogRef.current, "second catalog").counterScope;
-    expect(replacementScope).not.toBe(firstScope);
-    expect(runtime.telemetry()).toMatchObject({ counterScope: replacementScope, searchCount: 0 });
   });
 
   it("scopes catalogs by run id when attempts share a session", async () => {
@@ -3658,59 +3756,85 @@ describe("Tool Search", () => {
     expect(laterRef.current?.counterScope).not.toBe(catalogAfterFirst.counterScope);
   });
 
-  it("restores an unchanged catalog after run cleanup", async () => {
-    const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
-    const alpha = pluginTool("fake_xrun_alpha", "Alpha tool");
-    const beta = pluginTool("fake_xrun_beta", "Beta tool");
-    const config = { tools: { toolSearch: true } } as never;
-    const sessionId = "session-cross-run-reuse";
-    const firstRef = createToolSearchCatalogRef();
+  it.each(["fresh", "same"] as const)(
+    "restores an unchanged catalog after run cleanup on a %s ref",
+    async (refMode) => {
+      const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");
+      const alpha = pluginTool("fake_xrun_alpha", "Alpha tool");
+      const beta = pluginTool("fake_xrun_beta", "Beta tool");
+      const config = { tools: { toolSearch: true } } as never;
+      const sessionId = `session-cross-run-reuse-${refMode}`;
+      const firstRef = createToolSearchCatalogRef();
 
-    const first = applyToolSearchCatalog({
-      tools: [codeTool, alpha, beta],
-      config,
-      sessionId,
-      runId: "run-1",
-      catalogRef: firstRef,
-    });
-    expect(first.catalogReused).toBe(false);
-    const firstCatalog = expectDefined(firstRef.current, "first run catalog");
-    const firstAlphaEntry = firstCatalog.entries.find((entry) => entry.name === alpha.name);
-    expect(firstAlphaEntry).toBeDefined();
-    const firstRuntime = new ToolSearchRuntime(
-      { catalogRef: firstRef },
-      resolveToolSearchConfig(config),
-    );
-    await firstRuntime.search(alpha.name);
-    expect(firstRuntime.telemetry()).toMatchObject({
-      counterScope: firstCatalog.counterScope,
-      searchCount: 1,
-    });
+      const first = applyToolSearchCatalog({
+        tools: [codeTool, alpha, beta],
+        config,
+        sessionId,
+        runId: "run-1",
+        catalogRef: firstRef,
+      });
+      expect(first.catalogReused).toBe(false);
+      const firstCatalog = expectDefined(firstRef.current, "first run catalog");
+      const firstAlphaEntry = firstCatalog.entries.find((entry) => entry.name === alpha.name);
+      expect(firstAlphaEntry).toBeDefined();
+      const firstRuntime = new ToolSearchRuntime(
+        { catalogRef: firstRef },
+        resolveToolSearchConfig(config),
+      );
+      await firstRuntime.search(alpha.name);
+      const firstCounters = {
+        counterScope: firstCatalog.counterScope,
+        searchCount: 1,
+        describeCount: 0,
+        callCount: 0,
+      };
+      expect(firstRuntime.telemetry()).toMatchObject(firstCounters);
 
-    clearToolSearchCatalog({
-      sessionId,
-      runId: "run-1",
-      catalogRef: firstRef,
-    });
-    expect(firstRef.current).toBeUndefined();
+      clearToolSearchCatalog({
+        sessionId,
+        runId: "run-1",
+        catalogRef: firstRef,
+      });
+      expect(firstRef.current).toBeUndefined();
+      expect(firstRuntime.telemetry()).toMatchObject(firstCounters);
 
-    const secondRef = createToolSearchCatalogRef();
-    const second = applyToolSearchCatalog({
-      tools: [codeTool, alpha, beta],
-      config,
-      sessionId,
-      runId: "run-2",
-      catalogRef: secondRef,
-    });
-    expect(second.catalogRegistered).toBe(true);
-    expect(second.catalogReused).toBe(true);
-    const restoredCatalog = expectDefined(secondRef.current, "restored run catalog");
-    expect(restoredCatalog.entries.find((entry) => entry.name === alpha.name)).toBe(
-      firstAlphaEntry,
-    );
-    expect(restoredCatalog.counterScope).not.toBe(firstCatalog.counterScope);
-    expect(restoredCatalog.searchCount).toBe(0);
-  });
+      const restoredRef = refMode === "same" ? firstRef : createToolSearchCatalogRef();
+      const second = applyToolSearchCatalog({
+        tools: [codeTool, alpha, beta],
+        config,
+        sessionId,
+        runId: "run-2",
+        catalogRef: restoredRef,
+      });
+      expect(second.catalogRegistered).toBe(true);
+      expect(second.catalogReused).toBe(true);
+      const restoredCatalog = expectDefined(restoredRef.current, "restored run catalog");
+      expect(restoredCatalog.entries.find((entry) => entry.name === alpha.name)).toBe(
+        firstAlphaEntry,
+      );
+      expect(restoredCatalog.counterScope).not.toBe(firstCatalog.counterScope);
+      expect(restoredCatalog.searchCount).toBe(0);
+      const restoredRuntime = new ToolSearchRuntime(
+        { catalogRef: restoredRef },
+        resolveToolSearchConfig(config),
+      );
+      const restoredCounters = {
+        counterScope: restoredCatalog.counterScope,
+        searchCount: 0,
+        describeCount: 0,
+        callCount: 0,
+      };
+      for (const phase of ["active", "closed"] as const) {
+        if (phase === "closed") {
+          clearToolSearchCatalog({ sessionId, catalogRef: restoredRef });
+        }
+        expect(restoredRuntime.telemetry(), phase).toMatchObject(restoredCounters);
+        expect(firstRuntime.telemetry(), phase).toMatchObject(
+          refMode === "same" ? restoredCounters : firstCounters,
+        );
+      }
+    },
+  );
 
   it("does not retain hook-bound catalogs, including prewrapped tools", () => {
     const codeTool = fakeTool(TOOL_SEARCH_CODE_MODE_TOOL_NAME, "code mode");


### PR DESCRIPTION
Closes #131299 — Code Mode loses cancellation diagnostics when the tool catalog closes.

Related: #131186 — canceled timers and closed parked owners release their work and execution slots.

## What Problem This Solves

Fixes an issue where Code Mode users receive `Tool Search catalog is unavailable for this run.` instead of the intended cancellation result when a run-owned catalog closes while `wait` is observing pending host work. The snapshot and pending work are already correctly disposed; reporting that outcome fails.

## Why This Change Was Made

The catalog lifecycle owner now retains only its final aggregate telemetry before clearing executable state. Live telemetry still reads the current catalog; closed telemetry reads a copied, data-only summary. The existing projection moves to the owner rather than introducing runtime-local caches or consumer catches.

The retained record contains only catalog size, source counts, counter scope, and search/describe/call counts. Replacement and restore supersede it; repeated clear preserves it. No tool, schema, namespace binding, or VM state is retained by the diagnostic record. Executable/discovery guards, cancellation, snapshot ownership, and failed-wait recovery policy are unchanged.

## User Impact

An observing wait now reports `failed` / `aborted` with the final diagnostics. Closed runs cannot resume, stale catalog operations still reject, and no repair or continuation authority is added. No configuration, dependency, database/schema, or public result-shape changes are required.

The documentation also corrects the adjacent telemetry wording: `visibleTools` reports the Code Mode controls, not retained direct-only tools.

## Evidence

### Before and after

A real QuickJS-WASI 3.4.0 worker exercised public `exec`/`wait` with the canonical read tool and a gated filesystem backend. Before the source change, catalog closure produced the raw error from `runWait`'s catch at `src/agents/code-mode-execution.ts:720`.

The unchanged proof now verifies:

- `status: "failed"`, `code: "aborted"`, and unchanged final aggregate telemetry (`searchCount: 1`, `describeCount: 1`, `callCount: 1`).
- Pending cancellation, snapshot removal, and rejection of stale wait/search/describe/call/exact-call attempts.
- No repair provenance, no reconciliation, a terminal outcome, and zero continuation effects after the gated read finishes.

Nine regression cases failed on the pre-fix source with the actual telemetry error before passing with the owner repair. Existing close-during-exec coverage had a cold-start timing race; the touched fixtures now control host time instead of raising timeouts or retrying.

### Focused validation

```bash
node scripts/run-vitest.mjs src/agents/code-mode.bridge.lifecycle.test.ts src/agents/tool-search.test.ts src/agents/tool-search-runtime.test.ts src/agents/code-mode-headless.cancellation.test.ts src/agents/code-mode-headless.test.ts src/agents/code-mode-headless.validation.test.ts src/agents/code-mode.wait.test.ts src/agents/code-mode.preflight-repair.test.ts src/agents/code-mode.agent-loop.test.ts src/agents/embedded-agent-runner/run/code-mode-outcome.test.ts
```

Initial validation passed 337 tests across 10 files. After the native wrapper required a conflict-free rebase, the same command passed all 346 tests across those 10 files on `71e3fda1bdc33244e48cf0a5b883912ead7cd4a0` (3 unit-fast, 334 agents-core, 9 embedded-run). `git range-diff` confirms the six-file patch is unchanged. Coverage includes shared runtime counters, closure before the first telemetry read, append/restriction metadata, replacement and fresh/same-ref restore lifetimes, repeated clear, valid empty versus never-registered catalogs, headless cancellation, and unchanged continuation policy.

```bash
node scripts/check-changed.mjs -- src/agents/tool-search-types.ts src/agents/tool-search-catalog.ts src/agents/tool-search-runtime.ts src/agents/code-mode.bridge.lifecycle.test.ts src/agents/tool-search.test.ts docs/tools/code-mode.md
```

Passed formatting, core and core-test typechecks, changed-file lint, dead-export checks, import-cycle checks, and the remaining classified guards. `git diff --check` passed. Fresh isolated Codex autoreview reported no actionable findings at its P0-only threshold; the maintainer also inspected the owner/caller/sibling paths.

`pnpm build` passed locally in 8m 25s, including plugin bundles, CLI import guards, SDK export checks, and the Control UI build. No ineffective dynamic-import warnings were reported.

Premerge evidence was real worker/control-tool and subscribed bridge proof. The requested authenticated post-merge Gateway verification is recorded below, with its exact cancellation and visual-proof boundaries.

### Scope and source contracts

Production LOC: +41/-17 (net +24). Tests: +243/-85 (net +158). Docs: +8/-2 (net +6). The production increase expresses only the necessary diagnostic lifetime independent of executable authority; the existing 15-line projection is moved, not duplicated.

Directly inspected the catalog register/restore/clear/restrict owner, runtime operations and telemetry, exec/wait/state lifecycles, Tool Search's Node bridge sibling, headless cleanup, and embedded teardown. Installed QuickJS source confirms that snapshot memory and host callback disposal remain separate from host diagnostics. The same affected owners were checked on main revision `4ef9446daf156f6252bc81e2e250ff3d37755e69`.

Provenance: the raw telemetry dependency predates the recent lifecycle repair and exists in stable `v2026.7.1-2` source. The reported parked-owner scenario was made visible by #131186 (code author, PR author, and merger: @steipete, 2026-08-27). This change preserves that PR's correct teardown behavior.

AI-assisted implementation and review.

Exact-head hosted CI passed on `71e3fda1bdc33244e48cf0a5b883912ead7cd4a0`: [CI run 33129650218](https://github.com/openclaw/openclaw/actions/runs/33129650218), including `openclaw/ci-gate`. The native exact-SHA watcher completed `GREEN`.

## Post-merge live Gateway verification

Built freshly pulled main [`a6cc62fce55f`](https://github.com/openclaw/openclaw/commit/a6cc62fce55f02302883408f8b7a11b0d2465688), containing merge [`f1dd2b72d49c`](https://github.com/openclaw/openclaw/commit/f1dd2b72d49c214b678ae63baf44571e03783cc9). The complete local build passed in 11m34s. The live run used a token-authenticated foreground dev Gateway on loopback port 28789, with a fresh isolated home/state/workspace, only the Anthropic plugin, and workspace-only read access. No operator Gateway or state was used.

Real provider: `anthropic/claude-opus-5`; runtime: `openclaw`. The returned receipt confirmed the effective response model, no rerouting, `codeModeEngaged: true`, and model-visible tools exactly `exec` and `wait`.

- **Completion:** the model executed the prescribed program unchanged: catalog search, describe, one canonical read, explicit yield, then `wait` on the same cell. It completed in 11.0s over three assistant turns, returned the exact synthetic file contents, and preserved the same counter scope and search/describe/call counts of `1/1/1` across yield/resume. No duplicate read or active run remained.
- **Cancellation:** a fresh normal Gateway-backed `openclaw agent` process was interrupted with SIGINT only after the transcript showed a sleep-parked cell and a subsequent `wait` still in flight. The CLI used its supported owner connection and exited 130. Gateway `agent.wait` recorded terminal `status: "error"` with `stopReason: "rpc"`; the session was `killed`, `abortedLastRun: true`, with no active run. A later check past the original 60-second sleep deadline found no additional tool calls or continuation marker. Pre-abort telemetry remained `1/1/1`.

The first cancellation attempt used a separate least-privileged `gateway call chat.abort` connection and was correctly rejected as unauthorized; it was not counted as cancellation proof. A temporary observer also initially assumed final session metadata already contained `lastRunId`; the successful repeat used the authoritative run id attached to the in-flight transcript message instead. No authentication, cancellation, recovery, or production code was changed to make these tests pass.

Proof boundary: normal Gateway cancellation balances the interrupted tool call with its synthetic missing-result transcript entry; it does not persist the lower-level structured aborted telemetry. The public cancellation path aborts the owner before attempt teardown clears the catalog, so it does not independently exercise catalog-first closure. The exact catalog-close-while-wait-observes-pending-read ordering was therefore reverified separately with the unchanged real QuickJS/public-control-tool probe on this same pulled main revision: `failed` / `aborted`, final diagnostics, canceled work, dropped snapshot, denied stale calls, and no repair/reconciliation/continuation authority all passed.

Visual evidence remains unavailable: the Chrome extension relay was disconnected and the documented direct-attachment fallback returned HTTP 403. No screenshots or video are claimed.

Cleanup verified: all four isolated sessions were terminal; the session-owned Gateway stopped and port 28789 was released; temporary credentials, home/state directories, and preview configuration were removed. The visible worktree is clean and detached at the tested main revision because another session owns the `main` checkout.
