### PR TITLE
perf(sessions): reduce CPU work when listing session previews

### DIFF
--- a/src/gateway/session-transcript-title-reader.markdown.test.ts
+++ b/src/gateway/session-transcript-title-reader.markdown.test.ts
@@ -1,7 +1,12 @@
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { persistSessionTranscriptTurn } from "../config/sessions/session-accessor.js";
+import * as sessionAccessor from "../config/sessions/session-accessor.js";
+import {
+  persistSessionTranscriptTurn,
+  type SessionTranscriptMessageEvent,
+} from "../config/sessions/session-accessor.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
@@ -9,6 +14,15 @@ import {
   readSessionTitleFieldsFromTranscript,
   readSessionTitleFieldsFromTranscriptBatch,
 } from "./session-transcript-title-reader.js";
+
+vi.mock("../config/sessions/session-accessor.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions/session-accessor.js")>();
+  return {
+    ...actual,
+    readSessionTranscriptMessageEventPage: vi.fn(actual.readSessionTranscriptMessageEventPage),
+    readSessionTranscriptTitleProbeBatch: vi.fn(actual.readSessionTranscriptTitleProbeBatch),
+  };
+});
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -81,6 +95,102 @@ describe("session transcript Markdown title previews", () => {
           : readSessionTitleFieldsFromTranscriptBatch([scope])[0];
 
       expect(fields?.lastMessagePreview).toBeNull();
+    },
+  );
+
+  test.each([
+    { mode: "single", widen: false },
+    { mode: "batch", widen: false },
+    { mode: "single", widen: true },
+    { mode: "batch", widen: true },
+  ] as const)(
+    "stops reading older content after the newest visible $mode preview (widen=$widen)",
+    async ({ mode, widen }) => {
+      const hiddenMessages = [
+        { role: "toolResult", content: "tool output" },
+        { role: "system", content: "system event" },
+        { role: "assistant", content: [{ type: "thinking", thinking: "private thought" }] },
+        { role: "assistant", content: "NO_REPLY" },
+        { role: "assistant", content: "ANNOUNCE_SKIP" },
+        { role: "assistant", content: "REPLY_SKIP" },
+        { role: "assistant", content: [{ type: "text", text: "" }] },
+        { role: "assistant", content: "```ts\nconst hidden = true;\n```" },
+      ];
+      const olderText = "Earlier **reply**";
+      // Keep the observed row outside the first-user head probe, including after widening.
+      const prefix = [
+        { role: "user", content: "Keep **title Markdown** unchanged" },
+        ...Array.from({ length: 100 }, () => ({ role: "toolResult", content: "tool output" })),
+      ];
+      const olderSeq = prefix.length + 1;
+      const scope = await writeMessages(`reader-title-short-circuit-${mode}-${widen}`, [
+        ...prefix,
+        { role: "assistant", content: [{ type: "text", text: olderText }] },
+        { role: "assistant", content: "# Latest\n\nRead the [guide](https://example.com)." },
+        ...(widen ? Array.from({ length: 3 }, () => hiddenMessages).flat() : []),
+      ]);
+      const actual = await vi.importActual<typeof import("../config/sessions/session-accessor.js")>(
+        "../config/sessions/session-accessor.js",
+      );
+      const readOlderText = vi.fn(() => olderText);
+      let observedRows = 0;
+      const observeOlderContent = (entries: SessionTranscriptMessageEvent[]) =>
+        entries.map((entry) => {
+          if (entry.seq !== olderSeq) {
+            return entry;
+          }
+          observedRows += 1;
+          return {
+            ...entry,
+            event: {
+              ...asOptionalRecord(entry.event),
+              message: {
+                role: "assistant",
+                // Nested text survives transcript metadata normalization; only projection reads it.
+                content: [
+                  {
+                    type: "text",
+                    get text() {
+                      return readOlderText();
+                    },
+                  },
+                ],
+              },
+            },
+          };
+        });
+      const pageReader = vi.mocked(sessionAccessor.readSessionTranscriptMessageEventPage);
+      const batchReader = vi.mocked(sessionAccessor.readSessionTranscriptTitleProbeBatch);
+      try {
+        pageReader.mockImplementation((readScope, options) => {
+          const page = actual.readSessionTranscriptMessageEventPage(readScope, options);
+          return { ...page, events: observeOlderContent(page.events) };
+        });
+        batchReader.mockImplementation((readScopes) => {
+          const probes = actual.readSessionTranscriptTitleProbeBatch(readScopes);
+          for (const probe of probes) {
+            if (probe) {
+              probe.tail = observeOlderContent(probe.tail);
+            }
+          }
+          return probes;
+        });
+
+        const fields =
+          mode === "single"
+            ? readSessionTitleFieldsFromTranscript(scope)
+            : readSessionTitleFieldsFromTranscriptBatch([scope])[0];
+
+        expect(fields).toEqual({
+          firstUserMessage: "Keep **title Markdown** unchanged",
+          lastMessagePreview: "Latest Read the guide.",
+        });
+        expect(observedRows).toBe(1);
+        expect(readOlderText).not.toHaveBeenCalled();
+      } finally {
+        pageReader.mockImplementation(actual.readSessionTranscriptMessageEventPage);
+        batchReader.mockImplementation(actual.readSessionTranscriptTitleProbeBatch);
+      }
     },
   );
 });

--- a/src/gateway/session-transcript-title-reader.ts
+++ b/src/gateway/session-transcript-title-reader.ts
@@ -94,13 +94,13 @@ function findFirstTitleUserMessage(
 }
 
 function findLastMessageText(entries: readonly SessionTranscriptMessageEvent[]): string | null {
-  return (
-    entries
-      .toReversed()
-      .map(sqliteMessageEventWithSeq)
-      .map((message) => projectSessionDisplayMessage(message, { flattenMarkdown: true }))
-      .find(Boolean)?.text ?? null
-  );
+  let text: string | null = null;
+  entries.findLast((entry) => {
+    const message = sqliteMessageEventWithSeq(entry);
+    text = projectSessionDisplayMessage(message, { flattenMarkdown: true })?.text ?? null;
+    return text !== null;
+  });
+  return text;
 }
 
 function readSqliteTitleFields(


### PR DESCRIPTION
## What Problem This Solves

Resolves unnecessary Gateway CPU work when listing session previews: a readable newest reply still caused older, discarded tail messages to be projected and Markdown-flattened. The ordinary probe contains up to 20 messages, with bounded widening when newer rows are not displayable.

## Why This Change Was Made

Use native reverse short-circuit traversal in the existing title-reader selector. Each visited row still passes through the same transcript normalization and canonical display projector; traversal ends as soon as the newest visible text is found. This removes the eager maps and reversed-array allocation without changing visibility, suppression, Markdown flattening, truncation, null results, title selection, probe limits, or cache behavior.

Production LOC: +7/-7 (net 0). Tests: +112/-2 (net +110). No new production API, dependency, configuration, schema, or cache. AI-assisted with Codex.

## User Impact

Session lists produce the same titles and previews while avoiding unnecessary work on older messages. Hidden, tool, system, thinking-only, suppressed control replies, and Markdown that flattens to empty still fall through according to the existing display rules. There is no visual or protocol change.

Release-note context: reduce redundant transcript projection when generating session-list last-message previews.

## Evidence

Four new regression cases exercise the actual single-session and batched title readers, both with immediate success and bounded widening. They instrument an older nested text accessor at the existing storage-reader seam while retaining real SQLite reads, transcript normalization, and display projection. The observed row is outside the first-user head probe.

Before the production change, all four cases failed because the older text accessor was read three times after a valid newer preview was available; the exact title/preview assertions and all 48 existing tests passed. After the change, all 52 tests pass and the older accessor is untouched.

Focused test command (five files, 52 passed):

```bash
node scripts/run-vitest.mjs src/gateway/session-transcript-title-reader.markdown.test.ts src/gateway/session-transcript-title-reader.placeholder.test.ts src/gateway/session-display-projection.test.ts src/gateway/session-transcript-readers.test.ts src/gateway/session-title-inbound-metadata.test.ts
```

Changed-file validation passed, including core and core-test typechecks, formatting, lint, dead-export and boundary guards, and import-cycle checks:

```bash
node scripts/check-changed.mjs -- src/gateway/session-transcript-title-reader.ts src/gateway/session-transcript-title-reader.markdown.test.ts
```

A local synthetic benchmark using the real display projector and 20 assistant messages (19 older 8,560-byte Markdown messages plus one short newest reply), over 100 iterations, measured 2,000 versus 100 projections and approximately 159.92 ms versus 0.25 ms. Outputs also matched empty, tool-only, hidden-last, suppressed-control, and empty-after-flattening cases. This excludes storage, RPC, and cache costs and is **not a measured production speedup**.

No production service or live state was accessed or changed. This is a bounded behavior-neutral optimization; deterministic reader-boundary regression proof is used rather than visual evidence. Fresh independent autoreview and exact-head CI are recorded in the landing proof.
