### PR TITLE
fix(ui): show agent pictures in Activity and owner avatars

### DIFF
--- a/ui/src/components/session-owner-chip.test.ts
+++ b/ui/src/components/session-owner-chip.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, expect, it, vi } from "vitest";
+import { setAvatarGatewayOrigin } from "../lib/identity-avatar.ts";
 import { listAssignableSessionOwners, type SessionCreatedActor } from "./session-owner-chip.ts";
 
 type OwnerChipElement = HTMLElement & {
@@ -14,6 +15,8 @@ type OwnerChipElement = HTMLElement & {
 
 afterEach(() => {
   document.body.replaceChildren();
+  setAvatarGatewayOrigin(null);
+  vi.restoreAllMocks();
 });
 
 async function mount(params: { participants?: SessionCreatedActor[]; participantCount?: number }) {
@@ -43,7 +46,9 @@ it("keeps the single owner chip unchanged without participants", async () => {
 
 it("renders one participant behind the owner with combined accessibility", async () => {
   const chip = await mount({
-    participants: [{ type: "agent", id: "research", label: "Research" }],
+    participants: [
+      { type: "agent", id: "research", label: "Research", avatarUrl: "/avatar/research" },
+    ],
     participantCount: 1,
   });
   expect(chip.querySelector(".session-owner-stack__back .viewer-avatar")).not.toBeNull();
@@ -51,7 +56,29 @@ it("renders one participant behind the owner with combined accessibility", async
   expect(chip.querySelector(".session-owner-stack")?.getAttribute("aria-label")).toBe(
     "Owned by Ada · with Research",
   );
+  expect(chip.querySelector(".session-owner-stack__back img")?.getAttribute("src")).toBe(
+    "/avatar/research",
+  );
 });
+
+it.each(["row", "header"] as const)(
+  "renders the configured agent picture in a %s owner chip",
+  async (size) => {
+    const chip = await mount({});
+    chip.owner = {
+      type: "agent",
+      id: "research",
+      label: "Research",
+      avatarUrl: "/avatar/research",
+    };
+    chip.size = size;
+    await vi.waitFor(() => {
+      expect(chip.querySelector(".session-owner-chip img")?.getAttribute("src")).toBe(
+        "/avatar/research",
+      );
+    });
+  },
+);
 
 it("renders the total participant count in the back slot for three identities", async () => {
   const chip = await mount({
@@ -70,18 +97,29 @@ it("renders the total participant count in the back slot for three identities", 
 it("treats a present owner facet as authoritative before adding self and configured agents", () => {
   const facet = [
     { type: "human" as const, id: "profile:channel:opaque", label: "Opaque Person" },
-    { type: "agent" as const, id: "facet-agent", label: "Facet Agent" },
+    {
+      type: "agent" as const,
+      id: "facet-agent",
+      label: "Facet Agent",
+      avatarUrl: "/avatar/facet-agent",
+    },
+    { type: "agent" as const, id: "avatar-only", avatarUrl: "/avatar/avatar-only" },
   ];
 
   expect(
     listAssignableSessionOwners({
       facet,
-      agents: [{ id: "configured-agent", name: "Configured Agent" }],
+      agents: [
+        { id: "configured-agent", name: "Configured Agent" },
+        { id: "facet-agent", name: "Configured name" },
+        { id: "avatar-only", name: "Avatar Only" },
+      ],
       self: { id: "profile-self", name: "Self" },
     }),
   ).toEqual([
+    { type: "agent", id: "avatar-only", label: "Avatar Only", avatarUrl: "/avatar/avatar-only" },
     { type: "agent", id: "configured-agent", label: "Configured Agent" },
-    { type: "agent", id: "facet-agent", label: "Facet Agent" },
+    { type: "agent", id: "facet-agent", label: "Facet Agent", avatarUrl: "/avatar/facet-agent" },
     { type: "human", id: "profile:channel:opaque", label: "Opaque Person" },
     { type: "human", id: "profile-self", label: "Self" },
   ]);

--- a/ui/src/components/session-owner-chip.ts
+++ b/ui/src/components/session-owner-chip.ts
@@ -26,10 +26,13 @@ export function listAssignableSessionOwners(params: {
     });
   }
   for (const agent of params.agents ?? []) {
+    const owner = owners.get(agent.id);
     owners.set(agent.id, {
       type: "agent",
       id: agent.id,
       ...(agent.name ? { label: agent.name } : {}),
+      // Keep the enriched identity, with the roster name when no identity name is configured.
+      ...(owner?.type === "agent" ? owner : {}),
     });
   }
   return [...owners.values()].toSorted(

--- a/ui/src/lib/identity-avatar-loader.ts
+++ b/ui/src/lib/identity-avatar-loader.ts
@@ -7,7 +7,14 @@ import {
 
 const IDENTITY_AVATAR_CACHE_MAX_ENTRIES = 128;
 const IDENTITY_AVATAR_FETCH_TIMEOUT_MS = 30_000;
-const IDENTITY_AVATAR_MIME_TYPES = new Set(["image/gif", "image/jpeg", "image/png", "image/webp"]);
+// Agent identity files also support SVG; these blobs render only as <img>, never inline markup.
+const IDENTITY_AVATAR_MIME_TYPES = new Set([
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/svg+xml",
+]);
 
 type CachedIdentityAvatar = {
   blobUrl: string | null;

--- a/ui/src/lib/identity-avatar.test.ts
+++ b/ui/src/lib/identity-avatar.test.ts
@@ -93,6 +93,27 @@ describe("resolveAvatar profile URL origin restriction", () => {
 });
 
 describe("resolveAvatar gateway origin trust", () => {
+  it.each([
+    ["https://gw.example.com", "", "/avatar/research", "/avatar/research"],
+    [
+      "https://gw.example.com",
+      "/control",
+      "/control/avatar/research?v=2#f",
+      "/control/avatar/research?v=2",
+    ],
+    ["https://ui.example.com", "/control", "/avatar/research", "/avatar/research"],
+  ])(
+    "resolves agent images for page %s and mount %s",
+    (pageOrigin, basePath, avatarUrl, expectedPath) => {
+      vi.stubGlobal("location", { origin: pageOrigin });
+      setAvatarGatewayOrigin("wss://gw.example.com/ws", null, basePath);
+      expect(resolveAvatar({ id: "research", profileAvatarUrl: avatarUrl })).toEqual({
+        kind: "profile",
+        url: `https://gw.example.com${expectedPath}`,
+      });
+    },
+  );
+
   it("applies an explicit base path for a same-origin gateway", () => {
     vi.stubGlobal("location", { origin: "https://gw.example.com" });
     setAvatarGatewayOrigin("wss://gw.example.com/ws", null, "/wilfred");
@@ -204,24 +225,28 @@ describe("resolveAvatar profile-id senders", () => {
 });
 
 describe("authenticated profile avatar cache", () => {
-  it("shares one authenticated image fetch and blob across avatar surfaces", async () => {
+  it.each([
+    ["/api/users/profile-ada/avatar?v=7", "image/png"],
+    ["/avatar/research", "image/png"],
+    ["/avatar/research", "image/svg+xml"],
+  ])("shares one authenticated fetch for %s (%s)", async (avatarPath, mimeType) => {
     setAvatarGatewayOrigin("wss://gateway.example.test/ws", "Bearer profile-token");
     const fetchAvatar = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(new Uint8Array([1, 2, 3]), {
-        headers: { "content-type": "image/png" },
+        headers: { "content-type": mimeType },
       }),
     );
     const createObjectURL = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:profile-ada");
 
-    const first = resolveAvatarImageUrl("/api/users/profile-ada/avatar?v=7");
-    const second = resolveAvatarImageUrl("/api/users/profile-ada/avatar?v=7");
+    const first = resolveAvatarImageUrl(avatarPath);
+    const second = resolveAvatarImageUrl(avatarPath);
 
     expect(first).toBe(second);
     await expect(first).resolves.toBe("blob:profile-ada");
     await expect(second).resolves.toBe("blob:profile-ada");
     expect(fetchAvatar).toHaveBeenCalledOnce();
     expect(fetchAvatar).toHaveBeenCalledWith(
-      "https://gateway.example.test/api/users/profile-ada/avatar?v=7",
+      `https://gateway.example.test${avatarPath}`,
       expect.objectContaining({
         credentials: "include",
         headers: { Authorization: "Bearer profile-token" },
@@ -361,6 +386,10 @@ describe("authenticated profile avatar cache", () => {
       "https://gateway.example.test@evil.example/api/users/profile-ada/avatar?v=7",
       "//evil.example/api/users/profile-ada/avatar?v=7",
       "/api/secrets",
+      "https://evil.example/avatar/research",
+      "//evil.example/avatar/research",
+      "/avatar/research/extra",
+      "/avatar/%",
     ]) {
       expect(resolveAvatarImageUrl(avatarUrl)).toBeNull();
       expect(resolveAvatar({ id: "profile-ada", profileAvatarUrl: avatarUrl })).toMatchObject({

--- a/ui/src/lib/identity-avatar.ts
+++ b/ui/src/lib/identity-avatar.ts
@@ -1,4 +1,8 @@
 import {
+  buildControlUiResourcePath,
+  parseControlUiResourcePath,
+} from "../../../src/gateway/control-ui-resource-routes.js";
+import {
   buildControlUiUserAvatarPath,
   canonicalizeControlUiUserAvatarPath,
 } from "../../../src/gateway/control-ui-user-avatar-route.js";
@@ -75,12 +79,9 @@ export function setAvatarGatewayOrigin(
 }
 
 /**
- * Returns a browser-safe avatar URL, or null. Only the canonical
- * /api/users/<id>/avatar route is trusted (pathname pinned, fragment dropped).
- * The query is preserved: the gateway stamps a ?v=<updatedAt> revision there so
- * replacing an image invalidates its bounded authenticated blob-cache entry.
- * Relative paths resolve against the trusted gateway origin; absolute URLs
- * must match that origin.
+ * Trust only canonical user and agent image routes on the connected Gateway.
+ * Keep revision queries for cache invalidation, drop fragments, and apply the
+ * mount once: agent URLs arrive already prefixed, unlike user-profile URLs.
  */
 export function resolveTrustedAvatarUrl(
   value: string,
@@ -90,14 +91,17 @@ export function resolveTrustedAvatarUrl(
   try {
     const parsed = new URL(value, ORIGIN_PROBE);
     const relativeRoute = parsed.origin === ORIGIN_PROBE;
-    const canonicalPathname = canonicalizeControlUiUserAvatarPath(
-      parsed.pathname,
-      relativeRoute ? "" : resourceBasePath,
-    );
-    if (!canonicalPathname) {
+    const userPath = canonicalizeControlUiUserAvatarPath(parsed.pathname, resourceBasePath);
+    const agentPath = parseControlUiResourcePath("agentAvatar", parsed.pathname, resourceBasePath);
+    const pathname = userPath
+      ? `${resourceBasePath}${userPath}`
+      : agentPath.matched && agentPath.value
+        ? buildControlUiResourcePath("agentAvatar", resourceBasePath, agentPath.value)
+        : null;
+    if (!pathname) {
       return null;
     }
-    const suffix = `${resourceBasePath}${canonicalPathname}${parsed.search}`;
+    const suffix = `${pathname}${parsed.search}`;
     if (relativeRoute) {
       return gatewayOrigin ? new URL(suffix, gatewayOrigin).toString() : suffix;
     }
@@ -139,10 +143,8 @@ export function resolveIdentityHue(input: IdentityAvatarInput): number {
 }
 
 /**
- * Resolves a trusted gateway avatar route, else deterministic initials.
- * Gravatar is served by the gateway inside the profile avatar route itself, so
- * the client never constructs a Gravatar URL — it only ever renders the
- * canonical /api/users/<id>/avatar endpoint or falls back to initials.
+ * Resolve a Gateway user/agent avatar, else deterministic initials. Remote
+ * sources (including Gravatar) remain Gateway-owned, never browser fetches.
  */
 // User-profile ids are crypto UUIDs. Chat sender metadata carries only the id
 // (the prompt-visible envelope stays free of URLs), so a UUID-shaped sender id

--- a/ui/src/pages/activity/session-activity-view.test.ts
+++ b/ui/src/pages/activity/session-activity-view.test.ts
@@ -1,9 +1,10 @@
 /* @vitest-environment jsdom */
 
 import { render } from "lit";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
+import { setAvatarGatewayOrigin } from "../../lib/identity-avatar.ts";
 import type { PresenceViewer } from "../../lib/presence-users.ts";
 import { renderSessionActivityView } from "./session-activity-view.ts";
 
@@ -47,6 +48,10 @@ function props(overrides: Partial<Parameters<typeof renderSessionActivityView>[0
 }
 
 describe("session activity semantics", () => {
+  afterEach(() => {
+    setAvatarGatewayOrigin(null);
+    vi.restoreAllMocks();
+  });
   beforeEach(() => {
     document.body.innerHTML = "";
   });
@@ -58,6 +63,68 @@ describe("session activity semantics", () => {
     render(renderSessionActivityView(props()), container);
 
     expect(container.querySelectorAll("main")).toHaveLength(0);
+  });
+
+  it("renders agent-owned session and people images without replacing human pictures", async () => {
+    setAvatarGatewayOrigin("https://gateway.example.test");
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(new Uint8Array([1, 2, 3]), {
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    vi.spyOn(URL, "createObjectURL")
+      .mockReturnValueOnce("blob:human")
+      .mockReturnValueOnce("blob:agent");
+    const agent = {
+      type: "agent" as const,
+      id: "research",
+      label: "Research",
+      avatarUrl: "/avatar/research",
+    };
+    const human = {
+      type: "human" as const,
+      id: "person",
+      label: "Person",
+      avatarUrl: "/api/users/person/avatar",
+    };
+    const container = document.createElement("div");
+    document.body.append(container);
+    render(
+      renderSessionActivityView(
+        props({
+          rows: [
+            row("Human session", human, Date.now(), { owner: { actor: human } }),
+            row("Agent session", agent, Date.now() - 1, {
+              owner: { actor: agent },
+              createdActor: agent,
+            }),
+            row("Unattributed session", agent, Date.now() - 2, {
+              owner: undefined,
+              createdActor: undefined,
+              agentId: "research",
+            }),
+          ],
+        }),
+      ),
+      container,
+    );
+    await vi.waitFor(() => {
+      expect(
+        container.querySelector('[data-activity-session="Human session"] img')?.getAttribute("src"),
+      ).toBe("blob:human");
+      expect(
+        container.querySelector('[data-activity-session="Agent session"] img')?.getAttribute("src"),
+      ).toBe("blob:agent");
+      expect(
+        container.querySelector('[data-activity-person="research"] img')?.getAttribute("src"),
+      ).toBe("blob:agent");
+      expect(
+        container
+          .querySelector('[data-activity-session="Unattributed session"] img')
+          ?.getAttribute("src"),
+      ).toBe("blob:agent");
+    });
   });
 });
 

--- a/ui/src/pages/activity/session-activity.ts
+++ b/ui/src/pages/activity/session-activity.ts
@@ -1,5 +1,7 @@
+import { buildControlUiResourcePath } from "../../../../src/gateway/control-ui-resource-routes.js";
 import type { GatewaySessionRow } from "../../api/types.ts";
 import { ACTIVITY_PERSON_PARAM } from "../../app-route-paths.ts";
+import { readAvatarGatewayContext } from "../../lib/identity-avatar.ts";
 import {
   presenceViewerLabel,
   projectPresencePayload,
@@ -92,10 +94,16 @@ function sessionActors(row: GatewaySessionRow) {
 
 export function sessionActivityOwner(row: GatewaySessionRow): PresenceViewer {
   const actor = row.owner?.actor ?? row.createdActor;
+  const agentId = normalized(row.agentId);
+  const { resourceBasePath } = readAvatarGatewayContext();
   return {
-    id: normalized(actor?.id) ?? normalized(row.agentId) ?? "system",
-    name: normalized(actor?.label) ?? normalized(row.agentId),
-    avatarUrl: normalized(actor?.avatarUrl),
+    id: normalized(actor?.id) ?? agentId ?? "system",
+    name: normalized(actor?.label) ?? agentId,
+    avatarUrl: actor
+      ? normalized(actor.avatarUrl)
+      : agentId
+        ? buildControlUiResourcePath("agentAvatar", resourceBasePath, agentId)
+        : undefined,
     watchedSessions: [],
   };
 }


### PR DESCRIPTION
Closes #131240 (agent-owned Activity and owner avatars show initials).

## What Problem This Solves

Fixes an issue where users viewing Activity, owner menus, participant chips, or session hovercards saw initials instead of configured agent pictures. Sessions without a recorded person also displayed an agent name without its picture.

## Why This Change Was Made

The gateway already supplies agent image routes. The shared identity renderer only accepted human-profile routes, so every consumer discarded those images. The canonical resolver now accepts the exact authenticated agent-image route as well, preserving connected-gateway origin checks, mount paths, revision queries, and the shared bounded blob lifecycle. SVG is included because the existing agent-image endpoint supports it.

Owner menus retain gateway-enriched agent pictures and identity labels while preserving roster-name fallback. Activity's existing agent fallback now includes its image only when no actor was recorded; human attribution is not replaced. No provider-specific or deployment-specific branch, new config, protocol, schema, or dependency.

## User Impact

Configured agent pictures consistently identify agent-owned items on any installation. Human pictures and deterministic initials remain intact. No image is hardcoded or shipped in the product; proof uses a synthetic local agent.

## Evidence

- Full `pnpm build`, changed-file checks, and formatting passed. Focused owner/sibling run: 88 tests passed; the final roster-name regression additionally passed all 7 owner-chip tests.
- Production delta: +40/-20 (net +20); tests +144/-10. Growth covers the additional canonical image route, SVG MIME contract, and existing ownerless-session image fallback; no alternate loader or actor policy layer.
- Fresh structured Codex/Sol autoreview passed with no P0 findings. Independent hands-on review found one roster-name fallback regression; it was reproduced, fixed, and retested before the final clean review.

- Regression tests failed before the fixes: shared agent-route resolution, PNG/SVG authenticated loading, mounted Activity images, owner/participant pictures, and enriched owner facets. A separately reproduced ownerless-session case and an independent-review roster-name fallback regression are now covered and passing.
- Focused owner/sibling tests: `node scripts/run-vitest.mjs ui/src/lib/identity-avatar.test.ts ui/src/components/session-owner-chip.test.ts ui/src/components/identity-avatar-view.test.ts ui/src/components/viewer-facepile.test.ts ui/src/components/session-hovercard.test.ts ui/src/pages/activity/session-activity.test.ts ui/src/pages/activity/session-activity-view.test.ts`.
- Real isolated gateway on its own state directory and loopback port, with `/control` base path. A session created through `sessions.create` renders the configured robot image in desktop and mobile Activity. Browser verified `naturalWidth=1254`, `naturalHeight=1254`, and authenticated-loader `blob:` rendering. This is an auth-none local operator flow, not a claim of live multi-user authentication; protected-fetch credentials and origin rejection have focused tests.
- Before uses the installed baseline with the same affected renderer. After uses the candidate Control UI build and the same isolated gateway/session. No mocked WebSocket, DOM injection, operator gateway restart, or production state mutation was used for proof.
- Related but distinct work: #130779 (identity-editor save lifecycle), #126392 (held channel-avatar reconnect), #130986 (participant attribution). This repair does not supersede those PRs.

### Before

![Activity uses an initial despite the configured agent picture](https://github.com/user-attachments/assets/74a98a64-e33d-4adc-b69d-ecd8282f1478)

### After

![Activity displays the configured agent picture](https://github.com/user-attachments/assets/daf97d69-6acc-45e4-a208-6e920b3852ec)

![Mobile Activity displays the configured agent picture](https://github.com/user-attachments/assets/07b18b2a-9db2-4e87-b472-fa5b73d2d5ff)

AI-assisted implementation and verification.
