### PR TITLE
fix(workers): evict quiescent live-event windows instead of rejecting new sessions

### DIFF
--- a/src/gateway/worker-environments/live-events.test.ts
+++ b/src/gateway/worker-environments/live-events.test.ts
@@ -24,6 +24,7 @@ import {
   claimAgentRunContext,
   clearAgentRunContext,
   getAgentRunContext,
+  getAgentRunContextOwnership,
   hasProjectedAgentRunForSession,
   releaseAgentRunContext,
   sweepStaleRunContexts,
@@ -783,6 +784,82 @@ describe("worker live events", () => {
     rx.clear();
     expect(getAgentRunContext(RUN)).toBeDefined();
     releaseAgentRunContext(RUN, gatewayClaim);
+  });
+
+  const farmIdentity = (n: number): Identity => ({
+    ...ID,
+    environmentId: `environment-farm-${n}`,
+    sessionId: `session-farm-${n}`,
+    runId: `run-farm-${n}`,
+    turnClaim: {
+      sessionId: `session-farm-${n}`,
+      claimId: `claim-farm-${n}`,
+      runId: `run-farm-${n}`,
+      placementGeneration: 4,
+      owner: { kind: "worker", environmentId: `environment-farm-${n}`, ownerEpoch: EPOCH },
+    },
+  });
+  const farmSession = (n: number, updatedAt = 20) =>
+    sessions.upsertSessionEntryCore(
+      { agentId: "main", sessionKey: `agent:main:farm-${n}`, storePath: store },
+      { sessionId: `session-farm-${n}`, updatedAt },
+    );
+  const farmStart = (count: number, maxSessions: number) => {
+    start({
+      maxSessions,
+      startupBindings: Array.from({ length: count }, (_, i) => binding(farmIdentity(i + 1))),
+      startupOwners: new Map(
+        Array.from({ length: count }, (_, i) => [`environment-farm-${i + 1}`, EPOCH]),
+      ),
+    });
+  };
+  const farmEvent = (n: number, seq: number, event: Params["event"]): Params => ({
+    runEpoch: EPOCH,
+    lastAckedSeq: seq - 1,
+    seq,
+    runId: `run-farm-${n}`,
+    event,
+  });
+
+  it("evicts the oldest quiescent window instead of rejecting new sessions at the cap", async () => {
+    await Promise.all([farmSession(1), farmSession(2), farmSession(3)]);
+    farmStart(3, 2);
+    for (const n of [1, 2]) {
+      ack(
+        farmEvent(n, 1, { kind: "assistant", payload: { text: "hi", delta: "hi" } }),
+        1,
+        farmIdentity(n),
+      );
+      // Turn completion releases the run context gateway-side; the window's
+      // stale activeRuns entry lingers until the next event revalidates it.
+      for (const claimId of getAgentRunContextOwnership(`run-farm-${n}`)?.claimIds ?? []) {
+        releaseAgentRunContext(`run-farm-${n}`, claimId);
+      }
+    }
+    // Both existing windows are quiescent per the run-context registry; the
+    // third session evicts the oldest instead of failing with capacity-exceeded.
+    ack(
+      farmEvent(3, 1, { kind: "assistant", payload: { text: "new", delta: "new" } }),
+      1,
+      farmIdentity(3),
+    );
+  });
+
+  it("rejects a new session only when every window has an active run", async () => {
+    await Promise.all([farmSession(1), farmSession(2), farmSession(3)]);
+    farmStart(3, 2);
+    for (const n of [1, 2]) {
+      ack(
+        farmEvent(n, 1, { kind: "assistant", payload: { text: "hi", delta: "hi" } }),
+        1,
+        farmIdentity(n),
+      );
+    }
+    fail(
+      farmEvent(3, 1, { kind: "assistant", payload: { text: "new", delta: "new" } }),
+      "capacity-exceeded",
+      farmIdentity(3),
+    );
   });
 
   it("rejects a compatible context held by an exclusive Gateway owner", () => {

--- a/src/gateway/worker-environments/live-events.ts
+++ b/src/gateway/worker-environments/live-events.ts
@@ -376,13 +376,9 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
         return resyncRequired(0);
       }
       if (windows.size >= maxSessions) {
-        // Sessions outliving their turns keep windows while attached, so a
-        // long-lived gateway crosses the cap on lifetime sessions, not load.
-        // Runs linger in activeRuns until a later event revalidates them, so a
-        // resting window can look busy; consult the run-context registry for
-        // real activity. Evict the oldest quiescent window — its session
-        // rebinds on the next event through the resync path. Reject only when
-        // every window still owns an active run (true concurrency limit).
+        // Attached sessions keep windows for the gateway's lifetime, so at the cap
+        // evict the oldest registry-quiescent window (stale activeRuns look busy);
+        // it rebinds via resync. Reject only when every window has an active run.
         let evicted = false;
         for (const candidate of windows.values()) {
           const busy = [...candidate.activeRuns.entries()].some(

--- a/src/gateway/worker-environments/live-events.ts
+++ b/src/gateway/worker-environments/live-events.ts
@@ -376,7 +376,29 @@ export function createWorkerLiveEventReceiver(options: WorkerLiveEventReceiverOp
         return resyncRequired(0);
       }
       if (windows.size >= maxSessions) {
-        return capacityExceeded();
+        // Sessions outliving their turns keep windows while attached, so a
+        // long-lived gateway crosses the cap on lifetime sessions, not load.
+        // Runs linger in activeRuns until a later event revalidates them, so a
+        // resting window can look busy; consult the run-context registry for
+        // real activity. Evict the oldest quiescent window — its session
+        // rebinds on the next event through the resync path. Reject only when
+        // every window still owns an active run (true concurrency limit).
+        let evicted = false;
+        for (const candidate of windows.values()) {
+          const busy = [...candidate.activeRuns.entries()].some(
+            ([runId, owned]) =>
+              getAgentRunContextOwnerStatus(runId, owned.claimId, owned.lifecycleGeneration) ===
+              "active",
+          );
+          if (!busy) {
+            clearWindow(candidate);
+            evicted = true;
+            break;
+          }
+        }
+        if (!evicted) {
+          return capacityExceeded();
+        }
       }
       window = {
         activeRuns: new Map(),

--- a/src/worker/worker-rpc-live-event-client.ts
+++ b/src/worker/worker-rpc-live-event-client.ts
@@ -183,7 +183,7 @@ export class WorkerLiveEventClient {
         return;
       }
       fenceForOwnershipError(this.connection, response.error);
-      throw new Error(response.error.message);
+      throw new Error(`${response.error.message}: ${response.error.details.reason}`);
     } catch (error) {
       if (
         error instanceof WorkerConnectionInterruptedError &&


### PR DESCRIPTION
## What Problem This Solves
Fixes #131305: a gateway hosting cloud-worker sessions permanently stops accepting new cloud-worker turns after ~128 lifetime sessions. A 50-session farm crosses this in three batches; every later turn fails with an unattributable "worker live event rejected".

## Why This Change Was Made
`createWorkerLiveEventReceiver` keeps one in-memory window per session, capped at `DEFAULT_MAX_SESSIONS = 128`, and only environment teardown evicts windows — but sessions that finish their turn stay attached (warm by design), so the cap counts lifetime sessions, not load. Two owner-level repairs:

- At the cap, `resolveOrCreateWindow` now evicts the oldest **quiescent** window instead of rejecting the new session. Quiescence is judged against the run-context registry (finished runs linger in `window.activeRuns` until a later event revalidates them, so a resting window looks busy without the registry check). The evicted session rebinds through the existing resync path on its next event. `capacity-exceeded` remains only when every window still owns a registry-active run — a true concurrency limit.
- The worker-side client now includes `details.reason` in the thrown error, so the operator-visible failure says `capacity-exceeded` (or `epoch-mismatch`, etc.) instead of a bare rejection — attributing this bug originally took a gateway-restart bisection.

## User Impact
Long-lived gateways running many worker sessions (the farm/BYO-node use case from #129979) no longer wedge after 128 sessions; live-event rejections are attributable from the error text.

## Evidence
- Live reproduction: stress phases of 10+50+60 sessions ran green (120 windows); the next batch completed exactly 8 turns (=128) and then **every** turn on every new session failed, surviving a clean node restart; gateway restart cleared it.
- Live proof on this branch's build: 135 sessions across three phases on one gateway lifetime — 135/135 turns completed, 135/135 workspace files reconciled, zero capacity errors.
- Regression tests fail pre-fix: eviction admits a new session at the cap when quiescent windows exist; capacity-exceeded still fires when every window owns an active run.
- `pnpm check:changed` green; worker + live-events suites green; autoreview (branch vs origin/main): no actionable findings.
