### PR TITLE
fix(doctor): ignore disabled MCP servers in warnings

### DIFF
--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts
@@ -139,6 +139,26 @@ describe("collectPluginToolAllowlistWarnings", () => {
     ]);
   });
 
+  it("does not warn when all configured MCP servers are disabled", () => {
+    const warnings = collectPluginToolAllowlistWarnings({
+      cfg: {
+        agents: { defaults: { sandbox: { mode: "all" } } },
+        mcp: {
+          servers: {
+            supabase: {
+              url: "http://localhost:54321/mcp",
+              enabled: false,
+            },
+          },
+        },
+        tools: { sandbox: { tools: { alsoAllow: ["web_search"] } } },
+      },
+      manifestRegistry,
+    });
+
+    expect(warnings).toStrictEqual([]);
+  });
+
   it("uses a config-path source label when sandbox allowlist is unset", () => {
     const warnings = collectPluginToolAllowlistWarnings({
       cfg: {

--- a/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
+++ b/src/commands/doctor/shared/plugin-tool-allowlist-warnings.ts
@@ -142,7 +142,7 @@ function collectConfiguredMcpServerNames(cfg: OpenClawConfig): string[] {
     return [];
   }
   return Object.entries(servers)
-    .filter(([, value]) => hasRecord(value))
+    .filter(([, value]) => hasRecord(value) && value.enabled !== false)
     .map(([name]) => name.trim())
     .filter(Boolean)
     .toSorted((left, right) => left.localeCompare(right));


### PR DESCRIPTION
Closes #131103

## What Problem This Solves

Fixes an issue where `openclaw doctor` reports an MCP sandbox allowlist warning for a server that is explicitly disabled in configuration.

## Why This Change Was Made

The doctor-side MCP server projection now applies the same `enabled: false` exclusion as the runtime resolver. Active configured servers remain eligible for the warning, so this only removes the false positive for disabled definitions.

## User Impact

Operators can keep disabled MCP server definitions in their configuration without receiving a misleading sandbox allowlist warning. Enabled MCP servers continue to receive the existing warning when their tools are not allowed in the sandbox.

## Evidence

- Real production CLI call chain: `pnpm openclaw doctor --no-workspace-suggestions` with an isolated config fixture and state directory; the command reaches `src/commands/doctor-config-flow.ts` and the changed MCP warning collector.
- Canonical precedent: the existing runtime resolver in `src/agents/tool-policy-declared-context.ts` already excludes records where `enabled === false`.

```text
$ OPENCLAW_CONFIG_PATH=<disabled-mcp-fixture> OPENCLAW_STATE_DIR=<isolated-state> pnpm openclaw doctor --no-workspace-suggestions
base e946d226f73c8827205b0efd94dcd82e199e48b7: Doctor warnings included "mcp.servers defines 1 MCP server (\"supabase\")..."
after-fix head ee6b744190938f917f0f249749d6414928938d0c: no MCP sandbox allowlist warning for disabled "supabase"
negative-control at the same head with enabled=true: Doctor warnings included "mcp.servers defines 1 MCP server (\"supabase\")..."
```

<details>
<summary>Proof script</summary>

```bash
set -eu

run_doctor() {
  fixture="$1"
  state_dir="$(mktemp -d)"
  env -u NODE_OPTIONS OPENCLAW_NO_RESPAWN=1 \
    OPENCLAW_CONFIG_PATH="$fixture" OPENCLAW_STATE_DIR="$state_dir" \
    pnpm openclaw doctor --no-workspace-suggestions
}

run_doctor <disabled-mcp-fixture>
run_doctor <enabled-mcp-fixture>
```

</details>

- `env -u NODE_OPTIONS pnpm test src/commands/doctor/shared/plugin-tool-allowlist-warnings.test.ts` — 28 tests passed.
- `git diff --check` — passed.

AI-assisted: built with Codex
