### PR TITLE
fix(git): keep worktree failure messages readable

### DIFF
--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -59,6 +59,14 @@ The resulting managed worktree is owned by the session, and every agent run in t
 
 `sessions.create` also accepts `worktreeBaseRef` and `worktreeName` alongside `worktree: true` to pick the base ref and the worktree name (the branch becomes `openclaw/<name>`); both stay at `operator.write`. If `worktreeName` is omitted, the session label or generated first-message title supplies the readable branch name, with a crustacean-themed fallback. The created worktree is returned in the create result and persisted on the session row as `worktree: { id, branch, repoRoot }`, so session lists can show the checkout and branch. When session deletion cannot finish that cleanup, `worktreePreserved` identifies the active worktree record that needs attention and reports one bounded reason: owner mismatch, active use or competing cleanup, a foreign Git lock, snapshot failure, or another cleanup failure. These reasons describe cleanup and ownership, not whether the checkout is dirty or has unpushed commits.
 
+## Troubleshoot creation
+
+If **New session** reports `git worktree add failed`, read the termination reason and the final Git error lines. `Preparing worktree` and `Updating files` are progress, not the cause of failure. Error messages collapse carriage-return progress redraws and bound the diagnostic tail so it cannot flood the banner.
+
+`timed out after 120 seconds` means the Git command reached OpenClaw's execution limit. Check repository access and available disk space on the Gateway host. A signal or nonzero exit status alone does not establish a timeout; use any accompanying `fatal:` or `error:` detail to investigate. An output-limit error means the command exceeded its output capture limit.
+
+Before another creation attempt, inspect `git -C <repo-root> worktree list` and `git -C <repo-root> branch --list 'openclaw/*'` for partial state. A failed creation does not guarantee that its checkout and branch were removed. Do not delete a checkout or branch without checking whether it contains work you need.
+
 ## Snapshots, cleanup, and restore
 
 Removal first creates a synthetic commit containing tracked and non-ignored untracked files, then pins it at `refs/openclaw/snapshots/<id>`. Ignored files never enter the repository object database. OpenClaw stores only the ignored files it actually provisioned in chunked shared-state database rows; the recorded path set remains authoritative even if `.worktreeinclude` later changes or disappears. Restore reads those bytes from the immutable snapshot and reapplies their complete modes. Automatic cleanup preserves a live worktree when a recorded path can no longer be snapshotted safely. If snapshot creation fails, removal stops unless an explicit force delete discards snapshot safety.

--- a/src/agents/worktrees/git.test.ts
+++ b/src/agents/worktrees/git.test.ts
@@ -1,11 +1,31 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, expectTypeOf, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { findGitCheckoutRoot, hasSelfContainedGitMetadata, insideGitCheckout } from "./git.js";
+import type { SpawnResult } from "../../process/exec.js";
+import {
+  commandError,
+  findGitCheckoutRoot,
+  hasSelfContainedGitMetadata,
+  insideGitCheckout,
+  runGit,
+} from "./git.js";
 
 describe("Git checkout discovery", () => {
   const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it("reports a real Git failure with execution metadata through the worktree wrapper", async () => {
+    const root = tempDirs.make("openclaw-git-error-");
+    const result = await runGit(path.join(root, "missing"), ["status"]);
+
+    expectTypeOf(result).toEqualTypeOf<SpawnResult>();
+    expect(result.code).toBe(128);
+    expect(result).toMatchObject({ termination: "exit", signal: null });
+    const message = commandError("git status", result).message;
+    expect(message).toContain("git status failed (exit code 128)");
+    expect(message).toContain("fatal:");
+    expect(message).not.toMatch(/timeout|timed out/i);
+  });
 
   it("returns the nearest checkout root for nested paths", async () => {
     const root = tempDirs.make("openclaw-git-root-");

--- a/src/agents/worktrees/git.ts
+++ b/src/agents/worktrees/git.ts
@@ -10,11 +10,7 @@ import {
   requireGitCommandRaw,
 } from "../../infra/git-exec.js";
 
-export type GitResult = {
-  stdout: string;
-  stderr: string;
-  code: number | null;
-};
+export type GitResult = Awaited<ReturnType<typeof executeGitCommand>>;
 
 type WorktreeListEntry = {
   path: string;

--- a/src/gateway/control-ui-session-prs.test.ts
+++ b/src/gateway/control-ui-session-prs.test.ts
@@ -435,6 +435,9 @@ describe("loadControlUiSessionPullRequests", () => {
       stdout: ` 1 file changed, ${root === "/repo/b" ? 3 : additions} insertions(+)`,
       stderr: "",
       code: 0,
+      signal: null,
+      killed: false,
+      termination: "exit" as const,
     }));
     const load = (sessionKey: string, refresh = false) =>
       loadControlUiSessionPullRequests(

--- a/src/infra/git-exec.test.ts
+++ b/src/infra/git-exec.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as processExec from "../process/exec.js";
+import type { SpawnResult } from "../process/exec.js";
+import { requireGitCommand, requireGitCommandBuffer, requireGitCommandRaw } from "./git-exec.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+const progress = Array.from({ length: 1000 }, (_, i) => `Updating files: ${i}/1000`).join("\r");
+const failure = {
+  stdout: "",
+  stderr: "",
+  code: 128,
+  signal: null,
+  killed: false,
+  termination: "exit",
+} satisfies SpawnResult;
+
+describe.each([
+  ["text", requireGitCommand],
+  ["raw", requireGitCommandRaw],
+  ["buffered", requireGitCommandBuffer],
+] as const)("Git %s diagnostics", (_kind, requireGit) => {
+  async function failureMessage(args: string[]): Promise<string> {
+    try {
+      await requireGit("/repo", args);
+    } catch (error) {
+      if (error instanceof Error) {
+        return error.message;
+      }
+      throw error;
+    }
+    throw new Error("Expected Git to fail");
+  }
+
+  function failWith(overrides: Partial<SpawnResult>) {
+    const result = { ...failure, ...overrides };
+    vi.spyOn(processExec, "runCommandWithTimeout").mockResolvedValueOnce(result);
+    vi.spyOn(processExec, "runCommandBuffered").mockResolvedValueOnce({
+      ...result,
+      stdout: Buffer.from(result.stdout),
+      stderr: Buffer.from(result.stderr),
+      termination: result.outputLimitExceeded
+        ? "output-limit"
+        : result.termination === "no-output-timeout"
+          ? "timeout"
+          : result.termination,
+    });
+  }
+
+  it.each(["\n", "\r\n"])(
+    "collapses redraws and preserves fatal details with %j",
+    async (newline) => {
+      failWith({
+        stderr: `Preparing worktree${newline}${progress}\r${newline}\u001b[31mfatal: disk full\u001b[0m${newline}`,
+      });
+      await expect(requireGit("/repo", ["worktree", "add"])).rejects.toThrow(
+        "git worktree add failed (exit code 128):\nPreparing worktree\nUpdating files: 999/1000\nfatal: disk full",
+      );
+    },
+  );
+
+  it("bounds long diagnostic lines and keeps the useful tail", async () => {
+    failWith({ stderr: `${"x".repeat(30_000)}\nfatal: permission denied\n` });
+    const message = await failureMessage(["status"]);
+    expect(message.length).toBeLessThanOrEqual(2400);
+    expect(message).toContain("…");
+    expect(message).toMatch(/fatal: permission denied$/);
+  });
+
+  it("bounds newline progress and reports exit 124 without inventing a timeout", async () => {
+    failWith({ code: 124, stderr: progress.replaceAll("\r", "\n") });
+    const message = await failureMessage(["status"]);
+    expect(message.length).toBeLessThanOrEqual(2400);
+    expect(message.split("\n").length).toBeLessThanOrEqual(14);
+    expect(message).toContain("exit code 124");
+    expect(message).not.toMatch(/timed out|timeout/i);
+  });
+
+  it.each([
+    {
+      termination: "timeout",
+      signal: "SIGKILL",
+      code: 124,
+      expected: "timed out after 120 seconds; signal SIGKILL",
+    },
+    {
+      termination: "signal",
+      signal: "SIGTERM",
+      code: null,
+      expected: "signal SIGTERM",
+    },
+    {
+      termination: "signal",
+      signal: "SIGKILL",
+      outputLimitExceeded: true,
+      code: null,
+      expected: "output limit exceeded; signal SIGKILL",
+    },
+  ] satisfies Array<Partial<SpawnResult> & { expected: string }>)(
+    "reports $expected even when only progress was captured",
+    async ({ expected, ...metadata }) => {
+      failWith({ ...metadata, stderr: progress });
+      const message = await failureMessage(["worktree", "add"]);
+      expect(message).toContain(`failed (${expected})`);
+      expect(message.length).toBeLessThan(400);
+      expect(message).toContain("Updating files: 999/1000");
+      if (metadata.termination === "timeout") {
+        expect(message).toContain("Check repository access and disk space.");
+      } else {
+        expect(message).not.toMatch(/timed out|timeout/i);
+      }
+    },
+  );
+
+  it.each(["", " \t\r\n", `${String.fromCharCode(27)}[0m`])(
+    "uses stdout when stderr has no visible diagnostic: %j",
+    async (stderr) => {
+      failWith({ stderr, stdout: "error: cannot read index\n" });
+      await expect(requireGit("/repo", ["status"])).rejects.toThrow("error: cannot read index");
+    },
+  );
+});
+
+describe("successful Git output", () => {
+  it("keeps raw text byte-for-byte and preserves the trimmed text contract", async () => {
+    const stdout = " \u001b[31mname\u001b[0m\rredraw\0\r\n ";
+    vi.spyOn(processExec, "runCommandWithTimeout").mockResolvedValue({
+      ...failure,
+      code: 0,
+      stdout,
+    });
+    await expect(requireGitCommandRaw("/repo", ["status"])).resolves.toBe(stdout);
+    await expect(requireGitCommand("/repo", ["status"])).resolves.toBe(stdout.trim());
+  });
+
+  it("keeps binary output including invalid UTF-8 and terminal control bytes", async () => {
+    const stdout = Buffer.from([0, 255, 13, 10, 27, 91, 51, 49, 109, 32]);
+    vi.spyOn(processExec, "runCommandBuffered").mockResolvedValue({
+      ...failure,
+      code: 0,
+      stdout,
+      stderr: Buffer.alloc(0),
+    });
+    await expect(requireGitCommandBuffer("/repo", ["show"])).resolves.toEqual(stdout);
+  });
+});

--- a/src/infra/git-exec.ts
+++ b/src/infra/git-exec.ts
@@ -1,18 +1,14 @@
-import { runCommandBuffered, runCommandWithTimeout } from "../process/exec.js";
+import { sliceUtf16Safe, truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
+import { runCommandBuffered, runCommandWithTimeout, type SpawnResult } from "../process/exec.js";
 
 export const GIT_TIMEOUT_MS = 120_000;
-
-type GitCommandResult = {
-  stdout: string;
-  stderr: string;
-  code: number | null;
-};
 
 export async function executeGitCommand(
   cwd: string,
   args: string[],
   options: { env?: NodeJS.ProcessEnv; input?: string | Uint8Array } = {},
-): Promise<GitCommandResult> {
+): Promise<SpawnResult> {
   return await runCommandWithTimeout(["git", "-C", cwd, ...args], {
     timeoutMs: GIT_TIMEOUT_MS,
     env: options.env,
@@ -20,9 +16,46 @@ export async function executeGitCommand(
   });
 }
 
-export function createGitCommandError(command: string, result: GitCommandResult): Error {
-  const detail = (result.stderr || result.stdout).trim().split("\n").slice(-12).join("\n");
-  return new Error(`${command} failed${detail ? `:\n${detail}` : ""}`);
+export function createGitCommandError(
+  command: string,
+  result: SpawnResult | Awaited<ReturnType<typeof runCommandBuffered>>,
+): Error {
+  const output = stripAnsi(result.stderr.toString()).trim() || stripAnsi(result.stdout.toString());
+  // Git progress redraws use CR, not LF. Keep the last frame of each line,
+  // including an unfinished redraw, without changing successful command output.
+  const normalized = output
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/\r+$/, "").split("\r").at(-1) ?? "")
+    .join("\n")
+    .trim();
+  const tail = normalized.split("\n").slice(-12).join("\n");
+  const omitted = tail.length < normalized.length || tail.length > 2000;
+  const detail = `${omitted ? "…\n" : ""}${sliceUtf16Safe(tail, -2000)}`;
+  const reasons: string[] = [];
+  const timedOut = result.termination === "timeout";
+  if (timedOut) {
+    reasons.push(`timed out after ${GIT_TIMEOUT_MS / 1000} seconds`);
+  } else if (result.termination === "no-output-timeout") {
+    reasons.push("timed out waiting for output");
+  } else if (
+    result.termination === "output-limit" ||
+    ("outputLimitExceeded" in result && result.outputLimitExceeded)
+  ) {
+    reasons.push("output limit exceeded");
+  }
+  if (result.signal) {
+    reasons.push(`signal ${result.signal}`);
+  } else if (result.termination === "signal" && reasons.length === 0) {
+    reasons.push("terminated");
+  }
+  if (reasons.length === 0 && result.code !== null) {
+    reasons.push(`exit code ${result.code}`);
+  }
+  const label = truncateUtf16Safe(stripAnsi(command).replace(/[\r\n]+/g, " "), 256);
+  const reason = reasons.length > 0 ? ` (${reasons.join("; ")})` : "";
+  const nextStep = timedOut ? "\nCheck repository access and disk space." : "";
+  return new Error(`${label} failed${reason}${detail ? `:\n${detail}` : ""}${nextStep}`);
 }
 
 export async function requireGitCommand(
@@ -61,13 +94,7 @@ export async function requireGitCommandBuffer(
     ...(options.maxOutputBytes !== undefined ? { maxOutputBytes: options.maxOutputBytes } : {}),
   });
   if (result.code !== 0) {
-    const detail = (result.stderr.length > 0 ? result.stderr : result.stdout)
-      .toString("utf8")
-      .trim()
-      .split("\n")
-      .slice(-12)
-      .join("\n");
-    throw new Error(`git ${args.join(" ")} failed${detail ? `:\n${detail}` : ""}`);
+    throw createGitCommandError(`git ${args.join(" ")}`, result);
   }
   return result.stdout;
 }

--- a/src/snapshot/git-backup.test.ts
+++ b/src/snapshot/git-backup.test.ts
@@ -30,7 +30,14 @@ vi.mock("../infra/git-exec.js", async (importOriginal) => {
       ...args: Parameters<typeof actual.executeGitCommand>
     ): ReturnType<typeof actual.executeGitCommand> => {
       if (args[1][0] === "push" && mocks.pushDiagnostic) {
-        return { code: 1, stdout: "", stderr: mocks.pushDiagnostic };
+        return {
+          code: 1,
+          stdout: "",
+          stderr: mocks.pushDiagnostic,
+          signal: null,
+          killed: false,
+          termination: "exit",
+        };
       }
       return await actual.executeGitCommand(...args);
     },


### PR DESCRIPTION
Closes #131323

## What Problem This Solves

Fixes an issue where users creating a worktree through **New session** would see an error banner flooded with Git checkout progress when creation failed. The useful failure detail could be buried, and the message did not preserve the execution result needed to distinguish an actual timeout from a normal Git failure or signal.

## Why This Change Was Made

The shared Git diagnostic owner now collapses carriage-return redraws, strips ANSI formatting, bounds the final diagnostic tail to 12 lines/2,000 characters, and bounds the command label. Text, raw-text, and buffered Git failures use the same formatter and retain actual termination, signal, and exit facts; a confirmed timeout includes a concrete next step. Successful raw and binary output is unchanged. This does not change timeouts, retries, repository setup, cleanup authority, or UI layout.

The newline-only formatter was carried forward unchanged in #122485 (commit 37b4fc8621d98a3debbd2202d27f40aa039f386f, August 12, 2026; code author, PR author, and merger @steipete). It was already present in the worktree formatter in stable v2026.7.1-2; the shared-helper extraction was not the original introduction.

## User Impact

Failed Git operations show a compact diagnostic with the useful final error lines and the known termination reason. Operators can distinguish progress from the cause of failure and inspect partial worktree state before trying again. [Managed worktree troubleshooting](https://docs.openclaw.ai/concepts/managed-worktrees#troubleshoot-creation) documents that workflow.

AI-assisted, maintainer-authored change. The code and its failure/success contracts have been reviewed and understood.

## Evidence

- Pre-fix regression proof: 21 shared Git diagnostic failures and one real worktree-wrapper failure; the additional blank/ANSI-only stderr cases reproduced six failures before their fix.
- `node scripts/run-vitest.mjs src/infra/git-exec.test.ts src/agents/worktrees/git.test.ts src/agents/worktrees/service.test.ts src/agents/worktrees/service.hooks.test.ts src/snapshot/git-backup.test.ts` — 94 passed.
- `node scripts/run-vitest.mjs src/gateway/control-ui-session-prs.test.ts` — 19 passed. After fixture typing was refined with `satisfies`, the 32 infra tests and core test types were rerun successfully.
- `node scripts/check-changed.mjs -- src/infra/git-exec.ts src/infra/git-exec.test.ts src/agents/worktrees/git.ts src/agents/worktrees/git.test.ts src/snapshot/git-backup.test.ts src/gateway/control-ui-session-prs.test.ts docs/concepts/managed-worktrees.md` — passed production/test types, lint, formatting, dead-export checks, import cycles, and the selected guards. Two incomplete test fixtures initially failed typing and were corrected before the final green run.
- Real Git proof: `runGit(nonexistentPath, ['status'])` returns exit 128 and the fatal diagnostic through the worktree wrapper, without claiming a timeout.
- Same simulated timeout and 1,000 carriage-return progress updates: the error shrank from 30,867 to 194 characters, and from 1,000 progress entries to one. This is deterministic diagnostic proof, not live UI proof. The original banner stopped at 85% without a fatal tail; its lost termination metadata does **not** establish that the original incident timed out.
- Fresh precommit Codex autoreview covered all seven files, including the final fixture fixes, and reported no actionable findings at its requested P0 blocking threshold. No source edits followed that review.

- `pnpm build` — passed in 45m39s, including runtime/declaration bundles, CLI bootstrap imports, plugin SDK exports, and Control UI asset/performance checks. No `INEFFECTIVE_DYNAMIC_IMPORT` warning. Dependency `eval` and plugin-timing warnings were non-fatal.

- Exact-head [CI run 33132547773](https://github.com/openclaw/openclaw/actions/runs/33132547773) completed successfully at `d02a918d0a00bf937534d60570928ecc79fb84a5`. `node scripts/watch-pr-ci.mjs 131363 d02a918d0a00bf937534d60570928ecc79fb84a5` exited 0 with `GREEN` and zero pending checks. No test rerun or CI repair was needed; the watcher retried one changing-pagination read.

Visual-proof gap: two attempts through authenticated, extension-backed Chrome could read the operator page but could not operate local proof tabs, which were reported as restricted or unavailable to OpenClaw. Evaluation timed out at five seconds and click handles became stale. The original page contained private sidebar/session data and was not uploaded. The preview was stopped and the original tab restored. No before/after UI capture is claimed. This is a deterministic backend diagnostic repair with real Git owner-boundary proof, no UI source/layout change, and no external API change; the built CLI failure-flow verification below is complete. UI capture is skipped for the concrete browser-tool limitation above, not claimed as covered by the CLI proof.

- Built CLI / unmodified Git proof: `pnpm openclaw worktrees create <fixture-repo> --base-ref HEAD --name diagnostic-exit` ran against a disposable committed tree with a 300-character filename that the host filesystem cannot check out. The CLI exited 1 and reported `git worktree add failed (exit code 128)`, `File name too long`, and Git's fatal index diagnostic in 635 characters, without claiming a timeout. This completed in 8.925s with isolated HOME/state and cleanup of the fixture. No Git executable shim or operator state was used in the successful proof. This verifies the built CLI failure flow, not live UI rendering or a real timeout; timeout branches remain covered by the focused regressions.

Production LOC: +46/-23 (net +23). Tests: +179/-3 (net +176). Docs: +8. The production growth supplies the missing bounded-diagnostic and truthful-termination contracts after removing the duplicate buffered formatter and metadata-stripping result types. A UI-only truncation would leave other Git callers broken and still lose termination facts.

Known follow-up: setup/cleanup script diagnostics in `src/agents/worktrees/service.ts` still use newline-only formatting. That separate non-Git diagnostic owner is outside this repair and is tracked as a follow-up task.

ClawSweeper review follow-through: the [published review](https://github.com/openclaw/openclaw/pull/131363#issuecomment-5447357906) found no correctness/security defects and agreed that the shared formatter is the best repair boundary. Its two remaining items are resolved: exact-head CI run 33132547773 is successful, and the earlier local `pnpm docs:list` completed successfully with the managed-worktrees entry (the reviewer could not initialize Corepack cache in its read-only environment). Maintainer review accepts the +23 production lines for bounded diagnostics and truthful termination facts after duplicate formatter/type deletion. No code change or Rank-up skip is needed. The final built-CLI proof and accepted, explicitly documented browser-capture exception remain as described above; CLI proof is not UI rendering proof.
