### PR TITLE
test: repair stale E2E fixtures

### DIFF
--- a/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/agent-tools.before-tool-call.integration.e2e.test.ts
@@ -1476,7 +1476,10 @@ describe("before_tool_call hook deduplication (#15502)", () => {
         );
 
         if (replacement === "return 3;") {
-          expect(result.details).toMatchObject({ status: "completed", value: 3 });
+          expect(result.details, JSON.stringify(result.details)).toMatchObject({
+            status: "completed",
+            value: 3,
+          });
         } else {
           expect(result.details).toEqual({
             status: "error",

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -63,6 +63,7 @@ import {
 import { testing as replyRunTesting } from "./reply-run-registry.test-support.js";
 import { bindReplyOperationTyping } from "./reply-run-typing.js";
 import { resolveFollowupRunToolAuthorityFingerprint } from "./reply-tool-authority.js";
+import { runWithReplyOperationLifecycleAdmission } from "./reply-turn-admission.js";
 import { consumeReplyUsageState } from "./reply-usage-state.js";
 import { buildChannelSourceTurnId, setChannelSourceTurnId } from "./source-turn-id.js";
 import { createMockTypingController } from "./test-helpers.js";
@@ -2139,11 +2140,19 @@ describe("runReplyAgent pending final delivery capture", () => {
     const sessionKey = "agent:main:main";
     const { sessionEntry, sessionStore, storePath } = await makeSessionFixture({}, sessionKey);
     state.runEmbeddedAgentMock.mockImplementationOnce(async () => {
-      await applySessionEntryLifecycleMutation({
-        removals: [{ sessionKey }],
-        skipMaintenance: true,
-        storePath,
-      });
+      const operation = replyRunRegistry.get(sessionKey);
+      if (!operation) {
+        throw new Error("expected admitted reply operation");
+      }
+      // Match the dispatcher's initiating context so the injected deletion reaches
+      // final-delivery persistence instead of the competing-work guard.
+      await runWithReplyOperationLifecycleAdmission(operation, () =>
+        applySessionEntryLifecycleMutation({
+          removals: [{ sessionKey }],
+          skipMaintenance: true,
+          storePath,
+        }),
+      );
       return {
         payloads: [{ text: "final from deleted session" }],
         meta: {},

--- a/test/cli-json-stdout.e2e.test.ts
+++ b/test/cli-json-stdout.e2e.test.ts
@@ -2635,14 +2635,16 @@ describe("cli json stdout contract", () => {
       explicitGateway: true,
     })),
     {
-      name: "curator mutation",
+      name: "retired curator mutation",
       args: ["skills", "curator", "pin", "missing-skill", "--json"],
-      message: "Curated skill not found: missing-skill",
+      message:
+        "Skill lifecycle curation is retired. The weekly collection review manages the skill collection; pin, unpin, and restore no longer exist.",
     },
     {
-      name: "curator mutation with parent JSON",
+      name: "retired curator mutation with parent JSON",
       args: ["skills", "curator", "--json", "pin", "missing-skill"],
-      message: "Curated skill not found: missing-skill",
+      message:
+        "Skill lifecycle curation is retired. The weekly collection review manages the skill collection; pin, unpin, and restore no longer exist.",
     },
     {
       name: "workshop workspace validation with parent JSON",


### PR DESCRIPTION
Related: #131043 (pnpm 12 migration investigation; not included or approved by this PR).

## What Problem This Solves

Resolves a problem where E2E validation fails on three stale fixture assertions after existing session-lifecycle and skills-curator changes. This maintainer-requested, AI-assisted test-only repair is deliberately separate from the pnpm migration PR and includes only three reviewed test edits.

The investigation began with migration head `76feb368b5aa4122af8fb4e2f08b457d3ab8d460`. The original aggregate was interrupted: these results do not establish a green aggregate or validate the migration's newer heads.

## Why This Change Was Made

The deleted-session fixture now enters the registered reply operation's existing initiating admission context, matching the real dispatcher, so its actual SQLite deletion reaches the original pending-final rejection and deleted-row assertions. The two curator JSON cases expect the documented retirement error, and the trusted-rewrite hook assertion includes the complete result details as its diagnostic message without changing the completed/value-3 assertion.

The competing-work guard from #128366 (`0924fd9a0c401464d6257ca59a160d1b292f5441`) made the unscoped direct-run fixture fail before deletion; the fixture previously observed a generic model-path error instead of testing persistence after deletion. The intentional curator retirement in #129769 (`4bd88591264accae10fbca7f6a9c3dc23b7e22b2`) updated runtime, docs, and owner tests but left two process-boundary expectations stale. Both changes were authored and merged by @steipete. The canonical owners and safety guards remain unchanged.

## User Impact

No production or operator-visible behavior changes. E2E coverage again exercises deletion and canonical CLI JSON failures while preserving full-envelope equality, exit/stderr checks, and both JSON flag placements. Existing admission and curator APIs are reused; no new production seam or dependency is needed.

Production LOC: +0/-0. Tests: +24/-10 (net +14), three files. No changelog, schema, persistent-state, configuration, dependency, timeout, heap, or assertion weakening.

## Evidence

Before/after investigation on `715859aacb1b876c0aa9a08da17ba116f5d5cf1c`:

- Complete reply file: 157 passed / 1 failed before; 158 passed after. The original diagnostic proved the deletion was rejected as competing work before it committed.
- Fresh built-CLI skills JSON table: 23 passed / 2 failed before; all 25 passed after. Artifacts were built through normal E2E global setup.
- Complete hook file: 62 passed using the maintained wrapper and 62 passed using the historical tsx bootstrap.
- Explicit original-order five-file prefix under the historical bootstrap: 658 tests, 655 passed / only the three known original fixture failures, 934.90 seconds. Both historical hook failure rows passed (2.91 / 2.56 seconds). This control restored the original failing fixtures and is not a green suite claim.
- Final focused corrected E2E: 34 passed; sibling admission/CLI/Gateway contracts: 93 passed across three shards.
- Changed-file checks: exit 0, including selected guards, test types, formatting, and lint. Isolated Codex autoreview at the configured P0 threshold: no accepted/actionable findings.

Focused E2E command (after this task's successful artifact build):

```sh
OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts test/cli-json-stdout.e2e.test.ts src/agents/agent-tools.before-tool-call.integration.e2e.test.ts -t 'canonical SQLite pending final delivery|returns one canonical JSON document when skills|hook after a trusted rewrite'
```

Sibling and changed checks:

```sh
node scripts/run-vitest.mjs src/auto-reply/reply/reply-turn-admission.test.ts src/cli/skills-cli.curator.test.ts src/gateway/server-methods/skills.proposals.test.ts
node scripts/check-changed.mjs -- src/agents/agent-tools.before-tool-call.integration.e2e.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts test/cli-json-stdout.e2e.test.ts
```

Source evidence: `src/auto-reply/reply/reply-turn-admission.ts:77` and `src/auto-reply/reply/dispatch-from-config.lifecycle.ts:189` supply the existing initiating admission; `src/config/sessions/session-accessor.sqlite-deletion.ts:90` retains competing-work protection; `src/auto-reply/reply/agent-runner-result-complete.ts:393` still rejects an uncommitted pending final; the CLI and Gateway curator owners match the [documented retirement contract](https://docs.openclaw.ai/cli/skills). Installed Vitest `toMatchObject` strips unmatched actual fields from assertion failures, motivating the diagnostic-only hook edit.

Known gaps: the cause of the historical hook failures is unresolved. The shared tsx-cache repair in #130924 is a plausible overhead improvement, not proved attribution; the discovery recovery repair in #131079 does not exercise this pure-return path. No full E2E aggregate, agent-plugin-Gateway phase, UI E2E phase, new pnpm 12 installation comparison, live provider, or live channel proof is claimed. Production is unchanged, so those broader lanes are not needed for this bounded test-only patch. A separate follow-up is recorded for the test documentation's omitted agent-plugin-Gateway aggregate stage.

Post-refresh verification at head `834003c25222dd4c379a4ed4df95784b89a6d7ef`, rebased onto `6ac9e3eae6e550c52478f5015d7ec0d21b5f000b`: the patch is byte-identical to the reviewed diff. The focused E2E command above, run without `OPENCLAW_E2E_SKIP_BUILD`, completed fresh global setup and passed all 34 selected tests on Node v26.7.0. [Exact-head CI run 33132148433](https://github.com/openclaw/openclaw/actions/runs/33132148433) completed successfully: 95 successful jobs, 18 scoped skips, including a successful `openclaw/ci-gate`.

[ClawSweeper's completed exact-head review](https://github.com/openclaw/openclaw/pull/131348#issuecomment-5447127107) found no actionable correctness or security findings and no Rank-up moves list. Its sole before-merge item is ordinary maintainer handling: this repair was explicitly requested, receives native review/preparation, and stops for an independent lead check before merge. The newer automatic review refresh does not change the head or supersede the completed evidence while pending.

The sibling contract command also passed again on the final head: 93 tests across three shards (Gateway proposals 21, CLI curator 24, reply admission 48).
