### PR TITLE
fix(sandbox): revert Daytona cloud sandbox plugin

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/TestProcessSupportPipeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TestProcessSupportPipeTests.swift
@@ -1,17 +1,20 @@
+import Darwin
 import Foundation
 import Testing
 
 struct TestProcessSupportPipeTests {
-    @Test func `suppressed write end reports EPIPE instead of killing the harness`() throws {
+    @Test func `suppression sets the pipe write end no-SIGPIPE flag`() throws {
         let pipe = Pipe()
-        try TestProcessSupport.suppressSIGPIPE(pipe.fileHandleForWriting)
-        try pipe.fileHandleForReading.close()
-
-        // Without suppression this write would raise SIGPIPE and take down the
-        // whole swiftpm-testing-helper process instead of throwing.
-        #expect(throws: Error.self) {
-            try pipe.fileHandleForWriting.write(contentsOf: Data("x".utf8))
+        defer {
+            try? pipe.fileHandleForReading.close()
+            try? pipe.fileHandleForWriting.close()
         }
-        try pipe.fileHandleForWriting.close()
+        let writeEnd = pipe.fileHandleForWriting
+
+        // Concurrent preforked children can retain readers, so local closure cannot
+        // prove process-global reader closure. This helper owns the writer's flag.
+        #expect(fcntl(writeEnd.fileDescriptor, F_GETNOSIGPIPE) == 0)
+        try TestProcessSupport.suppressSIGPIPE(writeEnd)
+        #expect(fcntl(writeEnd.fileDescriptor, F_GETNOSIGPIPE) == 1)
     }
 }

--- a/extensions/acpx/test/fixtures/codex-app-server.mjs
+++ b/extensions/acpx/test/fixtures/codex-app-server.mjs
@@ -114,7 +114,7 @@ async function handle(method, params) {
   throw new Error(`unsupported fixture method: ${method}`);
 }
 
-async function handleLine(line) {
+readline.createInterface({ input: process.stdin }).on("line", async (line) => {
   let message;
   try {
     message = JSON.parse(line);
@@ -142,8 +142,4 @@ async function handleLine(line) {
       error: { code: -32601, message: error instanceof Error ? error.message : String(error) },
     });
   }
-}
-
-readline.createInterface({ input: process.stdin }).on("line", (line) => {
-  void handleLine(line);
 });

--- a/extensions/browser/chrome-extension/bootstrap-diagnostics.test-support.ts
+++ b/extensions/browser/chrome-extension/bootstrap-diagnostics.test-support.ts
@@ -1,0 +1,255 @@
+import type { Page } from "playwright-core";
+import { z } from "zod";
+import type { ExtensionRelayBridge } from "../src/browser/extension-relay/relay-bridge.js";
+
+const METHODS = [
+  "Target.attachedToTarget",
+  "Target.detachedFromTarget",
+  "Target.attachToTarget",
+  "Page.navigate",
+  "Page.frameNavigated",
+  "Page.frameDetached",
+  "Page.lifecycleEvent",
+  "Page.loadEventFired",
+  "Page.domContentEventFired",
+  "Fetch.enable",
+  "Fetch.disable",
+  "Fetch.requestPaused",
+  "Fetch.continueRequest",
+  "Fetch.continueResponse",
+  "Fetch.fulfillRequest",
+  "Fetch.failRequest",
+  "Network.requestWillBeSent",
+  "Network.responseReceived",
+  "Network.loadingFinished",
+  "Network.loadingFailed",
+] as const;
+const id = z.string().max(200).optional();
+const fields = z.object({
+  sessionId: id,
+  targetId: id,
+  requestId: id,
+  networkId: id,
+  frameId: id,
+  loaderId: id,
+  name: z.string().optional(),
+  frame: z.object({ id, loaderId: id }).optional(),
+  targetInfo: z.object({ targetId: id }).optional(),
+});
+const envelope = z.object({
+  id: z.number().int().optional(),
+  method: z.enum(METHODS).optional(),
+  sessionId: id,
+  params: fields.optional(),
+  result: fields.extend({ errorText: z.string().optional() }).optional(),
+  error: z.unknown().optional(),
+});
+type Method = (typeof METHODS)[number];
+type Phase =
+  | "injection.used"
+  | "injection.calls"
+  | "adapter.fresh"
+  | "navigate.status"
+  | "owner.selected"
+  | "owner.unrelated"
+  | "direct.url"
+  | "unrelated.url"
+  | "direct.commit"
+  | "direct.domcontentloaded"
+  | "direct.load"
+  | "direct.closed"
+  | "http.request"
+  | "http.finish"
+  | "http.closed"
+  | "relay.clients"
+  | "relay.closed"
+  | "mcp.closed";
+type RecordEntry = { phase: string; [key: string]: string | number | boolean };
+
+// Stage-one fixture observation only: no extension rewrite, new CDP client/domain,
+// event replay, or action waits. Stop retaining data at the cap, including during cleanup.
+export function createBootstrapDiagnostic() {
+  const started = performance.now();
+  const records: RecordEntry[] = [];
+  const ordinals = new Map<string, number>();
+  const pending = new Map<string, { method: Method; command: number }>();
+  const restores: Array<() => void> = [];
+  let remaining = 256;
+  let dropped = 0;
+  let active = false;
+  let nextClient = 0;
+  let nextCommand = 0;
+  let flushes = 0;
+  const append = (entry: RecordEntry) => {
+    if (remaining === 0) {
+      dropped = Math.min(dropped + 1, 1_000_000);
+      return;
+    }
+    remaining--;
+    records.push({ ms: Math.round(performance.now() - started), ...entry });
+  };
+  const ordinal = (kind: string, value: string | undefined) => {
+    if (value === undefined) {
+      return 0;
+    }
+    const key = `${kind}:${value}`;
+    const found = ordinals.get(key);
+    if (found) {
+      return found;
+    }
+    if (ordinals.size === 128) {
+      return 0;
+    }
+    const next = ordinals.size + 1;
+    ordinals.set(key, next);
+    return next;
+  };
+  const observe = (client: number, outgoing: boolean, raw: string) => {
+    if (!active) {
+      return;
+    }
+    // Reserve the final records for action outcome and teardown, even on event floods.
+    if (remaining <= 32 || raw.length > 64 * 1024) {
+      dropped = Math.min(dropped + 1, 1_000_000);
+      return;
+    }
+    try {
+      const parsed = envelope.safeParse(JSON.parse(raw));
+      if (!parsed.success) {
+        return;
+      }
+      const msg = parsed.data;
+      const key = `${client}:${msg.id}`;
+      const command = outgoing ? pending.get(key) : undefined;
+      if (outgoing) {
+        pending.delete(key);
+      }
+      const method = command?.method ?? msg.method;
+      if (!method) {
+        return;
+      }
+      const commandId = command?.command ?? (!outgoing ? ++nextCommand : 0);
+      if (!outgoing && msg.id !== undefined && pending.size < 128) {
+        pending.set(key, { method, command: commandId });
+      }
+      const data = msg.params ?? msg.result;
+      append({
+        phase: !outgoing ? "cdp.command" : command ? "cdp.result" : "cdp.event",
+        client,
+        method,
+        command: commandId,
+        session: ordinal("session", msg.sessionId ?? data?.sessionId),
+        childSession: ordinal("session", data?.sessionId),
+        target: ordinal("target", data?.targetId ?? data?.targetInfo?.targetId),
+        request: ordinal(method.startsWith("Fetch.") ? "fetch" : "network", data?.requestId),
+        network: ordinal("network", data?.networkId),
+        frame: ordinal("frame", data?.frameId ?? data?.frame?.id),
+        loader: ordinal("loader", data?.loaderId ?? data?.frame?.loaderId),
+        load: data?.name === "load",
+        domContentLoaded: data?.name === "DOMContentLoaded",
+        error: msg.error !== undefined || Boolean(msg.result?.errorText),
+      });
+    } catch {
+      // Observation must not replace a transport result/error, including malformed input.
+    }
+  };
+  const mark = (phase: Phase, value: boolean | number) => append({ phase, value });
+  return {
+    mark,
+    arm(selected: string, unrelated: string) {
+      active = true;
+      append({
+        phase: "armed",
+        selected: ordinal("target", selected),
+        unrelated: ordinal("target", unrelated),
+      });
+    },
+    watchRelay(bridge: Pick<ExtensionRelayBridge, "attachCdpClientSocket" | "cdpClientCount">) {
+      const original = bridge.attachCdpClientSocket;
+      bridge.attachCdpClientSocket = (socket) => {
+        const client = Math.min(++nextClient, 1_000_000);
+        const callbacks = original.call(bridge, {
+          send: (raw) => {
+            observe(client, true, raw);
+            socket.send(raw);
+          },
+          close: (code, reason) => socket.close(code, reason),
+        });
+        append({ phase: "client.attach", client, count: bridge.cdpClientCount });
+        return {
+          onMessage: (raw) => {
+            observe(client, false, raw);
+            callbacks.onMessage(raw);
+          },
+          onClose: () => {
+            try {
+              callbacks.onClose();
+            } finally {
+              append({ phase: "client.close", client, count: bridge.cdpClientCount });
+            }
+          },
+        };
+      };
+      restores.push(() => {
+        bridge.attachCdpClientSocket = original;
+      });
+    },
+    watchPage(page: Page, expectedUrl: string) {
+      const commit = (frame: ReturnType<Page["mainFrame"]>) => {
+        if (frame === page.mainFrame()) {
+          mark("direct.commit", page.url() === expectedUrl);
+        }
+      };
+      const ready = () => mark("direct.domcontentloaded", page.url() === expectedUrl);
+      const loaded = () => mark("direct.load", page.url() === expectedUrl);
+      const closed = () => mark("direct.closed", true);
+      page
+        .on("framenavigated", commit)
+        .on("domcontentloaded", ready)
+        .on("load", loaded)
+        .on("close", closed);
+      const stop = () => {
+        page
+          .off("framenavigated", commit)
+          .off("domcontentloaded", ready)
+          .off("load", loaded)
+          .off("close", closed);
+      };
+      restores.push(stop);
+      return stop;
+    },
+    peer(info: { name: string; version: string } | undefined) {
+      // Actual cached MCP peer's handshake metadata, not an npx/latest version guess.
+      const version =
+        info?.name === "chrome_devtools" && /^(\d{1,6})\.(\d{1,6})\.(\d{1,6})$/.exec(info.version);
+      append({
+        phase: "mcp.peer",
+        known: Boolean(version),
+        major: version ? Number(version[1]) : 0,
+        minor: version ? Number(version[2]) : 0,
+        patch: version ? Number(version[3]) : 0,
+      });
+    },
+    flush() {
+      if (++flushes > 2) {
+        return;
+      }
+      active = false;
+      try {
+        process.stderr.write(
+          `[browser-bootstrap-diagnostic] ${JSON.stringify({ stage: 1, instrumentedFixture: true, extensionCopyModified: false, dropped, records })}\n`,
+        );
+      } catch {
+        /* A diagnostic sink cannot replace the original test failure. */
+      }
+      records.length = 0;
+    },
+    dispose() {
+      for (const restore of restores) {
+        restore();
+      }
+      pending.clear();
+      ordinals.clear();
+    },
+  };
+}

--- a/extensions/browser/chrome-extension/bootstrap-diagnostics.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap-diagnostics.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ExtensionRelayBridge } from "../src/browser/extension-relay/relay-bridge.js";
+import { createBootstrapDiagnostic } from "./bootstrap-diagnostics.test-support.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+function observerFixture() {
+  let count = 0;
+  let reply: ((raw: string) => void) | undefined;
+  const receive = vi.fn();
+  const bridge = {
+    get cdpClientCount() {
+      return count;
+    },
+    attachCdpClientSocket(this: void, socket) {
+      count++;
+      reply = socket.send;
+      return {
+        onMessage: receive,
+        onClose: () => {
+          count--;
+          socket.close();
+        },
+      };
+    },
+  } satisfies Pick<ExtensionRelayBridge, "attachCdpClientSocket" | "cdpClientCount">;
+  return { bridge, receive, reply: (raw: string) => reply?.(raw) };
+}
+
+describe("bootstrap diagnostic observation", () => {
+  it("projects only fixed names and ordinals while forwarding exact bytes", () => {
+    const output = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const diagnostic = createBootstrapDiagnostic();
+    const { bridge, receive, reply } = observerFixture();
+    const original = bridge.attachCdpClientSocket;
+    diagnostic.watchRelay(bridge);
+    const send = vi.fn();
+    const callbacks = bridge.attachCdpClientSocket({ send, close: vi.fn() });
+    diagnostic.arm("private-selected", "private-unrelated");
+    const command = JSON.stringify({
+      id: 42,
+      method: "Page.navigate",
+      sessionId: "private-session",
+      params: { url: "https://private.invalid", headers: { authorization: "private-credential" } },
+    });
+    callbacks.onMessage(command);
+    const response = JSON.stringify({ id: 42, error: { message: "private-error" } });
+    reply(response);
+    reply(
+      JSON.stringify({ method: "Runtime.consoleAPICalled", params: { args: ["private-content"] } }),
+    );
+    callbacks.onMessage("private-malformed");
+    diagnostic.peer({ name: "private-peer", version: "private-version" });
+    diagnostic.flush();
+    expect(receive.mock.calls[0]).toEqual([command]);
+    expect(receive).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls[0]).toEqual([response]);
+    expect(send).toHaveBeenCalledTimes(2);
+    const printed = String(output.mock.calls[0]?.[0]);
+    expect(printed).not.toContain("private-");
+    expect(printed).not.toContain("Runtime.consoleAPICalled");
+    expect(printed).toContain('"method":"Page.navigate"');
+    expect(printed).toContain('"error":true');
+    diagnostic.dispose();
+    expect(bridge.attachCdpClientSocket).toBe(original);
+  });
+
+  it("caps flood output but retains the action outcome and teardown", () => {
+    const output = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const diagnostic = createBootstrapDiagnostic();
+    const { bridge, reply } = observerFixture();
+    diagnostic.watchRelay(bridge);
+    const callbacks = bridge.attachCdpClientSocket({ send: () => {}, close: () => {} });
+    diagnostic.arm("selected", "unrelated");
+    for (let index = 0; index < 1_000; index++) {
+      reply(
+        JSON.stringify({
+          method: "Network.requestWillBeSent",
+          params: { requestId: `request-${index}` },
+        }),
+      );
+    }
+    diagnostic.mark("navigate.status", 500);
+    diagnostic.flush();
+    callbacks.onClose();
+    diagnostic.mark("relay.closed", true);
+    diagnostic.flush();
+    diagnostic.flush();
+    const printed = output.mock.calls.map(([value]) => String(value)).join("");
+    expect(output).toHaveBeenCalledTimes(2);
+    expect(printed.length).toBeLessThan(100_000);
+    expect(printed).toContain('"phase":"navigate.status","value":500');
+    expect(printed).toContain('"phase":"relay.closed","value":true');
+    expect(printed).not.toContain('"dropped":0');
+    diagnostic.dispose();
+  });
+
+  it("preserves a transport exception and ignores a diagnostic sink exception", () => {
+    vi.spyOn(process.stderr, "write").mockImplementation(() => {
+      throw new Error("sink");
+    });
+    const diagnostic = createBootstrapDiagnostic();
+    const { bridge, receive } = observerFixture();
+    diagnostic.watchRelay(bridge);
+    const failure = new Error("transport");
+    receive.mockImplementation(() => {
+      throw failure;
+    });
+    const callbacks = bridge.attachCdpClientSocket({
+      send: () => {
+        throw failure;
+      },
+      close: () => {},
+    });
+    diagnostic.arm("selected", "unrelated");
+    expect(() => callbacks.onMessage("malformed")).toThrow(failure);
+    expect(() => diagnostic.flush()).not.toThrow();
+    diagnostic.dispose();
+  });
+});

--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { chromium, type BrowserContext } from "playwright-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { chromeMcpSessions } from "../src/browser/chrome-mcp-state.js";
 import {
   chromeProductRoots,
   generateChromeExtensionIdForPath,
@@ -19,6 +20,7 @@ import { createBrowserRouteDispatcher } from "../src/browser/routes/dispatcher.j
 import { createBrowserRouteContext } from "../src/browser/server-context.js";
 import { getFreePort } from "../src/browser/test-port.js";
 import { getBrowserControlState, stopBrowserControlService } from "../src/control-service.js";
+import { createBootstrapDiagnostic } from "./bootstrap-diagnostics.test-support.js";
 import chromeExtensionManifest from "./manifest.json" with { type: "json" };
 import { relayTestKey } from "./relay-key.test-support.js";
 
@@ -146,6 +148,11 @@ function decodeSingleNativeResponse(frame: Buffer): Record<string, unknown> {
 
 describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
   it("pre-registers before the first native call, auto-pairs, and revokes a paused tab", async () => {
+    const diagnostic = createBootstrapDiagnostic();
+    cleanups.push(async () => {
+      diagnostic.dispose();
+      diagnostic.flush();
+    });
     const root = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-extension-e2e-")),
     );
@@ -209,6 +216,8 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         };
         const gatewayServer = http.createServer((req, res) => {
           if (req.url === "/browser-owner-proof") {
+            diagnostic.mark("http.request", true);
+            res.once("finish", () => diagnostic.mark("http.finish", res.statusCode));
             res.writeHead(200, { "content-type": "text/html" });
             res.end("<title>OpenClaw selected tab</title>");
             return;
@@ -225,10 +234,30 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         cleanups.push(
           async () =>
             await new Promise<void>((resolve) => {
-              gatewayServer.close(() => resolve());
+              gatewayServer.close(() => {
+                diagnostic.mark("http.closed", !gatewayServer.listening);
+                resolve();
+              });
             }),
         );
-        cleanups.push(stopBrowserControlService);
+        cleanups.push(async () => {
+          const bridge = getBrowserControlState()?.extensionRelays?.get("e2e")?.bridge;
+          const sessions = [...chromeMcpSessions.values()].slice(0, 8);
+          try {
+            await stopBrowserControlService();
+          } finally {
+            diagnostic.mark(
+              "relay.closed",
+              Boolean(bridge && !bridge.extensionConnected && bridge.cdpClientCount === 0),
+            );
+            for (const session of sessions) {
+              diagnostic.mark(
+                "mcp.closed",
+                session.transport.pid === null && session.processCleanup?.status === "closed",
+              );
+            }
+          }
+        });
         const browserEnv: NodeJS.ProcessEnv = {
           ...process.env,
           HOME: homeDir,
@@ -352,6 +381,7 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         if (!relay || relay.port !== relayPort) {
           throw new Error("Gateway wakeup did not start the configured extension relay");
         }
+        diagnostic.watchRelay(relay.bridge);
         const browserState = getBrowserControlState();
         const extensionProfile = browserState?.resolved.profiles.e2e;
         if (!browserState || !extensionProfile) {
@@ -515,14 +545,24 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
         const previousSsrfPolicy = browserState.resolved.ssrfPolicy;
         browserState.resolved.ssrfPolicy = { allowPrivateNetwork: true };
         const extensionCdpUrl = routeContext.forProfile("e2e").profile.cdpUrl;
+        const proofUrl = `http://127.0.0.1:${gatewayPort}/browser-owner-proof`;
+        diagnostic.arm(selectedTab.targetId, unrelatedTab.targetId);
+        diagnostic.mark("relay.clients", relay.bridge.cdpClientCount);
+        for (const session of [...chromeMcpSessions.values()].slice(0, 8)) {
+          diagnostic.peer(session.client.getServerVersion());
+        }
+        const stopPageObservation = diagnostic.watchPage(controlled, proofUrl);
+        const selectedOwner = relay.bridge.captureOperationTarget(selectedTab.targetId);
+        const unrelatedOwner = relay.bridge.captureOperationTarget(unrelatedTab.targetId);
         const actedPage = await getPageForTargetId({
           cdpUrl: extensionCdpUrl,
           targetId: selectedTab.targetId,
           ssrfPolicy: browserState.resolved.ssrfPolicy,
         });
-        const detachedNavigation = vi
-          .spyOn(actedPage, "goto")
-          .mockRejectedValueOnce(new Error("page.goto: Frame has been detached"));
+        const detachedNavigation = vi.spyOn(actedPage, "goto").mockImplementationOnce(() => {
+          diagnostic.mark("injection.used", true);
+          return Promise.reject(new Error("page.goto: Frame has been detached"));
+        });
         try {
           const navigationResponse = await dispatcher.dispatch({
             method: "POST",
@@ -533,6 +573,7 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
               url: `http://127.0.0.1:${gatewayPort}/browser-owner-proof`,
             },
           });
+          diagnostic.mark("navigate.status", navigationResponse.status);
           expect(navigationResponse.status, JSON.stringify(navigationResponse.body)).toBe(200);
           expect(navigationResponse.body).toMatchObject({
             ok: true,
@@ -545,12 +586,21 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
             targetId: selectedTab.targetId,
             ssrfPolicy: browserState.resolved.ssrfPolicy,
           });
+          diagnostic.mark("adapter.fresh", recoveredPage !== actedPage);
           expect(recoveredPage).not.toBe(actedPage);
           expect(distractingPage.url()).toBe(distractingUrl);
           process.stderr.write(
             "[browser-extension-e2e] injected-detach=1 production-reconnect=1 owner-target-preserved=1 unrelated-tab-unchanged=1 status=200\n",
           );
         } finally {
+          diagnostic.mark("injection.calls", detachedNavigation.mock.calls.length);
+          diagnostic.mark("owner.selected", selectedOwner?.() === selectedTab.targetId);
+          diagnostic.mark("owner.unrelated", unrelatedOwner?.() === unrelatedTab.targetId);
+          diagnostic.mark("direct.url", controlled.url() === proofUrl);
+          diagnostic.mark("unrelated.url", distractingPage.url() === distractingUrl);
+          diagnostic.mark("relay.clients", relay.bridge.cdpClientCount);
+          stopPageObservation();
+          diagnostic.flush();
           detachedNavigation.mockRestore();
           browserState.resolved.ssrfPolicy = previousSsrfPolicy;
         }

--- a/extensions/tlon/package.json
+++ b/extensions/tlon/package.json
@@ -8,8 +8,8 @@
   },
   "type": "module",
   "dependencies": {
-    "@aws-sdk/client-s3": "3.1117.0",
-    "@aws-sdk/s3-request-presigner": "3.1117.0",
+    "@aws-sdk/client-s3": "3.1113.0",
+    "@aws-sdk/s3-request-presigner": "3.1113.0",
     "@tloncorp/tlon-skill": "0.5.0",
     "@urbit/aura": "3.0.0",
     "zod": "4.4.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5241,6 +5241,10 @@ packages:
     resolution: {integrity: sha512-6iv9dLiDX4he0KLFr2vw2u98Q+lIEsF0G+1MZVy5kWjZRLYXvY6S4uJ+R3aC4xYBkjljAtCB3uG9Y8pBL3O3Ug==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.11.2':
+    resolution: {integrity: sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.11.3':
     resolution: {integrity: sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==}
     engines: {node: '>=18.0.0'}
@@ -12504,6 +12508,12 @@ snapshots:
   '@smithy/node-config-provider@4.5.14':
     dependencies:
       '@smithy/core': 3.33.3
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.17.2
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.11.3':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1897,11 +1897,11 @@ importers:
   extensions/tlon:
     dependencies:
       '@aws-sdk/client-s3':
-        specifier: 3.1117.0
-        version: 3.1117.0
+        specifier: 3.1113.0
+        version: 3.1113.0
       '@aws-sdk/s3-request-presigner':
-        specifier: 3.1117.0
-        version: 3.1117.0
+        specifier: 3.1113.0
+        version: 3.1113.0
       '@tloncorp/tlon-skill':
         specifier: 0.5.0
         version: 0.5.0
@@ -2688,8 +2688,8 @@ packages:
     resolution: {integrity: sha512-KoC+gBIwMQlzFuSf99MT6S6Uy6E+H+9FQ6W1jLn+gDLK/8McNF6tBTD6bmddgvvRXVvJPkpRkyCDgLBY/LmI1A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-s3@3.1117.0':
-    resolution: {integrity: sha512-M/zyjg0u0Sxm73sInvyDb9+/YUuAOz8/xxmcmj0quJ7NXllZqXPxzjti3oVDz/lQ5mDf7iuxBLc0Y3deJI2hRw==}
+  '@aws-sdk/client-s3@3.1113.0':
+    resolution: {integrity: sha512-NRqdtohoMRyWkEeeznfG1KPN08dclCbl+HFuLPB2v8qPcgoNmTFlLKl9ELiR6hsGXQ4Ur3qvRnoJVEk8ND74pg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/core@3.977.8':
@@ -2788,8 +2788,8 @@ packages:
     resolution: {integrity: sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/s3-request-presigner@3.1117.0':
-    resolution: {integrity: sha512-4aivFw3OXy83wuh3utC2F6bgNg4SCdcCLOSXRvYF23qEL0OzGvkjqzLTU+T191laBKjbU/m6nJLFrZsEtOo9ow==}
+  '@aws-sdk/s3-request-presigner@3.1113.0':
+    resolution: {integrity: sha512-FdbHboJSscXRHnqOGRLN+MvtcYNlxw1+XWMKcKi72nBPxpSTGQA+/zmxEBTlkCvTdIPtl/g383nNY0RiKYPmWQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.46':
@@ -9784,7 +9784,7 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/client-s3@3.1117.0':
+  '@aws-sdk/client-s3@3.1113.0':
     dependencies:
       '@aws-sdk/checksums': 3.1000.29
       '@aws-sdk/core': 3.977.8
@@ -9794,7 +9794,7 @@ snapshots:
       '@aws-sdk/types': 3.974.5
       '@smithy/core': 3.33.3
       '@smithy/fetch-http-handler': 5.7.2
-      '@smithy/node-http-handler': 4.11.3
+      '@smithy/node-http-handler': 4.11.2
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
@@ -10045,7 +10045,7 @@ snapshots:
       '@smithy/types': 4.17.2
       tslib: 2.8.1
 
-  '@aws-sdk/s3-request-presigner@3.1117.0':
+  '@aws-sdk/s3-request-presigner@3.1113.0':
     dependencies:
       '@aws-sdk/core': 3.977.8
       '@aws-sdk/signature-v4-multi-region': 3.996.46

--- a/ui/src/components/tooltip-content.ts
+++ b/ui/src/components/tooltip-content.ts
@@ -20,6 +20,7 @@ function collectTooltipText(element: Element, checkOpacity: boolean): string {
   const style = element.ownerDocument.defaultView?.getComputedStyle(element);
   if (
     element.hasAttribute("hidden") ||
+    (!checkOpacity && element.getAttribute("aria-hidden") === "true") ||
     style?.display === "none" ||
     style?.contentVisibility === "hidden"
   ) {

--- a/ui/src/components/tooltip-title.browser.test.ts
+++ b/ui/src/components/tooltip-title.browser.test.ts
@@ -1,44 +1,121 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { installTitleTooltips } from "./tooltip-title.ts";
 
-// Opacity and accessibility require real layout; the root jsdom lane cannot
-// exercise the browser's checkVisibility or accessible-name computation.
+// Accessible names and opacity require real layout; keep the canonical browser-only gate.
 describe.skipIf(typeof HTMLElement.prototype.checkVisibility !== "function")(
   "title tooltip accessible names",
   () => {
-    it.each(["focus", "hover"] as const)(
-      "preserves the button name when %s precedes its ancestor becoming opaque",
-      async (interaction) => {
-        const { page } = await import("vitest/browser");
-        const host = document.createElement("div");
+    let page: (typeof import("vitest/browser"))["page"];
+    let dispose: () => void;
+
+    beforeEach(async () => {
+      ({ page } = await import("vitest/browser"));
+      dispose = installTitleTooltips(document);
+    });
+
+    afterEach(() => {
+      dispose();
+      document.body.replaceChildren();
+    });
+
+    it.each([
+      ["pointer", "button"],
+      ["pointer", "ancestor"],
+      ["focus", "button"],
+      ["focus", "ancestor"],
+    ] as const)(
+      "preserves a text-labelled button after %s enhancement during a %s opacity transition",
+      async (input, target) => {
+        const container = document.createElement("div");
         const button = document.createElement("button");
-        button.textContent = "Raw";
-        button.title = "Edit raw JSON configuration";
-        host.style.opacity = "0";
-        host.append(button);
-        document.body.append(host);
-        const byName = page.getByRole("button", { name: "Raw", exact: true });
-        expect(byName.elements()).toEqual([button]);
+        button.textContent = "Edit";
+        button.title = "Edit configuration as text";
+        const animated = target === "button" ? button : container;
+        animated.style.opacity = "0";
+        container.append(button);
+        document.body.append(container);
+        const namedButton = page.getByRole("button", { name: "Edit", exact: true });
+        expect(namedButton.elements()).toEqual([button]);
         expect(button.checkVisibility({ checkOpacity: true })).toBe(false);
-        const dispose = installTitleTooltips(document);
-        try {
-          if (interaction === "focus") {
-            button.focus();
-          } else {
-            await byName.hover();
-          }
-          await document.querySelector("openclaw-tooltip")?.updateComplete;
-          host.style.opacity = "1";
-          await new Promise<void>((resolve) => {
-            requestAnimationFrame(() => resolve());
-          });
-          expect(button.checkVisibility({ checkOpacity: true })).toBe(true);
-          expect(byName.elements()).toEqual([button]);
-        } finally {
-          dispose();
-          host.remove();
+
+        if (input === "pointer") {
+          await page.elementLocator(button).hover();
+        } else {
+          button.focus();
         }
+        expect(button.title).toBe("");
+        animated.style.opacity = "1";
+        await new Promise<void>((resolve) => {
+          requestAnimationFrame(() => resolve());
+        });
+        expect(button.checkVisibility({ checkOpacity: true })).toBe(true);
+        expect(namedButton.elements()).toEqual([button]);
+        await namedButton.click();
       },
     );
+
+    it("releases an injected name when an existing text node becomes the label", async () => {
+      const button = document.createElement("button");
+      const label = document.createTextNode("");
+      button.title = "Edit configuration as text";
+      button.append(label);
+      document.body.append(button);
+      await page.elementLocator(button).hover();
+      expect(
+        page.getByRole("button", { name: "Edit configuration as text", exact: true }).elements(),
+      ).toEqual([button]);
+
+      label.data = "Edit";
+      await expect
+        .poll(() => page.getByRole("button", { name: "Edit", exact: true }).elements())
+        .toEqual([button]);
+    });
+
+    it.each(["hidden", "display", "visibility", "aria-hidden"] as const)(
+      "preserves title naming when the only text is %s",
+      async (hidden) => {
+        const button = document.createElement("button");
+        const label = document.createElement("span");
+        button.title = "Edit configuration";
+        label.textContent = "Decorative text";
+        if (hidden === "hidden") {
+          label.hidden = true;
+        }
+        if (hidden === "display") {
+          label.style.display = "none";
+        }
+        if (hidden === "visibility") {
+          label.style.visibility = "hidden";
+        }
+        if (hidden === "aria-hidden") {
+          label.setAttribute("aria-hidden", "true");
+        }
+        button.append(label);
+        document.body.append(button);
+        const namedButton = page.getByRole("button", { name: "Edit configuration", exact: true });
+        expect(namedButton.elements()).toEqual([button]);
+        await page.elementLocator(button).hover();
+        expect(namedButton.elements()).toEqual([button]);
+        await page.elementLocator(button).unhover();
+        expect(button.title).toBe("Edit configuration");
+        expect(button.hasAttribute("aria-label")).toBe(false);
+        expect(namedButton.elements()).toEqual([button]);
+      },
+    );
+
+    it("preserves an explicit name supplied while the tooltip owns a temporary name", async () => {
+      const button = document.createElement("button");
+      button.title = "Edit configuration as text";
+      document.body.append(button);
+      await page.elementLocator(button).hover();
+      button.setAttribute("aria-label", "Open editor");
+      button.title = "Updated hint";
+      await expect.poll(() => button.title).toBe("");
+      await page.elementLocator(button).unhover();
+      expect(page.getByRole("button", { name: "Open editor", exact: true }).elements()).toEqual([
+        button,
+      ]);
+      expect(button.title).toBe("Updated hint");
+    });
   },
 );

--- a/ui/src/components/tooltip-title.browser.test.ts
+++ b/ui/src/components/tooltip-title.browser.test.ts
@@ -71,6 +71,44 @@ describe.skipIf(typeof HTMLElement.prototype.checkVisibility !== "function")(
         .toEqual([button]);
     });
 
+    it.each(["label", "nested subtree"] as const)(
+      "updates the active name when aria-hidden changes on the %s",
+      async (target) => {
+        const button = document.createElement("button");
+        const label = document.createElement("span");
+        const wrapper = document.createElement("span");
+        button.title = "Edit configuration as text";
+        label.textContent = "Edit";
+        wrapper.append(label);
+        button.append(wrapper);
+        const hidden = target === "label" ? label : wrapper;
+        hidden.setAttribute("aria-hidden", "true");
+        document.body.append(button);
+        const titleNamedButton = page.getByRole("button", {
+          name: "Edit configuration as text",
+          exact: true,
+        });
+        const textNamedButton = page.getByRole("button", { name: "Edit", exact: true });
+        await titleNamedButton.hover();
+        expect(button.title).toBe("");
+        expect(titleNamedButton.elements()).toEqual([button]);
+
+        hidden.setAttribute("aria-hidden", "false");
+        await expect.poll(() => textNamedButton.elements()).toEqual([button]);
+        await textNamedButton.click();
+
+        hidden.setAttribute("aria-hidden", "true");
+        await expect.poll(() => titleNamedButton.elements()).toEqual([button]);
+        await titleNamedButton.click();
+
+        await page.elementLocator(button).unhover();
+        button.blur();
+        expect(button.title).toBe("Edit configuration as text");
+        expect(button.hasAttribute("aria-label")).toBe(false);
+        expect(titleNamedButton.elements()).toEqual([button]);
+      },
+    );
+
     it.each(["hidden", "display", "visibility", "aria-hidden"] as const)(
       "preserves title naming when the only text is %s",
       async (hidden) => {

--- a/ui/src/components/tooltip-title.ts
+++ b/ui/src/components/tooltip-title.ts
@@ -162,7 +162,12 @@ export function installTitleTooltips(ownerDocument: Document) {
     }
     anchor.addEventListener("pointerleave", handlePointerLeave);
     anchor.addEventListener("focusout", handleFocusOut);
-    observer.observe(anchor, { attributes: true, attributeFilter: ["title", "data-tooltip"] });
+    observer.observe(anchor, {
+      attributes: true,
+      attributeFilter: ["title", "data-tooltip"],
+      characterData: true,
+      subtree: true,
+    });
     observer.observe(ownerDocument, { childList: true, subtree: true });
     const root = anchor.getRootNode();
     if (root instanceof ShadowRoot) {

--- a/ui/src/components/tooltip-title.ts
+++ b/ui/src/components/tooltip-title.ts
@@ -164,7 +164,7 @@ export function installTitleTooltips(ownerDocument: Document) {
     anchor.addEventListener("focusout", handleFocusOut);
     observer.observe(anchor, {
       attributes: true,
-      attributeFilter: ["title", "data-tooltip"],
+      attributeFilter: ["title", "data-tooltip", "aria-hidden"],
       characterData: true,
       subtree: true,
     });

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -6,7 +6,6 @@ import net from "node:net";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
-import type { RouterState } from "@openclaw/uirouter";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
@@ -17,6 +16,7 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../../src/test-utils/openclaw-test-state.js";
+import type { ApplicationRuntime } from "../app/bootstrap.ts";
 import {
   canRunPlaywrightChromium,
   controlUiE2eWaitTimeoutMs,
@@ -589,83 +589,64 @@ async function readConfigProofSnapshot(): Promise<{ identifier: unknown; prefix:
   };
 }
 
-async function captureConfigReadbackFailure(page: Page, pageErrors: string[]): Promise<void> {
+async function captureConfigReadbackFailure(page: Page): Promise<void> {
   const deadline = new AbortController();
   try {
-    // Capture only route/DOM facts, never config values or the runtime's auth/hello state.
-    // Playwright evaluate has no timeout; a stalled renderer must not hide the click failure.
+    // Capture fixed name/connection facts, never label text or auth/config state.
+    // The separate deadline must not hide the original click failure.
     const snapshot = await Promise.race([
-      page
-        .evaluate(() => {
-          const app = document.querySelector<
-            HTMLElement & {
-              runtime?: { router: { getState: () => RouterState } };
-            }
-          >("openclaw-app");
-          const state = app?.runtime?.router.getState();
-          const matches = (entries: RouterState["matches"] = []) =>
-            entries.slice(0, 3).map((entry) => ({
-              routeId: entry.routeId.slice(0, 80),
-              status: entry.status,
-              fetching: entry.isFetching,
-              moduleLoaded: entry.module !== undefined,
-              hasError: entry.error !== undefined,
-            }));
-          const rawButtons = [...document.querySelectorAll<HTMLButtonElement>("button")].filter(
-            (button) => button.textContent?.trim() === "Raw",
+      Promise.all([
+        page.evaluate(() => {
+          const app = document.querySelector<HTMLElement & { runtime?: ApplicationRuntime }>(
+            "openclaw-app",
           );
+          const phase = app?.runtime?.context.gateway.snapshot.phase;
+          const phases = [
+            "stopped",
+            "connecting",
+            "starting",
+            "connected",
+            "reconnecting",
+            "reload-required",
+            "offline",
+          ];
           return {
             pathname: location.pathname.slice(0, 160),
-            readyState: document.readyState,
-            routerStatus: state?.status ?? null,
-            resolvedPathname: state?.resolvedLocation?.pathname.slice(0, 160) ?? null,
-            matches: matches(state?.matches),
-            pendingMatches: matches(state?.pendingMatches),
-            configPageId:
-              document
-                .querySelector<HTMLElement & { pageId?: string }>("openclaw-config-page")
-                ?.pageId?.slice(0, 80) ?? null,
-            elements: Object.fromEntries(
-              [
-                "openclaw-app-shell",
-                "openclaw-config-page",
-                ".config-mode-toggle",
-                ".lazy-view-error",
-                ".lazy-view-state--loading",
-                ".login-gate__failure",
-              ].map((selector) => [selector, document.querySelectorAll(selector).length]),
-            ),
-            rawButtonCount: rawButtons.length,
-            rawButtons: rawButtons.slice(0, 3).map((button) => ({
-              disabled: button.disabled,
-              hasLayout: button.getClientRects().length > 0,
-            })),
-            scripts: (performance.getEntriesByType("resource") as PerformanceResourceTiming[])
-              .filter((entry) => entry.initiatorType === "script")
-              .filter((entry) => {
-                const url = new URL(entry.name);
-                return url.origin === location.origin && url.pathname.startsWith("/assets/");
-              })
-              .slice(-8)
-              .map((entry) => ({
-                pathname: new URL(entry.name).pathname.slice(0, 160),
-                responseStatus: entry.responseStatus,
+            navigationAgeMs: Math.round(performance.now()),
+            gatewayPhase: phases.includes(phase ?? "") ? phase : "unknown",
+            mainInert: document.querySelector("main")?.inert ?? null,
+            outletInert:
+              document.querySelector<HTMLElement>("openclaw-router-outlet")?.inert ?? null,
+            rawButtons: [
+              ...document.querySelectorAll<HTMLButtonElement>(".config-mode-toggle button"),
+            ]
+              .filter((button) => button.textContent?.trim() === "Raw")
+              .slice(0, 3)
+              .map((button) => ({
+                disabled: button.disabled,
+                hasLayout: button.getClientRects().length > 0,
+                inertAncestor: button.closest("[inert]") !== null,
+                label: !button.hasAttribute("aria-label")
+                  ? "absent"
+                  : button.getAttribute("aria-label") === "Raw"
+                    ? "raw"
+                    : "other",
+                labelledBy: button.hasAttribute("aria-labelledby"),
               })),
           };
-        })
+        }),
+        page.getByRole("button", { name: "Raw", exact: true }).count(),
+        page.getByRole("button", { name: "Raw", exact: true, includeHidden: true }).count(),
+      ])
+        .then(([state, roleMatches, roleMatchesIncludingHidden]) => ({
+          ...state,
+          roleMatches,
+          roleMatchesIncludingHidden,
+        }))
         .catch(() => "unavailable"),
       delay(1_000, "timed-out", { signal: deadline.signal }),
     ]);
-    const errorCategories = pageErrors
-      .slice(-8)
-      .map((error) =>
-        /dynamically imported module|module script|ChunkLoadError/u.test(error)
-          ? "module-load"
-          : (/^(?:TypeError|ReferenceError|SyntaxError|RangeError)\b/u.exec(error)?.[0] ?? "other"),
-      );
-    console.error(
-      `[real-config-readback-failure] ${JSON.stringify({ pathname: new URL(page.url()).pathname.slice(0, 160), snapshot, errorCategories })}`,
-    );
+    console.error(`[real-config-readback-failure] ${JSON.stringify(snapshot)}`);
   } finally {
     deadline.abort();
   }
@@ -821,7 +802,7 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
     try {
       await connected.page.getByRole("button", { name: "Raw", exact: true }).click();
     } catch (error) {
-      await captureConfigReadbackFailure(connected.page, connected.errors).catch(() => {});
+      await captureConfigReadbackFailure(connected.page).catch(() => {});
       throw error;
     }
     const rawEditor = connected.page.locator(".config-raw-field textarea");

--- a/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
+++ b/ui/src/e2e/control-ui-auth-transports.e2e.test.ts
@@ -4,7 +4,9 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer, type IncomingMessage } from "node:http";
 import net from "node:net";
 import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import { asNullableRecord } from "@openclaw/normalization-core/record-coerce";
+import type { RouterState } from "@openclaw/uirouter";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { WebSocket, WebSocketServer, type RawData } from "ws";
@@ -587,6 +589,88 @@ async function readConfigProofSnapshot(): Promise<{ identifier: unknown; prefix:
   };
 }
 
+async function captureConfigReadbackFailure(page: Page, pageErrors: string[]): Promise<void> {
+  const deadline = new AbortController();
+  try {
+    // Capture only route/DOM facts, never config values or the runtime's auth/hello state.
+    // Playwright evaluate has no timeout; a stalled renderer must not hide the click failure.
+    const snapshot = await Promise.race([
+      page
+        .evaluate(() => {
+          const app = document.querySelector<
+            HTMLElement & {
+              runtime?: { router: { getState: () => RouterState } };
+            }
+          >("openclaw-app");
+          const state = app?.runtime?.router.getState();
+          const matches = (entries: RouterState["matches"] = []) =>
+            entries.slice(0, 3).map((entry) => ({
+              routeId: entry.routeId.slice(0, 80),
+              status: entry.status,
+              fetching: entry.isFetching,
+              moduleLoaded: entry.module !== undefined,
+              hasError: entry.error !== undefined,
+            }));
+          const rawButtons = [...document.querySelectorAll<HTMLButtonElement>("button")].filter(
+            (button) => button.textContent?.trim() === "Raw",
+          );
+          return {
+            pathname: location.pathname.slice(0, 160),
+            readyState: document.readyState,
+            routerStatus: state?.status ?? null,
+            resolvedPathname: state?.resolvedLocation?.pathname.slice(0, 160) ?? null,
+            matches: matches(state?.matches),
+            pendingMatches: matches(state?.pendingMatches),
+            configPageId:
+              document
+                .querySelector<HTMLElement & { pageId?: string }>("openclaw-config-page")
+                ?.pageId?.slice(0, 80) ?? null,
+            elements: Object.fromEntries(
+              [
+                "openclaw-app-shell",
+                "openclaw-config-page",
+                ".config-mode-toggle",
+                ".lazy-view-error",
+                ".lazy-view-state--loading",
+                ".login-gate__failure",
+              ].map((selector) => [selector, document.querySelectorAll(selector).length]),
+            ),
+            rawButtonCount: rawButtons.length,
+            rawButtons: rawButtons.slice(0, 3).map((button) => ({
+              disabled: button.disabled,
+              hasLayout: button.getClientRects().length > 0,
+            })),
+            scripts: (performance.getEntriesByType("resource") as PerformanceResourceTiming[])
+              .filter((entry) => entry.initiatorType === "script")
+              .filter((entry) => {
+                const url = new URL(entry.name);
+                return url.origin === location.origin && url.pathname.startsWith("/assets/");
+              })
+              .slice(-8)
+              .map((entry) => ({
+                pathname: new URL(entry.name).pathname.slice(0, 160),
+                responseStatus: entry.responseStatus,
+              })),
+          };
+        })
+        .catch(() => "unavailable"),
+      delay(1_000, "timed-out", { signal: deadline.signal }),
+    ]);
+    const errorCategories = pageErrors
+      .slice(-8)
+      .map((error) =>
+        /dynamically imported module|module script|ChunkLoadError/u.test(error)
+          ? "module-load"
+          : (/^(?:TypeError|ReferenceError|SyntaxError|RangeError)\b/u.exec(error)?.[0] ?? "other"),
+      );
+    console.error(
+      `[real-config-readback-failure] ${JSON.stringify({ pathname: new URL(page.url()).pathname.slice(0, 160), snapshot, errorCategories })}`,
+    );
+  } finally {
+    deadline.abort();
+  }
+}
+
 async function waitForConnectionEvidence(
   predicate: (entry: ProxyConnectionEvidence) => boolean,
   evidenceStartIndex: number,
@@ -734,7 +818,12 @@ describeControlUiE2e("Control UI real auth transports E2E", () => {
       .locator("openclaw-app-shell")
       .waitFor({ timeout: controlUiSettleTimeoutMs });
     expect((await connected.page.goto(rawSettingsUrl.toString()))?.status()).toBe(200);
-    await connected.page.getByRole("button", { name: "Raw", exact: true }).click();
+    try {
+      await connected.page.getByRole("button", { name: "Raw", exact: true }).click();
+    } catch (error) {
+      await captureConfigReadbackFailure(connected.page, connected.errors).catch(() => {});
+      throw error;
+    }
     const rawEditor = connected.page.locator(".config-raw-field textarea");
     await rawEditor.waitFor();
     await expect.poll(() => rawEditor.inputValue()).toContain(`"${configProofIdentifier}"`);


### PR DESCRIPTION
Related: [original Daytona addition #121554](https://github.com/openclaw/openclaw/pull/121554), [canonical plugin/SDK removal #130996](https://github.com/openclaw/openclaw/pull/130996), [canonical MCP cancellation proof #131680](https://github.com/openclaw/openclaw/pull/131680), [transcript repair #131539](https://github.com/openclaw/openclaw/pull/131539), and [SQLite fixture repair within #130986](https://github.com/openclaw/openclaw/pull/130986).

## What Problem This Solves

This completes the incidental ACPX/Tlon portion of the maintainer's explicitly requested **whole-original-commit rollback**. Daytona's plugin, SDK, catalogs and docs were already removed by #130996; this PR preserves that canonical removal rather than duplicating it. It also retains the independently proven Swift test repair and fixes shared-tooltip accessible names uncovered while satisfying the landing gates.

A title tooltip could retain its temporary accessible name when an existing text node became a label or when an ARIA-hidden descendant became visible. Decorative ARIA-hidden text could also prevent a title from naming an otherwise unnamed control. The final repair covers initial content and active descendant/subtree transitions, without a Raw-button-specific workaround.

## Why This Change Was Made

Current head: `8b01ee1ac17995a5ab8f0fcc536016b63ae9c121`. Pinned branch base: `a696e4f6875014a9a76fb48ead73b0f7da4937cb`.

The final refresh was driven by an actual failed merged dependency graph, not routine main drift. Main's valid [dependency refresh #131719](https://github.com/openclaw/openclaw/pull/131719) removed its last handler 4.11.2 caller and pruned that resolution. Git's textual merge retained this PR's reintroduced Tlon caller while accepting the pruning. Both parents had valid graphs; their merged graph did not. One conflict-free rebase plus **ten restored lockfile lines** retains the exact previously reviewed package/snapshot, integrity and transitive references. All ten non-lock PR files are byte-identical to the prior head; no versions, overrides or guards changed.

The remaining inverse restores the ACPX fixture callback and Tlon S3 client/presigner pins from 3.1117.0 to 3.1113.0, including their 22 lockfile lines. This is deliberate whole-commit scope, not an accidental downgrade. Historical full revert `13bf3d26892d7b1cd8fff5dbe3c28a482de7d97d` was checked across the original 30 paths against `3a5cb3847c77a0e021fdc90da8cdce0005e99d46`; the current residual patch is not claimed byte-identical to that historical inverse.

The Swift test now checks the writer's no-SIGPIPE flag, the property its helper owns. Concurrent forked children can retain pipe readers, so closing one local reader cannot prove process-wide reader closure. The unchanged real worker test still verifies that closed child input fails without terminating the app.

The tooltip repair extends the existing name predicate and active-trigger observer. Main's opacity/name distinction is preserved. The observer now receives both text-node and `aria-hidden` changes; it releases only an adapter-owned name and preserves explicit ARIA ownership. Canonical MCP/transcript repairs are retained with no duplicate overlay. No SQLite or Doctor repair is included here: main's #130986 already owns the fixture writer-release/offline-maintenance correction.

Two bounded test diagnostics remain: the existing catch-only Raw context and a browser-bootstrap observer on existing relay/direct-page boundaries. Neither changes production browser behavior, adds a CDP client/domain, rewrites the installed extension, retries an action, or weakens access checks/assertions/timeouts.

## User Impact

Tooltips preserve the control's current accessible name across opacity, text and ARIA-hidden transitions, including nested labels. There is no new public API, configuration option, schema, protocol, dependency or runtime fallback. Crabbox remains unchanged; this is not a claim of Daytona feature parity or a fix for the separate direct-dispatch resource-class incompatibility.

Tlon's dependency reversal remains an intentional runtime-graph change. The inspected caller signs locally and uploads through guarded fetch rather than the SDK HTTP transport. The evidence below supports that specific path, not blanket security equivalence for arbitrary SDK consumers.

## Evidence

**Current source:** 11 files, **+691/-66**. Production **+7/-1 (net +6)**; tests/support **+661/-52**; dependency metadata/lock **+23/-13**. The active-ARIA repair is production +1/-1 and tests +38/-0; the final lock repair is metadata +10/-0 only. Production growth is confined to the existing tooltip predicate/observer; diagnostic growth is test-only.

**Final dependency/build proof:** the exact failed merge and clean rebased tree reproduced the missing snapshot with both frozen install and the existing production-audit owner. After restoring the original records, online pnpm normalization and actual frozen install both passed without changing the repaired lock bytes. The production audit passed its high-severity threshold, actual synthetic SDK signing again made zero transport calls, and **32 Tlon files / 300 tests passed**. The complete standard root build passed in **5m 1.4s** using the existing CI-supported 8 GB setting, including runtime/plugin compilation, CLI bootstrap, SDK declarations, UI and final metadata. The complete lock-selected changed gate passed all selected lanes, all 94 generated npm-lock checks, types/lints/guards, and zero runtime import cycles. No stages or safety checks were skipped.

```bash
pnpm install --frozen-lockfile
```

```bash
node scripts/pre-commit/pnpm-audit-prod.mjs --audit-level=high
```

```bash
node --import ./scripts/tsx.mjs scripts/test-extension.mts tlon
```

```bash
NODE_OPTIONS=--max-old-space-size=8192 pnpm build
```

```bash
node scripts/check-changed.mjs -- pnpm-lock.yaml
```

The current full build's startup JavaScript is **345361 B**, below the unchanged **347037 B** limit, with 774 finalized sidecars. Node 24.20.0 / repository-pinned pnpm 11.22.0 were used. An initial offline normalization failed for unavailable cached registry metadata; normal online normalization passed with the exact repaired bytes unchanged. The installed Tlon client resolves handler **4.11.2**; main's other callers retain their separate **4.11.3** resolution.

**Active-ARIA behavioral proof (unchanged source bytes, before rebase):** both new cases failed against unchanged production (**2 failed / 10 passed**): the real `Edit` role lookup returned no control while the stale injected title name remained. The one-line observer repair then passed **49/49** tooltip tests (12 real-browser cases and 37 unit cases). Both new cases exercise hidden → revealed → hidden, real clicks by the exact current name, and restoration, for a label and its enclosing subtree. The earlier static-name regressions also failed against canonical main before repair.

Local proof used Node 24.20.0 and independently signature-verified Google Chrome 151.0.7922.175 through the UI harness's existing executable override. Fresh temporary profiles, headless debugging pipes and cleanup were observed. This is signed local Chrome proof, **not Linux Chromium 151.0.7922.34 parity**. The separate extension-bootstrap fixture was not substituted onto that browser.

```bash
# From ui/, with the existing signed-browser override and live-mode flags unset:
node ../scripts/run-vitest.mjs run --config vitest.config.ts src/components/tooltip-title.browser.test.ts src/components/tooltip.test.ts
```

The UI build passed unchanged budgets: **346512 startup gzip bytes <= 347037**, with 774 finalized sidecars. Complete selected changed-file gates passed, including guards, dead exports, i18n, core-test/UI types, lint, styles and formatting.

```bash
node scripts/ui.js build
```

```bash
node scripts/check-changed.mjs -- ui/src/components/tooltip-title.ts ui/src/components/tooltip-title.browser.test.ts
```

The full, original-order real-Gateway auth file passed **3/3** in 63.12 seconds. It verified the served and loaded `assets/index-DK7nVSjM.js` against build SHA256 `9f4e454eaf61bf7f3822dc4c47dbe865786dcc8400f6bc09253db9b1690d68ac`, one `config.set`, exact 64-bit string persistence, both Raw interactions/readback, proxy and origin behavior, and closed Gateway/proxy ports. Only isolated test state was used.

```bash
OPENCLAW_CAPTURE_UI_PROOF=0 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/control-ui-auth-transports.e2e.test.ts
```

Fresh independent Codex autoreview of the rebased final tree covered **all 11 files**, including the restored lock records through complete scanned working-tree datasets. It returned **no actionable P0–P2 findings**, confidence 0.90. Source hashes remained unchanged through the subsequently completed build/checks and commit. The reviewer did not independently execute tests or count then-pending gates as passed. The earlier complete ARIA review was also clean; neither review is a substitute for exact-head hosted CI.

**Hosted proof remains SHA-specific.** [Diagnostic-head run 33174560802](https://github.com/openclaw/openclaw/actions/runs/33174560802), attempt 1, completed successfully on `b8fa96c7c4ab481e1c7355f97eebcae54ac67fda`, tested as merge `8f975a07d0e4b908d2d6ce8ff7f6da61e7111c03` into `cb696a1bb3b66a8d51392a8ab743e270e4f249cf`. The repaired head's [CI run 33180044724](https://github.com/openclaw/openclaw/actions/runs/33180044724), attempt 1, has now completed **SUCCESS** on `8b01ee1ac17995a5ab8f0fcc536016b63ae9c121`, tested as merge `cf0ef00f9634d60da0bdfc19bd5828a9fe960606`. Actual executed proof includes **11,897 UI tests** (one unrelated skip), all **49 tooltip cases** including both active-ARIA regressions, real-Gateway MCP 2/2, auth 3/3, usage 2/2 and Logs 1/1; actual parallel Swift **1,859 app tests + 1,493 Kit tests**; and complete browser-bootstrap and SQLite-lifecycle cases. Build and security-fast passed. This is current-head Linux proof, not reuse of the older run. A separately constructed merge with current main `74d1852f730c3f095184808256179a36c3d9e4fd` also resolves all 1,132 production package names through the canonical audit owner, retaining both handler versions. The intervening [failed run 33177042544](https://github.com/openclaw/openclaw/actions/runs/33177042544), attempt 1, tested prior head d428 as merge `f0121270c65a0b4428c0fdf5eabcfa8f2671f6dc` into `1bfcb7158414f3152591524dd5d8967716ebf7b0`. Its missing handler snapshot caused broad setup/audit failures before the affected tests, not tooltip assertions or a new advisory. That exact graph failure was reproduced and repaired as described above; the failed run remains failed evidence.

- [Browser bootstrap job 98859967213](https://github.com/openclaw/openclaw/actions/runs/33174560802/job/98859967213) passed the complete original flow. Its bounded trace recorded injection consumption, actual reconnect, HTTP 200, navigation/load, preserved selected/unrelated ownership and cleanup: 126 records, no diagnostic drops. This does not prove the cause or repair of the historical 20-second timeout. A separate follow-up is recorded for shared Fetch completion ownership: MCP and Playwright attempted to complete the same pause; exact error category and any relationship to the old timeout remain unproven. No policy bypass was demonstrated.
- [SQLite lifecycle job 98860996185](https://github.com/openclaw/openclaw/actions/runs/33174560802/job/98860996185) passed with main's canonical fixture repair already in the tested base. Its helper is byte-identical to the separately tested #130986 candidate. **Chronology correction:** the prior logged Gateway refusal was the intentional pre-Doctor negative control, not a failed post-import restart. The earlier full Doctor timeout remains causally unproven. Successful Doctor stdout was not independently emitted; the complete lifecycle test pass is the evidence.
- Earlier exact-head [run 33169454798](https://github.com/openclaw/openclaw/actions/runs/33169454798) supplies unchanged-source detailed proof: 11,880 UI tests including the then-47 tooltip cases, real-Gateway MCP/auth/usage/Logs, and actual parallel Swift 1,854 app tests plus 1,484 Kit tests. Its browser/SQLite failures are retained as failed history, not relabeled passes.

**Latest review dispositions:** the active `aria-hidden` finding is repaired with failed-before/passed-after real-browser proof. ClawSweeper's own mis-scoped UI command exceeded its terminal budget; the focused commands above completed. Its upstream/Codex availability gaps are covered by direct maintainer inspection:

- S3 source trees are identical in 3.1113.0 and 3.1117.0: client `48dc20b6d01327fe9c8a5faa5fc6a9c76e325add`, presigner `6b5165f75fe30b7e2146259c4965f1d5189bba19`. The resolved handler difference is the inspected [Smithy own-property guard patch](https://github.com/smithy-lang/smithy-typescript/commit/a825452362c87c376e8e75db8691e6ef81002e83). Tlon's unchanged sign-then-guarded-fetch caller, actual synthetic SDK signing with zero calls to a throwing transport, and **32 files / 296 tests passed** support the used path. No live S3 or blanket security claim.
- Direct [Codex stdio source](https://github.com/openai/codex/blob/d47e5cc0e2bbd35774dff15c83570519735d2ac4/codex-rs/app-server-transport/src/transport/stdio.rs#L46) confirms line-delimited input and newline-delimited output at line 88; transport JSON/RPC contracts were also inspected. ACPX's real subprocess test and targeted type-aware lint passed. The request to retain the newer wrapper/pins is intentionally declined under the whole-commit inverse instruction.

Generic local captures were inspected, but unchanged pixels do not demonstrate accessible-name semantics; real browser role/name assertions do. Media upload remains unavailable because device classification/publication approval is not established. No raw auth/config/hello/protocol bundles, transcripts or media are published. The current uninterrupted root build now passes; earlier 4 GB/partial build failures remain historical failures, and no new full release-suite or release-fixture-copy pass is claimed. A metadata-only commit also exposed a non-fatal macOS Bash 3 empty-array warning in `git-hooks/pre-commit:53`; the commit completed and independently checked source hashes/gates remained unchanged. The empty-restage hook path is a named maintainer-tooling follow-up, not a hook bypass or change here. **Land-ready on the verified PR head.** After the main-only failures and expanded cleanup scope were disclosed, the maintainer explicitly requested landing this existing PR. Its required exact-head CI is green, direct dependency/Codex proof is recorded, and the current main `9a7de4daa8102a77c1b4280a2bf4a4d55ec2177c` merge candidate's dependency graph resolves correctly. Proceed through the normal native prepare/merge gates without an admin bypass or more unrelated code changes. The [earlier main agent.wait failure](https://github.com/openclaw/openclaw/actions/runs/33181411519/job/98883624703) and [newer main CI failures](https://github.com/openclaw/openclaw/actions/runs/33183713795) remain separate, documented follow-ups; no cause or repair is claimed for them. The main investigation was read-only, with no runtime or storage edits.
