### PR TITLE
fix(telegram): cap rich message media at 20

### DIFF
--- a/extensions/telegram/src/rich-block-model.ts
+++ b/extensions/telegram/src/rich-block-model.ts
@@ -337,11 +337,11 @@ export function maxInputRichBlockNesting(blocks: readonly InputRichBlock[]): num
   return Math.max(0, ...blocks.map(blockDepth));
 }
 
-/** Media elements per block, for the wire's 50-media message cap. */
+/** Media elements per block, for Telegram's observed 20-media message cap. */
 export function countInputRichBlockMedia(block: InputRichBlock): number {
   switch (block.type) {
     // Maps are excluded: 51 maps in one message were accepted live, so they
-    // do not consume the 50-attachment budget.
+    // do not consume the media-attachment budget.
     case "photo":
     case "video":
     case "audio":

--- a/extensions/telegram/src/rich-block-split.ts
+++ b/extensions/telegram/src/rich-block-split.ts
@@ -235,10 +235,36 @@ function splitOversizedRichBlock(block: InputRichBlock, limits: RichBlockLimits)
     return pieces;
   }
   if (block.type === "list") {
+    const expandedItems = block.items.flatMap((item) => {
+      if (measureRichBlocks(item.blocks).media <= TELEGRAM_RICH_MEDIA_LIMIT) {
+        return [item];
+      }
+      const itemChunks = splitTelegramRichBlocks(item.blocks, {
+        textLimit,
+        // Reserve one block for the list wrapper and one for the item itself.
+        blockLimit: Math.max(1, blockLimit - 2),
+      });
+      return itemChunks.map((blocks) => {
+        const piece: InputRichBlockListItem = { blocks };
+        if (item.has_checkbox !== undefined) {
+          piece.has_checkbox = item.has_checkbox;
+        }
+        if (item.is_checked !== undefined) {
+          piece.is_checked = item.is_checked;
+        }
+        if (item.value !== undefined) {
+          piece.value = item.value;
+        }
+        if (item.type !== undefined) {
+          piece.type = item.type;
+        }
+        return piece;
+      });
+    });
     const pieces: InputRichBlock[] = [];
     let items: InputRichBlockListItem[] = [];
     let size: RichBlockBudget = { chars: 0, blocks: 1, media: 0 };
-    for (const item of block.items) {
+    for (const item of expandedItems) {
       const measured = measureRichBlocks(item.blocks);
       const itemSize = { ...measured, blocks: measured.blocks + 1 };
       const nextSize = addRichBlockBudget(size, itemSize);

--- a/extensions/telegram/src/rich-block-split.ts
+++ b/extensions/telegram/src/rich-block-split.ts
@@ -13,7 +13,9 @@ import {
 } from "./rich-block-model.js";
 import { splitTelegramPlainTextChunks, surrogateSafeChunkEnd } from "./rich-plain-fallback.js";
 
-const TELEGRAM_RICH_MEDIA_LIMIT = 50;
+// Telegram's server silently drops the overflowing media block and its tail
+// above 20 rich-media items, despite the documented 50-item limit.
+export const TELEGRAM_RICH_MEDIA_LIMIT = 20;
 
 type RichBlockBudget = { chars: number; blocks: number; media: number };
 type RichBlockLimits = { textLimit: number; blockLimit: number };

--- a/extensions/telegram/src/rich-blocks.test.ts
+++ b/extensions/telegram/src/rich-blocks.test.ts
@@ -736,6 +736,29 @@ describe("splitTelegramRichBlocks", () => {
     ).toEqual([20, 1]);
   });
 
+  it("splits a single list item containing 21 media without dropping its tail", () => {
+    const photos: InputRichBlock[] = Array.from({ length: 21 }, (_, index) => ({
+      type: "photo",
+      photo: { type: "photo", media: `https://example.com/${index}.jpg` },
+    }));
+    const tail: InputRichBlock = { type: "paragraph", text: "after media" };
+    const chunks = splitTelegramRichBlocks([
+      { type: "list", items: [{ value: 7, blocks: [...photos, tail] }] },
+    ]);
+    const lists = chunks.flat().filter((block) => block.type === "list");
+
+    expect(
+      chunks.map((chunk) =>
+        chunk.reduce((total, block) => total + countInputRichBlockMedia(block), 0),
+      ),
+    ).toEqual([20, 1]);
+    expect(lists.flatMap((list) => list.items).flatMap((item) => item.blocks)).toEqual([
+      ...photos,
+      tail,
+    ]);
+    expect(lists.flatMap((list) => list.items).map((item) => item.value)).toEqual([7, 7]);
+  });
+
   it("moves a gallery whole to the next rich message and preserves surrounding text order", () => {
     const photo = (index: number): InputRichBlock => ({
       type: "photo",

--- a/extensions/telegram/src/rich-blocks.test.ts
+++ b/extensions/telegram/src/rich-blocks.test.ts
@@ -691,7 +691,7 @@ describe("splitTelegramRichBlocks", () => {
     const collage: InputRichBlock = {
       type: "collage",
       caption: { text: "Album caption" },
-      blocks: Array.from({ length: 51 }, (_, index) => ({
+      blocks: Array.from({ length: 21 }, (_, index) => ({
         type: "photo" as const,
         photo: { type: "photo" as const, media: `https://example.com/${index}.jpg` },
       })),
@@ -709,12 +709,53 @@ describe("splitTelegramRichBlocks", () => {
     ]);
     expect(
       mediaChunks.every(
-        (chunk) => chunk.reduce((total, block) => total + countInputRichBlockMedia(block), 0) <= 50,
+        (chunk) => chunk.reduce((total, block) => total + countInputRichBlockMedia(block), 0) <= 20,
       ),
     ).toBe(true);
     expect(albums.flatMap((album) => album.blocks)).toEqual(collage.blocks);
     expect(albums.flatMap((album) => (album.caption ? [album.caption.text] : []))).toEqual([
       "Album caption",
+    ]);
+  });
+
+  it("keeps exactly 20 media in one rich message and splits 21 into two", () => {
+    const photo = (index: number): InputRichBlock => ({
+      type: "photo",
+      photo: { type: "photo", media: `https://example.com/${index}.jpg` },
+    });
+
+    expect(
+      splitTelegramRichBlocks(Array.from({ length: 20 }, (_, index) => photo(index))),
+    ).toHaveLength(1);
+    const chunks = splitTelegramRichBlocks(Array.from({ length: 21 }, (_, index) => photo(index)));
+    expect(chunks).toHaveLength(2);
+    expect(
+      chunks.map((chunk) =>
+        chunk.reduce((total, block) => total + countInputRichBlockMedia(block), 0),
+      ),
+    ).toEqual([20, 1]);
+  });
+
+  it("moves a gallery whole to the next rich message and preserves surrounding text order", () => {
+    const photo = (index: number): InputRichBlock => ({
+      type: "photo",
+      photo: { type: "photo", media: `https://example.com/${index}.jpg` },
+    });
+    const leadingPhotos = Array.from({ length: 18 }, (_, index) => photo(index));
+    const slideshow: InputRichBlock = {
+      type: "slideshow",
+      blocks: Array.from({ length: 5 }, (_, index) => photo(index + 18)),
+    };
+    const chunks = splitTelegramRichBlocks([
+      ...leadingPhotos,
+      { type: "paragraph", text: "between albums" },
+      slideshow,
+      { type: "paragraph", text: "after albums" },
+    ]);
+
+    expect(chunks).toEqual([
+      [...leadingPhotos, { type: "paragraph", text: "between albums" }],
+      [slideshow, { type: "paragraph", text: "after albums" }],
     ]);
   });
 });

--- a/extensions/telegram/src/rich-plain-fallback.ts
+++ b/extensions/telegram/src/rich-plain-fallback.ts
@@ -11,7 +11,7 @@ const RICH_ENTITY_INVALID_RE = /RICH_MESSAGE_[A-Z_]+_INVALID/i;
 const RICH_CONTENT_REQUIRED_RE = /RICH_MESSAGE_CONTENT_REQUIRED/i;
 const EMPTY_TEXT_RE = /message text is empty|text must be non-empty/i;
 // Structural-limit rejections, live-verified against Bot API 10.2 (2026-07-15):
-// >500 recursively counted blocks, >16 depth, oversized text, >50 media, >20 table cols.
+// >500 recursively counted blocks, >16 depth, oversized text, >20 media, >20 table cols.
 const RICH_STRUCTURE_INVALID_RE =
   /RICH_MESSAGE_(?:BLOCKS_TOO_MANY|DEPTH_INVALID|TEXT_TOO_LONG|MEDIA_TOO_MANY|TABLE_COLS_TOO_MANY)/i;
 const PARSE_ERR_RE =

--- a/extensions/telegram/src/send-edit.ts
+++ b/extensions/telegram/src/send-edit.ts
@@ -28,6 +28,7 @@ import {
   deliverTelegramTextPage,
   planTelegramTextDeliveryPages,
 } from "./telegram-text-delivery.js";
+import { TELEGRAM_TEXT_CHUNK_LIMIT } from "./text-chunk-limit.js";
 import { resolveTelegramBotUserIdFromToken } from "./token-fingerprint.js";
 
 type TelegramEditMessageTextParams = Parameters<TelegramApiContext["api"]["editMessageText"]>[3];
@@ -215,13 +216,19 @@ async function editMessageTelegramWithContext(
       fallbackLimit: Number.MAX_SAFE_INTEGER,
       sender: {
         sendPlain: (value, _fallback, label) =>
-          edit(
-            () =>
-              Object.keys(commonTextParams).length
-                ? api.editMessageText(chatId, messageId, value, commonTextParams)
-                : api.editMessageText(chatId, messageId, value),
-            label,
-          ),
+          value.length > TELEGRAM_TEXT_CHUNK_LIMIT
+            ? Promise.reject(
+                new Error(
+                  `telegram editMessage failed: complete plain fallback is ${value.length} characters, exceeding the ${TELEGRAM_TEXT_CHUNK_LIMIT}-character edit limit`,
+                ),
+              )
+            : edit(
+                () =>
+                  Object.keys(commonTextParams).length
+                    ? api.editMessageText(chatId, messageId, value, commonTextParams)
+                    : api.editMessageText(chatId, messageId, value),
+                label,
+              ),
         sendHtml: (value) =>
           edit(() =>
             api.editMessageText(chatId, messageId, value, {

--- a/extensions/telegram/src/send-edit.ts
+++ b/extensions/telegram/src/send-edit.ts
@@ -9,6 +9,8 @@ import {
   recordOutboundMessageForPromptContext,
   type TelegramOutboundPromptContextMessage,
 } from "./outbound-message-context.js";
+import { countInputRichBlockMedia } from "./rich-block-model.js";
+import { TELEGRAM_RICH_MEDIA_LIMIT } from "./rich-block-split.js";
 import { buildTelegramRichMarkdownPlan } from "./rich-message.js";
 import { withTelegramPlainFallback } from "./rich-plain-fallback.js";
 import {
@@ -170,18 +172,37 @@ async function editMessageTelegramWithContext(
     const richPlan = useRichMessages
       ? buildTelegramRichMarkdownPlan(text, { tableMode, skipEntityDetection: !linkPreviewEnabled })
       : undefined;
+    const richMediaCount =
+      richPlan?.richMessage.blocks.reduce(
+        (total, block) => total + countInputRichBlockMedia(block),
+        0,
+      ) ?? 0;
+    const richEditExceedsMediaLimit = richMediaCount > TELEGRAM_RICH_MEDIA_LIMIT;
+    if (richEditExceedsMediaLimit) {
+      sendLogger.warn(
+        `telegram editMessage degrade=plain-fallback:rich-media-too-many: ${richMediaCount} media exceeds rich edit limit of ${TELEGRAM_RICH_MEDIA_LIMIT}`,
+      );
+    }
     // An edit replaces one message. Keep the complete rich document so a
     // structural-limit rejection recovers all its text, not just the first send page.
-    const page = richPlan?.richMessage.blocks.length
-      ? { ...richPlan, sourceText: richPlan.plainText, sourceTextMode: "markdown" as const }
-      : planTelegramTextDeliveryPages({
-          text: textMode === "html" ? htmlText : text,
-          maxChars: Number.MAX_SAFE_INTEGER,
-          tableMode,
-          richMessages: useRichMessages,
-          skipEntityDetection: !linkPreviewEnabled,
-          ...(textMode === "html" ? { textMode: "html" as const } : {}),
-        })[0];
+    // Telegram can silently accept and truncate over-limit rich-media edits, so
+    // proactively replace those with the complete visible plain projection.
+    const page = richEditExceedsMediaLimit
+      ? {
+          plainText: richPlan?.plainText ?? text,
+          sourceText: richPlan?.plainText ?? text,
+          sourceTextMode: "markdown" as const,
+        }
+      : richPlan?.richMessage.blocks.length
+        ? { ...richPlan, sourceText: richPlan.plainText, sourceTextMode: "markdown" as const }
+        : planTelegramTextDeliveryPages({
+            text: textMode === "html" ? htmlText : text,
+            maxChars: Number.MAX_SAFE_INTEGER,
+            tableMode,
+            richMessages: useRichMessages,
+            skipEntityDetection: !linkPreviewEnabled,
+            ...(textMode === "html" ? { textMode: "html" as const } : {}),
+          })[0];
     if (!page) {
       throw new Error("telegram editMessage failed: empty text");
     }

--- a/extensions/telegram/src/send-rich-editing.test.ts
+++ b/extensions/telegram/src/send-rich-editing.test.ts
@@ -117,19 +117,32 @@ describe("Telegram rich message edits", () => {
     expect(botRawApi.editMessageText).not.toHaveBeenCalled();
   });
 
-  it("rejects an oversized plain replacement without editing separate chunks", async () => {
+  it("rejects an oversized rich fallback locally without editing separate chunks", async () => {
     const text = `START${"x".repeat(4100)}END`;
     botRawApi.editMessageText.mockRejectedValueOnce(
       new Error("400: Bad Request: RICH_MESSAGE_URL_INVALID"),
     );
-    const rejection = new Error("400: Bad Request: message is too long");
-    botApi.editMessageText.mockRejectedValueOnce(rejection);
 
     await expect(
       editMessageTelegram("123", 321, text, { cfg: richConfig, token: "tok" }),
-    ).rejects.toBe(rejection);
+    ).rejects.toThrow(
+      "telegram editMessage failed: complete plain fallback is 4108 characters, exceeding the 4000-character edit limit",
+    );
 
-    expect(botApi.editMessageText).toHaveBeenCalledExactlyOnceWith("123", 321, text);
+    expect(botRawApi.editMessageText).toHaveBeenCalledOnce();
+    expect(botApi.editMessageText).not.toHaveBeenCalled();
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized 21-media plain projection before any edit request", async () => {
+    const text = `${mediaMarkdown(21)}\n\n${"x".repeat(4100)}`;
+
+    await expect(
+      editMessageTelegram("123", 321, text, { cfg: richConfig, token: "tok" }),
+    ).rejects.toThrow(/complete plain fallback is \d+ characters, exceeding the 4000-character/);
+
+    expect(botRawApi.editMessageText).not.toHaveBeenCalled();
+    expect(botApi.editMessageText).not.toHaveBeenCalled();
     expect(botApi.sendMessage).not.toHaveBeenCalled();
   });
 });

--- a/extensions/telegram/src/send-rich-editing.test.ts
+++ b/extensions/telegram/src/send-rich-editing.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   getTelegramSendTestMocks,
   importTelegramSendModule,
@@ -9,12 +9,19 @@ installTelegramSendTestHooks();
 
 const { botApi, botRawApi } = getTelegramSendTestMocks();
 const { editMessageTelegram } = await importTelegramSendModule();
+const { sendLogger } = await import("./send-context.js");
 const richConfig = { channels: { telegram: { richMessages: true } } };
 const editedMessage = { message_id: 321, chat: { id: 123, type: "private" } };
 const paragraphs = (count: number) =>
   Array.from({ length: count }, (_, index) => `P${String(index + 1).padStart(3, "0")}`);
 const listItems = (count: number) =>
   Array.from({ length: count }, (_, index) => `L${String(index + 1).padStart(3, "0")}`);
+const mediaMarkdown = (count: number) =>
+  Array.from(
+    { length: count },
+    (_, index) =>
+      `<figure><img src="https://example.com/${index + 1}.jpg"/><figcaption>photo-${index + 1}</figcaption></figure>`,
+  ).join("\n\n");
 
 describe("Telegram rich message edits", () => {
   it.each([
@@ -66,6 +73,38 @@ describe("Telegram rich message edits", () => {
     );
     expect(botApi.editMessageText).not.toHaveBeenCalled();
     expect(botApi.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps exactly 20 media on the rich edit endpoint", async () => {
+    botRawApi.editMessageText.mockResolvedValueOnce(editedMessage);
+
+    await editMessageTelegram("123", 321, mediaMarkdown(20), {
+      cfg: richConfig,
+      token: "tok",
+    });
+
+    expect(botRawApi.editMessageText).toHaveBeenCalledOnce();
+    expect(botApi.editMessageText).not.toHaveBeenCalled();
+  });
+
+  it("degrades a 21-media rich edit to one complete visible plain replacement", async () => {
+    const warn = vi.spyOn(sendLogger, "warn").mockImplementation(() => {});
+    botApi.editMessageText.mockResolvedValueOnce(editedMessage);
+
+    await editMessageTelegram("123", 321, mediaMarkdown(21), {
+      cfg: richConfig,
+      token: "tok",
+    });
+
+    expect(botRawApi.editMessageText).not.toHaveBeenCalled();
+    expect(botApi.editMessageText).toHaveBeenCalledOnce();
+    const deliveredText = String(botApi.editMessageText.mock.calls[0]?.[2]);
+    expect(deliveredText.match(/https:\/\/example\.com\/\d+\.jpg/g)).toHaveLength(21);
+    expect(warn).toHaveBeenCalledWith(
+      "telegram editMessage degrade=plain-fallback:rich-media-too-many: 21 media exceeds rich edit limit of 20",
+    );
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it("keeps source text visible when rich rendering produces no blocks", async () => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -256,6 +256,15 @@ function markdownTable(columns: number): string {
     .join("\n");
 }
 
+function richMediaMarkdown(count: number, trailingText?: string): string {
+  const media = Array.from(
+    { length: count },
+    (_, index) =>
+      `<figure><img src="https://example.com/${index + 1}.jpg"/><figcaption>photo-${index + 1}</figcaption></figure>`,
+  );
+  return [...media, ...(trailingText ? [`<p>${trailingText}</p>`] : [])].join("\n\n");
+}
+
 function countTelegramRichBlocks(blocks: readonly InputRichBlock[] | undefined): number {
   return countInputRichBlocks(blocks ?? []);
 }
@@ -1548,6 +1557,48 @@ describe("sendMessageTelegram", () => {
     expect(plain).toContain("paragraph 500");
   });
 
+  it("uses one send for 20 rich media and two complete ordered sends for 21", async () => {
+    botApi.sendMessage.mockImplementation(async (chatId) => ({
+      message_id: botApi.sendMessage.mock.calls.length,
+      chat: { id: Number(chatId) },
+    }));
+
+    for (const [mediaCount, expectedSends] of [
+      [20, 1],
+      [21, 2],
+    ] as const) {
+      const trailingText = `TRAILING-CONTENT-${mediaCount}`;
+      await sendMessageTelegram("123", richMediaMarkdown(mediaCount, trailingText), {
+        cfg: { channels: { telegram: { richMessages: true } } },
+        token: "tok",
+      });
+
+      expect(botRawApi.sendRichMessage, `${mediaCount} media`).toHaveBeenCalledTimes(expectedSends);
+      const richMessages = botRawApi.sendRichMessage.mock.calls.map(
+        (call) => call[0]?.rich_message,
+      );
+      expect(
+        richMessages.map((message) =>
+          (message?.blocks ?? []).reduce(
+            (total, block) => total + countInputRichBlockMedia(block),
+            0,
+          ),
+        ),
+      ).toEqual(mediaCount === 20 ? [20] : [20, 1]);
+      const wireMedia = richMessages
+        .map((message) => JSON.stringify(message?.blocks ?? []))
+        .join("")
+        .match(/https:\/\/example\.com\/\d+\.jpg/g);
+      expect(wireMedia).toEqual(
+        Array.from({ length: mediaCount }, (_, index) => `https://example.com/${index + 1}.jpg`),
+      );
+      expect(inputRichBlocksToPlainText(richMessages.at(-1)?.blocks ?? [])).toContain(trailingText);
+
+      botRawApi.sendRichMessage.mockClear();
+      botApi.sendMessage.mockClear();
+    }
+  });
+
   it("keeps recursive list and album payloads within Telegram transport limits", async () => {
     botApi.sendMessage.mockResolvedValue({ message_id: 45, chat: { id: "123" } });
     const list = Array.from({ length: 250 }, (_, index) => `${index + 1}. item ${index + 1}`).join(
@@ -1583,7 +1634,7 @@ describe("sendMessageTelegram", () => {
           (request?.blocks ?? []).reduce(
             (total, block) => total + countInputRichBlockMedia(block),
             0,
-          ) <= 50,
+          ) <= 20,
       ),
     ).toBe(true);
     expect(items.map((item) => item.value)).toEqual(

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1574,9 +1574,8 @@ describe("sendMessageTelegram", () => {
       });
 
       expect(botRawApi.sendRichMessage, `${mediaCount} media`).toHaveBeenCalledTimes(expectedSends);
-      const richMessages = botRawApi.sendRichMessage.mock.calls.map(
-        (call) => call[0]?.rich_message,
-      );
+      const richMessages: Array<RichMessageTestPayload | undefined> =
+        botRawApi.sendRichMessage.mock.calls.map((call) => call[0]?.rich_message);
       expect(
         richMessages.map((message) =>
           (message?.blocks ?? []).reduce(


### PR DESCRIPTION
Closes #129004

## What Problem This Solves

Telegram's rich-message server silently drops the media block that crosses 20 items and every following block, although the Bot API documentation advertises a 50-media limit. The typed rich-block splitter used the documented 50-item budget, so messages containing 21 to 50 media items could report success while losing their tail. Direct rich-message edits bypassed that splitter and could hit the same silent-loss boundary.

## Why This Change Was Made

The shared typed rich-message page planner now uses the observed 20-media transport limit. Normal sends split before the overflowing block while preserving order and atomic galleries.

An edit can replace only one message, so it cannot use the multi-message splitter without changing edit semantics. The direct edit owner therefore detects an over-limit rich plan before dispatch and degrades it to one complete visible plain projection when that projection fits Telegram’s 4,096-character edit limit. If a complete replacement cannot fit, it fails locally before the legacy edit endpoint is called. Exactly 20 media still use the rich edit endpoint; 21 media never reach the silently truncating rich edit endpoint.

## User Impact

- Rich Telegram sends with 21 or more media are delivered as multiple ordered messages instead of silently losing media or trailing content.
- Exactly 20 media remain one rich message.
- Over-limit rich edits use a complete visible plain replacement when it fits one message; an oversized replacement fails locally with an explicit limit error instead of reaching Telegram or appearing to succeed with missing content.

## Current integration validation

This update preserves aspalagin's original implementation and ancestry while integrating main `47664a29e9fb2db3875738703889ddbdbf026ba2`. The reviewed candidate is `21332384fb81adc6e366ff6159ce214b5505f9df`.

The edit endpoint bound is now **4096**, distinct from the 4000-character send chunk target. Tests accept 4001/4096-character complete replacements and reject 4097 before any edit mutation on the over-media path.

- **378 focused tests passed** on the integrated source, including ordered 20/21-media sends, galleries/list tails, buttons/captions/replies/receipts and the five new boundary cases.
- Independent P0–P2 review: no findings.
- Full isolated Linux runtime build passed at this exact commit; final source hashes and a clean checkout were verified. This is not a live Telegram gateway/readback claim.
- Maintained changed-file checks: passed (production and test typechecks, formatting, targeted lint, contract guards, dead-export scans, and runtime import cycles).
- **Current gateway/Test Server recipient readback is not yet proved.** An authorized exact-head proof host with existing Convex broker access is still needed. The existing credentialed CI workflows do not directly admit this fork head under their same-repository/trusted-ref guards.
- Exact-head hosted CI and native prepare/LAND remain separate requirements. Historical endpoint observations below are not evidence for this integrated head.


## Historical evidence (prior head; not current gateway proof)

Tested exact head: `6caa2b268277e205fd069b5da890492ae5fb1730` (rebased onto main `1478fcc961`; the edit-path fallback was adapted to main's direct `api.raw.editMessageText` shape, behaviour unchanged).

- Pre-fix regression: a 21-media direct edit called the raw rich edit endpoint with all 21 media, demonstrating that the splitter was bypassed.
- Exact-head `extensions/telegram` rich-message, send-edit and transport tests: 3 files, 327 passed, including a single list item with 21 media split as `[20, 1]` with its trailing paragraph preserved and oversized plain edit fallbacks stopping locally before a legacy edit request.
- Changed-file `oxfmt`, `oxlint`, `git diff --check`, and `pnpm check:changed` (dead export scan, guard checks, extensions typecheck): passed. Full exact-head repository CI is green.

### Real Telegram endpoint proof (exact head `6caa2b2682`)

**Setup.** I ran the exact-head exported `sendMessageTelegram` / `editMessageTelegram` paths against the real `@<redacted-bot>` private chat (`<redacted-chat-id>`) through the configured Bot API 10.x endpoint (GrammY 1.46.0, `@grammyjs/types` 5.0.0). The transport used 21 distinct HTTPS image seeds. I recorded the Bot API middleware calls, then independently read the resulting conversation through Telethon/MTProto as the recipient account. (Bot API and MTProto message IDs are necessarily different.)

| Case | Expected | Observed |
|---|---|---|
| A: 20 media + tail | one rich send with 20 media | one `sendRichMessage` (20) → Bot API `<bot-result-a>`; Telethon RichMessage `<mtproto-result-a>` contains 20 `PageBlockPhoto` items and the tail text. |
| B: 21 media + tail | ordered rich sends `[20, 1]`, tail retained | `sendRichMessage` (20) → `<bot-result-b1>`, then `sendRichMessage` (1) → `<bot-result-b2>`; Telethon `<mtproto-result-b1>`, `<mtproto-result-b2>` has `[20, 1]`, with the tail in the second message. |
| C: edit to 21 media | one bounded plain-text replacement, not a multi-message edit | seed `<bot-result-c>`, then exactly one `editMessageText`; Telethon message `<mtproto-result-c>` is edited, non-rich, contains 21 media-url markers plus the trailing text. |

All three checks passed. For C, Telegram adds a normal web-page preview because the intentional plain replacement contains HTTPS URLs; it is not a RichMessage and has zero rich photo blocks.

<details>
<summary>Redacted Bot API transcript</summary>

```text
setup: head=6caa2b268277e205fd069b5da890492ae5fb1730 chat_id=<redacted-chat-id> local_assets=21

case A marker -> <bot-marker-a>
request  sendRichMessage  payload_bytes=2313  media_count=20
         media=[media-url:01] ... [media-url:20]
response sendRichMessage  ok=true
case A result: message_id=<bot-result-a>

case B marker -> <bot-marker-b>
request  sendRichMessage  payload_bytes=2239  media_count=20
         media=[media-url:01] ... [media-url:20]
response sendRichMessage  ok=true  message_id=<bot-result-b1>
request  sendRichMessage  payload_bytes=263   media_count=1
         media=[media-url:21]
response sendRichMessage  ok=true  message_id=<bot-result-b2>
case B receipt: platform_message_ids=[<bot-result-b1>,<bot-result-b2>]

case C marker -> <bot-marker-c>
request  sendRichMessage  payload_bytes=115   media_count=0
response sendRichMessage  ok=true  message_id=<bot-result-c>  # seed
request  editMessageText  payload_bytes=1266  media_count=0
         text has 21 redacted media-url markers and the tail text
response editMessageText  ok=true
case C result: message_id=<bot-result-c>

Telethon: A=<mtproto-result-a> rich/photos=20; B=<mtproto-result-b1>,<mtproto-result-b2> rich/photos=20,1;
          C=<mtproto-result-c> rich=false/photo_blocks=0/plain_media_url_count=21/edited=true.
```

</details>

Local redacted evidence and the exact proof runner are retained in the runtime workspace; the same transcript is posted as a PR comment (2026-08-30 16:39 UTC).

This PR was AI-assisted; the implementation, tests, and validation were reviewed by the submitting author.

