### PR TITLE
fix(ui): make reconnect banner full width

### DIFF
--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -303,6 +303,30 @@ suite.define(() => {
   });
 
   it.each([
+    { name: "tablet", width: 1024 },
+    { name: "phone", width: 390 },
+  ])("spans the $name settings viewport while reconnecting", async ({ width }) => {
+    const context = await suite.browser.newContext({ viewport: { height: 900, width } });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page);
+
+    try {
+      await page.goto(new URL("settings/connection", suite.server.baseUrl).href);
+      await page.locator("openclaw-app-shell").waitFor();
+      await gateway.deferNext("connect");
+      await gateway.closeLatest(1012, "test reconnect");
+
+      const notice = page.locator('.connection-action-block[role="status"]');
+      await notice.waitFor();
+      const bounds = await notice.boundingBox();
+      expect(bounds?.x).toBe(0);
+      expect(bounds?.width).toBe(width);
+    } finally {
+      await closeContext(context);
+    }
+  });
+
+  it.each([
     {
       name: "missing token",
       error: {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -296,11 +296,10 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
 
 .shell--settings.shell--mobile-nav {
   --settings-content-block-start-padding: 4px;
-  --settings-content-inline-padding: 4px;
 }
 
 .shell--settings .connection-action-block {
-  margin-inline: calc(0px - var(--settings-content-inline-padding));
+  margin-inline: calc(0px - var(--settings-content-inline-padding, var(--content-inline-padding)));
   border-inline: 0;
   border-radius: 0;
 }
@@ -4029,7 +4028,8 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
 
 .content {
   grid-area: content;
-  padding: 16px 20px 32px;
+  --content-inline-padding: 20px;
+  padding: 16px var(--content-inline-padding) 32px;
   display: block;
   min-height: 0;
   overflow-y: auto;

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -371,7 +371,8 @@ html.openclaw-native-macos body .shell--mobile-nav .topnav-shell__actions {
   }
 
   .content {
-    padding: 4px 4px 16px;
+    --content-inline-padding: 4px;
+    padding: 4px var(--content-inline-padding) 16px;
     gap: 12px;
   }
 
@@ -544,7 +545,7 @@ html.openclaw-native-macos body .shell--mobile-nav .topnav-shell__actions {
   }
 
   .content {
-    padding: 4px 4px 12px;
+    padding: 4px var(--content-inline-padding) 12px;
     gap: 10px;
   }
 


### PR DESCRIPTION
## Summary

- make the settings reconnect banner full-bleed across tablet and phone drawer layouts
- make the content inline inset the single source of truth for both content padding and banner compensation
- add mocked-Gateway E2E geometry coverage at 1024px and 390px

## Root cause and repair

The drawer layout activates at 1100px, but the content inset only shrinks at the narrower mobile breakpoint. The banner hard-coded the narrow 4px inset for the entire drawer range, leaving 16px visible on each side at tablet widths. The content container now owns its current inline inset and the banner consumes that value. No fallback path or route-specific literal was added.

Architectural owner: Control UI shell layout.
Removed path: the duplicate mobile-only banner inset value.
Sibling coverage: desktop settings behavior is unchanged; the phone path remains full width and is now asserted alongside tablet.
Production LOC delta: +1 net CSS line. The added line is the shared content-inset owner used across the base and narrow layout rules.

## Visual proof: mocked Gateway reconnect flow

| Viewport | Before | After |
| --- | --- | --- |
| Tablet, 1024×900 | x=16, width=992 | x=0, width=1024 |
| Phone, 390×900 | x=0, width=390 | x=0, width=390 |

Screenshots were captured from the same real Control UI route and mocked WebSocket reconnect sequence used by the regression test.

## Validation

- node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/login-gate.e2e.test.ts — 15 passed
- pnpm lint:ui:styles
- pnpm exec oxfmt --check ui/src/e2e/login-gate.e2e.test.ts ui/src/styles/layout.css ui/src/styles/layout.mobile.css
- git diff origin/main...HEAD --check