### PR TITLE
fix(qa): node protocol proof fails before Gateway startup

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-node-control-plane.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-control-plane.e2e.test.ts
@@ -21,7 +21,6 @@ import {
   PROTOCOL_VERSION,
   type HelloOk,
 } from "../../../../packages/gateway-protocol/src/index.js";
-import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
 import {
   loadOrCreateDeviceIdentity,
   type DeviceIdentity,
@@ -524,23 +523,24 @@ describe("Gateway node control plane", () => {
             OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
           },
           mutateConfig: (cfg) => {
-            // Bundled plugins are disabled for this focused proof, so their
-            // configured slots cannot remain while the fixture plugin is merged.
-            const { slots: _bundledSlots, ...plugins } = cfg.plugins ?? {};
-            return withFixturePlugin(
-              {
-                ...cfg,
-                plugins,
-                gateway: {
-                  ...cfg.gateway,
-                  nodes: {
-                    ...cfg.gateway?.nodes,
-                    commands: { allow: ["camera.list", FIXTURE_COMMAND] },
-                  },
+            // This control-plane fixture must not request unrelated QA runtime plugin installs.
+            const { plugins: _plugins, ...withoutPlugins } = cfg;
+            return {
+              ...withoutPlugins,
+              plugins: {
+                enabled: true,
+                allow: [FIXTURE_PLUGIN_ID],
+                load: { paths: [fixture.pluginDir] },
+                entries: { [FIXTURE_PLUGIN_ID]: { enabled: true } },
+              },
+              gateway: {
+                ...cfg.gateway,
+                nodes: {
+                  ...cfg.gateway?.nodes,
+                  commands: { allow: ["camera.list", FIXTURE_COMMAND] },
                 },
               },
-              fixture.pluginDir,
-            );
+            };
           },
         });
         const identity = loadOrCreateDeviceIdentity({
@@ -1145,25 +1145,6 @@ async function createFixturePlugin(): Promise<{
     }
     throw error;
   }
-}
-
-function withFixturePlugin(config: OpenClawConfig, pluginDir: string): OpenClawConfig {
-  return {
-    ...config,
-    plugins: {
-      ...config.plugins,
-      enabled: true,
-      allow: [...new Set([...(config.plugins?.allow ?? []), FIXTURE_PLUGIN_ID])],
-      load: {
-        ...config.plugins?.load,
-        paths: [...new Set([...(config.plugins?.load?.paths ?? []), pluginDir])],
-      },
-      entries: {
-        ...config.plugins?.entries,
-        [FIXTURE_PLUGIN_ID]: { enabled: true },
-      },
-    },
-  };
 }
 
 function parseConnectEnvelope(


### PR DESCRIPTION
Related: #119991, #130168

## What Problem This Solves

Resolves a problem where the Gateway node rolling-compatibility E2E proof exits during startup instead of testing v3/v4 reconnect behavior. Its focused Gateway disables bundled plugins, but the fixture retained QA Lab's enabled `acpx`, `memory-core`, and `qa-lab` defaults. The resulting unrelated ACPX installation request is correctly refused without capability consent.

This is a maintainer-requested QA repair identified during a full retest, not a product change or a weakened consent check.

## Why This Change Was Made

Construct the test's plugin configuration from only its actual local fixture requirements, matching the isolation used by the earlier real-Gateway case. Delete the one-use merge helper and unused type import that retained unrelated defaults.

All existing assertions remain: paired identity, v3/v4 envelopes, inventory, invocation, presence, plugin route HTTP 204, and cleanup. No protocol, authority, persistence, capability consent, runtime setting, timeout, or production code changes.

Provenance: the slot-only fixture configuration came from #119991, authored and merged by @vincentkoc on 2026-08-09 as [c8a99f7aabec](https://github.com/openclaw/openclaw/commit/c8a99f7aabec44b2e8c0d15406ca3e35d5ba79d9). The stale assumption became visible with #130168's capability-consent enforcement; that enforcement is preserved.

## User Impact

No runtime user-visible change. Developers regain a meaningful node protocol proof that reaches the real paired-device reconnect, local plugin route, and invocation assertions without trying to install unrelated QA runtime plugins.

## Evidence

Original full Gateway E2E execution at `79dfa81664fd64a3f6192331af4953ff9f9bf1ef` ran this complete five-case file in its original order: **4 passed, 1 failed**. The rolling case reported:

```text
gateway exited before listening (exitCode=1, signal=null)
OpenClaw plugin verification failed; refusing to report the gateway ready.
Plugin "acpx" requires capability consent.
```

Before editing fresh main `af52e62e85ad98bc3c7421eb329f54cd3d9bdf80`, direct comparison verified the test and relevant QA config, child, readiness, startup-verification, and consent owners were unchanged. The captured RED was reused; no redundant ACPX staging attempt was needed.

After the repair, the same complete five-case file passed **5/5**, in its original order, under explicitly pinned Node 24.20.0 and repository-selected pnpm 11.22.0:

```sh
OPENCLAW_E2E_WORKERS=1 pnpm test test/e2e/qa-lab/runtime/gateway-node-control-plane.e2e.test.ts
```

The canonical wrapper completed the required private QA/runtime build before admitting Vitest workers. The test phase took 127.73 seconds; Vitest took 174.46 seconds; the complete wrapper including prerequisite build took 514.05 seconds. No build-skip flag, consent override, assertion change, or network workaround was used.

Both the uncommitted and actual committed-base changed-file gates passed **13/13**, including root-test typecheck and full script lint. The committed check used:

```sh
node scripts/check-changed.mjs --timed --base HEAD^ --head HEAD -- test/e2e/qa-lab/runtime/gateway-node-control-plane.e2e.test.ts
```

Formatting, `git diff --check`, and the diff-scoped cleanup pass passed. Independent Codex review returned no findings in its P0-focused pass. The reviewed, tested, and committed test blob is `3ec07ef17d87c8f7998be686f96b05fe011f509b`.

Production LOC: **+0/-0**. Tests: **+16/-35**, net **-19**. No new test or production test seam was added; the existing regression already detected the failure. No full-suite rerun, external ACPX install, release validation, or native-device proof is claimed for this repair. AI-assisted; no changelog change because this is test-only.
