### PR TITLE
fix: interactive update can leave the Gateway stopped when completion refresh fails

### DIFF
--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -2,11 +2,15 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
 import { defaultRuntime } from "../../runtime.js";
 
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const mocks = vi.hoisted(() => ({
+  checkCompletionStatus: vi.fn(),
   completePluginUpdate: vi.fn(),
+  ensureCompletionCache: vi.fn(),
   leaseActive: false,
   loadPluginRecords: vi.fn(),
   markSentinelFailure: vi.fn(async () => undefined),
@@ -24,8 +28,6 @@ const mocks = vi.hoisted(() => ({
       typeof import("./update-command-service.js").revalidateManagedGatewayServiceAfterUpdate
     >(),
   restoreWindowsAutoStart: vi.fn(async () => true),
-  tryInstallCompletion: vi.fn(async () => undefined),
-  tryWriteCompletionCache: vi.fn(async () => undefined),
   updatePlugins: vi.fn(),
   writeSentinel: vi.fn(async () => undefined),
 }));
@@ -42,6 +44,11 @@ vi.mock("../../config/io.js", async (importOriginal) => ({
 vi.mock("../../daemon/service.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../daemon/service.js")>()),
   readGatewayServiceState: mocks.readServiceState,
+}));
+vi.mock("../../commands/doctor-completion.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../commands/doctor-completion.js")>()),
+  checkShellCompletionStatus: mocks.checkCompletionStatus,
+  ensureCompletionCacheExists: mocks.ensureCompletionCache,
 }));
 vi.mock("../../plugins/plugin-lifecycle-lease.js", () => ({
   withPluginLifecycleLease: async (_params: unknown, callback: () => unknown) => {
@@ -72,10 +79,6 @@ vi.mock("./update-command-fresh-doctor.js", () => ({
 vi.mock("./update-command-plugins.js", () => ({
   updatePluginsAfterCoreUpdate: mocks.updatePlugins,
 }));
-vi.mock("./shared.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("./shared.js")>()),
-  tryWriteCompletionCache: mocks.tryWriteCompletionCache,
-}));
 vi.mock("./restart-helper.js", () => ({
   prepareRestartScript: mocks.prepareRestartScript,
 }));
@@ -85,7 +88,6 @@ vi.mock("./update-command-service.js", async (importOriginal) => ({
   maybeRestartServiceAfterFailedMutableUpdate: mocks.restart,
   revalidateManagedGatewayServiceAfterUpdate: mocks.revalidateService,
   restoreWindowsTaskAutoStartOrExit: mocks.restoreWindowsAutoStart,
-  tryInstallShellCompletion: mocks.tryInstallCompletion,
 }));
 vi.mock("./update-command-post-core.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./update-command-post-core.js")>()),
@@ -98,6 +100,15 @@ import { finishUpdate } from "./update-command-post-update.js";
 import { resolveUpdatedGatewayRestartPort } from "./update-command-service.js";
 
 type FinishUpdateParams = Parameters<typeof finishUpdate>[0];
+const stdinIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+
+afterEach(() => {
+  if (stdinIsTTYDescriptor) {
+    Object.defineProperty(process.stdin, "isTTY", stdinIsTTYDescriptor);
+  } else {
+    Reflect.deleteProperty(process.stdin, "isTTY");
+  }
+});
 
 const validConfigSnapshot = {
   valid: true,
@@ -290,6 +301,83 @@ describe("successful update finalization ordering", () => {
     vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined as never);
     vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
     vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
+  });
+
+  it("restarts after completion status inspection fails", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    mocks.checkCompletionStatus.mockRejectedValueOnce(
+      Object.assign(new Error("EACCES: completion profile read denied"), { code: "EACCES" }),
+    );
+
+    let failure: unknown;
+    try {
+      await finishSuccessfulPackageSwitch({
+        previousRoot: "/tmp/openclaw-update",
+        packageRoot: "/tmp/openclaw-update",
+        restartEnvironment: process.env,
+      });
+    } catch (err) {
+      failure = err;
+    }
+
+    const output = vi.mocked(defaultRuntime.log).mock.calls.flat().map(String).join("\n");
+    expect.soft(failure).toBeUndefined();
+    expect.soft(output).toContain("Shell completion refresh failed");
+    expect.soft(mocks.restartService).toHaveBeenCalledOnce();
+    expect(mocks.restartService.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.checkCompletionStatus.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it("restarts when completion cache refresh reports failure", async () => {
+    const root = tempDirs.make("openclaw-completion-failure-");
+    await fs.writeFile(
+      path.join(root, "openclaw.mjs"),
+      'process.stderr.write("injected completion cache failure"); process.exit(1);',
+    );
+
+    await finishSuccessfulPackageSwitch({
+      previousRoot: root,
+      packageRoot: root,
+      restartEnvironment: process.env,
+    });
+
+    const logCalls = vi.mocked(defaultRuntime.log).mock.calls;
+    const warningIndex = logCalls.findIndex((call) =>
+      call.some((value) => String(value).includes("Completion cache update failed")),
+    );
+    expect(warningIndex).toBeGreaterThanOrEqual(0);
+    expect(mocks.restartService.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(defaultRuntime.log).mock.invocationCallOrder[warningIndex] ??
+        Number.POSITIVE_INFINITY,
+    );
+    expect(logCalls[warningIndex]?.join(" ")).toContain("openclaw completion --write-state");
+  });
+
+  it("restarts when shell completion cache generation returns false", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    mocks.checkCompletionStatus.mockResolvedValueOnce({
+      shell: "zsh",
+      profileInstalled: true,
+      cacheExists: true,
+      cachePath: "/tmp/openclaw-completion.zsh",
+      usesSlowPattern: true,
+    });
+    mocks.ensureCompletionCache.mockResolvedValueOnce(false);
+
+    await finishSuccessfulPackageSwitch({
+      previousRoot: "/tmp/openclaw-update",
+      packageRoot: "/tmp/openclaw-update",
+      restartEnvironment: process.env,
+    });
+
+    const output = vi.mocked(defaultRuntime.log).mock.calls.flat().map(String).join("\n");
+    expect(output).toContain("completion cache generation failed");
+    expect(output).toContain("openclaw completion --write-state --install");
+    expect(mocks.restartService).toHaveBeenCalledOnce();
+    expect(mocks.restartService.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.ensureCompletionCache.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+    );
   });
 
   it("retires the wrapper before persisting and printing success", async () => {

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -140,6 +140,7 @@ async function finishSuccessfulPackageSwitch(params: {
   previousRoot: string;
   packageRoot: string;
   restartEnvironment?: NodeJS.ProcessEnv;
+  json?: boolean;
   sealed?: boolean;
   updateMode?: UpdateRunResult["mode"];
   stoppedForUpdate?: boolean;
@@ -168,7 +169,7 @@ async function finishSuccessfulPackageSwitch(params: {
     channel: params.updateMode === "git" ? "dev" : "stable",
     downgradeRisk: true,
     shouldRestart: Boolean(params.restartEnvironment),
-    opts: {},
+    opts: { json: params.json },
     showProgress: false,
     controlPlaneUpdateSentinelMeta: {},
     preUpdatePluginInstallRecords: {},
@@ -378,6 +379,44 @@ describe("successful update finalization ordering", () => {
     expect(mocks.restartService.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.ensureCompletionCache.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     );
+  });
+
+  it.each([
+    { name: "JSON mode", isTTY: true, json: true },
+    { name: "non-TTY mode", isTTY: false, json: false },
+  ])("skips interactive completion in $name", async ({ isTTY, json }) => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: isTTY });
+
+    await finishSuccessfulPackageSwitch({
+      previousRoot: "/tmp/openclaw-update",
+      packageRoot: "/tmp/openclaw-update",
+      restartEnvironment: process.env,
+      json,
+    });
+
+    expect(mocks.checkCompletionStatus).not.toHaveBeenCalled();
+    expect(mocks.ensureCompletionCache).not.toHaveBeenCalled();
+    expect(mocks.restartService).toHaveBeenCalledOnce();
+  });
+
+  it("keeps an unhealthy restart blocking before completion refresh", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+    mocks.restartService.mockResolvedValueOnce(false);
+    mocks.checkCompletionStatus.mockRejectedValueOnce(
+      new Error("completion status should not run after failed restart health"),
+    );
+
+    await finishSuccessfulPackageSwitch({
+      previousRoot: "/tmp/openclaw-update",
+      packageRoot: "/tmp/openclaw-update",
+      restartEnvironment: process.env,
+    });
+
+    expect(mocks.markSentinelFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "restart-unhealthy" }),
+    );
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expect(mocks.checkCompletionStatus).not.toHaveBeenCalled();
   });
 
   it("retires the wrapper before persisting and printing success", async () => {

--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -381,17 +381,31 @@ describe("successful update finalization ordering", () => {
     );
   });
 
-  it.each([
-    { name: "JSON mode", isTTY: true, json: true },
-    { name: "non-TTY mode", isTTY: false, json: false },
-  ])("skips interactive completion in $name", async ({ isTTY, json }) => {
-    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: isTTY });
+  it("keeps JSON completion cache failures silent and restarts", async () => {
+    const root = tempDirs.make("openclaw-json-completion-failure-");
+    await fs.writeFile(path.join(root, "openclaw.mjs"), "process.exit(1);");
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
+
+    await finishSuccessfulPackageSwitch({
+      previousRoot: root,
+      packageRoot: root,
+      restartEnvironment: process.env,
+      json: true,
+    });
+
+    expect(defaultRuntime.error).not.toHaveBeenCalled();
+    expect(mocks.checkCompletionStatus).not.toHaveBeenCalled();
+    expect(mocks.ensureCompletionCache).not.toHaveBeenCalled();
+    expect(mocks.restartService).toHaveBeenCalledOnce();
+  });
+
+  it("skips interactive completion in non-TTY mode", async () => {
+    Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
 
     await finishSuccessfulPackageSwitch({
       previousRoot: "/tmp/openclaw-update",
       packageRoot: "/tmp/openclaw-update",
       restartEnvironment: process.env,
-      json,
     });
 
     expect(mocks.checkCompletionStatus).not.toHaveBeenCalled();

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -470,12 +470,6 @@ export async function finishUpdate(params: {
     }
   }
 
-  await tryWriteCompletionCache(postUpdateRoot, Boolean(params.opts.json));
-  await tryInstallShellCompletion({
-    jsonMode: Boolean(params.opts.json),
-    skipPrompt: Boolean(params.opts.yes),
-  });
-
   await writeControlPlaneUpdateRestartSentinelBestEffort({
     meta: params.controlPlaneUpdateSentinelMeta,
     result: buildControlPlaneUpdateRestartHealthPendingResult(resultWithPostUpdate),
@@ -514,6 +508,35 @@ export async function finishUpdate(params: {
     defaultRuntime.exit(1);
     return;
   }
+
+  // Restart and health verification own recovery of the service stopped for this update.
+  // Optional completion refresh must run only after that lifecycle boundary settles.
+  const completionCacheRefreshCommand = replaceCliName(
+    formatCliCommand("openclaw completion --write-state"),
+    CLI_NAME,
+  );
+  try {
+    const completionCacheResult = await tryWriteCompletionCache(
+      postUpdateRoot,
+      Boolean(params.opts.json),
+    );
+    if (completionCacheResult === "failed" && params.opts.json) {
+      defaultRuntime.error(
+        `Completion cache update failed. Update will continue; retry with: ${completionCacheRefreshCommand}`,
+      );
+    }
+  } catch (err) {
+    const message = `Completion cache update failed: ${formatErrorMessage(err)}. Update will continue; retry with: ${completionCacheRefreshCommand}`;
+    if (params.opts.json) {
+      defaultRuntime.error(message);
+    } else {
+      defaultRuntime.log(theme.warn(message));
+    }
+  }
+  await tryInstallShellCompletion({
+    jsonMode: Boolean(params.opts.json),
+    skipPrompt: Boolean(params.opts.yes),
+  });
 
   if (params.installKindChanged && resultWithPostUpdate.mode !== "git") {
     const retirement = await retireStandaloneGitWrapper({

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -511,26 +511,19 @@ export async function finishUpdate(params: {
 
   // Restart and health verification own recovery of the service stopped for this update.
   // Optional completion refresh must run only after that lifecycle boundary settles.
-  const completionCacheRefreshCommand = replaceCliName(
-    formatCliCommand("openclaw completion --write-state"),
-    CLI_NAME,
-  );
   try {
-    const completionCacheResult = await tryWriteCompletionCache(
-      postUpdateRoot,
-      Boolean(params.opts.json),
-    );
-    if (completionCacheResult === "failed" && params.opts.json) {
-      defaultRuntime.error(
-        `Completion cache update failed. Update will continue; retry with: ${completionCacheRefreshCommand}`,
-      );
-    }
+    await tryWriteCompletionCache(postUpdateRoot, Boolean(params.opts.json));
   } catch (err) {
-    const message = `Completion cache update failed: ${formatErrorMessage(err)}. Update will continue; retry with: ${completionCacheRefreshCommand}`;
-    if (params.opts.json) {
-      defaultRuntime.error(message);
-    } else {
-      defaultRuntime.log(theme.warn(message));
+    if (!params.opts.json) {
+      const completionCacheRefreshCommand = replaceCliName(
+        formatCliCommand("openclaw completion --write-state"),
+        CLI_NAME,
+      );
+      defaultRuntime.log(
+        theme.warn(
+          `Completion cache update failed: ${formatErrorMessage(err)}. Update will continue; retry with: ${completionCacheRefreshCommand}`,
+        ),
+      );
     }
   }
   await tryInstallShellCompletion({

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -40,6 +40,7 @@ import {
 import { readGatewayServiceState, resolveGatewayService } from "../../daemon/service.js";
 import { resolveSystemdServiceName } from "../../daemon/systemd-service-files.js";
 import { sha256Hex } from "../../infra/crypto-digest.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { assertGatewayServiceMutationAllowed } from "../../infra/gateway-supervision.js";
 import { getSelfAndAncestorPidsSync } from "../../infra/restart-stale-pids.js";
 import { nodeVersionSatisfiesEngine } from "../../infra/runtime-guard.js";
@@ -874,60 +875,59 @@ export async function tryInstallShellCompletion(opts: {
     return;
   }
 
-  const status = await checkShellCompletionStatus(CLI_NAME);
-  const generationOptions = { generationMode: "core-only" } as const;
+  try {
+    const status = await checkShellCompletionStatus(CLI_NAME);
+    const generationOptions = { generationMode: "core-only" } as const;
 
-  if (status.usesSlowPattern) {
-    defaultRuntime.log(theme.muted("Upgrading shell completion to cached version..."));
-    const cacheGenerated = await ensureCompletionCacheExists(CLI_NAME, generationOptions);
-    if (cacheGenerated) {
-      await installShellCompletionForUpdate(status.shell, true);
+    if (status.usesSlowPattern) {
+      defaultRuntime.log(theme.muted("Upgrading shell completion to cached version..."));
+      if (!(await ensureCompletionCacheExists(CLI_NAME, generationOptions))) {
+        throw new Error("completion cache generation failed");
+      }
+      await installCompletion(status.shell, true, CLI_NAME);
+      return;
     }
-    return;
-  }
 
-  if (status.profileInstalled && !status.cacheExists) {
-    defaultRuntime.log(theme.muted("Regenerating shell completion cache..."));
-    await ensureCompletionCacheExists(CLI_NAME, generationOptions);
-    return;
-  }
-
-  if (!status.profileInstalled) {
-    defaultRuntime.log("");
-    defaultRuntime.log(theme.heading("Shell completion"));
-
-    const shouldInstall = await confirm({
-      message: stylePromptMessage(`Enable ${status.shell} shell completion for ${CLI_NAME}?`),
-      initialValue: true,
-    });
-
-    if (isCancel(shouldInstall) || !shouldInstall) {
-      if (!opts.skipPrompt) {
-        defaultRuntime.log(
-          theme.muted(
-            `Skipped. Run \`${replaceCliName(formatCliCommand("openclaw completion --install"), CLI_NAME)}\` later to enable.`,
-          ),
-        );
+    if (status.profileInstalled && !status.cacheExists) {
+      defaultRuntime.log(theme.muted("Regenerating shell completion cache..."));
+      if (!(await ensureCompletionCacheExists(CLI_NAME, generationOptions))) {
+        throw new Error("completion cache generation failed");
       }
       return;
     }
 
-    const cacheGenerated = await ensureCompletionCacheExists(CLI_NAME, generationOptions);
-    if (!cacheGenerated) {
-      defaultRuntime.log(theme.warn("Failed to generate completion cache."));
-      return;
+    if (!status.profileInstalled) {
+      defaultRuntime.log("");
+      defaultRuntime.log(theme.heading("Shell completion"));
+
+      const shouldInstall = await confirm({
+        message: stylePromptMessage(`Enable ${status.shell} shell completion for ${CLI_NAME}?`),
+        initialValue: true,
+      });
+
+      if (isCancel(shouldInstall) || !shouldInstall) {
+        if (!opts.skipPrompt) {
+          defaultRuntime.log(
+            theme.muted(
+              `Skipped. Run \`${replaceCliName(formatCliCommand("openclaw completion --install"), CLI_NAME)}\` later to enable.`,
+            ),
+          );
+        }
+        return;
+      }
+
+      if (!(await ensureCompletionCacheExists(CLI_NAME, generationOptions))) {
+        throw new Error("completion cache generation failed");
+      }
+      await installCompletion(status.shell, opts.skipPrompt, CLI_NAME);
     }
-
-    await installShellCompletionForUpdate(status.shell, opts.skipPrompt);
-  }
-}
-
-async function installShellCompletionForUpdate(shell: string, yes: boolean): Promise<void> {
-  try {
-    await installCompletion(shell, yes, CLI_NAME);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    defaultRuntime.log(theme.warn(`Shell completion refresh failed: ${message}`));
+    const message = formatErrorMessage(err);
+    defaultRuntime.log(
+      theme.warn(
+        `Shell completion refresh failed: ${message}. Update will continue; retry with: ${replaceCliName(formatCliCommand("openclaw completion --write-state --install"), CLI_NAME)}`,
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
Fixes #129190

## What Problem This Solves

Fixes an issue where users running an interactive update could be left with a stopped Gateway when optional shell-completion inspection failed after the update stopped the managed service but before restart.

It also preserves the established JSON-mode contract: optional completion refresh failures do not emit diagnostics into otherwise successful machine-readable update flows.

## Why This Change Was Made

The update now settles the existing Gateway restart and health-verification result before running optional completion refresh work. Completion cache failures, completion status-read errors, cache-generation failures, prompt failures, and profile installation failures remain advisory without changing service ownership, service-definition refresh, or restart health policy.

Human-facing updates retain useful completion recovery warnings. JSON-mode updates keep completion refresh failures quiet, matching the prior compatibility contract, while still restarting and verifying the Gateway.

## User Impact

An optional completion refresh can no longer strand a Gateway that the update stopped. Interactive users still receive recovery guidance when completion refresh fails, while JSON consumers continue to receive clean successful output without optional-completion diagnostics.

Completion refresh behaves the same when successful, and non-TTY invocations continue to skip interactive completion work.

## Evidence

### Reproduction

At base `cf95246bc2127dc04d33be2d84e25fad8586e9b0`, the focused test injected an `EACCES` rejection from completion status inspection after supplying a stopped managed-service state. The pre-fix run failed because the error escaped and the restart mock was never called.

At reviewed head `286aef10ca07676f441d696c06f88a0d7b570dc9`, the JSON regression used a real completion-cache command returning nonzero. The test failed because `defaultRuntime.error` received:

`Completion cache update failed. Update will continue; retry with: openclaw completion --write-state`

The Gateway restart still ran, isolating the compatibility defect to JSON diagnostics.

### Test Changes

Added six focused cases:

- Restart continues after completion status inspection throws.
- Restart continues when the completion cache command returns a failed result.
- Restart continues when shell-completion cache generation returns `false`.
- A successful JSON-mode update keeps a failed completion refresh silent and still restarts.
- Non-TTY mode skips interactive completion inspection.
- An unhealthy restart remains blocking and completion refresh does not run afterward.

Modified existing test cases: none from the base. During review correction, the newly added generic JSON skip case was replaced with the failing-cache JSON compatibility regression.

Deleted existing test cases: none.

### Verification

- Exact corrected head: `5b859b7b92c33bd4d18e36604ed3ab192bee85a6`.
- `pnpm test src/cli/update-cli/update-command-post-update.test.ts`: 19 passed on Blacksmith Testbox.
- `pnpm check:changed`: passed on the same exact head.
- `git diff --check cf95246bc2127dc04d33be2d84e25fad8586e9b0..HEAD`: passed.
- Blacksmith Testbox: `tbx_01m13hcrrv7nvwh4q0sf07swgv`, completed and stopped.
- Testbox Actions run: https://github.com/openclaw/openclaw/actions/runs/33148552644
- Remote branch verified at the exact corrected head.

Production delta: 66 additions, 50 deletions, net +16 lines.

Test delta: 150 additions, 9 deletions, net +141 lines.
