### PR TITLE
fix(transcripts): report auto-start shutdown warnings

### DIFF
--- a/docs/cli/transcripts.md
+++ b/docs/cli/transcripts.md
@@ -103,14 +103,22 @@ when it will not repeat on the same date.
 
 ## Missing summaries
 
-Live sessions store and materialize `summary.md` when the session stops;
-imported transcripts do so immediately after import. A session can appear in
-`list` without a summary while capture is still active, if a provider failed
-during stop, or if metadata was stored before any utterances arrived.
+Live sessions save summaries when capture stops; imported transcripts do so
+immediately after import. Tool-driven stops, configured auto-start shutdown, and
+imports also attempt to materialize `summary.md`. A session can appear in `list`
+without a summary while capture is still active, if a provider failed during stop,
+or if metadata was stored before any utterances arrived.
 
 Use `path <session> --transcript` to inspect the raw append-only transcript,
 or run the `transcripts` tool's `summarize` action to regenerate the Markdown
 summary.
+
+Summaries are saved in SQLite before optional artifact export. If export fails,
+the saved summary remains available even when `summary.md` is missing. Configured
+auto-start captures log warnings during shutdown for failed exports or provider
+stop errors. Correct the export destination problem, then run
+`openclaw transcripts path <session>` or `openclaw transcripts show <session>`
+to retry the export; an intended path in a warning is not proof of an exported file.
 
 Historical sessions without complete account-owner metadata remain on a local
 recovery path. Recover an agent-owned row with a local turn for that agent; a row

--- a/src/agents/tools/transcripts-tool.auto-start.test.ts
+++ b/src/agents/tools/transcripts-tool.auto-start.test.ts
@@ -1,0 +1,229 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hasTerminalControl } from "../../../packages/terminal-core/src/safe-text.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  closeOpenClawStateDatabaseForTest,
+  getOpenClawStateDatabaseIfOpen,
+} from "../../state/openclaw-state-db.js";
+import type {
+  TranscriptSourceProvider,
+  TranscriptStartRequest,
+  TranscriptStopRequest,
+} from "../../transcripts/provider-types.js";
+import { TranscriptsStore } from "../../transcripts/store.js";
+import { createTranscriptsAutoStartService, createTranscriptsTool } from "./transcripts-tool.js";
+
+const tempDirs = createTempDirTracker();
+const capturedText = "Private captured decision: keep these notes out of operator logs.";
+const obstruction = "existing file; do not overwrite\n";
+const credential = "fixture-secret-value-1234567890";
+const providerError = `fixture stop failure\n\u001b[31mred\u001b[0m\u0085 token=${credential} ${"🦞".repeat(2_000)}`;
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  tempDirs.cleanup();
+});
+
+describe("transcripts auto-start stop reporting", () => {
+  it.each([
+    { name: "export failure", blocked: true, outcome: "ok", manual: false },
+    { name: "fulfilled provider warning", blocked: false, outcome: "warn", manual: false },
+    { name: "both warnings", blocked: true, outcome: "warn", manual: false },
+    { name: "healthy stop", blocked: false, outcome: "ok", manual: false },
+    { name: "thrown provider error", blocked: false, outcome: "throw", manual: false },
+    {
+      name: "manual export failure then skipped auto-stop",
+      blocked: true,
+      outcome: "ok",
+      manual: true,
+    },
+    {
+      name: "manual both warnings then skipped auto-stop",
+      blocked: true,
+      outcome: "warn",
+      manual: true,
+    },
+  ])("$name preserves state and finishes siblings", async ({ blocked, outcome, manual }) => {
+    const stateDir = await fs.realpath(tempDirs.make("openclaw-transcripts-auto-stop-"));
+    const options = { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } };
+    const exportRoot = path.join(stateDir, "transcripts");
+    const store = new TranscriptsStore(exportRoot, options);
+    const requests = new Map<string, TranscriptStartRequest>();
+    const subjectId = "subject";
+    const ids = [subjectId, "healthy-sibling"];
+    const gates = new Map(ids.map((id) => [id, createDeferred()]));
+    const stop = vi.fn(async ({ sessionId }: TranscriptStopRequest) => {
+      if (sessionId === subjectId) {
+        if (outcome === "throw" && stop.mock.calls.length === 1) {
+          throw new Error(providerError);
+        }
+        if (outcome === "warn") {
+          return { ok: false as const, error: providerError };
+        }
+      }
+      return { ok: true as const, sessionId };
+    });
+    const provider: TranscriptSourceProvider = {
+      id: "stop-reporting-fixture",
+      name: "Stop reporting fixture",
+      sourceKinds: ["live-caption"],
+      async start(request) {
+        requests.set(request.session.sessionId, request);
+        await gates.get(request.session.sessionId)?.promise;
+        return { ok: true, session: request.session };
+      },
+      stop,
+    };
+    const registry = createEmptyPluginRegistry();
+    registry.transcriptSourceProviders.push({
+      pluginId: provider.id,
+      provider,
+      source: import.meta.url,
+    });
+    const logger = { warn: vi.fn<(message: string) => void>() };
+    const ctx = {
+      config: {
+        transcripts: {
+          enabled: true,
+          autoStart: ids.map((sessionId) => ({ providerId: provider.id, sessionId })),
+        },
+      },
+      stateDir,
+      logger,
+      caller: { kind: "operator" as const, source: "local" as const },
+    };
+    const service = createTranscriptsAutoStartService(ctx);
+    const tool = createTranscriptsTool(ctx);
+    const execute = (action: string, sessionId?: string) =>
+      tool.execute("stop-proof", { action, sessionId });
+
+    await withPluginRuntimeRegistryScope(registry, async () => {
+      try {
+        service.start();
+        for (const id of ids) {
+          gates.get(id)?.resolve();
+          await vi.waitFor(async () => {
+            expect(await execute("status")).toMatchObject({
+              details: {
+                active: expect.arrayContaining([expect.objectContaining({ sessionId: id })]),
+              },
+            });
+          });
+          const request = requests.get(id)!;
+          await request.onUtterance({ text: capturedText, final: true });
+          await expect(store.readUtterancesForSession(request.session)).resolves.toEqual([
+            expect.objectContaining({ text: capturedText }),
+          ]);
+        }
+        const subject = requests.get(subjectId)!.session;
+        const sessionDir = store.sessionDir(subject);
+        const summaryPath = path.join(sessionDir, "summary.md");
+        if (blocked) {
+          // Fault only the optional export, after provider admission and durable capture.
+          await fs.mkdir(path.dirname(sessionDir), { recursive: true });
+          await fs.writeFile(sessionDir, obstruction, { flag: "wx" });
+        }
+        if (manual) {
+          const result = await execute("stop", subject.sessionId);
+          expect(result.details).toMatchObject({
+            summaryExportError: expect.stringContaining("ENOTDIR"),
+            intendedSummaryPath: summaryPath,
+            summary: { utteranceCount: 1 },
+          });
+          expect(result.details).not.toHaveProperty("summaryPath");
+          if (outcome === "warn") {
+            expect(result.details).toHaveProperty("providerStopError", providerError);
+          } else {
+            expect(result.details).not.toHaveProperty("providerStopError");
+          }
+        }
+        await expect(service.stop()).resolves.toBeUndefined();
+        expect(stop.mock.calls.map(([request]) => request.sessionId)).toEqual(ids);
+        const warnings = logger.warn.mock.calls.map(([message]) => message);
+        await service.stop();
+        expect(stop).toHaveBeenCalledTimes(2);
+        expect(logger.warn.mock.calls.map(([message]) => message)).toEqual(warnings);
+
+        const database = getOpenClawStateDatabaseIfOpen(options)!;
+        expect(database.db.isOpen).toBe(true);
+        expect(closeOpenClawStateDatabaseByPath(database.path)).toBe(true);
+        expect(database.db.isOpen).toBe(false);
+        const reopened = new TranscriptsStore(exportRoot, options);
+        for (const id of ids) {
+          const stored = (await reopened.readSession(id))!;
+          const summary = await reopened.readSummary(stored);
+          if (id === subject.sessionId && outcome === "throw") {
+            expect(stored.stoppedAt).toBeUndefined();
+            expect(summary).toEqual({});
+            continue;
+          }
+          expect(stored.stoppedAt).toEqual(expect.any(String));
+          expect(summary).toMatchObject({
+            summary: { utteranceCount: 1, transcript: [capturedText] },
+            markdown: expect.stringContaining(capturedText),
+          });
+          if (id === subject.sessionId && blocked) {
+            expect((await fs.lstat(sessionDir)).isFile()).toBe(true);
+            expect(await fs.readFile(sessionDir, "utf8")).toBe(obstruction);
+            await expect(fs.readFile(summaryPath)).rejects.toMatchObject({ code: "ENOTDIR" });
+          } else {
+            expect(
+              await fs.readFile(path.join(reopened.sessionDir(stored), "summary.md"), "utf8"),
+            ).toContain(capturedText);
+          }
+        }
+        expect(getOpenClawStateDatabaseIfOpen(options)).not.toBe(database);
+        await expect(execute("status")).resolves.toMatchObject({
+          details: {
+            active:
+              outcome === "throw"
+                ? [expect.objectContaining({ sessionId: subject.sessionId })]
+                : [],
+          },
+        });
+
+        if (manual || (!blocked && outcome === "ok")) {
+          expect(warnings).toEqual([]);
+        } else {
+          expect(warnings.length).toBeGreaterThan(0);
+          const logged = warnings.join(" ");
+          expect(logged).toContain(subject.sessionId);
+          if (blocked) {
+            expect(logged).toMatch(/summary saved.*export failed/i);
+            expect(logged).toContain("ENOTDIR");
+            expect(logged).toContain(JSON.stringify(summaryPath));
+            expect(logged).toContain("openclaw transcripts path <session>");
+            expect(logged).toMatch(/(?:repair|correct).*destination/i);
+          }
+          if (outcome !== "ok") {
+            expect(logged).toContain("fixture stop failure");
+            expect(logged).toMatch(outcome === "throw" ? /stop failed/ : /provider stop failed/);
+          }
+          for (const warning of warnings) {
+            expect(warning.length).toBeLessThanOrEqual(2_200);
+            expect(hasTerminalControl(warning)).toBe(false);
+            expect(warning).not.toMatch(/[\uD800-\uDFFF]/u);
+            expect(warning).not.toContain(credential);
+            expect(warning).not.toContain(capturedText);
+            expect(warning).not.toContain('"transcript":');
+          }
+        }
+      } finally {
+        for (const gate of gates.values()) {
+          gate.resolve();
+        }
+        await service.stop();
+        // Thrown provider stops retain capture ownership; clean up via the public tool.
+        for (const id of requests.keys()) {
+          await execute("stop", id);
+        }
+      }
+    });
+  });
+});

--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -7,8 +7,10 @@ import path from "node:path";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { Type } from "typebox";
+import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 import { resolveStateDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import {
   type ResolvedTranscriptsAutoStartConfig,
   resolveTranscriptsConfig,
@@ -22,6 +24,7 @@ import type {
 import { sanitizeTranscriptSourceLocator } from "../../transcripts/source-locator.js";
 import { TranscriptsStore, type TranscriptsSessionEntry } from "../../transcripts/store.js";
 import { summarizeTranscripts } from "../../transcripts/summary.js";
+import { truncateUtf16Safe } from "../../utils.js";
 import type { AnyAgentTool } from "./common.js";
 import {
   activeSessions,
@@ -41,6 +44,10 @@ const AUTO_START_RETRY_ATTEMPTS = 12;
 const AUTO_START_RETRY_MS = 5_000;
 const AUTO_START_STOP_TIMEOUT_MS = 5_000;
 const AUTO_START_PROVIDER_READY_TIMEOUT_MS = 30_000;
+
+function formatAutoStopDiagnostic(value: unknown): string {
+  return JSON.stringify(truncateUtf16Safe(sanitizeTerminalText(formatErrorMessage(value)), 300));
+}
 
 type TranscriptSessionIdentity = Pick<TranscriptSessionDescriptor, "sessionId" | "startedAt">;
 
@@ -582,20 +589,36 @@ export function createTranscriptsAutoStartService(ctx: TranscriptsRuntimeContext
       }
       const store = createStore(ctx);
       for (const [sessionId, lifecycleToken] of startedSessions) {
-        await stopTranscripts({
-          ctx,
-          store,
-          rawParams: { action: "stop", sessionId },
-          // Bypass authorization only while the exact capture created by this
-          // service is still active; a reused id may belong to another owner.
-          lifecycleToken,
-        }).catch((err: unknown) =>
+        const warnings: string[] = [];
+        try {
+          const { details } = await stopTranscripts({
+            ctx,
+            store,
+            rawParams: { action: "stop", sessionId },
+            // Bypass authorization only while the exact capture created by this
+            // service is still active; a reused id may belong to another owner.
+            lifecycleToken,
+          });
+          // Fulfillment can include partial success; only diagnostics belong in logs,
+          // never the tool content or summary. Skipped captures have no warnings.
+          if (typeof details.summaryExportError === "string") {
+            warnings.push(
+              `summary saved; export failed intendedSummaryPath=${formatAutoStopDiagnostic(details.intendedSummaryPath)}: ${formatAutoStopDiagnostic(details.summaryExportError)}. Correct the export destination, then run openclaw transcripts path <session> or openclaw transcripts show <session>.`,
+            );
+          }
+          if (typeof details.providerStopError === "string") {
+            warnings.push(
+              `provider stop failed: ${formatAutoStopDiagnostic(details.providerStopError)}. Check the provider capture status and connection.`,
+            );
+          }
+        } catch (error) {
+          warnings.push(`stop failed: ${formatAutoStopDiagnostic(error)}`);
+        }
+        for (const warning of warnings) {
           ctx.logger.warn(
-            `transcripts autoStart stop failed session=${sessionId}: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          ),
-        );
+            `transcripts autoStart session=${formatAutoStopDiagnostic(sessionId)}: ${warning}`,
+          );
+        }
       }
       startedSessions.clear();
     },


### PR DESCRIPTION
Closes #131375 ([transcript auto-start shutdown warning loss](https://github.com/openclaw/openclaw/issues/131375)).

## What Problem This Solves

Fixes an issue where operators using configured transcript auto-start captures would receive no warning when shutdown saved meeting notes but failed to export their files. The same unattended stop path also discarded fulfilled provider-stop warnings.

## Why This Change Was Made

Refactor the existing auto-start stop loop into one result/error reporting flow. Consume the existing structured warning fields rather than discarding fulfilled tool results; reuse the existing logger with redacted, escaped, bounded diagnostic values. Export warnings distinguish a saved summary from a failed artifact, label the intended path, and explain how to retry after correcting the destination.

Canonical summary persistence remains successful, healthy sibling captures still finish, and intentional skipped ownership outcomes remain quiet. The manual tool result, lifecycle/stop tokens, storage/schema, transcript ID admission, fs-safe classification, provider cleanup/retry policy, and Gateway shutdown ordering are unchanged. No new configuration, dependency, or public API is introduced.

## User Impact

Operators now get actionable warnings in the normal Gateway logging surface instead of discovering missing exported summaries later. Notes remain durable when export fails, and warning logs do not include transcript or summary payloads. The [transcripts CLI documentation](https://docs.openclaw.ai/cli/transcripts) now explains this distinction and explicit export recovery.

## Evidence

AI-assisted implementation with direct owner/caller/sibling inspection and an independent Codex autoreview; no accepted/actionable findings from the blocking review pass.

- **Before/after regression:** the new seven-case auto-start suite failed on original source for export-only, provider-only, and combined warning loss (zero warnings), plus the existing unbounded thrown-error diagnostic. The exact suite passes after the repair.
- **Original independent reproduction, unchanged:** seven scenarios now pass the expected-warning invariant using real service start/status/utterance/stop ordering, a native post-start `ENOTDIR` export obstruction, SQLite close/reopen, and the actual subsystem file logger. Summary durability, unchanged obstruction, sibling continuation, repeated stop, manual result fields, and warning delivery were verified. All task-owned state and database handles were cleaned up.
- **Focused owner/sibling tests:** 81 tests passed across transcript tool/auto-start/account ownership/import, transcript store, transcript CLI, and meeting bridge suites.
- **Formatting:** targeted oxfmt and `git diff --check` passed.
- **Changed gate:** full `check-changed` run passed without skipped guards: production types, all 14 core test type graphs, changed-file lint/format, unused-export scans, plugin boundaries, schema/storage guards, runtime-loader checks, and import cycles. Initial test-only type/lint compatibility errors were repaired using existing helpers and supported assertions, without compiler, guard, dependency, or baseline changes. The final path-quoting assertion and documentation clarification were separately rechecked with the focused seven-case suite, typed lint, formatting, and diff checks.
- **Build:** `pnpm build` passed all phases, including CLI bootstrap, plugin SDK exports, and Control UI sidecar/budget checks. No ineffective dynamic import warning was emitted; runtime source was unchanged by subsequent test/docs refinements.

Focused command:

```bash
node scripts/run-vitest.mjs src/agents/tools/transcripts-tool.auto-start.test.ts src/agents/tools/transcripts-tool.test.ts src/agents/tools/transcripts-tool.import.test.ts src/agents/tools/transcripts-tool.account-ownership.test.ts src/transcripts/store.test.ts src/cli/program/register.transcripts.test.ts src/meeting-bot/transcripts-bridge.test.ts
```

Observed transcript warning progression (isolated paths abbreviated):

```text
Before: auto-export -> summary persisted; export absent; warnings=[]
After:  transcripts autoStart session="auto-export": summary saved; export failed intendedSummaryPath="<isolated-state>/.../summary.md": "Error: ENOTDIR: not a directory, scandir ...". Correct the export destination, then run openclaw transcripts path <session> or openclaw transcripts show <session>.
After:  transcripts autoStart session="provider-warning": provider stop failed: "fixture stop warning". Check the provider capture status and connection.
```

Production LOC: +36/-13 (net +23). Tests: +229/-0. Docs: +12/-4 (net +8). The old catch-only reporting path is replaced rather than retained. Production growth implements the missing two-stage lifecycle warning reporting and bounded/redacted rendering; no unrelated deletion was used to reduce the count.

Proof boundary: the real in-process lifecycle/store/log sink was exercised with a fixture external provider; no real Discord/meeting connection, live Gateway service, or UI was used. No external provider API changed. The existing rejected-provider-stop cleanup-retention behavior and aggregate Gateway shutdown warning summary remain separate follow-ups, not changes in this PR.

Release-note context: transcript auto-start shutdown now reports failed summary exports and provider-stop warnings while preserving saved notes and continuing sibling cleanup.
