### PR TITLE
fix(ui): keep setup channels visible after configuration

### DIFF
--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -89,6 +89,35 @@ function createProps(snapshot: ChannelsProps["snapshot"]): ChannelsProps {
 }
 
 describe("channels setup access", () => {
+  it("keeps unconfigured recommended channels available after one channel is configured", () => {
+    const props = createProps({
+      ts: Date.now(),
+      channelOrder: ["slack"],
+      channelLabels: { slack: "Slack" },
+      channelMeta: [{ id: "slack", label: "Slack", detailLabel: "Slack Bot" }],
+      channels: { slack: { configured: true } },
+      channelAccounts: {},
+      channelDefaultAccountId: {},
+    });
+    const container = document.createElement("div");
+
+    render(renderChannels(props), container);
+
+    const availableLabels = Array.from(
+      container.querySelectorAll(".channels-item__detail .settings-row__title"),
+      (node) => node.textContent?.trim(),
+    );
+    expect(availableLabels).toEqual([
+      "whatsapp",
+      "telegram",
+      "discord",
+      "googlechat",
+      "signal",
+      "imessage",
+      "nostr",
+    ]);
+  });
+
   it("replaces setup actions with an admin-required notice for non-admin viewers", () => {
     const onStartSetup = vi.fn();
     const props = createProps({

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -34,6 +34,17 @@ import { renderChannelWizard } from "./wizard-view.ts";
 
 type ChannelCardState = "running" | "configured" | "attention";
 
+const RECOMMENDED_CHANNEL_ORDER: ChannelKey[] = [
+  "whatsapp",
+  "telegram",
+  "discord",
+  "googlechat",
+  "slack",
+  "signal",
+  "imessage",
+  "nostr",
+];
+
 export function renderChannels(props: ChannelsProps) {
   const channelOrder = resolveChannelOrder(props.snapshot);
   const connected = channelOrder.filter((key) => channelEnabled(key, props));
@@ -159,13 +170,10 @@ function buildChannelData(props: ChannelsProps): ChannelsChannelData {
 }
 
 function resolveChannelOrder(snapshot: ChannelsStatusSnapshot | null): ChannelKey[] {
-  if (snapshot?.channelMeta?.length) {
-    return snapshot.channelMeta.map((entry) => entry.id);
-  }
-  if (snapshot?.channelOrder?.length) {
-    return snapshot.channelOrder;
-  }
-  return ["whatsapp", "telegram", "discord", "googlechat", "slack", "signal", "imessage", "nostr"];
+  const statusOrder = snapshot?.channelMeta?.length
+    ? snapshot.channelMeta.map((entry) => entry.id)
+    : (snapshot?.channelOrder ?? []);
+  return [...new Set([...statusOrder, ...RECOMMENDED_CHANNEL_ORDER])];
 }
 
 function resolveChannelLabel(snapshot: ChannelsStatusSnapshot | null, key: string): string {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users with one configured channel would see no direct setup choices under **Add a channel**, even though the full recommended list appeared before any channel was configured.

## Why This Change Was Made

The Channels status payload intentionally describes loaded/configured channel runtimes, while the recommended setup list is a separate UI concern. The view previously treated any non-empty status order as a replacement for that list. This change preserves status ordering, appends the recommended choices once, and lets the existing configured-state filter remove channels already in use.

No Gateway, plugin, protocol, config, or persistence contract changes.

## User Impact

After configuring Slack (or any other channel), the remaining recommended channels stay visible with their **Set up** actions. The configured channel appears only under **Your channels**.

## Evidence

Same mocked Gateway payload and viewport in both captures: Slack configured; no other channels configured.

### Before

![Before: Add a channel only shows More channels](https://github.com/user-attachments/assets/2177fddd-74a2-468e-85c8-bca220f306b7)

### After

![After: seven unconfigured recommended channels remain available](https://github.com/user-attachments/assets/07d15a95-a742-451a-a785-5a4ad5d9ef18)

Regression proof:

- Pre-fix focused test: failed with `expected []` for the remaining setup rows.
- Fixed focused test: `ui/src/pages/channels/view.test.ts` — 31 passed on current `main`.
- `node scripts/check-changed.mjs -- ui/src/pages/channels/view.ts ui/src/pages/channels/view.test.ts` — passed repository ratchets, format, dead exports, i18n, core/UI typechecks, lint, and style checks with fresh dependencies.
- Isolated autoreview — no actionable findings.

Production LOC: +15/-7 (net +8) | Tests: +29/-0. The production growth promotes the existing recommended IDs to one named list so status IDs and recommended IDs can be deduplicated in one canonical order.
