### PR TITLE
fix(cron): avoid cold script timeouts during plugin preparation

### DIFF
--- a/src/agents/openclaw-plugin-tools.ts
+++ b/src/agents/openclaw-plugin-tools.ts
@@ -287,8 +287,15 @@ export function resolveOpenClawPluginToolsForOptions(params: {
     : undefined;
   const existingToolNames = new Set(params.existingToolNames ?? []);
   const preparedModelRuntime = params.options?.preparedModelRuntime;
-  const runtimeRegistry =
-    getPluginRuntimeGatewayRequestScope()?.pluginRegistry ?? getActivePluginRegistry() ?? undefined;
+  const requestRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+  const runtimeRegistry = requestRegistry ?? getActivePluginRegistry() ?? undefined;
+  // A scoped registry can own prepared plugin facts without a model runtime (headless cron).
+  // Never borrow process-global load facts for an unrelated direct caller.
+  const preparedRegistry = preparedModelRuntime
+    ? preparedModelRuntime.pluginRegistry
+    : requestRegistry;
+  const loadContext = getPluginRuntimeLoadContext(preparedRegistry);
+  const metadataSnapshot = preparedModelRuntime?.metadataSnapshot ?? loadContext?.metadataSnapshot;
   const pluginTools = resolvePluginTools({
     ...pluginToolInputs,
     context: {
@@ -304,12 +311,12 @@ export function resolveOpenClawPluginToolsForOptions(params: {
     allowGatewaySubagentBinding: params.options?.allowGatewaySubagentBinding,
     ...(hasAuthForProvider ? { hasAuthForProvider } : {}),
     ...(runtimeRegistry ? { runtimeRegistry } : {}),
-    ...(preparedModelRuntime
+    ...(metadataSnapshot
       ? {
           preparedRuntime: {
-            loadContext: getPluginRuntimeLoadContext(preparedModelRuntime.pluginRegistry),
-            metadataSnapshot: preparedModelRuntime.metadataSnapshot,
-            registry: preparedModelRuntime.pluginRegistry,
+            loadContext,
+            metadataSnapshot,
+            registry: preparedRegistry,
           },
         }
       : {}),

--- a/src/agents/openclaw-tools.browser-plugin.integration.test.ts
+++ b/src/agents/openclaw-tools.browser-plugin.integration.test.ts
@@ -483,7 +483,7 @@ describe("createOpenClawTools browser plugin integration", () => {
     });
     expect(
       prepareOwnedPluginLoadContext(
-        { agentDir: "/tmp/agent", config, workspaceDir: "/tmp" },
+        { config, workspaceDir: "/tmp" },
         process.env,
         pluginRegistry,
         metadataSnapshot,

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -11,15 +11,21 @@ import {
   getActivePluginRegistryWorkspaceDir,
   getActivePluginRuntimeSubagentMode,
 } from "../plugins/runtime.js";
+import { prepareOwnedPluginLoadContext } from "./prepared-model-runtime.plugin-context.js";
 import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
 import { loadAgentRuntimePluginRegistryHandle } from "./runtime-plugins.js";
 
+type PreparedInboundRegistryInput = Pick<
+  PreparedModelRuntimeInput,
+  "config" | "env" | "workspaceDir" | "allowGatewaySubagentBinding"
+>;
+
 export type PreparedInboundRegistryLoader = (
-  input: PreparedModelRuntimeInput,
+  input: PreparedInboundRegistryInput,
   metadataSnapshot: PluginMetadataSnapshot,
 ) => PluginRegistry;
 
-function inboundRegistryIdentity(input: PreparedModelRuntimeInput): string {
+function inboundRegistryIdentity(input: PreparedInboundRegistryInput): string {
   return JSON.stringify({
     config: hashRuntimeConfigValue(input.config),
     env: hashRuntimeConfigValue(input.env ?? process.env),
@@ -46,47 +52,60 @@ export function preparedModelRuntimeWorkspaceFactsKey(input: PreparedModelRuntim
   });
 }
 
+/** Loads generic plugin facts without acquiring model, catalog, or credential state. */
+export function loadPreparedInboundPluginRegistry(
+  input: PreparedInboundRegistryInput,
+  metadataSnapshot = prepareOwnedPluginLoadContext(input, input.env ?? process.env, undefined),
+): PluginRegistry {
+  const activeRegistry = getActivePluginRegistry();
+  // Identity is the generation authority. Manifest equivalence alone could let a
+  // stale active registry satisfy a newer bundled snapshot.
+  const reusableGatewayRegistry =
+    input.allowGatewaySubagentBinding === true &&
+    input.env === undefined &&
+    getActivePluginRuntimeSubagentMode() === "gateway-bindable" &&
+    activeRegistry &&
+    getActivePluginRegistryWorkspaceDir() === metadataSnapshot.workspaceDir &&
+    getCurrentPluginMetadataSnapshot({
+      config: input.config,
+      workspaceDir: metadataSnapshot.workspaceDir,
+      allowWorkspaceScopedSnapshot: true,
+    }) === metadataSnapshot &&
+    registryMatchesManifestPluginIds(
+      activeRegistry,
+      metadataSnapshot.manifestRegistry.plugins,
+      listRuntimePluginIdsFromRegistry(activeRegistry),
+    )
+      ? activeRegistry
+      : undefined;
+  const registry =
+    reusableGatewayRegistry ??
+    loadAgentRuntimePluginRegistryHandle({
+      config: input.config,
+      env: input.env ?? process.env,
+      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+      ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
+      metadataSnapshot,
+      preferBuiltPluginArtifacts: true,
+    });
+  prepareOwnedPluginLoadContext(input, input.env ?? process.env, registry, metadataSnapshot, true);
+  return registry;
+}
+
 /** Creates one lifecycle-batch loader that shares exact generic registry identities. */
 export function createPreparedInboundRegistryLoader(): PreparedInboundRegistryLoader {
-  const registries = new Map<string, PluginRegistry>();
+  const registries = new Map<
+    string,
+    { metadataSnapshot: PluginMetadataSnapshot; registry: PluginRegistry }
+  >();
   return (input, metadataSnapshot) => {
     const key = inboundRegistryIdentity(input);
     const existing = registries.get(key);
-    if (existing) {
-      return existing;
+    if (existing?.metadataSnapshot === metadataSnapshot) {
+      return existing.registry;
     }
-    const activeRegistry = getActivePluginRegistry();
-    // Identity is the generation authority. Manifest equivalence alone could let a
-    // stale active registry satisfy a newer bundled snapshot.
-    const reusableGatewayRegistry =
-      input.allowGatewaySubagentBinding === true &&
-      input.env === undefined &&
-      getActivePluginRuntimeSubagentMode() === "gateway-bindable" &&
-      activeRegistry &&
-      getActivePluginRegistryWorkspaceDir() === metadataSnapshot.workspaceDir &&
-      getCurrentPluginMetadataSnapshot({
-        config: input.config,
-        workspaceDir: metadataSnapshot.workspaceDir,
-        allowWorkspaceScopedSnapshot: true,
-      }) === metadataSnapshot &&
-      registryMatchesManifestPluginIds(
-        activeRegistry,
-        metadataSnapshot.manifestRegistry.plugins,
-        listRuntimePluginIdsFromRegistry(activeRegistry),
-      )
-        ? activeRegistry
-        : undefined;
-    const registry =
-      reusableGatewayRegistry ??
-      loadAgentRuntimePluginRegistryHandle({
-        config: input.config,
-        env: input.env ?? process.env,
-        ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-        ...(input.allowGatewaySubagentBinding ? { allowGatewaySubagentBinding: true } : {}),
-        metadataSnapshot,
-        preferBuiltPluginArtifacts: true,
-      });
-    registries.set(key, registry);
+    const registry = loadPreparedInboundPluginRegistry(input, metadataSnapshot);
+    registries.set(key, { metadataSnapshot, registry });
     return registry;
   };
 }

--- a/src/agents/prepared-model-runtime.plugin-context.test.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.test.ts
@@ -76,7 +76,6 @@ describe("prepared model runtime plugin metadata ownership", () => {
       expect(
         prepareOwnedPluginLoadContext(
           {
-            agentDir: "/tmp/direct-agent",
             config,
             workspaceDir,
           },
@@ -114,7 +113,6 @@ describe("prepared model runtime plugin metadata ownership", () => {
     try {
       prepareOwnedPluginLoadContext(
         {
-          agentDir: "/tmp/selected-runtime-agent",
           config,
           loadRuntimePlugins: true,
           runtimePluginSelections: [{ provider: "selected", modelId: "model" }],

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -6,25 +6,51 @@ import type { PluginRegistry } from "../plugins/registry-types.js";
 import {
   resolvePluginRuntimeLoadContext,
   setPluginRuntimeLoadContext,
-  type PluginRuntimeLoadContext,
 } from "../plugins/runtime/load-context.js";
 import { createAgentRuntimeMetadataPluginIdScope } from "./harness/runtime-plugin-load-plan.js";
 import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
 
+type PreparedPluginContextInput = Pick<
+  PreparedModelRuntimeInput,
+  "config" | "workspaceDir" | "loadRuntimePlugins" | "runtimePluginSelections"
+>;
+
 const emptyPluginDiscovery: PluginDiscoveryResult = { candidates: [], diagnostics: [] };
 
-function preparePluginLoadContext(
-  input: PreparedModelRuntimeInput,
+/** Resolves and attaches the plugin facts owned by one prepared workspace generation. */
+export function prepareOwnedPluginLoadContext(
+  input: PreparedPluginContextInput,
   env: NodeJS.ProcessEnv,
   registry: PluginRegistry | undefined,
-  metadataSnapshot: PluginMetadataSnapshot,
-  preferBuiltPluginArtifacts: boolean,
-): PluginRuntimeLoadContext & { metadataSnapshot: PluginMetadataSnapshot } {
+  preparedMetadataSnapshot?: PluginMetadataSnapshot,
+  preferBuiltPluginArtifacts = false,
+): PluginMetadataSnapshot {
+  const metadataSnapshot =
+    preparedMetadataSnapshot ??
+    resolvePluginMetadataSnapshot({
+      config: input.config,
+      env,
+      ...(input.workspaceDir
+        ? { workspaceDir: input.workspaceDir, allowWorkspaceScopedCurrent: true }
+        : {}),
+      ...(input.loadRuntimePlugins && input.runtimePluginSelections && input.workspaceDir
+        ? {
+            pluginIdScope: createAgentRuntimeMetadataPluginIdScope({
+              config: input.config,
+              workspaceDir: input.workspaceDir,
+              selections: input.runtimePluginSelections,
+            }),
+          }
+        : {}),
+    });
+  if (!registry) {
+    return metadataSnapshot;
+  }
   const { config } = input;
   const workspaceDir = metadataSnapshot.workspaceDir ?? input.workspaceDir;
   // The prepared owner already selected the exact metadata generation for this runtime.
   // Missing discovery facts stay empty here instead of reopening cold plugin discovery.
-  const preparedMetadataSnapshot = metadataSnapshot.discovery
+  const discoverySnapshot = metadataSnapshot.discovery
     ? metadataSnapshot
     : { ...metadataSnapshot, discovery: emptyPluginDiscovery };
   const context = {
@@ -32,54 +58,14 @@ function preparePluginLoadContext(
       config,
       env,
       workspaceDir,
-      metadataSnapshot: preparedMetadataSnapshot,
+      metadataSnapshot: discoverySnapshot,
       manifestRegistry: metadataSnapshot.manifestRegistry,
       preferBuiltPluginArtifacts,
     }),
     metadataSnapshot,
     installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index),
   };
-  if (registry) {
-    // The prepared registry is the lifecycle-owned carrier; standalone callers keep the cold path.
-    setPluginRuntimeLoadContext(registry, context);
-  }
-  return context;
-}
-
-/** Resolves and attaches the plugin facts owned by one prepared workspace generation. */
-export function prepareOwnedPluginLoadContext(
-  input: PreparedModelRuntimeInput,
-  env: NodeJS.ProcessEnv,
-  registry: PluginRegistry | undefined,
-  preparedMetadataSnapshot?: PluginMetadataSnapshot,
-  preferBuiltPluginArtifacts = false,
-): PluginMetadataSnapshot {
-  const metadataSnapshot = preparedMetadataSnapshot ?? resolveColdMetadataSnapshot(input, env);
-  preparePluginLoadContext(input, env, registry, metadataSnapshot, preferBuiltPluginArtifacts);
+  // The prepared registry is the lifecycle-owned carrier; standalone callers keep the cold path.
+  setPluginRuntimeLoadContext(registry, context);
   return metadataSnapshot;
-}
-
-function resolveColdMetadataSnapshot(
-  input: PreparedModelRuntimeInput,
-  env: NodeJS.ProcessEnv,
-): PluginMetadataSnapshot {
-  // Slot probing preserves the published Gateway generation identity; cold callers
-  // still fall through to a fresh metadata load.
-  const resolvedMetadataSnapshot = resolvePluginMetadataSnapshot({
-    config: input.config,
-    env,
-    ...(input.workspaceDir
-      ? { workspaceDir: input.workspaceDir, allowWorkspaceScopedCurrent: true }
-      : {}),
-    ...(input.loadRuntimePlugins && input.runtimePluginSelections && input.workspaceDir
-      ? {
-          pluginIdScope: createAgentRuntimeMetadataPluginIdScope({
-            config: input.config,
-            workspaceDir: input.workspaceDir,
-            selections: input.runtimePluginSelections,
-          }),
-        }
-      : {}),
-  });
-  return resolvedMetadataSnapshot;
 }

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -275,7 +275,6 @@ describe("agent runtime plugin registries", () => {
 
     const inbound = createPreparedInboundRegistryLoader()(
       {
-        agentDir: "/tmp/agent",
         allowGatewaySubagentBinding: true,
         config,
         workspaceDir,
@@ -286,6 +285,21 @@ describe("agent runtime plugin registries", () => {
 
     expect(inbound).not.toBe(activeRegistry);
     expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledOnce();
+  });
+
+  it("does not reuse a batch registry across metadata generations with identical config", () => {
+    const input = { config: {}, workspaceDir: "/tmp/workspace" };
+    const firstMetadata = createMetadataSnapshot(input.workspaceDir);
+    const replacementMetadata = createMetadataSnapshot(input.workspaceDir);
+    hoisted.loadPluginRegistryHandle.mockImplementation(() => createEmptyPluginRegistry());
+    const load = createPreparedInboundRegistryLoader();
+
+    const first = load(input, firstMetadata as never);
+    expect(load(input, firstMetadata as never)).toBe(first);
+    const replacement = load(input, replacementMetadata as never);
+    expect(replacement).not.toBe(first);
+    expect(load(input, replacementMetadata as never)).toBe(replacement);
+    expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledTimes(2);
   });
 
   it("keeps direct no-current loads on the requested workspace", () => {

--- a/src/cron/trigger-script.preparation.test.ts
+++ b/src/cron/trigger-script.preparation.test.ts
@@ -1,0 +1,243 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { CodeModeHeadlessResult } from "../agents/code-mode.js";
+import { resolveOpenClawPluginToolsForOptions } from "../agents/openclaw-plugin-tools.js";
+import {
+  createPreparedInboundRegistryLoader,
+  loadPreparedInboundPluginRegistry,
+} from "../agents/prepared-model-runtime.inbound-registry.js";
+import { prepareOwnedPluginLoadContext } from "../agents/prepared-model-runtime.plugin-context.js";
+import { resolveToolSearchConfig, ToolSearchRuntime } from "../agents/tool-search.js";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  clearPluginLoaderCache,
+  writePlugin,
+} from "../plugins/loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { setActivePluginRegistry } from "../plugins/runtime.js";
+import {
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeRegistryScope,
+} from "../plugins/runtime/gateway-request-scope.js";
+import { getPluginRuntimeLoadContext } from "../plugins/runtime/load-context.js";
+import { resetPluginToolDescriptorCacheForTest } from "../plugins/tools.test-fixtures.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createCronScriptRuntime } from "./trigger-script.js";
+
+type HeadlessParams = Parameters<
+  NonNullable<Parameters<typeof createCronScriptRuntime>[0]["runHeadless"]>
+>[0];
+
+let state: Awaited<ReturnType<typeof createOpenClawTestState>>;
+let config: OpenClawConfig;
+let registrations: string;
+
+beforeEach(async () => {
+  state = await createOpenClawTestState({
+    prefix: "openclaw-cron-preparation-",
+    env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+  });
+  registrations = state.path("registrations.jsonl");
+  const dir = state.path("plugin");
+  for (const artifact of ["source", "built"]) {
+    const body = `module.exports = {
+      id: "cold-probe",
+      register(api) {
+        require("node:fs").appendFileSync(${JSON.stringify(registrations)}, JSON.stringify({ artifact: ${JSON.stringify(artifact)}, mode: api.registrationMode }) + "\\n");
+        if (api.registrationMode !== "tool-discovery") return;
+        api.registerTool((ctx) => {
+          let calls = 0;
+          return {
+            name: "cold_probe", label: "Cold probe", description: "Fixture preparation probe",
+            parameters: { type: "object", properties: {} },
+            async execute() {
+              return { content: [], details: { artifact: ${JSON.stringify(artifact)}, calls: ++calls, agentId: ctx.agentId, sessionKey: ctx.sessionKey } };
+            }
+          };
+        }, { names: ["cold_probe"] });
+      }
+    };`;
+    writePlugin({
+      id: "cold-probe",
+      dir: artifact === "source" ? dir : path.join(dir, "dist"),
+      filename: artifact === "source" ? "index.ts" : "index.js",
+      body,
+    });
+  }
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ name: "cold-probe", openclaw: { extensions: ["./index.ts"] } }),
+  );
+  fs.writeFileSync(
+    path.join(dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "cold-probe",
+      configSchema: { type: "object", properties: {} },
+      contracts: { tools: ["cold_probe"] },
+    }),
+  );
+  config = {
+    agents: {
+      defaults: { workspace: state.workspaceDir, skipBootstrap: true },
+      entries: {
+        main: { workspace: state.workspaceDir },
+        other: { workspace: state.path("other-workspace") },
+      },
+    },
+    plugins: {
+      allow: ["cold-probe"],
+      // Explicit source entry keeps artifact selection at the runtime owner boundary.
+      load: { paths: [path.join(dir, "index.ts")] },
+      slots: { memory: "none" },
+      entries: { "cold-probe": { enabled: true } },
+    },
+  };
+});
+
+afterEach(async () => {
+  clearRuntimeConfigSnapshot();
+  clearPluginLoaderCache();
+  resetPluginToolDescriptorCacheForTest();
+  clearPluginMetadataLifecycleCaches();
+  await state?.cleanup();
+});
+
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+function readRegistrations() {
+  return fs
+    .readFileSync(registrations, "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as { artifact: string; mode: string });
+}
+
+async function executeProbe({ ctx }: HeadlessParams): Promise<CodeModeHeadlessResult> {
+  const tool = ctx.catalogRef?.current?.entries.find(
+    (entry) => entry.tool.name === "cold_probe",
+  )?.tool;
+  const runtime = new ToolSearchRuntime(ctx, resolveToolSearchConfig(ctx.runtimeConfig), {
+    prepareInput: true,
+    validateInput: true,
+  });
+  const result = tool ? await runtime.callValue("cold_probe", {}) : null;
+  return {
+    status: "completed",
+    value: { state: result },
+    output: [],
+    toolCallCount: tool ? 1 : 0,
+  };
+}
+
+describe("cron preparation plugin ownership", () => {
+  it.each(["gateway", "standalone"] as const)(
+    "preserves %s artifact selection through both real preparation loads",
+    async (owner) => {
+      const metadataSnapshot = loadPluginMetadataSnapshot({
+        config,
+        workspaceDir: state.workspaceDir,
+      });
+      setCurrentPluginMetadataSnapshot(metadataSnapshot, { config });
+      const contexts: Array<ReturnType<typeof getPluginRuntimeLoadContext>> = [];
+      const deps = {
+        config,
+        ...(owner === "gateway" ? { loadPluginRegistry: loadPreparedInboundPluginRegistry } : {}),
+        runHeadless: async (params: HeadlessParams) => {
+          contexts.push(
+            getPluginRuntimeLoadContext(getPluginRuntimeGatewayRequestScope()?.pluginRegistry),
+          );
+          return executeProbe(params);
+        },
+      };
+      const runtime = createCronScriptRuntime(deps);
+      const artifact = owner === "gateway" ? "built" : "source";
+      const run = (jobId: string, agentId = "main", toolsAllow = ["*"]) =>
+        runtime.executePayload({
+          jobId,
+          agentId,
+          toolsAllow,
+          script: "return {}",
+          state: null,
+          timeoutSeconds: 5,
+        });
+      for (const [jobId, agentId, calls] of [
+        ["first", "main", 1],
+        ["first", "main", 2],
+        ["second", "main", 1],
+        ["first", "other", 1],
+      ] as const) {
+        await expect(run(jobId, agentId)).resolves.toMatchObject({
+          kind: "completed",
+          state: { artifact, calls, agentId, sessionKey: `agent:${agentId}:cron:${jobId}:trigger` },
+        });
+      }
+      expect(readRegistrations()).toEqual(
+        expect.arrayContaining([
+          { artifact, mode: "discovery" },
+          { artifact, mode: "tool-discovery" },
+        ]),
+      );
+      expect(readRegistrations().every((entry) => entry.artifact === artifact)).toBe(true);
+      if (owner === "gateway") {
+        expect(contexts[0]?.metadataSnapshot).toBe(metadataSnapshot);
+        expect(contexts[1]).toBe(contexts[0]);
+      }
+      await expect(run("first", "other", [])).resolves.toMatchObject({
+        kind: "completed",
+        state: null,
+      });
+      await expect(run("first", "other", ["cold_probe"])).resolves.toMatchObject({
+        kind: "completed",
+        state: { calls: 1 },
+      });
+      const nextConfig = structuredClone(config);
+      nextConfig.tools = { deny: ["cold_probe"] };
+      setRuntimeConfigSnapshot(nextConfig, config);
+      await expect(run("first", "other", ["cold_probe"])).resolves.toMatchObject({
+        kind: "completed",
+        state: null,
+      });
+    },
+  );
+
+  it.each(["scoped", "global"] as const)(
+    "uses only %s registry ownership during downstream loading without a model runtime",
+    async (owner) => {
+      const input = { config, workspaceDir: state.workspaceDir, agentDir: state.agentDir() };
+      const metadataSnapshot = loadPluginMetadataSnapshot(input);
+      const registry = createPreparedInboundRegistryLoader()(input, metadataSnapshot);
+      prepareOwnedPluginLoadContext(input, process.env, registry, metadataSnapshot, true);
+      if (owner === "global") {
+        setActivePluginRegistry(registry);
+      }
+      const tools = withPluginRuntimeRegistryScope(owner === "scoped" ? registry : undefined, () =>
+        resolveOpenClawPluginToolsForOptions({
+          options: {
+            config,
+            workspaceDir: state.workspaceDir,
+            agentSessionKey: "agent:main:cron:scoped:trigger",
+            pluginToolAllowlist: ["cold_probe"],
+          },
+          resolvedConfig: config,
+        }),
+      );
+      expect(tools.map((tool) => tool.name)).toEqual(["cold_probe"]);
+      await expect(tools[0]!.execute("scoped-call", {})).resolves.toMatchObject({
+        details: {
+          artifact: owner === "scoped" ? "built" : "source",
+          agentId: "main",
+          sessionKey: "agent:main:cron:scoped:trigger",
+        },
+      });
+      expect(readRegistrations()).toEqual([
+        { artifact: "built", mode: "discovery" },
+        { artifact: owner === "scoped" ? "built" : "source", mode: "tool-discovery" },
+      ]);
+    },
+  );
+});

--- a/src/cron/trigger-script.ts
+++ b/src/cron/trigger-script.ts
@@ -26,6 +26,7 @@ import {
   applyEmbeddedAttemptToolsAllow,
   resolveEmbeddedAttemptToolConstructionPlan,
 } from "../agents/embedded-agent-runner/run/attempt-tool-construction-plan.js";
+import type { loadPreparedInboundPluginRegistry } from "../agents/prepared-model-runtime.inbound-registry.js";
 import { loadAgentRuntimePluginRegistryHandle } from "../agents/runtime-plugins.js";
 import { resolveSandboxContext } from "../agents/sandbox.js";
 import {
@@ -98,6 +99,7 @@ type CronTriggerEvaluatorDeps = {
   config: OpenClawConfig;
   runHeadless?: typeof runCodeModeScriptHeadless;
   prepareRuntime?: PrepareTriggerRuntime;
+  loadPluginRegistry?: typeof loadPreparedInboundPluginRegistry;
 };
 
 type TriggerRuntimeCacheEntry = {
@@ -111,14 +113,10 @@ function resolveTriggerAgentId(config: OpenClawConfig, agentId?: string): string
   return agentId?.trim() ? normalizeAgentId(agentId) : resolveDefaultAgentId(config);
 }
 
-async function prepareTriggerRuntime(params: {
-  runtimeConfig: OpenClawConfig;
-  jobId: string;
-  agentId?: string;
-  toolsAllow?: string[];
-  scheduledToolPolicy?: ScheduledToolPolicyContext;
-  signal?: AbortSignal;
-}): Promise<PreparedTriggerRuntime> {
+async function prepareTriggerRuntime(
+  params: Parameters<PrepareTriggerRuntime>[0],
+  loadPluginRegistry: typeof loadPreparedInboundPluginRegistry = loadAgentRuntimePluginRegistryHandle,
+): Promise<PreparedTriggerRuntime> {
   params.signal?.throwIfAborted();
   const agentId = resolveTriggerAgentId(params.runtimeConfig, params.agentId);
   const selectedAgentConfig = resolveAgentConfig(params.runtimeConfig, agentId);
@@ -136,7 +134,7 @@ async function prepareTriggerRuntime(params: {
   });
   params.signal?.throwIfAborted();
   const workspaceDir = workspace.dir;
-  const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
+  const pluginRegistry = loadPluginRegistry({
     config,
     workspaceDir,
     allowGatewaySubagentBinding: true,
@@ -336,7 +334,8 @@ async function awaitTriggerSignal<T>(promise: Promise<T>, signal: AbortSignal): 
 
 function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
   const runHeadless = deps.runHeadless ?? runCodeModeScriptHeadless;
-  const prepareRuntime = deps.prepareRuntime ?? prepareTriggerRuntime;
+  const prepareRuntime =
+    deps.prepareRuntime ?? ((params) => prepareTriggerRuntime(params, deps.loadPluginRegistry));
   // Config identity is the reload epoch; caching the preparation promise makes
   // concurrent cold evaluations for one job single-flight.
   const runtimeCache = new Map<string, TriggerRuntimeCacheEntry>();

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -8,6 +8,7 @@ import {
   tryResolveAmbientOwnerAgentId,
 } from "../agents/agent-scope.js";
 import { abortAndDrainEmbeddedAgentRun } from "../agents/embedded-agent.js";
+import { loadPreparedInboundPluginRegistry } from "../agents/prepared-model-runtime.inbound-registry.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { resolveControlUiAutomationRunUrl } from "../config/control-ui-link-base.js";
@@ -585,7 +586,10 @@ export function buildGatewayCronService(params: {
   const sessionStorePath = resolveSessionStorePath(defaultAgentId);
   const cronTriggersEnabled = params.cfg.cron?.triggers?.enabled !== false;
   const scriptRuntime = cronTriggersEnabled
-    ? createCronScriptRuntime({ config: params.cfg })
+    ? createCronScriptRuntime({
+        config: params.cfg,
+        loadPluginRegistry: loadPreparedInboundPluginRegistry,
+      })
     : undefined;
 
   const runCronChangedHook = (evt: PluginHookCronChangedEvent) => {


### PR DESCRIPTION
Closes #131271 (cold script automation preparation reloads plugin sources before guest entry).

AI-assisted with Codex; implementation, ownership, regression behavior, and actual Gateway measurements reviewed by the maintainer.

## What Problem This Solves

Fixes an issue where users running a headless script automation on a source-built Gateway could exhaust an explicit short execution budget before their JavaScript started. The first run redundantly loaded plugin TypeScript sources through Jiti/Babel; the identical warmed job then succeeded. Synchronous preparation also delayed unrelated Gateway liveness responses.

This is **not** a default-timeout regression: the reproduced payload explicitly uses five seconds, while the default remains 300 seconds. Timer cancellation is a separate workstream and is untouched.

## Why This Change Was Made

Headless script preparation did not carry the Gateway's applicable plugin metadata and built-artifact selection through both registry preparation and downstream plugin tool construction. Setting the preference at only the first load merely moved the source-loading cost into tool discovery.

This refactor extracts the existing generic inbound registry flow into a narrow, non-caching plugin-only loader. Gateway cron supplies that owner, and tool construction consumes facts carried by the explicitly scoped registry even when no model runtime exists. The existing batch loader uses the same canonical flow and now checks metadata-generation identity before reuse. Duplicate preparation wrappers/input declarations are removed.

No model/auth/catalog runtime is acquired merely to carry plugin facts. There is no global built-loading override, plugin-specific branch, new service-lifetime cache, prewarming workaround, timeout increase, dependency/config/schema change, or cross-owner sharing of concrete tools. Standalone/direct callers retain source-default behavior. Per-job cache invalidation, tool policy, scheduled authority, session identity, cancellation, and whole-run deadlines remain intact.

Production LOC: **+119/-104 (net +15)**. Tests: **+259/-4 (net +255)**. The production growth establishes the missing plugin-only ownership handoff and exact metadata-generation reuse check; it is partially absorbed by deleting duplicate preparation code.

## User Impact

Source-built Gateways can prepare the first script automation without unnecessarily reconstructing the already-built plugin runtime graph. In two fresh-process measurements, the actual patch completed the cold job within its unchanged five-second budget and preserved the guest-visible tool catalog. No operator action or new setting is required.

This removes the measured source-loading detour; it does not guarantee that arbitrary scripts or every host can meet a five-second deadline, nor claim to eliminate all synchronous preparation work.

## Evidence

### Actual Gateway behavior

Node 24.20.0 on macOS 26.6.2 arm64. Each process used a fresh isolated HOME/state/workspace/transform cache, normal plugin/tool defaults, an explicit main agent, unconfigured channels, disabled heartbeat scheduling, and its own loopback port. No provider/model call, real credential, or operator state was used.

The actual flow was `cron.add` -> `cron.run` in force mode -> exact-run `cron.runs` -> `cron.get`. Jobs were disabled and no-delivery. Payload: `await new Promise(resolve => setTimeout(resolve, 20)); return { state: { counter: (trigger.state?.counter ?? 0) + 1 } };`, with `timeoutSeconds: 5` and `toolsAllow: ["*"]`.

The patched measurements use ordinary built runtime code, **without diagnostic loader overrides or CPU instrumentation**. Each process ran job A twice, then a separate job B. A subsequent real guest `catalog.all()` probe checked catalog parity.

| Sample | First job A | Repeated job A | Separate job B | Persisted counters |
| --- | ---: | ---: | ---: | --- |
| Before, unprofiled | 29,438 ms, timeout | 218 ms, succeeded | 334 ms, succeeded | absent, 1, 1 |
| Actual patch, fresh process A | **496 ms, succeeded** | 88 ms, succeeded | 129 ms, succeeded | **1, 2, 1** |
| Actual patch, fresh process B | **2,387 ms, succeeded** | 448 ms, succeeded | 325 ms, succeeded | **1, 2, 1** |

Times are scheduler-recorded durations, not client polling times. The before build was `18ed2dbaff2f43fca6542da1e5cf763caf895dac`; the patch was built on `0fdae639d1fda5583f221bfa93c01f7af29e8ff2`, whose implicated preparation modules were unchanged. Host I/O/GC and other main changes mean these are observations, not controlled performance ratios.

Both actual-patch guest catalogs matched all **50 baseline entries** exactly. Cold-run RSS grew by approximately **33 MiB** and **22 MiB**, versus approximately **352 MiB** in the unprofiled before sample. Cold health probes had **0/6** and **4/25** one-second timeouts, versus **274/288** before. The second sample's residual stalls are disclosed; full event-loop responsiveness is not claimed.

Earlier phase/CPU profiles isolated 24.6 seconds of registry preparation, primarily Teams/Zoom source entry loading through shared SDK dependencies; tool construction took 1.85 seconds and catalog registration about 3 ms. The failed cold run never entered the headless executor. Those plugin names are measured examples only; production selection remains generic.

### Regression and sibling proof

The final regression fixture uses actual cron preparation, real source/built plugin loading, downstream tool discovery, and the canonical catalog dispatcher. It forces both loading stages rather than replacing `prepareRuntime` with a mock. With only the production patch reversed, **2 tests fail with `artifact: "source"` instead of `"built"`**, while standalone/global-owner cases pass. The production patch was then restored byte-for-byte; **41 cron tests pass**.

Coverage includes same-job reuse, distinct job/agent mutable tool state and session identity, empty/narrowed tool policies, config-epoch invalidation, exact metadata identity, unrelated global-owner rejection, standalone source defaults, existing scheduled-authority/abort/deadline cases, browser-plugin integration, model-preparation/context-engine siblings, and Gateway cron composition/drain/lazy lifecycle.

Commands run:

```bash
node scripts/run-vitest.mjs src/cron/trigger-script.preparation.test.ts src/cron/trigger-script.test.ts src/agents/runtime-plugins.test.ts src/agents/prepared-model-runtime.plugin-context.test.ts src/agents/openclaw-tools.browser-plugin.integration.test.ts src/agents/prepared-model-runtime.inbound-registry.test.ts src/plugins/tools.optional.test.ts
```

174 tests passed across seven files.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cron/trigger-script.preparation.test.ts src/agents/runtime-plugins.test.ts src/agents/prepared-model-runtime.test.ts src/agents/prepared-model-runtime.owner-selection.test.ts src/agents/runtime-plugins.context-engine.integration.test.ts
```

87 owner/sibling test executions passed; this includes repeats, not 87 additional unique tests.

```bash
node scripts/run-vitest.mjs src/gateway/server-cron.test.ts src/gateway/server-cron.drain.test.ts src/gateway/server-cron-lazy.test.ts
```

145 Gateway caller/lifecycle tests passed.

```bash
node scripts/run-vitest.mjs src/cron/trigger-script.preparation.test.ts src/cron/trigger-script.test.ts
```

Final 41 cron tests passed after routing the fixture through the canonical dispatcher. The first full type gate caught its direct union-executor call signature; that test-only defect was fixed without casts or a production workaround.

```bash
node scripts/check-changed.mjs -- src/cron/trigger-script.ts src/cron/trigger-script.preparation.test.ts src/gateway/server-cron.ts src/agents/openclaw-plugin-tools.ts src/agents/prepared-model-runtime.inbound-registry.ts src/agents/prepared-model-runtime.plugin-context.ts src/agents/runtime-plugins.test.ts src/agents/prepared-model-runtime.plugin-context.test.ts src/agents/openclaw-tools.browser-plugin.integration.test.ts
```

Final changed gate passed, including core production/test types, lint, formatting, dead exports, plugin boundaries, import cycles, and selected architecture guards.

```bash
pnpm build
```

Passed; no ineffective dynamic-import warning. The later fixture-only correction did not change production build inputs.

Fresh Codex autoreview of the final diff passed with no accepted/actionable findings at its default P0 threshold. Local manual review separately checked the ownership boundary, callers/siblings, dependency loader contracts, and alternatives. No source changes followed that review.

### Provenance and remaining scope

Blame locates the trigger preparation in [event-trigger introduction](https://github.com/openclaw/openclaw/pull/101195) and the current registry-handle call in [scoped registry handles](https://github.com/openclaw/openclaw/pull/117587). [Prepared plugin context handoff](https://github.com/openclaw/openclaw/pull/118398) covered model-backed tool construction but not this headless path. Blamed code author, PR author, and merger for those changes: @steipete; dates 2026-07-07, 2026-08-01, and 2026-08-03 respectively. This establishes code provenance, not a verified first-bad stable release.

Best-fix judgment: repair both owner handoffs using existing plugin-generation mechanisms. The first-load-only flag was experimentally insufficient; a global loader default would break intentional standalone source behavior; acquiring an entire model runtime would add unrelated preparation and ownership.

Named follow-up: residual synchronous workspace/tool-capability preparation and liveness stalls. The scope here is the demonstrated redundant source-runtime loading; universal latency, every third-party artifact's source/build equivalence, installed-package performance, and all production-tool authorization combinations are not claimed. No Control UI/native rendering or chat delivery code changes; proof exercises the real non-delivering scheduler/RPC flow. All local proof Gateways were stopped. CI and native landing proof will be recorded before merge.
