### PR TITLE
fix: open terminals block cooperative release updates

### DIFF
--- a/docs/gateway/external-apps.md
+++ b/docs/gateway/external-apps.md
@@ -62,7 +62,7 @@ host-neutral suspension handshake:
 2. Call `gateway.suspend.prepare` with a stable, unique `requestId`.
 3. If the response is `busy`, keep the process running and retry later. To hold
    admission closed while already-admitted work finishes, request the optional
-   preserve-only drain mode and poll `gateway.suspend.status` instead.
+   drain mode and poll `gateway.suspend.status` instead.
 4. If the response is `ready`, save the returned `suspensionId`, then freeze or
    snapshot the process before `expiresAtMs`.
 5. After thaw, or if suspension is abandoned, call `gateway.suspend.resume`
@@ -94,14 +94,17 @@ The RPC contract is:
 
 `terminalPolicy` and `drain` are optional. `terminalPolicy` accepts only
 `"preserve"` or `"terminate"` and defaults to `"preserve"`; `drain` defaults
-to `false`. With `drain: false` or no `drain` field, request handling and
-response shapes are unchanged: open terminal sessions block normal host
-suspension. A caller preparing an update that will terminate the Gateway may
-explicitly use `"terminate"`; this ignores open process-local terminal sessions
-only. Terminal persistence activity and all other tracked work still block
-preparation. Drain mode always preserves terminals: combining `drain: true`
-with `terminalPolicy: "terminate"` returns `INVALID_REQUEST` without acquiring
-a lease.
+to `false`. The terminal policy applies to both immediate preparation and drain
+mode:
+
+- `"preserve"`: open terminal sessions block suspension. Use this for host
+  freeze/snapshot operations that must preserve the running process.
+- `"terminate"`: open process-local terminal sessions do not block suspension.
+  Use this for release updates that will restart the Gateway. Preparation does
+  not close terminals; the actual Gateway restart ends their PTYs and commands.
+
+Pending final chat-state writes (`terminal-persistence`) and all other tracked
+work still block preparation under either policy.
 
 IDs are trimmed, must contain a non-whitespace character, and are limited to
 128 characters. A busy prepare result has `status: "busy"`, `reason`,
@@ -136,11 +139,12 @@ and returns:
 ```
 
 Already-admitted work and its owned completions continue naturally; unrelated
-new runs, sessions, scheduled jobs, and independent work stay rejected. Open
-terminal sessions and terminal-persistence work remain blockers until they
-settle naturally. Drain mode never terminates or detaches a terminal. A terminal
-that remains open indefinitely can therefore keep the lease draining until the
-controller resumes it or the lease expires.
+new runs, sessions, scheduled jobs, and independent work stay rejected. With
+`terminalPolicy: "preserve"`, an open terminal can keep the lease draining until
+it closes, the controller resumes the Gateway, or the lease expires. With
+`terminalPolicy: "terminate"`, that same terminal remains open but does not
+block readiness. Neither policy terminates or detaches terminals during
+preparation, polling, renewal, resume, or lease expiry.
 
 Poll `gateway.suspend.status` with the returned `suspensionId`, honoring
 `retryAfterMs`. While blockers remain, status returns `status: "draining"`
@@ -165,6 +169,19 @@ openclaw gateway call gateway.suspend.status \
   --json
 openclaw gateway resume '<suspension-id>'
 ```
+
+For a release update, use the same handshake with `terminalPolicy: "terminate"`
+so an open terminal cannot hold the drain indefinitely:
+
+```bash
+openclaw gateway call gateway.suspend.prepare \
+  --params '{"requestId":"release-update-1","terminalPolicy":"terminate","drain":true}' \
+  --json
+```
+
+Wait for the lease to become `ready` before performing the checked restart.
+Terminal commands and scrollback are not recovered after restart; see
+[Restart recovery](/gateway/restart-recovery#what-is-not-resumed).
 
 A competing request ID or transient scheduler-resume failure returns retryable
 `UNAVAILABLE` with `retryAfterMs`. During scheduler recovery, prepare, status,

--- a/src/gateway/server-methods.suspension-admission.test.ts
+++ b/src/gateway/server-methods.suspension-admission.test.ts
@@ -15,6 +15,8 @@ import {
 import { handleGatewayRequest, runWithGatewayRequestEnvelope } from "./server-methods.js";
 import { suspendHandlers } from "./server-methods/suspend.js";
 import type { GatewayRequestHandler } from "./server-methods/types.js";
+import { TerminalSessionManager } from "./terminal/session-manager.js";
+import { baseOpenRequest, makeFakePty } from "./terminal/session-manager.test-helpers.js";
 
 function deferred() {
   let resolve = () => {};
@@ -312,154 +314,186 @@ describe("gateway request suspension admission", () => {
     );
   });
 
-  it("drains an admitted request while fencing new roots until terminal delivery settles", async () => {
-    const started = deferred();
-    const finish = deferred();
-    const active = dispatch({
-      method: "suspend-proof.admitted",
-      scope: "operator.write",
-      handler: async ({ respond }) => {
-        started.resolve();
-        await finish.promise;
-        respond(true, { delivered: true });
-      },
-    });
-    await started.promise;
-
-    const cron = {
-      pauseScheduling: vi.fn(),
-      resumeScheduling: vi.fn(),
-      getSuspensionBlockerCount: vi.fn(() => 0),
-    };
-    const terminalSessions = new Set(["terminal-preserved"]);
-    const chatAbortControllers = new Map([
-      [
-        "reply-pending",
-        {
-          controller: new AbortController(),
-          sessionId: "session-pending",
-          sessionKey: "agent:main:session-pending",
-          startedAtMs: 1,
-          expiresAtMs: 2,
-          registrationCleanupRequested: true,
-          controlUiVisible: true,
-          projectSessionTerminalPending: true,
+  it.each(["preserve", "terminate"] as const)(
+    "drains admitted work and final-state writes with %s terminal policy",
+    async (terminalPolicy) => {
+      const preservingTerminals = terminalPolicy === "preserve";
+      const started = deferred();
+      const finish = deferred();
+      const active = dispatch({
+        method: "suspend-proof.admitted",
+        scope: "operator.write",
+        handler: async ({ respond }) => {
+          started.resolve();
+          await finish.promise;
+          respond(true, { delivered: true });
         },
-      ],
-    ]);
-    const context = {
-      cron,
-      logGateway: { warn: vi.fn() },
-      chatAbortControllers,
-      chatQueuedTurns: new Map(),
-      terminalSessions,
-    } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"];
+      });
+      await started.promise;
 
-    const prepareHandler = suspendHandlers["gateway.suspend.prepare"];
-    const statusHandler = suspendHandlers["gateway.suspend.status"];
-    const resumeHandler = suspendHandlers["gateway.suspend.resume"];
-    if (!prepareHandler || !statusHandler || !resumeHandler) {
-      throw new Error("expected complete gateway suspension RPC handlers");
-    }
+      const cron = {
+        pauseScheduling: vi.fn(),
+        resumeScheduling: vi.fn(),
+        getSuspensionBlockerCount: vi.fn(() => 0),
+      };
+      const pty = makeFakePty();
+      const terminalSessions = new TerminalSessionManager({
+        emit: vi.fn(),
+        spawn: async () => pty,
+      });
+      await terminalSessions.open(baseOpenRequest());
+      const chatAbortControllers = new Map([
+        [
+          "reply-pending",
+          {
+            controller: new AbortController(),
+            sessionId: "session-pending",
+            sessionKey: "agent:main:session-pending",
+            startedAtMs: 1,
+            expiresAtMs: 2,
+            registrationCleanupRequested: true,
+            controlUiVisible: true,
+            projectSessionTerminalPending: true,
+          },
+        ],
+      ]);
+      const context = {
+        cron,
+        logGateway: { warn: vi.fn() },
+        chatAbortControllers,
+        chatQueuedTurns: new Map(),
+        terminalSessions,
+      } as unknown as Parameters<typeof handleGatewayRequest>[0]["context"];
 
-    const prepared = dispatch({
-      method: "gateway.suspend.prepare",
-      scope: "operator.admin",
-      handler: prepareHandler,
-      requestParams: { requestId: "issue-129906-drain", drain: true },
-      context,
-    });
-    await prepared.request;
+      let suspensionId: string | undefined;
+      try {
+        const prepareHandler = suspendHandlers["gateway.suspend.prepare"];
+        const statusHandler = suspendHandlers["gateway.suspend.status"];
+        const resumeHandler = suspendHandlers["gateway.suspend.resume"];
+        if (!prepareHandler || !statusHandler || !resumeHandler) {
+          throw new Error("expected complete gateway suspension RPC handlers");
+        }
 
-    const result = prepared.respond.mock.calls[0]?.[1] as
-      | { suspensionId: string; expiresAtMs: number }
-      | undefined;
-    expect(prepared.respond).toHaveBeenCalledWith(true, {
-      status: "draining",
-      suspensionId: expect.any(String),
-      expiresAtMs: expect.any(Number),
-      retryAfterMs: 20_000,
-      activeCount: 3,
-      blockers: expect.arrayContaining([
-        expect.objectContaining({ kind: "root-request", count: 1 }),
-        expect.objectContaining({ kind: "terminal-persistence", count: 1 }),
-        expect.objectContaining({ kind: "terminal-session", count: 1 }),
-      ]),
-    });
-    if (!result) {
-      throw new Error("expected an owned draining suspension lease");
-    }
-    expect(cron.pauseScheduling).toHaveBeenCalledOnce();
-    expect(cron.resumeScheduling).not.toHaveBeenCalled();
+        const prepared = dispatch({
+          method: "gateway.suspend.prepare",
+          scope: "operator.admin",
+          handler: prepareHandler,
+          requestParams: {
+            requestId: "request-terminal-policy-drain",
+            terminalPolicy,
+            drain: true,
+          },
+          context,
+        });
+        await prepared.request;
 
-    const unrelatedHandler = vi.fn<GatewayRequestHandler>();
-    const unrelated = dispatch({
-      method: "suspend-proof.unrelated",
-      scope: "operator.write",
-      handler: unrelatedHandler,
-      context,
-    });
-    await unrelated.request;
-    expect(unrelatedHandler).not.toHaveBeenCalled();
-    expect(unrelated.respond).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({
-        code: "UNAVAILABLE",
-        details: expect.objectContaining({ phase: "draining" }),
-      }),
-    );
+        const result = prepared.respond.mock.calls[0]?.[1] as
+          | { suspensionId: string; expiresAtMs: number }
+          | undefined;
+        suspensionId = result?.suspensionId;
+        expect(prepared.respond).toHaveBeenCalledWith(true, {
+          status: "draining",
+          suspensionId: expect.any(String),
+          expiresAtMs: expect.any(Number),
+          retryAfterMs: 20_000,
+          activeCount: preservingTerminals ? 3 : 2,
+          blockers: expect.arrayContaining([
+            expect.objectContaining({ kind: "root-request", count: 1 }),
+            expect.objectContaining({ kind: "terminal-persistence", count: 1 }),
+            ...(preservingTerminals
+              ? [expect.objectContaining({ kind: "terminal-session", count: 1 })]
+              : []),
+          ]),
+        });
+        if (!result) {
+          throw new Error("expected an owned draining suspension lease");
+        }
+        expect(cron.pauseScheduling).toHaveBeenCalledOnce();
+        expect(cron.resumeScheduling).not.toHaveBeenCalled();
 
-    finish.resolve();
-    await active.request;
-    terminalSessions.clear();
+        const unrelatedHandler = vi.fn<GatewayRequestHandler>();
+        const unrelated = dispatch({
+          method: "suspend-proof.unrelated",
+          scope: "operator.write",
+          handler: unrelatedHandler,
+          context,
+        });
+        await unrelated.request;
+        expect(unrelatedHandler).not.toHaveBeenCalled();
+        expect(unrelated.respond).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({
+            code: "UNAVAILABLE",
+            details: expect.objectContaining({ phase: "draining" }),
+          }),
+        );
 
-    const pending = dispatch({
-      method: "gateway.suspend.status",
-      scope: "operator.read",
-      handler: statusHandler,
-      requestParams: { suspensionId: result.suspensionId },
-      context,
-    });
-    await pending.request;
-    expect(pending.respond).toHaveBeenCalledWith(true, {
-      status: "draining",
-      expiresAtMs: result.expiresAtMs,
-      retryAfterMs: 20_000,
-      activeCount: 1,
-      blockers: [expect.objectContaining({ kind: "terminal-persistence", count: 1 })],
-    });
+        expect(terminalSessions.size).toBe(1);
+        expect(pty.killed).toBe(false);
+        finish.resolve();
+        await active.request;
+        if (preservingTerminals) {
+          terminalSessions.disposeAll();
+        }
 
-    chatAbortControllers.clear();
-    const ready = dispatch({
-      method: "gateway.suspend.status",
-      scope: "operator.read",
-      handler: statusHandler,
-      requestParams: { suspensionId: result.suspensionId },
-      context,
-    });
-    await ready.request;
-    expect(ready.respond).toHaveBeenCalledWith(true, {
-      status: "ready",
-      expiresAtMs: result.expiresAtMs,
-    });
-    expect(cron.resumeScheduling).not.toHaveBeenCalled();
+        const pending = dispatch({
+          method: "gateway.suspend.status",
+          scope: "operator.read",
+          handler: statusHandler,
+          requestParams: { suspensionId: result.suspensionId },
+          context,
+        });
+        await pending.request;
+        expect(pending.respond).toHaveBeenCalledWith(true, {
+          status: "draining",
+          expiresAtMs: result.expiresAtMs,
+          retryAfterMs: 20_000,
+          activeCount: 1,
+          blockers: [expect.objectContaining({ kind: "terminal-persistence", count: 1 })],
+        });
 
-    const resumed = dispatch({
-      method: "gateway.suspend.resume",
-      scope: "operator.admin",
-      handler: resumeHandler,
-      requestParams: { suspensionId: result.suspensionId },
-      context,
-    });
-    await resumed.request;
-    expect(resumed.respond).toHaveBeenCalledWith(true, {
-      ok: true,
-      status: "running",
-      resumed: true,
-    });
-    expect(cron.resumeScheduling).toHaveBeenCalledOnce();
-  });
+        chatAbortControllers.clear();
+        const ready = dispatch({
+          method: "gateway.suspend.status",
+          scope: "operator.read",
+          handler: statusHandler,
+          requestParams: { suspensionId: result.suspensionId },
+          context,
+        });
+        await ready.request;
+        expect(ready.respond).toHaveBeenCalledWith(true, {
+          status: "ready",
+          expiresAtMs: result.expiresAtMs,
+        });
+        expect(cron.resumeScheduling).not.toHaveBeenCalled();
+
+        const resumed = dispatch({
+          method: "gateway.suspend.resume",
+          scope: "operator.admin",
+          handler: resumeHandler,
+          requestParams: { suspensionId: result.suspensionId },
+          context,
+        });
+        await resumed.request;
+        expect(resumed.respond).toHaveBeenCalledWith(true, {
+          ok: true,
+          status: "running",
+          resumed: true,
+        });
+        expect(cron.resumeScheduling).toHaveBeenCalledOnce();
+        expect(terminalSessions.size).toBe(preservingTerminals ? 0 : 1);
+        expect(pty.killed).toBe(preservingTerminals);
+      } finally {
+        finish.resolve();
+        await active.request;
+        if (suspensionId) {
+          resumeGatewaySuspend(suspensionId);
+        }
+        terminalSessions.disposeAll();
+      }
+    },
+  );
 
   it("rejects new read and write handlers outside the suspension allowlist", async () => {
     const suspension = tryBeginGatewaySuspendAdmission(() => {});

--- a/src/gateway/server-methods/suspend.test.ts
+++ b/src/gateway/server-methods/suspend.test.ts
@@ -58,20 +58,6 @@ describe("gateway suspend handlers", () => {
     });
   });
 
-  it("rejects draining requests that would terminate preserved terminals", async () => {
-    const { respond } = await invoke("gateway.suspend.prepare", {
-      requestId: "request-terminate-drain",
-      terminalPolicy: "terminate",
-      drain: true,
-    });
-
-    expect(coordinator.prepare).not.toHaveBeenCalled();
-    expect(respond).toHaveBeenCalledWith(false, undefined, {
-      code: "INVALID_REQUEST",
-      message: "invalid gateway.suspend.prepare params",
-    });
-  });
-
   it("wires prepare to scheduler pause/resume and returns busy or ready", async () => {
     coordinator.prepare.mockReturnValueOnce({
       status: "busy",

--- a/src/gateway/server-methods/suspend.ts
+++ b/src/gateway/server-methods/suspend.ts
@@ -28,10 +28,7 @@ function schedulerRecoveryError(retryAfterMs: number) {
 
 export const suspendHandlers: GatewayRequestHandlers = {
   "gateway.suspend.prepare": async ({ respond, params, context }) => {
-    if (
-      !validateGatewaySuspendPrepareParams(params) ||
-      (params.drain === true && params.terminalPolicy === "terminate")
-    ) {
+    if (!validateGatewaySuspendPrepareParams(params)) {
       respond(false, undefined, invalidParams("gateway.suspend.prepare"));
       return;
     }

--- a/src/infra/gateway-suspend-coordinator.test.ts
+++ b/src/infra/gateway-suspend-coordinator.test.ts
@@ -133,24 +133,6 @@ describe("gateway suspend coordinator", () => {
     expect(isGatewayWorkAdmissionClosed()).toBe(false);
   });
 
-  it("rejects terminating drain requests before acquiring admission or pausing scheduling", () => {
-    const pauseScheduling = vi.fn();
-
-    expect(() =>
-      prepareGatewaySuspend({
-        requestId: "request-invalid-terminating-drain",
-        terminalPolicy: "terminate",
-        drain: true,
-        pauseScheduling,
-        resumeScheduling: vi.fn(),
-        inspect: inspectors(),
-      }),
-    ).toThrow("gateway suspension draining requires terminalPolicy preserve");
-
-    expect(pauseScheduling).not.toHaveBeenCalled();
-    expect(isGatewayWorkAdmissionClosed()).toBe(false);
-  });
-
   it("holds a preserve-only drain until terminal persistence, delivery, and sessions settle", () => {
     let pendingReplies = 1;
     let terminalPersistence = 1;
@@ -224,62 +206,69 @@ describe("gateway suspend coordinator", () => {
     expect(isGatewayWorkAdmissionClosed()).toBe(false);
   });
 
-  it("renews the same draining owner and rejects conflicting request, policy, or drain modes", () => {
-    let queued = 2;
-    let nowMs = 1_000;
-    const pauseScheduling = vi.fn();
-    const resumeScheduling = vi.fn();
-    const params = {
-      requestId: "request-drain-renewal",
-      terminalPolicy: "preserve" as const,
-      drain: true,
-      pauseScheduling,
-      resumeScheduling,
-      inspect: inspectors({ getQueueSize: () => queued }),
-      nowMs: () => nowMs,
-      createSuspensionId: () => "suspension-drain-renewal",
-    };
+  it.each(["preserve", "terminate"] as const)(
+    "renews the same %s drain and rejects conflicting request, policy, or drain modes",
+    (terminalPolicy) => {
+      let queued = 2;
+      let nowMs = 1_000;
+      const pauseScheduling = vi.fn();
+      const resumeScheduling = vi.fn();
+      const params = {
+        requestId: "request-drain-renewal",
+        terminalPolicy,
+        drain: true,
+        pauseScheduling,
+        resumeScheduling,
+        inspect: inspectors({
+          getQueueSize: () => queued,
+          getTerminalSessions: () => (terminalPolicy === "terminate" ? 2 : 0),
+        }),
+        nowMs: () => nowMs,
+        createSuspensionId: () => "suspension-drain-renewal",
+      };
 
-    expect(prepareGatewaySuspend(params)).toMatchObject({
-      status: "draining",
-      suspensionId: "suspension-drain-renewal",
-      expiresAtMs: 1_000 + SUSPEND_TTL_MS,
-      activeCount: 2,
-    });
-
-    nowMs = 2_000;
-    queued = 1;
-    expect(prepareGatewaySuspend(params)).toMatchObject({
-      status: "draining",
-      suspensionId: "suspension-drain-renewal",
-      expiresAtMs: 2_000 + SUSPEND_TTL_MS,
-      activeCount: 1,
-    });
-    for (const conflict of [
-      { requestId: "request-other" },
-      { drain: false },
-      { terminalPolicy: "terminate" as const, drain: false },
-    ]) {
-      expect(prepareGatewaySuspend({ ...params, ...conflict })).toEqual({
-        status: "conflict",
-        expiresAtMs: 2_000 + SUSPEND_TTL_MS,
+      expect(prepareGatewaySuspend(params)).toMatchObject({
+        status: "draining",
+        suspensionId: "suspension-drain-renewal",
+        expiresAtMs: 1_000 + SUSPEND_TTL_MS,
+        activeCount: 2,
       });
-    }
-    expect(pauseScheduling).toHaveBeenCalledOnce();
 
-    nowMs = 3_000;
-    queued = 0;
-    expect(prepareGatewaySuspend(params)).toEqual({
-      status: "ready",
-      suspensionId: "suspension-drain-renewal",
-      expiresAtMs: 3_000 + SUSPEND_TTL_MS,
-      activeCount: 0,
-      blockers: [],
-    });
-    expect(getGatewaySuspendAdmissionPhase()).toBe("prepared");
-    expect(pauseScheduling).toHaveBeenCalledOnce();
-    expect(resumeScheduling).not.toHaveBeenCalled();
-  });
+      nowMs = 2_000;
+      queued = 1;
+      expect(prepareGatewaySuspend(params)).toMatchObject({
+        status: "draining",
+        suspensionId: "suspension-drain-renewal",
+        expiresAtMs: 2_000 + SUSPEND_TTL_MS,
+        activeCount: 1,
+      });
+      const otherTerminalPolicy = terminalPolicy === "preserve" ? "terminate" : "preserve";
+      for (const conflict of [
+        { requestId: "request-other" },
+        { drain: false },
+        { terminalPolicy: otherTerminalPolicy },
+      ] satisfies Partial<typeof params>[]) {
+        expect(prepareGatewaySuspend({ ...params, ...conflict })).toEqual({
+          status: "conflict",
+          expiresAtMs: 2_000 + SUSPEND_TTL_MS,
+        });
+      }
+      expect(pauseScheduling).toHaveBeenCalledOnce();
+
+      nowMs = 3_000;
+      queued = 0;
+      expect(prepareGatewaySuspend(params)).toEqual({
+        status: "ready",
+        suspensionId: "suspension-drain-renewal",
+        expiresAtMs: 3_000 + SUSPEND_TTL_MS,
+        activeCount: 0,
+        blockers: [],
+      });
+      expect(getGatewaySuspendAdmissionPhase()).toBe("prepared");
+      expect(pauseScheduling).toHaveBeenCalledOnce();
+      expect(resumeScheduling).not.toHaveBeenCalled();
+    },
+  );
 
   it("resumes a still-draining lease without dropping its admission fence first", () => {
     const resumeScheduling = vi.fn(() => {
@@ -352,10 +341,11 @@ describe("gateway suspend coordinator", () => {
     });
   });
 
-  it("prepares with terminal sessions excluded when they will be terminated", () => {
+  it.each([false, true])("prepares with terminal sessions excluded (drain: %s)", (drain) => {
     const params = {
       requestId: "request-terminal-terminate",
       terminalPolicy: "terminate" as const,
+      drain,
       pauseScheduling: vi.fn(),
       resumeScheduling: vi.fn(),
       inspect: inspectors({ getTerminalSessions: () => 2 }),

--- a/src/infra/gateway-suspend-coordinator.ts
+++ b/src/infra/gateway-suspend-coordinator.ts
@@ -1,4 +1,4 @@
-// Coordinates atomic host suspension preparation and preserve-only drain leases.
+// Coordinates atomic host suspension preparation and terminal-policy-aware drain leases.
 import { randomUUID } from "node:crypto";
 import type {
   GatewaySuspendPrepareParams,
@@ -238,7 +238,10 @@ function refreshHeldSuspension(held: HeldGatewaySuspension): HeldGatewaySuspensi
   if (held.phase.status === "ready") {
     return held.phase;
   }
-  const snapshot = createGatewayActiveWorkSnapshot(held.phase.inspect);
+  // Polls and renewals must retain the update's terminal policy until the lease is ready.
+  const snapshot = createGatewayActiveWorkSnapshot(held.phase.inspect, {
+    ignoreTerminalSessions: held.terminalPolicy === "terminate",
+  });
   if (!snapshot.idle) {
     held.phase.snapshot = snapshot;
     return held.phase;
@@ -279,9 +282,6 @@ export function prepareGatewaySuspend(params: {
 }): GatewaySuspendPrepareResult {
   const terminalPolicy = params.terminalPolicy ?? "preserve";
   const drain = params.drain === true;
-  if (drain && terminalPolicy !== "preserve") {
-    throw new TypeError("gateway suspension draining requires terminalPolicy preserve");
-  }
   const activeWorkOptions = {
     ignoreTerminalSessions: terminalPolicy === "terminate",
   };


### PR DESCRIPTION
Closes #131308
Related: #130003, #121601

## What Problem This Solves

Fixes an issue where release-update controllers using cooperative Gateway draining cannot proceed while a terminal remains open, even when the controller explicitly accepts that process-local terminals end on restart.

The request `{ "terminalPolicy": "terminate", "drain": true }` is rejected. Removing only that rejection would still leave updates stuck: the next status poll or lease renewal loses the policy and counts the terminal again.

## Why This Change Was Made

Allow the two existing options to compose and retain the held terminal policy when refreshing a drain snapshot. This repairs the coordinator that owns readiness instead of closing terminals early, weakening active-work checks, or adding another updater workaround.

Default/explicit `preserve` remains unchanged for freeze/snapshot callers. Pending final chat-state writes (`terminal-persistence`) and all other real work remain blockers. There are no new protocol/configuration fields, dependencies, schema changes, or timing changes.

**Provenance:** the preserve-only restriction was added by #130003 / 093166c7d94ffc81a34214197b609abccd89d8af on 2026-08-26 (code author, PR author, and merger: @steipete). The earlier terminal exemption from #121601 remains the intended update policy.

## User Impact

Controllers can drain admitted work without letting an indefinitely open shell veto a release update. Prepare, status, renewal, resume, and lease expiry do not kill or detach the terminal. The actual Gateway restart remains the owner of PTY termination; terminal commands and scrollback are not recovered afterward.

This does not change the built-in update campaign's 15-minute hard deadline or any external deployment controller's grace period. Existing clients must explicitly request the termination policy for an update drain; preserve remains the default.

## Evidence

- Failing-first dispatcher/coordinator regression: original code returns `INVALID_REQUEST`; removing only the guards still fails when status polling reintroduces `terminal-session` as a blocker.
- The repaired tests cover preparation, polling, draining-to-ready renewal, policy conflicts, preserved terminals, nonterminal work, pending final-state persistence, and resume without killing the PTY.
- Focused suite: **83 tests across 7 files**, including update-campaign and restart-suspension siblings. A later test-type tightening also passed the 29-test coordinator rerun.
- `pnpm build` passed; changed checks passed, including core/test types, lint, runtime-cycle and architecture guards. The first changed-check attempt caught a widened test string; it was corrected before the complete clean rerun.
- Real isolated Gateway/Control UI proof: a real Bash PTY and background child survived ready/renew/resume, then both exited on an actual Gateway restart; the reconnected UI showed the old terminal as exited. This is local runtime proof, not a production deployment or live-provider claim. Inspected media is attached below.
- Fresh Codex autoreview completed with no actionable findings. The fresh landing rerun passed **83 tests in 3 routed shards** (154.68 seconds). Exact-head CI passed. Post-merge main snapshot `a6cc62fce55f02302883408f8b7a11b0d2465688` also passed the real Docker Gateway/PTY/restart flow; the separate native 15-minute controller check passed after 900,013.7 ms. [Docker recording, screenshots, artifact identities, and proof boundaries](https://github.com/openclaw/openclaw/pull/131314#issuecomment-5447291380).

Focused command:

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/run-vitest.mjs src/infra/gateway-suspend-coordinator.test.ts src/gateway/server-methods/suspend.test.ts src/gateway/server-methods.suspension-admission.test.ts src/gateway/server-active-work.test.ts src/infra/restart-suspension.test.ts src/infra/update-campaign.test.ts packages/gateway-protocol/src/gateway-suspend.test.ts
```

**LOC:** production +6/−9 (**net −3**); tests +240/−230 (**net +10**); docs +31/−14 (**net +17**). Test churn mainly extends/table-drives existing scenarios. No persistent-state changes.

AI-assisted implementation and review. No agent transcripts, private deployment data, or live credentials are included.

![Terminal remains alive after update preparation](https://github.com/user-attachments/assets/312d247e-3d73-4bc2-b021-98ab60d088a0)

![Terminal exits only on actual Gateway restart](https://github.com/user-attachments/assets/c01c3ea2-e9f4-4716-900b-92bac4c1de49)

https://github.com/user-attachments/assets/11509ae2-37d2-479d-97b4-42b60d670b38