### PR TITLE
fix: agent database reopen accepts a newer schema after close or eviction

### DIFF
--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -509,7 +509,7 @@ export function assertAgentDatabaseIntegrityBeforeMutation(
   database: DatabaseSync,
   agentId: string,
   pathname: string,
-): void {
+): boolean {
   database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
   const userVersion = readSqliteUserVersion(database);
   const hasApplicationSchema = database
@@ -547,6 +547,7 @@ export function assertAgentDatabaseIntegrityBeforeMutation(
   if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION && !hasPendingCurrentVersionMigration) {
     assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname });
   }
+  return hasPendingCurrentVersionMigration;
 }
 
 function ensureAgentSchema(

--- a/src/state/openclaw-agent-db.cache-eviction.test.ts
+++ b/src/state/openclaw-agent-db.cache-eviction.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   closeOpenClawAgentDatabasesForTest,
@@ -138,8 +139,22 @@ describe("openclaw agent database handle cache", () => {
     openOpenClawAgentDatabase({ agentId: "durability-evictor", env });
     expect(evicted.db.isOpen).toBe(false);
 
+    const { DatabaseSync } = requireNodeSqlite();
+    const divergent = new DatabaseSync(evicted.path);
+    try {
+      divergent.exec("ALTER TABLE session_nodes DROP COLUMN project_id;");
+    } finally {
+      divergent.close();
+    }
+
     const reopened = openOpenClawAgentDatabase({ agentId: evicted.agentId, env });
     expect(reopened).not.toBe(evicted);
+    expect(
+      reopened.db
+        .prepare("PRAGMA table_info(session_nodes)")
+        .all()
+        .some((row) => (row as { name?: unknown }).name === "project_id"),
+    ).toBe(true);
     expect(
       reopened.db
         .prepare("SELECT state_json, updated_at FROM auth_profile_state WHERE state_key = ?")

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -2,6 +2,7 @@
 import { execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import {
@@ -42,6 +43,7 @@ import {
   disposeOpenClawAgentDatabaseByPath,
   ensureOpenClawAgentDatabaseSchema,
   inspectOpenClawAgentDatabaseOwner,
+  isOpenClawAgentDatabaseOpen,
   listOpenClawRegisteredAgentDatabases,
   migrateOpenClawAgentDatabaseForMaintenance,
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -4520,6 +4522,122 @@ describe("openclaw agent database", () => {
     );
   });
 
+  it("reopens a validated current-schema database promptly while a WAL writer is active", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
+    expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const writer = new DatabaseSync(databasePath);
+    let reopened: ReturnType<typeof openOpenClawAgentDatabase> | undefined;
+    try {
+      writer.exec("PRAGMA journal_mode = WAL; BEGIN IMMEDIATE;");
+      const startedAt = performance.now();
+      reopened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+      const elapsedMs = performance.now() - startedAt;
+
+      expect(reopened.db.isOpen).toBe(true);
+      expect(elapsedMs).toBeLessThan(1_000);
+    } finally {
+      writer.exec("ROLLBACK;");
+      writer.close();
+      if (reopened) {
+        closeOpenClawAgentDatabaseByPath(reopened.path);
+      }
+    }
+  });
+
+  it.each([
+    {
+      replacement: "non-agent schema role",
+      role: "global",
+      agentId: null,
+      expectedError: /schema role global; expected agent/iu,
+    },
+    {
+      replacement: "different agent id",
+      role: "agent",
+      agentId: "worker-2",
+      expectedError: /belongs to agent worker-2; requested agent worker-1/iu,
+    },
+  ])(
+    "rejects a validated reopen after $replacement replacement before write-capable checks",
+    ({ role, agentId, expectedError }) => {
+      const stateDir = createTempStateDir();
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+      const databasePath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
+      expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
+      createCacheExpiryIndexPhysicalDrift(databasePath);
+
+      const { DatabaseSync } = requireNodeSqlite();
+      const writer = new DatabaseSync(databasePath);
+      try {
+        writer
+          .prepare("UPDATE schema_meta SET role = ?, agent_id = ? WHERE meta_key = 'primary'")
+          .run(role, agentId);
+        writer.exec("PRAGMA journal_mode = WAL; BEGIN IMMEDIATE;");
+
+        const startedAt = performance.now();
+        let failure: unknown;
+        try {
+          openOpenClawAgentDatabase({ agentId: "worker-1", env });
+        } catch (error) {
+          failure = error;
+        }
+        const elapsedMs = performance.now() - startedAt;
+
+        expect(failure).toBeInstanceOf(Error);
+        if (!(failure instanceof Error)) {
+          throw new Error("validated owner replacement reopen unexpectedly succeeded");
+        }
+        expect(failure.message).toMatch(expectedError);
+        expect(elapsedMs).toBeLessThan(1_000);
+      } finally {
+        writer.exec("ROLLBACK;");
+        writer.close();
+      }
+
+      expect(isOpenClawAgentDatabaseOpen(databasePath)).toBe(false);
+      expect(
+        openOpenClawStateDatabase({ env })
+          .db.prepare("SELECT lease_id FROM agent_database_leases WHERE path = ?")
+          .get(databasePath),
+      ).toBeUndefined();
+
+      const restored = new DatabaseSync(databasePath);
+      try {
+        expect(restored.prepare("PRAGMA integrity_check('cache_entries')").all()).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              integrity_check: expect.stringMatching(/idx_agent_cache_expiry/),
+            }),
+          ]),
+        );
+        restored
+          .prepare(
+            "UPDATE schema_meta SET role = 'agent', agent_id = 'worker-1' WHERE meta_key = 'primary'",
+          )
+          .run();
+      } finally {
+        restored.close();
+      }
+
+      nowSpy.mockReturnValue(2_000);
+      try {
+        openOpenClawAgentDatabase({ agentId: "worker-1", env });
+        expect(
+          listOpenClawRegisteredAgentDatabases({ env }).find(
+            (entry) => entry.agentId === "worker-1" && entry.path === databasePath,
+          ),
+        ).toMatchObject({ lastSeenAt: 2_000 });
+      } finally {
+        nowSpy.mockRestore();
+      }
+    },
+  );
+
   it.each([0, 16])(
     "rechecks the media version guard at v%d after a validated handle is physically reopened",
     (version) => {
@@ -4640,11 +4758,11 @@ describe("openclaw agent database", () => {
     );
   });
 
-  it("latches newer per-agent schema failures before integrity scans", () => {
+  it("latches newer per-agent schema failures on a validated physical reopen", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const databasePath = openOpenClawAgentDatabase({ agentId: "worker-1", env }).path;
-    closeOpenClawAgentDatabasesForTest();
+    expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
     closeOpenClawStateDatabaseForTest();
     createUnsafeIndexDrift(databasePath);
     const { DatabaseSync } = requireNodeSqlite();
@@ -4662,6 +4780,24 @@ describe("openclaw agent database", () => {
       name: "SqliteSchemaVersionError",
       message: expect.stringContaining("https://docs.openclaw.ai/reference/database-schemas"),
     });
+    expect(isOpenClawAgentDatabaseOpen(databasePath)).toBe(false);
+    expect(
+      openOpenClawStateDatabase({ env })
+        .db.prepare("SELECT lease_id FROM agent_database_leases WHERE path = ?")
+        .get(databasePath),
+    ).toBeUndefined();
+    const stillDrifted = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(
+        stillDrifted
+          .prepare("SELECT sql FROM sqlite_schema WHERE name = 'unsafe_index_records_value'")
+          .get(),
+      ).toEqual({
+        sql: "CREATE INDEX unsafe_index_records_value ON unsafe_index_records(alternate_value)",
+      });
+    } finally {
+      stillDrifted.close();
+    }
 
     for (const candidate of [databasePath, `${databasePath}-wal`, `${databasePath}-shm`]) {
       fs.rmSync(candidate, { force: true });
@@ -4675,7 +4811,18 @@ describe("openclaw agent database", () => {
     expect(secondFailure).toBe(firstFailure);
 
     clearOpenClawAgentDatabaseOpenFailure(databasePath);
-    expect(openOpenClawAgentDatabase({ agentId: "worker-1", env }).db.isOpen).toBe(true);
+    const reopened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    expect(readSqliteNumberPragma(reopened.db, "user_version")).toBe(OPENCLAW_AGENT_SCHEMA_VERSION);
+    expect(
+      reopened.db
+        .prepare("SELECT role, agent_id FROM schema_meta WHERE meta_key = 'primary'")
+        .get(),
+    ).toEqual({ role: "agent", agent_id: "worker-1" });
+    expect(
+      listOpenClawRegisteredAgentDatabases({ env }).find(
+        (entry) => entry.agentId === "worker-1" && entry.path === databasePath,
+      ),
+    ).toBeDefined();
   });
 
   it("closes cached handles on normal process exit so no stale WAL remains", () => {

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -4522,6 +4522,39 @@ describe("openclaw agent database", () => {
     );
   });
 
+  it("converges same-version divergence after a validated handle is physically reopened", () => {
+    const stateDir = createTempStateDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const database = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    const databasePath = database.path;
+    const versionBefore = readSqliteNumberPragma(database.db, "user_version");
+    expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const divergent = new DatabaseSync(databasePath);
+    try {
+      divergent.exec("ALTER TABLE session_nodes DROP COLUMN project_id;");
+      expect(readSqliteNumberPragma(divergent, "user_version")).toBe(versionBefore);
+      expect(
+        divergent
+          .prepare("PRAGMA table_info(session_nodes)")
+          .all()
+          .some((row) => (row as { name?: unknown }).name === "project_id"),
+      ).toBe(false);
+    } finally {
+      divergent.close();
+    }
+
+    const reopened = openOpenClawAgentDatabase({ agentId: "worker-1", env });
+    expect(readSqliteNumberPragma(reopened.db, "user_version")).toBe(versionBefore);
+    expect(
+      reopened.db
+        .prepare("PRAGMA table_info(session_nodes)")
+        .all()
+        .some((row) => (row as { name?: unknown }).name === "project_id"),
+    ).toBe(true);
+  });
+
   it("reopens a validated current-schema database promptly while a WAL writer is active", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -325,17 +325,15 @@ export function openOpenClawAgentDatabase(
     const db = openNodeSqliteDatabase(pathname);
     enableNodeSqliteKyselyStatementCache(db);
     openedDb = db;
-    // Eviction churn must avoid schema/registry busy waits on the event loop while
-    // reconcile workers hold write transactions on these same agent databases.
+    // Eviction churn must avoid migration/convergence and registry busy waits.
+    // Version and owner can change while evicted, so their read-only gates run on every open.
     const isValidatedReopen = validatedAgentDatabasePaths.get(pathname) === agentId;
     const walMaintenance = (() => {
       let maintenance: OpenClawAgentDatabase["walMaintenance"] | undefined;
       try {
         db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-        if (!isValidatedReopen) {
-          assertSupportedAgentSchemaVersion(db, pathname);
-          assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(db), agentId, pathname);
-        }
+        assertSupportedAgentSchemaVersion(db, pathname);
+        assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(db), agentId, pathname);
         // Integrity is not process-stable: the file can be damaged while evicted.
         // This guard is read-only (no busy waits), so every physical open pays it.
         assertAgentDatabaseIntegrityBeforeMutation(db, agentId, pathname);
@@ -358,6 +356,7 @@ export function openOpenClawAgentDatabase(
       } catch (err) {
         maintenance?.close();
         db.close();
+        validatedAgentDatabasePaths.delete(pathname);
         if (
           err instanceof Error &&
           (isSqliteSchemaVersionError(err) || isTerminalSqliteIntegrityError(err))

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -327,7 +327,7 @@ export function openOpenClawAgentDatabase(
     openedDb = db;
     // Eviction churn must avoid migration/convergence and registry busy waits.
     // Version and owner can change while evicted, so their read-only gates run on every open.
-    const isValidatedReopen = validatedAgentDatabasePaths.get(pathname) === agentId;
+    let isValidatedReopen = validatedAgentDatabasePaths.get(pathname) === agentId;
     const walMaintenance = (() => {
       let maintenance: OpenClawAgentDatabase["walMaintenance"] | undefined;
       try {
@@ -336,7 +336,17 @@ export function openOpenClawAgentDatabase(
         assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(db), agentId, pathname);
         // Integrity is not process-stable: the file can be damaged while evicted.
         // This guard is read-only (no busy waits), so every physical open pays it.
-        assertAgentDatabaseIntegrityBeforeMutation(db, agentId, pathname);
+        const requiresCurrentVersionConvergence = assertAgentDatabaseIntegrityBeforeMutation(
+          db,
+          agentId,
+          pathname,
+        );
+        if (isValidatedReopen && requiresCurrentVersionConvergence) {
+          // Same-version replacement can preserve owner/version while dropping additive schema.
+          // Demote trust so the existing full path repairs atomically before exposure.
+          validatedAgentDatabasePaths.delete(pathname);
+          isValidatedReopen = false;
+        }
         assertCanonicalAgentPersistenceVersion(db, pathname);
         configureSqlitePreSchemaPragmas(db, {
           busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,


### PR DESCRIPTION
Fixes #129185

## What Problem This Solves

Fixes an issue where an older OpenClaw process could physically reopen a previously validated agent database after another process upgraded or replaced it.

The initial repair restored schema-version and durable-owner checks, but a same-version replacement could still retain those values while dropping an additive schema surface. In the reproduced case, `session_nodes.project_id` was removed at the current schema version and the trusted reopen exposed that divergent database without convergence.

## Why This Change Was Made

Every physical open continues to run the existing read-only version, owner, and integrity preflight. That preflight now returns its existing pending-current-version result to the writable opener.

When, and only when, a process-trusted reopen reports pending same-version convergence, the opener revokes its trusted classification and routes that same connection through the existing full validation, atomic convergence, and registration path. This preserves same-version repair instead of converting repairable divergence into a hard rejection.

Unchanged trusted reopens still skip convergence and registry refreshes. The rebase preserves schema v18's maintenance-authorized participant-identity migration and `assertCanonicalAgentPersistenceVersion`: runtime v17 opens still fail with Doctor guidance, while repairable divergence at current version 18 remains eligible for ordinary same-version convergence.

No SQLite schema, schema version, migration definition, configuration, protocol, integrity algorithm, or media check changed in this PR.

## User Impact

Operators can no longer receive a writable agent-database handle whose known same-version schema divergence was detected but skipped because the pathname had been validated earlier in the process.

Ordinary-close and LRU-eviction reopens now repair the missing additive column before exposure. Existing durable data is preserved, while unchanged current-schema reopens retain the fast path.

## Evidence

### Reproduction

On exact pre-rebase starting head `6ff3f90526fc284a763d1dee3749c8e93cb19141`:

1. Opened and validated an agent database at its current schema version.
2. Closed the handle normally, retaining process pathname trust.
3. Externally ran `ALTER TABLE session_nodes DROP COLUMN project_id`.
4. Confirmed `user_version` was unchanged and `project_id` was absent.
5. Reopened through the trusted path.

Before the correction:

- Ordinary-close reopen exposed the schema with `project_id` still absent.
- Eviction-path reopen exposed the same divergence.
- The focused run failed exactly those two assertions; 119 existing tests passed and 6 skipped.

### Test Changes

Added:

- `converges same-version divergence after a validated handle is physically reopened`

Modified:

- `reopens an evicted database without losing durable rows`
  - Externally removes `project_id` after eviction.
  - Verifies convergence restores the column and preserves the durable row.

Deleted:

- None.

Audited and retained unchanged:

- `reopens a validated current-schema database promptly while a WAL writer is active`
  - Equivalent proof that unchanged trusted reopens do not rerun convergence.
- `registers a first open without refreshing registry metadata after eviction`
  - Proves unchanged eviction reopens do not enter the full registration path.

### Verification

Exact correction candidate:

- Rebased base: `1186e6a6f3d45494e1d2c22b626480471713797f`
- Commit: `d498fba5a3c4ec7b8e2042b4245c982be928c623`
- Tree: `c392e6959774908b41f1714688362e322f8c72ff`
- Testbox: `tbx_01m14a08q1h707h87pd43jdg0h`

Candidate identity proof reconstructed the exact rebased tree from the pinned base, verified all four changed blobs, and ran candidate-bound `git diff --check`.

- `pnpm test src/state/openclaw-agent-db.test.ts src/state/openclaw-agent-db.cache-eviction.test.ts`
  - 2 files passed
  - 121 tests passed
  - 6 skipped
- `pnpm check:changed --base 1186e6a6f3d45494e1d2c22b626480471713797f --head 1186e6a6f3d45494e1d2c22b626480471713797f -- <four PR paths>`
  - Core and core-test lanes passed

Rebased PR delta:

- Production: +19/-9, net +10
- Tests: +198/-3, net +195

The rebase range-diff preserves both commits. The only conflict adaptations were v18's fixed media-version cases `[0, 16]`, its renamed persistence guard, and the moved schema-helper context.

Workloop correction lock creation failed repeatedly, so the user-authorized direct fallback was used in the required retained checkout with exact-tree Testbox proof and a full self-review.
