### PR TITLE
fix(ui): unselected channel picker shows prompt

### DIFF
--- a/ui/src/components/select-picker.ts
+++ b/ui/src/components/select-picker.ts
@@ -46,6 +46,7 @@ export function renderPicker<Option extends PickerOption>(params: PickerParams<O
       class=${`settings-select picker-select ${params.className ?? ""}`}
       style="width:100%;min-width:min(138px,100%)"
       title=${params.title ?? nothing}
+      placeholder=${params.value === null ? params.label : nothing}
       placement=${params.placement ?? nothing}
       .value=${params.value}
       ?disabled=${params.disabled}

--- a/ui/src/pages/channels/wizard-view.busy.test.ts
+++ b/ui/src/pages/channels/wizard-view.busy.test.ts
@@ -123,6 +123,25 @@ describe("renderChannelWizard busy controls", () => {
     expect(group?.querySelector('[slot="label"]')?.textContent).toBe("Pick one");
   });
 
+  it("shows the channel prompt inside an unselected channel picker", () => {
+    const select = renderStep(
+      {
+        id: "channel",
+        type: "select",
+        message: "Select a channel",
+        options: [
+          { label: "Telegram", value: "telegram" },
+          { label: "Discord", value: "discord" },
+        ],
+      },
+      false,
+    );
+
+    expect(select.container.querySelector("wa-select")?.getAttribute("placeholder")).toBe(
+      "Select a channel",
+    );
+  });
+
   it("disables multiselect choices and submission while a step is running", () => {
     const multiselect = renderStep({
       id: "multi",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the generic channel setup wizard saw an empty selector before choosing a channel.

## Why This Change Was Made

The shared picker now uses its existing accessible label as Web Awesome's native placeholder whenever it has no selected value. This keeps the behavior generic and avoids adding a channel-specific fallback.

## User Impact

The empty channel selector now visibly says “Select a channel,” so the next action is clear.

## Evidence

### Before

![Blank channel selector before the fix](https://github.com/user-attachments/assets/6d5acc25-1e9e-4ead-8199-d8696a76d765)

### After

![Channel selector showing Select a channel](https://github.com/user-attachments/assets/37185a81-5aa4-4669-966c-e9f1f7b13614)

- Regression: `node scripts/run-vitest.mjs ui/src/pages/channels/wizard-view.busy.test.ts` failed before the fix (`placeholder` was `null`) and passes after it.
- Focused picker coverage: `node scripts/run-vitest.mjs ui/src/pages/channels/wizard-view.busy.test.ts ui/src/components/select-picker.test.ts ui/src/components/channel-picker.test.ts` (11 passed).
- Repository changed-file gate: `node scripts/check-changed.mjs -- ui/src/components/select-picker.ts ui/src/pages/channels/wizard-view.busy.test.ts` passed in a fresh normal checkout.
- Browser proof: deterministic mocked Gateway flow asserted both the `wa-select` placeholder and Web Awesome's visible display-input placeholder before capturing the after screenshot.
- Structured review: clean; no accepted or actionable findings.

Root cause: the picker consolidation in #122964 replaced the channel radio group with Web Awesome but did not provide its built-in placeholder for the null selection state.

Production LOC: +1/-0 (net +1) | Tests: +19/-0
