### PR TITLE
fix(ui): declutter Channels refresh controls

### DIFF
--- a/ui/src/pages/channels/view.pairing.ts
+++ b/ui/src/pages/channels/view.pairing.ts
@@ -11,6 +11,7 @@ import {
 } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
+import { renderChannelRefreshAction } from "./view.shared.ts";
 import type { ChannelsProps } from "./view.types.ts";
 
 function accountName(account: ChannelsPairingAccount): string {
@@ -164,23 +165,11 @@ export function renderChannelPairingQueue(props: ChannelsProps) {
           title: t("channels.pairing.title"),
           description: t("channels.pairing.subtitle"),
           ...(count > 0 ? { count } : {}),
-          actions: html`
-            <span class="settings-row__value">
-              ${props.canManagePairing && props.pairingLastSuccessAt
-                ? t("channels.hub.updatedAgo", {
-                    ago: formatRelativeTimestamp(props.pairingLastSuccessAt),
-                  })
-                : t("common.na")}
-            </span>
-            <button
-              type="button"
-              class="btn btn--sm"
-              ?disabled=${props.pairingLoading || !props.canManagePairing}
-              @click=${props.onPairingRefresh}
-            >
-              ${t("common.refresh")}
-            </button>
-          `,
+          actions: renderChannelRefreshAction({
+            updatedAt: props.canManagePairing ? props.pairingLastSuccessAt : null,
+            disabled: props.pairingLoading || !props.canManagePairing,
+            onRefresh: props.onPairingRefresh,
+          }),
         },
         !props.canManagePairing
           ? html`

--- a/ui/src/pages/channels/view.shared.ts
+++ b/ui/src/pages/channels/view.shared.ts
@@ -174,7 +174,7 @@ export function renderChannelRefreshAction(params: {
   return html`<openclaw-tooltip .content=${updatedLabel}>
     <button
       type="button"
-      class="btn btn--sm btn--icon"
+      class="btn btn--xs btn--icon"
       aria-label=${t("common.refresh")}
       ?disabled=${params.disabled}
       @click=${params.onRefresh}

--- a/ui/src/pages/channels/view.shared.ts
+++ b/ui/src/pages/channels/view.shared.ts
@@ -2,6 +2,7 @@
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
 import { html, nothing } from "lit";
 import type { ChannelAccountSnapshot } from "../../api/types.ts";
+import { icons } from "../../components/icons.ts";
 import { renderSettingsSection, renderSettingsStatus } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { channelSnapshotEntryIsActive, resolveChannelAccounts } from "../../lib/channels/index.ts";
@@ -160,6 +161,27 @@ export function renderChannelActionRow(actions: unknown) {
       <div class="settings-row__control">${actions}</div>
     </div>
   `;
+}
+
+export function renderChannelRefreshAction(params: {
+  updatedAt?: number | null;
+  disabled: boolean;
+  onRefresh: () => void;
+}) {
+  const updatedLabel = params.updatedAt
+    ? t("channels.hub.updatedAgo", { ago: formatRelativeTimestamp(params.updatedAt) })
+    : t("common.na");
+  return html`<openclaw-tooltip .content=${updatedLabel}>
+    <button
+      type="button"
+      class="btn btn--sm btn--icon"
+      aria-label=${t("common.refresh")}
+      ?disabled=${params.disabled}
+      @click=${params.onRefresh}
+    >
+      ${icons.refresh}
+    </button>
+  </openclaw-tooltip>`;
 }
 
 /** One account inside a multi-account channel group. */

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -88,6 +88,47 @@ function createProps(snapshot: ChannelsProps["snapshot"]): ChannelsProps {
   };
 }
 
+describe("channel hub refresh actions", () => {
+  it("keeps both timestamps in icon-button tooltips", () => {
+    const onRefresh = vi.fn();
+    const onPairingRefresh = vi.fn();
+    const props = createProps({
+      ts: Date.now(),
+      channelOrder: ["slack"],
+      channelLabels: { slack: "Slack" },
+      channels: { slack: { configured: true } },
+      channelAccounts: {},
+      channelDefaultAccountId: {},
+    });
+    props.lastSuccessAt = Date.now();
+    props.pairingLastSuccessAt = Date.now();
+    props.onRefresh = onRefresh;
+    props.onPairingRefresh = onPairingRefresh;
+    const container = document.createElement("div");
+
+    render(renderChannels(props), container);
+
+    const refreshButtons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('button[aria-label="Refresh"]'),
+    );
+    expect(refreshButtons).toHaveLength(2);
+    expect(refreshButtons.map((button) => button.textContent?.trim())).toEqual(["", ""]);
+    expect(container.textContent).not.toContain("Updated just now");
+    expect(
+      refreshButtons.map(
+        (button) =>
+          (button.closest("openclaw-tooltip") as (HTMLElement & { content?: string }) | null)
+            ?.content,
+      ),
+    ).toEqual(["Updated just now", "Updated just now"]);
+
+    refreshButtons[0]!.click();
+    refreshButtons[1]!.click();
+    expect(onPairingRefresh).toHaveBeenCalledOnce();
+    expect(onRefresh).toHaveBeenCalledWith(true);
+  });
+});
+
 describe("channels setup access", () => {
   it("replaces setup actions with an admin-required notice for non-admin viewers", () => {
     const onStartSetup = vi.fn();

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -28,7 +28,11 @@ import { formatUiExternalText } from "../../lib/format-error.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
 import { renderChannelDetail } from "./view.detail.ts";
 import { renderChannelPairingPrompt, renderChannelPairingQueue } from "./view.pairing.ts";
-import { channelEnabled, resolveChannelDisplayState } from "./view.shared.ts";
+import {
+  channelEnabled,
+  renderChannelRefreshAction,
+  resolveChannelDisplayState,
+} from "./view.shared.ts";
 import type { ChannelKey, ChannelsChannelData, ChannelsProps } from "./view.types.ts";
 import { renderChannelWizard } from "./wizard-view.ts";
 
@@ -67,23 +71,11 @@ export function renderChannels(props: ChannelsProps) {
         {
           title: t("channels.hub.connectedTitle"),
           ...(connected.length > 0 ? { count: connected.length } : {}),
-          actions: html`
-            <span class="settings-row__value">
-              ${props.lastSuccessAt
-                ? t("channels.hub.updatedAgo", {
-                    ago: formatRelativeTimestamp(props.lastSuccessAt),
-                  })
-                : t("common.na")}
-            </span>
-            <button
-              type="button"
-              class="btn btn--sm"
-              ?disabled=${props.loading}
-              @click=${() => props.onRefresh(true)}
-            >
-              ${t("common.refresh")}
-            </button>
-          `,
+          actions: renderChannelRefreshAction({
+            updatedAt: props.lastSuccessAt,
+            disabled: props.loading,
+            onRefresh: () => props.onRefresh(true),
+          }),
         },
         connected.length === 0
           ? html`

--- a/ui/src/styles/channels.css
+++ b/ui/src/styles/channels.css
@@ -2,7 +2,18 @@
    detail overlay, and the guided setup wizard dialog. Everything else uses the
    shared settings design language. */
 
-/* Row with a leading 44px art tile (mirrors the plugins hub row anatomy). */
+/* Compact refresh actions should not retain the spacing and top alignment
+   reserved for settings headers with full-size controls. */
+.settings-section:has(.settings-section__actions .btn--xs.btn--icon) {
+  gap: var(--space-2);
+}
+
+.settings-section__header:not(:has(.settings-section__desc)):has(
+  .settings-section__actions .btn--xs.btn--icon
+) {
+  align-items: center;
+}
+
 .channels-empty {
   display: grid;
   place-items: center;
@@ -18,6 +29,7 @@
   text-align: left;
 }
 
+/* Row with a leading 44px art tile (mirrors the plugins hub row anatomy). */
 .channels-tile {
   display: grid;
   width: var(--channels-art-size, 44px);

--- a/ui/src/styles/channels.css
+++ b/ui/src/styles/channels.css
@@ -8,10 +8,12 @@
   gap: var(--space-2);
 }
 
-.settings-section__header:not(:has(.settings-section__desc)):has(
-  .settings-section__actions .btn--xs.btn--icon
-) {
-  align-items: center;
+@media not all and (max-width: 640px) {
+  .settings-section__header:not(:has(.settings-section__desc)):has(
+    .settings-section__actions .btn--xs.btn--icon
+  ) {
+    align-items: center;
+  }
 }
 
 .channels-empty {

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -533,6 +533,17 @@
   padding-inline: 0;
 }
 
+.settings-section__actions .btn--xs.btn--icon {
+  width: 28px;
+  min-width: 28px;
+  height: 28px;
+}
+
+.settings-section__actions .btn--xs.btn--icon svg {
+  width: 16px;
+  height: 16px;
+}
+
 .settings-toggle {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Channels page repeated visible refresh labels and last-updated timestamps in each section header, adding avoidable visual weight.

## Why This Change Was Made

Both Channels header refresh actions now share one icon-button renderer built from the existing Lucide refresh glyph and tooltip component. The tooltip owns the last-updated timestamp while the button keeps an accessible Refresh name and unchanged loading/permission behavior.

## User Impact

Channels section headers are more compact. Hovering or keyboard-focusing either refresh icon reveals when that section was last updated.

## Evidence

- Focused Channels view tests: 37 passed
- Full changed-file gate: passed (format, i18n, typecheck, lint, repository guards)
- Regression proof: the new test failed against the pre-fix UI because neither refresh action had an icon-button accessible name or timestamp tooltip, then passed after the owner-boundary repair
- [Before/after/hover visual proof](https://github.com/openclaw/openclaw/pull/131367#issuecomment-5447270316)

Production LOC: +38/-35 (net +3); tests: +41/-0. The small production growth is the shared accessible renderer that keeps the two section actions from drifting.
