### PR TITLE
fix(memory): indexing fails when provider API key uses a SecretRef

### DIFF
--- a/extensions/memory-core/src/cli-runtime-common.ts
+++ b/extensions/memory-core/src/cli-runtime-common.ts
@@ -11,6 +11,7 @@ import { asNullableRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   defaultRuntime,
   formatErrorMessage,
+  getMemoryEmbeddingCommandSecretTargetIds,
   getMemorySearchManager,
   getRuntimeConfig,
   resolveCommandSecretRefsViaGateway,
@@ -27,9 +28,6 @@ export type MemoryManager = NonNullable<
   Awaited<ReturnType<typeof getMemorySearchManager>>["manager"]
 >;
 type MemoryManagerPurpose = Parameters<typeof getMemorySearchManager>[0]["purpose"];
-function getMemoryCommandSecretTargetIds(): Set<string> {
-  return new Set(["memory.search.remote.apiKey", "agents.entries.*.memory.search.remote.apiKey"]);
-}
 function isMemorySecretOwnerFailure(error: unknown, message: string): boolean {
   const candidate = error && typeof error === "object" ? (error as Record<string, unknown>) : {};
   if (
@@ -60,7 +58,7 @@ async function loadMemoryCommandConfig(
     const { resolvedConfig, diagnostics } = await resolveCommandSecretRefsViaGateway({
       config,
       commandName,
-      targetIds: getMemoryCommandSecretTargetIds(),
+      targetIds: getMemoryEmbeddingCommandSecretTargetIds(),
       ...(mode ? { mode } : {}),
     });
     return { config: resolvedConfig, diagnostics };

--- a/extensions/memory-core/src/cli.host.runtime.ts
+++ b/extensions/memory-core/src/cli.host.runtime.ts
@@ -2,6 +2,7 @@
 export {
   defaultRuntime,
   formatErrorMessage,
+  getMemoryEmbeddingCommandSecretTargetIds,
   resolveCommandSecretRefsViaGateway,
   setVerbose,
   shortenHomeInString,

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -90,6 +90,7 @@ vi.mock("./cli.host.runtime.js", async () => {
     {
       defaultRuntime,
       formatErrorMessage,
+      getMemoryEmbeddingCommandSecretTargetIds,
       setVerbose,
       shortenHomeInString,
       shortenHomePath,
@@ -108,6 +109,7 @@ vi.mock("./cli.host.runtime.js", async () => {
   return {
     defaultRuntime,
     formatErrorMessage,
+    getMemoryEmbeddingCommandSecretTargetIds,
     getMemorySearchManager,
     listMemoryFiles,
     getRuntimeConfig,
@@ -128,6 +130,7 @@ vi.mock("./cli.host.runtime.js", async () => {
 
 let registerMemoryCli: typeof import("./cli.js").registerMemoryCli;
 let defaultRuntime: typeof import("openclaw/plugin-sdk/memory-core-host-runtime-cli").defaultRuntime;
+let getMemoryEmbeddingCommandSecretTargetIds: typeof import("openclaw/plugin-sdk/memory-core-host-runtime-cli").getMemoryEmbeddingCommandSecretTargetIds;
 let isVerbose: typeof import("openclaw/plugin-sdk/memory-core-host-runtime-cli").isVerbose;
 let setVerbose: typeof import("openclaw/plugin-sdk/memory-core-host-runtime-cli").setVerbose;
 let fixtureRoot = "";
@@ -139,10 +142,12 @@ beforeAll(async () => {
   ({ registerMemoryCli } = await import("./cli.js"));
   const {
     defaultRuntime: loadedDefaultRuntime,
+    getMemoryEmbeddingCommandSecretTargetIds: loadedGetMemoryEmbeddingCommandSecretTargetIds,
     isVerbose: loadedIsVerbose,
     setVerbose: loadedSetVerbose,
   } = await import("openclaw/plugin-sdk/memory-core-host-runtime-cli");
   defaultRuntime = loadedDefaultRuntime;
+  getMemoryEmbeddingCommandSecretTargetIds = loadedGetMemoryEmbeddingCommandSecretTargetIds;
   isVerbose = loadedIsVerbose;
   setVerbose = loadedSetVerbose;
   fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "memory-cli-fixtures-"));
@@ -966,9 +971,7 @@ describe("memory cli", () => {
     ) as { config?: unknown; commandName?: unknown; targetIds?: unknown; mode?: unknown };
     expect(secretRefsCall.config).toBe(config);
     expect(secretRefsCall.commandName).toBe("memory status");
-    expect(secretRefsCall.targetIds).toStrictEqual(
-      new Set(["memory.search.remote.apiKey", "agents.entries.*.memory.search.remote.apiKey"]),
-    );
+    expect(secretRefsCall.targetIds).toStrictEqual(getMemoryEmbeddingCommandSecretTargetIds());
     expect(secretRefsCall.mode).toBe("read_only_status");
   });
 

--- a/src/plugin-sdk/memory-core-host-runtime-cli.ts
+++ b/src/plugin-sdk/memory-core-host-runtime-cli.ts
@@ -4,6 +4,7 @@
 
 export { formatErrorMessage, withManager } from "../cli/cli-utils.js";
 export { resolveCommandSecretRefsViaGateway } from "../cli/command-secret-gateway.js";
+export { getMemoryEmbeddingCommandSecretTargetIds } from "../cli/command-secret-targets.js";
 export { formatHelpExamples } from "../cli/help-format.js";
 export { withProgress, withProgressTotals } from "../cli/progress.js";
 export { isVerbose, setVerbose } from "../globals.js";


### PR DESCRIPTION
Closes #129749

## What Problem This Solves

Fixes an issue where users running `openclaw memory index`, `memory search`, or `memory status` could not use an embedding API key configured as a SecretRef under `models.providers.*.apiKey`. The memory CLI requested only memory-specific secret targets, so the active gateway snapshot omitted the selected model provider credential.

## Why This Change Was Made

The memory CLI now reuses the canonical memory-embedding command target set already owned by core instead of maintaining a smaller private copy. This keeps provider API keys, provider request credentials, and memory-specific credentials aligned with the existing embedding capability CLI without changing config, schema, defaults, or secret-resolution policy.

## User Impact

Memory CLI commands can index and search with provider API-key SecretRefs even when the credential is available only to the running gateway and not to the CLI process. Literal credentials and memory-specific remote credentials keep their existing behavior.

## Evidence

Before the fix, the focused regression failed because the memory CLI target set omitted `models.providers.*.apiKey`:

```text
FAIL extensions/memory-core/src/cli.test.ts > resolves configured memory SecretRefs through gateway snapshot
AssertionError: expected [ 'memory.search.remote.apiKey', … ] to include 'models.providers.*.apiKey'
```

After the fix, the focused memory CLI suite passes all 99 tests:

```text
Test Files  1 passed (1)
Tests       99 passed (99)
```

Issue-specific runtime proof used a built OpenClaw gateway and built CLI with an isolated config. The provider key existed only in the gateway environment; the CLI environment explicitly omitted it. `memory index` indexed one real `MEMORY.md`, and the local OpenAI-compatible endpoint received the exact gateway-resolved Bearer credential:

```json
{"exitCode":0,"gatewayReady":true,"cliEnvironmentHadProviderKey":false,"embeddingRequestCount":1,"embeddingPaths":["/v1/embeddings"],"providerSecretDelivered":true,"authorizationClasses":["expected-proof-key"],"indexCompleted":true}
```

Additional checks:

- canonical command-secret target suites: 54 tests passed
- full production build, including 64 external plugin bundles and all 147 public Plugin SDK subpaths: passed
- Plugin SDK surface budget: passed
- extension-to-SDK import boundary: passed
- changed-file format and lint: passed

Risk is limited to expanding the memory command's allowed secret-resolution target set to the existing canonical embedding set. No secret values are persisted or logged, and no public subpath, config surface, or resolution policy changes.
