### PR TITLE
refactor(memory): simplify provenance and dreaming flows

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -788,7 +788,6 @@ extensions/memory-core/src/session-ingestion.ts	2
 extensions/memory-core/src/session-reset-recall-metadata.ts	3
 extensions/memory-core/src/session-search-visibility.ts	2
 extensions/memory-core/src/short-term-promotion-apply.ts	4
-extensions/memory-core/src/short-term-promotion-artifacts.ts	2
 extensions/memory-core/src/short-term-promotion-memory-write.ts	4
 extensions/memory-core/src/short-term-promotion-record.ts	1
 extensions/memory-core/src/short-term-promotion-rehydrate.ts	1

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -17,7 +17,7 @@ Dreaming is enabled by default. Set
 
 ## What dreaming writes
 
-- **Machine state** in `memory/.dreams/` (recall store, phase signals, ingestion checkpoints, locks).
+- **Machine state** in SQLite-backed plugin state (recall store, phase signals, ingestion checkpoints, locks).
 - **Rewrite preimages** in SQLite-backed plugin state before an accepted `MEMORY.md` rewrite.
 - **Human-readable output** in `DREAMS.md` (or an existing `dreams.md`) and optional phase report files under `memory/dreaming/<phase>/YYYY-MM-DD.md`.
 
@@ -149,7 +149,7 @@ Deep ranking uses six weighted base signals plus phase reinforcement:
 | Consolidation       | 0.10   | Multi-day recurrence strength                     |
 | Conceptual richness | 0.06   | Concept-tag density from snippet/path             |
 
-Light and REM phase hits add a small recency-decayed boost from `memory/.dreams/phase-signals.json`.
+Light and REM phase hits recorded in SQLite-backed plugin state add a small recency-decayed boost.
 
 ## Scheduling
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -271,11 +271,7 @@ async function startNarrativeRunOrFallback(params: {
       throw runErr;
     }
     await appendFallbackNarrativeEntry({
-      workspaceDir: params.workspaceDir,
-      data: params.data,
-      nowMs: params.nowMs,
-      timezone: params.timezone,
-      logger: params.logger,
+      ...params,
       reason: "subagent runtime is request-scoped",
     });
     return null;
@@ -893,16 +889,12 @@ async function generateAndAppendDreamNarrative(
           }
 
           const runId = await startNarrativeRunOrFallback({
-            subagent: params.subagent,
+            ...params,
             sessionKey: attemptSessionKey,
             runKey: attemptRunKey,
             message,
-            data: params.data,
-            workspaceDir: params.workspaceDir,
             nowMs,
-            timezone: params.timezone,
             model: attemptModel,
-            logger: params.logger,
           });
           if (!runId) {
             return;
@@ -941,11 +933,8 @@ async function generateAndAppendDreamNarrative(
             })} for ${params.data.phase} phase; writing fallback diary entry.`,
           );
           await appendFallbackNarrativeEntry({
-            workspaceDir: params.workspaceDir,
-            data: params.data,
+            ...params,
             nowMs,
-            timezone: params.timezone,
-            logger: params.logger,
             reason: `the narrative run ended with ${formatNarrativeTerminalStatus({
               status: result.status,
               error: result.error,
@@ -986,11 +975,8 @@ async function generateAndAppendDreamNarrative(
           `memory-core: narrative generation produced no text for ${params.data.phase} phase; writing fallback diary entry.`,
         );
         await appendFallbackNarrativeEntry({
-          workspaceDir: params.workspaceDir,
-          data: params.data,
+          ...params,
           nowMs,
-          timezone: params.timezone,
-          logger: params.logger,
           reason: "the narrative run produced no text",
         });
         return;
@@ -1023,11 +1009,8 @@ async function generateAndAppendDreamNarrative(
         `memory-core: narrative generation failed for ${params.data.phase} phase: ${formatErrorMessage(err)}`,
       );
       await appendFallbackNarrativeEntry({
-        workspaceDir: params.workspaceDir,
-        data: params.data,
+        ...params,
         nowMs,
-        timezone: params.timezone,
-        logger: params.logger,
         reason: `the narrative run failed (${formatErrorMessage(err)})`,
       });
     } finally {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -1564,77 +1564,35 @@ export async function runDreamingSweepPhases(params: {
   const admissionPolicy = resolveAdmissionPolicy(params.pluginConfig);
   let degradedPhases = 0;
   let pendingNarratives = 0;
-  const recordNarrativeOutcome = (outcome: DreamNarrativeOutcome): void => {
-    if (outcome.status === "degraded") {
-      degradedPhases += 1;
-    } else if (outcome.status === "pending") {
-      pendingNarratives += 1;
+  async function runPhase<TConfig extends LightDreamingConfig | RemDreamingConfig>(
+    phase: "light" | "rem",
+    config: TConfig,
+    run: (params: DreamingPhaseRunParams<TConfig>) => Promise<DreamNarrativeOutcome>,
+  ): Promise<void> {
+    if (!config.enabled || config.limit <= 0) {
+      return;
     }
-  };
-
-  const light = resolveMemoryLightDreamingConfig({
-    pluginConfig: params.pluginConfig,
-    cfg: params.cfg,
-  });
-  if (light.enabled && light.limit > 0) {
     try {
-      recordNarrativeOutcome(
-        await runLightDreaming({
-          agentId: params.agentId,
-          workspaceDir: params.workspaceDir,
-          cfg: params.cfg,
-          config: light,
-          logger: params.logger,
-          subagent: params.subagent,
-          nowMs: sweepNowMs,
-          detachNarratives: params.detachNarratives,
-          admissionPolicy,
-        }),
-      );
+      const outcome = await run({ ...params, config, nowMs: sweepNowMs, admissionPolicy });
+      if (outcome.status === "degraded") {
+        degradedPhases += 1;
+      } else if (outcome.status === "pending") {
+        pendingNarratives += 1;
+      }
     } catch (err) {
       await appendFailedDreamingEvent({
         workspaceDir: params.workspaceDir,
-        phase: "light",
+        phase,
         error: formatErrorMessage(err),
-        storageMode: light.storage.mode,
+        storageMode: config.storage.mode,
         nowMs: sweepNowMs,
         logger: params.logger,
       });
       throw err;
     }
   }
-
-  const rem = resolveMemoryRemDreamingConfig({
-    pluginConfig: params.pluginConfig,
-    cfg: params.cfg,
-  });
-  if (rem.enabled && rem.limit > 0) {
-    try {
-      recordNarrativeOutcome(
-        await runRemDreaming({
-          agentId: params.agentId,
-          workspaceDir: params.workspaceDir,
-          cfg: params.cfg,
-          config: rem,
-          logger: params.logger,
-          subagent: params.subagent,
-          nowMs: sweepNowMs,
-          detachNarratives: params.detachNarratives,
-          admissionPolicy,
-        }),
-      );
-    } catch (err) {
-      await appendFailedDreamingEvent({
-        workspaceDir: params.workspaceDir,
-        phase: "rem",
-        error: formatErrorMessage(err),
-        storageMode: rem.storage.mode,
-        nowMs: sweepNowMs,
-        logger: params.logger,
-      });
-      throw err;
-    }
-  }
+  await runPhase("light", resolveMemoryLightDreamingConfig(params), runLightDreaming);
+  await runPhase("rem", resolveMemoryRemDreamingConfig(params), runRemDreaming);
   return { degradedPhases, pendingNarratives };
 }
 

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -927,10 +927,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   }
 
   private async writeChunks(
-    entry: MemoryIndexEntry,
-    source: MemorySource,
+    { entry, source, chunks }: PreparedMemoryIndexEntry,
     generation: MemorySyncProviderGeneration | null,
-    chunks: IndexedMemoryChunk[],
     embeddings: number[][],
     vectorReady: boolean,
   ): Promise<void> {
@@ -945,137 +943,127 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         );
         this.assertMemoryFileSnapshot(entry, current?.hash);
       }
-      this.commitIndexChunks(entry, source, generation, chunks, embeddings, vectorReady);
-    });
-  }
-
-  private commitIndexChunks(
-    entry: MemoryIndexEntry,
-    source: MemorySource,
-    generation: MemorySyncProviderGeneration | null,
-    chunks: IndexedMemoryChunk[],
-    embeddings: number[][],
-    vectorReady: boolean,
-  ): void {
-    const now = Date.now();
-    const model = generation?.provider?.model ?? "fts-only";
-    const needsVectorRebuild = !vectorReady && embeddings.some((embedding) => embedding.length > 0);
-    runSqliteImmediateTransactionSync(this.db, () => {
-      if (source === "sessions") {
-        const sessionId = expectDefined(entry.sessionId, "memory index session identity");
-        // Embedding and vector setup may await while a purge completes. Read the
-        // live owner, never the shadow index, immediately before publishing.
-        if (hasMemorySessionTombstone(generation?.database ?? this.db, this.agentId, sessionId)) {
-          this.markFailedFullReindexRetry({ memory: false, sessions: true });
-          throw new Error(
-            "A session was forgotten while memory indexing was running; retry the memory index.",
-          );
+      const now = Date.now();
+      const model = generation?.provider?.model ?? "fts-only";
+      const needsVectorRebuild =
+        !vectorReady && embeddings.some((embedding) => embedding.length > 0);
+      runSqliteImmediateTransactionSync(this.db, () => {
+        if (source === "sessions") {
+          const sessionId = expectDefined(entry.sessionId, "memory index session identity");
+          // Embedding and vector setup may await while a purge completes. Read the
+          // live owner, never the shadow index, immediately before publishing.
+          if (hasMemorySessionTombstone(generation?.database ?? this.db, this.agentId, sessionId)) {
+            this.markFailedFullReindexRetry({ memory: false, sessions: true });
+            throw new Error(
+              "A session was forgotten while memory indexing was running; retry the memory index.",
+            );
+          }
         }
-      }
-      this.clearIndexedFileData(entry.path, source);
-      for (const [i, chunk] of chunks.entries()) {
-        const embedding = embeddings[i] ?? [];
-        const id = hashText(
-          `${source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${model}`,
-        );
-        this.db
-          .prepare(
-            `INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-             ON CONFLICT(id) DO UPDATE SET
-               hash=excluded.hash,
-               model=excluded.model,
-               text=excluded.text,
-               embedding=excluded.embedding,
-               updated_at=excluded.updated_at`,
-          )
-          .run(
-            id,
-            entry.path,
-            source,
-            chunk.startLine,
-            chunk.endLine,
-            chunk.hash,
-            model,
-            chunk.text,
-            JSON.stringify(embedding),
-            now,
+        this.clearIndexedFileData(entry.path, source);
+        for (const [i, chunk] of chunks.entries()) {
+          const embedding = embeddings[i] ?? [];
+          const id = hashText(
+            `${source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${model}`,
           );
-        this.db
-          .prepare(
-            `INSERT INTO ${MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE} (
-               chunk_id, importance, triggers, project_key
-             ) VALUES (?, ?, ?, ?)
-             ON CONFLICT(chunk_id) DO UPDATE SET
-               importance=excluded.importance,
-               triggers=excluded.triggers,
-               project_key=excluded.project_key`,
-          )
-          .run(id, chunk.importance, chunk.triggers, chunk.projectKey);
-        const provenance = chunk.provenance ?? {
-          originClass: "untrusted" as const,
-          sessionKind: "unknown" as const,
-          observedAt: now,
-        };
-        this.db
-          .prepare(
-            `INSERT INTO ${MEMORY_INDEX_CHUNK_PROVENANCE_TABLE} (
-               chunk_id, origin_class, session_kind, observed_at, supersedes_key
-             ) VALUES (?, ?, ?, ?, ?)
-             ON CONFLICT(chunk_id) DO UPDATE SET
-               origin_class=excluded.origin_class,
-               session_kind=excluded.session_kind,
-               observed_at=excluded.observed_at,
-               supersedes_key=excluded.supersedes_key`,
-          )
-          .run(
-            id,
-            provenance.originClass,
-            provenance.sessionKind,
-            provenance.observedAt,
-            provenance.supersedesKey ?? null,
-          );
-        if (vectorReady && embedding.length > 0) {
-          replaceMemoryVectorRow({
-            db: this.db,
-            tableName: VECTOR_TABLE,
-            id,
-            embedding,
-          });
-        }
-        if (this.fts.enabled && this.fts.available) {
           this.db
             .prepare(
-              `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)\n` +
-                ` VALUES (?, ?, ?, ?, ?, ?, ?)`,
+              `INSERT INTO memory_index_chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+               ON CONFLICT(id) DO UPDATE SET
+                 hash=excluded.hash,
+                 model=excluded.model,
+                 text=excluded.text,
+                 embedding=excluded.embedding,
+                 updated_at=excluded.updated_at`,
             )
-            .run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
+            .run(
+              id,
+              entry.path,
+              source,
+              chunk.startLine,
+              chunk.endLine,
+              chunk.hash,
+              model,
+              chunk.text,
+              JSON.stringify(embedding),
+              now,
+            );
+          this.db
+            .prepare(
+              `INSERT INTO ${MEMORY_INDEX_CHUNK_RECALL_METADATA_TABLE} (
+                 chunk_id, importance, triggers, project_key
+               ) VALUES (?, ?, ?, ?)
+               ON CONFLICT(chunk_id) DO UPDATE SET
+                 importance=excluded.importance,
+                 triggers=excluded.triggers,
+                 project_key=excluded.project_key`,
+            )
+            .run(id, chunk.importance, chunk.triggers, chunk.projectKey);
+          const provenance = chunk.provenance ?? {
+            originClass: "untrusted" as const,
+            sessionKind: "unknown" as const,
+            observedAt: now,
+          };
+          this.db
+            .prepare(
+              `INSERT INTO ${MEMORY_INDEX_CHUNK_PROVENANCE_TABLE} (
+                 chunk_id, origin_class, session_kind, observed_at, supersedes_key
+               ) VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(chunk_id) DO UPDATE SET
+                 origin_class=excluded.origin_class,
+                 session_kind=excluded.session_kind,
+                 observed_at=excluded.observed_at,
+                 supersedes_key=excluded.supersedes_key`,
+            )
+            .run(
+              id,
+              provenance.originClass,
+              provenance.sessionKind,
+              provenance.observedAt,
+              provenance.supersedesKey ?? null,
+            );
+          if (vectorReady && embedding.length > 0) {
+            replaceMemoryVectorRow({
+              db: this.db,
+              tableName: VECTOR_TABLE,
+              id,
+              embedding,
+            });
+          }
+          if (this.fts.enabled && this.fts.available) {
+            this.db
+              .prepare(
+                `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)\n` +
+                  ` VALUES (?, ?, ?, ?, ?, ?, ?)`,
+              )
+              .run(chunk.text, id, entry.path, source, model, chunk.startLine, chunk.endLine);
+          }
         }
-      }
-      upsertMemoryEmbeddingCache({
-        db: this.db,
-        enabled: this.cache.enabled,
-        provider: generation?.provider ?? null,
-        providerKey: generation?.providerKey ?? null,
-        entries: chunks.map((chunk, index) => ({
-          hash: chunk.hash,
-          embedding: embeddings[index] ?? [],
-        })),
-        now,
-        tableName: EMBEDDING_CACHE_TABLE,
+        upsertMemoryEmbeddingCache({
+          db: this.db,
+          enabled: this.cache.enabled,
+          provider: generation?.provider ?? null,
+          providerKey: generation?.providerKey ?? null,
+          entries: chunks.map((chunk, index) => ({
+            hash: chunk.hash,
+            embedding: embeddings[index] ?? [],
+          })),
+          now,
+          tableName: EMBEDDING_CACHE_TABLE,
+        });
+        this.upsertFileRecord(entry, source);
+        if (needsVectorRebuild) {
+          this.markVectorRebuildRequired();
+        }
       });
-      this.upsertFileRecord(entry, source);
-      if (needsVectorRebuild) {
-        this.markVectorRebuildRequired();
-      }
-    });
-    this.database.vectorDegradedWriteWarningShown = logMemoryVectorDegradedWrite({
-      vectorEnabled: this.vector.enabled,
-      vectorReady,
-      chunkCount: chunks.length,
-      warningShown: this.database.vectorDegradedWriteWarningShown,
-      loadError: this.vector.loadError,
-      warn: (message) => log.warn(message),
+      this.database.vectorDegradedWriteWarningShown = logMemoryVectorDegradedWrite({
+        vectorEnabled: this.vector.enabled,
+        vectorReady,
+        chunkCount: chunks.length,
+        warningShown: this.database.vectorDegradedWriteWarningShown,
+        loadError: this.vector.loadError,
+        warn: (message) => log.warn(message),
+      });
     });
   }
 
@@ -1084,111 +1072,103 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     options: { source: MemorySource; content?: string },
     generation: MemorySyncProviderGeneration | null,
   ): Promise<PreparedMemoryIndexEntry | null> {
-    return await withMemoryWorkspaceLock(this.workspaceDir, () =>
-      this.prepareLockedIndexEntry(entry, options, generation),
-    );
-  }
-
-  private async prepareLockedIndexEntry(
-    entry: MemoryIndexEntry,
-    options: { source: MemorySource; content?: string },
-    generation: MemorySyncProviderGeneration | null,
-  ): Promise<PreparedMemoryIndexEntry | null> {
-    const pathClassification = await resolveMemoryPathClassification({
-      absolutePath: entry.absPath,
-      source: options.source,
-      workspaceDir: this.workspaceDir,
-    });
-    if ("kind" in entry && entry.kind === "multimodal") {
-      const multimodalChunk = await buildMultimodalChunkForIndexing(entry);
-      if (!multimodalChunk) {
-        this.clearIndexedFileData(entry.path, options.source);
-        this.deleteFileRecord(entry.path, options.source);
-        return null;
-      }
-      const chunk: IndexedMemoryChunk = {
-        ...multimodalChunk.chunk,
-        importance: null,
-        triggers: null,
-        projectKey: null,
-      };
-      chunk.provenance = this.resolveChunkProvenance(
-        entry,
-        options.source,
-        chunk,
-        pathClassification.originClass,
-      );
-      return {
-        entry,
+    return await withMemoryWorkspaceLock(this.workspaceDir, async () => {
+      const pathClassification = await resolveMemoryPathClassification({
+        absolutePath: entry.absPath,
         source: options.source,
-        chunks: [chunk],
-        structuredInputBytes: multimodalChunk.structuredInputBytes,
-      };
-    }
-
-    const content =
-      options.content ??
-      entry.content ??
-      (await retryTransientMemoryRead(
-        () => fs.readFile(entry.absPath, "utf-8"),
-        `read memory markdown for indexing ${entry.absPath}`,
-      ));
-    if (options.source === "memory") {
-      this.assertMemoryFileSnapshot(entry, hashText(content));
-    }
-    const normalizedEntryPath = entry.path.replaceAll("\\", "/");
-    const perEntry =
-      options.source === "memory" &&
-      (normalizedEntryPath === "MEMORY.md" || normalizedEntryPath === "USER.md");
-    const indexingContent =
-      options.source === "memory" ? stripMemoryAnnotationCarriers(content) : content;
-    const chunkOptions = { ...this.settings.chunking, perEntry };
-    const baseChunks = filterNonEmptyMemoryChunks(
-      options.source === "sessions"
-        ? chunkSessionContentAtResetBoundary({
-            content: indexingContent,
-            cutoffLine: (() => {
-              const cutoff = readSessionResetRecallCutoffMetadata(entry);
-              return cutoff.state === "valid" ? cutoff.cutoffLine : undefined;
-            })(),
-            lineMap: entry.lineMap,
-            chunking: chunkOptions,
-          })
-        : chunkMarkdown(indexingContent, chunkOptions),
-    );
-    for (const chunk of baseChunks) {
-      chunk.provenance = this.resolveChunkProvenance(
-        entry,
-        options.source,
-        chunk,
-        pathClassification.originClass,
-      );
-    }
-    const chunks = (
-      generation?.kind === "semantic"
-        ? enforceEmbeddingMaxInputTokens(
-            generation.provider,
-            baseChunks,
-            EMBEDDING_BATCH_MAX_TOKENS,
-          )
-        : baseChunks
-    ).map(
-      (chunk): IndexedMemoryChunk =>
-        Object.assign(
+        workspaceDir: this.workspaceDir,
+      });
+      if ("kind" in entry && entry.kind === "multimodal") {
+        const multimodalChunk = await buildMultimodalChunkForIndexing(entry);
+        if (!multimodalChunk) {
+          this.clearIndexedFileData(entry.path, options.source);
+          this.deleteFileRecord(entry.path, options.source);
+          return null;
+        }
+        const chunk: IndexedMemoryChunk = {
+          ...multimodalChunk.chunk,
+          importance: null,
+          triggers: null,
+          projectKey: null,
+        };
+        chunk.provenance = this.resolveChunkProvenance(
+          entry,
+          options.source,
           chunk,
-          resolveChunkRecallMetadata({
-            curatedRoot: pathClassification.curatedRoot,
-            projectScopeEligible:
-              options.source === "memory" && normalizedEntryPath.toUpperCase() !== "USER.MD",
-            content,
+          pathClassification.originClass,
+        );
+        return {
+          entry,
+          source: options.source,
+          chunks: [chunk],
+          structuredInputBytes: multimodalChunk.structuredInputBytes,
+        };
+      }
+
+      const content =
+        options.content ??
+        entry.content ??
+        (await retryTransientMemoryRead(
+          () => fs.readFile(entry.absPath, "utf-8"),
+          `read memory markdown for indexing ${entry.absPath}`,
+        ));
+      if (options.source === "memory") {
+        this.assertMemoryFileSnapshot(entry, hashText(content));
+      }
+      const normalizedEntryPath = entry.path.replaceAll("\\", "/");
+      const perEntry =
+        options.source === "memory" &&
+        (normalizedEntryPath === "MEMORY.md" || normalizedEntryPath === "USER.md");
+      const indexingContent =
+        options.source === "memory" ? stripMemoryAnnotationCarriers(content) : content;
+      const chunkOptions = { ...this.settings.chunking, perEntry };
+      const baseChunks = filterNonEmptyMemoryChunks(
+        options.source === "sessions"
+          ? chunkSessionContentAtResetBoundary({
+              content: indexingContent,
+              cutoffLine: (() => {
+                const cutoff = readSessionResetRecallCutoffMetadata(entry);
+                return cutoff.state === "valid" ? cutoff.cutoffLine : undefined;
+              })(),
+              lineMap: entry.lineMap,
+              chunking: chunkOptions,
+            })
+          : chunkMarkdown(indexingContent, chunkOptions),
+      );
+      for (const chunk of baseChunks) {
+        chunk.provenance = this.resolveChunkProvenance(
+          entry,
+          options.source,
+          chunk,
+          pathClassification.originClass,
+        );
+      }
+      const chunks = (
+        generation?.kind === "semantic"
+          ? enforceEmbeddingMaxInputTokens(
+              generation.provider,
+              baseChunks,
+              EMBEDDING_BATCH_MAX_TOKENS,
+            )
+          : baseChunks
+      ).map(
+        (chunk): IndexedMemoryChunk =>
+          Object.assign(
             chunk,
-          }),
-        ),
-    );
-    if (options.source === "sessions" && "lineMap" in entry) {
-      remapChunkLines(chunks, entry.lineMap);
-    }
-    return { entry, source: options.source, chunks };
+            resolveChunkRecallMetadata({
+              curatedRoot: pathClassification.curatedRoot,
+              projectScopeEligible:
+                options.source === "memory" && normalizedEntryPath.toUpperCase() !== "USER.MD",
+              content,
+              chunk,
+            }),
+          ),
+      );
+      if (options.source === "sessions" && "lineMap" in entry) {
+        remapChunkLines(chunks, entry.lineMap);
+      }
+      return { entry, source: options.source, chunks };
+    });
   }
 
   private resolveChunkProvenance(
@@ -1320,14 +1300,7 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       for (const item of current) {
         const fileEmbeddings = embeddings.slice(offset, offset + item.chunks.length);
         offset += item.chunks.length;
-        await this.writeChunks(
-          item.entry,
-          item.source,
-          generation,
-          item.chunks,
-          fileEmbeddings,
-          vectorReady,
-        );
+        await this.writeChunks(item, generation, fileEmbeddings, vectorReady);
       }
       prepared = [];
       preparedRequestCount = 0;
@@ -1383,19 +1356,16 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     options: { source: MemorySource; content?: string },
     generation: MemorySyncProviderGeneration | null,
   ): Promise<void> {
-    // FTS-only mode: no embedding provider, but we can still build a FTS index
-    if (generation?.kind !== "semantic") {
-      // Multimodal files require an embedding provider; skip in FTS-only mode.
-      if ("kind" in entry && entry.kind === "multimodal") {
-        return;
-      }
-      const prepared = await this.prepareIndexEntry(entry, options, null);
-      await this.writeChunks(entry, options.source, generation, prepared?.chunks ?? [], [], false);
+    // Multimodal files require an embedding provider; skip in FTS-only mode.
+    if (generation?.kind !== "semantic" && "kind" in entry && entry.kind === "multimodal") {
       return;
     }
-
     const prepared = await this.prepareIndexEntry(entry, options, generation);
     if (!prepared) {
+      return;
+    }
+    if (generation?.kind !== "semantic") {
+      await this.writeChunks(prepared, generation, [], false);
       return;
     }
 
@@ -1420,21 +1390,14 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           model: generation.provider.model,
           error: message,
         });
-        await this.writeChunks(entry, options.source, generation, [], [], false);
+        await this.writeChunks({ ...prepared, chunks: [] }, generation, [], false);
         return;
       }
       throw err;
     }
     const sample = embeddings.find((embedding) => embedding.length > 0);
     const vectorReady = sample ? await this.ensureVectorReady(sample.length) : false;
-    await this.writeChunks(
-      entry,
-      options.source,
-      generation,
-      prepared.chunks,
-      embeddings,
-      vectorReady,
-    );
+    await this.writeChunks(prepared, generation, embeddings, vectorReady);
   }
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/memory-core/src/short-term-promotion-artifacts.ts
+++ b/extensions/memory-core/src/short-term-promotion-artifacts.ts
@@ -36,7 +36,6 @@ import type {
   ShortTermRecallStore,
 } from "./short-term-promotion-types.js";
 import {
-  MAX_QUERY_HASHES,
   MAX_RECALL_DAYS,
   SHORT_TERM_RECALL_MAX_ENTRIES,
   enforceShortTermRecallStoreRetention,
@@ -219,15 +218,6 @@ export async function repairShortTermPromotionArtifacts(params: {
             key,
             {
               ...entry,
-              dailyCount: Math.max(
-                0,
-                Math.floor((entry as { dailyCount?: number }).dailyCount ?? 0),
-              ),
-              groundedCount: Math.max(
-                0,
-                Math.floor((entry as { groundedCount?: number }).groundedCount ?? 0),
-              ),
-              queryHashes: (entry.queryHashes ?? []).slice(-MAX_QUERY_HASHES),
               recallDays: mergeRecentDistinct(entry.recallDays ?? [], fallbackDay, MAX_RECALL_DAYS),
               conceptTags: conceptTags.length > 0 ? conceptTags : (entry.conceptTags ?? []),
             } satisfies ShortTermRecallEntry,

--- a/extensions/memory-core/src/short-term-promotion-record.ts
+++ b/extensions/memory-core/src/short-term-promotion-record.ts
@@ -26,9 +26,9 @@ import {
   isContaminatedDreamingSnippet,
   isShortTermMemoryPath,
   isShortTermSessionCorpusPath,
+  MAX_QUERY_HASHES,
   MAX_RECALL_DAYS,
   mergeProjectKeyLists,
-  mergeQueryHashes,
   mergeRecentDistinct,
   normalizeIsoDay,
   normalizeMemoryPath,
@@ -289,7 +289,7 @@ export async function recordShortTermRecalls(params: {
       );
       const totalScore = Math.max(0, (existing?.totalScore ?? 0) + score * addedSignals);
       const maxScore = Math.max(existing?.maxScore ?? 0, dedupeSignal ? 0 : score);
-      const queryHashes = mergeQueryHashes(existing?.queryHashes ?? [], queryHash);
+      const queryHashes = mergeRecentDistinct(queryHashesBase, queryHash, MAX_QUERY_HASHES);
       const recallDays = mergeRecentDistinct(recallDaysBase, dayBucket, MAX_RECALL_DAYS);
       const conceptTags = deriveConceptTags({ path: normalizedPath, snippet });
       // Workspace-file hits without explicit provenance retain the index's

--- a/extensions/memory-core/src/short-term-promotion-store.ts
+++ b/extensions/memory-core/src/short-term-promotion-store.ts
@@ -11,7 +11,6 @@ import {
 import type {
   ShortTermPhaseSignalEntry,
   ShortTermPhaseSignalStore,
-  ShortTermRecallEntry,
   ShortTermRecallStore,
   ShortTermStoreMeta,
 } from "./short-term-promotion-types.js";
@@ -21,6 +20,53 @@ import {
   normalizeShortTermRecallStore,
   toFiniteNonNegativeInt,
 } from "./short-term-promotion-utils.js";
+
+const SHORT_TERM_STORE_NAMESPACES = {
+  recall: SHORT_TERM_RECALL_NAMESPACE,
+  phase: SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
+};
+
+async function readShortTermStore(
+  workspaceDir: string,
+  kind: keyof typeof SHORT_TERM_STORE_NAMESPACES,
+  nowIso: string,
+) {
+  const [entryRows, metaRows] = await Promise.all([
+    readMemoryCoreWorkspaceEntries<unknown>({
+      namespace: SHORT_TERM_STORE_NAMESPACES[kind],
+      workspaceDir,
+    }),
+    readMemoryCoreWorkspaceEntries<ShortTermStoreMeta>({
+      namespace: SHORT_TERM_META_NAMESPACE,
+      workspaceDir,
+    }),
+  ]);
+  return {
+    version: 1,
+    updatedAt: metaRows.find((entry) => entry.key === kind)?.value?.updatedAt ?? nowIso,
+    entries: Object.fromEntries(entryRows.map((entry) => [entry.key, entry.value])),
+  };
+}
+
+async function writeShortTermStore(
+  workspaceDir: string,
+  kind: keyof typeof SHORT_TERM_STORE_NAMESPACES,
+  store: ShortTermRecallStore | ShortTermPhaseSignalStore,
+): Promise<void> {
+  await Promise.all([
+    writeMemoryCoreWorkspaceEntries({
+      namespace: SHORT_TERM_STORE_NAMESPACES[kind],
+      workspaceDir,
+      entries: Object.entries(store.entries).map(([key, value]) => ({ key, value })),
+    }),
+    writeMemoryCoreWorkspaceEntry({
+      namespace: SHORT_TERM_META_NAMESPACE,
+      workspaceDir,
+      key: kind,
+      value: { updatedAt: store.updatedAt },
+    }),
+  ]);
+}
 
 export function resolveStorePath(workspaceDir: string): string {
   return memoryCoreStateReference(SHORT_TERM_RECALL_NAMESPACE, workspaceDir);
@@ -34,23 +80,8 @@ export async function readStore(
   workspaceDir: string,
   nowIso: string,
 ): Promise<ShortTermRecallStore> {
-  const [entryRows, metaRows] = await Promise.all([
-    readMemoryCoreWorkspaceEntries<ShortTermRecallEntry>({
-      namespace: SHORT_TERM_RECALL_NAMESPACE,
-      workspaceDir,
-    }),
-    readMemoryCoreWorkspaceEntries<ShortTermStoreMeta>({
-      namespace: SHORT_TERM_META_NAMESPACE,
-      workspaceDir,
-    }),
-  ]);
-  const meta = metaRows.find((entry) => entry.key === "recall")?.value;
   const store = normalizeShortTermRecallStore(
-    {
-      version: 1,
-      updatedAt: meta?.updatedAt ?? nowIso,
-      entries: Object.fromEntries(entryRows.map((entry) => [entry.key, entry.value])),
-    },
+    await readShortTermStore(workspaceDir, "recall", nowIso),
     nowIso,
   );
   enforceShortTermRecallStoreRetention(store);
@@ -124,23 +155,8 @@ export async function readPhaseSignalStore(
   workspaceDir: string,
   nowIso: string,
 ): Promise<ShortTermPhaseSignalStore> {
-  const [entryRows, metaRows] = await Promise.all([
-    readMemoryCoreWorkspaceEntries<ShortTermPhaseSignalEntry>({
-      namespace: SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
-      workspaceDir,
-    }),
-    readMemoryCoreWorkspaceEntries<ShortTermStoreMeta>({
-      namespace: SHORT_TERM_META_NAMESPACE,
-      workspaceDir,
-    }),
-  ]);
-  const meta = metaRows.find((entry) => entry.key === "phase")?.value;
   return normalizeShortTermPhaseSignalStore(
-    {
-      version: 1,
-      updatedAt: meta?.updatedAt ?? nowIso,
-      entries: Object.fromEntries(entryRows.map((entry) => [entry.key, entry.value])),
-    },
+    await readShortTermStore(workspaceDir, "phase", nowIso),
     nowIso,
   );
 }
@@ -149,35 +165,11 @@ export async function writePhaseSignalStore(
   workspaceDir: string,
   store: ShortTermPhaseSignalStore,
 ): Promise<void> {
-  await Promise.all([
-    writeMemoryCoreWorkspaceEntries({
-      namespace: SHORT_TERM_PHASE_SIGNAL_NAMESPACE,
-      workspaceDir,
-      entries: Object.entries(store.entries).map(([key, value]) => ({ key, value })),
-    }),
-    writeMemoryCoreWorkspaceEntry({
-      namespace: SHORT_TERM_META_NAMESPACE,
-      workspaceDir,
-      key: "phase",
-      value: { updatedAt: store.updatedAt },
-    }),
-  ]);
+  await writeShortTermStore(workspaceDir, "phase", store);
 }
 
 export async function writeStore(workspaceDir: string, store: ShortTermRecallStore): Promise<void> {
   enforceShortTermRecallSnippetCap(store);
   enforceShortTermRecallStoreRetention(store);
-  await Promise.all([
-    writeMemoryCoreWorkspaceEntries({
-      namespace: SHORT_TERM_RECALL_NAMESPACE,
-      workspaceDir,
-      entries: Object.entries(store.entries).map(([key, value]) => ({ key, value })),
-    }),
-    writeMemoryCoreWorkspaceEntry({
-      namespace: SHORT_TERM_META_NAMESPACE,
-      workspaceDir,
-      key: "recall",
-      value: { updatedAt: store.updatedAt },
-    }),
-  ]);
+  await writeShortTermStore(workspaceDir, "recall", store);
 }

--- a/extensions/memory-core/src/short-term-promotion-utils.ts
+++ b/extensions/memory-core/src/short-term-promotion-utils.ts
@@ -216,27 +216,6 @@ export function hashQuery(query: string): string {
     .slice(0, 12);
 }
 
-export function mergeQueryHashes(existing: string[], queryHash: string): string[] {
-  if (!queryHash) {
-    return existing;
-  }
-  const seen = new Set<string>();
-  const next = existing.filter((value) => {
-    if (!value || seen.has(value)) {
-      return false;
-    }
-    seen.add(value);
-    return true;
-  });
-  if (!seen.has(queryHash)) {
-    next.push(queryHash);
-  }
-  if (next.length <= MAX_QUERY_HASHES) {
-    return next;
-  }
-  return next.slice(next.length - MAX_QUERY_HASHES);
-}
-
 export function mergeRecentDistinct(
   existing: string[],
   nextValue: string,


### PR DESCRIPTION
Related: #130451, #131179, #131248.

## What Problem This Solves

Maintainer-requested cleanup of the recent memory provenance work. The deletion safeguards are necessary, but repeated store plumbing, parameter forwarding, and phase orchestration made the surrounding code larger and harder to follow.

## Why This Change Was Made

Reuse the existing bounded distinct-value merger, share recall/phase store I/O, remove normalization already performed by the store reader, and centralize light/REM outcome and error handling. Pass each prepared index entry directly into its locked commit and remove the forwarding-only index methods.

The workspace locks, synchronous index transaction, tombstone checks, file-snapshot validation, and shadow-publication revision checks retain their existing scope and order. Retry evidence and consolidation-history cleanup from the newer repairs are untouched.

Production: **+291 / −426 (net −135 lines)** across seven files. Tests: **unchanged**. Documentation: two corrected references to SQLite-backed dreaming state.

## User Impact

No intended runtime behavior, public API, configuration, schema, retention, or migration change. Dreaming documentation now describes where machine state actually lives.

## Evidence

- Before cleanup: 266 tests passed in seven focused memory files.
- After cleanup: 386 tests passed in 13 files, including pending-embedding deletion races, stale file/shadow publication, partial-purge retry, consolidation history, short-term repair/retention, backfill, narrative cleanup, source-wide batching, multimodal indexing, and FTS-only indexing.
- Fresh Codex autoreview: no actionable findings at the default P0 threshold.
- Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/33130145189) on `3838707ee977d7a3eb4465ef12465d24f40eb1a2`.
- All 12 real built-CLI commands and behavior assertions passed with fresh isolated state: index/search, replace/reindex, absence of stale content, backfill/staging, repeat staging without duplicate candidates, and rollback preserving curated memory.
- CLI proof used the CI build at `c5f642a0126de8bb9d4df755e4a3d5943c86e5d3`, whose parent is the exact PR head and whose touched sources and dependency manifests match. Provider `none` exercises real local FTS and SQLite behavior; this is not live-model proof. No mocks or operator Gateway changes.
- The supplementary local `node scripts/check-changed.mjs` run also passed (completed after merge): production/test extension typechecks, extension/script lint, formatting, boundary/dependency guards, assertion baseline, three unused-export scans, five doctor-contract tests, storage/media/runtime-loader guards, and zero runtime import cycles.

The initial broad check caught the obsolete assertion-baseline entry after two casts were removed; the entry is now pruned. The first CLI fixture used an unsupported `memory.search.sync` field and correctly failed config validation; the fixture was corrected before the complete 12-command run. Neither correction changed runtime behavior.
