### PR TITLE
fix(test): clean up relative-path SQLite fixtures

### DIFF
--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -2817,6 +2817,8 @@ describe("openclaw agent database", () => {
             process.chdir(previousCwd);
             closeOpenClawAgentDatabasesForTest();
             closeOpenClawStateDatabaseForTest();
+            fs.rmSync(root, { recursive: true, force: true });
+            fs.rmSync(stateDir, { recursive: true, force: true });
           }
         `,
       ],


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where running the agent database test `keys explicit relative paths by resolved database pathname` leaves two SQLite fixture directories in the system temporary directory on every invocation.

## Why This Change Was Made

The embedded child process owns its `stateDir` and relative-path `root`; neither allocation belongs to the parent suite's temporary-directory tracker. Its `finally` now removes those exact two roots after restoring cwd, closing agent databases, and closing shared-state databases, in that order.

This is a maintainer-requested, test-only fix. It does not enumerate or sweep temporary directories, delete preexisting fixtures, or change shared default PID-namespace lifetime. Production LOC: +0/-0. Tests: +2/-0.

## User Impact

No runtime or user-visible behavior changes. Developers and CI no longer accumulate these two fixture roots when the test succeeds or its body throws.

## Evidence

A bounded probe ran the actual embedded child script with real SQLite modules, both normally and with an exception injected after the two agent databases opened. Exit-time observations were recorded before probe-owned cleanup. Separately allocated matching-prefix sentinel directories stayed intact in every scenario.

| Scenario | Before | After | Preserved invariants |
| --- | --- | --- | --- |
| Successful body | Both fixture roots remained | Both fixture roots removed | cwd restored; agent then shared close; sentinels unchanged |
| Throwing body | Both fixture roots remained | Both fixture roots removed | cwd restored; agent then shared close; sentinels unchanged |

The pre-fix probe failed with `child leaked invocation-owned fixture directories`; the unchanged probe passed after the repair. All probe-created roots were cleaned using their exact allocation results; no preexisting temp directories were removed.

Passed locally:

```bash
node scripts/run-vitest.mjs src/state/openclaw-agent-db.test.ts -t 'keys explicit relative paths by resolved database pathname'
```

One test passed, 115 skipped. The existing test retains its distinct-handle, file-existence, and registered-path assertions.

```bash
node scripts/check-changed.mjs -- src/state/openclaw-agent-db.test.ts
```

Passed the required guards, formatting, dead-export scans, temp-creation report, core test typechecks, and targeted lint. Targeted `oxfmt --check` and `git diff --check` also passed. Independent Codex autoreview reported no accepted/actionable findings.

No new permanent meta-test was added: this repairs the existing fixture owner, and the bounded before/after filesystem probe proves cleanup without adding a production seam or duplicating the database-path regression.

AI-assisted; implementation and proof reviewed by the maintainer's coding session.
