### PR TITLE
fix(ui): unify tooltip appearance and dismissal

### DIFF
--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -10,7 +10,7 @@ import "../components/github-link-hovercard-registration.ts";
 import "../components/login-gate.ts";
 import "../components/openclaw-mascot.ts";
 import { renderLazyElementState } from "../components/lazy-view-error.ts";
-import { installNativeTitleGuard } from "../components/tooltip.ts";
+import { installTitleTooltips } from "../components/tooltip-title.ts";
 import { t } from "../i18n/index.ts";
 import { formatUiError } from "../lib/format-error.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
@@ -120,7 +120,7 @@ export class OpenClawApp extends OpenClawLightDomElement {
         () => (this.terminalOnly ? this.context?.theme : undefined),
         (theme, notify) => theme.subscribe(notify),
       )
-      .effect(() => this.ownerDocument, installNativeTitleGuard);
+      .effect(() => this.ownerDocument, installTitleTooltips);
   }
 
   override connectedCallback() {

--- a/ui/src/components/tooltip-content.ts
+++ b/ui/src/components/tooltip-content.ts
@@ -1,0 +1,67 @@
+export function normalizeTooltipText(text: string) {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+export function isTooltipTriggerElement(element: unknown): element is HTMLElement | SVGElement {
+  return (
+    typeof element === "object" &&
+    element !== null &&
+    "namespaceURI" in element &&
+    (element.namespaceURI === "http://www.w3.org/1999/xhtml" ||
+      element.namespaceURI === "http://www.w3.org/2000/svg")
+  );
+}
+
+function isElementNode(node: Node): node is Element {
+  return node.nodeType === Node.ELEMENT_NODE;
+}
+
+export function collectTooltipVisibleText(element: Element): string {
+  const style = element.ownerDocument.defaultView?.getComputedStyle(element);
+  if (
+    element.hasAttribute("hidden") ||
+    style?.display === "none" ||
+    style?.contentVisibility === "hidden"
+  ) {
+    return "";
+  }
+  const rendersOwnText =
+    style?.visibility !== "hidden" &&
+    style?.visibility !== "collapse" &&
+    (style?.display === "contents" ||
+      typeof element.checkVisibility !== "function" ||
+      element.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true }));
+  return [...element.childNodes]
+    .map((node) => {
+      if (isElementNode(node)) {
+        return collectTooltipVisibleText(node);
+      }
+      return node.nodeType === Node.TEXT_NODE && rendersOwnText ? (node.textContent ?? "") : "";
+    })
+    .join(" ");
+}
+
+function hasTooltipOverflow(element: Element) {
+  return (
+    element.matches("[data-tooltip-overflow]") ||
+    element.scrollWidth > element.clientWidth ||
+    element.scrollHeight > element.clientHeight
+  );
+}
+
+export function isTooltipTextRedundant(content: string, trigger: Element) {
+  const tooltipText = normalizeTooltipText(content);
+  const triggerText = normalizeTooltipText(collectTooltipVisibleText(trigger));
+  if (!tooltipText || !triggerText.includes(tooltipText)) {
+    return false;
+  }
+  if (hasTooltipOverflow(trigger)) {
+    return false;
+  }
+  for (const element of trigger.querySelectorAll("*")) {
+    if (isTooltipTriggerElement(element) && hasTooltipOverflow(element)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/ui/src/components/tooltip-title.ts
+++ b/ui/src/components/tooltip-title.ts
@@ -1,0 +1,187 @@
+import "./tooltip.ts";
+import { collectTooltipVisibleText, isTooltipTriggerElement } from "./tooltip-content.ts";
+
+function titleNamesElement(element: Element) {
+  if (
+    element.hasAttribute("aria-label") ||
+    element.hasAttribute("aria-labelledby") ||
+    element.matches("img[alt], input[alt]") ||
+    collectTooltipVisibleText(element).trim()
+  ) {
+    return false;
+  }
+  if (
+    element instanceof HTMLInputElement ||
+    element instanceof HTMLTextAreaElement ||
+    element instanceof HTMLSelectElement
+  ) {
+    return (
+      !element.labels?.length &&
+      !element.matches('input[type="button"], input[type="submit"], input[type="reset"]')
+    );
+  }
+  return true;
+}
+
+/** `title` remains a declarative hint source; only the shared Tooltip renders it. */
+export function installTitleTooltips(ownerDocument: Document) {
+  let tooltip: HTMLElementTagNameMap["openclaw-tooltip"] | null = null;
+  let active: {
+    anchor: HTMLElement | SVGElement;
+    title: string | null;
+    label: string | null;
+    pointer: boolean;
+    focus: boolean;
+  } | null = null;
+
+  const restore = () => {
+    if (!active) {
+      return;
+    }
+    const { anchor, title, label } = active;
+    active = null;
+    observer.disconnect();
+    anchor.removeEventListener("pointerleave", handlePointerLeave);
+    anchor.removeEventListener("focusout", handleFocusOut);
+    if (title !== null && anchor.getAttribute("title") === "") {
+      anchor.setAttribute("title", title);
+    }
+    if (label !== null && anchor.getAttribute("aria-label") === label) {
+      anchor.removeAttribute("aria-label");
+    }
+    if (tooltip) {
+      tooltip.anchor = null;
+      tooltip.remove();
+    }
+  };
+
+  const content = () => active?.anchor.getAttribute("data-tooltip") ?? active?.title ?? "";
+  const update = (records: MutationRecord[]) => {
+    if (!active) {
+      return;
+    }
+    if (!active.anchor.isConnected) {
+      restore();
+      return;
+    }
+    if (!records.some((record) => active?.anchor.contains(record.target))) {
+      return;
+    }
+    if (
+      records.some((record) => record.target === active?.anchor && record.attributeName === "title")
+    ) {
+      active.title = active.anchor.getAttribute("title");
+      if (active.title !== null) {
+        active.anchor.setAttribute("title", "");
+        // Drop only our synchronous suppression write; a real empty title must
+        // still clear a disabled reason or a completed action's previous hint.
+        observer.takeRecords();
+      }
+    }
+    if (active.label !== null && active.anchor.getAttribute("aria-label") === active.label) {
+      active.anchor.removeAttribute("aria-label");
+      active.label = null;
+    }
+    if (active.title && titleNamesElement(active.anchor)) {
+      active.label = active.title;
+      active.anchor.setAttribute("aria-label", active.label);
+    }
+    if (tooltip) {
+      // Updates refresh an open hint, never reopen a dismissed action. Reentry
+      // or keyboard focus supplies new intent after an empty title clears it.
+      tooltip.content = content();
+    }
+  };
+  const observer = new MutationObserver(update);
+  const handlePointerLeave = (event: Event) => {
+    if (!active || event.target !== active.anchor) {
+      return;
+    }
+    active.pointer = false;
+    if (!active.focus) {
+      restore();
+    }
+  };
+  const handleFocusOut = (event: Event) => {
+    if (
+      !active ||
+      (event instanceof FocusEvent &&
+        event.relatedTarget instanceof Node &&
+        active.anchor.contains(event.relatedTarget))
+    ) {
+      return;
+    }
+    active.focus = false;
+    if (!active.pointer) {
+      restore();
+    }
+  };
+  const discover = (event: Event) => {
+    if ("pointerType" in event && event.pointerType === "touch") {
+      return;
+    }
+    const elements = event.composedPath().filter(isTooltipTriggerElement);
+    // Iframe titles name browsing contexts, not hints. Explicit wrappers already
+    // own their trigger; adapting those again would create competing popups.
+    const explicit = elements.some((element) => element.localName === "openclaw-tooltip");
+    let anchor: HTMLElement | SVGElement | undefined;
+    for (const element of elements) {
+      if (element.localName === "iframe") {
+        break;
+      }
+      const title = element === active?.anchor ? active.title : element.getAttribute("title");
+      const hint = element.getAttribute("data-tooltip") ?? title;
+      if (hint !== null) {
+        anchor = hint ? element : undefined;
+        break;
+      }
+    }
+    const input = event.type === "focusin" ? "focus" : "pointer";
+    if (anchor === active?.anchor) {
+      if (active) {
+        active[input] = true;
+      }
+      return;
+    }
+    if (!anchor && active?.focus && input === "pointer") {
+      return;
+    }
+    restore();
+    if (!anchor) {
+      return;
+    }
+    const title = anchor.getAttribute("title");
+    const label = title && titleNamesElement(anchor) ? title : null;
+    active = { anchor, title, label, pointer: input === "pointer", focus: input === "focus" };
+    if (title !== null) {
+      // An empty title blocks browser inheritance without exposing the next ancestor.
+      anchor.setAttribute("title", "");
+    }
+    if (label !== null) {
+      anchor.setAttribute("aria-label", label);
+    }
+    anchor.addEventListener("pointerleave", handlePointerLeave);
+    anchor.addEventListener("focusout", handleFocusOut);
+    observer.observe(anchor, { attributes: true, attributeFilter: ["title", "data-tooltip"] });
+    observer.observe(ownerDocument, { childList: true, subtree: true });
+    const root = anchor.getRootNode();
+    if (root instanceof ShadowRoot) {
+      observer.observe(root, { childList: true, subtree: true });
+    }
+    if (!explicit) {
+      tooltip ??= ownerDocument.createElement("openclaw-tooltip");
+      const mount =
+        elements.find((element) => element.localName === "openclaw-modal-dialog") ??
+        ownerDocument.body;
+      mount.append(tooltip);
+      tooltip.previewForAnchor(anchor, content(), input);
+    }
+  };
+  ownerDocument.addEventListener("pointerover", discover, true);
+  ownerDocument.addEventListener("focusin", discover, true);
+  return () => {
+    ownerDocument.removeEventListener("pointerover", discover, true);
+    ownerDocument.removeEventListener("focusin", discover, true);
+    restore();
+  };
+}

--- a/ui/src/components/tooltip.test.ts
+++ b/ui/src/components/tooltip.test.ts
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { installNativeTitleGuard } from "./tooltip.ts";
+import { installTitleTooltips } from "./tooltip-title.ts";
 
 type TooltipElement = HTMLElement & {
   closeDelay: number;
@@ -44,8 +44,11 @@ function focusTrigger(trigger: HTMLElement) {
   trigger.dispatchEvent(new FocusEvent("focusin", { bubbles: true, composed: true }));
 }
 
-function dispatchMousePointer(target: EventTarget, type: "pointerenter" | "pointerleave") {
-  const event = new MouseEvent(type, { bubbles: true, buttons: 0 });
+function dispatchMousePointer(
+  target: EventTarget,
+  type: "pointerenter" | "pointerleave" | "pointerover" | "pointerdown",
+) {
+  const event = new MouseEvent(type, { bubbles: true, composed: true, buttons: 0 });
   Object.defineProperty(event, "pointerType", { value: "mouse" });
   target.dispatchEvent(event);
 }
@@ -303,6 +306,69 @@ describe("openclaw-tooltip", () => {
     expectOpenCount(1);
   });
 
+  it("pins reveal-only hints until toggled, dismissed, or replaced", async () => {
+    const provider = createProvider();
+    const reveal = createRichTooltip("Message context");
+    const action = createTooltip("Reply");
+    const outside = document.createElement("button");
+    reveal.tooltip.openOnClick = true;
+    provider.append(reveal.tooltip, action.tooltip, outside);
+    document.body.append(provider);
+    await Promise.all([reveal.tooltip.updateComplete, action.tooltip.updateComplete]);
+
+    hoverTrigger(reveal.trigger);
+    vi.advanceTimersByTime(150);
+    dispatchMousePointer(reveal.trigger, "pointerdown");
+    reveal.trigger.click();
+    dispatchMousePointer(reveal.trigger, "pointerleave");
+    vi.advanceTimersByTime(500);
+    expectOpenCount(1);
+
+    dispatchMousePointer(reveal.trigger, "pointerdown");
+    reveal.trigger.click();
+    expectOpenCount(0);
+
+    reveal.trigger.click();
+    await webAwesomeTooltip(reveal.tooltip)?.updateComplete;
+    const escape = new KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true });
+    document.dispatchEvent(escape);
+    expectOpenCount(0);
+    expect(escape.defaultPrevented).toBe(true);
+    await webAwesomeTooltip(reveal.tooltip)?.updateComplete;
+
+    reveal.trigger.click();
+    dispatchMousePointer(outside, "pointerdown");
+    expectOpenCount(0);
+
+    reveal.trigger.click();
+    focusTrigger(action.trigger);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    focusTrigger(action.trigger);
+    expect(webAwesomeTooltip(action.tooltip)?.open).toBe(true);
+    expect(webAwesomeTooltip(reveal.tooltip)?.open).toBe(false);
+  });
+
+  it("keeps portaled and provider-scoped tooltips mutually exclusive", async () => {
+    const provider = createProvider();
+    const scoped = createTooltip("Reply");
+    const portaled = createTooltip("Menu action");
+    provider.append(scoped.tooltip);
+    document.body.append(provider, portaled.tooltip);
+    await Promise.all([scoped.tooltip.updateComplete, portaled.tooltip.updateComplete]);
+
+    hoverTrigger(scoped.trigger);
+    vi.advanceTimersByTime(150);
+    expect(webAwesomeTooltip(scoped.tooltip)?.open).toBe(true);
+    hoverTrigger(portaled.trigger);
+    vi.advanceTimersByTime(150);
+    expect(webAwesomeTooltip(portaled.tooltip)?.open).toBe(true);
+    expect(webAwesomeTooltip(scoped.tooltip)?.open).toBe(false);
+    hoverTrigger(scoped.trigger);
+    vi.advanceTimersByTime(150);
+    expect(webAwesomeTooltip(portaled.tooltip)?.open).toBe(false);
+    expect(webAwesomeTooltip(scoped.tooltip)?.open).toBe(true);
+  });
+
   it("honors per-tooltip hover intent while keyboard focus stays immediate", async () => {
     const provider = createProvider();
     const { tooltip, trigger } = createRichTooltip("Intentional hovercard");
@@ -396,6 +462,9 @@ describe("openclaw-tooltip", () => {
     const descriptionId = trigger.getAttribute("aria-describedby") ?? "";
     expect(document.getElementById(descriptionId)?.textContent).toBe("Initial detail");
 
+    tooltip.remove();
+    document.body.append(tooltip);
+    await tooltip.updateComplete;
     detail.textContent = "Updated detail";
     await Promise.resolve();
     expect(document.getElementById(descriptionId)?.textContent).toBe("Updated detail");
@@ -497,16 +566,18 @@ describe("openclaw-tooltip", () => {
   });
 });
 
-describe("native title guard", () => {
+describe("title tooltips", () => {
   let stopGuard: (() => void) | undefined;
 
   beforeEach(() => {
-    stopGuard = installNativeTitleGuard(document);
+    vi.useFakeTimers();
+    stopGuard = installTitleTooltips(document);
   });
 
   afterEach(() => {
     stopGuard?.();
     document.body.replaceChildren();
+    vi.useRealTimers();
   });
 
   it("suppresses a redundant title through open shadow DOM until true pointer leave", () => {
@@ -551,7 +622,7 @@ describe("native title guard", () => {
         trigger.firstElementChild?.setAttribute("hidden", "");
       },
     },
-  ])("keeps $name native titles", ({ title, text, prepare }) => {
+  ])("routes $name titles through the shared tooltip", async ({ title, text, prepare }) => {
     const trigger = document.createElement("button");
     trigger.title = title;
     const label = document.createElement("span");
@@ -562,7 +633,138 @@ describe("native title guard", () => {
 
     label.dispatchEvent(new MouseEvent("pointerover", { bubbles: true, composed: true }));
 
-    expect(trigger.title).toBe(title);
+    expect(trigger.title).toBe("");
+    const tooltip = document.querySelector<TooltipElement>("openclaw-tooltip");
+    expect(tooltip).not.toBeNull();
+    await tooltip!.updateComplete;
+    vi.advanceTimersByTime(150);
+    expect(webAwesomeTooltip(tooltip!)?.open).toBe(true);
+    expect(tooltip!.content).toBe(title);
+  });
+
+  it("shares delay and exclusivity with explicit tooltips without moving titled nodes", async () => {
+    const provider = createProvider();
+    provider.delay = 40;
+    const explicit = createTooltip("Reply");
+    const trigger = document.createElement("button");
+    trigger.title = "Full timestamp";
+    trigger.setAttribute("aria-label", "Message timestamp");
+    provider.append(explicit.tooltip, trigger);
+    document.body.append(provider);
+    await explicit.tooltip.updateComplete;
+
+    dispatchMousePointer(trigger, "pointerover");
+    const delegated = [...document.querySelectorAll<TooltipElement>("openclaw-tooltip")].find(
+      (tooltip) => tooltip !== explicit.tooltip,
+    );
+    expect(delegated).toBeDefined();
+    await delegated!.updateComplete;
+    vi.advanceTimersByTime(39);
+    expectOpenCount(0);
+    vi.advanceTimersByTime(1);
+    expectOpenCount(1);
+    expect(trigger.parentElement).toBe(provider);
+    expect(trigger.getAttribute("aria-label")).toBe("Message timestamp");
+
+    hoverTrigger(explicit.trigger);
+    vi.advanceTimersByTime(0);
+    expect(webAwesomeTooltip(delegated!)?.open).toBe(false);
+    expect(webAwesomeTooltip(explicit.tooltip)?.open).toBe(true);
+  });
+
+  it("tracks dynamic titles and restores the latest title and accessible name", async () => {
+    const trigger = document.createElement("button");
+    trigger.title = "Pin widget";
+    document.body.append(trigger);
+    dispatchMousePointer(trigger, "pointerover");
+    const tooltip = document.querySelector<TooltipElement>("openclaw-tooltip")!;
+    expect(tooltip).not.toBeNull();
+    await tooltip.updateComplete;
+    vi.advanceTimersByTime(150);
+    expect(trigger.getAttribute("aria-label")).toBe("Pin widget");
+
+    trigger.title = "Pinned widget";
+    await Promise.resolve();
+    await tooltip.updateComplete;
+    expect(tooltip.content).toBe("Pinned widget");
+    expect(trigger.title).toBe("");
+    expect(trigger.getAttribute("aria-label")).toBe("Pinned widget");
+
+    dispatchMousePointer(trigger, "pointerleave");
+    expect(trigger.title).toBe("Pinned widget");
+    expect(trigger.hasAttribute("aria-label")).toBe(false);
+    expectOpenCount(0);
+  });
+
+  it.each(["", null])("dismisses an active title when it changes to %j", async (title) => {
+    const trigger = document.createElement("button");
+    trigger.title = "Action unavailable";
+    document.body.append(trigger);
+    dispatchMousePointer(trigger, "pointerover");
+    const tooltip = document.querySelector<TooltipElement>("openclaw-tooltip")!;
+    await tooltip.updateComplete;
+    vi.advanceTimersByTime(150);
+    expectOpenCount(1);
+
+    if (title === null) {
+      trigger.removeAttribute("title");
+    } else {
+      trigger.title = title;
+    }
+    await Promise.resolve();
+    await tooltip.updateComplete;
+    expectOpenCount(0);
+    expect(trigger.hasAttribute("aria-label")).toBe(false);
+    expect(trigger.getAttribute("title")).toBe(title);
+    trigger.title = "Action available";
+    await Promise.resolve();
+    await tooltip.updateComplete;
+    expectOpenCount(0);
+    dispatchMousePointer(trigger, "pointerleave");
+    expect(trigger.getAttribute("title")).toBe("Action available");
+    dispatchMousePointer(trigger, "pointerover");
+    await tooltip.updateComplete;
+    vi.advanceTimersByTime(150);
+    expectOpenCount(1);
+  });
+
+  it("uses the nearest inherited title through shadow DOM and preserves iframe names", async () => {
+    const parent = document.createElement("div");
+    parent.title = "Inherited hint";
+    const shadow = parent.attachShadow({ mode: "open" });
+    const trigger = document.createElement("button");
+    shadow.append(trigger);
+    document.body.append(parent);
+    focusTrigger(trigger);
+    const tooltip = document.querySelector<TooltipElement>("openclaw-tooltip")!;
+    expect(tooltip).not.toBeNull();
+    await tooltip.updateComplete;
+    expect(tooltip.content).toBe("Inherited hint");
+    expect(webAwesomeTooltip(tooltip)?.open).toBe(true);
+
+    const iframe = document.createElement("iframe");
+    iframe.title = "Dashboard document";
+    document.body.append(iframe);
+    dispatchMousePointer(iframe, "pointerover");
+    expect(iframe.title).toBe("Dashboard document");
+  });
+
+  it("adapts SVG data hints through the same popup without changing their accessible name", async () => {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const rect = document.createElementNS(svg.namespaceURI, "rect");
+    rect.setAttribute("data-tooltip", "12 requests");
+    rect.setAttribute("aria-label", "12 requests");
+    svg.append(rect);
+    document.body.append(svg);
+    dispatchMousePointer(rect, "pointerover");
+    const tooltip = document.querySelector<TooltipElement>("openclaw-tooltip")!;
+    expect(tooltip).not.toBeNull();
+    await tooltip.updateComplete;
+    await webAwesomeTooltip(tooltip)?.updateComplete;
+    vi.advanceTimersByTime(150);
+    expect(webAwesomeTooltip(tooltip)?.open).toBe(true);
+    expect(webAwesomeTooltip(tooltip)?.anchor).toBe(rect);
+    expect(rect.getAttribute("aria-label")).toBe("12 requests");
   });
 
   it("restores a removed suppressed trigger when hover moves elsewhere", () => {

--- a/ui/src/components/tooltip.ts
+++ b/ui/src/components/tooltip.ts
@@ -5,6 +5,11 @@ import type WaTooltip from "@awesome.me/webawesome/dist/components/tooltip/toolt
 import { css, html } from "lit";
 import { property, query } from "lit/decorators.js";
 import { OpenClawLitElement } from "../lit/openclaw-element.ts";
+import {
+  isTooltipTextRedundant,
+  isTooltipTriggerElement,
+  normalizeTooltipText,
+} from "./tooltip-content.ts";
 
 const DESCRIBABLE_SELECTOR =
   'a[href], button, input, select, textarea, [tabindex]:not([tabindex="-1"])';
@@ -18,138 +23,10 @@ function createTooltipId() {
   return `openclaw-tooltip-${++nextTooltipId}`;
 }
 
-function normalizeTooltipText(text: string) {
-  return text.replace(/\s+/g, " ").trim();
-}
-
-function isHtmlElement(element: unknown): element is HTMLElement {
-  return (
-    typeof element === "object" &&
-    element !== null &&
-    "namespaceURI" in element &&
-    element.namespaceURI === "http://www.w3.org/1999/xhtml"
-  );
-}
-
-function isElementNode(node: Node): node is Element {
-  return node.nodeType === Node.ELEMENT_NODE;
-}
-
-function collectVisibleText(element: Element): string {
-  const style = element.ownerDocument.defaultView?.getComputedStyle(element);
-  if (
-    element.hasAttribute("hidden") ||
-    style?.display === "none" ||
-    style?.contentVisibility === "hidden"
-  ) {
-    return "";
-  }
-  const rendersOwnText =
-    style?.visibility !== "hidden" &&
-    style?.visibility !== "collapse" &&
-    (style?.display === "contents" ||
-      typeof element.checkVisibility !== "function" ||
-      element.checkVisibility({ checkOpacity: true, checkVisibilityCSS: true }));
-  return [...element.childNodes]
-    .map((node) => {
-      if (isElementNode(node)) {
-        return collectVisibleText(node);
-      }
-      return node.nodeType === Node.TEXT_NODE && rendersOwnText ? (node.textContent ?? "") : "";
-    })
-    .join(" ");
-}
-
-function hasTooltipOverflow(element: HTMLElement) {
-  return (
-    element.matches("[data-tooltip-overflow]") ||
-    element.scrollWidth > element.clientWidth ||
-    element.scrollHeight > element.clientHeight
-  );
-}
-
-function isTooltipTextRedundant(content: string, trigger: HTMLElement) {
-  const tooltipText = normalizeTooltipText(content);
-  const triggerText = normalizeTooltipText(collectVisibleText(trigger));
-  if (!tooltipText || !triggerText.includes(tooltipText)) {
-    return false;
-  }
-  if (hasTooltipOverflow(trigger)) {
-    return false;
-  }
-  for (const element of trigger.querySelectorAll("*")) {
-    if (isHtmlElement(element) && hasTooltipOverflow(element)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-export function installNativeTitleGuard(ownerDocument: Document) {
-  const suppressed = new Map<HTMLElement, string>();
-  const restore = (trigger: HTMLElement) => {
-    const title = suppressed.get(trigger);
-    if (title === undefined) {
-      return;
-    }
-    suppressed.delete(trigger);
-    trigger.removeEventListener("pointerleave", handlePointerLeave);
-    if (trigger.getAttribute("title") === "") {
-      trigger.setAttribute("title", title);
-    }
-  };
-  const handlePointerLeave = (event: Event) => {
-    if (isHtmlElement(event.currentTarget)) {
-      restore(event.currentTarget);
-    }
-  };
-  const handlePointerOver = (event: PointerEvent) => {
-    if (event.pointerType === "touch") {
-      return;
-    }
-    const path = event.composedPath();
-    for (const trigger of suppressed.keys()) {
-      if (!path.includes(trigger)) {
-        restore(trigger);
-      }
-    }
-    for (const candidate of path) {
-      if (!isHtmlElement(candidate)) {
-        continue;
-      }
-      const title = candidate.getAttribute("title");
-      const previous = suppressed.get(candidate);
-      if (previous) {
-        if (title === "") {
-          continue;
-        }
-        candidate.removeEventListener("pointerleave", handlePointerLeave);
-        suppressed.delete(candidate);
-      }
-      if (!title || !isTooltipTextRedundant(title, candidate)) {
-        continue;
-      }
-      suppressed.set(candidate, title);
-      // An empty title also blocks inherited native titles until the pointer
-      // truly leaves this trigger; removing the attribute would expose them.
-      candidate.setAttribute("title", "");
-      candidate.addEventListener("pointerleave", handlePointerLeave, { once: true });
-    }
-  };
-  ownerDocument.addEventListener("pointerover", handlePointerOver, true);
-  return () => {
-    ownerDocument.removeEventListener("pointerover", handlePointerOver, true);
-    for (const trigger of suppressed.keys()) {
-      restore(trigger);
-    }
-  };
-}
-
 class TooltipProvider extends OpenClawLitElement {
   @property({ type: Number }) delay = HOVER_DELAY;
   @property({ type: Number }) skipDelay = SKIP_DELAY;
 
-  private activeTooltip: Tooltip | null = null;
   delayed = true;
   private focusInput: "keyboard" | "pointer" = "keyboard";
   private skipDelayTimer: number | null = null;
@@ -167,9 +44,7 @@ class TooltipProvider extends OpenClawLitElement {
   override disconnectedCallback() {
     this.ownerDocument.removeEventListener("keydown", this.handleDocumentKeyDown, true);
     this.ownerDocument.removeEventListener("pointerdown", this.handleDocumentPointerDown, true);
-    const activeTooltip = this.activeTooltip;
-    this.activeTooltip = null;
-    activeTooltip?.closeFromProvider();
+    Tooltip.closeForProvider(this);
     this.clearSkipDelayTimer();
     this.delayed = true;
     super.disconnectedCallback();
@@ -179,20 +54,12 @@ class TooltipProvider extends OpenClawLitElement {
     return this.focusInput === "keyboard";
   }
 
-  openTooltip(tooltip: Tooltip) {
-    if (this.activeTooltip && this.activeTooltip !== tooltip) {
-      this.activeTooltip.closeFromProvider();
-    }
-    this.activeTooltip = tooltip;
+  openTooltip() {
     this.delayed = false;
     this.clearSkipDelayTimer();
   }
 
-  closeTooltip(tooltip: Tooltip) {
-    if (this.activeTooltip !== tooltip) {
-      return;
-    }
-    this.activeTooltip = null;
+  closeTooltip() {
     this.clearSkipDelayTimer();
     if (this.skipDelay <= 0) {
       this.delayed = true;
@@ -227,6 +94,15 @@ class TooltipProvider extends OpenClawLitElement {
 }
 
 class Tooltip extends OpenClawLitElement {
+  private static readonly activeByDocument = new WeakMap<Document, Tooltip>();
+
+  static closeForProvider(provider: TooltipProvider) {
+    const active = Tooltip.activeByDocument.get(provider.ownerDocument);
+    if (active?.tooltipProvider === provider) {
+      active.close();
+    }
+  }
+
   @property() content = "";
 
   @property({ type: Number }) closeDelay = RICH_CONTENT_CLOSE_DELAY;
@@ -240,10 +116,13 @@ class Tooltip extends OpenClawLitElement {
   /** Let a reveal-only trigger open on click instead of dismissing. */
   @property({ type: Boolean, attribute: "open-on-click" }) openOnClick = false;
 
+  @property({ attribute: false }) anchor: HTMLElement | SVGElement | null = null;
+
   @query("wa-tooltip") private webAwesomeTooltip?: WaTooltip;
 
-  private triggerElement: HTMLElement | null = null;
-  private describedElement: HTMLElement | null = null;
+  private triggerElement: HTMLElement | SVGElement | null = null;
+  private pinned = false;
+  private describedElement: Element | null = null;
   private openTimer: number | null = null;
   private closeTimer: number | null = null;
   private triggerHovered = false;
@@ -331,7 +210,6 @@ class Tooltip extends OpenClawLitElement {
 
   override connectedCallback() {
     super.connectedCallback();
-    this.tooltipProvider = this.closest<TooltipProvider>("openclaw-tooltip-provider");
     this.style.display = "contents";
   }
 
@@ -339,15 +217,13 @@ class Tooltip extends OpenClawLitElement {
     this.attachTrigger();
     this.syncDescription();
     this.syncWebAwesomeTooltip();
-    if (this.disabled) {
+    if (this.disabled || !this.tooltipText || this.isRedundant()) {
       this.close();
     }
   }
 
   override disconnectedCallback() {
     this.close();
-    this.triggerHovered = false;
-    this.contentHovered = false;
     this.richContentObserver?.disconnect();
     this.richContentObserver = null;
     this.tooltipProvider = null;
@@ -357,7 +233,8 @@ class Tooltip extends OpenClawLitElement {
 
   private attachTrigger() {
     const slot = this.renderRoot.querySelector<HTMLSlotElement>("slot:not([name])");
-    const trigger = slot?.assignedElements({ flatten: true }).find(isHtmlElement);
+    const trigger =
+      this.anchor ?? slot?.assignedElements({ flatten: true }).find(isTooltipTriggerElement);
     if (trigger === this.triggerElement) {
       return;
     }
@@ -367,6 +244,17 @@ class Tooltip extends OpenClawLitElement {
       return;
     }
     this.triggerElement = trigger;
+    this.tooltipProvider = null;
+    let owner: Element | null = trigger;
+    while (owner) {
+      const provider = owner.closest<TooltipProvider>("openclaw-tooltip-provider");
+      if (provider) {
+        this.tooltipProvider = provider;
+        break;
+      }
+      const root = owner.getRootNode();
+      owner = root instanceof ShadowRoot ? root.host : null;
+    }
     trigger.addEventListener("pointerenter", this.handlePointerEnter);
     trigger.addEventListener("pointerleave", this.handlePointerLeave);
     trigger.addEventListener("pointerdown", this.handlePointerDown);
@@ -374,7 +262,7 @@ class Tooltip extends OpenClawLitElement {
     trigger.addEventListener("focusin", this.handleFocusIn);
     trigger.addEventListener("focusout", this.handleFocusOut);
     trigger.addEventListener("click", this.handleClick, true);
-    trigger.addEventListener("keydown", this.handleKeyDown);
+    this.observeRichContent();
     this.syncDescription();
     this.syncWebAwesomeTooltip();
   }
@@ -391,9 +279,25 @@ class Tooltip extends OpenClawLitElement {
     trigger.removeEventListener("focusin", this.handleFocusIn);
     trigger.removeEventListener("focusout", this.handleFocusOut);
     trigger.removeEventListener("click", this.handleClick, true);
-    trigger.removeEventListener("keydown", this.handleKeyDown);
     this.restoreDescription();
     this.triggerElement = null;
+  }
+
+  /** Attribute hints share the wrapped trigger's lifecycle without reparenting its DOM. */
+  previewForAnchor(anchor: HTMLElement | SVGElement, content: string, input: "pointer" | "focus") {
+    this.anchor = anchor;
+    this.content = content;
+    void this.updateComplete.then(() => {
+      if (this.anchor !== anchor || !anchor.isConnected || !this.isConnected) {
+        return;
+      }
+      if (input === "focus") {
+        this.handleFocusIn();
+      } else {
+        this.triggerHovered = true;
+        this.scheduleOpen();
+      }
+    });
   }
 
   private syncWebAwesomeTooltip() {
@@ -413,16 +317,16 @@ class Tooltip extends OpenClawLitElement {
     });
   }
 
-  private readonly handlePointerEnter = (event: PointerEvent) => {
-    if (event.pointerType !== "touch") {
+  private readonly handlePointerEnter = (event: Event) => {
+    if (!("pointerType" in event) || event.pointerType !== "touch") {
       this.triggerHovered = true;
       this.clearCloseTimer();
       this.scheduleOpen();
     }
   };
 
-  private readonly handlePointerLeave = (event: PointerEvent) => {
-    if (event.pointerType !== "touch") {
+  private readonly handlePointerLeave = (event: Event) => {
+    if (!("pointerType" in event) || event.pointerType !== "touch") {
       this.triggerHovered = false;
       this.clearTimers(false);
       this.maybeClose();
@@ -445,7 +349,9 @@ class Tooltip extends OpenClawLitElement {
   };
 
   private readonly handlePointerDown = () => {
-    this.close();
+    if (!this.openOnClick) {
+      this.close();
+    }
   };
 
   private readonly handlePointerCancel = () => {
@@ -456,9 +362,12 @@ class Tooltip extends OpenClawLitElement {
       this.show();
     }
   };
-  private readonly handleFocusOut = (event: FocusEvent) => {
+  private readonly handleFocusOut = (event: Event) => {
     if (
-      (event.relatedTarget instanceof Node && this.contains(event.relatedTarget)) ||
+      (event instanceof FocusEvent &&
+        event.relatedTarget instanceof Node &&
+        this.containsInteractionTarget(event.relatedTarget)) ||
+      this.pinned ||
       this.triggerHovered ||
       this.contentHovered
     ) {
@@ -471,16 +380,12 @@ class Tooltip extends OpenClawLitElement {
   // touch and in browsers that do not focus buttons on click there is no other
   // way to read it.
   private readonly handleClick = () => {
-    if (this.openOnClick) {
+    if (this.openOnClick && !this.pinned) {
       this.show();
+      this.pinned = this.webAwesomeTooltip?.open === true;
       return;
     }
     this.close();
-  };
-  private readonly handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === "Escape") {
-      this.close();
-    }
   };
 
   private scheduleOpen() {
@@ -510,25 +415,46 @@ class Tooltip extends OpenClawLitElement {
       return;
     }
     this.clearTimers(false);
-    this.tooltipProvider?.openTooltip(this);
+    const active = Tooltip.activeByDocument.get(this.ownerDocument);
+    if (active && active !== this) {
+      active.close();
+    }
+    // Portaled menus and modal roots can sit outside the provider. The document
+    // owns exclusivity; providers configure timing and input modality only.
+    Tooltip.activeByDocument.set(this.ownerDocument, this);
+    this.tooltipProvider?.openTooltip();
     this.syncDescription();
     tooltip.open = true;
+    // Light-DOM owners can retain a revealed trigger without another popup lifecycle.
+    this.setAttribute("open", "");
+    this.ownerDocument.addEventListener("pointerdown", this.handleDocumentDismiss, true);
+    this.ownerDocument.addEventListener("focusin", this.handleDocumentDismiss, true);
+  }
+
+  // Web Awesome owns Escape/top-layer ordering; wa-hide releases our pin and
+  // provider state without letting the same Escape dismiss an underlying dialog.
+  private readonly handleDocumentDismiss = (event: Event) => {
+    if (!event.composedPath().some((target) => target === this || target === this.triggerElement)) {
+      this.close();
+    }
+  };
+
+  private containsInteractionTarget(target: Node) {
+    return this.contains(target) || this.triggerElement?.contains(target) === true;
   }
 
   private close() {
+    this.pinned = false;
+    this.removeAttribute("open");
+    this.ownerDocument.removeEventListener("pointerdown", this.handleDocumentDismiss, true);
+    this.ownerDocument.removeEventListener("focusin", this.handleDocumentDismiss, true);
     this.clearTimers();
-    this.triggerHovered = false;
-    this.contentHovered = false;
     if (this.webAwesomeTooltip?.open) {
       this.webAwesomeTooltip.open = false;
     }
-    this.tooltipProvider?.closeTooltip(this);
-  }
-
-  closeFromProvider() {
-    this.clearTimers();
-    if (this.webAwesomeTooltip?.open) {
-      this.webAwesomeTooltip.open = false;
+    if (Tooltip.activeByDocument.get(this.ownerDocument) === this) {
+      Tooltip.activeByDocument.delete(this.ownerDocument);
+      this.tooltipProvider?.closeTooltip();
     }
   }
 
@@ -543,14 +469,14 @@ class Tooltip extends OpenClawLitElement {
     return isTooltipTextRedundant(this.content, trigger);
   }
 
-  private resolveDescribedElement(): HTMLElement | null {
+  private resolveDescribedElement(): Element | null {
     const trigger = this.triggerElement;
     if (!trigger) {
       return null;
     }
     return trigger.matches(DESCRIBABLE_SELECTOR)
       ? trigger
-      : (trigger.querySelector<HTMLElement>(DESCRIBABLE_SELECTOR) ?? trigger);
+      : (trigger.querySelector(DESCRIBABLE_SELECTOR) ?? trigger);
   }
 
   private syncDescription() {
@@ -574,7 +500,8 @@ class Tooltip extends OpenClawLitElement {
       const description = this.ownerDocument.createElement("span");
       description.id = this.descriptionId;
       description.hidden = true;
-      this.append(description);
+      const root = trigger.getRootNode();
+      (root instanceof ShadowRoot ? root : this).append(description);
       this.descriptionElement = description;
     }
     this.descriptionElement.textContent = this.tooltipText;
@@ -608,11 +535,14 @@ class Tooltip extends OpenClawLitElement {
   }
 
   private shouldRemainOpen() {
-    const activeElement = document.activeElement;
+    const root = this.triggerElement?.getRootNode();
+    const activeElement =
+      root instanceof ShadowRoot ? root.activeElement : this.ownerDocument.activeElement;
     return (
+      this.pinned ||
       this.triggerHovered ||
       this.contentHovered ||
-      (activeElement instanceof Node && this.contains(activeElement))
+      (activeElement instanceof Node && this.containsInteractionTarget(activeElement))
     );
   }
 
@@ -683,7 +613,7 @@ class Tooltip extends OpenClawLitElement {
   override render() {
     return html`
       <slot @slotchange=${() => this.attachTrigger()}></slot>
-      <wa-tooltip id=${this.tooltipId} trigger="manual">
+      <wa-tooltip id=${this.tooltipId} trigger="manual" @wa-hide=${() => this.close()}>
         <span class="tooltip-content">${this.content}</span>
         <span
           class="tooltip-rich-content"

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -166,6 +166,93 @@ describeControlUiE2e("Control UI chat message actions", () => {
     await server?.close();
   });
 
+  it("shares tooltip styling and dismissal across message metadata, actions, and file hints", async () => {
+    const context = await browser.newContext({
+      colorScheme: "dark",
+      hasTouch: true,
+      locale: "en-US",
+      recordVideo: captureUiProof
+        ? { dir: path.join(artifactDir, "tooltips-video"), size: { height: 900, width: 1440 } }
+        : undefined,
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    await installMockGateway(page, {
+      historyMessages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "Tooltip proof. See /workspace/tooltip-proof.txt." }],
+          timestamp: Date.now() - 5 * 60_000,
+          model: "openai/gpt-5.6-luna",
+          usage: { input: 12_000, output: 300, cost: { total: 0.12 } },
+          __openclaw: { id: "tooltip-proof", seq: 1 },
+        },
+      ],
+    });
+    const openTooltip = page.locator("wa-tooltip[open]");
+    const popupStyle = () =>
+      openTooltip.locator('[part="body"]').evaluate((element) => {
+        const style = getComputedStyle(element);
+        return {
+          background: style.backgroundColor,
+          border: style.border,
+          radius: style.borderRadius,
+          padding: style.padding,
+          fontSize: style.fontSize,
+        };
+      });
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      const group = page.locator(".chat-group.assistant").filter({ hasText: "Tooltip proof." });
+      await group
+        .locator(".chat-text")
+        .first()
+        .tap({ position: { x: 4, y: 4 } });
+      const timestamp = group.locator(".msg-meta__summary");
+      await timestamp.hover();
+      await expect.poll(() => openTooltip.count()).toBe(1);
+      await group.locator(".msg-meta__details").waitFor({ state: "visible" });
+      const metadataStyle = await popupStyle();
+      expect(await group.locator(".msg-meta__details").textContent()).toContain("gpt-5.6-luna");
+      expect(await group.locator(".msg-meta__cost").textContent()).toContain("$0.12");
+      await screenshot(page, "tooltip-metadata.png");
+
+      await timestamp.click();
+      await page.mouse.move(0, 0);
+      await expect.poll(() => openTooltip.count()).toBe(1);
+      const reply = group.getByRole("button", { name: "Reply to message" });
+      await expectHoverTooltip(reply, "Reply");
+      await expect.poll(() => openTooltip.count()).toBe(1);
+      expect(await popupStyle()).toEqual(metadataStyle);
+      await screenshot(page, "tooltip-reply.png");
+      await page.keyboard.press("Escape");
+      await expect.poll(() => openTooltip.count()).toBe(0);
+
+      const file = group.locator("a").filter({ hasText: "tooltip-proof.txt" });
+      await file.hover();
+      await expect.poll(() => openTooltip.count()).toBe(1);
+      expect(await openTooltip.textContent()).toContain("/workspace/tooltip-proof.txt");
+      expect(await popupStyle()).toEqual(metadataStyle);
+      expect(await file.getAttribute("title")).toBe("");
+      await screenshot(page, "tooltip-file-hint.png");
+
+      await page.setViewportSize({ width: 390, height: 844 });
+      await timestamp.tap();
+      await expect.poll(() => openTooltip.count()).toBe(1);
+      await group.locator(".msg-meta__details").waitFor({ state: "visible" });
+      const bounds = await openTooltip.locator('[part="body"]').boundingBox();
+      expect(bounds).not.toBeNull();
+      expect(bounds!.x).toBeGreaterThanOrEqual(0);
+      expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(390);
+      await screenshot(page, "tooltip-mobile.png");
+      await timestamp.tap();
+      await expect.poll(() => openTooltip.count()).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it("keeps oversized history notices consistent through recovery and message actions", async () => {
     const context = await browser.newContext({
       colorScheme: "dark",

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -488,7 +488,11 @@ suite.define(() => {
     await toast.waitFor();
     expect(await toast.textContent()).toContain("Could not pin to dashboard. Try again.");
     expect(await pin.isEnabled()).toBe(true);
-    expect(await pin.getAttribute("title")).toBe("Could not pin to dashboard. Try again.");
+    await page.mouse.move(0, 0);
+    await pin.hover();
+    const hint = page.locator("wa-tooltip[open]");
+    await hint.locator('[part="body"]').waitFor({ state: "visible" });
+    expect(await hint.textContent()).toContain("Could not pin to dashboard. Try again.");
     expect(await page.getByText("internal path detail", { exact: false }).count()).toBe(0);
     if (recordProof) {
       await page.screenshot({ path: path.join(workboardPinFailureProofDir, "pin-failed.png") });

--- a/ui/src/pages/chat/chat-pane-shared.ts
+++ b/ui/src/pages/chat/chat-pane-shared.ts
@@ -233,7 +233,7 @@ export type ChatPaneConnectionScope = {
   sessions: ChatPageContext["sessions"];
 };
 export const CHAT_OPEN_DETAILS_SELECTOR =
-  ".chat-controls__inline-select[open], .context-usage details[open], .agent-chat__attach-menu[open], .chat-pr__checks[open], details.msg-meta[open]:not([data-preview])";
+  ".chat-controls__inline-select[open], .context-usage details[open], .agent-chat__attach-menu[open], .chat-pr__checks[open]";
 export const CHAT_COMPOSER_TEXTAREA_SELECTOR = ".agent-chat__composer-combobox > textarea";
 export const CHAT_AUTOTYPE_EXEMPT_SELECTOR =
   "input, textarea, select, [contenteditable]:not([contenteditable='false']), [role='combobox'], [role='listbox'], [role='textbox'], [data-chat-autotype-exempt]";

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -2062,88 +2062,6 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
     }
   });
 
-  it("paints open message context above its virtual row", async () => {
-    const page = await openBrowserPage(900, 500);
-    try {
-      await page.setContent(
-        `<!doctype html><html><head><style>${readUiCss()}</style></head><body>
-          <div class="chat-thread chat-thread--direct" style="width: 720px; height: 400px;">
-            <div class="chat-thread-inner chat-thread-inner--virtual" style="width: 720px;">
-              <div class="chat-virtual-sizer" style="height: 400px;">
-                <div class="chat-virtual-block">
-                  <div
-                    class="chat-virtual-row"
-                    data-previous-row
-                    style="height: 100px;"
-                  >
-                    <div class="chat-group tool">
-                      <div class="chat-group-messages">Previous transcript row</div>
-                    </div>
-                  </div>
-                  <div
-                    class="chat-virtual-row"
-                    data-context-row
-                    style="contain-intrinsic-block-size: auto 28px;"
-                  >
-                    <div class="chat-group assistant chat-group--with-footer">
-                      <div class="chat-group-messages"></div>
-                      <div class="chat-group-footer">
-                        <div class="chat-group-footer__meta">
-                          <span class="chat-sender-name">Assistant</span>
-                          <details class="msg-meta" open>
-                            <summary class="msg-meta__summary">
-                              <time class="chat-group-timestamp">just now</time>
-                            </summary>
-                            <span class="msg-meta__details">
-                              <span class="msg-meta__time">Aug 24, 2026, 1:15 PM UTC</span>
-                              <span class="msg-meta__tokens">↑19.6k</span>
-                              <span class="msg-meta__tokens">↓126</span>
-                              <span class="msg-meta__cache">R2.4k</span>
-                              <span class="msg-meta__model">gpt-5.5</span>
-                            </span>
-                          </details>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </body></html>`,
-      );
-      await waitForLayoutSettled(page, "[data-context-row], .msg-meta__details");
-
-      const layout = await page.evaluate(() => {
-        const row = document.querySelector<HTMLElement>("[data-context-row]")!;
-        const popover = row.querySelector<HTMLElement>(".msg-meta__details")!;
-        const rowRect = row.getBoundingClientRect();
-        const popoverRect = popover.getBoundingClientRect();
-        const sample = {
-          x: popoverRect.left + Math.min(10, popoverRect.width / 2),
-          y: Math.min(rowRect.top - 1, popoverRect.bottom - 1),
-        };
-        const target = document.elementFromPoint(sample.x, sample.y);
-        return {
-          paintedAboveRow:
-            sample.y >= popoverRect.top &&
-            sample.y < rowRect.top &&
-            target !== null &&
-            popover.contains(target),
-          popoverBottom: popoverRect.bottom,
-          popoverTop: popoverRect.top,
-          rowTop: rowRect.top,
-        };
-      });
-
-      expect(layout.popoverTop).toBeLessThan(layout.rowTop);
-      expect(layout.popoverBottom).toBeGreaterThan(layout.rowTop - 1);
-      expect(layout.paintedAboveRow).toBe(true);
-    } finally {
-      await closeBrowserPage(page);
-    }
-  });
-
   it("keeps attributed user avatar fallbacks beside the message after identity resolution", async () => {
     const page = await openBrowserPage(860, 900);
     try {
@@ -2436,18 +2354,27 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
   );
 
   it(
-    "reveals, pins, and dismisses message context from the timestamp",
+    "reveals, pins, and dismisses shared message context above virtual-row containment",
     FULL_APP_TEST_OPTIONS,
     async () => {
       const page = await getSharedAppPage();
       try {
         await page.setViewportSize({ width: 1366, height: 900 });
         const group = page.locator(".chat-group").filter({ hasText: SHARED_APP_CONTEXT_TEXT });
-        const details = group.locator("details.msg-meta");
-        const context = details.locator(".msg-meta__details");
-        const summary = details.locator(".msg-meta__summary");
+        const tooltip = group.locator("openclaw-tooltip.msg-meta");
+        const context = tooltip.locator(".msg-meta__details");
+        const summary = tooltip.locator(".msg-meta__summary");
         const messageText = group.locator(".chat-text").first();
         await messageText.waitFor({ timeout: APP_FIRST_RENDER_TIMEOUT_MS });
+        expect(await context.isVisible()).toBe(false);
+
+        // The shared group also contains an aborted image; finish its fallback
+        // layout before measuring whether opening the tooltip moves the row.
+        await messageText.hover();
+        await page.waitForFunction(
+          () => document.querySelector<HTMLImageElement>(".chat-message-image")?.complete,
+        );
+        await waitForLayoutSettled(page, ".chat-group");
         const initialLayout = await group.evaluate((node) => {
           const footer = node.querySelector<HTMLElement>(".chat-group-footer")!;
           return {
@@ -2455,14 +2382,7 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             groupHeight: (node as HTMLElement).getBoundingClientRect().height,
           };
         });
-        expect(await context.isVisible()).toBe(false);
-
-        // Travel like a real pointer: the footer overlay is pointer-gated until
-        // the group is hovered, so enter through the message body first.
-        await messageText.hover();
         await summary.hover();
-        // The reveal is state-driven, so the re-render can lag the hover event
-        // under CPU contention; poll instead of a one-shot visibility read.
         await context.waitFor({ state: "visible", timeout: 10_000 });
         const hoverLayout = await group.evaluate((node) => {
           const footer = node.querySelector<HTMLElement>(".chat-group-footer")!;
@@ -2479,30 +2399,86 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
         expect(hoverLayout.groupHeight).toBeCloseTo(initialLayout.groupHeight, 2);
         expect(hoverLayout.contextBottom).toBeLessThanOrEqual(hoverLayout.summaryTop + 4);
 
+        // Real top-layer placement replaces the old per-row containment escape.
+        // Hit-test rendered content, not just the popup's open flag.
+        await expect
+          .poll(() =>
+            context.evaluate((node) => {
+              const row = node.closest<HTMLElement>(".chat-virtual-row")!;
+              const tooltipNode = node.closest("openclaw-tooltip")!;
+              const popup = tooltipNode.shadowRoot
+                ?.querySelector("wa-tooltip")
+                ?.shadowRoot?.querySelector("wa-popup")
+                ?.shadowRoot?.querySelector<HTMLElement>('[part="popup"]');
+              const rect = node.getBoundingClientRect();
+              const target = document.elementFromPoint(rect.left + 8, rect.top + rect.height / 2);
+              return {
+                rowContainment: getComputedStyle(row).contentVisibility,
+                topLayer: popup?.matches(":popover-open") ?? false,
+                painted: target !== null && node.contains(target),
+              };
+            }),
+          )
+          .toEqual({ rowContainment: "auto", topLayer: true, painted: true });
+
         await page.mouse.move(0, 0);
         await context.waitFor({ state: "hidden", timeout: 10_000 });
 
-        await messageText.hover();
-        await summary.hover();
-        // Escape only owns pinned disclosures; it must not corrupt an active
-        // hover preview before the click converts that preview into a pin.
-        await page.keyboard.press("Escape");
-        await summary.click();
-        await page.mouse.move(0, 0);
-        // Click-to-open must survive the pointer leaving the message group.
+        // Keyboard discovery must reveal the timestamp itself, not just its tip.
+        await page.keyboard.press("Tab");
+        await summary.focus();
         await context.waitFor({ state: "visible", timeout: 10_000 });
-        expect(await details.getAttribute("open")).toBe("");
+        await expect
+          .poll(() =>
+            summary.evaluate((node) => {
+              const footer = node.closest<HTMLElement>(".chat-group-footer")!;
+              return {
+                footerOpacity: getComputedStyle(footer).opacity,
+                summaryOpacity: getComputedStyle(node).opacity,
+                pointerEvents: getComputedStyle(node).pointerEvents,
+                focused: document.activeElement === node,
+              };
+            }),
+          )
+          .toEqual({
+            footerOpacity: "1",
+            summaryOpacity: "1",
+            pointerEvents: "auto",
+            focused: true,
+          });
+        await page.keyboard.press("Escape");
+        await context.waitFor({ state: "hidden", timeout: 10_000 });
+        expect(await tooltip.getAttribute("open")).toBeNull();
+
+        await summary.press("Enter");
+        await context.waitFor({ state: "visible", timeout: 10_000 });
+        // Remove focus without focusing an outside control: only the pin should
+        // retain this disclosure, even in browsers that do not focus on click.
+        await summary.evaluate((node) => (node as HTMLElement).blur());
+        await expect
+          .poll(() =>
+            group.evaluate((node) => ({
+              hovered: node.matches(":hover"),
+              focused: node.matches(":focus-within"),
+              footerOpacity: getComputedStyle(
+                node.querySelector<HTMLElement>(".chat-group-footer")!,
+              ).opacity,
+            })),
+          )
+          .toEqual({ hovered: false, focused: false, footerOpacity: "1" });
+        expect(await tooltip.getAttribute("open")).toBe("");
+        expect(await context.isVisible()).toBe(true);
 
         await page.mouse.click(0, 0);
         await context.waitFor({ state: "hidden", timeout: 10_000 });
-        expect(await details.getAttribute("open")).toBeNull();
+        expect(await tooltip.getAttribute("open")).toBeNull();
 
         await messageText.hover();
         await summary.click();
         await context.waitFor({ state: "visible", timeout: 10_000 });
         await page.keyboard.press("Escape");
         await context.waitFor({ state: "hidden", timeout: 10_000 });
-        expect(await details.getAttribute("open")).toBeNull();
+        expect(await tooltip.getAttribute("open")).toBeNull();
       } finally {
         await page.keyboard.press("Escape");
         await page.mouse.move(0, 0);

--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -3861,6 +3861,9 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             expectedColor,
           );
           const retry = status.locator("button");
+          expect(await retry.evaluate((element) => getComputedStyle(element).borderStyle)).toBe(
+            "none",
+          );
           expect(await retry.evaluate((element) => getComputedStyle(element).color)).toBe(
             expectedColor,
           );

--- a/ui/src/pages/chat/components/chat-message-timestamp.ts
+++ b/ui/src/pages/chat/components/chat-message-timestamp.ts
@@ -1,4 +1,4 @@
-import { html } from "lit";
+import { html, nothing, type TemplateResult } from "lit";
 import { t } from "../../../i18n/index.ts";
 import type { MessageGroup } from "../../../lib/chat/chat-types.ts";
 import { formatCompactTokenCount, formatCost, formatTimeAgo } from "../../../lib/format.ts";
@@ -68,56 +68,35 @@ function formatChatRelativeTimestampLabel(timestamp: number, nowMs = Date.now())
   });
 }
 
-// Footer times read relative ("5m ago"); the absolute timestamp lives in the
-// tooltip, or in the msg-meta popover when usage metadata makes the
-// timestamp interactive (a nested tooltip would fight the popover).
-export function renderChatTimestamp(timestamp: number, interactive = false) {
+export function renderChatTimestamp(timestamp: number, metadata: TemplateResult[] = []) {
   const display = formatChatTimestampForDisplay(timestamp);
-  const timeEl = html`
+  const time = html`
     <time class="chat-group-timestamp" datetime=${display.dateTime} aria-live="off">
       ${formatChatRelativeTimestampLabel(timestamp)}
     </time>
   `;
-  if (interactive) {
-    return timeEl;
-  }
-  return html`<openclaw-tooltip content=${display.label}>${timeEl}</openclaw-tooltip>`;
-}
-
-function resolveMessageMetaDetails(target: EventTarget | null): HTMLDetailsElement | null {
-  if (target instanceof HTMLDetailsElement) {
-    return target;
-  }
-  return target instanceof HTMLElement
-    ? target.closest<HTMLDetailsElement>("details.msg-meta")
-    : null;
-}
-
-function previewMessageMeta(event: PointerEvent | FocusEvent) {
-  const details = resolveMessageMetaDetails(event.currentTarget);
-  if (!details || details.open || ("pointerType" in event && event.pointerType === "touch")) {
-    return;
-  }
-  details.dataset.preview = "true";
-  details.open = true;
-}
-
-function closeMessageMetaPreview(event: PointerEvent | FocusEvent) {
-  const details = resolveMessageMetaDetails(event.currentTarget);
-  if (!details || details.dataset.preview !== "true" || details.matches(":hover, :focus-within")) {
-    return;
-  }
-  delete details.dataset.preview;
-  details.open = false;
-}
-
-function pinMessageMetaPreview(event: MouseEvent) {
-  const details = resolveMessageMetaDetails(event.currentTarget);
-  if (details?.dataset.preview !== "true") {
-    return;
-  }
-  event.preventDefault();
-  delete details.dataset.preview;
+  return html`
+    <openclaw-tooltip
+      class="msg-meta"
+      ?open-on-click=${metadata.length > 0}
+      content=${metadata.length ? "" : display.label}
+    >
+      ${metadata.length
+        ? html`<button
+            type="button"
+            class="msg-meta__summary"
+            aria-label=${t("chat.messages.contextFor", { timestamp: display.title })}
+          >
+            ${time}
+          </button>`
+        : time}
+      ${metadata.length
+        ? html`<span slot="content" class="msg-meta__details">
+            <span class="msg-meta__time">${display.label}</span>${metadata}
+          </span>`
+        : nothing}
+    </openclaw-tooltip>
+  `;
 }
 
 type GroupMeta = {
@@ -240,30 +219,5 @@ export function renderMessageMeta(timestamp: number, meta: GroupMeta | null) {
     parts.push(html`<span class="msg-meta__model">${shortModel}</span>`);
   }
 
-  if (parts.length === 0) {
-    return renderChatTimestamp(timestamp);
-  }
-
-  const display = formatChatTimestampForDisplay(timestamp);
-  // Absolute time leads the popover; the summary label itself stays relative.
-  parts.unshift(html`<span class="msg-meta__time">${display.label}</span>`);
-
-  return html`
-    <details
-      class="msg-meta"
-      @pointerenter=${previewMessageMeta}
-      @pointerleave=${closeMessageMetaPreview}
-      @focusin=${previewMessageMeta}
-      @focusout=${closeMessageMetaPreview}
-    >
-      <summary
-        class="msg-meta__summary"
-        aria-label=${t("chat.messages.contextFor", { timestamp: display.title })}
-        @click=${pinMessageMetaPreview}
-      >
-        ${renderChatTimestamp(timestamp, true)}
-      </summary>
-      <span class="msg-meta__details">${parts}</span>
-    </details>
-  `;
+  return renderChatTimestamp(timestamp, parts);
 }

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1420,9 +1420,7 @@ describe("grouped chat rendering", () => {
       },
       1_000_000,
     );
-    const meta = cached.querySelector<HTMLDetailsElement>("details.msg-meta");
-    expect(meta?.open).toBe(false);
-    const summary = meta?.querySelector<HTMLElement>(".msg-meta__summary");
+    const summary = cached.querySelector<HTMLButtonElement>(".msg-meta__summary");
     const time = summary?.querySelector<HTMLTimeElement>(".chat-group-timestamp");
     expect(time).not.toBeNull();
     expect(time?.title).toBe("");
@@ -1457,35 +1455,38 @@ describe("grouped chat rendering", () => {
     expect(withCost.querySelector(".msg-meta__cost")?.textContent).toContain("$0.12");
   });
 
-  it("previews message context from the timestamp and pins it on click", () => {
+  it("dismisses message context when the neighboring reply tooltip opens", async () => {
+    vi.useFakeTimers();
+    const provider = document.createElement("openclaw-tooltip-provider");
     const container = document.createElement("div");
+    provider.append(container);
+    document.body.append(provider);
     renderAssistantMessage(
       container,
       createAssistantMessage("Done", {
         usage: { input: 12_000, output: 300 },
-        model: "openai/gpt-5.5",
+        model: "openai/gpt-5.6-luna",
         timestamp: 1000,
       }),
-      { contextWindow: 100_000 },
+      { contextWindow: 100_000, onReply: vi.fn() },
     );
 
-    const details = container.querySelector<HTMLDetailsElement>("details.msg-meta")!;
-    const summary = details.querySelector<HTMLElement>("summary")!;
-    const pointerEnter = new Event("pointerenter");
-    Object.defineProperty(pointerEnter, "pointerType", { value: "mouse" });
-    details.dispatchEvent(pointerEnter);
-    expect(details.open).toBe(true);
-
-    details.dispatchEvent(new Event("pointerleave"));
-    expect(details.open).toBe(false);
-
-    details.dispatchEvent(pointerEnter);
-    summary.click();
-    details.dispatchEvent(new Event("pointerleave"));
-    expect(details.open).toBe(true);
-
-    summary.click();
-    expect(details.open).toBe(false);
+    try {
+      await Promise.all(
+        [...container.querySelectorAll("openclaw-tooltip")].map((tip) => tip.updateComplete),
+      );
+      const summary = container.querySelector<HTMLElement>(".msg-meta__summary")!;
+      summary.click();
+      const reply = container.querySelector<HTMLButtonElement>(".chat-reply-btn")!;
+      reply.focus();
+      const replyTooltip = reply.closest("openclaw-tooltip")!;
+      await Promise.resolve();
+      expect(replyTooltip.shadowRoot?.querySelector("wa-tooltip")?.hasAttribute("open")).toBe(true);
+      const metadata = summary.closest("openclaw-tooltip")!;
+      expect(metadata.shadowRoot?.querySelector("wa-tooltip")?.hasAttribute("open")).toBe(false);
+    } finally {
+      provider.remove();
+    }
   });
 
   it("uses the largest single assistant call for grouped context usage", () => {

--- a/ui/src/pages/usage/view-details.test.ts
+++ b/ui/src/pages/usage/view-details.test.ts
@@ -146,7 +146,9 @@ describe("renderSessionDetailPanel filtered usage", () => {
     expect(
       [...container.querySelectorAll(".ts-axis-label")].map((label) => label.textContent),
     ).toEqual(expect.arrayContaining(["utc-time", "utc-time"]));
-    expect(container.querySelector(".ts-bar title")?.textContent).toContain("utc-date-time");
+    expect(container.querySelector(".ts-bar")?.getAttribute("data-tooltip")).toContain(
+      "utc-date-time",
+    );
   });
 
   it("filters detail points by the selected UTC day and keeps the final millisecond", () => {

--- a/ui/src/pages/usage/view-details.ts
+++ b/ui/src/pages/usage/view-details.ts
@@ -622,7 +622,7 @@ function renderTimeSeriesCompact(
             const isOutside = hasSelection && (i < rangeStartIdx || i >= rangeEndIdx);
 
             if (!breakdownByType) {
-              return svg`<rect x="${x}" y="${y}" width="${barWidth}" height="${bh}" class="ts-bar${isOutside ? " dimmed" : ""}" rx="1"><title>${tooltip}</title></rect>`;
+              return svg`<rect x="${x}" y="${y}" width="${barWidth}" height="${bh}" class="ts-bar${isOutside ? " dimmed" : ""}" rx="1" data-tooltip=${tooltip} aria-label=${tooltip}></rect>`;
             }
             let yC = padding.top + chartHeight;
             const dim = isOutside ? " dimmed" : "";
@@ -634,7 +634,7 @@ function renderTimeSeriesCompact(
                 }
                 const sh = bh * (value / val);
                 yC -= sh;
-                return svg`<rect x="${x}" y="${yC}" width="${barWidth}" height="${sh}" class="ts-bar ${className}${dim}" rx="1"><title>${tooltip}</title></rect>`;
+                return svg`<rect x="${x}" y="${yC}" width="${barWidth}" height="${sh}" class="ts-bar ${className}${dim}" rx="1" data-tooltip=${tooltip} aria-label=${tooltip}></rect>`;
               })}
             `;
           })}

--- a/ui/src/pages/usage/view-heatmap.ts
+++ b/ui/src/pages/usage/view-heatmap.ts
@@ -59,7 +59,9 @@ function renderHeatmapSvg(heatmap: UsageHeatmap) {
               width=${HEATMAP_CELL}
               height=${HEATMAP_CELL}
               rx="2.5"
-            ><title>${tooltip}</title></rect>
+              data-tooltip=${tooltip}
+              aria-label=${tooltip}
+            ></rect>
           `;
         }),
       )}

--- a/ui/src/pages/usage/view-overview.test.ts
+++ b/ui/src/pages/usage/view-overview.test.ts
@@ -281,9 +281,11 @@ describe("renderUsageHeatmap", () => {
       "Token Activity",
     );
     expect(container.querySelectorAll(".usage-heatmap__cell")).toHaveLength(52 * 7);
-    expect(container.querySelector(".usage-heatmap__cell--l4 title")?.textContent).toContain(
-      "20 tokens",
-    );
+    expect(
+      container
+        .querySelector(".usage-heatmap__svg .usage-heatmap__cell--l4")
+        ?.getAttribute("data-tooltip"),
+    ).toContain("20 tokens");
   });
 
   it("keeps short ranges at their natural cell width", () => {

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -181,7 +181,7 @@
 
 .chat-group:hover .chat-group-footer,
 .chat-group:focus-within .chat-group-footer,
-.chat-group-footer:has(details.msg-meta[open]) {
+.chat-group-footer:has(.msg-meta[open]) {
   opacity: 1;
   pointer-events: auto;
 }
@@ -201,7 +201,7 @@
 
 .chat-group-footer--persistent-identity .chat-confirm-wrap,
 .chat-group-footer--persistent-identity .chat-group-timestamp,
-.chat-group-footer--persistent-identity .msg-meta,
+.chat-group-footer--persistent-identity .msg-meta__summary,
 .chat-group-footer--persistent-identity .chat-group-footer-actions {
   position: var(--chat-footer-detail-position, absolute);
   opacity: var(--chat-footer-disclosure-opacity, 0);
@@ -210,22 +210,22 @@
 
 .chat-group:hover .chat-group-footer--persistent-identity,
 .chat-group:focus-within .chat-group-footer--persistent-identity,
-.chat-group-footer--persistent-identity:has(details.msg-meta[open]) {
+.chat-group-footer--persistent-identity:has(.msg-meta[open]) {
   pointer-events: auto;
 }
 
 .chat-group:hover .chat-group-footer--persistent-identity .chat-confirm-wrap,
 .chat-group:hover .chat-group-footer--persistent-identity .chat-group-timestamp,
-.chat-group:hover .chat-group-footer--persistent-identity .msg-meta,
+.chat-group:hover .chat-group-footer--persistent-identity .msg-meta__summary,
 .chat-group:focus-within .chat-group-footer--persistent-identity .chat-confirm-wrap,
 .chat-group:focus-within .chat-group-footer--persistent-identity .chat-group-timestamp,
-.chat-group:focus-within .chat-group-footer--persistent-identity .msg-meta,
-.chat-group-footer--persistent-identity:has(details.msg-meta[open]) .chat-confirm-wrap,
-.chat-group-footer--persistent-identity:has(details.msg-meta[open]) .chat-group-timestamp,
-.chat-group-footer--persistent-identity:has(details.msg-meta[open]) .msg-meta,
+.chat-group:focus-within .chat-group-footer--persistent-identity .msg-meta__summary,
+.chat-group-footer--persistent-identity:has(.msg-meta[open]) .chat-confirm-wrap,
+.chat-group-footer--persistent-identity:has(.msg-meta[open]) .chat-group-timestamp,
+.chat-group-footer--persistent-identity:has(.msg-meta[open]) .msg-meta__summary,
 .chat-group:hover .chat-group-footer--persistent-identity .chat-group-footer-actions,
 .chat-group:focus-within .chat-group-footer--persistent-identity .chat-group-footer-actions,
-.chat-group-footer--persistent-identity:has(details.msg-meta[open]) .chat-group-footer-actions {
+.chat-group-footer--persistent-identity:has(.msg-meta[open]) .chat-group-footer-actions {
   position: static;
   opacity: 1;
   pointer-events: auto;
@@ -270,7 +270,7 @@
   margin-left: 0;
 }
 
-.chat-group.user.chat-group--peer .chat-group-footer button:focus-visible {
+.chat-group.user.chat-group--peer .chat-group-footer-actions button:focus-visible {
   opacity: 1;
 }
 
@@ -361,7 +361,7 @@
 }
 
 /* ── Group footer action buttons ── */
-.chat-group-footer button,
+.chat-group-footer-actions button,
 .chat-message-actions-row button {
   background: none;
   border: none;
@@ -381,26 +381,26 @@
   justify-content: center;
 }
 
-.chat-group:hover .chat-group-footer button,
+.chat-group:hover .chat-group-footer-actions button,
 .chat-group:hover .chat-message-actions-row button {
   opacity: 0.6;
   pointer-events: auto;
 }
 
-.chat-group:hover .chat-group-footer button:disabled,
+.chat-group:hover .chat-group-footer-actions button:disabled,
 .chat-reply-context-menu button:disabled {
   opacity: 0.3;
   pointer-events: none;
 }
 
-.chat-group-footer button:hover,
+.chat-group-footer-actions button:hover,
 .chat-message-actions-row button:hover {
   opacity: 1 !important;
   background: transparent;
   color: var(--accent);
 }
 
-.chat-group-footer button svg,
+.chat-group-footer-actions button svg,
 .chat-message-actions-row button svg {
   width: 14px;
   height: 14px;
@@ -1032,17 +1032,10 @@ img.chat-avatar.chat-avatar--logo {
 
 /* ── Message metadata (tokens, cost, model, context %) ── */
 .msg-meta {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 12px; /* was 11px */
-  line-height: 1;
-  color: var(--muted);
-  position: relative;
+  --openclaw-tooltip-max-width: min(36rem, calc(100vw - 32px));
 }
 
 .msg-meta__summary {
-  list-style: none;
   display: inline-flex;
   align-items: center;
   padding: 4px 2px;
@@ -1051,11 +1044,8 @@ img.chat-avatar.chat-avatar--logo {
   border-radius: var(--radius-sm, 4px);
   background: transparent;
   color: inherit;
+  font: inherit;
   user-select: none;
-}
-
-.msg-meta__summary::-webkit-details-marker {
-  display: none;
 }
 
 .msg-meta__summary .chat-group-timestamp {
@@ -1080,37 +1070,11 @@ img.chat-avatar.chat-avatar--logo {
   outline-offset: 3px;
 }
 
-details.msg-meta:not([open]) .msg-meta__details {
-  display: none;
-}
-
 .msg-meta__details {
   display: inline-flex;
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
-  position: absolute;
-  right: auto;
-  bottom: 100%;
-  left: 0;
-  z-index: 30;
-  width: max-content;
-  max-width: min(36rem, calc(100vw - 32px));
-  padding: 3px 7px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-full);
-  background: var(--card);
-  box-shadow: 0 8px 24px color-mix(in srgb, black 30%, transparent);
-}
-
-.chat-group.user .msg-meta__details {
-  right: 0;
-  left: auto;
-}
-
-.chat-group.user.chat-group--peer .msg-meta__details {
-  right: auto;
-  left: 0;
 }
 
 .msg-meta__time,

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -362,6 +362,7 @@
 
 /* ── Group footer action buttons ── */
 .chat-group-footer-actions button,
+.chat-group-footer .chat-send-status__retry,
 .chat-message-actions-row button {
   background: none;
   border: none;

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -711,12 +711,6 @@ openclaw-chat-page {
   content-visibility: auto;
 }
 
-/* Message context can extend above its row. Release paint containment only
-   while it is open so the popover stays visible without giving up idle skips. */
-.chat-virtual-row:has(details.msg-meta[open]) {
-  content-visibility: visible;
-}
-
 .chat-virtual-row--first > :first-child {
   margin-top: 0 !important;
 }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainers can push to this same-repository branch.

</details>

## What Problem This Solves

Fixes an issue where Control UI users see differently styled, overlapping hints when pinning a message timestamp and hovering Reply. Timestamps used a custom details popup, standard actions used Web Awesome, and HTML/SVG titles still used browser-native hints.

Maintainer-requested consolidation; AI-assisted.

## Why This Change Was Made

`openclaw-tooltip` is the canonical owner of hover timing, input modality, click-to-pin, dismissal, accessibility descriptions, and document-wide exclusivity. Web Awesome continues to own positioning, rendering, and Escape/top-layer ordering. A document-owned title adapter feeds HTML and SVG hints into that same owner without reparenting their triggers.

Removes the timestamp-specific details state machine, chat dismissal selector, popup CSS, and virtual-row paint-containment escape. Footer action styles no longer hide the timestamp button, while Retry retains its existing borderless action styling (dark/light browser regression covered). The old static clipping test is consolidated into the real-app timestamp flow. Rich descriptions resume observation after reconnection (reproduced failing before repair).

Interactive dialogs/hovercards and browser-inspector annotations remain separate: they are not standard tooltips.

## User Impact

Consistent tooltip appearance and one visible hint at a time across metadata, message actions, file links, and charts. Timestamp metadata remains pinnable by click/tap, keyboard-accessible, and dismissible by Escape or outside interaction. No configuration, protocol, persistence, or dependency changes.

## Evidence

- 370 post-rebase component, chat, usage, and responsive-browser tests pass, including keyboard pin/dismiss and real top-layer hit testing.
- Both built-UI chat action E2Es and all 8 dashboard E2Es pass. The dashboard failure assertion now checks the visible shared tooltip rather than its intentionally suppressed native title.
- `node scripts/check-changed.mjs` passes (types, lint, styles, formatting, dead exports, and guards).
- `pnpm build` passes.
- Fresh Codex autoreview: no accepted/actionable findings; clean mechanical rebase preserves the patch.
- Browser screenshots inspected; before captures the original overlapping metadata and Reply popups; after shows shared styling and exclusivity.
- Isolated same-version Gateway boot was verified on port 19843 with separate state and plugins disabled. A live-provider chat turn was not attempted: the clean state correctly requires verified model setup before opening conversations. The complete changed chat flow was tested in real Chromium with the repository's mock-Gateway fixture. No operator Gateway or live state was modified.

Exact-head CI: [run 33131525063](https://github.com/openclaw/openclaw/actions/runs/33131525063) for `4df16863238bc25a55392a1cfedd69e3898b90ef`. The first run’s sole failing test asserted a native title; it was reproduced and updated to assert the visible shared tooltip.

### Commands

```text
node scripts/run-vitest.mjs ui/src/components/tooltip.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/chat-responsive.browser.test.ts ui/src/pages/usage/view-details.test.ts ui/src/pages/usage/view-overview.test.ts
OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-message-actions.e2e.test.ts
node scripts/run-tsgo.mjs -p tsconfig.ui.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/ui.tsbuildinfo
node scripts/check-changed.mjs
pnpm build
.agents/skills/autoreview/scripts/autoreview --mode uncommitted
```

### Before

![Before: overlapping timestamp and Reply](https://github.com/user-attachments/assets/def890c5-abe3-49b3-b58d-9a3be8894d9b)

### After: shared metadata, exclusive Reply, and mobile

![Shared metadata](https://github.com/user-attachments/assets/2f88a743-c49e-49c4-8377-1745d58a41e9)
![Reply replaces metadata](https://github.com/user-attachments/assets/02d7a7c5-91d9-400d-97ae-1fd51f4451cf)
![Mobile timestamp](https://github.com/user-attachments/assets/19ac32c8-233b-4d80-ae9a-d807580a6a2c)

### Scope and size

Production LOC: +414/-315 (net +99). Tests: +415/-138 (net +277). Growth is the generic HTML/SVG title adapter and accessible-name preservation required to route existing declarative hints through the shared owner; hundreds of call-site wrappers would be larger. Existing text helpers moved out of the component; timestamp-local policy and positioning were deleted. No second popup implementation is introduced.
