### PR TITLE
fix(test): restore managed plugin E2E after capability consent

### DIFF
--- a/extensions/diagnostics-prometheus/src/install-runtime.e2e.test.ts
+++ b/extensions/diagnostics-prometheus/src/install-runtime.e2e.test.ts
@@ -307,7 +307,11 @@ describe("diagnostics-prometheus managed install runtime", () => {
       stateDir,
     });
 
-    await runCli(["plugins", "install", `npm:${packageName}@${pluginVersion}`], env, true);
+    await runCli(
+      ["plugins", "install", `npm:${packageName}@${pluginVersion}`, "--accept-capabilities"],
+      env,
+      true,
+    );
     const inspect = JSON.parse(
       await runCli(["plugins", "inspect", pluginId, "--runtime", "--json"], env),
     ) as {

--- a/scripts/agent-plugin-gateway-e2e.ts
+++ b/scripts/agent-plugin-gateway-e2e.ts
@@ -363,7 +363,7 @@ async function main(): Promise<void> {
 
     install = spawnCaptured(
       process.execPath,
-      [devRunnerPath, "plugins", "install", fixtureDir, "--force"],
+      [devRunnerPath, "plugins", "install", fixtureDir, "--force", "--accept-capabilities"],
       { cwd: repoRoot, env: childEnv, label: "plugin install" },
     );
     await waitForExit(install);

--- a/test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts
@@ -256,17 +256,15 @@ async function restartWithOtelConfig(params: {
   });
 }
 
-async function installAndConfigure(params: {
-  configTraceEndpoint: string;
+// Return the handle before installation so the caller's finally owns every later failure.
+async function startInstallGateway(params: {
   envTraceEndpoint: string;
   mockBaseUrl: string;
   nodeOptions?: string;
-  packageVersion: string;
   registryBaseUrl: string;
   repoRoot: string;
-  sampleRate?: number;
 }) {
-  const gateway = await startQaGatewayChild({
+  return await startQaGatewayChild({
     repoRoot: params.repoRoot,
     providerBaseUrl: `${params.mockBaseUrl}/v1`,
     providerMode: "mock-openai",
@@ -292,8 +290,17 @@ async function installAndConfigure(params: {
       ...(params.nodeOptions ? { OPENCLAW_OTEL_PRELOADED: "1" } : {}),
     },
   });
+}
+
+async function installAndConfigure(params: {
+  gateway: Awaited<ReturnType<typeof startQaGatewayChild>>;
+  configTraceEndpoint: string;
+  packageVersion: string;
+  sampleRate?: number;
+}) {
+  const { gateway } = params;
   const spec = `npm:${PACKAGE_NAME}@${params.packageVersion}`;
-  await gateway.runCli(["plugins", "install", spec, "--force"]);
+  await gateway.runCli(["plugins", "install", spec, "--force", "--accept-capabilities"]);
   const stateDir = gateway.runtimeEnv.OPENCLAW_STATE_DIR;
   if (!stateDir) {
     throw new Error("qa gateway state directory was not configured");
@@ -332,7 +339,6 @@ async function installAndConfigure(params: {
     id: "diagnostics-otel",
     status: "loaded",
   });
-  return gateway;
 }
 
 describe("managed diagnostics-otel install runtime", () => {
@@ -348,13 +354,16 @@ describe("managed diagnostics-otel install runtime", () => {
       const packed = await packPlugin(repoRoot, scratch);
       registry = await startRegistry(repoRoot, scratch, packed.tarball, packed.version);
       mock = await startQaMockOpenAiServer();
-      gateway = await installAndConfigure({
-        configTraceEndpoint: configured.baseUrl,
+      gateway = await startInstallGateway({
         envTraceEndpoint: envOnly.baseUrl,
         mockBaseUrl: mock.baseUrl,
-        packageVersion: packed.version,
         registryBaseUrl: registry.baseUrl,
         repoRoot,
+      });
+      await installAndConfigure({
+        gateway,
+        configTraceEndpoint: configured.baseUrl,
+        packageVersion: packed.version,
         sampleRate: 0,
       });
       await runTurn(gateway, "OTEL-MANAGED-SAMPLED-OUT");
@@ -457,14 +466,17 @@ describe("managed diagnostics-otel install runtime", () => {
           "globalThis.__openclawQaPreloadedOtelSdk = sdk;",
         ].join("\n"),
       );
-      gateway = await installAndConfigure({
-        configTraceEndpoint: ignoredConfig.baseUrl,
+      gateway = await startInstallGateway({
         envTraceEndpoint: receiver.baseUrl,
         mockBaseUrl: mock.baseUrl,
         nodeOptions: `--import=${pathToFileURL(preloadPath).href}`,
-        packageVersion: packed.version,
         registryBaseUrl: registry.baseUrl,
         repoRoot,
+      });
+      await installAndConfigure({
+        gateway,
+        configTraceEndpoint: ignoredConfig.baseUrl,
+        packageVersion: packed.version,
       });
       const stateDir = gateway.runtimeEnv.OPENCLAW_STATE_DIR;
       if (!stateDir) {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where managed-plugin QA stopped at installation after capability consent became mandatory. Both OTel install cases, the Prometheus install case, and the portable Agent Plugins Gateway scenario failed before reaching their runtime assertions. The OTel fixture could also leave a Gateway running when installation failed.

## Why This Change Was Made

The fixtures now pass the documented `--accept-capabilities` option when installing their own reviewed packages. `--force` is a separate trust/overwrite decision, not capability consent. Product consent policy remains unchanged.

The OTel fixture now acquires and assigns its Gateway handle before awaiting installation/configuration, so its existing `finally` owns cleanup on both success and failure. The later flag-free disable/enable flow still proves persisted consent reuse. Prometheus and portable Agent Plugins already acquire their cleanup handles before fallible awaits, so those paths only need the install acknowledgment.

Provenance is clear: #130168 (2026-08-27, code/PR author and merger @steipete) made the older fixture omissions visible. The OTel acquisition gap and install command date to #118965 (2026-08-05, code/PR author and merger @vincentkoc); the Prometheus command dates to #118867 (merged 2026-08-03 UTC, code/PR author and merger @vincentkoc). The portable Agent Plugins command dates to #120303 (2026-08-07, code/PR author and merger @steipete). Those fixtures and the relevant consent contract are unchanged between the original failing snapshot and this fix's base.

## User Impact

No production behavior, configuration, schema, dependency, or consent-policy changes. Maintainers regain four native QA scenarios without weakening assertions, increasing timeouts, adding retries, or bypassing the installer. OTel setup failures now stop the acquired Gateway through the existing cleanup path.

Production LOC: +0/-0. Test fixtures: +30/-14. Executable E2E tooling: +1/-1. Total: three files, +31/-15.

## Evidence

Verified with Node 24.20.0 and the frozen pnpm 11.22.0 dependency contract in an isolated normal checkout:

- Original full-run RED: both managed OTel cases, Prometheus, and portable Agent Plugins failed their real CLI install with the capability-consent diagnostic.
- Managed OTel: **2/2 passed**, preserving exact package/version/integrity, consent reuse, loaded runtime, sampling, endpoint precedence, flush timing, and independently preloaded SDK assertions. Every observed descendant exited and all 10 observed listening ports closed.
- Cleanup negative control: deliberately removed only OTel's consent acknowledgment, then ran its unchanged first case. The real CLI still rejected installation as expected; the acquired Gateway and registry exited, with all five observed ports closed. The acknowledgment was restored after the run drained. This is a deliberate failing control, not another passing scenario.
- Managed Prometheus: **1/1 passed**, including official package identity, trusted runtime, denied unauthenticated scrape, successful authenticated text response, and startup exporter metric. Both observed listening ports closed; no surviving descendants.
- Portable Agent Plugins: the canonical executable returned `ok: true` and `AGENT_BUNDLE_MCP_OK`, preserving startup activation, foreign-namespace handling, the model-driven MCP call, and exact subprocess argument/directory/environment contracts. Both observed listening ports closed; no surviving descendants.
- Full changed-file gate: all **22 checks passed**, both before commit and again against the exact committed `HEAD^..HEAD` patch.
- One isolated Codex P0 review: no findings. Formatting and `git diff --check` passed. Commit `e6a5a6ab65188bcd8d27c4a8d3946131c4119dbe` preserves the reviewed patch bytes.

ClawSweeper follow-up: [exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33134225218) is now successful, including `openclaw/ci-gate`. The requested isolated Codex review already completed successfully on these unchanged patch bytes through the canonical helper, including its mandatory fail-closed TruffleHog preflight, with no findings. The bot's separate unavailable scanner does not invalidate that completed review; an additional unchanged review is therefore skipped. Its 30-second `AGENT_BUNDLE_MCP_OK` probe stopped during `pnpm build` at `tsdown-packages`, before the E2E command ran. The completed native Agent Plugins run above reached `ok: true`, checked the MCP and launch contracts, and cleaned up; the short build probe is not reported as a failing test.

The native commands were:

```sh
node scripts/run-vitest.mjs run test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts
node scripts/run-vitest.mjs run extensions/diagnostics-prometheus/src/install-runtime.e2e.test.ts
node --import ./scripts/tsx.mjs scripts/agent-plugin-gateway-e2e.ts
node scripts/check-changed.mjs --base HEAD^ --head HEAD --timed -- scripts/agent-plugin-gateway-e2e.ts test/e2e/qa-lab/runtime/diagnostics-otel-install-runtime.e2e.test.ts extensions/diagnostics-prometheus/src/install-runtime.e2e.test.ts
```

The independent OTel outbound-reply timeout in `otel-gateway-runtime.e2e.test.ts` remains a separate investigation and is not claimed fixed here. Another named follow-up is the Prometheus fixture's existing lack of an exit assertion after its final kill wait; no observed leak justified expanding this repair.

AI-assisted with Codex; implementation, owner contracts, and native evidence were reviewed directly.
