### PR TITLE
fix(ui): keep Continue visible with wizard spinner

### DIFF
--- a/ui/src/components/wizard-step-controls.ts
+++ b/ui/src/components/wizard-step-controls.ts
@@ -31,11 +31,15 @@ type WizardStepControlsProps = {
   onToggleSensitiveVisibility?: () => void;
 };
 
-export function renderWizardBusyButton(label: string) {
+export function renderWizardBusyButton(
+  statusLabel: string,
+  buttonLabel = t("modelSetup.wizard.continue"),
+) {
   return html`
-    <button type="button" class="btn primary" disabled aria-busy="true">
+    <button type="button" class="btn primary" disabled aria-busy="true" aria-label=${buttonLabel}>
+      <span class="btn__label">${buttonLabel}</span>
       <span class="btn__spinner" aria-hidden="true"></span>
-      <span class="sr-only" role="status" aria-live="polite">${label}</span>
+      <span class="sr-only" role="status" aria-live="polite">${statusLabel}</span>
     </button>
   `;
 }

--- a/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
+++ b/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
@@ -20,6 +20,12 @@ const uiProofArtifactDir = path.join(
   "control-ui-e2e",
   "channels-save-failure",
 );
+const wizardUiProofArtifactDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "channel-wizard-continue-spinner",
+);
 
 suite.define(() => {
   it("shows rejected channel configuration saves in the open editor without losing the draft", async () => {
@@ -371,6 +377,9 @@ suite.define(() => {
   });
 
   it("preserves standard channel details and the complete Telegram setup wizard", async () => {
+    if (captureUiProofEnabled) {
+      await mkdir(wizardUiProofArtifactDir, { recursive: true });
+    }
     await suite.withPage({ locale: "en-US", serviceWorkers: "block" }, async ({ page }) => {
       const channelEntries = [
         ["discord", "Discord"],
@@ -483,7 +492,11 @@ suite.define(() => {
       await expect.poll(() => account.getAttribute("disabled")).not.toBeNull();
       const busyButton = wizard.locator('button[aria-busy="true"]');
       await expect.poll(() => busyButton.getAttribute("disabled")).not.toBeNull();
+      await expect.poll(() => busyButton.locator(".btn__label").textContent()).toBe("Continue");
       await expect.poll(() => busyButton.locator(".btn__spinner").count()).toBe(1);
+      if (captureUiProofEnabled) {
+        await wizard.screenshot({ path: path.join(wizardUiProofArtifactDir, "after.png") });
+      }
       await expect
         .poll(() => wizard.locator(".channels-wizard__spinner", { hasText: "Working…" }).count())
         .toBe(0);

--- a/ui/src/pages/channels/wizard-view.busy.test.ts
+++ b/ui/src/pages/channels/wizard-view.busy.test.ts
@@ -102,7 +102,10 @@ describe("renderChannelWizard busy controls", () => {
       );
 
       expect(busyButton?.disabled).toBe(true);
+      expect(busyButton?.getAttribute("aria-label")).toBe("Continue");
+      expect(busyButton?.querySelector(".btn__label")?.textContent).toBe("Continue");
       expect(busyButton?.querySelector(".btn__spinner")).not.toBeNull();
+      expect(busyButton?.querySelector(".btn__label + .btn__spinner")).not.toBeNull();
       expect(busyButton?.querySelector(".sr-only")?.textContent).toBe("Working…");
       expect(rendered.container.querySelectorAll(".btn__spinner")).toHaveLength(1);
       expect(
@@ -140,7 +143,10 @@ describe("renderChannelWizard busy controls", () => {
     );
 
     expect(busyButton?.disabled).toBe(true);
+    expect(busyButton?.getAttribute("aria-label")).toBe("Continue");
+    expect(busyButton?.querySelector(".btn__label")?.textContent).toBe("Continue");
     expect(busyButton?.querySelector(".btn__spinner")).not.toBeNull();
+    expect(busyButton?.querySelector(".btn__label + .btn__spinner")).not.toBeNull();
     expect(busyButton?.querySelector(".sr-only")?.textContent).toBe(status);
     expect(rendered.container.querySelectorAll(".btn__spinner")).toHaveLength(1);
   });


### PR DESCRIPTION
## Summary

- keep the localized `Continue` label visible while every channel setup step is busy
- place the spinner immediately after the label inside the disabled button
- preserve the hidden live status for `Working…`, startup, gateway progress, and WhatsApp QR generation

Corrective follow-up to #131377 after the final busy-button wording was clarified.

## Visual proof

Before — detached `Working…` status:

![Before](https://github.com/user-attachments/assets/e1178f89-6513-4441-ae35-a89ac7d3b298)

After — persistent `Continue` button with inline spinner:

![After](https://github.com/user-attachments/assets/e66636d7-a4af-4c25-8fbf-7585c1fb0fb1)

## Validation

- `pnpm exec vitest run ui/src/pages/channels/wizard-view.busy.test.ts` — 16 passed
- `OPENCLAW_CAPTURE_UI_PROOF=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/channels-whatsapp-logout.e2e.test.ts -t "preserves standard channel details and the complete Telegram setup wizard"` — 1 passed, 4 skipped
- `pnpm check:changed -- ui/src/components/wizard-step-controls.ts ui/src/pages/channels/wizard-view.busy.test.ts ui/src/e2e/channels-whatsapp-logout.e2e.test.ts` — passed
- structured autoreview — clean, no actionable findings

## Repair notes

- Root cause: the shared busy-button helper rendered only the spinner visually and kept the operation text screen-reader-only.
- Owner: `renderWizardBusyButton`, shared by all channel wizard busy surfaces.
- Production LOC: +7 / -3 (net +4) for the visible localized label and exact accessible name.
- Sibling coverage: note, select, multiselect, text, confirm, action, progress, startup, and WhatsApp QR busy states.
- Pathfinder: exact-head CI exposed an unrelated font-picker transition race three times. Current `main` independently landed the same lifecycle repair in #131392, so this branch rebased onto it and dropped the duplicate local commit; the focused upstream suite passes 17/17.
