### PR TITLE
fix(openshell): retain FIFOs and sockets after sandbox commands

### DIFF
--- a/docs/gateway/openshell.md
+++ b/docs/gateway/openshell.md
@@ -409,8 +409,9 @@ Workspace synchronization excludes `.git`, `hooks`, and `git-hooks` in both
 directions. Repository credentials, history, and trusted hook code remain on
 the OpenClaw Gateway host instead of being copied into an untrusted sandbox.
 
-Mirror synchronization never copies symlinks into either workspace. Existing
-host symlinks remain intact at every depth, along with their parent directories,
+Mirror synchronization never copies entries it cannot represent, such as
+symlinks, FIFOs, or Unix sockets, into either workspace. Existing host entries
+of those types remain intact at every depth, along with their parent directories,
 even if the sandbox deletes those directories or replaces them with files.
 Remote replacements that conflict with these preserved host paths are ignored;
 ordinary files and directories still receive remote changes and deletions.

--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -420,7 +420,7 @@ describe("openshell sandbox backend e2e", () => {
       const previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
       const previousXdgCacheHome = process.env.XDG_CACHE_HOME;
       const workspaceDir = path.join(rootDir, "workspace");
-      const mirrorWorkspaceDir = path.join(rootDir, "mirror-workspace");
+      const mirrorWorkspaceDir = path.join(rootDir, "mirror");
       const dockerfileDir = path.join(rootDir, "custom-image");
       const dockerfilePath = path.join(dockerfileDir, "Dockerfile");
       const denyPolicyPath = path.join(rootDir, "deny-policy.yaml");
@@ -430,6 +430,7 @@ describe("openshell sandbox backend e2e", () => {
       const testRunId = `${process.pid.toString(36)}${Date.now().toString(36)}`;
       const openShellWorkspace = `oc-w-${testRunId.slice(-14)}`;
       let hostPolicyServer: HostPolicyServer | null | undefined;
+      let mirrorSocketServer: net.Server | undefined;
       let workspaceCreated = false;
       const sandboxCfg = {
         mode: "all" as const,
@@ -553,6 +554,21 @@ describe("openshell sandbox backend e2e", () => {
           await fs.symlink(hostLinkTarget, linkPath);
         }
         await fs.link(hostLinkTarget, path.join(mirrorWorkspaceDir, "links", "hardlinked.txt"));
+        const mirrorFifoPath = path.join(mirrorWorkspaceDir, "host.fifo");
+        const mirrorSocketPath = path.join(mirrorWorkspaceDir, "host.sock");
+        const mkfifoResult = await runCommand({
+          command: "mkfifo",
+          args: [mirrorFifoPath],
+          timeoutMs: 10_000,
+        });
+        expect(mkfifoResult.code).toBe(0);
+        const socketServer = net.createServer();
+        mirrorSocketServer = socketServer;
+        socketServer.listen(mirrorSocketPath);
+        await new Promise<void>((resolve, reject) => {
+          socketServer.once("listening", resolve);
+          socketServer.once("error", reject);
+        });
         await fs.writeFile(dockerfilePath, CUSTOM_IMAGE_DOCKERFILE, "utf8");
         await fs.writeFile(
           denyPolicyPath,
@@ -666,6 +682,8 @@ describe("openshell sandbox backend e2e", () => {
         });
         expect(mirrorExecResult.stdout).toContain("/sandbox/project");
         expect(mirrorExecResult.stdout).toContain("mirror-from-local");
+        expect((await fs.lstat(mirrorFifoPath)).isFIFO()).toBe(true);
+        expect((await fs.lstat(mirrorSocketPath)).isSocket()).toBe(true);
         for (const relativePath of hostLinks) {
           await expect(fs.readlink(path.join(mirrorWorkspaceDir, relativePath))).resolves.toBe(
             hostLinkTarget,
@@ -862,6 +880,12 @@ describe("openshell sandbox backend e2e", () => {
             env,
             allowFailure: true,
             timeoutMs: 30_000,
+          });
+        }
+        const socketServer = mirrorSocketServer;
+        if (socketServer) {
+          await new Promise<void>((resolve) => {
+            socketServer.close(() => resolve());
           });
         }
         await hostPolicyServer?.close().catch(() => {});

--- a/extensions/openshell/src/mirror.test.ts
+++ b/extensions/openshell/src/mirror.test.ts
@@ -1,5 +1,7 @@
 // Openshell tests cover mirror plugin behavior.
+import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
@@ -233,6 +235,36 @@ describe("replaceDirectoryContents", () => {
     await expectPathMissing(path.join(target, "escaped-link"));
     await expectPathMissing(path.join(target, "nested", "escaped-dir"));
   });
+
+  it.runIf(process.platform !== "win32")(
+    "preserves target-only special files and their ancestor directories",
+    async () => {
+      const source = await makeTmpDir();
+      const target = await makeTmpDir();
+      const nested = path.join(target, "nested");
+      const fifoPath = path.join(nested, "host.fifo");
+      const socketPath = path.join(nested, "host.sock");
+      await fs.mkdir(nested);
+      execFileSync("mkfifo", [fifoPath]);
+      const server = net.createServer();
+      server.listen(socketPath);
+      await new Promise<void>((resolve, reject) => {
+        server.once("listening", resolve);
+        server.once("error", reject);
+      });
+
+      try {
+        await replaceDirectoryContents({ sourceDir: source, targetDir: target });
+
+        expect((await fs.lstat(fifoPath)).isFIFO()).toBe(true);
+        expect((await fs.lstat(socketPath)).isSocket()).toBe(true);
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
 
   it.each(["directory", "absent", "file", "symlink"] as const)(
     "preserves trusted host symlinks when their remote ancestor is %s",

--- a/extensions/openshell/src/mirror.ts
+++ b/extensions/openshell/src/mirror.ts
@@ -30,7 +30,8 @@ async function reconcileMirrorPath(params: {
   replace: boolean;
 }): Promise<boolean> {
   const targetStats = await lstatIfExists(params.targetPath);
-  if (targetStats?.isSymbolicLink()) {
+  // Preserve host entries mirror transport cannot represent and their ancestor directories.
+  if (targetStats && !targetStats.isDirectory() && !targetStats.isFile()) {
     return true;
   }
   const sourceStats = params.sourcePath ? await runLimitedFs(fs.lstat, params.sourcePath) : null;
@@ -44,15 +45,14 @@ async function reconcileMirrorPath(params: {
     if (targetStats && !targetStats.isDirectory()) {
       await runLimitedFs(fs.rm, params.targetPath, { force: true });
     }
-    const preservedLinks = await reconcileMirrorDirectory({
+    const preservedEntries = await reconcileMirrorDirectory({
       sourceDir,
       targetDir: params.targetPath,
       replace: params.replace,
     });
-    // Host links also protect their ancestor directories. A conflicting remote
-    // file cannot replace those directories, just as it cannot replace a link.
-    if (sourceDir || preservedLinks) {
-      return preservedLinks;
+    // A remote file cannot replace a directory containing preserved host entries.
+    if (sourceDir || preservedEntries) {
+      return preservedEntries;
     }
     await runLimitedFs(fs.rmdir, params.targetPath);
   } else if (targetStats) {
@@ -94,14 +94,14 @@ async function reconcileMirrorDirectory(params: {
         }),
       ),
   );
-  let preservedLinks = false;
+  let preservedEntries = false;
   for (const result of results) {
     if (result.status === "rejected") {
       throw result.reason;
     }
-    preservedLinks ||= result.value;
+    preservedEntries ||= result.value;
   }
-  return preservedLinks;
+  return preservedEntries;
 }
 
 export async function replaceDirectoryContents(params: {


### PR DESCRIPTION
Fixes #131209

## What Problem This Solves

Fixes an issue where OpenShell mirror-mode commands could delete host FIFOs, Unix sockets, and other special filesystem entries when synchronizing the sandbox workspace back to the host.

## Why This Change Was Made

The mirror transport represents regular files and directories. Download reconciliation previously treated any target-only entry as stale, even when that entry's type could never have appeared in the remote source listing.

This changes the reconciler's existing preservation rule to retain every host entry that the transport cannot represent, and retains its ancestor directories as well. The policy is deliberately type-generic rather than special-casing the reported FIFO and socket examples. Regular files remain replaceable, and there are no config, schema, protocol, or fallback changes.

Production delta: +9/-9 (net zero). Tests: +57/-1. Docs: +3/-2.

## User Impact

Operators can run OpenShell commands in mirror mode without losing host-created FIFOs, listening Unix sockets, symlinks, devices, or other non-file/non-directory entries under the mirrored workspace.

## Evidence

### Reproduction and owner-boundary coverage

Before the production change, the new focused regression deleted `nested/host.fifo` during `replaceDirectoryContents`. On this head, all 13 mirror tests pass using real FIFO and listening Unix socket filesystem objects.

### Exact-head real behavior proof

Validated commit `1299746c6f3ffea6be63d840ef913488b71c397c` with OpenShell 0.0.106, Podman 6.0.2, and an isolated local OpenShell gateway:

```console
OPENCLAW_E2E_OPENSHELL=1 \
OPENCLAW_E2E_OPENSHELL_CONFIG_HOME=<isolated-config> \
OPENCLAW_E2E_SKIP_BUILD=1 \
DOCKER_HOST=unix://<podman-socket> \
node scripts/run-vitest.mjs extensions/openshell/src/backend.e2e.test.ts \
  --reporter=json --outputFile=<proof>/backend-e2e.json
```

Result: 5/5 tests passed in 489.59 seconds. The mirror stress case passed in 236.11 seconds and asserted after the full upload/exec/download cycle that the real host FIFO was still a FIFO and the listening Unix socket was still a socket. The remote stress sibling passed in 248.96 seconds; all three gateway discovery cases also passed.

Retained Vitest JSON SHA-256: `6ad7df61073870d1d557440ca2c1fe1a053f5a088ca61e9a02b703c2cdc1a8f2`.

### Additional checks

- Focused mirror tests: 13/13 passed
- Focused Oxlint: passed
- Oxfmt check on all changed files: passed
- `git diff --check origin/main...HEAD`: passed
- Autoreview: no findings; patch correct at 0.99 confidence

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted Codex session transcript (selected task-relevant excerpts)</summary>

````text
source: local Codex session
redaction: local paths, secrets, auth/session details, and unrelated tool-setup discussion omitted

[user]
let's get a worktree created with a fix for 131209

[assistant]
I’ll create an isolated worktree and implement the root-cause repair for #131209, with a regression test that fails on current `main` and passes after the change.

[assistant]
The new owner-boundary test failed exactly as intended: reconciliation deleted `nested/host.fifo` before the assertion. The canonical fix is to generalize the existing protected-target rule from “symlink” to “anything the mirror cannot represent,” while keeping regular files—including hardlinks—on the unlink-and-copy path.

[user]
work on this branch until it is the most plausible fix for the issue that you determine. You can spin up a local openshell gateway and test locally with podman

[assistant]
I’m treating the invariant as “never delete host entries the mirror cannot represent,” then proving that policy through the real OpenShell upload/exec/download cycle. I’ll also reconcile the user-facing docs with that policy before rerunning both reviews.

[assistant]
Live proof is now clean: both the mirror-stress and remote-stress variants passed, 5/5 tests, against OpenShell 0.0.106 and the Podman-backed gateway. The mirror run specifically exercised the host FIFO and listening Unix socket through the full upload/exec/download lifecycle.

[user]
rebase then push to sallyom remote

[assistant]
Rebased onto `origin/main` (`6b404043aab`) and pushed to `sallyom/fix/issue-131209`.

New commit: `1299746c6f3`
Focused tests: 13/13 passed.
Worktree is clean and remote SHA verified.

[user]
please get this ready for a PR and open a PR with real behavior proof

[assistant]
The proof environment is clean and isolated: temporary OpenShell config/state, a local callback-only gateway, and the Podman machine. I’m now running the full repository OpenShell E2E on pushed SHA `1299746c6f3`, with Vitest’s JSON report retained for the PR record.

[assistant]
Exact-head real behavior passed, and the JSON report is saved. Exact-head unit, format, lint, and diff checks are clean. Autoreview is clean at 0.99 confidence.

[user]
you think we can open a PR now and let the GH clawsweeper kick in? you confident this is the best narrow fix?

[assistant]
Yes. I’m confident this is the best narrow fix: it repairs the mirror reconciler’s invariant—remote absence cannot mean deletion for host entry types the transport cannot represent—without special-casing FIFOs/sockets, changing config, or growing production code (net zero production LOC). The real full-flow test proves both reported node types survive.
````

</details>
<!-- agent-transcript:end -->
