### PR TITLE
fix(test): avoid slow and incorrect test discovery in large checkouts

### DIFF
--- a/scripts/lib/extension-test-plan.mts
+++ b/scripts/lib/extension-test-plan.mts
@@ -161,37 +161,37 @@ function isSkippedTrackedTestFile(relativePath: string) {
 let trackedRepoTestFiles: string[] | null | undefined;
 // Large checkouts exceed Node's 1 MiB spawnSync default. Preserve the Git inventory path;
 // ENOBUFS would otherwise trigger expensive extension-directory walks.
-const GIT_LS_FILES_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
+export const GIT_LS_FILES_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
 
-function loadTrackedRepoTestFiles() {
-  if (trackedRepoTestFiles !== undefined) {
-    return trackedRepoTestFiles;
-  }
-
+export function listTrackedTestPlanFiles(cwd: string, pathspecs: readonly string[]) {
   // Query only the planner-owned tree: a full-repo inventory can overflow
   // spawnSync's buffer and either truncate the plan or force directory walks.
-  const result = spawnSync("git", ["ls-files", "--", ...TRACKED_EXTENSION_TEST_PATHSPECS], {
-    cwd: repoRoot,
+  const result = spawnSync("git", ["ls-files", "--", ...pathspecs], {
+    cwd,
     encoding: "utf8",
     maxBuffer: GIT_LS_FILES_MAX_BUFFER_BYTES,
     stdio: ["ignore", "pipe", "ignore"],
   });
   if (result.status !== 0 || result.error) {
-    trackedRepoTestFiles = null;
-    return trackedRepoTestFiles;
+    return null;
   }
-
-  // Tracked repository metadata is immutable during one planner invocation.
-  // Reuse one inventory so broad extension plans do not fork Git per plugin.
-  trackedRepoTestFiles = result.stdout
+  return result.stdout
     .split("\n")
     .map((line) => line.trim().replaceAll("\\", "/"))
-    .filter(
-      (line) =>
-        line.length > 0 &&
-        !isSkippedTrackedTestFile(line) &&
-        (line.endsWith(".test.ts") || line.endsWith(".test.tsx")),
-    );
+    .filter(Boolean);
+}
+
+function loadTrackedRepoTestFiles() {
+  // Tracked repository metadata is immutable during one planner invocation.
+  // Reuse one inventory so broad extension plans do not fork Git per plugin.
+  if (trackedRepoTestFiles === undefined) {
+    trackedRepoTestFiles =
+      listTrackedTestPlanFiles(repoRoot, TRACKED_EXTENSION_TEST_PATHSPECS)?.filter(
+        (line) =>
+          !isSkippedTrackedTestFile(line) &&
+          (line.endsWith(".test.ts") || line.endsWith(".test.tsx")),
+      ) ?? null;
+  }
   return trackedRepoTestFiles;
 }
 

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -1,7 +1,7 @@
 // Test-project planning helpers used by scripts/run-vitest.mts,
 // scripts/test-projects.mts, and focused tests. Exports are intentionally
 // granular so project selection stays testable without spawning Vitest.
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncOptionsWithStringEncoding } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -93,7 +93,9 @@ import {
 import { parsePermissiveBooleanToken } from "./lib/arg-utils.mts";
 import { getChangedPathFacts } from "./lib/changed-path-facts.mjs";
 import {
+  GIT_LS_FILES_MAX_BUFFER_BYTES,
   createExtensionTestProcessTargetChunks,
+  listTrackedTestPlanFiles,
   splitExtensionTestProcessTargets,
 } from "./lib/extension-test-plan.mts";
 import {
@@ -154,6 +156,7 @@ type ImportGraph = {
   reverseReexports: Map<string, string[]>;
   testFiles: Set<string>;
 };
+type ImportGraphEdges = { file: string; imports: Set<string>; reexports: Set<string> };
 type UnmatchedExplicitTestTarget = {
   target: string;
   reason: "glob-matched-no-files" | "path-does-not-exist" | "target-matched-no-test-files";
@@ -1145,6 +1148,7 @@ function listExplicitTestTargetFilesFromGit(cwd: string) {
     {
       cwd,
       encoding: "utf8",
+      maxBuffer: GIT_LS_FILES_MAX_BUFFER_BYTES,
       stdio: ["ignore", "pipe", "pipe"],
     },
   );
@@ -1480,30 +1484,11 @@ function resolveImportSpecifier(
 let cachedImportGraph: ImportGraph | null = null;
 let cachedImportGraphCwd: string | null = null;
 const cachedImportGraphFiles = new Map<string, string[]>();
-const cachedImportGraphGrepMatches = new Map<string, string[] | null>();
-const cachedDirectImporters = new Map<string, string[] | null>();
+const cachedImportGraphGrepMatches = new Map<string, ImportGraphEdges[] | null>();
+const cachedImportGraphEdges = new Map<string, ImportGraphEdges>();
 
 function isImportableGraphFile(relative: string) {
   return IMPORTABLE_FILE_EXTENSIONS.some((ext) => relative.endsWith(ext));
-}
-
-function listImportGraphFilesFromGit(
-  cwd: string,
-  roots: readonly string[],
-  extensions: readonly string[],
-) {
-  const result = spawnSync("git", ["ls-files", "--", ...roots], {
-    cwd,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  if (result.status !== 0) {
-    return null;
-  }
-  return result.stdout
-    .split("\n")
-    .map((line) => normalizePathPattern(line.trim()))
-    .filter((line) => line.length > 0 && extensions.some((ext) => line.endsWith(ext)));
 }
 
 function listImportGraphFilesForCwd(cwd: string, options: ImportGraphOptions = {}) {
@@ -1515,8 +1500,10 @@ function listImportGraphFilesForCwd(cwd: string, options: ImportGraphOptions = {
   const roots = tooling ? TOOLING_IMPORT_GRAPH_ROOTS : SOURCE_ROOTS_FOR_IMPORT_GRAPH;
   const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
   const files =
-    listImportGraphFilesFromGit(cwd, roots, extensions) ??
-    roots.flatMap((root) => listImportGraphFiles(cwd, root, [], extensions));
+    listTrackedTestPlanFiles(
+      cwd,
+      tooling ? TOOLING_IMPORT_GRAPH_GREP_PATHS : IMPORT_GRAPH_GREP_PATHS,
+    ) ?? roots.flatMap((root) => listImportGraphFiles(cwd, root, [], extensions));
   cachedImportGraphFiles.set(cacheKey, files);
   return files;
 }
@@ -1538,7 +1525,7 @@ function resolveImportGraphSearchTerms(
   extensions: readonly string[] = IMPORTABLE_FILE_EXTENSIONS,
 ) {
   const withoutExtension = stripImportableGraphExtension(relative, extensions);
-  const basename = path.posix.basename(stripImportableGraphExtension(relative, extensions));
+  const basename = path.posix.basename(withoutExtension);
   if (basename === "index" || basename.length < 3) {
     return [];
   }
@@ -1554,15 +1541,68 @@ function resolveImportGraphSearchTerms(
   return [...new Set(terms)];
 }
 
-function listImportGraphGrepMatches(cwd: string, term: string, options: ImportGraphOptions = {}) {
-  const tooling = options.tooling === true;
-  const cacheKey = `${cwd}\0${tooling ? "tooling" : "source"}\0${term}`;
-  if (cachedImportGraphGrepMatches.has(cacheKey)) {
-    return cachedImportGraphGrepMatches.get(cacheKey) ?? null;
+function readImportGraphEdges(
+  cwd: string,
+  file: string,
+  fileSet: ReadonlySet<string>,
+  tooling = false,
+  suppliedSource?: string,
+) {
+  const cacheKey = `${cwd}\0${tooling}\0${file}`;
+  const cached = cachedImportGraphEdges.get(cacheKey);
+  if (cached) {
+    return cached;
   }
+  let source;
+  try {
+    source = suppliedSource ?? fs.readFileSync(path.join(cwd, file), "utf8");
+  } catch {
+    return null;
+  }
+  const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
+  const resolve = (pattern: RegExp) =>
+    new Set(
+      [...source.matchAll(pattern)]
+        .map((match) =>
+          resolveImportSpecifier(file, match[1] ?? match[2] ?? "", fileSet, extensions),
+        )
+        .filter((imported) => imported !== null),
+    );
+  const edges = {
+    file,
+    imports: resolve(IMPORT_SPECIFIER_PATTERN),
+    reexports: resolve(REEXPORT_SPECIFIER_PATTERN),
+  };
+  cachedImportGraphEdges.set(cacheKey, edges);
+  return edges;
+}
 
+function listImportGraphGrepMatches(
+  cwd: string,
+  terms: string[],
+  options: ImportGraphOptions = {},
+) {
+  const tooling = options.tooling === true;
+  const cacheKey = (term: string) => `${cwd}\0${tooling}\0${term}`;
+  const matches = new Map(
+    terms.map((term) => [term, cachedImportGraphGrepMatches.get(cacheKey(term)) ?? null]),
+  );
+  const missing = [...new Set(terms)].filter(
+    (term) => !cachedImportGraphGrepMatches.has(cacheKey(term)),
+  );
+  if (missing.length === 0) {
+    return matches;
+  }
   const roots = tooling ? TOOLING_IMPORT_GRAPH_ROOTS : SOURCE_ROOTS_FOR_IMPORT_GRAPH;
   const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
+  const spawnOptions: SpawnSyncOptionsWithStringEncoding = {
+    cwd,
+    encoding: "utf8",
+    // A frontier can exceed the platform argv limit; both search tools accept stdin patterns.
+    input: missing.join("\n"),
+    maxBuffer: GIT_LS_FILES_MAX_BUFFER_BYTES,
+    stdio: ["pipe", "pipe", "pipe"],
+  };
   let result = spawnSync(
     "rg",
     [
@@ -1577,15 +1617,12 @@ function listImportGraphGrepMatches(cwd: string, term: string, options: ImportGr
       "!**/dist/**",
       "--glob",
       "!**/vendor/**",
-      term,
+      "-f",
+      "-",
       "--",
       ...roots,
     ],
-    {
-      cwd,
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-    },
+    spawnOptions,
   );
   if (result.error || (result.status !== 0 && result.status !== 1)) {
     result = spawnSync(
@@ -1594,68 +1631,65 @@ function listImportGraphGrepMatches(cwd: string, term: string, options: ImportGr
         "grep",
         "-l",
         "--fixed-strings",
-        term,
+        "-f",
+        "-",
         "--",
         ...(tooling ? TOOLING_IMPORT_GRAPH_GREP_PATHS : IMPORT_GRAPH_GREP_PATHS),
       ],
-      {
-        cwd,
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      },
+      spawnOptions,
     );
   }
-  if (result.status === 1) {
-    cachedImportGraphGrepMatches.set(cacheKey, []);
-    return [];
+  for (const term of missing) {
+    matches.set(term, result.status === 0 || result.status === 1 ? [] : null);
   }
-  if (result.status !== 0) {
-    cachedImportGraphGrepMatches.set(cacheKey, null);
-    return null;
+  if (result.status === 0) {
+    const trackedFiles = new Set(listImportGraphFilesForCwd(cwd, { tooling }));
+    const candidates = result.stdout
+      .split("\n")
+      .map((line) => normalizePathPattern(line.trim()))
+      .filter((file) => trackedFiles.has(file))
+      .toSorted((left, right) => left.localeCompare(right));
+    for (const file of candidates) {
+      let source;
+      try {
+        source = fs.readFileSync(path.join(cwd, file), "utf8");
+      } catch {
+        continue;
+      }
+      // Keep per-term membership: the broad-term cap and helper first-success rule
+      // apply to each search, not the union of the frontier's candidates.
+      const edges = readImportGraphEdges(cwd, file, trackedFiles, tooling, source);
+      if (edges) {
+        for (const term of missing) {
+          if (source.includes(term)) {
+            matches.get(term)?.push(edges);
+          }
+        }
+      }
+    }
   }
-  const trackedFiles = new Set(listImportGraphFilesForCwd(cwd, { tooling }));
-  const matches = result.stdout
-    .split("\n")
-    .map((line) => normalizePathPattern(line.trim()))
-    .filter(
-      (line) =>
-        line.length > 0 &&
-        trackedFiles.has(line) &&
-        (tooling
-          ? TOOLING_IMPORTABLE_FILE_EXTENSIONS.some((ext) => line.endsWith(ext))
-          : isImportableGraphFile(line)),
-    )
-    .toSorted((left, right) => left.localeCompare(right));
-  cachedImportGraphGrepMatches.set(cacheKey, matches);
+  for (const term of missing) {
+    cachedImportGraphGrepMatches.set(cacheKey(term), matches.get(term) ?? null);
+  }
   return matches;
 }
 
-function findDirectImportersWithGitGrep(
-  cwd: string,
+function findDirectImporters(
   importedFile: string,
-  fileSet: ReadonlySet<string>,
-  options: ImportGraphOptions = {},
+  matches: ReadonlyMap<string, ImportGraphEdges[] | null>,
+  extensions: readonly string[],
 ) {
-  const tooling = options.tooling === true;
-  const cacheKey = `${cwd}\0${tooling ? "tooling" : "source"}\0${importedFile}`;
   const isTestHelper = importedFile.startsWith("test/helpers/");
-  if (cachedDirectImporters.has(cacheKey)) {
-    return cachedDirectImporters.get(cacheKey) ?? null;
-  }
-
-  const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
   const terms = resolveImportGraphSearchTerms(importedFile, extensions);
   if (terms.length === 0) {
-    cachedDirectImporters.set(cacheKey, null);
     return null;
   }
 
   let skippedBroadTerm = false;
   const importers: string[] = [];
   for (const term of terms) {
-    const candidates = listImportGraphGrepMatches(cwd, term, { tooling });
+    const candidates = matches.get(term);
     if (!candidates) {
-      cachedDirectImporters.set(cacheKey, null);
       return null;
     }
     // Central test helpers intentionally fan out broadly; incomplete scans silently drop owning tests.
@@ -1663,36 +1697,16 @@ function findDirectImportersWithGitGrep(
       skippedBroadTerm = true;
       continue;
     }
-    for (const file of candidates) {
-      if (file === importedFile || !fileSet.has(file) || importers.includes(file)) {
-        continue;
-      }
-      let source;
-      try {
-        source = fs.readFileSync(path.join(cwd, file), "utf8");
-      } catch {
-        continue;
-      }
-      for (const match of source.matchAll(IMPORT_SPECIFIER_PATTERN)) {
-        const imported = resolveImportSpecifier(
-          file,
-          match[1] ?? match[2] ?? "",
-          fileSet,
-          extensions,
-        );
-        if (imported === importedFile) {
-          importers.push(file);
-          break;
-        }
+    for (const { file, imports } of candidates) {
+      if (file !== importedFile && !importers.includes(file) && imports.has(importedFile)) {
+        importers.push(file);
       }
     }
     if (isTestHelper && importers.length > 0 && term.includes("/")) {
       break;
     }
   }
-  const result = skippedBroadTerm && importers.length === 0 && !isTestHelper ? null : importers;
-  cachedDirectImporters.set(cacheKey, result);
-  return result;
+  return skippedBroadTerm && importers.length === 0 && !isTestHelper ? null : importers;
 }
 
 function resolveAffectedTestsFromTargetedImportScan(
@@ -1711,28 +1725,32 @@ function resolveAffectedTestsFromTargetedImportScan(
   const testFiles = new Set(
     files.filter((file) => isTestFileTarget(file) && !file.endsWith(".live.test.ts")),
   );
-  const queue = [normalized];
-  const seen = new Set(queue);
+  let frontier = [normalized];
+  const seen = new Set(frontier);
   const targets = [];
-
-  for (const current of queue) {
-    const importers = findDirectImportersWithGitGrep(cwd, current, fileSet, { tooling });
-    if (importers === null) {
-      return null;
+  const extensions = tooling ? TOOLING_IMPORTABLE_FILE_EXTENSIONS : IMPORTABLE_FILE_EXTENSIONS;
+  while (frontier.length > 0) {
+    const terms = frontier.flatMap((file) => resolveImportGraphSearchTerms(file, extensions));
+    const matches = listImportGraphGrepMatches(cwd, terms, { tooling });
+    const next = [];
+    for (const current of frontier) {
+      const importers = findDirectImporters(current, matches, extensions);
+      if (importers === null) {
+        return null;
+      }
+      for (const importer of importers) {
+        if (seen.has(importer)) {
+          continue;
+        }
+        seen.add(importer);
+        if (testFiles.has(importer)) {
+          targets.push(importer);
+        } else if (options.direct !== true) {
+          next.push(importer);
+        }
+      }
     }
-    for (const importer of importers) {
-      if (seen.has(importer)) {
-        continue;
-      }
-      seen.add(importer);
-      if (testFiles.has(importer)) {
-        targets.push(importer);
-        continue;
-      }
-      if (options.direct !== true) {
-        queue.push(importer);
-      }
-    }
+    frontier = next;
   }
 
   return [...new Set(targets)].toSorted((left, right) => left.localeCompare(right));
@@ -1752,29 +1770,19 @@ function getImportGraph(cwd: string) {
   );
 
   for (const file of files) {
-    let source;
-    try {
-      source = fs.readFileSync(path.join(cwd, file), "utf8");
-    } catch {
+    const edges = readImportGraphEdges(cwd, file, fileSet);
+    if (!edges) {
       continue;
     }
-    for (const match of source.matchAll(IMPORT_SPECIFIER_PATTERN)) {
-      const imported = resolveImportSpecifier(file, match[1] ?? match[2] ?? "", fileSet);
-      if (!imported) {
-        continue;
+    for (const [imports, reverse] of [
+      [edges.imports, reverseImports],
+      [edges.reexports, reverseReexports],
+    ] as const) {
+      for (const imported of imports) {
+        const importers = reverse.get(imported) ?? [];
+        importers.push(file);
+        reverse.set(imported, importers);
       }
-      const importers = reverseImports.get(imported) ?? [];
-      importers.push(file);
-      reverseImports.set(imported, importers);
-    }
-    for (const match of source.matchAll(REEXPORT_SPECIFIER_PATTERN)) {
-      const imported = resolveImportSpecifier(file, match[1] ?? "", fileSet);
-      if (!imported) {
-        continue;
-      }
-      const importers = reverseReexports.get(imported) ?? [];
-      importers.push(file);
-      reverseReexports.set(imported, importers);
     }
   }
 
@@ -2938,16 +2946,18 @@ function resolveGithubYamlGuardTargets(changedPath: string) {
 
 function resolveDirectToolingReferenceTests(changedPath: string, cwd: string) {
   const normalized = normalizePathPattern(changedPath);
-  return (listImportGraphGrepMatches(cwd, normalized, { tooling: true }) ?? []).filter(
-    (file) =>
-      file !== "test/scripts/test-projects.test.ts" &&
-      !file.endsWith(".live.test.ts") &&
-      isTestFileTarget(file) &&
-      fs
-        .readFileSync(path.join(cwd, file), "utf8")
-        .match(/[A-Za-z0-9_.@+/-]{4,}/gu)
-        ?.includes(normalized),
-  );
+  return (listImportGraphGrepMatches(cwd, [normalized], { tooling: true }).get(normalized) ?? [])
+    .map(({ file }) => file)
+    .filter(
+      (file) =>
+        file !== "test/scripts/test-projects.test.ts" &&
+        !file.endsWith(".live.test.ts") &&
+        isTestFileTarget(file) &&
+        fs
+          .readFileSync(path.join(cwd, file), "utf8")
+          .match(/[A-Za-z0-9_.@+/-]{4,}/gu)
+          ?.includes(normalized),
+    );
 }
 
 function resolveToolingTestTargets(changedPath: string, cwd = process.cwd()) {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1131,6 +1131,98 @@ describe("scripts/test-projects changed-target routing", () => {
     ]);
   });
 
+  it("preserves Git membership for large changed and explicit test inventories", () => {
+    withTinyGitRepo(
+      {
+        ".gitignore": "src/runtime.ignored.test.ts\n",
+        "src/runtime.ts": "export const value = 1;\n",
+        "src/runtime.consumer.test.ts": 'import "./runtime.js";\n',
+      },
+      (cwd) => {
+        // Index-only padding reproduces a large checkout without thousands of fixture files.
+        const blob = spawnSync("git", ["hash-object", "-w", "--stdin"], {
+          cwd,
+          encoding: "utf8",
+          input: "",
+        });
+        expect(blob.status).toBe(0);
+        const padding = Array.from(
+          { length: 6_000 },
+          (_, index) =>
+            `100644 ${blob.stdout.trim()}\tsrc/padding/${index}-${"x".repeat(190)}.ts\n`,
+        ).join("");
+        const indexed = spawnSync("git", ["update-index", "--index-info"], {
+          cwd,
+          input: padding,
+        });
+        expect(indexed.status).toBe(0);
+        for (const root of ["extensions", "packages", "ui/src", "ui/config", "test"]) {
+          fs.mkdirSync(path.join(cwd, root), { recursive: true });
+        }
+        fs.writeFileSync(
+          path.join(cwd, "src/runtime.untracked.test.ts"),
+          'import "./runtime.js";\n',
+        );
+        fs.writeFileSync(path.join(cwd, "src/runtime.ignored.test.ts"), 'import "./runtime.js";\n');
+
+        expect(resolveChangedTestTargetPlan(["src/runtime.ts"], { cwd }).targets).toEqual([
+          "src/runtime.consumer.test.ts",
+        ]);
+        const includeFile = path.join(cwd, "include.json");
+        writeVitestIncludeFile(includeFile, ["src/**/*.test.ts"], { cwd });
+        expect(JSON.parse(fs.readFileSync(includeFile, "utf8")).toSorted()).toEqual([
+          "src/runtime.consumer.test.ts",
+          "src/runtime.untracked.test.ts",
+        ]);
+      },
+    );
+  });
+
+  it("follows converging import frontiers without crossing test boundaries", () => {
+    withTinyGitRepo(
+      {
+        "src/value.ts": 'export * from "./left/bridge.js";\n',
+        "src/left/bridge.ts": 'export * from "../value.js";\n',
+        "src/right/bridge.ts": 'export * from "../value.js";\n',
+        "src/other/bridge.ts": "export const unrelated = 1;\n",
+        "src/combined.consumer.test.ts":
+          'import "./left/bridge.js";\nimport("./right/bridge.js");\n',
+        "src/right.consumer.test.ts": 'import "./right/bridge.js";\n',
+        "src/other.consumer.test.ts": 'import "./other/bridge.js";\n',
+        "src/after-test.consumer.test.ts": 'import "./combined.consumer.test.js";\n',
+        "src/value.consumer.live.test.ts": 'import "./value.js";\n',
+      },
+      (cwd) => {
+        expect(resolveChangedTestTargetPlan(["src/value.ts"], { cwd }).targets).toEqual([
+          "src/combined.consumer.test.ts",
+          "src/right.consumer.test.ts",
+        ]);
+      },
+    );
+  });
+
+  it("keeps tooling imports direct while preserving literal file references", () => {
+    withTinyGitRepo(
+      {
+        "scripts/fixture-source.mts": "export const value = 1;\n",
+        "scripts/fixture-bridge.mts": 'export * from "./fixture-source.mjs";\n',
+        "test/scripts/direct.consumer.test.ts": 'import "../../scripts/fixture-source.mjs";\n',
+        "test/scripts/transitive.consumer.test.ts": 'import "../../scripts/fixture-bridge.mjs";\n',
+        "test/scripts/literal.consumer.test.ts": 'const fixture = "scripts/fixture-source.mts";\n',
+        "test/scripts/substring.consumer.test.ts":
+          'const fixture = "scripts/fixture-source.mts.bak";\n',
+      },
+      (cwd) => {
+        expect(
+          resolveChangedTestTargetPlan(["scripts/fixture-source.mts"], { cwd }).targets,
+        ).toEqual([
+          "test/scripts/direct.consumer.test.ts",
+          "test/scripts/literal.consumer.test.ts",
+        ]);
+      },
+    );
+  });
+
   it("routes many explicit source files through one import-graph-backed owner set", () => {
     let plans: ReturnType<typeof buildVitestRunPlans> = [];
     const files: Record<string, string> = {};


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where developers running targeted tests could spend minutes discovering helper dependents, causing the planner's own startup hook to exceed its 180-second limit and skip all 84 tests. In large checkouts, test discovery could also silently include the wrong files: untracked tests in changed-source impact plans, and ignored tests in explicit glob selections.

## Why This Change Was Made

The targeted import scanner searched the repository separately for each term of each reverse-import node and repeatedly parsed overlapping candidates. It now searches once per uncached frontier and shares parsed import edges with the existing full-graph fallback. Each term retains its own candidate membership, so the existing broad-term cap, central-helper first-success rule, direct-only tooling scan, stop-at-test boundary, and literal-reference checks remain intact. Patterns travel on stdin to avoid the operating system's argument-size limit.

Both affected Git inventories could exceed Node's default 1 MiB output buffer and silently fall back to a directory walk, changing their membership rules. Import discovery now reuses the existing scoped, bounded 16 MiB planner inventory implementation. Explicit glob discovery retains its distinct tracked-plus-untracked, exclude-ignored contract and uses the same finite bound.

Provenance: the per-node scan and import-inventory query without an explicit output bound are traceable to `dd4613a26870e6b0b1183becd7ebb17432a60ca5` (May 16, 2026; code author and committer @vincentkoc; no PR traced). The structure was carried forward by #117407 (tooling discovery, August 1) and #122572 (ripgrep optimization, August 12), both authored and merged by @steipete. This establishes code ancestry, not when repository growth first made the failures observable.

This removes the duplicate import-graph inventory query, per-node importer cache, and repeated parsing paths. A blanket full-graph replacement was evaluated but rejected because it slowed a narrow cold target and changed selected coverage. No timeout increase, new configuration, dependency change, or forced test environment is involved.

Tooling LOC: **+177 / −167 (net +10)**; tests: **+92 / −0**. The remaining tooling growth owns batched per-term selection and bounded stdin transport while consolidating inventory and parsing ownership. Product runtime code is unchanged.

## User Impact

Developers get faster targeted-test planning with the same selected coverage. Changed-source impact remains tracked-only; explicit globs still include newly authored untracked tests while respecting ignored files. There are no product configuration, protocol, storage, or user-facing runtime changes.

## Evidence

Two authentic regressions use a real Git index larger than 1 MiB, with index-only padding instead of thousands of physical fixture files:

- Before the import-inventory repair, changing a tracked source selected an untracked importing test. The fixed result selects only the tracked consumer.
- Before the explicit-inventory repair, glob expansion included an ignored test. The fixed result contains exactly the tracked and untracked consumers, excluding the ignored file. The assertion compares exact sorted membership and still rejects duplicates and omissions.

Preservation tests cover converging/cyclic import frontiers, same-basename isolation, stopping at test boundaries, live-test exclusion, direct-only tooling imports, and exact literal tooling references.

On the same source base and Node 24.20.0, all seven saved complete before/after plan objects and SHA-256 digests match. The four original startup calls changed as follows:

| Target | Cold before | Cold after | Repository searches |
| --- | ---: | ---: | ---: |
| Gateway connection test mocks | 5.887 s | 3.108 s | 3 → 1 |
| Memory runtime test mocks | 10.359 s | 3.701 s | 9 → 2 |
| Temporary-directory helper | 121.604 s | 13.041 s | 58 → 4 |
| Non-interactive onboarding helpers | 16.931 s | 6.237 s | 6 → 2 |

Total: **154.782 → 26.088 seconds**, with **76 → 9 searches**. The broad helper retains all 766 entries across 42 plans. An explicit owner, workflow literal references, and a separate narrow helper process also retain identical plans. Warm calls issue no subprocesses; fixed Git inventory queries exit successfully without ENOBUFS. These are observed standalone timings, not timing assertions or portable performance guarantees.

Validation on the unchanged production patch:

- `node scripts/run-vitest.mjs src/scripts/test-projects.test.ts`: **84 passed**, 32.56 seconds, fresh worker with no preceding test file and the original four-call hook order unchanged. The original Node 24 hook exceeded 180 seconds.
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts`: **305 passed**, original case order, 189.85 seconds.
- `test/scripts/test-extension.test.ts`: **158 passed** in the same-production grouped run. That grouped run exposed an incorrect ordering assumption in the new inventory fixture; exact membership was corrected and the complete 305-case planner file rerun successfully. No production ordering was changed.
- `node scripts/check-changed.mjs --base HEAD^ --head HEAD -- scripts/test-projects.test-support.mts scripts/lib/extension-test-plan.mts test/scripts/test-projects.test.ts`: **passed** on commit `63c62a28990f0dab590f8ab1948acd98daeb5ba0`, including script/root-test typechecks, formatting, targeted lint, and selected guards.
- One isolated Codex review at the default P0 scope: no accepted/actionable findings.

The real planner and real Git/ripgrep commands were exercised locally. This change does not involve a provider/channel API, product Gateway, or graphical interface; no live-provider or GUI proof is claimed.

AI-assisted implementation and review with Codex.
