### PR TITLE
fix(transcripts): stop reporting replaced captures as active

### DIFF
--- a/docs/cli/transcripts.md
+++ b/docs/cli/transcripts.md
@@ -103,11 +103,23 @@ when it will not repeat on the same date.
 
 ## Missing summaries
 
-Live sessions save summaries when capture stops; imported transcripts do so
-immediately after import. Tool-driven stops, configured auto-start shutdown, and
-imports also attempt to materialize `summary.md`. A session can appear in `list`
-without a summary while capture is still active, if a provider failed during stop,
-or if metadata was stored before any utterances arrived.
+The tool's `status` action lists active capture subscriptions, not historical
+notes. When a provider ends or replaces a subscription, OpenClaw records
+`stoppedAt` and stores its summary; the transcript remains available to `list`,
+`show`, and the tool's `summarize` action. A temporary transport disconnect does
+not end a subscription. Stopping historical notes does not stop a newer capture
+or change the recorded stop time.
+
+Provider-driven completion stores the summary without exporting files. Explicit
+tool stop, import, summarize, and configured auto-start shutdown also attempt to
+materialize `summary.md`.
+If terminal persistence fails, `status` reports the ended capture under
+`pendingFinalization`, separately from active captures. Use the tool's `stop`
+action for that session to retry persistence without stopping the provider again.
+
+A session can appear in `list` without a summary while capture is still active,
+if a provider failed during stop, or if metadata was stored before any utterances
+arrived.
 
 Use `path <session> --transcript` to inspect the raw append-only transcript,
 or run the `transcripts` tool's `summarize` action to regenerate the Markdown

--- a/extensions/discord/src/voice/realtime-turns.test.ts
+++ b/extensions/discord/src/voice/realtime-turns.test.ts
@@ -32,6 +32,45 @@ defineDiscordVoiceTests(
     expectUserMessageIncludes,
     expectUserMessageNotIncludes,
   }) => {
+    it.each(["before-final", "before-delivery"] as const)(
+      "keeps realtime transcript output with its retired audio binding %s",
+      async (ordering) => {
+        const manager = createAgentProxyManager(undefined, {
+          voice: { realtime: { requireWakeName: true } },
+        });
+        await manager.join({ guildId: "g1", channelId: "1001" });
+        const first = vi.fn();
+        const second = vi.fn();
+        await manager.join(
+          { guildId: "g1", channelId: "1001" },
+          { transcripts: { sessionId: "old", onUtterance: first } },
+        );
+        const entry = getSessionEntry(manager);
+        const bridge = lastRealtimeBridgeParams();
+        beginSpeakerTurn(entry);
+        if (ordering === "before-delivery") {
+          bridge?.onTranscript?.("user", "old room speech", true);
+        }
+        const replacing = manager.join(
+          { guildId: "g1", channelId: "1001" },
+          { transcripts: { sessionId: "new", onUtterance: second } },
+        );
+        await replacing;
+        if (ordering === "before-final") {
+          bridge?.onTranscript?.("user", "old room speech", true);
+        }
+        await Promise.resolve();
+        expect(first).not.toHaveBeenCalled();
+        expect(second).not.toHaveBeenCalled();
+        beginSpeakerTurn(entry);
+        await emitFinalRealtimeUserTranscript(bridge, "fresh room speech");
+        expect(second).toHaveBeenCalledWith(
+          expect.objectContaining({ sessionId: "new", text: "fresh room speech" }),
+        );
+        await manager.destroy();
+      },
+    );
+
     it("applies Discord realtime model and voice overrides during provider auto-selection", async () => {
       const manager = createManager(
         makeVoiceConfig(

--- a/extensions/discord/src/voice/realtime-turns.ts
+++ b/extensions/discord/src/voice/realtime-turns.ts
@@ -36,6 +36,8 @@ const DISCORD_REALTIME_TRAILING_SILENCE_MAX_MS = 3_000;
 export type DiscordRealtimeSpeakerContext = VoiceRealtimeSpeakerContext & { userId: string };
 
 type PendingSpeakerTurnStats = {
+  // Final text keeps the audio turn's subscription across capture replacement.
+  transcripts: VoiceSessionEntry["transcripts"];
   inputDiscordBytes: number;
   inputRealtimeBytes: number;
   inputChunks: number;
@@ -48,6 +50,7 @@ type PendingSpeakerTurn = RealtimeVoiceTurnContextHandle<
 >;
 
 type TranscriptUtteranceAttribution = {
+  transcripts: VoiceSessionEntry["transcripts"];
   context: DiscordRealtimeSpeakerContext;
   startedAt: number;
 };
@@ -72,6 +75,7 @@ export class DiscordRealtimeTurns {
         context: DiscordRealtimeSpeakerContext;
         startedAt: number;
         expiresAt: number;
+        transcripts: VoiceSessionEntry["transcripts"];
       }
     | undefined;
 
@@ -101,6 +105,7 @@ export class DiscordRealtimeTurns {
     const turn = this.speakerTurns.open(
       { ...context, userId },
       {
+        transcripts: this.params.entry.transcripts,
         inputDiscordBytes: 0,
         inputRealtimeBytes: 0,
         inputChunks: 0,
@@ -319,7 +324,9 @@ export class DiscordRealtimeTurns {
   private transcriptAttributionFromTurn(
     turn: PendingSpeakerTurn | undefined,
   ): TranscriptUtteranceAttribution | undefined {
-    return turn ? { context: turn.context, startedAt: turn.startedAt } : undefined;
+    return turn
+      ? { context: turn.context, startedAt: turn.startedAt, transcripts: turn.transcripts }
+      : undefined;
   }
 
   private recordTranscriptUtterance(
@@ -327,8 +334,8 @@ export class DiscordRealtimeTurns {
     attribution: TranscriptUtteranceAttribution | undefined,
     providerEpoch: number,
   ): void {
-    const transcripts = this.params.entry.transcripts;
-    if (!transcripts || !attribution) {
+    const transcripts = attribution?.transcripts;
+    if (!transcripts || !attribution || this.params.entry.transcripts !== transcripts) {
       return;
     }
     const context = attribution.context;
@@ -347,7 +354,10 @@ export class DiscordRealtimeTurns {
     };
     void Promise.resolve()
       .then(() => {
-        if (providerEpoch !== this.params.providerEpoch()) {
+        if (
+          providerEpoch !== this.params.providerEpoch() ||
+          this.params.entry.transcripts !== transcripts
+        ) {
           return;
         }
         return transcripts.onUtterance(utterance);
@@ -374,6 +384,7 @@ export class DiscordRealtimeTurns {
     }
     this.pendingWakeNameFollowup = {
       context,
+      transcripts: turn?.transcripts,
       startedAt: turn?.startedAt ?? Date.now(),
       expiresAt,
     };
@@ -397,7 +408,11 @@ export class DiscordRealtimeTurns {
     if (currentTurn) {
       this.consumePendingSpeakerContext();
     }
-    return { context: pending.context, startedAt: pending.startedAt };
+    return {
+      context: pending.context,
+      startedAt: pending.startedAt,
+      transcripts: pending.transcripts,
+    };
   }
 
   private rememberIgnoredWakeNameSpeakerContext(

--- a/extensions/discord/src/voice/segment.test.ts
+++ b/extensions/discord/src/voice/segment.test.ts
@@ -16,9 +16,75 @@ defineDiscordVoiceTests(
     loggerWarnMock,
     makeVoiceConfig,
     processVoiceSegment,
+    transcribeAudioFileMock,
+    decodeOpusStreamMock,
     textToSpeechMock,
     textToSpeechStreamMock,
   }) => {
+    it.each(["transcribing", "queued"] as const)(
+      "drops retired transcript audio while %s",
+      async (phase) => {
+        const client = createClientWithMember("u-guest", "Guest", "4321");
+        const manager = createManager(
+          makeVoiceConfig({}, { groupPolicy: "open", allowFrom: ["discord:u-guest"] }),
+          client,
+        );
+        const first = vi.fn();
+        const second = vi.fn();
+        const onStop = vi.fn();
+        await manager.join(
+          { guildId: "g1", channelId: "1001" },
+          { transcripts: { sessionId: "old", onUtterance: first, onStop } },
+        );
+        const entry = getSessionEntry(manager);
+        let release!: () => void;
+        const gate = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        let entered!: () => void;
+        const started = new Promise<void>((resolve) => {
+          entered = resolve;
+        });
+        let processing: Promise<void>;
+        if (phase === "transcribing") {
+          transcribeAudioFileMock.mockImplementationOnce(async () => {
+            entered();
+            await gate;
+            return { text: "retired" };
+          });
+          processing = getVoiceReceive(manager).processSegment({
+            entry,
+            wavPath: "/tmp/test.wav",
+            userId: "u-guest",
+            durationSeconds: 1,
+          });
+          await started;
+        } else {
+          entry.processingQueue = gate;
+          decodeOpusStreamMock.mockResolvedValueOnce(Buffer.alloc(192_000));
+          await getVoiceReceive(manager).handleSpeakingStart(entry, "u-guest");
+          processing = entry.processingQueue;
+        }
+        await manager.join(
+          { guildId: "g1", channelId: "1001" },
+          { transcripts: { sessionId: "new", onUtterance: second } },
+        );
+        release();
+        await processing;
+        expect(first).not.toHaveBeenCalled();
+        expect(second).not.toHaveBeenCalled();
+        expect(onStop).toHaveBeenCalledOnce();
+        await getVoiceReceive(manager).processSegment({
+          entry,
+          wavPath: "/tmp/test.wav",
+          userId: "u-guest",
+          durationSeconds: 1,
+        });
+        expect(second).toHaveBeenCalledOnce();
+        await manager.destroy();
+      },
+    );
+
     it("keeps streaming TTS audio alive until Discord finishes playback without a duration deadline", async () => {
       const release = vi.fn(async () => undefined);
       let finishPlayback!: () => void;

--- a/extensions/discord/src/voice/segment.ts
+++ b/extensions/discord/src/voice/segment.ts
@@ -79,6 +79,10 @@ export async function processDiscordVoiceSegment(params: {
     `transcript from ${ingress.speakerLabel} (${userId}) in guild ${entry.guildId} channel ${entry.channelId}: ${formatVoiceLogPreview(transcript)}`,
   );
   if (params.transcripts) {
+    // Ingress and STT awaits can outlive this binding while the voice entry is reused.
+    if (entry.sessionLifecycle.status === "stopped" || entry.transcripts !== params.transcripts) {
+      return;
+    }
     await params.transcripts.onUtterance({
       sessionId: params.transcripts.sessionId,
       startedAt: new Date().toISOString(),

--- a/extensions/discord/src/voice/session.ts
+++ b/extensions/discord/src/voice/session.ts
@@ -110,6 +110,7 @@ export type VoiceSessionEntry = {
   transcripts?: {
     sessionId: string;
     onUtterance: (utterance: TranscriptUtterance) => void | Promise<void>;
+    onStop?: () => void | Promise<void>;
   };
   receiveRecovery: VoiceReceiveRecoveryState;
   stop: (reason?: string) => void;

--- a/extensions/discord/src/voice/transcripts-source.lifecycle.test.ts
+++ b/extensions/discord/src/voice/transcripts-source.lifecycle.test.ts
@@ -1,0 +1,157 @@
+import path from "node:path";
+import { activeSessions } from "../../../../src/agents/tools/transcripts-tool-runtime.js";
+import { createTranscriptsTool } from "../../../../src/agents/tools/transcripts-tool.js";
+import { createEmptyPluginRegistry } from "../../../../src/plugins/registry-empty.js";
+import { withPluginRuntimeRegistryScope } from "../../../../src/plugins/runtime/gateway-request-scope.js";
+import { closeOpenClawStateDatabaseForTest } from "../../../../src/state/openclaw-state-db.js";
+import { TranscriptsStore } from "../../../../src/transcripts/store.js";
+import { createTempDirTracker } from "../../../../test/helpers/temp-dir.js";
+import {
+  discordVoiceTranscriptsSourceProvider,
+  setDiscordTranscriptsVoiceManager,
+} from "./transcripts-source.js";
+import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+
+defineDiscordVoiceTests(
+  ({
+    expect,
+    expectDefined,
+    it,
+    vi,
+    createClientWithMember,
+    createManager,
+    makeVoiceConfig,
+    getSessionEntry,
+    getVoiceReceive,
+    expectConnectedStatus,
+    requireRecord,
+    transcribeAudioFileMock,
+  }) => {
+    it("retires a replaced transcript capture in core without stopping its Discord replacement", async () => {
+      const tempDirs = createTempDirTracker();
+      const stateDir = tempDirs.make("discord-transcripts-replacement-");
+      const accountId = "transcript-replacement";
+      const discordConfig = makeVoiceConfig(
+        {},
+        { token: "test-token", groupPolicy: "open", allowFrom: ["discord:u-speaker"] },
+      );
+      const config = {
+        transcripts: { enabled: true },
+        channels: { discord: { accounts: { [accountId]: discordConfig } } },
+      };
+      const manager = createManager(
+        discordConfig,
+        createClientWithMember("u-speaker", "Speaker", "0001"),
+        config,
+        accountId,
+      );
+      const registry = createEmptyPluginRegistry();
+      registry.transcriptSourceProviders.push({
+        pluginId: "discord",
+        source: "discord/transcripts-source-api.ts",
+        provider: discordVoiceTranscriptsSourceProvider,
+      });
+      const tool = createTranscriptsTool({
+        config,
+        stateDir,
+        agentId: "transcript-replacement",
+        caller: { kind: "operator", source: "local" },
+      });
+      const execute = (params: Record<string, unknown>) =>
+        withPluginRuntimeRegistryScope(registry, () => tool.execute("transcripts", params));
+      const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      });
+      const source = { providerId: "discord-voice", accountId, guildId: "g1", channelId: "1001" };
+      const providerStop = vi.spyOn(discordVoiceTranscriptsSourceProvider, "stop");
+      setDiscordTranscriptsVoiceManager({ accountId, manager });
+
+      try {
+        await expect(
+          execute({ action: "start", sessionId: "first", ...source }),
+        ).resolves.toMatchObject({
+          details: { sessionId: "first", providerId: "discord-voice", accountId },
+        });
+        const entry = getSessionEntry(manager);
+        const segment = {
+          entry,
+          wavPath: path.join(stateDir, "speech.wav"),
+          userId: "u-speaker",
+          durationSeconds: 1,
+        };
+        transcribeAudioFileMock.mockResolvedValueOnce({
+          text: "Keep the original historical note.",
+        });
+        await getVoiceReceive(manager).processSegment(segment);
+
+        await expect(
+          execute({ action: "start", sessionId: "second", ...source }),
+        ).resolves.toMatchObject({
+          details: { sessionId: "second", providerId: "discord-voice", accountId },
+        });
+        transcribeAudioFileMock.mockResolvedValueOnce({
+          text: "This belongs only to the replacement.",
+        });
+        await getVoiceReceive(manager).processSegment({
+          ...segment,
+          entry: getSessionEntry(manager),
+        });
+
+        const first = expectDefined(await store.readSession("first"), "first capture");
+        const second = expectDefined(await store.readSession("second"), "second capture");
+        expect(first.source).toMatchObject(source);
+        expect(second.source).toEqual(first.source);
+        expect(
+          (await store.readUtterancesForSession(first)).map((utterance) => utterance.text),
+        ).toEqual(["Keep the original historical note."]);
+        expect(
+          (await store.readUtterancesForSession(second)).map((utterance) => utterance.text),
+        ).toEqual(["This belongs only to the replacement."]);
+        expectConnectedStatus(manager, "1001");
+        expect(providerStop).not.toHaveBeenCalled();
+
+        const status = await execute({ action: "status" });
+        const active = requireRecord(status.details, "transcript status").active;
+        expect(Array.isArray(active)).toBe(true);
+        if (!Array.isArray(active)) {
+          throw new Error("expected transcript status active sessions");
+        }
+        // Keep the stale-status failure first, then exercise historical recovery as well.
+        expect
+          .soft(active.map((capture) => requireRecord(capture, "active capture").sessionId))
+          .toEqual(["second"]);
+        expect.soft(first.stoppedAt).toEqual(expect.any(String));
+
+        await expect(execute({ action: "summarize", sessionId: "first" })).resolves.toMatchObject({
+          details: { summary: { sessionId: "first", utteranceCount: 1 } },
+        });
+        await execute({ action: "stop", sessionId: "first" });
+        expect.soft(providerStop).not.toHaveBeenCalled();
+        expectConnectedStatus(manager, "1001");
+        await expect(execute({ action: "status" })).resolves.toMatchObject({
+          details: { active: [expect.objectContaining({ sessionId: "second" })] },
+        });
+        await manager.destroy();
+        await vi.waitFor(async () => {
+          await expect(execute({ action: "status" })).resolves.toMatchObject({
+            details: { active: [], pendingFinalization: [] },
+          });
+          expect(await store.readSession("second")).toMatchObject({
+            stoppedAt: expect.any(String),
+          });
+        });
+      } finally {
+        try {
+          await manager.destroy();
+        } finally {
+          setDiscordTranscriptsVoiceManager({ accountId, manager: null });
+          activeSessions.delete("first");
+          activeSessions.delete("second");
+          providerStop.mockRestore();
+          closeOpenClawStateDatabaseForTest();
+          tempDirs.cleanup();
+        }
+      }
+    });
+  },
+);

--- a/extensions/discord/src/voice/transcripts-source.test.ts
+++ b/extensions/discord/src/voice/transcripts-source.test.ts
@@ -109,14 +109,15 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
     ).resolves.toMatchObject({ ok: false });
   });
 
-  it("starts Discord voice in transcripts mode", async () => {
-    const join = vi.fn(async () => ({ ok: true, message: "joined" }));
+  it("starts Discord voice capture and reports the retired subscription", async () => {
+    const join = vi.fn<DiscordVoiceManager["join"]>(async () => ({ ok: true, message: "joined" }));
     setDiscordTranscriptsVoiceManager({
       accountId: "primary",
       manager: { join } as unknown as DiscordVoiceManager,
     });
 
     const onUtterance = vi.fn();
+    const onStatus = vi.fn();
     const result = await discordVoiceTranscriptsSourceProvider.start?.({
       session: {
         sessionId: "notes-1",
@@ -129,6 +130,7 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
         },
       },
       onUtterance,
+      onStatus,
     });
 
     expect(result).toMatchObject({ ok: true });
@@ -138,9 +140,16 @@ describe("discordVoiceTranscriptsSourceProvider", () => {
         transcripts: {
           sessionId: "notes-1",
           onUtterance,
+          onStop: expect.any(Function),
         },
       },
     );
+    await join.mock.calls[0]?.[1]?.transcripts?.onStop?.();
+    expect(onStatus).toHaveBeenCalledExactlyOnceWith({
+      active: false,
+      sessionId: "notes-1",
+      source: { providerId: "discord-voice", accountId: "primary", guildId: "g1", channelId: "c1" },
+    });
   });
 
   it("uses the sole voice-capable account instead of a text-only default", async () => {

--- a/extensions/discord/src/voice/transcripts-source.ts
+++ b/extensions/discord/src/voice/transcripts-source.ts
@@ -236,6 +236,12 @@ export const discordVoiceTranscriptsSourceProvider: TranscriptSourceProvider = {
         transcripts: {
           sessionId: request.session.sessionId,
           onUtterance: request.onUtterance,
+          onStop: () =>
+            request.onStatus?.({
+              sessionId: request.session.sessionId,
+              active: false,
+              source: request.session.source,
+            }),
         },
       },
     );

--- a/extensions/discord/src/voice/voice-receive.ts
+++ b/extensions/discord/src/voice/voice-receive.ts
@@ -124,6 +124,8 @@ export class DiscordVoiceReceive {
       `capture start: guild ${entry.guildId} channel ${entry.channelId} user ${userId}`,
     );
     const voiceSdk = loadDiscordVoiceSdk();
+    // Queued STT belongs to the subscription that received the audio.
+    const transcripts = entry.transcripts;
     const voiceMode = resolveDiscordVoiceMode(this.params.discordConfig.voice);
     const realtime =
       entry.realtimeLifecycle.status === "active" && isDiscordRealtimeVoiceMode(voiceMode)
@@ -245,6 +247,9 @@ export class DiscordVoiceReceive {
       entry.processingQueue = entry.processingQueue
         .then(async () => {
           if (!this.params.isEntryCurrent(entry)) {
+            return;
+          }
+          if (entry.transcripts !== transcripts) {
             return;
           }
           await this.processSegment({ entry, wavPath, userId, durationSeconds });

--- a/extensions/discord/src/voice/voice-session.lifecycle.test.ts
+++ b/extensions/discord/src/voice/voice-session.lifecycle.test.ts
@@ -78,15 +78,27 @@ defineDiscordVoiceTests(
       });
 
       const manager = createManager();
+      const oldStopped = vi.fn();
+      const newStopped = vi.fn();
 
-      await manager.join({ guildId: "g1", channelId: "1001" });
-      await manager.join({ guildId: "g1", channelId: "1002" });
+      await manager.join(
+        { guildId: "g1", channelId: "1001" },
+        { transcripts: { sessionId: "old", onUtterance: vi.fn(), onStop: oldStopped } },
+      );
+      await manager.join(
+        { guildId: "g1", channelId: "1002" },
+        { transcripts: { sessionId: "new", onUtterance: vi.fn(), onStop: newStopped } },
+      );
 
       const oldDisconnected = oldConnection.handlers.get("disconnected");
       expect(oldDisconnected).toBeTypeOf("function");
       await oldDisconnected?.();
 
       expectConnectedStatus(manager, "1002");
+      expect(oldStopped).toHaveBeenCalledOnce();
+      expect(newStopped).not.toHaveBeenCalled();
+      await manager.destroy();
+      expect(newStopped).toHaveBeenCalledOnce();
     });
 
     it("keeps the new session when an old destroyed handler fires", async () => {
@@ -95,15 +107,27 @@ defineDiscordVoiceTests(
       joinVoiceChannelMock.mockReturnValueOnce(oldConnection).mockReturnValueOnce(newConnection);
 
       const manager = createManager();
+      const oldStopped = vi.fn();
+      const newStopped = vi.fn();
 
-      await manager.join({ guildId: "g1", channelId: "1001" });
-      await manager.join({ guildId: "g1", channelId: "1002" });
+      await manager.join(
+        { guildId: "g1", channelId: "1001" },
+        { transcripts: { sessionId: "old", onUtterance: vi.fn(), onStop: oldStopped } },
+      );
+      await manager.join(
+        { guildId: "g1", channelId: "1002" },
+        { transcripts: { sessionId: "new", onUtterance: vi.fn(), onStop: newStopped } },
+      );
 
       const oldDestroyed = oldConnection.handlers.get("destroyed");
       expect(oldDestroyed).toBeTypeOf("function");
       oldDestroyed?.();
 
       expectConnectedStatus(manager, "1002");
+      expect(oldStopped).toHaveBeenCalledOnce();
+      expect(newStopped).not.toHaveBeenCalled();
+      await manager.destroy();
+      expect(newStopped).toHaveBeenCalledOnce();
     });
 
     it("attaches transcripts capture to an existing voice session", async () => {
@@ -172,12 +196,14 @@ defineDiscordVoiceTests(
     it("upgrades a transcripts-only session to realtime on a normal join", async () => {
       const manager = createAgentProxyManager();
       const onUtterance = vi.fn();
+      const onStop = vi.fn();
 
       await manager.join(
         { guildId: "g1", channelId: "1001" },
         {
           transcripts: {
             sessionId: "notes-1",
+            onStop,
             onUtterance,
           },
         },
@@ -208,6 +234,7 @@ defineDiscordVoiceTests(
       expect(realtimeSessionMock.connect).toHaveBeenCalledTimes(1);
       expect(entry.transcripts).toEqual({
         sessionId: "notes-1",
+        onStop,
         onUtterance,
       });
       expect(entry.realtime).toBeTruthy();
@@ -221,6 +248,7 @@ defineDiscordVoiceTests(
 
       expect(stopNotesResult.ok).toBe(true);
       expect(entry.transcripts).toBeUndefined();
+      expect(onStop).toHaveBeenCalledOnce();
       expect(entry.realtime).toBeTruthy();
       expect(realtimeSessionMock.close).not.toHaveBeenCalled();
       expect(attempts.has("g1")).toBe(true);
@@ -269,12 +297,14 @@ defineDiscordVoiceTests(
     it("detaches transcripts without leaving voice during pending realtime upgrade", async () => {
       const manager = createAgentProxyManager();
       const onUtterance = vi.fn();
+      const onStop = vi.fn();
 
       await manager.join(
         { guildId: "g1", channelId: "1001" },
         {
           transcripts: {
             sessionId: "notes-1",
+            onStop,
             onUtterance,
           },
         },
@@ -296,6 +326,7 @@ defineDiscordVoiceTests(
 
       expect(stopNotesResult.ok).toBe(true);
       expect(entry.transcripts).toBeUndefined();
+      expect(onStop).toHaveBeenCalledOnce();
       expect(entry.pendingRealtime).toBeTruthy();
       expect(entry.realtime).toBeUndefined();
 
@@ -975,8 +1006,17 @@ defineDiscordVoiceTests(
       const connection = createConnectionMock();
       joinVoiceChannelMock.mockReturnValueOnce(connection);
       const manager = createManager();
+      const onStop = vi.fn();
 
-      await manager.join({ guildId: "g1", channelId: "1001" });
+      await manager.join(
+        { guildId: "g1", channelId: "1001" },
+        { transcripts: { sessionId: "notes", onUtterance: vi.fn(), onStop } },
+      );
+      connection.handlers.get("disconnected")?.();
+      await vi.waitFor(() =>
+        expect(entersStateMock).toHaveBeenCalledWith(connection, "connecting", 15_000),
+      );
+      expect(onStop).not.toHaveBeenCalled();
 
       entersStateMock.mockClear();
       entersStateMock.mockRejectedValueOnce(new Error("still disconnected"));
@@ -990,6 +1030,7 @@ defineDiscordVoiceTests(
       expect(entersStateMock).toHaveBeenCalledWith(connection, "connecting", 15_000);
       await vi.waitFor(() => expect(connection.destroy).toHaveBeenCalledTimes(1));
       await vi.waitFor(() => expect(manager.status()).toStrictEqual([]));
+      expect(onStop).toHaveBeenCalledOnce();
     });
 
     it("closes realtime sessions when disconnected recovery destroys the connection", async () => {

--- a/extensions/discord/src/voice/voice-session.ts
+++ b/extensions/discord/src/voice/voice-session.ts
@@ -37,6 +37,20 @@ function isVoiceSessionStopped(entry: VoiceSessionEntry): boolean {
   return entry.sessionLifecycle.status === "stopped";
 }
 
+function retireTranscripts(entry: VoiceSessionEntry): void {
+  const transcripts = entry.transcripts;
+  entry.transcripts = undefined;
+  // Detach before notifying: retained delivery and reentrant stop cannot target
+  // this binding or a replacement installed while notification settles.
+  try {
+    void Promise.resolve(transcripts?.onStop?.()).catch((error: unknown) => {
+      logger.warn(`discord voice: transcripts retirement failed: ${formatErrorMessage(error)}`);
+    });
+  } catch (error) {
+    logger.warn(`discord voice: transcripts retirement failed: ${formatErrorMessage(error)}`);
+  }
+}
+
 type DiscordVoiceSdk = ReturnType<typeof loadDiscordVoiceSdk>;
 type DiscordVoiceConnection = ReturnType<DiscordVoiceSdk["joinVoiceChannel"]>;
 
@@ -173,6 +187,7 @@ export class DiscordVoiceSessions {
         existing.generation = authority.generation;
       }
       if (options?.transcripts) {
+        retireTranscripts(existing);
         existing.transcripts = options.transcripts;
       }
       if (
@@ -388,6 +403,7 @@ export class DiscordVoiceSessions {
         return;
       }
       entry.sessionLifecycle = { status: "stopped", reason: optionsLocal.reason };
+      retireTranscripts(entry);
       // A late callback from an old connection must not remove its replacement.
       if (this.params.sessions.get(guildId) === entry) {
         this.params.sessions.delete(guildId);
@@ -590,7 +606,7 @@ export class DiscordVoiceSessions {
         entry.realtimeLifecycle.status === "active" ||
         entry.realtimeLifecycle.status === "starting"
       ) {
-        entry.transcripts = undefined;
+        retireTranscripts(entry);
         return {
           ok: true,
           message: `Stopped transcripts for ${formatMention({ channelId: entry.channelId })}.`,

--- a/extensions/discord/src/voice/voice-test-harness.test-support.ts
+++ b/extensions/discord/src/voice/voice-test-harness.test-support.ts
@@ -1,8 +1,8 @@
 import { PassThrough } from "node:stream";
 import { DAVESession } from "@discordjs/voice";
-import { expectDefined } from "@openclaw/normalization-core";
 import { VoiceOpcodes, type VoiceSendPayload } from "discord-api-types/voice/v8";
 import { createOpenClawCodingTools } from "openclaw/plugin-sdk/agent-harness";
+import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelType } from "../internal/discord.js";
 import { createVoiceCaptureState } from "./capture-state.js";

--- a/extensions/discord/test-api.ts
+++ b/extensions/discord/test-api.ts
@@ -3,3 +3,7 @@ export {
   discordVoiceTranscriptsSourceProvider,
   setDiscordTranscriptsVoiceManager,
 } from "./src/voice/transcripts-source.js";
+
+// Voice harness mocks must remain opt-in for provider-only integration tests.
+export const loadDiscordVoiceTestHarness = () =>
+  import("./src/voice/voice-test-harness.test-support.js");

--- a/src/agents/tools/transcripts-tool-runtime.ts
+++ b/src/agents/tools/transcripts-tool-runtime.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveTranscriptsConfig } from "../../transcripts/config.js";
 import { manualTranscriptSourceProvider } from "../../transcripts/manual-source.js";
 import { getTranscriptSourceProvider } from "../../transcripts/provider-registry.js";
 import type {
@@ -12,6 +13,7 @@ import type {
 } from "../../transcripts/provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "../../transcripts/source-locator.js";
 import type { TranscriptsStore } from "../../transcripts/store.js";
+import { summarizeTranscripts } from "../../transcripts/summary.js";
 import { truncateUtf16Safe } from "../../utils.js";
 
 const ACCOUNT_ID_OUTPUT_MAX_CHARS = 64;
@@ -41,9 +43,11 @@ type ActiveTranscriptsSession = {
   // Durable timestamps can collide; lifecycle cleanup must match this exact process-owned capture.
   lifecycleToken?: symbol;
   // Keep the capture reserved until provider and durable stop work both finish.
-  stopToken?: symbol;
+  stopping?: true;
   // Aborted starts stay active until a later stop confirms provider cleanup.
   cleanupPending?: true;
+  phase: "starting" | "active" | "terminal" | "failed";
+  finalization?: Promise<Awaited<ReturnType<typeof persistTranscriptSummary>>>;
 };
 
 // Process-local ownership shared by tool-driven and configured transcript captures.
@@ -51,6 +55,60 @@ export const activeSessions = new Map<string, ActiveTranscriptsSession>();
 // Reserve ids across async provider startup so overlapping starts cannot
 // replace the only cleanup owner for an existing or still-starting capture.
 const startingSessionIds = new Set<string>();
+
+export function isTranscriptSessionStarting(sessionId: string): boolean {
+  return startingSessionIds.has(sessionId);
+}
+
+export async function persistTranscriptSummary(params: {
+  config: ReturnType<typeof resolveTranscriptsConfig>;
+  store: TranscriptsStore;
+  session: TranscriptSessionDescriptor;
+}) {
+  const utterances = await params.store.readUtterancesForSession(params.session, {
+    maxUtterances: params.config.maxUtterances,
+  });
+  const summary = summarizeTranscripts({ session: params.session, utterances });
+  const intendedSummaryPath = await params.store.writeSummary(summary, params.session);
+  return { summary, intendedSummaryPath };
+}
+
+// Retain the exact owner on failure so stop can retry persistence without touching
+// the provider again. A stop in flight keeps its reservation until it settles.
+export function finalizeTranscriptCapture(params: {
+  ctx: TranscriptsRuntimeContext;
+  store: TranscriptsStore;
+  entry: ActiveTranscriptsSession;
+}) {
+  const { entry } = params;
+  entry.phase = "terminal";
+  entry.session = {
+    ...entry.session,
+    stoppedAt: entry.session.stoppedAt ?? new Date().toISOString(),
+  };
+  entry.finalization ??= (async () => {
+    await params.store.writeSession(entry.session);
+    return await persistTranscriptSummary({
+      config: resolveTranscriptsConfig(params.ctx.config?.transcripts),
+      store: params.store,
+      session: entry.session,
+    });
+  })()
+    .then((result) => {
+      if (!entry.stopping && activeSessions.get(entry.session.sessionId) === entry) {
+        activeSessions.delete(entry.session.sessionId);
+      }
+      return result;
+    })
+    .catch((error: unknown) => {
+      delete entry.finalization;
+      params.ctx.logger.warn(
+        `transcripts finalization failed session=${entry.session.sessionId}; capture ended, use transcripts stop to retry: ${String(error)}`,
+      );
+      throw error;
+    });
+  return entry.finalization;
+}
 
 function createStartupAbortScope(parent?: AbortSignal): {
   signal?: AbortSignal;
@@ -319,57 +377,91 @@ export async function startTranscripts(params: {
     throw new Error(`transcripts session already active: ${session.sessionId}`);
   }
   startingSessionIds.add(session.sessionId);
+  const entry: ActiveTranscriptsSession = {
+    session,
+    providerId: provider.id,
+    phase: "starting",
+    lifecycleToken: params.lifecycleToken,
+  };
   try {
     await params.store.writeSession(session);
-    let startupPending = true;
     const startupAbort = createStartupAbortScope(params.abortSignal);
     let result: TranscriptsStartResult;
     try {
       result = await provider.start({
         cfg: params.ctx.config,
-        session: { ...session, source: providerSource },
+        session: { ...session, source: { ...providerSource }, metadata: { ...session.metadata } },
         abortSignal: startupAbort.signal,
         startupWaitMs: params.startupWaitMs,
         onUtterance: async (utterance) => {
-          // Provider callbacks can race abort cleanup; never persist that late startup audio.
-          if (startupPending && startupAbort.signal?.aborted) {
+          // Abort, retirement, and id reuse fence this callback before any durable append.
+          if (
+            entry.phase === "terminal" ||
+            entry.phase === "failed" ||
+            entry.cleanupPending ||
+            (entry.phase === "starting"
+              ? startupAbort.signal?.aborted
+              : activeSessions.get(session.sessionId) !== entry)
+          ) {
             return;
           }
           await params.store.appendUtteranceForSession(session, utterance);
         },
+        onStatus: async (status) => {
+          // Payload ids/source are descriptive, never authority over another capture.
+          if (status.active || entry.phase === "failed" || entry.phase === "terminal") {
+            return;
+          }
+          if (entry.phase !== "starting" && activeSessions.get(session.sessionId) !== entry) {
+            return;
+          }
+          entry.phase = "terminal";
+          entry.session = { ...session, stoppedAt: new Date().toISOString() };
+          // Awaiting start here would deadlock providers that notify inline.
+          if (activeSessions.get(session.sessionId) === entry) {
+            await finalizeTranscriptCapture({ ...params, entry });
+          }
+        },
       });
+    } catch (error) {
+      entry.phase = "failed";
+      throw error;
     } finally {
       startupAbort.detach();
     }
     // Provider failures retain cleanup ownership; only a successful result can
     // transfer a live capture to this lifecycle for abort/stop retry handling.
     if (!result.ok) {
+      entry.phase = "failed";
       throw new Error(result.error);
     }
+    activeSessions.set(session.sessionId, entry);
     if (startupAbort.signal?.aborted) {
-      const cleanupError = await stopPendingTranscriptCapture({
-        ctx: params.ctx,
-        provider,
-        session,
-        reason: "service-stop",
-      });
+      entry.cleanupPending = true;
+      const cleanupError =
+        entry.phase === "terminal"
+          ? undefined
+          : await stopPendingTranscriptCapture({
+              ctx: params.ctx,
+              provider,
+              session,
+              reason: "service-stop",
+            });
       if (cleanupError) {
-        activeSessions.set(session.sessionId, {
-          session,
-          providerId: provider.id,
-          cleanupPending: true,
-          ...(params.lifecycleToken ? { lifecycleToken: params.lifecycleToken } : {}),
-        });
         throw new Error(`transcripts start aborted; provider cleanup failed: ${cleanupError}`);
       }
+      await finalizeTranscriptCapture({ ...params, entry });
       throw new Error("transcripts start aborted");
     }
-    startupPending = false;
-    activeSessions.set(session.sessionId, {
-      session,
-      providerId: provider.id,
-      ...(params.lifecycleToken ? { lifecycleToken: params.lifecycleToken } : {}),
-    });
+    if (entry.phase === "terminal") {
+      await finalizeTranscriptCapture({ ...params, entry });
+      return toolText(`Transcripts ended during startup: ${session.sessionId}`, {
+        sessionId: session.sessionId,
+        active: false,
+        stoppedAt: entry.session.stoppedAt,
+      });
+    }
+    entry.phase = "active";
     const effectiveAccount = session.source.accountId;
     return toolText(
       `Transcripts started: ${session.sessionId}${effectiveAccount ? `\nAccount: ${formatAccountIdForToolText(effectiveAccount)}` : ""}`,

--- a/src/agents/tools/transcripts-tool.lifecycle.test.ts
+++ b/src/agents/tools/transcripts-tool.lifecycle.test.ts
@@ -1,0 +1,279 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import type {
+  TranscriptSourceProvider,
+  TranscriptStartRequest,
+} from "../../transcripts/provider-types.js";
+import { TranscriptsStore } from "../../transcripts/store.js";
+import { activeSessions } from "./transcripts-tool-runtime.js";
+import { createTranscriptsTool } from "./transcripts-tool.js";
+
+const { getProvider } = vi.hoisted(() => ({ getProvider: vi.fn() }));
+vi.mock("../../transcripts/provider-registry.js", () => ({
+  getTranscriptSourceProvider: getProvider,
+  listTranscriptSourceProviders: () => [],
+}));
+const tempDirs = createTempDirTracker();
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  activeSessions.clear();
+  closeOpenClawStateDatabaseForTest();
+  tempDirs.cleanup();
+});
+
+function harness() {
+  const stateDir = tempDirs.make("transcript-lifecycle-");
+  const requests: TranscriptStartRequest[] = [];
+  const logger = { warn: vi.fn() };
+  const provider: TranscriptSourceProvider = {
+    id: "capture",
+    name: "Capture",
+    sourceKinds: ["live-audio"],
+    start: vi.fn<NonNullable<TranscriptSourceProvider["start"]>>(async (request) => {
+      requests.push(request);
+      return { ok: true, session: request.session };
+    }),
+    stop: vi.fn<NonNullable<TranscriptSourceProvider["stop"]>>(async (request) => ({
+      ok: true,
+      sessionId: request.sessionId,
+    })),
+  };
+  getProvider.mockReturnValue(provider);
+  const createTool = (assertCallerActive?: () => void) =>
+    createTranscriptsTool({
+      config: { transcripts: { enabled: true } },
+      stateDir,
+      agentId: "research",
+      logger,
+      caller: { kind: "operator", source: "local" },
+      assertCallerActive,
+    });
+  const tool = createTool();
+  const execute = (params: Record<string, unknown>) => tool.execute("lifecycle", params);
+  const start = () =>
+    execute({
+      action: "start",
+      providerId: provider.id,
+      sessionId: "notes",
+      accountId: "admitted",
+      meetingUrl: "https://meeting.example/room?private=opaque#fragment",
+    });
+  const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+  });
+  const session = async () => {
+    const value = await store.readSession("notes");
+    if (!value) {
+      throw new Error("missing capture");
+    }
+    return value;
+  };
+  return { stateDir, requests, logger, provider, createTool, execute, start, store, session };
+}
+
+describe("transcript capture ownership", () => {
+  it.each(["terminal", "rejected", "thrown"] as const)(
+    "fences a %s startup and its retained callbacks after same-millisecond id reuse",
+    async (outcome) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const h = harness();
+      let retained!: TranscriptStartRequest;
+      h.provider.start = async (request) => {
+        retained = request;
+        await request.onUtterance({ text: "before closure" });
+        await request.onStatus?.({
+          active: false,
+          sessionId: "another-id",
+          source: { providerId: "other", accountId: "other" },
+        });
+        await request.onStatus?.({ active: true });
+        await request.onUtterance({ text: "after closure" });
+        if (outcome === "thrown") {
+          throw new Error("start failed");
+        }
+        return outcome === "rejected"
+          ? { ok: false, error: "start failed" }
+          : {
+              ok: true,
+              session: {
+                ...request.session,
+                source: { providerId: "other" },
+                metadata: { agentId: "other" },
+              },
+            };
+      };
+      if (outcome === "terminal") {
+        await expect(h.start()).resolves.toMatchObject({
+          details: { sessionId: "notes", active: false, stoppedAt: expect.any(String) },
+        });
+        expect(await h.store.readSummary(await h.session())).toMatchObject({
+          summary: { utteranceCount: 1 },
+        });
+        await expect(fs.stat(h.store.sessionDir(await h.session()))).rejects.toMatchObject({
+          code: "ENOENT",
+        });
+      } else {
+        await expect(h.start()).rejects.toThrow("start failed");
+      }
+      await expect(h.execute({ action: "status" })).resolves.toMatchObject({
+        details: { active: [] },
+      });
+      const first = await h.session();
+      expect(first).toMatchObject({
+        source: {
+          providerId: "capture",
+          accountId: "admitted",
+          agentId: "research",
+          meetingUrl: "https://meeting.example/room",
+        },
+        metadata: { agentId: "research" },
+      });
+      h.provider.start = async (request) => ({ ok: true, session: request.session });
+      await h.start();
+      await retained.onStatus?.({ active: false, sessionId: "notes" });
+      await retained.onUtterance({ text: "stale callback after reuse" });
+      const replacement = await h.session();
+      expect(replacement.startedAt).toBe(first.startedAt);
+      expect(replacement.stoppedAt).toBeUndefined();
+      expect((await h.store.readUtterancesForSession(replacement)).map((row) => row.text)).toEqual([
+        "before closure",
+      ]);
+      await expect(h.execute({ action: "status" })).resolves.toMatchObject({
+        details: { active: [{ sessionId: "notes" }] },
+      });
+      expect(h.provider.stop).not.toHaveBeenCalled();
+      await h.execute({ action: "stop", sessionId: "notes" });
+    },
+  );
+
+  it.each(["inline", "microtask", "after-stop"] as const)(
+    "shares durable finalization with an explicit stop notification delivered %s",
+    async (ordering) => {
+      const h = harness();
+      await h.start();
+      const request = h.requests[0]!;
+      await request.onUtterance({ text: "final audio" });
+      const writeSession = vi.spyOn(TranscriptsStore.prototype, "writeSession");
+      const writeSummary = vi.spyOn(TranscriptsStore.prototype, "writeSummary");
+      const terminal = () => request.onStatus?.({ active: false });
+      let notification: Promise<void> | undefined;
+      h.provider.stop = vi.fn<NonNullable<TranscriptSourceProvider["stop"]>>(async () => {
+        if (ordering === "inline") {
+          await terminal();
+        }
+        if (ordering === "microtask") {
+          notification = Promise.resolve().then(terminal);
+        }
+        return { ok: true, sessionId: "notes" };
+      });
+      await expect(h.execute({ action: "stop", sessionId: "notes" })).resolves.toMatchObject({
+        details: { summary: { utteranceCount: 1 } },
+      });
+      await notification;
+      if (ordering === "after-stop") {
+        await terminal();
+      }
+      await request.onUtterance({ text: "too late" });
+      expect(writeSession).toHaveBeenCalledOnce();
+      expect(writeSummary).toHaveBeenCalledOnce();
+      const stoppedAt = (await h.session()).stoppedAt;
+      await h.execute({ action: "stop", sessionId: "notes" });
+      expect((await h.session()).stoppedAt).toBe(stoppedAt);
+      expect(h.provider.stop).toHaveBeenCalledOnce();
+      expect(
+        (await h.store.readUtterancesForSession(await h.session())).map((row) => row.text),
+      ).toEqual(["final audio"]);
+    },
+  );
+
+  it.each(["writeSession", "readUtterancesForSession", "writeSummary"] as const)(
+    "exposes terminal %s failures and recovers without another provider stop",
+    async (operation) => {
+      const h = harness();
+      await h.start();
+      const request = h.requests[0]!;
+      await request.onUtterance({ text: "retained note" });
+      const failure = vi
+        .spyOn(TranscriptsStore.prototype, operation)
+        .mockRejectedValueOnce(new Error("store unavailable"));
+      await expect(request.onStatus?.({ active: false })).rejects.toThrow("store unavailable");
+      failure.mockRestore();
+      await request.onUtterance({ text: "retired audio" });
+      await expect(h.execute({ action: "status" })).resolves.toMatchObject({
+        details: {
+          active: [],
+          pendingFinalization: [{ sessionId: "notes", stoppedAt: expect.any(String) }],
+        },
+      });
+      expect(h.logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("use transcripts stop to retry"),
+      );
+      await expect(h.start()).rejects.toThrow("already active");
+      await expect(h.execute({ action: "stop", sessionId: "notes" })).resolves.toMatchObject({
+        details: { summary: { utteranceCount: 1 } },
+      });
+      expect(h.provider.stop).not.toHaveBeenCalled();
+      expect((await h.session()).stoppedAt).toEqual(expect.any(String));
+      await expect(h.execute({ action: "status" })).resolves.toMatchObject({
+        details: { active: [], pendingFinalization: [] },
+      });
+    },
+  );
+
+  it.each(["stop", "status"] as const)(
+    "revalidates capture identity after awaited %s authorization without reusing startup authority",
+    async (action) => {
+      vi.useFakeTimers({ toFake: ["Date"] });
+      const h = harness();
+      let callerActive = true;
+      const startingTool = h.createTool(() => {
+        if (!callerActive) {
+          throw new Error("starting run ended");
+        }
+      });
+      let authorizeEntered!: () => void;
+      const entered = new Promise<void>((resolve) => {
+        authorizeEntered = resolve;
+      });
+      let releaseAuthorization!: () => void;
+      const authorization = new Promise<void>((resolve) => {
+        releaseAuthorization = resolve;
+      });
+      let delayAuthorization = true;
+      h.provider.accessControl = {
+        channelId: "capture-channel",
+        resolveAccountId: ({ source }) => ({ ok: true, value: source.accountId }),
+        authorize: async (request) => {
+          if (request.action === action && delayAuthorization) {
+            delayAuthorization = false;
+            authorizeEntered();
+            await authorization;
+          }
+          return { ok: true, value: undefined };
+        },
+      };
+      await startingTool.execute("start", {
+        action: "start",
+        providerId: "capture",
+        sessionId: "notes",
+      });
+      const delayed = h.execute({ action, sessionId: "notes" });
+      await entered;
+      callerActive = false;
+      await h.requests[0]!.onStatus?.({ active: false });
+      await h.start();
+      releaseAuthorization();
+      await expect(delayed).resolves.toMatchObject({
+        details: action === "stop" ? { skipped: true } : { active: [] },
+      });
+      expect(h.provider.stop).not.toHaveBeenCalled();
+      expect((await h.session()).stoppedAt).toBeUndefined();
+      await h.execute({ action: "stop", sessionId: "notes" });
+    },
+  );
+});

--- a/src/agents/tools/transcripts-tool.test.ts
+++ b/src/agents/tools/transcripts-tool.test.ts
@@ -3,6 +3,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import type {
@@ -378,12 +379,11 @@ describe("transcripts tool", () => {
 
   it("reserves a session id while provider startup is pending", async () => {
     const stateDir = tempDirs.make("openclaw-transcripts-");
-    let releaseStart: (() => void) | undefined;
-    const startGate = new Promise<void>((resolve) => {
-      releaseStart = resolve;
-    });
+    const started = createDeferred();
+    const startGate = createDeferred();
     const start = vi.fn(async (request) => {
-      await startGate;
+      started.resolve();
+      await startGate.promise;
       return { ok: true as const, session: request.session };
     });
     const stop = vi.fn(async () => ({ ok: true as const, sessionId: "shared-session" }));
@@ -402,30 +402,30 @@ describe("transcripts tool", () => {
       undefined,
       vi.fn(),
     );
-    await vi.waitFor(() => {
-      expect(start).toHaveBeenCalledOnce();
-    });
-
-    await expect(
-      tool.execute(
-        "call-2",
-        { action: "start", providerId: "proof-live", sessionId: "shared-session" },
+    await started.promise;
+    try {
+      await expect(
+        tool.execute(
+          "call-2",
+          { action: "start", providerId: "proof-live", sessionId: "shared-session" },
+          undefined,
+          vi.fn(),
+        ),
+      ).rejects.toThrow("transcripts session already active: shared-session");
+      await expect(
+        tool.execute("stop-pending", { action: "stop", sessionId: "shared-session" }),
+      ).resolves.toMatchObject({ details: { sessionId: "shared-session", skipped: true } });
+      expect(stop).not.toHaveBeenCalled();
+    } finally {
+      startGate.resolve();
+      await firstStart;
+      await tool.execute(
+        "call-3",
+        { action: "stop", sessionId: "shared-session" },
         undefined,
         vi.fn(),
-      ),
-    ).rejects.toThrow("transcripts session already active: shared-session");
-    await expect(
-      tool.execute("stop-pending", { action: "stop", sessionId: "shared-session" }),
-    ).resolves.toMatchObject({ details: { sessionId: "shared-session", skipped: true } });
-    expect(stop).not.toHaveBeenCalled();
-    releaseStart?.();
-    await firstStart;
-    await tool.execute(
-      "call-3",
-      { action: "stop", sessionId: "shared-session" },
-      undefined,
-      vi.fn(),
-    );
+      );
+    }
 
     expect(start).toHaveBeenCalledOnce();
     expect(stop).toHaveBeenCalledOnce();

--- a/src/agents/tools/transcripts-tool.test.ts
+++ b/src/agents/tools/transcripts-tool.test.ts
@@ -414,6 +414,10 @@ describe("transcripts tool", () => {
         vi.fn(),
       ),
     ).rejects.toThrow("transcripts session already active: shared-session");
+    await expect(
+      tool.execute("stop-pending", { action: "stop", sessionId: "shared-session" }),
+    ).resolves.toMatchObject({ details: { sessionId: "shared-session", skipped: true } });
+    expect(stop).not.toHaveBeenCalled();
     releaseStart?.();
     await firstStart;
     await tool.execute(
@@ -694,6 +698,9 @@ describe("transcripts tool", () => {
     );
 
     expect(stop).not.toHaveBeenCalled();
+    await expect(store.readSession("2026-05-21/standup")).resolves.toMatchObject({
+      stoppedAt: olderSession.stoppedAt,
+    });
     await expect(
       fs.readFile(
         path.join(stateDir, "transcripts", "2026-05-21", "standup", "summary.md"),

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -23,13 +23,15 @@ import type {
 } from "../../transcripts/provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "../../transcripts/source-locator.js";
 import { TranscriptsStore, type TranscriptsSessionEntry } from "../../transcripts/store.js";
-import { summarizeTranscripts } from "../../transcripts/summary.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import type { AnyAgentTool } from "./common.js";
 import {
   activeSessions,
   authorizeTranscriptSource,
   createTranscriptSessionId,
+  finalizeTranscriptCapture,
+  isTranscriptSessionStarting,
+  persistTranscriptSummary,
   readTranscriptStringParam,
   resolveTranscriptSourceOwnership,
   resolveSourceProvider,
@@ -144,13 +146,20 @@ async function summarizeAndPersist(params: {
   store: TranscriptsStore;
   session: TranscriptSessionDescriptor;
 }) {
-  const utterances = await params.store.readUtterancesForSession(params.session, {
-    maxUtterances: params.config.maxUtterances,
-  });
-  const summary = summarizeTranscripts({ session: params.session, utterances });
-  const intendedSummaryPath = await params.store.writeSummary(summary, params.session);
+  return await exportTranscriptSummary(
+    params.store,
+    params.session,
+    await persistTranscriptSummary(params),
+  );
+}
+
+async function exportTranscriptSummary(
+  store: TranscriptsStore,
+  session: TranscriptSessionDescriptor,
+  { summary, intendedSummaryPath }: Awaited<ReturnType<typeof persistTranscriptSummary>>,
+) {
   try {
-    const artifacts = await params.store.materializeSessionArtifacts(params.session, "all");
+    const artifacts = await store.materializeSessionArtifacts(session, "all");
     return { summary, summaryPath: artifacts.summaryPath };
   } catch (error) {
     return { summary, intendedSummaryPath, summaryExportError: String(error) };
@@ -196,85 +205,98 @@ async function stopTranscripts(params: {
     throw new Error(`transcripts session not found: ${sessionSelector}`);
   }
   const sessionId = session.sessionId;
-  if (selectedActive?.stopToken) {
+  if (!params.lifecycleToken) {
+    params.ctx.assertCallerActive?.();
+  }
+  const noLongerActive = () =>
+    toolText(`Transcripts session no longer active: ${sessionId}`, {
+      sessionId,
+      skipped: true,
+    });
+  if (isTranscriptSessionStarting(sessionId)) {
+    return toolText(
+      `Transcripts session start still in progress: ${sessionId}; retry stop after startup settles.`,
+      {
+        sessionId,
+        skipped: true,
+      },
+    );
+  }
+  // Authorization may await native policy while the provider retires this owner.
+  if (selectedActive && activeSessions.get(sessionId) !== selectedActive) {
+    return noLongerActive();
+  }
+  if (!selectedActive && activeSessions.get(sessionId) !== activeCandidate) {
+    return noLongerActive();
+  }
+  if (selectedActive?.stopping) {
     return toolText(`Transcripts session stop already in progress: ${sessionId}`, {
       sessionId,
       skipped: true,
     });
   }
-  const stopToken = selectedActive ? Symbol("transcripts-stop") : undefined;
-  if (selectedActive && stopToken) {
-    selectedActive.stopToken = stopToken;
+  if (selectedActive) {
+    selectedActive.stopping = true;
   }
-  const providerId = selectedActive?.providerId ?? session.source.providerId;
-  const provider = resolveSourceProvider(providerId, params.ctx);
+  let finalized = false;
   try {
     let providerStopError: string | undefined;
-    if (selectedActive?.cleanupPending) {
-      providerStopError = await stopPendingTranscriptCapture({
-        ctx: params.ctx,
-        provider,
-        session,
-        reason: "tool-stop",
-      });
-      if (providerStopError) {
-        throw new Error(`transcripts provider cleanup failed: ${providerStopError}`);
-      }
-    } else if (selectedActive && provider?.stop) {
-      const result = await provider.stop({
-        cfg: params.ctx.config,
-        sessionId,
-        source: session.source,
-        reason: "tool-stop",
-      });
-      if (!result.ok) {
-        providerStopError = result.error;
-      }
-    }
-    if (
-      selectedActive &&
-      (activeSessions.get(sessionId) !== selectedActive || selectedActive.stopToken !== stopToken)
-    ) {
-      return toolText(`Transcripts session no longer active: ${sessionId}`, {
-        sessionId,
-        skipped: true,
-      });
-    }
-    const stoppedAt = new Date().toISOString();
-    const stoppedSession: TranscriptSessionDescriptor = {
-      ...session,
-      stoppedAt,
-      ...(providerStopError
-        ? {
-            metadata: {
-              ...session.metadata,
-              providerStopError,
-              providerStopFailedAt: stoppedAt,
-            },
-          }
-        : {}),
-    };
-    if (selectedActive) {
-      await params.store.writeSession(stoppedSession);
-      if (
-        activeSessions.get(sessionId) !== selectedActive ||
-        selectedActive.stopToken !== stopToken
-      ) {
-        return toolText(`Transcripts session no longer active: ${sessionId}`, {
-          sessionId,
-          skipped: true,
+    if (selectedActive && selectedActive.phase !== "terminal") {
+      const provider = resolveSourceProvider(selectedActive.providerId, params.ctx);
+      if (selectedActive.cleanupPending) {
+        providerStopError = await stopPendingTranscriptCapture({
+          ctx: params.ctx,
+          provider,
+          session,
+          reason: "tool-stop",
         });
+        if (providerStopError) {
+          throw new Error(`transcripts provider cleanup failed: ${providerStopError}`);
+        }
+      } else if (provider?.stop) {
+        const result = await provider.stop({
+          cfg: params.ctx.config,
+          sessionId,
+          source: session.source,
+          reason: "tool-stop",
+        });
+        if (!result.ok) {
+          providerStopError = result.error;
+        }
       }
-      activeSessions.delete(sessionId);
-    } else {
-      await params.store.updateStopped(sessionSelector, stoppedAt);
+      if (activeSessions.get(sessionId) !== selectedActive) {
+        return noLongerActive();
+      }
+      if (providerStopError && !selectedActive.session.stoppedAt) {
+        selectedActive.session = {
+          ...session,
+          metadata: {
+            ...session.metadata,
+            providerStopError,
+            providerStopFailedAt: new Date().toISOString(),
+          },
+        };
+      }
     }
-    const { summaryPath, intendedSummaryPath, summary, summaryExportError } =
-      await summarizeAndPersist({
+    let persisted: Awaited<ReturnType<typeof persistTranscriptSummary>>;
+    let stoppedSession: TranscriptSessionDescriptor;
+    if (selectedActive) {
+      persisted = await finalizeTranscriptCapture({ ...params, entry: selectedActive });
+      stoppedSession = selectedActive.session;
+      finalized = true;
+    } else {
+      stoppedSession = { ...session, stoppedAt: session.stoppedAt ?? new Date().toISOString() };
+      if (!session.stoppedAt) {
+        await params.store.writeSession(stoppedSession);
+      }
+      persisted = await persistTranscriptSummary({
         config: resolveTranscriptsConfig(params.ctx.config?.transcripts),
         store: params.store,
         session: stoppedSession,
       });
+    }
+    const { summaryPath, intendedSummaryPath, summary, summaryExportError } =
+      await exportTranscriptSummary(params.store, stoppedSession, persisted);
     return toolText(
       `Transcripts stopped: ${sessionId}${summaryPath ? `\nSummary: ${summaryPath}` : `\nSummary export failed: ${summaryExportError}`}`,
       {
@@ -287,12 +309,11 @@ async function stopTranscripts(params: {
       },
     );
   } finally {
-    if (
-      selectedActive &&
-      activeSessions.get(sessionId) === selectedActive &&
-      selectedActive.stopToken === stopToken
-    ) {
-      delete selectedActive.stopToken;
+    if (selectedActive && activeSessions.get(sessionId) === selectedActive) {
+      delete selectedActive.stopping;
+      if (finalized) {
+        activeSessions.delete(sessionId);
+      }
     }
   }
 }
@@ -410,20 +431,36 @@ async function statusTranscripts(ctx: TranscriptsRuntimeContext) {
         (await canAccessTranscriptSession(ctx, entry.session, "status")) ? entry : undefined,
       ),
     )
-  ).filter((entry) => entry !== undefined);
-  const active = visibleEntries.map((entry) => ({
-    sessionId: entry.session.sessionId,
-    providerId: entry.providerId,
-    title: entry.session.title,
-    source: entry.session.source,
-    cleanupPending: entry.cleanupPending === true,
-  }));
+  )
+    .filter((entry) => entry !== undefined)
+    .filter((entry) => activeSessions.get(entry.session.sessionId) === entry);
+  ctx.assertCallerActive?.();
+  const pendingFinalization = visibleEntries
+    .filter((entry) => entry.phase === "terminal")
+    .map((entry) => ({
+      sessionId: entry.session.sessionId,
+      stoppedAt: entry.session.stoppedAt,
+    }));
+  const active = visibleEntries
+    .filter((entry) => entry.phase !== "terminal")
+    .map((entry) => ({
+      sessionId: entry.session.sessionId,
+      providerId: entry.providerId,
+      title: entry.session.title,
+      source: entry.session.source,
+      cleanupPending: entry.cleanupPending === true,
+    }));
   return toolText(
     [
       `Transcripts providers: ${uniqueProviders.length ? uniqueProviders.join(", ") : "none"}`,
       `Active sessions: ${active.length}`,
+      ...(pendingFinalization.length
+        ? [
+            `Ended captures awaiting persistence: ${pendingFinalization.length}; use transcripts stop to retry.`,
+          ]
+        : []),
     ].join("\n"),
-    { providers: uniqueProviders, active },
+    { providers: uniqueProviders, active, pendingFinalization },
   );
 }
 
@@ -452,7 +489,7 @@ export function createTranscriptsTool(options?: {
     name: "transcripts",
     label: "Transcripts",
     description:
-      "Start/stop/import/summarize/status meeting transcripts: Discord, Google Meet, Slack huddles, others.",
+      "Start, stop, import, summarize, or inspect meeting transcript captures and historical notes.",
     parameters: TranscriptsSchema,
     async execute(_toolCallId, rawParams, signal) {
       const config = resolveTranscriptsConfig(ctx.config?.transcripts);

--- a/src/meeting-bot/transcripts-bridge.runtime.ts
+++ b/src/meeting-bot/transcripts-bridge.runtime.ts
@@ -99,7 +99,7 @@ export function createMeetingDurableTranscriptBridge<
     env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
   });
   const captures = new Map<string, ActiveCapture<TSession>>();
-  const pendingSubscribers = new Map<string, { agentId: string; meetingSessionId: string }>();
+  const pendingSubscribers = new Map<string, Subscriber>();
   const subscribers = new Map<string, Subscriber>();
   const lifecycleTasks = new KeyedAsyncQueue();
   const tasks = new KeyedAsyncQueue();
@@ -265,67 +265,82 @@ export function createMeetingDurableTranscriptBridge<
       if (!active) {
         return false;
       }
-      let initializationError: Error | undefined;
-      if (!active.initialized) {
-        try {
-          await store.writeSession(active.descriptor);
-          active.initialized = true;
-        } catch (error) {
-          initializationError =
-            error instanceof Error
-              ? error
-              : new Error("could not initialize durable transcript session", { cause: error });
+      try {
+        let initializationError: Error | undefined;
+        if (!active.initialized) {
+          try {
+            await store.writeSession(active.descriptor);
+            active.initialized = true;
+          } catch (error) {
+            initializationError =
+              error instanceof Error
+                ? error
+                : new Error("could not initialize durable transcript session", { cause: error });
+          }
         }
-      }
-      let deliveryError: MeetingTranscriptDeliveryError | undefined;
-      for (let attempt = 0; attempt < 3; attempt += 1) {
-        try {
-          await active.runCapture(finalCapture);
-          deliveryError = undefined;
-          break;
-        } catch (error) {
-          if (!(error instanceof MeetingTranscriptDeliveryError)) {
-            reportCaptureError(session.id, error);
-            active.finalCaptureError = coerceErrorMessage(error);
-            active.finalCaptureFailedAt ??= new Date().toISOString();
+        let deliveryError: MeetingTranscriptDeliveryError | undefined;
+        for (let attempt = 0; attempt < 3; attempt += 1) {
+          try {
+            await active.runCapture(finalCapture);
             deliveryError = undefined;
             break;
-          }
-          if (error.finalCaptureError !== undefined) {
-            active.finalCaptureError = error.finalCaptureError;
-            active.finalCaptureFailedAt ??= new Date().toISOString();
-          }
-          deliveryError = error;
-        }
-      }
-      if (deliveryError) {
-        throw deliveryError;
-      }
-      if (initializationError !== undefined) {
-        throw initializationError;
-      }
-      const finalCaptureError = active.finalCaptureError;
-      const stoppedAt = new Date().toISOString();
-      const stopped = {
-        ...active.descriptor,
-        stoppedAt,
-        ...(finalCaptureError !== undefined
-          ? {
-              metadata: {
-                ...active.descriptor.metadata,
-                finalCaptureError,
-                finalCaptureFailedAt: active.finalCaptureFailedAt,
-              },
+          } catch (error) {
+            if (!(error instanceof MeetingTranscriptDeliveryError)) {
+              reportCaptureError(session.id, error);
+              active.finalCaptureError = coerceErrorMessage(error);
+              active.finalCaptureFailedAt ??= new Date().toISOString();
+              deliveryError = undefined;
+              break;
             }
-          : {}),
-      };
-      try {
-        await tasks.enqueue(session.id, async () => {
-          await store.writeSession(stopped);
-          const utterances = await store.readUtterancesForSession(stopped, {
-            maxUtterances: config.maxUtterances,
+            if (error.finalCaptureError !== undefined) {
+              active.finalCaptureError = error.finalCaptureError;
+              active.finalCaptureFailedAt ??= new Date().toISOString();
+            }
+            deliveryError = error;
+          }
+        }
+        if (deliveryError) {
+          throw deliveryError;
+        }
+        if (initializationError !== undefined) {
+          throw initializationError;
+        }
+        const finalCaptureError = active.finalCaptureError;
+        const stoppedAt = new Date().toISOString();
+        const stopped = {
+          ...active.descriptor,
+          stoppedAt,
+          ...(finalCaptureError !== undefined
+            ? {
+                metadata: {
+                  ...active.descriptor.metadata,
+                  finalCaptureError,
+                  finalCaptureFailedAt: active.finalCaptureFailedAt,
+                },
+              }
+            : {}),
+        };
+        try {
+          await tasks.enqueue(session.id, async () => {
+            await store.writeSession(stopped);
+            const utterances = await store.readUtterancesForSession(stopped, {
+              maxUtterances: config.maxUtterances,
+            });
+            await store.writeSummary(
+              summarizeTranscripts({ session: stopped, utterances }),
+              stopped,
+            );
           });
-          await store.writeSummary(summarizeTranscripts({ session: stopped, utterances }), stopped);
+        } catch (error) {
+          params.logger.warn(
+            `[meeting-transcripts] could not finalize durable capture session=${session.id}: ${coerceErrorMessage(error)}`,
+          );
+          throw error;
+        }
+      } finally {
+        // Final delivery drains before retirement, even if durable finalization
+        // needs recovery. Subscribers no longer receive this capture's audio.
+        await tasks.enqueue(session.id, async () => {
           for (const [subscriberSessionId, subscriber] of subscribers) {
             if (subscriber.meetingSessionId !== session.id) {
               continue;
@@ -334,16 +349,11 @@ export function createMeetingDurableTranscriptBridge<
               sessionId: subscriberSessionId,
               active: false,
               message: `${params.options.providerName} meeting capture ended.`,
-              source: stopped.source,
+              source: active.descriptor.source,
             });
             subscribers.delete(subscriberSessionId);
           }
         });
-      } catch (error) {
-        params.logger.warn(
-          `[meeting-transcripts] could not finalize durable capture session=${session.id}: ${coerceErrorMessage(error)}`,
-        );
-        throw error;
       }
       captures.delete(session.id);
       return true;
@@ -366,17 +376,21 @@ export function createMeetingDurableTranscriptBridge<
         };
       }
       let attached = false;
-      pendingSubscribers.set(request.session.sessionId, {
+      const subscriber: Subscriber = {
         agentId: session.agentId,
         meetingSessionId: session.id,
-      });
+        deliveredUtteranceIds: new Set(),
+        onStatus: request.onStatus,
+        onUtterance: request.onUtterance,
+      };
+      pendingSubscribers.set(request.session.sessionId, subscriber);
       try {
         await tasks.enqueue(session.id, async () => {
           if (captures.get(session.id) !== active || active.closing) {
             return;
           }
           const utterances = await store.readUtterancesForSession(active.descriptor);
-          const deliveredUtteranceIds = new Set<string>();
+          const { deliveredUtteranceIds } = subscriber;
           for (const utterance of utterances) {
             await request.onUtterance({
               ...utterance,
@@ -387,13 +401,7 @@ export function createMeetingDurableTranscriptBridge<
               deliveredUtteranceIds.add(utterance.id);
             }
           }
-          subscribers.set(request.session.sessionId, {
-            agentId: session.agentId,
-            deliveredUtteranceIds,
-            meetingSessionId: session.id,
-            onStatus: request.onStatus,
-            onUtterance: request.onUtterance,
-          });
+          subscribers.set(request.session.sessionId, subscriber);
           try {
             await request.onStatus?.({
               sessionId: request.session.sessionId,
@@ -426,19 +434,17 @@ export function createMeetingDurableTranscriptBridge<
       }
       return await tasks.enqueue(owner.meetingSessionId, async () => {
         const current = subscribers.get(request.sessionId);
-        if (!current) {
+        // A queued detach must not consume a replacement attachment with the same id.
+        if (current !== owner) {
           return { ok: true, sessionId: request.sessionId, stoppedAt: new Date().toISOString() };
         }
-        if (request.source.agentId !== current.agentId) {
-          return { ok: false as const, error: "transcripts session belongs to another agent" };
-        }
+        subscribers.delete(request.sessionId);
         notifySubscriberStatus(current, {
           sessionId: request.sessionId,
           active: false,
           message: `Detached from ${params.options.providerName} meeting capture.`,
           source: request.source,
         });
-        subscribers.delete(request.sessionId);
         return {
           ok: true as const,
           sessionId: request.sessionId,

--- a/src/meeting-bot/transcripts-bridge.test.ts
+++ b/src/meeting-bot/transcripts-bridge.test.ts
@@ -2,15 +2,24 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { activeSessions } from "../agents/tools/transcripts-tool-runtime.js";
+import { createTranscriptsTool } from "../agents/tools/transcripts-tool.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { TranscriptsStore } from "../transcripts/store.js";
 import { MeetingTranscriptDeliveryError } from "./session-transcript-store.js";
 import type { MeetingSessionRecord } from "./session-types.js";
+import { createMeetingTranscriptSourceProvider } from "./transcripts-bridge.js";
 import { createMeetingDurableTranscriptBridge } from "./transcripts-bridge.runtime.js";
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
+  activeSessions.clear();
+  closeOpenClawStateDatabaseForTest();
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { force: true, recursive: true })));
 });
 
@@ -31,6 +40,91 @@ function session(): MeetingSessionRecord<"chrome", "agent"> {
 }
 
 describe("MeetingDurableTranscriptBridge", () => {
+  it.each([false, true])(
+    "retires simultaneous tool subscribers when meeting capture ends (metadata failure: %s)",
+    async (failMetadata) => {
+      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-bridge-"));
+      tempDirs.push(stateDir);
+      const current = session();
+      const logger = { warn: vi.fn() };
+      const bridge = createMeetingDurableTranscriptBridge({
+        logger,
+        options: { providerId: "meeting", providerName: "Meeting", stateDir },
+      });
+      const stopSource = vi.fn(bridge.detach.bind(bridge));
+      const provider = createMeetingTranscriptSourceProvider({
+        id: "meeting",
+        name: "Meeting",
+        runtime: async () => ({
+          startTranscriptSource: async (request) => await bridge.attach(current, request),
+          stopTranscriptSource: stopSource,
+        }),
+      });
+      const registry = createEmptyPluginRegistry();
+      registry.transcriptSourceProviders.push({ pluginId: "meeting", source: "test", provider });
+      const tool = createTranscriptsTool({
+        stateDir,
+        agentId: "research",
+        logger,
+        caller: { kind: "operator", source: "local" },
+      });
+      const execute = (params: Record<string, unknown>) =>
+        withPluginRuntimeRegistryScope(registry, () => tool.execute("meeting", params));
+      const attach = (sessionId: string) =>
+        execute({ action: "start", providerId: "meeting", meetingUrl: current.url, sessionId });
+      const store = new TranscriptsStore(path.join(stateDir, "transcripts"), {
+        env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      });
+      await bridge.start(current, async () => {});
+      await bridge.ingest(current, [{ text: "existing note" }]);
+      await attach("first-subscriber");
+      await attach("second-subscriber");
+      await execute({ action: "stop", sessionId: "first-subscriber" });
+      await expect(execute({ action: "status" })).resolves.toMatchObject({
+        details: { active: [{ sessionId: "second-subscriber" }] },
+      });
+      await attach("third-subscriber");
+      const writeSession = store.writeSession.bind(store);
+      const fault = vi
+        .spyOn(TranscriptsStore.prototype, "writeSession")
+        .mockImplementation(async (descriptor) => {
+          if (failMetadata && descriptor.sessionId === current.id && descriptor.stoppedAt) {
+            throw new Error("meeting metadata unavailable");
+          }
+          return await writeSession(descriptor);
+        });
+      const stopping = bridge.stop(current, async () => {
+        await bridge.ingest(current, [{ text: "final note" }]);
+      });
+      if (failMetadata) {
+        await expect(stopping).rejects.toThrow("meeting metadata unavailable");
+      } else {
+        await expect(stopping).resolves.toBe(true);
+      }
+      fault.mockRestore();
+      await vi.waitFor(async () => {
+        for (const sessionId of ["second-subscriber", "third-subscriber"]) {
+          const stored = await store.readSession(sessionId);
+          expect(stored?.stoppedAt).toEqual(expect.any(String));
+          expect(stored?.metadata).toMatchObject({ agentId: "research" });
+          expect(stored?.source).toMatchObject({ providerId: "meeting", agentId: "research" });
+          expect(stored && (await store.readSummary(stored))).toMatchObject({
+            summary: { utteranceCount: 2 },
+          });
+        }
+        await expect(execute({ action: "status" })).resolves.toMatchObject({
+          details: { active: [], pendingFinalization: [] },
+        });
+      });
+      expect(stopSource).toHaveBeenCalledOnce();
+      await execute({ action: "stop", sessionId: "second-subscriber" });
+      expect(stopSource).toHaveBeenCalledOnce();
+      if (failMetadata) {
+        await bridge.stop(current, async () => {});
+      }
+    },
+  );
+
   it("replays stored lines to an attached provider and streams new lines in order", async () => {
     const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transcript-bridge-"));
     tempDirs.push(stateDir);

--- a/src/transcripts/provider-types.ts
+++ b/src/transcripts/provider-types.ts
@@ -63,6 +63,12 @@ export type TranscriptStartRequest = {
   abortSignal?: AbortSignal;
   startupWaitMs?: number;
   onUtterance: (utterance: TranscriptUtterance) => void | Promise<void>;
+  /**
+   * `active: false` permanently ends this exact capture subscription, including
+   * replacement or detach; transient transport disconnects must not emit it.
+   * Deliver final utterances first. Callback payload ids/source are descriptive;
+   * consumers retain their admitted session identity and ownership metadata.
+   */
   onStatus?: (status: TranscriptSourceStatus) => void | Promise<void>;
 };
 

--- a/src/transcripts/store.test.ts
+++ b/src/transcripts/store.test.ts
@@ -263,9 +263,9 @@ describe("TranscriptsStore", () => {
     const artifacts = await store.materializeSessionArtifacts(target, "transcript");
     fs.appendFileSync(artifacts.transcriptPath, '{"text":"external edit"}\n');
 
-    await expect(store.updateStopped(target.sessionId, "2026-07-01T11:00:00.000Z")).resolves.toBe(
-      undefined,
-    );
+    await expect(
+      store.writeSession({ ...target, stoppedAt: "2026-07-01T11:00:00.000Z" }),
+    ).resolves.toBeUndefined();
     await expect(store.readSession(target.sessionId)).resolves.toMatchObject({
       stoppedAt: "2026-07-01T11:00:00.000Z",
     });

--- a/src/transcripts/store.ts
+++ b/src/transcripts/store.ts
@@ -449,14 +449,6 @@ export class TranscriptsStore {
       .map(utteranceFromRow);
   }
 
-  async updateStopped(sessionSelector: string, stoppedAt: string): Promise<void> {
-    const entry = await this.readSessionEntry(sessionSelector);
-    if (!entry) {
-      return;
-    }
-    await this.writeSession({ ...entry.session, stoppedAt });
-  }
-
   async writeSummary(
     summary: TranscriptsSummary,
     session?: TranscriptSessionDescriptor,

--- a/test/transcripts-tool.discord-lifecycle.integration.test.ts
+++ b/test/transcripts-tool.discord-lifecycle.integration.test.ts
@@ -1,16 +1,18 @@
 import path from "node:path";
-import { activeSessions } from "../../../../src/agents/tools/transcripts-tool-runtime.js";
-import { createTranscriptsTool } from "../../../../src/agents/tools/transcripts-tool.js";
-import { createEmptyPluginRegistry } from "../../../../src/plugins/registry-empty.js";
-import { withPluginRuntimeRegistryScope } from "../../../../src/plugins/runtime/gateway-request-scope.js";
-import { closeOpenClawStateDatabaseForTest } from "../../../../src/state/openclaw-state-db.js";
-import { TranscriptsStore } from "../../../../src/transcripts/store.js";
-import { createTempDirTracker } from "../../../../test/helpers/temp-dir.js";
 import {
   discordVoiceTranscriptsSourceProvider,
+  loadDiscordVoiceTestHarness,
   setDiscordTranscriptsVoiceManager,
-} from "./transcripts-source.js";
-import { defineDiscordVoiceTests } from "./voice-test-harness.test-support.js";
+} from "../extensions/discord/test-api.js";
+import { activeSessions } from "../src/agents/tools/transcripts-tool-runtime.js";
+import { createTranscriptsTool } from "../src/agents/tools/transcripts-tool.js";
+import { createEmptyPluginRegistry } from "../src/plugins/registry-empty.js";
+import { withPluginRuntimeRegistryScope } from "../src/plugins/runtime/gateway-request-scope.js";
+import { closeOpenClawStateDatabaseForTest } from "../src/state/openclaw-state-db.js";
+import { TranscriptsStore } from "../src/transcripts/store.js";
+import { createTempDirTracker } from "./helpers/temp-dir.js";
+
+const { defineDiscordVoiceTests } = await loadDiscordVoiceTestHarness();
 
 defineDiscordVoiceTests(
   ({


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who stop or replace a Discord transcript capture can still receive late utterances in the retired transcript, see both old and new captures reported as active, or have historical stop actions reach the provider again. The live capture and its durable notes have different lifetimes, but core bookkeeping did not consume provider termination notifications.

Closes #127426 — Discord transcript stop or replacement does not fence in-flight utterance delivery.

Related: #130860 — preserving meeting logs through voice reconnects. That open capture-owner refactor is separate: this PR repairs the pre-existing core lifecycle gap and deferred transcript delivery without including or depending on its commits. The separate realtime `onClose` repair is also not bundled.

## Why This Change Was Made

The existing `onStatus` callback now closes the exact admitted capture, and provider-driven completion and explicit stop share one finalizer that preserves terminal timestamps, persists the summary once, and retains visible recovery ownership when persistence fails. Discord retires the old binding before notification and carries its exact subscription through queued audio, STT, and realtime delivery; the shared meeting bridge drains final delivery and independently retires subscribers even when meeting metadata persistence fails.

## User Impact

`transcripts` status reports current capture subscriptions rather than historical notes. A replaced capture gets a durable stop time and summary, remains available to list/show/summarize, and cannot accept a delayed utterance or stop its replacement. Historical stop preserves its recorded timestamp and admitted source/account/agent ownership.

Temporary transport disconnects do not terminate a subscription. Simultaneous meeting subscribers remain independent. Provider completion stores summaries without creating file exports; explicit stop, import, and summarize actions still materialize artifacts. Ended captures whose persistence failed appear separately under `pendingFinalization`, with an instruction to retry `stop` without stopping the provider again. This retry state is process-owned; no new automatic recovery replay across Gateway restart is introduced.

There is no provider-status polling, source-based deduplication, Discord policy in core, or new schema, configuration, environment, or dependency surface. The CLI documentation explains active capture versus durable history and persistence recovery.

## Evidence

AI-assisted implementation and validation. The final committed patch is byte-identical to the reviewed staged diff. Fresh pre-commit autoreview reported no actionable findings at its default **P0-only threshold**; that review did not run tests and is not a claim of broader review or live proof.

The original regression uses the real transcripts tool, Discord provider/manager, and SQLite store under the test harness. Before the repair, replacing `first` with `second` produced `active: ["first", "second"]` instead of `["second"]`, left `first.stoppedAt` unset, and invoked provider stop when stopping historical `first`. After the repair, only `second` is active, `first` retains its utterance and summary, historical stop never reaches the provider, the replacement stays connected, and manager destruction finalizes it.

Negative tests against the original source also reproduced 12 core failures, 11 Discord failures, and meeting subscriber termination failures. Isolating the old STT/realtime producer paths while retaining repaired core reproduced all four selected delayed-delivery failures, so the producer proof does not rely only on the core callback fence.

Executed focused commands recorded during implementation:

```sh
node scripts/run-vitest.mjs extensions/discord/src/voice/transcripts-source.lifecycle.test.ts extensions/discord/src/voice/transcripts-source.test.ts extensions/discord/src/voice/voice-session.lifecycle.test.ts extensions/discord/src/voice/segment.test.ts extensions/discord/src/voice/realtime-turns.test.ts src/agents/tools/transcripts-tool.lifecycle.test.ts src/agents/tools/transcripts-tool.test.ts src/agents/tools/transcripts-tool.account-ownership.test.ts src/agents/tools/transcripts-tool.import.test.ts src/meeting-bot/transcripts-bridge.test.ts src/meeting-bot/session-runtime.test.ts src/transcripts/store.test.ts test/transcripts-tool.discord-provider.integration.test.ts
node scripts/run-vitest.mjs src/meeting-bot/transcripts-bridge.test.ts src/transcripts/source-locator.test.ts src/transcripts/summary.test.ts
node scripts/run-vitest.mjs src/agents/tools/transcripts-tool.lifecycle.test.ts src/agents/tools/transcripts-tool.test.ts
node scripts/check-changed.mjs
node --import ./scripts/tsx.mjs scripts/build-all.mts
```

The focused proof covers **203 distinct tests in 15 files**, including account ownership, manual import, source sanitization, summary/store behavior, shared meeting lifecycle, and Discord replacement/delivery. A subsequent final core/meeting rerun passed **41 tests in 3 files** after test-style/type corrections. All changed-file gates passed, including core/plugin production and test typechecks, lint, formatting, import cycles, and storage guards. The full build passed. Build and plugin lint artifact preparation were serialized for the final proof after an earlier concurrent attempt raced over generated SDK output.

Production LOC: **+379 / -199 = +180**; tests: **+702 / -10 = +692**; docs: **+16 / -4 = +12**, across 21 files. The net production growth supplies the missing exact-capture terminal/recovery state, one shared finalizer, the operator-visible pending outcome, and producer-side audio subscription identity. A smaller consumer-only filter would leave retired callbacks deliverable and persistence failures without an owner. The repair removes duplicate explicit-stop durable bookkeeping, the obsolete selector-resolving `TranscriptsStore.updateStopped` wrapper, and the separate per-stop symbol; it adds no production file or generic lifecycle framework.

**Live-proof limitation and maintainer decision:** the maintainer explicitly waived live Discord QA for this deterministic lifecycle repair after the dedicated QA credentials could not be found at their documented locations. No live Discord call or production-state mutation was performed. The evidence above is controlled tool/provider/manager/SQLite and meeting-lifecycle boundary proof, not live channel proof. Landing still requires exact-head CI, current review resolution, and the repository-native prepare/merge gates. The optional QA harness safety findings discovered during proof preparation were preserved separately and are not included in this PR.

