### PR TITLE
refactor(gateway): consolidate node catalog projections

### DIFF
--- a/src/gateway/node-registry-private.ts
+++ b/src/gateway/node-registry-private.ts
@@ -596,80 +596,47 @@ export function forgetNodeRunnerInventory(nodeRegistry: object, connId: string):
   state.runnerState.reconcile(declaration.nodeId, true);
 }
 
-export function isNodeRunnerSessionHost(params: {
-  registry: object;
-  nodeId: string;
-  connId: string;
-  pairingGeneration?: string;
-}): boolean {
-  const state = NODE_REGISTRY_PRIVATE_STATES.get(params.registry);
-  const node = state?.context.getNode(params.nodeId);
-  if (!state || !node || node.connId !== params.connId) {
-    return false;
+/** Capture the catalog's live metadata without reloading pairing or mutating registry state. */
+export function collectNodeCatalogRuntimeState(
+  registry: object,
+  connectedNodes: ReadonlyArray<
+    Pick<NodeRegistryPrivateSession, "nodeId" | "connId" | "pairingGeneration">
+  >,
+) {
+  const sessionHostNodeIds = new Set<string>();
+  const issuesByNodeId = new Map<string, NodeRunnerInventoryIssue[]>();
+  const workerSlotsByNodeId = new Map<string, NodeWorkerCapacitySnapshot>();
+  const workerBundleByNodeId = new Map<string, NodeWorkerBundleStatus>();
+  const state = NODE_REGISTRY_PRIVATE_STATES.get(registry);
+  // This synchronous projection reads one current connection per supplied snapshot row;
+  // it must not reload pairing, publish presence, or admit worker execution.
+  for (const node of connectedNodes) {
+    const current = state?.context.getNode(node.nodeId);
+    if (!state || !current || current.connId !== node.connId) {
+      continue;
+    }
+    const proof = resolveNodeWorkerSupervisorProof(current, state.runnerInventoryByConn);
+    if (proof && proof.pairingGeneration === node.pairingGeneration) {
+      sessionHostNodeIds.add(node.nodeId);
+    }
+    const issue = resolveNodeRunnerInventoryIssue(current, state.runnerInventoryByConn);
+    if (issue) {
+      issuesByNodeId.set(node.nodeId, [issue]);
+    }
+    if (proof) {
+      workerSlotsByNodeId.set(node.nodeId, { ...proof.workerHost.capacity });
+    }
+    const observation = state.bundleStatusByConn.get(node.connId);
+    if (observation) {
+      workerBundleByNodeId.set(node.nodeId, structuredClone(observation.status));
+    }
   }
-  const proof = resolveNodeWorkerSupervisorProof(node, state.runnerInventoryByConn);
-  return Boolean(proof && proof.pairingGeneration === params.pairingGeneration);
-}
-
-function getNodeRunnerInventoryIssue(params: {
-  registry: object;
-  nodeId: string;
-  connId: string;
-}): NodeRunnerInventoryIssue | undefined {
-  const state = NODE_REGISTRY_PRIVATE_STATES.get(params.registry);
-  const node = state?.context.getNode(params.nodeId);
-  return state && node?.connId === params.connId
-    ? resolveNodeRunnerInventoryIssue(node, state.runnerInventoryByConn)
-    : undefined;
-}
-
-export function collectNodeWorkerCapacityByNodeId(
-  registry: object,
-  connectedNodes: ReadonlyArray<{ nodeId: string; connId: string }>,
-): Map<string, NodeWorkerCapacitySnapshot> {
-  const state = NODE_REGISTRY_PRIVATE_STATES.get(registry);
-  return new Map(
-    connectedNodes.flatMap((node) => {
-      const current = state?.context.getNode(node.nodeId);
-      if (!state || !current || current.connId !== node.connId) {
-        return [];
-      }
-      const proof = resolveNodeWorkerSupervisorProof(current, state.runnerInventoryByConn);
-      return proof ? [[node.nodeId, { ...proof.workerHost.capacity }] as const] : [];
-    }),
-  );
-}
-
-export function collectNodeWorkerBundleStatusByNodeId(
-  registry: object,
-  connectedNodes: ReadonlyArray<{ nodeId: string; connId: string }>,
-): Map<string, NodeWorkerBundleStatus> {
-  const state = NODE_REGISTRY_PRIVATE_STATES.get(registry);
-  return new Map(
-    connectedNodes.flatMap((node) => {
-      const current = state?.context.getNode(node.nodeId);
-      const observation =
-        current?.connId === node.connId ? state?.bundleStatusByConn.get(node.connId) : undefined;
-      return observation ? [[node.nodeId, structuredClone(observation.status)] as const] : [];
-    }),
-  );
-}
-
-/** Shared node/environments read-projection shape: nodeId -> runner issues. */
-export function collectNodeRunnerIssuesByNodeId(
-  registry: object,
-  connectedNodes: ReadonlyArray<{ nodeId: string; connId: string }>,
-): Map<string, NodeRunnerInventoryIssue[]> {
-  return new Map(
-    connectedNodes.flatMap((node) => {
-      const issue = getNodeRunnerInventoryIssue({
-        registry,
-        nodeId: node.nodeId,
-        connId: node.connId,
-      });
-      return issue ? [[node.nodeId, [issue]] as const] : [];
-    }),
-  );
+  return {
+    sessionHostNodeIds,
+    issuesByNodeId,
+    workerSlotsByNodeId,
+    workerBundleByNodeId,
+  };
 }
 
 export function isNodeRegistryPendingInvokeConnectionActive(params: {

--- a/src/gateway/node-registry.test.ts
+++ b/src/gateway/node-registry.test.ts
@@ -28,8 +28,8 @@ import { createDiagnosticLogRecordCapture } from "../logging/test-helpers/diagno
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { listConnectedNodePluginTools } from "./node-plugin-tool-snapshot.js";
 import {
+  collectNodeCatalogRuntimeState,
   createNodeRegistryRuntime,
-  isNodeRunnerSessionHost,
   setNodeRunnerStateChangedListener,
   updateNodeRunnerInventory,
 } from "./node-registry-private.js";
@@ -451,12 +451,9 @@ describe("gateway/node-registry", () => {
     ]);
     expect(nodeRegistry.get("node-1")).not.toHaveProperty("protocolFeatures");
     expect(
-      isNodeRunnerSessionHost({
-        registry: nodeRegistry,
-        nodeId: "node-1",
-        connId: "conn-1",
-        pairingGeneration: "generation-a",
-      }),
+      collectNodeCatalogRuntimeState(nodeRegistry, [
+        { nodeId: "node-1", connId: "conn-1", pairingGeneration: "generation-a" },
+      ]).sessionHostNodeIds.has("node-1"),
     ).toBe(true);
 
     currentGeneration = "generation-b";
@@ -474,12 +471,9 @@ describe("gateway/node-registry", () => {
     ).not.toBeNull();
     await expect(nodeWorkerSupervisorTransport.listCurrentNodes()).resolves.toEqual([]);
     expect(
-      isNodeRunnerSessionHost({
-        registry: nodeRegistry,
-        nodeId: "node-1",
-        connId: "conn-1",
-        pairingGeneration: "generation-b",
-      }),
+      collectNodeCatalogRuntimeState(nodeRegistry, [
+        { nodeId: "node-1", connId: "conn-1", pairingGeneration: "generation-b" },
+      ]).sessionHostNodeIds.has("node-1"),
     ).toBe(false);
     expect(
       updateNodeRunnerInventory({
@@ -790,13 +784,26 @@ describe("gateway/node-registry", () => {
       }),
     ).toEqual({ changed: true });
     expect(
-      isNodeRunnerSessionHost({
-        registry: nodeRegistry,
-        nodeId: "node-1",
-        connId: "conn-1",
-        pairingGeneration: "generation-a",
-      }),
+      collectNodeCatalogRuntimeState(nodeRegistry, [
+        { nodeId: "node-1", connId: "conn-1", pairingGeneration: "generation-a" },
+      ]).sessionHostNodeIds.has("node-1"),
     ).toBe(true);
+
+    // Catalog host consent uses the supplied generation; capacity still describes
+    // the current connection, including a full host with zero available slots.
+    const snapshot = collectNodeCatalogRuntimeState(nodeRegistry, [
+      { nodeId: "node-1", connId: "conn-1", pairingGeneration: "stale-generation" },
+    ]);
+    expect(snapshot.sessionHostNodeIds.has("node-1")).toBe(false);
+    expect(snapshot.workerSlotsByNodeId.get("node-1")).toEqual({ total: 2, available: 0 });
+    const projectedCapacity = snapshot.workerSlotsByNodeId.get("node-1");
+    if (!projectedCapacity) {
+      throw new Error("expected projected capacity");
+    }
+    // JavaScript consumers can mutate a readonly-typed snapshot without changing admission.
+    Object.assign(projectedCapacity, { available: 2 });
+    expect(nodeWorkerSupervisorTransport.isCurrent(proof, true)).toBe(false);
+    expect(frames).toEqual([]);
 
     const workspaceInvoke = nodeWorkerSupervisorTransport.invoke({
       node: proof,

--- a/src/gateway/server-methods/environments.node-command-authority.test.ts
+++ b/src/gateway/server-methods/environments.node-command-authority.test.ts
@@ -13,10 +13,12 @@ vi.mock("../../infra/device-pairing-node.js", () => ({
 }));
 
 vi.mock("../node-registry-private.js", () => ({
-  collectNodeRunnerIssuesByNodeId: vi.fn(() => new Map()),
-  collectNodeWorkerBundleStatusByNodeId: vi.fn(() => new Map()),
-  collectNodeWorkerCapacityByNodeId: vi.fn(() => new Map()),
-  isNodeRunnerSessionHost: vi.fn(() => false),
+  collectNodeCatalogRuntimeState: vi.fn(() => ({
+    sessionHostNodeIds: new Set(),
+    issuesByNodeId: new Map(),
+    workerSlotsByNodeId: new Map(),
+    workerBundleByNodeId: new Map(),
+  })),
 }));
 
 beforeEach(() => {

--- a/src/gateway/server-methods/environments.node-ownership.test.ts
+++ b/src/gateway/server-methods/environments.node-ownership.test.ts
@@ -2,12 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { listNodePairing } from "../../infra/device-pairing-node.js";
 import { listDevicePairing } from "../../infra/device-pairing.js";
-import {
-  collectNodeRunnerIssuesByNodeId,
-  collectNodeWorkerBundleStatusByNodeId,
-  collectNodeWorkerCapacityByNodeId,
-  isNodeRunnerSessionHost,
-} from "../node-registry-private.js";
+import { collectNodeCatalogRuntimeState } from "../node-registry-private.js";
 import type {
   WorkerEnvironmentServiceContract,
   WorkerEnvironmentServiceRecord,
@@ -24,10 +19,12 @@ vi.mock("../../infra/device-pairing-node.js", () => ({
 }));
 
 vi.mock("../node-registry-private.js", () => ({
-  collectNodeRunnerIssuesByNodeId: vi.fn(() => new Map()),
-  collectNodeWorkerBundleStatusByNodeId: vi.fn(() => new Map()),
-  collectNodeWorkerCapacityByNodeId: vi.fn(() => new Map()),
-  isNodeRunnerSessionHost: vi.fn(() => false),
+  collectNodeCatalogRuntimeState: vi.fn(() => ({
+    sessionHostNodeIds: new Set(),
+    issuesByNodeId: new Map(),
+    workerSlotsByNodeId: new Map(),
+    workerBundleByNodeId: new Map(),
+  })),
 }));
 
 type TestWorkerService = Pick<WorkerEnvironmentServiceContract, "get" | "list">;
@@ -96,10 +93,12 @@ async function callEnvironmentMethod(
 }
 
 beforeEach(() => {
-  vi.mocked(isNodeRunnerSessionHost).mockReturnValue(false);
-  vi.mocked(collectNodeRunnerIssuesByNodeId).mockReturnValue(new Map());
-  vi.mocked(collectNodeWorkerCapacityByNodeId).mockReturnValue(new Map());
-  vi.mocked(collectNodeWorkerBundleStatusByNodeId).mockReturnValue(new Map());
+  vi.mocked(collectNodeCatalogRuntimeState).mockReturnValue({
+    sessionHostNodeIds: new Set(),
+    issuesByNodeId: new Map(),
+    workerSlotsByNodeId: new Map(),
+    workerBundleByNodeId: new Map(),
+  });
   vi.mocked(listDevicePairing).mockResolvedValue({ paired: [] } as never);
   vi.mocked(listNodePairing).mockResolvedValue({ paired: [] } as never);
 });

--- a/src/gateway/server-methods/environments.test.ts
+++ b/src/gateway/server-methods/environments.test.ts
@@ -3,16 +3,12 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import { listNodePairing } from "../../infra/device-pairing-node.js";
-import { listDevicePairing } from "../../infra/device-pairing.js";
+import { listDevicePairing, type PairedDevice } from "../../infra/device-pairing.js";
 import { NODE_RUNNER_UPDATE_REQUIRED_ISSUE } from "../../infra/node-runner-inventory.js";
 import { NODE_DESKTOP_STREAM_COMMAND } from "../../shared/node-desktop-stream.js";
-import {
-  collectNodeRunnerIssuesByNodeId,
-  collectNodeWorkerBundleStatusByNodeId,
-  collectNodeWorkerCapacityByNodeId,
-  isNodeRunnerSessionHost,
-} from "../node-registry-private.js";
+import { collectNodeCatalogRuntimeState } from "../node-registry-private.js";
 import type {
   WorkerEnvironmentServiceContract,
   WorkerEnvironmentServiceRecord,
@@ -20,9 +16,9 @@ import type {
 import type { WorkerEnvironmentRecord } from "../worker-environments/store.js";
 import { environmentsHandlers, summarizeWorkerEnvironment } from "./environments.js";
 
-vi.mock("../../infra/device-pairing.js", () => ({
+vi.mock("../../infra/device-pairing.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/device-pairing.js")>()),
   listDevicePairing: vi.fn(),
-  resolveNodePairingState: vi.fn(),
 }));
 
 vi.mock("../../infra/device-pairing-node.js", () => ({
@@ -30,13 +26,16 @@ vi.mock("../../infra/device-pairing-node.js", () => ({
 }));
 
 vi.mock("../node-registry-private.js", () => ({
-  collectNodeRunnerIssuesByNodeId: vi.fn(() => new Map()),
-  collectNodeWorkerBundleStatusByNodeId: vi.fn(() => new Map()),
-  collectNodeWorkerCapacityByNodeId: vi.fn(() => new Map()),
-  isNodeRunnerSessionHost: vi.fn(() => false),
+  collectNodeCatalogRuntimeState: vi.fn(() => ({
+    sessionHostNodeIds: new Set(),
+    issuesByNodeId: new Map(),
+    workerSlotsByNodeId: new Map(),
+    workerBundleByNodeId: new Map(),
+  })),
 }));
 
 const NOW = 10_000;
+let runtimeState: ReturnType<typeof collectNodeCatalogRuntimeState>;
 
 type TestWorkerRecord = WorkerEnvironmentRecord & WorkerEnvironmentServiceRecord;
 
@@ -188,10 +187,13 @@ class FakeWorkerServiceError extends Error {
 
 beforeEach(() => {
   vi.spyOn(Date, "now").mockReturnValue(NOW);
-  vi.mocked(isNodeRunnerSessionHost).mockReturnValue(false);
-  vi.mocked(collectNodeRunnerIssuesByNodeId).mockReturnValue(new Map());
-  vi.mocked(collectNodeWorkerCapacityByNodeId).mockReturnValue(new Map());
-  vi.mocked(collectNodeWorkerBundleStatusByNodeId).mockReturnValue(new Map());
+  runtimeState = {
+    sessionHostNodeIds: new Set(),
+    issuesByNodeId: new Map(),
+    workerSlotsByNodeId: new Map(),
+    workerBundleByNodeId: new Map(),
+  };
+  vi.mocked(collectNodeCatalogRuntimeState).mockReturnValue(runtimeState);
   vi.mocked(listDevicePairing).mockResolvedValue({ paired: [] } as never);
   vi.mocked(listNodePairing).mockResolvedValue({
     paired: [
@@ -208,8 +210,88 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("environment gateway methods", () => {
+  it.each(["devices", "nodes"] as const)(
+    "waits for both independent pairing reads when %s finishes first",
+    async (first) => {
+      const devices = createDeferred<Awaited<ReturnType<typeof listDevicePairing>>>();
+      const nodes = createDeferred<Awaited<ReturnType<typeof listNodePairing>>>();
+      vi.mocked(listDevicePairing).mockClear().mockReturnValue(devices.promise);
+      vi.mocked(listNodePairing).mockClear().mockReturnValue(nodes.promise);
+      const context = mockContext();
+      const project = vi.spyOn(context.nodeRegistry, "listConnectedForPairingStates");
+      const respond = vi.fn();
+      const request = environmentsHandlers["environments.list"]?.({
+        params: {},
+        respond,
+        context,
+      } as never);
+
+      const liveDevice: PairedDevice = {
+        deviceId: "node-live",
+        publicKey: "public-key-live",
+        roles: ["node"],
+        tokens: { node: { token: "test-node-token", role: "node", scopes: [], createdAtMs: 1 } },
+        createdAtMs: 1,
+        approvedAtMs: 1,
+      };
+      const deviceSnapshot = {
+        paired: [
+          liveDevice,
+          { ...liveDevice, deviceId: "operator-only", roles: ["operator"], tokens: {} },
+        ],
+        pending: [],
+      };
+      const nodeSnapshot = {
+        paired: [
+          {
+            nodeId: "node-offline",
+            displayName: "Independent snapshot",
+            createdAtMs: 1,
+            approvedAtMs: 1,
+          },
+        ],
+        pending: [],
+      };
+      try {
+        expect(listDevicePairing).toHaveBeenCalledTimes(1);
+        expect(listNodePairing).toHaveBeenCalledTimes(1);
+        if (first === "devices") {
+          devices.resolve(deviceSnapshot);
+          await devices.promise;
+        } else {
+          nodes.resolve(nodeSnapshot);
+          await nodes.promise;
+        }
+        expect(project).not.toHaveBeenCalled();
+        expect(respond).not.toHaveBeenCalled();
+        devices.resolve(deviceSnapshot);
+        nodes.resolve(nodeSnapshot);
+        await request;
+        expect(respond).toHaveBeenCalledWith(
+          true,
+          expect.objectContaining({
+            environments: expect.arrayContaining([
+              expect.objectContaining({ id: "node:node-offline", label: "Independent snapshot" }),
+            ]),
+          }),
+          undefined,
+        );
+        expect(project).toHaveBeenCalledTimes(1);
+        expect(project).toHaveBeenCalledWith(
+          new Map([["node-live", { identity: expect.any(String) }]]),
+        );
+        expect(listDevicePairing).toHaveBeenCalledTimes(1);
+        expect(listNodePairing).toHaveBeenCalledTimes(1);
+      } finally {
+        devices.resolve(deviceSnapshot);
+        nodes.resolve(nodeSnapshot);
+        await request;
+      }
+    },
+  );
+
   it("projects live node session-host capability without a worker service", async () => {
-    vi.mocked(isNodeRunnerSessionHost).mockImplementation(({ nodeId }) => nodeId === "node-live");
+    runtimeState.sessionHostNodeIds.add("node-live");
     const [ok, payload] = await callEnvironmentMethod("environments.list", {});
 
     expect(ok).toBe(true);
@@ -331,12 +413,11 @@ describe("environment gateway methods", () => {
   });
 
   it("projects the same exact slots and redacted bundle status through list and status", async () => {
-    vi.mocked(collectNodeWorkerCapacityByNodeId).mockReturnValue(
-      new Map([["node-live", { total: 2, available: 1 }]]),
-    );
-    vi.mocked(collectNodeWorkerBundleStatusByNodeId).mockReturnValue(
-      new Map([["node-live", { status: "installed", version: "2026.8.9" }]]),
-    );
+    runtimeState.workerSlotsByNodeId.set("node-live", { total: 2, available: 1 });
+    runtimeState.workerBundleByNodeId.set("node-live", {
+      status: "installed",
+      version: "2026.8.9",
+    });
 
     const [, listPayload] = await callEnvironmentMethod("environments.list", {});
     const [, statusPayload] = await callEnvironmentMethod("environments.status", {
@@ -358,9 +439,7 @@ describe("environment gateway methods", () => {
   });
 
   it("projects the same current-node update issue through list and status", async () => {
-    vi.mocked(collectNodeRunnerIssuesByNodeId).mockReturnValue(
-      new Map([["node-live", [NODE_RUNNER_UPDATE_REQUIRED_ISSUE]]]),
-    );
+    runtimeState.issuesByNodeId.set("node-live", [NODE_RUNNER_UPDATE_REQUIRED_ISSUE]);
 
     const [, listPayload] = await callEnvironmentMethod("environments.list", {});
     const [, statusPayload] = await callEnvironmentMethod("environments.status", {
@@ -567,7 +646,7 @@ describe("environment gateway methods", () => {
   });
 
   it("returns status for one node environment", async () => {
-    vi.mocked(isNodeRunnerSessionHost).mockReturnValue(true);
+    runtimeState.sessionHostNodeIds.add("node-live");
     const [ok, payload] = await callEnvironmentMethod("environments.status", {
       environmentId: "node:node-live",
     });

--- a/src/gateway/server-methods/environments.ts
+++ b/src/gateway/server-methods/environments.ts
@@ -13,20 +13,16 @@ import {
   validateWorkerDesktopObserveParams,
   validateWorkerDesktopLaunchParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { projectPairedDeviceNodeBindings } from "../../infra/device-pairing-node-state.js";
 import { listNodePairing } from "../../infra/device-pairing-node.js";
-import { listDevicePairing, resolveNodePairingState } from "../../infra/device-pairing.js";
+import { listDevicePairing } from "../../infra/device-pairing.js";
 import { NODE_DESKTOP_STREAM_COMMAND } from "../../shared/node-desktop-stream.js";
 import type { NodeListNode } from "../../shared/node-list-types.js";
 import { isDesktopCredentialsRequiredError } from "../desktop/host-source-errors.js";
 import { getNodeDesktopService } from "../desktop/node-source-context.js";
 import { createKnownNodeCatalog, listKnownNodes } from "../node-catalog.js";
 import { isNodeCommandAllowed, resolveNodeCommandAllowlist } from "../node-command-policy.js";
-import {
-  collectNodeRunnerIssuesByNodeId,
-  collectNodeWorkerBundleStatusByNodeId,
-  collectNodeWorkerCapacityByNodeId,
-  isNodeRunnerSessionHost,
-} from "../node-registry-private.js";
+import { collectNodeCatalogRuntimeState } from "../node-registry-private.js";
 import type { WorkerEnvironmentServiceRecord } from "../worker-environments/service-contract.js";
 import type { WorkerEnvironmentState } from "../worker-environments/state.js";
 import { formatForLog } from "../ws-log.js";
@@ -159,46 +155,15 @@ export async function listGatewayEnvironments(
   const visibleDevices = devices.paired.filter(
     (device) => !managedCloudNodeIds.has(device.deviceId),
   );
-  const currentPairingStates = new Map<string, { identity: string; generation?: string }>();
-  for (const device of visibleDevices) {
-    const state = resolveNodePairingState(device);
-    if (state) {
-      currentPairingStates.set(state.identity.nodeId, {
-        identity: state.identity.key,
-        ...(state.generation ? { generation: state.generation.key } : {}),
-      });
-    }
-  }
-  const connectedNodes = context.nodeRegistry.listConnectedForPairingStates(currentPairingStates);
-  const sessionHostNodeIds = new Set(
-    connectedNodes.flatMap((node) =>
-      isNodeRunnerSessionHost({
-        registry: context.nodeRegistry,
-        nodeId: node.nodeId,
-        connId: node.connId,
-        pairingGeneration: node.pairingGeneration,
-      })
-        ? [node.nodeId]
-        : [],
-    ),
+  const connectedNodes = context.nodeRegistry.listConnectedForPairingStates(
+    projectPairedDeviceNodeBindings(visibleDevices),
   );
-  const issuesByNodeId = collectNodeRunnerIssuesByNodeId(context.nodeRegistry, connectedNodes);
-  const workerSlotsByNodeId = collectNodeWorkerCapacityByNodeId(
-    context.nodeRegistry,
-    connectedNodes,
-  );
-  const workerBundleByNodeId = collectNodeWorkerBundleStatusByNodeId(
-    context.nodeRegistry,
-    connectedNodes,
-  );
+  const runtimeState = collectNodeCatalogRuntimeState(context.nodeRegistry, connectedNodes);
   const catalog = createKnownNodeCatalog({
     pairedDevices: visibleDevices,
     pairedNodes: nodes.paired.filter((node) => !managedCloudNodeIds.has(node.nodeId)),
     connectedNodes: connectedNodes.filter((node) => !managedCloudNodeIds.has(node.nodeId)),
-    sessionHostNodeIds,
-    workerSlotsByNodeId,
-    workerBundleByNodeId,
-    issuesByNodeId,
+    ...runtimeState,
   });
   const config = context.getRuntimeConfig();
   const gateway =

--- a/src/gateway/server-methods/nodes.read.test.ts
+++ b/src/gateway/server-methods/nodes.read.test.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import type { PairedDevice } from "../../infra/device-pairing.js";
 import { resolveNodePairingState } from "../../infra/device-pairing.js";
 import {
@@ -85,6 +86,70 @@ function registerNode(registry: NodeRegistry, pairedNode: PairedDevice) {
 }
 
 describe("node read projections", () => {
+  it.each(["node.list", "node.describe"] as const)(
+    "%s uses one loaded pairing snapshot without reconciling the live registry",
+    async (method) => {
+      const pairedNode = createPairedNode("snapshot-node");
+      const snapshot =
+        createDeferred<
+          Awaited<ReturnType<(typeof import("../../infra/device-pairing.js"))["listDevicePairing"]>>
+        >();
+      listDevicePairingMock.mockClear().mockReturnValue(snapshot.promise);
+      listNodePairingMock.mockClear();
+      resolveLocalNodeIdMock.mockResolvedValue(undefined);
+      const resolveCurrentPairingState = vi.fn();
+      const { nodeRegistry } = createNodeRegistryRuntime(
+        () => new NodeRegistry({ resolveCurrentPairingState }),
+      );
+      const registered = registerNode(nodeRegistry, pairedNode);
+      const respond = vi.fn();
+      const params = method === "node.list" ? {} : { nodeId: pairedNode.deviceId };
+      const request = expectDefined(
+        nodeReadHandlers[method],
+        method,
+      )({
+        req: { type: "req", id: method, method, params },
+        params,
+        client: {
+          connect: { scopes: ["operator.read"] },
+        } as GatewayRequestHandlerOptions["client"],
+        isWebchatConnect: () => false,
+        respond,
+        context: {
+          nodeRegistry,
+          logGateway: { warn: vi.fn() },
+        } as unknown as GatewayRequestHandlerOptions["context"],
+      });
+
+      try {
+        expect(listDevicePairingMock).toHaveBeenCalledTimes(1);
+        expect(respond).not.toHaveBeenCalled();
+        snapshot.resolve({ paired: [pairedNode], pending: [] });
+        await request;
+        expect(respond).toHaveBeenCalledWith(
+          true,
+          method === "node.list"
+            ? expect.objectContaining({
+                nodes: [expect.objectContaining({ nodeId: pairedNode.deviceId, connected: true })],
+              })
+            : expect.objectContaining({ nodeId: pairedNode.deviceId, connected: true }),
+          undefined,
+        );
+        expect(listDevicePairingMock).toHaveBeenCalledTimes(1);
+        expect(listNodePairingMock).not.toHaveBeenCalled();
+        expect(resolveCurrentPairingState).not.toHaveBeenCalled();
+        expect(registered.invalidated).not.toBe(true);
+      } finally {
+        snapshot.resolve({ paired: [pairedNode], pending: [] });
+        try {
+          await request;
+        } finally {
+          nodeRegistry.unregister(registered.connId);
+        }
+      }
+    },
+  );
+
   it("preserves Gateway-local ownership across list and describe", async () => {
     const localNodeId = "local-node";
     const remoteNodeId = "remote-node";

--- a/src/gateway/server-methods/nodes.read.ts
+++ b/src/gateway/server-methods/nodes.read.ts
@@ -9,8 +9,9 @@ import {
 } from "../../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { updatePairedNodeSessionHost } from "../../infra/device-pairing-node-facts.js";
+import { projectPairedDeviceNodeBindings } from "../../infra/device-pairing-node-state.js";
 import { listNodePairing, projectNodePairing } from "../../infra/device-pairing-node.js";
-import { listDevicePairing, resolveNodePairingState } from "../../infra/device-pairing.js";
+import { listDevicePairing } from "../../infra/device-pairing.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
   formatNodeRunnerUpdateRequired,
@@ -24,10 +25,7 @@ import { replaceRemoteNodeSkills } from "../../skills/runtime/remote-skills.js";
 import { recordRemoteNodeInfo, refreshRemoteNodeBins } from "../../skills/runtime/remote.js";
 import { createKnownNodeCatalog, getKnownNode, listKnownNodes } from "../node-catalog.js";
 import {
-  collectNodeRunnerIssuesByNodeId,
-  collectNodeWorkerBundleStatusByNodeId,
-  collectNodeWorkerCapacityByNodeId,
-  isNodeRunnerSessionHost,
+  collectNodeCatalogRuntimeState,
   updateNodeRunnerInventory,
 } from "../node-registry-private.js";
 import type { NodeSession } from "../node-registry.js";
@@ -75,24 +73,6 @@ function isVisibleNode(node: NodeListNode | null): node is NodeListNode {
   return node !== null;
 }
 
-function currentSessionHostNodeIds(params: {
-  connectedNodes: readonly NodeSession[];
-  nodeRegistry: GatewayRequestContext["nodeRegistry"];
-}): Set<string> {
-  return new Set(
-    params.connectedNodes.flatMap((node) =>
-      isNodeRunnerSessionHost({
-        registry: params.nodeRegistry,
-        nodeId: node.nodeId,
-        connId: node.connId,
-        pairingGeneration: node.pairingGeneration,
-      })
-        ? [node.nodeId]
-        : [],
-    ),
-  );
-}
-
 async function listNodesForClient(params: {
   client: GatewayClient | null;
   context: GatewayRequestContext;
@@ -102,19 +82,7 @@ async function listNodesForClient(params: {
   pendingNodes: ReturnType<typeof projectNodePairing>["pending"];
   connectedNodes: readonly NodeSession[];
 }): Promise<NodeListNode[]> {
-  const sessionHostNodeIds = currentSessionHostNodeIds({
-    connectedNodes: params.connectedNodes,
-    nodeRegistry: params.context.nodeRegistry,
-  });
-  const issuesByNodeId = collectNodeRunnerIssuesByNodeId(
-    params.context.nodeRegistry,
-    params.connectedNodes,
-  );
-  const workerSlotsByNodeId = collectNodeWorkerCapacityByNodeId(
-    params.context.nodeRegistry,
-    params.connectedNodes,
-  );
-  const workerBundleByNodeId = collectNodeWorkerBundleStatusByNodeId(
+  const runtimeState = collectNodeCatalogRuntimeState(
     params.context.nodeRegistry,
     params.connectedNodes,
   );
@@ -123,10 +91,7 @@ async function listNodesForClient(params: {
     pairedNodes: params.pairedNodes,
     pendingNodes: params.pendingNodes,
     connectedNodes: params.connectedNodes,
-    sessionHostNodeIds,
-    workerSlotsByNodeId,
-    workerBundleByNodeId,
-    issuesByNodeId,
+    ...runtimeState,
   });
   const localNodeId = await resolveLocalNodeId().catch((error: unknown) => {
     params.context.logGateway.warn(
@@ -145,23 +110,6 @@ async function listNodesForClient(params: {
   }
   const ownDeviceId = nodeReadCallerDeviceId(params.client);
   return nodes.map((node) => safeNodeReadProjection(node, ownDeviceId)).filter(isVisibleNode);
-}
-
-function listCurrentConnectedNodes(
-  context: GatewayRequestContext,
-  pairedDevices: Awaited<ReturnType<typeof listDevicePairing>>["paired"],
-): NodeSession[] {
-  const currentPairingStates = new Map<string, { identity: string; generation?: string }>();
-  for (const device of pairedDevices) {
-    const state = resolveNodePairingState(device);
-    if (state) {
-      currentPairingStates.set(state.identity.nodeId, {
-        identity: state.identity.key,
-        ...(state.generation ? { generation: state.generation.key } : {}),
-      });
-    }
-  }
-  return context.nodeRegistry.listConnectedForPairingStates(currentPairingStates);
 }
 
 function normalizePluginSurfaceRefreshParams(
@@ -288,7 +236,9 @@ export const nodeReadHandlers: GatewayRequestHandlers = {
     await respondUnavailableOnThrow(respond, async () => {
       const devicePairing = await listDevicePairing();
       const nodePairing = projectNodePairing(devicePairing.paired);
-      const connectedNodes = listCurrentConnectedNodes(context, devicePairing.paired);
+      const connectedNodes = context.nodeRegistry.listConnectedForPairingStates(
+        projectPairedDeviceNodeBindings(devicePairing.paired),
+      );
       const nodes = await listNodesForClient({
         client,
         context,
@@ -317,7 +267,9 @@ export const nodeReadHandlers: GatewayRequestHandlers = {
     await respondUnavailableOnThrow(respond, async () => {
       const devicePairing = await listDevicePairing();
       const nodePairing = projectNodePairing(devicePairing.paired);
-      const connectedNodes = listCurrentConnectedNodes(context, devicePairing.paired);
+      const connectedNodes = context.nodeRegistry.listConnectedForPairingStates(
+        projectPairedDeviceNodeBindings(devicePairing.paired),
+      );
       const nodes = await listNodesForClient({
         client,
         context,

--- a/src/gateway/server-methods/nodes.runner-inventory.test.ts
+++ b/src/gateway/server-methods/nodes.runner-inventory.test.ts
@@ -6,8 +6,7 @@ import {
   NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE,
 } from "../../infra/node-runner-inventory.js";
 import {
-  collectNodeWorkerBundleStatusByNodeId,
-  collectNodeWorkerCapacityByNodeId,
+  collectNodeCatalogRuntimeState,
   createNodeRegistryRuntime,
   setNodeRunnerStateChangedListener,
 } from "../node-registry-private.js";
@@ -124,9 +123,8 @@ describe("nodeHandlers node.runnerInventory.update", () => {
       }),
     ]);
     expect(
-      collectNodeWorkerCapacityByNodeId(runtime.nodeRegistry, [
-        { nodeId: "node-1", connId: "conn-1" },
-      ]),
+      collectNodeCatalogRuntimeState(runtime.nodeRegistry, [{ nodeId: "node-1", connId: "conn-1" }])
+        .workerSlotsByNodeId,
     ).toEqual(new Map([["node-1", AVAILABLE_CAPACITY]]));
     runtime.nodeRegistry.unregister("conn-1");
   });
@@ -160,11 +158,18 @@ describe("nodeHandlers node.runnerInventory.update", () => {
       bundleHash: "a".repeat(64),
       status: { status: "installed", version: "2026.8.9" },
     });
-    expect(
-      collectNodeWorkerBundleStatusByNodeId(runtime.nodeRegistry, [
-        { nodeId: "node-1", connId: "conn-1" },
-      ]),
-    ).toEqual(new Map([["node-1", { status: "installed", version: "2026.8.9" }]]));
+    const catalog = collectNodeCatalogRuntimeState(runtime.nodeRegistry, [
+      { nodeId: "node-1", connId: "conn-1" },
+    ]);
+    expect(catalog.workerBundleByNodeId).toEqual(
+      new Map([["node-1", { status: "installed", version: "2026.8.9" }]]),
+    );
+    const bundle = expectDefined(catalog.workerBundleByNodeId.get("node-1"), "projected bundle");
+    bundle.status = "missing";
+    expect(runtime.nodeWorkerSupervisorTransport.getBundleStatus?.("node-1")?.status).toEqual({
+      status: "installed",
+      version: "2026.8.9",
+    });
 
     expect(
       runtime.nodeRegistry.updateSurface(
@@ -185,9 +190,8 @@ describe("nodeHandlers node.runnerInventory.update", () => {
       }),
     ).toBe(false);
     expect(
-      collectNodeWorkerBundleStatusByNodeId(runtime.nodeRegistry, [
-        { nodeId: "node-1", connId: "conn-1" },
-      ]),
+      collectNodeCatalogRuntimeState(runtime.nodeRegistry, [{ nodeId: "node-1", connId: "conn-1" }])
+        .workerBundleByNodeId,
     ).toEqual(new Map());
 
     await runnerInventoryHandler(
@@ -221,16 +225,14 @@ describe("nodeHandlers node.runnerInventory.update", () => {
       }),
     ).toBe(false);
     expect(
-      collectNodeWorkerBundleStatusByNodeId(runtime.nodeRegistry, [
-        { nodeId: "node-1", connId: "conn-1" },
-      ]),
+      collectNodeCatalogRuntimeState(runtime.nodeRegistry, [{ nodeId: "node-1", connId: "conn-1" }])
+        .workerBundleByNodeId,
     ).toEqual(new Map());
 
     runtime.nodeRegistry.unregister("conn-1");
     expect(
-      collectNodeWorkerBundleStatusByNodeId(runtime.nodeRegistry, [
-        { nodeId: "node-1", connId: "conn-1" },
-      ]),
+      collectNodeCatalogRuntimeState(runtime.nodeRegistry, [{ nodeId: "node-1", connId: "conn-1" }])
+        .workerBundleByNodeId,
     ).toEqual(new Map());
   });
 

--- a/src/infra/device-pairing-node-state.ts
+++ b/src/infra/device-pairing-node-state.ts
@@ -6,6 +6,7 @@ import {
   resolveNodePairingState,
   type NodePairingGeneration,
   type NodePairingState,
+  type PairedDevice,
 } from "./device-pairing.js";
 
 export type { NodePairingGeneration, NodePairingIdentity } from "./device-pairing.js";
@@ -25,6 +26,20 @@ function toPairedDeviceNodeBinding(
         ...(state.generation ? { generation: state.generation.key } : {}),
       }
     : undefined;
+}
+
+/** Project only authenticated node-role bindings from the caller's loaded device snapshot. */
+export function projectPairedDeviceNodeBindings(
+  pairedDevices: readonly PairedDevice[],
+): Map<string, PairedDeviceNodeBinding> {
+  const bindings = new Map<string, PairedDeviceNodeBinding>();
+  for (const device of pairedDevices) {
+    const binding = toPairedDeviceNodeBinding(resolveNodePairingState(device));
+    if (binding) {
+      bindings.set(device.deviceId, binding);
+    }
+  }
+  return bindings;
 }
 
 export async function captureNodePairingState(


### PR DESCRIPTION
## What Problem This Solves

The node list, node description, and environment catalog repeat the same pairing-binding projection and separately traverse connected nodes for session-host eligibility, runner issues, capacity, and bundle status. This maintainer-requested cleanup removes that duplicate implementation without changing the catalog presented to operators.

## Why This Change Was Made

Pairing-state code now projects authenticated node bindings from the caller's already-loaded snapshot. The private node registry gathers the catalog's runtime metadata in one synchronous pass, and both RPC owners consume that result. The old collectors, session-host wrapper, and duplicated pairing loops are removed.

The boundaries stay intact: node reads use one pairing snapshot; environment reads still await two independent snapshots. Catalog reads do not reload pairing, mutate presence, invalidate connections, or admit worker execution. Connection identity, generation-based session-host consent, defensive capacity/bundle copies, cloud-managed-node filtering, and redacted read projections are preserved. No configuration, persisted schema, protocol, or public SDK contract changes.

## User Impact

No intended user-visible behavior change. Production: +73/-174, net -101 lines. Tests: +238/-84, net +154 lines, extending the existing ownership and snapshot-boundary coverage.

## Evidence

AI-assisted with Codex. Pre-commit review and a separate exact published-head review completed with no actionable findings. The published review covered three complete semantic partitions; all three normal reviewer processes and their isolation/cleanup checks exited zero on `abc55fa93b6e6a9bcc909b67ad5f1d741ce49050`.

Exact-head [CI 33135167953](https://github.com/openclaw/openclaw/actions/runs/33135167953) passed on its first attempt: 160 successful jobs, 18 skipped, no failed or pending jobs. The repository's canonical PR-check watcher also completed green. Native landing checks remain separate.

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/131412#issuecomment-5447709823) found no code or security findings on that same head. Its remaining exact-head CI and maintainer-review steps are now complete. The maintainer review confirmed the canonical owner boundary, rejected combining the independently owned environment reads, and verified unchanged before-files and relevant callers against newer main. No additional Rank-up moves or source repairs were requested.

Clean Linux/CI-parity proof ran through the repository Crabbox wrapper on Blacksmith Testbox: [run 33132678980](https://github.com/openclaw/openclaw/actions/runs/33132678980). Base `2026a7b47b1b9833dd36efc38feb4f014fd820ef`; candidate tree `b79a8f82e03a0a29cea9f4835d309636faa331c9`. Actual Node 24.19.0 and pnpm 11.22.0; dependency fingerprint and relevant installed pins matched the target.

- Baseline: 264 existing tests passed. Candidate: 268 tests passed across the same nine owner/sibling files, including real SQLite and Gateway WebSocket authorization coverage.
- The same task-only differential fixture passed 12 cases on both sides: four deferred-read schedules and eight catalog scenarios. All 36 complete RPC responses were byte-identical; reads left registry/presence state unchanged.
- Full canonical changed gate passed, including production and all core-test typechecks, changed-file lint, dead-export scans, runtime import cycles, and storage/pairing guards.
- Default `pnpm build` passed after the environment correction below, including 48 native plugin-module loads, all 147 public SDK subpaths, UI build, and CLI startup metadata. All 34,410 tracked sources matched the frozen candidate after installation, tests, and build; final runtime pins and workspace resolution passed. Independent audit verified all 33 collected artifacts. Both proof trees were removed and the lease reached its terminal completed state; owned SSH key and claim were removed.

The differential fixture uses real handlers and registry behavior but mocks pairing I/O and local-node identity; it is not a live external-device or provider claim. The retained WebSocket authorization suite is separate integration evidence. No UI behavior changed, and no screenshot is presented as proof.

Focused command on each side:

```sh
node scripts/run-vitest.mjs src/gateway/node-registry.test.ts src/gateway/server-methods/nodes.runner-inventory.test.ts src/gateway/server-methods/environments.test.ts src/gateway/server-methods/environments.node-ownership.test.ts src/gateway/server-methods/environments.node-command-authority.test.ts src/gateway/server-methods/nodes.read.test.ts src/gateway/node-catalog.test.ts src/gateway/server-methods/nodes.test.ts src/gateway/server.node-pairing-diagnostics-authz.test.ts
```

The remote proof passed the complete selected checks with `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 node scripts/check-changed.mjs --base origin/main --staged`. Its first default build then failed in the post-build module-import check: borrowing fingerprint-identical dependencies from the hydrated checkout left workspace package links pointing to that checkout, rather than the freshly built proof tree. Diagnosis confirmed the three missing modules existed in the new tree but not at the resolved paths, with every tracked source byte unchanged.

Recovery used an ordinary frozen install in a fresh task-owned tree on the same lease and exact source. The 268 candidate tests and 12-case/36-response comparison passed again, followed by the default full build and final source/runtime attestations; the wrapper exited zero. No product code, dependency pin, assertion, or gate was weakened to address the proof layout. Dependency `eval` warnings and the UI's `node:path` browser-externalization warnings remain recorded in the raw build log; no ineffective-dynamic-import warning was emitted.

The cleanup supervisor initially rejected the provider's terminal `completed` label because its final assertion expected `stopped`; the cleanup, stop, and status commands had each exited zero. A fresh read-only status check against the provider's documented terminal-state contract reconciled that receipt. No cleanup or stop operation was repeated.
