### PR TITLE
test(ui): hold replacement session loads

### DIFF
--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -528,7 +528,8 @@ suite.define(() => {
     await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
       const gateway = await installMockGateway(page, {
         featureMethods: ["chat.metadata", "chat.startup", "sessions.patch", "tools.effective"],
-        deferredMethods: ["sessions.list", "tools.effective"],
+        deferredMethods: ["tools.effective"],
+        heldMethods: ["sessions.list"],
         methodResponses: {
           "config.get": configResponse({
             github: { url: "https://mcp.example.test", enabled: true },


### PR DESCRIPTION
## Summary

- hold every replacement `sessions.list` request while the capability-menu E2E test proves its loading gate
- keep the production loading behavior and its disabled/title assertions unchanged

## Root cause and repair

The mock used `deferredMethods`, which intentionally holds only the next matching request. Under slower CI timing, startup could replace the first `sessions.list` request; that replacement resolved immediately, published the session, and correctly cleared the loading title before the assertion observed it.

The test now uses the mock's existing `heldMethods` contract so every replacement remains blocked until explicit release. A controlled forced-replacement proof changes from `{ requests: 2, disabled: false, title: "" }` with the one-shot deferral to `{ requests: 2, disabled: true, title: "Loading…" }` with the hold.

This is test-only and does not change production behavior.

The earlier typography picker race that initially motivated this PR landed independently in #131392 while this branch was rebasing, so that redundant commit is no longer part of this diff.

## Reproduction

CI shard 3 failed twice at `ui/src/e2e/chat-composer-capability-menu.e2e.test.ts:553` before the hold repair.

## Validation

- controlled replacement proof for one-shot versus held requests
- focused capability-menu loading test: passed
- complete `chat-composer-capability-menu.e2e.test.ts`: 10 passed
- `pnpm exec oxfmt --check ui/src/e2e/chat-composer-capability-menu.e2e.test.ts`
- `git diff --check`
