### PR TITLE
fix(ui): keep active picker subtext legible

### DIFF
--- a/ui/src/e2e/channel-wizard-option-contrast.e2e.test.ts
+++ b/ui/src/e2e/channel-wizard-option-contrast.e2e.test.ts
@@ -1,0 +1,120 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI channel wizard option contrast",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) =>
+    `Playwright Chromium is required for channel wizard contrast proof at ${executablePath}`,
+});
+
+const proofVariant = process.env.OPENCLAW_PICKER_PROOF_VARIANT;
+const proofDirectory = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "channel-wizard-option-contrast",
+);
+
+suite.define(() => {
+  it("keeps active option subtext as legible as its label", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          featureMethods: ["channels.status", "channels.pairing.list", "wizard.start"],
+          methodResponses: {
+            "channels.status": {
+              ts: Date.now(),
+              channelOrder: ["imessage"],
+              channelLabels: { imessage: "iMessage" },
+              channelMeta: [{ id: "imessage", label: "iMessage" }],
+              channels: { imessage: { configured: true, running: true } },
+              channelAccounts: {},
+              channelDefaultAccountId: {},
+            },
+            "channels.pairing.list": {
+              accounts: [],
+              requests: [],
+              commandOwnerConfigured: true,
+              limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+            },
+            "wizard.start": {
+              sessionId: "channel-option-contrast-proof",
+              done: false,
+              status: "running",
+              step: {
+                id: "account",
+                type: "select",
+                message: "Account",
+                initialValue: "primary",
+                options: [
+                  {
+                    value: "primary",
+                    label: "Primary iMessage connection",
+                    hint: "The main iMessage connection for this OpenClaw gateway",
+                  },
+                  {
+                    value: "another",
+                    label: "Add another iMessage account",
+                  },
+                ],
+              },
+            },
+          },
+        });
+
+        expect((await page.goto(`${suite.server.baseUrl}settings/channels`))?.status()).toBe(200);
+        await page.locator(".channels-item", { hasText: "iMessage" }).first().click();
+        await page.locator(".channels-detail").getByRole("button", { name: "Run setup" }).click();
+
+        const wizard = page.locator(".channels-wizard");
+        const picker = wizard.locator("wa-select");
+        await picker.click();
+        await expect.poll(() => picker.getAttribute("open")).not.toBeNull();
+
+        const activeOption = wizard.locator("wa-option").filter({
+          has: page.getByText("Primary iMessage connection", { exact: true }),
+        });
+        await expect
+          .poll(() => activeOption.evaluate((option) => option.matches(":state(current)")))
+          .toBe(true);
+        const colors = await activeOption.evaluate((option) => {
+          const label = option.querySelector<HTMLElement>(".picker-select__label");
+          const description = option.querySelector<HTMLElement>(".picker-select__description");
+          if (!label || !description) {
+            throw new Error("Expected the active picker option label and description");
+          }
+          return {
+            background: getComputedStyle(option).backgroundColor,
+            description: getComputedStyle(description).color,
+            label: getComputedStyle(label).color,
+          };
+        });
+
+        if (proofVariant) {
+          await mkdir(proofDirectory, { recursive: true });
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(proofDirectory, `${proofVariant}.png`),
+          });
+          await writeFile(
+            path.join(proofDirectory, `${proofVariant}.json`),
+            `${JSON.stringify(colors, null, 2)}\n`,
+          );
+        }
+
+        expect(colors.description).toBe(colors.label);
+      },
+    );
+  });
+});

--- a/ui/src/styles/select-picker.css
+++ b/ui/src/styles/select-picker.css
@@ -92,6 +92,10 @@ wa-select.settings-select wa-option:state(current) {
   white-space: normal;
 }
 
+.picker-select__option:state(current) .picker-select__description {
+  color: inherit;
+}
+
 /* The model picker composes the shared picker and loads this same stylesheet. */
 .model-picker {
   display: grid;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a channel setup account picker would see the active option's descriptive subtext in muted gray against the red active background, making it difficult to read.

Reported directly during maintainer review of the iMessage setup wizard.

## Why This Change Was Made

The channel wizard uses the standard shared picker. Its description color explicitly overrode Web Awesome's active-option foreground, so active descriptions now inherit the option's canonical foreground while inactive descriptions remain muted. A browser-rendered regression test covers the real channel-wizard path.

Production LOC: +4/-0 (active-state presentation rule) | Tests: +120/-0

AI-assisted: yes. The patch was inspected and independently autoreviewed; I understand the change.

## User Impact

Active option subtext is now as legible as the option label in the channel setup wizard and every other shared picker with descriptions.

## Evidence

Before — active label was `rgb(255, 255, 255)`, but subtext stayed `rgb(139, 139, 148)` on `rgb(209, 60, 60)`:

![Before: muted gray active picker subtext](https://github.com/user-attachments/assets/720de028-686e-4bbd-9a66-daecdd471ee0)

After — active label and subtext both render `rgb(255, 255, 255)` on the same active background:

![After: white active picker subtext](https://github.com/user-attachments/assets/715dc3ab-0e9d-49e8-bdf1-00489c2f26c6)

Focused validation:

- `node scripts/run-vitest.mjs ui/src/components/select-picker.test.ts ui/src/e2e/channel-wizard-option-contrast.e2e.test.ts` — 3 tests passed across 2 shards
- `node scripts/check-changed.mjs -- ui/src/styles/select-picker.css ui/src/e2e/channel-wizard-option-contrast.e2e.test.ts` — passed
- `.agents/skills/autoreview/scripts/autoreview --mode uncommitted --stream-engine-output` — no findings; patch correct (0.99 confidence)

Root cause: `.picker-select__description` set `color: var(--muted)`, overriding the inherited active foreground selected by Web Awesome's `current` state.

Best-fix verdict: shared picker owner is the correct layer; a wizard-only override would leave model, settings, and other shared pickers inconsistent.
