### PR TITLE
fix: Claude auth failures disappear in channel chats

### DIFF
--- a/src/agents/failover/classification-rules.ts
+++ b/src/agents/failover/classification-rules.ts
@@ -407,13 +407,15 @@ export function isExactUnknownNoDetailsError(raw: string): boolean {
     normalizeOptionalLowercaseString(raw)?.trim() === "unknown error (no error details in response)"
   );
 }
-export function isClaudeCliLoggedOutError(raw: string, provider?: string): boolean {
-  // This upstream phrase is generic prose. Provider identity must come from
-  // the runner metadata so other providers cannot inherit Claude CLI policy.
+export function isClaudeCliAuthError(raw: string, provider?: string): boolean {
+  // These upstream phrases overlap generic session/auth wording. Provider identity
+  // must come from runner metadata so other CLIs cannot inherit Claude policy.
   if (normalizeOptionalLowercaseString(provider)?.trim() !== "claude-cli") {
     return false;
   }
-  return /\bnot logged in\b\s*·\s*please run \/login\b/i.test(raw);
+  return /\bnot logged in\b\s*·\s*please run \/login\b|\bfailed to authenticate:\s*oauth session expired and could not be refreshed\b/i.test(
+    raw,
+  );
 }
 export function isUnsupportedImageInputErrorMessage(raw: string | undefined): boolean {
   const normalized = normalizeOptionalLowercaseString(raw);

--- a/src/agents/failover/classify.test.ts
+++ b/src/agents/failover/classify.test.ts
@@ -10,3 +10,15 @@ describe("Claude CLI logged-out failures", () => {
     expect(classifyFailoverReason(loggedOutMessage)).toBeNull();
   });
 });
+
+describe("OAuth session expiry", () => {
+  const expiredMessage = "Failed to authenticate: OAuth session expired and could not be refreshed";
+
+  it("classifies OAuth expiry as auth only for claude-cli", () => {
+    expect(classifyFailoverReason(expiredMessage, { provider: "claude-cli" })).toBe("auth");
+    expect(classifyFailoverReason(expiredMessage, { provider: "custom-cli" })).toBe(
+      "session_expired",
+    );
+    expect(classifyFailoverReason(expiredMessage)).toBe("session_expired");
+  });
+});

--- a/src/agents/failover/classify.ts
+++ b/src/agents/failover/classify.ts
@@ -130,8 +130,12 @@ function classifyFailoverClassificationFromMessage(
   if (isUnsupportedImageInputErrorMessage(raw)) {
     return toReasonClassification("format");
   }
-  // OAuth sessions are credentials, not resumable CLI conversations.
-  if (isCliSessionExpiredErrorMessage(raw) && !/\boauth session\b/i.test(raw)) {
+  // Claude CLI OAuth sessions are credentials, not resumable CLI conversations.
+  if (
+    isCliSessionExpiredErrorMessage(raw) &&
+    (normalizeOptionalLowercaseString(provider)?.trim() !== "claude-cli" ||
+      !/\boauth session\b/i.test(raw))
+  ) {
     return toReasonClassification("session_expired");
   }
   if (isModelNotFoundErrorMessage(raw)) {

--- a/src/agents/failover/classify.ts
+++ b/src/agents/failover/classify.ts
@@ -22,7 +22,7 @@ import {
   classifyFailoverReasonFromCode,
   failoverReasonFromClassification,
   inferSignalStatus,
-  isClaudeCliLoggedOutError,
+  isClaudeCliAuthError,
   isExactUnknownNoDetailsError,
   isGenericUnknownStreamErrorMessage,
   isTransientHttpError,
@@ -130,12 +130,10 @@ function classifyFailoverClassificationFromMessage(
   if (isUnsupportedImageInputErrorMessage(raw)) {
     return toReasonClassification("format");
   }
-  // Claude CLI OAuth sessions are credentials, not resumable CLI conversations.
-  if (
-    isCliSessionExpiredErrorMessage(raw) &&
-    (normalizeOptionalLowercaseString(provider)?.trim() !== "claude-cli" ||
-      !/\boauth session\b/i.test(raw))
-  ) {
+  if (isClaudeCliAuthError(raw, provider)) {
+    return toReasonClassification("auth");
+  }
+  if (isCliSessionExpiredErrorMessage(raw)) {
     return toReasonClassification("session_expired");
   }
   if (isModelNotFoundErrorMessage(raw)) {
@@ -204,9 +202,6 @@ function classifyFailoverClassificationFromMessage(
   // Auth classifiers run before the broad isJsonApiInternalServerError check so that
   // provider errors like {"type":"api_error","message":"invalid api key"} are
   // correctly classified as "auth" rather than "timeout".
-  if (isClaudeCliLoggedOutError(raw, provider)) {
-    return toReasonClassification("auth");
-  }
   const oauthRefreshFailure = classifyOAuthRefreshFailure(raw);
   if (oauthRefreshFailure?.reason) {
     return toReasonClassification("auth_permanent");

--- a/src/agents/failover/classify.ts
+++ b/src/agents/failover/classify.ts
@@ -130,7 +130,8 @@ function classifyFailoverClassificationFromMessage(
   if (isUnsupportedImageInputErrorMessage(raw)) {
     return toReasonClassification("format");
   }
-  if (isCliSessionExpiredErrorMessage(raw)) {
+  // OAuth sessions are credentials, not resumable CLI conversations.
+  if (isCliSessionExpiredErrorMessage(raw) && !/\boauth session\b/i.test(raw)) {
     return toReasonClassification("session_expired");
   }
   if (isModelNotFoundErrorMessage(raw)) {

--- a/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
@@ -316,27 +316,31 @@ describe("executeAgentTurn: authentication failures", () => {
     }
   });
 
-  it("surfaces claude-cli re-auth hint over generic provider auth copy for 401 OAuth expiry", async () => {
-    // When the claude subprocess emits a 401 "Failed to authenticate" because
-    // its OAuth token has expired, the error is wrapped as a FailoverError with
-    // reason:"auth" and status:401.  Without the ordering fix, this would be
-    // caught by generic provider-auth mapping before the typed refresh cause,
-    // producing generic provider copy instead of the
-    // targeted claude-cli re-auth command.
-    state.runEmbeddedAgentMock.mockRejectedValueOnce(
-      new FailoverError(
-        "Provider claude-cli failed: Failed to authenticate. API Error: 401 Invalid authentication credentials",
-        {
-          reason: "auth",
-          provider: "claude-cli",
-          model: "claude-sonnet-4-20250514",
-          status: 401,
-        },
-      ),
-    );
+  it("surfaces Agent SDK OAuth session expiry in Discord channels", async () => {
+    const error = createCliOutputFailoverError({
+      output: {
+        text: "",
+        errorText: "Failed to authenticate: OAuth session expired and could not be refreshed",
+      },
+      provider: "claude-cli",
+      model: "claude-opus-5",
+    });
+    if (!error) {
+      throw new Error("expected CLI output failure");
+    }
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(error);
 
     const executeAgentTurn = await getExecuteAgentTurnForTest();
-    const result = await executeAgentTurn(createMinimalRunAgentTurnParams());
+    const result = await executeAgentTurn(
+      createMinimalRunAgentTurnParams({
+        sessionCtx: {
+          Provider: "discord",
+          Surface: "discord",
+          ChatType: "channel",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    );
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
@@ -382,40 +386,6 @@ describe("executeAgentTurn: authentication failures", () => {
 
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     const result = await executeAgentTurn(createMinimalRunAgentTurnParams());
-
-    expect(result.kind).toBe("final");
-    if (result.kind === "final") {
-      expect(result.payload.text).toBe(
-        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli` in a terminal, then try again.",
-      );
-    }
-  });
-
-  it("surfaces claude-cli OAuth session expiry in Discord channels", async () => {
-    const error = createCliOutputFailoverError({
-      output: {
-        text: "",
-        errorText: "Failed to authenticate: OAuth session expired and could not be refreshed",
-      },
-      provider: "claude-cli",
-      model: "claude-opus-5",
-    });
-    if (!error) {
-      throw new Error("expected CLI output failure");
-    }
-    state.runEmbeddedAgentMock.mockRejectedValueOnce(error);
-
-    const executeAgentTurn = await getExecuteAgentTurnForTest();
-    const result = await executeAgentTurn(
-      createMinimalRunAgentTurnParams({
-        sessionCtx: {
-          Provider: "discord",
-          Surface: "discord",
-          ChatType: "channel",
-          MessageSid: "msg",
-        } as unknown as TemplateContext,
-      }),
-    );
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {

--- a/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { OAuthRefreshFailureError } from "../../agents/auth-profiles/oauth-refresh-failure.js";
+import { createCliOutputFailoverError } from "../../agents/cli-runner/output-error.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { MissingProviderAuthError, ProviderAuthError } from "../../agents/model-auth.js";
 import type { TemplateContext } from "../templating.js";
@@ -381,6 +382,40 @@ describe("executeAgentTurn: authentication failures", () => {
 
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     const result = await executeAgentTurn(createMinimalRunAgentTurnParams());
+
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(
+        "⚠️ Model login expired on the gateway for claude-cli. Re-auth with `claude auth login && openclaw models auth login --provider anthropic --method cli` in a terminal, then try again.",
+      );
+    }
+  });
+
+  it("surfaces claude-cli OAuth session expiry in Discord channels", async () => {
+    const error = createCliOutputFailoverError({
+      output: {
+        text: "",
+        errorText: "Failed to authenticate: OAuth session expired and could not be refreshed",
+      },
+      provider: "claude-cli",
+      model: "claude-opus-5",
+    });
+    if (!error) {
+      throw new Error("expected CLI output failure");
+    }
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(error);
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(
+      createMinimalRunAgentTurnParams({
+        sessionCtx: {
+          Provider: "discord",
+          Surface: "discord",
+          ChatType: "channel",
+          MessageSid: "msg",
+        } as unknown as TemplateContext,
+      }),
+    );
 
     expect(result.kind).toBe("final");
     if (result.kind === "final") {


### PR DESCRIPTION
AI-assisted.

## What Problem This Solves

Discord channel users did not get the existing Claude re-authentication steps when the Claude Agent SDK OAuth login expired. The runtime treated the credential failure as an expired resumable conversation.

## Why This Change Was Made

Claude Code 2.1.233 emits this terminal Agent SDK result in non-interactive mode:

`Failed to authenticate: OAuth session expired and could not be refreshed`

The generic session matcher saw `session expired` first. It returned `session_expired`, status 410, and exhausted the fallback chain before the existing OAuth recovery owner could build its reply.

This change extends the existing provider-scoped Claude CLI authentication matcher with the dependency-owned wording and runs that matcher before generic resumable-session classification. Other CLI providers, missing provider metadata, and real stale conversation IDs keep `session_expired` behavior.

## User Impact

Discord users now receive the established recovery steps:

`claude auth login && openclaw models auth login --provider anthropic --method cli`

No configuration, retry, provider bypass, schema, or new recovery path was added.

## Evidence

- Exact current main `56d89073dda41ccf19189474b8f2c110243afc4b`: a real leased Discord mention ran through an isolated Gateway, the installed Anthropic Agent SDK, the real Claude subprocess, JSONL parsing, fallback classification, reply construction, and Discord delivery. Raw CLI output contained the OAuth-expiry result. Classification was `session_expired`/410 with `chain_exhausted`. Discord showed only the generic temporary-failure reply.
- Exact repaired head `b070b97e48becb053574750d55b2c463b427984b`: the identical scenario and raw CLI result classified as `auth`/401. Discord showed the established Claude CLI re-authentication reply.
- The disposable invalid login failed locally in Claude Code before inference. No operator credential or provider content was used.
- Regression control: the classifier test failed before the repair because it received `session_expired` instead of `auth`.
- Focused repaired suites: 24 tests passed.
- Parser, session, and CLI recovery siblings: 224 tests passed.
- Changed-scope gate passed on the repaired head, including format, lint, core and test type-check, dead-code, import-cycle, dependency, and policy guards.
- Exact-head build passed.
- Production code: +2 lines. Tests: +17 lines. The production growth adds the second dependency-owned Claude authentication wording to the existing classifier; no separate path remains.
