### PR TITLE
fix(tui): make terminal safety proof reliable over SSH

### DIFF
--- a/src/tui/tui-pty-harness-assertion-test-support.ts
+++ b/src/tui/tui-pty-harness-assertion-test-support.ts
@@ -645,11 +645,8 @@ async function exerciseMarkdownAndAutocompleteOutputSafety(
     await fixture.run.write("\x14", { delay: false });
     await commandAssertion;
 
-    await fixture.run.write("\x1b", { delay: false });
-    await sleep(50);
-    await fixture.run.write("\x15", { delay: false });
-    await sleep(50);
-    await fixture.run.write("/think ", { delay: false });
+    // Ctrl+U replaces the input without a lone Escape absorbing it as an Alt chord over SSH.
+    await fixture.run.write("\x15/think ", { delay: false });
     await fixture.run.waitForOutput("T08_SAFE_THINKING", 5_000);
     const raw = fixture.run.output();
     expect(thinking.markers.some((marker) => raw.includes(marker))).toBe(false);


### PR DESCRIPTION
Closes #131346.

## What Problem This Solves

Resolves a problem where the TUI terminal-output safety PTY test fails over SSH before reaching its thinking-label assertions. The test leaves `/t08d/think` in the editor and times out waiting for `T08_SAFE_THINKING`.

## Why This Change Was Made

The test sends a bare Escape, waits 50 ms, and sends Ctrl+U. Pinned pi-tui 0.84.2 waits 100 ms for a lone Escape over SSH; its input buffer therefore combines those bytes into an Alt chord. Ctrl+U already clears input while autocomplete is open. Send Ctrl+U and the replacement command directly, removing the unnecessary Escape and both sleeps.

All sanitization assertions, payloads, concurrency, and deadlines remain unchanged. Increasing sleeps or forcing a shorter terminal timeout would preserve the timing dependency; fixing the test's input sequence removes it.

## User Impact

Test-only reliability repair found during maintainer-requested TUI QA. No production behavior, terminal-library policy, configuration, or dependency change. Production LOC: +0/-0. Test support: +2/-5 (net -3).

## Evidence

- Baseline: main `af52e62e85ad98bc3c7421eb329f54cd3d9bdf80`, clean Linux Blacksmith Testbox over SSH, pinned dependencies.
- Before: full PTY suite had 77 passing tests and two failures; an isolated rerun reproduced this same `/t08d/think` failure.
- After: the unchanged terminal-output safety case passes both in isolation and in the full-suite rerun (9.239 s for that case). The full rerun finished with 77 passed and two separate timing failures: reconnect-history coverage reached its existing 45 s total deadline, and the synthetic xAI error case again reached its existing 2 s output deadline. No deadlines were changed.
- Exact focused command: `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-harness.e2e.test.ts -t 'sanitizes ANSI OSC and C1'`.
- Environment/proof workflow: https://github.com/openclaw/openclaw/actions/runs/33130199317. Testbox wrapper returned exit 1 before and exit 0 after; this kept-lease workflow's final status is not itself the individual command verdict.
- Direct dependency inspection: `ProcessTerminal.resolveEscapeTimeoutMs`, `StdinBuffer.process`, and `Editor.handleInput`/`deleteToStartOfLine`. A direct buffer probe emitted one `ESC + Ctrl+U` sequence for the old timing.
- Independent Codex autoreview completed with no findings. Targeted formatting and `git diff --check` passed. Exact-head CI passed on `0ad088134c8fbda882df954af79052de2eb67222`: https://github.com/openclaw/openclaw/actions/runs/33131818071. Local `check-changed` passed its static scans, dead-export scans, and core typecheck, then failed test typechecking because the shared install lacks the declared `@types/jsdom@30.0.0` dependency (TS7016 and resulting implicit-any errors in unchanged Control UI helpers). Both the task and shared install lack that package; no shared dependencies were edited. Hosted test-type checks passed with the clean pinned install.
- Scope: real PTY and `runTui()` with a synthetic backend. This does not establish authenticated-provider, Gateway, or embedded-backend behavior. No visual UI change or screenshot claim.
- Additional QA: the real embedded-backend PTY steering/fresh-session/exit scenario passed (17.11 s), mocking only the external model endpoint: `OPENCLAW_TUI_PTY_INCLUDE_LOCAL=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts src/tui/tui-pty-local.e2e.test.ts -t 'drives and steers the real local backend'`. This is separate from the safety regression proof and does not test real provider authentication.

Known separate follow-ups: the synthetic xAI account-limit error needs real embedded-backend timing evidence before choosing a production change; the reconnect-history exercise combines multiple fresh terminal startups under one overall deadline (baseline passed in 44.295 s; rerun timed out at 45 s). This PR neither suppresses those tests nor claims to fix them.

Provenance: the test input sequence came from #118998, commit `4bdf9ca789b59fdf07f3f8c67c4ae390f2d211bb` (code author, PR author, and merger: @vincentkoc). The production sanitization fix remains intact.

AI-assisted with Codex.

Latest completed ClawSweeper disposition (reviewed 01:56 UTC): https://github.com/openclaw/openclaw/pull/131357#issuecomment-5447211696 identifies no correctness or security findings. Its same-buffer dependency check and Rank-up move are fulfilled. Direct inspection of pinned pi-tui 0.84.2 `dist/stdin-buffer.js:163-220,312-315` confirms that non-Escape bytes become individual sequences emitted synchronously in order. A direct probe of the exact `\x15/think ` buffer emitted `["\u0015","/","t","h","i","n","k"," "]`, with no buffered remainder. `dist/keybindings.js:63-65` and `dist/components/editor.js:530-588,1288-1315` confirm Ctrl+U reaches delete-to-line-start while autocomplete is open. Combined with the completed real-PTY regression proof, this resolves the stated concern; maintainer decision is to accept and land. Exact-head CI is complete and successful. The bot's separate 30-second output-watch attempt did not reach a test verdict; the passing Testbox commands above are the actual changed-path proof.
