### PR TITLE
fix(ui): replace channel setup Working text with spinner buttons

### DIFF
--- a/ui/src/components/wizard-step-controls.ts
+++ b/ui/src/components/wizard-step-controls.ts
@@ -24,11 +24,21 @@ type WizardStepControlsProps = {
   presentation?: "channels";
   channelSelect?: boolean;
   answerLabel?: string;
+  busyLabel?: string;
   confirmAffirmativeLabel?: string;
   leadingAction?: TemplateResult;
   sensitiveRevealed?: boolean;
   onToggleSensitiveVisibility?: () => void;
 };
+
+export function renderWizardBusyButton(label: string) {
+  return html`
+    <button type="button" class="btn primary" disabled aria-busy="true">
+      <span class="btn__spinner" aria-hidden="true"></span>
+      <span class="sr-only" role="status" aria-live="polite">${label}</span>
+    </button>
+  `;
+}
 
 function stepClass(props: WizardStepControlsProps, name: string): string {
   return `${props.presentation === "channels" ? "channels-wizard" : "wizard-step"}__${name}`;
@@ -97,6 +107,12 @@ function renderAnswerButton(
   onClick?: () => void,
   disabled = props.busy,
 ) {
+  const buttonLabel = props.answerLabel ?? label;
+  if (props.presentation === "channels" && props.busy) {
+    return html`<div class="channels-wizard__footer">
+      ${renderWizardBusyButton(props.busyLabel ?? buttonLabel)}
+    </div>`;
+  }
   const button = html`
     <button
       type=${onClick ? "button" : "submit"}
@@ -104,7 +120,7 @@ function renderAnswerButton(
       ?disabled=${disabled}
       @click=${onClick}
     >
-      ${props.answerLabel ?? label}
+      ${buttonLabel}
     </button>
   `;
   if (props.presentation === "channels") {
@@ -267,6 +283,9 @@ function renderOptionsStep(props: WizardStepControlsProps) {
         disabled: props.busy,
         onChange: (value) => props.onAnswer(channels ? value : options[Number(value)]?.value),
       })}
+      ${props.busy
+        ? renderAnswerButton(props, t("modelSetup.wizard.continue"), undefined, true)
+        : nothing}
     `;
   }
   const answer = multiple
@@ -298,16 +317,18 @@ function renderConfirmStep(props: WizardStepControlsProps) {
         : actionClass}
     >
       ${props.presentation === "channels" ? nothing : (props.leadingAction ?? nothing)}
-      ${[false, true].map(
-        (answer) => html`<button
-          type="button"
-          class=${answer ? "btn primary" : "btn"}
-          ?disabled=${props.busy}
-          @click=${() => props.onAnswer(answer)}
-        >
-          ${answer ? (props.confirmAffirmativeLabel ?? t("common.yes")) : t("common.no")}
-        </button>`,
-      )}
+      ${props.presentation === "channels" && props.busy
+        ? renderWizardBusyButton(props.busyLabel ?? t("common.loading"))
+        : [false, true].map(
+            (answer) => html`<button
+              type="button"
+              class=${answer ? "btn primary" : "btn"}
+              ?disabled=${props.busy}
+              @click=${() => props.onAnswer(answer)}
+            >
+              ${answer ? (props.confirmAffirmativeLabel ?? t("common.yes")) : t("common.no")}
+            </button>`,
+          )}
     </div>
   `;
 }

--- a/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
+++ b/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
@@ -481,6 +481,12 @@ suite.define(() => {
       });
       await expect.poll(async () => gateway.getRequests("wizard.next")).toHaveLength(1);
       await expect.poll(() => account.getAttribute("disabled")).not.toBeNull();
+      const busyButton = wizard.locator('button[aria-busy="true"]');
+      await expect.poll(() => busyButton.getAttribute("disabled")).not.toBeNull();
+      await expect.poll(() => busyButton.locator(".btn__spinner").count()).toBe(1);
+      await expect
+        .poll(() => wizard.locator(".channels-wizard__spinner", { hasText: "Working…" }).count())
+        .toBe(0);
       await gateway.resolveDeferred("wizard.next");
 
       const token = wizard.getByLabel("Telegram bot token");

--- a/ui/src/pages/channels/wizard-view.busy.test.ts
+++ b/ui/src/pages/channels/wizard-view.busy.test.ts
@@ -6,11 +6,9 @@ import { i18n } from "../../i18n/index.ts";
 import type { ChannelWizardStep } from "./wizard-controller.ts";
 import { renderChannelWizard } from "./wizard-view.ts";
 
-function renderStep(
-  step: ChannelWizardStep,
-  busy = true,
-  textValue = typeof step.initialValue === "string" ? step.initialValue : "",
-) {
+type WizardProps = Parameters<typeof renderChannelWizard>[0];
+
+function renderWizard(wizard: WizardProps["wizard"], overrides: Partial<WizardProps> = {}) {
   const container = document.createElement("div");
   const onAnswer = vi.fn();
   const onClose = vi.fn();
@@ -18,18 +16,11 @@ function renderStep(
   document.body.append(container);
   render(
     renderChannelWizard({
-      wizard: {
-        phase: "step",
-        channel: null,
-        step,
-        stepIndex: 1,
-        busy,
-        validationError: null,
-      },
+      wizard,
       channelLabel: (channelId) => channelId,
       multiselectValues: ["alpha"],
       onToggleMultiselect,
-      textValue,
+      textValue: "",
       secretVisible: false,
       onTextInput: vi.fn(),
       onToggleSecretVisibility: vi.fn(),
@@ -41,10 +32,29 @@ function renderStep(
       whatsappBusy: false,
       onWhatsAppStart: vi.fn(),
       onWhatsAppWait: vi.fn(),
+      ...overrides,
     }),
     container,
   );
   return { container, onAnswer, onClose, onToggleMultiselect };
+}
+
+function renderStep(
+  step: ChannelWizardStep,
+  busy = true,
+  textValue = typeof step.initialValue === "string" ? step.initialValue : "",
+) {
+  return renderWizard(
+    {
+      phase: "step",
+      channel: null,
+      step,
+      stepIndex: 1,
+      busy,
+      validationError: null,
+    },
+    { textValue },
+  );
 }
 
 describe("renderChannelWizard busy controls", () => {
@@ -59,24 +69,80 @@ describe("renderChannelWizard busy controls", () => {
     document.body.replaceChildren();
   });
 
-  it("disables note and confirm answers while a step is running", () => {
-    const note = renderStep({ id: "note", type: "note", message: "Do this" });
-    const noteContinue = note.container.querySelector<HTMLButtonElement>(
-      ".channels-wizard__footer .primary",
-    );
-    expect(noteContinue?.disabled).toBe(true);
-    noteContinue?.click();
-    expect(note.onAnswer).not.toHaveBeenCalled();
+  it.each([
+    { name: "note", step: { id: "note", type: "note", message: "Do this" } },
+    {
+      name: "select",
+      step: {
+        id: "select",
+        type: "select",
+        message: "Pick one",
+        options: [{ label: "Alpha", value: "alpha" }],
+      },
+    },
+    {
+      name: "multiselect",
+      step: {
+        id: "multi",
+        type: "multiselect",
+        message: "Pick several",
+        options: [{ label: "Alpha", value: "alpha" }],
+      },
+    },
+    { name: "text", step: { id: "text", type: "text", message: "Enter a value" } },
+    { name: "confirm", step: { id: "confirm", type: "confirm", message: "Continue?" } },
+    { name: "action", step: { id: "action", type: "action", message: "Run action" } },
+    { name: "progress", step: { id: "progress", type: "progress", message: "Run action" } },
+  ] satisfies Array<{ name: string; step: ChannelWizardStep }>)(
+    "shows one spinner button while a $name answer is running",
+    ({ step }) => {
+      const rendered = renderStep(step);
+      const busyButton = rendered.container.querySelector<HTMLButtonElement>(
+        '.channels-wizard__footer button[aria-busy="true"]',
+      );
 
-    const confirm = renderStep({ id: "confirm", type: "confirm", message: "Continue?" });
-    const confirmButtons = Array.from(
-      confirm.container.querySelectorAll<HTMLButtonElement>(".channels-wizard__footer button"),
+      expect(busyButton?.disabled).toBe(true);
+      expect(busyButton?.querySelector(".btn__spinner")).not.toBeNull();
+      expect(busyButton?.querySelector(".sr-only")?.textContent).toBe("Working…");
+      expect(rendered.container.querySelectorAll(".btn__spinner")).toHaveLength(1);
+      expect(
+        Array.from(rendered.container.querySelectorAll(".channels-wizard__spinner")).some(
+          (element) => element.textContent?.trim() === "Working…",
+        ),
+      ).toBe(false);
+      busyButton?.click();
+      expect(rendered.onAnswer).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {
+      name: "wizard startup",
+      wizard: { phase: "starting", channel: "telegram" } as const,
+      overrides: {},
+      status: "Starting setup…",
+    },
+    {
+      name: "WhatsApp QR loading",
+      wizard: {
+        phase: "done",
+        channel: "whatsapp",
+        channels: ["whatsapp"],
+        accounts: [{ channel: "whatsapp", accountId: "default" }],
+      } as const,
+      overrides: { whatsappBusy: true },
+      status: "Generating QR code…",
+    },
+  ])("uses the same spinner button for $name", ({ wizard, overrides, status }) => {
+    const rendered = renderWizard(wizard, overrides);
+    const busyButton = rendered.container.querySelector<HTMLButtonElement>(
+      'button[aria-busy="true"]',
     );
-    expect(confirmButtons).toHaveLength(2);
-    expect(confirmButtons.map((button) => button.textContent?.trim())).toEqual(["No", "Yes"]);
-    expect(confirmButtons.every((button) => button.disabled)).toBe(true);
-    confirmButtons.forEach((button) => button.click());
-    expect(confirm.onAnswer).not.toHaveBeenCalled();
+
+    expect(busyButton?.disabled).toBe(true);
+    expect(busyButton?.querySelector(".btn__spinner")).not.toBeNull();
+    expect(busyButton?.querySelector(".sr-only")?.textContent).toBe(status);
+    expect(rendered.container.querySelectorAll(".btn__spinner")).toHaveLength(1);
   });
 
   it.each([
@@ -96,12 +162,16 @@ describe("renderChannelWizard busy controls", () => {
       expect(status?.textContent?.trim()).toBe(expectedStatus);
       expect(status?.getAttribute("aria-live")).toBe("polite");
       expect(progress.container.querySelectorAll('[role="status"]')).toHaveLength(1);
+      const busyButton = progress.container.querySelector<HTMLButtonElement>(
+        '.channels-wizard__footer button[aria-busy="true"]',
+      );
+      expect(busyButton?.disabled).toBe(true);
+      expect(busyButton?.querySelector(".btn__spinner")).not.toBeNull();
 
       const cancel = progress.container.querySelector<HTMLButtonElement>(
-        ".channels-wizard__footer button",
+        '.channels-wizard__footer button:not([aria-busy="true"])',
       );
       expect(cancel?.textContent?.trim()).toBe("Cancel");
-      expect(progress.container.querySelector(".channels-wizard__footer .primary")).toBeNull();
       cancel?.click();
       expect(progress.onClose).toHaveBeenCalledOnce();
       expect(progress.onAnswer).not.toHaveBeenCalled();
@@ -153,7 +223,7 @@ describe("renderChannelWizard busy controls", () => {
       "replacement",
     );
     const input = text.container.querySelector<HTMLInputElement>('input[name="wizard-text"]');
-    const submit = text.container.querySelector<HTMLButtonElement>('button[type="submit"]');
+    const submit = text.container.querySelector<HTMLButtonElement>('button[aria-busy="true"]');
     const toggle = text.container.querySelector<HTMLButtonElement>(".oc-sensitive-toggle");
     expect(input?.disabled).toBe(true);
     expect(input?.type).toBe("password");

--- a/ui/src/pages/channels/wizard-view.ts
+++ b/ui/src/pages/channels/wizard-view.ts
@@ -3,7 +3,10 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { renderChannelIcon } from "../../components/channel-icon.ts";
 import { handleCopyButton } from "../../components/copy-button.ts";
-import { renderWizardStepControls } from "../../components/wizard-step-controls.ts";
+import {
+  renderWizardBusyButton,
+  renderWizardStepControls,
+} from "../../components/wizard-step-controls.ts";
 import { t } from "../../i18n/index.ts";
 import "../../components/modal-dialog.ts";
 import { channelDocsUrl } from "./hub-meta.ts";
@@ -39,13 +42,12 @@ function renderNoteStep(step: ChannelWizardStep, props: ChannelWizardViewProps) 
   if (step.executor === "gateway") {
     return html`
       ${step.title ? html`<div class="channels-wizard__message">${step.title}</div>` : nothing}
-      <div class="channels-wizard__spinner" role="status" aria-live="polite">
-        ${message || t("channels.setup.working")}
-      </div>
+      ${message ? html`<div class="channels-wizard__message">${message}</div>` : nothing}
       <div class="channels-wizard__footer">
         <button type="button" class="btn" @click=${() => props.onClose()}>
           ${t("common.cancel")}
         </button>
+        ${renderWizardBusyButton(message || t("channels.setup.working"))}
       </div>
     `;
   }
@@ -71,14 +73,11 @@ function renderNoteStep(step: ChannelWizardStep, props: ChannelWizardViewProps) 
         `
       : nothing}
     <div class="channels-wizard__footer">
-      <button
-        type="button"
-        class="btn primary"
-        ?disabled=${stepIsBusy(props)}
-        @click=${() => props.onAnswer(null)}
-      >
-        ${t("channels.setup.continue")}
-      </button>
+      ${stepIsBusy(props)
+        ? renderWizardBusyButton(t("channels.setup.working"))
+        : html`<button type="button" class="btn primary" @click=${() => props.onAnswer(null)}>
+            ${t("channels.setup.continue")}
+          </button>`}
     </div>
   `;
 }
@@ -100,6 +99,7 @@ function renderStepBody(step: ChannelWizardStep, props: ChannelWizardViewProps) 
     presentation: "channels",
     channelSelect: props.wizard.phase === "step" && props.wizard.channel === null,
     answerLabel: t("channels.setup.continue"),
+    busyLabel: t("channels.setup.working"),
     sensitiveRevealed: props.secretVisible,
     onValueChange:
       step.type === "text"
@@ -128,11 +128,11 @@ function renderWhatsAppLinking(props: ChannelWizardViewProps) {
                   src=${props.whatsappQrDataUrl}
                   alt=${t("channels.setup.whatsappQrAlt")}
                 />`
-              : html`<div class="channels-wizard__spinner">
-                  ${props.whatsappBusy
-                    ? t("channels.setup.whatsappQrLoading")
-                    : t("channels.setup.whatsappQrHint")}
-                </div>`}
+              : props.whatsappBusy
+                ? nothing
+                : html`<div class="channels-wizard__spinner">
+                    ${t("channels.setup.whatsappQrHint")}
+                  </div>`}
           </div>
           <div class="channels-wizard__note">${t("channels.setup.whatsappScanHelp")}</div>
         `}
@@ -144,26 +144,26 @@ function renderWhatsAppLinking(props: ChannelWizardViewProps) {
             </button>
           `
         : html`
-            <button
-              type="button"
-              class="btn"
-              ?disabled=${props.whatsappBusy}
-              @click=${() => props.onWhatsAppStart(true)}
-            >
-              ${props.whatsappQrDataUrl ? t("channels.setup.regenerateQr") : t("common.showQr")}
-            </button>
-            ${props.whatsappQrDataUrl
-              ? html`
-                  <button
-                    type="button"
-                    class="btn primary"
-                    ?disabled=${props.whatsappBusy}
-                    @click=${() => props.onWhatsAppWait()}
-                  >
-                    ${t("common.waitForScan")}
+            ${props.whatsappBusy
+              ? renderWizardBusyButton(t("channels.setup.whatsappQrLoading"))
+              : html`
+                  <button type="button" class="btn" @click=${() => props.onWhatsAppStart(true)}>
+                    ${props.whatsappQrDataUrl
+                      ? t("channels.setup.regenerateQr")
+                      : t("common.showQr")}
                   </button>
-                `
-              : nothing}
+                  ${props.whatsappQrDataUrl
+                    ? html`
+                        <button
+                          type="button"
+                          class="btn primary"
+                          @click=${() => props.onWhatsAppWait()}
+                        >
+                          ${t("common.waitForScan")}
+                        </button>
+                      `
+                    : nothing}
+                `}
             <button type="button" class="btn" @click=${() => props.onClose()}>
               ${t("channels.setup.linkLater")}
             </button>
@@ -223,7 +223,9 @@ export function renderChannelWizard(
 
   let body: unknown;
   if (wizard.phase === "starting") {
-    body = html`<div class="channels-wizard__spinner">${t("channels.setup.starting")}</div>`;
+    body = html`<div class="channels-wizard__footer">
+      ${renderWizardBusyButton(t("channels.setup.starting"))}
+    </div>`;
   } else if (wizard.phase === "error") {
     body = html`
       <div class="channels-wizard__error">${wizard.message}</div>
@@ -241,9 +243,6 @@ export function renderChannelWizard(
         ? html`<div class="channels-wizard__error">${wizard.validationError}</div>`
         : nothing}
       ${renderStepBody(step, props)}
-      ${wizard.phase === "step" && wizard.busy && step.executor !== "gateway"
-        ? html`<div class="channels-wizard__spinner">${t("channels.setup.working")}</div>`
-        : nothing}
     `;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where channel setup showed a detached “Working…” line while the step controls were disabled, making the active operation look disconnected from the button that triggered it.

## Why This Change Was Made

Channel setup now uses the Control UI’s existing button spinner for every busy wizard surface: startup, note/action/progress, select, multiselect, text, confirmation, gateway-owned progress, and WhatsApp QR generation. Each state renders exactly one disabled busy action and keeps its status available to assistive technology.

## User Impact

Operators now see one consistent spinner button in the wizard action area instead of a separate “Working…” label during setup.

## Evidence

### Before

![Channel setup with a detached Working status](https://github.com/user-attachments/assets/e1178f89-6513-4441-ae35-a89ac7d3b298)

### After

![Channel setup with a spinner button](https://github.com/user-attachments/assets/92a821bd-9fe8-4eab-a2cd-c404a236f49b)

- Pre-fix regression proof: the cross-step busy-state test failed for all six interactive variants plus gateway progress.
- `node scripts/run-vitest.mjs ui/src/pages/channels/wizard-view.busy.test.ts ui/src/pages/channels/wizard-view.test.ts` — 24 passed.
- Focused mocked Gateway browser flow — 1 passed, 4 skipped.
- `node scripts/check-changed.mjs -- <changed files>` — passed.
- Structured autoreview — no actionable findings.
