### PR TITLE
test: select manual approval in MCP App revocation fixture

### DIFF
--- a/test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts
@@ -106,7 +106,13 @@ function appConfig(cfg: OpenClawConfig, fixture: HttpFixture): OpenClawConfig {
         },
       },
     },
-    tools: { ...cfg.tools, profile: "full", toolSearch: false, codeMode: false },
+    tools: {
+      ...cfg.tools,
+      profile: "full",
+      toolSearch: false,
+      codeMode: false,
+      exec: { ...cfg.tools?.exec, mode: "ask" },
+    },
     channels: {},
   };
 }


### PR DESCRIPTION
Related: #129970 (widget approval follows session policy), #126415 (MCP App revocation after catalog waits), #129550 (resource revocation).

AI-assisted with Codex; independently reviewed.

## What Problem This Solves

Resolves a problem where the MCP App grant-revalidation E2E stopped at its initial `board.put` assertion instead of exercising revocation during a real catalog refresh. The fixture expected `pending` but inherited full-access execution policy, which correctly returned `granted`.

This is maintainer-requested QA repair. The observed failure occurred before manual grant, ticket minting, catalog gating, or revocation; it is not evidence of an authorization defect.

## Why This Change Was Made

The fixture now explicitly selects the existing `tools.exec.mode: "ask"` policy required by its manual-grant flow, preserving other tool and exec settings. Every assertion remains unchanged, including rejection of both tool calls and resource reads after widget removal. Production policy and revocation guards are untouched.

The stale premise became visible after #129970 intentionally aligned widget approval with session policy. That change updated the board unit fixture to manual approval but left this older E2E's policy implicit. The original fixture came from #126415; #129550 later extended resource-revocation coverage.

Provenance: #129970 (August 26, policy alignment) and #126415 (August 19, original fixture) both have code/PR author and PR merger @steipete, verified from blame and PR metadata. The resource-coverage commit for #129550 names @joshavant as code author; its merger is not inferred.

## User Impact

No runtime or user-facing behavior changes. Developers regain the real-process regression proof for revocation during awaited MCP catalog work. Default/full approval remains covered by the existing board permission matrix.

## Evidence

Original RED: the full Gateway suite failed this case with `expected 'granted' to be 'pending'` at the initial grant-state assertion. The fixture, relevant owners/helpers, sibling tests, and dependency declarations were unchanged between the original failing revision and this patch's base, so that reproduction was retained.

Validation used Node 24.20.0 and pnpm 11.22.0 in an isolated checkout with owned dependencies:

- `node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts` — 1/1 passed. The canonical runner rebuilt private QA output, then exercised a real isolated Gateway, mock OpenAI provider, and local MCP HTTP server. Manual grant and allowed resource access succeeded; removal during the controlled catalog refresh caused tool and resource HTTP 403 responses, with no resource leak or post-revocation tool execution.
- `node scripts/run-vitest.mjs src/gateway/server-methods/board.test.ts src/gateway/mcp-app-standalone.test.ts src/gateway/server-methods/mcp-app.test.ts src/boards/board-store.parity.test.ts` — 124/124 passed.
- `node scripts/check-changed.mjs --base HEAD^ --head HEAD -- test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts` — passed on the committed patch, including root-test typecheck, formatting, applicable guards, and script lint.
- `git diff --check HEAD^ HEAD` — passed.
- Independent Codex review — no P0 findings; static review, not another test run.

Production LOC: +0/-0. Tests: +7/-1. No new tests, production interfaces, configuration options, retries, skips, timeout increases, or weakened assertions. Real-process proof is mock-provider/local-MCP evidence, not a live authenticated provider test. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33134070745) is green for `90083a884709c37493793bf948e3eec291931001`.

ClawSweeper's separate 30-second output probe stopped during private-QA preparation after compilation group 2/11, before Vitest started; it did not reach the test and is not counted as passing evidence. The completed canonical run above took 326.59 seconds including the build, with the test case itself passing in 22.484 seconds. The review reports no findings or rank-up moves; its pending-CI item is now resolved.
