### PR TITLE
fix(config): preserve indexed and whole-list agent edits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@ Docs: https://docs.openclaw.ai
 - **Control UI Gateway labels:** keep the discovered machine name through recovery initialization and refresh open folder-browser labels when name discovery finishes.
 - **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
 - **Nextcloud Talk diagnostics:** redact reflected credentials before displaying send, reaction, and bot-preflight errors, and suppress incomplete error bodies. (#119976) Thanks @xialonglee.
-- **Config CLI roster edits:** preserve legacy indexed and whole-list mutations in the keyed agent roster, honor ordered mixed patches, and share write-time ownership preparation with read-only previews. (#131054)
 - **Control UI config drafts:** preserve external changes and newer Form or Raw edits across reconnects, including saves whose acknowledgments were lost, by keeping the draft's original document and write revision together.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
 - **Android gateway discovery:** resolve nearby gateways one at a time on Android 12 and 13 so simultaneously advertised gateways are not silently omitted.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI Gateway labels:** keep the discovered machine name through recovery initialization and refresh open folder-browser labels when name discovery finishes.
 - **Android settings:** keep form fields and actions reachable above the keyboard, and respect bottom system insets without duplicating navigation padding.
 - **Nextcloud Talk diagnostics:** redact reflected credentials before displaying send, reaction, and bot-preflight errors, and suppress incomplete error bodies. (#119976) Thanks @xialonglee.
+- **Config CLI roster edits:** preserve legacy indexed and whole-list mutations in the keyed agent roster, honor ordered mixed patches, and share write-time ownership preparation with read-only previews. (#131054)
 - **Control UI config drafts:** preserve external changes and newer Form or Raw edits across reconnects, including saves whose acknowledgments were lost, by keeping the draft's original document and write revision together.
 - Codex image attachments: decode mixed-case `file://` URLs as local image paths while preserving existing file URL validation and platform behavior. (#121611) Thanks @sunlit-deng.
 - **Android gateway discovery:** resolve nearby gateways one at a time on Android 12 and 13 so simultaneously advertised gateways are not silently omitted.

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2370,7 +2370,7 @@ src/cli/completion-runtime.ts	4
 src/cli/config-cli-input.ts	3
 src/cli/config-cli-path.ts	6
 src/cli/config-cli-runner.ts	7
-src/cli/config-cli.ts	11
+src/cli/config-cli.ts	8
 src/cli/config-model-validation.ts	7
 src/cli/config-set-input.ts	2
 src/cli/connect-cli.ts	1
@@ -2662,11 +2662,11 @@ src/config/io.snapshot.ts	1
 src/config/io.warnings.ts	2
 src/config/io.write-prepare.ts	16
 src/config/io.write-safety.ts	4
-src/config/io.write.ts	13
+src/config/io.write.ts	10
 src/config/issue-location.ts	2
 src/config/legacy-private-network-migration.ts	1
 src/config/legacy.default-agent-roles.ts	1
-src/config/legacy.roster.ts	15
+src/config/legacy.roster.ts	13
 src/config/legacy.ts	3
 src/config/markdown-tables.ts	3
 src/config/materialize.ts	2

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -56,6 +56,13 @@ openclaw config get agents.entries
 openclaw config set 'agents.entries.work.tools.exec.node' "node-id-or-name"
 ```
 
+Prefer `agents.entries.<id>` paths for agent edits. The legacy `agents.list[0]`
+syntax and whole-list inputs still work with `set`, `patch`, and `unset`; writes
+persist the canonical keyed roster. Indexed edits use the current roster order.
+Within a batch, a submitted list keeps its order across subsequent keyed edits,
+including when agent IDs are numeric strings. Existing roster-deletion and
+`$include` ownership protections still apply.
+
 ### `config get`
 
 Reads a value from the redacted config snapshot (secrets never print). `--json` prints the same redacted value as JSON; otherwise strings/numbers/booleans print bare and objects/arrays print as formatted JSON.

--- a/src/cli/config-cli-roster.ts
+++ b/src/cli/config-cli-roster.ts
@@ -33,11 +33,15 @@ export class ConfigMutationAgentRoster {
     const submittedRoster =
       path.length === 1 ? readAgentRosterProperty({ agents: operation.value }) : undefined;
     const kind = path.length === 1 ? submittedRoster?.kind : path[1];
+    const roster = readAgentRosterProperty(this.root);
+    // A removed roster's indexes cannot select entries in its replacement.
+    if (!roster) {
+      this.legacyOrder = undefined;
+    }
     const agents = this.root.agents;
     if ((kind !== "list" && kind !== "entries") || !isRecord(agents)) {
       return;
     }
-    const roster = readAgentRosterProperty(this.root);
     if (kind === "entries") {
       if (path.length <= 2 && !merge) {
         delete agents.list;

--- a/src/cli/config-cli-roster.ts
+++ b/src/cli/config-cli-roster.ts
@@ -42,11 +42,15 @@ export class ConfigMutationAgentRoster {
     if ((kind !== "list" && kind !== "entries") || !isRecord(agents)) {
       return;
     }
+    // Whole replacements discard the old representation without validating it.
+    // A list deletion still needs projection so unset can find its keyed target.
+    if (path.length <= 2 && !merge && (kind === "entries" || operation.mutation !== "delete")) {
+      delete agents[kind === "entries" ? "list" : "entries"];
+      this.legacyOrder = undefined;
+      return;
+    }
     if (kind === "entries") {
-      if (path.length <= 2 && !merge) {
-        delete agents.list;
-        this.legacyOrder = undefined;
-      } else if (roster?.kind === "list") {
+      if (roster?.kind === "list") {
         this.canonicalize(true);
       }
       return;

--- a/src/cli/config-cli-roster.ts
+++ b/src/cli/config-cli-roster.ts
@@ -1,0 +1,115 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { readAgentRosterProperty } from "../agents/agent-scope-config.js";
+import { parseLegacyAgentRoster } from "../config/legacy.roster.js";
+import type { ConfigSetOperation } from "./config-cli-input.js";
+import { getAtPath, type PathSegment } from "./config-cli-path.js";
+
+/** Keeps the documented list input and keyed input on one mutable roster. */
+export class ConfigMutationAgentRoster {
+  private legacyOrder: string[] | undefined;
+
+  constructor(
+    private readonly root: Record<string, unknown>,
+    sourceConfigBeforeMigrations: unknown,
+  ) {
+    const sourceRoster = readAgentRosterProperty(sourceConfigBeforeMigrations);
+    this.legacyOrder =
+      sourceRoster?.kind === "list" ? parseLegacyAgentRoster(sourceRoster.value)?.order : undefined;
+  }
+
+  prepare(operation: ConfigSetOperation, merge: boolean): void {
+    const path = operation.setPath;
+    if (path[0] !== "agents") {
+      return;
+    }
+    if (
+      path.length === 1 &&
+      isRecord(operation.value) &&
+      Object.hasOwn(operation.value, "list") &&
+      Object.hasOwn(operation.value, "entries")
+    ) {
+      throw new Error("Set either agents.list or agents.entries in one value, not both.");
+    }
+    const submittedRoster =
+      path.length === 1 ? readAgentRosterProperty({ agents: operation.value }) : undefined;
+    const kind = path.length === 1 ? submittedRoster?.kind : path[1];
+    const agents = this.root.agents;
+    if ((kind !== "list" && kind !== "entries") || !isRecord(agents)) {
+      return;
+    }
+    const roster = readAgentRosterProperty(this.root);
+    if (kind === "entries") {
+      if (path.length <= 2 && !merge) {
+        delete agents.list;
+        this.legacyOrder = undefined;
+      } else if (roster?.kind === "list") {
+        this.canonicalize(true);
+      }
+      return;
+    }
+    if (roster?.kind !== "entries") {
+      return;
+    }
+    if (
+      !isRecord(roster.value) ||
+      Object.values(roster.value).some((entry) => !isRecord(entry) || Object.hasOwn(entry, "id"))
+    ) {
+      throw new Error(
+        "Cannot address agents.list while agents.entries contains invalid entries; correct the keyed roster first.",
+      );
+    }
+    const entries = roster.value;
+    // Integer-like ids enumerate numerically in objects. A keyed leaf edit must not
+    // change the index selected by a later operation in the same submitted list.
+    const order = [...new Set([...(this.legacyOrder ?? []), ...Object.keys(entries)])].filter(
+      (id) => Object.hasOwn(entries, id),
+    );
+    const list = [];
+    for (const id of order) {
+      // SAFETY: The roster check above rejects non-record entries and conflicting in-entry ids.
+      list.push({ ...(entries[id] as Record<string, unknown>), id });
+    }
+    agents.list = list;
+    delete agents.entries;
+  }
+
+  writePath(path: PathSegment[]): PathSegment[] {
+    if (path[0] !== "agents" || path[1] !== "list") {
+      return path;
+    }
+    if (path.length === 2) {
+      const roster = readAgentRosterProperty(this.root);
+      return roster?.kind === "list" && parseLegacyAgentRoster(roster.value)
+        ? ["agents", "entries"]
+        : path;
+    }
+    const entry = getAtPath(this.root, path.slice(0, 3));
+    const roster = entry.found ? parseLegacyAgentRoster([entry.value]) : undefined;
+    const id = roster?.order[0];
+    return id === undefined ? path : ["agents", "entries", id, ...path.slice(3)];
+  }
+
+  finish(): void {
+    this.canonicalize(false);
+  }
+
+  private canonicalize(required: boolean): void {
+    const agents = this.root.agents;
+    const roster = readAgentRosterProperty(this.root);
+    if (!isRecord(agents) || roster?.kind !== "list") {
+      return;
+    }
+    const parsed = parseLegacyAgentRoster(roster.value);
+    if (!parsed) {
+      if (required) {
+        throw new Error(
+          "Cannot address agents.entries while agents.list contains invalid or duplicate ids; correct the list first.",
+        );
+      }
+      return;
+    }
+    this.legacyOrder = parsed.order;
+    agents.entries = parsed.entries;
+    delete agents.list;
+  }
+}

--- a/src/cli/config-cli-runner.ts
+++ b/src/cli/config-cli-runner.ts
@@ -1,7 +1,9 @@
 import { isDeepStrictEqual } from "node:util";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
+import { resolveManagedUnsetPathsForWrite } from "../config/config-path-mutation.js";
 import { replaceConfigFile } from "../config/config.js";
 import { AUTO_MANAGED_CONFIG_META_PATHS } from "../config/io.meta.js";
+import { prepareConfigWriteTopology } from "../config/io.write-topology.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { ConfigMutationConflictError } from "../config/mutation-conflict.js";
 import { resolveConfigPath } from "../config/paths.js";
@@ -30,13 +32,16 @@ import {
 import {
   assertNonDestructiveReplacement,
   formatConfigSetPath,
+  formatConfigUnsetMissingPathMessage,
   getAtPath,
   mergeAtPath,
+  parseConfigSetPath,
   setAtPath,
   type JsonSchemaRecord,
   type PathSegment,
   unsetAtPath,
 } from "./config-cli-path.js";
+import { ConfigMutationAgentRoster } from "./config-cli-roster.js";
 import {
   assertStrictConfigForMutation,
   collectDryRunRefs,
@@ -138,15 +143,6 @@ function formatAutoManagedMetaError(paths: readonly PathSegment[][]): string {
   ].join("\n");
 }
 
-export function assertConfigPathIsNotAutoManaged(path: PathSegment[]): void {
-  const targets = findAutoManagedMetaTargets([
-    { inputMode: "json", requestedPath: path, setPath: path, value: undefined, mutation: "delete" },
-  ]);
-  if (targets.length > 0) {
-    throw new Error(formatAutoManagedMetaError(targets));
-  }
-}
-
 function pruneInactiveGatewayAuthCredentials(params: {
   root: Record<string, unknown>;
   operations: ConfigSetOperation[];
@@ -222,7 +218,7 @@ function expandActualChangedPaths(
   return [...expanded];
 }
 
-export function configApplyHintForOperations(
+function configApplyHintForOperations(
   operations: ReadonlyArray<{ requestedPath?: PathSegment[] }>,
   beforeConfig: OpenClawConfig,
   afterConfig: OpenClawConfig,
@@ -303,18 +299,73 @@ export async function runConfigOperations(params: {
     structuredClone(snapshot.resolved) as OpenClawConfig,
   );
   const mutationSchema = await loadMutationSchema();
-  const unsetPaths: PathSegment[][] = [];
+  const roster = new ConfigMutationAgentRoster(next, snapshot.sourceConfigBeforeMigrations);
+  let unsetPaths: PathSegment[][] = [];
   const explicitSetPaths: PathSegment[][] = [];
+  const appliedOperations: ConfigSetOperation[] = [];
+  const recordOperation = (operation: ConfigSetOperation): PathSegment[] => {
+    const setPath = roster.writePath(operation.setPath);
+    let touchedSecretTargetPath = operation.touchedSecretTargetPath;
+    if (touchedSecretTargetPath) {
+      const path = parseConfigSetPath(touchedSecretTargetPath);
+      const writePath = roster.writePath(path);
+      if (writePath !== path) {
+        touchedSecretTargetPath = toDotPath(writePath);
+      }
+    }
+    appliedOperations.push({
+      ...operation,
+      setPath,
+      ...(touchedSecretTargetPath ? { touchedSecretTargetPath } : {}),
+    });
+    return setPath;
+  };
   for (const operation of operations) {
+    const merge =
+      operation.mutation === "merge" || (options.merge && operation.mutation !== "replace");
+    roster.prepare(operation, Boolean(merge));
     if (operation.mutation === "delete") {
+      const writePath = recordOperation(operation);
       const unsetResult = unsetAtPath(next, operation.setPath);
+      if (!unsetResult.removed && operation.inputMode === "unset") {
+        const runtimeOnly = getAtPath(snapshot.runtimeConfig, operation.setPath).found;
+        const message = formatConfigUnsetMissingPathMessage({
+          path: formatConfigSetPath(operation.requestedPath, operation.pathTokens),
+          runtimeOnly,
+        });
+        if (options.dryRun && options.json) {
+          throw new ConfigSetDryRunValidationError({
+            ok: false,
+            operations: 1,
+            configPath: snapshot.path,
+            inputModes: ["unset"],
+            checks: { schema: false, resolvability: false, resolvabilityComplete: false },
+            refsChecked: 0,
+            skippedExecRefs: 0,
+            errors: [
+              {
+                kind: "missing-path",
+                message: runtimeOnly
+                  ? message
+                  : `Config path not found: ${formatConfigSetPath(operation.requestedPath, operation.pathTokens)}. Nothing was changed.`,
+              },
+            ],
+          });
+        }
+        if (!options.dryRun) {
+          assertStrictConfigForMutation(
+            currentConfig,
+            mutationStart.writeOptions.basePluginMetadataSnapshot,
+          );
+        }
+        throw new Error(message);
+      }
       if (!unsetResult.removed || unsetResult.leafContainer !== "array") {
-        unsetPaths.push(operation.setPath);
+        unsetPaths.push(writePath);
       }
       continue;
     }
-    explicitSetPaths.push(operation.setPath);
-    if (operation.mutation === "merge" || (options.merge && operation.mutation !== "replace")) {
+    if (merge) {
       mergeAtPath(next, operation.setPath, operation.value, {
         numericObjectKeys: params.successMode === "patch",
         ...(operation.pathTokens ? { pathTokens: operation.pathTokens } : {}),
@@ -339,10 +390,25 @@ export async function runConfigOperations(params: {
         schema: mutationSchema,
       });
     }
+    explicitSetPaths.push(recordOperation(operation));
   }
+  roster.finish();
+  // A later operation can recreate a deleted path, including through a roster alias.
+  // Only final deletions may be replayed by the persistence owner.
+  unsetPaths = unsetPaths.filter((path) => !getAtPath(next, path).found);
   const removedGatewayAuthPaths = pruneInactiveGatewayAuthCredentials({ root: next, operations });
-  const nextConfig = normalizeConfigMutationModelRefs(next as OpenClawConfig);
+  let nextConfig = normalizeConfigMutationModelRefs(next as OpenClawConfig);
   const normalizedExplicitSetPaths = explicitSetPaths.map(normalizeConfigMutationExplicitSetPath);
+  if (options.dryRun) {
+    nextConfig = prepareConfigWriteTopology({
+      snapshot,
+      pluginMetadataSnapshot: mutationStart.writeOptions.basePluginMetadataSnapshot,
+      nextConfig,
+      options: { explicitSetPaths: normalizedExplicitSetPaths },
+      unsetPaths: resolveManagedUnsetPathsForWrite(unsetPaths),
+      env: process.env,
+    }).nextConfig;
+  }
   const policyIssueLines = formatConfigIssueLines(
     collectUnsupportedSecretRefPolicyIssues(nextConfig),
     "",
@@ -350,7 +416,7 @@ export async function runConfigOperations(params: {
   ).map((line) => line.trim());
   const pluginIntegrationErrors = collectPluginIntegrationProviderErrors({
     config: nextConfig,
-    operations,
+    operations: appliedOperations,
   });
   if (options.dryRun) {
     const hasJsonMode = operations.some(({ inputMode }) => inputMode === "json");
@@ -362,7 +428,9 @@ export async function runConfigOperations(params: {
         (operation.inputMode === "json" && operation.schemaValidated !== true),
     );
     const checksRefs = hasJsonMode || hasBuilderMode || hasUnsetMode;
-    const refs = checksRefs ? collectDryRunRefs({ config: nextConfig, operations }) : [];
+    const refs = checksRefs
+      ? collectDryRunRefs({ config: nextConfig, operations: appliedOperations })
+      : [];
     const selectedRefs = selectDryRunRefsForResolution({
       refs,
       allowExecInDryRun: Boolean(options.allowExec),
@@ -371,7 +439,7 @@ export async function runConfigOperations(params: {
     const modelRefCheck = await checkTouchedTextModelRefs({
       config: nextConfig,
       previousConfig: currentConfig,
-      touchedPaths: operations.map(({ setPath }) => setPath),
+      touchedPaths: appliedOperations.map(({ setPath }) => setPath),
       redactDependencyValues: true,
     });
     errors.push(...modelRefCheck.errors.map((message) => ({ kind: "model" as const, message })));
@@ -479,7 +547,7 @@ export async function runConfigOperations(params: {
   const modelRefCheck = await checkTouchedTextModelRefs({
     config: nextConfig,
     previousConfig: currentConfig,
-    touchedPaths: operations.map(({ setPath }) => setPath),
+    touchedPaths: appliedOperations.map(({ setPath }) => setPath),
     redactDependencyValues: true,
   });
   if (modelRefCheck.errors[0]) {

--- a/src/cli/config-cli-validation.ts
+++ b/src/cli/config-cli-validation.ts
@@ -1,6 +1,6 @@
 import { isRecord as isPlainRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ConfigFileSnapshot } from "../config/config.js";
-import { readConfigFileSnapshot, readConfigFileSnapshotForWrite } from "../config/config.js";
+import { readConfigFileSnapshotForWrite } from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
 import { renderConfigValidationIssueLines } from "../config/issue-location.js";
 import { isPluginPackagingRuntimeOutputInvalidConfigSnapshot } from "../config/recovery-policy.js";
@@ -66,18 +66,6 @@ export function ensureValidConfigSnapshotForCli(
   runtime.error(formatInvalidConfigRepairHint(snapshot, "to repair, then retry."));
   runtime.exit(1);
   return false;
-}
-
-export async function loadValidConfig(
-  runtime: RuntimeEnv = defaultRuntime,
-  options: { observe?: boolean; json?: boolean } = {},
-) {
-  const snapshot =
-    options.observe === false
-      ? await readConfigFileSnapshot({ observe: false })
-      : await readConfigFileSnapshot();
-  ensureValidConfigSnapshotForCli(snapshot, runtime, options);
-  return snapshot;
 }
 
 export async function loadValidConfigForWrite(runtime: RuntimeEnv = defaultRuntime) {

--- a/src/cli/config-cli.integration.test-harness.ts
+++ b/src/cli/config-cli.integration.test-harness.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { defaultRuntime } from "../runtime.js";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { registerConfigCli } from "./config-cli.js";
+
+// Config mutation owns these assertions; plugin discovery suites own registry breadth.
+// Keep the real schemas this suite exercises, but build their metadata only once.
+vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>();
+  let snapshot: ReturnType<typeof actual.loadPluginMetadataSnapshot> | undefined;
+  return {
+    ...actual,
+    resolvePluginMetadataSnapshot: (
+      params: Parameters<typeof actual.resolvePluginMetadataSnapshot>[0],
+    ) => {
+      snapshot ??= actual.loadPluginMetadataSnapshot({
+        ...params,
+        pluginIds: ["codex", "discord", "openclaw-mem0"],
+        pluginIdScope: undefined,
+      });
+      return snapshot;
+    },
+  };
+});
+
+export function createTestRuntime() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    logs,
+    errors,
+    runtime: {
+      log: (...args: unknown[]) => logs.push(args.map((arg) => String(arg)).join(" ")),
+      error: (...args: unknown[]) => errors.push(args.map((arg) => String(arg)).join(" ")),
+      exit: (code: number) => {
+        throw new Error(`__exit__:${code}`);
+      },
+    },
+  };
+}
+
+export function useConfigCliIntegrationHarness() {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  const registeredRuntimeLogs: string[] = [];
+  const registeredRuntimeErrors: string[] = [];
+  afterEach(() => {
+    registeredRuntimeLogs.length = 0;
+    registeredRuntimeErrors.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  async function runRegisteredConfigCommand(args: string[]): Promise<void> {
+    vi.spyOn(defaultRuntime, "log").mockImplementation((...values: unknown[]) => {
+      registeredRuntimeLogs.push(values.map(String).join(" "));
+    });
+    vi.spyOn(defaultRuntime, "error").mockImplementation((...values: unknown[]) => {
+      registeredRuntimeErrors.push(values.map(String).join(" "));
+    });
+    vi.spyOn(defaultRuntime, "exit").mockImplementation((code: number) => {
+      throw new Error(`__exit__:${code}: ${registeredRuntimeErrors.at(-1) ?? ""}`);
+    });
+    const program = new Command();
+    program.exitOverride();
+    registerConfigCli(program);
+    await program.parseAsync(args, { from: "user" });
+  }
+
+  async function withConfigFileHarness(
+    prefix: string,
+    raw: string,
+    run: (params: { configPath: string; tempDir: string }) => Promise<void>,
+  ): Promise<void> {
+    const tempDir = tempDirs.make(prefix);
+    const configPath = path.join(tempDir, "openclaw.json");
+    const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH", "OPENCLAW_TEST_FAST"]);
+    try {
+      fs.writeFileSync(configPath, raw, "utf8");
+      setTestEnvValue("OPENCLAW_TEST_FAST", "1");
+      setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+      clearConfigCache();
+      clearRuntimeConfigSnapshot();
+      await run({ configPath, tempDir });
+    } finally {
+      envSnapshot.restore();
+      clearConfigCache();
+      clearRuntimeConfigSnapshot();
+    }
+  }
+
+  return {
+    registeredRuntimeLogs,
+    registeredRuntimeErrors,
+    runRegisteredConfigCommand,
+    withConfigFileHarness,
+  };
+}

--- a/src/cli/config-cli.integration.test.ts
+++ b/src/cli/config-cli.integration.test.ts
@@ -2,79 +2,23 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { Command } from "commander";
 import JSON5 from "json5";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import * as configRuntime from "../config/config.js";
-import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
-import { REDACTED_SENTINEL } from "../config/redact-snapshot.js";
-import * as runtimeSchema from "../config/runtime-schema.js";
-import { defaultRuntime } from "../runtime.js";
+import { describe, expect, it, vi } from "vitest";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import {
-  registerConfigCli,
-  runConfigGet,
-  runConfigPatch,
-  runConfigSet,
-  runConfigUnset,
-} from "./config-cli.js";
+  createTestRuntime,
+  useConfigCliIntegrationHarness,
+} from "./config-cli.integration.test-harness.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-const registeredRuntimeLogs: string[] = [];
-const registeredRuntimeErrors: string[] = [];
-
-// Config mutation owns these assertions; plugin discovery suites own registry breadth.
-// Keep the real schemas this suite exercises, but build their metadata only once.
-vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>();
-  let snapshot: ReturnType<typeof actual.loadPluginMetadataSnapshot> | undefined;
-  return {
-    ...actual,
-    resolvePluginMetadataSnapshot: (
-      params: Parameters<typeof actual.resolvePluginMetadataSnapshot>[0],
-    ) => {
-      snapshot ??= actual.loadPluginMetadataSnapshot({
-        ...params,
-        pluginIds: ["codex", "discord", "openclaw-mem0"],
-        pluginIdScope: undefined,
-      });
-      return snapshot;
-    },
-  };
-});
-
-function createTestRuntime() {
-  const logs: string[] = [];
-  const errors: string[] = [];
-  return {
-    logs,
-    errors,
-    runtime: {
-      log: (...args: unknown[]) => logs.push(args.map((arg) => String(arg)).join(" ")),
-      error: (...args: unknown[]) => errors.push(args.map((arg) => String(arg)).join(" ")),
-      exit: (code: number) => {
-        throw new Error(`__exit__:${code}`);
-      },
-    },
-  };
-}
-
-async function runRegisteredConfigCommand(args: string[]): Promise<void> {
-  vi.spyOn(defaultRuntime, "log").mockImplementation((...values: unknown[]) => {
-    registeredRuntimeLogs.push(values.map(String).join(" "));
-  });
-  vi.spyOn(defaultRuntime, "error").mockImplementation((...values: unknown[]) => {
-    registeredRuntimeErrors.push(values.map(String).join(" "));
-  });
-  vi.spyOn(defaultRuntime, "exit").mockImplementation((code: number) => {
-    throw new Error(`__exit__:${code}`);
-  });
-  const program = new Command();
-  program.exitOverride();
-  registerConfigCli(program);
-  await program.parseAsync(args, { from: "user" });
-}
+// Register the harness metadata mock before loading the real config and command modules.
+const configRuntime = await import("../config/config.js");
+const { clearConfigCache, clearRuntimeConfigSnapshot } = configRuntime;
+const { REDACTED_SENTINEL } = await import("../config/redact-snapshot.js");
+const runtimeSchema = await import("../config/runtime-schema.js");
+const { runConfigGet, runConfigPatch, runConfigSet, runConfigUnset } =
+  await import("./config-cli.js");
+const { registeredRuntimeErrors, runRegisteredConfigCommand, withConfigFileHarness } =
+  useConfigCliIntegrationHarness();
 
 function installRuntimeSchemaReadHook(hook: () => void | Promise<void>): void {
   const readSchema = runtimeSchema.readBestEffortRuntimeConfigSchema;
@@ -83,28 +27,6 @@ function installRuntimeSchemaReadHook(hook: () => void | Promise<void>): void {
     await hook();
     return result;
   });
-}
-
-async function withConfigFileHarness(
-  prefix: string,
-  raw: string,
-  run: (params: { configPath: string; tempDir: string }) => Promise<void>,
-): Promise<void> {
-  const tempDir = tempDirs.make(prefix);
-  const configPath = path.join(tempDir, "openclaw.json");
-  const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH", "OPENCLAW_TEST_FAST"]);
-  try {
-    fs.writeFileSync(configPath, raw, "utf8");
-    setTestEnvValue("OPENCLAW_TEST_FAST", "1");
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-    clearConfigCache();
-    clearRuntimeConfigSnapshot();
-    await run({ configPath, tempDir });
-  } finally {
-    envSnapshot.restore();
-    clearConfigCache();
-    clearRuntimeConfigSnapshot();
-  }
 }
 
 function createExecDryRunBatch(params: { markerPath: string }) {
@@ -153,54 +75,23 @@ async function withExecDryRunConfigHarness(
     runtime: ReturnType<typeof createTestRuntime>;
   }) => Promise<void>,
 ) {
-  const tempDir = tempDirs.make(prefix);
-  const configPath = path.join(tempDir, "openclaw.json");
-  const batchPath = path.join(tempDir, "batch.json");
-  const markerPath = path.join(tempDir, "marker.txt");
-  const envSnapshot = captureEnv(["OPENCLAW_CONFIG_PATH", "OPENCLAW_TEST_FAST"]);
-  try {
-    fs.writeFileSync(
-      configPath,
-      `${JSON.stringify(
-        {
-          gateway: { port: 18789 },
-        },
-        null,
-        2,
-      )}\n`,
-      "utf8",
-    );
-    fs.writeFileSync(
-      batchPath,
-      `${JSON.stringify(createExecDryRunBatch({ markerPath }), null, 2)}\n`,
-      "utf8",
-    );
-
-    setTestEnvValue("OPENCLAW_TEST_FAST", "1");
-    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
-    clearConfigCache();
-    clearRuntimeConfigSnapshot();
-
-    await run({
-      batchPath,
-      configPath,
-      markerPath,
-      runtime: createTestRuntime(),
-    });
-  } finally {
-    envSnapshot.restore();
-    clearConfigCache();
-    clearRuntimeConfigSnapshot();
-  }
+  await withConfigFileHarness(
+    prefix,
+    `${JSON.stringify({ gateway: { port: 18789 } }, null, 2)}\n`,
+    async ({ configPath, tempDir }) => {
+      const batchPath = path.join(tempDir, "batch.json");
+      const markerPath = path.join(tempDir, "marker.txt");
+      fs.writeFileSync(
+        batchPath,
+        `${JSON.stringify(createExecDryRunBatch({ markerPath }), null, 2)}\n`,
+        "utf8",
+      );
+      await run({ batchPath, configPath, markerPath, runtime: createTestRuntime() });
+    },
+  );
 }
 
 describe("config cli integration", () => {
-  afterEach(() => {
-    registeredRuntimeLogs.length = 0;
-    registeredRuntimeErrors.length = 0;
-    vi.restoreAllMocks();
-  });
-
   it("redacts SecretRef ids and plugin-only sensitive fields in JSON/text order", async () => {
     const secretRefId = "CONFIG_GET_TEST_TOKEN";
     const schemaOnlySecrets = ["first-private-route", "second-private-route"];

--- a/src/cli/config-cli.roster.integration.test.ts
+++ b/src/cli/config-cli.roster.integration.test.ts
@@ -211,7 +211,12 @@ describe("config cli roster integration", () => {
     );
   });
 
-  it("uses the original numeric roster order when reading a legacy file", async () => {
+  it.each([
+    { name: "retained legacy source", replacement: undefined, editedId: "2" },
+    { name: "replaced object parent", replacement: { ownership: "explicit" }, editedId: "1" },
+    { name: "replaced null parent", replacement: null, editedId: "1" },
+  ])("uses current numeric roster order after $name", async ({ replacement, editedId }) => {
+    const entries = { "1": { name: "first" }, "2": { name: "second" } };
     const raw = JSON.stringify({
       agents: {
         ownership: "explicit",
@@ -225,15 +230,27 @@ describe("config cli roster integration", () => {
       "openclaw-config-cli-roster-source-order-",
       raw,
       async ({ configPath }) => {
-        await runRegisteredConfigCommand([
-          "config",
-          "set",
-          "agents.list[0].name",
-          "changed-second",
-        ]);
+        const args =
+          replacement === undefined
+            ? ["config", "set", "agents.list[0].name", "indexed-change"]
+            : [
+                "config",
+                "set",
+                "--batch-json",
+                JSON.stringify([
+                  { path: "agents", value: replacement },
+                  { path: "agents.entries.1", value: entries["1"] },
+                  { path: "agents.entries.2", value: entries["2"] },
+                  { path: "agents.list[0].name", value: "indexed-change" },
+                ]),
+                "--replace",
+              ];
+        await runRegisteredConfigCommand([...args, "--dry-run"]);
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+        await runRegisteredConfigCommand(args);
         expect(JSON5.parse(fs.readFileSync(configPath, "utf8")).agents.entries).toEqual({
-          "1": { name: "first" },
-          "2": { name: "changed-second" },
+          ...entries,
+          [editedId]: { name: "indexed-change" },
         });
       },
     );

--- a/src/cli/config-cli.roster.integration.test.ts
+++ b/src/cli/config-cli.roster.integration.test.ts
@@ -1,0 +1,352 @@
+// Real config CLI coverage for legacy roster input, canonical writes, and ownership.
+import fs from "node:fs";
+import path from "node:path";
+import JSON5 from "json5";
+import { describe, expect, it, vi } from "vitest";
+import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import { useConfigCliIntegrationHarness } from "./config-cli.integration.test-harness.js";
+
+const cronOwnerRefusal = await import("../config/io.cron-owner-refusal.js");
+const {
+  registeredRuntimeLogs,
+  registeredRuntimeErrors,
+  runRegisteredConfigCommand,
+  withConfigFileHarness,
+} = useConfigCliIntegrationHarness();
+
+describe("config cli roster integration", () => {
+  const originalEntries = {
+    main: { name: "original-main" },
+    worker: { name: "original-worker" },
+  };
+  const changedEntries = { ...originalEntries, main: { name: "changed-main" } };
+  const changedList = Object.entries(changedEntries).map(([id, entry]) =>
+    Object.assign({ id }, entry),
+  );
+  const rosterMutations = [
+    { name: "indexed set", args: ["set", "agents.list[0].name", "changed-main"] },
+    {
+      name: "strict indexed set",
+      args: ["set", "agents.list[0].name", '"changed-main"', "--strict-json"],
+    },
+    {
+      name: "batch indexed set",
+      args: [
+        "set",
+        "--batch-json",
+        JSON.stringify([{ path: "agents.list[0].name", value: "changed-main" }]),
+      ],
+    },
+    {
+      name: "whole list set",
+      args: ["set", "agents.list", JSON.stringify(changedList), "--strict-json"],
+    },
+    { name: "whole list patch", patch: { agents: { list: changedList } } },
+    {
+      name: "indexed unset",
+      args: ["unset", "agents.list[0].name"],
+      expected: { ...originalEntries, main: {} },
+    },
+    { name: "canonical control", args: ["set", "agents.entries.main.name", "changed-main"] },
+  ];
+
+  it.each(
+    rosterMutations.flatMap((mutation) =>
+      [false, true].map((legacy) => Object.assign({}, mutation, { legacy })),
+    ),
+  )(
+    "persists roster intent for $name (legacy file: $legacy) after a read-only preview",
+    async (mutation) => {
+      const agents = {
+        ownership: "explicit",
+        ...(mutation.legacy
+          ? {
+              list: Object.entries(originalEntries).map(([id, entry]) =>
+                Object.assign({ id }, entry),
+              ),
+            }
+          : { entries: originalEntries }),
+      };
+      const raw = `${JSON.stringify({ agents })}\n`;
+      await withConfigFileHarness(
+        "openclaw-config-cli-roster-",
+        raw,
+        async ({ configPath, tempDir }) => {
+          const patchPath = path.join(tempDir, "patch.json");
+          const args = mutation.args ?? ["patch", "--file", patchPath];
+          if (mutation.patch) {
+            fs.writeFileSync(patchPath, JSON.stringify(mutation.patch));
+          }
+          await runRegisteredConfigCommand(["config", ...args, "--dry-run"]);
+          expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+          await runRegisteredConfigCommand(["config", ...args]);
+          const after = JSON5.parse(fs.readFileSync(configPath, "utf8"));
+          expect(after.agents.entries).toEqual(mutation.expected ?? changedEntries);
+          expect(after.agents).not.toHaveProperty("list");
+          expect(registeredRuntimeErrors).toEqual([]);
+        },
+      );
+    },
+  );
+
+  it("keeps submitted numeric list order through later indexed batch edits", async () => {
+    const entries = { "1": { name: "first" }, "2": { name: "second" } };
+    const raw = `${JSON.stringify({ agents: { ownership: "explicit", entries } })}\n`;
+    await withConfigFileHarness(
+      "openclaw-config-cli-roster-order-",
+      raw,
+      async ({ configPath }) => {
+        const args = [
+          "config",
+          "set",
+          "--batch-json",
+          JSON.stringify([
+            {
+              path: "agents.list",
+              value: [
+                { id: "2", name: "second" },
+                { id: "1", name: "first" },
+              ],
+            },
+            { path: "agents.entries.1.name", value: "changed-first" },
+            { path: "agents.list[0].name", value: "changed-second" },
+          ]),
+        ];
+        await runRegisteredConfigCommand([...args, "--dry-run"]);
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+        await runRegisteredConfigCommand(args);
+        expect(JSON5.parse(fs.readFileSync(configPath, "utf8")).agents.entries).toEqual({
+          "1": { name: "changed-first" },
+          "2": { name: "changed-second" },
+        });
+      },
+    );
+  });
+
+  it.each(["agents.list[0]", "agents.entries.main"])(
+    "preserves authored references during %s edits with equal resolved values",
+    async (agentPath) => {
+      const raw = JSON.stringify({
+        agents: {
+          ownership: "explicit",
+          entries: {
+            main: { workspace: "${ROSTER_WORKSPACE}", skills: ["${ROSTER_SKILL}"] },
+            worker: { name: "${ROSTER_NAME}" },
+          },
+        },
+        gateway: { port: 19001 },
+      });
+      await withConfigFileHarness(
+        "openclaw-config-cli-roster-env-",
+        raw,
+        async ({ configPath, tempDir }) => {
+          const envSnapshot = captureEnv(["ROSTER_WORKSPACE", "ROSTER_SKILL", "ROSTER_NAME"]);
+          try {
+            const workspace = path.join(fs.realpathSync(tempDir), "workspace");
+            setTestEnvValue("ROSTER_WORKSPACE", workspace);
+            setTestEnvValue("ROSTER_SKILL", "fixture-skill");
+            setTestEnvValue("ROSTER_NAME", "untouched");
+            const args = [
+              "config",
+              "set",
+              "--batch-json",
+              JSON.stringify([
+                { path: `${agentPath}.workspace`, value: workspace },
+                { path: `${agentPath}.skills[0]`, value: "fixture-skill" },
+                { path: `${agentPath}.name`, value: "changed-main" },
+                { path: "gateway.port", value: 19002 },
+              ]),
+            ];
+            await runRegisteredConfigCommand([...args, "--dry-run"]);
+            expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+            await runRegisteredConfigCommand(args);
+            expect(JSON5.parse(fs.readFileSync(configPath, "utf8")).agents.entries).toEqual({
+              main: {
+                workspace: "${ROSTER_WORKSPACE}",
+                skills: ["${ROSTER_SKILL}"],
+                name: "changed-main",
+              },
+              worker: { name: "${ROSTER_NAME}" },
+            });
+          } finally {
+            envSnapshot.restore();
+          }
+        },
+      );
+    },
+  );
+
+  it.each([
+    { name: "leaf recreated", removed: { main: { name: null } }, main: { name: "changed-main" } },
+    { name: "entry recreated", removed: { main: null }, main: { name: "changed-main" } },
+    { name: "leaf remains deleted", removed: { main: { name: null } }, main: {} },
+  ])("honors mixed patch ordering when $name", async ({ removed, main }) => {
+    const raw = JSON.stringify({ agents: { ownership: "explicit", entries: originalEntries } });
+    await withConfigFileHarness(
+      "openclaw-config-cli-roster-patch-order-",
+      raw,
+      async ({ configPath, tempDir }) => {
+        const patchPath = path.join(tempDir, "patch.json");
+        fs.writeFileSync(
+          patchPath,
+          JSON.stringify({
+            agents: {
+              entries: removed,
+              list: [
+                { id: "main", ...main },
+                { id: "worker", name: "original-worker" },
+              ],
+            },
+          }),
+        );
+        const args = ["config", "patch", "--file", patchPath];
+        await runRegisteredConfigCommand([...args, "--dry-run"]);
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+        await runRegisteredConfigCommand(args);
+        expect(JSON5.parse(fs.readFileSync(configPath, "utf8")).agents.entries).toEqual({
+          main,
+          worker: originalEntries.worker,
+        });
+      },
+    );
+  });
+
+  it("uses the original numeric roster order when reading a legacy file", async () => {
+    const raw = JSON.stringify({
+      agents: {
+        ownership: "explicit",
+        list: [
+          { id: "2", name: "second" },
+          { id: "1", name: "first" },
+        ],
+      },
+    });
+    await withConfigFileHarness(
+      "openclaw-config-cli-roster-source-order-",
+      raw,
+      async ({ configPath }) => {
+        await runRegisteredConfigCommand([
+          "config",
+          "set",
+          "agents.list[0].name",
+          "changed-second",
+        ]);
+        expect(JSON5.parse(fs.readFileSync(configPath, "utf8")).agents.entries).toEqual({
+          "1": { name: "first" },
+          "2": { name: "changed-second" },
+        });
+      },
+    );
+  });
+
+  it("validates the final replacement instead of a discarded intermediate roster", async () => {
+    const raw = JSON.stringify({ agents: { ownership: "explicit", entries: originalEntries } });
+    await withConfigFileHarness(
+      "openclaw-config-cli-roster-final-replacement-",
+      raw,
+      async ({ configPath }) => {
+        const args = [
+          "config",
+          "set",
+          "--batch-json",
+          JSON.stringify([
+            { path: "agents.list", value: [{ id: "main" }, { id: "main" }] },
+            { path: "agents.entries", value: changedEntries },
+          ]),
+          "--replace",
+        ];
+        await runRegisteredConfigCommand([...args, "--dry-run"]);
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+        await runRegisteredConfigCommand(args);
+        expect(JSON5.parse(fs.readFileSync(configPath, "utf8")).agents.entries).toEqual(
+          changedEntries,
+        );
+      },
+    );
+  });
+
+  it.each(["agents.list[0].model", "agents.entries.main.model"])(
+    "validates model references before writing %s",
+    async (modelPath) => {
+      const raw = JSON.stringify({ agents: { entries: { main: { name: "unchanged" } } } });
+      await withConfigFileHarness(
+        "openclaw-config-cli-roster-model-",
+        raw,
+        async ({ configPath }) => {
+          await expect(
+            runRegisteredConfigCommand([
+              "config",
+              "set",
+              modelPath,
+              "missing-roster-provider/missing-model",
+            ]),
+          ).rejects.toThrow("__exit__:1");
+          expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+          expect(registeredRuntimeErrors.join("\n")).toContain(
+            'Cannot set model reference "<configured model reference>" at agents.entries.main.model',
+          );
+          expect(registeredRuntimeErrors.join("\n")).toContain("openclaw models list");
+        },
+      );
+    },
+  );
+
+  it.each([
+    {
+      name: "removed member",
+      list: [{ id: "main", name: "changed-main" }],
+      error: "drop agent roster entries",
+    },
+    { name: "duplicate identity", list: [{ id: "main" }, { id: "main" }], error: "duplicate" },
+  ])("does not write a legacy roster with $name", async ({ list, error }) => {
+    const raw = JSON.stringify({ agents: { ownership: "explicit", entries: originalEntries } });
+    await withConfigFileHarness(
+      "openclaw-config-cli-roster-reject-",
+      raw,
+      async ({ configPath }) => {
+        await expect(
+          runRegisteredConfigCommand([
+            "config",
+            "set",
+            "agents.list",
+            JSON.stringify(list),
+            "--replace",
+            "--strict-json",
+          ]),
+        ).rejects.toThrow("__exit__:1");
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+        expect(registeredRuntimeErrors.join("\n")).toContain(error);
+        expect(registeredRuntimeLogs.join("\n")).not.toContain("Updated");
+      },
+    );
+  });
+
+  it("previews the same ownership preparation used when adding a second agent", async () => {
+    const prepareCronOwner = vi.spyOn(cronOwnerRefusal, "prepareCronOwnerWriteRefusal");
+    const raw = `${JSON.stringify({ agents: { entries: { main: { name: "original-main" } } } })}\n`;
+    await withConfigFileHarness(
+      "openclaw-config-cli-roster-owner-",
+      raw,
+      async ({ configPath, tempDir }) => {
+        const patchFile = path.join(tempDir, "patch.json");
+        fs.writeFileSync(
+          patchFile,
+          JSON.stringify({ agents: { entries: { work: { name: "new-worker" } } } }),
+        );
+        const args = ["config", "patch", "--file", patchFile];
+        await runRegisteredConfigCommand([...args, "--dry-run"]);
+        expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+        expect(prepareCronOwner).not.toHaveBeenCalled();
+        await runRegisteredConfigCommand(args);
+        expect(prepareCronOwner).toHaveBeenCalledOnce();
+        const after = JSON5.parse(fs.readFileSync(configPath, "utf8"));
+        expect(after.agents).toMatchObject({
+          ownership: "explicit",
+          entries: { main: { name: "original-main" }, work: { name: "new-worker" } },
+          defaults: { heartbeat: { agentId: "main" }, systemAgent: { agentId: "main" } },
+        });
+        expect(after.agents.entries.main.workspace).toEqual(expect.any(String));
+      },
+    );
+  });
+});

--- a/src/cli/config-cli.roster.integration.test.ts
+++ b/src/cli/config-cli.roster.integration.test.ts
@@ -256,22 +256,53 @@ describe("config cli roster integration", () => {
     );
   });
 
-  it("validates the final replacement instead of a discarded intermediate roster", async () => {
+  it.each([
+    {
+      name: "list to keyed",
+      operations: [
+        { path: "agents.list", value: [{ id: "main" }, { id: "main" }] },
+        { path: "agents.entries", value: changedEntries },
+      ],
+    },
+    {
+      name: "malformed keyed to list",
+      operations: [
+        { path: "agents.entries", value: "discarded" },
+        { path: "agents.list", value: changedList },
+      ],
+    },
+    {
+      name: "keyed identity to list",
+      operations: [
+        { path: "agents.entries.main.id", value: "main" },
+        { path: "agents.list", value: changedList },
+      ],
+    },
+    {
+      name: "keyed identity to parent",
+      operations: [
+        { path: "agents.entries.main.id", value: "main" },
+        { path: "agents", value: { ownership: "explicit", list: changedList } },
+      ],
+    },
+    {
+      name: "keyed identity to list patch",
+      patch: { agents: { entries: { main: { id: "main" } }, list: changedList } },
+    },
+  ])("validates the final $name replacement instead of a discarded roster", async (scenario) => {
     const raw = JSON.stringify({ agents: { ownership: "explicit", entries: originalEntries } });
     await withConfigFileHarness(
       "openclaw-config-cli-roster-final-replacement-",
       raw,
-      async ({ configPath }) => {
-        const args = [
-          "config",
-          "set",
-          "--batch-json",
-          JSON.stringify([
-            { path: "agents.list", value: [{ id: "main" }, { id: "main" }] },
-            { path: "agents.entries", value: changedEntries },
-          ]),
-          "--replace",
-        ];
+      async ({ configPath, tempDir }) => {
+        const patchPath = path.join(tempDir, "replacement.json");
+        if ("patch" in scenario) {
+          fs.writeFileSync(patchPath, JSON.stringify(scenario.patch));
+        }
+        const args =
+          "patch" in scenario
+            ? ["config", "patch", "--file", patchPath, "--replace-path", "agents.list"]
+            : ["config", "set", "--batch-json", JSON.stringify(scenario.operations), "--replace"];
         await runRegisteredConfigCommand([...args, "--dry-run"]);
         expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
         await runRegisteredConfigCommand(args);

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -169,7 +169,7 @@ vi.mock("../gateway/config-reload-plan.js", () => ({
     const hotReasons = changedPaths.filter(
       (changedPath) =>
         !restartReasons.includes(changedPath) &&
-        (changedPath.startsWith("agents.list.") ||
+        (changedPath.startsWith("agents.entries.") ||
           changedPath.startsWith("agents.defaults.models.") ||
           changedPath.startsWith("models.") ||
           changedPath.startsWith("plugins.")),
@@ -620,7 +620,7 @@ describe("config cli", () => {
     it("preserves existing config keys when setting a new value", async () => {
       const resolved: OpenClawConfig = {
         agents: {
-          list: [{ id: "main" }, { id: "oracle", workspace: "~/oracle-workspace" }],
+          entries: { main: {}, oracle: { workspace: "~/oracle-workspace" } },
         },
         gateway: { port: 18789 },
         tools: { allow: ["group:fs"] },
@@ -978,18 +978,17 @@ describe("config cli", () => {
       ]);
     });
 
-    it("normalizes agent-list model refs before writing config mutations", async () => {
+    it("normalizes per-agent model refs before writing config mutations", async () => {
       const resolved: OpenClawConfig = {
         agents: {
-          list: [
-            {
-              id: "tester",
+          entries: {
+            tester: {
               model: { primary: "google/gemini-3-pro-preview" },
               models: {
                 "google/gemini-3-pro-preview": { alias: "gemini" },
               },
             },
-          ],
+          },
         },
       };
       setSnapshot(resolved, resolved);
@@ -997,7 +996,7 @@ describe("config cli", () => {
       await runConfigSet("gateway.port", "18790");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
-      const agent = firstWrittenConfig().agents?.list?.[0];
+      const agent = firstWrittenConfig().agents?.entries?.tester;
       expect(agent?.model).toEqual({ primary: "google/gemini-3.1-pro-preview" });
       expect(agent?.models).toEqual({
         "google/gemini-3.1-pro-preview": { alias: "gemini" },
@@ -2101,7 +2100,7 @@ describe("config cli", () => {
       expect(Array.isArray(written.channels?.telegram?.groups)).toBe(false);
     });
 
-    it("still creates arrays for schema-backed numeric list indexes", async () => {
+    it("canonicalizes schema-backed numeric agent list indexes before writing", async () => {
       setConfigMutationShapeSchema();
       const resolved: OpenClawConfig = {};
       setSnapshot(resolved, resolved);
@@ -2109,11 +2108,9 @@ describe("config cli", () => {
       await runConfigSet("agents.list.0.id", '"tech"', "--strict-json");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
-      const written = firstWrittenConfig() as {
-        agents?: { list?: unknown };
-      };
-      expect(written.agents?.list).toEqual([{ id: "tech" }]);
-      expect(Array.isArray(written.agents?.list)).toBe(true);
+      const written = firstWrittenConfig();
+      expect(written.agents?.entries).toEqual({ tech: {} });
+      expect(written.agents).not.toHaveProperty("list");
     });
 
     it("fails early when unsupported mutable paths are assigned SecretRef objects (builder mode)", async () => {
@@ -2660,7 +2657,7 @@ describe("config cli", () => {
       expect(written.gateway?.auth).toEqual({ mode: "token" });
     });
 
-    it("batch-file nested leaf updates preserve agents defaults and list siblings", async () => {
+    it("batch-file nested leaf updates preserve agents defaults and roster siblings", async () => {
       const resolved: OpenClawConfig = {
         agents: {
           defaults: {
@@ -2669,7 +2666,7 @@ describe("config cli", () => {
             },
             model: { primary: "openai/gpt-5.4" },
           },
-          list: [{ id: "main" }, { id: "ops" }],
+          entries: { main: {}, ops: {} },
         },
         plugins: {
           entries: {
@@ -2707,7 +2704,7 @@ describe("config cli", () => {
         provider: "gemini",
         sources: ["memory"],
       });
-      expect(written.agents?.list).toEqual(resolved.agents?.list);
+      expect(written.agents?.entries).toEqual(resolved.agents?.entries);
       expect(written.plugins).toEqual(resolved.plugins);
     });
 
@@ -4138,16 +4135,15 @@ describe("config cli", () => {
 
     it("preserves valid bracket path forms", async () => {
       const resolved: OpenClawConfig = {
-        agents: { list: [{ id: "main" }, { id: "other" }] },
+        agents: { entries: { main: {}, other: { name: "Other" } } },
       };
       setSnapshot(resolved, resolved);
 
-      await runConfigSet("agents.list[1].id", "renamed");
+      await runConfigSet("agents.list[1].name", "renamed");
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       const written = firstWrittenConfig();
-      expect(written.agents?.list?.[1]?.id).toBe("renamed");
-      expect(written.agents?.list?.[0]?.id).toBe("main");
+      expect(written.agents?.entries).toEqual({ main: {}, other: { name: "renamed" } });
     });
 
     it("preserves escaped dots inside path segments", async () => {
@@ -4205,7 +4201,7 @@ describe("config cli", () => {
       const written = firstWrittenConfig();
       expect(written.tools).not.toHaveProperty("alsoAllow");
       expect(written.agents).not.toHaveProperty("defaults");
-      expect(written.agents?.list).toEqual(resolved.agents?.list);
+      expect(written.agents?.entries).toEqual(resolved.agents?.entries);
       expect(written.gateway).toEqual(resolved.gateway);
       expect(written.tools?.profile).toBe("coding");
       expect(written.logging).toEqual(resolved.logging);
@@ -4215,10 +4211,10 @@ describe("config cli", () => {
       });
     });
 
-    it("removes only the specified array element", async () => {
+    it("submits only the specified roster entry removal for writer validation", async () => {
       const resolved: OpenClawConfig = {
         agents: {
-          list: [{ id: "agent-a" }, { id: "agent-b" }, { id: "agent-c" }],
+          entries: { "agent-a": {}, "agent-b": {}, "agent-c": {} },
         },
       };
       const runtimeMerged: OpenClawConfig = {
@@ -4230,7 +4226,8 @@ describe("config cli", () => {
 
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       const written = firstWrittenConfig();
-      expect(written.agents?.list).toEqual([{ id: "agent-a" }, { id: "agent-c" }]);
+      // The real writer's roster-loss guard is exercised by config-cli.integration.test.ts.
+      expect(written.agents?.entries).toEqual({ "agent-a": {}, "agent-c": {} });
       expect(firstWriteConfigOptions()).toEqual({ auditOrigin: "cli" });
     });
 
@@ -4272,13 +4269,12 @@ describe("config cli", () => {
         },
       };
       setSnapshot(resolved, resolved);
-      setSnapshot(resolved, resolved);
 
       await runConfigCommand(["config", "unset", "tools.alsoAllow", "--dry-run"]);
 
       expect(mockWriteConfigFile).not.toHaveBeenCalled();
       expectLogIncludes("Dry run successful: 1 update(s) validated against /tmp/openclaw.json.");
-      expect(mockReadConfigFileSnapshot).toHaveBeenCalledTimes(2);
+      expect(mockReadConfigFileSnapshot).toHaveBeenCalledTimes(1);
     });
 
     it("rejects an unset that makes a dependent model reference unresolved", async () => {
@@ -4622,10 +4618,7 @@ describe("config cli", () => {
     it("prints a hot-reload hint for agents.list model changes", async () => {
       const resolved: OpenClawConfig = {
         agents: {
-          list: [
-            { id: "main" },
-            { id: "mason-vale", model: { primary: "ollama/qwen3-coder-next" } },
-          ],
+          entries: { main: {}, "mason-vale": { model: { primary: "ollama/qwen3-coder-next" } } },
         },
       };
       setSnapshot(resolved, withRuntimeDefaults(resolved));
@@ -4646,13 +4639,12 @@ describe("config cli", () => {
     it("does not treat legacy per-agent agentRuntime as restart-required", async () => {
       const resolved: OpenClawConfig = {
         agents: {
-          list: [
-            {
-              id: "codex-legacy",
+          entries: {
+            "codex-legacy": {
               agentRuntime: { id: "codex" },
               model: { primary: "openai/gpt-5.5" },
             },
-          ],
+          },
         },
       } as unknown as OpenClawConfig;
       setSnapshot(resolved, withRuntimeDefaults(resolved));
@@ -4672,7 +4664,7 @@ describe("config cli", () => {
     it("keeps the restart hint for hot-path edits when reload mode is off", async () => {
       const resolved: OpenClawConfig = {
         agents: {
-          list: [{ id: "main", model: { primary: "openai/gpt-5.4" } }],
+          entries: { main: { model: { primary: "openai/gpt-5.4" } } },
         },
         gateway: {
           reload: { mode: "off" },
@@ -4696,7 +4688,7 @@ describe("config cli", () => {
     it("normalizes legacy restart mode to hot apply semantics", async () => {
       const resolved: OpenClawConfig = {
         agents: {
-          list: [{ id: "main", model: { primary: "openai/gpt-5.4" } }],
+          entries: { main: { model: { primary: "openai/gpt-5.4" } } },
         },
         gateway: {
           reload: { mode: "restart" },
@@ -4720,12 +4712,11 @@ describe("config cli", () => {
     it("prints a hot-reload hint when removing legacy per-agent agentRuntime", async () => {
       const resolved: OpenClawConfig = {
         agents: {
-          list: [
-            {
-              id: "codex-legacy",
+          entries: {
+            "codex-legacy": {
               agentRuntime: { id: "codex" },
             },
-          ],
+          },
         },
       } as unknown as OpenClawConfig;
       setSnapshot(resolved, withRuntimeDefaults(resolved));
@@ -4807,7 +4798,7 @@ describe("config cli", () => {
 
     it("keeps the restart hint for restart-required config paths", async () => {
       const resolved: OpenClawConfig = {
-        agents: { list: [{ id: "main" }] },
+        agents: { entries: { main: {} } },
         gateway: { port: 18789 },
       };
       setSnapshot(resolved, withRuntimeDefaults(resolved));
@@ -4845,7 +4836,7 @@ describe("config cli", () => {
 
     it("keeps the restart hint for mixed hot and restart batch updates", async () => {
       const resolved: OpenClawConfig = {
-        agents: { list: [{ id: "main", model: { primary: "openai/gpt-5.4" } }] },
+        agents: { entries: { main: { model: { primary: "openai/gpt-5.4" } } } },
         gateway: { port: 18789 },
       };
       setSnapshot(resolved, withRuntimeDefaults(resolved));

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1,9 +1,8 @@
 // Config CLI command implementation for get/set/unset/patch/validate and secret refs.
-import { isDeepStrictEqual } from "node:util";
 import type { Command } from "commander";
 import { formatDocsLink } from "../../packages/terminal-core/src/links.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
-import { readConfigFileSnapshotWithPluginMetadata, replaceConfigFile } from "../config/config.js";
+import { readConfigFileSnapshotWithPluginMetadata } from "../config/config.js";
 import { formatConfigIssueLines, normalizeConfigIssues } from "../config/issue-format.js";
 import { renderConfigValidationIssueLines } from "../config/issue-location.js";
 import { CONFIG_PATH, resolveConfigPath } from "../config/paths.js";
@@ -12,8 +11,7 @@ import {
   buildRuntimeConfigSchemaFromRegistry,
   readBestEffortRuntimeConfigSchema,
 } from "../config/runtime-schema.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { danger, info, success, warn } from "../globals.js";
+import { danger, success, warn } from "../globals.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   ExitError,
@@ -28,36 +26,19 @@ import { formatCliCommand } from "./command-format.js";
 import {
   buildConfigSetOperations,
   buildUnsetOperation,
-  ConfigSetDryRunValidationError,
   configPatchModeError,
   modeError,
   readConfigPatchOperations,
   type ConfigPatchOptions,
   type ConfigUnsetOptions,
 } from "./config-cli-input.js";
-import { normalizeConfigMutationModelRefs } from "./config-cli-model-normalization.js";
+import { getAtPath, isConfigSchemaPath, parseConfigSetPath } from "./config-cli-path.js";
+import { handleConfigMutationError, runConfigOperations } from "./config-cli-runner.js";
 import {
-  formatConfigUnsetMissingPathMessage,
-  getAtPath,
-  isConfigSchemaPath,
-  parseConfigSetPath,
-  unsetAtPath,
-} from "./config-cli-path.js";
-import {
-  assertConfigPathIsNotAutoManaged,
-  configApplyHintForOperations,
-  handleConfigMutationError,
-  runConfigOperations,
-} from "./config-cli-runner.js";
-import {
-  assertStrictConfigForMutation,
   ensureValidConfigSnapshotForCli,
   formatInvalidConfigRepairHint,
-  loadValidConfig,
-  loadValidConfigForWrite,
   strictlyValidateConfigSnapshotForCli,
 } from "./config-cli-validation.js";
-import { checkTouchedTextModelRefs } from "./config-model-validation.js";
 import { isConfigMachineOutput, isConfigSetJsonParseOnly } from "./config-output-mode.js";
 import {
   hasBatchMode,
@@ -232,91 +213,12 @@ export async function runConfigUnset(opts: {
     }
     const pathTokens = parseConcreteConfigPathTokens(opts.path);
     const parsedPath = pathTokens.map(String);
-    assertConfigPathIsNotAutoManaged(parsedPath);
-    const mutationStart = cliOptions.dryRun
-      ? { snapshot: await loadValidConfig(runtime), writeOptions: {} }
-      : await loadValidConfigForWrite(runtime);
-    const { snapshot } = mutationStart;
-    // Mutate resolved config so runtime defaults never leak into the authored file.
-    const next = structuredClone(snapshot.resolved) as Record<string, unknown>;
-    const currentConfig = normalizeConfigMutationModelRefs(
-      structuredClone(snapshot.resolved) as OpenClawConfig,
-    );
-    const unsetResult = unsetAtPath(next, parsedPath);
-    if (!unsetResult.removed) {
-      const runtimeOnly = getAtPath(snapshot.runtimeConfig, parsedPath).found;
-      const missingPathMessage = formatConfigUnsetMissingPathMessage({
-        path: opts.path,
-        runtimeOnly,
-      });
-      if (cliOptions.json) {
-        throw new ConfigSetDryRunValidationError({
-          ok: false,
-          operations: 1,
-          configPath: snapshot.path,
-          inputModes: ["unset"],
-          checks: { schema: false, resolvability: false, resolvabilityComplete: false },
-          refsChecked: 0,
-          skippedExecRefs: 0,
-          errors: [
-            {
-              kind: "missing-path",
-              message: runtimeOnly
-                ? missingPathMessage
-                : `Config path not found: ${opts.path}. Nothing was changed.`,
-            },
-          ],
-        });
-      }
-      if (!cliOptions.dryRun) {
-        assertStrictConfigForMutation(
-          currentConfig,
-          mutationStart.writeOptions.basePluginMetadataSnapshot,
-        );
-      }
-      runtime.error(danger(missingPathMessage));
-      runtime.exit(1);
-      return;
-    }
-    const operation = buildUnsetOperation(parsedPath, pathTokens);
-    if (cliOptions.dryRun) {
-      await runConfigOperations({
-        runtime,
-        operations: [operation],
-        options: cliOptions,
-        successMode: "set",
-      });
-      return;
-    }
-    const nextConfig = normalizeConfigMutationModelRefs(structuredClone(next) as OpenClawConfig);
-    if (isDeepStrictEqual(currentConfig, nextConfig)) {
-      assertStrictConfigForMutation(
-        nextConfig,
-        mutationStart.writeOptions.basePluginMetadataSnapshot,
-      );
-      runtime.log(info("No change"));
-      return;
-    }
-    const modelRefCheck = await checkTouchedTextModelRefs({
-      config: nextConfig,
-      previousConfig: currentConfig,
-      touchedPaths: [parsedPath],
-      redactDependencyValues: true,
+    await runConfigOperations({
+      runtime,
+      operations: [buildUnsetOperation(parsedPath, pathTokens)],
+      options: cliOptions,
+      successMode: "set",
     });
-    if (modelRefCheck.errors[0]) {
-      throw new Error(modelRefCheck.errors[0]);
-    }
-    await replaceConfigFile({
-      nextConfig,
-      snapshot,
-      ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
-      writeOptions:
-        unsetResult.leafContainer === "array"
-          ? { ...mutationStart.writeOptions, auditOrigin: "cli" }
-          : { ...mutationStart.writeOptions, auditOrigin: "cli", unsetPaths: [parsedPath] },
-    });
-    const hint = configApplyHintForOperations([operation], currentConfig, nextConfig);
-    runtime.log(info(`Removed ${opts.path}. ${hint}`));
   } catch (err) {
     handleConfigMutationError({ err, runtime, options: cliOptions });
   }

--- a/src/config/io.write-topology.ts
+++ b/src/config/io.write-topology.ts
@@ -1,0 +1,178 @@
+import { isDeepStrictEqual } from "node:util";
+import { listAgentEntries, tryResolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { isRecord } from "../utils.js";
+import { pinSurvivorWorkspaceForRosterCollapse } from "./agent-workspace-roster-transition.js";
+import { getConfigValueAtPath, setConfigValueAtPath } from "./config-paths.js";
+import { prepareAuthInheritanceOwnerForWrite } from "./io.auth-inheritance-owner.js";
+import { assertAutomaticBindingsWriteAllowed } from "./io.ownership-write-guard.js";
+import { prepareSessionStoreOwnershipForWrite } from "./io.session-store-owner.js";
+import type {
+  ConfigWriteOptions,
+  ReadConfigFileSnapshotWithPluginMetadataResult,
+} from "./io.types.js";
+import { migratePersistedImplicitMainRoster } from "./legacy.roster.js";
+import type { OpenClawConfig } from "./types.js";
+import { materializeLegacyAgentOwnershipForActiveChannelsResult } from "./validation.js";
+
+// Validation and commits share ownership preparation. Cron migration, runtime refresh,
+// and persistence remain in the committing writer.
+export function prepareConfigWriteTopology(
+  params: ReadConfigFileSnapshotWithPluginMetadataResult & {
+    nextConfig: OpenClawConfig;
+    options: Pick<ConfigWriteOptions, "explicitSetPaths" | "explicitSetValueSource">;
+    unsetPaths: readonly (readonly string[])[];
+    env: NodeJS.ProcessEnv;
+  },
+) {
+  const { snapshot, options, unsetPaths, env, pluginMetadataSnapshot } = params;
+  let nextConfig = params.nextConfig;
+  const sourceRosterMigration = migratePersistedImplicitMainRoster(
+    snapshot.sourceConfigBeforeMigrations ?? snapshot.parsed,
+  );
+  const retainedLegacyDefaultAgentId = sourceRosterMigration.retainedLegacyDefaultAgentId;
+  const previousEntries = listAgentEntries(snapshot.config);
+  const nextEntries = listAgentEntries(nextConfig);
+  const nextAgentIds = new Set(nextEntries.map((entry) => normalizeAgentId(entry.id)));
+  const previousSoleAgentId = tryResolveDefaultAgentId(snapshot.config);
+  const entersMultiAgent = previousEntries.length <= 1 && nextEntries.length > 1;
+  const previousSoleRemains = Boolean(
+    previousSoleAgentId && nextAgentIds.has(normalizeAgentId(previousSoleAgentId)),
+  );
+  const writesOwnershipTopology =
+    !isDeepStrictEqual(previousEntries, nextEntries) ||
+    [...(options.explicitSetPaths ?? []), ...unsetPaths].some(
+      (writePath) =>
+        writePath[0] === "agents" &&
+        (writePath.length === 1 ||
+          writePath[1] === "entries" ||
+          writePath[1] === "list" ||
+          writePath[1] === "ownership"),
+    );
+  const persistOwnership =
+    entersMultiAgent || (retainedLegacyDefaultAgentId !== undefined && writesOwnershipTopology);
+  const keepOwnership = nextEntries.length > 1 && snapshot.config.agents?.ownership === "explicit";
+  const stampOwnership =
+    (persistOwnership || keepOwnership) && nextConfig.agents?.ownership === undefined;
+  if (stampOwnership) {
+    nextConfig = {
+      ...nextConfig,
+      agents: { ...nextConfig.agents, ownership: "explicit" },
+    };
+  }
+
+  const workspaceCollapse = pinSurvivorWorkspaceForRosterCollapse(snapshot.config, nextConfig, env);
+  nextConfig = workspaceCollapse.config;
+
+  const authInheritanceOwnership = prepareAuthInheritanceOwnerForWrite({
+    currentConfig: snapshot.config,
+    targetConfig: nextConfig,
+    writesOwnershipTopology,
+    explicitSetPaths: options.explicitSetPaths,
+    env,
+  });
+  nextConfig = authInheritanceOwnership.config;
+
+  const sessionStoreOwnership = prepareSessionStoreOwnershipForWrite({
+    currentConfig: snapshot.config,
+    currentStore: (snapshot.sourceConfigBeforeMigrations ?? snapshot.config).session?.store,
+    targetConfig: nextConfig,
+    env,
+    explicitSetPaths: options.explicitSetPaths,
+    explicitSetValueSource: options.explicitSetValueSource,
+  });
+  nextConfig = sessionStoreOwnership.config;
+  const { sameFixedSessionStore } = sessionStoreOwnership;
+  const retainedFleetOwner =
+    retainedLegacyDefaultAgentId &&
+    writesOwnershipTopology &&
+    nextAgentIds.has(normalizeAgentId(retainedLegacyDefaultAgentId))
+      ? retainedLegacyDefaultAgentId
+      : undefined;
+  const ownerAgentId =
+    (entersMultiAgent && previousSoleRemains ? previousSoleAgentId : undefined) ??
+    retainedFleetOwner;
+  const ownershipMaterialization = ownerAgentId
+    ? materializeLegacyAgentOwnershipForActiveChannelsResult(
+        nextConfig,
+        ownerAgentId,
+        env,
+        pluginMetadataSnapshot?.manifestRegistry.plugins,
+        { materializeSessionStore: sameFixedSessionStore, materializeWorkspace: true },
+      )
+    : { config: nextConfig, insertedPaths: [] };
+  nextConfig = ownershipMaterialization.config;
+  const insertedPaths = [
+    ...(persistOwnership || keepOwnership
+      ? (sourceRosterMigration.insertedPaths ?? []).filter(
+          (entry) =>
+            sameFixedSessionStore || entry.join(".") !== "agents.defaults.sessionStore.agentId",
+        )
+      : []),
+    ...((persistOwnership || keepOwnership) &&
+    retainedLegacyDefaultAgentId &&
+    Array.isArray(snapshot.config.bindings) &&
+    !isDeepStrictEqual(snapshot.sourceConfigBeforeMigrations?.bindings, snapshot.config.bindings)
+      ? [["bindings"]]
+      : []),
+    ...ownershipMaterialization.insertedPaths.concat(workspaceCollapse.insertedPaths),
+    ...authInheritanceOwnership.insertedPaths, // Persisting explicit ownership must replace the authored legacy roster too.
+    ...(persistOwnership ? [["agents", "entries"]] : []), // Otherwise projection restores the retired default marker.
+    ...(stampOwnership ? [["agents", "ownership"]] : []),
+  ];
+
+  const nextSessionStoreConfig = nextConfig.agents?.defaults?.sessionStore;
+  if (
+    !ownerAgentId &&
+    writesOwnershipTopology &&
+    previousEntries.length === 1 &&
+    previousSoleAgentId &&
+    !previousSoleRemains &&
+    sameFixedSessionStore &&
+    (nextSessionStoreConfig === undefined ||
+      (isRecord(nextSessionStoreConfig) && !Object.hasOwn(nextSessionStoreConfig, "agentId")))
+  ) {
+    nextConfig = {
+      ...nextConfig,
+      agents: {
+        ...nextConfig.agents,
+        defaults: {
+          ...nextConfig.agents?.defaults,
+          sessionStore: {
+            ...(isRecord(nextSessionStoreConfig) ? nextSessionStoreConfig : {}),
+            agentId: normalizeAgentId(previousSoleAgentId),
+          },
+        },
+      },
+    };
+    insertedPaths.push(["agents", "defaults", "sessionStore", "agentId"]);
+  }
+
+  const topologyPaths = [
+    ...new Map(insertedPaths.map((entry) => [entry.join("\0"), entry])).values(),
+  ];
+  assertAutomaticBindingsWriteAllowed({
+    bindingsIncludeOwned: snapshot.bindingsIncludeOwned === true,
+    ownershipPaths: topologyPaths,
+  });
+  const explicitSetPaths = [...(options.explicitSetPaths ?? []), ...topologyPaths];
+  const explicitSetValueSource = structuredClone(options.explicitSetValueSource ?? nextConfig);
+  for (const ownershipPath of topologyPaths) {
+    setConfigValueAtPath(
+      explicitSetValueSource,
+      ownershipPath,
+      getConfigValueAtPath(nextConfig, ownershipPath),
+    );
+  }
+  return {
+    nextConfig,
+    explicitSetPaths,
+    explicitSetValueSource,
+    preserveLegacyAgentRoster: Boolean(retainedLegacyDefaultAgentId) && !writesOwnershipTopology,
+    cronOwner: persistOwnership
+      ? retainedFleetOwner
+        ? { provenOwnerAgentId: retainedFleetOwner }
+        : {}
+      : undefined,
+  };
+}

--- a/src/config/io.write.ts
+++ b/src/config/io.write.ts
@@ -1,15 +1,10 @@
 import type fs from "node:fs";
 import path from "node:path";
-import { isDeepStrictEqual } from "node:util";
-import { listAgentEntries, tryResolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import { resolveCronJobsStorePathFromConfig } from "../cron/store.js";
 import { isVerbose } from "../global-state.js";
 import { isVitestRuntimeEnv } from "../infra/env.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { replaceFileAtomic } from "../infra/replace-file.js";
-import { normalizeAgentId } from "../routing/session-key.js";
-import { isRecord } from "../utils.js";
-import { pinSurvivorWorkspaceForRosterCollapse } from "./agent-workspace-roster-transition.js";
 import { maintainConfigBackups } from "./backup-rotation.js";
 import { collectChangedPaths } from "./config-change-paths.js";
 import {
@@ -23,7 +18,6 @@ import {
   applyUnsetPathsForWrite,
   resolveManagedUnsetPathsForWrite,
 } from "./config-path-mutation.js";
-import { getConfigValueAtPath, setConfigValueAtPath } from "./config-paths.js";
 import {
   EnvRefArrayMutationError,
   restoreEnvRefsFromMap,
@@ -39,11 +33,9 @@ import {
   formatConfigOverwriteLogMessage,
   type ConfigWriteAuditResult,
 } from "./io.audit.js";
-import { prepareAuthInheritanceOwnerForWrite } from "./io.auth-inheritance-owner.js";
 import type { ConfigIoContext } from "./io.context.js";
 import { prepareCronOwnerWriteRefusal } from "./io.cron-owner-refusal.js";
 import { recordConfigWriteMetadata } from "./io.meta.js";
-import { assertAutomaticBindingsWriteAllowed } from "./io.ownership-write-guard.js";
 import {
   collectEnvRefPaths,
   containsConfigIncludeDirective,
@@ -55,7 +47,6 @@ import {
   resolveGatewayMode,
   restoreAuthoredTildePathsForWrite,
 } from "./io.read-helpers.js";
-import { prepareSessionStoreOwnershipForWrite } from "./io.session-store-owner.js";
 import { loggedConfigWarningFingerprints, setBoundedConfigIoWarningEntry } from "./io.state.js";
 import type {
   ConfigWriteOptions,
@@ -80,17 +71,14 @@ import {
   stampConfigVersion,
   tightenStateDirPermissionsIfNeeded,
 } from "./io.write-safety.js";
+import { prepareConfigWriteTopology } from "./io.write-topology.js";
 import { formatConfigIssueLines } from "./issue-format.js";
 import { warnIfJSON5CommentsWillBeStripped } from "./json5-comments.js";
-import { migratePersistedImplicitMainRoster } from "./legacy.roster.js";
 import { assertConfigWriteAllowedInCurrentMode } from "./nix-mode-write-guard.js";
 import { resolveIncludeRoots } from "./paths.js";
 import { preflightRuntimeSnapshotWrite } from "./runtime-snapshot.js";
 import type { OpenClawConfig } from "./types.js";
-import {
-  materializeLegacyAgentOwnershipForActiveChannelsResult,
-  validateConfigObjectRawWithPlugins,
-} from "./validation.js";
+import { validateConfigObjectRawWithPlugins } from "./validation.js";
 
 function hasOwnIncludeDirective(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && Object.hasOwn(value, INCLUDE_KEY);
@@ -123,7 +111,6 @@ export async function writeConfigFileFromContext(
   options.assertConfigPathForWrite?.();
   assertConfigWriteAllowedInCurrentMode({ configPath, env: deps.env });
   const unsetPaths = resolveManagedUnsetPathsForWrite(options.unsetPaths);
-  let nextConfig = cfg;
   const snapshotRead = options.baseSnapshot
     ? {
         snapshot: options.baseSnapshot,
@@ -135,153 +122,23 @@ export async function writeConfigFileFromContext(
     assertBaseSnapshotStillCurrent(snapshot, configPath, deps.fs);
   }
 
-  const sourceRosterMigration = migratePersistedImplicitMainRoster(
-    snapshot.sourceConfigBeforeMigrations ?? snapshot.parsed,
-  );
-  const retainedLegacyDefaultAgentId = sourceRosterMigration.retainedLegacyDefaultAgentId;
-  const previousEntries = listAgentEntries(snapshot.config);
-  const nextEntries = listAgentEntries(nextConfig);
-  const nextAgentIds = new Set(nextEntries.map((entry) => normalizeAgentId(entry.id)));
-  const previousSoleAgentId = tryResolveDefaultAgentId(snapshot.config);
-  const entersMultiAgent = previousEntries.length <= 1 && nextEntries.length > 1;
-  const previousSoleRemains = Boolean(
-    previousSoleAgentId && nextAgentIds.has(normalizeAgentId(previousSoleAgentId)),
-  );
-  const writesOwnershipTopology =
-    !isDeepStrictEqual(previousEntries, nextEntries) ||
-    [...(options.explicitSetPaths ?? []), ...unsetPaths].some(
-      (writePath) =>
-        writePath[0] === "agents" &&
-        (writePath.length === 1 ||
-          writePath[1] === "entries" ||
-          writePath[1] === "list" ||
-          writePath[1] === "ownership"),
-    );
-  const persistOwnership =
-    entersMultiAgent || (retainedLegacyDefaultAgentId !== undefined && writesOwnershipTopology);
-  const keepOwnership = nextEntries.length > 1 && snapshot.config.agents?.ownership === "explicit";
-  const stampOwnership =
-    (persistOwnership || keepOwnership) && nextConfig.agents?.ownership === undefined;
-  if (stampOwnership) {
-    nextConfig = {
-      ...nextConfig,
-      agents: { ...nextConfig.agents, ownership: "explicit" },
-    };
-  }
-
-  const workspaceCollapse = pinSurvivorWorkspaceForRosterCollapse(
-    snapshot.config,
+  const {
     nextConfig,
-    deps.env,
-  );
-  nextConfig = workspaceCollapse.config;
-
-  const authInheritanceOwnership = prepareAuthInheritanceOwnerForWrite({
-    currentConfig: snapshot.config,
-    targetConfig: nextConfig,
-    writesOwnershipTopology,
-    explicitSetPaths: options.explicitSetPaths,
+    explicitSetPaths,
+    explicitSetValueSource,
+    preserveLegacyAgentRoster,
+    cronOwner,
+  } = prepareConfigWriteTopology({
+    ...snapshotRead,
+    nextConfig: cfg,
+    options,
+    unsetPaths,
     env: deps.env,
   });
-  nextConfig = authInheritanceOwnership.config;
-
-  const sessionStoreOwnership = prepareSessionStoreOwnershipForWrite({
-    currentConfig: snapshot.config,
-    currentStore: (snapshot.sourceConfigBeforeMigrations ?? snapshot.config).session?.store,
-    targetConfig: nextConfig,
-    env: deps.env,
-    explicitSetPaths: options.explicitSetPaths,
-    explicitSetValueSource: options.explicitSetValueSource,
-  });
-  nextConfig = sessionStoreOwnership.config;
-  const { sameFixedSessionStore } = sessionStoreOwnership;
-  const retainedFleetOwner =
-    retainedLegacyDefaultAgentId &&
-    writesOwnershipTopology &&
-    nextAgentIds.has(normalizeAgentId(retainedLegacyDefaultAgentId))
-      ? retainedLegacyDefaultAgentId
-      : undefined;
-  const ownerAgentId =
-    (entersMultiAgent && previousSoleRemains ? previousSoleAgentId : undefined) ??
-    retainedFleetOwner;
-  const ownershipMaterialization = ownerAgentId
-    ? materializeLegacyAgentOwnershipForActiveChannelsResult(
-        nextConfig,
-        ownerAgentId,
-        deps.env,
-        snapshotRead.pluginMetadataSnapshot?.manifestRegistry.plugins,
-        { materializeSessionStore: sameFixedSessionStore, materializeWorkspace: true },
-      )
-    : { config: nextConfig, insertedPaths: [] as string[][] };
-  nextConfig = ownershipMaterialization.config;
-  const insertedPaths = [
-    ...(persistOwnership || keepOwnership
-      ? (sourceRosterMigration.insertedPaths ?? []).filter(
-          (entry) =>
-            sameFixedSessionStore || entry.join(".") !== "agents.defaults.sessionStore.agentId",
-        )
-      : []),
-    ...((persistOwnership || keepOwnership) &&
-    retainedLegacyDefaultAgentId &&
-    Array.isArray(snapshot.config.bindings) &&
-    !isDeepStrictEqual(snapshot.sourceConfigBeforeMigrations?.bindings, snapshot.config.bindings)
-      ? [["bindings"]]
-      : []),
-    ...ownershipMaterialization.insertedPaths.concat(workspaceCollapse.insertedPaths),
-    ...authInheritanceOwnership.insertedPaths, // Persisting explicit ownership must replace the authored legacy roster too.
-    ...(persistOwnership ? [["agents", "entries"]] : []), // Otherwise projection restores the retired default marker.
-    ...(stampOwnership ? [["agents", "ownership"]] : []),
-  ];
-
-  const nextSessionStoreConfig = nextConfig.agents?.defaults?.sessionStore;
-  if (
-    !ownerAgentId &&
-    writesOwnershipTopology &&
-    previousEntries.length === 1 &&
-    previousSoleAgentId &&
-    !previousSoleRemains &&
-    sameFixedSessionStore &&
-    (nextSessionStoreConfig === undefined ||
-      (isRecord(nextSessionStoreConfig) && !Object.hasOwn(nextSessionStoreConfig, "agentId")))
-  ) {
-    nextConfig = {
-      ...nextConfig,
-      agents: {
-        ...nextConfig.agents,
-        defaults: {
-          ...nextConfig.agents?.defaults,
-          sessionStore: {
-            ...(isRecord(nextSessionStoreConfig) ? nextSessionStoreConfig : {}),
-            agentId: normalizeAgentId(previousSoleAgentId),
-          },
-        },
-      },
-    };
-    insertedPaths.push(["agents", "defaults", "sessionStore", "agentId"]);
-  }
-
-  const topologyPaths = [
-    ...new Map(insertedPaths.map((entry) => [entry.join("\0"), entry])).values(),
-  ];
-  assertAutomaticBindingsWriteAllowed({
-    bindingsIncludeOwned: snapshot.bindingsIncludeOwned === true,
-    ownershipPaths: topologyPaths,
-  });
-  const explicitSetPaths = [...(options.explicitSetPaths ?? []), ...topologyPaths];
-  const explicitSetValueSource = structuredClone(
-    options.explicitSetValueSource ?? nextConfig,
-  ) as Record<string, unknown>;
-  for (const ownershipPath of topologyPaths) {
-    setConfigValueAtPath(
-      explicitSetValueSource,
-      ownershipPath,
-      getConfigValueAtPath(nextConfig as Record<string, unknown>, ownershipPath),
-    );
-  }
-  const cronOwnerRefusal = persistOwnership
+  const cronOwnerRefusal = cronOwner
     ? await prepareCronOwnerWriteRefusal(snapshot.config, {
         storePath: resolveCronJobsStorePathFromConfig(nextConfig, deps.env),
-        ...(retainedFleetOwner ? { provenOwnerAgentId: retainedFleetOwner } : {}),
+        ...cronOwner,
         env: deps.env,
       })
     : undefined;
@@ -314,7 +171,7 @@ export async function writeConfigFileFromContext(
       explicitSetValueSource,
       allowedAgentRosterRemovals: options.allowedAgentRosterRemovals,
       allowIncludeAncestorExplicitSetPaths: options.allowIncludeAncestorExplicitSetPaths,
-      preserveLegacyAgentRoster: Boolean(retainedLegacyDefaultAgentId) && !writesOwnershipTopology,
+      preserveLegacyAgentRoster,
     });
   } else if (snapshot.exists && hasAuthoredIncludes) {
     persistCandidate = preserveIncludeOwnedConfigForWrite({

--- a/src/config/legacy.roster.ts
+++ b/src/config/legacy.roster.ts
@@ -15,6 +15,33 @@ type MigrationResult = {
   retainedLegacyDefaultAgentId?: string;
 };
 
+/** Converts a valid legacy roster without applying ownership or runtime migrations. */
+export function parseLegacyAgentRoster(
+  value: unknown,
+): { entries: Record<string, unknown>; order: string[] } | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const ids = new Set<string>();
+  const entries: [string, Record<string, unknown>][] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return undefined;
+    }
+    const { id, ...config } = entry as Record<string, unknown>;
+    if (typeof id !== "string" || id.trim() !== id || !id) {
+      return undefined;
+    }
+    const normalizedId = normalizeAgentId(id);
+    if (normalizedId !== id || ids.has(normalizedId)) {
+      return undefined;
+    }
+    ids.add(id);
+    entries.push([id, config]);
+  }
+  return { entries: Object.fromEntries(entries), order: [...ids] };
+}
+
 export function migratePersistedImplicitMainRoster(
   raw: unknown,
   options: { materializeWorkspace?: boolean } = {},
@@ -37,37 +64,13 @@ export function migratePersistedImplicitMainRoster(
   let legacyRosterOrder: string[] | undefined;
   let rosterProperty = readAgentRosterProperty({ ...root, agents });
   if (rosterProperty?.kind === "list") {
-    if (!Array.isArray(rosterProperty.value)) {
+    const roster = parseLegacyAgentRoster(rosterProperty.value);
+    if (!roster) {
       return { config: raw, changed: false, diagnostics: [] };
     }
-    const legacyList = rosterProperty.value;
-    if (legacyList.some((value) => !value || typeof value !== "object" || Array.isArray(value))) {
-      return { config: raw, changed: false, diagnostics: [] };
-    }
-    const legacyIds = new Set<string>();
-    const legacyOrder: string[] = [];
-    for (const value of legacyList) {
-      const entry = value as Record<string, unknown>;
-      if (typeof entry.id !== "string" || entry.id.trim() !== entry.id || !entry.id) {
-        return { config: raw, changed: false, diagnostics: [] };
-      }
-      const normalizedId = normalizeAgentId(entry.id);
-      if (normalizedId !== entry.id || legacyIds.has(normalizedId)) {
-        return { config: raw, changed: false, diagnostics: [] };
-      }
-      legacyIds.add(normalizedId);
-      legacyOrder.push(entry.id);
-    }
-    legacyRosterOrder = legacyOrder;
-    const entries = Object.fromEntries(
-      legacyList.map((value) => {
-        const entry = value as Record<string, unknown>;
-        const { id, ...config } = entry;
-        return [id as string, config];
-      }),
-    );
+    legacyRosterOrder = roster.order;
     const { list: _list, ...rest } = agents;
-    agents = { ...rest, entries };
+    agents = { ...rest, entries: roster.entries };
     convertedLegacyList = true;
     rosterProperty = readAgentRosterProperty({ ...root, agents });
   }


### PR DESCRIPTION
Closes #131054

## What Problem This Solves

Operators editing an agent through `config set` or `config patch` using `agents.list` could receive a successful exit and message while the requested edit never reached the keyed roster. Indexed `unset` also failed to find existing fields. Separately, a preview could reject adding a second agent even though the actual writer prepared ownership and succeeded.

## Why This Change Was Made

The CLI cloned the resolved keyed config and then created an independent list at the submitted path. Persistence correctly preferred the existing `agents.entries`, discarding the edit. The CLI now owns one mutable roster, preserves ordered list/index intent, and records canonical paths for validation and persistence. Runtime readers and keyed-roster precedence are unchanged.

`set`, `patch`, and `unset` share the mutation runner. Preview and the ordinary writer share existing ownership-topology preparation; cron migration, runtime activation, audit, backups, and atomic persistence stay commit-only. Later operations win over earlier deletions across list/keyed aliases. Whole replacements discard obsolete order and invalid intermediate state; indexed edits and merges still validate the state they consume. List deletion still projects the keyed target before unsetting it.

The indexed CLI syntax is a public contract documented in stable [v2026.7.1](https://github.com/openclaw/openclaw/blob/v2026.7.1/docs/cli/config.md#paths). Rejecting all list input would break that contract; reversing global roster precedence would affect unrelated readers; invoking the full writer during previews could persist cron ownership. None of those alternatives is used.

## User Impact

Existing indexed and whole-list mutation commands apply edits to canonical `agents.entries`; keyed paths remain preferred. Numeric agent IDs retain submitted list order across keyed leaf edits. Authored environment references, include ownership, duplicate-ID validation, and unauthorized roster-deletion refusals remain protected. No config option, environment variable, database schema, persistence format, or runtime fallback is added.

## Evidence

The built baseline on `bcb5403d5757b6df045160db7ea805e93aabe3a5`, Node 26.7.0, reproduced the silent no-op and false preview refusal in 14 isolated commands with a working canonical control. Initial registered-CLI regressions failed 14 cases with two controls passing. Further failing-first proof caught stale deletion replay, premature intermediate validation, and wrong-agent selection after parent replacement.

An additional pre-landing challenge held the previously green `a314c1cf` head: actual built CLI control preview/write succeeded, while a valid final whole-list replacement incorrectly rejected invalid intermediate keyed entries. Four new real registered-CLI cases reproduced that failure on unchanged production; the symmetric five-case table passes after the shared-owner correction, now at `46a17c6321a48d1dd770b6829c92247493ca1d9d`. Both preview immutability and exact committed canonical values are checked. This is a correction to this PR's candidate, not a regression attributed to another contributor.

Current focused proof: 482 tests pass across seven CLI integration/unit, legacy migration, writer preparation, cron-refusal, and real writer files. That includes 52 registered-CLI integration cases and the four writer regressions newly landed in #131413. The patch was composed onto that actual persistence-owner change; all 12 repaired production/test/docs blobs remain identical. Fresh independent source challenge and complete-patch Codex P0 review are clear at their stated scopes. Broader environment-restoration changes were rejected after inspecting plugin/Doctor callers: `explicitSetPaths` records persistence coverage, not literal-authoring authority.

All 28 selected changed checks passed on the correction before this conflict-free composition, including production types, all 14 core-test type shards, targeted type-aware lint, storage/sidecar/import/pairing guards. The 482-test run and fresh complete-branch review above are on the composed `46a17c63` head; the pre-composition gate is not claimed as a new local full-gate run at that head.

The exact `46a17c63` head passed the standard Node 26.7.0 `ciArtifacts` build in 2m 18s, including runtime bundles, plugin load guards, scoped SDK declarations/147 exports, and Control UI checks. Build metadata and the emitted replacement branch were independently inspected. Then 26 scenarios / 52 direct compiled-CLI invocations passed: 26 previews preserved config bytes, the four expected refusal outcomes retained their guards, the scalar include changed only its owning file, and isolated HOME/state directories were removed. The five new symmetric replacement scenarios account for 10 of those commands. No timeout, validation, or performance limit was weakened.

Focused command on runtime head `46a17c63`:

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs \
  src/cli/config-cli.integration.test.ts src/cli/config-cli.roster.integration.test.ts \
  src/cli/config-cli.test.ts src/config/legacy.roster.test.ts \
  src/config/io.write-prepare.test.ts src/config/io.cron-owner-refusal.test.ts \
  src/config/io.write-config.test.ts
node --import ./scripts/tsx.mjs scripts/build-all.mts ciArtifacts
```

Exact runtime head `46a17c6321a48d1dd770b6829c92247493ca1d9d` passed [CI 33139751996](https://github.com/openclaw/openclaw/actions/runs/33139751996): 162 successful jobs, 17 intentional skips, and required `openclaw/ci-gate` successful. The final bookkeeping-only follow-up removes this PR's manual changelog line to satisfy the native release-ownership gate; release-note context remains in this body. All code, tests, and CLI documentation are byte-identical to the tested runtime head. The single-line deletion also passed fresh Codex P0 review and diff checks. Final head `018cb643f34242e8e7f22e440cd176650b7c2ee9` passed [CI 33140582048](https://github.com/openclaw/openclaw/actions/runs/33140582048): 162 successful jobs, 17 intentional skips, and required [`openclaw/ci-gate`](https://github.com/openclaw/openclaw/actions/runs/33140582048/job/98751940954) successful, with no failures or retries. No release-only override or native gate bypass is used.

Historical proof is retained separately: the preceding frozen patch passed all 29 selected checks, a full Node 26.7.0 build including declarations, and 21 scenarios / 42 actual compiled-CLI invocations. One initial full-core lint run hit its 900-second cap without a code diagnostic; the normal throttled retry passed within the same cap, and the remaining checks completed separately. Those old results do not substitute for the late correction's new-code proof.

Production LOC: +444/-325 (net +119); tests/support: +562/-179 (net +383). The topology module is predominantly moved code. Growth restores the shipped CLI contract and ordered identity mapping while deleting duplicate unset mutation/write logic and obsolete exports. The late correction itself is +4 production / +31 tests. Docs and shrink-only assertion-baseline bookkeeping are separate; `CHANGELOG.md` has no final diff.

Preview remains non-committing, not a guarantee that every later write will pass commit-only guards. No Gateway, provider, or channel request is needed for this config-only flow. The original silent-no-op introducing revision remains unproven in local shallow history; no original regression author is inferred.

Named follow-up: review the separately documented legacy `config get` aliases. This PR repairs mutation commands, not read-side aliases.

AI-assisted repair, with direct source review and isolated behavior verification.
