### PR TITLE
fix: gateway shutdown cannot cancel deferred context-engine maintenance

### DIFF
--- a/docs/concepts/context-engine.md
+++ b/docs/concepts/context-engine.md
@@ -215,11 +215,13 @@ Required members:
 
 Set `info.acceptedHostParams` to restrict the host-added lifecycle fields the
 engine receives. Current keys are `sessionKey`, `prompt`, `runtimeSettings`,
-`sessionTarget`, and `runtimeContext`. OpenClaw intersects the declaration with
-the fields available for each lifecycle method, so undeclared or unknown keys
-are never injected. Engines without this declaration receive every current
-host field; declare an explicit list, including `[]`, when the engine validates
-a narrower input shape.
+`sessionTarget`, `runtimeContext`, and `abortSignal`. OpenClaw intersects the
+declaration with the fields available for each lifecycle method, so undeclared
+or unknown keys are never injected. `abortSignal` governs optional cooperative
+cancellation for `maintain()`; the existing compact-operation abort signal is
+always preserved. Engines without this declaration receive every current host
+field; declare an explicit list, including `[]`, when the engine validates a
+narrower input shape.
 
 For durable admitted turns, declare both transcript semantics:
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -710,10 +710,10 @@ For an end-to-end authoring guide, see
 
 ### Exclusive slots
 
-| Method                                     | What it registers                                                                                                                                                          |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `api.registerContextEngine(id, factory)`   | Context engine (one active at a time). Use `info.acceptedHostParams` to restrict accepted host-added lifecycle fields; undeclared engines receive all current host fields. |
-| `api.registerMemoryCapability(capability)` | Unified memory capability                                                                                                                                                  |
+| Method                                     | What it registers                                                                                                                                                                                                        |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `api.registerContextEngine(id, factory)`   | Context engine (one active at a time). Use `info.acceptedHostParams` to restrict accepted host-added lifecycle fields, including optional `maintain()` cancellation; undeclared engines receive all current host fields. |
+| `api.registerMemoryCapability(capability)` | Unified memory capability                                                                                                                                                                                                |
 
 To participate in durable admitted turns, context engines must declare
 `currentTurnFence: "before-current-turn-entry-v1"` and

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -749,174 +749,197 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
-  it("settles abort-waiting deferred maintenance during shutdown without rerun", async () => {
-    await withStateDirEnv("openclaw-turn-maintenance-abort-waiting-", async () => {
-      resetCommandQueueStateForTest();
-      resetTaskRegistryForTests({ persist: false });
-      resetTaskFlowRegistryForTests({ persist: false });
+  it.each([
+    {
+      name: "SIGTERM",
+      trigger: () => process.emit("SIGTERM", "SIGTERM"),
+    },
+    {
+      name: "accepted restart drain",
+      trigger: () => markGatewayDraining(),
+    },
+  ])(
+    "settles abort-waiting deferred maintenance during $name without rerun",
+    async ({ trigger }) => {
+      await withStateDirEnv("openclaw-turn-maintenance-abort-waiting-", async () => {
+        resetCommandQueueStateForTest();
+        resetTaskRegistryForTests({ persist: false });
+        resetTaskFlowRegistryForTests({ persist: false });
 
-      const sessionKey = "agent:main:session-abort-waiting";
-      const lane = `context-engine-turn-maintenance:${sessionKey}`;
-      const keepProcessAlive = () => {};
-      process.on("SIGTERM", keepProcessAlive);
+        const sessionKey = "agent:main:session-abort-waiting";
+        const lane = `context-engine-turn-maintenance:${sessionKey}`;
+        const keepProcessAlive = () => {};
+        process.on("SIGTERM", keepProcessAlive);
 
-      let releaseFirstMaintenance: (() => void) | undefined;
-      let observedSignal: AbortSignal | undefined;
-      const firstMaintain = vi.fn(async (rawParams?: unknown) => {
-        const signal = (rawParams as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
-        observedSignal = signal;
-        await new Promise<void>((resolve, reject) => {
-          releaseFirstMaintenance = resolve;
-          if (!signal) {
-            return;
-          }
-          const onAbort = () => {
-            signal.removeEventListener("abort", onAbort);
-            reject(
-              signal.reason instanceof Error
-                ? signal.reason
-                : new Error("maintenance aborted", { cause: signal.reason }),
-            );
+        let releaseFirstMaintenance: (() => void) | undefined;
+        let observedSignal: AbortSignal | undefined;
+        const firstMaintain = vi.fn(async (rawParams?: unknown) => {
+          const signal = (rawParams as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+          observedSignal = signal;
+          await new Promise<void>((resolve, reject) => {
+            releaseFirstMaintenance = resolve;
+            if (!signal) {
+              return;
+            }
+            const onAbort = () => {
+              signal.removeEventListener("abort", onAbort);
+              reject(
+                signal.reason instanceof Error
+                  ? signal.reason
+                  : new Error("maintenance aborted", { cause: signal.reason }),
+              );
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+            if (signal.aborted) {
+              onAbort();
+            }
+          });
+          return {
+            changed: false,
+            bytesFreed: 0,
+            rewrittenEntries: 0,
           };
-          signal.addEventListener("abort", onAbort, { once: true });
-          if (signal.aborted) {
-            onAbort();
-          }
         });
-        return {
+        const secondMaintain = vi.fn(async () => ({
           changed: false,
           bytesFreed: 0,
           rewrittenEntries: 0,
+        }));
+        const createOwnedEngine = (
+          id: string,
+          maintain: typeof firstMaintain | typeof secondMaintain,
+        ) =>
+          ({
+            info: {
+              id,
+              name: "Test Engine",
+              turnMaintenanceMode: "background" as const,
+            },
+            ingest: async () => ({ ingested: true }),
+            assemble: async ({ messages }: { messages: unknown[] }) => ({
+              messages,
+              estimatedTokens: 0,
+            }),
+            compact: async () => ({ ok: true, compacted: false }),
+            maintain,
+            dispose: vi.fn(async () => {}),
+          }) as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+        const firstEngine = createOwnedEngine("first", firstMaintain);
+        const secondEngine = createOwnedEngine("second", secondMaintain);
+        registerLegacyContextEngine();
+        const sharedEngineId = "shutdown-shared-engine";
+        registerContextEngineForOwner(sharedEngineId, () => firstEngine, `test:${sharedEngineId}`, {
+          allowSameOwnerRefresh: true,
+        });
+        const contextEngineConfig = {
+          plugins: { slots: { contextEngine: sharedEngineId } },
         };
-      });
-      const secondMaintain = vi.fn(async () => ({
-        changed: false,
-        bytesFreed: 0,
-        rewrittenEntries: 0,
-      }));
-      const createOwnedEngine = (
-        id: string,
-        maintain: typeof firstMaintain | typeof secondMaintain,
-      ) =>
-        ({
-          info: {
-            id,
-            name: "Test Engine",
-            turnMaintenanceMode: "background" as const,
-          },
-          ingest: async () => ({ ingested: true }),
-          assemble: async ({ messages }: { messages: unknown[] }) => ({
-            messages,
-            estimatedTokens: 0,
-          }),
-          compact: async () => ({ ok: true, compacted: false }),
-          maintain,
-          dispose: vi.fn(async () => {}),
-        }) as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
-      const firstEngine = createOwnedEngine("first", firstMaintain);
-      const secondEngine = createOwnedEngine("second", secondMaintain);
-      registerLegacyContextEngine();
-      const sharedEngineId = "shutdown-shared-engine";
-      registerContextEngineForOwner(sharedEngineId, () => firstEngine, `test:${sharedEngineId}`, {
-        allowSameOwnerRefresh: true,
-      });
-      const contextEngineConfig = {
-        plugins: { slots: { contextEngine: sharedEngineId } },
-      };
-      const firstResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
-      const firstRerunResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
-      const finalRerunResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
-      let deferred: Promise<void> | undefined;
+        const firstResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
+        const firstRerunResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
+        const finalRerunResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
+        let deferred: Promise<void> | undefined;
 
-      try {
-        expect(firstResolution.configured.engine).not.toBe(firstRerunResolution.configured.engine);
-        expect(firstRerunResolution.configured.engine).not.toBe(
-          finalRerunResolution.configured.engine,
-        );
-        await runContextEngineMaintenance({
-          contextEngine: firstResolution.configured.engine,
-          sessionId: "session-abort-waiting",
-          sessionKey,
-          sessionFile: "/tmp/session-abort-waiting.jsonl",
-          reason: "turn",
-          onDeferredMaintenance: (promise) => {
-            deferred = promise;
-          },
-        });
-        await vi.waitFor(() => expect(firstMaintain).toHaveBeenCalledTimes(1));
+        try {
+          expect(firstResolution.configured.engine).not.toBe(
+            firstRerunResolution.configured.engine,
+          );
+          expect(firstRerunResolution.configured.engine).not.toBe(
+            finalRerunResolution.configured.engine,
+          );
+          await runContextEngineMaintenance({
+            contextEngine: firstResolution.configured.engine,
+            sessionId: "session-abort-waiting",
+            sessionKey,
+            sessionFile: "/tmp/session-abort-waiting.jsonl",
+            reason: "turn",
+            onDeferredMaintenance: (promise) => {
+              deferred = promise;
+            },
+          });
+          await vi.waitFor(() => expect(firstMaintain).toHaveBeenCalledTimes(1));
 
-        await runContextEngineMaintenance({
-          contextEngine: firstRerunResolution.configured.engine,
-          sessionId: "session-abort-waiting",
-          sessionKey,
-          sessionFile: "/tmp/session-abort-waiting.jsonl",
-          reason: "turn",
-          disposeDeferredContextEngineAfterMaintenance: true,
-        });
-        await runContextEngineMaintenance({
-          contextEngine: secondEngine,
-          sessionId: "session-abort-waiting",
-          sessionKey,
-          sessionFile: "/tmp/session-abort-waiting.jsonl",
-          reason: "turn",
-          disposeDeferredContextEngineAfterMaintenance: true,
-        });
-        expect(firstEngine["dispose"]).not.toHaveBeenCalled();
-        await runContextEngineMaintenance({
-          contextEngine: finalRerunResolution.configured.engine,
-          sessionId: "session-abort-waiting",
-          sessionKey,
-          sessionFile: "/tmp/session-abort-waiting.jsonl",
-          reason: "turn",
-          disposeDeferredContextEngineAfterMaintenance: true,
-        });
-        await vi.waitFor(() => expect(secondEngine["dispose"]).toHaveBeenCalledTimes(1));
+          await runContextEngineMaintenance({
+            contextEngine: firstRerunResolution.configured.engine,
+            sessionId: "session-abort-waiting",
+            sessionKey,
+            sessionFile: "/tmp/session-abort-waiting.jsonl",
+            reason: "turn",
+            disposeDeferredContextEngineAfterMaintenance: true,
+          });
+          await runContextEngineMaintenance({
+            contextEngine: secondEngine,
+            sessionId: "session-abort-waiting",
+            sessionKey,
+            sessionFile: "/tmp/session-abort-waiting.jsonl",
+            reason: "turn",
+            disposeDeferredContextEngineAfterMaintenance: true,
+          });
+          expect(firstEngine["dispose"]).not.toHaveBeenCalled();
+          await runContextEngineMaintenance({
+            contextEngine: finalRerunResolution.configured.engine,
+            sessionId: "session-abort-waiting",
+            sessionKey,
+            sessionFile: "/tmp/session-abort-waiting.jsonl",
+            reason: "turn",
+            disposeDeferredContextEngineAfterMaintenance: true,
+          });
+          await vi.waitFor(() => expect(secondEngine["dispose"]).toHaveBeenCalledTimes(1));
 
-        process.emit("SIGTERM", "SIGTERM");
-        let timeout: ReturnType<typeof setTimeout> | undefined;
-        const settled = await Promise.race([
-          waitForDeferredTurnMaintenanceForSession(sessionKey).then(() => true),
-          new Promise<false>((resolve) => {
-            timeout = setTimeout(() => resolve(false), 500);
-          }),
-        ]);
-        if (timeout) {
-          clearTimeout(timeout);
+          trigger();
+          let timeout: ReturnType<typeof setTimeout> | undefined;
+          const settled = await Promise.race([
+            waitForDeferredTurnMaintenanceForSession(sessionKey).then(() => true),
+            new Promise<false>((resolve) => {
+              timeout = setTimeout(() => resolve(false), 500);
+            }),
+          ]);
+          if (timeout) {
+            clearTimeout(timeout);
+          }
+
+          expect(settled).toBe(true);
+          expect(observedSignal?.aborted).toBe(true);
+          expect(firstMaintain).toHaveBeenCalledTimes(1);
+          expect(secondMaintain).not.toHaveBeenCalled();
+          expect(firstEngine["dispose"]).toHaveBeenCalledTimes(1);
+          expect(secondEngine["dispose"]).toHaveBeenCalledTimes(1);
+          expect(
+            listTasksForOwnerKey(sessionKey).find(
+              (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+            ),
+          ).toMatchObject({
+            status: "cancelled",
+            terminalSummary: "Deferred maintenance cancelled during shutdown.",
+          });
+          expect(getCommandLaneSnapshot(lane)).toMatchObject({
+            activeCount: 0,
+            queuedCount: 0,
+          });
+        } finally {
+          releaseFirstMaintenance?.();
+          await Promise.allSettled(deferred ? [deferred] : []);
+          await Promise.allSettled([
+            firstResolution.fallback.engine.dispose?.(),
+            firstRerunResolution.fallback.engine.dispose?.(),
+            finalRerunResolution.fallback.engine.dispose?.(),
+          ]);
+          process.off("SIGTERM", keepProcessAlive);
+          resetDeferredTurnMaintenanceStateForTest();
         }
+      });
+    },
+  );
 
-        expect(settled).toBe(true);
-        expect(observedSignal?.aborted).toBe(true);
-        expect(firstMaintain).toHaveBeenCalledTimes(1);
-        expect(secondMaintain).not.toHaveBeenCalled();
-        expect(firstEngine["dispose"]).toHaveBeenCalledTimes(1);
-        expect(secondEngine["dispose"]).toHaveBeenCalledTimes(1);
-        expect(
-          listTasksForOwnerKey(sessionKey).find(
-            (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
-          ),
-        ).toMatchObject({
-          status: "cancelled",
-          terminalSummary: "Deferred maintenance cancelled during shutdown.",
-        });
-        expect(getCommandLaneSnapshot(lane)).toMatchObject({
-          activeCount: 0,
-          queuedCount: 0,
-        });
-      } finally {
-        releaseFirstMaintenance?.();
-        await Promise.allSettled(deferred ? [deferred] : []);
-        await Promise.allSettled([
-          firstResolution.fallback.engine.dispose?.(),
-          firstRerunResolution.fallback.engine.dispose?.(),
-          finalRerunResolution.fallback.engine.dispose?.(),
-        ]);
-        process.off("SIGTERM", keepProcessAlive);
-        resetDeferredTurnMaintenanceStateForTest();
-      }
-    });
-  });
-
-  it("does not start queued deferred maintenance after shutdown", async () => {
+  it.each([
+    {
+      name: "SIGTERM",
+      trigger: () => process.emit("SIGTERM", "SIGTERM"),
+    },
+    {
+      name: "accepted restart drain",
+      trigger: () => markGatewayDraining(),
+    },
+  ])("does not start queued deferred maintenance after $name", async ({ trigger }) => {
     await withStateDirEnv("openclaw-turn-maintenance-queued-abort-", async () => {
       resetCommandQueueStateForTest();
       resetTaskRegistryForTests({ persist: false });
@@ -969,7 +992,7 @@ describe("runContextEngineMaintenance", () => {
           },
         });
 
-        process.emit("SIGTERM", "SIGTERM");
+        trigger();
         releaseLane?.();
         await laneBlocker;
         await deferred;
@@ -1722,7 +1745,7 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
-  it("surfaces unrelated abort-shaped maintenance failures during shutdown", async () => {
+  it("surfaces unrelated maintenance failures during shutdown", async () => {
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();
       const keepProcessAlive = () => {};
@@ -1754,9 +1777,7 @@ describe("runContextEngineMaintenance", () => {
             await new Promise<void>((_resolve, reject) => {
               const onAbort = () => {
                 signal.removeEventListener("abort", onAbort);
-                const error = new Error("maintenance cancellation failed");
-                error.name = "AbortError";
-                reject(error);
+                reject(new Error("maintenance cleanup failed"));
               };
               signal.addEventListener("abort", onAbort, { once: true });
               if (signal.aborted) {
@@ -1791,7 +1812,7 @@ describe("runContextEngineMaintenance", () => {
         }
         expect(task).toMatchObject({
           status: "failed",
-          error: "maintenance cancellation failed",
+          error: "maintenance cleanup failed",
         });
         expect(getTaskFlowById(parentFlowId)?.status).toBe("failed");
       } finally {

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -824,23 +824,35 @@ describe("runContextEngineMaintenance", () => {
         plugins: { slots: { contextEngine: sharedEngineId } },
       };
       const firstResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
-      const repeatedResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
+      const firstRerunResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
+      const finalRerunResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
       let deferred: Promise<void> | undefined;
 
       try {
+        expect(firstResolution.configured.engine).not.toBe(firstRerunResolution.configured.engine);
+        expect(firstRerunResolution.configured.engine).not.toBe(
+          finalRerunResolution.configured.engine,
+        );
         await runContextEngineMaintenance({
           contextEngine: firstResolution.configured.engine,
           sessionId: "session-abort-waiting",
           sessionKey,
           sessionFile: "/tmp/session-abort-waiting.jsonl",
           reason: "turn",
-          disposeDeferredContextEngineAfterMaintenance: true,
           onDeferredMaintenance: (promise) => {
             deferred = promise;
           },
         });
         await vi.waitFor(() => expect(firstMaintain).toHaveBeenCalledTimes(1));
 
+        await runContextEngineMaintenance({
+          contextEngine: firstRerunResolution.configured.engine,
+          sessionId: "session-abort-waiting",
+          sessionKey,
+          sessionFile: "/tmp/session-abort-waiting.jsonl",
+          reason: "turn",
+          disposeDeferredContextEngineAfterMaintenance: true,
+        });
         await runContextEngineMaintenance({
           contextEngine: secondEngine,
           sessionId: "session-abort-waiting",
@@ -849,8 +861,9 @@ describe("runContextEngineMaintenance", () => {
           reason: "turn",
           disposeDeferredContextEngineAfterMaintenance: true,
         });
+        expect(firstEngine["dispose"]).not.toHaveBeenCalled();
         await runContextEngineMaintenance({
-          contextEngine: repeatedResolution.configured.engine,
+          contextEngine: finalRerunResolution.configured.engine,
           sessionId: "session-abort-waiting",
           sessionKey,
           sessionFile: "/tmp/session-abort-waiting.jsonl",
@@ -894,7 +907,8 @@ describe("runContextEngineMaintenance", () => {
         await Promise.allSettled(deferred ? [deferred] : []);
         await Promise.allSettled([
           firstResolution.fallback.engine.dispose?.(),
-          repeatedResolution.fallback.engine.dispose?.(),
+          firstRerunResolution.fallback.engine.dispose?.(),
+          finalRerunResolution.fallback.engine.dispose?.(),
         ]);
         process.off("SIGTERM", keepProcessAlive);
         resetDeferredTurnMaintenanceStateForTest();

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -3,6 +3,11 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerLegacyContextEngine } from "../../context-engine/legacy.registration.js";
+import {
+  registerContextEngineForOwner,
+  resolveLogicalTurnContextEngines,
+} from "../../context-engine/registry.js";
 import type { ContextEngineRuntimeContext } from "../../context-engine/types.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
 import {
@@ -810,11 +815,21 @@ describe("runContextEngineMaintenance", () => {
         }) as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
       const firstEngine = createOwnedEngine("first", firstMaintain);
       const secondEngine = createOwnedEngine("second", secondMaintain);
+      registerLegacyContextEngine();
+      const sharedEngineId = "shutdown-shared-engine";
+      registerContextEngineForOwner(sharedEngineId, () => firstEngine, `test:${sharedEngineId}`, {
+        allowSameOwnerRefresh: true,
+      });
+      const contextEngineConfig = {
+        plugins: { slots: { contextEngine: sharedEngineId } },
+      };
+      const firstResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
+      const repeatedResolution = await resolveLogicalTurnContextEngines(contextEngineConfig);
       let deferred: Promise<void> | undefined;
 
       try {
         await runContextEngineMaintenance({
-          contextEngine: firstEngine,
+          contextEngine: firstResolution.configured.engine,
           sessionId: "session-abort-waiting",
           sessionKey,
           sessionFile: "/tmp/session-abort-waiting.jsonl",
@@ -835,7 +850,7 @@ describe("runContextEngineMaintenance", () => {
           disposeDeferredContextEngineAfterMaintenance: true,
         });
         await runContextEngineMaintenance({
-          contextEngine: firstEngine,
+          contextEngine: repeatedResolution.configured.engine,
           sessionId: "session-abort-waiting",
           sessionKey,
           sessionFile: "/tmp/session-abort-waiting.jsonl",
@@ -877,6 +892,10 @@ describe("runContextEngineMaintenance", () => {
       } finally {
         releaseFirstMaintenance?.();
         await Promise.allSettled(deferred ? [deferred] : []);
+        await Promise.allSettled([
+          firstResolution.fallback.engine.dispose?.(),
+          repeatedResolution.fallback.engine.dispose?.(),
+        ]);
         process.off("SIGTERM", keepProcessAlive);
         resetDeferredTurnMaintenanceStateForTest();
       }

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.test.ts
@@ -5,7 +5,11 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ContextEngineRuntimeContext } from "../../context-engine/types.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../../infra/system-events.js";
-import { enqueueCommandInLane, markGatewayDraining } from "../../process/command-queue.js";
+import {
+  enqueueCommandInLane,
+  getCommandLaneSnapshot,
+  markGatewayDraining,
+} from "../../process/command-queue.js";
 import * as commandQueueModule from "../../process/command-queue.js";
 import { resetCommandQueueStateForTest } from "../../process/command-queue.test-support.js";
 import { onSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
@@ -227,6 +231,7 @@ describe("runContextEngineMaintenance", () => {
       sessionTarget,
       sessionFile: "/tmp/session.jsonl",
     });
+    expect(maintainParams.abortSignal).toBeUndefined();
     const maintainRuntimeContext = requireRecord(
       maintainParams.runtimeContext,
       "maintain runtime context",
@@ -735,6 +740,227 @@ describe("runContextEngineMaintenance", () => {
         expect(tasks.every((task) => task.status === "succeeded")).toBe(true);
       } finally {
         vi.useRealTimers();
+      }
+    });
+  });
+
+  it("settles abort-waiting deferred maintenance during shutdown without rerun", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-abort-waiting-", async () => {
+      resetCommandQueueStateForTest();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+
+      const sessionKey = "agent:main:session-abort-waiting";
+      const lane = `context-engine-turn-maintenance:${sessionKey}`;
+      const keepProcessAlive = () => {};
+      process.on("SIGTERM", keepProcessAlive);
+
+      let releaseFirstMaintenance: (() => void) | undefined;
+      let observedSignal: AbortSignal | undefined;
+      const firstMaintain = vi.fn(async (rawParams?: unknown) => {
+        const signal = (rawParams as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+        observedSignal = signal;
+        await new Promise<void>((resolve, reject) => {
+          releaseFirstMaintenance = resolve;
+          if (!signal) {
+            return;
+          }
+          const onAbort = () => {
+            signal.removeEventListener("abort", onAbort);
+            reject(
+              signal.reason instanceof Error
+                ? signal.reason
+                : new Error("maintenance aborted", { cause: signal.reason }),
+            );
+          };
+          signal.addEventListener("abort", onAbort, { once: true });
+          if (signal.aborted) {
+            onAbort();
+          }
+        });
+        return {
+          changed: false,
+          bytesFreed: 0,
+          rewrittenEntries: 0,
+        };
+      });
+      const secondMaintain = vi.fn(async () => ({
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+      }));
+      const createOwnedEngine = (
+        id: string,
+        maintain: typeof firstMaintain | typeof secondMaintain,
+      ) =>
+        ({
+          info: {
+            id,
+            name: "Test Engine",
+            turnMaintenanceMode: "background" as const,
+          },
+          ingest: async () => ({ ingested: true }),
+          assemble: async ({ messages }: { messages: unknown[] }) => ({
+            messages,
+            estimatedTokens: 0,
+          }),
+          compact: async () => ({ ok: true, compacted: false }),
+          maintain,
+          dispose: vi.fn(async () => {}),
+        }) as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+      const firstEngine = createOwnedEngine("first", firstMaintain);
+      const secondEngine = createOwnedEngine("second", secondMaintain);
+      let deferred: Promise<void> | undefined;
+
+      try {
+        await runContextEngineMaintenance({
+          contextEngine: firstEngine,
+          sessionId: "session-abort-waiting",
+          sessionKey,
+          sessionFile: "/tmp/session-abort-waiting.jsonl",
+          reason: "turn",
+          disposeDeferredContextEngineAfterMaintenance: true,
+          onDeferredMaintenance: (promise) => {
+            deferred = promise;
+          },
+        });
+        await vi.waitFor(() => expect(firstMaintain).toHaveBeenCalledTimes(1));
+
+        await runContextEngineMaintenance({
+          contextEngine: secondEngine,
+          sessionId: "session-abort-waiting",
+          sessionKey,
+          sessionFile: "/tmp/session-abort-waiting.jsonl",
+          reason: "turn",
+          disposeDeferredContextEngineAfterMaintenance: true,
+        });
+        await runContextEngineMaintenance({
+          contextEngine: firstEngine,
+          sessionId: "session-abort-waiting",
+          sessionKey,
+          sessionFile: "/tmp/session-abort-waiting.jsonl",
+          reason: "turn",
+          disposeDeferredContextEngineAfterMaintenance: true,
+        });
+        await vi.waitFor(() => expect(secondEngine["dispose"]).toHaveBeenCalledTimes(1));
+
+        process.emit("SIGTERM", "SIGTERM");
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        const settled = await Promise.race([
+          waitForDeferredTurnMaintenanceForSession(sessionKey).then(() => true),
+          new Promise<false>((resolve) => {
+            timeout = setTimeout(() => resolve(false), 500);
+          }),
+        ]);
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+
+        expect(settled).toBe(true);
+        expect(observedSignal?.aborted).toBe(true);
+        expect(firstMaintain).toHaveBeenCalledTimes(1);
+        expect(secondMaintain).not.toHaveBeenCalled();
+        expect(firstEngine["dispose"]).toHaveBeenCalledTimes(1);
+        expect(secondEngine["dispose"]).toHaveBeenCalledTimes(1);
+        expect(
+          listTasksForOwnerKey(sessionKey).find(
+            (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+          ),
+        ).toMatchObject({
+          status: "cancelled",
+          terminalSummary: "Deferred maintenance cancelled during shutdown.",
+        });
+        expect(getCommandLaneSnapshot(lane)).toMatchObject({
+          activeCount: 0,
+          queuedCount: 0,
+        });
+      } finally {
+        releaseFirstMaintenance?.();
+        await Promise.allSettled(deferred ? [deferred] : []);
+        process.off("SIGTERM", keepProcessAlive);
+        resetDeferredTurnMaintenanceStateForTest();
+      }
+    });
+  });
+
+  it("does not start queued deferred maintenance after shutdown", async () => {
+    await withStateDirEnv("openclaw-turn-maintenance-queued-abort-", async () => {
+      resetCommandQueueStateForTest();
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+
+      const sessionKey = "agent:main:session-queued-abort";
+      const lane = `context-engine-turn-maintenance:${sessionKey}`;
+      let releaseLane: (() => void) | undefined;
+      const laneBlocker = enqueueCommandInLane(lane, async () => {
+        await new Promise<void>((resolve) => {
+          releaseLane = resolve;
+        });
+      });
+      await vi.waitFor(() => expect(releaseLane).toBeTypeOf("function"));
+
+      const keepProcessAlive = () => {};
+      process.on("SIGTERM", keepProcessAlive);
+      const maintain = vi.fn(async () => ({
+        changed: false,
+        bytesFreed: 0,
+        rewrittenEntries: 0,
+      }));
+      const engine = {
+        info: {
+          id: "queued",
+          name: "Queued Engine",
+          turnMaintenanceMode: "background" as const,
+        },
+        ingest: async () => ({ ingested: true }),
+        assemble: async ({ messages }: { messages: unknown[] }) => ({
+          messages,
+          estimatedTokens: 0,
+        }),
+        compact: async () => ({ ok: true, compacted: false }),
+        maintain,
+        dispose: vi.fn(async () => {}),
+      } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
+      let deferred: Promise<void> | undefined;
+
+      try {
+        await runContextEngineMaintenance({
+          contextEngine: engine,
+          sessionId: "session-queued-abort",
+          sessionKey,
+          sessionFile: "/tmp/session-queued-abort.jsonl",
+          reason: "turn",
+          disposeDeferredContextEngineAfterMaintenance: true,
+          onDeferredMaintenance: (promise) => {
+            deferred = promise;
+          },
+        });
+
+        process.emit("SIGTERM", "SIGTERM");
+        releaseLane?.();
+        await laneBlocker;
+        await deferred;
+        await waitForDeferredTurnMaintenanceForSession(sessionKey);
+
+        expect(maintain).not.toHaveBeenCalled();
+        expect(engine["dispose"]).toHaveBeenCalledTimes(1);
+        expect(
+          listTasksForOwnerKey(sessionKey).find(
+            (task) => task.taskKind === TURN_MAINTENANCE_TASK_KIND,
+          ),
+        ).toMatchObject({
+          status: "cancelled",
+          terminalSummary: "Deferred maintenance cancelled during shutdown.",
+        });
+        expect(getCommandLaneSnapshot(lane)).toMatchObject({
+          activeCount: 0,
+          queuedCount: 0,
+        });
+      } finally {
+        releaseLane?.();
+        await Promise.allSettled([laneBlocker, ...(deferred ? [deferred] : [])]);
+        process.off("SIGTERM", keepProcessAlive);
+        resetDeferredTurnMaintenanceStateForTest();
       }
     });
   });
@@ -1463,9 +1689,11 @@ describe("runContextEngineMaintenance", () => {
     });
   });
 
-  it("surfaces deferred maintenance failures even when they fail quickly", async () => {
+  it("surfaces unrelated abort-shaped maintenance failures during shutdown", async () => {
     await withStateDirEnv("openclaw-turn-maintenance-", async () => {
       vi.useFakeTimers();
+      const keepProcessAlive = () => {};
+      process.on("SIGTERM", keepProcessAlive);
       try {
         resetCommandQueueStateForTest();
         resetTaskRegistryForTests({ persist: false });
@@ -1485,8 +1713,24 @@ describe("runContextEngineMaintenance", () => {
             estimatedTokens: 0,
           }),
           compact: async () => ({ ok: true, compacted: false }),
-          maintain: vi.fn(async () => {
-            throw new Error("maintenance exploded");
+          maintain: vi.fn(async (rawParams?: unknown) => {
+            const signal = (rawParams as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
+            if (!signal) {
+              throw new Error("expected deferred maintenance abort signal");
+            }
+            await new Promise<void>((_resolve, reject) => {
+              const onAbort = () => {
+                signal.removeEventListener("abort", onAbort);
+                const error = new Error("maintenance cancellation failed");
+                error.name = "AbortError";
+                reject(error);
+              };
+              signal.addEventListener("abort", onAbort, { once: true });
+              if (signal.aborted) {
+                onAbort();
+              }
+            });
+            return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
           }),
         } as NonNullable<Parameters<typeof runContextEngineMaintenance>[0]["contextEngine"]>;
 
@@ -1497,6 +1741,8 @@ describe("runContextEngineMaintenance", () => {
           sessionFile: "/tmp/session-fail.jsonl",
           reason: "turn",
         });
+        await waitForAssertion(() => expect(backgroundEngine["maintain"]).toHaveBeenCalledTimes(1));
+        process.emit("SIGTERM", "SIGTERM");
         await waitForAssertion(() =>
           expectSystemEventContaining(
             sessionKey,
@@ -1510,8 +1756,14 @@ describe("runContextEngineMaintenance", () => {
         if (!parentFlowId) {
           throw new Error("Expected failed maintenance to have a task flow");
         }
+        expect(task).toMatchObject({
+          status: "failed",
+          error: "maintenance cancellation failed",
+        });
         expect(getTaskFlowById(parentFlowId)?.status).toBe("failed");
       } finally {
+        process.off("SIGTERM", keepProcessAlive);
+        resetDeferredTurnMaintenanceStateForTest();
         vi.useRealTimers();
       }
     });

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -7,6 +7,7 @@ import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import { publishTranscriptUpdate } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
+  hasSameContextEngineInstance,
   isContextEngineAbortRejection,
   resolveContextEngineOwnerPluginId,
 } from "../../context-engine/registry.js";
@@ -547,7 +548,7 @@ function scheduleDeferredTurnMaintenance(
       await scheduleDeferredTurnMaintenance(rerunParams);
     } else if (
       discardedRerunParams?.disposeContextEngineAfterMaintenance &&
-      (discardedRerunParams.contextEngine !== params.contextEngine ||
+      (!hasSameContextEngineInstance(discardedRerunParams.contextEngine, params.contextEngine) ||
         !params.disposeContextEngineAfterMaintenance)
     ) {
       await disposeDeferredMaintenanceContextEngine(discardedRerunParams.contextEngine);

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -84,6 +84,8 @@ type DeferredTurnMaintenanceScheduleParams = ContextEngineMaintenanceParams & {
 type DeferredTurnMaintenanceRunState = {
   promise: Promise<void>;
   rerunRequested: boolean;
+  activeContextEngine: ContextEngine;
+  disposeActiveContextEngineAfterMaintenance: boolean;
   latestParams: DeferredTurnMaintenanceScheduleParams;
 };
 
@@ -427,9 +429,6 @@ async function runDeferredTurnMaintenanceWorker(
     if (longRunningTimer) {
       clearTimeout(longRunningTimer);
     }
-    if (params.disposeContextEngineAfterMaintenance) {
-      await disposeDeferredMaintenanceContextEngine(params.contextEngine);
-    }
   }
 }
 
@@ -448,11 +447,30 @@ function scheduleDeferredTurnMaintenance(
   const activeRun = activeDeferredTurnMaintenanceRuns.get(sessionKey);
   if (activeRun) {
     const supersededParams = activeRun.rerunRequested ? activeRun.latestParams : undefined;
-    activeRun.rerunRequested = true;
-    activeRun.latestParams = { ...params, sessionKey };
+    const latestParams = { ...params, sessionKey };
+    // Coalesced resolutions may wrap one shared factory instance. Carry disposal
+    // ownership forward without closing an engine still used by active or newer work.
     if (
       supersededParams?.disposeContextEngineAfterMaintenance &&
-      supersededParams.contextEngine !== params.contextEngine
+      hasSameContextEngineInstance(supersededParams.contextEngine, latestParams.contextEngine)
+    ) {
+      latestParams.disposeContextEngineAfterMaintenance = true;
+    }
+    if (
+      latestParams.disposeContextEngineAfterMaintenance &&
+      hasSameContextEngineInstance(latestParams.contextEngine, activeRun.activeContextEngine)
+    ) {
+      activeRun.disposeActiveContextEngineAfterMaintenance = true;
+    }
+    activeRun.rerunRequested = true;
+    activeRun.latestParams = latestParams;
+    if (
+      supersededParams?.disposeContextEngineAfterMaintenance &&
+      !hasSameContextEngineInstance(
+        supersededParams.contextEngine,
+        activeRun.activeContextEngine,
+      ) &&
+      !hasSameContextEngineInstance(supersededParams.contextEngine, latestParams.contextEngine)
     ) {
       void disposeDeferredMaintenanceContextEngine(supersededParams.contextEngine);
     }
@@ -545,11 +563,31 @@ function scheduleDeferredTurnMaintenance(
       current.rerunRequested && shutdownTriggered ? current.latestParams : undefined;
     activeDeferredTurnMaintenanceRuns.delete(sessionKey);
     if (rerunParams) {
-      await scheduleDeferredTurnMaintenance(rerunParams);
-    } else if (
+      const rerunSharesActiveEngine = hasSameContextEngineInstance(
+        rerunParams.contextEngine,
+        current.activeContextEngine,
+      );
+      if (!rerunSharesActiveEngine && current.disposeActiveContextEngineAfterMaintenance) {
+        await disposeDeferredMaintenanceContextEngine(current.activeContextEngine);
+      }
+      const nextParams =
+        rerunSharesActiveEngine && current.disposeActiveContextEngineAfterMaintenance
+          ? { ...rerunParams, disposeContextEngineAfterMaintenance: true }
+          : rerunParams;
+      const scheduledRerun = scheduleDeferredTurnMaintenance(nextParams);
+      if (!scheduledRerun && nextParams.disposeContextEngineAfterMaintenance) {
+        await disposeDeferredMaintenanceContextEngine(nextParams.contextEngine);
+      } else {
+        await scheduledRerun;
+      }
+      return;
+    }
+    if (current.disposeActiveContextEngineAfterMaintenance) {
+      await disposeDeferredMaintenanceContextEngine(current.activeContextEngine);
+    }
+    if (
       discardedRerunParams?.disposeContextEngineAfterMaintenance &&
-      (!hasSameContextEngineInstance(discardedRerunParams.contextEngine, params.contextEngine) ||
-        !params.disposeContextEngineAfterMaintenance)
+      !hasSameContextEngineInstance(discardedRerunParams.contextEngine, current.activeContextEngine)
     ) {
       await disposeDeferredMaintenanceContextEngine(discardedRerunParams.contextEngine);
     }
@@ -566,6 +604,9 @@ function scheduleDeferredTurnMaintenance(
   const state: DeferredTurnMaintenanceRunState = {
     promise: trackedPromise,
     rerunRequested: false,
+    activeContextEngine: params.contextEngine,
+    disposeActiveContextEngineAfterMaintenance:
+      params.disposeContextEngineAfterMaintenance === true,
     latestParams: { ...params, sessionKey },
   };
   activeDeferredTurnMaintenanceRuns.set(sessionKey, state);

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -24,6 +24,7 @@ import {
   GatewayDrainingError,
   isGatewayDraining,
 } from "../../process/command-queue.js";
+import { getGatewayRestartDrainSignal } from "../../process/gateway-work-admission.js";
 import {
   CONTEXT_ENGINE_TURN_MAINTENANCE_TASK_KIND as TURN_MAINTENANCE_TASK_KIND,
   registerContextEngineMaintenanceTaskOwner,
@@ -162,9 +163,10 @@ function createDeferredTurnMaintenanceAbortSignal(params?: {
   }
 
   const controller = new AbortController();
+  const abortSignal = AbortSignal.any([controller.signal, getGatewayRestartDrainSignal()]);
   state.controllers.add(controller);
   return {
-    abortSignal: controller.signal,
+    abortSignal,
     dispose: () => {
       state.controllers.delete(controller);
       if (state.controllers.size === 0) {

--- a/src/agents/embedded-agent-runner/context-engine-maintenance.ts
+++ b/src/agents/embedded-agent-runner/context-engine-maintenance.ts
@@ -6,7 +6,10 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import { publishTranscriptUpdate } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { resolveContextEngineOwnerPluginId } from "../../context-engine/registry.js";
+import {
+  isContextEngineAbortRejection,
+  resolveContextEngineOwnerPluginId,
+} from "../../context-engine/registry.js";
 import type {
   ContextEngine,
   ContextEngineMaintenanceResult,
@@ -290,6 +293,7 @@ function buildContextEngineMaintenanceRuntimeContext(
 
 async function executeContextEngineMaintenance(
   params: ContextEngineMaintenanceParams & {
+    abortSignal?: AbortSignal;
     contextEngine: ContextEngine;
     executionMode: "foreground" | "background";
   },
@@ -297,6 +301,7 @@ async function executeContextEngineMaintenance(
   if (typeof params.contextEngine.maintain !== "function") {
     return undefined;
   }
+  params.abortSignal?.throwIfAborted();
   const result = await params.contextEngine.maintain({
     sessionId: params.sessionId,
     sessionKey: params.sessionKey,
@@ -312,7 +317,9 @@ async function executeContextEngineMaintenance(
       purpose: `context-engine.${params.reason}.maintenance`,
       contextEnginePluginId: resolveContextEngineOwnerPluginId(params.contextEngine),
     }),
+    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
   });
+  params.abortSignal?.throwIfAborted();
   if (result.changed) {
     log.info(
       `[context-engine] maintenance(${params.reason}) changed transcript ` +
@@ -325,12 +332,12 @@ async function executeContextEngineMaintenance(
 
 async function runDeferredTurnMaintenanceWorker(
   params: DeferredTurnMaintenanceScheduleParams & {
+    abortSignal: AbortSignal;
     runId: string;
   },
 ): Promise<void> {
   let surfacedUserNotice = false;
   let longRunningTimer: ReturnType<typeof setTimeout> | undefined;
-  const shutdownAbort = createDeferredTurnMaintenanceAbortSignal();
   const taskRun = { runId: params.runId, runtime: "acp" as const, sessionKey: params.sessionKey };
   const makeTaskVisible = (notifyPolicy: "done_only" | "state_changes") =>
     buildTurnMaintenanceTaskDescriptor({
@@ -382,7 +389,7 @@ async function runDeferredTurnMaintenanceWorker(
         : "No transcript changes were needed.",
     });
   } catch (err) {
-    if (shutdownAbort.abortSignal.aborted) {
+    if (isContextEngineAbortRejection(err, params.abortSignal)) {
       const task = findTaskByRunIdForOwner({
         runId: params.runId,
         callerOwnerKey: params.sessionKey,
@@ -419,7 +426,6 @@ async function runDeferredTurnMaintenanceWorker(
     if (longRunningTimer) {
       clearTimeout(longRunningTimer);
     }
-    shutdownAbort.dispose();
     if (params.disposeContextEngineAfterMaintenance) {
       await disposeDeferredMaintenanceContextEngine(params.contextEngine);
     }
@@ -511,7 +517,12 @@ function scheduleDeferredTurnMaintenance(
   let runPromise: Promise<void>;
   try {
     runPromise = enqueueCommandInLane(lane, () =>
-      runDeferredTurnMaintenanceWorker({ ...params, sessionKey, runId: task.runId! }),
+      runDeferredTurnMaintenanceWorker({
+        ...params,
+        abortSignal: schedulerAbort.abortSignal,
+        sessionKey,
+        runId: task.runId!,
+      }),
     );
   } catch (err) {
     releaseProcessOwner();
@@ -534,7 +545,11 @@ function scheduleDeferredTurnMaintenance(
     activeDeferredTurnMaintenanceRuns.delete(sessionKey);
     if (rerunParams) {
       await scheduleDeferredTurnMaintenance(rerunParams);
-    } else if (discardedRerunParams?.disposeContextEngineAfterMaintenance) {
+    } else if (
+      discardedRerunParams?.disposeContextEngineAfterMaintenance &&
+      (discardedRerunParams.contextEngine !== params.contextEngine ||
+        !params.disposeContextEngineAfterMaintenance)
+    ) {
       await disposeDeferredMaintenanceContextEngine(discardedRerunParams.contextEngine);
     }
   };

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1898,6 +1898,7 @@ describe("runGatewayLoop", () => {
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { close, start } = await createSignaledLoopHarness();
       const sigusr1 = captureSignal("SIGUSR1");
+      const restartDrainSignal = gatewayWorkAdmissionActual.getGatewayRestartDrainSignal();
 
       sigusr1();
       await new Promise<void>((resolve) => {
@@ -1906,6 +1907,8 @@ describe("runGatewayLoop", () => {
 
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
       expect(scheduleGatewaySigusr1Restart).not.toHaveBeenCalled();
+      expect(restartDrainSignal.aborted).toBe(false);
+      expect(gatewayWorkAdmissionActual.isGatewayRestartDraining()).toBe(false);
       expect(close).not.toHaveBeenCalled();
       expect(start).toHaveBeenCalledTimes(1);
       expect(gatewayLog.warn).toHaveBeenCalledWith(

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1202,6 +1202,13 @@ describe("runGatewayLoop", () => {
       detail: "OPENCLAW_NO_RESPAWN",
     });
     markUpdateRestartSentinelFailure.mockClear();
+    let releaseFirstCronTaskDrain: (() => void) | undefined;
+    waitForActiveCronTaskRuns.mockImplementationOnce(
+      async () =>
+        await new Promise<{ drained: true; active: 0 }>((resolve) => {
+          releaseFirstCronTaskDrain = () => resolve({ drained: true, active: 0 });
+        }),
+    );
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       const timedOutSnapshot = createActiveWorkSnapshot({ activeTasks: 2, embeddedRuns: 1 }, [
@@ -1244,11 +1251,17 @@ describe("runGatewayLoop", () => {
       });
 
       let resolveSecond: (() => void) | null = null;
+      let secondAgentEventGeneration: string | undefined;
+      let secondRestartDrainSignal: AbortSignal | undefined;
       const startedSecond = new Promise<void>((resolve) => {
         resolveSecond = resolve;
       });
       start.mockImplementationOnce(async () => {
         expect(lifecycleSlot.size).toBe(0);
+        secondAgentEventGeneration = agentEventsActual.getAgentEventLifecycleGeneration();
+        secondRestartDrainSignal = gatewayWorkAdmissionActual.getGatewayRestartDrainSignal();
+        expect(secondRestartDrainSignal.aborted).toBe(false);
+        lifecycleSlot.set("second", 2);
         resolveSecond?.();
         return createGatewayServer(closeSecond);
       });
@@ -1280,16 +1293,15 @@ describe("runGatewayLoop", () => {
 
       sigusr1();
 
+      await waitForLoopCondition(
+        () => waitForActiveCronTaskRuns.mock.calls.length === 1,
+        "expected first restart to reach cron task drain",
+      );
+      sigusr1();
+      releaseFirstCronTaskDrain?.();
       await startedSecond;
-      const secondAgentEventGeneration = agentEventsActual.getAgentEventLifecycleGeneration();
       expect(secondAgentEventGeneration).not.toBe(firstAgentEventGeneration);
-      expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(false);
-      expect(start).toHaveBeenCalledTimes(2);
-      await new Promise<void>((resolve) => {
-        setImmediate(resolve);
-      });
 
-      expect(waitForGatewayActiveWork).toHaveBeenCalledOnce();
       expect(waitForGatewayActiveWork.mock.calls[0]?.[0]).toBeLessThanOrEqual(
         DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS,
       );
@@ -1297,34 +1309,8 @@ describe("runGatewayLoop", () => {
         "active-work drain timeout reached; proceeding with restart: 2 active background task run(s); 1 active embedded run(s)",
       );
       expectRestartCloseCall(closeFirst, DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS);
-      expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
-      expect(abortActiveCronTaskRuns).toHaveBeenCalledWith("Gateway restarting.");
-      expect(waitForActiveCronTaskRuns).toHaveBeenCalledWith(1_000);
-      expect(waitForActiveCronJobs).toHaveBeenCalledWith(1_000);
-      expect(advanceCronActiveJobGeneration).toHaveBeenCalledTimes(1);
-      expect(retireActiveCronTaskRunTracking).toHaveBeenCalledTimes(1);
-      expect(resetCronActiveJobs).toHaveBeenCalledTimes(1);
-      expect(clearRuntimeConfigSnapshot).toHaveBeenCalledTimes(1);
-      expect(resetGatewaySuspendCoordinatorForLifecycleRestart).toHaveBeenCalledTimes(1);
-      expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(1);
-      expect(reloadTaskRuntimeStateFromStore).toHaveBeenCalledTimes(1);
-      expect(reloadTaskRuntimeStateFromStore.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
-        start.mock.invocationCallOrder[1] ?? Infinity,
-      );
-      expect(advanceCronActiveJobGeneration.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
-        abortActiveCronTaskRuns.mock.invocationCallOrder[0] ?? Infinity,
-      );
-      expect(waitForActiveCronJobs.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
-        retireActiveCronTaskRunTracking.mock.invocationCallOrder[0] ?? Infinity,
-      );
-      expect(retireActiveCronTaskRunTracking.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
-        resetCronActiveJobs.mock.invocationCallOrder[0] ?? Infinity,
-      );
-
-      lifecycleSlot.set("second", 2);
-      sigusr1();
-
       await startedThird;
+      expect(secondRestartDrainSignal?.aborted).toBe(true);
       const thirdAgentEventGeneration = agentEventsActual.getAgentEventLifecycleGeneration();
       expect(thirdAgentEventGeneration).not.toBe(secondAgentEventGeneration);
       expect(gatewayWorkAdmissionActual.isGatewayWorkAdmissionClosed()).toBe(false);
@@ -1344,6 +1330,18 @@ describe("runGatewayLoop", () => {
       expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(2);
       expect(reloadTaskRuntimeStateFromStore).toHaveBeenCalledTimes(2);
       expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
+      expect(reloadTaskRuntimeStateFromStore.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
+        start.mock.invocationCallOrder[1] ?? Infinity,
+      );
+      expect(advanceCronActiveJobGeneration.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
+        abortActiveCronTaskRuns.mock.invocationCallOrder[0] ?? Infinity,
+      );
+      expect(waitForActiveCronJobs.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
+        retireActiveCronTaskRunTracking.mock.invocationCallOrder[0] ?? Infinity,
+      );
+      expect(retireActiveCronTaskRunTracking.mock.invocationCallOrder[0] ?? Infinity).toBeLessThan(
+        resetCronActiveJobs.mock.invocationCallOrder[0] ?? Infinity,
+      );
 
       sigterm();
       await expect(exited).resolves.toBe(0);

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1006,6 +1006,9 @@ export async function runGatewayLoop(params: {
       // suspension admission callback and discards the coordinator entry.
       resetGatewaySuspendCoordinatorForLifecycleRestart();
       resetAllLanes();
+      // resetAllLanes installs the next admission generation. Keep the local
+      // mirror aligned so a restart queued during cleanup closes that generation.
+      restartDrainingMarked = false;
       clearRuntimeConfigSnapshot();
       resetGatewayRestartStateForInProcessRestart();
       // Rent: a failed startup has no server close handle, and restart hooks can
@@ -1023,9 +1026,6 @@ export async function runGatewayLoop(params: {
     // SIGTERM/SIGINT still exit after a graceful shutdown.
     let isFirstIteration = true;
     for (;;) {
-      // The restart hook reopens admission before reloading durable state. Clear
-      // its local mirror first so a failed reload cannot skip the next drain.
-      restartDrainingMarked = false;
       let startupFailedBeforeServerHandle = false;
       const isRestartIteration = !isFirstIteration;
       isFirstIteration = false;

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -1775,13 +1775,53 @@ describe("Invalid engine fallback", () => {
     expect(listContextEngineQuarantines()).toEqual([]);
   });
 
-  it("quarantines unrelated abort-shaped maintenance failures after abort", async () => {
-    const engineId = uniqueEngineId("maintain-unrelated-abort");
+  it("does not quarantine standard AbortError from aborted maintenance", async () => {
+    const engineId = uniqueEngineId("maintain-standard-abort");
     const controller = new AbortController();
-    const unrelatedError = new Error("maintenance cancellation failed");
-    unrelatedError.name = "AbortError";
+    const abortError = new Error("This operation was aborted");
+    abortError.name = "AbortError";
+    let observedSignal: AbortSignal | undefined;
     registerTestContextEngine(engineId, () => ({
-      info: { id: engineId, name: "Unrelated Abort Engine" },
+      info: { id: engineId, name: "Standard Abort Engine" },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble({ messages }: { messages: AgentMessage[] }) {
+        return { messages, estimatedTokens: 0 };
+      },
+      async compact() {
+        return { ok: true, compacted: false };
+      },
+      async maintain({ abortSignal }) {
+        observedSignal = abortSignal;
+        await new Promise<void>((_resolve, reject) => {
+          abortSignal?.addEventListener("abort", () => reject(abortError), { once: true });
+        });
+        return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+      },
+    }));
+    const engine = await resolveContextEngine(configWithSlot(engineId));
+
+    const maintenance = engine.maintain?.({
+      sessionId: "s1",
+      sessionFile: "/tmp/s1.jsonl",
+      abortSignal: controller.signal,
+    });
+    await vi.waitFor(() => expect(observedSignal).toBe(controller.signal));
+    controller.abort(new Error("gateway shutdown"));
+
+    await expect(maintenance).rejects.toBe(abortError);
+    expect((await resolveContextEngine(configWithSlot(engineId))).info.id).toBe(engineId);
+    expect(listContextEngineQuarantines()).toEqual([]);
+  });
+
+  it("quarantines standard AbortError when maintenance was not aborted", async () => {
+    const engineId = uniqueEngineId("maintain-unrelated-standard-abort");
+    const controller = new AbortController();
+    const abortError = new Error("This operation was aborted");
+    abortError.name = "AbortError";
+    registerTestContextEngine(engineId, () => ({
+      info: { id: engineId, name: "Unrelated Standard Abort Engine" },
       async ingest() {
         return { ingested: true };
       },
@@ -1792,8 +1832,7 @@ describe("Invalid engine fallback", () => {
         return { ok: true, compacted: false };
       },
       async maintain() {
-        controller.abort(new Error("gateway shutdown"));
-        throw unrelatedError;
+        throw abortError;
       },
     }));
     const engine = await resolveContextEngine(configWithSlot(engineId));
@@ -1806,12 +1845,13 @@ describe("Invalid engine fallback", () => {
       }),
     ).resolves.toMatchObject({ changed: false });
 
+    expect(controller.signal.aborted).toBe(false);
     expect((await resolveContextEngine(configWithSlot(engineId))).info.id).toBe("legacy");
     expect(listContextEngineQuarantines()).toEqual([
       expect.objectContaining({
         engineId,
         operation: "maintain",
-        reason: "maintenance cancellation failed",
+        reason: "This operation was aborted",
       }),
     ]);
   });

--- a/src/context-engine/context-engine.test.ts
+++ b/src/context-engine/context-engine.test.ts
@@ -1684,11 +1684,18 @@ describe("Invalid engine fallback", () => {
     expect(listContextEngineQuarantines()).toEqual([]);
   });
 
-  it("does not quarantine abort rejections from lifecycle methods", async () => {
+  it("does not quarantine causal abort rejections from lifecycle methods", async () => {
     const engineId = uniqueEngineId("abort-rejection");
-    const abortError = new Error("compaction aborted");
-    abortError.name = "AbortError";
-    const controller = new AbortController();
+    const compactAbortReason = new Error("user stopped compaction");
+    const compactAbortError = new Error("compaction aborted", { cause: compactAbortReason });
+    compactAbortError.name = "AbortError";
+    const compactController = new AbortController();
+    const maintainAbortReason = new Error("gateway shutdown");
+    const maintainAbortError = new Error("maintenance cancelled", {
+      cause: maintainAbortReason,
+    });
+    maintainAbortError.name = "AbortError";
+    const maintainController = new AbortController();
     registerTestContextEngine(engineId, () => ({
       info: { id: engineId, name: "Abort Aware Engine" },
       async ingest() {
@@ -1698,8 +1705,12 @@ describe("Invalid engine fallback", () => {
         return { messages, estimatedTokens: 0 };
       },
       async compact() {
-        controller.abort(new Error("user stopped run"));
-        throw abortError;
+        compactController.abort(compactAbortReason);
+        throw compactAbortError;
+      },
+      async maintain() {
+        maintainController.abort(maintainAbortReason);
+        throw maintainAbortError;
       },
     }));
 
@@ -1709,14 +1720,100 @@ describe("Invalid engine fallback", () => {
       engine.compact({
         sessionId: "s1",
         sessionKey: "agent:main:s1",
-        abortSignal: controller.signal,
+        abortSignal: compactController.signal,
       }),
     ).rejects.toThrow("compaction aborted");
+    await expect(
+      engine.maintain?.({
+        sessionId: "s1",
+        sessionFile: "/tmp/s1.jsonl",
+        abortSignal: maintainController.signal,
+      }),
+    ).rejects.toThrow("maintenance cancelled");
 
     const nextEngine = await resolveContextEngine(configWithSlot(engineId));
     expect(nextEngine.info.id).toBe(engineId);
     expect(listContextEngineQuarantines()).toEqual([]);
     expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke guarded maintenance for an already-aborted signal", async () => {
+    const engineId = uniqueEngineId("maintain-pre-abort");
+    const maintain = vi.fn(async () => ({
+      changed: false,
+      bytesFreed: 0,
+      rewrittenEntries: 0,
+    }));
+    registerTestContextEngine(engineId, () => ({
+      info: { id: engineId, name: "Pre-Abort Engine" },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble({ messages }: { messages: AgentMessage[] }) {
+        return { messages, estimatedTokens: 0 };
+      },
+      async compact() {
+        return { ok: true, compacted: false };
+      },
+      maintain,
+    }));
+    const controller = new AbortController();
+    const reason = new Error("shutdown already requested");
+    controller.abort(reason);
+    const engine = await resolveContextEngine(configWithSlot(engineId));
+
+    await expect(
+      engine.maintain?.({
+        sessionId: "s1",
+        sessionFile: "/tmp/s1.jsonl",
+        abortSignal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+
+    expect(maintain).not.toHaveBeenCalled();
+    expect((await resolveContextEngine(configWithSlot(engineId))).info.id).toBe(engineId);
+    expect(listContextEngineQuarantines()).toEqual([]);
+  });
+
+  it("quarantines unrelated abort-shaped maintenance failures after abort", async () => {
+    const engineId = uniqueEngineId("maintain-unrelated-abort");
+    const controller = new AbortController();
+    const unrelatedError = new Error("maintenance cancellation failed");
+    unrelatedError.name = "AbortError";
+    registerTestContextEngine(engineId, () => ({
+      info: { id: engineId, name: "Unrelated Abort Engine" },
+      async ingest() {
+        return { ingested: true };
+      },
+      async assemble({ messages }: { messages: AgentMessage[] }) {
+        return { messages, estimatedTokens: 0 };
+      },
+      async compact() {
+        return { ok: true, compacted: false };
+      },
+      async maintain() {
+        controller.abort(new Error("gateway shutdown"));
+        throw unrelatedError;
+      },
+    }));
+    const engine = await resolveContextEngine(configWithSlot(engineId));
+
+    await expect(
+      engine.maintain?.({
+        sessionId: "s1",
+        sessionFile: "/tmp/s1.jsonl",
+        abortSignal: controller.signal,
+      }),
+    ).resolves.toMatchObject({ changed: false });
+
+    expect((await resolveContextEngine(configWithSlot(engineId))).info.id).toBe("legacy");
+    expect(listContextEngineQuarantines()).toEqual([
+      expect.objectContaining({
+        engineId,
+        operation: "maintain",
+        reason: "maintenance cancellation failed",
+      }),
+    ]);
   });
 
   it("quarantines subagent preparation failures while failing the active spawn closed", async () => {

--- a/src/context-engine/host-param-projection.test.ts
+++ b/src/context-engine/host-param-projection.test.ts
@@ -22,6 +22,7 @@ function registerProbeEngine(params: {
   assembleCalls: Array<Record<string, unknown>>;
   compactCalls: Array<Record<string, unknown>>;
   commitTurnCalls?: Array<Record<string, unknown>>;
+  maintainCalls?: Array<Record<string, unknown>>;
   rejectAssemble?: boolean;
 }): string {
   const engineId = `host-param-probe-${++engineCounter}`;
@@ -48,6 +49,10 @@ function registerProbeEngine(params: {
           params.compactCalls.push({ ...callParams });
           return { ok: true, compacted: false };
         },
+        async maintain(callParams) {
+          params.maintainCalls?.push({ ...callParams });
+          return { changed: false, bytesFreed: 0, rewrittenEntries: 0 };
+        },
         async commitTurn(callParams) {
           params.commitTurnCalls?.push({ ...callParams });
           return { status: "committed" };
@@ -59,6 +64,7 @@ function registerProbeEngine(params: {
 }
 
 async function invokeHostParamMethods(engine: ContextEngine) {
+  const abortSignal = new AbortController().signal;
   await engine.assemble({
     sessionId: "session-1",
     sessionKey: "agent:main:session-1",
@@ -72,7 +78,17 @@ async function invokeHostParamMethods(engine: ContextEngine) {
     sessionTarget: { agentId: "main", sessionId: "session-1" },
     runtimeSettings,
     runtimeContext: { tokenBudget: 1000 },
+    abortSignal,
   });
+  await engine.maintain?.({
+    sessionId: "session-1",
+    sessionKey: "agent:main:session-1",
+    sessionFile: "/tmp/session-1.jsonl",
+    runtimeSettings,
+    runtimeContext: { tokenBudget: 1000 },
+    abortSignal,
+  });
+  return abortSignal;
 }
 
 describe("context-engine host parameter projection", () => {
@@ -99,6 +115,7 @@ describe("context-engine host parameter projection", () => {
   it("passes declared current host parameters", async () => {
     const assembleCalls: Array<Record<string, unknown>> = [];
     const compactCalls: Array<Record<string, unknown>> = [];
+    const maintainCalls: Array<Record<string, unknown>> = [];
     const engineId = registerProbeEngine({
       acceptedHostParams: [
         "sessionKey",
@@ -106,12 +123,14 @@ describe("context-engine host parameter projection", () => {
         "runtimeSettings",
         "sessionTarget",
         "runtimeContext",
+        "abortSignal",
       ],
       assembleCalls,
       compactCalls,
+      maintainCalls,
     });
 
-    await invokeHostParamMethods(
+    const abortSignal = await invokeHostParamMethods(
       await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } }),
     );
 
@@ -125,29 +144,42 @@ describe("context-engine host parameter projection", () => {
       sessionTarget: { agentId: "main", sessionId: "session-1" },
       runtimeSettings,
       runtimeContext: { tokenBudget: 1000 },
+      abortSignal,
+    });
+    expect(maintainCalls[0]).toMatchObject({
+      sessionKey: "agent:main:session-1",
+      runtimeSettings,
+      runtimeContext: { tokenBudget: 1000 },
+      abortSignal,
     });
   });
 
   it("projects host parameters on fresh logical-turn engines", async () => {
     const assembleCalls: Array<Record<string, unknown>> = [];
     const compactCalls: Array<Record<string, unknown>> = [];
+    const maintainCalls: Array<Record<string, unknown>> = [];
     const engineId = registerProbeEngine({
       acceptedHostParams: ["runtimeSettings"],
       assembleCalls,
       compactCalls,
+      maintainCalls,
     });
     const resolution = await resolveLogicalTurnContextEngines({
       plugins: { slots: { contextEngine: engineId } },
     });
 
-    await invokeHostParamMethods(resolution.configured.engine);
+    const abortSignal = await invokeHostParamMethods(resolution.configured.engine);
 
     expect(assembleCalls[0]).toMatchObject({ sessionId: "session-1", runtimeSettings });
     expect(assembleCalls[0]).not.toHaveProperty("sessionKey");
     expect(assembleCalls[0]).not.toHaveProperty("prompt");
-    expect(compactCalls[0]).toMatchObject({ sessionId: "session-1", runtimeSettings });
+    expect(compactCalls[0]).toMatchObject({ sessionId: "session-1", runtimeSettings, abortSignal });
     expect(compactCalls[0]).not.toHaveProperty("sessionTarget");
     expect(compactCalls[0]).not.toHaveProperty("runtimeContext");
+    expect(maintainCalls[0]).toMatchObject({ sessionId: "session-1", runtimeSettings });
+    expect(maintainCalls[0]).not.toHaveProperty("sessionKey");
+    expect(maintainCalls[0]).not.toHaveProperty("runtimeContext");
+    expect(maintainCalls[0]).not.toHaveProperty("abortSignal");
     await Promise.allSettled([
       resolution.configured.engine.dispose?.(),
       resolution.fallback.engine.dispose?.(),
@@ -216,12 +248,13 @@ describe("context-engine host parameter projection", () => {
   it("passes every host parameter to fresh undeclared engines", async () => {
     const assembleCalls: Array<Record<string, unknown>> = [];
     const compactCalls: Array<Record<string, unknown>> = [];
-    const engineId = registerProbeEngine({ assembleCalls, compactCalls });
+    const maintainCalls: Array<Record<string, unknown>> = [];
+    const engineId = registerProbeEngine({ assembleCalls, compactCalls, maintainCalls });
     const resolution = await resolveLogicalTurnContextEngines({
       plugins: { slots: { contextEngine: engineId } },
     });
 
-    await invokeHostParamMethods(resolution.configured.engine);
+    const abortSignal = await invokeHostParamMethods(resolution.configured.engine);
 
     expect(assembleCalls[0]).toMatchObject({
       sessionId: "session-1",
@@ -235,6 +268,14 @@ describe("context-engine host parameter projection", () => {
       sessionTarget: { agentId: "main", sessionId: "session-1" },
       runtimeSettings,
       runtimeContext: { tokenBudget: 1000 },
+      abortSignal,
+    });
+    expect(maintainCalls[0]).toMatchObject({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runtimeSettings,
+      runtimeContext: { tokenBudget: 1000 },
+      abortSignal,
     });
     await Promise.allSettled([
       resolution.configured.engine.dispose?.(),
@@ -245,10 +286,11 @@ describe("context-engine host parameter projection", () => {
   it("passes every host parameter to resolved undeclared engines", async () => {
     const assembleCalls: Array<Record<string, unknown>> = [];
     const compactCalls: Array<Record<string, unknown>> = [];
-    const engineId = registerProbeEngine({ assembleCalls, compactCalls });
+    const maintainCalls: Array<Record<string, unknown>> = [];
+    const engineId = registerProbeEngine({ assembleCalls, compactCalls, maintainCalls });
     const engine = await resolveContextEngine({ plugins: { slots: { contextEngine: engineId } } });
 
-    await invokeHostParamMethods(engine);
+    const abortSignal = await invokeHostParamMethods(engine);
 
     expect(assembleCalls[0]).toMatchObject({
       sessionId: "session-1",
@@ -262,6 +304,14 @@ describe("context-engine host parameter projection", () => {
       sessionTarget: { agentId: "main", sessionId: "session-1" },
       runtimeSettings,
       runtimeContext: { tokenBudget: 1000 },
+      abortSignal,
+    });
+    expect(maintainCalls[0]).toMatchObject({
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      runtimeSettings,
+      runtimeContext: { tokenBudget: 1000 },
+      abortSignal,
     });
   });
 

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -51,6 +51,7 @@ export const CONTEXT_ENGINE_HOST_PARAMS = new Set(
 type ResolvedContextEngineMetadata = {
   owner: string;
   engineId: string;
+  sourceEngine?: ContextEngine;
 };
 
 const resolvedEngineMetadata = new WeakMap<ContextEngine, ResolvedContextEngineMetadata>();
@@ -96,7 +97,10 @@ function wrapContextEngineHostParamProjection(
       },
     },
   );
-  resolvedEngineMetadata.set(wrapped, metadata);
+  resolvedEngineMetadata.set(wrapped, {
+    ...metadata,
+    sourceEngine: resolvedEngineMetadata.get(engine)?.sourceEngine ?? engine,
+  });
   return wrapped;
 }
 
@@ -205,7 +209,10 @@ function wrapResolvedContextEngine(
       },
     },
   );
-  resolvedEngineMetadata.set(wrapped, metadata);
+  resolvedEngineMetadata.set(wrapped, {
+    ...metadata,
+    sourceEngine: resolvedEngineMetadata.get(engine)?.sourceEngine ?? engine,
+  });
   return wrapped;
 }
 
@@ -462,6 +469,10 @@ export function resolveContextEngineOwnerPluginId(
     metadata && !getContextEngineQuarantine(metadata.engineId) ? metadata.owner : undefined;
   return owner ? pluginIdFromContextEngineOwner(owner) : undefined;
 }
+
+export const hasSameContextEngineInstance = (left: ContextEngine, right: ContextEngine): boolean =>
+  (resolvedEngineMetadata.get(left)?.sourceEngine ?? left) ===
+  (resolvedEngineMetadata.get(right)?.sourceEngine ?? right);
 
 function pluginIdFromContextEngineOwner(owner: string): string | undefined {
   if (!owner.startsWith("plugin:")) {

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -46,7 +46,7 @@ const GUARDED_CONTEXT_ENGINE_METHODS = new Set<PropertyKey>(
   ),
 );
 export const CONTEXT_ENGINE_HOST_PARAMS = new Set(
-  "sessionKey prompt runtimeSettings sessionTarget runtimeContext".split(" "),
+  "sessionKey prompt runtimeSettings sessionTarget runtimeContext abortSignal".split(" "),
 );
 type ResolvedContextEngineMetadata = {
   owner: string;
@@ -56,6 +56,7 @@ type ResolvedContextEngineMetadata = {
 const resolvedEngineMetadata = new WeakMap<ContextEngine, ResolvedContextEngineMetadata>();
 function projectContextEngineHostParams(
   engine: ContextEngine,
+  methodName: PropertyKey,
   params: Record<string, unknown>,
 ): Record<string, unknown> {
   const accepted = engine.info.acceptedHostParams;
@@ -64,7 +65,10 @@ function projectContextEngineHostParams(
   }
   return Object.fromEntries(
     Object.entries(params).filter(
-      ([key]) => accepted.includes(key) || !CONTEXT_ENGINE_HOST_PARAMS.has(key),
+      ([key]) =>
+        accepted.includes(key) ||
+        !CONTEXT_ENGINE_HOST_PARAMS.has(key) ||
+        (methodName === "compact" && key === "abortSignal"),
     ),
   );
 }
@@ -88,7 +92,7 @@ function wrapContextEngineHostParamProjection(
           return method.bind(engine);
         }
         return (params: Record<string, unknown>) =>
-          method.call(engine, projectContextEngineHostParams(engine, params));
+          method.call(engine, projectContextEngineHostParams(engine, property, params));
       },
     },
   );
@@ -148,12 +152,12 @@ function wrapResolvedContextEngine(
         if (!GUARDED_CONTEXT_ENGINE_METHODS.has(property)) {
           return method.bind(engine);
         }
+        const methodName = property as GuardedContextEngineMethodName;
         if (!fallback || !getFallbackEngine) {
           return (params: Record<string, unknown>) =>
-            method.call(engine, projectContextEngineHostParams(engine, params));
+            method.call(engine, projectContextEngineHostParams(engine, methodName, params));
         }
 
-        const methodName = property as GuardedContextEngineMethodName;
         return async (methodParams: Record<string, unknown>) => {
           const abortSignal = contextEngineAbortSignal(methodParams);
           if (abortSignal?.aborted) {
@@ -174,7 +178,10 @@ function wrapResolvedContextEngine(
           }
 
           try {
-            return await method.call(engine, projectContextEngineHostParams(engine, methodParams));
+            return await method.call(
+              engine,
+              projectContextEngineHostParams(engine, methodName, methodParams),
+            );
           } catch (error) {
             if (isContextEngineAbortRejection(error, abortSignal)) {
               // Abort is caller intent, not engine instability; never quarantine for it.
@@ -525,17 +532,28 @@ function contextEngineAbortSignal(methodParams: unknown): AbortSignal | undefine
     : undefined;
 }
 
-function isContextEngineAbortRejection(error: unknown, signal: AbortSignal | undefined): boolean {
+export function isContextEngineAbortRejection(
+  error: unknown,
+  signal: AbortSignal | undefined,
+): boolean {
   if (!signal?.aborted) {
     return false;
   }
   if (error === signal.reason) {
     return true;
   }
-  if (error instanceof Error) {
-    return error.name === "AbortError" || /abort|cancelled|canceled/iu.test(error.message);
+  const seen = new Set<Error>();
+  for (
+    let current = error;
+    current instanceof Error && !seen.has(current);
+    current = current.cause
+  ) {
+    seen.add(current);
+    if (current.cause === signal.reason) {
+      return true;
+    }
   }
-  return typeof error === "string" && /abort|cancelled|canceled/iu.test(error);
+  return false;
 }
 
 async function invokeFallbackContextEngineMethod(params: {

--- a/src/context-engine/registry.ts
+++ b/src/context-engine/registry.ts
@@ -1,7 +1,7 @@
 // Context-engine registry owns engine registration, resolution, compatibility, and quarantine.
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { createAbortError } from "../infra/abort-signal.js";
+import { createAbortError, isAbortError } from "../infra/abort-signal.js";
 import type {
   ContextEngineFactory,
   ContextEngineFactoryContext,
@@ -550,7 +550,7 @@ export function isContextEngineAbortRejection(
   if (!signal?.aborted) {
     return false;
   }
-  if (error === signal.reason) {
+  if (error === signal.reason || isAbortError(error)) {
     return true;
   }
   const seen = new Set<Error>();

--- a/src/context-engine/types.ts
+++ b/src/context-engine/types.ts
@@ -379,6 +379,11 @@ export interface ContextEngine {
     sessionFile: string;
     runtimeSettings?: ContextEngineRuntimeSettings;
     runtimeContext?: ContextEngineRuntimeContext;
+    /**
+     * Optional caller cancellation for maintenance work that may block.
+     * Engines should reject promptly when this signal aborts.
+     */
+    abortSignal?: AbortSignal;
   }): Promise<ContextEngineMaintenanceResult>;
 
   /**

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -6,6 +6,7 @@ import {
   captureGatewayRootWorkAdmissionContinuationScope,
   GatewayDrainingError,
   getActiveGatewayRootWorkCount,
+  getGatewayRestartDrainSignal,
   getGatewaySuspendAdmissionPhase,
   isGatewayRestartDrainError,
   isGatewaySubordinateWorkAdmissionClosed,
@@ -28,6 +29,7 @@ afterEach(resetGatewayWorkAdmission);
 
 it("classifies draining errors only while an authoritative restart signal or drain is active", () => {
   const error = new GatewayDrainingError();
+  const firstDrainSignal = getGatewayRestartDrainSignal();
 
   expect(isGatewayRestartDrainError(error)).toBe(false);
   expect(isGatewayRestartDrainError(new Error("GatewayDrainingError"))).toBe(false);
@@ -44,6 +46,14 @@ it("classifies draining errors only while an authoritative restart signal or dra
 
   markGatewayRestartDraining();
   expect(isGatewayRestartDrainError(error)).toBe(true);
+  expect(firstDrainSignal.aborted).toBe(true);
+
+  resetGatewayWorkAdmission();
+  const nextDrainSignal = getGatewayRestartDrainSignal();
+  expect(nextDrainSignal).not.toBe(firstDrainSignal);
+  expect(nextDrainSignal.aborted).toBe(false);
+  markGatewayRestartDraining();
+  expect(nextDrainSignal.aborted).toBe(true);
 });
 
 it("counts one nested root chain once and excludes the preparing caller", async () => {

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -23,6 +23,7 @@ type GatewayRootWorkAdmission = {
 
 type GatewayWorkAdmissionState = {
   restartDraining: boolean;
+  restartDrainController: AbortController;
   restartSignalPending: boolean;
   restartSignalGeneration: number;
   suspendPhase: GatewaySuspendAdmissionPhase;
@@ -39,6 +40,7 @@ const GATEWAY_WORK_ADMISSION_STATE = resolveGlobalSingleton(
   Symbol.for("openclaw.gatewayWorkAdmissionState"),
   (): GatewayWorkAdmissionState => ({
     restartDraining: false,
+    restartDrainController: new AbortController(),
     restartSignalPending: false,
     restartSignalGeneration: 0,
     suspendPhase: "accepting",
@@ -185,6 +187,10 @@ export function isGatewayRestartDraining(): boolean {
   );
 }
 
+export function getGatewayRestartDrainSignal(): AbortSignal {
+  return GATEWAY_WORK_ADMISSION_STATE.restartDrainController.signal;
+}
+
 export function isGatewayRestartDrainError(error: unknown): error is GatewayDrainingError {
   return error instanceof GatewayDrainingError && isGatewayRestartDraining();
 }
@@ -199,6 +205,9 @@ export function markGatewayRestartDraining(): void {
   GATEWAY_WORK_ADMISSION_STATE.restartSignalPending = false;
   GATEWAY_WORK_ADMISSION_STATE.restartSignalGeneration += 1;
   GATEWAY_WORK_ADMISSION_STATE.restartDraining = true;
+  GATEWAY_WORK_ADMISSION_STATE.restartDrainController.abort(
+    new GatewayDrainingError("gateway is draining for restart"),
+  );
   resolveSuspendOpenWaiters();
   logAdmissionClosed("restart drain");
   if (GATEWAY_WORK_ADMISSION_STATE.suspendPhase !== "accepting") {
@@ -500,6 +509,7 @@ export function resetGatewayWorkAdmission(): void {
   }
   GATEWAY_WORK_ADMISSION_STATE.activeRootWork.clear();
   GATEWAY_WORK_ADMISSION_STATE.restartDraining = false;
+  GATEWAY_WORK_ADMISSION_STATE.restartDrainController = new AbortController();
   GATEWAY_WORK_ADMISSION_STATE.restartSignalPending = false;
   GATEWAY_WORK_ADMISSION_STATE.restartSignalGeneration += 1;
   if (GATEWAY_WORK_ADMISSION_STATE.suspendPhase !== "accepting") {


### PR DESCRIPTION
Fixes #129200

## What Problem This Solves

Fixes an issue where operators stopping or restarting the Gateway could wait indefinitely when
deferred context-engine maintenance was active or queued. Maintenance could retain its task state,
command-lane ownership, coalesced rerun, and engine resources because the engine had no cooperative
shutdown cancellation signal.

The initial fix covered SIGINT and SIGTERM but missed accepted in-process restart drain, including
authorized SIGUSR1 restart paths. It also classified only causally linked abort errors, which could
quarantine existing plugin engines that reject with a standard plain `AbortError` after honoring
the supplied signal.

## Why This Change Was Made

`ContextEngine.maintain()` accepts optional cooperative cancellation, and deferred maintenance uses
one scheduler-owned signal from queue admission through engine execution. That signal now composes
process termination with the Gateway admission owner's accepted restart-drain signal.

The restart-drain signal is generation-owned and replaced during in-process lifecycle reset.
The run loop resets its local drain mirror immediately after the new admission generation is
installed, so an accepted SIGUSR1 queued during restart cleanup re-aborts the fresh generation.
Raw or unauthorized SIGUSR1 does not mark restart drain and does not cancel maintenance.

Abort classification preserves plugin compatibility: when the supplied signal is aborted, a
standard `AbortError` is cancellation and does not quarantine the engine. The same error with a
non-aborted signal remains an unrelated failure and follows the existing quarantine/fallback path.

Deferred engine disposal remains owned by the per-session scheduler state and keyed to the
underlying factory instance rather than wrapper identity. Foreground maintenance and existing
compaction abort behavior are unchanged.

## User Impact

SIGINT, SIGTERM, and accepted in-process Gateway restart can now promptly settle cooperative
deferred maintenance instead of waiting for active-work drain timeout. Background task state
becomes cancelled, the maintenance lane is released, shutdown-time reruns are discarded, and owned
context engines are disposed.

Existing context-engine plugins that reject with a normal `AbortError` after cancellation continue
to be treated as cancelled rather than unstable. Genuine abort-shaped failures without a pending
caller abort still surface and quarantine normally.

## Evidence

Pre-fix reproductions on head `a8554ecab956eb8ae1ff2554dbc5a2305db1f832`:

- Maintenance suite: 2 expected failures showed active and queued accepted-restart drain did not
  cancel deferred maintenance; the 19 existing cases passed.
- Registry suite: 1 expected failure showed a plugin-style plain `AbortError` after signal abort was
  quarantined and replaced by fallback; the other 65 cases passed.

Final proof on commit `98bfeb480eeb2b1b62fefc45e5ecf2b40cccf342`, tree
`36fe008e187d3c077fba328de70a94ed78b5d6b2`:

- Focused suites: 179 tests passed across deferred maintenance, context-engine registry,
  host-parameter projection, Gateway work admission, and Gateway run-loop tests.
- `pnpm check:changed`: passed.
- Provider: Blacksmith Testbox through Crabbox, branch-seeded from
  `shakkernerd/deferred-maintenance-shutdown-abort`.
- Each final command verified the staged remote tree matched the exact candidate tree before and
  after execution.
- Independent direct review: clean, including the accepted-SIGUSR1-during-reset race and scope
  containment.

Test changes:

- Added case: active deferred maintenance under accepted restart drain.
- Added case: queued deferred maintenance under accepted restart drain.
- Added: standard `AbortError` with a non-aborted signal remains failure/quarantine.
- Modified: active SIGTERM deferred-maintenance shutdown test to cover both triggers.
- Modified: queued SIGTERM deferred-maintenance shutdown test to cover both triggers.
- Modified: post-shutdown unrelated maintenance failure to use a genuine non-abort error.
- Modified: conflicting post-abort quarantine test into plugin-style plain `AbortError`
  cancellation coverage.
- Modified: Gateway draining-error test with restart-signal generation reset coverage.
- Modified: unauthorized SIGUSR1 test to prove the restart-drain signal remains live.
- Modified: multi-restart SIGUSR1 test with the accepted-signal-during-reset race.
- Deleted: none.
