### PR TITLE
fix(sessions): explain ACP category recovery options

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -867,6 +867,25 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
+  it("explains both recoveries when an ACP run includes a category", async () => {
+    registerAcpBackendForTest();
+    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:main:main" });
+
+    await expect(
+      tool.execute("acp-category", {
+        task: "Investigate the failure",
+        runtime: "acp",
+        mode: "run",
+        streamTo: "parent",
+        category: "handoff investigation",
+      }),
+    ).rejects.toThrow(
+      'category is only available for visible dashboard sessions. Choose one: omit category for a hidden or ACP run; or set visible=true, use runtime="subagent", and omit mode and streamTo.',
+    );
+    expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
+    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
+  });
+
   it("applies a per-run timeout to visible dashboard sessions", async () => {
     const callGateway = vi.fn(async () => ({
       key: "agent:main:dashboard:timed-child",

--- a/src/agents/tools/sessions-spawn-visible.ts
+++ b/src/agents/tools/sessions-spawn-visible.ts
@@ -114,6 +114,11 @@ export async function maybeSpawnVisibleSession(params: {
   const categoryProvided = Object.hasOwn(params.raw, "category");
   const requestedCategory = readToolStringParam(params.raw, "category", { allowEmpty: true });
   if (params.raw.visible !== true) {
+    if (params.runtime === "acp" && requestedCategory) {
+      throw new ToolInputError(
+        'category is only available for visible dashboard sessions. Choose one: omit category for a hidden or ACP run; or set visible=true, use runtime="subagent", and omit mode and streamTo.',
+      );
+    }
     const visibleOnlyParams = [
       ["category", categoryProvided ? requestedCategory : undefined],
       ["worktree", worktree],


### PR DESCRIPTION
<!-- AI-assisted change. -->

Closes #131221

## What Problem This Solves

Fixes an issue where an ACP run with a category received a generic visible-session error that could steer the model into another incompatible retry.

## Why This Change Was Made

The visible-session validation owner now gives both valid recovery choices for a non-empty ACP category: remove category and keep the hidden or ACP run, or switch to a visible subagent while omitting mode and streamTo. This leaves accepted spawn semantics and dispatch unchanged.

A focused diagnostic is preferable to a discriminated-union or oneOf schema redesign because the request fields are individually valid and the incompatibility is contextual. Changing the schema would broaden the public tool contract, add provider-compatibility risk, and duplicate runtime constraints without improving dispatch. The owner already has the parsed runtime and category needed to return the right recovery guidance.

The separate blank and whitespace category concern from #130960 is unchanged.

## User Impact

Agents can recover from this invalid ACP spawn request in one retry without being directed toward an incompatible visible ACP session.

## Evidence

- pnpm test src/agents/tools/sessions-spawn-tool.test.ts: PASS. 1 test file passed; 116 tests passed; Vitest duration 11.48s; shard completed in 13.23s.
- pnpm check:changed -- src/agents/tools/sessions-spawn-visible.ts src/agents/tools/sessions-spawn-tool.test.ts: PASS, exit 0. Selected lanes: core and coreTests. Changed-file lint reported 0 warnings and 0 errors; runtime import-cycle check reported 0 cycles.
- Final branch autoreview against upstream/main: clean; no accepted or actionable findings.
- Existing visible category coverage remains green. The new regression asserts that neither ACP nor subagent dispatch runs after the validation error.
- Live ACP proof was not run because this invalid request is rejected at the public tool-validation boundary before backend dispatch. The focused regression observes the returned diagnostic and proves both dispatch functions remain untouched.

## Worked on by

- Benjamin Jesuiter
