### PR TITLE
fix(config): omit unauthored agents parent on writes

### DIFF
--- a/src/config/io.write-prepare.test.ts
+++ b/src/config/io.write-prepare.test.ts
@@ -55,6 +55,38 @@ const writeCases: WriteCase[] = [
     expected: { gateway: { port: 18789, auth: { mode: "token" } } },
   },
   {
+    name: "omits the unauthored parent after removing an injected roster",
+    current: { gateway: { port: 18789 }, ...roster({ main: {} }) },
+    authored: { gateway: { port: 18789 } },
+    next: { gateway: { port: 19001 }, ...roster({ main: {} }) },
+    expected: { gateway: { port: 19001 } },
+  },
+  {
+    name: "retains an explicitly authored empty agents section",
+    current: { gateway: { port: 18789 }, ...roster({ main: {} }) },
+    authored: { gateway: { port: 18789 }, agents: {} },
+    next: { gateway: { port: 19001 }, ...roster({ main: {} }) },
+    expected: { gateway: { port: 19001 }, agents: {} },
+  },
+  {
+    name: "retains newly authored defaults after removing an injected roster",
+    current: { gateway: { port: 18789 }, ...roster({ main: {} }) },
+    authored: { gateway: { port: 18789 } },
+    next: { agents: { entries: { main: {} }, defaults: {} }, gateway: { port: 18789 } },
+    options: { explicitSetPaths: [["agents", "defaults"]] },
+    expected: { agents: { defaults: {} }, gateway: { port: 18789 } },
+  },
+  {
+    name: "restores an untouched authored roster without aliasing its nested values",
+    current: roster({ main: runtimeSecretEntry }),
+    authored: roster({ main: authoredSecretEntry }),
+    next: { ...roster({ main: runtimeSecretEntry }), gateway: { port: 19001 } },
+    expected: { ...roster({ main: authoredSecretEntry }), gateway: { port: 19001 } },
+    verify: (persisted) => {
+      expect(persisted.agents?.entries?.main?.sandbox?.ssh?.identityData).not.toBe(identityRef);
+    },
+  },
+  {
     name: "persists the complete injected roster when a pre-roster config adds an agent",
     current: { gateway: { mode: "local" }, ...roster({ main }) },
     authored: { gateway: { mode: "local" } },

--- a/src/config/io.write-prepare.ts
+++ b/src/config/io.write-prepare.ts
@@ -51,20 +51,15 @@ function assertUniqueNormalizedLegacyRosterIds(value: readonly unknown[]): void 
   }
 }
 
-// Clone config fragments before patching so mutation preparation never aliases callers.
-function cloneUnknown<T>(value: T): T {
-  return structuredClone(value);
-}
-
 export function projectSourceOntoRuntimeShape(source: unknown, runtime: unknown): unknown {
   if (!isRecord(source) || !isRecord(runtime)) {
-    return cloneUnknown(source);
+    return structuredClone(source);
   }
 
   const next: Record<string, unknown> = {};
   for (const [key, sourceValue] of Object.entries(source)) {
     if (!(key in runtime)) {
-      next[key] = cloneUnknown(sourceValue);
+      next[key] = structuredClone(sourceValue);
       continue;
     }
     next[key] = projectSourceOntoRuntimeShape(sourceValue, runtime[key]);
@@ -205,7 +200,7 @@ function getPathValue(value: unknown, path: string[]): unknown {
 
 function setPathValue(value: unknown, path: string[], nextValue: unknown): unknown {
   if (path.length === 0) {
-    return cloneUnknown(nextValue);
+    return structuredClone(nextValue);
   }
   const head = expectDefined(path[0], "config path head");
   const tail = path.slice(1);
@@ -264,7 +259,7 @@ function findOverlappingIncludeOwnedPath(
 
 function setPathValueCreatingParents(value: unknown, path: string[], nextValue: unknown): unknown {
   if (path.length === 0) {
-    return cloneUnknown(nextValue);
+    return structuredClone(nextValue);
   }
   const head = expectDefined(path[0], "config path head");
   const tail = path.slice(1);
@@ -518,7 +513,7 @@ function projectRootAuthoredIncludeSibling(params: {
     params.baselinePresent &&
     isDeepStrictEqual(params.next, params.baseline)
   ) {
-    return { ok: true, present: true, value: cloneUnknown(params.authored) };
+    return { ok: true, present: true, value: structuredClone(params.authored) };
   }
   if (!params.nextPresent) {
     return collectIncludeOwnedPaths(params.authored).length > 0
@@ -526,7 +521,7 @@ function projectRootAuthoredIncludeSibling(params: {
       : { ok: true, present: false };
   }
   if (!params.baselinePresent) {
-    return { ok: true, present: true, value: cloneUnknown(params.next) };
+    return { ok: true, present: true, value: structuredClone(params.next) };
   }
   if (hasOwnValidIncludeDirective(params.authored)) {
     return { ok: false };
@@ -534,21 +529,21 @@ function projectRootAuthoredIncludeSibling(params: {
   if (Array.isArray(params.authored)) {
     return Array.isArray(params.next)
       ? { ok: false }
-      : { ok: true, present: true, value: cloneUnknown(params.next) };
+      : { ok: true, present: true, value: structuredClone(params.next) };
   }
   if (!isRecord(params.authored)) {
-    return { ok: true, present: true, value: cloneUnknown(params.next) };
+    return { ok: true, present: true, value: structuredClone(params.next) };
   }
   if (!isRecord(params.next)) {
     return collectIncludeOwnedPaths(params.authored).length > 0
       ? { ok: false }
-      : { ok: true, present: true, value: cloneUnknown(params.next) };
+      : { ok: true, present: true, value: structuredClone(params.next) };
   }
   if (!isRecord(params.baseline)) {
-    return { ok: true, present: true, value: cloneUnknown(params.next) };
+    return { ok: true, present: true, value: structuredClone(params.next) };
   }
 
-  const value: Record<string, unknown> = cloneUnknown(params.authored);
+  const value: Record<string, unknown> = structuredClone(params.authored);
   const keys = new Set([
     ...Object.keys(params.authored),
     ...Object.keys(params.baseline),
@@ -739,7 +734,7 @@ function mergeMissingExplicitValues(
         continue;
       }
       if (index >= next.length || next[index] === undefined) {
-        next[index] = cloneUnknown(childExplicitValue);
+        next[index] = structuredClone(childExplicitValue);
         changed = true;
         continue;
       }
@@ -758,7 +753,7 @@ function mergeMissingExplicitValues(
       continue;
     }
     if (!Object.hasOwn(next, key)) {
-      next[key] = cloneUnknown(childExplicitValue);
+      next[key] = structuredClone(childExplicitValue);
       changed = true;
       continue;
     }
@@ -985,7 +980,7 @@ function projectAuthoredRosterValue(params: {
   }
   if (Array.isArray(params.next)) {
     if (explicitlySet && params.explicitPresent && Array.isArray(params.explicit)) {
-      return { present: true, value: cloneUnknown(params.explicit) };
+      return { present: true, value: structuredClone(params.explicit) };
     }
     const authored = Array.isArray(params.authored) ? params.authored : [];
     const explicit = Array.isArray(params.explicit) ? params.explicit : [];
@@ -1057,7 +1052,7 @@ function projectAuthoredRosterValue(params: {
     };
   }
   if (explicitlySet && params.explicitPresent) {
-    return { present: true, value: cloneUnknown(params.explicit) };
+    return { present: true, value: structuredClone(params.explicit) };
   }
   const unchangedFromRuntime =
     params.runtimePresent && isDeepStrictEqual(params.runtime, params.next);
@@ -1066,8 +1061,8 @@ function projectAuthoredRosterValue(params: {
     present: true,
     value:
       params.authoredPresent && (unchangedFromRuntime || unchangedFromSource)
-        ? cloneUnknown(params.authored)
-        : cloneUnknown(params.next),
+        ? structuredClone(params.authored)
+        : structuredClone(params.next),
   };
 }
 
@@ -1378,7 +1373,7 @@ function canonicalizeAgentRosterForExplicitWrite(params: {
                 isRecord(sourceEntries[priorId]) &&
                 isDeepStrictEqual(sourceEntries[priorId].default, nextEntry.default)));
           if (!preservesAuthoredReference) {
-            value.default = cloneUnknown(nextEntry.default);
+            value.default = structuredClone(nextEntry.default);
           }
         } else {
           delete value.default;
@@ -1473,12 +1468,13 @@ function restoreAuthoredAgentRoster(value: unknown, rootAuthoredConfig: unknown)
   let next = deletePathValue(value, ["agents", "entries"]);
   next = deletePathValue(next, ["agents", "list"]);
   const authoredRoster = readAgentRosterProperty(rootAuthoredConfig);
-  return authoredRoster
-    ? setPathValueCreatingParents(
-        next,
-        ["agents", authoredRoster.kind],
-        cloneUnknown(authoredRoster.value),
-      )
+  if (authoredRoster) {
+    return setPathValueCreatingParents(next, ["agents", authoredRoster.kind], authoredRoster.value);
+  }
+  // Roster injection must not leave an unauthored parent, but empty authored sections are intent.
+  return !hasPathValue(rootAuthoredConfig, ["agents"]) &&
+    isDeepStrictEqual(getPathValue(next, ["agents"]), {})
+    ? deletePathValue(next, ["agents"])
     : next;
 }
 


### PR DESCRIPTION
Related: #112678

## What Problem This Solves

Configuration writes could persist an empty `agents` object even when the operator never authored an agents section. This happened when the runtime's implicit `main` roster was projected back onto an otherwise unrelated write and then removed, leaving its unauthored parent behind.

## Why This Change Was Made

The existing authored-roster projection now removes the empty `agents` parent only when that parent was absent from the authored source. Explicitly authored `agents: {}`, authored defaults, include-owned values, and intentional roster changes remain intact. The same cleanup removes a one-line clone wrapper and a redundant double clone while preserving the setter's existing clone ownership and aliasing guarantees.

## User Impact

Credential and configuration writes no longer invent an empty agents section merely because the runtime materialized its implicit roster. The authored structure of explicit empty sections, defaults, and includes is preserved, and this change does not rewrite existing files proactively. There is no new config key, default, schema, migration, or operator action.

## Evidence

- Genuine source-blind baseline: six clauses covering 10 contract actions completed across 11 built CLI attempts, including one explicit K1b retry. The two successful write clauses failed only because they added `agents: {}`, while the remaining preservation/no-op clauses passed.
- Candidate source-blind built CLI proof: all six clauses and 10 CLI commands passed from fresh homes, with no credentials, network, or Gateway. Raw records SHA-256: `87359ff73be3b7326ace01aefe597073bd081161cb2192ccdef446147b7f0002`.
- Focused owner and sibling proof: 219 tests passed.
- Complete changed-file gate: exit 0.
- Exact committed-head full build: exit 0 with matching build stamps.
- Fresh isolated P0 Codex review: no findings, 0.99 confidence.
- K1a reproduced the empty-`agents` write before K1b exposed literal private-file sandbox permissions as an SQLite open error. The permission envelope was corrected, then validation resumed from the same already-mutated baseline fixtures without replay or reset. Only the candidate run uses fresh homes; the sandbox error was not classified as a product database failure.
- Production LOC: +25/-29 (net -4). Tests: +32/-0.
