### PR TITLE
test(ui): await owner chip render completion

### DIFF
--- a/ui/src/components/session-owner-chip.test.ts
+++ b/ui/src/components/session-owner-chip.test.ts
@@ -19,6 +19,14 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+async function waitForChipUpdate(chip: OwnerChipElement) {
+  await chip.updateComplete;
+  // The parent's update does not include the nested avatar's render.
+  await Promise.all(
+    [...chip.querySelectorAll("openclaw-viewer-avatar")].map((avatar) => avatar.updateComplete),
+  );
+}
+
 async function mount(params: { participants?: SessionCreatedActor[]; participantCount?: number }) {
   // SAFETY: the imported module registers this custom element with these reactive properties.
   const chip = document.createElement("openclaw-session-owner-chip") as OwnerChipElement;
@@ -28,10 +36,8 @@ async function mount(params: { participants?: SessionCreatedActor[]; participant
   chip.participants = params.participants ?? [];
   chip.participantCount = params.participantCount ?? chip.participants.length;
   document.body.append(chip);
-  await vi.waitFor(async () => {
-    await chip.updateComplete;
-    expect(chip.querySelector(".session-owner-chip")).not.toBeNull();
-  });
+  await waitForChipUpdate(chip);
+  expect(chip.querySelector(".session-owner-chip")).not.toBeNull();
   return chip;
 }
 
@@ -72,11 +78,10 @@ it.each(["row", "header"] as const)(
       avatarUrl: "/avatar/research",
     };
     chip.size = size;
-    await vi.waitFor(() => {
-      expect(chip.querySelector(".session-owner-chip img")?.getAttribute("src")).toBe(
-        "/avatar/research",
-      );
-    });
+    await waitForChipUpdate(chip);
+    expect(chip.querySelector(".session-owner-chip img")?.getAttribute("src")).toBe(
+      "/avatar/research",
+    );
   },
 );
 


### PR DESCRIPTION
## What Problem This Solves

The session owner-chip tests spend two default 50 ms polling intervals waiting for Lit renders that expose their own completion promises. This makes the focused developer test run slower without adding coverage.

## Why This Change Was Made

Await the owner chip's `updateComplete`, then each nested `openclaw-viewer-avatar.updateComplete`, before asserting. The mount wait already awaited its owner and normally resolved on its first attempt; the row/header picture cases started their assertions before the reactive update and each paid one polling interval. All existing assertions and table cases remain.

Lit 3.3.3 / reactive-element 2.1.2 resolves an element's own update promise, not its children's renders. The OpenClaw light-DOM base adds locale invalidation but does not override that scheduling contract. The fixtures use relative avatar URLs with no connected Gateway/auth context, so the loader returns the trusted URL directly: there is no image-fetch completion or negative observation window to preserve here. Authenticated image-loading tests remain unchanged. See [Lit update completion](https://lit.dev/docs/components/lifecycle/#updatecomplete).

## User Impact

No product or visual behavior changes. The focused seven-test run is 7.14% faster by median wall time on one stable Linux Testbox. Production LOC: +0/-0. Tests: +14/-9 (net +5). No dependency, configuration, snapshot, baseline, or changelog changes. AI-assisted with Codex.

## Evidence

Benchmark base: `2026a7b47b1b9833dd36efc38feb4f014fd820ef`. One Blacksmith Testbox (`tbx_01m12yp5er2v5ffv9pgv6k8hhx`), Node 24.19.0, pnpm 11.22.0; [provisioning workflow](https://github.com/openclaw/openclaw/actions/runs/33132038207). The prepared environment uses a synthetic `remote-testbox-sync` commit; full content digests match for all 34,410 tracked local/remote paths. Provisioning/sync time is excluded from test-command wall time.

Before editing, the unchanged seven-test baseline passed. Then excluded one warmup per variant and measured eight paired samples, ordered AB/BA/BA/AB/AB/BA/BA/AB, with one worker, a distinct module cache per sample, import diagnostics, and `/usr/bin/time -v`:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 \
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/owner-chip-benchmark/cache-01-baseline \
OPENCLAW_VITEST_IMPORT_DURATIONS=1 \
OPENCLAW_VITEST_PRINT_IMPORT_BREAKDOWN=1 \
/usr/bin/time -v pnpm test ui/src/components/session-owner-chip.test.ts --maxWorkers=1 --reporter=verbose
```

| Median | Before | After |
| --- | ---: | ---: |
| Command wall | 1.421944 s | 1.320366 s |
| Vitest | 798 ms | 695 ms |
| Test bodies | 138.5 ms | 38 ms |
| Import | 176 ms | 169.5 ms |
| Max RSS | 560,894 KiB | 560,480 KiB |
| CPU user/system | 1.56/0.19 s | 1.57/0.20 s |
| Tests | 7 passed | 7 passed |

Median wall savings: 0.101579 s (7.14%). Pairwise wall gains: 10.70%, 6.39%, 3.61%, 9.01%, 9.95%, 5.73%, 4.61%, 5.97%. Every pair clears the 3% scoped-wall acceptance threshold. Test-body savings account for the improvement; CPU and RSS are effectively unchanged.

| Pair | Order | Before wall | After wall | Gain |
| --- | --- | ---: | ---: | ---: |
| 1 | AB | 1.427695 s | 1.274923 s | 10.70% |
| 2 | BA | 1.410904 s | 1.320761 s | 6.39% |
| 3 | BA | 1.424487 s | 1.373055 s | 3.61% |
| 4 | AB | 1.419401 s | 1.291557 s | 9.01% |
| 5 | AB | 1.443838 s | 1.300151 s | 9.95% |
| 6 | BA | 1.400165 s | 1.319971 s | 5.73% |
| 7 | BA | 1.395658 s | 1.331311 s | 4.61% |
| 8 | AB | 1.432836 s | 1.347319 s | 5.97% |

Reversible production fault proof, each restored byte-for-byte:

- Suppress owner-chip updates after the first render: both row/header image cases fail on the missing expected image source.
- Suppress nested viewer-avatar rendering: participant plus both row/header image cases fail.
- Drop the owner avatar URL passed to the child: both row/header image cases fail.
- Delay the child's real `scheduleUpdate` by a macrotask: all seven optimized tests still pass. Remove the explicit child await under that delay: participant plus both row/header cases fail. This confirms that the test does not depend on synchronous jsdom rendering.
- Restore all production/test bytes: all seven pass again; production diff remains empty.

Focused sibling proof: 118 tests in nine files pass in normal order and with shuffle seeds `131316` and `20260827`, one worker, separate caches, retaining the repository's shared/isolated routing. Scope includes owner chip, viewer facepile, identity-avatar view/resolver, Lit base/controller/settle helper, and chat-header integration/identity tests.

Test audit: protects real registered custom-element rendering, owner reassignment, participant stacking/count/accessibility, both row/header images and resolved sources, and owner-facet enrichment. Credible faults above are detected at the DOM boundary. Existing tests are improved in place, with no duplicate cases or test-only production seam; avatar-origin cleanup and mock restoration are retained. The generic Lit settle helper intentionally approximates deeper chains and is unnecessary for these explicit owner/child boundaries.

Formatting and `git diff --check` pass. Deslop found no changes needed. Fresh isolated Codex autoreview completed with no accepted/actionable findings. The complete `pnpm check:changed -- ui/src/components/session-owner-chip.test.ts` gate passed on the same Testbox (exit 0, 642.705 s), including all test-typecheck shards, i18n, guards, dead-export checks, formatting, and lint. After rebasing onto `ae0e25c5038`, 63 focused tests across five files also passed locally, including the updated tooltip dependency. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33132949317) passed for `26ad073ac55eeb9d18db2923c44ea9f556146218`: 57 successful jobs and 16 intentional skips, no failures/retries. The task-owned Testbox has been stopped (provider state `completed`).
