### PR TITLE
fix(test): release mock fixtures between non-isolated files

### DIFF
--- a/test/non-isolated-runner.test.ts
+++ b/test/non-isolated-runner.test.ts
@@ -50,6 +50,11 @@ function fixtureFiles(): Record<string, string> {
   const agentEventsPath = JSON.stringify(path.join(repoRoot, "src", "infra", "agent-events.ts"));
   const loggingConsolePath = JSON.stringify(path.join(repoRoot, "src", "logging", "console.ts"));
   const loggingStatePath = JSON.stringify(path.join(repoRoot, "src", "logging", "state.ts"));
+  const payloadImports = [
+    'import { createRequire } from "node:module";',
+    'import { queryObjects } from "node:v8";',
+    'const { ManualPayload, AutoPayload } = createRequire(import.meta.url)("./mock-payloads.cjs");',
+  ].join("\n");
 
   return {
     "01-dep.ts": 'export function flavor(): string {\n  return "real";\n}\n',
@@ -196,6 +201,125 @@ function fixtureFiles(): Record<string, string> {
       "});",
       "",
     ].join("\n"),
+    // Native require keeps only the constructors stable across module resets.
+    // Plain factory closures avoid vi.fn's separate process-lifetime mock set.
+    "mock-payloads.cjs": [
+      'class ManualPayload { value = "manual"; }',
+      "class AutoPayload extends Date {}",
+      "module.exports = { ManualPayload, AutoPayload };",
+      "",
+    ].join("\n"),
+    "07-manual-dep.ts": [
+      'export function flavor() { return "real"; }',
+      'export const untouched = "original";',
+      "",
+    ].join("\n"),
+    "07-a-manual-payload.test.ts": [
+      'import { expect, it, vi } from "vitest";',
+      payloadImports,
+      'vi.mock("./07-manual-dep.js", () => {',
+      "  const payload = new ManualPayload();",
+      "  return { flavor: () => payload.value };",
+      "});",
+      'it("creates a file-owned manual mock payload", async () => {',
+      "  expect(queryObjects(ManualPayload)).toBe(0);",
+      '  const { flavor } = await import("./07-manual-dep.js");',
+      '  expect(flavor()).toBe("manual");',
+      "  expect(queryObjects(ManualPayload)).toBe(1);",
+      "});",
+      "",
+    ].join("\n"),
+    "07-b-manual-release.test.ts": [
+      'import { expect, it } from "vitest";',
+      payloadImports,
+      'it("releases the previous file manual mock payload", async () => {',
+      "  expect(queryObjects(ManualPayload)).toBe(0);",
+      '  const { flavor, untouched } = await import("./07-manual-dep.js");',
+      '  expect(flavor()).toBe("real");',
+      '  expect(untouched).toBe("original");',
+      "});",
+      "",
+    ].join("\n"),
+    "07-c-manual-remock.test.ts": [
+      'import { expect, it, vi } from "vitest";',
+      'vi.mock("./07-manual-dep.js", async (importOriginal) => ({',
+      "  ...await importOriginal(),",
+      '  flavor: () => "remocked",',
+      "}));",
+      'it("uses a fresh partial mock after a real import", async () => {',
+      '  const { flavor, untouched } = await import("./07-manual-dep.js");',
+      '  expect(flavor()).toBe("remocked");',
+      '  expect(untouched).toBe("original");',
+      "  vi.resetModules();",
+      '  expect((await import("./07-manual-dep.js")).flavor()).toBe("remocked");',
+      "});",
+      "",
+    ].join("\n"),
+    "07-d-manual-real.test.ts": [
+      'import { expect, it } from "vitest";',
+      'import { flavor, untouched } from "./07-manual-dep.js";',
+      'it("restores real imports after the partial mock", () => {',
+      '  expect(flavor()).toBe("real");',
+      '  expect(untouched).toBe("original");',
+      "});",
+      "",
+    ].join("\n"),
+    "08-auto-dep.ts": [
+      'import { createRequire } from "node:module";',
+      'const { AutoPayload } = createRequire(import.meta.url)("./mock-payloads.cjs");',
+      "export const payload = new AutoPayload(1234);",
+      "",
+    ].join("\n"),
+    "08-a-auto-payload.test.ts": [
+      'import { expect, it, vi } from "vitest";',
+      payloadImports,
+      'vi.mock("./08-auto-dep.js");',
+      'it("creates a file-owned automock payload", async () => {',
+      "  expect(queryObjects(AutoPayload)).toBe(0);",
+      '  const { payload } = await import("./08-auto-dep.js");',
+      "  expect(payload.getTime()).toBe(1234);",
+      "  expect(queryObjects(AutoPayload)).toBe(1);",
+      "});",
+      "",
+    ].join("\n"),
+    "08-b-auto-release.test.ts": [
+      'import { expect, it } from "vitest";',
+      payloadImports,
+      'it("releases the previous file automock payload", async () => {',
+      "  expect(queryObjects(AutoPayload)).toBe(0);",
+      '  const { payload } = await import("./08-auto-dep.js");',
+      "  expect(payload.getTime()).toBe(1234);",
+      "});",
+      "",
+    ].join("\n"),
+    "09-redirect-dep.ts": 'export const flavor = "real";\n',
+    "__mocks__/09-redirect-dep.ts": 'export const flavor = "redirected";\n',
+    "09-a-redirect.test.ts": [
+      'import { expect, it, vi } from "vitest";',
+      'vi.mock("./09-redirect-dep.js");',
+      'import { flavor } from "./09-redirect-dep.js";',
+      'it("loads the redirected mock", () => {',
+      '  expect(flavor).toBe("redirected");',
+      "});",
+      "",
+    ].join("\n"),
+    "09-b-redirect-real.test.ts": [
+      'import { expect, it } from "vitest";',
+      'import { flavor } from "./09-redirect-dep.js";',
+      'it("restores the real module after a redirect", () => {',
+      '  expect(flavor).toBe("real");',
+      "});",
+      "",
+    ].join("\n"),
+    "09-c-redirect-remock.test.ts": [
+      'import { expect, it, vi } from "vitest";',
+      'vi.mock("./09-redirect-dep.js");',
+      'import { flavor } from "./09-redirect-dep.js";',
+      'it("reloads the redirected mock after a real import", () => {',
+      '  expect(flavor).toBe("redirected");',
+      "});",
+      "",
+    ].join("\n"),
   };
 }
 
@@ -205,6 +329,7 @@ it("cleans every shared runner surface between files", async () => {
     const vitestPackageDir = path.dirname(require.resolve("vitest/package.json"));
     await fs.symlink(path.dirname(vitestPackageDir), path.join(root, "node_modules"), "junction");
     for (const [name, content] of Object.entries(fixtureFiles())) {
+      await fs.mkdir(path.dirname(path.join(root, name)), { recursive: true });
       await fs.writeFile(path.join(root, name), content, "utf8");
     }
     await fs.writeFile(
@@ -251,7 +376,7 @@ it("cleans every shared runner surface between files", async () => {
     // The collection failure is intentional. Every behavior test after it must
     // pass; any leaked surface turns the summary into a second failure.
     expect(output).toContain("synthetic collect failure");
-    expect(output).toContain("1 failed | 11 passed");
+    expect(output).toContain("1 failed | 20 passed");
     expect(output).not.toContain("first-file");
   } finally {
     await fs.rm(root, { recursive: true, force: true });

--- a/test/non-isolated-runner.ts
+++ b/test/non-isolated-runner.ts
@@ -1,5 +1,9 @@
 // Non-isolated runner helps execute tests without Vitest isolation.
 import path from "node:path";
+import type {
+  EvaluatedModuleNode as ViteEvaluatedModuleNode,
+  EvaluatedModules as ViteEvaluatedModules,
+} from "vite/module-runner";
 import { TestRunner, type RunnerTask, type RunnerTestFile, vi } from "vitest";
 import { resetAgentEventsForTest } from "../src/infra/agent-events.js";
 import { loggingState } from "../src/logging/state.js";
@@ -10,15 +14,13 @@ import {
   trackCustomElementRegistry,
 } from "./jsdom-custom-elements.ts";
 
-type EvaluatedModuleNode = {
-  promise?: unknown;
-  exports?: unknown;
-  evaluated?: boolean;
-  importers: Set<string>;
+type EvaluatedModuleNode = ViteEvaluatedModuleNode & {
+  mockedExports?: unknown;
 };
 
 type EvaluatedModules = {
   idToModuleMap: Map<string, EvaluatedModuleNode>;
+  invalidateModule: ViteEvaluatedModules["invalidateModule"];
 };
 
 type SerializableMocker = {
@@ -69,21 +71,23 @@ function getSharedTestHome(): string | undefined {
   return globalState[SHARED_TEST_SETUP]?.tempHome ?? process.env.OPENCLAW_TEST_HOME;
 }
 
-function resetEvaluatedModules(modules: EvaluatedModules, resetMocks: boolean) {
-  const skipPaths = [
-    /\/vitest\/dist\//,
-    /vitest-virtual-\w+\/dist/u,
-    /@vitest\/dist/u,
-    ...(resetMocks ? [] : [/^mock:/u]),
-  ];
+function resetEvaluatedModules(modules: EvaluatedModules) {
+  const skipPaths = [/\/vitest\/dist\//, /vitest-virtual-\w+\/dist/u, /@vitest\/dist/u];
 
   modules.idToModuleMap.forEach((node, modulePath) => {
     if (skipPaths.some((pattern) => pattern.test(modulePath))) {
       return;
     }
-    node.promise = undefined;
-    node.exports = undefined;
-    node.evaluated = false;
+    // Mock metadata owns factories and cached exports after the registry resets.
+    // Retire those nodes while preserving ordinary transformed-code metadata.
+    if (modulePath.startsWith("mock:") || (node.meta && "mockedModule" in node.meta)) {
+      modules.invalidateModule(node);
+      node.mockedExports = undefined;
+    } else {
+      node.promise = undefined;
+      node.exports = undefined;
+      node.evaluated = false;
+    }
     node.importers.clear();
   });
 }
@@ -482,6 +486,6 @@ export default class OpenClawNonIsolatedRunner extends TestRunner {
     resetSharedDocumentBody();
     vi.resetModules();
     internals.moduleRunner?.mocker?.reset?.();
-    resetEvaluatedModules(internals.workerState.evaluatedModules as EvaluatedModules, true);
+    resetEvaluatedModules(internals.workerState.evaluatedModules as EvaluatedModules);
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where non-isolated test workers retained completed files' mock factories and exported fixtures after their module registry had been reset. This was found while investigating a commands-suite heap exhaustion during maintainer-requested QA.

This fixes the demonstrated mock-metadata lifetime defect. **It does not fix the entire commands-suite OOM:** the full 348-file verification still exhausted the default Node 24 heap.

## Why This Change Was Made

The after-file cleanup cleared evaluated exports and promises but left Vite module metadata holding Vitest's mock objects, factories, and cached exports. The runner now uses Vite's canonical invalidation method only for mock-prefixed nodes or metadata carrying a mocked module, and clears Vitest's separate cached mocked exports. Ordinary transformed-code metadata stays reusable, and importer cleanup remains unconditional.

The obsolete `resetMocks` argument/unused alternative path is removed. There are no dependency changes, heap increases, timeout changes, global cache purges, isolation changes, or additional production test seams.

Provenance: the manually maintained reset path was introduced in [1ceaad18a690](https://github.com/openclaw/openclaw/commit/1ceaad18a69007ccc6b4e297a6fa3d143472a335), authored and committed by @steipete on March 22, and carried forward. The historical dependency version at which this became observable has not been established.

## User Impact

No product behavior changes. Developers running non-isolated tests get correct retirement of file-owned manual/automatic mock fixtures while real imports, partial mocks, redirects, and remocking continue to work.

Production LOC: +0/-0. Test support: +20/-16 (net +4). Regression tests: +126/-1 (net +125). AI-assisted with Codex; independently reviewed with no actionable findings.

## Evidence

The existing ordered child-run integration fixture now checks count-only garbage-collection lifetime behavior using owned constructors. On the unchanged runner, exactly the manual and automatic mock lifetime assertions failed (`1` retained instance instead of `0`); the other 18 cases passed. With this fix, both assertions pass. The intentional collection failure and all existing behavioral assertions remain covered, including real → mock → real, partial import-original, redirects, and within-file module resets.

Focused proof on the frozen QA base:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/non-isolated-runner.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs test/non-isolated-runner.test.ts test/non-isolated-runner.resolve-mocks.test.ts
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.root.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-root.tsbuildinfo
```

The first command was RED before the repair and GREEN afterward. The sibling run passed the integration test plus seven mock-resolution tests. Formatting, the root test typecheck, and the canonical explicitly scoped changed gate passed.

The same reviewed patch was rebased without overlap onto `4ef9446daf156f6252bc81e2e250ff3d37755e69`; both source-file hashes and the stable patch ID are unchanged. On head `7fd7a1aad2dd624232bd1e3de1168da26b09eb1d`, explicit Node 24 reran the sibling command above: eight outer tests passed (the integration fixture still requires all 20 child cases and its intentional collection failure). The actual committed-diff gate also passed:

```sh
node scripts/check-changed.mjs --base 4ef9446daf156f6252bc81e2e250ff3d37755e69 --head HEAD -- test/non-isolated-runner.ts test/non-isolated-runner.test.ts
```

Known limitations and follow-ups:

- The same-shape cold commands run selected 348 files with the unchanged canonical config, forks, serial files, `isolate:false`, one worker, and default Node 24 heap. It preserved the original first 209-file order but OOMed during file 214: 213 files completed, with 4,330 passed cases, one known frozen-baseline Doctor assertion failure, three skipped cases, and one worker error. This is explicitly **not** a full-suite pass or complete OOM repair. Both previously failing health-snapshot error-path assertions passed unchanged in this order.
- Residual mock-registry retention is tracked upstream in [Vitest #9492](https://github.com/vitest-dev/vitest/issues/9492). Direct inspection of installed/published Vitest 4.1.11 and a count-only dependency probe confirmed that public clear/reset/restore APIs do not retire original mock or spy closures. That is a distinct lifetime limitation, not proof of its share of the OOM.
- An extra direct type-aware lint invocation reports two unchanged `onAfterRunFiles` async/void diagnostics (`no-misused-promises` and `await-thenable`). They remain a named follow-up; this patch adds no suppression or unrelated hook change. The canonical changed gate passes.
- The original dirty-tree warning-only temporary-directory report used base=head and did not inspect the patch. The passing committed current-main gate supersedes that limited receipt and reports no new temporary-directory migration warnings.

No raw heap snapshots or runtime environment data are uploaded.
