### PR TITLE
fix(sandbox): stage inbound media up to 50 MiB

### DIFF
--- a/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
+++ b/src/auto-reply/reply.triggers.trigger-handling.stages-inbound-media-into-sandbox-workspace.test.ts
@@ -4,7 +4,7 @@ import path, { basename, dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MEDIA_MAX_BYTES } from "../media/store.js";
-import { stageSandboxMedia } from "./reply/stage-sandbox-media.js";
+import { SANDBOX_MEDIA_MAX_BYTES, stageSandboxMedia } from "./reply/stage-sandbox-media.js";
 import {
   createSandboxMediaContexts,
   createSandboxMediaStageConfig,
@@ -568,18 +568,18 @@ describe("stageSandboxMedia", () => {
     });
   });
 
-  it("skips oversized media staging and keeps original media paths", async () => {
+  it("stages media above the generic media-store limit", async () => {
     await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
       const { cfg, workspaceDir, sandboxDir } = await setupSandboxWorkspace(home);
 
       const mediaPath = await writeInboundMedia(
         home,
-        "oversized.bin",
+        "larger-than-generic-limit.bin",
         Buffer.alloc(MEDIA_MAX_BYTES + 1, 0x41),
       );
 
       const { ctx, sessionCtx } = createSandboxMediaContexts(mediaPath);
-      await stageSandboxMedia({
+      const result = await stageSandboxMedia({
         ctx,
         sessionCtx,
         cfg,
@@ -587,15 +587,44 @@ describe("stageSandboxMedia", () => {
         workspaceDir,
       });
 
-      let stagedStatError: NodeJS.ErrnoException | undefined;
-      try {
-        await fs.stat(join(sandboxDir, "media", "inbound", basename(mediaPath)));
-      } catch (error) {
-        stagedStatError = error as NodeJS.ErrnoException;
-      }
-      expect(stagedStatError?.code).toBe("ENOENT");
+      const stagedPath = `media/inbound/${basename(mediaPath)}`;
+      expect(result.staged.get(0)).toBe(stagedPath);
+      expect(ctx.media?.[0]?.path).toBe(stagedPath);
+      expect(sessionCtx.media?.[0]?.path).toBe(stagedPath);
+      await expect(fs.stat(join(sandboxDir, stagedPath))).resolves.toMatchObject({
+        size: MEDIA_MAX_BYTES + 1,
+      });
+    });
+  });
+
+  it("warns and keeps original media paths above the sandbox staging limit", async () => {
+    await withSandboxMediaTempHome("openclaw-triggers-", async (home) => {
+      const { cfg, workspaceDir, sandboxDir } = await setupSandboxWorkspace(home);
+      const stagingMaxBytes = SANDBOX_MEDIA_MAX_BYTES;
+      const mediaPath = await writeInboundMedia(home, "oversized.bin", "");
+      await fs.truncate(mediaPath, stagingMaxBytes + 1);
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { ctx, sessionCtx } = createSandboxMediaContexts(mediaPath);
+      const result = await stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey: "agent:main:main",
+        workspaceDir,
+      });
+
+      await expect(
+        fs.stat(join(sandboxDir, "media", "inbound", basename(mediaPath))),
+      ).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      expect(result.staged).toEqual(new Map());
       expect(ctx.media?.[0]?.path).toBe(mediaPath);
       expect(sessionCtx.media?.[0]?.path).toBe(mediaPath);
+      expect(warn).toHaveBeenCalledWith(
+        `Inbound media staging skipped for oversized.bin: file exceeds limit of ${stagingMaxBytes} bytes (got ${stagingMaxBytes + 1})`,
+      );
     });
   });
 });

--- a/src/auto-reply/reply/stage-sandbox-media.ts
+++ b/src/auto-reply/reply/stage-sandbox-media.ts
@@ -17,12 +17,13 @@ import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js"
 import { resolveChannelRemoteInboundAttachmentRoots } from "../../media/channel-inbound-roots.js";
 import { normalizeMediaFacts, type MediaFact } from "../../media/media-facts.js";
 import { resolveInboundMediaReference } from "../../media/media-reference.js";
-import { getMediaDir, MEDIA_MAX_BYTES } from "../../media/store.js";
+import { getMediaDir } from "../../media/store.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { CONFIG_DIR } from "../../utils.js";
 import type { RuntimeMsgContext as MsgContext, TemplateContext } from "../templating.js";
 
-const STAGED_MEDIA_MAX_BYTES = MEDIA_MAX_BYTES;
+/** Maximum size of one file copied into an agent sandbox or staging workspace. */
+export const SANDBOX_MEDIA_MAX_BYTES = 50 * 1024 * 1024;
 const SCP_STDERR_TAIL_CHARS = 16_384;
 
 // Attachment indexes are the staging identity. Callers use this map to detect
@@ -120,7 +121,7 @@ export async function stageSandboxMedia(params: {
           remotePath: source.physicalPath,
           rootDir: effectiveWorkspaceDir,
           relativeDestPath: relativeDest,
-          maxBytes: STAGED_MEDIA_MAX_BYTES,
+          maxBytes: SANDBOX_MEDIA_MAX_BYTES,
         });
       } else {
         const copySource = await fs.realpath(source.physicalPath).catch(() => source.physicalPath);
@@ -128,14 +129,12 @@ export async function stageSandboxMedia(params: {
           sourcePath: copySource,
           rootDir: effectiveWorkspaceDir,
           relativeDestPath: relativeDest,
-          maxBytes: STAGED_MEDIA_MAX_BYTES,
+          maxBytes: SANDBOX_MEDIA_MAX_BYTES,
         });
       }
     } catch (err) {
       if (err instanceof FsSafeError && err.code === "too-large") {
-        logVerbose(
-          `Blocking inbound media staging above ${STAGED_MEDIA_MAX_BYTES} bytes: ${source.physicalPath}`,
-        );
+        console.warn(`Inbound media staging skipped for ${fileName}: ${err.message}`);
       } else {
         logVerbose(`Failed to stage inbound media path ${source.physicalPath}: ${String(err)}`);
       }

--- a/src/gateway/server-methods/chat-send-attachments.ts
+++ b/src/gateway/server-methods/chat-send-attachments.ts
@@ -4,6 +4,7 @@ import { ErrorCodes, errorShape } from "../../../packages/gateway-protocol/src/i
 import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox/context.js";
 import {
+  SANDBOX_MEDIA_MAX_BYTES,
   stageSandboxMedia,
   type StageSandboxMediaResult,
 } from "../../auto-reply/reply/stage-sandbox-media.js";
@@ -13,7 +14,6 @@ import { clearAgentRunContext } from "../../infra/agent-run-registry.js";
 import { measureDiagnosticsTimelineSpan } from "../../infra/diagnostics-timeline.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { parseInboundMediaUri } from "../../media/media-reference.js";
-import { MEDIA_MAX_BYTES } from "../../media/store.js";
 import { resolveChatAttachmentMaxBytes } from "../chat-attachment-policy.js";
 import {
   discardPreparedInboundMedia,
@@ -57,9 +57,8 @@ function isManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
 }
 
 function shouldPassThroughManagedInboundPdfOffloadRef(ref: OffloadedRef): boolean {
-  // Oversized managed PDFs remain host-readable. A sandbox copy only hits the
-  // 5 MB staging cap without making the attachment more available.
-  return ref.sizeBytes > MEDIA_MAX_BYTES && isManagedInboundPdfOffloadRef(ref);
+  // Host-readable managed PDFs above the staging cap do not need a sandbox copy.
+  return ref.sizeBytes > SANDBOX_MEDIA_MAX_BYTES && isManagedInboundPdfOffloadRef(ref);
 }
 
 // Stage media before ACK so permanent client errors stay 4xx and retryable
@@ -103,14 +102,16 @@ async function prestageMediaPathOffloads(params: {
 
     // The parser admits more than the sandbox can stage. Reject non-PDF files
     // in that gap as permanent 4xx instead of a retryable staging failure.
-    const oversizedForSandbox = refsToStage.filter((ref) => ref.sizeBytes > MEDIA_MAX_BYTES);
+    const oversizedForSandbox = refsToStage.filter(
+      (ref) => ref.sizeBytes > SANDBOX_MEDIA_MAX_BYTES,
+    );
     if (oversizedForSandbox.length > 0) {
       const details = oversizedForSandbox
         .map((ref) => `${ref.label} (${ref.sizeBytes} bytes)`)
         .join(", ");
       throw new UnsupportedAttachmentError(
         "non-image-too-large-for-sandbox",
-        `attachments exceed sandbox staging limit (${MEDIA_MAX_BYTES} bytes): ${details}`,
+        `attachments exceed sandbox staging limit (${SANDBOX_MEDIA_MAX_BYTES} bytes): ${details}`,
       );
     }
 

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -500,6 +500,7 @@ vi.mock("../../agents/sandbox/context.js", async () => {
 });
 
 vi.mock("../../auto-reply/reply/stage-sandbox-media.js", () => ({
+  SANDBOX_MEDIA_MAX_BYTES: 50 * 1024 * 1024,
   stageSandboxMedia: vi.fn(
     async (params: {
       ctx: { media?: Array<{ path?: string; contentType?: string; workspaceDir?: string }> };
@@ -6623,16 +6624,18 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     ]);
   });
 
-  it("passes already-managed oversized inbound PDFs through staging instead of rejecting", async () => {
-    // #90097: a managed inbound PDF above the sandbox staging cap is read
-    // host-side (media-understanding) rather than copied into the sandbox, so
-    // it must reach dispatch with its managed media path instead of a 4xx.
+  it("stages already-managed PDFs above the generic media-store limit", async () => {
+    // #90097: the sandbox staging ceiling is intentionally higher than the
+    // generic media-store limit, so a 6 MiB PDF should still land in the
+    // workspace rather than taking the oversized host-path fallback.
     await createReadyChatTranscript("openclaw-chat-send-managed-pdf-pass-through-");
     useChatTestModel("vision-model");
     setSavedMediaResults(["/home/user/.openclaw/media/inbound/huge.pdf", "application/pdf"]);
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
+    mockState.stagedRelativePaths = ["media/inbound/huge.pdf"];
     const { send } = createChatRequestFixture();
-    // 6MB PDF — above STAGED_MEDIA_MAX_BYTES (5MB) but below the 20MB parse cap.
+    // 6 MiB PDF — above MEDIA_MAX_BYTES (5 MiB) but below both the default
+    // 20 MiB parser cap and the 50 MiB sandbox staging cap.
     const oversized = Buffer.alloc(6 * 1024 * 1024);
     oversized.set(Buffer.from("%PDF-1.4\n"), 0);
 
@@ -6647,13 +6650,12 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       expectBroadcast: false,
     });
 
-    // Reaches dispatch with the managed media path; not staged into the sandbox,
-    // so no workspace dir, and the media-store entry is kept (not cleaned up).
+    // Reaches dispatch through the same staged workspace path as other files.
     expect(mockState.lastDispatchCtx?.media).toEqual([
       {
-        path: "/home/user/.openclaw/media/inbound/huge.pdf",
+        path: "media/inbound/huge.pdf",
         contentType: "application/pdf",
-        workspaceDir: "/home/user/.openclaw/media/inbound",
+        workspaceDir: "/sandbox/workspace",
       },
     ]);
     expect(mockState.deleteMediaBufferCalls).toEqual([]);
@@ -6776,14 +6778,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     ]);
   });
 
-  it("rejects sandbox-oversized non-image attachments as 4xx before staging", async () => {
-    // Regression: resolveChatAttachmentMaxBytes defaults to 20MB, but
-    // stageSandboxMedia caps each file at STAGED_MEDIA_MAX_BYTES (5MB) and
-    // silently drops oversize files. Without a pre-check, a sandbox session
-    // accepting a 5-20MB non-image would fail staging and surface as a
-    // retryable 5xx UNAVAILABLE, misleading clients into retrying a
-    // deterministically broken request. Managed PDFs pass through (see above);
-    // other oversized non-image files must still be rejected.
+  it("stages non-image attachments above the generic media-store limit", async () => {
+    // Regression: Gateway used MEDIA_MAX_BYTES (5 MiB) as a pre-staging cap
+    // even though stageSandboxMedia accepts files up to 50 MiB.
     await createReadyChatTranscript("openclaw-chat-send-sandbox-oversize-");
     useChatTestModel("vision-model");
     setSavedMediaResults([
@@ -6791,8 +6788,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       "application/octet-stream",
     ]);
     mockState.sandboxWorkspace = { workspaceDir: "/sandbox/workspace" };
-    const { respond, send } = createChatRequestFixture();
-    // 6MB buffer — above STAGED_MEDIA_MAX_BYTES (5MB) but below the 20MB parse cap.
+    mockState.stagedRelativePaths = ["media/inbound/huge.bin"];
+    const { send } = createChatRequestFixture();
+    // 6 MiB buffer — above MEDIA_MAX_BYTES but below the default 20 MiB parser
+    // cap and the canonical 50 MiB sandbox staging cap.
     const oversized = Buffer.alloc(6 * 1024 * 1024);
     oversized.set(Buffer.from("OPENCLAW-BINARY\n"), 0);
     const oversizedPayload = oversized.toString("base64");
@@ -6806,20 +6805,16 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         ],
       },
       expectBroadcast: false,
-      waitFor: "none",
     });
 
-    expect(mockState.lastDispatchCtx).toBeUndefined();
-    expect(respond).toHaveBeenCalledTimes(1);
-    const [ok, payload, error] = lastRespondCall(respond) ?? [];
-    expect(ok).toBe(false);
-    expect(payload).toBeUndefined();
-    // 4xx, not 5xx — retrying a file that exceeds the staging cap cannot
-    // succeed, so the failure must be surfaced as a client-side rejection.
-    expect(error?.code).toBe(ErrorCodes.INVALID_REQUEST);
-    expect(responseErrorMessage(error)).toMatch(/sandbox staging limit/i);
-    // Orphaned media-store entries are cleaned up before the 4xx surfaces.
-    expect(mockState.deleteMediaBufferCalls).toEqual([{ id: "saved-media", subdir: "inbound" }]);
+    expect(mockState.lastDispatchCtx?.media).toEqual([
+      {
+        path: "media/inbound/huge.bin",
+        contentType: "application/octet-stream",
+        workspaceDir: "/sandbox/workspace",
+      },
+    ]);
+    expect(mockState.deleteMediaBufferCalls).toEqual([]);
   });
 
   it("passes imageOrder for mixed inline and offloaded chat.send attachments", async () => {

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -27,7 +27,7 @@ import { isFsSafeError, readLocalFileSafely, type FsSafeLikeError } from "./stor
 import { formatMediaLimitMb, MEDIA_FILE_MODE } from "./store.shared.js";
 
 const resolveMediaDir = () => path.join(resolveConfigDir(), "media");
-/** Default per-file media-store byte cap used by inbound staging and plugin SDK callers. */
+/** Default per-file media-store byte cap used by store and plugin SDK callers. */
 export const MEDIA_MAX_BYTES = 5 * 1024 * 1024;
 export const PLAYBACK_TRANSCODE_SUBDIR = "playback-transcode";
 


### PR DESCRIPTION
## What Problem This Solves

Sandbox inbound media staging reused `MEDIA_MAX_BYTES`, the generic 5 MiB media-store default. A channel could accept a larger attachment, but sandbox staging then skipped it. Gateway `chat.send` also copied the 5 MiB value into its pre-ACK rejection path, so the same attachment behaved differently by ingress path.

## Why This Change Was Made

Sandbox staging now owns one bounded 50 MiB per-file contract. Local staging, remote staging, managed-PDF fallback, and Gateway prechecks all consume that same value.

The media-store default remains 5 MiB. Gateway keeps its existing decoded attachment and WebSocket frame limits. Files above the sandbox staging ceiling remain unstaged and produce a warning with the file name, observed size, and limit.

The repair also removes a duplicate local `stat` check. `@openclaw/fs-safe@0.5.6` already enforces `maxBytes` on the pinned source during `Root.copyIn`, so the staging owner uses that single safe copy boundary.

## User Impact

Attachments between 5 MiB and 50 MiB that reach normal ingress can now reach `media/inbound` for sandboxed agents. Gateway `chat.send` follows the same staging contract instead of rejecting at 5 MiB.

## Evidence

Current main `532dfd4ecb82fde540ac9c39ab1e333b291cb688` was red before the repair:

- two different real 6 MiB files both produced `stagedCount: 0` through the production staging function;
- the owner regression failed because the staged path was missing;
- the Gateway regression failed because `chat.send` rejected before dispatch.

Live-proof head `5a10219fd8373d9223782de2f132cdbabe529f49` is green:

- the same production function staged both 6 MiB files into the real sandbox workspace;
- each staged SHA-256 hash matched its source, and the two inputs had different hashes;
- a 50 MiB plus 1 byte file stayed unstaged and produced the bounded warning;
- owner staging: 21/21 passed;
- remote staging sibling: 4/4 passed;
- Gateway parser and policy siblings: 57/57 passed;
- full Gateway method suite: 203/203 passed;
- Oxfmt, Oxlint, repository ratchets, dead-export scan, import-cycle check, and `git diff --check`: passed.

Current head `5856981ceb1c11ac49cf9083d66ec0d49bb429f0` is a patch-identical rebase onto healed main `9d79bf3f8c5f18f7c35d028d57402f5085659640`; the stable patch ID is `180f6032e6dc8cc637b5dea4b5e3fdfbcc099826` before and after. Focused regressions, changed-file lint, and the formerly failing full lint stripe pass on the current head.

Production code is +14/-14, net zero. Tests are +66/-42.

Codex contract check used `openai/codex@6478a751fde8884b2fdc76486fe23175a8e795d4`: `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:403` keeps local media path-based at admission, while `codex-rs/protocol/src/local_media.rs:18` performs the later bounded read. OpenClaw must therefore make accepted media reachable in the sandbox workspace before dispatch.

This PR was AI-assisted; the implementation, tests, and validation were reviewed by the submitting author and maintainer.
