### PR TITLE
improve(ui): place DM access requests last

### DIFF
--- a/ui/src/e2e/theme-typography.e2e.test.ts
+++ b/ui/src/e2e/theme-typography.e2e.test.ts
@@ -1,5 +1,6 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import type { Locator } from "playwright";
 import { expect, it } from "vitest";
 import {
   formatKeyboardShortcutCombo,
@@ -118,6 +119,37 @@ async function captureTypography(
   }
 }
 
+async function openPicker(picker: Locator) {
+  await Promise.all([
+    picker.evaluate(
+      (select) =>
+        new Promise<void>((resolve) => {
+          select.addEventListener("wa-after-show", () => resolve(), { once: true });
+        }),
+    ),
+    picker.click(),
+  ]);
+}
+
+async function selectPickerOption(picker: Locator, value: string) {
+  await openPicker(picker);
+  await clickPickerOption(picker, value);
+}
+
+async function clickPickerOption(picker: Locator, value: string) {
+  const option = picker.locator(`wa-option[value="${value}"]`);
+  await option.waitFor({ state: "visible" });
+  await Promise.all([
+    picker.evaluate(
+      (select) =>
+        new Promise<void>((resolve) => {
+          select.addEventListener("wa-after-hide", () => resolve(), { once: true });
+        }),
+    ),
+    option.click(),
+  ]);
+}
+
 suite.define(() => {
   it("previews fonts on demand, applies independent overrides, and restores theme typography", async () => {
     const { page, themeRequests, gateway } = await openThemedChat("dash", "dark");
@@ -151,23 +183,14 @@ suite.define(() => {
       await preview.scrollIntoViewIfNeeded();
     }
     await captureTypography(page, "picker-default");
-    await Promise.all([
-      ui.evaluate(
-        (select) =>
-          new Promise<void>((resolve) => {
-            select.addEventListener("wa-after-show", () => resolve(), { once: true });
-          }),
-      ),
-      ui.click(),
-    ]);
+    await openPicker(ui);
     await ui.locator('wa-option[value="geist"]').waitFor({ state: "visible" });
     await expect.poll(() => fontRequests().length).toBe(9);
     await captureTypography(page, "picker-specimens");
-    await ui.locator('wa-option[value="geist"]').click();
+    await clickPickerOption(ui, "geist");
     await expect.poll(async () => (await families()).ui).toContain("Geist");
     expect((await families()).chat).toContain("Fraunces");
-    await chat.click();
-    await chat.locator('wa-option[value="lora"]').click();
+    await selectPickerOption(chat, "lora");
     await expect.poll(async () => (await families()).chat).toContain("Lora");
     await expect
       .poll(() =>
@@ -183,13 +206,10 @@ suite.define(() => {
     await waitForControlUiSettingsTakeover(page);
     await expect.poll(async () => (await families()).ui).toContain("Geist");
     await expect.poll(async () => (await families()).chat).toContain("Lora");
-    await ui.click();
-    await ui.locator('wa-option[value="system"]').click();
+    await selectPickerOption(ui, "system");
     await expect.poll(async () => (await families()).ui).toContain("-apple-system");
-    await ui.click();
-    await ui.locator('wa-option[value="theme"]').click();
-    await chat.click();
-    await chat.locator('wa-option[value="theme"]').click();
+    await selectPickerOption(ui, "theme");
+    await selectPickerOption(chat, "theme");
     await expect.poll(families).toEqual(initial);
     expect(
       await page.evaluate(() =>

--- a/ui/src/pages/channels/view.test.ts
+++ b/ui/src/pages/channels/view.test.ts
@@ -115,6 +115,26 @@ describe("channels setup access", () => {
   });
 });
 
+describe("channels section order", () => {
+  it("places DM access requests after the channel management sections", () => {
+    const props = createProps({
+      ts: Date.now(),
+      channelOrder: ["telegram"],
+      channelLabels: { telegram: "Telegram" },
+      channels: { telegram: { configured: false } },
+      channelAccounts: {},
+      channelDefaultAccountId: {},
+    });
+    const container = document.createElement("div");
+    render(renderChannels(props), container);
+
+    const headings = Array.from(container.querySelectorAll(".settings-section__heading"), (node) =>
+      node.textContent?.trim(),
+    );
+    expect(headings).toEqual(["Your channels", "Add a channel", "DM access requests"]);
+  });
+});
+
 function createWhatsAppStatus(overrides: Partial<WhatsAppStatus> = {}): WhatsAppStatus {
   return {
     configured: true,

--- a/ui/src/pages/channels/view.ts
+++ b/ui/src/pages/channels/view.ts
@@ -63,7 +63,6 @@ export function renderChannels(props: ChannelsProps) {
       ${props.setupBlockedByDirtyConfig && props.configFormDirty
         ? html`<div class="callout warn">${t("channels.hub.saveBeforeSetup")}</div>`
         : nothing}
-      ${renderChannelPairingQueue(props)}
       ${renderSettingsSection(
         {
           title: t("channels.hub.connectedTitle"),
@@ -108,6 +107,7 @@ export function renderChannels(props: ChannelsProps) {
               ${renderBrowseAllRow(props)}`}
         `,
       )}
+      ${renderChannelPairingQueue(props)}
     `)}
     ${selected
       ? renderChannelDetail({


### PR DESCRIPTION
## What Problem This Solves

The Channels page currently puts the low-frequency DM access request queue before the primary channel management sections. This makes **Your channels** and **Add a channel** appear later than the page's supporting access-review workflow.

## Why This Change Was Made

Moves the existing DM access request section to the end of the Channels settings page, after **Your channels** and **Add a channel**. The queue's behavior and data flow are unchanged. A rendered DOM-order test protects the intended hierarchy.

## User Impact

Operators now see channel status and setup first, with DM access requests last in the section.

## Evidence

Before:

![DM access requests shown before Your channels](https://github.com/user-attachments/assets/f372fcf4-7f37-4e1b-821d-54e144033dd9)

- Regression proof before the production edit: the new test received `DM access requests`, `Your channels`, `Add a channel` and failed against the requested order.
- `pnpm test ui/src/pages/channels/view.test.ts` — 30 tests passed.
- `pnpm test ui/src/e2e/theme-typography.e2e.test.ts` — 17 tests passed after reproducing and repairing a newly landed picker-transition race caught by exact-head CI run 33134582053. The test now waits for Web Awesome's `wa-after-show` and `wa-after-hide` lifecycle events instead of overlapping close/open animations.
- `node scripts/check-changed.mjs -- ui/src/e2e/theme-typography.e2e.test.ts ui/src/pages/channels/view.ts ui/src/pages/channels/view.test.ts` — passed, including UI typecheck, formatting, lint, and repository guards.
- Autoreview: clean, no accepted/actionable findings.
- Production delta: 1 insertion, 1 deletion (the existing render call moved); test delta: +40 net lines, including the CI flake repair.

After-screenshot gap: the Codex in-app Browser pane did not register a controllable session after reopening and rediscovery, so local visual capture was infeasible. Per repository policy, no Chrome, Computer Use, or desktop-browser fallback was used. The rendered DOM-order test verifies the final section sequence as `Your channels`, `Add a channel`, `DM access requests`.

AI-assisted: yes. I reviewed the implementation and understand the change.
