### PR TITLE
refactor(codex): simplify conversation thread and lease ownership

### DIFF
--- a/extensions/codex/src/app-server/client-runtime.test.ts
+++ b/extensions/codex/src/app-server/client-runtime.test.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CodexAppServerClient } from "./client.js";
 import { createClientHarness } from "./test-support.js";
@@ -340,13 +341,10 @@ describe("Codex app-server client runtime", () => {
   ])(
     "blocks same-thread replacement until unsubscribe is acknowledged (claimed: $claimed, unpin: $unpinDuringRelease)",
     async ({ claimed, unpinDuringRelease }) => {
-      let acknowledgeUnsubscribe: (() => void) | undefined;
-      const unsubscribeAcknowledged = new Promise<void>((resolve) => {
-        acknowledgeUnsubscribe = resolve;
-      });
+      const unsubscribeAcknowledged = createDeferred<void>();
       const request = vi.fn(async (method: string) => {
         if (method === "thread/unsubscribe") {
-          await unsubscribeAcknowledged;
+          await unsubscribeAcknowledged.promise;
         }
         return {};
       });
@@ -393,7 +391,7 @@ describe("Codex app-server client runtime", () => {
 
       expect(replacementPublished).toBe(false);
       expect(isCodexAppServerLiveThreadClaimed(client, "thread-transition")).toBe(claimed);
-      acknowledgeUnsubscribe?.();
+      unsubscribeAcknowledged.resolve();
 
       await expect(releasing).resolves.toBeUndefined();
       await expect(duplicateRelease).resolves.toBeUndefined();
@@ -479,11 +477,12 @@ describe("Codex app-server client runtime", () => {
     clients.push(harness.client);
     ensureCodexAppServerClientRuntime(harness.client, { agentDir: "/tmp/agent" });
 
-    let finishRelease: (() => void) | undefined;
-    const pendingRelease = new Promise<void>((resolve) => {
-      finishRelease = resolve;
-    });
-    await retainCodexAppServerLiveThread(harness.client, "thread-a", async () => pendingRelease);
+    const releaseGate = createDeferred<void>();
+    await retainCodexAppServerLiveThread(
+      harness.client,
+      "thread-a",
+      async () => releaseGate.promise,
+    );
     await retainCodexAppServerLiveThread(harness.client, "thread-b");
     const release = releaseCodexAppServerLiveThread(harness.client, "thread-a");
     const sameThreadAcquisition = consumeCodexAppServerLiveThread(harness.client, "thread-a");
@@ -491,7 +490,7 @@ describe("Codex app-server client runtime", () => {
     await expect(consumeCodexAppServerLiveThread(harness.client, "thread-b")).resolves.toEqual(
       expect.objectContaining({ release: expect.any(Function) }),
     );
-    finishRelease?.();
+    releaseGate.resolve();
     await expect(release).resolves.toBe(true);
     await expect(sameThreadAcquisition).resolves.toBeUndefined();
   });
@@ -607,14 +606,11 @@ describe("Codex app-server client runtime", () => {
     const harness = createClientHarness();
     clients.push(harness.client);
     ensureCodexAppServerClientRuntime(harness.client, { agentDir: "/tmp/agent" });
-    let finishRelease: (() => void) | undefined;
-    const pendingRelease = new Promise<void>((resolve) => {
-      finishRelease = resolve;
-    });
+    const pendingRelease = createDeferred<void>();
     await retainCodexAppServerLiveThread(
       harness.client,
       "thread-oldest",
-      async () => pendingRelease,
+      async () => pendingRelease.promise,
     );
     for (let index = 1; index < EXPECTED_MAX_IDLE_LIVE_THREADS; index += 1) {
       await retainCodexAppServerLiveThread(harness.client, `thread-${index}`);
@@ -622,7 +618,7 @@ describe("Codex app-server client runtime", () => {
     const retain = retainCodexAppServerLiveThread(harness.client, "thread-overflow");
 
     harness.client.close();
-    finishRelease?.();
+    pendingRelease.resolve();
 
     await expect(retain).resolves.toBe(false);
     await expect(
@@ -673,11 +669,8 @@ describe("Codex app-server client runtime", () => {
     const harness = createClientHarness();
     clients.push(harness.client);
     ensureCodexAppServerClientRuntime(harness.client, { agentDir: "/tmp/agent" });
-    let rejectUnsubscribe: ((error: Error) => void) | undefined;
-    const failedUnsubscribe = new Promise<void>((_resolve, reject) => {
-      rejectUnsubscribe = reject;
-    });
-    const release = vi.fn(async () => await failedUnsubscribe);
+    const failedUnsubscribe = createDeferred<void>();
+    const release = vi.fn(async () => await failedUnsubscribe.promise);
     await retainCodexAppServerLiveThread(harness.client, "thread-terminal", release);
     const notificationObserved = new Promise<void>((resolve) => {
       harness.client.addNotificationHandler((notification) => {
@@ -691,7 +684,7 @@ describe("Codex app-server client runtime", () => {
 
     harness.send({ method: "thread/closed", params: { threadId: "thread-terminal" } });
     await notificationObserved;
-    rejectUnsubscribe?.(new Error("client closed before unsubscribe completed"));
+    failedUnsubscribe.reject(new Error("client closed before unsubscribe completed"));
 
     await expect(releasing).rejects.toThrow("client closed before unsubscribe completed");
     await expect(
@@ -836,20 +829,17 @@ describe("Codex app-server client runtime", () => {
     const harness = createClientHarness();
     clients.push(harness.client);
     ensureCodexAppServerClientRuntime(harness.client, { agentDir: "/tmp/agent" });
-    let finishRelease: (() => void) | undefined;
-    const pendingRelease = new Promise<void>((resolve) => {
-      finishRelease = resolve;
-    });
+    const pendingRelease = createDeferred<void>();
     await retainCodexAppServerLiveThread(
       harness.client,
       "thread-stale",
-      async () => pendingRelease,
+      async () => pendingRelease.promise,
     );
     const release = releaseCodexAppServerLiveThread(harness.client, "thread-stale");
     const retain = retainCodexAppServerLiveThread(harness.client, "thread-stale");
 
     harness.client.close();
-    finishRelease?.();
+    pendingRelease.resolve();
 
     await expect(release).resolves.toBe(true);
     await expect(retain).resolves.toBe(false);

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -590,38 +590,52 @@ describe("shared Codex app-server client", () => {
     expect(harness.stdinDestroyed).toBe(true);
   });
 
-  it("does not consume a co-lease when selection replacement acquisition fails", async () => {
-    const harness = createClientHarness();
-    vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
-    const options = { timeoutMs: 1_000 };
-    const firstLease = getLeasedSharedCodexAppServerClient(options);
-    await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
-    const client = await firstLease;
-    await expect(getLeasedSharedCodexAppServerClient(options)).resolves.toBe(client);
-    const ownedLease = { client };
-    mocks.resolveManagedCodexAppServerStartOptions.mockRejectedValueOnce(
-      new Error("replacement acquisition failed"),
-    );
+  it.each(["fails", "succeeds"])(
+    "preserves a co-lease when selection replacement acquisition %s",
+    async (replacementOutcome) => {
+      const harness = createClientHarness();
+      const replacement = createClientHarness();
+      const start = vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
+      const options = { timeoutMs: 1_000 };
+      const firstLease = getLeasedSharedCodexAppServerClient(options);
+      await sendInitializeResult(harness, "openclaw/0.149.0 (Linux; test)");
+      const client = await firstLease;
+      await expect(getLeasedSharedCodexAppServerClient(options)).resolves.toBe(client);
+      const ownedLease = { client };
+      if (replacementOutcome === "fails") {
+        mocks.resolveManagedCodexAppServerStartOptions.mockRejectedValueOnce(
+          new Error("replacement acquisition failed"),
+        );
+      } else {
+        start.mockReturnValue(replacement.client);
+      }
 
-    await expect(
-      withLeasedCodexAppServerClientStartSelectionRetry({
+      const retry = withLeasedCodexAppServerClientStartSelectionRetry({
         lease: ownedLease,
         options,
-        run: async () => {
+        run: async (attemptClient) => {
+          if (attemptClient !== client) {
+            return attemptClient;
+          }
           throw Object.assign(new Error("selection changed"), {
             code: "CODEX_APP_SERVER_START_SELECTION_CHANGED",
           });
         },
-        onClientChange: () => undefined,
-      }),
-    ).rejects.toThrow("replacement acquisition failed");
-
-    expect(ownedLease.client).toBeUndefined();
-    expect(releaseCodexAppServerClientLease(ownedLease)).toBe(false);
-    expect(harness.stdinDestroyed).toBe(false);
-    expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
-    await vi.waitFor(() => expect(harness.stdinDestroyed).toBe(true));
-  });
+      });
+      if (replacementOutcome === "fails") {
+        await expect(retry).rejects.toThrow("replacement acquisition failed");
+        expect(ownedLease.client).toBeUndefined();
+      } else {
+        await sendInitializeResult(replacement, "openclaw/0.149.0 (Linux; test)");
+        await expect(retry).resolves.toBe(replacement.client);
+        expect(ownedLease.client).toBe(replacement.client);
+      }
+      expect(releaseCodexAppServerClientLease(ownedLease)).toBe(replacementOutcome === "succeeds");
+      expect(harness.stdinDestroyed).toBe(false);
+      expect(releaseLeasedSharedCodexAppServerClient(client)).toBe(true);
+      await vi.waitFor(() => expect(harness.stdinDestroyed).toBe(true));
+    },
+  );
 
   it("falls back before starting a desktop candidate with incomplete Computer Use artifacts", async () => {
     const pluginLocal = createClientHarness();

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -559,7 +559,7 @@ export async function withLeasedCodexAppServerClientStartSelectionRetry<T>(param
     client: CodexAppServerClient,
     requestOptions: () => CodexAppServerLeasedRequestOptions,
   ) => Promise<T>;
-  onClientChange: (client: CodexAppServerClient) => void;
+  onClientChange?: (client: CodexAppServerClient) => void;
 }): Promise<T> {
   let client = params.lease.client;
   if (!client) {
@@ -621,7 +621,7 @@ export async function withLeasedCodexAppServerClientStartSelectionRetry<T>(param
         ...(signal ? { abandonSignal: signal } : {}),
       });
       params.lease.client = client;
-      params.onClientChange(client);
+      params.onClientChange?.(client);
     } finally {
       scopeActive = false;
     }

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -191,35 +191,32 @@ async function writeTestBinding(
   await testCodexAppServerBindingStore.mutate(identity, { kind: "set", binding });
 }
 
-async function completeResumeControlRequest(
-  options: CodexControlRequestOptions | undefined,
-  response: ReturnType<typeof createThreadResumeResponse>,
-  client: CodexAppServerClient,
-  auth: { authProfileId?: string } = {},
-) {
-  await options?.beforeRequest?.(async <T>() => ({ thread: response.thread }) as T);
-  await options?.onResponse?.(response, client, { ...auth, assertCurrent: () => undefined });
-}
-
 function createResumeControlRequest(
   response:
     | ReturnType<typeof createThreadResumeResponse>
     | (() => Promise<ReturnType<typeof createThreadResumeResponse>>),
-  auth: { authProfileId?: string } = {},
+  options: { client?: CodexAppServerClient; authProfileId?: string } = {},
 ) {
-  const harness = createClientHarness();
-  resumeClients.push(harness.client);
-  ensureCodexAppServerClientRuntime(harness.client, { agentDir: tempDir });
-  vi.spyOn(harness.client, "request").mockResolvedValue({} as never);
+  const { client: suppliedClient, ...auth } = options;
+  const client = suppliedClient ?? createClientHarness().client;
+  if (!suppliedClient) {
+    resumeClients.push(client);
+    ensureCodexAppServerClientRuntime(client, { agentDir: tempDir });
+    vi.spyOn(client, "request").mockResolvedValue({} as never);
+  }
   return vi.fn(
     async (
       _pluginConfig: unknown,
       _method: string,
       _params: unknown,
-      options?: CodexControlRequestOptions,
+      requestOptions?: CodexControlRequestOptions,
     ) => {
       const value = typeof response === "function" ? await response() : response;
-      await completeResumeControlRequest(options, value, harness.client, auth);
+      await requestOptions?.beforeRequest?.(async <T>() => ({ thread: value.thread }) as T);
+      await requestOptions?.onResponse?.(value, client, {
+        ...auth,
+        assertCurrent: () => undefined,
+      });
       return value;
     },
   );
@@ -928,17 +925,7 @@ describe("codex command", () => {
     const harness = createClientHarness();
     ensureCodexAppServerClientRuntime(harness.client, { agentDir: tempDir });
     const response = createThreadResumeResponse({ threadId: "thread-owned-resume" });
-    const codexControlRequest = vi.fn(
-      async (
-        _pluginConfig: unknown,
-        _method: string,
-        _params: unknown,
-        options?: CodexControlRequestOptions,
-      ) => {
-        await completeResumeControlRequest(options, response, harness.client);
-        return response;
-      },
-    );
+    const codexControlRequest = createResumeControlRequest(response, { client: harness.client });
 
     try {
       const result = await runCommand("resume thread-owned-resume", { codexControlRequest });
@@ -985,17 +972,7 @@ describe("codex command", () => {
       cwd: "/repo",
     });
     const response = createThreadResumeResponse({ threadId: "thread-overflow" });
-    const codexControlRequest = vi.fn(
-      async (
-        _pluginConfig: unknown,
-        _method: string,
-        _params: unknown,
-        options?: CodexControlRequestOptions,
-      ) => {
-        await completeResumeControlRequest(options, response, harness.client);
-        return response;
-      },
-    );
+    const codexControlRequest = createResumeControlRequest(response, { client: harness.client });
 
     try {
       const result = await runCommand("resume thread-overflow", { codexControlRequest });
@@ -1061,17 +1038,9 @@ describe("codex command", () => {
             : undefined,
         );
       const response = createThreadResumeResponse({ threadId: "thread-manual-migration" });
-      const codexControlRequest = vi.fn(
-        async (
-          _pluginConfig: unknown,
-          _method: string,
-          _params: unknown,
-          options?: CodexControlRequestOptions,
-        ) => {
-          await completeResumeControlRequest(options, response, replacement.client);
-          return response;
-        },
-      );
+      const codexControlRequest = createResumeControlRequest(response, {
+        client: replacement.client,
+      });
 
       try {
         const result = await runCommand("resume thread-manual-migration", { codexControlRequest });
@@ -1135,17 +1104,7 @@ describe("codex command", () => {
       "priority",
     );
     const response = createThreadResumeResponse({ threadId: "thread-known-resume" });
-    const codexControlRequest = vi.fn(
-      async (
-        _pluginConfig: unknown,
-        _method: string,
-        _params: unknown,
-        options?: CodexControlRequestOptions,
-      ) => {
-        await completeResumeControlRequest(options, response, harness.client);
-        return response;
-      },
-    );
+    const codexControlRequest = createResumeControlRequest(response, { client: harness.client });
 
     try {
       await expect(
@@ -1234,20 +1193,15 @@ describe("codex command", () => {
           true,
         ),
       );
-      const codexControlRequest = vi.fn(
-        async (
-          _pluginConfig: unknown,
-          _method: string,
-          _params: unknown,
-          options?: CodexControlRequestOptions,
-        ) => {
+      const codexControlRequest = createResumeControlRequest(
+        async () => {
           await harness.client.request("thread/resume", {
             threadId: "thread-active-resume",
             excludeTurns: true,
           });
-          await completeResumeControlRequest(options, response, harness.client);
           return response;
         },
+        { client: harness.client },
       );
 
       try {

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -317,40 +317,26 @@ async function startCodexConversationThread(
     authProfileId: params.authProfileId ?? existingBinding?.authProfileId,
     ...agentLookup,
   });
-  const incognito = isIncognitoSessionKey(params.sessionKey);
-  if (params.threadId?.trim()) {
-    await attachExistingThread({
-      pluginConfig: params.pluginConfig,
-      bindingStore: params.bindingStore,
-      identity,
-      threadId: params.threadId.trim(),
-      workspaceDir,
-      ...(agentDir ? { agentDir } : {}),
-      model: params.model,
-      modelProvider: params.modelProvider,
-      authProfileId,
-      serviceTier: params.serviceTier,
-      config: params.config,
-      sessionKey: params.sessionKey,
-      incognito,
-      agentId: params.agentId,
-    });
+  const bindingParams: CodexThreadBindingParams = {
+    pluginConfig: params.pluginConfig,
+    bindingStore: params.bindingStore,
+    identity,
+    workspaceDir,
+    ...(agentDir ? { agentDir } : {}),
+    model: params.model,
+    modelProvider: params.modelProvider,
+    authProfileId,
+    serviceTier: params.serviceTier,
+    config: params.config,
+    sessionKey: params.sessionKey,
+    incognito: isIncognitoSessionKey(params.sessionKey),
+    agentId: params.agentId,
+  };
+  const threadId = params.threadId?.trim();
+  if (threadId) {
+    await attachExistingThread({ ...bindingParams, threadId });
   } else {
-    await bindThread({
-      pluginConfig: params.pluginConfig,
-      bindingStore: params.bindingStore,
-      identity,
-      workspaceDir,
-      ...(agentDir ? { agentDir } : {}),
-      model: params.model,
-      modelProvider: params.modelProvider,
-      authProfileId,
-      serviceTier: params.serviceTier,
-      config: params.config,
-      sessionKey: params.sessionKey,
-      incognito,
-      agentId: params.agentId,
-    });
+    await bindThread(bindingParams);
   }
   const storedBinding = await params.bindingStore.read(identity);
   if (!storedBinding) {
@@ -543,18 +529,9 @@ type CodexThreadBindingParams = {
 
 type ConversationAppServerRuntime = Awaited<ReturnType<typeof resolveConversationAppServerRuntime>>;
 
-type CodexThreadBindingRuntime = ConversationAppServerRuntime & {
-  agentLookup: ReturnType<typeof buildAgentLookup>;
-  client: Awaited<ReturnType<typeof getLeasedSharedCodexAppServerClient>>;
-  clientLease: CodexAppServerClientLease;
-  clientOptions: CodexAppServerClientOptions;
-  model?: string;
-  modelProvider?: string;
-};
+type CodexThreadBindingRuntime = Awaited<ReturnType<typeof resolveThreadBindingRuntime>>;
 
-async function resolveThreadBindingRuntime(
-  params: CodexThreadBindingParams,
-): Promise<CodexThreadBindingRuntime> {
+async function resolveThreadBindingRuntime(params: CodexThreadBindingParams) {
   const agentLookup = buildAgentLookup({ agentDir: params.agentDir, config: params.config });
   const modelProvider = resolveThreadRequestModelProvider({
     authProfileId: params.authProfileId,
@@ -598,32 +575,25 @@ async function resolveThreadBindingRuntime(
     authProfileId: params.authProfileId,
     ...agentLookup,
   } satisfies CodexAppServerClientOptions;
-  const client = await getLeasedSharedCodexAppServerClient(clientOptions);
   return {
     runtime: modelScopedRuntime,
     workspaceDir,
     agentLookup,
     model: modelSelection?.model,
     modelProvider: modelSelection?.modelProvider ?? modelProvider,
-    client,
-    clientLease: { client },
     clientOptions,
   };
 }
 
-function buildThreadRequestRuntimeOptions(
-  params: CodexThreadBindingParams,
-  resolved: CodexThreadBindingRuntime,
-): {
-  approvalPolicy: ConversationAppServerRuntime["runtime"]["approvalPolicy"];
-  approvalsReviewer: ConversationAppServerRuntime["runtime"]["approvalsReviewer"];
-  sandbox?: ConversationAppServerRuntime["runtime"]["sandbox"];
-  runtimeWorkspaceRoots?: string[];
-  serviceTier?: CodexServiceTier;
-  config?: JsonObject;
-} {
-  const serviceTier = params.serviceTier ?? resolved.runtime.serviceTier;
+function buildConversationThreadRequest(
+  resolved: ConversationAppServerRuntime & { model?: string; modelProvider?: string },
+  serviceTier?: CodexServiceTier | null,
+): CodexThreadStartParams {
   return {
+    cwd: resolved.workspaceDir,
+    ...(resolved.model ? { model: resolved.model } : {}),
+    ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
+    personality: CODEX_NATIVE_PERSONALITY_NONE,
     approvalPolicy: resolved.runtime.approvalPolicy,
     approvalsReviewer: resolved.runtime.approvalsReviewer,
     ...(resolved.runtime.sessionRoot
@@ -658,6 +628,7 @@ function codexConversationSandboxOrPermissions(
 async function writeThreadBindingFromResponse(
   params: CodexThreadBindingParams,
   resolved: CodexThreadBindingRuntime,
+  client: CodexAppServerClient,
   response: CodexThreadResumeResponse | CodexThreadStartResponse,
   requestOptions: () => CodexAppServerLeasedRequestOptions,
 ): Promise<void> {
@@ -666,16 +637,15 @@ async function writeThreadBindingFromResponse(
   try {
     const current = await params.bindingStore.read(params.identity);
     assertCodexBindingMayBeReplaced(current, "storing a conversation-bound Codex thread");
-    const trackSubscription =
-      !params.incognito && isCodexAppServerClientRuntimeLive(resolved.client);
+    const trackSubscription = !params.incognito && isCodexAppServerClientRuntimeLive(client);
     sameOwner = isSameCodexAppServerThreadOwner(current, {
       threadId: response.thread.id,
-      clientId: resolved.client.getInstanceId(),
+      clientId: client.getInstanceId(),
     });
     requestOptions();
     assertCodexThreadAcceptsDirectInput(response.thread);
     if (trackSubscription) {
-      retained = await retainCodexAppServerBindingSubscription(resolved.client, response.thread.id);
+      retained = await retainCodexAppServerBindingSubscription(client, response.thread.id);
       if (!retained) {
         throw new Error("Codex conversation thread lost its native subscription owner.");
       }
@@ -693,7 +663,7 @@ async function writeThreadBindingFromResponse(
         kind: "set",
         binding: {
           threadId: response.thread.id,
-          clientId: resolved.client.getInstanceId(),
+          clientId: client.getInstanceId(),
           cwd: resolved.workspaceDir,
           authProfileId: params.authProfileId,
           model: response.model ?? resolved.model ?? params.model,
@@ -715,15 +685,8 @@ async function writeThreadBindingFromResponse(
   } catch (error) {
     // A matching stored binding may already have lost its idle subscription.
     // Keep existing live owners, but never leave an accepted resume untracked.
-    if (
-      (retained && !sameOwner) ||
-      !hasCodexAppServerLiveThread(resolved.client, response.thread.id)
-    ) {
-      await rollbackCodexAppServerBindingSubscription(
-        resolved.client,
-        response.thread.id,
-        retained,
-      );
+    if ((retained && !sameOwner) || !hasCodexAppServerLiveThread(client, response.thread.id)) {
+      await rollbackCodexAppServerBindingSubscription(client, response.thread.id, retained);
     }
     throw error;
   }
@@ -746,18 +709,18 @@ async function bindThread(params: CodexThreadBindingParams, threadId?: string): 
   const current = await params.bindingStore.read(params.identity);
   assertCodexBindingMayBeReplaced(current, "binding a conversation-bound Codex thread");
   const resolved = await resolveThreadBindingRuntime(params);
+  const clientLease: CodexAppServerClientLease = {
+    client: await getLeasedSharedCodexAppServerClient(resolved.clientOptions),
+  };
   try {
     await withLeasedCodexAppServerClientStartSelectionRetry({
-      lease: resolved.clientLease,
+      lease: clientLease,
       options: resolved.clientOptions,
       run: async (client, requestOptions) => {
-        const request = {
-          cwd: resolved.workspaceDir,
-          ...(resolved.model ? { model: resolved.model } : {}),
-          ...(resolved.modelProvider ? { modelProvider: resolved.modelProvider } : {}),
-          personality: CODEX_NATIVE_PERSONALITY_NONE,
-          ...buildThreadRequestRuntimeOptions(params, resolved),
-        } satisfies CodexThreadStartParams;
+        const request = buildConversationThreadRequest(
+          resolved,
+          params.serviceTier ?? resolved.runtime.serviceTier,
+        );
         let response: CodexThreadResumeResponse | CodexThreadStartResponse;
         // Codex applies network-proxy permission profiles at thread/start. Resuming
         // an arbitrary existing thread cannot prove that profile is active.
@@ -801,14 +764,11 @@ async function bindThread(params: CodexThreadBindingParams, threadId?: string): 
             requestOptions(),
           );
         }
-        await writeThreadBindingFromResponse(params, resolved, response, requestOptions);
-      },
-      onClientChange: (client) => {
-        resolved.client = client;
+        await writeThreadBindingFromResponse(params, resolved, client, response, requestOptions);
       },
     });
   } finally {
-    releaseCodexAppServerClientLease(resolved.clientLease);
+    releaseCodexAppServerClientLease(clientLease);
   }
 }
 
@@ -878,6 +838,7 @@ async function runBoundTurn(params: {
         ...agentLookup,
       })
     : undefined;
+  const threadRequestRuntime = { runtime: modelScopedRuntime, workspaceDir, ...modelSelection };
 
   const clientOptions = {
     startOptions: runtime.start,
@@ -930,17 +891,7 @@ async function runBoundTurn(params: {
             await requestClient.request(
               "thread/start",
               {
-                cwd: workspaceDir,
-                ...(sessionRoot ? { runtimeWorkspaceRoots: [sessionRoot] } : {}),
-                ...(modelSelection?.model ? { model: modelSelection.model } : {}),
-                ...(modelSelection?.modelProvider
-                  ? { modelProvider: modelSelection.modelProvider }
-                  : {}),
-                personality: CODEX_NATIVE_PERSONALITY_NONE,
-                approvalPolicy,
-                approvalsReviewer: modelScopedRuntime.approvalsReviewer,
-                ...codexConversationSandboxOrPermissions(modelScopedRuntime, sandbox),
-                ...(serviceTier ? { serviceTier } : {}),
+                ...buildConversationThreadRequest(threadRequestRuntime, serviceTier),
                 developerInstructions: CODEX_CONVERSATION_THREAD_DEVELOPER_INSTRUCTIONS,
                 experimentalRawEvents: true,
                 ...(params.incognito ? { ephemeral: true } : {}),
@@ -1030,17 +981,7 @@ async function runBoundTurn(params: {
             },
             request: {
               threadId,
-              cwd: workspaceDir,
-              ...(sessionRoot ? { runtimeWorkspaceRoots: [sessionRoot] } : {}),
-              ...(modelSelection?.model ? { model: modelSelection.model } : {}),
-              ...(modelSelection?.modelProvider
-                ? { modelProvider: modelSelection.modelProvider }
-                : {}),
-              personality: CODEX_NATIVE_PERSONALITY_NONE,
-              approvalPolicy,
-              approvalsReviewer: modelScopedRuntime.approvalsReviewer,
-              ...codexConversationSandboxOrPermissions(modelScopedRuntime, sandbox),
-              ...(serviceTier ? { serviceTier } : {}),
+              ...buildConversationThreadRequest(threadRequestRuntime, serviceTier),
             },
             requestResume: (request) =>
               requestClient.request("thread/resume", request, requestOptions()),

--- a/src/commands/sessions-cleanup.test.ts
+++ b/src/commands/sessions-cleanup.test.ts
@@ -1,22 +1,12 @@
 // Sessions cleanup tests cover stale session cleanup and runtime output.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { visibleWidth } from "../../packages/terminal-core/src/ansi.js";
-import type { SessionEntry } from "../config/sessions.js";
 import { GatewayTransportError } from "../gateway/transport-error.js";
 import type { RuntimeEnv } from "../runtime.js";
 
 const mocks = vi.hoisted(() => ({
   loadConfig: vi.fn(),
-  resolveSessionStoreTargets: vi.fn(),
   resolveSessionStoreTargetsOrExit: vi.fn(),
-  resolveMaintenanceConfig: vi.fn(),
-  loadSessionStore: vi.fn(),
-  resolveSessionFilePath: vi.fn(),
-  resolveSessionFilePathOptions: vi.fn(),
-  pruneStaleEntries: vi.fn(),
-  capEntryCount: vi.fn(),
-  updateSessionStore: vi.fn(),
-  enforceSessionDiskBudget: vi.fn(),
   resolveSessionCleanupAction: vi.fn(),
   runSessionsCleanup: vi.fn(),
   runLocalSessionsCleanup: vi.fn(),
@@ -26,7 +16,6 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../config/config.js", () => ({
   getRuntimeConfig: mocks.loadConfig,
-  loadConfig: mocks.loadConfig,
 }));
 
 vi.mock("./sessions-cleanup.runtime.js", () => ({
@@ -34,19 +23,10 @@ vi.mock("./sessions-cleanup.runtime.js", () => ({
 }));
 
 vi.mock("./session-store-targets.js", () => ({
-  resolveSessionStoreTargets: mocks.resolveSessionStoreTargets,
   resolveSessionStoreTargetsOrExit: mocks.resolveSessionStoreTargetsOrExit,
 }));
 
 vi.mock("../config/sessions.js", () => ({
-  resolveMaintenanceConfig: mocks.resolveMaintenanceConfig,
-  loadSessionStore: mocks.loadSessionStore,
-  resolveSessionFilePathCore: mocks.resolveSessionFilePath,
-  resolveSessionFilePathOptions: mocks.resolveSessionFilePathOptions,
-  pruneStaleEntries: mocks.pruneStaleEntries,
-  capEntryCount: mocks.capEntryCount,
-  updateSessionStore: mocks.updateSessionStore,
-  enforceSessionDiskBudget: mocks.enforceSessionDiskBudget,
   resolveSessionCleanupAction: mocks.resolveSessionCleanupAction,
   runSessionsCleanup: mocks.runSessionsCleanup,
   serializeSessionCleanupResult: mocks.serializeSessionCleanupResult,
@@ -92,50 +72,9 @@ describe("sessionsCleanupCommand", () => {
     vi.clearAllMocks();
     mocks.runLocalSessionsCleanup.mockImplementation((params) => mocks.runSessionsCleanup(params));
     mocks.loadConfig.mockReturnValue({ session: { store: "/cfg/sessions.json" } });
-    mocks.resolveSessionStoreTargets.mockReturnValue([
+    mocks.resolveSessionStoreTargetsOrExit.mockReturnValue([
       { agentId: "main", storePath: "/resolved/sessions.json" },
     ]);
-    mocks.resolveSessionStoreTargetsOrExit.mockImplementation(
-      (params: { cfg: unknown; opts: unknown; runtime: RuntimeEnv }) => {
-        try {
-          return mocks.resolveSessionStoreTargets(params.cfg, params.opts);
-        } catch (error) {
-          params.runtime.error(error instanceof Error ? error.message : String(error));
-          params.runtime.exit(1);
-          return null;
-        }
-      },
-    );
-    mocks.resolveMaintenanceConfig.mockReturnValue({
-      mode: "warn",
-      pruneAfterMs: 7 * 24 * 60 * 60 * 1000,
-      archiveDashboardAfterMs: 7 * 24 * 60 * 60 * 1000,
-      modelRunPruneAfterMs: 24 * 60 * 60 * 1000,
-      maxEntries: 500,
-      resetArchiveRetentionMs: 7 * 24 * 60 * 60 * 1000,
-      maxDiskBytes: null,
-      highWaterBytes: null,
-    });
-    mocks.pruneStaleEntries.mockImplementation(
-      (
-        store: Record<string, SessionEntry>,
-        _maxAgeMs: number,
-        opts?: { onPruned?: (params: { key: string; entry: SessionEntry }) => void },
-      ) => {
-        if (store.stale) {
-          opts?.onPruned?.({ key: "stale", entry: store.stale });
-          delete store.stale;
-          return 1;
-        }
-        return 0;
-      },
-    );
-    mocks.resolveSessionFilePathOptions.mockReturnValue({});
-    mocks.resolveSessionFilePath.mockImplementation(
-      (sessionId: string) => `/missing/${sessionId}.jsonl`,
-    );
-    mocks.capEntryCount.mockImplementation(() => 0);
-    mocks.updateSessionStore.mockResolvedValue(0);
     mocks.callGateway.mockResolvedValue(null);
     mocks.resolveSessionCleanupAction.mockImplementation(
       (params: {
@@ -178,16 +117,6 @@ describe("sessionsCleanupCommand", () => {
       mode: "warn",
       previewResults: [],
       appliedSummaries: [],
-    });
-    mocks.enforceSessionDiskBudget.mockResolvedValue({
-      totalBytesBefore: 1000,
-      totalBytesAfter: 700,
-      removedFiles: 1,
-      removedEntries: 1,
-      freedBytes: 300,
-      maxBytes: 900,
-      highWaterBytes: 700,
-      overBudget: true,
     });
   });
 
@@ -338,7 +267,6 @@ describe("sessionsCleanupCommand", () => {
     expect(gatewayCall?.params.enforce).toBe(true);
     expect(gatewayCall?.requiredMethods).toEqual(["sessions.cleanup"]);
     expect(mocks.runLocalSessionsCleanup).not.toHaveBeenCalled();
-    expect(mocks.updateSessionStore).not.toHaveBeenCalled();
     expect(logs).toHaveLength(1);
     expect(JSON.parse(logs[0] ?? "{}")).toEqual({
       agentId: "main",
@@ -462,11 +390,9 @@ describe("sessionsCleanupCommand", () => {
     expect(mocks.runSessionsCleanup).toHaveBeenCalled();
     expect(mocks.runLocalSessionsCleanup).not.toHaveBeenCalled();
     expect(mocks.callGateway).not.toHaveBeenCalled();
-    expect(mocks.updateSessionStore).not.toHaveBeenCalled();
   });
 
   it("counts missing transcript entries when --fix-missing is enabled in dry-run", async () => {
-    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
     mocks.runSessionsCleanup.mockResolvedValue({
       mode: "warn",
       previewResults: [
@@ -526,7 +452,6 @@ describe("sessionsCleanupCommand", () => {
   });
 
   it("renders a dry-run action table with keep/prune actions", async () => {
-    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
     mocks.runSessionsCleanup.mockResolvedValue({
       mode: "warn",
       previewResults: [
@@ -588,7 +513,6 @@ describe("sessionsCleanupCommand", () => {
   });
 
   it("renders a dry-run summary grouped by session label", async () => {
-    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
     mocks.runSessionsCleanup.mockResolvedValue({
       mode: "warn",
       previewResults: [
@@ -685,7 +609,6 @@ describe("sessionsCleanupCommand", () => {
   });
 
   it("aligns the label summary columns for emoji and CJK labels", async () => {
-    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
     mocks.runSessionsCleanup.mockResolvedValue({
       mode: "warn",
       previewResults: [
@@ -754,11 +677,10 @@ describe("sessionsCleanupCommand", () => {
   });
 
   it("returns grouped JSON for --all-agents dry-runs", async () => {
-    mocks.resolveSessionStoreTargets.mockReturnValue([
+    mocks.resolveSessionStoreTargetsOrExit.mockReturnValue([
       { agentId: "main", storePath: "/resolved/main-sessions.json" },
       { agentId: "work", storePath: "/resolved/work-sessions.json" },
     ]);
-    mocks.enforceSessionDiskBudget.mockResolvedValue(null);
     mocks.runSessionsCleanup.mockResolvedValue({
       mode: "warn",
       previewResults: [


### PR DESCRIPTION
Related: #130864

## What Problem This Solves

Maintainer-requested cleanup of the Codex lifecycle repair. Starting, attaching, and continuing a conversation-bound native thread repeated the same thread request construction, while the binding path kept both a mutable client alias and the lease that already owned it. The tests also retained duplicate resume fixtures and obsolete storage mocks.

## Why This Change Was Made

Use one fresh thread request builder for the shared start/resume fields, and let `bindThread` acquire and release its own client lease. Pass the exact client from each retry attempt to the binding writer, so no change observer is needed merely to mirror the lease. Other callers retain their observers where they rebind handlers or need post-retry state.

Keep start-only fields, turn policy, direct-input checks, thread locking, retained subscriptions, and commit/rollback behavior at their existing owners. Reuse the existing resume fixture and deferred helper in tests; remove mocks for storage functions the cleanup command no longer calls. No schema, configuration, dependency, or model-routing changes.

Production LOC: +51/-110 (net -59). Tests: +84/-204 (net -120). Total: 179 fewer lines across six files. Existing scenarios and meaningful assertions remain; the shared-client suite gains successful replacement coverage without a change observer.

## User Impact

No intended user-visible behavior change. The prior lifecycle fixes remain intact, with less duplicated policy and one explicit owner for each binding attempt's client lease. The separate parent-fork persistence and automatic native-history-fork decisions remain out of scope.

## Evidence

- Before edits: 1,029 focused tests passed across 18 files.
- After cleanup: 1,042 focused tests passed across 19 files (1,008 Codex tests and 34 command/resolver tests). Coverage includes startup retries, subscription ownership/races, native subagents, start/resume, command control, conversation binding, offline cleanup, and real store-target resolution.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33129987790): passed on `20c738de9cf243710f38f3126a69ee87f8e138a2`, with no failed jobs or retries.
- Clean Linux container: frozen-lockfile install and full `pnpm build` passed, including plugin SDK exports, CLI bootstrap, and Control UI asset checks. Codex reports version `0.150.1`.
- Authenticated live proof (`run_5319cd190092`, `openai/gpt-5.6-luna`) passed four real turns: fresh `startThread`, same-client attachment with history recall, a real webchat conversation binding through `handleInboundClaim`, and cold resume after closing the exact physical client. Cold resume retained the native thread, used a different client, and recalled the prior marker. Production binding/session/auth cleanup passed.
- The live proof calls production owner APIs with real SQLite stores, Codex, and provider authentication; it is not a new Gateway/UI E2E run. The preceding UI proof remains [on #130864](https://github.com/openclaw/openclaw/pull/130864#issuecomment-5437764086). Source HEAD and SHA-256 fingerprints of both changed production files matched the candidate.
- Verification note: the local broad changed-file check passed guards, formatting, dead-export scans, and doctor tests, then stopped because this worktree lacks the already-declared `@types/jsdom` dependency. The resulting errors are confined to unchanged UI tests; clean-install CI passed all core test-type lanes. A separate clean-container run of both UI typecheck shards passed (`run_c46290237b58`), confirming the worktree dependency issue.
- Independent Codex review: no actionable P0–P2 findings.
- Personally checked current upstream `openai/codex` at `426fa8cdab4247e5623e9617d531f6917482b947`: `codex-rs/app-server-protocol/src/protocol/v2/thread.rs:62` and `:335` for the common start/resume contract; `codex-rs/app-server/src/request_processors/thread_input.rs:12` for direct-input capability; `request_processors/thread_processor.rs:3854` and `thread_state.rs:497` for attachment/unsubscribe ordering. The managed runtime remains pinned to Codex 0.150.1.

AI-assisted implementation and review.
