### PR TITLE
fix(agents): expose queued run status in sessions_list tool

### DIFF
--- a/src/agents/tool-description-presets.test.ts
+++ b/src/agents/tool-description-presets.test.ts
@@ -27,7 +27,7 @@ const SESSION_DESCRIPTIONS = [
     tool: "sessions_list",
     describe: describeSessionsListTool,
     original:
-      "List visible sessions and sidebar categories; filter kind/label/agentId/search/activity/archive. Preview recent messages inline via includeLastMessage/messageLimit; includeDerivedTitles adds derived titles. Use before history/send target selection.",
+      "List visible sessions and sidebar categories; filter kind/label/agentId/search/activity/archive. Preview recent messages inline via includeLastMessage/messageLimit; includeDerivedTitles adds derived titles. Use before history/send target selection. A row `status` reflects the run lifecycle: `queued` means admitted and waiting to start (not idle — do not re-dispatch), `running` is executing, and `done`/`failed`/`killed`/`timeout` are terminal.",
   },
   {
     tool: "sessions_history",

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -69,6 +69,7 @@ export function describeSessionsListTool(options?: SessionLinkDescriptionOptions
     "List visible sessions and sidebar categories; filter kind/label/agentId/search/activity/archive.",
     "Preview recent messages inline via includeLastMessage/messageLimit; includeDerivedTitles adds derived titles.",
     "Use before history/send target selection.",
+    "A row `status` reflects the run lifecycle: `queued` means admitted and waiting to start (not idle — do not re-dispatch), `running` is executing, and `done`/`failed`/`killed`/`timeout` are terminal.",
     ...(options?.sessionLinkBase ? [describeSessionLinkRule(options.sessionLinkBase)] : []),
   ].join(" ");
 }

--- a/src/agents/tools/sessions-list-tool.test.ts
+++ b/src/agents/tools/sessions-list-tool.test.ts
@@ -396,7 +396,7 @@ describe("sessions-list-tool", () => {
       linkedDetails.sessionLinkRule,
     );
     expect(compactToolOutputHint(tool.outputSchema)).toBe(
-      '{ count: number; sessions: Array<{ agentId: string; archived: boolean; channel: string; key: string; kind: "main" | "group" | "cron" | "hook" | "node" | "other"; pinned: boolean; abortedLastRun?: boolean; category?: string; childSessions?: Array<string>; contextTokens?: number; derivedTitle?: string; displayName?: string; label?: string; lastMessagePreview?: string; messages?: Array<unknown>; model?: string; parentSessionKey?: string; sessionId?: string; stateVersion?: number; status?: "running" | "done" | "failed" | "killed" | "timeout"; totalTokens?: number; updatedAt?: number }>; sessionLinkRule?: string; visibility?: { mode: "self" | "tree" | "agent"; restricted: true; warning: string } }',
+      '{ count: number; sessions: Array<{ agentId: string; archived: boolean; channel: string; key: string; kind: "main" | "group" | "cron" | "hook" | "node" | "other"; pinned: boolean; abortedLastRun?: boolean; category?: string; childSessions?: Array<string>; contextTokens?: number; derivedTitle?: string; displayName?: string; label?: string; lastMessagePreview?: string; messages?: Array<unknown>; model?: string; parentSessionKey?: string; sessionId?: string; stateVersion?: number; status?: "queued" | "running" | "done" | "failed" | "killed" | "timeout"; totalTokens?: number; updatedAt?: number }>; sessionLinkRule?: string; visibility?: { mode: "self" | "tree" | "agent"; restricted: true; warning: string } }',
     );
     expect(result.details).toEqual({
       count: 1,
@@ -426,6 +426,34 @@ describe("sessions-list-tool", () => {
         },
       ],
     });
+  });
+
+  it("exposes the queued run status the Gateway produces for admitted-but-waiting sessions", async () => {
+    mocks.gatewayCall.mockResolvedValue({
+      path: "/tmp/sessions.json",
+      sessions: [
+        {
+          key: "agent:main:subagent:queued",
+          sessionId: "session-queued",
+          agentId: "main",
+          kind: "direct",
+          classification: "subagent",
+          channel: "discord",
+          spawnedBy: "agent:main:main",
+          updatedAt: 100,
+          archived: false,
+          pinned: false,
+          status: "queued",
+        },
+      ],
+    });
+    const tool = createSessionsListTool({ config: VALID_CONFIG });
+    const result = await tool.execute("queued-status", {});
+
+    expect(tool.outputSchema).toBeDefined();
+    expect(Value.Check(tool.outputSchema!, result.details)).toBe(true);
+    expect(getSessionsListDetails(result).sessions?.[0]?.status).toBe("queued");
+    expect(tool.description).toContain("queued");
   });
 
   it("preserves the context window already projected by the Gateway", async () => {

--- a/src/agents/tools/sessions-list-tool.ts
+++ b/src/agents/tools/sessions-list-tool.ts
@@ -86,6 +86,7 @@ const SessionListRowOutputSchema = Type.Object(
     totalTokens: Type.Optional(Type.Number()),
     status: Type.Optional(
       Type.Union([
+        Type.Literal("queued"),
         Type.Literal("running"),
         Type.Literal("done"),
         Type.Literal("failed"),
@@ -128,7 +129,8 @@ type GatewayCaller = AgentToolGatewayRequestCaller;
 const SESSIONS_LIST_TRANSCRIPT_FIELD_ROWS = 100;
 
 function readSessionRunStatus(value: unknown): SessionRunStatus | undefined {
-  return value === "running" ||
+  return value === "queued" ||
+    value === "running" ||
     value === "done" ||
     value === "failed" ||
     value === "killed" ||

--- a/src/gateway/server.sessions.list-queued-status.real-server.test.ts
+++ b/src/gateway/server.sessions.list-queued-status.real-server.test.ts
@@ -1,0 +1,103 @@
+// Real dev-Gateway proof that `sessions_list` accepts the Gateway's `queued`
+// lifecycle status.
+//
+// Unlike the handler-level tests in server.sessions.list-queued-status.test.ts,
+// this boots a real loopback Gateway server and drives it over a real WebSocket:
+// `chat.send` admits a run whose reply backend never starts executing (it stays
+// pending until we settle it), so the Gateway's own lifecycle reports the row as
+// `queued`, and `sessions.list` over that same WebSocket surfaces it.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "vitest";
+import type { WebSocket } from "ws";
+import {
+  mockGetReplyFromConfigOnce,
+  onceMessage,
+  rpcReq,
+  startConnectedServerWithClient,
+  testState,
+  writeSessionStore,
+} from "./test-helpers.js";
+import { setupGatewaySessionsHandlerTestHarness } from "./test/server-sessions.test-helpers.js";
+
+type WireFrame = {
+  type?: string;
+  id?: string;
+  ok?: boolean;
+  payload?: Record<string, unknown> | null;
+  error?: { code?: string; message?: string };
+};
+
+type SessionsRow = { key?: string; status?: string; hasActiveRun?: boolean };
+
+// Establishes the gateway test environment (config home, hooks, cleanup).
+setupGatewaySessionsHandlerTestHarness();
+
+test("real gateway reports an admitted-but-not-started run as queued through sessions.list", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-queued-real-"));
+  const sessionId = "sess-queued-real";
+  let started:
+    | { ws: WebSocket; port: number; server: { close: () => Promise<void> } }
+    | undefined;
+  try {
+    testState.sessionStorePath = path.join(dir, "sessions.json");
+    await writeSessionStore({
+      entries: {
+        main: {
+          sessionId,
+          sessionFile: path.join(dir, `${sessionId}.jsonl`),
+          updatedAt: Date.now(),
+        },
+      },
+    });
+
+    const { ws } = (started = await startConnectedServerWithClient());
+    const { promise: replySettled, resolve: settleReply } = defer<string>();
+
+    // chat.send admits the turn; the reply backend stays pending (never starts
+    // executing), so the run's lifecycle reports `queued` until we settle it.
+    mockGetReplyFromConfigOnce(async () => replySettled);
+
+    const send = await rpcReq(ws, "chat.send", {
+      sessionKey: "main",
+      message: "real gateway queued proof",
+      idempotencyKey: "real-queued-run",
+    });
+    expect(send.ok, JSON.stringify(send.error)).toBe(true);
+
+    const listPromise = onceMessage<WireFrame>(
+      ws,
+      (frame) => frame.type === "res" && frame.id === "real-queued-list",
+    );
+    ws.send(
+      JSON.stringify({
+        type: "req",
+        id: "real-queued-list",
+        method: "sessions.list",
+        params: {},
+      }),
+    );
+    const res = await listPromise;
+    const sessions = ((res.payload ?? {}) as { sessions?: SessionsRow[] }).sessions ?? [];
+    const row = sessions.find((row) => row.key === "agent:main:main");
+
+    expect(row?.status).toBe("queued");
+    expect(row?.hasActiveRun).toBe(true);
+
+    // Settle the pending reply so the run drains cleanly before teardown.
+    settleReply('{ "text": "done" }');
+    await replySettled.catch(() => undefined);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    await started?.server.close().catch(() => undefined);
+  }
+});
+
+function defer<T = unknown>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}

--- a/src/gateway/server.sessions.list-queued-status.test.ts
+++ b/src/gateway/server.sessions.list-queued-status.test.ts
@@ -1,0 +1,111 @@
+// Real-call proof that `sessions.list` produces `status: "queued"` for an
+// admitted-but-not-executing run and that the `sessions_list` agent tool
+// propagates it instead of dropping it.
+import { expect, test } from "vitest";
+import type { AgentToolGatewayRequestCaller } from "../agents/tools/in-process-gateway.js";
+import { createSessionsListTool } from "../agents/tools/sessions-list-tool.js";
+import { type ChatAbortControllerEntry, registerChatAbortController } from "./chat-abort.js";
+import { writeSessionStore } from "./test-helpers.js";
+import {
+  directSessionReq,
+  setupGatewaySessionsHandlerTestHarness,
+} from "./test/server-sessions.test-helpers.js";
+
+const { createSessionStoreDir } = setupGatewaySessionsHandlerTestHarness();
+
+type SessionsListRow = {
+  key?: string;
+  sessionId?: string;
+  status?: string;
+  hasActiveRun?: boolean;
+};
+
+test("sessions.list projects a tracked-but-not-started run as status=queued", async () => {
+  await createSessionStoreDir();
+  const sessionId = "sess-queued";
+  const sessionKey = "agent:main:queued";
+  await writeSessionStore({
+    entries: { queued: { sessionId, updatedAt: 1 } },
+  });
+
+  // Register a real tracked run that has not started executing. The Gateway
+  // derives `status: "queued"` from matchingTrackedRuns.length > 0 with no
+  // executionStarted (session-active-runs.ts:205-210).
+  const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+  const registration = registerChatAbortController({
+    chatAbortControllers,
+    runId: "queued-run",
+    sessionId,
+    sessionKey,
+    agentId: "main",
+    timeoutMs: 60_000,
+    kind: "agent",
+  });
+
+  const result = await directSessionReq<{ sessions: SessionsListRow[] }>(
+    "sessions.list",
+    { includeUnknown: true },
+    { context: { chatAbortControllers } as never },
+  );
+
+  expect(result.ok).toBe(true);
+  const row = result.payload?.sessions.find((session) => session.key === sessionKey);
+  expect(row?.hasActiveRun).toBe(true);
+  expect(row?.status).toBe("queued");
+
+  registration.cleanup({ force: true });
+});
+
+test("sessions_list agent tool propagates the Gateway's queued status", async () => {
+  await createSessionStoreDir();
+  const sessionId = "sess-queued-tool";
+  const sessionKey = "agent:main:queued-tool";
+  await writeSessionStore({
+    entries: { "queued-tool": { sessionId, updatedAt: 1 } },
+  });
+
+  const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+  const registration = registerChatAbortController({
+    chatAbortControllers,
+    runId: "queued-run-tool",
+    sessionId,
+    sessionKey,
+    agentId: "main",
+    timeoutMs: 60_000,
+    kind: "agent",
+  });
+
+  // Wire the tool's gateway call to the REAL sessions.list handler. No mock:
+  // the handler reads the seeded session store and computes the queued status
+  // from the tracked run registered above.
+  const callGateway: AgentToolGatewayRequestCaller = async (request) => {
+    const response = await directSessionReq<{ sessions: SessionsListRow[] }>(
+      "sessions.list",
+      (request.params ?? {}) as Record<string, unknown>,
+      { context: { chatAbortControllers } as never },
+    );
+    if (!response.ok) {
+      throw new Error(`sessions.list failed: ${response.error?.message ?? "unknown"}`);
+    }
+    return {
+      sessions: response.payload?.sessions ?? [],
+      hasMore: false,
+      nextOffset: null,
+    } as never;
+  };
+
+  const tool = createSessionsListTool({
+    config: {
+      agents: { entries: { main: { default: true } } },
+      tools: { sessions: { visibility: "all" } },
+    } as never,
+    callGateway,
+  });
+
+  const output = await tool.execute("queued-tool-proof", {});
+  const details = output.details as { sessions?: SessionsListRow[] };
+  const row = details.sessions?.find((session) => session.key === sessionKey);
+  expect(row?.status).toBe("queued");
+
+  registration.cleanup({ force: true });
+});

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1087,7 +1087,7 @@
       },
       {
         "deferLoading": true,
-        "description": "List visible sessions and sidebar categories; filter kind/label/agentId/search/activity/archive. Preview recent messages inline via includeLastMessage/messageLimit; includeDerivedTitles adds derived titles. Use before history/send target selection.",
+        "description": "List visible sessions and sidebar categories; filter kind/label/agentId/search/activity/archive. Preview recent messages inline via includeLastMessage/messageLimit; includeDerivedTitles adds derived titles. Use before history/send target selection. A row `status` reflects the run lifecycle: `queued` means admitted and waiting to start (not idle — do not re-dispatch), `running` is executing, and `done`/`failed`/`killed`/`timeout` are terminal.",
         "inputSchema": {
           "properties": {
             "activeMinutes": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=5b4b164ad416cb871634c615e6e1abfbfa509da37945ea1215e43d4f6998029b
-+++ discord-group-codex-message-tool.md	sha256=e165bae0dd776c27549f7196ff1b0fd1fb20a998ebe0d8da9f4a4d1e04324ba5
+--- telegram-direct-codex-message-tool.md	sha256=d3b247e55a177345d9aae3c59d2ec4c8b6df11adafc1eb096bfb926ec62cec8b
++++ discord-group-codex-message-tool.md	sha256=7bacd884e4d0d39410fa8666188b42fd714374456b23ea98d4bc67674f9ded9c
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -29,10 +29,10 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.discord-group.json",
 @@ -235,2 +235,2 @@
--    "chars": 55447,
--    "roughTokens": 13862
-+    "chars": 55755,
-+    "roughTokens": 13939
+-    "chars": 55645,
+-    "roughTokens": 13912
++    "chars": 55953,
++    "roughTokens": 13989
 @@ -239,2 +239,2 @@
 -    "chars": 3518,
 -    "roughTokens": 880
@@ -44,10 +44,10 @@
 +    "chars": 28944,
 +    "roughTokens": 7236
 @@ -247,2 +247,2 @@
--    "chars": 82913,
--    "roughTokens": 20729
-+    "chars": 84701,
-+    "roughTokens": 21176
+-    "chars": 83111,
+-    "roughTokens": 20778
++    "chars": 84899,
++    "roughTokens": 21225
 @@ -251,2 +251,2 @@
 -    "chars": 863,
 -    "roughTokens": 216

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -232,8 +232,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 55447,
-    "roughTokens": 13862
+    "chars": 55645,
+    "roughTokens": 13912
   },
   "openClawDeveloperInstructions": {
     "chars": 3518,
@@ -244,8 +244,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6866
   },
   "totalWithDynamicToolsJson": {
-    "chars": 82913,
-    "roughTokens": 20729
+    "chars": 83111,
+    "roughTokens": 20778
   },
   "userInputText": {
     "chars": 863,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=5b4b164ad416cb871634c615e6e1abfbfa509da37945ea1215e43d4f6998029b
-+++ telegram-heartbeat-codex-tool.md	sha256=1d575d3564e0435c836b6396cc7aa98a3ffdfc0e91ab479f1eb50a62c3d4b303
+--- telegram-direct-codex-message-tool.md	sha256=d3b247e55a177345d9aae3c59d2ec4c8b6df11adafc1eb096bfb926ec62cec8b
++++ telegram-heartbeat-codex-tool.md	sha256=d88cb76a91cc2b9eb5568d6814e4f6cc95caf3a717fb71afc0395dd24a1a2cff
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -32,20 +32,20 @@
 -    "dynamicToolsFrom": "codex-dynamic-tools.telegram-direct.json",
 +    "dynamicToolsFrom": "codex-dynamic-tools.heartbeat-turn.json",
 @@ -235,2 +230,2 @@
--    "chars": 55447,
--    "roughTokens": 13862
-+    "chars": 56940,
-+    "roughTokens": 14235
+-    "chars": 55645,
+-    "roughTokens": 13912
++    "chars": 57138,
++    "roughTokens": 14285
 @@ -243,2 +238,2 @@
 -    "chars": 27464,
 -    "roughTokens": 6866
 +    "chars": 27806,
 +    "roughTokens": 6952
 @@ -247,2 +242,2 @@
--    "chars": 82913,
--    "roughTokens": 20729
-+    "chars": 84748,
-+    "roughTokens": 21187
+-    "chars": 83111,
+-    "roughTokens": 20778
++    "chars": 84946,
++    "roughTokens": 21237
 @@ -251,2 +246,2 @@
 -    "chars": 863,
 -    "roughTokens": 216


### PR DESCRIPTION
## What Problem This Solves

The `sessions_list` agent tool silently dropped the `queued` session-run status that the Gateway produces for admitted-but-not-executing runs. When a parent agent used `sessions_list` to monitor a child session that was admitted but not yet executing, the row arrived with **no `status` field at all**, so the agent misread "queued / waiting to start" as "no active run" and could re-dispatch duplicate work or report nothing happening.

This is a tool-schema parity gap: the underlying Gateway session row schema has 6 status values, but the agent-facing tool only exposed 5. `queued` is already a shipped Gateway contract (#125654 exposed it across Gateway protocol, Web, Android, and Apple), but the agent tool layer was never updated to propagate it.

Fixes #131012.

## Why This Change Was Made

The Gateway already produces `status: "queued"` for sessions with tracked runs that have not started executing (`src/gateway/server-methods/session-active-runs.ts:205-210`), and `sessions.list` propagates it into the returned row (`src/gateway/server-methods/sessions-read.ts:435`). The `sessions_list` tool then re-filtered the Gateway row through `readSessionRunStatus`, which only accepted 5 values and mapped `queued` to `undefined`, omitting `row.status` from the tool output.

The fix mirrors the underlying Gateway schema (`packages/gateway-protocol/src/schema/sessions-row.ts:81-90`) in the tool:

1. Add `Type.Literal("queued")` to the `status` union in `SessionListRowOutputSchema` (`src/agents/tools/sessions-list-tool.ts`).
2. Accept `"queued"` in `readSessionRunStatus` so the status is propagated instead of dropped.
3. Surface status semantics in `describeSessionsListTool` so the model interprets `queued` as "admitted, waiting to start" and does not re-dispatch.

This is an owner-boundary change: the tool owns only filtering/narrowing of the Gateway row, and `queued` is a shipped Gateway contract, not a new product decision. The `SessionRunStatus` type (derived from the Gateway schema) already included `queued`, so no type contract changed.

### Production LOC

The 3 net production lines are the minimum owner-boundary alignment with the shipped Gateway schema and cannot be absorbed net-neutral without dropping the fix:

- `Type.Literal("queued")` in the output schema union — the tool must declare every status it propagates; omitting it makes `Value.Check` reject a `queued` row (`sessions-list-tool.test.ts:392` asserts schema validity).
- `value === "queued" ||` in `readSessionRunStatus` — the filter function is the single place that narrows the Gateway row; without this branch it maps `queued` → `undefined`, which is the bug.
- The description line — without it the model sees an undocumented `queued` value and may still treat it as idle, defeating the fix.

Each line closes a distinct boundary (schema declaration, runtime filter, model guidance); none duplicates another. The alternative — deriving the union from the Gateway schema type — would add an import coupling the agent tool to the gateway-protocol package, which the tool currently avoids by owning its narrow output schema.

## User Impact

A parent agent that spawns a child session and polls `sessions_list` now sees `status: "queued"` for a session that is admitted but waiting to start (e.g. behind a concurrency slot). The agent can distinguish "queued / waiting to start" from "no active run", avoiding duplicate re-dispatch and letting it report the true state. The tool description now documents the full status lifecycle so the model does not misinterpret `queued` as idle.

## Evidence

**Real dev-Gateway proof (fresh, rebased + review response):** `src/gateway/server.sessions.list-queued-status.real-server.test.ts`

This boots a **real loopback Gateway server** (`startConnectedServerWithClient`) and drives it over a real WebSocket — not a mock and not an in-process handler call. `chat.send` admits a run whose reply backend stays pending (we only mock the reply resolution, never run status), so the Gateway's **own lifecycle** flags the row `queued` (admitted, execution not started). A second RPC then reads `sessions.list` on that same live server, and the real server returns the row with `status: "queued"`:

```json
{
  "key": "agent:main:main",
  "sessionId": "sess-queued-real",
  "status": "queued",
  "hasActiveRun": true,
  "activeRunIds": ["real-queued-run"]
}
```

This is the requested real dev-Gateway output: a concurrency-queued (admitted-but-not-started) run is produced by the real Gateway and returned by `sessions.list` over a real transport.

```
src/gateway/server.sessions.list-queued-status.real-server.test.ts:
  Test Files  1 passed (1)
       Tests  1 passed (1)
  (real loopback Gateway server + real WebSocket chat.send → sessions.list)
```

**Root cause (source):**
- Gateway schema has `queued`: `packages/gateway-protocol/src/schema/sessions-row.ts:81-90`
- Gateway produces `queued` for admitted-but-not-started runs: `src/gateway/server-methods/session-active-runs.ts:205-210`
- `sessions.list` propagates it into the row: `src/gateway/server-methods/sessions-read.ts:435`
- Tool read-side dropped `queued` → `undefined`: `src/agents/tools/sessions-list-tool.ts` (`readSessionRunStatus`)

**Real-call proof (no mocks in the gateway→tool path):** `src/gateway/server.sessions.list-queued-status.test.ts`

Both tests seed a real session store and register a **real** tracked-but-not-started run via `registerChatAbortController` (no `markExecutionStarted`), so the run is admitted but not executing — the exact concurrency-queued state. They then drive the **real** `sessions.list` handler through `directSessionReq` (no mock `gatewayCall`).

Test 1 — Gateway real call: asserts the real handler output row has `hasActiveRun === true` and `status === "queued"` for the tracked-but-not-started run.

Test 2 — Tool real call: wires the `sessions_list` tool's `callGateway` to the **real** `sessions.list` handler (no mock), with the same seeded queued session, and asserts the tool output row has `status: "queued"`. This is the after-fix agent tool flow observing a concurrency-queued child.

Redacted real handler output (Test 1, captured from the real `sessions.list` handler over a real tracked run):
```json
{
  "key": "agent:main:queued",
  "sessionId": "sess-queued",
  "hasActiveRun": true,
  "status": "queued"
}
```

After the fix, the same row reaches the `sessions_list` tool output with `status: "queued"` intact (Test 2). Pre-fix, `readSessionRunStatus` mapped `queued` → `undefined` and the tool omitted `row.status`.

**Regression proof (fails on pre-fix code):** with the `readSessionRunStatus` `queued` branch reverted, Test 2 fails with `expected undefined to be 'queued'` (the tool dropped `queued` → `row.status` omitted), while Test 1 still passes — pinning the bug to the tool layer, not the Gateway.

```
src/gateway/server.sessions.list-queued-status.real-server.test.ts (real loopback Gateway server):
  Test Files  1 passed (1)
       Tests  1 passed (1)

src/gateway/server.sessions.list-queued-status.test.ts (real-call harness, tool-propagates-queued boundary):
  Test Files  1 passed (1)
       Tests  2 passed (2)

src/agents/tools/sessions-list-tool.test.ts (unit + schema hint):
  Test Files  1 passed (1)
       Tests  31 passed (31)

src/agents/tool-description-presets.test.ts:
  Test Files  1 passed (1)
       Tests  4 passed (4)

Prompt snapshots: 7 files current (node --import tsx scripts/generate-prompt-snapshots.ts --check)
```

Pre-fix (reverted `queued` branch in `readSessionRunStatus`):
```
  × sessions_list agent tool propagates the Gateway's queued status
    AssertionError: expected undefined to be 'queued'
  ✓ sessions.list projects a tracked-but-not-started run as status=queued
  Tests  1 failed | 1 passed (2)
```

Production LOC: +3 (`sessions-list-tool.ts` +2, `tool-description-presets.ts` +1); test lines counted separately.
