### PR TITLE
fix(plugins): avoid duplicate manifest reads during status

### DIFF
--- a/src/plugins/status-snapshot.ts
+++ b/src/plugins/status-snapshot.ts
@@ -17,11 +17,10 @@ import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
 import { tracePluginLifecyclePhase } from "./plugin-lifecycle-trace.js";
-import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
-import {
-  loadPluginRegistrySnapshotWithMetadata,
-  type PluginRegistrySnapshotDiagnostic,
-  type PluginRegistrySnapshotSource,
+import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+import type {
+  PluginRegistrySnapshotDiagnostic,
+  PluginRegistrySnapshotSource,
 } from "./plugin-registry.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRecord, PluginRegistry } from "./registry-types.js";
@@ -179,27 +178,22 @@ export function buildPluginRegistrySnapshotReport(
     env,
     workspaceDir: params?.workspaceDir,
   });
-  const result = tracePluginLifecyclePhase(
+  // Status may reuse lifecycle metadata, but must not publish its own discovery as current.
+  const metadataSnapshot = tracePluginLifecyclePhase(
     "plugin registry snapshot",
     () =>
-      loadPluginRegistrySnapshotWithMetadata({
+      loadPluginMetadataSnapshot({
         config,
-        env: params?.env,
+        env,
         workspaceDir: workspace.workspaceDir,
       }),
     { surface: "status" },
   );
-  const metadataSnapshot = resolvePluginMetadataSnapshot({
-    index: result.snapshot,
-    config,
-    env,
-    workspaceDir: workspace.workspaceDir,
-  });
-  const manifestByPluginId = metadataSnapshot.byPluginId;
+  const { index, byPluginId: manifestByPluginId, registryDiagnostics } = metadataSnapshot;
   const diagnostics = [
-    ...result.snapshot.diagnostics,
+    ...index.diagnostics,
     ...collectPluginCapabilityConsentDiagnostics({
-      index: result.snapshot,
+      index,
       manifests: manifestByPluginId,
     }),
   ];
@@ -207,11 +201,12 @@ export function buildPluginRegistrySnapshotReport(
     workspaceDir: workspace.workspaceDir,
     workspaceScope: workspace.workspaceScope,
     ...createEmptyPluginRegistry(),
-    plugins: result.snapshot.plugins.map((plugin) =>
+    plugins: index.plugins.map((plugin) =>
       buildPluginRecordFromInstalledIndex(plugin, manifestByPluginId.get(plugin.pluginId)),
     ),
     diagnostics: appendPluginControlPlaneWorkspaceDiagnostic(diagnostics, workspace),
-    registrySource: result.source,
-    registryDiagnostics: result.diagnostics,
+    registrySource:
+      metadataSnapshot.registrySource ?? (registryDiagnostics.length > 0 ? "derived" : "provided"),
+    registryDiagnostics,
   });
 }

--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -2,14 +2,20 @@ import fs from "node:fs";
 import path from "node:path";
 // Covers plugin status snapshots built from registry state.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { buildPluginCapabilitySummary, computeDeclaredSurfaceHash } from "./capability-summary.js";
+import {
+  getCurrentPluginMetadataSnapshot,
+  setCurrentPluginMetadataSnapshot,
+} from "./current-plugin-metadata-snapshot.js";
 import {
   readPersistedInstalledPluginIndex,
   writePersistedInstalledPluginIndexSync,
 } from "./installed-plugin-index-store.js";
 import { loadInstalledPluginIndex } from "./installed-plugin-index.js";
+import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import { refreshPluginRegistry } from "./plugin-registry.js";
 import { collectPluginCapabilityConsentDiagnostics } from "./status-snapshot.js";
 import {
@@ -53,6 +59,8 @@ function createGlobalPluginFixture(stateDir: string, pluginId: string) {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
+  clearPluginMetadataLifecycleCaches();
   cleanupTrackedTempDirs(tempDirs);
 });
 
@@ -188,6 +196,8 @@ describe("buildPluginRegistrySnapshotReport", () => {
     });
 
     for (const config of [makeConfig(false), makeConfig(true)]) {
+      const scoped = loadPluginMetadataSnapshot({ config, env, workspaceDir: mainWorkspace });
+      setCurrentPluginMetadataSnapshot(scoped, { config, env, workspaceDir: mainWorkspace });
       const reports = [
         buildPluginRegistrySnapshotReport({ config, env }),
         buildPluginSnapshotReport({ config, env }),
@@ -452,18 +462,87 @@ describe("buildPluginRegistrySnapshotReport", () => {
     });
   });
 
-  it("reconstructs list metadata from indexed manifests without importing plugin runtime", () => {
-    const fixture = createColdPluginFixture({
-      rootDir: makeTempDir(),
-      pluginId: "indexed-demo",
-      packageName: "@example/openclaw-indexed-demo",
-      packageVersion: "9.8.7",
-      manifest: {
+  it.each(
+    (["missing", "stale-policy", "stale-source", "persisted"] as const).flatMap((state) =>
+      (["selected", "omitted"] as const).map((workspaceScope) => ({ state, workspaceScope })),
+    ),
+  )(
+    "reuses prepared list metadata with $state registry and $workspaceScope workspace",
+    ({ state, workspaceScope }) => {
+      const tempRoot = fs.realpathSync(makeTempDir());
+      const stateDir = path.join(tempRoot, "state");
+      const workspaceDir = workspaceScope === "selected" ? tempRoot : undefined;
+      const enabled = workspaceScope === "selected";
+      const fixture = createColdPluginFixture({
+        rootDir: tempRoot,
+        pluginId: "indexed-demo",
+        packageName: "@example/openclaw-indexed-demo",
+        packageVersion: "9.8.7",
+        manifest: {
+          id: "indexed-demo",
+          name: "Indexed Demo",
+          description: "Manifest-backed list metadata",
+          version: "1.2.3",
+          providers: ["indexed-provider"],
+          contracts: {
+            agentToolResultMiddleware: ["openclaw", "codex"],
+            speechProviders: ["indexed-speech-provider"],
+            realtimeTranscriptionProviders: ["indexed-transcription-provider"],
+            realtimeVoiceProviders: ["indexed-voice-provider"],
+            tools: ["indexed_echo", "indexed_search", "indexed_echo"],
+            trustedToolPolicies: ["workflow-budget"],
+          },
+          commandAliases: [{ name: "indexed-demo" }],
+          configSchema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {},
+          },
+        },
+      });
+
+      const config = {
+        agents: { ownership: "explicit" as const, entries: { first: {}, second: {} } },
+        plugins: {
+          load: { paths: [fixture.rootDir] },
+          entries: { [fixture.pluginId]: { enabled } },
+        },
+      };
+      const env = {
+        ...createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: makeTempDir() }),
+        OPENCLAW_STATE_DIR: stateDir,
+      };
+      if (state !== "missing") {
+        const index = loadInstalledPluginIndex({ config, env, workspaceDir });
+        if (state === "stale-policy") {
+          index.policyHash = "stale-policy";
+        } else if (state === "stale-source") {
+          for (const plugin of index.plugins) {
+            plugin.packageVersion = "0.0.0";
+          }
+        }
+        writePersistedInstalledPluginIndexSync(index, { stateDir });
+      }
+      const open = vi.spyOn(fs, "openSync");
+      const report = buildPluginRegistrySnapshotReport({ config, env, workspaceDir });
+      const manifestOpens = open.mock.calls.filter(
+        ([file]) => file === path.join(fixture.rootDir, "openclaw.plugin.json"),
+      ).length;
+      open.mockRestore();
+
+      expect(report.plugins).toHaveLength(1);
+      expectFields(requirePlugin(report.plugins, "indexed-demo"), {
         id: "indexed-demo",
         name: "Indexed Demo",
         description: "Manifest-backed list metadata",
-        version: "1.2.3",
-        providers: ["indexed-provider"],
+        version: "9.8.7",
+        format: "openclaw",
+        providerIds: ["indexed-provider"],
+        speechProviderIds: ["indexed-speech-provider"],
+        realtimeTranscriptionProviderIds: ["indexed-transcription-provider"],
+        realtimeVoiceProviderIds: ["indexed-voice-provider"],
+        toolNames: ["indexed_echo", "indexed_search"],
+        configSchema: true,
         contracts: {
           agentToolResultMiddleware: ["openclaw", "codex"],
           speechProviders: ["indexed-speech-provider"],
@@ -472,49 +551,88 @@ describe("buildPluginRegistrySnapshotReport", () => {
           tools: ["indexed_echo", "indexed_search", "indexed_echo"],
           trustedToolPolicies: ["workflow-budget"],
         },
-        commandAliases: [{ name: "indexed-demo" }],
-        configSchema: {
-          type: "object",
-          additionalProperties: false,
-          properties: {},
-        },
-      },
-    });
+        commands: ["indexed-demo"],
+        source: fs.realpathSync(fixture.runtimeSource),
+        enabled,
+        status: enabled ? "loaded" : "disabled",
+      });
+      expect(report.workspaceDir).toBe(workspaceDir);
+      expect(report.workspaceScope).toBe(workspaceScope);
+      expect(report.registrySource).toBe(state === "persisted" ? "persisted" : "derived");
+      expect(report.registryDiagnostics).toEqual(
+        state === "persisted"
+          ? []
+          : [
+              {
+                level: state === "missing" ? "info" : "warn",
+                code: `persisted-registry-${state}`,
+                message: expect.any(String),
+              },
+            ],
+      );
+      expect(report.diagnostics).toEqual(
+        workspaceScope === "selected"
+          ? []
+          : [expect.objectContaining({ level: "warn", code: "workspace-scope-omitted" })],
+      );
+      expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+      expect(getCurrentPluginMetadataSnapshot({ config, env, workspaceDir })).toBeUndefined();
+      // Discovery, manifest validation, and index hashing already read this manifest.
+      // Status must carry that prepared metadata rather than read it a fourth time.
+      expect(manifestOpens).toBe(3);
+    },
+  );
 
-    const report = buildPluginRegistrySnapshotReport({
-      config: {
-        plugins: {
-          load: { paths: [fixture.rootDir] },
-        },
-      },
-    });
+  it.each([false, true])(
+    "reuses current metadata without a recorded source (diagnostics: %s)",
+    (hasDiagnostics) => {
+      const rootDir = fs.realpathSync(makeTempDir());
+      const fixture = createColdPluginFixture({
+        rootDir,
+        pluginId: "current-demo",
+        packageJson: { description: "Package-backed summary" },
+      });
+      const config = createColdPluginConfig(rootDir, fixture.pluginId);
+      const env = {
+        ...createColdPluginHermeticEnv(rootDir, { bundledPluginsDir: makeTempDir() }),
+        OPENCLAW_STATE_DIR: path.join(rootDir, "state"),
+      };
+      const params = { config, env, workspaceDir: rootDir };
+      const coldReport = buildPluginRegistrySnapshotReport(params);
+      const { registrySource: _registrySource, ...current } = loadPluginMetadataSnapshot(params);
+      if (!hasDiagnostics) {
+        current.registryDiagnostics = [];
+      }
+      setCurrentPluginMetadataSnapshot(current, params);
+      const open = vi.spyOn(fs, "openSync");
 
-    expectFields(requirePlugin(report.plugins, "indexed-demo"), {
-      id: "indexed-demo",
-      name: "Indexed Demo",
-      description: "Manifest-backed list metadata",
-      version: "9.8.7",
-      format: "openclaw",
-      providerIds: ["indexed-provider"],
-      speechProviderIds: ["indexed-speech-provider"],
-      realtimeTranscriptionProviderIds: ["indexed-transcription-provider"],
-      realtimeVoiceProviderIds: ["indexed-voice-provider"],
-      toolNames: ["indexed_echo", "indexed_search"],
-      configSchema: true,
-      contracts: {
-        agentToolResultMiddleware: ["openclaw", "codex"],
-        speechProviders: ["indexed-speech-provider"],
-        realtimeTranscriptionProviders: ["indexed-transcription-provider"],
-        realtimeVoiceProviders: ["indexed-voice-provider"],
-        tools: ["indexed_echo", "indexed_search", "indexed_echo"],
-        trustedToolPolicies: ["workflow-budget"],
-      },
-      commands: ["indexed-demo"],
-      source: fs.realpathSync(fixture.runtimeSource),
-      status: "loaded",
-    });
-    expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
-  });
+      const report = buildPluginRegistrySnapshotReport(params);
+      const metadataOpens = open.mock.calls.filter(
+        ([file]) =>
+          file === path.join(rootDir, "openclaw.plugin.json") ||
+          file === path.join(rootDir, "package.json"),
+      );
+      open.mockRestore();
+
+      expectFields(requirePlugin(report.plugins, fixture.pluginId), {
+        name: "Cold Control Plane",
+        description: "Package-backed summary",
+        providerIds: [fixture.providerId],
+        status: "loaded",
+      });
+      expect(report.plugins).toEqual(coldReport.plugins);
+      expect(report.registrySource).toBe(hasDiagnostics ? "derived" : "provided");
+      expect(report.registryDiagnostics).toEqual(
+        hasDiagnostics
+          ? [expect.objectContaining({ level: "info", code: "persisted-registry-missing" })]
+          : [],
+      );
+      expect(report.diagnostics).toEqual([]);
+      expect(metadataOpens).toEqual([]);
+      expect(getCurrentPluginMetadataSnapshot(params)).toBe(current);
+      expect(isColdPluginRuntimeLoaded(fixture)).toBe(false);
+    },
+  );
 
   it("discovers the configured default-agent workspace without importing plugin runtime", () => {
     const tempRoot = makeTempDir();


### PR DESCRIPTION
Related: #130860 (the independent investigation that identified this handoff; this is not a startup-RSS ceiling repair).

## What Problem This Solves

Fixes an issue where plugin-list and metadata status reports reread every plugin manifest during cold discovery even though discovery had already prepared the same metadata. The index-only handoff also discarded package-backed descriptions that were available in the prepared snapshot.

## Why This Change Was Made

Build the report from one canonical `loadPluginMetadataSnapshot` result, carrying the installed index, prepared manifest registry, source, and registry diagnostics together instead of reconstructing manifests from the index. Use the loader rather than the adopting resolver so status can reuse a lifecycle-owned snapshot without publishing report-owned discovery as process-wide metadata.

The existing metadata-only/no-runtime-import boundary, selected and omitted workspace behavior, registry provenance, disabled-plugin metadata, capability-consent diagnostics, and dependency-health projection remain intact. No new cache, configuration, schema, dependency, or compatibility surface.

## User Impact

Plugin inventory avoids one redundant manifest open per plugin. A fresh 151-plugin measurement reduced manifest opens from **604 to 453 (25%)**. Identity and enablement are unchanged; a full report comparison found only **74 restored package-backed descriptions**, each checked against the package and manifest files. All other report fields were unchanged.

This change does **not** claim lower RSS or resolve the 401 MB CI startup-memory ceiling. It repairs prepared-metadata ownership, not the independent memory-budget investigation.

## Evidence

- Real filesystem boundary regression across missing, stale-policy, stale-source, and persisted registries, each with selected and omitted workspace scope: **8 failures before the repair** (`expected 4 to be 3` manifest opens), **8 passes afterward**.
- Extended existing fixtures rather than adding a test-only production seam. Assertions cover report metadata, diagnostic channels, disabled plugins, no global snapshot adoption, incompatible workspace-snapshot exclusion, warm snapshot provenance, cold/warm package-description parity, and runtime-import sentinels.
- **134 focused tests passed** across the report, cold-import, dependency-health, metadata-snapshot, current-snapshot, and registry-snapshot suites. The final report suite rerun passed **31 tests** after correcting an unchecked array access in test setup.
- Changed-file formatting, production/test typechecks, lint, dependency/boundary/storage guards, and import-cycle checks passed. No runtime import cycles.
- Full build passed, including CLI bootstrap imports, built plugin control-plane loads, and plugin SDK export checks. No ineffective dynamic-import warning.
- A real built `plugins list --json` invocation under isolated temporary HOME/config/state returned 151 plugins and exactly matched the corrected source report. No operator Gateway or live state was touched.
- Fresh Codex autoreview completed before publication with no accepted/actionable blocking findings.

Validation commands:

```bash
node scripts/run-vitest.mjs src/plugins/status.registry-snapshot.test.ts -t 'reuses prepared list metadata'
```

```bash
node scripts/run-vitest.mjs src/plugins/status.registry-snapshot.test.ts src/plugins/status-snapshot.cold-imports.test.ts src/plugins/status.dependency-health.test.ts src/plugins/plugin-metadata-snapshot.test.ts src/plugins/current-plugin-metadata-snapshot.test.ts src/plugins/plugin-registry-snapshot.test.ts
```

```bash
node scripts/check-changed.mjs -- src/plugins/status-snapshot.ts src/plugins/status.registry-snapshot.test.ts
```

```bash
pnpm build
```

```bash
pnpm --silent openclaw plugins list --json
```

Production LOC: **+15/-20 (net -5)**. Tests: **+169/-51 (net +118)**, including indentation changes from parameterizing existing coverage. Two files; no changelog generation or release changes.

Separate follow-up: model-list contribution-owner lookup also passes an index where a prepared snapshot is available. That path was source-inspected but not measured or changed here.

AI-assisted; the owner boundary, full report differences, and validation results were inspected before landing.
