### PR TITLE
fix(ui): keep mobile transcript notices below the topbar

### DIFF
--- a/ui/src/pages/chat/chat-responsive.browser.test.ts
+++ b/ui/src/pages/chat/chat-responsive.browser.test.ts
@@ -1817,28 +1817,37 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
 
   it.each([
     [1200, 800, "desktop"],
-    [390, 844, "mobile"],
+    [320, 568, "mobile-320"],
+    [375, 812, "mobile-375"],
+    [430, 932, "mobile-430"],
   ] as const)(
-    "keeps topbar and composer notices out of the %s transcript layout",
+    "keeps floating notices clear of mobile chrome without shifting the %s transcript layout",
     async (width, height, label) => {
       const page = await openBrowserPage(width, height);
       try {
         await page.setContent(`<!doctype html><html><head><style>${readUiCss()}</style></head><body style="margin:0;height:100vh;overflow:hidden">
-          <section class="card chat">
-            <div class="chat-main">
-              <div class="chat-main__conversation-column">
-                <header class="chat-pane__header">Session</header>
-                <div class="chat-topbar-notices"></div>
-                <div class="chat-main__conversation">
-                  <div class="chat-thread" role="log"><div class="chat-thread-inner">Transcript</div></div>
-                  <div class="agent-chat__composer-shell">
-                    <div class="agent-chat__composer-overlay"></div>
-                    <div class="agent-chat__input">Composer</div>
+          <div class="shell shell--chat ${label.startsWith("mobile") ? "shell--mobile-nav shell--merged-chat-chrome" : ""}">
+            <main class="content content--chat" style="padding:0">
+              <section class="card chat">
+                <div class="chat-main">
+                  <div class="chat-main__conversation-column">
+                    <header class="chat-pane__header">Session</header>
+                    <div class="chat-topbar-notices"></div>
+                    <div class="chat-main__conversation">
+                      <div class="chat-thread" role="log"><div class="chat-thread-inner">Transcript</div></div>
+                      <button class="btn btn--sm chat-history-available">Earlier history available</button>
+                      <div class="chat-gutter-stack"><div class="task-suggestions">Task suggestion</div></div>
+                      <div class="agent-chat__composer-shell">
+                        <div class="agent-chat__composer-overlay"></div>
+                        <div class="agent-chat__input">Composer</div>
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          </section>
+              </section>
+            </main>
+            <openclaw-toast-host><div class="app-toast">Connection notice</div></openclaw-toast-host>
+          </div>
         </body></html>`);
         // The card entrance animation moves every measured descendant together.
         await page.locator(".card.chat").evaluate(async (node) => {
@@ -1893,6 +1902,31 @@ describeBrowserLayout.concurrent("chat responsive browser layout", () => {
             .locator(".agent-chat__composer-overlay")
             .evaluate((node) => getComputedStyle(node).position),
         ).toBe("absolute");
+        const header = await getBoundingBox(page, ".chat-pane__header");
+        const overlayTops = await Promise.all(
+          [
+            ".chat-history-available",
+            ".chat-topbar-notices",
+            ".chat-gutter-stack",
+            ".app-toast",
+          ].map(async (selector) => ({ selector, top: (await getBoundingBox(page, selector)).y })),
+        );
+        if (label.startsWith("mobile")) {
+          for (const overlay of overlayTops) {
+            expect(overlay.top, overlay.selector).toBeGreaterThanOrEqual(header.y + header.height);
+          }
+        } else {
+          expect(
+            overlayTops.find((overlay) => overlay.selector === ".chat-history-available")?.top,
+          ).toBeCloseTo(header.y + header.height + 10, 0);
+          expect(
+            overlayTops.find((overlay) => overlay.selector === ".chat-topbar-notices")?.top,
+          ).toBeCloseTo(8, 0);
+          expect(overlayTops.find((overlay) => overlay.selector === ".app-toast")?.top).toBeCloseTo(
+            20,
+            0,
+          );
+        }
         const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
         if (artifactDir) {
           await mkdir(artifactDir, { recursive: true });

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -1,6 +1,11 @@
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
-  .chat-main__conversation-column {
+  :root {
+    /* The mobile pane header leaves flow; top-owned overlays consume this same
+       clearance so new transcript notices cannot cover its controls. */
     --chat-mobile-pane-header-height: 52px;
+  }
+
+  .chat-main__conversation-column {
     --chat-mobile-pane-header-fade-overhang: 8px;
     --chat-mobile-pane-header-paint-height: calc(
       var(--chat-mobile-pane-header-height) + var(--chat-mobile-pane-header-fade-overhang)

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -423,7 +423,7 @@ openclaw-chat-page {
 .chat-topbar-notices {
   position: absolute;
   z-index: 24;
-  top: 8px;
+  top: calc(var(--chat-mobile-pane-header-height, 0px) + 8px);
   left: 50%;
   display: flex;
   align-items: center;
@@ -767,7 +767,7 @@ openclaw-chat-page {
 .chat-history-available {
   position: absolute;
   z-index: 10;
-  top: 10px;
+  top: calc(var(--chat-mobile-pane-header-height, 0px) + 10px);
   left: 50%;
   max-width: calc(100% - 2 * var(--chat-thread-gutter));
   border-radius: var(--radius-full);
@@ -2013,7 +2013,7 @@ button.chat-reply-preview--message:disabled {
 .chat-gutter-stack {
   position: absolute;
   z-index: 24;
-  top: 10px;
+  top: calc(var(--chat-mobile-pane-header-height, 0px) + 10px);
   right: 14px;
   display: grid;
   width: min(450px, calc(100% - 28px));

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -762,6 +762,15 @@ openclaw-session-owner-chip {
 /* A corner toast degenerates at phone widths, where it would span nearly the
  * whole viewport anyway. Use the full-width top idiom instead. */
 @media (max-width: 768px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
+  /* The unanchored chat toast shares the viewport with shell and pane chrome.
+     Anchored permission toasts already carry a measured pane-header offset. */
+  .shell--chat > openclaw-toast-host .app-toast:not(.app-toast--anchored) {
+    top: calc(
+      var(--safe-area-top) + var(--shell-topbar-height) + var(--chat-mobile-pane-header-height) +
+        20px
+    );
+  }
+
   .app-toast {
     left: max(12px, var(--safe-area-left));
     right: max(12px, var(--safe-area-right));


### PR DESCRIPTION
Closes #131307

## What Problem This Solves

Fixes an issue where mobile Control UI users could have transcript notices cover the session topbar, obscuring the workspace title, participant context, and header controls. The earlier-history pill made the regression especially visible, but the same missing clearance affected general notices, task suggestions, and unanchored chat toasts.

## Why This Change Was Made

The mobile pane header is positioned outside normal flow, so this PR makes its existing height the shared clearance for top-owned transcript overlays. History, general notice, task-suggestion, and unanchored chat-toast placement now consume that owner token; desktop positioning, anchored permission toasts, and bottom-owned composer overlays remain unchanged.

## User Impact

After this lands, floating transcript feedback remains readable below the mobile session header at narrow widths, including when the sidebar drawer is opened and closed. Desktop retains its existing placement.

## Evidence

### Maintainer report

| Mobile bug | Desktop reference |
| --- | --- |
| ![Reported mobile history notice covering the session topbar](https://github.com/user-attachments/assets/7b6f172f-2c7d-4490-bff8-40c3581db10c) | ![Reported desktop history notice correctly below the session topbar](https://github.com/user-attachments/assets/276006f0-b066-4ebe-b05b-6374a2ec2ce9) |

### Real Control UI with mock Gateway — mobile before/after at 375 px

| Floating surface | Before | After |
| --- | --- | --- |
| Earlier-history pill | ![Before: earlier-history pill covers the mobile session header](https://github.com/user-attachments/assets/ffb8514e-64f8-4962-812d-65db1336c045) | ![After: earlier-history pill sits below the mobile session header](https://github.com/user-attachments/assets/87033dee-8000-406b-87c7-d483a12d064a) |
| Connection/error notice | ![Before: connection error notice covers the mobile session header](https://github.com/user-attachments/assets/802e03e3-2cbf-4975-84b8-d0ed997005cc) | ![After: connection error notice sits below the mobile session header](https://github.com/user-attachments/assets/7709a942-562f-4c97-9307-c85978946147) |
| Task suggestion | ![Before: task suggestion covers the mobile session header](https://github.com/user-attachments/assets/ed26d83d-103b-4006-a5fd-78abb04d8025) | ![After: task suggestion starts below the mobile session header](https://github.com/user-attachments/assets/8247262e-7ddc-4745-baf4-40aa047f557d) |
| Unanchored toast | ![Before: chat toast covers the mobile session header](https://github.com/user-attachments/assets/3d5ba72a-549e-41ee-a1db-33702e822cf1) | ![After: chat toast sits below the mobile session header](https://github.com/user-attachments/assets/721fcaff-59be-4aed-89d6-7e5a8adc2359) |

### Mobile width and drawer stress

| Width | Sidebar closed | Sidebar open |
| --- | --- | --- |
| 320 px | ![320 px with floating surfaces clear of the session header](https://github.com/user-attachments/assets/356f3835-cfac-488d-9a07-7af335732ba4) | ![320 px with the sidebar drawer open and toast owned by the drawer](https://github.com/user-attachments/assets/c5a3a7c1-aaf4-4d1b-bbc3-9574147bc3d2) |
| 375 px | ![375 px with floating surfaces clear of the session header](https://github.com/user-attachments/assets/ca012340-c4ec-4a92-8118-1437f4430069) | ![375 px with the sidebar drawer open and toast owned by the drawer](https://github.com/user-attachments/assets/b1da1603-5501-45cc-bcd5-360517b6b33b) |
| 430 px | ![430 px with floating surfaces clear of the session header](https://github.com/user-attachments/assets/6d30c9e2-8469-4062-9e05-6b3cb95f33f8) | ![430 px with the sidebar drawer open and toast owned by the drawer](https://github.com/user-attachments/assets/980bcd4c-b4e1-47cd-9a46-5957fb514709) |

### Desktop unchanged

The before and after captures are pixel-identical (matching SHA-256), preserving the existing desktop offset.

| Before | After |
| --- | --- |
| ![Desktop history notice before this mobile-only change](https://github.com/user-attachments/assets/0d59fcbb-5b39-4e1d-a32e-a3787347d99c) | ![Desktop history notice after this mobile-only change](https://github.com/user-attachments/assets/b801e985-bfb7-41c2-af6d-525a312a7ec2) |

- The focused browser regression failed before the production change at 320, 375, and 430 px (`target top 10 px`, `header bottom 52 px`) and passes after it: desktop plus all three mobile widths, 4/4.
- Real Control UI stress assertions passed for every listed floating surface at 320, 375, and 430 px, with the sidebar drawer opened and closed at each width.
- `check:changed` passed, including core/UI typechecks, formatting, lint, style checks, and repository guards.
- Production CSS: +18/-4 (net +14). Test: +49/-15 (net +34). The production growth promotes the existing mobile header height to the owning responsive scope and applies it to all current top-overlay siblings; no compatibility path or duplicate positioning flow was added.
