### PR TITLE
refactor: split two files off the max-lines cap

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2989,7 +2989,6 @@ src/gateway/server-methods/skills-workspace-handler.ts	1
 src/gateway/server-methods/skills.ts	8
 src/gateway/server-methods/system-agent-chat-params.ts	2
 src/gateway/server-methods/system-changes.ts	9
-src/gateway/server-methods/talk-client.ts	1
 src/gateway/server-methods/talk-shared.ts	6
 src/gateway/server-methods/talk.ts	7
 src/gateway/server-methods/task-suggestions.ts	7

--- a/src/cron/isolated-agent/run-fallback-policy.ts
+++ b/src/cron/isolated-agent/run-fallback-policy.ts
@@ -3,11 +3,17 @@ import { resolveModelCandidateChain } from "../../agents/model-fallback-candidat
 import type { ModelCandidate } from "../../agents/model-fallback.types.js";
 import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import type { CronJob } from "../types.js";
 import {
   resolveEffectiveModelFallbacks,
   resolveSubagentModelFallbacksOverride,
 } from "./run-execution.runtime.js";
+import { logWarn } from "./run.runtime.js";
+
+const cronModelPreflightRuntimeLoader = createLazyImportLoader(
+  () => import("./model-preflight.runtime.js"),
+);
 
 /** Resolves cron model fallbacks, giving explicit payload fallbacks precedence over subagent/default policy. */
 export function resolveCronFallbacksOverride(params: {
@@ -74,4 +80,61 @@ export function resolveCronPreflightCandidates(params: {
     requestedRouteResolution: "resolved",
     fallbacksOverride,
   });
+}
+
+/** Selects the reachable candidate and retains only its remaining fallback chain. */
+export async function resolveCronPreflight(
+  params: Parameters<typeof resolveCronPreflightCandidates>[0],
+) {
+  const modelPreflightRuntime = await cronModelPreflightRuntimeLoader.load();
+  const preflightCandidates = resolveCronPreflightCandidates(params);
+  let { provider, model } = params;
+  let selectedPreflightCandidate: ModelCandidate | undefined;
+  let selectedPreflightCandidateIndex = -1;
+  let firstUnavailablePreflight:
+    | Awaited<ReturnType<typeof modelPreflightRuntime.preflightCronModelProvider>>
+    | undefined;
+  for (const [index, candidate] of preflightCandidates.entries()) {
+    const candidatePreflight = await modelPreflightRuntime.preflightCronModelProvider({
+      cfg: params.cfg,
+      provider: candidate.provider,
+      model: candidate.model,
+    });
+    if (candidatePreflight.status === "available") {
+      selectedPreflightCandidate = candidate;
+      selectedPreflightCandidateIndex = index;
+      break;
+    }
+    firstUnavailablePreflight ??= candidatePreflight;
+  }
+  if (!selectedPreflightCandidate && firstUnavailablePreflight?.status === "unavailable") {
+    return { ok: false as const, reason: firstUnavailablePreflight.reason };
+  }
+  const modelFallbacksOverride =
+    selectedPreflightCandidate &&
+    (selectedPreflightCandidate.provider !== provider || selectedPreflightCandidate.model !== model)
+      ? preflightCandidates
+          .slice(selectedPreflightCandidateIndex + 1)
+          .map((candidate) => `${candidate.provider}/${candidate.model}`)
+      : undefined;
+  // When preflight skips the first local candidate, start at the reachable provider.
+  if (selectedPreflightCandidate && modelFallbacksOverride) {
+    if (firstUnavailablePreflight?.status === "unavailable") {
+      logWarn(
+        `[cron:${params.job.id}] ${firstUnavailablePreflight.reason}; continuing with fallback ${selectedPreflightCandidate.provider}/${selectedPreflightCandidate.model}.`,
+      );
+    }
+    provider = selectedPreflightCandidate.provider;
+    model = selectedPreflightCandidate.model;
+  }
+  return {
+    ok: true as const,
+    provider,
+    model,
+    modelFallbacksOverride,
+    runtimePluginCandidates:
+      selectedPreflightCandidateIndex >= 0
+        ? preflightCandidates.slice(selectedPreflightCandidateIndex)
+        : preflightCandidates,
+  };
 }

--- a/src/cron/isolated-agent/run-prepare-runtime.ts
+++ b/src/cron/isolated-agent/run-prepare-runtime.ts
@@ -51,9 +51,6 @@ const cronExternalContentRuntimeLoader = createLazyImportLoader(
 const cronAuthProfileRuntimeLoader = createLazyImportLoader(
   () => import("./run-auth-profile.runtime.js"),
 );
-const cronModelPreflightRuntimeLoader = createLazyImportLoader(
-  () => import("./model-preflight.runtime.js"),
-);
 export async function loadSessionAccessorRuntime() {
   return await sessionAccessorRuntimeLoader.load();
 }
@@ -64,10 +61,6 @@ export async function loadCronExternalContentRuntime() {
 
 async function loadCronAuthProfileRuntime() {
   return await cronAuthProfileRuntimeLoader.load();
-}
-
-export async function loadCronModelPreflightRuntime() {
-  return await cronModelPreflightRuntimeLoader.load();
 }
 
 function hasConfiguredAuthProfiles(cfg: OpenClawConfig): boolean {

--- a/src/cron/isolated-agent/run-prepare.ts
+++ b/src/cron/isolated-agent/run-prepare.ts
@@ -42,12 +42,11 @@ import {
   type ResolvedCronDeliveryTarget,
   resolveCronDeliveryContext,
 } from "./run-delivery-trace.js";
-import { resolveCronPreflightCandidates } from "./run-fallback-policy.js";
+import { resolveCronPreflight } from "./run-fallback-policy.js";
 import {
   appendCronUnattendedRunPreamble,
   resolveCronAuthSelection,
   loadCronExternalContentRuntime,
-  loadCronModelPreflightRuntime,
   loadSessionAccessorRuntime,
   resolveCronAgentTurnMessage,
   retireRolledCronSessionMcpRuntime,
@@ -363,79 +362,38 @@ export async function prepareCronRunContext(params: {
       typeof ownerAgentConfig?.model === "string" &&
       resolveAgentModelPrimaryValue(ownerAgentConfig.model) ===
         resolveAgentModelPrimaryValue(modelOwner.config.agents?.defaults?.model);
-    let { provider, model } = resolvedModelSelection;
     const useSubagentFallbacks = resolvedModelSelection.modelSource === "subagent";
     const inheritDefaultFallbacksForAgentStringModel =
       matchesDefaultFallbackAgentStringModel &&
       (resolvedModelSelection.modelSource === "default" ||
         resolvedModelSelection.modelSource === "agent");
 
-    const modelPreflightRuntime = await loadCronModelPreflightRuntime();
-    const preflightCandidates = resolveCronPreflightCandidates({
+    const preflight = await resolveCronPreflight({
       cfg: cfgWithAgentDefaults,
       job: input.job,
       agentId: modelOwner.agentId,
-      provider,
-      model,
+      provider: resolvedModelSelection.provider,
+      model: resolvedModelSelection.model,
       useSubagentFallbacks,
       inheritDefaultFallbacksForAgentStringModel,
     });
-    let selectedPreflightCandidate: { provider: string; model: string } | undefined;
-    let selectedPreflightCandidateIndex = -1;
-    let firstUnavailablePreflight:
-      | Awaited<ReturnType<typeof modelPreflightRuntime.preflightCronModelProvider>>
-      | undefined;
-    for (const [index, candidate] of preflightCandidates.entries()) {
-      const candidatePreflight = await modelPreflightRuntime.preflightCronModelProvider({
-        cfg: cfgWithAgentDefaults,
-        provider: candidate.provider,
-        model: candidate.model,
-      });
-      if (candidatePreflight.status === "available") {
-        selectedPreflightCandidate = candidate;
-        selectedPreflightCandidateIndex = index;
-        break;
-      }
-      firstUnavailablePreflight ??= candidatePreflight;
-    }
-    if (!selectedPreflightCandidate && firstUnavailablePreflight?.status === "unavailable") {
-      logWarn(`[cron:${input.job.id}] ${firstUnavailablePreflight.reason}`);
+    if (!preflight.ok) {
+      logWarn(`[cron:${input.job.id}] ${preflight.reason}`);
       sessionWorkAdmission.release();
       return {
         ok: false,
         result: withRunSession({
           status: "skipped",
-          error: firstUnavailablePreflight.reason,
-          diagnostics: createCronRunDiagnosticsFromError(
-            "model-preflight",
-            firstUnavailablePreflight.reason,
-            {
-              severity: "warn",
-            },
-          ),
-          provider,
-          model,
+          error: preflight.reason,
+          diagnostics: createCronRunDiagnosticsFromError("model-preflight", preflight.reason, {
+            severity: "warn",
+          }),
+          provider: resolvedModelSelection.provider,
+          model: resolvedModelSelection.model,
         }),
       };
     }
-    const modelFallbacksOverride =
-      selectedPreflightCandidate &&
-      (selectedPreflightCandidate.provider !== provider ||
-        selectedPreflightCandidate.model !== model)
-        ? preflightCandidates
-            .slice(selectedPreflightCandidateIndex + 1)
-            .map((candidate) => `${candidate.provider}/${candidate.model}`)
-        : undefined;
-    // When preflight skips the first local candidate, start at the reachable provider.
-    if (selectedPreflightCandidate && modelFallbacksOverride) {
-      if (firstUnavailablePreflight?.status === "unavailable") {
-        logWarn(
-          `[cron:${input.job.id}] ${firstUnavailablePreflight.reason}; continuing with fallback ${selectedPreflightCandidate.provider}/${selectedPreflightCandidate.model}.`,
-        );
-      }
-      provider = selectedPreflightCandidate.provider;
-      model = selectedPreflightCandidate.model;
-    }
+    const { provider, model, modelFallbacksOverride, runtimePluginCandidates } = preflight;
     const thinkingSelection = await resolveCronThinkingSelection({
       cfg: cfgWithAgentDefaults,
       owner: modelOwner,
@@ -629,10 +587,6 @@ export async function prepareCronRunContext(params: {
       authProfileId,
       authProfileIdSource: authSelection?.source,
     };
-    const runtimePluginCandidates =
-      selectedPreflightCandidateIndex >= 0
-        ? preflightCandidates.slice(selectedPreflightCandidateIndex)
-        : preflightCandidates;
     const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
       config: cfgWithAgentDefaults,
       workspaceDir,

--- a/src/gateway/server-methods/talk-client-create.ts
+++ b/src/gateway/server-methods/talk-client-create.ts
@@ -1,0 +1,421 @@
+import { randomUUID } from "node:crypto";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "@openclaw/normalization-core/string-coerce";
+import {
+  ErrorCodes,
+  errorShape,
+  validateTalkClientCreateParams,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { AgentSelectionRequiredError, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import { buildAgentMainSessionKey } from "../../routing/session-key.js";
+import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
+import { REALTIME_VOICE_AGENT_CONSULT_TOOL } from "../../talk/agent-consult-tool.js";
+import { REALTIME_VOICE_AGENT_CONTROL_TOOL } from "../../talk/agent-run-control-shared.js";
+import { resolveTalkSessionAgentId } from "../../talk/agent-target.js";
+import {
+  appendClientVoiceTranscript,
+  closeClientVoiceSession,
+  closeStaleClientVoiceSessions,
+  createOrResumeClientVoiceSession,
+  ensureClientVoiceAgentSessionEntry,
+  flushClientVoiceSessionWrites,
+  resolveClientVoiceAgentSessionId,
+} from "../../talk/client-voice-session.js";
+import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL } from "../../talk/describe-view-tool.js";
+import {
+  cancelInternalRealtimeVoiceBrowserSession,
+  type InternalRealtimeVoiceBrowserSessionCreateRequest,
+} from "../../talk/provider-internal.js";
+import {
+  resolveConfiguredRealtimeVoiceProvider,
+  resolveRealtimeVoiceProviderCapabilities,
+} from "../../talk/provider-resolver.js";
+import {
+  authorizeGatewaySessionCreation,
+  resolveSandboxedSessionCreation,
+} from "../operator-role-policy.js";
+import { readSessionPreviewItemsFromTranscript } from "../session-transcript-readers.js";
+import {
+  boundTalkClientRealtimeInitialItems,
+  createTalkClientAgentConsultRunner,
+  createTalkClientGatewayControlOwner,
+  resolveTalkAgentConsultAuthority,
+} from "../talk-client-gateway-control.js";
+import { formatForLog } from "../ws-log.js";
+import { rememberLegacyVoiceBinding } from "./talk-client-legacy-voice-bindings.js";
+import {
+  buildRealtimeInstructions,
+  buildRealtimeVoiceLaunchOptions,
+  buildTalkRealtimeConfig,
+  isUnsupportedBrowserWebRtcSession,
+  resolveTalkRealtimeProviderInstructions,
+} from "./talk-shared.js";
+import type { GatewayRequestHandler, RespondFn } from "./types.js";
+import { assertValidParams } from "./validation.js";
+
+const REALTIME_VOICE_CONTEXT_MAX_ITEMS = 16;
+const REALTIME_VOICE_CONTEXT_MAX_ITEM_CHARS = 800;
+const REALTIME_VOICE_CLIENT_SESSION_MIN_TTL_MS = 5_000;
+function rejectTalkClientRequest(
+  respond: RespondFn,
+  code: Parameters<typeof errorShape>[0],
+  message: string,
+): void {
+  respond(false, undefined, errorShape(code, message));
+}
+
+export const createTalkClient: GatewayRequestHandler = async ({
+  params,
+  respond,
+  context,
+  client,
+}) => {
+  if (!assertValidParams(params, validateTalkClientCreateParams, "talk.client.create", respond)) {
+    return;
+  }
+  try {
+    const runtimeConfig = context.getRuntimeConfig();
+    const realtimeConfig = buildTalkRealtimeConfig(runtimeConfig, params.provider);
+    const mode = normalizeOptionalLowercaseString(params.mode) ?? realtimeConfig.mode ?? "realtime";
+    if (mode !== "realtime") {
+      rejectTalkClientRequest(
+        respond,
+        ErrorCodes.INVALID_REQUEST,
+        `talk.client.create only supports mode="realtime"; use talk.catalog for ${mode} provider discovery`,
+      );
+      return;
+    }
+    const brain =
+      normalizeOptionalLowercaseString(params.brain) ?? realtimeConfig.brain ?? "agent-consult";
+    if (brain !== "agent-consult") {
+      rejectTalkClientRequest(
+        respond,
+        ErrorCodes.INVALID_REQUEST,
+        `talk.client.create only supports brain="agent-consult"`,
+      );
+      return;
+    }
+    const transport =
+      normalizeOptionalLowercaseString(params.transport) ?? realtimeConfig.transport;
+    const wantsCameraFrames = params.capabilities?.includes("camera-frame") === true;
+    const wantsGatewayControl = params.capabilities?.includes("gateway-control-v1") === true;
+    if (wantsGatewayControl && wantsCameraFrames) {
+      rejectTalkClientRequest(
+        respond,
+        ErrorCodes.INVALID_REQUEST,
+        "gateway-control-v1 supports audio-only WebRTC sessions",
+      );
+      return;
+    }
+    if (transport === "managed-room") {
+      rejectTalkClientRequest(
+        respond,
+        ErrorCodes.UNAVAILABLE,
+        "managed-room realtime Talk sessions are not available in the browser UI yet",
+      );
+      return;
+    }
+    if (transport === "gateway-relay") {
+      rejectTalkClientRequest(
+        respond,
+        ErrorCodes.INVALID_REQUEST,
+        wantsCameraFrames
+          ? "gateway-relay does not support browser video frames"
+          : `talk.client.create is client-owned; use talk.session.create for gateway-relay`,
+      );
+      return;
+    }
+    const launchOptions = buildRealtimeVoiceLaunchOptions({
+      requested: params,
+      defaults: realtimeConfig,
+    });
+    const requestedAgentId = resolveTalkSessionAgentId(runtimeConfig, params.sessionKey);
+    assertSecretOwnerAvailable("capability", "talk:realtime");
+    const resolution = resolveConfiguredRealtimeVoiceProvider({
+      configuredProviderId: realtimeConfig.provider,
+      providerConfigs: realtimeConfig.providers,
+      ...(launchOptions.model ? { providerConfigOverrides: { model: launchOptions.model } } : {}),
+      cfg: runtimeConfig,
+      agentId: requestedAgentId,
+      defaultModel: realtimeConfig.model,
+      surface: "browser-session",
+    });
+    const providerCapabilities = resolveRealtimeVoiceProviderCapabilities({
+      provider: resolution.provider,
+      providerConfig: resolution.providerConfig,
+      cfg: runtimeConfig,
+      agentId: requestedAgentId,
+      model: launchOptions.model,
+      surface: "browser-session",
+    });
+    if (wantsGatewayControl && providerCapabilities?.supportsGatewayControl !== true) {
+      rejectTalkClientRequest(
+        respond,
+        ErrorCodes.UNAVAILABLE,
+        `Realtime provider "${resolution.provider.id}" does not support gateway-control-v1 with its configured authentication`,
+      );
+      return;
+    }
+    if (wantsCameraFrames && providerCapabilities?.supportsVideoFrames !== true) {
+      rejectTalkClientRequest(
+        respond,
+        ErrorCodes.INVALID_REQUEST,
+        `Realtime provider ${resolution.provider.id} does not support browser video frames`,
+      );
+      return;
+    }
+    const realtimeContext = await resolveTalkRealtimeProviderInstructions({
+      config: runtimeConfig,
+      agentId: requestedAgentId,
+      configuredInstructions: realtimeConfig.instructions,
+      sessionKey: params.sessionKey,
+      // Legacy creates can drift to another agent's session at toolCall time, so
+      // the default agent's profile must not leak into the provider session.
+      requireSessionKeyForProfile: true,
+      warn: (message) => context.logGateway.warn(`talk realtime context: ${message}`),
+    });
+    const { agentId, requestedSessionKey } = realtimeContext;
+    const sessionKey = requestedSessionKey ?? buildAgentMainSessionKey({ agentId });
+    const creationError = authorizeGatewaySessionCreation({
+      cfg: runtimeConfig,
+      client,
+      agentId,
+    });
+    if (creationError) {
+      respond(false, undefined, creationError);
+      return;
+    }
+    if (resolution.provider.createBrowserSession && transport !== "gateway-relay") {
+      const agentSessionId = resolveClientVoiceAgentSessionId({ agentId, sessionKey });
+      const initialItems = agentSessionId
+        ? boundTalkClientRealtimeInitialItems(
+            readSessionPreviewItemsFromTranscript(
+              {
+                agentId,
+                sessionId: agentSessionId,
+                sessionKey,
+              },
+              REALTIME_VOICE_CONTEXT_MAX_ITEMS,
+              REALTIME_VOICE_CONTEXT_MAX_ITEM_CHARS,
+            ).filter(
+              (
+                item,
+              ): item is {
+                role: "user" | "assistant";
+                text: string;
+              } => item.role === "user" || item.role === "assistant",
+            ),
+          )
+        : [];
+      const tools =
+        providerCapabilities?.supportsToolCalls === false
+          ? []
+          : [REALTIME_VOICE_AGENT_CONSULT_TOOL, REALTIME_VOICE_AGENT_CONTROL_TOOL];
+      if (wantsCameraFrames && tools.length > 0) {
+        tools.push(REALTIME_VOICE_DESCRIBE_VIEW_TOOL);
+      }
+      const instructions =
+        providerCapabilities?.handlesAgentConsult === true
+          ? normalizeOptionalString(realtimeContext.instructions)
+          : buildRealtimeInstructions(realtimeContext.instructions);
+      const requestedVoiceSessionId = normalizeOptionalString(params.voiceSessionId);
+      let activeVoiceSessionId = wantsGatewayControl
+        ? (requestedVoiceSessionId ?? randomUUID())
+        : undefined;
+      const ownerConnId = normalizeOptionalString(client?.connId);
+      if (wantsGatewayControl && !ownerConnId) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.UNAVAILABLE, "gateway-control-v1 requires a connected client"),
+        );
+        return;
+      }
+      const consultRunner = createTalkClientAgentConsultRunner({
+        config: runtimeConfig,
+        context,
+        agentId,
+        sessionKey,
+        ...(ownerConnId ? { ownerConnId } : {}),
+        authority: resolveTalkAgentConsultAuthority(client?.connect?.scopes),
+        getVoiceSessionId: () => activeVoiceSessionId,
+        initialItems,
+      });
+      const runAgentConsult: NonNullable<
+        InternalRealtimeVoiceBrowserSessionCreateRequest["runAgentConsult"]
+      > = consultRunner.runPrompt;
+      const gatewayControlOwner = wantsGatewayControl
+        ? createTalkClientGatewayControlOwner({
+            voiceSessionId: activeVoiceSessionId!,
+            providerId: resolution.provider.id,
+            sessionKey,
+            connId: ownerConnId!,
+            context,
+            runAgentConsult: consultRunner.runArgs,
+            appendTranscript: ({ entryId, role, text }) =>
+              appendClientVoiceTranscript({
+                agentId,
+                sessionKey,
+                voiceSessionId: activeVoiceSessionId!,
+                entryId,
+                role,
+                text,
+                config: runtimeConfig,
+              }),
+            flushTranscript: () =>
+              flushClientVoiceSessionWrites({
+                agentId,
+                voiceSessionId: activeVoiceSessionId!,
+              }),
+            closeLogicalSession: async () => {
+              await closeClientVoiceSession({
+                agentId,
+                sessionKey,
+                voiceSessionId: activeVoiceSessionId!,
+                config: runtimeConfig,
+              });
+            },
+          })
+        : undefined;
+      const browserSessionRequest: InternalRealtimeVoiceBrowserSessionCreateRequest = {
+        cfg: runtimeConfig,
+        agentId,
+        ...(ownerConnId ? { ownerConnId } : {}),
+        workspaceDir: resolveAgentWorkspaceDir(runtimeConfig, agentId),
+        providerConfig: resolution.providerConfig,
+        instructions,
+        initialItems,
+        runAgentConsult,
+        ...(gatewayControlOwner ? { gatewayControl: gatewayControlOwner.control } : {}),
+        ...(tools.length > 0 ? { tools } : {}),
+        ...launchOptions,
+      };
+      const session = await resolution.provider.createBrowserSession(browserSessionRequest);
+      // Client-owned voice records are minted only for client-owned transports;
+      // relay sessions are created via talk.session.create and keyed by relaySessionId.
+      // Widening this guard would hand relay calls a mismatched voiceSessionId.
+      if (
+        (session.transport === "webrtc" || session.transport === "provider-websocket") &&
+        !isUnsupportedBrowserWebRtcSession(session) &&
+        (!transport || session.transport === transport)
+      ) {
+        try {
+          const sessionEntryDeadlineAt =
+            session.expiresAt === undefined
+              ? undefined
+              : session.expiresAt - REALTIME_VOICE_CLIENT_SESSION_MIN_TTL_MS;
+          if (sessionEntryDeadlineAt !== undefined && Date.now() >= sessionEntryDeadlineAt) {
+            throw new Error("Realtime browser session expired during startup; try again");
+          }
+          // Defer persistent session creation until the provider has returned a
+          // usable client transport. The write boundary rechecks the credential
+          // deadline so queued storage work cannot leave a phantom chat.
+          await ensureClientVoiceAgentSessionEntry({
+            agentId,
+            sessionKey,
+            creation: resolveSandboxedSessionCreation(client, runtimeConfig),
+            deadlineAt: sessionEntryDeadlineAt,
+          });
+        } catch (error) {
+          try {
+            await cancelInternalRealtimeVoiceBrowserSession({
+              provider: resolution.provider,
+              request: browserSessionRequest,
+              session,
+            });
+          } catch (cancelError) {
+            context.logGateway.warn(
+              `talk browser session cleanup failed: ${formatForLog(cancelError)}`,
+            );
+          }
+          throw error;
+        }
+        // Recovering 6h-abandoned calls (and retrying their digests) is not on the
+        // start path; running it inline would delay use of time-sensitive provider
+        // credentials behind slow channel sends. Fire it off the response path.
+        void closeStaleClientVoiceSessions({
+          agentId,
+          config: runtimeConfig,
+          excludeVoiceSessionId: normalizeOptionalString(params.voiceSessionId),
+          warn: (message) => context.logGateway.warn(`talk voice session recovery: ${message}`),
+        }).catch((error: unknown) =>
+          context.logGateway.warn(`talk voice session recovery failed: ${formatForLog(error)}`),
+        );
+        const voiceSessionId = createOrResumeClientVoiceSession({
+          agentId,
+          sessionKey,
+          provider: resolution.provider.id,
+          origin: "client",
+          // Deployed clients sent sessionKey before transcripts existed, so capability
+          // must be negotiated explicitly; declaring it turns the confirmation gate on.
+          transcriptCapable:
+            wantsGatewayControl || params.capabilities?.includes("voice-transcript") === true,
+          voiceSessionId: activeVoiceSessionId ?? requestedVoiceSessionId,
+        });
+        activeVoiceSessionId = voiceSessionId;
+        const connId = ownerConnId;
+        if (connId) {
+          rememberLegacyVoiceBinding({
+            connId,
+            sessionKey: params.sessionKey?.trim() || sessionKey,
+            voiceSessionId,
+          });
+        }
+        gatewayControlOwner?.activate(() =>
+          cancelInternalRealtimeVoiceBrowserSession({
+            provider: resolution.provider,
+            request: browserSessionRequest,
+            session,
+          }),
+        );
+        respond(
+          true,
+          {
+            ...session,
+            voiceSessionId,
+            ...(wantsGatewayControl ? { clientControl: { owner: "gateway" as const } } : {}),
+          },
+          undefined,
+        );
+        return;
+      }
+      try {
+        await cancelInternalRealtimeVoiceBrowserSession({
+          provider: resolution.provider,
+          request: browserSessionRequest,
+          session,
+        });
+      } catch (cancelError) {
+        context.logGateway.warn(
+          `talk browser session cleanup failed: ${formatForLog(cancelError)}`,
+        );
+      }
+      if (transport) {
+        rejectTalkClientRequest(
+          respond,
+          ErrorCodes.UNAVAILABLE,
+          `Realtime provider "${resolution.provider.id}" does not support requested browser transport "${transport}"`,
+        );
+        return;
+      }
+    }
+    rejectTalkClientRequest(
+      respond,
+      ErrorCodes.UNAVAILABLE,
+      `Realtime provider "${resolution.provider.id}" does not support client-owned realtime sessions`,
+    );
+  } catch (err) {
+    respond(
+      false,
+      undefined,
+      errorShape(
+        err instanceof AgentSelectionRequiredError
+          ? ErrorCodes.INVALID_REQUEST
+          : ErrorCodes.UNAVAILABLE,
+        formatForLog(err),
+      ),
+    );
+  }
+};

--- a/src/gateway/server-methods/talk-client.ts
+++ b/src/gateway/server-methods/talk-client.ts
@@ -1,28 +1,19 @@
 // Talk client methods create browser-owned realtime voice sessions and route
 // client tool calls back into OpenClaw agent consult/control flows.
-import { randomUUID } from "node:crypto";
-import {
-  normalizeOptionalLowercaseString,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
   errorShape,
   validateTalkClientCloseParams,
-  validateTalkClientCreateParams,
   validateTalkClientSteerParams,
   validateTalkClientToolCallParams,
   validateTalkClientTranscriptParams,
 } from "../../../packages/gateway-protocol/src/index.js";
-import { AgentSelectionRequiredError, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
-import { buildAgentMainSessionKey } from "../../routing/session-key.js";
-import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
+import { AgentSelectionRequiredError } from "../../agents/agent-scope.js";
 import {
-  REALTIME_VOICE_AGENT_CONSULT_TOOL,
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
   parseRealtimeVoiceAgentConsultArgs,
 } from "../../talk/agent-consult-tool.js";
-import { REALTIME_VOICE_AGENT_CONTROL_TOOL } from "../../talk/agent-run-control-shared.js";
 import { controlRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
 import { resolveTalkSessionAgentId } from "../../talk/agent-target.js";
 import {
@@ -34,68 +25,32 @@ import {
   appendClientVoiceTranscript,
   assertClientVoiceSessionOpen,
   closeClientVoiceSession,
-  closeStaleClientVoiceSessions,
   createOrResumeClientVoiceSession,
   ensureClientVoiceAgentSessionEntry,
-  flushClientVoiceSessionWrites,
   registerClientVoiceConsultRun,
-  resolveClientVoiceAgentSessionId,
   resolveClientVoiceSessionOrigin,
   resolveOpenClientVoiceSessionId,
 } from "../../talk/client-voice-session.js";
-import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL } from "../../talk/describe-view-tool.js";
-import {
-  cancelInternalRealtimeVoiceBrowserSession,
-  type InternalRealtimeVoiceBrowserSessionCreateRequest,
-} from "../../talk/provider-internal.js";
-import {
-  resolveConfiguredRealtimeVoiceProvider,
-  resolveRealtimeVoiceProviderCapabilities,
-} from "../../talk/provider-resolver.js";
 import {
   authorizeGatewaySessionCreation,
   resolveSandboxedSessionCreation,
 } from "../operator-role-policy.js";
-import { readSessionPreviewItemsFromTranscript } from "../session-transcript-readers.js";
 import { startTalkRealtimeAgentConsult } from "../talk-agent-consult.js";
-import {
-  boundTalkClientRealtimeInitialItems,
-  closeTalkClientGatewayControlSession,
-  createTalkClientAgentConsultRunner,
-  createTalkClientGatewayControlOwner,
-  resolveTalkAgentConsultAuthority,
-} from "../talk-client-gateway-control.js";
+import { closeTalkClientGatewayControlSession } from "../talk-client-gateway-control.js";
 import {
   ensureTalkRealtimeRelayVoiceSession,
   flushTalkRealtimeRelayVoiceWrites,
 } from "../talk-realtime-relay.js";
 import { formatForLog } from "../ws-log.js";
+import { createTalkClient } from "./talk-client-create.js";
 import {
   forgetLegacyVoiceBinding,
   readLegacyVoiceBinding,
   rememberLegacyVoiceBinding,
 } from "./talk-client-legacy-voice-bindings.js";
 import { hasOwnedActiveTalkClientRun } from "./talk-client-run-ownership.js";
-import {
-  buildRealtimeInstructions,
-  buildRealtimeVoiceLaunchOptions,
-  buildTalkRealtimeConfig,
-  isUnsupportedBrowserWebRtcSession,
-  resolveTalkRealtimeProviderInstructions,
-} from "./talk-shared.js";
-import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
-
-const REALTIME_VOICE_CONTEXT_MAX_ITEMS = 16;
-const REALTIME_VOICE_CONTEXT_MAX_ITEM_CHARS = 800;
-const REALTIME_VOICE_CLIENT_SESSION_MIN_TTL_MS = 5_000;
-function rejectTalkClientRequest(
-  respond: RespondFn,
-  code: Parameters<typeof errorShape>[0],
-  message: string,
-): void {
-  respond(false, undefined, errorShape(code, message));
-}
 
 /**
  * Gateway methods for browser-owned realtime Talk sessions.
@@ -104,373 +59,7 @@ function rejectTalkClientRequest(
  * calls back into OpenClaw agent consult runs.
  */
 export const talkClientHandlers: GatewayRequestHandlers = {
-  "talk.client.create": async ({ params, respond, context, client }) => {
-    if (!assertValidParams(params, validateTalkClientCreateParams, "talk.client.create", respond)) {
-      return;
-    }
-    const typedParams = params as {
-      sessionKey?: string;
-      voiceSessionId?: string;
-      provider?: string;
-      model?: string;
-      voice?: string;
-      vadThreshold?: number;
-      silenceDurationMs?: number;
-      prefixPaddingMs?: number;
-      reasoningEffort?: string;
-      mode?: string;
-      transport?: string;
-      brain?: string;
-      capabilities?: string[];
-    };
-    try {
-      const runtimeConfig = context.getRuntimeConfig();
-      const realtimeConfig = buildTalkRealtimeConfig(runtimeConfig, typedParams.provider);
-      const mode =
-        normalizeOptionalLowercaseString(typedParams.mode) ?? realtimeConfig.mode ?? "realtime";
-      if (mode !== "realtime") {
-        rejectTalkClientRequest(
-          respond,
-          ErrorCodes.INVALID_REQUEST,
-          `talk.client.create only supports mode="realtime"; use talk.catalog for ${mode} provider discovery`,
-        );
-        return;
-      }
-      const brain =
-        normalizeOptionalLowercaseString(typedParams.brain) ??
-        realtimeConfig.brain ??
-        "agent-consult";
-      if (brain !== "agent-consult") {
-        rejectTalkClientRequest(
-          respond,
-          ErrorCodes.INVALID_REQUEST,
-          `talk.client.create only supports brain="agent-consult"`,
-        );
-        return;
-      }
-      const transport =
-        normalizeOptionalLowercaseString(typedParams.transport) ?? realtimeConfig.transport;
-      const wantsCameraFrames = typedParams.capabilities?.includes("camera-frame") === true;
-      const wantsGatewayControl = typedParams.capabilities?.includes("gateway-control-v1") === true;
-      if (wantsGatewayControl && wantsCameraFrames) {
-        rejectTalkClientRequest(
-          respond,
-          ErrorCodes.INVALID_REQUEST,
-          "gateway-control-v1 supports audio-only WebRTC sessions",
-        );
-        return;
-      }
-      if (transport === "managed-room") {
-        rejectTalkClientRequest(
-          respond,
-          ErrorCodes.UNAVAILABLE,
-          "managed-room realtime Talk sessions are not available in the browser UI yet",
-        );
-        return;
-      }
-      if (transport === "gateway-relay") {
-        rejectTalkClientRequest(
-          respond,
-          ErrorCodes.INVALID_REQUEST,
-          wantsCameraFrames
-            ? "gateway-relay does not support browser video frames"
-            : `talk.client.create is client-owned; use talk.session.create for gateway-relay`,
-        );
-        return;
-      }
-      const launchOptions = buildRealtimeVoiceLaunchOptions({
-        requested: typedParams,
-        defaults: realtimeConfig,
-      });
-      const requestedAgentId = resolveTalkSessionAgentId(runtimeConfig, typedParams.sessionKey);
-      assertSecretOwnerAvailable("capability", "talk:realtime");
-      const resolution = resolveConfiguredRealtimeVoiceProvider({
-        configuredProviderId: realtimeConfig.provider,
-        providerConfigs: realtimeConfig.providers,
-        ...(launchOptions.model ? { providerConfigOverrides: { model: launchOptions.model } } : {}),
-        cfg: runtimeConfig,
-        agentId: requestedAgentId,
-        defaultModel: realtimeConfig.model,
-        surface: "browser-session",
-      });
-      const providerCapabilities = resolveRealtimeVoiceProviderCapabilities({
-        provider: resolution.provider,
-        providerConfig: resolution.providerConfig,
-        cfg: runtimeConfig,
-        agentId: requestedAgentId,
-        model: launchOptions.model,
-        surface: "browser-session",
-      });
-      if (wantsGatewayControl && providerCapabilities?.supportsGatewayControl !== true) {
-        rejectTalkClientRequest(
-          respond,
-          ErrorCodes.UNAVAILABLE,
-          `Realtime provider "${resolution.provider.id}" does not support gateway-control-v1 with its configured authentication`,
-        );
-        return;
-      }
-      if (wantsCameraFrames && providerCapabilities?.supportsVideoFrames !== true) {
-        rejectTalkClientRequest(
-          respond,
-          ErrorCodes.INVALID_REQUEST,
-          `Realtime provider ${resolution.provider.id} does not support browser video frames`,
-        );
-        return;
-      }
-      const realtimeContext = await resolveTalkRealtimeProviderInstructions({
-        config: runtimeConfig,
-        agentId: requestedAgentId,
-        configuredInstructions: realtimeConfig.instructions,
-        sessionKey: typedParams.sessionKey,
-        // Legacy creates can drift to another agent's session at toolCall time, so
-        // the default agent's profile must not leak into the provider session.
-        requireSessionKeyForProfile: true,
-        warn: (message) => context.logGateway.warn(`talk realtime context: ${message}`),
-      });
-      const { agentId, requestedSessionKey } = realtimeContext;
-      const sessionKey = requestedSessionKey ?? buildAgentMainSessionKey({ agentId });
-      const creationError = authorizeGatewaySessionCreation({
-        cfg: runtimeConfig,
-        client,
-        agentId,
-      });
-      if (creationError) {
-        respond(false, undefined, creationError);
-        return;
-      }
-      if (resolution.provider.createBrowserSession && transport !== "gateway-relay") {
-        const agentSessionId = resolveClientVoiceAgentSessionId({ agentId, sessionKey });
-        const initialItems = agentSessionId
-          ? boundTalkClientRealtimeInitialItems(
-              readSessionPreviewItemsFromTranscript(
-                {
-                  agentId,
-                  sessionId: agentSessionId,
-                  sessionKey,
-                },
-                REALTIME_VOICE_CONTEXT_MAX_ITEMS,
-                REALTIME_VOICE_CONTEXT_MAX_ITEM_CHARS,
-              ).filter(
-                (
-                  item,
-                ): item is {
-                  role: "user" | "assistant";
-                  text: string;
-                } => item.role === "user" || item.role === "assistant",
-              ),
-            )
-          : [];
-        const tools =
-          providerCapabilities?.supportsToolCalls === false
-            ? []
-            : [REALTIME_VOICE_AGENT_CONSULT_TOOL, REALTIME_VOICE_AGENT_CONTROL_TOOL];
-        if (wantsCameraFrames && tools.length > 0) {
-          tools.push(REALTIME_VOICE_DESCRIBE_VIEW_TOOL);
-        }
-        const instructions =
-          providerCapabilities?.handlesAgentConsult === true
-            ? normalizeOptionalString(realtimeContext.instructions)
-            : buildRealtimeInstructions(realtimeContext.instructions);
-        const requestedVoiceSessionId = normalizeOptionalString(typedParams.voiceSessionId);
-        let activeVoiceSessionId = wantsGatewayControl
-          ? (requestedVoiceSessionId ?? randomUUID())
-          : undefined;
-        const ownerConnId = normalizeOptionalString(client?.connId);
-        if (wantsGatewayControl && !ownerConnId) {
-          respond(
-            false,
-            undefined,
-            errorShape(ErrorCodes.UNAVAILABLE, "gateway-control-v1 requires a connected client"),
-          );
-          return;
-        }
-        const consultRunner = createTalkClientAgentConsultRunner({
-          config: runtimeConfig,
-          context,
-          agentId,
-          sessionKey,
-          ...(ownerConnId ? { ownerConnId } : {}),
-          authority: resolveTalkAgentConsultAuthority(client?.connect?.scopes),
-          getVoiceSessionId: () => activeVoiceSessionId,
-          initialItems,
-        });
-        const runAgentConsult: NonNullable<
-          InternalRealtimeVoiceBrowserSessionCreateRequest["runAgentConsult"]
-        > = consultRunner.runPrompt;
-        const gatewayControlOwner = wantsGatewayControl
-          ? createTalkClientGatewayControlOwner({
-              voiceSessionId: activeVoiceSessionId!,
-              providerId: resolution.provider.id,
-              sessionKey,
-              connId: ownerConnId!,
-              context,
-              runAgentConsult: consultRunner.runArgs,
-              appendTranscript: ({ entryId, role, text }) =>
-                appendClientVoiceTranscript({
-                  agentId,
-                  sessionKey,
-                  voiceSessionId: activeVoiceSessionId!,
-                  entryId,
-                  role,
-                  text,
-                  config: runtimeConfig,
-                }),
-              flushTranscript: () =>
-                flushClientVoiceSessionWrites({
-                  agentId,
-                  voiceSessionId: activeVoiceSessionId!,
-                }),
-              closeLogicalSession: async () => {
-                await closeClientVoiceSession({
-                  agentId,
-                  sessionKey,
-                  voiceSessionId: activeVoiceSessionId!,
-                  config: runtimeConfig,
-                });
-              },
-            })
-          : undefined;
-        const browserSessionRequest: InternalRealtimeVoiceBrowserSessionCreateRequest = {
-          cfg: runtimeConfig,
-          agentId,
-          ...(ownerConnId ? { ownerConnId } : {}),
-          workspaceDir: resolveAgentWorkspaceDir(runtimeConfig, agentId),
-          providerConfig: resolution.providerConfig,
-          instructions,
-          initialItems,
-          runAgentConsult,
-          ...(gatewayControlOwner ? { gatewayControl: gatewayControlOwner.control } : {}),
-          ...(tools.length > 0 ? { tools } : {}),
-          ...launchOptions,
-        };
-        const session = await resolution.provider.createBrowserSession(browserSessionRequest);
-        // Client-owned voice records are minted only for client-owned transports;
-        // relay sessions are created via talk.session.create and keyed by relaySessionId.
-        // Widening this guard would hand relay calls a mismatched voiceSessionId.
-        if (
-          (session.transport === "webrtc" || session.transport === "provider-websocket") &&
-          !isUnsupportedBrowserWebRtcSession(session) &&
-          (!transport || session.transport === transport)
-        ) {
-          try {
-            const sessionEntryDeadlineAt =
-              session.expiresAt === undefined
-                ? undefined
-                : session.expiresAt - REALTIME_VOICE_CLIENT_SESSION_MIN_TTL_MS;
-            if (sessionEntryDeadlineAt !== undefined && Date.now() >= sessionEntryDeadlineAt) {
-              throw new Error("Realtime browser session expired during startup; try again");
-            }
-            // Defer persistent session creation until the provider has returned a
-            // usable client transport. The write boundary rechecks the credential
-            // deadline so queued storage work cannot leave a phantom chat.
-            await ensureClientVoiceAgentSessionEntry({
-              agentId,
-              sessionKey,
-              creation: resolveSandboxedSessionCreation(client, runtimeConfig),
-              deadlineAt: sessionEntryDeadlineAt,
-            });
-          } catch (error) {
-            try {
-              await cancelInternalRealtimeVoiceBrowserSession({
-                provider: resolution.provider,
-                request: browserSessionRequest,
-                session,
-              });
-            } catch (cancelError) {
-              context.logGateway.warn(
-                `talk browser session cleanup failed: ${formatForLog(cancelError)}`,
-              );
-            }
-            throw error;
-          }
-          // Recovering 6h-abandoned calls (and retrying their digests) is not on the
-          // start path; running it inline would delay use of time-sensitive provider
-          // credentials behind slow channel sends. Fire it off the response path.
-          void closeStaleClientVoiceSessions({
-            agentId,
-            config: runtimeConfig,
-            excludeVoiceSessionId: normalizeOptionalString(typedParams.voiceSessionId),
-            warn: (message) => context.logGateway.warn(`talk voice session recovery: ${message}`),
-          }).catch((error: unknown) =>
-            context.logGateway.warn(`talk voice session recovery failed: ${formatForLog(error)}`),
-          );
-          const voiceSessionId = createOrResumeClientVoiceSession({
-            agentId,
-            sessionKey,
-            provider: resolution.provider.id,
-            origin: "client",
-            // Deployed clients sent sessionKey before transcripts existed, so capability
-            // must be negotiated explicitly; declaring it turns the confirmation gate on.
-            transcriptCapable:
-              wantsGatewayControl ||
-              typedParams.capabilities?.includes("voice-transcript") === true,
-            voiceSessionId: activeVoiceSessionId ?? requestedVoiceSessionId,
-          });
-          activeVoiceSessionId = voiceSessionId;
-          const connId = ownerConnId;
-          if (connId) {
-            rememberLegacyVoiceBinding({
-              connId,
-              sessionKey: typedParams.sessionKey?.trim() || sessionKey,
-              voiceSessionId,
-            });
-          }
-          gatewayControlOwner?.activate(() =>
-            cancelInternalRealtimeVoiceBrowserSession({
-              provider: resolution.provider,
-              request: browserSessionRequest,
-              session,
-            }),
-          );
-          respond(
-            true,
-            {
-              ...session,
-              voiceSessionId,
-              ...(wantsGatewayControl ? { clientControl: { owner: "gateway" as const } } : {}),
-            },
-            undefined,
-          );
-          return;
-        }
-        try {
-          await cancelInternalRealtimeVoiceBrowserSession({
-            provider: resolution.provider,
-            request: browserSessionRequest,
-            session,
-          });
-        } catch (cancelError) {
-          context.logGateway.warn(
-            `talk browser session cleanup failed: ${formatForLog(cancelError)}`,
-          );
-        }
-        if (transport) {
-          rejectTalkClientRequest(
-            respond,
-            ErrorCodes.UNAVAILABLE,
-            `Realtime provider "${resolution.provider.id}" does not support requested browser transport "${transport}"`,
-          );
-          return;
-        }
-      }
-      rejectTalkClientRequest(
-        respond,
-        ErrorCodes.UNAVAILABLE,
-        `Realtime provider "${resolution.provider.id}" does not support client-owned realtime sessions`,
-      );
-    } catch (err) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          err instanceof AgentSelectionRequiredError
-            ? ErrorCodes.INVALID_REQUEST
-            : ErrorCodes.UNAVAILABLE,
-          formatForLog(err),
-        ),
-      );
-    }
-  },
+  "talk.client.create": createTalkClient,
   "talk.client.toolCall": async (request) => {
     const { params, respond } = request;
     if (
@@ -479,10 +68,10 @@ export const talkClientHandlers: GatewayRequestHandlers = {
       return;
     }
     if (params.name !== REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME) {
-      rejectTalkClientRequest(
-        respond,
-        ErrorCodes.INVALID_REQUEST,
-        `unsupported realtime Talk tool: ${params.name}`,
+      respond(
+        false,
+        undefined,
+        errorShape(ErrorCodes.INVALID_REQUEST, `unsupported realtime Talk tool: ${params.name}`),
       );
       return;
     }
@@ -683,10 +272,13 @@ export const talkClientHandlers: GatewayRequestHandlers = {
         sessionKey: params.sessionKey,
       })
     ) {
-      rejectTalkClientRequest(
-        respond,
-        ErrorCodes.INVALID_REQUEST,
-        "talk.client.steer requires an active browser-owned Talk run",
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "talk.client.steer requires an active browser-owned Talk run",
+        ),
       );
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

Two files sat at the repo's hard 700-line oxlint cap, which made them landmines: any PR touching either failed `check-lint`, and because CI lints the merge-ref, the failure showed up only after push even when the branch passed locally. This happened twice while landing #131147 and #131156.

- `src/cron/isolated-agent/run-prepare.ts` — 692 counted lines, essentially one ~590-line function.
- `src/gateway/server-methods/talk-client.ts` — 681 counted lines, with a ~360-line `talk.client.create` handler inline.

`max-lines` suppressions are forbidden by `AGENTS.md`, and the sanctioned remedy at this size is a split.

## Why This Change Was Made

Both extractions are coherent units, not line-golf.

**Cron.** `prepareCronRunContext` walked the preflight candidate list inline while tracking three mutable locals — the selected candidate, its index, and the first unavailable result — then reconstructed a decision from them at two later points. That work moved into `resolveCronPreflight`, which lives in `run-fallback-policy.ts` beside the candidate list it consumes, and returns a closed `ok`/`reason` result. The caller now reads a decision instead of rebuilding one, which is the repo's own guidance on closed result shapes over parallel nullable fields. The lazy model-preflight loader moved to its only consumer, so `run-prepare-runtime.ts` stops exporting a wrapper nobody else calls.

One thing deliberately left alone: the pre-run persistence failure policy stays in `run-prepare.ts`. Moving it into `createPersistCronSessionEntry` looks tempting and would have saved more lines, but the function it guards is also awaited from `run-finalize.ts` and two sites in `run-executor.ts`, where swallowing errors would change unrelated behavior.

**Talk.** The `talk.client.create` handler moved to `talk-client-create.ts`, matching the existing sibling-module pattern (`talk-client-run-ownership.ts`, `talk-session-mark.ts`, `talk-client-legacy-voice-bindings.ts`). The handlers object reads as a routing table again. The extraction exposed a redundant type assertion; removing it shrinks the assertion-safety baseline by one entry — a shrink-only ratchet update.

Counted lines: `run-prepare.ts` 692 → 647, `talk-client.ts` 681 → 287.

## User Impact

None. This is behavior-neutral: no functional change, no new config, no schema change, no new dependency, no public API change. The benefit is that these two files stop failing CI for unrelated PRs.

## Evidence

- `CI=true pnpm check:changed` exit 0 on the rebased branch.
- `CI=true pnpm tsgo` exit 0; all oxlint shards exit 0; `node scripts/run-oxlint.mjs` clean on every touched file.
- `pnpm build` exit 0 with no `INEFFECTIVE_DYNAMIC_IMPORT` — checked specifically because a lazy import loader changed modules.
- Affected cron suites and the full talk suites pass (`run-fallback-policy`, `run-session-state`; 306 talk tests).
- Production LOC: +514/-491, net +23 — the phase-API boundary (params object, return type, imports) against ~420 lines of moved code. No test changes; existing coverage exercises both paths.

Note on local proof: the full 191-file `src/cron` suite could not be run to completion on this host, which is currently at load ~113 from unrelated concurrent work and evicts vitest workers at collection. The suites covering the changed code pass, and CI runs the full matrix.
