### PR TITLE
fix(memory-wiki): index vault-wide lint targets

### DIFF
--- a/extensions/memory-wiki/src/bounded-walk.test.ts
+++ b/extensions/memory-wiki/src/bounded-walk.test.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { walkMemoryWikiDirectory } from "./bounded-walk.js";
+import {
+  isMemoryWikiRepositoryOrDependencyDirectory,
+  walkMemoryWikiDirectory,
+} from "./bounded-walk.js";
 import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 const tempDirs = createMemoryWikiTestHarness();
@@ -27,21 +30,24 @@ describe("walkMemoryWikiDirectory", () => {
 
   it("prunes ignored subtrees before their descendants consume the budget", async () => {
     const root = await tempDirs.createTempDir("memory-wiki-walk-");
-    await fs.mkdir(path.join(root, "node_modules"));
+    await Promise.all([
+      fs.mkdir(path.join(root, ".git")),
+      fs.mkdir(path.join(root, "node_modules")),
+    ]);
     await Promise.all(
-      Array.from({ length: 10 }, (_, index) =>
-        fs.writeFile(path.join(root, "node_modules", `ignored-${index}.md`), "ignored"),
+      [".git", "node_modules"].flatMap((directory) =>
+        Array.from({ length: 10 }, (_, index) =>
+          fs.writeFile(path.join(root, directory, `ignored-${index}.md`), "ignored"),
+        ),
       ),
     );
     await fs.writeFile(path.join(root, "visible.md"), "visible");
 
     await expect(
       walkMemoryWikiDirectory(root, "", {
-        maxEntries: 2,
+        maxEntries: 3,
         entryFilter: (entry) =>
-          entry.kind === "directory" && path.basename(entry.relativePath) === "node_modules"
-            ? "skip-subtree"
-            : "include",
+          isMemoryWikiRepositoryOrDependencyDirectory(entry) ? "skip-subtree" : "include",
       }),
     ).resolves.toEqual([expect.objectContaining({ relativePath: "visible.md", kind: "file" })]);
   });

--- a/extensions/memory-wiki/src/bounded-walk.test.ts
+++ b/extensions/memory-wiki/src/bounded-walk.test.ts
@@ -28,14 +28,12 @@ describe("walkMemoryWikiDirectory", () => {
     await expect(walkMemoryWikiDirectory(root, "missing")).resolves.toEqual([]);
   });
 
-  it("prunes ignored subtrees before their descendants consume the budget", async () => {
+  it("prunes case-insensitive ignored subtrees before descendants consume the budget", async () => {
     const root = await tempDirs.createTempDir("memory-wiki-walk-");
-    await Promise.all([
-      fs.mkdir(path.join(root, ".git")),
-      fs.mkdir(path.join(root, "node_modules")),
-    ]);
+    const ignoredDirectories = [".GIT", "Node_Modules"];
+    await Promise.all(ignoredDirectories.map((directory) => fs.mkdir(path.join(root, directory))));
     await Promise.all(
-      [".git", "node_modules"].flatMap((directory) =>
+      ignoredDirectories.flatMap((directory) =>
         Array.from({ length: 10 }, (_, index) =>
           fs.writeFile(path.join(root, directory, `ignored-${index}.md`), "ignored"),
         ),
@@ -45,7 +43,7 @@ describe("walkMemoryWikiDirectory", () => {
 
     await expect(
       walkMemoryWikiDirectory(root, "", {
-        maxEntries: 3,
+        maxEntries: ignoredDirectories.length + 1,
         entryFilter: (entry) =>
           isMemoryWikiRepositoryOrDependencyDirectory(entry) ? "skip-subtree" : "include",
       }),

--- a/extensions/memory-wiki/src/bounded-walk.ts
+++ b/extensions/memory-wiki/src/bounded-walk.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import {
   walkRootDirectory,
   type RootWalkEntry,
@@ -16,11 +15,14 @@ type MemoryWikiWalkLimits = {
   onDirectoryError?: RootWalkOptions["onDirectoryError"];
 };
 
+export function isMemoryWikiRepositoryOrDependencyPath(relativePath: string): boolean {
+  return relativePath
+    .split(/[\\/]/)
+    .some((segment) => MEMORY_WIKI_REPOSITORY_OR_DEPENDENCY_DIRECTORIES.has(segment));
+}
+
 export function isMemoryWikiRepositoryOrDependencyDirectory(entry: RootWalkEntry): boolean {
-  return (
-    entry.kind === "directory" &&
-    MEMORY_WIKI_REPOSITORY_OR_DEPENDENCY_DIRECTORIES.has(path.basename(entry.relativePath))
-  );
+  return entry.kind === "directory" && isMemoryWikiRepositoryOrDependencyPath(entry.relativePath);
 }
 
 export async function walkMemoryWikiDirectory(

--- a/extensions/memory-wiki/src/bounded-walk.ts
+++ b/extensions/memory-wiki/src/bounded-walk.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import {
   walkRootDirectory,
   type RootWalkEntry,
@@ -6,6 +7,7 @@ import {
 
 const MEMORY_WIKI_WALK_MAX_DEPTH = 128;
 const MEMORY_WIKI_WALK_MAX_ENTRIES = 20_000;
+const MEMORY_WIKI_REPOSITORY_OR_DEPENDENCY_DIRECTORIES = new Set([".git", "node_modules"]);
 
 type MemoryWikiWalkLimits = {
   maxDepth?: number;
@@ -13,6 +15,13 @@ type MemoryWikiWalkLimits = {
   entryFilter?: RootWalkOptions["entryFilter"];
   onDirectoryError?: RootWalkOptions["onDirectoryError"];
 };
+
+export function isMemoryWikiRepositoryOrDependencyDirectory(entry: RootWalkEntry): boolean {
+  return (
+    entry.kind === "directory" &&
+    MEMORY_WIKI_REPOSITORY_OR_DEPENDENCY_DIRECTORIES.has(path.basename(entry.relativePath))
+  );
+}
 
 export async function walkMemoryWikiDirectory(
   rootDir: string,

--- a/extensions/memory-wiki/src/bounded-walk.ts
+++ b/extensions/memory-wiki/src/bounded-walk.ts
@@ -15,10 +15,16 @@ type MemoryWikiWalkLimits = {
   onDirectoryError?: RootWalkOptions["onDirectoryError"];
 };
 
+export function foldMemoryWikiDirectoryName(segment: string): string {
+  return segment.replace(/[A-Z]/gu, (character) => character.toLowerCase());
+}
+
 export function isMemoryWikiRepositoryOrDependencyPath(relativePath: string): boolean {
   return relativePath
     .split(/[\\/]/)
-    .some((segment) => MEMORY_WIKI_REPOSITORY_OR_DEPENDENCY_DIRECTORIES.has(segment));
+    .some((segment) =>
+      MEMORY_WIKI_REPOSITORY_OR_DEPENDENCY_DIRECTORIES.has(foldMemoryWikiDirectoryName(segment)),
+    );
 }
 
 export function isMemoryWikiRepositoryOrDependencyDirectory(entry: RootWalkEntry): boolean {

--- a/extensions/memory-wiki/src/lint-path-safety.test.ts
+++ b/extensions/memory-wiki/src/lint-path-safety.test.ts
@@ -1,0 +1,235 @@
+// Memory Wiki tests cover bounded, abortable direct lint path checks.
+import fs from "node:fs/promises";
+import path from "node:path";
+import { root as createFsSafeRoot } from "openclaw/plugin-sdk/file-access-runtime";
+import { describe, expect, it, vi } from "vitest";
+import { lintMemoryWikiVault } from "./lint.js";
+import { renderWikiMarkdown } from "./markdown.js";
+import { createMemoryWikiTestHarness } from "./test-helpers.js";
+
+vi.mock("openclaw/plugin-sdk/file-access-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/file-access-runtime")>();
+  return {
+    ...actual,
+    root: vi.fn(actual.root),
+  };
+});
+
+const { createVault } = createMemoryWikiTestHarness();
+const FALLBACK_PATH_CHECK_BUDGET = 512;
+
+describe("lintMemoryWikiVault direct path safety", () => {
+  it("stops fallback path checks on abort without publishing a lint report", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-abort-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: "# References\n\n[[people/ada-lovelace]]\n[[people/grace-hopper]]\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
+
+    const rootMock = vi.mocked(createFsSafeRoot);
+    const createRoot = rootMock.getMockImplementation();
+    if (!createRoot) {
+      throw new Error("file-access root mock has no implementation");
+    }
+    const abortController = new AbortController();
+    let openCalls = 0;
+    rootMock.mockImplementationOnce(async (requestedRoot, defaults) => {
+      const safeRoot = await createRoot(requestedRoot, defaults);
+      const open = safeRoot.open.bind(safeRoot);
+      vi.spyOn(safeRoot, "open").mockImplementation(async (...args) => {
+        openCalls += 1;
+        const opened = await open(...args);
+        abortController.abort();
+        return opened;
+      });
+      return safeRoot;
+    });
+
+    await expect(lintMemoryWikiVault(config, { signal: abortController.signal })).rejects.toThrow();
+    expect(openCalls).toBe(1);
+    await expect(fs.stat(path.join(rootDir, "reports", "lint.md"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("fails clearly when unique fallback path checks exhaust their budget", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-budget-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
+    const links = Array.from(
+      { length: FALLBACK_PATH_CHECK_BUDGET + 1 },
+      (_, index) => `[[archive/missing-${index}]]`,
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: ["# References", "", ...links].join("\n"),
+      }),
+      "utf8",
+    );
+
+    await expect(lintMemoryWikiVault(config)).rejects.toThrow(
+      `Memory Wiki lint fallback path check budget exceeded (${FALLBACK_PATH_CHECK_BUDGET} unique targets)`,
+    );
+    await expect(fs.stat(path.join(rootDir, "reports", "lint.md"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("does not spend the fallback path budget on rejected targets", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-rejected-budget-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+    const rejectedLinks = Array.from(
+      { length: FALLBACK_PATH_CHECK_BUDGET + 1 },
+      (_, index) => `[[.GiT/private-${index}]]`,
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: ["# References", "", ...rejectedLinks, "[[people/ada-lovelace]]"].join("\n"),
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues.filter((issue) => issue.code === "broken-wikilink")).toHaveLength(
+      rejectedLinks.length,
+    );
+  });
+
+  it("keeps direct fallback path spelling exact on case-insensitive filesystems", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-exact-case-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: "# References\n\n[[people/Ada-Lovelace]]\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
+
+    const rootMock = vi.mocked(createFsSafeRoot);
+    const createRoot = rootMock.getMockImplementation();
+    if (!createRoot) {
+      throw new Error("file-access root mock has no implementation");
+    }
+    let openCalls = 0;
+    rootMock.mockImplementationOnce(async (requestedRoot, defaults) => {
+      const safeRoot = await createRoot(requestedRoot, defaults);
+      const open = safeRoot.open.bind(safeRoot);
+      vi.spyOn(safeRoot, "open").mockImplementation(async (relativePath, options) => {
+        openCalls += 1;
+        return await open(relativePath.replace("Ada-Lovelace", "ada-lovelace"), options);
+      });
+      return safeRoot;
+    });
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "broken-wikilink",
+          message: "Broken wikilink target `people/Ada-Lovelace`.",
+        }),
+      ]),
+    );
+    expect(openCalls).toBe(0);
+  });
+
+  it("propagates path-identity races instead of publishing a broken-link warning", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-path-race-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: "# References\n\n[[people/ada-lovelace]]\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
+
+    const rootMock = vi.mocked(createFsSafeRoot);
+    const createRoot = rootMock.getMockImplementation();
+    if (!createRoot) {
+      throw new Error("file-access root mock has no implementation");
+    }
+    rootMock.mockImplementationOnce(async (requestedRoot, defaults) => {
+      const safeRoot = await createRoot(requestedRoot, defaults);
+      vi.spyOn(safeRoot, "open").mockRejectedValue(
+        Object.assign(new Error("path changed during open"), { code: "path-mismatch" }),
+      );
+      return safeRoot;
+    });
+
+    await expect(lintMemoryWikiVault(config)).rejects.toMatchObject({ code: "path-mismatch" });
+    await expect(fs.stat(path.join(rootDir, "reports", "lint.md"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});

--- a/extensions/memory-wiki/src/lint-path-safety.test.ts
+++ b/extensions/memory-wiki/src/lint-path-safety.test.ts
@@ -187,7 +187,62 @@ describe("lintMemoryWikiVault direct path safety", () => {
         }),
       ]),
     );
-    expect(openCalls).toBe(0);
+    expect(openCalls).toBe(1);
+  });
+
+  it("resolves a target in a large directory without enumerating its siblings", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-large-directory-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: "# References\n\n[[people/ada-lovelace]]\n",
+      }),
+      "utf8",
+    );
+    await Promise.all([
+      fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8"),
+      ...Array.from({ length: 2_048 }, (_, index) =>
+        fs.writeFile(
+          path.join(rootDir, "people", `unrelated-${index}.md`),
+          "# Unrelated\n",
+          "utf8",
+        ),
+      ),
+    ]);
+
+    const rootMock = vi.mocked(createFsSafeRoot);
+    const createRoot = rootMock.getMockImplementation();
+    if (!createRoot) {
+      throw new Error("file-access root mock has no implementation");
+    }
+    let listCalls = 0;
+    rootMock.mockImplementationOnce(async (requestedRoot, defaults) => {
+      const safeRoot = await createRoot(requestedRoot, defaults);
+      const list = safeRoot.list.bind(safeRoot);
+      vi.spyOn(safeRoot, "list").mockImplementation(async (...args) => {
+        listCalls += 1;
+        return await list(...args);
+      });
+      return safeRoot;
+    });
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues.filter((issue) => issue.code === "broken-wikilink")).toEqual([]);
+    expect(listCalls).toBe(0);
   });
 
   it("propagates path-identity races instead of publishing a broken-link warning", async () => {

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -1,11 +1,10 @@
 // Memory Wiki tests cover lint plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
-import { root as createFsSafeRoot } from "openclaw/plugin-sdk/file-access-runtime";
 import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { walkMemoryWikiDirectory } from "./bounded-walk.js";
-import { lintMemoryWikiVault, MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS } from "./lint.js";
+import { lintMemoryWikiVault } from "./lint.js";
 import {
   renderWikiMarkdown,
   WIKI_RAW_SOURCE_MARKER,
@@ -20,14 +19,6 @@ vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
   return {
     ...actual,
     replaceFileAtomic: vi.fn(actual.replaceFileAtomic),
-  };
-});
-
-vi.mock("openclaw/plugin-sdk/file-access-runtime", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/file-access-runtime")>();
-  return {
-    ...actual,
-    root: vi.fn(actual.root),
   };
 });
 
@@ -557,220 +548,6 @@ describe("lintMemoryWikiVault", () => {
       "Broken wikilink target `missing-page`.",
     ]);
     expect(lintWalkCalls.some(([, relativePath]) => relativePath === "")).toBe(false);
-  });
-
-  it("stops fallback path checks on abort without publishing a lint report", async () => {
-    const { rootDir, config } = await createVault({
-      prefix: "memory-wiki-lint-vault-wide-abort-",
-      config: {
-        vault: { renderMode: "obsidian" },
-      },
-    });
-    await Promise.all(
-      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
-    );
-    await fs.writeFile(
-      path.join(rootDir, "sources", "references.md"),
-      renderWikiMarkdown({
-        frontmatter: {
-          pageType: "source",
-          id: "source.references",
-          title: "References",
-        },
-        body: "# References\n\n[[people/ada-lovelace]]\n[[people/grace-hopper]]\n",
-      }),
-      "utf8",
-    );
-    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
-
-    const rootMock = vi.mocked(createFsSafeRoot);
-    const createRoot = rootMock.getMockImplementation();
-    if (!createRoot) {
-      throw new Error("file-access root mock has no implementation");
-    }
-    const abortController = new AbortController();
-    let openCalls = 0;
-    rootMock.mockImplementationOnce(async (requestedRoot, defaults) => {
-      const safeRoot = await createRoot(requestedRoot, defaults);
-      const open = safeRoot.open.bind(safeRoot);
-      vi.spyOn(safeRoot, "open").mockImplementation(async (...args) => {
-        openCalls += 1;
-        const opened = await open(...args);
-        abortController.abort();
-        return opened;
-      });
-      return safeRoot;
-    });
-
-    await expect(lintMemoryWikiVault(config, { signal: abortController.signal })).rejects.toThrow();
-    expect(openCalls).toBe(1);
-    await expect(fs.stat(path.join(rootDir, "reports", "lint.md"))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-  });
-
-  it("fails clearly when unique fallback path checks exhaust their budget", async () => {
-    const { rootDir, config } = await createVault({
-      prefix: "memory-wiki-lint-vault-wide-budget-",
-      config: {
-        vault: { renderMode: "obsidian" },
-      },
-    });
-    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
-    const links = Array.from(
-      { length: MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS + 1 },
-      (_, index) => `[[archive/missing-${index}]]`,
-    );
-    await fs.writeFile(
-      path.join(rootDir, "sources", "references.md"),
-      renderWikiMarkdown({
-        frontmatter: {
-          pageType: "source",
-          id: "source.references",
-          title: "References",
-        },
-        body: ["# References", "", ...links].join("\n"),
-      }),
-      "utf8",
-    );
-
-    await expect(lintMemoryWikiVault(config)).rejects.toThrow(
-      `Memory Wiki lint fallback path check budget exceeded (${MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS} unique targets)`,
-    );
-    await expect(fs.stat(path.join(rootDir, "reports", "lint.md"))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
-  });
-
-  it("does not spend the fallback path budget on rejected targets", async () => {
-    const { rootDir, config } = await createVault({
-      prefix: "memory-wiki-lint-vault-wide-rejected-budget-",
-      config: {
-        vault: { renderMode: "obsidian" },
-      },
-    });
-    await Promise.all(
-      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
-    );
-    const rejectedLinks = Array.from(
-      { length: MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS + 1 },
-      (_, index) => `[[.GiT/private-${index}]]`,
-    );
-    await fs.writeFile(
-      path.join(rootDir, "sources", "references.md"),
-      renderWikiMarkdown({
-        frontmatter: {
-          pageType: "source",
-          id: "source.references",
-          title: "References",
-        },
-        body: ["# References", "", ...rejectedLinks, "[[people/ada-lovelace]]"].join("\n"),
-      }),
-      "utf8",
-    );
-    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
-
-    const result = await lintMemoryWikiVault(config);
-
-    expect(result.issues.filter((issue) => issue.code === "broken-wikilink")).toHaveLength(
-      rejectedLinks.length,
-    );
-  });
-
-  it("keeps direct fallback path spelling exact on case-insensitive filesystems", async () => {
-    const { rootDir, config } = await createVault({
-      prefix: "memory-wiki-lint-vault-wide-exact-case-",
-      config: {
-        vault: { renderMode: "obsidian" },
-      },
-    });
-    await Promise.all(
-      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
-    );
-    await fs.writeFile(
-      path.join(rootDir, "sources", "references.md"),
-      renderWikiMarkdown({
-        frontmatter: {
-          pageType: "source",
-          id: "source.references",
-          title: "References",
-        },
-        body: "# References\n\n[[people/Ada-Lovelace]]\n",
-      }),
-      "utf8",
-    );
-    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
-
-    const rootMock = vi.mocked(createFsSafeRoot);
-    const createRoot = rootMock.getMockImplementation();
-    if (!createRoot) {
-      throw new Error("file-access root mock has no implementation");
-    }
-    let openCalls = 0;
-    rootMock.mockImplementationOnce(async (requestedRoot, defaults) => {
-      const safeRoot = await createRoot(requestedRoot, defaults);
-      const open = safeRoot.open.bind(safeRoot);
-      vi.spyOn(safeRoot, "open").mockImplementation(async (relativePath, options) => {
-        openCalls += 1;
-        return await open(relativePath.replace("Ada-Lovelace", "ada-lovelace"), options);
-      });
-      return safeRoot;
-    });
-
-    const result = await lintMemoryWikiVault(config);
-
-    expect(result.issues).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          code: "broken-wikilink",
-          message: "Broken wikilink target `people/Ada-Lovelace`.",
-        }),
-      ]),
-    );
-    expect(openCalls).toBe(0);
-  });
-
-  it("propagates path-identity races instead of publishing a broken-link warning", async () => {
-    const { rootDir, config } = await createVault({
-      prefix: "memory-wiki-lint-vault-wide-path-race-",
-      config: {
-        vault: { renderMode: "obsidian" },
-      },
-    });
-    await Promise.all(
-      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
-    );
-    await fs.writeFile(
-      path.join(rootDir, "sources", "references.md"),
-      renderWikiMarkdown({
-        frontmatter: {
-          pageType: "source",
-          id: "source.references",
-          title: "References",
-        },
-        body: "# References\n\n[[people/ada-lovelace]]\n",
-      }),
-      "utf8",
-    );
-    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
-
-    const rootMock = vi.mocked(createFsSafeRoot);
-    const createRoot = rootMock.getMockImplementation();
-    if (!createRoot) {
-      throw new Error("file-access root mock has no implementation");
-    }
-    rootMock.mockImplementationOnce(async (requestedRoot, defaults) => {
-      const safeRoot = await createRoot(requestedRoot, defaults);
-      vi.spyOn(safeRoot, "open").mockRejectedValue(
-        Object.assign(new Error("path changed during open"), { code: "path-mismatch" }),
-      );
-      return safeRoot;
-    });
-
-    await expect(lintMemoryWikiVault(config)).rejects.toMatchObject({ code: "path-mismatch" });
-    await expect(fs.stat(path.join(rootDir, "reports", "lint.md"))).rejects.toMatchObject({
-      code: "ENOENT",
-    });
   });
 
   it("keeps path target matching case-sensitive", async () => {

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -467,9 +467,15 @@ describe("lintMemoryWikiVault", () => {
       },
     });
     await Promise.all(
-      ["sources", "syntheses", "people", ".git", "node_modules/example"].map((dir) =>
-        fs.mkdir(path.join(rootDir, dir), { recursive: true }),
-      ),
+      [
+        "sources",
+        "syntheses",
+        "people",
+        ".GiT",
+        "Node_Modules/example",
+        ".OpenClaw-Wiki",
+        "_Attachments",
+      ].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
     );
 
     await fs.writeFile(
@@ -485,8 +491,10 @@ describe("lintMemoryWikiVault", () => {
           "",
           "[[syntheses/summary]]",
           "[[people/ada-lovelace]]",
-          "[[.git/private]]",
-          "[[node_modules/example/private]]",
+          "[[.GiT/private]]",
+          "[[Node_Modules/example/private]]",
+          "[[.OpenClaw-Wiki/private]]",
+          "[[_Attachments/private]]",
           "[[missing-page]]",
         ].join("\n"),
       }),
@@ -507,10 +515,20 @@ describe("lintMemoryWikiVault", () => {
     );
     await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
     await Promise.all([
-      fs.writeFile(path.join(rootDir, ".git", "private.md"), "# Git metadata\n", "utf8"),
+      fs.writeFile(path.join(rootDir, ".GiT", "private.md"), "# Git metadata variant\n", "utf8"),
       fs.writeFile(
-        path.join(rootDir, "node_modules", "example", "private.md"),
-        "# Dependency metadata\n",
+        path.join(rootDir, "Node_Modules", "example", "private.md"),
+        "# Dependency metadata variant\n",
+        "utf8",
+      ),
+      fs.writeFile(
+        path.join(rootDir, ".OpenClaw-Wiki", "private.md"),
+        "# Internal state\n",
+        "utf8",
+      ),
+      fs.writeFile(
+        path.join(rootDir, "_Attachments", "private.md"),
+        "# Private attachment\n",
         "utf8",
       ),
     ]);
@@ -523,8 +541,10 @@ describe("lintMemoryWikiVault", () => {
       .map((issue) => issue.message);
 
     expect(brokenTargets).toEqual([
-      "Broken wikilink target `.git/private`.",
-      "Broken wikilink target `node_modules/example/private`.",
+      "Broken wikilink target `.GiT/private`.",
+      "Broken wikilink target `Node_Modules/example/private`.",
+      "Broken wikilink target `.OpenClaw-Wiki/private`.",
+      "Broken wikilink target `_Attachments/private`.",
       "Broken wikilink target `missing-page`.",
     ]);
     expect(lintWalkCalls.some(([, relativePath]) => relativePath === "")).toBe(false);

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -1,6 +1,7 @@
 // Memory Wiki tests cover lint plugin behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { root as createFsSafeRoot } from "openclaw/plugin-sdk/file-access-runtime";
 import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { walkMemoryWikiDirectory } from "./bounded-walk.js";
@@ -19,6 +20,14 @@ vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
   return {
     ...actual,
     replaceFileAtomic: vi.fn(actual.replaceFileAtomic),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/file-access-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/file-access-runtime")>();
+  return {
+    ...actual,
+    root: vi.fn(actual.root),
   };
 });
 
@@ -548,6 +557,56 @@ describe("lintMemoryWikiVault", () => {
       "Broken wikilink target `missing-page`.",
     ]);
     expect(lintWalkCalls.some(([, relativePath]) => relativePath === "")).toBe(false);
+  });
+
+  it("stops fallback path checks on abort without publishing a lint report", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-abort-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: "# References\n\n[[people/ada-lovelace]]\n[[people/grace-hopper]]\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
+
+    const rootMock = vi.mocked(createFsSafeRoot);
+    const createRoot = rootMock.getMockImplementation();
+    if (!createRoot) {
+      throw new Error("file-access root mock has no implementation");
+    }
+    const abortController = new AbortController();
+    let openCalls = 0;
+    rootMock.mockImplementationOnce(async (requestedRoot, defaults) => {
+      const safeRoot = await createRoot(requestedRoot, defaults);
+      const open = safeRoot.open.bind(safeRoot);
+      vi.spyOn(safeRoot, "open").mockImplementation(async (...args) => {
+        openCalls += 1;
+        const opened = await open(...args);
+        abortController.abort();
+        return opened;
+      });
+      return safeRoot;
+    });
+
+    await expect(lintMemoryWikiVault(config, { signal: abortController.signal })).rejects.toThrow();
+    expect(openCalls).toBe(1);
+    await expect(fs.stat(path.join(rootDir, "reports", "lint.md"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
   });
 
   it("keeps path target matching case-sensitive", async () => {

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -642,6 +642,41 @@ describe("lintMemoryWikiVault", () => {
     });
   });
 
+  it("does not spend the fallback path budget on rejected targets", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-rejected-budget-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+    const rejectedLinks = Array.from(
+      { length: MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS + 1 },
+      (_, index) => `[[.GiT/private-${index}]]`,
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: ["# References", "", ...rejectedLinks, "[[people/ada-lovelace]]"].join("\n"),
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues.filter((issue) => issue.code === "broken-wikilink")).toHaveLength(
+      rejectedLinks.length,
+    );
+  });
+
   it("keeps direct fallback path spelling exact on case-insensitive filesystems", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-lint-vault-wide-exact-case-",

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -634,6 +634,38 @@ describe("lintMemoryWikiVault", () => {
       "utf8",
     );
 
+    await expect(lintMemoryWikiVault(config)).rejects.toThrow(
+      `Memory Wiki lint fallback path check budget exceeded (${MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS} unique targets)`,
+    );
+    await expect(fs.stat(path.join(rootDir, "reports", "lint.md"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("keeps direct fallback path spelling exact on case-insensitive filesystems", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-exact-case-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: "# References\n\n[[people/Ada-Lovelace]]\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
+
     const rootMock = vi.mocked(createFsSafeRoot);
     const createRoot = rootMock.getMockImplementation();
     if (!createRoot) {
@@ -642,17 +674,65 @@ describe("lintMemoryWikiVault", () => {
     let openCalls = 0;
     rootMock.mockImplementationOnce(async (requestedRoot, defaults) => {
       const safeRoot = await createRoot(requestedRoot, defaults);
-      vi.spyOn(safeRoot, "open").mockImplementation(async () => {
+      const open = safeRoot.open.bind(safeRoot);
+      vi.spyOn(safeRoot, "open").mockImplementation(async (relativePath, options) => {
         openCalls += 1;
-        throw Object.assign(new Error("missing"), { code: "not-found" });
+        return await open(relativePath.replace("Ada-Lovelace", "ada-lovelace"), options);
       });
       return safeRoot;
     });
 
-    await expect(lintMemoryWikiVault(config)).rejects.toThrow(
-      `Memory Wiki lint fallback path check budget exceeded (${MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS} unique targets)`,
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "broken-wikilink",
+          message: "Broken wikilink target `people/Ada-Lovelace`.",
+        }),
+      ]),
     );
-    expect(openCalls).toBe(MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS);
+    expect(openCalls).toBe(0);
+  });
+
+  it("propagates path-identity races instead of publishing a broken-link warning", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-path-race-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "people"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: "# References\n\n[[people/ada-lovelace]]\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
+
+    const rootMock = vi.mocked(createFsSafeRoot);
+    const createRoot = rootMock.getMockImplementation();
+    if (!createRoot) {
+      throw new Error("file-access root mock has no implementation");
+    }
+    rootMock.mockImplementationOnce(async (requestedRoot, defaults) => {
+      const safeRoot = await createRoot(requestedRoot, defaults);
+      vi.spyOn(safeRoot, "open").mockRejectedValue(
+        Object.assign(new Error("path changed during open"), { code: "path-mismatch" }),
+      );
+      return safeRoot;
+    });
+
+    await expect(lintMemoryWikiVault(config)).rejects.toMatchObject({ code: "path-mismatch" });
     await expect(fs.stat(path.join(rootDir, "reports", "lint.md"))).rejects.toMatchObject({
       code: "ENOENT",
     });

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -450,6 +450,74 @@ describe("lintMemoryWikiVault", () => {
     expect(result.issues.filter((issue) => issue.code === "broken-wikilink")).toEqual([]);
   });
 
+  it("resolves vault-wide path targets without accepting missing targets", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-links-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "syntheses", "people", ".git", "node_modules/example"].map((dir) =>
+        fs.mkdir(path.join(rootDir, dir), { recursive: true }),
+      ),
+    );
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: [
+          "# References",
+          "",
+          "[[syntheses/summary]]",
+          "[[people/ada-lovelace]]",
+          "[[.git/private]]",
+          "[[node_modules/example/private]]",
+          "[[missing-page]]",
+        ].join("\n"),
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "summary.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "synthesis",
+          id: "synthesis.summary",
+          title: "Summary",
+          sourceIds: ["source.references"],
+        },
+        body: "# Summary\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(path.join(rootDir, "people", "ada-lovelace.md"), "# Ada Lovelace\n", "utf8");
+    await Promise.all([
+      fs.writeFile(path.join(rootDir, ".git", "private.md"), "# Git metadata\n", "utf8"),
+      fs.writeFile(
+        path.join(rootDir, "node_modules", "example", "private.md"),
+        "# Dependency metadata\n",
+        "utf8",
+      ),
+    ]);
+
+    const result = await lintMemoryWikiVault(config);
+    const brokenTargets = result.issues
+      .filter((issue) => issue.code === "broken-wikilink")
+      .map((issue) => issue.message);
+
+    expect(brokenTargets).toEqual([
+      "Broken wikilink target `.git/private`.",
+      "Broken wikilink target `node_modules/example/private`.",
+      "Broken wikilink target `missing-page`.",
+    ]);
+  });
+
   it("keeps path target matching case-sensitive", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-lint-path-case-",

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -5,7 +5,7 @@ import { root as createFsSafeRoot } from "openclaw/plugin-sdk/file-access-runtim
 import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { walkMemoryWikiDirectory } from "./bounded-walk.js";
-import { lintMemoryWikiVault } from "./lint.js";
+import { lintMemoryWikiVault, MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS } from "./lint.js";
 import {
   renderWikiMarkdown,
   WIKI_RAW_SOURCE_MARKER,
@@ -604,6 +604,55 @@ describe("lintMemoryWikiVault", () => {
 
     await expect(lintMemoryWikiVault(config, { signal: abortController.signal })).rejects.toThrow();
     expect(openCalls).toBe(1);
+    await expect(fs.stat(path.join(rootDir, "reports", "lint.md"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("fails clearly when unique fallback path checks exhaust their budget", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-vault-wide-budget-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
+    const links = Array.from(
+      { length: MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS + 1 },
+      (_, index) => `[[archive/missing-${index}]]`,
+    );
+    await fs.writeFile(
+      path.join(rootDir, "sources", "references.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.references",
+          title: "References",
+        },
+        body: ["# References", "", ...links].join("\n"),
+      }),
+      "utf8",
+    );
+
+    const rootMock = vi.mocked(createFsSafeRoot);
+    const createRoot = rootMock.getMockImplementation();
+    if (!createRoot) {
+      throw new Error("file-access root mock has no implementation");
+    }
+    let openCalls = 0;
+    rootMock.mockImplementationOnce(async (requestedRoot, defaults) => {
+      const safeRoot = await createRoot(requestedRoot, defaults);
+      vi.spyOn(safeRoot, "open").mockImplementation(async () => {
+        openCalls += 1;
+        throw Object.assign(new Error("missing"), { code: "not-found" });
+      });
+      return safeRoot;
+    });
+
+    await expect(lintMemoryWikiVault(config)).rejects.toThrow(
+      `Memory Wiki lint fallback path check budget exceeded (${MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS} unique targets)`,
+    );
+    expect(openCalls).toBe(MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS);
     await expect(fs.stat(path.join(rootDir, "reports", "lint.md"))).rejects.toMatchObject({
       code: "ENOENT",
     });

--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import { describe, expect, it, vi } from "vitest";
+import { walkMemoryWikiDirectory } from "./bounded-walk.js";
 import { lintMemoryWikiVault } from "./lint.js";
 import {
   renderWikiMarkdown,
@@ -18,6 +19,14 @@ vi.mock("openclaw/plugin-sdk/security-runtime", async (importOriginal) => {
   return {
     ...actual,
     replaceFileAtomic: vi.fn(actual.replaceFileAtomic),
+  };
+});
+
+vi.mock("./bounded-walk.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./bounded-walk.js")>();
+  return {
+    ...actual,
+    walkMemoryWikiDirectory: vi.fn(actual.walkMemoryWikiDirectory),
   };
 });
 
@@ -506,7 +515,9 @@ describe("lintMemoryWikiVault", () => {
       ),
     ]);
 
+    const walkCallOffset = vi.mocked(walkMemoryWikiDirectory).mock.calls.length;
     const result = await lintMemoryWikiVault(config);
+    const lintWalkCalls = vi.mocked(walkMemoryWikiDirectory).mock.calls.slice(walkCallOffset);
     const brokenTargets = result.issues
       .filter((issue) => issue.code === "broken-wikilink")
       .map((issue) => issue.message);
@@ -516,6 +527,7 @@ describe("lintMemoryWikiVault", () => {
       "Broken wikilink target `node_modules/example/private`.",
       "Broken wikilink target `missing-page`.",
     ]);
+    expect(lintWalkCalls.some(([, relativePath]) => relativePath === "")).toBe(false);
   });
 
   it("keeps path target matching case-sensitive", async () => {

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -230,15 +230,9 @@ async function hasExactVaultPathSpelling(
   return true;
 }
 
-async function hasVaultMarkdownPathTarget(
-  vaultRoot: Awaited<ReturnType<typeof createFsSafeRoot>>,
-  rawTarget: string,
-  directoryEntries: Map<string, Promise<Set<string>>>,
-  signal?: AbortSignal,
-): Promise<boolean> {
-  signal?.throwIfAborted();
+function resolveLintFallbackMarkdownPath(rawTarget: string): string | undefined {
   if (!isLintPathStyleTarget(rawTarget)) {
-    return false;
+    return undefined;
   }
   const normalized = normalizeLintPathTarget(rawTarget);
   const segments = normalized.split("/").filter(Boolean);
@@ -251,9 +245,18 @@ async function hasVaultMarkdownPathTarget(
       MEMORY_WIKI_LINT_INTERNAL_DIRECTORIES.has(foldMemoryWikiDirectoryName(segment)),
     )
   ) {
-    return false;
+    return undefined;
   }
-  const requestedPath = `${normalized}.md`;
+  return `${normalized}.md`;
+}
+
+async function hasVaultMarkdownPathTarget(
+  vaultRoot: Awaited<ReturnType<typeof createFsSafeRoot>>,
+  requestedPath: string,
+  directoryEntries: Map<string, Promise<Set<string>>>,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  signal?.throwIfAborted();
   try {
     if (!(await hasExactVaultPathSpelling(vaultRoot, requestedPath, directoryEntries, signal))) {
       return false;
@@ -313,19 +316,26 @@ async function collectBrokenLinkIssues(
       signal?.throwIfAborted();
       let valid = hasValidWikiLinkTarget(validTargets, linkTarget);
       if (!valid && isLintPathStyleTarget(linkTarget)) {
-        const cacheKey = normalizeLintPathTarget(linkTarget);
-        let pending = directPathTargets.get(cacheKey);
-        if (!pending) {
-          if (directPathTargets.size >= MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS) {
-            throw new Error(
-              `Memory Wiki lint fallback path check budget exceeded (${MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS} unique targets)`,
+        const requestedPath = resolveLintFallbackMarkdownPath(linkTarget);
+        if (requestedPath) {
+          let pending = directPathTargets.get(requestedPath);
+          if (!pending) {
+            if (directPathTargets.size >= MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS) {
+              throw new Error(
+                `Memory Wiki lint fallback path check budget exceeded (${MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS} unique targets)`,
+              );
+            }
+            pending = hasVaultMarkdownPathTarget(
+              vaultRoot,
+              requestedPath,
+              directoryEntries,
+              signal,
             );
+            directPathTargets.set(requestedPath, pending);
           }
-          pending = hasVaultMarkdownPathTarget(vaultRoot, linkTarget, directoryEntries, signal);
-          directPathTargets.set(cacheKey, pending);
+          valid = await pending;
+          signal?.throwIfAborted();
         }
-        valid = await pending;
-        signal?.throwIfAborted();
       }
       if (!valid) {
         issues.push({

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -209,7 +209,9 @@ const NON_TARGET_PATH_ERROR_CODES = new Set([
 async function hasVaultMarkdownPathTarget(
   vaultRoot: Awaited<ReturnType<typeof createFsSafeRoot>>,
   rawTarget: string,
+  signal?: AbortSignal,
 ): Promise<boolean> {
+  signal?.throwIfAborted();
   if (!isLintPathStyleTarget(rawTarget)) {
     return false;
   }
@@ -232,8 +234,10 @@ async function hasVaultMarkdownPathTarget(
       symlinks: "reject",
     });
     await opened.handle.close();
+    signal?.throwIfAborted();
     return true;
   } catch (error) {
+    signal?.throwIfAborted();
     const code =
       typeof error === "object" &&
       error !== null &&
@@ -251,27 +255,33 @@ async function hasVaultMarkdownPathTarget(
 async function collectBrokenLinkIssues(
   rootDir: string,
   pages: WikiPageSummary[],
+  signal?: AbortSignal,
 ): Promise<MemoryWikiLintIssue[]> {
+  signal?.throwIfAborted();
   const validTargets = buildWikiLinkTargetIndex(pages);
   const vaultRoot = await createFsSafeRoot(rootDir, {
     hardlinks: "allow",
     mkdir: false,
     symlinks: "reject",
   });
+  signal?.throwIfAborted();
   const directPathTargets = new Map<string, Promise<boolean>>();
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
+    signal?.throwIfAborted();
     for (const linkTarget of page.linkTargets) {
+      signal?.throwIfAborted();
       let valid = hasValidWikiLinkTarget(validTargets, linkTarget);
       if (!valid && isLintPathStyleTarget(linkTarget)) {
         const cacheKey = normalizeLintPathTarget(linkTarget);
         let pending = directPathTargets.get(cacheKey);
         if (!pending) {
-          pending = hasVaultMarkdownPathTarget(vaultRoot, linkTarget);
+          pending = hasVaultMarkdownPathTarget(vaultRoot, linkTarget, signal);
           directPathTargets.set(cacheKey, pending);
         }
         valid = await pending;
+        signal?.throwIfAborted();
       }
       if (!valid) {
         issues.push({
@@ -291,12 +301,14 @@ async function collectPageIssues(
   rootDir: string,
   pages: WikiPageSummary[],
   managedImportedSourcePagePaths: Set<string>,
+  signal?: AbortSignal,
 ): Promise<MemoryWikiLintIssue[]> {
   const issues: MemoryWikiLintIssue[] = [];
   const pagesById = new Map<string, WikiPageSummary[]>();
   const claimHealth = collectWikiClaimHealth(pages);
 
   for (const page of pages) {
+    signal?.throwIfAborted();
     const requiresStructuredPageMetadata = !isUnmanagedRawSourcePage(
       page,
       managedImportedSourcePagePaths,
@@ -488,7 +500,7 @@ async function collectPageIssues(
     }
   }
 
-  issues.push(...(await collectBrokenLinkIssues(rootDir, pages)));
+  issues.push(...(await collectBrokenLinkIssues(rootDir, pages, signal)));
   return issues.toSorted((left, right) => left.path.localeCompare(right.path));
 }
 
@@ -603,6 +615,7 @@ export async function lintMemoryWikiVault(
   );
   options.signal?.throwIfAborted();
   const sourceSyncState = await readMemoryWikiSourceSyncState(config.vault.path);
+  options.signal?.throwIfAborted();
   const managedImportedSourcePagePaths = new Set(
     Object.values(sourceSyncState.entries).map((entry) => entry.pagePath.split(path.sep).join("/")),
   );
@@ -620,9 +633,11 @@ export async function lintMemoryWikiVault(
       config.vault.path,
       compileResult.pages,
       managedImportedSourcePagePaths,
+      options.signal,
     )),
   ].toSorted((left, right) => left.path.localeCompare(right.path));
   const issuesByCategory = buildIssuesByCategory(issues);
+  options.signal?.throwIfAborted();
   const reportPath = await writeLintReport(config.vault.path, issues);
   options.signal?.throwIfAborted();
 

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -8,6 +8,10 @@ import {
 import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
+  isMemoryWikiRepositoryOrDependencyDirectory,
+  walkMemoryWikiDirectory,
+} from "./bounded-walk.js";
+import {
   assessPageFreshness,
   buildClaimContradictionClusters,
   collectWikiClaimHealth,
@@ -155,7 +159,10 @@ function addPathSuffixTargets(index: WikiLinkTargetIndex, raw: string | undefine
   }
 }
 
-function buildWikiLinkTargetIndex(pages: WikiPageSummary[]): WikiLinkTargetIndex {
+async function buildWikiLinkTargetIndex(
+  rootDir: string,
+  pages: WikiPageSummary[],
+): Promise<WikiLinkTargetIndex> {
   const index: WikiLinkTargetIndex = {
     pathTargets: new Set(),
     aliasTargets: new Set(),
@@ -166,6 +173,21 @@ function buildWikiLinkTargetIndex(pages: WikiPageSummary[]): WikiLinkTargetIndex
     addPathSuffixTargets(index, page.sourcePath);
     addPathSuffixTargets(index, page.bridgeRelativePath);
     addPathSuffixTargets(index, page.unsafeLocalRelativePath);
+  }
+  const entries = await walkMemoryWikiDirectory(rootDir, "", {
+    entryFilter: (entry) =>
+      isMemoryWikiRepositoryOrDependencyDirectory(entry) ||
+      (entry.kind === "directory" &&
+        [".openclaw-wiki", "_attachments"].includes(path.basename(entry.relativePath)))
+        ? "skip-subtree"
+        : "include",
+  });
+  for (const entry of entries) {
+    if (entry.kind !== "file" || !entry.relativePath.endsWith(".md")) {
+      continue;
+    }
+    const relativePath = entry.relativePath.split(path.sep).join("/");
+    addPathTarget(index, relativePath);
   }
   return index;
 }
@@ -190,8 +212,11 @@ function hasValidWikiLinkTarget(index: WikiLinkTargetIndex, rawTarget: string): 
   );
 }
 
-function collectBrokenLinkIssues(pages: WikiPageSummary[]): MemoryWikiLintIssue[] {
-  const validTargets = buildWikiLinkTargetIndex(pages);
+async function collectBrokenLinkIssues(
+  rootDir: string,
+  pages: WikiPageSummary[],
+): Promise<MemoryWikiLintIssue[]> {
+  const validTargets = await buildWikiLinkTargetIndex(rootDir, pages);
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
@@ -210,10 +235,11 @@ function collectBrokenLinkIssues(pages: WikiPageSummary[]): MemoryWikiLintIssue[
   return issues;
 }
 
-function collectPageIssues(
+async function collectPageIssues(
+  rootDir: string,
   pages: WikiPageSummary[],
   managedImportedSourcePagePaths: Set<string>,
-): MemoryWikiLintIssue[] {
+): Promise<MemoryWikiLintIssue[]> {
   const issues: MemoryWikiLintIssue[] = [];
   const pagesById = new Map<string, WikiPageSummary[]>();
   const claimHealth = collectWikiClaimHealth(pages);
@@ -410,7 +436,7 @@ function collectPageIssues(
     }
   }
 
-  issues.push(...collectBrokenLinkIssues(pages));
+  issues.push(...(await collectBrokenLinkIssues(rootDir, pages)));
   return issues.toSorted((left, right) => left.path.localeCompare(right.path));
 }
 
@@ -538,7 +564,11 @@ export async function lintMemoryWikiVault(
         message: `Frontmatter failed to parse: ${error.message}`,
       }),
     ),
-    ...collectPageIssues(compileResult.pages, managedImportedSourcePagePaths),
+    ...(await collectPageIssues(
+      config.vault.path,
+      compileResult.pages,
+      managedImportedSourcePagePaths,
+    )),
   ].toSorted((left, right) => left.path.localeCompare(right.path));
   const issuesByCategory = buildIssuesByCategory(issues);
   const reportPath = await writeLintReport(config.vault.path, issues);

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -196,7 +196,7 @@ function hasValidWikiLinkTarget(index: WikiLinkTargetIndex, rawTarget: string): 
 }
 
 const MEMORY_WIKI_LINT_INTERNAL_DIRECTORIES = new Set([".openclaw-wiki", "_attachments"]);
-export const MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS = 512;
+const MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS = 512;
 const NON_TARGET_PATH_ERROR_CODES = new Set([
   "device-path",
   "invalid-path",

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -203,13 +203,37 @@ const NON_TARGET_PATH_ERROR_CODES = new Set([
   "not-file",
   "not-found",
   "outside-workspace",
-  "path-mismatch",
   "symlink",
 ]);
+
+async function hasExactVaultPathSpelling(
+  vaultRoot: Awaited<ReturnType<typeof createFsSafeRoot>>,
+  requestedPath: string,
+  directoryEntries: Map<string, Promise<Set<string>>>,
+  signal?: AbortSignal,
+): Promise<boolean> {
+  let parentPath = "";
+  for (const segment of requestedPath.split("/")) {
+    signal?.throwIfAborted();
+    let pendingEntries = directoryEntries.get(parentPath);
+    if (!pendingEntries) {
+      pendingEntries = vaultRoot.list(parentPath).then((entries) => new Set(entries));
+      directoryEntries.set(parentPath, pendingEntries);
+    }
+    const entries = await pendingEntries;
+    signal?.throwIfAborted();
+    if (!entries.has(segment)) {
+      return false;
+    }
+    parentPath = parentPath ? `${parentPath}/${segment}` : segment;
+  }
+  return true;
+}
 
 async function hasVaultMarkdownPathTarget(
   vaultRoot: Awaited<ReturnType<typeof createFsSafeRoot>>,
   rawTarget: string,
+  directoryEntries: Map<string, Promise<Set<string>>>,
   signal?: AbortSignal,
 ): Promise<boolean> {
   signal?.throwIfAborted();
@@ -229,14 +253,27 @@ async function hasVaultMarkdownPathTarget(
   ) {
     return false;
   }
+  const requestedPath = `${normalized}.md`;
   try {
-    const opened = await vaultRoot.open(`${normalized}.md`, {
+    if (!(await hasExactVaultPathSpelling(vaultRoot, requestedPath, directoryEntries, signal))) {
+      return false;
+    }
+    const opened = await vaultRoot.open(requestedPath, {
       hardlinks: "allow",
       symlinks: "reject",
     });
-    await opened.handle.close();
+    let exactSpelling = false;
+    try {
+      const openedRelativePath = path
+        .relative(vaultRoot.rootReal, opened.realPath)
+        .split(path.sep)
+        .join("/");
+      exactSpelling = openedRelativePath === requestedPath;
+    } finally {
+      await opened.handle.close();
+    }
     signal?.throwIfAborted();
-    return true;
+    return exactSpelling;
   } catch (error) {
     signal?.throwIfAborted();
     const code =
@@ -267,6 +304,7 @@ async function collectBrokenLinkIssues(
   });
   signal?.throwIfAborted();
   const directPathTargets = new Map<string, Promise<boolean>>();
+  const directoryEntries = new Map<string, Promise<Set<string>>>();
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
@@ -283,7 +321,7 @@ async function collectBrokenLinkIssues(
               `Memory Wiki lint fallback path check budget exceeded (${MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS} unique targets)`,
             );
           }
-          pending = hasVaultMarkdownPathTarget(vaultRoot, linkTarget, signal);
+          pending = hasVaultMarkdownPathTarget(vaultRoot, linkTarget, directoryEntries, signal);
           directPathTargets.set(cacheKey, pending);
         }
         valid = await pending;

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -1,16 +1,14 @@
 // Memory Wiki plugin module implements lint behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { root as createFsSafeRoot } from "openclaw/plugin-sdk/file-access-runtime";
 import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
 } from "openclaw/plugin-sdk/memory-host-markdown";
 import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  isMemoryWikiRepositoryOrDependencyDirectory,
-  walkMemoryWikiDirectory,
-} from "./bounded-walk.js";
+import { isMemoryWikiRepositoryOrDependencyPath } from "./bounded-walk.js";
 import {
   assessPageFreshness,
   buildClaimContradictionClusters,
@@ -159,10 +157,7 @@ function addPathSuffixTargets(index: WikiLinkTargetIndex, raw: string | undefine
   }
 }
 
-async function buildWikiLinkTargetIndex(
-  rootDir: string,
-  pages: WikiPageSummary[],
-): Promise<WikiLinkTargetIndex> {
+function buildWikiLinkTargetIndex(pages: WikiPageSummary[]): WikiLinkTargetIndex {
   const index: WikiLinkTargetIndex = {
     pathTargets: new Set(),
     aliasTargets: new Set(),
@@ -173,21 +168,6 @@ async function buildWikiLinkTargetIndex(
     addPathSuffixTargets(index, page.sourcePath);
     addPathSuffixTargets(index, page.bridgeRelativePath);
     addPathSuffixTargets(index, page.unsafeLocalRelativePath);
-  }
-  const entries = await walkMemoryWikiDirectory(rootDir, "", {
-    entryFilter: (entry) =>
-      isMemoryWikiRepositoryOrDependencyDirectory(entry) ||
-      (entry.kind === "directory" &&
-        [".openclaw-wiki", "_attachments"].includes(path.basename(entry.relativePath)))
-        ? "skip-subtree"
-        : "include",
-  });
-  for (const entry of entries) {
-    if (entry.kind !== "file" || !entry.relativePath.endsWith(".md")) {
-      continue;
-    }
-    const relativePath = entry.relativePath.split(path.sep).join("/");
-    addPathTarget(index, relativePath);
   }
   return index;
 }
@@ -212,16 +192,77 @@ function hasValidWikiLinkTarget(index: WikiLinkTargetIndex, rawTarget: string): 
   );
 }
 
+const MEMORY_WIKI_LINT_INTERNAL_DIRECTORIES = new Set([".openclaw-wiki", "_attachments"]);
+const NON_TARGET_PATH_ERROR_CODES = new Set([
+  "device-path",
+  "invalid-path",
+  "not-file",
+  "not-found",
+  "outside-workspace",
+  "path-mismatch",
+  "symlink",
+]);
+
+async function hasVaultMarkdownPathTarget(
+  vaultRoot: Awaited<ReturnType<typeof createFsSafeRoot>>,
+  rawTarget: string,
+): Promise<boolean> {
+  if (!isLintPathStyleTarget(rawTarget)) {
+    return false;
+  }
+  const normalized = normalizeLintPathTarget(rawTarget);
+  const segments = normalized.split("/").filter(Boolean);
+  if (
+    !normalized ||
+    /^[a-zA-Z]:($|\/)/.test(normalized) ||
+    segments.includes("..") ||
+    isMemoryWikiRepositoryOrDependencyPath(normalized) ||
+    segments.some((segment) => MEMORY_WIKI_LINT_INTERNAL_DIRECTORIES.has(segment))
+  ) {
+    return false;
+  }
+  try {
+    const opened = await vaultRoot.open(`${normalized}.md`, {
+      hardlinks: "allow",
+      symlinks: "reject",
+    });
+    await opened.handle.close();
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code && NON_TARGET_PATH_ERROR_CODES.has(code)) {
+      return false;
+    }
+    throw error;
+  }
+}
+
 async function collectBrokenLinkIssues(
   rootDir: string,
   pages: WikiPageSummary[],
 ): Promise<MemoryWikiLintIssue[]> {
-  const validTargets = await buildWikiLinkTargetIndex(rootDir, pages);
+  const validTargets = buildWikiLinkTargetIndex(pages);
+  const vaultRoot = await createFsSafeRoot(rootDir, {
+    hardlinks: "allow",
+    mkdir: false,
+    symlinks: "reject",
+  });
+  const directPathTargets = new Map<string, Promise<boolean>>();
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
     for (const linkTarget of page.linkTargets) {
-      if (!hasValidWikiLinkTarget(validTargets, linkTarget)) {
+      let valid = hasValidWikiLinkTarget(validTargets, linkTarget);
+      if (!valid && isLintPathStyleTarget(linkTarget)) {
+        const cacheKey = normalizeLintPathTarget(linkTarget);
+        let pending = directPathTargets.get(cacheKey);
+        if (!pending) {
+          pending = hasVaultMarkdownPathTarget(vaultRoot, linkTarget);
+          directPathTargets.set(cacheKey, pending);
+        }
+        valid = await pending;
+      }
+      if (!valid) {
         issues.push({
           severity: "warning",
           category: "links",

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -206,30 +206,6 @@ const NON_TARGET_PATH_ERROR_CODES = new Set([
   "symlink",
 ]);
 
-async function hasExactVaultPathSpelling(
-  vaultRoot: Awaited<ReturnType<typeof createFsSafeRoot>>,
-  requestedPath: string,
-  directoryEntries: Map<string, Promise<Set<string>>>,
-  signal?: AbortSignal,
-): Promise<boolean> {
-  let parentPath = "";
-  for (const segment of requestedPath.split("/")) {
-    signal?.throwIfAborted();
-    let pendingEntries = directoryEntries.get(parentPath);
-    if (!pendingEntries) {
-      pendingEntries = vaultRoot.list(parentPath).then((entries) => new Set(entries));
-      directoryEntries.set(parentPath, pendingEntries);
-    }
-    const entries = await pendingEntries;
-    signal?.throwIfAborted();
-    if (!entries.has(segment)) {
-      return false;
-    }
-    parentPath = parentPath ? `${parentPath}/${segment}` : segment;
-  }
-  return true;
-}
-
 function resolveLintFallbackMarkdownPath(rawTarget: string): string | undefined {
   if (!isLintPathStyleTarget(rawTarget)) {
     return undefined;
@@ -253,14 +229,10 @@ function resolveLintFallbackMarkdownPath(rawTarget: string): string | undefined 
 async function hasVaultMarkdownPathTarget(
   vaultRoot: Awaited<ReturnType<typeof createFsSafeRoot>>,
   requestedPath: string,
-  directoryEntries: Map<string, Promise<Set<string>>>,
   signal?: AbortSignal,
 ): Promise<boolean> {
   signal?.throwIfAborted();
   try {
-    if (!(await hasExactVaultPathSpelling(vaultRoot, requestedPath, directoryEntries, signal))) {
-      return false;
-    }
     const opened = await vaultRoot.open(requestedPath, {
       hardlinks: "allow",
       symlinks: "reject",
@@ -307,7 +279,6 @@ async function collectBrokenLinkIssues(
   });
   signal?.throwIfAborted();
   const directPathTargets = new Map<string, Promise<boolean>>();
-  const directoryEntries = new Map<string, Promise<Set<string>>>();
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
@@ -325,12 +296,7 @@ async function collectBrokenLinkIssues(
                 `Memory Wiki lint fallback path check budget exceeded (${MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS} unique targets)`,
               );
             }
-            pending = hasVaultMarkdownPathTarget(
-              vaultRoot,
-              requestedPath,
-              directoryEntries,
-              signal,
-            );
+            pending = hasVaultMarkdownPathTarget(vaultRoot, requestedPath, signal);
             directPathTargets.set(requestedPath, pending);
           }
           valid = await pending;

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -8,7 +8,10 @@ import {
 } from "openclaw/plugin-sdk/memory-host-markdown";
 import { replaceFileAtomic } from "openclaw/plugin-sdk/security-runtime";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { isMemoryWikiRepositoryOrDependencyPath } from "./bounded-walk.js";
+import {
+  foldMemoryWikiDirectoryName,
+  isMemoryWikiRepositoryOrDependencyPath,
+} from "./bounded-walk.js";
 import {
   assessPageFreshness,
   buildClaimContradictionClusters,
@@ -217,7 +220,9 @@ async function hasVaultMarkdownPathTarget(
     /^[a-zA-Z]:($|\/)/.test(normalized) ||
     segments.includes("..") ||
     isMemoryWikiRepositoryOrDependencyPath(normalized) ||
-    segments.some((segment) => MEMORY_WIKI_LINT_INTERNAL_DIRECTORIES.has(segment))
+    segments.some((segment) =>
+      MEMORY_WIKI_LINT_INTERNAL_DIRECTORIES.has(foldMemoryWikiDirectoryName(segment)),
+    )
   ) {
     return false;
   }

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -229,7 +229,13 @@ async function hasVaultMarkdownPathTarget(
     await opened.handle.close();
     return true;
   } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
+    const code =
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      typeof error.code === "string"
+        ? error.code
+        : undefined;
     if (code && NON_TARGET_PATH_ERROR_CODES.has(code)) {
       return false;
     }

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -196,6 +196,7 @@ function hasValidWikiLinkTarget(index: WikiLinkTargetIndex, rawTarget: string): 
 }
 
 const MEMORY_WIKI_LINT_INTERNAL_DIRECTORIES = new Set([".openclaw-wiki", "_attachments"]);
+export const MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS = 512;
 const NON_TARGET_PATH_ERROR_CODES = new Set([
   "device-path",
   "invalid-path",
@@ -277,6 +278,11 @@ async function collectBrokenLinkIssues(
         const cacheKey = normalizeLintPathTarget(linkTarget);
         let pending = directPathTargets.get(cacheKey);
         if (!pending) {
+          if (directPathTargets.size >= MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS) {
+            throw new Error(
+              `Memory Wiki lint fallback path check budget exceeded (${MEMORY_WIKI_LINT_MAX_FALLBACK_PATH_CHECKS} unique targets)`,
+            );
+          }
           pending = hasVaultMarkdownPathTarget(vaultRoot, linkTarget, signal);
           directPathTargets.set(cacheKey, pending);
         }

--- a/extensions/memory-wiki/src/okf.ts
+++ b/extensions/memory-wiki/src/okf.ts
@@ -8,7 +8,10 @@ import {
   normalizeSingleOrTrimmedStringList,
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { walkMemoryWikiDirectory } from "./bounded-walk.js";
+import {
+  isMemoryWikiRepositoryOrDependencyDirectory,
+  walkMemoryWikiDirectory,
+} from "./bounded-walk.js";
 import { compileMemoryWikiVault } from "./compile.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { appendMemoryWikiLog } from "./log.js";
@@ -133,10 +136,7 @@ async function collectOkfMarkdownFiles(
 ): Promise<string[]> {
   const entries = await walkMemoryWikiDirectory(rootDir, "", {
     entryFilter: (entry) =>
-      entry.kind === "directory" &&
-      [".git", "node_modules"].includes(path.basename(entry.relativePath))
-        ? "skip-subtree"
-        : "include",
+      isMemoryWikiRepositoryOrDependencyDirectory(entry) ? "skip-subtree" : "include",
     onDirectoryError: "skip-and-report",
   });
   const files: string[] = [];


### PR DESCRIPTION
## What Problem This Solves

`openclaw wiki lint` builds its target index from compiled page summaries. Compilation deliberately scans only `sources/`, `entities/`, `concepts/`, `syntheses/`, and `reports/`, so a valid path link such as `[[people/ada-lovelace]]` to an existing Markdown file elsewhere in the same vault is reported as `broken-wikilink`.

The first version of the vault-wide repair also traversed `.git` and `node_modules`. Those non-content trees could consume the bounded walk's 20,000-entry budget and make lint reject an otherwise valid vault.

## Why This Change Was Made

Lint keeps the existing compiled-page title and alias index, then resolves only unresolved path-style targets through a root-bounded file open. It does not enumerate the vault. Unsafe, escaping, symlinked, internal, repository, and dependency targets remain invalid.

The change keeps the existing title, alias, normalization, and case-sensitive path matching rules; only explicit existing Markdown paths outside compiled namespaces gain the new lookup.

## User Impact

Vaults that organize pages in additional namespaces, such as `people/`, `projects/`, or `timeline/`, no longer receive false `broken-wikilink` warnings for path-style links to those pages. Links to absent files remain warnings, and Markdown under `.git` or `node_modules` is never accepted. Unrelated vault entries no longer participate in link validation, so they cannot exhaust its traversal budget.

## Evidence

Tested exact head: `efa1079b0a73fc41398e4b43bbd6f1d9309db18a` on main `640d73e3d452b3fb53f78cfa679c23101434c927`.

- Pre-fix regression failed: existing `.git/private.md` and `node_modules/example/private.md` were incorrectly accepted as valid link targets; only `missing-page` was reported broken.
- ClawSweeper’s preceding-head live run passed the lint + bounded-walk suites 20/20. The exact head adds a regression asserting lint never performs a vault-root walk; full exact-head repository CI completed successfully.
- The existing OKF repository/dependency pruning test passed through the new shared predicate.
- Production Memory Wiki CLI command proof (`wiki lint --json`) on an isolated vault produced these link findings:

```json
[
  "Broken wikilink target `.git/private`.",
  "Broken wikilink target `node_modules/example/private`.",
  "Broken wikilink target `missing-page`."
]
```

  The existing custom-namespace target `people/ada-lovelace` was absent from the findings, and the command wrote `reports/lint.md` successfully.
- Exact-head formatting, direct Oxlint of the three newly changed files, and `git diff --check`: clean.

This PR was AI-assisted; the implementation, tests, and validation were reviewed by the submitting author.

<!-- final-repair-2026-08-31 -->
## Final repair follow-up (2026-08-31)

Current exact head: `f4f7855e0b0ebe747323268e67ef275ebdc81a90`.

- Unresolved path targets now go directly through the root-bounded safe open. Parent directories are never enumerated or retained in a `Set`.
- Exact case identity is still enforced by comparing the requested vault-relative path with the opened file's resolved real path.
- Reserved, repository, dependency, internal, escaping, symlinked, and non-file paths remain rejected.
- The 512-unique-target budget, cancellation propagation, duplicate-result cache, and path-identity-race behavior are unchanged.
- A new regression creates 2,048 unrelated Markdown siblings beside the referenced file and asserts both that the target resolves and that the safe-root `list()` surface is never called.
- Focused exact-head suite: 26/26 passed across `lint.test.ts`, `lint-path-safety.test.ts`, and `bounded-walk.test.ts`.
- Changed-file format, max-lines, dependency, boundary, and dead-export guards passed. The broad local extension typecheck still encounters the unrelated existing Telegram/`grammy` mismatch; the preceding hosted exact-head typecheck was green.

### Exact-head real CLI proof with a large directory

The isolated proof vault contains:

- `sources/references.md` linking to `[[people/ada-lovelace]]` and `[[archive/missing-page]]`;
- the existing `people/ada-lovelace.md`;
- 2,048 unrelated sibling Markdown files under `people/`;
- no `archive/missing-page.md`.

Fixture count and command:

```bash
find /tmp/openclaw-pr131362-proof-f4f7855e0b0/vault/people -maxdepth 1 -type f | wc -l
# 2049

OPENCLAW_STATE_DIR=/tmp/openclaw-pr131362-proof-f4f7855e0b0/state \
OPENCLAW_CONFIG_PATH=/tmp/openclaw-pr131362-proof-f4f7855e0b0/state/openclaw.json \
pnpm openclaw wiki lint --json
```

Exact-head result (exit 0):

```json
{
  "vaultRoot": "/tmp/openclaw-pr131362-proof-f4f7855e0b0/vault",
  "issueCount": 1,
  "issues": [
    {
      "severity": "warning",
      "category": "links",
      "code": "broken-wikilink",
      "path": "sources/references.md",
      "message": "Broken wikilink target `archive/missing-page`."
    }
  ],
  "issuesByCategory": {
    "structure": [],
    "provenance": [],
    "links": [
      {
        "severity": "warning",
        "category": "links",
        "code": "broken-wikilink",
        "path": "sources/references.md",
        "message": "Broken wikilink target `archive/missing-page`."
      }
    ],
    "contradictions": [],
    "open-questions": [],
    "quality": []
  },
  "reportPath": "/tmp/openclaw-pr131362-proof-f4f7855e0b0/vault/reports/lint.md"
}
```

The real CLI therefore accepts the existing target in a 2,049-file custom directory while reporting only the absent target, without any directory inventory in the fallback implementation. Current hosted CI: https://github.com/openclaw/openclaw/actions/runs/33406118453.

<!-- final-rebase-2026-09-01 -->
## Exact-head CI repair follow-up (2026-09-01)

Current exact head: `bef1d2111066889d58cdb757db089684f42556c9`.

- Rebased the 11-commit PR stack onto current `main` (`29cc0bd10fb`) to pick up the merged gateway fixture repairs from #134165 and #134207. `git range-diff` reports all 11 commits as patch-equivalent; no Memory Wiki behavior changed during the rebase.
- The prior hosted failures were outside this PR: `src/gateway/server-kernel.test.ts` lint and `src/gateway/server.channels-start-outcomes.test.ts` types. The rebased head passes the formerly failing `server-kernel` lint plus both underlying type-check configs (`gateway-root` and `config-cli`).
- Exact-head Memory Wiki validation passes: 3 test files, 26 tests. Formatting and lint pass for all six changed files, and `git diff --check` is clean.
- The earlier exact-head CLI proof remains behavior-equivalent because the PR patches are unchanged by the rebase. New hosted CI is expected on this head; no green hosted-CI claim is made until it completes.
