### PR TITLE
fix(sessions): stop deriving parent model overrides for Telegram DM topics

### DIFF
--- a/extensions/telegram/src/bot-handlers.message-context.ts
+++ b/extensions/telegram/src/bot-handlers.message-context.ts
@@ -23,6 +23,7 @@ import {
   buildSenderName,
   getTelegramTextParts,
   resolveTelegramPrimaryMedia,
+  shouldUseTelegramDmThreadSession,
   type TelegramThreadSpec,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
@@ -218,6 +219,12 @@ export function createTelegramMessageSessionRuntime({
       loadSessionEntry: (parentSessionKey) =>
         loadSessionEntry({ storePath, sessionKey: parentSessionKey }),
       sessionKey,
+      parentSessionKey: shouldUseTelegramDmThreadSession({
+        dmThreadId,
+        botHasTopicsEnabled: params.botHasTopicsEnabled,
+      })
+        ? null
+        : undefined,
       defaultProvider: resolveDefaultModelForAgent({
         cfg: params.runtimeCfg,
         agentId: route.agentId,

--- a/extensions/telegram/src/bot-handlers.message-session.runtime.test.ts
+++ b/extensions/telegram/src/bot-handlers.message-session.runtime.test.ts
@@ -5,7 +5,7 @@ import type { TelegramBotDeps } from "./bot-deps.js";
 import { createTelegramMessageSessionRuntime } from "./bot-handlers.message-context.js";
 
 describe("createTelegramMessageSessionRuntime", () => {
-  it("inherits a DM topic model override through keyed session loads", () => {
+  it("keeps a DM topic independent from the flat DM model override", () => {
     const storePath = "/tmp/telegram-sessions.sqlite";
     const childSessionKey = "agent:main:main:thread:12345:99";
     const parentSessionKey = "agent:main:main";
@@ -42,10 +42,8 @@ describe("createTelegramMessageSessionRuntime", () => {
     });
 
     expect(state.sessionKey).toBe(childSessionKey);
-    expect(state.model).toBe("anthropic/claude-opus-4-7");
-    expect(getSessionEntry.mock.calls.map(([params]) => params)).toEqual([
-      { storePath, sessionKey: childSessionKey },
-      { storePath, sessionKey: parentSessionKey },
-    ]);
+    expect(state.model).toBeUndefined();
+    expect(getSessionEntry).toHaveBeenCalledOnce();
+    expect(getSessionEntry).toHaveBeenCalledWith({ storePath, sessionKey: childSessionKey });
   });
 });

--- a/extensions/telegram/src/bot-message-context.dm-threads.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-threads.test.ts
@@ -128,6 +128,7 @@ describe("buildTelegramMessageContext dm thread sessions", () => {
 
     expect(ctx?.ctxPayload?.MessageThreadId).toBe(42);
     expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:main:thread:1234:42");
+    expect(ctx?.ctxPayload?.ModelParentSessionKey).toBeNull();
   });
 
   it("does not use configured bot-private topics without bot topic capability", async () => {
@@ -167,6 +168,7 @@ describe("buildTelegramMessageContext dm thread sessions", () => {
 
     expect(ctx?.ctxPayload?.MessageThreadId).toBe(42);
     expect(ctx?.ctxPayload?.SessionKey).toBe("agent:support:main:thread:1234:42");
+    expect(ctx?.ctxPayload?.ModelParentSessionKey).toBeNull();
   });
 
   it("uses the main session key when no thread id", async () => {

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -234,6 +234,7 @@ export async function buildTelegramInboundContextPayload(params: {
   dmThreadId?: number;
   threadSpec: TelegramThreadSpec;
   route: ResolvedAgentRoute;
+  modelParentSessionKey?: string | null;
   rawBody: string;
   bodyText: string;
   historyKey?: string;
@@ -287,6 +288,7 @@ export async function buildTelegramInboundContextPayload(params: {
     dmThreadId,
     threadSpec,
     route,
+    modelParentSessionKey,
     rawBody,
     bodyText,
     historyKey,
@@ -722,6 +724,7 @@ export async function buildTelegramInboundContextPayload(params: {
       dmScope: route.dmScope,
       accountId: route.accountId,
       routeSessionKey: route.sessionKey,
+      modelParentSessionKey,
       mainSessionKey: route.mainSessionKey,
     },
     reply: {

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -521,6 +521,7 @@ export const buildTelegramMessageContext = async ({
     dmThreadId,
     threadSpec,
     route,
+    modelParentSessionKey: useDmThreadSession ? null : undefined,
     rawBody: bodyResult.rawBody,
     bodyText: bodyResult.bodyText,
     historyKey: bodyResult.historyKey ?? "",

--- a/extensions/telegram/src/bot-native-command-builtins.test.ts
+++ b/extensions/telegram/src/bot-native-command-builtins.test.ts
@@ -175,7 +175,7 @@ describe("Telegram native command built-ins", () => {
     expect(menuRecord.catalog).toEqual(runtimeCatalog);
   });
 
-  it("inherits the parent session model when building DM thread native argument menus", async () => {
+  it("keeps DM thread native argument menus independent from the flat DM model", async () => {
     const cfg: OpenClawConfig = {};
     sessionMocks.sessionStoreEntries.mockReturnValue({
       "agent:main:main": {
@@ -191,14 +191,14 @@ describe("Telegram native command built-ins", () => {
       cfg,
       allowFrom: ["*"],
     });
-    await handler(createTelegramPrivateCommandContext({ threadId: 77 }));
+    await handler(createTelegramPrivateCommandContext({ threadId: 77, botHasTopicsEnabled: true }));
 
     const menuCall = commandAuthMocks.resolveCommandArgMenu.mock.calls.find(
-      ([params]) => params.command.key === "think" && params.provider === "anthropic",
+      ([params]) => params.command.key === "think",
     )?.[0];
     expectRecordFields(
       menuCall,
-      { provider: "anthropic", model: "claude-opus-4-7" },
+      { provider: undefined, model: undefined },
       "thread thinking menu call",
     );
     expectSendMessageCall({

--- a/extensions/telegram/src/bot-native-command-builtins.ts
+++ b/extensions/telegram/src/bot-native-command-builtins.ts
@@ -166,6 +166,7 @@ function resolveTelegramFastCommandState(params: {
   cfg: OpenClawConfig;
   agentId: string;
   sessionKey: string;
+  parentSessionKey?: string | null;
 }) {
   const defaultModel = resolveDefaultModelForAgent({ cfg: params.cfg, agentId: params.agentId });
   const fallback = () =>

--- a/extensions/telegram/src/bot-native-command-builtins.ts
+++ b/extensions/telegram/src/bot-native-command-builtins.ts
@@ -65,6 +65,7 @@ function resolveTelegramCommandMenuModelContext(params: {
   cfg: OpenClawConfig;
   agentId: string;
   sessionKey: string;
+  parentSessionKey?: string | null;
 }): TelegramCommandMenuModelContext {
   if (!params.sessionKey.trim()) {
     return {};
@@ -88,6 +89,7 @@ function resolveTelegramCommandMenuModelContext(params: {
         sessionEntry: entry,
         loadSessionEntry: (sessionKey) => getSessionEntry({ storePath, sessionKey }),
         sessionKey: params.sessionKey,
+        parentSessionKey: params.parentSessionKey,
         defaultProvider: defaultModel.provider,
       });
       if (override?.model) {
@@ -131,6 +133,7 @@ function resolveTelegramFastCommandModelContext(params: {
   cfg: OpenClawConfig;
   agentId: string;
   sessionKey: string;
+  parentSessionKey?: string | null;
 }): { provider?: string; model?: string } {
   const defaultModel = resolveDefaultModelForAgent({ cfg: params.cfg, agentId: params.agentId });
   const fallback = () => ({ provider: defaultModel.provider, model: defaultModel.model });
@@ -147,6 +150,7 @@ function resolveTelegramFastCommandModelContext(params: {
       sessionEntry: entry,
       loadSessionEntry: (sessionKey) => getSessionEntry({ storePath, sessionKey }),
       sessionKey: params.sessionKey,
+      parentSessionKey: params.parentSessionKey,
       defaultProvider: defaultModel.provider,
     });
     return {
@@ -281,12 +285,15 @@ export async function executeTelegramBuiltinCommand(
     );
   const sessionKeyForMenu =
     commandDefinition && menuNeedsModelContext ? dispatch.targetSessionKey : "";
+  const modelParentSessionKey =
+    dispatch.threadSpec.scope === "dm" && dispatch.threadSpec.id != null ? null : undefined;
   const fastCommandState =
     commandDefinition?.key === "fast" && menuNeedsModelContext
       ? resolveTelegramFastCommandState({
           cfg: dispatch.runtimeCfg,
           agentId: dispatch.route.agentId,
           sessionKey: sessionKeyForMenu,
+          parentSessionKey: modelParentSessionKey,
         })
       : undefined;
   const fastMenuModelContext =
@@ -295,6 +302,7 @@ export async function executeTelegramBuiltinCommand(
           cfg: dispatch.runtimeCfg,
           agentId: dispatch.route.agentId,
           sessionKey: sessionKeyForMenu,
+          parentSessionKey: modelParentSessionKey,
         })
       : undefined;
   const menuModelContext =
@@ -304,6 +312,7 @@ export async function executeTelegramBuiltinCommand(
           cfg: dispatch.runtimeCfg,
           agentId: dispatch.route.agentId,
           sessionKey: sessionKeyForMenu,
+          parentSessionKey: modelParentSessionKey,
         }))
       : {};
   // Native /think must not wait on provider discovery; persisted rows retain its metadata.

--- a/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
@@ -67,9 +67,20 @@ export function createTelegramPrivateCommandContext(params?: {
   userId?: number;
   username?: string;
   threadId?: number;
+  botHasTopicsEnabled?: boolean;
 }) {
   return {
     match: params?.match ?? "",
+    ...(params?.botHasTopicsEnabled !== undefined
+      ? {
+          me: {
+            id: 999,
+            is_bot: true,
+            first_name: "OpenClaw",
+            has_topics_enabled: params.botHasTopicsEnabled,
+          },
+        }
+      : {}),
     message: {
       message_id: params?.messageId ?? 1,
       date: params?.date ?? Math.floor(Date.now() / 1000),

--- a/extensions/telegram/src/conversation-route.ts
+++ b/extensions/telegram/src/conversation-route.ts
@@ -69,6 +69,10 @@ export function buildTelegramConversationRouteContext(params: {
       ? buildTelegramConversationId({ chatId: params.chatId, thread: params.threadSpec })
       : resolveTelegramDirectPeerId(params),
     ThreadParentId: buildTelegramParentPeer(params)?.id,
+    ModelParentSessionKey:
+      !params.isGroup && params.threadSpec.scope === "dm" && params.threadSpec.id != null
+        ? null
+        : undefined,
   };
 }
 

--- a/src/auto-reply/reply/dispatch-from-config.harness-defaults.ts
+++ b/src/auto-reply/reply/dispatch-from-config.harness-defaults.ts
@@ -88,12 +88,13 @@ function resolveHarnessDefaultChannel(params: {
 function resolveHarnessDefaultParentSessionKey(params: {
   ctx: FinalizedMsgContext;
   entry?: SessionEntry;
-}): string | undefined {
-  return (
-    params.entry?.parentSessionKey ??
-    params.ctx.ModelParentSessionKey ??
-    params.ctx.ParentSessionKey
-  );
+}): string | null | undefined {
+  if (params.entry?.parentSessionKey !== undefined) {
+    return params.entry.parentSessionKey;
+  }
+  return params.ctx.ModelParentSessionKey !== undefined
+    ? params.ctx.ModelParentSessionKey
+    : params.ctx.ParentSessionKey;
 }
 
 export function resolveTurnModelOverride(
@@ -111,7 +112,7 @@ function resolveChannelModelCandidate(params: {
   ctx: FinalizedMsgContext;
   defaultProvider: string;
   entry?: SessionEntry;
-  parentSessionKey?: string;
+  parentSessionKey?: string | null;
 }): HarnessDefaultCandidate | undefined {
   if (!params.cfg.channels?.modelByChannel) {
     return undefined;
@@ -153,7 +154,7 @@ function resolveStoredModelCandidate(params: {
   cfg: OpenClawConfig;
   defaultProvider: string;
   entry?: SessionEntry;
-  parentSessionKey?: string;
+  parentSessionKey?: string | null;
   sessionAgentId: string;
   sessionKey?: string;
   sessionStore?: Record<string, SessionEntry>;

--- a/src/auto-reply/reply/dispatch-from-config.send-policy-routing.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.send-policy-routing.test-utils.ts
@@ -1001,6 +1001,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       (params as { sessionKey?: string }).sessionKey === parentSessionKey
         ? parentEntry
         : sessionStoreMocks.currentEntry) as () => Record<string, unknown> | undefined);
+    sessionStoreMocks.loadSessionStoreEntry.mockClear();
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
       expect(opts?.sourceReplyDeliveryMode).toBe("automatic");
@@ -1032,6 +1033,67 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     });
     expect(result.queuedFinal).toBe(true);
     expect(firstFinalReplyPayload(dispatcher)?.text).toBe("visible parent-model reply");
+    sessionStoreMocks.loadSessionStoreEntry.mockImplementation(defaultLoadSessionStoreEntry);
+  });
+
+  it("does not derive a flat DM model override when a Telegram topic suppresses inheritance", async () => {
+    setNoAbort();
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      deliveryDefaults: { visibleReplies: "message_tool" },
+      supports: (ctx) =>
+        ctx.provider === "codex"
+          ? { supported: true, priority: 100 }
+          : { supported: false, reason: "codex provider only" },
+      runAttempt: vi.fn(async () => ({}) as never),
+    });
+    const parentSessionKey = "agent:main:main";
+    const childSessionKey = `${parentSessionKey}:thread:12345:99`;
+    sessionStoreMocks.currentEntry = {
+      sessionId: "child",
+      updatedAt: 0,
+      agentHarnessId: "codex",
+      sendPolicy: "allow",
+    };
+    const parentEntry = {
+      sessionId: "parent",
+      updatedAt: 0,
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4.6",
+    };
+    const defaultLoadSessionStoreEntry = () => sessionStoreMocks.currentEntry;
+    sessionStoreMocks.loadSessionStoreEntry.mockImplementation(((params: unknown) =>
+      (params as { sessionKey?: string }).sessionKey === parentSessionKey
+        ? parentEntry
+        : sessionStoreMocks.currentEntry) as () => Record<string, unknown> | undefined);
+    sessionStoreMocks.loadSessionStoreEntry.mockClear();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      expect(opts?.sourceReplyDeliveryMode).toBe("automatic");
+      return { text: "topic reply" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "direct",
+        CommandSource: undefined,
+        ModelParentSessionKey: null,
+        Provider: "telegram",
+        Surface: "telegram",
+        SessionKey: childSessionKey,
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(sessionStoreMocks.loadSessionStoreEntry).not.toHaveBeenCalledWith(
+      expect.objectContaining({ sessionKey: parentSessionKey }),
+    );
+    expect(result.queuedFinal).toBe(true);
+    expect(firstFinalReplyPayload(dispatcher)?.text).toBe("topic reply");
     sessionStoreMocks.loadSessionStoreEntry.mockImplementation(defaultLoadSessionStoreEntry);
   });
 

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -474,8 +474,9 @@ export async function resolveReplyDirectives(params: {
           sessionKey,
           parentSessionKey:
             targetSessionEntry?.parentSessionKey ??
-            ctx.ModelParentSessionKey ??
-            ctx.ParentSessionKey,
+            (ctx.ModelParentSessionKey !== undefined
+              ? ctx.ModelParentSessionKey
+              : ctx.ParentSessionKey),
           storePath,
           defaultProvider,
           defaultModel,

--- a/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
+++ b/src/auto-reply/reply/get-reply-native-slash-fast-path.ts
@@ -214,8 +214,9 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
           sessionKey: sessionState.sessionKey,
           parentSessionKey:
             targetSessionEntry?.parentSessionKey ??
-            params.ctx.ModelParentSessionKey ??
-            params.ctx.ParentSessionKey,
+            (params.ctx.ModelParentSessionKey !== undefined
+              ? params.ctx.ModelParentSessionKey
+              : params.ctx.ParentSessionKey),
           defaultProvider: params.defaultProvider,
         })
       : null;
@@ -242,9 +243,9 @@ export async function maybeResolveNativeSlashCommandFastReply(params: {
           groupChannel: targetSessionEntry?.groupChannel ?? params.ctx.GroupChannel,
           groupSubject: targetSessionEntry?.subject ?? params.ctx.GroupSubject,
           parentSessionKey:
-            params.ctx.ModelParentSessionKey ??
-            params.ctx.ParentSessionKey ??
-            targetSessionEntry?.parentSessionKey,
+            params.ctx.ModelParentSessionKey !== undefined
+              ? params.ctx.ModelParentSessionKey
+              : (params.ctx.ParentSessionKey ?? targetSessionEntry?.parentSessionKey),
           directUserIds: [
             deliveryOrigin?.nativeDirectUserId,
             deliveryOrigin?.from,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -800,7 +800,10 @@ export async function getReplyFromConfig(
         groupChannel:
           sessionEntry.groupChannel ?? sessionCtx.GroupChannel ?? finalized.GroupChannel,
         groupSubject: sessionEntry.subject ?? sessionCtx.GroupSubject ?? finalized.GroupSubject,
-        parentSessionKey: sessionCtx.ModelParentSessionKey ?? sessionCtx.ParentSessionKey,
+        parentSessionKey:
+          sessionCtx.ModelParentSessionKey !== undefined
+            ? sessionCtx.ModelParentSessionKey
+            : sessionCtx.ParentSessionKey,
         directUserIds: [
           sessionDeliveryOrigin(sessionEntry)?.nativeDirectUserId,
           sessionDeliveryOrigin(sessionEntry)?.from,
@@ -833,8 +836,9 @@ export async function getReplyFromConfig(
     sessionKey,
     parentSessionKey:
       sessionEntry.parentSessionKey ??
-      sessionCtx.ModelParentSessionKey ??
-      sessionCtx.ParentSessionKey,
+      (sessionCtx.ModelParentSessionKey !== undefined
+        ? sessionCtx.ModelParentSessionKey
+        : sessionCtx.ParentSessionKey),
     defaultProvider,
   });
   const staleHeartbeatAutoFallbackOverride =
@@ -1164,8 +1168,9 @@ export async function getReplyFromConfig(
         sessionKey,
         parentSessionKey:
           sessionEntry.parentSessionKey ??
-          sessionCtx.ModelParentSessionKey ??
-          sessionCtx.ParentSessionKey,
+          (sessionCtx.ModelParentSessionKey !== undefined
+            ? sessionCtx.ModelParentSessionKey
+            : sessionCtx.ParentSessionKey),
         storePath,
         defaultProvider,
         defaultModel,

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -144,7 +144,7 @@ export async function createModelSelectionState(params: {
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
-  parentSessionKey?: string;
+  parentSessionKey?: string | null;
   storePath?: string;
   defaultProvider: string;
   defaultModel: string;

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -85,7 +85,7 @@ export type SupplementalContextFacts = {
     historyBody?: string;
     label?: string;
     parentSessionKey?: string;
-    modelParentSessionKey?: string;
+    modelParentSessionKey?: string | null;
     senderAllowed?: boolean;
   };
   channelStructuredContext?: ChannelStructuredContextEntry[];
@@ -160,9 +160,10 @@ export type MsgContext = Partial<CanonicalInboundText> & {
   /**
    * Session key used only for inheriting session-scoped model/provider
    * overrides. Unlike ParentSessionKey, this must not trigger transcript
-   * forking or parent-session lifecycle behavior.
+   * forking or parent-session lifecycle behavior. Null explicitly suppresses
+   * model-parent derivation for this channel turn.
    */
-  ModelParentSessionKey?: string;
+  ModelParentSessionKey?: string | null;
   MessageSid?: string;
   /** Provider-specific full message id when MessageSid is a shortened alias. */
   MessageSidFull?: string;

--- a/src/channels/turn/types.ts
+++ b/src/channels/turn/types.ts
@@ -99,7 +99,7 @@ export type RouteFacts = {
   dispatchSessionKey?: string;
   persistedSessionKey?: string;
   parentSessionKey?: string;
-  modelParentSessionKey?: string;
+  modelParentSessionKey?: string | null;
   mainSessionKey?: string;
   createIfMissing?: boolean;
 };

--- a/src/sessions/stored-model-overrides.test.ts
+++ b/src/sessions/stored-model-overrides.test.ts
@@ -19,9 +19,9 @@ describe("resolveStoredModelOverride", () => {
     ).toMatchObject({ routeResolution: "resolved" });
   });
 
-  it("loads parent overrides without requiring a whole session store", () => {
+  it("keeps explicit parent overrides in Telegram direct threads", () => {
     const loadSessionEntry = vi.fn((sessionKey: string) =>
-      sessionKey === "agent:main:telegram:dm:parent"
+      sessionKey === "agent:main:telegram:direct:parent"
         ? {
             sessionId: "parent-session",
             updatedAt: 1782259200000,
@@ -35,7 +35,8 @@ describe("resolveStoredModelOverride", () => {
       resolveStoredModelOverride({
         defaultProvider: "openai",
         loadSessionEntry,
-        sessionKey: "agent:main:telegram:dm:parent:thread:child",
+        sessionKey: "agent:main:telegram:direct:parent:thread:child",
+        parentSessionKey: "agent:main:telegram:direct:parent",
       }),
     ).toEqual({
       provider: "anthropic",
@@ -43,7 +44,49 @@ describe("resolveStoredModelOverride", () => {
       source: "parent",
       routeResolution: "raw",
     });
-    expect(loadSessionEntry).toHaveBeenCalledWith("agent:main:telegram:dm:parent");
+    expect(loadSessionEntry).toHaveBeenCalledWith("agent:main:telegram:direct:parent");
+  });
+
+  it("does not derive a parent when the channel explicitly suppresses model inheritance", () => {
+    const loadSessionEntry = vi.fn(() => ({
+      sessionId: "parent-session",
+      updatedAt: 1782259200000,
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-7",
+    }));
+
+    expect(
+      resolveStoredModelOverride({
+        defaultProvider: "openai",
+        loadSessionEntry,
+        sessionKey: "agent:main:main:thread:12345:99",
+        parentSessionKey: null,
+      }),
+    ).toBeNull();
+    expect(loadSessionEntry).not.toHaveBeenCalled();
+  });
+
+  it("keeps explicit Telegram direct parents for unthreaded sessions", () => {
+    expect(
+      resolveStoredModelOverride({
+        defaultProvider: "openai",
+        sessionKey: "agent:main:telegram:direct:child",
+        parentSessionKey: "agent:main:telegram:direct:parent",
+        sessionStore: {
+          "agent:main:telegram:direct:parent": {
+            sessionId: "parent-session",
+            updatedAt: 1,
+            providerOverride: "anthropic",
+            modelOverride: "claude-sonnet-4-6",
+          },
+        },
+      }),
+    ).toEqual({
+      provider: "anthropic",
+      model: "claude-sonnet-4-6",
+      source: "parent",
+      routeResolution: "raw",
+    });
   });
 
   it("does not inherit active automatic fallback overrides from parent sessions", () => {

--- a/src/sessions/stored-model-overrides.ts
+++ b/src/sessions/stored-model-overrides.ts
@@ -57,11 +57,14 @@ export function resolveDirectStoredModelOverride(params: {
 
 function resolveParentSessionKeyCandidate(params: {
   sessionKey?: string;
-  parentSessionKey?: string;
+  parentSessionKey?: string | null;
 }): string | null {
   const explicit = normalizeOptionalString(params.parentSessionKey);
   if (explicit && explicit !== params.sessionKey) {
     return explicit;
+  }
+  if (params.parentSessionKey === null) {
+    return null;
   }
   const derived = resolveSessionParentSessionKey(params.sessionKey);
   if (derived && derived !== params.sessionKey) {
@@ -76,7 +79,8 @@ export function resolveStoredModelOverride(params: {
   sessionEntry?: SessionEntry;
   sessionStore?: Record<string, SessionEntry>;
   sessionKey?: string;
-  parentSessionKey?: string;
+  /** Explicit parent key; null suppresses suffix-derived inheritance. */
+  parentSessionKey?: string | null;
   defaultProvider: string;
 }): StoredModelOverride | null {
   const direct = resolveDirectStoredModelOverride({


### PR DESCRIPTION
## What Problem This Solves

Fixes #131355.

Telegram bots with private-chat topics enabled create distinct topic sessions. Under the default `dmScope: main`, the real topic key is `agent:<agent>:main:thread:<chat>:<topic>`. A topic without its own `/model` selection previously derived the flat DM session as its model parent, so a model pinned in the plain DM silently changed the model used by every new topic.

## Why This Change Was Made

The old fix inferred Telegram ownership by parsing the session-key string. That missed the default shared-main key because it contains no Telegram delivery segment.

This revision carries the fact from the Telegram routing owner instead:

- Telegram marks a real private-topic turn with `ModelParentSessionKey: null`;
- the generic inbound and reply paths preserve that explicit `null` through normal replies, session-state resolution, native slash handling, and native argument menus;
- stored model resolution interprets `null` as “do not derive a model parent”;
- an explicit persisted `parentSessionKey` still wins, so forks and spawned sessions keep their existing inheritance;
- other channels retain the existing suffix-derived behavior.

No persisted schema or configuration changes are required.

## User Impact

A Telegram DM topic without its own `/model` selection starts on the configured default instead of inheriting the flat DM pin. A model selected inside the topic remains topic-local.

## Evidence

Before the production change, the new default-key regression failed with the parent `anthropic` override for `agent:main:main:thread:12345:99`. After the change, the same resolver receives the Telegram-owned `null`, returns no inherited override, and does not load `agent:main:main`.

Validation on exact head `40bb3b8690bdb85f50ebe5059dc6ee827c26865c`, rebased onto `origin/main` at `56d89073dd`:

- `src/sessions/stored-model-overrides.test.ts` — 7 passed.
- Telegram normal-message context, session-runtime, and native-menu regressions — 30 passed across 3 files.
- Dispatch boundary regression (`does not derive a flat DM model override when a Telegram topic suppresses inheritance`) — passed; it asserts that the flat DM row is never loaded.
- Changed-file `oxfmt`, `oxlint`, and `git diff --check` — passed.
- Full exact-head repository CI completed successfully.

An equivalent user-visible behavior repair has been running since 2026-08-08 on a Telegram deployment with private topics enabled. A fresh Telegram-visible Mantis capture is requested below so the after-fix UI behavior is inspectable on this exact revision.

This PR was AI-assisted; the implementation, tests, and validation were reviewed by the submitting author.
