### PR TITLE
improve(ui): rename connected channels heading

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -275,7 +275,7 @@ export const en: TranslationMap = {
     refreshingStaleSnapshot:
       "Refreshing channel status in the background; showing the last successful snapshot.",
     hub: {
-      connectedTitle: "Your channels",
+      connectedTitle: "Connected channels",
       addTitle: "Add a channel",
       addSubtitle: "Pick a service and follow the guided setup.",
       updatedAgo: "Updated {ago}",

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -131,7 +131,7 @@ describe("channels section order", () => {
     const headings = Array.from(container.querySelectorAll(".settings-section__heading"), (node) =>
       node.textContent?.trim(),
     );
-    expect(headings).toEqual(["Your channels", "Add a channel", "DM access requests"]);
+    expect(headings).toEqual(["Connected channels", "Add a channel", "DM access requests"]);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

The channels hub labels its connected-channel section as “Your channels,” while the section specifically describes connection state. This makes the heading less precise than the content beneath it.

## Why This Change Was Made

Rename the canonical English heading to “Connected channels” and keep the existing section-order assertion aligned with the rendered copy. The post-merge localization workflow will propagate the source-copy update to generated translations.

## User Impact

Users see the clearer “Connected channels” heading on the channels hub.

## Evidence

- `pnpm ui:i18n:baseline`
- `pnpm ui:i18n:verify`
- `pnpm test ui/src/pages/channels/view.test.ts` — 30 passed
- `pnpm check:changed -- ui/src/i18n/locales/en.ts ui/src/pages/channels/view.test.ts`
- `pnpm ui:build`
- `.agents/skills/autoreview/scripts/autoreview --mode local ...` — clean, no accepted/actionable findings
- Live mock server started at `http://127.0.0.1:5197/channels` and the URL was opened in the Codex app Browser pane.

Before:

![Channels hub showing the previous “Your channels” heading](https://github.com/user-attachments/assets/18f5dfa5-fde5-4722-9e73-07aaccaabdfd)

Visual-proof gap: the Codex in-app Browser pane opened successfully, but its automation interface did not register after the required retry, so an inspected after screenshot could not be captured without switching to an unapproved browser surface. Deterministic i18n checks, the focused channels test, and the production UI build passed.

AI-assisted: yes.
