### PR TITLE
fix(plugin-sdk): read snake_case keys in readBooleanParam

### DIFF
--- a/extensions/imessage/src/actions.ts
+++ b/extensions/imessage/src/actions.ts
@@ -760,7 +760,7 @@ export const imessageMessageActions: ChannelMessageActionAdapter = {
     if (action === "sendAttachment" || action === "upload-file") {
       await assertPrivateApiEnabled();
       const filename = readStringParam(params, "filename", { required: true });
-      const asVoice = readBooleanParam(params, "asVoice") ?? readBooleanParam(params, "as_voice");
+      const asVoice = readBooleanParam(params, "asVoice");
       const resolvedChatGuid = await chatGuid();
       const result = await runtime.sendAttachment({
         chatGuid: resolvedChatGuid,

--- a/src/agents/tools/media-tool-shared.test.ts
+++ b/src/agents/tools/media-tool-shared.test.ts
@@ -8,7 +8,6 @@ import { withEnvAsync } from "../../test-utils/env.js";
 import {
   hasGenerationToolAvailability,
   isCapabilityProviderConfigured,
-  readBooleanToolParam,
   resolveGenerateAction,
   resolveMediaToolInboundRoots,
   resolveCapabilityModelConfigForTool,
@@ -43,14 +42,6 @@ vi.mock("../../media/channel-inbound-roots.js", () => ({
 function normalizeHostPath(value: string): string {
   return path.normalize(path.resolve(value));
 }
-
-describe("readBooleanToolParam", () => {
-  it("parses booleans and true/false string tokens", () => {
-    expect(readBooleanToolParam({ audio: true }, "audio")).toBe(true);
-    expect(readBooleanToolParam({ audio: " FALSE " }, "audio")).toBe(false);
-    expect(readBooleanToolParam({ audio: "yes" }, "audio")).toBeUndefined();
-  });
-});
 
 describe("resolveGenerateAction", () => {
   it.each([

--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -1,7 +1,6 @@
 /** Shared media tool routing, auth, path, and reference helpers. */
 import { normalizeInboundPathRoots } from "@openclaw/media-core/inbound-path-policy";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { parseBoolean } from "@openclaw/normalization-core/boolean-coercion";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -23,7 +22,6 @@ import {
   normalizeMediaReferenceSource,
 } from "../../media/media-reference.js";
 import type { WebMediaResult } from "../../media/web-media.js";
-import { readSnakeCaseParamRaw } from "../../param-key.js";
 import { loadCapabilityManifestSnapshot } from "../../plugins/capability-provider-runtime.js";
 import { listAvailableManifestContractValues } from "../../plugins/manifest-contract-eligibility.js";
 import { resolveUserPath } from "../../utils.js";
@@ -461,16 +459,6 @@ export function resolveGenerateAction(
     default:
       throw new ToolInputError('action must be "generate", "status", or "list"');
   }
-}
-
-/**
- * Reads boolean tool parameters from either canonical or snake_case keys.
- */
-export function readBooleanToolParam(
-  params: Record<string, unknown>,
-  key: string,
-): boolean | undefined {
-  return parseBoolean(readSnakeCaseParamRaw(params, key));
 }
 
 /**

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -20,6 +20,7 @@ import type {
   MusicGenerationSourceImage,
 } from "../../music-generation/types.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
+import { readBooleanParam } from "../../plugin-sdk/boolean-param.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import {
@@ -50,7 +51,6 @@ import {
   hasGenerationToolAvailability,
   loadMediaToolReferences,
   normalizeMediaReferenceInputs,
-  readBooleanToolParam,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
   resolveRemoteMediaSsrfPolicy,
@@ -599,7 +599,7 @@ export function createMusicGenerateTool(options?: {
       }
 
       const lyrics = readToolStringParam(args, "lyrics");
-      const instrumental = readBooleanToolParam(args, "instrumental");
+      const instrumental = readBooleanParam(args, "instrumental");
       const durationSeconds = readNumberParam(args, "durationSeconds", {
         positiveInteger: true,
         strict: true,

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -9,6 +9,7 @@ import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.
 import { probeMediaFilesWithinBudget } from "../../media/media-probe.js";
 import { saveMediaBuffer } from "../../media/store.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
+import { readBooleanParam } from "../../plugin-sdk/boolean-param.js";
 import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
@@ -57,7 +58,6 @@ import {
   hasGenerationToolAvailability,
   loadMediaToolReferences,
   normalizeMediaReferenceInputs,
-  readBooleanToolParam,
   readGenerationTimeoutMs,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
@@ -900,8 +900,8 @@ export function createVideoGenerateTool(options?: {
       ) {
         throw new ToolInputError("durationSeconds must be a positive integer");
       }
-      const audio = readBooleanToolParam(args, "audio");
-      const watermark = readBooleanToolParam(args, "watermark");
+      const audio = readBooleanParam(args, "audio");
+      const watermark = readBooleanParam(args, "watermark");
       const timeoutMs = readGenerationTimeoutMs(args) ?? videoGenerationModelConfig.timeoutMs;
       // providerOptions must be a plain object. Arrays are objects in JS, so
       // exclude them explicitly — a bogus call like `providerOptions: ["seed", 42]`

--- a/src/plugin-sdk/boolean-param.test.ts
+++ b/src/plugin-sdk/boolean-param.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { readBooleanParam } from "./boolean-param.js";
+
+describe("readBooleanParam", () => {
+  it("reads a snake_case key when the camelCase key is absent", () => {
+    expect(readBooleanParam({ dry_run: true }, "dryRun")).toBe(true);
+    expect(readBooleanParam({ dry_run: "false" }, "dryRun")).toBe(false);
+  });
+
+  it("prefers the exact key over the snake_case variant", () => {
+    expect(readBooleanParam({ dryRun: false, dry_run: true }, "dryRun")).toBe(false);
+  });
+});

--- a/src/plugin-sdk/boolean-param.ts
+++ b/src/plugin-sdk/boolean-param.ts
@@ -1,10 +1,11 @@
 // Boolean parameter helpers parse plugin-facing string flags into stable booleans.
 import { parseBoolean } from "../../packages/normalization-core/src/boolean-coercion.js";
+import { readSnakeCaseParamRaw } from "../param-key.js";
 
-/** Read loose boolean params from tool input that may arrive as booleans or "true"/"false" strings. */
+/** Read boolean or string params from exact or snake_case tool-input keys. */
 export function readBooleanParam(
   params: Record<string, unknown>,
   key: string,
 ): boolean | undefined {
-  return parseBoolean(params[key]);
+  return parseBoolean(readSnakeCaseParamRaw(params, key));
 }


### PR DESCRIPTION
## Summary

Make `readBooleanParam` use the shared exact-key-first snake_case resolver used by the other typed tool parameter readers.

## What Problem This Solves

OpenClaw has accepted snake_case model tool parameters through the shared reader path since `v2026.4.1`. The public boolean reader was the exception: it read only `params[key]`.

This silently ignored boolean flags such as `dry_run`, `reply_broadcast`, and `as_voice`. For `dry_run: true`, the outbound route could treat a preview request as a real delivery.

## Root cause

`src/plugin-sdk/boolean-param.ts` passed an exact property lookup directly to `parseBoolean`. String, number, array, poll, and media readers already resolve exact and snake_case keys through `readSnakeCaseParamRaw`.

## Fix

- Route the public boolean reader through `readSnakeCaseParamRaw`.
- Keep exact-key precedence and the existing boolean/string value parsing.
- Delete the duplicate media boolean reader and route music/video callers to the public helper.
- Remove the obsolete iMessage `as_voice` call-site fallback.
- Add focused public-contract tests for snake_case lookup and exact-key precedence.

## Evidence

The same public Plugin SDK call ran against exact current main and this head:

```text
input: { dry_run: true }, requested key: "dryRun"

main 4963095f2225: result undefined, effective dry-run false, delivery would proceed
head 7a9aa7535dc4: result true, effective dry-run true, delivery would not proceed
```

The new regression test failed on main because the reader returned `undefined`. It passes on this head.

## Validation

- 2 focused Plugin SDK tests passed.
- 99 media-tool sibling tests passed after the duplicate helper test was removed.
- 78 iMessage action tests passed, including both `asVoice` and `as_voice`.
- Targeted Oxfmt and Oxlint checks passed.
- Plugin SDK export and surface checks passed.
- Coercion, boundary, deprecated API, wrapper-shadowing, assertion-safety, and max-lines guards passed.
- Production: +9/-20, net -11 lines. Tests: +13/-9, net +4 lines.

## Compatibility decision

This restores the casing contract already shipped by the public `plugin-sdk/param-readers` family. Exact keys still win, and boolean value parsing is unchanged. The only newly observed case is a snake_case value that the helper previously ignored when its exact key was absent.

`readReactionParams` stays unchanged because every current caller uses `remove`, whose camelCase and snake_case spellings are identical. Changing its value parsing would be unrelated behavior.
