### PR TITLE
fix(test): clean fallback SQLite state after test runs

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -81,8 +81,8 @@ reconcile dependencies before the remote wrapper starts.
 
 Maintained JavaScript tooling wrappers and root package commands use tsx's
 in-process transform cache. They skip its shared disk cache before the loader
-starts, and child tooling inherits that policy. This does not relocate or clean
-temporary directories, Node or Vitest caches, or other global caches. Standalone
+starts, and child tooling inherits that policy. This cache policy does not clean
+existing temporary directories, Node or Vitest caches, or other global caches. Standalone
 `pnpm ui:build` keeps native startup and applies the same preload to its post-build
 validators; it does not require `TSX_DISABLE_CACHE` in the invoking shell. Raw
 external `tsx` and `node --import tsx` invocations outside these launchers are unchanged.
@@ -124,6 +124,14 @@ Python helper coverage remains separate, including macOS; these fixture gates
 do not restrict the [SSH backend's Gateway host](/gateway/sandboxing#ssh-backend).
 
 ## Shared test state and process helpers
+
+On POSIX hosts, the Vitest wrapper gives each invocation an owned temporary
+namespace through `TMPDIR`, `TMP`, and `TEMP`. Fallback SQLite state stays available
+across shared-worker files and module resets, then the wrapper removes the namespace
+after its child process group has stopped, including failed test runs. Explicit state
+and artifact paths outside that namespace are unchanged. Windows and raw invocations
+outside the wrapper are unchanged; interrupted wrappers or unverified process-group
+teardown can retain their temporary files. The wrapper never sweeps old PID directories.
 
 - `src/test-utils/openclaw-test-state.ts`: use from Vitest when a test needs an isolated `HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, config fixture, workspace, agent dir, or auth-profile store.
 - `pnpm test:env-mutations:report`: non-blocking report of tests/harnesses that mutate `HOME`, `OPENCLAW_STATE_DIR`, `OPENCLAW_CONFIG_PATH`, `OPENCLAW_WORKSPACE_DIR`, or related env keys directly. Use it to find migration candidates for the shared test-state helper.

--- a/scripts/docs-i18n/translator_test.go
+++ b/scripts/docs-i18n/translator_test.go
@@ -202,6 +202,14 @@ func TestBuildCodexTranslationPromptIncludesGuardrailsAndInput(t *testing.T) {
 
 func TestRunCodexExecPromptUsesOutputLastMessage(t *testing.T) {
 	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(dir, "cache"))
+	t.Setenv("LocalAppData", filepath.Join(dir, "cache"))
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("EXPECTED_CODEX_HOME_BASE", filepath.Join(cacheDir, "openclaw-docs-i18n"))
 	fakeCodex := filepath.Join(dir, "codex")
 	if err := os.WriteFile(fakeCodex, []byte(`#!/bin/sh
 set -eu
@@ -254,11 +262,22 @@ if ! grep -q '"OPENAI_API_KEY":"test-openai-key"' "$CODEX_HOME/auth.json"; then
   exit 1
 fi
 case "$CODEX_HOME" in
-  /tmp/*)
-    echo "CODEX_HOME must not be under /tmp" >&2
+  "$EXPECTED_CODEX_HOME_BASE"/codex-home-*) ;;
+  *)
+    echo "CODEX_HOME must belong to the user cache" >&2
     exit 1
     ;;
 esac
+for private_dir in "$EXPECTED_CODEX_HOME_BASE" "$CODEX_HOME"; do
+  if [ -z "$(find "$private_dir" -prune -type d -perm 0700)" ]; then
+    echo "Codex cache and home must have mode 0700" >&2
+    exit 1
+  fi
+done
+if [ -z "$(find "$CODEX_HOME/auth.json" -prune -type f -perm 0600)" ]; then
+  echo "auth.json must have mode 0600" >&2
+  exit 1
+fi
 printf 'translated from codex\n' > "$out"
 `), 0o755); err != nil {
 		t.Fatalf("write fake codex: %v", err)
@@ -277,6 +296,13 @@ printf 'translated from codex\n' > "$out"
 	}
 	if got != "translated from codex" {
 		t.Fatalf("unexpected output %q", got)
+	}
+	entries, err := os.ReadDir(filepath.Join(cacheDir, "openclaw-docs-i18n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("Codex home was not removed: %v", entries)
 	}
 }
 

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -3,8 +3,9 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import { createRequire } from "node:module";
-import { constants as osConstants } from "node:os";
+import { constants as osConstants, tmpdir } from "node:os";
 import path from "node:path";
+import { createTempDirTracker } from "../test/helpers/temp-dir.js";
 import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,
@@ -1259,10 +1260,28 @@ export function spawnWatchedVitestProcess({
 }) {
   let forwardedSignal: NodeSignal | null = null;
   let diagnosticsCompletion: Promise<void> | null = null;
-  const child = spawnVitestProcess({
-    pnpmArgs,
-    spawnParams,
-  });
+  const tempDirs = createTempDirTracker();
+  let childSpawnParams = spawnParams;
+  // The POSIX completion contract joins all workers before deleting SQLite files.
+  // Own a fresh namespace outside worker module resets, never ambient PID directories.
+  if (spawnParams.detached && shouldUseDetachedVitestProcessGroup()) {
+    const childEnv = spawnParams.env ?? process.env;
+    const tempRoot = tempDirs.make(
+      "oc-vt-",
+      fs.realpathSync(childEnv.TMPDIR || childEnv.TMP || childEnv.TEMP || tmpdir()),
+    );
+    childSpawnParams = {
+      ...spawnParams,
+      env: { ...childEnv, TMPDIR: tempRoot, TMP: tempRoot, TEMP: tempRoot },
+    };
+  }
+  let child: ChildProcess;
+  try {
+    child = spawnVitestProcess({ pnpmArgs, spawnParams: childSpawnParams });
+  } catch (error) {
+    tempDirs.cleanup();
+    throw error;
+  }
   const teardownChildCleanup = installVitestProcessGroupCleanup({
     child,
     forceSignal: "SIGKILL",
@@ -1321,11 +1340,19 @@ export function spawnWatchedVitestProcess({
   ])
     .then(async ([{ code, signal }]) => {
       await diagnosticsCompletion;
+      tempDirs.cleanup();
       const result = unhandledErrors.finish();
       if (result) {
         writeVitestUnhandledErrorSummary(result, env);
       }
       return { code, signal: normalizeNodeSignal(signal) };
+    })
+    .catch((error: unknown) => {
+      // A failed spawn owns no handles. A failed group join may still own them.
+      if (!child.pid) {
+        tempDirs.cleanup();
+      }
+      throw error;
     })
     .finally(teardown);
 

--- a/scripts/run-vitest.mts
+++ b/scripts/run-vitest.mts
@@ -5,7 +5,7 @@ import fs from "node:fs";
 import { createRequire } from "node:module";
 import { constants as osConstants, tmpdir } from "node:os";
 import path from "node:path";
-import { createTempDirTracker } from "../test/helpers/temp-dir.js";
+import { createTempDirTracker } from "../test/helpers/temp-dir.ts";
 import {
   agentVitestProjectOwners,
   embeddedAgentVitestProjectOwners,

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -2536,22 +2536,21 @@ describe("runDoctorSessionSqlite", () => {
     const manifestPath = path.join(store.tempDir, "failed-migration.json");
     const unpairedSurrogate =
       /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u;
-    const writeManifest = (messages: string[], targetCount = 1) => {
+    const writeManifest = (messages: string[]) => {
       const manifest: SessionSqliteMigrationManifest = {
         failedAt: "2030-01-01T00:00:00.000Z",
         manifestVersion: 2,
         openClawVersion: "test",
         runId: "utf16-boundary",
         startedAt: "2030-01-01T00:00:00.000Z",
-        targets: Array.from({ length: targetCount }, (_, index) => {
-          const targetMessages = index === targetCount - 1 ? messages : ["x".repeat(500)];
+        targets: Array.from({ length: Math.ceil(messages.length / 10) }, (_, index) => {
           return {
-            agentId:
-              targetCount === 1
-                ? "agent-with-long-name-".repeat(10)
-                : `agent-${index}-${"long-name-".repeat(10)}`,
+            agentId: `agent-${index}`,
             completedMoves: [],
-            issues: targetMessages.map((message) => ({ code: "startup_failure", message })),
+            issues: messages.slice(index * 10, (index + 1) * 10).map((message) => ({
+              code: "startup_failure",
+              message,
+            })),
             plannedMoves: [],
             sqlitePath: path.join(store.tempDir, "openclaw-agent.sqlite"),
             storePath: store.storePath,
@@ -2564,40 +2563,51 @@ describe("runDoctorSessionSqlite", () => {
 
     writeManifest([`${"x".repeat(499)}🎉tail`]);
     const fieldIssue = createSessionSqliteMigrationFailureIssue(manifestPath);
+    expect(fieldIssue?.body).toContain(`${"x".repeat(499)}\n`);
+    expect(fieldIssue?.body).not.toContain("🎉tail");
     expect(fieldIssue?.body).not.toMatch(unpairedSurrogate);
     expect(new URL(fieldIssue?.url ?? "").searchParams.get("body")).not.toContain("�");
 
-    const baseMessages = Array.from({ length: 9 }, () => "x".repeat(500));
-    writeManifest([...baseMessages, "MESSAGE_START"]);
-    const probe = createSessionSqliteMigrationFailureIssue(manifestPath);
-    const messageOffset = probe?.body.indexOf("MESSAGE_START") ?? -1;
-    expect(5_999 - messageOffset).toBeLessThan(500);
+    for (const [limit, messageCount] of [
+      [6_000, 20],
+      [20_000, 50],
+    ] as const) {
+      const marker = "BOUNDARY";
+      const messages = Array.from({ length: messageCount - 1 }, () => "");
+      writeManifest([...messages, `${marker}!!tail`]);
+      const probe = createSessionSqliteMigrationFailureIssue(manifestPath);
+      const markerOffset = probe?.body.indexOf(marker) ?? -1;
+      expect(markerOffset).toBeGreaterThanOrEqual(0);
+      let padding = limit - 1 - markerOffset - marker.length;
+      expect(padding).toBeGreaterThanOrEqual(0);
 
-    writeManifest([...baseMessages, `${"x".repeat(5_999 - messageOffset)}🎉tail`]);
-    const issue = createSessionSqliteMigrationFailureIssue(manifestPath);
-    expect(issue?.body).toContain("🎉tail");
-    const urlBody = new URL(issue?.url ?? "").searchParams.get("body");
-    expect(urlBody).not.toContain("�");
-    expect(urlBody).toContain("truncated for URL");
-
-    let bodyTargetCount = 0;
-    let bodyMessageOffset = -1;
-    for (let count = 1; count < 50; count += 1) {
-      writeManifest(["BODY_START"], count);
-      const candidateIssue = createSessionSqliteMigrationFailureIssue(manifestPath);
-      const candidateOffset = candidateIssue?.body.indexOf("BODY_START") ?? -1;
-      if (candidateOffset < 0) {
-        break;
+      // Fill earlier fields, each within its 500-unit cap, so path length cannot
+      // move the surrogate away from the URL/body boundary being exercised.
+      for (let index = 0; index < messages.length; index += 1) {
+        const length = Math.min(padding, 500);
+        messages[index] = "x".repeat(length);
+        padding -= length;
       }
-      bodyTargetCount = count;
-      bodyMessageOffset = candidateOffset;
-    }
-    expect(bodyMessageOffset).toBeGreaterThanOrEqual(0);
-    expect(19_999 - bodyMessageOffset).toBeLessThan(600);
+      expect(padding).toBe(0);
+      writeManifest([...messages, `${marker}!!tail`]);
+      const aligned = createSessionSqliteMigrationFailureIssue(manifestPath);
+      expect(aligned?.body.slice(limit - 1 - marker.length, limit)).toBe(`${marker}!`);
 
-    writeManifest([`${"x".repeat(19_999 - bodyMessageOffset)}🎉tail`], bodyTargetCount);
-    const bodyIssue = createSessionSqliteMigrationFailureIssue(manifestPath);
-    expect(bodyIssue?.body).not.toMatch(unpairedSurrogate);
+      writeManifest([...messages, `${marker}🎉tail`]);
+      const issue = createSessionSqliteMigrationFailureIssue(manifestPath);
+      const urlBody = new URL(issue?.url ?? "").searchParams.get("body");
+      expect(urlBody).not.toContain("�");
+      expect(urlBody).toContain("truncated for URL");
+      expect(issue?.body).not.toMatch(unpairedSurrogate);
+      if (limit === 6_000) {
+        expect(issue?.body).toContain(`${marker}🎉tail`);
+        expect(urlBody?.split("\n\n...(truncated for URL")[0]).toHaveLength(limit - 1);
+        expect(urlBody).toContain(`${marker}\n\n...(truncated for URL`);
+      } else {
+        expect(issue?.body).toHaveLength(limit - 1);
+        expect(issue?.body.endsWith(marker)).toBe(true);
+      }
+    }
   });
 
   it("recovers only manifests matching an explicit store selector", async () => {

--- a/test/scripts/docs-i18n.test.ts
+++ b/test/scripts/docs-i18n.test.ts
@@ -14,15 +14,17 @@ describe.skipIf(!hasGoToolchain)("docs-i18n Go module", () => {
   let tempDir = "";
 
   beforeAll(() => {
-    const tempRoot = tmpdir() === "/tmp" ? "/var/tmp" : tmpdir();
-    tempDir = mkdtempSync(path.join(tempRoot, "openclaw-docs-i18n-test-"));
+    tempDir = mkdtempSync(path.join(tmpdir(), "openclaw-docs-i18n-test-"));
     binaryPath = path.join(
       tempDir,
       process.platform === "win32" ? "docs-i18n.test.exe" : "docs-i18n.test",
     );
-    const result = spawnSync("go", ["test", "-c", "-o", binaryPath, "."], {
+    const result = spawnSync("go", ["test", "-modcacherw", "-c", "-o", binaryPath, "."], {
       cwd: "scripts/docs-i18n",
       encoding: "utf8",
+      // Go's default read-only module directories prevent recursive teardown.
+      // Keep this build's writable module cache inside the suite-owned root.
+      env: { ...process.env, GOMODCACHE: path.join(tempDir, "gomodcache") },
     });
     if (result.error || result.status !== 0) {
       throw result.error ?? new Error(result.stderr || result.stdout || "failed to build Go tests");
@@ -44,7 +46,7 @@ describe.skipIf(!hasGoToolchain)("docs-i18n Go module", () => {
     await execFileAsync(binaryPath, ["-test.count=1", `-test.run=${pattern}`], {
       cwd: "scripts/docs-i18n",
       encoding: "utf8",
-      // The fixture verifies Codex auth never lands under the shared system temp directory.
+      // The user cache can be under /tmp when the test invocation owns it.
       env: { ...process.env, XDG_CACHE_HOME: path.join(tempDir, "cache", partition) },
     });
   });

--- a/test/scripts/run-vitest-state-cleanup.test.ts
+++ b/test/scripts/run-vitest-state-cleanup.test.ts
@@ -1,0 +1,146 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { promisify } from "node:util";
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const execFileAsync = promisify(execFile);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const posixIt = process.platform === "win32" ? it.skip : it;
+
+posixIt.each([
+  { pool: "threads", failRun: false },
+  { pool: "threads", failRun: true },
+  { pool: "forks", failRun: false },
+  { pool: "forks", failRun: true },
+])(
+  "cleans fallback SQLite after $pool completion (failed run: $failRun)",
+  async ({ pool, failRun }) => {
+    const root = tempDirs.make("oc-vt-state-");
+    const tmp = path.join(root, "tmp");
+    const home = path.join(root, "home");
+    fs.mkdirSync(tmp);
+    fs.mkdirSync(home);
+    fs.symlinkSync(
+      path.join(repoRoot, "node_modules"),
+      path.join(root, "node_modules"),
+      "junction",
+    );
+
+    // These namespaces belong to callers, not the child invocation. Keep an open
+    // SQLite reader in a sibling PID namespace throughout the real Vitest run.
+    const siblingRoot = path.join(tmp, "openclaw-test-state", `${process.pid}-7`);
+    fs.mkdirSync(siblingRoot, { recursive: true });
+    const sibling = new DatabaseSync(path.join(siblingRoot, "sentinel.sqlite"));
+    const explicitPath = path.join(home, "live-state", "state", "openclaw.sqlite");
+    const receiptPath = path.join(root, "receipt.json");
+    const databaseModule = JSON.stringify(path.join(repoRoot, "src/state/openclaw-state-db.ts"));
+    const setupModule = path.join(repoRoot, "test/setup.ts");
+    fs.writeFileSync(
+      path.join(root, "01-open.test.ts"),
+      `import fs from "node:fs";
+import { expect, it } from "vitest";
+import { openOpenClawStateDatabase, closeOpenClawStateDatabaseForTest } from ${databaseModule};
+it("opens actual fallback SQLite and retains it until the worker finishes", () => {
+  const first = openOpenClawStateDatabase();
+  expect(first.db.prepare("SELECT count(*) AS count FROM sqlite_schema").get().count).toBeGreaterThan(0);
+  closeOpenClawStateDatabaseForTest();
+  expect(first.db.isOpen).toBe(false);
+  const reopened = openOpenClawStateDatabase();
+  const explicit = openOpenClawStateDatabase({ env: { OPENCLAW_STATE_DIR: ${JSON.stringify(path.dirname(path.dirname(explicitPath)))} } });
+  globalThis[Symbol.for("openclaw.stateLeakFixture")] = { reopened, explicit, pid: process.pid };
+  fs.writeFileSync(${JSON.stringify(receiptPath)}, JSON.stringify({ path: reopened.path }));
+});
+`,
+    );
+    fs.writeFileSync(
+      path.join(root, "02-reset.test.ts"),
+      `import fs from "node:fs";
+import { expect, it, vi } from "vitest";
+it("keeps the same worker namespace alive across files and module resets", async () => {
+  const previous = globalThis[Symbol.for("openclaw.stateLeakFixture")];
+  expect(process.pid).toBe(previous.pid);
+  expect(previous.reopened.db.isOpen).toBe(true);
+  expect(previous.explicit.db.isOpen).toBe(true);
+  vi.resetModules();
+  const { openOpenClawStateDatabase } = await import(${databaseModule});
+  const current = openOpenClawStateDatabase();
+  expect(current.path).toBe(previous.reopened.path);
+  expect(current.db.prepare("SELECT count(*) AS count FROM sqlite_schema").get().count).toBeGreaterThan(0);
+  expect(fs.existsSync(current.path)).toBe(true);
+  fs.writeFileSync(${JSON.stringify(receiptPath)}, JSON.stringify({ path: current.path, resetVerified: true }));
+  ${failRun ? 'expect.fail("intentional failure after SQLite allocation");' : ""}
+});
+`,
+    );
+    const configPath = path.join(root, "vitest.config.ts");
+    fs.writeFileSync(
+      configPath,
+      `import { sharedVitestConfig } from ${JSON.stringify(path.join(repoRoot, "test/vitest/vitest.shared.config.ts"))};
+import { BaseSequencer } from "vitest/node";
+class AlphabeticalSequencer extends BaseSequencer {
+  async sort(files) { return [...files].sort((a, b) => a.moduleId.localeCompare(b.moduleId)); }
+}
+export default {
+  resolve: sharedVitestConfig.resolve,
+  cacheDir: ${JSON.stringify(path.join(root, ".vite"))},
+  test: {
+    pool: ${JSON.stringify(pool)}, isolate: false, fileParallelism: false, maxWorkers: 1,
+    sequence: { sequencer: AlphabeticalSequencer },
+    runner: ${JSON.stringify(path.join(repoRoot, "test/non-isolated-runner.ts"))},
+    setupFiles: [${JSON.stringify(setupModule)}],
+  },
+};
+`,
+    );
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of Object.keys(env)) {
+      if (key.startsWith("VITEST") || key.startsWith("OPENCLAW_") || key === "LIVE") {
+        delete env[key];
+      }
+    }
+    Object.assign(env, { HOME: home, USERPROFILE: home, TMPDIR: tmp, TMP: tmp, TEMP: tmp });
+    try {
+      const result = await execFileAsync(
+        process.execPath,
+        [
+          path.join(repoRoot, "scripts/run-vitest.mjs"),
+          "run",
+          "--root",
+          root,
+          "--config",
+          configPath,
+        ],
+        { cwd: repoRoot, env },
+      ).then(
+        ({ stdout, stderr }) => ({ code: 0, output: stdout + stderr }),
+        (error: { code: number; stdout: string; stderr: string }) => ({
+          code: error.code,
+          output: error.stdout + error.stderr,
+        }),
+      );
+      expect(result.code, result.output).toBe(failRun ? 1 : 0);
+      const receipt = JSON.parse(fs.readFileSync(receiptPath, "utf8")) as {
+        path: string;
+        resetVerified: boolean;
+      };
+      expect(receipt.resetVerified).toBe(true);
+      expect(fs.existsSync(path.dirname(path.dirname(receipt.path)))).toBe(false);
+      expect(sibling.prepare("PRAGMA quick_check").get()).toEqual({ quick_check: "ok" });
+      expect(fs.existsSync(siblingRoot)).toBe(true);
+      const explicit = new DatabaseSync(explicitPath, { readOnly: true });
+      try {
+        expect(
+          explicit.prepare("SELECT count(*) AS count FROM sqlite_schema").get()?.count,
+        ).toBeGreaterThan(0);
+      } finally {
+        explicit.close();
+      }
+    } finally {
+      sibling.close();
+    }
+  },
+);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where repeated POSIX Vitest runs retain SQLite test state after workers stop. The original leak used a PID-based fallback outside the isolated test HOME. Main now resolves SQLite through the test HOME, but real worker teardown can still leave that owned directory behind. Closing a database must preserve its files for reopening during the same invocation; final cleanup belongs to the invocation owner.

The worker-scoped fallback originated in [d115fb4cf9f9](https://github.com/openclaw/openclaw/commit/d115fb4cf9f901f292981b338dc65f86cd54fdfd).

## Why This Change Was Made

The Vitest runner allocates a unique invocation-owned temporary namespace through the existing temp-directory tracker and removes it only after its POSIX process group, output, and diagnostics finish. This keeps cleanup outside worker module resets and preserves close/reopen behavior across files. Explicit state paths outside the namespace remain untouched. Database-close deletion, global PID sweeps, and forced state-directory overrides are not used.

The initial [CI run 33129635903](https://github.com/openclaw/openclaw/actions/runs/33129635903) exposed three connected fixture defects, repaired at their owners:

- The Unicode fixture depended on path lengths and tried to pad one field beyond its existing 500-unit cap. It now distributes bounded padding across earlier fields, proves alignment with an ASCII control, and checks exact retained prefixes at the unchanged field, URL, and body limits.
- The fake Codex fixture rejected any path beginning with `/tmp`, including a private user cache. It now owns its user-cache inputs and verifies the selected cache owner, 0700 directories, 0600 auth file, and home deletion. Existing auth-mode and output-file checks remain; the `/var/tmp` escape is removed.
- Go compilation created default 0555 module-cache directories inside the test HOME, which prevented final cleanup. The compilation owner now supplies a suite-local `GOMODCACHE` and Go's supported `-modcacherw` flag. No generic chmod traversal, retry, or suppressed cleanup error is added.

Production database paths, stores, schema, configuration, authentication, and Unicode limits are unchanged.

## User Impact

Developers using the supported POSIX wrappers no longer retain fallback SQLite fixtures after normal or failed test completion. Invocation scratch files are also owned by the run; retain diagnostic artifacts outside the namespace when they must survive. Production Gateway behavior is unchanged.

Windows and raw invocations outside the wrapper remain unchanged. A forcibly terminated wrapper or unverified process-group teardown may retain its namespace rather than delete potentially live state. No historical directories are swept.

## Evidence

The disposable reproduction used actual OpenClaw SQLite: a closed handle left the database/root behind before the fix, while both disappeared after runner completion with the fix. All four fallback regression cases failed on the pre-fix runner and pass after it: threads/forks × successful/failing runs. They preserve state across two files and module resets, an explicit database outside the namespace, and another process's open sibling database.

Local owner/sibling proof passed **264 tests, with one existing platform skip**, including all 171 original-scope tests:

```bash
node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts test/scripts/docs-i18n.test.ts
node scripts/run-vitest.mjs test/scripts/run-vitest-state-cleanup.test.ts test/scripts/run-vitest.test.ts test/scripts/vitest-process-group.test.ts test/helpers/temp-dir.test.ts src/commands/doctor-session-sqlite-github-issue.test.ts
node scripts/run-vitest.mjs test/test-env.test.ts src/test-utils/openclaw-test-state.test.ts
```

Both scoped changed gates passed, including types, lint, formatting, erasability, dead-export checks, and selected guards:

```bash
node scripts/check-changed.mjs -- scripts/run-vitest.mts test/scripts/run-vitest-state-cleanup.test.ts docs/reference/test.md
node scripts/check-changed.mjs -- src/commands/doctor-session-sqlite.test.ts test/scripts/docs-i18n.test.ts scripts/docs-i18n/translator_test.go
```

After the final platform-cache fixture input was added, the docs suite and fallback matrix passed again (**8 tests**), the Go-path changed gate passed, and `gofmt -l` plus `git diff --check` were clean.

Non-root Linux proof used Node 24.19 and Go 1.27: the original 66-file `core-tooling-7` selection passed **1,228 tests**, with **24 pre-existing PowerShell-dependent skips** because the raw image lacks PowerShell. The changed docs suite ran all four partitions. Another **238 runner/doctor sibling tests passed, with two platform skips**. No cleanup error remained. Run: `run_c710c939a6d6`; the disposable remote lease was released. This reproduced the original file selection, not its precise cache-dependent completion order; the docs-only reproduction independently established that no earlier fixture was needed to cause the leak.

Seven fault controls confirmed the assertions: raw slicing independently failed the field/URL/body checks, and Go overlays independently failed for 0644 auth, 0755 cache, an auth home outside the cache, and omitted cleanup. Production source was restored byte-for-byte before positive reruns. The Unicode controls and restored pass are in `run_25bb674a5e5c`; that combined driver later stopped on an ineffective permission injection under a restrictive umask, so its overall exit is not counted as green. The corrected four Go controls and restored positive all completed in `run_09dddd7e5f0b`, without changing umask.

Fresh Codex autoreviews for the original repair and the subsequent test-only repairs completed with no accepted/actionable findings at default **P0 scope**. Unchanged owner/dependency implementations were inspected separately, including Go module-cache/UserCacheDir source and Codex `login/src/auth/storage.rs:39–46,154–155,195–220`, `exec/src/cli.rs:67–76`, and `utils/home-dir/src/lib.rs:13–65`. This is subprocess-fixture proof, not live authenticated Codex execution.

ClawSweeper's [review and Rank-up move](https://github.com/openclaw/openclaw/pull/131313#issuecomment-5446921116) found no patch defect and independently passed the four-case fallback regression. Its requested compact-check investigation is addressed above; renewed exact-head CI remains mandatory before merge.

The Gateway prerequisite is now landed as [#131515](https://github.com/openclaw/openclaw/pull/131515), [e0edb3a9791be96acedac450a61d2a0823e11299](https://github.com/openclaw/openclaw/commit/e0edb3a9791be96acedac450a61d2a0823e11299), after green exact-head CI and native prepare/merge. [Issue #131405](https://github.com/openclaw/openclaw/issues/131405) is closed. The old cleanup head `8a245bc887458d0f07521ff7b135db77b9bd406b` and its failed [CI run 33132861934](https://github.com/openclaw/openclaw/actions/runs/33132861934) have not been relabeled green: that failure triggered the prerequisite; the rebased head below must pass renewed exact-head gates.

The branch is rebased onto `abf412aba4708e16641b2cf9134bad43c14a8bfd`, which contains both the Gateway prerequisite and [#131343](https://github.com/openclaw/openclaw/pull/131343). Only a documentation conflict was resolved; main’s newer UI-build guidance is preserved, and the approved implementation/test changes are preserved. Four files are byte-identical to the prior head; the doctor test file additionally contains 63 lines of tests inherited from main, with its approved Unicode fixture change unchanged. The rebase produced head `0dd12b52a7fc43f222bc75a9523a2f736fb20810`; the subsequent native-import correction below is the only further code change.

The overlap was checked directly rather than assuming the cleanup was superseded. On that pinned main, the exact unchanged four-case regression still failed: three cases reached the retained-directory assertion at `test/scripts/run-vitest-state-cleanup.test.ts:131` (failing threads, successful forks, failing forks); the successful-thread case instead hit its existing five-second SQLite-open timeout and is not counted as retained-state proof. The same four cases all passed on the rebased candidate. Main’s four standalone HOME-lifetime tests passed without the patch, showing that manual owner cleanup works but is not sufficient proof of actual Vitest worker teardown. Vitest 4.1.11 source confirms fork teardown sends signals and thread teardown calls `terminate()`; `test/setup.shared.ts` registers cleanup on the worker’s process exit event. No timeout, retry, or worker behavior was changed.

Fresh rebased proof passed **250 tests with one existing platform skip**:

```bash
node scripts/run-vitest.mjs test/scripts/run-vitest-state-cleanup.test.ts test/test-env.state-lifetime.test.ts
node scripts/run-vitest.mjs test/scripts/run-vitest.test.ts test/scripts/vitest-process-group.test.ts test/helpers/temp-dir.test.ts src/commands/doctor-session-sqlite.test.ts test/scripts/docs-i18n.test.ts
```

Formatting and `git diff --check` passed. Fresh isolated Codex branch autoreview completed with no actionable findings at default P0 scope, with the complete changed-owner/caller/dependency evidence supplied. The initial oversized evidence-file refusal occurred before provider submission; splitting at module boundaries preserved all evidence and scanner enforcement. [CI run 33144920896](https://github.com/openclaw/openclaw/actions/runs/33144920896) then failed two tooling checks, both because native Node could not resolve the runner’s `../test/helpers/temp-dir.js` import: the repository file is `.ts`. The tsx path had resolved it, masking the native preflight defect. [Commit 08527b3b94f3b979acb779818886cd8f1607a035](https://github.com/openclaw/openclaw/commit/08527b3b94f3b979acb779818886cd8f1607a035) changes only that import suffix; the existing helper depends solely on Node built-ins, so cleanup logic and ownership remain unchanged.

Direct native Node 24 import reproduced `ERR_MODULE_NOT_FOUND` before the change and succeeds afterward. Both failed checks now pass locally (**2 selected tests, 178 unselected**):

```bash
node --input-type=module -e 'await import("./scripts/run-vitest.mts")'
node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts test/scripts/pr-prepare-gates.test.ts -t 'keeps the preflight manifest import closure dependency-free|builds the canonical deterministic proof command'
```

Focused script lint, script typechecking, formatting, and TypeScript erasability pass. A fresh isolated Codex review of the one-line repair has no actionable P0 findings. The preceding selected local check completed guards, formatting, dead-export scans, and erasability, then was deliberately stopped during core-test typechecking before this edit; it is **not** represented as a complete local gate pass. The current head is `08527b3b94f3b979acb779818886cd8f1607a035`; renewed exact-head CI is required before native prepare/merge. No failed historical run has been relabeled green.

Production runtime **+0/-0**; test tooling **+32/-5**; tests/support **+227/-43**; documentation **+10/-2** after main-equivalent overlap. Total **+269/-50 across six files**. No full local suite or Windows runtime claim. No UI change; real process/filesystem behavior is the changed surface. AI-assisted with Codex.


Final gate: [CI33145816811](https://github.com/openclaw/openclaw/actions/runs/33145816811) and its required `openclaw/ci-gate` are green on `08527b3b94f3b979acb779818886cd8f1607a035`. [Land-ready proof](https://github.com/openclaw/openclaw/pull/131313#issuecomment-5449040864) records the exact commands, review scope, native-import correction, and remaining platform/QA-selection limits. Native preparation and merge completed successfully. Merged as [9a38b5ec8f6025dd52f89ab040d8a3413a473dd7](https://github.com/openclaw/openclaw/commit/9a38b5ec8f6025dd52f89ab040d8a3413a473dd7); [native completion](https://github.com/openclaw/openclaw/pull/131313#issuecomment-5449060795). The merged patch ID matches the reviewed candidate, and main contains both this cleanup and Gateway prerequisite #131515.
