### PR TITLE
feat(control-ui): add session Goal mode and management

### DIFF
--- a/ui/src/e2e/chat-goal-mode.e2e.test.ts
+++ b/ui/src/e2e/chat-goal-mode.e2e.test.ts
@@ -1,0 +1,281 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Control UI Goal mode" });
+const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const activeGoal = {
+  schemaVersion: 1,
+  id: "goal-active",
+  objective: "Ship the Goal UI",
+  status: "active",
+  createdAt: Date.now() - 15_000,
+  updatedAt: Date.now(),
+  tokenStart: 0,
+  tokensUsed: 10,
+  continuationTurns: 0,
+} as const;
+
+suite.define(() => {
+  it("starts a Goal from human text", async () => {
+    await suite.withPage(
+      {
+        viewport: { width: 1280, height: 900 },
+        ...(artifactDir
+          ? { recordVideo: { dir: artifactDir, size: { width: 1280, height: 900 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        if (artifactDir) {
+          await fs.mkdir(artifactDir, { recursive: true });
+        }
+        const gateway = await installMockGateway(page, {
+          featureCapabilities: ["session-goal-start-v1"],
+          deferredMethods: ["chat.send"],
+          methodResponses: {
+            "chat.startup": {
+              messages: [],
+              metadata: { models: [] },
+              sessionId: "goal-mode-session",
+              thinkingLevel: null,
+            },
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        const composer = page.locator(".agent-chat__composer-combobox textarea");
+        await composer.waitFor({ state: "visible" });
+        if (artifactDir) {
+          await page.screenshot({ path: path.join(artifactDir, "goal-normal-desktop.png") });
+        }
+
+        await composer.fill("/");
+        await page
+          .locator(".slash-menu[role='listbox']")
+          .getByRole("option")
+          .filter({ hasText: "/goal" })
+          .click();
+        await page.locator(".agent-chat__goal-mode").waitFor();
+        expect(await composer.inputValue()).toBe("");
+        if (artifactDir) {
+          await page.screenshot({ path: path.join(artifactDir, "goal-mode-desktop.png") });
+        }
+
+        const objective = "/ship this\nwith measurable outcomes";
+        await composer.fill(objective);
+        await composer.press("Control+Enter");
+        const request = await gateway.waitForRequest("chat.send");
+        expect(request.params).toMatchObject({
+          message: objective,
+          intent: { kind: "session-goal-start", version: 1 },
+        });
+        expect(request.params).not.toHaveProperty("deliver");
+        expect(request.params).not.toHaveProperty("queueMode");
+        expect(await gateway.getRequests("chat.send")).toHaveLength(1);
+        expect(await composer.inputValue()).toBe(objective);
+        expect(await page.locator(".agent-chat__goal-mode").count()).toBe(1);
+        if (artifactDir) {
+          await page.screenshot({ path: path.join(artifactDir, "goal-submitting-desktop.png") });
+        }
+        await gateway.resolveDeferred("chat.send", {
+          runId: (request.params as { idempotencyKey: string }).idempotencyKey,
+          goalId: "goal-e2e",
+          status: "started",
+        });
+        await expect.poll(() => composer.inputValue()).toBe("");
+        await expect.poll(() => page.locator(".agent-chat__goal-mode").count()).toBe(0);
+        await gateway.emitChatFinal({
+          runId: (request.params as { idempotencyKey: string }).idempotencyKey,
+          text: "Goal accepted.",
+        });
+      },
+    );
+  });
+
+  it("keeps Goal mode visible when admission fails", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureCapabilities: ["session-goal-start-v1"],
+        deferredMethods: ["chat.send"],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill("/goal");
+      await composer.press("Enter");
+      await composer.fill("Keep this objective after failure");
+      await composer.press("Control+Enter");
+      await gateway.waitForRequest("chat.send");
+      await gateway.rejectDeferred("chat.send", {
+        code: "UNAVAILABLE",
+        message: "session has active or queued work",
+        retryable: true,
+      });
+
+      await page.locator(".agent-chat__goal-mode").waitFor();
+      expect(await composer.inputValue()).toBe("Keep this objective after failure");
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, "goal-failure-desktop.png") });
+      }
+    });
+  });
+
+  it("manages an active Goal through typed RPCs without chat turns", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["sessions.goal.update", "sessions.goal.clear"],
+        methodResponses: {
+          "sessions.list": {
+            ts: 2,
+            path: "",
+            count: 1,
+            defaults: { model: "gpt-5.6-luna", modelProvider: "openai", contextTokens: 128_000 },
+            sessions: [
+              { key: "main", kind: "direct", label: "Main", updatedAt: 2, goal: activeGoal },
+            ],
+          },
+          "sessions.goal.update": {
+            ok: true,
+            sessionKey: "main",
+            operationId: "ignored-by-fixture",
+            goal: { ...activeGoal, status: "paused", pausedAt: 3, updatedAt: 3 },
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const goal = page.locator(".agent-chat__goal");
+      await goal.getByText("Pursuing goal", { exact: true }).waitFor();
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill("/goal");
+      await composer.press("Enter");
+      await expect.poll(() => goal.getAttribute("data-expanded")).toBe("true");
+      await expect
+        .poll(() => goal.evaluate((element) => element === document.activeElement))
+        .toBe(true);
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, "goal-active-desktop.png") });
+      }
+      await goal.getByRole("button", { name: "Edit goal" }).click();
+      await goal.getByRole("textbox", { name: "Edit goal" }).waitFor();
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, "goal-management-desktop.png") });
+      }
+      await goal.getByRole("button", { name: "Cancel" }).click();
+      await goal.getByRole("button", { name: "Pause goal" }).click();
+      const update = await gateway.waitForRequest("sessions.goal.update");
+      expect(update.params).toMatchObject({
+        sessionKey: "main",
+        goalId: "goal-active",
+        action: "pause",
+      });
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+    });
+  });
+
+  it("keeps an explicit Goal tail on the textual path", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureCapabilities: ["session-goal-start-v1"],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill("/goal status");
+      await composer.press("Control+Enter");
+
+      const textual = await gateway.waitForRequest("chat.send");
+      expect(textual.params).toMatchObject({ message: "/goal status" });
+      expect(textual.params).not.toHaveProperty("intent");
+    });
+  });
+
+  it("keeps Goal activation textual without capability on mobile", async () => {
+    await suite.withPage({ viewport: { width: 390, height: 844 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page);
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill("/goal");
+      await composer.press("Enter");
+
+      await expect.poll(() => composer.inputValue()).toBe("/goal ");
+      expect(await page.locator(".agent-chat__goal-mode").count()).toBe(0);
+      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+        390,
+      );
+    });
+  });
+
+  it("renders removable Goal mode without mobile overflow", async () => {
+    await suite.withPage({ viewport: { width: 390, height: 844 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureCapabilities: ["session-goal-start-v1"],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill("/goal");
+      await composer.press("Enter");
+      await page.locator(".agent-chat__goal-mode").waitFor();
+      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+        390,
+      );
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, "goal-mode-mobile.png") });
+      }
+    });
+  });
+
+  it("keeps active Goal management reachable on mobile", async () => {
+    await suite.withPage({ viewport: { width: 390, height: 844 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: ["sessions.goal.update", "sessions.goal.clear"],
+        methodResponses: {
+          "sessions.list": {
+            ts: 2,
+            path: "",
+            count: 1,
+            defaults: { model: "gpt-5.6-luna", modelProvider: "openai", contextTokens: 128_000 },
+            sessions: [
+              { key: "main", kind: "direct", label: "Main", updatedAt: 2, goal: activeGoal },
+            ],
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      const goal = page.locator(".agent-chat__goal");
+      await goal.getByText("Pursuing goal", { exact: true }).waitFor();
+      await goal.getByRole("button", { name: "Edit goal" }).click();
+      await goal.getByRole("textbox", { name: "Edit goal" }).waitFor();
+      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+        390,
+      );
+      expect(await gateway.getRequests("chat.send")).toHaveLength(0);
+      if (artifactDir) {
+        await page.screenshot({ path: path.join(artifactDir, "goal-management-mobile.png") });
+      }
+    });
+  });
+
+  it("drops Goal mode on reload while preserving its text as an ordinary draft", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureCapabilities: ["session-goal-start-v1"],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+      const composer = page.locator(".agent-chat__composer-combobox textarea");
+      await composer.fill("/goal");
+      await composer.press("Enter");
+      await composer.fill("Draft survives reload");
+      await page.reload();
+
+      await composer.waitFor({ state: "visible" });
+      await expect.poll(() => composer.inputValue()).toBe("Draft survives reload");
+      expect(await page.locator(".agent-chat__goal-mode").count()).toBe(0);
+    });
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5741,9 +5741,13 @@ export const en: TranslationMap = {
       imageCount: "Image ({count})",
     },
     goals: {
+      modeLabel: "Goal",
+      modePlaceholder: "Describe your goal; measurable outcomes help",
+      removeMode: "Remove Goal mode",
       edit: "Edit goal",
       pause: "Pause goal",
       resume: "Resume goal",
+      complete: "Complete goal",
       clear: "Clear goal",
       showDetails: "Show goal details",
       hideDetails: "Hide goal details",

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -3,7 +3,10 @@
  */
 
 import type { MediaKind } from "@openclaw/media-core/constants";
-import type { QueueMode } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
+import type {
+  ChatSendIntent as GatewayChatSendIntent,
+  QueueMode,
+} from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import type { toolIcons } from "../../components/icons-tools.ts";
 import type { SenderIdentity } from "./sender-label.ts";
 
@@ -39,6 +42,8 @@ export type ChatComposerMemoryFallback = {
   sequence: number;
 };
 
+export type ChatSendIntent = GatewayChatSendIntent;
+
 export type ChatGuardianNotice = {
   key: string;
   runId: string;
@@ -67,6 +72,9 @@ export type ChatQueueItem = {
   /** Operator-owned queue position; absent means "wherever arrival put it". */
   orderKey?: number;
   attachments?: ChatAttachment[];
+  intent?: ChatSendIntent;
+  /** Stable Goal draft identity excludes hydration-local attachment ids. */
+  goalDraftSignature?: string;
   refreshSessions?: boolean;
   /** Transcript id of the replied-to message; Gateway hydrates reply context. */
   replyToId?: string;

--- a/ui/src/lib/chat/command-interactions/index.test.ts
+++ b/ui/src/lib/chat/command-interactions/index.test.ts
@@ -61,6 +61,8 @@ function createContext(
       { value: "staging", label: "Staging" },
       { value: "production", label: "Production" },
     ],
+    placement: "standalone",
+    goalStartAvailable: false,
   };
 }
 
@@ -131,5 +133,52 @@ describe("command activation planning", () => {
         provider,
       ]).kind,
     ).toBe("insert-text");
+  });
+
+  it.each([
+    { name: "typed", source: "typed" as const },
+    { name: "sheet", source: "sheet" as const },
+  ])("activates Goal mode from a bare $name command", ({ source }) => {
+    const command = createCommand("native");
+    command.key = "goal";
+    command.name = "goal";
+    command.definition = defineChatCommand({
+      key: "goal",
+      textAlias: "/goal",
+      description: "Goal",
+    });
+    const context = createContext(command, { source });
+    context.invocation = parseCommandInvocation(command.definition, "/goal")!;
+    context.goalStartAvailable = true;
+
+    expect(resolveCommandActivation(context)).toEqual({
+      kind: "activate-composer-mode",
+      mode: { kind: "goal" },
+    });
+  });
+
+  it("opens management for an existing Goal and keeps unsupported or inline use textual", () => {
+    const command = createCommand("native");
+    command.key = "goal";
+    command.name = "goal";
+    command.definition = defineChatCommand({
+      key: "goal",
+      textAlias: "/goal",
+      description: "Goal",
+    });
+    const context = createContext(command);
+    context.invocation = parseCommandInvocation(command.definition, "/goal")!;
+    context.goal = { id: "goal-1" };
+
+    expect(resolveCommandActivation(context)).toEqual({
+      kind: "open-surface",
+      surface: "goal-management",
+      focus: "goal-1",
+    });
+    context.goal = undefined;
+    expect(resolveCommandActivation(context).kind).toBe("insert-text");
+    context.goalStartAvailable = true;
+    context.placement = "inline";
+    expect(resolveCommandActivation(context).kind).toBe("insert-text");
   });
 });

--- a/ui/src/lib/chat/command-interactions/index.ts
+++ b/ui/src/lib/chat/command-interactions/index.ts
@@ -5,9 +5,9 @@ import type {
 import type { CommandArgDefinition } from "../../../../../src/auto-reply/commands-registry.types.js";
 import type { SlashCommandDef } from "../commands.ts";
 
-type KnownControlUiSurface = "command-help" | "device-pairing";
+type KnownControlUiSurface = "command-help" | "device-pairing" | "goal-management";
 type StructuredCommandAction = { kind: "run-local-command"; commandKey: string };
-type ComposerModeActivation = { kind: string };
+type ComposerModeActivation = { kind: "goal" };
 type KnownControlUiRoute = { path: string };
 
 type ExplicitArgumentCollectionPlan = {
@@ -37,6 +37,9 @@ export type CommandActivationContext = {
   command: SlashCommandDef;
   invocation: CanonicalCommandInvocation;
   resolveChoices: (arg: CommandArgDefinition) => ResolvedCommandArgChoice[];
+  placement: "standalone" | "inline";
+  goal?: { id: string };
+  goalStartAvailable: boolean;
 };
 
 export interface ControlUiCommandInteractionProvider {
@@ -76,7 +79,26 @@ const declaredInteractionProvider: ControlUiCommandInteractionProvider = {
   },
 };
 
-const DEFAULT_PROVIDERS = [declaredInteractionProvider, localCommandProvider];
+const goalProvider: ControlUiCommandInteractionProvider = {
+  id: "session-goal",
+  resolve(context) {
+    if (
+      context.command.key !== "goal" ||
+      context.placement !== "standalone" ||
+      !context.invocation.isExactBare
+    ) {
+      return null;
+    }
+    if (context.goal) {
+      return { kind: "open-surface", surface: "goal-management", focus: context.goal.id };
+    }
+    return context.goalStartAvailable
+      ? { kind: "activate-composer-mode", mode: { kind: "goal" } }
+      : null;
+  },
+};
+
+const DEFAULT_PROVIDERS = [goalProvider, declaredInteractionProvider, localCommandProvider];
 
 /** Resolves interaction policy separately from command grammar. */
 export function resolveCommandActivation(

--- a/ui/src/lib/chat/outbox-store-codec.ts
+++ b/ui/src/lib/chat/outbox-store-codec.ts
@@ -90,6 +90,18 @@ export function normalizeStoredQueueItem(value: unknown): ChatQueueItem | null {
   if (attachments.length) {
     item.attachments = attachments;
   }
+  if (
+    isRecord(entry.intent) &&
+    Object.keys(entry.intent).length === 2 &&
+    entry.intent.kind === "session-goal-start" &&
+    entry.intent.version === 1
+  ) {
+    item.intent = { kind: "session-goal-start", version: 1 };
+    const goalDraftSignature = normalizeOptionalString(entry.goalDraftSignature);
+    if (goalDraftSignature) {
+      item.goalDraftSignature = goalDraftSignature;
+    }
+  }
   const refreshSessions = normalizeOptionalBoolean(entry.refreshSessions);
   if (refreshSessions !== undefined) {
     item.refreshSessions = refreshSessions;

--- a/ui/src/lib/chat/outbox-store.test.ts
+++ b/ui/src/lib/chat/outbox-store.test.ts
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../../test-helpers/storage.ts";
+import { normalizeStoredQueueItem } from "./outbox-store-codec.ts";
 import { listStoredChatOutboxes, summarizeStoredChatOutboxes } from "./outbox-store-projection.ts";
 import {
   readProjectedOutboxStore,
@@ -20,6 +21,38 @@ afterEach(() => {
 });
 
 describe("stored outbox summaries", () => {
+  it("restores only the closed structured Goal start intent", () => {
+    const stored = {
+      id: "goal-start",
+      text: "Finish the migration",
+      createdAt: 1,
+    };
+
+    expect(
+      normalizeStoredQueueItem({
+        ...stored,
+        intent: { kind: "session-goal-start", version: 1 },
+        goalDraftSignature: '["Ship",[]]',
+      }),
+    ).toMatchObject({
+      ...stored,
+      intent: { kind: "session-goal-start", version: 1 },
+      goalDraftSignature: '["Ship",[]]',
+    });
+    expect(
+      normalizeStoredQueueItem({
+        ...stored,
+        intent: { kind: "session-goal-start", version: 1, unexpected: true },
+      }),
+    ).not.toHaveProperty("intent");
+    expect(
+      normalizeStoredQueueItem({
+        ...stored,
+        intent: { kind: "session-goal-start", version: 2 },
+      }),
+    ).not.toHaveProperty("intent");
+  });
+
   it("normalizes an unchanged projection once and refreshes after an external write", () => {
     const unsubscribe = subscribeStoredChatOutboxChanges(() => undefined);
     const gatewayUrl = "ws://gateway.test/control";

--- a/ui/src/pages/chat/chat-composer-goal-mode.test.ts
+++ b/ui/src/pages/chat/chat-composer-goal-mode.test.ts
@@ -1,0 +1,115 @@
+/* @vitest-environment jsdom */
+
+import { render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createComposerProps } from "./chat-composer.test-support.ts";
+import { getChatComposerState, resetChatComposerState } from "./components/chat-composer-state.ts";
+import { renderChatComposer } from "./components/chat-composer.ts";
+
+function mount(paneId: string, overrides: Parameters<typeof createComposerProps>[0] = {}) {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const props = createComposerProps({ paneId, goalStartAvailable: true, ...overrides });
+  const draw = () => render(renderChatComposer(props), container);
+  draw();
+  return { container, props, draw };
+}
+
+afterEach(() => {
+  resetChatComposerState();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("Goal composer mode", () => {
+  it("renders a removable mode without changing the draft or attachments", () => {
+    const onDraftChange = vi.fn();
+    const view = mount("goal-mode", {
+      draft: "multiline\nobjective",
+      attachments: [{ id: "attachment-1", name: "proof.txt", mimeType: "text/plain" } as never],
+      onDraftChange,
+    });
+    getChatComposerState("goal-mode").goalMode = true;
+    view.draw();
+
+    expect(view.container.querySelector(".agent-chat__goal-mode")?.textContent).toContain("Goal");
+    expect(view.container.querySelector("textarea")?.getAttribute("placeholder")).toBe(
+      "Describe your goal; measurable outcomes help",
+    );
+    view.container
+      .querySelector<HTMLButtonElement>('button[aria-label="Remove Goal mode"]')
+      ?.click();
+    expect(getChatComposerState("goal-mode").goalMode).toBe(false);
+    expect(onDraftChange).not.toHaveBeenCalled();
+  });
+
+  it("removes Goal mode with Escape before aborting a run", () => {
+    const onAbort = vi.fn();
+    const view = mount("goal-escape", { canAbort: true, onAbort, draft: "keep me" });
+    getChatComposerState("goal-escape").goalMode = true;
+    view.draw();
+    const input = view.container.querySelector<HTMLTextAreaElement>("textarea")!;
+
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(getChatComposerState("goal-escape").goalMode).toBe(false);
+    expect(onAbort).not.toHaveBeenCalled();
+  });
+
+  it("keeps mode until the structured send owns the durable queue row", () => {
+    let admitted: (() => void) | undefined;
+    const onGoalStart = vi.fn((onDurableAdmission: () => void) => {
+      admitted = onDurableAdmission;
+    });
+    const view = mount("goal-submit", { draft: "ship safely", onGoalStart });
+    getChatComposerState("goal-submit").goalMode = true;
+    view.draw();
+
+    view.container.querySelector<HTMLButtonElement>('button[aria-label="Send message"]')?.click();
+    expect(onGoalStart).toHaveBeenCalledOnce();
+    expect(getChatComposerState("goal-submit").goalMode).toBe(true);
+    admitted?.();
+    expect(getChatComposerState("goal-submit").goalMode).toBe(false);
+  });
+
+  it("keeps Goal submission ahead of the active-run modifier steer shortcut", () => {
+    const onGoalStart = vi.fn();
+    const onSend = vi.fn();
+    const view = mount("goal-steer", {
+      canAbort: true,
+      draft: "goal objective",
+      followUpMode: "queue",
+      onAbort: vi.fn(),
+      onGoalStart,
+      onSend,
+    });
+    getChatComposerState("goal-steer").goalMode = true;
+    view.draw();
+    const input = view.container.querySelector<HTMLTextAreaElement>("textarea")!;
+
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true, bubbles: true }),
+    );
+    expect(onGoalStart).toHaveBeenCalledOnce();
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("retains mode while capability is temporarily unknown", () => {
+    const view = mount("goal-reconnect");
+    getChatComposerState("goal-reconnect").goalMode = true;
+    view.props.goalStartAvailable = undefined;
+    view.draw();
+
+    expect(view.container.querySelector(".agent-chat__goal-mode")).not.toBeNull();
+  });
+
+  it("isolates mode by pane and session presentation", () => {
+    const first = mount("pane-a:session-a");
+    const second = mount("pane-b:session-b");
+    getChatComposerState("pane-a:session-a").goalMode = true;
+    first.draw();
+    second.draw();
+
+    expect(first.container.querySelector(".agent-chat__goal-mode")).not.toBeNull();
+    expect(second.container.querySelector(".agent-chat__goal-mode")).toBeNull();
+  });
+});

--- a/ui/src/pages/chat/chat-composer-goal.test.ts
+++ b/ui/src/pages/chat/chat-composer-goal.test.ts
@@ -6,6 +6,7 @@ import type { SessionGoal } from "../../api/types.ts";
 import { i18n } from "../../i18n/index.ts";
 import { renderChatGoal, clearGoalElapsedTimers } from "./components/chat-composer-goal.ts";
 import { getChatComposerState, resetChatComposerState } from "./components/chat-composer-state.ts";
+import type { ChatGoalManagementProps } from "./components/chat-composer-types.ts";
 
 const goal: SessionGoal = {
   schemaVersion: 1,
@@ -19,12 +20,21 @@ const goal: SessionGoal = {
   continuationTurns: 0,
 };
 
-function mountGoal(initial: SessionGoal) {
+function mountGoal(initial: SessionGoal, management?: ChatGoalManagementProps) {
   const container = document.createElement("div");
   document.body.append(container);
   const state = getChatComposerState("goal-timing");
-  const draw = (value: SessionGoal | undefined) =>
-    render(renderChatGoal(state, value, { canAct: false, requestUpdate: () => {} }), container);
+  const draw = (value: SessionGoal | undefined, nextManagement = management) =>
+    render(
+      renderChatGoal(state, value, {
+        canAct: Boolean(nextManagement),
+        paneId: "goal-timing",
+        management: nextManagement,
+        onGoalEdit: () => {},
+        requestUpdate: () => {},
+      }),
+      container,
+    );
   const part = draw(initial);
   return {
     container,
@@ -97,5 +107,59 @@ describe("goal elapsed presentation", () => {
     view.part.setConnected(true);
     expect(view.elapsed()).toBe("3m");
     expect(vi.getTimerCount()).toBe(1);
+  });
+});
+
+describe("goal management presentation", () => {
+  beforeEach(async () => {
+    await i18n.setLocale("en");
+  });
+
+  afterEach(() => {
+    clearGoalElapsedTimers();
+    resetChatComposerState();
+    document.body.replaceChildren();
+  });
+
+  it("makes the management group focusable and disables every control while pending", () => {
+    const view = mountGoal(goal, {
+      pending: true,
+      error: null,
+      editObjective: null,
+      onEditStart: () => {},
+      onUpdate: () => {},
+      onClear: () => {},
+    });
+
+    const group = view.container.querySelector<HTMLElement>(".agent-chat__goal");
+    const buttons = [...view.container.querySelectorAll<HTMLButtonElement>("button")];
+    expect(group?.tabIndex).toBe(-1);
+    expect(group?.getAttribute("aria-busy")).toBe("true");
+    expect(buttons.length).toBeGreaterThan(0);
+    expect(buttons.every((button) => button.disabled)).toBe(true);
+  });
+
+  it("keeps a failed edit visible and retryable", async () => {
+    const onUpdate = vi.fn();
+    const view = mountGoal(goal, {
+      pending: false,
+      error: "Goal update failed",
+      editObjective: "Retry deployment verification",
+      onEditChange: () => {},
+      onEditCancel: () => {},
+      onUpdate,
+      onClear: () => {},
+    });
+
+    expect(view.container.querySelector('[role="alert"]')?.textContent).toBe("Goal update failed");
+    const input = view.container.querySelector<HTMLInputElement>('input[aria-label="Edit goal"]');
+    expect(input?.value).toBe("Retry deployment verification");
+    await Promise.resolve();
+    expect(input).toBe(document.activeElement);
+    input?.closest("form")?.dispatchEvent(new SubmitEvent("submit", { cancelable: true }));
+    expect(onUpdate).toHaveBeenCalledWith({
+      action: "edit",
+      objective: "Retry deployment verification",
+    });
   });
 });

--- a/ui/src/pages/chat/chat-goal-management.ts
+++ b/ui/src/pages/chat/chat-goal-management.ts
@@ -1,0 +1,129 @@
+import type { SessionsGoalClearResult, SessionsGoalUpdateResult } from "@openclaw/gateway-protocol";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { formatUiError } from "../../lib/format-error.ts";
+import type { SessionCapability } from "../../lib/sessions/index.ts";
+import { generateUUID } from "../../lib/uuid.ts";
+import type { ChatGoalManagementProps, ChatGoalUpdate } from "./components/chat-composer-types.ts";
+
+type GoalManagementTarget = {
+  client: GatewayBrowserClient;
+  sessions: Pick<SessionCapability, "patchRowLocal">;
+  sessionKey: string;
+  agentId: string;
+  goalId: string;
+  canUpdate: boolean;
+  canClear: boolean;
+  requestUpdate: () => void;
+};
+
+type GoalManagementState = {
+  client: GatewayBrowserClient;
+  targetKey: string;
+  generation: number;
+  pending: boolean;
+  error: string | null;
+  editObjective: string | null;
+  retry?: { requestKey: string; operationId: string };
+};
+
+const states = new WeakMap<object, GoalManagementState>();
+
+function readState(owner: object, target: GoalManagementTarget): GoalManagementState {
+  const targetKey = `${target.sessionKey}\0${target.agentId}\0${target.goalId}`;
+  const current = states.get(owner);
+  if (current?.targetKey === targetKey) {
+    current.client = target.client;
+    return current;
+  }
+  const next = {
+    client: target.client,
+    targetKey,
+    generation: (current?.generation ?? 0) + 1,
+    pending: false,
+    error: null,
+    editObjective: null,
+  };
+  states.set(owner, next);
+  return next;
+}
+
+export function createChatGoalManagementProps(
+  owner: object,
+  target: GoalManagementTarget,
+): ChatGoalManagementProps | undefined {
+  if (!target.canUpdate && !target.canClear) {
+    return undefined;
+  }
+  const state = readState(owner, target);
+  const ownsState = () => states.get(owner) === state;
+  const setState = (patch: Partial<GoalManagementState>) => {
+    Object.assign(state, patch);
+    target.requestUpdate();
+  };
+  const run = async (request: ChatGoalUpdate | { action: "clear" }) => {
+    if (state.pending) {
+      return;
+    }
+    const generation = state.generation;
+    const requestKey = JSON.stringify(request);
+    const operationId =
+      state.retry?.requestKey === requestKey ? state.retry.operationId : generateUUID();
+    state.retry = { requestKey, operationId };
+    setState({ pending: true, error: null });
+    try {
+      if (request.action === "clear") {
+        await target.client.request<SessionsGoalClearResult>("sessions.goal.clear", {
+          sessionKey: target.sessionKey,
+          agentId: target.agentId,
+          goalId: target.goalId,
+          operationId,
+        });
+        if (ownsState() && state.generation === generation) {
+          target.sessions.patchRowLocal(target.sessionKey, { goal: undefined });
+          state.retry = undefined;
+        }
+      } else {
+        const result = await target.client.request<SessionsGoalUpdateResult>(
+          "sessions.goal.update",
+          {
+            sessionKey: target.sessionKey,
+            agentId: target.agentId,
+            goalId: target.goalId,
+            operationId,
+            ...request,
+          },
+        );
+        if (ownsState() && state.generation === generation) {
+          target.sessions.patchRowLocal(target.sessionKey, { goal: result.goal });
+          state.editObjective = null;
+          state.retry = undefined;
+        }
+      }
+    } catch (error) {
+      if (ownsState() && state.generation === generation) {
+        state.error = formatUiError(error);
+      }
+    } finally {
+      if (ownsState() && state.generation === generation) {
+        state.pending = false;
+        target.requestUpdate();
+      }
+    }
+  };
+  return {
+    pending: state.pending,
+    error: state.error,
+    editObjective: state.editObjective,
+    onEditStart: target.canUpdate
+      ? (objective) => setState({ editObjective: objective, error: null })
+      : undefined,
+    onEditChange: target.canUpdate
+      ? (objective) => setState({ editObjective: objective })
+      : undefined,
+    onEditCancel: target.canUpdate
+      ? () => setState({ editObjective: null, error: null })
+      : undefined,
+    onUpdate: target.canUpdate ? (update) => void run(update) : undefined,
+    onClear: target.canClear ? () => void run({ action: "clear" }) : undefined,
+  };
+}

--- a/ui/src/pages/chat/chat-outbox-drain.ts
+++ b/ui/src/pages/chat/chat-outbox-drain.ts
@@ -32,6 +32,7 @@ import {
   syncVisibleChatQueueProjection,
   updateQueuedMessageForSession,
 } from "./chat-queue.ts";
+import { clearAcceptedGoalComposerDraft } from "./chat-send-composer.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import {
   chatMessagesContainQueuedSend,
@@ -52,6 +53,8 @@ import { isChatBusy } from "./run-lifecycle.ts";
 export type QueuedChatSendResult = "sent" | "pending" | "failed";
 export type QueuedChatStorageMode = "durable" | "memory";
 export type QueuedChatSendOptions = {
+  /** Fires only after the Gateway confirms durable admission of this exact turn. */
+  onAccepted?: () => void;
   /** Fresh selected-session sends may let the Gateway resolve its effective active-run mode. */
   allowActiveRunSend?: boolean;
   /** Exact submit-time leaf; restored drains omit it so intervening advances park the draft. */
@@ -224,11 +227,17 @@ async function readCurrentStoredChatHistory(
   if (chatMessagesContainQueuedSend(history.messages, item)) {
     // Materialize server history locally before removing the queue bubble.
     preserveQueuedUserTurn(host, item);
+    const clearedAttachments =
+      item.intent?.kind === "session-goal-start" &&
+      visibleSessionMatches(host, outbox.sessionKey, outbox.agentId)
+        ? clearAcceptedGoalComposerDraft(host, item)
+        : [];
     const removed = removeQueuedMessageWithoutReleasing(host, item.id, outbox.sessionKey);
     if (!removed) {
       return "blocked";
     }
     releaseChatAttachmentPayloads(excludeComposerAttachments(host, removed.attachments));
+    releaseChatAttachmentPayloads(clearedAttachments);
     if (visibleSessionMatches(host, outbox.sessionKey, outbox.agentId)) {
       void loadChatHistory(host);
     }

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -1,4 +1,4 @@
-import type { ProgressCard } from "@openclaw/gateway-protocol";
+import { GATEWAY_SERVER_CAPS, type ProgressCard } from "@openclaw/gateway-protocol";
 import { html, nothing } from "lit";
 import { findInlineApproval } from "../../app/approval-presentation.ts";
 import { hasOperatorAdminAccess, hasOperatorWriteAccess } from "../../app/operator-access.ts";
@@ -14,7 +14,10 @@ import {
 } from "../../lib/chat/follow-up-mode.ts";
 import { isChatModelUnavailable } from "../../lib/chat/model-select-state.ts";
 import { formatUiError } from "../../lib/format-error.ts";
-import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
+import {
+  isGatewayCapabilityAdvertised,
+  isGatewayMethodAdvertised,
+} from "../../lib/gateway-methods.ts";
 import {
   pickFreshestObserverDigest,
   projectSessionObserverDigest,
@@ -25,6 +28,7 @@ import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import { buildAgentMainSessionKey } from "../../lib/sessions/session-key.ts";
 import { showToast } from "../../lib/toast.ts";
 import { generateUUID } from "../../lib/uuid.ts";
+import { createChatGoalManagementProps } from "./chat-goal-management.ts";
 import { clearChatHistory } from "./chat-history.ts";
 import { resolveChatMessageAccess } from "./chat-message-access.ts";
 import { requiresChatModelSetup } from "./chat-model-setup.ts";
@@ -289,6 +293,23 @@ export class ChatPane extends ChatPaneLayoutRender {
           toastAnchor: this,
           onModelSetup: () => this.context.navigate("model-setup"),
         });
+    const goalManagement =
+      !catalogKey && selectedSession?.goal && state.client
+        ? createChatGoalManagementProps(this, {
+            client: state.client,
+            sessions: state.sessions,
+            sessionKey: selectedSession.key,
+            agentId: currentAgentId,
+            goalId: selectedSession.goal.id,
+            canUpdate:
+              hasOperatorWriteAccess(gatewaySnapshot.hello?.auth ?? null) &&
+              isGatewayMethodAdvertised(gatewaySnapshot, "sessions.goal.update") === true,
+            canClear:
+              hasOperatorWriteAccess(gatewaySnapshot.hello?.auth ?? null) &&
+              isGatewayMethodAdvertised(gatewaySnapshot, "sessions.goal.clear") === true,
+            requestUpdate: () => state.requestUpdate?.(),
+          })
+        : undefined;
     const props: ChatProps = {
       transcript: this.transcript,
       paneId: this.presentationId,
@@ -599,7 +620,28 @@ export class ChatPane extends ChatPaneLayoutRender {
         onEditSubmit: sessionParticipationBlocked ? undefined : state.submitQueuedChatMessageEdit,
         onCancel: state.cancelQueuedChatMessageEdit,
       },
-      onGoalCommand: (command) => void state.handleSendChat(command),
+      goalManagement,
+      goalStartAvailable:
+        catalogKey || suggestionViewer || selectedSession?.goal
+          ? false
+          : hasOperatorWriteAccess(gatewaySnapshot.hello?.auth ?? null)
+            ? (isGatewayCapabilityAdvertised(
+                gatewaySnapshot,
+                GATEWAY_SERVER_CAPS.SESSION_GOAL_START,
+              ) ?? undefined)
+            : false,
+      onGoalCommand: hasOperatorWriteAccess(gatewaySnapshot.hello?.auth ?? null)
+        ? (command) => void state.handleSendChat(command)
+        : undefined,
+      onGoalStart: (onDurableAdmission, submissionAction) =>
+        void state.handleSendChat(
+          undefined,
+          {
+            intent: { kind: "session-goal-start", version: 1 },
+            onDurableAdmission,
+          },
+          submissionAction,
+        ),
       onCompanionQuestion: (question) => void this.submitSessionCompanionQuestion(question),
       onCompanionPrefill: this.prefillSessionCompanionQuestion,
       replyTarget: state.chatReplyTarget ?? null,

--- a/ui/src/pages/chat/chat-send-composer.ts
+++ b/ui/src/pages/chat/chat-send-composer.ts
@@ -1,6 +1,10 @@
+import { sha256 } from "@noble/hashes/sha2.js";
 import type { ChatAttachment, ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { visibleSessionMatches } from "../../lib/sessions/index.ts";
-import { releaseChatAttachmentPayloads } from "./attachment-payload-store.ts";
+import {
+  getChatAttachmentDataUrl,
+  releaseChatAttachmentPayloads,
+} from "./attachment-payload-store.ts";
 import {
   captureChatComposerMemoryFallbackOwnership,
   clearChatComposerMemoryFallback,
@@ -15,6 +19,42 @@ import {
 import type { ChatHost } from "./chat-send-contract.ts";
 import type { ChatPageHost } from "./chat-state-host.ts";
 import type { StoredChatOutboxScope } from "./composer-persistence.ts";
+
+export function goalComposerDraftSignature(
+  text: string,
+  attachments: readonly ChatAttachment[],
+): string {
+  const source = JSON.stringify([
+    text,
+    attachments.map((attachment) => [
+      attachment.mimeType,
+      attachment.fileName ?? "",
+      attachment.sizeBytes ?? -1,
+      attachment.browserAnnotation ?? null,
+      getChatAttachmentDataUrl(attachment),
+    ]),
+  ]);
+  return Array.from(sha256(new TextEncoder().encode(source)), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+export function clearAcceptedGoalComposerDraft(
+  host: ChatHost,
+  item: Pick<ChatQueueItem, "goalDraftSignature">,
+): ChatAttachment[] {
+  if (
+    !item.goalDraftSignature ||
+    item.goalDraftSignature !==
+      goalComposerDraftSignature(host.chatMessage.trim(), host.chatAttachments)
+  ) {
+    return [];
+  }
+  const attachments = host.chatAttachments;
+  host.chatMessage = "";
+  host.chatAttachments = [];
+  return attachments;
+}
 
 export type ChatCommandComposerRecovery = {
   client: ChatHost["client"];

--- a/ui/src/pages/chat/chat-send-delivery.ts
+++ b/ui/src/pages/chat/chat-send-delivery.ts
@@ -5,7 +5,10 @@ import { t } from "../../i18n/index.ts";
 import type { ChatQueueItem } from "../../lib/chat/chat-types.ts";
 import { scopedAgentIdForSession, visibleSessionMatches } from "../../lib/sessions/index.ts";
 import { generateUUID } from "../../lib/uuid.ts";
-import { discardChatAttachmentDataUrls } from "./attachment-payload-store.ts";
+import {
+  discardChatAttachmentDataUrls,
+  releaseChatAttachmentPayloads,
+} from "./attachment-payload-store.ts";
 import { readChatResetTargetAccess } from "./chat-commands.ts";
 import { loadChatBranches, loadChatHistory } from "./chat-history.ts";
 import {
@@ -27,7 +30,11 @@ import {
 } from "./chat-queue.ts";
 import { createResetSlashCommandSender } from "./chat-reset-delivery.ts";
 import { isTerminalFailureChatSendAck } from "./chat-send-ack.ts";
-import { cancelChatDelivery, canRestoreComposer } from "./chat-send-composer.ts";
+import {
+  cancelChatDelivery,
+  canRestoreComposer,
+  clearAcceptedGoalComposerDraft,
+} from "./chat-send-composer.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
 import {
   captureChatConnectionOwner,
@@ -285,6 +292,7 @@ async function sendQueuedChatMessage(
       runId,
       sessionKey,
       agentId: prepared.agentId,
+      ...(prepared.intent ? { intent: prepared.intent } : {}),
       ...(prepared.queueMode ? { queueMode: prepared.queueMode } : {}),
       ...(prepared.queueMode !== "steer" && options?.expectedLeafEntryId !== undefined
         ? { expectedLeafEntryId: options.expectedLeafEntryId }
@@ -343,6 +351,12 @@ async function sendQueuedChatMessage(
       });
       return "failed";
     }
+    if (prepared.intent?.kind === "session-goal-start" && isVisible()) {
+      const clearedAttachments = clearAcceptedGoalComposerDraft(host, prepared);
+      releaseChatAttachmentPayloads(clearedAttachments);
+      resetChatInputHistoryNavigation(host);
+    }
+    options?.onAccepted?.();
     const retireOnAck = ack.status === "ok" || storageMode === "memory";
     let retirementFailed = false;
     if (retireOnAck) {
@@ -453,6 +467,13 @@ async function sendQueuedChatMessage(
         err.message === "gateway not connected";
       const retryDelayMs = retryableGatewayDelayMs(err);
       const safelyRejected = failedBeforeTransport || retryDelayMs !== null;
+      if (prepared.intent?.kind === "session-goal-start" && safelyRejected && options?.onAccepted) {
+        removeQueuedMessageWithoutReleasing(host, id, sessionKey);
+        finishScopedChatSending(host, scope);
+        surfaceChatDeliveryFailure(host, sessionKey, prepared.agentId, error);
+        recordChatSendTiming(host, prepared, "failed", prepared.sendSubmittedAtMs, { error });
+        return "failed";
+      }
       const rollbackAttempt = safelyRejected
         ? {
             sendAttempts: queued.sendAttempts,

--- a/ui/src/pages/chat/chat-send-queue-state.ts
+++ b/ui/src/pages/chat/chat-send-queue-state.ts
@@ -42,6 +42,8 @@ export function enqueuePendingSendMessage(
   replyToId?: string,
   resumedOrderKey?: number,
   queueMode?: ChatQueueItem["queueMode"],
+  intent?: ChatQueueItem["intent"],
+  goalDraftSignature?: string,
 ): ChatQueueItem | null {
   const trimmed = text.trim();
   const hasAttachments = Boolean(attachments && attachments.length > 0);
@@ -62,6 +64,8 @@ export function enqueuePendingSendMessage(
     sendRunId: generateUUID(),
     sendState,
     ...(queueMode ? { queueMode } : {}),
+    ...(intent ? { intent } : {}),
+    ...(goalDraftSignature ? { goalDraftSignature } : {}),
     sendSubmittedAtMs: submittedAtMs,
     sessionKey: host.sessionKey,
     agentId: scopedAgentIdForSession(host, host.sessionKey),

--- a/ui/src/pages/chat/chat-send-request.ts
+++ b/ui/src/pages/chat/chat-send-request.ts
@@ -1,6 +1,6 @@
 import type { QueueMode } from "../../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import { GatewayRequestError } from "../../api/gateway.ts";
-import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import type { ChatAttachment, ChatSendIntent } from "../../lib/chat/chat-types.ts";
 import {
   isUiGlobalSessionKey,
   normalizeAgentId,
@@ -18,6 +18,7 @@ export async function requestChatSend(
     runId: string;
     sessionKey?: string;
     agentId?: string;
+    intent?: ChatSendIntent;
     queueMode?: QueueMode;
     replyToId?: string;
     expectedLeafEntryId?: string | null;
@@ -35,9 +36,9 @@ export async function requestChatSend(
     ...(routing.sessionId ? { sessionId: routing.sessionId } : {}),
     ...(controlUiReconnectResume ? { __controlUiReconnectResume: true } : {}),
     message: params.message,
-    deliver: false,
+    ...(params.intent ? { intent: params.intent } : { deliver: false }),
     ...(params.replyToId ? { replyToId: params.replyToId } : {}),
-    ...(params.queueMode ? { queueMode: params.queueMode } : {}),
+    ...(!params.intent && params.queueMode ? { queueMode: params.queueMode } : {}),
     ...(params.expectedLeafEntryId !== undefined
       ? { expectedLeafEntryId: params.expectedLeafEntryId }
       : {}),

--- a/ui/src/pages/chat/chat-send-submit.test.ts
+++ b/ui/src/pages/chat/chat-send-submit.test.ts
@@ -10,8 +10,11 @@ import {
 } from "./attachment-payload-store.ts";
 import { composeBrowserAnnotationContext } from "./browser-annotation-context.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
+import { retryQueuedChatMessage } from "./chat-send-actions.ts";
 import type { ChatHost } from "./chat-send-contract.ts";
+import { requestChatSend } from "./chat-send-request.ts";
 import { handleSendChat } from "./chat-send-submit.ts";
+import { loadChatComposerSnapshot } from "./composer-persistence.ts";
 
 const attachmentsToRelease: ChatAttachment[] = [];
 const attachmentDataUrl = "data:application/pdf;base64,JVBERi0xLjQK";
@@ -537,5 +540,205 @@ describe("handleSendChat session ownership", () => {
     expect(host.chatQueue).toEqual([]);
     expect(host.lastError).toBe("The active session is unavailable; refresh and try again.");
     expect(host.chatError).toBe(host.lastError);
+  });
+});
+
+describe("handleSendChat structured Goal start", () => {
+  const intent = { kind: "session-goal-start", version: 1 } as const;
+
+  it("shapes structured and ordinary chat.send controls independently", async () => {
+    const host = makeChatHost({
+      requestHandlers: { "chat.send": { runId: "request-shape", status: "started" } },
+    });
+
+    await requestChatSend(host, {
+      intent,
+      message: "Structured objective",
+      queueMode: "steer",
+      runId: "goal-request",
+    });
+    const goalPayload = findChatSendPayload(host);
+    expect(goalPayload.intent).toEqual(intent);
+    expect(goalPayload).not.toHaveProperty("deliver");
+    expect(goalPayload).not.toHaveProperty("queueMode");
+
+    host.request.mockClear();
+    await requestChatSend(host, {
+      message: "Ordinary message",
+      queueMode: "steer",
+      runId: "ordinary-request",
+    });
+    expect(findChatSendPayload(host)).toEqual({
+      sessionKey: "agent:main",
+      message: "Ordinary message",
+      deliver: false,
+      queueMode: "steer",
+      idempotencyKey: "ordinary-request",
+      attachments: undefined,
+    });
+  });
+
+  it("sends the raw objective without local command or browser annotation interpretation", async () => {
+    const annotation = createBrowserAnnotationAttachment("goal", "Do not prepend this context");
+    const onDurableAdmission = vi.fn();
+    const createChatSession = vi.fn(async () => true);
+    const host = makeChatHost({
+      requestHandlers: { "chat.send": { runId: "goal-run", status: "started" } },
+      createChatSession,
+    });
+
+    await handleSendChat(host, "/new\nFinish the migration", {
+      attachmentsOverride: [annotation],
+      intent,
+      onDurableAdmission,
+    });
+
+    expect(createChatSession).not.toHaveBeenCalled();
+    expect(onDurableAdmission).toHaveBeenCalledOnce();
+    expect(host.chatQueue[0]).toMatchObject({
+      intent,
+      text: "/new\nFinish the migration",
+    });
+    expect(host.chatQueue[0]).not.toHaveProperty("queueMode");
+    const payload = findChatSendPayload(host);
+    expect(payload).toMatchObject({
+      intent,
+      message: "/new\nFinish the migration",
+    });
+    expect(payload).not.toHaveProperty("deliver");
+    expect(payload).not.toHaveProperty("queueMode");
+  });
+
+  it("does not apply active-run queue policy to a Goal start", async () => {
+    const host = makeChatHost({
+      requestHandlers: { "chat.send": { runId: "goal-active-run", status: "started" } },
+      chatFollowUpMode: "queue",
+      chatRunId: "active-run",
+    });
+
+    await handleSendChat(host, "Start after the current work", { intent });
+
+    expect(host.chatQueue).toEqual([
+      expect.objectContaining({
+        intent,
+        sendState: "sending",
+        text: "Start after the current work",
+      }),
+    ]);
+    expect(host.chatQueue[0]).not.toHaveProperty("queueMode");
+    expect(findChatSendPayload(host)).not.toHaveProperty("queueMode");
+  });
+
+  it("retains caller-owned Goal input when durable admission fails", async () => {
+    const storage = createStorageMock();
+    vi.spyOn(storage, "setItem").mockImplementation(() => {
+      throw new DOMException("quota exceeded", "QuotaExceededError");
+    });
+    vi.stubGlobal("sessionStorage", storage);
+    const attachment = createStagedAttachment("goal-admission-failure");
+    const caller = {
+      mode: "goal" as const,
+      text: "Keep this objective",
+      attachments: [attachment],
+    };
+    const onDurableAdmission = vi.fn(() => {
+      caller.text = "";
+      caller.attachments = [];
+    });
+    const host = makeChatHost({
+      requestHandlers: { "chat.send": { runId: "must-not-send", status: "started" } },
+    });
+
+    await handleSendChat(host, caller.text, {
+      attachmentsOverride: caller.attachments,
+      intent,
+      onDurableAdmission,
+    });
+
+    expect(onDurableAdmission).not.toHaveBeenCalled();
+    expect(caller).toEqual({
+      mode: "goal",
+      text: "Keep this objective",
+      attachments: [attachment],
+    });
+    expect(getChatAttachmentDataUrl(caller.attachments[0]!)).toBe(attachmentDataUrl);
+    expect(host.request).not.toHaveBeenCalledWith("chat.send", expect.anything());
+    expect(host.chatQueue).toEqual([]);
+  });
+
+  it("keeps Goal input when the Gateway rejects before admission", async () => {
+    const caller = {
+      mode: "goal" as "chat" | "goal",
+      text: "Durably owned objective",
+      attachments: [createStagedAttachment("owned-goal")],
+    };
+    const host = makeChatHost({
+      requestHandlers: { "chat.send": { runId: "failed-goal", status: "error" } },
+    });
+
+    await handleSendChat(host, caller.text, {
+      attachmentsOverride: caller.attachments,
+      intent,
+      onDurableAdmission: () => {
+        caller.mode = "chat";
+        caller.text = "";
+        caller.attachments = [];
+      },
+    });
+
+    expect(caller).toEqual({
+      mode: "goal",
+      text: "Durably owned objective",
+      attachments: [expect.objectContaining({ id: "owned-goal" })],
+    });
+    expect(host.chatQueue).toEqual([
+      expect.objectContaining({
+        intent,
+        sendState: "failed",
+        text: "Durably owned objective",
+      }),
+    ]);
+  });
+
+  it("preserves intent through storage, reconnect, and retry", async () => {
+    const offline = makeChatHost({
+      requestHandlers: {},
+      connected: false,
+    });
+
+    await handleSendChat(offline, "Reconnect this Goal", { intent });
+
+    const restored = loadChatComposerSnapshot(offline, offline.sessionKey)?.queue;
+    expect(restored).toEqual([
+      expect.objectContaining({
+        intent,
+        sendState: "waiting-reconnect",
+        text: "Reconnect this Goal",
+      }),
+    ]);
+
+    const reconnected = makeChatHost({
+      requestHandlers: {
+        "chat.history": {
+          messages: [],
+          sessionInfo: {
+            key: "agent:main",
+            kind: "direct",
+            updatedAt: null,
+            hasActiveRun: false,
+            status: "done",
+          },
+        },
+        "chat.send": { runId: "reconnected-goal", status: "started" },
+      },
+      chatQueue: restored,
+    });
+
+    await retryQueuedChatMessage(reconnected, restored![0]!.id);
+
+    const payload = findChatSendPayload(reconnected);
+    expect(payload.intent).toEqual(intent);
+    expect(payload).not.toHaveProperty("deliver");
+    expect(payload).not.toHaveProperty("queueMode");
   });
 });

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -1,7 +1,7 @@
 import { shouldForwardModelCommandToServer } from "../../../../src/auto-reply/commands-registry.shared.js";
 import { normalizeChatFollowUpModeOverride, setLastActiveSessionKey } from "../../app/settings.ts";
 import { t } from "../../i18n/index.ts";
-import type { ChatAttachment } from "../../lib/chat/chat-types.ts";
+import type { ChatAttachment, ChatSendIntent } from "../../lib/chat/chat-types.ts";
 import { parseSlashCommand } from "../../lib/chat/commands.ts";
 import { extractCompanionCommandQuestion } from "../../lib/chat/companion-question.ts";
 import { resolveCurrentUserIdentity } from "../../lib/chat/current-user-identity.ts";
@@ -32,6 +32,7 @@ import {
   cancelChatDelivery,
   clearOwnedCommandComposerFallback,
   commandComposerFallbackRetainsAttachments,
+  goalComposerDraftSignature,
   restoreFailedCommandComposer,
   submittedCommandConnectionIsCurrent,
   submittedCommandScopeIsVisible,
@@ -72,6 +73,9 @@ import {
 type ChatSendSubmitOptions = {
   attachmentsOverride?: readonly ChatAttachment[];
   followUpMode?: ControlUiFollowUpMode;
+  intent?: ChatSendIntent;
+  /** Caller-owned Goal UI state may clear only after the outbox accepts the turn. */
+  onDurableAdmission?: () => void;
   /** Only the inline queued-row submit may resume and replace an edited row. */
   resumeQueuedMessageEditId?: string;
   restoreDraft?: boolean;
@@ -209,6 +213,10 @@ export async function handleSendChat(
     messageOverride == null ? host.chatAttachments : (opts?.attachmentsOverride ?? []),
   );
   const hasAttachments = attachmentsToSend.length > 0;
+  const structuredGoalStart = opts?.intent?.kind === "session-goal-start";
+  const goalDraftSignature = structuredGoalStart
+    ? goalComposerDraftSignature(userMessage, attachmentsToSend)
+    : undefined;
   const requestedEditId = opts?.resumeQueuedMessageEditId;
   const inlineEdit = requestedEditId ? activeQueuedMessageEdit(host) : null;
   if (requestedEditId != null && !inlineEdit) {
@@ -219,7 +227,7 @@ export async function handleSendChat(
   // Classify the operator's raw row draft before browser annotation context is
   // prepended. Otherwise annotation text can hide /stop, /compact, or a stop
   // alias from the inline-edit command fence.
-  const rawParsedCommand = parseSlashCommand(userMessage);
+  const rawParsedCommand = structuredGoalStart ? null : parseSlashCommand(userMessage);
   if (isInlineEditSubmission && (rawParsedCommand || isChatStopCommand(userMessage))) {
     setChatError(
       host,
@@ -230,9 +238,11 @@ export async function handleSendChat(
 
   // Commands own the raw composer text. Annotation context is model input and must not
   // turn a recognized command into an ordinary message.
-  const message = rawParsedCommand
+  const message = structuredGoalStart
     ? userMessage
-    : composeBrowserAnnotationContext(userMessage, attachmentsToSend);
+    : rawParsedCommand
+      ? userMessage
+      : composeBrowserAnnotationContext(userMessage, attachmentsToSend);
   // Slash commands may use ordinary files, but annotations belong to the next model prompt.
   const deliveredAttachments = rawParsedCommand
     ? attachmentsToSend.filter((attachment) => !attachment.browserAnnotation)
@@ -242,7 +252,7 @@ export async function handleSendChat(
     return;
   }
 
-  {
+  if (!structuredGoalStart) {
     // Natural stop aliases require a run; explicit /stop is always available.
     if (
       isChatStopCommand(userMessage) &&
@@ -466,7 +476,7 @@ export async function handleSendChat(
     }
   }
 
-  const replyTarget = isInlineEditSubmission ? null : host.chatReplyTarget;
+  const replyTarget = structuredGoalStart || isInlineEditSubmission ? null : host.chatReplyTarget;
   // Persisted ids use replyToId; synthetic replies fall back to a quote.
   const replyToId = isInlineEditSubmission
     ? inlineEdit.replyToId
@@ -474,7 +484,7 @@ export async function handleSendChat(
   const effectiveMessage =
     replyTarget && !replyToId ? prependReplyQuote(message, replyTarget) : message;
 
-  const refreshSessions = isChatResetCommand(message);
+  const refreshSessions = !structuredGoalStart && isChatResetCommand(message);
   // A row edit and a composer send may intentionally carry the same payload.
   // Keep their guards independent so submitting one cannot suppress the other.
   const submitKind = requestedEditId ? "queued-edit" : "message";
@@ -507,7 +517,7 @@ export async function handleSendChat(
       return;
     }
     const cleared =
-      messageOverride == null
+      messageOverride == null && !structuredGoalStart
         ? clearSubmittedComposerState(
             host,
             previousDraft,
@@ -528,7 +538,9 @@ export async function handleSendChat(
       host.chatFollowUpMode ??
       normalizeChatFollowUpModeOverride(host.settings?.chatFollowUpMode);
     const activeRunQueueMode =
-      directRunActive && followUpMode !== "queue" ? followUpMode : undefined;
+      !structuredGoalStart && directRunActive && followUpMode !== "queue"
+        ? followUpMode
+        : undefined;
     // The edited row hands its place to the replacement and is retired by the same
     // store write, so a rejected write leaves the original queued and editable.
     const resumedEdit =
@@ -543,6 +555,8 @@ export async function handleSendChat(
       replyToId,
       resumedEdit?.orderKey,
       activeRunQueueMode,
+      opts?.intent,
+      goalDraftSignature,
     );
     if (!queued) {
       return;
@@ -563,6 +577,7 @@ export async function handleSendChat(
     }
     const canSendFromMemory =
       !admittedDurably &&
+      !structuredGoalStart &&
       (!resumedEdit || !resumedEdit.sourceWasDurable) &&
       // A still-open edit means its stored source outlived the rejected write;
       // sending the replacement from memory would strand the original as a duplicate.
@@ -570,17 +585,30 @@ export async function handleSendChat(
       !waitingForSettings &&
       canSendVolatileQueueItem(host, queued, submittedSessionKey);
     if (!admittedDurably && !canSendFromMemory) {
-      cancelChatDelivery(host, queued, {
-        previousDraft: cleared.previousDraft,
-        previousAttachments: cleared.previousAttachments,
-      });
+      if (structuredGoalStart) {
+        removeQueuedMessageWithoutReleasing(host, queued.id);
+      } else {
+        cancelChatDelivery(host, queued, {
+          previousDraft: cleared.previousDraft,
+          previousAttachments: cleared.previousAttachments,
+        });
+      }
       setChatError(host, OFFLINE_QUEUE_STORAGE_ERROR);
       return;
     }
     const sendResult = await deliverChatQueueItem(host, queued, {
       previousDraft: cleared.previousDraft,
       previousAttachments: cleared.previousAttachments,
-      ...(directRunActive && followUpMode !== "queue" ? { allowActiveRunSend: true } : {}),
+      ...(structuredGoalStart && opts?.onDurableAdmission
+        ? {
+            onAccepted: () => {
+              opts.onDurableAdmission?.();
+            },
+          }
+        : {}),
+      ...(structuredGoalStart || (directRunActive && followUpMode !== "queue")
+        ? { allowActiveRunSend: true }
+        : {}),
       ...(expectedLeafEntryId !== undefined ? { expectedLeafEntryId } : {}),
       ...(pendingSettings ? { pendingSettings } : {}),
       restoreAttachments: Boolean(messageOverride && opts?.restoreDraft),

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -34,6 +34,7 @@ import {
   registerChatAttachmentPayload as registerStoredChatAttachmentPayload,
   releaseChatAttachmentPayloads,
 } from "./attachment-payload-store.ts";
+import { createChatGoalManagementProps } from "./chat-goal-management.ts";
 import * as chatProgress from "./chat-progress.ts";
 import { switchChatFastMode, switchChatModel, switchChatThinkingLevel } from "./chat-session.ts";
 import * as chatThread from "./chat-thread.ts";
@@ -1854,16 +1855,49 @@ describe("chat goal status", () => {
     expect(goal?.closest(".agent-chat__composer-status-stack")).toBeNull();
   });
 
-  it("dispatches goal commands from the pill controls", () => {
+  it("keeps textual goal controls when typed methods are unavailable", () => {
     const onGoalCommand = vi.fn();
     const container = renderChatView({ sessions: goalSessions(), onGoalCommand });
 
     container.querySelector<HTMLButtonElement>('button[aria-label="Pause goal"]')?.click();
+    container.querySelector<HTMLButtonElement>('button[aria-label="Complete goal"]')?.click();
     container.querySelector<HTMLButtonElement>('button[aria-label="Clear goal"]')?.click();
 
     expect(onGoalCommand).toHaveBeenNthCalledWith(1, "/goal pause");
-    expect(onGoalCommand).toHaveBeenNthCalledWith(2, "/goal clear");
+    expect(onGoalCommand).toHaveBeenNthCalledWith(2, "/goal complete");
+    expect(onGoalCommand).toHaveBeenNthCalledWith(3, "/goal clear");
     expect(container.querySelector('button[aria-label="Resume goal"]')).toBeNull();
+  });
+
+  it("uses typed management callbacks independently for advertised methods", () => {
+    const onGoalCommand = vi.fn();
+    const onDraftChange = vi.fn();
+    const onEditStart = vi.fn();
+    const onUpdate = vi.fn();
+    const container = renderChatView({
+      sessions: goalSessions(),
+      onGoalCommand,
+      onDraftChange,
+      goalManagement: {
+        pending: false,
+        error: null,
+        editObjective: null,
+        onEditStart,
+        onUpdate,
+      },
+    });
+
+    container.querySelector<HTMLButtonElement>('button[aria-label="Edit goal"]')?.click();
+    container.querySelector<HTMLButtonElement>('button[aria-label="Pause goal"]')?.click();
+    container.querySelector<HTMLButtonElement>('button[aria-label="Complete goal"]')?.click();
+    container.querySelector<HTMLButtonElement>('button[aria-label="Clear goal"]')?.click();
+
+    expect(onEditStart).toHaveBeenCalledWith("Land the web goal UI");
+    expect(onDraftChange).not.toHaveBeenCalled();
+    expect(onUpdate).toHaveBeenNthCalledWith(1, { action: "pause" });
+    expect(onUpdate).toHaveBeenNthCalledWith(2, { action: "complete" });
+    expect(onGoalCommand).toHaveBeenCalledOnce();
+    expect(onGoalCommand).toHaveBeenCalledWith("/goal clear");
   });
 
   it("offers resume instead of pause for paused goals", () => {
@@ -1936,6 +1970,187 @@ describe("chat goal status", () => {
 
     expect(container.querySelector('button[aria-label="Pause goal"]')).toBeNull();
     expect(container.querySelector('button[aria-label="Show goal details"]')).not.toBeNull();
+  });
+});
+
+describe("chat goal RPC management", () => {
+  const rpcGoal = {
+    schemaVersion: 1 as const,
+    id: "goal-1",
+    objective: "Land the web goal UI",
+    status: "active" as const,
+    createdAt: 1,
+    updatedAt: 2,
+    tokenStart: 0,
+    tokensUsed: 0,
+    continuationTurns: 0,
+  };
+
+  it("uses a fresh operation id for each RPC and projects successful results", async () => {
+    const updatedGoal = {
+      schemaVersion: 1 as const,
+      id: "goal-1",
+      objective: "Land the web goal UI",
+      status: "paused" as const,
+      createdAt: 1,
+      updatedAt: 2,
+      tokenStart: 0,
+      tokensUsed: 0,
+      continuationTurns: 0,
+      pausedAt: 2,
+    };
+    const request = vi.fn(async (method: string, params: { operationId: string }) =>
+      method === "sessions.goal.update"
+        ? { ok: true, sessionKey: "main", operationId: params.operationId, goal: updatedGoal }
+        : {
+            ok: true,
+            sessionKey: "main",
+            goalId: "goal-1",
+            operationId: params.operationId,
+          },
+    );
+    const patchRowLocal = vi.fn();
+    const target = {
+      client: { request } as unknown as GatewayBrowserClient,
+      sessions: { patchRowLocal },
+      sessionKey: "main",
+      agentId: "main",
+      goalId: "goal-1",
+      canUpdate: true,
+      canClear: true,
+      requestUpdate: vi.fn(),
+    };
+    const owner = {};
+
+    createChatGoalManagementProps(owner, target)?.onUpdate?.({ action: "pause" });
+    await vi.waitFor(() =>
+      expect(patchRowLocal).toHaveBeenCalledWith("main", { goal: updatedGoal }),
+    );
+    createChatGoalManagementProps(owner, target)?.onClear?.();
+    await vi.waitFor(() => expect(patchRowLocal).toHaveBeenCalledWith("main", { goal: undefined }));
+
+    expect(request).toHaveBeenNthCalledWith(1, "sessions.goal.update", {
+      sessionKey: "main",
+      agentId: "main",
+      goalId: "goal-1",
+      operationId: expect.any(String),
+      action: "pause",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "sessions.goal.clear", {
+      sessionKey: "main",
+      agentId: "main",
+      goalId: "goal-1",
+      operationId: expect.any(String),
+    });
+    expect(request.mock.calls[0]?.[1].operationId).not.toBe(request.mock.calls[1]?.[1].operationId);
+    expect(request.mock.calls.some(([method]) => method === "chat.send")).toBe(false);
+  });
+
+  it("keeps rejected edits available for retry with a visible error", async () => {
+    const target = {
+      client: {
+        request: vi.fn(async () => {
+          throw new Error("Goal changed; retry the request");
+        }),
+      } as unknown as GatewayBrowserClient,
+      sessions: { patchRowLocal: vi.fn() },
+      sessionKey: "main",
+      agentId: "main",
+      goalId: "goal-1",
+      canUpdate: true,
+      canClear: true,
+      requestUpdate: vi.fn(),
+    };
+    const owner = {};
+    const management = createChatGoalManagementProps(owner, target);
+    management?.onEditStart?.("Retry this objective");
+    createChatGoalManagementProps(owner, target)?.onUpdate?.({
+      action: "edit",
+      objective: "Retry this objective",
+    });
+
+    await vi.waitFor(() =>
+      expect(createChatGoalManagementProps(owner, target)).toMatchObject({
+        pending: false,
+        error: "Goal changed; retry the request",
+        editObjective: "Retry this objective",
+      }),
+    );
+    expect(target.sessions.patchRowLocal).not.toHaveBeenCalled();
+  });
+
+  it("keeps an edit and operation identity across reconnect retry", async () => {
+    const firstRequest = vi.fn(async (_method: string, _params: { operationId: string }) => {
+      throw new Error("Gateway disconnected");
+    });
+    const secondRequest = vi.fn(async (_method: string, params: { operationId: string }) => ({
+      ok: true,
+      sessionKey: "main",
+      operationId: params.operationId,
+      goal: rpcGoal,
+    }));
+    const target = {
+      client: { request: firstRequest } as unknown as GatewayBrowserClient,
+      sessions: { patchRowLocal: vi.fn() },
+      sessionKey: "main",
+      agentId: "main",
+      goalId: "goal-1",
+      canUpdate: true,
+      canClear: true,
+      requestUpdate: vi.fn(),
+    };
+    const owner = {};
+    const update = { action: "edit" as const, objective: "Retry this objective" };
+    const first = createChatGoalManagementProps(owner, target)!;
+    first.onEditStart?.(update.objective);
+    first.onUpdate?.(update);
+    await vi.waitFor(() => expect(firstRequest).toHaveBeenCalledOnce());
+    const operationId = firstRequest.mock.calls[0]![1].operationId;
+
+    target.client = { request: secondRequest } as unknown as GatewayBrowserClient;
+    const reconnected = createChatGoalManagementProps(owner, target)!;
+    expect(reconnected.editObjective).toBe(update.objective);
+    reconnected.onUpdate?.(update);
+    await vi.waitFor(() => expect(secondRequest).toHaveBeenCalledOnce());
+    expect(secondRequest.mock.calls[0]?.[1].operationId).toBe(operationId);
+  });
+
+  it.each([
+    { update: { action: "pause" as const }, expectedAction: "pause" },
+    { update: { action: "resume" as const }, expectedAction: "resume" },
+    { update: { action: "complete" as const }, expectedAction: "complete" },
+    {
+      update: { action: "edit" as const, objective: "Updated objective" },
+      expectedAction: "edit",
+    },
+  ])("sends typed $expectedAction updates directly", async ({ update, expectedAction }) => {
+    const request = vi.fn(async (_method: string, params: { operationId: string }) => ({
+      ok: true,
+      sessionKey: "main",
+      operationId: params.operationId,
+      goal: rpcGoal,
+    }));
+    const management = createChatGoalManagementProps(
+      {},
+      {
+        client: { request } as unknown as GatewayBrowserClient,
+        sessions: { patchRowLocal: vi.fn() },
+        sessionKey: "main",
+        agentId: "main",
+        goalId: "goal-1",
+        canUpdate: true,
+        canClear: true,
+        requestUpdate: vi.fn(),
+      },
+    );
+    management?.onUpdate?.(update);
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
+    expect(request.mock.calls[0]?.[0]).toBe("sessions.goal.update");
+    expect(request.mock.calls[0]?.[1]).toMatchObject({
+      action: expectedAction,
+      operationId: expect.any(String),
+    });
   });
 });
 

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -53,6 +53,7 @@ import type {
   CapabilityMenuProps,
   ChatComposerDisabledBanner,
   ChatComposerProps,
+  ChatGoalManagementProps,
   ChatQueuedEditProps,
 } from "./components/chat-composer-types.ts";
 import { isChatRunWorking, renderChatComposer } from "./components/chat-composer.ts";
@@ -239,7 +240,10 @@ export type ChatProps = ChatTaskSuggestionTrayProps &
     onQueueSteer?: (id: string) => void;
     onQueueMove?: (id: string, toIndex: number) => void;
     queuedEdit?: ChatQueuedEditProps;
+    goalManagement?: ChatGoalManagementProps;
+    goalStartAvailable?: boolean;
     onGoalCommand?: (command: string) => void;
+    onGoalStart?: ChatComposerProps["onGoalStart"];
     onHistoryIntent?: (event: Event) => void;
     onCompanionQuestion?: (question: string) => void;
     onCompanionPrefill?: (question: string) => void;
@@ -494,7 +498,10 @@ export function renderChat(props: ChatProps) {
     onQueueSteer: props.onQueueSteer,
     onQueueMove: props.onQueueMove,
     queuedEdit: props.queuedEdit,
+    goalManagement: props.goalManagement,
+    goalStartAvailable: props.goalStartAvailable,
     onGoalCommand: props.onGoalCommand,
+    onGoalStart: props.onGoalStart,
     onGatewayQuestionChange: props.onGatewayQuestionChange,
     onGatewayQuestionSubmit: props.onGatewayQuestionSubmit,
     onGatewayQuestionSkip: props.onGatewayQuestionSkip,

--- a/ui/src/pages/chat/components/chat-composer-command-activation.ts
+++ b/ui/src/pages/chat/components/chat-composer-command-activation.ts
@@ -38,6 +38,9 @@ export function resolveComposerCommandActivation(
     trigger,
     command,
     invocation,
+    placement: state.slashMenuCompletion?.inline ? "inline" : "standalone",
+    goal: host.goal,
+    goalStartAvailable: host.goalStartAvailable === true,
     resolveChoices: () => host.resolveArgOptions(command).map((value) => ({ value, label: value })),
   });
 }
@@ -72,6 +75,12 @@ export function applyComposerCommandActivation(
   } else if (plan.kind === "insert-text") {
     const acceptsTail = command.definition?.acceptsArgs === true;
     host.commitDraft(`${plan.invocation.text}${acceptsTail ? " " : ""}`);
+  } else if (plan.kind === "activate-composer-mode" && plan.mode.kind === "goal") {
+    host.commitDraft("");
+    host.activateGoalMode?.();
+  } else if (plan.kind === "open-surface" && plan.surface === "goal-management") {
+    host.commitDraft("");
+    host.openGoalManagement?.(plan.focus ?? "");
   }
   requestUpdate();
 }

--- a/ui/src/pages/chat/components/chat-composer-goal.ts
+++ b/ui/src/pages/chat/components/chat-composer-goal.ts
@@ -11,9 +11,11 @@ import {
   formatGoalUsage,
   goalElapsedMs,
 } from "../../../lib/session-goal.ts";
-import type { ChatComposerState } from "./chat-composer-types.ts";
+import { paneDomId } from "./chat-composer-dom.ts";
+import type { ChatComposerState, ChatGoalManagementProps } from "./chat-composer-types.ts";
 
 const goalElapsedTimers = new Map<HTMLElement, ReturnType<typeof setInterval>>();
+const focusedGoalEditInputs = new WeakSet<HTMLInputElement>();
 const goalIcon = strokeIcon(svg` <path d="M12 13V2l8 4-8 4" />
   <path d="M20.561 10.222a9 9 0 1 1-12.55-5.29" />
   <path d="M8.002 9.997a5 5 0 1 0 8.9 2.02" />`);
@@ -57,6 +59,8 @@ function createGoalElapsedRef(goal: SessionGoal) {
 
 type ChatGoalActions = {
   canAct: boolean;
+  paneId: string;
+  management?: ChatGoalManagementProps;
   onGoalCommand?: (command: string) => void;
   onGoalEdit?: (goal: SessionGoal) => void;
   requestUpdate: () => void;
@@ -66,6 +70,7 @@ function renderChatGoalActionButton(options: {
   className: string;
   label: string;
   icon: TemplateResult;
+  disabled?: boolean;
   onClick: () => void;
 }): TemplateResult {
   return html`
@@ -74,6 +79,7 @@ function renderChatGoalActionButton(options: {
         class="agent-chat__goal-action ${options.className}"
         type="button"
         aria-label=${options.label}
+        ?disabled=${options.disabled}
         @click=${options.onClick}
       >
         ${options.icon}
@@ -93,7 +99,11 @@ export function renderChatGoal(
   const elapsed = formatGoalElapsed(goalElapsedMs(goal, Date.now()));
   const usage = formatGoalUsage(goal);
   const expanded = state.goalExpandedId === goal.id;
-  const showActions = actions.canAct && Boolean(actions.onGoalCommand);
+  const management = actions.management;
+  const pending = management?.pending === true;
+  const editing = management?.editObjective !== null && management?.editObjective !== undefined;
+  const canUpdate = actions.canAct && Boolean(management?.onUpdate || actions.onGoalCommand);
+  const canClear = actions.canAct && Boolean(management?.onClear || actions.onGoalCommand);
   const canResume =
     goal.status === "paused" ||
     goal.status === "blocked" ||
@@ -103,12 +113,37 @@ export function renderChatGoal(
     state.goalExpandedId = expanded ? null : goal.id;
     actions.requestUpdate();
   };
+  const updateGoal = (action: "pause" | "resume" | "complete") => {
+    if (management?.onUpdate) {
+      management.onUpdate({ action });
+      return;
+    }
+    actions.onGoalCommand?.(`/goal ${action}`);
+  };
+  const editGoal = () => {
+    if (management?.onUpdate && management.onEditStart) {
+      management.onEditStart(goal.objective);
+      return;
+    }
+    actions.onGoalEdit?.(goal);
+  };
+  const clearGoal = () => {
+    if (management?.onClear) {
+      management.onClear();
+      return;
+    }
+    actions.onGoalCommand?.("/goal clear");
+  };
+  const detailExpanded = expanded || editing;
   return html`
     <div
       class="agent-chat__goal agent-chat__goal--${goal.status}"
-      data-expanded=${String(expanded)}
+      data-expanded=${String(detailExpanded)}
       role="group"
+      id=${paneDomId(actions.paneId, "goal-management")}
       aria-label=${formatGoalDetail(goal)}
+      aria-busy=${pending ? "true" : "false"}
+      tabindex="-1"
     >
       <div class="agent-chat__goal-row">
         <span class="agent-chat__goal-icon">${goalIcon}</span>
@@ -118,36 +153,52 @@ export function renderChatGoal(
         </span>
         <span class="agent-chat__goal-elapsed" ${ref(createGoalElapsedRef(goal))}></span>
         <span class="agent-chat__goal-actions">
-          ${showActions && actions.onGoalEdit && goal.status !== "complete"
+          ${canUpdate &&
+          (management?.onEditStart || actions.onGoalEdit) &&
+          goal.status !== "complete" &&
+          !editing
             ? renderChatGoalActionButton({
                 className: "agent-chat__goal-edit",
                 label: t("chat.goals.edit"),
                 icon: icons.penLine,
-                onClick: () => actions.onGoalEdit?.(goal),
+                disabled: pending,
+                onClick: editGoal,
               })
             : nothing}
-          ${showActions && goal.status === "active"
+          ${canUpdate && goal.status === "active"
             ? renderChatGoalActionButton({
                 className: "agent-chat__goal-pause",
                 label: t("chat.goals.pause"),
                 icon: icons.pause,
-                onClick: () => actions.onGoalCommand?.("/goal pause"),
+                disabled: pending,
+                onClick: () => updateGoal("pause"),
               })
             : nothing}
-          ${showActions && canResume
+          ${canUpdate && canResume
             ? renderChatGoalActionButton({
                 className: "agent-chat__goal-resume",
                 label: t("chat.goals.resume"),
                 icon: icons.play,
-                onClick: () => actions.onGoalCommand?.("/goal resume"),
+                disabled: pending,
+                onClick: () => updateGoal("resume"),
               })
             : nothing}
-          ${showActions
+          ${canUpdate && goal.status !== "complete"
+            ? renderChatGoalActionButton({
+                className: "agent-chat__goal-complete",
+                label: t("chat.goals.complete"),
+                icon: icons.check,
+                disabled: pending,
+                onClick: () => updateGoal("complete"),
+              })
+            : nothing}
+          ${canClear
             ? renderChatGoalActionButton({
                 className: "agent-chat__goal-clear",
                 label: t("chat.goals.clear"),
                 icon: icons.trash,
-                onClick: () => actions.onGoalCommand?.("/goal clear"),
+                disabled: pending,
+                onClick: clearGoal,
               })
             : nothing}
           <button
@@ -155,20 +206,72 @@ export function renderChatGoal(
             type="button"
             aria-expanded=${expanded ? "true" : "false"}
             aria-label=${t(expanded ? "chat.goals.hideDetails" : "chat.goals.showDetails")}
+            ?disabled=${pending}
             @click=${toggleExpanded}
           >
             ${expanded ? icons.chevronDown : icons.chevronRight}
           </button>
         </span>
       </div>
+      ${management?.error
+        ? html`<div class="agent-chat__goal-detail-note" role="alert">${management.error}</div>`
+        : nothing}
       <div
         class="agent-chat__goal-detail"
-        data-expanded=${String(expanded)}
-        aria-hidden=${String(!expanded)}
-        ?inert=${!expanded}
+        data-expanded=${String(detailExpanded)}
+        aria-hidden=${String(!detailExpanded)}
+        ?inert=${!detailExpanded}
       >
         <div class="agent-chat__goal-detail-content">
-          <div class="agent-chat__goal-detail-objective">${goal.objective}</div>
+          ${editing
+            ? html`<form
+                @submit=${(event: SubmitEvent) => {
+                  event.preventDefault();
+                  const objective = management.editObjective?.trim();
+                  if (objective) {
+                    management.onUpdate?.({ action: "edit", objective });
+                  }
+                }}
+              >
+                <input
+                  class="agent-chat__goal-edit-input"
+                  aria-label=${t("chat.goals.edit")}
+                  .value=${management.editObjective ?? ""}
+                  ?disabled=${pending}
+                  ${ref((element) => {
+                    if (
+                      element instanceof HTMLInputElement &&
+                      !focusedGoalEditInputs.has(element)
+                    ) {
+                      focusedGoalEditInputs.add(element);
+                      queueMicrotask(() => element.focus({ preventScroll: true }));
+                    }
+                  })}
+                  @input=${(event: InputEvent) => {
+                    if (event.currentTarget instanceof HTMLInputElement) {
+                      management.onEditChange?.(event.currentTarget.value);
+                    }
+                  }}
+                />
+                <button
+                  class="agent-chat__goal-action"
+                  type="submit"
+                  aria-label=${t("common.save")}
+                  ?disabled=${pending || !management.editObjective?.trim()}
+                >
+                  ${icons.check}
+                </button>
+                <button
+                  class="agent-chat__goal-action"
+                  type="button"
+                  aria-label=${t("common.cancel")}
+                  ?disabled=${pending}
+                  @click=${management.onEditCancel}
+                >
+                  ${icons.x}
+                </button>
+              </form>`
+            : html`<div class="agent-chat__goal-detail-objective">${goal.objective}</div>`}
           ${goal.lastStatusNote
             ? html`<div class="agent-chat__goal-detail-note">${goal.lastStatusNote}</div>`
             : nothing}

--- a/ui/src/pages/chat/components/chat-composer-keydown.ts
+++ b/ui/src/pages/chat/components/chat-composer-keydown.ts
@@ -62,6 +62,13 @@ export function createComposerKeyDownHandler({
       return;
     }
 
+    if (event.key === "Escape" && state.goalMode) {
+      event.preventDefault();
+      state.goalMode = false;
+      requestUpdate();
+      return;
+    }
+
     if ((event.key === "ArrowUp" || event.key === "ArrowDown") && props.onHistoryKeydown) {
       commitDraft(target.value);
       const result = props.onHistoryKeydown({
@@ -132,7 +139,12 @@ export function createComposerKeyDownHandler({
       event.preventDefault();
       commitDraft(target.value);
       const steerImmediately = steerNowEnabled && (event.metaKey || event.ctrlKey) && !event.altKey;
-      if (steerImmediately) {
+      if (state.goalMode && props.onGoalStart) {
+        props.onGoalStart(() => {
+          state.goalMode = false;
+          requestUpdate();
+        }, event);
+      } else if (steerImmediately) {
         props.onSend("steer", event);
       } else {
         props.onSend(undefined, event);

--- a/ui/src/pages/chat/components/chat-composer-slash-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-slash-menu.ts
@@ -54,6 +54,10 @@ export type SlashMenuHost = {
   runInlineCommand?: (command: string) => void;
   refreshCommands?: () => void | Promise<void>;
   commandFilter?: (command: SlashCommandDef) => boolean;
+  goal?: { id: string };
+  goalStartAvailable?: boolean;
+  activateGoalMode?: () => void;
+  openGoalManagement?: (goalId: string) => void;
 };
 export function resetSlashMenuState(state: SlashMenuState): void {
   state.slashMenuOpen = false;

--- a/ui/src/pages/chat/components/chat-composer-state.ts
+++ b/ui/src/pages/chat/components/chat-composer-state.ts
@@ -18,6 +18,7 @@ function createChatComposerState(): ChatComposerState {
     composerInputIntentKey: null,
     pendingClearedSubmittedDraft: null,
     goalExpandedId: null,
+    goalMode: false,
     activeGatewayQuestionId: null,
     gatewayQuestionCollapsed: false,
     questionTakeoverActive: false,

--- a/ui/src/pages/chat/components/chat-composer-types.ts
+++ b/ui/src/pages/chat/components/chat-composer-types.ts
@@ -39,6 +39,21 @@ export type ChatQueuedEditProps = {
 
 export type CapabilityMenuProps = ChatComposerCapabilityMenuProps;
 
+export type ChatGoalUpdate =
+  | { action: "pause" | "resume" | "complete" }
+  | { action: "edit"; objective: string };
+
+export type ChatGoalManagementProps = {
+  pending: boolean;
+  error: string | null;
+  editObjective: string | null;
+  onEditStart?: (objective: string) => void;
+  onEditChange?: (objective: string) => void;
+  onEditCancel?: () => void;
+  onUpdate?: (update: ChatGoalUpdate) => void;
+  onClear?: () => void;
+};
+
 type ChatComposerDisabledBannerContent = {
   title?: string;
   text: string;
@@ -134,8 +149,12 @@ export type ChatComposerProps = ChatAttachmentControlsProps & {
   onQueueSteer?: (id: string) => void;
   onQueueMove?: (id: string, toIndex: number) => void;
   queuedEdit?: ChatQueuedEditProps;
+  goalManagement?: ChatGoalManagementProps;
+  /** True when supported, false when explicitly unavailable, undefined while reconnecting. */
+  goalStartAvailable?: boolean;
   onClearReply?: () => void;
   onGoalCommand?: (command: string) => void;
+  onGoalStart?: (onDurableAdmission: () => void, submissionAction?: Event) => void;
   onGatewayQuestionChange?: () => void;
   onGatewayQuestionSubmit?: (id: string, answers: Record<string, string[]>) => void | Promise<void>;
   onGatewayQuestionSkip?: (id: string) => void | Promise<void>;
@@ -158,6 +177,7 @@ export type ChatComposerState = SkillMenuState &
     composerInputIntentKey: string | null;
     pendingClearedSubmittedDraft: PendingClearedSubmittedDraft | null;
     goalExpandedId: string | null;
+    goalMode: boolean;
     activeGatewayQuestionId: string | null;
     gatewayQuestionCollapsed: boolean;
     questionTakeoverActive: boolean;

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -290,6 +290,8 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
     ? html`<div class="agent-chat__goal-float">
         ${renderChatGoal(state, activeSession.goal, {
           canAct: props.connected && canCompose,
+          paneId: props.paneId,
+          management: props.goalManagement,
           onGoalCommand: props.onGoalCommand,
           onGoalEdit: (updatedGoal) => {
             commitComposerDraft(props, `/goal edit ${updatedGoal.objective}`);
@@ -349,6 +351,24 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
             ${skillMenuVisible ? renderSkillMenu(state, skillMenuHost, requestUpdate) : nothing}
             <div class="agent-chat__composer-lede">
               ${renderAttachmentPreview(props)}
+              ${state.goalMode
+                ? html`<div class="agent-chat__goal-mode" role="status">
+                    <span>${t("chat.goals.modeLabel")}</span>
+                    <button
+                      type="button"
+                      class="agent-chat__goal-mode-dismiss"
+                      aria-label=${t("chat.goals.removeMode")}
+                      title=${t("chat.goals.removeMode")}
+                      @click=${() => {
+                        state.goalMode = false;
+                        state.restoreComposerFocus = true;
+                        requestUpdate();
+                      }}
+                    >
+                      ${icons.x}
+                    </button>
+                  </div>`
+                : nothing}
               ${props.replyTarget
                 ? html`
                     <div class="chat-reply-preview">

--- a/ui/src/pages/chat/components/chat-composer.ts
+++ b/ui/src/pages/chat/components/chat-composer.ts
@@ -100,6 +100,9 @@ export function renderChatComposer(props: ChatComposerProps) {
   const activeSession = props.sessions?.sessions?.find((row) =>
     areUiSessionKeysEquivalent(row.key, props.sessionKey),
   );
+  if (state.goalMode && (props.goalStartAvailable === false || activeSession?.goal)) {
+    state.goalMode = false;
+  }
   const draftKey = composerDraftKey(props);
   if (state.dictationDraftKey !== null && state.dictationDraftKey !== draftKey) {
     state.dictation?.dispose();
@@ -190,6 +193,23 @@ export function renderChatComposer(props: ChatComposerProps) {
     canRunInlineCommand: () => state.slashCommandDispatchConnected && Boolean(props.onSlashCommand),
     runInlineCommand: props.connected ? props.onSlashCommand : undefined,
     refreshCommands: props.onSlashIntent,
+    goal: activeSession?.goal ? { id: activeSession.goal.id } : undefined,
+    goalStartAvailable: props.goalStartAvailable,
+    activateGoalMode: () => {
+      state.goalMode = true;
+      state.restoreComposerFocus = true;
+      requestUpdate();
+    },
+    openGoalManagement: (goalId) => {
+      state.goalExpandedId = goalId;
+      requestUpdate();
+      queueMicrotask(() => {
+        const shell = state.composerInput?.closest(".agent-chat__composer-shell");
+        shell
+          ?.querySelector<HTMLElement>(`#${CSS.escape(paneDomId(props.paneId, "goal-management"))}`)
+          ?.focus({ preventScroll: true });
+      });
+    },
   };
   const sendShortcut = normalizeChatSendShortcut(props.sendShortcut);
   const steerNowEnabled =
@@ -269,9 +289,11 @@ export function renderChatComposer(props: ChatComposerProps) {
   state.questionTakeoverActive = questionTakeoverActive;
   const showComposer = !questionTakeoverActive;
 
-  const placeholder = hasVisualAttachments
-    ? t("chat.composer.placeholderWithAttachments")
-    : t("chat.composer.placeholder", { name: props.assistantName || "agent" });
+  const placeholder = state.goalMode
+    ? t("chat.goals.modePlaceholder")
+    : hasVisualAttachments
+      ? t("chat.composer.placeholderWithAttachments")
+      : t("chat.composer.placeholder", { name: props.assistantName || "agent" });
 
   // Offline text and attachments may enter the persisted reconnect queue, but
   // slash commands are live controls and must not execute against stale state.
@@ -280,6 +302,7 @@ export function renderChatComposer(props: ChatComposerProps) {
     state.dictation?.locksComposer !== true &&
     !(state.skillMenuOpen && state.skillCommandRefreshPending) &&
     (props.getPendingAttachmentReads?.() ?? props.pendingAttachmentReads ?? 0) === 0 &&
+    (!state.goalMode || (Boolean(draft.trim()) && Boolean(props.onGoalStart))) &&
     (props.connected || !draft.trimStart().startsWith("/"));
 
   const syncComposerDraftAfterSend = (target: HTMLTextAreaElement | null) => {
@@ -399,7 +422,14 @@ export function renderChatComposer(props: ChatComposerProps) {
     state.composingDraft = null;
     commitComposerDraft(props, draft);
     props.onTypingChange?.(false);
-    props.onSend(undefined, submissionAction);
+    if (state.goalMode && props.onGoalStart) {
+      props.onGoalStart(() => {
+        state.goalMode = false;
+        requestUpdate();
+      }, submissionAction);
+    } else {
+      props.onSend(undefined, submissionAction);
+    }
     syncComposerDraftAfterSend(state.composerTextarea);
   };
   state.microphonePicker ??= new ComposerMicrophonePicker(requestUpdate);

--- a/ui/src/styles/chat/composer-progress.css
+++ b/ui/src/styles/chat/composer-progress.css
@@ -404,6 +404,38 @@
   border-color: color-mix(in srgb, var(--text-strong) 11%, var(--border));
 }
 
+.agent-chat__goal-mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  margin: 8px 8px 0;
+  padding: 4px 6px 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--text);
+  background: var(--card);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.agent-chat__goal-mode-dismiss {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  color: var(--muted);
+  background: transparent;
+}
+
+.agent-chat__goal-mode-dismiss:hover {
+  color: var(--text);
+  background: var(--secondary);
+}
+
 .agent-chat__goal--active .agent-chat__goal-icon,
 .agent-chat__goal--active .agent-chat__goal-actions {
   color: var(--muted);


### PR DESCRIPTION
Related: #131063

Stacked on #131245; merge via stack.

## What Problem This Solves

The Control UI still presents Goal as slash-command grammar. Starting a Goal exposes `/goal start ...` mechanics, and the existing edit/pause/resume/clear controls create visible command turns instead of directly managing the persisted Goal.

## Why This Change Was Made

This adds a Goal interaction provider to the activation-plan registry. Bare typed or sheet-selected `/goal` enters a pane-and-session-scoped composer mode when `session-goal-start-v1` is advertised, or opens and focuses management when a Goal already exists. Explicit command tails and capability absence remain visible textual paths.

Goal mode sends the human objective with the structured intent, carries intent and a content-bound draft signature through the durable outbox, and clears matching composer state only after the Gateway confirms admission or history reconciliation proves it. Existing Goal controls call typed update/clear RPCs when their exact methods and `operator.write` are available; otherwise their textual fallback remains visible.

## User Impact

Operators can select Goal, write multiline human text with normal composer attachments, and send once without a slash-command turn. The removable Goal chip, contextual placeholder, keyboard Escape, submitting state, failure preservation, reload behavior, and mobile layout all retain normal composer semantics.

Existing and completed Goals open the management surface. Edit, pause, resume, complete, and clear use direct typed mutations and no longer create visible command turns on the supported path. Manually typed `/goal ...` commands remain unchanged in every client and channel.

## Evidence

- Focused UI suites — 665 passed across activation, outbox, mode, management, send, and chat-view owners.
- Mocked-Gateway browser E2E — 8 passed: pointer/typed activation, structured payload, ACK lifecycle, visible failure, existing-Goal focus, typed management, textual fallback, reload, desktop, and mobile.
- `pnpm ui:build` — passed; startup and largest-chunk budgets remained within limits.
- `node scripts/run-tsgo.mjs -p tsconfig.ui.json` — passed.
- UI i18n, stylelint, type-aware oxlint, dead-export, import-cycle, and remaining changed gates — passed.
- Fresh autoreview — no accepted/actionable P0 findings, correctness 0.98.
- Independent final P0/P1 review — no findings.

Visual proof was captured from the real Control UI in Chromium against the mocked Gateway and inspected before upload. It covers normal, mode, submitting, failure, active, edit management, desktop, and mobile states. The video shows Goal submission retaining the visible human objective while admission is pending.

### Surface

| Area | Added | Removed |
| --- | ---: | ---: |
| Production | 605 | 47 |
| Tests | 965 | 5 |

Production growth adds the Goal provider/mode owner, replay-safe composer/outbox lifecycle, typed management controller, accessibility states, and responsive styling. No textual command path was removed.
