### PR TITLE
fix(gateway): admin-only roles reject valid scope upgrades

### DIFF
--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -149,9 +149,12 @@ configured host targets cannot bypass this restriction. The agent's managed
 GitHub identity is not injected into sandboxed execution: `GH_CONFIG_DIR` is
 absent, and `GH_TOKEN` and `GITHUB_TOKEN` are blanked.
 
-The role's `scopes` list intersects scopes granted through connection auth,
-identity grants, pairing, scope upgrades, and authenticated trusted-proxy HTTP
-requests. It cannot grant scopes the connection did not already receive.
+The role's `scopes` list caps scopes granted through connection auth, identity
+grants, pairing, scope upgrades, and authenticated trusted-proxy HTTP requests.
+The ceiling uses the normal scope implications: `operator.admin` permits every
+operator scope, and `operator.write` permits `operator.read` and `operator.talk`.
+It only filters existing grants; it cannot add scopes the connection did not
+already receive.
 Control UI plugin grants carry the authenticated profile inside a signed
 cookie; plugin HTTP requests reapply the profile's current role ceiling and
 reject grants without a matching durable identity when roles are enabled.
@@ -307,8 +310,14 @@ the Gateway returns the new token only to that device's live waiter; the browser
 stores it before reconnecting. Canceling the wait or disconnecting before
 approval falls back to the ordinary pairing repair flow on the next connection.
 
+A role with only `operator.admin` permits the Control UI's full operator scope
+request. Approval is still required; the role ceiling does not grant device
+scopes on its own.
+
 Requests outside the authenticated person's assigned role ceiling are denied,
-not queued for device approval. The Control UI shows the denial and administrator
+not queued for device approval. The Gateway checks the current role again after
+approval, before returning the token, so a role demotion during the wait still
+blocks an out-of-role result. The Control UI shows the denial and administrator
 guidance without **Retry**; an administrator must change the role first.
 
 The explicit exception is the administrator-capable Control UI owner profile

--- a/docs/gateway/operator-scopes.md
+++ b/docs/gateway/operator-scopes.md
@@ -155,6 +155,10 @@ The ceiling uses the normal scope implications: `operator.admin` permits every
 operator scope, and `operator.write` permits `operator.read` and `operator.talk`.
 It only filters existing grants; it cannot add scopes the connection did not
 already receive.
+This includes plugin HTTP requests and WebSocket upgrades: without a scope
+header, ordinary Gateway-authenticated plugin routes start with only
+`operator.write`, then apply the role ceiling. Read-only and empty roles
+therefore receive no runtime scopes on that default path.
 Control UI plugin grants carry the authenticated profile inside a signed
 cookie; plugin HTTP requests reapply the profile's current role ceiling and
 reject grants without a matching durable identity when roles are enabled.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -374,6 +374,7 @@ Operator scopes (`src/gateway/operator-scopes.ts`), the full closed set:
 - `operator.write`
 - `operator.admin`
 - `operator.approvals`
+- `operator.questions`
 - `operator.pairing`
 - `operator.talk`
 - `operator.talk.secrets`

--- a/src/gateway/control-ui-plugin-auth-cookie.test.ts
+++ b/src/gateway/control-ui-plugin-auth-cookie.test.ts
@@ -1,10 +1,15 @@
 import type { IncomingMessage } from "node:http";
 import { describe, expect, it } from "vitest";
+import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profiles.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   resolveControlUiPluginAuthCookieGrants,
   setControlUiPluginAuthCookie,
 } from "./control-ui-plugin-auth-cookie.js";
+import { authorizeControlUiPluginCookieRequest } from "./http-auth-utils.js";
+import { invalidateOperatorRolePolicy } from "./operator-role-policy.js";
 import { makeMockHttpResponse } from "./test-http-response.js";
+import { withTempConfig } from "./test-temp-config.js";
 
 function issueCookie(profileId?: string): string {
   const { res, setHeader } = makeMockHttpResponse();
@@ -21,7 +26,70 @@ function issueCookie(profileId?: string): string {
   return header.split(";", 1)[0]!;
 }
 
+function authorizeCookie(cookie: string) {
+  return authorizeControlUiPluginCookieRequest(
+    { method: "GET", headers: { cookie } } as IncomingMessage,
+    {
+      requestPath: "/plugins/example/session",
+      authGeneration: "generation",
+    },
+  );
+}
+
+async function withRoleConfig(run: () => Promise<void>) {
+  await withOpenClawTestState({ scenario: "minimal" }, async () => {
+    await withTempConfig({
+      cfg: {
+        gateway: {
+          roles: {
+            default: "denied",
+            definitions: {
+              admin: { sessions: { others: "write" }, agents: "*", scopes: ["operator.admin"] },
+              writer: { sessions: { others: "write" }, agents: "*", scopes: ["operator.write"] },
+              denied: { sessions: { others: "none" }, agents: [], scopes: [] },
+            },
+          },
+        },
+      },
+      run,
+    });
+  });
+}
+
 describe("Control UI plugin auth cookie profile binding", () => {
+  it.each(["admin", "writer"])(
+    "preserves a read grant under %s until the profile is demoted",
+    async (role) => {
+      await withRoleConfig(async () => {
+        const profile = ensureProfileForEmail("plugin-reader@example.test");
+        setUserProfileRole(profile.id, role);
+        const cookie = issueCookie(profile.id);
+        try {
+          expect(authorizeCookie(cookie)?.requestAuth).toMatchObject({
+            authenticatedUserProfile: { profileId: profile.id },
+            controlUiPluginGrants: [{ pluginId: "example", scopes: ["operator.read"] }],
+          });
+          setUserProfileRole(profile.id, "denied");
+          invalidateOperatorRolePolicy(profile.id);
+          expect(authorizeCookie(cookie)?.requestAuth.controlUiPluginGrants).toMatchObject([
+            { pluginId: "example", scopes: [] },
+          ]);
+        } finally {
+          invalidateOperatorRolePolicy(profile.id);
+        }
+      });
+    },
+  );
+
+  it.each([undefined, "missing-profile"])(
+    "rejects a signed grant without a current durable profile (%s)",
+    async (profileId) => {
+      await withRoleConfig(async () => {
+        expect(authorizeCookie(issueCookie(profileId))).toBeNull();
+      });
+    },
+  );
+
   it("preserves the authenticated durable profile inside the signed grant", () => {
     const request = {
       headers: { cookie: issueCookie("profile-guest") },
@@ -43,7 +111,7 @@ describe("Control UI plugin auth cookie profile binding", () => {
     ]);
   });
 
-  it("keeps legacy grants unchanged when no profile is bound", () => {
+  it("keeps legacy grants unchanged when no profile is bound", async () => {
     const request = { headers: { cookie: issueCookie() } } as IncomingMessage;
 
     expect(
@@ -59,5 +127,18 @@ describe("Control UI plugin auth cookie profile binding", () => {
         scopes: ["operator.read"],
       },
     ]);
+    await withTempConfig({
+      cfg: {},
+      run: async () => {
+        expect(authorizeCookie(issueCookie())?.requestAuth.controlUiPluginGrants).toEqual([
+          {
+            pluginId: "example",
+            path: "/plugins/example",
+            match: "prefix",
+            scopes: ["operator.read"],
+          },
+        ]);
+      },
+    });
   });
 });

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -192,7 +192,7 @@ function resolveHttpProfile(profileId: string, updatedAt: number, cfg: OpenClawC
   };
 }
 
-function applyHttpOperatorRoleScopeCeiling<Scope extends string>(
+export function applyHttpOperatorRoleScopeCeiling<Scope extends string>(
   scopes: Scope[],
   auth: Pick<AuthorizedGatewayHttpRequest, "operatorRolePolicy"> | undefined,
 ): Scope[] {

--- a/src/gateway/http-auth-utils.ts
+++ b/src/gateway/http-auth-utils.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { verifyDeviceToken } from "../infra/device-pairing-tokens.js";
 import { listDevicePairing } from "../infra/device-pairing.js";
 import { verifyPairingToken } from "../infra/pairing-token.js";
+import { roleScopesAllow } from "../shared/operator-scope-compat.js";
 import {
   ensureProfileForEmail,
   ensureProfileForTailscaleIdentity,
@@ -191,12 +192,16 @@ function resolveHttpProfile(profileId: string, updatedAt: number, cfg: OpenClawC
   };
 }
 
-function applyHttpOperatorRoleScopeCeiling(
-  scopes: string[],
+function applyHttpOperatorRoleScopeCeiling<Scope extends string>(
+  scopes: Scope[],
   auth: Pick<AuthorizedGatewayHttpRequest, "operatorRolePolicy"> | undefined,
-): string[] {
-  const allowedScopes: readonly string[] | undefined = auth?.operatorRolePolicy?.scopes;
-  return allowedScopes ? scopes.filter((scope) => allowedScopes.includes(scope)) : scopes;
+): Scope[] {
+  const allowedScopes = auth?.operatorRolePolicy?.scopes;
+  return allowedScopes
+    ? scopes.filter((scope) =>
+        roleScopesAllow({ role: "operator", requestedScopes: [scope], allowedScopes }),
+      )
+    : scopes;
 }
 
 function shouldTrustDeclaredHttpOperatorScopes(
@@ -519,18 +524,13 @@ export function authorizeControlUiPluginCookieRequest(
       return null;
     }
   }
-  const authorizedGrants = authenticatedProfile.operatorRolePolicy
-    ? grants.map((grant) => ({
-        ...grant,
-        scopes: grant.scopes.filter((scope) =>
-          authenticatedProfile.operatorRolePolicy?.scopes.includes(scope),
-        ),
-      }))
-    : grants;
+  for (const grant of grants) {
+    grant.scopes = applyHttpOperatorRoleScopeCeiling(grant.scopes, authenticatedProfile);
+  }
   return {
     requestAuth: {
       trustDeclaredOperatorScopes: false,
-      controlUiPluginGrants: authorizedGrants,
+      controlUiPluginGrants: grants,
       ...authenticatedProfile,
     },
     // Route dispatch selects the candidate that owns the first matched gateway

--- a/src/gateway/http-utils.request-context.test.ts
+++ b/src/gateway/http-utils.request-context.test.ts
@@ -3,6 +3,7 @@
  */
 import type { IncomingMessage } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GatewayOperatorRoleDefinition } from "../config/types.gateway.js";
 import { resolveHttpSenderIsOwner } from "./http-auth-utils.js";
 import {
   authorizeOpenAiCompatibleHttpModelOverride,
@@ -11,6 +12,7 @@ import {
   resolveGatewayRequestContext,
   resolveTrustedHttpOperatorScopes,
 } from "./http-utils.js";
+import { CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
 
 const sessionEntries = vi.hoisted(() => new Map<string, Record<string, unknown>>());
 
@@ -222,24 +224,71 @@ describe("resolveTrustedHttpOperatorScopes", () => {
     expect(scopes).toStrictEqual([]);
   });
 
-  it("caps trusted-proxy headers and defaults to the verified profile's role", () => {
-    const requestAuth = {
-      trustDeclaredOperatorScopes: true,
-      operatorRolePolicy: {
-        sessions: { others: "view" as const },
-        agents: ["guest"],
-        scopes: ["operator.read" as const],
-      },
-    };
+  it.each<{
+    label: string;
+    roleScopes: GatewayOperatorRoleDefinition["scopes"];
+    expectedScopes: string[];
+    expectedDefaults: string[];
+  }>([
+    {
+      label: "read",
+      roleScopes: ["operator.read"],
+      expectedScopes: ["operator.read"],
+      expectedDefaults: ["operator.read"],
+    },
+    {
+      label: "admin",
+      roleScopes: ["operator.admin"],
+      expectedScopes: [
+        "operator.admin",
+        "operator.read",
+        "operator.write",
+        "operator.talk",
+        "operator.approvals",
+        "operator.talk.secrets",
+      ],
+      expectedDefaults: [...CLI_DEFAULT_OPERATOR_SCOPES],
+    },
+    {
+      label: "write",
+      roleScopes: ["operator.write"],
+      expectedScopes: ["operator.read", "operator.write", "operator.talk"],
+      expectedDefaults: ["operator.read", "operator.write"],
+    },
+    { label: "empty", roleScopes: [], expectedScopes: [], expectedDefaults: [] },
+  ])(
+    "caps trusted-proxy headers and defaults to the verified profile's $label role",
+    ({ roleScopes, expectedScopes, expectedDefaults }) => {
+      const requestAuth = {
+        trustDeclaredOperatorScopes: true,
+        operatorRolePolicy: {
+          sessions: { others: "view" as const },
+          agents: ["guest"],
+          scopes: roleScopes,
+        },
+      };
 
-    expect(
-      resolveTrustedHttpOperatorScopes(
-        createReq({ "x-openclaw-scopes": "operator.admin, operator.read, operator.write" }),
-        requestAuth,
-      ),
-    ).toEqual(["operator.read"]);
-    expect(resolveTrustedHttpOperatorScopes(createReq(), requestAuth)).toEqual(["operator.read"]);
-  });
+      expect(
+        resolveTrustedHttpOperatorScopes(
+          createReq({
+            "x-openclaw-scopes":
+              "operator.admin, operator.read, operator.write, operator.talk, operator.approvals, operator.talk.secrets",
+          }),
+          requestAuth,
+        ),
+      ).toEqual(expectedScopes);
+      expect(resolveTrustedHttpOperatorScopes(createReq(), requestAuth)).toEqual(expectedDefaults);
+      expect(
+        resolveTrustedHttpOperatorScopes(
+          createReq({ "x-openclaw-scopes": "operator.read" }),
+          requestAuth,
+        ),
+      ).toEqual(roleScopes.length ? ["operator.read"] : []);
+      expect(
+        resolveTrustedHttpOperatorScopes(createReq({ "x-openclaw-scopes": "" }), requestAuth),
+      ).toEqual([]);
+    },
+  );
 });
 
 describe("resolveHttpSenderIsOwner", () => {

--- a/src/gateway/server-methods/device-scope-upgrade.test.ts
+++ b/src/gateway/server-methods/device-scope-upgrade.test.ts
@@ -1,5 +1,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ScopeUpgradeResult } from "../../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { GatewayOperatorRoleDefinition } from "../../config/types.gateway.js";
 
 const { getPairedDeviceMock, requestDevicePairingMock, resolveOperatorRolePolicyMock } = vi.hoisted(
@@ -26,6 +28,66 @@ const GUEST_ROLE = {
   agents: "*",
   scopes: ["operator.read", "operator.write"],
 } satisfies GatewayOperatorRoleDefinition;
+
+const FULL_SCOPES = [
+  "operator.admin",
+  "operator.read",
+  "operator.write",
+  "operator.approvals",
+  "operator.questions",
+  "operator.pairing",
+];
+
+const ROLE_SCOPE_CASES = [
+  {
+    name: "admin implies the full Control UI scope set",
+    allowedScopes: ["operator.admin"],
+    scopes: FULL_SCOPES,
+    allowed: true,
+  },
+  {
+    name: "write implies read and talk",
+    allowedScopes: ["operator.write"],
+    scopes: ["operator.read", "operator.talk"],
+    allowed: true,
+  },
+  {
+    name: "exact scopes within the guest ceiling",
+    allowedScopes: GUEST_ROLE.scopes,
+    scopes: GUEST_ROLE.scopes,
+    allowed: true,
+  },
+  {
+    name: "no operator role policy",
+    allowedScopes: undefined,
+    scopes: FULL_SCOPES,
+    allowed: true,
+  },
+  {
+    name: "guest cannot request admin",
+    allowedScopes: GUEST_ROLE.scopes,
+    scopes: FULL_SCOPES,
+    allowed: false,
+  },
+  {
+    name: "empty ceiling denies read",
+    allowedScopes: [],
+    scopes: ["operator.read"],
+    allowed: false,
+  },
+  {
+    name: "read does not imply write",
+    allowedScopes: ["operator.read"],
+    scopes: ["operator.read", "operator.write"],
+    allowed: false,
+  },
+  {
+    name: "write does not imply approvals",
+    allowedScopes: ["operator.write"],
+    scopes: ["operator.read", "operator.approvals"],
+    allowed: false,
+  },
+];
 
 function createUpgradeContext() {
   const coordinator = {
@@ -90,78 +152,109 @@ describe("device scope upgrade role ceiling", () => {
     resolveOperatorRolePolicyMock.mockReturnValue(undefined);
   });
 
-  it("rejects scope requests outside the authenticated person's assigned role", async () => {
-    resolveOperatorRolePolicyMock.mockReturnValue(GUEST_ROLE);
-
-    const { respond } = await runUpgradeHandler("device.scopes.requestUpgrade", {
-      scopes: ["operator.read", "operator.admin"],
+  describe.each(ROLE_SCOPE_CASES)("$name", ({ allowedScopes, scopes, allowed }) => {
+    const rolePolicy = allowedScopes ? { ...GUEST_ROLE, scopes: allowedScopes } : undefined;
+    const roleDenial = expect.objectContaining({
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("assigned operator role"),
     });
 
-    expect(respond).toHaveBeenCalledWith(
-      false,
-      undefined,
-      expect.objectContaining({
-        code: "INVALID_REQUEST",
-        message: expect.stringContaining("assigned operator role"),
-      }),
-    );
-    expect(requestDevicePairingMock).not.toHaveBeenCalled();
-  });
+    it("enforces the ceiling when requesting approval", async () => {
+      resolveOperatorRolePolicyMock.mockReturnValue(rolePolicy);
 
-  it("allows additional scopes that remain inside the assigned role ceiling", async () => {
-    resolveOperatorRolePolicyMock.mockReturnValue(GUEST_ROLE);
+      const { respond, context } = await runUpgradeHandler("device.scopes.requestUpgrade", {
+        scopes,
+      });
 
-    const { respond } = await runUpgradeHandler("device.scopes.requestUpgrade", {
-      scopes: ["operator.read", "operator.write"],
-    });
-
-    expect(respond).toHaveBeenCalledWith(true, { requestId: "request-1" }, undefined);
-    expect(requestDevicePairingMock).toHaveBeenCalledWith(
-      expect.objectContaining({ scopes: ["operator.read", "operator.write"] }),
-    );
-  });
-
-  it("preserves unrestricted upgrades when no operator role resolves", async () => {
-    const { respond } = await runUpgradeHandler("device.scopes.requestUpgrade", {
-      scopes: ["operator.read", "operator.admin"],
-    });
-
-    expect(respond).toHaveBeenCalledWith(true, { requestId: "request-1" }, undefined);
-    expect(requestDevicePairingMock).toHaveBeenCalledOnce();
-  });
-
-  it("rechecks the current role after approval before disclosing a stronger device token", async () => {
-    const context = createUpgradeContext();
-    let finishApproval: ((result: object) => void) | undefined;
-    context.scopeUpgradeCoordinator.wait.mockImplementation(
-      async () =>
-        await new Promise<object>((resolve) => {
-          finishApproval = resolve;
+      expect(respond).toHaveBeenCalledOnce();
+      if (!allowed) {
+        expect(respond).toHaveBeenCalledWith(false, undefined, roleDenial);
+        expect(requestDevicePairingMock).not.toHaveBeenCalled();
+        expect(context.scopeUpgradeCoordinator.register).not.toHaveBeenCalled();
+        return;
+      }
+      expect(respond).toHaveBeenCalledWith(true, { requestId: "request-1" }, undefined);
+      expect(requestDevicePairingMock).toHaveBeenCalledWith(
+        expect.objectContaining({ scopes: scopes.toSorted(), silent: false }),
+      );
+      expect(context.scopeUpgradeCoordinator.register).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestId: "request-1",
+          owner: { deviceId: "device-1", publicKey: "public-key-1" },
+          requestedScopes: scopes.toSorted(),
+          initialToken: "old-token",
+          initialApprovedAtMs: 1,
         }),
-    );
-    const pending = runUpgradeHandler(
+      );
+    });
+
+    it("uses the current role after waiting before disclosing the approved token", async () => {
+      const context = createUpgradeContext();
+      const approval = createDeferred<ScopeUpgradeResult>();
+      context.scopeUpgradeCoordinator.wait.mockReturnValue(approval.promise);
+      resolveOperatorRolePolicyMock.mockReturnValue({
+        ...GUEST_ROLE,
+        scopes: allowed ? [] : ["operator.admin"],
+      });
+      const pending = runUpgradeHandler(
+        "device.scopes.waitUpgrade",
+        { requestId: "request-1" },
+        context,
+      );
+      expect(context.scopeUpgradeCoordinator.wait).toHaveBeenCalledWith("request-1", {
+        deviceId: "device-1",
+        publicKey: "public-key-1",
+      });
+      resolveOperatorRolePolicyMock.mockReturnValue(rolePolicy);
+      const result: ScopeUpgradeResult = {
+        status: "approved",
+        requestId: "request-1",
+        deviceToken: "upgraded-token",
+        scopes,
+      };
+      approval.resolve(result);
+      const { respond } = await pending;
+
+      expect(respond).toHaveBeenCalledOnce();
+      expect(respond).toHaveBeenCalledWith(
+        allowed,
+        allowed ? result : undefined,
+        allowed ? undefined : roleDenial,
+      );
+    });
+  });
+
+  it.each(["rejected", "expired"] as const)("returns an unchanged %s result", async (status) => {
+    resolveOperatorRolePolicyMock.mockReturnValue({ ...GUEST_ROLE, scopes: [] });
+    const context = createUpgradeContext();
+    const result: ScopeUpgradeResult = { status, requestId: "request-1" };
+    context.scopeUpgradeCoordinator.wait.mockResolvedValue(result);
+
+    const { respond } = await runUpgradeHandler(
       "device.scopes.waitUpgrade",
       { requestId: "request-1" },
       context,
     );
-    expect(finishApproval).toBeDefined();
-    resolveOperatorRolePolicyMock.mockReturnValue(GUEST_ROLE);
-    finishApproval?.({
-      status: "approved",
-      requestId: "request-1",
-      deviceToken: "admin-token",
-      scopes: ["operator.read", "operator.admin"],
-    });
-    const { respond } = await pending;
+
+    expect(respond).toHaveBeenCalledWith(true, result, undefined);
+  });
+
+  it.each([
+    { scopes: ["operator.read", "operator.unknown"], message: "unknown operator scope" },
+    { scopes: ["operator.approvals"], message: "current scopes" },
+  ])("rejects $message even with an admin ceiling", async ({ scopes, message }) => {
+    resolveOperatorRolePolicyMock.mockReturnValue({ ...GUEST_ROLE, scopes: FULL_SCOPES });
+
+    const { respond } = await runUpgradeHandler("device.scopes.requestUpgrade", { scopes });
 
     expect(respond).toHaveBeenCalledWith(
       false,
       undefined,
       expect.objectContaining({
         code: "INVALID_REQUEST",
-        message: expect.stringContaining("assigned operator role"),
+        message: expect.stringContaining(message),
       }),
     );
-    expect(respond.mock.calls[0]?.[1]).toBeUndefined();
+    expect(requestDevicePairingMock).not.toHaveBeenCalled();
   });
 });

--- a/src/gateway/server-methods/device-scope-upgrade.ts
+++ b/src/gateway/server-methods/device-scope-upgrade.ts
@@ -76,7 +76,14 @@ export const scopeUpgradeHandlers: GatewayRequestHandlers = {
       return;
     }
     const rolePolicy = resolveOperatorRolePolicy(client, context.getRuntimeConfig());
-    if (rolePolicy && requestedScopes.some((scope) => !rolePolicy.scopes.includes(scope))) {
+    if (
+      rolePolicy &&
+      !roleScopesAllow({
+        role: "operator",
+        requestedScopes,
+        allowedScopes: rolePolicy.scopes,
+      })
+    ) {
       respond(
         false,
         undefined,
@@ -184,12 +191,15 @@ export const scopeUpgradeHandlers: GatewayRequestHandlers = {
       return;
     }
     if (result.status === "approved") {
+      // Approval may outlive a role change; use the current ceiling before releasing the token.
       const rolePolicy = resolveOperatorRolePolicy(client, context.getRuntimeConfig());
       if (
         rolePolicy &&
-        result.scopes.some(
-          (scope) => !rolePolicy.scopes.some((allowedScope) => allowedScope === scope),
-        )
+        !roleScopesAllow({
+          role: "operator",
+          requestedScopes: result.scopes,
+          allowedScopes: rolePolicy.scopes,
+        })
       ) {
         respond(
           false,

--- a/src/gateway/server.auth.identity-scopes.test.ts
+++ b/src/gateway/server.auth.identity-scopes.test.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from "node:crypto";
-import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -8,6 +6,8 @@ import type { GatewayAuthConfig, GatewayOperatorRolesConfig } from "../config/ty
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { getPairedDevice, listDevicePairing } from "../infra/device-pairing.js";
 import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profiles.js";
+import { invalidateOperatorRolePolicy } from "./operator-role-policy.js";
+import type { OperatorScope } from "./operator-scopes.js";
 import {
   connectReq,
   CONTROL_UI_CLIENT,
@@ -32,9 +32,18 @@ const TRUSTED_PROXY_HEADERS = {
   "x-forwarded-proto": "https",
   "x-forwarded-user": "admin@example.com",
 };
+const NARROW_SCOPES = ["operator.read", "operator.write", "operator.talk"];
+const UPGRADE_SCOPES = [
+  "operator.admin",
+  "operator.read",
+  "operator.write",
+  "operator.approvals",
+  "operator.questions",
+  "operator.pairing",
+];
 
 function deviceIdentityPath(label: string): string {
-  return path.join(os.tmpdir(), `openclaw-${label}-${randomUUID()}.sqlite`);
+  return path.join(tempDirs.make("openclaw-identity-scopes-"), `${label}.sqlite`);
 }
 
 async function configureGatewayAuth(
@@ -70,11 +79,36 @@ describe("gateway identity scope grants", () => {
       assignedRole: "maintainer",
       expectedScopes: ["operator.read", "operator.write", "operator.admin"],
     },
+    {
+      label: "admin-only without identity grants",
+      assignedRole: "admin-only",
+      identityScopes: [],
+      deviceScopes: NARROW_SCOPES,
+      expectedScopes: NARROW_SCOPES,
+    },
+    {
+      label: "write-only with broader identity grants",
+      assignedRole: "write-only",
+      identityScopes: [
+        "operator.admin",
+        "operator.approvals",
+        "operator.talk.secrets",
+      ] satisfies OperatorScope[],
+      deviceScopes: NARROW_SCOPES,
+      expectedScopes: NARROW_SCOPES,
+    },
+    {
+      label: "empty",
+      assignedRole: "denied",
+      deviceScopes: NARROW_SCOPES,
+      expectedScopes: [],
+    },
   ])("applies the $label role ceiling after device and identity grants", async (scenario) => {
+    const identityScopes: OperatorScope[] = scenario.identityScopes ?? ["operator.admin"];
     await configureGatewayAuth(
       {
         mode: "trusted-proxy",
-        identityScopes: { "admin@example.com": ["operator.admin"] },
+        identityScopes: { "admin@example.com": identityScopes },
         trustedProxy: {
           userHeader: "x-forwarded-user",
           requiredHeaders: ["x-forwarded-proto"],
@@ -95,12 +129,23 @@ describe("gateway identity scope grants", () => {
               agents: "*",
               scopes: ["operator.read", "operator.write", "operator.admin"],
             },
+            "admin-only": {
+              sessions: { others: "write" },
+              agents: "*",
+              scopes: ["operator.admin"],
+            },
+            "write-only": {
+              sessions: { others: "write" },
+              agents: "*",
+              scopes: ["operator.write"],
+            },
+            denied: { sessions: { others: "none" }, agents: [], scopes: [] },
           },
         },
       },
     );
+    const profile = ensureProfileForEmail("admin@example.com");
     if (scenario.assignedRole) {
-      const profile = ensureProfileForEmail("admin@example.com");
       setUserProfileRole(profile.id, scenario.assignedRole);
     }
 
@@ -110,12 +155,13 @@ describe("gateway identity scope grants", () => {
         const connected = await connectReq(ws, {
           skipDefaultAuth: true,
           prePairDevice: true,
-          scopes: ["operator.read", "operator.write"],
+          scopes: scenario.deviceScopes ?? ["operator.read", "operator.write"],
           client: CONTROL_UI_CLIENT,
           deviceIdentityPath: deviceIdentityPath(`identity-role-${scenario.label}`),
           browserOrigin: BROWSER_ORIGIN,
         });
         expect(connected.ok).toBe(true);
+        expect((await rpcReq(ws, "status")).ok).toBe(scenario.expectedScopes.length > 0);
         expect(responseScopes(connected)).toEqual(scenario.expectedScopes);
         expect((connected.payload as { auth?: { deviceToken?: string } }).auth?.deviceToken).toBe(
           undefined,
@@ -135,8 +181,53 @@ describe("gateway identity scope grants", () => {
             },
           });
         }
+        if (scenario.assignedRole === "admin-only") {
+          const admin = await openWs(port, TRUSTED_PROXY_HEADERS);
+          try {
+            const adminConnected = await connectReq(admin, {
+              skipDefaultAuth: true,
+              prePairDevice: true,
+              scopes: ["operator.admin"],
+              client: CONTROL_UI_CLIENT,
+              deviceIdentityPath: deviceIdentityPath("scope-upgrade-approver"),
+              browserOrigin: BROWSER_ORIGIN,
+            });
+            expect(adminConnected.ok).toBe(true);
+            expect(
+              (adminConnected.payload as { auth?: { deviceToken?: string } }).auth?.deviceToken,
+            ).toBeUndefined();
+            const registration = await rpcReq<{ requestId: string }>(
+              ws,
+              "device.scopes.requestUpgrade",
+              {
+                scopes: UPGRADE_SCOPES,
+              },
+            );
+            expect(registration.ok).toBe(true);
+            const requestId = registration.payload?.requestId;
+            expect(requestId).toBeTypeOf("string");
+            expect((await rpcReq(admin, "device.pair.approve", { requestId })).ok).toBe(true);
+            const result = await rpcReq<{ status: string; scopes: string[]; deviceToken: string }>(
+              ws,
+              "device.scopes.waitUpgrade",
+              { requestId },
+            );
+            expect(result).toMatchObject({
+              ok: true,
+              payload: {
+                status: "approved",
+                scopes: [...UPGRADE_SCOPES, "operator.talk"].toSorted(),
+              },
+            });
+            expect(result.payload?.deviceToken).toBeTypeOf("string");
+            expect((await rpcReq(ws, "set-heartbeats", { enabled: false })).ok).toBe(false);
+          } finally {
+            admin.close();
+          }
+        }
       } finally {
         ws.close();
+        invalidateOperatorRolePolicy(profile.id);
       }
     });
   });

--- a/src/gateway/server.plugin-http-auth.test.ts
+++ b/src/gateway/server.plugin-http-auth.test.ts
@@ -1,7 +1,7 @@
 // Plugin HTTP auth tests cover protected route canonicalization, operator scope
 // checks, hook/plugin route precedence, and unauthorized variant handling.
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { authorizeOperatorScopesForMethod } from "./method-scopes.js";
 import { canonicalizePathVariant } from "./security-path.js";
@@ -210,6 +210,12 @@ async function expectPluginRequestOk(
 }
 
 describe("gateway plugin HTTP auth boundary", () => {
+  beforeAll(async () => {
+    // Compile the real Control UI owner before the request deadline starts;
+    // this suite verifies route/auth ownership, not source-loader startup latency.
+    await import("./control-ui.js");
+  });
+
   test("applies default security headers and optional strict transport security", async () => {
     await withGatewayTempConfig("openclaw-plugin-http-security-headers-test-", async () => {
       const withoutHsts = createTestGatewayServer({ resolvedAuth: AUTH_NONE });

--- a/src/gateway/server.plugin-http-role-scopes.test.ts
+++ b/src/gateway/server.plugin-http-role-scopes.test.ts
@@ -12,6 +12,7 @@ import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profile
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { authorizeOperatorScopesForMethod, CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
 import { invalidateOperatorRolePolicy } from "./operator-role-policy.js";
+import { MAX_PREAUTH_PAYLOAD_BYTES } from "./server-constants.js";
 import { attachGatewayUpgradeHandler } from "./server-http-upgrades.js";
 import { createRequest, createTestGatewayServer, sendRequest } from "./server-http.test-harness.js";
 import { createGatewayTestRegistry } from "./server/__tests__/test-utils.js";
@@ -140,7 +141,7 @@ describe.each(["write-default", "trusted-operator"] as const)(
         const shouldEnforcePluginGatewayAuth = (
           pathContext: Parameters<typeof shouldEnforceGatewayAuthForPluginPath>[1],
         ) => shouldEnforceGatewayAuthForPluginPath(registry, pathContext);
-        const wss = new WebSocketServer({ noServer: true });
+        const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_PREAUTH_PAYLOAD_BYTES });
         try {
           await withTempConfig({
             cfg,

--- a/src/gateway/server.plugin-http-role-scopes.test.ts
+++ b/src/gateway/server.plugin-http-role-scopes.test.ts
@@ -1,0 +1,210 @@
+// Exercise named-role ceilings through real HTTP auth and plugin runtime dispatch.
+import { once } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { PassThrough } from "node:stream";
+import { describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+import type { GatewayOperatorRoleDefinition } from "../config/types.gateway.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profiles.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { authorizeOperatorScopesForMethod, CLI_DEFAULT_OPERATOR_SCOPES } from "./method-scopes.js";
+import { invalidateOperatorRolePolicy } from "./operator-role-policy.js";
+import { attachGatewayUpgradeHandler } from "./server-http-upgrades.js";
+import { createRequest, createTestGatewayServer, sendRequest } from "./server-http.test-harness.js";
+import { createGatewayTestRegistry } from "./server/__tests__/test-utils.js";
+import {
+  createGatewayPluginRequestHandler,
+  createGatewayPluginUpgradeHandler,
+  shouldEnforceGatewayAuthForPluginPath,
+} from "./server/plugins-http.js";
+import { createPreauthConnectionBudget } from "./server/preauth-connection-budget.js";
+import { withTempConfig } from "./test-temp-config.js";
+
+const routePath = "/role-scoped-plugin";
+const proxyAddress = "203.0.113.10";
+const proxyAuth = {
+  mode: "trusted-proxy",
+  allowTailscale: false,
+  trustedProxy: { userHeader: "x-forwarded-user" },
+} as const;
+const roleCases: Array<{
+  role: string;
+  scopes: GatewayOperatorRoleDefinition["scopes"];
+  writeDefault: string[];
+  trustedDefault: string[];
+  declaredRead: string[];
+}> = [
+  { role: "empty", scopes: [], writeDefault: [], trustedDefault: [], declaredRead: [] },
+  {
+    role: "reader",
+    scopes: ["operator.read"],
+    writeDefault: [],
+    trustedDefault: ["operator.read"],
+    declaredRead: ["operator.read"],
+  },
+  {
+    role: "writer",
+    scopes: ["operator.write"],
+    writeDefault: ["operator.write"],
+    trustedDefault: ["operator.read", "operator.write"],
+    declaredRead: ["operator.read"],
+  },
+  {
+    role: "admin",
+    scopes: ["operator.admin"],
+    writeDefault: ["operator.write"],
+    trustedDefault: [...CLI_DEFAULT_OPERATOR_SCOPES],
+    declaredRead: ["operator.read"],
+  },
+];
+
+function observeRuntimeScope() {
+  const client = getPluginRuntimeGatewayRequestScope()?.client;
+  const scopes = client?.connect?.scopes;
+  return {
+    scopes,
+    profileId: client?.authenticatedUserProfile?.profileId,
+    writeAllowed: authorizeOperatorScopesForMethod("node.invoke", scopes ?? []).allowed,
+  };
+}
+
+async function dispatchPluginUpgrade(
+  server: ReturnType<typeof createTestGatewayServer>,
+  req: IncomingMessage,
+): Promise<string> {
+  const socket = new PassThrough();
+  let body = "";
+  socket.setEncoding("utf8");
+  socket.on("data", (chunk: string) => {
+    body += chunk;
+  });
+  const closed = once(socket, "close");
+  try {
+    server.emit("upgrade", req, socket, Buffer.alloc(0));
+    await closed;
+    return body;
+  } finally {
+    socket.destroy();
+  }
+}
+
+describe.each(["write-default", "trusted-operator"] as const)(
+  "plugin %s named-role ceiling",
+  (surface) => {
+    it.each(roleCases)("caps HTTP and upgrade runtime clients for $role", async (roleCase) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const email = "plugin-role@example.test";
+        const profile = ensureProfileForEmail(email);
+        setUserProfileRole(profile.id, roleCase.role);
+        const cfg: OpenClawConfig = {
+          gateway: {
+            trustedProxies: [proxyAddress],
+            auth: proxyAuth,
+            roles: {
+              default: "denied",
+              definitions: {
+                denied: { sessions: { others: "none" }, agents: [], scopes: [] },
+                [roleCase.role]: {
+                  sessions: { others: "view" },
+                  agents: "*",
+                  scopes: roleCase.scopes,
+                },
+              },
+            },
+          },
+        };
+        const registry = createGatewayTestRegistry({
+          httpRoutes: [
+            {
+              pluginId: "role-scoped-plugin",
+              source: "role-scoped-plugin",
+              path: routePath,
+              auth: "gateway",
+              match: "exact",
+              gatewayRuntimeScopeSurface: surface,
+              handler: async (_req: IncomingMessage, res: ServerResponse) => {
+                res.end(JSON.stringify(observeRuntimeScope()));
+                return true;
+              },
+              handleUpgrade: async (_req, socket) => {
+                socket.end(JSON.stringify(observeRuntimeScope()));
+                return true;
+              },
+            },
+          ],
+        });
+        const log = createSubsystemLogger("test/plugin-role-scopes");
+        const shouldEnforcePluginGatewayAuth = (
+          pathContext: Parameters<typeof shouldEnforceGatewayAuthForPluginPath>[1],
+        ) => shouldEnforceGatewayAuthForPluginPath(registry, pathContext);
+        const wss = new WebSocketServer({ noServer: true });
+        try {
+          await withTempConfig({
+            cfg,
+            run: async () => {
+              const server = createTestGatewayServer({
+                resolvedAuth: proxyAuth,
+                overrides: {
+                  handlePluginRequest: createGatewayPluginRequestHandler({ registry, log }),
+                  shouldEnforcePluginGatewayAuth,
+                },
+              });
+              attachGatewayUpgradeHandler({
+                httpServer: server,
+                wss,
+                handlePluginUpgrade: createGatewayPluginUpgradeHandler({ registry, log }),
+                shouldEnforcePluginGatewayAuth,
+                clients: new Set(),
+                preauthConnectionBudget: createPreauthConnectionBudget(),
+                resolvedAuth: proxyAuth,
+              });
+              const defaultScopes =
+                surface === "write-default" ? roleCase.writeDefault : roleCase.trustedDefault;
+              for (const [header, expectedScopes] of [
+                [undefined, defaultScopes],
+                ["operator.read", roleCase.declaredRead],
+                ["", []],
+              ] as const) {
+                const request = {
+                  path: routePath,
+                  remoteAddress: proxyAddress,
+                  headers: {
+                    "x-forwarded-user": email,
+                    "x-forwarded-for": "198.51.100.20",
+                    ...(header === undefined ? {} : { "x-openclaw-scopes": header }),
+                  },
+                };
+                const expected = {
+                  scopes: expectedScopes,
+                  profileId: profile.id,
+                  writeAllowed: expectedScopes.some(
+                    (scope) => scope === "operator.write" || scope === "operator.admin",
+                  ),
+                };
+                const response = await sendRequest(server, request);
+                expect(response.res.statusCode).toBe(200);
+                expect
+                  .soft(JSON.parse(response.getBody()), `HTTP header=${header}`)
+                  .toEqual(expected);
+                const upgraded = await dispatchPluginUpgrade(
+                  server,
+                  createRequest({
+                    ...request,
+                    headers: { ...request.headers, connection: "upgrade", upgrade: "websocket" },
+                  }),
+                );
+                expect.soft(JSON.parse(upgraded), `upgrade header=${header}`).toEqual(expected);
+              }
+            },
+          });
+        } finally {
+          wss.close();
+          invalidateOperatorRolePolicy(profile.id);
+        }
+      });
+    });
+  },
+);

--- a/src/gateway/server/plugin-route-runtime-scopes.ts
+++ b/src/gateway/server/plugin-route-runtime-scopes.ts
@@ -1,6 +1,7 @@
 // Plugin route runtime scopes map authenticated HTTP callers to operator scopes exposed inside plugin handlers.
 import type { IncomingMessage } from "node:http";
 import {
+  applyHttpOperatorRoleScopeCeiling,
   getHeader,
   resolveTrustedHttpOperatorScopes,
   type AuthorizedGatewayHttpRequest,
@@ -18,19 +19,17 @@ export function resolvePluginRouteRuntimeOperatorScopes(
   requestAuth: AuthorizedGatewayHttpRequest,
   surface: PluginRouteRuntimeScopeSurface = "write-default",
 ): string[] {
-  if (surface === "trusted-operator") {
-    if (!requestAuth.trustDeclaredOperatorScopes) {
-      return [...CLI_DEFAULT_OPERATOR_SCOPES];
-    }
+  const useTrustedScopes =
+    surface === "trusted-operator"
+      ? requestAuth.trustDeclaredOperatorScopes
+      : requestAuth.authMethod === "trusted-proxy" &&
+        getHeader(req, "x-openclaw-scopes") !== undefined;
+  if (useTrustedScopes) {
     return resolveTrustedHttpOperatorScopes(req, requestAuth);
   }
-  if (requestAuth.authMethod !== "trusted-proxy") {
-    return [WRITE_SCOPE];
-  }
-  if (getHeader(req, "x-openclaw-scopes") === undefined) {
-    // Trusted-proxy callers without an explicit scope header keep the legacy
-    // write-default surface instead of inheriting every CLI operator scope.
-    return [WRITE_SCOPE];
-  }
-  return resolveTrustedHttpOperatorScopes(req, requestAuth);
+  // Ordinary plugin routes grant only write by default; a named role can narrow
+  // that grant, never replace it with the role's scopes or the CLI defaults.
+  const defaultScopes =
+    surface === "trusted-operator" ? [...CLI_DEFAULT_OPERATOR_SCOPES] : [WRITE_SCOPE];
+  return applyHttpOperatorRoleScopeCeiling(defaultScopes, requestAuth);
 }

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -18,6 +18,7 @@ import { upsertPresence } from "../../../infra/system-presence.js";
 import { loadVoiceWakeRoutingConfig } from "../../../infra/voicewake-routing.js";
 import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { resolveLocalNodeId } from "../../../node-host/local-id.js";
+import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import { recordRemoteNodeInfo, refreshRemoteNodeBins } from "../../../skills/runtime/remote.js";
 import { classifyTailscaleLogin } from "../../../state/user-profiles-tailscale-login.js";
 import {
@@ -250,7 +251,11 @@ export async function attachAuthenticatedGatewayConnect(
       ? []
       : rolePolicy
         ? effectiveScopes.scopes.filter((scope) =>
-            rolePolicy.scopes.some((allowedScope) => allowedScope === scope),
+            roleScopesAllow({
+              role: "operator",
+              requestedScopes: [scope],
+              allowedScopes: rolePolicy.scopes,
+            }),
           )
         : effectiveScopes.scopes;
   state.scopes = scopes;


### PR DESCRIPTION
Related: #128548 (named operator roles)

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes Control UI administrator-access requests being rejected by a named role containing only `operator.admin`, despite its existing scope implications. The same literal-membership mismatch removed valid read/write grants during WebSocket and HTTP authorization, including read-only plugin-tab cookies.

The review also identified a connected omission: ordinary Gateway-authenticated plugin HTTP requests and WebSocket upgrades without `x-openclaw-scopes` returned a default write grant without applying the named-role ceiling. This PR now repairs that producer as well, rather than leaving a read-only or empty role with plugin write authority.

## Why This Change Was Made

Named-role ceilings use the existing canonical `roleScopesAllow` implication rules. General HTTP, plugin cookies, and plugin default grants share the existing internal ceiling filter. The plugin resolver consolidates duplicate default returns; no new production module, SDK export, or test-only production seam was introduced.

Roles remain ceilings, never grant sources. Ordinary plugin defaults remain only `operator.write`: admin/write roles retain that grant, while read-only/empty roles receive no default runtime scopes. Explicit headers and the existing `trusted-operator` route opt-in retain their separate semantics. Role definitions are not expanded.

Device upgrade admission and approved-result release still deny out-of-role scopes, with the current role resolved after awaiting approval and before token disclosure. Device identity binding, empty-role denial, explicit proxy-header caps, shared-secret exemptions, and token-preservation rules remain intact. No configuration option, schema, protocol, dependency, or deployment change.

Provenance: the literal comparisons and omission of plugin default ceilings came from the named-role integration in #128548, commit 53dcaaedec195fdaf5af06357557c706d3c0caf5, on 2026-08-24. Code author, PR author, and merger: @steipete. The older plugin default itself predates roles; shallow-boundary blame is not used to attribute its original author.

## User Impact

Admin-only roles can request the Control UI's complete scope set without listing each implied scope. Write-only roles retain already-granted read and Talk scopes without gaining admin, approvals, or secret-reading authority. Plugin-tab read grants survive an admin/write ceiling and are removed on demotion. Read-only and empty roles no longer receive headerless plugin write authority.

The scope documentation explains implications, plugin defaults, and post-approval revalidation. The protocol list includes the already-supported `operator.questions` scope.

## Evidence

- Pre-fix handler tests captured four intended implication failures; sibling WebSocket/HTTP/signed-cookie tests captured six more. The plugin-default regression captured four additional assertion failures: HTTP and upgrade dispatch for read-only and empty roles incorrectly received write scope.
- Original boundary/sibling proof passed 169 tests across 11 files. The reviewer's four-file selection passed 75 tests, including deferred role changes before token disclosure and durable-profile cookie demotion.
- The completed plugin follow-up passed 119 tests across eight files. Its eight new role/surface cases perform 48 HTTP/upgrade runtime observations using real authentication, durable temporary profiles, and plugin dispatch; no role/auth helper is mocked. Existing shared-secret/no-role behavior is covered by the retained sibling suites.
- All 28 scoped check stages passed, including production/test types, lint, formatting, dead exports, import cycles, and authorization/storage guards. A test tuple-inference error was corrected and the final 119-test selection passed again. The mechanical rebase preserved both patch identities; 41 authorization sanity tests passed afterward.
- Nearby test cleanup: repeated plugin-manager reservation timeouts came from cold Control UI module loading. A diagnostic waited another 6.75 seconds after the 15-second request deadline; the loaded real handler responded in 0.52 ms. Suite setup now preloads the real module, without changing production behavior, deadlines, or assertions. The complete file and broader selection pass.
- CI's precise scanner found the new test WebSocket fixture lacked an explicit payload bound. It now uses production's `MAX_PREAUTH_PAYLOAD_BYTES`; all eight cases and focused lint pass. No scanner rule or suppression was changed.
- Fresh Codex autoreviews of the follow-up and final test correction passed at the configured P0 threshold. AI-assisted implementation and verification.
- Production LOC: +46/-32 (net +14). Tests: +607/-76 (net +531). Docs: +18/-4. The plugin follow-up removes one net production line; the remaining growth is direct canonical-predicate calls at independent authorization owners and the post-await invariant comment.
- [Inspected live Control UI screenshots/video](https://github.com/openclaw/openclaw/pull/131410#issuecomment-5448300493) show the real limited browser → six-scope request → separate approver → same-device reconnect flow. This evidence is explicitly bound to the earlier implementation head and CI merge recorded in that comment, not misrepresented as a recording of the later plugin-default repair.
- [Final-head CI 33146495334](https://github.com/openclaw/openclaw/actions/runs/33146495334) and [precise scan 33146495323](https://github.com/openclaw/openclaw/actions/runs/33146495323) passed. The [additional real plugin-role matrix](https://github.com/openclaw/openclaw/pull/131410#issuecomment-5448300493) passed 60 operation probes and five missing-identity controls across five fresh isolated Gateways. It uses complete runtime artifact `9676052360`, built at CI merge `6db647f1851c7adbbb4e98a0d0afa2f75992e885` with final head `e6e8f6bf23ad7ec1fe0995795f013fd7178420a2` as a parent; relevant source and locks match. Real public-SDK dispatch distinguishes missing-scope denial from the deliberate absent-node fence, without dispatching a node command. All fixtures are stopped; no real permissions or deployment changed.
- Local build limitation: SDK declarations passed with CI's documented 8 GiB heap, but local CLI startup-metadata generation stalled at `nodes --help`. No timeout or assertion was relaxed; the partial local build was not used as live proof. The original movie uses the complete artifact from [green CI run 33135037051](https://github.com/openclaw/openclaw/actions/runs/33135037051).

Plugin follow-up test command:

```bash
OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/gateway/server.plugin-http-role-scopes.test.ts src/gateway/server.plugin-http-auth.test.ts src/gateway/server/plugin-route-runtime-scopes.test.ts src/gateway/server/plugins-http.runtime-scopes.test.ts src/gateway/http-utils.request-context.test.ts src/gateway/http-utils.authorize-request.test.ts src/gateway/control-ui-plugin-auth-cookie.test.ts src/gateway/server-http.upgrade-claim.test.ts
```

Completed follow-up check command:

```bash
node scripts/check-changed.mjs --timed -- src/gateway/http-auth-utils.ts src/gateway/server/plugin-route-runtime-scopes.ts src/gateway/server.plugin-http-role-scopes.test.ts src/gateway/server.plugin-http-auth.test.ts docs/gateway/operator-scopes.md
```

No real user's permissions, operator gateway, or deployment configuration was changed. The separate Control UI retryable-error repair, dynamic plugin-action Talk-scope follow-up, and local CLI metadata stall remain separately tracked. No release or deployment is requested.
