### PR TITLE
refactor(infra): unify Unix listener inspection

### DIFF
--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -384,9 +384,11 @@ async function readUnixListenersFromSs(port: number): Promise<ListenerReadResult
   return { listeners: [], detail: undefined, errors };
 }
 
-async function readUnixListenerSnapshot(): Promise<UnixListenerSnapshot> {
+async function readUnixListenerSnapshot(port?: number): Promise<UnixListenerSnapshot> {
   const lsof = await resolveLsofCommand();
-  const res = await runCommandSafe([lsof, "-nP", "-iTCP", "-sTCP:LISTEN", "-FpFcn"]);
+  // Keep single-port lifecycle checks targeted; batches share one all-port scan.
+  const tcpSelector = port === undefined ? "-iTCP" : `-iTCP:${port}`;
+  const res = await runCommandSafe([lsof, "-nP", tcpSelector, "-sTCP:LISTEN", "-FpFcn"]);
   if (res.code === 0) {
     return {
       recordsByPort: parseLsofListenerRecordsByPort(res.stdout),
@@ -409,60 +411,15 @@ async function readUnixListenerSnapshot(): Promise<UnixListenerSnapshot> {
   return { recordsByPort: new Map(), errors, lsofUnavailable: true };
 }
 
-async function readUnixListenersFromLsof(port: number): Promise<
-  ListenerReadResult & {
-    lsofUnavailable: boolean;
-  }
-> {
-  const lsof = await resolveLsofCommand();
-  const res = await runCommandSafe([lsof, "-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-FpFcn"]);
-  if (res.code === 0) {
-    const result = readLsofListenersForPort(parseLsofListenerRecordsByPort(res.stdout), port);
-    await enrichUnixListenerProcessInfo(result.listeners);
-    return { ...result, errors: [], lsofUnavailable: false };
-  }
-
-  const errors: string[] = [];
-  const stderr = res.stderr.trim();
-  if (res.code === 1 && !res.error && !stderr) {
-    return { listeners: [], detail: undefined, errors, lsofUnavailable: false };
-  }
-  if (res.error) {
-    errors.push(res.error);
-  }
-  const detail = [stderr, res.stdout.trim()].filter(Boolean).join("\n");
-  if (detail) {
-    errors.push(detail);
-  }
-  return { listeners: [], detail: undefined, errors, lsofUnavailable: true };
-}
-
 async function readUnixListeners(
   port: number,
   snapshot?: UnixListenerSnapshot,
 ): Promise<ListenerReadResult> {
-  if (snapshot) {
-    if (!snapshot.lsofUnavailable) {
-      const result = readLsofListenersForPort(snapshot.recordsByPort, port);
-      await enrichUnixListenerProcessInfo(result.listeners);
-      return { ...result, errors: snapshot.errors };
-    }
-
-    const ssFallback = await readUnixListenersFromSs(port);
-    if (ssFallback.listeners.length > 0) {
-      return ssFallback;
-    }
-
-    return {
-      listeners: [],
-      detail: undefined,
-      errors: [...snapshot.errors, ...ssFallback.errors],
-    };
-  }
-
-  const lsofResult = await readUnixListenersFromLsof(port);
-  if (!lsofResult.lsofUnavailable) {
-    return lsofResult;
+  const listenerSnapshot = snapshot ?? (await readUnixListenerSnapshot(port));
+  if (!listenerSnapshot.lsofUnavailable) {
+    const result = readLsofListenersForPort(listenerSnapshot.recordsByPort, port);
+    await enrichUnixListenerProcessInfo(result.listeners);
+    return { ...result, errors: listenerSnapshot.errors };
   }
   const ssFallback = await readUnixListenersFromSs(port);
   if (ssFallback.listeners.length > 0) {
@@ -471,7 +428,7 @@ async function readUnixListeners(
   return {
     listeners: [],
     detail: undefined,
-    errors: [...lsofResult.errors, ...ssFallback.errors],
+    errors: [...listenerSnapshot.errors, ...ssFallback.errors],
   };
 }
 

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -331,7 +331,7 @@ describeUnix("inspectPortUsage", () => {
     }
   });
 
-  it("falls back to ss when lsof is unavailable", async () => {
+  it.each(["single", "batch"])("falls back to ss when lsof is unavailable (%s)", async (mode) => {
     const server = net.createServer();
     const address = await listenServer(server, 0, "127.0.0.1");
     if (!address) {
@@ -350,12 +350,73 @@ describeUnix("inspectPortUsage", () => {
     });
 
     try {
-      const result = await inspectPortUsage(port);
-      expect(result.status).toBe("busy");
-      expect(result.listeners.length).toBeGreaterThan(0);
-      expect(result.listeners[0]?.pid).toBe(process.pid);
-      expect(result.listeners[0]?.commandLine).toContain("openclaw");
-      expect(result.errors).toBeUndefined();
+      const result =
+        mode === "single"
+          ? await inspectPortUsage(port)
+          : (await inspectPortUsages([port])).get(port);
+      expect(result).toBeDefined();
+      expect(result?.status).toBe("busy");
+      expect(result?.listeners.length).toBeGreaterThan(0);
+      expect(result?.listeners[0]?.pid).toBe(process.pid);
+      expect(result?.listeners[0]?.commandLine).toContain("openclaw");
+      expect(result?.errors).toBeUndefined();
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it.each(
+    [
+      { name: "successful empty scan", lsof: commandOutput(""), ssCalls: 0 },
+      { name: "quiet exit one", lsof: commandOutput("ignored output", 1, " \n"), ssCalls: 0 },
+      {
+        name: "nonzero empty scan",
+        lsof: commandOutput("", 2),
+        ssCalls: 1,
+      },
+      {
+        name: "unavailable lsof with an empty fallback",
+        lsof: new Error("lsof unavailable"),
+        ssCalls: 1,
+        errors: ["Error: lsof unavailable"],
+      },
+      {
+        name: "both commands failing",
+        lsof: commandOutput("lsof output\n", 1, "lsof error\n"),
+        ss: commandOutput("ss output\n", 2, "ss error\n"),
+        ssCalls: 1,
+        errors: ["lsof error\nlsof output", "ss error\nss output"],
+      },
+    ].flatMap((scenario) =>
+      ["single", "batch"].map((mode) => ({ name: scenario.name, scenario, mode })),
+    ),
+  )("preserves $name diagnostics ($mode)", async ({ scenario, mode }) => {
+    const { lsof, ss, ssCalls, errors } = scenario;
+    const server = net.createServer();
+    const address = await listenServer(server, 0, "127.0.0.1");
+    if (!address) {
+      return;
+    }
+    mockUnixCommands({ lsof, ss });
+
+    try {
+      const result =
+        mode === "single"
+          ? await inspectPortUsage(address.port)
+          : (await inspectPortUsages([address.port])).get(address.port);
+      expect(result).toMatchObject({
+        port: address.port,
+        status: "busy",
+        listeners: [],
+        detail: undefined,
+        errors,
+      });
+      expect(result?.hints).toContain(
+        "Port is in use but process details are unavailable (install lsof or run as an admin user).",
+      );
+      expect(
+        runCommandWithTimeoutMock.mock.calls.filter(([argv]) => argv[0] === "ss"),
+      ).toHaveLength(ssCalls);
     } finally {
       await closeServer(server);
     }


### PR DESCRIPTION
## What Problem This Solves

Unix port inspection maintained separate single-port and batch listener flows with duplicated `lsof` parsing, fallback, enrichment, and error projection. The two paths represented the same listener contract, which made future fixes easy to apply to only one mode.

## Why This Change Was Made

The existing private snapshot reader now owns `lsof` acquisition and exit classification for both modes, while `readUnixListeners` owns one enrichment, `ss` fallback, and error-projection flow. Single-port inspection still uses a targeted `-iTCP:<port>` query; batch inspection still uses one `-iTCP` scan. The duplicate private implementation and fallback branch are removed.

## User Impact

No user-visible behavior, public API, configuration, protocol, dependency, or platform policy changes. Unix single-port and batch inspection retain their existing query scope, listener ordering, PID attribution, fallback semantics, and error ordering. Windows behavior is untouched.

## Evidence

- Pre-change owner baseline: 132 passed, with 1 native-Windows-only case skipped.
- Strengthened pre-change characterization: 47 passed, with 1 native-Windows-only case skipped.
- Final owner and sibling proof: 143 passed, with 1 native-Windows-only case skipped across port inspection, `lsof`, bind probes, formatting, and daemon status.
- Native source smoke: two session-owned ephemeral listeners matched exactly across single-port and batch inspection, retained the owning PID, deduplicated duplicate input, and closed cleanly.
- Complete changed-file gate passed, including full core/core-test types, lint, Knip export scans, guards, and import-cycle checks.
- Fresh isolated P0 Codex review reported no findings.
- Production LOC: +10/-53 (net -43). Tests: +68/-7 (net +61).
- Full build was not run because this is a private in-file flow consolidation with unchanged imports and public surfaces; exact-head CI remains required before landing.
