### PR TITLE
fix(update): keep repair JSON stdout parseable

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -119,6 +119,10 @@ managed npm plugin installs, repairs missing configured plugin payloads,
 refreshes the plugin registry, and writes converged install-record metadata.
 It does not install a new core package and does not restart the Gateway.
 
+With `--json`, stdout contains one JSON document. Doctor panels and other
+diagnostics go to stderr, so stdout can be parsed directly. Failed doctor or
+plugin finalization steps still exit non-zero.
+
 ## `update wizard`
 
 Interactive flow to pick an update channel and confirm whether to restart the

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1004,7 +1004,10 @@ describe("update-cli", () => {
     vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
   };
 
-  const expectFreshPostUpdateDoctor = (params: { yes: boolean }) => {
+  const expectFreshPostUpdateDoctor = (params: {
+    yes: boolean;
+    workspaceSuggestions?: boolean;
+  }) => {
     const calls = vi
       .mocked(runExec)
       .mock.calls.filter(
@@ -1016,7 +1019,7 @@ describe("update-cli", () => {
       "doctor",
       "--repair",
       "--non-interactive",
-      "--no-workspace-suggestions",
+      ...(params.workspaceSuggestions ? [] : ["--no-workspace-suggestions"]),
       ...(params.yes ? ["--yes"] : []),
     ]);
   };
@@ -2853,16 +2856,17 @@ describe("update-cli", () => {
   });
 
   it("keeps fresh doctor output off stdout during json post-core resume", async () => {
-    vi.mocked(runExec).mockResolvedValueOnce({
-      stdout: "doctor ui output",
-      stderr: "doctor diagnostic output",
-    });
+    vi.mocked(runExec).mockImplementation(async (_file, args) => ({
+      stdout: args.includes("doctor") ? "doctor ui output" : "",
+      stderr: args.includes("doctor") ? "doctor diagnostic output" : "",
+    }));
 
     await runPostCoreCommand({ json: true, restart: false });
 
     expectFreshPostUpdateDoctor({ yes: false });
     expect(getLogOutput()).not.toContain("doctor ui output");
-    expect(getErrorOutput()).not.toContain("doctor diagnostic output");
+    expect(getErrorOutput()).toContain("doctor ui output");
+    expect(getErrorOutput()).toContain("doctor diagnostic output");
     expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
       expect.objectContaining({ status: "ok" }),
     );
@@ -7375,6 +7379,7 @@ describe("update-cli", () => {
   });
 
   it("updateFinalizeCommand defers plugin installation during pre-plugin doctor", async () => {
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
     await withEnvAsync(
       {
         OPENCLAW_UPDATE_IN_PROGRESS: undefined,
@@ -7384,8 +7389,11 @@ describe("update-cli", () => {
       },
       async () => {
         let doctorEnv: NodeJS.ProcessEnv | undefined;
-        vi.mocked(doctorCommand).mockImplementationOnce(async () => {
-          doctorEnv = { ...process.env };
+        vi.mocked(runExec).mockImplementationOnce(async (_file, _args, options) => {
+          if (typeof options === "object") {
+            doctorEnv = { ...options.baseEnv, ...options.env };
+          }
+          return { stdout: "", stderr: "" };
         });
         vi.mocked(defaultRuntime.writeJson).mockClear();
 
@@ -7405,11 +7413,7 @@ describe("update-cli", () => {
         expect(process.env.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE).toBe("1");
-        expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
-          nonInteractive: true,
-          repair: true,
-          yes: true,
-        });
+        expectFreshPostUpdateDoctor({ yes: true, workspaceSuggestions: true });
         expect(syncPluginCall()?.channel).toBe("stable");
         expect(syncPluginCall()?.acknowledgeClawHubRisk).toBe(true);
         expect(lastNpmPluginUpdateCall()?.timeoutMs).toBe(9_000);
@@ -7487,6 +7491,9 @@ describe("update-cli", () => {
     pathExists.mockResolvedValue(false);
     await withEnvAsync({ OPENCLAW_UPDATE_POST_CORE: "1" }, async () => {
       const run = async (command: "repair" | "finalize") => {
+        vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(
+          FRESH_POST_UPDATE_ENTRYPOINT,
+        );
         vi.mocked(defaultRuntime.writeJson).mockClear();
         const program = new Command();
         program.name("openclaw");
@@ -7515,7 +7522,7 @@ describe("update-cli", () => {
       restart: false,
     });
 
-    expectNoSideEffects(replaceConfigFile, doctorCommand, syncPluginsForUpdateChannel);
+    expectNoSideEffects(replaceConfigFile, runExec, syncPluginsForUpdateChannel);
     expect(lastWriteJsonCall()).toMatchObject({
       status: "error",
       mode: "git",
@@ -7525,7 +7532,9 @@ describe("update-cli", () => {
   });
 
   it("updateFinalizeCommand repairs doctor by default and refreshes plugin state after doctor", async () => {
-    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce("/tmp/openclaw-entry.mjs");
+    vi.mocked(resolveGatewayInstallEntrypoint)
+      .mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT)
+      .mockResolvedValueOnce("/tmp/openclaw-entry.mjs");
     const preDoctorConfig = {
       update: { channel: "stable" },
       plugins: { entries: { pre: { enabled: true } } },
@@ -7560,15 +7569,12 @@ describe("update-cli", () => {
 
     await updateFinalizeCommand({ json: true, timeout: "9", restart: false });
 
-    expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
-      nonInteractive: true,
-      repair: true,
-      yes: false,
-    });
-    expect(doctorCommand).toHaveBeenCalledTimes(1);
+    expectFreshPostUpdateDoctor({ yes: false, workspaceSuggestions: true });
     const freshDoctorCall = vi
       .mocked(runExec)
-      .mock.calls.find(([, args]) => args.includes("doctor"));
+      .mock.calls.find(
+        ([, args]) => args[0] === "/tmp/openclaw-entry.mjs" && args.includes("doctor"),
+      );
     expect(freshDoctorCall?.[1]).toEqual([
       "/tmp/openclaw-entry.mjs",
       "doctor",
@@ -7594,13 +7600,14 @@ describe("update-cli", () => {
       },
     });
     expect(lastReplaceConfigCall()?.baseHash).toBe("post-doctor");
-    expect(vi.mocked(doctorCommand).mock.invocationCallOrder[0] ?? 0).toBeLessThan(
+    expect(vi.mocked(runExec).mock.invocationCallOrder[0] ?? 0).toBeLessThan(
       loadInstalledPluginIndexInstallRecords.mock.invocationCallOrder[0] ?? 0,
     );
     expect((lastWriteJsonCall() as { channel?: string } | undefined)?.channel).toBe("beta");
   });
 
   it("updateFinalizeCommand restores channels from the RPC pre-update config payload", async () => {
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
     const tempDir = createCaseDir("openclaw-rpc-finalize");
     const sourceConfigPath = path.join(tempDir, "source-config.json");
     const preUpdateConfig = {
@@ -7643,6 +7650,7 @@ describe("update-cli", () => {
   });
 
   it("updateFinalizeCommand reapplies requested channel against post-doctor config", async () => {
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
     const preDoctorConfig = { update: { channel: "stable" } } as OpenClawConfig;
     const postDoctorConfig = { update: { channel: "beta" } } as OpenClawConfig;
     const preDoctorSnapshot = configSnapshot(preDoctorConfig, {
@@ -7671,6 +7679,7 @@ describe("update-cli", () => {
   });
 
   it("updateFinalizeCommand converges on the effective channel from env without persisting update.channel", async () => {
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValueOnce(FRESH_POST_UPDATE_ENTRYPOINT);
     const noChannelConfig = {} as OpenClawConfig;
     const noChannelSnapshot = configSnapshot(noChannelConfig, {
       parsed: baseSnapshot.parsed,

--- a/src/cli/update-cli/update-command-finalize.ts
+++ b/src/cli/update-cli/update-command-finalize.ts
@@ -1,6 +1,5 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
-import { doctorCommand } from "../../commands/doctor.js";
 import {
   assertConfigWriteAllowedInCurrentMode,
   readConfigFileSnapshot,
@@ -34,6 +33,7 @@ import {
 } from "./update-command-config.js";
 import {
   completePostCorePluginUpdate,
+  runUpdateFinalizationDoctorInFreshProcess,
   withPrePluginUpdateDoctorEnv,
 } from "./update-command-fresh-doctor.js";
 import {
@@ -197,10 +197,13 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
       phaseTimings,
       phase: "doctor",
       run: async () => {
-        await doctorCommand(defaultRuntime, {
-          nonInteractive: true,
-          repair: true,
+        await runUpdateFinalizationDoctorInFreshProcess({
+          phase: "pre-plugin",
+          root,
           yes: opts.yes === true,
+          json: opts.json === true,
+          workspaceSuggestions: true,
+          timeoutMs: timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS,
         });
       },
     });

--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -1,4 +1,5 @@
 // Runs the post-plugin migration pass without retaining pre-update plugin modules.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV,
   UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
@@ -99,6 +100,7 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
   root: string;
   yes: boolean;
   json: boolean;
+  workspaceSuggestions?: boolean;
   timeoutMs: number;
   nodeRunner?: string;
   entryPath?: string;
@@ -112,29 +114,38 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
     "doctor",
     "--repair",
     "--non-interactive",
-    "--no-workspace-suggestions",
+    ...(params.workspaceSuggestions ? [] : ["--no-workspace-suggestions"]),
     ...(params.yes ? ["--yes"] : []),
   ];
   const baseEnv = stripGatewayServiceMarkerEnv(disableUpdatedPackageCompileCacheEnv(process.env));
   delete baseEnv[UPDATE_POST_CORE_CONVERGENCE_ENV];
-  const result = await runExec(params.nodeRunner ?? resolveNodeRunner(), args, {
-    cwd: params.root,
-    timeoutMs: params.timeoutMs,
-    maxBuffer: 4 * 1024 * 1024,
-    logOutput: false,
-    baseEnv,
-    env: {
-      OPENCLAW_UPDATE_IN_PROGRESS: "1",
-      [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
-      [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
-      ...(params.phase === "post-plugin" ? { [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1" } : {}),
-    },
-  });
-  if (!params.json) {
-    if (result.stdout.trim()) {
-      defaultRuntime.log(result.stdout.trimEnd());
+  let result: { stdout?: unknown; stderr?: unknown } | undefined;
+  try {
+    result = await runExec(params.nodeRunner ?? resolveNodeRunner(), args, {
+      cwd: params.root,
+      timeoutMs: params.timeoutMs,
+      maxBuffer: 4 * 1024 * 1024,
+      logOutput: false,
+      baseEnv,
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
+        [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
+        ...(params.phase === "post-plugin" ? { [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1" } : {}),
+      },
+    });
+  } catch (error) {
+    if (isRecord(error)) {
+      result = error;
     }
-    if (result.stderr.trim()) {
+    throw error;
+  } finally {
+    // Clack writes directly to the child's stdout. Preserve diagnostics on either
+    // exit path without letting them share the parent's JSON result stream.
+    if (typeof result?.stdout === "string" && result.stdout.trim()) {
+      defaultRuntime[params.json ? "error" : "log"](result.stdout.trimEnd());
+    }
+    if (typeof result?.stderr === "string" && result.stderr.trim()) {
       defaultRuntime.error(result.stderr.trimEnd());
     }
   }

--- a/src/cli/update-cli/update-command-lifecycle.test.ts
+++ b/src/cli/update-cli/update-command-lifecycle.test.ts
@@ -37,12 +37,6 @@ function record(name: string): void {
   mocks.events.push(`${name}:${mocks.leaseActive}`);
 }
 
-vi.mock("../../commands/doctor.js", () => ({
-  doctorCommand: vi.fn(async () => {
-    record("doctor");
-  }),
-}));
-
 vi.mock("../../config/config.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../config/config.js")>()),
   assertConfigWriteAllowedInCurrentMode: vi.fn(),
@@ -207,8 +201,8 @@ describe("update plugin lifecycle lease boundaries", () => {
       yes: true,
     });
 
-    expectLifecycleBoundary("doctor");
-    const doctorIndex = mocks.events.indexOf("doctor:false");
+    expectLifecycleBoundary("fresh-doctor");
+    const doctorIndex = mocks.events.indexOf("fresh-doctor:false");
     expect(mocks.events.slice(0, doctorIndex)).toContain("read-config:true");
     expect(mocks.events).not.toContain("persisted-index:true");
   });

--- a/src/cli/update-finalization-output.process.test.ts
+++ b/src/cli/update-finalization-output.process.test.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs/promises";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { formatCliProcessFailure, runCliProcessChild } from "./cli-process-child.test-helpers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const fixture = fileURLToPath(
+  new URL("./update-finalization-output.test-support.ts", import.meta.url),
+);
+const doctorDiagnostics = [
+  "OpenClaw doctor",
+  "Doctor panel diagnostic",
+  "Doctor workspace diagnostic",
+  "Doctor console diagnostic",
+  "Doctor complete.",
+];
+
+describe.each(["repair", "finalize"])("update %s process output", (command) => {
+  it.each(["json", "inherited-json", "doctor-error", "plugin-error", "human"])(
+    "%s preserves the output and exit contract without restarting",
+    async (scenario) => {
+      const root = tempDirs.make("openclaw-update-json-");
+      const state = path.join(root, "state");
+      const config = path.join(root, "openclaw.json");
+      const workspace = path.join(root, "workspace");
+      const server = net.createServer();
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing isolated port");
+      }
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+      expect(address.port).not.toBe(18789);
+      await fs.mkdir(state);
+      await fs.mkdir(workspace);
+      await fs.writeFile(
+        config,
+        JSON.stringify({
+          gateway: { mode: "local", port: address.port, auth: { mode: "none" } },
+          plugins: { enabled: false, allow: [] },
+          agents: { defaults: { workspace } },
+          logging: { file: path.join(root, "openclaw.log") },
+        }),
+      );
+      const json = scenario !== "human";
+      const args = [
+        "update",
+        ...(scenario === "inherited-json" ? ["--json"] : []),
+        command,
+        "--channel",
+        "dev",
+        "--yes",
+        "--no-restart",
+        "--timeout",
+        "9",
+        ...(json && scenario !== "inherited-json" ? ["--json"] : []),
+      ];
+      const result = await runCliProcessChild({
+        nodeArgs: ["--import", "tsx", fixture, scenario, ...args],
+        env: {
+          PATH: path.dirname(process.execPath),
+          HOME: root,
+          USERPROFILE: root,
+          OPENCLAW_HOME: root,
+          OPENCLAW_STATE_DIR: state,
+          OPENCLAW_CONFIG_PATH: config,
+          OPENCLAW_SERVICE_REPAIR_POLICY: "external",
+          OPENCLAW_GATEWAY_PORT: String(address.port),
+          XDG_CONFIG_HOME: path.join(root, "xdg-config"),
+          XDG_DATA_HOME: path.join(root, "xdg-data"),
+          XDG_CACHE_HOME: path.join(root, "xdg-cache"),
+          XDG_STATE_HOME: path.join(root, "xdg-state"),
+          XDG_RUNTIME_DIR: path.join(root, "xdg-runtime"),
+          TMPDIR: root,
+          NODE_DISABLE_COMPILE_CACHE: "1",
+          NO_COLOR: "1",
+          TERM: "dumb",
+        },
+      });
+      const failure = formatCliProcessFailure({ reason: `${command} ${scenario}`, ...result });
+      expect(result.signal, failure).toBeNull();
+      expect(result.code, failure).toBe(scenario.endsWith("error") ? 1 : 0);
+      const diagnostics = json ? result.stderr : result.stdout;
+      for (const diagnostic of doctorDiagnostics) {
+        expect(diagnostics, failure).toContain(diagnostic);
+      }
+      expect(result.stderr, failure).toContain("Doctor stderr diagnostic");
+      if (!json) {
+        expect(result.stdout).toContain("Update finalization completed.");
+        return;
+      }
+      // Parse the whole pipe: accepting a suffix would hide Clack's direct stdout writes.
+      const output = JSON.parse(result.stdout);
+      if (scenario === "doctor-error") {
+        expect(output).toMatchObject({
+          ok: false,
+          error: { type: "cli_error", message: expect.stringContaining("Doctor repair failed") },
+        });
+      } else {
+        expect(output).toMatchObject({
+          status: scenario === "plugin-error" ? "error" : "ok",
+          mode: "finalize",
+          restart: false,
+          channel: "dev",
+          postUpdate: { doctor: { status: "ok" } },
+        });
+      }
+    },
+  );
+});

--- a/src/cli/update-finalization-output.test-support.ts
+++ b/src/cli/update-finalization-output.test-support.ts
@@ -1,0 +1,123 @@
+// Child fixture: keep registration, finalization, JSON routing, and terminal writers real;
+// replace filesystem/plugin work and emit deterministic doctor diagnostics.
+import fs from "node:fs/promises";
+import { createRequire, registerHooks } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+const root = process.env.HOME!;
+const [scenario, ...args] = process.argv.slice(2);
+const sourceUrl = (relative: string) => new URL(relative, import.meta.url).href;
+const doctorSource = `
+import { intro, note, outro } from ${JSON.stringify(pathToFileURL(require.resolve("@clack/prompts")).href)};
+export async function doctorCommand() {
+  intro('OpenClaw doctor');
+  note('Doctor panel diagnostic', 'Repair');
+  if (!process.argv.includes('--no-workspace-suggestions')) note('Doctor workspace diagnostic', 'Workspace');
+  console.log('Doctor console diagnostic');
+  process.stderr.write('Doctor stderr diagnostic\\n');
+  outro('Doctor complete.');
+  ${scenario === "doctor-error" ? "throw new Error('Doctor repair failed');" : ""}
+}
+`;
+const doctorEntry = path.join(root, "doctor.mjs");
+await fs.writeFile(
+  doctorEntry,
+  `${doctorSource}\ntry { await doctorCommand(); } catch (error) { console.error(error.message); process.exitCode = 1; }\n`,
+);
+const snapshotSource = `
+const config = { update: { channel: 'dev' }, plugins: { enabled: false } };
+export const readConfigFileSnapshot = async () => ({ valid: true, config, sourceConfig: config, parsed: config });
+export const assertConfigWriteAllowedInCurrentMode = () => {};
+`;
+const stubs = new Map<string, string>([
+  [
+    sourceUrl("./update-cli/update-command.ts"),
+    `export { updateFinalizeCommand } from ${JSON.stringify(sourceUrl("./update-cli/update-command-finalize.ts"))}; export const updateCommand = async () => { throw new Error('Unexpected core update'); };`,
+  ],
+  [sourceUrl("./update-cli/status.ts"), "export const updateStatusCommand = async () => {};"],
+  [sourceUrl("./update-cli/wizard.ts"), "export const updateWizardCommand = async () => {};"],
+  [sourceUrl("../commands/doctor.ts"), doctorSource],
+  [sourceUrl("../config/config.ts"), snapshotSource],
+  [
+    sourceUrl("../infra/update-check.ts"),
+    "export const checkUpdateStatus = async () => { throw new Error('Unexpected registry check'); };",
+  ],
+  [
+    sourceUrl("../plugins/installed-plugin-index-records.ts"),
+    "export const loadInstalledPluginIndexInstallRecords = async () => ({});",
+  ],
+  [
+    sourceUrl("../plugins/plugin-lifecycle-lease.ts"),
+    "export const withPluginLifecycleLease = async (_options, run) => await run();",
+  ],
+  [
+    sourceUrl("../state/openclaw-state-db.paths.ts"),
+    "export const resolveOpenClawStateSqlitePath = () => '';",
+  ],
+  [
+    sourceUrl("../state/openclaw-state-ownership.ts"),
+    "export const assertOpenClawStateWriteAllowedAtPath = async () => {};",
+  ],
+  [
+    sourceUrl("./update-cli/shared.ts"),
+    `export const parseTimeoutMsOrExit = () => 9000; export const resolveUpdateRoot = async () => ${JSON.stringify(root)}; export const tryWriteCompletionCache = async () => 'skipped'; export const resolveNodeRunner = () => process.execPath;`,
+  ],
+  [
+    sourceUrl("./update-cli/update-command-config.ts"),
+    "export const createUpdateConfigSnapshot = async () => {}; export const readPostCorePreUpdateSourceConfig = async () => undefined; export const persistRequestedUpdateChannel = async ({configSnapshot}) => configSnapshot; export const restoreDroppedPreUpdateChannels = snapshot => ({snapshot, changed: false});",
+  ],
+  [
+    sourceUrl("./update-cli/update-command-plugins.ts"),
+    `export const updatePluginsAfterCoreUpdate = async ({opts}) => { if (opts.restart !== false) throw new Error('Unexpected restart'); return {status: ${JSON.stringify(scenario === "plugin-error" ? "error" : "ok")}, changed: false}; };`,
+  ],
+  [
+    sourceUrl("./update-cli/update-command-post-core.ts"),
+    "export const reportPreMutationUpdateFailure = async () => { throw new Error('Unexpected channel'); };",
+  ],
+  [
+    sourceUrl("./update-cli/update-command-service.ts"),
+    "export const stripGatewayServiceMarkerEnv = env => ({...env}); export const disableUpdatedPackageCompileCacheEnv = env => ({...env});",
+  ],
+  [
+    sourceUrl("../daemon/gateway-entrypoint.ts"),
+    `export const resolveGatewayInstallEntrypoint = async () => ${JSON.stringify(doctorEntry)};`,
+  ],
+]);
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith(".") || specifier.startsWith("file:")) {
+      const url = new URL(specifier, context.parentURL).href.replace(/\.js$/, ".ts");
+      const source = stubs.get(url);
+      if (source !== undefined) {
+        return { url: `data:text/javascript,${encodeURIComponent(source)}`, shortCircuit: true };
+      }
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const { Command } = await import("commander");
+const { registerUpdateCli } = await import("./update-cli.js");
+const { defaultRuntime } = await import("../runtime.js");
+const { formatCliJsonFailure } = await import("./failure-output.js");
+const { enableConsoleCapture } = await import("../logging/console.js");
+const { withConsoleLogsRoutedToStderrForJson, applyResolvedCommandOutputMode } =
+  await import("./json-output-mode.js");
+const { isCommandJsonOutputMode } = await import("./program/json-mode.js");
+process.argv = [process.execPath, "openclaw", ...args];
+enableConsoleCapture();
+await withConsoleLogsRoutedToStderrForJson(process.argv, async () => {
+  const program = new Command().name("openclaw");
+  program.hook("preAction", (_root, command) => {
+    applyResolvedCommandOutputMode(isCommandJsonOutputMode(command));
+  });
+  registerUpdateCli(program);
+  try {
+    await program.parseAsync(process.argv);
+  } catch (error) {
+    defaultRuntime.writeJson(formatCliJsonFailure(error));
+    process.exitCode = 1;
+  }
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch that maintainers can update.

</details>

## What Problem This Solves

Fixes an issue where users running `openclaw update repair --json` receive doctor panels before the JSON result, making the complete stdout stream impossible to parse. The hidden `update finalize` command shares the same failure. A successful repair can therefore look broken to automation even when the command exits zero.

## Why This Change Was Made

Finalization now uses the existing fresh-process doctor owner already used by resumed updates and post-plugin convergence, removing the second in-process execution path whose Clack panels bypass console routing. The owner forwards captured diagnostics to stderr in JSON mode, including on rejected subprocesses, then preserves the original failure for the canonical CLI JSON error formatter.

Workspace suggestions and human-mode streams are retained. Plugin lease ordering, authoritative config rereads, and the no-restart contract are unchanged. The deliberate tradeoff is subprocess startup and buffered doctor diagnostics until completion, under the existing 4 MiB capture bound. There is no new dependency, parser, global stdout patch, helper, public option, configuration/environment surface, or schema change.

## User Impact

Automation can parse one complete JSON document from repair/finalize stdout while still receiving doctor diagnostics on stderr. Doctor or plugin failures remain nonzero exits. Human output keeps its panels and workspace suggestions. The [update CLI documentation](https://docs.openclaw.ai/cli/update#update-repair) now explains this output contract.

## Evidence

AI-assisted with Codex. The implementation and its execution boundaries were inspected directly.

Before the production change, the process regression produced eight JSON failures and two human-mode passes. A real built `update repair --channel dev --yes --json --no-restart --timeout 1800` exited 0 with status `ok`, but stdout contained 20,260 bytes beginning with a Clack panel and failed whole-stream `JSON.parse`.

After the change, six isolated real built-CLI runs cover both repair and finalize in JSON success, JSON doctor failure, and human modes. Both successes emit one JSON document with `status: "ok"` and `restart: false`; both failures emit one error document with `ok: false` and exit 1. All 21 original doctor headings, including workspace suggestions, remain visible. Two additional independently executed built cases verify migration, parseable stdout, stderr diagnostics, no service operations, and an unused fixture port afterward.

All real CLI proof used fresh synthetic HOME/config/state/workspace/XDG directories, an unused non-default port, a clean allowlisted environment, external service-repair policy, the dev channel, and an empty tracked plugin set. No operator state, running gateway, credentials, external deployments, or plugin downloads were used. This is real local built-CLI proof with real doctor, not authenticated provider or live managed-service proof; those unchanged surfaces were deliberately outside this test.

Validation completed before publication:

- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/cli/update-cli/update-command-lifecycle.test.ts src/cli/update-cli.option-collisions.test.ts src/cli/update-finalization-output.process.test.ts src/cli/json-output-mode.test.ts src/cli/program/preaction-output-mode.test.ts src/cli/run-main.exit.test.ts src/cli/update-cli/update-command-post-core.test.ts` — 546 tests in eight files passed.
- `node scripts/run-vitest.mjs src/cli/update-finalization-output.process.test.ts` — final 10/10 process cases passed, covering both commands, inherited and leaf JSON flags, doctor/plugin errors, and human streams. An independent four-file rerun passed 44/44.
- `node scripts/check-changed.mjs -- src/cli/update-cli/update-command-finalize.ts src/cli/update-cli/update-command-fresh-doctor.ts src/cli/update-cli.test.ts src/cli/update-cli/update-command-lifecycle.test.ts src/cli/update-finalization-output.process.test.ts src/cli/update-finalization-output.test-support.ts docs/cli/update.md` — types, lint, and selected architecture/guard checks passed.
- `pnpm build`, `pnpm docs:list`, and `git diff --check` passed; no ineffective dynamic-import warnings.
- Fresh isolated Codex autoreview exited 0 with no findings (configured P0 scope; reviewer did not run tests).

Production LOC: +36/-22 (net +14). Tests and test support: +276/-32 (net +244). Docs: +4. The production growth preserves rejected-process diagnostics and public workspace suggestions inside the existing owner; it does not add a parallel path. Existing pre-plugin environment scope remains because plugin-phase work still relies on it.

Source evidence: the shared command registration, finalization owner, fresh-process doctor owner, console routing, `src/process/exec.ts` rejection-output contract, and installed Clack stdout writes were inspected. Stable tag `v2026.7.1-2` contains the in-process doctor call before finalization JSON; this is shipped-source inspection, not an executed release test. Current main still has that call. The latest refactor carried it forward in #131062 (plugin convergence through package restart); the defect predates that refactor.

Completed ClawSweeper review on this exact head found no actionable findings or before-merge moves and independently passed the ten process regression cases: https://github.com/openclaw/openclaw/pull/131411#issuecomment-5447701470 . Its generic stored-data heuristic does not identify a changed schema or storage contract: this diff changes neither; the existing doctor migration was exercised by the isolated built-CLI proof, and authoritative rereads and lease boundaries remain covered. Exact-head CI completed successfully: https://github.com/openclaw/openclaw/actions/runs/33135063501 .
