### PR TITLE
fix(agents): prevent invalid sessions_spawn recovery loops

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -867,24 +867,47 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it("explains both recoveries when an ACP run includes a category", async () => {
-    registerAcpBackendForTest();
-    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:main:main" });
+  it.each([
+    {
+      name: "category",
+      category: "handoff investigation",
+      extra: {},
+      visibleOnlyParams: "category",
+    },
+    {
+      name: "an empty category",
+      category: "",
+      extra: {},
+      visibleOnlyParams: "category",
+    },
+    {
+      name: "category and worktree",
+      category: "handoff investigation",
+      extra: { worktree: true },
+      visibleOnlyParams: "category, worktree",
+    },
+  ])(
+    "explains both recoveries when an ACP run includes $name",
+    async ({ category, extra, visibleOnlyParams }) => {
+      registerAcpBackendForTest();
+      const tool = createSessionsSpawnTool({ agentSessionKey: "agent:main:main" });
 
-    await expect(
-      tool.execute("acp-category", {
-        task: "Investigate the failure",
-        runtime: "acp",
-        mode: "run",
-        streamTo: "parent",
-        category: "handoff investigation",
-      }),
-    ).rejects.toThrow(
-      'category is only available for visible dashboard sessions. Choose one: omit category for a hidden or ACP run; or set visible=true, use runtime="subagent", and omit mode and streamTo.',
-    );
-    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
-  });
+      await expect(
+        tool.execute("acp-category", {
+          task: "Investigate the failure",
+          runtime: "acp",
+          mode: "run",
+          streamTo: "parent",
+          category,
+          ...extra,
+        }),
+      ).rejects.toThrow(
+        `Parameters only available for visible dashboard sessions: ${visibleOnlyParams}. Choose one: omit them for a hidden or ACP run; or set visible=true, use runtime="subagent", and omit mode and streamTo.`,
+      );
+      expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+      expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("applies a per-run timeout to visible dashboard sessions", async () => {
     const callGateway = vi.fn(async () => ({

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -867,6 +867,25 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
+  it("explains both recoveries when an ACP run includes a category", async () => {
+    registerAcpBackendForTest();
+    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:main:main" });
+
+    await expect(
+      tool.execute("acp-category", {
+        task: "Investigate the failure",
+        runtime: "acp",
+        mode: "run",
+        streamTo: "parent",
+        category: "handoff investigation",
+      }),
+    ).rejects.toThrow(
+      'category is only available for visible dashboard sessions. Choose one: omit category for a hidden or ACP run; or set visible=true, use runtime="subagent", and omit mode and streamTo.',
+    );
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
   it("applies a per-run timeout to visible dashboard sessions", async () => {
     const callGateway = vi.fn(async () => ({
       key: "agent:main:dashboard:timed-child",

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -114,11 +114,6 @@ export async function maybeSpawnVisibleSession(params: {
   const categoryProvided = Object.hasOwn(params.raw, "category");
   const requestedCategory = readToolStringParam(params.raw, "category", { allowEmpty: true });
   if (params.raw.visible !== true) {
-    if (params.runtime === "acp" && requestedCategory) {
-      throw new ToolInputError(
-        'category is only available for visible dashboard sessions. Choose one: omit category for a hidden or ACP run; or set visible=true, use runtime="subagent", and omit mode and streamTo.',
-      );
-    }
     const visibleOnlyParams = [
       ["category", categoryProvided ? requestedCategory : undefined],
       ["worktree", worktree],
@@ -128,6 +123,11 @@ export async function maybeSpawnVisibleSession(params: {
     const providedVisibleOnlyParams = visibleOnlyParams
       .filter(([, value]) => value !== undefined && value !== false)
       .map(([name]) => name);
+    if (params.runtime === "acp" && categoryProvided) {
+      throw new ToolInputError(
+        `Parameters only available for visible dashboard sessions: ${providedVisibleOnlyParams.join(", ")}. Choose one: omit them for a hidden or ACP run; or set visible=true, use runtime="subagent", and omit mode and streamTo.`,
+      );
+    }
     if (providedVisibleOnlyParams.length > 0) {
       throw new ToolInputError(
         `Parameters require visible=true: ${providedVisibleOnlyParams.join(", ")}`,

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -114,6 +114,11 @@ export async function maybeSpawnVisibleSession(params: {
   const categoryProvided = Object.hasOwn(params.raw, "category");
   const requestedCategory = readToolStringParam(params.raw, "category", { allowEmpty: true });
   if (params.raw.visible !== true) {
+    if (params.runtime === "acp" && requestedCategory) {
+      throw new ToolInputError(
+        'category is only available for visible dashboard sessions. Choose one: omit category for a hidden or ACP run; or set visible=true, use runtime="subagent", and omit mode and streamTo.',
+      );
+    }
     const visibleOnlyParams = [
       ["category", categoryProvided ? requestedCategory : undefined],
       ["worktree", worktree],


### PR DESCRIPTION
Fixes #131221

## What problem this solves

Agents can enter an invalid `sessions_spawn` retry loop when an ACP run includes the dashboard-only `category` parameter. The old error only recommends enabling `visible:true`, which creates another invalid request with `runtime:"acp"`, `mode:"run"`, and `streamTo:"parent"`.

## Why this change was made

The validator now gives both valid recovery paths:

- remove every supplied visible-only parameter for a hidden or ACP run;
- use `visible:true` with `runtime:"subagent"`, then remove `mode` and `streamTo`.

The ACP recovery lists every supplied visible-only parameter, including compound requests such as `category + worktree`. It also handles an explicitly empty category. Spawn semantics and the flat tool schema remain unchanged.

This keeps the repair local to validation instead of adding a discriminated union or `oneOf` schema that provider adapters may handle inconsistently.

## User impact

Agents receive recovery advice that produces a valid next request, including compound invalid inputs.

## Evidence

### Tests and checks

- The regression table covers a normal category, an empty category, and `category + worktree` on an ACP run using `mode:"run"` and `streamTo:"parent"`.
- Before the compound repair, the new cases failed because the diagnostic named only `category`.
- `node scripts/run-vitest.mjs src/agents/tools/sessions-spawn-tool.test.ts`: 118 tests passed after the repair and again after rebasing.
- `node scripts/check-changed.mjs -- src/agents/tools/sessions-spawn-visible.ts src/agents/tools/sessions-spawn-tool.test.ts`: passed.
- Production delta: +5 lines. Test delta: +42 lines.

### Autoreview

Command:

```text
autoreview --mode branch --base upstream/main --engine codex --stream-engine-output
```

The first run found the empty-category gap. After adding that case, the final run reported no findings and rated the patch correct with 0.94 confidence.

### Runtime proof

Lapis Heart Core Lab ran the rebased PR head `bfd59df0e922` through a real Gateway on the isolated `heart` profile. The CLI and Gateway both reported OpenClaw `2026.8.1 (bfd59df)`. A real `openai/gpt-5.6-sol` agent was instructed to make exactly one tool call and not retry.

Tool input:

```json
{
  "task": "Runtime proof only; do not perform work",
  "runtime": "acp",
  "mode": "run",
  "streamTo": "parent",
  "category": "runtime proof",
  "worktree": true
}
```

Observed tool error:

```text
Parameters only available for visible dashboard sessions: category, worktree. Choose one: omit them for a hidden or ACP run; or set visible=true, use runtime="subagent", and omit mode and streamTo.
```

The run reported `toolSummary.calls=1`, `toolSummary.failures=1`, `tools=["sessions_spawn"]`, and `successfulToolNames=[]`. No child session was created.

## Worked on by

- Benjamin Jesuiter (@bjesuiter)
