### PR TITLE
docs(test): include agent-plugin gateway in E2E aggregate

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -120,7 +120,7 @@ Test wrapper runs end with a short `[test] passed|failed|skipped ... in ...` sum
 ## Gateway and E2E
 
 - Gateway tests are included in the untargeted `pnpm test` full suite; run them alone with `pnpm test:gateway`.
-- `pnpm test:e2e`: repo E2E aggregate = `pnpm test:e2e:gateway && pnpm test:ui:e2e`.
+- `pnpm test:e2e`: repo E2E aggregate = `pnpm test:e2e:gateway && pnpm test:e2e:agent-plugin-gateway && pnpm test:ui:e2e`.
 - `pnpm test:e2e:gateway`: gateway end-to-end smoke tests (multi-instance WS/HTTP/node pairing). Defaults to `threads` + `isolate: false` with one worker in `vitest.e2e.config.ts`; opt into parallelism with `OPENCLAW_E2E_WORKERS=<n>` (capped at 16), and enable verbose logs with `OPENCLAW_E2E_VERBOSE=1`.
 - `pnpm test:live`: provider live tests (Claude/Minimax/DeepSeek/z.ai/etc, gated by `*.live.test.ts`). Requires API keys and `LIVE=1` (or `OPENCLAW_LIVE_TEST=1`) to unskip; verbose output with `OPENCLAW_LIVE_TEST_QUIET=0`.
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers reading the [test reference](https://docs.openclaw.ai/reference/test#gateway-and-e2e) see an incomplete expansion of `pnpm test:e2e`: the documented aggregate omits the agent-plugin gateway lane.

## Why This Change Was Made

`package.json` already runs `pnpm test:e2e:gateway && pnpm test:e2e:agent-plugin-gateway && pnpm test:ui:e2e`. This one-line documentation correction includes the middle command in that exact order. No runtime, scripts, assertions, configuration, or dependencies change.

## User Impact

Developers can see all three lanes included in the existing E2E aggregate. Test execution behavior is unchanged.

## Evidence

Compared the aggregate in `package.json` with `docs/reference/test.md:123`; the corrected sequence matches exactly.

- `pnpm docs:list` — passed; the test reference is indexed.
- `node scripts/check-docs-mdx.mjs docs/reference/test.md` — passed (1 file).
- `node_modules/.bin/oxfmt --check docs/reference/test.md` — passed (1 file).
- `git diff --check` — passed.
- `git diff --numstat` — only `docs/reference/test.md`, 1 insertion / 1 deletion; production and test code both unchanged.

The E2E aggregate and its individual lanes were intentionally not run for this docs-only correction. No regression test was added because no executable behavior changes. AI-assisted; reviewed under the repository's truly trivial/docs-only autoreview exception.
