### PR TITLE
fix(test): avoid premature CUA proxy readiness failures

### DIFF
--- a/extensions/cua-computer/src/mcp-driver-client.test.ts
+++ b/extensions/cua-computer/src/mcp-driver-client.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 import { ClickButton, EscalationReason } from "./driver-client.js";
 import { createCuaMcpDriver } from "./mcp-driver-client.js";
 
@@ -103,6 +103,8 @@ socket.on("close", () => process.exit(0));
       await fs.rm(directory, { recursive: true, force: true });
     },
   });
+  // Register first so later driver hooks dispose before socket cleanup, even when a test fails.
+  onTestFinished(endpoint.close);
   return endpoint;
 }
 
@@ -193,92 +195,89 @@ describe.runIf(process.platform !== "win32")("CUA MCP proxy transport", () => {
           break;
       }
     });
-    try {
-      const driver = createCuaMcpDriver({
-        ...endpoint,
-        env: {
-          ...process.env,
-          CUA_DRIVER_EMBEDDED: "1",
-          CUA_DRIVER_PERMISSION_MODE: "unrestricted",
-          CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS: "1",
-        },
-      });
-      await vi.waitFor(() => expect(driver.isAvailable()).toBe(true));
+    const driver = createCuaMcpDriver({
+      ...endpoint,
+      env: {
+        ...process.env,
+        CUA_DRIVER_EMBEDDED: "1",
+        CUA_DRIVER_PERMISSION_MODE: "unrestricted",
+        CUA_DRIVER_DANGEROUSLY_BYPASS_APPROVALS: "1",
+      },
+    });
+    onTestFinished(() => driver.dispose());
 
-      const desktop = await driver.getDesktopState();
-      expect(JSON.parse(desktop.structuredJson!)).toMatchObject({
-        platform: "macos",
-        screenshot_width: 200,
-      });
-      expect(desktop.images).toHaveLength(1);
-      const cursor = await driver.getCursorPosition();
-      expect(JSON.parse(cursor.structuredJson!)).toMatchObject({ x: 11, y: 12 });
-      const click = await driver.click({ x: 20, y: 30, button: ClickButton.Left, count: 1 });
-      expect(click.action).toEqual({
-        effect: 0,
-        route: 0,
-        delivery: { mode: 0, deliveredCount: 1 },
-        evidence: [{ kind: 0 }],
-      });
-      await expect(driver.callTool("list_windows", {})).resolves.toMatchObject({
-        isError: false,
-      });
-      await driver.escalateScope(EscalationReason.Other);
-      await expect(driver.callTool("list_windows", {})).resolves.toMatchObject({
-        isError: false,
-      });
+    const desktop = await driver.getDesktopState();
+    expect(driver.isAvailable()).toBe(true);
+    expect(JSON.parse(desktop.structuredJson!)).toMatchObject({
+      platform: "macos",
+      screenshot_width: 200,
+    });
+    expect(desktop.images).toHaveLength(1);
+    const cursor = await driver.getCursorPosition();
+    expect(JSON.parse(cursor.structuredJson!)).toMatchObject({ x: 11, y: 12 });
+    const click = await driver.click({ x: 20, y: 30, button: ClickButton.Left, count: 1 });
+    expect(click.action).toEqual({
+      effect: 0,
+      route: 0,
+      delivery: { mode: 0, deliveredCount: 1 },
+      evidence: [{ kind: 0 }],
+    });
+    await expect(driver.callTool("list_windows", {})).resolves.toMatchObject({
+      isError: false,
+    });
+    await driver.escalateScope(EscalationReason.Other);
+    await expect(driver.callTool("list_windows", {})).resolves.toMatchObject({
+      isError: false,
+    });
 
-      const startCalls = endpoint.requests.filter(
-        (request) => request.method === "tools/call" && request.params?.name === "start_session",
+    const startCalls = endpoint.requests.filter(
+      (request) => request.method === "tools/call" && request.params?.name === "start_session",
+    );
+    expect(startCalls).toHaveLength(1);
+    expect(startCalls[0]?.params?.arguments).not.toHaveProperty("capture_scope");
+    const session = startCalls[0]?.params?.arguments?.session;
+    expect(session).toEqual(expect.stringMatching(/^openclaw-/));
+    expect(
+      endpoint.requests.find(
+        (request) =>
+          request.method === "tools/call" && request.params?.name === "get_session_state",
+      )?.params?.arguments?.session,
+    ).toBe(session);
+    expect(
+      endpoint.requests
+        .filter(
+          (request) => request.method === "tools/call" && request.params?.name === "list_windows",
+        )
+        .map((request) => request.params?.arguments?.session),
+    ).toEqual([session, session]);
+    expect(
+      endpoint.requests.find(
+        (request) =>
+          request.method === "tools/call" && request.params?.name === "get_cursor_position",
+      )?.params?.arguments,
+    ).toEqual({ session });
+
+    await driver.dispose();
+    await vi.waitFor(() => {
+      closed = endpoint.requests.some(
+        (request) => request.method === "tools/call" && request.params?.name === "end_session",
       );
-      expect(startCalls).toHaveLength(1);
-      expect(startCalls[0]?.params?.arguments).not.toHaveProperty("capture_scope");
-      const session = startCalls[0]?.params?.arguments?.session;
-      expect(session).toEqual(expect.stringMatching(/^openclaw-/));
-      expect(
-        endpoint.requests.find(
-          (request) =>
-            request.method === "tools/call" && request.params?.name === "get_session_state",
-        )?.params?.arguments?.session,
-      ).toBe(session);
-      expect(
-        endpoint.requests
-          .filter(
-            (request) => request.method === "tools/call" && request.params?.name === "list_windows",
-          )
-          .map((request) => request.params?.arguments?.session),
-      ).toEqual([session, session]);
-      expect(
-        endpoint.requests.find(
-          (request) =>
-            request.method === "tools/call" && request.params?.name === "get_cursor_position",
-        )?.params?.arguments,
-      ).toEqual({ session });
-
-      await driver.dispose();
-      await vi.waitFor(() => {
-        closed = endpoint.requests.some(
-          (request) => request.method === "tools/call" && request.params?.name === "end_session",
-        );
-        expect(closed).toBe(true);
-      });
-      expect(endpoint.requests.map((request) => request.method)).toContain(
-        "notifications/initialized",
-      );
-      expect(
-        endpoint.requests.find(
-          (request) => request.method === "tools/call" && request.params?.name === "click",
-        )?.params?.arguments,
-      ).toMatchObject({
-        x: 20,
-        y: 30,
-        button: "left",
-        count: 1,
-        target: { kind: "desktop", display_id: "primary" },
-      });
-    } finally {
-      await endpoint.close();
-    }
+      expect(closed).toBe(true);
+    });
+    expect(endpoint.requests.map((request) => request.method)).toContain(
+      "notifications/initialized",
+    );
+    expect(
+      endpoint.requests.find(
+        (request) => request.method === "tools/call" && request.params?.name === "click",
+      )?.params?.arguments,
+    ).toMatchObject({
+      x: 20,
+      y: 30,
+      button: "left",
+      count: 1,
+      target: { kind: "desktop", display_id: "primary" },
+    });
   });
 
   it("fails closed on invalid proxy JSON", async () => {
@@ -287,14 +286,11 @@ describe.runIf(process.platform !== "win32")("CUA MCP proxy transport", () => {
         fake.writeRaw(request, "not-json\n");
       }
     });
-    try {
-      const driver = createCuaMcpDriver(endpoint);
-      await expect(driver.getDesktopState()).rejects.toThrow("COMPUTER_DRIVER_ERROR");
-      expect(driver.isAvailable()).toBe(false);
-      await driver.dispose();
-    } finally {
-      await endpoint.close();
-    }
+    const driver = createCuaMcpDriver(endpoint);
+    onTestFinished(() => driver.dispose());
+    await expect(driver.getDesktopState()).rejects.toThrow("COMPUTER_DRIVER_ERROR");
+    expect(driver.isAvailable()).toBe(false);
+    await driver.dispose();
   });
 
   it("bounds pending calls and tears down the proxy on cancellation", async () => {
@@ -314,29 +310,26 @@ describe.runIf(process.platform !== "win32")("CUA MCP proxy transport", () => {
         fake.respond(request, toolResult({ session: "openclaw-test", active: false }));
       }
     });
-    try {
-      const driver = createCuaMcpDriver(endpoint);
-      await vi.waitFor(() => expect(driver.isAvailable()).toBe(true));
-      const calls = Array.from({ length: 65 }, () => driver.callTool("list_windows", {}));
-      await expect(calls[64]).rejects.toThrow("too many pending requests");
-      await vi.waitFor(() => expect(held).toHaveLength(64));
-      expect(held[0]?.params?.arguments).toMatchObject({
-        session: expect.stringMatching(/^openclaw-/),
-      });
-      for (const request of held) {
-        endpoint.respond(request, toolResult({ windows: [] }));
-      }
-      await Promise.all(calls.slice(0, 64));
-
-      const controller = new AbortController();
-      const cancelled = driver.callTool("list_windows", {}, controller.signal);
-      await vi.waitFor(() => expect(held).toHaveLength(65));
-      controller.abort(new Error("test cancellation"));
-      await expect(cancelled).rejects.toThrow("request was cancelled");
-      expect(driver.isAvailable()).toBe(false);
-      await driver.dispose();
-    } finally {
-      await endpoint.close();
+    const driver = createCuaMcpDriver(endpoint);
+    onTestFinished(() => driver.dispose());
+    const calls = Array.from({ length: 65 }, () => driver.callTool("list_windows", {}));
+    await expect(calls[64]).rejects.toThrow("too many pending requests");
+    expect(driver.isAvailable()).toBe(true);
+    await vi.waitFor(() => expect(held).toHaveLength(64));
+    expect(held[0]?.params?.arguments).toMatchObject({
+      session: expect.stringMatching(/^openclaw-/),
+    });
+    for (const request of held) {
+      endpoint.respond(request, toolResult({ windows: [] }));
     }
+    await Promise.all(calls.slice(0, 64));
+
+    const controller = new AbortController();
+    const cancelled = driver.callTool("list_windows", {}, controller.signal);
+    await vi.waitFor(() => expect(held).toHaveLength(65));
+    controller.abort(new Error("test cancellation"));
+    await expect(cancelled).rejects.toThrow("request was cancelled");
+    expect(driver.isAvailable()).toBe(false);
+    await driver.dispose();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where CUA MCP transport tests can fail their initial availability check before exercising the operation they are intended to verify. A clean Node 24 reproduction failed the first one-second readiness poll with `expected false to be true`; an early assertion also bypassed driver disposal.

## Why This Change Was Made

Use the existing awaited operations as the readiness boundary: `getDesktopState()` awaits initialization and session startup, and the pending-call test already awaits its exact overflow result. Keep the availability assertions after those operations, along with every response, session, pending-call, and cancellation assertion. No production deadlines, retries, fake responses, or APIs change.

Register cleanup through Vitest's per-test lifecycle. The later driver hook disposes before the earlier endpoint hook closes the socket, on failure as well as success. Existing explicit disposal and end-session checks remain. Vitest's hook runner preserves the primary error and continues later cleanup if another hook fails.

Provenance: the polls and endpoint-only cleanup originated in [#123635](https://github.com/openclaw/openclaw/pull/123635), code/PR author @steipete, merged by @steipete on 2026-08-14 (`19ace6830b17`). This fixes the test boundary, not a claimed native CUA regression.

## User Impact

No production or desktop behavior changes. Developers get transport tests synchronized with the operation they actually exercise, plus cleanup that still runs after an assertion fails.

Production LOC: +0/-0. Tests: +107/-114 (net -7); excluding mechanical indentation changes, +8/-15.

## Evidence

Executed with Node 24.20.0, pnpm 11.22.0, Vitest 4.1.11, private copied dependencies, and canonical test routing:

- Baseline `79dfa81664fd`: complete MCP file reproduced 1 failure / 2 passes; the failure was the first readiness poll at line 206 after 1,136ms.
- Candidate: the same complete MCP file passed 3/3. This includes valid desktop/cursor/action results, shared session identity and end-session, invalid JSON, the 65-call bound, and cancellation.
- Direct-driver siblings: six fake-SDK cases passed. The native SDK enum-import case was intentionally excluded; this is not a full seven-case or real-desktop proof.
- The complete selected changed-file gate passed on committed `79dfa81664fd..e0b74137a0c7`, including the actual committed temp-creation delta report, all guards, formatting, extension test types, and scoped lint. This supersedes the earlier dirty-tree gate limitation.
- Independent Codex review: no actionable P0 findings; static review only.
- Exact-head [CI run 33131932374](https://github.com/openclaw/openclaw/actions/runs/33131932374) passed on `e0b74137a0c7458978348672246f08557c6ac917`, including [the required CI gate](https://github.com/openclaw/openclaw/actions/runs/33131932374/job/98724658711). The [Ubuntu changed-plugin job](https://github.com/openclaw/openclaw/actions/runs/33131932374/job/98723326636) passed all 3 MCP tests and all 7 direct-driver tests, including the enum-import case excluded locally. Its full result was 448 files passed / 1 skipped and 5,883 tests passed / 57 skipped, on Node 24.19.0. Hosted enum-import coverage is not live desktop proof.

```sh
OPENCLAW_TEST_PROJECTS_PARALLEL=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/cua-computer/src/mcp-driver-client.test.ts -- --reporter=verbose
OPENCLAW_TEST_PROJECTS_PARALLEL=1 OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/cua-computer/src/driver-client.test.ts -- --reporter=verbose -t '^(?!.*matches the installed CUA Driver desktop input enum contract).*$'
```

The MCP tests launch only a temporary Node proxy and Unix socket, with fixed fake responses. Local runs did not import the native driver, and no live desktop or credentialed service was used. Hosted CI additionally imported the SDK for its enum-contract test. The historical proxy's underlying startup outcome and the original full-suite worker crash remain unexplained; this does not claim original shared-order proof. A separate fixture follow-up is cleanup for acquisition failure before `createFakeEndpoint` returns (write/listen setup), outside this post-construction disposal repair.
