### PR TITLE
fix(test): prevent stale SQLite state after PID reuse

### DIFF
--- a/src/commands/backup-sqlite.test.ts
+++ b/src/commands/backup-sqlite.test.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createLocalSqliteSnapshotProvider } from "../snapshot/local-repository.js";
@@ -11,6 +10,10 @@ import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import {
   backupSqliteCreateCommand,
   backupSqliteListCommand,
@@ -27,22 +30,21 @@ vi.mock("../config/config.js", async (importOriginal) => {
   return { ...actual, getRuntimeConfig: configMocks.getRuntimeConfig };
 });
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-let previousStateDir: string | undefined;
+let state: OpenClawTestState;
 
-beforeEach(() => {
-  previousStateDir = process.env.OPENCLAW_STATE_DIR;
+beforeEach(async () => {
+  // Rejected requests can record outcomes too; every case must own its state.
+  state = await createOpenClawTestState({
+    prefix: "openclaw-backup-sqlite-",
+    layout: "state-only",
+  });
   configMocks.getRuntimeConfig.mockReset().mockReturnValue({
     agents: { list: [{ id: "main" }, { id: "ops-team" }] },
   });
 });
 
-afterEach(() => {
-  if (previousStateDir === undefined) {
-    delete process.env.OPENCLAW_STATE_DIR;
-  } else {
-    process.env.OPENCLAW_STATE_DIR = previousStateDir;
-  }
+afterEach(async () => {
+  await state.cleanup();
 });
 
 function createGlobalDatabase(databasePath: string): void {
@@ -131,12 +133,10 @@ function createAgentDatabase(databasePath: string, agentId: string): void {
 
 describe("SQLite backup commands", () => {
   it("creates, lists, verifies, and fresh-restores the global database", async () => {
-    const tempDir = tempDirs.make("openclaw-backup-sqlite-");
-    const stateDir = path.join(tempDir, "state");
+    const tempDir = state.root;
     const repositoryPath = path.join(tempDir, "snapshots");
     const scratchPath = path.join(tempDir, "scratch");
     const restorePath = path.join(tempDir, "restore", "openclaw.sqlite");
-    process.env.OPENCLAW_STATE_DIR = stateDir;
     const databasePath = resolveOpenClawStateSqlitePath();
     await fs.mkdir(path.dirname(databasePath), { recursive: true });
     await fs.mkdir(scratchPath, { mode: 0o700 });
@@ -205,7 +205,7 @@ describe("SQLite backup commands", () => {
   });
 
   it("reports missing snapshot paths for verify and restore", async () => {
-    const tempDir = tempDirs.make("openclaw-backup-sqlite-missing-");
+    const tempDir = state.root;
     const repositoryPath = path.join(tempDir, "snapshots");
     const snapshotPath = path.join(repositoryPath, "missing-snapshot");
     const restorePath = path.join(tempDir, "restored.sqlite");
@@ -235,10 +235,8 @@ describe("SQLite backup commands", () => {
   ])(
     "creates a snapshot for a normalized $label per-agent database",
     async ({ customAgentDir }) => {
-      const tempDir = tempDirs.make("openclaw-backup-sqlite-");
-      const stateDir = path.join(tempDir, "state");
+      const tempDir = state.root;
       const repositoryPath = path.join(tempDir, "snapshots");
-      process.env.OPENCLAW_STATE_DIR = stateDir;
       const agentDir = customAgentDir ? path.join(tempDir, "external-agent") : undefined;
       if (agentDir) {
         configMocks.getRuntimeConfig.mockReturnValue({
@@ -292,7 +290,6 @@ describe("SQLite backup commands", () => {
     ["empty", "", "--agent must not be blank"],
     ["whitespace-only", "   ", "--agent must not be blank"],
   ])("rejects an %s SQLite snapshot agent", async (_label, agent, message) => {
-    process.env.OPENCLAW_STATE_DIR = tempDirs.make("openclaw-backup-sqlite-agent-rejection-");
     await expect(
       backupSqliteCreateCommand(createRuntimeCapture(), {
         agent,
@@ -302,10 +299,8 @@ describe("SQLite backup commands", () => {
   });
 
   it("does not claim completion when a corrupt database also rejects outcome recording", async () => {
-    const tempDir = tempDirs.make("openclaw-backup-sqlite-corrupt-");
-    const stateDir = path.join(tempDir, "state");
+    const tempDir = state.root;
     const repositoryPath = path.join(tempDir, "snapshots");
-    process.env.OPENCLAW_STATE_DIR = stateDir;
     const databasePath = resolveOpenClawStateSqlitePath();
     await fs.mkdir(path.dirname(databasePath), { recursive: true });
     await fs.writeFile(databasePath, Buffer.alloc(32));
@@ -336,7 +331,7 @@ describe("SQLite backup commands", () => {
   });
 
   it("rejects generic provider artifacts before verify or restore", async () => {
-    const tempDir = tempDirs.make("openclaw-backup-sqlite-");
+    const tempDir = state.root;
     const databasePath = path.join(tempDir, "generic.sqlite");
     const repositoryPath = path.join(tempDir, "snapshots");
     const restorePath = path.join(tempDir, "restore", "generic.sqlite");

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -1,7 +1,6 @@
 // OpenClaw agent database tests cover agent-scoped DB storage and migrations.
 import { execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
@@ -993,26 +992,23 @@ describe("openclaw agent database", () => {
     ).toBe(path.join(stateDir, "agents", "worker-1", "agent", "openclaw-agent.sqlite"));
   });
 
-  it("keeps test default state under a worker-sharded temp directory", () => {
-    expect(
-      resolveOpenClawAgentSqlitePath({
-        agentId: "main",
-        env: {
-          VITEST: "true",
-          VITEST_WORKER_ID: "7",
-        } as NodeJS.ProcessEnv,
-      }),
-    ).toBe(
-      path.join(
-        os.tmpdir(),
-        "openclaw-test-state",
-        `${process.pid}-7`,
-        "agents",
-        "main",
-        "agent",
-        "openclaw-agent.sqlite",
-      ),
-    );
+  it("opens the agent and its shared registry under the default HOME state owner", () => {
+    const home = createTempStateDir();
+    const env = { HOME: home, NODE_ENV: "test" };
+    const options = { agentId: "main", env };
+    const stateDir = path.join(home, ".openclaw");
+    const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+
+    // Fail before opening if path resolution escapes the test-owned home.
+    expect(resolveOpenClawAgentSqlitePath(options)).toBe(agentPath);
+    const agent = openOpenClawAgentDatabaseRuntime(options);
+    const shared = openOpenClawStateDatabase({ env });
+
+    expect(agent.path).toBe(agentPath);
+    expect(shared.path).toBe(path.join(stateDir, "state", "openclaw.sqlite"));
+    expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([
+      expect.objectContaining({ agentId: "main", path: agentPath }),
+    ]);
   });
 
   it("returns typed not-found without creating a missing read-only database", () => {

--- a/src/state/openclaw-state-db.paths.ts
+++ b/src/state/openclaw-state-db.paths.ts
@@ -1,38 +1,10 @@
 // State database path helpers resolve shared OpenClaw state DB paths.
-import os from "node:os";
 import path from "node:path";
-import { isMainThread, threadId } from "node:worker_threads";
-import { parseStrictNonNegativeInteger } from "@openclaw/normalization-core/number-coercion";
 import { resolveStateDir } from "../config/paths.js";
-
-/**
- * Path helpers for the shared OpenClaw SQLite state database.
- *
- * Tests get worker-scoped temp state roots unless they explicitly provide
- * `OPENCLAW_STATE_DIR`, which prevents parallel Vitest workers from sharing WAL files.
- */
-function resolveOpenClawStateRootDir(env: NodeJS.ProcessEnv): string {
-  if (env.OPENCLAW_STATE_DIR?.trim()) {
-    return resolveStateDir(env);
-  }
-  if (env.VITEST || env.NODE_ENV === "test") {
-    const workerId = parseStrictNonNegativeInteger(
-      env.VITEST_WORKER_ID ?? env.VITEST_POOL_ID ?? "",
-    );
-    const shardSuffix =
-      workerId !== undefined
-        ? `${process.pid}-${workerId}`
-        : isMainThread
-          ? String(process.pid)
-          : `${process.pid}-${threadId}`;
-    return path.join(os.tmpdir(), "openclaw-test-state", shardSuffix);
-  }
-  return resolveStateDir(env);
-}
 
 /** Resolve the directory that contains the shared state SQLite file. */
 export function resolveOpenClawStateSqliteDir(env: NodeJS.ProcessEnv = process.env): string {
-  return path.join(resolveOpenClawStateRootDir(env), "state");
+  return path.join(resolveStateDir(env), "state");
 }
 
 /** Resolve the shared state SQLite file path. */

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -1560,14 +1560,14 @@ describe("openclaw state database", () => {
     );
   });
 
-  it("keeps test default state under a worker-sharded temp directory", () => {
-    expect(
-      resolveOpenClawStateSqlitePath({
-        VITEST: "true",
-        VITEST_WORKER_ID: "7",
-      } as NodeJS.ProcessEnv),
-    ).toBe(
-      path.join(os.tmpdir(), "openclaw-test-state", `${process.pid}-7`, "state", "openclaw.sqlite"),
+  it.each([
+    { NODE_ENV: "production" },
+    { NODE_ENV: "test" },
+    { VITEST: "true", VITEST_WORKER_ID: "7" },
+  ])("resolves default SQLite state through HOME with %j", (runtimeEnv) => {
+    const home = createTempStateDir();
+    expect(resolveOpenClawStateSqlitePath({ ...runtimeEnv, HOME: home })).toBe(
+      path.join(home, ".openclaw", "state", "openclaw.sqlite"),
     );
   });
 

--- a/test/test-env.state-lifetime.test.ts
+++ b/test/test-env.state-lifetime.test.ts
@@ -1,0 +1,174 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listOpenClawRegisteredAgentDatabases } from "../src/state/openclaw-agent-db-registry-listing.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  openOpenClawStateDatabase,
+  OPENCLAW_STATE_SCHEMA_VERSION,
+} from "../src/state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../src/state/openclaw-state-db.paths.js";
+import { captureFullEnv, setTestEnvValue, withPathResolutionEnv } from "../src/test-utils/env.js";
+import { cleanupTempDirs, makeTempDir } from "./helpers/temp-dir.js";
+import { installTestEnv } from "./test-env.js";
+
+const require = createRequire(import.meta.url);
+const pathsModule = path.resolve(import.meta.dirname, "../src/state/openclaw-state-db.paths.ts");
+const tempDirs = new Set<string>();
+const cleanups: Array<() => void> = [];
+let sandbox: string;
+
+function installOwnedEnv() {
+  const testEnv = installTestEnv({ mode: "hermetic" });
+  const databasePath = resolveOpenClawStateSqlitePath();
+  cleanups.push(() => {
+    // Callers close their handles before the environment removes its filesystem tree.
+    closeOpenClawStateDatabaseByPath(databasePath);
+    testEnv.cleanup();
+  });
+  return { ...testEnv, databasePath };
+}
+
+beforeEach(() => {
+  const snapshot = captureFullEnv();
+  cleanups.push(snapshot.restore);
+  sandbox = makeTempDir(tempDirs, "openclaw-test-state-lifetime-");
+  vi.spyOn(os, "tmpdir").mockReturnValue(sandbox);
+  setTestEnvValue("VITEST_WORKER_ID", "7");
+});
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()?.();
+  }
+  vi.restoreAllMocks();
+  cleanupTempDirs(tempDirs);
+});
+
+describe("test environment SQLite lifetime", () => {
+  it("does not reuse a legacy database in a recycled PID namespace", () => {
+    // Reproduce the old namespace only beneath a directory this test created.
+    const legacyPath = path.join(
+      sandbox,
+      "openclaw-test-state",
+      `${process.pid}-7`,
+      "state",
+      "openclaw.sqlite",
+    );
+    fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
+    const legacy = new DatabaseSync(legacyPath);
+    legacy.exec(`
+      PRAGMA user_version = 9;
+      CREATE TABLE agent_databases (
+        agent_id TEXT NOT NULL, path TEXT NOT NULL, schema_version INTEGER NOT NULL,
+        last_seen_at INTEGER NOT NULL, size_bytes INTEGER, PRIMARY KEY (agent_id, path)
+      );
+      CREATE TABLE auth_profile_stores (agent_id TEXT PRIMARY KEY);
+    `);
+    legacy.close();
+    const legacyBytes = fs.readFileSync(legacyPath);
+    expect(() => listOpenClawRegisteredAgentDatabases({ path: legacyPath })).toThrow(
+      "has a legacy agent database registry schema",
+    );
+
+    const testEnv = installOwnedEnv();
+    expect(listOpenClawRegisteredAgentDatabases()).toEqual([]);
+    const database = openOpenClawStateDatabase();
+    expect(database.path).toBe(
+      path.join(testEnv.tempHome, ".openclaw", "state", "openclaw.sqlite"),
+    );
+    expect(database.db.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
+
+    cleanups.pop()?.();
+    expect(fs.existsSync(testEnv.tempHome)).toBe(false);
+    expect(fs.existsSync(database.path)).toBe(false);
+    expect(fs.readFileSync(legacyPath)).toEqual(legacyBytes);
+  });
+
+  it("owns distinct nested and subsequent generations and restores the caller's state", () => {
+    const callerState = path.join(sandbox, "caller-state");
+    fs.mkdirSync(callerState);
+    fs.writeFileSync(path.join(callerState, "keep"), "caller-owned");
+    setTestEnvValue("OPENCLAW_STATE_DIR", callerState);
+    const callerHome = process.env.HOME;
+    const callerTestHome = process.env.OPENCLAW_TEST_HOME;
+    const outer = installOwnedEnv();
+    const outerDatabase = openOpenClawStateDatabase();
+    expect(resolveOpenClawStateSqlitePath()).toBe(outer.databasePath);
+    expect(openOpenClawStateDatabase()).toBe(outerDatabase);
+
+    const inner = installOwnedEnv();
+    expect(inner.databasePath).not.toBe(outer.databasePath);
+    expect(openOpenClawStateDatabase().path).toBe(inner.databasePath);
+    cleanups.pop()?.();
+    expect(fs.existsSync(inner.tempHome)).toBe(false);
+    expect(fs.existsSync(inner.databasePath)).toBe(false);
+    expect(process.env.HOME).toBe(outer.tempHome);
+    expect(process.env.OPENCLAW_TEST_HOME).toBe(outer.tempHome);
+    expect(openOpenClawStateDatabase()).toBe(outerDatabase);
+
+    cleanups.pop()?.();
+    expect(fs.existsSync(outer.databasePath)).toBe(false);
+    expect(process.env.HOME).toBe(callerHome);
+    expect(process.env.OPENCLAW_TEST_HOME).toBe(callerTestHome);
+    expect(process.env.OPENCLAW_STATE_DIR).toBe(callerState);
+    const next = installOwnedEnv();
+    expect(next.databasePath).not.toBe(outer.databasePath);
+    expect(next.databasePath).not.toBe(inner.databasePath);
+    expect(fs.readFileSync(path.join(callerState, "keep"), "utf8")).toBe("caller-owned");
+  });
+
+  it("follows a nested HOME scope without pinning it to the enclosing test home", () => {
+    const outer = installOwnedEnv();
+    const nestedHome = makeTempDir(tempDirs, "nested-home-", sandbox);
+    withPathResolutionEnv(nestedHome, {}, () => {
+      expect(resolveOpenClawStateSqlitePath()).toBe(
+        path.join(nestedHome, ".openclaw", "state", "openclaw.sqlite"),
+      );
+    });
+    expect(resolveOpenClawStateSqlitePath()).toBe(outer.databasePath);
+  });
+
+  it("shares the owned path across module reloads, inherited workers, and subprocesses", async () => {
+    const testEnv = installOwnedEnv();
+    const freshPaths = await vi.importActual<
+      typeof import("../src/state/openclaw-state-db.paths.js")
+    >("../src/state/openclaw-state-db.paths.js?lifetime");
+    expect(freshPaths.resolveOpenClawStateSqlitePath()).toBe(testEnv.databasePath);
+    const source = `
+      import { resolveOpenClawStateSqlitePath } from ${JSON.stringify(pathToFileURL(pathsModule).href)};
+      process.stdout.write(resolveOpenClawStateSqlitePath());
+    `;
+    const childPath = execFileSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", source],
+      { env: { ...process.env }, encoding: "utf8" },
+    );
+    expect(childPath).toBe(testEnv.databasePath);
+
+    const worker = new Worker(
+      `require(${JSON.stringify(require.resolve("tsx/cjs"))});
+       const { parentPort } = require("node:worker_threads");
+       const { resolveOpenClawStateSqlitePath } = require(${JSON.stringify(pathsModule)});
+       parentPort.postMessage(resolveOpenClawStateSqlitePath());`,
+      { eval: true, execArgv: [], env: { ...process.env, VITEST_WORKER_ID: "8" } },
+    );
+    try {
+      const workerPath = await new Promise<string>((resolve, reject) => {
+        worker.once("message", resolve);
+        worker.once("error", reject);
+      });
+      expect(workerPath).toBe(testEnv.databasePath);
+    } finally {
+      await worker.terminate();
+    }
+  });
+});

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -241,7 +241,8 @@ function createIsolatedTestHome(restore: RestoreEntry[]): {
   deleteTestEnvValue("OPENCLAW_HOME");
   // Ensure test runs never touch the developer's real config/state, even if they have overrides set.
   deleteTestEnvValue("OPENCLAW_CONFIG_PATH");
-  // Prefer deriving state dir from HOME so nested tests that change HOME also isolate correctly.
+  // Derive all state, including SQLite, from this unique HOME so cleanup owns it.
+  // Leave the override unset so nested HOME scopes also isolate their state.
   deleteTestEnvValue("OPENCLAW_STATE_DIR");
   deleteTestEnvValue("OPENCLAW_AGENT_DIR");
   // Prefer test-controlled ports over developer overrides (avoid port collisions across tests/workers).


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed. This is a same-repository branch.

</details>

Related: #131313 (POSIX wrapper invocation cleanup; separate from environment-generation ownership here).

## What Problem This Solves

Resolves a problem where developers running tests encounter legacy SQLite schema rejection after a reused process/worker ID selects a database left by an earlier run. Creating a fresh test environment did not create fresh database state, and cleaning up its HOME did not remove that database.

This is a bounded, maintainer-requested harness repair. A deterministic regression reproduces the stale-schema failure using only a newly allocated test-owned sandbox; no historical databases are swept or changed.

## Why This Change Was Made

The shared SQLite path now follows canonical `resolveStateDir` and the unique HOME already allocated and tracked by `installTestEnv`, deleting the duplicate test-only PID/worker path policy. Each environment generation therefore owns its database lifetime, while repeated calls, module reloads, inherited workers/subprocesses, and deliberate explicit roots retain their intended sharing.

Nested HOME scopes still work because the harness continues to leave `OPENCLAW_STATE_DIR` unset. Explicit state overrides and normal non-test resolution are unchanged; no schema, configuration, dependency, allocator, fallback, or eager database imports are added. The SQLite backup test suite now uses the existing per-case state fixture for every case, including rejected requests that record backup outcomes. This removes the ambient-state leak exposed by the first CI run without changing status assertions or production backup behavior.

Invocation cleanup in #131313 is complementary: this change also separates nested/subsequent environments within one invocation and does not depend on a POSIX wrapper.

## User Impact

Developers get fresh SQLite state with each owned test environment and cleanup of that environment's files. There is no normal production runtime behavior change. Live-aware staging, explicit-root subprocess sharing, and caller-owned roots remain intact.

## Evidence

Exact-head [CI run 33133182504](https://github.com/openclaw/openclaw/actions/runs/33133182504) completed successfully: 162 jobs succeeded and 17 were intentionally skipped. The required `openclaw/ci-gate` and both hosted Windows test jobs passed. The formerly failing command shard passed **1,024 tests, 1 existing skip, across 92 files**, including the original backup-before-status order.

- The new lifetime suite produced **4 intended failures before the resolver change**, then **4 passes**. It exercises the real legacy schema guard, preserves the seeded legacy database bytes, and verifies distinct generations, stable resolution, nested HOME, restoration, cleanup, and module/worker/subprocess sharing.
- Final serial owner/sibling run: **354 passed, 7 existing platform/filesystem skips across 14 files**. Includes the complete agent DB suite (**112 passed, 4 skipped**), shared DB suite (**175 passed, 2 skipped**), lifetime suite, incognito paths, cleanup helpers, session ownership, and all **3 SDK recovery cases**.
- Real explicit-root CLI subprocess maintenance: **6 passed**, including compaction of the parent's database by a child CLI.
- Environment ordering: **17 passed** with isolation disabled; **16 passed** with isolation enabled. A real macOS process-exit probe verified owned HOME/shared/agent databases remain removed after exit hooks. Independent Node 24 selected proof: **8 passed**.
- The first exact-head CI run (33130803093) exposed two status JSON failures caused by the backup test producer leaking error history. A deterministic backup-before-status replay with a real database in a harness-owned HOME reproduced **12 passed / 2 failed**; after the fixture repair, the identical replay passed **14/14**. No CI rerun or consumer override was used.
- After that producer repair, a fresh single wrapper invocation ran the full agent DB, shared DB, lifetime, backup, and status JSON suites: **305 passed, 6 existing skips across 5 files**.
- The obsolete agent PID assertion was separately reproduced before replacement. Its replacement checks the owned path before opening real agent/shared databases and verifying registry discovery.

```bash
OPENCLAW_VITEST_MAX_WORKERS=16 node scripts/run-vitest.mjs test/test-env.state-lifetime.test.ts

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/state/openclaw-agent-db.test.ts src/state/openclaw-state-db.test.ts \
  test/test-env.state-lifetime.test.ts src/state/openclaw-agent-db.incognito.test.ts \
  src/state/openclaw-state-db-readonly.test.ts src/state/openclaw-database-paths.windows.test.ts \
  test/test-env.test.ts test/setup-home-isolation.test.ts \
  src/config/sessions/session-sqlite-target.test.ts \
  src/config/sessions/session-sqlite-target.ownership.test.ts \
  src/plugin-sdk/session-store-runtime.recovery.test.ts src/test-utils/env.test.ts \
  src/test-utils/openclaw-test-state.test.ts src/test-utils/session-state-cleanup.test.ts \
  --maxWorkers=1 --no-file-parallelism --reporter=verbose

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/commands/backup-sqlite.test.ts src/commands/status-json.test.ts \
  src/state/openclaw-agent-db.test.ts src/state/openclaw-state-db.test.ts \
  test/test-env.state-lifetime.test.ts --maxWorkers=1 --no-file-parallelism --reporter=verbose

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  test/cli-state-sqlite.e2e.test.ts --maxWorkers=1 --no-file-parallelism --reporter=verbose

node scripts/check-changed.mjs -- \
  src/state/openclaw-state-db.paths.ts src/state/openclaw-state-db.test.ts \
  src/state/openclaw-agent-db.test.ts test/test-env.ts test/test-env.state-lifetime.test.ts \
  src/commands/backup-sqlite.test.ts
```

The full changed gate passed after removing the obsolete agent test's unused import. No assertions, schema guards, retries, or timeouts were weakened. Local proof is on macOS; no local Windows execution was performed. Both hosted Windows test jobs passed in final CI. No UI/provider behavior changes require screenshots or authenticated gateway testing.

Production LOC: **+1/-29 (net -28)**. Tests: **+217/-52 (net +165)**. Test support: **+2/-1**, comment only. AI-assisted with Codex; implementation and ownership were inspected directly.

Fresh isolated Codex autoreview completed with no accepted/actionable findings at the default P0 scope before publication; another fresh isolated pass covered the backup fixture follow-up before its commit. The unchanged owner/caller/sibling paths were inspected separately, and current `main` still contains the PID policy being removed.
