### PR TITLE
fix(openshell): prevent workspace races and unblock remote commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- OpenShell execution: remove shared workdir-preparation handoffs, preserve complete mirror-operation ownership, and let remote commands and file tools overlap after initialization without retaining a workspace lock across turns.
 - **Control UI Gateway labels:** keep the discovered machine name through recovery initialization and refresh open folder-browser labels when name discovery finishes.
 - **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
 - **Nextcloud Talk diagnostics:** redact reflected credentials before displaying send, reaction, and bot-preflight errors, and suppress incomplete error bodies. (#119976) Thanks @xialonglee.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- OpenShell execution: remove shared workdir-preparation handoffs, preserve complete mirror-operation ownership, and let remote commands and file tools overlap after initialization without retaining a workspace lock across turns.
 - **Control UI Gateway labels:** keep the discovered machine name through recovery initialization and refresh open folder-browser labels when name discovery finishes.
 - **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
 - **Nextcloud Talk diagnostics:** redact reflected credentials before displaying send, reaction, and bot-preflight errors, and suppress incomplete error bodies. (#119976) Thanks @xialonglee.

--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -132,6 +132,11 @@ canonical**:
   its synchronization; separate backend handles share the same lock.
 - File tools go through the sandbox bridge, but local stays source of truth
   between turns.
+- Working-directory checks inspect the host directories that will be uploaded
+  and release their lock before returning. Execution owns its own complete
+  upload-to-download operation; an abandoned check cannot block later tools.
+  Remote permissions and image-specific restrictions are checked when execution
+  starts.
 
 Best for development workflows: local edits outside OpenClaw show up on the
 next exec, and the sandbox behaves close to the Docker backend.
@@ -153,6 +158,13 @@ its download can replace those external edits.
 - After that, `exec`, `read`, `write`, `edit`, and `apply_patch` operate
   directly on the remote workspace. OpenClaw does **not** sync remote changes
   back to local.
+- Initialization is serialized per remote runtime, but commands and file tools
+  can overlap after initialization, including across agent turns. A background
+  command can therefore wait for a file written by a later turn. Concurrent
+  writes to the same file follow normal remote filesystem semantics.
+- Materialized skills refresh when a backend initializes for a turn, rather
+  than before every filesystem operation. As with other sandbox backends, a
+  later turn can refresh skills while older background commands are running.
 - Prompt-time media reads still work (file/media tools read through the
   sandbox bridge).
 - Outbound images and other attachments can use paths under the configured

--- a/extensions/openshell/src/backend.e2e.test-support.ts
+++ b/extensions/openshell/src/backend.e2e.test-support.ts
@@ -81,8 +81,13 @@ export async function runBackendExec(params: {
   allowFailure?: boolean;
   timeoutMs?: number;
 }): Promise<ExecResult> {
+  const workdir = expectDefined(
+    await params.backend.validateWorkdir?.(params.backend.workdir),
+    "OpenShell validated working directory",
+  );
   const execSpec = await params.backend.buildExecSpec({
     command: params.command,
+    workdir,
     env: params.env ?? {},
     usePty: false,
   });
@@ -116,6 +121,61 @@ export async function runPreparedBackendExec(params: {
   }
 }
 
+export async function verifyRemoteExecOverlap(params: {
+  backend: SandboxBackendHandle;
+  twin: SandboxBackendHandle;
+  bridge: SandboxFsBridge;
+}): Promise<void> {
+  const probeDir = "exec-overlap";
+  await params.bridge.mkdirp({ filePath: probeDir });
+  await runBackendExec({ backend: params.twin, command: "true", timeoutMs: 60_000 });
+  const waitingScript = `import pathlib,time
+root=pathlib.Path("exec-overlap")
+root.joinpath("ready").write_text("ready")
+deadline=time.monotonic()+30
+for name in ("command-release", "file-release"):
+    target=root.joinpath(name)
+    while not target.is_file() or target.read_text() != name:
+        if time.monotonic() >= deadline:
+            raise RuntimeError("remote execution prevented concurrent " + name)
+        time.sleep(0.05)
+print("remote-exec-overlapped-command-and-file")`;
+  const releaseScript = `import pathlib,time
+root=pathlib.Path("exec-overlap")
+deadline=time.monotonic()+30
+while not root.joinpath("ready").exists():
+    if time.monotonic() >= deadline:
+        raise RuntimeError("waiting command did not start")
+    time.sleep(0.05)
+root.joinpath("command-release").write_text("command-release")`;
+  // A process that waits for the next turn's write must not retain the runtime lease.
+  // Observe rejection immediately, but join it in finally even if the writer fails.
+  const waiting = runBackendExec({
+    backend: params.backend,
+    command: `python3 -c '${waitingScript}'`,
+    timeoutMs: 60_000,
+  });
+  const settled = Promise.allSettled([waiting]);
+  try {
+    await runBackendExec({
+      backend: params.twin,
+      command: `python3 -c '${releaseScript}'`,
+      timeoutMs: 60_000,
+    });
+    await params.bridge.writeFile({
+      filePath: `${probeDir}/file-release`,
+      data: "file-release",
+    });
+    await expect(waiting).resolves.toMatchObject({
+      code: 0,
+      stdout: "remote-exec-overlapped-command-and-file\n",
+    });
+  } finally {
+    await settled;
+    await params.bridge.remove({ filePath: probeDir, recursive: true });
+  }
+}
+
 export async function stressBackend(params: {
   backends: Array<Parameters<typeof runBackendExec>[0]["backend"]>;
   bridge: SandboxFsBridge;
@@ -137,9 +197,13 @@ export async function stressBackend(params: {
         if (slot % 2 === 0) {
           expectedIds.push(id);
           const exitCode = slot === 0 ? 23 : 0;
+          const serialMutation =
+            params.mode === "mirror"
+              ? `n=$(cat stress/count 2>/dev/null || echo 0); sleep 0.02; printf '%s\\n' "$((n + 1))" > stress/count; printf '%s\\n' '${id}' >> stress/ledger; `
+              : "";
           const result = await runBackendExec({
             backend,
-            command: `mkdir -p stress; n=$(cat stress/count 2>/dev/null || echo 0); sleep 0.02; printf '%s\\n' "$((n + 1))" > stress/count; printf '%s\\n' '${id}' >> stress/ledger; printf '%s' "$STRESS_VALUE" > 'stress/@exec-${id}'; exit ${exitCode}`,
+            command: `mkdir -p stress; ${serialMutation}printf '%s' "$STRESS_VALUE" > 'stress/@exec-${id}'; exit ${exitCode}`,
             env: { STRESS_VALUE: `value-${id}` },
             allowFailure: true,
             timeoutMs: 60_000,
@@ -201,12 +265,13 @@ export async function stressBackend(params: {
     args: [`${params.backends[0]!.workdir}/stress`],
   });
   const remoteFiles = JSON.parse(inventory.stdout.toString("utf8")) as Record<string, string>;
-  const ledger = expectDefined(remoteFiles.ledger, "OpenShell remote command ledger");
-  expect(ledger.trim().split("\n").toSorted()).toEqual(expectedIds.toSorted());
-  const expectedFiles: Record<string, string> = {
-    ledger,
-    count: `${expectedIds.length}\n`,
-  };
+  const expectedFiles: Record<string, string> = {};
+  if (params.mode === "mirror") {
+    const ledger = expectDefined(remoteFiles.ledger, "OpenShell mirror command ledger");
+    expect(ledger.trim().split("\n").toSorted()).toEqual(expectedIds.toSorted());
+    expectedFiles.ledger = ledger;
+    expectedFiles.count = `${expectedIds.length}\n`;
+  }
   for (let wave = 0; wave < waves; wave++) {
     for (let slot = 0; slot < concurrency; slot++) {
       const id = `${wave}-${slot}`;
@@ -246,7 +311,7 @@ export async function stressBackend(params: {
       elapsedMs: Date.now() - startedAt,
       p50Ms: orderedLatencies[Math.floor(latencies.length / 2)],
       p95Ms: orderedLatencies[Math.floor(latencies.length * 0.95)],
-      verifiedFiles: Object.keys(expectedFiles).length - 2,
+      verifiedFiles: Object.keys(expectedFiles).length,
     }),
   );
 }

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -15,6 +15,7 @@ import {
   runBackendExec,
   runPreparedBackendExec,
   stressBackend,
+  verifyRemoteExecOverlap,
 } from "./backend.e2e.test-support.js";
 import {
   createOpenShellSandboxBackendFactory,
@@ -774,6 +775,9 @@ describe("openshell sandbox backend e2e", () => {
           agentWorkspaceDir: workspaceDir,
           cfg: sandboxCfg,
         });
+        if (stressMode === "remote") {
+          await verifyRemoteExecOverlap({ backend, twin: remoteTwin, bridge });
+        }
         await stressBackend(
           stressMode === "mirror"
             ? {
@@ -790,7 +794,17 @@ describe("openshell sandbox backend e2e", () => {
               },
         );
 
-        for (const candidate of [mirrorBackend, backend]) {
+        for (const [candidate, candidateBridge] of [
+          [mirrorBackend, mirrorBridge],
+          [backend, bridge],
+        ] as const) {
+          await expect(
+            runBackendExec({ backend: candidate, command: "exit 23", timeoutMs: 60_000 }),
+          ).rejects.toThrow("exit: 23");
+          await candidateBridge.writeFile({ filePath: "after-failed-exec.txt", data: "recovered" });
+          await expect(
+            runBackendExec({ backend: candidate, command: "cat after-failed-exec.txt" }),
+          ).resolves.toMatchObject({ code: 0, stdout: "recovered" });
           await expect(
             candidate.buildExecSpec({
               command: "true",
@@ -804,7 +818,6 @@ describe("openshell sandbox backend e2e", () => {
           await expect(candidate.validateWorkdir?.(candidate.workdir)).resolves.toBe(
             candidate.workdir,
           );
-          candidate.discardPreparedWorkdir?.(candidate.workdir);
           const unspawned = await candidate.buildExecSpec({
             command: "exit 99",
             env: {},

--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
+import type { SandboxBackendHandle } from "openclaw/plugin-sdk/sandbox";
 import {
   resolvePreferredOpenClawTmpDir,
   tempWorkspace,
@@ -44,25 +45,52 @@ vi.mock("./cli.js", async (importOriginal) => {
 });
 
 const tempWorkspaces: TempWorkspace[] = [];
+const createdBackends: SandboxBackendHandle[] = [];
 
 async function createOpenShellBackendFixture(params: {
   workspaceDir: string;
   scopeKey: string;
   command?: string;
+  agentWorkspaceDir?: string;
+  skillsWorkspaceDir?: string;
+  workspaceAccess?: "rw" | "ro" | "none";
+  remoteWorkspaceDir?: string;
+  remoteAgentWorkspaceDir?: string;
 }) {
   const factory = createOpenShellSandboxBackendFactory({
     pluginConfig: resolveOpenShellPluginConfig({
       command: params.command ?? "openshell",
       mode: "mirror",
+      remoteWorkspaceDir: params.remoteWorkspaceDir,
+      remoteAgentWorkspaceDir: params.remoteAgentWorkspaceDir,
     }),
   });
-  return await factory({
+  const backend = await factory({
     sessionKey: `${params.scopeKey}:turn`,
     scopeKey: params.scopeKey,
     workspaceDir: params.workspaceDir,
-    agentWorkspaceDir: params.workspaceDir,
-    cfg: createOpenShellBackendSandboxConfig(),
+    agentWorkspaceDir: params.agentWorkspaceDir ?? params.workspaceDir,
+    skillsWorkspaceDir: params.skillsWorkspaceDir,
+    cfg: {
+      ...createOpenShellBackendSandboxConfig(),
+      workspaceAccess: params.workspaceAccess ?? "rw",
+    },
   });
+  createdBackends.push(backend);
+  return backend;
+}
+
+async function createWorkspace(prefix = "workspace") {
+  const workspace = await tempWorkspace({
+    rootDir: resolvePreferredOpenClawTmpDir(),
+    prefix: `openclaw-openshell-${prefix}-`,
+  });
+  tempWorkspaces.push(workspace);
+  return await fs.realpath(workspace.dir);
+}
+
+async function finalize(backend: SandboxBackendHandle, token: unknown) {
+  await backend.finalizeExec?.({ status: "completed", exitCode: 0, timedOut: false, token });
 }
 
 describe("openshell backend exec workdir validation", () => {
@@ -92,7 +120,7 @@ describe("openshell backend exec workdir validation", () => {
     );
     sdkMocks.runSshSandboxCommand.mockImplementation(async ({ remoteCommand }) => ({
       stdout: String(remoteCommand).includes("openclaw-validate-workdir")
-        ? Buffer.from("/workspace\n")
+        ? Buffer.from("/sandbox\n")
         : Buffer.alloc(0),
       stderr: Buffer.alloc(0),
       code: 0,
@@ -100,11 +128,14 @@ describe("openshell backend exec workdir validation", () => {
   });
 
   afterEach(async () => {
+    for (const backend of createdBackends.splice(0)) {
+      backend.discardPreparedWorkdir?.("/sandbox");
+    }
     vi.unstubAllEnvs();
     await Promise.all(tempWorkspaces.splice(0).map((workspace) => workspace.cleanup()));
   });
 
-  it("reuses validation-time workspace preparation for the following exec", async () => {
+  it("validates locally and uploads the workspace once when exec begins", async () => {
     vi.stubEnv("OPENAI_API_KEY", "fixture");
     vi.stubEnv("ANTHROPIC_API_KEY", "fixture");
     vi.stubEnv("LANG", "en_US.UTF-8");
@@ -126,10 +157,12 @@ describe("openshell backend exec workdir validation", () => {
       workspaceDir,
     });
 
-    await expect(backend.validateWorkdir?.("/workspace")).resolves.toBe("/workspace");
+    await expect(backend.validateWorkdir?.("/sandbox")).resolves.toBe("/sandbox");
+    expect(cliMocks.runOpenShellCli).not.toHaveBeenCalled();
+    expect(cliMocks.createOpenShellSshSession).not.toHaveBeenCalled();
     const execSpec = await backend.buildExecSpec({
       command: "pwd",
-      workdir: "/workspace",
+      workdir: "/sandbox",
       env: {},
       usePty: false,
     });
@@ -193,38 +226,215 @@ describe("openshell backend exec workdir validation", () => {
     expect(execSpec.argv).toContain("openshell-test");
   });
 
-  it("does not reuse validation-time workspace preparation after discard", async () => {
-    const workspace = await tempWorkspace({
-      rootDir: resolvePreferredOpenClawTmpDir(),
-      prefix: "openclaw-openshell-workspace-",
-    });
-    tempWorkspaces.push(workspace);
-    const workspaceDir = workspace.dir;
-    await fs.writeFile(path.join(workspaceDir, "seed.txt"), "seed", "utf8");
+  it("does not retain an abandoned validation lease before a file write or exec", async () => {
+    const workspaceDir = await createWorkspace();
     const backend = await createOpenShellBackendFixture({
-      scopeKey: "agent:main",
+      scopeKey: "agent:abandoned-validation",
       workspaceDir,
     });
-
-    await expect(backend.validateWorkdir?.("/workspace")).resolves.toBe("/workspace");
-    backend.discardPreparedWorkdir?.("/workspace");
+    await expect(backend.validateWorkdir?.("/sandbox")).resolves.toBe("/sandbox");
+    const bridge = expectDefined(
+      backend.createFsBridge?.({
+        sandbox: createSandboxTestContext({
+          overrides: {
+            backendId: "openshell",
+            workspaceDir,
+            agentWorkspaceDir: workspaceDir,
+            containerWorkdir: backend.workdir,
+            backend,
+          },
+        }),
+      }),
+      "OpenShell mirror bridge",
+    );
+    let wrote = false;
+    const write = bridge.writeFile({ filePath: "note.txt", data: "after validation" }).then(() => {
+      wrote = true;
+    });
+    try {
+      await vi.waitFor(() => expect(wrote).toBe(true));
+    } finally {
+      backend.discardPreparedWorkdir?.("/sandbox");
+      await write;
+    }
+    await expect(fs.readFile(path.join(workspaceDir, "note.txt"), "utf8")).resolves.toBe(
+      "after validation",
+    );
     const execSpec = await backend.buildExecSpec({
       command: "pwd",
-      workdir: "/workspace",
+      workdir: "/sandbox",
       env: {},
       usePty: false,
     });
+    await finalize(backend, execSpec.finalizeToken);
+  });
 
-    const uploadCalls = cliMocks.runOpenShellCli.mock.calls.filter(
-      ([params]) => params.args[0] === "sandbox" && params.args[1] === "upload",
-    );
-    expect(uploadCalls).toHaveLength(2);
-    await backend.finalizeExec?.({
-      status: "completed",
-      exitCode: 0,
-      timedOut: false,
-      token: execSpec.finalizeToken,
+  it("completes concurrent validations without starting remote work or retaining a lease", async () => {
+    const workspaceDir = await createWorkspace();
+    const backend = await createOpenShellBackendFixture({
+      workspaceDir,
+      scopeKey: "agent:parallel-validation",
     });
+    const completed: Array<string | null | undefined> = [];
+    let cleaningUp = false;
+    const validations = [0, 1].map(async () => {
+      const result = await backend.validateWorkdir?.("/sandbox");
+      completed.push(result);
+      if (cleaningUp) backend.discardPreparedWorkdir?.("/sandbox");
+    });
+    try {
+      await vi.waitFor(() => expect(completed).toEqual(["/sandbox", "/sandbox"]));
+      expect(cliMocks.runOpenShellCli).not.toHaveBeenCalled();
+      expect(cliMocks.createOpenShellSshSession).not.toHaveBeenCalled();
+    } finally {
+      cleaningUp = true;
+      backend.discardPreparedWorkdir?.("/sandbox");
+      await Promise.all(validations);
+    }
+  });
+
+  it.each([
+    { name: "filesystem root", target: "/", expected: null },
+    { name: "outside managed roots", target: "/outside", expected: null },
+    { name: "ordinary directory", target: "/sandbox/nested", expected: "/sandbox/nested" },
+    { name: "missing directory", target: "/sandbox/missing", expected: null },
+    { name: "regular file", target: "/sandbox/file.txt", expected: null },
+    ...[".git", "hooks", "git-hooks"].map((name) => ({
+      name,
+      target: `/sandbox/${name}/nested`,
+      expected: null,
+    })),
+    { name: "mid-path symlink", target: "/sandbox/link/nested", expected: null },
+    {
+      name: "agent read-only directory",
+      target: "/agent/nested",
+      expected: "/agent/nested",
+      access: "ro" as const,
+    },
+    {
+      name: "agent disabled mount",
+      target: "/agent/nested",
+      expected: null,
+      access: "none" as const,
+    },
+    {
+      name: "generated skills ancestor",
+      target: "/sandbox/.openclaw",
+      expected: "/sandbox/.openclaw",
+    },
+    {
+      name: "materialized skills root",
+      target: "/sandbox/.openclaw/sandbox-skills",
+      expected: "/sandbox/.openclaw/sandbox-skills",
+    },
+    {
+      name: "materialized skills child",
+      target: "/sandbox/.openclaw/sandbox-skills/skills/demo",
+      expected: "/sandbox/.openclaw/sandbox-skills/skills/demo",
+    },
+    {
+      name: "missing materialized child",
+      target: "/sandbox/.openclaw/sandbox-skills/skills/missing",
+      expected: null,
+    },
+    {
+      name: "symlinked materialized source",
+      target: "/sandbox/.openclaw/sandbox-skills/nested",
+      expected: null,
+      sourceLink: true,
+    },
+  ])("validates the uploaded host directory for $name", async (scenario) => {
+    const workspaceDir = await createWorkspace();
+    const agentWorkspaceDir = await createWorkspace("agent");
+    const skillsWorkspaceDir = await createWorkspace("skills");
+    for (const root of [workspaceDir, agentWorkspaceDir]) await fs.mkdir(path.join(root, "nested"));
+    await fs.writeFile(path.join(workspaceDir, "file.txt"), "not a directory");
+    for (const excluded of [".git", "hooks", "git-hooks"])
+      await fs.mkdir(path.join(workspaceDir, excluded, "nested"), { recursive: true });
+    await fs.symlink(workspaceDir, path.join(workspaceDir, "link"), "junction");
+    await fs.mkdir(path.join(skillsWorkspaceDir, "skills", "demo"), { recursive: true });
+    if (scenario.sourceLink) {
+      await fs.rm(skillsWorkspaceDir, { recursive: true });
+      await fs.symlink(workspaceDir, skillsWorkspaceDir, "junction");
+    }
+    const backend = await createOpenShellBackendFixture({
+      workspaceDir,
+      agentWorkspaceDir,
+      skillsWorkspaceDir,
+      scopeKey: `agent:validation:${scenario.name}`,
+      workspaceAccess: scenario.access,
+    });
+    await expect(backend.validateWorkdir?.(scenario.target)).resolves.toBe(scenario.expected);
+    expect(cliMocks.runOpenShellCli).not.toHaveBeenCalled();
+    expect(cliMocks.createOpenShellSshSession).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { workspace: "/sandbox", agent: "/sandbox", target: "/sandbox/agent-only", exists: true },
+    {
+      workspace: "/sandbox/primary",
+      agent: "/sandbox",
+      target: "/sandbox/primary/host-only",
+      exists: false,
+    },
+    {
+      workspace: "/sandbox",
+      agent: "/sandbox/nested/agent",
+      target: "/sandbox/nested",
+      exists: true,
+    },
+  ])("resolves overlapping uploads in publication order: $target", async (scenario) => {
+    const workspaceDir = await createWorkspace();
+    const agentWorkspaceDir = await createWorkspace("agent");
+    await fs.mkdir(path.join(workspaceDir, "host-only"));
+    await fs.mkdir(path.join(agentWorkspaceDir, "agent-only"));
+    const backend = await createOpenShellBackendFixture({
+      workspaceDir,
+      agentWorkspaceDir,
+      scopeKey: `agent:overlap:${scenario.target}`,
+      remoteWorkspaceDir: scenario.workspace,
+      remoteAgentWorkspaceDir: scenario.agent,
+    });
+    await expect(backend.validateWorkdir?.(scenario.target)).resolves.toBe(
+      scenario.exists ? scenario.target : null,
+    );
+  });
+
+  it("rejects an aborted file write after waiting for mirror publication", async () => {
+    const workspaceDir = await createWorkspace();
+    const backend = await createOpenShellBackendFixture({
+      workspaceDir,
+      scopeKey: "agent:aborted-write",
+    });
+    const bridge = expectDefined(
+      backend.createFsBridge?.({
+        sandbox: createSandboxTestContext({
+          overrides: {
+            workspaceDir,
+            agentWorkspaceDir: workspaceDir,
+            containerWorkdir: backend.workdir,
+            backend,
+          },
+        }),
+      }),
+      "mirror bridge",
+    );
+    const exec = await backend.buildExecSpec({ command: "true", env: {}, usePty: false });
+    const controller = new AbortController();
+    const write = bridge.writeFile({
+      filePath: "cancelled.txt",
+      data: "cancelled",
+      signal: controller.signal,
+    });
+    const rejected = expect(write).rejects.toThrow("cancelled while queued");
+    controller.abort(new Error("cancelled while queued"));
+    await finalize(backend, exec.finalizeToken);
+    await rejected;
+    await expect(fs.stat(path.join(workspaceDir, "cancelled.txt"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await bridge.writeFile({ filePath: "next.txt", data: "next" });
+    await expect(fs.readFile(path.join(workspaceDir, "next.txt"), "utf8")).resolves.toBe("next");
   });
 
   it.each([
@@ -338,6 +548,51 @@ describe("openshell backend exec workdir validation", () => {
       token: secondExec.finalizeToken,
     });
   });
+
+  it.each(["exec preparation", "mirror publication", "SSH cleanup"])(
+    "releases workspace ownership after failed %s",
+    async (failure) => {
+      const workspaceDir = await createWorkspace("failure");
+      const scopeKey = `agent:failed:${failure}`;
+      const first = await createOpenShellBackendFixture({ workspaceDir, scopeKey });
+      const second = await createOpenShellBackendFixture({ workspaceDir, scopeKey });
+      if (failure === "exec preparation") {
+        sdkMocks.prepareSshSandboxExec.mockRejectedValueOnce(new Error("prepare failed"));
+        await expect(
+          first.buildExecSpec({ command: "first", env: {}, usePty: false }),
+        ).rejects.toThrow("prepare failed");
+      } else {
+        if (failure === "SSH cleanup") {
+          sdkMocks.prepareSshSandboxExec.mockResolvedValueOnce({
+            argv: ["ssh", "openshell-test"],
+            cleanup: async () => {
+              throw new Error("cleanup failed");
+            },
+          });
+        }
+        const firstExec = await first.buildExecSpec({ command: "first", env: {}, usePty: false });
+        if (failure === "mirror publication") {
+          cliMocks.runOpenShellCli.mockResolvedValueOnce({
+            code: 1,
+            stdout: "",
+            stderr: "download failed",
+          });
+        }
+        await expect(finalize(first, firstExec.finalizeToken)).rejects.toThrow(
+          failure === "SSH cleanup" ? "cleanup failed" : "download failed",
+        );
+      }
+      let secondExec: Awaited<ReturnType<SandboxBackendHandle["buildExecSpec"]>> | undefined;
+      const secondPreparation = second
+        .buildExecSpec({ command: "second", env: {}, usePty: false })
+        .then((prepared) => {
+          secondExec = prepared;
+          return prepared;
+        });
+      await vi.waitFor(() => expect(secondExec).toBeDefined());
+      await finalize(second, (await secondPreparation).finalizeToken);
+    },
+  );
 
   it("keeps operations against different workspaces parallel", async () => {
     const workspaces = await Promise.all(

--- a/extensions/openshell/src/backend.exec-workdir.test.ts
+++ b/extensions/openshell/src/backend.exec-workdir.test.ts
@@ -280,7 +280,9 @@ describe("openshell backend exec workdir validation", () => {
     const validations = [0, 1].map(async () => {
       const result = await backend.validateWorkdir?.("/sandbox");
       completed.push(result);
-      if (cleaningUp) backend.discardPreparedWorkdir?.("/sandbox");
+      if (cleaningUp) {
+        backend.discardPreparedWorkdir?.("/sandbox");
+      }
     });
     try {
       await vi.waitFor(() => expect(completed).toEqual(["/sandbox", "/sandbox"]));
@@ -347,10 +349,13 @@ describe("openshell backend exec workdir validation", () => {
     const workspaceDir = await createWorkspace();
     const agentWorkspaceDir = await createWorkspace("agent");
     const skillsWorkspaceDir = await createWorkspace("skills");
-    for (const root of [workspaceDir, agentWorkspaceDir]) await fs.mkdir(path.join(root, "nested"));
+    for (const root of [workspaceDir, agentWorkspaceDir]) {
+      await fs.mkdir(path.join(root, "nested"));
+    }
     await fs.writeFile(path.join(workspaceDir, "file.txt"), "not a directory");
-    for (const excluded of [".git", "hooks", "git-hooks"])
+    for (const excluded of [".git", "hooks", "git-hooks"]) {
       await fs.mkdir(path.join(workspaceDir, excluded, "nested"), { recursive: true });
+    }
     await fs.symlink(workspaceDir, path.join(workspaceDir, "link"), "junction");
     await fs.mkdir(path.join(skillsWorkspaceDir, "skills", "demo"), { recursive: true });
     if (scenario.sourceLink) {

--- a/extensions/openshell/src/backend.remote-seed.test.ts
+++ b/extensions/openshell/src/backend.remote-seed.test.ts
@@ -3,6 +3,8 @@
 // memory, and must never re-seed roots that already hold content.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import type { SandboxBackendHandle } from "openclaw/plugin-sdk/sandbox";
 import {
   resolvePreferredOpenClawTmpDir,
   tempWorkspace,
@@ -45,7 +47,10 @@ vi.mock("./cli.js", async (importOriginal) => {
 
 const tempWorkspaces: TempWorkspace[] = [];
 
-async function createAdoptedRemoteBackend(params: { probeStdout: string }) {
+async function createAdoptedRemoteBackend(params: {
+  probeStdout: string;
+  skillsWorkspaceDir?: string;
+}) {
   const workspace = await tempWorkspace({
     rootDir: resolvePreferredOpenClawTmpDir(),
     prefix: "openclaw-openshell-remote-seed-",
@@ -82,8 +87,13 @@ async function createAdoptedRemoteBackend(params: { probeStdout: string }) {
     scopeKey: "agent:main",
     workspaceDir: workspace.dir,
     agentWorkspaceDir: workspace.dir,
+    skillsWorkspaceDir: params.skillsWorkspaceDir,
     cfg: createOpenShellBackendSandboxConfig(),
   });
+}
+
+async function finalize(backend: SandboxBackendHandle, token: unknown) {
+  await backend.finalizeExec?.({ status: "completed", exitCode: 0, timedOut: false, token });
 }
 
 function seedUploadCalls() {
@@ -135,5 +145,122 @@ describe("openshell remote-mode seed across gateway restart", () => {
       timedOut: false,
       token: execSpec.finalizeToken,
     });
+  });
+
+  it.each(["same handle", "another handle"])(
+    "starts remote operations on %s while an earlier command is still running",
+    async (handleKind) => {
+      const first = await createAdoptedRemoteBackend({ probeStdout: "1\n" });
+      const second =
+        handleKind === "same handle"
+          ? first
+          : await createAdoptedRemoteBackend({ probeStdout: "1\n" });
+      const firstExec = await first.buildExecSpec({
+        command: "wait-for-file",
+        env: {},
+        usePty: false,
+      });
+      let secondExec: Awaited<ReturnType<SandboxBackendHandle["buildExecSpec"]>> | undefined;
+      const secondPreparation = second
+        .buildExecSpec({ command: "write-file", env: {}, usePty: false })
+        .then((prepared) => {
+          secondExec = prepared;
+          return prepared;
+        });
+      try {
+        await vi.waitFor(() => expect(secondExec).toBeDefined());
+        expect(seedUploadCalls()).toHaveLength(0);
+      } finally {
+        await finalize(first, firstExec.finalizeToken);
+        const prepared = await secondPreparation;
+        await finalize(second, prepared.finalizeToken);
+      }
+    },
+  );
+
+  it("refreshes materialized skills once per handle, not between remote operations", async () => {
+    const skillsWorkspace = await tempWorkspace({
+      rootDir: resolvePreferredOpenClawTmpDir(),
+      prefix: "openclaw-openshell-remote-skills-",
+    });
+    tempWorkspaces.push(skillsWorkspace);
+    await fs.mkdir(path.join(skillsWorkspace.dir, "skills", "demo"), { recursive: true });
+    await fs.writeFile(path.join(skillsWorkspace.dir, "skills", "demo", "SKILL.md"), "# Demo\n");
+    const backend = await createAdoptedRemoteBackend({
+      probeStdout: "1\n",
+      skillsWorkspaceDir: skillsWorkspace.dir,
+    });
+    const firstExec = await backend.buildExecSpec({ command: "first", env: {}, usePty: false });
+    await finalize(backend, firstExec.finalizeToken);
+    const initialUploads = seedUploadCalls().length;
+    expect(initialUploads).toBeGreaterThan(0);
+    const initialClears = sdkMocks.runSshSandboxCommand.mock.calls.filter(([params]) =>
+      String(params.remoteCommand).includes("rm -rf"),
+    ).length;
+    expect(initialClears).toBeGreaterThan(0);
+    await backend.runShellCommand?.({ script: "printf file-operation", args: [] });
+    const secondExec = await backend.buildExecSpec({ command: "second", env: {}, usePty: false });
+    try {
+      expect(seedUploadCalls()).toHaveLength(initialUploads);
+      expect(
+        sdkMocks.runSshSandboxCommand.mock.calls.filter(([params]) =>
+          String(params.remoteCommand).includes("rm -rf"),
+        ),
+      ).toHaveLength(initialClears);
+    } finally {
+      await finalize(backend, secondExec.finalizeToken);
+    }
+  });
+
+  it("serializes initial seed publication across handles without serializing later commands", async () => {
+    const first = await createAdoptedRemoteBackend({ probeStdout: "0\n" });
+    const second = await createAdoptedRemoteBackend({ probeStdout: "1\n" });
+    const seedStarted = createDeferred<void>();
+    const releaseSeed = createDeferred<void>();
+    let seeded = false;
+    sdkMocks.runSshSandboxCommand.mockImplementation(async ({ remoteCommand }) => ({
+      stdout: String(remoteCommand).includes("ls -A")
+        ? Buffer.from(seeded ? "1\n" : "0\n")
+        : Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      code: 0,
+    }));
+    cliMocks.runOpenShellCli.mockImplementation(async ({ args }: { args: string[] }) => {
+      if (args[1] === "upload") {
+        seedStarted.resolve();
+        await releaseSeed.promise;
+        seeded = true;
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    const firstPreparation = first.buildExecSpec({ command: "first", env: {}, usePty: false });
+    await seedStarted.promise;
+    let secondStarted = false;
+    const secondPreparation = second
+      .buildExecSpec({ command: "second", env: {}, usePty: false })
+      .then((prepared) => {
+        secondStarted = true;
+        return prepared;
+      });
+    try {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(
+        cliMocks.runOpenShellCli.mock.calls.filter(([params]) => params.args[1] === "get"),
+      ).toHaveLength(1);
+      expect(secondStarted).toBe(false);
+    } finally {
+      releaseSeed.resolve();
+    }
+    const firstExec = await firstPreparation;
+    try {
+      await vi.waitFor(() => expect(secondStarted).toBe(true));
+      expect(seedUploadCalls()).toHaveLength(1);
+    } finally {
+      await finalize(first, firstExec.finalizeToken);
+      const secondExec = await secondPreparation;
+      await finalize(second, secondExec.finalizeToken);
+    }
   });
 });

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -12,7 +12,6 @@ import type {
   SandboxBackendFactory,
   SandboxBackendManager,
   SandboxFsBridge,
-  SshSandboxSession,
 } from "openclaw/plugin-sdk/sandbox";
 import {
   createRemoteShellSandboxFsBridge,
@@ -48,16 +47,15 @@ type CreateOpenShellSandboxBackendFactoryParams = {
 };
 
 type PendingExec = {
-  sshSession: SshSandboxSession;
   cleanup: () => Promise<void>;
-  workspaceLease: OpenShellWorkspaceLease;
+  workspaceLease?: OpenShellWorkspaceLease;
 };
 
 type OpenShellWorkspaceLease = {
   release: () => void;
 };
 
-// A command owns both its remote runtime and host mirror until final publication finishes.
+// Mirror commands own their snapshot until publication; remote runtimes only serialize initialization.
 const openShellWorkspaceOperations = new KeyedAsyncQueue();
 let openShellDetachedCreateSupport: { key: string; promise: Promise<boolean> } | undefined;
 const MATERIALIZED_SKILLS_REMOTE_PARTS = [".openclaw", "sandbox-skills"] as const;
@@ -304,11 +302,6 @@ class OpenShellSandboxBackendImpl {
   // Filesystem bridges must retain the same lifecycle owner returned by the factory.
   private handle: OpenShellSandboxBackend | null = null;
   private ensurePromise: Promise<void> | null = null;
-  private preparedRemoteWorkspaceForNextExec: {
-    workdir: string;
-    promise: Promise<void>;
-    lease: OpenShellWorkspaceLease;
-  } | null = null;
   private remoteSeedPending = false;
 
   constructor(
@@ -325,6 +318,10 @@ class OpenShellSandboxBackendImpl {
     if (this.handle) {
       return this.handle;
     }
+    const runRemoteShellScript = (command: SandboxBackendCommandParams) =>
+      this.params.execContext.config.mode === "mirror"
+        ? this.runWorkspaceOperation(() => this.runRemoteShellScript(command), command.signal)
+        : this.runRemoteShellScript(command);
     const handle: OpenShellSandboxBackend = {
       id: "openshell",
       runtimeId: this.params.execContext.sandboxName,
@@ -336,7 +333,6 @@ class OpenShellSandboxBackendImpl {
       configLabelKind: "Source",
       workdirValidation: "backend",
       validateWorkdir: async (workdir) => await this.validateWorkdir(workdir),
-      discardPreparedWorkdir: (workdir) => this.discardPreparedWorkdir(workdir),
       workdirRoots: [this.params.remoteWorkspaceDir, this.params.remoteAgentWorkspaceDir],
       remoteWorkspaceDir: this.params.remoteWorkspaceDir,
       remoteAgentWorkspaceDir: this.params.remoteAgentWorkspaceDir,
@@ -352,8 +348,7 @@ class OpenShellSandboxBackendImpl {
       finalizeExec: async ({ token }) => {
         await this.finalizeExec(token as PendingExec | undefined);
       },
-      runShellCommand: async (command) =>
-        await this.runWorkspaceOperation(async () => await this.runRemoteShellScript(command)),
+      runShellCommand: runRemoteShellScript,
       createFsBridge: ({ sandbox }) =>
         this.params.execContext.config.mode === "remote"
           ? createRemoteShellSandboxFsBridge({
@@ -361,8 +356,7 @@ class OpenShellSandboxBackendImpl {
               runtime: handle,
             })
           : this.createMirrorFsBridge(sandbox),
-      runRemoteShellScript: async (command) =>
-        await this.runWorkspaceOperation(async () => await this.runRemoteShellScript(command)),
+      runRemoteShellScript,
     };
     this.handle = handle;
     return handle;
@@ -384,20 +378,27 @@ class OpenShellSandboxBackendImpl {
     // Otherwise exec publication can erase a successful file-tool write or expose partial reads.
     return {
       resolvePath: (params) => bridge.resolvePath(params),
-      readFile: (params) => this.runWorkspaceOperation(() => bridge.readFile(params)),
-      writeFile: (params) => this.runWorkspaceOperation(() => bridge.writeFile(params)),
+      readFile: (params) =>
+        this.runWorkspaceOperation(() => bridge.readFile(params), params.signal),
+      writeFile: (params) =>
+        this.runWorkspaceOperation(() => bridge.writeFile(params), params.signal),
       createFileExclusive: (params) =>
-        this.runWorkspaceOperation(() => bridge.createFileExclusive(params)),
-      mkdirp: (params) => this.runWorkspaceOperation(() => bridge.mkdirp(params)),
-      remove: (params) => this.runWorkspaceOperation(() => bridge.remove(params)),
-      rename: (params) => this.runWorkspaceOperation(() => bridge.rename(params)),
-      stat: (params) => this.runWorkspaceOperation(() => bridge.stat(params)),
+        this.runWorkspaceOperation(() => bridge.createFileExclusive(params), params.signal),
+      mkdirp: (params) => this.runWorkspaceOperation(() => bridge.mkdirp(params), params.signal),
+      remove: (params) => this.runWorkspaceOperation(() => bridge.remove(params), params.signal),
+      rename: (params) => this.runWorkspaceOperation(() => bridge.rename(params), params.signal),
+      stat: (params) => this.runWorkspaceOperation(() => bridge.stat(params), params.signal),
     };
   }
 
-  private async runWorkspaceOperation<T>(operation: () => Promise<T>): Promise<T> {
+  private async runWorkspaceOperation<T>(
+    operation: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    signal?.throwIfAborted();
     const lease = await this.acquireWorkspaceLease();
     try {
+      signal?.throwIfAborted();
       return await operation();
     } finally {
       lease.release();
@@ -416,31 +417,15 @@ class OpenShellSandboxBackendImpl {
       ])}`,
     ].toSorted();
     const releases: Array<() => void> = [];
-    try {
-      for (const key of keys) {
-        const acquired = createDeferred<void>();
-        const released = createDeferred<void>();
-        void openShellWorkspaceOperations.enqueue(key, async () => {
-          acquired.resolve();
-          await released.promise;
-        });
-        await acquired.promise;
-        releases.push(released.resolve);
-      }
-    } catch (error) {
-      for (const release of releases.toReversed()) {
-        release();
-      }
-      throw error;
+    for (const key of keys) {
+      const acquired = createDeferred<() => void>();
+      void openShellWorkspaceOperations.enqueue(key, () => new Promise<void>(acquired.resolve));
+      releases.push(await acquired.promise);
     }
-    let active = true;
     return {
       release: () => {
-        if (!active) {
-          return;
-        }
-        active = false;
         for (const release of releases.toReversed()) {
+          // Deferred resolution is idempotent, including repeated finalization cleanup.
           release();
         }
       },
@@ -459,10 +444,16 @@ class OpenShellSandboxBackendImpl {
       workdir: remoteWorkdir,
       env: {},
     });
-    const preparedWorkspace = this.consumePreparedRemoteWorkspaceForNextExec(remoteWorkdir);
-    const workspaceLease = preparedWorkspace?.lease ?? (await this.acquireWorkspaceLease());
+    const workspaceLease =
+      this.params.execContext.config.mode === "mirror"
+        ? await this.acquireWorkspaceLease()
+        : undefined;
     try {
-      await (preparedWorkspace?.promise ?? this.prepareRemoteWorkspaceForExec());
+      await this.ensureSandboxExists();
+      if (workspaceLease) {
+        await this.syncWorkspaceToRemote();
+        this.remoteSeedPending = false;
+      }
       const sshSession = await createOpenShellSshSession({
         context: this.params.execContext,
       });
@@ -475,59 +466,47 @@ class OpenShellSandboxBackendImpl {
         });
         return {
           argv: prepared.argv,
-          token: { sshSession, cleanup: prepared.cleanup, workspaceLease },
+          token: {
+            workspaceLease,
+            cleanup: async () => {
+              try {
+                await prepared.cleanup();
+              } finally {
+                await disposeSshSandboxSession(sshSession);
+              }
+            },
+          },
         };
       } catch (error) {
         await disposeSshSandboxSession(sshSession);
         throw error;
       }
     } catch (error) {
-      workspaceLease.release();
+      workspaceLease?.release();
       throw error;
     }
   }
 
   async validateWorkdir(workdir: string): Promise<string | null> {
-    this.discardPreparedRemoteWorkspace();
-    const lease = await this.acquireWorkspaceLease();
-    const preparedWorkspace = this.prepareRemoteWorkspaceForExec();
-    const reusablePreparation = { workdir, promise: preparedWorkspace, lease };
-    this.preparedRemoteWorkspaceForNextExec = reusablePreparation;
+    if (this.params.execContext.config.mode === "mirror") {
+      // Validate the canonical upload source after any outstanding publication.
+      // Never retain a lease across the caller's env hooks, approvals, or abandonment.
+      return await this.runWorkspaceOperation(() => this.validateMirrorWorkdir(workdir));
+    }
+    await this.ensureSandboxExists();
+    const sshSession = await createOpenShellSshSession({ context: this.params.execContext });
     try {
-      await preparedWorkspace;
-      const sshSession = await createOpenShellSshSession({
-        context: this.params.execContext,
+      const result = await runSshSandboxCommand({
+        session: sshSession,
+        remoteCommand: buildRemoteWorkdirValidationCommand({
+          workdir,
+          root: this.resolveWorkdirValidationRoot(workdir),
+        }),
+        allowFailure: true,
       });
-      try {
-        const result = await runSshSandboxCommand({
-          session: sshSession,
-          remoteCommand: buildRemoteWorkdirValidationCommand({
-            workdir,
-            root: this.resolveWorkdirValidationRoot(workdir),
-          }),
-          allowFailure: true,
-        });
-        const resolvedWorkdir = result.code === 0 ? result.stdout.toString("utf8").trim() : "";
-        if (this.preparedRemoteWorkspaceForNextExec === reusablePreparation) {
-          this.preparedRemoteWorkspaceForNextExec = resolvedWorkdir
-            ? { workdir: resolvedWorkdir, promise: preparedWorkspace, lease }
-            : null;
-          if (!resolvedWorkdir) {
-            lease.release();
-          }
-        } else {
-          lease.release();
-        }
-        return resolvedWorkdir || null;
-      } finally {
-        await disposeSshSandboxSession(sshSession);
-      }
-    } catch (error) {
-      if (this.preparedRemoteWorkspaceForNextExec?.lease === lease) {
-        this.preparedRemoteWorkspaceForNextExec = null;
-      }
-      lease.release();
-      throw error;
+      return result.code === 0 ? result.stdout.toString("utf8").trim() || null : null;
+    } finally {
+      await disposeSshSandboxSession(sshSession);
     }
   }
 
@@ -546,66 +525,67 @@ class OpenShellSandboxBackendImpl {
     }
   }
 
-  private consumePreparedRemoteWorkspaceForNextExec(workdir: string): {
-    promise: Promise<void>;
-    lease: OpenShellWorkspaceLease;
-  } | null {
-    const preparedWorkspace = this.preparedRemoteWorkspaceForNextExec;
-    if (!preparedWorkspace || preparedWorkspace.workdir !== workdir) {
-      this.discardPreparedRemoteWorkspace();
+  private async validateMirrorWorkdir(workdir: string): Promise<string | null> {
+    const normalized = normalizeRemotePath(workdir);
+    const roots = this.workspaceUploadRoots();
+    if (!roots.some((root) => isRemotePathInside(root.remote, normalized))) {
       return null;
     }
-    this.preparedRemoteWorkspaceForNextExec = null;
-    return preparedWorkspace;
-  }
-
-  discardPreparedWorkdir(workdir: string): void {
-    if (this.preparedRemoteWorkspaceForNextExec?.workdir === workdir) {
-      this.discardPreparedRemoteWorkspace();
+    const { cfg, skillsWorkspaceDir } = this.params.createParams;
+    if (cfg.workspaceAccess === "rw" && skillsWorkspaceDir) {
+      roots.push({
+        remote: resolveRemoteMaterializedSkillsWorkspaceDir(this.params.remoteWorkspaceDir),
+        local: skillsWorkspaceDir,
+      });
     }
-  }
-
-  private discardPreparedRemoteWorkspace(): void {
-    const preparedWorkspace = this.preparedRemoteWorkspaceForNextExec;
-    if (!preparedWorkspace) {
-      return;
+    // Later uploads replace overlapping roots. Their ancestors are created by mkdirp,
+    // while descendants must be real directories in the symlink-free upload source.
+    let createdAncestor = false;
+    for (const root of roots.toReversed()) {
+      if (!isRemotePathInside(root.remote, normalized)) {
+        createdAncestor ||= isRemotePathInside(normalized, root.remote);
+        continue;
+      }
+      const relative = path.posix.relative(root.remote, normalized);
+      if (!relative) {
+        return normalized;
+      }
+      const parts = relative.split("/");
+      if (
+        DEFAULT_OPEN_SHELL_MIRROR_EXCLUDE_DIRS.some(
+          (excluded) => excluded === normalizeLowercaseStringOrEmpty(parts[0]),
+        )
+      ) {
+        return createdAncestor ? normalized : null;
+      }
+      let local = root.local;
+      for (const part of root.local === skillsWorkspaceDir ? ["", ...parts] : parts) {
+        local = path.join(local, part);
+        const stats = await fs.lstat(local).catch(() => null);
+        if (!stats?.isDirectory()) {
+          return createdAncestor && (!stats || stats.isSymbolicLink()) ? normalized : null;
+        }
+      }
+      return normalized;
     }
-    this.preparedRemoteWorkspaceForNextExec = null;
-    void preparedWorkspace.promise.then(
-      () => preparedWorkspace.lease.release(),
-      () => preparedWorkspace.lease.release(),
-    );
-  }
-
-  private async prepareRemoteWorkspaceForExec(): Promise<void> {
-    await this.ensureSandboxExists();
-    if (this.params.execContext.config.mode === "mirror") {
-      await this.syncWorkspaceToRemote();
-      return;
-    }
-    const seeded = await this.maybeSeedRemoteWorkspace();
-    if (!seeded) {
-      await this.syncSkillsWorkspaceToRemote();
-    }
+    return null;
   }
 
   async finalizeExec(token?: PendingExec): Promise<void> {
-    const workspaceLease = token?.workspaceLease ?? (await this.acquireWorkspaceLease());
+    const workspaceLease =
+      token?.workspaceLease ??
+      (this.params.execContext.config.mode === "mirror"
+        ? await this.acquireWorkspaceLease()
+        : undefined);
     try {
       if (this.params.execContext.config.mode === "mirror") {
         await this.syncWorkspaceFromRemote();
       }
     } finally {
       try {
-        if (token?.sshSession) {
-          try {
-            await token.cleanup();
-          } finally {
-            await disposeSshSandboxSession(token.sshSession);
-          }
-        }
+        await token?.cleanup();
       } finally {
-        workspaceLease.release();
+        workspaceLease?.release();
       }
     }
   }
@@ -614,9 +594,8 @@ class OpenShellSandboxBackendImpl {
     params: SandboxBackendCommandParams,
   ): Promise<SandboxBackendCommandResult> {
     await this.ensureSandboxExists();
-    const seeded = await this.maybeSeedRemoteWorkspace();
-    if (!seeded) {
-      await this.syncSkillsWorkspaceToRemote();
+    if (this.params.execContext.config.mode === "mirror") {
+      await this.maybeSeedRemoteWorkspace();
     }
     return await this.runRemoteShellScriptInternal(params);
   }
@@ -791,7 +770,21 @@ class OpenShellSandboxBackendImpl {
     if (this.ensurePromise) {
       return await this.ensurePromise;
     }
-    this.ensurePromise = this.ensureSandboxExistsInner();
+    const initialize = async () => {
+      await this.ensureSandboxExistsInner();
+      if (
+        this.params.execContext.config.mode === "remote" &&
+        !(await this.maybeSeedRemoteWorkspace())
+      ) {
+        await this.syncSkillsWorkspaceToRemote();
+      }
+    };
+    // Remote commands must not block later turns that supply their input. Only
+    // discovery, seeding and this turn's skill refresh share the runtime lock.
+    this.ensurePromise =
+      this.params.execContext.config.mode === "remote"
+        ? this.runWorkspaceOperation(initialize)
+        : initialize();
     try {
       await this.ensurePromise;
     } catch (error) {
@@ -957,29 +950,25 @@ class OpenShellSandboxBackendImpl {
     );
   }
 
-  private async syncWorkspaceToRemote(): Promise<void> {
-    await this.runRemoteShellScriptInternal({
-      script: 'mkdir -p -- "$1" && find "$1" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
-      args: [this.params.remoteWorkspaceDir],
-    });
-    await this.uploadPathToRemote(
-      this.params.createParams.workspaceDir,
-      this.params.remoteWorkspaceDir,
-    );
-
+  private workspaceUploadRoots(): Array<{ remote: string; local: string }> {
+    const { createParams, remoteWorkspaceDir, remoteAgentWorkspaceDir } = this.params;
+    const roots = [{ remote: remoteWorkspaceDir, local: createParams.workspaceDir }];
     if (
-      this.params.createParams.cfg.workspaceAccess !== "none" &&
-      path.resolve(this.params.createParams.agentWorkspaceDir) !==
-        path.resolve(this.params.createParams.workspaceDir)
+      createParams.cfg.workspaceAccess !== "none" &&
+      path.resolve(createParams.agentWorkspaceDir) !== path.resolve(createParams.workspaceDir)
     ) {
+      roots.push({ remote: remoteAgentWorkspaceDir, local: createParams.agentWorkspaceDir });
+    }
+    return roots;
+  }
+
+  private async syncWorkspaceToRemote(): Promise<void> {
+    for (const root of this.workspaceUploadRoots()) {
       await this.runRemoteShellScriptInternal({
         script: 'mkdir -p -- "$1" && find "$1" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +',
-        args: [this.params.remoteAgentWorkspaceDir],
+        args: [root.remote],
       });
-      await this.uploadPathToRemote(
-        this.params.createParams.agentWorkspaceDir,
-        this.params.remoteAgentWorkspaceDir,
-      );
+      await this.uploadPathToRemote(root.local, root.remote);
     }
     await this.syncSkillsWorkspaceToRemote();
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running overlapping OpenShell commands could lose workspace serialization after concurrent working-directory checks. An abandoned check could also retain the workspace lock and block later file tools. In remote mode, a background command waiting for input from a later turn blocked the very command or file write needed to continue it.

## Why This Change Was Made

Remove the shared “preparation for the next exec” slot and the OpenShell discard hook. Mirror checks inspect the canonical host upload source and release their short lease before returning. Each mirror exec owns its upload, command, download, and cleanup; file operations retain the same serialization and reject cancellation before committing a queued write. Mirror cwd validation accounts for excluded directories, symlinks, generated skills, agent mounts, and legacy overlapping upload roots. Remote permissions and image-specific restrictions are checked at execution rather than during the host-source check.

Remote backends cache complete initialization—discovery, initial seeding, and the turn's materialized skills refresh—under a short shared lock. Commands and file tools do not retain that lock, including across separate handles and agent turns. Skill refresh remains consistent with the existing shared owner: later turns may update skills visible to older background commands. No new SDK, configuration, dependency, or persistence surface.

The lease race was introduced by #130031 (`c69abc232755c9a4f6e78f279cb05b51392df281`, 2026-08-26); code author, PR author, and merger were @steipete. The older preparation cache predates that change. This PR removes the ownership problem rather than adding another handoff guard.

Production LOC: **+143/-154 (net -11)**. Tests and test support: **+504/-39**. Docs: **+12/-0**.

## User Impact

Mirror commands cannot release one another's workspace ownership through concurrent validation. Rejected or abandoned cwd checks do not strand later operations. Remote commands can wait for input supplied by another command or a file tool on a later turn. Concurrent writes to the same remote file follow normal filesystem semantics.

## Evidence

- Before the repair, the new focused tests reported **19 failures / 10 passes**, including retained validation leases, remote serialization, and repeated skills refresh. A deterministic controlled-transport reproduction admitted a third exec before the first finalized.
- After the repair, all **143 OpenShell tests across seven files pass**, including initialization ordering, cross-handle overlap, mirror publication, cancellation, excluded/symlinked cwd paths, and preparation/publication/SSH-cleanup failures. Two broad parallel local attempts hit the runner's no-output watchdog during imports; the complete serial run passed without changing timeouts or assertions.
- Independent Codex review found no blocking findings.
- Final candidate `0b8d1031e9d716af41abf42b08fa730d90d0299b` passed all **143 unit tests / seven files** again in isolated Linux (110.61s), with source SHA-256 checks matching the final runtime and tests.
- **Live OpenShell v0.0.109: 5/5 E2E checks pass** against a real mTLS gateway, custom sandbox image and SSH transport in a disposable Linux Docker container. Mirror scenario: 224.642s; remote scenario: 142.168s. Both exercise validation → preparation → real execution → finalization, 64 mixed workflows with eight concurrent callers, nonzero exits and recovery. Mirror asserts lossless counter/ledger publication; remote requires a waiting process to receive input from another handle and a file tool. Gateway protected calls passed. Total runner time including private QA build: 968.96s.
- [Exact-head CI run 33130199914](https://github.com/openclaw/openclaw/actions/runs/33130199914) is green. An earlier run identified three missing brace pairs in tests; corrected and verified by final CI.
- Local changed-code checks passed formatting, architecture/dependency guards, unused-export checks, and production/test typechecks, but SDK declaration preparation hit its existing 300s timeout before lint. An extra local regression attempt hit the 120s import watchdog. Neither is counted as a passing run; the complete final Linux suite and CI passed without increasing timeouts or weakening assertions.
- This is local disposable-container live proof, not hosted Testbox/AWS proof. Blacksmith CLI authentication was unavailable. The existing hosted bootstrap follow-up is #131134; fixture CIDRs in #130465 and memory work in #117757 remain separately owned and untouched. The live setup required the existing private-QA build prerequisite; no environment workaround was added to production or tests.

AI-assisted implementation and independent Codex review. Latest ClawSweeper comment is a review-start placeholder; it has no findings or Rank-up moves yet.
